### PR TITLE
Fix the off-by-one error in the emission of epoch phase change events

### DIFF
--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -507,7 +507,16 @@ func (m *FollowerState) Finalize(blockID flow.Identifier) error {
 		return fmt.Errorf("could not retrieve setup event for current epoch: %w", err)
 	}
 
-	payload := block.Payload
+	// We will process service events from blocks which are sealed by this
+	// block's PARENT. The events are emitted when we finalize the first child
+	// of the block containing the seal for the result containing the
+	// corresponding service event.
+	parent, err := m.blocks.ByID(header.ParentID)
+	if err != nil {
+		return fmt.Errorf("could not get parent (id=%x): %w", header.ParentID, err)
+	}
+
+	payload := parent.Payload
 	// track protocol events that should be emitted
 	var events []func()
 	for _, seal := range payload.Seals {

--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -16,8 +16,6 @@ func isValidEpochSetup(setup *flow.EpochSetup) error {
 		return fmt.Errorf("seed has incorrect length (%d != %d)", len(setup.RandomSource), flow.EpochSetupRandomSourceLength)
 	}
 
-	fmt.Printf("XXX setup participants: %#v\n", setup.Participants)
-
 	// STEP 2: sanity checks of all nodes listed as participants
 	// there should be no duplicate node IDs
 	identLookup := make(map[flow.Identifier]struct{})

--- a/state/protocol/events.go
+++ b/state/protocol/events.go
@@ -38,7 +38,7 @@ type Consumer interface {
 	// phase for the current epoch.
 	//
 	// Referencing the diagram below, the event is emitted when block c is incorporated.
-	// The block parameter is the first block of the epoch setup phase (block b).
+	// The block parameter is the first block of the epoch setup phase (block c).
 	//
 	// |<-- Epoch N ------------------------------------------------->|
 	// |<-- StakingPhase -->|<-- SetupPhase -->|<-- CommittedPhase -->|
@@ -54,7 +54,7 @@ type Consumer interface {
 	// phase for the current epoch.
 	//
 	// Referencing the diagram below, the event is emitted when block f is received.
-	// The block parameter is the first block of the epoch committed phase (block e).
+	// The block parameter is the first block of the epoch committed phase (block f).
 	//
 	// |<-- Epoch N ------------------------------------------------->|
 	// |<-- StakingPhase -->|<-- SetupPhase -->|<-- CommittedPhase -->|

--- a/state/protocol/events.go
+++ b/state/protocol/events.go
@@ -43,8 +43,9 @@ type Consumer interface {
 	// |<-- Epoch N ------------------------------------------------->|
 	// |<-- StakingPhase -->|<-- SetupPhase -->|<-- CommittedPhase -->|
 	//                    ^--- block A - this block's execution result contains an EpochSetup event
-	//                      ^--- block b - contains seal for block A, first block of Setup phase
-	//                         ^--- block c - finalizes block b and triggers `EpochSetupPhaseStarted`
+	//                      ^--- block b - contains seal for block A
+	//                         ^--- block c - contains qc for block b, first block of Setup phase
+	//                           ^--- block d - finalizes block c, triggers EpochSetupPhaseStarted event
 	//
 	// NOTE: Only called once the phase transition has been finalized.
 	EpochSetupPhaseStarted(epoch uint64, first *flow.Header)
@@ -59,8 +60,9 @@ type Consumer interface {
 	// |<-- Epoch N ------------------------------------------------->|
 	// |<-- StakingPhase -->|<-- SetupPhase -->|<-- CommittedPhase -->|
 	//                                       ^--- block D - this block's execution result contains an EpochCommit event
-	//                                         ^--- block e - contains seal for block D, first block of Committed phase
-	//                                            ^--- block f - this block finalizes block e, and triggers `EpochCommittedPhaseStarted`
+	//                                         ^--- block e - contains seal for block D
+	//                                            ^--- block f - contains qc for block e, first block of Committed phase
+	//                                              ^--- block g - finalizes block f, triggers EpochCommittedPhaseStarted event
 	///
 	//
 	// NOTE: Only called once the phase transition has been finalized.


### PR DESCRIPTION
This PR addresses [issue 5560](https://github.com/dapperlabs/flow-go/issues/5560)