### PR TITLE
[Consensus] Repopulating of execution tree on startup

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -329,7 +329,7 @@ func main() {
 
 			// initialize the block builder
 			var build module.Builder
-			build = builder.NewBuilder(
+			build, err = builder.NewBuilder(
 				node.Metrics.Mempool,
 				node.DB,
 				mutableState,
@@ -347,6 +347,10 @@ func main() {
 				builder.WithMaxSealCount(maxSealPerBlock),
 				builder.WithMaxGuaranteeCount(maxGuaranteePerBlock),
 			)
+			if err != nil {
+				return nil, fmt.Errorf("could not initialized block builder: %w", err)
+			}
+
 			build = blockproducer.NewMetricsWrapper(build, mainMetrics) // wrapper for measuring time spent building block payload component
 
 			// initialize the block finalizer

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -184,8 +184,9 @@ func createNode(
 	seals := stdmap.NewIncorporatedResultSeals(stdmap.WithLimit(sealLimit))
 
 	// initialize the block builder
-	build := builder.NewBuilder(metrics, db, fullState, headersDB, sealsDB, indexDB, blocksDB, resultsDB,
+	build, err := builder.NewBuilder(metrics, db, fullState, headersDB, sealsDB, indexDB, blocksDB, resultsDB,
 		guarantees, seals, receipts, tracer)
+	require.NoError(t, err)
 
 	signer := &Signer{identity.ID()}
 

--- a/module/forest/leveled_forrest.go
+++ b/module/forest/leveled_forrest.go
@@ -51,11 +51,14 @@ func (f *LevelledForest) PruneUpToLevel(level uint64) error {
 	if level < f.LowestLevel {
 		return fmt.Errorf("new lowest level %d cannot be smaller than previous last retained level %d", level, f.LowestLevel)
 	}
-	for l := f.LowestLevel; l < level; l++ {
-		for _, v := range f.verticesAtLevel[l] { // nil map behaves like empty map when iterating over it
-			delete(f.vertices, v.id)
+
+	if len(f.verticesAtLevel) > 0 {
+		for l := f.LowestLevel; l < level; l++ {
+			for _, v := range f.verticesAtLevel[l] { // nil map behaves like empty map when iterating over it
+				delete(f.vertices, v.id)
+			}
+			delete(f.verticesAtLevel, l)
 		}
-		delete(f.verticesAtLevel, l)
 	}
 	f.LowestLevel = level
 	return nil

--- a/module/mempool/consensus/execution_tree.go
+++ b/module/mempool/consensus/execution_tree.go
@@ -189,11 +189,13 @@ func (et *ExecutionTree) PruneUpToHeight(limit uint64) error {
 
 	// count how many receipts are stored in the Execution Tree that will be removed
 	numberReceiptsRemoved := uint(0)
-	for l := et.forest.LowestLevel; l < limit; l++ {
-		iterator := et.forest.GetVerticesAtLevel(l)
-		for iterator.HasNext() {
-			vertex := iterator.NextVertex()
-			numberReceiptsRemoved += vertex.(*ReceiptsOfSameResult).Size()
+	if et.size > 0 {
+		for l := et.forest.LowestLevel; l < limit; l++ {
+			iterator := et.forest.GetVerticesAtLevel(l)
+			for iterator.HasNext() {
+				vertex := iterator.NextVertex()
+				numberReceiptsRemoved += vertex.(*ReceiptsOfSameResult).Size()
+			}
 		}
 	}
 


### PR DESCRIPTION
[dapperlabs/flow-go/issues/5414](https://github.com/dapperlabs/flow-go/issues/5414)

This PR implements logic for repopulating execution tree on startup.

- Changed builder constructor to perform repopulating on construction time
- Implemented a shortcut for pruning execution tree when it's empty, since it was very slow, especially in tests
- Implemented fork traversing from finalized block to last sealed
- Removed logic for adding last sealed result to execution tree.