### PR TITLE
update go version check to support up 1.13-1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ tool-remove-execution-fork: docker-build-remove-execution-fork
 # Check if the go version is 1.13 or higher. flow-go only supports go 1.13 and up.
 .PHONY: check-go-version
 check-go-version:
-	go version | grep 1.13 || go version | grep 1.14 || go version | grep 1.15
+	go version | grep '1.1[3-6]'
 
 #----------------------------------------------------------------------
 # CD COMMANDS


### PR DESCRIPTION
updating grep regex to cover for newer version of go