### PR TITLE
increase collection size

### DIFF
--- a/module/builder/collection/config.go
+++ b/module/builder/collection/config.go
@@ -42,7 +42,7 @@ func DefaultConfig() Config {
 		ExpiryBuffer:            15,                              // 15 blocks for collections to be included
 		MaxPayerTransactionRate: 0,                               // no rate limiting
 		UnlimitedPayers:         make(map[flow.Address]struct{}), // no unlimited payers
-		MaxCollectionByteSize:   uint64(1000000),                 // ~1MB
+		MaxCollectionByteSize:   uint64(1750000),                 // ~1.75MB. This is slightly higher than the limit on single tx size, which is 1.5MB.
 		MaxCollectionTotalGas:   uint64(1000000),                 // 1M
 	}
 }


### PR DESCRIPTION
[We've increased the limit on transaction size](https://github.com/onflow/flow-go/commit/c88e4e950cc341536d88928c17c9009582a0912b#diff-0b6b63ad3693b4a15a89df18ea07d931dcef6ef167cd785ed6bf4dfb6dde87afR23), we also need to increase the size of the collection, otherwise, the tx would still be oversized to be included in a collection.

