### PR TITLE
[Sealing] Yurii/5198 emergency sealing

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -70,6 +70,7 @@ func main() {
 		chunkAlpha                             uint
 		requiredApprovalsForSealVerification   uint
 		requiredApprovalsForSealConstruction   uint
+		emergencySealing                       bool
 
 		err              error
 		mutableState     protocol.MutableState
@@ -109,6 +110,7 @@ func main() {
 			flags.UintVar(&chunkAlpha, "chunk-alpha", chmodule.DefaultChunkAssignmentAlpha, "number of verifiers that should be assigned to each chunk")
 			flags.UintVar(&requiredApprovalsForSealVerification, "required-verification-seal-approvals", validation.DefaultRequiredApprovalsForSealValidation, "minimum number of approvals that are required to verify a seal")
 			flags.UintVar(&requiredApprovalsForSealConstruction, "required-construction-seal-approvals", matching.DefaultRequiredApprovalsForSealConstruction, "minimum number of approvals that are required to verify a seal")
+			flags.BoolVar(&emergencySealing, "emergency-sealing-active", matching.DefaultEmergencySealingActive, "(de)activation of emergency sealing")
 		}).
 		Module("consensus node metrics", func(node *cmd.FlowNodeBuilder) error {
 			conMetrics = metrics.NewConsensusCollector(node.Tracer, node.MetricsRegisterer)
@@ -247,6 +249,7 @@ func main() {
 				chunkAssigner,
 				receiptValidator,
 				requiredApprovalsForSealConstruction,
+				emergencySealing,
 			)
 
 			receiptRequester.WithHandle(match.HandleReceipt)

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -643,7 +643,6 @@ func (e *Engine) sealableResults() ([]*flow.IncorporatedResult, error) {
 		}
 
 		if !checked {
-			//
 			block, err := e.headersDB.ByBlockID(incorporatedResult.IncorporatedBlockID)
 			if err != nil {
 				continue
@@ -653,7 +652,6 @@ func (e *Engine) sealableResults() ([]*flow.IncorporatedResult, error) {
 				continue
 			}
 		}
-
 		// add the result to the results that should be sealed
 		results = append(results, incorporatedResult)
 	}

--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -99,6 +99,7 @@ func (ms *MatchingSuite) SetupTest() {
 		requestTracker:                       NewRequestTracker(1, 3),
 		approvalRequestsThreshold:            10,
 		requiredApprovalsForSealConstruction: DefaultRequiredApprovalsForSealConstruction,
+		emergencySealingActive:               false,
 	}
 }
 
@@ -489,7 +490,8 @@ func (ms *MatchingSuite) TestSealableResultsInsufficientApprovals() {
 // When emergency sealing is active we should be able to identify and pick as candidates incorporated results
 // that are deep enough but still without verifications.
 func (ms *MatchingSuite) TestSealableResultsEmergencySealingMultipleCandidates() {
-
+	// make sure that emergency sealing is enabled
+	ms.matching.emergencySealingActive = true
 	emergencySealingCandidates := make([]flow.Identifier, 10)
 
 	lastFinalizedBlock := unittest.BlockWithParentFixture(ms.LatestFinalizedBlock.Header)
@@ -526,7 +528,6 @@ func (ms *MatchingSuite) TestSealableResultsEmergencySealingMultipleCandidates()
 	results, err = ms.matching.sealableResults()
 	ms.Require().NoError(err)
 	ms.Assert().Equal(len(emergencySealingCandidates), len(results), "expecting valid number of sealable results")
-
 }
 
 // TestRequestPendingReceipts tests matching.Engine.requestPendingReceipts():

--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -494,22 +494,19 @@ func (ms *MatchingSuite) TestSealableResultsEmergencySealingMultipleCandidates()
 	ms.matching.emergencySealingActive = true
 	emergencySealingCandidates := make([]flow.Identifier, 10)
 
-	lastFinalizedBlock := unittest.BlockWithParentFixture(ms.LatestFinalizedBlock.Header)
-	ms.Extend(&lastFinalizedBlock)
-
 	for i, _ := range emergencySealingCandidates {
-		block := unittest.BlockWithParentFixture(lastFinalizedBlock.Header)
-		emergencySealingCandidates[i] = block.ID()
+		block := unittest.BlockWithParentFixture(ms.LatestFinalizedBlock.Header)
 		receipt := unittest.ExecutionReceiptFixture(
 			unittest.WithExecutorID(ms.ExeID),
-			unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&lastFinalizedBlock))),
-		)
+			unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(ms.LatestFinalizedBlock))))
 		block.SetPayload(flow.Payload{
 			Receipts: []*flow.ExecutionReceipt{receipt},
 		})
+		// TODO: replace this with block.ID(), for now IncoroporatedBlockID == ExecutionResult.BlockID
+		emergencySealingCandidates[i] = receipt.ExecutionResult.BlockID
 		ms.Extend(&block)
 		delete(ms.PendingApprovals[receipt.ExecutionResult.ID()], uint64(len(receipt.ExecutionResult.Chunks)-1))
-		lastFinalizedBlock = block
+		ms.LatestFinalizedBlock = &block
 	}
 
 	// at this point we have results without enough approvals
@@ -519,15 +516,27 @@ func (ms *MatchingSuite) TestSealableResultsEmergencySealingMultipleCandidates()
 	ms.Assert().Empty(results, "expecting no sealable result")
 
 	// setup a new finalized block which is new enough that satisfies emergency sealing condition
-	newFinalizedBlock := unittest.BlockFixture()
-	newFinalizedBlock.Header.Height = lastFinalizedBlock.Header.Height + DefaultEmergencySealingThreshold
-	ms.LatestFinalizedBlock = newFinalizedBlock
+	for i := 0; i < DefaultEmergencySealingThreshold; i++ {
+		block := unittest.BlockWithParentFixture(ms.LatestFinalizedBlock.Header)
+		ms.Extend(&block)
+		ms.LatestFinalizedBlock = &block
+	}
 
 	// once emergency sealing is active and ERs are deep enough in chain
 	// we are expecting all stalled seals to be selected as candidates
 	results, err = ms.matching.sealableResults()
 	ms.Require().NoError(err)
-	ms.Assert().Equal(len(emergencySealingCandidates), len(results), "expecting valid number of sealable results")
+	ms.Require().Equal(len(emergencySealingCandidates), len(results), "expecting valid number of sealable results")
+	for _, id := range emergencySealingCandidates {
+		matched := false
+		for _, ir := range results {
+			if ir.IncorporatedBlockID == id {
+				matched = true
+				break
+			}
+		}
+		ms.Assert().True(matched, "expect to find IR with valid ID")
+	}
 }
 
 // TestRequestPendingReceipts tests matching.Engine.requestPendingReceipts():
@@ -546,7 +555,7 @@ func (ms *MatchingSuite) TestRequestPendingReceipts() {
 
 	// progress latest sealed and latest finalized:
 	ms.LatestSealedBlock = orderedBlocks[0]
-	ms.LatestFinalizedBlock = orderedBlocks[n-1]
+	ms.LatestFinalizedBlock = &orderedBlocks[n-1]
 
 	// Expecting all blocks to be requested: from sealed height + 1 up to (incl.) latest finalized
 	for i := 1; i < n; i++ {
@@ -587,7 +596,7 @@ func (ms *MatchingSuite) TestRequestPendingApprovals() {
 
 	// progress latest sealed and latest finalized:
 	ms.LatestSealedBlock = unsealedFinalizedBlocks[0]
-	ms.LatestFinalizedBlock = unsealedFinalizedBlocks[n-1]
+	ms.LatestFinalizedBlock = &unsealedFinalizedBlocks[n-1]
 
 	// add an unfinalized block; it shouldn't require an approval request
 	unfinalizedBlock := unittest.BlockWithParentFixture(parentBlock.Header)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -269,7 +269,8 @@ func ConsensusNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		seals,
 		assigner,
 		validator,
-		validation.DefaultRequiredApprovalsForSealValidation)
+		validation.DefaultRequiredApprovalsForSealValidation,
+		matching.DefaultEmergencySealingActive)
 	require.Nil(t, err)
 
 	return testmock.ConsensusNode{

--- a/module/validation/seal_validator_test.go
+++ b/module/validation/seal_validator_test.go
@@ -36,7 +36,7 @@ func (s *SealValidationSuite) TestSealValid() {
 	blockParent := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
 	receipt := unittest.ExecutionReceiptFixture(
 		unittest.WithExecutorID(s.ExeID),
-		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&s.LatestFinalizedBlock))),
+		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(s.LatestFinalizedBlock))),
 	)
 	blockParent.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{receipt},
@@ -61,7 +61,7 @@ func (s *SealValidationSuite) TestSealInvalidBlockID() {
 	blockParent := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
 	receipt := unittest.ExecutionReceiptFixture(
 		unittest.WithExecutorID(s.ExeID),
-		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&s.LatestFinalizedBlock))),
+		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(s.LatestFinalizedBlock))),
 	)
 	blockParent.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{receipt},
@@ -88,7 +88,7 @@ func (s *SealValidationSuite) TestSealInvalidAggregatedSigCount() {
 	blockParent := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
 	receipt := unittest.ExecutionReceiptFixture(
 		unittest.WithExecutorID(s.ExeID),
-		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&s.LatestFinalizedBlock))),
+		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(s.LatestFinalizedBlock))),
 	)
 	blockParent.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{receipt},
@@ -123,7 +123,7 @@ func (s *SealValidationSuite) TestSealEmergencySeal() {
 	blockParent := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
 	receipt := unittest.ExecutionReceiptFixture(
 		unittest.WithExecutorID(s.ExeID),
-		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&s.LatestFinalizedBlock))),
+		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(s.LatestFinalizedBlock))),
 	)
 	blockParent.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{receipt},
@@ -155,7 +155,7 @@ func (s *SealValidationSuite) TestSealInvalidChunkSignersCount() {
 	blockParent := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
 	receipt := unittest.ExecutionReceiptFixture(
 		unittest.WithExecutorID(s.ExeID),
-		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&s.LatestFinalizedBlock))),
+		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(s.LatestFinalizedBlock))),
 	)
 	blockParent.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{receipt},
@@ -182,7 +182,7 @@ func (s *SealValidationSuite) TestSealInvalidChunkSignaturesCount() {
 	blockParent := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
 	receipt := unittest.ExecutionReceiptFixture(
 		unittest.WithExecutorID(s.ExeID),
-		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&s.LatestFinalizedBlock))),
+		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(s.LatestFinalizedBlock))),
 	)
 	blockParent.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{receipt},
@@ -209,7 +209,7 @@ func (s *SealValidationSuite) TestSealInvalidChunkAssignment() {
 	blockParent := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
 	receipt := unittest.ExecutionReceiptFixture(
 		unittest.WithExecutorID(s.ExeID),
-		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&s.LatestFinalizedBlock))),
+		unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(s.LatestFinalizedBlock))),
 	)
 	blockParent.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{receipt},
@@ -235,7 +235,7 @@ func (s *SealValidationSuite) TestSealInvalidChunkAssignment() {
 func (s *SealValidationSuite) TestHighestSeal() {
 	// take finalized block and build a receipt for it
 	block3 := unittest.BlockWithParentFixture(s.LatestFinalizedBlock.Header)
-	block2Receipt := unittest.ReceiptForBlockFixture(&s.LatestFinalizedBlock)
+	block2Receipt := unittest.ReceiptForBlockFixture(s.LatestFinalizedBlock)
 	block3.SetPayload(flow.Payload{
 		Receipts: []*flow.ExecutionReceipt{block2Receipt},
 	})

--- a/utils/unittest/chain_suite.go
+++ b/utils/unittest/chain_suite.go
@@ -28,7 +28,7 @@ type BaseChainSuite struct {
 	// BLOCKS
 	RootBlock            flow.Block
 	LatestSealedBlock    flow.Block
-	LatestFinalizedBlock flow.Block
+	LatestFinalizedBlock *flow.Block
 	UnfinalizedBlock     flow.Block
 	Blocks               map[flow.Identifier]*flow.Block
 
@@ -101,13 +101,14 @@ func (bc *BaseChainSuite) SetupChain() {
 	// RootBlock <- LatestSealedBlock <- LatestFinalizedBlock <- UnfinalizedBlock
 	bc.RootBlock = BlockFixture()
 	bc.LatestSealedBlock = BlockWithParentFixture(bc.RootBlock.Header)
-	bc.LatestFinalizedBlock = BlockWithParentFixture(bc.LatestSealedBlock.Header)
+	latestFinalizedBlock := BlockWithParentFixture(bc.LatestSealedBlock.Header)
+	bc.LatestFinalizedBlock = &latestFinalizedBlock
 	bc.UnfinalizedBlock = BlockWithParentFixture(bc.LatestFinalizedBlock.Header)
 
 	bc.Blocks = make(map[flow.Identifier]*flow.Block)
 	bc.Blocks[bc.RootBlock.ID()] = &bc.RootBlock
 	bc.Blocks[bc.LatestSealedBlock.ID()] = &bc.LatestSealedBlock
-	bc.Blocks[bc.LatestFinalizedBlock.ID()] = &bc.LatestFinalizedBlock
+	bc.Blocks[bc.LatestFinalizedBlock.ID()] = bc.LatestFinalizedBlock
 	bc.Blocks[bc.UnfinalizedBlock.ID()] = &bc.UnfinalizedBlock
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~ SETUP PROTOCOL STATE ~~~~~~~~~~~~~~~~~~~~~~~~ //


### PR DESCRIPTION
This PR includes:
- implementation of emergency sealing
- cmd argument support, [issue](https://github.com/dapperlabs/flow-go/issues/5199)