### PR TITLE
Simplify address conversion

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -303,7 +303,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		serviceEventA := cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress(serviceEvents.EpochSetup.Address.Bytes()),
+					Address: common.Address(serviceEvents.EpochSetup.Address),
 				},
 				QualifiedIdentifier: serviceEvents.EpochSetup.QualifiedIdentifier(),
 			},
@@ -311,7 +311,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		serviceEventB := cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress(serviceEvents.EpochCommit.Address.Bytes()),
+					Address: common.Address(serviceEvents.EpochCommit.Address),
 				},
 				QualifiedIdentifier: serviceEvents.EpochCommit.QualifiedIdentifier(),
 			},

--- a/fvm/account.go
+++ b/fvm/account.go
@@ -24,7 +24,7 @@ func getAccount(
 
 	if ctx.ServiceAccountEnabled {
 		env := NewScriptEnvironment(ctx, vm, sth, programs)
-		balance, err := env.GetAccountBalance(common.BytesToAddress(address.Bytes()))
+		balance, err := env.GetAccountBalance(common.Address(address))
 		if err != nil {
 			return nil, err
 		}

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -1218,7 +1218,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				txBody := transferTokensTx(chain).
 					AddArgument(jsoncdc.MustEncode(cadence.UFix64(1_0000_0000))).
-					AddArgument(jsoncdc.MustEncode(cadence.BytesToAddress(account.Bytes()))).
+					AddArgument(jsoncdc.MustEncode(cadence.Address(account))).
 					AddAuthorizer(chain.ServiceAddress())
 
 				tx := fvm.Transaction(txBody, 0)
@@ -1254,7 +1254,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				txBody := transferTokensTx(chain).
 					AddArgument(jsoncdc.MustEncode(cadence.UFix64(1_0000_0000))).
-					AddArgument(jsoncdc.MustEncode(cadence.BytesToAddress(account.Bytes()))).
+					AddArgument(jsoncdc.MustEncode(cadence.Address(account))).
 					AddAuthorizer(chain.ServiceAddress())
 
 				tx := fvm.Transaction(txBody, 0)
@@ -1293,7 +1293,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				txBody := transferTokensTx(chain).
 					AddArgument(jsoncdc.MustEncode(cadence.UFix64(1_0000_0000))).
-					AddArgument(jsoncdc.MustEncode(cadence.BytesToAddress(account.Bytes()))).
+					AddArgument(jsoncdc.MustEncode(cadence.Address(account))).
 					AddAuthorizer(chain.ServiceAddress())
 
 				tx := fvm.Transaction(txBody, 0)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -435,7 +435,7 @@ func BenchRunNFTBatchTransfer(b *testing.B,
 	// Transfer NFTs
 	transferTx := []byte(fmt.Sprintf(TransferTxTemplate, accounts[0].Address.Hex(), accounts[1].Address.Hex()))
 
-	encodedAddress, err := jsoncdc.Encode(cadence.BytesToAddress(accounts[2].Address.Bytes()))
+	encodedAddress, err := jsoncdc.Encode(cadence.Address(accounts[2].Address))
 	require.NoError(b, err)
 
 	var computationResult *execution.ComputationResult
@@ -559,7 +559,7 @@ func fundAccounts(b *testing.B, be TestBenchBlockExecutor, value cadence.UFix64,
 		txBody := transferTokensTx(be.Chain(b))
 		txBody.SetProposalKey(serviceAccount.Address, 0, serviceAccount.RetAndIncSeqNumber())
 		txBody.AddArgument(jsoncdc.MustEncode(value))
-		txBody.AddArgument(jsoncdc.MustEncode(cadence.BytesToAddress(a.Bytes())))
+		txBody.AddArgument(jsoncdc.MustEncode(cadence.Address(a)))
 		txBody.AddAuthorizer(serviceAccount.Address)
 		txBody.SetPayer(serviceAccount.Address)
 

--- a/fvm/handler/event_test.go
+++ b/fvm/handler/event_test.go
@@ -25,7 +25,7 @@ func Test_IsServiceEvent(t *testing.T) {
 			isServiceEvent, err := handler.IsServiceEvent(cadence.Event{
 				EventType: &cadence.EventType{
 					Location: common.AddressLocation{
-						Address: common.BytesToAddress(event.Address.Bytes()),
+						Address: common.Address(event.Address),
 					},
 					QualifiedIdentifier: event.QualifiedIdentifier(),
 				},
@@ -39,7 +39,7 @@ func Test_IsServiceEvent(t *testing.T) {
 		isServiceEvent, err := handler.IsServiceEvent(cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress(flow.Testnet.Chain().ServiceAddress().Bytes()),
+					Address: common.Address(flow.Testnet.Chain().ServiceAddress()),
 				},
 				QualifiedIdentifier: events.EpochCommit.QualifiedIdentifier(),
 			},
@@ -52,7 +52,7 @@ func Test_IsServiceEvent(t *testing.T) {
 		isServiceEvent, err := handler.IsServiceEvent(cadence.Event{
 			EventType: &cadence.EventType{
 				Location: common.AddressLocation{
-					Address: common.BytesToAddress(chain.Chain().ServiceAddress().Bytes()),
+					Address: common.Address(chain.Chain().ServiceAddress()),
 				},
 				QualifiedIdentifier: "SomeContract.SomeEvent",
 			},

--- a/fvm/handler/programs_test.go
+++ b/fvm/handler/programs_test.go
@@ -23,17 +23,17 @@ func Test_Programs(t *testing.T) {
 	addressC := flow.HexToAddress("0c")
 
 	contractALocation := common.AddressLocation{
-		Address: common.BytesToAddress(addressA.Bytes()),
+		Address: common.Address(addressA),
 		Name:    "A",
 	}
 
 	contractBLocation := common.AddressLocation{
-		Address: common.BytesToAddress(addressB.Bytes()),
+		Address: common.Address(addressB),
 		Name:    "B",
 	}
 
 	contractCLocation := common.AddressLocation{
-		Address: common.BytesToAddress(addressC.Bytes()),
+		Address: common.Address(addressC),
 		Name:    "C",
 	}
 

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -156,7 +156,7 @@ func (e *ScriptEnv) ValueExists(owner, key []byte) (exists bool, err error) {
 }
 
 func (e *ScriptEnv) AccountExists(address common.Address) (exists bool, err error) {
-	return e.accounts.Exists(flow.BytesToAddress(address.Bytes()))
+	return e.accounts.Exists(flow.Address(address))
 }
 
 func (e *ScriptEnv) GetStorageUsed(address common.Address) (value uint64, err error) {
@@ -165,7 +165,7 @@ func (e *ScriptEnv) GetStorageUsed(address common.Address) (value uint64, err er
 		defer sp.Finish()
 	}
 
-	value, err = e.accounts.GetStorageUsed(flow.BytesToAddress(address.Bytes()))
+	value, err = e.accounts.GetStorageUsed(flow.Address(address))
 	if err != nil {
 		return value, fmt.Errorf("getting storage used failed: %w", err)
 	}
@@ -179,7 +179,7 @@ func (e *ScriptEnv) GetStorageCapacity(address common.Address) (value uint64, er
 		defer sp.Finish()
 	}
 
-	script := Script(blueprints.GetStorageCapacityScript(flow.BytesToAddress(address.Bytes()), e.ctx.Chain.ServiceAddress()))
+	script := Script(blueprints.GetStorageCapacityScript(flow.Address(address), e.ctx.Chain.ServiceAddress()))
 
 	// TODO (ramtin) this shouldn't be this way, it should call the invokeMeta
 	// and we handle the errors and still compute the state interactions
@@ -214,7 +214,7 @@ func (e *ScriptEnv) GetAccountBalance(address common.Address) (value uint64, err
 		defer sp.Finish()
 	}
 
-	script := Script(blueprints.GetFlowTokenBalanceScript(flow.BytesToAddress(address.Bytes()), e.ctx.Chain.ServiceAddress()))
+	script := Script(blueprints.GetFlowTokenBalanceScript(flow.Address(address), e.ctx.Chain.ServiceAddress()))
 
 	// TODO similar to the one above
 	err = e.vm.Run(
@@ -242,7 +242,7 @@ func (e *ScriptEnv) GetAccountAvailableBalance(address common.Address) (value ui
 		defer sp.Finish()
 	}
 
-	script := Script(blueprints.GetFlowTokenAvailableBalanceScript(flow.BytesToAddress(address.Bytes()), e.ctx.Chain.ServiceAddress()))
+	script := Script(blueprints.GetFlowTokenAvailableBalanceScript(flow.Address(address), e.ctx.Chain.ServiceAddress()))
 
 	// TODO similar to the one above
 	err = e.vm.Run(
@@ -341,7 +341,7 @@ func (e *ScriptEnv) GetAccountContractNames(address runtime.Address) ([]string, 
 		defer sp.Finish()
 	}
 
-	a := flow.BytesToAddress(address.Bytes())
+	a := flow.Address(address)
 
 	freezeError := e.accounts.CheckAccountNotFrozen(a)
 	if freezeError != nil {
@@ -362,7 +362,7 @@ func (e *ScriptEnv) GetCode(location runtime.Location) ([]byte, error) {
 		return nil, errors.NewInvalidLocationErrorf(location, "expecting an AddressLocation, but other location types are passed")
 	}
 
-	address := flow.BytesToAddress(contractLocation.Address.Bytes())
+	address := flow.Address(contractLocation.Address)
 
 	err := e.accounts.CheckAccountNotFrozen(address)
 	if err != nil {
@@ -384,7 +384,7 @@ func (e *ScriptEnv) GetProgram(location common.Location) (*interpreter.Program, 
 	}
 
 	if addressLocation, ok := location.(common.AddressLocation); ok {
-		address := flow.BytesToAddress(addressLocation.Address.Bytes())
+		address := flow.Address(addressLocation.Address)
 
 		freezeError := e.accounts.CheckAccountNotFrozen(address)
 		if freezeError != nil {

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -253,7 +253,7 @@ func (e *TransactionEnv) GetStorageUsed(address common.Address) (value uint64, e
 		defer sp.Finish()
 	}
 
-	value, err = e.accounts.GetStorageUsed(flow.BytesToAddress(address.Bytes()))
+	value, err = e.accounts.GetStorageUsed(flow.Address(address))
 	if err != nil {
 		return value, fmt.Errorf("getting storage used failed: %w", err)
 	}
@@ -267,7 +267,7 @@ func (e *TransactionEnv) GetStorageCapacity(address common.Address) (value uint6
 		defer sp.Finish()
 	}
 
-	script := Script(blueprints.GetStorageCapacityScript(flow.BytesToAddress(address.Bytes()), e.ctx.Chain.ServiceAddress()))
+	script := Script(blueprints.GetStorageCapacityScript(flow.Address(address), e.ctx.Chain.ServiceAddress()))
 
 	// TODO (ramtin) this shouldn't be this way, it should call the invokeMeta
 	// and we handle the errors and still compute the state interactions
@@ -302,7 +302,7 @@ func (e *TransactionEnv) GetAccountBalance(address common.Address) (value uint64
 		defer sp.Finish()
 	}
 
-	script := Script(blueprints.GetFlowTokenBalanceScript(flow.BytesToAddress(address.Bytes()), e.ctx.Chain.ServiceAddress()))
+	script := Script(blueprints.GetFlowTokenBalanceScript(flow.Address(address), e.ctx.Chain.ServiceAddress()))
 
 	// TODO similar to the one above
 	err = e.vm.Run(
@@ -330,7 +330,7 @@ func (e *TransactionEnv) GetAccountAvailableBalance(address common.Address) (val
 		defer sp.Finish()
 	}
 
-	script := Script(blueprints.GetFlowTokenAvailableBalanceScript(flow.BytesToAddress(address.Bytes()), e.ctx.Chain.ServiceAddress()))
+	script := Script(blueprints.GetFlowTokenAvailableBalanceScript(flow.Address(address), e.ctx.Chain.ServiceAddress()))
 
 	// TODO similar to the one above
 	err = e.vm.Run(
@@ -434,7 +434,7 @@ func (e *TransactionEnv) GetCode(location runtime.Location) ([]byte, error) {
 		return nil, errors.NewInvalidLocationErrorf(location, "expecting an AddressLocation, but other location types are passed")
 	}
 
-	address := flow.BytesToAddress(contractLocation.Address.Bytes())
+	address := flow.Address(contractLocation.Address)
 
 	err := e.accounts.CheckAccountNotFrozen(address)
 	if err != nil {
@@ -455,7 +455,7 @@ func (e *TransactionEnv) GetAccountContractNames(address runtime.Address) ([]str
 		defer sp.Finish()
 	}
 
-	a := flow.BytesToAddress(address.Bytes())
+	a := flow.Address(address)
 
 	freezeError := e.accounts.CheckAccountNotFrozen(a)
 	if freezeError != nil {
@@ -472,7 +472,7 @@ func (e *TransactionEnv) GetProgram(location common.Location) (*interpreter.Prog
 	}
 
 	if addressLocation, ok := location.(common.AddressLocation); ok {
-		address := flow.BytesToAddress(addressLocation.Address.Bytes())
+		address := flow.Address(addressLocation.Address)
 
 		freezeError := e.accounts.CheckAccountNotFrozen(address)
 		if freezeError != nil {
@@ -732,11 +732,11 @@ func (e *TransactionEnv) CreateAccount(payer runtime.Address) (address runtime.A
 	if e.ctx.ServiceAccountEnabled {
 		// uses `FlowServiceAccount.setupNewAccount` from https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowServiceAccount.cdc
 		invoker := NewTransactionContractFunctionInvocator(
-			common.AddressLocation{Address: common.BytesToAddress(e.ctx.Chain.ServiceAddress().Bytes()), Name: flowServiceAccountContract},
+			common.AddressLocation{Address: common.Address(e.ctx.Chain.ServiceAddress()), Name: flowServiceAccountContract},
 			"setupNewAccount",
 			[]interpreter.Value{
-				interpreter.NewAddressValue(common.BytesToAddress(flowAddress.Bytes())),
-				interpreter.NewAddressValue(common.BytesToAddress(payer.Bytes())),
+				interpreter.NewAddressValue(common.Address(flowAddress)),
+				interpreter.NewAddressValue(payer),
 			},
 			[]sema.Type{
 				sema.AuthAccountType,

--- a/fvm/transactionInvocator.go
+++ b/fvm/transactionInvocator.go
@@ -243,12 +243,12 @@ func (i *TransactionInvocator) deductTransactionFees(env *TransactionEnv, proc *
 
 	invocator := NewTransactionContractFunctionInvocator(
 		common.AddressLocation{
-			Address: common.BytesToAddress(env.ctx.Chain.ServiceAddress().Bytes()),
+			Address: common.Address(env.ctx.Chain.ServiceAddress()),
 			Name:    flowServiceAccountContract,
 		},
 		deductFeesContractFunction,
 		[]interpreter.Value{
-			interpreter.NewAddressValue(common.BytesToAddress(proc.Transaction.Payer.Bytes())),
+			interpreter.NewAddressValue(common.Address(proc.Transaction.Payer)),
 		},
 		[]sema.Type{
 			sema.AuthAccountType,

--- a/fvm/transactionInvocator_test.go
+++ b/fvm/transactionInvocator_test.go
@@ -244,8 +244,10 @@ func TestSafetyCheck(t *testing.T) {
 								TargetType: sema.AnyType,
 							}, // some dummy error
 							&sema.ImportedProgramError{
-								Err:      &sema.CheckerError{},
-								Location: common.AddressLocation{Address: common.BytesToAddress([]byte{1, 2, 3, 4})},
+								Err: &sema.CheckerError{},
+								Location: common.AddressLocation{
+									Address: common.BytesToAddress([]byte{1, 2, 3, 4}),
+								},
 							},
 						},
 					},

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -25,7 +25,7 @@ func (d *TransactionStorageLimiter) CheckLimits(
 
 	// iterating through a map in a non-deterministic order! Do not exit the loop early.
 	for _, address := range addresses {
-		commonAddress := common.BytesToAddress(address.Bytes())
+		commonAddress := common.Address(address)
 
 		capacity, err := env.GetStorageCapacity(commonAddress)
 		if err != nil {

--- a/integration/convert/convert.go
+++ b/integration/convert/convert.go
@@ -26,7 +26,7 @@ func ToSDKID(id flow.Identifier) sdk.Identifier {
 }
 
 func ToSDKAddress(addr flow.Address) sdk.Address {
-	return sdk.BytesToAddress(addr.Bytes())
+	return sdk.Address(addr)
 }
 
 func ToSDKTransactionSignature(sig flow.TransactionSignature) sdk.TransactionSignature {


### PR DESCRIPTION
There is no need to convert from a Cadence address, an 8-byte array, to a short byte slice (leading zeros removed), then convert back to a Flow address, again an 8-byte array. Simply convert directly between the two arrays address types