### PR TITLE
Remove unused identities parameter from GenesisFixture

### DIFF
--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -86,7 +86,7 @@ func (suite *Suite) SetupTest() {
 	suite.clusters, err = flow.NewClusterList(assignments, collectors)
 	suite.Require().NoError(err)
 
-	suite.root = unittest.GenesisFixture(suite.identities)
+	suite.root = unittest.GenesisFixture()
 	suite.final = suite.root
 	suite.blocks = make(map[flow.Identifier]*flow.Block)
 	suite.blocks[suite.root.ID()] = suite.root

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -298,7 +298,7 @@ func StateDeltaWithParentFixture(parent *flow.Header) *messages.ExecutionStateDe
 	}
 }
 
-func GenesisFixture(identities flow.IdentityList) *flow.Block {
+func GenesisFixture() *flow.Block {
 	genesis := flow.Genesis(flow.Emulator)
 	return genesis
 }
@@ -1462,7 +1462,7 @@ func EpochCommitFixture(opts ...func(*flow.EpochCommit)) *flow.EpochCommit {
 // protocol state.
 func BootstrapFixture(participants flow.IdentityList, opts ...func(*flow.Block)) (*flow.Block, *flow.ExecutionResult, *flow.Seal) {
 
-	root := GenesisFixture(participants)
+	root := GenesisFixture()
 	for _, apply := range opts {
 		apply(root)
 	}


### PR DESCRIPTION
Identities are no longer stored in block payloads directly, so this was unused.