### PR TITLE
Yahya/refactor chunk queue

### DIFF
--- a/engine/verification/assigner/engine.go
+++ b/engine/verification/assigner/engine.go
@@ -17,11 +17,11 @@ type Engine struct {
 	me      module.Local
 	state   protocol.State
 
-	headerStorage    storage.Headers       // used to check block existence before verifying
-	assigner         module.ChunkAssigner  // used to determine chunks this node needs to verify
-	chunksQueue      storage.ChunksQueue   // to store chunks to be verified
-	newChunkListener module.NewJobListener // to notify about a new chunk
-	finishProcessing finishProcessing      // to report a block has been processed
+	headerStorage    storage.Headers           // used to check block existence before verifying
+	assigner         module.ChunkAssigner      // used to determine chunks this node needs to verify
+	chunksQueue      storage.ChunkLocatorQueue // to store chunks to be verified
+	newChunkListener module.NewJobListener     // to notify about a new chunk
+	finishProcessing finishProcessing          // to report a block has been processed
 }
 
 func New(
@@ -32,7 +32,7 @@ func New(
 	state protocol.State,
 	headerStorage storage.Headers,
 	assigner module.ChunkAssigner,
-	chunksQueue storage.ChunksQueue,
+	chunksQueue storage.ChunkLocatorQueue,
 	newChunkListener module.NewJobListener,
 ) *Engine {
 	e := &Engine{

--- a/engine/verification/assigner/engine.go
+++ b/engine/verification/assigner/engine.go
@@ -17,11 +17,11 @@ type Engine struct {
 	me      module.Local
 	state   protocol.State
 
-	headerStorage    storage.Headers           // used to check block existence before verifying
-	assigner         module.ChunkAssigner      // used to determine chunks this node needs to verify
-	chunksQueue      storage.ChunkLocatorQueue // to store chunks to be verified
-	newChunkListener module.NewJobListener     // to notify about a new chunk
-	finishProcessing finishProcessing          // to report a block has been processed
+	headerStorage    storage.Headers       // used to check block existence before verifying
+	assigner         module.ChunkAssigner  // used to determine chunks this node needs to verify
+	chunksQueue      storage.ChunkQueue    // to store chunks to be verified
+	newChunkListener module.NewJobListener // to notify about a new chunk
+	finishProcessing finishProcessing      // to report a block has been processed
 }
 
 func New(
@@ -32,7 +32,7 @@ func New(
 	state protocol.State,
 	headerStorage storage.Headers,
 	assigner module.ChunkAssigner,
-	chunksQueue storage.ChunkLocatorQueue,
+	chunksQueue storage.ChunkQueue,
 	newChunkListener module.NewJobListener,
 ) *Engine {
 	e := &Engine{

--- a/engine/verification/fetcher/consumer.go
+++ b/engine/verification/fetcher/consumer.go
@@ -42,7 +42,7 @@ func JobToChunk(job storage.Job) *chunkmodels.Locator {
 // ChunksJob wraps the storage layer to provide an abstraction for
 // consumers to read jobs
 type ChunksJob struct {
-	chunks storage.ChunkLocatorQueue
+	chunks storage.ChunkQueue
 }
 
 func (j ChunksJob) AtIndex(index int64) (storage.Job, error) {
@@ -102,7 +102,7 @@ type ChunkConsumer struct {
 func NewChunkConsumer(
 	log zerolog.Logger,
 	processedIndex storage.ConsumerProgress, // to persist the processed index
-	chunksQueue storage.ChunkLocatorQueue, // to read jobs (chunks) from
+	chunksQueue storage.ChunkQueue, // to read jobs (chunks) from
 	engine EngineWorker, // to process jobs (chunks)
 	maxProcessing int64, // max number of jobs to be processed in parallel
 	maxFinished int64, // when the next unprocessed job is not finished,

--- a/engine/verification/fetcher/consumer.go
+++ b/engine/verification/fetcher/consumer.go
@@ -18,7 +18,7 @@ const (
 
 // ChunkJob converts a Chunk into a Job to be used by job queue
 type ChunkJob struct {
-	ChunkLocator *chunkmodels.ChunkLocator
+	ChunkLocator *chunkmodels.Locator
 }
 
 // ID converts chunk id into job id, which guarantees uniqueness
@@ -30,11 +30,11 @@ func chunkIDToJobID(chunkID flow.Identifier) module.JobID {
 	return module.JobID(fmt.Sprintf("%v", chunkID))
 }
 
-func ChunkLocatorToJob(locator *chunkmodels.ChunkLocator) *ChunkJob {
+func ChunkLocatorToJob(locator *chunkmodels.Locator) *ChunkJob {
 	return &ChunkJob{ChunkLocator: locator}
 }
 
-func JobToChunk(job storage.Job) *chunkmodels.ChunkLocator {
+func JobToChunk(job storage.Job) *chunkmodels.Locator {
 	chunkjob, _ := job.(*ChunkJob)
 	return chunkjob.ChunkLocator
 }
@@ -54,7 +54,7 @@ func (j ChunksJob) AtIndex(index int64) (storage.Job, error) {
 }
 
 type EngineWorker interface {
-	ProcessMyChunk(locator *chunkmodels.ChunkLocator)
+	ProcessMyChunk(locator *chunkmodels.Locator)
 	WithFinishProcessing(finishProcessing FinishProcessing)
 }
 

--- a/engine/verification/fetcher/consumer_test.go
+++ b/engine/verification/fetcher/consumer_test.go
@@ -50,13 +50,12 @@ func TestProduceConsume(t *testing.T) {
 			resultID := unittest.IdentifierFixture()
 
 			for i := 0; i < 10; i++ {
-				chunkID := unittest.IdentifierFixture()
 				chunkLocator := &chunks.ChunkLocator{
 					ResultID: resultID,
 					Index:    uint64(i),
 				}
 
-				ok, err := chunksQueue.StoreChunkLocator(chunkID, chunkLocator)
+				ok, err := chunksQueue.StoreChunkLocator(chunkLocator)
 				require.NoError(t, err, fmt.Sprintf("chunk locator %v can't be stored", i))
 				require.True(t, ok)
 				locators = append(locators, chunkLocator)
@@ -88,12 +87,11 @@ func TestProduceConsume(t *testing.T) {
 			resultID := unittest.IdentifierFixture()
 
 			for i := 0; i < 10; i++ {
-				chunkID := unittest.IdentifierFixture()
 				chunkLocator := &chunks.ChunkLocator{
 					ResultID: resultID,
 					Index:    uint64(i),
 				}
-				ok, err := chunksQueue.StoreChunkLocator(chunkID, chunkLocator)
+				ok, err := chunksQueue.StoreChunkLocator(chunkLocator)
 				require.NoError(t, err, fmt.Sprintf("chunk %v can't be stored", i))
 				require.True(t, ok)
 				locators = append(locators, chunkLocator)
@@ -124,12 +122,11 @@ func TestProduceConsume(t *testing.T) {
 
 			for i := 0; i < 100; i++ {
 				go func(i int) {
-					chunkID := unittest.IdentifierFixture()
 					chunkLocator := &chunks.ChunkLocator{
 						ResultID: resultID,
 						Index:    uint64(i),
 					}
-					ok, err := chunksQueue.StoreChunkLocator(chunkID, chunkLocator)
+					ok, err := chunksQueue.StoreChunkLocator(chunkLocator)
 					require.NoError(t, err, fmt.Sprintf("chunk %v can't be stored", i))
 					require.True(t, ok)
 					total.Inc()

--- a/engine/verification/fetcher/consumer_test.go
+++ b/engine/verification/fetcher/consumer_test.go
@@ -43,7 +43,7 @@ func TestProduceConsume(t *testing.T) {
 			defer lock.Unlock()
 			called = append(called, chunk)
 		}
-		WithConsumer(t, neverFinish, func(consumer *fetcher.ChunkConsumer, chunksQueue *storage.ChunksQueue) {
+		WithConsumer(t, neverFinish, func(consumer *fetcher.ChunkConsumer, chunksQueue *storage.ChunkLocatorQueue) {
 			<-consumer.Ready()
 
 			block := unittest.BlockFixture()
@@ -73,7 +73,7 @@ func TestProduceConsume(t *testing.T) {
 			called = append(called, chunk)
 			go finishProcessing.FinishProcessing(chunk.ID())
 		}
-		WithConsumer(t, alwaysFinish, func(consumer *fetcher.ChunkConsumer, chunksQueue *storage.ChunksQueue) {
+		WithConsumer(t, alwaysFinish, func(consumer *fetcher.ChunkConsumer, chunksQueue *storage.ChunkLocatorQueue) {
 			<-consumer.Ready()
 
 			block := unittest.BlockFixture()
@@ -102,7 +102,7 @@ func TestProduceConsume(t *testing.T) {
 			called = append(called, chunk)
 			go finishProcessing.FinishProcessing(chunk.ID())
 		}
-		WithConsumer(t, alwaysFinish, func(consumer *fetcher.ChunkConsumer, chunksQueue *storage.ChunksQueue) {
+		WithConsumer(t, alwaysFinish, func(consumer *fetcher.ChunkConsumer, chunksQueue *storage.ChunkLocatorQueue) {
 			<-consumer.Ready()
 
 			block := unittest.BlockFixture()
@@ -133,7 +133,7 @@ func TestProduceConsume(t *testing.T) {
 func WithConsumer(
 	t *testing.T,
 	process func(fetcher.FinishProcessing, *flow.Chunk),
-	withConsumer func(*fetcher.ChunkConsumer, *storage.ChunksQueue),
+	withConsumer func(*fetcher.ChunkConsumer, *storage.ChunkLocatorQueue),
 ) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		maxProcessing := int64(3)

--- a/engine/verification/fetcher/consumer_test.go
+++ b/engine/verification/fetcher/consumer_test.go
@@ -92,7 +92,7 @@ func TestProduceConsume(t *testing.T) {
 					Index:    uint64(i),
 				}
 				ok, err := chunksQueue.StoreChunkLocator(chunkLocator)
-				require.NoError(t, err, fmt.Sprintf("chunk %v can't be stored", i))
+				require.NoError(t, err, fmt.Sprintf("chunk locator %v can't be stored", i))
 				require.True(t, ok)
 				locators = append(locators, chunkLocator)
 				consumer.Check() // notify the consumer
@@ -127,7 +127,7 @@ func TestProduceConsume(t *testing.T) {
 						Index:    uint64(i),
 					}
 					ok, err := chunksQueue.StoreChunkLocator(chunkLocator)
-					require.NoError(t, err, fmt.Sprintf("chunk %v can't be stored", i))
+					require.NoError(t, err, fmt.Sprintf("chunk locator %v can't be stored", i))
 					require.True(t, ok)
 					total.Inc()
 					consumer.Check() // notify the consumer
@@ -154,7 +154,7 @@ func WithConsumer(
 		maxFinished := int64(8)
 
 		processedIndex := storage.NewConsumeProgress(db, module.ConsumeProgressVerificationChunkIndex)
-		chunksQueue := storage.NewChunkLocatorQueue(db)
+		chunksQueue := storage.NewChunkQueue(db)
 		ok, err := chunksQueue.Init(fetcher.DefaultJobIndex)
 		require.NoError(t, err)
 		require.True(t, ok)

--- a/engine/verification/fetcher/consumer_test.go
+++ b/engine/verification/fetcher/consumer_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-// chunk can convert to job and converted back
-func TestChunkToJob(t *testing.T) {
+// TestChunkLocatorToJob evaluates that a chunk locator can be converted to a job, and its corresponding job can be converted back to a locator.
+func TestChunkLocatorToJob(t *testing.T) {
 	locator := &chunks.ChunkLocator{
 		ResultID: unittest.IdentifierFixture(),
 		Index:    rand.Uint64(),

--- a/model/chunks/chunkLocator.go
+++ b/model/chunks/chunkLocator.go
@@ -11,7 +11,7 @@ type ChunkLocator struct {
 	Index    uint64          // index of chunk in the execution result
 }
 
-// ID returns a unique id for chunk locator
+// ID returns a unique id for chunk locator.
 func (c ChunkLocator) ID() flow.Identifier {
 	return flow.MakeID(c)
 }

--- a/model/chunks/chunkLocator.go
+++ b/model/chunks/chunkLocator.go
@@ -4,19 +4,18 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// ChunkLocator is stored and maintained in ChunksQueue and used to located a chunk by providing the execution result the chunk
-// belongs to as well as the chunk index within the execution result.
-type ChunkLocator struct {
+// Locator is used located a chunk by providing the execution result the chunk belongs to as well as the chunk index within that execution result.
+type Locator struct {
 	ResultID flow.Identifier // execution result id that chunk belongs to
 	Index    uint64          // index of chunk in the execution result
 }
 
 // ID returns a unique id for chunk locator.
-func (c ChunkLocator) ID() flow.Identifier {
+func (c Locator) ID() flow.Identifier {
 	return flow.MakeID(c)
 }
 
 // Checksum provides a cryptographic commitment for a chunk locator content.
-func (c ChunkLocator) Checksum() flow.Identifier {
+func (c Locator) Checksum() flow.Identifier {
 	return flow.MakeID(c)
 }

--- a/model/chunks/chunkLocator.go
+++ b/model/chunks/chunkLocator.go
@@ -1,0 +1,22 @@
+package chunks
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// ChunkLocator is stored and maintained in ChunksQueue and used to located a chunk by providing the execution result the chunk
+// belongs to as well as the chunk index within the execution result.
+type ChunkLocator struct {
+	ResultID flow.Identifier // execution result id that chunk belongs to
+	Index    uint64          // index of chunk in the execution result
+}
+
+// ID returns a unique id for chunk locator
+func (c ChunkLocator) ID() flow.Identifier {
+	return flow.MakeID(c)
+}
+
+// Checksum provides a cryptographic commitment for a chunk locator content.
+func (c ChunkLocator) Checksum() flow.Identifier {
+	return flow.MakeID(c)
+}

--- a/storage/badger/chunks_queue.go
+++ b/storage/badger/chunks_queue.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dgraph-io/badger/v2"
 
+	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
@@ -18,23 +19,22 @@ type ChunkLocatorQueue struct {
 	db *badger.DB
 }
 
-const JobQueueChunksQueue = "JobQueueChunksQueue"
+const JobQueueChunkLocatorQueue = "JobQueueChunkLocatorQueue"
 
-// NewChunksQueue will initialize the index of the latest chunk stored with
-// the given default index if it was never initialized
-func NewChunksQueue(db *badger.DB) *ChunkLocatorQueue {
+// NewChunkLocatorQueue will initialize the underlying badger database of chunk locator queue.
+func NewChunkLocatorQueue(db *badger.DB) *ChunkLocatorQueue {
 	return &ChunkLocatorQueue{
 		db: db,
 	}
 }
 
-// Init initial chunks queue's latest index witht the given default index
+// Init initial chunk locator queue's latest index with the given default index.
 func (q *ChunkLocatorQueue) Init(defaultIndex int64) (bool, error) {
 	_, err := q.LatestIndex()
 	if errors.Is(err, storage.ErrNotFound) {
-		err = q.db.Update(operation.InitJobLatestIndex(JobQueueChunksQueue, defaultIndex))
+		err = q.db.Update(operation.InitJobLatestIndex(JobQueueChunkLocatorQueue, defaultIndex))
 		if err != nil {
-			return false, fmt.Errorf("could not init chunks queue with default index %v: %w", defaultIndex, err)
+			return false, fmt.Errorf("could not init chunk locator queue with default index %v: %w", defaultIndex, err)
 		}
 		return true, nil
 	}
@@ -45,33 +45,33 @@ func (q *ChunkLocatorQueue) Init(defaultIndex int64) (bool, error) {
 	return false, nil
 }
 
-// StoreChunk stores a new chunk that assigned to me to the job queue
-// true will be returned, if the chunk was a new chunk
-// false will be returned, if the chunk was a duplicate
-func (q *ChunkLocatorQueue) StoreChunk(chunkID flow.Identifier, resultID flow.Identifier) (bool, error) {
+// StoreChunkLocator stores a new chunk locator that assigned to me to the job queue.
+// true will be returned, if the chunk was a new chunk.
+// false will be returned, if the chunk was a duplicate.
+func (q *ChunkLocatorQueue) StoreChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) (bool, error) {
 	err := operation.RetryOnConflict(q.db.Update, func(tx *badger.Txn) error {
-		// make sure the chunk is unique
-		err := operation.InsertChunkResultIDs(chunkID, resultID)(tx)
+		// make sure the chunk locator is unique
+		err := operation.InsertChunkLocator(chunkID, locator)(tx)
 		if err != nil {
-			return fmt.Errorf("failed to insert (chunkID, resultID): %w", err)
+			return fmt.Errorf("failed to insert chunk locator: %w", err)
 		}
 
 		// read the latest index
 		var latest int64
-		err = operation.RetrieveJobLatestIndex(JobQueueChunksQueue, &latest)(tx)
+		err = operation.RetrieveJobLatestIndex(JobQueueChunkLocatorQueue, &latest)(tx)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve job index for chunks queue: %w", err)
+			return fmt.Errorf("failed to retrieve job index for chunk locator queue: %w", err)
 		}
 
 		// insert to the next index
 		next := latest + 1
-		err = operation.InsertJobAtIndex(JobQueueChunksQueue, next, chunkID)(tx)
+		err = operation.InsertJobAtIndex(JobQueueChunkLocatorQueue, next, chunkID)(tx)
 		if err != nil {
-			return fmt.Errorf("failed to set job index for chunks queue at index %v: %w", next, err)
+			return fmt.Errorf("failed to set job index for chunk locator queue at index %v: %w", next, err)
 		}
 
 		// update the next index as the latest index
-		err = operation.SetJobLatestIndex(JobQueueChunksQueue, next)(tx)
+		err = operation.SetJobLatestIndex(JobQueueChunkLocatorQueue, next)(tx)
 		if err != nil {
 			return fmt.Errorf("failed to update latest index %v: %w", next, err)
 		}
@@ -89,31 +89,29 @@ func (q *ChunkLocatorQueue) StoreChunk(chunkID flow.Identifier, resultID flow.Id
 	return true, nil
 }
 
-// LatestIndex returns the index of the latest chunk stored
-// in the queue
+// LatestIndex returns the index of the latest chunk locator stored in the queue.
 func (q *ChunkLocatorQueue) LatestIndex() (int64, error) {
 	var latest int64
-	err := q.db.View(operation.RetrieveJobLatestIndex(JobQueueChunksQueue, &latest))
+	err := q.db.View(operation.RetrieveJobLatestIndex(JobQueueChunkLocatorQueue, &latest))
 	if err != nil {
 		return 0, fmt.Errorf("could not retrieve latest index for chunks queue: %w", err)
 	}
 	return latest, nil
 }
 
-// AtIndex returns the chunk stored at the given index in the
-// queue
-func (q *ChunkLocatorQueue) AtIndex(index int64) (*flow.Chunk, error) {
+// AtIndex returns the chunk locator stored at the given index in the queue.
+func (q *ChunkLocatorQueue) AtIndex(index int64) (*chunks.ChunkLocator, error) {
 	var chunkID flow.Identifier
-	err := q.db.View(operation.RetrieveJobAtIndex(JobQueueChunksQueue, index, &chunkID))
+	err := q.db.View(operation.RetrieveJobAtIndex(JobQueueChunkLocatorQueue, index, &chunkID))
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve chunk in chunks queue: %w", err)
+		return nil, fmt.Errorf("could not retrieve chunk locator in queue: %w", err)
 	}
 
-	var chunk flow.Chunk
-	err = q.db.View(operation.RetrieveChunk(chunkID, &chunk))
+	var locator chunks.ChunkLocator
+	err = q.db.View(operation.RetrieveChunkLocator(chunkID, &locator))
 	if err != nil {
-		return nil, fmt.Errorf("could not retrieve chunk with id %v: %w", chunkID, err)
+		return nil, fmt.Errorf("could not retrieve locator for chunk id %v: %w", chunkID, err)
 	}
 
-	return &chunk, nil
+	return &locator, nil
 }

--- a/storage/badger/chunks_queue.go
+++ b/storage/badger/chunks_queue.go
@@ -48,10 +48,10 @@ func (q *ChunkLocatorQueue) Init(defaultIndex int64) (bool, error) {
 // StoreChunkLocator stores a new chunk locator that assigned to me to the job queue.
 // true will be returned, if the chunk was a new chunk.
 // false will be returned, if the chunk was a duplicate.
-func (q *ChunkLocatorQueue) StoreChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) (bool, error) {
+func (q *ChunkLocatorQueue) StoreChunkLocator(locator *chunks.ChunkLocator) (bool, error) {
 	err := operation.RetryOnConflict(q.db.Update, func(tx *badger.Txn) error {
 		// make sure the chunk locator is unique
-		err := operation.InsertChunkLocator(chunkID, locator)(tx)
+		err := operation.InsertChunkLocator(locator)(tx)
 		if err != nil {
 			return fmt.Errorf("failed to insert chunk locator: %w", err)
 		}
@@ -65,7 +65,7 @@ func (q *ChunkLocatorQueue) StoreChunkLocator(chunkID flow.Identifier, locator *
 
 		// insert to the next index
 		next := latest + 1
-		err = operation.InsertJobAtIndex(JobQueueChunkLocatorQueue, next, chunkID)(tx)
+		err = operation.InsertJobAtIndex(JobQueueChunkLocatorQueue, next, locator.ID())(tx)
 		if err != nil {
 			return fmt.Errorf("failed to set job index for chunk locator queue at index %v: %w", next, err)
 		}

--- a/storage/badger/chunks_queue.go
+++ b/storage/badger/chunks_queue.go
@@ -12,24 +12,24 @@ import (
 	"github.com/onflow/flow-go/storage/badger/operation"
 )
 
-// ChunkLocatorQueue stores a queue of chunks that assigned to me to be verified.
-// Job consumers can read the chunk as job from the queue by index
-// Chunks stored in this queue are unique
-type ChunkLocatorQueue struct {
+// ChunkQueue stores a queue of chunk locators that assigned to me to verify.
+// Job consumers can read the locators as job from the queue by index.
+// Chunk locators stored in this queue are unique.
+type ChunkQueue struct {
 	db *badger.DB
 }
 
 const JobQueueChunkQueue = "JobQueueChunkQueue"
 
 // NewChunkQueue will initialize the underlying badger database of chunk locator queue.
-func NewChunkQueue(db *badger.DB) *ChunkLocatorQueue {
-	return &ChunkLocatorQueue{
+func NewChunkQueue(db *badger.DB) *ChunkQueue {
+	return &ChunkQueue{
 		db: db,
 	}
 }
 
 // Init initial chunk locator queue's latest index with the given default index.
-func (q *ChunkLocatorQueue) Init(defaultIndex int64) (bool, error) {
+func (q *ChunkQueue) Init(defaultIndex int64) (bool, error) {
 	_, err := q.LatestIndex()
 	if errors.Is(err, storage.ErrNotFound) {
 		err = q.db.Update(operation.InitJobLatestIndex(JobQueueChunkQueue, defaultIndex))
@@ -46,9 +46,9 @@ func (q *ChunkLocatorQueue) Init(defaultIndex int64) (bool, error) {
 }
 
 // StoreChunkLocator stores a new chunk locator that assigned to me to the job queue.
-// true will be returned, if the chunk was a new chunk.
-// false will be returned, if the chunk was a duplicate.
-func (q *ChunkLocatorQueue) StoreChunkLocator(locator *chunks.ChunkLocator) (bool, error) {
+// A true will be returned, if the locator was new.
+// A false will be returned, if the locator was duplicate.
+func (q *ChunkQueue) StoreChunkLocator(locator *chunks.Locator) (bool, error) {
 	err := operation.RetryOnConflict(q.db.Update, func(tx *badger.Txn) error {
 		// make sure the chunk locator is unique
 		err := operation.InsertChunkLocator(locator)(tx)
@@ -79,18 +79,18 @@ func (q *ChunkLocatorQueue) StoreChunkLocator(locator *chunks.ChunkLocator) (boo
 		return nil
 	})
 
-	// was trying to store a duplicate chunk
+	// was trying to store a duplicate locator
 	if errors.Is(err, storage.ErrAlreadyExists) {
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("failed to store chunk: %w", err)
+		return false, fmt.Errorf("failed to store chunk locator: %w", err)
 	}
 	return true, nil
 }
 
 // LatestIndex returns the index of the latest chunk locator stored in the queue.
-func (q *ChunkLocatorQueue) LatestIndex() (int64, error) {
+func (q *ChunkQueue) LatestIndex() (int64, error) {
 	var latest int64
 	err := q.db.View(operation.RetrieveJobLatestIndex(JobQueueChunkQueue, &latest))
 	if err != nil {
@@ -100,14 +100,14 @@ func (q *ChunkLocatorQueue) LatestIndex() (int64, error) {
 }
 
 // AtIndex returns the chunk locator stored at the given index in the queue.
-func (q *ChunkLocatorQueue) AtIndex(index int64) (*chunks.ChunkLocator, error) {
+func (q *ChunkQueue) AtIndex(index int64) (*chunks.Locator, error) {
 	var chunkID flow.Identifier
 	err := q.db.View(operation.RetrieveJobAtIndex(JobQueueChunkQueue, index, &chunkID))
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve chunk locator in queue: %w", err)
 	}
 
-	var locator chunks.ChunkLocator
+	var locator chunks.Locator
 	err = q.db.View(operation.RetrieveChunkLocator(chunkID, &locator))
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve locator for chunk id %v: %w", chunkID, err)

--- a/storage/badger/chunks_queue.go
+++ b/storage/badger/chunks_queue.go
@@ -19,7 +19,7 @@ type ChunkLocatorQueue struct {
 	db *badger.DB
 }
 
-const JobQueueChunkLocatorQueue = "JobQueueChunkLocatorQueue"
+const JobQueueChunkQueue = "JobQueueChunkQueue"
 
 // NewChunkQueue will initialize the underlying badger database of chunk locator queue.
 func NewChunkQueue(db *badger.DB) *ChunkLocatorQueue {
@@ -32,7 +32,7 @@ func NewChunkQueue(db *badger.DB) *ChunkLocatorQueue {
 func (q *ChunkLocatorQueue) Init(defaultIndex int64) (bool, error) {
 	_, err := q.LatestIndex()
 	if errors.Is(err, storage.ErrNotFound) {
-		err = q.db.Update(operation.InitJobLatestIndex(JobQueueChunkLocatorQueue, defaultIndex))
+		err = q.db.Update(operation.InitJobLatestIndex(JobQueueChunkQueue, defaultIndex))
 		if err != nil {
 			return false, fmt.Errorf("could not init chunk locator queue with default index %v: %w", defaultIndex, err)
 		}
@@ -58,20 +58,20 @@ func (q *ChunkLocatorQueue) StoreChunkLocator(locator *chunks.ChunkLocator) (boo
 
 		// read the latest index
 		var latest int64
-		err = operation.RetrieveJobLatestIndex(JobQueueChunkLocatorQueue, &latest)(tx)
+		err = operation.RetrieveJobLatestIndex(JobQueueChunkQueue, &latest)(tx)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve job index for chunk locator queue: %w", err)
 		}
 
 		// insert to the next index
 		next := latest + 1
-		err = operation.InsertJobAtIndex(JobQueueChunkLocatorQueue, next, locator.ID())(tx)
+		err = operation.InsertJobAtIndex(JobQueueChunkQueue, next, locator.ID())(tx)
 		if err != nil {
 			return fmt.Errorf("failed to set job index for chunk locator queue at index %v: %w", next, err)
 		}
 
 		// update the next index as the latest index
-		err = operation.SetJobLatestIndex(JobQueueChunkLocatorQueue, next)(tx)
+		err = operation.SetJobLatestIndex(JobQueueChunkQueue, next)(tx)
 		if err != nil {
 			return fmt.Errorf("failed to update latest index %v: %w", next, err)
 		}
@@ -92,7 +92,7 @@ func (q *ChunkLocatorQueue) StoreChunkLocator(locator *chunks.ChunkLocator) (boo
 // LatestIndex returns the index of the latest chunk locator stored in the queue.
 func (q *ChunkLocatorQueue) LatestIndex() (int64, error) {
 	var latest int64
-	err := q.db.View(operation.RetrieveJobLatestIndex(JobQueueChunkLocatorQueue, &latest))
+	err := q.db.View(operation.RetrieveJobLatestIndex(JobQueueChunkQueue, &latest))
 	if err != nil {
 		return 0, fmt.Errorf("could not retrieve latest index for chunks queue: %w", err)
 	}
@@ -102,7 +102,7 @@ func (q *ChunkLocatorQueue) LatestIndex() (int64, error) {
 // AtIndex returns the chunk locator stored at the given index in the queue.
 func (q *ChunkLocatorQueue) AtIndex(index int64) (*chunks.ChunkLocator, error) {
 	var chunkID flow.Identifier
-	err := q.db.View(operation.RetrieveJobAtIndex(JobQueueChunkLocatorQueue, index, &chunkID))
+	err := q.db.View(operation.RetrieveJobAtIndex(JobQueueChunkQueue, index, &chunkID))
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve chunk locator in queue: %w", err)
 	}

--- a/storage/badger/chunks_queue.go
+++ b/storage/badger/chunks_queue.go
@@ -21,8 +21,8 @@ type ChunkLocatorQueue struct {
 
 const JobQueueChunkLocatorQueue = "JobQueueChunkLocatorQueue"
 
-// NewChunkLocatorQueue will initialize the underlying badger database of chunk locator queue.
-func NewChunkLocatorQueue(db *badger.DB) *ChunkLocatorQueue {
+// NewChunkQueue will initialize the underlying badger database of chunk locator queue.
+func NewChunkQueue(db *badger.DB) *ChunkLocatorQueue {
 	return &ChunkLocatorQueue{
 		db: db,
 	}

--- a/storage/badger/operation/chunks.go
+++ b/storage/badger/operation/chunks.go
@@ -7,10 +7,10 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func InsertChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) func(*badger.Txn) error {
-	return insert(makePrefix(codeChunk, chunkID), locator)
+func InsertChunkLocator(locator *chunks.ChunkLocator) func(*badger.Txn) error {
+	return insert(makePrefix(codeChunk, locator.ID()), locator)
 }
 
-func RetrieveChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) func(*badger.Txn) error {
-	return retrieve(makePrefix(codeChunk, chunkID), locator)
+func RetrieveChunkLocator(locatorID flow.Identifier, locator *chunks.ChunkLocator) func(*badger.Txn) error {
+	return retrieve(makePrefix(codeChunk, locatorID), locator)
 }

--- a/storage/badger/operation/chunks.go
+++ b/storage/badger/operation/chunks.go
@@ -3,13 +3,14 @@ package operation
 import (
 	"github.com/dgraph-io/badger/v2"
 
+	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func InsertChunk(chunk *flow.Chunk) func(*badger.Txn) error {
-	return insert(makePrefix(codeChunk, chunk.ID()), chunk)
+func InsertChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) func(*badger.Txn) error {
+	return insert(makePrefix(codeChunk, chunkID), locator)
 }
 
-func RetrieveChunk(chunkID flow.Identifier, chunk *flow.Chunk) func(*badger.Txn) error {
-	return retrieve(makePrefix(codeChunk, chunkID), chunk)
+func RetrieveChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) func(*badger.Txn) error {
+	return retrieve(makePrefix(codeChunk, chunkID), locator)
 }

--- a/storage/badger/operation/chunks.go
+++ b/storage/badger/operation/chunks.go
@@ -7,10 +7,10 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func InsertChunkLocator(locator *chunks.ChunkLocator) func(*badger.Txn) error {
+func InsertChunkLocator(locator *chunks.Locator) func(*badger.Txn) error {
 	return insert(makePrefix(codeChunk, locator.ID()), locator)
 }
 
-func RetrieveChunkLocator(locatorID flow.Identifier, locator *chunks.ChunkLocator) func(*badger.Txn) error {
+func RetrieveChunkLocator(locatorID flow.Identifier, locator *chunks.Locator) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeChunk, locatorID), locator)
 }

--- a/storage/chunks_queue.go
+++ b/storage/chunks_queue.go
@@ -2,11 +2,10 @@ package storage
 
 import (
 	"github.com/onflow/flow-go/model/chunks"
-	"github.com/onflow/flow-go/model/flow"
 )
 
 type ChunkLocatorQueue interface {
-	StoreChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) (bool, error)
+	StoreChunkLocator(locator *chunks.ChunkLocator) (bool, error)
 
 	LatestIndex() (int64, error)
 

--- a/storage/chunks_queue.go
+++ b/storage/chunks_queue.go
@@ -1,11 +1,14 @@
 package storage
 
-import "github.com/onflow/flow-go/model/flow"
+import (
+	"github.com/onflow/flow-go/model/chunks"
+	"github.com/onflow/flow-go/model/flow"
+)
 
-type ChunksQueue interface {
-	StoreChunk(*flow.Chunk) (bool, error)
+type ChunkLocatorQueue interface {
+	StoreChunkLocator(chunkID flow.Identifier, locator *chunks.ChunkLocator) (bool, error)
 
 	LatestIndex() (int64, error)
 
-	AtIndex(index int64) (*flow.Chunk, error)
+	AtIndex(index int64) (*chunks.ChunkLocator, error)
 }

--- a/storage/chunks_queue.go
+++ b/storage/chunks_queue.go
@@ -4,7 +4,7 @@ import (
 	"github.com/onflow/flow-go/model/chunks"
 )
 
-type ChunkLocatorQueue interface {
+type ChunkQueue interface {
 	StoreChunkLocator(locator *chunks.Locator) (bool, error)
 
 	LatestIndex() (int64, error)

--- a/storage/chunks_queue.go
+++ b/storage/chunks_queue.go
@@ -5,9 +5,9 @@ import (
 )
 
 type ChunkLocatorQueue interface {
-	StoreChunkLocator(locator *chunks.ChunkLocator) (bool, error)
+	StoreChunkLocator(locator *chunks.Locator) (bool, error)
 
 	LatestIndex() (int64, error)
 
-	AtIndex(index int64) (*chunks.ChunkLocator, error)
+	AtIndex(index int64) (*chunks.Locator, error)
 }


### PR DESCRIPTION
This PR refactors the underlying data object in `ChunkQueue`. Prior to this PR it as the `Chunk` stored in the `ChunkQueue`. However, we found it redundant to store the results and chunks separately. So, we introduce the chunk `Locator` which enables retrieving a chunk from an execution result. 