### PR TITLE
Add checks to chunkVerifier.verifyTransactions

### DIFF
--- a/engine/verification/utils/fixtures.go
+++ b/engine/verification/utils/fixtures.go
@@ -306,8 +306,7 @@ func executeCollection(
 			BlockID:         executableBlock.ID(),
 			// TODO: record gas used
 			TotalComputationUsed: 0,
-			// TODO: record number of txs
-			NumberOfTransactions: 0,
+			NumberOfTransactions: uint64(collection.Len()),
 		},
 		Index:    uint64(chunkIndex),
 		EndState: endStateCommitment,

--- a/model/chunks/chunkFaults.go
+++ b/model/chunks/chunkFaults.go
@@ -91,7 +91,7 @@ type CFInvalidVerifiableChunk struct {
 }
 
 func (cf CFInvalidVerifiableChunk) String() string {
-	return fmt.Sprint("invalid verifiable chunk due to ", cf.reason, cf.details.Error())
+	return fmt.Sprintf("invalid verifiable chunk due to %s: %s", cf.reason, cf.details.Error())
 }
 
 // ChunkIndex returns chunk index of the faulty chunk


### PR DESCRIPTION
This PR addresses issue [4219](https://github.com/dapperlabs/flow-go/issues/4219)

The logic for verifying faulty computations was already there. I just completed a few
of the TODOs that were in the verifyTransactions function:

* Check ChunkDataPack.ChunkID corresponds to the proper Chunk
* Check ChunkDataPack.CollectionID is consistant with the set
  of transactions
* Check that the number of transactions matches what is
  specified in the Chunk