### PR TITLE
draft for separating Receipts storage Layer

### DIFF
--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -57,7 +57,7 @@ func main() {
 		serviceEvents         *storage.ServiceEvents
 		txResults             *storage.TransactionResults
 		results               *storage.ExecutionResults
-		receipts              *storage.ExecutionReceipts
+		receipts              *storage.MyExecutionReceipts
 		providerEngine        *exeprovider.Engine
 		checkerEng            *checker.Engine
 		syncCore              *chainsync.Core
@@ -159,7 +159,8 @@ func main() {
 		}).
 		Module("execution receipts storage", func(node *cmd.FlowNodeBuilder) error {
 			results = storage.NewExecutionResults(node.Metrics.Cache, node.DB)
-			receipts = storage.NewExecutionReceipts(node.Metrics.Cache, node.DB, results)
+			genericReceipts := storage.NewExecutionReceipts(node.Metrics.Cache, node.DB, results)
+			receipts = storage.NewMyExecutionReceipts(node.Metrics.Cache, node.DB, genericReceipts)
 			return nil
 		}).
 		Module("pending block cache", func(node *cmd.FlowNodeBuilder) error {

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -101,7 +101,7 @@ type state struct {
 	collections        storage.Collections
 	chunkDataPacks     storage.ChunkDataPacks
 	results            storage.ExecutionResults
-	receipts           storage.ExecutionReceipts
+	receipts           storage.MyExecutionReceipts
 	events             storage.Events
 	serviceEvents      storage.ServiceEvents
 	transactionResults storage.TransactionResults
@@ -139,7 +139,7 @@ func NewExecutionState(
 	collections storage.Collections,
 	chunkDataPacks storage.ChunkDataPacks,
 	results storage.ExecutionResults,
-	receipts storage.ExecutionReceipts,
+	receipts storage.MyExecutionReceipts,
 	events storage.Events,
 	serviceEvents storage.ServiceEvents,
 	transactionResults storage.TransactionResults,
@@ -351,7 +351,7 @@ func (s *state) PersistExecutionReceipt(ctx context.Context, receipt *flow.Execu
 		defer span.Finish()
 	}
 
-	err := s.receipts.Store(receipt)
+	err := s.receipts.StoreMyReceipt(receipt)
 	if err != nil {
 		return fmt.Errorf("could not persist execution result: %w", err)
 	}

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -44,6 +44,7 @@ const (
 	ResourceGuarantee                = "guarantee"
 	ResourceResult                   = "result"
 	ResourceReceipt                  = "receipt"
+	ResourceMyReceipt                = "my_receipt"
 	ResourceCollection               = "collection"
 	ResourceApproval                 = "approval"
 	ResourceSeal                     = "seal"

--- a/storage/badger/cache.go
+++ b/storage/badger/cache.go
@@ -106,10 +106,10 @@ func (c *Cache) Get(key interface{}) func(*badger.Txn) (interface{}, error) {
 
 // Put will add an resource to the cache with the given ID.
 func (c *Cache) Put(key interface{}, resource interface{}) func(*badger.Txn) error {
-	return func(tx *badger.Txn) error {
+	storeOps := c.store(key, resource) // assemble DB operations to store resource (no execution)
 
-		// try to store the resource
-		err := c.store(key, resource)(tx)
+	return func(tx *badger.Txn) error {
+		err := storeOps(tx) // execute operations to store recourse
 		if err != nil {
 			return fmt.Errorf("could not store resource: %w", err)
 		}

--- a/storage/badger/my_receipts.go
+++ b/storage/badger/my_receipts.go
@@ -1,0 +1,103 @@
+package badger
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/badger/v2"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/storage/badger/operation"
+)
+
+// MyExecutionReceipts holds and indexes Execution Receipts.
+// MyExecutionReceipts is implemented as a wrapper around badger.ExecutionReceipts
+// The wrapper ads the ability to "MY execution receipt", from the viewpoint
+// of an individual Execution Node.
+type MyExecutionReceipts struct {
+	*ExecutionReceipts
+	db    *badger.DB
+	cache *Cache
+}
+
+func NewMyExecutionReceipts(collector module.CacheMetrics, db *badger.DB, receipts *ExecutionReceipts) *MyExecutionReceipts {
+	store := func(key interface{}, val interface{}) func(tx *badger.Txn) error {
+		receipt := val.(*flow.ExecutionReceipt)
+		// assemble DB operations to store receipt (no execution)
+		storeReceiptOps := receipts.store(receipt)
+		// assemble DB operations to index receipt as one of my own (no execution)
+		indexOwnReceiptOps := operation.SkipDuplicates(
+			operation.IndexOwnExecutionReceipt(receipt.ExecutionResult.BlockID, receipt.ID()),
+		)
+
+		return func(tx *badger.Txn) error {
+			err := storeReceiptOps(tx) // execute operations to store receipt
+			if err != nil {
+				return fmt.Errorf("could not store receipt: %w", err)
+			}
+			err = indexOwnReceiptOps(tx) // execute operations to index receipt as one of my own
+			if err != nil {
+				return fmt.Errorf("could not index receipt as one of my own: %w", err)
+			}
+			return nil
+		}
+	}
+
+	retrieve := func(key interface{}) func(tx *badger.Txn) (interface{}, error) {
+		blockID := key.(flow.Identifier)
+
+		return func(tx *badger.Txn) (interface{}, error) {
+			var receiptID flow.Identifier
+			err := operation.LookupOwnExecutionReceipt(blockID, &receiptID)(tx)
+			if err != nil {
+				return nil, fmt.Errorf("could not lookup receipt ID: %w", err)
+			}
+			receipt, err := receipts.byID(receiptID)(tx)
+			if err != nil {
+				return nil, err
+			}
+			return receipt, nil
+		}
+	}
+
+	return &MyExecutionReceipts{
+		ExecutionReceipts: receipts,
+		db:                db,
+		cache: newCache(collector,
+			withLimit(flow.DefaultTransactionExpiry+100),
+			withStore(store),
+			withRetrieve(retrieve),
+			withResource(metrics.ResourceMyReceipt)),
+	}
+}
+
+// storeMyReceipt assembles the operations to store the receipt and marks it as mine (trusted).
+func (m *MyExecutionReceipts) storeMyReceipt(receipt *flow.ExecutionReceipt) func(*badger.Txn) error {
+	return m.cache.Put(receipt.ID(), receipt)
+}
+
+// storeMyReceipt assembles the operations to retrieve my receipt for the given block ID.
+func (m *MyExecutionReceipts) myReceipt(blockID flow.Identifier) func(*badger.Txn) (*flow.ExecutionReceipt, error) {
+	retrievalOps := m.cache.Get(blockID) // assemble DB operations to retrieve receipt (no execution)
+	return func(tx *badger.Txn) (*flow.ExecutionReceipt, error) {
+		val, err := retrievalOps(tx) // execute operations to retrieve receipt
+		if err != nil {
+			return nil, err
+		}
+		return val.(*flow.ExecutionReceipt), nil
+	}
+}
+
+// StoreMyReceipt stores the receipt and marks it as mine (trusted).
+func (m *MyExecutionReceipts) StoreMyReceipt(receipt *flow.ExecutionReceipt) error {
+	return operation.RetryOnConflict(m.db.Update, m.storeMyReceipt(receipt))
+}
+
+// MyReceipt retrieves my receipt for the given block.
+// Returns badger.ErrKeyNotFound if no receipt was persisted for the block.
+func (m *MyExecutionReceipts) MyReceipt(blockID flow.Identifier) (*flow.ExecutionReceipt, error) {
+	tx := m.db.NewTransaction(false)
+	defer tx.Discard()
+	return m.myReceipt(blockID)(tx)
+}

--- a/storage/badger/operation/prefix.go
+++ b/storage/badger/operation/prefix.go
@@ -53,7 +53,7 @@ const (
 	codeOwnBlockReceipt     = 55 // index mapping block ID to execution receipt ID for execution nodes
 	codeBlockEpochStatus    = 56 // index mapping block ID to epoch status
 	codePayloadReceipts     = 57 // index mapping block ID  to payload receipts
-	codeAllBlockReceipt     = 58 // index mapping of blockID to multiple receipts
+	codeAllBlockReceipts    = 58 // index mapping of blockID to multiple receipts
 	codeIndexBlockByChunkID = 59 // index mapping chunk ID to block ID
 
 	// codes related to epoch information

--- a/storage/badger/operation/receipts.go
+++ b/storage/badger/operation/receipts.go
@@ -16,25 +16,25 @@ func RetrieveExecutionReceiptMeta(receiptID flow.Identifier, meta *flow.Executio
 	return retrieve(makePrefix(codeExecutionReceiptMeta, receiptID), meta)
 }
 
-// IndexExecutionReceipt inserts an execution receipt ID keyed by block ID
-func IndexExecutionReceipt(blockID flow.Identifier, receiptID flow.Identifier) func(*badger.Txn) error {
+// IndexOwnExecutionReceipt inserts an execution receipt ID keyed by block ID
+func IndexOwnExecutionReceipt(blockID flow.Identifier, receiptID flow.Identifier) func(*badger.Txn) error {
 	return insert(makePrefix(codeOwnBlockReceipt, blockID), receiptID)
 }
 
-// LookupExecutionReceipt finds execution receipt ID by block
-func LookupExecutionReceipt(blockID flow.Identifier, receiptID *flow.Identifier) func(*badger.Txn) error {
+// LookupOwnExecutionReceipt finds execution receipt ID by block
+func LookupOwnExecutionReceipt(blockID flow.Identifier, receiptID *flow.Identifier) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeOwnBlockReceipt, blockID), receiptID)
 }
 
 // IndexExecutionReceipts inserts an execution receipt ID keyed by block ID
 func IndexExecutionReceipts(blockID, receiptID flow.Identifier) func(*badger.Txn) error {
-	return insert(makePrefix(codeAllBlockReceipt, blockID, receiptID), struct{}{})
+	return insert(makePrefix(codeAllBlockReceipts, blockID, receiptID), struct{}{})
 }
 
 // LookupExecutionReceipts finds all execution receipts by block ID
 func LookupExecutionReceipts(blockID flow.Identifier, receiptIDs *[]flow.Identifier) func(*badger.Txn) error {
 	iterationFunc := receiptIterationFunc(receiptIDs)
-	return traverse(makePrefix(codeAllBlockReceipt, blockID), iterationFunc)
+	return traverse(makePrefix(codeAllBlockReceipts, blockID), iterationFunc)
 }
 
 // receiptIterationFunc returns an in iteration function which returns all receipt IDs found during traversal

--- a/storage/receipts.go
+++ b/storage/receipts.go
@@ -18,7 +18,8 @@ type ExecutionReceipts interface {
 	// ByID retrieves an execution receipt by its ID.
 	ByID(receiptID flow.Identifier) (*flow.ExecutionReceipt, error)
 
-	// ByBlockID retrieves all known execution receipts for the given block.
+	// ByBlockID retrieves all known execution receipts for the given block
+	// (from any Execution Node).
 	ByBlockID(blockID flow.Identifier) ([]*flow.ExecutionReceipt, error)
 }
 

--- a/storage/receipts.go
+++ b/storage/receipts.go
@@ -6,6 +6,10 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+// ExecutionReceipts holds and indexes Execution Receipts. The storage-layer
+// abstraction is from the viewpoint of the network: there are multiple
+// execution nodes which produce several receipts for each block. By default,
+// there is no distinguished execution node (the are all equal).
 type ExecutionReceipts interface {
 
 	// Store stores an execution receipt.
@@ -14,6 +18,20 @@ type ExecutionReceipts interface {
 	// ByID retrieves an execution receipt by its ID.
 	ByID(receiptID flow.Identifier) (*flow.ExecutionReceipt, error)
 
-	// ByBlockID retrieves an execution receipt by block ID.
+	// ByBlockID retrieves all known execution receipts for the given block.
 	ByBlockID(blockID flow.Identifier) ([]*flow.ExecutionReceipt, error)
+}
+
+// MyExecutionReceipts holds and indexes Execution Receipts.
+// MyExecutionReceipts is an extension of storage.ExecutionReceipts API.
+// It introduces the notion of "MY execution receipt", from the viewpoint
+// of an individual Execution Node.
+type MyExecutionReceipts interface {
+	ExecutionReceipts
+
+	// StoreMyReceipt stores the receipt and marks it as mine (trusted).
+	StoreMyReceipt(receipt *flow.ExecutionReceipt) error
+
+	// MyReceipt retrieves my receipt for the given block.
+	MyReceipt(blockID flow.Identifier) (*flow.ExecutionReceipt, error)
 }


### PR DESCRIPTION
draft for separating Receipts (from all Execution Nodes) from receipts that a specific execution Node stored as "mine"