### PR TITLE
Remove old epochs leader selection from memory

### DIFF
--- a/consensus/hotstuff/committees/consensus_committee.go
+++ b/consensus/hotstuff/committees/consensus_committee.go
@@ -169,6 +169,7 @@ func (c *Consensus) precomputedLeaderForView(view uint64) (flow.Identifier, erro
 
 		return leaderID, nil
 	}
+
 	return flow.ZeroID, errSelectionNotComputed
 }
 

--- a/consensus/hotstuff/committees/consensus_committee_test.go
+++ b/consensus/hotstuff/committees/consensus_committee_test.go
@@ -165,7 +165,7 @@ func TestRemoveOldEpochs(t *testing.T) {
 				assert.Equal(t, 3, len(committee.leaders))
 			}
 
-			// check we have the right epochs stored
+			// check we have the correct epochs stored
 			for i := uint64(0); i < 3; i++ {
 				counter := currentEpochCounter - i
 				if counter < firstEpochCounter {

--- a/consensus/hotstuff/committees/leader/leader_selection.go
+++ b/consensus/hotstuff/committees/leader/leader_selection.go
@@ -48,7 +48,7 @@ func (l LeaderSelection) FirstView() uint64 {
 }
 
 func (l LeaderSelection) FinalView() uint64 {
-	return l.firstView + uint64(len(l.leaderIndexes))
+	return l.firstView + uint64(len(l.leaderIndexes)) - 1
 }
 
 // LeaderForView returns the node ID of the leader for a given view.

--- a/consensus/hotstuff/committees/leader/leader_selection.go
+++ b/consensus/hotstuff/committees/leader/leader_selection.go
@@ -89,6 +89,11 @@ func (l LeaderSelection) newInvalidViewError(view uint64) InvalidViewError {
 // identities - the identities that contain the stake info, which is used as weight for the chance of
 // 							the identity to be selected as leader.
 func ComputeLeaderSelectionFromSeed(firstView uint64, seed []byte, count int, identities flow.IdentityList) (*LeaderSelection, error) {
+
+	if count < 1 {
+		return nil, fmt.Errorf("number of views must be positive (got %d)", count)
+	}
+
 	weights := make([]uint64, 0, len(identities))
 	for _, id := range identities {
 		weights = append(weights, id.Stake)

--- a/consensus/hotstuff/committees/leader/leader_selection_test.go
+++ b/consensus/hotstuff/committees/leader/leader_selection_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/crypto/random"
@@ -94,6 +95,25 @@ func TestDeterministic(t *testing.T) {
 
 		require.Equal(t, l1, l2)
 	}
+}
+
+func TestInputValidation(t *testing.T) {
+
+	// should return an error if we request to compute leader selection for <1 views
+	t.Run("epoch containing no views", func(t *testing.T) {
+		count := 0
+		_, err := ComputeLeaderSelectionFromSeed(0, someSeed, count, unittest.IdentityListFixture(4))
+		assert.Error(t, err)
+		count = -1
+		_, err = ComputeLeaderSelectionFromSeed(0, someSeed, count, unittest.IdentityListFixture(4))
+		assert.Error(t, err)
+	})
+
+	t.Run("epoch without participants", func(t *testing.T) {
+		identities := unittest.IdentityListFixture(0)
+		_, err := ComputeLeaderSelectionFromSeed(0, someSeed, 100, identities)
+		assert.Error(t, err)
+	})
 }
 
 func TestDifferentSeedWillProduceDifferentSelection(t *testing.T) {

--- a/consensus/hotstuff/committees/leader/leader_selection_test.go
+++ b/consensus/hotstuff/committees/leader/leader_selection_test.go
@@ -142,14 +142,22 @@ func TestViewOutOfRange(t *testing.T) {
 
 	// views before first view should return error
 	t.Run("before first view", func(t *testing.T) {
-		before := rand.Uint64() % firstView
+		before := firstView - 1 // 1 before first view
+		_, err = leaders.LeaderForView(before)
+		assert.Error(t, err)
+
+		before = rand.Uint64() % firstView // random view before first view
 		_, err = leaders.LeaderForView(before)
 		assert.Error(t, err)
 	})
 
 	// views after final view should return error
 	t.Run("after final view", func(t *testing.T) {
-		after := finalView + uint64(rand.Uint32()) + 1
+		after := finalView + 1 // 1 after final view
+		_, err = leaders.LeaderForView(after)
+		assert.Error(t, err)
+
+		after = finalView + uint64(rand.Uint32()) + 1 // random view after final view
 		_, err = leaders.LeaderForView(after)
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
This PR addresses a TODO from https://github.com/onflow/flow-go/pull/157 to remove old epochs such that we only ever store at most 2 epochs worth of leader selection.