### PR TITLE
[FVM] program cache patch 2

### DIFF
--- a/fvm/handler/programs.go
+++ b/fvm/handler/programs.go
@@ -124,5 +124,13 @@ func (h *ProgramsHandler) Cleanup() error {
 		}
 	}
 
-	return h.initialState.MergeState(h.viewsStack[0].state)
+	err := h.initialState.MergeState(h.viewsStack[0].state)
+	if err != nil {
+		return err
+	}
+
+	// reset the stack
+	h.viewsStack = nil
+	h.masterState.SetActiveState(h.initialState)
+	return nil
 }


### PR DESCRIPTION
we need to reset the active state back to the initial state on clean up. this impacts after clean up updates like commit smart contract updates.