### PR TITLE
Disable state sync test for now

### DIFF
--- a/integration/tests/execution/state_sync_test.go
+++ b/integration/tests/execution/state_sync_test.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/onflow/flow-go-sdk"
 
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/integration/tests/common"
@@ -16,7 +15,8 @@ import (
 )
 
 func TestExecutionStateSync(t *testing.T) {
-	suite.Run(t, new(StateSyncSuite))
+	// TODO: We've removed state sync, so tests are not currently maintained, and flakey
+	// suite.Run(t, new(StateSyncSuite))
 }
 
 type StateSyncSuite struct {


### PR DESCRIPTION
ref: https://github.com/dapperlabs/flow-go/issues/5131

State sync will be disabled by: https://github.com/onflow/flow-go/pull/240 

And these tests are flakey, so no need to run for now.