### PR TITLE
FVM: Improve parsing/checking safety check

### DIFF
--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -113,7 +113,8 @@ func (i *TransactionInvocator) Process(
 // This is a temporary measure.
 func (i *TransactionInvocator) safetyErrorCheck(err error) {
 
-	// Only runtime errors, in particular only parsing/checking errors
+	// Only consider runtime errors,
+	// in particular only consider parsing/checking errors
 
 	var runtimeErr runtime.Error
 	if !errors.As(err, &runtimeErr) {
@@ -126,8 +127,6 @@ func (i *TransactionInvocator) safetyErrorCheck(err error) {
 	}
 
 	// Only consider errors in deployed contracts.
-	// If the error is not in a address location,
-	// it must be an imported program error
 
 	checkerError, ok := parsingCheckingError.Err.(*sema.CheckerError)
 	if !ok {

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -1,11 +1,12 @@
 package fvm
 
 import (
+	"encoding/json"
 	"errors"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/sema"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm/state"
@@ -111,15 +112,54 @@ func (i *TransactionInvocator) Process(
 // Parsing and checking of deployed contracts should normally succeed.
 // This is a temporary measure.
 func (i *TransactionInvocator) safetyErrorCheck(err error) {
+
+	// Only runtime errors, in particular only parsing/checking errors
+
+	var runtimeErr runtime.Error
+	if !errors.As(err, &runtimeErr) {
+		return
+	}
+
 	var parsingCheckingError *runtime.ParsingCheckingError
 	if !errors.As(err, &parsingCheckingError) {
 		return
 	}
 
-	// serializing such large and complex objects to JSON
-	// causes stack overflow, spew works fine
-	spew.Config.DisableMethods = true
-	dump := spew.Sdump(parsingCheckingError)
+	// Only consider errors in deployed contracts.
+	// If the error is not in a address location,
+	// it must be an imported program error
 
-	i.logger.Error().Str("extended_error", dump).Msg("checking failed")
+	checkerError, ok := parsingCheckingError.Err.(*sema.CheckerError)
+	if !ok {
+		return
+	}
+
+	var foundImportedProgramError bool
+
+	for _, checkingErr := range checkerError.Errors {
+		importedProgramError, ok := checkingErr.(*sema.ImportedProgramError)
+		if !ok {
+			continue
+		}
+
+		_, ok = importedProgramError.Location.(common.AddressLocation)
+		if !ok {
+			continue
+		}
+
+		foundImportedProgramError = true
+		break
+	}
+
+	if !foundImportedProgramError {
+		return
+	}
+
+	codesJSON, _ := json.Marshal(runtimeErr.Codes)
+	programsJSON, _ := json.Marshal(runtimeErr.Programs)
+
+	i.logger.Error().
+		Str("codes", string(codesJSON)).
+		Str("programs", string(programsJSON)).
+		Msg("checking failed")
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/bsipos/thist v1.0.0
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/codahale/hdrhistogram v0.9.0 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/ethereum/go-ethereum v1.9.13
@@ -34,7 +33,7 @@ require (
 	github.com/libp2p/go-libp2p-transport-upgrader v0.3.0
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.12.1
+	github.com/onflow/cadence v0.12.3
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db
 	github.com/onflow/flow-go-sdk v0.14.0
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -705,6 +705,8 @@ github.com/onflow/cadence v0.4.0-beta1/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVH
 github.com/onflow/cadence v0.4.0/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNNmCTn3I=
 github.com/onflow/cadence v0.12.1 h1:1XzcjUHPYMj1NrIrYddoj0aE6vegRoX/99+cy8/RDPc=
 github.com/onflow/cadence v0.12.1/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
+github.com/onflow/cadence v0.12.3 h1:TLC34jmFJZgM7sBUIGjWAY5Tf6EeXVcUxCVFC9nb4cI=
+github.com/onflow/cadence v0.12.3/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db h1:iMuIiGtc9EIE8RVSXHH+qFf/yITMT1yXQtXjFK19OW4=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db/go.mod h1:yuFiT2+dZm42smG7XZQlMgZyb31hn5dvLrIDq0/PVc8=
 github.com/onflow/flow-ft/contracts v0.1.3/go.mod h1:IKe3yEurEKpg/J15q5WBlHkuMmt1iRECSHgnIa1gvRw=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.12.1
+	github.com/onflow/cadence v0.12.3
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.14.0
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -783,6 +783,8 @@ github.com/onflow/cadence v0.4.0-beta1/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVH
 github.com/onflow/cadence v0.4.0/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNNmCTn3I=
 github.com/onflow/cadence v0.12.1 h1:1XzcjUHPYMj1NrIrYddoj0aE6vegRoX/99+cy8/RDPc=
 github.com/onflow/cadence v0.12.1/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
+github.com/onflow/cadence v0.12.3 h1:TLC34jmFJZgM7sBUIGjWAY5Tf6EeXVcUxCVFC9nb4cI=
+github.com/onflow/cadence v0.12.3/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db h1:iMuIiGtc9EIE8RVSXHH+qFf/yITMT1yXQtXjFK19OW4=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db/go.mod h1:yuFiT2+dZm42smG7XZQlMgZyb31hn5dvLrIDq0/PVc8=
 github.com/onflow/flow-ft/contracts v0.1.3/go.mod h1:IKe3yEurEKpg/J15q5WBlHkuMmt1iRECSHgnIa1gvRw=


### PR DESCRIPTION
Improve the error safety check in the FVM: When a deployed contract is imported and it fails to parse or check, then log an extended error with all source programs, both in source code form and their ASTs.

The use of spew to dump all information in the error caused an infinite recursion in some cases.
JSON-serializing source codes and ASTs is fine, and what we are actually interested in.

This is a fix for the bug I discovered while updating the core contracts to Cadence v0.12.