### PR TITLE
Disable contract update validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.13.1
+	github.com/onflow/cadence v0.13.1-no-contract-update-validation
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1
 	github.com/onflow/flow-go-sdk v0.15.0
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -826,8 +826,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.13.0 h1:rMQpIwbZyqdiKV3f8nwxmyqyJahHcDRHDaZcjNH3sfI=
 github.com/onflow/cadence v0.13.0/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
-github.com/onflow/cadence v0.13.1 h1:OSgpeUNAvGzJMtGmICgFG8vvnZ9DYYFMk0UB2DGhmoE=
-github.com/onflow/cadence v0.13.1/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
+github.com/onflow/cadence v0.13.1-no-contract-update-validation h1:A9ZHXXGNOnv70V0WlVnVmtddwBbLM/IRdFDBSXDWahs=
+github.com/onflow/cadence v0.13.1-no-contract-update-validation/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.13.1
+	github.com/onflow/cadence v0.13.1-no-contract-update-validation
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.15.0
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -889,8 +889,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.13.0 h1:rMQpIwbZyqdiKV3f8nwxmyqyJahHcDRHDaZcjNH3sfI=
 github.com/onflow/cadence v0.13.0/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
-github.com/onflow/cadence v0.13.1 h1:OSgpeUNAvGzJMtGmICgFG8vvnZ9DYYFMk0UB2DGhmoE=
-github.com/onflow/cadence v0.13.1/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
+github.com/onflow/cadence v0.13.1-no-contract-update-validation h1:A9ZHXXGNOnv70V0WlVnVmtddwBbLM/IRdFDBSXDWahs=
+github.com/onflow/cadence v0.13.1-no-contract-update-validation/go.mod h1:VuW4hf5AuC/PkxKD6akqq03Fgk0CpOM3ZOR6n7htNIw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1 h1:nmIDPf94F9Ecx6ecGyd4uYBUl4LluntWLvtwAJYt4tw=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.1/go.mod h1:4zE/4A+5zyahxSFccQmcBqzp4ONXIwvGHaOKN8h8CRM=
 github.com/onflow/flow-ft/lib/go/contracts v0.4.0 h1:M1I4z027GHOLcjkj9lL2UUUpZpEAF90hY5gRqvFGAPg=


### PR DESCRIPTION
Update to Cadence v0.13.1-no-contract-validation, which contains onflow/cadence#647, which disables the contract update validation for now, and adds an option to enable it again eventually.