### PR TITLE
[Ledger] Fix a typo in copy function

### DIFF
--- a/ledger/common/hash/copy_generic.go
+++ b/ledger/common/hash/copy_generic.go
@@ -74,7 +74,7 @@ func copyIn512(d *state, buf1, buf2 Hash) {
 func copyIn256(d *state, buf Hash) {
 	sliceBuf := buf[:]
 
-	for i = 0; i < 4; i++ {
+	for i := 0; i < 4; i++ {
 		d.a[i] = binary.LittleEndian.Uint64(sliceBuf)
 		sliceBuf = sliceBuf[8:]
 	}


### PR DESCRIPTION
Fix a typo in the for loop definition.