### PR TITLE
Ignore `coverage.txt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # Coverage artifacts
 coverage.zip
+coverage.txt
 cover.json
 cover-summary
 index.html


### PR DESCRIPTION
Adds `coverage.txt` to `.gitignore`. Seems like this file sticks around when the tests are interrupted or fail.