### PR TITLE
Kan/v0.11 access older results

### DIFF
--- a/access/api.go
+++ b/access/api.go
@@ -58,6 +58,16 @@ func TransactionResultToMessage(result *TransactionResult) *access.TransactionRe
 	}
 }
 
+func MessageToTransactionResult(message *access.TransactionResultResponse) *TransactionResult {
+
+	return &TransactionResult{
+		Status:       flow.TransactionStatus(message.Status),
+		StatusCode:   uint(message.StatusCode),
+		ErrorMessage: message.ErrorMessage,
+		Events:       convert.MessagesToEvents(message.Events),
+	}
+}
+
 // NetworkParameters contains the network-wide parameters for the Flow blockchain.
 type NetworkParameters struct {
 	ChainID flow.ChainID

--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -53,6 +53,7 @@ func main() {
 		rpcEng                       *rpc.Engine
 		collectionRPC                access.AccessAPIClient
 		executionRPC                 execution.ExecutionAPIClient
+		historicalAccessRPCs         []access.AccessAPIClient
 		err                          error
 		conCache                     *buffer.PendingBlocks // pending block cache for follower
 		transactionTimings           *stdmap.TransactionTimings
@@ -77,6 +78,7 @@ func main() {
 			flags.StringVarP(&rpcConf.HTTPListenAddr, "http-addr", "h", "localhost:8000", "the address the http proxy server listens on")
 			flags.StringVarP(&rpcConf.CollectionAddr, "static-collection-ingress-addr", "", "", "the address (of the collection node) to send transactions to")
 			flags.StringVarP(&rpcConf.ExecutionAddr, "script-addr", "s", "localhost:9000", "the address (of the execution node) forward the script to")
+			flags.StringVarP(&rpcConf.HistoricalAccessAddrs, "historical-access-addr", "", "", "comma separated rpc addresses for historical access nodes")
 			flags.BoolVar(&logTxTimeToFinalized, "log-tx-time-to-finalized", false, "log transaction time to finalized")
 			flags.BoolVar(&logTxTimeToExecuted, "log-tx-time-to-executed", false, "log transaction time to executed")
 			flags.BoolVar(&logTxTimeToFinalizedExecuted, "log-tx-time-to-finalized-executed", false, "log transaction time to finalized and executed")
@@ -112,6 +114,24 @@ func main() {
 			}
 			executionRPC = execution.NewExecutionAPIClient(executionRPCConn)
 			return nil
+		}).
+		Module("historical access node clients", func(node *cmd.FlowNodeBuilder) error {
+			addrs := strings.Split(rpcConf.HistoricalAccessAddrs)
+			for _, addr := range addrs {
+				if strings.TrimSpace(addr) == "" {
+					continue
+				}
+				node.Logger.Info().Err(err).Msgf("Historical access node Addr: %s", addr)
+
+				historicalAccessRPCConn, err := grpc.Dial(
+					addr,
+					grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcutils.DefaultMaxMsgSize)),
+					grpc.WithInsecure())
+				if err != nil {
+					return err
+				}
+				historicalAccessRPCs = append(historicalAccessRPCs, access.NewAccessAPIClient(historicalAccessRPCConn))
+			}
 		}).
 		Module("block cache", func(node *cmd.FlowNodeBuilder) error {
 			conCache = buffer.NewPendingBlocks()
@@ -156,6 +176,7 @@ func main() {
 				rpcConf,
 				executionRPC,
 				collectionRPC,
+				historicalAccessRPCs,
 				node.Storage.Blocks,
 				node.Storage.Headers,
 				node.Storage.Collections,

--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -116,7 +116,7 @@ func main() {
 			return nil
 		}).
 		Module("historical access node clients", func(node *cmd.FlowNodeBuilder) error {
-			addrs := strings.Split(rpcConf.HistoricalAccessAddrs)
+			addrs := strings.Split(rpcConf.HistoricalAccessAddrs, ",")
 			for _, addr := range addrs {
 				if strings.TrimSpace(addr) == "" {
 					continue
@@ -132,6 +132,7 @@ func main() {
 				}
 				historicalAccessRPCs = append(historicalAccessRPCs, access.NewAccessAPIClient(historicalAccessRPCConn))
 			}
+			return nil
 		}).
 		Module("block cache", func(node *cmd.FlowNodeBuilder) error {
 			conCache = buffer.NewPendingBlocks()

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -100,6 +100,7 @@ func (suite *Suite) RunTest(
 			suite.state,
 			suite.execClient,
 			suite.collClient,
+			nil,
 			blocks,
 			headers,
 			collections,
@@ -280,6 +281,7 @@ func (suite *Suite) TestSendTransactionToRandomCollectionNode() {
 			nil, // setting collectionRPC to nil to choose a random collection node for each send tx request
 			nil,
 			nil,
+			nil,
 			collections,
 			transactions,
 			suite.chainID,
@@ -444,7 +446,7 @@ func (suite *Suite) TestGetSealedTransaction() {
 		blocksToMarkExecuted, err := stdmap.NewTimes(100)
 		require.NoError(suite.T(), err)
 
-		rpcEng := rpc.New(suite.log, suite.state, rpc.Config{}, nil, nil, blocks, headers, collections, transactions,
+		rpcEng := rpc.New(suite.log, suite.state, rpc.Config{}, nil, nil, nil, blocks, headers, collections, transactions,
 			suite.chainID, metrics, 0, false)
 
 		// create the ingest engine

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -89,7 +89,7 @@ func (suite *Suite) SetupTest() {
 	blocksToMarkExecuted, err := stdmap.NewTimes(100)
 	require.NoError(suite.T(), err)
 
-	rpcEng := rpc.New(log, suite.proto.state, rpc.Config{}, nil, nil, suite.blocks, suite.headers, suite.collections,
+	rpcEng := rpc.New(log, suite.proto.state, rpc.Config{}, nil, nil, nil, suite.blocks, suite.headers, suite.collections,
 		suite.transactions, flow.Testnet, metrics.NewNoopCollector(), 0, false)
 
 	eng, err := New(log, net, suite.proto.state, suite.me, suite.request, suite.blocks, suite.headers, suite.collections,

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -166,6 +166,13 @@ func (b *Backend) GetNetworkParameters(_ context.Context) access.NetworkParamete
 }
 
 func convertStorageError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) == codes.NotFound {
+		// Already converted
+		return err
+	}
 	if errors.Is(err, storage.ErrNotFound) {
 		return status.Errorf(codes.NotFound, "not found: %v", err)
 	}

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -47,6 +47,7 @@ func New(
 	state protocol.State,
 	executionRPC execproto.ExecutionAPIClient,
 	collectionRPC accessproto.AccessAPIClient,
+	historicalAccessNodes []accessproto.AccessAPIClient,
 	blocks storage.Blocks,
 	headers storage.Headers,
 	collections storage.Collections,
@@ -84,6 +85,7 @@ func New(
 			retry:                retry,
 			collectionGRPCPort:   collectionGRPCPort,
 			connFactory:          connFactory,
+			previousAccessNodes:  historicalAccessNodes,
 		},
 		backendEvents: backendEvents{
 			executionRPC: executionRPC,

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -61,7 +61,6 @@ func (suite *Suite) SetupTest() {
 	suite.execClient = new(access.ExecutionAPIClient)
 	suite.chainID = flow.Testnet
 	suite.historicalAccessClient = new(access.AccessAPIClient)
-
 }
 
 func (suite *Suite) TestPing() {

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -32,13 +32,14 @@ type Suite struct {
 	snapshot *protocol.Snapshot
 	log      zerolog.Logger
 
-	blocks       *storagemock.Blocks
-	headers      *storagemock.Headers
-	collections  *storagemock.Collections
-	transactions *storagemock.Transactions
-	colClient    *access.AccessAPIClient
-	execClient   *access.ExecutionAPIClient
-	chainID      flow.ChainID
+	blocks                 *storagemock.Blocks
+	headers                *storagemock.Headers
+	collections            *storagemock.Collections
+	transactions           *storagemock.Transactions
+	colClient              *access.AccessAPIClient
+	execClient             *access.ExecutionAPIClient
+	historicalAccessClient *access.AccessAPIClient
+	chainID                flow.ChainID
 }
 
 func TestHandler(t *testing.T) {
@@ -59,6 +60,8 @@ func (suite *Suite) SetupTest() {
 	suite.colClient = new(access.AccessAPIClient)
 	suite.execClient = new(access.ExecutionAPIClient)
 	suite.chainID = flow.Testnet
+	suite.historicalAccessClient = new(access.AccessAPIClient)
+
 }
 
 func (suite *Suite) TestPing() {
@@ -74,7 +77,7 @@ func (suite *Suite) TestPing() {
 		suite.state,
 		suite.execClient,
 		suite.colClient,
-		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
 		suite.chainID,
 		metrics.NewNoopCollector(),
 		0,
@@ -96,7 +99,7 @@ func (suite *Suite) TestGetLatestFinalizedBlockHeader() {
 	backend := New(
 		suite.state,
 		suite.execClient,
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil,
 		suite.chainID,
 		metrics.NewNoopCollector(),
 		0,
@@ -123,7 +126,7 @@ func (suite *Suite) TestGetLatestSealedBlockHeader() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 		suite.headers, nil, nil,
 		suite.chainID,
 		metrics.NewNoopCollector(),
@@ -155,7 +158,7 @@ func (suite *Suite) TestGetTransaction() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil,
 		suite.transactions,
 		suite.chainID,
 		metrics.NewNoopCollector(),
@@ -182,7 +185,7 @@ func (suite *Suite) TestGetCollection() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
 		suite.collections,
 		suite.transactions,
 		suite.chainID,
@@ -248,6 +251,7 @@ func (suite *Suite) TestTransactionStatusTransition() {
 	backend := New(
 		suite.state,
 		suite.execClient,
+		nil,
 		nil,
 		suite.blocks,
 		suite.headers,
@@ -350,6 +354,7 @@ func (suite *Suite) TestTransactionExpiredStatusTransition() {
 		suite.state,
 		suite.execClient,
 		nil,
+		nil,
 		suite.blocks,
 		suite.headers,
 		suite.collections,
@@ -396,7 +401,7 @@ func (suite *Suite) TestGetLatestFinalizedBlock() {
 
 	backend := New(
 		suite.state,
-		nil, nil,
+		nil, nil, nil,
 		suite.blocks,
 		nil, nil, nil,
 		suite.chainID,
@@ -480,7 +485,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 	backend := New(
 		suite.state,
 		suite.execClient,
-		nil,
+		nil, nil,
 		suite.blocks,
 		nil, nil, nil,
 		suite.chainID,
@@ -573,7 +578,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 	suite.Run("invalid request max height < min height", func() {
 		backend := New(
 			suite.state,
-			nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil,
 			suite.chainID,
 			metrics.NewNoopCollector(),
 			0,
@@ -600,7 +605,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 		backend := New(
 			suite.state,
 			suite.execClient,
-			nil,
+			nil, nil,
 			suite.blocks,
 			suite.headers,
 			nil, nil,
@@ -629,7 +634,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 		backend := New(
 			suite.state,
 			suite.execClient,
-			nil,
+			nil, nil,
 			suite.blocks,
 			suite.headers,
 			nil, nil,
@@ -691,7 +696,7 @@ func (suite *Suite) TestGetAccount() {
 	backend := New(
 		suite.state,
 		suite.execClient,
-		nil, nil,
+		nil, nil, nil,
 		suite.headers,
 		nil, nil,
 		suite.chainID,
@@ -750,7 +755,7 @@ func (suite *Suite) TestGetAccountAtBlockHeight() {
 	backend := New(
 		suite.state,
 		suite.execClient,
-		nil, nil,
+		nil, nil, nil,
 		suite.headers,
 		nil, nil,
 		flow.Testnet,
@@ -774,7 +779,7 @@ func (suite *Suite) TestGetNetworkParameters() {
 	expectedChainID := flow.Mainnet
 
 	backend := New(
-		nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil,
 		flow.Mainnet,
 		metrics.NewNoopCollector(),
 		0,

--- a/engine/access/rpc/backend/historical_access_test.go
+++ b/engine/access/rpc/backend/historical_access_test.go
@@ -13,27 +13,18 @@ import (
 	"github.com/onflow/flow/protobuf/go/flow/entities"
 )
 
-// TestHistoricalTransaction tests that the status of transaction changes from Finalized to Sealed
-// when the protocol state is updated
+// TestHistoricalTransaction tests to see if the historical transaction status can be retrieved
 func (suite *Suite) TestHistoricalTransaction() {
 
 	ctx := context.Background()
 	collection := unittest.CollectionFixture(1)
 	transactionBody := collection.Transactions[0]
-	block := unittest.BlockFixture()
-	block.Header.Height = 2
-	headBlock := unittest.BlockFixture()
-	headBlock.Header.Height = block.Header.Height - 1 // head is behind the current block
-
-	suite.snapshot.
-		On("Head").
-		Return(headBlock.Header, nil)
 
 	txID := transactionBody.ID()
 	// transaction storage returns the corresponding transaction
 	suite.transactions.
 		On("ByID", txID).
-		Return(nil, status.Errorf(codes.NotFound, "not found"))
+		Return(nil, status.Errorf(codes.NotFound, "not found on main node"))
 
 	accessEventReq := accessproto.GetTransactionRequest{
 		Id: txID[:],

--- a/engine/access/rpc/backend/historical_access_test.go
+++ b/engine/access/rpc/backend/historical_access_test.go
@@ -1,0 +1,77 @@
+package backend
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/utils/unittest"
+	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
+)
+
+// TestHistoricalTransaction tests that the status of transaction changes from Finalized to Sealed
+// when the protocol state is updated
+func (suite *Suite) TestHistoricalTransaction() {
+
+	ctx := context.Background()
+	collection := unittest.CollectionFixture(1)
+	transactionBody := collection.Transactions[0]
+	block := unittest.BlockFixture()
+	block.Header.Height = 2
+	headBlock := unittest.BlockFixture()
+	headBlock.Header.Height = block.Header.Height - 1 // head is behind the current block
+
+	suite.snapshot.
+		On("Head").
+		Return(headBlock.Header, nil)
+
+	txID := transactionBody.ID()
+	// transaction storage returns the corresponding transaction
+	suite.transactions.
+		On("ByID", txID).
+		Return(nil, status.Errorf(codes.NotFound, "not found"))
+
+	accessEventReq := accessproto.GetTransactionRequest{
+		Id: txID[:],
+	}
+
+	accessEventResp := accessproto.TransactionResultResponse{
+		Status: entities.TransactionStatus(flow.TransactionStatusSealed),
+		Events: nil,
+	}
+
+	backend := New(
+		suite.state,
+		suite.execClient,
+		nil,
+		[]accessproto.AccessAPIClient{suite.historicalAccessClient},
+		suite.blocks,
+		suite.headers,
+		suite.collections,
+		suite.transactions,
+		suite.chainID,
+		metrics.NewNoopCollector(),
+		0,
+		nil,
+		false,
+	)
+
+	// Successfully return empty event list
+	suite.historicalAccessClient.
+		On("GetTransactionResult", ctx, &accessEventReq).
+		Return(&accessEventResp, nil).
+		Once()
+
+	// first call - when block under test is greater height than the sealed head, but execution node does not know about Tx
+	result, err := backend.GetTransactionResult(ctx, txID)
+	suite.checkResponse(result, err)
+
+	// status should be finalized since the sealed blocks is smaller in height
+	suite.Assert().Equal(flow.TransactionStatusSealed, result.Status)
+
+	suite.assertAllExpectations()
+}

--- a/engine/access/rpc/backend/retry_test.go
+++ b/engine/access/rpc/backend/retry_test.go
@@ -40,7 +40,7 @@ func (suite *Suite) TestTransactionRetry() {
 	// txID := transactionBody.ID()
 	// blockID := block.ID()
 	// Setup Handler + Retry
-	backend := New(suite.state, suite.execClient, suite.colClient, suite.blocks, suite.headers,
+	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
 		suite.collections, suite.transactions, suite.chainID, metrics.NewNoopCollector(), 0, nil, false)
 	retry := newRetry().SetBackend(backend).Activate()
 	backend.retry = retry
@@ -98,7 +98,7 @@ func (suite *Suite) TestSuccessfulTransactionsDontRetry() {
 	}
 
 	// Setup Handler + Retry
-	backend := New(suite.state, suite.execClient, suite.colClient, suite.blocks, suite.headers,
+	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
 		suite.collections, suite.transactions, suite.chainID, metrics.NewNoopCollector(), 0, nil, false)
 	retry := newRetry().SetBackend(backend).Activate()
 	backend.retry = retry

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -27,11 +27,12 @@ import (
 
 // Config defines the configurable options for the access node server
 type Config struct {
-	GRPCListenAddr string
-	HTTPListenAddr string
-	ExecutionAddr  string
-	CollectionAddr string
-	MaxMsgSize     int // In bytes
+	GRPCListenAddr        string
+	HTTPListenAddr        string
+	ExecutionAddr         string
+	CollectionAddr        string
+	HistoricalAccessAddrs string
+	MaxMsgSize            int // In bytes
 }
 
 // Engine implements a gRPC server with a simplified version of the Observation API.
@@ -50,6 +51,7 @@ func New(log zerolog.Logger,
 	config Config,
 	executionRPC execproto.ExecutionAPIClient,
 	collectionRPC accessproto.AccessAPIClient,
+	historicalAccessNodes []accessproto.AccessAPIClient,
 	blocks storage.Blocks,
 	headers storage.Headers,
 	collections storage.Collections,
@@ -79,6 +81,7 @@ func New(log zerolog.Logger,
 		state,
 		executionRPC,
 		collectionRPC,
+		historicalAccessNodes,
 		blocks,
 		headers,
 		collections,

--- a/go.sum
+++ b/go.sum
@@ -672,7 +672,6 @@ github.com/onflow/cadence v0.9.2 h1:8ItrQY39NG3MSCGfLnsVa1eHbviLZ6SN243afz7ZrcU=
 github.com/onflow/cadence v0.9.2 h1:8ItrQY39NG3MSCGfLnsVa1eHbviLZ6SN243afz7ZrcU=
 github.com/onflow/cadence v0.9.2/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/cadence v0.9.2/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
-github.com/onflow/flow v0.1.3 h1:qhtGJtJoz8GeAKLDq914f26/UvZ16v/R2sJ6WreGLqA=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0 h1:MUivqc0+0WY2TsDhggcKAiHD6sR24xOscpcd5m3CLIQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0/go.mod h1:4oPXY+JffxZhnl7B23J2ttjAWJeVqdL6ZU2yhzgQLqU=
 github.com/onflow/flow-ft/contracts v0.1.3/go.mod h1:IKe3yEurEKpg/J15q5WBlHkuMmt1iRECSHgnIa1gvRw=
@@ -686,7 +685,6 @@ github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27 h1:
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onflow/flow/protobuf/go/flow v0.1.7 h1:BaZVc1XWkI1vx/+qvdkXnKjsWk4UFRBAg7vvfQ/u5Pk=
 github.com/onflow/flow/protobuf/go/flow v0.1.7/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
-github.com/onflow/flow/protobuf/go/flow v0.1.8 h1:jBR8aXEL0MOh3gVJmCr0KYXmtG3JUBhzADonKkYE6oI=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -672,6 +672,7 @@ github.com/onflow/cadence v0.9.2 h1:8ItrQY39NG3MSCGfLnsVa1eHbviLZ6SN243afz7ZrcU=
 github.com/onflow/cadence v0.9.2 h1:8ItrQY39NG3MSCGfLnsVa1eHbviLZ6SN243afz7ZrcU=
 github.com/onflow/cadence v0.9.2/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
 github.com/onflow/cadence v0.9.2/go.mod h1:R43uGnqQsTcnFf1fMPCcMjDPplBIzbR5XkFZRF2OH3Y=
+github.com/onflow/flow v0.1.3 h1:qhtGJtJoz8GeAKLDq914f26/UvZ16v/R2sJ6WreGLqA=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0 h1:MUivqc0+0WY2TsDhggcKAiHD6sR24xOscpcd5m3CLIQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.1.0/go.mod h1:4oPXY+JffxZhnl7B23J2ttjAWJeVqdL6ZU2yhzgQLqU=
 github.com/onflow/flow-ft/contracts v0.1.3/go.mod h1:IKe3yEurEKpg/J15q5WBlHkuMmt1iRECSHgnIa1gvRw=
@@ -685,6 +686,7 @@ github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27 h1:
 github.com/onflow/flow/protobuf/go/flow v0.1.5-0.20200619174948-a3a856d16a27/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onflow/flow/protobuf/go/flow v0.1.7 h1:BaZVc1XWkI1vx/+qvdkXnKjsWk4UFRBAg7vvfQ/u5Pk=
 github.com/onflow/flow/protobuf/go/flow v0.1.7/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.1.8 h1:jBR8aXEL0MOh3gVJmCr0KYXmtG3JUBhzADonKkYE6oI=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
This adds the ability to talk to historical access nodes.

Will only call the previous access node if the Tx cannot be found on the current node.