### PR TITLE
[Verification] Yahya/5343-improve-verification-logging

### DIFF
--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -240,6 +240,7 @@ func (e *Engine) handleExecutionResult(originID flow.Identifier, result *flow.Ex
 
 	log.Info().
 		Int("total_assigned_chunks", len(chunks)).
+		Uints64("assigned_chunks_indices", chunks.Indices()).
 		Msg("chunk assignment done")
 
 	if len(chunks) == 0 {

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -475,6 +475,7 @@ func (e *Engine) handleChunkDataPack(originID flow.Identifier,
 		Hex("chunk_data_pack_id", logging.Entity(chunkDataPack)).
 		Hex("collection_id", logging.ID(chunkDataPack.CollectionID)).
 		Hex("chunk_id", logging.ID(chunkID)).Logger()
+
 	log.Info().Msg("chunk data pack received")
 
 	// monitoring: increments number of received chunk data packs

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -475,7 +475,9 @@ func (e *Engine) handleChunkDataPack(originID flow.Identifier,
 
 	log := e.log.With().
 		Hex("executor_id", logging.ID(originID)).
-		Hex("chunk_data_pack_id", logging.Entity(chunkDataPack)).Logger()
+		Hex("chunk_data_pack_id", logging.Entity(chunkDataPack)).
+		Hex("collection_id", logging.ID(chunkDataPack.CollectionID)).
+		Hex("chunk_id", logging.ID(chunkID)).Logger()
 	log.Info().Msg("chunk data pack received")
 
 	// monitoring: increments number of received chunk data packs

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -439,28 +439,27 @@ func (e *Engine) handleChunk(chunk *flow.Chunk, resultID flow.Identifier, execut
 	chunkID := chunk.ID()
 	status := NewChunkStatus(chunk, resultID, executorID)
 	added := e.pendingChunks.Add(status)
+	log := e.log.With().
+		Hex("result_id", logging.ID(status.ExecutionResultID)).
+		Hex("chunk_id", logging.ID(chunkID)).
+		Uint64("chunk_index", chunk.Index).
+		Logger()
+
 	if !added {
-		e.log.Debug().
-			Hex("chunk_id", logging.ID(chunkID)).
-			Hex("result_id", logging.ID(status.ExecutionResultID)).
-			Msg("could not add chunk status to pendingChunks mempool")
+		log.Debug().Msg("could not add chunk status to pendingChunks mempool")
 		return
 	}
 
 	// attachs the chunk ID to its result ID for sake of memory cleanup tracking
 	err := e.chunkIdsByResult.Append(resultID, chunkID)
 	if err != nil {
-		e.log.Debug().
+		log.Debug().
 			Err(err).
-			Hex("chunk_id", logging.ID(chunkID)).
-			Hex("result_id", logging.ID(status.ExecutionResultID)).
 			Msg("could not append chunk id to its result id")
 		return
 	}
 
 	e.log.Debug().
-		Hex("chunk_id", logging.ID(chunkID)).
-		Hex("result_id", logging.ID(status.ExecutionResultID)).
 		Msg("chunk marked assigned to this verification node")
 }
 

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -450,7 +450,7 @@ func (e *Engine) handleChunk(chunk *flow.Chunk, resultID flow.Identifier, execut
 		return
 	}
 
-	// attachs the chunk ID to its result ID for sake of memory cleanup tracking
+	// attaches the chunk ID to its result ID for sake of memory cleanup tracking
 	err := e.chunkIdsByResult.Append(resultID, chunkID)
 	if err != nil {
 		log.Debug().

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -254,8 +254,7 @@ func (e *Engine) handleExecutionResult(originID flow.Identifier, result *flow.Ex
 		ExecutionResult: result,
 	}
 	if ok := e.results.Add(rdp); !ok {
-		log.Debug().
-			Msg("could not add result to results mempool")
+		log.Debug().Msg("could not add result to results mempool")
 		return nil
 	}
 

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -453,14 +453,11 @@ func (e *Engine) handleChunk(chunk *flow.Chunk, resultID flow.Identifier, execut
 	// attaches the chunk ID to its result ID for sake of memory cleanup tracking
 	err := e.chunkIdsByResult.Append(resultID, chunkID)
 	if err != nil {
-		log.Debug().
-			Err(err).
-			Msg("could not append chunk id to its result id")
+		log.Debug().Err(err).Msg("could not append chunk id to its result id")
 		return
 	}
 
-	e.log.Debug().
-		Msg("chunk marked assigned to this verification node")
+	e.log.Debug().Msg("chunk marked assigned to this verification node")
 }
 
 // handleChunkDataPack receives a chunk data pack, verifies its origin ID, pull other data to make a
@@ -573,33 +570,29 @@ func (e *Engine) handleChunkDataPack(originID flow.Identifier,
 // If all assigned chunks of the corresponding result have been dropped, it also removes
 // the result from the memory.
 func (e *Engine) chunkMetaDataCleanup(chunkID, resultID flow.Identifier) {
+	log := e.log.With().
+		Hex("result_id", logging.ID(resultID)).
+		Hex("chunk_id", logging.ID(chunkID)).
+		Logger()
 	err := e.chunkIdsByResult.RemIdFromKey(resultID, chunkID)
 	if err != nil {
-		e.log.Debug().
-			Err(err).
-			Hex("result_id", logging.ID(resultID)).
-			Hex("chunk_id", logging.ID(chunkID)).
-			Msg("could not dropped chunk")
+		log.Debug().Err(err).Msg("could not dropped chunk")
 		return
 	}
 
 	if e.chunkIdsByResult.Has(resultID) {
 		// there are still un-matched chunks correspond to this result
-		// so the result should not be cleanned.
+		// so the result should not be cleaned.
 		return
 	}
 
 	// no pending chunk is attached to this result, hence removes it
 	if ok := e.results.Rem(resultID); !ok {
-		e.log.Debug().
-			Hex("result_id", logging.ID(resultID)).
-			Msg("could not remove result")
+		log.Debug().Msg("could not remove result")
 		return
 	}
 
-	e.log.Info().
-		Hex("result_id", logging.ID(resultID)).
-		Msg("result successfully removed")
+	e.log.Info().Msg("result successfully removed")
 }
 
 // matchChunk performs the last step in matching pipeline for a chunk.

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -339,9 +339,10 @@ func (e *Engine) onTimer() {
 		chunkID := chunk.ID()
 
 		log := e.log.With().
-			Hex("chunk_id", logging.ID(chunkID)).
 			Hex("block_id", logging.ID(chunk.Chunk.BlockID)).
 			Hex("result_id", logging.ID(chunk.ExecutionResultID)).
+			Hex("chunk_id", logging.ID(chunkID)).
+			Uint64("chunk_index", chunk.Chunk.Index).
 			Logger()
 
 		header, err := e.headers.ByBlockID(chunk.Chunk.BlockID)

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -244,7 +244,7 @@ func (e *Engine) handleExecutionResult(originID flow.Identifier, result *flow.Ex
 		Msg("chunk assignment done")
 
 	if len(chunks) == 0 {
-		// no chunk is assigned to this verifiaction node
+		// no chunk is assigned to this verification node
 		return nil
 	}
 

--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -158,7 +158,7 @@ func (e *Engine) verify(ctx context.Context, originID flow.Identifier,
 	log := e.log.With().Timestamp().
 		Hex("origin", logging.ID(originID)).
 		Uint64("chunk_index", vc.Chunk.Index).
-		Hex("execution_result_id", logging.Entity(vc.Result)).
+		Hex("result_id", logging.Entity(vc.Result)).
 		Logger()
 
 	log.Info().Msg("verifiable chunk received by verifier engine")
@@ -315,19 +315,18 @@ func (e *Engine) verifiableChunkHandler(originID flow.Identifier, ch *verificati
 	// for sake of metrics
 	e.metrics.OnVerifiableChunkReceived()
 
-	e.log.Info().
-		Hex("chunk_id", logging.ID(ch.Chunk.ID())).
+	log := e.log.With().
 		Hex("result_id", logging.ID(ch.Result.ID())).
-		Msg("verifiable chunk received")
+		Hex("chunk_id", logging.ID(ch.Chunk.ID())).
+		Uint64("chunk_index", ch.Chunk.Index).Logger()
+
+	log.Info().Msg("verifiable chunk received")
 
 	// starts verification of chunk
 	err := e.verify(ctx, originID, ch)
 
 	if err != nil {
-		e.log.Debug().
-			Err(err).
-			Hex("chunk_id", logging.ID(ch.Chunk.ID())).
-			Msg("could not verify chunk")
+		log.Info().Err(err).Msg("could not verify chunk")
 	}
 
 	// closes verification performance metrics trackers

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -1,9 +1,5 @@
 package flow
 
-import (
-	"github.com/gogo/protobuf/sortkeys"
-)
-
 type ChunkBody struct {
 	CollectionIndex uint
 
@@ -75,7 +71,6 @@ func (cl ChunkList) Indices() []uint64 {
 	for i, chunk := range cl {
 		indices[i] = chunk.Index
 	}
-
 
 	return indices
 }

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -76,7 +76,6 @@ func (cl ChunkList) Indices() []uint64 {
 		indices[i] = chunk.Index
 	}
 
-	sortkeys.Uint64s(indices)
 
 	return indices
 }

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -1,5 +1,9 @@
 package flow
 
+import (
+	"github.com/gogo/protobuf/sortkeys"
+)
+
 type ChunkBody struct {
 	CollectionIndex uint
 
@@ -71,6 +75,8 @@ func (cl ChunkList) Indices() []uint64 {
 	for i, chunk := range cl {
 		indices[i] = chunk.Index
 	}
+
+	sortkeys.Uint64s(indices)
 
 	return indices
 }

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -66,6 +66,15 @@ func (cl ChunkList) Items() []*Chunk {
 	return cl
 }
 
+func (cl ChunkList) Indices() []uint64 {
+	indices := make([]uint64, len(cl))
+	for i, chunk := range cl {
+		indices[i] = chunk.Index
+	}
+
+	return indices
+}
+
 // ByChecksum returns an entity from the list by entity fingerprint
 func (cl ChunkList) ByChecksum(cs Identifier) (*Chunk, bool) {
 	for _, ch := range cl {

--- a/model/flow/chunk_test.go
+++ b/model/flow/chunk_test.go
@@ -75,3 +75,15 @@ func TestDistinctChunkIDs_FullChunks(t *testing.T) {
 	// chunks with distinct block ids should have distinct chunk ids
 	require.NotEqual(t, chunkA.ID(), chunkB.ID())
 }
+
+func TestChunkList_Indices(t *testing.T) {
+	cl := unittest.ChunkListFixture(10, unittest.IdentifierFixture())
+	t.Run("single chunk subset indices", func(t *testing.T) {
+		// subset of chunk list that contains chunk index of zero, should
+		// return a uint64 slice that only contains chunk index of zero.
+		subset := cl[:1]
+		indices := subset.Indices()
+		require.Len(t, indices, 1)
+		require.Contains(t, indices, uint64(0))
+	})
+}

--- a/model/flow/chunk_test.go
+++ b/model/flow/chunk_test.go
@@ -77,7 +77,7 @@ func TestDistinctChunkIDs_FullChunks(t *testing.T) {
 }
 
 func TestChunkList_Indices(t *testing.T) {
-	cl := unittest.ChunkListFixture(10, unittest.IdentifierFixture())
+	cl := unittest.ChunkListFixture(5, unittest.IdentifierFixture())
 	t.Run("single chunk subset indices", func(t *testing.T) {
 		// subset of chunk list that contains chunk index of zero, should
 		// return a uint64 slice that only contains chunk index of zero.
@@ -85,5 +85,14 @@ func TestChunkList_Indices(t *testing.T) {
 		indices := subset.Indices()
 		require.Len(t, indices, 1)
 		require.Contains(t, indices, uint64(0))
+	})
+
+	t.Run("multiple chunk subset indices", func(t *testing.T) {
+		// subset that only contains even chunk indices, should return
+		// a uint64 slice that only contains even chunk indices
+		subset := flow.ChunkList{cl[0], cl[2], cl[4]}
+		indices := subset.Indices()
+		require.Len(t, indices, 3)
+		require.Contains(t, indices, uint64(0), uint64(2), uint64(4))
 	})
 }

--- a/model/flow/chunk_test.go
+++ b/model/flow/chunk_test.go
@@ -76,8 +76,16 @@ func TestDistinctChunkIDs_FullChunks(t *testing.T) {
 	require.NotEqual(t, chunkA.ID(), chunkB.ID())
 }
 
+// TestChunkList_Indices evaluates the Indices method of ChunkList on lists of different sizes.
 func TestChunkList_Indices(t *testing.T) {
 	cl := unittest.ChunkListFixture(5, unittest.IdentifierFixture())
+	t.Run("empty chunk subset indices", func(t *testing.T) {
+		// subset of chunk list that is empty should return an empty list
+		subset := flow.ChunkList{}
+		indices := subset.Indices()
+		require.Len(t, indices, 0)
+	})
+
 	t.Run("single chunk subset indices", func(t *testing.T) {
 		// subset of chunk list that contains chunk index of zero, should
 		// return a uint64 slice that only contains chunk index of zero.

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -482,7 +482,7 @@ func WithBlock(block *flow.Block) func(*flow.ExecutionResult) {
 	return func(result *flow.ExecutionResult) {
 		startState := result.Chunks[0].StartState // retain previous start state in case it was user-defined
 		result.BlockID = blockID
-		result.Chunks = ChunksFixture(uint(chunks), block.ID())
+		result.Chunks = ChunkListFixture(uint(chunks), block.ID())
 		result.Chunks[0].StartState = startState // set start state to value before update
 		result.PreviousResultID = previousResultID
 	}
@@ -493,7 +493,7 @@ func ExecutionResultFixture(opts ...func(*flow.ExecutionResult)) *flow.Execution
 	result := &flow.ExecutionResult{
 		PreviousResultID: IdentifierFixture(),
 		BlockID:          IdentifierFixture(),
-		Chunks:           ChunksFixture(2, blockID),
+		Chunks:           ChunkListFixture(2, blockID),
 	}
 
 	for _, apply := range opts {
@@ -730,7 +730,7 @@ func ChunkFixture(blockID flow.Identifier, collectionIndex uint) *flow.Chunk {
 	}
 }
 
-func ChunksFixture(n uint, blockID flow.Identifier) []*flow.Chunk {
+func ChunkListFixture(n uint, blockID flow.Identifier) flow.ChunkList {
 	chunks := make([]*flow.Chunk, 0, n)
 	for i := uint64(0); i < uint64(n); i++ {
 		chunk := ChunkFixture(blockID, uint(i))


### PR DESCRIPTION
To have more visibility on tracing the journey of chunks in the verification node, this PR improves the logging in the match and finder engines of the verification node by adding the following details to the logs wherever needed:
- List of assigned chunk indices. 
- Chunk index, and id