### PR TITLE
Update relic_build.sh

### DIFF
--- a/crypto/relic_build.sh
+++ b/crypto/relic_build.sh
@@ -42,7 +42,8 @@ if [[ "$ARCH" =~ ^(arm64|armv7|armv7s)$ && "${CC_VERSION_STR[0]}" =~ (clang)  ]]
     #  the "-march=native" option is not supported with clang on ARM
     MARCH=""
 else
-    MARCH="-march=native"
+    # Target standard x86-64 CPU. Avoids AVX512 SIGILL: illegal instruction
+    MARCH="-march=x86-64"
 fi
 
 # Set RELIC config for Flow


### PR DESCRIPTION
Images are being build with instructions which are not available on most processors (like AVX-512). This produces illegal instruction error.

This MR targets generic x64 processor.

See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html

```
SIGILL: illegal instruction
PC=0x14e66eb m=0 sigcode=2
signal arrived during cgo execution
instruction bytes: 0x62 0xf1 0xfd 0x28 0x6f 0x5 0x4b 0x5 0xaa 0x0 0x66 0x89 0x47 0x28 0x31 0xc0
```

