### PR TITLE
Vishal/increasing msg size limits

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -184,8 +184,6 @@ func (fnb *FlowNodeBuilder) enqueueNetworkInit() {
 			libP2PNodeFactory,
 			fnb.Me.NodeID(),
 			fnb.Metrics.Network,
-			p2p.DefaultMaxUnicastMsgSize,
-			p2p.DefaultMaxPubSubMsgSize,
 			fnb.RootBlock.ID().String(),
 			fnb.MsgValidators...)
 

--- a/network/p2p/middleware.go
+++ b/network/p2p/middleware.go
@@ -32,11 +32,13 @@ const (
 )
 
 const (
+	mb = 1 << 20
+
 	// defines maximum message size in publish and multicast modes
-	DefaultMaxPubSubMsgSize = 1 << 21 // 2 mb
+	DefaultMaxPubSubMsgSize = 5 * mb // 5 mb
 
 	// defines maximum message size in unicast mode
-	DefaultMaxUnicastMsgSize = 5 * DefaultMaxPubSubMsgSize // 10 mb
+	DefaultMaxUnicastMsgSize = 10 * mb // 10 mb
 
 	// maximum time to wait for a unicast request to complete
 	DefaultUnicastTimeout = 2 * time.Second

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -261,6 +261,35 @@ func (m *MiddlewareTestSuite) TestMaxMessageSize_SendDirect() {
 	require.Error(m.Suite.T(), err)
 }
 
+// TestLargeMessageSize_SendDirect asserts that a large message can be unicasted successfully
+func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
+	first := 0
+	last := m.size - 1
+	firstNode := m.ids[first].NodeID
+	lastNode := m.ids[last].NodeID
+
+	msg := createMessage(firstNode, lastNode, "")
+
+	// creates a network payload with a size greater than the default max size
+	payload := networkPayloadFixture(m.T(), uint(p2p.DefaultMaxUnicastMsgSize)+1000)
+	event := &libp2pmessage.TestMessage{
+		Text: string(payload),
+	}
+
+	// set the message type to a known large message type
+	msg.Type = "messages.ChunkDataResponse"
+
+	codec := json.NewCodec()
+	encodedEvent, err := codec.Encode(event)
+	require.NoError(m.T(), err)
+
+	msg.Payload = encodedEvent
+
+	// sends a direct message from first node to the last node
+	err = m.mws[first].SendDirect(msg, lastNode)
+	require.NoError(m.Suite.T(), err)
+}
+
 // TestMaxMessageSize_Publish evaluates that invoking Publish method of the middleware on a message
 // size beyond the permissible publish message size returns an error.
 func (m *MiddlewareTestSuite) TestMaxMessageSize_Publish() {

--- a/network/test/testUtil.go
+++ b/network/test/testUtil.go
@@ -79,8 +79,6 @@ func GenerateMiddlewares(t *testing.T, logger zerolog.Logger, identities flow.Id
 			factory,
 			id.NodeID,
 			metrics,
-			p2p.DefaultMaxUnicastMsgSize,
-			p2p.DefaultMaxPubSubMsgSize,
 			rootBlockID)
 	}
 	return mws

--- a/network/validator/msgSizeValidator.go
+++ b/network/validator/msgSizeValidator.go
@@ -14,14 +14,14 @@ type maxMsgSizeLimitLookupFunc func(msg *message.Message) int
 
 // MsgSizeValidator validates the incoming unicast message size
 type MsgSizeValidator struct {
-	log zerolog.Logger
+	log        zerolog.Logger
 	lookupFunc maxMsgSizeLimitLookupFunc
 }
 
 // NewMsgSizeValidator creates and returns a new MsgSizeValidator
 func NewMsgSizeValidator(log zerolog.Logger, lookupFunc maxMsgSizeLimitLookupFunc) *MsgSizeValidator {
 	msgSizeValidator := &MsgSizeValidator{
-		log: log,
+		log:        log,
 		lookupFunc: lookupFunc,
 	}
 	return msgSizeValidator
@@ -29,8 +29,8 @@ func NewMsgSizeValidator(log zerolog.Logger, lookupFunc maxMsgSizeLimitLookupFun
 
 // Validate returns true if the message size is less than or equal to the maximum permissible message size
 func (msv *MsgSizeValidator) Validate(msg message.Message) bool {
-	size := msv.lookupFunc(&msg)
-	if size <= msg.Size() {
+	maxSize := msv.lookupFunc(&msg)
+	if msg.Size() <= maxSize {
 		return true
 	}
 
@@ -39,8 +39,8 @@ func (msv *MsgSizeValidator) Validate(msg message.Message) bool {
 		Hex("event_id", msg.EventID).
 		Str("event_type", msg.Type).
 		Str("channel_id", msg.ChannelID).
-		Int("size", size).
-		Msg("received message exceeded permissible message size")
+		Int("maxSize", maxSize).
+		Msg("received message exceeded permissible message maxSize")
 
 	return false
 }

--- a/network/validator/msgSizeValidator.go
+++ b/network/validator/msgSizeValidator.go
@@ -1,0 +1,46 @@
+package validator
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/network"
+	"github.com/onflow/flow-go/network/message"
+)
+
+var _ network.MessageValidator = &MsgSizeValidator{}
+
+// maxMsgSizeLimitLookupFunc a function to lookup the maximum permissible size for a given message
+type maxMsgSizeLimitLookupFunc func(msg *message.Message) int
+
+// MsgSizeValidator validates the incoming unicast message size
+type MsgSizeValidator struct {
+	log zerolog.Logger
+	lookupFunc maxMsgSizeLimitLookupFunc
+}
+
+// NewMsgSizeValidator creates and returns a new MsgSizeValidator
+func NewMsgSizeValidator(log zerolog.Logger, lookupFunc maxMsgSizeLimitLookupFunc) *MsgSizeValidator {
+	msgSizeValidator := &MsgSizeValidator{
+		log: log,
+		lookupFunc: lookupFunc,
+	}
+	return msgSizeValidator
+}
+
+// Validate returns true if the message size is less than or equal to the maximum permissible message size
+func (msv *MsgSizeValidator) Validate(msg message.Message) bool {
+	size := msv.lookupFunc(&msg)
+	if size <= msg.Size() {
+		return true
+	}
+
+	msv.log.Error().
+		Hex("sender", msg.OriginID).
+		Hex("event_id", msg.EventID).
+		Str("event_type", msg.Type).
+		Str("channel_id", msg.ChannelID).
+		Int("size", size).
+		Msg("received message exceeded permissible message size")
+
+	return false
+}


### PR DESCRIPTION
Two changes-
1. Increase the pusub message size to `5mb` from `2mb`
2. Allow the size of the unicast message type `messages.ChunkDataResponse` to be upto `5GB`
3. Changed `p2p.NewMiddleware` to no longer accept the pubsub and unicast message sizes as parameters but to just default to the constants defined in `middleware.go`.