### PR TITLE
Add proposer to finalized block count metric

### DIFF
--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -3,6 +3,7 @@ package metrics
 const (
 	LabelChannel     = "topic"
 	LabelChain       = "chain"
+	LabelProposer    = "proposer"
 	EngineLabel      = "engine"
 	LabelResource    = "resource"
 	LabelMessage     = "message"


### PR DESCRIPTION
Including the proposer in finalized block count metric lets us see which nodes are successfully proposing blocks, which should correspond to health, up-to-date nodes. This graph shows how we can see which node is down:
![image](https://user-images.githubusercontent.com/10557821/111014847-97158f80-835a-11eb-93ee-76a5b388f3f6.png)
