### PR TITLE
Fix cadence auto update CI not running 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - 'auto-cadence-upgrade/*'
+      - 'auto-cadence-upgrade/**'
   pull_request:
     branches:
       - master
-      - 'auto-cadence-upgrade/*'
+      - 'auto-cadence-upgrade/**'
 
 jobs:
   golangci:


### PR DESCRIPTION
There was one more mistake after https://github.com/onflow/flow-go/pull/941: the pattern matching does not account for `/` which it should.

see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet:

> `*`: Matches zero or more characters, but does not match the `/` character. For example, `Octo*` matches `Octocat`
> `**`: Matches zero or more of any character.