### PR TITLE
making the peer update interval configurable via a command line argum…

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -47,19 +47,20 @@ const notSet = "not set"
 
 // BaseConfig is the general config for the FlowNodeBuilder
 type BaseConfig struct {
-	nodeIDHex        string
-	bindAddr         string
-	nodeRole         string
-	timeout          time.Duration
-	datadir          string
-	level            string
-	metricsPort      uint
-	BootstrapDir     string
-	profilerEnabled  bool
-	profilerDir      string
-	profilerInterval time.Duration
-	profilerDuration time.Duration
-	tracerEnabled    bool
+	nodeIDHex          string
+	bindAddr           string
+	nodeRole           string
+	timeout            time.Duration
+	datadir            string
+	level              string
+	metricsPort        uint
+	BootstrapDir       string
+	peerUpdateInterval time.Duration
+	profilerEnabled    bool
+	profilerDir        string
+	profilerInterval   time.Duration
+	profilerDuration   time.Duration
+	tracerEnabled      bool
 }
 
 type Metrics struct {
@@ -152,6 +153,7 @@ func (fnb *FlowNodeBuilder) baseFlags() {
 	fnb.flags.DurationVarP(&fnb.BaseConfig.timeout, "timeout", "t", 1*time.Minute, "how long to try connecting to the network")
 	fnb.flags.StringVarP(&fnb.BaseConfig.datadir, "datadir", "d", datadir, "directory to store the protocol state")
 	fnb.flags.StringVarP(&fnb.BaseConfig.level, "loglevel", "l", "info", "level for logging output")
+	fnb.flags.DurationVar(&fnb.BaseConfig.peerUpdateInterval, "peerupdate-interval", p2p.DefaultPeerUpdateInterval, "how often to refresh the peer connections for the node")
 	fnb.flags.UintVarP(&fnb.BaseConfig.metricsPort, "metricport", "m", 8080, "port for /metrics endpoint")
 	fnb.flags.BoolVar(&fnb.BaseConfig.profilerEnabled, "profiler-enabled", false, "whether to enable the auto-profiler")
 	fnb.flags.StringVar(&fnb.BaseConfig.profilerDir, "profiler-dir", "profiler", "directory to create auto-profiler profiles")
@@ -205,6 +207,7 @@ func (fnb *FlowNodeBuilder) enqueueNetworkInit() {
 			fnb.Me.NodeID(),
 			fnb.Metrics.Network,
 			fnb.RootBlock.ID().String(),
+			p2p.DefaultPeerUpdateInterval,
 			fnb.MsgValidators...)
 
 		participants, err := fnb.State.Final().Identities(p2p.NetworkingSetFilter)

--- a/network/p2p/peerManager_test.go
+++ b/network/p2p/peerManager_test.go
@@ -124,11 +124,13 @@ func (suite *PeerManagerTestSuite) TestPeriodicPeerUpdate() {
 			wg.Done()
 		}
 	}).Return(nil)
-	pm := NewPeerManager(suite.log, idProvider, connector)
-	PeerUpdateInterval = 5 * time.Millisecond
+
+	peerUpdateInterval := 5 * time.Millisecond
+	pm := NewPeerManager(suite.log, idProvider, connector, WithInterval(peerUpdateInterval))
+
 	unittest.RequireCloseBefore(suite.T(), pm.Ready(), 2*time.Second, "could not start peer manager")
 
-	unittest.RequireReturnsBefore(suite.T(), wg.Wait, 2*PeerUpdateInterval,
+	unittest.RequireReturnsBefore(suite.T(), wg.Wait, 2*peerUpdateInterval,
 		"UpdatePeers is not running on UpdateIntervals")
 }
 
@@ -140,7 +142,7 @@ func (suite *PeerManagerTestSuite) TestOnDemandPeerUpdate() {
 	}
 
 	// chooses peer interval rate deliberately long to capture on demand peer update
-	PeerUpdateInterval = time.Hour
+	peerUpdateInterval := time.Hour
 
 	// creates mock connector
 	wg := &sync.WaitGroup{} // keeps track of number of calls on `ConnectPeers`
@@ -160,7 +162,7 @@ func (suite *PeerManagerTestSuite) TestOnDemandPeerUpdate() {
 		}
 	}).Return(nil)
 
-	pm := NewPeerManager(suite.log, idProvider, connector)
+	pm := NewPeerManager(suite.log, idProvider, connector, WithInterval(peerUpdateInterval))
 	unittest.RequireCloseBefore(suite.T(), pm.Ready(), 2*time.Second, "could not start peer manager")
 
 	unittest.RequireReturnsBefore(suite.T(), wg.Wait, 1*time.Second,
@@ -187,12 +189,12 @@ func (suite *PeerManagerTestSuite) TestConcurrentOnDemandPeerUpdate() {
 	connectPeerGate := make(chan time.Time)
 	defer close(connectPeerGate)
 
+	// choose the periodic interval as a high value so that periodic runs don't interfere with this test
+	peerUpdateInterval := time.Hour
+
 	connector.On("UpdatePeers", mock.Anything, mock.Anything).Return(nil).
 		WaitUntil(connectPeerGate) // blocks call for connectPeerGate channel
-	pm := NewPeerManager(suite.log, idProvider, connector)
-
-	// set the periodic interval to a high value so that periodic runs don't interfere with this test
-	PeerUpdateInterval = time.Hour
+	pm := NewPeerManager(suite.log, idProvider, connector, WithInterval(peerUpdateInterval))
 
 	// start the peer manager
 	// this should trigger the first update and which will block on the ConnectPeers to return

--- a/network/test/testUtil.go
+++ b/network/test/testUtil.go
@@ -80,7 +80,8 @@ func GenerateMiddlewares(t *testing.T, logger zerolog.Logger, identities flow.Id
 			factory,
 			id.NodeID,
 			metrics,
-			rootBlockID)
+			rootBlockID,
+			p2p.DefaultPeerUpdateInterval)
 	}
 	return mws
 }


### PR DESCRIPTION
…ent; bumping up the default duration to 10 minutes from 1 minute

Currently, the network topology does not change. It only changes at a Spork. Hence, the peer update can be done less frequently. This change does the following:
1. Make the PeerUpdate configurable via a command line arg.
2. Bumps up the default interval to 10 minutes instead of 1 minute.
