### PR TITLE
reducing error logging on the access node

### DIFF
--- a/engine/access/rpc/logging_interceptor.go
+++ b/engine/access/rpc/logging_interceptor.go
@@ -11,7 +11,7 @@ import (
 
 func customClientCodeToLevel(code codes.Code) logging.Level {
 	switch code {
-	case codes.OK, codes.ResourceExhausted, codes.Internal:
+	case codes.OK, codes.ResourceExhausted, codes.Internal, codes.Unknown:
 		return logging.DEBUG
 	default:
 		return logging.DefaultServerCodeToLevel(code)

--- a/engine/access/rpc/logging_interceptor.go
+++ b/engine/access/rpc/logging_interceptor.go
@@ -9,12 +9,13 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func customClientCodeToLevel(c codes.Code) logging.Level {
-	if c == codes.OK {
-		// log successful returns as Debug to avoid excessive logging in info mode
+func customClientCodeToLevel(code codes.Code) logging.Level {
+	switch code {
+	case codes.OK, codes.ResourceExhausted, codes.Internal:
 		return logging.DEBUG
+	default:
+		return logging.DefaultServerCodeToLevel(code)
 	}
-	return logging.DefaultServerCodeToLevel(c)
 }
 
 // loggingInterceptor creates the logging interceptors


### PR DESCRIPTION
Access nodes on mainnet are reporting a lot of grpc errors. These errors are related to script failures on the execution node and filling up the logs.

This change is to log such errors as `debug` instead of `error` since these are expected to happen a lot.


Sample logs:

Mar 12 16:44:44 access-001 docker[25659]: {"level":"error","node_role":"access","node_id":"4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990","engine":"rpc","grpc.method":"ExecuteScriptAtBlockHeight","grpc.method_type":"unary","grpc.service":"flow.access.AccessAPI","grpc.start_time":"2021-03-12T16:44:43Z","kind":"server","system":"grpc","peer.address":"34.228.124.173:57510","grpc.code":"Unknown","error":"3 errors occurred:\n\t* rpc error: code = Internal desc = failed to execute the script on the execution node execution-160241f88cbfaa0f361cf64adb0a1c9fc19dec1daf4b96550cd67b7a9fb26cd9@execution-002.mainnet6.nodes.onflow.org:3569=1000: rpc error: code = Internal desc = failed to execute script: failed to execute script (internal error): ledger returns unsuccessful: error getting register (account_address_state) value at b5b5d5fc5690d9bd917999dc90a7702c13d9a50f79d4f38e2b6b751bf652cbee: trie with the given rootHash [b5b5d5fc5690d9bd917999dc90a7702c13d9a50f79d4f38e2b6b751bf652cbee] not found\n\t* rpc error: code = Internal desc = failed to execute the script on the execution node execution-e52cbcd825e328acac8db6bcbdcbb6e7724862c8b89b09d85edccf41ff9981eb@p2p.9ceef7f8-b83c-49d9-b116-626d1e8bc849.flow.bison.run:3569=1000: rpc error: code = Internal desc = failed to execute script: failed to execute script (internal error): ledger returns unsuccessful: error getting register (account_address_state) value at b5b5d5fc5690d9bd917999dc90a7702c13d9a50f79d4f38e2b6b751bf652cbee: trie with the given rootHash [b5b5d5fc5690d9bd917999dc90a7702c13d9a50f79d4f38e2b6b751bf652cbee] not found\n\t* rpc error: code = Internal desc = failed to execute the script on the execution node execution-6c6af0933b710655ec553f4bead3b01c5e0a3ffd1194ee536efb926b356c54aa@flow-execution.samsungnext.com:3569=1000: rpc error: code = Internal desc = failed to execute script: failed to execute script (internal error): ledger returns unsuccessful: error getting register (account_address_state) value at b5b5d5fc5690d9bd917999dc90a7702c13d9a50f79d4f38e2b6b751bf652cbee: trie with the given rootHash [b5b5d5fc5690d9bd917999dc90a7702c13d9a50f79d4f38e2b6b751bf652cbee] not found\n\n","grpc.time_ms":"511.838","time":"2021-03-12T16:44:44Z","message":"finished server unary call"}
Mar 12 16:44:44 access-001 docker[25659]: {"level":"error","node_role":"access","node_id":"4e17496619df8bb4dcd579c252d9fb026e54995db0dc6825bdcd27bd3288a990","engine":"rpc","grpc.method":"ExecuteScriptAtBlockHeight","grpc.method_type":"unary","grpc.service":"flow.access.AccessAPI","grpc.start_time":"2021-03-12T16:44:44Z","kind":"server","system":"grpc","peer.address":"34.228.124.173:57510","grpc.code":"Unknown","error":"3 errors occurred:\n\t* rpc error: code = Internal desc = failed to execute the script on the execution node execution-160241f88cbfaa0f361cf64adb0a1c9fc19dec1daf4b96550cd67b7a9fb26cd9@execution-002.mainnet6.nodes.onflow.org:3569=1000: rpc error: code = Internal desc = failed to execute script: failed to execute script (internal error): ledger returns unsuccessful: error getting register (account_address_state) value at 713c39141caed3ae75ccd05f3ae958326c7e8d401b008c710c8d20c1b48ecb3c: trie with the given rootHash [713c39141caed3ae75ccd05f3ae958326c7e8d401b008c710c8d20c1b48ecb3c] not found\n\t* rpc error: code = Internal desc = failed to execute the script on the execution node execution-0ca407c1da940952ebcc02283b60cd97c9a008e111a48ea6cf1ce8f36f1e0153@execution-004.mainnet6.nodes.onflow.org:3569=1000: rpc error: code = Internal desc = failed to execute script: failed to execute script (internal error): ledger returns unsuccessful: error getting register (account_address_state) value at 713c39141caed3ae75ccd05f3ae958326c7e8d401b008c710c8d20c1b48ecb3c: trie with the given rootHash [713c39141caed3ae75ccd05f3ae958326c7e8d401b008c710c8d20c1b48ecb3c] not found\n\t* rpc error: code = Internal desc = failed to execute the script on the execution node execution-4ab025ab974e7ad7f344fbd16e5fbcb17fb8769fc8849b9d241ae518787695bd@execution-003.mainnet6.nodes.onflow.org:3569=1000: rpc error: code = Internal desc = failed to execute script: failed to execute script (internal error): ledger returns unsuccessful: error getting register (account_address_state) value at 713c39141caed3ae75ccd05f3ae958326c7e8d401b008c710c8d20c1b48ecb3c: trie with the given rootHash [713c39141caed3ae75ccd05f3ae958326c7e8d401b008c710c8d20c1b48ecb3c] not found\n\n","grpc.time_ms":"10.539","time":"2021-03-12T16:44:44Z","message":"finished server unary call"