### PR TITLE
Auto Cadence Update: Bump postcss from 7.0.34 to 7.0.36 in /npm-packages/cadence-language-server-demo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/m4ksio/wal v1.0.0
 	github.com/marten-seemann/qtls-go1-15 v0.1.4 // indirect
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.17.1-0.20210615162754-3e4815fc8334
+	github.com/onflow/cadence v0.17.1-0.20210615162925-54143da406e4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a
 	github.com/onflow/flow-go-sdk v0.20.0-alpha.1
 	github.com/onflow/flow-go/crypto v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -854,8 +854,8 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
-github.com/onflow/cadence v0.17.1-0.20210615162754-3e4815fc8334 h1:cHf5IhuejatGydy1dxbt8XaE7vH7IhVVVeRYemG73ZI=
-github.com/onflow/cadence v0.17.1-0.20210615162754-3e4815fc8334/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/onflow/cadence v0.17.1-0.20210615162925-54143da406e4 h1:PEi3DXl84nylOwHqkTaxV+XW28cI3RHsa+F/pliA/ko=
+github.com/onflow/cadence v0.17.1-0.20210615162925-54143da406e4/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a h1:7d+9evYk21NhHivkqeyWXId2ai+YMnDxl05VfKlbkaY=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-openapi/strfmt v0.20.0 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.17.1-0.20210615162754-3e4815fc8334
+	github.com/onflow/cadence v0.17.1-0.20210615162925-54143da406e4
 	github.com/onflow/flow-go v0.11.1 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.20.0-alpha.1
 	github.com/onflow/flow-go/crypto v0.18.0 // replaced by version on-disk

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -874,8 +874,8 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
-github.com/onflow/cadence v0.17.1-0.20210615162754-3e4815fc8334 h1:cHf5IhuejatGydy1dxbt8XaE7vH7IhVVVeRYemG73ZI=
-github.com/onflow/cadence v0.17.1-0.20210615162754-3e4815fc8334/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/onflow/cadence v0.17.1-0.20210615162925-54143da406e4 h1:PEi3DXl84nylOwHqkTaxV+XW28cI3RHsa+F/pliA/ko=
+github.com/onflow/cadence v0.17.1-0.20210615162925-54143da406e4/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a h1:7d+9evYk21NhHivkqeyWXId2ai+YMnDxl05VfKlbkaY=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=


### PR DESCRIPTION
Auto generated PR to update Cadence version.

References: https://github.com/onflow/cadence/pull/1009