### PR TITLE
add exported wrapper funcs for random seed util

### DIFF
--- a/cmd/bootstrap/cmd/util.go
+++ b/cmd/bootstrap/cmd/util.go
@@ -14,12 +14,22 @@ import (
 	"github.com/onflow/flow-go/utils/io"
 )
 
+// GenerateRandomSeeds exported wrapper around func to generate seed values used for key generation.
+func GenerateRandomSeeds(n int) [][]byte  {
+	return generateRandomSeeds(n)
+}
+
 func generateRandomSeeds(n int) [][]byte {
 	seeds := make([][]byte, 0, n)
 	for i := 0; i < n; i++ {
 		seeds = append(seeds, generateRandomSeed())
 	}
 	return seeds
+}
+
+// GenerateRandomSeed exported wrapper around func to generate seed value used for key generation.
+func GenerateRandomSeed() []byte  {
+	return generateRandomSeed()
 }
 
 func generateRandomSeed() []byte {

--- a/cmd/bootstrap/cmd/util.go
+++ b/cmd/bootstrap/cmd/util.go
@@ -15,7 +15,7 @@ import (
 )
 
 // GenerateRandomSeeds exported wrapper around func to generate seed values used for key generation.
-func GenerateRandomSeeds(n int) [][]byte  {
+func GenerateRandomSeeds(n int) [][]byte {
 	return generateRandomSeeds(n)
 }
 
@@ -28,7 +28,7 @@ func generateRandomSeeds(n int) [][]byte {
 }
 
 // GenerateRandomSeed exported wrapper around func to generate seed value used for key generation.
-func GenerateRandomSeed() []byte  {
+func GenerateRandomSeed() []byte {
 	return generateRandomSeed()
 }
 


### PR DESCRIPTION
Adds exported funcs that wrap seed generation util funcs. This is needed to use key generation util funcs in other projects. 