### PR TITLE
[Synchronization] update HandleHeight logic

### DIFF
--- a/module/synchronization/core.go
+++ b/module/synchronization/core.go
@@ -106,7 +106,7 @@ func (c *Core) HandleHeight(final *flow.Header, height uint64) {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		for h := final.Height + 1; h <= height; h++ {
-			c.queueByHeight(h)
+			c.requeueHeight(h)
 		}
 	}
 }
@@ -129,6 +129,12 @@ func (c *Core) RequestHeight(height uint64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.requeueHeight(height)
+}
+
+// requeueHeight queues the given height, ignoring any previously received
+// blocks at that height
+func (c *Core) requeueHeight(height uint64) {
 	// if we already received this block, reset the status so we can re-queue
 	status := c.heights[height]
 	if status.WasReceived() {


### PR DESCRIPTION
See https://github.com/onflow/flow-go/pull/1377#discussion_r718934777 for context.

Note that `RequestHeight` api is currently not being used anywhere in the code. Shall we just delete this method?