### PR TITLE
Add metric to track Current Epoch Phase and Counter

### DIFF
--- a/module/metrics.go
+++ b/module/metrics.go
@@ -53,6 +53,8 @@ type ComplianceMetrics interface {
 	BlockFinalized(*flow.Block)
 	BlockSealed(*flow.Block)
 	BlockProposalDuration(duration time.Duration)
+	CurrentEpochCounter(counter uint64)
+	CurrentEpochPhase(phase flow.EpochPhase)
 }
 
 type CleanerMetrics interface {

--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -20,11 +20,27 @@ type ComplianceCollector struct {
 	lastBlockFinalizedAt     time.Time
 	finalizedBlocksPerSecond prometheus.Summary
 	committedEpochFinalView  prometheus.Gauge
+	currentEpochCounter      prometheus.Gauge
+	currentEpochPhase        prometheus.Gauge
 }
 
 func NewComplianceCollector() *ComplianceCollector {
 
 	cc := &ComplianceCollector{
+
+		currentEpochCounter: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "consensus_compliance_current_epoch_counter",
+			Namespace: namespaceConsensus,
+			Subsystem: subsystemCompliance,
+			Help:      "the current epoch counter",
+		}),
+
+		currentEpochPhase: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "consensus_compliance_current_epoch_phase",
+			Namespace: namespaceConsensus,
+			Subsystem: subsystemCompliance,
+			Help:      "the current epoch phase",
+		}),
 
 		committedEpochFinalView: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "committed_epoch_final_view",

--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -32,14 +32,14 @@ func NewComplianceCollector() *ComplianceCollector {
 			Name:      "consensus_compliance_current_epoch_counter",
 			Namespace: namespaceConsensus,
 			Subsystem: subsystemCompliance,
-			Help:      "the current epoch counter",
+			Help:      "the current epoch's counter",
 		}),
 
 		currentEpochPhase: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "consensus_compliance_current_epoch_phase",
 			Namespace: namespaceConsensus,
 			Subsystem: subsystemCompliance,
-			Help:      "the current epoch phase",
+			Help:      "the current epoch's phase",
 		}),
 
 		committedEpochFinalView: promauto.NewGauge(prometheus.GaugeOpts{
@@ -155,4 +155,12 @@ func (cc *ComplianceCollector) BlockProposalDuration(duration time.Duration) {
 
 func (cc *ComplianceCollector) CommittedEpochFinalView(view uint64) {
 	cc.committedEpochFinalView.Set(float64(view))
+}
+
+func (cc *ComplianceCollector) CurrentEpochCounter(counter uint64) {
+	cc.currentEpochCounter.Set(float64(counter))
+}
+
+func (cc *ComplianceCollector) CurrentEpochPhase(phase flow.EpochPhase) {
+	cc.currentEpochCounter.Set(float64(phase))
 }

--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -36,7 +36,7 @@ func NewComplianceCollector() *ComplianceCollector {
 		}),
 
 		currentEpochPhase: promauto.NewGauge(prometheus.GaugeOpts{
-			Name:      "consensus_compliance_current_epoch_phase",
+			Name:      "current_epoch_phase",
 			Namespace: namespaceConsensus,
 			Subsystem: subsystemCompliance,
 			Help:      "the current epoch's phase",

--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -29,7 +29,7 @@ func NewComplianceCollector() *ComplianceCollector {
 	cc := &ComplianceCollector{
 
 		currentEpochCounter: promauto.NewGauge(prometheus.GaugeOpts{
-			Name:      "consensus_compliance_current_epoch_counter",
+			Name:      "current_epoch_counter",
 			Namespace: namespaceConsensus,
 			Subsystem: subsystemCompliance,
 			Help:      "the current epoch's counter",

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -45,6 +45,8 @@ func (nc *NoopCollector) BlockFinalized(*flow.Block)                            
 func (nc *NoopCollector) BlockSealed(*flow.Block)                                                {}
 func (nc *NoopCollector) BlockProposalDuration(duration time.Duration)                           {}
 func (nc *NoopCollector) CommittedEpochFinalView(view uint64)                                    {}
+func (nc *NoopCollector) CurrentEpochCounter(counter uint64)                                     {}
+func (nc *NoopCollector) CurrentEpochPhase(phase flow.EpochPhase)                                {}
 func (nc *NoopCollector) CacheEntries(resource string, entries uint)                             {}
 func (nc *NoopCollector) CacheHit(resource string)                                               {}
 func (nc *NoopCollector) CacheNotFound(resource string)                                          {}

--- a/module/mock/compliance_metrics.go
+++ b/module/mock/compliance_metrics.go
@@ -34,6 +34,16 @@ func (_m *ComplianceMetrics) CommittedEpochFinalView(view uint64) {
 	_m.Called(view)
 }
 
+// CurrentEpochCounter provides a mock function with given fields: counter
+func (_m *ComplianceMetrics) CurrentEpochCounter(counter uint64) {
+	_m.Called(counter)
+}
+
+// CurrentEpochPhase provides a mock function with given fields: phase
+func (_m *ComplianceMetrics) CurrentEpochPhase(phase flow.EpochPhase) {
+	_m.Called(phase)
+}
+
 // FinalizedHeight provides a mock function with given fields: height
 func (_m *ComplianceMetrics) FinalizedHeight(height uint64) {
 	_m.Called(height)

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -519,9 +519,13 @@ func (m *FollowerState) Finalize(blockID flow.Identifier) error {
 		for _, event := range result.ServiceEvents {
 			switch ev := event.Event.(type) {
 			case *flow.EpochSetup:
+				// update current epoch phase
+				events = append(events, func() { m.metrics.CurrentEpochPhase(flow.EpochPhaseSetup) })
 				// track epoch phase transition (staking->setup)
 				events = append(events, func() { m.consumer.EpochSetupPhaseStarted(ev.Counter-1, header) })
 			case *flow.EpochCommit:
+				// update current epoch phase
+				events = append(events, func() { m.metrics.CurrentEpochPhase(flow.EpochPhaseCommitted) })
 				// track epoch phase transition (setup->committed)
 				events = append(events, func() { m.consumer.EpochCommittedPhaseStarted(ev.Counter-1, header) })
 				// track final view of committed epoch
@@ -546,6 +550,9 @@ func (m *FollowerState) Finalize(blockID flow.Identifier) error {
 	// this block begins the next epoch
 	if header.View > finalView {
 		events = append(events, func() { m.consumer.EpochTransition(currentEpochSetup.Counter, header) })
+
+		// set current epoch counter
+		events = append(events, func() { m.metrics.CurrentEpochCounter(currentEpochSetup.Counter) })
 	}
 
 	// FINALLY: any block that is finalized is already a valid extension;

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -564,7 +564,6 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.Error(t, err)
 
 		// finalize block 3 so we can finalize subsequent blocks
-		// ensure an epoch phase transition when we finalize block 3
 		err = state.Finalize(block3.ID())
 		require.NoError(t, err)
 

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -399,7 +399,7 @@ func OpenState(
 	// update all epoch related metrics
 	err = state.updateEpochMetrics(finalSnapshot)
 	if err != nil {
-		return nil, fmt.Errorf("failed to update current epoch phase: %w", err)
+		return nil, fmt.Errorf("failed to update epoch metrics: %w", err)
 	}
 
 	return state, nil


### PR DESCRIPTION
Resolves https://github.com/dapperlabs/flow-go/issues/5587.

- Adds and sets `consensus_compliance_current_epoch_counter` metric on opening the state, bootstrapping the state and on an epoch boundary
- Adds and sets `consensus_compliance_current_epoch_phase` metric on opening the state, bootstrapping the state and also on phase transitions
- Adds tests for metric calls