### PR TITLE
update README to force build relic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flow [![GoDoc](https://godoc.org/github.com/onflow/flow-go?status.svg)](https://godoc.org/github.com/onflow/flow-go)
 
-Flow is a fast, secure, and developer-friendly blockchain built to support the 
+Flow is a fast, secure, and developer-friendly blockchain built to support the
 next generation of games, apps and the digital assets that power them. Read more
 about it [here](https://github.com/onflow/flow).
 
@@ -30,11 +30,11 @@ about it [here](https://github.com/onflow/flow).
 
 ## Documentation
 
-You can find an overview of the Flow architecture on the [documentation website](https://www.onflow.org/primer). 
+You can find an overview of the Flow architecture on the [documentation website](https://www.onflow.org/primer).
 
-Development on Flow is divided into work streams. Each work stream has a home 
+Development on Flow is divided into work streams. Each work stream has a home
 directory containing high-level documentation for the stream, as well as links
-to documentation for relevant components used by that work stream. 
+to documentation for relevant components used by that work stream.
 
 The following table lists all work streams and links to their home directory and documentation:
 
@@ -78,11 +78,17 @@ make install-tools
 
 At this point, you should be ready to build, test, and run Flow! 🎉
 
+Note: if there is error about "relic" or "crypto", trying force removing the relic build and reinstall the tools again:
+```bash
+rm -rf crypto/relic
+make install-tools
+```
+
 ## Development Workflow
 
 ### Testing
 
-Flow has a unit test suite and an integration test suite. Unit tests for a module 
+Flow has a unit test suite and an integration test suite. Unit tests for a module
 live within the module they are testing. Integration tests live in `integration/tests`.
 
 Run the unit test suite:
@@ -99,7 +105,7 @@ make integration-test
 
 ### Building
 
-The recommended way to build and run Flow for local development is using Docker. 
+The recommended way to build and run Flow for local development is using Docker.
 
 Build a Docker image for all nodes:
 ```bash
@@ -113,12 +119,12 @@ make docker-build-$ROLE
 
 ### Local Network
 
-A local version of the network can be run for manual testing and integration. 
+A local version of the network can be run for manual testing and integration.
 See the [Local Network Guide](/integration/localnet/README.md) for instructions.
 
 ### Code Generation
 
-Generated code is kept up to date in the repository, so should be committed whenever it changes. 
+Generated code is kept up to date in the repository, so should be committed whenever it changes.
 
 Run all code generators:
 


### PR DESCRIPTION
I ran into the following error when switching repos. 

```
ERRO Running error: buildssa: analysis skipped: errors in package: [/Users/leo/onflow-go/model/encodable/keys.go:11:2: could not import github.com/onflow/flow-go/crypto (/Users/leo/onflow-go/crypto/bls.go:31:8: could not import C (cgo preprocessing failed)) /Users/leo/onflow-go/model/encodable/keys.go:24:26: pub.Encode undefined (type NetworkPubKey has no field or method Encode) /Users/leo/onflow-go/model/encodable/keys.go:52:27: priv.Encode undefined (type NetworkPrivKey has no field or method Encode) /Users/leo/onflow-go/model/encodable/keys.go:78:26: pub.Encode undefined (type StakingPubKey has no field or method Encode) /Users/leo/onflow-go/model/encodable/keys.go:106:27: priv.Encode undefined (type StakingPrivKey has no field or method Encode) /Users/leo/onflow-go/model/encodable/keys.go:132:26: pub.Encode undefined (type RandomBeaconPubKey has no field or method Encode) /Users/leo/onflow-go/model/encodable/keys.go:181:27: priv.Encode undefined (type RandomBeaconPrivKey has no field or method Encode) -: could not load export data: no export data for "github.com/onflow/flow-go/model/encodable"]
```

I happens when I ran make `install-tools` before replacing the remaining `dapperlabs/flow-go`, so the wrong relic build was cached, and never get deleted again. I have to manually delete it. 

Adding the resolve steps in the install instruction