### PR TITLE
[CI] Activate CI for branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@ on:
       - 'auto-cadence-upgrade/**'
       - staging
       - trying
+      - 'feature/**'
   pull_request:
     branches:
       - master
       - 'auto-cadence-upgrade/**'
+      - 'feature/**'
 
 jobs:
   golangci:


### PR DESCRIPTION
We're developing several significant features using branches these days: unstaked AN, Epochs, Consensus V2 ...
This activates CI runs on branches named `feature/XXX`, on PRs targeting them and on pushes. 
Of course those branches cannot be created publicly.

Hopefully we'll thereby get CI signal on those big feature branches.