### PR TITLE
Porting the change on v0.14 to access node to consider at least 2 matching ER

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -502,7 +502,7 @@ func (suite *Suite) TestExecuteScript() {
 
 		suite.backend = backend.New(
 			suite.state,
-			nil,
+			suite.execClient,
 			suite.collClient,
 			nil,
 			blocks,

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -54,7 +54,7 @@ type Suite struct {
 }
 
 // TestAccess tests scenarios which exercise multiple API calls using both the RPC handler and the ingest engine
-// and using a real badger storage.
+// and using a real badger storage
 func TestAccess(t *testing.T) {
 	suite.Run(t, new(Suite))
 }

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -209,21 +209,63 @@ func convertStorageError(err error) error {
 func executionNodesForBlockID(
 	blockID flow.Identifier,
 	executionReceipts storage.ExecutionReceipts,
-	state protocol.State) (flow.IdentityList, error) {
+	state protocol.State,
+	log zerolog.Logger) (flow.IdentityList, error) {
 
 	// lookup the receipts storage with the block ID
-	receipts, err := executionReceipts.ByBlockID(blockID)
+	allReceipts, err := executionReceipts.ByBlockID(blockID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retreive execution receipts for block ID %v: %w", blockID, err)
 	}
 
-	// collect the execution node id in each of the receipts
-	var executorIDs flow.IdentifierList
-	for _, receipt := range receipts {
-		executorIDs = append(executorIDs, receipt.ExecutorID)
+	// execution result ID to execution receipt map to keep track of receipts by their result id
+	var identicalReceipts = make(map[flow.Identifier][]*flow.ExecutionReceipt)
+
+	// maximum number of matching receipts found so far for any execution result id
+	maxMatchedReceiptCnt := 0
+	// execution result id key for the highest number of matching receipts in the identicalReceipts map
+	var maxMatchedReceiptResultID flow.Identifier
+
+	// find the largest list of receipts which have the same result ID
+	for _, receipt := range allReceipts {
+
+		resultID := receipt.ExecutionResult.ID()
+		identicalReceipts[resultID] = append(identicalReceipts[resultID], receipt)
+
+		currentMatchedReceiptCnt := len(identicalReceipts[resultID])
+		if currentMatchedReceiptCnt > maxMatchedReceiptCnt {
+			maxMatchedReceiptCnt = currentMatchedReceiptCnt
+			maxMatchedReceiptResultID = resultID
+		}
 	}
 
-	if len(executorIDs) == 0 {
+	mismatchReceiptCnt := len(identicalReceipts)
+	// if there are more than one execution result for the same block ID, log as error
+	if mismatchReceiptCnt > 1 {
+		identicalReceiptsStr := fmt.Sprintf("%v", flow.GetIDs(allReceipts))
+		log.Error().
+			Str("block_id", blockID.String()).
+			Str("execution_receipts", identicalReceiptsStr).
+			Msg("execution receipt mismatch")
+	}
+
+	// pick the largest list of matching receipts
+	matchingReceipts := identicalReceipts[maxMatchedReceiptResultID]
+
+	// collect all unique execution node ids from the receipts
+	var executorIDs flow.IdentifierList
+	executorIDMap := make(map[flow.Identifier]bool)
+	for _, receipt := range matchingReceipts {
+		if executorIDMap[receipt.ExecutorID] {
+			continue
+		}
+		executorIDs = append(executorIDs, receipt.ExecutorID)
+		executorIDMap[receipt.ExecutorID] = true
+	}
+
+	// return if less than 2 unique execution node ids were found
+	// since we want matching receipts from at least 2 ENs
+	if len(executorIDs) < 2 {
 		return flow.IdentityList{}, nil
 	}
 

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -82,7 +82,7 @@ func (b *backendAccounts) getAccountAtBlockID(
 		BlockId: blockID[:],
 	}
 
-	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state)
+	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get account from the execution node: %v", err)
 	}

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -117,7 +117,7 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 	// choose the last block ID to find the list of execution nodes
 	lastBlockID := blockIDs[len(blockIDs)-1]
 
-	execNodes, err := executionNodesForBlockID(lastBlockID, b.executionReceipts, b.state)
+	execNodes, err := executionNodesForBlockID(lastBlockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to retrieve events from execution node: %v", err)
 	}

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -87,7 +87,7 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 	}
 
 	// find few execution nodes which have executed the block earlier and provided an execution receipt for it
-	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state)
+	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to execute the script on the execution node: %v", err)
 	}

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -52,7 +52,7 @@ func TestHandler(t *testing.T) {
 
 func (suite *Suite) SetupTest() {
 	rand.Seed(time.Now().UnixNano())
-	suite.log = zerolog.Logger{}
+	suite.log = zerolog.New(zerolog.NewConsoleWriter())
 	suite.state = new(protocol.State)
 	suite.snapshot = new(protocol.Snapshot)
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
@@ -246,13 +246,7 @@ func (suite *Suite) TestTransactionStatusTransition() {
 	txID := transactionBody.ID()
 	blockID := block.ID()
 
-	ids := unittest.IdentityListFixture(1)
-	receipt := unittest.ReceiptForBlockFixture(&block)
-	receipt.ExecutorID = ids[0].NodeID
-	suite.receipts.
-		On("ByBlockID", mock.Anything).
-		Return([]*flow.ExecutionReceipt{receipt}, nil)
-	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
+	suite.setupReceipts(&block)
 
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
@@ -529,6 +523,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 
 	setupStorage := func(n int) []*flow.Header {
 		headers := make([]*flow.Header, n)
+		ids := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
 
 		for i := 0; i < n; i++ {
 			b := unittest.BlockFixture()
@@ -538,10 +533,14 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 
 			headers[i] = b.Header
 
-			r := unittest.ReceiptForBlockFixture(&b)
+			receipt1 := unittest.ReceiptForBlockFixture(&b)
+			receipt1.ExecutorID = ids[0].NodeID
+			receipt2 := unittest.ReceiptForBlockFixture(&b)
+			receipt2.ExecutorID = ids[1].NodeID
+			receipt1.ExecutionResult = receipt2.ExecutionResult
 			suite.receipts.
 				On("ByBlockID", b.ID()).
-				Return([]*flow.ExecutionReceipt{r}, nil).Once()
+				Return([]*flow.ExecutionReceipt{receipt1, receipt2}, nil).Once()
 		}
 
 		return headers
@@ -904,14 +903,7 @@ func (suite *Suite) TestGetAccount() {
 		Return(exeResp, nil).
 		Once()
 
-	ids := unittest.IdentityListFixture(1)
-	receipt := unittest.ReceiptForBlockFixture(&block)
-	receipt.ExecutorID = ids[0].NodeID
-	suite.receipts.
-		On("ByBlockID", blockID).
-		Return([]*flow.ExecutionReceipt{receipt}, nil).Once()
-	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
-
+	suite.setupReceipts(&block)
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
 	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
@@ -1043,10 +1035,14 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 		blockIDExecNodeMap[block.ID()] = ids
 		allExecutionIDs = append(allExecutionIDs, ids...)
 
+		// same execution result for all receipts for this block
+		executionResult := unittest.ExecutionResultFixture()
 		receipts := make([]*flow.ExecutionReceipt, receiptPerBlock)
 		for j := 0; j < receiptPerBlock; j++ {
 			r := unittest.ReceiptForBlockFixture(block)
 			r.ExecutorID = ids[j].NodeID
+			er := *executionResult
+			r.ExecutionResult = er
 			receipts[j] = r
 		}
 		suite.receipts.
@@ -1063,7 +1059,7 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 
 	testBlock := blocks[0]
 	expectedList := blockIDExecNodeMap[testBlock.ID()]
-	actualList, err := executionNodesForBlockID(testBlock.ID(), suite.receipts, suite.state)
+	actualList, err := executionNodesForBlockID(testBlock.ID(), suite.receipts, suite.state, suite.log)
 	require.NoError(suite.T(), err)
 	require.ElementsMatch(suite.T(), actualList, expectedList)
 }
@@ -1081,6 +1077,23 @@ func (suite *Suite) assertAllExpectations() {
 func (suite *Suite) checkResponse(resp interface{}, err error) {
 	suite.Require().NoError(err)
 	suite.Require().NotNil(resp)
+}
+
+func (suite *Suite) setupReceipts(block *flow.Block) []*flow.ExecutionReceipt {
+	ids := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
+	receipt1 := unittest.ReceiptForBlockFixture(block)
+	receipt1.ExecutorID = ids[0].NodeID
+	receipt2 := unittest.ReceiptForBlockFixture(block)
+	receipt2.ExecutorID = ids[1].NodeID
+	receipt1.ExecutionResult = receipt2.ExecutionResult
+
+	receipts := []*flow.ExecutionReceipt{receipt1, receipt2}
+	suite.receipts.
+		On("ByBlockID", block.ID()).
+		Return(receipts, nil)
+	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
+	return receipts
+
 }
 
 func getEvents(n int) []flow.Event {

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -438,7 +438,7 @@ func (b *backendTransactions) getTransactionResultFromExecutionNode(
 		TransactionId: transactionID,
 	}
 
-	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state)
+	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
 		return nil, 0, "", status.Errorf(codes.Internal, "failed to retrieve result from any execution node: %v", err)
 	}

--- a/engine/access/rpc/logging_interceptor.go
+++ b/engine/access/rpc/logging_interceptor.go
@@ -17,7 +17,7 @@ func customClientCodeToLevel(c codes.Code) logging.Level {
 	return logging.DefaultServerCodeToLevel(c)
 }
 
-// loggingInterceptor creates the logging interceptors
+// loggingInterceptor creates the logging interceptors to log incoming GRPC request and response (minus the payload body)
 func loggingInterceptor(log zerolog.Logger) []grpc.UnaryServerInterceptor {
 	tagsInterceptor := tags.UnaryServerInterceptor(tags.WithFieldExtractor(tags.CodeGenRequestFieldExtractor))
 	loggingInterceptor := logging.UnaryServerInterceptor(grpczerolog.InterceptorLogger(log), logging.WithLevels(customClientCodeToLevel))


### PR DESCRIPTION
access node change to consider the execution receipts which have the most common execution result

Original PR: https://github.com/onflow/flow-go/pull/428
Cherry-picked commit: https://github.com/onflow/flow-go/commit/99a851570808b99d15b74149db2103d58454ae32