### PR TITLE
[ci, crypto] Detect CPU arch and feed that info to blst

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         file: ./coverage.txt
         flags: unittests
         name: codecov-umbrella
-    
+
   integration-test:
     name: Integration Tests
     strategy:
@@ -103,6 +103,9 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+    - name: CPU information
+      run: |
+        lscpu
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
@@ -113,11 +116,19 @@ jobs:
       run: make crypto/relic/build
     - name: Run tests
       if: github.actor != 'bors[bot]'
-      run: make -C crypto cross-blst-test
+      run: |
+        if ! (grep -q -e '^flags.*\badx\b' /proc/cpuinfo) 2>/dev/null; then
+            export CGO_CFLAGS="-D__BLST_PORTABLE__"
+        fi
+        make -C crypto cross-blst-test
     - name: Run tests (Bors)
       if: github.actor == 'bors[bot]'
       uses: nick-invision/retry@v2
       with:
         timeout_minutes: 25
         max_attempts: 2
-        command: make -C crypto cross-blst-test
+        command: |
+          if ! (grep -q -e '^flags.*\badx\b' /proc/cpuinfo) 2>/dev/null; then
+              export CGO_CFLAGS="-D__BLST_PORTABLE__"
+          fi
+          make -C crypto cross-blst-test


### PR DESCRIPTION
The Go bindings for BLST run with unconditional [-D__ADX__ flag](https://en.wikipedia.org/wiki/Intel_ADX). While that is fine for newer
machines, GH Actions run tests on a variety of underlying architectures, some of which do not have
those CPU extensions. See:
https://docs.microsoft.com/en-ca/azure/virtual-machines/dv2-dsv2-series#dsv2-series

As a consequence, this runs detection before setting CGO compilation flags approaprately.