### PR TITLE
increasing timeout of transit pull command to accommodate the download of the root.checkpoint

### DIFF
--- a/cmd/bootstrap/transit/cmd/pull.go
+++ b/cmd/bootstrap/transit/cmd/pull.go
@@ -13,6 +13,8 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+const timeout = 5 * time.Minute
+
 // pullCmd represents a command to pull keys and metadata from the Google bucket
 var pullCmd = &cobra.Command{
 	Use:   "pull",
@@ -38,7 +40,7 @@ func addPullCmdFlags() {
 func pull(cmd *cobra.Command, args []string) {
 	log.Info().Msg("running pull")
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	nodeID, err := readNodeID()

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -445,13 +445,14 @@ func (n *Node) Ping(ctx context.Context, identity flow.Identity) (message.PingRe
 // UpdateAllowList allows the peer allow list to be updated.
 func (n *Node) UpdateAllowList(identities flow.IdentityList) error {
 	// generates peer address information for all identities
-	allowlist := make([]peer.AddrInfo, len(identities))
-	var err error
-	for i, identity := range identities {
-		allowlist[i], err = PeerAddressInfo(*identity)
+	allowlist := make([]peer.AddrInfo, 0, len(identities))
+	for _, identity := range identities {
+		addressInfo, err := PeerAddressInfo(*identity)
 		if err != nil {
-			return fmt.Errorf("could not generate address info: %w", err)
+			n.logger.Err(err).Str("identity", identity.String()).Msg("could not generate address info")
+			continue
 		}
+		allowlist = append(allowlist, addressInfo)
 	}
 
 	n.connGater.update(allowlist)


### PR DESCRIPTION
T-systems ran into an issue in mainnet-8 spork where the transit script key timing out when trying to download root.checkpoint. `root.checkpoint` can be upwards of 18GB and may take more than 30 seconds to download.
Hence bumping up the timeout value for `transit pull`