### PR TITLE
adding RemovePeer method to libp2pNode to disconnect from a node

### DIFF
--- a/network/gossip/libp2p/connManager.go
+++ b/network/gossip/libp2p/connManager.go
@@ -21,7 +21,10 @@ func NewConnManager(log zerolog.Logger) ConnManager {
 		log:         log,
 		NullConnMgr: connmgr.NullConnMgr{},
 	}
-	n := &network.NotifyBundle{ListenCloseF: cn.ListenCloseNotifee, ListenF: cn.ListenNotifee, DisconnectedF: cn.Disconnected}
+	n := &network.NotifyBundle{ListenCloseF: cn.ListenCloseNotifee,
+		ListenF:       cn.ListenNotifee,
+		ConnectedF:    cn.Connected,
+		DisconnectedF: cn.Disconnected}
 	cn.n = n
 	return cn
 }

--- a/network/gossip/libp2p/discovery.go
+++ b/network/gossip/libp2p/discovery.go
@@ -38,8 +38,7 @@ func (d *Discovery) Advertise(_ context.Context, _ string, _ ...discovery.Option
 	}
 }
 
-// FindPeers returns a channel providing all peers of the node. No parameters are needed as of now since the overlay.Identity
-// provides all the information about the other nodes.
+// FindPeers returns a channel providing all peers of the node.
 func (d *Discovery) FindPeers(_ context.Context, _ string, _ ...discovery.Option) (<-chan peer.AddrInfo, error) {
 
 	// if middleware has been stopped, don't return any peers

--- a/network/gossip/libp2p/discovery.go
+++ b/network/gossip/libp2p/discovery.go
@@ -38,7 +38,8 @@ func (d *Discovery) Advertise(_ context.Context, _ string, _ ...discovery.Option
 	}
 }
 
-// FindPeers returns a channel providing all peers of the node.
+// FindPeers returns a channel providing all peers of the node. No parameters are needed as of now since the overlay.Identity
+// provides all the information about the other nodes.
 func (d *Discovery) FindPeers(_ context.Context, _ string, _ ...discovery.Option) (<-chan peer.AddrInfo, error) {
 
 	// if middleware has been stopped, don't return any peers

--- a/network/gossip/libp2p/libp2pNode.go
+++ b/network/gossip/libp2p/libp2pNode.go
@@ -208,19 +208,36 @@ func (p *P2PNode) Stop() (chan struct{}, error) {
 	return done, nil
 }
 
-// AddPeers adds other nodes as peers to this node by adding them to the node's peerstore and connecting to them
-func (p *P2PNode) AddPeers(ctx context.Context, peers ...NodeAddress) error {
-	p.Lock()
-	defer p.Unlock()
-	for _, peer := range peers {
-		pInfo, err := GetPeerInfo(peer)
-		if err != nil {
-			return err
-		}
+// AddPeer adds a peer to this node by adding it to this node's peerstore and connecting to it
+func (p *P2PNode) AddPeer(ctx context.Context, peer NodeAddress) error {
 
-		err = p.libP2PHost.Connect(ctx, pInfo)
+	pInfo, err := GetPeerInfo(peer)
+	if err != nil {
+		return err
+	}
+
+	err = p.libP2PHost.Connect(ctx, pInfo)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemovePeer closes the connection with the peer
+func (p *P2PNode) RemovePeer(ctx context.Context, peer NodeAddress) error {
+
+	pInfo, err := GetPeerInfo(peer)
+	if err != nil {
+		return fmt.Errorf("failed to remove peer %s: %w", peer.Name, err)
+	}
+
+	conns := p.libP2PHost.Network().ConnsToPeer(pInfo.ID)
+	// close all connections with the peer
+	for _, c := range conns {
+		err = c.Close()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to remove peer %s: %w", peer.Name, err)
 		}
 	}
 	return nil
@@ -274,7 +291,7 @@ func (p *P2PNode) tryCreateNewStream(ctx context.Context, n NodeAddress, targetI
 		}
 
 		// add node address as a peer
-		err = p.AddPeers(ctx, n)
+		err = p.AddPeer(ctx, n)
 		if err != nil {
 
 			// if the connection was rejected due to invalid node id, skip the re-attempt

--- a/network/gossip/libp2p/libp2pNode.go
+++ b/network/gossip/libp2p/libp2pNode.go
@@ -210,12 +210,13 @@ func (p *P2PNode) Stop() (chan struct{}, error) {
 
 // AddPeer adds a peer to this node by adding it to this node's peerstore and connecting to it
 func (p *P2PNode) AddPeer(ctx context.Context, peer NodeAddress) error {
-
 	pInfo, err := GetPeerInfo(peer)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to add peer %s: %w", peer.Name, err)
 	}
 
+	p.Lock()
+	defer p.Unlock()
 	err = p.libP2PHost.Connect(ctx, pInfo)
 	if err != nil {
 		return err
@@ -226,12 +227,13 @@ func (p *P2PNode) AddPeer(ctx context.Context, peer NodeAddress) error {
 
 // RemovePeer closes the connection with the peer
 func (p *P2PNode) RemovePeer(ctx context.Context, peer NodeAddress) error {
-
 	pInfo, err := GetPeerInfo(peer)
 	if err != nil {
 		return fmt.Errorf("failed to remove peer %s: %w", peer.Name, err)
 	}
 
+	p.Lock()
+	defer p.Unlock()
 	conns := p.libP2PHost.Network().ConnsToPeer(pInfo.ID)
 	// close all connections with the peer
 	for _, c := range conns {


### PR DESCRIPTION
This PR adds the ability to disconnect from a peer by closing the connection. This is needed for evicting nodes and when a collection node moves over from one cluster to another thus changing it's peers.