### PR TITLE
Update v0.19 to Cadence v0.18.0-patch.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,4 +72,4 @@ replace mellium.im/sasl => github.com/mellium/sasl v0.2.1
 
 replace github.com/onflow/flow-go/crypto => ./crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.5
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.6

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.5 h1:ky4rzqliDTYZ1IHONNMyWOt0PbBkQn3ecqKbzttgVQ4=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.5/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.6 h1:6kUSMy94ApeP3LH1lUlzhIJseDgS1JFA+SMbwnfsi08=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.6/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -28,4 +28,4 @@ replace github.com/onflow/flow-go => ../
 
 replace github.com/onflow/flow-go/crypto => ../crypto
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.5
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.18.0-patch.6

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -181,8 +181,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.5 h1:ky4rzqliDTYZ1IHONNMyWOt0PbBkQn3ecqKbzttgVQ4=
-github.com/dapperlabs/cadence-internal v0.18.0-patch.5/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.6 h1:6kUSMy94ApeP3LH1lUlzhIJseDgS1JFA+SMbwnfsi08=
+github.com/dapperlabs/cadence-internal v0.18.0-patch.6/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90 h1:RYSKhK13V8pZq+AqjWnH1vrENL/ZMyWqj2W2rGPDmYo=
 github.com/dapperlabs/testingdock v0.4.3-0.20200626075145-ea23fc16bb90/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Diff: https://github.com/dapperlabs/cadence-internal/compare/v0.18.0-patch.5..v0.18.0-patch.6