### PR TITLE
poc of panicable storage

### DIFF
--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -17,9 +17,9 @@ import (
 	recovery "github.com/onflow/flow-go/consensus/recovery/protocol"
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/engine/access/ingestion"
-	accessstorage "github.com/onflow/flow-go/engine/access/storage"
 	pingeng "github.com/onflow/flow-go/engine/access/ping"
 	"github.com/onflow/flow-go/engine/access/rpc"
+	accessstorage "github.com/onflow/flow-go/engine/access/storage"
 	followereng "github.com/onflow/flow-go/engine/common/follower"
 	"github.com/onflow/flow-go/engine/common/requester"
 	synceng "github.com/onflow/flow-go/engine/common/synchronization"
@@ -207,8 +207,8 @@ func main() {
 			return nil
 		}).
 		Component("RPC engine", func(node *cmd.FlowNodeBuilder) (module.ReadyDoneAware, error) {
-			blocks := &accessstorage.Blocks{
-				node.Storage.Blocks,
+			panicyBlocks := &accessstorage.Blocks{
+				Blocks: node.Storage.Blocks,
 			}
 			rpcEng = rpc.New(
 				node.Logger,
@@ -217,7 +217,7 @@ func main() {
 				executionRPC,
 				collectionRPC,
 				historicalAccessRPCs,
-				blocks,
+				panicyBlocks,
 				node.Storage.Headers,
 				node.Storage.Collections,
 				node.Storage.Transactions,

--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -17,6 +17,7 @@ import (
 	recovery "github.com/onflow/flow-go/consensus/recovery/protocol"
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/engine/access/ingestion"
+	accessstorage "github.com/onflow/flow-go/engine/access/storage"
 	pingeng "github.com/onflow/flow-go/engine/access/ping"
 	"github.com/onflow/flow-go/engine/access/rpc"
 	followereng "github.com/onflow/flow-go/engine/common/follower"
@@ -206,6 +207,9 @@ func main() {
 			return nil
 		}).
 		Component("RPC engine", func(node *cmd.FlowNodeBuilder) (module.ReadyDoneAware, error) {
+			blocks := &accessstorage.Blocks{
+				node.Storage.Blocks,
+			}
 			rpcEng = rpc.New(
 				node.Logger,
 				node.State,
@@ -213,7 +217,7 @@ func main() {
 				executionRPC,
 				collectionRPC,
 				historicalAccessRPCs,
-				node.Storage.Blocks,
+				blocks,
 				node.Storage.Headers,
 				node.Storage.Collections,
 				node.Storage.Transactions,

--- a/engine/access/storage/Blocks.go
+++ b/engine/access/storage/Blocks.go
@@ -1,0 +1,22 @@
+package storage
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+)
+
+type Blocks struct {
+	storage.Blocks
+}
+
+func (blocks *Blocks) Store(block *flow.Block) error {
+	err := blocks.Blocks.Store(block)
+	return panicOnError(err)
+}
+
+func panicOnError(err error) error {
+	if err != nil {
+		panic(err)
+	}
+	return err
+}

--- a/integration/testnet/container.go
+++ b/integration/testnet/container.go
@@ -38,6 +38,7 @@ type ContainerConfig struct {
 	LogLevel        zerolog.Level
 	Ghost           bool
 	AdditionalFlags []string
+	DiskSpace int64
 }
 
 // ImageName returns the Docker image name for the given config.

--- a/integration/tests/common/crash_and_burn_test.go
+++ b/integration/tests/common/crash_and_burn_test.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/integration/testnet"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestCrashAndBurnBehaviour(t *testing.T) {
+	collectionConfigs := []func(*testnet.NodeConfig){
+		testnet.WithAdditionalFlag("--hotstuff-timeout=12s"),
+		testnet.WithAdditionalFlag("--block-rate-delay=100ms"),
+		testnet.WithLogLevel(zerolog.WarnLevel),
+	}
+
+	consensusConfigs := append(collectionConfigs,
+		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", 1)),
+		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", 1)),
+		testnet.WithLogLevel(zerolog.DebugLevel),
+	)
+
+	net := []testnet.NodeConfig{
+		testnet.NewNodeConfig(flow.RoleCollection, collectionConfigs...),
+		testnet.NewNodeConfig(flow.RoleCollection, collectionConfigs...),
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.DebugLevel)),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(flow.RoleVerification),
+		testnet.NewNodeConfig(flow.RoleAccess, testnet.WithDiskSpace(100)),
+	}
+
+	conf := testnet.NewNetworkConfig("mvp", net)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	flowNetwork := testnet.PrepareFlowNetwork(t, conf)
+
+	flowNetwork.Start(ctx)
+	defer flowNetwork.Remove()
+
+	runMVPTest(t, ctx, flowNetwork)
+}

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -160,9 +160,11 @@ func RunWithTempDir(t testing.TB, f func(string)) {
 
 func BadgerDB(t testing.TB, dir string) *badger.DB {
 	opts := badger.
-		DefaultOptions(dir).
+		DefaultOptions("dir").
 		WithKeepL0InMemory(true).
-		WithLogger(nil)
+		WithLogger(nil).
+		WithMaxTableSize(10).
+		WithValueThreshold(0)
 	db, err := badger.Open(opts)
 	require.NoError(t, err)
 	return db


### PR DESCRIPTION
this is still something I am trying to figure out -
Access node should crash if there is a storage error such as out-of-disk space when trying to save something.
I was thinking of writing these wrapper implementations for each of the storage interfaces that the AN uses and then panicing if the store fails.
Wanted to get your opinion on it.