### PR TITLE
Additional tests for phase 2

### DIFF
--- a/integration/testnet/container.go
+++ b/integration/testnet/container.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	defaultRegistry = "gcr.io/dl-flow"
+	defaultRegistry = "gcr.io/flow-container-registry"
 
 	checkContainerTimeout = time.Second * 10
 	checkContainerPeriod  = time.Millisecond * 50

--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -40,7 +40,7 @@ func NewIncorporatedResult(incorporatedBlockID Identifier, result *ExecutionResu
 // ID implements flow.Entity.ID for IncorporatedResult to make it capable of
 // being stored directly in mempools and storage.
 func (ir *IncorporatedResult) ID() Identifier {
-	return MakeID(ir)
+	return MakeID([2]Identifier{ir.IncorporatedBlockID, ir.Result.ID()})
 }
 
 // CheckSum implements flow.Entity.CheckSum for IncorporatedResult to make it

--- a/model/flow/incorporated_result_test.go
+++ b/model/flow/incorporated_result_test.go
@@ -37,7 +37,7 @@ func TestIncorporatedResultID(t *testing.T) {
 
 // Test that the same result incorporated (from a different receipt) in the
 // same block produces the same IncorporatedResult (with same ID).
-func TestIDCollusion(t *testing.T) {
+func TestIDCollision(t *testing.T) {
 	incorporatedBlockID := unittest.IdentifierFixture()
 	executionResult := unittest.ExecutionResultFixture()
 

--- a/model/flow/incorporated_result_test.go
+++ b/model/flow/incorporated_result_test.go
@@ -41,11 +41,18 @@ func TestIDCollision(t *testing.T) {
 	incorporatedBlockID := unittest.IdentifierFixture()
 	executionResult := unittest.ExecutionResultFixture()
 
-	ir1 := flow.NewIncorporatedResult(incorporatedBlockID, executionResult)
-	ir2 := flow.NewIncorporatedResult(incorporatedBlockID, executionResult)
+	// Note:
+	//  * Only the ExecutionResultBody is fully independent of the executor.
+	//  * The (full) ExecutionResult contains the additional field ExecutionResult.Signatures,
+	//    which holds the signature of the EN computing the result
+	ir := flow.NewIncorporatedResult(incorporatedBlockID, executionResult)
+	id1 := ir.ID()
 
-	id1 := ir1.ID()
-	id2 := ir2.ID()
+	// make alternative signature
+	altSig := unittest.SignaturesFixture(1)
+	assert.NotEqual(t, ir.Result.Signatures, altSig) // check that new signature is in fact different (not that they are both empty, or constant dummy values)
+	ir.Result.Signatures = altSig
+	id2 := ir.ID()
 
 	assert.Equal(t, id1, id2)
 }

--- a/model/flow/incorporated_result_test.go
+++ b/model/flow/incorporated_result_test.go
@@ -34,3 +34,18 @@ func TestIncorporatedResultID(t *testing.T) {
 	assert.Equal(t, id1, id2)
 	assert.Equal(t, cs1, cs2)
 }
+
+// Test that the same result incorporated (from a different receipt) in the
+// same block produces the same IncorporatedResult (with same ID).
+func TestIDCollusion(t *testing.T) {
+	incorporatedBlockID := unittest.IdentifierFixture()
+	executionResult := unittest.ExecutionResultFixture()
+
+	ir1 := flow.NewIncorporatedResult(incorporatedBlockID, executionResult)
+	ir2 := flow.NewIncorporatedResult(incorporatedBlockID, executionResult)
+
+	id1 := ir1.ID()
+	id2 := ir2.ID()
+
+	assert.Equal(t, id1, id2)
+}

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -5,7 +5,6 @@ package consensus
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/mempool"
-	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
@@ -94,24 +92,8 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	b.tracer.StartSpan(parentID, trace.CONBuildOn)
 	defer b.tracer.FinishSpan(parentID, trace.CONBuildOn)
 
-	b.tracer.StartSpan(parentID, trace.CONBuildOnSetup)
-	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnSetup)
-
-	var finalized uint64
-	err := b.db.View(operation.RetrieveFinalizedHeight(&finalized))
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve finalized height: %w", err)
-	}
-	var finalID flow.Identifier
-	err = b.db.View(operation.LookupBlockHeight(finalized, &finalID))
-	if err != nil {
-		return nil, fmt.Errorf("could not lookup finalized block: %w", err)
-	}
-
-	b.tracer.FinishSpan(parentID, trace.CONBuildOnSetup)
-
 	// get the collection guarantees to insert in the payload
-	insertableGuarantees, err := b.getInsertableGuarantees(parentID, finalID, finalized)
+	insertableGuarantees, err := b.getInsertableGuarantees(parentID)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +105,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	}
 
 	// get the receipts to insert in the payload
-	insertableReceipts, err := b.getInsertableReceipts(parentID, finalID, finalized)
+	insertableReceipts, err := b.getInsertableReceipts(parentID)
 	if err != nil {
 		return nil, err
 	}
@@ -153,53 +135,14 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 // be inserted in the next payload. It looks in the collection mempool and
 // applies the following filters:
 //
-// 1) If it was already included in the finalized part of the chain, remove it
-//    from the memory pool and skip.
+// 1) If it was already included in the fork, skip.
 //
-// 2) If it references an unknown block, remove it from the memory pool and
-//    skip.
+// 2) If it references an unknown block, skip.
 //
-// 3) If the reference block has an expired height, also remove it from the
-//    memory pool and skip.
+// 3) If the referenced block has an expired height, skip.
 //
-// 4) If it was already included in the pending part of the chain, skip, but
-//    keep in memory pool for now.
-//
-// 5) Otherwise, this guarantee can be included in the payload.
-func (b *Builder) getInsertableGuarantees(parentID flow.Identifier,
-	finalID flow.Identifier,
-	finalHeight uint64) ([]*flow.CollectionGuarantee, error) {
-
-	// STEP ONE: Create a lookup of all previously used guarantees on the part
-	// of the chain that we are building on. We do this separately for pending
-	// and finalized ancestors, so we can differentiate what to do about it.
-
-	b.tracer.StartSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
-	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
-
-	ancestorID := parentID
-	pendingLookup := make(map[flow.Identifier]struct{})
-	for ancestorID != finalID {
-		ancestor, err := b.headers.ByBlockID(ancestorID)
-		if err != nil {
-			return nil, fmt.Errorf("could not get ancestor header (%x): %w", ancestorID, err)
-		}
-		if ancestor.Height <= finalHeight {
-			return nil, fmt.Errorf("should always build on last finalized block")
-		}
-		index, err := b.index.ByBlockID(ancestorID)
-		if err != nil {
-			return nil, fmt.Errorf("could not get ancestor payload (%x): %w", ancestorID, err)
-		}
-		for _, collID := range index.CollectionIDs {
-			pendingLookup[collID] = struct{}{}
-		}
-		ancestorID = ancestor.ParentID
-	}
-
-	b.tracer.FinishSpan(parentID, trace.CONBuildOnUnfinalizedLookup)
-	b.tracer.StartSpan(parentID, trace.CONBuildOnFinalizedLookup)
-	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnFinalizedLookup)
+// 4) Otherwise, this guarantee can be included in the payload.
+func (b *Builder) getInsertableGuarantees(parentID flow.Identifier) ([]*flow.CollectionGuarantee, error) {
 
 	// we look back only as far as the expiry limit for the current height we
 	// are building for; any guarantee with a reference block before that can
@@ -225,38 +168,42 @@ func (b *Builder) getInsertableGuarantees(parentID flow.Identifier,
 		limit = rootHeight
 	}
 
-	ancestorID = finalID
-	finalLookup := make(map[flow.Identifier]struct{})
+	// blockLookup keeps track of the blocks from limit to parent
+	blockLookup := make(map[flow.Identifier]struct{})
+
+	// receiptLookup keeps track of the receipts contained in blocks between
+	// limit and parent
+	receiptLookup := make(map[flow.Identifier]struct{})
+
+	// loop through the fork backwards, from parent to limit, and keep track of
+	// blocks and collections visited on the way
+	ancestorID := parentID
 	for {
+
 		ancestor, err := b.headers.ByBlockID(ancestorID)
 		if err != nil {
 			return nil, fmt.Errorf("could not get ancestor header (%x): %w", ancestorID, err)
 		}
+
+		blockLookup[ancestorID] = struct{}{}
+
 		index, err := b.index.ByBlockID(ancestorID)
 		if err != nil {
 			return nil, fmt.Errorf("could not get ancestor payload (%x): %w", ancestorID, err)
 		}
+
 		for _, collID := range index.CollectionIDs {
-			finalLookup[collID] = struct{}{}
+			receiptLookup[collID] = struct{}{}
 		}
+
 		if ancestor.Height <= limit {
 			break
 		}
+
 		ancestorID = ancestor.ParentID
 	}
 
-	b.tracer.FinishSpan(parentID, trace.CONBuildOnFinalizedLookup)
-	b.tracer.StartSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
-	defer b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
-
-	// STEP TWO: Go through the guarantees in our memory pool.
-	// 1) If it was already included on the finalized part of the chain, remove
-	// it from the memory pool and skip.
-	// 2) If the reference block has an expired height, also remove it from the
-	// memory pool and skip.
-	// 3) If it was already included on the pending part of the chain, skip, but
-	// keep in memory pool for now.
-	// 4) Otherwise, this guarantee can be included in the payload.
+	// go through mempool and collect valid collections
 	var guarantees []*flow.CollectionGuarantee
 	for _, guarantee := range b.guarPool.All() {
 		// add at most <maxGuaranteeCount> number of collection guarantees in a new block proposal
@@ -267,33 +214,21 @@ func (b *Builder) getInsertableGuarantees(parentID flow.Identifier,
 		}
 
 		collID := guarantee.ID()
-		_, duplicated := finalLookup[collID]
-		if duplicated {
-			_ = b.guarPool.Rem(collID)
-			continue
-		}
-		ref, err := b.headers.ByBlockID(guarantee.ReferenceBlockID)
-		if errors.Is(err, storage.ErrNotFound) {
-			_ = b.guarPool.Rem(collID)
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("could not get reference block: %w", err)
-		}
-		if ref.Height < limit {
-			_ = b.guarPool.Rem(collID)
-			continue
-		}
-		_, duplicated = pendingLookup[collID]
+
+		// skip collections that are already included in a block on the fork
+		_, duplicated := receiptLookup[collID]
 		if duplicated {
 			continue
 		}
+
+		// skip collections for blocks that are not within the limit
+		_, ok := blockLookup[guarantee.ReferenceBlockID]
+		if !ok {
+			continue
+		}
+
 		guarantees = append(guarantees, guarantee)
 	}
-
-	b.metrics.MempoolEntries(metrics.ResourceGuarantee, b.guarPool.Size())
-
-	b.tracer.FinishSpan(parentID, trace.CONBuildOnCreatePayloadGuarantees)
 
 	return guarantees, nil
 }
@@ -468,27 +403,14 @@ func (b *Builder) getInsertableSeals(parentID flow.Identifier) ([]*flow.Seal, er
 // inserted in the next payload. It looks in the receipts mempool and applies
 // the following filter:
 //
-// 1) If it corresponds to an unknown block, remove it from the mempool and
-//    skip.
+// 1) If it doesn't correspond to an unsealed block on the fork, skip it.
 //
-// 2) If the corresponding block was already sealed, remove it from the mempool
-//    and skip.
+// 2) If it was already included in the fork, skip it.
 //
-// 3) If it was already included in the finalized part of the chain, remove it
-//    from the memory pool and skip.
-//
-// 4) If it was already included in the pending part of the chain, skip, but
-//    keep in memory pool for now.
-//
-// 5) If the receipt corresponds to a block that is not on this fork, skip, but
-//    but keep in mempool for now.
-//
-// 6) Otherwise, this receipt can be included in the payload.
+// 3) Otherwise, this receipt can be included in the payload.
 //
 // Receipts have to be ordered by block height.
-func (b *Builder) getInsertableReceipts(parentID flow.Identifier,
-	finalID flow.Identifier,
-	finalHeight uint64) ([]*flow.ExecutionReceipt, error) {
+func (b *Builder) getInsertableReceipts(parentID flow.Identifier) ([]*flow.ExecutionReceipt, error) {
 
 	// Get the latest sealed block on this fork, ie the highest block for which
 	// there is a seal in this fork. This block is not necessarily finalized.
@@ -501,9 +423,9 @@ func (b *Builder) getInsertableReceipts(parentID flow.Identifier,
 		return nil, fmt.Errorf("could not retrieve sealed block (%x): %w", last.BlockID, err)
 	}
 
-	// forkBlocks is used to keep the IDs of the blocks we iterate through. We
-	// use it to skip receipts that are not for blocks in the fork.
-	forkBlocks := make(map[flow.Identifier]struct{})
+	// unsealedBlocks is used to keep the IDs of the blocks we iterate through.
+	// We use it to skip receipts that are not for unsealed blocks in the fork.
+	unsealedBlocks := make(map[flow.Identifier]*flow.Header)
 
 	// lookup is a lookup table of all the receipts that are contained in
 	// unsealed blocks along the fork. The map tracks the receipt ID and the
@@ -525,7 +447,7 @@ func (b *Builder) getInsertableReceipts(parentID flow.Identifier,
 			break
 		}
 
-		forkBlocks[ancestorID] = struct{}{}
+		unsealedBlocks[ancestorID] = ancestor
 
 		index, err := b.index.ByBlockID(ancestorID)
 		if err != nil {
@@ -545,42 +467,15 @@ func (b *Builder) getInsertableReceipts(parentID flow.Identifier,
 	receipts := make(map[uint64][]*flow.ExecutionReceipt) // [height] -> []receipt
 	for _, receipt := range b.recPool.All() {
 
-		// if block is unknown, remove from mempool and continue
-		h, err := b.headers.ByBlockID(receipt.ExecutionResult.BlockID)
-		if errors.Is(err, storage.ErrNotFound) {
-			_ = b.recPool.Rem(receipt.ID())
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("could not get reference block: %w", err)
-		}
-
-		// check whether receipt is for block at or below the sealed and
-		// finalized height
-		if h.Height <= sealed.Height {
-			// Block has either already been sealed and finalized  _or_
-			// block is a _sibling_ of a sealed and finalized block.
-			// In either case, we don't need to seal the block anymore
-			// and therefore can discard any ExecutionResults for it.
-			continue
-		}
-
 		// skip receipts that are already included in a block on this fork
-		containingBlockHeight, ok := lookup[receipt.ID()]
+		_, ok := lookup[receipt.ID()]
 		if ok {
-			// if the block that contains the receipt is finalized, remove the
-			// receipt from the mempool
-			if containingBlockHeight <= finalHeight {
-				_ = b.recPool.Rem(receipt.ID())
-			}
-			// if the block is not finalized, skip the receipt but don't remove
-			// it from the mempool
 			continue
 		}
 
-		// skip the receipt if it is not for a block on this fork, but don't
-		// remove it from the mempool
-		if _, ok := forkBlocks[receipt.ExecutionResult.BlockID]; !ok {
+		// skip the receipt if it is not for a block on this fork
+		h, ok := unsealedBlocks[receipt.ExecutionResult.BlockID]
+		if !ok {
 			continue
 		}
 

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -190,15 +190,9 @@ func (bs *BuilderSuite) SetupTest() {
 	first := bs.createAndRecordBlock(nil)
 	bs.firstID = first.ID()
 	firstResult := unittest.ExecutionResultFixture(unittest.WithBlock(first))
-	firstSealedState, ok := firstResult.FinalStateCommitment()
-	if !ok {
-		panic("missing first execution result's final state commitment")
-	}
-	bs.lastSeal = &flow.Seal{
-		BlockID:    first.ID(),
-		ResultID:   firstResult.ID(),
-		FinalState: firstSealedState,
-	}
+	bs.lastSeal = unittest.Seal.Fixture(
+		unittest.Seal.WithResult(firstResult),
+	)
 	bs.resultForBlock[firstResult.BlockID] = firstResult
 
 	// insert the finalized blocks between first and final
@@ -629,7 +623,7 @@ func (bs *BuilderSuite) TestPayloadReceiptSealsOtherFork() {
 	}
 
 	mockSealDB := &storage.Seals{}
-	// set last seal on A fork to F0
+	// set last seal on A fork to F0 (block A's id is  bs.parentID)
 	mockSealDB.On("ByBlockID", bs.parentID).Return(bs.irsList[0].Seal, nil)
 	// set last seal on B fork to `first`
 	mockSealDB.On("ByBlockID", forkHead.ID()).Return(bs.lastSeal, nil)

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -41,11 +41,9 @@ const (
 
 	// Builder
 	CONBuildOn                        = "con.builder"
-	CONBuildOnSetup                   = "con.builder.setup"
-	CONBuildOnUnfinalizedLookup       = "con.builder.unfinalizedLookup"
-	CONBuildOnFinalizedLookup         = "con.builder.finalizedLookup"
 	CONBuildOnCreatePayloadGuarantees = "con.builder.createPayload.guarantees"
 	CONBuildOnCreatePayloadSeals      = "con.builder.createPayload.seals"
+	CONBuildOnCreatePayloadReceipts   = "con.builder.createPayload.receipts"
 	CONBuildOnCreateHeader            = "con.builder.createHeader"
 	CONBuildOnDBInsert                = "con.builder.dbInsert"
 

--- a/module/validation/receipt_validator_test.go
+++ b/module/validation/receipt_validator_test.go
@@ -83,7 +83,22 @@ func (s *ReceiptValidationSuite) TestReceiptInvalidStake() {
 	s.Require().Error(err, "should reject invalid identity")
 }
 
-func (s *ReceiptValidationSuite) TestReceiptTooFewChunksChunks() {
+func (s *ReceiptValidationSuite) TestReceiptInvalidSignature() {
+	valSubgrph := s.ValidSubgraphFixture()
+	receipt := unittest.ExecutionReceiptFixture(unittest.WithExecutorID(s.ExeID),
+		unittest.WithResult(valSubgrph.Result))
+	s.AddSubgraphFixtureToMempools(valSubgrph)
+
+	s.verifier.On("Verify",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything).Return(false, nil).Once()
+
+	err := s.receiptValidator.Validate(receipt)
+	s.Require().Error(err, "should reject invalid signature")
+}
+
+func (s *ReceiptValidationSuite) TestReceiptTooFewChunks() {
 	valSubgrph := s.ValidSubgraphFixture()
 	chunks := valSubgrph.Result.Chunks
 	valSubgrph.Result.Chunks = chunks[0 : len(chunks)-2] // drop the last chunk

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -714,7 +714,7 @@ func (m *Mutator) lastSealed(candidate *flow.Block) (*flow.Seal, error) {
 		for i, seal := range payload.Seals {
 			header, err := m.state.headers.ByBlockID(seal.BlockID)
 			if err != nil {
-				return nil, fmt.Errorf("could not retrieve the header %v for seal: %w", seal.BlockID, err)
+				return nil, state.NewInvalidExtensionErrorf("could not retrieve the header %v for seal: %w", seal.BlockID, err)
 			}
 
 			if i == 0 || header.Height > highestHeader.Height {

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -888,46 +888,133 @@ func TestExtendHighestSeal(t *testing.T) {
 	})
 }
 
+// Test that Extend will refuse payloads that contain duplicate receipts, where
+// duplicates can be in another block on the fork, or withing the payload.
 func TestExtendReceiptsDuplicate(t *testing.T) {
 
 	util.RunWithProtocolStateAndMutatorFactory(t, mockMutatorFactory(), func(db *badger.DB, state *protocol.State) {
 		// bootstrap the root block
 		block1, result, seal := unittest.BootstrapFixture(participants)
-		block1.Payload.Guarantees = nil
-		block1.Header.PayloadHash = block1.Payload.Hash()
 		err := state.Mutate().Bootstrap(block1, result, seal)
 		require.NoError(t, err)
 
-		// create block2 and block3
 		block2 := unittest.BlockWithParentFixture(block1.Header)
-		block2.Payload.Guarantees = nil
-		block2.Header.PayloadHash = block2.Payload.Hash()
+		block2.SetPayload(flow.Payload{})
 		err = state.Mutate().Extend(&block2)
 		require.Nil(t, err)
 
 		receipt := unittest.ReceiptForBlockFixture(&block2)
 
-		block3 := unittest.BlockWithParentFixture(block2.Header)
-		block3.Payload.Guarantees = nil
-		block3.Payload.Receipts = append(block3.Payload.Receipts, receipt)
-		block3.Header.PayloadHash = block3.Payload.Hash()
-		err = state.Mutate().Extend(&block3)
-		require.Nil(t, err)
+		t.Run("duplicate receipt in different block", func(t *testing.T) {
+			block3 := unittest.BlockWithParentFixture(block2.Header)
+			block3.SetPayload(flow.Payload{
+				Receipts: []*flow.ExecutionReceipt{receipt},
+			})
+			err = state.Mutate().Extend(&block3)
+			require.Nil(t, err)
 
-		// insert a duplicate receipt
-		block4 := unittest.BlockWithParentFixture(block3.Header)
-		block4.Payload.Guarantees = nil
-		block4.Payload.Receipts = append(block4.Payload.Receipts, receipt)
-		block4.Header.PayloadHash = block4.Payload.Hash()
-		err = state.Mutate().Extend(&block4)
-		require.Error(t, err)
-		require.True(t, st.IsInvalidExtensionError(err), err)
+			block4 := unittest.BlockWithParentFixture(block3.Header)
+			block4.SetPayload(flow.Payload{
+				Receipts: []*flow.ExecutionReceipt{receipt},
+			})
+			err = state.Mutate().Extend(&block4)
+			require.Error(t, err)
+			require.True(t, st.IsInvalidExtensionError(err), err)
+		})
+
+		t.Run("duplicate receipt in same block", func(t *testing.T) {
+			block3 := unittest.BlockWithParentFixture(block2.Header)
+			block3.SetPayload(flow.Payload{
+				Receipts: []*flow.ExecutionReceipt{
+					receipt,
+					receipt,
+				},
+			})
+			err = state.Mutate().Extend(&block3)
+			require.Error(t, err)
+			require.True(t, st.IsInvalidExtensionError(err), err)
+		})
+
 	})
 }
 
-func TestExtendReceiptsLatestSealed(t *testing.T) {
+// Test that Extend will refuse payloads that contain receipts for blocks that
+// are already sealed on the fork, but will accept receipts for blocks that are
+// sealed on another fork.
+func TestExtendReceiptsSealedBlock(t *testing.T) {
 
 	util.RunWithProtocolStateAndMutatorFactory(t, mockMutatorFactory(), func(db *badger.DB, state *protocol.State) {
+		// bootstrap the root block
+		block1, result, seal := unittest.BootstrapFixture(participants)
+		block1.SetPayload(flow.Payload{})
+		err := state.Mutate().Bootstrap(block1, result, seal)
+		require.NoError(t, err)
+
+		// create block2
+		block2 := unittest.BlockWithParentFixture(block1.Header)
+		block2.SetPayload(flow.Payload{})
+		err = state.Mutate().Extend(&block2)
+		require.Nil(t, err)
+
+		block2Receipt := unittest.ReceiptForBlockFixture(&block2)
+
+		// B1<--B2<--B3{R{B2)}<--B4{S(R(B2))}<--B5{R'(B2)}
+
+		// create block3 with a receipt for block2
+		block3 := unittest.BlockWithParentFixture(block2.Header)
+		block3.SetPayload(flow.Payload{
+			Receipts: []*flow.ExecutionReceipt{block2Receipt},
+		})
+		err = state.Mutate().Extend(&block3)
+		require.Nil(t, err)
+
+		// create a seal for block2
+		seal2 := unittest.Seal.Fixture(unittest.Seal.WithResult(&block2Receipt.ExecutionResult))
+
+		// create block4 containing a seal for block2
+		block4 := unittest.BlockWithParentFixture(block3.Header)
+		block4.SetPayload(flow.Payload{
+			Seals: []*flow.Seal{seal2},
+		})
+		err = state.Mutate().Extend(&block4)
+		require.Nil(t, err)
+
+		// insert another receipt for block 2, which is now the highest sealed
+		// block, and ensure that the receipt is rejected
+		receipt := unittest.ReceiptForBlockFixture(&block2)
+		block5 := unittest.BlockWithParentFixture(block4.Header)
+		block5.SetPayload(flow.Payload{
+			Receipts: []*flow.ExecutionReceipt{receipt},
+		})
+		err = state.Mutate().Extend(&block5)
+		require.Error(t, err)
+		require.True(t, st.IsInvalidExtensionError(err), err)
+
+		// B1<--B2<--B3{R{B2)}<--B4{S(R(B2))}<--B5{R'(B2)}
+		//       |
+		//       +---B6{R''(B2)}
+
+		// insert another receipt for B2 but in a separate fork. The fact that
+		// B2 is sealed on a separate fork should not cause the receipt to be
+		// rejected
+		block6 := unittest.BlockWithParentFixture(block2.Header)
+		block6.SetPayload(flow.Payload{
+			Receipts: []*flow.ExecutionReceipt{receipt},
+		})
+		err = state.Mutate().Extend(&block6)
+		require.Nil(t, err)
+	})
+}
+
+// Test that Extend will reject payloads that contain receipts for blocks that
+// are not on the fork
+//
+// B1<--B2<--B3
+//      |
+//      +----B4{R(B3)}
+func TestExtendReceiptsBlockNotOnFork(t *testing.T) {
+	util.RunWithProtocolState(t, func(db *badger.DB, state *protocol.State) {
+
 		// bootstrap the root block
 		block1, result, seal := unittest.BootstrapFixture(participants)
 		block1.Payload.Guarantees = nil
@@ -942,64 +1029,19 @@ func TestExtendReceiptsLatestSealed(t *testing.T) {
 		err = state.Mutate().Extend(&block2)
 		require.Nil(t, err)
 
-		// create block3 with a receipt for block2
-		block2Receipt := unittest.ReceiptForBlockFixture(&block2)
+		// create block3
 		block3 := unittest.BlockWithParentFixture(block2.Header)
-		block3.SetPayload(flow.Payload{
-			Receipts: []*flow.ExecutionReceipt{block2Receipt},
-		})
+		block3.SetPayload(flow.Payload{})
 		err = state.Mutate().Extend(&block3)
 		require.Nil(t, err)
 
-		// create a seals for block2
-		seal2 := unittest.Seal.Fixture(unittest.Seal.WithResult(&block2Receipt.ExecutionResult))
+		block3Receipt := unittest.ReceiptForBlockFixture(&block3)
 
-		// create block4 containing a seal for block2
-		block4 := unittest.BlockWithParentFixture(block3.Header)
+		block4 := unittest.BlockWithParentFixture(block2.Header)
 		block4.SetPayload(flow.Payload{
-			Seals: []*flow.Seal{seal2},
+			Receipts: []*flow.ExecutionReceipt{block3Receipt},
 		})
 		err = state.Mutate().Extend(&block4)
-		require.Nil(t, err)
-
-		// insert another receipt for block 2, which is now the highest sealed
-		// block
-		receipt := unittest.ReceiptForBlockFixture(&block2)
-		// test that the receipt is rejected
-		block5 := unittest.BlockWithParentFixture(block4.Header)
-		block5.SetPayload(flow.Payload{
-			Receipts: []*flow.ExecutionReceipt{receipt},
-		})
-		err = state.Mutate().Extend(&block5)
-		require.Error(t, err)
-		require.True(t, st.IsInvalidExtensionError(err), err)
-	})
-}
-
-func TestExtendReceiptsBlockNotOnFork(t *testing.T) {
-	util.RunWithProtocolState(t, func(db *badger.DB, state *protocol.State) {
-		// bootstrap the root block
-		block1, result, seal := unittest.BootstrapFixture(participants)
-		block1.Payload.Guarantees = nil
-		block1.Header.PayloadHash = block1.Payload.Hash()
-		err := state.Mutate().Bootstrap(block1, result, seal)
-		require.NoError(t, err)
-
-		// create block2 and block3
-		block2 := unittest.BlockWithParentFixture(block1.Header)
-		block2.Payload.Guarantees = nil
-		block2.Header.PayloadHash = block2.Payload.Hash()
-		err = state.Mutate().Extend(&block2)
-		require.Nil(t, err)
-
-		// Add a receipt that is not tied to a block on the fork
-		receipt := unittest.ExecutionReceiptFixture()
-
-		block3 := unittest.BlockWithParentFixture(block2.Header)
-		block3.Payload.Guarantees = nil
-		block3.Payload.Receipts = append(block3.Payload.Receipts, receipt)
-		block3.Header.PayloadHash = block3.Payload.Hash()
-		err = state.Mutate().Extend(&block3)
 		require.Error(t, err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
 	})
@@ -1041,22 +1083,20 @@ func TestExtendReceiptsNotSorted(t *testing.T) {
 	})
 }
 
-func TestExtendReceiptInvalid(t *testing.T) {
+func TestExtendReceiptsInvalid(t *testing.T) {
 	validator := &mock2.ReceiptValidator{}
 	mockFactory := protocol.NewMutatorFactoryWithValidator(validator)
 
 	util.RunWithProtocolStateAndMutatorFactory(t, mockFactory, func(db *badger.DB, state *protocol.State) {
 		// bootstrap the root block
 		block1, result, seal := unittest.BootstrapFixture(participants)
-		block1.Payload.Guarantees = nil
-		block1.Header.PayloadHash = block1.Payload.Hash()
+		block1.SetPayload(flow.EmptyPayload())
 		err := state.Mutate().Bootstrap(block1, result, seal)
 		require.NoError(t, err)
 
 		// create block2 and block3
 		block2 := unittest.BlockWithParentFixture(block1.Header)
-		block2.Payload.Guarantees = nil
-		block2.Header.PayloadHash = block2.Payload.Hash()
+		block2.SetPayload(flow.EmptyPayload())
 		err = state.Mutate().Extend(&block2)
 		require.Nil(t, err)
 
@@ -1067,9 +1107,9 @@ func TestExtendReceiptInvalid(t *testing.T) {
 		validator.On("Validate", mock.Anything).Return(engine.NewInvalidInputError(""))
 
 		block3 := unittest.BlockWithParentFixture(block2.Header)
-		block3.Payload.Guarantees = nil
-		block3.Payload.Receipts = append(block3.Payload.Receipts, receipt)
-		block3.Header.PayloadHash = block3.Payload.Hash()
+		block3.SetPayload(flow.Payload{
+			Receipts: []*flow.ExecutionReceipt{receipt},
+		})
 		err = state.Mutate().Extend(&block3)
 		require.Error(t, err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
@@ -1081,38 +1121,32 @@ func TestExtendReceiptsValid(t *testing.T) {
 	util.RunWithProtocolStateAndMutatorFactory(t, mockMutatorFactory(), func(db *badger.DB, state *protocol.State) {
 		// bootstrap the root block
 		block1, result, seal := unittest.BootstrapFixture(participants)
-		block1.Payload.Guarantees = nil
-		block1.Header.PayloadHash = block1.Payload.Hash()
+		block1.SetPayload(flow.EmptyPayload())
 		err := state.Mutate().Bootstrap(block1, result, seal)
 		require.NoError(t, err)
 
-		// create block2 and block3
 		block2 := unittest.BlockWithParentFixture(block1.Header)
-		block2.Payload.Guarantees = nil
-		block2.Header.PayloadHash = block2.Payload.Hash()
+		block2.SetPayload(flow.EmptyPayload())
 		err = state.Mutate().Extend(&block2)
 		require.Nil(t, err)
 
 		block3 := unittest.BlockWithParentFixture(block2.Header)
-		block3.Payload.Guarantees = nil
-		block3.Payload.Receipts = append(block3.Payload.Receipts, unittest.ReceiptForBlockFixture(&block2))
-		block3.Header.PayloadHash = block3.Payload.Hash()
+		block3.SetPayload(flow.EmptyPayload())
 		err = state.Mutate().Extend(&block3)
 		require.Nil(t, err)
 
 		block4 := unittest.BlockWithParentFixture(block3.Header)
-		block4.Payload.Guarantees = nil
-		block4.Header.PayloadHash = block4.Payload.Hash()
+		block4.SetPayload(flow.EmptyPayload())
 		err = state.Mutate().Extend(&block4)
 		require.Nil(t, err)
 
 		block5 := unittest.BlockWithParentFixture(block4.Header)
-		block5.Payload.Guarantees = nil
-		block5.Payload.Receipts = append(block5.Payload.Receipts,
-			unittest.ReceiptForBlockFixture(&block3),
-			unittest.ReceiptForBlockFixture(&block4),
-		)
-		block5.Header.PayloadHash = block5.Payload.Hash()
+		block5.SetPayload(flow.Payload{
+			Receipts: []*flow.ExecutionReceipt{
+				unittest.ReceiptForBlockFixture(&block3),
+				unittest.ReceiptForBlockFixture(&block4),
+			},
+		})
 		err = state.Mutate().Extend(&block5)
 		require.Nil(t, err)
 	})

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -1145,10 +1145,18 @@ func TestExtendReceiptsValid(t *testing.T) {
 		err = state.Mutate().Extend(&block4)
 		require.Nil(t, err)
 
+		receipt3a := unittest.ReceiptForBlockFixture(&block3)
+		receipt3b := unittest.ReceiptForBlockFixture(&block3)
+		var altResult flow.ExecutionResult = receipt3b.ExecutionResult // copy
+		altResult.Signatures = unittest.SignaturesFixture(1)
+		receipt3c := unittest.ExecutionReceiptFixture(unittest.WithResult(&altResult))
+
 		block5 := unittest.BlockWithParentFixture(block4.Header)
 		block5.SetPayload(flow.Payload{
 			Receipts: []*flow.ExecutionReceipt{
-				unittest.ReceiptForBlockFixture(&block3),
+				receipt3a,
+				receipt3b,
+				receipt3c,
 				unittest.ReceiptForBlockFixture(&block4),
 			},
 		})

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -5,14 +5,13 @@ package badger
 import (
 	"fmt"
 
-	"github.com/onflow/flow-go/model/encoding"
-	"github.com/onflow/flow-go/module/signature"
-	"github.com/onflow/flow-go/module/validation"
-
 	"github.com/dgraph-io/badger/v2"
 
+	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/signature"
+	"github.com/onflow/flow-go/module/validation"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"

--- a/utils/unittest/seals.go
+++ b/utils/unittest/seals.go
@@ -30,7 +30,10 @@ func (f *sealFactory) Fixtures(n int) []*flow.Seal {
 
 func (f *sealFactory) WithResult(result *flow.ExecutionResult) func(*flow.Seal) {
 	return func(seal *flow.Seal) {
-		finalState, _ := result.FinalStateCommitment()
+		finalState, ok := result.FinalStateCommitment()
+		if !ok {
+			panic("missing first execution result's final state commitment")
+		}
 		seal.ResultID = result.ID()
 		seal.BlockID = result.BlockID
 		seal.FinalState = finalState


### PR DESCRIPTION
Linked to issues [5085](https://github.com/dapperlabs/flow-go/issues/5085) and [5126](https://github.com/dapperlabs/flow-go/issues/5126)

* Builder: test excluding receipts for blocks that have seal in fork in
           finalized or pending blocks
* Builder: test including receipts for blocks that have seal in a separate fork
* Builder: test maxSealLimit
* Builder: test excluding seals for blocks that already have seals on the fork
* Mutator: test rejecting duplicate receipts within payload
* Mutator: test inserting a receipt for a block that is sealed on another fork