### PR TITLE
skip returning error is an identity address on chain cannot be parsed

### DIFF
--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -536,7 +536,7 @@ func (n *Node) UpdateAllowList(identities flow.IdentityList) error {
 	for i, identity := range identities {
 		allowlist[i], err = PeerAddressInfo(*identity)
 		if err != nil {
-			return fmt.Errorf("could not generate address info: %w", err)
+			n.logger.Err(err).Str("identity", identity.String()).Msg("could not generate address info")
 		}
 	}
 

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -531,13 +531,14 @@ func (n *Node) UpdateAllowList(identities flow.IdentityList) error {
 	}
 
 	// generates peer address information for all identities
-	allowlist := make([]peer.AddrInfo, len(identities))
-	var err error
-	for i, identity := range identities {
-		allowlist[i], err = PeerAddressInfo(*identity)
+	allowlist := make([]peer.AddrInfo, 0, len(identities))
+	for _, identity := range identities {
+		addressInfo, err := PeerAddressInfo(*identity)
 		if err != nil {
 			n.logger.Err(err).Str("identity", identity.String()).Msg("could not generate address info")
+			continue
 		}
+		allowlist = append(allowlist, addressInfo)
 	}
 
 	n.connGater.update(allowlist)


### PR DESCRIPTION
Canary network nodes are currently down because of the following error:

> Aug 13 17:20:29 execution-001 docker[916872]: {"level":"fatal","node_role":"execution","node_id":"4beb93e69d8f3de3771336881b589330b1e1be7b0256467a36a1870855a2d828","error":"could not update approved peer list: could not generate address info: could not get translate identity to networking info 80514ec67dcd19a1000000000000000000000000000000000000000000000001: could not parse address ddba41333a7f7605ff0a5cd2d2966819c2c2aba71728826b5b10478dd49feec804a0eb063c3ffc2c55f76318f3f2386a181cbefbfb49495de2297bf5937a05ad: address ddba41333a7f7605ff0a5cd2d2966819c2c2aba71728826b5b10478dd49feec804a0eb063c3ffc2c55f76318f3f2386a181cbefbfb49495de2297bf5937a05ad: missing port in address","time":"2021-08-13T17:20:29Z","message":"failed to start middleware"}


There was some recent Flow port testing that was done which submitted an identity with an address which was missing the port field.

