### PR TITLE
[FVM] prefixed hashers and a few changes

### DIFF
--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -762,7 +762,7 @@ func TestAddAccountKey(t *testing.T) {
 						require.NoError(t, err)
 
 						require.Error(t, tx.Err)
-						assert.Contains(t, tx.Err.Error(), "hashing algorithm type not found")
+						assert.Contains(t, tx.Err.Error(), "hashing algorithm type not supported")
 
 						after, err := vm.GetAccount(ctx, address, view, programs)
 						require.NoError(t, err)

--- a/fvm/crypto/crypto.go
+++ b/fvm/crypto/crypto.go
@@ -36,25 +36,21 @@ func (DefaultSignatureVerifier) Verify(
 	publicKey crypto.PublicKey,
 	hashAlgo hash.HashingAlgorithm,
 ) (bool, error) {
+
 	var hasher hash.Hasher
 
 	switch hashAlgo {
 	case hash.SHA2_256:
-		hasher = hash.NewSHA2_256()
+		fallthrough
 	case hash.SHA3_256:
-		hasher = hash.NewSHA3_256()
-	case hash.SHA2_384:
-		hasher = hash.NewSHA2_384()
-	case hash.SHA3_384:
-		hasher = hash.NewSHA3_384()
+		var err error
+		if hasher, err = NewPrefixedHashing(hashAlgo, string(tag)); err != nil {
+			return false, errors.NewValueErrorf(err.Error(), "verification failed")
+		}
 	case hash.KMAC128:
 		hasher = crypto.NewBLSKMAC(string(tag))
 	default:
 		return false, errors.NewValueErrorf(hashAlgo.String(), "hashing algorithm type not found")
-	}
-
-	if hashAlgo != hash.KMAC128 {
-		message = append(tag, message...)
 	}
 
 	valid, err := publicKey.Verify(signature, message, hasher)
@@ -66,34 +62,28 @@ func (DefaultSignatureVerifier) Verify(
 }
 
 func Hash(hashAlgo hash.HashingAlgorithm, tag string, data []byte) ([]byte, error) {
-	var hashFunc func(tag string, data []byte) hash.Hash
-
-	shaHashWrapper := func(f func([]byte) hash.Hash) func(tag string, data []byte) hash.Hash {
-		return func(tag string, data []byte) hash.Hash {
-			message := append([]byte(tag), data...)
-			return f(message)
-		}
-	}
+	var hasher hash.Hasher
 
 	switch hashAlgo {
 	case hash.SHA2_256:
-		hashFunc = shaHashWrapper(hash.NewSHA2_256().ComputeHash)
+		fallthrough
 	case hash.SHA3_256:
-		hashFunc = shaHashWrapper(hash.NewSHA3_256().ComputeHash)
+		fallthrough
 	case hash.SHA2_384:
-		hashFunc = shaHashWrapper(hash.NewSHA2_384().ComputeHash)
+		fallthrough
 	case hash.SHA3_384:
-		hashFunc = shaHashWrapper(hash.NewSHA3_384().ComputeHash)
-	case hash.KMAC128:
-		hashFunc = func(tag string, data []byte) hash.Hash {
-			return crypto.NewBLSKMAC(tag).ComputeHash(data)
+		var err error
+		if hasher, err = NewPrefixedHashing(hashAlgo, tag); err != nil {
+			return nil, errors.NewValueErrorf(err.Error(), "verification failed")
 		}
+	case hash.KMAC128:
+		hasher = crypto.NewBLSKMAC(tag)
 	default:
-		err := errors.NewValueErrorf(hashAlgo.String(), "hashing algorithm type not found")
+		err := errors.NewValueErrorf(fmt.Sprint(hashAlgo), "hashing algorithm type not found")
 		return nil, fmt.Errorf("hashing failed: %w", err)
 	}
 
-	return hashFunc(tag, data), nil
+	return hasher.ComputeHash(data), nil
 }
 
 // RuntimeToCryptoSigningAlgorithm converts a runtime signature algorithm to a crypto signature algorithm.

--- a/fvm/crypto/hash.go
+++ b/fvm/crypto/hash.go
@@ -1,0 +1,1 @@
+package crypto

--- a/fvm/crypto/hash.go
+++ b/fvm/crypto/hash.go
@@ -11,7 +11,8 @@ import (
 // prefixedHashing, embeds a crypto hasher
 type prefixedHashing struct {
 	hash.Hasher
-	tag [flow.DomainTagLength]byte
+	usePrefix bool
+	tag       [flow.DomainTagLength]byte
 }
 
 // paddedDomainTag converts a string into a padded byte array
@@ -50,7 +51,9 @@ func NewPrefixedHashing(shaAlgo hash.HashingAlgorithm, tag string) (hash.Hasher,
 
 	return &prefixedHashing{
 		Hasher: hasher,
-		tag:    paddedTag,
+		// if tag is empty, do not use any prefix (standard hashing)
+		usePrefix: tag != "",
+		tag:       paddedTag,
 	}, nil
 }
 
@@ -65,5 +68,8 @@ func (s *prefixedHashing) ComputeHash(data []byte) hash.Hash {
 // Reset gets the hasher back to its original state.
 func (s *prefixedHashing) Reset() {
 	s.Hasher.Reset()
-	_, _ = s.Write(s.tag[:])
+	// include the tag only when using a prefix is enabled
+	if s.usePrefix {
+		_, _ = s.Write(s.tag[:])
+	}
 }

--- a/fvm/crypto/hash.go
+++ b/fvm/crypto/hash.go
@@ -1,1 +1,69 @@
 package crypto
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// prefixedHashing, embeds a crypto hasher
+type prefixedHashing struct {
+	hash.Hasher
+	tag [flow.DomainTagLength]byte
+}
+
+// paddedDomainTag converts a string into a padded byte array
+func paddedDomainTag(s string) ([flow.DomainTagLength]byte, error) {
+	var tag [flow.DomainTagLength]byte
+	if len(s) > flow.DomainTagLength {
+		return tag, fmt.Errorf("domain tag %s cannot be longer than %d characters", s, flow.DomainTagLength)
+	}
+	copy(tag[:], s)
+	return tag, nil
+}
+
+// NewPrefixedHashing returns a new hasher that prefixes the tag for all
+// hash computations.
+// Only SHA2 and SHA3 algorithms are supported.
+func NewPrefixedHashing(shaAlgo hash.HashingAlgorithm, tag string) (hash.Hasher, error) {
+
+	var hasher hash.Hasher
+	switch shaAlgo {
+	case hash.SHA2_256:
+		hasher = hash.NewSHA2_256()
+	case hash.SHA3_256:
+		hasher = hash.NewSHA3_256()
+	case hash.SHA2_384:
+		hasher = hash.NewSHA2_384()
+	case hash.SHA3_384:
+		hasher = hash.NewSHA3_384()
+	default:
+		return nil, errors.New("hashing algorithm is not a supported for prefixed algorithm")
+	}
+
+	paddedTag, err := paddedDomainTag(tag)
+	if err != nil {
+		return nil, fmt.Errorf("prefixed hashing failed: %w", err)
+	}
+
+	return &prefixedHashing{
+		Hasher: hasher,
+		tag:    paddedTag,
+	}, nil
+}
+
+// ComputeHash calculates and returns the digest of input byte array prefixed by a tag.
+// Not thread-safe
+func (s *prefixedHashing) ComputeHash(data []byte) hash.Hash {
+	s.Reset()
+	_, _ = s.Write(data)
+	return s.Hasher.SumHash()
+}
+
+// Reset gets the hasher back to its original state.
+func (s *prefixedHashing) Reset() {
+	s.Hasher.Reset()
+	_, _ = s.Write(s.tag[:])
+}

--- a/fvm/crypto/hash.go
+++ b/fvm/crypto/hash.go
@@ -8,14 +8,19 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// prefixedHashing, embeds a crypto hasher
+// prefixedHashing embeds a crypto hasher and implements
+// hashing with a prefix : prefixedHashing(data) = hasher(prefix || data)
+//
+// Prefixes are padded tags till 32 bytes to guarantee prefixedHashers are independant
+// hashers.
+// Prefixes are disabled with the particular tag value ""
 type prefixedHashing struct {
 	hash.Hasher
 	usePrefix bool
 	tag       [flow.DomainTagLength]byte
 }
 
-// paddedDomainTag converts a string into a padded byte array
+// paddedDomainTag converts a string into a padded byte array.
 func paddedDomainTag(s string) ([flow.DomainTagLength]byte, error) {
 	var tag [flow.DomainTagLength]byte
 	if len(s) > flow.DomainTagLength {
@@ -26,7 +31,7 @@ func paddedDomainTag(s string) ([flow.DomainTagLength]byte, error) {
 }
 
 // NewPrefixedHashing returns a new hasher that prefixes the tag for all
-// hash computations.
+// hash computations (only when tag is not empty).
 // Only SHA2 and SHA3 algorithms are supported.
 func NewPrefixedHashing(shaAlgo hash.HashingAlgorithm, tag string) (hash.Hasher, error) {
 

--- a/fvm/crypto/hash_test.go
+++ b/fvm/crypto/hash_test.go
@@ -1,0 +1,68 @@
+package crypto_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"crypto/sha256"
+	"crypto/sha512"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/sha3"
+
+	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/fvm/crypto"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// TestPrefixedHash is a specific test for prefixed hashing
+func TestPrefixedHash(t *testing.T) {
+
+	hashingAlgoToTestingAlgo := map[hash.HashingAlgorithm](func([]byte) []byte){
+		hash.SHA2_256: func(data []byte) []byte {
+			h := sha256.Sum256(data)
+			return h[:]
+		},
+		hash.SHA3_256: func(data []byte) []byte {
+			h := sha3.Sum256(data)
+			return h[:]
+		},
+		hash.SHA2_384: func(data []byte) []byte {
+			h := sha512.Sum384(data)
+			return h[:]
+		},
+		hash.SHA3_384: func(data []byte) []byte {
+			h := sha3.Sum384(data)
+			return h[:]
+		},
+	}
+
+	r := time.Now().UnixNano()
+	rand.Seed(r)
+	t.Logf("math rand seed is %d", r)
+
+	for hashAlgo, testFunction := range hashingAlgoToTestingAlgo {
+		t.Run(hashAlgo.String(), func(t *testing.T) {
+			for i := 32; i < 5000; i++ {
+				// first 32 bytes of data are the tag
+				data := make([]byte, i)
+				rand.Read(data)
+				expected := testFunction(data)
+
+				tag := string(data[:flow.DomainTagLength])
+				message := data[flow.DomainTagLength:]
+				hasher, err := crypto.NewPrefixedHashing(hashAlgo, tag)
+				require.NoError(t, err)
+				h := hasher.ComputeHash(message)
+				assert.Equal(t, expected, []byte(h))
+			}
+		})
+	}
+
+	t.Run("non supported algorithm", func(t *testing.T) {
+		_, err := crypto.NewPrefixedHashing(hash.KMAC128, "")
+		require.Error(t, err)
+	})
+}

--- a/fvm/crypto/hash_test.go
+++ b/fvm/crypto/hash_test.go
@@ -44,7 +44,7 @@ func TestPrefixedHash(t *testing.T) {
 	t.Logf("math rand seed is %d", r)
 
 	for hashAlgo, testFunction := range hashingAlgoToTestingAlgo {
-		t.Run(hashAlgo.String(), func(t *testing.T) {
+		t.Run(hashAlgo.String()+" with a prefix", func(t *testing.T) {
 			for i := 32; i < 5000; i++ {
 				// first 32 bytes of data are the tag
 				data := make([]byte, i)
@@ -56,6 +56,20 @@ func TestPrefixedHash(t *testing.T) {
 				hasher, err := crypto.NewPrefixedHashing(hashAlgo, tag)
 				require.NoError(t, err)
 				h := hasher.ComputeHash(message)
+				assert.Equal(t, expected, []byte(h))
+			}
+		})
+
+		t.Run(hashAlgo.String()+" without a prefix", func(t *testing.T) {
+			for i := 0; i < 5000; i++ {
+				data := make([]byte, i)
+				rand.Read(data)
+				expected := testFunction(data)
+
+				tag := ""
+				hasher, err := crypto.NewPrefixedHashing(hashAlgo, tag)
+				require.NoError(t, err)
+				h := hasher.ComputeHash(data)
 				assert.Equal(t, expected, []byte(h))
 			}
 		})

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"github.com/onflow/cadence/runtime"
 	"strconv"
 	"testing"
+
+	"github.com/onflow/cadence/runtime"
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
@@ -1654,7 +1655,7 @@ func TestHashing(t *testing.T) {
 			Check: func(t *testing.T, result string, scriptErr errors.Error, executionErr error) {
 				require.NoError(t, scriptErr)
 				require.NoError(t, executionErr)
-				require.Equal(t, "cd323b6743f8c72d1b19697aebb0c6c90240c258cd58a2f183c4fde9753143e2", result)
+				require.Equal(t, "4e07609b9a856a5e10703d1dba73be34d9ca0f4e780859d66983f41d746ec8b2", result)
 			},
 		},
 		{
@@ -1664,7 +1665,7 @@ func TestHashing(t *testing.T) {
 			Check: func(t *testing.T, result string, scriptErr errors.Error, executionErr error) {
 				require.NoError(t, scriptErr)
 				require.NoError(t, executionErr)
-				require.Equal(t, "bb7c965165ab02e8196cc2ba1159a3212ed94b8ca27b34698a08bd8f1dcfe2cd5806561e3d66fde304f786069fb89094", result)
+				require.Equal(t, "f9bd89e15f341a225656944dc8b3c405e66a0f97838ad44c9803164c911e677aea7ad4e24486fba3f803d83ed1ccfce5", result)
 			},
 		},
 		{
@@ -1674,7 +1675,7 @@ func TestHashing(t *testing.T) {
 			Check: func(t *testing.T, result string, scriptErr errors.Error, executionErr error) {
 				require.NoError(t, scriptErr)
 				require.NoError(t, executionErr)
-				require.Equal(t, "8cd65b26b10c596628357d9ab47c4730228d27db11580ddd584e490107cb9c76", result)
+				require.Equal(t, "f59e2ccc9d7f008a96948a31573670d9976a4a161601ab1cd1d2da019779a0f6", result)
 			},
 		},
 		{
@@ -1684,7 +1685,7 @@ func TestHashing(t *testing.T) {
 			Check: func(t *testing.T, result string, scriptErr errors.Error, executionErr error) {
 				require.NoError(t, scriptErr)
 				require.NoError(t, executionErr)
-				require.Equal(t, "8f3d63c56dda4ea9dd638a22bda104b1e272feb11c415ac48f4d3dd1dfd3de5f091a5417501615968d5e3729a74f03fa", result)
+				require.Equal(t, "e7875eafdb53327faeace8478d1650c6547d04fb4fb42f34509ad64bde0267bea7e1b3af8fda3ef9d9c9327dd4e97a96", result)
 			},
 		},
 		{


### PR DESCRIPTION
 - move `AddAccountKey` to `accountKey.go` as it is more about accounts than crypto.
  - restrict account keys to ECDSA and SHA2/SHA3 256 only.
 - introduce prefixed hashers to put more emphasis on customized hashing required by domain separated signatures.
 - use padded tags till 32 bytes. 
 - disable prefixing with tags if an empty tag is used ( to accommodate the way the crypto contract is written today: `hash(data) = haswWithTag("", data)` )
 - restrict ECDSA signatures to hashers with SHA2/SHA3 256 only.
