### PR TITLE
Check dir exists before checking files exists

### DIFF
--- a/cmd/bootstrap/cmd/util.go
+++ b/cmd/bootstrap/cmd/util.go
@@ -71,8 +71,17 @@ func pubKeyToString(key crypto.PublicKey) string {
 }
 
 func filesInDir(dir string) ([]string, error) {
+	exists, err := pathExists(dir)
+	if err != nil {
+		return nil, fmt.Errorf("could not check if dir exists: %w", err)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("dir %v does not exist", dir)
+	}
+
 	var files []string
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
 			files = append(files, path)
 		}


### PR DESCRIPTION
This PR fixes a bug in bootstrapping script when `--partner-dir` is specified with a folder that doesn't exists, it hits the following panic error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1092bff]
```