### PR TITLE
[Synchronization] Sync request handler refactoring

### DIFF
--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -40,7 +40,6 @@ type Engine struct {
 	metrics SyncEngineMetrics
 	me      module.Local
 	con     network.Conduit
-	blocks  storage.Blocks
 	comp    network.Engine // compliance layer engine
 
 	pollInterval    time.Duration
@@ -86,9 +85,8 @@ func New(
 		log:             log.With().Str("engine", "synchronization").Logger(),
 		metrics:         NewSyncEngineMetrics(metrics.EngineSynchronization, engineMetrics),
 		me:              me,
-		blocks:          blocks,
-		comp:            comp,
 		core:            core,
+		comp:            comp,
 		pollInterval:    opt.pollInterval,
 		scanInterval:    opt.scanInterval,
 		finalizedHeader: finalizedHeader,
@@ -107,7 +105,8 @@ func New(
 	}
 	e.con = con
 
-	e.requestHandler = NewRequestHandlerEngine(log, e.metrics, con, me, blocks, core, finalizedHeader)
+	requestHandlerCore := NewRequestHandlerCore(log, blocks, core)
+	e.requestHandler = NewRequestHandlerEngine(log, e.metrics, con, me, requestHandlerCore, finalizedHeader)
 
 	return e, nil
 }

--- a/engine/common/synchronization/interface.go
+++ b/engine/common/synchronization/interface.go
@@ -1,0 +1,29 @@
+package synchronization
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/messages"
+)
+
+// SyncEngineMetrics is a helper interface which is built around module.EngineMetrics.
+// It's useful for RequestHandlerEngine since it can be used to report metrics for different engine names.
+type SyncEngineMetrics interface {
+	MessageSent(message string)
+	MessageReceived(message string)
+	MessageHandled(messages string)
+}
+
+// RequestHandlerCore is a helper interface which makes possible to implement request handling core for collection and consensus
+// clusters using same codebase for message routing using RequestHandlerEngine.
+// This interface implements bare minimum functions to handle 3 types of requests.
+type RequestHandlerCore interface {
+	// HandleSyncRequest handles sync request and returns response, response can be nil, means we should ignore it
+	// and omit sending
+	HandleSyncRequest(req *messages.SyncRequest, finalized *flow.Header) (interface{}, error)
+	// HandleRangeRequest handles range request and returns response, response can be nil, means we should ignore it
+	// and omit sending
+	HandleRangeRequest(req *messages.RangeRequest, finalized *flow.Header) (interface{}, error)
+	// HandleBatchRequest handles batch request and returns response, response can be nil, means we should ignore it
+	// and omit sending
+	HandleBatchRequest(req *messages.BatchRequest) (interface{}, error)
+}

--- a/engine/common/synchronization/metrics.go
+++ b/engine/common/synchronization/metrics.go
@@ -1,0 +1,59 @@
+package synchronization
+
+import (
+	"github.com/onflow/flow-go/module"
+)
+
+// SyncEngineMetrics is a helper interface which is built around module.EngineMetrics.
+// It's useful for RequestHandlerEngine since it can be used to report metrics for different engine names.
+type SyncEngineMetrics interface {
+	MessageSent(message string)
+	MessageReceived(message string)
+	MessageHandled(messages string)
+}
+
+// SyncEngineMetricsImpl implements SyncEngineMetrics proxying all calls to module.EngineMetrics with
+// preset engine name at construction time.
+type SyncEngineMetricsImpl struct {
+	engineName string
+	metrics    module.EngineMetrics
+}
+
+func NewSyncEngineMetrics(engineName string, metrics module.EngineMetrics) *SyncEngineMetricsImpl {
+	return &SyncEngineMetricsImpl{
+		engineName: engineName,
+		metrics:    metrics,
+	}
+}
+
+func (r *SyncEngineMetricsImpl) MessageSent(message string) {
+	r.metrics.MessageSent(r.engineName, message)
+}
+
+func (r *SyncEngineMetricsImpl) MessageReceived(message string) {
+	r.metrics.MessageReceived(r.engineName, message)
+}
+
+func (r *SyncEngineMetricsImpl) MessageHandled(message string) {
+	r.metrics.MessageHandled(r.engineName, message)
+}
+
+// NoopSyncEngineMetrics is a dummy implementation which doesn't report any metrics
+type NoopSyncEngineMetrics struct {
+}
+
+func NewNoopSyncEngineMetrics() *NoopSyncEngineMetrics {
+	return &NoopSyncEngineMetrics{}
+}
+
+func (n *NoopSyncEngineMetrics) MessageSent(message string) {
+
+}
+
+func (n *NoopSyncEngineMetrics) MessageReceived(message string) {
+
+}
+
+func (n *NoopSyncEngineMetrics) MessageHandled(messages string) {
+
+}

--- a/engine/common/synchronization/metrics.go
+++ b/engine/common/synchronization/metrics.go
@@ -4,14 +4,6 @@ import (
 	"github.com/onflow/flow-go/module"
 )
 
-// SyncEngineMetrics is a helper interface which is built around module.EngineMetrics.
-// It's useful for RequestHandlerEngine since it can be used to report metrics for different engine names.
-type SyncEngineMetrics interface {
-	MessageSent(message string)
-	MessageReceived(message string)
-	MessageHandled(messages string)
-}
-
 // SyncEngineMetricsImpl implements SyncEngineMetrics proxying all calls to module.EngineMetrics with
 // preset engine name at construction time.
 type SyncEngineMetricsImpl struct {

--- a/engine/common/synchronization/request_handler.go
+++ b/engine/common/synchronization/request_handler.go
@@ -34,7 +34,7 @@ type RequestHandlerEngine struct {
 
 	me      module.Local
 	log     zerolog.Logger
-	metrics module.EngineMetrics
+	metrics SyncEngineMetrics
 
 	blocks          storage.Blocks
 	core            module.SyncCore
@@ -49,7 +49,7 @@ type RequestHandlerEngine struct {
 
 func NewRequestHandlerEngine(
 	log zerolog.Logger,
-	metrics module.EngineMetrics,
+	metrics SyncEngineMetrics,
 	con network.Conduit,
 	me module.Local,
 	blocks storage.Blocks,
@@ -140,7 +140,7 @@ func (r *RequestHandlerEngine) setupRequestMessageHandler() {
 			Match: func(msg *engine.Message) bool {
 				_, ok := msg.Payload.(*messages.SyncRequest)
 				if ok {
-					r.metrics.MessageReceived(metrics.EngineSynchronization, metrics.MessageSyncRequest)
+					r.metrics.MessageReceived(metrics.MessageSyncRequest)
 				}
 				return ok
 			},
@@ -150,7 +150,7 @@ func (r *RequestHandlerEngine) setupRequestMessageHandler() {
 			Match: func(msg *engine.Message) bool {
 				_, ok := msg.Payload.(*messages.RangeRequest)
 				if ok {
-					r.metrics.MessageReceived(metrics.EngineSynchronization, metrics.MessageRangeRequest)
+					r.metrics.MessageReceived(metrics.MessageRangeRequest)
 				}
 				return ok
 			},
@@ -160,7 +160,7 @@ func (r *RequestHandlerEngine) setupRequestMessageHandler() {
 			Match: func(msg *engine.Message) bool {
 				_, ok := msg.Payload.(*messages.BatchRequest)
 				if ok {
-					r.metrics.MessageReceived(metrics.EngineSynchronization, metrics.MessageBatchRequest)
+					r.metrics.MessageReceived(metrics.MessageBatchRequest)
 				}
 				return ok
 			},
@@ -194,7 +194,7 @@ func (r *RequestHandlerEngine) onSyncRequest(originID flow.Identifier, req *mess
 		r.log.Warn().Err(err).Msg("sending sync response failed")
 		return nil
 	}
-	r.metrics.MessageSent(metrics.EngineSynchronization, metrics.MessageSyncResponse)
+	r.metrics.MessageSent(metrics.MessageSyncResponse)
 
 	return nil
 }
@@ -239,7 +239,7 @@ func (r *RequestHandlerEngine) onRangeRequest(originID flow.Identifier, req *mes
 		r.log.Warn().Err(err).Hex("origin_id", originID[:]).Msg("sending range response failed")
 		return nil
 	}
-	r.metrics.MessageSent(metrics.EngineSynchronization, metrics.MessageBlockResponse)
+	r.metrics.MessageSent(metrics.MessageBlockResponse)
 
 	return nil
 }
@@ -287,7 +287,7 @@ func (r *RequestHandlerEngine) onBatchRequest(originID flow.Identifier, req *mes
 		r.log.Warn().Err(err).Hex("origin_id", originID[:]).Msg("sending batch response failed")
 		return nil
 	}
-	r.metrics.MessageSent(metrics.EngineSynchronization, metrics.MessageBlockResponse)
+	r.metrics.MessageSent(metrics.MessageBlockResponse)
 
 	return nil
 }

--- a/engine/common/synchronization/request_handler_core.go
+++ b/engine/common/synchronization/request_handler_core.go
@@ -1,0 +1,115 @@
+package synchronization
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/messages"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/storage"
+)
+
+type ConsensusRequestHandlerCore struct {
+	log    zerolog.Logger
+	blocks storage.Blocks
+	core   module.SyncCore
+}
+
+func NewRequestHandlerCore(
+	log zerolog.Logger,
+	blocks storage.Blocks,
+	core module.SyncCore,
+) *ConsensusRequestHandlerCore {
+	return &ConsensusRequestHandlerCore{
+		log:    log,
+		blocks: blocks,
+		core:   core,
+	}
+}
+
+func (c *ConsensusRequestHandlerCore) HandleSyncRequest(req *messages.SyncRequest, final *flow.Header) (interface{}, error) {
+	// queue any missing heights as needed
+	c.core.HandleHeight(final, req.Height)
+
+	// don't bother sending a response if we're within tolerance or if we're
+	// behind the requester
+	if c.core.WithinTolerance(final, req.Height) || req.Height > final.Height {
+		return nil, nil
+	}
+
+	// if we're sufficiently ahead of the requester, send a response
+	return &messages.SyncResponse{
+		Height: final.Height,
+		Nonce:  req.Nonce,
+	}, nil
+}
+
+func (c *ConsensusRequestHandlerCore) HandleRangeRequest(req *messages.RangeRequest, finalized *flow.Header) (interface{}, error) {
+	// if we don't have anything to send, we can bail right away
+	if finalized.Height < req.FromHeight || req.FromHeight > req.ToHeight {
+		return nil, nil
+	}
+
+	// get all the blocks, one by one
+	blocks := make([]*flow.Block, 0, req.ToHeight-req.FromHeight+1)
+	for height := req.FromHeight; height <= req.ToHeight; height++ {
+		block, err := c.blocks.ByHeight(height)
+		if errors.Is(err, storage.ErrNotFound) {
+			c.log.Error().Uint64("height", height).Msg("skipping unknown heights")
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not get block for height (%d): %w", height, err)
+		}
+		blocks = append(blocks, block)
+	}
+
+	// if there are no blocks to send, skip network message
+	if len(blocks) == 0 {
+		c.log.Debug().Msg("skipping empty range response")
+		return nil, nil
+	}
+
+	// send the response
+	return &messages.BlockResponse{
+		Nonce:  req.Nonce,
+		Blocks: blocks,
+	}, nil
+}
+
+func (c *ConsensusRequestHandlerCore) HandleBatchRequest(req *messages.BatchRequest) (interface{}, error) {
+	// deduplicate the block IDs in the batch request
+	blockIDs := make(map[flow.Identifier]struct{})
+	for _, blockID := range req.BlockIDs {
+		blockIDs[blockID] = struct{}{}
+	}
+
+	// try to get all the blocks by ID
+	blocks := make([]*flow.Block, 0, len(blockIDs))
+	for blockID := range blockIDs {
+		block, err := c.blocks.ByID(blockID)
+		if errors.Is(err, storage.ErrNotFound) {
+			c.log.Debug().Hex("block_id", blockID[:]).Msg("skipping unknown block")
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("could not get block by ID (%s): %w", blockID, err)
+		}
+		blocks = append(blocks, block)
+	}
+
+	// if there are no blocks to send, skip network message
+	if len(blocks) == 0 {
+		c.log.Debug().Msg("skipping empty batch response")
+		return nil, nil
+	}
+
+	// send the response
+	return &messages.BlockResponse{
+		Nonce:  req.Nonce,
+		Blocks: blocks,
+	}, nil
+}


### PR DESCRIPTION
### Context

I am currently working on https://github.com/dapperlabs/flow-go/issues/5807 it has a lot of overlap with consensus sync engine and request handler engine. My plan is to reuse `RequestHandlerEngine` in `engine/collection/synchronization` since it has identical functionality in collection sync engine. For that reason I need to make changes to reporting metrics inside of `RequestHandlerEngine`. 


I have abstracted out metrics reporting so it could be configured in independent way. 
+ 
I have abstracted out core logic for handling messages, now it's possible to implement different core for handling messages for consensus & collection clusters.
All changes are internal and don't impact external API. 