### PR TITLE
Enable transaction fees on mainnet

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -671,11 +671,11 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 		fvm.WithChain(fnb.RootChainID.Chain()),
 		fvm.WithBlocks(blockFinder),
 		fvm.WithAccountStorageLimit(true),
+		fvm.WithTransactionFeesEnabled(true),
 	}
 	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary {
 		vmOpts = append(vmOpts,
 			fvm.WithRestrictedDeployment(false),
-			fvm.WithTransactionFeesEnabled(true),
 		)
 	}
 	fnb.FvmOptions = vmOpts

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -671,7 +671,9 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 		fvm.WithChain(fnb.RootChainID.Chain()),
 		fvm.WithBlocks(blockFinder),
 		fvm.WithAccountStorageLimit(true),
-		fvm.WithTransactionFeesEnabled(true),
+	}
+	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary || fnb.RootChainID == flow.Mainnet {
+		fvm.WithTransactionFeesEnabled(true)
 	}
 	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary {
 		vmOpts = append(vmOpts,


### PR DESCRIPTION
## Context

Fees will get turned on on mainnet soon. Currently they are both disabled and set to `0.0`. They need to be enabled (with this PR) during a spork. After that they can be set to non `0.0` when desired.

## Checks

I verified that:
- mainnet tx fees are really set to `0.0`
- having tx fees on and set to `0.0` doesn't lead to any unexpected problems (on the emulator)
- having tx fees on and set to `0.0` doesn't emit fee deduction events (see the [contract](https://github.com/onflow/flow-core-contracts/blob/51b4191ee4367dc33e868b91a32e9cdab98fd519/contracts/FlowServiceAccount.cdc#L65))
