### PR TITLE
Update sequence number and fees even if a tx fails

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -272,9 +272,7 @@ func (e *blockComputer) executeTransaction(
 			Msg("transaction executed successfully")
 	}
 
-	if tx.Err == nil {
-		collectionView.MergeView(txView)
-	}
+	collectionView.MergeView(txView)
 
 	return tx.Events, txResult, tx.GasUsed, nil
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -89,6 +89,7 @@ func (i *TransactionInvocator) Process(
 	)
 
 	if err != nil {
+		st.Rollback()
 		i.safetyErrorCheck(err)
 		return err
 	}

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -89,7 +89,10 @@ func (i *TransactionInvocator) Process(
 	)
 
 	if err != nil {
-		st.Rollback()
+		er := st.Rollback()
+		if er != nil {
+			panic(er)
+		}
 		i.safetyErrorCheck(err)
 		return err
 	}

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -96,6 +96,7 @@ func (i *TransactionInvocator) Process(
 
 	i.logger.Info().Str("txHash", proc.ID.String()).Msgf("(%d) ledger interactions used by transaction", st.InteractionUsed())
 
+	// TODO: this can cause issue for fee events
 	proc.Events = env.getEvents()
 	proc.Logs = env.getLogs()
 

--- a/fvm/transactionFeeDeductor.go
+++ b/fvm/transactionFeeDeductor.go
@@ -20,8 +20,6 @@ func (d *TransactionFeeDeductor) Process(
 	err := d.deductFees(vm, ctx, proc.Transaction, st)
 	if err != nil {
 		st.Commit()
-	} else {
-		st.Rollback()
 	}
 	return err
 }

--- a/fvm/transactionFeeDeductor.go
+++ b/fvm/transactionFeeDeductor.go
@@ -19,7 +19,10 @@ func (d *TransactionFeeDeductor) Process(
 ) error {
 	err := d.deductFees(vm, ctx, proc.Transaction, st)
 	if err == nil {
-		st.Commit()
+		er := st.Commit()
+		if er != nil {
+			panic(er)
+		}
 	}
 	return err
 }

--- a/fvm/transactionFeeDeductor.go
+++ b/fvm/transactionFeeDeductor.go
@@ -18,7 +18,7 @@ func (d *TransactionFeeDeductor) Process(
 	st *state.State,
 ) error {
 	err := d.deductFees(vm, ctx, proc.Transaction, st)
-	if err != nil {
+	if err == nil {
 		st.Commit()
 	}
 	return err

--- a/fvm/transactionFeeDeductor.go
+++ b/fvm/transactionFeeDeductor.go
@@ -17,7 +17,13 @@ func (d *TransactionFeeDeductor) Process(
 	proc *TransactionProcedure,
 	st *state.State,
 ) error {
-	return d.deductFees(vm, ctx, proc.Transaction, st)
+	err := d.deductFees(vm, ctx, proc.Transaction, st)
+	if err != nil {
+		st.Commit()
+	} else {
+		st.Rollback()
+	}
+	return err
 }
 
 func (d *TransactionFeeDeductor) deductFees(

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -61,7 +61,10 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	}
 
 	accountKey.SeqNumber++
-	st.Commit()
+	er := st.Commit()
+	if er != nil {
+		panic(er)
+	}
 
 	_, err = accounts.SetPublicKey(proposalKey.Address, proposalKey.KeyIndex, accountKey)
 	if err != nil {

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -61,6 +61,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	}
 
 	accountKey.SeqNumber++
+	st.Commit()
 
 	_, err = accounts.SetPublicKey(proposalKey.Address, proposalKey.KeyIndex, accountKey)
 	if err != nil {

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -77,7 +77,10 @@ func (d *TransactionStorageLimiter) Process(
 		}
 
 		if usage > capacity {
-			st.Rollback()
+			er := st.Rollback()
+			if er != nil {
+				panic(er)
+			}
 			return &StorageCapacityExceededError{
 				Address:         address,
 				StorageUsed:     usage,
@@ -86,6 +89,9 @@ func (d *TransactionStorageLimiter) Process(
 		}
 	}
 
-	st.Commit()
+	er := st.Commit()
+	if er != nil {
+		panic(er)
+	}
 	return nil
 }

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -77,6 +77,7 @@ func (d *TransactionStorageLimiter) Process(
 		}
 
 		if usage > capacity {
+			st.Rollback()
 			return &StorageCapacityExceededError{
 				Address:         address,
 				StorageUsed:     usage,
@@ -84,5 +85,7 @@ func (d *TransactionStorageLimiter) Process(
 			}
 		}
 	}
+
+	st.Commit()
 	return nil
 }


### PR DESCRIPTION
Test cases to add
- [ ] don't deduct fees if seq number is invalid 
- [ ] update sequence number as long as sequence number is valid even if tx fails
- [ ] deduct fees even if tx fails
- [ ] don't commit tx changes if storage fails.