### PR TITLE
Integration test fix for PR 736

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/engine/common/requester"
 	synceng "github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/engine/consensus/approvals"
 	"github.com/onflow/flow-go/engine/consensus/compliance"
 	"github.com/onflow/flow-go/engine/consensus/ingestion"
 	"github.com/onflow/flow-go/engine/consensus/matching"
@@ -368,7 +369,7 @@ func main() {
 				node.Storage.Results,
 				node.Storage.Receipts,
 				guarantees,
-				seals,
+				approvals.NewIncorporatedResultSeals(seals, node.Storage.Receipts),
 				receipts,
 				node.Tracer,
 				builder.WithMinInterval(minInterval),

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/onflow/flow-go/engine/consensus/approvals"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -19,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications/pubsub"
 	"github.com/onflow/flow-go/consensus/hotstuff/persister"
 	synceng "github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/engine/consensus/approvals"
 	"github.com/onflow/flow-go/engine/consensus/compliance"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/engine/consensus/approvals"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -185,7 +186,7 @@ func createNode(
 
 	// initialize the block builder
 	build, err := builder.NewBuilder(metrics, db, fullState, headersDB, sealsDB, indexDB, blocksDB, resultsDB, receiptsDB,
-		guarantees, seals, receipts, tracer)
+		guarantees, approvals.NewIncorporatedResultSeals(seals, receiptsDB), receipts, tracer)
 	require.NoError(t, err)
 
 	signer := &Signer{identity.ID()}

--- a/engine/consensus/approvals/incorporated_result_seals.go
+++ b/engine/consensus/approvals/incorporated_result_seals.go
@@ -21,9 +21,10 @@ type IncorporatedResultSeals struct {
 }
 
 // NewIncorporatedResultSeals creates a mempool for the incorporated result seals
-func NewIncorporatedResultSeals(mempool mempool.IncorporatedResultSeals) *IncorporatedResultSeals {
+func NewIncorporatedResultSeals(mempool mempool.IncorporatedResultSeals, receiptsDB storage.ExecutionReceipts) *IncorporatedResultSeals {
 	return &IncorporatedResultSeals{
-		seals: mempool,
+		seals:      mempool,
+		receiptsDB: receiptsDB,
 	}
 }
 
@@ -74,9 +75,19 @@ func (ir *IncorporatedResultSeals) ByID(id flow.Identifier) (*flow.IncorporatedR
 	return seal, true
 }
 
+// Limit returns the size limit of the mempool
+func (ir *IncorporatedResultSeals) Limit() uint {
+	return ir.seals.Limit()
+}
+
 // Rem removes an IncorporatedResultSeal from the mempool
 func (ir *IncorporatedResultSeals) Rem(id flow.Identifier) bool {
 	return ir.seals.Rem(id)
+}
+
+// Size returns the number of items in the mempool
+func (ir *IncorporatedResultSeals) Size() uint {
+	return ir.seals.Size()
 }
 
 // Clear removes all entities from the pool.

--- a/integration/tests/execution/failing_tx_reverted_test.go
+++ b/integration/tests/execution/failing_tx_reverted_test.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -44,6 +45,7 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 	finalStateBlockB, err := erBlockB.ExecutionResult.FinalStateCommitment()
 	require.NoError(s.T(), err)
 
+	time.Sleep(5 * time.Second)
 	// send transaction that panics and should revert
 	tx := common.SDKTransactionFixture(
 		common.WithTransactionDSL(common.CreateCounterPanicTx(chain)),

--- a/integration/tests/execution/failing_tx_reverted_test.go
+++ b/integration/tests/execution/failing_tx_reverted_test.go
@@ -3,7 +3,6 @@ package execution
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -45,7 +44,6 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 	finalStateBlockB, err := erBlockB.ExecutionResult.FinalStateCommitment()
 	require.NoError(s.T(), err)
 
-	time.Sleep(5 * time.Second)
 	// send transaction that panics and should revert
 	tx := common.SDKTransactionFixture(
 		common.WithTransactionDSL(common.CreateCounterPanicTx(chain)),


### PR DESCRIPTION
I think the problem with the integration test is:
* Access nodes now wait until they know _two_ consistent receipts before reporting any state values
* With out updated logic, consensus nodes seal right away (without waiting for _two_ consistent receipts)
* The failing `TestExecutionFailingTxReverted` test waited for the seal and then queried the access node about state values, which declined the request with the error
   ```
    insufficient execution receipts found (1) for block ID ...
   ```

Previously, we also had the consensus node wait for 2 consistent receipts before sealing. But this logic is now no longer present. Hence, problems arise in the integration test, when 1 Exec node is behind. 

#### Solution:
* The `consensus.Builder` waits until 2 consistent receipts are known before including the seal in the block. This can be easily achieved by wrapping the `Builder`'s `IncorporatedResultSeals` mempool with an instance of `approvals/IncorporatedResultSeals`. This works nicely with the builder's selection logic https://github.com/onflow/flow-go/blob/7e5f2ed34d66d2a3f89b94d967c03f20aef11d94/module/builder/consensus/builder.go#L401-L407
* `approvals.IncorporatedResultSeals` was a bit outdated and needed to be updated to implement the interface `mempool.IncorporatedResultSeals`