### PR TITLE
Update to Cadence v0.12.11, port patches to v0.14

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -220,7 +220,7 @@ func (e *blockComputer) executeCollection(
 	for _, txBody := range collection.Transactions {
 
 		txEvents, txServiceEvents, txResult, txGasUsed, err :=
-		 	e.executeTransaction(txBody, colSpan, txMetrics, collectionView, txCtx, txIndex)
+			e.executeTransaction(txBody, colSpan, txMetrics, collectionView, txCtx, txIndex)
 
 		txIndex++
 		events = append(events, txEvents...)

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -122,7 +122,10 @@ func (e *blockComputer) executeBlock(
 
 		collectionView := stateView.NewChild()
 
-		e.log.Debug().Hex("block_id", logging.Entity(block)).Hex("collection_id", logging.Entity(collection.Guarantee)).Msg("executing collection")
+		e.log.Debug().
+			Hex("block_id", logging.Entity(block)).
+			Hex("collection_id", logging.Entity(collection.Guarantee)).
+			Msg("executing collection")
 
 		collEvents, collServiceEvents, txResults, nextIndex, gas, err := e.executeCollection(
 			ctx, txIndex, blockCtx, collectionView, collection,
@@ -215,7 +218,9 @@ func (e *blockComputer) executeCollection(
 	txCtx := fvm.NewContextFromParent(blockCtx, fvm.WithMetricsCollector(txMetrics))
 
 	for _, txBody := range collection.Transactions {
-		txEvents, txServiceEvents, txResult, txGasUsed, err := e.executeTransaction(txBody, colSpan, txMetrics, collectionView, txCtx, txIndex)
+
+		txEvents, txServiceEvents, txResult, txGasUsed, err :=
+		 	e.executeTransaction(txBody, colSpan, txMetrics, collectionView, txCtx, txIndex)
 
 		txIndex++
 		events = append(events, txEvents...)
@@ -262,6 +267,10 @@ func (e *blockComputer) executeTransaction(
 			txSpan.Finish()
 		}()
 	}
+
+	e.log.Debug().
+		Hex("tx_id", logging.Entity(txBody)).
+		Msg("executing transaction")
 
 	txView := collectionView.NewChild()
 

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -44,7 +44,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	var expectedStateCommitment, _ = hex.DecodeString("715aa98fd5fad32ba328239bc37f3694b09ee95c2e1667002baa4bbde1f7d009")
+	var expectedStateCommitment, _ = hex.DecodeString("8e16c6bb5a42a4bcbd01d156c7d6f4b4cd2f37bcd2bdf5779338b2d9585eaab5")
 
 	unittest.RunWithTempDir(t, func(dbDir string) {
 

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -549,7 +549,7 @@ func (e *hostEnv) GetSigningAccounts() ([]runtime.Address, error) {
 }
 
 func (e *hostEnv) ImplementationDebugLog(message string) error {
-	e.ctx.Logger.Debug().Msg(fmt.Sprintf("Cadence: %s", message))
+	e.ctx.Logger.Debug().Msgf("Cadence: %s", message)
 	return nil
 }
 

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -299,7 +299,7 @@ func (e *hostEnv) CacheProgram(location common.Location, program *ast.Program) e
 	return e.ctx.ASTCache.SetProgram(location, program)
 }
 
-func (e *hostEnv) Log(message string) error {
+func (e *hostEnv) ProgramLog(message string) error {
 	if e.ctx.CadenceLoggingEnabled {
 		e.logs = append(e.logs, message)
 	}
@@ -546,6 +546,11 @@ func (e *hostEnv) GetSigningAccounts() ([]runtime.Address, error) {
 	}
 
 	return e.transactionEnv.GetSigningAccounts(), nil
+}
+
+func (e *hostEnv) ImplementationDebugLog(message string) error {
+	e.ctx.Logger.Debug().Msg(fmt.Sprintf("Cadence: %s", message))
+	return nil
 }
 
 // Transaction Environment

--- a/fvm/errors.go
+++ b/fvm/errors.go
@@ -3,6 +3,7 @@ package fvm
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -28,6 +29,8 @@ const (
 	errCodeStorageCapacityExceeded = 11
 
 	errCodeEventLimitExceededError = 20
+
+	errCodeEncodingUnsupportedValue = 30
 
 	errCodeExecution = 100
 )
@@ -261,6 +264,25 @@ func (e *ExecutionError) Error() string {
 
 func (e *ExecutionError) Code() uint32 {
 	return errCodeExecution
+}
+
+// EncodingUnsupportedValueError indicates that Cadence attempted
+// to encode a value that is not supported.
+type EncodingUnsupportedValueError struct {
+	Value interpreter.Value
+	Path  []string
+}
+
+func (e *EncodingUnsupportedValueError) Error() string {
+	return fmt.Sprintf(
+		"encoding unsupported value to path [%s]: %[1]T, %[1]v",
+		strings.Join(e.Path, ","),
+		e.Value,
+	)
+}
+
+func (e *EncodingUnsupportedValueError) Code() uint32 {
+	return errCodeEncodingUnsupportedValue
 }
 
 func handleError(err error) (vmErr Error, fatalErr error) {

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -94,7 +94,9 @@ func (i *TransactionInvocator) Process(
 		return err
 	}
 
-	i.logger.Info().Str("txHash", proc.ID.String()).Msgf("(%d) ledger interactions used by transaction", st.InteractionUsed())
+	i.logger.Info().
+		Str("txHash", proc.ID.String()).
+		Msgf("(%d) ledger interactions used by transaction", st.InteractionUsed())
 
 	proc.Events = env.getEvents()
 	proc.ServiceEvents = env.getServiceEvents()

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.12.10
+	github.com/onflow/cadence v0.12.11
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.12.9
+	github.com/onflow/cadence v0.12.10
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.12.7
+	github.com/onflow/cadence v0.12.8
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.12.6
+	github.com/onflow/cadence v0.12.7
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.12.8
+	github.com/onflow/cadence v0.12.9
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -823,8 +823,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
-github.com/onflow/cadence v0.12.8 h1:zeaxpbESgG422pwt/XjDBjQPCODehSqrZRJx9ngcarY=
-github.com/onflow/cadence v0.12.8/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.9 h1:uGzomFVQOjRLDb9Dv8hUTLXpYK1U/MDK+m73gxHRGbc=
+github.com/onflow/cadence v0.12.9/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/go.sum
+++ b/go.sum
@@ -823,8 +823,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
-github.com/onflow/cadence v0.12.9 h1:uGzomFVQOjRLDb9Dv8hUTLXpYK1U/MDK+m73gxHRGbc=
-github.com/onflow/cadence v0.12.9/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.10 h1:MPcA9A1/GEjN6L2/hwiveuTKlV5bTuakliFgOq4ZOeE=
+github.com/onflow/cadence v0.12.10/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/go.sum
+++ b/go.sum
@@ -823,8 +823,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
-github.com/onflow/cadence v0.12.10 h1:MPcA9A1/GEjN6L2/hwiveuTKlV5bTuakliFgOq4ZOeE=
-github.com/onflow/cadence v0.12.10/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.11 h1:58liHX4nioCmFwaIZ0usBwT91j0G9XIZu4Bvl5oUhQs=
+github.com/onflow/cadence v0.12.11/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/go.sum
+++ b/go.sum
@@ -823,6 +823,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.7 h1:AJAaC8DieEmUqAiDP5fFL8Qo5J1HzeWubD35S8GNxKA=
+github.com/onflow/cadence v0.12.7/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/go.sum
+++ b/go.sum
@@ -823,8 +823,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
-github.com/onflow/cadence v0.12.7 h1:AJAaC8DieEmUqAiDP5fFL8Qo5J1HzeWubD35S8GNxKA=
-github.com/onflow/cadence v0.12.7/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.8 h1:zeaxpbESgG422pwt/XjDBjQPCODehSqrZRJx9ngcarY=
+github.com/onflow/cadence v0.12.8/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.12.9
+	github.com/onflow/cadence v0.12.10
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.12.8
+	github.com/onflow/cadence v0.12.9
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.12.10
+	github.com/onflow/cadence v0.12.11
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.12.6
+	github.com/onflow/cadence v0.12.8
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.14.3
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -887,8 +887,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
-github.com/onflow/cadence v0.12.10 h1:MPcA9A1/GEjN6L2/hwiveuTKlV5bTuakliFgOq4ZOeE=
-github.com/onflow/cadence v0.12.10/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.11 h1:58liHX4nioCmFwaIZ0usBwT91j0G9XIZu4Bvl5oUhQs=
+github.com/onflow/cadence v0.12.11/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -887,8 +887,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
-github.com/onflow/cadence v0.12.9 h1:uGzomFVQOjRLDb9Dv8hUTLXpYK1U/MDK+m73gxHRGbc=
-github.com/onflow/cadence v0.12.9/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.10 h1:MPcA9A1/GEjN6L2/hwiveuTKlV5bTuakliFgOq4ZOeE=
+github.com/onflow/cadence v0.12.10/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -887,6 +887,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.8 h1:zeaxpbESgG422pwt/XjDBjQPCODehSqrZRJx9ngcarY=
+github.com/onflow/cadence v0.12.8/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -887,8 +887,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.12.6 h1:IvKSx5C84B4DGBf4DUAtLE2WtC24KAZR4z5XZyGGPYM=
 github.com/onflow/cadence v0.12.6/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
-github.com/onflow/cadence v0.12.8 h1:zeaxpbESgG422pwt/XjDBjQPCODehSqrZRJx9ngcarY=
-github.com/onflow/cadence v0.12.8/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
+github.com/onflow/cadence v0.12.9 h1:uGzomFVQOjRLDb9Dv8hUTLXpYK1U/MDK+m73gxHRGbc=
+github.com/onflow/cadence v0.12.9/go.mod h1:CHQIgovf2fks/6kwrpBaatNarHxX5qJggynAbjEnSvQ=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -19,7 +19,7 @@ import (
 const ServiceAccountPrivateKeyHex = "e3a08ae3d0461cfed6d6f49bfc25fa899351c39d1bd21fdba8c87595b6c49bb4cc430201"
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "a8821281ef643bee84d3d0d4aee75435555a9205805881ec30a3c637ff5ba013"
+const GenesisStateCommitmentHex = "1abd0d7da12fbae71913d0280d2b100acf73cf3ac4ae37be8a65384a521219d8"
 
 var GenesisStateCommitment flow.StateCommitment
 


### PR DESCRIPTION
Cherry-pick the patches applied to `v0.14` also to `master`, namely these PRs:
- Debug log execution of transaction #368
- Handle encoding errors gracefully #369 
- Update to Cadence v0.12.8, implement debug log function #370 
- Update to Cadence v0.12.9 #371 
- Update to Cadence v0.12.10 #375 
- Update to Cadence v0.12.11 #379 