### PR TITLE
[network, crypto] Compressed serialization, key conversions and message signing

### DIFF
--- a/crypto/bls.go
+++ b/crypto/bls.go
@@ -211,14 +211,8 @@ func (a *blsBLS12381Algo) decodePrivateKey(privateKeyBytes []byte) (PrivateKey, 
 }
 
 // decodePublicKey decodes a slice of bytes into a public key.
-// since we use the compressed representation by default, this delegates to decodePublicKeyCompressed
-func (a *blsBLS12381Algo) decodePublicKey(publicKeyBytes []byte) (PublicKey, error) {
-	return a.decodePublicKeyCompressed(publicKeyBytes)
-}
-
-// decodePublicKeyCompressed decodes a slice of bytes into a public key.
 // This function includes a membership check in G2 and rejects the infinity point.
-func (a *blsBLS12381Algo) decodePublicKeyCompressed(publicKeyBytes []byte) (PublicKey, error) {
+func (a *blsBLS12381Algo) decodePublicKey(publicKeyBytes []byte) (PublicKey, error) {
 	if len(publicKeyBytes) != pubKeyLengthBLSBLS12381 {
 		return nil, newInvalidInputsError(
 			"the input length has to be %d",
@@ -236,6 +230,15 @@ func (a *blsBLS12381Algo) decodePublicKeyCompressed(publicKeyBytes []byte) (Publ
 		return nil, newInvalidInputsError("the input is infinity or does not encode a BLS12-381 point in the valid group")
 	}
 	return &pk, nil
+}
+
+// decodePublicKeyCompressed decodes a slice of bytes into a public key.
+// since we use the compressed representation by default, this checks the default and delegates to decodePublicKeyCompressed
+func (a *blsBLS12381Algo) decodePublicKeyCompressed(publicKeyBytes []byte) (PublicKey, error) {
+	if serializationG2 != compressed {
+		panic("library is not configured to use compressed public key serialization")
+	}
+	return a.decodePublicKey(publicKeyBytes)
 }
 
 // PrKeyBLSBLS12381 is the private key of BLS using BLS12_381, it implements PrivateKey
@@ -346,15 +349,18 @@ func (pk *PubKeyBLSBLS12381) Size() int {
 // The encoding is a compressed encoding of the point
 // [zcash] https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 func (a *PubKeyBLSBLS12381) EncodeCompressed() []byte {
-	dest := make([]byte, pubKeyLengthBLSBLS12381)
-	writePointG2(dest, &a.point)
-	return dest
+	if serializationG2 != compressed {
+		panic("library is not configured to use compressed public key serialization")
+	}
+	return a.Encode()
 }
 
 // Encode returns a byte encoding of the public key.
 // Since we use a compressed encoding by default, this delegates to EncodeCompressed
 func (a *PubKeyBLSBLS12381) Encode() []byte {
-	return a.EncodeCompressed()
+	dest := make([]byte, pubKeyLengthBLSBLS12381)
+	writePointG2(dest, &a.point)
+	return dest
 }
 
 // Equals checks is two public keys are equal

--- a/crypto/bls.go
+++ b/crypto/bls.go
@@ -211,8 +211,14 @@ func (a *blsBLS12381Algo) decodePrivateKey(privateKeyBytes []byte) (PrivateKey, 
 }
 
 // decodePublicKey decodes a slice of bytes into a public key.
-// This function includes a membership check in G2 and rejects the infinity point.
+// since we use the compressed representation by default, this delegates to decodePublicKeyCompressed
 func (a *blsBLS12381Algo) decodePublicKey(publicKeyBytes []byte) (PublicKey, error) {
+	return a.decodePublicKeyCompressed(publicKeyBytes)
+}
+
+// decodePublicKeyCompressed decodes a slice of bytes into a public key.
+// This function includes a membership check in G2 and rejects the infinity point.
+func (a *blsBLS12381Algo) decodePublicKeyCompressed(publicKeyBytes []byte) (PublicKey, error) {
 	if len(publicKeyBytes) != pubKeyLengthBLSBLS12381 {
 		return nil, newInvalidInputsError(
 			"the input length has to be %d",
@@ -339,10 +345,16 @@ func (pk *PubKeyBLSBLS12381) Size() int {
 // Encode returns a byte encoding of the public key.
 // The encoding is a compressed encoding of the point
 // [zcash] https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
-func (a *PubKeyBLSBLS12381) Encode() []byte {
+func (a *PubKeyBLSBLS12381) EncodeCompressed() []byte {
 	dest := make([]byte, pubKeyLengthBLSBLS12381)
 	writePointG2(dest, &a.point)
 	return dest
+}
+
+// Encode returns a byte encoding of the public key.
+// Since we use a compressed encoding by default, this delegates to EncodeCompressed
+func (a *PubKeyBLSBLS12381) Encode() []byte {
+	return a.EncodeCompressed()
 }
 
 // Equals checks is two public keys are equal

--- a/crypto/ecdsa_test.go
+++ b/crypto/ecdsa_test.go
@@ -8,33 +8,10 @@ import (
 	"crypto/rand"
 	"math/big"
 
-	"github.com/btcsuite/btcd/btcec"
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func createSeed(t *testing.T) []byte {
-	seedLen := int(math.Max(KeyGenSeedMinLenECDSAP256, KeyGenSeedMinLenECDSASecp256k1))
-	seed := make([]byte, seedLen)
-	n, err := rand.Read(seed)
-	require.NoError(t, err)
-	require.Equal(t, n, seedLen)
-
-	return seed
-}
-
-// keyType returns an elliptic.Curve for an fcrypto.SigningAlgorithm if it exists
-func ecdsaCurveType(sa SigningAlgorithm) (elliptic.Curve, error) {
-	switch sa {
-	case ECDSAP256:
-		return elliptic.P256(), nil
-	case ECDSASecp256k1:
-		return btcec.S256(), nil
-	default:
-		return nil, newInvalidInputsError("Input does not correspond to an ECDSA Algorithm")
-	}
-}
 
 // ECDSA tests
 func TestECDSA(t *testing.T) {
@@ -313,7 +290,7 @@ func TestCompressionRoundTrip(t *testing.T) {
 	sa := []SigningAlgorithm{ECDSAP256, ECDSASecp256k1}
 	loops := 50
 	for _, s := range sa {
-		ct, err := ecdsaCurveType(s)
+		ct, err := ecdsaAlgoFromSA(s)
 		require.NoError(t, err)
 
 		for i := 0; i < loops; i++ {
@@ -326,20 +303,17 @@ func TestCompressionRoundTrip(t *testing.T) {
 			// get the Flow public key
 			fpublic := fpk.PublicKey()
 
-			// retrieve the ECDSA variant
-			fpublicEcdsa := fpublic.(*PubKeyECDSA)
-
 			// get the compressed bytes
-			fpublicBytes := fpublicEcdsa.encodeCompressed()
+			fpublicBytes := fpublic.EncodeCompressed()
 
 			// test the length  (it's the same value for PubKeyLenECDSASecp256k1)
 			require.Len(t, fpublicBytes, PubKeyLenECDSAP256/2+1)
 
 			// get the key back
-			fpublicOut, err := decodeCompressed(ct, fpublicBytes)
+			fpublicOut, err := ct.decodePublicKeyCompressed(fpublicBytes)
 
 			require.NoError(t, err)
-			require.Equal(t, fpublicEcdsa, fpublicOut)
+			require.Equal(t, fpublic, fpublicOut)
 
 		}
 	}

--- a/crypto/ecdsa_test.go
+++ b/crypto/ecdsa_test.go
@@ -1,13 +1,14 @@
 package crypto
 
 import (
-	"math"
+	"encoding/hex"
 	"testing"
 
 	"crypto/elliptic"
 	"crypto/rand"
 	"math/big"
 
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -286,35 +287,35 @@ func TestSignatureFormatCheck(t *testing.T) {
 	}
 }
 
-func TestCompressionRoundTrip(t *testing.T) {
-	sa := []SigningAlgorithm{ECDSAP256, ECDSASecp256k1}
-	loops := 50
-	for _, s := range sa {
-		ct, err := ecdsaAlgoFromSA(s)
+func TestEllipticUnmarshalSecp256k1(t *testing.T) {
+
+	testVectors := []string{
+		"028b10bf56476bf7da39a3286e29df389177a2fa0fca2d73348ff78887515d8da1", // IsOnCurve for elliptic returns false
+		"03d39427f07f680d202fe8504306eb29041aceaf4b628c2c69b0ec248155443166", // negative, IsOnCurve for elliptic returns false
+		"0267d1942a6cbe4daec242ea7e01c6cdb82dadb6e7077092deb55c845bf851433e", // arith of sqrt in elliptic doesn't match secp256k1
+		"0345d45eda6d087918b041453a96303b78c478dce89a4ae9b3c933a018888c5e06", // negative, arith of sqrt in elliptic doesn't match secp256k1
+	}
+
+	s := ECDSASecp256k1
+
+	for _, testVector := range testVectors {
+
+		// get the compressed bytes
+		publicBytes, err := hex.DecodeString(testVector)
 		require.NoError(t, err)
 
-		for i := 0; i < loops; i++ {
+		// decompress, check that those are perfectly valid Secp256k1 public keys
+		retrieved, err := DecodePublicKeyCompressed(s, publicBytes)
+		require.NoError(t, err)
 
-			// generate seed
-			seed := createSeed(t)
-			fpk, err := GeneratePrivateKey(s, seed)
-			require.NoError(t, err)
+		// check the compression is canonical by re-compressing to the same bytes
+		require.Equal(t, retrieved.EncodeCompressed(), publicBytes)
 
-			// get the Flow public key
-			fpublic := fpk.PublicKey()
+		// check that elliptic fails at decompressing them
+		x, y := elliptic.UnmarshalCompressed(btcec.S256(), publicBytes)
+		require.Nil(t, x)
+		require.Nil(t, y)
 
-			// get the compressed bytes
-			fpublicBytes := fpublic.EncodeCompressed()
-
-			// test the length  (it's the same value for PubKeyLenECDSASecp256k1)
-			require.Len(t, fpublicBytes, PubKeyLenECDSAP256/2+1)
-
-			// get the key back
-			fpublicOut, err := ct.decodePublicKeyCompressed(fpublicBytes)
-
-			require.NoError(t, err)
-			require.Equal(t, fpublic, fpublicOut)
-
-		}
 	}
+
 }

--- a/crypto/sign.go
+++ b/crypto/sign.go
@@ -16,12 +16,14 @@ import (
 
 // Signer interface
 type signer interface {
-	// generatePrKey generates a private key
+	// generatePrivateKey generates a private key
 	generatePrivateKey([]byte) (PrivateKey, error)
-	// decodePrKey loads a private key from a byte array
+	// decodePrivateKey loads a private key from a byte array
 	decodePrivateKey([]byte) (PrivateKey, error)
-	// decodePubKey loads a public key from a byte array
+	// decodePublicKey loads a public key from a byte array
 	decodePublicKey([]byte) (PublicKey, error)
+	// decodePublicKeyCompressed loads a public key from a byte array representing a point in compressed form
+	decodePublicKeyCompressed([]byte) (PublicKey, error)
 }
 
 // newNonRelicSigner returns a signer that does not depend on Relic library.
@@ -107,6 +109,15 @@ func DecodePublicKey(algo SigningAlgorithm, data []byte) (PublicKey, error) {
 	return signer.decodePublicKey(data)
 }
 
+// DecodePublicKeyCompressed decodes an array of bytes given in a compressed representation into a public key of the given algorithm
+func DecodePublicKeyCompressed(algo SigningAlgorithm, data []byte) (PublicKey, error) {
+	signer, err := newSigner(algo)
+	if err != nil {
+		return nil, newInvalidInputsError("decode public key failed: %s", err)
+	}
+	return signer.decodePublicKeyCompressed(data)
+}
+
 // Signature type tools
 
 // Bytes returns a byte array of the signature data
@@ -153,6 +164,10 @@ type PublicKey interface {
 	Verify(Signature, []byte, hash.Hasher) (bool, error)
 	// Encode returns a bytes representation of the public key.
 	Encode() []byte
+	// Encode returns a compressed byte representation of the public key.
+	// The compressed serialization concept is generic to elliptic curves,
+	// but we refer to individual curve parameters for details of the compressed format
+	EncodeCompressed() []byte
 	// Equals returns true if the given PublicKeys are equal. Keys are considered unequal if their algorithms are
 	// unequal or if their encoded representations are unequal. If the encoding of either key fails, they are considered
 	// unequal as well.

--- a/crypto/sign_test_utils.go
+++ b/crypto/sign_test_utils.go
@@ -134,6 +134,16 @@ func testEncodeDecode(t *testing.T, salg SigningAlgorithm) {
 		assert.Equal(t, pkBytes, pkCheckBytes, "keys should be equal")
 		distinctPkBytes := distinctSk.PublicKey().Encode()
 		assert.NotEqual(t, pkBytes, distinctPkBytes, "keys should be different")
+
+		// same for the compressed encoding
+		pkComprBytes := pk.EncodeCompressed()
+		pkComprCheck, err := DecodePublicKeyCompressed(salg, pkComprBytes)
+		require.Nil(t, err, "the key decoding has failed")
+		assert.True(t, pk.Equals(pkComprCheck), "key equality check failed")
+		pkCheckComprBytes := pkComprCheck.EncodeCompressed()
+		assert.Equal(t, pkComprBytes, pkCheckComprBytes, "keys should be equal")
+		distinctPkComprBytes := distinctSk.PublicKey().EncodeCompressed()
+		assert.NotEqual(t, pkComprBytes, distinctPkComprBytes, "keys should be different")
 	}
 
 	// test invalid private keys (equal to the curve group order)

--- a/network/p2p/keyTranslator.go
+++ b/network/p2p/keyTranslator.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/onflow/flow-go/crypto"
 	fcrypto "github.com/onflow/flow-go/crypto"
-
-	"github.com/btcsuite/btcd/btcec"
 )
 
 // This module is meant to help libp2p <-> flow public key conversions
@@ -145,9 +143,11 @@ func PublicKeyFromNetwork(lpk lcrypto.PubKey) (fcrypto.PublicKey, error) {
 		if !ok {
 			return nil, lcrypto.ErrBadKeyType
 		}
-		pk_uncompressed := (*btcec.PublicKey)(lpk_secp256k1).SerializeUncompressed()
-		// the first bit is the compression bit of X9.62
-		pk, err := crypto.DecodePublicKey(crypto.ECDSASecp256k1, pk_uncompressed[1:])
+		secpBytes, err := lpk_secp256k1.Raw()
+		if err != nil { // this never errors
+			return nil, lcrypto.ErrBadKeyType
+		}
+		pk, err := crypto.DecodePublicKeyCompressed(crypto.ECDSASecp256k1, secpBytes)
 		if err != nil {
 			return nil, lcrypto.ErrNotECDSAPubKey
 		}

--- a/network/p2p/keyTranslator.go
+++ b/network/p2p/keyTranslator.go
@@ -44,7 +44,7 @@ func setPubKey(c elliptic.Curve, x *big.Int, y *big.Int) *goecdsa.PublicKey {
 // These utility functions convert a Flow crypto key to a LibP2P key (Flow --> LibP2P)
 
 // PrivKey converts a Flow private key to a LibP2P Private key
-func PrivKey(fpk fcrypto.PrivateKey) (lcrypto.PrivKey, error) {
+func LibP2PPrivKeyFromFlow(fpk fcrypto.PrivateKey) (lcrypto.PrivKey, error) {
 	// get the signature algorithm
 	keyType, err := keyType(fpk.Algorithm())
 	if err != nil {
@@ -75,7 +75,7 @@ func PrivKey(fpk fcrypto.PrivateKey) (lcrypto.PrivKey, error) {
 }
 
 // PublicKey converts a Flow public key to a LibP2P public key
-func PublicKey(fpk fcrypto.PublicKey) (lcrypto.PubKey, error) {
+func LibP2PPublicKeyFromFlow(fpk fcrypto.PublicKey) (lcrypto.PubKey, error) {
 	keyType, err := keyType(fpk.Algorithm())
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func PublicKey(fpk fcrypto.PublicKey) (lcrypto.PubKey, error) {
 // This converts some libp2p PubKeys to a flow PublicKey
 // - the supported key types are ECDSA P-256 and ECDSA Secp256k1 public keys,
 // - libp2p also supports RSA and Ed25519 keys, which Flow doesn't, their conversion will return an error.
-func PublicKeyFromNetwork(lpk lcrypto.PubKey) (fcrypto.PublicKey, error) {
+func FlowPublicKeyFromLibP2P(lpk lcrypto.PubKey) (fcrypto.PublicKey, error) {
 
 	switch ktype := lpk.Type(); ktype {
 	case lcrypto_pb.KeyType_ECDSA:

--- a/network/p2p/keyTranslator_test.go
+++ b/network/p2p/keyTranslator_test.go
@@ -45,7 +45,7 @@ func (k *KeyTranslatorTestSuite) TestPrivateKeyConversion() {
 			require.NoError(k.T(), err)
 
 			// convert it to a LibP2P private key
-			lpk, err := PrivKey(fpk)
+			lpk, err := LibP2PPrivKeyFromFlow(fpk)
 			require.NoError(k.T(), err)
 
 			// get the raw bytes of both the keys
@@ -91,7 +91,7 @@ func (k *KeyTranslatorTestSuite) TestPublicKeyConversion() {
 			fpublic := fpk.PublicKey()
 
 			// convert the Flow public key to a Libp2p public key
-			lpublic, err := PublicKey(fpublic)
+			lpublic, err := LibP2PPublicKeyFromFlow(fpublic)
 			require.NoError(k.T(), err)
 
 			// compare raw bytes of the public keys
@@ -125,10 +125,10 @@ func (k *KeyTranslatorTestSuite) TestPublicKeyRoundTrip() {
 			fpublic := fpk.PublicKey()
 
 			// convert the Flow public key to a Libp2p public key
-			lpublic, err := PublicKey(fpublic)
+			lpublic, err := LibP2PPublicKeyFromFlow(fpublic)
 			require.NoError(k.T(), err)
 
-			fpublic2, err := PublicKeyFromNetwork(lpublic)
+			fpublic2, err := FlowPublicKeyFromLibP2P(lpublic)
 			require.NoError(k.T(), err)
 			require.Equal(k.T(), fpublic, fpublic2)
 
@@ -150,7 +150,7 @@ func (k *KeyTranslatorTestSuite) TestPeerIDGenerationIsConsistent() {
 	fpublic := fpk.PublicKey()
 
 	// convert it to the Libp2p Public key
-	lconverted, err := PublicKey(fpublic)
+	lconverted, err := LibP2PPublicKeyFromFlow(fpublic)
 	require.NoError(k.T(), err)
 
 	// check that the LibP2P Id generation is deterministic

--- a/network/p2p/keyTranslator_test.go
+++ b/network/p2p/keyTranslator_test.go
@@ -110,6 +110,33 @@ func (k *KeyTranslatorTestSuite) TestPublicKeyConversion() {
 	}
 }
 
+func (k *KeyTranslatorTestSuite) TestPublicKeyRoundTrip() {
+	sa := []fcrypto.SigningAlgorithm{fcrypto.ECDSAP256, fcrypto.ECDSASecp256k1}
+	loops := 50
+	for _, s := range sa {
+		for i := 0; i < loops; i++ {
+
+			// generate seed
+			seed := k.createSeed()
+			fpk, err := fcrypto.GeneratePrivateKey(s, seed)
+			require.NoError(k.T(), err)
+
+			// get the Flow public key
+			fpublic := fpk.PublicKey()
+
+			// convert the Flow public key to a Libp2p public key
+			lpublic, err := PublicKey(fpublic)
+			require.NoError(k.T(), err)
+
+			fpublic2, err := PublicKeyFromNetwork(lpublic)
+			require.NoError(k.T(), err)
+			require.Equal(k.T(), fpublic, fpublic2)
+
+		}
+	}
+
+}
+
 // TestLibP2PIDGenerationIsConsistent tests that a LibP2P peer ID generated using Flow ECDSA key is deterministic
 func (k *KeyTranslatorTestSuite) TestPeerIDGenerationIsConsistent() {
 	// generate a seed which will be used for both - Flow keys and Libp2p keys

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -655,9 +655,9 @@ func DefaultPubsubOptions(maxPubSubMsgSize int) []PubsubOption {
 	}
 	return []PubsubOption{
 		// skip message signing
-		pubSubOptionFunc(pubsub.WithMessageSigning(false)),
+		pubSubOptionFunc(pubsub.WithMessageSigning(true)),
 		// skip message signature
-		pubSubOptionFunc(pubsub.WithStrictSignatureVerification(false)),
+		pubSubOptionFunc(pubsub.WithStrictSignatureVerification(true)),
 		// set max message size limit for 1-k PubSub messaging
 		pubSubOptionFunc(pubsub.WithMaxMessageSize(maxPubSubMsgSize)),
 		// no discovery

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -598,7 +598,7 @@ func DefaultLibP2PHost(ctx context.Context, address string, key fcrypto.PrivateK
 // DefaultLibP2POptions creates and returns the standard LibP2P host options that are used for the Flow Libp2p network
 func DefaultLibP2POptions(address string, key fcrypto.PrivateKey) ([]config.Option, error) {
 
-	libp2pKey, err := PrivKey(key)
+	libp2pKey, err := LibP2PPrivKeyFromFlow(key)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate libp2p key: %w", err)
 	}

--- a/network/p2p/libp2pUtils.go
+++ b/network/p2p/libp2pUtils.go
@@ -106,7 +106,7 @@ func networkingInfo(identity flow.Identity) (string, string, crypto.PubKey, erro
 	}
 
 	// convert the Flow key to a LibP2P key
-	lkey, err := PublicKey(identity.NetworkPubKey)
+	lkey, err := LibP2PPublicKeyFromFlow(identity.NetworkPubKey)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("could not convert flow key to libp2p key: %w", err)
 	}

--- a/network/p2p/libp2pUtils_test.go
+++ b/network/p2p/libp2pUtils_test.go
@@ -53,7 +53,7 @@ func idsAndPeerInfos(t *testing.T) (flow.IdentityList, []peer.AddrInfo) {
 		ids[i] = id
 
 		// create a libp2p PeerAddressInfo
-		libp2pKey, err := PublicKey(id.NetworkPubKey)
+		libp2pKey, err := LibP2PPublicKeyFromFlow(id.NetworkPubKey)
 		assert.NoError(t, err)
 		peerID, err := peer.IDFromPublicKey(libp2pKey)
 		assert.NoError(t, err)

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -400,34 +400,30 @@ func (m *MiddlewareTestSuite) TestUnsubscribe() {
 		}
 	}
 
-	origin := 0
-	target := m.size - 1
-
-	originID := m.ids[origin].NodeID
 	message1 := createMessage(firstNode, lastNode, "hello1")
 
-	m.ov[target].On("Receive", originID, mockery.Anything).Return(nil).Once()
+	m.ov[last].On("Receive", firstNode, mockery.Anything).Return(nil).Once()
 
 	// first test that when both nodes are subscribed to the channel, the target node receives the message
-	err := m.mws[origin].Publish(message1, testChannel)
+	err := m.mws[first].Publish(message1, testChannel)
 	assert.NoError(m.T(), err)
 
 	assert.Eventually(m.T(), func() bool {
-		return m.ov[target].AssertCalled(m.T(), "Receive", originID, mockery.Anything)
+		return m.ov[last].AssertCalled(m.T(), "Receive", firstNode, mockery.Anything)
 	}, 2*time.Second, time.Millisecond)
 
 	// now unsubscribe the target node from the channel
-	err = m.mws[target].Unsubscribe(testChannel)
+	err = m.mws[last].Unsubscribe(testChannel)
 	assert.NoError(m.T(), err)
 
 	// create and send a new message on the channel from the origin node
 	message2 := createMessage(firstNode, lastNode, "hello2")
-	err = m.mws[origin].Publish(message2, testChannel)
+	err = m.mws[first].Publish(message2, testChannel)
 	assert.NoError(m.T(), err)
 
 	// assert that the new message is not received by the target node
 	assert.Never(m.T(), func() bool {
-		return !m.ov[target].AssertNumberOfCalls(m.T(), "Receive", 1)
+		return !m.ov[last].AssertNumberOfCalls(m.T(), "Receive", 1)
 	}, 2*time.Second, time.Millisecond)
 }
 

--- a/utils/grpc/grpc.go
+++ b/utils/grpc/grpc.go
@@ -24,7 +24,7 @@ const DefaultMaxMsgSize = 1024 * 1024 * 16
 func X509Certificate(privKey crypto.PrivateKey) (*tls.Certificate, error) {
 
 	// convert the Flow crypto private key to a Libp2p private crypto key
-	libP2PKey, err := p2p.PrivKey(privKey)
+	libP2PKey, err := p2p.LibP2PPrivKeyFromFlow(privKey)
 	if err != nil {
 		return nil, fmt.Errorf("could not convert Flow key to libp2p key: %w", err)
 	}
@@ -102,7 +102,7 @@ func DefaultClientTLSConfig(publicKey crypto.PublicKey) (*tls.Config, error) {
 func verifyPeerCertificateFunc(expectedPublicKey crypto.PublicKey) (func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error, error) {
 
 	// convert the Flow.crypto key to LibP2P key for easy comparision using LibP2P TLS utils
-	expectedLibP2PKey, err := p2p.PublicKey(expectedPublicKey)
+	expectedLibP2PKey, err := p2p.LibP2PPublicKeyFromFlow(expectedPublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate a libp2p key from a Flow key: %w", err)
 	}

--- a/utils/grpc/grpc_test.go
+++ b/utils/grpc/grpc_test.go
@@ -36,7 +36,7 @@ func TestCertificateGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	// convert the test key to a libp2p key for easy comparision
-	libp2pKey, err := p2p.PrivKey(key)
+	libp2pKey, err := p2p.LibP2PPrivKeyFromFlow(key)
 	expectedKey := libp2pKey.GetPublic()
 	require.NoError(t, err)
 


### PR DESCRIPTION
This:
- implements compressed (32/33 bytes instead of 64) (de)serialization for `crypto.PublicKey`. 
   + This is something we want to work on transitioning to more widely next cycle,
   + it's a milestone towards [#5739](https://github.com/dapperlabs/flow-go/issues/5739)
 - re-activates message signing and verification, closes [#5634](https://github.com/dapperlabs/flow-go/issues/5634)
 - ~~checks the OriginID contained in a message with respect to the (now cryptographically-verified) libp2p source, closes #1115~~
 
 Edit: Splitting this in 2 PRs, to work on the concurrency issues w/ @vishalchangrani : this is the straightwforward crypto PR that will go easier