### PR TITLE
Clean up DefaultServerTLSConfig & an unnecessary md5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2.3.0
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.29
+        version: v1.41
         args: -v --build-tags relic
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,12 @@ linters-settings:
     # To select a subset of rules to run.
     # Available rules: https://github.com/securego/gosec#available-rules
     includes:
+      - G401
       - G402
+      - G501
+      - G502
+      - G503
+      - G505
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,13 @@ linters-settings:
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/onflow/flow-go
 
+  gosec:
+    # To select a subset of rules to run.
+    # Available rules: https://github.com/securego/gosec#available-rules
+    includes:
+      - G402
+
 linters:
   enable:
     - goimports
+    - gosec

--- a/cmd/bootstrap/transit/cmd/crypto_test.go
+++ b/cmd/bootstrap/transit/cmd/crypto_test.go
@@ -59,7 +59,7 @@ func TestEndToEnd(t *testing.T) {
 	}
 }
 
-func TestMd5(t *testing.T) {
+func TestSha256(t *testing.T) {
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "prefix-")
 	assert.NoError(t, err)
 	defer os.Remove(tmpFile.Name())
@@ -70,7 +70,7 @@ func TestMd5(t *testing.T) {
 
 	assert.NoError(t, tmpFile.Close())
 
-	md5, err := getFileMD5(tmpFile.Name())
+	hash, err := getFileSHA256(tmpFile.Name())
 	assert.NoError(t, err)
-	assert.Equal(t, "1b8e86521e7e04d647faa9e6192a65f5", md5)
+	assert.Equal(t, "876a3eab5fe740cb864a3d62869b0eefd6fbc34ec331c3064a6ffac0f9485a88", hash)
 }

--- a/cmd/bootstrap/transit/cmd/pull.go
+++ b/cmd/bootstrap/transit/cmd/pull.go
@@ -114,11 +114,11 @@ func pull(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// calculate MD5 of rootsnapshot
+	// calculate SHA256 of rootsnapshot
 	rootFile := filepath.Join(flagBootDir, model.PathRootProtocolStateSnapshot)
-	rootMD5, err := getFileMD5(rootFile)
+	rootSHA256, err := getFileSHA256(rootFile)
 	if err != nil {
-		log.Fatal().Err(err).Str("file", rootFile).Msg("failed to calculate md5")
+		log.Fatal().Err(err).Str("file", rootFile).Msg("failed to calculate SHA256 of root file")
 	}
-	log.Info().Str("md5", rootMD5).Msg("calculated MD5 of protocol snapshot")
+	log.Info().Str("sha256", rootSHA256).Msg("calculated SHA256 of protocol snapshot")
 }

--- a/cmd/bootstrap/transit/cmd/utils.go
+++ b/cmd/bootstrap/transit/cmd/utils.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"crypto/md5"
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -73,18 +73,17 @@ func getFilesToUpload(role flow.Role) []string {
 	}
 }
 
-func getFileMD5(file string) (string, error) {
+func getFileSHA256(file string) (string, error) {
 	f, err := os.Open(file)
 	if err != nil {
 		return "", err
 	}
 	defer f.Close()
 
-	h := md5.New()
+	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}
-
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 

--- a/engine/execution/state/delta/delta.go
+++ b/engine/execution/state/delta/delta.go
@@ -89,7 +89,7 @@ func (d Delta) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func (d Delta) UnmarshalJSON(data []byte) error {
+func (d *Delta) UnmarshalJSON(data []byte) error {
 
 	var m flow.RegisterEntries
 

--- a/utils/grpc/grpc.go
+++ b/utils/grpc/grpc.go
@@ -82,9 +82,11 @@ func IsServerAuthError(err error) bool {
 // The TLSConfig verifies that the server certifcate is valid and has the correct signature
 func DefaultClientTLSConfig(publicKey crypto.PublicKey) (*tls.Config, error) {
 
+	// #nosec G402
 	config := &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true, // This is not insecure here. We will verify the cert chain ourselves.
+		MinVersion: tls.VersionTLS13,
+		// This is not insecure here. We will verify the cert chain ourselves.
+		InsecureSkipVerify: true,
 		ClientAuth:         tls.RequireAnyClientCert,
 	}
 


### PR DESCRIPTION
This impacts the check of the `rootsnapshot` file: CLI users would have to run the `sha256sum` command-line utility on it instead of `md5sum`