### PR TITLE
[Bootstrap] Extracted `rootblock` and updated `finalize`

### DIFF
--- a/cmd/bootstrap/cmd/constraints.go
+++ b/cmd/bootstrap/cmd/constraints.go
@@ -9,8 +9,7 @@ import (
 // Checks constraints about the number of partner and internal nodes.
 // Internal nodes must comprise >2/3 of consensus committee.
 // Internal nodes must comprise >2/3 of each collector cluster.
-func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
-
+func checkConsensusConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 	partners := model.ToIdentityList(partnerNodes)
 	internals := model.ToIdentityList(internalNodes)
 	all := append(partners, internals...)
@@ -39,6 +38,14 @@ func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 			partnerCONCount, internalCONCount, partnerCONCount*2+1)
 	}
 
+}
+
+// Checks constraints about the number of partner and internal nodes.
+// Internal nodes must comprise >2/3 of consensus committee.
+// Internal nodes must comprise >2/3 of each collector cluster.
+func checkCollectionConstraints(partnerNodes, internalNodes []model.NodeInfo) {
+	partners := model.ToIdentityList(partnerNodes)
+	internals := model.ToIdentityList(internalNodes)
 	// check collection committee Byzantine threshold for each cluster
 	// for checking Byzantine constraints, the seed doesn't matter
 	_, clusters := constructClusterAssignment(partnerNodes, internalNodes, 0)

--- a/cmd/bootstrap/cmd/final_list.go
+++ b/cmd/bootstrap/cmd/final_list.go
@@ -52,7 +52,8 @@ func finalList(cmd *cobra.Command, args []string) {
 	flowNodes := assembleInternalNodesWithoutStake()
 
 	log.Info().Msg("checking constraints on consensus/cluster nodes")
-	checkConstraints(partnerNodes, flowNodes)
+	checkConsensusConstraints(partnerNodes, flowNodes)
+	checkCollectionConstraints(partnerNodes, flowNodes)
 
 	log.Info().Msgf("reading staking contract node information: %s", flagStakingNodesPath)
 	stakingNodes := readStakingContractDetails()

--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -136,7 +136,8 @@ func finalize(cmd *cobra.Command, args []string) {
 	log.Info().Msg("")
 
 	log.Info().Msg("checking constraints on consensus/cluster nodes")
-	checkConstraints(partnerNodes, internalNodes)
+	checkConsensusConstraints(partnerNodes, internalNodes)
+	checkCollectionConstraints(partnerNodes, internalNodes)
 	log.Info().Msg("")
 
 	log.Info().Msg("assembling network and staking keys")

--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/onflow/cadence"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-go/cmd"
 	"github.com/onflow/flow-go/cmd/bootstrap/run"
+	"github.com/onflow/flow-go/cmd/bootstrap/utils"
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/fvm"
 	model "github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/dkg"
@@ -31,11 +32,9 @@ var (
 	flagCollectionClusters          uint
 	flagPartnerNodeInfoDir          string
 	flagPartnerStakes               string
-	flagFastKG                      bool
-	flagRootChain                   string
-	flagRootParent                  string
-	flagRootHeight                  uint64
-	flagRootTimestamp               string
+	flagDKGPubDataPath              string
+	flagSignerDKGDataPath           string
+	flagRootBlock                   string
 	flagRootCommit                  string
 	flagServiceAccountPublicKeyJSON string
 	flagGenesisTokenSupply          string
@@ -76,26 +75,27 @@ func addFinalizeCmdFlags() {
 		" in the JSON file: Role, Address, NodeID, NetworkPubKey, StakingPubKey)")
 	finalizeCmd.Flags().StringVar(&flagPartnerStakes, "partner-stakes", "", "path to a JSON file containing "+
 		"a map from partner node's NodeID to their stake")
+	finalizeCmd.Flags().StringVar(&flagDKGPubDataPath, "dkg-data", "", "path to a JSON file containing public data as output from DKG process")
+	finalizeCmd.Flags().StringVar(&flagSignerDKGDataPath, "signer-dkg-data", "",
+		"path to a JSON file containing private DKG data of node that will sign the QC")
 
 	cmd.MarkFlagRequired(finalizeCmd, "config")
 	cmd.MarkFlagRequired(finalizeCmd, "internal-priv-dir")
 	cmd.MarkFlagRequired(finalizeCmd, "partner-dir")
 	cmd.MarkFlagRequired(finalizeCmd, "partner-stakes")
+	cmd.MarkFlagRequired(finalizeCmd, "dkg-data")
+	cmd.MarkFlagRequired(finalizeCmd, "signer-dkg-data")
 
 	// required parameters for generation of root block, root execution result and root block seal
-	finalizeCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'canary', 'bench', or 'local'")
-	finalizeCmd.Flags().StringVar(&flagRootParent, "root-parent", "0000000000000000000000000000000000000000000000000000000000000000", "ID for the parent of the root block")
-	finalizeCmd.Flags().Uint64Var(&flagRootHeight, "root-height", 0, "height of the root block")
-	finalizeCmd.Flags().StringVar(&flagRootTimestamp, "root-timestamp", time.Now().UTC().Format(time.RFC3339), "timestamp of the root block (RFC3339)")
+	finalizeCmd.Flags().StringVar(&flagRootBlock, "root-block", "",
+		"path to a JSON file containing root block and votes")
 	finalizeCmd.Flags().StringVar(&flagRootCommit, "root-commit", "0000000000000000000000000000000000000000000000000000000000000000", "state commitment of root execution state")
 	finalizeCmd.Flags().Uint64Var(&flagEpochCounter, "epoch-counter", 0, "epoch counter for the epoch beginning with the root block")
 	finalizeCmd.Flags().Uint64Var(&flagNumViewsInEpoch, "epoch-length", 4000, "length of each epoch measured in views")
 	finalizeCmd.Flags().Uint64Var(&flagNumViewsInStakingAuction, "epoch-staking-phase-length", 100, "length of the epoch staking phase measured in views")
 	finalizeCmd.Flags().Uint64Var(&flagNumViewsInDKGPhase, "epoch-dkg-phase-length", 1000, "length of each DKG phase measured in views")
 
-	cmd.MarkFlagRequired(finalizeCmd, "root-chain")
-	cmd.MarkFlagRequired(finalizeCmd, "root-parent")
-	cmd.MarkFlagRequired(finalizeCmd, "root-height")
+	cmd.MarkFlagRequired(finalizeCmd, "root-block")
 	cmd.MarkFlagRequired(finalizeCmd, "root-commit")
 	cmd.MarkFlagRequired(finalizeCmd, "epoch-counter")
 	cmd.MarkFlagRequired(finalizeCmd, "epoch-length")
@@ -106,7 +106,6 @@ func addFinalizeCmdFlags() {
 
 	// optional parameters to influence various aspects of identity generation
 	finalizeCmd.Flags().UintVar(&flagCollectionClusters, "collection-clusters", 2, "number of collection clusters")
-	finalizeCmd.Flags().BoolVar(&flagFastKG, "fast-kg", false, "use fast (centralized) random beacon key generation instead of DKG")
 
 	// these two flags are only used when setup a network from genesis
 	finalizeCmd.Flags().StringVar(&flagServiceAccountPublicKeyJSON, "service-account-public-key-json",
@@ -148,19 +147,24 @@ func finalize(cmd *cobra.Command, args []string) {
 	// create flow.IdentityList representation of participant set
 	participants := model.ToIdentityList(stakingNodes).Sort(order.Canonical)
 
-	log.Info().Msg("running DKG for consensus nodes")
-	dkgData := runDKG(model.FilterByRole(stakingNodes, flow.RoleConsensus))
+	log.Info().Msg("reading root block data")
+	rootBlockData := readRootBlockData()
+	block := rootBlockData.Block
 	log.Info().Msg("")
 
-	log.Info().Msg("constructing root block")
-	block := constructRootBlock(flagRootChain, flagRootParent, flagRootHeight, flagRootTimestamp)
+	log.Info().Msg("reading dkg pub data")
+	dkgData := readDKGPubData()
+	log.Info().Msg("")
+
+	log.Info().Msg("reading QC signer")
+	signer := readQCSigner()
 	log.Info().Msg("")
 
 	log.Info().Msg("constructing root QC")
 	rootQC := constructRootQC(
 		block,
-		model.FilterByRole(stakingNodes, flow.RoleConsensus),
 		model.FilterByRole(internalNodes, flow.RoleConsensus),
+		signer,
 		dkgData,
 	)
 	log.Info().Msg("")
@@ -423,6 +427,32 @@ func mergeNodeInfos(internalNodes, partnerNodes []model.NodeInfo) []model.NodeIn
 	return nodes
 }
 
+// readRootBlockData reads root block data from disc, this file needs to be prepared with
+// rootblock command
+func readRootBlockData() *inmem.EncodableRootBlockData {
+	rootBlockData, err := utils.ReadRootBlockData(flagRootBlock)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not read root block data")
+	}
+	return rootBlockData
+}
+
+func readDKGPubData() inmem.EncodableDKG {
+	dkgData, err := utils.ReadDKGPubData(flagDKGPubDataPath)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not read DKG data")
+	}
+	return *dkgData
+}
+
+func readQCSigner() dkg.DKGParticipantPriv {
+	participant, err := utils.ReadDKGParticipant(flagSignerDKGDataPath)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not read signer DKG data")
+	}
+	return *participant
+}
+
 // Validation utility methods ------------------------------------------------
 
 func validateNodeID(nodeID flow.Identifier) flow.Identifier {
@@ -472,7 +502,7 @@ func generateEmptyExecutionState(
 	randomSource []byte,
 	assignments flow.AssignmentList,
 	clusterQCs []*flow.QuorumCertificate,
-	dkg dkg.DKGData,
+	dkg inmem.EncodableDKG,
 	identities flow.IdentityList,
 ) (commit flow.StateCommitment) {
 
@@ -493,6 +523,11 @@ func generateEmptyExecutionState(
 		log.Fatal().Err(err).Msg("invalid random source")
 	}
 
+	dkgPubKeys := make([]crypto.PublicKey, 0)
+	for _, participant := range dkg.Participants {
+		dkgPubKeys = append(dkgPubKeys, participant.KeyShare)
+	}
+
 	epochConfig := epochs.EpochConfig{
 		EpochTokenPayout:             cadence.UFix64(0),
 		RewardCut:                    cadence.UFix64(0),
@@ -505,7 +540,7 @@ func generateEmptyExecutionState(
 		RandomSource:                 cdcRandomSource,
 		CollectorClusters:            assignments,
 		ClusterQCs:                   clusterQCs,
-		DKGPubKeys:                   dkg.PubKeyShares,
+		DKGPubKeys:                   dkgPubKeys,
 	}
 
 	commit, err = run.GenerateExecutionState(

--- a/cmd/bootstrap/cmd/finalize_test.go
+++ b/cmd/bootstrap/cmd/finalize_test.go
@@ -72,6 +72,7 @@ func TestFinalize_HappyPath(t *testing.T) {
 
 		flagFastKG = true
 
+		// rootBlock will generate DKG and place it into bootDir/public-root-information
 		rootBlock(nil, nil)
 
 		flagRootCommit = hex.EncodeToString(rootCommit[:])
@@ -79,6 +80,8 @@ func TestFinalize_HappyPath(t *testing.T) {
 		flagRootChain = chainName
 		flagRootHeight = rootHeight
 		flagEpochCounter = epochCounter
+		flagRootBlock = filepath.Join(bootDir, model.PathRootBlockData)
+		flagDKGPubDataPath = filepath.Join(bootDir, model.PathRandomBeaconPub)
 
 		// set deterministic bootstrapping seed
 		flagBootstrapRandomSeed = deterministicSeed

--- a/cmd/bootstrap/cmd/finalize_test.go
+++ b/cmd/bootstrap/cmd/finalize_test.go
@@ -72,6 +72,8 @@ func TestFinalize_HappyPath(t *testing.T) {
 
 		flagFastKG = true
 
+		rootBlock(nil, nil)
+
 		flagRootCommit = hex.EncodeToString(rootCommit[:])
 		flagRootParent = hex.EncodeToString(rootParent[:])
 		flagRootChain = chainName

--- a/cmd/bootstrap/cmd/qc.go
+++ b/cmd/bootstrap/cmd/qc.go
@@ -6,11 +6,12 @@ import (
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/dkg"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state/protocol/inmem"
 )
 
 // NOTE: allNodes must be in the same order as when generating the DKG
-func constructRootQC(block *flow.Block, allNodes, internalNodes []bootstrap.NodeInfo, dkgData dkg.DKGData) *flow.QuorumCertificate {
-	participantData, err := run.GenerateQCParticipantData(allNodes, internalNodes, dkgData)
+func constructRootQC(block *flow.Block, internalNodes []bootstrap.NodeInfo, signer dkg.DKGParticipantPriv, dkgData inmem.EncodableDKG) *flow.QuorumCertificate {
+	participantData, err := run.GenerateQCSignerParticipantData(internalNodes, signer, dkgData)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to generate QC participant data")
 	}

--- a/cmd/bootstrap/cmd/qc.go
+++ b/cmd/bootstrap/cmd/qc.go
@@ -10,13 +10,13 @@ import (
 )
 
 // NOTE: allNodes must be in the same order as when generating the DKG
-func constructRootQC(block *flow.Block, internalNodes []bootstrap.NodeInfo, signer dkg.DKGParticipantPriv, dkgData inmem.EncodableDKG) *flow.QuorumCertificate {
+func constructRootQC(block *flow.Block, votes []*model.Vote, internalNodes []bootstrap.NodeInfo, signer dkg.DKGParticipantPriv, dkgData inmem.EncodableDKG) *flow.QuorumCertificate {
 	participantData, err := run.GenerateQCSignerParticipantData(internalNodes, signer, dkgData)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to generate QC participant data")
 	}
 
-	qc, err := run.GenerateRootQC(block, participantData)
+	qc, err := run.GenerateRootQC(block, votes, participantData)
 	if err != nil {
 		log.Fatal().Err(err).Msg("generating root QC failed")
 	}

--- a/cmd/bootstrap/cmd/qc.go
+++ b/cmd/bootstrap/cmd/qc.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/onflow/flow-go/cmd/bootstrap/run"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/dkg"
 	"github.com/onflow/flow-go/model/flow"
@@ -20,4 +21,19 @@ func constructRootQC(block *flow.Block, allNodes, internalNodes []bootstrap.Node
 	}
 
 	return qc
+}
+
+// NOTE: allNodes must be in the same order as when generating the DKG
+func constructRootVotes(block *flow.Block, allNodes, internalNodes []bootstrap.NodeInfo, dkgData dkg.DKGData) []*model.Vote {
+	participantData, err := run.GenerateQCParticipantData(allNodes, internalNodes, dkgData)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to generate QC participant data")
+	}
+
+	votes, err := run.GenerateRootBlockVotes(block, participantData)
+	if err != nil {
+		log.Fatal().Err(err).Msg("generating votes for root block failed")
+	}
+
+	return votes
 }

--- a/cmd/bootstrap/cmd/rootblock.go
+++ b/cmd/bootstrap/cmd/rootblock.go
@@ -12,6 +12,14 @@ import (
 	"github.com/onflow/flow-go/state/protocol/inmem"
 )
 
+var (
+	flagFastKG        bool
+	flagRootChain     string
+	flagRootParent    string
+	flagRootHeight    uint64
+	flagRootTimestamp string
+)
+
 // rootBlockCmd represents the rootBlock command
 var rootBlockCmd = &cobra.Command{
 	Use:   "rootblock",

--- a/cmd/bootstrap/cmd/rootblock.go
+++ b/cmd/bootstrap/cmd/rootblock.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"encoding/hex"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/cmd"
+	model "github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state/protocol/inmem"
+)
+
+// rootBlockCmd represents the rootBlock command
+var rootBlockCmd = &cobra.Command{
+	Use:   "rootblock",
+	Short: "Generate root block data",
+	Long:  `Run DKG, generate root block and votes for root block needed for constructing QC. Serialize all info into file`,
+	Run:   rootBlock,
+}
+
+func init() {
+	rootCmd.AddCommand(rootBlockCmd)
+	addRootBlockCmdFlags()
+}
+
+func addRootBlockCmdFlags() {
+	// required parameters for network configuration and generation of root node identities
+	rootBlockCmd.Flags().StringVar(&flagConfig, "config", "",
+		"path to a JSON file containing multiple node configurations (fields Role, Address, Stake)")
+	rootBlockCmd.Flags().StringVar(&flagInternalNodePrivInfoDir, "internal-priv-dir", "", "path to directory "+
+		"containing the output from the `keygen` command for internal nodes")
+	rootBlockCmd.Flags().StringVar(&flagPartnerNodeInfoDir, "partner-dir", "", "path to directory "+
+		"containing one JSON file starting with node-info.pub.<NODE_ID>.json for every partner node (fields "+
+		" in the JSON file: Role, Address, NodeID, NetworkPubKey, StakingPubKey)")
+	rootBlockCmd.Flags().StringVar(&flagPartnerStakes, "partner-stakes", "", "path to a JSON file containing "+
+		"a map from partner node's NodeID to their stake")
+
+	cmd.MarkFlagRequired(rootBlockCmd, "config")
+	cmd.MarkFlagRequired(rootBlockCmd, "internal-priv-dir")
+	cmd.MarkFlagRequired(rootBlockCmd, "partner-dir")
+	cmd.MarkFlagRequired(rootBlockCmd, "partner-stakes")
+
+	// required parameters for generation of root block, root execution result and root block seal
+	rootBlockCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'canary', 'bench', or 'local'")
+	rootBlockCmd.Flags().StringVar(&flagRootParent, "root-parent", "0000000000000000000000000000000000000000000000000000000000000000", "ID for the parent of the root block")
+	rootBlockCmd.Flags().Uint64Var(&flagRootHeight, "root-height", 0, "height of the root block")
+	rootBlockCmd.Flags().StringVar(&flagRootTimestamp, "root-timestamp", time.Now().UTC().Format(time.RFC3339), "timestamp of the root block (RFC3339)")
+
+	cmd.MarkFlagRequired(rootBlockCmd, "root-chain")
+	cmd.MarkFlagRequired(rootBlockCmd, "root-parent")
+	cmd.MarkFlagRequired(rootBlockCmd, "root-height")
+
+	rootBlockCmd.Flags().BytesHexVar(&flagBootstrapRandomSeed, "random-seed", GenerateRandomSeed(), "The seed used to for DKG, Clustering and Cluster QC generation")
+
+	// optional parameters to influence various aspects of identity generation
+	rootBlockCmd.Flags().BoolVar(&flagFastKG, "fast-kg", false, "use fast (centralized) random beacon key generation instead of DKG")
+}
+
+func rootBlock(cmd *cobra.Command, args []string) {
+
+	actualSeedLength := len(flagBootstrapRandomSeed)
+	if actualSeedLength != randomSeedBytes {
+		log.Error().Int("expected", randomSeedBytes).Int("actual", actualSeedLength).Msg("random seed provided length is not valid")
+		return
+	}
+
+	log.Info().Str("seed", hex.EncodeToString(flagBootstrapRandomSeed)).Msg("deterministic bootstrapping random seed")
+	log.Info().Msg("")
+
+	log.Info().Msg("collecting partner network and staking keys")
+	partnerNodes := assemblePartnerNodes()
+	log.Info().Msg("")
+
+	log.Info().Msg("generating internal private networking and staking keys")
+	internalNodes := assembleInternalNodes()
+	log.Info().Msg("")
+
+	log.Info().Msg("checking constraints on consensus nodes")
+	checkConsensusConstraints(partnerNodes, internalNodes)
+	log.Info().Msg("")
+
+	log.Info().Msg("assembling network and staking keys")
+	stakingNodes := mergeNodeInfos(internalNodes, partnerNodes)
+	writeJSON(model.PathNodeInfosPub, model.ToPublicNodeInfoList(stakingNodes))
+	log.Info().Msg("")
+
+	log.Info().Msg("running DKG for consensus nodes")
+	dkgData := runDKG(model.FilterByRole(stakingNodes, flow.RoleConsensus))
+	log.Info().Msg("")
+
+	log.Info().Msg("constructing root block")
+	block := constructRootBlock(flagRootChain, flagRootParent, flagRootHeight, flagRootTimestamp)
+	log.Info().Msg("")
+
+	log.Info().Msg("constructing votes")
+	votes := constructRootVotes(
+		block,
+		model.FilterByRole(stakingNodes, flow.RoleConsensus),
+		model.FilterByRole(internalNodes, flow.RoleConsensus),
+		dkgData,
+	)
+	log.Info().Msg("")
+
+	writeJSON(model.PathRootBlockData, inmem.EncodableRootBlockData{
+		Block: block,
+		Votes: votes,
+	})
+	log.Info().Msg("")
+	log.Info().Msg("Done - Created root block data")
+}

--- a/cmd/bootstrap/cmd/rootblock_test.go
+++ b/cmd/bootstrap/cmd/rootblock_test.go
@@ -32,6 +32,7 @@ const rootBlockHappyPathLogs = "^deterministic bootstrapping random seed" +
 	`will run DKG` +
 	`finished running DKG` +
 	`.+/random-beacon.priv.json` +
+	`.+/random-beacon.pub.json` +
 	`constructing root block` +
 	`constructing votes` +
 	`wrote file \S+/root-block-data.json` +
@@ -71,8 +72,8 @@ func TestRootBlock_HappyPath(t *testing.T) {
 		hook.logs.Reset()
 
 		// check if root protocol snapshot exists
-		snapshotPath := filepath.Join(bootDir, model.PathRootBlockData)
-		assert.FileExists(t, snapshotPath)
+		rootBlockDataPath := filepath.Join(bootDir, model.PathRootBlockData)
+		assert.FileExists(t, rootBlockDataPath)
 	})
 }
 
@@ -108,15 +109,15 @@ func TestRootBlock_Deterministic(t *testing.T) {
 		hook.logs.Reset()
 
 		// check if root protocol snapshot exists
-		snapshotPath := filepath.Join(bootDir, model.PathRootBlockData)
-		assert.FileExists(t, snapshotPath)
+		rootBlockDataPath := filepath.Join(bootDir, model.PathRootBlockData)
+		assert.FileExists(t, rootBlockDataPath)
 
 		// read snapshot
-		firstRootBlockData, err := utils.ReadRootBlockData(bootDir)
+		firstRootBlockData, err := utils.ReadRootBlockData(rootBlockDataPath)
 		require.NoError(t, err)
 
 		// delete snapshot file
-		err = os.Remove(snapshotPath)
+		err = os.Remove(rootBlockDataPath)
 		require.NoError(t, err)
 
 		rootBlock(nil, nil)
@@ -124,10 +125,10 @@ func TestRootBlock_Deterministic(t *testing.T) {
 		hook.logs.Reset()
 
 		// check if root protocol snapshot exists
-		assert.FileExists(t, snapshotPath)
+		assert.FileExists(t, rootBlockDataPath)
 
 		// read snapshot
-		secondRootBlockData, err := utils.ReadRootBlockData(bootDir)
+		secondRootBlockData, err := utils.ReadRootBlockData(rootBlockDataPath)
 		require.NoError(t, err)
 
 		assert.Equal(t, firstRootBlockData, secondRootBlockData)

--- a/cmd/bootstrap/run/qc.go
+++ b/cmd/bootstrap/run/qc.go
@@ -68,6 +68,25 @@ func GenerateRootQC(block *flow.Block, participantData *ParticipantData) (*flow.
 	return qc, err
 }
 
+func GenerateRootBlockVotes(block *flow.Block, participantData *ParticipantData) ([]*model.Vote, error) {
+	_, signers, err := createValidators(participantData)
+	if err != nil {
+		return nil, err
+	}
+
+	hotBlock := model.GenesisBlockFromFlow(block.Header)
+
+	votes := make([]*model.Vote, 0, len(signers))
+	for _, signer := range signers {
+		vote, err := signer.CreateVote(hotBlock)
+		if err != nil {
+			return nil, err
+		}
+		votes = append(votes, vote)
+	}
+	return votes, nil
+}
+
 func createValidators(participantData *ParticipantData) ([]hotstuff.Validator, []hotstuff.SignerVerifier, error) {
 	n := len(participantData.Participants)
 	identities := participantData.Identities()

--- a/cmd/bootstrap/run/qc_test.go
+++ b/cmd/bootstrap/run/qc_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"crypto/rand"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestGenerateRootQC(t *testing.T) {
 	block.Header.View = 3
 	block.Header.PayloadHash = block.Payload.Hash()
 
-	_, err := GenerateRootQC(&block, participantData)
+	_, err := GenerateRootQC(&block, votes, participantData)
 	require.NoError(t, err)
 }
 

--- a/cmd/bootstrap/utils/file.go
+++ b/cmd/bootstrap/utils/file.go
@@ -63,7 +63,7 @@ func ReadDKGPubData(dkgDataPath string) (*inmem.EncodableDKG, error) {
 func ReadDKGParticipant(dkgParticipantPath string) (*dkg.DKGParticipantPriv, error) {
 	bytes, err := io.ReadFile(dkgParticipantPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not dkg participant: %w", err)
+		return nil, fmt.Errorf("could not read dkg participant: %w", err)
 	}
 
 	var encodable dkg.DKGParticipantPriv

--- a/cmd/bootstrap/utils/file.go
+++ b/cmd/bootstrap/utils/file.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 
@@ -28,4 +29,21 @@ func ReadRootProtocolSnapshot(bootDir string) (*inmem.Snapshot, error) {
 	}
 
 	return snapshot, nil
+}
+
+func ReadRootBlockData(bootDir string) (*inmem.EncodableRootBlockData, error) {
+	rootBlockDataPath := filepath.Join(bootDir, model.PathRootBlockData)
+
+	// read snapshot file bytes
+	bytes, err := io.ReadFile(rootBlockDataPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read snapshot: %w", err)
+	}
+
+	var encodable inmem.EncodableRootBlockData
+	err = json.Unmarshal(bytes, &encodable)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal snapshot data retreived from access node: %w", err)
+	}
+	return &encodable, nil
 }

--- a/cmd/bootstrap/utils/file.go
+++ b/cmd/bootstrap/utils/file.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	model "github.com/onflow/flow-go/model/bootstrap"
+	"github.com/onflow/flow-go/model/dkg"
 	"github.com/onflow/flow-go/state/protocol/inmem"
 	io "github.com/onflow/flow-go/utils/io"
 )
@@ -31,19 +32,44 @@ func ReadRootProtocolSnapshot(bootDir string) (*inmem.Snapshot, error) {
 	return snapshot, nil
 }
 
-func ReadRootBlockData(bootDir string) (*inmem.EncodableRootBlockData, error) {
-	rootBlockDataPath := filepath.Join(bootDir, model.PathRootBlockData)
-
-	// read snapshot file bytes
+func ReadRootBlockData(rootBlockDataPath string) (*inmem.EncodableRootBlockData, error) {
 	bytes, err := io.ReadFile(rootBlockDataPath)
 	if err != nil {
-		return nil, fmt.Errorf("could not read snapshot: %w", err)
+		return nil, fmt.Errorf("could not read root block data: %w", err)
 	}
 
 	var encodable inmem.EncodableRootBlockData
 	err = json.Unmarshal(bytes, &encodable)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal snapshot data retreived from access node: %w", err)
+		return nil, fmt.Errorf("could not unmarshal root block data: %w", err)
+	}
+	return &encodable, nil
+}
+
+func ReadDKGPubData(dkgDataPath string) (*inmem.EncodableDKG, error) {
+	bytes, err := io.ReadFile(dkgDataPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read dkg pub data: %w", err)
+	}
+
+	var encodable inmem.EncodableDKG
+	err = json.Unmarshal(bytes, &encodable)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal dkg pub data: %w", err)
+	}
+	return &encodable, nil
+}
+
+func ReadDKGParticipant(dkgParticipantPath string) (*dkg.DKGParticipantPriv, error) {
+	bytes, err := io.ReadFile(dkgParticipantPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not dkg participant: %w", err)
+	}
+
+	var encodable dkg.DKGParticipantPriv
+	err = json.Unmarshal(bytes, &encodable)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal dkg participant: %w", err)
 	}
 	return &encodable, nil
 }

--- a/model/bootstrap/filenames.go
+++ b/model/bootstrap/filenames.go
@@ -21,6 +21,7 @@ var (
 	PathPartnerNodeInfoPrefix = filepath.Join(DirnamePublicBootstrap, "node-info.pub.")
 	PathNodeInfoPub           = filepath.Join(DirnamePublicBootstrap, "node-info.pub.%v.json") // %v will be replaced by NodeID
 
+	PathRootBlockData             = filepath.Join(DirnamePublicBootstrap, "root-block-data.json")
 	PathRootProtocolStateSnapshot = filepath.Join(DirnamePublicBootstrap, "root-protocol-state-snapshot.json")
 
 	FilenameWALRootCheckpoint = "root.checkpoint"

--- a/model/bootstrap/filenames.go
+++ b/model/bootstrap/filenames.go
@@ -23,11 +23,12 @@ var (
 
 	PathRootBlockData             = filepath.Join(DirnamePublicBootstrap, "root-block-data.json")
 	PathRootProtocolStateSnapshot = filepath.Join(DirnamePublicBootstrap, "root-protocol-state-snapshot.json")
+	PathRandomBeaconPub           = filepath.Join(DirnamePublicBootstrap, "random-beacon.pub.json")
 
+	// private genesis information
 	FilenameWALRootCheckpoint = "root.checkpoint"
 	PathRootCheckpoint        = filepath.Join(DirnameExecutionState, FilenameWALRootCheckpoint) // only available on an execution node
 
-	// private genesis information
 	DirPrivateRoot                   = "private-root-information"
 	FilenameRandomBeaconPriv         = "random-beacon.priv.json"
 	PathPrivNodeInfoPrefix           = "node-info.priv."

--- a/state/protocol/inmem/encodable.go
+++ b/state/protocol/inmem/encodable.go
@@ -1,6 +1,7 @@
 package inmem
 
 import (
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
@@ -53,4 +54,10 @@ type EncodableCluster struct {
 	Members   flow.IdentityList
 	RootBlock *cluster.Block
 	RootQC    *flow.QuorumCertificate
+}
+
+// EncodableRootBlockData is the encoding format for root block and []*model.Block
+type EncodableRootBlockData struct {
+	Block *flow.Block
+	Votes []*model.Vote
 }


### PR DESCRIPTION
dapperlabs/flow-go#5889
dapperlabs/flow-go#5891


### Context
This PR implements `rootblock` command for bootstrap utility and updates `finalize`.

As result of `rootblock` we output DKG info and root block + votes into separate files.
`finalize` will consume public DKG data, root block and votes to construct QC and initialize collection clusters. 