### PR TITLE
VER: Yahya/5270 fix block ids fixture

### DIFF
--- a/engine/testutil/mock/nodes.go
+++ b/engine/testutil/mock/nodes.go
@@ -198,7 +198,6 @@ type VerificationNode struct {
 	ReceiptIDsByResult       mempool.IdentifierMap
 	ChunkIDsByResult         mempool.IdentifierMap
 	PendingChunks            *match.Chunks
-	HeaderStorage            storage.Headers
 	VerifierEngine           network.Engine
 	FinderEngine             *finder.Engine
 	MatchEngine              network.Engine

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -626,10 +626,6 @@ func VerificationNode(t testing.TB,
 		require.Nil(t, err)
 	}
 
-	if node.HeaderStorage == nil {
-		node.HeaderStorage = storage.NewHeaders(node.Metrics, node.DB)
-	}
-
 	if node.PendingChunks == nil {
 		node.PendingChunks = match.NewChunks(chunksLimit)
 
@@ -732,7 +728,7 @@ func VerificationNode(t testing.TB,
 			assigner,
 			node.State,
 			node.PendingChunks,
-			node.HeaderStorage,
+			node.Headers,
 			requestInterval,
 			int(failureThreshold))
 		require.Nil(t, err)

--- a/engine/verification/utils/fixtures.go
+++ b/engine/verification/utils/fixtures.go
@@ -146,8 +146,13 @@ func CompleteExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Cha
 		Payload: &payload,
 	}
 
+	blockID := block.ID()
+	for _, chunk := range chunks {
+		require.Equal(t, blockID, chunk.BlockID, "inconsistent block id in chunk fixture")
+	}
+
 	result := flow.ExecutionResult{
-		BlockID: block.ID(),
+		BlockID: blockID,
 		Chunks:  chunks,
 	}
 

--- a/engine/verification/utils/fixtures.go
+++ b/engine/verification/utils/fixtures.go
@@ -66,6 +66,10 @@ func CompleteExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Cha
 	chunks := make([]*flow.Chunk, 0)
 	chunkDataPacks := make([]*flow.ChunkDataPack, 0)
 
+	var payload flow.Payload
+	var block flow.Block
+	header := unittest.BlockHeaderWithParentFixture(root)
+
 	unittest.RunWithTempDir(t, func(dir string) {
 		led, err := completeLedger.NewLedger(dir, 100, metricsCollector, zerolog.Nop(), nil, completeLedger.DefaultPathFinderVersion)
 		require.NoError(t, err)
@@ -115,10 +119,23 @@ func CompleteExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Cha
 		sysGuarantee.ReferenceBlockID = root.ID()
 		guarantees = append(guarantees, sysGuarantee)
 
+		// shapes the block out of collections
+		payload = flow.Payload{
+			Guarantees: guarantees,
+		}
+		header.PayloadHash = payload.Hash()
+		block = flow.Block{
+			Header:  &header,
+			Payload: &payload,
+		}
+		blockID := block.ID()
+
+		// executes collections
 		for i := 0; i < len(collections); i++ {
 			collection := collections[i]
 			guarantee := guarantees[i]
 			chunk, chunkDataPack, endStateCommitment, spock := executeCollection(t,
+				blockID,
 				collection,
 				guarantee,
 				uint(i),
@@ -135,17 +152,8 @@ func CompleteExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Cha
 		}
 
 	})
-	payload := flow.Payload{
-		Guarantees: guarantees,
-	}
-	header := unittest.BlockHeaderWithParentFixture(root)
-	header.PayloadHash = payload.Hash()
 
-	block := flow.Block{
-		Header:  &header,
-		Payload: &payload,
-	}
-
+	// makes sure all chunks are referencing the correct block id.
 	blockID := block.ID()
 	for _, chunk := range chunks {
 		require.Equal(t, blockID, chunk.BlockID, "inconsistent block id in chunk fixture")
@@ -253,6 +261,7 @@ func SystemChunkCollectionFixture(serviceAddress flow.Address) (*flow.Collection
 // It executes the collection and returns its corresponding chunk, chunk data pack, end state, and spock.
 func executeCollection(
 	t *testing.T,
+	blockID flow.Identifier,
 	collection *flow.Collection,
 	guarantee *flow.CollectionGuarantee,
 	chunkIndex uint,
@@ -304,7 +313,7 @@ func executeCollection(
 			StartState:      startStateCommitment,
 			// TODO: include event collection hash
 			EventCollection: flow.ZeroID,
-			BlockID:         executableBlock.ID(),
+			BlockID:         blockID,
 			// TODO: record gas used
 			TotalComputationUsed: 0,
 			// TODO: record number of txs


### PR DESCRIPTION
This PR fixes the inconsistency of block ID in the chunks of `CompleteExecutionResult` test fixture. 