### PR TITLE
Cache Transaction Results

### DIFF
--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -102,6 +102,7 @@ func main() {
 			flags.UintVar(&cadenceExecutionCache, "cadence-execution-cache", computation.DefaultProgramsCacheSize, "cache size for Cadence execution")
 			flags.DurationVar(&requestInterval, "request-interval", 60*time.Second, "the interval between requests for the requester engine")
 			flags.StringVar(&preferredExeNodeIDStr, "preferred-exe-node-id", "", "node ID for preferred execution node used for state sync")
+			flags.IntVar(&transactionResultsCacheSize, "transaction-results-cache-size", 10000, "number of transaction results to be cached")
 			flags.BoolVar(&syncByBlocks, "sync-by-blocks", true, "deprecated, sync by blocks instead of execution state deltas")
 			flags.BoolVar(&syncFast, "sync-fast", false, "fast sync allows execution node to skip fetching collection during state syncing, and rely on state syncing to catch up")
 			flags.IntVar(&syncThreshold, "sync-threshold", 100, "the maximum number of sealed and unexecuted blocks before triggering state syncing")
@@ -234,7 +235,7 @@ func main() {
 			// Needed for gRPC server, make sure to assign to main scoped vars
 			events = storage.NewEvents(node.Metrics.Cache, node.DB)
 			serviceEvents = storage.NewServiceEvents(node.Metrics.Cache, node.DB)
-			txResults = storage.NewTransactionResults(node.Metrics.Cache, node.DB)
+			txResults = storage.NewTransactionResults(node.Metrics.Cache, node.DB, transactionResultsCacheSize)
 
 			executionState = state.NewExecutionState(
 				ledgerStorage,

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -51,41 +51,42 @@ import (
 func main() {
 
 	var (
-		followerState         protocol.MutableState
-		ledgerStorage         *ledger.Ledger
-		events                *storage.Events
-		serviceEvents         *storage.ServiceEvents
-		txResults             *storage.TransactionResults
-		results               *storage.ExecutionResults
-		receipts              *storage.ExecutionReceipts
-		myReceipts            *storage.MyExecutionReceipts
-		providerEngine        *exeprovider.Engine
-		checkerEng            *checker.Engine
-		syncCore              *chainsync.Core
-		pendingBlocks         *buffer.PendingBlocks // used in follower engine
-		deltas                *ingestion.Deltas
-		syncEngine            *synchronization.Engine
-		followerEng           *followereng.Engine // to sync blocks from consensus nodes
-		computationManager    *computation.Manager
-		collectionRequester   *requester.Engine
-		ingestionEng          *ingestion.Engine
-		rpcConf               rpc.Config
-		err                   error
-		executionState        state.ExecutionState
-		triedir               string
-		collector             module.ExecutionMetrics
-		mTrieCacheSize        uint32
-		checkpointDistance    uint
-		checkpointsToKeep     uint
-		stateDeltasLimit      uint
-		cadenceExecutionCache uint
-		requestInterval       time.Duration
-		preferredExeNodeIDStr string
-		syncByBlocks          bool
-		syncFast              bool
-		syncThreshold         int
-		extensiveLog          bool
-		checkStakedAtBlock    func(blockID flow.Identifier) (bool, error)
+		followerState               protocol.MutableState
+		ledgerStorage               *ledger.Ledger
+		events                      *storage.Events
+		serviceEvents               *storage.ServiceEvents
+		txResults                   *storage.TransactionResults
+		results                     *storage.ExecutionResults
+		receipts                    *storage.ExecutionReceipts
+		myReceipts                  *storage.MyExecutionReceipts
+		providerEngine              *exeprovider.Engine
+		checkerEng                  *checker.Engine
+		syncCore                    *chainsync.Core
+		pendingBlocks               *buffer.PendingBlocks // used in follower engine
+		deltas                      *ingestion.Deltas
+		syncEngine                  *synchronization.Engine
+		followerEng                 *followereng.Engine // to sync blocks from consensus nodes
+		computationManager          *computation.Manager
+		collectionRequester         *requester.Engine
+		ingestionEng                *ingestion.Engine
+		rpcConf                     rpc.Config
+		err                         error
+		executionState              state.ExecutionState
+		triedir                     string
+		collector                   module.ExecutionMetrics
+		mTrieCacheSize              uint32
+		transactionResultsCacheSize uint
+		checkpointDistance          uint
+		checkpointsToKeep           uint
+		stateDeltasLimit            uint
+		cadenceExecutionCache       uint
+		requestInterval             time.Duration
+		preferredExeNodeIDStr       string
+		syncByBlocks                bool
+		syncFast                    bool
+		syncThreshold               int
+		extensiveLog                bool
+		checkStakedAtBlock          func(blockID flow.Identifier) (bool, error)
 	)
 
 	cmd.FlowNode(flow.RoleExecution.String()).

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -231,6 +231,11 @@ func main() {
 			chunkDataPacks := storage.NewChunkDataPacks(node.DB)
 			stateCommitments := storage.NewCommits(node.Metrics.Cache, node.DB)
 
+			// Needed for gRPC server, make sure to assign to main scoped vars
+			events = storage.NewEvents(node.Metrics.Cache, node.DB)
+			serviceEvents = storage.NewServiceEvents(node.Metrics.Cache, node.DB)
+			txResults = storage.NewTransactionResults(node.Metrics.Cache, node.DB)
+
 			executionState = state.NewExecutionState(
 				ledgerStorage,
 				stateCommitments,
@@ -288,10 +293,6 @@ func main() {
 				node.Logger.Debug().Str("prefered_exe_node_id_string", preferredExeNodeIDStr).Msg("could not parse exe node id, starting WITHOUT preferred exe sync node")
 			}
 
-			// Needed for gRPC server, make sure to assign to main scoped vars
-			events = storage.NewEvents(node.Metrics.Cache, node.DB)
-			serviceEvents = storage.NewServiceEvents(node.Metrics.Cache, node.DB)
-			txResults = storage.NewTransactionResults(node.Metrics.Cache, node.DB)
 			ingestionEng, err = ingestion.New(
 				node.Logger,
 				node.Network,

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -289,10 +289,9 @@ func main() {
 			}
 
 			// Needed for gRPC server, make sure to assign to main scoped vars
-			events = storage.NewEvents(node.DB)
-			serviceEvents := storage.NewServiceEvents(node.DB)
-			txResults = storage.NewTransactionResults(node.DB)
-
+			events = storage.NewEvents(node.Metrics.Cache, node.DB)
+			serviceEvents = storage.NewServiceEvents(node.Metrics.Cache, node.DB)
+			txResults = storage.NewTransactionResults(node.Metrics.Cache, node.DB)
 			ingestionEng, err = ingestion.New(
 				node.Logger,
 				node.Network,

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -102,7 +102,7 @@ func main() {
 			flags.UintVar(&cadenceExecutionCache, "cadence-execution-cache", computation.DefaultProgramsCacheSize, "cache size for Cadence execution")
 			flags.DurationVar(&requestInterval, "request-interval", 60*time.Second, "the interval between requests for the requester engine")
 			flags.StringVar(&preferredExeNodeIDStr, "preferred-exe-node-id", "", "node ID for preferred execution node used for state sync")
-			flags.IntVar(&transactionResultsCacheSize, "transaction-results-cache-size", 10000, "number of transaction results to be cached")
+			flags.UintVar(&transactionResultsCacheSize, "transaction-results-cache-size", 10000, "number of transaction results to be cached")
 			flags.BoolVar(&syncByBlocks, "sync-by-blocks", true, "deprecated, sync by blocks instead of execution state deltas")
 			flags.BoolVar(&syncFast, "sync-fast", false, "fast sync allows execution node to skip fetching collection during state syncing, and rely on state syncing to catch up")
 			flags.IntVar(&syncThreshold, "sync-threshold", 100, "the maximum number of sealed and unexecuted blocks before triggering state syncing")

--- a/cmd/util/cmd/exec-data-json-export/event_exporter.go
+++ b/cmd/util/cmd/exec-data-json-export/event_exporter.go
@@ -33,7 +33,7 @@ func ExportEvents(blockID flow.Identifier, dbPath string, outputPath string) err
 
 	cacheMetrics := &metrics.NoopCollector{}
 	headers := badger.NewHeaders(cacheMetrics, db)
-	events := badger.NewEvents(db)
+	events := badger.NewEvents(cacheMetrics, db)
 	activeBlockID := blockID
 
 	outputFile := filepath.Join(outputPath, "events.jsonl")

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/storage"
+	badgerstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/storage/badger/operation"
 )
 
@@ -352,7 +353,7 @@ func (s *state) PersistExecutionState(ctx context.Context, header *flow.Header, 
 	// as tightly as possible to let Badger manage it.
 	// Note, that it does not guarantee atomicity as transactions has size limit
 	// but it's the closes thing to atomicity we could have
-	batch := s.db.NewWriteBatch()
+	batch := badgerstorage.NewBatch(s.db)
 
 	for _, chunkDataPack := range chunkDataPacks {
 		err := s.chunkDataPacks.BatchStore(chunkDataPack, batch)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -315,7 +315,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 	collectionsStorage := storage.NewCollections(node.DB, transactionsStorage)
 	eventsStorage := storage.NewEvents(node.Metrics, node.DB)
 	serviceEventsStorage := storage.NewServiceEvents(node.Metrics, node.DB)
-	txResultStorage := storage.NewTransactionResults(node.Metrics, node.DB)
+	txResultStorage := storage.NewTransactionResults(node.Metrics, node.DB, 1000)
 	commitsStorage := storage.NewCommits(node.Metrics, node.DB)
 	chunkDataPackStorage := storage.NewChunkDataPacks(node.DB)
 	results := storage.NewExecutionResults(node.Metrics, node.DB)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -313,9 +313,9 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 
 	transactionsStorage := storage.NewTransactions(node.Metrics, node.DB)
 	collectionsStorage := storage.NewCollections(node.DB, transactionsStorage)
-	eventsStorage := storage.NewEvents(node.DB)
-	serviceEventsStorage := storage.NewServiceEvents(node.DB)
-	txResultStorage := storage.NewTransactionResults(node.DB)
+	eventsStorage := storage.NewEvents(node.Metrics, node.DB)
+	serviceEventsStorage := storage.NewServiceEvents(node.Metrics, node.DB)
+	txResultStorage := storage.NewTransactionResults(node.Metrics, node.DB)
 	commitsStorage := storage.NewCommits(node.Metrics, node.DB)
 	chunkDataPackStorage := storage.NewChunkDataPacks(node.DB)
 	results := storage.NewExecutionResults(node.Metrics, node.DB)

--- a/storage/badger/all.go
+++ b/storage/badger/all.go
@@ -23,9 +23,9 @@ func InitAll(metrics module.CacheMetrics, db *badger.DB) *storage.All {
 	chunkDataPacks := NewChunkDataPacks(db)
 	commits := NewCommits(metrics, db)
 	transactions := NewTransactions(metrics, db)
-	transactionResults := NewTransactionResults(db)
+	transactionResults := NewTransactionResults(metrics, db)
 	collections := NewCollections(db, transactions)
-	events := NewEvents(db)
+	events := NewEvents(metrics, db)
 
 	return &storage.All{
 		Headers:            headers,

--- a/storage/badger/all.go
+++ b/storage/badger/all.go
@@ -23,7 +23,7 @@ func InitAll(metrics module.CacheMetrics, db *badger.DB) *storage.All {
 	chunkDataPacks := NewChunkDataPacks(db)
 	commits := NewCommits(metrics, db)
 	transactions := NewTransactions(metrics, db)
-	transactionResults := NewTransactionResults(metrics, db)
+	transactionResults := NewTransactionResults(metrics, db, 10000)
 	collections := NewCollections(db, transactions)
 	events := NewEvents(metrics, db)
 

--- a/storage/badger/batch.go
+++ b/storage/badger/batch.go
@@ -1,6 +1,8 @@
 package badger
 
-import "github.com/dgraph-io/badger/v2"
+import (
+	"github.com/dgraph-io/badger/v2"
+)
 
 type Batch struct {
 	writer    *badger.WriteBatch

--- a/storage/badger/batch.go
+++ b/storage/badger/batch.go
@@ -21,10 +21,17 @@ func (b *Batch) GetWriter() *badger.WriteBatch {
 	return b.writer
 }
 
+// OnSucceed adds a callback to execute after the batch has
+// been successfully flushed.
+// useful for implementing the cache where we will only cache
+// after the batch has been successfully flushed
 func (b *Batch) OnSucceed(callback func()) {
 	b.callbacks = append(b.callbacks, callback)
 }
 
+// Flush will call the badger Batch's Flush method, in
+// addition, it will call the callbacks added by
+// OnSucceed
 func (b *Batch) Flush() error {
 	err := b.writer.Flush()
 	if err != nil {

--- a/storage/badger/batch.go
+++ b/storage/badger/batch.go
@@ -1,0 +1,36 @@
+package badger
+
+import "github.com/dgraph-io/badger/v2"
+
+type Batch struct {
+	writer    *badger.WriteBatch
+	callbacks []func()
+}
+
+func NewBatch(db *badger.DB) *Batch {
+	batch := db.NewWriteBatch()
+	return &Batch{
+		writer:    batch,
+		callbacks: make([]func(), 0),
+	}
+}
+
+func (b *Batch) GetWriter() *badger.WriteBatch {
+	return b.writer
+}
+
+func (b *Batch) OnSucceed(callback func()) {
+	b.callbacks = append(b.callbacks, callback)
+}
+
+func (b *Batch) Flush() error {
+	err := b.writer.Flush()
+	if err != nil {
+		return err
+	}
+
+	for _, callback := range b.callbacks {
+		callback()
+	}
+	return nil
+}

--- a/storage/badger/cache.go
+++ b/storage/badger/cache.go
@@ -30,6 +30,12 @@ func noStore(key interface{}, val interface{}) func(*badger.Txn) error {
 	}
 }
 
+func noopStore(key interface{}, val interface{}) func(*badger.Txn) error {
+	return func(tx *badger.Txn) error {
+		return nil
+	}
+}
+
 type retrieveFunc func(key interface{}) func(*badger.Txn) (interface{}, error)
 
 func withRetrieve(retrieve retrieveFunc) func(*Cache) {

--- a/storage/badger/chunkDataPacks.go
+++ b/storage/badger/chunkDataPacks.go
@@ -38,10 +38,8 @@ func (ch *ChunkDataPacks) Remove(chunkID flow.Identifier) error {
 }
 
 func (ch *ChunkDataPacks) BatchStore(c *flow.ChunkDataPack, batch storage.BatchStorage) error {
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		return operation.BatchInsertChunkDataPack(c)(writeBatch)
-	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
+	writeBatch := batch.GetWriter()
+	return operation.BatchInsertChunkDataPack(c)(writeBatch)
 }
 
 func (ch *ChunkDataPacks) ByChunkID(chunkID flow.Identifier) (*flow.ChunkDataPack, error) {

--- a/storage/badger/cluster_payloads.go
+++ b/storage/badger/cluster_payloads.go
@@ -30,7 +30,7 @@ func NewClusterPayloads(cacheMetrics module.CacheMetrics, db *badger.DB) *Cluste
 		blockID := key.(flow.Identifier)
 		var payload cluster.Payload
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(procedure.RetrieveClusterPayload(blockID, &payload))
+			err := procedure.RetrieveClusterPayload(blockID, &payload)(tx)
 			return &payload, err
 		}
 	}

--- a/storage/badger/commits.go
+++ b/storage/badger/commits.go
@@ -27,7 +27,7 @@ func NewCommits(collector module.CacheMetrics, db *badger.DB) *Commits {
 		blockID := key.(flow.Identifier)
 		var commit flow.StateCommitment
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(operation.LookupStateCommitment(blockID, &commit))
+			err := operation.LookupStateCommitment(blockID, &commit)(tx)
 			return commit, err
 		}
 	}

--- a/storage/badger/commits.go
+++ b/storage/badger/commits.go
@@ -1,8 +1,6 @@
 package badger
 
 import (
-	"fmt"
-
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -68,10 +66,8 @@ func (c *Commits) Store(blockID flow.Identifier, commit flow.StateCommitment) er
 func (c *Commits) BatchStore(blockID flow.Identifier, commit flow.StateCommitment, batch storage.BatchStorage) error {
 	// we can't cache while using batches, as it's unknown at this point when, and if
 	// the batch will be committed. Cache will be populated on read however.
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		return operation.BatchIndexStateCommitment(blockID, commit)(writeBatch)
-	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
+	writeBatch := batch.GetWriter()
+	return operation.BatchIndexStateCommitment(blockID, commit)(writeBatch)
 }
 
 func (c *Commits) ByBlockID(blockID flow.Identifier) (flow.StateCommitment, error) {

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -6,100 +6,139 @@ import (
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
 )
 
 type Events struct {
-	db *badger.DB
+	db    *badger.DB
+	cache *Cache
 }
 
-func NewEvents(db *badger.DB) *Events {
+func NewEvents(collector module.CacheMetrics, db *badger.DB) *Events {
+	retrieve := func(key interface{}) func(tx *badger.Txn) (interface{}, error) {
+		blockID := key.(flow.Identifier)
+		var events []flow.Event
+		return func(tx *badger.Txn) (interface{}, error) {
+			err := db.View(operation.LookupEventsByBlockID(blockID, &events))
+			return events, handleError(err, flow.Event{})
+		}
+	}
+
 	return &Events{
 		db: db,
+		cache: newCache(collector,
+			withStore(noopStore),
+			withRetrieve(retrieve)),
 	}
 }
 
 func (e *Events) BatchStore(blockID flow.Identifier, events []flow.Event, batch storage.BatchStorage) error {
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		for _, event := range events {
-			err := operation.BatchInsertEvent(blockID, event)(writeBatch)
-			if err != nil {
-				return fmt.Errorf("cannot batch insert event: %w", err)
-			}
+	writeBatch := batch.GetWriter()
+	for _, event := range events {
+		err := operation.BatchInsertEvent(blockID, event)(writeBatch)
+		if err != nil {
+			return fmt.Errorf("cannot batch insert event: %w", err)
 		}
-		return nil
 	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
+	return nil
+
+	callback := func() {
+		e.cache.Put(blockID, events)
+	}
+	batch.OnSucceed(callback)
+	return nil
 }
 
 // ByBlockID returns the events for the given block ID
 func (e *Events) ByBlockID(blockID flow.Identifier) ([]flow.Event, error) {
-
-	var events []flow.Event
-	err := e.db.View(operation.LookupEventsByBlockID(blockID, &events))
+	tx := e.db.NewTransaction(false)
+	defer tx.Discard()
+	val, err := e.cache.Get(blockID)(tx)
 	if err != nil {
-		return nil, handleError(err, flow.Event{})
+		return nil, err
 	}
-
-	return events, nil
+	return val.([]flow.Event), nil
 }
 
 // ByBlockIDTransactionID returns the events for the given block ID and transaction ID
 func (e *Events) ByBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) ([]flow.Event, error) {
-
-	var events []flow.Event
-	err := e.db.View(operation.RetrieveEvents(blockID, txID, &events))
+	events, err := e.ByBlockID(blockID)
 	if err != nil {
 		return nil, handleError(err, flow.Event{})
 	}
 
-	return events, nil
+	matched := make([]flow.Event, 0, len(events))
+	for _, event := range events {
+		if event.TransactionID == txID {
+			matched = append(matched, event)
+		}
+	}
+	return matched, nil
 }
 
 // ByBlockIDEventType returns the events for the given block ID and event type
-func (e *Events) ByBlockIDEventType(blockID flow.Identifier, event flow.EventType) ([]flow.Event, error) {
-
-	var events []flow.Event
-	err := e.db.View(operation.LookupEventsByBlockIDEventType(blockID, event, &events))
+func (e *Events) ByBlockIDEventType(blockID flow.Identifier, eventType flow.EventType) ([]flow.Event, error) {
+	events, err := e.ByBlockID(blockID)
 	if err != nil {
 		return nil, handleError(err, flow.Event{})
 	}
 
-	return events, nil
+	matched := make([]flow.Event, 0, len(events))
+	for _, event := range events {
+		if event.Type == eventType {
+			matched = append(matched, event)
+		}
+	}
+	return matched, nil
 }
 
 type ServiceEvents struct {
-	db *badger.DB
+	db    *badger.DB
+	cache *Cache
 }
 
-func NewServiceEvents(db *badger.DB) *ServiceEvents {
+func NewServiceEvents(collector module.CacheMetrics, db *badger.DB) *ServiceEvents {
+	retrieve := func(key interface{}) func(tx *badger.Txn) (interface{}, error) {
+		blockID := key.(flow.Identifier)
+		var events []flow.Event
+		return func(tx *badger.Txn) (interface{}, error) {
+			err := db.View(operation.LookupServiceEventsByBlockID(blockID, &events))
+			return events, handleError(err, flow.Event{})
+		}
+	}
+
 	return &ServiceEvents{
 		db: db,
+		cache: newCache(collector,
+			withStore(noopStore),
+			withRetrieve(retrieve)),
 	}
 }
 
 func (e *ServiceEvents) BatchStore(blockID flow.Identifier, events []flow.Event, batch storage.BatchStorage) error {
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		for _, event := range events {
-			err := operation.BatchInsertServiceEvent(blockID, event)(writeBatch)
-			if err != nil {
-				return fmt.Errorf("cannot batch insert service event: %w", err)
-			}
+	writeBatch := batch.GetWriter()
+	for _, event := range events {
+		err := operation.BatchInsertServiceEvent(blockID, event)(writeBatch)
+		if err != nil {
+			return fmt.Errorf("cannot batch insert service event: %w", err)
 		}
-		return nil
 	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
+	callback := func() {
+		e.cache.Put(blockID, events)
+	}
+	batch.OnSucceed(callback)
+	return nil
 }
 
 // ByBlockID returns the events for the given block ID
 func (e *ServiceEvents) ByBlockID(blockID flow.Identifier) ([]flow.Event, error) {
-
-	var events []flow.Event
-	err := e.db.View(operation.LookupServiceEventsByBlockID(blockID, &events))
+	tx := e.db.NewTransaction(false)
+	defer tx.Discard()
+	val, err := e.cache.Get(blockID)(tx)
 	if err != nil {
-		return nil, handleError(err, flow.Event{})
+		return nil, err
 	}
-
-	return events, nil
+	return val.([]flow.Event), nil
 }

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -68,7 +68,7 @@ func (e *Events) ByBlockIDTransactionID(blockID flow.Identifier, txID flow.Ident
 		return nil, handleError(err, flow.Event{})
 	}
 
-	matched := make([]flow.Event, 0, len(events))
+	var matched []flow.Event
 	for _, event := range events {
 		if event.TransactionID == txID {
 			matched = append(matched, event)
@@ -84,7 +84,7 @@ func (e *Events) ByBlockIDEventType(blockID flow.Identifier, eventType flow.Even
 		return nil, handleError(err, flow.Event{})
 	}
 
-	matched := make([]flow.Event, 0, len(events))
+	var matched []flow.Event
 	for _, event := range events {
 		if event.Type == eventType {
 			matched = append(matched, event)

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -21,7 +21,7 @@ func NewEvents(collector module.CacheMetrics, db *badger.DB) *Events {
 		blockID := key.(flow.Identifier)
 		var events []flow.Event
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(operation.LookupEventsByBlockID(blockID, &events))
+			err := operation.LookupEventsByBlockID(blockID, &events)(tx)
 			return events, handleError(err, flow.Event{})
 		}
 	}
@@ -103,7 +103,7 @@ func NewServiceEvents(collector module.CacheMetrics, db *badger.DB) *ServiceEven
 		blockID := key.(flow.Identifier)
 		var events []flow.Event
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(operation.LookupServiceEventsByBlockID(blockID, &events))
+			err := operation.LookupServiceEventsByBlockID(blockID, &events)(tx)
 			return events, handleError(err, flow.Event{})
 		}
 	}

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -42,7 +42,6 @@ func (e *Events) BatchStore(blockID flow.Identifier, events []flow.Event, batch 
 			return fmt.Errorf("cannot batch insert event: %w", err)
 		}
 	}
-	return nil
 
 	callback := func() {
 		e.cache.Put(blockID, events)

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -20,19 +20,6 @@ func NewEvents(db *badger.DB) *Events {
 	}
 }
 
-// Store will store events for the given block ID
-func (e *Events) Store(blockID flow.Identifier, events []flow.Event) error {
-	return operation.RetryOnConflict(e.db.Update, func(btx *badger.Txn) error {
-		for _, event := range events {
-			err := operation.SkipDuplicates(operation.InsertEvent(blockID, event))(btx)
-			if err != nil {
-				return fmt.Errorf("could not insert event: %w", err)
-			}
-		}
-		return nil
-	})
-}
-
 func (e *Events) BatchStore(blockID flow.Identifier, events []flow.Event, batch storage.BatchStorage) error {
 	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
 		for _, event := range events {
@@ -90,19 +77,6 @@ func NewServiceEvents(db *badger.DB) *ServiceEvents {
 	return &ServiceEvents{
 		db: db,
 	}
-}
-
-// Store will store events for the given block ID
-func (e *ServiceEvents) Store(blockID flow.Identifier, events []flow.Event) error {
-	return operation.RetryOnConflict(e.db.Update, func(btx *badger.Txn) error {
-		for _, event := range events {
-			err := operation.SkipDuplicates(operation.InsertServiceEvent(blockID, event))(btx)
-			if err != nil {
-				return fmt.Errorf("could not insert event: %w", err)
-			}
-		}
-		return nil
-	})
 }
 
 func (e *ServiceEvents) BatchStore(blockID flow.Identifier, events []flow.Event, batch storage.BatchStorage) error {

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -124,6 +124,7 @@ func (e *ServiceEvents) BatchStore(blockID flow.Identifier, events []flow.Event,
 			return fmt.Errorf("cannot batch insert service event: %w", err)
 		}
 	}
+
 	callback := func() {
 		e.cache.Put(blockID, events)
 	}

--- a/storage/badger/events_test.go
+++ b/storage/badger/events_test.go
@@ -67,6 +67,16 @@ func TestEventStoreRetrieve(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, actual, 1)
 		require.Contains(t, actual, evt1)
+
+		// test loading from database
+
+		newStore := badgerstorage.NewEvents(metrics, db)
+		actual, err = newStore.ByBlockID(blockID)
+		require.NoError(t, err)
+		require.Len(t, actual, 3)
+		require.Contains(t, actual, evt1)
+		require.Contains(t, actual, evt2)
+		require.Contains(t, actual, evt3)
 	})
 }
 

--- a/storage/badger/events_test.go
+++ b/storage/badger/events_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/utils/unittest"
 
 	badgerstorage "github.com/onflow/flow-go/storage/badger"
@@ -14,7 +15,8 @@ import (
 
 func TestEventStoreRetrieve(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		store := badgerstorage.NewEvents(db)
+		metrics := metrics.NewNoopCollector()
+		store := badgerstorage.NewEvents(metrics, db)
 
 		blockID := unittest.IdentifierFixture()
 		tx1ID := unittest.IdentifierFixture()
@@ -28,7 +30,7 @@ func TestEventStoreRetrieve(t *testing.T) {
 			evt3,
 		}
 
-		batch := db.NewWriteBatch()
+		batch := badgerstorage.NewBatch(db)
 		// store event
 		err := store.BatchStore(blockID, expected, batch)
 		require.NoError(t, err)
@@ -70,7 +72,8 @@ func TestEventStoreRetrieve(t *testing.T) {
 
 func TestEventRetrieveWithoutStore(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		store := badgerstorage.NewEvents(db)
+		metrics := metrics.NewNoopCollector()
+		store := badgerstorage.NewEvents(metrics, db)
 
 		blockID := unittest.IdentifierFixture()
 		txID := unittest.IdentifierFixture()

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -49,7 +49,7 @@ func NewHeaders(collector module.CacheMetrics, db *badger.DB) *Headers {
 		blockID := key.(flow.Identifier)
 		var header flow.Header
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(operation.RetrieveHeader(blockID, &header))
+			err := operation.RetrieveHeader(blockID, &header)(tx)
 			return &header, err
 		}
 	}
@@ -58,7 +58,7 @@ func NewHeaders(collector module.CacheMetrics, db *badger.DB) *Headers {
 		height := key.(uint64)
 		var id flow.Identifier
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(operation.LookupBlockHeight(height, &id))
+			err := operation.LookupBlockHeight(height, &id)(tx)
 			return id, err
 		}
 	}
@@ -67,7 +67,7 @@ func NewHeaders(collector module.CacheMetrics, db *badger.DB) *Headers {
 		chunkID := key.(flow.Identifier)
 		var blockID flow.Identifier
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(operation.LookupBlockIDByChunkID(chunkID, &blockID))
+			err := operation.LookupBlockIDByChunkID(chunkID, &blockID)(tx)
 			return blockID, err
 		}
 	}

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -169,8 +169,6 @@ func (h *Headers) IndexByChunkID(headerID, chunkID flow.Identifier) error {
 }
 
 func (h *Headers) BatchIndexByChunkID(headerID, chunkID flow.Identifier, batch storage.BatchStorage) error {
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		return operation.BatchIndexBlockByChunkID(headerID, chunkID)(writeBatch)
-	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
+	writeBatch := batch.GetWriter()
+	return operation.BatchIndexBlockByChunkID(headerID, chunkID)(writeBatch)
 }

--- a/storage/badger/operation/max.go
+++ b/storage/badger/operation/max.go
@@ -42,7 +42,7 @@ func InitMax(tx *badger.Txn) error {
 }
 
 // SetMax sets the value for the maximum key length used for efficient iteration.
-func SetMax(tx storage.BatchStorage) error {
+func SetMax(tx storage.Transaction) error {
 	key := makePrefix(codeMax)
 	val := make([]byte, 4)
 	binary.LittleEndian.PutUint32(val, max)

--- a/storage/badger/results.go
+++ b/storage/badger/results.go
@@ -105,18 +105,13 @@ func (r *ExecutionResults) Store(result *flow.ExecutionResult) error {
 }
 
 func (r *ExecutionResults) BatchStore(result *flow.ExecutionResult, batch storage.BatchStorage) error {
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		return operation.BatchInsertExecutionResult(result)(writeBatch)
-	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
+	writeBatch := batch.GetWriter()
+	return operation.BatchInsertExecutionResult(result)(writeBatch)
 }
 
 func (r *ExecutionResults) BatchIndex(blockID flow.Identifier, resultID flow.Identifier, batch storage.BatchStorage) error {
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		return operation.BatchIndexExecutionResult(blockID, resultID)(writeBatch)
-	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
-
+	writeBatch := batch.GetWriter()
+	return operation.BatchIndexExecutionResult(blockID, resultID)(writeBatch)
 }
 
 func (r *ExecutionResults) ByID(resultID flow.Identifier) (*flow.ExecutionResult, error) {

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -20,15 +20,6 @@ func NewTransactionResults(db *badger.DB) *TransactionResults {
 	}
 }
 
-// Store will store the transaction result for the given block ID
-func (tr *TransactionResults) Store(blockID flow.Identifier, transactionResult *flow.TransactionResult) error {
-	err := operation.RetryOnConflict(tr.db.Update, operation.SkipDuplicates(operation.InsertTransactionResult(blockID, transactionResult)))
-	if err != nil {
-		return fmt.Errorf("could not insert transaction result: %w", err)
-	}
-	return nil
-}
-
 // BatchStore will store the transaction results for the given block ID in a batch
 func (tr *TransactionResults) BatchStore(blockID flow.Identifier, transactionResults []flow.TransactionResult, batch storage.BatchStorage) error {
 

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -6,43 +6,99 @@ import (
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
 )
 
 type TransactionResults struct {
-	db *badger.DB
+	db    *badger.DB
+	cache *Cache
 }
 
-func NewTransactionResults(db *badger.DB) *TransactionResults {
+type BlockIDTransactionID struct {
+	BlockID       flow.Identifier
+	TransactionID flow.Identifier
+}
+
+func keyFromBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) string {
+	return fmt.Sprintf("%x%x", blockID, txID)
+}
+
+func keyToBlockIDTransactionID(key string) (flow.Identifier, flow.Identifier, error) {
+	blockIDStr := key[:32]
+	txIDStr := key[32:]
+	blockID, err := flow.HexStringToIdentifier(blockIDStr)
+	if err != nil {
+		return flow.ZeroID, flow.ZeroID, fmt.Errorf("could not get block ID: %w", err)
+	}
+
+	txID, err := flow.HexStringToIdentifier(txIDStr)
+	if err != nil {
+		return flow.ZeroID, flow.ZeroID, fmt.Errorf("could not get transaction id: %w", err)
+	}
+
+	return blockID, txID, nil
+}
+
+func NewTransactionResults(collector module.CacheMetrics, db *badger.DB) *TransactionResults {
+	retrieve := func(key interface{}) func(tx *badger.Txn) (interface{}, error) {
+		var txResult flow.TransactionResult
+		return func(tx *badger.Txn) (interface{}, error) {
+
+			blockID, txID, err := keyToBlockIDTransactionID(key.(string))
+			if err != nil {
+				return nil, fmt.Errorf("could not convert key: %w", err)
+			}
+
+			err = db.View(operation.RetrieveTransactionResult(blockID, txID, &txResult))
+			if err != nil {
+				return nil, handleError(err, flow.TransactionResult{})
+			}
+			return txResult, nil
+		}
+	}
 	return &TransactionResults{
 		db: db,
+		cache: newCache(collector,
+			withLimit(10000),
+			withStore(noopStore),
+			withRetrieve(retrieve)),
 	}
 }
 
 // BatchStore will store the transaction results for the given block ID in a batch
 func (tr *TransactionResults) BatchStore(blockID flow.Identifier, transactionResults []flow.TransactionResult, batch storage.BatchStorage) error {
+	writeBatch := batch.GetWriter()
 
-	if writeBatch, ok := batch.(*badger.WriteBatch); ok {
-		for _, result := range transactionResults {
-			err := operation.BatchInsertTransactionResult(blockID, &result)(writeBatch)
-			if err != nil {
-				return fmt.Errorf("cannot batch insert tx result: %w", err)
-			}
+	for _, result := range transactionResults {
+		err := operation.BatchInsertTransactionResult(blockID, &result)(writeBatch)
+		if err != nil {
+			return fmt.Errorf("cannot batch insert tx result: %w", err)
 		}
-		return nil
 	}
-	return fmt.Errorf("unsupported BatchStore type %T", batch)
+
+	batch.OnSucceed(func() {
+		for _, result := range transactionResults {
+			key := keyFromBlockIDTransactionID(blockID, result.TransactionID)
+			// cache for each transaction, so that it's faster to retrieve
+			tr.cache.Put(key, result)
+		}
+	})
+	return nil
 }
 
 // ByBlockIDTransactionID returns the runtime transaction result for the given block ID and transaction ID
 func (tr *TransactionResults) ByBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) (*flow.TransactionResult, error) {
-
-	var txResult flow.TransactionResult
-	err := tr.db.View(operation.RetrieveTransactionResult(blockID, txID, &txResult))
+	tx := tr.db.NewTransaction(false)
+	defer tx.Discard()
+	val, err := tr.cache.Get(blockID)(tx)
 	if err != nil {
-		return nil, handleError(err, flow.TransactionResult{})
+		return nil, err
 	}
-
-	return &txResult, nil
+	transactionResult, ok := val.(flow.TransactionResult)
+	if !ok {
+		return nil, fmt.Errorf("could not convert transaction result: %w", err)
+	}
+	return &transactionResult, nil
 }

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -51,7 +51,7 @@ func NewTransactionResults(collector module.CacheMetrics, db *badger.DB) *Transa
 				return nil, fmt.Errorf("could not convert key: %w", err)
 			}
 
-			err = db.View(operation.RetrieveTransactionResult(blockID, txID, &txResult))
+			err = operation.RetrieveTransactionResult(blockID, txID, &txResult)(tx)
 			if err != nil {
 				return nil, handleError(err, flow.TransactionResult{})
 			}

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -16,11 +16,6 @@ type TransactionResults struct {
 	cache *Cache
 }
 
-type BlockIDTransactionID struct {
-	BlockID       flow.Identifier
-	TransactionID flow.Identifier
-}
-
 func KeyFromBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) string {
 	return fmt.Sprintf("%x%x", blockID, txID)
 }

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -41,7 +41,7 @@ func KeyToBlockIDTransactionID(key string) (flow.Identifier, flow.Identifier, er
 	return blockID, txID, nil
 }
 
-func NewTransactionResults(collector module.CacheMetrics, db *badger.DB) *TransactionResults {
+func NewTransactionResults(collector module.CacheMetrics, db *badger.DB, transactionResultsCacheSize uint) *TransactionResults {
 	retrieve := func(key interface{}) func(tx *badger.Txn) (interface{}, error) {
 		var txResult flow.TransactionResult
 		return func(tx *badger.Txn) (interface{}, error) {
@@ -61,7 +61,7 @@ func NewTransactionResults(collector module.CacheMetrics, db *badger.DB) *Transa
 	return &TransactionResults{
 		db: db,
 		cache: newCache(collector,
-			withLimit(10000),
+			withLimit(transactionResultsCacheSize),
 			withStore(noopStore),
 			withRetrieve(retrieve)),
 	}

--- a/storage/badger/transaction_results_test.go
+++ b/storage/badger/transaction_results_test.go
@@ -59,3 +59,13 @@ func TestReadingNotStoreTransaction(t *testing.T) {
 		assert.True(t, errors.Is(err, storage.ErrNotFound))
 	})
 }
+
+func TestKeyConversion(t *testing.T) {
+	blockID := unittest.IdentifierFixture()
+	txID := unittest.IdentifierFixture()
+	key := bstorage.KeyFromBlockIDTransactionID(blockID, txID)
+	bID, tID, err := bstorage.KeyToBlockIDTransactionID(key)
+	require.NoError(t, err)
+	require.Equal(t, blockID, bID)
+	require.Equal(t, txID, tID)
+}

--- a/storage/badger/transaction_results_test.go
+++ b/storage/badger/transaction_results_test.go
@@ -16,32 +16,6 @@ import (
 	bstorage "github.com/onflow/flow-go/storage/badger"
 )
 
-func TestStoringTransactionResults(t *testing.T) {
-	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		store := bstorage.NewTransactionResults(db)
-
-		blockID := unittest.IdentifierFixture()
-		txResults := make([]*flow.TransactionResult, 0)
-		for i := 0; i < 10; i++ {
-			txID := unittest.IdentifierFixture()
-			expected := &flow.TransactionResult{
-				TransactionID: txID,
-				ErrorMessage:  fmt.Sprintf("a runtime error %d", i),
-			}
-			txResults = append(txResults, expected)
-		}
-		for _, txResult := range txResults {
-			err := store.Store(blockID, txResult)
-			require.Nil(t, err)
-		}
-		for _, txResult := range txResults {
-			actual, err := store.ByBlockIDTransactionID(blockID, txResult.TransactionID)
-			require.Nil(t, err)
-			assert.Equal(t, txResult, actual)
-		}
-	})
-}
-
 func TestBatchStoringTransactionResults(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		store := bstorage.NewTransactionResults(db)

--- a/storage/badger/transaction_results_test.go
+++ b/storage/badger/transaction_results_test.go
@@ -44,6 +44,14 @@ func TestBatchStoringTransactionResults(t *testing.T) {
 			require.Nil(t, err)
 			assert.Equal(t, txResult, *actual)
 		}
+
+		// test loading from database
+		newStore := bstorage.NewTransactionResults(metrics, db)
+		for _, txResult := range txResults {
+			actual, err := newStore.ByBlockIDTransactionID(blockID, txResult.TransactionID)
+			require.Nil(t, err)
+			assert.Equal(t, txResult, *actual)
+		}
 	})
 }
 

--- a/storage/badger/transaction_results_test.go
+++ b/storage/badger/transaction_results_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/utils/unittest"
 
@@ -18,7 +19,8 @@ import (
 
 func TestBatchStoringTransactionResults(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		store := bstorage.NewTransactionResults(db)
+		metrics := metrics.NewNoopCollector()
+		store := bstorage.NewTransactionResults(metrics, db)
 
 		blockID := unittest.IdentifierFixture()
 		txResults := make([]flow.TransactionResult, 0)
@@ -30,7 +32,7 @@ func TestBatchStoringTransactionResults(t *testing.T) {
 			}
 			txResults = append(txResults, expected)
 		}
-		writeBatch := db.NewWriteBatch()
+		writeBatch := bstorage.NewBatch(db)
 		err := store.BatchStore(blockID, txResults, writeBatch)
 		require.NoError(t, err)
 
@@ -47,7 +49,8 @@ func TestBatchStoringTransactionResults(t *testing.T) {
 
 func TestReadingNotStoreTransaction(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		store := bstorage.NewTransactionResults(db)
+		metrics := metrics.NewNoopCollector()
+		store := bstorage.NewTransactionResults(metrics, db)
 
 		blockID := unittest.IdentifierFixture()
 		txID := unittest.IdentifierFixture()

--- a/storage/badger/transaction_results_test.go
+++ b/storage/badger/transaction_results_test.go
@@ -20,7 +20,7 @@ import (
 func TestBatchStoringTransactionResults(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		metrics := metrics.NewNoopCollector()
-		store := bstorage.NewTransactionResults(metrics, db)
+		store := bstorage.NewTransactionResults(metrics, db, 1000)
 
 		blockID := unittest.IdentifierFixture()
 		txResults := make([]flow.TransactionResult, 0)
@@ -46,7 +46,7 @@ func TestBatchStoringTransactionResults(t *testing.T) {
 		}
 
 		// test loading from database
-		newStore := bstorage.NewTransactionResults(metrics, db)
+		newStore := bstorage.NewTransactionResults(metrics, db, 1000)
 		for _, txResult := range txResults {
 			actual, err := newStore.ByBlockIDTransactionID(blockID, txResult.TransactionID)
 			require.Nil(t, err)
@@ -58,7 +58,7 @@ func TestBatchStoringTransactionResults(t *testing.T) {
 func TestReadingNotStoreTransaction(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		metrics := metrics.NewNoopCollector()
-		store := bstorage.NewTransactionResults(metrics, db)
+		store := bstorage.NewTransactionResults(metrics, db, 1000)
 
 		blockID := unittest.IdentifierFixture()
 		txID := unittest.IdentifierFixture()

--- a/storage/badger/transactions.go
+++ b/storage/badger/transactions.go
@@ -27,7 +27,7 @@ func NewTransactions(cacheMetrics module.CacheMetrics, db *badger.DB) *Transacti
 		txID := key.(flow.Identifier)
 		var flowTx flow.TransactionBody
 		return func(tx *badger.Txn) (interface{}, error) {
-			err := db.View(operation.RetrieveTransaction(txID, &flowTx))
+			err := operation.RetrieveTransaction(txID, &flowTx)(tx)
 			return &flowTx, err
 		}
 	}

--- a/storage/batch.go
+++ b/storage/batch.go
@@ -12,12 +12,10 @@ type BatchStorage interface {
 
 	// OnSucceed adds a callback to execute after the batch has
 	// been successfully flushed.
-	// useful for implement the cache where we will only cache
-	// after the batch has been succesfully flushed
+	// useful for implementing the cache where we will only cache
+	// after the batch has been successfully flushed
 	OnSucceed(callback func())
 
-	// Flush will call the badger Batch's Flush method, in
-	// addition, it will call the callbacks added by
-	// OnSucceed
+	// Flush will flush the write batch and update the cache.
 	Flush() error
 }

--- a/storage/batch.go
+++ b/storage/batch.go
@@ -1,6 +1,23 @@
 package storage
 
+import "github.com/dgraph-io/badger/v2"
+
+type Transaction interface {
+	Set(key, val []byte) error
+}
+
 // BatchStorage
 type BatchStorage interface {
-	Set(key, val []byte) error
+	GetWriter() *badger.WriteBatch
+
+	// OnSucceed adds a callback to execute after the batch has
+	// been successfully flushed.
+	// useful for implement the cache where we will only cache
+	// after the batch has been succesfully flushed
+	OnSucceed(callback func())
+
+	// Flush will call the badger Batch's Flush method, in
+	// addition, it will call the callbacks added by
+	// OnSucceed
+	Flush() error
 }

--- a/storage/events.go
+++ b/storage/events.go
@@ -5,9 +5,6 @@ import "github.com/onflow/flow-go/model/flow"
 // Events represents persistent storage for events.
 type Events interface {
 
-	// Store will store events for the given block ID
-	Store(blockID flow.Identifier, events []flow.Event) error
-
 	// BatchStore will store events for the given block ID in a given batch
 	BatchStore(blockID flow.Identifier, events []flow.Event, batch BatchStorage) error
 
@@ -22,9 +19,6 @@ type Events interface {
 }
 
 type ServiceEvents interface {
-	// Store will store events marked as service events for the given block ID
-	Store(blockID flow.Identifier, events []flow.Event) error
-
 	// BatchStore will store service events for the given block ID in a given batch
 	BatchStore(blockID flow.Identifier, events []flow.Event, batch BatchStorage) error
 

--- a/storage/transaction_results.go
+++ b/storage/transaction_results.go
@@ -5,9 +5,6 @@ import "github.com/onflow/flow-go/model/flow"
 // TransactionResults represents persistent storage for transaction result
 type TransactionResults interface {
 
-	// Store inserts the transaction result
-	Store(blockID flow.Identifier, transactionResult *flow.TransactionResult) error
-
 	// BatchStore inserts a batch of transaction result into a batch
 	BatchStore(blockID flow.Identifier, transactionResults []flow.TransactionResult, batch BatchStorage) error
 


### PR DESCRIPTION
This PR caches the transaction results, events for the blocks with a LRU cache.

Also fixed an issue that the badger events instance was used before initialized, wasn't an issue before because it was stateless. Now with caching it's stateful.

Address https://github.com/dapperlabs/flow-go/issues/5370