### PR TITLE
Close database when using badger cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,7 @@ language/tools/vscode-extension/out/*
 # Mock generation
 **/gomock_reflect*/*
 
-
+# command line tool
+read-badger
+read-protocol-state
+remove-execution-fork

--- a/cmd/util/cmd/read-badger/cmd/blocks.go
+++ b/cmd/util/cmd/read-badger/cmd/blocks.go
@@ -21,7 +21,8 @@ var blocksCmd = &cobra.Command{
 	Use:   "blocks",
 	Short: "get a block by block ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)

--- a/cmd/util/cmd/read-badger/cmd/blocks.go
+++ b/cmd/util/cmd/read-badger/cmd/blocks.go
@@ -27,13 +27,15 @@ var blocksCmd = &cobra.Command{
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed block id")
+			log.Error().Err(err).Msg("malformed block id")
+			return
 		}
 
 		log.Info().Msgf("getting block by id: %v", blockID)
 		block, err := storages.Blocks.ByID(blockID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get block with id: %v", blockID)
+			log.Error().Err(err).Msgf("could not get block with id: %v", blockID)
+			return
 		}
 
 		common.PrettyPrintEntity(block)

--- a/cmd/util/cmd/read-badger/cmd/chunk_data_pack.go
+++ b/cmd/util/cmd/read-badger/cmd/chunk_data_pack.go
@@ -27,13 +27,15 @@ var chunkDataPackCmd = &cobra.Command{
 		log.Info().Msgf("got flag chunk id: %s", flagChunkID)
 		chunkID, err := flow.HexStringToIdentifier(flagChunkID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed chunk id")
+			log.Error().Err(err).Msg("malformed chunk id")
+			return
 		}
 
 		log.Info().Msgf("getting chunk data pack by chunk id: %v", chunkID)
 		chunkDataPack, err := storages.ChunkDataPacks.ByChunkID(chunkID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get chunk data pack with chunk id: %v", chunkID)
+			log.Error().Err(err).Msgf("could not get chunk data pack with chunk id: %v", chunkID)
+			return
 		}
 
 		common.PrettyPrintEntity(chunkDataPack)

--- a/cmd/util/cmd/read-badger/cmd/chunk_data_pack.go
+++ b/cmd/util/cmd/read-badger/cmd/chunk_data_pack.go
@@ -21,7 +21,8 @@ var chunkDataPackCmd = &cobra.Command{
 	Use:   "chunk-data",
 	Short: "get chunk data pack by chunk ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag chunk id: %s", flagChunkID)
 		chunkID, err := flow.HexStringToIdentifier(flagChunkID)

--- a/cmd/util/cmd/read-badger/cmd/cluster_blocks.go
+++ b/cmd/util/cmd/read-badger/cmd/cluster_blocks.go
@@ -39,7 +39,7 @@ var clusterBlocksCmd = &cobra.Command{
 		clusterBlocks := badger.NewClusterBlocks(db, chainID, headers, clusterPayloads)
 
 		if flagClusterBlockID != "" && flagHeight != 0 {
-			log.Fatal().Msg("provide either a --id or --height and not both")
+			log.Error().Msg("provide either a --id or --height and not both")
 			return
 		}
 
@@ -47,13 +47,15 @@ var clusterBlocksCmd = &cobra.Command{
 			log.Info().Msgf("got flag cluster block id: %s", flagClusterBlockID)
 			clusterBlockID, err := flow.HexStringToIdentifier(flagClusterBlockID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed cluster block id")
+				log.Error().Err(err).Msg("malformed cluster block id")
+				return
 			}
 
 			log.Info().Msgf("getting cluster block by id: %v", clusterBlockID)
 			clusterBlock, err := clusterBlocks.ByID(clusterBlockID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get cluster block with id: %v", clusterBlockID)
+				log.Error().Err(err).Msgf("could not get cluster block with id: %v", clusterBlockID)
+				return
 			}
 
 			common.PrettyPrint(clusterBlock)
@@ -64,7 +66,8 @@ var clusterBlocksCmd = &cobra.Command{
 			log.Info().Msgf("getting cluster block by height: %v", flagHeight)
 			clusterBlock, err := clusterBlocks.ByHeight(flagHeight)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get cluster block with height: %v", flagHeight)
+				log.Error().Err(err).Msgf("could not get cluster block with height: %v", flagHeight)
+				return
 			}
 
 			log.Info().Msgf("block id: %v", clusterBlock.ID())
@@ -72,6 +75,6 @@ var clusterBlocksCmd = &cobra.Command{
 			return
 		}
 
-		log.Fatal().Msg("provide either a --id or --height")
+		log.Error().Msg("provide either a --id or --height")
 	},
 }

--- a/cmd/util/cmd/read-badger/cmd/collections.go
+++ b/cmd/util/cmd/read-badger/cmd/collections.go
@@ -22,7 +22,8 @@ var collectionsCmd = &cobra.Command{
 	Use:   "collections",
 	Short: "get collection by collection or transaction ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		if flagCollectionID != "" {
 			log.Info().Msgf("got flag collection id: %s", flagCollectionID)

--- a/cmd/util/cmd/read-badger/cmd/collections.go
+++ b/cmd/util/cmd/read-badger/cmd/collections.go
@@ -29,13 +29,15 @@ var collectionsCmd = &cobra.Command{
 			log.Info().Msgf("got flag collection id: %s", flagCollectionID)
 			collectionID, err := flow.HexStringToIdentifier(flagCollectionID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed collection id")
+				log.Error().Err(err).Msg("malformed collection id")
+				return
 			}
 
 			log.Info().Msgf("getting collection by id: %v", collectionID)
 			collection, err := storages.Collections.ByID(collectionID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get collection with id: %v", collectionID)
+				log.Error().Err(err).Msgf("could not get collection with id: %v", collectionID)
+				return
 			}
 
 			common.PrettyPrintEntity(collection)
@@ -52,19 +54,21 @@ var collectionsCmd = &cobra.Command{
 			log.Info().Msgf("got flag transaction id: %s", flagTransactionID)
 			transactionID, err := flow.HexStringToIdentifier(flagTransactionID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed transaction id")
+				log.Error().Err(err).Msg("malformed transaction id")
+				return
 			}
 
 			log.Info().Msgf("getting collections by transaction id: %v", transactionID)
 			collections, err := storages.Collections.LightByTransactionID(transactionID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get collections for transaction id: %v", transactionID)
+				log.Error().Err(err).Msgf("could not get collections for transaction id: %v", transactionID)
+				return
 			}
 
 			common.PrettyPrintEntity(collections)
 			return
 		}
 
-		log.Fatal().Msg("missing flags --collection-id or --transaction-id")
+		log.Error().Msg("missing flags --collection-id or --transaction-id")
 	},
 }

--- a/cmd/util/cmd/read-badger/cmd/collections.go
+++ b/cmd/util/cmd/read-badger/cmd/collections.go
@@ -39,6 +39,12 @@ var collectionsCmd = &cobra.Command{
 			}
 
 			common.PrettyPrintEntity(collection)
+			// print each transaction id
+
+			for i, tx := range collection.Transactions {
+				log.Info().Msgf("transaction at index %v's ID: %v", i, tx.ID())
+			}
+
 			return
 		}
 

--- a/cmd/util/cmd/read-badger/cmd/commits.go
+++ b/cmd/util/cmd/read-badger/cmd/commits.go
@@ -18,7 +18,8 @@ var commitsCmd = &cobra.Command{
 	Use:   "commits",
 	Short: "get commit by block ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)

--- a/cmd/util/cmd/read-badger/cmd/commits.go
+++ b/cmd/util/cmd/read-badger/cmd/commits.go
@@ -24,13 +24,15 @@ var commitsCmd = &cobra.Command{
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed block id")
+			log.Error().Err(err).Msg("malformed block id")
+			return
 		}
 
 		log.Info().Msgf("getting commit by block id: %v", blockID)
 		commit, err := storages.Commits.ByBlockID(blockID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get commit for block id: %v", blockID)
+			log.Error().Err(err).Msgf("could not get commit for block id: %v", blockID)
+			return
 		}
 
 		log.Info().Msgf("commit: %x", commit)

--- a/cmd/util/cmd/read-badger/cmd/epoch_commit.go
+++ b/cmd/util/cmd/read-badger/cmd/epoch_commit.go
@@ -27,13 +27,15 @@ var epochCommitCmd = &cobra.Command{
 		log.Info().Msgf("got flag commit id: %s", flagEpochCommitID)
 		commitID, err := flow.HexStringToIdentifier(flagEpochCommitID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed epoch commit id")
+			log.Error().Err(err).Msg("malformed epoch commit id")
+			return
 		}
 
 		log.Info().Msgf("getting epoch commit by id: %v", commitID)
 		epochCommit, err := storages.EpochCommits.ByID(commitID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get epoch commit with id: %v", commitID)
+			log.Error().Err(err).Msgf("could not get epoch commit with id: %v", commitID)
+			return
 		}
 
 		log.Info().Msgf("epoch commit id: %v", epochCommit.ID())

--- a/cmd/util/cmd/read-badger/cmd/epoch_commit.go
+++ b/cmd/util/cmd/read-badger/cmd/epoch_commit.go
@@ -21,7 +21,8 @@ var epochCommitCmd = &cobra.Command{
 	Use:   "epoch-commit",
 	Short: "get epoch commit by ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag commit id: %s", flagEpochCommitID)
 		commitID, err := flow.HexStringToIdentifier(flagEpochCommitID)

--- a/cmd/util/cmd/read-badger/cmd/epoch_statuses.go
+++ b/cmd/util/cmd/read-badger/cmd/epoch_statuses.go
@@ -25,13 +25,15 @@ var epochStatusesCmd = &cobra.Command{
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed block id")
+			log.Error().Err(err).Msg("malformed block id")
+			return
 		}
 
 		log.Info().Msgf("getting epoch status by block id: %v", blockID)
 		epochStatus, err := storages.Statuses.ByBlockID(blockID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get epoch status for block id: %v", blockID)
+			log.Error().Err(err).Msgf("could not get epoch status for block id: %v", blockID)
+			return
 		}
 
 		common.PrettyPrint(epochStatus)

--- a/cmd/util/cmd/read-badger/cmd/epoch_statuses.go
+++ b/cmd/util/cmd/read-badger/cmd/epoch_statuses.go
@@ -19,7 +19,8 @@ var epochStatusesCmd = &cobra.Command{
 	Use:   "epoch-statuses",
 	Short: "get epoch statuses by block ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)

--- a/cmd/util/cmd/read-badger/cmd/events.go
+++ b/cmd/util/cmd/read-badger/cmd/events.go
@@ -25,7 +25,8 @@ var eventsCmd = &cobra.Command{
 	Use:   "events",
 	Short: "Read events from badger",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		if flagEventType != "" && flagTransactionID != "" {
 			log.Fatal().Msg("provide only one of --transaction-id or --event-type")

--- a/cmd/util/cmd/read-badger/cmd/events.go
+++ b/cmd/util/cmd/read-badger/cmd/events.go
@@ -29,27 +29,30 @@ var eventsCmd = &cobra.Command{
 		defer db.Close()
 
 		if flagEventType != "" && flagTransactionID != "" {
-			log.Fatal().Msg("provide only one of --transaction-id or --event-type")
+			log.Error().Msg("provide only one of --transaction-id or --event-type")
 			return
 		}
 
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed block id")
+			log.Error().Err(err).Msg("malformed block id")
+			return
 		}
 
 		if flagTransactionID != "" {
 			log.Info().Msgf("got flag transaction id: %s", flagTransactionID)
 			transactionID, err := flow.HexStringToIdentifier(flagTransactionID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed transaction id")
+				log.Error().Err(err).Msg("malformed transaction id")
+				return
 			}
 
 			log.Info().Msgf("getting events for block id: %v, transaction id: %v", blockID, transactionID)
 			events, err := storages.Events.ByBlockIDTransactionID(blockID, transactionID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get events for block id: %v, transaction id: %v", blockID, transactionID)
+				log.Error().Err(err).Msgf("could not get events for block id: %v, transaction id: %v", blockID, transactionID)
+				return
 			}
 
 			for _, event := range events {
@@ -69,7 +72,8 @@ var eventsCmd = &cobra.Command{
 				log.Info().Msgf("getting events for block id: %v, event type: %s", blockID, flagEventType)
 				events, err := storages.Events.ByBlockIDEventType(blockID, flow.EventType(flagEventType))
 				if err != nil {
-					log.Fatal().Err(err).Msgf("could not get events for block id: %v, event type: %s", blockID, flagEventType)
+					log.Error().Err(err).Msgf("could not get events for block id: %v, event type: %s", blockID, flagEventType)
+					return
 				}
 
 				for _, event := range events {
@@ -86,7 +90,8 @@ var eventsCmd = &cobra.Command{
 		log.Info().Msgf("getting events for block id: %v", blockID)
 		events, err := storages.Events.ByBlockID(blockID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get events for block id: %v", blockID)
+			log.Error().Err(err).Msgf("could not get events for block id: %v", blockID)
+			return
 		}
 
 		for _, event := range events {

--- a/cmd/util/cmd/read-badger/cmd/guarantees.go
+++ b/cmd/util/cmd/read-badger/cmd/guarantees.go
@@ -25,13 +25,15 @@ var guaranteesCmd = &cobra.Command{
 		log.Info().Msgf("got flag collection id: %s", flagCollectionID)
 		collectionID, err := flow.HexStringToIdentifier(flagCollectionID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed collection idenitifer")
+			log.Error().Err(err).Msg("malformed collection idenitifer")
+			return
 		}
 
 		log.Info().Msgf("getting guarantee by collection id: %v", collectionID)
 		guarantee, err := storages.Guarantees.ByCollectionID(collectionID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get guarantee for collection id: %v", collectionID)
+			log.Error().Err(err).Msgf("could not get guarantee for collection id: %v", collectionID)
+			return
 		}
 
 		common.PrettyPrintEntity(guarantee)

--- a/cmd/util/cmd/read-badger/cmd/guarantees.go
+++ b/cmd/util/cmd/read-badger/cmd/guarantees.go
@@ -19,7 +19,8 @@ var guaranteesCmd = &cobra.Command{
 	Use:   "guarantees",
 	Short: "get guarantees by collection ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag collection id: %s", flagCollectionID)
 		collectionID, err := flow.HexStringToIdentifier(flagCollectionID)

--- a/cmd/util/cmd/read-badger/cmd/receipts.go
+++ b/cmd/util/cmd/read-badger/cmd/receipts.go
@@ -21,7 +21,8 @@ var receiptsCmd = &cobra.Command{
 	Use:   "receipts",
 	Short: "get receipt by block or receipt ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		if flagBlockID != "" {
 			log.Info().Msgf("got flag block id: %s", flagBlockID)

--- a/cmd/util/cmd/read-badger/cmd/receipts.go
+++ b/cmd/util/cmd/read-badger/cmd/receipts.go
@@ -28,13 +28,14 @@ var receiptsCmd = &cobra.Command{
 			log.Info().Msgf("got flag block id: %s", flagBlockID)
 			blockID, err := flow.HexStringToIdentifier(flagBlockID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed block id")
+				log.Error().Err(err).Msg("malformed block id")
+				return
 			}
 
 			log.Info().Msgf("getting receipt by block id: %v", blockID)
 			receipt, err := storages.Receipts.ByBlockID(blockID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get receipt for block id: %v", blockID)
+				log.Error().Err(err).Msgf("could not get receipt for block id: %v", blockID)
 			}
 
 			common.PrettyPrintEntity(receipt)
@@ -45,19 +46,21 @@ var receiptsCmd = &cobra.Command{
 			log.Info().Msgf("got flag receipt id: %s", flagReceiptID)
 			receiptID, err := flow.HexStringToIdentifier(flagReceiptID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed receipt id")
+				log.Error().Err(err).Msg("malformed receipt id")
+				return
 			}
 
 			log.Info().Msgf("getting receipt by id: %v", receiptID)
 			receipt, err := storages.Receipts.ByID(receiptID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get receipt with id: %v", receiptID)
+				log.Error().Err(err).Msgf("could not get receipt with id: %v", receiptID)
+				return
 			}
 
 			common.PrettyPrintEntity(receipt)
 			return
 		}
 
-		log.Fatal().Msg("missing flags: --block-id or --receipt-id")
+		log.Error().Msg("missing flags: --block-id or --receipt-id")
 	},
 }

--- a/cmd/util/cmd/read-badger/cmd/results.go
+++ b/cmd/util/cmd/read-badger/cmd/results.go
@@ -21,7 +21,8 @@ var resultsCmd = &cobra.Command{
 	Use:   "results",
 	Short: "get result by block or result ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		if flagBlockID != "" {
 			log.Info().Msgf("got flag block id: %s", flagBlockID)

--- a/cmd/util/cmd/read-badger/cmd/results.go
+++ b/cmd/util/cmd/read-badger/cmd/results.go
@@ -28,13 +28,15 @@ var resultsCmd = &cobra.Command{
 			log.Info().Msgf("got flag block id: %s", flagBlockID)
 			blockID, err := flow.HexStringToIdentifier(flagBlockID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed block id")
+				log.Error().Err(err).Msg("malformed block id")
+				return
 			}
 
 			log.Info().Msgf("getting result by block id: %v", blockID)
 			result, err := storages.Results.ByBlockID(blockID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get result for block id: %v", blockID)
+				log.Error().Err(err).Msgf("could not get result for block id: %v", blockID)
+				return
 			}
 
 			common.PrettyPrintEntity(result)
@@ -45,19 +47,21 @@ var resultsCmd = &cobra.Command{
 			log.Info().Msgf("got flag result id: %s", flagResultID)
 			resultID, err := flow.HexStringToIdentifier(flagResultID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed result id")
+				log.Error().Err(err).Msg("malformed result id")
+				return
 			}
 
 			log.Info().Msgf("getting result by id: %v", resultID)
 			result, err := storages.Results.ByID(resultID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get result with id: %v", resultID)
+				log.Error().Err(err).Msgf("could not get result with id: %v", resultID)
+				return
 			}
 
 			common.PrettyPrintEntity(result)
 			return
 		}
 
-		log.Fatal().Msg("missing flags: --block-id or --result-id")
+		log.Error().Msg("missing flags: --block-id or --result-id")
 	},
 }

--- a/cmd/util/cmd/read-badger/cmd/seals.go
+++ b/cmd/util/cmd/read-badger/cmd/seals.go
@@ -21,7 +21,8 @@ var sealsCmd = &cobra.Command{
 	Use:   "seals",
 	Short: "get seals by block or seal ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		if flagSealID != "" && flagBlockID != "" {
 			log.Fatal().Msg("provide one of the flags --id or --block-id")

--- a/cmd/util/cmd/read-badger/cmd/seals.go
+++ b/cmd/util/cmd/read-badger/cmd/seals.go
@@ -25,7 +25,7 @@ var sealsCmd = &cobra.Command{
 		defer db.Close()
 
 		if flagSealID != "" && flagBlockID != "" {
-			log.Fatal().Msg("provide one of the flags --id or --block-id")
+			log.Error().Msg("provide one of the flags --id or --block-id")
 			return
 		}
 
@@ -33,13 +33,15 @@ var sealsCmd = &cobra.Command{
 			log.Info().Msgf("got flag seal id: %s", flagSealID)
 			sealID, err := flow.HexStringToIdentifier(flagSealID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed seal id")
+				log.Error().Err(err).Msg("malformed seal id")
+				return
 			}
 
 			log.Info().Msgf("getting seal by id: %v", sealID)
 			seal, err := storages.Seals.ByID(sealID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get seal with id: %v", sealID)
+				log.Error().Err(err).Msgf("could not get seal with id: %v", sealID)
+				return
 			}
 
 			common.PrettyPrintEntity(seal)
@@ -50,19 +52,21 @@ var sealsCmd = &cobra.Command{
 			log.Info().Msgf("got flag block id: %s", flagBlockID)
 			blockID, err := flow.HexStringToIdentifier(flagBlockID)
 			if err != nil {
-				log.Fatal().Err(err).Msg("malformed block id")
+				log.Error().Err(err).Msg("malformed block id")
+				return
 			}
 
 			log.Info().Msgf("getting seal by block id: %v", blockID)
 			seal, err := storages.Seals.ByBlockID(blockID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get seal for block id: %v", blockID)
+				log.Error().Err(err).Msgf("could not get seal for block id: %v", blockID)
+				return
 			}
 
 			common.PrettyPrintEntity(seal)
 			return
 		}
 
-		log.Fatal().Msg("missing flags --id or --block-id")
+		log.Error().Msg("missing flags --id or --block-id")
 	},
 }

--- a/cmd/util/cmd/read-badger/cmd/storages.go
+++ b/cmd/util/cmd/read-badger/cmd/storages.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/dgraph-io/badger/v2"
+
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/storage"
 )

--- a/cmd/util/cmd/read-badger/cmd/storages.go
+++ b/cmd/util/cmd/read-badger/cmd/storages.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"github.com/dgraph-io/badger/v2"
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/storage"
 )
 
-func InitStorages() *storage.All {
+func InitStorages() (*storage.All, *badger.DB) {
 	db := common.InitStorage(flagDatadir)
 	storages := common.InitStorages(db)
-	return storages
+	return storages, db
 }

--- a/cmd/util/cmd/read-badger/cmd/transaction_results.go
+++ b/cmd/util/cmd/read-badger/cmd/transaction_results.go
@@ -25,13 +25,15 @@ var transactionResultsCmd = &cobra.Command{
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed block id")
+			log.Error().Err(err).Msg("malformed block id")
+			return
 		}
 
 		log.Info().Msgf("getting transaction results by block id: %v", blockID)
 		block, err := storages.Blocks.ByID(blockID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("could not get block with id: %w")
+			log.Error().Err(err).Msg("could not get block with id: %w")
+			return
 		}
 
 		txIDs := make([]flow.Identifier, 0)
@@ -39,7 +41,8 @@ var transactionResultsCmd = &cobra.Command{
 		for _, guarantee := range block.Payload.Guarantees {
 			collection, err := storages.Collections.ByID(guarantee.CollectionID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get collection with id: %v", guarantee.CollectionID)
+				log.Error().Err(err).Msgf("could not get collection with id: %v", guarantee.CollectionID)
+				return
 			}
 			for _, tx := range collection.Transactions {
 				txIDs = append(txIDs, tx.ID())
@@ -49,7 +52,8 @@ var transactionResultsCmd = &cobra.Command{
 		for _, txID := range txIDs {
 			transactionResult, err := storages.TransactionResults.ByBlockIDTransactionID(blockID, txID)
 			if err != nil {
-				log.Fatal().Err(err).Msgf("could not get transaction result for block id and transaction id: %v", txID)
+				log.Error().Err(err).Msgf("could not get transaction result for block id and transaction id: %v", txID)
+				return
 			}
 			common.PrettyPrintEntity(transactionResult)
 		}

--- a/cmd/util/cmd/read-badger/cmd/transaction_results.go
+++ b/cmd/util/cmd/read-badger/cmd/transaction_results.go
@@ -19,7 +19,8 @@ var transactionResultsCmd = &cobra.Command{
 	Use:   "transaction-results",
 	Short: "get transaction-result by block ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag block id: %s", flagBlockID)
 		blockID, err := flow.HexStringToIdentifier(flagBlockID)

--- a/cmd/util/cmd/read-badger/cmd/transactions.go
+++ b/cmd/util/cmd/read-badger/cmd/transactions.go
@@ -25,13 +25,15 @@ var transactionsCmd = &cobra.Command{
 		log.Info().Msgf("got flag transaction id: %s", flagTransactionID)
 		transactionID, err := flow.HexStringToIdentifier(flagTransactionID)
 		if err != nil {
-			log.Fatal().Err(err).Msg("malformed transaction id")
+			log.Error().Err(err).Msg("malformed transaction id")
+			return
 		}
 
 		log.Info().Msgf("getting transaction by id: %v", transactionID)
 		tx, err := storages.Transactions.ByID(transactionID)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("could not get transaction with id: %v", transactionID)
+			log.Error().Err(err).Msgf("could not get transaction with id: %v", transactionID)
+			return
 		}
 
 		common.PrettyPrintEntity(tx)

--- a/cmd/util/cmd/read-badger/cmd/transactions.go
+++ b/cmd/util/cmd/read-badger/cmd/transactions.go
@@ -19,7 +19,8 @@ var transactionsCmd = &cobra.Command{
 	Use:   "transactions",
 	Short: "get transaction by ID",
 	Run: func(cmd *cobra.Command, args []string) {
-		storages := InitStorages()
+		storages, db := InitStorages()
+		defer db.Close()
 
 		log.Info().Msgf("got flag transaction id: %s", flagTransactionID)
 		transactionID, err := flow.HexStringToIdentifier(flagTransactionID)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/codahale/hdrhistogram v0.9.0 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
+	github.com/dgraph-io/badger v1.6.1
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/ethereum/go-ethereum v1.9.13
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/codahale/hdrhistogram v0.9.0 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
-	github.com/dgraph-io/badger v1.6.1
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/ethereum/go-ethereum v1.9.13
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803


### PR DESCRIPTION
## Problem
The read-badger tool didn't close the database after finish executing the commands. 
This results a dirty way of leaving the database open. It is fine if we re-execute the commandline again, because we truncate the log. However, the node software have truncate log option as `false` by default, which causes the node software unable to start up.

## Fix
This PR fixes the badger related tools to close database properly