### PR TITLE
Retry unit-tests & integration-tests twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Run tests
-      run: make ci
+      uses: nick-invision/retry@v2
+      with:
+        timeout_minutes: 15
+        max_attempts: 2
+        command: make ci
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
       if: ${{ matrix.go-version == '1.15' }}
@@ -76,4 +80,8 @@ jobs:
     - name: Docker build
       run: make docker-build-flow
     - name: Run tests
-      run: make ci-integration
+      uses: nick-invision/retry@v2
+      with:
+        timeout_minutes: 15
+        max_attempts: 2
+        command: make ci-integration


### PR DESCRIPTION
- #988 introduced parallel testing on 1.15 / 1.16
- hence #988 multiplies the chance of failing under flaky tests by 2
- this should bring the probability back to where it was

### Isn't this bad?

Yes it is. But we're trying to merge fixes to flakiness (#987) and hotfixes (#1001 ), and the process of [requiring the branch to be up to date before merging](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) means a branch can only merge if it's:
- right on top of the latest master,
- which is a target that moves on each merge,
- and passing CI.

This PR attempts to reduce churn and manual work and widen the firing window on the way to master 🚀 