### PR TITLE
Storage reporter output directory fix

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -33,7 +33,7 @@ func extractExecutionState(dir string, targetHash flow.StateCommitment, outputDi
 
 	newState, err := led.ExportCheckpointAt(targetHash,
 		[]ledger.Migration{},
-		[]ledger.Reporter{migrations.StorageReporter{Log: log}},
+		[]ledger.Reporter{migrations.StorageReporter{Log: log, OutputDir: outputDir}},
 		complete.DefaultPathFinderVersion,
 		outputDir,
 		wal.RootCheckpointFilename)

--- a/cmd/util/ledger/migrations/storage_reporter.go
+++ b/cmd/util/ledger/migrations/storage_reporter.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path"
 	"time"
 
 	"github.com/onflow/cadence/runtime/common"
@@ -19,15 +20,16 @@ import (
 // iterates through registers keeping a map of register sizes
 // reports on storage metrics
 type StorageReporter struct {
-	Log zerolog.Logger
+	Log       zerolog.Logger
+	OutputDir string
 }
 
-func filename() string {
-	return fmt.Sprintf("./storage_report_%d.csv", int32(time.Now().Unix()))
+func (r StorageReporter) filename() string {
+	return path.Join(r.OutputDir, fmt.Sprintf("storage_report_%d.csv", int32(time.Now().Unix())))
 }
 
 func (r StorageReporter) Report(payload []ledger.Payload) error {
-	fn := filename()
+	fn := r.filename()
 	r.Log.Info().Msgf("Running Storage Reporter. Saving output to %s.", fn)
 
 	f, err := os.Create(fn)


### PR DESCRIPTION
Running the test would create a `cmd/util/cmd/execution-state-extract/storage_report_*.csv` file. This was produced by the storage reporter.

By changing the output dir of the storage reporter to the output dir of the migrated root checkpoint (which is more sensible as well) the tests produce the `storage_report_*.csv` in a temp folder (along with the other outputs).