### PR TITLE
[Crypto] use BLS multi-sig to create and verify QCs

### DIFF
--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -22,6 +22,7 @@ import (
 	followereng "github.com/onflow/flow-go/engine/common/follower"
 	"github.com/onflow/flow-go/engine/common/requester"
 	synceng "github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -264,7 +265,7 @@ func main() {
 			// initialize the staking & beacon verifiers, signature joiner
 			staking := signature.NewAggregationVerifier(encoding.ConsensusVoteTag)
 			beacon := signature.NewThresholdVerifier(encoding.RandomBeaconTag)
-			merger := signature.NewCombiner()
+			merger := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
 
 			// initialize consensus committee's membership state
 			// This committee state is for the HotStuff follower, which follows the MAIN CONSENSUS Committee

--- a/cmd/bootstrap/run/qc.go
+++ b/cmd/bootstrap/run/qc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/verification"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/local"
@@ -101,7 +102,7 @@ func createValidators(participantData *ParticipantData) ([]hotstuff.Validator, [
 		// create signer
 		stakingSigner := signature.NewAggregationProvider(encoding.ConsensusVoteTag, local)
 		beaconSigner := signature.NewThresholdProvider(encoding.RandomBeaconTag, participant.RandomBeaconPrivKey)
-		merger := signature.NewCombiner()
+		merger := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
 		signer := verification.NewCombinedSigner(committee, stakingSigner, beaconSigner, merger, participant.NodeID)
 		signers[i] = signer
 

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -21,6 +21,7 @@ import (
 	followereng "github.com/onflow/flow-go/engine/common/follower"
 	"github.com/onflow/flow-go/engine/common/provider"
 	consync "github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -164,7 +165,7 @@ func main() {
 			// initialize the staking & beacon verifiers, signature joiner
 			staking := signature.NewAggregationVerifier(encoding.ConsensusVoteTag)
 			beacon := signature.NewThresholdVerifier(encoding.RandomBeaconTag)
-			merger := signature.NewCombiner()
+			merger := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
 
 			// initialize consensus committee's membership state
 			// This committee state is for the HotStuff follower, which follows the MAIN CONSENSUS Committee

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/flow-go/engine/consensus/matching"
 	"github.com/onflow/flow-go/engine/consensus/provider"
 	"github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -357,7 +358,7 @@ func main() {
 			beacon := signature.NewThresholdProvider(encoding.RandomBeaconTag, privateDKGData.RandomBeaconPrivKey)
 
 			// initialize the simple merger to combine staking & beacon signatures
-			merger := signature.NewCombiner()
+			merger := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
 
 			// initialize Main consensus committee's state
 			var committee hotstuff.Committee

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -31,6 +31,7 @@ import (
 	ledger "github.com/onflow/flow-go/ledger/complete"
 	wal "github.com/onflow/flow-go/ledger/complete/wal"
 	bootstrapFilenames "github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -295,7 +296,7 @@ func main() {
 			// initialize the staking & beacon verifiers, signature joiner
 			staking := signature.NewAggregationVerifier(encoding.ConsensusVoteTag)
 			beacon := signature.NewThresholdVerifier(encoding.RandomBeaconTag)
-			merger := signature.NewCombiner()
+			merger := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
 
 			// initialize consensus committee's membership state
 			// This committee state is for the HotStuff follower, which follows the MAIN CONSENSUS Committee

--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/engine/verification/match"
 	"github.com/onflow/flow-go/engine/verification/verifier"
 	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
@@ -334,7 +335,7 @@ func main() {
 			// initialize the staking & beacon verifiers, signature joiner
 			staking := signature.NewAggregationVerifier(encoding.ConsensusVoteTag)
 			beacon := signature.NewThresholdVerifier(encoding.RandomBeaconTag)
-			merger := signature.NewCombiner()
+			merger := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
 
 			// initialize consensus committee's membership state
 			// This committee state is for the HotStuff follower, which follows the MAIN CONSENSUS Committee

--- a/consensus/hotstuff/verification/combined_signer.go
+++ b/consensus/hotstuff/verification/combined_signer.go
@@ -90,6 +90,7 @@ func (c *CombinedSigner) CreateVote(block *model.Block) (*model.Vote, error) {
 func (c *CombinedSigner) CreateQC(votes []*model.Vote) (*flow.QuorumCertificate, error) {
 
 	// check the consistency of the votes
+	// TODO: why do we check for message consistency here? (single votes are supposed to be already checked)
 	err := checkVotesValidity(votes)
 	if err != nil {
 		return nil, fmt.Errorf("votes are not valid: %w", err)
@@ -153,7 +154,7 @@ func (c *CombinedSigner) CreateQC(votes []*model.Vote) (*flow.QuorumCertificate,
 	}
 
 	// construct the threshold signature from the shares
-	beaconThresSig, err := c.beacon.Combine(dkg.Size(), beaconShares, dkgIndices)
+	beaconThresSig, err := c.beacon.Reconstruct(dkg.Size(), beaconShares, dkgIndices)
 	if err != nil {
 		return nil, fmt.Errorf("could not aggregate second signatures: %w", err)
 	}

--- a/consensus/hotstuff/verification/combined_signer.go
+++ b/consensus/hotstuff/verification/combined_signer.go
@@ -90,7 +90,7 @@ func (c *CombinedSigner) CreateVote(block *model.Block) (*model.Vote, error) {
 func (c *CombinedSigner) CreateQC(votes []*model.Vote) (*flow.QuorumCertificate, error) {
 
 	// check the consistency of the votes
-	// TODO: why do we check for message consistency here? (single votes are supposed to be already checked)
+	// TODO: why do we check for message consistency here? (votes are supposed to be already checked before createQC)
 	err := checkVotesValidity(votes)
 	if err != nil {
 		return nil, fmt.Errorf("votes are not valid: %w", err)
@@ -158,10 +158,6 @@ func (c *CombinedSigner) CreateQC(votes []*model.Vote) (*flow.QuorumCertificate,
 	if err != nil {
 		return nil, fmt.Errorf("could not aggregate second signatures: %w", err)
 	}
-
-	// TODO: once true BLS signature aggregation has been implemented, the performance
-	// impact of verifying the aggregated signature and the threshold signature should
-	// be minor and we can consider adding a sanity check
 
 	// combine the aggregated staking signature with the threshold beacon signature
 	combinedMultiSig, err := c.merger.Join(stakingAggSig, beaconThresSig)

--- a/consensus/hotstuff/verification/combined_test.go
+++ b/consensus/hotstuff/verification/combined_test.go
@@ -119,8 +119,9 @@ func TestCombinedQC(t *testing.T) {
 	assert.True(t, valid, "original QC should be valid")
 
 	// verification with missing identity should be invalid
-	_, err = signers[0].VerifyQC(voterIDs[:minShares-1], qc.SigData, block)
-	assert.Error(t, err, "verification of QC should fail with missing voter ID")
+	valid, err = signers[0].VerifyQC(voterIDs[:minShares-1], qc.SigData, block)
+	require.NoError(t, err)
+	assert.False(t, valid, "verification of QC should fail with missing voter ID")
 
 	// verification with changed signature should fail
 	// TODO: change error handling so split failure & invalid signature is

--- a/consensus/hotstuff/verification/combined_verifier.go
+++ b/consensus/hotstuff/verification/combined_verifier.go
@@ -57,19 +57,10 @@ func (c *CombinedVerifier) VerifyVote(voterID flow.Identifier, sigData []byte, b
 	}
 
 	// split the two signatures from the vote
-	splitSigs, err := c.merger.Split(sigData)
+	stakingSig, beaconShare, err := c.merger.Split(sigData)
 	if err != nil {
 		return false, fmt.Errorf("could not split signature: %w", ErrInvalidFormat)
 	}
-
-	// check if we have two signature
-	if len(splitSigs) != 2 {
-		return false, fmt.Errorf("wrong number of combined signatures: %w", ErrInvalidFormat)
-	}
-
-	// assign the signtures
-	stakingSig := splitSigs[0]
-	beaconShare := splitSigs[1]
 
 	dkg, err := c.committee.DKG(block.BlockID)
 	if err != nil {
@@ -117,19 +108,10 @@ func (c *CombinedVerifier) VerifyQC(voterIDs []flow.Identifier, sigData []byte, 
 	}
 
 	// split the aggregated staking & beacon signatures
-	splitSigs, err := c.merger.Split(sigData)
+	stakingAggSig, beaconThresSig, err := c.merger.Split(sigData)
 	if err != nil {
 		return false, fmt.Errorf("could not split signature: %w", ErrInvalidFormat)
 	}
-
-	// check we have the right amount of split sigs
-	if len(splitSigs) != 2 {
-		return false, fmt.Errorf("invalid number of split signatures: %w", ErrInvalidFormat)
-	}
-
-	// assign the signatures
-	stakingAggSig := splitSigs[0]
-	beaconThresSig := splitSigs[1]
 
 	msg := makeVoteMessage(block.View, block.BlockID)
 	// TODO: verify if batch verification is faster

--- a/consensus/hotstuff/verification/common.go
+++ b/consensus/hotstuff/verification/common.go
@@ -43,6 +43,7 @@ func checkVotesValidity(votes []*model.Vote) error {
 
 	// go through all votes to check their validity
 	for _, vote := range votes {
+		// TODO: is checking the view and block id needed? (single votes are supposed to be already checked)
 
 		// if we have a view mismatch, bail
 		if vote.View != view {

--- a/consensus/hotstuff/verification/common_test.go
+++ b/consensus/hotstuff/verification/common_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/helper"
 	"github.com/onflow/flow-go/consensus/hotstuff/mocks"
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/module/signature"
@@ -50,7 +51,7 @@ func MakeBeaconSigner(t *testing.T, committee hotstuff.Committee, signerID flow.
 	require.NoError(t, err)
 	staking := signature.NewAggregationProvider("test_staking", local)
 	beacon := signature.NewThresholdProvider("test_beacon", beaconPriv)
-	combiner := signature.NewCombiner()
+	combiner := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
 	signer := NewCombinedSigner(committee, staking, beacon, combiner, signerID)
 	return signer
 }

--- a/consensus/hotstuff/verification/single_signer.go
+++ b/consensus/hotstuff/verification/single_signer.go
@@ -92,7 +92,6 @@ func (s *SingleSigner) CreateVote(block *model.Block) (*model.Vote, error) {
 func (s *SingleSigner) CreateQC(votes []*model.Vote) (*flow.QuorumCertificate, error) {
 
 	// check the consistency of the votes
-	// TODO: why do we check for message consistency here? (single votes are supposed to be already checked)
 	err := checkVotesValidity(votes)
 	if err != nil {
 		return nil, fmt.Errorf("votes are not valid: %w", err)

--- a/consensus/hotstuff/verification/single_signer.go
+++ b/consensus/hotstuff/verification/single_signer.go
@@ -92,6 +92,7 @@ func (s *SingleSigner) CreateVote(block *model.Block) (*model.Vote, error) {
 func (s *SingleSigner) CreateQC(votes []*model.Vote) (*flow.QuorumCertificate, error) {
 
 	// check the consistency of the votes
+	// TODO: why do we check for message consistency here? (single votes are supposed to be already checked)
 	err := checkVotesValidity(votes)
 	if err != nil {
 		return nil, fmt.Errorf("votes are not valid: %w", err)

--- a/consensus/hotstuff/verification/single_test.go
+++ b/consensus/hotstuff/verification/single_test.go
@@ -115,7 +115,8 @@ func TestSingleQC(t *testing.T) {
 
 	// verification with missing identity should be invalid
 	valid, err = signers[0].VerifyQC(voterIDs[:minShares-1], qc.SigData, block)
-	assert.Error(t, err, "verification with missing voter ID should not work")
+	require.NoError(t, err)
+	assert.False(t, valid, "verification with missing voter ID should not work")
 
 	// verification with changed signature should fail
 	// TODO: change error handling so split failure and invalid signature are

--- a/consensus/hotstuff/verification/single_verifier.go
+++ b/consensus/hotstuff/verification/single_verifier.go
@@ -7,7 +7,6 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
-	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module"
 )
 
@@ -65,7 +64,6 @@ func (s *SingleVerifier) VerifyQC(voterIDs []flow.Identifier, sigData []byte, bl
 	if len(signers) < len(voterIDs) { // check we have valid consensus member Identities for all signers
 		return false, fmt.Errorf("some signers are not valid consensus participants at block %x: %w", block.BlockID, model.ErrInvalidSigner)
 	}
-	signers = signers.Order(order.ByReferenceOrder(voterIDs)) // re-arrange Identities into the same order as in voterIDs
 
 	// create the message we verify against and check signature
 	msg := makeVoteMessage(block.View, block.BlockID)

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -82,9 +82,8 @@ func createNodes(t *testing.T, n int, finalizedCount uint, tolerate int) ([]*Nod
 	rand.Read(sig1[:])
 	sig2 := make([]byte, 32)
 	rand.Read(sig2[:])
-	c := &signature.Combiner{}
-	combined, err := c.Join(sig1, sig2)
-	require.NoError(t, err)
+	c := signature.NewCombiner(32, 32)
+	combined := c.Join(sig1, sig2)
 
 	// all participants will sign the rootBlock block
 	signerIDs := make([]flow.Identifier, 0)

--- a/crypto/bls_test.go
+++ b/crypto/bls_test.go
@@ -404,6 +404,7 @@ func TestBatchVerify(t *testing.T) {
 	// hasher
 	kmac := NewBLSKMAC("test tag")
 	// number of signatures to aggregate
+	// TODO: add a test for 1 signature
 	sigsNum := mrand.Intn(100) + 2
 	sigs := make([]Signature, 0, sigsNum)
 	sks := make([]PrivateKey, 0, sigsNum)

--- a/model/encodable/keys.go
+++ b/model/encodable/keys.go
@@ -12,6 +12,12 @@ import (
 	"github.com/onflow/flow-go/crypto"
 )
 
+// ConsensusVoteSigLen is the length of a consensus vote as well as aggregated consensus votes.
+const ConsensusVoteSigLen = uint(crypto.SignatureLenBLSBLS12381)
+
+// RandomBeaconSigLen is the length of a randon beacon signature share as well as the random beacon resonstructed signature.
+const RandomBeaconSigLen = uint(crypto.SignatureLenBLSBLS12381)
+
 func toHex(bs []byte) string {
 	return fmt.Sprintf("%x", bs)
 }

--- a/model/flow/order/identity.go
+++ b/model/flow/order/identity.go
@@ -11,17 +11,3 @@ import (
 func ByNodeIDAsc(identity1 *flow.Identity, identity2 *flow.Identity) bool {
 	return bytes.Compare(identity1.NodeID[:], identity2.NodeID[:]) < 0
 }
-
-func ByReferenceOrder(nodeIDs []flow.Identifier) func(*flow.Identity, *flow.Identity) bool {
-	indices := make(map[flow.Identifier]uint)
-	for index, nodeID := range nodeIDs {
-		_, ok := indices[nodeID]
-		if ok {
-			panic("should never order by reference order with duplicate node IDs")
-		}
-		indices[nodeID] = uint(index)
-	}
-	return func(identity1 *flow.Identity, identity2 *flow.Identity) bool {
-		return indices[identity1.NodeID] < indices[identity2.NodeID]
-	}
-}

--- a/module/merger.go
+++ b/module/merger.go
@@ -8,6 +8,6 @@ import (
 // in a cryptographically unaware way (agnostic of the byte structure of the
 // signatures).
 type Merger interface {
-	Join(sigs ...crypto.Signature) ([]byte, error)
-	Split(combined []byte) ([]crypto.Signature, error)
+	Join(sig1, sig2 crypto.Signature) []byte
+	Split(combined []byte) (crypto.Signature, crypto.Signature, error)
 }

--- a/module/mock/merger.go
+++ b/module/mock/merger.go
@@ -12,54 +12,50 @@ type Merger struct {
 	mock.Mock
 }
 
-// Join provides a mock function with given fields: sigs
-func (_m *Merger) Join(sigs ...crypto.Signature) ([]byte, error) {
-	_va := make([]interface{}, len(sigs))
-	for _i := range sigs {
-		_va[_i] = sigs[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// Join provides a mock function with given fields: sig1, sig2
+func (_m *Merger) Join(sig1 crypto.Signature, sig2 crypto.Signature) []byte {
+	ret := _m.Called(sig1, sig2)
 
 	var r0 []byte
-	if rf, ok := ret.Get(0).(func(...crypto.Signature) []byte); ok {
-		r0 = rf(sigs...)
+	if rf, ok := ret.Get(0).(func(crypto.Signature, crypto.Signature) []byte); ok {
+		r0 = rf(sig1, sig2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(...crypto.Signature) error); ok {
-		r1 = rf(sigs...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // Split provides a mock function with given fields: combined
-func (_m *Merger) Split(combined []byte) ([]crypto.Signature, error) {
+func (_m *Merger) Split(combined []byte) (crypto.Signature, crypto.Signature, error) {
 	ret := _m.Called(combined)
 
-	var r0 []crypto.Signature
-	if rf, ok := ret.Get(0).(func([]byte) []crypto.Signature); ok {
+	var r0 crypto.Signature
+	if rf, ok := ret.Get(0).(func([]byte) crypto.Signature); ok {
 		r0 = rf(combined)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]crypto.Signature)
+			r0 = ret.Get(0).(crypto.Signature)
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func([]byte) error); ok {
+	var r1 crypto.Signature
+	if rf, ok := ret.Get(1).(func([]byte) crypto.Signature); ok {
 		r1 = rf(combined)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(crypto.Signature)
+		}
 	}
 
-	return r0, r1
+	var r2 error
+	if rf, ok := ret.Get(2).(func([]byte) error); ok {
+		r2 = rf(combined)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }

--- a/module/mock/threshold_signer.go
+++ b/module/mock/threshold_signer.go
@@ -12,8 +12,8 @@ type ThresholdSigner struct {
 	mock.Mock
 }
 
-// Combine provides a mock function with given fields: size, shares, indices
-func (_m *ThresholdSigner) Combine(size uint, shares []crypto.Signature, indices []uint) (crypto.Signature, error) {
+// Reconstruct provides a mock function with given fields: size, shares, indices
+func (_m *ThresholdSigner) Reconstruct(size uint, shares []crypto.Signature, indices []uint) (crypto.Signature, error) {
 	ret := _m.Called(size, shares, indices)
 
 	var r0 crypto.Signature

--- a/module/signature/aggregation_test.go
+++ b/module/signature/aggregation_test.go
@@ -104,15 +104,15 @@ func TestAggregationAggregateVerifyMany(t *testing.T) {
 	require.True(t, valid)
 
 	// signature should fail with one key missing
-	_, err = agg.VerifyMany(msg, aggSig, keys[1:])
-	require.Error(t, err)
+	valid, err = agg.VerifyMany(msg, aggSig, keys[1:])
+	require.NoError(t, err)
+	require.False(t, valid)
 
-	// signature should be invalid with one key swapped
+	// signature should be valid with one key swapped
 	keys[0], keys[1] = keys[1], keys[0]
 	valid, err = agg.VerifyMany(msg, aggSig, keys)
 	require.NoError(t, err)
-	require.False(t, valid)
-	keys[1], keys[0] = keys[0], keys[1]
+	require.True(t, valid)
 
 	// signature should be invalid with one byte changed
 	msg[0]++

--- a/module/signature/combine.go
+++ b/module/signature/combine.go
@@ -25,6 +25,9 @@ func NewCombiner() *Combiner {
 // Join will concatenate the provided signatures into a common byte slice, with
 // added length information. It will never fail.
 func (c *Combiner) Join(sigs ...crypto.Signature) ([]byte, error) {
+	// TODO: will only be used when the signatures are 2
+	// TODO: Optimize for bandwith and performance
+
 	var combined []byte
 	for _, sig := range sigs {
 		length := make([]byte, 4)
@@ -39,6 +42,8 @@ func (c *Combiner) Join(sigs ...crypto.Signature) ([]byte, error) {
 // embedded length information. If any length is invalid, it will fail.
 func (c *Combiner) Split(combined []byte) ([]crypto.Signature, error) {
 
+	// TODO: will only be used when the signatures are 2
+	// TODO: Optimize for bandwith and performance
 	var sigs []crypto.Signature
 	for next := 0; next < len(combined); {
 

--- a/module/signature/combine_test.go
+++ b/module/signature/combine_test.go
@@ -7,46 +7,45 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/onflow/flow-go/crypto"
 )
-
-// TODO: make tests more robust by testing unhappy paths of splitter
-
-const NUM_SIGS = 10
 
 func TestCombinerJoinSplitEven(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	c := &Combiner{}
-	sigs := make([]crypto.Signature, 0, NUM_SIGS)
-	for i := 0; i < NUM_SIGS; i++ {
-		sig := make([]byte, 32)
-		n, err := rand.Read(sig[:])
-		require.Equal(t, n, len(sig))
-		require.NoError(t, err)
-		sigs = append(sigs, sig)
-	}
-	combined, err := c.Join(sigs...)
+	c := NewCombiner(32, 32)
+
+	sig1 := make([]byte, 32)
+	sig2 := make([]byte, 32)
+	n, err := rand.Read(sig1)
+	require.Equal(t, n, 32)
 	require.NoError(t, err)
-	splitted, err := c.Split(combined)
+	n, err = rand.Read(sig2)
+	require.Equal(t, n, 32)
+	require.NoError(t, err)
+
+	combined := c.Join(sig1, sig2)
+	split1, split2, err := c.Split(combined)
 	assert.NoError(t, err)
-	assert.Equal(t, sigs, splitted)
+	assert.Equal(t, sig1, []byte(split1))
+	assert.Equal(t, sig2, []byte(split2))
 }
 
 func TestCombinerJoinSplitUneven(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	c := &Combiner{}
-	sigs := make([]crypto.Signature, 0, NUM_SIGS)
-	for i := 0; i < NUM_SIGS; i++ {
-		sig := make([]byte, rand.Intn(128)+1)
-		n, err := rand.Read(sig[:])
-		require.Equal(t, n, len(sig))
-		require.NoError(t, err)
-		sigs = append(sigs, sig)
-	}
-	combined, err := c.Join(sigs...)
+	len1 := rand.Intn(128) + 1
+	len2 := rand.Intn(128) + 1
+	c := NewCombiner(uint(len1), uint(len2))
+
+	sig1 := make([]byte, len1)
+	sig2 := make([]byte, len2)
+	n, err := rand.Read(sig1)
+	require.Equal(t, n, len1)
 	require.NoError(t, err)
-	splitted, err := c.Split(combined)
-	assert.NoError(t, err)
-	assert.Equal(t, sigs, splitted)
+	n, err = rand.Read(sig2)
+	require.Equal(t, n, len2)
+	require.NoError(t, err)
+
+	combined := c.Join(sig1, sig2)
+	split1, split2, err := c.Split(combined)
+	assert.Equal(t, sig1, []byte(split1))
+	assert.Equal(t, sig2, []byte(split2))
 }

--- a/module/signature/threshold.go
+++ b/module/signature/threshold.go
@@ -91,10 +91,10 @@ func EnoughThresholdShares(size int, shares int) (bool, error) {
 	return enoughShares, nil
 }
 
-// Combine will combine the provided public signature shares to attempt and reconstruct a threshold
+// Reconstruct will combine the provided public signature shares to attempt and reconstruct a threshold
 // signature for the group of the given size. The indices represent the index for ech signature share
 // within the DKG algorithm.
-func (tp *ThresholdProvider) Combine(size uint, shares []crypto.Signature, indices []uint) (crypto.Signature, error) {
+func (tp *ThresholdProvider) Reconstruct(size uint, shares []crypto.Signature, indices []uint) (crypto.Signature, error) {
 
 	// check that we have sufficient shares to reconstruct the threshold signature
 	enoughShares, err := EnoughThresholdShares(int(size), len(shares))

--- a/module/signature/threshold_test.go
+++ b/module/signature/threshold_test.go
@@ -90,7 +90,7 @@ func TestThresholdCombineVerifyThreshold(t *testing.T) {
 			enoughShares, err = crypto.EnoughShares(RandomBeaconThreshold(len(signers)), sufficient)
 			require.NoError(t, err)
 		}
-		threshold, err := signers[0].Combine(uint(len(signers)), shares[:sufficient], indices[:sufficient])
+		threshold, err := signers[0].Reconstruct(uint(len(signers)), shares[:sufficient], indices[:sufficient])
 		require.NoError(t, err, "should be able to create threshold signature with sufficient shares")
 
 		// should not generate valid signature with insufficient signers
@@ -101,11 +101,11 @@ func TestThresholdCombineVerifyThreshold(t *testing.T) {
 			enoughShares, err = crypto.EnoughShares(RandomBeaconThreshold(len(signers)), insufficient)
 			require.NoError(t, err)
 		}
-		_, err = signers[0].Combine(uint(len(signers)), shares[:insufficient], indices[:insufficient])
+		_, err = signers[0].Reconstruct(uint(len(signers)), shares[:insufficient], indices[:insufficient])
 		require.Error(t, err, "should not be able to create threshold signature with insufficient shares")
 
 		// should not be able to generate signature with missing indices
-		_, err = signers[0].Combine(uint(len(signers)), shares, indices[:len(indices)-1])
+		_, err = signers[0].Reconstruct(uint(len(signers)), shares, indices[:len(indices)-1])
 		require.Error(t, err, "should not be able to create threshold signature with missing indices")
 
 		// threshold signature should be valid for the group public key
@@ -134,7 +134,7 @@ func TestThresholdCombineVerifyThreshold(t *testing.T) {
 
 		// should not generate valid signature with swapped indices
 		indices[0], indices[1] = indices[1], indices[0]
-		threshold, err = signers[0].Combine(n, shares, indices)
+		threshold, err = signers[0].Reconstruct(n, shares, indices)
 		require.NoError(t, err)
 		valid, err = signers[0].VerifyThreshold(msg, threshold, groupKey)
 		require.NoError(t, err)
@@ -179,7 +179,7 @@ func BenchmarkThresholdCombination(b *testing.B) {
 	// start the timer and run the benchmark on threshold signatures
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
-		_, err := signers[0].Combine(uint(len(signers)), sigs, indices)
+		_, err := signers[0].Reconstruct(uint(len(signers)), sigs, indices)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/module/signature/threshold_test.go
+++ b/module/signature/threshold_test.go
@@ -156,7 +156,7 @@ func createThresholdsB(b *testing.B, n uint) []*ThresholdProvider {
 	return signers
 }
 
-func BenchmarkThresholdCombination(b *testing.B) {
+func BenchmarkThresholdReconstruction(b *testing.B) {
 
 	// stop timer and reset to zero
 	b.StopTimer()

--- a/module/signer.go
+++ b/module/signer.go
@@ -24,5 +24,5 @@ type AggregatingSigner interface {
 type ThresholdSigner interface {
 	ThresholdVerifier
 	Sign(msg []byte) (crypto.Signature, error)
-	Combine(size uint, shares []crypto.Signature, indices []uint) (crypto.Signature, error)
+	Reconstruct(size uint, shares []crypto.Signature, indices []uint) (crypto.Signature, error)
 }

--- a/state/protocol/seed/seed.go
+++ b/state/protocol/seed/seed.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/module/signature"
 )
 
@@ -14,16 +15,13 @@ import (
 // generate task-specific seeds from the same signature.
 func FromParentSignature(indices []uint32, combinedSig crypto.Signature) ([]byte, error) {
 	// split the parent voter sig into staking & beacon parts
-	combiner := signature.NewCombiner()
-	sigs, err := combiner.Split(combinedSig)
+	combiner := signature.NewCombiner(encodable.ConsensusVoteSigLen, encodable.RandomBeaconSigLen)
+	_, randomBeaconSig, err := combiner.Split(combinedSig)
 	if err != nil {
 		return nil, fmt.Errorf("could not split block signature: %w", err)
 	}
-	if len(sigs) != 2 {
-		return nil, fmt.Errorf("invalid block signature split")
-	}
 
-	return FromRandomSource(indices, sigs[1])
+	return FromRandomSource(indices, randomBeaconSig)
 }
 
 // FromRandomSource generates a task-specific seed (task is determined by indices).


### PR DESCRIPTION
 Addresses #[5295](https://github.com/dapperlabs/flow-go/issues/5295).
 
 - use BLS aggregation for staking signatures when creating a QC.
 - use BLS multi-sig verification for staking signatures when verifying a QC (public keys are aggregated naively for now).
 - update the `merger` module as it is only used to join/split the staking and random beacon votes, and avoid encoding the lengths within the vote.
 - add more benchmarking.