### PR TITLE
suggestions for PR 910

### DIFF
--- a/module/synchronization/core.go
+++ b/module/synchronization/core.go
@@ -96,9 +96,6 @@ func (c *Core) HandleBlock(header *flow.Header) bool {
 // If the height difference between local and the reported height, we do nothing.
 // Otherwise, we queue each missing height.
 func (c *Core) HandleHeight(final *flow.Header, height uint64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	// don't bother queueing anything if we're within tolerance
 	if c.WithinTolerance(final, height) {
 		return
@@ -106,6 +103,8 @@ func (c *Core) HandleHeight(final *flow.Header, height uint64) {
 
 	// if we are sufficiently behind, we want to sync the missing blocks
 	if height > final.Height {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 		for h := final.Height + 1; h <= height; h++ {
 			c.queueByHeight(h)
 		}

--- a/storage/badger/blocks.go
+++ b/storage/badger/blocks.go
@@ -77,12 +77,14 @@ func (b *Blocks) ByID(blockID flow.Identifier) (*flow.Block, error) {
 
 // ByHeight ...
 func (b *Blocks) ByHeight(height uint64) (*flow.Block, error) {
-	var blockID flow.Identifier
-	err := b.db.View(operation.LookupBlockHeight(height, &blockID))
+	tx := b.db.NewTransaction(false)
+	defer tx.Discard()
+
+	blockID, err := b.headers.retrieveIdByHeightTx(height)(tx)
 	if err != nil {
-		return nil, fmt.Errorf("could not look up block: %w", err)
+		return nil, err
 	}
-	return b.ByID(blockID)
+	return b.retrieveTx(blockID)(tx)
 }
 
 // ByCollectionID ...


### PR DESCRIPTION
#### Implements suggestions for PR https://github.com/onflow/flow-go/pull/910:

* It would be great to fix this performance bottleneck: https://github.com/onflow/flow-go/blob/5fd2ff27a74127c0cd23fdfaa96d69fb7a9716c6/engine/common/synchronization/engine.go#L489
   - In contrast to `badger.Headers`, which has a cache for heights, `badger.blocks` does not have such a cache and instead _always_ hits the data base. 
* I think we could inline method https://github.com/onflow/flow-go/blob/5fd2ff27a74127c0cd23fdfaa96d69fb7a9716c6/engine/common/synchronization/engine.go#L581-L596 as it is only used once. 
* We might be able to reduce lock congestion in [`Core. HandleHeight `](https://github.com/onflow/flow-go/blob/5fd2ff27a74127c0cd23fdfaa96d69fb7a9716c6/module/synchronization/core.go#L98):
   * we always lock right away, but on the happy path when the node is up to date, this code would return right away: https://github.com/onflow/flow-go/blob/5fd2ff27a74127c0cd23fdfaa96d69fb7a9716c6/module/synchronization/core.go#L102-L105. `WithinTolerance` is fully concurrency safe without any locks (we also call it externally, [here](https://github.com/onflow/flow-go/blob/5fd2ff27a74127c0cd23fdfaa96d69fb7a9716c6/engine/common/synchronization/engine.go#L448)). Hence, we could move the lock further down into the `if` statement, where we actually update `Core`'s state. 
