### PR TITLE
Enforce maxReceiptCount in block builder

### DIFF
--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -57,6 +57,7 @@ func NewBuilder(
 		maxInterval:       10 * time.Second,
 		maxSealCount:      100,
 		maxGuaranteeCount: 100,
+		maxReceiptCount:   200,
 		expiry:            flow.DefaultTransactionExpiry,
 	}
 
@@ -435,6 +436,11 @@ func (b *Builder) getInsertableReceipts(parentID flow.Identifier) ([]*flow.Execu
 
 	// sort receipts by block height
 	sortedReceipts := sortReceipts(receipts)
+
+	// don't collect more than maxReceiptCount receipts
+	if uint(len(sortedReceipts)) > b.cfg.maxReceiptCount {
+		sortedReceipts = sortedReceipts[:b.cfg.maxReceiptCount]
+	}
 
 	return sortedReceipts, nil
 }

--- a/module/builder/consensus/config.go
+++ b/module/builder/consensus/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	// the max number of seals to be included in a block proposal
 	maxSealCount      uint
 	maxGuaranteeCount uint
+	maxReceiptCount   uint
 	expiry            uint
 }
 
@@ -36,5 +37,11 @@ func WithMaxSealCount(maxSealCount uint) func(*Config) {
 func WithMaxGuaranteeCount(maxGuaranteeCount uint) func(*Config) {
 	return func(cfg *Config) {
 		cfg.maxGuaranteeCount = maxGuaranteeCount
+	}
+}
+
+func WithMaxReceiptCount(maxReceiptCount uint) func(*Config) {
+	return func(cfg *Config) {
+		cfg.maxReceiptCount = maxReceiptCount
 	}
 }


### PR DESCRIPTION
This PR addresses issue [5202](https://github.com/dapperlabs/flow-go/issues/5202)

It adds a limit to the number of receipts that can be included in a block.

The limit is set to 200 by default