### PR TITLE
Refactor FinalStateCommit in Execution Result

### DIFF
--- a/cmd/bootstrap/run/result.go
+++ b/cmd/bootstrap/run/result.go
@@ -1,23 +1,16 @@
 package run
 
 import (
+	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
 )
 
 func GenerateRootResult(block *flow.Block, commit flow.StateCommitment) *flow.ExecutionResult {
-	// add commit as endstate of chunk
-	chunks := flow.ChunkList{}
-	chunk := &flow.Chunk{
-		Index:    0,
-		EndState: commit,
-	}
-	chunks.Insert(chunk)
-
 	result := &flow.ExecutionResult{
 		ExecutionResultBody: flow.ExecutionResultBody{
 			PreviousResultID: flow.ZeroID,
 			BlockID:          block.ID(),
-			Chunks:           chunks,
+			Chunks:           chunks.ChunkListFromCommit(commit),
 		},
 		Signatures: nil,
 	}

--- a/cmd/bootstrap/run/result.go
+++ b/cmd/bootstrap/run/result.go
@@ -5,12 +5,19 @@ import (
 )
 
 func GenerateRootResult(block *flow.Block, commit flow.StateCommitment) *flow.ExecutionResult {
+	// add commit as endstate of chunk
+	chunks := flow.ChunkList{}
+	chunk := &flow.Chunk{
+		Index:    0,
+		EndState: commit,
+	}
+	chunks.Insert(chunk)
+
 	result := &flow.ExecutionResult{
 		ExecutionResultBody: flow.ExecutionResultBody{
 			PreviousResultID: flow.ZeroID,
 			BlockID:          block.ID(),
-			FinalStateCommit: commit,
-			Chunks:           nil,
+			Chunks:           chunks,
 		},
 		Signatures: nil,
 	}

--- a/cmd/bootstrap/run/seal.go
+++ b/cmd/bootstrap/run/seal.go
@@ -8,7 +8,7 @@ func GenerateRootSeal(result *flow.ExecutionResult, setup *flow.EpochSetup, comm
 	seal := &flow.Seal{
 		BlockID:       result.BlockID,
 		ResultID:      result.ID(),
-		FinalState:    result.FinalStateCommit,
+		FinalState:    result.FinalStateCommit(),
 		ServiceEvents: []flow.ServiceEvent{setup.ServiceEvent(), commit.ServiceEvent()},
 	}
 	return seal

--- a/cmd/bootstrap/run/seal.go
+++ b/cmd/bootstrap/run/seal.go
@@ -5,10 +5,11 @@ import (
 )
 
 func GenerateRootSeal(result *flow.ExecutionResult, setup *flow.EpochSetup, commit *flow.EpochCommit) *flow.Seal {
+	finalState, _ := result.FinalStateCommitment()
 	seal := &flow.Seal{
 		BlockID:       result.BlockID,
 		ResultID:      result.ID(),
-		FinalState:    result.FinalStateCommit(),
+		FinalState:    finalState,
 		ServiceEvents: []flow.ServiceEvent{setup.ServiceEvent(), commit.ServiceEvent()},
 	}
 	return seal

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -198,7 +198,6 @@ func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 
 // onReceipt processes a new execution receipt.
 func (e *Engine) onReceipt(originID flow.Identifier, receipt *flow.ExecutionReceipt) error {
-
 	log := e.log.With().
 		Hex("origin_id", originID[:]).
 		Hex("receipt_id", logging.Entity(receipt)).
@@ -206,8 +205,14 @@ func (e *Engine) onReceipt(originID flow.Identifier, receipt *flow.ExecutionRece
 		Hex("previous_id", receipt.ExecutionResult.PreviousResultID[:]).
 		Hex("block_id", receipt.ExecutionResult.BlockID[:]).
 		Hex("executor_id", receipt.ExecutorID[:]).
-		Hex("final_state", receipt.ExecutionResult.FinalStateCommit()).
 		Logger()
+
+	resultFinalState, ok := receipt.ExecutionResult.FinalStateCommitment()
+	if !ok {
+		return fmt.Errorf("could not get final state: no chunks found")
+	}
+
+	log = log.With().Hex("final_state", resultFinalState).Logger()
 
 	log.Info().Msg("execution receipt received")
 
@@ -593,11 +598,17 @@ func (e *Engine) sealResult(result *flow.ExecutionResult) error {
 	// collect aggregate signatures
 	aggregatedSigs := e.collectAggregateSignatures(result)
 
+	// get finalS state of execution result
+	finalState, ok := result.FinalStateCommitment()
+	if !ok {
+		return fmt.Errorf("could not get final state: no chunks found")
+	}
+
 	// generate & store seal
 	seal := &flow.Seal{
 		BlockID:                result.BlockID,
 		ResultID:               result.ID(),
-		FinalState:             result.FinalStateCommit(),
+		FinalState:             finalState,
 		AggregatedApprovalSigs: aggregatedSigs,
 	}
 

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -206,7 +206,7 @@ func (e *Engine) onReceipt(originID flow.Identifier, receipt *flow.ExecutionRece
 		Hex("previous_id", receipt.ExecutionResult.PreviousResultID[:]).
 		Hex("block_id", receipt.ExecutionResult.BlockID[:]).
 		Hex("executor_id", receipt.ExecutorID[:]).
-		Hex("final_state", receipt.ExecutionResult.FinalStateCommit).
+		Hex("final_state", receipt.ExecutionResult.FinalStateCommit()).
 		Logger()
 
 	log.Info().Msg("execution receipt received")
@@ -597,7 +597,7 @@ func (e *Engine) sealResult(result *flow.ExecutionResult) error {
 	seal := &flow.Seal{
 		BlockID:                result.BlockID,
 		ResultID:               result.ID(),
-		FinalState:             result.FinalStateCommit,
+		FinalState:             result.FinalStateCommit(),
 		AggregatedApprovalSigs: aggregatedSigs,
 	}
 

--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -351,7 +351,7 @@ func TestExecutionStateSyncMultipleExecutionNodes(t *testing.T) {
 			consensusNode.Log.Debug().
 				Hex("origin", originID[:]).
 				Hex("block", receipt.ExecutionResult.BlockID[:]).
-				Hex("commit", receipt.ExecutionResult.FinalStateCommit).
+				Hex("commit", receipt.ExecutionResult.FinalStateCommit()).
 				Msg("execution receipt delivered")
 
 		}).Return(nil)
@@ -532,7 +532,7 @@ func TestExecutionQueryMissingBlocks(t *testing.T) {
 			consensusNode.Log.Debug().
 				Hex("origin", originID[:]).
 				Hex("block", receipt.ExecutionResult.BlockID[:]).
-				Hex("commit", receipt.ExecutionResult.FinalStateCommit).
+				Hex("commit", receipt.ExecutionResult.FinalStateCommit()).
 				Msg("execution receipt delivered")
 
 		}).Return(nil)

--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -348,12 +348,12 @@ func TestExecutionStateSyncMultipleExecutionNodes(t *testing.T) {
 			receiptsReceived++
 			originID := args[0].(flow.Identifier)
 			receipt := args[1].(*flow.ExecutionReceipt)
+			finalState, _ := receipt.ExecutionResult.FinalStateCommitment()
 			consensusNode.Log.Debug().
 				Hex("origin", originID[:]).
 				Hex("block", receipt.ExecutionResult.BlockID[:]).
-				Hex("commit", receipt.ExecutionResult.FinalStateCommit()).
+				Hex("commit", finalState).
 				Msg("execution receipt delivered")
-
 		}).Return(nil)
 
 	// submit block2 from consensus node to execution node 1
@@ -529,10 +529,11 @@ func TestExecutionQueryMissingBlocks(t *testing.T) {
 			receiptsReceived++
 			originID := args[0].(flow.Identifier)
 			receipt := args[1].(*flow.ExecutionReceipt)
+			finalState, _ := receipt.ExecutionResult.FinalStateCommitment()
 			consensusNode.Log.Debug().
 				Hex("origin", originID[:]).
 				Hex("block", receipt.ExecutionResult.BlockID[:]).
-				Hex("commit", receipt.ExecutionResult.FinalStateCommit()).
+				Hex("commit", finalState).
 				Msg("execution receipt delivered")
 
 		}).Return(nil)

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -678,6 +678,10 @@ func (e *Engine) handleComputationResult(
 		return nil, fmt.Errorf("could not send broadcast order: %w", err)
 	}
 
+	if receipt.ExecutionResult.Chunks.Len() == 0 {
+		return startState, nil
+	}
+
 	return receipt.ExecutionResult.FinalStateCommit(), nil
 }
 

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -1161,7 +1161,8 @@ func (e *Engine) saveDelta(ctx context.Context, executionStateDelta *messages.Ex
 
 	finalState, ok := executionReceipt.ExecutionResult.FinalStateCommitment()
 	if !ok {
-		log.Error().Msg("could not get final state: no chunks found")
+		// set to start state next line will fail anyways
+		finalState = executionStateDelta.StartState
 	}
 
 	if !bytes.Equal(finalState, executionStateDelta.EndState) {

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -678,7 +678,7 @@ func (e *Engine) handleComputationResult(
 		return nil, fmt.Errorf("could not send broadcast order: %w", err)
 	}
 
-	return receipt.ExecutionResult.FinalStateCommit, nil
+	return receipt.ExecutionResult.FinalStateCommit(), nil
 }
 
 func (e *Engine) saveExecutionResults(
@@ -878,7 +878,6 @@ func (e *Engine) generateExecutionResultForBlock(
 		ExecutionResultBody: flow.ExecutionResultBody{
 			PreviousResultID: previousErID,
 			BlockID:          block.ID(),
-			FinalStateCommit: endState,
 			Chunks:           chunks,
 		},
 	}
@@ -1155,9 +1154,9 @@ func (e *Engine) saveDelta(ctx context.Context, executionStateDelta *messages.Ex
 		log.Fatal().Err(err).Msg("fatal error while processing sync message")
 	}
 
-	if !bytes.Equal(executionReceipt.ExecutionResult.FinalStateCommit, executionStateDelta.EndState) {
+	if !bytes.Equal(executionReceipt.ExecutionResult.FinalStateCommit(), executionStateDelta.EndState) {
 		log.Fatal().
-			Hex("saved_state", executionReceipt.ExecutionResult.FinalStateCommit).
+			Hex("saved_state", executionReceipt.ExecutionResult.FinalStateCommit()).
 			Hex("delta_end_state", executionStateDelta.EndState).
 			Hex("delta_start_state", executionStateDelta.StartState).
 			Err(err).Msg("processing sync message produced unexpected state commitment")
@@ -1243,7 +1242,7 @@ func (e *Engine) saveDelta(ctx context.Context, executionStateDelta *messages.Ex
 		for _, queue := range newQueues {
 			if !bytes.Equal(
 				queue.Head.Item.(*messages.ExecutionStateDelta).StartState,
-				executionReceipt.ExecutionResult.FinalStateCommit,
+				executionReceipt.ExecutionResult.FinalStateCommit(),
 			) {
 				return fmt.Errorf("internal incosistency with delta - state commitment for after applying delta different from start state of next one! ")
 			}

--- a/engine/execution/provider/engine.go
+++ b/engine/execution/provider/engine.go
@@ -203,6 +203,10 @@ func (e *Engine) onChunkDataRequest(
 }
 
 func (e *Engine) BroadcastExecutionReceipt(ctx context.Context, receipt *flow.ExecutionReceipt) error {
+	finalState, ok := receipt.ExecutionResult.FinalStateCommitment()
+	if !ok {
+		return fmt.Errorf("could not get final state: no chunks found")
+	}
 
 	span, _ := e.tracer.StartSpanFromContext(ctx, trace.EXEBroadcastExecutionReceipt)
 	defer span.Finish()
@@ -210,7 +214,7 @@ func (e *Engine) BroadcastExecutionReceipt(ctx context.Context, receipt *flow.Ex
 	e.log.Debug().
 		Hex("block_id", logging.ID(receipt.ExecutionResult.BlockID)).
 		Hex("receipt_id", logging.Entity(receipt)).
-		Hex("final_state", receipt.ExecutionResult.FinalStateCommit()).
+		Hex("final_state", finalState).
 		Msg("broadcasting execution receipt")
 
 	identities, err := e.state.Final().Identities(filter.HasRole(flow.RoleAccess, flow.RoleConsensus,

--- a/engine/execution/provider/engine.go
+++ b/engine/execution/provider/engine.go
@@ -210,7 +210,7 @@ func (e *Engine) BroadcastExecutionReceipt(ctx context.Context, receipt *flow.Ex
 	e.log.Debug().
 		Hex("block_id", logging.ID(receipt.ExecutionResult.BlockID)).
 		Hex("receipt_id", logging.Entity(receipt)).
-		Hex("final_state", receipt.ExecutionResult.FinalStateCommit).
+		Hex("final_state", receipt.ExecutionResult.FinalStateCommit()).
 		Msg("broadcasting execution receipt")
 
 	identities, err := e.state.Final().Identities(filter.HasRole(flow.RoleAccess, flow.RoleConsensus,

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -475,8 +475,13 @@ func (e *Engine) handleChunkDataPack(originID flow.Identifier,
 	var endState flow.StateCommitment
 	if int(status.Chunk.Index) == len(result.ExecutionResult.Chunks)-1 {
 		// last chunk in a result is the system chunk and takes final state commitment
+		finalState, ok := result.ExecutionResult.FinalStateCommitment()
+		if !ok {
+			return fmt.Errorf("could not get final state: no chunks found")
+		}
+
 		isSystemChunk = true
-		endState = result.ExecutionResult.FinalStateCommit()
+		endState = finalState
 	} else {
 		// any chunk except last takes the subsequent chunk's start state
 		isSystemChunk = false

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -476,7 +476,7 @@ func (e *Engine) handleChunkDataPack(originID flow.Identifier,
 	if int(status.Chunk.Index) == len(result.ExecutionResult.Chunks)-1 {
 		// last chunk in a result is the system chunk and takes final state commitment
 		isSystemChunk = true
-		endState = result.ExecutionResult.FinalStateCommit
+		endState = result.ExecutionResult.FinalStateCommit()
 	} else {
 		// any chunk except last takes the subsequent chunk's start state
 		isSystemChunk = false

--- a/engine/verification/test/helper.go
+++ b/engine/verification/test/helper.go
@@ -468,7 +468,7 @@ func VerifiableDataChunk(chunkIndex uint64, er utils.CompleteExecutionResult) *v
 	var endState flow.StateCommitment
 	// last chunk
 	if int(chunkIndex) == len(er.Receipt.ExecutionResult.Chunks)-1 {
-		endState = er.Receipt.ExecutionResult.FinalStateCommit
+		endState = er.Receipt.ExecutionResult.FinalStateCommit()
 	} else {
 		endState = er.Receipt.ExecutionResult.Chunks[chunkIndex+1].StartState
 	}

--- a/engine/verification/test/helper.go
+++ b/engine/verification/test/helper.go
@@ -468,7 +468,8 @@ func VerifiableDataChunk(chunkIndex uint64, er utils.CompleteExecutionResult) *v
 	var endState flow.StateCommitment
 	// last chunk
 	if int(chunkIndex) == len(er.Receipt.ExecutionResult.Chunks)-1 {
-		endState = er.Receipt.ExecutionResult.FinalStateCommit()
+		finalState, _ := er.Receipt.ExecutionResult.FinalStateCommitment()
+		endState = finalState
 	} else {
 		endState = er.Receipt.ExecutionResult.Chunks[chunkIndex+1].StartState
 	}

--- a/engine/verification/test/helper.go
+++ b/engine/verification/test/helper.go
@@ -464,11 +464,12 @@ func SetupMockVerifierEng(t testing.TB,
 	return eng, &wg
 }
 
-func VerifiableDataChunk(chunkIndex uint64, er utils.CompleteExecutionResult) *verification.VerifiableChunkData {
+func VerifiableDataChunk(t *testing.T, chunkIndex uint64, er utils.CompleteExecutionResult) *verification.VerifiableChunkData {
 	var endState flow.StateCommitment
 	// last chunk
 	if int(chunkIndex) == len(er.Receipt.ExecutionResult.Chunks)-1 {
-		finalState, _ := er.Receipt.ExecutionResult.FinalStateCommitment()
+		finalState, ok := er.Receipt.ExecutionResult.FinalStateCommitment()
+		require.True(t, ok)
 		endState = finalState
 	} else {
 		endState = er.Receipt.ExecutionResult.Chunks[chunkIndex+1].StartState

--- a/engine/verification/utils/fixtures.go
+++ b/engine/verification/utils/fixtures.go
@@ -146,9 +146,8 @@ func CompleteExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Cha
 
 	result := flow.ExecutionResult{
 		ExecutionResultBody: flow.ExecutionResultBody{
-			BlockID:          block.ID(),
-			Chunks:           chunks,
-			FinalStateCommit: chunks[len(chunks)-1].EndState,
+			BlockID: block.ID(),
+			Chunks:  chunks,
 		},
 	}
 

--- a/integration/tests/common/receipt_state.go
+++ b/integration/tests/common/receipt_state.go
@@ -65,12 +65,14 @@ func (rs *ReceiptState) WaitForReceiptFrom(t *testing.T, blockID, executorID flo
 func WaitUntilFinalizedStateCommitmentChanged(t *testing.T, bs *BlockState, rs *ReceiptState) (*messages.BlockProposal,
 	*flow.ExecutionReceipt) {
 
+	r1finalState, _ := r1.ExecutionResult.FinalStateCommitment()
+
 	// get the state commitment for the highest finalized block
 	initialFinalizedSC := unittest.GenesisStateCommitment
 	b1, ok := bs.HighestFinalized()
 	if ok {
 		r1 := rs.WaitForReceiptFromAny(t, b1.Header.ID())
-		initialFinalizedSC = r1.ExecutionResult.FinalStateCommit()
+		initialFinalizedSC = r1finalState
 	}
 
 	currentHeight := b1.Header.Height + 1
@@ -85,7 +87,8 @@ func WaitUntilFinalizedStateCommitmentChanged(t *testing.T, bs *BlockState, rs *
 		}
 		currentID = b2.Header.ID()
 		r2 = rs.WaitForReceiptFromAny(t, b2.Header.ID())
-		if bytes.Compare(initialFinalizedSC, r2.ExecutionResult.FinalStateCommit()) == 0 {
+		r2finalState, _ := r2.ExecutionResult.FinalStateCommitment()
+		if bytes.Compare(initialFinalizedSC, r2finalState) == 0 {
 			// received a new execution result for the next finalized block, but it has the same final state commitment
 			// check the next finalized block
 			currentHeight++

--- a/integration/tests/common/receipt_state.go
+++ b/integration/tests/common/receipt_state.go
@@ -65,7 +65,8 @@ func (rs *ReceiptState) WaitForReceiptFrom(t *testing.T, blockID, executorID flo
 func WaitUntilFinalizedStateCommitmentChanged(t *testing.T, bs *BlockState, rs *ReceiptState) (*messages.BlockProposal,
 	*flow.ExecutionReceipt) {
 
-	r1finalState, _ := r1.ExecutionResult.FinalStateCommitment()
+	r1finalState, ok := r1.ExecutionResult.FinalStateCommitment()
+	require.True(t, ok)
 
 	// get the state commitment for the highest finalized block
 	initialFinalizedSC := unittest.GenesisStateCommitment
@@ -87,7 +88,8 @@ func WaitUntilFinalizedStateCommitmentChanged(t *testing.T, bs *BlockState, rs *
 		}
 		currentID = b2.Header.ID()
 		r2 = rs.WaitForReceiptFromAny(t, b2.Header.ID())
-		r2finalState, _ := r2.ExecutionResult.FinalStateCommitment()
+		r2finalState, ok := r2.ExecutionResult.FinalStateCommitment()
+		require.True(t, ok)
 		if bytes.Compare(initialFinalizedSC, r2finalState) == 0 {
 			// received a new execution result for the next finalized block, but it has the same final state commitment
 			// check the next finalized block

--- a/integration/tests/common/receipt_state.go
+++ b/integration/tests/common/receipt_state.go
@@ -70,7 +70,7 @@ func WaitUntilFinalizedStateCommitmentChanged(t *testing.T, bs *BlockState, rs *
 	b1, ok := bs.HighestFinalized()
 	if ok {
 		r1 := rs.WaitForReceiptFromAny(t, b1.Header.ID())
-		initialFinalizedSC = r1.ExecutionResult.FinalStateCommit
+		initialFinalizedSC = r1.ExecutionResult.FinalStateCommit()
 	}
 
 	currentHeight := b1.Header.Height + 1
@@ -85,7 +85,7 @@ func WaitUntilFinalizedStateCommitmentChanged(t *testing.T, bs *BlockState, rs *
 		}
 		currentID = b2.Header.ID()
 		r2 = rs.WaitForReceiptFromAny(t, b2.Header.ID())
-		if bytes.Compare(initialFinalizedSC, r2.ExecutionResult.FinalStateCommit) == 0 {
+		if bytes.Compare(initialFinalizedSC, r2.ExecutionResult.FinalStateCommit()) == 0 {
 			// received a new execution result for the next finalized block, but it has the same final state commitment
 			// check the next finalized block
 			currentHeight++

--- a/integration/tests/common/testnet_state_tracker.go
+++ b/integration/tests/common/testnet_state_tracker.go
@@ -87,12 +87,13 @@ func (tst *TestnetStateTracker) Track(t *testing.T, ctx context.Context, ghost *
 					m.Body.ExecutionResultID,
 					m.Body.ChunkIndex)
 			case *flow.ExecutionReceipt:
+				finalState, _ := m.ExecutionResult.FinalStateCommitment()
 				tst.ReceiptState.Add(m)
 				t.Logf("execution receipts received from %s for block ID %x by executor ID %x with SC %x resultID %x",
 					sender,
 					m.ExecutionResult.BlockID,
 					m.ExecutorID,
-					m.ExecutionResult.FinalStateCommit(),
+					finalState,
 					m.ExecutionResult.ID())
 			default:
 				t.Logf("other msg received from %s: %#v", sender, msg)

--- a/integration/tests/common/testnet_state_tracker.go
+++ b/integration/tests/common/testnet_state_tracker.go
@@ -92,7 +92,7 @@ func (tst *TestnetStateTracker) Track(t *testing.T, ctx context.Context, ghost *
 					sender,
 					m.ExecutionResult.BlockID,
 					m.ExecutorID,
-					m.ExecutionResult.FinalStateCommit,
+					m.ExecutionResult.FinalStateCommit(),
 					m.ExecutionResult.ID())
 			default:
 				t.Logf("other msg received from %s: %#v", sender, msg)

--- a/integration/tests/common/testnet_state_tracker.go
+++ b/integration/tests/common/testnet_state_tracker.go
@@ -87,7 +87,9 @@ func (tst *TestnetStateTracker) Track(t *testing.T, ctx context.Context, ghost *
 					m.Body.ExecutionResultID,
 					m.Body.ChunkIndex)
 			case *flow.ExecutionReceipt:
-				finalState, _ := m.ExecutionResult.FinalStateCommitment()
+				finalState, ok := m.ExecutionResult.FinalStateCommitment()
+				require.True(t, ok)
+
 				tst.ReceiptState.Add(m)
 				t.Logf("execution receipts received from %s for block ID %x by executor ID %x with SC %x resultID %x",
 					sender,

--- a/integration/tests/consensus/sealing_test.go
+++ b/integration/tests/consensus/sealing_test.go
@@ -194,7 +194,6 @@ SearchLoop:
 		ExecutionResultBody: flow.ExecutionResultBody{
 			PreviousResultID: resultID,               // need genesis result
 			BlockID:          targetID,               // refer the target block
-			FinalStateCommit: chunk.EndState,         // end state of only chunk
 			Chunks:           flow.ChunkList{&chunk}, // include only chunk
 		},
 		Signatures: nil,

--- a/integration/tests/execution/chunk_data_pack_test.go
+++ b/integration/tests/execution/chunk_data_pack_test.go
@@ -34,7 +34,7 @@ func (gs *ChunkDataPacksSuite) TestVerificationNodesRequestChunkDataPacks() {
 
 	// wait for execution receipt for blockA from execution node 1
 	erExe1BlockA := gs.ReceiptState.WaitForReceiptFrom(gs.T(), blockA.Header.ID(), gs.exe1ID)
-	gs.T().Logf("got erExe1BlockA with SC %x", erExe1BlockA.ExecutionResult.FinalStateCommit)
+	gs.T().Logf("got erExe1BlockA with SC %x", erExe1BlockA.ExecutionResult.FinalStateCommit())
 
 	// assert there were no ChunkDataRequests from the verification node yet
 	require.Equal(gs.T(), 0, gs.MsgState.LenFrom(gs.verID),
@@ -50,7 +50,7 @@ func (gs *ChunkDataPacksSuite) TestVerificationNodesRequestChunkDataPacks() {
 
 	// wait for execution receipt for blockB from execution node 1
 	erExe1BlockB := gs.ReceiptState.WaitForReceiptFrom(gs.T(), blockB.Header.ID(), gs.exe1ID)
-	gs.T().Logf("got erExe1BlockB with SC %x", erExe1BlockB.ExecutionResult.FinalStateCommit)
+	gs.T().Logf("got erExe1BlockB with SC %x", erExe1BlockB.ExecutionResult.FinalStateCommit())
 
 	// extract chunk ID from execution receipt
 	// expecting the chunk itself plus the system chunk

--- a/integration/tests/execution/chunk_data_pack_test.go
+++ b/integration/tests/execution/chunk_data_pack_test.go
@@ -34,7 +34,8 @@ func (gs *ChunkDataPacksSuite) TestVerificationNodesRequestChunkDataPacks() {
 
 	// wait for execution receipt for blockA from execution node 1
 	erExe1BlockA := gs.ReceiptState.WaitForReceiptFrom(gs.T(), blockA.Header.ID(), gs.exe1ID)
-	finalStateErExec1BlockA, _ := erExe1BlockA.ExecutionResult.FinalStateCommitment()
+	finalStateErExec1BlockA, ok := erExe1BlockA.ExecutionResult.FinalStateCommitment()
+	require.True(gs.T(), ok)
 	gs.T().Logf("got erExe1BlockA with SC %x", finalStateErExec1BlockA)
 
 	// assert there were no ChunkDataRequests from the verification node yet
@@ -51,7 +52,8 @@ func (gs *ChunkDataPacksSuite) TestVerificationNodesRequestChunkDataPacks() {
 
 	// wait for execution receipt for blockB from execution node 1
 	erExe1BlockB := gs.ReceiptState.WaitForReceiptFrom(gs.T(), blockB.Header.ID(), gs.exe1ID)
-	finalStateErExec1BlockB, _ := erExe1BlockB.ExecutionResult.FinalStateCommitment()
+	finalStateErExec1BlockB, ok := erExe1BlockB.ExecutionResult.FinalStateCommitment()
+	require.True(gs.T(), ok)
 	gs.T().Logf("got erExe1BlockB with SC %x", finalStateErExec1BlockB)
 
 	// extract chunk ID from execution receipt

--- a/integration/tests/execution/chunk_data_pack_test.go
+++ b/integration/tests/execution/chunk_data_pack_test.go
@@ -34,7 +34,8 @@ func (gs *ChunkDataPacksSuite) TestVerificationNodesRequestChunkDataPacks() {
 
 	// wait for execution receipt for blockA from execution node 1
 	erExe1BlockA := gs.ReceiptState.WaitForReceiptFrom(gs.T(), blockA.Header.ID(), gs.exe1ID)
-	gs.T().Logf("got erExe1BlockA with SC %x", erExe1BlockA.ExecutionResult.FinalStateCommit())
+	finalStateErExec1BlockA, _ := erExe1BlockA.ExecutionResult.FinalStateCommitment()
+	gs.T().Logf("got erExe1BlockA with SC %x", finalStateErExec1BlockA)
 
 	// assert there were no ChunkDataRequests from the verification node yet
 	require.Equal(gs.T(), 0, gs.MsgState.LenFrom(gs.verID),
@@ -50,7 +51,8 @@ func (gs *ChunkDataPacksSuite) TestVerificationNodesRequestChunkDataPacks() {
 
 	// wait for execution receipt for blockB from execution node 1
 	erExe1BlockB := gs.ReceiptState.WaitForReceiptFrom(gs.T(), blockB.Header.ID(), gs.exe1ID)
-	gs.T().Logf("got erExe1BlockB with SC %x", erExe1BlockB.ExecutionResult.FinalStateCommit())
+	finalStateErExec1BlockB, _ := erExe1BlockB.ExecutionResult.FinalStateCommitment()
+	gs.T().Logf("got erExe1BlockB with SC %x", finalStateErExec1BlockB)
 
 	// extract chunk ID from execution receipt
 	// expecting the chunk itself plus the system chunk

--- a/integration/tests/execution/failing_tx_reverted_test.go
+++ b/integration/tests/execution/failing_tx_reverted_test.go
@@ -64,8 +64,8 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 
 	// wait for execution receipt for blockC from execution node 1
 	erBlockC := s.ReceiptState.WaitForReceiptFrom(s.T(), blockC.Header.ID(), s.exe1ID)
-	s.T().Logf("got erBlockC with SC %x", erBlockC.ExecutionResult.FinalStateCommit)
+	s.T().Logf("got erBlockC with SC %x", erBlockC.ExecutionResult.FinalStateCommit())
 
 	// assert that state did not change between blockB and blockC
-	require.Equal(s.T(), erBlockB.ExecutionResult.FinalStateCommit, erBlockC.ExecutionResult.FinalStateCommit)
+	require.Equal(s.T(), erBlockB.ExecutionResult.FinalStateCommit(), erBlockC.ExecutionResult.FinalStateCommit())
 }

--- a/integration/tests/execution/failing_tx_reverted_test.go
+++ b/integration/tests/execution/failing_tx_reverted_test.go
@@ -62,10 +62,14 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 	blockC := s.BlockState.WaitUntilNextHeightFinalized(s.T())
 	s.T().Logf("got blockC height %v ID %v", blockC.Header.Height, blockC.Header.ID())
 
+	// final states
+	finalStateBlockB, _ := erBlockB.ExecutionResult.FinalStateCommitment()
+	finalStateBlockC, _ := erBlockC.ExecutionResult.FinalStateCommitment()
+
 	// wait for execution receipt for blockC from execution node 1
 	erBlockC := s.ReceiptState.WaitForReceiptFrom(s.T(), blockC.Header.ID(), s.exe1ID)
-	s.T().Logf("got erBlockC with SC %x", erBlockC.ExecutionResult.FinalStateCommit())
+	s.T().Logf("got erBlockC with SC %x", finalStateBlockC)
 
 	// assert that state did not change between blockB and blockC
-	require.Equal(s.T(), erBlockB.ExecutionResult.FinalStateCommit(), erBlockC.ExecutionResult.FinalStateCommit())
+	require.Equal(s.T(), finalStateBlockB, finalStateBlockC)
 }

--- a/integration/tests/execution/failing_tx_reverted_test.go
+++ b/integration/tests/execution/failing_tx_reverted_test.go
@@ -63,8 +63,10 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 	s.T().Logf("got blockC height %v ID %v", blockC.Header.Height, blockC.Header.ID())
 
 	// final states
-	finalStateBlockB, _ := erBlockB.ExecutionResult.FinalStateCommitment()
-	finalStateBlockC, _ := erBlockC.ExecutionResult.FinalStateCommitment()
+	finalStateBlockB, ok := erBlockB.ExecutionResult.FinalStateCommitment()
+	require.True(s.T(), ok)
+	finalStateBlockC, ok := erBlockC.ExecutionResult.FinalStateCommitment()
+	require.True(s.T(), ok)
 
 	// wait for execution receipt for blockC from execution node 1
 	erBlockC := s.ReceiptState.WaitForReceiptFrom(s.T(), blockC.Header.ID(), s.exe1ID)

--- a/integration/tests/execution/state_sync_test.go
+++ b/integration/tests/execution/state_sync_test.go
@@ -31,7 +31,7 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockA from execution node 1
 	erExe1BlockA := s.ReceiptState.WaitForReceiptFrom(s.T(), blockA.Header.ID(), s.exe1ID)
-	s.T().Logf("got erExe1BlockA with SC %x", erExe1BlockA.ExecutionResult.FinalStateCommit)
+	s.T().Logf("got erExe1BlockA with SC %x", erExe1BlockA.ExecutionResult.FinalStateCommit())
 
 	// send transaction
 	err := s.AccessClient().DeployContract(context.Background(), sdk.Identifier(s.net.Root().ID()), common.CounterContract)
@@ -43,11 +43,11 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockB from execution node 1
 	erExe1BlockB := s.ReceiptState.WaitForReceiptFrom(s.T(), blockB.Header.ID(), s.exe1ID)
-	s.T().Logf("got erExe1BlockB with SC %x", erExe1BlockB.ExecutionResult.FinalStateCommit)
+	s.T().Logf("got erExe1BlockB with SC %x", erExe1BlockB.ExecutionResult.FinalStateCommit())
 
 	// require that state between blockA and blockB has changed
-	require.NotEqual(s.T(), erExe1BlockA.ExecutionResult.FinalStateCommit,
-		erExe1BlockB.ExecutionResult.FinalStateCommit)
+	require.NotEqual(s.T(), erExe1BlockA.ExecutionResult.FinalStateCommit(),
+		erExe1BlockB.ExecutionResult.FinalStateCommit())
 
 	// wait until the next proposed block is finalized, called blockC
 	blockC := s.BlockState.WaitUntilNextHeightFinalized(s.T())
@@ -55,10 +55,10 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockC from execution node 1
 	erExe1BlockC := s.ReceiptState.WaitForReceiptFrom(s.T(), blockC.Header.ID(), s.exe1ID)
-	s.T().Logf("got erExe1BlockC with SC %x", erExe1BlockC.ExecutionResult.FinalStateCommit)
+	s.T().Logf("got erExe1BlockC with SC %x", erExe1BlockC.ExecutionResult.FinalStateCommit())
 
 	// require that state between blockB and blockC has not changed
-	require.Equal(s.T(), erExe1BlockB.ExecutionResult.FinalStateCommit, erExe1BlockC.ExecutionResult.FinalStateCommit)
+	require.Equal(s.T(), erExe1BlockB.ExecutionResult.FinalStateCommit(), erExe1BlockC.ExecutionResult.FinalStateCommit())
 
 	// send a ExecutionStateSyncRequest from Ghost node
 	err = s.Ghost().Send(context.Background(), engine.SyncExecution,
@@ -69,5 +69,5 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 	// wait for ExecutionStateDelta
 	msg2 := s.MsgState.WaitForMsgFrom(s.T(), common.MsgIsExecutionStateDeltaWithChanges, s.exe1ID)
 	executionStateDelta := msg2.(*messages.ExecutionStateDelta)
-	require.Equal(s.T(), erExe1BlockB.ExecutionResult.FinalStateCommit, executionStateDelta.EndState)
+	require.Equal(s.T(), erExe1BlockB.ExecutionResult.FinalStateCommit(), executionStateDelta.EndState)
 }

--- a/integration/tests/execution/state_sync_test.go
+++ b/integration/tests/execution/state_sync_test.go
@@ -31,7 +31,8 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockA from execution node 1
 	erExe1BlockA := s.ReceiptState.WaitForReceiptFrom(s.T(), blockA.Header.ID(), s.exe1ID)
-	finalStateExe1BlockA, _ := erExe1BlockA.ExecutionResult.FinalStateCommitment()
+	finalStateExe1BlockA, ok := erExe1BlockA.ExecutionResult.FinalStateCommitment()
+	require.True(s.T(), ok)
 	s.T().Logf("got erExe1BlockA with SC %x", finalStateExe1BlockA)
 
 	// send transaction
@@ -44,7 +45,8 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockB from execution node 1
 	erExe1BlockB := s.ReceiptState.WaitForReceiptFrom(s.T(), blockB.Header.ID(), s.exe1ID)
-	finalStateExe1BlockB, _ := erExe1BlockB.ExecutionResult.FinalStateCommitment()
+	finalStateExe1BlockB, ok := erExe1BlockB.ExecutionResult.FinalStateCommitment()
+	require.True(s.T(), ok)
 	s.T().Logf("got erExe1BlockB with SC %x", finalStateExe1BlockB)
 
 	// require that state between blockA and blockB has changed
@@ -56,7 +58,8 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockC from execution node 1
 	erExe1BlockC := s.ReceiptState.WaitForReceiptFrom(s.T(), blockC.Header.ID(), s.exe1ID)
-	finalStateExe1BlockC, _ := erExe1BlockC.ExecutionResult.FinalStateCommitment()
+	finalStateExe1BlockC, ok := erExe1BlockC.ExecutionResult.FinalStateCommitment()
+	require.True(s.T(), ok)
 	s.T().Logf("got erExe1BlockC with SC %x", finalStateExe1BlockC)
 
 	// require that state between blockB and blockC has not changed

--- a/integration/tests/execution/state_sync_test.go
+++ b/integration/tests/execution/state_sync_test.go
@@ -31,7 +31,8 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockA from execution node 1
 	erExe1BlockA := s.ReceiptState.WaitForReceiptFrom(s.T(), blockA.Header.ID(), s.exe1ID)
-	s.T().Logf("got erExe1BlockA with SC %x", erExe1BlockA.ExecutionResult.FinalStateCommit())
+	finalStateExe1BlockA, _ := erExe1BlockA.ExecutionResult.FinalStateCommitment()
+	s.T().Logf("got erExe1BlockA with SC %x", finalStateExe1BlockA)
 
 	// send transaction
 	err := s.AccessClient().DeployContract(context.Background(), sdk.Identifier(s.net.Root().ID()), common.CounterContract)
@@ -43,11 +44,11 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockB from execution node 1
 	erExe1BlockB := s.ReceiptState.WaitForReceiptFrom(s.T(), blockB.Header.ID(), s.exe1ID)
-	s.T().Logf("got erExe1BlockB with SC %x", erExe1BlockB.ExecutionResult.FinalStateCommit())
+	finalStateExe1BlockB, _ := erExe1BlockB.ExecutionResult.FinalStateCommitment()
+	s.T().Logf("got erExe1BlockB with SC %x", finalStateExe1BlockB)
 
 	// require that state between blockA and blockB has changed
-	require.NotEqual(s.T(), erExe1BlockA.ExecutionResult.FinalStateCommit(),
-		erExe1BlockB.ExecutionResult.FinalStateCommit())
+	require.NotEqual(s.T(), finalStateExe1BlockA, finalStateExe1BlockB)
 
 	// wait until the next proposed block is finalized, called blockC
 	blockC := s.BlockState.WaitUntilNextHeightFinalized(s.T())
@@ -55,10 +56,11 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 
 	// wait for execution receipt for blockC from execution node 1
 	erExe1BlockC := s.ReceiptState.WaitForReceiptFrom(s.T(), blockC.Header.ID(), s.exe1ID)
-	s.T().Logf("got erExe1BlockC with SC %x", erExe1BlockC.ExecutionResult.FinalStateCommit())
+	finalStateExe1BlockC, _ := erExe1BlockC.ExecutionResult.FinalStateCommitment()
+	s.T().Logf("got erExe1BlockC with SC %x", finalStateExe1BlockC)
 
 	// require that state between blockB and blockC has not changed
-	require.Equal(s.T(), erExe1BlockB.ExecutionResult.FinalStateCommit(), erExe1BlockC.ExecutionResult.FinalStateCommit())
+	require.Equal(s.T(), finalStateExe1BlockB, finalStateExe1BlockC)
 
 	// send a ExecutionStateSyncRequest from Ghost node
 	err = s.Ghost().Send(context.Background(), engine.SyncExecution,
@@ -69,5 +71,5 @@ func (s *StateSyncSuite) TestStateSyncAfterNetworkPartition() {
 	// wait for ExecutionStateDelta
 	msg2 := s.MsgState.WaitForMsgFrom(s.T(), common.MsgIsExecutionStateDeltaWithChanges, s.exe1ID)
 	executionStateDelta := msg2.(*messages.ExecutionStateDelta)
-	require.Equal(s.T(), erExe1BlockB.ExecutionResult.FinalStateCommit(), executionStateDelta.EndState)
+	require.Equal(s.T(), finalStateExe1BlockB, executionStateDelta.EndState)
 }

--- a/model/chunks/chunks.go
+++ b/model/chunks/chunks.go
@@ -1,0 +1,18 @@
+package chunks
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// ChunkListFromCommit creates a chunklist with one chunk whos final state is
+// the commit
+func ChunkListFromCommit(commit flow.StateCommitment) flow.ChunkList {
+	chunks := flow.ChunkList{}
+	chunk := &flow.Chunk{
+		Index:    0,
+		EndState: commit,
+	}
+	chunks.Insert(chunk)
+
+	return chunks
+}

--- a/model/flow/executionResult.go
+++ b/model/flow/executionResult.go
@@ -4,31 +4,35 @@ import (
 	"github.com/onflow/flow-go/crypto"
 )
 
+// ExecutionResultBody ...
 type ExecutionResultBody struct {
 	PreviousResultID Identifier // commit of the previous ER
 	BlockID          Identifier // commit of the current block
 	Chunks           ChunkList
 }
 
+// ExecutionResult ...
 type ExecutionResult struct {
 	ExecutionResultBody
 	Signatures []crypto.Signature
 }
 
+// ID returns the hash of the execution result body
 func (er ExecutionResult) ID() Identifier {
 	return MakeID(er.ExecutionResultBody)
 }
 
+// Checksum ...
 func (er ExecutionResult) Checksum() Identifier {
 	return MakeID(er)
 }
 
-// FinalStateCommit gets the final state of the result
-// if the number of chunks are 0 returns empty statecommit
-func (er ExecutionResult) FinalStateCommit() StateCommitment {
+// FinalStateCommitment gets the final state of the result and returns false
+// if the number of chunks is 0 (used as a sanity check)
+func (er ExecutionResult) FinalStateCommitment() (StateCommitment, bool) {
 	if er.Chunks.Len() == 0 {
-		return StateCommitment{}
+		return nil, false
 	}
 
-	return er.Chunks[er.Chunks.Len()-1].EndState
+	return er.Chunks[er.Chunks.Len()-1].EndState, true
 }

--- a/model/flow/executionResult.go
+++ b/model/flow/executionResult.go
@@ -24,6 +24,11 @@ func (er ExecutionResult) Checksum() Identifier {
 }
 
 // FinalStateCommit gets the final state of the result
+// if the number of chunks are 0 returns empty statecommit
 func (er ExecutionResult) FinalStateCommit() StateCommitment {
+	if er.Chunks.Len() == 0 {
+		return StateCommitment{}
+	}
+
 	return er.Chunks[er.Chunks.Len()-1].EndState
 }

--- a/model/flow/executionResult.go
+++ b/model/flow/executionResult.go
@@ -5,9 +5,8 @@ import (
 )
 
 type ExecutionResultBody struct {
-	PreviousResultID Identifier      // commit of the previous ER
-	BlockID          Identifier      // commit of the current block
-	FinalStateCommit StateCommitment // final state commitment
+	PreviousResultID Identifier // commit of the previous ER
+	BlockID          Identifier // commit of the current block
 	Chunks           ChunkList
 }
 
@@ -22,4 +21,9 @@ func (er ExecutionResult) ID() Identifier {
 
 func (er ExecutionResult) Checksum() Identifier {
 	return MakeID(er)
+}
+
+// FinalStateCommit gets the final state of the result
+func (er ExecutionResult) FinalStateCommit() StateCommitment {
+	return er.Chunks[er.Chunks.Len()-1].EndState
 }

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -227,7 +227,7 @@ func TestBootstrapWithSeal(t *testing.T) {
 		seal := unittest.SealFixture()
 		seal.BlockID = block.ID()
 		seal.ResultID = result.ID()
-		seal.FinalState = result.FinalStateCommit
+		seal.FinalState = result.FinalStateCommit()
 
 		err := state.Mutate().Bootstrap(block, result, seal)
 		require.Error(t, err)

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -224,10 +224,13 @@ func TestBootstrapWithSeal(t *testing.T) {
 		result := unittest.ExecutionResultFixture()
 		result.BlockID = block.ID()
 
+		finalState, ok := result.FinalStateCommitment()
+		require.True(t, ok)
+
 		seal := unittest.SealFixture()
 		seal.BlockID = block.ID()
 		seal.ResultID = result.ID()
-		seal.FinalState = result.FinalStateCommit()
+		seal.FinalState = finalState
 
 		err := state.Mutate().Bootstrap(block, result, seal)
 		require.Error(t, err)

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -11,6 +11,7 @@ import (
 	hotstuff "github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/engine/verification"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
@@ -124,6 +125,10 @@ func BlockWithParentFixture(parent *flow.Header) flow.Block {
 	}
 }
 
+func StateInteractionsFixture() *delta.Snapshot {
+	return delta.NewView(nil).Interactions()
+}
+
 func StateDeltaWithParentFixture(parent *flow.Header) *messages.ExecutionStateDelta {
 	payload := PayloadFixture()
 	header := BlockHeaderWithParentFixture(parent)
@@ -132,10 +137,15 @@ func StateDeltaWithParentFixture(parent *flow.Header) *messages.ExecutionStateDe
 		Header:  &header,
 		Payload: payload,
 	}
+
+	var stateInteractions []*delta.Snapshot
+	stateInteractions = append(stateInteractions, StateInteractionsFixture())
+
 	return &messages.ExecutionStateDelta{
 		ExecutableBlock: entity.ExecutableBlock{
 			Block: &block,
 		},
+		StateInteractions: stateInteractions,
 	}
 }
 

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -6,6 +6,8 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/onflow/flow-go/model/chunks"
+
 	sdk "github.com/onflow/flow-go-sdk"
 
 	hotstuff "github.com/onflow/flow-go/consensus/hotstuff/model"
@@ -266,9 +268,10 @@ func CollectionGuaranteesFixture(n int, options ...func(*flow.CollectionGuarante
 
 func SealFromResult(result *flow.ExecutionResult) func(*flow.Seal) {
 	return func(seal *flow.Seal) {
+		finalState, _ := result.FinalStateCommitment()
 		seal.ResultID = result.ID()
 		seal.BlockID = result.BlockID
-		seal.FinalState = result.FinalStateCommit()
+		seal.FinalState = finalState
 	}
 }
 
@@ -821,18 +824,11 @@ func BatchListFixture(n int) []flow.Batch {
 }
 
 func BootstrapExecutionResultFixture(block *flow.Block, commit flow.StateCommitment) *flow.ExecutionResult {
-	chunks := flow.ChunkList{}
-	chunk := &flow.Chunk{
-		Index:    0,
-		EndState: commit,
-	}
-	chunks.Insert(chunk)
-
 	result := &flow.ExecutionResult{
 		ExecutionResultBody: flow.ExecutionResultBody{
 			BlockID:          block.ID(),
 			PreviousResultID: flow.ZeroID,
-			Chunks:           chunks,
+			Chunks:           chunks.ChunkListFromCommit(commit),
 		},
 		Signatures: nil,
 	}


### PR DESCRIPTION
- Refactor `FinalStateCommit` to method to return last chunk's `EndState`
- Added check for empty chunks in `ExecutionResult.FinalStateCommit()`
- Fixed tests and captures unhappy path 

The `FinalStateCommit` method in `ExecutionResult` now takes the following signature

```go
// FinalStateCommitment gets the final state of the result and returns false
// if the number of chunks is 0 (used as a sanity check)
func (er ExecutionResult) FinalStateCommitment() (StateCommitment, bool) {
	if er.Chunks.Len() == 0 {
		return nil, false
	}

	return er.Chunks[er.Chunks.Len()-1].EndState, true
}
```