### PR TITLE
Reject duplicated signatures

### DIFF
--- a/access/errors.go
+++ b/access/errors.go
@@ -61,6 +61,16 @@ func (e InvalidAddressError) Error() string {
 	return fmt.Sprintf("invalid address: %s", e.Address)
 }
 
+// DuplicatedSignatureError indicates that two signatures havs been provided for a key (combination of account and key index)
+type DuplicatedSignatureError struct {
+	Address  flow.Address
+	KeyIndex uint64
+}
+
+func (e DuplicatedSignatureError) Error() string {
+	return fmt.Sprintf("duplicated signature for key (address: %s, index: %d)", e.Address.String(), e.KeyIndex)
+}
+
 // InvalidSignatureError indicates that a transaction contains a signature
 // with a wrong format.
 type InvalidSignatureError struct {

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -166,6 +166,19 @@ func (suite *Suite) TestInvalidTransaction() {
 	})
 
 	suite.Run("invalid signature format", func() {
+		signer := flow.Testnet.Chain().ServiceAddress()
+		keyIndex := uint64(0)
+
+		sig1 := unittest.TransactionSignatureFixture()
+		sig1.KeyIndex = keyIndex
+		sig1.Address = signer
+		sig1.SignerIndex = 0
+
+		sig2 := unittest.TransactionSignatureFixture()
+		sig2.KeyIndex = keyIndex
+		sig2.Address = signer
+		sig2.SignerIndex = 1
+
 		suite.Run("invalid format of an enveloppe signature", func() {
 			invalidSig := unittest.InvalidFormatSignature()
 			tx := unittest.TransactionBodyFixture()
@@ -191,8 +204,7 @@ func (suite *Suite) TestInvalidTransaction() {
 		suite.Run("duplicated signature (envelope only)", func() {
 			tx := unittest.TransactionBodyFixture()
 			tx.ReferenceBlockID = suite.root.ID()
-			tx.EnvelopeSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture(), unittest.TransactionSignatureFixture()}
-
+			tx.EnvelopeSignatures = []flow.TransactionSignature{sig1, sig2}
 			err := suite.engine.ProcessLocal(&tx)
 			suite.Assert().Error(err)
 			suite.Assert().True(errors.As(err, &access.DuplicatedSignatureError{}))
@@ -201,7 +213,7 @@ func (suite *Suite) TestInvalidTransaction() {
 		suite.Run("duplicated signature (payload only)", func() {
 			tx := unittest.TransactionBodyFixture()
 			tx.ReferenceBlockID = suite.root.ID()
-			tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture(), unittest.TransactionSignatureFixture()}
+			tx.PayloadSignatures = []flow.TransactionSignature{sig1, sig2}
 
 			err := suite.engine.ProcessLocal(&tx)
 			suite.Assert().Error(err)
@@ -211,8 +223,8 @@ func (suite *Suite) TestInvalidTransaction() {
 		suite.Run("duplicated signature (cross case)", func() {
 			tx := unittest.TransactionBodyFixture()
 			tx.ReferenceBlockID = suite.root.ID()
-			tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()}
-			tx.EnvelopeSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()}
+			tx.PayloadSignatures = []flow.TransactionSignature{sig1}
+			tx.EnvelopeSignatures = []flow.TransactionSignature{sig2}
 
 			err := suite.engine.ProcessLocal(&tx)
 			suite.Assert().Error(err)

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -187,6 +187,37 @@ func (suite *Suite) TestInvalidTransaction() {
 			suite.Assert().Error(err)
 			suite.Assert().True(errors.As(err, &access.InvalidSignatureError{}))
 		})
+
+		suite.Run("duplicated signature (envelope only)", func() {
+			tx := unittest.TransactionBodyFixture()
+			tx.ReferenceBlockID = suite.root.ID()
+			tx.EnvelopeSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture(), unittest.TransactionSignatureFixture()}
+
+			err := suite.engine.ProcessLocal(&tx)
+			suite.Assert().Error(err)
+			suite.Assert().True(errors.As(err, &access.DuplicatedSignatureError{}))
+		})
+
+		suite.Run("duplicated signature (payload only)", func() {
+			tx := unittest.TransactionBodyFixture()
+			tx.ReferenceBlockID = suite.root.ID()
+			tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture(), unittest.TransactionSignatureFixture()}
+
+			err := suite.engine.ProcessLocal(&tx)
+			suite.Assert().Error(err)
+			suite.Assert().True(errors.As(err, &access.DuplicatedSignatureError{}))
+		})
+
+		suite.Run("duplicated signature (cross case)", func() {
+			tx := unittest.TransactionBodyFixture()
+			tx.ReferenceBlockID = suite.root.ID()
+			tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()}
+			tx.EnvelopeSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()}
+
+			err := suite.engine.ProcessLocal(&tx)
+			suite.Assert().Error(err)
+			suite.Assert().True(errors.As(err, &access.DuplicatedSignatureError{}))
+		})
 	})
 
 	suite.Run("invalid signature", func() {

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -181,7 +181,7 @@ func (suite *Suite) TestInvalidTransaction() {
 			invalidSig := unittest.InvalidFormatSignature()
 			tx := unittest.TransactionBodyFixture()
 			tx.ReferenceBlockID = suite.root.ID()
-			tx.PayloadSignatures[0] = invalidSig
+			tx.PayloadSignatures = []flow.TransactionSignature{invalidSig}
 
 			err := suite.engine.ProcessLocal(&tx)
 			suite.Assert().Error(err)

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -170,14 +170,7 @@ func TestPrograms(t *testing.T) {
 						SetProposalKey(serviceAddress, 0, uint64(i)).
 						SetPayer(serviceAddress)
 
-					err := testutil.SignPayload(
-						txBody,
-						serviceAddress,
-						unittest.ServiceAccountPrivateKey,
-					)
-					require.NoError(t, err)
-
-					err = testutil.SignEnvelope(
+					err := testutil.SignEnvelope(
 						txBody,
 						serviceAddress,
 						unittest.ServiceAccountPrivateKey,
@@ -1087,14 +1080,13 @@ func TestBlockContext_GetAccount(t *testing.T) {
 	createAccount := func() (flow.Address, crypto.PublicKey) {
 		privateKey, txBody := testutil.CreateAccountCreationTransaction(t, chain)
 
-		err := testutil.SignTransactionAsServiceAccount(txBody, sequenceNumber, chain)
-		require.NoError(t, err)
-
+		txBody.SetProposalKey(chain.ServiceAddress(), 0, sequenceNumber)
+		txBody.SetPayer(chain.ServiceAddress())
 		sequenceNumber++
 
 		rootHasher := hash.NewSHA2_256()
 
-		err = txBody.SignEnvelope(
+		err := txBody.SignEnvelope(
 			chain.ServiceAddress(),
 			0,
 			unittest.ServiceAccountPrivateKey.PrivateKey,
@@ -2022,9 +2014,6 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			txBody.SetProposalKey(accounts[0], 0, 0)
 			txBody.SetPayer(accounts[0])
 
-			err = testutil.SignPayload(txBody, accounts[0], privateKeys[0])
-			require.NoError(t, err)
-
 			err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 			require.NoError(t, err)
 
@@ -2066,9 +2055,6 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				txBody.SetProposalKey(accounts[0], 0, 10)
 				txBody.SetPayer(accounts[0])
 
-				err = testutil.SignPayload(txBody, accounts[0], privateKeys[0])
-				require.NoError(t, err)
-
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
@@ -2105,9 +2091,6 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 				txBody.SetProposalKey(accounts[0], 0, 0)
 				txBody.SetPayer(accounts[0])
-
-				err = testutil.SignPayload(txBody, accounts[0], privateKeys[0])
-				require.NoError(t, err)
 
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
@@ -2329,12 +2312,12 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				// ==== Create an account ====
 				privateKey, txBody := testutil.CreateAccountCreationTransaction(t, chain)
 
-				err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
-				require.NoError(t, err)
+				txBody.SetProposalKey(chain.ServiceAddress(), 0, 0)
+				txBody.SetPayer(chain.ServiceAddress())
 
 				rootHasher := hash.NewSHA2_256()
 
-				err = txBody.SignEnvelope(
+				err := txBody.SignEnvelope(
 					chain.ServiceAddress(),
 					0,
 					unittest.ServiceAccountPrivateKey.PrivateKey,
@@ -2369,13 +2352,6 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				txBody.SetProposalKey(chain.ServiceAddress(), 0, 1)
 				txBody.SetPayer(chain.ServiceAddress())
 
-				err = testutil.SignPayload(
-					txBody,
-					chain.ServiceAddress(),
-					unittest.ServiceAccountPrivateKey,
-				)
-				require.NoError(t, err)
-
 				err = testutil.SignEnvelope(
 					txBody,
 					chain.ServiceAddress(),
@@ -2400,13 +2376,6 @@ func TestTransactionFeeDeduction(t *testing.T) {
 
 				txBody.SetProposalKey(address, 0, 0)
 				txBody.SetPayer(address)
-
-				err = testutil.SignPayload(
-					txBody,
-					address,
-					privateKey,
-				)
-				require.NoError(t, err)
 
 				err = testutil.SignEnvelope(
 					txBody,

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -1,3 +1,69 @@
 package fvm_test
 
-// TODO add some unit tests for tx verifier
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/programs"
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/utils"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestTransactionVerification(t *testing.T) {
+	ledger := utils.NewSimpleView()
+	sth := state.NewStateHolder(state.NewState(ledger))
+	accounts := state.NewAccounts(sth)
+
+	// create an account
+	address := flow.HexToAddress("1234")
+	privKey, err := unittest.AccountKeyDefaultFixture()
+	require.NoError(t, err)
+	err = accounts.Create([]flow.AccountPublicKey{privKey.PublicKey(1000)}, address)
+	require.NoError(t, err)
+
+	sig1 := flow.TransactionSignature{
+		Address:     address,
+		SignerIndex: 0,
+		KeyIndex:    0,
+		Signature:   []byte("SIGNATURE"),
+	}
+
+	sig2 := flow.TransactionSignature{
+		Address:     address,
+		SignerIndex: 1,
+		KeyIndex:    0,
+		Signature:   []byte("SIGNATURE"),
+	}
+
+	t.Run("duplicated authorization signatures", func(t *testing.T) {
+		tx := flow.TransactionBody{}
+		tx.SetProposalKey(address, 0, 0)
+		tx.SetPayer(address)
+		tx.PayloadSignatures = []flow.TransactionSignature{sig1, sig2}
+		proc := fvm.Transaction(&tx, 0)
+
+		txVerifier := fvm.NewTransactionSignatureVerifier(1000)
+		err = txVerifier.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "duplicate signatures are provided for the same key"))
+	})
+	t.Run("duplicated authorization and envelope signatures", func(t *testing.T) {
+		tx := flow.TransactionBody{}
+		tx.SetProposalKey(address, 0, 0)
+		tx.SetPayer(address)
+
+		tx.PayloadSignatures = []flow.TransactionSignature{sig1}
+		tx.EnvelopeSignatures = []flow.TransactionSignature{sig2}
+		proc := fvm.Transaction(&tx, 0)
+
+		txVerifier := fvm.NewTransactionSignatureVerifier(1000)
+		err = txVerifier.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "duplicate signatures are provided for the same key"))
+	})
+}

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -307,9 +307,6 @@ func TestAccountFreezing(t *testing.T) {
 		txBody.SetPayer(accounts[0])
 		txBody.SetProposalKey(accounts[0], 0, 0)
 
-		err = testutil.SignPayload(txBody, accounts[0], privateKeys[0])
-		require.NoError(t, err)
-
 		err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 		require.NoError(t, err)
 
@@ -327,9 +324,6 @@ func TestAccountFreezing(t *testing.T) {
 		txBody.AddAuthorizer(serviceAddress)
 		txBody.SetPayer(serviceAddress)
 		txBody.SetProposalKey(serviceAddress, 0, 0)
-
-		err = testutil.SignPayload(txBody, serviceAddress, unittest.ServiceAccountPrivateKey)
-		require.NoError(t, err)
 
 		err = testutil.SignEnvelope(txBody, serviceAddress, unittest.ServiceAccountPrivateKey)
 		require.NoError(t, err)
@@ -385,9 +379,6 @@ func TestAccountFreezing(t *testing.T) {
 		txBody.SetProposalKey(serviceAddress, 0, 0)
 		txBody.SetPayer(serviceAddress)
 		txBody.AddAuthorizer(serviceAddress)
-
-		err = testutil.SignPayload(txBody, serviceAddress, unittest.ServiceAccountPrivateKey)
-		require.NoError(t, err)
 
 		err = testutil.SignEnvelope(txBody, serviceAddress, unittest.ServiceAccountPrivateKey)
 		require.NoError(t, err)

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1542,7 +1542,6 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
-pgregory.net/rapid v0.4.6 h1:0z4eYXX8FaxgeFLAaPce6zMAiQYKLMN9dqKzZgtpv4w=
 pgregory.net/rapid v0.4.6/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/integration/tests/common/util.go
+++ b/integration/tests/common/util.go
@@ -178,7 +178,7 @@ func SDKTransactionFixture(opts ...func(*sdk.Transaction)) sdk.Transaction {
 		ProposalKey:        convert.ToSDKProposalKey(unittest.ProposalKeyFixture()),
 		Payer:              sdk.Address(unittest.AddressFixture()),
 		Authorizers:        []sdk.Address{sdk.Address(unittest.AddressFixture())},
-		PayloadSignatures:  []sdk.TransactionSignature{convert.ToSDKTransactionSignature(unittest.TransactionSignatureFixture())},
+		PayloadSignatures:  []sdk.TransactionSignature{},
 		EnvelopeSignatures: []sdk.TransactionSignature{convert.ToSDKTransactionSignature(unittest.TransactionSignatureFixture())},
 	}
 

--- a/model/flow/transaction.go
+++ b/model/flow/transaction.go
@@ -455,6 +455,11 @@ func (s TransactionSignature) String() string {
 		s.Address, s.SignerIndex, s.KeyIndex, s.Signature)
 }
 
+// UniqueKeyString returns constructs an string with combination of address and key
+func (s TransactionSignature) UniqueKeyString() string {
+	return fmt.Sprintf("%s-%d", s.Address.String(), s.KeyIndex)
+}
+
 // ByteSize returns the byte size of the transaction signature
 func (s TransactionSignature) ByteSize() int {
 	signerIndexLen := 8

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -465,8 +465,8 @@ func (suite *BuilderSuite) TestBuildOn_MaxCollectionSize() {
 }
 
 func (suite *BuilderSuite) TestBuildOn_MaxCollectionByteSize() {
-	// set the max collection byte size to 600 (each tx is about 273 bytes)
-	suite.builder = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, builder.WithMaxCollectionByteSize(600))
+	// set the max collection byte size to 400 (each tx is about 150 bytes)
+	suite.builder = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, builder.WithMaxCollectionByteSize(400))
 
 	// build a block
 	header, err := suite.builder.BuildOn(suite.genesis.ID(), noopSetter)

--- a/module/mock/job_consumer.go
+++ b/module/mock/job_consumer.go
@@ -18,17 +18,12 @@ func (_m *JobConsumer) Check() {
 }
 
 // NotifyJobIsDone provides a mock function with given fields: _a0
-func (_m *JobConsumer) NotifyJobIsDone(_a0 module.JobID) {
-	_m.Called(_a0)
-}
-
-// ProcessedIndex provides a mock function with given fields:
-func (_m *JobConsumer) ProcessedIndex() uint64 {
-	ret := _m.Called()
+func (_m *JobConsumer) NotifyJobIsDone(_a0 module.JobID) uint64 {
+	ret := _m.Called(_a0)
 
 	var r0 uint64
-	if rf, ok := ret.Get(0).(func() uint64); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(module.JobID) uint64); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1011,7 +1011,7 @@ func TransactionBodyFixture(opts ...func(*flow.TransactionBody)) flow.Transactio
 		ProposalKey:        ProposalKeyFixture(),
 		Payer:              AddressFixture(),
 		Authorizers:        []flow.Address{AddressFixture()},
-		PayloadSignatures:  []flow.TransactionSignature{TransactionSignatureFixture()},
+		PayloadSignatures:  []flow.TransactionSignature{},
 		EnvelopeSignatures: []flow.TransactionSignature{TransactionSignatureFixture()},
 	}
 

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1011,7 +1011,6 @@ func TransactionBodyFixture(opts ...func(*flow.TransactionBody)) flow.Transactio
 		ProposalKey:        ProposalKeyFixture(),
 		Payer:              AddressFixture(),
 		Authorizers:        []flow.Address{AddressFixture()},
-		PayloadSignatures:  []flow.TransactionSignature{},
 		EnvelopeSignatures: []flow.TransactionSignature{TransactionSignatureFixture()},
 	}
 


### PR DESCRIPTION
this backports #884

It rejects duplicated signatures both on access/collection level and FVM level
