### PR TITLE
Drop half chunk data pack requests to investigate EN4 issue

### DIFF
--- a/engine/execution/provider/engine.go
+++ b/engine/execution/provider/engine.go
@@ -152,6 +152,13 @@ func (e *Engine) onChunkDataRequest(
 	// increases collector metric
 	e.metrics.ChunkDataPackRequested()
 
+	// randomly drop half of the chunk data pack requests
+	// to confirm whether the execution hiccup of EN4 was
+	// caused by slow chunk data pack requests
+	if chunkID%2 == 0 {
+		return nil
+	}
+
 	cdp, err := e.execState.ChunkDataPackByChunkID(ctx, chunkID)
 	// we might be behind when we don't have the requested chunk.
 	// if this happen, log it and return nil


### PR DESCRIPTION
Context:
https://github.com/dapperlabs/flow-go/issues/5532#issuecomment-845553015

Based on the metrics data, I suspect the execution hiccup on EN4 might be caused by chunk data pack requests. 

In order to quickly confirm, I'd like to try randomly dropping half of the chunk data pack requests, reducing the load, and see whether the hiccup still exists.

If the hiccup is gone, then, we can confirm the problem is caused by chunk data pack requests.