### PR TITLE
making scaffold ReadyDoneAware

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -21,6 +21,7 @@ import (
 
 // NodeBuilder declares the initialization methods needed to bootstrap up a Flow node
 type NodeBuilder interface {
+	module.ReadyDoneAware
 
 	// BaseFlags reads the command line arguments common to all nodes
 	BaseFlags()

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/onflow/flow-go/cmd/build"
+	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
@@ -99,6 +100,7 @@ type FlowNodeBuilder struct {
 	components  []namedComponentFunc
 	doneObject  []namedDoneObject
 	sig         chan os.Signal
+	unit        *engine.Unit
 	preInitFns  []func(NodeBuilder, *NodeConfig)
 	postInitFns []func(NodeBuilder, *NodeConfig)
 }
@@ -574,7 +576,7 @@ func (fnb *FlowNodeBuilder) handleComponent(v namedComponentFunc) {
 		log.Fatal().Msg("component startup timed out")
 	case <-fnb.sig:
 		log.Warn().Msg("component startup aborted")
-		os.Exit(1)
+		return
 	}
 
 	fnb.doneObject = append(fnb.doneObject, namedDoneObject{
@@ -593,7 +595,7 @@ func (fnb *FlowNodeBuilder) handleDoneObject(v namedDoneObject) {
 		log.Fatal().Msg("component shutdown timed out")
 	case <-fnb.sig:
 		log.Warn().Msg("component shutdown aborted")
-		os.Exit(1)
+		return
 	}
 }
 
@@ -659,6 +661,7 @@ func FlowNode(role string) *FlowNodeBuilder {
 			Logger: zerolog.New(os.Stderr),
 		},
 		flags: pflag.CommandLine,
+		unit:  engine.NewUnit(),
 	}
 	return builder
 }
@@ -691,60 +694,89 @@ func (fnb *FlowNodeBuilder) Run() {
 	fnb.sig = make(chan os.Signal, 1)
 	signal.Notify(fnb.sig, os.Interrupt, syscall.SIGTERM)
 
-	// seed random generator
-	rand.Seed(time.Now().UnixNano())
-
-	fnb.initNodeInfo()
-
-	fnb.initLogger()
-
-	fnb.initProfiler()
-
-	fnb.initDB()
-
-	fnb.initMetrics()
-
-	fnb.initStorage()
-
-	for _, f := range fnb.preInitFns {
-		fnb.handlePreInit(f)
+	select {
+	case <-fnb.Ready():
+		fnb.Logger.Info().Msgf("%s node startup complete", fnb.BaseConfig.NodeRole)
+	case <-time.After(fnb.BaseConfig.timeout):
+		fnb.Logger.Fatal().Msg("node startup timed out")
+	case <-fnb.sig:
+		fnb.Logger.Warn().Msg("node startup aborted")
+		os.Exit(1)
 	}
 
-	fnb.initState()
-
-	fnb.initFvmOptions()
-
-	for _, f := range fnb.postInitFns {
-		fnb.handlePostInit(f)
-	}
-
-	// set up all modules
-	for _, f := range fnb.modules {
-		fnb.handleModule(f)
-	}
-
-	// initialize all components
-	for _, f := range fnb.components {
-		fnb.handleComponent(f)
-	}
-
-	fnb.Logger.Info().Msgf("%s node startup complete", fnb.BaseConfig.NodeRole)
-
+	// block till a SIGINT is received
 	<-fnb.sig
 
 	fnb.Logger.Info().Msgf("%s node shutting down", fnb.BaseConfig.NodeRole)
 
-	for i := len(fnb.doneObject) - 1; i >= 0; i-- {
-		doneObject := fnb.doneObject[i]
-
-		fnb.handleDoneObject(doneObject)
+	select {
+	case <-fnb.Done():
+		fnb.Logger.Info().Msgf("%s node shutdown complete", fnb.BaseConfig.NodeRole)
+	case <-time.After(fnb.BaseConfig.timeout):
+		fnb.Logger.Fatal().Msg("node shutdown timed out")
+	case <-fnb.sig:
+		fnb.Logger.Warn().Msg("node shutdown aborted")
+		os.Exit(1)
 	}
 
-	fnb.closeDatabase()
-
-	fnb.Logger.Info().Msgf("%s node shutdown complete", fnb.BaseConfig.NodeRole)
-
 	os.Exit(0)
+}
+
+func (fnb *FlowNodeBuilder) Ready() <-chan struct{} {
+
+	return fnb.unit.Ready(func() {
+
+		// seed random generator
+		rand.Seed(time.Now().UnixNano())
+
+		fnb.initNodeInfo()
+
+		fnb.initLogger()
+
+		fnb.initProfiler()
+
+		fnb.initDB()
+
+		fnb.initMetrics()
+
+		fnb.initStorage()
+
+		for _, f := range fnb.preInitFns {
+			fnb.handlePreInit(f)
+		}
+
+		fnb.initState()
+
+		fnb.initFvmOptions()
+
+		for _, f := range fnb.postInitFns {
+			fnb.handlePostInit(f)
+		}
+
+		// set up all modules
+		for _, f := range fnb.modules {
+			fnb.handleModule(f)
+		}
+
+		// initialize all components
+		for _, f := range fnb.components {
+			fnb.handleComponent(f)
+		}
+	})
+}
+
+func (fnb *FlowNodeBuilder) Done() <-chan struct{} {
+
+	return fnb.unit.Ready(func() {
+		for i := len(fnb.doneObject) - 1; i >= 0; i-- {
+			doneObject := fnb.doneObject[i]
+
+			fnb.handleDoneObject(doneObject)
+		}
+
+		fnb.closeDatabase()
+	})
+
 }
 
 func (fnb *FlowNodeBuilder) handlePreInit(f func(builder NodeBuilder, node *NodeConfig)) {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -17,11 +17,11 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/onflow/flow-go/cmd/build"
-	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/lifecycle"
 	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/trace"
@@ -100,9 +100,9 @@ type FlowNodeBuilder struct {
 	components  []namedComponentFunc
 	doneObject  []namedDoneObject
 	sig         chan os.Signal
-	unit        *engine.Unit
 	preInitFns  []func(NodeBuilder, *NodeConfig)
 	postInitFns []func(NodeBuilder, *NodeConfig)
+	lm          *lifecycle.LifecycleManager
 }
 
 func (fnb *FlowNodeBuilder) BaseFlags() {
@@ -112,7 +112,7 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 	fnb.flags.StringVar(&fnb.BaseConfig.nodeIDHex, "nodeid", NotSet, "identity of our node")
 	fnb.flags.StringVar(&fnb.BaseConfig.bindAddr, "bind", NotSet, "address to bind on")
 	fnb.flags.StringVarP(&fnb.BaseConfig.BootstrapDir, "bootstrapdir", "b", "bootstrap", "path to the bootstrap directory")
-	fnb.flags.DurationVarP(&fnb.BaseConfig.timeout, "timeout", "t", 1*time.Minute, "how long to try connecting to the network")
+	fnb.flags.DurationVarP(&fnb.BaseConfig.timeout, "timeout", "t", 1*time.Minute, "node startup / shutdown timeout")
 	fnb.flags.StringVarP(&fnb.BaseConfig.datadir, "datadir", "d", datadir, "directory to store the protocol state")
 	fnb.flags.StringVarP(&fnb.BaseConfig.level, "loglevel", "l", "info", "level for logging output")
 	fnb.flags.DurationVar(&fnb.BaseConfig.peerUpdateInterval, "peerupdate-interval", p2p.DefaultPeerUpdateInterval, "how often to refresh the peer connections for the node")
@@ -572,8 +572,6 @@ func (fnb *FlowNodeBuilder) handleComponent(v namedComponentFunc) {
 	select {
 	case <-readyAware.Ready():
 		log.Info().Msg("component startup complete")
-	case <-time.After(fnb.BaseConfig.timeout):
-		log.Fatal().Msg("component startup timed out")
 	case <-fnb.sig:
 		log.Warn().Msg("component startup aborted")
 		return
@@ -591,8 +589,6 @@ func (fnb *FlowNodeBuilder) handleDoneObject(v namedDoneObject) {
 	select {
 	case <-v.ob.Done():
 		log.Info().Msg("component shutdown complete")
-	case <-time.After(fnb.BaseConfig.timeout):
-		log.Fatal().Msg("component shutdown timed out")
 	case <-fnb.sig:
 		log.Warn().Msg("component shutdown aborted")
 		return
@@ -661,7 +657,7 @@ func FlowNode(role string) *FlowNodeBuilder {
 			Logger: zerolog.New(os.Stderr),
 		},
 		flags: pflag.CommandLine,
-		unit:  engine.NewUnit(),
+		lm:    lifecycle.NewLifecycleManager(),
 	}
 	return builder
 }
@@ -725,9 +721,7 @@ func (fnb *FlowNodeBuilder) Run() {
 // Ready returns a channel that closes after initiating all common components (logger, database, protocol state etc.)
 // and then starting all modules and components.
 func (fnb *FlowNodeBuilder) Ready() <-chan struct{} {
-
-	return fnb.unit.Ready(func() {
-
+	fnb.lm.OnStart(func() {
 		// seed random generator
 		rand.Seed(time.Now().UnixNano())
 
@@ -765,12 +759,12 @@ func (fnb *FlowNodeBuilder) Ready() <-chan struct{} {
 			fnb.handleComponent(f)
 		}
 	})
+	return fnb.lm.Started()
 }
 
 // Done returns a channel that closes after all registered components are stopped
 func (fnb *FlowNodeBuilder) Done() <-chan struct{} {
-
-	return fnb.unit.Ready(func() {
+	fnb.lm.OnStop(func() {
 		for i := len(fnb.doneObject) - 1; i >= 0; i-- {
 			doneObject := fnb.doneObject[i]
 
@@ -779,7 +773,7 @@ func (fnb *FlowNodeBuilder) Done() <-chan struct{} {
 
 		fnb.closeDatabase()
 	})
-
+	return fnb.lm.Stopped()
 }
 
 func (fnb *FlowNodeBuilder) handlePreInit(f func(builder NodeBuilder, node *NodeConfig)) {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -685,9 +685,9 @@ func (fnb *FlowNodeBuilder) Initialize() NodeBuilder {
 	return fnb
 }
 
-// Run initiates all common components (logger, database, protocol state etc.)
-// then starts each component. It also sets up a channel to gracefully shut
-// down each component if a SIGINT is received.
+// Run calls Ready() to start all the node modules and components. It also sets up a channel to gracefully shut
+// down each component if a SIGINT is received. Until a SIGINT is received, Run will block.
+// Since, Run is a blocking call it should only be used when running a node as it's own independent process.
 func (fnb *FlowNodeBuilder) Run() {
 
 	// initialize signal catcher
@@ -722,6 +722,8 @@ func (fnb *FlowNodeBuilder) Run() {
 	os.Exit(0)
 }
 
+// Ready returns a channel that closes after initiating all common components (logger, database, protocol state etc.)
+// and then starting all modules and components.
 func (fnb *FlowNodeBuilder) Ready() <-chan struct{} {
 
 	return fnb.unit.Ready(func() {
@@ -765,6 +767,7 @@ func (fnb *FlowNodeBuilder) Ready() <-chan struct{} {
 	})
 }
 
+// Done returns a channel that closes after all registered components are stopped
 func (fnb *FlowNodeBuilder) Done() <-chan struct{} {
 
 	return fnb.unit.Ready(func() {


### PR DESCRIPTION
First set of change to run the unstaked AN as a library instead of a standalone node -

1. Currently, the `NodeBuilder.Run()` method starts all modules and components and then blocks till a SIGINT is received. However, for the unstaked AN to run as a library, its lifecycle will be managed by the caller (DPS). This PR makes the NodeBuilder `ReadyDoneAware` so that it can be started and stopped on-demand. The `Run()` in turn now calls `Ready` and `Done`.
2. All the calls to `os.Exit` have been restricted to the `Run()` method.