### PR TITLE
Add log hooks to catch warnings from DKGProcessor in integration tests

### DIFF
--- a/integration/dkg/dkg_whiteboard_test.go
+++ b/integration/dkg/dkg_whiteboard_test.go
@@ -121,6 +121,13 @@ func createNode(
 	)
 	require.NoError(t, err)
 
+	var hook zerolog.HookFunc = func(e *zerolog.Event, level zerolog.Level, message string) {
+		if level == zerolog.WarnLevel {
+			t.Fatal(message)
+		}
+	}
+	controllerFactoryLogger := core.Log.Hook(hook)
+
 	// the reactor engine reacts to new views being finalized and drives the
 	// DKG protocol
 	reactorEngine := dkgeng.NewReactorEngine(
@@ -129,7 +136,7 @@ func createNode(
 		core.State,
 		dkgKeys,
 		dkg.NewControllerFactory(
-			core.Log,
+			controllerFactoryLogger,
 			core.Me,
 			NewWhiteboardClient(id.NodeID, whiteboard),
 			brokerTunnel,

--- a/integration/dkg/dkg_whiteboard_test.go
+++ b/integration/dkg/dkg_whiteboard_test.go
@@ -72,7 +72,7 @@ func createNode(
 	firstBlock flow.Identifier) *node {
 
 	core := testutil.GenericNodeFromParticipants(t, hub, id, ids, chainID)
-	core.Log = zerolog.New(os.Stdout).Level(zerolog.ErrorLevel)
+	core.Log = zerolog.New(os.Stdout).Level(zerolog.WarnLevel)
 
 	// the viewsObserver is used by the reactor engine to subscribe to when
 	// blocks are finalized that are in a new view
@@ -121,12 +121,14 @@ func createNode(
 	)
 	require.NoError(t, err)
 
-	var hook zerolog.HookFunc = func(e *zerolog.Event, level zerolog.Level, message string) {
+	// We add a hook to the logger such that the test fails if the broker writes
+	// a Warn log, which happens when it flags or disqualifies a node
+	hook := zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, message string) {
 		if level == zerolog.WarnLevel {
-			t.Fatal(message)
+			t.Fatal("DKG flagging misbehaviour")
 		}
-	}
-	controllerFactoryLogger := core.Log.Hook(hook)
+	})
+	controllerFactoryLogger := zerolog.New(os.Stdout).Hook(hook)
 
 	// the reactor engine reacts to new views being finalized and drives the
 	// DKG protocol

--- a/module/dkg/broker.go
+++ b/module/dkg/broker.go
@@ -39,6 +39,7 @@ type Broker struct {
 	broadcastMsgCh    chan messages.DKGMessage // channel to forward incoming broadcast messages to consumers
 	messageOffset     uint                     // offset for next broadcast messages to fetch
 	shutdownCh        chan struct{}            // channel to stop the broker from listening
+	broadcasts        uint                     // broadcasts counts the number of succesful broadcasts
 }
 
 // NewBroker instantiates a new epoch-specific broker capable of communicating
@@ -95,6 +96,11 @@ func (b *Broker) PrivateSend(dest int, data []byte) {
 
 // Broadcast signs and broadcasts a message to all participants.
 func (b *Broker) Broadcast(data []byte) {
+	if b.broadcasts > 0 {
+		// The Warn log is used by the integration tests to check if this method
+		// is called more than once within one epoch.
+		b.log.Warn().Msgf("DKG broadcast number %d", b.broadcasts+1)
+	}
 	bcastMsg, err := b.prepareBroadcastMessage(data)
 	if err != nil {
 		b.log.Fatal().Err(err).Msg("failed to create broadcast message")
@@ -111,15 +117,20 @@ func (b *Broker) Broadcast(data []byte) {
 		return
 	}
 	b.log.Debug().Msg("dkg message broadcast")
+	b.broadcasts++
 }
 
 // Disqualify flags that a node is misbehaving and got disqualified
 func (b *Broker) Disqualify(node int, log string) {
+	// The Warn log is used by the integration tests to check if this method is
+	// called.
 	b.log.Warn().Msgf("participant %d is disqualifying participant %d because: %s", b.myIndex, node, log)
 }
 
 // FlagMisbehavior warns that a node is misbehaving.
 func (b *Broker) FlagMisbehavior(node int, log string) {
+	// The Warn log is used by the integration tests to check if this method is
+	// called.
 	b.log.Warn().Msgf("participant %d is flagging participant %d because: %s", b.myIndex, node, log)
 }
 

--- a/module/dkg/broker.go
+++ b/module/dkg/broker.go
@@ -39,7 +39,7 @@ type Broker struct {
 	broadcastMsgCh    chan messages.DKGMessage // channel to forward incoming broadcast messages to consumers
 	messageOffset     uint                     // offset for next broadcast messages to fetch
 	shutdownCh        chan struct{}            // channel to stop the broker from listening
-	broadcasts        uint                     // broadcasts counts the number of succesful broadcasts
+	broadcasts        uint                     // broadcasts counts the number of successful broadcasts
 }
 
 // NewBroker instantiates a new epoch-specific broker capable of communicating


### PR DESCRIPTION
This PR addresses issue [5607](https://github.com/dapperlabs/flow-go/issues/5607) with log hooks