### PR TITLE
Add starter contracts from flow-nft

### DIFF
--- a/fvm/blueprints/flow-nft.go
+++ b/fvm/blueprints/flow-nft.go
@@ -1,0 +1,34 @@
+package blueprints
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-nft/lib/go/contracts"
+)
+
+func DeployNonFungibleTokenTransaction(nonFungibleToken flow.Address) *flow.TransactionBody {
+	contract := contracts.NonFungibleToken()
+	contractName := "NonFungibleToken"
+	return DeployContractTransaction(
+		nonFungibleToken,
+		contract,
+		contractName)
+}
+
+const deployExampleNFTTransactionTemplate = `
+transaction {
+  prepare(exampleNFT: AuthAccount) {
+    exampleNFT.contracts.add(name: "ExampleNFT", code: "%s".decodeHex())
+  }
+}
+`
+
+func DeployExampleNFTTransaction(nonFungibleToken, exampleNFT flow.Address) *flow.TransactionBody {
+	contract := contracts.ExampleNFT(nonFungibleToken.Hex())
+
+	return flow.NewTransactionBody().
+		SetScript([]byte(fmt.Sprintf(deployExampleNFTTransactionTemplate, hex.EncodeToString(contract)))).
+		AddAuthorizer(exampleNFT)
+}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/onflow/flow-emulator v0.20.3
 	github.com/onflow/flow-go-sdk v0.21.0
 	github.com/onflow/flow-go/crypto v0.21.3
+	github.com/onflow/flow-nft/lib/go/contracts v0.0.0-20210915191154-12ee8c507a0e // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.2.2
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pelletier/go-toml v1.9.4 // indirect


### PR DESCRIPTION

# Summary

This change will include additional NFT contracts when the emulator starts up. The contracts are from https://github.com/onflow/flow-nft

This is actually part of https://github.com/onflow/flip-fest/issues/27!

# Tests
So far, I've just run the emulator!

<img width="967" alt="Screenshot 2021-09-24 at 20 59 23" src="https://user-images.githubusercontent.com/30219253/134754370-1c40a9f5-8e70-48e5-993e-8fd77e51c70b.png">


