### PR TITLE
Fix for error wrapping problem

### DIFF
--- a/consensus/hotstuff/model/errors.go
+++ b/consensus/hotstuff/model/errors.go
@@ -121,6 +121,13 @@ func IsDoubleVoteError(err error) bool {
 	return errors.As(err, &e)
 }
 
+// AsDoubleVoteError determines whether the given error is a DoubleVoteError
+// (potentially wrapped). It follows the same semantics as a checked type cast.
+func AsDoubleVoteError(err error) (*DoubleVoteError, bool) {
+	var e *DoubleVoteError
+	return e, errors.As(err, e)
+}
+
 func (e DoubleVoteError) Unwrap() error {
 	return e.err
 }

--- a/consensus/hotstuff/votecollector/statemachine.go
+++ b/consensus/hotstuff/votecollector/statemachine.go
@@ -81,8 +81,7 @@ func (m *VoteCollector) AddVote(vote *model.Vote) error {
 		if errors.Is(err, RepeatedVoteErr) {
 			return nil
 		}
-		if model.IsDoubleVoteError(err) {
-			doubleVoteErr := err.(model.DoubleVoteError)
+		if doubleVoteErr, isDoubleVoteErr := model.AsDoubleVoteError(err); isDoubleVoteErr {
 			m.notifier.OnDoubleVotingDetected(doubleVoteErr.FirstVote, doubleVoteErr.ConflictingVote)
 			return nil
 		}


### PR DESCRIPTION
I think the following code is vulnerable to wrapped errors: https://github.com/onflow/flow-go/blob/da30152b02bc18f9941463f720f176fb110dafc6/consensus/hotstuff/votecollector/statemachine.go#L84-L85
* we check that `err` is a (potentially wrapped) `DoubleVoteError`
* we directly cast to `DoubleVoteError`, which I think would fail for wrapped errors. 

At the moment, the `VotesCache` returns the pure `DoubleVoteError` without any wrapping: https://github.com/onflow/flow-go/blob/da30152b02bc18f9941463f720f176fb110dafc6/consensus/hotstuff/votecollector/vote_cache.go#L77
 Therefore, the code works as is. Though the code is brittle, because it is easily broken during future maintenance. I think the consuming code should also tolerate a wrapped error



