### PR TITLE
[Consensus Voting] Use DKG Signer

### DIFF
--- a/consensus/hotstuff/verification/combined_signer_v2.go
+++ b/consensus/hotstuff/verification/combined_signer_v2.go
@@ -1,0 +1,124 @@
+package verification
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/consensus/hotstuff"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+)
+
+// CombinedSignerV2 is a signer capable of creating two signatures for each signing
+// operation, combining them and adding them as the signature data on the generated
+// data structures. The first type is an aggregating signer, which creates single
+// signatures that can be aggregated into a single aggregated signature. The second
+// type is a threshold signer, which creates threshold signature shares, which can
+// be used to reconstruct a threshold signature.
+type CombinedSignerV2 struct {
+	*CombinedVerifier
+	staking              module.AggregatingSigner
+	merger               module.Merger
+	thresholdSignerStore module.ThresholdSignerStoreV2
+	signerID             flow.Identifier
+}
+
+// NewCombinedSignerV2 creates a new combined signer with the given dependencies:
+// - the hotstuff committee's state is used to retrieve public keys for signers;
+// - the staking signer is used to create and verify aggregatable signatures for the first signature part;
+// - the thresholdVerifier is used to verify threshold signatures
+// - the merger is used to join and split the two signature parts on our models;
+// - the thresholdSignerStore is used to get threshold-signers by epoch/view;
+// - the signer ID is used as the identity when creating signatures;
+func NewCombinedSignerV2(
+	committee hotstuff.Committee,
+	staking module.AggregatingSigner,
+	thresholdVerifier module.ThresholdVerifier,
+	merger module.Merger,
+	thresholdSignerStore module.ThresholdSignerStore,
+	signerID flow.Identifier) *CombinedSignerV2 {
+
+	sc := &CombinedSignerV2{
+		CombinedVerifier:     NewCombinedVerifier(committee, staking, thresholdVerifier, merger),
+		staking:              staking,
+		merger:               merger,
+		thresholdSignerStore: thresholdSignerStore,
+		signerID:             signerID,
+	}
+	return sc
+}
+
+// CreateProposal will create a proposal with a combined signature for the given block.
+func (c *CombinedSignerV2) CreateProposal(block *model.Block) (*model.Proposal, error) {
+
+	// check that the block is created by us
+	if block.ProposerID != c.signerID {
+		return nil, fmt.Errorf("can't create proposal for someone else's block")
+	}
+
+	// create the signature data
+	sigData, err := c.genSigData(block)
+	if err != nil {
+		return nil, fmt.Errorf("could not create signature: %w", err)
+	}
+
+	// create the proposal
+	proposal := &model.Proposal{
+		Block:   block,
+		SigData: sigData,
+	}
+
+	return proposal, nil
+}
+
+// CreateVote will create a vote with a combined signature for the given block.
+func (c *CombinedSignerV2) CreateVote(block *model.Block) (*model.Vote, error) {
+
+	// create the signature data
+	sigData, err := c.genSigData(block)
+	if err != nil {
+		return nil, fmt.Errorf("could not create signature: %w", err)
+	}
+
+	// create the vote
+	vote := &model.Vote{
+		View:     block.View,
+		BlockID:  block.BlockID,
+		SignerID: c.signerID,
+		SigData:  sigData,
+	}
+
+	return vote, nil
+}
+
+// genSigData generates the signature data for our local node for the given block.
+func (c *CombinedSignerV2) genSigData(block *model.Block) ([]byte, error) {
+
+	// create the message to be signed and generate signatures
+	msg := MakeVoteMessage(block.View, block.BlockID)
+
+	beacon, hasBeaconSigner, err := c.thresholdSignerStore.GetThresholdSigner(block.View)
+	if err != nil {
+		return nil, fmt.Errorf("could not get threshold signer for view %d: %w", block.View, err)
+	}
+
+	// if the node is a DKG node and has completed DKG, then using the random beacon key
+	// to sign the block
+	if hasBeaconSigner {
+		beaconShare, err := beacon.Sign(msg)
+		if err != nil {
+			return nil, fmt.Errorf("could not generate beacon signature: %w", err)
+		}
+		return beaconShare, nil
+	}
+
+	// if the node didn't complete DKG, then using the staking key to sign the block as a
+	// fallback
+
+	stakingSig, err := c.staking.Sign(msg)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate staking signature: %w", err)
+	}
+
+	return stakingSig
+}

--- a/consensus/hotstuff/verification/combined_signer_v2.go
+++ b/consensus/hotstuff/verification/combined_signer_v2.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/consensus/hotstuff/signature"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 )
@@ -109,7 +110,8 @@ func (c *CombinedSignerV2) genSigData(block *model.Block) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not generate beacon signature: %w", err)
 		}
-		return beaconShare, nil
+
+		return signature.EncodeSingleSig(hotstuff.SigTypeRandomBeacon, beaconShare), nil
 	}
 
 	// if the node didn't complete DKG, then using the staking key to sign the block as a
@@ -120,5 +122,5 @@ func (c *CombinedSignerV2) genSigData(block *model.Block) ([]byte, error) {
 		return nil, fmt.Errorf("could not generate staking signature: %w", err)
 	}
 
-	return stakingSig
+	return signature.EncodeSingleSig(hotstuff.SigTypeStaking, stakingSig)
 }

--- a/module/signature/dkg_signer.go
+++ b/module/signature/dkg_signer.go
@@ -1,0 +1,40 @@
+// +build !relic
+
+package signature
+
+import (
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/model/encodable"
+	"github.com/onflow/flow-go/module"
+)
+
+type DKGVerifier struct {
+	hasher hash.Hasher
+}
+
+func NewDKGVerifier(tag string) *DKGVerifier {
+	return &DKGVerifier{
+		hasher: crypto.NewBLSKMAC(tag),
+	}
+}
+
+func (v *DKGVerifier) Verify(msg []byte, sig crypto.Signature, key crypto.PublicKey) (bool, error) {
+	return key.Verify(sig, msg, v.hasher)
+}
+
+type DKGSigner struct {
+	*DKGVerifier
+	privKey crypto.PrivateKey
+}
+
+func NewDKGSigner(tag string, privKey encodable.RandomBeaconPrivKey) module.Signer {
+	return &DKGSigner{
+		DKGVerifier: NewDKGVerifier(tag),
+		privKey:     privKey,
+	}
+}
+
+func (s *DKGSigner) Sign(msg []byte) (crypto.Signature, error) {
+	return s.privKey.Sign(msg, s.hasher)
+}

--- a/module/signature/signer_store.go
+++ b/module/signature/signer_store.go
@@ -10,12 +10,12 @@ import (
 )
 
 // EpochAwareSignerStore implements the SignerStore interface. It is epoch
-// aware, and provides the appropriate threshold signers on a per-view basis,
+// aware, and provides the appropriate dkg signers on a per-view basis,
 // using the database to retrieve the relevant DKG keys.
 type EpochAwareSignerStore struct {
-	epochLookup module.EpochLookup                // used to fetch epoch counter by view
-	keys        storage.DKGKeys                   // used to fetch DKG private key by epoch
-	signers     map[uint64]module.ThresholdSigner // cache of signers by epoch
+	epochLookup module.EpochLookup       // used to fetch epoch counter by view
+	keys        storage.DKGKeys          // used to fetch DKG private key by epoch
+	signers     map[uint64]module.Signer // cache of signers by epoch
 }
 
 // NewEpochAwareSignerStore instantiates a new EpochAwareSignerStore
@@ -23,14 +23,14 @@ func NewEpochAwareSignerStore(epochLookup module.EpochLookup, keys storage.DKGKe
 	return &EpochAwareSignerStore{
 		epochLookup: epochLookup,
 		keys:        keys,
-		signers:     make(map[uint64]module.ThresholdSigner),
+		signers:     make(map[uint64]module.Signer),
 	}
 }
 
-// GetThresholdSigner returns the threshold-signer for signing objects at a
+// GetSigner returns the threshold-signer for signing objects at a
 // given view. The view determines the epoch, which determines the DKG private
 // key underlying the signer.
-func (s *EpochAwareSignerStore) GetThresholdSigner(view uint64) (module.ThresholdSigner, bool, error) {
+func (s *EpochAwareSignerStore) GetSigner(view uint64) (module.Signer, bool, error) {
 	epoch, err := s.epochLookup.EpochForView(view)
 	if err != nil {
 		return nil, false, fmt.Errorf("could not get epoch by view: %v, %w", view, err)
@@ -67,17 +67,17 @@ func (s *EpochAwareSignerStore) GetThresholdSigner(view uint64) (module.Threshol
 // keeps one signer and is not epoch-aware. It is used only for the
 // bootstrapping process.
 type SingleSignerStore struct {
-	signer module.ThresholdSigner
+	signer module.Signer
 }
 
 // NewSingleSignerStore instantiates a new SingleSignerStore.
-func NewSingleSignerStore(signer module.ThresholdSigner) *SingleSignerStore {
+func NewSingleSignerStore(signer module.Signer) *SingleSignerStore {
 	return &SingleSignerStore{
 		signer: signer,
 	}
 }
 
 // GetThresholdSigner returns the signer.
-func (s *SingleSignerStore) GetThresholdSigner(view uint64) (module.ThresholdSigner, error) {
+func (s *SingleSignerStore) GetSigner(view uint64) (module.Signer, error) {
 	return s.signer, nil
 }

--- a/module/signer.go
+++ b/module/signer.go
@@ -30,3 +30,12 @@ type ThresholdSigner interface {
 type ThresholdSignerStore interface {
 	GetThresholdSigner(view uint64) (ThresholdSigner, error)
 }
+
+// ThresholdSignerStoreV2 returns the threshold signer object by view
+// It returns:
+//  - (signer, true, nil) if DKG was completed in the epoch of the view
+//  - (nil, false, nil) if DKG was not completed in the epoch of the view
+//  - (nil, false, err) if there is any exception
+type ThresholdSignerStoreV2 interface {
+	GetThresholdSigner(view uint64) (ThresholdSigner, bool, error)
+}

--- a/module/signer.go
+++ b/module/signer.go
@@ -31,11 +31,11 @@ type ThresholdSignerStore interface {
 	GetThresholdSigner(view uint64) (ThresholdSigner, error)
 }
 
-// ThresholdSignerStoreV2 returns the threshold signer object by view
+// DKGSignerStore returns the threshold signer object by view
 // It returns:
 //  - (signer, true, nil) if DKG was completed in the epoch of the view
 //  - (nil, false, nil) if DKG was not completed in the epoch of the view
 //  - (nil, false, err) if there is any exception
-type ThresholdSignerStoreV2 interface {
-	GetThresholdSigner(view uint64) (ThresholdSigner, bool, error)
+type DKGSignerStore interface {
+	GetSigner(view uint64) (Signer, bool, error)
 }


### PR DESCRIPTION
In consensus cluster, when Block Producer and Voter signs a block, it might use the random beacon key to sign the block. Currently, we use a ThresholdSigner object to sig the block, but actually is not necessary. 

Since the signing a block can be done in a contextless manner, we can replace the ThresholdSigner object with a single module that is holding the private key for signing. And the ThresholdSigner object will be used by the VoteCollector to verify and store the vote signatures.