### PR TITLE
removing node version from ping metric

### DIFF
--- a/engine/access/ping/engine.go
+++ b/engine/access/ping/engine.go
@@ -107,7 +107,7 @@ func (e *Engine) startPing() {
 // pingNode pings the given peer and updates the metrics with the result and the additional node information
 func (e *Engine) pingNode(peer *flow.Identity) {
 	id := peer.ID()
-	var pingFailed bool
+	pingFailed := false
 
 	// ping the node
 	resp, rtt, err := e.middleware.Ping(id) // ping will timeout in libp2p.PingTimeoutSecs seconds

--- a/engine/access/ping/engine.go
+++ b/engine/access/ping/engine.go
@@ -107,15 +107,13 @@ func (e *Engine) startPing() {
 // pingNode pings the given peer and updates the metrics with the result and the additional node information
 func (e *Engine) pingNode(peer *flow.Identity) {
 	id := peer.ID()
-	pingFailed := false
 
 	// ping the node
-	resp, rtt, err := e.middleware.Ping(id) // ping will timeout in libp2p.PingTimeoutSecs seconds
-	if err != nil {
-		e.log.Debug().Err(err).Str("target", id.String()).Msg("failed to ping")
+	resp, rtt, pingErr := e.middleware.Ping(id) // ping will timeout in libp2p.PingTimeoutSecs seconds
+	if pingErr != nil {
+		e.log.Debug().Err(pingErr).Str("target", id.String()).Msg("failed to ping")
 		// report the rtt duration as negative to make it easier to distinguish between pingable and non-pingable nodes
 		rtt = -1
-		pingFailed = true
 	}
 
 	// get the additional info about the node
@@ -125,7 +123,7 @@ func (e *Engine) pingNode(peer *flow.Identity) {
 	e.metrics.NodeReachable(peer, info, rtt)
 
 	// if ping succeeded then update the node info metric
-	if !pingFailed {
+	if pingErr == nil {
 		e.metrics.NodeInfo(peer, info, resp.Version, resp.BlockHeight)
 	}
 }

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -368,6 +368,8 @@ type TransactionMetrics interface {
 type PingMetrics interface {
 	// NodeReachable tracks the round trip time in milliseconds taken to ping a node
 	// The nodeInfo provides additional information about the node such as the name of the node operator
-	// version is the software version the target node is running
-	NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration, version string, sealedHeight uint64)
+	NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration)
+
+	// NodeInfo tracks the software version and sealed height of a node
+	NodeInfo(node *flow.Identity, nodeInfo string, version string, sealedHeight uint64)
 }

--- a/module/metrics/ping.go
+++ b/module/metrics/ping.go
@@ -21,7 +21,7 @@ func NewPingCollector() *PingCollector {
 			Namespace: namespaceNetwork,
 			Subsystem: subsystemGossip,
 			Help:      "report whether a node is reachable",
-		}, []string{LabelNodeID, LabelNodeAddress, LabelNodeRole, LabelNodeInfo, LabelNodeVersion}),
+		}, []string{LabelNodeID, LabelNodeAddress, LabelNodeRole, LabelNodeInfo}),
 		sealedHeight: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name:      "sealed_height",
 			Namespace: namespaceNetwork,
@@ -33,7 +33,7 @@ func NewPingCollector() *PingCollector {
 	return pc
 }
 
-func (pc *PingCollector) NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration, version string, sealedHeight uint64) {
+func (pc *PingCollector) NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration) {
 	var rttValue float64
 	if rtt > 0 {
 		rttValue = float64(rtt.Milliseconds())
@@ -45,10 +45,11 @@ func (pc *PingCollector) NodeReachable(node *flow.Identity, nodeInfo string, rtt
 		LabelNodeID:      node.NodeID.String(),
 		LabelNodeAddress: node.Address,
 		LabelNodeRole:    node.Role.String(),
-		LabelNodeInfo:    nodeInfo,
-		LabelNodeVersion: version}).
+		LabelNodeInfo:    nodeInfo}).
 		Set(rttValue)
+}
 
+func (pc *PingCollector) NodeInfo(node *flow.Identity, nodeInfo string, version string, sealedHeight uint64) {
 	pc.sealedHeight.With(prometheus.Labels{
 		LabelNodeID:      node.NodeID.String(),
 		LabelNodeAddress: node.Address,


### PR DESCRIPTION
Fixing the issue with the Mainnet Partner Node Availability Grafana dashboard -

Earlier I had added `nodeversion` to the Ping metric and to the `network_gossip_sealed_height` metric.
The metrics now show up accordingly as (using Staked Collection node as an example):


> network_gossip_node_reachable{nodeaddress="flow-0.staked.cloud:3569",nodeid="fcb55c2d1fb2737b159704b5a30b194b8a8ddfb4691d55692af597ac6e236201",nodeinfo="Staked",noderole="collection",**nodeversion="v0.17.4_without_netgo"**} 16

and

> network_gossip_sealed_height{nodeaddress="flow-0.staked.cloud:3569",nodeid="fcb55c2d1fb2737b159704b5a30b194b8a8ddfb4691d55692af597ac6e236201",nodeinfo="Staked",noderole="collection",**nodeversion="v0.17.4_without_netgo"**} 1.4931077e+07


However, initially when a node is not pingable, the Ping metric reports the RTT as -1 and with an empty value for the `nodeversion` because the nodeversion is not known (since the ping was not replied as the remote node was down).
e.g.
network_gossip_node_reachable{nodeaddress="flow-0.staked.cloud:3569",nodeid="fcb55c2d1fb2737b159704b5a30b194b8a8ddfb4691d55692af597ac6e236201",nodeinfo="Staked",noderole="collection",**nodeversion=""**} -1

This results in two different `network_gossip_node_reachable` time series for the same node id - one with the `nodeversion` as empty and one with the `nodeversion` as v0.17.4_without_netgo.
That causes Grafana to continue to show the node as down even if the node came up since it tends to extrapolate the `-1` for the old series when the `nodeversion` was empty.

On the left is the series with the nodeversion and on the right it is the extrapolated series without the version for a node id which was down yesterday and is now up -

![Screen Shot 2021-05-27 at 3 29 06 PM](https://user-images.githubusercontent.com/1117327/119904887-f0c03b80-beff-11eb-8ae3-bc4469a75efd.png)


## This PR does the following:
1. Removes the `nodeversion` label from the ping metric to keep the RTT metric simple to deal with. (I tried using prometheus `without` function but decided its best to remove the extra label).
2. Reports the `network_gossip_sealed_height` only when the ping succeeded not otherwise.

_If you approve of this PR, I would like to deploy it to Mainnet-9 AN3 to fix the Candidate partner availability dashboard._