### PR TITLE
Skip sending chunk data pack requests

### DIFF
--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -36,7 +36,7 @@ const (
 	// requestInterval represents the time interval in milliseconds that the
 	// match engine retries sending resource requests to the network
 	// this value is set following this issue (3443)
-	requestInterval = 1000 * time.Millisecond
+	requestInterval = 30 * time.Second
 
 	// processInterval represents the time interval in milliseconds that the
 	// finder engine iterates over the execution receipts ready to process

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -350,6 +350,15 @@ func (e *Engine) requestChunkDataPack(c *ChunkStatus, allExecutors flow.Identity
 
 	targetIDs := chooseChunkDataPackTarget(allExecutors, c.Agrees, c.Disagrees)
 
+	// TEMP: skip sending chunk data pack requests to avoid overloading ENs
+	// This is OK because RAs are not yet used in the sealing process.
+	e.log.Warn().
+		Hex("block_id", c.Chunk.BlockID[:]).
+		Uint64("chunk_index", c.Chunk.Index).
+		Msg("skipping sending chunk data pack request")
+
+	return nil
+
 	// publishes the chunk data request to the network
 	err := e.con.Publish(req, targetIDs...)
 	if err != nil {

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -350,15 +350,6 @@ func (e *Engine) requestChunkDataPack(c *ChunkStatus, allExecutors flow.Identity
 
 	targetIDs := chooseChunkDataPackTarget(allExecutors, c.Agrees, c.Disagrees)
 
-	// TEMP: skip sending chunk data pack requests to avoid overloading ENs
-	// This is OK because RAs are not yet used in the sealing process.
-	e.log.Warn().
-		Hex("block_id", c.Chunk.BlockID[:]).
-		Uint64("chunk_index", c.Chunk.Index).
-		Msg("skipping sending chunk data pack request")
-
-	return nil
-
 	// publishes the chunk data request to the network
 	err := e.con.Publish(req, targetIDs...)
 	if err != nil {

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -425,6 +425,15 @@ func (e *Engine) requestChunkDataPack(c *ChunkStatus) error {
 		targetIDs = append(targetIDs, other)
 	}
 
+	// TEMP: skip sending chunk data pack requests to avoid overloading ENs
+	// This is OK because RAs are not yet used in the sealing process.
+	e.log.Warn().
+		Hex("block_id", c.Chunk.BlockID[:]).
+		Uint64("chunk_index", c.Chunk.Index).
+		Msg("skipping sending chunk data pack request")
+
+	return nil
+
 	// publishes the chunk data request to the network
 	err = e.con.Publish(req, targetIDs...)
 	if err != nil {


### PR DESCRIPTION
* do not send CHDP requests in `match` or `fetcher` engine
* change retry interval to 30s from 1s