### PR TITLE
Reduce the number of metrics buckets for tracking duration

### DIFF
--- a/module/trace/metrics.go
+++ b/module/trace/metrics.go
@@ -9,6 +9,6 @@ var (
 	spanDurationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "span_duration_s",
 		Help:    "The duration of the Jaeger span in seconds",
-		Buckets: []float64{.001, .005, .01, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+		Buckets: []float64{.001, .01, .1, .5, 5, 10},
 	}, []string{"name"})
 )


### PR DESCRIPTION
The metrics cost is multiplied by the number of buckets. Currently the span_duration_s_bucket is the one most costly metrics. Reducing the number would be a massive saving.