### PR TITLE
Disable event emission for non-transactions and improve FVM errors

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -254,6 +254,10 @@ func (e *hostEnv) Log(message string) error {
 
 func (e *hostEnv) EmitEvent(event cadence.Event) error {
 
+	if e.transactionEnv == nil {
+		return errors.New("emitting events is not supported")
+	}
+
 	payload, err := jsoncdc.Encode(event)
 	if err != nil {
 		return fmt.Errorf("failed to json encode a cadence event: %w", err)

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -357,7 +357,7 @@ func (e *hostEnv) SetCadenceValue(owner common.Address, key string, value cadenc
 // GetCurrentBlockHeight returns the current block height.
 func (e *hostEnv) GetCurrentBlockHeight() (uint64, error) {
 	if e.ctx.BlockHeader == nil {
-		return 0, errors.New("GetCurrentBlockHeight is not supported by this environment")
+		return 0, errors.New("getting the current block height is not supported")
 	}
 	return e.ctx.BlockHeader.Height, nil
 }
@@ -366,7 +366,7 @@ func (e *hostEnv) GetCurrentBlockHeight() (uint64, error) {
 // secure.
 func (e *hostEnv) UnsafeRandom() (uint64, error) {
 	if e.rng == nil {
-		return 0, errors.New("UnsafeRandom is not supported by this environment")
+		return 0, errors.New("unsafe random is not supported")
 	}
 	buf := make([]byte, 8)
 	_, _ = e.rng.Read(buf) // Always succeeds, no need to check error
@@ -385,7 +385,7 @@ func runtimeBlockFromHeader(header *flow.Header) runtime.Block {
 // GetBlockAtHeight returns the block at the given height.
 func (e *hostEnv) GetBlockAtHeight(height uint64) (runtime.Block, bool, error) {
 	if e.ctx.Blocks == nil {
-		panic("GetBlockAtHeight is not supported by this environment")
+		return runtime.Block{}, false, errors.New("getting block information is not supported")
 	}
 
 	if e.ctx.BlockHeader != nil && height == e.ctx.BlockHeader.Height {
@@ -409,7 +409,7 @@ func (e *hostEnv) GetBlockAtHeight(height uint64) (runtime.Block, bool, error) {
 
 func (e *hostEnv) CreateAccount(payer runtime.Address) (address runtime.Address, err error) {
 	if e.transactionEnv == nil {
-		panic("CreateAccount is not supported by this environment")
+		return runtime.Address{}, errors.New("creating accounts is not supported")
 	}
 
 	// TODO: improve error passing https://github.com/onflow/cadence/issues/202
@@ -418,7 +418,7 @@ func (e *hostEnv) CreateAccount(payer runtime.Address) (address runtime.Address,
 
 func (e *hostEnv) AddAccountKey(address runtime.Address, publicKey []byte) error {
 	if e.transactionEnv == nil {
-		panic("AddAccountKey is not supported by this environment")
+		return errors.New("adding account keys is not supported")
 	}
 
 	// TODO: improve error passing https://github.com/onflow/cadence/issues/202
@@ -427,7 +427,7 @@ func (e *hostEnv) AddAccountKey(address runtime.Address, publicKey []byte) error
 
 func (e *hostEnv) RemoveAccountKey(address runtime.Address, index int) (publicKey []byte, err error) {
 	if e.transactionEnv == nil {
-		panic("RemoveAccountKey is not supported by this environment")
+		return nil, errors.New("removing account keys is not supported")
 	}
 
 	// TODO: improve error passing https://github.com/onflow/cadence/issues/202
@@ -436,7 +436,7 @@ func (e *hostEnv) RemoveAccountKey(address runtime.Address, index int) (publicKe
 
 func (e *hostEnv) UpdateAccountContractCode(address runtime.Address, name string, code []byte) (err error) {
 	if e.transactionEnv == nil {
-		panic("UpdateAccountContractCode is not supported by this environment")
+		return errors.New("updating account contract code is not supported")
 	}
 
 	// TODO: improve error passing https://github.com/onflow/cadence/issues/202
@@ -452,7 +452,7 @@ func (e *hostEnv) GetAccountContractCode(address runtime.Address, name string) (
 
 func (e *hostEnv) RemoveAccountContractCode(address runtime.Address, name string) (err error) {
 	if e.transactionEnv == nil {
-		panic("RemoveAccountContractCode is not supported by this environment")
+		return errors.New("removing account contracts is not supported")
 	}
 
 	// TODO: improve error passing https://github.com/onflow/cadence/issues/202
@@ -465,7 +465,7 @@ func (e *transactionEnv) UpdateAccountContractCode(address runtime.Address, name
 	// must be signed by the service account
 	if e.ctx.RestrictedDeploymentEnabled && !e.isAuthorizer(runtime.Address(e.ctx.Chain.ServiceAddress())) {
 		// TODO: improve error passing https://github.com/onflow/cadence/issues/202
-		return fmt.Errorf("code deployment requires authorization from the service account")
+		return errors.New("code deployment requires authorization from the service account")
 	}
 
 	return e.accounts.SetContract(name, accountAddress, code)
@@ -477,7 +477,7 @@ func (e *transactionEnv) RemoveAccountContractCode(address runtime.Address, name
 	// must be signed by the service account
 	if e.ctx.RestrictedDeploymentEnabled && !e.isAuthorizer(runtime.Address(e.ctx.Chain.ServiceAddress())) {
 		// TODO: improve error passing https://github.com/onflow/cadence/issues/202
-		return fmt.Errorf("code deployment requires authorization from the service account")
+		return errors.New("code deployment requires authorization from the service account")
 	}
 
 	return e.accounts.DeleteContract(name, accountAddress)
@@ -485,7 +485,7 @@ func (e *transactionEnv) RemoveAccountContractCode(address runtime.Address, name
 
 func (e *hostEnv) GetSigningAccounts() ([]runtime.Address, error) {
 	if e.transactionEnv == nil {
-		return nil, errors.New("GetSigningAccounts is not supported by this environment")
+		return nil, errors.New("getting signer accounts is not supported")
 	}
 
 	return e.transactionEnv.GetSigningAccounts(), nil


### PR DESCRIPTION
1. Scripts may attempt to emit events from scripts. This currently causes a crash, because the current implementation of `EmitEvent` assumes a transaction environment exists. Instead, disable event emission from scripts by returning an error
2. Improve the error returns from the FVM host environment, and make sure all errors that are caused by unavailability are user errors (i.e. don't panic, but return an error)