### PR TITLE
Vishal/grpc marshal error

### DIFF
--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -3,7 +3,10 @@ package rpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"strings"
+	"unicode/utf8"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/rs/zerolog"
@@ -76,6 +79,7 @@ func New(
 			events:             events,
 			exeResults:         exeResults,
 			transactionResults: txResults,
+			log:                log,
 		},
 		server: server,
 		config: config,
@@ -131,6 +135,7 @@ type handler struct {
 	events             storage.Events
 	exeResults         storage.ExecutionResults
 	transactionResults storage.TransactionResults
+	log                zerolog.Logger
 }
 
 var _ execution.ExecutionAPIServer = &handler{}
@@ -237,9 +242,17 @@ func (h *handler) GetTransactionResult(
 
 		return nil, status.Errorf(codes.Internal, "failed to get transaction result: %v", err)
 	}
+
 	if txResult.ErrorMessage != "" {
+		cadenceErrMessage := txResult.ErrorMessage
+		if !utf8.ValidString(cadenceErrMessage) {
+			h.log.Error().Str("error_mgs", fmt.Sprintf("%q", cadenceErrMessage)).Msg("Invalid character in Cadence error")
+			// convert non UTF-8 string to a UTF-8 string for safe GRPC marshaling
+			cadenceErrMessage = strings.ToValidUTF8(txResult.ErrorMessage, "?")
+		}
+
 		statusCode = 1 // for now a statusCode of 1 indicates an error and 0 indicates no error
-		errMsg = txResult.ErrorMessage
+		errMsg = cadenceErrMessage
 	}
 
 	// lookup events by block id and transaction ID

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -246,7 +246,11 @@ func (h *handler) GetTransactionResult(
 	if txResult.ErrorMessage != "" {
 		cadenceErrMessage := txResult.ErrorMessage
 		if !utf8.ValidString(cadenceErrMessage) {
-			h.log.Error().Str("error_mgs", fmt.Sprintf("%q", cadenceErrMessage)).Msg("Invalid character in Cadence error")
+			h.log.Error().
+				Str("block_id", blockID.String()).
+				Str("transaction_id", txID.String()).
+				Str("error_mgs", fmt.Sprintf("%q", cadenceErrMessage)).
+				Msg("invalid character in Cadence error")
 			// convert non UTF-8 string to a UTF-8 string for safe GRPC marshaling
 			cadenceErrMessage = strings.ToValidUTF8(txResult.ErrorMessage, "?")
 		}


### PR DESCRIPTION
The Bug -

Metrika [reported](https://axiomzen.slack.com/archives/C01FNL8769W/p1622578354041600) that one of the transactions on testnet is returning the following error

> grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
>     status = StatusCode.INTERNAL
>     details = "failed to find: rpc error: code = Internal desc = failed to retrieve result from execution node: 2 errors occurred:
>     * rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8
>     * rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8

Root cause:

Cadence runtime threw an error with the error message containing non UTF-8 characters. This lead to the GRPC marshalling to fail since it expects strings to only have utf-8 charecters.

The fix:
1. Check for non utf-8 characters in the error message and replace them with `?`. 
2. Log the error to help debug

Cadence side fix:
https://github.com/onflow/cadence/issues/966
