### PR TITLE
Update Godoc for ReadyDoneAware

### DIFF
--- a/module/common.go
+++ b/module/common.go
@@ -1,6 +1,6 @@
 package module
 
-// ReadyDoneAware provides easy interface to wait for module startup and shutdown.
+// ReadyDoneAware provides an easy interface to wait for module startup and shutdown.
 // Modules that implement this interface only support a single start-stop cycle, and
 // will not restart if Ready() is called again after shutdown has already commenced.
 type ReadyDoneAware interface {

--- a/module/common.go
+++ b/module/common.go
@@ -8,7 +8,7 @@ type ReadyDoneAware interface {
 	// startup has completed.
 	// If shutdown has already commenced before this method is called for the first time,
 	// startup will not be performed and the returned channel will never close.
-	// This is an idempotent method.
+	// This should be an idempotent method.
 	Ready() <-chan struct{}
 
 	// Done commences shutdown of the module, and returns a done channel that is closed once

--- a/module/common.go
+++ b/module/common.go
@@ -1,7 +1,15 @@
 package module
 
-// ReadyDoneAware provides easy interface to wait for module startup and shutdown
+// ReadyDoneAware provides easy interface to wait for module startup and shutdown.
+// Modules that implement this interface only support a single start-stop cycle,
+// and if Ready() is called again after shutdown has already commenced, the module
+// will not restart.
 type ReadyDoneAware interface {
+	// Ready commences startup of the module, and returns a ready channel that is closed once
+	// startup has completed.
 	Ready() <-chan struct{}
+
+	// Done commences shutdown of the module, and returns a done channel that is closed once
+	// shutdown has completed.
 	Done() <-chan struct{}
 }

--- a/module/common.go
+++ b/module/common.go
@@ -1,14 +1,18 @@
 package module
 
 // ReadyDoneAware provides easy interface to wait for module startup and shutdown.
-// Modules that implement this interface only support a single start-stop cycle,
-// and will not restart if Ready() is called again after shutdown has already commenced.
+// Modules that implement this interface only support a single start-stop cycle, and
+// will not restart if Ready() is called again after shutdown has already commenced.
 type ReadyDoneAware interface {
 	// Ready commences startup of the module, and returns a ready channel that is closed once
-	// startup has completed. This is an idempotent method.
+	// startup has completed.
+	// If shutdown has already commenced before this method is called for the first time,
+	// startup will not be performed and the returned channel will never close.
+	// This is an idempotent method.
 	Ready() <-chan struct{}
 
 	// Done commences shutdown of the module, and returns a done channel that is closed once
-	// shutdown has completed. This is an idempotent method.
+	// shutdown has completed.
+	// This is an idempotent method.
 	Done() <-chan struct{}
 }

--- a/module/common.go
+++ b/module/common.go
@@ -2,14 +2,13 @@ package module
 
 // ReadyDoneAware provides easy interface to wait for module startup and shutdown.
 // Modules that implement this interface only support a single start-stop cycle,
-// and if Ready() is called again after shutdown has already commenced, the module
-// will not restart.
+// and will not restart if Ready() is called again after shutdown has already commenced.
 type ReadyDoneAware interface {
 	// Ready commences startup of the module, and returns a ready channel that is closed once
-	// startup has completed.
+	// startup has completed. This is an idempotent method.
 	Ready() <-chan struct{}
 
 	// Done commences shutdown of the module, and returns a done channel that is closed once
-	// shutdown has completed.
+	// shutdown has completed. This is an idempotent method.
 	Done() <-chan struct{}
 }

--- a/module/common.go
+++ b/module/common.go
@@ -13,6 +13,6 @@ type ReadyDoneAware interface {
 
 	// Done commences shutdown of the module, and returns a done channel that is closed once
 	// shutdown has completed.
-	// This is an idempotent method.
+	// This should be an idempotent method.
 	Done() <-chan struct{}
 }


### PR DESCRIPTION
This PR updates the Godoc for `ReadyDoneAware` to more clearly define the conventions for its implementation. There are many different implementations in the code base which interpret the `Ready` and `Done` methods to mean different things (see https://github.com/dapperlabs/flow-go/issues/5702). 

In particular, the implementations are inconsistent regarding the concurrency-safety and idempotency of these methods. It is also not clear by looking at the interface whether the `Ready` / `Done` methods actually provide the mechanism to start / stop the module, or simply return channels that are closed when the module is started / stopped via some other means (in the latter case, how does one start / stop the module?).

Documenting the interface will hopefully lessen the confusion, and encourage better implementations in the future.