### PR TITLE
Handle encoding errors gracefully

### DIFF
--- a/fvm/errors.go
+++ b/fvm/errors.go
@@ -3,6 +3,7 @@ package fvm
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -28,6 +29,8 @@ const (
 	errCodeStorageCapacityExceeded = 11
 
 	errCodeEventLimitExceededError = 20
+
+	errCodeEncodingUnsupportedValue = 30
 
 	errCodeExecution = 100
 )
@@ -261,6 +264,25 @@ func (e *ExecutionError) Error() string {
 
 func (e *ExecutionError) Code() uint32 {
 	return errCodeExecution
+}
+
+// EncodingUnsupportedValueError indicates that Cadence attempted
+// to encode a value that is not supported.
+type EncodingUnsupportedValueError struct {
+	Value interpreter.Value
+	Path  []string
+}
+
+func (e *EncodingUnsupportedValueError) Error() string {
+	return fmt.Sprintf(
+		"encoding unsupported value to path [%s]: %[1]T, %[1]v",
+		strings.Join(e.Path, ","),
+		e.Value,
+	)
+}
+
+func (e *EncodingUnsupportedValueError) Code() uint32 {
+	return errCodeEncodingUnsupportedValue
 }
 
 func handleError(err error) (vmErr Error, fatalErr error) {

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -94,7 +94,9 @@ func (i *TransactionInvocator) Process(
 		return err
 	}
 
-	i.logger.Info().Str("txHash", proc.ID.String()).Msgf("(%d) ledger interactions used by transaction", st.InteractionUsed())
+	i.logger.Info().
+		Str("txHash", proc.ID.String()).
+		Msgf("(%d) ledger interactions used by transaction", st.InteractionUsed())
 
 	proc.Events = env.getEvents()
 	proc.ServiceEvents = env.getServiceEvents()

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.12.6
+	github.com/onflow/cadence v0.12.7
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -823,6 +823,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.7 h1:AJAaC8DieEmUqAiDP5fFL8Qo5J1HzeWubD35S8GNxKA=
+github.com/onflow/cadence v0.12.7/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=


### PR DESCRIPTION
Cadence might panic when failing to encode an unsupported value. 
For now, gracefully handle these errors and abort the execution, e.g. revert a transaction.