### PR TITLE
removing the check for consensus committee Byzantine threshold

### DIFF
--- a/cmd/bootstrap/cmd/constraints.go
+++ b/cmd/bootstrap/cmd/constraints.go
@@ -7,7 +7,6 @@ import (
 )
 
 // Checks constraints about the number of partner and internal nodes.
-// Internal nodes must comprise >2/3 of consensus committee.
 // Internal nodes must comprise >2/3 of each collector cluster.
 func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 
@@ -27,16 +26,6 @@ func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 					role, expectedStake, node.Stake)
 			}
 		}
-	}
-
-	// check consensus committee Byzantine threshold
-	partnerCONCount := partners.Filter(filter.HasRole(flow.RoleConsensus)).Count()
-	internalCONCount := internals.Filter(filter.HasRole(flow.RoleConsensus)).Count()
-	if internalCONCount <= partnerCONCount*2 {
-		log.Fatal().Msgf(
-			"will not bootstrap configuration without Byzantine majority of consensus nodes: "+
-				"(partners=%d, internals=%d, min_internals=%d)",
-			partnerCONCount, internalCONCount, partnerCONCount*2+1)
 	}
 
 	// check collection committee Byzantine threshold for each cluster


### PR DESCRIPTION
For the consensus node test which has a 79 external partner consensus nodes and only 46 of our nodes, the finalize command fails with the error: 
`FTL will not bootstrap configuration without Byzantine majority of consensus nodes`
This assumption of the internal nodes having a majority will no longer be true starting from the next spork, hence this change to remove that check.