### PR TITLE
[crypto] Update relic to 9206ae5

### DIFF
--- a/crypto/bls.go
+++ b/crypto/bls.go
@@ -305,15 +305,12 @@ type PubKeyBLSBLS12381 struct {
 // If no scalar is provided, the function allocates an
 // empty scalar.
 func newPubKeyBLSBLS12381(p *pointG2) *PubKeyBLSBLS12381 {
-	var pk PubKeyBLSBLS12381
-	if p == nil {
-		// initialize the point
-		C.ep2_new_wrapper((*C.ep2_st)(&pk.point))
-	} else {
-		// set the point
-		pk.point = *p
+	if p != nil {
+		return &PubKeyBLSBLS12381{
+			point: *p,
+		}
 	}
-	return &pk
+	return &PubKeyBLSBLS12381{}
 }
 
 // Algorithm returns the Signing Algorithm

--- a/crypto/bls.go
+++ b/crypto/bls.go
@@ -171,10 +171,7 @@ func (a *blsBLS12381Algo) generatePrivateKey(seed []byte) (PrivateKey, error) {
 			KeyGenSeedMaxLenBLSBLS12381)
 	}
 
-	sk := &PrKeyBLSBLS12381{
-		// public key is only computed when needed
-		pk: nil,
-	}
+	sk := newPrKeyBLSBLS12381()
 
 	// maps the seed to a private key
 	// error is not checked as it is guaranteed to be nil
@@ -190,9 +187,8 @@ func (a *blsBLS12381Algo) decodePrivateKey(privateKeyBytes []byte) (PrivateKey, 
 			"the input length has to be equal to %d",
 			prKeyLengthBLSBLS12381)
 	}
-	sk := &PrKeyBLSBLS12381{
-		pk: nil,
-	}
+	sk := newPrKeyBLSBLS12381()
+
 	readScalar(&sk.scalar, privateKeyBytes)
 	if C.check_membership_Zr((*C.bn_st)(&sk.scalar)) == valid {
 		return sk, nil
@@ -229,6 +225,16 @@ type PrKeyBLSBLS12381 struct {
 	pk *PubKeyBLSBLS12381
 	// private key data
 	scalar scalar
+}
+
+func newPrKeyBLSBLS12381() *PrKeyBLSBLS12381 {
+	sk := PrKeyBLSBLS12381{
+		// public key is only computed when needed
+		pk: nil,
+	}
+	// initialize the scalar
+	C.bn_new_wrapper((*C.bn_st)(&sk.scalar))
+	return &sk
 }
 
 // Algorithm returns the Signing Algorithm

--- a/crypto/bls12381_utils.c
+++ b/crypto/bls12381_utils.c
@@ -22,6 +22,10 @@ void bn_new_wrapper(bn_t a) {
     bn_new(a);
 }
 
+void  ep2_new_wrapper(ep2_t p) {
+    ep2_new(p);
+}
+
 // global variable of the pre-computed data
 prec_st bls_prec_st;
 prec_st* bls_prec = NULL;

--- a/crypto/bls12381_utils.c
+++ b/crypto/bls12381_utils.c
@@ -22,10 +22,6 @@ void bn_new_wrapper(bn_t a) {
     bn_new(a);
 }
 
-void  ep2_new_wrapper(ep2_t p) {
-    ep2_new(p);
-}
-
 // global variable of the pre-computed data
 prec_st bls_prec_st;
 prec_st* bls_prec = NULL;

--- a/crypto/bls12381_utils.h
+++ b/crypto/bls12381_utils.h
@@ -75,6 +75,7 @@ typedef struct prec_ {
 int      get_valid();
 int      get_invalid();
 void     bn_new_wrapper(bn_t a);
+void     ep2_new_wrapper(ep2_t p);
 
 ctx_t*   relic_init_BLS12_381();
 prec_st* init_precomputed_data_BLS12_381();

--- a/crypto/bls12381_utils.h
+++ b/crypto/bls12381_utils.h
@@ -74,10 +74,11 @@ typedef struct prec_ {
 // Utility functions
 int      get_valid();
 int      get_invalid();
+void     bn_new_wrapper(bn_t a);
 
 ctx_t*   relic_init_BLS12_381();
 prec_st* init_precomputed_data_BLS12_381();
-void     precomputed_data_set(prec_st* p);
+void     precomputed_data_set(const prec_st* p);
 void     seed_relic(byte*, int);
 
 int      ep_read_bin_compact(ep_t, const byte *, const int);

--- a/crypto/bls12381_utils.h
+++ b/crypto/bls12381_utils.h
@@ -75,7 +75,6 @@ typedef struct prec_ {
 int      get_valid();
 int      get_invalid();
 void     bn_new_wrapper(bn_t a);
-void     ep2_new_wrapper(ep2_t p);
 
 ctx_t*   relic_init_BLS12_381();
 prec_st* init_precomputed_data_BLS12_381();

--- a/crypto/bls_multisig.go
+++ b/crypto/bls_multisig.go
@@ -133,12 +133,10 @@ func AggregateBLSPrivateKeys(keys []PrivateKey) (PrivateKey, error) {
 	}
 
 	var sum scalar
+
 	C.bn_sum_vector((*C.bn_st)(&sum), (*C.bn_st)(&scalars[0]),
 		(C.int)(len(scalars)))
-	return &PrKeyBLSBLS12381{
-		pk:     nil,
-		scalar: sum,
-	}, nil
+	return newPrKeyBLSBLS12381(&sum), nil
 }
 
 // AggregateBLSPublicKeys aggregate multiple BLS public keys into one.
@@ -167,9 +165,7 @@ func AggregateBLSPublicKeys(keys []PublicKey) (PublicKey, error) {
 	var sum pointG2
 	C.ep2_sum_vector((*C.ep2_st)(&sum), (*C.ep2_st)(&points[0]),
 		(C.int)(len(points)))
-	return &PubKeyBLSBLS12381{
-		point: sum,
-	}, nil
+	return newPubKeyBLSBLS12381(&sum), nil
 }
 
 func NeutralBLSPublicKey() PublicKey {
@@ -217,9 +213,7 @@ func RemoveBLSPublicKeys(aggKey PublicKey, keysToRemove []PublicKey) (PublicKey,
 	C.ep2_subtract_vector((*C.ep2_st)(&resultKey), (*C.ep2_st)(&aggPKBLS.point),
 		(*C.ep2_st)(&pointsToSubtract[0]), (C.int)(len(pointsToSubtract)))
 
-	return &PubKeyBLSBLS12381{
-		point: resultKey,
-	}, nil
+	return newPubKeyBLSBLS12381(&resultKey), nil
 }
 
 // VerifyBLSSignatureOneMessage is a multi-signature verification that verifies a

--- a/crypto/bls_multisig.go
+++ b/crypto/bls_multisig.go
@@ -133,7 +133,7 @@ func AggregateBLSPrivateKeys(keys []PrivateKey) (PrivateKey, error) {
 	}
 
 	var sum scalar
-
+	C.bn_new_wrapper((*C.bn_st)(&sum))
 	C.bn_sum_vector((*C.bn_st)(&sum), (*C.bn_st)(&scalars[0]),
 		(C.int)(len(scalars)))
 	return newPrKeyBLSBLS12381(&sum), nil
@@ -172,7 +172,7 @@ func NeutralBLSPublicKey() PublicKey {
 	// set BLS context
 	blsInstance.reInit()
 
-	var neutralPk PubKeyBLSBLS12381
+	neutralPk := *newPubKeyBLSBLS12381(nil)
 	// set the point to infinity
 	C.ep2_set_infty((*C.ep2_st)(&neutralPk.point))
 	return &neutralPk

--- a/crypto/build_dependency.sh
+++ b/crypto/build_dependency.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # relic version or tag
-relic_version="7a9bba7f"
+relic_version="9206ae50"
 
 rm -rf relic
 

--- a/crypto/dkg_feldmanvss.go
+++ b/crypto/dkg_feldmanvss.go
@@ -73,6 +73,7 @@ func (s *feldmanVSSstate) init() {
 	s.y = nil
 	s.xReceived = false
 	s.vAReceived = false
+	C.bn_new_wrapper((*C.bn_st)(&s.x))
 }
 
 // Start starts running the protocol in the current node
@@ -236,6 +237,7 @@ func (s *feldmanVSSstate) generateShares(seed []byte) error {
 	randZrStar(&s.a[0]) // non zero a[0]
 	genScalarMultG2(&s.vA[0], &s.a[0])
 	for i := 1; i < s.threshold+1; i++ {
+		C.bn_new_wrapper((*C.bn_st)(&s.a[i]))
 		randZr(&s.a[i])
 		genScalarMultG2(&s.vA[i], &s.a[i])
 	}

--- a/crypto/dkg_feldmanvss.go
+++ b/crypto/dkg_feldmanvss.go
@@ -107,21 +107,15 @@ func (s *feldmanVSSstate) End() (PrivateKey, PublicKey, []PublicKey, error) {
 		return nil, nil, nil, errors.New("keys are not correct")
 	}
 	// private key of the current node
-	x := &PrKeyBLSBLS12381{
-		scalar: s.x, // the private share
-	}
+	x := newPrKeyBLSBLS12381(&s.x)
 
 	// Group public key
-	Y := &PubKeyBLSBLS12381{
-		point: s.vA[0],
-	}
+	Y := newPubKeyBLSBLS12381(&s.vA[0])
 
 	// The nodes public keys
 	y := make([]PublicKey, s.size)
 	for i, p := range s.y {
-		y[i] = &PubKeyBLSBLS12381{
-			point: p,
-		}
+		y[i] = newPubKeyBLSBLS12381(&p)
 	}
 	return x, Y, y, nil
 }

--- a/crypto/dkg_feldmanvssq.go
+++ b/crypto/dkg_feldmanvssq.go
@@ -557,6 +557,7 @@ func (s *feldmanVSSQualState) receiveComplaintAnswer(origin index, data []byte) 
 		}
 
 		// read the complainer private share
+		C.bn_new_wrapper((*C.bn_st)(&s.complaints[complainer].answer))
 		if C.bn_read_Zr_bin((*C.bn_st)(&s.complaints[complainer].answer),
 			(*C.uchar)(&data[1]),
 			PrKeyLenBLSBLS12381,
@@ -577,9 +578,10 @@ func (s *feldmanVSSQualState) receiveComplaintAnswer(origin index, data []byte) 
 	}
 	c.answerReceived = true
 
-	// first flag check is a sanity check
+	// flag check is a sanity check
 	if c.received {
 		// read the complainer private share
+		C.bn_new_wrapper((*C.bn_st)(&c.answer))
 		if C.bn_read_Zr_bin((*C.bn_st)(&c.answer),
 			(*C.uchar)(&data[1]),
 			PrKeyLenBLSBLS12381,

--- a/crypto/dkg_feldmanvssq.go
+++ b/crypto/dkg_feldmanvssq.go
@@ -155,19 +155,14 @@ func (s *feldmanVSSQualState) End() (PrivateKey, PublicKey, []PublicKey, error) 
 	}
 
 	// private key of the current node
-	x := &PrKeyBLSBLS12381{
-		scalar: s.x, // the private share
-	}
+	x := newPrKeyBLSBLS12381(&s.x)
+
 	// Group public key
-	Y := &PubKeyBLSBLS12381{
-		point: s.vA[0],
-	}
+	Y := newPubKeyBLSBLS12381(&s.vA[0])
 	// The nodes public keys
 	y := make([]PublicKey, s.size)
 	for i, p := range s.y {
-		y[i] = &PubKeyBLSBLS12381{
-			point: p,
-		}
+		y[i] = newPubKeyBLSBLS12381(&p)
 	}
 	return x, Y, y, nil
 }

--- a/crypto/dkg_jointfeldman.go
+++ b/crypto/dkg_jointfeldman.go
@@ -180,19 +180,15 @@ func (s *JointFeldmanState) End() (PrivateKey, PublicKey, []PublicKey, error) {
 	jointx, jointPublicKey, jointy := s.sumUpQualifiedKeys(s.size - disqualifiedTotal)
 
 	// private key of the current node
-	x := &PrKeyBLSBLS12381{
-		scalar: *jointx, // the private share
-	}
+	x := newPrKeyBLSBLS12381(jointx)
+
 	// Group public key
-	Y := &PubKeyBLSBLS12381{
-		point: *jointPublicKey,
-	}
+	Y := newPubKeyBLSBLS12381(jointPublicKey)
+
 	// The nodes public keys
 	y := make([]PublicKey, s.size)
 	for i, p := range jointy {
-		y[i] = &PubKeyBLSBLS12381{
-			point: p,
-		}
+		y[i] = newPubKeyBLSBLS12381(&p)
 	}
 	return x, Y, y, nil
 }

--- a/crypto/dkg_jointfeldman.go
+++ b/crypto/dkg_jointfeldman.go
@@ -260,6 +260,7 @@ func (s *JointFeldmanState) sumUpQualifiedKeys(qualified int) (*scalar, *pointG2
 
 	// sum up x
 	var jointx scalar
+	C.bn_new_wrapper((*C.bn_st)(&jointx))
 	C.bn_sum_vector((*C.bn_st)(&jointx), (*C.bn_st)(&qualifiedx[0]),
 		(C.int)(qualified))
 	// sum up Y

--- a/crypto/relic_build.sh
+++ b/crypto/relic_build.sh
@@ -46,7 +46,7 @@ else
 fi
 
 # Set RELIC config for Flow
-COMP=(-DCOMP="-O3 -funroll-loops -fomit-frame-pointer ${MARCH} -mtune=native")
+COMP=(-DCFLAGS="-O3 -funroll-loops -fomit-frame-pointer ${MARCH} -mtune=native")
 GENERAL=(-DTIMER=CYCLE -DCHECK=OFF -DVERBS=OFF)
 LIBS=(-DSHLIB=OFF -DSTLIB=ON)
 RAND=(-DRAND=HASHD -DSEED=)

--- a/crypto/thresholdsign.go
+++ b/crypto/thresholdsign.go
@@ -499,15 +499,9 @@ func ThresholdSignKeyGen(size int, threshold int, seed []byte) ([]PrivateKey,
 	pkShares := make([]PublicKey, size)
 	var pkGroup PublicKey
 	for i := 0; i < size; i++ {
-		skShares[i] = &PrKeyBLSBLS12381{
-			scalar: x[i],
-		}
-		pkShares[i] = &PubKeyBLSBLS12381{
-			point: y[i],
-		}
+		skShares[i] = newPrKeyBLSBLS12381(&x[i])
+		pkShares[i] = newPubKeyBLSBLS12381(&y[i])
 	}
-	pkGroup = &PubKeyBLSBLS12381{
-		point: X0,
-	}
+	pkGroup = newPubKeyBLSBLS12381(&X0)
 	return skShares, pkShares, pkGroup, nil
 }


### PR DESCRIPTION
The diff contains:
- a lot of changes that concern parts of the library we don't use (other curves a la BN, BLS24-X, BLS12-383 ...), integer protocols (ETRS), field extension machinery ...
- otherwise irrelevant changes, e.g. CI/CD
- some memory bug fixing

[Formatted Log](https://gist.githubusercontent.com/huitseeker/e8bbd3f0475ebe93277bdfd46d9424de/raw/385a3dba9fc927b76f1c04e4e96474bff99cab7c/gistfile1.txt)
[Full Changeset](https://github.com/relic-toolkit/relic/compare/7a9bba7f..9206ae5)

**Benchmark Diff:**

`benchstat ~/old_relic.txt ~/new_relic.txt `

```
name                           old time/op  new time/op  delta
ScalarMult/G1-8                 144µs ± 0%   142µs ± 0%   ~     (p=1.000 n=1+1)
ScalarMult/G2-8                 329µs ± 0%   326µs ± 0%   ~     (p=1.000 n=1+1)
HashToG1-8                      231µs ± 0%   230µs ± 0%   ~     (p=1.000 n=1+1)
CheckG1-8                       210µs ± 0%   209µs ± 0%   ~     (p=1.000 n=1+1)
BLSBLS12381Sign-8               477µs ± 0%   473µs ± 0%   ~     (p=1.000 n=1+1)
BLSBLS12381Verify-8            2.71ms ± 0%  2.64ms ± 0%   ~     (p=1.000 n=1+1)
BatchVerify/happy_path-8       81.5ms ± 0%  81.5ms ± 0%   ~     (p=1.000 n=1+1)
BatchVerify/unhappy_path-8      117ms ± 0%   115ms ± 0%   ~     (p=1.000 n=1+1)
VerifySignatureManyMessages-8  3.14ms ± 0%  3.12ms ± 0%   ~     (p=1.000 n=1+1)
Aggregate/PrivateKeys-8        71.6µs ± 0%  70.1µs ± 0%   ~     (p=1.000 n=1+1)
Aggregate/PublicKeys-8         2.85ms ± 0%  2.81ms ± 0%   ~     (p=1.000 n=1+1)
Aggregate/Signatures-8         47.9ms ± 0%  48.0ms ± 0%   ~     (p=1.000 n=1+1)
SimpleKeyGen-8                 20.2ms ± 0%  20.3ms ± 0%   ~     (p=1.000 n=1+1)
```

**Fixed bugs:**

- Unexpected failure of ep2\_mul\[\_lwnaf\] above the prime group order [\#64](https://github.com/relic-toolkit/relic/issues/64)

**Closed issues:**

- Other way to construct towered extension fields [\#203](https://github.com/relic-toolkit/relic/issues/203)
- blake2.h:101:5: error: size of array element is not a multiple of its alignment [\#202](https://github.com/relic-toolkit/relic/issues/202)
- ECIES 160bit [\#201](https://github.com/relic-toolkit/relic/issues/201)
- Compilation with "ARITH gmp" fails [\#200](https://github.com/relic-toolkit/relic/issues/200)
- Support for armv8-a ? [\#198](https://github.com/relic-toolkit/relic/issues/198)
- Function name bn\_init conflicts with OpenSSL when used in tandem [\#196](https://github.com/relic-toolkit/relic/issues/196)
- 16-bit MSP430 [\#193](https://github.com/relic-toolkit/relic/issues/193)
- Modular exponentiation returns 1 if exponent is 0 and modulo is 1 [\#185](https://github.com/relic-toolkit/relic/issues/185)
- Compilation of RELIC with bls12-446 and bls12-455 fails [\#182](https://github.com/relic-toolkit/relic/issues/182)
- test\_bn fails with BLS12-381 preset [\#181](https://github.com/relic-toolkit/relic/issues/181)
- \[BUG\] undefined reference to `bench_init', `bench\_clean' [\#180](https://github.com/relic-toolkit/relic/issues/180)
- Tests FTBFS because of missing symbol in header [\#179](https://github.com/relic-toolkit/relic/issues/179)
- Builds are broken [\#178](https://github.com/relic-toolkit/relic/issues/178)
- compile error  inlining failed in call to always\_inline ‘\_mm\_alignr\_epi8’ on unbantu20.04 gcc9 [\#177](https://github.com/relic-toolkit/relic/issues/177)
- bn\_write\_str buffer overflow [\#176](https://github.com/relic-toolkit/relic/issues/176)
- ECDSA verify succeeds when it should fail [\#175](https://github.com/relic-toolkit/relic/issues/175)
- ec\_mul\_gen hangs with curve SECG\_K256 [\#174](https://github.com/relic-toolkit/relic/issues/174)
- Wrong square root computation [\#173](https://github.com/relic-toolkit/relic/issues/173)
- Out-of-bounds read via bn\_sqr\_basic [\#172](https://github.com/relic-toolkit/relic/issues/172)
- OSS-Fuzz integration [\#171](https://github.com/relic-toolkit/relic/issues/171)
- Building Relic with Curve NIST\_P256 throws FATAL ERROR in relic\_fp\_prime.c:120 [\#170](https://github.com/relic-toolkit/relic/issues/170)
- Compressing \(packing\) a point to binary array does not comply with X9.62 standard [\#169](https://github.com/relic-toolkit/relic/issues/169)
-  ‘ctx\_t’ {aka ‘struct \_ctx\_t’} has no member named ‘total’ [\#168](https://github.com/relic-toolkit/relic/issues/168)
- relic does not work with C++ [\#167](https://github.com/relic-toolkit/relic/issues/167)
- Memory leak in ep2\_curve\_init/clean with ALLOC=DYNAMIC [\#166](https://github.com/relic-toolkit/relic/issues/166)
- \*\_is\_valid\(\) functions produce false negative for not normalized points [\#147](https://github.com/relic-toolkit/relic/issues/147)
- Bench and Test doesnt build [\#122](https://github.com/relic-toolkit/relic/issues/122)

**Merged pull requests:**

- Add pairing delegation protocols [\#199](https://github.com/relic-toolkit/relic/pull/199) ([dfaranha](https://github.com/dfaranha))
- Fix support for Win64/MSVC targets. [\#197](https://github.com/relic-toolkit/relic/pull/197) ([dfaranha](https://github.com/dfaranha))
- Simplify generator getting for Gt. [\#194](https://github.com/relic-toolkit/relic/pull/194) ([luozejiaqun](https://github.com/luozejiaqun))
- cmake: Always use user defined CFLAGS, not only for release builds [\#187](https://github.com/relic-toolkit/relic/pull/187) ([xdustinface](https://github.com/xdustinface))
- Fix MinGW build [\#186](https://github.com/relic-toolkit/relic/pull/186) ([xdustinface](https://github.com/xdustinface))
- Remove debug printf in bn\_mxp\_slide [\#184](https://github.com/relic-toolkit/relic/pull/184) ([guidovranken](https://github.com/guidovranken))
- Remove ALLOC = STACK to simplify memory allocation. [\#183](https://github.com/relic-toolkit/relic/pull/183) ([dfaranha](https://github.com/dfaranha))
- Update relic\_alloc.h [\#165](https://github.com/relic-toolkit/relic/pull/165) ([aguycalled](https://github.com/aguycalled))
- Add correct support for FreeBSD and NetBSD [\#164](https://github.com/relic-toolkit/relic/pull/164) ([hoffmang9](https://github.com/hoffmang9))