### PR TITLE
[FVM] Updating program cache handler to always clean up state stack

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -836,7 +836,10 @@ func (e *hostEnv) ValueDecoded(duration time.Duration) {
 
 func (e *hostEnv) Commit() ([]programs.ContractUpdateKey, error) {
 	// commit changes and return a list of updated keys
-	e.programs.Cleanup()
+	err := e.programs.Cleanup()
+	if err != nil {
+		return nil, err
+	}
 	return e.contracts.Commit()
 }
 

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -836,6 +836,7 @@ func (e *hostEnv) ValueDecoded(duration time.Duration) {
 
 func (e *hostEnv) Commit() ([]programs.ContractUpdateKey, error) {
 	// commit changes and return a list of updated keys
+	e.programs.Cleanup()
 	return e.contracts.Commit()
 }
 

--- a/fvm/handler/programs.go
+++ b/fvm/handler/programs.go
@@ -110,19 +110,19 @@ func (h *ProgramsHandler) Get(location common.Location) (*interpreter.Program, b
 }
 
 func (h *ProgramsHandler) Cleanup() error {
-
 	stackLen := len(h.viewsStack)
 
 	if stackLen == 0 {
 		return nil
 	}
 
-	for i := stackLen; i > 0; i-- {
+	for i := stackLen - 1; i > 0; i-- {
 		entry := h.viewsStack[i]
 		err := h.viewsStack[i-1].state.MergeState(entry.state)
 		if err != nil {
 			return fmt.Errorf("cannot merge state while cleanup: %w", err)
 		}
 	}
-	return h.masterState.State().MergeState(h.viewsStack[0].state)
+
+	return h.initialState.MergeState(h.viewsStack[0].state)
 }


### PR DESCRIPTION
This PR updates the cache handler to cover an edge case that a cadence runtime calls get and the cache is empty and it never calls set. This is necessary for smart contract update transactions.