### PR TITLE
Cannot use -l as a flag, therefore just use --light

### DIFF
--- a/cmd/util/cmd/read-badger/cmd/collections.go
+++ b/cmd/util/cmd/read-badger/cmd/collections.go
@@ -17,7 +17,7 @@ func init() {
 
 	collectionsCmd.Flags().StringVarP(&flagCollectionID, "id", "i", "", "the id of the collection")
 	collectionsCmd.Flags().StringVarP(&flagTransactionID, "transaction-id", "t", "", "the id of the transaction (always retrieves a light collection regardless of the --light flag)")
-	collectionsCmd.Flags().BoolVarP(&flagLightCollection, "light", "l", false, "whether to return the light collection (only transaction IDs)")
+	collectionsCmd.Flags().BoolVar(&flagLightCollection, "light", false, "whether to return the light collection (only transaction IDs)")
 }
 
 var collectionsCmd = &cobra.Command{


### PR DESCRIPTION
Was recently trying to use the util for reading collections from the badger DB. It doesn't work with out this change, since `-l` is being used for loglevel in the root CMD