### PR TITLE
[Network] enable subscription filter except ghost node

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -184,7 +184,8 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit(ctx context.Context) {
 			p2p.DefaultMaxPubSubMsgSize,
 			fnb.Metrics.Network,
 			pingProvider,
-			fnb.BaseConfig.DNSCacheTTL)
+			fnb.BaseConfig.DNSCacheTTL,
+			fnb.BaseConfig.NodeRole)
 
 		if err != nil {
 			return nil, fmt.Errorf("could not generate libp2p node factory: %w", err)

--- a/network/p2p/libp2pNode.go
+++ b/network/p2p/libp2pNode.go
@@ -72,7 +72,8 @@ func DefaultLibP2PNodeFactory(ctx context.Context,
 	maxPubSubMsgSize int,
 	metrics module.NetworkMetrics,
 	pingInfoProvider PingInfoProvider,
-	dnsResolverTTL time.Duration) (LibP2PFactoryFunc, error) {
+	dnsResolverTTL time.Duration,
+	role string) (LibP2PFactoryFunc, error) {
 
 	connManager := NewConnManager(log, metrics)
 
@@ -82,7 +83,7 @@ func DefaultLibP2PNodeFactory(ctx context.Context,
 
 	psOpts := DefaultPubsubOptions(maxPubSubMsgSize)
 
-	if chainID != flow.Localnet {
+	if role != "ghost" {
 		psOpts = append(psOpts, func(_ context.Context, h host.Host) (pubsub.Option, error) {
 			return pubsub.WithSubscriptionFilter(NewRoleBasedFilter(
 				h.ID(), rootBlockID, idProvider,


### PR DESCRIPTION
Previously, this was disabled on everything except localnet. 

Instead, we can probably only disable it for ghost nodes.