### PR TITLE
[Execution] Remove non-fatal error

### DIFF
--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -361,8 +361,8 @@ func (e *Engine) onBlockExecuted(executed *entity.ExecutableBlock, finalState fl
 			if !exists {
 				// when the block no longer exists in the queue, it means there was a race condition that
 				// two onBlockExecuted was called for the same block, and one process has already removed the
-				// block from the queue, so we could simply bail here.
-				return nil
+				// block from the queue, so we will print an error here
+				return fmt.Errorf("block has been executed already, no long exists in the queue")
 			}
 
 			// dismount the executed block and all its children

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -359,7 +359,10 @@ func (e *Engine) onBlockExecuted(executed *entity.ExecutableBlock, finalState fl
 			// find the block that was just executed
 			executionQueue, exists := executionQueues.ByID(executed.ID())
 			if !exists {
-				return fmt.Errorf("fatal error - executed block not present in execution queue")
+				// when the block no longer exists in the queue, it means there was a race condition that
+				// two onBlockExecuted was called for the same block, and one process has already removed the
+				// block from the queue, so we could simply bail here.
+				return nil
 			}
 
 			// dismount the executed block and all its children
@@ -370,6 +373,9 @@ func (e *Engine) onBlockExecuted(executed *entity.ExecutableBlock, finalState fl
 			for _, queue := range newQueues {
 				added := executionQueues.Add(queue)
 				if !added {
+					// blocks should be unique in execution queues, if we dismount all the children blocks, then
+					// add it back to the queues, then it should always be able to add.
+					// If not, then there is a bug that the queues have duplicated blocks
 					return fmt.Errorf("fatal error - child block already in execution queue")
 				}
 


### PR DESCRIPTION
Fix https://github.com/dapperlabs/flow-go/issues/4962

One of the fatal errors in execution ingestion engine was not actually a fatal error. This PR remove that non-fatal error. 
For the fatal error, which is an actual fatal error, I added more comment to explain the case.