### PR TITLE
Avoid retrieving headers from DB in event queries

### DIFF
--- a/model/flow/identifier.go
+++ b/model/flow/identifier.go
@@ -39,6 +39,14 @@ func HexStringToIdentifier(hexString string) (Identifier, error) {
 	return identifier, nil
 }
 
+// BytesToIdentifier converts a byte slice to an identifier. The byte slice must
+// contain exactly 32 bytes.
+func BytesToIdentifier(bytes []byte) Identifier {
+	var id Identifier
+	copy(id[:], bytes)
+	return id
+}
+
 // String returns the hex string representation of the identifier.
 func (id Identifier) String() string {
 	return hex.EncodeToString(id[:])

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -108,6 +108,17 @@ func (h *Headers) ByHeight(height uint64) (*flow.Header, error) {
 	return h.ByBlockID(blockID.(flow.Identifier))
 }
 
+func (h *Headers) IDByHeight(height uint64) (flow.Identifier, error) {
+	tx := h.db.NewTransaction(false)
+	defer tx.Discard()
+
+	blockID, err := h.heightCache.Get(height)(tx)
+	if err != nil {
+		return flow.ZeroID, fmt.Errorf("could not get id by height: %w", err)
+	}
+	return blockID.(flow.Identifier), nil
+}
+
 func (h *Headers) ByParentID(parentID flow.Identifier) ([]*flow.Header, error) {
 	var blockIDs []flow.Identifier
 	err := h.db.View(procedure.LookupBlockChildren(parentID, &blockIDs))

--- a/storage/headers.go
+++ b/storage/headers.go
@@ -20,6 +20,10 @@ type Headers interface {
 	// for finalized blocks.
 	ByHeight(height uint64) (*flow.Header, error)
 
+	// IDByHeight returns the ID of the block header with the given height. It
+	// is only available for finalized blocks.
+	IDByHeight(height uint64) (flow.Identifier, error)
+
 	// Find all children for the given parent block. The returned headers might
 	// be unfinalized; if there is more than one, at least one of them has to
 	// be unfinalized.

--- a/storage/mock/headers.go
+++ b/storage/mock/headers.go
@@ -81,6 +81,29 @@ func (_m *Headers) ByParentID(parentID flow.Identifier) ([]*flow.Header, error) 
 	return r0, r1
 }
 
+// IDByHeight provides a mock function with given fields: height
+func (_m *Headers) IDByHeight(height uint64) (flow.Identifier, error) {
+	ret := _m.Called(height)
+
+	var r0 flow.Identifier
+	if rf, ok := ret.Get(0).(func(uint64) flow.Identifier); ok {
+		r0 = rf(height)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(flow.Identifier)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(uint64) error); ok {
+		r1 = rf(height)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Store provides a mock function with given fields: header
 func (_m *Headers) Store(header *flow.Header) error {
 	ret := _m.Called(header)


### PR DESCRIPTION
We can _almost_ avoid needing to retrieve and decode full headers, which causes significant performance penalties for non-cache-friendly event range queries. The only thing we are missing is block timestamps, which are only accessible by retrieving the full header. Maybe we could include these in the EN response if the EN is retrieving the header anyway, change the API to not include this field for events, or add a more efficient index for this field if it is necessary to include in this API. 