### PR TITLE
[Execution] crash on detected execution fork

### DIFF
--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -248,6 +248,7 @@ func main() {
 				node.Logger,
 				node.State,
 				executionState,
+				node.Storage.Seals,
 			)
 			return checkerEng, nil
 		}).

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onflow/flow-go/engine/common/provider"
 	"github.com/onflow/flow-go/engine/common/requester"
 	"github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/engine/execution/checker"
 	"github.com/onflow/flow-go/engine/execution/computation"
 	"github.com/onflow/flow-go/engine/execution/ingestion"
 	exeprovider "github.com/onflow/flow-go/engine/execution/provider"
@@ -57,6 +58,7 @@ func main() {
 		results               *storage.ExecutionResults
 		receipts              *storage.ExecutionReceipts
 		providerEngine        *exeprovider.Engine
+		checkerEng            *checker.Engine
 		syncCore              *chainsync.Core
 		pendingBlocks         *buffer.PendingBlocks // used in follower engine
 		deltas                *ingestion.Deltas
@@ -241,6 +243,14 @@ func main() {
 
 			return providerEngine, err
 		}).
+		Component("checker engine", func(node *cmd.FlowNodeBuilder) (module.ReadyDoneAware, error) {
+			checkerEng = checker.New(
+				node.Logger,
+				node.State,
+				executionState,
+			)
+			return checkerEng, nil
+		}).
 		Component("ingestion engine", func(node *cmd.FlowNodeBuilder) (module.ReadyDoneAware, error) {
 			collectionRequester, err = requester.New(node.Logger, node.Metrics.Engine, node.Network, node.Me, node.State,
 				engine.RequestCollections,
@@ -326,7 +336,7 @@ func main() {
 
 			// creates a consensus follower with ingestEngine as the notifier
 			// so that it gets notified upon each new finalized block
-			followerCore, err := consensus.NewFollower(node.Logger, committee, node.Storage.Headers, final, verifier, ingestionEng, node.RootBlock.Header, node.RootQC, finalized, pending)
+			followerCore, err := consensus.NewFollower(node.Logger, committee, node.Storage.Headers, final, verifier, checkerEng, node.RootBlock.Header, node.RootQC, finalized, pending)
 			if err != nil {
 				return nil, fmt.Errorf("could not create follower core logic: %w", err)
 			}

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -172,7 +172,7 @@ func New(
 	// of conditions, which only change with new blocks or new receipts.
 	// TEMPORARY FIX: to avoid sealing checks to monopolize the engine and delay processing
 	// of receipts and approvals. Specifically, we schedule sealing checks every 2 seconds.
-	e.unit.LaunchPeriodically(e.checkSealing, 2*time.Second, 120*time.Second)
+	e.unit.LaunchPeriodically(e.checkSealing, 2*time.Second, 10*time.Second)
 
 	return e, nil
 }

--- a/engine/execution/checker/engine.go
+++ b/engine/execution/checker/engine.go
@@ -1,0 +1,97 @@
+package checker
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/consensus/hotstuff/notifications"
+	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/engine/execution/state"
+	"github.com/onflow/flow-go/state/protocol"
+	"github.com/onflow/flow-go/storage"
+)
+
+type Engine struct {
+	notifications.NoopConsumer // satisfy the FinalizationConsumer interface
+
+	unit      *engine.Unit
+	log       zerolog.Logger
+	state     protocol.State
+	execState state.ExecutionState
+}
+
+func New(
+	logger zerolog.Logger,
+	state protocol.State,
+	execState state.ExecutionState,
+) *Engine {
+	return &Engine{
+		unit:      engine.NewUnit(),
+		log:       logger.With().Str("engine", "checker").Logger(),
+		state:     state,
+		execState: execState,
+	}
+}
+
+func (e *Engine) Ready() <-chan struct{} {
+	// make sure we will run into a crashloop if result gets inconsistent
+	// with sealed result.
+	err := e.checkLastSealed()
+	if err != nil {
+		e.log.Fatal().Err(err).Msg("execution consistency check failed on startup")
+	}
+	return e.unit.Ready()
+}
+
+func (e *Engine) Done() <-chan struct{} {
+	return e.unit.Done()
+}
+
+// when a block is finalized check if the last sealed has been executed,
+// if it has been executed, check whether if the sealed result is consistent
+// with the executed result
+func (e *Engine) OnFinalizedBlock(block *model.Block) {
+	err := e.checkLastSealed()
+	if err != nil {
+		e.log.Fatal().Err(err).Msg("execution consistency check failed")
+	}
+}
+
+func (e *Engine) checkLastSealed() error {
+	sealedSnapshot := e.state.Sealed()
+	sealed, err := sealedSnapshot.Head()
+
+	if err != nil {
+		return fmt.Errorf("could not get sealed block OnFinalizedBlock: %w", err)
+	}
+
+	sealedCommit, err := sealedSnapshot.Commit()
+	if err != nil {
+		return fmt.Errorf("could not get sealed state commitment OnFinalizedBlock: %w", err)
+	}
+
+	blockID := sealed.ID()
+
+	mycommit, err := e.execState.StateCommitmentByBlockID(e.unit.Ctx(), blockID)
+	if errors.Is(err, storage.ErrNotFound) {
+		// have not executed the sealed block yet
+		// in other words, this can't detect execution fork, if the execution is behind
+		// the sealing
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("could not get my state commitment OnFinalizedBlock, blockID: %v", blockID)
+	}
+
+	if !bytes.Equal(mycommit, sealedCommit) {
+		return fmt.Errorf("execution result is different from the sealed result, height: %v, block_id: %v, sealed_commit: %x, my_commit: %x",
+			sealed.Height, blockID, sealedCommit, mycommit)
+	}
+
+	return nil
+}

--- a/engine/execution/checker/engine.go
+++ b/engine/execution/checker/engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications"
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/engine/execution/state"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 )
@@ -22,25 +23,35 @@ type Engine struct {
 	log       zerolog.Logger
 	state     protocol.State
 	execState state.ExecutionState
+	sealsDB   storage.Seals
 }
 
 func New(
 	logger zerolog.Logger,
 	state protocol.State,
 	execState state.ExecutionState,
+	sealsDB storage.Seals,
 ) *Engine {
 	return &Engine{
 		unit:      engine.NewUnit(),
 		log:       logger.With().Str("engine", "checker").Logger(),
 		state:     state,
 		execState: execState,
+		sealsDB:   sealsDB,
 	}
 }
 
 func (e *Engine) Ready() <-chan struct{} {
 	// make sure we will run into a crashloop if result gets inconsistent
 	// with sealed result.
-	err := e.checkLastSealed()
+
+	finalized, err := e.state.Final().Head()
+
+	if err != nil {
+		e.log.Fatal().Err(err).Msg("could not get finalized block on startup")
+	}
+
+	err = e.checkLastSealed(finalized.ID())
 	if err != nil {
 		e.log.Fatal().Err(err).Msg("execution consistency check failed on startup")
 	}
@@ -55,26 +66,22 @@ func (e *Engine) Done() <-chan struct{} {
 // if it has been executed, check whether if the sealed result is consistent
 // with the executed result
 func (e *Engine) OnFinalizedBlock(block *model.Block) {
-	err := e.checkLastSealed()
+	err := e.checkLastSealed(block.BlockID)
 	if err != nil {
 		e.log.Fatal().Err(err).Msg("execution consistency check failed")
 	}
 }
 
-func (e *Engine) checkLastSealed() error {
-	sealedSnapshot := e.state.Sealed()
-	sealed, err := sealedSnapshot.Head()
-
+func (e *Engine) checkLastSealed(finalizedID flow.Identifier) error {
+	// TODO: better to query seals from protocol state,
+	// switch to state.Final().LastSealed() when available
+	seal, err := e.sealsDB.ByBlockID(finalizedID)
 	if err != nil {
-		return fmt.Errorf("could not get sealed block OnFinalizedBlock: %w", err)
+		return fmt.Errorf("could not get the last sealed for the finalized block: %w", err)
 	}
 
-	sealedCommit, err := sealedSnapshot.Commit()
-	if err != nil {
-		return fmt.Errorf("could not get sealed state commitment OnFinalizedBlock: %w", err)
-	}
-
-	blockID := sealed.ID()
+	blockID := seal.BlockID
+	sealedCommit := seal.FinalState
 
 	mycommit, err := e.execState.StateCommitmentByBlockID(e.unit.Ctx(), blockID)
 	if errors.Is(err, storage.ErrNotFound) {
@@ -89,6 +96,11 @@ func (e *Engine) checkLastSealed() error {
 	}
 
 	if !bytes.Equal(mycommit, sealedCommit) {
+		sealed, err := e.state.AtBlockID(blockID).Head()
+		if err != nil {
+			return fmt.Errorf("could not get sealed block when checkLastSealed: %v, err: %w", blockID, err)
+		}
+
 		return fmt.Errorf("execution result is different from the sealed result, height: %v, block_id: %v, sealed_commit: %x, my_commit: %x",
 			sealed.Height, blockID, sealedCommit, mycommit)
 	}

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"github.com/onflow/flow-go/consensus/hotstuff/notifications"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/engine"
@@ -37,8 +36,7 @@ import (
 
 // An Engine receives and saves incoming blocks.
 type Engine struct {
-	psEvents.Noop              // satisfy protocol events consumer interface
-	notifications.NoopConsumer // satisfy the FinalizationConsumer interface
+	psEvents.Noop // satisfy protocol events consumer interface
 
 	unit               *engine.Unit
 	log                zerolog.Logger

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/flow-go/consensus"
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	mockhotstuff "github.com/onflow/flow-go/consensus/hotstuff/mocks"
+	"github.com/onflow/flow-go/consensus/hotstuff/notifications"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine"
 	collectioningest "github.com/onflow/flow-go/engine/collection/ingest"
@@ -306,6 +307,10 @@ func ConsensusNodes(t *testing.T, hub *stub.Hub, nNodes int, chainID flow.ChainI
 	return nodes
 }
 
+type CheckerMock struct {
+	notifications.NoopConsumer // satisfy the FinalizationConsumer interface
+}
+
 func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identities []*flow.Identity, syncThreshold int, chainID flow.ChainID) testmock.ExecutionNode {
 	node := GenericNode(t, hub, identity, identities, chainID)
 
@@ -394,6 +399,8 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 	deltas, err := ingestion.NewDeltas(1000)
 	require.NoError(t, err)
 
+	checkerEngine := &CheckerMock{}
+
 	rootHead, rootQC := getRoot(t, &node)
 	ingestionEngine, err := ingestion.New(
 		node.Log,
@@ -422,7 +429,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 
 	node.ProtocolEvents.AddConsumer(ingestionEngine)
 
-	followerCore, finalizer := createFollowerCore(t, &node, followerState, ingestionEngine, rootHead, rootQC)
+	followerCore, finalizer := createFollowerCore(t, &node, followerState, checkerEngine, rootHead, rootQC)
 
 	// initialize cleaner for DB
 	cleaner := storage.NewCleaner(node.Log, node.DB, node.Metrics, flow.DefaultValueLogGCFrequency)


### PR DESCRIPTION
This PR adds a check on block finalized, to check if a sealed block has been executed, if it has, it checks whether the sealed result is consistent with the executed block. 

If a node is falling behind, then the last sealed block might not be executed yet. But in this case, the receipt won't be broadcasted, when the execution node eventually catch up, it will crash and the bad receipt won't be broadcasted.

Tested on localnet, worked.