### PR TITLE
Re-order mocking of subgraph fixtures in matching engine

### DIFF
--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -1055,14 +1055,15 @@ func (ms *MatchingSuite) validSubgraphFixture() subgraphFixture {
 
 // addSubgraphFixtureToMempools adds add entities in subgraph to mempools and persistent storage mocks
 func (ms *MatchingSuite) addSubgraphFixtureToMempools(subgraph subgraphFixture) {
-	ms.blocks[subgraph.ParentBlock.ID()] = subgraph.ParentBlock
-	ms.blocks[subgraph.Block.ID()] = subgraph.Block
-	ms.persistedResults[subgraph.PreviousResult.ID()] = subgraph.PreviousResult
-	ms.persistedResults[subgraph.Result.ID()] = subgraph.Result
-	ms.pendingResults[subgraph.IncorporatedResult.ID()] = subgraph.IncorporatedResult
 
 	ms.assigner.On("Assign", subgraph.IncorporatedResult.Result, subgraph.IncorporatedResult.IncorporatedBlockID).Return(subgraph.Assignment, nil).Maybe()
 	for index := uint64(0); index < uint64(len(subgraph.IncorporatedResult.Result.Chunks)); index++ {
 		ms.approvalsPL.On("ByChunk", subgraph.IncorporatedResult.Result.ID(), index).Return(subgraph.Approvals[index]).Maybe()
 	}
+
+	ms.blocks[subgraph.ParentBlock.ID()] = subgraph.ParentBlock
+	ms.blocks[subgraph.Block.ID()] = subgraph.Block
+	ms.persistedResults[subgraph.PreviousResult.ID()] = subgraph.PreviousResult
+	ms.persistedResults[subgraph.Result.ID()] = subgraph.Result
+	ms.pendingResults[subgraph.IncorporatedResult.ID()] = subgraph.IncorporatedResult
 }


### PR DESCRIPTION
Mocks out the Assigner before adding results to the mempool mock to guarantee the Assigner mock is ready before it is called by the engine.

I believe there was a race condition here where the engine could call `sealableResults` after the result was added to the mempool but before the `Assigner` was mocked out, causing https://github.com/dapperlabs/flow-go/issues/5107. 

Like @arrivets I haven't been able to reproduce this issue locally (only on CI), so have not confirmed this fix.