### PR TITLE
extend the safetyErrorCheck on fvm

### DIFF
--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/rs/zerolog/log"
 
 	"github.com/onflow/flow-go/engine/execution/state"
 	"github.com/onflow/flow-go/ledger/common/utils"
@@ -234,7 +235,6 @@ func contractKey(contractName string) string {
 
 func (a *Accounts) getContract(contractName string, address flow.Address) ([]byte, error) {
 
-	fmt.Printf("TEMP LOGGING: get contract called for %s.%s \n", address.String(), contractName)
 	contract, err := a.getValue(address,
 		true,
 		contractKey(contractName))
@@ -242,7 +242,11 @@ func (a *Accounts) getContract(contractName string, address flow.Address) ([]byt
 		return nil, newLedgerGetError(contractName, address, err)
 	}
 
-	fmt.Printf("TEMP LOGGING: a contract returned for %s.%s: %s...%s (len: %d)\n", address.String(), contractName, contract[:30], contract[len(contract)-20:], len(contract))
+	log.Info().
+		Str("address", address.String()).
+		Str("contract", contractName).
+		Int("contract_len", len(contract)).
+		Msg(fmt.Sprintf("TEMP LOGGING: a contract returned for %s.%s", address.String(), contractName))
 
 	return contract, nil
 }

--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -233,12 +233,16 @@ func contractKey(contractName string) string {
 }
 
 func (a *Accounts) getContract(contractName string, address flow.Address) ([]byte, error) {
+
+	fmt.Printf("TEMP LOGGING: get contract called for %s.%s \n", address.String(), contractName)
 	contract, err := a.getValue(address,
 		true,
 		contractKey(contractName))
 	if err != nil {
 		return nil, newLedgerGetError(contractName, address, err)
 	}
+
+	fmt.Printf("TEMP LOGGING: a contract returned for %s.%s: %s...%s (len: %d)\n", address.String(), contractName, len(contract), contract[:30], contract[len(contract)-20:])
 
 	return contract, nil
 }

--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -242,7 +242,7 @@ func (a *Accounts) getContract(contractName string, address flow.Address) ([]byt
 		return nil, newLedgerGetError(contractName, address, err)
 	}
 
-	fmt.Printf("TEMP LOGGING: a contract returned for %s.%s: %s...%s (len: %d)\n", address.String(), contractName, len(contract), contract[:30], contract[len(contract)-20:])
+	fmt.Printf("TEMP LOGGING: a contract returned for %s.%s: %s...%s (len: %d)\n", address.String(), contractName, contract[:30], contract[len(contract)-20:], len(contract))
 
 	return contract, nil
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -12,7 +12,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-const TopShotContractAddress = "0b2a3299cc857e29"
+// const TopShotContractAddress = "0b2a3299cc857e29"
 
 func Transaction(tx *flow.TransactionBody, txIndex uint32) *TransactionProcedure {
 	return &TransactionProcedure{
@@ -81,7 +81,7 @@ func (i *TransactionInvocator) Process(
 	err = vm.Runtime.ExecuteTransaction(proc.Transaction.Script, proc.Transaction.Arguments, env, location)
 
 	if err != nil {
-		i.topshotSafetyErrorCheck(err)
+		i.safetyErrorCheck(err)
 		return err
 	}
 
@@ -91,22 +91,22 @@ func (i *TransactionInvocator) Process(
 	return nil
 }
 
-// topshotSafetyErrorCheck is additional check introduced to help chase erroneous execution results
+// safetyErrorCheck is additional check introduced to help chase erroneous execution results
 // which caused unexpected network fork. TopShot is first full-fledged game running on Flow, and
 // checking failures in this contract indicate the unexpected computation happening.
 // This is a temporary measure.
-func (i *TransactionInvocator) topshotSafetyErrorCheck(err error) {
-	fmt.Println("ERROR", err)
+func (i *TransactionInvocator) safetyErrorCheck(err error) {
+	fmt.Println("~Cadence Execution ERROR:", err)
 	e := err.Error()
-	if strings.Contains(e, TopShotContractAddress) && strings.Contains(e, "checking") {
+	if strings.Contains(e, "checking") {
 		re, isRuntime := err.(runtime.Error)
 		if !isRuntime {
-			i.logger.Err(err).Msg("found checking error for TopShot contract but exception is not RuntimeError")
+			i.logger.Err(err).Msg("found checking error for a contract but exception is not RuntimeError")
 			return
 		}
 		ee, is := re.Err.(*runtime.ParsingCheckingError)
 		if !is {
-			i.logger.Err(err).Msg("found checking error for TopShot contract but exception is not ExtendedParsingCheckingError")
+			i.logger.Err(err).Msg("found checking error for a contract but exception is not ExtendedParsingCheckingError")
 			return
 		}
 
@@ -115,6 +115,6 @@ func (i *TransactionInvocator) topshotSafetyErrorCheck(err error) {
 		spew.Config.DisableMethods = true
 		dump := spew.Sdump(ee)
 
-		i.logger.Error().Str("extended_error", dump).Msg("TopShot contract checking failed")
+		i.logger.Error().Str("extended_error", dump).Msg("A contract checking failed")
 	}
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -96,7 +96,7 @@ func (i *TransactionInvocator) Process(
 // checking failures in this contract indicate the unexpected computation happening.
 // This is a temporary measure.
 func (i *TransactionInvocator) safetyErrorCheck(err error) {
-	fmt.Println("~Cadence Execution ERROR:", err)
+	fmt.Println("TEMP LOGGING: Cadence Execution ERROR:", err)
 	e := err.Error()
 	if strings.Contains(e, "checking") {
 		re, isRuntime := err.(runtime.Error)

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -1,7 +1,6 @@
 package fvm
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"
@@ -96,8 +95,8 @@ func (i *TransactionInvocator) Process(
 // checking failures in this contract indicate the unexpected computation happening.
 // This is a temporary measure.
 func (i *TransactionInvocator) safetyErrorCheck(err error) {
-	fmt.Println("TEMP LOGGING: Cadence Execution ERROR:", err)
 	e := err.Error()
+	i.logger.Info().Str("error", e).Msg("TEMP LOGGING: Cadence Execution ERROR")
 	if strings.Contains(e, "checking") {
 		re, isRuntime := err.(runtime.Error)
 		if !isRuntime {
@@ -115,6 +114,6 @@ func (i *TransactionInvocator) safetyErrorCheck(err error) {
 		spew.Config.DisableMethods = true
 		dump := spew.Sdump(ee)
 
-		i.logger.Error().Str("extended_error", dump).Msg("A contract checking failed")
+		i.logger.Error().Str("extended_error", dump).Msg("contract checking failed")
 	}
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -11,8 +11,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// const TopShotContractAddress = "0b2a3299cc857e29"
-
 func Transaction(tx *flow.TransactionBody, txIndex uint32) *TransactionProcedure {
 	return &TransactionProcedure{
 		ID:          tx.ID(),


### PR DESCRIPTION
This PR
- Renames the ERROR to something more distinct as Stackdriver's text query is not case sensitive. 
- Extends the current check to be about any tx check fails. 
- Adds some temporary logs for when we fetch code for a contract. (this will help us track down to see if this is an error with ledger or cadence) 