### PR TITLE
Add DKG controller

### DIFF
--- a/engine/consensus/dkg/dkg_controller.go
+++ b/engine/consensus/dkg/dkg_controller.go
@@ -76,11 +76,11 @@ type Controller struct {
 	endCh      chan struct{}
 	shutdownCh chan struct{}
 
-	// private fields that hold the DKG artifacts when the protocol run to
+	// private fields that hold the DKG artifacts when the protocol runs to
 	// completion
-	privateShare crypto.PrivateKey
-	publicShare  crypto.PublicKey
-	publicKeys   []crypto.PublicKey
+	privateShare   crypto.PrivateKey
+	publicKeys     []crypto.PublicKey
+	groupPublicKey crypto.PublicKey
 
 	// artifactsLock protects access to artifacts
 	artifactsLock sync.Mutex
@@ -192,7 +192,7 @@ func (c *Controller) End() error {
 
 	// end and retrieve products of the DKG protocol
 	c.dkgLock.Lock()
-	privateShare, publicShare, publicKeys, err := c.dkg.End()
+	privateShare, groupPublicKey, publicKeys, err := c.dkg.End()
 	c.dkgLock.Unlock()
 
 	if err != nil {
@@ -201,7 +201,7 @@ func (c *Controller) End() error {
 
 	c.artifactsLock.Lock()
 	c.privateShare = privateShare
-	c.publicShare = publicShare
+	c.groupPublicKey = groupPublicKey
 	c.publicKeys = publicKeys
 	c.artifactsLock.Unlock()
 
@@ -222,7 +222,7 @@ func (c *Controller) Shutdown() {
 func (c *Controller) GetArtifacts() (crypto.PrivateKey, crypto.PublicKey, []crypto.PublicKey) {
 	c.artifactsLock.Lock()
 	defer c.artifactsLock.Unlock()
-	return c.privateShare, c.publicShare, c.publicKeys
+	return c.privateShare, c.groupPublicKey, c.publicKeys
 }
 
 /*******************************************************************************

--- a/engine/consensus/dkg/dkg_controller.go
+++ b/engine/consensus/dkg/dkg_controller.go
@@ -1,0 +1,289 @@
+/*
+
+Package dkg implements a controller that manages the lifecycle of a Joint
+Feldman DKG node.
+
+The state-machine can be represented as follows:
+
++-------+  /Run() +---------+  /EndPhase0() +---------+  /EndPhase1() +---------+  /End()   +----------+
+| Init  | ----->  | Phase 0 | ------------> | Phase 1 | ------------> | Phase 2 | --------> | Shutdown |
++-------+         +---------+               +---------+               +---------+           +----------+
+   |                   |                         |                         |                      ^
+   v___________________v_________________________v_________________________v______________________|
+                                            /Shutdown()
+
+The controller is always in one of 5 states:
+	- Init: Default state before the instance is started
+	- Phase 0: 1st phase of the JF DKG protocol while it's running
+	- Phase 1: 2nd phase of the JF DKG protocol while it's running
+	- Phase 2: 3rd phase of the JF DKG protocol while it's running
+	- Shutdown: When the controller is stopped
+
+The controller exposes the following functions to trigger transitions:
+
+Run(): Triggers transition from Init to Phase0. Starts the DKG protocol instance
+       and background communication routines.
+
+EndPhase0(): Triggers transition from Phase 0 to Phase 1.
+
+EndPhase1(): Triggers transition from Phase 1 to Phase 2.
+
+End(): Ends the DKG protocol and returns the artifacts. Triggers transition to
+	   Shutdown.
+
+Shutdown(): Can be called from any state to stop the DKG instance.
+
+*/
+package dkg
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/crypto"
+)
+
+// Controller controls the execution of a Joint Feldman DKG instance.
+type Controller struct {
+	// The embedded state Manager is used to manage the controller's underlying
+	// state.
+	Manager
+
+	// DKGState is the object that actually executes the protocol steps.
+	dkg crypto.DKGState
+
+	// seed is required by DKGState
+	seed []byte
+
+	// msgCh is the channel through which the controller receives private and
+	// broadcast messages. It is assumed that the messages are valid. All
+	// validity checks should be performed upstream.
+	msgCh chan DKGMessage
+
+	// Channels used internally to trigger state transitions
+	h0Ch       chan struct{}
+	h1Ch       chan struct{}
+	endCh      chan struct{}
+	shutdownCh chan struct{}
+
+	log zerolog.Logger
+}
+
+// NewController instantiates a new Joint Feldman DKG controller.
+func NewController(
+	dkg crypto.DKGState,
+	seed []byte,
+	msgCh chan DKGMessage,
+	log zerolog.Logger) *Controller {
+
+	return &Controller{
+		log:        log,
+		dkg:        dkg,
+		seed:       seed,
+		msgCh:      msgCh,
+		h0Ch:       make(chan struct{}),
+		h1Ch:       make(chan struct{}),
+		endCh:      make(chan struct{}),
+		shutdownCh: make(chan struct{}),
+	}
+}
+
+/*******************************************************************************
+CONTROLS
+*******************************************************************************/
+
+// Run starts the DKG controller. It is a blocking call that blocks until the
+// controller is shutdown or until an error is encountered in one of the
+// protocol phases.
+func (c *Controller) Run() error {
+
+	// Start DKG and transition to phase 0
+	err := c.start()
+	if err != nil {
+		return err
+	}
+
+	// Start a background routine to listen for incoming private and broadcast
+	// messages from other nodes
+	go c.doBackgroundWork()
+
+	// Execute DKG State Machine
+	for {
+		state := c.GetState()
+		c.log.Debug().Msgf("DKG: %s", c.state)
+
+		switch state {
+		case Phase0:
+			err := c.phase0()
+			if err != nil {
+				return err
+			}
+		case Phase1:
+			err := c.phase1()
+			if err != nil {
+				return err
+			}
+		case Phase2:
+			err := c.phase2()
+			if err != nil {
+				return err
+			}
+		case Shutdown:
+			return nil
+		}
+	}
+}
+
+// EndPhase0 notifies the controller to end phase 0, and start phase 1
+func (c *Controller) EndPhase0() error {
+	state := c.GetState()
+	if state != Phase0 {
+		return NewInvalidStateTransitionError(state, Phase1)
+	}
+
+	close(c.h0Ch)
+
+	c.SetState(Phase1)
+
+	return nil
+}
+
+// EndPhase1 notifies the controller to end phase 1, and start phase 2
+func (c *Controller) EndPhase1() error {
+	state := c.GetState()
+	if state != Phase1 {
+		return NewInvalidStateTransitionError(state, Phase2)
+	}
+
+	close(c.h1Ch)
+
+	c.SetState(Phase2)
+
+	return nil
+}
+
+// End terminates the DKG state machine and returns the artifacts
+func (c *Controller) End() (crypto.PrivateKey, crypto.PublicKey, []crypto.PublicKey, error) {
+	state := c.GetState()
+	if state != Phase2 {
+		return nil, nil, nil, NewInvalidStateTransitionError(state, Shutdown)
+	}
+
+	close(c.endCh)
+
+	c.SetState(Shutdown)
+
+	c.log.Debug().Msg("DKG engine end")
+
+	// return the products of the DKG protocol
+	return c.dkg.End()
+}
+
+// Shutdown stops the controller regardless of the current state.
+func (c *Controller) Shutdown() {
+	close(c.shutdownCh)
+}
+
+/*******************************************************************************
+WORKERS
+*******************************************************************************/
+
+func (c *Controller) doBackgroundWork() {
+	for {
+		select {
+		case msg := <-c.msgCh:
+			err := c.dkg.HandleMsg(msg.Orig, msg.Data)
+			if err != nil {
+				c.log.Err(err).Msg("Error processing DKG message")
+			}
+		case <-c.shutdownCh:
+			return
+		}
+	}
+}
+
+func (c *Controller) start() error {
+	state := c.GetState()
+	if state != Init {
+		return fmt.Errorf("Cannot execute start routine in state %s", state)
+	}
+
+	err := c.dkg.Start(c.seed)
+	if err != nil {
+		return fmt.Errorf("Error starting DKG: %w", err)
+	}
+
+	c.log.Debug().Msg("DKG engine started")
+
+	c.SetState(Phase0)
+
+	return nil
+}
+
+func (c *Controller) phase0() error {
+	state := c.GetState()
+	if state != Phase0 {
+		return fmt.Errorf("Cannot execute phase0 routine in state %s", state)
+	}
+
+	c.log.Debug().Msg("Waiting for end of phase 0")
+
+	for {
+		select {
+		case <-c.h0Ch:
+			return nil
+		case <-c.shutdownCh:
+			c.SetState(Shutdown)
+			return nil
+		}
+	}
+}
+
+func (c *Controller) phase1() error {
+	state := c.GetState()
+	if state != Phase1 {
+		return fmt.Errorf("Cannot execute phase1 routine in state %s", state)
+	}
+
+	err := c.dkg.NextTimeout()
+	if err != nil {
+		return fmt.Errorf("Error calling NextTimeout: %w", err)
+	}
+
+	c.log.Debug().Msg("Waiting for end of phase 1")
+
+	for {
+		select {
+		case <-c.h1Ch:
+			return nil
+		case <-c.shutdownCh:
+			c.SetState(Shutdown)
+			return nil
+		}
+	}
+}
+
+func (c *Controller) phase2() error {
+	state := c.GetState()
+	if state != Phase2 {
+		return fmt.Errorf("Cannot execute phase2 routine in state %s", state)
+	}
+
+	err := c.dkg.NextTimeout()
+	if err != nil {
+		return fmt.Errorf("Error calling NextTimeout: %w", err)
+	}
+
+	c.log.Debug().Msg("Waiting for end of phase 2")
+
+	for {
+		select {
+		case <-c.endCh:
+			return nil
+		case <-c.shutdownCh:
+			c.SetState(Shutdown)
+			return nil
+		}
+	}
+}

--- a/engine/consensus/dkg/dkg_controller_test.go
+++ b/engine/consensus/dkg/dkg_controller_test.go
@@ -1,0 +1,217 @@
+package dkg
+
+import (
+	"crypto/rand"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/crypto"
+)
+
+// node is a test object that simulates a running instance of the DKG protocol
+// where transitions from one phase to another are dictated by a timer.
+type node struct {
+	id            int
+	controller    *Controller
+	phaseDuration time.Duration
+
+	// artifacts of DKG
+	priv crypto.PrivateKey
+	pub  crypto.PublicKey
+	pubs []crypto.PublicKey
+}
+
+func newNode(id int, controller *Controller, phaseDuration time.Duration) *node {
+	return &node{
+		id:            id,
+		controller:    controller,
+		phaseDuration: phaseDuration,
+	}
+}
+
+func (n *node) run() error {
+	// start the DKG controller
+	go func() {
+		_ = n.controller.Run()
+	}()
+
+	// Wait and trigger transition from Phase 0 to Phase 1
+	err := n.delayedTask(n.phaseDuration, n.controller.EndPhase0)
+	if err != nil {
+		return err
+	}
+
+	// Wait and trigger transition from Phase 1 to Phase 2
+	err = n.delayedTask(n.phaseDuration, n.controller.EndPhase1)
+	if err != nil {
+		return err
+	}
+
+	// Wait and retrieve DKG results
+	err = n.delayedTask(
+		n.phaseDuration,
+		func() error {
+			n.priv, n.pub, n.pubs, err = n.controller.End()
+			return err
+		})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *node) delayedTask(delay time.Duration, task func() error) error {
+	timer := time.After(delay)
+	<-timer
+	return task()
+}
+
+// processor is an implementation of DKGProcessor that enables nodes to exchange
+// private and public messages.
+type processor struct {
+	id       int
+	channels []chan DKGMessage
+}
+
+func (proc *processor) PrivateSend(dest int, data []byte) {
+	proc.channels[dest] <- DKGMessage{Orig: proc.id, Data: data}
+}
+
+func (proc *processor) Broadcast(data []byte) {
+	for i := 0; i < len(proc.channels); i++ {
+		if i == proc.id {
+			continue
+		}
+		proc.channels[i] <- DKGMessage{Orig: proc.id, Data: data}
+	}
+}
+
+func (proc *processor) Blacklist(node int) {}
+
+func (proc *processor) FlagMisbehavior(node int, logData string) {}
+
+// TestDKG tests the controller in optimal conditions, when all nodes are
+// working correctly.
+func TestDKG(t *testing.T) {
+	t.Run("5nodes", func(t *testing.T) { testDKG(t, 5, 5, time.Second) })
+	t.Run("10nodes", func(t *testing.T) { testDKG(t, 10, 10, time.Second) })
+	// t.Run("20nodes", func(t *testing.T) { testDKG(t, 20, 5*time.Second) })
+}
+
+// TestDKGThreshold tests that the controller results in a successful DKG as
+// long as the minimum threshold for non-byzantine nodes is satisfied.
+func TestDKGThreshold(t *testing.T) {
+	n := 10
+	phaseDuration := 1 * time.Second
+
+	// gn is the minimum number of good nodes required for the DKG protocol to
+	// go well
+	gn := n - optimalThreshold(n)
+
+	testDKG(t, n, gn, phaseDuration)
+}
+
+func testDKG(t *testing.T, totalNodes int, goodNodes int, phaseDuration time.Duration) {
+	nodes := initNodes(t, totalNodes, phaseDuration)
+	gnodes := nodes[:goodNodes]
+
+	// Start all nodes in parallel
+	for _, n := range gnodes {
+		go func(node *node) {
+			err := node.run()
+			require.NoError(t, err)
+		}(n)
+	}
+
+	// Wait until they are all shutdown
+	wait(t, gnodes, 5*phaseDuration)
+
+	// Check that all nodes have agreed on the same set of public keys
+	checkArtifacts(t, gnodes)
+}
+
+func initNodes(t *testing.T, n int, phaseDuration time.Duration) []*node {
+	// Create the channels through which the nodes will communicate
+	channels := make([]chan DKGMessage, 0, n)
+	for i := 0; i < n; i++ {
+		channels = append(channels, make(chan DKGMessage, 5*n*n))
+	}
+
+	nodes := make([]*node, 0, n)
+
+	// Setup
+	for i := 0; i < n; i++ {
+		seed := make([]byte, 20)
+		_, _ = rand.Read(seed)
+
+		processor := &processor{
+			id:       i,
+			channels: channels,
+		}
+
+		dkg, err := crypto.NewJointFeldman(n, optimalThreshold(n), i, processor)
+		require.NoError(t, err)
+
+		controller := NewController(
+			dkg,
+			seed,
+			channels[i],
+			zerolog.New(os.Stderr).With().Int("id", i).Logger())
+
+		node := newNode(i, controller, phaseDuration)
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes
+}
+
+func wait(t *testing.T, nodes []*node, timeout time.Duration) {
+
+	timer := time.After(timeout)
+
+	for {
+		select {
+		case <-timer:
+			t.Fatal("TIMEOUT")
+		default:
+			done := true
+			for _, node := range nodes {
+				if node.controller.GetState() != Shutdown {
+					done = false
+					break
+				}
+			}
+			if done {
+				return
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+func checkArtifacts(t *testing.T, nodes []*node) {
+	for i := 1; i < len(nodes); i++ {
+		require.NotEmpty(t, nodes[i].priv)
+		require.NotEmpty(t, nodes[i].pub)
+		require.NotEmpty(t, nodes[i].pubs)
+		// require.Equal(t, nodes[0].pubs, nodes[i].pubs)
+		if !reflect.DeepEqual(nodes[0].pubs, nodes[i].pubs) {
+			t.Fatalf("pubs differ: %#v, %#v", nodes[0].pubs, nodes[i].pubs)
+		}
+	}
+}
+
+// optimal threshold (t) to allow the largest number of malicious nodes (m)
+// assuming the protocol requires:
+//   m<=t for unforgeability
+//   n-m>=t+1 for robustness
+func optimalThreshold(size int) int {
+	return (size - 1) / 2
+}

--- a/engine/consensus/dkg/dkg_controller_test.go
+++ b/engine/consensus/dkg/dkg_controller_test.go
@@ -141,6 +141,12 @@ func TestDKGThreshold(t *testing.T) {
 	}
 }
 
+// ATTENTION: This test seems to indicate that nodes end up with a different set
+// of public keys when the phase duration is short.
+func TestDKGShortDuration(t *testing.T) {
+	testDKG(t, 20, 20, 2*time.Second)
+}
+
 func testDKG(t *testing.T, totalNodes int, goodNodes int, phaseDuration time.Duration) {
 	nodes := initNodes(t, totalNodes, phaseDuration)
 	gnodes := nodes[:goodNodes]

--- a/engine/consensus/dkg/dkg_message.go
+++ b/engine/consensus/dkg/dkg_message.go
@@ -1,0 +1,6 @@
+package dkg
+
+type DKGMessage struct {
+	Orig int
+	Data []byte
+}

--- a/engine/consensus/dkg/errors.go
+++ b/engine/consensus/dkg/errors.go
@@ -1,0 +1,27 @@
+package dkg
+
+import (
+	"errors"
+	"fmt"
+)
+
+type InvalidStateTransitionError struct {
+	From State
+	To   State
+}
+
+func NewInvalidStateTransitionError(from State, to State) InvalidStateTransitionError {
+	return InvalidStateTransitionError{
+		From: from,
+		To:   to,
+	}
+}
+
+func (e InvalidStateTransitionError) Error() string {
+	return fmt.Sprintf("Invalid DKG state transition from %s to %s", e.From, e.To)
+}
+
+func IsInvalidStateTransitionError(err error) bool {
+	var errInvalidStateTransition InvalidStateTransitionError
+	return errors.As(err, &errInvalidStateTransition)
+}

--- a/engine/consensus/dkg/state.go
+++ b/engine/consensus/dkg/state.go
@@ -1,0 +1,49 @@
+package dkg
+
+import (
+	"sync/atomic"
+)
+
+// State captures the state of a DKG engine
+type State uint32
+
+const (
+	Init State = iota
+	Phase0
+	Phase1
+	Phase2
+	Shutdown
+)
+
+// String returns the string representation of a State
+func (s State) String() string {
+	switch s {
+	case Phase0:
+		return "Phase0"
+	case Phase1:
+		return "Phase1"
+	case Phase2:
+		return "Phase2"
+	case Shutdown:
+		return "Shutdown"
+	default:
+		return "Unknown"
+	}
+}
+
+// Manager wraps a State with get and set methods
+type Manager struct {
+	state State
+}
+
+// GetState returns the current state.
+func (m *Manager) GetState() State {
+	stateAddr := (*uint32)(&m.state)
+	return State(atomic.LoadUint32(stateAddr))
+}
+
+// SetState sets the state.
+func (m *Manager) SetState(s State) {
+	stateAddr := (*uint32)(&m.state)
+	atomic.StoreUint32(stateAddr, uint32(s))
+}

--- a/engine/consensus/dkg/state.go
+++ b/engine/consensus/dkg/state.go
@@ -1,7 +1,7 @@
 package dkg
 
 import (
-	"sync/atomic"
+	"sync"
 )
 
 // State captures the state of a DKG engine
@@ -33,17 +33,20 @@ func (s State) String() string {
 
 // Manager wraps a State with get and set methods
 type Manager struct {
+	sync.Mutex
 	state State
 }
 
 // GetState returns the current state.
 func (m *Manager) GetState() State {
-	stateAddr := (*uint32)(&m.state)
-	return State(atomic.LoadUint32(stateAddr))
+	m.Lock()
+	defer m.Unlock()
+	return m.state
 }
 
 // SetState sets the state.
 func (m *Manager) SetState(s State) {
-	stateAddr := (*uint32)(&m.state)
-	atomic.StoreUint32(stateAddr, uint32(s))
+	m.Lock()
+	defer m.Unlock()
+	m.state = s
 }

--- a/engine/consensus/dkg/state.go
+++ b/engine/consensus/dkg/state.go
@@ -12,6 +12,7 @@ const (
 	Phase0
 	Phase1
 	Phase2
+	End
 	Shutdown
 )
 
@@ -24,6 +25,8 @@ func (s State) String() string {
 		return "Phase1"
 	case Phase2:
 		return "Phase2"
+	case End:
+		return "End"
 	case Shutdown:
 		return "Shutdown"
 	default:


### PR DESCRIPTION
Implement DKG controller to start the DKG protocol, listen for incoming messages in the background, and trigger transitions from one phase to another. 

Incoming DKG messages (private and public) are received through a go channel. The responsibility of populating the channel with valid messages is left to the consumer.

Transitions from one phase to another are triggered by function calls, and it is left to the consumer to implement a mechansism to decide when to transition. 