### PR TITLE
updated logic in the Verifier Node to utilize separation of results from receipts in block Payload

### DIFF
--- a/engine/verification/assigner/engine.go
+++ b/engine/verification/assigner/engine.go
@@ -70,27 +70,23 @@ func (e *Engine) Done() <-chan struct{} {
 	return e.unit.Done()
 }
 
-// receiptChunkAssignment receives a receipt that appears in a finalized container block. In case this verification node
-// is staked at the reference block of this execution receipt's result, chunk assignment is done on the execution result of the receipt,
-// and the list of assigned chunks returned.
-func (e *Engine) receiptChunkAssignment(ctx context.Context,
-	receipt *flow.ExecutionReceipt,
-	containerBlockID flow.Identifier) (flow.ChunkList, error) {
-	receiptID := receipt.ID()
-	resultID := receipt.ExecutionResult.ID()
-	referenceBlockID := receipt.ExecutionResult.BlockID
-
+// resultChunkAssignment receives an execution result that appears in a finalized incorporating block.
+// In case this verification node is staked at the reference block of this execution receipt's result,
+// chunk assignment is computed for the result, and the list of assigned chunks returned.
+func (e *Engine) resultChunkAssignment(ctx context.Context,
+	result *flow.ExecutionResult,
+	incorporatingBlock flow.Identifier,
+) (flow.ChunkList, error) {
+	resultID := result.ID()
 	log := log.With().
-		Hex("receipt_id", logging.ID(receiptID)).
 		Hex("result_id", logging.ID(resultID)).
-		Hex("reference_block_id", logging.ID(referenceBlockID)).
-		Hex("container_block_id", logging.ID(containerBlockID)).
+		Hex("executed_block_id", logging.ID(result.BlockID)).
+		Hex("incorporating_block_id", logging.ID(incorporatingBlock)).
 		Logger()
-
 	e.metrics.OnExecutionReceiptReceived()
 
 	// verification node should be staked at the reference block id.
-	ok, err := stakedAsVerification(e.state, referenceBlockID, e.me.NodeID())
+	ok, err := stakedAsVerification(e.state, result.BlockID, e.me.NodeID())
 	if err != nil {
 		return nil, fmt.Errorf("could not verify stake of verification node for result at reference block id: %w", err)
 	}
@@ -100,7 +96,7 @@ func (e *Engine) receiptChunkAssignment(ctx context.Context,
 	}
 
 	// chunk assignment
-	chunkList, err := e.chunkAssignments(ctx, &receipt.ExecutionResult)
+	chunkList, err := e.chunkAssignments(ctx, result, incorporatingBlock)
 	if err != nil {
 		return nil, fmt.Errorf("could not determine chunk assignment: %w", err)
 	}
@@ -182,47 +178,41 @@ func (e *Engine) processFinalizedBlock(ctx context.Context, block *flow.Block) {
 	assignedChunksCount := uint64(0)
 	processedChunksCount := uint64(0)
 
-	log := e.log.With().
+	lg := e.log.With().
 		Hex("block_id", logging.ID(blockID)).
-		Uint64("block_height", block.Header.Height).
-		Int("receipt_num", len(block.Payload.Receipts)).Logger()
+		Uint64("block_height", block.Header.Height).Logger()
+	lg.Debug().Int("result_num", len(block.Payload.Results)).Msg("new finalized block arrived")
 
-	log.Debug().Msg("new finalized block arrived")
+	// performs chunk assigment on each result and pushes the assigned chunks to the chunks queue.
+	receiptsGroupedByResultID := block.Payload.Receipts.GroupByResultID() // for logging purposes
+	for _, result := range block.Payload.Results {
+		resultID := result.ID()
 
-	resultsById := block.Payload.ResultsById()
-
-	receiptFromMeta := func(meta *flow.ExecutionReceiptMeta) *flow.ExecutionReceipt {
-		if result, ok := resultsById[meta.ResultID]; ok {
-			return flow.ExecutionReceiptFromMeta(*meta, *result)
+		// log receipts committing to result
+		receiptsForResult := receiptsGroupedByResultID.GetGroup(resultID)
+		resultLog := lg.With().Hex("incorporated_result_id", logging.ID(resultID)).Logger()
+		if receiptsForResult.Size() < 1 {
+			// Producing such a block would be a protocol violation.
+			// If such a block gets finalized we have a byzantine consensus committee.
+			resultLog.Fatal().Msg("protocol violation: there are no receipts in the block that commit to result")
 		}
+		for _, receipt := range receiptsGroupedByResultID.GetGroup(resultID) {
+			resultLog.With().Hex("receipts_for_result", logging.ID(receipt.ID())).Logger()
+		}
+		resultLog.Debug().Msg("determining chunk assignment for incorporated result")
 
-		// TODO: add fetch of result from storage.
-		return nil
-	}
-
-	// performs chunk assigment on each receipt and pushes the assigned chunks to the
-	// chunks queue.
-	for _, meta := range block.Payload.Receipts {
-		receipt := receiptFromMeta(meta)
-		chunkList, err := e.receiptChunkAssignmentWithTracing(ctx, receipt, blockID)
-		resultID := receipt.ExecutionResult.ID()
+		// compute chunk assignment
+		chunkList, err := e.resultChunkAssignmentWithTracing(ctx, result, blockID)
 		if err != nil {
-			log.Fatal().
-				Err(err).
-				Hex("receipt_id", logging.ID(receipt.ID())).
-				Hex("result_id", logging.ID(resultID)).
-				Hex("executor_id", logging.ID(receipt.ExecutorID)).
-				Msg("could not determine assigned chunks of the receipt")
+			resultLog.Fatal().Err(err).Msg("could not determine assigned chunks of the receipt")
 		}
 
 		assignedChunksCount += uint64(len(chunkList))
-
 		for _, chunk := range chunkList {
 			processed, err := e.processChunkWithTracing(ctx, chunk, resultID)
 			if err != nil {
-				log.Fatal().
+				resultLog.Fatal().
 					Err(err).
-					Hex("result_id", logging.ID(resultID)).
 					Hex("chunk_id", logging.ID(chunk.ID())).
 					Uint64("chunk_index", chunk.Index).
 					Msg("could not process chunk")
@@ -242,12 +232,22 @@ func (e *Engine) processFinalizedBlock(ctx context.Context, block *flow.Block) {
 }
 
 // chunkAssignments returns the list of chunks in the chunk list assigned to this verification node.
-func (e *Engine) chunkAssignments(ctx context.Context, result *flow.ExecutionResult) (flow.ChunkList, error) {
+func (e *Engine) chunkAssignments(ctx context.Context, result *flow.ExecutionResult, incorporatingBlock flow.Identifier) (flow.ChunkList, error) {
 	var span opentracing.Span
 	span, _ = e.tracer.StartSpanFromContext(ctx, trace.VERMatchMyChunkAssignments)
 	defer span.Finish()
 
-	assignment, err := e.assigner.Assign(result, result.BlockID)
+	// TODO remove shortcut which is only applicable during Sealing Phase 2
+	// Details: in the mature protocol, the chunk assignment for a result is computed
+	// using the Source of Randomness from the _first_ block that incorporates the result
+	// in the respective fork. Per protocol definition, a result is only incorporated _once_
+	// in each fork, specifically in the first block that contains an execution receipt
+	// committing to the result.
+	// However, for Sealing Phase 2, we use a NON-BFT shortcut: we use the source of
+	// randomness from the block the result is for.
+	incorporatingBlock = result.BlockID
+
+	assignment, err := e.assigner.Assign(result, incorporatingBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -288,13 +288,16 @@ func stakedAsVerification(state protocol.State, blockID flow.Identifier, identif
 	return true, nil
 }
 
-// receiptChunkAssignmentWithTracing handles the chunk assignment of a receipt in a container block with tracing enabled.
-func (e *Engine) receiptChunkAssignmentWithTracing(ctx context.Context, receipt *flow.ExecutionReceipt,
-	containerBlockID flow.Identifier) (flow.ChunkList, error) {
+// resultChunkAssignmentWithTracing computes the chunk assignment for the provided receipt with tracing enabled.
+func (e *Engine) resultChunkAssignmentWithTracing(
+	ctx context.Context,
+	result *flow.ExecutionResult,
+	incorporatingBlock flow.Identifier,
+) (flow.ChunkList, error) {
 	var err error
 	var chunkList flow.ChunkList
 	e.tracer.WithSpanFromContext(ctx, trace.VERAssignerHandleExecutionReceipt, func() {
-		chunkList, err = e.receiptChunkAssignment(ctx, receipt, containerBlockID)
+		chunkList, err = e.resultChunkAssignment(ctx, result, incorporatingBlock)
 	})
 	return chunkList, err
 }

--- a/model/flow/execution_receipt_test.go
+++ b/model/flow/execution_receipt_test.go
@@ -41,3 +41,36 @@ func TestExecutionReceiptGroupBy(t *testing.T) {
 	unknown := groups.GetGroup(unittest.IdentifierFixture())
 	assert.Equal(t, 0, unknown.Size())
 }
+
+// TestExecutionReceiptMetaGroupBy tests the GroupBy method of ExecutionReceiptMetaList:
+// * grouping should preserve order and multiplicity of elements
+// * group for unknown identifier should be empty
+func TestExecutionReceiptMetaGroupBy(t *testing.T) {
+
+	er1 := unittest.ExecutionReceiptFixture().Meta()
+	er2 := unittest.ExecutionReceiptFixture().Meta()
+	er3 := unittest.ExecutionReceiptFixture().Meta()
+
+	idA := unittest.IdentifierFixture()
+	idB := unittest.IdentifierFixture()
+	grouperFunc := func(er *flow.ExecutionReceiptMeta) flow.Identifier {
+		switch er.ID() {
+		case er1.ID():
+			return idA
+		case er2.ID():
+			return idB
+		case er3.ID():
+			return idA
+		default:
+			panic("unexpected ExecutionReceipt")
+		}
+	}
+
+	groups := flow.ExecutionReceiptMetaList{er1, er2, er3, er1}.GroupBy(grouperFunc)
+	assert.Equal(t, 2, groups.NumberGroups())
+	assert.Equal(t, flow.ExecutionReceiptMetaList{er1, er3, er1}, groups.GetGroup(idA))
+	assert.Equal(t, flow.ExecutionReceiptMetaList{er2}, groups.GetGroup(idB))
+
+	unknown := groups.GetGroup(unittest.IdentifierFixture())
+	assert.Equal(t, 0, unknown.Size())
+}

--- a/model/flow/execution_result_test.go
+++ b/model/flow/execution_result_test.go
@@ -1,0 +1,43 @@
+package flow_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestExecutionResultGroupBy tests the GroupBy method of ExecutionResultList:
+// * grouping should preserve order and multiplicity of elements
+// * group for unknown identifier should be empty
+func TestExecutionResultGroupBy(t *testing.T) {
+
+	er1 := unittest.ExecutionResultFixture()
+	er2 := unittest.ExecutionResultFixture()
+	er3 := unittest.ExecutionResultFixture()
+
+	idA := unittest.IdentifierFixture()
+	idB := unittest.IdentifierFixture()
+	grouperFunc := func(er *flow.ExecutionResult) flow.Identifier {
+		switch er.ID() {
+		case er1.ID():
+			return idA
+		case er2.ID():
+			return idB
+		case er3.ID():
+			return idA
+		default:
+			panic("unexpected ExecutionReceipt")
+		}
+	}
+
+	groups := flow.ExecutionResultList{er1, er2, er3, er1}.GroupBy(grouperFunc)
+	assert.Equal(t, 2, groups.NumberGroups())
+	assert.Equal(t, flow.ExecutionResultList{er1, er3, er1}, groups.GetGroup(idA))
+	assert.Equal(t, flow.ExecutionResultList{er2}, groups.GetGroup(idB))
+
+	unknown := groups.GetGroup(unittest.IdentifierFixture())
+	assert.Equal(t, 0, unknown.Size())
+}

--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -184,7 +184,9 @@ func (c *SignatureCollector) NumberSignatures() uint {
 	return uint(len(c.signerIDs))
 }
 
-/* GROUPING allows to split a list or map of incorporated results by some property */
+/*******************************************************************************
+GROUPING allows to split a list incorporated results by some property
+*******************************************************************************/
 
 // IncorporatedResultList is a slice of IncorporatedResults with the additional
 // functionality to group them by various properties
@@ -208,7 +210,7 @@ func (l IncorporatedResultList) GroupBy(grouper IncorporatedResultGroupingFuncti
 	return groups
 }
 
-// GroupByExecutorID partitions the IncorporatedResultList by the ID of the block that
+// GroupByIncorporatedBlockID partitions the IncorporatedResultList by the ID of the block that
 // incorporates the result. Within each group, the order and multiplicity of the
 // IncorporatedResults is preserved.
 func (l IncorporatedResultList) GroupByIncorporatedBlockID() IncorporatedResultGroupedList {
@@ -223,7 +225,7 @@ func (l IncorporatedResultList) GroupByResultID() IncorporatedResultGroupedList 
 	return l.GroupBy(grouper)
 }
 
-// GroupByResultID partitions the IncorporatedResultList by the IDs of the executed blocks.
+// GroupByExecutedBlockID partitions the IncorporatedResultList by the IDs of the executed blocks.
 // Within each group, the order and multiplicity of the IncorporatedResults is preserved.
 func (l IncorporatedResultList) GroupByExecutedBlockID() IncorporatedResultGroupedList {
 	grouper := func(ir *IncorporatedResult) Identifier { return ir.Result.BlockID }

--- a/model/flow/payload.go
+++ b/model/flow/payload.go
@@ -8,8 +8,8 @@ import (
 type Payload struct {
 	Guarantees []*CollectionGuarantee
 	Seals      []*Seal
-	Receipts   []*ExecutionReceiptMeta
-	Results    []*ExecutionResult
+	Receipts   ExecutionReceiptMetaList
+	Results    ExecutionResultList
 }
 
 // EmptyPayload returns an empty block payload.

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -202,8 +202,8 @@ func WithAllTheFixins(payload *flow.Payload) {
 	payload.Seals = Seal.Fixtures(3)
 	payload.Guarantees = CollectionGuaranteesFixture(4)
 	receipt := ExecutionReceiptFixture()
-	payload.Receipts = []*flow.ExecutionReceiptMeta{receipt.Meta()}
-	payload.Results = []*flow.ExecutionResult{&receipt.ExecutionResult}
+	payload.Receipts = flow.ExecutionReceiptMetaList{receipt.Meta()}
+	payload.Results = flow.ExecutionResultList{&receipt.ExecutionResult}
 }
 
 func WithSeals(seals ...*flow.Seal) func(*flow.Payload) {


### PR DESCRIPTION
### 🚧 PR is depending on https://github.com/onflow/flow-go/pull/462 being merged 🚧 

**Do _not_ review yet**. Remaining pending steps:
* merge https://github.com/onflow/flow-go/pull/462
* update this PR 


implements https://github.com/dapperlabs/flow-go/issues/5397

• **updated logic in the verifier's `assigner.Engine`** to utilize separation of results from receipts in block Payload
• added grouping for `ExecutionReceiptMeta` and unit tests
• added grouping for `ExecutionResult` and unit tests
• updated Payload to use `ExecutionReceiptMetaList` and `ExecutionResultList`
