### PR TITLE
Use the correct type in NewThresholdSigner

### DIFF
--- a/module/signature/threshold_non_relic.go
+++ b/module/signature/threshold_non_relic.go
@@ -3,11 +3,11 @@
 package signature
 
 import (
-	"github.com/onflow/flow-go/model/encodable"
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/module"
 )
 
-func NewThresholdProvider(_ string, _ encodable.RandomBeaconPrivKey) module.ThresholdSigner {
+func NewThresholdProvider(_ string, _ crypto.PrivateKey) module.ThresholdSigner {
 	panic("NewThresholdProvider not supported with non-relic build")
 }
 


### PR DESCRIPTION
Previously, this was inconsistent with the `relic` version of the file, so that builds not using `relic` importing this package failed to compile.