### PR TITLE
suggested revisions Pt 2

### DIFF
--- a/cmd/util/cmd/read-execution-state/list-tries/cmd.go
+++ b/cmd/util/cmd/read-execution-state/list-tries/cmd.go
@@ -35,7 +35,7 @@ func run(*cobra.Command, []string) {
 	}
 
 	for _, trie := range tries {
-		fmt.Printf("%s\n", trie.StringRootHash())
+		fmt.Printf("%x\n", trie.RootHash())
 	}
 
 	duration := time.Since(startTime)

--- a/ledger/complete/mtrie/trie/trie.go
+++ b/ledger/complete/mtrie/trie/trie.go
@@ -1,7 +1,6 @@
 package trie
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -57,18 +56,6 @@ func (mt *MTrie) Height() int {
 	return mt.root.Height()
 }
 
-// StringRootHash returns the trie's Hex-encoded root hash.
-// Concurrency safe (as Tries are immutable structures by convention)
-func (mt *MTrie) StringRootHash() string {
-	var rootHash hash.Hash
-	if mt.root == nil {
-		// case of an empty trie
-		rootHash = hash.GetDefaultHashForHeight(hash.TreeMaxHeight)
-	}
-	rootHash = mt.root.Hash()
-	return hex.EncodeToString(rootHash[:])
-}
-
 // RootHash returns the trie's root hash (i.e. the hash of the trie's root node).
 // Concurrency safe (as Tries are immutable structures by convention)
 func (mt *MTrie) RootHash() ledger.RootHash {
@@ -93,10 +80,10 @@ func (mt *MTrie) RootNode() *node.Node {
 	return mt.root
 }
 
-// StringRootHash returns the trie's string representation.
+// String returns the trie's string representation.
 // Concurrency safe (as Tries are immutable structures by convention)
 func (mt *MTrie) String() string {
-	trieStr := fmt.Sprintf("Trie root hash: %v\n", mt.StringRootHash())
+	trieStr := fmt.Sprintf("Trie root hash: %x\n", mt.RootHash())
 	return trieStr + mt.root.FmtStr("", "")
 }
 

--- a/ledger/partial/ledger.go
+++ b/ledger/partial/ledger.go
@@ -76,16 +76,16 @@ func (l *Ledger) Get(query *ledger.Query) (values []ledger.Value, err error) {
 	if err != nil {
 		if pErr, ok := err.(*ptrie.ErrMissingPath); ok {
 			//store mappings and restore keys from missing paths
-			pathToKey := make(map[string]ledger.Key)
+			pathToKey := make(map[ledger.Path]ledger.Key)
 
 			for i, key := range query.Keys() {
 				path := paths[i]
-				pathToKey[string(path[:])] = key
+				pathToKey[path] = key
 			}
 
 			keys := make([]ledger.Key, 0, len(pErr.Paths))
 			for _, path := range pErr.Paths {
-				keys = append(keys, pathToKey[string(path[:])])
+				keys = append(keys, pathToKey[path])
 			}
 			return nil, &ledger.ErrMissingKeys{Keys: keys}
 		}
@@ -124,16 +124,16 @@ func (l *Ledger) Set(update *ledger.Update) (newState ledger.State, err error) {
 			}
 
 			//store mappings and restore keys from missing paths
-			pathToKey := make(map[string]ledger.Key)
+			pathToKey := make(map[ledger.Path]ledger.Key)
 
 			for i, key := range update.Keys() {
 				path := paths[i]
-				pathToKey[string(path[:])] = key
+				pathToKey[path] = key
 			}
 
 			keys := make([]ledger.Key, 0, len(pErr.Paths))
 			for _, path := range pErr.Paths {
-				keys = append(keys, pathToKey[string(path[:])])
+				keys = append(keys, pathToKey[path])
 			}
 			return emptyState, &ledger.ErrMissingKeys{Keys: keys}
 		}

--- a/ledger/partial/ptrie/partialTrie.go
+++ b/ledger/partial/ptrie/partialTrie.go
@@ -19,7 +19,7 @@ import (
 //     The height of a Trie is always the height of the fully-expanded tree.
 type PSMT struct {
 	root       *node // Root
-	pathLookUp map[string]*node
+	pathLookUp map[ledger.Path]*node
 }
 
 // RootHash returns the rootNode hash value of the SMT
@@ -34,7 +34,7 @@ func (p *PSMT) Get(paths []ledger.Path) ([]*ledger.Payload, error) {
 	payloads := make([]*ledger.Payload, 0)
 	for _, path := range paths {
 		// lookup the path for the payload
-		node, found := p.pathLookUp[string(path[:])]
+		node, found := p.pathLookUp[path]
 		if !found {
 			payloads = append(payloads, nil)
 			failedPaths = append(failedPaths, path)
@@ -56,7 +56,7 @@ func (p *PSMT) Update(paths []ledger.Path, payloads []*ledger.Payload) (hash.Has
 	for i, path := range paths {
 		payload := payloads[i]
 		// lookup the path and update the value
-		node, found := p.pathLookUp[string(path[:])]
+		node, found := p.pathLookUp[path]
 		if !found {
 			failedKeys = append(failedKeys, payload.Key)
 			continue
@@ -79,7 +79,7 @@ func NewPSMT(
 
 	height := hash.TreeMaxHeight
 
-	psmt := PSMT{newNode(hash.GetDefaultHashForHeight(height), height), make(map[string]*node)}
+	psmt := PSMT{newNode(hash.GetDefaultHashForHeight(height), height), make(map[ledger.Path]*node)}
 
 	paths := batchProof.Paths()
 	payloads := batchProof.Payloads()
@@ -150,7 +150,7 @@ func NewPSMT(
 			currentNode.hashValue = hash.ComputeCompactValue(hash.Hash(path), payload.Value, currentNode.height)
 		}
 		// keep a reference to this node by path (for update purpose)
-		psmt.pathLookUp[string(path[:])] = currentNode
+		psmt.pathLookUp[path] = currentNode
 
 	}
 


### PR DESCRIPTION
* forest's LRU cache working directly with rootHashes
*  `partial.ledger`:  removed unnecessary conversions of `ledger.Path` to `string` for map lookup
* `ptrie.PSMT`: removed unnecessary conversions of `ledger.Path` to `string` for map lookup