### PR TITLE
Transaction fees enable fix

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -706,7 +706,9 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 		fvm.WithAccountStorageLimit(true),
 	}
 	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary || fnb.RootChainID == flow.Mainnet {
-		fvm.WithTransactionFeesEnabled(true)
+		vmOpts = append(vmOpts,
+			fvm.WithTransactionFeesEnabled(true),
+		)
 	}
 	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary {
 		vmOpts = append(vmOpts,


### PR DESCRIPTION
`WithTransactionFeesEnabled` wasn't actually being added to the list of options. This meant transaction fees were never on.

They should be on on canary, testnet, and mainnet.