### PR TITLE
Update header's signature field

### DIFF
--- a/access/legacy/convert/convert.go
+++ b/access/legacy/convert/convert.go
@@ -164,7 +164,7 @@ func BlockToMessage(h *flow.Block) (*entitiesproto.Block, error) {
 		Timestamp:            t,
 		CollectionGuarantees: cg,
 		BlockSeals:           seals,
-		Signatures:           [][]byte{h.Header.ParentVoterSig},
+		Signatures:           [][]byte{h.Header.ParentVoterSigData},
 	}
 
 	return &bh, nil

--- a/cmd/bootstrap/run/block.go
+++ b/cmd/bootstrap/run/block.go
@@ -13,16 +13,16 @@ func GenerateRootBlock(chainID flow.ChainID, parentID flow.Identifier, height ui
 		Seals:      nil,
 	}
 	header := flow.Header{
-		ChainID:        chainID,
-		ParentID:       parentID,
-		Height:         height,
-		PayloadHash:    payload.Hash(),
-		Timestamp:      timestamp,
-		View:           0,
-		ParentVoterIDs: nil,
-		ParentVoterSig: nil,
-		ProposerID:     flow.ZeroID,
-		ProposerSig:    nil,
+		ChainID:            chainID,
+		ParentID:           parentID,
+		Height:             height,
+		PayloadHash:        payload.Hash(),
+		Timestamp:          timestamp,
+		View:               0,
+		ParentVoterIDs:     nil,
+		ParentVoterSigData: nil,
+		ProposerID:         flow.ZeroID,
+		ProposerSigData:    nil,
 	}
 
 	return &flow.Block{

--- a/cmd/util/cmd/exec-data-json-export/block_exporter.go
+++ b/cmd/util/cmd/exec-data-json-export/block_exporter.go
@@ -20,9 +20,9 @@ type blockSummary struct {
 	BlockID        string   `json:"block_id"`
 	ParentBlockID  string   `json:"parent_block_id"`
 	ParentVoterIDs []string `json:"parent_voter_ids"`
-	// ParentVoterSig []string  `json:"parent_voter_sig"`
+	// ParentVoterSigData []string  `json:"parent_voter_sig"`
 	ProposerID string `json:"proposer_id"`
-	// ProposerSig    string  `json:"proposer_sig"`
+	// ProposerSigData    string  `json:"proposer_sig"`
 	Timestamp         time.Time `json:"timestamp"`
 	CollectionIDs     []string  `json:"collection_ids"`
 	SealedBlocks      []string  `json:"sealed_blocks"`

--- a/consensus/hotstuff/blockproducer/block_producer.go
+++ b/consensus/hotstuff/blockproducer/block_producer.go
@@ -34,7 +34,7 @@ func (bp *BlockProducer) MakeBlockProposal(qc *flow.QuorumCertificate, view uint
 	setHotstuffFields := func(header *flow.Header) error {
 		header.View = view
 		header.ParentVoterIDs = qc.SignerIDs
-		header.ParentVoterSig = qc.SigData
+		header.ParentVoterSigData = qc.SigData
 		header.ProposerID = bp.committee.Self()
 
 		// turn the header into a block header proposal as known by hotstuff
@@ -53,7 +53,7 @@ func (bp *BlockProducer) MakeBlockProposal(qc *flow.QuorumCertificate, view uint
 			return fmt.Errorf("could not sign block proposal: %w", err)
 		}
 
-		header.ProposerSig = proposal.SigData
+		header.ProposerSigData = proposal.SigData
 		return nil
 	}
 

--- a/consensus/hotstuff/model/block.go
+++ b/consensus/hotstuff/model/block.go
@@ -24,7 +24,7 @@ func BlockFromFlow(header *flow.Header, parentView uint64) *Block {
 		BlockID:   header.ParentID,
 		View:      parentView,
 		SignerIDs: header.ParentVoterIDs,
-		SigData:   header.ParentVoterSig,
+		SigData:   header.ParentVoterSigData,
 	}
 
 	block := Block{

--- a/consensus/hotstuff/model/proposal.go
+++ b/consensus/hotstuff/model/proposal.go
@@ -29,7 +29,7 @@ func ProposalFromFlow(header *flow.Header, parentView uint64) *Proposal {
 
 	proposal := Proposal{
 		Block:   block,
-		SigData: header.ProposerSig,
+		SigData: header.ProposerSigData,
 	}
 
 	return &proposal
@@ -45,9 +45,9 @@ func ProposalToFlow(proposal *Proposal) *flow.Header {
 		Timestamp:      block.Timestamp,
 		View:           block.View,
 		ParentVoterIDs: block.QC.SignerIDs,
-		ParentVoterSig: block.QC.SigData,
+		ParentVoterSigData: block.QC.SigData,
 		ProposerID:     block.ProposerID,
-		ProposerSig:    proposal.SigData,
+		ProposerSigData:    proposal.SigData,
 	}
 
 	return &header

--- a/engine/common/rpc/convert/convert.go
+++ b/engine/common/rpc/convert/convert.go
@@ -155,7 +155,7 @@ func BlockToMessage(h *flow.Block) (*entities.Block, error) {
 		Timestamp:            t,
 		CollectionGuarantees: cg,
 		BlockSeals:           seals,
-		Signatures:           [][]byte{h.Header.ParentVoterSig},
+		Signatures:           [][]byte{h.Header.ParentVoterSigData},
 	}
 
 	return &bh, nil

--- a/model/flow/header.go
+++ b/model/flow/header.go
@@ -16,16 +16,28 @@ import (
 // the combined payload of the entire block. It is what consensus nodes agree
 // on after validating the contents against the payload hash.
 type Header struct {
-	ChainID        ChainID    // ChainID is a chain-specific value to prevent replay attacks.
-	ParentID       Identifier // ParentID is the ID of this block's parent.
-	Height         uint64
-	PayloadHash    Identifier       // PayloadHash is a hash of the payload of this block.
-	Timestamp      time.Time        // Timestamp is the time at which this block was proposed. The proposing node can choose any time, so this should not be trusted as accurate.
-	View           uint64           // View is the view number at which this block was proposed.
-	ParentVoterIDs []Identifier     // list of voters who signed the parent block
-	ParentVoterSig crypto.Signature // aggregated signature over the parent block
-	ProposerID     Identifier       // proposer identifier for the block
-	ProposerSig    crypto.Signature // signature of the proposer over the new block
+	ChainID ChainID // ChainID is a chain-specific value to prevent replay attacks.
+
+	ParentID Identifier // ParentID is the ID of this block's parent.
+
+	Height uint64 // Height is the height of the parent + 1
+
+	PayloadHash Identifier // PayloadHash is a hash of the payload of this block.
+
+	Timestamp time.Time // Timestamp is the time at which this block was proposed.
+	// The proposer can choose any time, so this should not be trusted as accurate.
+
+	View uint64 // View is the view number at which this block was proposed.
+
+	ParentVoterIDs []Identifier // List of voters who signed the parent block. Used as QC.SignerIDs
+	// aggregated signature over the parent block.
+
+	ParentVoterSig []byte // Used as QC.SigData. Not a crypto.Signature since it could be a serialization of multi sigs
+
+	ProposerID Identifier // proposer identifier for the block
+
+	ProposerSig []byte // signature of the proposer over the new block.
+	// Not a crypto.Signature, since it could be a serialization of multi sigs
 }
 
 // Body returns the immutable part of the block header.

--- a/model/flow/header.go
+++ b/model/flow/header.go
@@ -28,15 +28,19 @@ type Header struct {
 
 	View uint64 // View is the view number at which this block was proposed.
 
-	ParentVoterIDs []Identifier // List of voters who signed the parent block. Used as QC.SignerIDs
-	// aggregated signature over the parent block.
+	ParentVoterIDs []Identifier // List of voters who signed the parent block.
+	// A quorum certificate can be extrated from the header.
+	// This field is the SignerIDs field of the extracted quorum certificate.
 
-	ParentVoterSig []byte // Used as QC.SigData. Not a crypto.Signature since it could be a serialization of multi sigs
+	ParentVoterSig []byte // aggregated signature over the parent block. Not a single cryptographic
+	// signature since the data represents cryptographic signatures serialized in some way (concatenation or other)
+	// A quorum certificate can be extracted from the header.
+	// This field is the SigData field of the extracted quorum certificate.
 
 	ProposerID Identifier // proposer identifier for the block
 
-	ProposerSig []byte // signature of the proposer over the new block.
-	// Not a crypto.Signature, since it could be a serialization of multi sigs
+	ProposerSig []byte // signature of the proposer over the new block. Not a single cryptographic
+	// signature since the data represents cryptographic signatures serialized in some way (concatenation or other)
 }
 
 // Body returns the immutable part of the block header.

--- a/model/flow/header.go
+++ b/model/flow/header.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/vmihailenco/msgpack/v4"
 
-	"github.com/onflow/flow-go/crypto"
 	cborcodec "github.com/onflow/flow-go/model/encoding/cbor"
 	"github.com/onflow/flow-go/model/fingerprint"
 )
@@ -50,7 +49,7 @@ func (h Header) Body() interface{} {
 		Timestamp      uint64
 		View           uint64
 		ParentVoterIDs []Identifier
-		ParentVoterSig crypto.Signature
+		ParentVoterSig []byte
 		ProposerID     Identifier
 	}{
 		ChainID:        h.ChainID,

--- a/model/flow/header.go
+++ b/model/flow/header.go
@@ -32,39 +32,39 @@ type Header struct {
 	// A quorum certificate can be extrated from the header.
 	// This field is the SignerIDs field of the extracted quorum certificate.
 
-	ParentVoterSig []byte // aggregated signature over the parent block. Not a single cryptographic
+	ParentVoterSigData []byte // aggregated signature over the parent block. Not a single cryptographic
 	// signature since the data represents cryptographic signatures serialized in some way (concatenation or other)
 	// A quorum certificate can be extracted from the header.
 	// This field is the SigData field of the extracted quorum certificate.
 
 	ProposerID Identifier // proposer identifier for the block
 
-	ProposerSig []byte // signature of the proposer over the new block. Not a single cryptographic
+	ProposerSigData []byte // signature of the proposer over the new block. Not a single cryptographic
 	// signature since the data represents cryptographic signatures serialized in some way (concatenation or other)
 }
 
 // Body returns the immutable part of the block header.
 func (h Header) Body() interface{} {
 	return struct {
-		ChainID        ChainID
-		ParentID       Identifier
-		Height         uint64
-		PayloadHash    Identifier
-		Timestamp      uint64
-		View           uint64
-		ParentVoterIDs []Identifier
-		ParentVoterSig []byte
-		ProposerID     Identifier
+		ChainID            ChainID
+		ParentID           Identifier
+		Height             uint64
+		PayloadHash        Identifier
+		Timestamp          uint64
+		View               uint64
+		ParentVoterIDs     []Identifier
+		ParentVoterSigData []byte
+		ProposerID         Identifier
 	}{
-		ChainID:        h.ChainID,
-		ParentID:       h.ParentID,
-		Height:         h.Height,
-		PayloadHash:    h.PayloadHash,
-		Timestamp:      uint64(h.Timestamp.UnixNano()),
-		View:           h.View,
-		ParentVoterIDs: h.ParentVoterIDs,
-		ParentVoterSig: h.ParentVoterSig,
-		ProposerID:     h.ProposerID,
+		ChainID:            h.ChainID,
+		ParentID:           h.ParentID,
+		Height:             h.Height,
+		PayloadHash:        h.PayloadHash,
+		Timestamp:          uint64(h.Timestamp.UnixNano()),
+		View:               h.View,
+		ParentVoterIDs:     h.ParentVoterIDs,
+		ParentVoterSigData: h.ParentVoterSigData,
+		ProposerID:         h.ProposerID,
 	}
 }
 

--- a/model/flow/header_test.go
+++ b/model/flow/header_test.go
@@ -34,28 +34,28 @@ func TestHeaderFingerprint(t *testing.T) {
 	headerID := header.ID()
 	data := header.Fingerprint()
 	var decoded struct {
-		ChainID        flow.ChainID
-		ParentID       flow.Identifier
-		Height         uint64
-		PayloadHash    flow.Identifier
-		Timestamp      uint64
-		View           uint64
-		ParentVoterIDs []flow.Identifier
-		ParentVoterSig crypto.Signature
-		ProposerID     flow.Identifier
+		ChainID            flow.ChainID
+		ParentID           flow.Identifier
+		Height             uint64
+		PayloadHash        flow.Identifier
+		Timestamp          uint64
+		View               uint64
+		ParentVoterIDs     []flow.Identifier
+		ParentVoterSigData crypto.Signature
+		ProposerID         flow.Identifier
 	}
 	rlp.NewEncoder().MustDecode(data, &decoded)
 	decHeader := flow.Header{
-		ChainID:        decoded.ChainID,
-		ParentID:       decoded.ParentID,
-		Height:         decoded.Height,
-		PayloadHash:    decoded.PayloadHash,
-		Timestamp:      time.Unix(0, int64(decoded.Timestamp)).UTC(),
-		View:           decoded.View,
-		ParentVoterIDs: decoded.ParentVoterIDs,
-		ParentVoterSig: decoded.ParentVoterSig,
-		ProposerID:     decoded.ProposerID,
-		ProposerSig:    header.ProposerSig, // since this field is not encoded/decoded, just set it to the original
+		ChainID:            decoded.ChainID,
+		ParentID:           decoded.ParentID,
+		Height:             decoded.Height,
+		PayloadHash:        decoded.PayloadHash,
+		Timestamp:          time.Unix(0, int64(decoded.Timestamp)).UTC(),
+		View:               decoded.View,
+		ParentVoterIDs:     decoded.ParentVoterIDs,
+		ParentVoterSigData: decoded.ParentVoterSigData,
+		ProposerID:         decoded.ProposerID,
+		ProposerSigData:    header.ProposerSigData, // since this field is not encoded/decoded, just set it to the original
 		// value to pass test
 	}
 	decodedID := decHeader.ID()

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -626,11 +626,11 @@ func (b *Builder) createProposal(parentID flow.Identifier,
 		// the following fields should be set by the custom function as needed
 		// NOTE: we could abstract all of this away into an interface{} field,
 		// but that would be over the top as we will probably always use hotstuff
-		View:           0,
-		ParentVoterIDs: nil,
-		ParentVoterSig: nil,
-		ProposerID:     flow.ZeroID,
-		ProposerSig:    nil,
+		View:               0,
+		ParentVoterIDs:     nil,
+		ParentVoterSigData: nil,
+		ProposerID:         flow.ZeroID,
+		ProposerSigData:    nil,
 	}
 
 	// apply the custom fields setter of the consensus algorithm

--- a/module/finalizer/collection/finalizer.go
+++ b/module/finalizer/collection/finalizer.go
@@ -151,7 +151,7 @@ func (f *Finalizer) MakeFinal(blockID flow.Identifier) error {
 					CollectionID:     payload.Collection.ID(),
 					ReferenceBlockID: payload.ReferenceBlockID,
 					SignerIDs:        step.ParentVoterIDs,
-					Signature:        step.ParentVoterSig,
+					Signature:        step.ParentVoterSigData,
 				},
 			})
 		}

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -183,7 +183,7 @@ func TestFinalizer(t *testing.T) {
 				Guarantee: flow.CollectionGuarantee{
 					CollectionID: block.Payload.Collection.ID(),
 					SignerIDs:    block.Header.ParentVoterIDs,
-					Signature:    block.Header.ParentVoterSig,
+					Signature:    block.Header.ParentVoterSigData,
 				},
 			})
 		})
@@ -234,14 +234,14 @@ func TestFinalizer(t *testing.T) {
 				Guarantee: flow.CollectionGuarantee{
 					CollectionID: block1.Payload.Collection.ID(),
 					SignerIDs:    block1.Header.ParentVoterIDs,
-					Signature:    block1.Header.ParentVoterSig,
+					Signature:    block1.Header.ParentVoterSigData,
 				},
 			})
 			prov.AssertCalled(t, "SubmitLocal", &messages.SubmitCollectionGuarantee{
 				Guarantee: flow.CollectionGuarantee{
 					CollectionID: block2.Payload.Collection.ID(),
 					SignerIDs:    block2.Header.ParentVoterIDs,
-					Signature:    block2.Header.ParentVoterSig,
+					Signature:    block2.Header.ParentVoterSigData,
 				},
 			})
 		})
@@ -291,7 +291,7 @@ func TestFinalizer(t *testing.T) {
 				Guarantee: flow.CollectionGuarantee{
 					CollectionID: block1.Payload.Collection.ID(),
 					SignerIDs:    block1.Header.ParentVoterIDs,
-					Signature:    block1.Header.ParentVoterSig,
+					Signature:    block1.Header.ParentVoterSigData,
 				},
 			})
 		})
@@ -343,7 +343,7 @@ func TestFinalizer(t *testing.T) {
 				Guarantee: flow.CollectionGuarantee{
 					CollectionID: block1.Payload.Collection.ID(),
 					SignerIDs:    block1.Header.ParentVoterIDs,
-					Signature:    block1.Header.ParentVoterSig,
+					Signature:    block1.Header.ParentVoterSigData,
 				},
 			})
 		})

--- a/network/codec/roundTripHeader_test.go
+++ b/network/codec/roundTripHeader_test.go
@@ -31,7 +31,7 @@ func roundTripHeaderViaCodec(t *testing.T, codec network.Codec) {
 	decodedInterface, err := codec.Decode(encoded)
 	assert.NoError(t, err)
 	decoded := decodedInterface.(*messages.BlockProposal)
-	assert.Equal(t, message.Header.ProposerSig, decoded.Header.ProposerSig)
+	assert.Equal(t, message.Header.ProposerSigData, decoded.Header.ProposerSigData)
 	messageHeader := fmt.Sprintf("- .Header=%+v\n", message.Header)
 	decodedHeader := fmt.Sprintf("- .Header=%+v\n", decoded.Header)
 	assert.Equal(t, messageHeader, decodedHeader)

--- a/state/cluster/root_block.go
+++ b/state/cluster/root_block.go
@@ -20,16 +20,16 @@ func CanonicalRootBlock(epoch uint64, participants flow.IdentityList) *cluster.B
 	chainID := CanonicalClusterID(epoch, participants)
 	payload := cluster.EmptyPayload(flow.ZeroID)
 	header := &flow.Header{
-		ChainID:        chainID,
-		ParentID:       flow.ZeroID,
-		Height:         0,
-		PayloadHash:    payload.Hash(),
-		Timestamp:      flow.GenesisTime,
-		View:           0,
-		ParentVoterIDs: nil,
-		ParentVoterSig: nil,
-		ProposerID:     flow.ZeroID,
-		ProposerSig:    nil,
+		ChainID:            chainID,
+		ParentID:           flow.ZeroID,
+		Height:             0,
+		PayloadHash:        payload.Hash(),
+		Timestamp:          flow.GenesisTime,
+		View:               0,
+		ParentVoterIDs:     nil,
+		ParentVoterSigData: nil,
+		ProposerID:         flow.ZeroID,
+		ProposerSigData:    nil,
 	}
 
 	return &cluster.Block{

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -89,7 +89,7 @@ func (s *Snapshot) QuorumCertificate() (*flow.QuorumCertificate, error) {
 		View:      head.View,
 		BlockID:   s.blockID,
 		SignerIDs: child.ParentVoterIDs,
-		SigData:   child.ParentVoterSig,
+		SigData:   child.ParentVoterSigData,
 	}
 
 	return qc, nil
@@ -409,7 +409,7 @@ func (s *Snapshot) Seed(indices ...uint32) ([]byte, error) {
 		return nil, fmt.Errorf("could not get child: %w", err)
 	}
 
-	seed, err := seed.FromParentSignature(indices, child.ParentVoterSig)
+	seed, err := seed.FromParentSignature(indices, child.ParentVoterSigData)
 	if err != nil {
 		return nil, fmt.Errorf("could not create seed from header's signature: %w", err)
 	}

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -469,7 +469,7 @@ func TestQuorumCertificate(t *testing.T) {
 			assert.Nil(t, err)
 			// should have signatures from valid child (block 2)
 			assert.Equal(t, block2.Header.ParentVoterIDs, qc.SignerIDs)
-			assert.Equal(t, block2.Header.ParentVoterSig.Bytes(), qc.SigData)
+			assert.Equal(t, block2.Header.ParentVoterSig, qc.SigData)
 			// should have view matching block1 view
 			assert.Equal(t, block1.Header.View, qc.View)
 

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -469,7 +469,7 @@ func TestQuorumCertificate(t *testing.T) {
 			assert.Nil(t, err)
 			// should have signatures from valid child (block 2)
 			assert.Equal(t, block2.Header.ParentVoterIDs, qc.SignerIDs)
-			assert.Equal(t, block2.Header.ParentVoterSig, qc.SigData)
+			assert.Equal(t, block2.Header.ParentVoterSigData, qc.SigData)
 			// should have view matching block1 view
 			assert.Equal(t, block1.Header.View, qc.View)
 

--- a/storage/badger/operation/headers_test.go
+++ b/storage/badger/operation/headers_test.go
@@ -18,14 +18,14 @@ import (
 func TestHeaderInsertCheckRetrieve(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		expected := flow.Header{
-			View:           1337,
-			Timestamp:      time.Now().UTC(),
-			ParentID:       flow.Identifier{0x11},
-			PayloadHash:    flow.Identifier{0x22},
-			ParentVoterIDs: []flow.Identifier{{0x44}},
-			ParentVoterSig: []byte{0x88},
-			ProposerID:     flow.Identifier{0x33},
-			ProposerSig:    crypto.Signature{0x77},
+			View:               1337,
+			Timestamp:          time.Now().UTC(),
+			ParentID:           flow.Identifier{0x11},
+			PayloadHash:        flow.Identifier{0x22},
+			ParentVoterIDs:     []flow.Identifier{{0x44}},
+			ParentVoterSigData: []byte{0x88},
+			ProposerID:         flow.Identifier{0x33},
+			ProposerSigData:    crypto.Signature{0x77},
 		}
 		blockID := expected.ID()
 

--- a/storage/badger/operation/headers_test.go
+++ b/storage/badger/operation/headers_test.go
@@ -23,7 +23,7 @@ func TestHeaderInsertCheckRetrieve(t *testing.T) {
 			ParentID:       flow.Identifier{0x11},
 			PayloadHash:    flow.Identifier{0x22},
 			ParentVoterIDs: []flow.Identifier{{0x44}},
-			ParentVoterSig: crypto.Signature([]byte{0x88}),
+			ParentVoterSig: []byte{0x88},
 			ProposerID:     flow.Identifier{0x33},
 			ProposerSig:    crypto.Signature{0x77},
 		}

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -352,16 +352,16 @@ func BlockHeaderWithParentFixture(parent *flow.Header) flow.Header {
 	height := parent.Height + 1
 	view := parent.View + 1 + uint64(rand.Intn(10)) // Intn returns [0, n)
 	return flow.Header{
-		ChainID:        parent.ChainID,
-		ParentID:       parent.ID(),
-		Height:         height,
-		PayloadHash:    IdentifierFixture(),
-		Timestamp:      time.Now().UTC(),
-		View:           view,
-		ParentVoterIDs: IdentifierListFixture(4),
-		ParentVoterSig: CombinedSignatureFixture(2),
-		ProposerID:     IdentifierFixture(),
-		ProposerSig:    SignatureFixture(),
+		ChainID:            parent.ChainID,
+		ParentID:           parent.ID(),
+		Height:             height,
+		PayloadHash:        IdentifierFixture(),
+		Timestamp:          time.Now().UTC(),
+		View:               view,
+		ParentVoterIDs:     IdentifierListFixture(4),
+		ParentVoterSigData: CombinedSignatureFixture(2),
+		ProposerID:         IdentifierFixture(),
+		ProposerSigData:    SignatureFixture(),
 	}
 }
 


### PR DESCRIPTION
This PR 

- updated the signature field for header.
- renamed the `ParentVoterSig` field to `ParentVoterSigData`
- renamed the `ProposerSig` field to `ProposerSigData`

Since the signer signature could be a combination of multiple signature, it makes more sense to be `[]byte` type than `crypto.Signature`.