### PR TITLE
adding retry logic to look for at least two execution receipts for a …

### DIFF
--- a/deploy/systemd-docker/flow-access.service
+++ b/deploy/systemd-docker/flow-access.service
@@ -33,6 +33,5 @@ ExecStart=docker run --rm \
 	--rpc-addr 0.0.0.0:9000 \
 	--http-addr 0.0.0.0:8000 \
 	--collection-ingress-port 9000 \
-	--script-addr ${FLOW_NETWORK_EXECUTION_NODE} \
 	--bind 0.0.0.0:3569 \
 	--loglevel ERROR

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -69,6 +69,10 @@ func (suite *Suite) SetupTest() {
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Epochs").Return(suite.epochQuery).Maybe()
+	header := unittest.BlockHeaderFixture()
+	params := new(protocol.Params)
+	params.On("Root").Return(&header, nil)
+	suite.state.On("Params").Return(params).Maybe()
 
 	suite.collClient = new(accessmock.AccessAPIClient)
 	suite.execClient = new(accessmock.ExecutionAPIClient)
@@ -99,7 +103,6 @@ func (suite *Suite) RunTest(
 
 		suite.backend = backend.New(
 			suite.state,
-			suite.execClient,
 			suite.collClient,
 			nil,
 			blocks,
@@ -275,7 +278,6 @@ func (suite *Suite) TestSendTransactionToRandomCollectionNode() {
 
 		backend := backend.New(
 			suite.state,
-			nil,
 			nil, // setting collectionRPC to nil to choose a random collection node for each send tx request
 			nil,
 			nil,
@@ -411,10 +413,15 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 	})
 }
 
-// TestGetSealedTransaction tests that transactions status of transaction that belongs to a sealed blocked
+// TestGetSealedTransaction tests that transactions status of transaction that belongs to a sealed block
 // is reported as sealed
 func (suite *Suite) TestGetSealedTransaction() {
-	suite.RunTest(func(handler *access.Handler, db *badger.DB, blocks *storage.Blocks, headers *storage.Headers) {
+	unittest.RunWithBadgerDB(suite.T(), func(db *badger.DB) {
+		headers, _, _, _, _, blocks, _, _, _, _ := util.StorageLayer(suite.T(), db)
+		results := storage.NewExecutionResults(suite.metrics, db)
+		receipts := storage.NewExecutionReceipts(suite.metrics, db, results)
+		enIdentities := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
+		enNodeIDs := flow.IdentifierList(enIdentities.NodeIDs())
 
 		// create block -> collection -> transactions
 		block, collection := suite.createChain()
@@ -429,13 +436,23 @@ func (suite *Suite) TestGetSealedTransaction() {
 		suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
 
 		colIdentities := unittest.IdentityListFixture(1, unittest.WithRole(flow.RoleCollection))
-		suite.snapshot.On("Identities", mock.Anything).Return(colIdentities, nil).Once()
+		allIdentities := append(colIdentities, enIdentities...)
+
+		suite.snapshot.On("Identities", mock.Anything).Return(allIdentities, nil).Once()
 
 		exeEventResp := execproto.GetTransactionResultResponse{
 			Events: nil,
 		}
+
+		// generate receipts
+		executionReceipts := unittest.ReceiptsForBlockFixture(&block, enNodeIDs)
+
 		// assume execution node returns an empty list of events
 		suite.execClient.On("GetTransactionResult", mock.Anything, mock.Anything).Return(&exeEventResp, nil)
+
+		// create a mock connection factory
+		connFactory := new(factorymock.ConnectionFactory)
+		connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
 
 		// initialize storage
 		metrics := metrics.NewNoopCollector()
@@ -448,12 +465,33 @@ func (suite *Suite) TestGetSealedTransaction() {
 		blocksToMarkExecuted, err := stdmap.NewTimes(100)
 		require.NoError(suite.T(), err)
 
-		rpcEng := rpc.New(suite.log, suite.state, rpc.Config{}, nil, nil, nil, blocks, headers, collections, transactions,
-			nil, suite.chainID, metrics, 0, 0, false, false, nil, nil)
+		backend := backend.New(
+			suite.state,
+			suite.collClient,
+			nil,
+			blocks,
+			headers,
+			collections,
+			transactions,
+			receipts,
+			suite.chainID,
+			suite.metrics,
+			connFactory,
+			false,
+			backend.DefaultMaxHeightRange,
+			nil,
+			enNodeIDs.Strings(),
+			suite.log,
+		)
+
+		handler := access.NewHandler(backend, suite.chainID.Chain())
+
+		rpcEng := rpc.New(suite.log, suite.state, rpc.Config{}, nil, nil, blocks, headers, collections, transactions,
+			receipts, suite.chainID, metrics, 0, 0, false, false, nil, nil)
 
 		// create the ingest engine
 		ingestEng, err := ingestion.New(suite.log, suite.net, suite.state, suite.me, suite.request, blocks, headers, collections,
-			transactions, nil, metrics, collectionsToMarkFinalized, collectionsToMarkExecuted, blocksToMarkExecuted, rpcEng)
+			transactions, receipts, metrics, collectionsToMarkFinalized, collectionsToMarkExecuted, blocksToMarkExecuted, rpcEng)
 		require.NoError(suite.T(), err)
 
 		// 1. Assume that follower engine updated the block storage and the protocol state. The block is reported as sealed
@@ -471,11 +509,16 @@ func (suite *Suite) TestGetSealedTransaction() {
 		// 3. Request engine is used to request missing collection
 		suite.request.On("EntityByID", collection.ID(), mock.Anything).Return()
 
-		// 4. Ingest engine receives the requested collection and finishes processing
+		// 4. Ingest engine receives the requested collection and all the execution receipts
 		ingestEng.OnCollection(originID, &collection)
-		<-ingestEng.Done()
 
-		// 5. client requests a transaction
+		for _, r := range executionReceipts {
+			err = ingestEng.Process(enNodeIDs[0], r)
+			require.NoError(suite.T(), err)
+		}
+		unittest.AssertClosesBefore(suite.T(), ingestEng.Done(), 3*time.Second)
+
+		// 5. Client requests a transaction
 		tx := collection.Transactions[0]
 		txID := tx.ID()
 		getReq := &accessproto.GetTransactionRequest{
@@ -498,17 +541,15 @@ func (suite *Suite) TestExecuteScript() {
 		results := storage.NewExecutionResults(suite.metrics, db)
 		receipts := storage.NewExecutionReceipts(suite.metrics, db, results)
 
-		identities := unittest.IdentityListFixture(1)
+		identities := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
 		suite.snapshot.On("Identities", mock.Anything).Return(identities, nil)
-		executionNodeIdentity := identities[0]
 
 		// create a mock connection factory
 		connFactory := new(factorymock.ConnectionFactory)
-		connFactory.On("GetExecutionAPIClient", executionNodeIdentity.Address).Return(suite.execClient, &mockCloser{}, nil)
+		connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
 
 		suite.backend = backend.New(
 			suite.state,
-			suite.execClient,
 			suite.collClient,
 			nil,
 			blocks,
@@ -522,7 +563,7 @@ func (suite *Suite) TestExecuteScript() {
 			false,
 			backend.DefaultMaxHeightRange,
 			nil,
-			nil,
+			flow.IdentifierList(identities.NodeIDs()).Strings(),
 			suite.log,
 		)
 
@@ -554,13 +595,13 @@ func (suite *Suite) TestExecuteScript() {
 		require.NoError(suite.T(), err)
 		suite.snapshot.On("Head").Return(lastBlock.Header, nil).Once()
 
-		// create an execution receipt for the block
-		executionReceiptLast := unittest.ReceiptForBlockFixture(&lastBlock)
-		executionReceiptLast.ExecutorID = identities[0].NodeID
-
-		// notify the ingestion engine about the receipt
-		err = ingestEng.ProcessLocal(executionReceiptLast)
-		require.NoError(suite.T(), err)
+		// create execution receipts for each of the execution node and the last block
+		executionReceipts := unittest.ReceiptsForBlockFixture(&lastBlock, identities.NodeIDs())
+		// notify the ingest engine about the receipts
+		for _, r := range executionReceipts {
+			err = ingestEng.ProcessLocal(r)
+			require.NoError(suite.T(), err)
+		}
 
 		// create another block as a predecessor of the block created earlier
 		prevBlock := unittest.BlockFixture()
@@ -570,15 +611,17 @@ func (suite *Suite) TestExecuteScript() {
 		err = db.Update(operation.IndexBlockHeight(prevBlock.Header.Height, prevBlock.ID()))
 		require.NoError(suite.T(), err)
 
-		// create an execution receipt for the block
-		executionReceiptPrev := unittest.ReceiptForBlockFixture(&prevBlock)
-		executionReceiptPrev.ExecutorID = identities[0].NodeID
+		// create execution receipts for each of the execution node and the previous block
+		executionReceipts = unittest.ReceiptsForBlockFixture(&prevBlock, identities.NodeIDs())
+		// notify the ingest engine about the receipts
+		for _, r := range executionReceipts {
+			err = ingestEng.ProcessLocal(r)
+			require.NoError(suite.T(), err)
+		}
 
-		// notify the ingestion engine about the receipt
-		err = ingestEng.ProcessLocal(executionReceiptPrev)
-		require.NoError(suite.T(), err)
 		// wait for the receipt to be persisted
 		unittest.AssertClosesBefore(suite.T(), ingestEng.Done(), 3*time.Second)
+
 		ctx := context.Background()
 
 		script := []byte("dummy script")

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -89,7 +89,7 @@ func (suite *Suite) SetupTest() {
 	blocksToMarkExecuted, err := stdmap.NewTimes(100)
 	require.NoError(suite.T(), err)
 
-	rpcEng := rpc.New(log, suite.proto.state, rpc.Config{}, nil, nil, nil, suite.blocks, suite.headers, suite.collections,
+	rpcEng := rpc.New(log, suite.proto.state, rpc.Config{}, nil, nil, suite.blocks, suite.headers, suite.collections,
 		suite.transactions, suite.receipts, flow.Testnet, metrics.NewNoopCollector(), 0, 0, false, false, nil, nil)
 
 	eng, err := New(log, net, suite.proto.state, suite.me, suite.request, suite.blocks, suite.headers, suite.collections,

--- a/engine/access/rate_limit_test.go
+++ b/engine/access/rate_limit_test.go
@@ -107,7 +107,7 @@ func (suite *RateLimitTestSuite) SetupTest() {
 		"Ping": suite.rateLimit,
 	}
 
-	suite.rpcEng = rpc.New(suite.log, suite.state, config, suite.execClient, suite.collClient, nil, suite.blocks, suite.headers, suite.collections, suite.transactions,
+	suite.rpcEng = rpc.New(suite.log, suite.state, config, suite.collClient, nil, suite.blocks, suite.headers, suite.collections, suite.transactions,
 		nil, suite.chainID, suite.metrics, 0, 0, false, false, apiRateLimt, apiBurstLimt)
 	unittest.AssertClosesBefore(suite.T(), suite.rpcEng.Ready(), 2*time.Second)
 

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
-	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -22,6 +22,12 @@ import (
 
 // maxExecutionNodesCnt is the max number of execution nodes that will be contacted to complete an execution api request
 const maxExecutionNodesCnt = 3
+
+// minExecutionNodesCnt is the minimum number of execution nodes expected to have sent the execution receipt for a block
+const minExecutionNodesCnt = 2
+
+// maxAttemptsForExecutionReceipt is the maximum number of attempts to find execution receipts for a given block ID
+const maxAttemptsForExecutionReceipt = 3
 
 // DefaultMaxHeightRange is the default maximum size of range requests.
 const DefaultMaxHeightRange = 250
@@ -49,7 +55,6 @@ type Backend struct {
 	backendBlockDetails
 	backendAccounts
 
-	executionRPC      execproto.ExecutionAPIClient
 	state             protocol.State
 	chainID           flow.ChainID
 	collections       storage.Collections
@@ -59,7 +64,6 @@ type Backend struct {
 
 func New(
 	state protocol.State,
-	executionRPC execproto.ExecutionAPIClient,
 	collectionRPC accessproto.AccessAPIClient,
 	historicalAccessNodes []accessproto.AccessAPIClient,
 	blocks storage.Blocks,
@@ -82,20 +86,17 @@ func New(
 	}
 
 	b := &Backend{
-		executionRPC: executionRPC,
-		state:        state,
+		state: state,
 		// create the sub-backends
 		backendScripts: backendScripts{
-			headers:            headers,
-			executionReceipts:  executionReceipts,
-			staticExecutionRPC: executionRPC,
-			connFactory:        connFactory,
-			state:              state,
-			log:                log,
+			headers:           headers,
+			executionReceipts: executionReceipts,
+			connFactory:       connFactory,
+			state:             state,
+			log:               log,
 		},
 		backendTransactions: backendTransactions{
 			staticCollectionRPC:  collectionRPC,
-			executionRPC:         executionRPC,
 			state:                state,
 			chainID:              chainID,
 			collections:          collections,
@@ -110,13 +111,12 @@ func New(
 			log:                  log,
 		},
 		backendEvents: backendEvents{
-			staticExecutionRPC: executionRPC,
-			state:              state,
-			headers:            headers,
-			executionReceipts:  executionReceipts,
-			connFactory:        connFactory,
-			log:                log,
-			maxHeightRange:     maxHeightRange,
+			state:             state,
+			headers:           headers,
+			executionReceipts: executionReceipts,
+			connFactory:       connFactory,
+			log:               log,
+			maxHeightRange:    maxHeightRange,
 		},
 		backendBlockHeaders: backendBlockHeaders{
 			headers: headers,
@@ -127,12 +127,11 @@ func New(
 			state:  state,
 		},
 		backendAccounts: backendAccounts{
-			staticExecutionRPC: executionRPC,
-			state:              state,
-			headers:            headers,
-			executionReceipts:  executionReceipts,
-			connFactory:        connFactory,
-			log:                log,
+			state:             state,
+			headers:           headers,
+			executionReceipts: executionReceipts,
+			connFactory:       connFactory,
+			log:               log,
 		},
 		collections:       collections,
 		executionReceipts: executionReceipts,
@@ -187,14 +186,10 @@ func configureTransactionValidator(state protocol.State, chainID flow.ChainID) *
 
 // Ping responds to requests when the server is up.
 func (b *Backend) Ping(ctx context.Context) error {
-	_, err := b.executionRPC.Ping(ctx, &execproto.PingRequest{})
-	if err != nil {
-		return fmt.Errorf("could not ping execution node: %w", err)
-	}
 
 	// staticCollectionRPC is only set if a collection node address was provided at startup
 	if b.staticCollectionRPC != nil {
-		_, err = b.staticCollectionRPC.Ping(ctx, &accessproto.PingRequest{})
+		_, err := b.staticCollectionRPC.Ping(ctx, &accessproto.PingRequest{})
 		if err != nil {
 			return fmt.Errorf("could not ping collection node: %w", err)
 		}
@@ -249,71 +244,70 @@ func convertStorageError(err error) error {
 }
 
 // executionNodesForBlockID returns upto maxExecutionNodesCnt number of randomly chosen execution node identities
-// which have executed the given block ID. If no such execution node is found, an empty list is returned.
+// which have executed the given block ID.
+// If no such execution node is found, an InsufficientExecutionReceipts error is returned.
 func executionNodesForBlockID(
+	ctx context.Context,
 	blockID flow.Identifier,
 	executionReceipts storage.ExecutionReceipts,
 	state protocol.State,
 	log zerolog.Logger) (flow.IdentityList, error) {
 
-	// lookup the receipts storage with the block ID
-	allReceipts, err := executionReceipts.ByBlockID(blockID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retreive execution receipts for block ID %v: %w", blockID, err)
-	}
-
-	// execution result ID to execution receipt map to keep track of receipts by their result id
-	var identicalReceipts = make(map[flow.Identifier][]*flow.ExecutionReceipt)
-
-	// maximum number of matching receipts found so far for any execution result id
-	maxMatchedReceiptCnt := 0
-	// execution result id key for the highest number of matching receipts in the identicalReceipts map
-	var maxMatchedReceiptResultID flow.Identifier
-
-	// find the largest list of receipts which have the same result ID
-	for _, receipt := range allReceipts {
-
-		resultID := receipt.ExecutionResult.ID()
-		identicalReceipts[resultID] = append(identicalReceipts[resultID], receipt)
-
-		currentMatchedReceiptCnt := len(identicalReceipts[resultID])
-		if currentMatchedReceiptCnt > maxMatchedReceiptCnt {
-			maxMatchedReceiptCnt = currentMatchedReceiptCnt
-			maxMatchedReceiptResultID = resultID
-		}
-	}
-
-	mismatchReceiptCnt := len(identicalReceipts)
-	// if there are more than one execution result for the same block ID, log as error
-	if mismatchReceiptCnt > 1 {
-		identicalReceiptsStr := fmt.Sprintf("%v", flow.GetIDs(allReceipts))
-		log.Error().
-			Str("block_id", blockID.String()).
-			Str("execution_receipts", identicalReceiptsStr).
-			Msg("execution receipt mismatch")
-	}
-
-	// pick the largest list of matching receipts
-	matchingReceipts := identicalReceipts[maxMatchedReceiptResultID]
-
-	// collect all unique execution node ids from the receipts
 	var executorIDs flow.IdentifierList
-	executorIDMap := make(map[flow.Identifier]bool)
-	for _, receipt := range matchingReceipts {
-		if executorIDMap[receipt.ExecutorID] {
-			continue
+	var err error
+	attempt := 0
+
+	// check if the block ID is of the root block. If it is then don't look for execution receipts since they
+	// will not be present for the root block.
+	rootBlock, err := state.Params().Root()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retreive execution IDs for block ID %v: %w", blockID, err)
+	}
+
+	if rootBlock.ID() == blockID {
+		executorIdentities, err := state.Final().Identities(filter.HasRole(flow.RoleExecution))
+		if err != nil {
+			return nil, fmt.Errorf("failed to retreive execution IDs for block ID %v: %w", blockID, err)
 		}
-		executorIDs = append(executorIDs, receipt.ExecutorID)
-		executorIDMap[receipt.ExecutorID] = true
+		executorIDs = executorIdentities.NodeIDs()
+	} else {
+		// try to find atleast minExecutionNodesCnt execution node ids from the execution receipts for the given blockID
+		for ; attempt < maxAttemptsForExecutionReceipt; attempt++ {
+
+			executorIDs, err = findAllExecutionNodes(blockID, executionReceipts, log)
+			if err != nil {
+				return flow.IdentityList{}, err
+			}
+
+			if len(executorIDs) >= minExecutionNodesCnt {
+				break
+			}
+
+			// log the attempt
+			log.Debug().Int("attempt", attempt).Int("max_attempt", maxAttemptsForExecutionReceipt).
+				Int("execution_receipts_found", len(executorIDs)).
+				Str("block_id", blockID.String()).
+				Msg("insufficient execution receipts")
+
+			// if one or less execution receipts may have been received then re-query
+			// in the hope that more might have been received by now
+
+			select {
+			case <-ctx.Done():
+				return flow.IdentityList{}, err
+			case <-time.After(100 * time.Millisecond << time.Duration(attempt)):
+				//retry after an exponential backoff
+			}
+		}
+
+		receiptCnt := len(executorIDs)
+		// if less than minExecutionNodesCnt execution receipts have been received so far, then throw an error
+		if receiptCnt < minExecutionNodesCnt {
+			return flow.IdentityList{}, InsufficientExecutionReceipts{blockID: blockID, receiptCount: receiptCnt}
+		}
 	}
 
-	// return if less than 2 unique execution node ids were found
-	// since we want matching receipts from at least 2 ENs
-	if len(executorIDs) < 2 {
-		return flow.IdentityList{}, nil
-	}
-
-	// choose one of the preferred execution nodes
+	// choose from the preferred or fixed execution nodes
 	subsetENs, err := chooseExecutionNodes(state, executorIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retreive execution IDs for block ID %v: %w", blockID, err)
@@ -322,12 +316,74 @@ func executionNodesForBlockID(
 	// randomly choose upto maxExecutionNodesCnt identities
 	executionIdentitiesRandom := subsetENs.Sample(maxExecutionNodesCnt)
 
+	if len(executionIdentitiesRandom) == 0 {
+		return flow.IdentityList{},
+			fmt.Errorf("no matching execution node could for block ID %v", blockID)
+	}
+
 	return executionIdentitiesRandom, nil
+}
+
+// findAllExecutionNodes find all the execution nodes ids from the execution receipts that have been received for the
+// given blockID
+func findAllExecutionNodes(
+	blockID flow.Identifier,
+	executionReceipts storage.ExecutionReceipts,
+	log zerolog.Logger) (flow.IdentifierList, error) {
+
+	// lookup the receipts storage with the block ID
+	allReceipts, err := executionReceipts.ByBlockID(blockID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retreive execution receipts for block ID %v: %w", blockID, err)
+	}
+
+	executionResultMetaList := make(flow.ExecutionReceiptMetaList, 0, len(allReceipts))
+	for _, r := range allReceipts {
+		executionResultMetaList = append(executionResultMetaList, r.Meta())
+	}
+	executionResultGroupedMetaList := executionResultMetaList.GroupByResultID()
+
+	// maximum number of matching receipts found so far for any execution result id
+	maxMatchedReceiptCnt := 0
+	// execution result id key for the highest number of matching receipts in the identicalReceipts map
+	var maxMatchedReceiptResultID flow.Identifier
+
+	// find the largest list of receipts which have the same result ID
+	for resultID, executionReceiptList := range executionResultGroupedMetaList {
+		currentMatchedReceiptCnt := executionReceiptList.Size()
+		if currentMatchedReceiptCnt > maxMatchedReceiptCnt {
+			maxMatchedReceiptCnt = currentMatchedReceiptCnt
+			maxMatchedReceiptResultID = resultID
+		}
+	}
+
+	// if there are more than one execution result for the same block ID, log as error
+	if executionResultGroupedMetaList.NumberGroups() > 1 {
+		identicalReceiptsStr := fmt.Sprintf("%v", flow.GetIDs(allReceipts))
+		log.Error().
+			Str("block_id", blockID.String()).
+			Str("execution_receipts", identicalReceiptsStr).
+			Msg("execution receipt mismatch")
+	}
+
+	// pick the largest list of matching receipts
+	matchingReceiptMetaList := executionResultGroupedMetaList.GetGroup(maxMatchedReceiptResultID)
+
+	metaReceiptGroupedByExecutorID := matchingReceiptMetaList.GroupByExecutorID()
+
+	// collect all unique execution node ids from the receipts
+	var executorIDs flow.IdentifierList
+	for executorID := range metaReceiptGroupedByExecutorID {
+		executorIDs = append(executorIDs, executorID)
+	}
+
+	return executorIDs, nil
 }
 
 // chooseExecutionNodes finds the subset of execution nodes defined in the identity table by first
 // choosing the preferred execution nodes which have executed the transaction. If no such preferred
 // execution nodes are found, then the fixed execution nodes defined in the identity table are returned
+// If neither preferred nor fixed nodes are defined, then all execution node matching the executor IDs are returned.
 // e.g. If execution nodes in identity table are {1,2,3,4}, preferred ENs are defined as {2,3,4}
 // and the executor IDs is {1,2,3}, then {2, 3} is returned as the chosen subset of ENs
 func chooseExecutionNodes(state protocol.State, executorIDs flow.IdentifierList) (flow.IdentityList, error) {
@@ -337,22 +393,29 @@ func chooseExecutionNodes(state protocol.State, executorIDs flow.IdentifierList)
 		return nil, fmt.Errorf("failed to retreive all execution IDs: %w", err)
 	}
 
-	// If there are no preferred or fixed ENs, have the default behaviour be that
-	// we just return all the executor IDs, i.e. no preferrence at all.
-	if len(preferredENIdentifiers) == 0 && len(fixedENIdentifiers) == 0 {
-		return allENs.Filter(filter.HasNodeID(executorIDs...)), nil
+	// first try and choose from the preferred EN IDs
+	var chosenIDs flow.IdentityList
+	if len(preferredENIdentifiers) > 0 {
+		// find the preferred execution node IDs which have executed the transaction
+		chosenIDs = allENs.Filter(filter.And(filter.HasNodeID(preferredENIdentifiers...),
+			filter.HasNodeID(executorIDs...)))
+		if len(chosenIDs) > 0 {
+			return chosenIDs, nil
+		}
 	}
 
-	// find the preferred execution node IDs which have executed the transaction
-	preferredENIDs := allENs.Filter(filter.And(filter.HasNodeID(preferredENIdentifiers...),
-		filter.HasNodeID(executorIDs...)))
-
-	if len(preferredENIDs) > 0 {
-		return preferredENIDs, nil
+	// if no preferred EN ID is found, then choose from the fixed EN IDs
+	if len(fixedENIdentifiers) > 0 {
+		// choose fixed ENs which have executed the transaction
+		chosenIDs = allENs.Filter(filter.And(filter.HasNodeID(fixedENIdentifiers...), filter.HasNodeID(executorIDs...)))
+		if len(chosenIDs) > 0 {
+			return chosenIDs, nil
+		}
+		// if no such ENs are found then just choose all fixed ENs
+		chosenIDs = allENs.Filter(filter.HasNodeID(fixedENIdentifiers...))
+		return chosenIDs, nil
 	}
 
-	// if no such preferred ID is found, then choose the fixed EN IDs
-	fixedENIDs := allENs.Filter(filter.HasNodeID(fixedENIdentifiers...))
-
-	return fixedENIDs, nil
+	// If no preferred or fixed ENs have been specified, then return all executor IDs i.e. no preference at all
+	return allENs.Filter(filter.HasNodeID(executorIDs...)), nil
 }

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -17,12 +17,11 @@ import (
 )
 
 type backendAccounts struct {
-	state              protocol.State
-	staticExecutionRPC execproto.ExecutionAPIClient
-	headers            storage.Headers
-	executionReceipts  storage.ExecutionReceipts
-	connFactory        ConnectionFactory
-	log                zerolog.Logger
+	state             protocol.State
+	headers           storage.Headers
+	executionReceipts storage.ExecutionReceipts
+	connFactory       ConnectionFactory
+	log               zerolog.Logger
 }
 
 func (b *backendAccounts) GetAccount(ctx context.Context, address flow.Address) (*flow.Account, error) {
@@ -82,29 +81,17 @@ func (b *backendAccounts) getAccountAtBlockID(
 		BlockId: blockID[:],
 	}
 
-	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state, b.log)
+	execNodes, err := executionNodesForBlockID(ctx, blockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get account from the execution node: %v", err)
+		return nil, getAccountError(err)
 	}
 
 	var exeRes *execproto.GetAccountAtBlockIDResponse
-	if len(execNodes) == 0 {
-		if b.staticExecutionRPC == nil {
-			return nil, status.Errorf(codes.Internal, "failed to get account from the execution node")
-		}
-
-		exeRes, err = b.staticExecutionRPC.GetAccountAtBlockID(ctx, &exeReq)
-		if err != nil {
-			convertedErr := getAccountError(err)
-			return nil, convertedErr
-		}
-
-	} else {
-		exeRes, err = b.getAccountFromAnyExeNode(ctx, execNodes, exeReq)
-		if err != nil {
-			return nil, err
-		}
+	exeRes, err = b.getAccountFromAnyExeNode(ctx, execNodes, exeReq)
+	if err != nil {
+		return nil, err
 	}
+
 	account, err := convert.MessageToAccount(exeRes.GetAccount())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert account message: %v", err)

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -15,12 +15,11 @@ import (
 )
 
 type backendScripts struct {
-	headers            storage.Headers
-	executionReceipts  storage.ExecutionReceipts
-	state              protocol.State
-	staticExecutionRPC execproto.ExecutionAPIClient
-	connFactory        ConnectionFactory
-	log                zerolog.Logger
+	headers           storage.Headers
+	executionReceipts storage.ExecutionReceipts
+	state             protocol.State
+	connFactory       ConnectionFactory
+	log               zerolog.Logger
 }
 
 func (b *backendScripts) ExecuteScriptAtLatestBlock(
@@ -87,23 +86,9 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 	}
 
 	// find few execution nodes which have executed the block earlier and provided an execution receipt for it
-	execNodes, err := executionNodesForBlockID(blockID, b.executionReceipts, b.state, b.log)
+	execNodes, err := executionNodesForBlockID(ctx, blockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to execute the script on the execution node: %v", err)
-	}
-
-	// if no execution nodes were found, fall back to the static execution node if provided
-	if len(execNodes) == 0 {
-		if b.staticExecutionRPC == nil {
-			return nil, status.Errorf(codes.Internal, "failed to execute the script on the execution node")
-		}
-		// if an executionRPC is provided, send the script to that execution node
-		execResp, err := b.staticExecutionRPC.ExecuteScriptAtBlockID(ctx, &execReq)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to execute the script on the execution node: %v", err)
-		}
-		return execResp.GetValue(), nil
-
 	}
 
 	// try each of the execution nodes found

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -56,6 +56,10 @@ func (suite *Suite) SetupTest() {
 	suite.state = new(protocol.State)
 	suite.snapshot = new(protocol.Snapshot)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
+	header := unittest.BlockHeaderFixture()
+	params := new(protocol.Params)
+	params.On("Root").Return(&header, nil)
+	suite.state.On("Params").Return(params).Maybe()
 	suite.blocks = new(storagemock.Blocks)
 	suite.headers = new(storagemock.Headers)
 	suite.transactions = new(storagemock.Transactions)
@@ -79,7 +83,6 @@ func (suite *Suite) TestPing() {
 
 	backend := New(
 		suite.state,
-		suite.execClient,
 		suite.colClient,
 		nil, nil, nil, nil, nil, nil,
 		suite.chainID,
@@ -105,7 +108,6 @@ func (suite *Suite) TestGetLatestFinalizedBlockHeader() {
 
 	backend := New(
 		suite.state,
-		suite.execClient,
 		nil, nil, nil, nil, nil, nil, nil,
 		suite.chainID,
 		metrics.NewNoopCollector(),
@@ -137,7 +139,7 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil,
 		nil, nil, nil,
 		suite.chainID,
 		metrics.NewNoopCollector(),
@@ -157,8 +159,6 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot() {
 	convertedSnapshot, err := convert.SnapshotToBytes(snap)
 	suite.Require().NoError(err)
 	suite.Require().Equal(bytes, convertedSnapshot)
-
-	// suite.assertAllExpectations()
 }
 
 func (suite *Suite) TestGetLatestSealedBlockHeader() {
@@ -170,7 +170,7 @@ func (suite *Suite) TestGetLatestSealedBlockHeader() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil,
 		nil, nil, nil,
 		suite.chainID,
 		metrics.NewNoopCollector(),
@@ -207,7 +207,7 @@ func (suite *Suite) TestGetTransaction() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
 		suite.transactions,
 		nil,
 		suite.chainID,
@@ -240,7 +240,7 @@ func (suite *Suite) TestGetCollection() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil, nil, nil,
+		nil, nil, nil, nil,
 		suite.collections,
 		suite.transactions,
 		nil,
@@ -274,7 +274,6 @@ func (suite *Suite) TestTransactionStatusTransition() {
 	block.Header.Height = 2
 	headBlock := unittest.BlockFixture()
 	headBlock.Header.Height = block.Header.Height - 1 // head is behind the current block
-	fixedENIDs := flow.IdentifierList{}
 
 	suite.snapshot.
 		On("Head").
@@ -299,10 +298,8 @@ func (suite *Suite) TestTransactionStatusTransition() {
 
 	txID := transactionBody.ID()
 	blockID := block.ID()
-	receipts := suite.setupReceipts(&block)
-	fixedENIDs = append(fixedENIDs, receipts[0].ExecutorID)
-
-	suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(&block)
+	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
@@ -321,7 +318,6 @@ func (suite *Suite) TestTransactionStatusTransition() {
 		suite.state,
 		nil,
 		nil,
-		nil,
 		suite.blocks,
 		suite.headers,
 		suite.collections,
@@ -333,11 +329,9 @@ func (suite *Suite) TestTransactionStatusTransition() {
 		false,
 		DefaultMaxHeightRange,
 		nil,
-		nil,
+		flow.IdentifierList(fixedENIDs.NodeIDs()).Strings(),
 		suite.log,
 	)
-
-	preferredENIdentifiers = fixedENIDs
 
 	// Successfully return empty event list
 	suite.execClient.
@@ -438,7 +432,6 @@ func (suite *Suite) TestTransactionExpiredStatusTransition() {
 
 	backend := New(
 		suite.state,
-		suite.execClient,
 		nil,
 		nil,
 		suite.blocks,
@@ -534,9 +527,14 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 	snapshotAtBlock := new(protocol.Snapshot)
 	snapshotAtBlock.On("Head").Return(refBlock.Header, nil)
 
+	_, enIDs := suite.setupReceipts(&block)
+	suite.snapshot.On("Identities", mock.Anything).Return(enIDs, nil)
+
 	suite.state.
 		On("AtBlockID", refBlockID).
 		Return(snapshotAtBlock, nil)
+
+	suite.state.On("Final").Return(snapshotAtBlock, nil).Maybe()
 
 	// transaction storage returns the corresponding transaction
 	suite.transactions.
@@ -566,17 +564,7 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 		On("ByCollectionID", collection.ID()).
 		Return(&block, nil)
 
-	ids := unittest.IdentityListFixture(2)
-	receipt1 := unittest.ReceiptForBlockFixture(&block)
-	receipt1.ExecutorID = ids[0].NodeID
-	receipt2 := unittest.ReceiptForBlockFixture(&block)
-	receipt2.ExecutorID = ids[1].NodeID
-	receipt1.ExecutionResult = receipt2.ExecutionResult
-	suite.receipts.
-		On("ByBlockID", blockID).
-		Return(flow.ExecutionReceiptList{receipt1, receipt2}, nil).Once()
-
-	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
+	receipts, _ := suite.setupReceipts(&block)
 
 	exeEventReq := execproto.GetTransactionResultRequest{
 		BlockId:       blockID[:],
@@ -594,12 +582,10 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 		Once()
 
 	// create a mock connection factory
-	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory := suite.setupConnectionFactory()
 
 	backend := New(
 		suite.state,
-		suite.execClient,
 		nil,
 		nil,
 		suite.blocks,
@@ -613,9 +599,11 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 		false,
 		100,
 		nil,
-		nil,
+		flow.IdentifierList(enIDs.NodeIDs()).Strings(),
 		suite.log,
 	)
+
+	preferredENIdentifiers = flow.IdentifierList{receipts[0].ExecutorID}
 
 	// should return pending status when we have not observed collection for the transaction
 	suite.Run("pending", func() {
@@ -653,7 +641,6 @@ func (suite *Suite) TestTransactionResultUnknown() {
 
 	backend := New(
 		suite.state,
-		nil,
 		nil,
 		nil,
 		nil,
@@ -698,7 +685,7 @@ func (suite *Suite) TestGetLatestFinalizedBlock() {
 
 	backend := New(
 		suite.state,
-		nil, nil, nil,
+		nil, nil,
 		suite.blocks,
 		nil, nil, nil, nil,
 		suite.chainID,
@@ -739,7 +726,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			b := unittest.BlockFixture()
 			suite.headers.
 				On("ByBlockID", b.ID()).
-				Return(b.Header, nil).Twice()
+				Return(b.Header, nil).Once()
 
 			headers[i] = b.Header
 
@@ -758,7 +745,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 	}
 	blockHeaders := setupStorage(5)
 
-	suite.snapshot.On("Identities", mock.Anything).Return(validExecutorIdentities, nil).Once()
+	suite.snapshot.On("Identities", mock.Anything).Return(validExecutorIdentities, nil)
 	validENIDs := flow.IdentifierList(validExecutorIdentities.NodeIDs())
 
 	// create a mock connection factory
@@ -802,50 +789,23 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 		Type:     string(flow.EventAccountCreated),
 	}
 
+	// create receipt mocks that always returns empty
+	receipts := new(storagemock.ExecutionReceipts)
+	receipts.
+		On("ByBlockID", mock.Anything).
+		Return(flow.ExecutionReceiptList{}, nil)
+
 	// expect two calls to the executor api client (one for each of the following 2 test cases)
 	suite.execClient.
 		On("GetEventsForBlockIDs", ctx, exeReq).
 		Return(&exeResp, nil).
-		Twice()
+		Once()
 
-	suite.Run("with fixed execution node", func() {
-
-		// create receipt mocks that always returns empty
-		receipts := new(storagemock.ExecutionReceipts)
-		receipts.
-			On("ByBlockID", mock.Anything).
-			Return(flow.ExecutionReceiptList{}, nil).Once()
+	suite.Run("with an execution node chosen using block ID form the list of Fixed ENs", func() {
 
 		// create the handler
 		backend := New(
 			suite.state,
-			suite.execClient, // pass the default client
-			nil, nil,
-			nil,
-			suite.headers, nil, nil,
-			receipts,
-			suite.chainID,
-			metrics.NewNoopCollector(),
-			nil,
-			false,
-			DefaultMaxHeightRange,
-			nil,
-			nil,
-			suite.log,
-		)
-
-		// execute request
-		actual, err := backend.GetEventsForBlockIDs(ctx, string(flow.EventAccountCreated), blockIDs)
-		suite.checkResponse(actual, err)
-
-		suite.Require().Equal(expected, actual)
-	})
-
-	suite.Run("with an execution node chosen using block ID", func() {
-		// create the handler
-		backend := New(
-			suite.state,
-			nil,
 			nil, nil,
 			nil,
 			suite.headers, nil, nil,
@@ -872,11 +832,10 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 		// create the handler
 		backend := New(
 			suite.state,
-			nil, // no default client, hence the receipts storage should be looked up
 			nil, nil,
 			nil,
 			suite.headers, nil, nil,
-			suite.receipts,
+			receipts,
 			suite.chainID,
 			metrics.NewNoopCollector(),
 			connFactory, // the connection factory should be used to get the execution node client
@@ -887,7 +846,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 			suite.log,
 		)
 
-		// execute request with an empty block id list and expect an error (not a panic)
+		// execute request with an empty block id list and expect an empty list of events and no error
 		resp, err := backend.GetEventsForBlockIDs(ctx, string(flow.EventAccountCreated), []flow.Identifier{})
 		require.NoError(suite.T(), err)
 		require.Empty(suite.T(), resp)
@@ -897,22 +856,38 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 }
 
 func (suite *Suite) TestGetEventsForHeightRange() {
-	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
 
 	ctx := context.Background()
 	const minHeight uint64 = 5
 	const maxHeight uint64 = 10
 	var headHeight uint64
 	var blockHeaders []*flow.Header
+	var nodeIdentities flow.IdentityList
 
 	headersDB := make(map[uint64]*flow.Header) // backend for storage.Headers
 	var head *flow.Header                      // backend for Snapshot.Head
 
+	state := new(protocol.State)
+	snapshot := new(protocol.Snapshot)
+	state.On("Final").Return(snapshot, nil)
+	state.On("Sealed").Return(snapshot, nil)
+
+	rootHeader := unittest.BlockHeaderFixture()
+	params := new(protocol.Params)
+	params.On("Root").Return(&rootHeader, nil)
+	state.On("Params").Return(params).Maybe()
+
 	// mock snapshot to return head backend
-	suite.snapshot.On("Head").Return(
+	snapshot.On("Head").Return(
 		func() *flow.Header { return head },
 		func() error { return nil },
-	).Maybe()
+	)
+	snapshot.On("Identities", mock.Anything).Return(
+		func(_ flow.IdentityFilter) flow.IdentityList {
+			return nodeIdentities
+		},
+		func(flow.IdentityFilter) error { return nil },
+	)
 
 	// mock headers to pull from headers backend
 	suite.headers.On("ByHeight", mock.Anything).Return(
@@ -933,23 +908,23 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 		head = &header
 	}
 
-	setupStorage := func(min uint64, max uint64) []*flow.Header {
+	setupStorage := func(min uint64, max uint64) ([]*flow.Header, []*flow.ExecutionReceipt, flow.IdentityList) {
 		headersDB = make(map[uint64]*flow.Header) // reset backend
 
 		var headers []*flow.Header
+		var ers []*flow.ExecutionReceipt
+		var enIDs flow.IdentityList
 		for i := min; i <= max; i++ {
-			header := unittest.BlockHeaderFixture()
-			headersDB[i] = &header
-			headers = append(headers, &header)
+			block := unittest.BlockFixture()
+			header := block.Header
+			headersDB[i] = header
+			headers = append(headers, header)
+			newErs, ids := suite.setupReceipts(&block)
+			ers = append(ers, newErs...)
+			enIDs = append(enIDs, ids...)
 		}
-
-		return headers
+		return headers, ers, enIDs
 	}
-
-	// use the static execution node
-	suite.receipts.
-		On("ByBlockID", mock.Anything).
-		Return(flow.ExecutionReceiptList{}, nil)
 
 	setupExecClient := func() []flow.BlockEvents {
 		blockIDs := make([]flow.Identifier, len(blockHeaders))
@@ -994,14 +969,16 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 		return results
 	}
 
+	connFactory := suite.setupConnectionFactory()
+
 	suite.Run("invalid request max height < min height", func() {
 		backend := New(
 			suite.state,
-			nil, nil, nil, nil, suite.headers, nil, nil,
+			nil, nil, nil, suite.headers, nil, nil,
 			suite.receipts,
 			suite.chainID,
 			metrics.NewNoopCollector(),
-			nil,
+			connFactory,
 			false,
 			DefaultMaxHeightRange,
 			nil,
@@ -1021,13 +998,13 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 
 		// setup mocks
 		setupHeadHeight(headHeight)
-		blockHeaders = setupStorage(minHeight, maxHeight)
+		blockHeaders, _, nodeIdentities = setupStorage(minHeight, maxHeight)
 		expectedResp := setupExecClient()
+		fixedENIdentifiersStr := flow.IdentifierList(nodeIdentities.NodeIDs()).Strings()
 
 		// create handler
 		backend := New(
-			suite.state,
-			suite.execClient,
+			state,
 			nil, nil,
 			suite.blocks,
 			suite.headers,
@@ -1035,11 +1012,11 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			suite.receipts,
 			suite.chainID,
 			metrics.NewNoopCollector(),
-			nil,
+			connFactory,
 			false,
 			DefaultMaxHeightRange,
 			nil,
-			nil,
+			fixedENIdentifiersStr,
 			suite.log,
 		)
 
@@ -1055,12 +1032,12 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 	suite.Run("valid request with max_height > last_sealed_block_height", func() {
 		headHeight = maxHeight - 1
 		setupHeadHeight(headHeight)
-		blockHeaders = setupStorage(minHeight, headHeight)
+		blockHeaders, _, nodeIdentities = setupStorage(minHeight, headHeight)
 		expectedResp := setupExecClient()
+		fixedENIdentifiersStr := flow.IdentifierList(nodeIdentities.NodeIDs()).Strings()
 
 		backend := New(
-			suite.state,
-			suite.execClient,
+			state,
 			nil, nil,
 			suite.blocks,
 			suite.headers,
@@ -1068,11 +1045,11 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			suite.receipts,
 			suite.chainID,
 			metrics.NewNoopCollector(),
-			nil,
+			connFactory,
 			false,
 			DefaultMaxHeightRange,
 			nil,
-			nil,
+			fixedENIdentifiersStr,
 			suite.log,
 		)
 
@@ -1087,12 +1064,12 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 	suite.Run("invalid request exceeding max height range", func() {
 		headHeight = maxHeight - 1
 		setupHeadHeight(headHeight)
-		blockHeaders = setupStorage(minHeight, headHeight)
+		blockHeaders, _, nodeIdentities = setupStorage(minHeight, headHeight)
+		fixedENIdentifiersStr := flow.IdentifierList(nodeIdentities.NodeIDs()).Strings()
 
 		// create handler
 		backend := New(
-			suite.state,
-			suite.execClient,
+			state,
 			nil, nil,
 			suite.blocks,
 			suite.headers,
@@ -1100,11 +1077,11 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			suite.receipts,
 			suite.chainID,
 			metrics.NewNoopCollector(),
-			nil,
+			connFactory,
 			false,
 			1, // set maximum range to 1
 			nil,
-			nil,
+			fixedENIdentifiersStr,
 			suite.log,
 		)
 
@@ -1119,12 +1096,12 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 
 		// setup mocks
 		setupHeadHeight(headHeight)
-		blockHeaders = setupStorage(minHeight, maxHeight)
+		blockHeaders, _, nodeIdentities = setupStorage(minHeight, maxHeight)
+		fixedENIdentifiersStr := flow.IdentifierList(nodeIdentities.NodeIDs()).Strings()
 
 		// create handler
 		backend := New(
-			suite.state,
-			suite.execClient,
+			state,
 			nil, nil,
 			suite.blocks,
 			suite.headers,
@@ -1132,11 +1109,11 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 			suite.receipts,
 			suite.chainID,
 			metrics.NewNoopCollector(),
-			nil,
+			connFactory,
 			false,
 			DefaultMaxHeightRange,
 			nil,
-			nil,
+			fixedENIdentifiersStr,
 			suite.log,
 		)
 
@@ -1186,7 +1163,9 @@ func (suite *Suite) TestGetAccount() {
 		Return(exeResp, nil).
 		Once()
 
-	receipts := suite.setupReceipts(&block)
+	receipts, ids := suite.setupReceipts(&block)
+
+	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
 	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
@@ -1194,7 +1173,6 @@ func (suite *Suite) TestGetAccount() {
 	// create the handler with the mock
 	backend := New(
 		suite.state,
-		nil,
 		nil, nil, nil,
 		suite.headers,
 		nil, nil,
@@ -1232,17 +1210,21 @@ func (suite *Suite) TestGetAccountAtBlockHeight() {
 	ctx := context.Background()
 
 	// create a mock block header
-	h := unittest.BlockHeaderFixture()
+	b := unittest.BlockFixture()
+	h := b.Header
 
 	// setup headers storage to return the header when queried by height
 	suite.headers.
 		On("ByHeight", height).
-		Return(&h, nil).
+		Return(h, nil).
 		Once()
 
-	suite.receipts.
-		On("ByBlockID", mock.Anything).
-		Return(flow.ExecutionReceiptList{}, nil).Once()
+	receipts, ids := suite.setupReceipts(&b)
+	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
+
+	// create a mock connection factory
+	connFactory := new(backendmock.ConnectionFactory)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
 
 	// create the expected execution API request
 	blockID := h.ID()
@@ -1265,20 +1247,21 @@ func (suite *Suite) TestGetAccountAtBlockHeight() {
 	// create the handler with the mock
 	backend := New(
 		suite.state,
-		suite.execClient,
 		nil, nil, nil,
 		suite.headers,
 		nil, nil,
 		suite.receipts,
 		flow.Testnet,
 		metrics.NewNoopCollector(),
-		nil,
+		connFactory,
 		false,
 		DefaultMaxHeightRange,
 		nil,
 		nil,
 		suite.log,
 	)
+
+	preferredENIdentifiers = flow.IdentifierList{receipts[0].ExecutorID}
 
 	suite.Run("happy path - valid request and valid response", func() {
 		account, err := backend.GetAccountAtBlockHeight(ctx, address, height)
@@ -1296,7 +1279,7 @@ func (suite *Suite) TestGetNetworkParameters() {
 	expectedChainID := flow.Mainnet
 
 	backend := New(
-		nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil,
 		nil,
 		flow.Mainnet,
 		metrics.NewNoopCollector(),
@@ -1336,9 +1319,27 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 		r.ExecutionResult = er
 		receipts[j] = r
 	}
+
+	currentAttempt := 0
+	attempt1Receipts, attempt2Receipts, attempt3Receipts := receipts, receipts, receipts
+
+	// setup receipts storage mock to return different list of receipts on each call
 	suite.receipts.
-		On("ByBlockID", block.ID()).
-		Return(receipts, nil)
+		On("ByBlockID", block.ID()).Return(
+		func(id flow.Identifier) flow.ExecutionReceiptList {
+			switch currentAttempt {
+			case 0:
+				currentAttempt++
+				return attempt1Receipts
+			case 1:
+				currentAttempt++
+				return attempt2Receipts
+			default:
+				currentAttempt = 0
+				return attempt3Receipts
+			}
+		},
+		func(id flow.Identifier) error { return nil })
 
 	suite.snapshot.On("Identities", mock.Anything).Return(
 		func(filter flow.IdentityFilter) flow.IdentityList {
@@ -1354,7 +1355,7 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 		if fixedENs != nil {
 			fixedENIdentifiers = fixedENs.NodeIDs()
 		}
-		actualList, err := executionNodesForBlockID(block.ID(), suite.receipts, suite.state, suite.log)
+		actualList, err := executionNodesForBlockID(context.Background(), block.ID(), suite.receipts, suite.state, suite.log)
 		require.NoError(suite.T(), err)
 		if expectedENs == nil {
 			expectedENs = flow.IdentityList{}
@@ -1400,13 +1401,27 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 	})
 	// if both are specified, but the preferred ENs don't match the ExecutorIDs in the ER,
 	// the ExecutionNodesForBlockID function should return the fixed ENs list
-	suite.Run("four fixed ENs of which two are preferred ENs", func() {
+	suite.Run("four fixed ENs of which two are preferred ENs but have not generated the ER", func() {
 		// mark the first two ENs as fixed
 		fixedENs := allExecutionNodes[0:2]
 		// specify two ENs not specified in the ERs as preferred
 		preferredENs := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
 		expectedList := fixedENs
 		testExecutionNodesForBlockID(preferredENs, fixedENs, expectedList)
+	})
+	// if execution receipts are not yet available, the ExecutionNodesForBlockID function should retry twice
+	suite.Run("retry execution receipt query", func() {
+		// on first attempt, no execution receipts are available
+		attempt1Receipts = flow.ExecutionReceiptList{}
+		// on second attempt ony one is available
+		attempt2Receipts = flow.ExecutionReceiptList{receipts[0]}
+		// on third attempt all receipts are available
+		attempt3Receipts = receipts
+		currentAttempt = 0
+		// mark the first two ENs as preferred
+		preferredENs := allExecutionNodes[0:2]
+		expectedList := preferredENs
+		testExecutionNodesForBlockID(preferredENs, nil, expectedList)
 	})
 }
 
@@ -1425,7 +1440,7 @@ func (suite *Suite) checkResponse(resp interface{}, err error) {
 	suite.Require().NotNil(resp)
 }
 
-func (suite *Suite) setupReceipts(block *flow.Block) []*flow.ExecutionReceipt {
+func (suite *Suite) setupReceipts(block *flow.Block) ([]*flow.ExecutionReceipt, flow.IdentityList) {
 	ids := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
 	receipt1 := unittest.ReceiptForBlockFixture(block)
 	receipt1.ExecutorID = ids[0].NodeID
@@ -1437,9 +1452,15 @@ func (suite *Suite) setupReceipts(block *flow.Block) []*flow.ExecutionReceipt {
 	suite.receipts.
 		On("ByBlockID", block.ID()).
 		Return(receipts, nil)
-	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
-	return receipts
 
+	return receipts, ids
+}
+
+func (suite *Suite) setupConnectionFactory() ConnectionFactory {
+	// create a mock connection factory
+	connFactory := new(backendmock.ConnectionFactory)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	return connFactory
 }
 
 func getEvents(n int) []flow.Event {

--- a/engine/access/rpc/backend/errors.go
+++ b/engine/access/rpc/backend/errors.go
@@ -1,0 +1,17 @@
+package backend
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// InsufficientExecutionReceipts indicates that no execution receipt were found for a given block ID
+type InsufficientExecutionReceipts struct {
+	blockID      flow.Identifier
+	receiptCount int
+}
+
+func (e InsufficientExecutionReceipts) Error() string {
+	return fmt.Sprintf("insufficient execution receipts found (%d) for block ID: %s", e.receiptCount, e.blockID.String())
+}

--- a/engine/access/rpc/backend/historical_access_test.go
+++ b/engine/access/rpc/backend/historical_access_test.go
@@ -39,7 +39,6 @@ func (suite *Suite) TestHistoricalTransactionResult() {
 
 	backend := New(
 		suite.state,
-		suite.execClient,
 		nil,
 		[]accessproto.AccessAPIClient{suite.historicalAccessClient},
 		suite.blocks,
@@ -96,7 +95,6 @@ func (suite *Suite) TestHistoricalTransaction() {
 
 	backend := New(
 		suite.state,
-		suite.execClient,
 		nil,
 		[]accessproto.AccessAPIClient{suite.historicalAccessClient},
 		suite.blocks,

--- a/engine/access/rpc/backend/retry_test.go
+++ b/engine/access/rpc/backend/retry_test.go
@@ -40,7 +40,7 @@ func (suite *Suite) TestTransactionRetry() {
 	// txID := transactionBody.ID()
 	// blockID := block.ID()
 	// Setup Handler + Retry
-	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
+	backend := New(suite.state, suite.colClient, nil, suite.blocks, suite.headers,
 		suite.collections, suite.transactions, suite.receipts, suite.chainID, metrics.NewNoopCollector(), nil,
 		false, DefaultMaxHeightRange, nil, nil, suite.log)
 	retry := newRetry().SetBackend(backend).Activate()
@@ -98,13 +98,13 @@ func (suite *Suite) TestSuccessfulTransactionsDontRetry() {
 		Events: nil,
 	}
 
-	suite.receipts.
-		On("ByBlockID", mock.Anything).
-		Return(flow.ExecutionReceiptList{}, nil)
+	_, enIDs := suite.setupReceipts(&block)
+	suite.snapshot.On("Identities", mock.Anything).Return(enIDs, nil)
+	connFactory := suite.setupConnectionFactory()
 
 	// Setup Handler + Retry
-	backend := New(suite.state, suite.execClient, suite.colClient, nil, suite.blocks, suite.headers,
-		suite.collections, suite.transactions, suite.receipts, suite.chainID, metrics.NewNoopCollector(), nil,
+	backend := New(suite.state, suite.colClient, nil, suite.blocks, suite.headers,
+		suite.collections, suite.transactions, suite.receipts, suite.chainID, metrics.NewNoopCollector(), connFactory,
 		false, DefaultMaxHeightRange, nil, nil, suite.log)
 	retry := newRetry().SetBackend(backend).Activate()
 	backend.retry = retry

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -10,7 +10,6 @@ import (
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
-	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
 	legacyaccessproto "github.com/onflow/flow/protobuf/go/flow/legacy/access"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
@@ -30,7 +29,6 @@ import (
 type Config struct {
 	GRPCListenAddr            string        // the GRPC server address as ip:port
 	HTTPListenAddr            string        // the HTTP web proxy address as ip:port
-	ExecutionAddr             string        // the address of the upstream execution node
 	CollectionAddr            string        // the address of the upstream collection node
 	HistoricalAccessAddrs     string        // the list of all access nodes from previous spork
 	MaxMsgSize                int           // GRPC max message size
@@ -56,7 +54,6 @@ type Engine struct {
 func New(log zerolog.Logger,
 	state protocol.State,
 	config Config,
-	executionRPC execproto.ExecutionAPIClient,
 	collectionRPC accessproto.AccessAPIClient,
 	historicalAccessNodes []accessproto.AccessAPIClient,
 	blocks storage.Blocks,
@@ -122,7 +119,6 @@ func New(log zerolog.Logger,
 
 	backend := backend.New(
 		state,
-		executionRPC,
 		collectionRPC,
 		historicalAccessNodes,
 		blocks,

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -372,7 +372,6 @@ func prepareAccessService(container testnet.ContainerConfig, i int) Service {
 	service.Command = append(service.Command, []string{
 		fmt.Sprintf("--rpc-addr=%s:%d", container.ContainerName, RPCPort),
 		fmt.Sprintf("--collection-ingress-port=%d", RPCPort),
-		fmt.Sprintf("--script-addr=execution_1:%d", RPCPort),
 		"--log-tx-time-to-finalized",
 		"--log-tx-time-to-executed",
 		"--log-tx-time-to-finalized-executed",

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -513,8 +513,6 @@ func (net *FlowNetwork) AddNode(t *testing.T, bootstrapDir string, nodeConf Cont
 			// uncomment line below to point the access node exclusively to a single collection node
 			// nodeContainer.addFlag("static-collection-ingress-addr", "collection_1:9000")
 			nodeContainer.addFlag("collection-ingress-port", "9000")
-			// should always have at least 1 execution node
-			nodeContainer.addFlag("script-addr", "execution_1:9000")
 			nodeContainer.opts.HealthCheck = testingdock.HealthCheckCustom(healthcheckAccessGRPC(hostGRPCPort))
 			nodeContainer.Ports[AccessNodeAPIPort] = hostGRPCPort
 			nodeContainer.Ports[AccessNodeAPIProxyPort] = hostHTTPProxyPort

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -514,6 +514,15 @@ func ReceiptForBlockExecutorFixture(block *flow.Block, executor flow.Identifier)
 	return receipt
 }
 
+func ReceiptsForBlockFixture(block *flow.Block, ids []flow.Identifier) []*flow.ExecutionReceipt {
+	result := ExecutionResultFixture(WithBlock(block))
+	var ers []*flow.ExecutionReceipt
+	for _, id := range ids {
+		ers = append(ers, ExecutionReceiptFixture(WithResult(result), WithExecutorID(id)))
+	}
+	return ers
+}
+
 func WithPreviousResult(prevResult flow.ExecutionResult) func(*flow.ExecutionResult) {
 	return func(result *flow.ExecutionResult) {
 		result.PreviousResultID = prevResult.ID()


### PR DESCRIPTION
…block when serving an access node api call that needs an upstream execution node call