### PR TITLE
[crypto] Unplug ValidSignatureBytesBLST

### DIFF
--- a/crypto/bls_crossBLST_test.go
+++ b/crypto/bls_crossBLST_test.go
@@ -131,9 +131,8 @@ func testEncodeDecodePublicKeyCrossBLST(t *rapid.T) {
 func testEncodeDecodeSignatureCrossBLST(t *rapid.T) {
 	randomSlice := rapid.SliceOfN(rapid.Byte(), SignatureLenBLSBLS12381, SignatureLenBLSBLS12381)
 	validSignatureFlow := rapid.Custom(validSignatureBytesFlow)
-	validSignatureBLST := rapid.Custom(validSignatureBytesBLST)
 	// sigBytes are bytes of either a valid or a random signature
-	sigBytes := rapid.OneOf(randomSlice, validSignatureFlow, validSignatureBLST).Example().([]byte)
+	sigBytes := rapid.OneOf(randomSlice, validSignatureFlow).Example().([]byte)
 
 	// check decoding results are consistent
 	var pointFlow pointG1


### PR DESCRIPTION
The blst keygen is unstable on 1.15 (in ways that are hard to reproduce), leading to CI failures. https://github.com/onflow/flow-go/pull/1119 disabled the use of the blst keygen in generating valid slices of scalar bytes for cross-testing bls.go with BLST, this completes the job in de-activating the use of the keygen for creating siganture material.
We leave the auxiliary functions in place for future upgrades (the blst keygen is stable on go 1.16 and some architectures on go 1.15)