### PR TITLE
Bootstrapping bug fix and documentation update

### DIFF
--- a/cmd/bootstrap/README.md
+++ b/cmd/bootstrap/README.md
@@ -97,7 +97,7 @@ Each input is a config file specified as a command line parameter:
 
 #### Example
 ```bash
-go run -tags relic ./cmd/bootstrap finalize
+go run -tags relic ./cmd/bootstrap finalize \
  --fast-kg \
   --root-chain main \
   --root-height 0 \
@@ -106,6 +106,7 @@ go run -tags relic ./cmd/bootstrap finalize
   --config ./cmd/bootstrap/example_files/node-config.json \
   --partner-dir ./cmd/bootstrap/example_files/partner-node-infos \
   --partner-stakes ./cmd/bootstrap/example_files/partner-stakes.json \
+  --epoch-counter 1 \
   -o ./bootstrap/root-infos
 ```
 

--- a/cmd/bootstrap/cmd/constraints.go
+++ b/cmd/bootstrap/cmd/constraints.go
@@ -55,7 +55,7 @@ func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 			}
 			if clusterInternalCount <= clusterPartnerCount*2 {
 				log.Fatal().Msgf(
-					"will not bootstrap configuration without Byzantine majority of cluster: "+
+					"will not bootstrap configuration without Byzantine majority within cluster: "+
 						"(partners=%d, internals=%d, min_internals=%d)",
 					clusterPartnerCount, clusterInternalCount, clusterPartnerCount*2+1)
 			}

--- a/cmd/bootstrap/example_files/node-config.json
+++ b/cmd/bootstrap/example_files/node-config.json
@@ -15,6 +15,21 @@
     "Stake": 110
   },
   {
+    "Role": "collection",
+    "Address": "123.0.1.13",
+    "Stake": 110
+  },
+  {
+    "Role": "collection",
+    "Address": "123.0.1.14",
+    "Stake": 110
+  },
+  {
+    "Role": "collection",
+    "Address": "123.0.1.15",
+    "Stake": 110
+  },
+  {
     "Role": "consensus",
     "Address": "123.0.2.10",
     "Stake": 220


### PR DESCRIPTION
This PR some documentation/example updates for bootstrapping, and fixes a bug in the Byzantine constraint checking during the bootstrap process.

* update `README` example command to include new required flag and add a missing `\`
* update example `node-config.json` file to be compatible with the command in the `README`
* fix a bug in the total collector count, where a cluster count was used instead of the total count