### PR TITLE
[Verification] gracefully handle the missing register case

### DIFF
--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -195,7 +195,6 @@ func (e *Engine) verify(ctx context.Context, originID flow.Identifier,
 	}
 
 	// if any fault found with the chunk
-	sendApproval := true
 	if chFault != nil {
 		switch chFault.(type) {
 		case *chmodels.CFMissingRegisterTouch:
@@ -204,18 +203,14 @@ func (e *Engine) verify(ctx context.Context, originID flow.Identifier,
 		case *chmodels.CFNonMatchingFinalState:
 			// TODO raise challenge
 			e.log.Warn().Msg(chFault.String())
-			sendApproval = false
+			return nil
 		case *chmodels.CFInvalidVerifiableChunk:
 			// TODO raise challenge
 			e.log.Error().Msg(chFault.String())
-			sendApproval = false
+			return nil
 		default:
 			return engine.NewInvalidInputErrorf("unknown type of chunk fault is received (type: %T) : %v",
 				chFault, chFault.String())
-		}
-		if !sendApproval {
-			// don't do anything else, but skip generating result approvals
-			return nil
 		}
 	}
 

--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -199,7 +199,7 @@ func (e *Engine) verify(ctx context.Context, originID flow.Identifier,
 	if chFault != nil {
 		switch chFault.(type) {
 		case *chmodels.CFMissingRegisterTouch:
-			e.log.Error().Msg(chFault.String())
+			e.log.Warn().Msg(chFault.String())
 			// still create approvals for this case
 		case *chmodels.CFNonMatchingFinalState:
 			// TODO raise challenge

--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -195,22 +195,28 @@ func (e *Engine) verify(ctx context.Context, originID flow.Identifier,
 	}
 
 	// if any fault found with the chunk
+	sendApproval := true
 	if chFault != nil {
 		switch chFault.(type) {
 		case *chmodels.CFMissingRegisterTouch:
 			e.log.Error().Msg(chFault.String())
+			// still create approvals for this case
 		case *chmodels.CFNonMatchingFinalState:
 			// TODO raise challenge
 			e.log.Warn().Msg(chFault.String())
+			sendApproval = false
 		case *chmodels.CFInvalidVerifiableChunk:
 			// TODO raise challenge
 			e.log.Error().Msg(chFault.String())
+			sendApproval = false
 		default:
 			return engine.NewInvalidInputErrorf("unknown type of chunk fault is received (type: %T) : %v",
 				chFault, chFault.String())
 		}
-		// don't do anything else, but skip generating result approvals
-		return nil
+		if !sendApproval {
+			// don't do anything else, but skip generating result approvals
+			return nil
+		}
 	}
 
 	// Generate result approval

--- a/engine/verification/verifier/engine_test.go
+++ b/engine/verification/verifier/engine_test.go
@@ -237,7 +237,8 @@ func (v ChunkVerifierMock) Verify(vc *verification.VerifiableChunkData) ([]byte,
 		return nil, chmodel.NewCFMissingRegisterTouch(
 			[]string{"test missing register touch"},
 			vc.Chunk.Index,
-			vc.Result.ID()), nil
+			vc.Result.ID(),
+			unittest.TransactionFixture().ID()), nil
 
 	case 2:
 		return nil, chmodel.NewCFInvalidVerifiableChunk(

--- a/model/chunks/chunkFaults.go
+++ b/model/chunks/chunkFaults.go
@@ -20,6 +20,7 @@ type CFMissingRegisterTouch struct {
 	regsterIDs []string
 	chunkIndex uint64
 	execResID  flow.Identifier
+	txID       flow.Identifier // very first transaction inside the chunk that required this register
 }
 
 func (cf CFMissingRegisterTouch) String() string {
@@ -28,7 +29,7 @@ func (cf CFMissingRegisterTouch) String() string {
 		hexStrings[i] = hex.EncodeToString([]byte(s))
 	}
 
-	return fmt.Sprint("at least one register touch was missing inside the chunk data package that was needed while running transactions (hex-encoded): ", hexStrings)
+	return fmt.Sprintf("at least one register touch was missing inside the chunk data package that was needed while running transactions of chunk %d of result %s (tx hash of one of them: %s), hex-encoded register ids: %s", cf.chunkIndex, cf.execResID.String(), cf.txID.String(), hexStrings)
 }
 
 // ChunkIndex returns chunk index of the faulty chunk
@@ -42,10 +43,11 @@ func (cf CFMissingRegisterTouch) ExecutionResultID() flow.Identifier {
 }
 
 // NewCFMissingRegisterTouch creates a new instance of Chunk Fault (MissingRegisterTouch)
-func NewCFMissingRegisterTouch(regsterIDs []string, chInx uint64, execResID flow.Identifier) *CFMissingRegisterTouch {
+func NewCFMissingRegisterTouch(regsterIDs []string, chInx uint64, execResID flow.Identifier, txID flow.Identifier) *CFMissingRegisterTouch {
 	return &CFMissingRegisterTouch{regsterIDs: regsterIDs,
 		chunkIndex: chInx,
-		execResID:  execResID}
+		execResID:  execResID,
+		txID:       txID}
 }
 
 // CFNonMatchingFinalState is returned when the computed final state commitment

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -167,7 +167,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 		}
 
 		if len(unknownRegTouch) > 0 {
-			problematicTx = tx.ID()
+			problematicTx = tx.ID
 		}
 
 		// always merge back the tx view (fvm is responsible for changes on tx errors)
@@ -209,9 +209,9 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 			for i, key := range keys {
 				stringKeys[i] = key.String()
 			}
-			return nil, chmodels.NewCFMissingRegisterTouch(stringKeys, chIndex, execResID), nil
+			return nil, chmodels.NewCFMissingRegisterTouch(stringKeys, chIndex, execResID, problematicTx), nil
 		}
-		return nil, chmodels.NewCFMissingRegisterTouch(nil, chIndex, execResID), nil
+		return nil, chmodels.NewCFMissingRegisterTouch(nil, chIndex, execResID, problematicTx), nil
 	}
 
 	// TODO check if exec node provided register touches that was not used (no read and no update)

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -117,6 +117,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 	// unknown register tracks access to parts of the partial trie which
 	// are not expanded and values are unknown.
 	unknownRegTouch := make(map[string]*ledger.Key)
+	var problematicTx flow.Identifier
 	getRegister := func(owner, controller, key string) (flow.RegisterValue, error) {
 		// check if register has been provided in the chunk data pack
 		registerID := flow.NewRegisterID(owner, controller, key)
@@ -134,7 +135,6 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 			if errors.Is(err, ledger.ErrMissingKeys{}) {
 
 				unknownRegTouch[registerID.String()] = &registerKey
-
 				// don't send error just return empty byte slice
 				// we always assume empty value for missing registers (which might cause the transaction to fail)
 				// but after execution we check unknownRegTouch and if any
@@ -166,6 +166,10 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 			return nil, nil, fmt.Errorf("failed to execute transaction: %d (%w)", i, err)
 		}
 
+		if len(unknownRegTouch) > 0 {
+			problematicTx = tx.ID()
+		}
+
 		// always merge back the tx view (fvm is responsible for changes on tx errors)
 		err = chunkView.MergeView(txView)
 		if err != nil {
@@ -179,7 +183,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 		for _, key := range unknownRegTouch {
 			missingRegs = append(missingRegs, key.String())
 		}
-		return nil, chmodels.NewCFMissingRegisterTouch(missingRegs, chIndex, execResID), nil
+		return nil, chmodels.NewCFMissingRegisterTouch(missingRegs, chIndex, execResID, problematicTx), nil
 	}
 
 	// applying chunk delta (register updates at chunk level) to the partial trie


### PR DESCRIPTION
This change would let verification nodes to gracefully handle a very special edge case of missing some register touches until the root cause of this edge case is identified and patched.