### PR TITLE
Disable unnecessary migrations

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -60,21 +60,8 @@ func extractExecutionState(
 	reporters := []ledger.Reporter{}
 
 	if migrate {
-		storageFormatV5Migration := mgr.StorageFormatV5Migration{
-			Log:            log,
-			OutputDir:      outputDir,
-			CleanupStorage: cleanupStorage,
-		}
-
-		storageUsedUpdateMigration := mgr.StorageUsedUpdateMigration{
-			Log:       log,
-			OutputDir: outputDir,
-		}
-
 		migrations = []ledger.Migration{
 			mgr.PruneMigration,
-			storageFormatV5Migration.Migrate,
-			storageUsedUpdateMigration.Migrate,
 		}
 	}
 	if report {


### PR DESCRIPTION
In order to re-spork testnet with the same version, we need to disable the migrations that we have already applied.