### PR TITLE
[Verification] Fixing notifier id at fetcher

### DIFF
--- a/engine/verification/fetcher/engine_test.go
+++ b/engine/verification/fetcher/engine_test.go
@@ -470,7 +470,7 @@ func TestSkipChunkOfSealedBlock(t *testing.T) {
 	// expects processing notifier being invoked upon sealed chunk detected,
 	// which means the termination of processing a sealed chunk on fetcher engine
 	// side.
-	mockChunkConsumerNotifier(t, s.chunkConsumerNotifier, flow.GetIDs(statuses))
+	mockChunkConsumerNotifier(t, s.chunkConsumerNotifier, flow.GetIDs(locators))
 
 	e.ProcessAssignedChunk(locators[0])
 


### PR DESCRIPTION
This issue fixes a bug that the fetcher engine notifies the chunk consumer based on the chunk ID on sealed blocks. However, the chunk consumer would expect the chunk _locator_ ids, which results in a liveness issue on the fetcher engine in one event of fast forwarding.  