### PR TITLE
Martin/5260 consensus matching metrics

### DIFF
--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module/metrics"
 	mockmodule "github.com/onflow/flow-go/module/mock"
+	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/network/mocknetwork"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -73,6 +74,7 @@ func (ms *MatchingSuite) SetupTest() {
 	unit := engine.NewUnit()
 	log := zerolog.New(os.Stderr)
 	metrics := metrics.NewNoopCollector()
+	tracer := trace.NewNoopTracer()
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~ SETUP MATCHING ENGINE ~~~~~~~~~~~~~~~~~~~~~~~ //
 	ms.requester = new(mockmodule.Requester)
@@ -81,6 +83,7 @@ func (ms *MatchingSuite) SetupTest() {
 	ms.matching = &Engine{
 		unit:                                 unit,
 		log:                                  log,
+		tracer:                               tracer,
 		engineMetrics:                        metrics,
 		mempool:                              metrics,
 		metrics:                              metrics,

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -143,6 +143,9 @@ type ConsensusMetrics interface {
 
 	// EmergencySeal increments the number of seals that were created in emergency mode
 	EmergencySeal()
+
+	// IncreaseOnReceiptDuration increases the number of seconds spent processing receipts
+	IncreaseOnReceiptDuration(duration time.Duration)
 }
 
 type VerificationMetrics interface {

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -146,6 +146,9 @@ type ConsensusMetrics interface {
 
 	// IncreaseOnReceiptDuration increases the number of seconds spent processing receipts
 	IncreaseOnReceiptDuration(duration time.Duration)
+
+	// IncreaseOnApprovalDuration increases the number of seconds spent processing approval
+	IncreaseOnApprovalDuration(duration time.Duration)
 }
 
 type VerificationMetrics interface {

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -141,14 +141,14 @@ type ConsensusMetrics interface {
 	// EmergencySeal increments the number of seals that were created in emergency mode
 	EmergencySeal()
 
-	// IncreaseOnReceiptDuration increases the number of seconds spent processing receipts
-	IncreaseOnReceiptDuration(duration time.Duration)
+	// OnReceiptProcessingDuration records the number of seconds spent processing a receipt
+	OnReceiptProcessingDuration(duration time.Duration)
 
-	// IncreaseOnApprovalDuration increases the number of seconds spent processing approval
-	IncreaseOnApprovalDuration(duration time.Duration)
+	// OnApprovalProcessingDuration records the number of seconds spent processing an approval
+	OnApprovalProcessingDuration(duration time.Duration)
 
-	// IncreaseCheckSealingDuration records absolute time for the full sealing check by the consensus match engine
-	IncreaseCheckSealingDuration(duration time.Duration)
+	// CheckSealingDuration records absolute time for the full sealing check by the consensus match engine
+	CheckSealingDuration(duration time.Duration)
 }
 
 type VerificationMetrics interface {

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -138,9 +138,6 @@ type ConsensusMetrics interface {
 	// FinishBlockToSeal reports Metrics C4: Block Received by CCL → Block Seal in finalized block
 	FinishBlockToSeal(blockID flow.Identifier)
 
-	// CheckSealingDuration records absolute time for the full sealing check by the consensus match engine
-	CheckSealingDuration(duration time.Duration)
-
 	// EmergencySeal increments the number of seals that were created in emergency mode
 	EmergencySeal()
 
@@ -149,6 +146,9 @@ type ConsensusMetrics interface {
 
 	// IncreaseOnApprovalDuration increases the number of seconds spent processing approval
 	IncreaseOnApprovalDuration(duration time.Duration)
+
+	// IncreaseCheckSealingDuration records absolute time for the full sealing check by the consensus match engine
+	IncreaseCheckSealingDuration(duration time.Duration)
 }
 
 type VerificationMetrics interface {

--- a/module/metrics/consensus.go
+++ b/module/metrics/consensus.go
@@ -106,17 +106,17 @@ func (cc *ConsensusCollector) EmergencySeal() {
 	cc.emergencySealedBlocks.Inc()
 }
 
-// IncreaseOnReceiptDuration increases the number of seconds spent processing receipts
-func (cc *ConsensusCollector) IncreaseOnReceiptDuration(duration time.Duration) {
+// OnReceiptProcessingDuration increases the number of seconds spent processing receipts
+func (cc *ConsensusCollector) OnReceiptProcessingDuration(duration time.Duration) {
 	cc.onReceiptDuration.Add(duration.Seconds())
 }
 
-// IncreaseOnApprovalDuration increases the number of seconds spent processing approvals
-func (cc *ConsensusCollector) IncreaseOnApprovalDuration(duration time.Duration) {
+// OnApprovalProcessingDuration increases the number of seconds spent processing approvals
+func (cc *ConsensusCollector) OnApprovalProcessingDuration(duration time.Duration) {
 	cc.onApprovalDuration.Add(duration.Seconds())
 }
 
-// IncreaseCheckSealingDuration increases the number of seconds spent in checkSealing
-func (cc *ConsensusCollector) IncreaseCheckSealingDuration(duration time.Duration) {
+// CheckSealingDuration increases the number of seconds spent in checkSealing
+func (cc *ConsensusCollector) CheckSealingDuration(duration time.Duration) {
 	cc.checkSealingDuration.Add(duration.Seconds())
 }

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -66,10 +66,10 @@ func (nc *NoopCollector) StartCollectionToFinalized(collectionID flow.Identifier
 func (nc *NoopCollector) FinishCollectionToFinalized(collectionID flow.Identifier)               {}
 func (nc *NoopCollector) StartBlockToSeal(blockID flow.Identifier)                               {}
 func (nc *NoopCollector) FinishBlockToSeal(blockID flow.Identifier)                              {}
-func (nc *NoopCollector) CheckSealingDuration(duration time.Duration)                            {}
 func (nc *NoopCollector) EmergencySeal()                                                         {}
 func (nc *NoopCollector) IncreaseOnReceiptDuration(duration time.Duration)                       {}
 func (nc *NoopCollector) IncreaseOnApprovalDuration(duration time.Duration)                      {}
+func (nc *NoopCollector) IncreaseCheckSealingDuration(duration time.Duration)                    {}
 func (nc *NoopCollector) OnExecutionReceiptReceived()                                            {}
 func (nc *NoopCollector) OnExecutionResultSent()                                                 {}
 func (nc *NoopCollector) OnExecutionResultReceived()                                             {}

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -69,6 +69,7 @@ func (nc *NoopCollector) FinishBlockToSeal(blockID flow.Identifier)             
 func (nc *NoopCollector) CheckSealingDuration(duration time.Duration)                            {}
 func (nc *NoopCollector) EmergencySeal()                                                         {}
 func (nc *NoopCollector) IncreaseOnReceiptDuration(duration time.Duration)                       {}
+func (nc *NoopCollector) IncreaseOnApprovalDuration(duration time.Duration)                      {}
 func (nc *NoopCollector) OnExecutionReceiptReceived()                                            {}
 func (nc *NoopCollector) OnExecutionResultSent()                                                 {}
 func (nc *NoopCollector) OnExecutionResultReceived()                                             {}

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -67,9 +67,9 @@ func (nc *NoopCollector) FinishCollectionToFinalized(collectionID flow.Identifie
 func (nc *NoopCollector) StartBlockToSeal(blockID flow.Identifier)                               {}
 func (nc *NoopCollector) FinishBlockToSeal(blockID flow.Identifier)                              {}
 func (nc *NoopCollector) EmergencySeal()                                                         {}
-func (nc *NoopCollector) IncreaseOnReceiptDuration(duration time.Duration)                       {}
-func (nc *NoopCollector) IncreaseOnApprovalDuration(duration time.Duration)                      {}
-func (nc *NoopCollector) IncreaseCheckSealingDuration(duration time.Duration)                    {}
+func (nc *NoopCollector) OnReceiptProcessingDuration(duration time.Duration)                     {}
+func (nc *NoopCollector) OnApprovalProcessingDuration(duration time.Duration)                    {}
+func (nc *NoopCollector) CheckSealingDuration(duration time.Duration)                            {}
 func (nc *NoopCollector) OnExecutionReceiptReceived()                                            {}
 func (nc *NoopCollector) OnExecutionResultSent()                                                 {}
 func (nc *NoopCollector) OnExecutionResultReceived()                                             {}

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -68,6 +68,7 @@ func (nc *NoopCollector) StartBlockToSeal(blockID flow.Identifier)              
 func (nc *NoopCollector) FinishBlockToSeal(blockID flow.Identifier)                              {}
 func (nc *NoopCollector) CheckSealingDuration(duration time.Duration)                            {}
 func (nc *NoopCollector) EmergencySeal()                                                         {}
+func (nc *NoopCollector) IncreaseOnReceiptDuration(duration time.Duration)                       {}
 func (nc *NoopCollector) OnExecutionReceiptReceived()                                            {}
 func (nc *NoopCollector) OnExecutionResultSent()                                                 {}
 func (nc *NoopCollector) OnExecutionResultReceived()                                             {}

--- a/module/mock/consensus_metrics.go
+++ b/module/mock/consensus_metrics.go
@@ -14,11 +14,6 @@ type ConsensusMetrics struct {
 	mock.Mock
 }
 
-// CheckSealingDuration provides a mock function with given fields: duration
-func (_m *ConsensusMetrics) CheckSealingDuration(duration time.Duration) {
-	_m.Called(duration)
-}
-
 // EmergencySeal provides a mock function with given fields:
 func (_m *ConsensusMetrics) EmergencySeal() {
 	_m.Called()
@@ -32,6 +27,21 @@ func (_m *ConsensusMetrics) FinishBlockToSeal(blockID flow.Identifier) {
 // FinishCollectionToFinalized provides a mock function with given fields: collectionID
 func (_m *ConsensusMetrics) FinishCollectionToFinalized(collectionID flow.Identifier) {
 	_m.Called(collectionID)
+}
+
+// IncreaseCheckSealingDuration provides a mock function with given fields: duration
+func (_m *ConsensusMetrics) IncreaseCheckSealingDuration(duration time.Duration) {
+	_m.Called(duration)
+}
+
+// IncreaseOnApprovalDuration provides a mock function with given fields: duration
+func (_m *ConsensusMetrics) IncreaseOnApprovalDuration(duration time.Duration) {
+	_m.Called(duration)
+}
+
+// IncreaseOnReceiptDuration provides a mock function with given fields: duration
+func (_m *ConsensusMetrics) IncreaseOnReceiptDuration(duration time.Duration) {
+	_m.Called(duration)
 }
 
 // StartBlockToSeal provides a mock function with given fields: blockID

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -33,15 +33,15 @@ const (
 	CONCompBroadcastProposalWithDelay SpanName = "con.compliance.BroadcastProposalWithDelay"
 	CONCompOnBlockProposal            SpanName = "con.compliance.onBlockProposal"
 	CONProvOnBlockProposal            SpanName = "con.provider.onBlockProposal"
-	ConMatchOnReceipt                 SpanName = "con.matching.onReceipt"
-	CONMatchCheckSealing              SpanName = "con.matching.checkSealing"
+
+	// Consensus matching engine
+	CONMatchCheckSealing SpanName = "con.matching.checkSealing"
+	CONMatchOnReceipt    SpanName = "con.matching.onReceipt"
+	ConMatchOnReceiptVal SpanName = "con.matching.onReceipt.validation"
 
 	CONProcessBlock SpanName = "con.processBlock"
 	// children of CONProcessBlock
 	CONHotFinalizeBlock SpanName = "con.hotstuff.finalizeBlock"
-
-	// Entity Validation
-	ConValReceipt SpanName = "con.validation.receipt"
 
 	// Builder
 	CONBuildOn                        = "con.builder"

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -33,11 +33,15 @@ const (
 	CONCompBroadcastProposalWithDelay SpanName = "con.compliance.BroadcastProposalWithDelay"
 	CONCompOnBlockProposal            SpanName = "con.compliance.onBlockProposal"
 	CONProvOnBlockProposal            SpanName = "con.provider.onBlockProposal"
+	ConMatchOnReceipt                 SpanName = "con.matching.onReceipt"
 	CONMatchCheckSealing              SpanName = "con.matching.checkSealing"
 
 	CONProcessBlock SpanName = "con.processBlock"
 	// children of CONProcessBlock
 	CONHotFinalizeBlock SpanName = "con.hotstuff.finalizeBlock"
+
+	// Entity Validation
+	ConValReceipt SpanName = "con.validation.receipt"
 
 	// Builder
 	CONBuildOn                        = "con.builder"

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -37,7 +37,8 @@ const (
 	// Consensus matching engine
 	CONMatchCheckSealing SpanName = "con.matching.checkSealing"
 	CONMatchOnReceipt    SpanName = "con.matching.onReceipt"
-	ConMatchOnReceiptVal SpanName = "con.matching.onReceipt.validation"
+	CONMatchOnReceiptVal SpanName = "con.matching.onReceipt.validation"
+	CONMatchOnApproval   SpanName = "con.matching.onApproval"
 
 	CONProcessBlock SpanName = "con.processBlock"
 	// children of CONProcessBlock

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -34,11 +34,15 @@ const (
 	CONCompOnBlockProposal            SpanName = "con.compliance.onBlockProposal"
 	CONProvOnBlockProposal            SpanName = "con.provider.onBlockProposal"
 
-	// Consensus matching engine
-	CONMatchCheckSealing SpanName = "con.matching.checkSealing"
-	CONMatchOnReceipt    SpanName = "con.matching.onReceipt"
-	CONMatchOnReceiptVal SpanName = "con.matching.onReceipt.validation"
-	CONMatchOnApproval   SpanName = "con.matching.onApproval"
+	// Matching engine
+	CONMatchCheckSealing                        SpanName = "con.matching.checkSealing"
+	CONMatchCheckSealingSealableResults         SpanName = "con.matching.checkSealing.sealableResults"
+	CONMatchCheckSealingClearPools              SpanName = "con.matching.checkSealing.clearPools"
+	CONMatchCheckSealingRequestPendingReceipts  SpanName = "con.matching.checkSealing.requestPendingReceipts"
+	CONMatchCheckSealingRequestPendingApprovals SpanName = "con.matching.checkSealing.requestPendingApprovals"
+	CONMatchOnReceipt                           SpanName = "con.matching.onReceipt"
+	CONMatchOnReceiptVal                        SpanName = "con.matching.onReceipt.validation"
+	CONMatchOnApproval                          SpanName = "con.matching.onApproval"
 
 	CONProcessBlock SpanName = "con.processBlock"
 	// children of CONProcessBlock


### PR DESCRIPTION
This PR addresses issue [5260](https://github.com/dapperlabs/flow-go/issues/5260)

Added following metrics:

- `push_receipts_on_receipt_duration_seconds_total:` total seconds spent in `onReceipt` method, which is the function that processes incoming receipts from the `push-receipts` channel
- `on_approval_duration_seconds_total`: total seconds spent in `onApproval `method, which is the function that processes incoming approvals from the `push-approvals` AND `request-approvals-by-chunk`
- `check_sealing_duration_seconds_total`: total seconds spent in `checkingSealing` method

Note that onReceipt and onApproval call checkSealing **asynchronously** so the corresponding duration counters do not include the time spent in checkSealing

Added following spans:

```
con.matching.checkSealing
con.matching.checkSealing.sealableResults
con.matching.checkSealing.clearPools
con.matching.checkSealing.requestPendingReceipts
con.matching.checkSealing.requestPendingApprovals
con.matching.onReceipt
con.matching.onReceipt.validation
con.matching.onApproval
```
