### PR TITLE
V0.12 Patch increase gas limit for service account txs

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -100,7 +100,7 @@ func main() {
 				"maximum number of transactions in proposed collections")
 			flags.Uint64Var(&maxCollectionByteSize, "builder-max-collection-byte-size", 1000000,
 				"maximum byte size of the proposed collection")
-			flags.Uint64Var(&maxCollectionTotalGas, "builder-max-collection-total-gas", 1000000,
+			flags.Uint64Var(&maxCollectionTotalGas, "builder-max-collection-total-gas", 10000000,
 				"maximum total amount of maxgas of transactions in proposed collections")
 			flags.DurationVar(&hotstuffTimeout, "hotstuff-timeout", 60*time.Second,
 				"the initial timeout for the hotstuff pacemaker")

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -136,6 +136,7 @@ func (suite *Suite) TestInvalidTransaction() {
 
 	suite.Run("gas limit exceeds the maximum allowed", func() {
 		tx := unittest.TransactionBodyFixture()
+		tx.Payer = unittest.RandomAddressFixture()
 		tx.GasLimit = flow.DefaultMaxGasLimit + 1
 
 		err := suite.engine.ProcessLocal(&tx)

--- a/module/builder/collection/config.go
+++ b/module/builder/collection/config.go
@@ -43,7 +43,7 @@ func DefaultConfig() Config {
 		MaxPayerTransactionRate: 0,                               // no rate limiting
 		UnlimitedPayers:         make(map[flow.Address]struct{}), // no unlimited payers
 		MaxCollectionByteSize:   uint64(1750000),                 // ~1.75MB. This is slightly higher than the limit on single tx size, which is 1.5MB
-		MaxCollectionTotalGas:   uint64(1000000),                 // 1M
+		MaxCollectionTotalGas:   uint64(10000000),                // 10M
 	}
 }
 


### PR DESCRIPTION
This PR 
  - allows any limit for transactions with service account as payer 
  - increase the collection total gas limit to 10M from 1M