### PR TITLE
Update to Cadence v0.15.1-patch.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,4 @@ replace golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6
 
 replace github.com/onflow/flow-go/crypto => ./crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.3
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.4

--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,4 @@ replace golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6
 
 replace github.com/onflow/flow-go/crypto => ./crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.2
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.3

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.3 h1:IaSaBeeDyDgaQidV979nQI7rrkghg8sfMh/r0AEILPo=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.3/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.4 h1:izEAD19P631vPshSva1sKkZ4K+ohpBmgkjVg/Uic/gA=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.4/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.2 h1:sfaDwenz2K6SwHUQSvVMb6lBmiOyr0fvR/5mr/4iZHk=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.2/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.3 h1:IaSaBeeDyDgaQidV979nQI7rrkghg8sfMh/r0AEILPo=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.3/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -28,4 +28,4 @@ replace github.com/onflow/flow-go => ../
 
 replace github.com/onflow/flow-go/crypto => ../crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.2
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.3

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -28,4 +28,4 @@ replace github.com/onflow/flow-go => ../
 
 replace github.com/onflow/flow-go/crypto => ../crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.3
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.15.1-patch.4

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -166,8 +166,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.2 h1:sfaDwenz2K6SwHUQSvVMb6lBmiOyr0fvR/5mr/4iZHk=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.2/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.3 h1:IaSaBeeDyDgaQidV979nQI7rrkghg8sfMh/r0AEILPo=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.3/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90 h1:RYSKhK13V8pZq+AqjWnH1vrENL/ZMyWqj2W2rGPDmYo=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -166,8 +166,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.3 h1:IaSaBeeDyDgaQidV979nQI7rrkghg8sfMh/r0AEILPo=
-github.com/dapperlabs/cadence-internal v0.15.1-patch.3/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.4 h1:izEAD19P631vPshSva1sKkZ4K+ohpBmgkjVg/Uic/gA=
+github.com/dapperlabs/cadence-internal v0.15.1-patch.4/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90 h1:RYSKhK13V8pZq+AqjWnH1vrENL/ZMyWqj2W2rGPDmYo=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Includes:
- https://github.com/dapperlabs/cadence-internal/pull/11
- https://github.com/dapperlabs/cadence-internal/pull/12
- https://github.com/dapperlabs/cadence-internal/pull/13

Diff: https://github.com/dapperlabs/cadence-internal/compare/v0.15.1-patch.2..v0.15.1-patch.4