### PR TITLE
Fix cadence auto update CI not running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches: 
       - master
-      - auto-cadence-upgrade/*
+      - 'auto-cadence-upgrade/*'
   pull_request:
     branches:
       - master
-      - auto-cadence-upgrade/*
+      - 'auto-cadence-upgrade/*'
 
 jobs:
   golangci:


### PR DESCRIPTION
... when `auto-cadence-upgrade/` is the base branch.

If it does it will make it easier to tell which cadence updates are ready to merge.