### PR TITLE
[Consensus] Avoid overwritten error

### DIFF
--- a/engine/consensus/sealing/core.go
+++ b/engine/consensus/sealing/core.go
@@ -163,8 +163,8 @@ func (c *Core) OnReceipt(originID flow.Identifier, receipt *flow.ExecutionReceip
 
 	processed, err := c.processReceipt(receipt)
 	if err != nil {
-		marshalled, err := json.Marshal(receipt)
-		if err != nil {
+		marshalled, encErr := json.Marshal(receipt)
+		if encErr != nil {
 			marshalled = []byte("json_marshalling_failed")
 		}
 		c.log.Error().Err(err).


### PR DESCRIPTION
This PR fix an issue that when there is error processing a receipt, the error is overwritten by json encoding error, which we don't care.