### PR TITLE
Add locks around aggregatedSignatures in IncorporatedResult

### DIFF
--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -1,6 +1,10 @@
 package flow
 
-import "github.com/onflow/flow-go/crypto"
+import (
+	"sync"
+
+	"github.com/onflow/flow-go/crypto"
+)
 
 // IncorporatedResult is a wrapper around an ExecutionResult which contains the
 // ID of the first block on its fork in which it was incorporated.
@@ -15,13 +19,14 @@ type IncorporatedResult struct {
 	// incorporated in the payload of IncorporatedBlockID.
 	Result *ExecutionResult
 
-	// aggregatedSignature is a placeholder for attestation signatures collected
-	// for each chunk. It gets populated by the consensus matching engine when
-	// approvals are matched to execution results.
+	// aggregatedSignatures is a placeholder for attestation signatures
+	// collected for each chunk. It gets populated by the consensus matching
+	// engine when approvals are matched to execution results.
 	// This field is not exported (name doesn't start with a capital letter), so
 	// it is not used in calculating the ID and Checksum of the Incorporated
 	// Result (RLP encoding ignores private fields).
-	aggregatedSignatures map[uint64]*AggregatedSignature
+	aggregatedSignatures     map[uint64]*AggregatedSignature
+	aggregatedSignaturesLock sync.Mutex
 }
 
 func NewIncorporatedResult(incorporatedBlockID Identifier, result *ExecutionResult) *IncorporatedResult {
@@ -46,6 +51,9 @@ func (ir *IncorporatedResult) Checksum() Identifier {
 
 // GetSignature returns a signature by chunk index and signer ID.
 func (ir *IncorporatedResult) GetSignature(chunkIndex uint64, signerID Identifier) (*crypto.Signature, bool) {
+	ir.aggregatedSignaturesLock.Lock()
+	defer ir.aggregatedSignaturesLock.Unlock()
+
 	as, ok := ir.aggregatedSignatures[chunkIndex]
 	if !ok {
 		return nil, false
@@ -55,6 +63,9 @@ func (ir *IncorporatedResult) GetSignature(chunkIndex uint64, signerID Identifie
 
 // AddSignature adds a signature to the collection of AggregatedSignatures
 func (ir *IncorporatedResult) AddSignature(chunkIndex uint64, signerID Identifier, signature crypto.Signature) {
+	ir.aggregatedSignaturesLock.Lock()
+	defer ir.aggregatedSignaturesLock.Unlock()
+
 	as, ok := ir.aggregatedSignatures[chunkIndex]
 	if !ok {
 		as = &AggregatedSignature{}
@@ -68,6 +79,9 @@ func (ir *IncorporatedResult) AddSignature(chunkIndex uint64, signerID Identifie
 // GetAggregatedSignatures returns all the aggregated signatures orderd by chunk
 // index
 func (ir *IncorporatedResult) GetAggregatedSignatures() []AggregatedSignature {
+	ir.aggregatedSignaturesLock.Lock()
+	defer ir.aggregatedSignaturesLock.Unlock()
+
 	result := make([]AggregatedSignature, 0, len(ir.Result.Chunks))
 
 	for _, chunk := range ir.Result.Chunks {


### PR DESCRIPTION
This PR addresses issue [#5067](https://github.com/dapperlabs/flow-go/issues/5067)