### PR TITLE
[Collection] increase the address index limit

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -88,7 +88,7 @@ func main() {
 				"expiry buffer for inbound transactions")
 			flags.UintVar(&ingestConf.PropagationRedundancy, "ingest-tx-propagation-redundancy", 10,
 				"how many additional cluster members we propagate transactions to")
-			flags.Uint64Var(&ingestConf.MaxAddressIndex, "ingest-max-address-index", 1_000_000,
+			flags.Uint64Var(&ingestConf.MaxAddressIndex, "ingest-max-address-index", 10_000_000,
 				"the maximum address index allowed in transactions")
 			flags.UintVar(&builderExpiryBuffer, "builder-expiry-buffer", builder.DefaultExpiryBuffer,
 				"expiry buffer for transactions in proposed collections")

--- a/engine/collection/ingest/config.go
+++ b/engine/collection/ingest/config.go
@@ -25,7 +25,7 @@ func DefaultConfig() Config {
 		ExpiryBuffer:          flow.DefaultTransactionExpiryBuffer,
 		MaxGasLimit:           flow.DefaultMaxGasLimit,
 		CheckScriptsParse:     true,
-		MaxAddressIndex:       1_000_000,
+		MaxAddressIndex:       10_000_000,
 		PropagationRedundancy: 2,
 	}
 }


### PR DESCRIPTION
- collection nodes filter out transactions with account indices larger than a constant
- this PR bumps the constant from 1M to 10M.  