### PR TITLE
Fix inconsistent RLP encoding for Identity

### DIFF
--- a/model/flow/identity.go
+++ b/model/flow/identity.go
@@ -3,12 +3,14 @@ package flow
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"regexp"
 	"sort"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/pkg/errors"
 	"github.com/vmihailenco/msgpack"
 
@@ -131,6 +133,18 @@ func (iy Identity) MarshalMsgpack() ([]byte, error) {
 		return nil, fmt.Errorf("could not encode msgpack: %w", err)
 	}
 	return data, nil
+}
+
+func (iy Identity) EncodeRLP(w io.Writer) error {
+	encodable, err := encodableFromIdentity(iy)
+	if err != nil {
+		return fmt.Errorf("could not convert to encodable: %w", err)
+	}
+	err = rlp.Encode(w, encodable)
+	if err != nil {
+		return fmt.Errorf("could not encode rlp: %w", err)
+	}
+	return nil
 }
 
 func identityFromEncodable(ie encodableIdentity, identity *Identity) error {

--- a/model/flow/identity_test.go
+++ b/model/flow/identity_test.go
@@ -5,6 +5,7 @@ import (
 	//"encoding/json"
 	"testing"
 
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -150,4 +151,17 @@ func TestShuffle(t *testing.T) {
 		shuffled2 := il.DeterministicShuffle(seed)
 		assert.Equal(t, shuffled1, shuffled2)
 	})
+}
+
+// check that identities consistently hash to the same ID, even with different
+// public key implementations
+func TestIdentity_ID(t *testing.T) {
+	identity1 := unittest.IdentityFixture(unittest.WithKeys)
+	var identity2 = new(flow.Identity)
+	*identity2 = *identity1
+	identity2.StakingPubKey = encodable.StakingPubKey{PublicKey: identity1.StakingPubKey}
+
+	id1 := flow.MakeID(identity1)
+	id2 := flow.MakeID(identity2)
+	assert.Equal(t, id1, id2)
 }

--- a/model/flow/identity_test.go
+++ b/model/flow/identity_test.go
@@ -2,19 +2,14 @@ package flow_test
 
 import (
 	"math/rand"
-	//"encoding/json"
 	"testing"
 
-	"github.com/onflow/flow-go/model/encodable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	//"github.com/stretchr/testify/require"
-	//"github.com/vmihailenco/msgpack/v4"
-
+	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
-	//"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestHexStringToIdentifier(t *testing.T) {

--- a/state/protocol/inmem/encodable_test.go
+++ b/state/protocol/inmem/encodable_test.go
@@ -1,0 +1,39 @@
+package inmem_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/encodable"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state/protocol/inmem"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// test that we have the same snapshot after an encode/decode cycle
+// in particular with differing public key implementations
+func TestEncodeDecode(t *testing.T) {
+
+	participants := unittest.IdentityListFixture(10)
+	// add a partner, which has its key represented as an encodable wrapper
+	// type rather than the direct crypto type
+	partner := unittest.IdentityFixture(unittest.WithKeys, func(identity *flow.Identity) {
+		identity.NetworkPubKey = encodable.NetworkPubKey{PublicKey: identity.NetworkPubKey}
+	})
+	participants = append(participants, partner)
+	initialSnapshot := unittest.RootSnapshotFixture(participants)
+
+	// encode then decode the snapshto
+	var decodedSnapshot inmem.EncodableSnapshot
+	bz, err := json.Marshal(initialSnapshot.Encodable())
+	require.NoError(t, err)
+	err = json.Unmarshal(bz, &decodedSnapshot)
+	require.NoError(t, err)
+
+	// check that the computed and stored result IDs are consistent
+	decodedResult, decodedSeal := decodedSnapshot.LatestResult, decodedSnapshot.LatestSeal
+	assert.Equal(t, decodedResult.ID(), decodedSeal.ResultID)
+}


### PR DESCRIPTION
This PR adds custom RLP encoding for `flow.Identity` which addresses a problem where different underlying implementations of `crypto.PublicKey` in the `StakingPubKey` and `NetworkingPubKey` fields of `Identity` resulted in different RLP encodings for the same key.

This PR adds a test for result ID consistency after an encode/decode cycle for the entire snapshot, using differing `PublicKey` implementations. There is also [this proof-of-concept which focusses only on the keys](https://github.com/onflow/flow-go/compare/jordan/5430-inconsistent-snapshot-poc). 

💡  More details in https://github.com/dapperlabs/flow-go/issues/5430#issuecomment-828792960