### PR TITLE
Docker 20 compatibility

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -49,7 +49,7 @@ WORKDIR /app
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=ssh \
-    GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build --tags relic -ldflags "-extldflags -static" -o ./app ./cmd/${TARGET}
+    GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build --tags "relic,netgo" -ldflags "-extldflags -static" -o ./app ./cmd/${TARGET}
 
 RUN chmod a+x /app/app
 


### PR DESCRIPTION
Following https://github.com/golang/go/issues/30310#issuecomment-471669125, decided to use `netgo` which should resolve the docker 20 issues.