### PR TITLE
[Verification] Yahya/5421-adds-receipts-to-complete-execution-receipt-fixture

### DIFF
--- a/engine/verification/finder/concurrency_test.go
+++ b/engine/verification/finder/concurrency_test.go
@@ -181,7 +181,7 @@ func (suite *ConcurrencyTestSuite) testConcurrency(receiptCount, senderCount, ch
 	for i := 0; i < receiptCount; i++ {
 		completeER := utils.CompleteExecutionReceiptFixture(suite.T(), chunkCount, chainID.Chain(), parent)
 		receipts[i] = completeER
-		results[i] = completeER.ContainerBlock.Payload.Receipts[0].ExecutionResult
+		results[i] = completeER.Receipts[0].ExecutionResult
 	}
 
 	// sets up mock match engine that asserts:
@@ -246,9 +246,9 @@ func (suite *ConcurrencyTestSuite) testConcurrency(receiptCount, senderCount, ch
 
 				senderWG.Done()
 			}(i,
-				completeER.ContainerBlock.Payload.Receipts[0].ExecutionResult.ID(),
+				completeER.Receipts[0].ExecutionResult.ID(),
 				completeER.ReceiptsData[0].ReferenceBlock,
-				completeER.ContainerBlock.Payload.Receipts[0])
+				completeER.Receipts[0])
 		}
 	}
 

--- a/engine/verification/finder/engine_test.go
+++ b/engine/verification/finder/engine_test.go
@@ -102,7 +102,7 @@ func (suite *FinderEngineTestSuite) SetupTest() {
 	completeER := utils.LightExecutionResultFixture(1)
 	suite.collection = completeER.ReceiptsData[0].Collections[0]
 	suite.block = completeER.ReceiptsData[0].ReferenceBlock
-	suite.receipt = completeER.ContainerBlock.Payload.Receipts[0]
+	suite.receipt = completeER.Receipts[0]
 	suite.chunk = suite.receipt.ExecutionResult.Chunks[0]
 	suite.chunkDataPack = completeER.ReceiptsData[0].ChunkDataPacks[0]
 

--- a/engine/verification/test/helper.go
+++ b/engine/verification/test/helper.go
@@ -142,7 +142,7 @@ func VerificationHappyPath(t *testing.T,
 			defer verWG.Done()
 			err := vn.FinderEngine.Process(exeIdentity.NodeID, receipt)
 			require.NoError(t, err)
-		}(verNode, completeER.ContainerBlock.Payload.Receipts[0])
+		}(verNode, completeER.Receipts[0])
 	}
 
 	// requires all verification nodes process the receipt
@@ -231,7 +231,7 @@ func SetupMockExeNode(t *testing.T,
 
 	// determines the expected number of result chunk data pack requests
 	chunkDataPackCount := 0
-	chunks := completeER.ContainerBlock.Payload.Receipts[0].ExecutionResult.Chunks
+	chunks := completeER.Receipts[0].ExecutionResult.Chunks
 	chunksNum := len(chunks)
 	for _, chunk := range chunks {
 		if evenChunkIndexAssigner(chunk.Index, chunksNum) {
@@ -304,7 +304,7 @@ func SetupMockConsensusNode(t *testing.T,
 	chainID flow.ChainID) (*enginemock.GenericNode, *mocknetwork.Engine, *sync.WaitGroup) {
 	// determines the expected number of result approvals this node should receive
 	approvalsCount := 0
-	chunks := completeER.ContainerBlock.Payload.Receipts[0].ExecutionResult.Chunks
+	chunks := completeER.Receipts[0].ExecutionResult.Chunks
 	chunksNum := len(chunks)
 	for _, chunk := range chunks {
 		if evenChunkIndexAssigner(chunk.Index, chunksNum) {
@@ -462,7 +462,7 @@ func MockChunkAssignmentFixture(chunkAssigner *mock.ChunkAssigner,
 	visited := make(map[flow.Identifier]struct{})
 
 	for _, completeER := range completeERs {
-		for _, receipt := range completeER.ContainerBlock.Payload.Receipts {
+		for _, receipt := range completeER.Receipts {
 			a := chunks.NewAssignment()
 
 			_, duplicate := visited[receipt.ExecutionResult.ID()]

--- a/engine/verification/test/verification_test.go
+++ b/engine/verification/test/verification_test.go
@@ -140,7 +140,7 @@ func TestSingleCollectionProcessing(t *testing.T) {
 		chainID)
 
 	// send the ER from execution to verification node
-	err = verNode.FinderEngine.Process(exeIdentity.NodeID, completeER.ContainerBlock.Payload.Receipts[0])
+	err = verNode.FinderEngine.Process(exeIdentity.NodeID, completeER.Receipts[0])
 	assert.Nil(t, err)
 
 	unittest.RequireReturnsBefore(t, conWG.Wait, 10*time.Second, "consensus nodes process")
@@ -162,7 +162,7 @@ func TestSingleCollectionProcessing(t *testing.T) {
 	<-verNode.VerifierEngine.(module.ReadyDoneAware).Done()
 
 	// receipt ID should be added to the ingested results mempool
-	assert.True(t, verNode.ProcessedResultIDs.Has(completeER.ContainerBlock.Payload.Receipts[0].ExecutionResult.ID()))
+	assert.True(t, verNode.ProcessedResultIDs.Has(completeER.Receipts[0].ExecutionResult.ID()))
 
 	verNode.Done()
 	conNode.Done()


### PR DESCRIPTION
The `CompleteExecutionReceipt` is one of our test helper `struct` in the Verification Domain that represents a container block accompanied with all data required to verify its execution receipts.

At this moment that we are in transition between software architectures of verification node, `CompleteExecutionReceipt` should support both the `finder` engine (from old architecture) and `assigner` engine (from new architecture). However, these two engines behave quite differently. The former expects to receive receipts from the network while the latter reads receipts from the payload of blocks. 

The `CompleteExecutionReceipt` was mainly developed with the new `assigner` engine in mind. Hence, to imitate the old `finder` engine receives a block from the network, we needed to iterate over the receipts in the container block of the `CompleteExecutionReceipt`.

However, this approach would make the code less extensible for optimizing the `ExecutionReceipts` and would be a kind of blocker for some existing issues. 

This PR hence (temporarily) adds a `Receipts` field back to the `CompleteExecutionReceipt` which is used by the test helpers to imitate dispatched receipts on the network for the old `finder` engine. This ephemeral change is planned to be dropped once we completely remove the `finder` from architecture and replace it with the new `assigner` engine. 