### PR TITLE
[Consensus Voting] Handle Votes with invalid view

### DIFF
--- a/consensus/hotstuff/vote_collectors.go
+++ b/consensus/hotstuff/vote_collectors.go
@@ -12,16 +12,20 @@ import (
 type VoteCollectors interface {
 	// GetOrCreateCollector is used for getting hotstuff.VoteCollector.
 	// if there is no collector created or the given block ID, then it will create one.
-	// Collector is indexed by blockID for looking up by blockID, and also indexed by view for pruning.
+	// Collector is indexed by (blockID + view) for looking up collector by (blockID + view),
+	// and also indexed by view for pruning.
+	// Why indexing by blockID and view instead of blockID only?
+	// Because if a vote has incorrect view would cause us creating a vote collector indexed by
+	// a wrong view, and this vote collector might got pruned by the wrong view while it has
+	// collected votes from the valid block and other valid votes.
+	// Indexing by both blockID and view allows us to index vote collectors different for valid and
+	// invalid votes.
 	// When creating a vote collector, the view will be used to get epoch by view, then create the random beacon
 	// signer object by epoch, because epoch determines DKG, which determines random beacon committee.
 	// It returns:
 	//  -  (collector, true, nil) if no collector can be found by the block ID, and a new collector was created.
 	//  -  (collector, false, nil) if the collector can be found by the block ID
 	//  -  (nil, false, error) if running into any exception creating the vote collector state machine
-	// TODO: how to verify the view? if an invalid vote has an invalid view, then this method would be called with
-	// an invalid view. In that case, would we create a vote collector?
-	// indexed by a wrong view?
 	GetOrCreateCollector(view uint64, blockID flow.Identifier) (collector VoteCollector, created bool, err error)
 
 	// Prune the vote collectors whose view is below the given view

--- a/consensus/hotstuff/voteaggregator/vote_collectors.go
+++ b/consensus/hotstuff/voteaggregator/vote_collectors.go
@@ -2,6 +2,7 @@
 package voteaggregator
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
@@ -9,10 +10,22 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+type blockKey string
+
 type voteCollectors struct {
-	lock           sync.RWMutex
-	blockIDsByView map[uint64]map[flow.Identifier]struct{}    // for pruning
-	collectors     map[flow.Identifier]hotstuff.VoteCollector // blockID -> VoteCollector
+	lock sync.RWMutex
+
+	// for pruning by view
+	blockKeysByView map[uint64]map[blockKey]struct{}
+
+	// map of string(blockID+view) -> VoteCollector state machine
+	// collector are indexed by a block key, which is a combination of blockID and view.
+	// This is to handle the case where an invalid vote might have invalid view.
+	// If we have two different votes with the same blockID and different view,
+	// we will create two different VoteCollectors for each. When we receive the block, and
+	// learned one of the votes is valid, its VoteCollector will become VoteCollectorStatusVerifying,
+	// whereas the VoteCollector for the invalid vote will become VoteCollectorStatusInvalid.
+	collectors map[blockKey]hotstuff.VoteCollector
 }
 
 // GetOrCreateCollector performs lazy initialization of collectors based on their view and blockID
@@ -22,15 +35,14 @@ func (v *voteCollectors) GetOrCreateCollector(view uint64, blockID flow.Identifi
 
 // PruneUpToView prunes all collectors which target same view
 func (v *voteCollectors) PruneUpToView(view uint64) error {
-	v.lock.Lock()
-	defer v.lock.Unlock()
-	for blockID := range v.blockIDsByView[view] {
-		delete(v.collectors, blockID)
-	}
-	delete(v.blockIDsByView, view)
-	return nil
+	panic("implement me")
 }
 
 func (v *voteCollectors) ProcessBlock(block *model.Block) error {
 	panic("implement me")
+}
+
+func getBlockKey(view uint64, blockID flow.Identifier) blockKey {
+	key := fmt.Sprintf("%v-%v", blockID, view)
+	return blockKey(key)
 }

--- a/consensus/hotstuff/votecollector/statemachine.go
+++ b/consensus/hotstuff/votecollector/statemachine.go
@@ -28,6 +28,8 @@ type StateMachine struct {
 	createVerifyingCollector NewVerifyingCollectorFactoryMethod
 }
 
+var _ hotstuff.VoteCollector = &StateMachine{}
+
 func (m *StateMachine) atomicLoadCollector() hotstuff.VoteCollectorState {
 	return m.collector.Load().(*atomicValueWrapper).collector
 }


### PR DESCRIPTION
This PR handles a case for consensus voting v2 where vote aggregator processes an invalid vote with a wrong view.

A malicious node might be able to attack block rate by sending invalid votes to cause leader to drop valid votes.

How the attack might work before this fix:
Let's say there is a block A at view 20, and a node's finalized view is 5. so all vote collectors below view 5 have been pruned.
This node is the leader for view 10 and 20. A malicious node sends an invalid vote for blockA with view 10. The leader receives the vote, created a vote collector that is indexed by view 10 only. Later, this leader receives valid votes, and the block. These valid votes, and block are all stored in the vote collector that is indexed by the wrong view (10). 
Later on, block 15 is finalized, and we will prune all vote collectors including this vote collector that was indexed by view 10, which is incorrect. 
Since this vote collector has been pruned, which shouldn't, the valid votes along with the block are all dropped, the leader might not be able to collect enough votes for building QC.

The fix changes from indexing vote collector by block ID only to indexing by both blockID and view, such that votes with the same blockID but different views will be stored in different vote collectors.