### PR TITLE
Change default registry in testnet container.go

### DIFF
--- a/integration/testnet/container.go
+++ b/integration/testnet/container.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	defaultRegistry = "gcr.io/dl-flow"
+	defaultRegistry = "gcr.io/flow-container-registry"
 
 	checkContainerTimeout = time.Second * 10
 	checkContainerPeriod  = time.Millisecond * 50


### PR DESCRIPTION
This PR addresses a bug with the integration tests, whereby they were using the wrong docker images: https://github.com/dapperlabs/flow-go/issues/5117