### PR TITLE
proposal for handling networking errors in `synchronization.Engine`

### DIFF
--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -435,7 +435,7 @@ func (e *Engine) processAvailableRequests() error {
 		if ok {
 			err := e.onSyncRequest(msg.OriginID, msg.Payload.(*messages.SyncRequest))
 			if err != nil {
-				return fmt.Errorf("could not process sync request")
+				return fmt.Errorf("could not process sync request: %w", err)
 			}
 			continue
 		}
@@ -444,7 +444,7 @@ func (e *Engine) processAvailableRequests() error {
 		if ok {
 			err := e.onRangeRequest(msg.OriginID, msg.Payload.(*messages.RangeRequest))
 			if err != nil {
-				return fmt.Errorf("could not process range request")
+				return fmt.Errorf("could not process range request: %w", err)
 			}
 			continue
 		}
@@ -453,7 +453,7 @@ func (e *Engine) processAvailableRequests() error {
 		if ok {
 			err := e.onBatchRequest(msg.OriginID, msg.Payload.(*messages.BatchRequest))
 			if err != nil {
-				return fmt.Errorf("could not process batch request")
+				return fmt.Errorf("could not process batch request: %w", err)
 			}
 			continue
 		}

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -539,7 +539,7 @@ func (e *Engine) onRangeRequest(originID flow.Identifier, req *messages.RangeReq
 	}
 	err := e.con.Unicast(res, originID)
 	if err != nil {
-		e.log.Warn().Err(err).Msg("sending range response failed")
+		e.log.Warn().Err(err).Hex("origin_id", originID).Msg("sending range response failed")
 		return nil
 	}
 	e.metrics.MessageSent(metrics.EngineSynchronization, metrics.MessageBlockResponse)

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -587,7 +587,7 @@ func (e *Engine) onBatchRequest(originID flow.Identifier, req *messages.BatchReq
 	}
 	err := e.con.Unicast(res, originID)
 	if err != nil {
-		e.log.Warn().Err(err).Msg("sending batch response failed")
+		e.log.Warn().Err(err).Hex("origin_id", originID).Msg("sending batch response failed")
 		return nil
 	}
 	e.metrics.MessageSent(metrics.EngineSynchronization, metrics.MessageBlockResponse)

--- a/engine/consensus/ingestion/engine.go
+++ b/engine/consensus/ingestion/engine.go
@@ -94,7 +94,8 @@ func (e *Engine) SubmitLocal(event interface{}) {
 	e.unit.Launch(func() {
 		err := e.process(e.me.NodeID(), event)
 		if err != nil {
-			engine.LogError(e.log, err)
+			// receiving an input of incompatible type from a trusted internal component is fatal
+			e.log.Fatal().Err(err).Msg("internal error processing event")
 		}
 	})
 }
@@ -105,7 +106,15 @@ func (e *Engine) SubmitLocal(event interface{}) {
 func (e *Engine) Submit(channel network.Channel, originID flow.Identifier, event interface{}) {
 	e.unit.Launch(func() {
 		err := e.process(originID, event)
-		engine.LogError(e.log, err)
+		lg := e.log.With().
+			Err(err).
+			Str("channel", channel.String()).
+			Str("origin", originID.String()).
+			Logger()
+		if errors.Is(err, engine.IncompatibleInputTypeError) {
+			lg.Error().Msg("received message with incompatible type")
+		}
+		lg.Fatal().Msg("internal error processing message")
 	})
 }
 
@@ -131,9 +140,25 @@ func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 	switch ev := event.(type) {
 	case *flow.CollectionGuarantee:
 		e.metrics.MessageReceived(metrics.EngineConsensusIngestion, metrics.MessageCollectionGuarantee)
-		return e.onGuarantee(originID, ev)
+		err := e.onGuarantee(originID, ev)
+		if err != nil {
+			if engine.IsInvalidInputError(err) {
+				e.log.Error().Str("origin", originID.String()).Err(err).Msg("received invalid collection guarantee")
+				return nil
+			}
+			if engine.IsOutdatedInputError(err) {
+				e.log.Warn().Str("origin", originID.String()).Err(err).Msg("received outdated collection guarantee")
+				return nil
+			}
+			if engine.IsUnverifiableInputError(err) {
+				e.log.Warn().Str("origin", originID.String()).Err(err).Msg("received unverifiable collection guarantee")
+				return nil
+			}
+			return err
+		}
+		return nil
 	default:
-		return fmt.Errorf("invalid event type (%T)", event)
+		return fmt.Errorf("input with incompatible type %T: %w", event, engine.IncompatibleInputTypeError)
 	}
 }
 
@@ -141,7 +166,7 @@ func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 // from nodes that are not consensus nodes (notably collection nodes).
 // Returns expected errors:
 // * InvalidInputError
-// * UnverifiableInput
+// * UnverifiableInputError
 // * OutdatedInputError
 func (e *Engine) onGuarantee(originID flow.Identifier, guarantee *flow.CollectionGuarantee) error {
 

--- a/engine/consensus/sealing/engine.go
+++ b/engine/consensus/sealing/engine.go
@@ -1,6 +1,7 @@
 package sealing
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/rs/zerolog"
@@ -361,9 +362,10 @@ func (e *Engine) onApproval(originID flow.Identifier, approval *flow.ResultAppro
 
 // SubmitLocal submits an event originating on the local node.
 func (e *Engine) SubmitLocal(event interface{}) {
-	err := e.ProcessLocal(event)
+	err := e.messageHandler.Process(e.me.NodeID(), event)
 	if err != nil {
-		engine.LogError(e.log, err)
+		// receiving an input of incompatible type from a trusted internal component is fatal
+		e.log.Fatal().Err(err).Msg("internal error processing event")
 	}
 }
 
@@ -371,9 +373,17 @@ func (e *Engine) SubmitLocal(event interface{}) {
 // for processing in a non-blocking manner. It returns instantly and logs
 // a potential processing error internally when done.
 func (e *Engine) Submit(channel network.Channel, originID flow.Identifier, event interface{}) {
-	err := e.Process(channel, originID, event)
+	err := e.messageHandler.Process(e.me.NodeID(), event)
 	if err != nil {
-		engine.LogError(e.log, err)
+		lg := e.log.With().
+			Err(err).
+			Str("channel", channel.String()).
+			Str("origin", originID.String()).
+			Logger()
+		if errors.Is(err, engine.IncompatibleInputTypeError) {
+			lg.Error().Msg("received message with incompatible type")
+		}
+		lg.Fatal().Msg("internal error processing message")
 	}
 }
 

--- a/engine/enqueue.go
+++ b/engine/enqueue.go
@@ -50,7 +50,12 @@ func NewMessageHandler(log zerolog.Logger, notifier Notifier, patterns ...Patter
 	}
 }
 
-func (e *MessageHandler) Process(originID flow.Identifier, payload interface{}) (err error) {
+// Process iterates over the internal processing patterns and determines if the payload matches.
+// The _first_ matching pattern processes the payload.
+// Returns
+//  * IncompatibleInputTypeError if no matching processor was found
+//  * All other errors are potential symptoms of internal state corruption or bugs (fatal).
+func (e *MessageHandler) Process(originID flow.Identifier, payload interface{}) error {
 
 	msg := &Message{
 		OriginID: originID,
@@ -68,23 +73,23 @@ func (e *MessageHandler) Process(originID flow.Identifier, payload interface{}) 
 			if pattern.Map != nil {
 				msg, keep = pattern.Map(msg)
 				if !keep {
-					return
+					return nil
 				}
 			}
 
 			ok := pattern.Store.Put(msg)
 			if !ok {
 				log.Msg("failed to store message - discarding")
-				return
+				return nil
 			}
 			e.notifier.Notify()
 
 			// message can only be matched by one pattern, and processed by one handler
-			return
+			return nil
 		}
 	}
 
-	return fmt.Errorf("no matching processor pattern for message, type: %T, origin: %x", payload, originID[:])
+	return fmt.Errorf("no matching processor for message of type %T from origin %x: %w", payload, originID[:], IncompatibleInputTypeError)
 }
 
 func (e *MessageHandler) GetNotifier() <-chan struct{} {

--- a/engine/enqueue_test.go
+++ b/engine/enqueue_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -349,5 +350,18 @@ func TestProcessMessageMultiConcurrent(t *testing.T) {
 			return eng.MessageCount() == count
 		}, 2*time.Second, 10*time.Millisecond, "expect %v messages, but go %v messages",
 			count, eng.MessageCount())
+	})
+}
+
+// TestUnknownMessageType verifies that the message handler returns an
+// IncompatibleInputTypeError when receiving a message of unknown type
+func TestUnknownMessageType(t *testing.T) {
+	WithEngine(t, func(eng *TestEngine) {
+		id := unittest.IdentifierFixture()
+		unknownType := struct{ n int }{n: 10}
+
+		err := eng.Process(id, unknownType)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, engine.IncompatibleInputTypeError))
 	})
 }

--- a/engine/errors.go
+++ b/engine/errors.go
@@ -7,6 +7,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
+var (
+	// IncompatibleInputTypeError indicates that the input has an incompatible type
+	IncompatibleInputTypeError = errors.New("incompatible input type")
+)
+
 // InvalidInputError are errors for caused by invalid inputs.
 // It's useful to distinguish these known errors from exceptions.
 // By distinguishing errors from exceptions, we can log them


### PR DESCRIPTION
This PR is a suggestion for amending PR https://github.com/onflow/flow-go/pull/1001

At the moment, the `synchronization.Engine` bubbles up any networking errors from failed sends. Hence, they eventually crash the engine: https://github.com/onflow/flow-go/blob/538637074415a3ec41c76f78f395d4bec7583ca6/engine/common/synchronization/engine.go#L349-L352

#### Approach

[Best practise for the Flow protocol implementation](https://www.notion.so/dapperlabs/Technical-Product-Meeting-with-Dete-054824f0be334392806e1e39641afe48#43f0a2f00be541b48ba880c0855e078c) is to consistently distinguish between 
* expected errors as part of normal protocol → log error 
* unexpected errors in protocol logic (bug; potential security exploit) → crash node

Current situation:
  * The `synchronization.Engine` has recently been refactored and implements a clean separation between expected and unexpected errors. 
  * We expect networking errors as part of normal operations, e.g. if a node is unreachable. To the best of my understanding, the networking layer does not expose any sentinel errors at the moment, which we could check for. 
  * If we mix in networking error, which don't have a specific type, we loose the ability to distinguish expected errors within the `synchronization.Engine`. 

Hence, I think it might be most pragmatic to log all errors from the networking layer directly where they occur (as opposed to propagating networking errors inside the `synchronization.Engine`)

#### Scope of this PR

* `synchronization.Engine` handles networking errors right where they occur 
* added new sentinel error `engine.IncompatibleInputTypeError`, which engines can raise, if they receive an input that does _not_ have any of the expected types (previously, engines just errored with an unspecific error)
   * this allows us to reject inputs from the networking layer with incompatible types
   * In contrast, an engine should generally not receive an incompatible input from a _trusted_ internal component within the node. This would likely be an implementation bug and should crash the node
* I updated the consensus node's `synchronization.Engine`, `ingestion.Engine`, and `sealing.Engine` to follow this reasoning.  
* `MessageHandler` now also raises the `engine.IncompatibleInputTypeError` if it receives an input of incompatible type 