### PR TITLE
Revert update of v0.13 to Cadence v0.10.6, update to a minimal improvement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/libp2p/go-libp2p-transport-upgrader v0.3.0
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.10.6
+	github.com/onflow/cadence v0.10.4-hamt-update
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db
 	github.com/onflow/flow-go-sdk v0.12.2
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/onflow/cadence v0.4.0-beta1/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVH
 github.com/onflow/cadence v0.4.0/go.mod h1:gaPtSctdMzT5NAoJgzsRuwUkdgRswVHsRXFNNmCTn3I=
 github.com/onflow/cadence v0.10.2 h1:uBFhdlp0blYCddZTrnCjbLEVl/aYq1/9iP949KxzfbI=
 github.com/onflow/cadence v0.10.2/go.mod h1:ORAnWydDsrefAUazeD1g+l7vjNwEuJAcZ7bMz1KnSbg=
-github.com/onflow/cadence v0.10.6 h1:L2EsNluFJsqsoydYd/rTT6fEieDUTmEcDhpijAs4dFE=
-github.com/onflow/cadence v0.10.6/go.mod h1:JnvSkMZS1luAvqcSSm5WRLaU2oy2b74Xj1sj++hdY54=
+github.com/onflow/cadence v0.10.4-hamt-update h1:mvAzvOctJ8Vz7NdDTkf6lgsmJ1oT5B09XmCvlZE9Hoc=
+github.com/onflow/cadence v0.10.4-hamt-update/go.mod h1:JnvSkMZS1luAvqcSSm5WRLaU2oy2b74Xj1sj++hdY54=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db h1:iMuIiGtc9EIE8RVSXHH+qFf/yITMT1yXQtXjFK19OW4=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.3.1-0.20201122012505-4061d358b8db/go.mod h1:yuFiT2+dZm42smG7XZQlMgZyb31hn5dvLrIDq0/PVc8=
 github.com/onflow/flow-ft/contracts v0.1.3/go.mod h1:IKe3yEurEKpg/J15q5WBlHkuMmt1iRECSHgnIa1gvRw=


### PR DESCRIPTION
Revert #347. Instead, apply a minimal improvement: 
https://github.com/onflow/cadence/compare/v0.10.4...v0.10.4-hamt-update

See https://axiomzen.slack.com/archives/CEXKUH74G/p1612129623255100