### PR TITLE
Update .gitignore to support `go mod vendor` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ read-badger
 read-protocol-state
 remove-execution-fork
 bootstrap
+
+# Dependency directories
+vendor/


### PR DESCRIPTION
Vendoring is the act of making your own copy of the 3rd party packages your project is using. Those copies are traditionally placed inside each project and then saved in the project repository.

See https://blog.gopheracademy.com/advent-2015/vendor-folder/

