### PR TITLE
NET: Yahya/5258-engine-processing-time

### DIFF
--- a/module/metrics.go
+++ b/module/metrics.go
@@ -29,6 +29,9 @@ type NetworkMetrics interface {
 	// QueueDuration tracks the time spent by a message with the given priority in the queue
 	QueueDuration(duration time.Duration, priority int)
 
+	// InboundProcessDuration tracks the time a queue worker blocked by an engine for processing an incoming message.
+	InboundProcessDuration(topic string, duration time.Duration)
+
 	// OutboundConnections updates the metric tracking the number of outbound connections of this node
 	OutboundConnections(connectionCount uint)
 

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -29,7 +29,7 @@ type NetworkMetrics interface {
 	// QueueDuration tracks the time spent by a message with the given priority in the queue
 	QueueDuration(duration time.Duration, priority int)
 
-	// InboundProcessDuration tracks the time a queue worker blocked by an engine for processing an incoming message.
+	// InboundProcessDuration tracks the time a queue worker blocked by an engine for processing an incoming message on specified topic (i.e., channel).
 	InboundProcessDuration(topic string, duration time.Duration)
 
 	// OutboundConnections updates the metric tracking the number of outbound connections of this node

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -71,7 +71,7 @@ func NewNetworkCollector() *NetworkCollector {
 		inboundProcessTime: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespaceNetwork,
 			Subsystem: subsystemQueue,
-			Name:      "inbound_message_process_time",
+			Name:      "engine_message_processing_time_seconds",
 			Help:      "duration [seconds; measured with float64 precision] of how long a queue worker blocked for an engine processing message",
 		}, []string{LabelChannel}),
 

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -122,7 +122,7 @@ func (nc *NetworkCollector) QueueDuration(duration time.Duration, priority int) 
 	nc.queueDuration.WithLabelValues(strconv.Itoa(priority)).Observe(duration.Seconds())
 }
 
-// InboundProcessDuration tracks the time a queue worker blocked by an engine for processing an incoming message.
+// InboundProcessDuration tracks the time a queue worker blocked by an engine for processing an incoming message on specified topic (i.e., channel).
 func (nc *NetworkCollector) InboundProcessDuration(topic string, duration time.Duration) {
 	nc.inboundProcessTime.WithLabelValues(topic).Add(duration.Seconds())
 }

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -68,10 +68,10 @@ func NewNetworkCollector() *NetworkCollector {
 			Buckets:   []float64{0.01, 0.1, 0.5, 1, 2, 5}, // 10ms, 100ms, 500ms, 1s, 2s, 5s
 		}, []string{LabelPriority}),
 
-		inboundProcessTime: prometheus.NewCounterVec(prometheus.CounterOpts{
+		inboundProcessTime: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespaceNetwork,
 			Subsystem: subsystemQueue,
-			Name:      "inbound_process_time",
+			Name:      "inbound_message_process_time",
 			Help:      "duration [seconds; measured with float64 precision] of how long a queue worker blocked for an engine processing message",
 		}, []string{LabelChannel}),
 

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -20,6 +20,7 @@ func (nc *NoopCollector) NetworkDuplicateMessagesDropped(topic string, messageTy
 func (nc *NoopCollector) MessageAdded(priority int)                                              {}
 func (nc *NoopCollector) MessageRemoved(priority int)                                            {}
 func (nc *NoopCollector) QueueDuration(duration time.Duration, priority int)                     {}
+func (nc *NoopCollector) InboundProcessDuration(topic string, duration time.Duration)            {}
 func (nc *NoopCollector) MessageSent(engine string, message string)                              {}
 func (nc *NoopCollector) MessageReceived(engine string, message string)                          {}
 func (nc *NoopCollector) MessageHandled(engine string, message string)                           {}
@@ -45,7 +46,7 @@ func (nc *NoopCollector) CacheEntries(resource string, entries uint)            
 func (nc *NoopCollector) CacheHit(resource string)                                               {}
 func (nc *NoopCollector) CacheMiss(resource string)                                              {}
 func (nc *NoopCollector) MempoolEntries(resource string, entries uint)                           {}
-func (nm *NoopCollector) Register(resource string, entriesFunc EntriesFunc) error                { return nil }
+func (nc *NoopCollector) Register(resource string, entriesFunc EntriesFunc) error                { return nil }
 func (nc *NoopCollector) HotStuffBusyDuration(duration time.Duration, event string)              {}
 func (nc *NoopCollector) HotStuffIdleDuration(duration time.Duration)                            {}
 func (nc *NoopCollector) HotStuffWaitDuration(duration time.Duration, event string)              {}
@@ -83,7 +84,7 @@ func (nc *NoopCollector) ExecutionStateReadsPerBlock(reads uint64)              
 func (nc *NoopCollector) ExecutionStateStorageDiskTotal(bytes int64)                             {}
 func (nc *NoopCollector) ExecutionStorageStateCommitment(bytes int64)                            {}
 func (nc *NoopCollector) ExecutionLastExecutedBlockHeight(height uint64)                         {}
-func (ec *NoopCollector) ExecutionTotalExecutedTransactions(numberOfTx int)                      {}
+func (nc *NoopCollector) ExecutionTotalExecutedTransactions(numberOfTx int)                      {}
 func (nc *NoopCollector) ForestApproxMemorySize(bytes uint64)                                    {}
 func (nc *NoopCollector) ForestNumberOfTrees(number uint64)                                      {}
 func (nc *NoopCollector) LatestTrieRegCount(number uint64)                                       {}

--- a/module/mock/network_metrics.go
+++ b/module/mock/network_metrics.go
@@ -18,6 +18,11 @@ func (_m *NetworkMetrics) InboundConnections(connectionCount uint) {
 	_m.Called(connectionCount)
 }
 
+// InboundProcessDuration provides a mock function with given fields: topic, duration
+func (_m *NetworkMetrics) InboundProcessDuration(topic string, duration time.Duration) {
+	_m.Called(topic, duration)
+}
+
 // MessageAdded provides a mock function with given fields: priority
 func (_m *NetworkMetrics) MessageAdded(priority int) {
 	_m.Called(priority)

--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -437,7 +438,10 @@ func (n *Network) queueSubmitFunc(message interface{}) {
 		return
 	}
 
-	// submit the message to the engine synchronously
+	// submits the message to the engine synchronously and
+	// tracks its processing time.
+	startTimestamp := time.Now()
+
 	err = eng.Process(qm.SenderID, qm.Payload)
 	if err != nil {
 		n.logger.Error().
@@ -446,4 +450,6 @@ func (n *Network) queueSubmitFunc(message interface{}) {
 			Str("sender_id", qm.SenderID.String()).
 			Msg("failed to process message")
 	}
+
+	n.metrics.InboundProcessDuration(qm.Target.String(), time.Since(startTimestamp))
 }


### PR DESCRIPTION
This PR implements adding a _counter_ metric named `network_queue_inbound_message_process_time` which captures the _total_ time queue workers are blocked for an engine for processing the incoming messages. The metric defines a time series with different labels one for each channel (i.e., topic). Hence, `network_queue_inbound_message_process_time_X` represents the total time queue workers blocked for engines on channel `X` processing their incoming messages.