### PR TITLE
[FVM] adding an extra health check on the state holder

### DIFF
--- a/fvm/errors.go
+++ b/fvm/errors.go
@@ -32,8 +32,8 @@ const (
 
 	errCodeEncodingUnsupportedValue = 30
 
-	errCodeExecution    = 100
-	errCodeUnknownError = 200
+	errCodeExecution        = 100
+	errCodeFVMInternalError = 200
 )
 
 var ErrAccountNotFound = errors.New("account not found")
@@ -286,17 +286,17 @@ func (e *EncodingUnsupportedValueError) Code() uint32 {
 	return errCodeEncodingUnsupportedValue
 }
 
-// UnknownError indicates that an unknown error that occurs during tx execution.
-type UnknownError struct {
+// FVMInternalError indicates that an internal error occurs during tx execution.
+type FVMInternalError struct {
 	msg string
 }
 
-func (e *UnknownError) Error() string {
+func (e *FVMInternalError) Error() string {
 	return e.msg
 }
 
-func (e *UnknownError) Code() uint32 {
-	return errCodeUnknownError
+func (e *FVMInternalError) Code() uint32 {
+	return errCodeFVMInternalError
 }
 
 func handleError(err error) (vmErr Error, fatalErr error) {

--- a/fvm/errors.go
+++ b/fvm/errors.go
@@ -32,7 +32,8 @@ const (
 
 	errCodeEncodingUnsupportedValue = 30
 
-	errCodeExecution = 100
+	errCodeExecution    = 100
+	errCodeUnknownError = 200
 )
 
 var ErrAccountNotFound = errors.New("account not found")
@@ -283,6 +284,19 @@ func (e *EncodingUnsupportedValueError) Error() string {
 
 func (e *EncodingUnsupportedValueError) Code() uint32 {
 	return errCodeEncodingUnsupportedValue
+}
+
+// UnknownError indicates that an unknown error that occurs during tx execution.
+type UnknownError struct {
+	msg string
+}
+
+func (e *UnknownError) Error() string {
+	return e.msg
+}
+
+func (e *UnknownError) Code() uint32 {
+	return errCodeUnknownError
 }
 
 func handleError(err error) (vmErr Error, fatalErr error) {

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -162,6 +162,10 @@ func (i *TransactionInvocator) Process(
 	parentState := sth.State()
 	childState := sth.NewChild()
 	defer func() {
+		// an extra check for state holder health, this should never happen
+		if childState != sth.State() {
+			panic("child state doesn't match the active state on the state holder")
+		}
 		if mergeError := parentState.MergeState(childState); mergeError != nil {
 			panic(mergeError)
 		}

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -173,7 +173,7 @@ func (i *TransactionInvocator) Process(
 
 			// drop delta
 			childState.View().DropDelta()
-			proc.Err = &UnknownError{msg}
+			proc.Err = &FVMInternalError{msg}
 			proc.Logs = make([]string, 0)
 			proc.Events = make([]flow.Event, 0)
 			proc.ServiceEvents = make([]flow.Event, 0)

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -164,7 +164,12 @@ func (i *TransactionInvocator) Process(
 	defer func() {
 		// an extra check for state holder health, this should never happen
 		if childState != sth.State() {
-			panic("child state doesn't match the active state on the state holder")
+			msg := "child state doesn't match the active state on the state holder"
+			i.logger.Error().
+				Str("txHash", proc.ID.String()).
+				Uint64("blockHeight", blockHeight).
+				Msg(msg)
+			panic(msg)
 		}
 		if mergeError := parentState.MergeState(childState); mergeError != nil {
 			panic(mergeError)


### PR DESCRIPTION
This PR adds an extra health check for the state holder during the execution of transactions. 
If the state holder state doesn't match the initial state of the transaction, a state child merge has been missing somewhere, while this situation should never happen, this safety check makes sure we fail on those transactions gracefully. 