### PR TITLE
[Verification] increase verification retry attempts

### DIFF
--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -47,8 +47,8 @@ const (
 	// failureThreshold represents the number of retries match engine sends
 	// at `requestInterval` milliseconds for each of the missing resources.
 	// When it reaches the threshold ingest engine makes a missing challenge for the resources.
-	// this value is set following this issue (3443)
-	// such a big number means we will retry forever (100 days)
+	// Currently setting the threshold to a very large value (corresponding to 100 days),
+	// which for all practical purposes is equivalent to the Verifier trying indefinitely.
 	failureThreshold = 10000000
 )
 

--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -48,7 +48,8 @@ const (
 	// at `requestInterval` milliseconds for each of the missing resources.
 	// When it reaches the threshold ingest engine makes a missing challenge for the resources.
 	// this value is set following this issue (3443)
-	failureThreshold = 2
+	// such a big number means we will retry forever (100 days)
+	failureThreshold = 10000000
 )
 
 func main() {

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -346,7 +346,7 @@ func (e *Engine) onTimer() {
 
 		header, err := e.headers.ByBlockID(chunk.Chunk.BlockID)
 		if err != nil {
-			log.Error().Err(err).Msgf("could not get header for block")
+			log.Fatal().Err(err).Msgf("could not get header for block")
 			continue
 		}
 

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -350,6 +350,7 @@ func (e *Engine) onTimer() {
 			continue
 		}
 
+		// skips requesting chunks of already sealed blocks
 		isSealed := header.Height <= sealedHeight
 		if isSealed {
 			e.pendingChunks.Rem(chunkID)

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -321,6 +321,14 @@ func (e *Engine) onTimer() {
 
 	now := time.Now()
 	e.log.Debug().Int("total", len(allChunks)).Msg("start processing all pending pendingChunks")
+	sealed, err := e.state.Sealed().Head()
+	if err != nil {
+		e.log.Error().Err(err).Msg("could not get sealed height when calling onTimer")
+		return
+	}
+
+	sealedHeight := sealed.Height
+
 	defer e.log.Debug().
 		Int("processed", len(allChunks)-int(e.pendingChunks.Size())).
 		Uint("left", e.pendingChunks.Size()).
@@ -332,8 +340,23 @@ func (e *Engine) onTimer() {
 
 		log := e.log.With().
 			Hex("chunk_id", logging.ID(chunkID)).
+			Hex("block_id", logging.ID(chunk.Chunk.BlockID)).
 			Hex("result_id", logging.ID(chunk.ExecutionResultID)).
 			Logger()
+
+		header, err := e.headers.ByBlockID(chunk.Chunk.BlockID)
+		if err != nil {
+			log.Error().Err(err).Msgf("could not get header for block")
+			continue
+		}
+
+		isSealed := header.Height <= sealedHeight
+		if isSealed {
+			e.pendingChunks.Rem(chunkID)
+			e.chunkMetaDataCleanup(chunkID, chunk.ExecutionResultID)
+			log.Debug().Msg("block has been sealed")
+			continue
+		}
 
 		// check if has reached max try
 		if !CanTry(e.maxAttempt, chunk) {
@@ -354,7 +377,7 @@ func (e *Engine) onTimer() {
 			continue
 		}
 
-		err := e.requestChunkDataPack(chunk)
+		err = e.requestChunkDataPack(chunk)
 		if err != nil {
 			log.Warn().Msg("could not request chunk data pack")
 			continue


### PR DESCRIPTION
## Problem 

On my localnet, if I restart execution node, the sealing will be halt.
And the reason it halts is because the consensus didn’t receive approvals.
Why? because during the EN down time, VN has received the ER, and sent the chunk data pack request, but didn’t receive the response. And VN has a config to only retry 2 times, after which it will give up, and then the consensus will never receive approval, so sealing halts.


## Changes
This PR
- increased the retry attempts from 2 times to 10000000 (last for 115 days)
- remove pending chunks from mempool if the executed block is below sealed height. So that we won't keep sending chunk data pack request for them. 

Tested locally, it worked

