### PR TITLE
Vishal/consensus follower storage

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -117,6 +117,7 @@ type BaseConfig struct {
 	metricsEnabled        bool
 	guaranteesCacheSize   uint
 	receiptsCacheSize     uint
+	db                    *badger.DB
 }
 
 // NodeConfig contains all the derived parameters such the NodeID, private keys etc. and initialized instances of

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -369,6 +369,13 @@ func (fnb *FlowNodeBuilder) initProfiler() {
 }
 
 func (fnb *FlowNodeBuilder) initDB() {
+
+	// if a db has been passed in, use that instead of creating one
+	if fnb.BaseConfig.db != nil {
+		fnb.DB = fnb.BaseConfig.db
+		return
+	}
+
 	// Pre-create DB path (Badger creates only one-level dirs)
 	err := os.MkdirAll(fnb.BaseConfig.datadir, 0700)
 	fnb.MustNot(err).Str("dir", fnb.BaseConfig.datadir).Msg("could not create datadir")
@@ -735,6 +742,12 @@ func WithMetricsEnabled(enabled bool) Option {
 func WithLogLevel(level string) Option {
 	return func(config *BaseConfig) {
 		config.level = level
+	}
+}
+
+func WithDB(db *badger.DB) Option {
+	return func(config *BaseConfig) {
+		config.db = db
 	}
 }
 

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -729,7 +729,9 @@ func WithBindAddress(bindAddress string) Option {
 
 func WithDataDir(dataDir string) Option {
 	return func(config *BaseConfig) {
-		config.datadir = dataDir
+		if config.db == nil {
+			config.datadir = dataDir
+		}
 	}
 }
 
@@ -745,9 +747,11 @@ func WithLogLevel(level string) Option {
 	}
 }
 
+// WithDB takes precedence over WithDataDir and datadir will be set to empty if DB is set using this option
 func WithDB(db *badger.DB) Option {
 	return func(config *BaseConfig) {
 		config.db = db
+		config.datadir = ""
 	}
 }
 

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -103,6 +103,12 @@ func getBaseOptions(config *Config) []cmd.Option {
 	if config.bindAddr != "" {
 		options = append(options, cmd.WithBindAddress(config.bindAddr))
 	}
+	if config.logLevel != "" {
+		options = append(options, cmd.WithLogLevel(config.logLevel))
+	}
+	if config.db != nil {
+		options = append(options, cmd.WithDB(config.db))
+	}
 
 	return options
 }

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -37,9 +37,13 @@ type Config struct {
 
 type Option func(c *Config)
 
+// WithDataDir sets the underlying directory to be used to store the database
+// If a database is supplied, then data directory will be set to empty string
 func WithDataDir(dataDir string) Option {
 	return func(cf *Config) {
-		cf.dataDir = dataDir
+		if cf.db == nil {
+			cf.dataDir = dataDir
+		}
 	}
 }
 
@@ -55,9 +59,12 @@ func WithLogLevel(level string) Option {
 	}
 }
 
+// WithDB sets the underlying database that will be used to store the chain state
+// WithDB takes precedence over WithDataDir and datadir will be set to empty if DB is set using this option
 func WithDB(db *badger.DB) Option {
 	return func(cf *Config) {
 		cf.db = db
+		cf.dataDir = ""
 	}
 }
 


### PR DESCRIPTION
From @awfm9 
> We have another problem: we need to access the protocol state database in our code. However, since the DB is not injected into the consensus follower as a dependency, but rather you just pass the data directory as an option, the DB is opened internally by the follower's node builder.
> That makes it impossible for us to access the protocol state database, as it's not exposed in any meaningful way. Would it be possible to change that so that the node builder takes a database handle, and the consensus follower takes a *badger.DB as well, rather than a data directory?

This change allows the Badger db to be passed in as a dependency.