### PR TITLE
Fix error equality checking in collector test

### DIFF
--- a/integration/tests/collection/tx_ingress_test.go
+++ b/integration/tests/collection/tx_ingress_test.go
@@ -37,14 +37,10 @@ func (suite *CollectorSuite) TestTransactionIngress_InvalidTransaction() {
 			tx.SetReferenceBlockID(sdk.EmptyID)
 		})
 
-		expected := access.IncompleteTransactionError{
-			MissingFields: []string{flow.TransactionFieldRefBlockID.String()},
-		}
-
 		ctx, cancel := context.WithTimeout(suite.ctx, defaultTimeout)
 		defer cancel()
 		err := client.SendTransaction(ctx, *malformed)
-		unittest.AssertErrSubstringMatch(t, expected, err)
+		suite.Assert().Error(err)
 	})
 
 	t.Run("missing script", func(t *testing.T) {


### PR DESCRIPTION
The test assumed that transaction properties were validated in a particular order, which changed as part of implementing epochs. This commit changes the test's assertion to be less specific (merely that an error occurred), since the actual error that is returned is not directly related to the failure condition we are testing, it is instead a side effect of the failure condition we are testing.