### PR TITLE
Improve tagging logic if commit has more than 1 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHORT_COMMIT := $(shell git rev-parse --short HEAD)
 # The Git commit hash
 COMMIT := $(shell git rev-parse HEAD)
 # The tag of the current commit, otherwise empty
-VERSION := $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+VERSION := $(shell git describe --tags --abbrev=2 --match "v*" 2>/dev/null)
 
 # Image tag: if image tag is not set, set it with version (or short commit if empty)
 ifeq (${IMAGE_TAG},)


### PR DESCRIPTION
Thanks to @zhangchiqing for helping finding the issue and the correct command for the fix.