### PR TITLE
Bump Core Contracts Version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,8 +37,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/onflow/cadence v0.16.0
-	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210507220547-a2ecda1df019
-	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210507220547-a2ecda1df019
+	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210510205428-30d94f82bc8c
+	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210510205428-30d94f82bc8c
 	github.com/onflow/flow-emulator v0.19.0
 	github.com/onflow/flow-go-sdk v0.20.0-alpha.1
 	github.com/onflow/flow-go/crypto v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,12 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2/go.mod h1:IZ2e7UyL
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.2/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210507220547-a2ecda1df019 h1:u1stD0wHiMjhQlukS2PNdp1BdYC1OgEZjxjSd96oW/E=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210507220547-a2ecda1df019/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210510205428-30d94f82bc8c h1:6mdzMSlB/hY2iZ9NDrSpe8igP8re+FoaWgpL1+KgKFs=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210510205428-30d94f82bc8c/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210507220547-a2ecda1df019 h1:6UZQjkHzVvA3dY5Fnj+iFxLfe3z5B/4XgRKRPTbsJZE=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210507220547-a2ecda1df019/go.mod h1:fLJbjGUHrlHdrjaeRDgKG9nZJ6spiCScc+Q5SARgH38=
+github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210510205428-30d94f82bc8c h1:yna1nNjzkvtA3WVzPhLS/4YETspwYe7v//jCdoVaRD4=
+github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210510205428-30d94f82bc8c/go.mod h1:fLJbjGUHrlHdrjaeRDgKG9nZJ6spiCScc+Q5SARgH38=
 github.com/onflow/flow-emulator v0.19.0 h1:q2/UTmMuK4zwVnnOak1owFTTS70pYK9qDgoQTI30yGE=
 github.com/onflow/flow-emulator v0.19.0/go.mod h1:k5un51XlFJavboagCqTxd6x8Gle7lxWlXdUepoNB5fA=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/onflow/cadence v0.16.0
-	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210507220547-a2ecda1df019
-	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210507220547-a2ecda1df019
+	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210510205428-30d94f82bc8c
+	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210510205428-30d94f82bc8c
 	github.com/onflow/flow-emulator v0.19.0
 	github.com/onflow/flow-go v0.16.3-0.20210427194927-6050c2a3ae42 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.20.0-alpha.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -956,8 +956,12 @@ github.com/onflow/cadence v0.16.0 h1:wjGlR5cb+DOlgwkIfi20NnUNBPTdqcRPzJNXbHQa//Y
 github.com/onflow/cadence v0.16.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210507220547-a2ecda1df019 h1:u1stD0wHiMjhQlukS2PNdp1BdYC1OgEZjxjSd96oW/E=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210507220547-a2ecda1df019/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210510205428-30d94f82bc8c h1:6mdzMSlB/hY2iZ9NDrSpe8igP8re+FoaWgpL1+KgKFs=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210510205428-30d94f82bc8c/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210507220547-a2ecda1df019 h1:6UZQjkHzVvA3dY5Fnj+iFxLfe3z5B/4XgRKRPTbsJZE=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210507220547-a2ecda1df019/go.mod h1:fLJbjGUHrlHdrjaeRDgKG9nZJ6spiCScc+Q5SARgH38=
+github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210510205428-30d94f82bc8c h1:yna1nNjzkvtA3WVzPhLS/4YETspwYe7v//jCdoVaRD4=
+github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210510205428-30d94f82bc8c/go.mod h1:fLJbjGUHrlHdrjaeRDgKG9nZJ6spiCScc+Q5SARgH38=
 github.com/onflow/flow-emulator v0.19.0 h1:q2/UTmMuK4zwVnnOak1owFTTS70pYK9qDgoQTI30yGE=
 github.com/onflow/flow-emulator v0.19.0/go.mod h1:k5un51XlFJavboagCqTxd6x8Gle7lxWlXdUepoNB5fA=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=

--- a/module/epochs/epoch_config.go
+++ b/module/epochs/epoch_config.go
@@ -151,6 +151,12 @@ func EncodeClusterQCs(qcs []*flow.QuorumCertificate, service flow.Address) []byt
 							ElementType: cadence.StringType{},
 						},
 					},
+					{
+						Identifier: "voterIDs",
+						Type: cadence.ConstantSizedArrayType{
+							ElementType: cadence.StringType{},
+						},
+					},
 				},
 			})
 


### PR DESCRIPTION
Increments the version of `flow-core-contracts` to include the latest epoch-related change (including `voterIDs` in quorum certificates).