### PR TITLE
Fix flaky tests

### DIFF
--- a/engine/verification/assigner/blockconsumer/consumer_test.go
+++ b/engine/verification/assigner/blockconsumer/consumer_test.go
@@ -66,51 +66,10 @@ func TestProduceConsume(t *testing.T) {
 	// each received block immediately, results in processor receiving all 10 blocks:
 	// 10 blocks sequentially --> block reader --> consumer can read and push 3 blocks at a time to processor --> processor finishes blocks
 	// immediately.
-	t.Run("pushing 10 blocks, non-blocking, receives 10", func(t *testing.T) {
+	t.Run("pushing 100 blocks, non-blocking, receives 100", func(t *testing.T) {
 		received := make([]*flow.Block, 0)
 		lock := &sync.Mutex{}
 		var processAll sync.WaitGroup
-		alwaysFinish := func(notifier module.ProcessingNotifier, block *flow.Block) {
-			lock.Lock()
-			defer lock.Unlock()
-
-			received = append(received, block)
-
-			go func() {
-				notifier.Notify(block.ID())
-				processAll.Done()
-			}()
-		}
-
-		withConsumer(t, 10, 3, alwaysFinish, func(consumer *BlockConsumer, blocks []*flow.Block) {
-			unittest.RequireCloseBefore(t, consumer.Ready(), time.Second, "could not start consumer")
-			processAll.Add(len(blocks))
-
-			for i := 0; i < len(blocks); i++ {
-				// consumer is only required to be "notified" that a new finalized block available.
-				// It keeps track of the last finalized block it has read, and read the next height upon
-				// getting notified as follows:
-				consumer.OnFinalizedBlock(&model.Block{})
-			}
-
-			// waits until all blocks finish processing
-			unittest.RequireReturnsBefore(t, processAll.Wait, time.Second, "could not process all blocks on time")
-			unittest.RequireCloseBefore(t, consumer.Done(), time.Second, "could not terminate consumer")
-
-			// expects the mock engine receive all 10 blocks.
-			require.ElementsMatch(t, flow.GetIDs(blocks), flow.GetIDs(received))
-		})
-	})
-
-	// pushing 100 finalized blocks concurrently to block reader, with 3 workers on consumer and the processor finishes processing
-	// all blocks immediately, results in the processor receiving all 100 blocks:
-	// 100 blocks concurrently --> block reader --> consumer can read and push 3 blocks at a time to processor --> processor finishes blocks
-	// immediately.
-	t.Run("pushing 100 blocks concurrently, non-blocking, receives 100", func(t *testing.T) {
-		received := make([]*flow.Block, 0)
-		lock := &sync.Mutex{}
-		var processAll sync.WaitGroup
-
 		alwaysFinish := func(notifier module.ProcessingNotifier, block *flow.Block) {
 			lock.Lock()
 			defer lock.Unlock()
@@ -128,15 +87,13 @@ func TestProduceConsume(t *testing.T) {
 			processAll.Add(len(blocks))
 
 			for i := 0; i < len(blocks); i++ {
-				go func() {
-					// consumer is only required to be "notified" that a new finalized block available.
-					// It keeps track of the last finalized block it has read, and read the next height upon
-					// getting notified as follows:
-					consumer.OnFinalizedBlock(&model.Block{})
-				}()
+				// consumer is only required to be "notified" that a new finalized block available.
+				// It keeps track of the last finalized block it has read, and read the next height upon
+				// getting notified as follows:
+				consumer.OnFinalizedBlock(&model.Block{})
 			}
 
-			// waits until all finished
+			// waits until all blocks finish processing
 			unittest.RequireReturnsBefore(t, processAll.Wait, time.Second, "could not process all blocks on time")
 			unittest.RequireCloseBefore(t, consumer.Done(), time.Second, "could not terminate consumer")
 


### PR DESCRIPTION
Fixing the flakey tests with the following error:

```
=== RUN   TestProduceConsume/pushing_100_blocks_concurrently,_non-blocking,_receives_100
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xa7026a]
goroutine 14770 [running]:
github.com/dgraph-io/badger/v2/skl.(*Skiplist).IncrRef(...)
	/home/m4ks/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.3/skl/skl.go:86
github.com/dgraph-io/badger/v2.(*DB).getMemTables(0xc00057c000, 0x0, 0x0, 0x0, 0x0)
	/home/m4ks/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.3/db.go:578 +0xea
github.com/dgraph-io/badger/v2.(*DB).get(0xc00057c000, 0xc0147f8720, 0x2f, 0x2f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/m4ks/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.3/db.go:610 +0x66
github.com/dgraph-io/badger/v2.(*Txn).Get(0xc0147b5800, 0xc0147f86f0, 0x27, 0x30, 0x0, 0x0, 0x33)
	/home/m4ks/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.3/txn.go:409 +0xe7
github.com/onflow/flow-go/storage/badger/operation.update.func1(0xc0147b5800, 0x1, 0xc0147b5800)
	/home/m4ks/flow-go/storage/badger/operation/common.go:93 +0x78
github.com/dgraph-io/badger/v2.(*DB).Update(0xc00057c000, 0xc014812210, 0x0, 0x0)
	/home/m4ks/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.3/txn.go:698 +0x94
github.com/onflow/flow-go/storage/badger/operation.RetryOnConflict(0xc00b6a9b70, 0xc014812210, 0x31, 0xc014812210)
	/home/m4ks/flow-go/storage/badger/operation/modifiers.go:25 +0x40
github.com/onflow/flow-go/storage/badger.(*ConsumerProgress).SetProcessedIndex(0xc00bcc8160, 0x31, 0xc00d79e410, 0xc0147dbdc0)
	/home/m4ks/flow-go/storage/badger/consumer_progress.go:44 +0x7f
github.com/onflow/flow-go/module/jobqueue.(*Consumer).run(0xc00d79e410, 0x14d0606, 0x19, 0xc0142ff1a0)
	/home/m4ks/flow-go/module/jobqueue/consumer.go:218 +0x331
github.com/onflow/flow-go/module/jobqueue.(*Consumer).checkProcessable(0xc00d79e410)
	/home/m4ks/flow-go/module/jobqueue/consumer.go:167 +0x64
github.com/onflow/flow-go/module/jobqueue.(*Consumer).NotifyJobIsDone(0xc00d79e410, 0xc01477b880, 0x40)
	/home/m4ks/flow-go/module/jobqueue/consumer.go:139 +0x11f
github.com/onflow/flow-go/engine/verification/assigner/blockconsumer.(*BlockConsumer).NotifyJobIsDone(...)
	/home/m4ks/flow-go/engine/verification/assigner/blockconsumer/consumer.go:71
github.com/onflow/flow-go/engine/verification/assigner/blockconsumer.(*worker).Notify(0xc00cd98f80, 0xfd82377f9df1786a, 0xbcc1a793c7f09515, 0x231cab919b328a49, 0x194c28ce34a3c1fe)
	/home/m4ks/flow-go/engine/verification/assigner/blockconsumer/worker.go:49 +0xd4
github.com/onflow/flow-go/engine/verification/assigner/blockconsumer.TestProduceConsume.func3.1.1(0x17a8d60, 0xc00cd98f80, 0xc014621160, 0xc00bc905d0)
	/home/m4ks/flow-go/engine/verification/assigner/blockconsumer/consumer_test.go:121 +0xe4
created by github.com/onflow/flow-go/engine/verification/assigner/blockconsumer.TestProduceConsume.func3.1
	/home/m4ks/flow-go/engine/verification/assigner/blockconsumer/consumer_test.go:120 +0x117
FAIL	github.com/onflow/flow-go/engine/verification/assigner/blockconsumer	15.289s
```