### PR TITLE
MAINNET FIX v0.14: require multiple receipts to seal V3

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -225,6 +225,8 @@ func main() {
 				filter.HasRole(flow.RoleExecution),
 				func() flow.Entity { return &flow.ExecutionReceipt{} },
 				// requester.WithBatchThreshold(100),
+				requester.WithRetryInitial(2*time.Second),
+				requester.WithRetryMaximum(30*time.Second),
 			)
 			if err != nil {
 				return nil, err

--- a/engine/common/requester/engine.go
+++ b/engine/common/requester/engine.go
@@ -83,6 +83,7 @@ func New(log zerolog.Logger, metrics module.EngineMetrics, net module.Network, m
 	selector = filter.And(
 		selector,
 		filter.HasStake(true),
+		filter.Not(filter.Ejected),
 		filter.Not(filter.HasNodeID(me.NodeID())),
 	)
 

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -1163,15 +1163,6 @@ func (e *Engine) requestPendingReceipts() (int, uint64, error) {
 	// heights would stop the sealing.
 	missingBlocksOrderedByHeight := make([]flow.Identifier, 0, e.maxResultsToRequest)
 
-	// turn mempool into Lookup table: BlockID -> Result
-	knownResultForBlock := make(map[flow.Identifier]struct{})
-	for _, r := range e.incorporatedResults.All() {
-		knownResultForBlock[r.Result.BlockID] = struct{}{}
-	}
-	for _, s := range e.seals.All() {
-		knownResultForBlock[s.Seal.BlockID] = struct{}{}
-	}
-
 	var firstMissingHeight uint64 = math.MaxUint64
 	// traverse each unsealed and finalized block with height from low to high,
 	// if the result is missing, then add the blockID to a missing block list in

--- a/utils/unittest/chain_suite.go
+++ b/utils/unittest/chain_suite.go
@@ -423,6 +423,15 @@ func (bc *BaseChainSuite) SetupChain() {
 			return found
 		},
 	).Maybe()
+	bc.SealsPL.On("All").Return(
+		func() []*flow.IncorporatedResultSeal {
+			seals := make([]*flow.IncorporatedResultSeal, 0, len(bc.PendingSeals))
+			for _, seal := range bc.PendingSeals {
+				seals = append(seals, seal)
+			}
+			return seals
+		},
+	).Maybe()
 
 	bc.Assigner = &module.ChunkAssigner{}
 	bc.Assignments = make(map[flow.Identifier]*chunks.Assignment)


### PR DESCRIPTION
*  polished logic for requiring two receipts from _different_ ENs before sealing;
* fixed logic for re-requesting second receipt (as a single one is insufficient now)
* added unit tests