### PR TITLE
Access RPC: GetEvents Performance Improvements (v0.14)

### DIFF
--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -91,6 +91,7 @@ func main() {
 			flags.StringVarP(&rpcConf.HistoricalAccessAddrs, "historical-access-addr", "", "", "comma separated rpc addresses for historical access nodes")
 			flags.DurationVar(&rpcConf.CollectionClientTimeout, "collection-client-timeout", 3*time.Second, "grpc client timeout for a collection node")
 			flags.DurationVar(&rpcConf.ExecutionClientTimeout, "execution-client-timeout", 3*time.Second, "grpc client timeout for an execution node")
+			flags.UintVar(&rpcConf.MaxHeightRange, "rpc-max-height-range", 100, "maximum size for height range requests")
 			flags.StringSliceVar(&rpcConf.PreferredExecutionNodeIDs, "preferred-execution-node-ids", nil, "comma separated list of execution nodes ids to choose from when making an upstream call e.g. b4a4dbdcd443d...,fb386a6a... etc.")
 			flags.BoolVar(&logTxTimeToFinalized, "log-tx-time-to-finalized", false, "log transaction time to finalized")
 			flags.BoolVar(&logTxTimeToExecuted, "log-tx-time-to-executed", false, "log transaction time to executed")

--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -91,7 +91,7 @@ func main() {
 			flags.StringVarP(&rpcConf.HistoricalAccessAddrs, "historical-access-addr", "", "", "comma separated rpc addresses for historical access nodes")
 			flags.DurationVar(&rpcConf.CollectionClientTimeout, "collection-client-timeout", 3*time.Second, "grpc client timeout for a collection node")
 			flags.DurationVar(&rpcConf.ExecutionClientTimeout, "execution-client-timeout", 3*time.Second, "grpc client timeout for an execution node")
-			flags.UintVar(&rpcConf.MaxHeightRange, "rpc-max-height-range", 100, "maximum size for height range requests")
+			flags.UintVar(&rpcConf.MaxHeightRange, "rpc-max-height-range", backend.DefaultMaxHeightRange, "maximum size for height range requests")
 			flags.StringSliceVar(&rpcConf.PreferredExecutionNodeIDs, "preferred-execution-node-ids", nil, "comma separated list of execution nodes ids to choose from when making an upstream call e.g. b4a4dbdcd443d...,fb386a6a... etc.")
 			flags.BoolVar(&logTxTimeToFinalized, "log-tx-time-to-finalized", false, "log transaction time to finalized")
 			flags.BoolVar(&logTxTimeToExecuted, "log-tx-time-to-executed", false, "log transaction time to executed")

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -111,6 +111,7 @@ func (suite *Suite) RunTest(
 			suite.metrics,
 			nil,
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -285,6 +286,7 @@ func (suite *Suite) TestSendTransactionToRandomCollectionNode() {
 			metrics,
 			connFactory, // passing in the connection factory
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -516,6 +518,7 @@ func (suite *Suite) TestExecuteScript() {
 			suite.metrics,
 			connFactory,
 			false,
+			100,
 			nil,
 			suite.log,
 		)

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -111,7 +111,7 @@ func (suite *Suite) RunTest(
 			suite.metrics,
 			nil,
 			false,
-			100,
+			backend.DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -286,7 +286,7 @@ func (suite *Suite) TestSendTransactionToRandomCollectionNode() {
 			metrics,
 			connFactory, // passing in the connection factory
 			false,
-			100,
+			backend.DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -518,7 +518,7 @@ func (suite *Suite) TestExecuteScript() {
 			suite.metrics,
 			connFactory,
 			false,
-			100,
+			backend.DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -66,6 +66,7 @@ func New(
 	transactionMetrics module.TransactionMetrics,
 	connFactory ConnectionFactory,
 	retryEnabled bool,
+	maxHeightRange uint,
 	preferredExecutionNodeIDs []string,
 	log zerolog.Logger,
 ) *Backend {
@@ -105,10 +106,11 @@ func New(
 		backendEvents: backendEvents{
 			staticExecutionRPC: executionRPC,
 			state:              state,
-			blocks:             blocks,
+			headers:            headers,
 			executionReceipts:  executionReceipts,
 			connFactory:        connFactory,
 			log:                log,
+			maxHeightRange:     maxHeightRange,
 		},
 		backendBlockHeaders: backendBlockHeaders{
 			headers: headers,

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -22,6 +22,9 @@ import (
 // maxExecutionNodesCnt is the max number of execution nodes that will be contacted to complete an execution api request
 const maxExecutionNodesCnt = 3
 
+// DefaultMaxHeightRange is the default maximum size of range requests.
+const DefaultMaxHeightRange = 250
+
 var validENMap map[flow.Identifier]bool
 
 // Backends implements the Access API.

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -20,11 +20,12 @@ import (
 
 type backendEvents struct {
 	staticExecutionRPC execproto.ExecutionAPIClient
-	blocks             storage.Blocks
+	headers            storage.Headers
 	executionReceipts  storage.ExecutionReceipts
 	state              protocol.State
 	connFactory        ConnectionFactory
 	log                zerolog.Logger
+	maxHeightRange     uint
 }
 
 // GetEventsForHeightRange retrieves events for all sealed blocks between the start block height and
@@ -60,12 +61,12 @@ func (b *backendEvents) GetEventsForHeightRange(
 	blockHeaders := make([]*flow.Header, 0)
 
 	for i := startHeight; i <= endHeight; i++ {
-		block, err := b.blocks.ByHeight(i)
+		header, err := b.headers.ByHeight(i)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get events: %v", err)
 		}
 
-		blockHeaders = append(blockHeaders, block.Header)
+		blockHeaders = append(blockHeaders, header)
 	}
 
 	return b.getBlockEventsFromExecutionNode(ctx, blockHeaders, eventType)
@@ -81,12 +82,12 @@ func (b *backendEvents) GetEventsForBlockIDs(
 	// find the block headers for all the block IDs
 	blockHeaders := make([]*flow.Header, 0)
 	for _, blockID := range blockIDs {
-		block, err := b.blocks.ByID(blockID)
+		header, err := b.headers.ByBlockID(blockID)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get events: %v", err)
 		}
 
-		blockHeaders = append(blockHeaders, block.Header)
+		blockHeaders = append(blockHeaders, header)
 	}
 
 	// forward the request to the execution node
@@ -107,6 +108,11 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 
 	if len(blockIDs) == 0 {
 		return []flow.BlockEvents{}, nil
+	}
+
+	// limit height range queries
+	if uint(len(blockIDs)) > b.maxHeightRange {
+		return nil, fmt.Errorf("requested block range (%d) exceeded maximum (%d)", len(blockIDs), b.maxHeightRange)
 	}
 
 	req := execproto.GetEventsForBlockIDsRequest{

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -896,7 +896,6 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			false,
 			1, // set maximum range to 1
 			nil,
-			nil,
 			suite.log,
 		)
 

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -87,7 +87,7 @@ func (suite *Suite) TestPing() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -111,7 +111,7 @@ func (suite *Suite) TestGetLatestFinalizedBlockHeader() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -141,7 +141,7 @@ func (suite *Suite) TestGetLatestSealedBlockHeader() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -176,7 +176,7 @@ func (suite *Suite) TestGetTransaction() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -207,7 +207,7 @@ func (suite *Suite) TestGetCollection() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -287,7 +287,7 @@ func (suite *Suite) TestTransactionStatusTransition() {
 		metrics.NewNoopCollector(),
 		connFactory,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -401,7 +401,7 @@ func (suite *Suite) TestTransactionExpiredStatusTransition() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -484,7 +484,7 @@ func (suite *Suite) TestTransactionResultUnknown() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -521,7 +521,7 @@ func (suite *Suite) TestGetLatestFinalizedBlock() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -642,7 +642,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
-			100,
+			DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -668,7 +668,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			metrics.NewNoopCollector(),
 			connFactory, // the connection factory should be used to get the execution node client
 			false,
-			100,
+			DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -696,7 +696,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			metrics.NewNoopCollector(),
 			connFactory, // the connection factory should be used to get the execution node client
 			false,
-			100,
+			DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -798,7 +798,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
-			100,
+			DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -831,7 +831,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
-			100,
+			DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -863,7 +863,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
-			100,
+			DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -925,7 +925,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
-			100,
+			DefaultMaxHeightRange,
 			nil,
 			suite.log,
 		)
@@ -993,7 +993,7 @@ func (suite *Suite) TestGetAccount() {
 		metrics.NewNoopCollector(),
 		connFactory,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -1060,7 +1060,7 @@ func (suite *Suite) TestGetAccountAtBlockHeight() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -1085,7 +1085,7 @@ func (suite *Suite) TestGetNetworkParameters() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -87,6 +87,7 @@ func (suite *Suite) TestPing() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -110,6 +111,7 @@ func (suite *Suite) TestGetLatestFinalizedBlockHeader() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -139,6 +141,7 @@ func (suite *Suite) TestGetLatestSealedBlockHeader() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -173,6 +176,7 @@ func (suite *Suite) TestGetTransaction() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -203,6 +207,7 @@ func (suite *Suite) TestGetCollection() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -282,6 +287,7 @@ func (suite *Suite) TestTransactionStatusTransition() {
 		metrics.NewNoopCollector(),
 		connFactory,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -395,6 +401,7 @@ func (suite *Suite) TestTransactionExpiredStatusTransition() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -477,6 +484,7 @@ func (suite *Suite) TestTransactionResultUnknown() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -513,6 +521,7 @@ func (suite *Suite) TestGetLatestFinalizedBlock() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -633,6 +642,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -658,6 +668,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			metrics.NewNoopCollector(),
 			connFactory, // the connection factory should be used to get the execution node client
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -685,6 +696,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			metrics.NewNoopCollector(),
 			connFactory, // the connection factory should be used to get the execution node client
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -786,6 +798,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -818,6 +831,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -849,6 +863,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -882,6 +897,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			metrics.NewNoopCollector(),
 			nil,
 			false,
+			100,
 			nil,
 			suite.log,
 		)
@@ -949,6 +965,7 @@ func (suite *Suite) TestGetAccount() {
 		metrics.NewNoopCollector(),
 		connFactory,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -1015,6 +1032,7 @@ func (suite *Suite) TestGetAccountAtBlockHeight() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -1039,6 +1057,7 @@ func (suite *Suite) TestGetNetworkParameters() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)

--- a/engine/access/rpc/backend/historical_access_test.go
+++ b/engine/access/rpc/backend/historical_access_test.go
@@ -51,6 +51,7 @@ func (suite *Suite) TestHistoricalTransactionResult() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)
@@ -106,6 +107,7 @@ func (suite *Suite) TestHistoricalTransaction() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
+		100,
 		nil,
 		suite.log,
 	)

--- a/engine/access/rpc/backend/historical_access_test.go
+++ b/engine/access/rpc/backend/historical_access_test.go
@@ -51,7 +51,7 @@ func (suite *Suite) TestHistoricalTransactionResult() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)
@@ -107,7 +107,7 @@ func (suite *Suite) TestHistoricalTransaction() {
 		metrics.NewNoopCollector(),
 		nil,
 		false,
-		100,
+		DefaultMaxHeightRange,
 		nil,
 		suite.log,
 	)

--- a/engine/access/rpc/backend/retry_test.go
+++ b/engine/access/rpc/backend/retry_test.go
@@ -42,7 +42,7 @@ func (suite *Suite) TestTransactionRetry() {
 	// Setup Handler + Retry
 	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
 		suite.collections, suite.transactions, suite.receipts, suite.chainID, metrics.NewNoopCollector(), nil,
-		false, nil, suite.log)
+		false, 100, nil, suite.log)
 	retry := newRetry().SetBackend(backend).Activate()
 	backend.retry = retry
 
@@ -105,7 +105,7 @@ func (suite *Suite) TestSuccessfulTransactionsDontRetry() {
 	// Setup Handler + Retry
 	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
 		suite.collections, suite.transactions, suite.receipts, suite.chainID, metrics.NewNoopCollector(), nil,
-		false, nil, suite.log)
+		false, 100, nil, suite.log)
 	retry := newRetry().SetBackend(backend).Activate()
 	backend.retry = retry
 

--- a/engine/access/rpc/backend/retry_test.go
+++ b/engine/access/rpc/backend/retry_test.go
@@ -42,7 +42,7 @@ func (suite *Suite) TestTransactionRetry() {
 	// Setup Handler + Retry
 	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
 		suite.collections, suite.transactions, suite.receipts, suite.chainID, metrics.NewNoopCollector(), nil,
-		false, 100, nil, suite.log)
+		false, DefaultMaxHeightRange, nil, suite.log)
 	retry := newRetry().SetBackend(backend).Activate()
 	backend.retry = retry
 
@@ -105,7 +105,7 @@ func (suite *Suite) TestSuccessfulTransactionsDontRetry() {
 	// Setup Handler + Retry
 	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
 		suite.collections, suite.transactions, suite.receipts, suite.chainID, metrics.NewNoopCollector(), nil,
-		false, 100, nil, suite.log)
+		false, DefaultMaxHeightRange, nil, suite.log)
 	retry := newRetry().SetBackend(backend).Activate()
 	backend.retry = retry
 

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -36,6 +36,7 @@ type Config struct {
 	MaxMsgSize                int           // GRPC max message size
 	ExecutionClientTimeout    time.Duration // execution API GRPC client timeout
 	CollectionClientTimeout   time.Duration // collection API GRPC client timeout
+	MaxHeightRange            uint          // max size of height range requests
 	PreferredExecutionNodeIDs []string      // preferred list of upstream execution node IDs
 
 }
@@ -133,6 +134,7 @@ func New(log zerolog.Logger,
 		transactionMetrics,
 		connectionFactory,
 		retryEnabled,
+		config.MaxHeightRange,
 		config.PreferredExecutionNodeIDs,
 		log,
 	)


### PR DESCRIPTION
* Add configurable maximum size for range requests
* Retrieve headers rather than full blocks from storage while fulfilling GetEvents requests
  * Really we only need to ID, but are retrieving the entire block + payload. Changing to retrieve the header is quite simple, we could also enhance this to just lookup the height->ID index, which is happening anywhere here under the hood