### PR TITLE
Run localnet without running log search

### DIFF
--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -23,19 +23,16 @@ init:
 
 .PHONY: start
 start:
-	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.base.yml -f docker-compose.nodes.yml up --build -d
-
-.PHONY: nodes
-nodes:
+	docker-compose -f docker-compose.metrics.yml -f docker-compose.metrics.yml up -d
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml up --build -d
 
 .PHONY: logs
 logs:
-	docker-compose -f docker-compose.base.yml -f docker-compose.nodes.yml logs -f
+	docker-compose -f docker-compose.nodes.yml logs -f
 
 .PHONY: stop
 stop:
-	docker-compose -f docker-compose.base.yml -f docker-compose.nodes.yml down -v
+	docker-compose -f docker-compose.metrics.yml -f docker-compose.nodes.yml -f docker-compose.logs.yml down -v
 
 .PHONY: load
 load:

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -23,7 +23,7 @@ init:
 
 .PHONY: start
 start:
-	docker-compose -f docker-compose.metrics.yml -f docker-compose.metrics.yml up -d
+	docker-compose -f docker-compose.metrics.yml up -d
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml up --build -d
 
 .PHONY: logs

--- a/integration/localnet/docker-compose.logs.yml
+++ b/integration/localnet/docker-compose.logs.yml
@@ -1,31 +1,5 @@
 version: '3.7'
 services:
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    ports:
-      - "6831:6831/udp"
-      - "16686:16686"
-
-  prom:
-    image: prom/prometheus:latest
-    volumes:
-      - ./conf/prometheus.yaml:/etc/prometheus/prometheus.yaml
-      - ./targets.nodes.json:/etc/prometheus/targets.nodes.json
-    command: "--config.file=/etc/prometheus/prometheus.yaml --storage.tsdb.path=/prometheus"
-    ports:
-      - 9090:9090
-    depends_on:
-      - exporter
-    environment:
-      - LOGSPOUT=ignore
-
-  exporter:
-    image: prom/node-exporter:latest
-    ports:
-      - "9100:9100"
-    environment:
-      - LOGSPOUT=ignore
-
   grafana:
     image: grafana/grafana
     ports:

--- a/integration/localnet/docker-compose.metrics.yml
+++ b/integration/localnet/docker-compose.metrics.yml
@@ -1,0 +1,27 @@
+version: '3.7'
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "6831:6831/udp"
+      - "16686:16686"
+
+  prom:
+    image: prom/prometheus:latest
+    volumes:
+      - ./conf/prometheus.yaml:/etc/prometheus/prometheus.yaml
+      - ./targets.nodes.json:/etc/prometheus/targets.nodes.json
+    command: "--config.file=/etc/prometheus/prometheus.yaml --storage.tsdb.path=/prometheus"
+    ports:
+      - 9090:9090
+    depends_on:
+      - exporter
+    environment:
+      - LOGSPOUT=ignore
+
+  exporter:
+    image: prom/node-exporter:latest
+    ports:
+      - "9100:9100"
+    environment:
+      - LOGSPOUT=ignore


### PR DESCRIPTION
The default integration localnet starts containers for log search, for instance elastic search, grafana etc.

Those containers use a lot of machine resource, and might impact the real performance of the nodes that we wanted to test.

Making them option to start when running `make start` to start the localnet.

Now the localnet will only run the nodes and metrics.