### PR TITLE
Fix Cadence dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/libp2p/go-tcp-transport v0.2.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.15.1-patch.1
+	github.com/onflow/cadence v0.15.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2
 	github.com/onflow/flow-go-sdk v0.18.0
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.20.0 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.15.1-patch.1
+	github.com/onflow/cadence v0.15.1
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.18.0
 	github.com/onflow/flow-go/crypto v0.12.0 // replaced by version on-disk


### PR DESCRIPTION
For downstream dependencies, like the Emulator, the replace statement is not used, so the actual dependency statement is used. However, it incorrectly refers to a non-existent tag.  