### PR TITLE
add tool to remove execution fork

### DIFF
--- a/cmd/util/cmd/remove-execution-fork/cmd/execution-fork.go
+++ b/cmd/util/cmd/remove-execution-fork/cmd/execution-fork.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/onflow/flow-go/cmd/util/cmd/common"
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/badger/operation"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "remove-execution-fork",
+	Short: "Remove execution fork for conflicting results. Useful for resuming the sealing.",
+	Run:   run,
+}
+
+func init() {
+	rootCmd.AddCommand(Cmd)
+}
+
+func run(*cobra.Command, []string) {
+	log.Info().
+		Str("datadir", flagDatadir).
+		Msg("flags")
+
+	db := common.InitStorage(flagDatadir)
+	defer db.Close()
+
+	err := db.Update(operation.RemoveExecutionForkEvidence())
+
+	// for testing purpose
+	// expectedSeals := unittest.IncorporatedResultSeal.Fixtures(2)
+	// err := db.Update(operation.InsertExecutionForkEvidence(expectedSeals))
+
+	if err == storage.ErrNotFound {
+		log.Info().Msg("no execution fork was found, exit")
+		return
+	}
+
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not remove execution fork")
+		return
+	}
+
+	log.Info().Msg("execution fork removed")
+}

--- a/cmd/util/cmd/remove-execution-fork/cmd/root.go
+++ b/cmd/util/cmd/remove-execution-fork/cmd/root.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	flagDatadir string
+)
+
+// run with `./remove-execution-fork remove-execution-fork --datadir /var/flow/data/protocol`
+var rootCmd = &cobra.Command{
+	Use:   "remove-execution-fork",
+	Short: "remove execution fork",
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println("error", err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&flagDatadir, "datadir", "d", "/var/flow/data/protocol", "directory to the badger dababase")
+	_ = rootCmd.MarkPersistentFlagRequired("datadir")
+
+	cobra.OnInitialize(initConfig)
+}
+
+func initConfig() {
+	viper.AutomaticEnv()
+}

--- a/cmd/util/cmd/remove-execution-fork/main.go
+++ b/cmd/util/cmd/remove-execution-fork/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/onflow/flow-go/cmd/util/cmd/remove-execution-fork/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
v0.13 will introduce [the change to stop the consensus node if it detects conflicting seals](https://github.com/onflow/flow-go/pull/178)

In order to recover, we need the tool to remove the conflicting seals. 

This PR implements the tool, I called it `remove-execution-fork`.