### PR TITLE
builder internal consistency check

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -309,6 +309,7 @@ func main() {
 			// initialize the block builder
 			var build module.Builder
 			build = builder.NewBuilder(
+				node.Logger,
 				node.Metrics.Mempool,
 				node.DB,
 				mutableState,

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -200,7 +200,7 @@ func createNode(
 	seals := stdmap.NewIncorporatedResultSeals(stdmap.WithLimit(sealLimit))
 
 	// initialize the block builder
-	build := builder.NewBuilder(metrics, db, fullState, headersDB, sealsDB, indexDB, blocksDB, resultsDB,
+	build := builder.NewBuilder(log, metrics, db, fullState, headersDB, sealsDB, indexDB, blocksDB, resultsDB,
 		guarantees, seals, receipts, tracer)
 
 	signer := &Signer{identity.ID()}

--- a/model/flow/aggregated_signature.go
+++ b/model/flow/aggregated_signature.go
@@ -1,8 +1,6 @@
 package flow
 
 import (
-	"sync"
-
 	"github.com/onflow/flow-go/crypto"
 )
 
@@ -10,7 +8,6 @@ import (
 // to the validity of an execution result chunk.
 // TODO: this will be replaced with BLS aggregation
 type AggregatedSignature struct {
-	sync.Mutex
 	// List of signatures
 	VerifierSignatures []crypto.Signature
 	// List of signer identifiers
@@ -19,45 +16,15 @@ type AggregatedSignature struct {
 
 // Len returns the number of signatures in the AggregatedSignature
 func (a *AggregatedSignature) Len() int {
-	a.Lock()
-	defer a.Unlock()
 	return len(a.VerifierSignatures)
 }
 
 // BySigner returns a signer's signature if it exists
 func (a *AggregatedSignature) BySigner(signerID Identifier) (*crypto.Signature, bool) {
-	a.Lock()
-	defer a.Unlock()
 	for index, id := range a.SignerIDs {
 		if id == signerID {
 			return &a.VerifierSignatures[index], true
 		}
 	}
 	return nil, false
-}
-
-// Add appends a signature.
-// ATTENTION: it does not check for duplicates
-func (a *AggregatedSignature) Add(signerID Identifier, signature crypto.Signature) {
-	a.Lock()
-	defer a.Unlock()
-	a.SignerIDs = append(a.SignerIDs, signerID)
-	a.VerifierSignatures = append(a.VerifierSignatures, signature)
-}
-
-// Copy returns a deep copy of the AggregatedSignature
-func (a *AggregatedSignature) Copy() AggregatedSignature {
-	a.Lock()
-	defer a.Unlock()
-
-	signatures := make([]crypto.Signature, len(a.VerifierSignatures))
-	copy(signatures, a.VerifierSignatures)
-
-	signers := make([]Identifier, len(a.SignerIDs))
-	copy(signers, a.SignerIDs)
-
-	return AggregatedSignature{
-		VerifierSignatures: signatures,
-		SignerIDs:          signers,
-	}
 }

--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -19,21 +19,21 @@ type IncorporatedResult struct {
 	// incorporated in the payload of IncorporatedBlockID.
 	Result *ExecutionResult
 
-	// aggregatedSignatures is a placeholder for attestation signatures
+	// chunkApprovals is a placeholder for attestation signatures
 	// collected for each chunk. It gets populated by the consensus matching
 	// engine when approvals are matched to execution results.
 	// This field is not exported (name doesn't start with a capital letter), so
 	// it is not used in calculating the ID and Checksum of the Incorporated
 	// Result (RLP encoding ignores private fields).
-	aggregatedSignatures     map[uint64]*AggregatedSignature
-	aggregatedSignaturesLock sync.Mutex
+	chunkApprovals     map[uint64]*approverSignatures
+	chunkApprovalsLock sync.Mutex
 }
 
 func NewIncorporatedResult(incorporatedBlockID Identifier, result *ExecutionResult) *IncorporatedResult {
 	return &IncorporatedResult{
-		IncorporatedBlockID:  incorporatedBlockID,
-		Result:               result,
-		aggregatedSignatures: make(map[uint64]*AggregatedSignature),
+		IncorporatedBlockID: incorporatedBlockID,
+		Result:              result,
+		chunkApprovals:      make(map[uint64]*approverSignatures),
 	}
 }
 
@@ -51,22 +51,21 @@ func (ir *IncorporatedResult) Checksum() Identifier {
 
 // GetChunkSignatures returns the AggregatedSignature for a specific chunk
 func (ir *IncorporatedResult) GetChunkSignatures(chunkIndex uint64) (*AggregatedSignature, bool) {
-	ir.aggregatedSignaturesLock.Lock()
-	defer ir.aggregatedSignaturesLock.Unlock()
-	ar, ok := ir.aggregatedSignatures[chunkIndex]
+	ir.chunkApprovalsLock.Lock()
+	defer ir.chunkApprovalsLock.Unlock()
+	s, ok := ir.chunkApprovals[chunkIndex]
 	if !ok {
 		return nil, false
 	}
-	sigCopy := ar.Copy()
-	return &sigCopy, true
+	return s.ToAggregatedSignature(), true
 }
 
 // GetSignature returns a signature by chunk index and signer ID
 func (ir *IncorporatedResult) GetSignature(chunkIndex uint64, signerID Identifier) (*crypto.Signature, bool) {
-	ir.aggregatedSignaturesLock.Lock()
-	defer ir.aggregatedSignaturesLock.Unlock()
+	ir.chunkApprovalsLock.Lock()
+	defer ir.chunkApprovalsLock.Unlock()
 
-	as, ok := ir.aggregatedSignatures[chunkIndex]
+	as, ok := ir.chunkApprovals[chunkIndex]
 	if !ok {
 		return nil, false
 	}
@@ -75,13 +74,13 @@ func (ir *IncorporatedResult) GetSignature(chunkIndex uint64, signerID Identifie
 
 // AddSignature adds a signature to the collection of AggregatedSignatures
 func (ir *IncorporatedResult) AddSignature(chunkIndex uint64, signerID Identifier, signature crypto.Signature) {
-	ir.aggregatedSignaturesLock.Lock()
-	defer ir.aggregatedSignaturesLock.Unlock()
+	ir.chunkApprovalsLock.Lock()
+	defer ir.chunkApprovalsLock.Unlock()
 
-	as, ok := ir.aggregatedSignatures[chunkIndex]
+	as, ok := ir.chunkApprovals[chunkIndex]
 	if !ok {
-		as = &AggregatedSignature{}
-		ir.aggregatedSignatures[chunkIndex] = as
+		as = NewApproverSignatures()
+		ir.chunkApprovals[chunkIndex] = as
 	}
 
 	as.Add(signerID, signature)
@@ -90,19 +89,75 @@ func (ir *IncorporatedResult) AddSignature(chunkIndex uint64, signerID Identifie
 // GetAggregatedSignatures returns all the aggregated signatures orderd by chunk
 // index
 func (ir *IncorporatedResult) GetAggregatedSignatures() []AggregatedSignature {
-	ir.aggregatedSignaturesLock.Lock()
-	defer ir.aggregatedSignaturesLock.Unlock()
+	ir.chunkApprovalsLock.Lock()
+	defer ir.chunkApprovalsLock.Unlock()
 
 	result := make([]AggregatedSignature, 0, len(ir.Result.Chunks))
 
 	for _, chunk := range ir.Result.Chunks {
-		as, ok := ir.aggregatedSignatures[chunk.Index]
+		as, ok := ir.chunkApprovals[chunk.Index]
 		if ok {
-			result = append(result, as.Copy())
+			result = append(result, *as.ToAggregatedSignature())
 		} else {
 			result = append(result, AggregatedSignature{})
 		}
 	}
 
 	return result
+}
+
+/* ************************************************************************ */
+
+// approverSignatures contains a set of of signatures from verifiers attesting
+// to the validity of an execution result chunk.
+// TODO: this will be replaced with BLS aggregation
+type approverSignatures struct {
+	// List of signatures
+	verifierSignatures []crypto.Signature
+	// List of signer identifiers
+	signerIDs []Identifier
+
+	signerIDSet map[Identifier]struct{}
+}
+
+func NewApproverSignatures() *approverSignatures {
+	return &approverSignatures{
+		verifierSignatures: nil,
+		signerIDs:          nil,
+		signerIDSet:        make(map[Identifier]struct{}),
+	}
+}
+
+func (as *approverSignatures) ToAggregatedSignature() *AggregatedSignature {
+	signatures := make([]crypto.Signature, len(as.verifierSignatures))
+	copy(signatures, as.verifierSignatures)
+
+	signers := make([]Identifier, len(as.signerIDs))
+	copy(signers, as.signerIDs)
+
+	return &AggregatedSignature{
+		VerifierSignatures: signatures,
+		SignerIDs:          signers,
+	}
+}
+
+// BySigner returns a signer's signature if it exists
+func (as *approverSignatures) BySigner(signerID Identifier) (*crypto.Signature, bool) {
+	for index, id := range as.signerIDs {
+		if id == signerID {
+			return &as.verifierSignatures[index], true
+		}
+	}
+	return nil, false
+}
+
+// Add appends a signature.
+// ATTENTION: it does not check for duplicates
+func (as *approverSignatures) Add(signerID Identifier, signature crypto.Signature) {
+	if _, found := as.signerIDSet[signerID]; found {
+		return
+	}
+	as.signerIDSet[signerID] = struct{}{}
+	as.signerIDs = append(as.signerIDs, signerID)
+	as.verifierSignatures = append(as.verifierSignatures, signature)
 }

--- a/model/flow/incorporated_result_test.go
+++ b/model/flow/incorporated_result_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestIncorporatedResultID checks that the ID and Checksum of the Incorporated
-// Result do not depend on the aggregatedSignatures placeholder.
+// Result do not depend on the chunkApprovals placeholder.
 func TestIncorporatedResultID(t *testing.T) {
 
 	ir := flow.NewIncorporatedResult(

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -401,6 +401,10 @@ func (b *Builder) getInsertableReceipts(parentID flow.Identifier) ([]*flow.Execu
 	// includedReceipts is a set of all receipts that are contained in unsealed blocks along the fork.
 	includedReceipts := make(map[flow.Identifier]struct{})
 
+	// for sanity check
+	knownResults := make(map[flow.Identifier]struct{})
+	knownResults[]
+
 	// loop through the fork backwards, from parent to last sealed (including),
 	// and keep track of blocks and receipts visited on the way.
 	sealedBlockID := sealed.ID()
@@ -444,6 +448,11 @@ func (b *Builder) getInsertableReceipts(parentID flow.Identifier) ([]*flow.Execu
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve reachable receipts from memool: %w", err)
 	}
+
+	// sanity check:
+
+
+
 
 	// don't collect more than maxReceiptCount receipts
 	if uint(len(receipts)) > b.cfg.maxReceiptCount {

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -373,6 +374,7 @@ func (bs *BuilderSuite) SetupTest() {
 
 	// initialize the builder
 	bs.build = NewBuilder(
+		zerolog.New(os.Stderr),
 		noopMetrics,
 		bs.db,
 		bs.state,

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -379,23 +379,17 @@ func (m *MutableState) receiptExtend(candidate *flow.Block) error {
 		// keep track of blocks we iterate over
 		forkBlocks[ancestorID] = ancestor
 
+		// keep track of all receipts in ancestors
 		index, err := m.index.ByBlockID(ancestorID)
 		if err != nil {
 			return fmt.Errorf("could not retrieve ancestor index (%x): %w", ancestorID, err)
 		}
-
-		// keep track of all receipts we iterate over
 		for _, recID := range index.ReceiptIDs {
 			forkLookup[recID] = struct{}{}
 		}
 
 		ancestorID = ancestor.ParentID
 	}
-
-	// prevReceiptHeight is used to check that receipts within a payload are
-	// sorted by block height. For each receipt in the payload, we check that
-	// its block height is greater or equal than the previous receipt.
-	var prevReceiptHeight uint64 = 0
 
 	// check each receipt included in the payload for duplication
 	for _, receipt := range payload.Receipts {
@@ -409,31 +403,21 @@ func (m *MutableState) receiptExtend(candidate *flow.Block) error {
 		forkLookup[receipt.ID()] = struct{}{}
 
 		// if the receipt is not for a block on this fork, error
-		header, ok := forkBlocks[receipt.ExecutionResult.BlockID]
-		if !ok {
+		if _, forBlockOnFork := forkBlocks[receipt.ExecutionResult.BlockID]; !forBlockOnFork {
 			return state.NewInvalidExtensionErrorf("payload includes receipt for block not on fork (%x)", receipt.ExecutionResult.BlockID)
 		}
+	}
 
-		err = m.receiptValidator.Validate([]*flow.ExecutionReceipt{receipt})
-		if err != nil {
-			// TODO: this might be not an error, potentially it can be solved by requesting more data and processing this receipt again
-			if errors.Is(err, storage.ErrNotFound) {
-				return state.NewInvalidExtensionErrorf("some entities referenced by receipt %v are missing: %w", receipt.ID(), err)
-			}
-
-			if engine.IsInvalidInputError(err) {
-				return state.NewInvalidExtensionErrorf("payload includes invalid receipt %v: %w", receipt.ID(), err)
-			}
-
-			return fmt.Errorf("unexpected payload validation error %w", err)
+	err = m.receiptValidator.Validate(payload.Receipts)
+	if err != nil {
+		// TODO: this might be not an error, potentially it can be solved by requesting more data and processing this receipt again
+		if errors.Is(err, storage.ErrNotFound) {
+			return state.NewInvalidExtensionErrorf("some entities referenced by receipts are missing: %w", err)
 		}
-
-		// check receipts are sorted by block height
-		if header.Height < prevReceiptHeight {
-			return state.NewInvalidExtensionError("payload receipts should be sorted by block height")
+		if engine.IsInvalidInputError(err) {
+			return state.NewInvalidExtensionErrorf("payload includes invalid receipts: %w", err)
 		}
-
-		prevReceiptHeight = header.Height
+		return fmt.Errorf("unexpected payload validation error %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
added sanity check to builder:
* it will fail if any receipt references a parent result that is not on the fork in the list of candidate seals to be included in the block 