### PR TITLE
[Bootstrap] Extracted `rootblock` command 

### DIFF
--- a/cmd/bootstrap/cmd/constraints.go
+++ b/cmd/bootstrap/cmd/constraints.go
@@ -9,8 +9,7 @@ import (
 // Checks constraints about the number of partner and internal nodes.
 // Internal nodes must comprise >2/3 of consensus committee.
 // Internal nodes must comprise >2/3 of each collector cluster.
-func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
-
+func checkConsensusConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 	partners := model.ToIdentityList(partnerNodes)
 	internals := model.ToIdentityList(internalNodes)
 	all := append(partners, internals...)
@@ -39,6 +38,14 @@ func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 			partnerCONCount, internalCONCount, partnerCONCount*2+1)
 	}
 
+}
+
+// Checks constraints about the number of partner and internal nodes.
+// Internal nodes must comprise >2/3 of consensus committee.
+// Internal nodes must comprise >2/3 of each collector cluster.
+func checkCollectionConstraints(partnerNodes, internalNodes []model.NodeInfo) {
+	partners := model.ToIdentityList(partnerNodes)
+	internals := model.ToIdentityList(internalNodes)
 	// check collection committee Byzantine threshold for each cluster
 	// for checking Byzantine constraints, the seed doesn't matter
 	_, clusters := constructClusterAssignment(partnerNodes, internalNodes, 0)

--- a/cmd/bootstrap/cmd/final_list.go
+++ b/cmd/bootstrap/cmd/final_list.go
@@ -52,7 +52,8 @@ func finalList(cmd *cobra.Command, args []string) {
 	flowNodes := assembleInternalNodesWithoutStake()
 
 	log.Info().Msg("checking constraints on consensus/cluster nodes")
-	checkConstraints(partnerNodes, flowNodes)
+	checkConsensusConstraints(partnerNodes, flowNodes)
+	checkCollectionConstraints(partnerNodes, flowNodes)
 
 	log.Info().Msgf("reading staking contract node information: %s", flagStakingNodesPath)
 	stakingNodes := readStakingContractDetails()

--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -136,7 +136,8 @@ func finalize(cmd *cobra.Command, args []string) {
 	log.Info().Msg("")
 
 	log.Info().Msg("checking constraints on consensus/cluster nodes")
-	checkConstraints(partnerNodes, internalNodes)
+	checkConsensusConstraints(partnerNodes, internalNodes)
+	checkCollectionConstraints(partnerNodes, internalNodes)
 	log.Info().Msg("")
 
 	log.Info().Msg("assembling network and staking keys")

--- a/cmd/bootstrap/cmd/qc.go
+++ b/cmd/bootstrap/cmd/qc.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/onflow/flow-go/cmd/bootstrap/run"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/dkg"
 	"github.com/onflow/flow-go/model/flow"
@@ -20,4 +21,19 @@ func constructRootQC(block *flow.Block, allNodes, internalNodes []bootstrap.Node
 	}
 
 	return qc
+}
+
+// NOTE: allNodes must be in the same order as when generating the DKG
+func constructRootVotes(block *flow.Block, allNodes, internalNodes []bootstrap.NodeInfo, dkgData dkg.DKGData) []*model.Vote {
+	participantData, err := run.GenerateQCParticipantData(allNodes, internalNodes, dkgData)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to generate QC participant data")
+	}
+
+	votes, err := run.GenerateRootBlockVotes(block, participantData)
+	if err != nil {
+		log.Fatal().Err(err).Msg("generating votes for root block failed")
+	}
+
+	return votes
 }

--- a/cmd/bootstrap/cmd/rootblock.go
+++ b/cmd/bootstrap/cmd/rootblock.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"encoding/hex"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/cmd"
+	model "github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state/protocol/inmem"
+)
+
+// rootBlockCmd represents the rootBlock command
+var rootBlockCmd = &cobra.Command{
+	Use:   "rootblock",
+	Short: "Generate root block data",
+	Long:  `Run DKG, generate root block and votes for root block needed for constructing QC. Serialize all info into file`,
+	Run:   rootBlock,
+}
+
+func init() {
+	rootCmd.AddCommand(rootBlockCmd)
+	addRootBlockCmdFlags()
+}
+
+func addRootBlockCmdFlags() {
+	// required parameters for network configuration and generation of root node identities
+	rootBlockCmd.Flags().StringVar(&flagConfig, "config", "",
+		"path to a JSON file containing multiple node configurations (fields Role, Address, Stake)")
+	rootBlockCmd.Flags().StringVar(&flagInternalNodePrivInfoDir, "internal-priv-dir", "", "path to directory "+
+		"containing the output from the `keygen` command for internal nodes")
+	rootBlockCmd.Flags().StringVar(&flagPartnerNodeInfoDir, "partner-dir", "", "path to directory "+
+		"containing one JSON file starting with node-info.pub.<NODE_ID>.json for every partner node (fields "+
+		" in the JSON file: Role, Address, NodeID, NetworkPubKey, StakingPubKey)")
+	rootBlockCmd.Flags().StringVar(&flagPartnerStakes, "partner-stakes", "", "path to a JSON file containing "+
+		"a map from partner node's NodeID to their stake")
+
+	cmd.MarkFlagRequired(rootBlockCmd, "config")
+	cmd.MarkFlagRequired(rootBlockCmd, "internal-priv-dir")
+	cmd.MarkFlagRequired(rootBlockCmd, "partner-dir")
+	cmd.MarkFlagRequired(rootBlockCmd, "partner-stakes")
+
+	// required parameters for generation of root block, root execution result and root block seal
+	rootBlockCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'canary', 'bench', or 'local'")
+	rootBlockCmd.Flags().StringVar(&flagRootParent, "root-parent", "0000000000000000000000000000000000000000000000000000000000000000", "ID for the parent of the root block")
+	rootBlockCmd.Flags().Uint64Var(&flagRootHeight, "root-height", 0, "height of the root block")
+	rootBlockCmd.Flags().StringVar(&flagRootTimestamp, "root-timestamp", time.Now().UTC().Format(time.RFC3339), "timestamp of the root block (RFC3339)")
+
+	cmd.MarkFlagRequired(rootBlockCmd, "root-chain")
+	cmd.MarkFlagRequired(rootBlockCmd, "root-parent")
+	cmd.MarkFlagRequired(rootBlockCmd, "root-height")
+
+	rootBlockCmd.Flags().BytesHexVar(&flagBootstrapRandomSeed, "random-seed", GenerateRandomSeed(), "The seed used to for DKG, Clustering and Cluster QC generation")
+
+	// optional parameters to influence various aspects of identity generation
+	rootBlockCmd.Flags().BoolVar(&flagFastKG, "fast-kg", false, "use fast (centralized) random beacon key generation instead of DKG")
+}
+
+func rootBlock(cmd *cobra.Command, args []string) {
+
+	actualSeedLength := len(flagBootstrapRandomSeed)
+	if actualSeedLength != randomSeedBytes {
+		log.Error().Int("expected", randomSeedBytes).Int("actual", actualSeedLength).Msg("random seed provided length is not valid")
+		return
+	}
+
+	log.Info().Str("seed", hex.EncodeToString(flagBootstrapRandomSeed)).Msg("deterministic bootstrapping random seed")
+	log.Info().Msg("")
+
+	log.Info().Msg("collecting partner network and staking keys")
+	partnerNodes := assemblePartnerNodes()
+	log.Info().Msg("")
+
+	log.Info().Msg("generating internal private networking and staking keys")
+	internalNodes := assembleInternalNodes()
+	log.Info().Msg("")
+
+	log.Info().Msg("checking constraints on consensus nodes")
+	checkConsensusConstraints(partnerNodes, internalNodes)
+	log.Info().Msg("")
+
+	log.Info().Msg("assembling network and staking keys")
+	stakingNodes := mergeNodeInfos(internalNodes, partnerNodes)
+	writeJSON(model.PathNodeInfosPub, model.ToPublicNodeInfoList(stakingNodes))
+	log.Info().Msg("")
+
+	log.Info().Msg("running DKG for consensus nodes")
+	dkgData := runDKG(model.FilterByRole(stakingNodes, flow.RoleConsensus))
+	log.Info().Msg("")
+
+	log.Info().Msg("constructing root block")
+	block := constructRootBlock(flagRootChain, flagRootParent, flagRootHeight, flagRootTimestamp)
+	log.Info().Msg("")
+
+	log.Info().Msg("constructing votes")
+	votes := constructRootVotes(
+		block,
+		model.FilterByRole(stakingNodes, flow.RoleConsensus),
+		model.FilterByRole(internalNodes, flow.RoleConsensus),
+		dkgData,
+	)
+	log.Info().Msg("")
+
+	writeJSON(model.PathRootBlockData, inmem.EncodableRootBlockData{
+		Block: block,
+		Votes: votes,
+	})
+	log.Info().Msg("")
+	log.Info().Msg("Done - Created root block data")
+}

--- a/cmd/bootstrap/run/qc.go
+++ b/cmd/bootstrap/run/qc.go
@@ -68,6 +68,25 @@ func GenerateRootQC(block *flow.Block, participantData *ParticipantData) (*flow.
 	return qc, err
 }
 
+func GenerateRootBlockVotes(block *flow.Block, participantData *ParticipantData) ([]*model.Vote, error) {
+	_, signers, err := createValidators(participantData)
+	if err != nil {
+		return nil, err
+	}
+
+	hotBlock := model.GenesisBlockFromFlow(block.Header)
+
+	votes := make([]*model.Vote, 0, len(signers))
+	for _, signer := range signers {
+		vote, err := signer.CreateVote(hotBlock)
+		if err != nil {
+			return nil, err
+		}
+		votes = append(votes, vote)
+	}
+	return votes, nil
+}
+
 func createValidators(participantData *ParticipantData) ([]hotstuff.Validator, []hotstuff.SignerVerifier, error) {
 	n := len(participantData.Participants)
 	identities := participantData.Identities()

--- a/cmd/bootstrap/utils/file.go
+++ b/cmd/bootstrap/utils/file.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 
@@ -28,4 +29,21 @@ func ReadRootProtocolSnapshot(bootDir string) (*inmem.Snapshot, error) {
 	}
 
 	return snapshot, nil
+}
+
+func ReadRootBlockData(bootDir string) (*inmem.EncodableRootBlockData, error) {
+	rootBlockDataPath := filepath.Join(bootDir, model.PathRootBlockData)
+
+	// read snapshot file bytes
+	bytes, err := io.ReadFile(rootBlockDataPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read snapshot: %w", err)
+	}
+
+	var encodable inmem.EncodableRootBlockData
+	err = json.Unmarshal(bytes, &encodable)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal snapshot data retreived from access node: %w", err)
+	}
+	return &encodable, nil
 }

--- a/model/bootstrap/filenames.go
+++ b/model/bootstrap/filenames.go
@@ -21,6 +21,7 @@ var (
 	PathPartnerNodeInfoPrefix = filepath.Join(DirnamePublicBootstrap, "node-info.pub.")
 	PathNodeInfoPub           = filepath.Join(DirnamePublicBootstrap, "node-info.pub.%v.json") // %v will be replaced by NodeID
 
+	PathRootBlockData             = filepath.Join(DirnamePublicBootstrap, "root-block-data.json")
 	PathRootProtocolStateSnapshot = filepath.Join(DirnamePublicBootstrap, "root-protocol-state-snapshot.json")
 
 	FilenameWALRootCheckpoint = "root.checkpoint"

--- a/state/protocol/inmem/encodable.go
+++ b/state/protocol/inmem/encodable.go
@@ -1,6 +1,7 @@
 package inmem
 
 import (
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
@@ -53,4 +54,10 @@ type EncodableCluster struct {
 	Members   flow.IdentityList
 	RootBlock *cluster.Block
 	RootQC    *flow.QuorumCertificate
+}
+
+// EncodableRootBlockData is the encoding format for root block and []*model.Block
+type EncodableRootBlockData struct {
+	Block *flow.Block
+	Votes []*model.Vote
 }


### PR DESCRIPTION
https://github.com/dapperlabs/flow-go/issues/5889

### Context

This PR implements `rootblock` command for bootstrap utility.

Logic is mostly extracted from `finalize` command with some modifications for encoding and creating votes.

As result of `rootblock` we output DKG info and root block + votes in separate files.

Cleanup of `finalize` will be performed as part of https://github.com/dapperlabs/flow-go/issues/5891