### PR TITLE
Khalil/5766 improve epochs metrics

### DIFF
--- a/module/metrics.go
+++ b/module/metrics.go
@@ -55,6 +55,10 @@ type ComplianceMetrics interface {
 	BlockProposalDuration(duration time.Duration)
 	CurrentEpochCounter(counter uint64)
 	CurrentEpochPhase(phase flow.EpochPhase)
+	CurrentEpochFinalView(view uint64)
+	CurrentDKGPhase1FinalView(view uint64)
+	CurrentDKGPhase2FinalView(view uint64)
+	CurrentDKGPhase3FinalView(view uint64)
 }
 
 type CleanerMetrics interface {

--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -10,18 +10,22 @@ import (
 )
 
 type ComplianceCollector struct {
-	finalizedHeight          prometheus.Gauge
-	sealedHeight             prometheus.Gauge
-	finalizedBlocks          *prometheus.CounterVec
-	sealedBlocks             prometheus.Counter
-	blockProposalDuration    prometheus.Counter
-	finalizedPayload         *prometheus.CounterVec
-	sealedPayload            *prometheus.CounterVec
-	lastBlockFinalizedAt     time.Time
-	finalizedBlocksPerSecond prometheus.Summary
-	committedEpochFinalView  prometheus.Gauge
-	currentEpochCounter      prometheus.Gauge
-	currentEpochPhase        prometheus.Gauge
+	finalizedHeight           prometheus.Gauge
+	sealedHeight              prometheus.Gauge
+	finalizedBlocks           *prometheus.CounterVec
+	sealedBlocks              prometheus.Counter
+	blockProposalDuration     prometheus.Counter
+	finalizedPayload          *prometheus.CounterVec
+	sealedPayload             *prometheus.CounterVec
+	lastBlockFinalizedAt      time.Time
+	finalizedBlocksPerSecond  prometheus.Summary
+	committedEpochFinalView   prometheus.Gauge
+	currentEpochCounter       prometheus.Gauge
+	currentEpochPhase         prometheus.Gauge
+	currentEpochFinalView     prometheus.Gauge
+	currentDKGPhase1FinalView prometheus.Gauge
+	currentDKGPhase2FinalView prometheus.Gauge
+	currentDKGPhase3FinalView prometheus.Gauge
 }
 
 func NewComplianceCollector() *ComplianceCollector {
@@ -47,6 +51,33 @@ func NewComplianceCollector() *ComplianceCollector {
 			Namespace: namespaceConsensus,
 			Subsystem: subsystemCompliance,
 			Help:      "the final view of the committed epoch with the greatest counter",
+		}),
+
+		currentEpochFinalView: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "current_epoch_final_view",
+			Namespace: namespaceConsensus,
+			Subsystem: subsystemCompliance,
+			Help:      "the final view of the current epoch with the greatest counter",
+		}),
+
+		currentDKGPhase1FinalView: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "current_dkg_phase1_final_view",
+			Namespace: namespaceConsensus,
+			Subsystem: subsystemCompliance,
+			Help:      "the final view of phase 1 of the current epochs DKG with the greatest counter",
+		}),
+		currentDKGPhase2FinalView: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "current_dkg_phase1_final_view",
+			Namespace: namespaceConsensus,
+			Subsystem: subsystemCompliance,
+			Help:      "the final view of phase 2 of current epochs DKG with the greatest counter",
+		}),
+
+		currentDKGPhase3FinalView: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "current_dkg_phase3_final_view",
+			Namespace: namespaceConsensus,
+			Subsystem: subsystemCompliance,
+			Help:      "the final view of phase 3 of the current epochs DKG with the greatest counter",
 		}),
 
 		finalizedHeight: promauto.NewGauge(prometheus.GaugeOpts{
@@ -163,4 +194,20 @@ func (cc *ComplianceCollector) CurrentEpochCounter(counter uint64) {
 
 func (cc *ComplianceCollector) CurrentEpochPhase(phase flow.EpochPhase) {
 	cc.currentEpochCounter.Set(float64(phase))
+}
+
+func (cc *ComplianceCollector) CurrentEpochFinalView(view uint64) {
+	cc.currentEpochFinalView.Set(float64(view))
+}
+
+func (cc *ComplianceCollector) CurrentDKGPhase1FinalView(view uint64) {
+	cc.currentDKGPhase1FinalView.Set(float64(view))
+}
+
+func (cc *ComplianceCollector) CurrentDKGPhase2FinalView(view uint64) {
+	cc.currentDKGPhase2FinalView.Set(float64(view))
+}
+
+func (cc *ComplianceCollector) CurrentDKGPhase3FinalView(view uint64) {
+	cc.currentDKGPhase3FinalView.Set(float64(view))
 }

--- a/module/metrics/compliance.go
+++ b/module/metrics/compliance.go
@@ -67,7 +67,7 @@ func NewComplianceCollector() *ComplianceCollector {
 			Help:      "the final view of phase 1 of the current epochs DKG with the greatest counter",
 		}),
 		currentDKGPhase2FinalView: promauto.NewGauge(prometheus.GaugeOpts{
-			Name:      "current_dkg_phase1_final_view",
+			Name:      "current_dkg_phase2_final_view",
 			Namespace: namespaceConsensus,
 			Subsystem: subsystemCompliance,
 			Help:      "the final view of phase 2 of current epochs DKG with the greatest counter",

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -47,6 +47,10 @@ func (nc *NoopCollector) BlockProposalDuration(duration time.Duration)          
 func (nc *NoopCollector) CommittedEpochFinalView(view uint64)                                    {}
 func (nc *NoopCollector) CurrentEpochCounter(counter uint64)                                     {}
 func (nc *NoopCollector) CurrentEpochPhase(phase flow.EpochPhase)                                {}
+func (nc *NoopCollector) CurrentEpochFinalView(view uint64)                                      {}
+func (nc *NoopCollector) CurrentDKGPhase1FinalView(view uint64)                                  {}
+func (nc *NoopCollector) CurrentDKGPhase2FinalView(view uint64)                                  {}
+func (nc *NoopCollector) CurrentDKGPhase3FinalView(view uint64)                                  {}
 func (nc *NoopCollector) CacheEntries(resource string, entries uint)                             {}
 func (nc *NoopCollector) CacheHit(resource string)                                               {}
 func (nc *NoopCollector) CacheNotFound(resource string)                                          {}

--- a/module/mock/compliance_metrics.go
+++ b/module/mock/compliance_metrics.go
@@ -34,9 +34,29 @@ func (_m *ComplianceMetrics) CommittedEpochFinalView(view uint64) {
 	_m.Called(view)
 }
 
+// CurrentDKGPhase1FinalView provides a mock function with given fields: view
+func (_m *ComplianceMetrics) CurrentDKGPhase1FinalView(view uint64) {
+	_m.Called(view)
+}
+
+// CurrentDKGPhase2FinalView provides a mock function with given fields: view
+func (_m *ComplianceMetrics) CurrentDKGPhase2FinalView(view uint64) {
+	_m.Called(view)
+}
+
+// CurrentDKGPhase3FinalView provides a mock function with given fields: view
+func (_m *ComplianceMetrics) CurrentDKGPhase3FinalView(view uint64) {
+	_m.Called(view)
+}
+
 // CurrentEpochCounter provides a mock function with given fields: counter
 func (_m *ComplianceMetrics) CurrentEpochCounter(counter uint64) {
 	_m.Called(counter)
+}
+
+// CurrentEpochFinalView provides a mock function with given fields: view
+func (_m *ComplianceMetrics) CurrentEpochFinalView(view uint64) {
+	_m.Called(view)
 }
 
 // CurrentEpochPhase provides a mock function with given fields: phase

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -470,6 +470,20 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		metrics.On("CurrentEpochPhase", initialPhase).Once()
 		metrics.On("CommittedEpochFinalView", finalView).Once()
 
+		metrics.On("CurrentEpochFinalView", finalView).Once()
+
+		currentDKGPhase1FinalView, err := initialCurrentEpoch.DKGPhase1FinalView()
+		require.NoError(t, err)
+		metrics.On("CurrentDKGPhase1FinalView", currentDKGPhase1FinalView).Once()
+
+		currentDKGPhase2FinalView, err := initialCurrentEpoch.DKGPhase2FinalView()
+		require.NoError(t, err)
+		metrics.On("CurrentDKGPhase2FinalView", currentDKGPhase2FinalView).Once()
+
+		currentDKGPhase3FinalView, err := initialCurrentEpoch.DKGPhase3FinalView()
+		require.NoError(t, err)
+		metrics.On("CurrentDKGPhase3FinalView", currentDKGPhase3FinalView).Once()
+
 		tracer := trace.NewNoopTracer()
 		headers, _, seals, index, payloads, blocks, setups, commits, statuses, results := storeutil.StorageLayer(t, db)
 		protoState, err := protocol.Bootstrap(metrics, db, headers, seals, results, blocks, setups, commits, statuses, rootSnapshot)

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -514,13 +514,12 @@ func (state *State) updateEpochMetrics(snap protocol.Snapshot) error {
 		return fmt.Errorf("could not update committed epoch final view")
 	}
 
-	//@TODO add metrics for Final view of current epoch
 	currentEpochFinalView, err := snap.Epochs().Current().FinalView()
 	if err != nil {
 		return fmt.Errorf("could not update current epoch final view")
 	}
 	state.metrics.CurrentEpochFinalView(currentEpochFinalView)
-	
+
 	// update dkg phase 1 final view
 	dkgPhase1FinalView, err := snap.Epochs().Current().DKGPhase1FinalView()
 	if err != nil {

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -514,6 +514,34 @@ func (state *State) updateEpochMetrics(snap protocol.Snapshot) error {
 		return fmt.Errorf("could not update committed epoch final view")
 	}
 
+	//@TODO add metrics for Final view of current epoch
+	currentEpochFinalView, err := snap.Epochs().Current().FinalView()
+	if err != nil {
+		return fmt.Errorf("could not update current epoch final view")
+	}
+	state.metrics.CurrentEpochFinalView(currentEpochFinalView)
+	
+	// update dkg phase 1 final view
+	dkgPhase1FinalView, err := snap.Epochs().Current().DKGPhase1FinalView()
+	if err != nil {
+		return fmt.Errorf("could not update current dkg phase 1 final view")
+	}
+	state.metrics.CurrentDKGPhase1FinalView(dkgPhase1FinalView)
+
+	// update dkg phase 2 final view
+	dkgPhase2FinalView, err := snap.Epochs().Current().DKGPhase2FinalView()
+	if err != nil {
+		return fmt.Errorf("could not update current dkg phase 2 final view")
+	}
+	state.metrics.CurrentDKGPhase2FinalView(dkgPhase2FinalView)
+
+	// update dkg phase 3 final view
+	dkgPhase3FinalView, err := snap.Epochs().Current().DKGPhase3FinalView()
+	if err != nil {
+		return fmt.Errorf("could not update current dkg phase 3 final view")
+	}
+	state.metrics.CurrentDKGPhase3FinalView(dkgPhase3FinalView)
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds the following metrics

- consensus_compliance_**_current_epoch_final_view_** : the final view of the current epoch with the greatest counter
- consensus_compliance_**_current_dkg_phase1_final_view_**: the final view of phase 1 of the current epochs DKG with the greatest counter
- consensus_compliance_**_current_dkg_phase2_final_view_**: the final view of phase 2 of the current epochs DKG with the greatest counter
- consensus_compliance_**_current_dkg_phase3_final_view_**: the final view of phase 3 of the current epochs DKG with the greatest counter