### PR TITLE
Update to Cadence v0.18.0-patch.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,4 @@ replace mellium.im/sasl => github.com/mellium/sasl v0.2.1
 
 replace github.com/onflow/flow-go/crypto => ./crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.1
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.2

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.1 h1:+eW3ggjUpvh1MTwxKroSRY/+EE+E0okefT/UnXlNmlo=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.1/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.2 h1:/MMLOv6kbkqBVCbQ0a1nqq5cqyxQOxhBd3fmTwGGW14=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.2/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -28,4 +28,4 @@ replace github.com/onflow/flow-go => ../
 
 replace github.com/onflow/flow-go/crypto => ../crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.1
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.2

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -181,8 +181,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.1 h1:+eW3ggjUpvh1MTwxKroSRY/+EE+E0okefT/UnXlNmlo=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.1/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.2 h1:/MMLOv6kbkqBVCbQ0a1nqq5cqyxQOxhBd3fmTwGGW14=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.2/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90 h1:RYSKhK13V8pZq+AqjWnH1vrENL/ZMyWqj2W2rGPDmYo=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
dapperlabs/cadence-internal#22 ported to Cadence v0.18

Diff: https://github.com/dapperlabs/cadence-internal/compare/v0.18.0-patch.1..v0.18.0-patch.2

This was already applied as a hotfix to Flow Go v0.17 in #860