### PR TITLE
fixing the rootblock.json download path

### DIFF
--- a/cmd/bootstrap/transit/cmd/pull_root_block.go
+++ b/cmd/bootstrap/transit/cmd/pull_root_block.go
@@ -49,11 +49,11 @@ func pullRootBlock(c *cobra.Command, args []string) {
 
 	log.Info().Msg("downloading root block")
 
-	file := filepath.Join(flagToken, bootstrap.PathRootBlockData)
+	rootBlockFile := filepath.Join(flagToken, bootstrap.PathRootBlockData)
 	fullOutpath := filepath.Join(flagBootDir, bootstrap.PathRootBlockData)
 
-	log.Info().Str("source", bootstrap.PathRootBlockData).Str("dest", fullOutpath).Msgf("downloading root block file from transit servers")
-	err = bucket.DownloadFile(ctx, client, fullOutpath, file)
+	log.Info().Str("source", rootBlockFile).Str("dest", fullOutpath).Msgf("downloading root block file from transit servers")
+	err = bucket.DownloadFile(ctx, client, fullOutpath, rootBlockFile)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not download google bucket file")
 	}

--- a/cmd/bootstrap/transit/cmd/pull_root_block.go
+++ b/cmd/bootstrap/transit/cmd/pull_root_block.go
@@ -49,10 +49,11 @@ func pullRootBlock(c *cobra.Command, args []string) {
 
 	log.Info().Msg("downloading root block")
 
+	file := filepath.Join(flagToken, bootstrap.PathRootBlockData)
 	fullOutpath := filepath.Join(flagBootDir, bootstrap.PathRootBlockData)
 
 	log.Info().Str("source", bootstrap.PathRootBlockData).Str("dest", fullOutpath).Msgf("downloading root block file from transit servers")
-	err = bucket.DownloadFile(ctx, client, fullOutpath, bootstrap.PathRootBlockData)
+	err = bucket.DownloadFile(ctx, client, fullOutpath, file)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not download google bucket file")
 	}


### PR DESCRIPTION
operator ran into this error-

> flow@flow--testnetv2--consensus-2:~/testnetv2/bin$ boot-tools/transit pull-root-block -t consensus-test -b /home/flow/bootstrap
> <nil> INF downloading root block
> <nil> INF downloading root block file from transit servers dest=/home/flow/bootstrap/public-root-information/root-block.json source=public-root-information/root-block.json
> <nil> FTL could not download google bucket file error="error creating GCS object reader: storage: object doesn't exist"



The source `source=public-root-information/root-block.json` is incorrect and does not mention the bucket name