### PR TITLE
Default values for system smart contract addresses (by chain)

### DIFF
--- a/cmd/bootstrap/cmd/block.go
+++ b/cmd/bootstrap/cmd/block.go
@@ -26,8 +26,12 @@ func parseChainID(chainID string) flow.ChainID {
 		return flow.Mainnet
 	case "test":
 		return flow.Testnet
-	case "emulator":
-		return flow.Emulator
+	case "canary":
+		return flow.Canary
+	case "bench":
+		return flow.Benchnet
+	case "local":
+		return flow.Localnet
 	default:
 		log.Fatal().Str("chain_id", chainID).Msg("invalid chain ID")
 		return ""

--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -79,7 +79,7 @@ func addFinalizeCmdFlags() {
 	_ = finalizeCmd.MarkFlagRequired("partner-stakes")
 
 	// required parameters for generation of root block, root execution result and root block seal
-	finalizeCmd.Flags().StringVar(&flagRootChain, "root-chain", "emulator", "chain ID for the root block (can be \"main\", \"test\" or \"emulator\"")
+	finalizeCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'canary', 'bench', or 'local'")
 	finalizeCmd.Flags().StringVar(&flagRootParent, "root-parent", "0000000000000000000000000000000000000000000000000000000000000000", "ID for the parent of the root block")
 	finalizeCmd.Flags().Uint64Var(&flagRootHeight, "root-height", 0, "height of the root block")
 	finalizeCmd.Flags().StringVar(&flagRootTimestamp, "root-timestamp", time.Now().UTC().Format(time.RFC3339), "timestamp of the root block (RFC3339)")

--- a/cmd/bootstrap/cmd/keygen.go
+++ b/cmd/bootstrap/cmd/keygen.go
@@ -90,7 +90,7 @@ func init() {
 
 	// optional parameters, used for generating machine account files
 	keygenCmd.Flags().BoolVar(&flagDefaultMachineAccount, "machine-account", false, "whether or not to generate a default (same as networking key) machine account key file")
-	keygenCmd.Flags().StringVar(&flagRootChain, "root-chain", "emulator", "chain ID for the root block (can be \"main\", \"test\" or \"emulator\"")
+	keygenCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'canary', 'bench', or 'local'")
 }
 
 // isEmptyDir returns True if the directory contains children

--- a/cmd/bootstrap/cmd/keys.go
+++ b/cmd/bootstrap/cmd/keys.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+	"github.com/onflow/flow-go/model/flow/order"
 
 	"github.com/onflow/flow-go/cmd/bootstrap/run"
 	"github.com/onflow/flow-go/crypto"
@@ -44,7 +45,7 @@ func genNetworkAndStakingKeys() []model.NodeInfo {
 		internalNodes = append(internalNodes, nodeInfo)
 	}
 
-	return internalNodes
+	return model.Sort(internalNodes, order.Canonical)
 }
 
 func assembleNodeInfo(nodeConfig model.NodeConfig, networkKey, stakingKey crypto.PrivateKey) model.NodeInfo {

--- a/cmd/bootstrap/run/key_generation.go
+++ b/cmd/bootstrap/run/key_generation.go
@@ -74,7 +74,7 @@ func WriteMachineAccountFiles(chainID flow.ChainID, nodeInfos []bootstrap.NodeIn
 
 	// ensure the chain ID is for a transient chain, where it is possible to
 	// infer machine account addresses this way
-	if chainID != flow.Emulator && chainID != flow.Localnet && chainID != flow.Benchnet {
+	if !chainID.Transient() {
 		return fmt.Errorf("cannot write default machine account files for non-transient network")
 	}
 

--- a/cmd/bootstrap/run/key_generation.go
+++ b/cmd/bootstrap/run/key_generation.go
@@ -68,7 +68,15 @@ type WriteJSONFileFunc func(relativePath string, value interface{}) error
 // WriteMachineAccountFiles writes machine account key files for a set of nodeInfos.
 // Assumes that machine accounts have been created using the default execution state
 // bootstrapping.
+//
+// Only applicable for transient test networks.
 func WriteMachineAccountFiles(chainID flow.ChainID, nodeInfos []bootstrap.NodeInfo, write WriteJSONFileFunc) error {
+
+	// ensure the chain ID is for a transient chain, where it is possible to
+	// infer machine account addresses this way
+	if chainID != flow.Emulator && chainID != flow.Localnet && chainID != flow.Benchnet {
+		return fmt.Errorf("cannot write default machine account files for non-transient network")
+	}
 
 	// write machine account key files for each node which has a machine account (LN/SN)
 	//

--- a/cmd/bootstrap/run/key_generation_test.go
+++ b/cmd/bootstrap/run/key_generation_test.go
@@ -38,7 +38,7 @@ func TestWriteMachineAccountFiles(t *testing.T) {
 		unittest.PrivateNodeInfosFixture(5, unittest.WithRole(flow.RoleCollection))...,
 	)
 
-	chainID := flow.Testnet
+	chainID := flow.Localnet
 	chain := chainID.Chain()
 
 	nodeIDLookup := make(map[string]flow.Identifier)

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -411,7 +411,7 @@ func main() {
 				return nil, err
 			}
 
-			qcContractAddress, err := systemcontracts.ClusterQC.Address(node.RootChainID)
+			contracts, err := systemcontracts.SystemContractsForChain(node.RootChainID)
 			if err != nil {
 				return nil, err
 			}
@@ -421,7 +421,7 @@ func main() {
 				node.Me.NodeID(),
 				accountInfo.Address,
 				accountInfo.KeyIndex,
-				qcContractAddress.HexWithPrefix(),
+				contracts.ClusterQC.Address.HexWithPrefix(),
 				txSigner,
 			)
 

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -6,13 +6,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/onflow/flow-go/fvm/systemcontracts"
-	"google.golang.org/grpc"
-
 	"github.com/spf13/pflag"
+	"google.golang.org/grpc"
 
 	"github.com/onflow/flow-go-sdk/client"
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+
 	"github.com/onflow/flow-go/cmd"
 	"github.com/onflow/flow-go/consensus"
 	"github.com/onflow/flow-go/consensus/hotstuff/committees"
@@ -28,6 +27,7 @@ import (
 	followereng "github.com/onflow/flow-go/engine/common/follower"
 	"github.com/onflow/flow-go/engine/common/provider"
 	consync "github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/encoding"

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -648,7 +648,7 @@ func main() {
 				return nil, fmt.Errorf("could not initialise sdk client: %w", err)
 			}
 
-			dkgContractAddr, err := systemcontracts.DKG.Address(node.RootChainID)
+			contracts, err := systemcontracts.SystemContractsForChain(node.RootChainID)
 			if err != nil {
 				return nil, fmt.Errorf("unknown dkg contract address: %w", err)
 			}
@@ -656,7 +656,7 @@ func main() {
 				node.Logger,
 				sdkClient,
 				machineAccountSigner,
-				dkgContractAddr.HexWithPrefix(),
+				contracts.DKG.Address.HexWithPrefix(),
 				machineAccountInfo.Address,
 				machineAccountInfo.KeyIndex,
 			)

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 
@@ -647,11 +648,15 @@ func main() {
 				return nil, fmt.Errorf("could not initialise sdk client: %w", err)
 			}
 
+			dkgContractAddr, err := systemcontracts.DKG.Address(node.RootChainID)
+			if err != nil {
+				return nil, fmt.Errorf("unknown dkg contract address: %w", err)
+			}
 			dkgContractClient := dkgmodule.NewClient(
 				node.Logger,
 				sdkClient,
 				machineAccountSigner,
-				node.RootChainID.Chain().ServiceAddress().HexWithPrefix(),
+				dkgContractAddr.HexWithPrefix(),
 				machineAccountInfo.Address,
 				machineAccountInfo.KeyIndex,
 			)

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -9,12 +9,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 
 	"github.com/onflow/flow-go-sdk/client"
 	"github.com/onflow/flow-go-sdk/crypto"
+
 	"github.com/onflow/flow-go/cmd"
 	"github.com/onflow/flow-go/consensus"
 	"github.com/onflow/flow-go/consensus/hotstuff"
@@ -35,6 +35,7 @@ import (
 	"github.com/onflow/flow-go/engine/consensus/matching"
 	"github.com/onflow/flow-go/engine/consensus/provider"
 	"github.com/onflow/flow-go/engine/consensus/sealing"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/dkg"
 	dkgmodel "github.com/onflow/flow-go/model/dkg"

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -203,7 +203,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		serviceEventA := cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress(execCtx.Chain.ServiceAddress().Bytes()),
+					Address: common.BytesToAddress(serviceEvents.EpochSetup.Address.Bytes()),
 				},
 				QualifiedIdentifier: serviceEvents.EpochSetup.QualifiedIdentifier(),
 			},
@@ -211,7 +211,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		serviceEventB := cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress(execCtx.Chain.ServiceAddress().Bytes()),
+					Address: common.BytesToAddress(serviceEvents.EpochCommit.Address.Bytes()),
 				},
 				QualifiedIdentifier: serviceEvents.EpochCommit.QualifiedIdentifier(),
 			},

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +27,7 @@ import (
 	fvmErrors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/metrics"

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
 	fvmErrors "github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/handler"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -197,13 +197,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			},
 		}
 
-		eventWhitelist := handler.GetServiceEventWhitelist()
+		serviceEvents, err := systemcontracts.ServiceEventsForChain(execCtx.Chain.ChainID())
+		require.NoError(t, err)
+
 		serviceEventA := cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
 					Address: common.BytesToAddress(execCtx.Chain.ServiceAddress().Bytes()),
 				},
-				QualifiedIdentifier: eventWhitelist[rand.Intn(len(eventWhitelist))], //lets assume its not empty
+				QualifiedIdentifier: serviceEvents.EpochSetup.QualifiedIdentifier(),
 			},
 		}
 		serviceEventB := cadence.Event{
@@ -211,7 +213,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 				Location: common.AddressLocation{
 					Address: common.BytesToAddress(execCtx.Chain.ServiceAddress().Bytes()),
 				},
-				QualifiedIdentifier: eventWhitelist[rand.Intn(len(eventWhitelist))], //lets assume its not empty
+				QualifiedIdentifier: serviceEvents.EpochCommit.QualifiedIdentifier(),
 			},
 		}
 

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -1184,7 +1184,7 @@ func (e *Engine) generateExecutionResultForBlock(
 	// convert Cadence service event representation to flow-go representation
 	convertedServiceEvents := make([]flow.ServiceEvent, 0, len(serviceEvents))
 	for _, event := range serviceEvents {
-		converted, err := convert.ServiceEvent(block.Header.ChainID.Chain(), event)
+		converted, err := convert.ServiceEvent(block.Header.ChainID, event)
 		if err != nil {
 			return nil, fmt.Errorf("could not convert service event: %w", err)
 		}

--- a/fvm/handler/event.go
+++ b/fvm/handler/event.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 

--- a/fvm/handler/event.go
+++ b/fvm/handler/event.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
+	"fmt"
+
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
-	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/model/flow"
@@ -66,8 +68,14 @@ func (h *EventHandler) EmitEvent(event cadence.Event,
 		Payload:          payload,
 	}
 
-	if h.serviceEventCollectionEnabled && IsServiceEvent(event, h.chain) {
-		h.eventCollection.AppendServiceEvent(flowEvent, payloadSize)
+	if h.serviceEventCollectionEnabled {
+		ok, err := IsServiceEvent(event, h.chain.ChainID())
+		if err != nil {
+			return fmt.Errorf("unable to check service event: %w", err)
+		}
+		if ok {
+			h.eventCollection.AppendServiceEvent(flowEvent, payloadSize)
+		}
 		// we don't return and append the service event into event collection as well.
 	}
 
@@ -137,38 +145,22 @@ func (e *EventCollection) TotalByteSize() uint64 {
 	return e.totalByteSize
 }
 
-// TODO refactor this
-// Keep serviceEventWhitelist module-only to prevent accidental modifications
-var serviceEventWhitelist = map[string]struct{}{
-	"FlowEpoch.EpochSetup":     {},
-	"FlowEpoch.EpochCommitted": {},
-}
+// IsServiceEvent determines whether or not an emitted Cadence event is considered
+// a service event for the given chain.
+func IsServiceEvent(event cadence.Event, chain flow.ChainID) (bool, error) {
 
-var serviceEventWhitelistFlat []string
-
-func init() {
-	for s := range serviceEventWhitelist {
-		serviceEventWhitelistFlat = append(serviceEventWhitelistFlat, s)
-	}
-}
-
-func GetServiceEventWhitelist() []string {
-	return serviceEventWhitelistFlat
-}
-
-func IsServiceEvent(event cadence.Event, chain flow.Chain) bool {
-	serviceAccount := chain.ServiceAddress()
-
-	addressLocation, casted := event.EventType.Location.(common.AddressLocation)
-	if !casted {
-		return false
+	// retrieve the service event information for this chain
+	events, err := systemcontracts.ServiceEventsForChain(chain)
+	if err != nil {
+		return false, fmt.Errorf("unknown system contracts for chain (%s): %w", chain.String(), err)
 	}
 
-	flowAddress := flow.BytesToAddress(addressLocation.Address.Bytes())
-
-	if flowAddress != serviceAccount {
-		return false
+	eventType := flow.EventType(event.EventType.ID())
+	for _, serviceEvent := range events.All() {
+		if serviceEvent.EventType() == eventType {
+			return true, nil
+		}
 	}
-	_, has := serviceEventWhitelist[event.EventType.QualifiedIdentifier]
-	return has
+
+	return false, nil
 }

--- a/fvm/handler/event_test.go
+++ b/fvm/handler/event_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm/handler"
 	"github.com/onflow/flow-go/model/flow"
@@ -13,44 +15,48 @@ import (
 
 func Test_IsServiceEvent(t *testing.T) {
 
-	chain := flow.Mainnet.Chain()
+	chain := flow.Emulator
+	events, err := systemcontracts.ServiceEventsForChain(chain)
+	require.NoError(t, err)
 
 	t.Run("correct", func(t *testing.T) {
-		assert.True(t,
-			handler.IsServiceEvent(cadence.Event{
+		for _, event := range events.All() {
+			isServiceEvent, err := handler.IsServiceEvent(cadence.Event{
 				EventType: &cadence.EventType{
 					Location: common.AddressLocation{
-						Address: common.BytesToAddress(chain.ServiceAddress().Bytes()),
+						Address: common.BytesToAddress(event.Address.Bytes()),
 					},
-					QualifiedIdentifier: "FlowEpoch.EpochSetup",
+					QualifiedIdentifier: event.QualifiedIdentifier(),
 				},
-			}, chain),
-		)
+			}, chain)
+			require.NoError(t, err)
+			assert.True(t, isServiceEvent)
+		}
 	})
 
 	t.Run("wrong chain", func(t *testing.T) {
-		assert.False(t,
-			handler.IsServiceEvent(cadence.Event{
-				EventType: &cadence.EventType{
-					Location: common.AddressLocation{
-						Address: common.BytesToAddress(append([]byte{1, 2, 3}, chain.ServiceAddress().Bytes()...)),
-					},
+		isServiceEvent, err := handler.IsServiceEvent(cadence.Event{
+			EventType: &cadence.EventType{
+				Location: common.AddressLocation{
+					Address: common.BytesToAddress(flow.Testnet.Chain().ServiceAddress().Bytes()),
 				},
-			}, chain),
-		)
+				QualifiedIdentifier: events.EpochCommit.QualifiedIdentifier(),
+			},
+		}, chain)
+		require.NoError(t, err)
+		assert.False(t, isServiceEvent)
 	})
 
 	t.Run("wrong type", func(t *testing.T) {
-		assert.False(t,
-			handler.IsServiceEvent(cadence.Event{
-				EventType: &cadence.EventType{
-					Location: common.AddressLocation{
-						Address: common.BytesToAddress(chain.ServiceAddress().Bytes()),
-					},
-					QualifiedIdentifier: "SomeContract.SomeEvent",
+		isServiceEvent, err := handler.IsServiceEvent(cadence.Event{
+			EventType: &cadence.EventType{
+				Location: common.AddressLocation{
+					Address: common.BytesToAddress(chain.Chain().ServiceAddress().Bytes()),
 				},
-			}, chain),
-		)
+				QualifiedIdentifier: "SomeContract.SomeEvent",
+			},
+		}, chain)
+		require.NoError(t, err)
+		assert.False(t, isServiceEvent)
 	})
-
 }

--- a/fvm/handler/event_test.go
+++ b/fvm/handler/event_test.go
@@ -3,13 +3,14 @@ package handler_test
 import (
 	"testing"
 
-	"github.com/onflow/cadence"
-	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
+
 	"github.com/onflow/flow-go/fvm/handler"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -98,15 +98,21 @@ func ServiceEventsForChain(chainID flow.ChainID) (*ServiceEvents, error) {
 	events := &ServiceEvents{
 		EpochSetup: ServiceEvent{
 			Name:          EventNameEpochSetup,
-			QualifiedType: flow.EventType(fmt.Sprintf(eventEpochSetupFormat, addresses[ContractNameEpoch])),
+			QualifiedType: serviceEventQualifiedType(eventEpochSetupFormat, addresses[ContractNameEpoch]),
 		},
 		EpochCommit: ServiceEvent{
 			Name:          EventNameEpochCommit,
-			QualifiedType: flow.EventType(fmt.Sprintf(eventEpochCommitFormat, addresses[ContractNameEpoch])),
+			QualifiedType: serviceEventQualifiedType(eventEpochCommitFormat, addresses[ContractNameEpoch]),
 		},
 	}
 
 	return events, nil
+}
+
+// serviceEventQualifiedType returns the qualified event type for the
+// given service event format string and address location.
+func serviceEventQualifiedType(format string, addr flow.Address) flow.EventType {
+	return flow.EventType(fmt.Sprintf(format, addr))
 }
 
 // contractAddressesByChainID stores the default system smart contract

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -21,6 +21,17 @@ const (
 	DKG       systemContract = "FlowDKG"
 )
 
+// Address returns the canonical address of this system contract on the given chain.
+func (sc systemContract) Address(chainID flow.ChainID) (flow.Address, error) {
+	return systemContractAddressByChain(chainID, sc)
+}
+
+// String returns the string representation of the contract, which is also
+// the name of the contract.
+func (sc systemContract) String() string {
+	return string(sc)
+}
+
 // systemContractsByChainID stores the default system smart contract
 // addresses for each chain.
 var systemContractsByChainID map[flow.ChainID]map[systemContract]flow.Address
@@ -54,11 +65,6 @@ func init() {
 	systemContractsByChainID[flow.Emulator] = transient
 	systemContractsByChainID[flow.Localnet] = transient
 	systemContractsByChainID[flow.Benchnet] = transient
-}
-
-// Address returns the canonical address of this system contract on the given chain.
-func (sc systemContract) Address(chainID flow.ChainID) (flow.Address, error) {
-	return systemContractAddressByChain(chainID, sc)
 }
 
 func systemContractAddressByChain(chainID flow.ChainID, contract systemContract) (flow.Address, error) {

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -31,10 +31,6 @@ const (
 
 	EventNameEpochSetup  = "EpochSetup"
 	EventNameEpochCommit = "EpochCommitted"
-
-	// Format strings for qualified service event names (including address prefix)
-
-	serviceEventTypeIDFormat = "A.%s.%s.%s"
 )
 
 // SystemContract represents a system contract on a particular chain.
@@ -45,10 +41,9 @@ type SystemContract struct {
 
 // ServiceEvent represents a service event on a particular chain.
 type ServiceEvent struct {
-	Address       flow.Address
-	ContractName  string
-	Name          string
-	QualifiedType flow.EventType
+	Address      flow.Address
+	ContractName string
+	Name         string
 }
 
 // QualifiedIdentifier returns the Cadence qualified identifier of the service
@@ -130,12 +125,6 @@ func ServiceEventsForChain(chainID flow.ChainID) (*ServiceEvents, error) {
 	}
 
 	return events, nil
-}
-
-// serviceEventQualifiedType returns the qualified event type for the
-// given service event format string and address location.
-func serviceEventQualifiedType(format string, addr flow.Address) flow.EventType {
-	return flow.EventType(fmt.Sprintf(format, addr))
 }
 
 // contractAddressesByChainID stores the default system smart contract

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -1,0 +1,76 @@
+// Package systemcontracts stores canonical address locations for all system
+// smart contracts.
+//
+// For transient networks, all system contracts can be deployed to the service
+// account. For long-lived networks, system contracts are spread across several
+// accounts for historical reasons.
+package systemcontracts
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// systemContract represents a system smart contract owned by the service account.
+type systemContract string
+
+const (
+	Epoch     systemContract = "FlowEpoch"
+	ClusterQC systemContract = "FlowEpochClusterQC"
+	DKG       systemContract = "FlowDKG"
+)
+
+// systemContractsByChainID stores the default system smart contract
+// addresses for each chain.
+var systemContractsByChainID map[flow.ChainID]map[systemContract]flow.Address
+
+func init() {
+	systemContractsByChainID = make(map[flow.ChainID]map[systemContract]flow.Address)
+
+	// Main Flow network
+	mainnet := map[systemContract]flow.Address{
+		Epoch:     flow.EmptyAddress,
+		ClusterQC: flow.EmptyAddress,
+		DKG:       flow.EmptyAddress,
+	}
+	systemContractsByChainID[flow.Mainnet] = mainnet
+
+	// Long-lived test networks
+	testnet := map[systemContract]flow.Address{
+		Epoch:     flow.EmptyAddress,
+		ClusterQC: flow.EmptyAddress,
+		DKG:       flow.EmptyAddress,
+	}
+	systemContractsByChainID[flow.Testnet] = testnet
+	systemContractsByChainID[flow.Canary] = testnet
+
+	// Transient test networks
+	transient := map[systemContract]flow.Address{
+		Epoch:     flow.Emulator.Chain().ServiceAddress(),
+		ClusterQC: flow.Emulator.Chain().ServiceAddress(),
+		DKG:       flow.Emulator.Chain().ServiceAddress(),
+	}
+	systemContractsByChainID[flow.Emulator] = transient
+	systemContractsByChainID[flow.Localnet] = transient
+	systemContractsByChainID[flow.Benchnet] = transient
+}
+
+// Address returns the canonical address of this system contract on the given chain.
+func (sc systemContract) Address(chainID flow.ChainID) (flow.Address, error) {
+	return systemContractAddressByChain(chainID, sc)
+}
+
+func systemContractAddressByChain(chainID flow.ChainID, contract systemContract) (flow.Address, error) {
+	addresses, ok := systemContractsByChainID[chainID]
+	if !ok {
+		return flow.EmptyAddress, fmt.Errorf("unknown chain ID (%s)", chainID)
+	}
+
+	address, ok := addresses[contract]
+	if !ok {
+		return flow.EmptyAddress, fmt.Errorf("unknown contract (%s) for chain (%s)", contract, chainID)
+	}
+
+	return address, nil
+}

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -131,24 +131,36 @@ func ServiceEventsForChain(chainID flow.ChainID) (*ServiceEvents, error) {
 // addresses for each chain.
 var contractAddressesByChainID map[flow.ChainID]map[string]flow.Address
 
+// Well-known addresses for system contracts on long-running networks.
+// For now, all system contracts tracked by this package are deployed to the same
+// address (per chain) as the staking contract.
+//
+// Ref: https://docs.onflow.org/core-contracts/staking-contract-reference/
+var (
+	// stakingContractAddressMainnet is the address of the FlowIDTableStaking contract on Mainnet
+	stakingContractAddressMainnet = flow.HexToAddress("8624b52f9ddcd04a")
+	// stakingContractAddressTestnet is the address of the FlowIDTableStaking contract on Testnet and Canary
+	stakingContractAddressTestnet = flow.HexToAddress("9eca2b38b18b5dfe")
+)
+
 func init() {
 	contractAddressesByChainID = make(map[flow.ChainID]map[string]flow.Address)
 
 	// Main Flow network
-	// TODO need these address values
+	// All system contracts are deployed to the account of the staking contract
 	mainnet := map[string]flow.Address{
-		ContractNameEpoch:     flow.EmptyAddress,
-		ContractNameClusterQC: flow.EmptyAddress,
-		ContractNameDKG:       flow.EmptyAddress,
+		ContractNameEpoch:     stakingContractAddressMainnet,
+		ContractNameClusterQC: stakingContractAddressMainnet,
+		ContractNameDKG:       stakingContractAddressMainnet,
 	}
 	contractAddressesByChainID[flow.Mainnet] = mainnet
 
 	// Long-lived test networks
-	// TODO need these address values
+	// All system contracts are deployed to the account of the staking contract
 	testnet := map[string]flow.Address{
-		ContractNameEpoch:     flow.EmptyAddress,
-		ContractNameClusterQC: flow.EmptyAddress,
-		ContractNameDKG:       flow.EmptyAddress,
+		ContractNameEpoch:     stakingContractAddressTestnet,
+		ContractNameClusterQC: stakingContractAddressTestnet,
+		ContractNameDKG:       stakingContractAddressTestnet,
 	}
 	contractAddressesByChainID[flow.Testnet] = testnet
 	contractAddressesByChainID[flow.Canary] = testnet

--- a/fvm/systemcontracts/system_contracts_test.go
+++ b/fvm/systemcontracts/system_contracts_test.go
@@ -10,17 +10,12 @@ import (
 
 // TestSystemContract_Address tests that we can retrieve a canonical address
 // for all accepted chains and contracts.
-func TestSystemContract_Address(t *testing.T) {
+func TestSystemContracts(t *testing.T) {
 	chains := []flow.ChainID{flow.Mainnet, flow.Testnet, flow.Canary, flow.Benchnet, flow.Localnet, flow.Emulator}
-	contracts := []systemContract{Epoch, ClusterQC, DKG}
 
 	for _, chain := range chains {
-		for _, contract := range contracts {
-			expected := systemContractsByChainID[chain][contract]
-			actual, err := contract.Address(chain)
-			require.NoError(t, err)
-			require.Equal(t, expected, actual)
-		}
+		_, err := SystemContractsForChain(chain)
+		require.NoError(t, err)
 	}
 }
 
@@ -28,10 +23,27 @@ func TestSystemContract_Address(t *testing.T) {
 // invalid chain ID.
 func TestSystemContract_InvalidChainID(t *testing.T) {
 	invalidChain := flow.ChainID("invalid-chain")
-	contracts := []systemContract{Epoch, ClusterQC, DKG}
 
-	for _, contract := range contracts {
-		_, err := contract.Address(invalidChain)
-		assert.Error(t, err)
+	_, err := SystemContractsForChain(invalidChain)
+	assert.Error(t, err)
+}
+
+// TestServiceEvents tests that we can retrieve service events for all accepted
+// chains and contracts.
+func TestServiceEvents(t *testing.T) {
+	chains := []flow.ChainID{flow.Mainnet, flow.Testnet, flow.Canary, flow.Benchnet, flow.Localnet, flow.Emulator}
+
+	for _, chain := range chains {
+		_, err := ServiceEventsForChain(chain)
+		require.NoError(t, err)
 	}
+}
+
+// TestServiceEvents_InvalidChainID tests that we get an error if querying by an
+// invalid chain ID.
+func TestServiceEvents_InvalidChainID(t *testing.T) {
+	invalidChain := flow.ChainID("invalid-chain")
+
+	_, err := ServiceEventsForChain(invalidChain)
+	assert.Error(t, err)
 }

--- a/fvm/systemcontracts/system_contracts_test.go
+++ b/fvm/systemcontracts/system_contracts_test.go
@@ -4,9 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
 )
 
 // TestSystemContract_Address tests that we can retrieve a canonical address

--- a/fvm/systemcontracts/system_contracts_test.go
+++ b/fvm/systemcontracts/system_contracts_test.go
@@ -1,0 +1,37 @@
+package systemcontracts
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSystemContract_Address tests that we can retrieve a canonical address
+// for all accepted chains and contracts.
+func TestSystemContract_Address(t *testing.T) {
+	chains := []flow.ChainID{flow.Mainnet, flow.Testnet, flow.Canary, flow.Benchnet, flow.Localnet, flow.Emulator}
+	contracts := []systemContract{Epoch, ClusterQC, DKG}
+
+	for _, chain := range chains {
+		for _, contract := range contracts {
+			expected := systemContractsByChainID[chain][contract]
+			actual, err := contract.Address(chain)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		}
+	}
+}
+
+// TestSystemContract_InvalidChainID tests that we get an error if querying by an
+// invalid chain ID.
+func TestSystemContract_InvalidChainID(t *testing.T) {
+	invalidChain := flow.ChainID("invalid-chain")
+	contracts := []systemContract{Epoch, ClusterQC, DKG}
+
+	for _, contract := range contracts {
+		_, err := contract.Address(invalidChain)
+		assert.Error(t, err)
+	}
+}

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -220,14 +220,14 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
-		require.Contains(t, proc.Logs[0], "Düsseldorf")
+		require.Contains(t, proc.Logs[0], "\"D\\u{fc}sseldorf\"")
 
 		proc = fvm.Transaction(&flow.TransactionBody{Script: code(notFrozenAddress)}, 0)
 		err = vm.Run(context, proc, st.State().View(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
-		require.Contains(t, proc.Logs[0], "Düsseldorf")
+		require.Contains(t, proc.Logs[0], "\"D\\u{fc}sseldorf\"")
 
 		// freeze account
 		err = accounts.SetAccountFrozen(frozenAddress, true)

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/m4ksio/wal v1.0.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/multiformats/go-multiaddr v0.3.1
-	github.com/onflow/cadence v0.18.0
+	github.com/onflow/cadence v0.18.1-0.20210621164449-25b6135332eb
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210602203947-82cffc9c55ed
 	github.com/onflow/flow-emulator v0.20.3

--- a/go.sum
+++ b/go.sum
@@ -875,8 +875,8 @@ github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFc
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0 h1:TFpwYVIs2b/bd6TlYxa3zMZN2S9CByMvW7Uk01KFP9Y=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
-github.com/onflow/cadence v0.18.0 h1:Ntvb4UMAllt57qrfEPbyu+A/ktQhZvNmyoE5i09Gqx8=
-github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/onflow/cadence v0.18.1-0.20210621164449-25b6135332eb h1:4gURv4po+izGQlxaFGmcji5L9Iuir9PmSyzfH6cqnKQ=
+github.com/onflow/cadence v0.18.1-0.20210621164449-25b6135332eb/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a h1:7d+9evYk21NhHivkqeyWXId2ai+YMnDxl05VfKlbkaY=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed h1:bGOwiOZrST70f2SVNRxFK/nUOa9cXweTHlBwsHTxkEs=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.18.0
+	github.com/onflow/cadence v0.18.1-0.20210621164449-25b6135332eb
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210602203947-82cffc9c55ed
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1034,8 +1034,8 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0 h1:TFpwYVIs2b/bd6TlYxa3zMZN2S9CByMvW7Uk01KFP9Y=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
-github.com/onflow/cadence v0.18.0 h1:Ntvb4UMAllt57qrfEPbyu+A/ktQhZvNmyoE5i09Gqx8=
-github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/onflow/cadence v0.18.1-0.20210621164449-25b6135332eb h1:4gURv4po+izGQlxaFGmcji5L9Iuir9PmSyzfH6cqnKQ=
+github.com/onflow/cadence v0.18.1-0.20210621164449-25b6135332eb/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed h1:bGOwiOZrST70f2SVNRxFK/nUOa9cXweTHlBwsHTxkEs=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210602203947-82cffc9c55ed/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.3-0.20210602203947-82cffc9c55ed h1:CrFCZIm65gwmBntfqSzfxjM0vauM3K/uVTy2sv9fq8Y=

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -335,7 +335,6 @@ func prepareCollectionService(container testnet.ContainerConfig, i int, accessAd
 		fmt.Sprintf("--hotstuff-min-timeout=%s", timeout),
 		fmt.Sprintf("--ingress-addr=%s:%d", container.ContainerName, RPCPort),
 		fmt.Sprintf("--access-address=%s", accessAddress),
-		fmt.Sprintf("--qc-contract-address=%s", flow.Testnet.Chain().ServiceAddress().String()),
 	)
 
 	return service

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -590,8 +590,7 @@ func (net *FlowNetwork) WriteRootSnapshot(snapshot *inmem.Snapshot) {
 }
 
 func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string) (*flow.Block, *flow.ExecutionResult, *flow.Seal, []ContainerConfig, error) {
-	// Setup as Testnet
-	chainID := flow.Testnet
+	chainID := flow.Localnet
 	chain := chainID.Chain()
 
 	// number of nodes

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -490,7 +490,6 @@ func (net *FlowNetwork) AddNode(t *testing.T, bootstrapDir string, nodeConf Cont
 			net.AccessPorts[ColNodeAPIPort] = hostPort
 
 			nodeContainer.addFlag("access-address", "access_1:9000")
-			nodeContainer.addFlag("qc-contract-address", flow.Testnet.Chain().ServiceAddress().String())
 
 		case flow.RoleExecution:
 

--- a/integration/tests/common/mvp_test.go
+++ b/integration/tests/common/mvp_test.go
@@ -124,7 +124,6 @@ func buildMVPNetConfig() testnet.NetworkConfig {
 		testnet.WithLogLevel(zerolog.InfoLevel),
 		// TODO replace these with actual values
 		testnet.WithAdditionalFlag("--access-address=null"),
-		testnet.WithAdditionalFlag("--qc-contract-address=null"),
 	}
 
 	consensusConfigs := []func(config *testnet.NodeConfig){

--- a/integration/tests/common/util.go
+++ b/integration/tests/common/util.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 
 	"github.com/onflow/cadence"
+
 	sdk "github.com/onflow/flow-go-sdk"
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
 
@@ -198,5 +199,20 @@ func WithTransactionDSL(txDSL dsl.Transaction) func(tx *sdk.Transaction) {
 func WithReferenceBlock(id sdk.Identifier) func(tx *sdk.Transaction) {
 	return func(tx *sdk.Transaction) {
 		tx.ReferenceBlockID = id
+	}
+}
+
+func WithPayer(payer flow.Address) func(tx *sdk.Transaction) {
+	return func(tx *sdk.Transaction) {
+		tx.Payer = sdk.Address(payer)
+	}
+}
+
+func WithAuthorizers(authorizers ...flow.Address) func(tx *sdk.Transaction) {
+	return func(tx *sdk.Transaction) {
+		tx.Authorizers = make([]sdk.Address, 0, len(authorizers))
+		for _, authorizer := range authorizers {
+			tx.Authorizers = append(tx.Authorizers, sdk.Address(authorizer))
+		}
 	}
 }

--- a/integration/tests/execution/failing_tx_reverted_test.go
+++ b/integration/tests/execution/failing_tx_reverted_test.go
@@ -10,23 +10,20 @@ import (
 	sdk "github.com/onflow/flow-go-sdk"
 
 	"github.com/onflow/flow-go/integration/tests/common"
-	"github.com/onflow/flow-go/model/flow"
 )
 
 func TestExecutionFailingTxReverted(t *testing.T) {
-	suite.Run(t, &FailingTxRevertedSuite{
-		chainID: flow.Testnet,
-	})
+	suite.Run(t, new(FailingTxRevertedSuite))
 }
 
 type FailingTxRevertedSuite struct {
 	Suite
-	chainID flow.ChainID
 }
 
 func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 
 	chain := s.net.Root().Header.ChainID.Chain()
+	serviceAddress := chain.ServiceAddress()
 
 	// wait for first finalized block, called blockA
 	blockA := s.BlockState.WaitForFirstFinalized(s.T())
@@ -48,14 +45,18 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 	tx := common.SDKTransactionFixture(
 		common.WithTransactionDSL(common.CreateCounterPanicTx(chain)),
 		common.WithReferenceBlock(sdk.Identifier(s.net.Root().ID())),
+		common.WithPayer(serviceAddress),
+		common.WithAuthorizers(serviceAddress),
 	)
 	err = s.AccessClient().SendTransaction(context.Background(), &tx)
 	require.NoError(s.T(), err, "could not send tx to create counter that should panic")
 
 	// send transaction that has no sigs and should not execute
 	tx = common.SDKTransactionFixture(
-		common.WithTransactionDSL(common.CreateCounterTx(sdk.Address(chain.ServiceAddress()))),
+		common.WithTransactionDSL(common.CreateCounterTx(sdk.Address(serviceAddress))),
 		common.WithReferenceBlock(sdk.Identifier(s.net.Root().ID())),
+		common.WithPayer(serviceAddress),
+		common.WithAuthorizers(serviceAddress),
 	)
 	tx.PayloadSignatures = nil
 	tx.EnvelopeSignatures = nil

--- a/integration/tests/execution/failing_tx_reverted_test.go
+++ b/integration/tests/execution/failing_tx_reverted_test.go
@@ -22,7 +22,8 @@ type FailingTxRevertedSuite struct {
 
 func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 
-	chain := s.net.Root().Header.ChainID.Chain()
+	chainID := s.net.Root().Header.ChainID
+	chain := chainID.Chain()
 	serviceAddress := chain.ServiceAddress()
 
 	// wait for first finalized block, called blockA
@@ -45,9 +46,9 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 	tx := common.SDKTransactionFixture(
 		common.WithTransactionDSL(common.CreateCounterPanicTx(chain)),
 		common.WithReferenceBlock(sdk.Identifier(s.net.Root().ID())),
-		common.WithPayer(serviceAddress),
-		common.WithAuthorizers(serviceAddress),
+		common.WithChainID(chainID),
 	)
+
 	err = s.AccessClient().SendTransaction(context.Background(), &tx)
 	require.NoError(s.T(), err, "could not send tx to create counter that should panic")
 
@@ -55,8 +56,7 @@ func (s *FailingTxRevertedSuite) TestExecutionFailingTxReverted() {
 	tx = common.SDKTransactionFixture(
 		common.WithTransactionDSL(common.CreateCounterTx(sdk.Address(serviceAddress))),
 		common.WithReferenceBlock(sdk.Identifier(s.net.Root().ID())),
-		common.WithPayer(serviceAddress),
-		common.WithAuthorizers(serviceAddress),
+		common.WithChainID(chainID),
 	)
 	tx.PayloadSignatures = nil
 	tx.EnvelopeSignatures = nil

--- a/model/convert/fixtures.go
+++ b/model/convert/fixtures.go
@@ -18,7 +18,7 @@ func epochSetupFixture(chain flow.ChainID) (flow.Event, *flow.EpochSetup) {
 		panic(err)
 	}
 
-	event := unittest.EventFixture(events.EpochSetup.QualifiedType, 1, 1, unittest.IdentifierFixture())
+	event := unittest.EventFixture(events.EpochSetup.EventType(), 1, 1, unittest.IdentifierFixture())
 	event.Payload = []byte(epochSetupFixtureJSON)
 
 	// randomSource is [0,0,...,1,2,3,4]
@@ -117,7 +117,7 @@ func epochCommitFixture(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
 		panic(err)
 	}
 
-	event := unittest.EventFixture(events.EpochCommit.QualifiedType, 1, 1, unittest.IdentifierFixture())
+	event := unittest.EventFixture(events.EpochCommit.EventType(), 1, 1, unittest.IdentifierFixture())
 	event.Payload = []byte(epochCommitFixtureJSON)
 
 	expected := &flow.EpochCommit{

--- a/model/convert/fixtures.go
+++ b/model/convert/fixtures.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -11,8 +12,13 @@ import (
 
 // epochSetupFixture returns an EpochSetup service event as a Cadence event
 // representation and as a protocol model representation.
-func epochSetupFixture(chain flow.Chain) (flow.Event, *flow.EpochSetup) {
-	event := unittest.EventFixture(flow.EventEpochSetup(chain), 1, 1, unittest.IdentifierFixture())
+func epochSetupFixture(chain flow.ChainID) (flow.Event, *flow.EpochSetup) {
+	events, err := systemcontracts.ServiceEventsForChain(chain)
+	if err != nil {
+		panic(err)
+	}
+
+	event := unittest.EventFixture(events.EpochSetup.QualifiedType, 1, 1, unittest.IdentifierFixture())
 	event.Payload = []byte(epochSetupFixtureJSON)
 
 	// randomSource is [0,0,...,1,2,3,4]
@@ -104,8 +110,14 @@ func epochSetupFixture(chain flow.Chain) (flow.Event, *flow.EpochSetup) {
 
 // epochCommitFixture returns an EpochCommit service event as a Cadence event
 // representation and as a protocol model representation.
-func epochCommitFixture(chain flow.Chain) (flow.Event, *flow.EpochCommit) {
-	event := unittest.EventFixture(flow.EventEpochCommit(chain), 1, 1, unittest.IdentifierFixture())
+func epochCommitFixture(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
+
+	events, err := systemcontracts.ServiceEventsForChain(chain)
+	if err != nil {
+		panic(err)
+	}
+
+	event := unittest.EventFixture(events.EpochCommit.QualifiedType, 1, 1, unittest.IdentifierFixture())
 	event.Payload = []byte(epochCommitFixtureJSON)
 
 	expected := &flow.EpochCommit{

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
@@ -16,13 +17,18 @@ import (
 // ServiceEvent converts a service event encoded as the generic flow.Event
 // type to a flow.ServiceEvent type for use within protocol software and protocol
 // state. This acts as the conversion from the Cadence type to the flow-go type.
-func ServiceEvent(chain flow.Chain, event flow.Event) (*flow.ServiceEvent, error) {
+func ServiceEvent(chainID flow.ChainID, event flow.Event) (*flow.ServiceEvent, error) {
 
-	// depending on type of Epoch event construct Go type
+	events, err := systemcontracts.ServiceEventsForChain(chainID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get service event info: %w", err)
+	}
+
+	// depending on type of service event construct Go type
 	switch event.Type {
-	case flow.EventEpochSetup(chain):
+	case events.EpochSetup.QualifiedType:
 		return convertServiceEventEpochSetup(event)
-	case flow.EventEpochCommit(chain):
+	case events.EpochCommit.QualifiedType:
 		return convertServiceEventEpochCommit(event)
 	default:
 		return nil, fmt.Errorf("invalid event type: %s", event.Type)

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/json"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/signature"

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -26,9 +26,9 @@ func ServiceEvent(chainID flow.ChainID, event flow.Event) (*flow.ServiceEvent, e
 
 	// depending on type of service event construct Go type
 	switch event.Type {
-	case events.EpochSetup.QualifiedType:
+	case events.EpochSetup.EventType():
 		return convertServiceEventEpochSetup(event)
-	case events.EpochCommit.QualifiedType:
+	case events.EpochCommit.EventType():
 		return convertServiceEventEpochCommit(event)
 	default:
 		return nil, fmt.Errorf("invalid event type: %s", event.Type)

--- a/model/convert/service_event_test.go
+++ b/model/convert/service_event_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestEventConversion(t *testing.T) {
 
-	chain := flow.Emulator.Chain()
+	chainID := flow.Emulator
 
 	t.Run("epoch setup", func(t *testing.T) {
 
-		fixture, expected := epochSetupFixture(chain)
+		fixture, expected := epochSetupFixture(chainID)
 
 		// convert Cadence types to Go types
-		event, err := ServiceEvent(chain, fixture)
+		event, err := ServiceEvent(chainID, fixture)
 		require.NoError(t, err)
 		require.NotNil(t, event)
 
@@ -32,10 +32,10 @@ func TestEventConversion(t *testing.T) {
 
 	t.Run("epoch commit", func(t *testing.T) {
 
-		fixture, expected := epochCommitFixture(chain)
+		fixture, expected := epochCommitFixture(chainID)
 
 		// convert Cadence types to Go types
-		event, err := ServiceEvent(chain, fixture)
+		event, err := ServiceEvent(chainID, fixture)
 		require.NoError(t, err)
 		require.NotNil(t, event)
 

--- a/model/flow/address.go
+++ b/model/flow/address.go
@@ -234,10 +234,14 @@ const (
 	maxIndex = (1 << linearCodeK) - 1
 )
 
-// invalid code-words in the [64,45] code
-// these constants are used to generate non-Flow-Mainnet addresses
-const invalidCodeTestnet = uint64(0x6834ba37b3980209)
-const invalidCodeEmulator = uint64(0x1cb159857af02018)
+// The following are invalid code-words in the [64,45] code.
+// These constants are used to generate non-Flow-Mainnet addresses
+
+// invalidCodeTestNetwork is the invalid codeword used for long-lived test networks.
+const invalidCodeTestNetwork = uint64(0x6834ba37b3980209)
+
+// invalidCodeTransientNetwork  is the invalid codeword used for transient test networks.
+const invalidCodeTransientNetwork = uint64(0x1cb159857af02018)
 
 // encodeWord encodes a word into a code word.
 // In Flow, the word is the account index while the code word

--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -13,17 +13,29 @@ import (
 // Chain IDs are used used to prevent replay attacks and to support network-specific address generation.
 type ChainID string
 
-// Mainnet is the chain ID for the mainnet node chain.
-const Mainnet ChainID = "flow-mainnet"
+const (
+	// Mainnet is the chain ID for the mainnet chain.
+	Mainnet ChainID = "flow-mainnet"
 
-// Testnet is the chain ID for the testnet node chain.
-const Testnet ChainID = "flow-testnet"
+	// Long-lived test networks
 
-// Emulator is the chain ID for the emulated node chain.
-const Emulator ChainID = "flow-emulator"
+	// Testnet is the chain ID for the testnet chain.
+	Testnet ChainID = "flow-testnet"
+	// Canary is the chain ID for internal canary chain.
+	Canary ChainID = "flow-canary"
 
-// MonotonicEmulator is the chain ID for the emulated node chain with monotonic address generation.
-const MonotonicEmulator ChainID = "flow-emulator-monotonic"
+	// Transient test networks
+
+	// Benchnet is the chain ID for the transient benchmarking chain.
+	Benchnet ChainID = "flow-benchnet"
+	// Localnet is the chain ID for the local development chain.
+	Localnet ChainID = "flow-localnet"
+	// Emulator is the chain ID for the emulated chain.
+	Emulator ChainID = "flow-emulator"
+
+	// MonotonicEmulator is the chain ID for the emulated node chain with monotonic address generation.
+	MonotonicEmulator ChainID = "flow-emulator-monotonic"
+)
 
 // getChainCodeWord derives the network type used for address generation from the globally
 // configured chain ID.
@@ -31,10 +43,10 @@ func (c ChainID) getChainCodeWord() uint64 {
 	switch c {
 	case Mainnet:
 		return 0
-	case Testnet:
+	case Testnet, Canary:
 		return invalidCodeTestnet
-	case Emulator:
-		return invalidCodeEmulator
+	case Emulator, Localnet, Benchnet:
+		return invalidCodeTransientNetwork
 	default:
 		panic(fmt.Sprintf("chain ID [%s] is invalid or does not support linear code address generation", c))
 	}
@@ -148,6 +160,24 @@ var testnet = &addressedChain{
 	},
 }
 
+var canary = &addressedChain{
+	chainImpl: &linearCodeImpl{
+		chainID: Canary,
+	},
+}
+
+var benchnet = &addressedChain{
+	chainImpl: &linearCodeImpl{
+		chainID: Benchnet,
+	},
+}
+
+var localnet = &addressedChain{
+	chainImpl: &linearCodeImpl{
+		chainID: Localnet,
+	},
+}
+
 var emulator = &addressedChain{
 	chainImpl: &linearCodeImpl{
 		chainID: Emulator,
@@ -165,6 +195,12 @@ func (c ChainID) Chain() Chain {
 		return mainnet
 	case Testnet:
 		return testnet
+	case Canary:
+		return canary
+	case Benchnet:
+		return benchnet
+	case Localnet:
+		return localnet
 	case Emulator:
 		return emulator
 	case MonotonicEmulator:

--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -44,7 +44,7 @@ func (c ChainID) getChainCodeWord() uint64 {
 	case Mainnet:
 		return 0
 	case Testnet, Canary:
-		return invalidCodeTestnet
+		return invalidCodeTestNetwork
 	case Emulator, Localnet, Benchnet:
 		return invalidCodeTransientNetwork
 	default:

--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -37,6 +37,11 @@ const (
 	MonotonicEmulator ChainID = "flow-emulator-monotonic"
 )
 
+// Transient returns whether the chain ID is for a transient network.
+func (c ChainID) Transient() bool {
+	return c == Emulator || c == Localnet || c == Benchnet
+}
+
 // getChainCodeWord derives the network type used for address generation from the globally
 // configured chain ID.
 func (c ChainID) getChainCodeWord() uint64 {

--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -223,6 +223,7 @@ type Chain interface {
 	IsValid(Address) bool
 	IndexFromAddress(address Address) (uint64, error)
 	String() string
+	ChainID() ChainID
 	// required for tests
 	zeroAddress() Address
 	newAddressGeneratorAtIndex(index uint64) AddressGenerator
@@ -262,6 +263,11 @@ func (id *addressedChain) BytesToAddressGenerator(b []byte) AddressGenerator {
 
 	index := uint48(bytes[:])
 	return id.newAddressGeneratorAtIndex(index)
+}
+
+// ChainID returns the chain ID of the chain.
+func (id *addressedChain) ChainID() ChainID {
+	return id.chain()
 }
 
 func (id *addressedChain) String() string {

--- a/model/flow/event.go
+++ b/model/flow/event.go
@@ -14,20 +14,7 @@ import (
 const (
 	EventAccountCreated EventType = "flow.AccountCreated"
 	EventAccountUpdated EventType = "flow.AccountUpdated"
-
-	eventEpochSetupFormat  = "A.%s.FlowEpoch.EpochSetup"
-	eventEpochCommitFormat = "A.%s.FlowEpoch.EpochCommitted"
 )
-
-// TODO update in https://github.com/dapperlabs/flow-go/issues/5588
-func EventEpochSetup(chain Chain) EventType {
-	return EventType(fmt.Sprintf(eventEpochSetupFormat, chain.ServiceAddress().Hex()))
-}
-
-// TODO update in https://github.com/dapperlabs/flow-go/issues/5588
-func EventEpochCommit(chain Chain) EventType {
-	return EventType(fmt.Sprintf(eventEpochCommitFormat, chain.ServiceAddress().Hex()))
-}
 
 type EventType string
 

--- a/storage/badger/events_test.go
+++ b/storage/badger/events_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -58,7 +59,10 @@ func TestEventStoreRetrieve(t *testing.T) {
 		require.Len(t, actual, 1)
 		require.Contains(t, actual, evt3)
 
-		actual, err = store.ByBlockIDEventType(blockID, flow.EventEpochSetup(flow.Emulator.Chain()))
+		events, err := systemcontracts.ServiceEventsForChain(flow.Emulator)
+		require.NoError(t, err)
+
+		actual, err = store.ByBlockIDEventType(blockID, events.EpochSetup.QualifiedType)
 		require.NoError(t, err)
 		require.Len(t, actual, 0)
 

--- a/storage/badger/events_test.go
+++ b/storage/badger/events_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
-	"github.com/onflow/flow-go/utils/unittest"
-
 	badgerstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestEventStoreRetrieve(t *testing.T) {

--- a/storage/badger/events_test.go
+++ b/storage/badger/events_test.go
@@ -62,7 +62,7 @@ func TestEventStoreRetrieve(t *testing.T) {
 		events, err := systemcontracts.ServiceEventsForChain(flow.Emulator)
 		require.NoError(t, err)
 
-		actual, err = store.ByBlockIDEventType(blockID, events.EpochSetup.QualifiedType)
+		actual, err = store.ByBlockIDEventType(blockID, events.EpochSetup.EventType())
 		require.NoError(t, err)
 		require.Len(t, actual, 0)
 


### PR DESCRIPTION
Adds a package containing the locations for system smart contract addresses by chain. 

## Changes
* Adds chain IDs for networks that were re-using chain IDs from other networks
* Adds `systemcontracts` package which holds locations for system smart contract addresses by chain
* Updates QC/DKG clients to use addresses from `systemcontracts`
* Update service event detection to use `systemcontracts` package
