### PR TITLE
[network, easy] Chores & small bugs in middleware / p2p

### DIFF
--- a/network/middleware.go
+++ b/network/middleware.go
@@ -27,15 +27,6 @@ type Middleware interface {
 	// Stop will end the execution of the middleware and wait for it to end.
 	Stop()
 
-	// Send sends the message to the set of target ids
-	// If there is only one target NodeID, then a direct 1-1 connection is used by calling middleware.sendDirect
-	// Otherwise, middleware.Publish is used, which uses the PubSub method of communication.
-	//
-	// Deprecated: Send exists for historical compatibility, and should not be used on new
-	// developments. It is planned to be cleaned up in near future. Proper utilization of Dispatch or
-	// Publish are recommended instead.
-	Send(channel Channel, msg *message.Message, targetIDs ...flow.Identifier) error
-
 	// Dispatch sends msg on a 1-1 direct connection to the target ID. It models a guaranteed delivery asynchronous
 	// direct one-to-one connection on the underlying network. No intermediate node on the overlay is utilized
 	// as the router.

--- a/network/mocknetwork/middleware.go
+++ b/network/mocknetwork/middleware.go
@@ -60,27 +60,6 @@ func (_m *Middleware) Publish(msg *message.Message, channel network.Channel) err
 	return r0
 }
 
-// Send provides a mock function with given fields: channel, msg, targetIDs
-func (_m *Middleware) Send(channel network.Channel, msg *message.Message, targetIDs ...flow.Identifier) error {
-	_va := make([]interface{}, len(targetIDs))
-	for _i := range targetIDs {
-		_va[_i] = targetIDs[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, channel, msg)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(network.Channel, *message.Message, ...flow.Identifier) error); ok {
-		r0 = rf(channel, msg, targetIDs...)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // SendDirect provides a mock function with given fields: msg, targetID
 func (_m *Middleware) SendDirect(msg *message.Message, targetID flow.Identifier) error {
 	ret := _m.Called(msg, targetID)

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -444,6 +444,12 @@ func (n *Node) Ping(ctx context.Context, identity flow.Identity) (message.PingRe
 
 // UpdateAllowList allows the peer allow list to be updated.
 func (n *Node) UpdateAllowList(identities flow.IdentityList) error {
+	// if the node was so far not under allowList
+	if n.connGater == nil {
+		return fmt.Errorf("Could not add an allow list, this node was started without allow listing")
+
+	}
+
 	// generates peer address information for all identities
 	allowlist := make([]peer.AddrInfo, len(identities))
 	var err error

--- a/network/p2p/libp2pNode_test.go
+++ b/network/p2p/libp2pNode_test.go
@@ -574,6 +574,21 @@ func (suite *LibP2PNodeTestSuite) TestConnectionGating() {
 	})
 }
 
+func (suite *LibP2PNodeTestSuite) TestConnectionGatingBootstrap() {
+	// Create a Node with AllowList = false
+	node, identity := suite.NodesFixture(1, nil, false)
+	node1 := node[0]
+	node1Id := identity[0]
+	defer StopNode(suite.T(), node1)
+
+	suite.Run("updating allowlist of node w/o ConnGater does not crash", func() {
+
+		// node1 allowlists node1
+		err := node1.UpdateAllowList(flow.IdentityList{node1Id})
+		require.Error(suite.T(), err)
+	})
+}
+
 // NodesFixture creates a number of LibP2PNodes with the given callback function for stream handling.
 // It returns the nodes and their identities.
 func (suite *LibP2PNodeTestSuite) NodesFixture(count int, handler func(t *testing.T) network.StreamHandler, allowList bool) ([]*Node, flow.IdentityList) {

--- a/network/p2p/middleware.go
+++ b/network/p2p/middleware.go
@@ -191,43 +191,6 @@ func (m *Middleware) Stop() {
 	m.wg.Wait()
 }
 
-// Send sends the message to the set of target ids
-// If there is only one target NodeID, then a direct 1-1 connection is used by calling middleware.SendDirect
-// Otherwise, middleware.Publish is used, which uses the PubSub method of communication.
-//
-// Deprecated: Send exists for historical compatibility, and should not be used on new
-// developments. It is planned to be cleaned up in near future. Proper utilization of Dispatch or
-// Publish are recommended instead.
-func (m *Middleware) Send(channel network.Channel, msg *message.Message, targetIDs ...flow.Identifier) error {
-	var err error
-	mode := m.chooseMode(channel, msg, targetIDs...)
-	// decide what mode of communication to use
-	switch mode {
-	case NoOp:
-		// NOTE: we can't error on this at the moment, because single nodes of
-		// a role in tests will attempt to send messages like this, which should
-		// be a no-op, but not an error
-		m.log.Debug().Msg("send to no-one")
-		return nil
-	case OneToOne:
-		if targetIDs[0] == m.me {
-			// to avoid self dial by the underlay
-			m.log.Debug().Msg("send to self")
-			return nil
-		}
-		err = m.SendDirect(msg, targetIDs[0])
-	case OneToK:
-		err = m.Publish(msg, channel)
-	default:
-		err = fmt.Errorf("invalid communcation mode: %d", mode)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to send message to %s:%w", targetIDs, err)
-	}
-	return nil
-}
-
 // chooseMode determines the communication mode to use. Currently it only considers the length of the targetIDs.
 func (m *Middleware) chooseMode(_ network.Channel, _ *message.Message, targetIDs ...flow.Identifier) communicationMode {
 	switch len(targetIDs) {

--- a/network/p2p/middleware.go
+++ b/network/p2p/middleware.go
@@ -191,18 +191,6 @@ func (m *Middleware) Stop() {
 	m.wg.Wait()
 }
 
-// chooseMode determines the communication mode to use. Currently it only considers the length of the targetIDs.
-func (m *Middleware) chooseMode(_ network.Channel, _ *message.Message, targetIDs ...flow.Identifier) communicationMode {
-	switch len(targetIDs) {
-	case 0:
-		return NoOp
-	case 1:
-		return OneToOne
-	default:
-		return OneToK
-	}
-}
-
 // SendDirect sends msg on a 1-1 direct connection to the target ID. It models a guaranteed delivery asynchronous
 // direct one-to-one connection on the underlying network. No intermediate node on the overlay is utilized
 // as the router.


### PR DESCRIPTION
Forks a couple straightforward fixes discovered while working on libp2p peer discovery:
- removes a long-deprecated middleware method
- the interaction between the `allowList` flag in the libp2pNode constructor and `UpdateAllowList` can create a crasher, this fixes it