### PR TITLE
[network] Validate Unstaked ID translation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/onflow/flow-emulator v0.20.3
 	github.com/onflow/flow-go-sdk v0.21.0
 	github.com/onflow/flow-go/crypto v0.18.0
-	github.com/onflow/flow/protobuf/go/flow v0.2.0
+	github.com/onflow/flow/protobuf/go/flow v0.2.2
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pelletier/go-toml v1.7.0 // indirect
 	github.com/pkg/errors v0.9.1
@@ -66,7 +66,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.31.0
 	google.golang.org/grpc v1.36.1
-	google.golang.org/protobuf v1.26.0
+	google.golang.org/protobuf v1.27.1
 	gotest.tools v2.2.0+incompatible
 	pgregory.net/rapid v0.4.7
 )

--- a/go.sum
+++ b/go.sum
@@ -969,8 +969,9 @@ github.com/onflow/flow-go-sdk v0.20.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae
 github.com/onflow/flow-go-sdk v0.21.0 h1:KRU6F80KZLD+CJLj57S2EaAPNJUx4qpFTw1Ok0AJZ1M=
 github.com/onflow/flow-go-sdk v0.21.0/go.mod h1:2xhtzwRAeItwbHQzHiIK2gPgLDw1hNPa0xYlpvx8Gx4=
 github.com/onflow/flow/protobuf/go/flow v0.1.9/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
-github.com/onflow/flow/protobuf/go/flow v0.2.0 h1:a4Cg0ekoqb76zeOEo1wtSWtlnhGXwcxebp0itFwGtlE=
 github.com/onflow/flow/protobuf/go/flow v0.2.0/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
+github.com/onflow/flow/protobuf/go/flow v0.2.2 h1:EVhA0w3lu+BG7RK39ojIJVghLH998iP7YC0V/Op0KnU=
+github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1673,8 +1674,9 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/network/p2p/unstaked_translator_test.go
+++ b/network/p2p/unstaked_translator_test.go
@@ -1,0 +1,98 @@
+package p2p
+
+import (
+	"crypto/rand"
+	"math"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+
+	fcrypto "github.com/onflow/flow-go/crypto"
+)
+
+// This test shows we can't use ECDSA P-256 keys for libp2p and expect PeerID <=> PublicKey bijections
+func TestIDTranslationP256(t *testing.T) {
+	loops := 50
+	for i := 0; i < loops; i++ {
+		pID := createPeerIDFromAlgo(t, fcrypto.ECDSAP256)
+
+		// check that we can not extract the public key back
+		// This makes sense: the x509 serialization of ECDSA P-256 keys in uncompressed form is 64 + 2 bytes,
+		// and libp2p uses multihash.IDENTITY only on serializations of less than 42 bytes
+		_, err := pID.ExtractPublicKey()
+		require.NotNil(t, err)
+
+	}
+}
+
+// This test shows we can use ECDSA Secp256k1 keys for libp2p and expect PeerID <=> PublicKey bijections
+func TestIDTranslationSecp256k1(t *testing.T) {
+	loops := 50
+	for i := 0; i < loops; i++ {
+		pID := createPeerIDFromAlgo(t, fcrypto.ECDSASecp256k1)
+
+		// check that we can extract the public key back
+		// This makes sense: the compressed serialization of ECDSA Secp256k1 keys is 33 + 2 bytes,
+		// and libp2p uses multihash.IDENTITY on serializations of less than 42 bytes
+		_, err := pID.ExtractPublicKey()
+		require.NoError(t, err)
+
+	}
+}
+
+func TestUnstakedTranslationRoundTrip(t *testing.T) {
+	loops := 50
+	unstakedTranslator := NewUnstakedNetworkIDTranslator()
+	for i := 0; i < loops; i++ {
+		pID := createPeerIDFromAlgo(t, fcrypto.ECDSASecp256k1)
+
+		pk, err := pID.ExtractPublicKey()
+		require.NoError(t, err)
+
+		// for a secp256k1 key, this is compressed representation preceded by 00 bits
+		// indicating the multihash.IDENTITY
+		pkBytes, err := pk.Raw()
+		require.NoError(t, err)
+
+		// key is positive, roundtrip should be possible
+		if pkBytes[0] == 0x02 {
+			flowID, err := unstakedTranslator.GetFlowID(pID)
+			require.NoError(t, err)
+			retrievedPeerID, err := unstakedTranslator.GetPeerID(flowID)
+			require.NoError(t, err)
+			require.Equal(t, pID, retrievedPeerID)
+		}
+
+	}
+}
+
+func createPeerIDFromAlgo(t *testing.T, sa fcrypto.SigningAlgorithm) peer.ID {
+	seed := createSeed(t)
+
+	// this matches GenerateNetworkingKeys, and is intended to validate the choices in cmd/bootstrap
+	key, err := fcrypto.GeneratePrivateKey(fcrypto.ECDSASecp256k1, seed)
+	require.NoError(t, err)
+
+	// get the public key
+	pubKey := key.PublicKey()
+
+	// extract the corresponding libp2p public Key
+	libp2pPubKey, err := LibP2PPublicKeyFromFlow(pubKey)
+	require.NoError(t, err)
+
+	// obtain the PeerID based on libp2p's own rules
+	pID, err := peer.IDFromPublicKey(libp2pPubKey)
+	require.NoError(t, err)
+
+	return pID
+}
+
+func createSeed(t *testing.T) []byte {
+	seedLen := int(math.Max(fcrypto.KeyGenSeedMinLenECDSAP256, fcrypto.KeyGenSeedMinLenECDSASecp256k1))
+	seed := make([]byte, seedLen)
+	n, err := rand.Read(seed)
+	require.NoError(t, err)
+	require.Equal(t, n, seedLen)
+	return seed
+}


### PR DESCRIPTION
This shows we need to use Secp256k1 on the bootstrap key generation for unstaked Access nodes (and positive keys at that), which I'll add in a further PR. 


Unit-tests and validates the ID translation for unstaked network.