### PR TITLE
[Execution] increase the event size limit and ledger interaction limit

### DIFF
--- a/fvm/context.go
+++ b/fvm/context.go
@@ -57,7 +57,7 @@ const AccountKeyWeightThreshold = 1000
 
 const (
 	DefaultGasLimit                     = 100_000 // 100K
-	DefaultEventCollectionByteSizeLimit = 512_000 // 512KB
+	DefaultEventCollectionByteSizeLimit = 256_000 // 256KB
 )
 
 func defaultContext(logger zerolog.Logger) Context {

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -57,7 +57,7 @@ const AccountKeyWeightThreshold = 1000
 
 const (
 	DefaultGasLimit                     = 100_000 // 100K
-	DefaultEventCollectionByteSizeLimit = 128_000 // 128KB
+	DefaultEventCollectionByteSizeLimit = 512_000 // 512KB
 )
 
 func defaultContext(logger zerolog.Logger) Context {

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -10,9 +10,9 @@ import (
 // TODO we started with high numbers here and we might
 // tune (reduce) them when we have more data
 const (
-	DefaultMaxKeySize         = 16_000      // ~16KB
-	DefaultMaxValueSize       = 64_000_000  // ~64MB
-	DefaultMaxInteractionSize = 256_000_000 // ~256MB
+	DefaultMaxKeySize         = 16_000        // ~16KB
+	DefaultMaxValueSize       = 256_000_000   // ~256MB
+	DefaultMaxInteractionSize = 2_000_000_000 // ~2GB
 )
 
 type StateOption func(st *State) *State


### PR DESCRIPTION
increasing the limits for now, until we optimize event storage and improve ledger trie balance.

Note that event limits are not enforced for tx paid by the service account (for epoch switch operations) 