### PR TITLE
Remove flags for seeding key generation tool

### DIFF
--- a/cmd/bootstrap/cmd/key.go
+++ b/cmd/bootstrap/cmd/key.go
@@ -42,13 +42,24 @@ func init() {
 	keyCmd.Flags().StringVar(&flagAddress, "address", "", "network address")
 	_ = keyCmd.MarkFlagRequired("address")
 
-	keyCmd.Flags().BytesHexVar(&flagNetworkSeed, "networking-seed", GenerateRandomSeed(), fmt.Sprintf("hex encoded networking seed (min %v bytes)", minSeedBytes))
-	keyCmd.Flags().BytesHexVar(&flagStakingSeed, "staking-seed", GenerateRandomSeed(), fmt.Sprintf("hex encoded staking seed (min %v bytes)", minSeedBytes))
-	keyCmd.Flags().BytesHexVar(&flagMachineSeed, "machine-seed", GenerateRandomSeed(), fmt.Sprintf("hex encoded machine account seed (min %v bytes)", minSeedBytes))
+	keyCmd.Flags().BytesHexVar(&flagNetworkSeed, "networking-seed", []byte{}, fmt.Sprintf("hex encoded networking seed (min %d bytes)", minSeedBytes))
+	keyCmd.Flags().BytesHexVar(&flagStakingSeed, "staking-seed", []byte{}, fmt.Sprintf("hex encoded staking seed (min %d bytes)", minSeedBytes))
+	keyCmd.Flags().BytesHexVar(&flagMachineSeed, "machine-seed", []byte{}, fmt.Sprintf("hex encoded machine account seed (min %d bytes)", minSeedBytes))
 }
 
 // keyCmdRun generate the node staking key, networking key and node information
 func keyCmdRun(_ *cobra.Command, _ []string) {
+
+	// generate private key seeds if not specified via flag
+	if len(flagNetworkSeed) == 0 {
+		flagNetworkSeed = GenerateRandomSeed()
+	}
+	if len(flagStakingSeed) == 0 {
+		flagStakingSeed = GenerateRandomSeed()
+	}
+	if len(flagMachineSeed) == 0 {
+		flagMachineSeed = GenerateRandomSeed()
+	}
 
 	// validate inputs
 	role := validateRole(flagRole)

--- a/cmd/bootstrap/cmd/machine_account_key.go
+++ b/cmd/bootstrap/cmd/machine_account_key.go
@@ -23,11 +23,16 @@ var machineAccountKeyCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(machineAccountKeyCmd)
 
-	machineAccountKeyCmd.Flags().BytesHexVar(&flagMachineSeed, "seed", GenerateRandomSeed(), fmt.Sprintf("hex encoded machine account seed (min %v bytes)", minSeedBytes))
+	machineAccountKeyCmd.Flags().BytesHexVar(&flagMachineSeed, "seed", []byte{}, fmt.Sprintf("hex encoded machine account seed (min %d bytes)", minSeedBytes))
 }
 
 // machineAccountKeyRun generate a machine account key and writes it to a default file path.
 func machineAccountKeyRun(_ *cobra.Command, _ []string) {
+
+	// generate seed if not specified via flag
+	if len(flagMachineSeed) == 0 {
+		flagMachineSeed = GenerateRandomSeed()
+	}
 
 	// read nodeID written to boostrap dir by `bootstrap key`
 	nodeID, err := readNodeID()


### PR DESCRIPTION
This both encouraged users to put sensitive seed information into terminal output, and printed default generated seeds to terminal output when in "help mode" (these would not be used, but were misleading).