### PR TITLE
[v0.20] Fix bugs with epoch phase & counter metrics

### DIFF
--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -162,5 +162,5 @@ func (cc *ComplianceCollector) CurrentEpochCounter(counter uint64) {
 }
 
 func (cc *ComplianceCollector) CurrentEpochPhase(phase flow.EpochPhase) {
-	cc.currentEpochCounter.Set(float64(phase))
+	cc.currentEpochPhase.Set(float64(phase))
 }

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -573,8 +573,10 @@ func (m *FollowerState) Finalize(blockID flow.Identifier) error {
 	if header.View > finalView {
 		events = append(events, func() { m.consumer.EpochTransition(currentEpochSetup.Counter, header) })
 
-		// set current epoch counter
+		// set current epoch counter corresponding to new epoch
 		events = append(events, func() { m.metrics.CurrentEpochCounter(currentEpochSetup.Counter) })
+		// set epoch phase - since we are starting a new epoch we begin in the staking phase
+		events = append(events, func() { m.metrics.CurrentEpochPhase(flow.EpochPhaseStaking) })
 	}
 
 	// FINALLY: any block that is finalized is already a valid extension;

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -572,13 +572,11 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		// finalize block 4 so we can finalize subsequent blocks
 		// ensure an epoch phase transition when we finalize block 4
 		consumer.On("EpochSetupPhaseStarted", epoch2Setup.Counter-1, block4.Header).Once()
-		metrics.On("CurrentEpochPhase", flow.EpochPhaseSetup)
-		metrics.On("CurrentEpochCounter", epoch2Setup.Counter-1)
+		metrics.On("CurrentEpochPhase", flow.EpochPhaseSetup).Once()
 		err = state.Finalize(block4.ID())
 		require.NoError(t, err)
 		consumer.AssertCalled(t, "EpochSetupPhaseStarted", epoch2Setup.Counter-1, block4.Header)
 		metrics.AssertCalled(t, "CurrentEpochPhase", flow.EpochPhaseSetup)
-		metrics.AssertCalled(t, "CurrentEpochCounter", epoch2Setup.Counter-1)
 
 		// now that the setup event has been emitted, we should be in the setup phase
 		phase, err = state.AtBlockID(block4.ID()).Phase()
@@ -642,17 +640,15 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.NoError(t, err)
 
 		// expect epoch phase transition once we finalize block 7
-		consumer.On("EpochCommittedPhaseStarted", epoch2Setup.Counter-1, block7.Header)
+		consumer.On("EpochCommittedPhaseStarted", epoch2Setup.Counter-1, block7.Header).Once()
 		// expect committed final view to be updated, since we are committing epoch 2
-		metrics.On("CommittedEpochFinalView", epoch2Setup.FinalView)
-		metrics.On("CurrentEpochPhase", flow.EpochPhaseCommitted)
-		metrics.On("CurrentEpochCounter", epoch2Setup.Counter-1)
+		metrics.On("CommittedEpochFinalView", epoch2Setup.FinalView).Once()
+		metrics.On("CurrentEpochPhase", flow.EpochPhaseCommitted).Once()
 		err = state.Finalize(block7.ID())
 		require.NoError(t, err)
 		consumer.AssertCalled(t, "EpochCommittedPhaseStarted", epoch2Setup.Counter-1, block7.Header)
 		metrics.AssertCalled(t, "CommittedEpochFinalView", epoch2Setup.FinalView)
 		metrics.AssertCalled(t, "CurrentEpochPhase", flow.EpochPhaseCommitted)
-		metrics.AssertCalled(t, "CurrentEpochCounter", epoch2Setup.Counter-1)
 
 		// we should still be in epoch 1
 		epochCounter, err := state.AtBlockID(block4.ID()).Epochs().Current().Counter()
@@ -694,12 +690,14 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 
 		// expect epoch transition once we finalize block 9
 		consumer.On("EpochTransition", epoch2Setup.Counter, block9.Header).Once()
-		metrics.On("CurrentEpochCounter", epoch2Setup.Counter)
+		metrics.On("CurrentEpochCounter", epoch2Setup.Counter).Once()
+		metrics.On("CurrentEpochPhase", flow.EpochPhaseStaking).Once()
 		err = state.Finalize(block8.ID())
 		require.NoError(t, err)
 		err = state.Finalize(block9.ID())
 		require.NoError(t, err)
 		metrics.AssertCalled(t, "CurrentEpochCounter", epoch2Setup.Counter)
+		metrics.AssertCalled(t, "CurrentEpochPhase", flow.EpochPhaseStaking)
 		consumer.AssertCalled(t, "EpochTransition", epoch2Setup.Counter, block9.Header)
 
 		metrics.AssertExpectations(t)


### PR DESCRIPTION
This PR addresses the following problems:

* the counter metric was being set incorrectly in `CurrentEpochPhase`
* the phase transition from committed to staking was not captured in the metrics

Metrics results over several epochs on localnet:
![Screen Shot 2021-08-05 at 6 28 51 PM](https://user-images.githubusercontent.com/10557821/128442224-3febb17d-5293-4a85-a05e-9c56abe450d0.png)

![Screen Shot 2021-08-05 at 6 28 57 PM](https://user-images.githubusercontent.com/10557821/128442205-2a49233e-f363-4d83-8468-a2c5cb49b571.png)
