### PR TITLE
require construction seal with at least 1 approval by default

### DIFF
--- a/engine/consensus/sealing/core.go
+++ b/engine/consensus/sealing/core.go
@@ -28,7 +28,9 @@ import (
 
 // DefaultRequiredApprovalsForSealConstruction is the default number of approvals required to construct a candidate seal
 // for subsequent inclusion in block.
-const DefaultRequiredApprovalsForSealConstruction = 0
+// when set to 1, it requires at least 1 approval to build a seal
+// when set to 0, it can build seal without any approval
+const DefaultRequiredApprovalsForSealConstruction = 1
 
 // DefaultEmergencySealingActive is a flag which indicates when emergency sealing is active, this is a temporary measure
 // to make fire fighting easier while seal & verification is under development.

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -17,8 +17,7 @@ import (
 
 // DefaultChunkAssignmentAlpha is the default number of verifiers that should be
 // assigned to each chunk.
-// DISCLAIMER: the current value is not necessarily suitable for production
-const DefaultChunkAssignmentAlpha = 20
+const DefaultChunkAssignmentAlpha = 3
 
 // ChunkAssigner implements an instance of the Public Chunk Assignment
 // algorithm for assigning chunks to verifier nodes in a deterministic but


### PR DESCRIPTION
Since we are in the second phase, we can update the default to be `1`, and keep the option to set as `0` using flag