### PR TITLE
Update minimal go version to 1.13.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/flow-go
 
-go 1.13
+go 1.13.15
 
 require (
 	cloud.google.com/go/storage v1.10.0


### PR DESCRIPTION
Thisn includes the backported mitigation for CVE-2020-16845