### PR TITLE
Improve error handling in access node

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -472,10 +472,13 @@ func (anb *FlowAccessNodeBuilder) Build() AccessNodeBuilder {
 
 			anb.IngestEng, err = ingestion.New(node.Logger, node.Network, node.State, node.Me, anb.RequestEng, node.Storage.Blocks, node.Storage.Headers, node.Storage.Collections, node.Storage.Transactions, node.Storage.Results, node.Storage.Receipts, anb.TransactionMetrics,
 				anb.CollectionsToMarkFinalized, anb.CollectionsToMarkExecuted, anb.BlocksToMarkExecuted, anb.RpcEng)
+			if err != nil {
+				return nil, err
+			}
 			anb.RequestEng.WithHandle(anb.IngestEng.OnCollection)
 			anb.FinalizationDistributor.AddConsumer(anb.IngestEng)
 
-			return anb.IngestEng, err
+			return anb.IngestEng, nil
 		}).
 		Component("requester engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			// We initialize the requester engine inside the ingestion engine due to the mutual dependency. However, in

--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -159,7 +159,9 @@ func (builder *StakedAccessNodeBuilder) enqueueUnstakedNetworkInit(ctx context.C
 		libP2PFactory, err := builder.initLibP2PFactory(ctx,
 			builder.NodeID,
 			builder.NodeConfig.NetworkKey)
-		builder.MustNot(err)
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize libp2p factory: %w", err)
+		}
 
 		msgValidators := unstakedNetworkMsgValidators(node.Logger, node.IdentityProvider, builder.NodeID)
 
@@ -169,7 +171,9 @@ func (builder *StakedAccessNodeBuilder) enqueueUnstakedNetworkInit(ctx context.C
 		top := topology.EmptyListTopology{}
 
 		network, err := builder.initNetwork(builder.Me, node.Metrics.Network, middleware, top)
-		builder.MustNot(err)
+		if err != nil {
+			return nil, fmt.Errorf("could not initialize network: %w", err)
+		}
 
 		builder.Network = network
 		builder.Middleware = middleware

--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -160,7 +160,7 @@ func (builder *StakedAccessNodeBuilder) enqueueUnstakedNetworkInit(ctx context.C
 			builder.NodeID,
 			builder.NodeConfig.NetworkKey)
 		if err != nil {
-			return nil, fmt.Errorf("could not initialize libp2p factory: %w", err)
+			return nil, err
 		}
 
 		msgValidators := unstakedNetworkMsgValidators(node.Logger, node.IdentityProvider, builder.NodeID)
@@ -172,7 +172,7 @@ func (builder *StakedAccessNodeBuilder) enqueueUnstakedNetworkInit(ctx context.C
 
 		network, err := builder.initNetwork(builder.Me, node.Metrics.Network, middleware, top)
 		if err != nil {
-			return nil, fmt.Errorf("could not initialize network: %w", err)
+			return nil, err
 		}
 
 		builder.Network = network

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -146,7 +146,7 @@ func (builder *UnstakedAccessNodeBuilder) initLibP2PFactory(ctx context.Context,
 	// seed the DHT with the boostrap identities
 	bootstrapPeersOpt, err := p2p.WithBootstrapPeers(builder.bootstrapIdentities)
 	if err != nil {
-		return nil, fmt.Errorf("could not configure bootstrap peers opts: %w", err)
+		return nil, err
 	}
 	dhtOptions = append(dhtOptions, bootstrapPeersOpt)
 


### PR DESCRIPTION
* Fix a few error conditions where the fatal error was never thrown because `Msg()` was not called.
* Update Module and Component blocks to return the error instead of throwing since the handlers will do that automatically. This makes them more consistent with other uses in the codebase.