### PR TITLE
Support for epoch files & execution state options to bootstrapping script

### DIFF
--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/onflow/cadence"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go/cmd/bootstrap/run"
 	"github.com/onflow/flow-go/fvm"
 	model "github.com/onflow/flow-go/model/bootstrap"

--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -94,6 +94,9 @@ func addFinalizeCmdFlags() {
 	_ = finalizeCmd.MarkFlagRequired("root-height")
 	_ = finalizeCmd.MarkFlagRequired("root-commit")
 	_ = finalizeCmd.MarkFlagRequired("epoch-counter")
+	_ = finalizeCmd.MarkFlagRequired("epoch-length")
+	_ = finalizeCmd.MarkFlagRequired("epoch-staking-phase-length")
+	_ = finalizeCmd.MarkFlagRequired("epoch-dkg-phase-length")
 
 	// optional parameters to influence various aspects of identity generation
 	finalizeCmd.Flags().UintVar(&flagCollectionClusters, "collection-clusters", 2,

--- a/cmd/bootstrap/cmd/keygen.go
+++ b/cmd/bootstrap/cmd/keygen.go
@@ -5,13 +5,10 @@ import (
 	"io"
 	"os"
 
+	"github.com/onflow/flow-go/cmd/bootstrap/run"
 	"github.com/spf13/cobra"
 
-	"github.com/onflow/flow-go-sdk/crypto"
-	"github.com/onflow/flow-go/model/bootstrap"
 	model "github.com/onflow/flow-go/model/bootstrap"
-	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/model/flow/order"
 )
 
 var flagDefaultMachineAccount bool
@@ -48,12 +45,28 @@ var keygenCmd = &cobra.Command{
 		nodes := genNetworkAndStakingKeys()
 		log.Info().Msg("")
 
+		// write key files
+		writeFile := func(relativePath string, val interface{}) error {
+			writeJSON(relativePath, val)
+			return nil
+		}
+		log.Info().Msg("writing internal private key files")
+		err = run.WriteStakingNetworkingKeyFiles(nodes, writeFile)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to write internal private key files")
+		}
+		log.Info().Msg("")
+
 		// if specified, write machine account key files
 		// this should be only be used on non-production networks and immediately after
 		// bootstrapping from a fresh execution state (eg. benchnet)
 		if flagDefaultMachineAccount {
+			chainID := parseChainID(flagRootChain)
 			log.Info().Msg("writing default machine account files")
-			genDefaultMachineAccountKeys(nodes)
+			err = run.WriteMachineAccountFiles(chainID, nodes, writeFile)
+			if err != nil {
+				log.Fatal().Err(err).Msg("failed to write machine account key files")
+			}
 			log.Info().Msg("")
 		}
 
@@ -74,7 +87,10 @@ func init() {
 	// required parameters
 	keygenCmd.Flags().StringVar(&flagConfig, "config", "node-config.json", "path to a JSON file containing multiple node configurations (Role, Address, Stake)")
 	_ = keygenCmd.MarkFlagRequired("config")
+
+	// optional parameters, used for generating machine account files
 	keygenCmd.Flags().BoolVar(&flagDefaultMachineAccount, "machine-account", false, "whether or not to generate a default (same as networking key) machine account key file")
+	keygenCmd.Flags().StringVar(&flagRootChain, "root-chain", "emulator", "chain ID for the root block (can be \"main\", \"test\" or \"emulator\"")
 }
 
 // isEmptyDir returns True if the directory contains children
@@ -98,45 +114,4 @@ func genNodePubInfo(nodes []model.NodeInfo) {
 		pubNodes = append(pubNodes, node.Public())
 	}
 	writeJSON(model.PathInternalNodeInfosPub, pubNodes)
-}
-
-// Generates machine account key files using the node's networking key and assuming
-// a fresh empty execution state
-// TODO copied from testnet/network.go
-func genDefaultMachineAccountKeys(nodes []model.NodeInfo) {
-	nodes = model.Sort(nodes, order.Canonical)
-
-	addressIndex := uint64(4)
-	for _, nodeInfo := range nodes {
-
-		if nodeInfo.Role == flow.RoleCollection || nodeInfo.Role == flow.RoleConsensus {
-			addressIndex += 2
-		} else {
-			addressIndex += 1
-			continue
-		}
-
-		private, err := nodeInfo.Private()
-		if err != nil {
-			log.Fatal().Err(err).Msg("could not get node info private keys")
-		}
-
-		accountAddress, err := flow.Testnet.Chain().AddressAtIndex(addressIndex)
-		if err != nil {
-			log.Fatal().Err(err).Msg("failed to get address")
-		}
-
-		info := model.NodeMachineAccountInfo{
-			Address:           accountAddress.HexWithPrefix(),
-			EncodedPrivateKey: private.NetworkPrivKey.Encode(),
-			KeyIndex:          0,
-			SigningAlgorithm:  private.NetworkPrivKey.Algorithm(),
-			HashAlgorithm:     crypto.SHA3_256,
-		}
-
-		writeJSON(fmt.Sprintf(bootstrap.PathNodeMachineAccountInfoPriv, nodeInfo.NodeID), info)
-		if err != nil {
-			log.Fatal().Err(err).Msg("could not write machine account")
-		}
-	}
 }

--- a/cmd/bootstrap/cmd/keygen.go
+++ b/cmd/bootstrap/cmd/keygen.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/onflow/flow-go/cmd/bootstrap/run"
 	"github.com/spf13/cobra"
 
+	"github.com/onflow/flow-go/cmd/bootstrap/run"
 	model "github.com/onflow/flow-go/model/bootstrap"
 )
 

--- a/cmd/bootstrap/cmd/keys.go
+++ b/cmd/bootstrap/cmd/keys.go
@@ -52,16 +52,6 @@ func genNetworkAndStakingKeys() []model.NodeInfo {
 		writeJSON(fmt.Sprintf(model.PathNodeInfoPriv, nodeInfo.NodeID), private)
 	}
 
-	for _, nodeInfo := range internalNodes {
-		// retrieve private representation of the node
-		private, err := nodeInfo.Private()
-		if err != nil {
-			log.Fatal().Err(err).Msg("could not access private key for internal node")
-		}
-
-		writeJSON(fmt.Sprintf(model.PathNodeInfoPriv, nodeInfo.NodeID), private)
-	}
-
 	return internalNodes
 }
 

--- a/cmd/bootstrap/cmd/keys.go
+++ b/cmd/bootstrap/cmd/keys.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
 
 	"github.com/onflow/flow-go/cmd/bootstrap/run"
@@ -12,6 +10,9 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+// genNetworkAndStakingKeys generates network and staking keys for all nodes
+// specified in the config and returns a list of NodeInfo objects containing
+// these private keys.
 func genNetworkAndStakingKeys() []model.NodeInfo {
 
 	var nodeConfigs []model.NodeConfig
@@ -39,17 +40,8 @@ func genNetworkAndStakingKeys() []model.NodeInfo {
 	internalNodes := make([]model.NodeInfo, 0, len(nodeConfigs))
 	for i, nodeConfig := range nodeConfigs {
 		log.Debug().Int("i", i).Str("address", nodeConfig.Address).Msg("assembling node information")
-
 		nodeInfo := assembleNodeInfo(nodeConfig, networkKeys[i], stakingKeys[i])
 		internalNodes = append(internalNodes, nodeInfo)
-
-		// retrieve private representation of the node
-		private, err := nodeInfo.Private()
-		if err != nil {
-			log.Fatal().Err(err).Msg("could not access private key for internal node")
-		}
-
-		writeJSON(fmt.Sprintf(model.PathNodeInfoPriv, nodeInfo.NodeID), private)
 	}
 
 	return internalNodes

--- a/cmd/bootstrap/cmd/seal.go
+++ b/cmd/bootstrap/cmd/seal.go
@@ -9,7 +9,6 @@ import (
 	"github.com/onflow/flow-go/model/dkg"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/order"
-	"github.com/onflow/flow-go/module/epochs"
 )
 
 func constructRootResultAndSeal(
@@ -19,7 +18,6 @@ func constructRootResultAndSeal(
 	assignments flow.AssignmentList,
 	clusterQCs []*flow.QuorumCertificate,
 	dkgData dkg.DKGData,
-	epochConfig epochs.EpochConfig,
 ) (*flow.ExecutionResult, *flow.Seal) {
 
 	stateCommitBytes, err := hex.DecodeString(rootCommit)

--- a/cmd/bootstrap/run/key_generation.go
+++ b/cmd/bootstrap/run/key_generation.go
@@ -3,7 +3,11 @@ package run
 import (
 	"fmt"
 
+	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func GenerateMachineAccountKey(seed []byte) (crypto.PrivateKey, error) {
@@ -53,4 +57,98 @@ func GenerateKeys(algo crypto.SigningAlgorithm, n int, seeds [][]byte) ([]crypto
 	}
 
 	return keys, nil
+}
+
+// WriteJSONFileFunc is a function which writes a file during bootstrapping. It
+// accepts the path for the file (relative to the bootstrapping root directory)
+// and the value to write. The function must marshal the value as JSON and write
+// the result to the given path.
+type WriteJSONFileFunc func(relativePath string, value interface{}) error
+
+// WriteMachineAccountFiles writes machine account key files for a set of nodeInfos.
+// Assumes that machine accounts have been created using the default execution state
+// bootstrapping.
+func WriteMachineAccountFiles(chainID flow.ChainID, nodeInfos []bootstrap.NodeInfo, write WriteJSONFileFunc) error {
+
+	// write machine account key files for each node which has a machine account (LN/SN)
+	//
+	// for the machine account key, we keep track of the address index to map
+	// the Flow address of the machine account to the key.
+	addressIndex := uint64(4)
+	for _, nodeInfo := range nodeInfos {
+
+		// retrieve private representation of the node
+		private, err := nodeInfo.Private()
+		if err != nil {
+			return err
+		}
+
+		// We use the network key for the machine account. Normally it would be
+		// a separate key.
+
+		// Accounts are generated in a known order during bootstrapping, and
+		// account addresses are deterministic based on order for a given chain
+		// configuration. During the bootstrapping we create 4 Flow accounts besides
+		// the service account (index 0) so node accounts will start at index 5.
+		//
+		// All nodes have a staking account created for them, only collection and
+		// consensus nodes have a second machine account created.
+		//
+		// The accounts are created in the same order defined by the identity list
+		// provided to BootstrapProcedure, which is the same order as this iteration.
+		if nodeInfo.Role == flow.RoleCollection || nodeInfo.Role == flow.RoleConsensus {
+			// increment the address index to account for both the staking account
+			// and the machine account.
+			// now addressIndex points to the machine account address index
+			addressIndex += 2
+		} else {
+			// increment the address index to account for the staking account
+			// we don't need to persist anything related to the staking account
+			addressIndex += 1
+			continue
+		}
+
+		accountAddress, err := chainID.Chain().AddressAtIndex(addressIndex)
+		if err != nil {
+			return err
+		}
+
+		info := bootstrap.NodeMachineAccountInfo{
+			Address:           accountAddress.HexWithPrefix(),
+			EncodedPrivateKey: private.NetworkPrivKey.Encode(),
+			KeyIndex:          0,
+			SigningAlgorithm:  private.NetworkPrivKey.Algorithm(),
+			HashAlgorithm:     sdkcrypto.SHA3_256,
+		}
+
+		path := fmt.Sprintf(bootstrap.PathNodeMachineAccountInfoPriv, nodeInfo.NodeID)
+		err = write(path, info)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WriteStakingNetworkingKeyFiles writes staking and networking keys to private
+// node info files.
+func WriteStakingNetworkingKeyFiles(nodeInfos []bootstrap.NodeInfo, write WriteJSONFileFunc) error {
+
+	for _, nodeInfo := range nodeInfos {
+
+		// retrieve private representation of the node
+		private, err := nodeInfo.Private()
+		if err != nil {
+			return err
+		}
+
+		path := fmt.Sprintf(bootstrap.PathNodeInfoPriv, nodeInfo.NodeID)
+		err = write(path, private)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/cmd/bootstrap/run/key_generation_test.go
+++ b/cmd/bootstrap/run/key_generation_test.go
@@ -1,8 +1,13 @@
 package run
 
 import (
+	"fmt"
 	"testing"
 
+	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/crypto"
@@ -25,4 +30,90 @@ func TestGenerateStakingKeys(t *testing.T) {
 	keys, err := GenerateStakingKeys(2, unittest.SeedFixtures(2, crypto.KeyGenSeedMinLenBLSBLS12381))
 	require.NoError(t, err)
 	require.Len(t, keys, 2)
+}
+
+func TestWriteMachineAccountFiles(t *testing.T) {
+	nodes := append(
+		unittest.PrivateNodeInfosFixture(5, unittest.WithRole(flow.RoleConsensus)),
+		unittest.PrivateNodeInfosFixture(5, unittest.WithRole(flow.RoleCollection))...,
+	)
+
+	chainID := flow.Testnet
+	chain := chainID.Chain()
+
+	nodeIDLookup := make(map[string]flow.Identifier)
+	expected := make(map[string]bootstrap.NodeMachineAccountInfo)
+	for i, node := range nodes {
+		// See comments in WriteMachineAccountFiles for why addresses take this form
+		addr, err := chain.AddressAtIndex(uint64(6 + i*2))
+		require.NoError(t, err)
+		private, err := node.Private()
+		require.NoError(t, err)
+
+		expected[addr.HexWithPrefix()] = bootstrap.NodeMachineAccountInfo{
+			Address:           addr.HexWithPrefix(),
+			EncodedPrivateKey: private.NetworkPrivKey.Encode(),
+			KeyIndex:          0,
+			SigningAlgorithm:  private.NetworkPrivKey.Algorithm(),
+			HashAlgorithm:     sdkcrypto.SHA3_256,
+		}
+		nodeIDLookup[addr.HexWithPrefix()] = node.NodeID
+	}
+
+	write := func(path string, value interface{}) error {
+		actual, ok := value.(bootstrap.NodeMachineAccountInfo)
+		require.True(t, ok)
+
+		expectedInfo, ok := expected[actual.Address]
+		require.True(t, ok)
+		nodeID, ok := nodeIDLookup[actual.Address]
+		require.True(t, ok)
+		expectedPath := fmt.Sprintf(bootstrap.PathNodeMachineAccountInfoPriv, nodeID)
+
+		assert.Equal(t, expectedPath, path)
+		assert.Equal(t, expectedInfo, actual)
+		// remove the value from the mapping, this ensures each one is passed
+		// to the write function exactly once
+		delete(expected, actual.Address)
+
+		return nil
+	}
+
+	err := WriteMachineAccountFiles(chainID, nodes, write)
+	require.NoError(t, err)
+	assert.Len(t, expected, 0)
+}
+
+func TestWriteStakingNetworkingKeyFiles(t *testing.T) {
+	nodes := unittest.PrivateNodeInfosFixture(20, unittest.WithAllRoles())
+
+	// track expected calls to the write func
+	expected := make(map[flow.Identifier]bootstrap.NodeInfoPriv)
+	for _, node := range nodes {
+		private, err := node.Private()
+		require.NoError(t, err)
+		expected[node.NodeID] = private
+	}
+
+	// check that the correct path and value are passed to the write function
+	write := func(path string, value interface{}) error {
+		actual, ok := value.(bootstrap.NodeInfoPriv)
+		require.True(t, ok)
+
+		expectedInfo, ok := expected[actual.NodeID]
+		require.True(t, ok)
+		expectedPath := fmt.Sprintf(bootstrap.PathNodeInfoPriv, expectedInfo.NodeID)
+
+		assert.Equal(t, expectedPath, path)
+		assert.Equal(t, expectedInfo, actual)
+		// remove the value from the mapping, this ensures each one is passed
+		// to the write function exactly once
+		delete(expected, expectedInfo.NodeID)
+
+		return nil
+	}
+
+	err := WriteStakingNetworkingKeyFiles(nodes, write)
+	require.NoError(t, err)
+	assert.Len(t, expected, 0)
 }

--- a/cmd/bootstrap/run/key_generation_test.go
+++ b/cmd/bootstrap/run/key_generation_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
-	"github.com/onflow/flow-go/model/bootstrap"
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/m4ksio/wal v1.0.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.17.1-0.20210615183152-e12b4add8263
+	github.com/onflow/cadence v0.18.0
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210602203947-82cffc9c55ed
 	github.com/onflow/flow-emulator v0.20.3

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFc
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0 h1:TFpwYVIs2b/bd6TlYxa3zMZN2S9CByMvW7Uk01KFP9Y=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
-github.com/onflow/cadence v0.17.1-0.20210615183152-e12b4add8263 h1:ZFrlayk4zy6ebap12+uRRXmKRyjEHfcpcr2UPvIAJug=
-github.com/onflow/cadence v0.17.1-0.20210615183152-e12b4add8263/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/onflow/cadence v0.18.0 h1:Ntvb4UMAllt57qrfEPbyu+A/ktQhZvNmyoE5i09Gqx8=
+github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a h1:7d+9evYk21NhHivkqeyWXId2ai+YMnDxl05VfKlbkaY=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed h1:bGOwiOZrST70f2SVNRxFK/nUOa9cXweTHlBwsHTxkEs=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1034,7 +1034,6 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0 h1:TFpwYVIs2b/bd6TlYxa3zMZN2S9CByMvW7Uk01KFP9Y=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
-github.com/onflow/cadence v0.17.1-0.20210615183152-e12b4add8263/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.18.0 h1:Ntvb4UMAllt57qrfEPbyu+A/ktQhZvNmyoE5i09Gqx8=
 github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed h1:bGOwiOZrST70f2SVNRxFK/nUOa9cXweTHlBwsHTxkEs=

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/utils/io"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -639,9 +638,16 @@ func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string) (*flow.Blo
 	}
 
 	// write staking and machine account private key files
-	err = writePrivateKeyFiles(bootstrapDir, chainID, nodeInfos)
+	writeFile := func(relativePath string, val interface{}) error {
+		return WriteJSON(filepath.Join(bootstrapDir, relativePath), val)
+	}
+	err = run.WriteStakingNetworkingKeyFiles(nodeInfos, writeFile)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to write private key files: %w", err)
+	}
+	err = run.WriteMachineAccountFiles(chainID, nodeInfos, writeFile)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to write machine account files: %w", err)
 	}
 
 	// define root block parameters
@@ -687,11 +693,6 @@ func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string) (*flow.Blo
 		Participants:       participants,
 		Assignments:        clusterAssignments,
 		RandomSource:       randomSource,
-	}
-
-	log.Debug().Msg("testnet participants:")
-	for _, part := range participants {
-		log.Debug().Msg(part.String())
 	}
 
 	epochCommit := &flow.EpochCommit{

--- a/model/bootstrap/node_info.go
+++ b/model/bootstrap/node_info.go
@@ -260,6 +260,17 @@ func NodeInfoFromIdentity(identity *flow.Identity) NodeInfo {
 		identity.StakingPubKey)
 }
 
+func PrivateNodeInfoFromIdentity(identity *flow.Identity, networkKey, stakingKey crypto.PrivateKey) NodeInfo {
+	return NewPrivateNodeInfo(
+		identity.NodeID,
+		identity.Role,
+		identity.Address,
+		identity.Stake,
+		networkKey,
+		stakingKey,
+	)
+}
+
 func FilterByRole(nodes []NodeInfo, role flow.Role) []NodeInfo {
 	var filtered []NodeInfo
 	for _, node := range nodes {

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -788,6 +788,16 @@ func NodeInfosFixture(n int, opts ...func(*flow.Identity)) []bootstrap.NodeInfo 
 	return nodeInfos
 }
 
+func PrivateNodeInfosFixture(n int, opts ...func(*flow.Identity)) []bootstrap.NodeInfo {
+	il := IdentityListFixture(n, opts...)
+	nodeInfos := make([]bootstrap.NodeInfo, 0, n)
+	for _, identity := range il {
+		nodeInfo := bootstrap.PrivateNodeInfoFromIdentity(identity, KeyFixture(crypto.ECDSAP256), KeyFixture(crypto.BLSBLS12381))
+		nodeInfos = append(nodeInfos, nodeInfo)
+	}
+	return nodeInfos
+}
+
 // IdentityFixture returns a node identity.
 func IdentityFixture(opts ...func(*flow.Identity)) *flow.Identity {
 	nodeID := IdentifierFixture()


### PR DESCRIPTION
This PR adds additional flags to some commands in the bootstrapping utility to support running epochs on `benchnet`. 

#### Changes
* Adds epoch length flags to `bootstrap finalize` and pass through to execution state generation
* Adds flag to generate machine account files for a default fresh execution state