### PR TITLE
Mainnet quick fix fo address problems of nodes failing to catch up

### DIFF
--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -414,7 +414,7 @@ func (b *Builder) getInsertableSeals(parentID flow.Identifier) ([]*flow.Seal, er
 
 			// enforce condition (0): candidate seals are only constructed once sufficient
 			// approvals have been collected. Hence, any incorporated result for which we
-			// find a candidate seal satisfy condition (0)
+			// find a candidate seal satisfies condition (0)
 			irSeal, ok := b.sealPool.ByID(incorporatedResult.ID())
 			if !ok {
 				continue

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -386,10 +386,13 @@ func (b *Builder) getInsertableSeals(parentID flow.Identifier) ([]*flow.Seal, er
 		blockID := header.ID()
 		// TEMPORARY implementation (unpolished)
 		if blockID == parentID {
-			// Important protocol edge case: There must be at least one block in between the block incorporating a
-			// result and the block sealing the result. This guarantees that a verifier assignment can be computed
-			// without needing information from the block that we are just constructing. Hence, we don't consider
-			// results for sealing that were incorporated in the immediate parent which we are extending.
+			// Important protocol edge case: There must be at least one block in between the block incorporating
+			// a result and the block sealing the result. This is because we need the Source of Randomness for
+			// the block that _incorporates_ the result, to compute the verifier assignment. Therefore, we require
+			// that the block _incorporating_ the result has at least one child in the fork, _before_ we include
+			// the seal. Thereby, we guarantee that a verifier assignment can be computed without needing
+			// information from the block that we are just constructing. Hence, we don't consider results for
+			// sealing that were incorporated in the immediate parent which we are extending.
 			return nil
 		}
 

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -630,23 +630,23 @@ func (bs *BuilderSuite) TestPayloadSeals_EnforceGap() {
 	bs.sealDB.On("ByBlockID", b4.ID()).Return(b0seal, nil)
 	bs.build.seals = bs.sealDB
 
-	// Build on top of B4 and check that no seals are included
-	_, err := bs.build.BuildOn(b4.ID(), bs.setter)
-	bs.Require().NoError(err)
-	bs.recPool.AssertExpectations(bs.T())
-	bs.Assert().Empty(bs.assembled.Seals, "should not included any seals")
+	bs.T().Run("Build on top of B4 and check that no seals are included", func(t *testing.T) {
+		_, err := bs.build.BuildOn(b4.ID(), bs.setter)
+		bs.Require().NoError(err)
+		bs.recPool.AssertExpectations(bs.T())
+		bs.Assert().Empty(bs.assembled.Seals, "should not included any seals")
+	})
 
-	// Build on top of B5 and check that seals for B1 is included
+	bs.T().Run("Build on top of B5 and check that seals for B1 is included", func(t *testing.T) {
+		b5 := unittest.BlockWithParentFixture(b4.Header) // creating block b5
+		bs.storeBlock(&b5)
 
-	// Add B5 and check that no seals are included
-	b5 := unittest.BlockWithParentFixture(b4.Header)
-	bs.storeBlock(&b5)
-
-	_, err = bs.build.BuildOn(b5.ID(), bs.setter)
-	bs.Require().NoError(err)
-	bs.recPool.AssertExpectations(bs.T())
-	bs.Assert().Equal(1, len(bs.assembled.Seals), "only seal for B1 expected")
-	bs.Require().Equal(b1seal.Seal, bs.assembled.Seals[0])
+		_, err := bs.build.BuildOn(b5.ID(), bs.setter)
+		bs.Require().NoError(err)
+		bs.recPool.AssertExpectations(bs.T())
+		bs.Assert().Equal(1, len(bs.assembled.Seals), "only seal for B1 expected")
+		bs.Require().Equal(b1seal.Seal, bs.assembled.Seals[0])
+	})
 }
 
 // TestPayloadSeals_Duplicates verifies that the builder does not duplicate seals for already sealed blocks:

--- a/module/chunks.go
+++ b/module/chunks.go
@@ -25,7 +25,7 @@ type ChunkVerifier interface {
 	// TODO return challenges plus errors
 	Verify(ch *verification.VerifiableChunkData) ([]byte, chmodels.ChunkFault, error)
 
-	// VerifySystemChunk verifies a given VerifiableChunk corresponding to a system chunk.
+	// SystemChunkVerify verifies a given VerifiableChunk corresponding to a system chunk.
 	// by executing it and checking the final state commitment
 	// It returns a Spock Secret as a byte array, verification fault of the chunk, and an error.
 	// Note: Verify should only be executed on system chunks. It returns an error if it is invoked on

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -56,7 +56,7 @@ func (p *ChunkAssigner) Size() uint {
 //    (which contains the block's source of randomness)
 //  * unexpected errors should be considered symptoms of internal bugs
 func (p *ChunkAssigner) Assign(result *flow.ExecutionResult, blockID flow.Identifier) (*chunkmodels.Assignment, error) {
-	// computes a finger print for blockID||resultID||alpha
+	// computes a fingerprint for blockID||resultID||alpha
 	hash, err := fingerPrint(blockID, result.ID(), p.alpha)
 	if err != nil {
 		return nil, fmt.Errorf("could not compute hash of identifiers: %w", err)
@@ -96,16 +96,15 @@ func (p *ChunkAssigner) Assign(result *flow.ExecutionResult, blockID flow.Identi
 }
 
 func (p *ChunkAssigner) rngByBlockID(stateSnapshot protocol.Snapshot) (random.Rand, error) {
-	// TODO: rng could be cached to optimize performance
-
+	// TODO: seed could be cached to optimize performance
 	seed, err := stateSnapshot.Seed(indices.ProtocolVerificationChunkAssignment...) // potentially returns NoValidChildBlockError
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to retrieve source of randomness: %w", err)
 	}
 
 	rng, err := random.NewRand(seed)
 	if err != nil {
-		return nil, fmt.Errorf("could not generate random generator: %w", err)
+		return nil, fmt.Errorf("failed to instantiate random number generator: %w", err)
 	}
 
 	return rng, nil

--- a/module/validation/seal_validator.go
+++ b/module/validation/seal_validator.go
@@ -168,7 +168,7 @@ func (s *sealValidator) Validate(candidate *flow.Block) (*flow.Seal, error) {
 		for _, resultID := range payloadIndex.ResultIDs {
 			result, err := s.results.ByID(resultID)
 			if err != nil {
-				return fmt.Errorf("internal error fetching result %x incorporated in block %x: %w", resultID, blockID, err)
+				return fmt.Errorf("internal error fetching result %v incorporated in block %v: %w", resultID, blockID, err)
 			}
 			incorporatedResults[resultID] = flow.NewIncorporatedResult(blockID, result)
 		}

--- a/module/validation/seal_validator.go
+++ b/module/validation/seal_validator.go
@@ -168,7 +168,7 @@ func (s *sealValidator) Validate(candidate *flow.Block) (*flow.Seal, error) {
 		for _, resultID := range payloadIndex.ResultIDs {
 			result, err := s.results.ByID(resultID)
 			if err != nil {
-				return fmt.Errorf("internal error fetching result %v incorporated in stored block %v: %w", resultID, blockID, err)
+				return fmt.Errorf("internal error fetching result %x incorporated in block %x: %w", resultID, blockID, err)
 			}
 			incorporatedResults[resultID] = flow.NewIncorporatedResult(blockID, result)
 		}
@@ -210,9 +210,10 @@ func (s *sealValidator) Validate(candidate *flow.Block) (*flow.Seal, error) {
 		err := s.validateSeal(seal, incorporatedResult)
 		if err != nil {
 			if !engine.IsInvalidInputError(err) {
-				return nil, fmt.Errorf("unexpected internal error while validating seal %x: %w", seal.ID(), err)
+				return nil, fmt.Errorf("unexpected internal error while validating seal %x for result %x for block %x: %w",
+					seal.ID(), seal.ResultID, seal.BlockID, err)
 			}
-			return nil, fmt.Errorf("invalid seal %x for result %x: %w", seal.ID(), seal.ResultID, err)
+			return nil, fmt.Errorf("invalid seal %x for result %x for block %x: %w", seal.ID(), seal.ResultID, seal.BlockID, err)
 		}
 
 		// check that the sealed execution results form a chain
@@ -250,12 +251,11 @@ func (s *sealValidator) validateSeal(seal *flow.Seal, incorporatedResult *flow.I
 			len(seal.AggregatedApprovalSigs))
 	}
 
-	// TEMPORARY HOT-FIX: reduces security but allows consensus nodes to catch up that are very far behind
-	//
-	//assignments, err := s.assigner.Assign(executionResult, incorporatedResult.IncorporatedBlockID)
-	//if err != nil {
-	//	return fmt.Errorf("could not retreive assignments for block: %v, %v, %w", seal.BlockID, incorporatedResult.IncorporatedBlockID, err)
-	//}
+	assignments, err := s.assigner.Assign(executionResult, incorporatedResult.IncorporatedBlockID)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve verifier assignment for result %x incorporated in block %x: %w",
+			executionResult.ID(), incorporatedResult.IncorporatedBlockID, err)
+	}
 
 	// Check that each AggregatedSignature has enough valid signatures from
 	// verifiers that were assigned to the corresponding chunk.
@@ -288,14 +288,12 @@ func (s *sealValidator) validateSeal(seal *flow.Seal, incorporatedResult *flow.I
 			}
 		}
 
-		// TEMPORARY HOT-FIX: reduces security but allows consensus nodes to catch up that are very far behind
-		//
 		// only Verification Nodes that were assigned to the chunk are allowed to approve it
-		//for _, signerId := range chunkSigs.SignerIDs {
-		//	if !assignments.HasVerifier(chunk, signerId) {
-		//		return engine.NewInvalidInputErrorf("invalid signer id at chunk: %d", chunk.Index)
-		//	}
-		//}
+		for _, signerId := range chunkSigs.SignerIDs {
+			if !assignments.HasVerifier(chunk, signerId) {
+				return engine.NewInvalidInputErrorf("invalid signer id at chunk: %d", chunk.Index)
+			}
+		}
 
 		// Verification Nodes' approval signatures must be valid
 		err := s.verifySealSignature(chunkSigs, chunk, executionResultID)

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -408,7 +408,7 @@ func (s *Snapshot) Seed(indices ...uint32) ([]byte, error) {
 	// CASE 2: for any other block, use any valid child
 	child, err := s.validChild()
 	if err != nil {
-		return nil, fmt.Errorf("could not get valid child of block %x: %w", s.blockID, err)
+		return nil, fmt.Errorf("failed to get valid child of block %x: %w", s.blockID, err)
 	}
 
 	seed, err := seed.FromParentSignature(indices, child.ParentVoterSigData)

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -71,7 +71,7 @@ func (s *Snapshot) QuorumCertificate() (*flow.QuorumCertificate, error) {
 	// CASE 2: for any other block, generate the root QC from a valid child
 	child, err := s.validChild()
 	if err != nil {
-		return nil, fmt.Errorf("could not get child: %w", err)
+		return nil, fmt.Errorf("could not get valid child of block %x: %w", s.blockID, err)
 	}
 
 	// sanity check: ensure the child has the snapshot block as parent
@@ -118,7 +118,7 @@ func (s *Snapshot) validChild() (*flow.Header, error) {
 			continue
 		}
 		if err != nil {
-			return nil, fmt.Errorf("could not get child validity: %w", err)
+			return nil, fmt.Errorf("failed to determine validity of child block %v: %w", childID, err)
 		}
 		if valid {
 			validChildID = childID
@@ -380,6 +380,8 @@ func (s *Snapshot) descendants(blockID flow.Identifier) ([]flow.Identifier, erro
 }
 
 // Seed returns the random seed at the given indices for the current block snapshot.
+// Expected error returns:
+// * state.NoValidChildBlockError if no valid child is known
 func (s *Snapshot) Seed(indices ...uint32) ([]byte, error) {
 
 	// CASE 1: for the root block, generate the seed from the root qc
@@ -406,7 +408,7 @@ func (s *Snapshot) Seed(indices ...uint32) ([]byte, error) {
 	// CASE 2: for any other block, use any valid child
 	child, err := s.validChild()
 	if err != nil {
-		return nil, fmt.Errorf("could not get child: %w", err)
+		return nil, fmt.Errorf("could not get valid child of block %x: %w", s.blockID, err)
 	}
 
 	seed, err := seed.FromParentSignature(indices, child.ParentVoterSigData)


### PR DESCRIPTION
#### Bug description:

If consensus nodes are far behind and catching up on _finalized_ block, it can happen that they fail to validate a block and therefore get stuck. This is caused by a subtle edge case in the builder logic. See [incident report](https://www.notion.so/dapperlabs/Incident-Name-09-15-2021-e1c979212c54451abdb8200982b26b27) (notion doc) for details.

### Scope
This PR implements _step 1._ described in [#5857](https://github.com/dapperlabs/flow-go/issues/5857). 
* reverted [emergency-fix](https://github.com/onflow/flow-go/pull/1300) that was deployed to recover mainnet
* the [`consensus.Builder`](https://github.com/onflow/flow-go/blob/alex/5857_mainnet_quick-fix/module/builder/consensus/builder.go) logic is patched in a bit more of a hacky way
* refactored builder tests according to account for the updated business logic
* improved error handing in some of the relevant components 

