### PR TITLE
Flatten errors when processing pending children

### DIFF
--- a/engine/collection/proposal/engine.go
+++ b/engine/collection/proposal/engine.go
@@ -529,7 +529,7 @@ func (e *Engine) processPendingChildren(header *flow.Header) error {
 		Msg("processing pending children")
 
 	// then try to process children only this once
-	var result *multierror.Error
+	result := new(multierror.Error)
 	for _, child := range children {
 		proposal := &messages.ClusterBlockProposal{
 			Header:  child.Header,
@@ -544,7 +544,7 @@ func (e *Engine) processPendingChildren(header *flow.Header) error {
 	// remove children from cache
 	e.pending.DropForParent(blockID)
 
-	// flatten out the error tree before returning
+	// flatten out the error tree before returning the error
 	result = multierror.Flatten(result).(*multierror.Error)
 	return result.ErrorOrNil()
 }

--- a/engine/collection/proposal/engine.go
+++ b/engine/collection/proposal/engine.go
@@ -544,6 +544,8 @@ func (e *Engine) processPendingChildren(header *flow.Header) error {
 	// remove children from cache
 	e.pending.DropForParent(blockID)
 
+	// flatten out the error tree before returning
+	result = multierror.Flatten(result).(*multierror.Error)
 	return result.ErrorOrNil()
 }
 

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -579,6 +579,8 @@ func (e *Engine) processPendingChildren(header *flow.Header) error {
 
 	e.mempool.MempoolEntries(metrics.ResourceProposal, e.pending.Size())
 
+	// flatten out the error tree before returning
+	result = multierror.Flatten(result).(*multierror.Error)
 	return result.ErrorOrNil()
 }
 

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -562,7 +562,7 @@ func (e *Engine) processPendingChildren(header *flow.Header) error {
 		Msg("processing pending children")
 
 	// then try to process children only this once
-	var result *multierror.Error
+	result := new(multierror.Error)
 	for _, child := range children {
 		proposal := &messages.BlockProposal{
 			Header:  child.Header,
@@ -579,7 +579,7 @@ func (e *Engine) processPendingChildren(header *flow.Header) error {
 
 	e.mempool.MempoolEntries(metrics.ResourceProposal, e.pending.Size())
 
-	// flatten out the error tree before returning
+	// flatten out the error tree before returning the error
 	result = multierror.Flatten(result).(*multierror.Error)
 	return result.ErrorOrNil()
 }


### PR DESCRIPTION
When we get these pending child errors, they often form such deep trees that the actual root cause gets omitted in logs. This flattens out the multierror so that only root cause errors are included.