### PR TITLE
Update the min go version to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/flow-go
 
-go 1.13
+go 1.15
 
 require (
 	cloud.google.com/go/storage v1.10.0


### PR DESCRIPTION
1. We run CI on go 1.15, 1.16
2. Security updates are pushed for the last two released go versions, as per [the security policy](https://golang.org/security), so 1.13 and 1.14 are no longer supported,
3. Our compilation on a go 1.13 fails with the following messages: https://gist.github.com/huitseeker/760c98621531ff226bb4afdb8ef8ec22
4. Cadence already [requires 1.15](https://github.com/onflow/cadence/blob/cd7a7a4830000172119e34c2005aebac21415828/go.mod#L3)