### PR TITLE
adding a test to verify that nodes belonging to different sporks cann…

### DIFF
--- a/network/gossip/libp2p/sporking_test.go
+++ b/network/gossip/libp2p/sporking_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -120,8 +121,6 @@ func (h *SporkingTestSuite) TestOneToOneCrosstalkPrevention() {
 // TestOneToKCrosstalkPrevention tests that a node from the old chain cannot talk to a node in the new chain via PubSub
 // if the channel ID is updated while the network keys are kept the same.
 func (h *SporkingTestSuite) TestOneToKCrosstalkPrevention() {
-	// test channel
-	testChannelID := "test_channel"
 
 	// root id before spork
 	rootIDBeforeSpork := unittest.BlockFixture().ID().String()
@@ -142,7 +141,7 @@ func (h *SporkingTestSuite) TestOneToKCrosstalkPrevention() {
 	defer cancel()
 
 	// spork topic is derived by suffixing the channelID with the root block ID
-	topicBeforeSpork := testChannelID + "-" + rootIDBeforeSpork
+	topicBeforeSpork := engine.FullyQualifiedChannelName(engine.TestNetwork, rootIDBeforeSpork)
 
 	// both nodes are initially on the same spork and subscribed to the same topic
 	_, err = node1.Subscribe(ctx, topicBeforeSpork)
@@ -164,7 +163,7 @@ func (h *SporkingTestSuite) TestOneToKCrosstalkPrevention() {
 	rootIDAfterSpork := unittest.BlockFixture().ID().String()
 
 	// topic after the spork
-	topicAfterSpork := testChannelID + "-" + rootIDAfterSpork
+	topicAfterSpork := engine.FullyQualifiedChannelName(engine.TestNetwork, rootIDAfterSpork)
 
 	// mimic that node1 now is now part of the new spork while node2 remains on the old spork
 	// by unsubscribing node1 from 'topicBeforeSpork' and subscribing it to 'topicAfterSpork'

--- a/network/gossip/libp2p/sporking_test.go
+++ b/network/gossip/libp2p/sporking_test.go
@@ -152,7 +152,8 @@ func (h *SporkingTestSuite) TestOneToKCrosstalkPrevention() {
 	assert.NoError(h.T(), err)
 
 	// add node 2 as a peer of node 1
-	node1.AddPeer(ctx, addr2)
+	err = node1.AddPeer(ctx, addr2)
+	assert.NoError(h.T(), err)
 
 	// let the node form the mesh
 	time.Sleep(time.Second)

--- a/network/gossip/libp2p/sporking_test.go
+++ b/network/gossip/libp2p/sporking_test.go
@@ -137,7 +137,7 @@ func (h *SporkingTestSuite) TestOneToKCrosstalkPrevention() {
 	node2key, err := generateNetworkingKey("def")
 	assert.NoError(h.T(), err)
 	node2, addr2 := h.CreateNode("node1", node2key, "0.0.0.0", "0", rootIDBeforeSpork, nil, false)
-	defer h.StopNode(node1)
+	defer h.StopNode(node2)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
…ot talk to each other using 1-k messaging

This PR adds a test to verify that if there are two nodes belonging to different sporks, then they cannot communicate with each other using 1-k messaging. A similar test for 1-1 messaging already exists.