### PR TITLE
Add tracing to protocol state and consensus block builder

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -260,7 +260,7 @@ func main() {
 		// transition between epochs
 		Component("epoch manager", func(node *cmd.FlowNodeBuilder) (module.ReadyDoneAware, error) {
 
-			clusterStateFactory, err := factories.NewClusterStateFactory(node.DB, node.Metrics.Cache)
+			clusterStateFactory, err := factories.NewClusterStateFactory(node.DB, node.Metrics.Cache, node.Tracer)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -259,6 +259,7 @@ func main() {
 				node.Storage.Index,
 				guarantees,
 				seals,
+				node.Tracer,
 				builder.WithMinInterval(minInterval),
 				builder.WithMaxInterval(maxInterval),
 			)

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -387,6 +387,7 @@ func (fnb *FlowNodeBuilder) initState() {
 	distributor := events.NewDistributor()
 	state, err := protocol.NewState(
 		fnb.Metrics.Compliance,
+		fnb.Tracer,
 		fnb.DB,
 		fnb.Storage.Headers,
 		fnb.Storage.Seals,

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -137,7 +137,7 @@ func createNode(
 	statusesDB := storage.NewEpochStatuses(metrics, db)
 	consumer := events.NewNoop()
 
-	state, err := protocol.NewState(metrics, db, headersDB, sealsDB, indexDB, payloadsDB, blocksDB, setupsDB, commitsDB, statusesDB, consumer)
+	state, err := protocol.NewState(metrics, tracer, db, headersDB, sealsDB, indexDB, payloadsDB, blocksDB, setupsDB, commitsDB, statusesDB, consumer)
 	require.NoError(t, err)
 
 	err = state.Mutate().Bootstrap(root, result, seal)

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -189,7 +189,7 @@ func createNode(
 	require.NoError(t, err)
 
 	// initialize the block builder
-	build := builder.NewBuilder(metrics, db, state, headersDB, sealsDB, indexDB, guarantees, seals)
+	build := builder.NewBuilder(metrics, db, state, headersDB, sealsDB, indexDB, guarantees, seals, tracer)
 
 	signer := &Signer{identity.ID()}
 

--- a/engine/collection/epochmgr/factories/builder.go
+++ b/engine/collection/epochmgr/factories/builder.go
@@ -48,11 +48,11 @@ func (f *BuilderFactory) Create(
 
 	build := builder.NewBuilder(
 		f.db,
+		f.trace,
 		f.mainChainHeaders,
 		clusterHeaders,
 		clusterPayloads,
 		pool,
-		f.trace,
 		f.opts...,
 	)
 

--- a/engine/collection/epochmgr/factories/cluster_state.go
+++ b/engine/collection/epochmgr/factories/cluster_state.go
@@ -12,15 +12,18 @@ import (
 type ClusterStateFactory struct {
 	db      *badger.DB
 	metrics module.CacheMetrics
+	tracer  module.Tracer
 }
 
 func NewClusterStateFactory(
 	db *badger.DB,
 	metrics module.CacheMetrics,
+	tracer module.Tracer,
 ) (*ClusterStateFactory, error) {
 	factory := &ClusterStateFactory{
 		db:      db,
 		metrics: metrics,
+		tracer:  tracer,
 	}
 	return factory, nil
 }
@@ -39,6 +42,7 @@ func (f *ClusterStateFactory) Create(clusterID flow.ChainID) (
 
 	clusterState, err := clusterkv.NewState(
 		f.db,
+		f.tracer,
 		clusterID,
 		headers,
 		payloads,

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -64,6 +64,8 @@ func GenericNode(t testing.TB, hub *stub.Hub, identity *flow.Identity, participa
 	db := unittest.BadgerDB(t, dbDir)
 
 	metrics := metrics.NewNoopCollector()
+	tracer, err := trace.NewTracer(log, "test")
+	require.NoError(t, err)
 
 	guarantees := storage.NewGuarantees(metrics, db)
 	seals := storage.NewSeals(metrics, db)
@@ -76,7 +78,7 @@ func GenericNode(t testing.TB, hub *stub.Hub, identity *flow.Identity, participa
 	consumer := events.NewNoop()
 	statuses := storage.NewEpochStatuses(metrics, db)
 
-	state, err := protocol.NewState(metrics, db, headers, seals, index, payloads, blocks, setups, commits, statuses, consumer)
+	state, err := protocol.NewState(metrics, tracer, db, headers, seals, index, payloads, blocks, setups, commits, statuses, consumer)
 	require.NoError(t, err)
 
 	root, result, seal := unittest.BootstrapFixture(participants)
@@ -104,9 +106,6 @@ func GenericNode(t testing.TB, hub *stub.Hub, identity *flow.Identity, participa
 	require.NoError(t, err)
 
 	stubnet := stub.NewNetwork(state, me, hub)
-
-	tracer, err := trace.NewTracer(log, "test")
-	require.NoError(t, err)
 
 	return mock.GenericNode{
 		Log:        log,

--- a/integration/tests/collection/suite_test.go
+++ b/integration/tests/collection/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
 	clusterstate "github.com/onflow/flow-go/state/cluster"
 	clusterstateimpl "github.com/onflow/flow-go/state/cluster/badger"
 	storage "github.com/onflow/flow-go/storage/badger"
@@ -318,11 +319,12 @@ func (suite *CollectorSuite) ClusterStateFor(id flow.Identifier) *clusterstateim
 	require.Nil(suite.T(), err, "could not get node db")
 
 	metrics := metrics.NewNoopCollector()
+	tracer := trace.NewNoopTracer()
 
 	headers := storage.NewHeaders(metrics, db)
 	payloads := storage.NewClusterPayloads(metrics, db)
 
-	state, err := clusterstateimpl.NewState(db, rootBlock.Header.ChainID, headers, payloads)
+	state, err := clusterstateimpl.NewState(db, tracer, rootBlock.Header.ChainID, headers, payloads)
 	require.Nil(suite.T(), err, "could not get cluster state")
 
 	return state

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -51,21 +51,21 @@ func WithExpiryBuffer(buf uint) Opt {
 
 func NewBuilder(
 	db *badger.DB,
+	tracer module.Tracer,
 	mainHeaders storage.Headers,
 	clusterHeaders storage.Headers,
 	payloads storage.ClusterPayloads,
 	transactions mempool.Transactions,
-	tracer module.Tracer,
 	opts ...Opt,
 ) *Builder {
 
 	b := Builder{
 		db:                db,
+		tracer:            tracer,
 		mainHeaders:       mainHeaders,
 		clusterHeaders:    clusterHeaders,
 		payloads:          payloads,
 		transactions:      transactions,
-		tracer:            tracer,
 		maxCollectionSize: 100,
 		expiryBuffer:      15,
 	}

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -51,21 +51,21 @@ func WithExpiryBuffer(buf uint) Opt {
 
 func NewBuilder(
 	db *badger.DB,
-	tracer module.Tracer,
 	mainHeaders storage.Headers,
 	clusterHeaders storage.Headers,
 	payloads storage.ClusterPayloads,
 	transactions mempool.Transactions,
+	tracer module.Tracer,
 	opts ...Opt,
 ) *Builder {
 
 	b := Builder{
 		db:                db,
-		tracer:            tracer,
 		mainHeaders:       mainHeaders,
 		clusterHeaders:    clusterHeaders,
 		payloads:          payloads,
 		transactions:      transactions,
+		tracer:            tracer,
 		maxCollectionSize: 100,
 		expiryBuffer:      15,
 	}
@@ -90,6 +90,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 		// STEP ONE: Load some things we need to do our work.
 		b.tracer.StartSpan(parentID, trace.COLBuildOnSetup)
+		defer b.tracer.FinishSpan(parentID, trace.COLBuildOnSetup)
 
 		var parent flow.Header
 		err := operation.RetrieveHeader(parentID, &parent)(tx)
@@ -121,8 +122,10 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		// part of the chain we care about. We do this separately for
 		// un-finalized and finalized sections of the chain to decide whether to
 		// remove conflicting transactions from the mempool.
+
 		b.tracer.FinishSpan(parentID, trace.COLBuildOnSetup)
 		b.tracer.StartSpan(parentID, trace.COLBuildOnUnfinalizedLookup)
+		defer b.tracer.FinishSpan(parentID, trace.COLBuildOnUnfinalizedLookup)
 
 		// look up previously included transactions in UN-FINALIZED ancestors
 		ancestorID := parentID
@@ -152,6 +155,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 		b.tracer.FinishSpan(parentID, trace.COLBuildOnUnfinalizedLookup)
 		b.tracer.StartSpan(parentID, trace.COLBuildOnFinalizedLookup)
+		defer b.tracer.FinishSpan(parentID, trace.COLBuildOnFinalizedLookup)
 
 		//TODO for now we check a fixed # of finalized ancestors - we should
 		// instead look back based on reference block ID and expiry
@@ -188,6 +192,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		// time figuring out the correct reference block ID for the collection.
 		b.tracer.FinishSpan(parentID, trace.COLBuildOnFinalizedLookup)
 		b.tracer.StartSpan(parentID, trace.COLBuildOnCreatePayload)
+		defer b.tracer.FinishSpan(parentID, trace.COLBuildOnCreatePayload)
 
 		minRefHeight := uint64(math.MaxUint64)
 		// start with the finalized reference ID (longest expiry time)
@@ -251,6 +256,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		// used in the payload and construct the final proposal model
 		b.tracer.FinishSpan(parentID, trace.COLBuildOnCreatePayload)
 		b.tracer.StartSpan(parentID, trace.COLBuildOnCreateHeader)
+		defer b.tracer.FinishSpan(parentID, trace.COLBuildOnCreateHeader)
 
 		// build the payload from the transactions
 		payload := cluster.PayloadFromTransactions(minRefID, transactions...)

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -88,6 +88,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	// and finalized ancestors, so we can differentiate what to do about it.
 
 	b.tracer.StartSpan(parentID, trace.CONBuildOnSetup)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnSetup)
 
 	var finalized uint64
 	err := b.db.View(operation.RetrieveFinalizedHeight(&finalized))
@@ -102,6 +103,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 	b.tracer.FinishSpan(parentID, trace.CONBuildOnSetup)
 	b.tracer.StartSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
 
 	ancestorID := parentID
 	pendingLookup := make(map[flow.Identifier]struct{})
@@ -125,6 +127,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 	b.tracer.FinishSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
 	b.tracer.StartSpan(parentID, trace.CONBuildOnFinalizedLookup)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnFinalizedLookup)
 
 	// we look back only as far as the expiry limit for the current height we
 	// are building for; any guarantee with a reference block before that can
@@ -172,6 +175,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 	b.tracer.FinishSpan(parentID, trace.CONBuildOnFinalizedLookup)
 	b.tracer.StartSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
 
 	// STEP TWO: Go through the guarantees in our memory pool.
 	// 1) If it was already included on the finalized part of the chain, remove
@@ -213,6 +217,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 	b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
 	b.tracer.StartSpan(parentID, trace.CONBuildOnCreatePayloadSeals)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadSeals)
 
 	// STEP FOUR: We try to get all ancestors from last sealed block all the way
 	// to the parent. Then we try to get seals for each of them until we don't
@@ -316,6 +321,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 	b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadSeals)
 	b.tracer.StartSpan(parentID, trace.CONBuildOnCreateHeader)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnCreateHeader)
 
 	// STEP FOUR: We now have guarantees and seals we can validly include
 	// in the payload built on top of the given parent. Now we need to build

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/mempool"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
@@ -22,6 +23,7 @@ import (
 // hash, it also memorizes which entities were included into the payload.
 type Builder struct {
 	metrics  module.MempoolMetrics
+	tracer   module.Tracer
 	db       *badger.DB
 	state    protocol.State
 	seals    storage.Seals
@@ -42,6 +44,7 @@ func NewBuilder(
 	index storage.Index,
 	guarPool mempool.Guarantees,
 	sealPool mempool.Seals,
+	tracer module.Tracer,
 	options ...func(*Config),
 ) *Builder {
 
@@ -61,6 +64,7 @@ func NewBuilder(
 	b := &Builder{
 		metrics:  metrics,
 		db:       db,
+		tracer:   tracer,
 		state:    state,
 		headers:  headers,
 		seals:    seals,
@@ -76,9 +80,14 @@ func NewBuilder(
 // custom setter function to allow the caller to make changes to the header before storing it.
 func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) error) (*flow.Header, error) {
 
+	b.tracer.StartSpan(parentID, trace.CONBuildOn)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOn)
+
 	// STEP ONE: Create a lookup of all previously used guarantees on the part
 	// of the chain that we are building on. We do this separately for pending
 	// and finalized ancestors, so we can differentiate what to do about it.
+
+	b.tracer.StartSpan(parentID, trace.CONBuildOnSetup)
 
 	var finalized uint64
 	err := b.db.View(operation.RetrieveFinalizedHeight(&finalized))
@@ -90,6 +99,9 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	if err != nil {
 		return nil, fmt.Errorf("could not lookup finalized block: %w", err)
 	}
+
+	b.tracer.FinishSpan(parentID, trace.CONBuildOnSetup)
+	b.tracer.StartSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
 
 	ancestorID := parentID
 	pendingLookup := make(map[flow.Identifier]struct{})
@@ -110,6 +122,9 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		}
 		ancestorID = ancestor.ParentID
 	}
+
+	b.tracer.FinishSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
+	b.tracer.StartSpan(parentID, trace.CONBuildOnFinalizedLookup)
 
 	// we look back only as far as the expiry limit for the current height we
 	// are building for; any guarantee with a reference block before that can
@@ -155,6 +170,9 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		ancestorID = ancestor.ParentID
 	}
 
+	b.tracer.FinishSpan(parentID, trace.CONBuildOnFinalizedLookup)
+	b.tracer.StartSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
+
 	// STEP TWO: Go through the guarantees in our memory pool.
 	// 1) If it was already included on the finalized part of the chain, remove
 	// it from the memory pool and skip.
@@ -192,6 +210,9 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	}
 
 	b.metrics.MempoolEntries(metrics.ResourceGuarantee, b.guarPool.Size())
+
+	b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
+	b.tracer.StartSpan(parentID, trace.CONBuildOnCreatePayloadSeals)
 
 	// STEP FOUR: We try to get all ancestors from last sealed block all the way
 	// to the parent. Then we try to get seals for each of them until we don't
@@ -293,6 +314,9 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		last = next
 	}
 
+	b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadSeals)
+	b.tracer.StartSpan(parentID, trace.CONBuildOnCreateHeader)
+
 	// STEP FOUR: We now have guarantees and seals we can validly include
 	// in the payload built on top of the given parent. Now we need to build
 	// and store the block header, as well as index the payload contents.
@@ -345,6 +369,10 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		Header:  header,
 		Payload: payload,
 	}
+
+	b.tracer.FinishSpan(parentID, trace.CONBuildOnCreateHeader)
+	b.tracer.StartSpan(parentID, trace.CONBuildOnDBInsert)
+	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnDBInsert)
 
 	err = b.state.Mutate().Extend(proposal)
 	if err != nil {

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	mempool "github.com/onflow/flow-go/module/mempool/mock"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
 	protocol "github.com/onflow/flow-go/state/protocol/mock"
 	storerr "github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
@@ -79,7 +80,8 @@ func (bs *BuilderSuite) chainSeal(blockID flow.Identifier) {
 func (bs *BuilderSuite) SetupTest() {
 
 	// set up no-op dependencies
-	noop := metrics.NewNoopCollector()
+	noopMetrics := metrics.NewNoopCollector()
+	noopTracer := trace.NewNoopTracer()
 
 	// set up test parameters
 	numFinalized := 4
@@ -244,7 +246,7 @@ func (bs *BuilderSuite) SetupTest() {
 
 	// initialize the builder
 	bs.build = NewBuilder(
-		noop,
+		noopMetrics,
 		bs.db,
 		bs.state,
 		bs.headerDB,
@@ -252,6 +254,7 @@ func (bs *BuilderSuite) SetupTest() {
 		bs.indexDB,
 		bs.guarPool,
 		bs.sealPool,
+		noopTracer,
 	)
 
 	bs.build.cfg.expiry = 11

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onflow/flow-go/module/finalizer/collection"
 	"github.com/onflow/flow-go/module/mempool/stdmap"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
 	networkmock "github.com/onflow/flow-go/network/mock"
 	cluster "github.com/onflow/flow-go/state/cluster/badger"
 	storage "github.com/onflow/flow-go/storage/badger"
@@ -32,11 +33,12 @@ func TestFinalizer(t *testing.T) {
 		genesis := model.Genesis()
 
 		metrics := metrics.NewNoopCollector()
+		tracer := trace.NewNoopTracer()
 
 		headers := storage.NewHeaders(metrics, db)
 		payloads := storage.NewClusterPayloads(metrics, db)
 
-		state, err := cluster.NewState(db, genesis.Header.ChainID, headers, payloads)
+		state, err := cluster.NewState(db, tracer, genesis.Header.ChainID, headers, payloads)
 		require.NoError(t, err)
 		mutator := state.Mutate()
 

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -2,6 +2,25 @@ package trace
 
 // Span names
 const (
+
+	// Common
+	//
+
+	// State
+	// mutator.Extend - full payload check
+	ProtoStateMutatorExtend                = "common.state.proto.mutator.extend"
+	ProtoStateMutatorExtendCheckHeader     = "common.state.proto.mutator.extend.checkHeader"
+	ProtoStateMutatorExtendCheckGuarantees = "common.state.proto.mutator.extend.checkGuarantees"
+	ProtoStateMutatorExtendCheckSeals      = "common.state.proto.mutator.extend.checkSeals"
+	ProtoStateMutatorExtendDBInsert        = "common.state.proto.mutator.extend.dbInsert"
+
+	// mutator.HeaderExtend - header-only check
+	ProtoStateMutatorHeaderExtend              = "common.state.proto.mutator.headerExtend"
+	ProtoStateMutatorHeaderExtendGetLastSealed = "common.state.proto.mutator.headerExtend.lastSealed"
+
+	// mutator.Finalize
+	ProtoStateMutatorFinalize = "common.state.proto.mutator.finalize"
+
 	// Consensus Node
 	//
 
@@ -42,6 +61,7 @@ const (
 	COLBuildOnDBInsert          = "col.builder.dbInsert"
 
 	// Execution Node
+	//
 
 	EXEExecuteBlock           SpanName = "exe.ingestion.executeBlock"
 	EXESaveExecutionResults   SpanName = "exe.ingestion.saveExecutionResults"
@@ -68,6 +88,7 @@ const (
 	EXEGetHighestExecutedBlockID          SpanName = "exe.state.getHighestExecutedBlockID"
 
 	// Verification node
+	//
 
 	VERProcessExecutionReceipt SpanName = "ver.processExecutionReceipt"
 	// children of VERProcessExecutionReceipt

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -3,6 +3,7 @@ package trace
 // Span names
 const (
 	// Consensus Node
+	//
 
 	CONProcessCollection SpanName = "con.processCollection"
 	// children of CONProcessCollection
@@ -18,8 +19,20 @@ const (
 	// children of CONProcessBlock
 	CONHotFinalizeBlock SpanName = "con.hotstuff.finalizeBlock"
 
-	// Collection Node
+	// Builder
+	CONBuildOn                        = "con.builder"
+	CONBuildOnSetup                   = "con.builder.setup"
+	CONBuildOnUnfinalizedLookup       = "con.builder.unfinalizedLookup"
+	CONBuildOnFinalizedLookup         = "con.builder.finalizedLookup"
+	CONBuildOnCreatePayloadGuarantees = "con.builder.createPayload.guarantees"
+	CONBuildOnCreatePayloadSeals      = "con.builder.createPayload.seals"
+	CONBuildOnCreateHeader            = "con.builder.createHeader"
+	CONBuildOnDBInsert                = "con.builder.dbInsert"
 
+	// Collection Node
+	//
+
+	// Builder
 	COLBuildOn                  = "col.builder"
 	COLBuildOnSetup             = "col.builder.setup"
 	COLBuildOnUnfinalizedLookup = "col.builder.unfinalizedLookup"

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -60,6 +60,14 @@ const (
 	COLBuildOnCreateHeader      = "col.builder.createHeader"
 	COLBuildOnDBInsert          = "col.builder.dbInsert"
 
+	// Cluster State
+	COLClusterStateMutatorExtend                       = "col.state.mutator.extend"
+	COLClusterStateMutatorExtendSetup                  = "col.state.mutator.extend.setup"
+	COLClusterStateMutatorExtendCheckAncestry          = "col.state.mutator.extend.ancestry"
+	COLClusterStateMutatorExtendCheckTransactionsValid = "col.state.mutator.extend.transactions.validity"
+	COLClusterStateMutatorExtendCheckTransactionsDupes = "col.state.mutator.extend.transactions.dupes"
+	COLClusterStateMutatorExtendDBInsert               = "col.state.mutator.extend.dbInsert"
+
 	// Execution Node
 	//
 

--- a/state/cluster/badger/mutator.go
+++ b/state/cluster/badger/mutator.go
@@ -95,6 +95,7 @@ func (m *Mutator) Extend(block *cluster.Block) error {
 	err := m.state.db.View(func(tx *badger.Txn) error {
 
 		m.state.tracer.StartSpan(blockID, trace.COLClusterStateMutatorExtendSetup)
+		defer m.state.tracer.FinishSpan(blockID, trace.COLClusterStateMutatorExtendSetup)
 
 		header := block.Header
 		payload := block.Payload
@@ -132,6 +133,7 @@ func (m *Mutator) Extend(block *cluster.Block) error {
 
 		m.state.tracer.FinishSpan(blockID, trace.COLClusterStateMutatorExtendSetup)
 		m.state.tracer.StartSpan(blockID, trace.COLClusterStateMutatorExtendCheckAncestry)
+		defer m.state.tracer.FinishSpan(blockID, trace.COLClusterStateMutatorExtendCheckAncestry)
 
 		// start with the extending block's parent
 		parentID := header.ParentID
@@ -155,6 +157,7 @@ func (m *Mutator) Extend(block *cluster.Block) error {
 
 		m.state.tracer.FinishSpan(blockID, trace.COLClusterStateMutatorExtendCheckAncestry)
 		m.state.tracer.StartSpan(blockID, trace.COLClusterStateMutatorExtendCheckTransactionsValid)
+		defer m.state.tracer.FinishSpan(blockID, trace.COLClusterStateMutatorExtendCheckTransactionsValid)
 
 		// check that all transactions within the collection are valid
 		minRefID := flow.ZeroID

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -15,6 +15,7 @@ import (
 	model "github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state/cluster"
 	protocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/events"
@@ -55,6 +56,7 @@ func (suite *MutatorSuite) SetupTest() {
 	suite.db = unittest.BadgerDB(suite.T(), suite.dbdir)
 
 	metrics := metrics.NewNoopCollector()
+	tracer := trace.NewNoopTracer()
 	headers, _, seals, index, conPayloads, blocks, setups, commits, statuses := util.StorageLayer(suite.T(), suite.db)
 	colPayloads := storage.NewClusterPayloads(metrics, suite.db)
 
@@ -63,7 +65,7 @@ func (suite *MutatorSuite) SetupTest() {
 	suite.mutator = suite.state.Mutate()
 	consumer := events.NewNoop()
 
-	suite.protoState, err = protocol.NewState(metrics, suite.db, headers, seals, index, conPayloads, blocks, setups, commits, statuses, consumer)
+	suite.protoState, err = protocol.NewState(metrics, tracer, suite.db, headers, seals, index, conPayloads, blocks, setups, commits, statuses, consumer)
 	require.NoError(suite.T(), err)
 }
 

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -60,7 +60,7 @@ func (suite *MutatorSuite) SetupTest() {
 	headers, _, seals, index, conPayloads, blocks, setups, commits, statuses := util.StorageLayer(suite.T(), suite.db)
 	colPayloads := storage.NewClusterPayloads(metrics, suite.db)
 
-	suite.state, err = NewState(suite.db, suite.chainID, headers, colPayloads)
+	suite.state, err = NewState(suite.db, tracer, suite.chainID, headers, colPayloads)
 	suite.Assert().Nil(err)
 	suite.mutator = suite.state.Mutate()
 	consumer := events.NewNoop()

--- a/state/cluster/badger/snapshot_test.go
+++ b/state/cluster/badger/snapshot_test.go
@@ -58,7 +58,7 @@ func (suite *SnapshotSuite) SetupTest() {
 	headers, _, seals, index, conPayloads, blocks, setups, commits, statuses := util.StorageLayer(suite.T(), suite.db)
 	colPayloads := storage.NewClusterPayloads(metrics, suite.db)
 
-	suite.state, err = NewState(suite.db, suite.chainID, headers, colPayloads)
+	suite.state, err = NewState(suite.db, tracer, suite.chainID, headers, colPayloads)
 	suite.Assert().Nil(err)
 	suite.mutator = suite.state.Mutate()
 	consumer := events.NewNoop()

--- a/state/cluster/badger/snapshot_test.go
+++ b/state/cluster/badger/snapshot_test.go
@@ -14,6 +14,7 @@ import (
 	model "github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state/cluster"
 	protocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/events"
@@ -52,6 +53,7 @@ func (suite *SnapshotSuite) SetupTest() {
 	suite.db = unittest.BadgerDB(suite.T(), suite.dbdir)
 
 	metrics := metrics.NewNoopCollector()
+	tracer := trace.NewNoopTracer()
 
 	headers, _, seals, index, conPayloads, blocks, setups, commits, statuses := util.StorageLayer(suite.T(), suite.db)
 	colPayloads := storage.NewClusterPayloads(metrics, suite.db)
@@ -62,7 +64,7 @@ func (suite *SnapshotSuite) SetupTest() {
 	consumer := events.NewNoop()
 
 	// just bootstrap with a genesis block, we'll use this as reference
-	suite.protoState, err = protocol.NewState(metrics, suite.db, headers, seals, index, conPayloads, blocks, setups, commits, statuses, consumer)
+	suite.protoState, err = protocol.NewState(metrics, tracer, suite.db, headers, seals, index, conPayloads, blocks, setups, commits, statuses, consumer)
 	suite.Assert().Nil(err)
 	participants := unittest.IdentityListFixture(5, unittest.WithAllRoles())
 	genesis, result, seal := unittest.BootstrapFixture(participants)

--- a/state/cluster/badger/state.go
+++ b/state/cluster/badger/state.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/state/cluster"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
@@ -13,14 +14,16 @@ import (
 
 type State struct {
 	db        *badger.DB
+	tracer    module.Tracer
 	clusterID flow.ChainID
 	headers   storage.Headers
 	payloads  storage.ClusterPayloads
 }
 
-func NewState(db *badger.DB, clusterID flow.ChainID, headers storage.Headers, payloads storage.ClusterPayloads) (*State, error) {
+func NewState(db *badger.DB, tracer module.Tracer, clusterID flow.ChainID, headers storage.Headers, payloads storage.ClusterPayloads) (*State, error) {
 	state := &State{
 		db:        db,
+		tracer:    tracer,
 		clusterID: clusterID,
 		headers:   headers,
 		payloads:  payloads,

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -178,8 +178,9 @@ func (m *Mutator) Bootstrap(root *flow.Block, result *flow.ExecutionResult, seal
 
 func (m *Mutator) HeaderExtend(candidate *flow.Block) error {
 
-	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtend)
-	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtend)
+	blockID := candidate.ID()
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorHeaderExtend)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorHeaderExtend)
 
 	// check if he block header is a valid extension of the finalized state
 	err := m.headerExtend(candidate)
@@ -204,8 +205,9 @@ func (m *Mutator) HeaderExtend(candidate *flow.Block) error {
 
 func (m *Mutator) Extend(candidate *flow.Block) error {
 
-	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtend)
-	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtend)
+	blockID := candidate.ID()
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorExtend)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorExtend)
 
 	// check if the block header is a valid extension of the finalized state
 	err := m.headerExtend(candidate)
@@ -238,8 +240,9 @@ func (m *Mutator) Extend(candidate *flow.Block) error {
 // last finalized block.
 func (m *Mutator) headerExtend(candidate *flow.Block) error {
 
-	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckHeader)
-	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckHeader)
+	blockID := candidate.ID()
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorExtendCheckHeader)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorExtendCheckHeader)
 
 	// FIRST: We do some initial cheap sanity checks, like checking the payload
 	// hash is consistent
@@ -304,8 +307,9 @@ func (m *Mutator) headerExtend(candidate *flow.Block) error {
 // included in any previous payload.
 func (m *Mutator) guaranteeExtend(candidate *flow.Block) error {
 
-	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckGuarantees)
-	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckGuarantees)
+	blockID := candidate.ID()
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorExtendCheckGuarantees)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorExtendCheckGuarantees)
 
 	header := candidate.Header
 	payload := candidate.Payload
@@ -384,8 +388,9 @@ func (m *Mutator) guaranteeExtend(candidate *flow.Block) error {
 // remain.
 func (m *Mutator) sealExtend(candidate *flow.Block) (*flow.Seal, error) {
 
-	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckSeals)
-	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckSeals)
+	blockID := candidate.ID()
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorExtendCheckSeals)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorExtendCheckSeals)
 
 	header := candidate.Header
 	payload := candidate.Payload
@@ -506,8 +511,9 @@ func (m *Mutator) sealExtend(candidate *flow.Block) (*flow.Seal, error) {
 // be the last sealed for block 101.
 func (m *Mutator) lastSealed(candidate *flow.Block) (*flow.Seal, error) {
 
-	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtendGetLastSealed)
-	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtendGetLastSealed)
+	blockID := candidate.ID()
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorHeaderExtendGetLastSealed)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorHeaderExtendGetLastSealed)
 
 	header := candidate.Header
 	payload := candidate.Payload

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/storage/badger/operation"
 	"github.com/onflow/flow-go/storage/badger/procedure"
@@ -176,6 +177,10 @@ func (m *Mutator) Bootstrap(root *flow.Block, result *flow.ExecutionResult, seal
 }
 
 func (m *Mutator) HeaderExtend(candidate *flow.Block) error {
+
+	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtend)
+	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtend)
+
 	// check if he block header is a valid extension of the finalized state
 	err := m.headerExtend(candidate)
 	if err != nil {
@@ -198,6 +203,10 @@ func (m *Mutator) HeaderExtend(candidate *flow.Block) error {
 }
 
 func (m *Mutator) Extend(candidate *flow.Block) error {
+
+	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtend)
+	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtend)
+
 	// check if the block header is a valid extension of the finalized state
 	err := m.headerExtend(candidate)
 	if err != nil {
@@ -228,6 +237,10 @@ func (m *Mutator) Extend(candidate *flow.Block) error {
 // header compliance check to verify if the given block connects to the
 // last finalized block.
 func (m *Mutator) headerExtend(candidate *flow.Block) error {
+
+	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckHeader)
+	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckHeader)
+
 	// FIRST: We do some initial cheap sanity checks, like checking the payload
 	// hash is consistent
 
@@ -290,6 +303,10 @@ func (m *Mutator) headerExtend(candidate *flow.Block) error {
 // guarantee that was expired at the block height, nor should it have been
 // included in any previous payload.
 func (m *Mutator) guaranteeExtend(candidate *flow.Block) error {
+
+	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckGuarantees)
+	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckGuarantees)
+
 	header := candidate.Header
 	payload := candidate.Payload
 
@@ -366,6 +383,10 @@ func (m *Mutator) guaranteeExtend(candidate *flow.Block) error {
 // then make a list of unfinalized blocks for the remainder, if any seals
 // remain.
 func (m *Mutator) sealExtend(candidate *flow.Block) (*flow.Seal, error) {
+
+	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckSeals)
+	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorExtendCheckSeals)
+
 	header := candidate.Header
 	payload := candidate.Payload
 
@@ -484,6 +505,10 @@ func (m *Mutator) sealExtend(candidate *flow.Block) (*flow.Seal, error) {
 // Now, if block 101 is extending block 100, and its payload has a seal for 96, then it will
 // be the last sealed for block 101.
 func (m *Mutator) lastSealed(candidate *flow.Block) (*flow.Seal, error) {
+
+	m.state.tracer.StartSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtendGetLastSealed)
+	defer m.state.tracer.FinishSpan(candidate.ID(), trace.ProtoStateMutatorHeaderExtendGetLastSealed)
+
 	header := candidate.Header
 	payload := candidate.Payload
 
@@ -515,6 +540,11 @@ func (m *Mutator) lastSealed(candidate *flow.Block) (*flow.Seal, error) {
 
 func (m *Mutator) insert(candidate *flow.Block, last *flow.Seal) error {
 
+	blockID := candidate.ID()
+
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorExtendDBInsert)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorExtendDBInsert)
+
 	// SIXTH: epoch transitions and service events
 	//    (i) Determine protocol state for block's _current_ Epoch.
 	//        As we don't have slashing yet, the protocol state is fully
@@ -532,7 +562,6 @@ func (m *Mutator) insert(candidate *flow.Block, last *flow.Seal) error {
 	// protocol state. We can now store the candidate block, as well as adding
 	// its final seal to the seal index and initializing its children index.
 
-	blockID := candidate.ID()
 	err = operation.RetryOnConflict(m.state.db.Update, func(tx *badger.Txn) error {
 		// insert the block into the database AND cache
 		err := m.state.blocks.StoreTx(candidate)(tx)
@@ -571,6 +600,9 @@ func (m *Mutator) insert(candidate *flow.Block, last *flow.Seal) error {
 }
 
 func (m *Mutator) Finalize(blockID flow.Identifier) error {
+
+	m.state.tracer.StartSpan(blockID, trace.ProtoStateMutatorFinalize)
+	defer m.state.tracer.FinishSpan(blockID, trace.ProtoStateMutatorFinalize)
 
 	// FIRST: The finalize call on the protocol state can only finalize one
 	// block at a time. This implies that the parent of the pending block that

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
 	st "github.com/onflow/flow-go/state"
 	protocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/events"
@@ -341,6 +342,7 @@ func TestExtendValid(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 
 		metrics := metrics.NewNoopCollector()
+		tracer := trace.NewNoopTracer()
 		headers, _, seals, index, payloads, blocks, setups, commits, statuses := storeutil.StorageLayer(t, db)
 
 		// create a event consumer to test epoch transition events
@@ -348,7 +350,7 @@ func TestExtendValid(t *testing.T) {
 		consumer := new(mockprotocol.Consumer)
 		distributor.AddConsumer(consumer)
 
-		state, err := protocol.NewState(metrics, db, headers, seals, index, payloads, blocks, setups, commits, statuses, distributor)
+		state, err := protocol.NewState(metrics, tracer, db, headers, seals, index, payloads, blocks, setups, commits, statuses, distributor)
 		require.Nil(t, err)
 
 		block, result, seal := unittest.BootstrapFixture(participants)
@@ -673,6 +675,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 
 		metrics := metrics.NewNoopCollector()
+		tracer := trace.NewNoopTracer()
 		headers, _, seals, index, payloads, blocks, setups, commits, statuses := storeutil.StorageLayer(t, db)
 
 		// create a event consumer to test epoch transition events
@@ -681,7 +684,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		consumer.On("BlockFinalized", mock.Anything)
 		distributor.AddConsumer(consumer)
 
-		state, err := protocol.NewState(metrics, db, headers, seals, index, payloads, blocks, setups, commits, statuses, distributor)
+		state, err := protocol.NewState(metrics, tracer, db, headers, seals, index, payloads, blocks, setups, commits, statuses, distributor)
 		require.Nil(t, err)
 
 		// first bootstrap with the initial epoch

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -51,6 +51,7 @@ func NewState(
 
 	s := &State{
 		metrics:  metrics,
+		tracer:   tracer,
 		db:       db,
 		headers:  headers,
 		seals:    seals,

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -16,6 +16,7 @@ import (
 
 type State struct {
 	metrics  module.ComplianceMetrics
+	tracer   module.Tracer
 	db       *badger.DB
 	headers  storage.Headers
 	seals    storage.Seals
@@ -35,6 +36,7 @@ type State struct {
 // optional configuration parameters.
 func NewState(
 	metrics module.ComplianceMetrics,
+	tracer module.Tracer,
 	db *badger.DB,
 	headers storage.Headers,
 	seals storage.Seals,


### PR DESCRIPTION
Adds tracing to the following methods:
* `BuildOn` for consensus node
* `mutator.Extend` (for protocol state and cluster state)
* `mutator.HeaderExtend`
* `mutator.Finalize`