### PR TITLE
Change storage defaults

### DIFF
--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -142,7 +142,7 @@ func finalize(cmd *cobra.Command, args []string) {
 			fvm.WithInitialTokenSupply(value),
 			fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
 			fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
-			fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
+			fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 		)
 		if err != nil {
 			log.Fatal().Err(err).Msg("unable to generate execution state")

--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -141,7 +141,9 @@ func finalize(cmd *cobra.Command, args []string) {
 			parseChainID(flagRootChain).Chain(),
 			fvm.WithInitialTokenSupply(value),
 			fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
-			fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee))
+			fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
+			fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
+		)
 		if err != nil {
 			log.Fatal().Err(err).Msg("unable to generate execution state")
 		}

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -47,7 +47,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	var expectedStateCommitment, _ = hex.DecodeString("8e16c6bb5a42a4bcbd01d156c7d6f4b4cd2f37bcd2bdf5779338b2d9585eaab5")
+	var expectedStateCommitment, _ = hex.DecodeString("c2ad3d6736613e181a25e6e5b281f62217df17c9194e1dd3e9a736a74c816911")
 
 	unittest.RunWithTempDir(t, func(dbDir string) {
 

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -59,7 +59,7 @@ var DefaultMinimumStorageReservation = func() cadence.UFix64 {
 	return value
 }()
 
-var DefaultStoragePerFlow = func() cadence.UFix64 {
+var DefaultStorageMBPerFLOW = func() cadence.UFix64 {
 	value, err := cadence.NewUFix64("10.00000000")
 	if err != nil {
 		panic(fmt.Errorf("invalid default minimum storage reservation: %w", err))
@@ -98,7 +98,7 @@ func WithMinimumStorageReservation(reservation cadence.UFix64) BootstrapProcedur
 	}
 }
 
-func WithStoragePerFlow(ratio cadence.UFix64) BootstrapProcedureOption {
+func WithStorageMBPerFLOW(ratio cadence.UFix64) BootstrapProcedureOption {
 	return func(bp *BootstrapProcedure) *BootstrapProcedure {
 		bp.storagePerFlow = ratio
 		return bp

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -615,6 +615,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 	bootstrapOptions := []fvm.BootstrapProcedureOption{
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
+		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
 	}
 
 	t.Run("Storing too much data fails", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
@@ -1686,6 +1687,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 	t.Run("Transaction fails because of storage", newVMTest().withBootstrapProcedureOptions(
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
+		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
 	).run(
 		func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
 			ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
@@ -1730,6 +1732,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 	t.Run("Transaction fails but sequence number is incremented", newVMTest().withBootstrapProcedureOptions(
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
+		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
 	).
 		run(
 			func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -615,7 +615,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 	bootstrapOptions := []fvm.BootstrapProcedureOption{
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
-		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
+		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 	}
 
 	t.Run("Storing too much data fails", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
@@ -1687,7 +1687,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 	t.Run("Transaction fails because of storage", newVMTest().withBootstrapProcedureOptions(
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
-		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
+		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 	).run(
 		func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
 			ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
@@ -1732,7 +1732,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 	t.Run("Transaction fails but sequence number is incremented", newVMTest().withBootstrapProcedureOptions(
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
-		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
+		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 	).
 		run(
 			func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -604,7 +604,7 @@ func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string) (*flow.Blo
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply),
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
-		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
+		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -604,6 +604,7 @@ func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string) (*flow.Blo
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply),
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
+		fvm.WithStoragePerFlow(fvm.DefaultStoragePerFlow),
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -19,7 +19,7 @@ import (
 const ServiceAccountPrivateKeyHex = "e3a08ae3d0461cfed6d6f49bfc25fa899351c39d1bd21fdba8c87595b6c49bb4cc430201"
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "1abd0d7da12fbae71913d0280d2b100acf73cf3ac4ae37be8a65384a521219d8"
+const GenesisStateCommitmentHex = "344eb8ba50c683c1d9d5662afb8800f641518bc8349bf2427cb919e7f7a95edb"
 
 var GenesisStateCommitment flow.StateCommitment
 


### PR DESCRIPTION
Change the storage parameters defaults to what was originally deployed.

- minimum account balance        =  0.001 FLOW
- Storage megabytes per FLOW  =  10.0

Also made it possible to set any `Storage megabytes per FLOW` on the bootstrap level.