### PR TITLE
add generic retry func

### DIFF
--- a/engine/consensus/dkg/messaging_engine.go
+++ b/engine/consensus/dkg/messaging_engine.go
@@ -128,7 +128,6 @@ func (e *MessagingEngine) forwardOutgoingMessages() {
 			}
 
 			retry.BackoffExponential(f, RETRY_MAX, RETRY_MILLISECONDS, e.log)
-
 		case <-e.unit.Quit():
 			return
 		}

--- a/engine/consensus/dkg/messaging_engine.go
+++ b/engine/consensus/dkg/messaging_engine.go
@@ -1,6 +1,7 @@
 package dkg
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/onflow/flow-go/utils/retry"
@@ -118,7 +119,7 @@ func (e *MessagingEngine) forwardOutgoingMessages() {
 	for {
 		select {
 		case msg := <-e.tunnel.MsgChOut:
-			f := func() error {
+			f := func(ctx context.Context) error {
 				err := e.conduit.Unicast(&msg.DKGMessage, msg.DestID)
 				if err != nil {
 					return fmt.Errorf("error sending dkg message: %v", err)
@@ -127,7 +128,7 @@ func (e *MessagingEngine) forwardOutgoingMessages() {
 				return nil
 			}
 
-			retry.BackoffExponential(f, RETRY_MAX, RETRY_MILLISECONDS, e.log)
+			retry.BackoffExponential(context.TODO(),"MessagingEngine.forwardOutgoingMessages", f, RETRY_MAX, RETRY_MILLISECONDS, e.log)
 		case <-e.unit.Quit():
 			return
 		}

--- a/engine/consensus/dkg/messaging_engine.go
+++ b/engine/consensus/dkg/messaging_engine.go
@@ -128,7 +128,7 @@ func (e *MessagingEngine) forwardOutgoingMessages() {
 				return nil
 			}
 
-			retry.BackoffExponential(context.TODO(),"MessagingEngine.forwardOutgoingMessages", f, RETRY_MAX, RETRY_MILLISECONDS, e.log)
+			retry.BackoffExponential(e.unit.Ctx(),"MessagingEngine.forwardOutgoingMessages", f, RETRY_MAX, RETRY_MILLISECONDS, e.log)
 		case <-e.unit.Quit():
 			return
 		}

--- a/engine/consensus/dkg/messaging_engine.go
+++ b/engine/consensus/dkg/messaging_engine.go
@@ -128,7 +128,7 @@ func (e *MessagingEngine) forwardOutgoingMessages() {
 				return nil
 			}
 
-			retry.BackoffExponential(e.unit.Ctx(),"MessagingEngine.forwardOutgoingMessages", f, RETRY_MAX, RETRY_MILLISECONDS, e.log)
+			retry.BackoffExponential(e.unit.Ctx(), "MessagingEngine.forwardOutgoingMessages", f, RETRY_MAX, RETRY_MILLISECONDS, e.log)
 		case <-e.unit.Quit():
 			return
 		}

--- a/module/dkg/broker.go
+++ b/module/dkg/broker.go
@@ -108,8 +108,8 @@ func (b *Broker) Broadcast(data []byte) {
 	}
 
 	success := retry.BackoffExponential(
-		"Broker.Broadcast",
 		context.TODO(),
+		"Broker.Broadcast",
 		func(ctx context.Context) error {
 			return b.dkgContractClient.Broadcast(bcastMsg)
 		},
@@ -182,8 +182,8 @@ func (b *Broker) Poll(referenceBlock flow.Identifier) error {
 // SubmitResult publishes the result of the DKG protocol to the smart contract.
 func (b *Broker) SubmitResult(pubKey crypto.PublicKey, groupKeys []crypto.PublicKey) error {
 	success := retry.BackoffExponential(
-		"Broker.SubmitResult",
 		context.TODO(),
+		"Broker.SubmitResult",
 		func(ctx context.Context) error {
 			return b.dkgContractClient.SubmitResult(pubKey, groupKeys)
 		},

--- a/module/dkg/broker.go
+++ b/module/dkg/broker.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/utils/retry"
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/fingerprint"
@@ -104,12 +105,13 @@ func (b *Broker) Broadcast(data []byte) {
 	if err != nil {
 		b.log.Fatal().Err(err).Msg("failed to create broadcast message")
 	}
-	success := b.retry(
+	success := retry.BackoffExponential(
 		func() error {
 			return b.dkgContractClient.Broadcast(bcastMsg)
 		},
 		RETRY_MAX,
 		RETRY_MILLISECONDS,
+		b.log,
 	)
 	if !success {
 		b.log.Error().Msg("failed to broadcast message")
@@ -175,12 +177,13 @@ func (b *Broker) Poll(referenceBlock flow.Identifier) error {
 
 // SubmitResult publishes the result of the DKG protocol to the smart contract.
 func (b *Broker) SubmitResult(pubKey crypto.PublicKey, groupKeys []crypto.PublicKey) error {
-	success := b.retry(
+	success := retry.BackoffExponential(
 		func() error {
 			return b.dkgContractClient.SubmitResult(pubKey, groupKeys)
 		},
 		RETRY_MAX,
 		RETRY_MILLISECONDS,
+		b.log,
 	)
 	if !success {
 		return fmt.Errorf("failed to submit dkg result")
@@ -275,21 +278,4 @@ func (b *Broker) verifyBroadcastMessage(bcastMsg messages.BroadcastDKGMessage) (
 		signData[:],
 		NewDKGMessageHasher(),
 	)
-}
-
-// retry makes maxRetry attempts to executed function f, with retryMilliseconds
-// between each attempt. It returns an error if all attemps failed.
-func (b *Broker) retry(f func() error, maxRetry int, retryMilliseconds int) bool {
-	success := false
-	for attempt := 1; attempt <= maxRetry; attempt++ {
-		err := f()
-		if err != nil {
-			b.log.Warn().Err(err).Msgf("attempt %d/%d failed", attempt, maxRetry)
-			time.Sleep(RETRY_MILLISECONDS * time.Millisecond)
-			continue
-		}
-		success = true
-		break
-	}
-	return success
 }

--- a/module/dkg/broker_test.go
+++ b/module/dkg/broker_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/messages"
 	msg "github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/local"
@@ -360,4 +363,48 @@ func TestLogHook(t *testing.T) {
 	sender.Disqualify(1, "testing")
 	sender.FlagMisbehavior(1, "test")
 	require.Equal(t, 2, hookCalls)
+}
+
+// TestRetry checks that the client is using the correct underlying retry mechanism
+func TestRetry(t *testing.T) {
+	committee, locals := initCommittee(2)
+
+	mockClient := &mock.DKGContractClient{}
+	sender := NewBroker(
+		zerolog.Nop(),
+		dkgInstanceID,
+		committee,
+		locals[orig],
+		orig,
+		mockClient,
+		NewBrokerTunnel(),
+	)
+
+	// configure the mock client to return an error, requiring a retry
+	expectedMsg, err := sender.prepareBroadcastMessage(msgb)
+	require.NoError(t, err)
+
+	const succeedAfterCalls = 2
+	calls := 0
+	mockClient.On("Broadcast", expectedMsg).Return(func(_ messages.BroadcastDKGMessage) error {
+		calls++
+		if calls <= succeedAfterCalls {
+			return fmt.Errorf("fake error")
+		}
+		return nil
+	}).Times(succeedAfterCalls + 1)
+
+	// Ensure first the aggregate time for the broadcast exceeds the sum of
+	// the expected between-retry wait periods. Since there are 2 failed calls
+	// then 1 successful calls, there are 2 wait periods with length m+m*2
+	before := time.Now()
+	sender.Broadcast(msgb)
+	after := time.Now()
+
+	actualDuration := after.Sub(before).Nanoseconds()
+	expectedMinimumDuration := ((RETRY_MILLISECONDS + RETRY_MILLISECONDS*2) * time.Millisecond).Nanoseconds()
+	assert.True(t, actualDuration >= expectedMinimumDuration)
+
+	// Ensure second that the expected number of calls to the underlying client are made
+	mockClient.AssertExpectations(t)
 }

--- a/module/epochs/base_client.go
+++ b/module/epochs/base_client.go
@@ -3,8 +3,9 @@ package epochs
 import (
 	"context"
 	"fmt"
-	"github.com/onflow/flow-go/utils/retry"
 	"time"
+
+	"github.com/onflow/flow-go/utils/retry"
 
 	"github.com/rs/zerolog"
 
@@ -16,7 +17,7 @@ import (
 
 const (
 	waitForSealedTimeout = 5 * time.Minute
-	waitForSealedRetry = 1000
+	waitForSealedRetry   = 1000
 )
 
 // BaseClient represents the core fields and methods needed to create
@@ -86,7 +87,7 @@ func (c *BaseClient) SendTransaction(ctx context.Context, tx *sdk.Transaction) (
 func (c *BaseClient) WaitForSealed(ctx context.Context, txID sdk.Identifier, started time.Time) error {
 	var (
 		result *sdk.TransactionResult
-		err error
+		err    error
 	)
 
 	f := func(context.Context) error {

--- a/module/epochs/base_client.go
+++ b/module/epochs/base_client.go
@@ -100,7 +100,9 @@ func (c *BaseClient) WaitForSealed(ctx context.Context, txID sdk.Identifier, sta
 	}
 
 	for {
-		retry.WithTimeout(ctx, "BaseClient.WaitForSealed", f, waitForSealedTimeout, waitForSealedRetry, c.Log)
+		log := c.Log.With().Float64("time_elapsed_s", time.Since(started).Seconds()).Logger()
+
+		retry.WithTimeout(ctx, "BaseClient.WaitForSealed", f, waitForSealedTimeout, waitForSealedRetry, log)
 
 		if result.Error != nil {
 			return fmt.Errorf("error executing transaction: %w", result.Error)

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -24,10 +24,6 @@ const (
 
 	// TransactionSubmissionTimeout is the time after which we return an error.
 	TransactionSubmissionTimeout = 5 * time.Minute
-
-	// TransactionStatusRetryTimeout is the time after which the status of a
-	// transaction is checked again
-	TransactionStatusRetryTimeout = 1 * time.Second
 )
 
 // QCContractClient is a client to the Quorum Certificate contract. Allows the client to

--- a/utils/retry/retry.go
+++ b/utils/retry/retry.go
@@ -57,4 +57,3 @@ func WithTimeout(ctx context.Context, retryFuncName string, f func(context.Conte
 		}
 	}
 }
-

--- a/utils/retry/retry.go
+++ b/utils/retry/retry.go
@@ -10,8 +10,8 @@ import (
 // BackoffExponential makes maxRetry attempts to executed function f. After the nth attempt,
 // we wait retryMilliseconds*2^n ms before retrying. Returns an error after
 // maxRetry unsuccessful attempts. It will short circuit if ctx is Done.
-func BackoffExponential(ctx context.Context, retryFuncName string, f func(context.Context) error, maxRetry int, retryMilliseconds int, logger zerolog.Logger) bool {
-	wait := time.Duration(retryMilliseconds) * time.Millisecond
+func BackoffExponential(ctx context.Context, retryFuncName string, f func(context.Context) error, maxRetry int, retryMilliseconds time.Duration, logger zerolog.Logger) bool {
+	wait := retryMilliseconds * time.Millisecond
 	for attempt := 1; attempt <= maxRetry; attempt++ {
 		err := f(ctx)
 		if err != nil {
@@ -32,8 +32,8 @@ func BackoffExponential(ctx context.Context, retryFuncName string, f func(contex
 
 // WithTimeout attempts to execute function f with a retryMilliseconds sleep in between attempts
 // until the function f either succeeds, context is done or timeout has been reached.
-func WithTimeout(ctx context.Context, retryFuncName string, f func(context.Context) error, timeoutDuration time.Duration, retryMilliseconds int, logger zerolog.Logger) bool {
-	ticker := time.Tick(time.Duration(retryMilliseconds) * time.Millisecond)
+func WithTimeout(ctx context.Context, retryFuncName string, f func(context.Context) error, timeoutDuration time.Duration, retryMilliseconds time.Duration, logger zerolog.Logger) bool {
+	wait := retryMilliseconds * time.Millisecond
 	attempt := 0
 
 	ctxWithTimeOut, cancel := context.WithTimeout(ctx, timeoutDuration)
@@ -43,8 +43,8 @@ func WithTimeout(ctx context.Context, retryFuncName string, f func(context.Conte
 	var err error
 	for {
 		select {
-		case <-ticker:
-			err = f(ctx)
+		case <-time.After(wait):
+			err = f(ctxWithTimeOut)
 			attempt++
 			if err != nil {
 				logger.Warn().Err(err).Str("retrying_func", retryFuncName).Msgf("attempt %d failed", attempt)

--- a/utils/retry/retry.go
+++ b/utils/retry/retry.go
@@ -1,0 +1,24 @@
+package retry
+
+import (
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// BackoffExponential makes maxRetry attempts to executed function f. After the nth attempt,
+// we wait retryMilliseconds*2^n ms before retrying. Returns an error after
+// maxRetry unsuccessful attempts.
+func BackoffExponential(f func() error, maxRetry int, retryMilliseconds int, logger zerolog.Logger) bool {
+	for attempt := 1; attempt <= maxRetry; attempt++ {
+		err := f()
+		if err != nil {
+			logger.Warn().Err(err).Msgf("attempt %d/%d failed", attempt, maxRetry)
+			wait := time.Duration(retryMilliseconds<<(attempt-1)) * time.Millisecond
+			time.Sleep(wait)
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/utils/retry/retry.go
+++ b/utils/retry/retry.go
@@ -10,12 +10,15 @@ import (
 // we wait retryMilliseconds*2^n ms before retrying. Returns an error after
 // maxRetry unsuccessful attempts.
 func BackoffExponential(f func() error, maxRetry int, retryMilliseconds int, logger zerolog.Logger) bool {
+	wait := time.Duration(retryMilliseconds) * time.Millisecond
 	for attempt := 1; attempt <= maxRetry; attempt++ {
 		err := f()
 		if err != nil {
 			logger.Warn().Err(err).Msgf("attempt %d/%d failed", attempt, maxRetry)
-			wait := time.Duration(retryMilliseconds<<(attempt-1)) * time.Millisecond
 			time.Sleep(wait)
+			wait <<= 1
+
+			logger.Info().Msgf("%v", wait)
 			continue
 		}
 		return true

--- a/utils/retry/retry_test.go
+++ b/utils/retry/retry_test.go
@@ -1,6 +1,7 @@
 package retry
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -22,7 +23,7 @@ func TestBackoffExponential(t *testing.T) {
 
 	calls := 0
 
-	fakeFunc := func() error {
+	fakeFunc := func(ctx context.Context) error {
 		calls++
 		if calls <= succeedAfterCalls {
 			return fmt.Errorf("fake error")
@@ -34,7 +35,8 @@ func TestBackoffExponential(t *testing.T) {
 	// the expected between-retry wait periods. Since there are 2 failed calls
 	// then 1 successful calls, there are 2 wait periods with length m+m*2
 	before := time.Now()
-	BackoffExponential(fakeFunc, retryMax, retryMilliseconds, zerolog.Nop())
+	ctx := context.Background()
+	BackoffExponential(ctx, "TestRetry", fakeFunc, retryMax, retryMilliseconds, zerolog.Nop())
 	after := time.Now()
 
 	actualDuration := after.Sub(before).Nanoseconds()
@@ -43,4 +45,37 @@ func TestBackoffExponential(t *testing.T) {
 
 	// Ensure second that the expected number of calls to the func are made
 	assert.True(t, calls == 3)
+}
+
+func TestWithTimeout(t *testing.T) {
+	const (
+		// retry_max is the maximum number of times the func to rey will be executed
+		timeoutDuration = 2 * time.Second
+
+		// retry_milliseconds is the number of milliseconds to wait between retries
+		retryMilliseconds = 1000
+	)
+
+	calls := 0
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelCtxAfter1Call := func(ctx context.Context) error {
+		calls++
+		if calls == 1 {
+			cancel()
+		}
+		return fmt.Errorf("fake error")
+	}
+	WithTimeout(ctx, "TestRetry", cancelCtxAfter1Call, timeoutDuration, retryMilliseconds, zerolog.Nop())
+
+	// ensure retry loop exits when ctx is cancelled and that the expected number of calls to the func are made
+	assert.True(t, calls == 1)
+
+	before := time.Now()
+	// ensure retry loop exits when timeout is reached
+	WithTimeout(context.Background(), "TestRetry", func(ctx context.Context) error {
+		return fmt.Errorf("fake error")
+	}, timeoutDuration, retryMilliseconds, zerolog.Nop())
+	after := time.Now()
+	actualDuration := after.Sub(before).Nanoseconds()
+	assert.True(t, actualDuration < (3*time.Second).Nanoseconds())
 }

--- a/utils/retry/retry_test.go
+++ b/utils/retry/retry_test.go
@@ -1,0 +1,46 @@
+package retry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoffExponential(t *testing.T) {
+	const (
+		// retry_max is the maximum number of times the func to rey will be executed
+		retryMax = 5
+
+		// retry_milliseconds is the number of milliseconds to wait between retries
+		retryMilliseconds = 1000
+
+		succeedAfterCalls = 2
+	)
+
+	calls := 0
+
+	fakeFunc := func() error {
+		calls++
+		if calls <= succeedAfterCalls {
+			return fmt.Errorf("fake error")
+		}
+		return nil
+	}
+
+	// Ensure first the aggregate time for the func execution exceeds the sum of
+	// the expected between-retry wait periods. Since there are 2 failed calls
+	// then 1 successful calls, there are 2 wait periods with length m+m*2
+	before := time.Now()
+	BackoffExponential(fakeFunc, retryMax, retryMilliseconds, zerolog.Nop())
+	after := time.Now()
+
+	actualDuration := after.Sub(before).Nanoseconds()
+	expectedMinimumDuration := ((retryMilliseconds + retryMilliseconds*2) * time.Millisecond).Nanoseconds()
+	assert.True(t, actualDuration >= expectedMinimumDuration)
+
+	// Ensure second that the expected number of calls to the func are made
+	assert.True(t, calls == 3)
+}


### PR DESCRIPTION
This PR refactors a generic try func into the utils dir as to stay DRY, and adds exponential backoff retry to DKG private message sending. 