### PR TITLE
Sign and verify DKG broadcast messages with node staking key

### DIFF
--- a/engine/consensus/dkg/messaging_engine.go
+++ b/engine/consensus/dkg/messaging_engine.go
@@ -18,9 +18,9 @@ import (
 type MessagingEngine struct {
 	unit    *engine.Unit
 	log     zerolog.Logger
-	me      module.Local
-	conduit network.Conduit // network conduit for sending and receiving private messages
-	tunnel  *dkg.BrokerTunnel
+	me      module.Local      // local object to identify the node
+	conduit network.Conduit   // network conduit for sending and receiving private messages
+	tunnel  *dkg.BrokerTunnel // tunnel for relaying private messages to and from controllers
 }
 
 // NewMessagingEngine returns a new engine.
@@ -94,7 +94,7 @@ func (e *MessagingEngine) process(originID flow.Identifier, event interface{}) e
 	switch v := event.(type) {
 	case msg.DKGMessage:
 		e.tunnel.SendIn(
-			msg.DKGMessageIn{
+			msg.PrivDKGMessageIn{
 				DKGMessage: v,
 				OriginID:   originID,
 			},

--- a/engine/consensus/dkg/messaging_engine_test.go
+++ b/engine/consensus/dkg/messaging_engine_test.go
@@ -62,7 +62,7 @@ func TestForwardOutgoingMessages(t *testing.T) {
 		Once()
 	engine.conduit = conduit
 
-	engine.tunnel.SendOut(msg.DKGMessageOut{
+	engine.tunnel.SendOut(msg.PrivDKGMessageOut{
 		DKGMessage: expectedMsg,
 		DestID:     destinationID,
 	})
@@ -77,7 +77,7 @@ func TestForwardIncomingMessages(t *testing.T) {
 	engine := createTestEngine(t)
 
 	originID := unittest.IdentifierFixture()
-	expectedMsg := msg.DKGMessageIn{
+	expectedMsg := msg.PrivDKGMessageIn{
 		DKGMessage: msg.NewDKGMessage(1, []byte("hello"), "dkg-123"),
 		OriginID:   originID,
 	}

--- a/engine/consensus/dkg/reactor_engine_test.go
+++ b/engine/consensus/dkg/reactor_engine_test.go
@@ -109,13 +109,13 @@ func TestEpochSetup(t *testing.T) {
 	controller.On("End").Return(nil).Once()
 	controller.On("Poll", mock.Anything).Return(nil).Times(15)
 	controller.On("GetArtifacts").Return(expectedPrivKey, nil, nil).Once()
+	controller.On("GetIndex").Return(myIndex).Once()
 	controller.On("SubmitResult").Return(nil).Once()
 
 	factory := new(module.DKGControllerFactory)
 	factory.On("Create",
 		fmt.Sprintf("dkg-%d", epochSetup.Counter),
-		committee.NodeIDs(),
-		myIndex,
+		committee,
 		epochSetup.RandomSource).Return(controller, nil)
 
 	viewEvents := gadgets.NewViews()

--- a/engine/execution/utils/hasher.go
+++ b/engine/execution/utils/hasher.go
@@ -22,6 +22,12 @@ func NewSPOCKHasher() hash.Hasher {
 	return h
 }
 
+// NewDKGMessageHasher returns a hasher for signing and verifying DKG broadcast
+// messages.
+func NewDKGMessageHasher() hash.Hasher {
+	return crypto.NewBLSKMAC(encoding.DKGMessageTag)
+}
+
 // NewHasher returns one of the hashers supported by Flow transactions.
 func NewHasher(algo hash.HashingAlgorithm) (hash.Hasher, error) {
 	switch algo {

--- a/engine/execution/utils/hasher.go
+++ b/engine/execution/utils/hasher.go
@@ -22,12 +22,6 @@ func NewSPOCKHasher() hash.Hasher {
 	return h
 }
 
-// NewDKGMessageHasher returns a hasher for signing and verifying DKG broadcast
-// messages.
-func NewDKGMessageHasher() hash.Hasher {
-	return crypto.NewBLSKMAC(encoding.DKGMessageTag)
-}
-
 // NewHasher returns one of the hashers supported by Flow transactions.
 func NewHasher(algo hash.HashingAlgorithm) (hash.Hasher, error) {
 	switch algo {

--- a/model/encoding/signing_tags.go
+++ b/model/encoding/signing_tags.go
@@ -31,4 +31,6 @@ var (
 	ResultApprovalTag = tag("Result-Approval")
 	// SPOCKTag is used to generate SPoCK proofs
 	SPOCKTag = tag("SPoCK")
+	// DKGMessageTag is used for DKG messages
+	DKGMessageTag = tag("DKG-Message")
 )

--- a/model/messages/dkg.go
+++ b/model/messages/dkg.go
@@ -35,10 +35,10 @@ type PrivDKGMessageOut struct {
 	DestID flow.Identifier
 }
 
-// BcastDKGMessage is a wrapper around a DKGMessage intended for broadcasting.
+// BroadcastDKGMessage is a wrapper around a DKGMessage intended for broadcasting.
 // It contains a signature of the DKGMessage signed with the staking key of the
 // sender.
-type BcastDKGMessage struct {
+type BroadcastDKGMessage struct {
 	DKGMessage
 	Signature crypto.Signature
 }

--- a/model/messages/dkg.go
+++ b/model/messages/dkg.go
@@ -1,10 +1,13 @@
 package messages
 
-import "github.com/onflow/flow-go/model/flow"
+import (
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/model/flow"
+)
 
 // DKGMessage is the type of message exchanged between DKG nodes.
 type DKGMessage struct {
-	Orig          int
+	Orig          uint64
 	Data          []byte
 	DKGInstanceID string
 }
@@ -12,22 +15,30 @@ type DKGMessage struct {
 // NewDKGMessage creates a new DKGMessage.
 func NewDKGMessage(orig int, data []byte, dkgInstanceID string) DKGMessage {
 	return DKGMessage{
-		Orig:          orig,
+		Orig:          uint64(orig),
 		Data:          data,
 		DKGInstanceID: dkgInstanceID,
 	}
 }
 
-// DKGMessageIn is a wrapper around a DKGMessage containing the network ID of
-// the sender.
-type DKGMessageIn struct {
+// PrivDKGMessageIn is a wrapper around a DKGMessage containing the network ID
+// of the sender.
+type PrivDKGMessageIn struct {
 	DKGMessage
 	OriginID flow.Identifier
 }
 
-// DKGMessageOut is a wrapper around a DKGMessage containing the network ID of
+// PrivDKGMessageOut is a wrapper around a DKGMessage containing the network ID of
 // the destination.
-type DKGMessageOut struct {
+type PrivDKGMessageOut struct {
 	DKGMessage
 	DestID flow.Identifier
+}
+
+// BcastDKGMessage is a wrapper around a DKGMessage intended for broadcasting.
+// It contains a signature of the DKGMessage signed with the staking key of the
+// sender.
+type BcastDKGMessage struct {
+	DKGMessage
+	Signature crypto.Signature
 }

--- a/module/dkg.go
+++ b/module/dkg.go
@@ -18,7 +18,7 @@ type DKGContractClient interface {
 	// smart contract. An error is returned if the transaction has failed has
 	// failed.
 	// TBD: retry logic
-	Broadcast(msg messages.BcastDKGMessage) error
+	Broadcast(msg messages.BroadcastDKGMessage) error
 
 	// ReadBroadcast reads the broadcast messages from the smart contract.
 	// Messages are returned in the order in which they were broadcast (received
@@ -31,7 +31,7 @@ type DKGContractClient interface {
 	// DKG nodes should call ReadBroadcast one final time once they have
 	// observed the phase deadline trigger to guarantee they receive all
 	// messages for that phase.
-	ReadBroadcast(fromIndex uint, referenceBlock flow.Identifier) ([]messages.BcastDKGMessage, error)
+	ReadBroadcast(fromIndex uint, referenceBlock flow.Identifier) ([]messages.BroadcastDKGMessage, error)
 
 	// SubmitResult submits the final public result of the DKG protocol. This
 	// represents the group public key and the node's local computation of the
@@ -66,8 +66,9 @@ type DKGController interface {
 	// received messages are processed.
 	Poll(blockReference flow.Identifier) error
 
-	// GetArtifacts returns the private and public shares, as well as the set of
-	// public keys computed by DKG.
+	// GetArtifacts returns our node's private key share, the group public key,
+	// and the list of all nodes' public keys (including ours), as computed by
+	// the DKG.
 	GetArtifacts() (crypto.PrivateKey, crypto.PublicKey, []crypto.PublicKey)
 
 	// GetIndex returns the index of this node in the DKG committee list.

--- a/module/dkg/broker.go
+++ b/module/dkg/broker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/engine/execution/utils"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
@@ -20,7 +21,8 @@ type Broker struct {
 	sync.Mutex
 	log               zerolog.Logger
 	dkgInstanceID     string                   // unique identifier of the current dkg run (prevent replay attacks)
-	committee         flow.IdentifierList      // IDs of DKG members
+	committee         flow.IdentityList        // IDs of DKG members
+	me                module.Local             // used for signing bcast messages
 	myIndex           int                      // index of this instance in the committee
 	dkgContractClient module.DKGContractClient // client to communicate with the DKG smart contract
 	tunnel            *BrokerTunnel            // channels through which the broker communicates with the network engine
@@ -35,7 +37,8 @@ type Broker struct {
 func NewBroker(
 	log zerolog.Logger,
 	dkgInstanceID string,
-	committee flow.IdentifierList,
+	committee flow.IdentityList,
+	me module.Local,
 	myIndex int,
 	dkgContractClient module.DKGContractClient,
 	tunnel *BrokerTunnel) *Broker {
@@ -44,6 +47,7 @@ func NewBroker(
 		log:               log.With().Str("component", "broker").Str("dkg_instance_id", dkgInstanceID).Logger(),
 		dkgInstanceID:     dkgInstanceID,
 		committee:         committee,
+		me:                me,
 		myIndex:           myIndex,
 		dkgContractClient: dkgContractClient,
 		tunnel:            tunnel,
@@ -61,6 +65,11 @@ func NewBroker(
 Implement DKGBroker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
+// GetIndex returns the index of this node in the committee list.
+func (b *Broker) GetIndex() int {
+	return b.myIndex
+}
+
 // PrivateSend sends a DKGMessage to a destination over a private channel. It
 // appends the current DKG instance ID to the message.
 func (b *Broker) PrivateSend(dest int, data []byte) {
@@ -68,21 +77,20 @@ func (b *Broker) PrivateSend(dest int, data []byte) {
 		b.log.Error().Msgf("destination id out of range: %d", dest)
 		return
 	}
-	dkgMessageOut := messages.DKGMessageOut{
+	dkgMessageOut := messages.PrivDKGMessageOut{
 		DKGMessage: messages.NewDKGMessage(b.myIndex, data, b.dkgInstanceID),
-		DestID:     b.committee[dest],
+		DestID:     b.committee[dest].NodeID,
 	}
 	b.tunnel.SendOut(dkgMessageOut)
 }
 
-// Broadcast broadcasts a message to all participants.
+// Broadcast signs and broadcasts a message to all participants.
 func (b *Broker) Broadcast(data []byte) {
-	dkgMessage := messages.NewDKGMessage(
-		b.myIndex,
-		data,
-		b.dkgInstanceID,
-	)
-	err := b.dkgContractClient.Broadcast(dkgMessage)
+	bcastMsg, err := b.prepareBcastMessage(data)
+	if err != nil {
+		b.log.Error().Err(err).Msg("could not create broadcast message")
+	}
+	err = b.dkgContractClient.Broadcast(bcastMsg)
 	if err != nil {
 		b.log.Error().Err(err).Msg("could not broadcast message")
 	}
@@ -111,7 +119,7 @@ func (b *Broker) GetBroadcastMsgCh() <-chan messages.DKGMessage {
 }
 
 // Poll calls the DKG smart contract to get missing DKG messages for the current
-// epoch, and forwards them to the msgCh. It should be called with the ID of
+// epoch, and forwards them to the msgCh. It should be called with the ID of a
 // block whose seal is finalized. The function doesn't return until the received
 // messages are processed by the consumer because b.msgCh is not buffered.
 func (b *Broker) Poll(referenceBlock flow.Identifier) error {
@@ -122,13 +130,17 @@ func (b *Broker) Poll(referenceBlock flow.Identifier) error {
 		return fmt.Errorf("could not read broadcast messages: %w", err)
 	}
 	for _, msg := range msgs {
-		err := b.checkMessageInstanceAndOrigin(msg)
+		ok, err := b.verifyBcastMessage(msg)
 		if err != nil {
 			b.log.Error().Err(err).Msg("bad broadcast message")
 			continue
 		}
+		if !ok {
+			b.log.Debug().Msg("invalid signature on broadcast dkg message")
+			continue
+		}
 		b.log.Debug().Msgf("forwarding broadcast message to controller")
-		b.broadcastMsgCh <- msg
+		b.broadcastMsgCh <- msg.DKGMessage
 	}
 	b.messageOffset += uint(len(msgs))
 	return nil
@@ -168,7 +180,7 @@ func (b *Broker) onPrivateMessage(originID flow.Identifier, msg messages.DKGMess
 		return
 	}
 	// check that the message's origin matches the sender's flow identifier
-	nodeID := b.committee[msg.Orig]
+	nodeID := b.committee[msg.Orig].NodeID
 	if !bytes.Equal(nodeID[:], originID[:]) {
 		b.log.Error().Msgf("bad message: OriginID (%v) does not match committee member %d (%v)", originID, msg.Orig, nodeID)
 		return
@@ -185,8 +197,44 @@ func (b *Broker) checkMessageInstanceAndOrigin(msg messages.DKGMessage) error {
 		return fmt.Errorf("wrong DKG instance. Got %s, want %s", msg.DKGInstanceID, b.dkgInstanceID)
 	}
 	// check that the message's origin is not out of range
-	if msg.Orig >= len(b.committee) || msg.Orig < 0 {
+	if msg.Orig >= uint64(len(b.committee)) {
 		return fmt.Errorf("origin id out of range: %d", msg.Orig)
 	}
 	return nil
+}
+
+// prepareBcastMessage creates a BcastDKGMessage with a signature from the
+// node's staking key.
+func (b *Broker) prepareBcastMessage(data []byte) (messages.BcastDKGMessage, error) {
+	dkgMessage := messages.NewDKGMessage(
+		b.myIndex,
+		data,
+		b.dkgInstanceID,
+	)
+	sigData := flow.MakeID(dkgMessage)
+	signature, err := b.me.Sign(sigData[:], utils.NewDKGMessageHasher())
+	if err != nil {
+		return messages.BcastDKGMessage{}, err
+	}
+	bcastMsg := messages.BcastDKGMessage{
+		DKGMessage: dkgMessage,
+		Signature:  signature,
+	}
+	return bcastMsg, nil
+}
+
+// verifySignature checks the DKG instance and Origin of a broadcast message, as
+// well as the signature against the staking key of the sender.
+func (b *Broker) verifyBcastMessage(bcastMsg messages.BcastDKGMessage) (bool, error) {
+	err := b.checkMessageInstanceAndOrigin(bcastMsg.DKGMessage)
+	if err != nil {
+		return false, err
+	}
+	origin := b.committee[bcastMsg.Orig]
+	signData := flow.MakeID(bcastMsg.DKGMessage)
+	return origin.StakingPubKey.Verify(
+		bcastMsg.Signature,
+		signData[:],
+		utils.NewDKGMessageHasher(),
+	)
 }

--- a/module/dkg/broker_test.go
+++ b/module/dkg/broker_test.go
@@ -1,26 +1,39 @@
 package dkg
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/model/flow"
 	msg "github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
 // variables that are used throughout the tests
 var (
-	committee     = unittest.IdentifierListFixture(2) // dkg nodes
-	orig          = 0                                 // message sender
-	dest          = 1                                 // message destination
-	msgb          = []byte("hello world")             // message content
-	dkgInstanceID = "flow-testnet-42"                 // dkg instance identifier
+	orig          = 0                     // message sender
+	dest          = 1                     // message destination
+	msgb          = []byte("hello world") // message content
+	dkgInstanceID = "flow-testnet-42"     // dkg instance identifier
 )
+
+func initCommittee(n int) (identities flow.IdentityList, locals []module.Local) {
+	privateStakingKeys, _ := unittest.StakingKeys(n)
+	for i, k := range privateStakingKeys {
+		id := unittest.IdentityFixture(unittest.WithStakingPubKey(k.PublicKey()))
+		identities = append(identities, id)
+		local, _ := local.New(id, privateStakingKeys[i])
+		locals = append(locals, local)
+	}
+	return identities, locals
+}
 
 // TestImplementsDKGBroker ensures that Broker implements the DKGBroker
 // interface.
@@ -33,25 +46,27 @@ func TestImplementsDKGBroker(t *testing.T) {
 // public Identifier, and successfully sends a DKG message to the intended
 // recipient through the tunnel.
 func TestPrivateSend_Valid(t *testing.T) {
+	committee, locals := initCommittee(2)
 
 	// sender broker
 	sender := NewBroker(
 		zerolog.Logger{},
 		dkgInstanceID,
 		committee,
+		locals[orig],
 		orig,
 		&mock.DKGContractClient{},
 		NewBrokerTunnel(),
 	)
 
 	// expected DKGMessageOut
-	expectedMsg := msg.DKGMessageOut{
+	expectedMsg := msg.PrivDKGMessageOut{
 		DKGMessage: msg.NewDKGMessage(
 			orig,
 			msgb,
 			dkgInstanceID,
 		),
-		DestID: committee[dest],
+		DestID: committee[dest].NodeID,
 	}
 
 	// launch a background routine to capture messages sent through the tunnel,
@@ -73,12 +88,14 @@ func TestPrivateSend_Valid(t *testing.T) {
 // the message destination parameter is out of range with respect to the
 // committee list.
 func TestPrivateSend_IndexOutOfRange(t *testing.T) {
+	committee, locals := initCommittee(2)
 
 	// sender broker
 	sender := NewBroker(
 		zerolog.Logger{},
 		dkgInstanceID,
 		committee,
+		locals[orig],
 		orig,
 		&mock.DKGContractClient{},
 		NewBrokerTunnel(),
@@ -105,12 +122,14 @@ func TestPrivateSend_IndexOutOfRange(t *testing.T) {
 // correctly matched with origin's Identifier, and that the message is forwarded
 // to the message channel.
 func TestReceivePrivateMessage_Valid(t *testing.T) {
+	committee, locals := initCommittee(2)
 
 	// receiving broker
 	receiver := NewBroker(
 		zerolog.Logger{},
 		dkgInstanceID,
 		committee,
+		locals[dest],
 		dest,
 		&mock.DKGContractClient{},
 		NewBrokerTunnel(),
@@ -136,9 +155,9 @@ func TestReceivePrivateMessage_Valid(t *testing.T) {
 
 	// simulate receiving an incoming message through the broker
 	receiver.tunnel.SendIn(
-		msg.DKGMessageIn{
+		msg.PrivDKGMessageIn{
 			DKGMessage: expectedMsg,
-			OriginID:   committee[orig],
+			OriginID:   committee[orig].NodeID,
 		},
 	)
 
@@ -150,12 +169,14 @@ func TestReceivePrivateMessage_Valid(t *testing.T) {
 // the origin defined in the message, and the network identifier of the origin
 // (as provided by the network utilities).
 func TestProcessPrivateMessage_InvalidOrigin(t *testing.T) {
+	committee, locals := initCommittee(2)
 
 	// receiving broker
 	receiver := NewBroker(
 		zerolog.Logger{},
 		dkgInstanceID,
 		committee,
+		locals[dest],
 		dest,
 		&mock.DKGContractClient{},
 		NewBrokerTunnel(),
@@ -184,9 +205,9 @@ func TestProcessPrivateMessage_InvalidOrigin(t *testing.T) {
 		// simulate receiving an incoming message with bad Origin index field
 		// through the broker
 		receiver.tunnel.SendIn(
-			msg.DKGMessageIn{
+			msg.PrivDKGMessageIn{
 				DKGMessage: dkgMsg,
-				OriginID:   committee[orig],
+				OriginID:   committee[orig].NodeID,
 			},
 		)
 	}
@@ -200,7 +221,7 @@ func TestProcessPrivateMessage_InvalidOrigin(t *testing.T) {
 	)
 	// simulate receiving an incoming message through the broker
 	receiver.tunnel.SendIn(
-		msg.DKGMessageIn{
+		msg.PrivDKGMessageIn{
 			DKGMessage: dkgMsg,
 			OriginID:   unittest.IdentifierFixture(),
 		},
@@ -213,22 +234,21 @@ func TestProcessPrivateMessage_InvalidOrigin(t *testing.T) {
 // data in a DKGMessage (with origin and epochCounter), and that it calls the
 // dkg contract client.
 func TestBroadcastMessage(t *testing.T) {
+	committee, locals := initCommittee(2)
 
 	// sender
 	sender := NewBroker(
 		zerolog.Logger{},
 		dkgInstanceID,
 		committee,
+		locals[orig],
 		orig,
 		&mock.DKGContractClient{},
 		NewBrokerTunnel(),
 	)
 
-	expectedMsg := msg.NewDKGMessage(
-		orig,
-		msgb,
-		dkgInstanceID,
-	)
+	expectedMsg, err := sender.prepareBcastMessage(msgb)
+	require.NoError(t, err)
 
 	// check that the dkg contract client is called with the expected message
 	contractClient := &mock.DKGContractClient{}
@@ -244,57 +264,60 @@ func TestBroadcastMessage(t *testing.T) {
 // TestPoll checks that the broker correctly calls the smart contract to fetch
 // broadcast messages, and forwards the messages to the broadcast channel.
 func TestPoll(t *testing.T) {
+	committee, locals := initCommittee(2)
 
-	broker := NewBroker(
+	sender := NewBroker(
 		zerolog.Logger{},
 		dkgInstanceID,
 		committee,
+		locals[orig],
 		orig,
 		&mock.DKGContractClient{},
 		NewBrokerTunnel(),
 	)
 
+	recipient := NewBroker(
+		zerolog.Logger{},
+		dkgInstanceID,
+		committee,
+		locals[dest],
+		dest,
+		&mock.DKGContractClient{},
+		NewBrokerTunnel(),
+	)
+
 	blockID := unittest.IdentifierFixture()
-	expectedMsgs := []msg.DKGMessage{
-		msg.NewDKGMessage(
-			orig,
-			[]byte("message 1"),
-			dkgInstanceID,
-		),
-		msg.NewDKGMessage(
-			orig,
-			[]byte("message 2"),
-			dkgInstanceID,
-		),
-		msg.NewDKGMessage(
-			orig,
-			[]byte("message 3"),
-			dkgInstanceID,
-		),
+	bcastMsgs := []msg.BcastDKGMessage{}
+	expectedMsgs := []msg.DKGMessage{}
+	for i := 0; i < 3; i++ {
+		bmsg, err := sender.prepareBcastMessage([]byte(fmt.Sprintf("msg%d", i)))
+		require.NoError(t, err)
+		bcastMsgs = append(bcastMsgs, bmsg)
+		expectedMsgs = append(expectedMsgs, bmsg.DKGMessage)
 	}
 
 	// check that the dkg contract client is called correctly
 	contractClient := &mock.DKGContractClient{}
-	contractClient.On("ReadBroadcast", broker.messageOffset, blockID).
-		Return(expectedMsgs, nil).
+	contractClient.On("ReadBroadcast", recipient.messageOffset, blockID).
+		Return(bcastMsgs, nil).
 		Once()
-	broker.dkgContractClient = contractClient
+	sender.dkgContractClient = contractClient
 
 	// launch a background routine to capture messages forwarded to the msgCh
 	receivedMsgs := []msg.DKGMessage{}
 	doneCh := make(chan struct{})
 	go func() {
-		msgCh := broker.GetBroadcastMsgCh()
+		msgCh := sender.GetBroadcastMsgCh()
 		for {
 			msg := <-msgCh
 			receivedMsgs = append(receivedMsgs, msg)
-			if len(receivedMsgs) == len(expectedMsgs) {
+			if len(receivedMsgs) == len(bcastMsgs) {
 				close(doneCh)
 			}
 		}
 	}()
 
-	err := broker.Poll(blockID)
+	err := sender.Poll(blockID)
 	require.NoError(t, err)
 
 	// check that the contract has been correctly called
@@ -305,5 +328,5 @@ func TestPoll(t *testing.T) {
 	require.Equal(t, expectedMsgs, receivedMsgs)
 
 	// check that the message offset has been incremented
-	require.Equal(t, uint(len(expectedMsgs)), broker.messageOffset)
+	require.Equal(t, uint(len(bcastMsgs)), sender.messageOffset)
 }

--- a/module/dkg/broker_test.go
+++ b/module/dkg/broker_test.go
@@ -26,8 +26,8 @@ var (
 
 func initCommittee(n int) (identities flow.IdentityList, locals []module.Local) {
 	privateStakingKeys, _ := unittest.StakingKeys(n)
-	for i, k := range privateStakingKeys {
-		id := unittest.IdentityFixture(unittest.WithStakingPubKey(k.PublicKey()))
+	for i, key := range privateStakingKeys {
+		id := unittest.IdentityFixture(unittest.WithStakingPubKey(key.PublicKey()))
 		identities = append(identities, id)
 		local, _ := local.New(id, privateStakingKeys[i])
 		locals = append(locals, local)
@@ -247,7 +247,7 @@ func TestBroadcastMessage(t *testing.T) {
 		NewBrokerTunnel(),
 	)
 
-	expectedMsg, err := sender.prepareBcastMessage(msgb)
+	expectedMsg, err := sender.prepareBroadcastMessage(msgb)
 	require.NoError(t, err)
 
 	// check that the dkg contract client is called with the expected message
@@ -287,10 +287,10 @@ func TestPoll(t *testing.T) {
 	)
 
 	blockID := unittest.IdentifierFixture()
-	bcastMsgs := []msg.BcastDKGMessage{}
+	bcastMsgs := []msg.BroadcastDKGMessage{}
 	expectedMsgs := []msg.DKGMessage{}
 	for i := 0; i < 3; i++ {
-		bmsg, err := sender.prepareBcastMessage([]byte(fmt.Sprintf("msg%d", i)))
+		bmsg, err := sender.prepareBroadcastMessage([]byte(fmt.Sprintf("msg%d", i)))
 		require.NoError(t, err)
 		bcastMsgs = append(bcastMsgs, bmsg)
 		expectedMsgs = append(expectedMsgs, bmsg.DKGMessage)

--- a/module/dkg/controller.go
+++ b/module/dkg/controller.go
@@ -192,8 +192,9 @@ func (c *Controller) Poll(blockReference flow.Identifier) error {
 	return c.broker.Poll(blockReference)
 }
 
-// GetArtifacts returns the private and public shares, as well as the set of
-// public keys computed by DKG.
+// GetArtifacts returns our node's private key share, the group public key,
+// and the list of all nodes' public keys (including ours), as computed by
+// the DKG.
 func (c *Controller) GetArtifacts() (crypto.PrivateKey, crypto.PublicKey, []crypto.PublicKey) {
 	c.artifactsLock.Lock()
 	defer c.artifactsLock.Unlock()

--- a/module/dkg/controller_test.go
+++ b/module/dkg/controller_test.go
@@ -127,6 +127,11 @@ func (b *broker) FlagMisbehavior(node int, logData string) {
 	b.logger.Debug().Msgf("node %d flagged node %d: %s", b.id, node, logData)
 }
 
+// GetIndex implements the DKGBroker interface.
+func (b *broker) GetIndex() int {
+	return int(b.id)
+}
+
 // GetPrivateMsgCh implements the DKGBroker interface.
 func (b *broker) GetPrivateMsgCh() <-chan msg.DKGMessage {
 	return b.privateChannels[b.id]

--- a/module/dkg/doc.go
+++ b/module/dkg/doc.go
@@ -56,6 +56,8 @@ The Broker is responsible for:
   package.
 - appending dkg instance id to messages to prevent replay attacks
 - checking the integrity of incoming messages
+- signing and verifying broadcast messages (broadcast messages are signed with
+  the staking key of the sender)
 - forwarding incoming messages (private and broadcast) to the controller via a
   channel
 - forwarding outgoing messages (private and broadcast) to other nodes.

--- a/module/dkg/tunnel.go
+++ b/module/dkg/tunnel.go
@@ -8,26 +8,26 @@ import (
 // loosely-coupled Broker and Controller. The same BrokerTunnel is intended
 // to be reused across epochs.
 type BrokerTunnel struct {
-	MsgChIn  chan messages.DKGMessageIn  // from network engine to broker
-	MsgChOut chan messages.DKGMessageOut // from broker to network engine
+	MsgChIn  chan messages.PrivDKGMessageIn  // from network engine to broker
+	MsgChOut chan messages.PrivDKGMessageOut // from broker to network engine
 }
 
 // NewBrokerTunnel instantiates a new BrokerTunnel
 func NewBrokerTunnel() *BrokerTunnel {
 	return &BrokerTunnel{
-		MsgChIn:  make(chan messages.DKGMessageIn),
-		MsgChOut: make(chan messages.DKGMessageOut),
+		MsgChIn:  make(chan messages.PrivDKGMessageIn),
+		MsgChOut: make(chan messages.PrivDKGMessageOut),
 	}
 }
 
 // SendIn pushes incoming messages in the MsgChIn channel to be received by the
 // Broker.
-func (t *BrokerTunnel) SendIn(msg messages.DKGMessageIn) {
+func (t *BrokerTunnel) SendIn(msg messages.PrivDKGMessageIn) {
 	t.MsgChIn <- msg
 }
 
 // SendOut pushes outcoing messages in the MsgChOut channel to be received and
 // forwarded by the network engine.
-func (t *BrokerTunnel) SendOut(msg messages.DKGMessageOut) {
+func (t *BrokerTunnel) SendOut(msg messages.PrivDKGMessageOut) {
 	t.MsgChOut <- msg
 }

--- a/module/local/me.go
+++ b/module/local/me.go
@@ -11,7 +11,7 @@ import (
 
 type Local struct {
 	me *flow.Identity
-	sk crypto.PrivateKey // instance of the node's private key
+	sk crypto.PrivateKey // instance of the node's private staking key
 }
 
 func New(id *flow.Identity, sk crypto.PrivateKey) (*Local, error) {

--- a/module/mock/dkg_broker.go
+++ b/module/mock/dkg_broker.go
@@ -47,6 +47,20 @@ func (_m *DKGBroker) GetBroadcastMsgCh() <-chan messages.DKGMessage {
 	return r0
 }
 
+// GetIndex provides a mock function with given fields:
+func (_m *DKGBroker) GetIndex() int {
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
 // GetPrivateMsgCh provides a mock function with given fields:
 func (_m *DKGBroker) GetPrivateMsgCh() <-chan messages.DKGMessage {
 	ret := _m.Called()

--- a/module/mock/dkg_contract_client.go
+++ b/module/mock/dkg_contract_client.go
@@ -17,11 +17,11 @@ type DKGContractClient struct {
 }
 
 // Broadcast provides a mock function with given fields: msg
-func (_m *DKGContractClient) Broadcast(msg messages.DKGMessage) error {
+func (_m *DKGContractClient) Broadcast(msg messages.BcastDKGMessage) error {
 	ret := _m.Called(msg)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(messages.DKGMessage) error); ok {
+	if rf, ok := ret.Get(0).(func(messages.BcastDKGMessage) error); ok {
 		r0 = rf(msg)
 	} else {
 		r0 = ret.Error(0)
@@ -31,15 +31,15 @@ func (_m *DKGContractClient) Broadcast(msg messages.DKGMessage) error {
 }
 
 // ReadBroadcast provides a mock function with given fields: fromIndex, referenceBlock
-func (_m *DKGContractClient) ReadBroadcast(fromIndex uint, referenceBlock flow.Identifier) ([]messages.DKGMessage, error) {
+func (_m *DKGContractClient) ReadBroadcast(fromIndex uint, referenceBlock flow.Identifier) ([]messages.BcastDKGMessage, error) {
 	ret := _m.Called(fromIndex, referenceBlock)
 
-	var r0 []messages.DKGMessage
-	if rf, ok := ret.Get(0).(func(uint, flow.Identifier) []messages.DKGMessage); ok {
+	var r0 []messages.BcastDKGMessage
+	if rf, ok := ret.Get(0).(func(uint, flow.Identifier) []messages.BcastDKGMessage); ok {
 		r0 = rf(fromIndex, referenceBlock)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]messages.DKGMessage)
+			r0 = ret.Get(0).([]messages.BcastDKGMessage)
 		}
 	}
 

--- a/module/mock/dkg_controller.go
+++ b/module/mock/dkg_controller.go
@@ -90,6 +90,20 @@ func (_m *DKGController) GetArtifacts() (crypto.PrivateKey, crypto.PublicKey, []
 	return r0, r1, r2
 }
 
+// GetIndex provides a mock function with given fields:
+func (_m *DKGController) GetIndex() int {
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
 // Poll provides a mock function with given fields: blockReference
 func (_m *DKGController) Poll(blockReference flow.Identifier) error {
 	ret := _m.Called(blockReference)

--- a/module/mock/dkg_controller_factory.go
+++ b/module/mock/dkg_controller_factory.go
@@ -14,13 +14,13 @@ type DKGControllerFactory struct {
 	mock.Mock
 }
 
-// Create provides a mock function with given fields: dkgInstanceID, participants, myIndex, seed
-func (_m *DKGControllerFactory) Create(dkgInstanceID string, participants []flow.Identifier, myIndex int, seed []byte) (module.DKGController, error) {
-	ret := _m.Called(dkgInstanceID, participants, myIndex, seed)
+// Create provides a mock function with given fields: dkgInstanceID, participants, seed
+func (_m *DKGControllerFactory) Create(dkgInstanceID string, participants flow.IdentityList, seed []byte) (module.DKGController, error) {
+	ret := _m.Called(dkgInstanceID, participants, seed)
 
 	var r0 module.DKGController
-	if rf, ok := ret.Get(0).(func(string, []flow.Identifier, int, []byte) module.DKGController); ok {
-		r0 = rf(dkgInstanceID, participants, myIndex, seed)
+	if rf, ok := ret.Get(0).(func(string, flow.IdentityList, []byte) module.DKGController); ok {
+		r0 = rf(dkgInstanceID, participants, seed)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(module.DKGController)
@@ -28,8 +28,8 @@ func (_m *DKGControllerFactory) Create(dkgInstanceID string, participants []flow
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, []flow.Identifier, int, []byte) error); ok {
-		r1 = rf(dkgInstanceID, participants, myIndex, seed)
+	if rf, ok := ret.Get(1).(func(string, flow.IdentityList, []byte) error); ok {
+		r1 = rf(dkgInstanceID, participants, seed)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/utils/hasher/hasher.go
+++ b/utils/hasher/hasher.go
@@ -1,0 +1,13 @@
+package hasher
+
+import (
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/model/encoding"
+)
+
+// NewDKGMessageHasher returns a hasher for signing and verifying DKG broadcast
+// messages.
+func NewDKGMessageHasher() hash.Hasher {
+	return crypto.NewBLSKMAC(encoding.DKGMessageTag)
+}

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -645,6 +645,13 @@ func WithNodeID(b byte) func(*flow.Identity) {
 	}
 }
 
+// WithStakingPubKey adds a staking public key to the identity
+func WithStakingPubKey(pubKey crypto.PublicKey) func(*flow.Identity) {
+	return func(identity *flow.Identity) {
+		identity.StakingPubKey = pubKey
+	}
+}
+
 // WithRandomPublicKeys adds random public keys to an identity.
 func WithRandomPublicKeys() func(*flow.Identity) {
 	return func(identity *flow.Identity) {


### PR DESCRIPTION
This PR addresses issue [4465](https://github.com/dapperlabs/flow-go/issues/4465) to sign and verify DKG broadcast messages with a node's staking key.

The main changes are in the [DKG broker](https://github.com/onflow/flow-go/blob/549dff03ec7faf75295be11ba10eb1e72c73297f/module/dkg/broker.go#L206-L240) , but the PR also contains some refactoring that is not directly related to the issue.



