### PR TITLE
cmd remove execution results

### DIFF
--- a/cmd/bootstrap/run/key.go
+++ b/cmd/bootstrap/run/key.go
@@ -1,0 +1,25 @@
+package run
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/crypto"
+)
+
+func ReadPrivateKeyFromPath(path string) (crypto.PrivateKey, error) {
+	// validation
+	return nil, fmt.Errorf("not implemented")
+}
+
+func WritePrivateKeyToPath(path string, key crypto.PrivateKey) error {
+	return fmt.Errorf("not implemented")
+}
+
+func ReadPublicKeyFromPath(path string) (crypto.PublicKey, error) {
+	// validation
+	return nil, fmt.Errorf("not implemented")
+}
+
+func WritePublicKeyToPath(path string, key crypto.PublicKey) error {
+	return fmt.Errorf("not implemented")
+}

--- a/cmd/bootstrap/run/staking_transaction.go
+++ b/cmd/bootstrap/run/staking_transaction.go
@@ -1,0 +1,15 @@
+package run
+
+import (
+	"fmt"
+
+	flowsdk "github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go/crypto"
+)
+
+func GenerateStakingTransaction(
+	privateKeys []crypto.PrivateKey,
+	stakingContractAddress *flowsdk.Address,
+	stakingAmountPerKey uint64) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/cmd/util/cmd/remove-execution-results/cmd.go
+++ b/cmd/util/cmd/remove-execution-results/cmd.go
@@ -1,0 +1,219 @@
+package remove
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/cmd/util/cmd/common"
+	"github.com/onflow/flow-go/engine/execution/state"
+	ledger "github.com/onflow/flow-go/ledger/complete"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/trace"
+	"github.com/onflow/flow-go/state/protocol"
+	protocolbadger "github.com/onflow/flow-go/state/protocol/badger"
+	"github.com/onflow/flow-go/state/protocol/events"
+	"github.com/onflow/flow-go/storage"
+	storagebadger "github.com/onflow/flow-go/storage/badger"
+)
+
+var (
+	flagFromHeight        uint64
+	flagDataDir           string
+	flagExecutionStateDir string
+)
+
+var Cmd = &cobra.Command{
+	Use:   "remove-execution-results",
+	Short: "Remove execution results for blocks above a certain height",
+	Run:   run,
+}
+
+func init() {
+
+	Cmd.Flags().Uint64Var(&flagFromHeight, "from-height", 0,
+		"the height of the block to remove execution results from (inclusive). Must be a finalized height")
+	_ = Cmd.MarkFlagRequired("from-height")
+
+	Cmd.Flags().StringVar(&flagDataDir, "datadir", "",
+		"directory that stores the protocol state")
+	_ = Cmd.MarkFlagRequired("datadir")
+
+	Cmd.Flags().StringVar(&flagExecutionStateDir, "execution-state-dir", "",
+		"Execution Node state dir (where WAL logs are written")
+	_ = Cmd.MarkFlagRequired("execution-state-dir")
+}
+
+func run(*cobra.Command, []string) {
+	log.Info().
+		Str("datadir", flagDataDir).
+		Str("executiondir", flagExecutionStateDir).
+		Uint64("from-height", flagFromHeight).
+		Msg("flags")
+
+	db := common.InitStorage(flagDataDir)
+
+	protoState, execState, err := initStates(db, flagExecutionStateDir)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not init states")
+	}
+
+	transactionResults := storagebadger.NewTransactionResults(db)
+	err = removeExecutionResultsFromHeight(protoState, execState, transactionResults, flagFromHeight)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not remove results")
+	}
+
+	log.Info().Msgf("all results from height %v have been removed successfully", flagFromHeight)
+}
+
+func initStates(db *badger.DB, executionStateDir string) (protocol.State, state.ExecutionState, error) {
+
+	metrics := &metrics.NoopCollector{}
+	tracer := trace.NewNoopTracer()
+	distributor := events.NewDistributor()
+
+	headers := storagebadger.NewHeaders(metrics, db)
+	guarantees := storagebadger.NewGuarantees(metrics, db)
+	seals := storagebadger.NewSeals(metrics, db)
+	index := storagebadger.NewIndex(metrics, db)
+	payloads := storagebadger.NewPayloads(db, index, guarantees, seals)
+	blocks := storagebadger.NewBlocks(db, headers, payloads)
+	setups := storagebadger.NewEpochSetups(metrics, db)
+	commits := storagebadger.NewEpochCommits(metrics, db)
+	statuses := storagebadger.NewEpochStatuses(metrics, db)
+
+	protoState, err := protocolbadger.NewState(
+		metrics,
+		tracer,
+		db,
+		headers,
+		seals,
+		index,
+		payloads,
+		blocks,
+		setups,
+		commits,
+		statuses,
+		distributor,
+	)
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not init protocol state: %w", err)
+	}
+
+	results := storagebadger.NewExecutionResults(db)
+	receipts := storagebadger.NewExecutionReceipts(db, results)
+	chunkDataPacks := storagebadger.NewChunkDataPacks(db)
+	stateCommitments := storagebadger.NewCommits(metrics, db)
+	transactions := storagebadger.NewTransactions(metrics, db)
+	collections := storagebadger.NewCollections(db, transactions)
+
+	ledgerStorage, err := ledger.NewLedger(executionStateDir, 100, metrics, zerolog.Nop(), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not init ledger: %w", err)
+	}
+
+	execState := state.NewExecutionState(
+		ledgerStorage,
+		stateCommitments,
+		blocks,
+		collections,
+		chunkDataPacks,
+		results,
+		receipts,
+		db,
+		tracer,
+	)
+
+	return protoState, execState, nil
+}
+
+func removeExecutionResultsFromHeight(protoState protocol.State, execState state.ExecutionState, transactionResults storage.TransactionResults, fromHeight uint64) error {
+	log.Info().Msgf("removing results for blocks from height: %v", flagFromHeight)
+
+	root, err := protoState.Params().Root()
+	if err != nil {
+		return fmt.Errorf("could not get root: %w", err)
+	}
+
+	if fromHeight <= root.Height {
+		return fmt.Errorf("can only remove results for block above root block. fromHeight: %v, rootHeight: %v", fromHeight, root.Height)
+	}
+
+	final, err := protoState.Final().Head()
+	if err != nil {
+		return fmt.Errorf("could get not finalized height: %w", err)
+	}
+
+	count := 0
+	total := int(final.Height-fromHeight) + 1
+
+	// removing for finalized blocks
+	for height := fromHeight; height <= final.Height; height++ {
+		head, err := protoState.AtHeight(height).Head()
+		if err != nil {
+			return fmt.Errorf("could not get header at height: %w", err)
+		}
+
+		blockID := head.ID()
+
+		err = removeForBlockID(execState, transactionResults, blockID)
+		if err != nil {
+			return fmt.Errorf("could not remove result for finalized block: %v, %w", blockID, err)
+		}
+
+		count++
+		log.Info().Msgf("result at height :%v has been removed. progress (%v/%v)", height, count, total)
+	}
+
+	// removing for pending blocks
+	pendings, err := protoState.Final().Pending()
+	if err != nil {
+		return fmt.Errorf("could not get pending block: %w", err)
+	}
+
+	count = 0
+	total = len(pendings)
+
+	for _, pending := range pendings {
+		err = removeForBlockID(execState, transactionResults, pending)
+		if err != nil {
+			return fmt.Errorf("could not remove result for pending block: %v, %w", pending, err)
+		}
+
+		count++
+		log.Info().Msgf("result for pending block :%v has been removed. progress (%v/%v) ", pending, count, total)
+	}
+
+	// highest executed is one below the fromHeight
+	highest, err := protoState.AtHeight(fromHeight - 1).Head()
+	if err != nil {
+		return fmt.Errorf("could not get highest: %w", err)
+	}
+
+	err = execState.SetHighestExecuted(highest)
+	if err != nil {
+		return fmt.Errorf("failed to set highest executed")
+	}
+
+	return nil
+}
+
+func removeForBlockID(execState state.ExecutionState, transactionResults storage.TransactionResults, blockID flow.Identifier) error {
+	err := execState.RemoveByBlockID(blockID)
+	if err != nil {
+		return fmt.Errorf("could not remove by block ID: %v, %w", blockID, err)
+	}
+
+	err = transactionResults.RemoveByBlockID(blockID)
+	if err != nil {
+		return fmt.Errorf("could not remove transaction results by BlockID: %v, %w", blockID, err)
+	}
+
+	return nil
+}

--- a/engine/execution/state/mock/execution_state.go
+++ b/engine/execution/state/mock/execution_state.go
@@ -258,6 +258,20 @@ func (_m *ExecutionState) PersistStateInteractions(_a0 context.Context, _a1 flow
 	return r0
 }
 
+// RemoveByBlockID provides a mock function with given fields: _a0
+func (_m *ExecutionState) RemoveByBlockID(_a0 flow.Identifier) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(flow.Identifier) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RetrieveStateDelta provides a mock function with given fields: _a0, _a1
 func (_m *ExecutionState) RetrieveStateDelta(_a0 context.Context, _a1 flow.Identifier) (*messages.ExecutionStateDelta, error) {
 	ret := _m.Called(_a0, _a1)
@@ -279,6 +293,20 @@ func (_m *ExecutionState) RetrieveStateDelta(_a0 context.Context, _a1 flow.Ident
 	}
 
 	return r0, r1
+}
+
+// SetHighestExecuted provides a mock function with given fields: _a0
+func (_m *ExecutionState) SetHighestExecuted(_a0 *flow.Header) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*flow.Header) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // StateCommitmentByBlockID provides a mock function with given fields: _a0, _a1

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -72,6 +72,10 @@ type ExecutionState interface {
 	PersistStateInteractions(context.Context, flow.Identifier, []*delta.Snapshot) error
 
 	UpdateHighestExecutedBlockIfHigher(context.Context, *flow.Header) error
+
+	RemoveByBlockID(flow.Identifier) error
+
+	SetHighestExecuted(*flow.Header) error
 }
 
 const (
@@ -447,6 +451,36 @@ func (s *state) UpdateHighestExecutedBlockIfHigher(ctx context.Context, header *
 		err = operation.UpdateExecutedBlock(header.ID())(txn)
 		if err != nil {
 			return fmt.Errorf("cannot update highest executed block: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (s *state) RemoveByBlockID(blockID flow.Identifier) error {
+	err := s.receipts.RemoveByBlockID(blockID)
+	if err != nil {
+		return fmt.Errorf("could not remove receipt: %w", err)
+	}
+
+	err = s.commits.RemoveByBlockID(blockID)
+	if err != nil {
+		return fmt.Errorf("could not remove commits: %w", err)
+	}
+
+	err = s.results.RemoveByBlockID(blockID)
+	if err != nil {
+		return fmt.Errorf("could not remove result: %w", err)
+	}
+
+	return nil
+}
+
+func (s *state) SetHighestExecuted(header *flow.Header) error {
+	return operation.RetryOnConflict(s.db.Update, func(txn *badger.Txn) error {
+		err := operation.UpdateExecutedBlock(header.ID())(txn)
+		if err != nil {
+			return fmt.Errorf("cannot set highest executed block: %w", err)
 		}
 
 		return nil

--- a/storage/badger/commits.go
+++ b/storage/badger/commits.go
@@ -67,3 +67,7 @@ func (c *Commits) ByBlockID(blockID flow.Identifier) (flow.StateCommitment, erro
 	defer tx.Discard()
 	return c.retrieveTx(blockID)(tx)
 }
+
+func (c *Commits) RemoveByBlockID(blockID flow.Identifier) error {
+	return c.db.Update(operation.SkipNonExist(operation.RemoveStateCommitment(blockID)))
+}

--- a/storage/badger/commits_test.go
+++ b/storage/badger/commits_test.go
@@ -1,0 +1,76 @@
+package badger_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/storage"
+	bstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestCommitsReadNonExist(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		metrics := &metrics.NoopCollector{}
+		store := bstorage.NewCommits(metrics, db)
+
+		blockID := unittest.IdentifierFixture()
+		_, err := store.ByBlockID(blockID)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, storage.ErrNotFound))
+	})
+}
+
+func TestCommitsStoreRead(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		metrics := &metrics.NoopCollector{}
+		store := bstorage.NewCommits(metrics, db)
+
+		commit := unittest.StateCommitmentFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(blockID, commit)
+		require.NoError(t, err)
+
+		actual, err := store.ByBlockID(blockID)
+		require.NoError(t, err)
+
+		require.Equal(t, commit, actual)
+	})
+}
+
+func TestCommitsRemoveNonExist(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		metrics := &metrics.NoopCollector{}
+		store := bstorage.NewCommits(metrics, db)
+
+		blockID := unittest.IdentifierFixture()
+		err := store.RemoveByBlockID(blockID)
+		require.NoError(t, err)
+	})
+}
+
+func TestCommitsStoreRemove(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		metrics := &metrics.NoopCollector{}
+		store := bstorage.NewCommits(metrics, db)
+
+		commit := unittest.StateCommitmentFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(blockID, commit)
+		require.NoError(t, err)
+
+		err = store.RemoveByBlockID(blockID)
+		require.NoError(t, err)
+
+		storeWithoutCache := bstorage.NewCommits(metrics, db)
+		// using store.ByBlockID will not work, because the removed commitment
+		// was still cached
+		_, err = storeWithoutCache.ByBlockID(blockID)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, storage.ErrNotFound))
+	})
+}

--- a/storage/badger/operation/commits.go
+++ b/storage/badger/operation/commits.go
@@ -21,3 +21,7 @@ func IndexStateCommitment(blockID flow.Identifier, commit flow.StateCommitment) 
 func LookupStateCommitment(blockID flow.Identifier, commit *flow.StateCommitment) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeCommit, blockID), commit)
 }
+
+func RemoveStateCommitment(blockID flow.Identifier) func(*badger.Txn) error {
+	return remove(makePrefix(codeCommit, blockID))
+}

--- a/storage/badger/operation/modifiers.go
+++ b/storage/badger/operation/modifiers.go
@@ -20,6 +20,19 @@ func SkipDuplicates(op func(*badger.Txn) error) func(tx *badger.Txn) error {
 	}
 }
 
+func SkipNonExist(op func(*badger.Txn) error) func(tx *badger.Txn) error {
+	return func(tx *badger.Txn) error {
+		err := op(tx)
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+}
+
 func RetryOnConflict(action func(func(*badger.Txn) error) error, op func(tx *badger.Txn) error) error {
 	for {
 		err := action(op)

--- a/storage/badger/operation/receipts.go
+++ b/storage/badger/operation/receipts.go
@@ -25,3 +25,15 @@ func IndexExecutionReceipt(blockID flow.Identifier, receiptID flow.Identifier) f
 func LookupExecutionReceipt(blockID flow.Identifier, receiptID *flow.Identifier) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeBlockExecutionReceipt, blockID), receiptID)
 }
+
+func RemoveExecutionReceipt(blockID flow.Identifier, receipt *flow.ExecutionReceipt) func(*badger.Txn) error {
+	return func(txn *badger.Txn) error {
+		receiptID := receipt.ID()
+		err := remove(makePrefix(codeExecutionReceiptMeta, receiptID))(txn)
+		if err != nil {
+			return err
+		}
+
+		return remove(makePrefix(codeBlockExecutionReceipt, blockID))(txn)
+	}
+}

--- a/storage/badger/operation/results.go
+++ b/storage/badger/operation/results.go
@@ -25,3 +25,16 @@ func IndexExecutionResult(blockID flow.Identifier, resultID flow.Identifier) fun
 func LookupExecutionResult(blockID flow.Identifier, resultID *flow.Identifier) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeIndexExecutionResultByBlock, blockID), resultID)
 }
+
+func RemoveExecutionResult(blockID flow.Identifier, result *flow.ExecutionResult) func(*badger.Txn) error {
+	return func(txn *badger.Txn) error {
+		// remove index
+		err := remove(makePrefix(codeIndexExecutionResultByBlock, blockID))(txn)
+		if err != nil {
+			return err
+		}
+
+		// remove result
+		return remove(makePrefix(codeExecutionResult, result.ID()))(txn)
+	}
+}

--- a/storage/badger/operation/transaction_results.go
+++ b/storage/badger/operation/transaction_results.go
@@ -3,6 +3,8 @@
 package operation
 
 import (
+	"fmt"
+
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -33,5 +35,30 @@ func LookupTransactionResultsByBlockID(blockID flow.Identifier, txResults *[]flo
 		return check, create, handle
 	}
 
-	return traverse(makePrefix(codeEvent, blockID), txErrIterFunc)
+	return traverse(makePrefix(codeTransactionResult, blockID), txErrIterFunc)
+}
+
+func RemoveTransactionResultsByBlockID(blockID flow.Identifier) func(*badger.Txn) error {
+	return func(txn *badger.Txn) error {
+		var txResults []flow.TransactionResult
+
+		err := SkipNonExist(LookupTransactionResultsByBlockID(blockID, &txResults))(txn)
+		// don't return error if there is no result for the block
+		if err != nil {
+			return fmt.Errorf("could not find transaction results for block: %v, %w", blockID, err)
+		}
+
+		for _, result := range txResults {
+			err := RemoveTransactionResult(blockID, result.TransactionID)(txn)
+			if err != nil {
+				return fmt.Errorf("could not remove transaction result: %w", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func RemoveTransactionResult(blockID flow.Identifier, transactionResultID flow.Identifier) func(*badger.Txn) error {
+	return remove(makePrefix(codeTransactionResult, blockID, transactionResultID))
 }

--- a/storage/badger/receipts_test.go
+++ b/storage/badger/receipts_test.go
@@ -1,0 +1,41 @@
+package badger_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/storage"
+	bstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestReceiptsRemoveNotExist(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		results := bstorage.NewExecutionResults(db)
+		store := bstorage.NewExecutionReceipts(db, results)
+		blockID := unittest.IdentifierFixture()
+		require.NoError(t, store.RemoveByBlockID(blockID))
+	})
+}
+
+func TestReceiptsRemove(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		results := bstorage.NewExecutionResults(db)
+		store := bstorage.NewExecutionReceipts(db, results)
+
+		receipt := unittest.ExecutionReceiptFixture()
+		err := store.Store(receipt)
+		require.Nil(t, err)
+
+		// this is redundant, Store should be able to Index a receipt
+		require.NoError(t, store.Index(receipt.ExecutionResult.BlockID, receipt.ID()))
+
+		require.NoError(t, store.RemoveByBlockID(receipt.ExecutionResult.BlockID))
+
+		_, err = store.ByBlockID(receipt.ExecutionResult.BlockID)
+		require.True(t, errors.Is(err, storage.ErrNotFound))
+	})
+}

--- a/storage/badger/results_test.go
+++ b/storage/badger/results_test.go
@@ -1,0 +1,44 @@
+package badger_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/storage"
+	bstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestResultsRemoveNonExist(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		store := bstorage.NewExecutionResults(db)
+
+		blockID := unittest.IdentifierFixture()
+		err := store.RemoveByBlockID(blockID)
+		require.NoError(t, err)
+	})
+}
+
+func TestResultsStoreRemove(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		store := bstorage.NewExecutionResults(db)
+
+		result := unittest.ExecutionResultFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(result)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, result.ID())
+		require.NoError(t, err)
+
+		err = store.RemoveByBlockID(blockID)
+		require.NoError(t, err)
+
+		_, err = store.ByBlockID(blockID)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, storage.ErrNotFound))
+	})
+}

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -56,3 +56,8 @@ func (tr *TransactionResults) ByBlockIDTransactionID(blockID flow.Identifier, tx
 
 	return &txResult, nil
 }
+
+// RemoveByBlockID removes transaction results by block ID
+func (tr *TransactionResults) RemoveByBlockID(blockID flow.Identifier) error {
+	return tr.db.Update(operation.RemoveTransactionResultsByBlockID(blockID))
+}

--- a/storage/badger/transaction_results_test.go
+++ b/storage/badger/transaction_results_test.go
@@ -1,6 +1,8 @@
 package badger_test
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -8,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
 	bstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -59,5 +62,37 @@ func TestBatchStoringTransactionResults(t *testing.T) {
 			require.Nil(t, err)
 			assert.Equal(t, txResult, *actual)
 		}
+	})
+}
+
+func TestRemoveNotExistTransactionResult(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		store := bstorage.NewTransactionResults(db)
+		blockID := unittest.IdentifierFixture()
+		require.NoError(t, store.RemoveByBlockID(blockID))
+	})
+}
+
+func TestRemoveTransactionResult(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		store := bstorage.NewTransactionResults(db)
+
+		blockID := unittest.IdentifierFixture()
+		txResults := make([]flow.TransactionResult, 0)
+		for i := 0; i < 10; i++ {
+			txID := unittest.IdentifierFixture()
+			expected := flow.TransactionResult{
+				TransactionID: txID,
+				ErrorMessage:  "a runtime error " + string(i),
+			}
+			txResults = append(txResults, expected)
+		}
+		err := store.BatchStore(blockID, txResults)
+		require.Nil(t, err)
+
+		require.NoError(t, store.RemoveByBlockID(blockID), "remove for the first time should work, but didn't")
+
+		result, err := store.ByBlockIDTransactionID(blockID, txResults[1].TransactionID)
+		require.True(t, errors.Is(err, storage.ErrNotFound), fmt.Sprintf("%v", result))
 	})
 }

--- a/storage/commits.go
+++ b/storage/commits.go
@@ -12,4 +12,6 @@ type Commits interface {
 
 	// ByBlockID will retrieve a commit by its ID from persistent storage.
 	ByBlockID(blockID flow.Identifier) (flow.StateCommitment, error)
+
+	RemoveByBlockID(blockID flow.Identifier) error
 }

--- a/storage/mock/commits.go
+++ b/storage/mock/commits.go
@@ -35,6 +35,20 @@ func (_m *Commits) ByBlockID(blockID flow.Identifier) ([]byte, error) {
 	return r0, r1
 }
 
+// RemoveByBlockID provides a mock function with given fields: blockID
+func (_m *Commits) RemoveByBlockID(blockID flow.Identifier) error {
+	ret := _m.Called(blockID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(flow.Identifier) error); ok {
+		r0 = rf(blockID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Store provides a mock function with given fields: blockID, commit
 func (_m *Commits) Store(blockID flow.Identifier, commit []byte) error {
 	ret := _m.Called(blockID, commit)

--- a/storage/mock/execution_receipts.go
+++ b/storage/mock/execution_receipts.go
@@ -72,6 +72,20 @@ func (_m *ExecutionReceipts) Index(blockID flow.Identifier, resultID flow.Identi
 	return r0
 }
 
+// RemoveByBlockID provides a mock function with given fields: blockID
+func (_m *ExecutionReceipts) RemoveByBlockID(blockID flow.Identifier) error {
+	ret := _m.Called(blockID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(flow.Identifier) error); ok {
+		r0 = rf(blockID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Store provides a mock function with given fields: result
 func (_m *ExecutionReceipts) Store(result *flow.ExecutionReceipt) error {
 	ret := _m.Called(result)

--- a/storage/mock/execution_results.go
+++ b/storage/mock/execution_results.go
@@ -72,6 +72,20 @@ func (_m *ExecutionResults) Index(blockID flow.Identifier, resultID flow.Identif
 	return r0
 }
 
+// RemoveByBlockID provides a mock function with given fields: blockID
+func (_m *ExecutionResults) RemoveByBlockID(blockID flow.Identifier) error {
+	ret := _m.Called(blockID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(flow.Identifier) error); ok {
+		r0 = rf(blockID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Store provides a mock function with given fields: result
 func (_m *ExecutionResults) Store(result *flow.ExecutionResult) error {
 	ret := _m.Called(result)

--- a/storage/mock/transaction_results.go
+++ b/storage/mock/transaction_results.go
@@ -49,6 +49,20 @@ func (_m *TransactionResults) ByBlockIDTransactionID(blockID flow.Identifier, tr
 	return r0, r1
 }
 
+// RemoveByBlockID provides a mock function with given fields: blockID
+func (_m *TransactionResults) RemoveByBlockID(blockID flow.Identifier) error {
+	ret := _m.Called(blockID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(flow.Identifier) error); ok {
+		r0 = rf(blockID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Store provides a mock function with given fields: blockID, transactionResult
 func (_m *TransactionResults) Store(blockID flow.Identifier, transactionResult *flow.TransactionResult) error {
 	ret := _m.Called(blockID, transactionResult)

--- a/storage/mocks/storage.go
+++ b/storage/mocks/storage.go
@@ -364,6 +364,20 @@ func (mr *MockCommitsMockRecorder) ByBlockID(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByBlockID", reflect.TypeOf((*MockCommits)(nil).ByBlockID), arg0)
 }
 
+// RemoveByBlockID mocks base method
+func (m *MockCommits) RemoveByBlockID(arg0 flow.Identifier) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveByBlockID", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveByBlockID indicates an expected call of RemoveByBlockID
+func (mr *MockCommitsMockRecorder) RemoveByBlockID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveByBlockID", reflect.TypeOf((*MockCommits)(nil).RemoveByBlockID), arg0)
+}
+
 // Store mocks base method
 func (m *MockCommits) Store(arg0 flow.Identifier, arg1 []byte) error {
 	m.ctrl.T.Helper()
@@ -510,6 +524,20 @@ func (m *MockTransactionResults) ByBlockIDTransactionID(arg0, arg1 flow.Identifi
 func (mr *MockTransactionResultsMockRecorder) ByBlockIDTransactionID(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ByBlockIDTransactionID", reflect.TypeOf((*MockTransactionResults)(nil).ByBlockIDTransactionID), arg0, arg1)
+}
+
+// RemoveByBlockID mocks base method
+func (m *MockTransactionResults) RemoveByBlockID(arg0 flow.Identifier) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveByBlockID", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveByBlockID indicates an expected call of RemoveByBlockID
+func (mr *MockTransactionResultsMockRecorder) RemoveByBlockID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveByBlockID", reflect.TypeOf((*MockTransactionResults)(nil).RemoveByBlockID), arg0)
 }
 
 // Store mocks base method

--- a/storage/receipts.go
+++ b/storage/receipts.go
@@ -11,6 +11,9 @@ type ExecutionReceipts interface {
 	// Store stores an execution receipt.
 	Store(result *flow.ExecutionReceipt) error
 
+	// RemoveByBlockID receipt by block ID
+	RemoveByBlockID(blockID flow.Identifier) error
+
 	// ByID retrieves an execution receipt by its ID.
 	ByID(resultID flow.Identifier) (*flow.ExecutionReceipt, error)
 

--- a/storage/results.go
+++ b/storage/results.go
@@ -19,4 +19,6 @@ type ExecutionResults interface {
 
 	// ByBlockID retrieves an execution result by block ID.
 	ByBlockID(blockID flow.Identifier) (*flow.ExecutionResult, error)
+
+	RemoveByBlockID(blockID flow.Identifier) error
 }

--- a/storage/transaction_results.go
+++ b/storage/transaction_results.go
@@ -13,4 +13,7 @@ type TransactionResults interface {
 
 	// ByBlockIDTransactionID returns the transaction result for the given block ID and transaction ID
 	ByBlockIDTransactionID(blockID flow.Identifier, transactionID flow.Identifier) (*flow.TransactionResult, error)
+
+	// RemoveByBlockID removes transaction results by block ID
+	RemoveByBlockID(blockID flow.Identifier) error
 }


### PR DESCRIPTION
For #https://github.com/dapperlabs/flow-go/issues/5023


This PR added a tool for remove execution results. It's branched out from v0.10.3, and will NOT merge to `master`, since the remove methods are not safe.

Tests are added