### PR TITLE
Improve Logging within DKG & Epoch QC Clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,10 @@ name: CI
 
 on:
   push:
-    branches: 
+    branches:
       - master
       - feature/epochs
       - feature/dkg
-      - feature/epochs
   pull_request:
     branches:
       - master
@@ -17,41 +16,41 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-    - name: Build relic
-      run: make crypto/relic/build
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2.3.0
-      with:
-        # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.29
-        args: -v --build-tags relic
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build relic
+        run: make crypto/relic/build
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2.3.0
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.29
+          args: -v --build-tags relic
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.15'
-    - name: Checkout repo
-      uses: actions/checkout@v2
-    - name: Run tests
-      run: make ci
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.15"
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Run tests
+        run: make ci
   integration-test:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.15'
-    - name: Checkout repo
-      uses: actions/checkout@v2
-    - name: Build relic
-      run: make crypto/relic/build
-    - name: Docker build
-      run: make docker-build-flow
-    - name: Run tests
-      run: make ci-integration
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.15"
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build relic
+        run: make crypto/relic/build
+      - name: Docker build
+        run: make docker-build-flow
+      - name: Run tests
+        run: make ci-integration

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -386,15 +386,7 @@ func main() {
 			}
 
 			// loads the private account info for this node from disk for use in the QCContractClient.
-			accountInfo, err := func() (*bootstrap.NodeMachineAccountInfo, error) {
-				data, err := io.ReadFile(filepath.Join(node.BaseConfig.BootstrapDir, fmt.Sprintf(bootstrap.PathNodeMachineAccountInfoPriv, node.Me.NodeID())))
-				if err != nil {
-					return nil, err
-				}
-				var info bootstrap.NodeMachineAccountInfo
-				err = json.Unmarshal(data, &info)
-				return &info, err
-			}()
+			accountInfo, err := loadEpochQCPrivateData(node)
 			if err != nil {
 				return nil, err
 			}
@@ -412,7 +404,7 @@ func main() {
 				return nil, err
 			}
 
-			qcContractClient, err := epochs.NewQCContractClient(flowClient, node.Me.NodeID(), accountInfo.Address, accountInfo.KeyIndex, qcContractAddress, txSigner)
+			qcContractClient, err := epochs.NewQCContractClient(node.Logger, flowClient, node.Me.NodeID(), accountInfo.Address, accountInfo.KeyIndex, qcContractAddress, txSigner)
 			if err != nil {
 				return nil, err
 			}
@@ -457,4 +449,14 @@ func main() {
 			return manager, err
 		}).
 		Run()
+}
+
+func loadEpochQCPrivateData(node *cmd.FlowNodeBuilder) (*bootstrap.NodeMachineAccountInfo, error) {
+	data, err := io.ReadFile(filepath.Join(node.BaseConfig.BootstrapDir, fmt.Sprintf(bootstrap.PathNodeMachineAccountInfoPriv, node.Me.NodeID())))
+	if err != nil {
+		return nil, err
+	}
+	var info bootstrap.NodeMachineAccountInfo
+	err = json.Unmarshal(data, &info)
+	return &info, err
 }

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -404,10 +404,8 @@ func main() {
 				return nil, err
 			}
 
-			qcContractClient, err := epochs.NewQCContractClient(node.Logger, flowClient, node.Me.NodeID(), accountInfo.Address, accountInfo.KeyIndex, qcContractAddress, txSigner)
-			if err != nil {
-				return nil, err
-			}
+			qcContractClient := epochs.NewQCContractClient(node.Logger, flowClient, node.Me.NodeID(),
+				accountInfo.Address, accountInfo.KeyIndex, qcContractAddress, txSigner)
 
 			rootQCVoter := epochs.NewRootQCVoter(
 				node.Logger,

--- a/integration/epochs/epoch_qc_test.go
+++ b/integration/epochs/epoch_qc_test.go
@@ -75,7 +75,7 @@ func (s *Suite) TestEpochQuorumCertificate() {
 		address, err := s.blockchain.CreateAccount([]*sdk.AccountKey{key}, []sdktemplates.Contract{})
 		require.NoError(s.T(), err)
 
-		client, err := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, nodeID, address.String(), 0, s.qcAddress.String(), signer)
+		client := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, nodeID, address.String(), 0, s.qcAddress.String(), signer)
 		require.NoError(s.T(), err)
 
 		local := &modulemock.Local{}
@@ -122,7 +122,7 @@ func (s *Suite) CreateClusterNode(rootBlock *cluster.Block, me *flow.Identity) *
 	address, err := s.blockchain.CreateAccount([]*sdk.AccountKey{key}, []sdktemplates.Contract{})
 	require.NoError(s.T(), err)
 
-	client, err := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, me.NodeID, address.String(), 0, s.qcAddress.String(), signer)
+	client := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, me.NodeID, address.String(), 0, s.qcAddress.String(), signer)
 	require.NoError(s.T(), err)
 
 	local := &modulemock.Local{}

--- a/integration/epochs/epoch_qc_test.go
+++ b/integration/epochs/epoch_qc_test.go
@@ -75,7 +75,7 @@ func (s *Suite) TestEpochQuorumCertificate() {
 		address, err := s.blockchain.CreateAccount([]*sdk.AccountKey{key}, []sdktemplates.Contract{})
 		require.NoError(s.T(), err)
 
-		client, err := epochs.NewQCContractClient(s.emulatorClient, nodeID, address.String(), 0, s.qcAddress.String(), signer)
+		client, err := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, nodeID, address.String(), 0, s.qcAddress.String(), signer)
 		require.NoError(s.T(), err)
 
 		local := &modulemock.Local{}
@@ -122,7 +122,7 @@ func (s *Suite) CreateClusterNode(rootBlock *cluster.Block, me *flow.Identity) *
 	address, err := s.blockchain.CreateAccount([]*sdk.AccountKey{key}, []sdktemplates.Contract{})
 	require.NoError(s.T(), err)
 
-	client, err := epochs.NewQCContractClient(s.emulatorClient, me.NodeID, address.String(), 0, s.qcAddress.String(), signer)
+	client, err := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, me.NodeID, address.String(), 0, s.qcAddress.String(), signer)
 	require.NoError(s.T(), err)
 
 	local := &modulemock.Local{}

--- a/module/dkg/client.go
+++ b/module/dkg/client.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
 
@@ -30,6 +29,7 @@ import (
 type Client struct {
 	*epochs.BaseContractClient
 
+	log zerolog.Logger
 	env templates.Environment
 }
 
@@ -104,7 +104,7 @@ func (c *Client) Broadcast(msg model.BroadcastDKGMessage) error {
 	}
 
 	// submit signed transaction to node
-	log.Info().Msg("sending Broadcast transaction")
+	c.log.Info().Msg("sending Broadcast transaction")
 	txID, err := c.SendTransaction(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to submit transaction: %w", err)
@@ -207,7 +207,7 @@ func (c *Client) SubmitResult(groupPublicKey crypto.PublicKey, publicKeys []cryp
 		return fmt.Errorf("could not sign transaction: %w", err)
 	}
 
-	log.Info().Msg("sending SubmitResult transaction")
+	c.log.Info().Msg("sending SubmitResult transaction")
 	txID, err := c.SendTransaction(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to submit transaction: %w", err)

--- a/module/dkg/client.go
+++ b/module/dkg/client.go
@@ -27,7 +27,7 @@ import (
 // Client is a client to the Flow DKG contract. Allows functionality to Broadcast,
 // read a Broadcast and submit the final result of the DKG protocol
 type Client struct {
-	*epochs.BaseContractClient
+	epochs.BaseContractClient
 
 	log zerolog.Logger
 	env templates.Environment
@@ -48,7 +48,7 @@ func NewClient(log zerolog.Logger,
 	env := templates.Environment{DkgAddress: dkgContractAddress}
 
 	return &Client{
-		BaseContractClient: base,
+		BaseContractClient: *base,
 		env:                env,
 	}, nil
 }

--- a/module/dkg/client_test.go
+++ b/module/dkg/client_test.go
@@ -3,6 +3,7 @@ package dkg
 import (
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -56,7 +57,7 @@ func (s *ClientSuite) SetupTest() {
 	s.deployDKGContract()
 
 	// Note: using DKG address as DKG participant to avoid funding a new account key
-	s.contractClient = NewClient(s.emulatorClient, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
+	s.contractClient = NewClient(zerolog.Nop(), s.emulatorClient, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
 
 	s.setUpAdmin()
 }

--- a/module/dkg/client_test.go
+++ b/module/dkg/client_test.go
@@ -56,9 +56,7 @@ func (s *ClientSuite) SetupTest() {
 	// deploy contract
 	s.deployDKGContract()
 
-	// Note: using DKG address as DKG participant to avoid funding a new account key
-	s.contractClient, err = NewClient(zerolog.Nop(), s.emulatorClient, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
-	require.NoError(s.T(), err)
+	s.contractClient = NewClient(zerolog.Nop(), s.emulatorClient, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
 
 	s.setUpAdmin()
 }

--- a/module/dkg/client_test.go
+++ b/module/dkg/client_test.go
@@ -57,7 +57,8 @@ func (s *ClientSuite) SetupTest() {
 	s.deployDKGContract()
 
 	// Note: using DKG address as DKG participant to avoid funding a new account key
-	s.contractClient = NewClient(zerolog.Nop(), s.emulatorClient, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
+	s.contractClient, err = NewClient(zerolog.Nop(), s.emulatorClient, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
+	require.NoError(s.T(), err)
 
 	s.setUpAdmin()
 }

--- a/module/epochs/base_client.go
+++ b/module/epochs/base_client.go
@@ -81,7 +81,7 @@ func (c *BaseClient) WaitForSealed(ctx context.Context, txID sdk.Identifier, sta
 
 	attempts := 1
 	for {
-		log := c.Log.With().Int("attempt", attempts).Float64("time_elapsed", time.Since(started).Seconds()).Logger()
+		log := c.Log.With().Int("attempt", attempts).Float64("time_elapsed_s", time.Since(started).Seconds()).Logger()
 
 		result, err := c.FlowClient.GetTransactionResult(ctx, txID)
 		if err != nil {

--- a/module/epochs/base_contract_client.go
+++ b/module/epochs/base_contract_client.go
@@ -1,0 +1,103 @@
+package epochs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	sdk "github.com/onflow/flow-go-sdk"
+	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+
+	"github.com/onflow/flow-go/module"
+)
+
+// BaseContractClient represents the core fields and methods needed to create
+// a client to a contract on the Flow Network.
+type BaseContractClient struct {
+	log zerolog.Logger // default logger
+
+	ContractAddress string           // contract address
+	AccountKeyIndex uint             // account key index
+	Signer          sdkcrypto.Signer // signer used to sign transactions
+	Account         *sdk.Account     // account belonging to node interacting with the contract
+
+	Client module.SDKClientWrapper // flow access node client
+}
+
+// NewBaseContractClient ...
+func NewBaseContractClient(log zerolog.Logger,
+	flowClient module.SDKClientWrapper,
+	accountAddress string,
+	accountKeyIndex uint,
+	signer sdkcrypto.Signer,
+	contractAddress string) (*BaseContractClient, error) {
+
+	// get account from access node for given address
+	account, err := flowClient.GetAccount(context.Background(), sdk.HexToAddress(accountAddress))
+	if err != nil {
+		return nil, fmt.Errorf("could not get account: %w", err)
+	}
+
+	// check if account key index within range of keys
+	if len(account.Keys) <= int(accountKeyIndex) {
+		return nil, fmt.Errorf("given account key index is bigger than the number of keys for this account")
+	}
+
+	return &BaseContractClient{
+		ContractAddress: contractAddress,
+		Client:          flowClient,
+		AccountKeyIndex: accountKeyIndex,
+		Signer:          signer,
+		Account:         account,
+	}, nil
+}
+
+// SendTransaction submits a transaction to Flow. Requires transaction to be signed.
+func (c *BaseContractClient) SendTransaction(ctx context.Context, tx *sdk.Transaction) (sdk.Identifier, error) {
+
+	// check if the transaction has a signature
+	if len(tx.EnvelopeSignatures) == 0 {
+		return sdk.EmptyID, fmt.Errorf("can not submit an unsigned transaction")
+	}
+
+	// submit trnsaction to client
+	err := c.Client.SendTransaction(ctx, *tx)
+	if err != nil {
+		return sdk.EmptyID, fmt.Errorf("failed to send transaction: %w", err)
+	}
+
+	return tx.ID(), nil
+}
+
+// WaitForSealed waits for a transaction to be sealed
+func (c *BaseContractClient) WaitForSealed(ctx context.Context, txID sdk.Identifier, started time.Time) error {
+
+	attempts := 1
+	for {
+		log := c.log.With().Int("attempt", attempts).Float64("time_elapsed", time.Since(started).Seconds()).Logger()
+
+		result, err := c.Client.GetTransactionResult(ctx, txID)
+		if err != nil {
+			log.Error().Err(err).Msg("could not get transaction result")
+			continue
+		}
+		if result.Error != nil {
+			return fmt.Errorf("error executing transaction: %w", result.Error)
+		}
+		log.Info().Str("status", result.Status.String()).Msg("got transaction result")
+
+		// if the transaction has expired we skip waiting for seal
+		if result.Status == sdk.TransactionStatusExpired {
+			return fmt.Errorf("broadcast dkg message transaction has expired")
+		}
+
+		if result.Status == sdk.TransactionStatusSealed {
+			return nil
+		}
+
+		attempts++
+		time.Sleep(TransactionStatusRetryTimeout)
+	}
+}

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -33,7 +33,7 @@ const (
 // QCContractClient is a client to the Quorum Certificate contract. Allows the client to
 // functionality to submit a vote and check if collection node has voted already.
 type QCContractClient struct {
-	*BaseContractClient
+	BaseContractClient
 
 	nodeID flow.Identifier // flow identifier of the collection node
 
@@ -56,7 +56,7 @@ func NewQCContractClient(log zerolog.Logger,
 	env := templates.Environment{QuorumCertificateAddress: qcContractAddress}
 
 	return &QCContractClient{
-		BaseContractClient: base,
+		BaseContractClient: *base,
 		nodeID:             nodeID,
 		env:                env,
 	}, nil

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -46,7 +46,7 @@ func NewQCContractClient(log zerolog.Logger,
 	accountAddress string,
 	accountKeyIndex uint,
 	qcContractAddress string,
-	signer sdkcrypto.Signer) (*QCContractClient, error) {
+	signer sdkcrypto.Signer) *QCContractClient {
 
 	log = log.With().Str("component", "qc_contract_client").Logger()
 	base := NewBaseClient(log, flowClient, accountAddress, accountKeyIndex, signer, qcContractAddress)
@@ -58,7 +58,7 @@ func NewQCContractClient(log zerolog.Logger,
 		BaseClient: *base,
 		nodeID:     nodeID,
 		env:        env,
-	}, nil
+	}
 }
 
 // SubmitVote submits the given vote to the cluster QC aggregator smart

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
@@ -31,37 +33,32 @@ const (
 // QCContractClient is a client to the Quorum Certificate contract. Allows the client to
 // functionality to submit a vote and check if collection node has voted already.
 type QCContractClient struct {
-	nodeID            flow.Identifier  // flow identifier of the collection node
-	qcContractAddress string           // QuorumCertificate contract address
-	accountKeyIndex   uint             // account key index
-	signer            sdkcrypto.Signer // signer used to sign vote transaction
+	*BaseContractClient
 
-	account *sdk.Account // account belonging to the collection node
-	client  module.SDKClientWrapper
+	nodeID flow.Identifier // flow identifier of the collection node
+
+	env templates.Environment
 }
 
 // NewQCContractClient returns a new client to the Quorum Certificate contract
-func NewQCContractClient(flowClient module.SDKClientWrapper, nodeID flow.Identifier, accountAddress string,
-	accountKeyIndex uint, qcContractAddress string, signer sdkcrypto.Signer) (*QCContractClient, error) {
+func NewQCContractClient(log zerolog.Logger,
+	flowClient module.SDKClientWrapper,
+	nodeID flow.Identifier,
+	accountAddress string,
+	accountKeyIndex uint,
+	qcContractAddress string,
+	signer sdkcrypto.Signer) (*QCContractClient, error) {
 
-	// get account for given address
-	account, err := flowClient.GetAccount(context.Background(), sdk.HexToAddress(accountAddress))
+	base, err := NewBaseContractClient(log, flowClient, accountAddress, accountKeyIndex, signer, qcContractAddress)
 	if err != nil {
-		return nil, fmt.Errorf("could not get account: %w", err)
+		return nil, err
 	}
-
-	// check if account key index within range of keys
-	if len(account.Keys) <= int(accountKeyIndex) {
-		return nil, fmt.Errorf("given account key index is bigger than the number of keys for this account")
-	}
+	env := templates.Environment{QuorumCertificateAddress: qcContractAddress}
 
 	return &QCContractClient{
-		qcContractAddress: qcContractAddress,
-		client:            flowClient,
-		accountKeyIndex:   accountKeyIndex,
-		signer:            signer,
-		nodeID:            nodeID,
-		account:           account,
+		BaseContractClient: base,
+		nodeID:             nodeID,
+		env:                env,
 	}, nil
 }
 
@@ -71,32 +68,35 @@ func NewQCContractClient(flowClient module.SDKClientWrapper, nodeID flow.Identif
 // failed and should be re-submitted.
 func (c *QCContractClient) SubmitVote(ctx context.Context, vote *model.Vote) error {
 
+	// time method was invoked
+	started := time.Now()
+
 	// add a timeout to the context
 	ctx, cancel := context.WithTimeout(ctx, TransactionSubmissionTimeout)
 	defer cancel()
 
 	// get account for given address
-	account, err := c.client.GetAccount(ctx, c.account.Address)
+	account, err := c.Client.GetAccount(ctx, c.Account.Address)
 	if err != nil {
 		return fmt.Errorf("could not get account: %w", err)
 	}
-	c.account = account
+	c.Account = account
 
 	// get latest sealed block to execute transaction
-	latestBlock, err := c.client.GetLatestBlock(ctx, true)
+	latestBlock, err := c.Client.GetLatestBlock(ctx, true)
 	if err != nil {
 		return fmt.Errorf("could not get latest block from node: %w", err)
 	}
 
 	// attach submit vote transaction template and build transaction
-	seqNumber := c.account.Keys[int(c.accountKeyIndex)].SequenceNumber
+	seqNumber := c.Account.Keys[int(c.AccountKeyIndex)].SequenceNumber
 	tx := sdk.NewTransaction().
-		SetScript(templates.GenerateSubmitVoteScript(c.getEnvironment())).
+		SetScript(templates.GenerateSubmitVoteScript(c.env)).
 		SetGasLimit(9999).
 		SetReferenceBlockID(latestBlock.ID).
-		SetProposalKey(c.account.Address, int(c.accountKeyIndex), seqNumber).
-		SetPayer(c.account.Address).
-		AddAuthorizer(c.account.Address)
+		SetProposalKey(c.Account.Address, int(c.AccountKeyIndex), seqNumber).
+		SetPayer(c.Account.Address).
+		AddAuthorizer(c.Account.Address)
 
 	// add signature data to the transaction and submit to node
 	err = tx.AddArgument(cadence.NewString(hex.EncodeToString(vote.SigData)))
@@ -105,37 +105,20 @@ func (c *QCContractClient) SubmitVote(ctx context.Context, vote *model.Vote) err
 	}
 
 	// sign envelope using account signer
-	err = tx.SignEnvelope(c.account.Address, int(c.accountKeyIndex), c.signer)
+	err = tx.SignEnvelope(c.Account.Address, int(c.AccountKeyIndex), c.Signer)
 	if err != nil {
 		return fmt.Errorf("could not sign transaction: %w", err)
 	}
 
 	// submit signed transaction to node
-	txID, err := c.submitTx(tx)
+	txID, err := c.SendTransaction(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("failed to submit transaction: %w", err)
 	}
 
-	// wait for transaction to be sealed
-	result := &sdk.TransactionResult{Status: sdk.TransactionStatusUnknown}
-	for result.Status != sdk.TransactionStatusSealed {
-
-		result, err = c.client.GetTransactionResult(ctx, txID)
-		if err != nil {
-			return fmt.Errorf("could not get transaction result: %w", err)
-		}
-
-		// if the transaction has expired we skip waiting for seal
-		if result.Status == sdk.TransactionStatusExpired {
-			return fmt.Errorf("submit vote transaction has expired")
-		}
-
-		// wait 1 second before trying again.
-		time.Sleep(TransactionStatusRetryTimeout)
-	}
-
-	if result.Error != nil {
-		return fmt.Errorf("error executing transaction: %w", result.Error)
+	err = c.WaitForSealed(ctx, txID, started)
+	if err != nil {
+		return fmt.Errorf("failed to wait for transaction seal: %w", err)
 	}
 
 	return nil
@@ -147,8 +130,8 @@ func (c *QCContractClient) Voted(ctx context.Context) (bool, error) {
 
 	// execute script to read if voted
 	arg := jsoncdc.MustEncode(cadence.String(c.nodeID.String()))
-	template := templates.GenerateGetNodeHasVotedScript(c.getEnvironment())
-	hasVoted, err := c.client.ExecuteScriptAtLatestBlock(ctx, template, []cadence.Value{cadence.String(arg)})
+	template := templates.GenerateGetNodeHasVotedScript(c.env)
+	hasVoted, err := c.Client.ExecuteScriptAtLatestBlock(ctx, template, []cadence.Value{cadence.String(arg)})
 	if err != nil {
 		return false, fmt.Errorf("could not execute voted script: %w", err)
 	}
@@ -159,28 +142,4 @@ func (c *QCContractClient) Voted(ctx context.Context) (bool, error) {
 	}
 
 	return true, nil
-}
-
-// submitTx submits a transaction to flow
-func (c *QCContractClient) submitTx(tx *sdk.Transaction) (sdk.Identifier, error) {
-
-	// check if the transaction has a signature
-	if len(tx.EnvelopeSignatures) == 0 {
-		return sdk.EmptyID, fmt.Errorf("can not submit an unsigned transaction")
-	}
-
-	// submit trnsaction to client
-	err := c.client.SendTransaction(context.Background(), *tx)
-	if err != nil {
-		return sdk.EmptyID, fmt.Errorf("failed to send transaction: %w", err)
-	}
-
-	return tx.ID(), nil
-}
-
-func (c *QCContractClient) getEnvironment() templates.Environment {
-	// environment to override transaction template contract addresses
-	return templates.Environment{
-		QuorumCertificateAddress: c.qcContractAddress,
-	}
 }


### PR DESCRIPTION
This PR adds logging to both the Epoch QC and DKG contract clients. 

- Also moves common methods and fields for any contract client to `epochs/base_client`.
- All `SendTransaction` are logged. Also logs attempts at waiting for transaction to be sealed along with the time elapsed since the parent method was invoked.
- The check to verify that the `AccountKeyIndex` is valid has been moved to 
  ```BaseClient.GetAccount(ctx) (*sdk.Account, error)```