### PR TITLE
Remove unused closer from noop tracer

### DIFF
--- a/module/trace/noop.go
+++ b/module/trace/noop.go
@@ -2,7 +2,6 @@ package trace
 
 import (
 	"context"
-	"io"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -13,7 +12,6 @@ import (
 
 // NoopTracer is the implementation of the Tracer interface
 type NoopTracer struct {
-	closer io.Closer
 	tracer *InternalTracer
 }
 
@@ -27,19 +25,14 @@ func NewNoopTracer() *NoopTracer {
 // Ready returns a channel that will close when the network stack is ready.
 func (t *NoopTracer) Ready() <-chan struct{} {
 	ready := make(chan struct{})
-	go func() {
-		close(ready)
-	}()
+	close(ready)
 	return ready
 }
 
 // Done returns a channel that will close when shutdown is complete.
 func (t *NoopTracer) Done() <-chan struct{} {
 	done := make(chan struct{})
-	go func() {
-		t.closer.Close()
-		close(done)
-	}()
+	close(done)
 	return done
 }
 


### PR DESCRIPTION
This caused a panic on `Done` method