### PR TITLE
fixing race conditions in middleware_test unit test

### DIFF
--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -289,7 +289,6 @@ func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
 
 	// expect one message to be received by the target
 	ch := make(chan struct{})
-	fmt.Println(time.Now().String())
 	m.ov[targetIndex].On("Receive", sourceNode, msg).Return(nil).Once().
 		Run(func(args mockery.Arguments) {
 			close(ch)
@@ -301,7 +300,7 @@ func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
 	require.NoError(m.Suite.T(), err)
 
 	// check message reception on target
-	unittest.RequireCloseBefore(m.T(), ch, 30*time.Second, "source node failed to send large message to target")
+	unittest.RequireCloseBefore(m.T(), ch, 15*time.Second, "source node failed to send large message to target")
 
 	m.ov[targetIndex].AssertExpectations(m.T())
 }

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -158,7 +158,6 @@ func (m *MiddlewareTestSuite) Ping(expectID, expectPayload interface{}) {
 func (m *MiddlewareTestSuite) MultiPing(count int) {
 	wg := sync.WaitGroup{}
 	// extracts sender id based on the mock option
-	var err error
 	// mocks Overlay.Receive for  middleware.Overlay.Receive(*nodeID, payload)
 	firstNode := 0
 	lastNode := m.size - 1
@@ -171,7 +170,7 @@ func (m *MiddlewareTestSuite) MultiPing(count int) {
 			})
 		go func() {
 			// sends a direct message from first node to the last node
-			err = m.mws[firstNode].SendDirect(msg, m.ids[lastNode].NodeID)
+			err := m.mws[firstNode].SendDirect(msg, m.ids[lastNode].NodeID)
 			require.NoError(m.Suite.T(), err)
 		}()
 	}
@@ -208,7 +207,7 @@ func (m *MiddlewareTestSuite) TestEcho() {
 		Run(func(args mockery.Arguments) {
 			wg.Done()
 			// echos back the same message back to the sender
-			err = m.mws[last].SendDirect(replyMsg, firstNode)
+			err := m.mws[last].SendDirect(replyMsg, firstNode)
 			assert.NoError(m.T(), err)
 
 		})
@@ -290,6 +289,7 @@ func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
 
 	// expect one message to be received by the target
 	ch := make(chan struct{})
+	fmt.Println(time.Now().String())
 	m.ov[targetIndex].On("Receive", sourceNode, msg).Return(nil).Once().
 		Run(func(args mockery.Arguments) {
 			close(ch)
@@ -301,7 +301,7 @@ func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
 	require.NoError(m.Suite.T(), err)
 
 	// check message reception on target
-	unittest.RequireCloseBefore(m.T(), ch, 3*time.Second, "source node failed to send large message to target")
+	unittest.RequireCloseBefore(m.T(), ch, 30*time.Second, "source node failed to send large message to target")
 
 	m.ov[targetIndex].AssertExpectations(m.T())
 }


### PR DESCRIPTION
### On master

> cd network
> go test -v   -race -timeout 60s -run TestMiddlewareTestSuit  ./...

Output:

> github.com/onflow/flow-go/network       [no test files]
> ?       github.com/onflow/flow-go/network/codec/json    [no test files]
> ?       github.com/onflow/flow-go/network/message       [no test files]
> ?       github.com/onflow/flow-go/network/mocknetwork   [no test files]
> testing: warning: no tests to run
> PASS
> ok      github.com/onflow/flow-go/network/p2p   (cached) [no tests to run]
> testing: warning: no tests to run
> PASS
> ok      github.com/onflow/flow-go/network/queue (cached) [no tests to run]
> ?       github.com/onflow/flow-go/network/stub  [no test files]
> === RUN   TestMiddlewareTestSuit
> === RUN   TestMiddlewareTestSuit/**TestEcho**
> 
> WARNING: DATA RACE
> Write at 0x00c000122d90 by goroutine 126:
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).TestEcho.func1()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:211 +0x188
>   github.com/stretchr/testify/mock.(*Mock).MethodCalled()
>       /Users/vishalchangrani/go/pkg/mod/github.com/stretchr/testify@v1.7.0/mock/mock.go:452 +0xa69
>   github.com/stretchr/testify/mock.(*Mock).Called()
>       /Users/vishalchangrani/go/pkg/mod/github.com/stretchr/testify@v1.7.0/mock/mock.go:383 +0x1ed
>   github.com/onflow/flow-go/network/mocknetwork.(*Overlay).Receive()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/mocknetwork/overlay.go:42 +0x154
>   github.com/onflow/flow-go/network/p2p.(*Middleware).processMessage()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/p2p/middleware.go:400 +0x28d
>   github.com/onflow/flow-go/network/p2p.(*Middleware).processMessage-fm()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/p2p/middleware.go:389 +0x54
>   github.com/onflow/flow-go/network/p2p.(*readConnection).receiveLoop()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/p2p/readConnection.go:104 +0x2af
> 
> Previous write at 0x00c000122d90 by goroutine 27:
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).TestEcho()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:223 +0x1116
>   runtime.call16()
>       /usr/local/go/src/runtime/asm_amd64.s:550 +0x3d
>   reflect.Value.Call()
>       /usr/local/go/src/reflect/value.go:337 +0xd8
>   github.com/stretchr/testify/suite.Run.func1()
>       /Users/vishalchangrani/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:158 +0x391
>   testing.tRunner()
>       /usr/local/go/src/testing/testing.go:1193 +0x202
> 
> Goroutine 126 (running) created at:
>   github.com/onflow/flow-go/network/p2p.(*Middleware).handleIncomingStream()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/p2p/middleware.go:349 +0x484
>   github.com/onflow/flow-go/network/p2p.(*Middleware).handleIncomingStream-fm()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/p2p/middleware.go:337 +0x5e
>   github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1()
>       /Users/vishalchangrani/go/pkg/mod/github.com/libp2p/go-libp2p@v0.14.1/p2p/host/basic/basic_host.go:574 +0xb9
> 
> Goroutine 27 (running) created at:
>   testing.(*T).Run()
>       /usr/local/go/src/testing/testing.go:1238 +0x5d7
>   github.com/stretchr/testify/suite.runTests()
>       /Users/vishalchangrani/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:203 +0xf7
>   github.com/stretchr/testify/suite.Run()
>       /Users/vishalchangrani/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:176 +0x944
>   github.com/onflow/flow-go/network/test.TestMiddlewareTestSuit()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:40 +0x5e
>   testing.tRunner()
>       /usr/local/go/src/testing/testing.go:1193 +0x202
>     testing.go:1092: race detected during execution of test
> === RUN   TestMiddlewareTestSuit/**TestLargeMessageSize_SendDirect**
>     unittest.go:92: 
>                 Error Trace:    unittest.go:92
>                                                         middleware_test.go:304
>                 Error:          could not close done channel on time: source node failed to send large message to target
>                 Test:           TestMiddlewareTestSuit/TestLargeMessageSize_SendDirect
> === RUN   TestMiddlewareTestSuit/TestMaxMessageSize_Publish
> === RUN   TestMiddlewareTestSuit/TestMaxMessageSize_SendDirect
> === RUN   TestMiddlewareTestSuit/TestMultiPing
> 
> WARNING: DATA RACE
> Write at 0x00c0026087d0 by goroutine 159:
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).MultiPing.func2()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:174 +0x197
> 
> Previous write at 0x00c0026087d0 by goroutine 195:
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).MultiPing.func2()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:174 +0x197
> 
> Goroutine 159 (running) created at:
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).MultiPing()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:172 +0x17c
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).TestMultiPing()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:116 +0x5b
>   runtime.call16()
>       /usr/local/go/src/runtime/asm_amd64.s:550 +0x3d
>   reflect.Value.Call()
>       /usr/local/go/src/reflect/value.go:337 +0xd8
>   github.com/stretchr/testify/suite.Run.func1()
>       /Users/vishalchangrani/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:158 +0x391
>   testing.tRunner()
>       /usr/local/go/src/testing/testing.go:1193 +0x202
> 
> Goroutine 195 (finished) created at:
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).MultiPing()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:172 +0x17c
>   github.com/onflow/flow-go/network/test.(*MiddlewareTestSuite).TestMultiPing()
>       /Users/vishalchangrani/go/src/github.com/onflow/flow-go/network/test/middleware_test.go:116 +0x5b
>   runtime.call16()
>       /usr/local/go/src/runtime/asm_amd64.s:550 +0x3d
>   reflect.Value.Call()
>       /usr/local/go/src/reflect/value.go:337 +0xd8
>   github.com/stretchr/testify/suite.Run.func1()
>       /Users/vishalchangrani/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:158 +0x391
>   testing.tRunner()
>       /usr/local/go/src/testing/testing.go:1193 +0x202
>     middleware_test.go:183: PASS:       Identity()
>     middleware_test.go:183: PASS:       Topology()
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Identity()
>     middleware_test.go:183: PASS:       Topology()
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:183: PASS:       Receive(flow.Identifier,*message.Message)
>     testing.go:1092: race detected during execution of test
> === RUN   TestMiddlewareTestSuit/TestPingContentReception
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(flow.Identifier,*message.Message)
> === RUN   TestMiddlewareTestSuit/TestPingIDType
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(mock.AnythingOfTypeArgument,*message.Message)
> === RUN   TestMiddlewareTestSuit/TestPingRawReception
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(string,string)
> === RUN   TestMiddlewareTestSuit/TestPingTypeReception
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(string,mock.AnythingOfTypeArgument)
> === RUN   TestMiddlewareTestSuit/TestUnsubscribe
> === CONT  TestMiddlewareTestSuit
>     testing.go:1092: race detected during execution of test
> --- FAIL: TestMiddlewareTestSuit (16.47s)
>     --- FAIL: TestMiddlewareTestSuit/TestEcho (0.09s)
>     --- FAIL: TestMiddlewareTestSuit/TestLargeMessageSize_SendDirect (9.60s)
>     --- PASS: TestMiddlewareTestSuit/TestMaxMessageSize_Publish (0.81s)
>     --- PASS: TestMiddlewareTestSuit/TestMaxMessageSize_SendDirect (1.53s)
>     --- FAIL: TestMiddlewareTestSuit/TestMultiPing (0.14s)
>     --- PASS: TestMiddlewareTestSuit/TestPingContentReception (0.06s)
>     --- PASS: TestMiddlewareTestSuit/TestPingIDType (0.06s)
>     --- PASS: TestMiddlewareTestSuit/TestPingRawReception (0.07s)
>     --- PASS: TestMiddlewareTestSuit/TestPingTypeReception (0.07s)
>     --- PASS: TestMiddlewareTestSuit/TestUnsubscribe (4.03s)
> === CONT  
>     testing.go:1092: race detected during execution of test
> FAIL
> FAIL    github.com/onflow/flow-go/network/test  18.684s
> testing: warning: no tests to run
> PASS
> ok      github.com/onflow/flow-go/network/topology      (cached) [no tests to run]
> ?       github.com/onflow/flow-go/network/validator     [no test files]
> FAIL


### With this change

> ?       github.com/onflow/flow-go/network       [no test files]
> ?       github.com/onflow/flow-go/network/codec/json    [no test files]
> ?       github.com/onflow/flow-go/network/message       [no test files]
> ?       github.com/onflow/flow-go/network/mocknetwork   [no test files]
> testing: warning: no tests to run
> PASS
> ok      github.com/onflow/flow-go/network/p2p   (cached) [no tests to run]
> testing: warning: no tests to run
> PASS
> ok      github.com/onflow/flow-go/network/queue (cached) [no tests to run]
> ?       github.com/onflow/flow-go/network/stub  [no test files]
> === RUN   TestMiddlewareTestSuit
> === RUN   TestMiddlewareTestSuit/TestEcho
>     middleware_test.go:229: PASS:       Identity()
>     middleware_test.go:229: PASS:       Topology()
>     middleware_test.go:229: PASS:       Receive(flow.Identifier,*message.Message)
> === RUN   TestMiddlewareTestSuit/TestLargeMessageSize_SendDirect
> 2021-07-22 22:15:27.014532 -0700 PDT m=+3.240576100
>     middleware_test.go:306: PASS:       Identity()
>     middleware_test.go:306: PASS:       Topology()
>     middleware_test.go:306: PASS:       Receive(flow.Identifier,*message.Message)
> === RUN   TestMiddlewareTestSuit/TestMaxMessageSize_Publish
> === RUN   TestMiddlewareTestSuit/TestMaxMessageSize_SendDirect
> === RUN   TestMiddlewareTestSuit/TestMultiPing
>     middleware_test.go:182: PASS:       Identity()
>     middleware_test.go:182: PASS:       Topology()
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Identity()
>     middleware_test.go:182: PASS:       Topology()
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Identity()
>     middleware_test.go:182: PASS:       Topology()
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
>     middleware_test.go:182: PASS:       Receive(flow.Identifier,*message.Message)
> === RUN   TestMiddlewareTestSuit/TestPingContentReception
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(flow.Identifier,*message.Message)
> === RUN   TestMiddlewareTestSuit/TestPingIDType
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(mock.AnythingOfTypeArgument,*message.Message)
> === RUN   TestMiddlewareTestSuit/TestPingRawReception
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(string,string)
> === RUN   TestMiddlewareTestSuit/TestPingTypeReception
>     middleware_test.go:152: PASS:       Identity()
>     middleware_test.go:152: PASS:       Topology()
>     middleware_test.go:152: PASS:       Receive(string,mock.AnythingOfTypeArgument)
> === RUN   TestMiddlewareTestSuit/TestUnsubscribe
> --- PASS: TestMiddlewareTestSuit (25.63s)
>     --- PASS: TestMiddlewareTestSuit/TestEcho (0.08s)
>     --- PASS: TestMiddlewareTestSuit/TestLargeMessageSize_SendDirect (18.79s)
>     --- PASS: TestMiddlewareTestSuit/TestMaxMessageSize_Publish (0.80s)
>     --- PASS: TestMiddlewareTestSuit/TestMaxMessageSize_SendDirect (1.53s)
>     --- PASS: TestMiddlewareTestSuit/TestMultiPing (0.13s)
>     --- PASS: TestMiddlewareTestSuit/TestPingContentReception (0.06s)
>     --- PASS: TestMiddlewareTestSuit/TestPingIDType (0.07s)
>     --- PASS: TestMiddlewareTestSuit/TestPingRawReception (0.07s)
>     --- PASS: TestMiddlewareTestSuit/TestPingTypeReception (0.07s)
>     --- PASS: TestMiddlewareTestSuit/TestUnsubscribe (4.03s)
> PASS
> ok      github.com/onflow/flow-go/network/test  (cached)
> testing: warning: no tests to run
> PASS
> ok      github.com/onflow/flow-go/network/topology      (cached) [no tests to run]
> ?       github.com/onflow/flow-go/network/validator     [no test files]


