### PR TITLE
save node pub info when running keygen

### DIFF
--- a/cmd/bootstrap/cmd/keygen.go
+++ b/cmd/bootstrap/cmd/keygen.go
@@ -5,9 +5,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	model "github.com/onflow/flow-go/model/bootstrap"
+	"github.com/spf13/cobra"
 )
 
 // keygenCmd represents the key gen command
@@ -39,7 +38,7 @@ var keygenCmd = &cobra.Command{
 
 		// create keys
 		log.Info().Msg("generating internal private networking and staking keys")
-		nodes := genNetworkAndStakingKeys([]model.NodeInfo{})
+		nodes := genNetworkAndStakingKeys()
 		log.Info().Msg("")
 
 		// count roles
@@ -47,6 +46,9 @@ var keygenCmd = &cobra.Command{
 		for role, count := range roleCounts {
 			log.Info().Msg(fmt.Sprintf("created keys for %d %s nodes", count, role.String()))
 		}
+
+		log.Info().Msg("generating node public information")
+		genNodePubInfo(nodes)
 	},
 }
 
@@ -73,4 +75,12 @@ func isEmptyDir(path string) (bool, error) {
 		return true, nil
 	}
 	return false, err // Either not empty or error, suits both cases
+}
+
+func genNodePubInfo(nodes []model.NodeInfo) {
+	pubNodes := make([]model.NodeInfoPub, 0, len(nodes))
+	for _, node := range nodes {
+		pubNodes = append(pubNodes, node.Public())
+	}
+	writeJSON(model.PathInternalNodeInfosPub, pubNodes)
 }

--- a/cmd/bootstrap/cmd/keygen.go
+++ b/cmd/bootstrap/cmd/keygen.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"os"
 
-	model "github.com/onflow/flow-go/model/bootstrap"
 	"github.com/spf13/cobra"
+
+	model "github.com/onflow/flow-go/model/bootstrap"
 )
 
 // keygenCmd represents the key gen command

--- a/cmd/bootstrap/cmd/keys.go
+++ b/cmd/bootstrap/cmd/keys.go
@@ -9,7 +9,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func genNetworkAndStakingKeys(partnerNodes []model.NodeInfo) []model.NodeInfo {
+func genNetworkAndStakingKeys() []model.NodeInfo {
 
 	var nodeConfigs []model.NodeConfig
 	readJSON(flagConfig, &nodeConfigs)

--- a/model/bootstrap/filenames.go
+++ b/model/bootstrap/filenames.go
@@ -17,6 +17,7 @@ var (
 
 	// public genesis information
 	DirnamePublicBootstrap    = "public-root-information"
+	PathInternalNodeInfosPub  = filepath.Join(DirnamePublicBootstrap, "node-internal-infos.pub.json")
 	PathNodeInfosPub          = filepath.Join(DirnamePublicBootstrap, "node-infos.pub.json")
 	PathPartnerNodeInfoPrefix = filepath.Join(DirnamePublicBootstrap, "node-info.pub.")
 	PathNodeInfoPub           = filepath.Join(DirnamePublicBootstrap, "node-info.pub.%v.json") // %v will be replaced by NodeID


### PR DESCRIPTION
This UP updates the keygen command line to save the public info for the generated node infos.

The public info will be the input for the sporking script