### PR TITLE
[network] Makes mesh-dependent network tests asynchronous

### DIFF
--- a/network/p2p/connManager.go
+++ b/network/p2p/connManager.go
@@ -12,6 +12,16 @@ import (
 	"github.com/onflow/flow-go/module"
 )
 
+// TagLessConnManager is a companion interface to libp2p-core.connmgr.ConnManager which implements a (simplified) tagless variant of the Protect / Unprotect logic
+type TagLessConnManager interface {
+	connmgr.ConnManager
+	// ProtectPeer increments the stream setup count for the peer.ID
+	ProtectPeer(id peer.ID)
+	// UnprotectPeer decrements the stream setup count for the peer.ID.
+	// If the count reaches zero, the id is removed from the map
+	UnprotectPeer(id peer.ID)
+}
+
 // ConnManager provides an implementation of Libp2p's ConnManager interface (https://godoc.org/github.com/libp2p/go-libp2p-core/connmgr#ConnManager)
 // It is called back by libp2p when certain events occur such as opening/closing a stream, opening/closing connection etc.
 // This implementation updates networking metrics when a peer connection is added or removed

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -79,7 +79,7 @@ func DefaultLibP2PNodeFactory(ctx context.Context, log zerolog.Logger, me flow.I
 
 type NodeBuilder interface {
 	SetRootBlockID(string) NodeBuilder
-	SetConnectionManager(*ConnManager) NodeBuilder
+	SetConnectionManager(TagLessConnManager) NodeBuilder
 	SetConnectionGater(*ConnGater) NodeBuilder
 	SetPubsubOptions(...pubsub.Option) NodeBuilder
 	SetPingInfoProvider(PingInfoProvider) NodeBuilder
@@ -92,7 +92,7 @@ type DefaultLibP2PNodeBuilder struct {
 	rootBlockID      string
 	logger           zerolog.Logger
 	connGater        *ConnGater
-	connMngr         *ConnManager
+	connMngr         TagLessConnManager
 	pingInfoProvider PingInfoProvider
 	pubSubMaker      func(context.Context, host.Host, ...pubsub.Option) (*pubsub.PubSub, error)
 	hostMaker        func(context.Context, ...config.Option) (host.Host, error)
@@ -116,7 +116,7 @@ func (builder *DefaultLibP2PNodeBuilder) SetRootBlockID(rootBlockId string) Node
 	return builder
 }
 
-func (builder *DefaultLibP2PNodeBuilder) SetConnectionManager(connMngr *ConnManager) NodeBuilder {
+func (builder *DefaultLibP2PNodeBuilder) SetConnectionManager(connMngr TagLessConnManager) NodeBuilder {
 	builder.connMngr = connMngr
 	return builder
 }
@@ -221,7 +221,7 @@ type Node struct {
 	id                   flow.Identifier                        // used to represent id of flow node running this instance of libP2P node
 	flowLibP2PProtocolID protocol.ID                            // the unique protocol ID
 	pingService          *PingService
-	connMgr              *ConnManager
+	connMgr              TagLessConnManager
 }
 
 // Stop stops the libp2p node.

--- a/network/p2p/sporking_test.go
+++ b/network/p2p/sporking_test.go
@@ -33,7 +33,7 @@ type SporkingTestSuite struct {
 }
 
 func TestSporkingTestSuite(t *testing.T) {
-	golog.SetAllLoggers(golog.LevelDebug)
+	golog.SetAllLoggers(golog.LevelError)
 	suite.Run(t, new(SporkingTestSuite))
 }
 

--- a/network/test/echoengine_test.go
+++ b/network/test/echoengine_test.go
@@ -45,7 +45,7 @@ func (suite *EchoEngineTestSuite) SetupTest() {
 	logger := zerolog.New(os.Stderr).Level(zerolog.ErrorLevel)
 	log.SetAllLoggers(log.LevelError)
 	// both nodes should be of the same role to get connected on epidemic dissemination
-	suite.ids, _, suite.nets = GenerateIDsMiddlewaresNetworks(suite.T(), count, logger, 100, nil, !DryRun)
+	suite.ids, _, suite.nets, _ = GenerateIDsMiddlewaresNetworks(suite.T(), count, logger, 100, nil, !DryRun)
 }
 
 // TearDownTest closes the networks within a specified timeout

--- a/network/test/epochtransition_test.go
+++ b/network/test/epochtransition_test.go
@@ -175,7 +175,7 @@ func (suite *MutableIdentityTableSuite) setupStateMock() {
 func (suite *MutableIdentityTableSuite) addNodes(count int) {
 
 	// create the ids, middlewares and networks
-	ids, mws, nets := GenerateIDsMiddlewaresNetworks(suite.T(), count, suite.logger, 100, nil, !DryRun)
+	ids, mws, nets, _ := GenerateIDsMiddlewaresNetworks(suite.T(), count, suite.logger, 100, nil, !DryRun)
 
 	// create the engines for the new nodes
 	engines := GenerateEngines(suite.T(), nets)

--- a/network/test/meshengine.go
+++ b/network/test/meshengine.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,7 @@ import (
 // MeshEngine is a simple engine that is used for testing the correctness of
 // driving the engines with libp2p, it simply receives and stores the incoming messages
 type MeshEngine struct {
+	sync.Mutex
 	t        *testing.T
 	con      network.Conduit      // used to directly communicate with the network
 	originID flow.Identifier      // used to keep track of the id of the sender of the messages
@@ -64,6 +66,9 @@ func (e *MeshEngine) ProcessLocal(event interface{}) error {
 // Process receives an originID and an event and casts them into the corresponding fields of the
 // MeshEngine. It then flags the received channel on reception of an event.
 func (e *MeshEngine) Process(channel network.Channel, originID flow.Identifier, event interface{}) error {
+	e.Lock()
+	defer e.Unlock()
+
 	// stores the message locally
 	e.originID = originID
 	e.channel <- channel

--- a/network/test/meshengine_test.go
+++ b/network/test/meshengine_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/libp2p/message"
+	"github.com/onflow/flow-go/module/observable"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -32,6 +33,7 @@ type MeshEngineTestSuite struct {
 	ConduitWrapper                   // used as a wrapper around conduit methods
 	nets           []*p2p.Network    // used to keep track of the networks
 	ids            flow.IdentityList // used to keep track of the identifiers associated with networks
+	obs            chan string       // used to keep track of Protect events tagged by pubsub messages
 }
 
 // TestMeshNetTestSuite runs all tests in this test suit
@@ -46,7 +48,20 @@ func (suite *MeshEngineTestSuite) SetupTest() {
 	const count = 10
 	logger := zerolog.New(os.Stderr).Level(zerolog.ErrorLevel)
 	log.SetAllLoggers(log.LevelError)
-	suite.ids, _, suite.nets = GenerateIDsMiddlewaresNetworks(suite.T(), count, logger, 100, nil, !DryRun, unittest.WithAllRoles())
+
+	// set up a channl to receive pubsub tags from connManagers of the nodes
+	var obs []observable.Observable
+	peerChannel := make(chan string)
+	ob := TagsObserver{
+		tags: peerChannel,
+	}
+
+	suite.ids, _, suite.nets, obs = GenerateIDsMiddlewaresNetworks(suite.T(), count, logger, 100, nil, !DryRun, unittest.WithAllRoles())
+
+	for _, observableConnMgr := range obs {
+		observableConnMgr.Subscribe(&ob)
+	}
+	suite.obs = peerChannel
 }
 
 // TearDownTest closes the networks within a specified timeout
@@ -148,7 +163,11 @@ func (suite *MeshEngineTestSuite) allToAllScenario(send ConduitSendWrapperFunc) 
 	}
 
 	// allow nodes to heartbeat and discover each other
-	time.Sleep(2 * time.Second)
+	// each node will register ~D protect messages, where D is the default out-degree (6)
+	// see https://github.com/libp2p/go-libp2p-pubsub/blob/0c7092d1f50091ae88407ba93103ac5868da3d0a/gossipsub.go#L33
+	for i := 0; i < 6*count; i++ {
+		<-suite.obs
+	}
 
 	// Each node broadcasting a message to all others
 	for i := range suite.nets {
@@ -220,7 +239,11 @@ func (suite *MeshEngineTestSuite) targetValidatorScenario(send ConduitSendWrappe
 	}
 
 	// allow nodes to heartbeat and discover each other
-	time.Sleep(5 * time.Second)
+	// each node will register ~D protect messages, where D is the default out-degree (6)
+	// see https://github.com/libp2p/go-libp2p-pubsub/blob/0c7092d1f50091ae88407ba93103ac5868da3d0a/gossipsub.go#L33
+	for i := 0; i < 6*count; i++ {
+		<-suite.obs
+	}
 
 	// choose half of the nodes as target
 	allIds := suite.ids.NodeIDs()
@@ -273,8 +296,11 @@ func (suite *MeshEngineTestSuite) messageSizeScenario(send ConduitSendWrapperFun
 	}
 
 	// allow nodes to heartbeat and discover each other
-	time.Sleep(2 * time.Second)
-
+	// each node will register ~D protect messages per mesh setup, where D is the default out-degree (6)
+	// see https://github.com/libp2p/go-libp2p-pubsub/blob/0c7092d1f50091ae88407ba93103ac5868da3d0a/gossipsub.go#L33
+	for i := 0; i < 6*count; i++ {
+		<-suite.obs
+	}
 	// others keeps the identifier of all nodes except node that is sender.
 	others := suite.ids.Filter(filter.Not(filter.HasNodeID(suite.ids[0].NodeID))).NodeIDs()
 
@@ -320,7 +346,11 @@ func (suite *MeshEngineTestSuite) conduitCloseScenario(send ConduitSendWrapperFu
 	}
 
 	// allow nodes to heartbeat and discover each other
-	time.Sleep(2 * time.Second)
+	// each node will register ~D protect messages, where D is the default out-degree (6)
+	// see https://github.com/libp2p/go-libp2p-pubsub/blob/0c7092d1f50091ae88407ba93103ac5868da3d0a/gossipsub.go#L33
+	for i := 0; i < 6*count; i++ {
+		<-suite.obs
+	}
 
 	// unregister a random engine from the test topic by calling close on it's conduit
 	unregisterIndex := rand.Intn(count)

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -52,7 +52,7 @@ type MiddlewareTestSuite struct {
 	size    int               // used to determine number of middlewares under test
 	mws     []*p2p.Middleware // used to keep track of middlewares under test
 	ov      []*mocknetwork.Overlay
-	obs     chan string  // used to keep track of Protect events tagged by pubsub messages
+	obs     chan string // used to keep track of Protect events tagged by pubsub messages
 	ids     []*flow.Identity
 	metrics *metrics.NoopCollector // no-op performance monitoring simulation
 }

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -47,8 +47,9 @@ func (m *MiddlewareTestSuite) SetupTest() {
 
 	m.size = 2 // operates on two middlewares
 	m.metrics = metrics.NewNoopCollector()
+
 	// create and start the middlewares
-	m.ids, m.mws = GenerateIDsAndMiddlewares(m.T(), m.size, !DryRun, logger)
+	m.ids, m.mws, _ = GenerateIDsAndMiddlewares(m.T(), m.size, !DryRun, logger)
 
 	require.Len(m.Suite.T(), m.ids, m.size)
 	require.Len(m.Suite.T(), m.mws, m.size)

--- a/network/test/testUtil.go
+++ b/network/test/testUtil.go
@@ -71,6 +71,16 @@ func (cwcm *TagWatchingConnManager) Protect(id peer.ID, tag string) {
 	}
 }
 
+func (cwcm *TagWatchingConnManager) Unprotect(id peer.ID, tag string) bool {
+	cwcm.obsLock.RLock()
+	defer cwcm.obsLock.RUnlock()
+	res := cwcm.ConnManager.Unprotect(id, tag)
+	for obs := range cwcm.observers {
+		go obs.OnNext(PeerTag{peer: id, tag: tag})
+	}
+	return res
+}
+
 func NewTagWatchingConnManager(log zerolog.Logger, metrics module.NetworkMetrics) *TagWatchingConnManager {
 	cm := p2p.NewConnManager(log, metrics)
 	return &TagWatchingConnManager{

--- a/network/test/testUtil.go
+++ b/network/test/testUtil.go
@@ -202,15 +202,15 @@ func GenerateNetworks(t *testing.T,
 	return nets
 }
 
-// returns nodeIDs, middlewares, and observables which can be subscirbed to in order to witness connect events
+// returns nodeIDs, middlewares, and observables which can be subscirbed to in order to witness protect events from pubsub
 func GenerateIDsAndMiddlewares(t *testing.T,
 	n int,
 	dryRunMode bool,
 	logger zerolog.Logger, opts ...func(*flow.Identity)) (flow.IdentityList, []*p2p.Middleware, []observable.Observable) {
 
-	ids, libP2PNodes, connectObservables := GenerateIDs(t, logger, n, dryRunMode, opts...)
+	ids, libP2PNodes, protectObservables := GenerateIDs(t, logger, n, dryRunMode, opts...)
 	mws := GenerateMiddlewares(t, logger, ids, libP2PNodes)
-	return ids, mws, connectObservables
+	return ids, mws, protectObservables
 }
 
 func GenerateIDsMiddlewaresNetworks(t *testing.T,

--- a/network/test/testUtil.go
+++ b/network/test/testUtil.go
@@ -208,11 +208,12 @@ func GenerateIDsMiddlewaresNetworks(t *testing.T,
 	log zerolog.Logger,
 	csize int,
 	tops []network.Topology,
-	dryRun bool, opts ...func(*flow.Identity)) (flow.IdentityList, []*p2p.Middleware, []*p2p.Network) {
-	ids, mws, _ := GenerateIDsAndMiddlewares(t, n, dryRun, log, opts...)
+	dryRun bool, opts ...func(*flow.Identity)) (flow.IdentityList, []*p2p.Middleware, []*p2p.Network, []observable.Observable) {
+
+	ids, mws, observables := GenerateIDsAndMiddlewares(t, n, dryRun, log, opts...)
 	sms := GenerateSubscriptionManagers(t, mws)
 	networks := GenerateNetworks(t, log, ids, mws, csize, tops, sms, dryRun)
-	return ids, mws, networks
+	return ids, mws, networks, observables
 }
 
 // GenerateEngines generates MeshEngines for the given networks

--- a/network/topology/topology_test.go
+++ b/network/topology/topology_test.go
@@ -138,11 +138,11 @@ func (suite *TopologyTestSuite) generateSystem(acc, col, con, exe, ver, cluster 
 	flow.IdentityList,
 	[]network.SubscriptionManager) {
 
-	collector, _ := test.GenerateIDs(suite.T(), suite.logger, col, test.DryRun, unittest.WithRole(flow.RoleCollection))
-	access, _ := test.GenerateIDs(suite.T(), suite.logger, acc, test.DryRun, unittest.WithRole(flow.RoleAccess))
-	consensus, _ := test.GenerateIDs(suite.T(), suite.logger, con, test.DryRun, unittest.WithRole(flow.RoleConsensus))
-	verification, _ := test.GenerateIDs(suite.T(), suite.logger, ver, test.DryRun, unittest.WithRole(flow.RoleVerification))
-	execution, _ := test.GenerateIDs(suite.T(), suite.logger, exe, test.DryRun, unittest.WithRole(flow.RoleExecution))
+	collector, _, _ := test.GenerateIDs(suite.T(), suite.logger, col, test.DryRun, unittest.WithRole(flow.RoleCollection))
+	access, _, _ := test.GenerateIDs(suite.T(), suite.logger, acc, test.DryRun, unittest.WithRole(flow.RoleAccess))
+	consensus, _, _ := test.GenerateIDs(suite.T(), suite.logger, con, test.DryRun, unittest.WithRole(flow.RoleConsensus))
+	verification, _, _ := test.GenerateIDs(suite.T(), suite.logger, ver, test.DryRun, unittest.WithRole(flow.RoleVerification))
+	execution, _, _ := test.GenerateIDs(suite.T(), suite.logger, exe, test.DryRun, unittest.WithRole(flow.RoleExecution))
 
 	ids := flow.IdentityList{}
 	ids = ids.Union(collector)


### PR DESCRIPTION
The network tests in `TestMeshNetTestSuite` and `TestMiddlewareTestSuit/TestUnsubscribe` depend on waiting for mesh formation between libp2p nodes, and use `time.Sleep` for that, and are therefore flaky (see [issue](https://github.com/dapperlabs/flow-go/issues/5710)). 

The present PR:
- defines a customized `ConnManager` in `testUtils` that captures the *tagged* `Protect` events generated by gossipsub at the establishment of a PubSub mesh, using the `observable.Observable` interface,
- injects it in test suite setup,
- registers an `observable.Observer` instance that waits for the correct number of such events to notice the establishment of the mesh,
- thereby replacing the `time.Sleep` instances,
- does some cleanup (removes one minor race in a mock, quiet down the logs in a test).

Obsoletes https://github.com/onflow/flow-go/pull/1020
Fixes https://github.com/dapperlabs/flow-go/issues/5710