### PR TITLE
[Consensus] Logging information about next unsealed block

### DIFF
--- a/cmd/bootstrap/cmd/genconfig.go
+++ b/cmd/bootstrap/cmd/genconfig.go
@@ -46,6 +46,7 @@ func genconfigCmdRun(_ *cobra.Command, _ []string) {
 var genconfigCmd = &cobra.Command{
 	Use:   "genconfig",
 	Short: "Generate node-config.json",
+	Long:  "example: go run -tags relic ./cmd/bootstrap genconfig --address-format \"%s-%03d.devnet19.nodes.onflow.org:3569\" --access 2 --collection 3 --consensus 3 --execution 2 --verification 1 --stake 1000",
 	Run:   genconfigCmdRun,
 }
 

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -220,7 +220,7 @@ func (e *Engine) BroadcastProposalWithDelay(header *flow.Header, delay time.Dura
 		Hex("payload_hash", header.PayloadHash[:]).
 		Int("gaurantees_count", len(payload.Guarantees)).
 		Int("seals_count", len(payload.Seals)).
-		Int("receiptss_count", len(payload.Receipts)).
+		Int("receipts_count", len(payload.Receipts)).
 		Time("timestamp", header.Timestamp).
 		Hex("proposer", header.ProposerID[:]).
 		Int("num_signers", len(header.ParentVoterIDs)).

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -205,6 +205,12 @@ func (e *Engine) BroadcastProposalWithDelay(header *flow.Header, delay time.Dura
 	header.ChainID = parent.ChainID
 	header.Height = parent.Height + 1
 
+	// retrieve the payload for the block
+	payload, err := e.payloads.ByBlockID(header.ID())
+	if err != nil {
+		return fmt.Errorf("could not retrieve payload for proposal: %w", err)
+	}
+
 	log := e.log.With().
 		Str("chain_id", header.ChainID.String()).
 		Uint64("block_height", header.Height).
@@ -212,6 +218,9 @@ func (e *Engine) BroadcastProposalWithDelay(header *flow.Header, delay time.Dura
 		Hex("block_id", logging.Entity(header)).
 		Hex("parent_id", header.ParentID[:]).
 		Hex("payload_hash", header.PayloadHash[:]).
+		Int("gaurantees_count", len(payload.Guarantees)).
+		Int("seals_count", len(payload.Seals)).
+		Int("receiptss_count", len(payload.Receipts)).
 		Time("timestamp", header.Timestamp).
 		Hex("proposer", header.ProposerID[:]).
 		Int("num_signers", len(header.ParentVoterIDs)).
@@ -219,12 +228,6 @@ func (e *Engine) BroadcastProposalWithDelay(header *flow.Header, delay time.Dura
 		Logger()
 
 	log.Info().Msg("processing proposal broadcast request from hotstuff")
-
-	// retrieve the payload for the block
-	payload, err := e.payloads.ByBlockID(header.ID())
-	if err != nil {
-		return fmt.Errorf("could not retrieve payload for proposal: %w", err)
-	}
 
 	for _, g := range payload.Guarantees {
 		if span, ok := e.tracer.GetSpan(g.CollectionID, trace.CONProcessCollection); ok {

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -991,6 +991,7 @@ func (e *Engine) clearPools(sealedIDs []flow.Identifier) error {
 
 // requestPendingReceipts requests the execution receipts of unsealed finalized
 // blocks.
+// it returns the number of pending receipts requests being created
 func (e *Engine) requestPendingReceipts() (int, error) {
 
 	// last sealed block
@@ -1078,6 +1079,7 @@ func (e *Engine) requestPendingReceipts() (int, error) {
 //                              |                   |
 // ... <-- A <-- A+1 <- ... <-- D <-- D+1 <- ... -- F
 //       sealed       maxHeightForRequesting      final
+// it returns the number of pending approvals requests being created
 func (e *Engine) requestPendingApprovals() (int, error) {
 	// skip requesting approvals if they are not required for sealing
 	if e.requiredApprovalsForSealConstruction == 0 {

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -4,7 +4,6 @@ package matching
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -472,14 +471,6 @@ func (e *Engine) onApproval(originID flow.Identifier, approval *flow.ResultAppro
 	return nil
 }
 
-func nextUnsealedsPrintable(nextUnsealeds []*nextUnsealedResult) string {
-	nextUnsealedResultsAsJSON, err := json.Marshal(nextUnsealeds)
-	if err != nil {
-		return fmt.Sprintf("can not convert next unsealeds to json: %s", err.Error())
-	}
-	return string(nextUnsealedResultsAsJSON)
-}
-
 // checkSealing checks if there is anything worth sealing at the moment.
 func (e *Engine) checkSealing() {
 	// only check sealing when no one else is checking
@@ -517,7 +508,7 @@ func (e *Engine) checkingSealing() error {
 
 	lg := e.log.With().
 		Int("sealable_results_count", len(sealableResults)).
-		Str("next_unsealed_results", nextUnsealedsPrintable(nextUnsealeds)).
+		Str("next_unsealed_results", nextUnsealeds.String()).
 		Logger()
 
 	if len(sealableResults) == 0 {
@@ -657,7 +648,7 @@ func nextUnsealedID(state protocol.State) (flow.Identifier, bool) {
 // function. It also filters out results that have an incorrect sub-graph.
 // It specifically returns the information for the next unsealed results which will
 // be useful for debugging the potential sealing halt issue
-func (e *Engine) sealableResults() ([]*flow.IncorporatedResult, []*nextUnsealedResult, error) {
+func (e *Engine) sealableResults() ([]*flow.IncorporatedResult, nextUnsealedResults, error) {
 	var results []*flow.IncorporatedResult
 
 	lastFinalized, err := e.state.Final().Head()
@@ -760,18 +751,6 @@ func (e *Engine) sealableResults() ([]*flow.IncorporatedResult, []*nextUnsealedR
 	}
 
 	return results, nextUnsealeds, nil
-}
-
-// This struct is made for debugging potential sealing halt
-type nextUnsealedResult struct {
-	BlockID                  flow.Identifier // the block of of the next unsealed block
-	Height                   uint64          // the height of the block
-	ResultID                 flow.Identifier // if we haven't received the result, it would be ZeroID
-	IncorporatedResultID     flow.Identifier // to find seal in mempool
-	TotalChunks              int
-	FirstUnmatchedChunkIndex int  // show which chunk hasn't received approval
-	CanBeSealed              bool // if true, then it should soon go to seals mempool
-	SealedByEmergency        bool // if sealed by emergency since there are too many unsealed blocks
 }
 
 // matchChunk checks that the number of ResultApprovals collected by a chunk

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -593,6 +593,7 @@ func (e *Engine) checkingSealing() error {
 	requestReceiptsSpan := e.tracer.StartSpanFromParent(sealingSpan, trace.CONMatchCheckSealingRequestPendingReceipts)
 	pendingReceiptRequests, err := e.requestPendingReceipts()
 	requestReceiptsSpan.Finish()
+
 	if err != nil {
 		return fmt.Errorf("could not request pending block results: %w", err)
 	}
@@ -1055,7 +1056,7 @@ func (e *Engine) requestPendingReceipts() (int, error) {
 
 	// request missing execution results, if sealed height is low enough
 	if len(missingBlocksOrderedByHeight) > 0 {
-		log.Info().
+		log.Debug().
 			Int("finalized_blocks_without_result", len(missingBlocksOrderedByHeight)).
 			Msg("requesting receipts")
 		for _, blockID := range missingBlocksOrderedByHeight {
@@ -1223,7 +1224,7 @@ func (e *Engine) requestPendingApprovals() (int, error) {
 	}
 
 	if requestCount > 0 {
-		log.Info().Msgf("requested %d approvals", requestCount)
+		log.Debug().Msgf("requested %d approvals", requestCount)
 	}
 
 	return requestCount, nil

--- a/engine/consensus/matching/next_unsealed_results.go
+++ b/engine/consensus/matching/next_unsealed_results.go
@@ -11,14 +11,14 @@ type nextUnsealedResults []*nextUnsealedResult
 
 // This struct is made for debugging potential sealing halt
 type nextUnsealedResult struct {
-	BlockID                  flow.Identifier // the block of of the next unsealed block
-	Height                   uint64          // the height of the block
-	ResultID                 flow.Identifier // if we haven't received the result, it would be ZeroID
-	IncorporatedResultID     flow.Identifier // to find seal in mempool
-	TotalChunks              int
-	FirstUnmatchedChunkIndex int  // show which chunk hasn't received approval
-	CanBeSealed              bool // if true, then it should soon go to seals mempool
-	SealedByEmergency        bool // if sealed by emergency since there are too many unsealed blocks
+	BlockID                       flow.Identifier // the block of of the next unsealed block
+	Height                        uint64          // the height of the block
+	ResultID                      flow.Identifier // if we haven't received the result, it would be ZeroID
+	IncorporatedResultID          flow.Identifier // to find seal in mempool
+	TotalChunks                   int
+	FirstUnmatchedChunkIndex      int  // show which chunk hasn't received approval
+	SufficientApprovalsForSealing bool // if true, then it should soon go to seals mempool
+	QualifiesForEmergencySealing  bool // if sealed by emergency since there are too many unsealed blocks
 }
 
 func (rs *nextUnsealedResults) String() string {

--- a/engine/consensus/matching/next_unsealed_results.go
+++ b/engine/consensus/matching/next_unsealed_results.go
@@ -1,0 +1,30 @@
+package matching
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+type nextUnsealedResults []*nextUnsealedResult
+
+// This struct is made for debugging potential sealing halt
+type nextUnsealedResult struct {
+	BlockID                  flow.Identifier // the block of of the next unsealed block
+	Height                   uint64          // the height of the block
+	ResultID                 flow.Identifier // if we haven't received the result, it would be ZeroID
+	IncorporatedResultID     flow.Identifier // to find seal in mempool
+	TotalChunks              int
+	FirstUnmatchedChunkIndex int  // show which chunk hasn't received approval
+	CanBeSealed              bool // if true, then it should soon go to seals mempool
+	SealedByEmergency        bool // if sealed by emergency since there are too many unsealed blocks
+}
+
+func (rs *nextUnsealedResults) String() string {
+	bytes, err := json.Marshal(rs)
+	if err != nil {
+		return fmt.Sprintf("can not convert next unsealeds to json: %s", err.Error())
+	}
+	return string(bytes)
+}

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -299,6 +299,7 @@ func prepareConsensusService(container testnet.ContainerConfig, i int) Service {
 		fmt.Sprintf("--hotstuff-timeout=%s", timeout),
 		fmt.Sprintf("--hotstuff-min-timeout=%s", timeout),
 		fmt.Sprintf("--chunk-alpha=1"),
+		fmt.Sprintf("--emergency-sealing-active=false"),
 	)
 
 	return service

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -332,9 +332,9 @@ func (b *Builder) getInsertableSeals(parentID flow.Identifier) ([]*flow.Seal, er
 	// block
 	nextSealHeight := sealed.Height + 1
 	nextSeal, ok := filteredSeals[nextSealHeight]
+
 	var count uint = 0
 	for ok {
-
 		// don't include more than maxSealCount seals
 		if count >= b.cfg.maxSealCount {
 			break


### PR DESCRIPTION
## Context
This PR improves the logging in match engine for debugging potential sealing halt issue. See [Issue](https://github.com/dapperlabs/flow-go/issues/5247)

## Changes
- Log whether the consensus match engine has received an incorporated result for the next unsealed block
- Log whether the consensus match engine has received enough approvals for the next unsealed block, if not, which chunk index hasn't received enough approval.