### PR TITLE
[CI / build] Activate race-detection for those modules that are passing it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,10 @@ install-tools: crypto/relic/build check-go-version
 
 .PHONY: unittest
 unittest:
+	# test some packages with Relic library and data race detection enabled
+	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(JSON_OUTPUT),-json,) -race --tags relic ./access/... ./consensus/... ./model/... ./state/... ./storage/... ./utils/...
 	# test all packages with Relic library enabled
-	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(JSON_OUTPUT),-json,) --tags relic ./...
+	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) -covermode=atomic $(if $(JSON_OUTPUT),-json,) --tags relic ./cmd...  ./engine/... ./fvm/... ./ledger/... ./module/... ./network/...
 	$(MAKE) -C crypto test
 	$(MAKE) -C integration test
 


### PR DESCRIPTION
At present, the unit tests run as part of every CI build, but they do not run with with -race parameter which may be used to detect [data races](https://golang.org/doc/articles/race_detector).

Since data races may lead to instability and crashes, it's beneficial to ensure that we prevent data races from being introduced where possible. This runs unit tests with an explicit list of modules (rather than the recursive catch-all) and turns on `-race` for those that pass the build today, hoping others will join the list in the future.

To determine which modules "pass" with `-race` enabled, I've run `go test -race` in a loop and moved any directories that had a test failing because of a race condition move to the Makefile line (part of the unittest goal) without race detection.

## Will it make the tests slower?

[The cost of race detection varies by program, but for a typical program, memory usage may increase by 5-10x and execution time by 2-20x.](https://golang.org/doc/articles/race_detector#Runtime_Overheads)
But if not in CI, when?
