### PR TITLE
Update Access Nodes' EN selection logic for the default case

### DIFF
--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -337,6 +337,12 @@ func chooseExecutionNodes(state protocol.State, executorIDs flow.IdentifierList)
 		return nil, fmt.Errorf("failed to retreive all execution IDs: %w", err)
 	}
 
+	// If there are no preferred or fixed ENs, have the default behaviour be that
+	// we just return all the executor IDs, i.e. no preferrence at all.
+	if len(preferredENIdentifiers) == 0 && len(fixedENIdentifiers) == 0 {
+		return allENs.Filter(filter.HasNodeID(executorIDs...)), nil
+	}
+
 	// find the preferred execution node IDs which have executed the transaction
 	preferredENIDs := allENs.Filter(filter.And(filter.HasNodeID(preferredENIdentifiers...),
 		filter.HasNodeID(executorIDs...)))

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -1359,12 +1359,18 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 		if expectedENs == nil {
 			expectedENs = flow.IdentityList{}
 		}
-		require.ElementsMatch(suite.T(), actualList, expectedENs)
+		if len(expectedENs) > maxExecutionNodesCnt {
+			for _, actual := range actualList {
+				require.Contains(suite.T(), expectedENs, actual)
+			}
+		} else {
+			require.ElementsMatch(suite.T(), actualList, expectedENs)
+		}
 	}
 	// if no preferred or fixed ENs are specified, the ExecutionNodesForBlockID function should
-	// return an empty list
+	// return the exe node list without a filter
 	suite.Run("no preferred or fixed ENs", func() {
-		testExecutionNodesForBlockID(nil, nil, nil)
+		testExecutionNodesForBlockID(nil, nil, allExecutionNodes)
 	})
 	// if only preferred ENs are specified, the ExecutionNodesForBlockID function should
 	// return the preferred ENs list


### PR DESCRIPTION
Currently, the default behaviour of ANs is that if no Preferred and Fix ENs are provided, it will ALWAYS ask only the default EN. This is undesirable behaviour, as we want the default case to be that the AN will talk to ALL ENs if they happen to be one of the first ENs to produce the result.

This changes the default behaviour so that if no filters are provided, instead of returning an empty list, we return the non-filtered list.