### PR TITLE
revised scheduling of sealing check

### DIFF
--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -153,6 +153,17 @@ func New(
 		return nil, fmt.Errorf("could not register for requesting approvals: %w", err)
 	}
 
+	// Context:
+	// We expect a lot more Approvals compared to blocks or receipts. However, the level of
+	// information only changes significantly with new blocks or new receipts.
+	// We used to kick off the sealing check after every approval and receipt. In cases where
+	// the sealing check takes a lot more time than processing the actual messages (which we
+	// assume for the current implementation), we incur a large overhead as we check a lot
+	// of conditions, which only change with new blocks or new receipts.
+	// TEMPORARY FIX: to avoid sealing checks to monopolize the engine and delay processing
+	// of receipts and approvals. Specifically, we schedule sealing checks every 2 seconds.
+	e.unit.LaunchPeriodically(e.checkSealing, 2*time.Second, 120*time.Second)
+
 	return e, nil
 }
 
@@ -226,12 +237,20 @@ func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 		return e.onReceipt(originID, ev)
 	case *flow.ResultApproval:
 		e.engineMetrics.MessageReceived(metrics.EngineMatching, metrics.MessageResultApproval)
+		if e.requiredApprovalsForSealConstruction < 1 {
+			// if we don't require approvals to construct a seal, don't even process approvals.
+			return nil
+		}
 		e.unit.Lock()
 		defer e.unit.Unlock()
 		defer e.engineMetrics.MessageHandled(metrics.EngineMatching, metrics.MessageResultApproval)
 		return e.onApproval(originID, ev)
 	case *messages.ApprovalResponse:
 		e.engineMetrics.MessageReceived(metrics.EngineMatching, metrics.MessageResultApproval)
+		if e.requiredApprovalsForSealConstruction < 1 {
+			// if we don't require approvals to construct a seal, don't even process approvals.
+			return nil
+		}
 		e.unit.Lock()
 		defer e.unit.Unlock()
 		defer e.engineMetrics.MessageHandled(metrics.EngineMatching, metrics.MessageResultApproval)
@@ -323,9 +342,6 @@ func (e *Engine) onReceipt(originID flow.Identifier, receipt *flow.ExecutionRece
 	}
 
 	log.Info().Msg("execution result processed and stored")
-
-	// kick off a check for potential seal formation
-	e.unit.Launch(e.checkSealing)
 
 	return nil
 }
@@ -435,9 +451,6 @@ func (e *Engine) onApproval(originID flow.Identifier, approval *flow.ResultAppro
 		return nil
 	}
 	e.mempool.MempoolEntries(metrics.ResourceApproval, e.approvals.Size())
-
-	// kick off a check for potential seal formation
-	e.unit.Launch(e.checkSealing)
 
 	return nil
 }


### PR DESCRIPTION
This PR contains a temporary fix, which hopefully increases stability of block production. It contains two parts:

#### ignore approvals if not required for seal construction
When the matching engine does not require _any_ approvals for seal construction (i.e. `requiredApprovalsForSealConstruction == 0`), the matching engine drops the approvals without acquiring the engine lock


#### reduce frequency of sealing logic

We expect a lot more Approvals compared to blocks or receipts. However, the level of information only changes significantly with new blocks or new receipts. We used to kick off the sealing check after every approval and receipt. In cases where the sealing check takes a lot more time than processing the actual messages (which we assume for the current implementation), we incur a large overhead as we check a lot of conditions, which only change with new blocks or new receipts. 

TEMPORARY FIX: avoid sealing checks to monopolize the engine and delay processing of receipts and approvals. Specifically, we schedule sealing checks every 2 seconds.

 