### PR TITLE
Remove storage multierror from v0.20

### DIFF
--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -3,7 +3,6 @@ package fvm
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/onflow/cadence/runtime/common"
 
 	errors "github.com/onflow/flow-go/fvm/errors"
@@ -19,7 +18,7 @@ func NewTransactionStorageLimiter() *TransactionStorageLimiter {
 func (d *TransactionStorageLimiter) CheckLimits(
 	env Enviornment,
 	addresses []flow.Address,
-) (err error) {
+) error {
 	if !env.Context().LimitAccountStorage {
 		return nil
 	}
@@ -27,25 +26,19 @@ func (d *TransactionStorageLimiter) CheckLimits(
 	for _, address := range addresses {
 		commonAddress := common.BytesToAddress(address.Bytes())
 
-		capacity, aerr := env.GetStorageCapacity(commonAddress)
-		if aerr != nil {
-			aerr = fmt.Errorf("storage limit check failed: %w", aerr)
-			err = multierror.Append(err, aerr)
-			continue
+		capacity, err := env.GetStorageCapacity(commonAddress)
+		if err != nil {
+			return fmt.Errorf("storage limit check failed: %w", err)
 		}
 
-		usage, aerr := env.GetStorageUsed(commonAddress)
-		if aerr != nil {
-			aerr = fmt.Errorf("storage limit check failed: %w", aerr)
-			err = multierror.Append(err, aerr)
-			continue
+		usage, err := env.GetStorageUsed(commonAddress)
+		if err != nil {
+			return fmt.Errorf("storage limit check failed: %w", err)
 		}
 
 		if usage > capacity {
-			err = multierror.Append(err, errors.NewStorageCapacityExceededError(address, usage, capacity))
-			continue
+			return errors.NewStorageCapacityExceededError(address, usage, capacity)
 		}
 	}
-
-	return
+	return nil
 }


### PR DESCRIPTION
This relates to: https://github.com/onflow/flow-go/pull/1175

In https://github.com/onflow/flow-go/pull/1175 two separate things were done to fix iterating (and exiting early) over a random list:
1. order the list
2. don't exit early and use multierror to aggregate the errors if there is more then one.

Only one of these measures is actually required to solve the problem. Since number 2 introduces new error semantics it is better to remove that part from the v0.20 branch, and just go with number 1 for any patches.

Number 2. can go into the next spork the usual way.

This PR reverts number 2 from v0.20.


