### PR TITLE
skipping pruning of connections which have ongoing one-to-one traffic

### DIFF
--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -35,9 +35,16 @@ import (
 )
 
 const (
+
+	// The common prefix for all Libp2p protocol IDs used for Flow
+	FlowLibP2PProtocolCommonPrefix = "/flow"
+
 	// A unique Libp2p protocol ID prefix for Flow (https://docs.libp2p.io/concepts/protocols/)
 	// All nodes communicate with each other using this protocol id suffixed with the id of the root block
-	FlowLibP2PProtocolIDPrefix = "/flow/push/"
+	FlowLibP2POneToOneProtocolIDPrefix = FlowLibP2PProtocolCommonPrefix + "/push/"
+
+	// the Flow Ping protocol prefix
+	FlowLibP2PPingProtocolPrefix = FlowLibP2PProtocolCommonPrefix + "/ping/"
 
 	// Maximum time to wait for a ping reply from a remote node
 	PingTimeoutSecs = time.Second * 4

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -36,22 +36,12 @@ import (
 
 const (
 
-	// The common prefix for all Libp2p protocol IDs used for Flow
-	FlowLibP2PProtocolCommonPrefix = "/flow"
-
-	// A unique Libp2p protocol ID prefix for Flow (https://docs.libp2p.io/concepts/protocols/)
-	// All nodes communicate with each other using this protocol id suffixed with the id of the root block
-	FlowLibP2POneToOneProtocolIDPrefix = FlowLibP2PProtocolCommonPrefix + "/push/"
-
-	// the Flow Ping protocol prefix
-	FlowLibP2PPingProtocolPrefix = FlowLibP2PProtocolCommonPrefix + "/ping/"
-
 	// Maximum time to wait for a ping reply from a remote node
 	PingTimeoutSecs = time.Second * 4
-)
 
-// maximum number of attempts to be made to connect to a remote node for 1-1 direct communication
-const maxConnectAttempt = 3
+	// maximum number of attempts to be made to connect to a remote node for 1-1 direct communication
+	maxConnectAttempt = 3
+)
 
 // LibP2PFactoryFunc is a factory function type for generating libp2p Node instances.
 type LibP2PFactoryFunc func() (*Node, error)

--- a/network/p2p/libp2pUtils.go
+++ b/network/p2p/libp2pUtils.go
@@ -208,3 +208,13 @@ func peerInfosFromIDs(ids flow.IdentityList) ([]peer.AddrInfo, map[flow.Identifi
 	}
 	return validIDs, invalidIDs
 }
+
+// flowStream returns the Flow protocol Stream in the connection if one exist, else it returns nil
+func flowStream(conn network.Conn) network.Stream {
+	for _, s := range conn.GetStreams() {
+		if isFlowProtocol(s) {
+			return s
+		}
+	}
+	return nil
+}

--- a/network/p2p/libp2pUtils.go
+++ b/network/p2p/libp2pUtils.go
@@ -160,11 +160,11 @@ func IPPortFromMultiAddress(addrs ...multiaddr.Multiaddr) (string, string, error
 }
 
 func generateFlowProtocolID(rootBlockID string) protocol.ID {
-	return protocol.ID(FlowLibP2PProtocolIDPrefix + rootBlockID)
+	return protocol.ID(FlowLibP2POneToOneProtocolIDPrefix + rootBlockID)
 }
 
 func generatePingProtcolID(rootBlockID string) protocol.ID {
-	return protocol.ID(FlowLibP2PPingPrefix + rootBlockID)
+	return protocol.ID(FlowLibP2PPingProtocolPrefix + rootBlockID)
 }
 
 // PeerAddressInfo generates the libp2p peer.AddrInfo for the given Flow.Identity.

--- a/network/p2p/libp2pUtils.go
+++ b/network/p2p/libp2pUtils.go
@@ -224,7 +224,7 @@ func streamLogger(log zerolog.Logger, stream libp2pnetwork.Stream) zerolog.Logge
 // flowStream returns the Flow protocol Stream in the connection if one exist, else it returns nil
 func flowStream(conn network.Conn) network.Stream {
 	for _, s := range conn.GetStreams() {
-		if isFlowProtocol(s) {
+		if isFlowProtocolStream(s) {
 			return s
 		}
 	}

--- a/network/p2p/ping.go
+++ b/network/p2p/ping.go
@@ -16,9 +16,6 @@ import (
 	"github.com/onflow/flow-go/network/message"
 )
 
-// the Flow Ping protocol prefix
-const FlowLibP2PPingPrefix = "/flow/ping/"
-
 const maxPingMessageSize = 5 * kb
 
 const pingTimeout = time.Second * 60

--- a/network/p2p/protocol.go
+++ b/network/p2p/protocol.go
@@ -21,8 +21,8 @@ const (
 	FlowLibP2PPingProtocolPrefix = FlowLibP2PProtocolCommonPrefix + "/ping/"
 )
 
-// isFlowProtocol returns true if the libp2p stream is for a Flow protocol
-func isFlowProtocol(stream network.Stream) bool {
+// isFlowProtocolStream returns true if the libp2p stream is for a Flow protocol
+func isFlowProtocolStream(stream network.Stream) bool {
 	protocol := string(stream.Protocol())
 	return strings.HasPrefix(protocol, FlowLibP2PProtocolCommonPrefix)
 }

--- a/network/p2p/protocol.go
+++ b/network/p2p/protocol.go
@@ -1,0 +1,28 @@
+package p2p
+
+import (
+	"strings"
+
+	"github.com/libp2p/go-libp2p-core/network"
+)
+
+// Flow Libp2p protocols
+const (
+
+	// The common prefix for all Libp2p protocol IDs used for Flow
+	// ALL Flow libp2p protocols must start with this prefix
+	FlowLibP2PProtocolCommonPrefix = "/flow"
+
+	// A unique Libp2p protocol ID prefix for Flow (https://docs.libp2p.io/concepts/protocols/)
+	// All nodes communicate with each other using this protocol id suffixed with the id of the root block
+	FlowLibP2POneToOneProtocolIDPrefix = FlowLibP2PProtocolCommonPrefix + "/push/"
+
+	// the Flow Ping protocol prefix
+	FlowLibP2PPingProtocolPrefix = FlowLibP2PProtocolCommonPrefix + "/ping/"
+)
+
+// isFlowProtocol returns true if the libp2p stream is for a Flow protocol
+func isFlowProtocol(stream network.Stream) bool {
+	protocol := string(stream.Protocol())
+	return strings.HasPrefix(protocol, FlowLibP2PProtocolCommonPrefix)
+}


### PR DESCRIPTION
## Background
Earlier during the investigation of [5556](https://github.com/dapperlabs/flow-go/issues/5556), a lot of `stream reset` were observed. The root cause of that the connection pruning logic which kicks in every one minute, prunes all connection a node has which are not part of its 1-to-k PubSub topology. This also severs connection on which there is ongoing one-to-one traffic such as `ChunkDataResponse`, `Collection consensus vote` etc. When the connection is closed while there is ongoing one-to-one traffic it leads to a stream reset.

## Fix
The fix is to skip closing the connection when there is a stream created for one-to-one traffic. Such streams can be easily identified by their Protocol ID which all begin with the `/flow` prefix (the pubsub streams use an entirely different protocol id `/meshsub 1.0/` defined by libp2p).

## Some more background
- Connection - A regular TCP connection between to nodes.
- Stream - A logical stream build on top of a connection. One connection can have several streams.
- Stream Protocol ID - The Protocol ID is a unique string which helps sender and receiver figure out what protocol will they be using. These are user defined and we use `/flow/push` for our one-to-one communication and `/flow/ping` for the ping communication. Each stream is created for a particular protocol.  (think of them as application level protocols).