### PR TITLE
Change the key encoding from base64 to hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ about it [here](https://github.com/onflow/flow).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 ## Table of Contents
 
 - [Getting started](#getting-started)
@@ -23,10 +24,10 @@ about it [here](https://github.com/onflow/flow).
 
 ## Getting started
 
-* To install all dependencies and tools, see the [project setup](#installation) guide
-* To dig into more documentation about Flow, see the [documentation](#documentation)
-* To learn how to contribute, see the [contributing guide](/CONTRIBUTING.md)
-* To see information on developing Flow, see the [development workflow](#development-workflow)
+- To install all dependencies and tools, see the [project setup](#installation) guide
+- To dig into more documentation about Flow, see the [documentation](#documentation)
+- To learn how to contribute, see the [contributing guide](/CONTRIBUTING.md)
+- To see information on developing Flow, see the [development workflow](#development-workflow)
 
 ## Documentation
 
@@ -38,18 +39,18 @@ to documentation for relevant components used by that work stream.
 
 The following table lists all work streams and links to their home directory and documentation:
 
-| Work Stream    | Home directory  |
-| -------------- | --------------- |
-| Access Node | [/cmd/access](/cmd/access) |
-| Collection Node | [/cmd/collection](/engine/collection) |
-| Consensus Node | [/cmd/consensus](/engine/consensus) |
-| Execution Node | [/engine/execution](/engine/execution) |
-| Verification Node | [/cmd/verification](/cmd/verification) |
-| HotStuff | [/consensus/hotstuff](/consensus/hotstuff) |
-| Storage | [/storage](/storage) |
-| Ledger | [/ledger](/ledger) |
-| Networking | [/network](/network/) |
-| Cryptography | [/crypto](/crypto) |
+| Work Stream       | Home directory                             |
+| ----------------- | ------------------------------------------ |
+| Access Node       | [/cmd/access](/cmd/access)                 |
+| Collection Node   | [/cmd/collection](/engine/collection)      |
+| Consensus Node    | [/cmd/consensus](/engine/consensus)        |
+| Execution Node    | [/engine/execution](/engine/execution)     |
+| Verification Node | [/cmd/verification](/cmd/verification)     |
+| HotStuff          | [/consensus/hotstuff](/consensus/hotstuff) |
+| Storage           | [/storage](/storage)                       |
+| Ledger            | [/ledger](/ledger)                         |
+| Networking        | [/network](/network/)                      |
+| Cryptography      | [/crypto](/crypto)                         |
 
 ## Installation
 
@@ -77,6 +78,7 @@ make install-tools
 At this point, you should be ready to build, test, and run Flow! 🎉
 
 Note: if there is error about "relic" or "crypto", trying force removing the relic build and reinstall the tools again:
+
 ```bash
 rm -rf crypto/relic
 make install-tools
@@ -106,11 +108,13 @@ make integration-test
 The recommended way to build and run Flow for local development is using Docker.
 
 Build a Docker image for all nodes:
+
 ```bash
 make docker-build-flow
 ```
 
 Build a Docker image for a particular node role (replace `$ROLE` with `collection`, `consensus`, etc.):
+
 ```bash
 make docker-build-$ROLE
 ```

--- a/model/encodable/keys.go
+++ b/model/encodable/keys.go
@@ -1,6 +1,7 @@
 package encodable
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,18 @@ import (
 
 	"github.com/onflow/flow-go/crypto"
 )
+
+func toHex(bs []byte) string {
+	return fmt.Sprintf("%x", bs)
+}
+
+func fromHex(b []byte) ([]byte, error) {
+	var x string
+	if err := json.Unmarshal(b, &x); err != nil {
+		return nil, err
+	}
+	return hex.DecodeString(x)
+}
 
 // NetworkPubKey wraps a public key and allows it to be JSON encoded and decoded. It is not defined in the
 // crypto package since the crypto package should not know about the different key types.
@@ -21,18 +34,19 @@ func (pub NetworkPubKey) MarshalJSON() ([]byte, error) {
 	if pub.PublicKey == nil {
 		return json.Marshal(nil)
 	}
-	return json.Marshal(pub.Encode())
+	return json.Marshal(toHex(pub.Encode()))
 }
 
 func (pub *NetworkPubKey) UnmarshalJSON(b []byte) error {
-	var bz []byte
-	if err := json.Unmarshal(b, &bz); err != nil {
+	bz, err := fromHex(b)
+	if err != nil {
 		return err
 	}
+
 	if len(bz) == 0 {
 		return nil
 	}
-	var err error
+
 	pub.PublicKey, err = crypto.DecodePublicKey(crypto.ECDSAP256, bz)
 	return err
 }
@@ -49,18 +63,18 @@ func (priv NetworkPrivKey) MarshalJSON() ([]byte, error) {
 	if priv.PrivateKey == nil {
 		return json.Marshal(nil)
 	}
-	return json.Marshal(priv.Encode())
+	return json.Marshal(toHex(priv.Encode()))
 }
 
 func (priv *NetworkPrivKey) UnmarshalJSON(b []byte) error {
-	var bz []byte
-	if err := json.Unmarshal(b, &bz); err != nil {
+	bz, err := fromHex(b)
+	if err != nil {
 		return err
 	}
+
 	if len(bz) == 0 {
 		return nil
 	}
-	var err error
 	priv.PrivateKey, err = crypto.DecodePrivateKey(crypto.ECDSAP256, bz)
 	return err
 }
@@ -75,18 +89,18 @@ func (pub StakingPubKey) MarshalJSON() ([]byte, error) {
 	if pub.PublicKey == nil {
 		return json.Marshal(nil)
 	}
-	return json.Marshal(pub.Encode())
+	return json.Marshal(toHex(pub.Encode()))
 }
 
 func (pub *StakingPubKey) UnmarshalJSON(b []byte) error {
-	var bz []byte
-	if err := json.Unmarshal(b, &bz); err != nil {
+	bz, err := fromHex(b)
+	if err != nil {
 		return err
 	}
+
 	if len(bz) == 0 {
 		return nil
 	}
-	var err error
 	pub.PublicKey, err = crypto.DecodePublicKey(crypto.BLSBLS12381, bz)
 	return err
 }
@@ -103,18 +117,18 @@ func (priv StakingPrivKey) MarshalJSON() ([]byte, error) {
 	if priv.PrivateKey == nil {
 		return json.Marshal(nil)
 	}
-	return json.Marshal(priv.Encode())
+	return json.Marshal(toHex(priv.Encode()))
 }
 
 func (priv *StakingPrivKey) UnmarshalJSON(b []byte) error {
-	var bz []byte
-	if err := json.Unmarshal(b, &bz); err != nil {
+	bz, err := fromHex(b)
+	if err != nil {
 		return err
 	}
+
 	if len(bz) == 0 {
 		return nil
 	}
-	var err error
 	priv.PrivateKey, err = crypto.DecodePrivateKey(crypto.BLSBLS12381, bz)
 	return err
 }
@@ -129,18 +143,18 @@ func (pub RandomBeaconPubKey) MarshalJSON() ([]byte, error) {
 	if pub.PublicKey == nil {
 		return json.Marshal(nil)
 	}
-	return json.Marshal(pub.Encode())
+	return json.Marshal(toHex(pub.Encode()))
 }
 
 func (pub *RandomBeaconPubKey) UnmarshalJSON(b []byte) error {
-	var bz []byte
-	if err := json.Unmarshal(b, &bz); err != nil {
+	bz, err := fromHex(b)
+	if err != nil {
 		return err
 	}
+
 	if len(bz) == 0 {
 		return nil
 	}
-	var err error
 	pub.PublicKey, err = crypto.DecodePublicKey(crypto.BLSBLS12381, bz)
 	return err
 }
@@ -149,15 +163,18 @@ func (pub RandomBeaconPubKey) MarshalMsgpack() ([]byte, error) {
 	if pub.PublicKey == nil {
 		return nil, fmt.Errorf("empty public key")
 	}
-	return msgpack.Marshal(pub.PublicKey.Encode())
+	return msgpack.Marshal(toHex(pub.PublicKey.Encode()))
 }
 
 func (pub *RandomBeaconPubKey) UnmarshalMsgpack(b []byte) error {
-	var bz []byte
-	if err := msgpack.Unmarshal(b, &bz); err != nil {
+	bz, err := fromHex(b)
+	if err != nil {
 		return err
 	}
-	var err error
+
+	if len(bz) == 0 {
+		return nil
+	}
 	pub.PublicKey, err = crypto.DecodePublicKey(crypto.BLSBLS12381, bz)
 	return err
 }
@@ -178,18 +195,18 @@ func (priv RandomBeaconPrivKey) MarshalJSON() ([]byte, error) {
 	if priv.PrivateKey == nil {
 		return json.Marshal(nil)
 	}
-	return json.Marshal(priv.Encode())
+	return json.Marshal(toHex(priv.Encode()))
 }
 
 func (priv *RandomBeaconPrivKey) UnmarshalJSON(b []byte) error {
-	var bz []byte
-	if err := json.Unmarshal(b, &bz); err != nil {
+	bz, err := fromHex(b)
+	if err != nil {
 		return err
 	}
+
 	if len(bz) == 0 {
 		return nil
 	}
-	var err error
 	priv.PrivateKey, err = crypto.DecodePrivateKey(crypto.BLSBLS12381, bz)
 	return err
 }

--- a/model/encodable/keys.go
+++ b/model/encodable/keys.go
@@ -16,9 +16,17 @@ func toHex(bs []byte) string {
 	return fmt.Sprintf("%x", bs)
 }
 
-func fromHex(b []byte) ([]byte, error) {
+func fromJSONHex(b []byte) ([]byte, error) {
 	var x string
 	if err := json.Unmarshal(b, &x); err != nil {
+		return nil, err
+	}
+	return hex.DecodeString(x)
+}
+
+func fromMsgPackHex(b []byte) ([]byte, error) {
+	var x string
+	if err := msgpack.Unmarshal(b, &x); err != nil {
 		return nil, err
 	}
 	return hex.DecodeString(x)
@@ -38,7 +46,7 @@ func (pub NetworkPubKey) MarshalJSON() ([]byte, error) {
 }
 
 func (pub *NetworkPubKey) UnmarshalJSON(b []byte) error {
-	bz, err := fromHex(b)
+	bz, err := fromJSONHex(b)
 	if err != nil {
 		return err
 	}
@@ -67,7 +75,7 @@ func (priv NetworkPrivKey) MarshalJSON() ([]byte, error) {
 }
 
 func (priv *NetworkPrivKey) UnmarshalJSON(b []byte) error {
-	bz, err := fromHex(b)
+	bz, err := fromJSONHex(b)
 	if err != nil {
 		return err
 	}
@@ -93,7 +101,7 @@ func (pub StakingPubKey) MarshalJSON() ([]byte, error) {
 }
 
 func (pub *StakingPubKey) UnmarshalJSON(b []byte) error {
-	bz, err := fromHex(b)
+	bz, err := fromJSONHex(b)
 	if err != nil {
 		return err
 	}
@@ -121,7 +129,7 @@ func (priv StakingPrivKey) MarshalJSON() ([]byte, error) {
 }
 
 func (priv *StakingPrivKey) UnmarshalJSON(b []byte) error {
-	bz, err := fromHex(b)
+	bz, err := fromJSONHex(b)
 	if err != nil {
 		return err
 	}
@@ -147,7 +155,7 @@ func (pub RandomBeaconPubKey) MarshalJSON() ([]byte, error) {
 }
 
 func (pub *RandomBeaconPubKey) UnmarshalJSON(b []byte) error {
-	bz, err := fromHex(b)
+	bz, err := fromJSONHex(b)
 	if err != nil {
 		return err
 	}
@@ -167,11 +175,7 @@ func (pub RandomBeaconPubKey) MarshalMsgpack() ([]byte, error) {
 }
 
 func (pub *RandomBeaconPubKey) UnmarshalMsgpack(b []byte) error {
-	var x string
-	if err := msgpack.Unmarshal(b, &x); err != nil {
-		return err
-	}
-	bz, err := hex.DecodeString(x)
+	bz, err := fromMsgPackHex(b)
 	if err != nil {
 		return err
 	}
@@ -200,7 +204,7 @@ func (priv RandomBeaconPrivKey) MarshalJSON() ([]byte, error) {
 }
 
 func (priv *RandomBeaconPrivKey) UnmarshalJSON(b []byte) error {
-	bz, err := fromHex(b)
+	bz, err := fromJSONHex(b)
 	if err != nil {
 		return err
 	}

--- a/model/encodable/keys.go
+++ b/model/encodable/keys.go
@@ -167,14 +167,15 @@ func (pub RandomBeaconPubKey) MarshalMsgpack() ([]byte, error) {
 }
 
 func (pub *RandomBeaconPubKey) UnmarshalMsgpack(b []byte) error {
-	bz, err := fromHex(b)
+	var x string
+	if err := msgpack.Unmarshal(b, &x); err != nil {
+		return err
+	}
+	bz, err := hex.DecodeString(x)
 	if err != nil {
 		return err
 	}
 
-	if len(bz) == 0 {
-		return nil
-	}
 	pub.PublicKey, err = crypto.DecodePublicKey(crypto.BLSBLS12381, bz)
 	return err
 }

--- a/model/encodable/keys_test.go
+++ b/model/encodable/keys_test.go
@@ -233,6 +233,23 @@ func TestEncodableRandomBeaconPrivKeyNil(t *testing.T) {
 	require.NoError(t, isHexString(enc))
 }
 
+func TestEncodableRandomBeaconPrivKeyMsgPack(t *testing.T) {
+	randbeac, err := crypto.GeneratePrivateKey(crypto.BLSBLS12381, generateRandomSeed(t))
+	require.NoError(t, err)
+	key := RandomBeaconPubKey{randbeac.PublicKey()}
+	oldPubKey := key.PublicKey
+
+	b, err := key.MarshalMsgpack()
+	require.NoError(t, err)
+
+	fmt.Printf("bytes: %d", len(b))
+
+	err = key.UnmarshalMsgpack(b)
+	require.NoError(t, err)
+
+	require.Equal(t, oldPubKey, key.PublicKey)
+}
+
 func generateRandomSeed(t *testing.T) []byte {
 	seed := make([]byte, 48)
 	n, err := rand.Read(seed)

--- a/model/encodable/keys_test.go
+++ b/model/encodable/keys_test.go
@@ -21,6 +21,10 @@ func isHexString(enc []byte) error {
 		return fmt.Errorf("invalid hex: %v", str)
 	}
 
+	if str == "null" {
+		return nil
+	}
+
 	// remove the "
 	str = str[1 : len(str)-1]
 	_, err := hex.DecodeString(str)
@@ -30,6 +34,7 @@ func isHexString(enc []byte) error {
 func TestIsHexString(t *testing.T) {
 	require.NoError(t, isHexString([]byte("abcd")))
 	require.NoError(t, isHexString([]byte("\"\"")))
+	require.NoError(t, isHexString([]byte("null")))
 	require.Error(t, isHexString([]byte("\"")))
 	require.Error(t, isHexString([]byte("QEVX=")))
 }
@@ -62,6 +67,8 @@ func TestEncodableNetworkPubKeyNil(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.Equal(t, key, dec)
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableNetworkPrivKey(t *testing.T) {
@@ -77,6 +84,8 @@ func TestEncodableNetworkPrivKey(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.True(t, key.Equals(dec.PrivateKey))
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableNetworkPrivKeyNil(t *testing.T) {
@@ -90,6 +99,8 @@ func TestEncodableNetworkPrivKeyNil(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.Equal(t, key, dec)
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableStakingPubKey(t *testing.T) {
@@ -105,6 +116,8 @@ func TestEncodableStakingPubKey(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.True(t, key.Equals(dec.PublicKey))
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableStakingPubKeyNil(t *testing.T) {
@@ -118,6 +131,8 @@ func TestEncodableStakingPubKeyNil(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.Equal(t, key, dec)
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableStakingPrivKey(t *testing.T) {
@@ -134,6 +149,8 @@ func TestEncodableStakingPrivKey(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, key.Equals(dec.PrivateKey), "encoded/decoded key equality check failed")
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableStakingPrivKeyNil(t *testing.T) {
@@ -147,6 +164,8 @@ func TestEncodableStakingPrivKeyNil(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.Equal(t, key, dec)
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableRandomBeaconPubKey(t *testing.T) {
@@ -162,6 +181,8 @@ func TestEncodableRandomBeaconPubKey(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.True(t, key.Equals(dec.PublicKey))
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableRandomBeaconPubKeyNil(t *testing.T) {
@@ -175,6 +196,8 @@ func TestEncodableRandomBeaconPubKeyNil(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.Equal(t, key, dec)
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableRandomBeaconPrivKey(t *testing.T) {
@@ -191,6 +214,8 @@ func TestEncodableRandomBeaconPrivKey(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, key.Equals(dec.PrivateKey), "encoded/decoded key equality check failed")
+
+	require.NoError(t, isHexString(enc))
 }
 
 func TestEncodableRandomBeaconPrivKeyNil(t *testing.T) {
@@ -204,6 +229,8 @@ func TestEncodableRandomBeaconPrivKeyNil(t *testing.T) {
 	err = json.Unmarshal(enc, &dec)
 	require.NoError(t, err)
 	require.Equal(t, key, dec)
+
+	require.NoError(t, isHexString(enc))
 }
 
 func generateRandomSeed(t *testing.T) []byte {


### PR DESCRIPTION
This PR changes the key encoding to be `hex` instead of the `base64`, which is the default for `[]byte`

## Why this matters?

Before this PR, the key generation will produce networking key and staking keys in base64 , for instance:
```
go run -tags relic ./cmd/bootstrap key --address "example.com:3569" --role "consensus" -o ./bootstrap/partner-node-infos
```
will produce :
Note the NetworkPubKey and StakingPubKey are both in `base64`
```
{
  "Role": "consensus",
  "Address": "example.com:3569",
  "NodeID": "f1c2f6590da364793f8515712855dae00b135d53de646a4f17f381b28a0cbd2b",
  "Stake": 0,
  "NetworkPubKey": "1b24gbD5zmVgj7r1texoptzoaMZSw1iixRZsvByShLIzyEzKvJP5seTr5U9xF4q7HLrNduc0QaVCqTYsZsSWmQ==",
  "StakingPubKey": "l6Xy4gEisi+kBSocoNdt1P1a+mdzLkOLPS6kXGYDFDFIw24bhBZYOIIz+tZ/QmBxByyByHS0ZurB3SjwOplBz7CVEtm5Fwx4Sk2l16s7izGSED7qzhNvScjVXTZX9Zxm"
}

```

After the change, it now produces:
Note both `NetworkPubKey` and `StakingPubKey` are in `hex` format
```
{
  "Role": "consensus",
  "Address": "example.com:3569",
  "NodeID": "0fac00c2ff673307f327a3516f2d41ebaf7ebda9fc7e4b85f20cd7ebdb9d9714",
  "Stake": 0,
  "NetworkPubKey": "aa795dd59ee9fe9f9cca92f162b99a568f08b2f6b63fe9c8f9b7b7e15a606b7c4d81ff698730c6292334816961fe8c4fccb3d8ffdff2fd5a8b50eb063f5d14d0",
  "StakingPubKey": "aa2e0da5a5a8501ae61e163ad51605b9227e14bf30db969d56b036a330b357ca66c2aabc6bac7b44ce6ab65331c6661409786a8a268ecddd1ee5fb247e46bd5e1c6b692208c6dca6a6a71f6f32bf45ff118a0032ee641f08384c01d6784a15af"
}
```


