### PR TITLE
Migrate TokenForwarding.Forwarder recipient storage references to capabilities

### DIFF
--- a/cmd/util/ledger/migrations/storage_v4.go
+++ b/cmd/util/ledger/migrations/storage_v4.go
@@ -232,17 +232,26 @@ var flowTokenReceiverStorageKey = interpreter.StorageKey(
 	},
 )
 
-var flowTokenForwardingLocation = common.AddressLocation{
+var tokenForwardingLocationTestnet = common.AddressLocation{
 	Address: common.BytesToAddress([]byte{0x75, 0x4a, 0xed, 0x9d, 0xe6, 0x19, 0x76, 0x41}),
 	Name:    "TokenForwarding",
 }
 
-func rewriteTokenForwarderStorageReference(key string, value interpreter.Value) {
+var tokenForwardingLocationMainnet = common.AddressLocation{
+	Address: common.BytesToAddress([]byte{0x0e, 0xbf, 0x2b, 0xd5, 0x2a, 0xc4, 0x2c, 0xb3}),
+	Name:    "TokenForwarding",
+}
 
+func isTokenForwardingLocation(location common.Location) bool {
+	return common.LocationsMatch(location, tokenForwardingLocationTestnet) ||
+		common.LocationsMatch(location, tokenForwardingLocationMainnet)
+}
+
+func rewriteTokenForwarderStorageReference(key string, value interpreter.Value) {
 	compositeValue, ok := value.(*interpreter.CompositeValue)
 	if !ok ||
 		key != flowTokenReceiverStorageKey ||
-		!common.LocationsMatch(compositeValue.Location, flowTokenForwardingLocation) ||
+		!isTokenForwardingLocation(compositeValue.Location) ||
 		compositeValue.QualifiedIdentifier != "TokenForwarding.Forwarder" {
 
 		return

--- a/cmd/util/ledger/migrations/storage_v4.go
+++ b/cmd/util/ledger/migrations/storage_v4.go
@@ -158,6 +158,8 @@ func rencodeValueV4(data []byte, owner common.Address, key string, version uint1
 
 	// Encode the value using the new encoder
 
+	rewriteTokenForwarderStorageReference(key, value)
+
 	newData, deferrals, err := interpreter.EncodeValue(value, path, true, nil)
 	if err != nil {
 		//return nil, fmt.Errorf(
@@ -221,6 +223,75 @@ func rencodeValueV4(data []byte, owner common.Address, key string, version uint1
 	}
 
 	return newData, nil
+}
+
+var flowTokenReceiverStorageKey = interpreter.StorageKey(
+	interpreter.PathValue{
+		Domain:     common.PathDomainStorage,
+		Identifier: "flowTokenReceiver",
+	},
+)
+
+var flowTokenForwardingLocation = common.AddressLocation{
+	Address: common.BytesToAddress([]byte{0x75, 0x4a, 0xed, 0x9d, 0xe6, 0x19, 0x76, 0x41}),
+	Name:    "TokenForwarding",
+}
+
+func rewriteTokenForwarderStorageReference(key string, value interpreter.Value) {
+
+	compositeValue, ok := value.(*interpreter.CompositeValue)
+	if !ok ||
+		key != flowTokenReceiverStorageKey ||
+		!common.LocationsMatch(compositeValue.Location, flowTokenForwardingLocation) ||
+		compositeValue.QualifiedIdentifier != "TokenForwarding.Forwarder" {
+
+		return
+	}
+
+	const recipientField = "recipient"
+
+	recipient, ok := compositeValue.Fields.Get(recipientField)
+	if !ok {
+		fmt.Printf(
+			"Warning: missing recipient field for TokenForwarding Forwarder:\n%s\n\n",
+			value,
+		)
+		return
+	}
+
+	recipientRef, ok := recipient.(*interpreter.StorageReferenceValue)
+	if !ok {
+		fmt.Printf(
+			"Warning: TokenForwarding Forwarder field recipient is not a storage reference:\n%s\n\n",
+			value,
+		)
+		return
+	}
+
+	if recipientRef.TargetKey != "storage\x1fflowTokenVault" {
+		fmt.Printf(
+			"Warning: TokenForwarding Forwarder recipient reference has unsupported target key: %s\n",
+			recipientRef.TargetKey,
+		)
+		return
+	}
+
+	recipientCap := interpreter.CapabilityValue{
+		Address: interpreter.AddressValue(recipientRef.TargetStorageAddress),
+		Path: interpreter.PathValue{
+			Domain:     common.PathDomainStorage,
+			Identifier: "flowTokenVault",
+		},
+	}
+
+	fmt.Printf(
+		"Rewriting TokenForwarding Forwarder: %s\n\treference: %#+v\n\tcapability: %#+v\n",
+		compositeValue,
+		recipientRef,
+		recipientCap,
+	)
+
+	compositeValue.Fields.Set(recipientField, recipientCap)
 }
 
 func checkStorageFormatV4(payload ledger.Payload) error {

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -273,10 +273,19 @@ func (l *Ledger) ExportCheckpointAt(state ledger.State,
 		if err != nil {
 			return nil, fmt.Errorf("error applying migration (%d): %w", i, err)
 		}
-		if payloadSize != len(payloads) {
-			l.logger.Warn().Int("migration_step", i).Int("expected_size", payloadSize).Int("outcome_size", len(payloads)).Msg("payload counts has changed during migration, make sure this is expected.")
+
+		newPayloadSize := len(payloads)
+
+		if payloadSize != newPayloadSize {
+			l.logger.Warn().
+				Int("migration_step", i).
+				Int("expected_size", payloadSize).
+				Int("outcome_size", newPayloadSize).
+				Msg("payload counts has changed during migration, make sure this is expected.")
 		}
 		l.logger.Info().Msgf("migration %d is done", i)
+
+		payloadSize = newPayloadSize
 	}
 
 	// run reporters


### PR DESCRIPTION
The `TokenForwarding.Forwarder` resource's `recipient` field's type changed from a reference to a capability: https://github.com/onflow/flow-ft/pull/24/files#diff-f88272564fea81ead391ca2c9380749209bf7ed5219a1980aafac775df172fa8L29-R29

However, (some of) these resources were not migrated.

Detect `TokenForwarding.Forwarder` resources, and rewrite the `recipient` field from a storage referene value to a capability value.

Also, recalculate the expected payload size for the next migration, to avoid spurious warnings for a payload size mismatch caused by a previous migration