### PR TITLE
Add random delay to periodic peer update thread

### DIFF
--- a/engine/unit.go
+++ b/engine/unit.go
@@ -74,7 +74,12 @@ func (u *Unit) LaunchAfter(delay time.Duration, f func()) {
 // If f is executed, the unit will not shut down until after f returns.
 func (u *Unit) LaunchPeriodically(f func(), interval time.Duration, delay time.Duration) {
 	u.Launch(func() {
-		<-time.After(delay)
+		select {
+		case <-u.ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
We are observing synchronized goroutine spikes causing consensus finalization issues on large committees on benchnet, with the same period as this peer update process. 

This PR:
* Adds a uniform random delay to the initial launch of the peer update requesting routine, so that peer updates are not synchronized across the network
* Updates `engine.Unit` to exit goroutines launched with `LaunchPeriodically` immediately, even if they are waiting for the initial delay period when the unit is torn down

Run on Benchnet without this fix:
![Screen Shot 2021-09-10 at 6 43 25 PM](https://user-images.githubusercontent.com/10557821/132925136-5106d222-7a57-4066-be93-86bae0514766.png)

With this fix:
![Screen Shot 2021-09-10 at 6 43 34 PM](https://user-images.githubusercontent.com/10557821/132925139-eb54ebc2-6ff0-475c-97ed-745dd9a312d1.png)
