### PR TITLE
Fix `keygen` command default output file name

### DIFF
--- a/cmd/bootstrap/cmd/keygen.go
+++ b/cmd/bootstrap/cmd/keygen.go
@@ -55,7 +55,7 @@ func init() {
 
 	// required parameters
 	keygenCmd.Flags().
-		StringVar(&flagConfig, "config", "--node-config.json", "path to a JSON file containing multiple node configurations (Role, Address, Stake)")
+		StringVar(&flagConfig, "config", "node-config.json", "path to a JSON file containing multiple node configurations (Role, Address, Stake)")
 	_ = keygenCmd.MarkFlagRequired("config")
 
 }


### PR DESCRIPTION
PR fixes the default output file name of the `keygen` command