### PR TITLE
Run CI in parallel on go 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       run: make ci
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
+      if: ${{ matrix.go-version == '1.15' }}
       with:
         file: ./coverage.txt
         flags: unittests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,18 @@ jobs:
         ignore: 'relic'
   unit-test:
     name: Unit Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - 1.15
+          - 1.16
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: ${{ matrix.go-version }}
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Run tests
@@ -50,12 +56,18 @@ jobs:
         name: codecov-umbrella
   integration-test:
     name: Integration Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - 1.15
+          - 1.16
     runs-on: ubuntu-latest
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: ${{ matrix.go-version}}
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Build relic


### PR DESCRIPTION
9ae7a18c949d2eb7507459b3ecb8e72b7fb42f2c introduced changes to dependencies and mocks. 

This PR ~~adjusts~~ adjusted for them as they make some of our makefile targets fail on go 1.16
This PR's first 2 commits ~~is~~ was exactly the result of checking out master and running `make ci` on go 1.16.

the last commit runs CI in parallel on go 1.16 