### PR TITLE
Fix frozen account crashing FVM

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/event"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
@@ -112,7 +113,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			Run(func(args mock.Arguments) {
 				tx := args[1].(*fvm.TransactionProcedure)
 
-				tx.Err = &fvm.MissingPayerError{}
+				tx.Err = &errors.MissingPayerError{}
 				// create dummy events
 				tx.Events = generateEvents(eventsPerTransaction, tx.TxIndex)
 			}).

--- a/fvm/account.go
+++ b/fvm/account.go
@@ -8,6 +8,7 @@ import (
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
 
+	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -25,7 +26,7 @@ func getAccount(
 	account, err := accounts.Get(address)
 	if err != nil {
 		if errors.Is(err, state.ErrAccountNotFound) {
-			return nil, ErrAccountNotFound
+			return nil, fvmErrors.ErrAccountNotFound
 		}
 
 		return nil, err

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -118,6 +118,14 @@ func WithGasLimit(limit uint64) Option {
 	}
 }
 
+// WithSignatureVerifier sets the signature verifier
+func WithSignatureVerifier(verifier SignatureVerifier) Option {
+	return func(ctx Context) Context {
+		ctx.SignatureVerifier = verifier
+		return ctx
+	}
+}
+
 // WithMaxStateKeySize sets the byte size limit for ledger keys
 func WithMaxStateKeySize(limit uint64) Option {
 	return func(ctx Context) Context {

--- a/fvm/crypto.go
+++ b/fvm/crypto.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -35,7 +36,7 @@ func (DefaultSignatureVerifier) Verify(
 ) (bool, error) {
 	hasher := newHasher(hashAlgo)
 	if hasher == nil {
-		return false, ErrInvalidHashAlgorithm
+		return false, errors.ErrInvalidHashAlgorithm
 	}
 
 	message = append(tag, message...)

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	traceLog "github.com/opentracing/opentracing-go/log"
 
+	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	fvmEvent "github.com/onflow/flow-go/fvm/event"
 	"github.com/onflow/flow-go/fvm/handler"
 	"github.com/onflow/flow-go/fvm/programs"
@@ -411,7 +412,7 @@ func (e *hostEnv) EmitEvent(event cadence.Event) error {
 	// skip limit if payer is service account
 	if e.transactionEnv.tx.Payer != e.ctx.Chain.ServiceAddress() {
 		if e.totalEventByteSize > e.ctx.EventCollectionByteSizeLimit {
-			return &EventLimitExceededError{
+			return &fvmErrors.EventLimitExceededError{
 				TotalByteSize: e.totalEventByteSize,
 				Limit:         e.ctx.EventCollectionByteSizeLimit,
 			}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/errors"
 	fvmmock "github.com/onflow/flow-go/fvm/mock"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
@@ -380,7 +381,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		assert.Error(t, tx.Err)
 
 		assert.Contains(t, tx.Err.Error(), "code deployment requires authorization from specific accounts")
-		assert.Equal(t, (&fvm.ExecutionError{}).Code(), tx.Err.Code())
+		assert.Equal(t, (&errors.ExecutionError{}).Code(), tx.Err.Code())
 	})
 
 	t.Run("account update with set code fails if not signed by service account", func(t *testing.T) {
@@ -407,7 +408,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		assert.Error(t, tx.Err)
 
 		assert.Contains(t, tx.Err.Error(), "code deployment requires authorization from specific accounts")
-		assert.Equal(t, (&fvm.ExecutionError{}).Code(), tx.Err.Code())
+		assert.Equal(t, (&errors.ExecutionError{}).Code(), tx.Err.Code())
 	})
 }
 
@@ -649,7 +650,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
 
-				assert.Equal(t, (&fvm.StorageCapacityExceededError{}).Code(), tx.Err.Code())
+				assert.Equal(t, (&errors.StorageCapacityExceededError{}).Code(), tx.Err.Code())
 			}))
 	t.Run("Increasing storage capacity works", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		run(
@@ -1055,7 +1056,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 
 		var account *flow.Account
 		account, err = vm.GetAccount(ctx, address, ledger, programs)
-		assert.Equal(t, fvm.ErrAccountNotFound, err)
+		assert.Equal(t, errors.ErrAccountNotFound, err)
 		assert.Nil(t, account)
 	})
 }
@@ -1718,7 +1719,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 
-			require.Equal(t, (&fvm.StorageCapacityExceededError{}).Code(), tx.Err.Code())
+			require.Equal(t, (&errors.StorageCapacityExceededError{}).Code(), tx.Err.Code())
 
 			balanceAfter := getBalance(vm, chain, ctx, view, accounts[0])
 
@@ -1761,7 +1762,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
 
-				require.IsType(t, &fvm.ExecutionError{}, tx.Err)
+				require.IsType(t, &errors.ExecutionError{}, tx.Err)
 
 				// send it again
 				tx = fvm.Transaction(txBody, 0)
@@ -1769,8 +1770,8 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
 
-				require.Equal(t, (&fvm.InvalidProposalKeySequenceNumberError{}).Code(), tx.Err.Code())
-				require.Equal(t, uint64(1), tx.Err.(*fvm.InvalidProposalKeySequenceNumberError).CurrentSeqNumber)
+				require.Equal(t, (&errors.InvalidProposalKeySequenceNumberError{}).Code(), tx.Err.Code())
+				require.Equal(t, uint64(1), tx.Err.(*errors.InvalidProposalKeySequenceNumberError).CurrentSeqNumber)
 			}),
 	)
 }

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -5,6 +5,7 @@ import (
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -29,7 +30,7 @@ type ScriptProcedure struct {
 	Events    []flow.Event
 	// TODO: report gas consumption: https://github.com/dapperlabs/flow-go/issues/4139
 	GasUsed uint64
-	Err     Error
+	Err     errors.Error
 }
 
 type ScriptProcessor interface {

--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
+	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -31,14 +32,6 @@ var (
 	ErrAccountNotFound          = errors.New("account not found")
 	ErrAccountPublicKeyNotFound = errors.New("account public key not found")
 )
-
-type AccountFrozenError struct {
-	Address flow.Address
-}
-
-func (e *AccountFrozenError) Error() string {
-	return fmt.Sprintf("account %s is frozen", e.Address)
-}
 
 func keyPublicKey(index uint64) string {
 	return fmt.Sprintf("public_key_%d", index)
@@ -593,7 +586,7 @@ func (a *Accounts) CheckAccountNotFrozen(address flow.Address) error {
 		return fmt.Errorf("cannot check acount freeze status: %w", err)
 	}
 	if frozen {
-		return &AccountFrozenError{Address: address}
+		return &fvmErrors.AccountFrozenError{Address: address}
 	}
 	return nil
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -16,6 +16,7 @@ import (
 	traceLog "github.com/opentracing/opentracing-go/log"
 	"github.com/rs/zerolog"
 
+	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/extralog"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
@@ -44,7 +45,7 @@ type TransactionProcedure struct {
 	ServiceEvents []flow.Event
 	// TODO: report gas consumption: https://github.com/dapperlabs/flow-go/issues/4139
 	GasUsed   uint64
-	Err       Error
+	Err       fvmErrors.Error
 	Retried   int
 	TraceSpan opentracing.Span
 }
@@ -173,7 +174,7 @@ func (i *TransactionInvocator) Process(
 
 			// drop delta
 			childState.View().DropDelta()
-			proc.Err = &FVMInternalError{msg}
+			proc.Err = &fvmErrors.FVMInternalError{msg}
 			proc.Logs = make([]string, 0)
 			proc.Events = make([]flow.Event, 0)
 			proc.ServiceEvents = make([]flow.Event, 0)

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -174,7 +174,7 @@ func (i *TransactionInvocator) Process(
 
 			// drop delta
 			childState.View().DropDelta()
-			proc.Err = &fvmErrors.FVMInternalError{msg}
+			proc.Err = &fvmErrors.FVMInternalError{Msg: msg}
 			proc.Logs = make([]string, 0)
 			proc.Events = make([]flow.Event, 0)
 			proc.ServiceEvents = make([]flow.Event, 0)

--- a/fvm/transactionAccountFrozen.go
+++ b/fvm/transactionAccountFrozen.go
@@ -1,8 +1,6 @@
 package fvm
 
 import (
-	"fmt"
-
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -34,18 +32,18 @@ func (c *TransactionAccountFrozenChecker) checkAccountNotFrozen(
 	for _, authorizer := range tx.Authorizers {
 		err := accounts.CheckAccountNotFrozen(authorizer)
 		if err != nil {
-			return fmt.Errorf("check account not frozen authorizer: %w", err)
+			return err
 		}
 	}
 
 	err := accounts.CheckAccountNotFrozen(tx.ProposalKey.Address)
 	if err != nil {
-		return fmt.Errorf("check account not frozen proposal: %w", err)
+		return err
 	}
 
 	err = accounts.CheckAccountNotFrozen(tx.Payer)
 	if err != nil {
-		return fmt.Errorf("check account not frozen payer: %w", err)
+		return err
 	}
 
 	return nil

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/log"
 
+	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/module/trace"
@@ -56,7 +57,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	accountKey, err := accounts.GetPublicKey(proposalKey.Address, proposalKey.KeyIndex)
 	if err != nil {
 		if errors.Is(err, state.ErrAccountPublicKeyNotFound) {
-			return &InvalidProposalKeyPublicKeyDoesNotExistError{
+			return &fvmErrors.InvalidProposalKeyPublicKeyDoesNotExistError{
 				Address:  proposalKey.Address,
 				KeyIndex: proposalKey.KeyIndex,
 			}
@@ -66,7 +67,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	}
 
 	if accountKey.Revoked {
-		return &InvalidProposalKeyPublicKeyRevokedError{
+		return &fvmErrors.InvalidProposalKeyPublicKeyRevokedError{
 			Address:  proposalKey.Address,
 			KeyIndex: proposalKey.KeyIndex,
 		}
@@ -75,7 +76,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	valid := accountKey.SeqNumber == proposalKey.SequenceNumber
 
 	if !valid {
-		return &InvalidProposalKeySequenceNumberError{
+		return &fvmErrors.InvalidProposalKeySequenceNumberError{
 			Address:           proposalKey.Address,
 			KeyIndex:          proposalKey.KeyIndex,
 			CurrentSeqNumber:  accountKey.SeqNumber,

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -3,6 +3,7 @@ package fvm
 import (
 	"github.com/onflow/cadence/runtime/common"
 
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 )
@@ -81,7 +82,7 @@ func (d *TransactionStorageLimiter) Process(
 		}
 
 		if usage > capacity {
-			return &StorageCapacityExceededError{
+			return &errors.StorageCapacityExceededError{
 				Address:         address,
 				StorageUsed:     usage,
 				StorageCapacity: capacity,

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -98,12 +98,12 @@ func (v *TransactionSignatureVerifier) verifyTransactionSignatures(
 		}
 
 		if !v.hasSufficientKeyWeight(payloadWeights, addr) {
-			return &fvmErrors.MissingSignatureError{addr}
+			return &fvmErrors.MissingSignatureError{Address: addr}
 		}
 	}
 
 	if !v.hasSufficientKeyWeight(envelopeWeights, tx.Payer) {
-		return &fvmErrors.MissingSignatureError{tx.Payer}
+		return &fvmErrors.MissingSignatureError{Address: tx.Payer}
 	}
 
 	return nil

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 
 	executionState "github.com/onflow/flow-go/engine/execution/state"
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 
 	"github.com/stretchr/testify/assert"
@@ -281,7 +282,7 @@ func (vm *vmMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, progr
 	case "failedTx":
 		// add updates to the ledger
 		_ = led.Set("00", "", "", []byte{'F'})
-		tx.Err = &fvm.MissingPayerError{} // inside the runtime (e.g. div by zero, access account)
+		tx.Err = &errors.MissingPayerError{} // inside the runtime (e.g. div by zero, access account)
 	default:
 		_, _ = led.Get("00", "", "")
 		_, _ = led.Get("05", "", "")


### PR DESCRIPTION
Main reason was that `AccountFrozenError` was not a `fvm.Error` which means it's not handled properly by `VirtualMachine`.
However, to properly make this error a good implementation of `fvm.Error` I had to move `fvm/errors` to separate package to avoid circular dependencies.
Also, removed wrapping of this error in handler.

Added tests which reproduce the problem.

There is upcoming complete re-work of errors handling in FVM, so this solution is semi-temporary I think