### PR TITLE
[Execution] Add pause execution flag

### DIFF
--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -88,6 +88,7 @@ func main() {
 		syncFast                    bool
 		syncThreshold               int
 		extensiveLog                bool
+		pauseExecution              bool
 		checkStakedAtBlock          func(blockID flow.Identifier) (bool, error)
 		diskWAL                     *wal.DiskWAL
 		scriptLogThreshold          time.Duration
@@ -119,6 +120,7 @@ func main() {
 			flags.BoolVar(&extensiveLog, "extensive-logging", false, "extensive logging logs tx contents and block headers")
 			flags.UintVar(&chdpQueryTimeout, "chunk-data-pack-query-timeout-sec", 10, "number of seconds to determine a chunk data pack query being slow")
 			flags.UintVar(&chdpDeliveryTimeout, "chunk-data-pack-delivery-timeout-sec", 10, "number of seconds to determine a chunk data pack response delivery being slow")
+			flags.BoolVar(&pauseExecution, "pause-execution", false, "pause the execution. when set to true, no block will be executed, but still be able to serve queries")
 		}).
 		Module("mutable follower state", func(node *cmd.FlowNodeBuilder) error {
 			// For now, we only support state implementations from package badger.
@@ -337,6 +339,7 @@ func main() {
 				syncThreshold,
 				syncFast,
 				checkStakedAtBlock,
+				pauseExecution,
 			)
 
 			// TODO: we should solve these mutual dependencies better

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -64,6 +64,7 @@ type Engine struct {
 	syncDeltas         mempool.Deltas      // storing the synced state deltas
 	syncFast           bool                // sync fast allows execution node to skip fetching collection during state syncing, and rely on state syncing to catch up
 	checkStakedAtBlock func(blockID flow.Identifier) (bool, error)
+	pauseExecution     bool
 }
 
 func New(
@@ -88,6 +89,7 @@ func New(
 	syncThreshold int,
 	syncFast bool,
 	checkStakedAtBlock func(blockID flow.Identifier) (bool, error),
+	pauseExecution bool,
 ) (*Engine, error) {
 	log := logger.With().Str("engine", "ingestion").Logger()
 
@@ -118,6 +120,7 @@ func New(
 		syncDeltas:         syncDeltas,
 		syncFast:           syncFast,
 		checkStakedAtBlock: checkStakedAtBlock,
+		pauseExecution:     pauseExecution,
 	}
 
 	// move to state syncing engine
@@ -134,9 +137,11 @@ func New(
 // Ready returns a channel that will close when the engine has
 // successfully started.
 func (e *Engine) Ready() <-chan struct{} {
-	err := e.reloadUnexecutedBlocks()
-	if err != nil {
-		e.log.Fatal().Err(err).Msg("failed to load all unexecuted blocks")
+	if !e.pauseExecution {
+		err := e.reloadUnexecutedBlocks()
+		if err != nil {
+			e.log.Fatal().Err(err).Msg("failed to load all unexecuted blocks")
+		}
 	}
 
 	return e.unit.Ready()
@@ -379,6 +384,13 @@ func (e *Engine) reloadBlock(
 // have passed consensus validation) received from the consensus nodes
 // Note: BlockProcessable might be called multiple times for the same block.
 func (e *Engine) BlockProcessable(b *flow.Header) {
+
+	// when the flag is on, no block will be executed. Useful for EN to serve
+	// execution state queries
+	if e.pauseExecution {
+		return
+	}
+
 	blockID := b.ID()
 	newBlock, err := e.blocks.ByID(blockID)
 	if err != nil {

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -169,6 +169,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 		10,
 		false,
 		checkStakedAtBlock,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -982,6 +983,7 @@ func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mocks.Executi
 		10,
 		false,
 		checkStakedAtBlock,
+		false,
 	)
 
 	require.NoError(t, err)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -469,6 +469,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		syncThreshold,
 		false,
 		checkStakedAtBlock,
+		false,
 	)
 	require.NoError(t, err)
 	requestEngine.WithHandle(ingestionEngine.OnCollection)


### PR DESCRIPTION
Adding a flag `pause-execution` to execution node to pause the execution and allow the node to serve queries only