### PR TITLE
Add auto-cadence-upgrade branch to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches: 
       - master
+      - auto-cadence-upgrade/*
   pull_request:
     branches:
       - master
+      - auto-cadence-upgrade/*
 
 jobs:
   golangci:


### PR DESCRIPTION
References: https://github.com/onflow/cadence/pull/981

The auto create Cadence update PR in cadence will create branches prefixed by `auto-cadence-upgrade/` it will also base the PR on the latest created `auto-cadence-upgrade/` branch (or `master` if there is none). 

This is a suggestion to add `auto-cadence-upgrade/` to the CI. This will mean that CI will run all auto updates, not only the one based on `master`.