### PR TITLE
[Verification] fix the logic that handles missing registers

### DIFF
--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -134,7 +134,8 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 			if errors.Is(err, ledger.ErrMissingKeys{}) {
 
 				unknownRegTouch[registerID.String()] = &registerKey
-				return nil, fmt.Errorf("missing register")
+				// don't send error just return empty byte slice
+				return []byte{}, nil
 			}
 			// append to missing keys if error is ErrMissingKeys
 

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -134,11 +134,13 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 			if errors.Is(err, ledger.ErrMissingKeys{}) {
 
 				unknownRegTouch[registerID.String()] = &registerKey
+
 				// don't send error just return empty byte slice
 				// we always assume empty value for missing registers (which might cause the transaction to fail)
 				// but after execution we check unknownRegTouch and if any
-				// register is inside it, code won't generate approvals and 
+				// register is inside it, code won't generate approvals and
 				// it activates a challenge
+
 				return []byte{}, nil
 			}
 			// append to missing keys if error is ErrMissingKeys

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -135,6 +135,10 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 
 				unknownRegTouch[registerID.String()] = &registerKey
 				// don't send error just return empty byte slice
+				// we always assume empty value for missing registers (which might cause the transaction to fail)
+				// but after execution we check unknownRegTouch and if any
+				// register is inside it, code won't generate approvals and 
+				// it activates a challenge
 				return []byte{}, nil
 			}
 			// append to missing keys if error is ErrMissingKeys


### PR DESCRIPTION
Missing register should not return generic error back to FVM, since we consider undefined errors at FVM fatal. The idea is we always return empty slice but capture the missing call and use it for challenge creation later.