### PR TITLE
add a function to return an invalid BLS function

### DIFF
--- a/crypto/bls.go
+++ b/crypto/bls.go
@@ -183,7 +183,7 @@ func (a *blsBLS12381Algo) generatePrivateKey(seed []byte) (PrivateKey, error) {
 // with any message and public key.
 //
 // The signature bytes represent an invalid serialization of a point which
-// makes the verification fail early.
+// makes the verification fail early. The verification would return (false, nil).
 func BLSInvalidSignature() Signature {
 	signature := make([]byte, SignatureLenBLSBLS12381)
 	signature[0] = 0xC1 // invalid header as per C.ep_read_bin_compact

--- a/crypto/bls.go
+++ b/crypto/bls.go
@@ -179,6 +179,8 @@ func (a *blsBLS12381Algo) generatePrivateKey(seed []byte) (PrivateKey, error) {
 	return sk, nil
 }
 
+const invalidBLSSignatureHeader = byte(0xE0)
+
 // BLSInvalidSignature returns an invalid signature that fails when verified
 // with any message and public key.
 //
@@ -186,7 +188,7 @@ func (a *blsBLS12381Algo) generatePrivateKey(seed []byte) (PrivateKey, error) {
 // makes the verification fail early. The verification would return (false, nil).
 func BLSInvalidSignature() Signature {
 	signature := make([]byte, SignatureLenBLSBLS12381)
-	signature[0] = 0xC1 // invalid header as per C.ep_read_bin_compact
+	signature[0] = invalidBLSSignatureHeader // invalid header as per C.ep_read_bin_compact
 	return signature
 }
 

--- a/crypto/bls.go
+++ b/crypto/bls.go
@@ -179,6 +179,17 @@ func (a *blsBLS12381Algo) generatePrivateKey(seed []byte) (PrivateKey, error) {
 	return sk, nil
 }
 
+// BLSInvalidSignature returns an invalid signature that fails when verified
+// with any message and public key.
+//
+// The signature bytes represent an invalid serialization of a point which
+// makes the verification fail early.
+func BLSInvalidSignature() Signature {
+	signature := make([]byte, SignatureLenBLSBLS12381)
+	signature[0] = 0xC1 // invalid header as per C.ep_read_bin_compact
+	return signature
+}
+
 // decodePrivateKey decodes a slice of bytes into a private key.
 // This function checks the scalar is less than the group order
 func (a *blsBLS12381Algo) decodePrivateKey(privateKeyBytes []byte) (PrivateKey, error) {

--- a/crypto/bls12381_utils.go
+++ b/crypto/bls12381_utils.go
@@ -186,15 +186,6 @@ func readPointG1(a *pointG1, src []byte) error {
 }
 
 // This is only a TEST function.
-// It wraps calls to subgroup checks since cgo can't be used
-// in go test files.
-//
-// This wraps a subgroup check in G1
-func checkInG1Test(pt *pointG1) bool {
-	return C.check_membership_G1((*C.ep_st)(pt)) == valid
-}
-
-// This is only a TEST function.
 // It wraps calls to the relic hash-to-G1 map since cgo can't be used
 // in go test files.
 //
@@ -209,13 +200,20 @@ func mapToG1RelicTest(dest *pointG1, msg, dst []byte) {
 }
 
 // This is only a TEST function.
-// It wraps calls to subgroup checks since cgo can't be used
+// It wraps calls to subgroup check tests since cgo can't be used
 // in go test files.
 // if inG1 is true, the function tests the membership of a point in G1,
 // otherwise, a point in E1\G1 membership is tested.
 // method is the index of the membership check method as defined in bls12381_utils.h
 func checkG1Test(inG1 int, method int) bool {
 	return C.subgroup_check_G1_test((C.int)(inG1), (C.int)(method)) == valid
+}
+
+// This is only a TEST function.
+// It wraps a call to a subgroup check in G1 since cgo can't be used
+// in go test files.
+func checkInG1Test(pt *pointG1) bool {
+	return C.check_membership_G1((*C.ep_st)(pt)) == valid
 }
 
 // This is only a TEST function.

--- a/crypto/bls_multisig.go
+++ b/crypto/bls_multisig.go
@@ -440,7 +440,7 @@ func BatchVerifyBLSSignaturesOneMessage(pks []PublicKey, sigs []Signature,
 	flatSigs := make([]byte, 0, signatureLengthBLSBLS12381*len(sigs))
 	// an invalid signature with an incorrect header but correct length
 	invalidSig := make([]byte, signatureLengthBLSBLS12381)
-	invalidSig[0] = 0xC1 // incorrect header
+	invalidSig[0] = invalidBLSSignatureHeader // incorrect header
 	for _, sig := range sigs {
 		if len(sig) == signatureLengthBLSBLS12381 {
 			flatSigs = append(flatSigs, sig...)

--- a/crypto/bls_test.go
+++ b/crypto/bls_test.go
@@ -39,6 +39,7 @@ func BenchmarkBLSBLS12381Verify(b *testing.B) {
 	benchVerify(b, BLSBLS12381, halg)
 }
 
+// utility function to generate a random private key
 func randomSK(t *testing.T, seed []byte) PrivateKey {
 	n, err := rand.Read(seed)
 	require.Equal(t, n, KeyGenSeedMinLenBLSBLS12381)
@@ -105,6 +106,17 @@ func TestBLSEncodeDecode(t *testing.T) {
 	require.Error(t, err, "the key decoding should fail - key value is identity")
 	assert.IsType(t, expectedError, err)
 }
+
+// TestBLSInvalidSignature tests the function BLSInvalidSignature
+func TestBLSInvalidSignature(t *testing.T) {
+	s := BLSInvalidSignature()
+	var point pointG1
+	err := readPointG1(&point, s)
+	// check the returned error
+	require.Error(t, err)
+	assert.IsType(t, expectedError, err)
+}
+
 /////////////////////////////////////////
 //             Rapid tests             //
 /////////////////////////////////////////
@@ -255,16 +267,16 @@ func testBLSWithRelicSignCrossBLST(t *rapid.T) {
 	blstPass := res != nil
 	require.True(t, blsPass && blstPass, "deserialization of the private key %x differs", skBytes)
 
-		var sigBLST blst.P1Affine
-		sigBLST.Sign(&skBLST, msgBytes, blsCipher)
-		sigBytesBLST := sigBLST.Compress()
+	var sigBLST blst.P1Affine
+	sigBLST.Sign(&skBLST, msgBytes, blsCipher)
+	sigBytesBLST := sigBLST.Compress()
 
-		skBLS, ok := sk.(*PrKeyBLSBLS12381)
-		require.True(t, ok, "incoherent key type assertion")
+	skBLS, ok := sk.(*PrKeyBLSBLS12381)
+	require.True(t, ok, "incoherent key type assertion")
 
-		sig := skBLS.signWithRelicMapTest(msgBytes)
-		sigBytesBLS := sig.Bytes()
-		assert.Equal(t, sigBytesBLST, sigBytesBLS)
+	sig := skBLS.signWithRelicMapTest(msgBytes)
+	sigBytesBLS := sig.Bytes()
+	assert.Equal(t, sigBytesBLST, sigBytesBLS)
 
 }
 

--- a/crypto/bls_test.go
+++ b/crypto/bls_test.go
@@ -115,6 +115,15 @@ func TestBLSInvalidSignature(t *testing.T) {
 	// check the returned error
 	require.Error(t, err)
 	assert.IsType(t, expectedError, err)
+
+	// check the
+	kmac := NewBLSKMAC("tag")
+	seed := make([]byte, KeyGenSeedMinLenBLSBLS12381)
+	pk := randomSK(t, seed).PublicKey()
+	msg := []byte("message")
+	valid, err := pk.Verify(s, msg, kmac)
+	assert.NoError(t, err)
+	assert.False(t, valid)
 }
 
 /////////////////////////////////////////

--- a/crypto/bls_test.go
+++ b/crypto/bls_test.go
@@ -116,7 +116,7 @@ func TestBLSInvalidSignature(t *testing.T) {
 	require.Error(t, err)
 	assert.IsType(t, expectedError, err)
 
-	// check the
+	// check the signature verification behavior
 	kmac := NewBLSKMAC("tag")
 	seed := make([]byte, KeyGenSeedMinLenBLSBLS12381)
 	pk := randomSK(t, seed).PublicKey()


### PR DESCRIPTION
Adds a function to return an invalid BLS signature that fails verification early under any message and public key.