### PR TITLE
FVM flag update - Contract Upgrade Enable

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -568,7 +568,8 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 	if fnb.RootChainID == flow.Testnet {
 		vmOpts = append(vmOpts,
 			fvm.WithRestrictedAccountCreation(false),
-			fvm.WithRestrictedDeployment(false),
+			fvm.WithRestrictedContractDeployment(false),
+			fvm.WithRestrictedContractUpdate(false),
 		)
 	}
 	fnb.FvmOptions = vmOpts

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -56,7 +56,8 @@ func NewBlockComputer(
 		vmCtx,
 		fvm.WithASTCache(systemChunkASTCache),
 		fvm.WithRestrictedAccountCreation(false),
-		fvm.WithRestrictedDeployment(false),
+		fvm.WithRestrictedContractDeployment(false),
+		fvm.WithRestrictedContractUpdate(false),
 		fvm.WithTransactionProcessors(fvm.NewTransactionInvocator(logger)),
 	)
 

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -41,7 +41,10 @@ func Bootstrap(
 
 func (b *BootstrapProcedure) Run(vm *VirtualMachine, ctx Context, ledger state.Ledger) error {
 	b.vm = vm
-	b.ctx = NewContextFromParent(ctx, WithRestrictedDeployment(false))
+	b.ctx = NewContextFromParent(ctx,
+		WithRestrictedContractDeployment(false),
+		WithRestrictedContractUpdate(false),
+	)
 	b.ledger = ledger
 
 	// initialize the account addressing state

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -9,22 +9,23 @@ import (
 
 // A Context defines a set of execution parameters used by the virtual machine.
 type Context struct {
-	Chain                            flow.Chain
-	ASTCache                         ASTCache
-	Blocks                           Blocks
-	Metrics                          *MetricsCollector
-	GasLimit                         uint64
-	EventCollectionByteSizeLimit     uint64
-	BlockHeader                      *flow.Header
-	ServiceAccountEnabled            bool
-	RestrictedAccountCreationEnabled bool
-	RestrictedDeploymentEnabled      bool
-	CadenceLoggingEnabled            bool
-	SetValueHandler                  SetValueHandler
-	SignatureVerifier                SignatureVerifier
-	TransactionProcessors            []TransactionProcessor
-	ScriptProcessors                 []ScriptProcessor
-	Logger                           zerolog.Logger
+	Chain                               flow.Chain
+	ASTCache                            ASTCache
+	Blocks                              Blocks
+	Metrics                             *MetricsCollector
+	GasLimit                            uint64
+	EventCollectionByteSizeLimit        uint64
+	BlockHeader                         *flow.Header
+	ServiceAccountEnabled               bool
+	RestrictedAccountCreationEnabled    bool
+	RestrictedContractDeploymentEnabled bool
+	RestrictedContractUpdateEnabled     bool
+	CadenceLoggingEnabled               bool
+	SetValueHandler                     SetValueHandler
+	SignatureVerifier                   SignatureVerifier
+	TransactionProcessors               []TransactionProcessor
+	ScriptProcessors                    []ScriptProcessor
+	Logger                              zerolog.Logger
 }
 
 // SetValueHandler receives a value written by the Cadence runtime.
@@ -56,19 +57,20 @@ const defaultEventCollectionByteSizeLimit = 128_000 // 128KB
 
 func defaultContext(logger zerolog.Logger) Context {
 	return Context{
-		Chain:                            flow.Mainnet.Chain(),
-		ASTCache:                         nil,
-		Blocks:                           nil,
-		Metrics:                          nil,
-		GasLimit:                         defaultGasLimit,
-		EventCollectionByteSizeLimit:     defaultEventCollectionByteSizeLimit,
-		BlockHeader:                      nil,
-		ServiceAccountEnabled:            true,
-		RestrictedAccountCreationEnabled: true,
-		RestrictedDeploymentEnabled:      true,
-		CadenceLoggingEnabled:            false,
-		SetValueHandler:                  nil,
-		SignatureVerifier:                NewDefaultSignatureVerifier(),
+		Chain:                               flow.Mainnet.Chain(),
+		ASTCache:                            nil,
+		Blocks:                              nil,
+		Metrics:                             nil,
+		GasLimit:                            defaultGasLimit,
+		EventCollectionByteSizeLimit:        defaultEventCollectionByteSizeLimit,
+		BlockHeader:                         nil,
+		ServiceAccountEnabled:               true,
+		RestrictedAccountCreationEnabled:    true,
+		RestrictedContractDeploymentEnabled: true,
+		RestrictedContractUpdateEnabled:     true,
+		CadenceLoggingEnabled:               false,
+		SetValueHandler:                     nil,
+		SignatureVerifier:                   NewDefaultSignatureVerifier(),
 		TransactionProcessors: []TransactionProcessor{
 			NewTransactionSignatureVerifier(AccountKeyWeightThreshold),
 			NewTransactionSequenceNumberChecker(),
@@ -166,11 +168,20 @@ func WithServiceAccount(enabled bool) Option {
 	}
 }
 
-// WithRestrictedDeployment enables or disables restricted contract deployment for a
+// WithRestrictedContractDeployment enables or disables restricted contract deployment for a
 // virtual machine context.
-func WithRestrictedDeployment(enabled bool) Option {
+func WithRestrictedContractDeployment(enabled bool) Option {
 	return func(ctx Context) Context {
-		ctx.RestrictedDeploymentEnabled = enabled
+		ctx.RestrictedContractDeploymentEnabled = enabled
+		return ctx
+	}
+}
+
+// WithRestrictedContractUpdate enables or disables restricted contract deployment for a
+// virtual machine context.
+func WithRestrictedContractUpdate(enabled bool) Option {
+	return func(ctx Context) Context {
+		ctx.RestrictedContractUpdateEnabled = enabled
 		return ctx
 	}
 }

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -459,7 +459,7 @@ func (e *transactionEnv) UpdateAccountContractCode(address runtime.Address, name
 	accountAddress := flow.Address(address)
 
 	// must be signed by the service account
-	if e.ctx.RestrictedDeploymentEnabled && !e.isAuthorizer(runtime.Address(e.ctx.Chain.ServiceAddress())) {
+	if e.ctx.RestrictedContractUpdateEnabled && !e.isAuthorizer(runtime.Address(e.ctx.Chain.ServiceAddress())) {
 		// TODO: improve error passing https://github.com/onflow/cadence/issues/202
 		return fmt.Errorf("code deployment requires authorization from the service account")
 	}
@@ -471,7 +471,7 @@ func (e *transactionEnv) RemoveAccountContractCode(address runtime.Address, name
 	accountAddress := flow.Address(address)
 
 	// must be signed by the service account
-	if e.ctx.RestrictedDeploymentEnabled && !e.isAuthorizer(runtime.Address(e.ctx.Chain.ServiceAddress())) {
+	if e.ctx.RestrictedContractUpdateEnabled && !e.isAuthorizer(runtime.Address(e.ctx.Chain.ServiceAddress())) {
 		// TODO: improve error passing https://github.com/onflow/cadence/issues/202
 		return fmt.Errorf("code deployment requires authorization from the service account")
 	}


### PR DESCRIPTION
Separates out the contract upgrade flag from the deployment flag, allowing us to configure updates differently than deployments.