### PR TITLE
Update to Cadence v0.9.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/libp2p/go-libp2p-transport-upgrader v0.3.0
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.9.0
+	github.com/onflow/cadence v0.9.2
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0
 	github.com/onflow/flow-go-sdk v0.8.0
 	github.com/onflow/flow-go/crypto v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/onflow/cadence v0.4.0-beta1/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNNmCTn3I=
 github.com/onflow/cadence v0.4.0/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNNmCTn3I=
 github.com/onflow/cadence v0.6.0/go.mod h1:VCZ/aqMjf84JQDkCOGqGRQslVwFjx/7PJrH/zpAh/Qo=
-github.com/onflow/cadence v0.9.0 h1:PWfpVVDdVhfq0FxCobTbFM0WN/ebexD6nr67YkVdNRc=
-github.com/onflow/cadence v0.9.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
+github.com/onflow/cadence v0.9.2 h1:8ItrQY39NG3MSCGfLnsVa1eHbviLZ6SN243afz7ZrcU=
+github.com/onflow/cadence v0.9.2/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0 h1:MUivqc0+0WY2TsDhggcKAiHD6sR24xOscpcd5m3CLIQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0/go.mod h1:4oPXY+JffxZhnl7B23J2ttjAWJeVqdL6ZU2yhzgQLqU=
 github.com/onflow/flow-ft/contracts v0.1.3/go.mod h1:IKe3yEurEKpg/J15q5WBlHkuMmt1iRECSHgnIa1gvRw=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.9.0
+	github.com/onflow/cadence v0.9.2
 	github.com/onflow/flow-go v0.4.1-0.20200715183900-b337e998d486
 	github.com/onflow/flow-go-sdk v0.8.0
 	github.com/onflow/flow-go/crypto v0.9.4

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -750,8 +750,6 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/onflow/cadence v0.4.0-beta1/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNNmCTn3I=
 github.com/onflow/cadence v0.4.0/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNNmCTn3I=
 github.com/onflow/cadence v0.6.0/go.mod h1:VCZ/aqMjf84JQDkCOGqGRQslVwFjx/7PJrH/zpAh/Qo=
-github.com/onflow/cadence v0.9.0 h1:PWfpVVDdVhfq0FxCobTbFM0WN/ebexD6nr67YkVdNRc=
-github.com/onflow/cadence v0.9.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/cadence v0.9.2 h1:8ItrQY39NG3MSCGfLnsVa1eHbviLZ6SN243afz7ZrcU=
 github.com/onflow/cadence v0.9.2/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0 h1:MUivqc0+0WY2TsDhggcKAiHD6sR24xOscpcd5m3CLIQ=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -752,6 +752,8 @@ github.com/onflow/cadence v0.4.0/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNN
 github.com/onflow/cadence v0.6.0/go.mod h1:VCZ/aqMjf84JQDkCOGqGRQslVwFjx/7PJrH/zpAh/Qo=
 github.com/onflow/cadence v0.9.0 h1:PWfpVVDdVhfq0FxCobTbFM0WN/ebexD6nr67YkVdNRc=
 github.com/onflow/cadence v0.9.0/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
+github.com/onflow/cadence v0.9.2 h1:8ItrQY39NG3MSCGfLnsVa1eHbviLZ6SN243afz7ZrcU=
+github.com/onflow/cadence v0.9.2/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0 h1:MUivqc0+0WY2TsDhggcKAiHD6sR24xOscpcd5m3CLIQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0/go.mod h1:4oPXY+JffxZhnl7B23J2ttjAWJeVqdL6ZU2yhzgQLqU=
 github.com/onflow/flow-ft/contracts v0.1.3/go.mod h1:IKe3yEurEKpg/J15q5WBlHkuMmt1iRECSHgnIa1gvRw=


### PR DESCRIPTION
Fixes dapperlabs/flow-go#4894

[Cadence v0.9.2](https://github.com/onflow/cadence/releases/tag/v0.9.2) now panics with a dedicated error for out-of-bounds array accesses. Previously it relied on Go's bounds check, i.e. the error was a Go runtime error.

Non-Go runtime errors are bubbled to the host environment, as they indicate an implementation error, non-Go (Cadence) errors are returned as errors: https://github.com/onflow/cadence/blob/0a889feb15fb738b83924d372677cf8720cb8706/runtime/interpreter/interpreter.go#L855-L870

This means that nothing else needs to be done in flow-go, other than updating to the latest version.