### PR TITLE
V0.17: Fix QC generation in bootstrap when non-internal nodes are present

### DIFF
--- a/cmd/bootstrap/cmd/qc.go
+++ b/cmd/bootstrap/cmd/qc.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+// NOTE: allNodes must be in the same order as when generating the DKG
 func constructRootQC(block *flow.Block, allNodes, internalNodes []model.NodeInfo, dkgData model.DKGData) *flow.QuorumCertificate {
 	participantData, err := run.GenerateQCParticipantData(allNodes, internalNodes, dkgData)
 	if err != nil {

--- a/cmd/bootstrap/run/qc.go
+++ b/cmd/bootstrap/run/qc.go
@@ -114,6 +114,10 @@ func createValidators(participantData *ParticipantData) ([]hotstuff.Validator, [
 	return validators, signers, nil
 }
 
+// GenerateQCParticipantData generates QC participant data used to create the
+// random beacon and staking signatures on the QC.
+//
+// allNodes must be in the same order that was used when running the DKG.
 func GenerateQCParticipantData(allNodes, internalNodes []bootstrap.NodeInfo, dkgData bootstrap.DKGData) (*ParticipantData, error) {
 
 	// stakingNodes can include external validators, so it can be longer than internalNodes
@@ -130,6 +134,7 @@ func GenerateQCParticipantData(allNodes, internalNodes []bootstrap.NodeInfo, dkg
 
 	participantLookup := make(map[flow.Identifier]flow.DKGParticipant)
 
+	// the index here is important - we assume allNodes is in the same order as the DKG
 	for i := 0; i < len(allNodes); i++ {
 		// assign a node to a DGKdata entry, using the canonical ordering
 		node := allNodes[i]

--- a/cmd/bootstrap/run/qc.go
+++ b/cmd/bootstrap/run/qc.go
@@ -130,13 +130,17 @@ func GenerateQCParticipantData(allNodes, internalNodes []bootstrap.NodeInfo, dkg
 
 	participantLookup := make(map[flow.Identifier]flow.DKGParticipant)
 
-	// the QC will be signed by everyone in internalNodes
-	for i, node := range internalNodes {
+	for i := 0; i < len(allNodes); i++ {
 		// assign a node to a DGKdata entry, using the canonical ordering
+		node := allNodes[i]
 		participantLookup[node.NodeID] = flow.DKGParticipant{
 			KeyShare: dkgData.PubKeyShares[i],
 			Index:    uint(i),
 		}
+	}
+
+	// the QC will be signed by everyone in internalNodes
+	for _, node := range internalNodes {
 
 		if node.NodeID == flow.ZeroID {
 			return nil, fmt.Errorf("node id cannot be zero")
@@ -146,19 +150,16 @@ func GenerateQCParticipantData(allNodes, internalNodes []bootstrap.NodeInfo, dkg
 			return nil, fmt.Errorf("node (id=%s) cannot have 0 stake", node.NodeID)
 		}
 
+		dkgParticipant, ok := participantLookup[node.NodeID]
+		if !ok {
+			return nil, fmt.Errorf("nonexistannt node id (%x) in participant lookup", node.NodeID)
+		}
+		dkgIndex := dkgParticipant.Index
+
 		qcData.Participants = append(qcData.Participants, Participant{
 			NodeInfo:            node,
-			RandomBeaconPrivKey: dkgData.PrivKeyShares[i],
+			RandomBeaconPrivKey: dkgData.PrivKeyShares[dkgIndex],
 		})
-	}
-
-	for i := len(internalNodes); i < len(allNodes); i++ {
-		// assign a node to a DGKdata entry, using the canonical ordering
-		node := allNodes[i]
-		participantLookup[node.NodeID] = flow.DKGParticipant{
-			KeyShare: dkgData.PubKeyShares[i],
-			Index:    uint(i),
-		}
 	}
 
 	qcData.Lookup = participantLookup

--- a/model/bootstrap/node_info.go
+++ b/model/bootstrap/node_info.go
@@ -223,10 +223,8 @@ func FilterByRole(nodes []NodeInfo, role flow.Role) []NodeInfo {
 
 // Sort sorts the NodeInfo list using the given ordering.
 func Sort(nodes []NodeInfo, order flow.IdentityOrder) []NodeInfo {
-	dup := make([]NodeInfo, 0, len(nodes))
-	for _, node := range nodes {
-		dup = append(dup, node)
-	}
+	dup := make([]NodeInfo, len(nodes))
+	copy(dup, nodes)
 	sort.Slice(dup, func(i, j int) bool {
 		return order(dup[i].Identity(), dup[j].Identity())
 	})

--- a/model/bootstrap/node_info.go
+++ b/model/bootstrap/node_info.go
@@ -221,12 +221,16 @@ func FilterByRole(nodes []NodeInfo, role flow.Role) []NodeInfo {
 	return filtered
 }
 
-// Sort sorts the NodeInfo list in place using the given ordering.
+// Sort sorts the NodeInfo list using the given ordering.
 func Sort(nodes []NodeInfo, order flow.IdentityOrder) []NodeInfo {
-	sort.Slice(nodes, func(i, j int) bool {
-		return order(nodes[i].Identity(), nodes[j].Identity())
+	dup := make([]NodeInfo, 0, len(nodes))
+	for _, node := range nodes {
+		dup = append(dup, node)
+	}
+	sort.Slice(dup, func(i, j int) bool {
+		return order(dup[i].Identity(), dup[j].Identity())
 	})
-	return nodes
+	return dup
 }
 
 func ToIdentityList(nodes []NodeInfo) flow.IdentityList {


### PR DESCRIPTION
    the internal node list and all node list was inconsistent because the
    full node list had the canonical ordering applied (and this affected the
    internal node list because they shared a backing array).

    this changes the sorting of node infos to return a copy and updates the
    dkg participant data generation