### PR TITLE
Update to Go SDK v0.14.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/onflow/cadence v0.12.3
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.6.1-0.20210118202839-f8f9d9a04bcb
-	github.com/onflow/flow-go-sdk v0.14.0
+	github.com/onflow/flow-go-sdk v0.14.1
 	github.com/onflow/flow-go/crypto v0.12.0
 	github.com/onflow/flow/protobuf/go/flow v0.1.8
 	github.com/opentracing/opentracing-go v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -702,8 +702,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v0.6.1-0.20210118202839-f
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.6.1-0.20210118202839-f8f9d9a04bcb/go.mod h1:XI1LdeW0fkbPF0NjSu8Bd8kG1wSNfw9tO/claEXVs3E=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go-sdk v0.14.0 h1:P83cCi7SkqPUvl87k+9CDG1TMGbFOGvtrwQY9M/tKb4=
-github.com/onflow/flow-go-sdk v0.14.0/go.mod h1:h3FkeOdsmT+2t3dTvV0fhtw3Y2S2m4jvccZeHbg/i8Y=
+github.com/onflow/flow-go-sdk v0.14.1 h1:EiZRx4jL5T8nwWcC/AzKAyiui44lxYPJsiGucF1U600=
+github.com/onflow/flow-go-sdk v0.14.1/go.mod h1:h3FkeOdsmT+2t3dTvV0fhtw3Y2S2m4jvccZeHbg/i8Y=
 github.com/onflow/flow/protobuf/go/flow v0.1.8 h1:jBR8aXEL0MOh3gVJmCr0KYXmtG3JUBhzADonKkYE6oI=
 github.com/onflow/flow/protobuf/go/flow v0.1.8/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/onflow/cadence v0.12.3
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
-	github.com/onflow/flow-go-sdk v0.14.0
+	github.com/onflow/flow-go-sdk v0.14.1
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk
 	github.com/onflow/flow/protobuf/go/flow v0.1.8
 	github.com/plus3it/gorecurcopy v0.0.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -780,8 +780,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v0.6.1-0.20210118202839-f
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.6.1-0.20210118202839-f8f9d9a04bcb/go.mod h1:XI1LdeW0fkbPF0NjSu8Bd8kG1wSNfw9tO/claEXVs3E=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go-sdk v0.14.0 h1:P83cCi7SkqPUvl87k+9CDG1TMGbFOGvtrwQY9M/tKb4=
-github.com/onflow/flow-go-sdk v0.14.0/go.mod h1:h3FkeOdsmT+2t3dTvV0fhtw3Y2S2m4jvccZeHbg/i8Y=
+github.com/onflow/flow-go-sdk v0.14.1 h1:EiZRx4jL5T8nwWcC/AzKAyiui44lxYPJsiGucF1U600=
+github.com/onflow/flow-go-sdk v0.14.1/go.mod h1:h3FkeOdsmT+2t3dTvV0fhtw3Y2S2m4jvccZeHbg/i8Y=
 github.com/onflow/flow/protobuf/go/flow v0.1.8 h1:jBR8aXEL0MOh3gVJmCr0KYXmtG3JUBhzADonKkYE6oI=
 github.com/onflow/flow/protobuf/go/flow v0.1.8/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
Update to the latest version of the Go SDK. It fixes a bug with decoding Flow event type IDs