### PR TITLE
suggestions for updating the receipt validator

### DIFF
--- a/module/validation/receipt_validator.go
+++ b/module/validation/receipt_validator.go
@@ -139,7 +139,7 @@ func (v *receiptValidator) resultChainCheck(result *flow.ExecutionResult, prevRe
 	return nil
 }
 
-// Validate performs verifies that the ExecutionReceipt satisfies
+// Validate verifies that the ExecutionReceipt satisfies
 // the following conditions:
 // 	* is from Execution node with positive weight
 //	* has valid signature
@@ -148,13 +148,13 @@ func (v *receiptValidator) resultChainCheck(result *flow.ExecutionResult, prevRe
 // Returns nil if all checks passed successfully.
 // Expected errors during normal operations:
 // * engine.InvalidInputError
-// * validation.UnverifiableError
+// * engine.UnverifiableInputError
 func (v *receiptValidator) Validate(receipt *flow.ExecutionReceipt) error {
 	// TODO: this can be optimized by checking if result was already stored and validated.
 	// This needs to be addressed later since many tests depend on this behavior.
 	prevResult, err := v.fetchResult(receipt.ExecutionResult.PreviousResultID)
 	if err != nil {
-		return err
+		return fmt.Errorf("error fetching parent result of receipt %v: %w", receipt.ID(), err)
 	}
 
 	// first validate result to avoid signature check in in `validateReceipt` in case result is invalid.
@@ -173,134 +173,142 @@ func (v *receiptValidator) Validate(receipt *flow.ExecutionReceipt) error {
 	return nil
 }
 
+// ValidatePayload verifies the ExecutionReceipts and ExecutionResults
+// in the payload for compliance with the protocol:
+// Receipts:
+// 	* are from Execution node with positive weight
+//	* have valid signature
+//	* chunks are in correct format
+//  * no duplicates in fork
+// Results:
+// 	* have valid parents and satisfy the subgraph check
+//  * extend the execution tree, where the tree root is the latest finalized
+//    block and only results from this fork are included
+//  * no duplicates in fork
+// Expected errors during normal operations:
+// * engine.InvalidInputError
+// * engine.UnverifiableInputError
 func (v *receiptValidator) ValidatePayload(candidate *flow.Block) error {
-	// lookup cache to avoid linear search when checking for previous result that is
-	// part of payload
-	payloadExecutionResults := candidate.Payload.ResultsById()
-	// Build a functor that performs lookup first in receipts that were passed as payload and only then in
-	// local storage. This is needed to handle a case when same block payload contains receipts that
-	// reference each other.
-	// ATTENTION: Here we assume that ER is valid, this lookup can return a result which is actually invalid.
-	// Eventually invalid result will be detected and fail the whole validation.
-	fetchResult := func(previousResultID flow.Identifier) (*flow.ExecutionResult, error) {
-		prevResult, found := payloadExecutionResults[previousResultID]
-		if found {
-			return prevResult, nil
-		}
-
-		return v.fetchResult(previousResultID)
-	}
-
 	header := candidate.Header
 	payload := candidate.Payload
 
-	// Get the latest sealed block on this fork, ie the highest block for which
-	// there is a seal in this fork. This block is not necessarily finalized.
-	last, err := v.seals.ByBlockID(header.ParentID)
+	// Get the latest sealed result on this fork and the corresponding block,
+	// whose result is sealed. This block is not necessarily finalized.
+	lastSeal, err := v.seals.ByBlockID(header.ParentID)
 	if err != nil {
-		return fmt.Errorf("could not retrieve parent seal (%x): %w", header.ParentID, err)
+		return fmt.Errorf("could not retrieve latest seal for fork with head %x: %w", header.ParentID, err)
 	}
-	sealed, err := v.headers.ByBlockID(last.BlockID)
+	latestSealedResult, err := v.results.ByID(lastSeal.ResultID)
 	if err != nil {
-		return fmt.Errorf("could not retrieve sealed block (%x): %w", last.BlockID, err)
+		return fmt.Errorf("could not retrieve latest sealed result %x: %w", lastSeal.ResultID, err)
 	}
-	sealedHeight := sealed.Height
+	sealedBlock, err := v.headers.ByBlockID(lastSeal.BlockID)
+	if err != nil {
+		return fmt.Errorf("could not retrieve sealed block (%x): %w", lastSeal.BlockID, err)
+	}
+	sealedHeight := sealedBlock.Height
 
-	// forkBlocks is used to keep the IDs of the blocks we iterate through. We
+	// forkBlocks is the set of all _unsealed_ blocks on the fork. We
 	// use it to identify receipts that are for blocks not in the fork.
-	forkBlocks := make(map[flow.Identifier]*flow.Header)
+	forkBlocks := make(map[flow.Identifier]struct{})
 
-	// Create a lookup table of all the receipts that are already included in
-	// blocks on the fork.
-	forkLookup := make(map[flow.Identifier]struct{})
+	// Set of the execution tree with root latestSealedResult.
+	// Used for detecting duplicates and results with invalid parent results.
+	executionTree := make(map[flow.Identifier]*flow.ExecutionResult)
+	executionTree[lastSeal.ResultID] = latestSealedResult
 
-	// loop through the fork backwards, from parent to last sealed, and keep
-	// track of blocks and receipts visited on the way.
-	ancestorID := header.ParentID
-	for {
+	// Set of previously included results. Used for detecting duplicates.
+	forkReceipts := make(map[flow.Identifier]struct{})
 
-		ancestor, err := v.headers.ByBlockID(ancestorID)
-		if err != nil {
-			return fmt.Errorf("could not retrieve ancestor header (%x): %w", ancestorID, err)
+	// Start from the lowest unfinalized block and walk the chain upwards until we
+	// hit the candidate's parent. For each visited block track:
+	bookKeeper := func(blockID flow.Identifier, payloadIndex *flow.Index) error {
+		// track encountered blocks
+		forkBlocks[blockID] = struct{}{}
+
+		// track encountered receipts
+		for _, recID := range payloadIndex.ReceiptIDs {
+			forkReceipts[recID] = struct{}{}
 		}
 
-		// break out when we reach the sealed height
-		if ancestor.Height <= sealedHeight {
-			break
-		}
-
-		// keep track of blocks we iterate over
-		forkBlocks[ancestorID] = ancestor
-
-		// keep track of all receipts in ancestors
-		index, err := v.index.ByBlockID(ancestorID)
-		if err != nil {
-			return fmt.Errorf("could not retrieve ancestor index (%x): %w", ancestorID, err)
-		}
-		for _, recID := range index.ReceiptIDs {
-			forkLookup[recID] = struct{}{}
-		}
-
-		ancestorID = ancestor.ParentID
-	}
-
-	// results is used to keep unique execution results that were included into
-	// payload
-	results := make(map[flow.Identifier]*flow.ExecutionResult)
-
-	// check each receipt included in the payload for duplication
-	for _, receipt := range payload.Receipts {
-		result, found := results[receipt.ResultID]
-		// usually we will have many receipts for same result, let's collect results by their
-		// ids for easy lookup.
-		if !found {
-			result, err = fetchResult(receipt.ResultID)
+		// extend execution tree
+		for _, resultID := range payloadIndex.ResultIDs {
+			result, err := v.results.ByID(resultID)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not retrieve result %v: %w", resultID, err)
 			}
-			results[receipt.ResultID] = result
+			if _, ok := executionTree[result.PreviousResultID]; !ok {
+				// We only collect results that directly descend from the last sealed result.
+				// Because Results are listed in an order that satisfies the parent-first
+				// relationship, we can skip all results whose parent are unknown.
+				continue
+			}
+			executionTree[resultID] = result
 		}
-
-		// error if the receipt was already included in an other block on the
-		// fork
-		_, duplicated := forkLookup[receipt.ID()]
-		if duplicated {
-			return engine.NewInvalidInputErrorf("payload includes duplicate receipt (%x)", receipt.ID())
-		}
-		forkLookup[receipt.ID()] = struct{}{}
-
-		// if the receipt is not for a block on this fork, error
-		if _, forBlockOnFork := forkBlocks[result.BlockID]; !forBlockOnFork {
-			return engine.NewInvalidInputErrorf("payload includes receipt for block not on fork (%x)", result.BlockID)
-		}
+		return nil
+	}
+	err = v.forkCrawler(header.ParentID, sealedHeight+1, bookKeeper)
+	if err != nil {
+		return fmt.Errorf("internal error while traversing the ancestor fork of unsealed blocks: %w", err)
 	}
 
 	// first validate all results that were included into payload
 	// if one of results is invalid we fail the whole check because it could be violating
 	// parent-children relationship
-	for i, result := range candidate.Payload.Results {
-		prevResult, err := fetchResult(result.PreviousResultID)
-		if err != nil {
-			return err
+	for i, result := range payload.Results {
+		resultID := result.ID()
+
+		// check for duplicated results
+		if _, isDuplicate := executionTree[resultID]; isDuplicate {
+			return engine.NewInvalidInputErrorf("duplicate result %v at index %d", resultID, i)
 		}
 
+		// any result must extend the execution tree with root latestSealedResult
+		prevResult, extendsTree := executionTree[result.PreviousResultID]
+		if !extendsTree {
+			return engine.NewInvalidInputErrorf("results %v at index %d does not extend execution tree", resultID, i)
+		}
+
+		// result must be for block on fork
+		if _, forBlockOnFork := forkBlocks[result.BlockID]; !forBlockOnFork {
+			return engine.NewInvalidInputErrorf("results %v at index %d is for block not on fork (%x)", resultID, i, result.BlockID)
+		}
+
+		// validate result
 		err = v.validateResult(result, prevResult)
 		if err != nil {
-			return fmt.Errorf("could not validate result %v at index %d: %w", result.ID(), i, err)
+			return fmt.Errorf("could not validate result %v at index %d: %w", resultID, i, err)
+		}
+		executionTree[resultID] = result
+	}
+
+	// check receipts:
+	// * no duplicates
+	// * must commit to a result in the execution tree with root latestSealedResult,
+	//   but not latestSealedResult
+	// It's very important that we fail the whole validation if one of the receipts is invalid.
+	delete(executionTree, lastSeal.ResultID)
+	for i, receipt := range payload.Receipts {
+		receiptID := receipt.ID()
+
+		// error if the result is not part of the execution tree with root latestSealedResult
+		result, isForLegitimateResult := executionTree[receipt.ResultID]
+		if !isForLegitimateResult {
+			return engine.NewInvalidInputErrorf("receipt %v at index %d commits to unexpected result", receiptID, i)
+		}
+
+		// error if the receipt is duplicated in the fork
+		if _, isDuplicate := forkReceipts[receiptID]; isDuplicate {
+			return engine.NewInvalidInputErrorf("duplicate receipt %v at index %d", receiptID, i)
+		}
+		forkReceipts[receiptID] = struct{}{}
+
+		err = v.validateReceipt(receipt, result.BlockID)
+		if err != nil {
+			return fmt.Errorf("receipt %v at index %d failed validation: %w", receiptID, i, err)
 		}
 	}
 
-	// after results are validated we need to check if metas of receipts
-	// are valid
-	for i, r := range candidate.Payload.Receipts {
-		result := results[r.ResultID]
-		err = v.validateReceipt(r, result.BlockID)
-		if err != nil {
-			// It's very important that we fail the whole validation if one of the receipts is invalid.
-			// It allows us to make assumptions as stated in previous comment.
-			return fmt.Errorf("could not validate receipt %v at index %d: %w", r.ID(), i, err)
-		}
-	}
 	return nil
 }
 
@@ -359,4 +367,41 @@ func IntegrityCheck(receipt *flow.ExecutionReceipt) (flow.StateCommitment, flow.
 		return nil, nil, fmt.Errorf("execution receipt without InitialStateCommit: %x", receipt.ID())
 	}
 	return init, final, nil
+}
+
+// forkCrawler traverses the fork with the provided head. We start at the provided height
+// and work out way upwards until we arrive at the block with the provided ID. For each
+// visited block, we call the provided function.
+//
+// Note that internally, the forkCrawler is implemented as a recursive algorithm that crawls
+// the fork backwards (towards the genesis block) until it hits the specified height.
+func (v *receiptValidator) forkCrawler(
+	headID flow.Identifier,
+	lowestHeigth uint64,
+	blockConsumer func(blockID flow.Identifier, payloadIndex *flow.Index) error,
+) error {
+	head, err := v.headers.ByBlockID(headID)
+	if err != nil {
+		return fmt.Errorf("could not retrieve header for block %x: %w", headID, err)
+	}
+	if head.Height < lowestHeigth {
+		return nil
+	}
+
+	// descend further down the chain
+	err = v.forkCrawler(head.ParentID, lowestHeigth, blockConsumer)
+	if err != nil {
+		return err
+	}
+
+	// now we are on our way back up
+	index, err := v.index.ByBlockID(headID)
+	if err != nil {
+		return fmt.Errorf("could not retrieve payload index for block %x: %w", headID, err)
+	}
+	err = blockConsumer(headID, index)
+	if err != nil {
+		return fmt.Errorf("error in consumer function at height %d (block %x): %w", head.Height, headID, err)
+	}
+	return nil
 }

--- a/module/validation/receipt_validator_test.go
+++ b/module/validation/receipt_validator_test.go
@@ -213,6 +213,7 @@ func (s *ReceiptValidationSuite) TestReceiptNoPreviousResult() {
 
 	err := s.receiptValidator.Validate(receipt)
 	s.Require().Error(err, "should reject invalid receipt")
+	s.Assert().True(engine.IsUnverifiableInputError(err), err)
 }
 
 // TestReceiptInvalidPreviousResult tests that we reject receipt with invalid previous result
@@ -232,8 +233,11 @@ func (s *ReceiptValidationSuite) TestReceiptInvalidPreviousResult() {
 
 	err := s.receiptValidator.Validate(receipt)
 	s.Require().Error(err, "should reject invalid previous result")
+	s.Assert().True(engine.IsInvalidInputError(err), err)
 }
 
+// TestReceiptInvalidResultChain tests that we reject receipts,
+// where the start state does not match the parent result's end state
 func (s *ReceiptValidationSuite) TestReceiptInvalidResultChain() {
 	valSubgrph := s.ValidSubgraphFixture()
 	// invalidate prev execution result blockID, this should fail because
@@ -250,11 +254,16 @@ func (s *ReceiptValidationSuite) TestReceiptInvalidResultChain() {
 
 	err := s.receiptValidator.Validate(receipt)
 	s.Require().Error(err, "should reject invalid previous result")
+	s.Assert().True(engine.IsInvalidInputError(err), err)
 }
 
-// say B(A) means block B has receipt for A:
-// we have such chain in storage: G <- A <- B(A) <- C
-// if a block payload contains (B,C), they should be valid.
+// TestMultiReceiptValidResultChain tests that multiple within one block payload
+// are accepted, where the receipts are building on top of each other
+// (i.e. their results form a chain).
+// Say B(A) means block B has receipt for A:
+// * we have such chain in storage: G <- A <- B(A) <- C
+// * if a child block of C payload contains receipts and results for (B,C)
+//   it should be accepted as valid
 func (s *ReceiptValidationSuite) TestMultiReceiptValidResultChain() {
 	// assuming signatures are all good
 	s.verifier.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
@@ -334,6 +343,7 @@ func (s *ReceiptValidationSuite) TestMultiReceiptInvalidParent() {
 	// receiptB and receiptC
 	err := s.receiptValidator.ValidatePayload(&candidate)
 	s.Require().Error(err)
+	require.True(s.T(), engine.IsInvalidInputError(err), err)
 }
 
 // Test that `ValidatePayload` will refuse payloads that contain receipts for blocks that
@@ -401,7 +411,7 @@ func (s *ReceiptValidationSuite) TestValidationReceiptsForSealedBlock() {
 		Results:  []*flow.ExecutionResult{&receipt.ExecutionResult},
 	})
 	err = s.receiptValidator.ValidatePayload(&block6)
-	require.Nil(s.T(), err)
+	require.NoError(s.T(), err)
 }
 
 // Test that validator will accept payloads with receipts that are referring execution results
@@ -449,33 +459,47 @@ func (s *ReceiptValidationSuite) TestValidationReceiptForIncorporatedResult() {
 	require.NoError(s.T(), err)
 }
 
-// Test that validator will refuse payloads that contain receipts that contain
-// execution result which wasn't incorporated into fork or present in payload.
+// TestValidationReceiptWithoutIncorporatedResult verifies that receipts must commit
+// to results that are included in the respective fork. Specifically, we test that
+// the counter-example is rejected:
+//  * we have the chain in storage: G <- A <- B
+//                                        ^- C(Result[A], ReceiptMeta[A])
+//    here, block C contains the result _and_ the receipt Meta-data for block A
+//  * now receive the new block X: G <- A <- B <- X(ReceiptMeta[A])
+//    Note that X only contains the receipt for A, but _not_ the result.
+// Block X must be considered invalid, because confirming validity of
+// ReceiptMeta[A] requires information _not_ included in the fork.
 func (s *ReceiptValidationSuite) TestValidationReceiptWithoutIncorporatedResult() {
 	// assuming signatures are all good
 	s.verifier.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 
-	// create block2
-	block2 := unittest.BlockWithParentFixture(s.LatestSealedBlock.Header)
-	block2.SetPayload(flow.Payload{})
-	s.Extend(&block2)
+	// create block A
+	blockA := unittest.BlockWithParentFixture(s.LatestSealedBlock.Header) // for block G, we use the LatestSealedBlock
+	s.Extend(&blockA)
 
-	executionResult := unittest.ExecutionResultFixture(unittest.WithBlock(&block2),
-		unittest.WithPreviousResult(*s.LatestExecutionResult))
-	receipt := unittest.ExecutionReceiptFixture(
-		unittest.WithResult(executionResult),
-		unittest.WithExecutorID(s.ExeID))
+	// result for A; and receipt for A
+	resultA := unittest.ExecutionResultFixture(unittest.WithBlock(&blockA), unittest.WithPreviousResult(*s.LatestExecutionResult))
+	receiptA := unittest.ExecutionReceiptFixture(unittest.WithResult(resultA), unittest.WithExecutorID(s.ExeID))
 
-	// B1<--B2<--B3{R{B2)}<--B4{(R'(B2))}
-
-	// create block3 with a receipt for block2
-	block3 := unittest.BlockWithParentFixture(block2.Header)
-	block3.SetPayload(flow.Payload{
-		Receipts: []*flow.ExecutionReceiptMeta{receipt.Meta()},
+	// create block B and block C
+	blockB := unittest.BlockWithParentFixture(blockA.Header)
+	blockC := unittest.BlockWithParentFixture(blockA.Header)
+	blockC.SetPayload(flow.Payload{
+		Receipts: []*flow.ExecutionReceiptMeta{receiptA.Meta()},
+		Results:  []*flow.ExecutionResult{resultA},
 	})
-	err := s.receiptValidator.ValidatePayload(&block3)
+	s.Extend(&blockB)
+	s.Extend(&blockC)
+
+	// create block X:
+	blockX := unittest.BlockWithParentFixture(blockB.Header)
+	blockX.SetPayload(flow.Payload{
+		Receipts: []*flow.ExecutionReceiptMeta{receiptA.Meta()},
+	})
+
+	err := s.receiptValidator.ValidatePayload(&blockX)
 	require.Error(s.T(), err)
-	require.True(s.T(), engine.IsUnverifiableInputError(err), err)
+	require.True(s.T(), engine.IsInvalidInputError(err), err)
 }
 
 // Test that validator will reject payloads that contain receipts for blocks that


### PR DESCRIPTION
PR proposes fixes for a couple intricate edge cases in the receipt validator: https://github.com/onflow/flow-go/pull/462#discussion_r595738011

I have taken inspiration from your PR https://github.com/onflow/flow-go/pull/521 and extracted the block traversing into a custom function, which is highly tuned to for the `receiptValidator`. 