### PR TITLE
Update account key decoder to tolerate keys stored without a "Revoked" field

### DIFF
--- a/model/flow/account_encoder.go
+++ b/model/flow/account_encoder.go
@@ -85,11 +85,11 @@ func decodeAccountPublicKeyWrapper(b []byte) (accountPublicKeyWrapper, error) {
 		}
 
 		return accountPublicKeyWrapper{
-			PublicKey: wrapper.PublicKey,
-			SignAlgo:  wrapper.SignAlgo,
-			HashAlgo:  wrapper.HashAlgo,
-			Weight:    wrapper.Weight,
-			SeqNumber: wrapper.SeqNumber,
+			PublicKey: legacyWrapper.PublicKey,
+			SignAlgo:  legacyWrapper.SignAlgo,
+			HashAlgo:  legacyWrapper.HashAlgo,
+			Weight:    legacyWrapper.Weight,
+			SeqNumber: legacyWrapper.SeqNumber,
 			Revoked:   false, // all legacy keys are not revoked
 		}, nil
 	}

--- a/model/flow/account_encoder_test.go
+++ b/model/flow/account_encoder_test.go
@@ -1,0 +1,60 @@
+package flow_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+type legacyAccountPublicKeyWrapper struct {
+	PublicKey []byte
+	SignAlgo  uint
+	HashAlgo  uint
+	Weight    uint
+	SeqNumber uint64
+	// "Revoked" field intentionally omitted
+}
+
+func TestDecodeAccountPublicKey_Legacy(t *testing.T) {
+	publicKeyBytes, err := hex.DecodeString("98fd858d00b995cc9d67ec6c140f0fc26fcf7895621b3bf2661ea7b99e54f8cebd9143b50d21e6854187f895db7b6c7ec3032be5047b3652a0c2686e5b97de48")
+	require.NoError(t, err)
+
+	publicKey, err := crypto.DecodePublicKey(crypto.ECDSAP256, publicKeyBytes)
+	require.NoError(t, err)
+
+	sigAlgo := crypto.ECDSAP256
+	hashAlgo := hash.SHA3_256
+	weight := 1000
+	sequenceNumber := uint64(42)
+
+	// manually encode key in legacy format
+	w := legacyAccountPublicKeyWrapper{
+		PublicKey: publicKey.Encode(),
+		SignAlgo:  uint(crypto.ECDSAP256),
+		HashAlgo:  uint(hash.SHA3_256),
+		Weight:    uint(weight),
+		SeqNumber: sequenceNumber,
+	}
+
+	b, err := rlp.EncodeToBytes(&w)
+	require.NoError(t, err)
+
+	accountKey, err := flow.DecodeAccountPublicKey(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, publicKey, accountKey.PublicKey)
+	assert.Equal(t, sigAlgo, accountKey.SignAlgo)
+	assert.Equal(t, hashAlgo, accountKey.HashAlgo)
+	assert.Equal(t, weight, accountKey.Weight)
+	assert.Equal(t, sequenceNumber, accountKey.SeqNumber)
+
+	// legacy account key should not be revoked
+	assert.False(t, accountKey.Revoked)
+}


### PR DESCRIPTION
After the most recent spork, account keys are stored with a new `Revoked` field that indicates whether the key has been removed from the account. 

The problem is, any account keys stored _before the spork_ do not include a `Revoked` value in their RLP-encoded representation. The RLP decoder throws an error because it cannot read a field that does not exist.

For context, this bug has currently stalled testnet 😬 

@Kay-Zee and I discussed a few options, but since we are likely to refactor account keys in the near future to be stored as Cadence resources, we didn't want to over-engineer a solution.

This solution implements an optimistic decoding that first tries to decode with the `Revoked` field, then tries again without the field (legacy format). Whenever a legacy account key is used as a proposal key, it will be re-encoded and thus be updated with the `Revoked` field.

