### PR TITLE
Engine Message Queue Prototypes

### DIFF
--- a/mqueue/message.go
+++ b/mqueue/message.go
@@ -1,0 +1,24 @@
+package mqueue
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+type Message interface {
+	Payload() flow.Entity
+}
+
+type message struct {
+	payload flow.Entity
+}
+
+func (m *message) Payload() flow.Entity {
+	return m.payload
+}
+
+func FakeMessage() Message {
+	return &message{
+		payload: unittest.CollectionFixture(1),
+	}
+}

--- a/mqueue/poker/engine.go
+++ b/mqueue/poker/engine.go
@@ -18,6 +18,7 @@ type Engine struct {
 // the network->queue step processor just adds the item to the queue.
 func (e *Engine) ProcessMessageFromNetwork(message mqueue.Message) {
 	e.messages.Push(message)
+	e.poker.Poke()
 }
 
 func (e *Engine) ProcessMessagesFromQueue() {

--- a/mqueue/poker/engine.go
+++ b/mqueue/poker/engine.go
@@ -1,0 +1,5 @@
+package poker
+
+type Engine struct {}
+
+func (e *Engine) loop {}

--- a/mqueue/poker/engine.go
+++ b/mqueue/poker/engine.go
@@ -1,5 +1,57 @@
 package poker
 
-type Engine struct {}
+import (
+	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/mqueue"
+	"github.com/onflow/flow-go/utils/fifoqueue"
+)
 
-func (e *Engine) loop {}
+// Engine shows the
+type Engine struct {
+	// queue of inbound messages to process, populated by network worker thread
+	// calling ProcessMessageFromNetwork
+	messages *fifoqueue.FifoQueue
+	poker    Poker
+	unit     *engine.Unit
+}
+
+// the network->queue step processor just adds the item to the queue.
+func (e *Engine) ProcessMessageFromNetwork(message mqueue.Message) {
+	e.messages.Push(message)
+}
+
+func (e *Engine) ProcessMessagesFromQueue() {
+	for {
+		select {
+		case <-e.unit.Quit():
+			return
+
+		case <-e.poker.Wait():
+			e.processMessagesWhileAvailable()
+		}
+	}
+}
+
+func (e *Engine) processMessagesWhileAvailable() {
+	for {
+		msg, ok := e.selectNextMessage()
+		if !ok {
+			return
+		}
+		e.processMessage(msg)
+	}
+}
+
+// This can be a module separate from the engine/core, with read-only access to queue/pending state
+// Eg. `e.MessageSelector.Next()`
+func (e *Engine) selectNextMessage() (mqueue.Message, bool) {
+	// here we can implement arbitrary prioritization logic based on
+	// message type priority, our pending state, the size of all our
+	// inbound queues, etc.
+	return nil, true
+}
+
+// This represents the Core logic
+func (e *Engine) processMessage(_ mqueue.Message) {
+	// type switch, processing logic
+}

--- a/mqueue/poker/poker.go
+++ b/mqueue/poker/poker.go
@@ -1,0 +1,32 @@
+package poker
+
+type Poker interface {
+
+	// Poke will wake a goroutine waiting on the wait channel.
+	Poke()
+
+	// Wait returns a channel that may be blocked on until poked.
+	Wait() <-chan struct{}
+}
+
+type poker struct {
+	poke chan struct{}
+}
+
+func New() Poker {
+	p := &poker{
+		poke: make(chan struct{}),
+	}
+	return p
+}
+
+func (p *poker) Poke() {
+	select {
+	case p.poke <- struct{}{}:
+	default:
+	}
+}
+
+func (p *poker) Wait() <-chan struct{} {
+	return p.poke
+}

--- a/mqueue/rtqueue/engine.go
+++ b/mqueue/rtqueue/engine.go
@@ -1,0 +1,37 @@
+package rtqueue
+
+import (
+	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/mqueue"
+)
+
+type Engine struct {
+	// queue of inbound messages to process, populated by network worker thread
+	// calling ProcessMessageFromNetwork
+	messages Queue
+	unit     *engine.Unit
+}
+
+func (e *Engine) ProcessMessageFromNetwork(message mqueue.Message) {
+	e.messages.Add(message)
+}
+
+func (e *Engine) ProcessMessagesFromQueue() {
+	for {
+		select {
+		case <-e.unit.Quit():
+			return
+
+		case msg := <-e.messages.Recv():
+			// NOTE: if the engine has multiple input message queues, they would
+			// be additional case statements here
+			//
+			// CAUTION: using select directly makes it more difficult to prioritize messages
+			e.processMessage(msg)
+		}
+	}
+}
+
+func (e *Engine) processMessage(_ mqueue.Message) {
+	// type switch, processing logic
+}

--- a/mqueue/rtqueue/engine.go
+++ b/mqueue/rtqueue/engine.go
@@ -5,6 +5,8 @@ import (
 	"github.com/onflow/flow-go/mqueue"
 )
 
+// Engine shows the structure of an engine using a real-time queue with channel
+// based interface for outbound (queue->engine) messages.
 type Engine struct {
 	// queue of inbound messages to process, populated by network worker thread
 	// calling ProcessMessageFromNetwork

--- a/mqueue/rtqueue/rtqueue.go
+++ b/mqueue/rtqueue/rtqueue.go
@@ -1,0 +1,69 @@
+package rtqueue
+
+import (
+	"go.uber.org/atomic"
+
+	"github.com/onflow/flow-go/mqueue"
+
+	"github.com/onflow/flow-go/utils/fifoqueue"
+)
+
+// Queue is a real-time queue which guarantees that items added to the queue
+// will immediately be available to be received over Recv channel.
+type Queue interface {
+	Add(item mqueue.Message)
+
+	Recv() <-chan mqueue.Message
+}
+
+type queue struct {
+	items      *fifoqueue.FifoQueue
+	in, out    chan mqueue.Message
+	shovelling *atomic.Bool
+}
+
+func New() Queue {
+	fifo, _ := fifoqueue.NewFifoQueue()
+	q := &queue{
+		items:      fifo,
+		in:         make(chan mqueue.Message),
+		out:        make(chan mqueue.Message),
+		shovelling: atomic.NewBool(false),
+	}
+	return q
+}
+
+// shovel is a goroutine that lives for as long as the queue is non-empty.
+func (q *queue) shovel() {
+
+	// shovel is always started when at least one item is being added
+	head := <-q.in
+
+	for {
+		// if the queue is non-empty wait on both input and output channels
+		select {
+		case tail := <-q.in:
+			q.items.Push(tail)
+			continue
+		case q.out <- head:
+		}
+
+		next, ok := q.items.Pop()
+		if !ok {
+			q.shovelling.Store(false)
+			return
+		}
+		head = next.(mqueue.Message)
+	}
+}
+
+func (q *queue) Add(item mqueue.Message) {
+	if q.shovelling.CAS(false, true) {
+		go q.shovel()
+	}
+	q.in <- item
+}
+
+func (q *queue) Recv() <-chan mqueue.Message {
+	return q.out
+}

--- a/mqueue/rtqueue/rtqueue.go
+++ b/mqueue/rtqueue/rtqueue.go
@@ -40,16 +40,19 @@ func (q *queue) shovel() {
 	head := <-q.in
 
 	for {
-		// if the queue is non-empty wait on both input and output channels
 		select {
 		case tail := <-q.in:
+			// when a new item is added, re-enter this select with the same head
 			q.items.Push(tail)
 			continue
 		case q.out <- head:
+			// when the head of the queue is accepted, retrieve the next
+			// head before re-entering this select
 		}
 
 		next, ok := q.items.Pop()
 		if !ok {
+			// terminate this goroutine when the queue is empty
 			q.shovelling.Store(false)
 			return
 		}

--- a/mqueue/rtqueue/rtqueue_test.go
+++ b/mqueue/rtqueue/rtqueue_test.go
@@ -1,0 +1,52 @@
+package rtqueue
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-go/mqueue"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestQueueNonBlockingAdd(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		q := New()
+
+		unittest.AssertReturnsBefore(t, func() {
+			q.Add(mqueue.FakeMessage())
+		}, time.Second)
+	})
+
+	t.Run("non-empty", func(t *testing.T) {
+		q := New()
+
+		unittest.AssertReturnsBefore(t, func() {
+			q.Add(mqueue.FakeMessage())
+			q.Add(mqueue.FakeMessage())
+		}, time.Second)
+	})
+}
+
+func TestQueueReadWrite(t *testing.T) {
+	q := New()
+
+	expected := mqueue.FakeMessage()
+	q.Add(expected)
+
+	unittest.AssertReturnsBefore(t, func() {
+		actual := <-q.Recv()
+		assert.Equal(t, expected.Payload(), actual.Payload())
+	}, time.Second)
+}
+
+func TestReadEmpty(t *testing.T) {
+	q := New()
+
+	select {
+	case <-q.Recv():
+		t.Fail()
+	default:
+	}
+}


### PR DESCRIPTION
2 draft solutions for https://github.com/onflow/flow/issues/396.

## 1 - Poker

Package: `mqueue/poker`

This is similar to the example code shared during the meeting on Tuesday. It demonstrates the minimal communication requirements between the `network->queue` step and the `queue->engine` step of the processing pipeline to allow responsive processing of messages. This does not restrict engines to channel-based message selection -- they may select messages from their inbound message queues however they like. The downside is that the queues must be thread-safe. 

## 2 - Real-time Queue

Package: `mqueue/rtqueue`

This is based off @AlexHentschel's suggestion to move the "shovelling" of messages between the two steps in the processing pipeline into the queue. This maintains the design where the inbound (`queue->engine`) message queues enforce a channel-based message selection so the underlying queue structure doesn't need to be thread-safe. Downside is message prioritization becomes more difficult. This implementation notably only uses a goroutine when the queue is full, and handles terminating the goroutine when the queue is empty. The benefit is we don't need to make the `Queue` ready-done-aware to gracefully stop its spawned goroutine, we just need to drain the queue when exiting the engine.