### PR TITLE
Fix Deploy Epoch helper utility

### DIFF
--- a/cmd/util/cmd/epochs/cmd/deploy.go
+++ b/cmd/util/cmd/epochs/cmd/deploy.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -89,7 +91,7 @@ func deployRun(cmd *cobra.Command, args []string) {
 	txArgs := getDeployEpochTransactionArguments(snapshot)
 	log.Info().Msg("extracted `deploy_epoch_relative` transaction arguments from snapshot")
 
-	// ancode to JSON
+	// encode to JSON
 	enc, err := epochcmdutil.EncodeArgs(txArgs)
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not encode epoch transaction arguments")
@@ -116,24 +118,13 @@ func getDeployEpochTransactionArguments(snapshot *inmem.Snapshot) []cadence.Valu
 		log.Fatal().Err(err).Msgf("could not get head from snapshot")
 	}
 
-	// root chain id and system contractsRegister
-	chainID := head.ChainID
-	systemContracts, err := systemcontracts.SystemContractsForChain(chainID)
-	if err != nil {
-		log.Fatal().Err(err).Str("chain_id", chainID.String()).Msgf("could not get system contracts for chainID")
-	}
+	epochContractName := systemcontracts.ContractNameEpoch
 
 	// current epoch counter
 	currentEpochCounter, err := currentEpoch.Counter()
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not get `currentEpochCounter` from snapshot")
 	}
-
-	// epoch contract name and get code for contract
-	epochContractName := systemcontracts.ContractNameEpoch
-	epochContractCode := contracts.FlowEpoch(flagFungibleTokenAddress,
-		flagFlowTokenAddress, flagIDTableAddress,
-		systemContracts.ClusterQC.Address.Hex(), systemContracts.DKG.Address.Hex())
 
 	// get final view from snapshot
 	finalView, err := currentEpoch.FinalView()
@@ -167,8 +158,8 @@ func getDeployEpochTransactionArguments(snapshot *inmem.Snapshot) []cadence.Valu
 		log.Fatal().Err(err).Msgf("could not get `randomSource` for current epoch from snapshot")
 	}
 
-	return convertDeployEpochTransactionArguments(epochContractName,
-		epochContractCode,
+	return convertDeployEpochTransactionArguments(
+		epochContractName,
 		currentEpochCounter,
 		numViewsInEpoch,
 		numViewsInStakingAuction,
@@ -181,9 +172,17 @@ func getDeployEpochTransactionArguments(snapshot *inmem.Snapshot) []cadence.Valu
 }
 
 // convertDeployEpochTransactionArguments converts the `deploy_epoch_relative` transaction arguments to cadence representations
-func convertDeployEpochTransactionArguments(contractName string, contractCode []byte, currentCounter uint64,
-	numViewsInEpoch, numViewsInStakingAuction, numViewsInDKGPhase uint64, numCollectorClusters int,
-	FLOWsupplyIncreasePercentage string, randomSource []byte, clustering flow.ClusterList) []cadence.Value {
+func convertDeployEpochTransactionArguments(
+	contractName string,
+	currentCounter uint64,
+	numViewsInEpoch uint64,
+	numViewsInStakingAuction uint64,
+	numViewsInDKGPhase uint64,
+	numCollectorClusters int,
+	FLOWsupplyIncreasePercentage string,
+	randomSource []byte,
+	clustering flow.ClusterList,
+) []cadence.Value {
 
 	// arguments array
 	args := make([]cadence.Value, 0)
@@ -194,10 +193,6 @@ func convertDeployEpochTransactionArguments(contractName string, contractCode []
 		log.Fatal().Err(err).Msgf("could not convert `contractName` to cadence representation")
 	}
 	args = append(args, cdcContractName)
-
-	// add epoch contract code
-	cdcContractCode := epochcmdutil.BytesToCadenceUInt8Array(contractCode)
-	args = append(args, cdcContractCode)
 
 	// add epoch current counter
 	cdcCurrentCounter := cadence.NewUInt64(currentCounter)
@@ -234,4 +229,54 @@ func convertDeployEpochTransactionArguments(contractName string, contractCode []
 	args = append(args, cdcRandomSource)
 
 	return args
+}
+
+// getDeployEpochTransactionText returns the transaction text for the transaction
+// to deploy FlowEpoch for the given snapshot. Primarily this involves setting
+// the appropriate import addresses and injecting the FlowEpoch contract code
+// as a literal in the transaction text.
+func getDeployEpochTransactionText(snapshot *inmem.Snapshot) []byte {
+
+	head, err := snapshot.Head()
+	if err != nil {
+		log.Fatal().Err(err).Msgf("could not get head from snapshot")
+	}
+
+	// root chain id and system contractsRegister
+	chainID := head.ChainID
+	systemContracts, err := systemcontracts.SystemContractsForChain(chainID)
+	if err != nil {
+		log.Fatal().Err(err).Str("chain_id", chainID.String()).Msgf("could not get system contracts for chainID")
+	}
+
+	// epoch contract name and get code for contract
+	epochContractCode := contracts.FlowEpoch(
+		flagFungibleTokenAddress,
+		flagFlowTokenAddress,
+		flagIDTableAddress,
+		systemContracts.ClusterQC.Address.Hex(),
+		systemContracts.DKG.Address.Hex(),
+	)
+
+	// convert the epoch contract code to an [UInt8] literal string that can be
+	// injected to the Cadence transaction text.
+	// NOTE: this is encoded as a literal in the transaction text rather than an
+	// argument because the size of the encoded argument could exceed the stack
+	// limit.
+	builder := new(strings.Builder)
+	builder.WriteString("[")
+	for i, codeByte := range epochContractCode {
+		if i < len(epochContractCode)-1 {
+			builder.WriteString(fmt.Sprintf("%d,", codeByte))
+			continue
+		}
+		builder.WriteString(fmt.Sprintf("%d", codeByte))
+	}
+	builder.WriteString("]")
+
+	epochContractCodeAsCadenceLiteral := builder.String()
+
+	deployEpochTransactionText := fmt.Sprintf(deployEpochTransactionTemplate, epochContractCodeAsCadenceLiteral)
+
+	return []byte(deployEpochTransactionText)
 }

--- a/cmd/util/cmd/epochs/cmd/deploy.go
+++ b/cmd/util/cmd/epochs/cmd/deploy.go
@@ -220,7 +220,7 @@ func convertDeployEpochTransactionArguments(
 	args = append(args, cdcNumCollectorClusters)
 
 	// add FLOWSupplyIncreasePercentage
-	cdcFlowSupplyIncreasePercentage, err := cadence.NewFix64(FLOWsupplyIncreasePercentage)
+	cdcFlowSupplyIncreasePercentage, err := cadence.NewUFix64(FLOWsupplyIncreasePercentage)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not convert `FLOWSupplyIncreasePercentage` to cadence representation")
 	}

--- a/cmd/util/cmd/epochs/cmd/deploy.go
+++ b/cmd/util/cmd/epochs/cmd/deploy.go
@@ -22,6 +22,7 @@ import (
 )
 
 const deployArgsFileName = "deploy-epoch-args.json"
+const deployTxFileName = "deploy-epoch-tx.cdc"
 
 // deployCmd represents a command to generate `deploy_epoch_relative` transaction arguments and writes it to the
 // working directory this command was run.
@@ -103,6 +104,10 @@ func deployRun(cmd *cobra.Command, args []string) {
 		log.Fatal().Err(err).Msg("could not write jsoncdc encoded arguments")
 	}
 	log.Info().Str("path", argsPath).Msg("wrote `deploy_epoch_relative` transaction arguments")
+
+	// write the transaction text to a file
+	tx := getDeployEpochTransactionText(snapshot)
+	err = io.WriteFile(deployTxFileName, tx)
 }
 
 // getDeployEpochTransactionArguments pulls out required arguments for the `deploy_epoch_relative` transaction from the root

--- a/cmd/util/cmd/epochs/cmd/templates.go
+++ b/cmd/util/cmd/epochs/cmd/templates.go
@@ -1,3 +1,9 @@
+package cmd
+
+// deployEpochTransactionTemplate is the transaction text for deploying the FLowEpoch
+// contract. The contract code (including correct imports for the given chain
+// is encoded into the transaction text (via fmt.Sprintf).
+var deployEpochTransactionTemplate = `
 // The Epoch smart contract is deployed after a spork.
 // When we deploy the Epoch smart contract for the first time, we need to ensure 
 // the epoch length and staking auction length are consistent with the protocol state.
@@ -5,7 +11,6 @@
 // value based on the current block when epochs is deployed
 
 transaction(name: String, 
-            code: [UInt8],
             currentEpochCounter: UInt64,
             // this value should be the number of views in the epoch, as computed from the 
             // first and final views of the epoch info from the protocol state
@@ -19,6 +24,8 @@ transaction(name: String,
   prepare(signer: AuthAccount) {
 
     let currentBlock = getCurrentBlock()
+
+	let code = %s
 
     // The smart contract computes the final view of the epoch like currentBlock.view+numViewsInEpoch. 
     // Since the Epoch contract is deployed after the spork while the network is running, 
@@ -46,4 +53,4 @@ transaction(name: String,
             clusterQCs: [],
             dkgPubKeys: [])
   }
-}
+}`

--- a/cmd/util/cmd/epochs/cmd/templates.go
+++ b/cmd/util/cmd/epochs/cmd/templates.go
@@ -25,7 +25,7 @@ transaction(name: String,
 
     let currentBlock = getCurrentBlock()
 
-	let code = %s
+	let code: [UInt8] = %s
 
     // The smart contract computes the final view of the epoch like currentBlock.view+numViewsInEpoch. 
     // Since the Epoch contract is deployed after the spork while the network is running, 


### PR DESCRIPTION
This PR fixes some problems with the `util epochs deploy-tx-args` helper command:
* Moves the contract code into a variable defined within the transaction text, rather than a transaction argument
* Fixes a transaction argument type