### PR TITLE
Require resource name to create cache

### DIFF
--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -74,6 +74,7 @@ const (
 	ResourceBlockVoteQueue           = "compliance_vote_queue"            // consensus node, compliance engine
 	ResourceChunkDataPack            = "chunk_data_pack"                  // execution node
 	ResourceEvents                   = "events"                           // execution node
+	ResourceServiceEvents            = "service_events"                   // execution node
 	ResourceTransactionResults       = "transaction_results"              // execution node
 )
 

--- a/storage/badger/approvals.go
+++ b/storage/badger/approvals.go
@@ -37,11 +37,10 @@ func NewResultApprovals(collector module.CacheMetrics, db *badger.DB) *ResultApp
 
 	res := &ResultApprovals{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceResult,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceResult)),
+			withRetrieve(retrieve)),
 	}
 
 	return res

--- a/storage/badger/cache.go
+++ b/storage/badger/cache.go
@@ -7,7 +7,6 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/onflow/flow-go/module"
-	"github.com/onflow/flow-go/module/metrics"
 )
 
 func withLimit(limit uint) func(*Cache) {
@@ -50,12 +49,6 @@ func noRetrieve(key interface{}) func(*badger.Txn) (interface{}, error) {
 	}
 }
 
-func withResource(resource string) func(*Cache) {
-	return func(c *Cache) {
-		c.resource = resource
-	}
-}
-
 type Cache struct {
 	metrics  module.CacheMetrics
 	limit    uint
@@ -65,13 +58,13 @@ type Cache struct {
 	cache    *lru.Cache
 }
 
-func newCache(collector module.CacheMetrics, options ...func(*Cache)) *Cache {
+func newCache(collector module.CacheMetrics, resourceName string, options ...func(*Cache)) *Cache {
 	c := Cache{
 		metrics:  collector,
 		limit:    1000,
 		store:    noStore,
 		retrieve: noRetrieve,
-		resource: metrics.ResourceUndefined,
+		resource: resourceName,
 	}
 	for _, option := range options {
 		option(&c)

--- a/storage/badger/chunkDataPacks.go
+++ b/storage/badger/chunkDataPacks.go
@@ -34,11 +34,10 @@ func NewChunkDataPacks(collector module.CacheMetrics, db *badger.DB, byChunkIDCa
 		}
 	}
 
-	cache := newCache(collector,
+	cache := newCache(collector, metrics.ResourceChunkDataPack,
 		withLimit(byChunkIDCacheSize),
 		withStore(store),
 		withRetrieve(retrieve),
-		withResource(metrics.ResourceChunkDataPack),
 	)
 
 	ch := ChunkDataPacks{

--- a/storage/badger/cluster_payloads.go
+++ b/storage/badger/cluster_payloads.go
@@ -37,11 +37,10 @@ func NewClusterPayloads(cacheMetrics module.CacheMetrics, db *badger.DB) *Cluste
 
 	cp := &ClusterPayloads{
 		db: db,
-		cache: newCache(cacheMetrics,
+		cache: newCache(cacheMetrics, metrics.ResourceClusterPayload,
 			withLimit(flow.DefaultTransactionExpiry*4),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceClusterPayload)),
+			withRetrieve(retrieve)),
 	}
 
 	return cp

--- a/storage/badger/commits.go
+++ b/storage/badger/commits.go
@@ -34,11 +34,10 @@ func NewCommits(collector module.CacheMetrics, db *badger.DB) *Commits {
 
 	c := &Commits{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceCommit,
 			withLimit(100),
 			withStore(store),
 			withRetrieve(retrieve),
-			withResource(metrics.ResourceCommit),
 		),
 	}
 

--- a/storage/badger/epoch_commits.go
+++ b/storage/badger/epoch_commits.go
@@ -33,11 +33,10 @@ func NewEpochCommits(collector module.CacheMetrics, db *badger.DB) *EpochCommits
 
 	ec := &EpochCommits{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceEpochCommit,
 			withLimit(4*flow.DefaultTransactionExpiry),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceEpochCommit)),
+			withRetrieve(retrieve)),
 	}
 
 	return ec

--- a/storage/badger/epoch_setups.go
+++ b/storage/badger/epoch_setups.go
@@ -33,11 +33,10 @@ func NewEpochSetups(collector module.CacheMetrics, db *badger.DB) *EpochSetups {
 
 	es := &EpochSetups{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceEpochSetup,
 			withLimit(4*flow.DefaultTransactionExpiry),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceEpochSetup)),
+			withRetrieve(retrieve)),
 	}
 
 	return es

--- a/storage/badger/epoch_statuses.go
+++ b/storage/badger/epoch_statuses.go
@@ -34,11 +34,10 @@ func NewEpochStatuses(collector module.CacheMetrics, db *badger.DB) *EpochStatus
 
 	es := &EpochStatuses{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceEpochStatus,
 			withLimit(4*flow.DefaultTransactionExpiry),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceEpochStatus)),
+			withRetrieve(retrieve)),
 	}
 
 	return es

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -29,10 +29,9 @@ func NewEvents(collector module.CacheMetrics, db *badger.DB) *Events {
 
 	return &Events{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceEvents,
 			withStore(noopStore),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceEvents)),
+			withRetrieve(retrieve)),
 	}
 }
 
@@ -112,7 +111,7 @@ func NewServiceEvents(collector module.CacheMetrics, db *badger.DB) *ServiceEven
 
 	return &ServiceEvents{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceEvents,
 			withStore(noopStore),
 			withRetrieve(retrieve)),
 	}

--- a/storage/badger/guarantees.go
+++ b/storage/badger/guarantees.go
@@ -34,11 +34,10 @@ func NewGuarantees(collector module.CacheMetrics, db *badger.DB) *Guarantees {
 
 	g := &Guarantees{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceGuarantee,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceGuarantee)),
+			withRetrieve(retrieve)),
 	}
 
 	return g

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -74,22 +74,19 @@ func NewHeaders(collector module.CacheMetrics, db *badger.DB) *Headers {
 
 	h := &Headers{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceHeader,
 			withLimit(4*flow.DefaultTransactionExpiry),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceHeader)),
+			withRetrieve(retrieve)),
 
-		heightCache: newCache(collector,
+		heightCache: newCache(collector, metrics.ResourceFinalizedHeight,
 			withLimit(4*flow.DefaultTransactionExpiry),
 			withStore(storeHeight),
-			withRetrieve(retrieveHeight),
-			withResource(metrics.ResourceFinalizedHeight)),
-		chunkIDCache: newCache(collector,
+			withRetrieve(retrieveHeight)),
+		chunkIDCache: newCache(collector, metrics.ResourceFinalizedHeight,
 			withLimit(4*flow.DefaultTransactionExpiry),
 			withStore(storeChunkID),
-			withRetrieve(retrieveChunkID),
-			withResource(metrics.ResourceFinalizedHeight)),
+			withRetrieve(retrieveChunkID)),
 	}
 
 	return h

--- a/storage/badger/index.go
+++ b/storage/badger/index.go
@@ -37,11 +37,10 @@ func NewIndex(collector module.CacheMetrics, db *badger.DB) *Index {
 
 	p := &Index{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceIndex,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceIndex)),
+			withRetrieve(retrieve)),
 	}
 
 	return p

--- a/storage/badger/my_receipts.go
+++ b/storage/badger/my_receipts.go
@@ -87,11 +87,10 @@ func NewMyExecutionReceipts(collector module.CacheMetrics, db *badger.DB, receip
 	return &MyExecutionReceipts{
 		genericReceipts: receipts,
 		db:              db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceMyReceipt,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceMyReceipt)),
+			withRetrieve(retrieve)),
 	}
 }
 

--- a/storage/badger/receipts.go
+++ b/storage/badger/receipts.go
@@ -72,11 +72,10 @@ func NewExecutionReceipts(collector module.CacheMetrics, db *badger.DB, results 
 	return &ExecutionReceipts{
 		db:      db,
 		results: results,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceReceipt,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceReceipt)),
+			withRetrieve(retrieve)),
 	}
 }
 

--- a/storage/badger/results.go
+++ b/storage/badger/results.go
@@ -37,11 +37,10 @@ func NewExecutionResults(collector module.CacheMetrics, db *badger.DB) *Executio
 
 	res := &ExecutionResults{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceResult,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceResult)),
+			withRetrieve(retrieve)),
 	}
 
 	return res

--- a/storage/badger/seals.go
+++ b/storage/badger/seals.go
@@ -37,11 +37,10 @@ func NewSeals(collector module.CacheMetrics, db *badger.DB) *Seals {
 
 	s := &Seals{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceSeal,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceSeal)),
+			withRetrieve(retrieve)),
 	}
 
 	return s

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -56,11 +56,10 @@ func NewTransactionResults(collector module.CacheMetrics, db *badger.DB, transac
 	}
 	return &TransactionResults{
 		db: db,
-		cache: newCache(collector,
+		cache: newCache(collector, metrics.ResourceTransactionResults,
 			withLimit(transactionResultsCacheSize),
 			withStore(noopStore),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceTransactionResults)),
+			withRetrieve(retrieve)),
 	}
 }
 

--- a/storage/badger/transactions.go
+++ b/storage/badger/transactions.go
@@ -34,11 +34,10 @@ func NewTransactions(cacheMetrics module.CacheMetrics, db *badger.DB) *Transacti
 
 	t := &Transactions{
 		db: db,
-		cache: newCache(cacheMetrics,
+		cache: newCache(cacheMetrics, metrics.ResourceTransaction,
 			withLimit(flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve),
-			withResource(metrics.ResourceTransaction)),
+			withRetrieve(retrieve)),
 	}
 
 	return t


### PR DESCRIPTION
We rather need a name for every cache instance, so make it mandatory