### PR TITLE
Use lifecycle manager instead of engine unit

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -774,16 +774,6 @@ func (fnb *FlowNodeBuilder) Done() <-chan struct{} {
 		fnb.closeDatabase()
 	})
 	return fnb.lm.Stopped()
-	return fnb.unit.Ready(func() {
-		for i := len(fnb.doneObject) - 1; i >= 0; i-- {
-			doneObject := fnb.doneObject[i]
-
-			fnb.handleDoneObject(doneObject)
-		}
-
-		fnb.closeDatabase()
-	})
-
 }
 
 func (fnb *FlowNodeBuilder) handlePreInit(f func(builder NodeBuilder, node *NodeConfig)) {


### PR DESCRIPTION
A couple of points here:
* Since this `Ready` and `Done` will likely be exposed to external callers (DPS), it is even more important than ever that we guarantee idempotency and concurrency-safety. Hence, we should use `LifecycleManager` here.
* `engine.unit` was originally intended for use by engines, so it doesn't really fit for this usecase anyways. `LifecycleManager` is more generally intended for use by `ReadyDoneAware` modules.
* Since we are already checking the timeout in `Run`, we don't have to do so in `handleComponent` and `handleDoneObject`. Note that we don't need to check the timeout in `Ready` or `Done`, since the caller of those methods will receive a channel and they can implement any timeout they want themselves.