### PR TITLE
[Execution] fix time tracking for tracing tx execution

### DIFF
--- a/fvm/metrics.go
+++ b/fvm/metrics.go
@@ -35,19 +35,28 @@ type metricsCollector struct {
 
 func (m metricsCollector) ProgramParsed(location common.Location, duration time.Duration) {
 	if m.MetricsCollector != nil {
-		m.parsed += duration
+		// only capture tx parsing time
+		if _, ok := location.(common.TransactionLocation); ok {
+			m.parsed = duration
+		}
 	}
 }
 
 func (m metricsCollector) ProgramChecked(location common.Location, duration time.Duration) {
 	if m.MetricsCollector != nil {
-		m.checked += duration
+		// only capture tx checking time
+		if _, ok := location.(common.TransactionLocation); ok {
+			m.checked = duration
+		}
 	}
 }
 
 func (m metricsCollector) ProgramInterpreted(location common.Location, duration time.Duration) {
 	if m.MetricsCollector != nil {
-		m.interpreted += duration
+		// only capture tx interpreting time
+		if _, ok := location.(common.TransactionLocation); ok {
+			m.interpreted = duration
+		}
 	}
 }
 


### PR DESCRIPTION
Currently, there are two problems with time tracking for parsing, checking and interpreting a transaction:
- the Metric is constructed in the context (shared for all collections in a block) 
- metric calls by the cadence runtime have overlaps. 


This patch will change the logic to only capture the time spend by tx itself. in the following PR to the master, we revisit the whole structure. 