### PR TITLE
[Execution] allow re-executing blocks

### DIFF
--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -545,6 +545,10 @@ func (e *Engine) executeBlock(ctx context.Context, executableBlock *entity.Execu
 	e.metrics.ExecutionStateReadsPerBlock(computationResult.StateReads)
 
 	finalState, receipt, err := e.handleComputationResult(ctx, computationResult, executableBlock.StartState)
+	if errors.Is(err, storage.ErrDataMismatch) {
+		e.log.Fatal().Err(err).Msg("fatal: trying to store different results for the same block")
+	}
+
 	if err != nil {
 		e.log.Err(err).
 			Hex("block_id", logging.Entity(executableBlock)).

--- a/storage/badger/receipts_test.go
+++ b/storage/badger/receipts_test.go
@@ -1,0 +1,104 @@
+package badger_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/storage"
+	bstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestReceiptStoreAndRetrieve(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		results := bstorage.NewExecutionResults(db)
+		store := bstorage.NewExecutionReceipts(db, results)
+
+		receipt := unittest.ExecutionReceiptFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(receipt)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, receipt.ID())
+		require.NoError(t, err)
+
+		actual, err := store.ByBlockID(blockID)
+		require.NoError(t, err)
+
+		require.Equal(t, receipt, actual)
+	})
+}
+
+func TestReceiptStoreTwice(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		results := bstorage.NewExecutionResults(db)
+		store := bstorage.NewExecutionReceipts(db, results)
+
+		receipt := unittest.ExecutionReceiptFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(receipt)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, receipt.ID())
+		require.NoError(t, err)
+
+		err = store.Store(receipt)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, receipt.ID())
+		require.NoError(t, err)
+	})
+}
+
+func TestReceiptStoreTwoDifferentReceiptsShouldFail(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		results := bstorage.NewExecutionResults(db)
+		store := bstorage.NewExecutionReceipts(db, results)
+
+		receipt1 := unittest.ExecutionReceiptFixture()
+		receipt2 := unittest.ExecutionReceiptFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(receipt1)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, receipt1.ID())
+		require.NoError(t, err)
+
+		// we can store a different receipt, but we can't index
+		// a different receipt for that block, because it will mean
+		// one block has two different receipts.
+		err = store.Store(receipt2)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, receipt2.ID())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, storage.ErrDataMismatch))
+	})
+}
+
+func TestReceiptStoreTwoDifferentReceiptsShouldOKIfResultAreSame(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		results := bstorage.NewExecutionResults(db)
+		store := bstorage.NewExecutionReceipts(db, results)
+
+		receipt1 := unittest.ExecutionReceiptFixture()
+		receipt2 := unittest.ExecutionReceiptFixture()
+		receipt2.ExecutionResult = receipt1.ExecutionResult
+
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(receipt1)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, receipt1.ID())
+		require.NoError(t, err)
+
+		err = store.Store(receipt2)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, receipt2.ID())
+		require.NoError(t, err)
+	})
+}

--- a/storage/badger/results_test.go
+++ b/storage/badger/results_test.go
@@ -1,0 +1,77 @@
+package badger_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/storage"
+	bstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestResultStoreAndRetrieve(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		store := bstorage.NewExecutionResults(db)
+
+		result := unittest.ExecutionResultFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(result)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, result.ID())
+		require.NoError(t, err)
+
+		actual, err := store.ByBlockID(blockID)
+		require.NoError(t, err)
+
+		require.Equal(t, result, actual)
+	})
+}
+
+func TestResultStoreTwice(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		store := bstorage.NewExecutionResults(db)
+
+		result := unittest.ExecutionResultFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(result)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, result.ID())
+		require.NoError(t, err)
+
+		err = store.Store(result)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, result.ID())
+		require.NoError(t, err)
+	})
+}
+
+func TestResultStoreTwoDifferentResultsShouldFail(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		store := bstorage.NewExecutionResults(db)
+
+		result1 := unittest.ExecutionResultFixture()
+		result2 := unittest.ExecutionResultFixture()
+		blockID := unittest.IdentifierFixture()
+		err := store.Store(result1)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, result1.ID())
+		require.NoError(t, err)
+
+		// we can store a different result, but we can't index
+		// a different result for that block, because it will mean
+		// one block has two different results.
+		err = store.Store(result2)
+		require.NoError(t, err)
+
+		err = store.Index(blockID, result2.ID())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, storage.ErrDataMismatch))
+	})
+}


### PR DESCRIPTION
[Execution node will re-execute a block on startup](https://github.com/onflow/flow-go/blob/master/engine/execution/ingestion/engine.go#L305-L308), however the storage layer will reject the call to store the execution results again, which will cause the block execution to halt on startup.

The behavior I've seen on testnet is that after a restart, only one block is executed. That's because the storage layer hit an `KeyAlreadyExist` error and cause the ingestion engine stop from executing the next block.

Logs:
```
Nov 05 15:33:41 execution-002 docker[56349]: {"level":"error","node_role":"execution","node_id":"639d905053cc36aa80a0c249ae659db8ec58946f1c6a0b2d9b67195646a7f6df","engine":"ingestion","error":"could not save execution results: could not persist execution result: could not store result: key already exists","block_id":"726e111e8e9d1f8faf4793fffff616f826aa02a0c070d5b6e86830dacf02fb51","time":"2020-11-05T15:33:41Z","message":"error while handing computation results"}
```