### PR TITLE
[Ledger] Adding a migration to prune the trie on sporks

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -51,6 +51,7 @@ func extractExecutionState(dir string, targetHash flow.StateCommitment, outputDi
 	newState, err := led.ExportCheckpointAt(
 		targetHash,
 		[]ledger.Migration{
+			migrations.PruneMigration,
 			migrations.StorageFormatV4Migration,
 		},
 		[]ledger.Reporter{

--- a/cmd/util/ledger/migrations/prune_migration.go
+++ b/cmd/util/ledger/migrations/prune_migration.go
@@ -1,0 +1,17 @@
+package migrations
+
+import (
+	"github.com/onflow/flow-go/ledger"
+)
+
+// PruneMigration removes all the payloads with empty value
+// this prunes the trie for values that has been deleted
+func PruneMigration(payload []ledger.Payload) ([]ledger.Payload, error) {
+	newPayload := make([]ledger.Payload, 0, len(payload))
+	for _, p := range payload {
+		if len(p.Value) > 0 {
+			newPayload = append(newPayload, p)
+		}
+	}
+	return newPayload, nil
+}

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/onflow/flow-go/fvm/errors"
@@ -232,4 +233,57 @@ func addressFromOwner(owner string) (flow.Address, bool) {
 	}
 	address := flow.BytesToAddress(ownerBytes)
 	return address, true
+}
+
+// IsFVMStateKey returns true if the
+// key is controlled by the fvm env and
+// return false otherwise (key controlled by the cadence env)
+func IsFVMStateKey(owner, controller, key string) bool {
+
+	// check if is a service level key (owner and controller is empty)
+	// cases:
+	// 		- "", "", "uuid"
+	// 		- "", "", "account_address_state"
+	if len(owner) == 0 && len(controller) == 0 {
+		return true
+	}
+	// check account level keys
+	// cases:
+	// 		- address, address, "public_key_%d" (index)
+	// 		- address, address, "public_key_count"
+	// 		- address, address, "contract_names"
+	// 		- address, address, "code.%s" (contract name)
+	// 		- address, "", exists
+	// 		- address, "", "storage_used"
+	// 		- address, "", "frozen"
+
+	if owner == controller && key == KeyPublicKeyCount {
+		return true
+	}
+
+	if owner == controller && bytes.HasPrefix([]byte(key), []byte("public_key_")) {
+		return true
+	}
+
+	if owner == controller && key == KeyContractNames {
+		return true
+	}
+
+	if owner == controller && bytes.HasPrefix([]byte(key), []byte(KeyCode)) {
+		return true
+	}
+
+	if len(controller) == 0 && key == KeyExists {
+		return true
+	}
+
+	if len(controller) == 0 && key == KeyStorageUsed {
+		return true
+	}
+
+	if len(controller) == 0 && key == KeyAccountFrozen {
+		return true
+	}
+
+	return false
 }

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -257,32 +257,33 @@ func IsFVMStateKey(owner, controller, key string) bool {
 	// 		- address, "", "storage_used"
 	// 		- address, "", "frozen"
 
-	if owner == controller && key == KeyPublicKeyCount {
-		return true
+	if owner == controller {
+
+		if key == KeyPublicKeyCount {
+			return true
+		}
+		if bytes.HasPrefix([]byte(key), []byte("public_key_")) {
+			return true
+		}
+		if key == KeyContractNames {
+			return true
+		}
+		if bytes.HasPrefix([]byte(key), []byte(KeyCode)) {
+			return true
+		}
+
 	}
 
-	if owner == controller && bytes.HasPrefix([]byte(key), []byte("public_key_")) {
-		return true
-	}
-
-	if owner == controller && key == KeyContractNames {
-		return true
-	}
-
-	if owner == controller && bytes.HasPrefix([]byte(key), []byte(KeyCode)) {
-		return true
-	}
-
-	if len(controller) == 0 && key == KeyExists {
-		return true
-	}
-
-	if len(controller) == 0 && key == KeyStorageUsed {
-		return true
-	}
-
-	if len(controller) == 0 && key == KeyAccountFrozen {
-		return true
+	if len(controller) == 0 {
+		if key == KeyExists {
+			return true
+		}
+		if key == KeyStorageUsed {
+			return true
+		}
+		if key == KeyAccountFrozen {
+			return true
+		}
 	}
 
 	return false

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -249,16 +249,14 @@ func IsFVMStateKey(owner, controller, key string) bool {
 	}
 	// check account level keys
 	// cases:
-	// 		- address, address, "public_key_%d" (index)
 	// 		- address, address, "public_key_count"
+	// 		- address, address, "public_key_%d" (index)
 	// 		- address, address, "contract_names"
 	// 		- address, address, "code.%s" (contract name)
 	// 		- address, "", exists
 	// 		- address, "", "storage_used"
 	// 		- address, "", "frozen"
-
 	if owner == controller {
-
 		if key == KeyPublicKeyCount {
 			return true
 		}
@@ -271,7 +269,6 @@ func IsFVMStateKey(owner, controller, key string) bool {
 		if bytes.HasPrefix([]byte(key), []byte(KeyCode)) {
 			return true
 		}
-
 	}
 
 	if len(controller) == 0 {

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -194,3 +194,10 @@ func TestState_MaxInteraction(t *testing.T) {
 	_, err = st.Get("3", "4", "5")
 	require.Error(t, err)
 }
+
+func TestState_IsFVMStateKey(t *testing.T) {
+	require.True(t, state.IsFVMStateKey("", "", "uuid"))
+	require.True(t, state.IsFVMStateKey("Address", "Address", state.KeyPublicKeyCount))
+	require.True(t, state.IsFVMStateKey("Address", "Address", "code.MYCODE"))
+	require.False(t, state.IsFVMStateKey("Address", "", "anything else"))
+}

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -198,6 +198,13 @@ func TestState_MaxInteraction(t *testing.T) {
 func TestState_IsFVMStateKey(t *testing.T) {
 	require.True(t, state.IsFVMStateKey("", "", "uuid"))
 	require.True(t, state.IsFVMStateKey("Address", "Address", state.KeyPublicKeyCount))
+	require.True(t, state.IsFVMStateKey("Address", "Address", "public_key_12"))
+	require.True(t, state.IsFVMStateKey("Address", "Address", state.KeyContractNames))
+	require.True(t, state.IsFVMStateKey("Address", "Address", state.KeyContractNames))
 	require.True(t, state.IsFVMStateKey("Address", "Address", "code.MYCODE"))
+	require.True(t, state.IsFVMStateKey("Address", "", state.KeyExists))
+	require.True(t, state.IsFVMStateKey("Address", "", state.KeyStorageUsed))
+	require.True(t, state.IsFVMStateKey("Address", "", state.KeyAccountFrozen))
+
 	require.False(t, state.IsFVMStateKey("Address", "", "anything else"))
 }


### PR DESCRIPTION
Currently, we don't prune tries on delete operations, instead, Cadence sets an empty value for those keys, this migration prunes those keys so the output trie at spork will be pruned.


Why this is safe to do:

Existence methods have always been based on the size of returned value and trie always returns empty slice for non-existence keys:
- `func (a *Accounts) Exists(address flow.Address)`
- `func (e *hostEnv) ValueExists(owner, key []byte)`

StorageUsed never considered any usage for registered with the value of length zero (RegisterSize returns zero for registers with empty) 

`storage_used` and `frozen` values are checked by length. frozen is considered false if register not exists, storage_used checks the size of what is returned. 

Account keys are never removed physically from the state only the revoke flag gets on 

Contract removal removes the contract from the list of contract names and sets the value to nil, but the nil value won't be ever accessible (name lookup will return false).
