### PR TITLE
removing node version from ping metric (#759)

### DIFF
--- a/engine/access/ping/engine.go
+++ b/engine/access/ping/engine.go
@@ -109,9 +109,9 @@ func (e *Engine) pingNode(peer *flow.Identity) {
 	id := peer.ID()
 
 	// ping the node
-	resp, rtt, err := e.middleware.Ping(id) // ping will timeout in libp2p.PingTimeoutSecs seconds
-	if err != nil {
-		e.log.Debug().Err(err).Str("target", id.String()).Msg("failed to ping")
+	resp, rtt, pingErr := e.middleware.Ping(id) // ping will timeout in libp2p.PingTimeoutSecs seconds
+	if pingErr != nil {
+		e.log.Debug().Err(pingErr).Str("target", id.String()).Msg("failed to ping")
 		// report the rtt duration as negative to make it easier to distinguish between pingable and non-pingable nodes
 		rtt = -1
 	}
@@ -120,5 +120,10 @@ func (e *Engine) pingNode(peer *flow.Identity) {
 	info := e.nodeInfo[id]
 
 	// update metric
-	e.metrics.NodeReachable(peer, info, rtt, resp.Version, resp.BlockHeight)
+	e.metrics.NodeReachable(peer, info, rtt)
+
+	// if ping succeeded then update the node info metric
+	if pingErr == nil {
+		e.metrics.NodeInfo(peer, info, resp.Version, resp.BlockHeight)
+	}
 }

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -368,6 +368,8 @@ type TransactionMetrics interface {
 type PingMetrics interface {
 	// NodeReachable tracks the round trip time in milliseconds taken to ping a node
 	// The nodeInfo provides additional information about the node such as the name of the node operator
-	// version is the software version the target node is running
-	NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration, version string, sealedHeight uint64)
+	NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration)
+
+	// NodeInfo tracks the software version and sealed height of a node
+	NodeInfo(node *flow.Identity, nodeInfo string, version string, sealedHeight uint64)
 }

--- a/module/metrics/ping.go
+++ b/module/metrics/ping.go
@@ -21,7 +21,7 @@ func NewPingCollector() *PingCollector {
 			Namespace: namespaceNetwork,
 			Subsystem: subsystemGossip,
 			Help:      "report whether a node is reachable",
-		}, []string{LabelNodeID, LabelNodeAddress, LabelNodeRole, LabelNodeInfo, LabelNodeVersion}),
+		}, []string{LabelNodeID, LabelNodeAddress, LabelNodeRole, LabelNodeInfo}),
 		sealedHeight: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name:      "sealed_height",
 			Namespace: namespaceNetwork,
@@ -33,7 +33,7 @@ func NewPingCollector() *PingCollector {
 	return pc
 }
 
-func (pc *PingCollector) NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration, version string, sealedHeight uint64) {
+func (pc *PingCollector) NodeReachable(node *flow.Identity, nodeInfo string, rtt time.Duration) {
 	var rttValue float64
 	if rtt > 0 {
 		rttValue = float64(rtt.Milliseconds())
@@ -45,10 +45,11 @@ func (pc *PingCollector) NodeReachable(node *flow.Identity, nodeInfo string, rtt
 		LabelNodeID:      node.NodeID.String(),
 		LabelNodeAddress: node.Address,
 		LabelNodeRole:    node.Role.String(),
-		LabelNodeInfo:    nodeInfo,
-		LabelNodeVersion: version}).
+		LabelNodeInfo:    nodeInfo}).
 		Set(rttValue)
+}
 
+func (pc *PingCollector) NodeInfo(node *flow.Identity, nodeInfo string, version string, sealedHeight uint64) {
 	pc.sealedHeight.With(prometheus.Labels{
 		LabelNodeID:      node.NodeID.String(),
 		LabelNodeAddress: node.Address,


### PR DESCRIPTION
Cherry-picking commit from [PR](https://github.com/onflow/flow-go/pull/759)

This change is currently on Access Node 3 on mainnet-9 and is working as expected.