### PR TITLE
[network] Check the originID in sendDirect too

### DIFF
--- a/network/p2p/middleware.go
+++ b/network/p2p/middleware.go
@@ -317,7 +317,7 @@ func (m *Middleware) handleIncomingStream(s libp2pnetwork.Stream) {
 	log.Info().Msg("incoming stream received")
 
 	//create a new readConnection with the context of the middleware
-	conn := newReadConnection(m.ctx, s, m.processMessage, log, m.metrics, LargeMsgMaxUnicastMsgSize)
+	conn := newReadConnection(m.ctx, s, m.processAuthenticatedMessage, log, m.metrics, LargeMsgMaxUnicastMsgSize)
 
 	// kick off the receive loop to continuously receive messages
 	m.wg.Add(1)

--- a/network/p2p/middleware.go
+++ b/network/p2p/middleware.go
@@ -362,6 +362,9 @@ func (m *Middleware) Unsubscribe(channel network.Channel) error {
 }
 
 // processAuthenticatedMessage processes a message and a source (indicated by its PublicKey) and eventually passes it to the overlay
+// In particular, it checks the claim of protocol authorship situated in the message against `originKey`
+// The assumption is that the message has been authenticated at the network level (libp2p) to origin at the network public key `originKey`
+// this requirement is fulfilled by e.g. the output of readConnection and readSubscription
 func (m *Middleware) processAuthenticatedMessage(msg *message.Message, originKey crypto.PublicKey) {
 	identities, err := m.ov.Identity()
 	if err != nil {


### PR DESCRIPTION
Follow-up to #1163.
This closes #1115 (finally) by adding anti-spoofing to `SendDirect` connections as well.