### PR TITLE
reduced logging of re-requesting receipts

### DIFF
--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -950,11 +950,13 @@ func (e *Engine) requestPendingReceipts() error {
 	}
 
 	// request missing execution results, if sealed height is low enough
-	log.Info().
-		Int("finalized_blocks_without_result", len(missingBlocksOrderedByHeight)).
-		Msg("requesting receipts")
-	for _, blockID := range missingBlocksOrderedByHeight {
-		e.receiptRequester.EntityByID(blockID, filter.Any)
+	if len(missingBlocksOrderedByHeight) > 0 {
+		log.Info().
+			Int("finalized_blocks_without_result", len(missingBlocksOrderedByHeight)).
+			Msg("requesting receipts")
+		for _, blockID := range missingBlocksOrderedByHeight {
+			e.receiptRequester.EntityByID(blockID, filter.Any)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
On benchnet, we have a high frequency of these log messages, as they are logged even if no receipts are top be requested: https://console.cloud.google.com/logs/query;query=jsonPayload.instance.name%20:%20%22consensus%22%20%0AAND%20jsonPayload.message%20:%20%22%5C%22requesting%20receipts%5C%22%22;timeRange=2021-01-28T18:34:00.000Z%2F2021-01-28T19:05:00.000Z?project=flow-benchmark&query=%0A

<img width="197" alt="Screen Shot 2021-01-28 at 12 23 03 PM" src="https://user-images.githubusercontent.com/26322303/106194369-94bcf480-6163-11eb-9823-84b39799aa57.png">
