### PR TITLE
Propagate Revoked

### DIFF
--- a/engine/common/rpc/convert/convert.go
+++ b/engine/common/rpc/convert/convert.go
@@ -289,6 +289,7 @@ func MessageToAccountKey(m *entities.AccountKey) (*flow.AccountPublicKey, error)
 		HashAlgo:  hashAlgo,
 		Weight:    int(m.GetWeight()),
 		SeqNumber: uint64(m.GetSequenceNumber()),
+		Revoked:   m.GetRevoked(),
 	}, nil
 }
 

--- a/engine/common/rpc/convert/convert_test.go
+++ b/engine/common/rpc/convert/convert_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -19,4 +20,22 @@ func TestConvertTransaction(t *testing.T) {
 
 	assert.Equal(t, tx, converted)
 	assert.Equal(t, tx.ID(), converted.ID())
+}
+
+func TestConvertAccountKey(t *testing.T) {
+	privateKey, _ := unittest.AccountKeyFixture()
+	accountKey := privateKey.PublicKey(fvm.AccountKeyWeightThreshold)
+
+	// Explicitly test if Revoked is properly converted
+	accountKey.Revoked = true
+
+	msg, err := convert.AccountKeyToMessage(accountKey)
+	assert.Nil(t, err)
+
+	converted, err := convert.MessageToAccountKey(msg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, accountKey, *converted)
+	assert.Equal(t, accountKey.PublicKey, converted.PublicKey)
+	assert.Equal(t, accountKey.Revoked, converted.Revoked)
 }


### PR DESCRIPTION
Noticed the `Revoked` field wasn't being pass to the client. Found that it was missing from one of the conversion steps.

Added it, and added a test, which explicitly tests the conversion and propagation of the Revoked field