### PR TITLE
[crypto, testonly] split rapid tests in go tests

### DIFF
--- a/crypto/bls_test.go
+++ b/crypto/bls_test.go
@@ -289,10 +289,19 @@ func testBLSWithRelicSignCrossBLST(t *rapid.T) {
 
 }
 
-func TestBLSCrossBLST(t *testing.T) {
+func TestCrossEncodeDecodeScalar(t *testing.T) {
 	rapid.Check(t, testBLSEncodeDecodeScalarCrossBLST)
+}
+
+func TestCrossEncodeDecodePubKey(t *testing.T) {
 	rapid.Check(t, testBLSEncodeDecodePubKeyCrossBLST)
+}
+
+func TestCrossEncodeDecodeSignature(t *testing.T) {
 	rapid.Check(t, testBLSEncodeDecodeSignatureCrossBLST)
+}
+
+func TestCrossSign(t *testing.T) {
 	rapid.Check(t, testBLSWithRelicSignCrossBLST)
 }
 


### PR DESCRIPTION
The rapid rng has sometimes problematic behavior.

See:
https://github.com/onflow/flow-go/pull/1085/checks?check_run_id=3285304328#step:4:2132
https://github.com/onflow/flow-go/runs/3293037063

we also detected a bad interaction with require.NoError in the past

The grouping of the rapid checks in a single go unit test makes it difficult to pinpoint where things
could have gone wrong -> this splits each rapid test in their go test.