### PR TITLE
[Verification] backports fix on crash loop of verification nodes upon an execution fork

### DIFF
--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -197,8 +197,7 @@ func (e *Engine) processAssignedChunk(chunk *flow.Chunk, result *flow.ExecutionR
 	}
 	added := e.pendingChunks.Add(status)
 	if !added {
-		// chunk locators are deduplicated by consumer, reaching this point hints failing deduplication on consumer.
-		return false, blockHeight, fmt.Errorf("data race detected, received a duplicate chunk locator")
+		return false, blockHeight, nil
 	}
 
 	err = e.requestChunkDataPack(chunkID, result.ID(), chunk.BlockID)


### PR DESCRIPTION
This PR backports a hotfix for the crash loop of verification nodes upon an execution fork from https://github.com/onflow/flow-go/pull/1403 to master. A long-term fix is in progress in https://github.com/dapperlabs/flow-go/issues/5902.