### PR TITLE
Consensus HOTFIX: wait for multiple receipts before seal

### DIFF
--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -818,6 +818,7 @@ func (e *Engine) sealableResults() ([]*flow.IncorporatedResult, nextUnsealedResu
 				block2ResultsCounter[resultID] += 1
 				if block2ResultsCounter[resultID] >= 2 {
 					results = append(results, incorporatedResult)
+					break
 				}
 			}
 		}


### PR DESCRIPTION
consensus nodes will only generate a candidate seal, if there are multiple _consistent_ results