### PR TITLE
Add flag to disable script executions on EN

### DIFF
--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -76,6 +76,7 @@ func main() {
 		syncThreshold         int
 		extensiveLog          bool
 		scriptsEnabled        bool
+		queriesEnabled        bool
 	)
 
 	cmd.FlowNode(flow.RoleExecution.String()).
@@ -94,7 +95,8 @@ func main() {
 			flags.BoolVar(&syncFast, "sync-fast", false, "fast sync allows execution node to skip fetching collection during state syncing, and rely on state syncing to catch up")
 			flags.IntVar(&syncThreshold, "sync-threshold", 100, "the maximum number of sealed and unexecuted blocks before triggering state syncing")
 			flags.BoolVar(&extensiveLog, "extensive-logging", false, "extensive logging logs tx contents and block headers")
-			flags.BoolVar(&scriptsEnabled, "scripts-enabled", true, "whether to enable script executions")
+			flags.BoolVar(&scriptsEnabled, "scripts-enabled", true, "whether to enable script executions and account queries")
+			flags.BoolVar(&queriesEnabled, "queries-enabled", true, "whether to enable event and transaction queries")
 		}).
 		Module("computation manager", func(node *cmd.FlowNodeBuilder) error {
 			rt := runtime.NewInterpreterRuntime()
@@ -377,6 +379,7 @@ func main() {
 				txResults,
 				node.RootChainID,
 				scriptsEnabled,
+				queriesEnabled,
 			)
 			return rpcEng, nil
 		}).Run()

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -75,6 +75,7 @@ func main() {
 		syncFast              bool
 		syncThreshold         int
 		extensiveLog          bool
+		scriptsEnabled        bool
 	)
 
 	cmd.FlowNode(flow.RoleExecution.String()).
@@ -93,6 +94,7 @@ func main() {
 			flags.BoolVar(&syncFast, "sync-fast", false, "fast sync allows execution node to skip fetching collection during state syncing, and rely on state syncing to catch up")
 			flags.IntVar(&syncThreshold, "sync-threshold", 100, "the maximum number of sealed and unexecuted blocks before triggering state syncing")
 			flags.BoolVar(&extensiveLog, "extensive-logging", false, "extensive logging logs tx contents and block headers")
+			flags.BoolVar(&scriptsEnabled, "scripts-enabled", true, "whether to enable script executions")
 		}).
 		Module("computation manager", func(node *cmd.FlowNodeBuilder) error {
 			rt := runtime.NewInterpreterRuntime()
@@ -365,7 +367,16 @@ func main() {
 			return syncEngine, nil
 		}).
 		Component("grpc server", func(node *cmd.FlowNodeBuilder) (module.ReadyDoneAware, error) {
-			rpcEng := rpc.New(node.Logger, rpcConf, ingestionEng, node.Storage.Blocks, events, results, txResults, node.RootChainID)
+			rpcEng := rpc.New(
+				node.Logger,
+				rpcConf,
+				ingestionEng,
+				node.Storage.Blocks,
+				events,
+				results,
+				txResults,
+				node.RootChainID,
+			)
 			return rpcEng, nil
 		}).Run()
 }

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -376,6 +376,7 @@ func main() {
 				results,
 				txResults,
 				node.RootChainID,
+				scriptsEnabled,
 			)
 			return rpcEng, nil
 		}).Run()

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -46,6 +46,7 @@ func New(
 	txResults storage.TransactionResults,
 	chainID flow.ChainID,
 	scriptsEnabled bool,
+	queriesEnabled bool,
 ) *Engine {
 	log = log.With().Str("engine", "rpc").Logger()
 
@@ -64,6 +65,7 @@ func New(
 			exeResults:         exeResults,
 			transactionResults: txResults,
 			scriptsEnabled:     scriptsEnabled,
+			queriesEnabled:     queriesEnabled,
 		},
 		server: grpc.NewServer(
 			grpc.MaxRecvMsgSize(config.MaxMsgSize),
@@ -118,6 +120,7 @@ type handler struct {
 	exeResults         storage.ExecutionResults
 	transactionResults storage.TransactionResults
 	scriptsEnabled     bool
+	queriesEnabled     bool
 }
 
 var _ execution.ExecutionAPIServer = &handler{}
@@ -157,6 +160,10 @@ func (h *handler) GetEventsForBlockIDs(
 	_ context.Context,
 	req *execution.GetEventsForBlockIDsRequest,
 ) (*execution.GetEventsForBlockIDsResponse, error) {
+
+	if !h.queriesEnabled {
+		return nil, status.Error(codes.Unimplemented, "event queries are disabled")
+	}
 
 	// validate request
 	blockIDs := req.GetBlockIds()
@@ -205,6 +212,10 @@ func (h *handler) GetTransactionResult(
 	_ context.Context,
 	req *execution.GetTransactionResultRequest,
 ) (*execution.GetTransactionResultResponse, error) {
+
+	if !h.queriesEnabled {
+		return nil, status.Error(codes.Unimplemented, "transaction result queries are disabled")
+	}
 
 	reqBlockID := req.GetBlockId()
 	blockID, err := convert.BlockID(reqBlockID)


### PR DESCRIPTION
This PR adds a `scripts-enabled` flag to the execution node that can be toggled to disabled calls to the `ExecuteScriptAtBlockID` and `GetAccountAtBlockID` RPC methods.