### PR TITLE
[Networking] Rolls in DNS caching

### DIFF
--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -3,7 +3,6 @@ package node_builder
 import (
 	"context"
 	"fmt"
-	"time"
 
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 
@@ -159,8 +158,7 @@ func (builder *StakedAccessNodeBuilder) enqueueUnstakedNetworkInit(ctx context.C
 
 		libP2PFactory, err := builder.initLibP2PFactory(ctx,
 			builder.NodeID,
-			builder.NodeConfig.NetworkKey,
-			builder.BaseConfig.DNSCacheTTL)
+			builder.NodeConfig.NetworkKey)
 		builder.MustNot(err)
 
 		msgValidators := unstakedNetworkMsgValidators(node.Logger, node.IdentityProvider, builder.NodeID)
@@ -194,8 +192,7 @@ func (builder *StakedAccessNodeBuilder) enqueueUnstakedNetworkInit(ctx context.C
 // 		Default Flow libp2p pubsub options
 func (builder *StakedAccessNodeBuilder) initLibP2PFactory(ctx context.Context,
 	nodeID flow.Identifier,
-	networkKey crypto.PrivateKey,
-	dnsCacheTTL time.Duration) (p2p.LibP2PFactoryFunc, error) {
+	networkKey crypto.PrivateKey) (p2p.LibP2PFactoryFunc, error) {
 
 	// The staked nodes act as the DHT servers
 	dhtOptions := []dht.Option{p2p.AsServer(true)}
@@ -207,7 +204,7 @@ func (builder *StakedAccessNodeBuilder) initLibP2PFactory(ctx context.Context,
 
 	connManager := p2p.NewConnManager(builder.Logger, builder.Metrics.Network, p2p.TrackUnstakedConnections(builder.IdentityProvider))
 
-	resolver, err := dns.NewResolver(builder.Metrics.Network, dns.WithTTL(dnsCacheTTL))
+	resolver, err := dns.NewResolver(builder.Metrics.Network, dns.WithTTL(builder.DNSCacheTTL))
 	if err != nil {
 		return nil, fmt.Errorf("could not create dns resolver: %w", err)
 	}

--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -204,7 +204,7 @@ func (builder *StakedAccessNodeBuilder) initLibP2PFactory(ctx context.Context,
 
 	connManager := p2p.NewConnManager(builder.Logger, builder.Metrics.Network, p2p.TrackUnstakedConnections(builder.IdentityProvider))
 
-	resolver, err := dns.NewResolver(builder.Metrics.Network, dns.WithTTL(builder.DNSCacheTTL))
+	resolver, err := dns.NewResolver(builder.Metrics.Network, dns.WithTTL(builder.BaseConfig.DNSCacheTTL))
 	if err != nil {
 		return nil, fmt.Errorf("could not create dns resolver: %w", err)
 	}

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -3,7 +3,6 @@ package node_builder
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
@@ -209,7 +208,7 @@ func (anb *UnstakedAccessNodeBuilder) enqueueMiddleware(ctx context.Context) {
 			// for now we use the empty metrics NoopCollector till we have defined the new unstaked network metrics
 			unstakedNetworkMetrics := metrics.NewNoopCollector()
 
-			libP2PFactory, err := anb.initLibP2PFactory(ctx, unstakedNodeID)
+			libP2PFactory, err := anb.initLibP2PFactory(ctx, unstakedNodeID, unstakedNetworkKey)
 			anb.MustNot(err)
 
 			msgValidators := unstakedNetworkMsgValidators(node.Logger, node.IdentityProvider, unstakedNodeID)

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -150,7 +150,7 @@ func (builder *UnstakedAccessNodeBuilder) initLibP2PFactory(ctx context.Context,
 
 	connManager := p2p.NewConnManager(builder.Logger, builder.Metrics.Network, p2p.TrackUnstakedConnections(builder.IdentityProvider))
 
-	resolver, err := dns.NewResolver(builder.Metrics.Network, dns.WithTTL(builder.DNSCacheTTL))
+	resolver, err := dns.NewResolver(builder.Metrics.Network, dns.WithTTL(builder.BaseConfig.DNSCacheTTL))
 	if err != nil {
 		return nil, fmt.Errorf("could not create dns resolver: %w", err)
 	}

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -109,6 +109,7 @@ type BaseConfig struct {
 	BootstrapDir          string
 	peerUpdateInterval    time.Duration
 	UnicastMessageTimeout time.Duration
+	DNSCacheTTL           time.Duration
 	profilerEnabled       bool
 	profilerDir           string
 	profilerInterval      time.Duration

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -30,7 +30,7 @@ import (
 	"github.com/onflow/flow-go/module/trace"
 	cborcodec "github.com/onflow/flow-go/network/codec/cbor"
 	"github.com/onflow/flow-go/network/p2p"
-	dns2 "github.com/onflow/flow-go/network/p2p/dns"
+	"github.com/onflow/flow-go/network/p2p/dns"
 	"github.com/onflow/flow-go/network/topology"
 	badgerState "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/events"
@@ -130,6 +130,7 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 		"the duration to run the auto-profile for")
 	fnb.flags.BoolVar(&fnb.BaseConfig.tracerEnabled, "tracer-enabled", defaultConfig.tracerEnabled,
 		"whether to enable tracer")
+	fnb.flags.DurationVar(&fnb.BaseConfig.DNSCacheTTL, "dns-cache-ttl", dns.DefaultTimeToLive, "time-to-live for dns cache")
 
 	fnb.flags.UintVar(&fnb.BaseConfig.guaranteesCacheSize, "guarantees-cache-size", bstorage.DefaultCacheSize, "collection guarantees cache size")
 	fnb.flags.UintVar(&fnb.BaseConfig.receiptsCacheSize, "receipts-cache-size", bstorage.DefaultCacheSize, "receipts cache size")
@@ -168,7 +169,7 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit(ctx context.Context) {
 			p2p.DefaultMaxPubSubMsgSize,
 			fnb.Metrics.Network,
 			pingProvider,
-			dns2.DefaultTimeToLive)
+			dns.DefaultTimeToLive)
 
 		if err != nil {
 			return nil, fmt.Errorf("could not generate libp2p node factory: %w", err)

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -169,7 +169,7 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit(ctx context.Context) {
 			p2p.DefaultMaxPubSubMsgSize,
 			fnb.Metrics.Network,
 			pingProvider,
-			dns.DefaultTimeToLive)
+			fnb.DNSCacheTTL)
 
 		if err != nil {
 			return nil, fmt.Errorf("could not generate libp2p node factory: %w", err)

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/flow-go/module/trace"
 	cborcodec "github.com/onflow/flow-go/network/codec/cbor"
 	"github.com/onflow/flow-go/network/p2p"
+	dns2 "github.com/onflow/flow-go/network/p2p/dns"
 	"github.com/onflow/flow-go/network/topology"
 	badgerState "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/events"
@@ -167,7 +168,8 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit(ctx context.Context) {
 			p2p.DefaultMaxPubSubMsgSize,
 			fnb.Metrics.Network,
 			pingProvider,
-		)
+			dns2.DefaultTimeToLive)
+
 		if err != nil {
 			return nil, fmt.Errorf("could not generate libp2p node factory: %w", err)
 		}

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -169,7 +169,7 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit(ctx context.Context) {
 			p2p.DefaultMaxPubSubMsgSize,
 			fnb.Metrics.Network,
 			pingProvider,
-			fnb.DNSCacheTTL)
+			fnb.BaseConfig.DNSCacheTTL)
 
 		if err != nil {
 			return nil, fmt.Errorf("could not generate libp2p node factory: %w", err)

--- a/network/p2p/dht_test.go
+++ b/network/p2p/dht_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	flownet "github.com/onflow/flow-go/network"
+	"github.com/onflow/flow-go/network/p2p/dns"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -235,11 +236,15 @@ func (suite *DHTTestSuite) CreateNodes(count int, dhtServer bool) (nodes []*Node
 
 		pingInfoProvider, _, _ := MockPingInfoProvider()
 
+		resolver, err := dns.NewResolver(noopMetrics)
+		require.NoError(suite.T(), err)
+
 		n, err := NewDefaultLibP2PNodeBuilder(flow.Identifier{}, "0.0.0.0:0", key).
 			SetRootBlockID(rootBlockID).
 			SetConnectionManager(connManager).
 			SetDHTOptions(AsServer(dhtServer)).
 			SetPingInfoProvider(pingInfoProvider).
+			SetResolver(resolver).
 			SetLogger(logger).
 			Build(suite.ctx)
 		require.NoError(suite.T(), err)

--- a/network/p2p/dns/cache.go
+++ b/network/p2p/dns/cache.go
@@ -6,9 +6,10 @@ import (
 	"time"
 )
 
-// defaultTimeToLive is the default duration a dns result is cached.
+// DefaultTimeToLive is the default duration a dns result is cached.
 const (
-	defaultTimeToLive     = 5 * time.Minute
+	// DefaultTimeToLive is the default duration a dns result is cached.
+	DefaultTimeToLive     = 60 * time.Minute
 	cacheEntryExists      = true
 	cacheEntryInvalidated = true
 )
@@ -23,7 +24,7 @@ type cache struct {
 
 func newCache() *cache {
 	return &cache{
-		ttl:      defaultTimeToLive,
+		ttl:      DefaultTimeToLive,
 		ipCache:  make(map[string]*ipCacheEntry),
 		txtCache: make(map[string]*txtCacheEntry),
 	}


### PR DESCRIPTION
This PR rolls DNS caching for LibP2P into production and makes its TTL configurable through a flag. Note that this is the first version of our DNS caching implementation, which is synchronized. We have an asynchronized implementation coming soon!
