### PR TITLE
Port to v0.22: Enable transaction fees on mainnet

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -669,11 +669,11 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 		fvm.WithChain(fnb.RootChainID.Chain()),
 		fvm.WithBlocks(blockFinder),
 		fvm.WithAccountStorageLimit(true),
+		fvm.WithTransactionFeesEnabled(true),
 	}
 	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary {
 		vmOpts = append(vmOpts,
 			fvm.WithRestrictedDeployment(false),
-			fvm.WithTransactionFeesEnabled(true),
 		)
 	}
 	fnb.FvmOptions = vmOpts


### PR DESCRIPTION
Port of https://github.com/onflow/flow-go/pull/1360 to v0.22.