### PR TITLE
[Consensus] v0.18 not require approval for sealing

### DIFF
--- a/engine/consensus/sealing/core.go
+++ b/engine/consensus/sealing/core.go
@@ -28,7 +28,7 @@ import (
 
 // DefaultRequiredApprovalsForSealConstruction is the default number of approvals required to construct a candidate seal
 // for subsequent inclusion in block.
-const DefaultRequiredApprovalsForSealConstruction = 3
+const DefaultRequiredApprovalsForSealConstruction = 0
 
 // DefaultEmergencySealingActive is a flag which indicates when emergency sealing is active, this is a temporary measure
 // to make fire fighting easier while seal & verification is under development.


### PR DESCRIPTION
In case we don't want to require approvals for sealing, simply merge this PR.

The emergency-sealing-active could be `true` doesn't need to be changed, because it will never be triggered.