### PR TITLE
Fallback to allowing startup without valid machine account

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -494,7 +494,8 @@ func createQCContractClient(node *cmd.NodeConfig, accessAddress string, flowClie
 
 	// if not valid return a mock qc contract client
 	if valid := cmd.IsValidNodeMachineAccountConfig(node, accessAddress); !valid {
-		return nil, fmt.Errorf("could not validate node machine account config")
+		//return nil, fmt.Errorf("could not validate node machine account config")
+		return epochs.NewMockQCContractClient(node.Logger), nil
 	}
 
 	// attempt to read NodeMachineAccountInfo

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -756,7 +756,8 @@ func createDKGContractClient(node *cmd.NodeConfig, accessAddress string, flowCli
 
 	// if not valid return a mock dkg contract client
 	if valid := cmd.IsValidNodeMachineAccountConfig(node, accessAddress); !valid {
-		return nil, fmt.Errorf("could not validate node machine account config")
+		//return nil, fmt.Errorf("could not validate node machine account config")
+		return dkgmodule.NewMockClient(node.Logger), nil
 	}
 
 	// attempt to read NodeMachineAccountInfo


### PR DESCRIPTION
This allows a node to startup without a valid machine account file. `--access-address` is still required.

This is a change on standby in case insufficiently many operators complete the machine account generation process in time for Wednesday's spork.