### PR TITLE
switching finalized block height to sealed block height in ping metric reporting

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -179,8 +179,8 @@ func (fnb *FlowNodeBuilder) enqueueNetworkInit() {
 			SoftwareVersionFun: func() string {
 				return build.Semver()
 			},
-			LatestFinalizedBlockHeightFun: func() (uint64, error) {
-				head, err := fnb.State.Final().Head()
+			SealedBlockHeightFun: func() (uint64, error) {
+				head, err := fnb.State.Sealed().Head()
 				if err != nil {
 					return 0, err
 				}

--- a/network/message/ping.proto
+++ b/network/message/ping.proto
@@ -7,5 +7,5 @@ message PingRequest {
 
 message PingResponse {
     string version = 1;     // node software version
-    uint64 blockHeight = 2; // latest finalized block height
+    uint64 blockHeight = 2; // latest sealed block height
 }

--- a/network/mocknetwork/ping_info_provider.go
+++ b/network/mocknetwork/ping_info_provider.go
@@ -9,8 +9,8 @@ type PingInfoProvider struct {
 	mock.Mock
 }
 
-// LatestFinalizedBlockHeight provides a mock function with given fields:
-func (_m *PingInfoProvider) LatestFinalizedBlockHeight() uint64 {
+// SealedBlockHeight provides a mock function with given fields:
+func (_m *PingInfoProvider) SealedBlockHeight() uint64 {
 	ret := _m.Called()
 
 	var r0 uint64

--- a/network/p2p/libp2pNode_test.go
+++ b/network/p2p/libp2pNode_test.go
@@ -630,7 +630,7 @@ func MockPingInfoProvider() (*mocknetwork.PingInfoProvider, string, uint64) {
 	height := uint64(5000)
 	pingInfoProvider := new(mocknetwork.PingInfoProvider)
 	pingInfoProvider.On("SoftwareVersion").Return(version)
-	pingInfoProvider.On("LatestFinalizedBlockHeight").Return(height)
+	pingInfoProvider.On("SealedBlockHeight").Return(height)
 	return pingInfoProvider, version, height
 }
 

--- a/network/p2p/ping.go
+++ b/network/p2p/ping.go
@@ -35,20 +35,20 @@ type PingService struct {
 // populated with the necessary details
 type PingInfoProvider interface {
 	SoftwareVersion() string
-	LatestFinalizedBlockHeight() uint64
+	SealedBlockHeight() uint64
 }
 
 type PingInfoProviderImpl struct {
-	SoftwareVersionFun            func() string
-	LatestFinalizedBlockHeightFun func() (uint64, error)
+	SoftwareVersionFun   func() string
+	SealedBlockHeightFun func() (uint64, error)
 }
 
 func (p PingInfoProviderImpl) SoftwareVersion() string {
 	return p.SoftwareVersionFun()
 }
-func (p PingInfoProviderImpl) LatestFinalizedBlockHeight() uint64 {
-	height, err := p.LatestFinalizedBlockHeightFun()
-	// if the node is unable to report the latest finalized block height, then report 0 instead of failing the ping
+func (p PingInfoProviderImpl) SealedBlockHeight() uint64 {
+	height, err := p.SealedBlockHeightFun()
+	// if the node is unable to report the latest sealed block height, then report 0 instead of failing the ping
 	if err != nil {
 		return uint64(0)
 	}
@@ -116,7 +116,7 @@ func (ps *PingService) PingHandler(s network.Stream) {
 	version := ps.pingInfoProvider.SoftwareVersion()
 
 	// query for the lastest finalized block height
-	blockHeight := ps.pingInfoProvider.LatestFinalizedBlockHeight()
+	blockHeight := ps.pingInfoProvider.SealedBlockHeight()
 
 	// create a PingResponse
 	pingResponse := &message.PingResponse{

--- a/network/test/testUtil.go
+++ b/network/test/testUtil.go
@@ -193,7 +193,7 @@ func generateLibP2PNode(t *testing.T,
 
 	pingInfoProvider := new(mocknetwork.PingInfoProvider)
 	pingInfoProvider.On("SoftwareVersion").Return("test")
-	pingInfoProvider.On("LatestFinalizedBlockHeight").Return(uint64(1000))
+	pingInfoProvider.On("SealedBlockHeight").Return(uint64(1000))
 
 	libP2PNode, err := p2p.NewLibP2PNode(logger,
 		id.NodeID,


### PR DESCRIPTION
In an earlier change, I added the finalized block height as an additional field to the ping response. However, I realized that it should have been the sealed block height and not the finalized height.