### PR TITLE
[Flaky test] peer manager flakiness fix

### DIFF
--- a/engine/unit.go
+++ b/engine/unit.go
@@ -74,14 +74,15 @@ func (u *Unit) LaunchAfter(delay time.Duration, f func()) {
 // If f is executed, the unit will not shut down until after f returns.
 func (u *Unit) LaunchPeriodically(f func(), interval time.Duration, delay time.Duration) {
 	u.Launch(func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
 		select {
 		case <-u.ctx.Done():
 			return
 		case <-time.After(delay):
 		}
 
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
 		for {
 			select {
 			case <-u.ctx.Done():

--- a/network/p2p/peerManager.go
+++ b/network/p2p/peerManager.go
@@ -84,6 +84,8 @@ func PeerManagerFactory(peerManagerOptions []Option, connectorOptions ...Connect
 
 // Ready kicks off the ambient periodic connection updates.
 func (pm *PeerManager) Ready() <-chan struct{} {
+	pm.unit.Launch(pm.updateLoop)
+
 	// makes sure that peer update request is invoked once before returning
 	pm.RequestPeerUpdate()
 
@@ -93,8 +95,6 @@ func (pm *PeerManager) Ready() <-chan struct{} {
 	// potentially expensive operation across the network
 	delay := time.Duration(mrand.Int63n(pm.peerUpdateInterval.Nanoseconds()))
 	pm.unit.LaunchPeriodically(pm.RequestPeerUpdate, pm.peerUpdateInterval, delay)
-
-	pm.unit.Launch(pm.updateLoop)
 
 	return pm.unit.Ready()
 }

--- a/network/p2p/peerManager.go
+++ b/network/p2p/peerManager.go
@@ -87,7 +87,7 @@ func (pm *PeerManager) Ready() <-chan struct{} {
 	pm.unit.Launch(pm.updateLoop)
 
 	// makes sure that peer update request is invoked once before returning
-	pm.peerRequestQ <- struct{}{}
+	pm.RequestPeerUpdate()
 
 	// also starts running it periodically
 	//

--- a/network/p2p/peerManager.go
+++ b/network/p2p/peerManager.go
@@ -87,7 +87,7 @@ func (pm *PeerManager) Ready() <-chan struct{} {
 	pm.unit.Launch(pm.updateLoop)
 
 	// makes sure that peer update request is invoked once before returning
-	pm.RequestPeerUpdate()
+	pm.peerRequestQ <- struct{}{}
 
 	// also starts running it periodically
 	//

--- a/network/p2p/peerManager_test.go
+++ b/network/p2p/peerManager_test.go
@@ -142,7 +142,7 @@ func (suite *PeerManagerTestSuite) TestPeriodicPeerUpdate() {
 		}
 	}).Return(nil)
 
-	peerUpdateInterval := 5 * time.Millisecond
+	peerUpdateInterval := 10 * time.Millisecond
 	pm := NewPeerManager(suite.log, idProvider, connector, WithInterval(peerUpdateInterval))
 
 	unittest.RequireCloseBefore(suite.T(), pm.Ready(), 2*time.Second, "could not start peer manager")


### PR DESCRIPTION
The flaky test in question is `TestPeerManagerTestSuite/TestPeriodicPeerUpdate`, but the actual issue is in the implementation of `PeerManager` and `engine.Unit`.

The root cause is described in comments below.

Before the change, `go test -race -count 10 -tags relic -run TestPeerManagerTestSuite -testify.m TestPeriodicPeerUpdate` almost always has at least one failure

After the change, never fails.