### PR TITLE
[ledger] Ledger cleanups + make a test async

### DIFF
--- a/ledger/common/encoding/encoding.go
+++ b/ledger/common/encoding/encoding.go
@@ -272,7 +272,7 @@ func DecodeValue(encodedValue []byte) (ledger.Value, error) {
 }
 
 func decodeValue(inp []byte) (ledger.Value, error) {
-	return ledger.Value(inp), nil
+	return inp, nil
 }
 
 // EncodePath encodes a path into a byte slice

--- a/ledger/common/encoding/encoding.go
+++ b/ledger/common/encoding/encoding.go
@@ -268,11 +268,7 @@ func DecodeValue(encodedValue []byte) (ledger.Value, error) {
 		return nil, err
 	}
 
-	return decodeValue(rest)
-}
-
-func decodeValue(inp []byte) (ledger.Value, error) {
-	return inp, nil
+	return rest, nil
 }
 
 // EncodePath encodes a path into a byte slice
@@ -406,13 +402,7 @@ func decodePayload(inp []byte) (*ledger.Payload, error) {
 		return nil, fmt.Errorf("error decoding payload: %w", err)
 	}
 
-	// decode value
-	value, err := decodeValue(encValue)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding payload: %w", err)
-	}
-
-	return &ledger.Payload{Key: *key, Value: value}, nil
+	return &ledger.Payload{Key: *key, Value: encValue}, nil
 }
 
 // EncodeTrieUpdate encodes a trie update struct

--- a/ledger/common/encoding/encoding_test.go
+++ b/ledger/common/encoding/encoding_test.go
@@ -26,7 +26,7 @@ func Test_KeyPartEncodingDecoding(t *testing.T) {
 	require.Error(t, err)
 
 	// test wrong version decoding
-	encoded[0] = byte(uint8(1))
+	encoded[0] = uint8(1)
 	_, err = encoding.DecodeKeyPart(encoded)
 	require.Error(t, err)
 }
@@ -96,12 +96,12 @@ func Test_TrieUpdateEncodingDecoding(t *testing.T) {
 	kp1 := ledger.NewKeyPart(uint16(1), []byte("key 1 part 1"))
 	kp2 := ledger.NewKeyPart(uint16(22), []byte("key 1 part 2"))
 	k1 := ledger.NewKey([]ledger.KeyPart{kp1, kp2})
-	pl1 := ledger.NewPayload(k1, ledger.Value([]byte{'A'}))
+	pl1 := ledger.NewPayload(k1, []byte{'A'})
 
 	p2 := utils.PathByUint16(2)
 	kp3 := ledger.NewKeyPart(uint16(1), []byte("key2 part 1"))
 	k2 := ledger.NewKey([]ledger.KeyPart{kp3})
-	pl2 := ledger.NewPayload(k2, ledger.Value([]byte{'B'}))
+	pl2 := ledger.NewPayload(k2, []byte{'B'})
 
 	tu := &ledger.TrieUpdate{
 		RootHash: utils.RootHashFixture(),

--- a/ledger/common/hash/hash_test.go
+++ b/ledger/common/hash/hash_test.go
@@ -36,7 +36,7 @@ func TestHash(t *testing.T) {
 			_, _ = hasher.Write(path[:])
 			_, _ = hasher.Write(value)
 			expected := hasher.Sum(nil)
-			assert.Equal(t, []byte(expected), []byte(h[:]))
+			assert.Equal(t, expected, h[:])
 		}
 	})
 
@@ -52,7 +52,7 @@ func TestHash(t *testing.T) {
 			_, _ = hasher.Write(h1[:])
 			_, _ = hasher.Write(h2[:])
 			expected := hasher.Sum(nil)
-			assert.Equal(t, []byte(expected), []byte(h[:]))
+			assert.Equal(t, expected, h[:])
 		}
 	})
 }
@@ -62,7 +62,7 @@ func Test_GetDefaultHashForHeight(t *testing.T) {
 	hasher := cryhash.NewSHA3_256()
 	defaultLeafHash := hasher.ComputeHash([]byte("default:"))
 	expected := ledger.GetDefaultHashForHeight(0)
-	assert.Equal(t, []byte(expected[:]), []byte(defaultLeafHash))
+	assert.Equal(t, expected[:], []byte(defaultLeafHash))
 
 	l1 := hash.HashInterNode(ledger.GetDefaultHashForHeight(0), ledger.GetDefaultHashForHeight(0))
 	assert.Equal(t, l1, ledger.GetDefaultHashForHeight(1))

--- a/ledger/common/utils/testutils.go
+++ b/ledger/common/utils/testutils.go
@@ -131,17 +131,6 @@ func ReadShortData(input []byte) (data []byte, rest []byte, err error) {
 	return
 }
 
-// ReadLongData read data shorter than 32MB and return the rest of bytes
-func ReadLongData(input []byte) (data []byte, rest []byte, err error) {
-	var size uint32
-	size, rest, err = ReadUint32(input)
-	if err != nil {
-		return nil, rest, err
-	}
-	data = rest[:size]
-	return
-}
-
 // ReadShortDataFromReader reads data shorter than 16kB from reader
 func ReadShortDataFromReader(reader io.Reader) ([]byte, error) {
 	buf, err := ReadFromBuffer(reader, 2)
@@ -406,14 +395,4 @@ func RandomUniqueKeys(n, m, minByteSize, maxByteSize int) []l.Key {
 		}
 	}
 	return keys
-}
-
-// RandomUniqueKeysRandomN generate n (0<n<maxN) random keys (each m random key part),
-func RandomUniqueKeysRandomN(maxN, m, minByteSize, maxByteSize int) []l.Key {
-	numberOfKeys := rand.Intn(maxN) + 1
-	// at least return 1 keys
-	if numberOfKeys == 0 {
-		numberOfKeys = 1
-	}
-	return RandomUniqueKeys(numberOfKeys, m, minByteSize, maxByteSize)
 }

--- a/ledger/common/utils/testutils.go
+++ b/ledger/common/utils/testutils.go
@@ -36,7 +36,7 @@ func Uint64ToBinary(integer uint64) []byte {
 
 // AppendUint8 appends the value byte to the input slice
 func AppendUint8(input []byte, value uint8) []byte {
-	return append(input, byte(value))
+	return append(input, value)
 }
 
 // AppendUint16 appends the value bytes to the input slice (big endian)
@@ -93,7 +93,7 @@ func ReadUint8(input []byte) (value uint8, rest []byte, err error) {
 	if len(input) < 1 {
 		return 0, input, fmt.Errorf("input size (%d) is too small to read a uint8", len(input))
 	}
-	return uint8(input[0]), input[1:], nil
+	return input[0], input[1:], nil
 }
 
 // ReadUint16 reads a uint16 from the input and returns the rest
@@ -247,7 +247,7 @@ func PathByUint16LeftPadded(inp uint16) l.Path {
 
 // KeyPartFixture returns a key part fixture
 func KeyPartFixture(typ uint16, val string) l.KeyPart {
-	kp1t := uint16(typ)
+	kp1t := typ
 	kp1v := []byte(val)
 	return l.NewKeyPart(kp1t, kp1v)
 }
@@ -307,7 +307,7 @@ func TrieBatchProofFixture() (*l.TrieBatchProof, l.State) {
 	bp := l.NewTrieBatchProof()
 	bp.Proofs = append(bp.Proofs, p)
 	bp.Proofs = append(bp.Proofs, p)
-	return bp, l.State(s)
+	return bp, s
 }
 
 // RandomPathsRandLen generate m random paths.

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -211,7 +211,7 @@ func (l *Ledger) Prove(query *ledger.Query) (proof ledger.Proof, err error) {
 		l.metrics.ProofSize(uint32(len(proofToGo) / len(paths)))
 	}
 
-	return ledger.Proof(proofToGo), err
+	return proofToGo, err
 }
 
 // MemSize return the amount of memory used by ledger

--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -357,9 +357,9 @@ func TestLedgerFunctionality(t *testing.T) {
 				for s := range histStorage {
 					value := histStorage[s]
 					var state ledger.State
-					copy(state[:], []byte(s[:stateComSize]))
+					copy(state[:], s[:stateComSize])
 					enk := []byte(s[stateComSize:])
-					key, err := encoding.DecodeKey([]byte(enk))
+					key, err := encoding.DecodeKey(enk)
 					assert.NoError(t, err)
 					query, err := ledger.NewQuery(state, []ledger.Key{*key})
 					assert.NoError(t, err)

--- a/ledger/complete/mtrie/forest.go
+++ b/ledger/complete/mtrie/forest.go
@@ -178,7 +178,7 @@ func (f *Forest) Update(u *ledger.TrieUpdate) (ledger.RootHash, error) {
 		return emptyHash, fmt.Errorf("adding updated trie to forest failed: %w", err)
 	}
 
-	return ledger.RootHash(newTrie.RootHash()), nil
+	return newTrie.RootHash(), nil
 }
 
 // Proofs returns a batch proof for the given paths.

--- a/ledger/complete/wal/compactor.go
+++ b/ledger/complete/wal/compactor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/onflow/flow-go/module/lifecycle"
+	"github.com/onflow/flow-go/module/observable"
 )
 
 type Compactor struct {
@@ -14,6 +15,7 @@ type Compactor struct {
 	stopc        chan struct{}
 	lm           *lifecycle.LifecycleManager
 	sync.Mutex
+	observers          map[observable.Observer]struct{}
 	interval           time.Duration
 	checkpointDistance uint
 	checkpointsToKeep  uint
@@ -26,11 +28,21 @@ func NewCompactor(checkpointer *Checkpointer, interval time.Duration, checkpoint
 	return &Compactor{
 		checkpointer:       checkpointer,
 		stopc:              make(chan struct{}),
+		observers:          make(map[observable.Observer]struct{}),
 		lm:                 lifecycle.NewLifecycleManager(),
 		interval:           interval,
 		checkpointDistance: checkpointDistance,
 		checkpointsToKeep:  checkpointsToKeep,
 	}
+}
+
+func (c *Compactor) Subscribe(observer observable.Observer) {
+	var void struct{}
+	c.observers[observer] = void
+}
+
+func (c *Compactor) Unsubscribe(observer observable.Observer) {
+	delete(c.observers, observer)
 }
 
 // Ready periodically fires Run function, every `interval`
@@ -43,6 +55,9 @@ func (c *Compactor) Ready() <-chan struct{} {
 
 func (c *Compactor) Done() <-chan struct{} {
 	c.lm.OnStop(func() {
+		for observer := range c.observers {
+			observer.OnComplete()
+		}
 		c.stopc <- struct{}{}
 	})
 	return c.lm.Stopped()
@@ -65,7 +80,7 @@ func (c *Compactor) Run() error {
 	c.Lock()
 	defer c.Unlock()
 
-	err := c.createCheckpoints()
+	newLatestCheckpoint, err := c.createCheckpoints()
 	if err != nil {
 		return fmt.Errorf("cannot create checkpoints: %w", err)
 	}
@@ -75,17 +90,25 @@ func (c *Compactor) Run() error {
 		return fmt.Errorf("cannot cleanup checkpoints: %w", err)
 	}
 
+	if newLatestCheckpoint > 0 {
+		for observer := range c.observers {
+			observer.OnNext(newLatestCheckpoint)
+		}
+	}
+
 	return nil
 }
 
-func (c *Compactor) createCheckpoints() error {
+func (c *Compactor) createCheckpoints() (int, error) {
 	from, to, err := c.checkpointer.NotCheckpointedSegments()
 	if err != nil {
-		return fmt.Errorf("cannot get latest checkpoint: %w", err)
+		return -1, fmt.Errorf("cannot get latest checkpoint: %w", err)
 	}
 
 	fmt.Printf("creating a checkpoint from segment %d to segment %d\n", from, to)
 
+	// we only return a positive value if the latest checkpoint index has changed
+	newLatestCheckpoint := -1
 	// more then one segment means we can checkpoint safely up to `to`-1
 	// presumably last segment is being written to
 	if to-from > int(c.checkpointDistance) {
@@ -96,10 +119,11 @@ func (c *Compactor) createCheckpoints() error {
 			return c.checkpointer.CheckpointWriter(checkpointNumber)
 		})
 		if err != nil {
-			return fmt.Errorf("error creating checkpoint (%d): %w", checkpointNumber, err)
+			return -1, fmt.Errorf("error creating checkpoint (%d): %w", checkpointNumber, err)
 		}
+		newLatestCheckpoint = checkpointNumber
 	}
-	return nil
+	return newLatestCheckpoint, nil
 }
 
 func (c *Compactor) cleanupCheckpoints() error {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -248,7 +248,7 @@ func (kp *KeyPart) Equals(other *KeyPart) bool {
 // DeepCopy returns a deep copy of the key part
 func (kp *KeyPart) DeepCopy() *KeyPart {
 	newV := make([]byte, 0, len(kp.Value))
-	newV = append(newV, []byte(kp.Value)...)
+	newV = append(newV, kp.Value...)
 	return &KeyPart{Type: kp.Type, Value: newV}
 }
 

--- a/ledger/trie.go
+++ b/ledger/trie.go
@@ -46,14 +46,6 @@ func init() {
 	}
 }
 
-// GetDefaultHashes returns the default hashes of the SMT.
-//
-// For each tree level N, there is a default hash equal to the chained
-// hashing of the default value N times.
-func GetDefaultHashes() [defaultHashesNum]hash.Hash {
-	return defaultHashes
-}
-
 // GetDefaultHashForHeight returns the default hashes of the SMT at a specified height.
 //
 // For each tree level N, there is a default hash equal to the chained

--- a/ledger/trie.go
+++ b/ledger/trie.go
@@ -289,7 +289,7 @@ func (p *TrieProof) String() string {
 	interimIndex := 0
 	for j := 0; j < int(p.Steps); j++ {
 		// if bit is set
-		if p.Flags[j/8]&(1<<int(7-j%8)) != 0 {
+		if p.Flags[j/8]&(1<<(7-j%8)) != 0 {
 			proofStr += fmt.Sprintf("\t\t %d: [%x]\n", j, p.Interims[interimIndex])
 			interimIndex++
 		}

--- a/module/observable/observable.go
+++ b/module/observable/observable.go
@@ -1,0 +1,8 @@
+package observable
+
+type Observable interface {
+	// indicates that the observer is ready to receive notifications from the Observable
+	Subscribe(observer Observer)
+	// indicates that the observer no longer wants to receive notifications from the Observable
+	Unsubscribe(observer Observer)
+}

--- a/module/observable/observer.go
+++ b/module/observable/observer.go
@@ -1,0 +1,10 @@
+package observable
+
+type Observer interface {
+	// conveys an item that is emitted by the Observable to the observer
+	OnNext(interface{})
+	// indicates that the Observable has terminated with a specified error condition and that it will be emitting no further items
+	OnError(err error)
+	// indicates that the Observable has completed successfully and that it will be emitting no further items
+	OnComplete()
+}


### PR DESCRIPTION
found while trying to read about / dig into the WAL:

- removes unneeded byte conversions,
- removes unused, untested functions either in test utils or for which there's a good alternative,
- makes `Test_Compactor/Compactor_creates_checkpoints_eventually` asynchronous but deterministic,
  (introduces a minimalistic `Observable` interface that I know I'll reuse elsewhere, though not in this PR, see #1020 )
- Simplifies Compactor's start / stop slightly, thanks to @smnzhu 's LifeCycleManager 