### PR TITLE
add proposer to finalized block count metric

### DIFF
--- a/module/metrics/collection.go
+++ b/module/metrics/collection.go
@@ -60,7 +60,7 @@ func NewCollectionCollector(tracer module.Tracer) *CollectionCollector {
 			Buckets:   []float64{5, 10, 50, 100}, //TODO(andrew) update once collection limits are known
 			Name:      "guarantees_size_transactions",
 			Help:      "size/number of guaranteed/finalized collections",
-		}, []string{LabelChain}),
+		}, []string{LabelChain, LabelProposer}),
 	}
 
 	return cc
@@ -100,12 +100,16 @@ func (cc *CollectionCollector) ClusterBlockProposed(block *cluster.Block) {
 func (cc *CollectionCollector) ClusterBlockFinalized(block *cluster.Block) {
 	collection := block.Payload.Collection.Light()
 	chainID := block.Header.ChainID
+	proposer := block.Header.ProposerID
 
 	cc.finalizedHeight.
 		With(prometheus.Labels{LabelChain: chainID.String()}).
 		Set(float64(block.Header.Height))
 	cc.guarantees.
-		With(prometheus.Labels{LabelChain: block.Header.ChainID.String()}).
+		With(prometheus.Labels{
+			LabelChain:    chainID.String(),
+			LabelProposer: proposer.String(),
+		}).
 		Observe(float64(collection.Len()))
 
 	for _, txID := range collection.Transactions {

--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -12,7 +12,7 @@ import (
 type ComplianceCollector struct {
 	finalizedHeight          prometheus.Gauge
 	sealedHeight             prometheus.Gauge
-	finalizedBlocks          prometheus.Counter
+	finalizedBlocks          *prometheus.CounterVec
 	sealedBlocks             prometheus.Counter
 	finalizedPayload         *prometheus.CounterVec
 	sealedPayload            *prometheus.CounterVec
@@ -38,12 +38,12 @@ func NewComplianceCollector() *ComplianceCollector {
 			Help:      "the last sealed height",
 		}),
 
-		finalizedBlocks: promauto.NewCounter(prometheus.CounterOpts{
+		finalizedBlocks: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name:      "finalized_blocks_total",
 			Namespace: namespaceConsensus,
 			Subsystem: subsystemCompliance,
 			Help:      "the number of finalized blocks",
-		}),
+		}, []string{LabelProposer}),
 
 		sealedBlocks: promauto.NewCounter(prometheus.CounterOpts{
 			Name:      "sealed_blocks_total",
@@ -100,7 +100,7 @@ func (cc *ComplianceCollector) BlockFinalized(block *flow.Block) {
 	}
 	cc.lastBlockFinalizedAt = now
 
-	cc.finalizedBlocks.Inc()
+	cc.finalizedBlocks.With(prometheus.Labels{LabelProposer: block.Header.ProposerID.String()}).Inc()
 	cc.finalizedPayload.With(prometheus.Labels{LabelResource: ResourceGuarantee}).Add(float64(len(block.Payload.Guarantees)))
 	cc.finalizedPayload.With(prometheus.Labels{LabelResource: ResourceSeal}).Add(float64(len(block.Payload.Seals)))
 }

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -3,6 +3,7 @@ package metrics
 const (
 	LabelChannel     = "topic"
 	LabelChain       = "chain"
+	LabelProposer    = "proposer"
 	EngineLabel      = "engine"
 	LabelResource    = "resource"
 	LabelMessage     = "message"


### PR DESCRIPTION
Cherry-picks the metric addition from https://github.com/onflow/flow-go/pull/523. Deployed to collection nodes 1,2,3 on mainnet6 with tag `v0.14.9-proposer-metric`.