### PR TITLE
Vishal/removing conduit submit

### DIFF
--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -129,7 +129,7 @@ func TestExecutionFlow(t *testing.T) {
 				Blobs:     blobs,
 			}
 
-			err := provConduit.Submit(res, originID)
+			err := provConduit.Publish(res, originID)
 			assert.NoError(t, err)
 		}).
 		Once().
@@ -402,7 +402,7 @@ func mockCollectionEngineToReturnCollections(t *testing.T, collectionNode *testm
 				assert.FailNow(t, "requesting unexpected collection", req.EntityIDs[0])
 			}
 			res := &messages.EntityResponse{Blobs: [][]byte{blob}, EntityIDs: req.EntityIDs[:1]}
-			err := colConduit.Submit(res, originID)
+			err := colConduit.Publish(res, originID)
 			assert.NoError(t, err)
 		}).
 		Return(nil).

--- a/network/conduit.go
+++ b/network/conduit.go
@@ -53,16 +53,6 @@ func (cl ChannelList) ID() flow.Identifier {
 // engines with the same ID over a shared bus, accessible through the conduit.
 type Conduit interface {
 
-	// Submit will submit an event to the network layer. The network layer will
-	// ensure that the event is delivered to the same engine on the desired target
-	// nodes. It's possible that the event traverses other nodes than the target
-	// nodes on its path across the network. The network codec needs to be aware
-	// of how to encode the given event type, otherwise the send will fail.
-	//
-	// Note: Submit method is planned for deprecation soon.
-	// Alternative methods are recommended, e.g., Publish, Unicast, and Multicast.
-	Submit(event interface{}, targetIDs ...flow.Identifier) error
-
 	// Publish submits an event to the network layer for unreliable delivery
 	// to subscribers of the given event on the network layer. It uses a
 	// publish-subscribe layer and can thus not guarantee that the specified

--- a/network/mocknetwork/conduit.go
+++ b/network/mocknetwork/conduit.go
@@ -68,27 +68,6 @@ func (_m *Conduit) Publish(event interface{}, targetIDs ...flow.Identifier) erro
 	return r0
 }
 
-// Submit provides a mock function with given fields: event, targetIDs
-func (_m *Conduit) Submit(event interface{}, targetIDs ...flow.Identifier) error {
-	_va := make([]interface{}, len(targetIDs))
-	for _i := range targetIDs {
-		_va[_i] = targetIDs[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, event)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(interface{}, ...flow.Identifier) error); ok {
-		r0 = rf(event, targetIDs...)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Unicast provides a mock function with given fields: event, targetID
 func (_m *Conduit) Unicast(event interface{}, targetID flow.Identifier) error {
 	ret := _m.Called(event, targetID)

--- a/network/p2p/conduit.go
+++ b/network/p2p/conduit.go
@@ -8,11 +8,6 @@ import (
 	"github.com/onflow/flow-go/network"
 )
 
-// SubmitFunc is a function that submits the given event for the given engine to
-// the overlay network, which should take care of delivering it to the given
-// recipients.
-type SubmitFunc func(channel network.Channel, event interface{}, targetIDs ...flow.Identifier) error
-
 // PublishFunc is a function that broadcasts the specified event
 // to all participants on the given channel.
 type PublishFunc func(channel network.Channel, event interface{}, targetIDs ...flow.Identifier) error

--- a/network/p2p/conduit.go
+++ b/network/p2p/conduit.go
@@ -35,20 +35,10 @@ type Conduit struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	channel   network.Channel
-	submit    SubmitFunc
 	publish   PublishFunc
 	unicast   UnicastFunc
 	multicast MulticastFunc
 	close     CloseFunc
-}
-
-// Submit will submit an event for delivery on the engine bus that is reserved
-// for events of the engine it was initialized with.
-func (c *Conduit) Submit(event interface{}, targetIDs ...flow.Identifier) error {
-	if c.ctx.Err() != nil {
-		return fmt.Errorf("conduit for channel %s closed", c.channel)
-	}
-	return c.submit(c.channel, event, targetIDs...)
 }
 
 // Publish sends an event to the network layer for unreliable delivery

--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -132,7 +132,6 @@ func (n *Network) Register(channel network.Channel, engine network.Engine) (netw
 		ctx:       ctx,
 		cancel:    cancel,
 		channel:   channel,
-		submit:    n.submit,
 		publish:   n.publish,
 		unicast:   n.unicast,
 		multicast: n.multicast,
@@ -291,32 +290,6 @@ func (n *Network) genNetworkMessage(channel network.Channel, event interface{}, 
 	}
 
 	return msg, nil
-}
-
-// submit method submits the given event for the given channel to the overlay layer
-// for processing; it is used by engines through conduits.
-func (n *Network) submit(channel network.Channel, event interface{}, targetIDs ...flow.Identifier) error {
-
-	// genNetworkMessage the event to get payload and event ID
-	msg, err := n.genNetworkMessage(channel, event, targetIDs...)
-	if err != nil {
-		return fmt.Errorf("could not cast the event into network message: %w", err)
-	}
-
-	// TODO: dedup the message here
-	if len(targetIDs) > 1 {
-		err = n.mw.Publish(msg, channel)
-	} else if len(targetIDs) == 1 {
-		err = n.mw.SendDirect(msg, targetIDs[0])
-	} else {
-		return fmt.Errorf("empty target ID list for the message")
-	}
-
-	if err != nil {
-		return fmt.Errorf("could not gossip event: %w", err)
-	}
-
-	return nil
 }
 
 // unicast sends the message in a reliable way to the given recipient.

--- a/network/stub/conduit.go
+++ b/network/stub/conduit.go
@@ -13,18 +13,10 @@ type Conduit struct {
 	channel   network.Channel
 	ctx       context.Context
 	cancel    context.CancelFunc
-	submit    p2p.SubmitFunc
 	publish   p2p.PublishFunc
 	unicast   p2p.UnicastFunc
 	multicast p2p.MulticastFunc
 	close     p2p.CloseFunc
-}
-
-func (c *Conduit) Submit(event interface{}, targetIDs ...flow.Identifier) error {
-	if c.ctx.Err() != nil {
-		return fmt.Errorf("conduit for channel %s closed", c.channel)
-	}
-	return c.submit(c.channel, event, targetIDs...)
 }
 
 func (c *Conduit) Publish(event interface{}, targetIDs ...flow.Identifier) error {

--- a/network/stub/network.go
+++ b/network/stub/network.go
@@ -66,7 +66,6 @@ func (n *Network) Register(channel network.Channel, engine network.Engine) (netw
 		ctx:       ctx,
 		cancel:    cancel,
 		channel:   channel,
-		submit:    n.submit,
 		publish:   n.publish,
 		unicast:   n.unicast,
 		multicast: n.multicast,

--- a/network/test/echoengine_test.go
+++ b/network/test/echoengine_test.go
@@ -81,14 +81,6 @@ func (suite *EchoEngineTestSuite) TestDuplicateChannel() {
 	require.Error(suite.T(), err)
 }
 
-// TestSingleMessage_Submit tests sending a single message from sender to receiver using
-// the Submit method of Conduit.
-func (suite *EchoEngineTestSuite) TestSingleMessage_Submit() {
-	suite.skipTest("covered by TestEchoMultiMsgAsync_Submit")
-	// set to false for no echo expectation
-	suite.singleMessage(false, suite.Submit)
-}
-
 // TestSingleMessage_Publish tests sending a single message from sender to receiver using
 // the Publish method of Conduit.
 func (suite *EchoEngineTestSuite) TestSingleMessage_Publish() {
@@ -111,15 +103,6 @@ func (suite *EchoEngineTestSuite) TestSingleMessage_Multicast() {
 	suite.skipTest("covered by TestEchoMultiMsgAsync_Multicast")
 	// set to false for no echo expectation
 	suite.singleMessage(false, suite.Multicast)
-}
-
-// TestSingleEcho_Submit tests sending a single message from sender to receiver using
-// the Submit method of its Conduit.
-// It also evaluates the correct reception of an echo message back.
-func (suite *EchoEngineTestSuite) TestSingleEcho_Submit() {
-	suite.skipTest("covered by TestEchoMultiMsgAsync_Submit")
-	// set to true for an echo expectation
-	suite.singleMessage(true, suite.Submit)
 }
 
 // TestSingleEcho_Publish tests sending a single message from sender to receiver using
@@ -149,15 +132,6 @@ func (suite *EchoEngineTestSuite) TestSingleEcho_Multicast() {
 	suite.singleMessage(true, suite.Multicast)
 }
 
-// TestMultiMsgSync_Submit tests sending multiple messages from sender to receiver
-// using the Submit method of its Conduit.
-// Sender and receiver are synced over reception.
-func (suite *EchoEngineTestSuite) TestMultiMsgSync_Submit() {
-	suite.skipTest("covered by TestEchoMultiMsgAsync_Submit")
-	// set to false for no echo expectation
-	suite.multiMessageSync(false, 10, suite.Submit)
-}
-
 // TestMultiMsgSync_Publish tests sending multiple messages from sender to receiver
 // using the Publish method of its Conduit.
 // Sender and receiver are synced over reception.
@@ -185,16 +159,6 @@ func (suite *EchoEngineTestSuite) TestMultiMsgSync_Multicast() {
 	suite.multiMessageSync(false, 10, suite.Multicast)
 }
 
-// TestEchoMultiMsgSync_Submit tests sending multiple messages from sender to receiver
-// using the Submit method of its Conduit.
-// It also evaluates the correct reception of an echo message back for each send
-// sender and receiver are synced over reception.
-func (suite *EchoEngineTestSuite) TestEchoMultiMsgSync_Submit() {
-	suite.skipTest("covered by TestEchoMultiMsgAsync_Submit")
-	// set to true for an echo expectation
-	suite.multiMessageSync(true, 10, suite.Submit)
-}
-
 // TestEchoMultiMsgSync_Publish tests sending multiple messages from sender to receiver
 // using the Publish method of its Conduit.
 // It also evaluates the correct reception of an echo message back for each send
@@ -205,16 +169,6 @@ func (suite *EchoEngineTestSuite) TestEchoMultiMsgSync_Publish() {
 	suite.multiMessageSync(true, 10, suite.Publish)
 }
 
-// TestEchoMultiMsgSync_Unicast tests sending multiple messages from sender to receiver
-// using the Unicast method of its Conduit.
-// It also evaluates the correct reception of an echo message back for each send
-// sender and receiver are synced over reception.
-func (suite *EchoEngineTestSuite) TestEchoMultiMsgSync_Unicast() {
-	suite.skipTest("covered by TestEchoMultiMsgAsync_Unicast")
-	// set to true for an echo expectation
-	suite.multiMessageSync(true, 10, suite.Submit)
-}
-
 // TestEchoMultiMsgSync_Multicast tests sending multiple messages from sender to receiver
 // using the Multicast method of its Conduit.
 // It also evaluates the correct reception of an echo message back for each send
@@ -223,15 +177,6 @@ func (suite *EchoEngineTestSuite) TestEchoMultiMsgSync_Multicast() {
 	suite.skipTest("covered by TestEchoMultiMsgAsync_Multicast")
 	// set to true for an echo expectation
 	suite.multiMessageSync(true, 10, suite.Multicast)
-}
-
-// TestMultiMsgAsync_Submit tests sending multiple messages from sender to receiver
-// using the Submit method of their Conduit.
-// Sender and receiver are not synchronized.
-func (suite *EchoEngineTestSuite) TestMultiMsgAsync_Submit() {
-	suite.skipTest("covered by TestEchoMultiMsgAsync_Submit")
-	// set to false for no echo expectation
-	suite.multiMessageAsync(false, 10, suite.Submit)
 }
 
 // TestMultiMsgAsync_Publish tests sending multiple messages from sender to receiver
@@ -261,15 +206,6 @@ func (suite *EchoEngineTestSuite) TestMultiMsgAsync_Multicast() {
 	suite.multiMessageAsync(false, 10, suite.Multicast)
 }
 
-// TestEchoMultiMsgAsync_Submit tests sending multiple messages from sender to receiver
-// using the Submit method of their Conduit.
-// It also evaluates the correct reception of an echo message back for each send.
-// Sender and receiver are not synchronized
-func (suite *EchoEngineTestSuite) TestEchoMultiMsgAsync_Submit() {
-	// set to true for an echo expectation
-	suite.multiMessageAsync(true, 10, suite.Submit)
-}
-
 // TestEchoMultiMsgAsync_Publish tests sending multiple messages from sender to receiver
 // using the Publish method of their Conduit.
 // It also evaluates the correct reception of an echo message back for each send.
@@ -297,14 +233,6 @@ func (suite *EchoEngineTestSuite) TestEchoMultiMsgAsync_Multicast() {
 	suite.multiMessageAsync(true, 10, suite.Multicast)
 }
 
-// TestDuplicateMessageSequential_Submit evaluates the correctness of network layer on deduplicating
-// the received messages over Submit method of nodes' Conduits.
-// Messages are delivered to the receiver in a sequential manner.
-func (suite *EchoEngineTestSuite) TestDuplicateMessageSequential_Submit() {
-	suite.skipTest("covered by TestDuplicateMessageParallel_Submit")
-	suite.duplicateMessageSequential(suite.Submit)
-}
-
 // TestDuplicateMessageSequential_Publish evaluates the correctness of network layer on deduplicating
 // the received messages over Publish method of nodes' Conduits.
 // Messages are delivered to the receiver in a sequential manner.
@@ -329,13 +257,6 @@ func (suite *EchoEngineTestSuite) TestDuplicateMessageSequential_Multicast() {
 	suite.duplicateMessageSequential(suite.Multicast)
 }
 
-// TestDuplicateMessageParallel_Submit evaluates the correctness of network layer
-// on deduplicating the received messages via Submit method of nodes' Conduits.
-// Messages are delivered to the receiver in parallel via the Submit method of Conduits.
-func (suite *EchoEngineTestSuite) TestDuplicateMessageParallel_Submit() {
-	suite.duplicateMessageParallel(suite.Submit)
-}
-
 // TestDuplicateMessageParallel_Publish evaluates the correctness of network layer
 // on deduplicating the received messages via Publish method of nodes' Conduits.
 // Messages are delivered to the receiver in parallel via the Publish method of Conduits.
@@ -355,14 +276,6 @@ func (suite *EchoEngineTestSuite) TestDuplicateMessageParallel_Unicast() {
 // Messages are delivered to the receiver in parallel via the Multicast method of Conduits.
 func (suite *EchoEngineTestSuite) TestDuplicateMessageParallel_Multicast() {
 	suite.duplicateMessageParallel(suite.Multicast)
-}
-
-// TestDuplicateMessageDifferentChan_Submit evaluates the correctness of network layer
-// on deduplicating the received messages via Submit method of Conduits against different engine ids. In specific, the
-// desire behavior is that the deduplication should happen based on both eventID and channel.
-// Messages are sent via the Submit method of the Conduits.
-func (suite *EchoEngineTestSuite) TestDuplicateMessageDifferentChan_Submit() {
-	suite.duplicateMessageDifferentChan(suite.Submit)
 }
 
 // TestDuplicateMessageDifferentChan_Publish evaluates the correctness of network layer

--- a/network/test/meshengine_test.go
+++ b/network/test/meshengine_test.go
@@ -53,12 +53,6 @@ func (suite *MeshEngineTestSuite) TearDownTest() {
 	stopNetworks(suite.T(), suite.nets, 3*time.Second)
 }
 
-// TestAllToAll_Submit evaluates the network of mesh engines against allToAllScenario scenario.
-// Network instances during this test use their Submit method to disseminate messages.
-func (suite *MeshEngineTestSuite) TestAllToAll_Submit() {
-	suite.allToAllScenario(suite.Submit)
-}
-
 // TestAllToAll_Publish evaluates the network of mesh engines against allToAllScenario scenario.
 // Network instances during this test use their Publish method to disseminate messages.
 func (suite *MeshEngineTestSuite) TestAllToAll_Publish() {
@@ -75,12 +69,6 @@ func (suite *MeshEngineTestSuite) TestAllToAll_Multicast() {
 // Network instances during this test use their Unicast method to disseminate messages.
 func (suite *MeshEngineTestSuite) TestAllToAll_Unicast() {
 	suite.allToAllScenario(suite.Unicast)
-}
-
-// TestTargetedValidators_Submit tests if only the intended recipients in a 1-k messaging actually receive the message.
-// The messages are disseminated through the Submit method of conduits.
-func (suite *MeshEngineTestSuite) TestTargetedValidators_Submit() {
-	suite.targetValidatorScenario(suite.Submit)
 }
 
 // TestTargetedValidators_Unicast tests if only the intended recipients in a 1-k messaging actually receive the message.
@@ -100,12 +88,6 @@ func (suite *MeshEngineTestSuite) TestTargetedValidators_Multicast() {
 // The messages are disseminated through the Multicast method of conduits.
 func (suite *MeshEngineTestSuite) TestTargetedValidators_Publish() {
 	suite.targetValidatorScenario(suite.Publish)
-}
-
-// TestMaxMessageSize_Submit evaluates the messageSizeScenario scenario using
-// the Submit method of conduits.
-func (suite *MeshEngineTestSuite) TestMaxMessageSize_Submit() {
-	suite.messageSizeScenario(suite.Submit, p2p.DefaultMaxPubSubMsgSize)
 }
 
 // TestMaxMessageSize_Unicast evaluates the messageSizeScenario scenario using
@@ -136,12 +118,6 @@ func (suite *MeshEngineTestSuite) TestUnregister_Publish() {
 // or receive any messages after the conduit is closed
 func (suite *MeshEngineTestSuite) TestUnregister_Multicast() {
 	suite.conduitCloseScenario(suite.Multicast)
-}
-
-// TestUnregister_Publish tests that an engine cannot send any message using Submit
-// or receive any messages after the conduit is closed
-func (suite *MeshEngineTestSuite) TestUnregister_Submit() {
-	suite.conduitCloseScenario(suite.Submit)
 }
 
 // TestUnregister_Publish tests that an engine cannot send any message using Unicast

--- a/network/test/wrapper.go
+++ b/network/test/wrapper.go
@@ -14,12 +14,6 @@ type ConduitSendWrapperFunc func(msg interface{}, conduit network.Conduit, targe
 
 type ConduitWrapper struct{}
 
-// Submit defines a function that receives a message, conduit of an engine instance, and
-// a set of target IDa. It then sends the message to the target IDs using the Submit method of conduit.
-func (c *ConduitWrapper) Submit(msg interface{}, conduit network.Conduit, targetIDs ...flow.Identifier) error {
-	return conduit.Submit(msg, targetIDs...)
-}
-
 // Publish defines a function that receives a message, conduit of an engine instance, and
 // a set target IDs. It then sends the message to the target IDs using the Publish method of conduit.
 func (c *ConduitWrapper) Publish(msg interface{}, conduit network.Conduit, targetIDs ...flow.Identifier) error {


### PR DESCRIPTION
- Removing the `conduit.Submit` function all together (since it has been replaced by `Publish` and `Mulitcast`)
- Removing all its usages and tests

(https://www.notion.so/dapperlabs/Networking-primitives-58460d04d78f4129b4222d732b5dff95)