### PR TITLE
[Verification] Chunk data request optimization

### DIFF
--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -47,9 +47,8 @@ const (
 	// failureThreshold represents the number of retries match engine sends
 	// at `requestInterval` milliseconds for each of the missing resources.
 	// When it reaches the threshold ingest engine makes a missing challenge for the resources.
-	// Currently setting the threshold to a very large value (corresponding to 100 days),
-	// which for all practical purposes is equivalent to the Verifier trying indefinitely.
-	failureThreshold = 10000000
+	// This value is currently set to account for a single 24-hour failure of an Execution node.
+	failureThreshold = 17500
 )
 
 func main() {

--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -37,7 +37,7 @@ const (
 	// requestInterval represents the time interval in milliseconds that the
 	// match engine retries sending resource requests to the network
 	// this value is set following this issue (3443)
-	requestInterval = 1000 * time.Millisecond
+	requestInterval = 5000 * time.Millisecond
 
 	// processInterval represents the time interval in milliseconds that the
 	// finder engine iterates over the execution receipts ready to process

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -395,7 +395,7 @@ func (e *Engine) onTimer() {
 
 }
 
-// requestChunkDataPack request the chunk data pack from the execution node.
+// requestChunkDataPack request the chunk data pack from the original execution node that executed the chunk.
 // the chunk data pack includes the collection and state commitments that
 // needed to make a VerifiableChunk
 func (e *Engine) requestChunkDataPack(c *ChunkStatus) error {
@@ -407,10 +407,8 @@ func (e *Engine) requestChunkDataPack(c *ChunkStatus) error {
 		Nonce:   rand.Uint64(), // prevent the request from being deduplicated by the receiver
 	}
 
-	targetIDs := []flow.Identifier{c.ExecutorID}
-
 	// publishes the chunk data request to the network
-	err := e.con.Publish(req, targetIDs...)
+	err := e.con.Publish(req, c.ExecutorID)
 	if err != nil {
 		return fmt.Errorf("could not publish chunk data pack request for chunk (id=%s): %w", chunkID, err)
 	}

--- a/engine/verification/match/engine.go
+++ b/engine/verification/match/engine.go
@@ -14,7 +14,6 @@ import (
 	"github.com/onflow/flow-go/engine/verification"
 	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/messages"
 	vermodel "github.com/onflow/flow-go/model/verification"
 	"github.com/onflow/flow-go/module"
@@ -397,7 +396,7 @@ func (e *Engine) onTimer() {
 }
 
 // requestChunkDataPack request the chunk data pack from the execution node.
-// the chunk data pack includes the collection and statecommitments that
+// the chunk data pack includes the collection and state commitments that
 // needed to make a VerifiableChunk
 func (e *Engine) requestChunkDataPack(c *ChunkStatus) error {
 	chunkID := c.ID()
@@ -408,25 +407,10 @@ func (e *Engine) requestChunkDataPack(c *ChunkStatus) error {
 		Nonce:   rand.Uint64(), // prevent the request from being deduplicated by the receiver
 	}
 
-	// find other execution nodes
-	others, err := e.state.Final().
-		Identities(filter.And(
-			filter.HasRole(flow.RoleExecution),
-			filter.Not(filter.HasNodeID(c.ExecutorID, e.me.NodeID()))))
-	if err != nil {
-		return fmt.Errorf("could not find other execution nodes identities: %w", err)
-	}
-
 	targetIDs := []flow.Identifier{c.ExecutorID}
 
-	// request chunk data pack from another execution node if exists as backup
-	if len(others) > 0 {
-		other := others.Sample(1).NodeIDs()[0]
-		targetIDs = append(targetIDs, other)
-	}
-
 	// publishes the chunk data request to the network
-	err = e.con.Publish(req, targetIDs...)
+	err := e.con.Publish(req, targetIDs...)
 	if err != nil {
 		return fmt.Errorf("could not publish chunk data pack request for chunk (id=%s): %w", chunkID, err)
 	}

--- a/engine/verification/match/engine_test.go
+++ b/engine/verification/match/engine_test.go
@@ -560,6 +560,10 @@ func (suite *MatchEngineTestSuite) TestRetry() {
 	<-vchunkC
 
 	<-e.Done()
+
+	// pending chunk should be removed from memory once we have the request received.
+	require.Len(suite.T(), suite.chunks.All(), 0)
+
 	mock.AssertExpectationsForObjects(suite.T(),
 		suite.assigner,
 		suite.con,


### PR DESCRIPTION
The PR implements minor optimizations on verification nodes for requesting chunk data from execution nodes. The changes are:
- Verification node only asking chunk data from _original_ executor of the chunk. 
- Bumping up the request intervals from `1s` to `5s` to account for transactions burst at the execution node.
- Limiting the maximum number of retries from literally indefinitely to a day (in case the execution node is failed or down for a long time). 