### PR TITLE
Add state migration for new Cadence storage format v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,4 @@ language/tools/vscode-extension/out/*
 read-badger
 read-protocol-state
 remove-execution-fork
-util
 bootstrap

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -21,7 +21,15 @@ func getStateCommitment(commits storage.Commits, blockHash flow.Identifier) (flo
 
 func extractExecutionState(dir string, targetHash flow.StateCommitment, outputDir string, log zerolog.Logger) error {
 
-	diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir, complete.DefaultCacheSize, pathfinder.PathByteSize, wal.SegmentSize)
+	diskWal, err := wal.NewDiskWAL(
+		zerolog.Nop(),
+		nil,
+		metrics.NewNoopCollector(),
+		dir,
+		complete.DefaultCacheSize,
+		pathfinder.PathByteSize,
+		wal.SegmentSize,
+	)
 	if err != nil {
 		return fmt.Errorf("cannot create disk WAL: %w", err)
 	}
@@ -39,15 +47,19 @@ func extractExecutionState(dir string, targetHash flow.StateCommitment, outputDi
 		return fmt.Errorf("cannot create ledger from write-a-head logs and checkpoints: %w", err)
 	}
 
-	newState, err := led.ExportCheckpointAt(targetHash,
-		[]ledger.Migration{},
+	newState, err := led.ExportCheckpointAt(
+		targetHash,
+		[]ledger.Migration{
+			migrations.StorageFormatV4Migration,
+		},
 		[]ledger.Reporter{
 			migrations.ContractReporter{Log: log, OutputDir: outputDir},
 			migrations.StorageReporter{Log: log, OutputDir: outputDir},
 		},
 		complete.DefaultPathFinderVersion,
 		outputDir,
-		wal.RootCheckpointFilename)
+		wal.RootCheckpointFilename,
+	)
 	if err != nil {
 		return fmt.Errorf("cannot generate the output checkpoint: %w", err)
 	}

--- a/cmd/util/ledger/migrations/storage_v4.go
+++ b/cmd/util/ledger/migrations/storage_v4.go
@@ -1,0 +1,127 @@
+package migrations
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+
+	"github.com/onflow/flow-go/ledger"
+)
+
+func StorageFormatV4Migration(payloads []ledger.Payload) ([]ledger.Payload, error) {
+
+	migratedPayloads := make([]ledger.Payload, 0, len(payloads))
+
+	for _, payload := range payloads {
+		migratedPayload, err := rencodePayloadV4(payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to migrate key: %#+v: %w", payload.Key, err)
+		}
+		migratedPayloads = append(migratedPayloads, migratedPayload)
+	}
+
+	return migratedPayloads, nil
+}
+
+func rencodePayloadV4(payload ledger.Payload) (ledger.Payload, error) {
+
+	// If the payload value is not a Cadence value (it does not have the Cadence data magic prefix),
+	// return the payload as is
+
+	value, version := interpreter.StripMagic(payload.Value)
+	if version == 0 {
+		return payload, nil
+	}
+
+	// Extract the owner from the key and re-encode the value
+
+	owner := common.BytesToAddress(payload.Key.KeyParts[0].Value)
+
+	var err error
+	payload.Value, err = rencodeValueV4(value, owner, version)
+	if err != nil {
+		return ledger.Payload{}, err
+	}
+
+	return payload, nil
+}
+
+func rencodeValueV4(data []byte, owner common.Address, version uint16) ([]byte, error) {
+
+	// Determine the appropriate decoder from the decoded version
+
+	decodeFunction := interpreter.DecodeValue
+	if version <= 3 {
+		decodeFunction = interpreter.DecodeValueV3
+	}
+
+	// Decode the value
+
+	value, err := decodeFunction(data, &owner, nil, version, nil)
+	if err != nil {
+		return nil,
+			fmt.Errorf("failed to decode value: %w\n%s\n", err, hex.Dump(data))
+	}
+
+	// Encode the value using the new encoder
+
+	newData, deferrals, err := interpreter.EncodeValue(value, nil, true, nil)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to encode value: %w\n%s\n",
+			err, value,
+		)
+	}
+
+	// Encoding should not provide any deferred values or deferred moves
+
+	if len(deferrals.Values) > 0 {
+		return nil, fmt.Errorf(
+			"re-encoding produced deferred values:\n%s\n",
+			value,
+		)
+	}
+
+	if len(deferrals.Moves) > 0 {
+		return nil, fmt.Errorf(
+			"re-encoding produced deferred moves:\n%s\n",
+			value,
+		)
+	}
+
+	// Sanity check: Decode the newly encoded data again
+	// and compare it to the initially decoded value
+
+	newValue, err := interpreter.DecodeValue(
+		newData,
+		&owner,
+		nil,
+		interpreter.CurrentEncodingVersion,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to decode re-encoded value: %w\n%s\n",
+			err, value,
+		)
+	}
+
+	equatableValue, ok := value.(interpreter.EquatableValue)
+	if !ok {
+		return nil, fmt.Errorf(
+			"cannot compare unequatable %[1]T\n%[1]s\n",
+			value,
+		)
+	}
+
+	if !equatableValue.Equal(newValue, nil, false) {
+		return nil, fmt.Errorf(
+			"values are unequal:\n%s\n%s\n",
+			value, newValue,
+		)
+	}
+
+	return newData, nil
+}


### PR DESCRIPTION
Closes dapperlabs/flow-go#5422

The next Cadence release will introduce a new storage format, which means the whole execution state needs to be migrated from an old format (there are multiple older versions) to the new format.

Implement a state migration function which decodes all Cadence values using the old decoder and encodes them using the new encoder. 

As a sanity check, the newly encoded data is re-decoded, and the resulting value is compared to the value which was initially decoded from the original data using the old decoder.