### PR TITLE
Migrate deferred values of contract values

### DIFF
--- a/cmd/util/ledger/migrations/multiple_contract_migration.go
+++ b/cmd/util/ledger/migrations/multiple_contract_migration.go
@@ -158,8 +158,8 @@ func migrateDeferredValueOfContractValue(
 ) {
 	registerKeySuffix := registerID.Key[len(deferredValueOfContractValuePrefix):]
 
-	address := string(payloadKeyAddress(payload))
-	contractName, ok := mappings[address]
+	rawAddress := string(payloadKeyAddress(payload))
+	contractName, ok := mappings[rawAddress]
 	if !ok {
 		return nil, fmt.Errorf("missing contract name for address: %s", address)
 	}
@@ -175,6 +175,10 @@ func migrateDeferredValueOfContractValue(
 		Key: changeKey(payload.Key, newRegisterKey),
 		Value: payload.Value,
 	}
+
+	address := common.BytesToAddress(flow.BytesToAddress([]byte(rawAddress)).Bytes())
+
+	logKeyChange(address.Hex(), payload.Key, newPayload.Key)
 
 	return []ledger.Payload{newPayload}, nil
 }

--- a/cmd/util/ledger/migrations/multiple_contract_migration.go
+++ b/cmd/util/ledger/migrations/multiple_contract_migration.go
@@ -174,10 +174,9 @@ func migrateDeferredValueOfContractValue(
 	}, "")
 
 	newPayload := ledger.Payload{
-		Key: changeKey(payload.Key, newRegisterKey),
+		Key:   changeKey(payload.Key, newRegisterKey),
 		Value: payload.Value,
 	}
-
 
 	logKeyChange(address.Hex(), payload.Key, newPayload.Key)
 
@@ -230,7 +229,7 @@ func migrateContractValues(payloads []ledger.Payload) ([]ledger.Payload, map[str
 }
 
 type contractValueMapping struct {
-	address []byte
+	address      []byte
 	contractName string
 }
 

--- a/cmd/util/ledger/migrations/multiple_contract_migration.go
+++ b/cmd/util/ledger/migrations/multiple_contract_migration.go
@@ -159,6 +159,8 @@ func migrateDeferredValueOfContractValue(
 	registerKeySuffix := registerID.Key[len(deferredValueOfContractValuePrefix):]
 
 	rawAddress := string(payloadKeyAddress(payload))
+	address := common.BytesToAddress(flow.BytesToAddress([]byte(rawAddress)).Bytes())
+
 	contractName, ok := mappings[rawAddress]
 	if !ok {
 		return nil, fmt.Errorf("missing contract name for address: %s", address)
@@ -176,7 +178,6 @@ func migrateDeferredValueOfContractValue(
 		Value: payload.Value,
 	}
 
-	address := common.BytesToAddress(flow.BytesToAddress([]byte(rawAddress)).Bytes())
 
 	logKeyChange(address.Hex(), payload.Key, newPayload.Key)
 

--- a/cmd/util/ledger/migrations/multiple_contract_migration_test.go
+++ b/cmd/util/ledger/migrations/multiple_contract_migration_test.go
@@ -67,7 +67,7 @@ func TestMultipleContractMigration(t *testing.T) {
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 1)
-		require.Equal(t, migrated[0], payload)
+		require.Equal(t, payload, migrated[0])
 	})
 
 	t.Run("Non address registers are not migrated", func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestMultipleContractMigration(t *testing.T) {
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 1)
-		require.Equal(t, migrated[0], payload)
+		require.Equal(t, payload, migrated[0])
 	})
 
 	t.Run("Empty code registers are removed", func(t *testing.T) {
@@ -173,8 +173,8 @@ func TestMultipleContractMigration(t *testing.T) {
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 2)
-		require.Equal(t, string(migrated[0].Key.KeyParts[2].Value), "code.Test")
-		require.Equal(t, string(migrated[0].Value), contract)
+		require.Equal(t, "code.Test", string(migrated[0].Key.KeyParts[2].Value))
+		require.Equal(t, contract, string(migrated[0].Value))
 	})
 
 	// this case was not allowed before, so it shouldn't really happen
@@ -195,8 +195,8 @@ func TestMultipleContractMigration(t *testing.T) {
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 2)
-		require.Equal(t, string(migrated[0].Key.KeyParts[2].Value), "code.Test")
-		require.Equal(t, string(migrated[0].Value), contract)
+		require.Equal(t, "code.Test", string(migrated[0].Key.KeyParts[2].Value))
+		require.Equal(t, contract, string(migrated[0].Value))
 	})
 
 	// this case was not allowed before, so it shouldn't really happen
@@ -290,10 +290,10 @@ func TestMultipleContractMigration(t *testing.T) {
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 3)
-		require.Equal(t, string(migrated[0].Key.KeyParts[2].Value), "code.ITest")
-		require.Equal(t, string(migrated[0].Value), expectedInterfaceCode)
-		require.Equal(t, string(migrated[1].Key.KeyParts[2].Value), "code.Test")
-		require.Equal(t, string(migrated[1].Value), expectedContractCode)
+		require.Equal(t, "code.ITest", string(migrated[0].Key.KeyParts[2].Value))
+		require.Equal(t, expectedInterfaceCode, string(migrated[0].Value))
+		require.Equal(t, "code.Test", string(migrated[1].Key.KeyParts[2].Value))
+		require.Equal(t, expectedContractCode, string(migrated[1].Value))
 	})
 	t.Run("If code has two declarations, correctly split them (ugly formatting)", func(t *testing.T) {
 		address := flow.HexToAddress("01")
@@ -331,10 +331,12 @@ func TestMultipleContractMigration(t *testing.T) {
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 3)
-		require.Equal(t, string(migrated[0].Key.KeyParts[2].Value), "code.ITest")
-		require.Equal(t, string(migrated[0].Value), expectedInterfaceCode)
-		require.Equal(t, string(migrated[1].Key.KeyParts[2].Value), "code.Test")
-		require.Equal(t, string(migrated[1].Value), expectedContractCode)
+
+		require.Equal(t, "code.ITest", string(migrated[0].Key.KeyParts[2].Value))
+		require.Equal(t, expectedInterfaceCode, string(migrated[0].Value))
+
+		require.Equal(t, "code.Test", string(migrated[1].Key.KeyParts[2].Value))
+		require.Equal(t, expectedContractCode, string(migrated[1].Value))
 	})
 
 	t.Run("If code has two declarations, correctly split them (interface last)", func(t *testing.T) {
@@ -385,10 +387,11 @@ func TestMultipleContractMigration(t *testing.T) {
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 3)
-		require.Equal(t, string(migrated[0].Key.KeyParts[2].Value), "code.ITest")
-		require.Equal(t, string(migrated[0].Value), expectedInterfaceCode)
-		require.Equal(t, string(migrated[1].Key.KeyParts[2].Value), "code.Test")
-		require.Equal(t, string(migrated[1].Value), expectedContractCode)
+		require.Equal(t, "code.ITest", string(migrated[0].Key.KeyParts[2].Value))
+		require.Equal(t, expectedInterfaceCode, string(migrated[0].Value))
+
+		require.Equal(t, "code.Test", string(migrated[1].Key.KeyParts[2].Value))
+		require.Equal(t, expectedContractCode, string(migrated[1].Value))
 	})
 
 	t.Run("If code has two declarations, correctly split them (imports)", func(t *testing.T) {
@@ -461,10 +464,12 @@ import ITest from %s
 		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
 		require.NoError(t, err)
 		require.Len(t, migrated, 3)
-		require.Equal(t, string(migrated[1].Key.KeyParts[2].Value), "code.Test")
-		require.Equal(t, string(migrated[1].Value), expectedContractCode)
-		require.Equal(t, string(migrated[0].Key.KeyParts[2].Value), "code.ITest")
-		require.Equal(t, string(migrated[0].Value), expectedInterfaceCode)
+
+		require.Equal(t, "code.Test", string(migrated[1].Key.KeyParts[2].Value))
+		require.Equal(t, expectedContractCode, string(migrated[1].Value))
+
+		require.Equal(t, "code.ITest", string(migrated[0].Key.KeyParts[2].Value))
+		require.Equal(t, expectedInterfaceCode, string(migrated[0].Value))
 	})
 
 	t.Run("If code has two declarations of the same type return error", func(t *testing.T) {
@@ -550,15 +555,14 @@ import ITest from %s
 
 	t.Run("contract object", func(t *testing.T) {
 
-		key := ledger.Key{
-			KeyParts: []ledger.KeyPart{
-				ledger.NewKeyPart(state.KeyPartOwner, flow.HexToAddress("01").Bytes()),
-				ledger.NewKeyPart(state.KeyPartController, []byte("")),
-				ledger.NewKeyPart(state.KeyPartKey, []byte("contract")),
+		payload1 := ledger.Payload{
+			Key: ledger.Key{
+				KeyParts: []ledger.KeyPart{
+					ledger.NewKeyPart(state.KeyPartOwner, flow.HexToAddress("01").Bytes()),
+					ledger.NewKeyPart(state.KeyPartController, []byte("")),
+					ledger.NewKeyPart(state.KeyPartKey, []byte("contract")),
+				},
 			},
-		}
-		payload := ledger.Payload{
-			Key:   key,
 			Value: []byte{
 				// tag
 				0xd8, 0x84,
@@ -575,11 +579,51 @@ import ITest from %s
 				// key 1
 				0x1,
 				// UTF-8 string, length 18
-				0x72,
-				// A.0x1.SimpleStruct
+				0x67,
+				// A.0x1.C
 				0x41,
 				0x2E, 0x30, 0x78, 0x31,
-				0x2E, 0x53, 0x69, 0x6d, 0x70, 0x6c, 0x65, 0x53, 0x74, 0x72, 0x75, 0x63, 0x74,
+				0x2E, 0x43,
+				// key 2
+				0x2,
+				// positive integer 1
+				0x3,
+				// key 3
+				0x3,
+				// map, 0 pairs of items follow
+				0xa0,
+			},
+		}
+
+		payload2 := ledger.Payload{
+			Key: ledger.Key{
+				KeyParts: []ledger.KeyPart{
+					ledger.NewKeyPart(state.KeyPartOwner, flow.HexToAddress("01").Bytes()),
+					ledger.NewKeyPart(state.KeyPartController, []byte("")),
+					ledger.NewKeyPart(state.KeyPartKey, []byte("contract\x1Fnodes\x1Fv\x1F1")),
+				},
+			},
+			Value: []byte{
+				// tag
+				0xd8, 0x84,
+				// map, 4 pairs of items follow
+				0xa4,
+				// key 0
+				0x0,
+				// tag
+				0xd8, 0xC0,
+				// byte sequence, length 1
+				0x41,
+				// positive integer 1
+				0x1,
+				// key 1
+				0x1,
+				// UTF-8 string, length 18
+				0x67,
+				// A.0x1.S
+				0x41,
+				0x2E, 0x30, 0x78, 0x31,
+				0x2E, 0x53,
 				// key 2
 				0x2,
 				// positive integer 1
@@ -591,11 +635,19 @@ import ITest from %s
 			},
 		}
 
-		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{payload})
+		migrated, err := migrations.MultipleContractMigration([]ledger.Payload{
+			payload1,
+			payload2,
+		})
 		require.NoError(t, err)
-		require.Len(t, migrated, 1)
-		require.Equal(t, string(migrated[0].Key.KeyParts[2].Value), "contract\x1fSimpleStruct")
-		require.Equal(t, migrated[0].Value, payload.Value)
-	})
+		require.Len(t, migrated, 2)
 
+		migrated1 := migrated[0]
+		require.Equal(t, "contract\x1fC", string(migrated1.Key.KeyParts[2].Value))
+		require.Equal(t, payload1.Value, migrated1.Value)
+
+		migrated2 := migrated[1]
+		require.Equal(t, "contract\x1fC\x1Fnodes\x1Fv\x1F1", string(migrated2.Key.KeyParts[2].Value))
+		require.Equal(t, payload2.Value, migrated2.Value)
+	})
 }


### PR DESCRIPTION
Cadence optimizes dictionaries where the value type is a resource: In this case, the values are not stored in the dictionary value, but in separate registers.

As the state migration for multiple contracts per account migrates contract values, we also must migrate potentially deferred registers of the contract value. 