### PR TITLE
Update v0.22 to Cadence v0.20.0-beta6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.3
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/onflow/atree v0.1.0-beta1
-	github.com/onflow/cadence v0.20.0-beta5
+	github.com/onflow/cadence v0.20.0-beta6
 	github.com/onflow/cadence/v19 v19.0.0-00010101000000-000000000000
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9

--- a/go.sum
+++ b/go.sum
@@ -1043,8 +1043,8 @@ github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2Zfu
 github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.19.0 h1:xpz3Cl57FMHgu3DuvxJa4869g6kDOTSU07pCPrddxSk=
 github.com/onflow/cadence v0.19.0/go.mod h1:ZXcJOh7LZkgqoArtvKx8UYcYQ0cC71zNffP6R1HGGB8=
-github.com/onflow/cadence v0.20.0-beta5 h1:deT7PunEQNqGMlCfiGyoPLIpUUgVwc6yl7LF9JbmrGo=
-github.com/onflow/cadence v0.20.0-beta5/go.mod h1:S6dhIZg63znBB720WcnXAquxiJVGUYVeaowiHZ62+0w=
+github.com/onflow/cadence v0.20.0-beta6 h1:ZxqK2c2o18pvB5obTxNXP2amjjSqVGwRRHtKEmYKv30=
+github.com/onflow/cadence v0.20.0-beta6/go.mod h1:S6dhIZg63znBB720WcnXAquxiJVGUYVeaowiHZ62+0w=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.20.0-beta5
+	github.com/onflow/cadence v0.20.0-beta6
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1164,8 +1164,8 @@ github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFc
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.19.0/go.mod h1:ZXcJOh7LZkgqoArtvKx8UYcYQ0cC71zNffP6R1HGGB8=
-github.com/onflow/cadence v0.20.0-beta5 h1:deT7PunEQNqGMlCfiGyoPLIpUUgVwc6yl7LF9JbmrGo=
-github.com/onflow/cadence v0.20.0-beta5/go.mod h1:S6dhIZg63znBB720WcnXAquxiJVGUYVeaowiHZ62+0w=
+github.com/onflow/cadence v0.20.0-beta6 h1:ZxqK2c2o18pvB5obTxNXP2amjjSqVGwRRHtKEmYKv30=
+github.com/onflow/cadence v0.20.0-beta6/go.mod h1:S6dhIZg63znBB720WcnXAquxiJVGUYVeaowiHZ62+0w=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9 h1:4Yk0ucsLhdh/TxYcCcE+2xXxsTqynvADAZ3d5tmTxVQ=


### PR DESCRIPTION
Includes https://github.com/onflow/cadence/commit/5ecf81d832c92d6032e853b6bd347ec6d189c02d