### PR TITLE
[State Sync Engine] state serialization module

### DIFF
--- a/engine/execution/state_synchronization/state_diff_storer.go
+++ b/engine/execution/state_synchronization/state_diff_storer.go
@@ -1,0 +1,179 @@
+package state_synchronization
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/encoding"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/network"
+)
+
+const MAX_BLOCK_SIZE = 1e6
+
+type ExecutionStateDiff struct {
+	Collections        []*flow.Collection
+	Events             []*flow.Event
+	TrieUpdate         []*ledger.TrieUpdate
+	TransactionResults []*flow.TransactionResult
+}
+
+type StateDiffStorer struct {
+	blockWriter *BlockWriter
+	codec       encoding.Codec
+	compressor  network.Compressor
+}
+
+func NewStateDiffStorer(
+	codec encoding.Codec,
+	compressor network.Compressor,
+	bstore blockstore.Blockstore,
+) (*StateDiffStorer, error) {
+	bw := &BlockWriter{
+		maxBlockSize: MAX_BLOCK_SIZE,
+		bstore:       bstore,
+	}
+	return &StateDiffStorer{bw, codec, compressor}, nil
+}
+
+func (s *StateDiffStorer) writeBlocks(v interface{}) ([]cid.Cid, error) {
+	comp, err := s.compressor.NewWriter(s.blockWriter)
+	if err != nil {
+		return nil, err
+	}
+	enc := s.codec.NewEncoder(comp)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	if err := comp.Close(); err != nil {
+		return nil, err
+	}
+	if err := s.blockWriter.Flush(); err != nil {
+		return nil, err
+	}
+	cids := s.blockWriter.GetWrittenCids()
+	s.blockWriter.Reset()
+	return cids, nil
+}
+
+func (s *StateDiffStorer) Store(sd *ExecutionStateDiff) (cid.Cid, error) {
+	if cids, err := s.writeBlocks(sd); err != nil {
+		return cid.Undef, fmt.Errorf("failed to write state diff blocks: %w", err)
+	} else {
+		for {
+			if len(cids) == 1 {
+				return cids[0], nil
+			}
+
+			if cids, err = s.writeBlocks(cids); err != nil {
+				return cid.Undef, fmt.Errorf("failed to write cid blocks: %w", err)
+			}
+		}
+	}
+}
+
+func (s *StateDiffStorer) readBlocks(cids []cid.Cid, v interface{}) error {
+	buf := &bytes.Buffer{}
+	comp, err := s.compressor.NewReader(buf)
+	if err != nil {
+		return err
+	}
+	dec := s.codec.NewDecoder(comp)
+	for _, c := range cids {
+		block, err := s.blockWriter.bstore.Get(c)
+		if err != nil {
+			return fmt.Errorf("failed to get block %v from blockstore: %w", c, err)
+		}
+		_, _ = buf.Write(block.RawData()) // never returns error
+	}
+	return dec.Decode(v)
+}
+
+func (s *StateDiffStorer) Load(c cid.Cid) (*ExecutionStateDiff, error) {
+	cids := []cid.Cid{c}
+	for {
+		var sd ExecutionStateDiff
+		if err := s.readBlocks(cids, &sd); err == nil {
+			return &sd, nil
+		} else {
+			if err := s.readBlocks(cids, &cids); err != nil {
+				return nil, fmt.Errorf("could not parse blocks as cids: %w", err)
+			}
+		}
+	}
+}
+
+var _ io.Writer = (*BlockWriter)(nil)
+
+type BlockWriter struct {
+	maxBlockSize int
+	bstore       blockstore.Blockstore
+	cids         []cid.Cid
+	buf          []byte // unflushed bytes from previous write
+}
+
+func (bw *BlockWriter) Reset() {
+	bw.cids = nil
+	bw.buf = nil
+}
+
+func (bw *BlockWriter) GetWrittenCids() []cid.Cid {
+	return bw.cids
+}
+
+func (bw *BlockWriter) Flush() error {
+	if len(bw.buf) > 0 {
+		if err := bw.writeBlock(bw.buf); err != nil {
+			return err
+		}
+		bw.buf = nil
+	}
+	return nil
+}
+
+func (bw *BlockWriter) writeBlock(data []byte) error {
+	block := blocks.NewBlock(data)
+	if err := bw.bstore.Put(block); err != nil {
+		return fmt.Errorf("failed to put block %v into blockstore: %w", block.Cid(), err)
+	}
+	bw.cids = append(bw.cids, block.Cid())
+	return nil
+}
+
+func (bw *BlockWriter) Write(p []byte) (n int, err error) {
+	var chunk []byte
+	if leftover := len(bw.buf); leftover > 0 {
+		fill := bw.maxBlockSize - leftover
+		if fill > len(p) {
+			bw.buf = append(bw.buf, p...)
+			return len(p), nil
+		}
+		chunk, p = append(bw.buf, p[:fill]...), p[fill:]
+		if err = bw.writeBlock(chunk); err != nil {
+			return
+		} else {
+			n += fill
+		}
+		bw.buf = nil
+	}
+	for len(p) >= bw.maxBlockSize {
+		chunk, p = p[:bw.maxBlockSize], p[bw.maxBlockSize:]
+		if err = bw.writeBlock(chunk); err != nil {
+			return
+		} else {
+			n += bw.maxBlockSize
+		}
+	}
+	if len(p) > 0 {
+		bw.buf = make([]byte, 0, bw.maxBlockSize)
+		bw.buf = append(bw.buf, p...)
+		n += len(bw.buf)
+	}
+	return
+}

--- a/engine/execution/state_synchronization/state_diff_storer.go
+++ b/engine/execution/state_synchronization/state_diff_storer.go
@@ -63,17 +63,18 @@ func (s *StateDiffStorer) writeBlocks(v interface{}) ([]cid.Cid, error) {
 }
 
 func (s *StateDiffStorer) Store(sd *ExecutionStateDiff) (cid.Cid, error) {
-	if cids, err := s.writeBlocks(sd); err != nil {
+	cids, err := s.writeBlocks(sd)
+	if err != nil {
 		return cid.Undef, fmt.Errorf("failed to write state diff blocks: %w", err)
-	} else {
-		for {
-			if len(cids) == 1 {
-				return cids[0], nil
-			}
+	}
 
-			if cids, err = s.writeBlocks(cids); err != nil {
-				return cid.Undef, fmt.Errorf("failed to write cid blocks: %w", err)
-			}
+	for {
+		if len(cids) == 1 {
+			return cids[0], nil
+		}
+
+		if cids, err = s.writeBlocks(cids); err != nil {
+			return cid.Undef, fmt.Errorf("failed to write cid blocks: %w", err)
 		}
 	}
 }
@@ -101,10 +102,9 @@ func (s *StateDiffStorer) Load(c cid.Cid) (*ExecutionStateDiff, error) {
 		var sd ExecutionStateDiff
 		if err := s.readBlocks(cids, &sd); err == nil {
 			return &sd, nil
-		} else {
-			if err := s.readBlocks(cids, &cids); err != nil {
-				return nil, fmt.Errorf("could not parse blocks as cids: %w", err)
-			}
+		}
+		if err := s.readBlocks(cids, &cids); err != nil {
+			return nil, fmt.Errorf("could not parse blocks as cids: %w", err)
 		}
 	}
 }

--- a/engine/execution/state_synchronization/state_diff_storer.go
+++ b/engine/execution/state_synchronization/state_diff_storer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/onflow/flow-go/network"
 )
 
-const MAX_BLOCK_SIZE = 1e6
+const MAX_BLOCK_SIZE = 1e6 // 1MB
 
 type ExecutionStateDiff struct {
 	Collections        []*flow.Collection
@@ -96,6 +96,10 @@ func (s *StateDiffStorer) readBlocks(cids []cid.Cid, v interface{}) error {
 	return dec.Decode(v)
 }
 
+// Load loads the ExecutionStateDiff represented by the given CID from the blockstore.
+// Since blocks are limited to MAX_BLOCK_SIZE bytes, it's possible that the data was
+// stored in multiple chunks, and hence the root CID may point to a block for which
+// the data itself is a list of concatenated CIDs.
 func (s *StateDiffStorer) Load(c cid.Cid) (*ExecutionStateDiff, error) {
 	cids := []cid.Cid{c}
 	for {

--- a/engine/execution/state_synchronization/state_diff_storer_test.go
+++ b/engine/execution/state_synchronization/state_diff_storer_test.go
@@ -118,7 +118,7 @@ func TestStateDiffStorer(t *testing.T) {
 		duration = time.Since(start)
 		require.NoError(t, err)
 		t.Logf("time to load state diff: %v\n", duration)
-		if maxLoadTime > duration {
+		if duration > maxLoadTime {
 			maxLoadTime = duration
 		}
 

--- a/engine/execution/state_synchronization/state_diff_storer_test.go
+++ b/engine/execution/state_synchronization/state_diff_storer_test.go
@@ -2,17 +2,12 @@ package state_synchronization
 
 import (
 	"context"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/fxamacker/cbor/v2"
-	datastore "github.com/ipfs/go-datastore/examples"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/iterator"
@@ -22,27 +17,14 @@ import (
 	cborcodec "github.com/onflow/flow-go/model/encoding/cbor"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/network/compressor"
+	"github.com/onflow/flow-go/network/test"
 )
-
-func makeBlockstore(t *testing.T, name string) (blockstore.Blockstore, func()) {
-	dsDir := filepath.Join(os.TempDir(), name)
-	require.NoError(t, os.RemoveAll(dsDir))
-	err := os.Mkdir(dsDir, fs.ModeDir)
-	require.NoError(t, err)
-
-	ds, err := datastore.NewDatastore(dsDir)
-	require.NoError(t, err)
-
-	return blockstore.NewBlockstore(ds.(*datastore.Datastore)), func() {
-		require.NoError(t, os.RemoveAll(dsDir))
-	}
-}
 
 const BUCKET_NAME = "flow_public_mainnet14_execution_state"
 
 func TestStateDiffStorer(t *testing.T) {
 	// this test is intended to be run locally
-	t.Skip()
+	t.Skip("manual test")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -74,7 +56,7 @@ func TestStateDiffStorer(t *testing.T) {
 		require.NoError(t, err)
 		defer reader.Close()
 
-		bstore, cleanup := makeBlockstore(t, "state-diff-storer-test")
+		bstore, cleanup := test.MakeBlockstore(t, "state-diff-storer-test")
 		defer cleanup()
 
 		sdp, err := NewStateDiffStorer(&cborcodec.Codec{}, compressor.NewLz4Compressor(), bstore)

--- a/engine/execution/state_synchronization/state_diff_storer_test.go
+++ b/engine/execution/state_synchronization/state_diff_storer_test.go
@@ -1,0 +1,70 @@
+package state_synchronization
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+	datastore "github.com/ipfs/go-datastore/examples"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/engine/execution/computation/computer/uploader"
+	cborcodec "github.com/onflow/flow-go/model/encoding/cbor"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/network/compressor"
+)
+
+func makeBlockstore(t *testing.T, name string) (blockstore.Blockstore, func()) {
+	dsDir := filepath.Join(os.TempDir(), name)
+	require.NoError(t, os.RemoveAll(dsDir))
+	err := os.Mkdir(dsDir, fs.ModeDir)
+	require.NoError(t, err)
+
+	ds, err := datastore.NewDatastore(dsDir)
+	require.NoError(t, err)
+
+	return blockstore.NewBlockstore(ds.(*datastore.Datastore)), func() {
+		require.NoError(t, os.RemoveAll(dsDir))
+	}
+}
+
+func TestStateDiffStorer(t *testing.T) {
+	bstore, cleanup := makeBlockstore(t, "state-diff-storer-test")
+	defer cleanup()
+
+	sdp, err := NewStateDiffStorer(&cborcodec.Codec{}, compressor.NewLz4Compressor(), bstore)
+	require.NoError(t, err)
+
+	file, err := os.Open("/Users/smnzhu/Downloads/8aeb01b08a446434ea4746aaaec1c458fd24922e26a13e94842bafb74e681670.cbor")
+	require.NoError(t, err)
+
+	var blockData uploader.BlockData
+
+	decoder := cbor.NewDecoder(file)
+	require.NoError(t, decoder.Decode(&blockData))
+
+	var collections []*flow.Collection
+	for _, c := range blockData.Collections {
+		collections = append(collections, &flow.Collection{Transactions: c.Transactions})
+	}
+
+	sd := &ExecutionStateDiff{
+		Collections:        collections,
+		TransactionResults: blockData.TxResults,
+		Events:             blockData.Events,
+		TrieUpdate:         blockData.TrieUpdates,
+	}
+
+	cid, err := sdp.Store(sd)
+	require.NoError(t, err)
+
+	sd2, err := sdp.Load(cid)
+	require.NoError(t, err)
+
+	assert.True(t, reflect.DeepEqual(sd, sd2))
+}

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/onflow/flow/protobuf/go/flow v0.2.3
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/psiemens/sconfig v0.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/onflow/flow/protobuf/go/flow v0.2.3
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
 	github.com/psiemens/sconfig v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1174,6 +1174,8 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
+github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1306,6 +1306,8 @@ github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssy
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
+github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/model/encoding/cbor/codec.go
+++ b/model/encoding/cbor/codec.go
@@ -2,14 +2,19 @@ package cbor
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/fxamacker/cbor/v2"
+
+	"github.com/onflow/flow-go/model/encoding"
 )
 
-type Encoder struct{}
+var _ encoding.Marshaler = (*Marshaler)(nil)
 
-func NewEncoder() *Encoder {
-	return &Encoder{}
+type Marshaler struct{}
+
+func NewMarshaler() *Marshaler {
+	return &Marshaler{}
 }
 
 // "For best performance, reuse EncMode and DecMode after creating them." [1]
@@ -26,16 +31,16 @@ var EncMode = func() cbor.EncMode {
 	return encMode
 }()
 
-func (e *Encoder) Encode(val interface{}) ([]byte, error) {
+func (m *Marshaler) Marshal(val interface{}) ([]byte, error) {
 	return EncMode.Marshal(val)
 }
 
-func (e *Encoder) Decode(b []byte, val interface{}) error {
+func (m *Marshaler) Unmarshal(b []byte, val interface{}) error {
 	return cbor.Unmarshal(b, val)
 }
 
-func (e *Encoder) MustEncode(val interface{}) []byte {
-	b, err := e.Encode(val)
+func (m *Marshaler) MustMarshal(val interface{}) []byte {
+	b, err := m.Marshal(val)
 	if err != nil {
 		panic(err)
 	}
@@ -43,9 +48,21 @@ func (e *Encoder) MustEncode(val interface{}) []byte {
 	return b
 }
 
-func (e *Encoder) MustDecode(b []byte, val interface{}) {
-	err := e.Decode(b, val)
+func (m *Marshaler) MustUnmarshal(b []byte, val interface{}) {
+	err := m.Unmarshal(b, val)
 	if err != nil {
 		panic(err)
 	}
+}
+
+var _ encoding.Codec = (*Codec)(nil)
+
+type Codec struct{}
+
+func (c *Codec) NewEncoder(w io.Writer) encoding.Encoder {
+	return EncMode.NewEncoder(w)
+}
+
+func (c *Codec) NewDecoder(r io.Reader) encoding.Decoder {
+	return cbor.NewDecoder(r)
 }

--- a/model/encoding/codec.go
+++ b/model/encoding/codec.go
@@ -1,7 +1,7 @@
 package encoding
 
 import (
-	"github.com/onflow/flow-go/model/encoding/json"
+	"io"
 )
 
 // Encodable is a type that defines a canonical encoding.
@@ -9,28 +9,38 @@ type Encodable interface {
 	Encode() []byte
 }
 
-// Encoder encodes and decodes values to and from bytes.
-type Encoder interface {
-	// Encode encodes a value as bytes.
+// Marshaler marshals and unmarshals values to and from bytes.
+type Marshaler interface {
+	// Marshaler marshals a value to bytes.
 	//
-	// This function returns an error if the value type is not supported by this encoder.
-	Encode(interface{}) ([]byte, error)
+	// This function returns an error if the value type is not supported by this marshaler.
+	Marshal(interface{}) ([]byte, error)
 
-	// Decode decodes bytes into a value.
+	// Unmarshal unmarshals bytes to a value.
 	//
 	// This functions returns an error if the bytes do not fit the provided value type.
-	Decode([]byte, interface{}) error
+	Unmarshal([]byte, interface{}) error
 
-	// MustEncode encodes a value as bytes.
+	// MustMarshal marshals a value to bytes.
 	//
-	// This functions panic if encoding fails.
-	MustEncode(interface{}) []byte
+	// This function panics if marshaling fails.
+	MustMarshal(interface{}) []byte
 
-	// MustDecode decodes bytes into a value.
+	// MustUnmarshal unmarshals bytes to a value.
 	//
-	// This functions panic if decoding fails.
-	MustDecode([]byte, interface{})
+	// This function panics if decoding fails.
+	MustUnmarshal([]byte, interface{})
 }
 
-// DefaultEncoder is the default encoder used by Flow.
-var DefaultEncoder Encoder = json.NewEncoder()
+type Encoder interface {
+	Encode(interface{}) error
+}
+
+type Decoder interface {
+	Decode(interface{}) error
+}
+
+type Codec interface {
+	NewEncoder(w io.Writer) Encoder
+	NewDecoder(r io.Reader) Decoder
+}

--- a/model/encoding/json/codec.go
+++ b/model/encoding/json/codec.go
@@ -2,24 +2,29 @@ package json
 
 import (
 	"encoding/json"
+	"io"
+
+	"github.com/onflow/flow-go/model/encoding"
 )
 
-type Encoder struct{}
+var _ encoding.Marshaler = (*Marshaler)(nil)
 
-func NewEncoder() *Encoder {
-	return &Encoder{}
+type Marshaler struct{}
+
+func NewMarshaler() *Marshaler {
+	return &Marshaler{}
 }
 
-func (e *Encoder) Encode(val interface{}) ([]byte, error) {
+func (m *Marshaler) Marshal(val interface{}) ([]byte, error) {
 	return json.Marshal(val)
 }
 
-func (e *Encoder) Decode(b []byte, val interface{}) error {
+func (m *Marshaler) Unmarshal(b []byte, val interface{}) error {
 	return json.Unmarshal(b, val)
 }
 
-func (e *Encoder) MustEncode(val interface{}) []byte {
-	b, err := e.Encode(val)
+func (m *Marshaler) MustMarshal(val interface{}) []byte {
+	b, err := m.Marshal(val)
 	if err != nil {
 		panic(err)
 	}
@@ -27,9 +32,21 @@ func (e *Encoder) MustEncode(val interface{}) []byte {
 	return b
 }
 
-func (e *Encoder) MustDecode(b []byte, val interface{}) {
-	err := e.Decode(b, val)
+func (m *Marshaler) MustUnmarshal(b []byte, val interface{}) {
+	err := m.Unmarshal(b, val)
 	if err != nil {
 		panic(err)
 	}
+}
+
+var _ encoding.Codec = (*Codec)(nil)
+
+type Codec struct{}
+
+func (c *Codec) NewEncoder(w io.Writer) encoding.Encoder {
+	return json.NewEncoder(w)
+}
+
+func (c *Codec) NewDecoder(r io.Reader) encoding.Decoder {
+	return json.NewDecoder(r)
 }

--- a/model/fingerprint/fingerprint.go
+++ b/model/fingerprint/fingerprint.go
@@ -23,5 +23,5 @@ func Fingerprint(entity interface{}) []byte {
 		return fingerprinter.Fingerprint()
 	}
 
-	return rlp.NewEncoder().MustEncode(entity)
+	return rlp.NewMarshaler().MustMarshal(entity)
 }

--- a/model/flow/collection_test.go
+++ b/model/flow/collection_test.go
@@ -16,7 +16,7 @@ func TestLightCollectionFingerprint(t *testing.T) {
 	colID := col.ID()
 	data := fingerprint.Fingerprint(col.Light())
 	var decoded flow.LightCollection
-	rlp.NewEncoder().MustDecode(data, &decoded)
+	rlp.NewMarshaler().MustUnmarshal(data, &decoded)
 	decodedID := decoded.ID()
 	assert.Equal(t, colID, decodedID)
 	assert.Equal(t, col.Light(), decoded)

--- a/model/flow/event.go
+++ b/model/flow/event.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/onflow/flow-go/crypto/hash"
-	"github.com/onflow/flow-go/model/encoding"
+	"github.com/onflow/flow-go/model/encoding/json"
 	"github.com/onflow/flow-go/model/fingerprint"
 )
 
@@ -51,7 +51,7 @@ func (e Event) Checksum() Identifier {
 // Encode returns the canonical encoding of this event, containing only the fields necessary to uniquely identify it.
 func (e Event) Encode() []byte {
 	w := wrapEventID(e)
-	return encoding.DefaultEncoder.MustEncode(w)
+	return json.NewMarshaler().MustMarshal(w)
 }
 
 func (e Event) Fingerprint() []byte {

--- a/model/flow/event_test.go
+++ b/model/flow/event_test.go
@@ -34,7 +34,7 @@ func TestEventFingerprint(t *testing.T) {
 
 	data := fingerprint.Fingerprint(evt)
 	var decoded eventWrapper
-	rlp.NewEncoder().MustDecode(data, &decoded)
+	rlp.NewMarshaler().MustUnmarshal(data, &decoded)
 	assert.Equal(t, wrapEvent(evt), decoded)
 }
 

--- a/model/flow/header_test.go
+++ b/model/flow/header_test.go
@@ -44,7 +44,7 @@ func TestHeaderFingerprint(t *testing.T) {
 		ParentVoterSigData crypto.Signature
 		ProposerID         flow.Identifier
 	}
-	rlp.NewEncoder().MustDecode(data, &decoded)
+	rlp.NewMarshaler().MustUnmarshal(data, &decoded)
 	decHeader := flow.Header{
 		ChainID:            decoded.ChainID,
 		ParentID:           decoded.ParentID,

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -168,7 +168,7 @@ func fingerPrint(blockID flow.Identifier, resultID flow.Identifier, alpha int) (
 	hasher := hash.NewSHA3_256()
 
 	// encodes alpha parameteer
-	encAlpha, err := json.NewMarshaler.Marshal(alpha)
+	encAlpha, err := json.NewMarshaler().Marshal(alpha)
 	if err != nil {
 		return nil, fmt.Errorf("could not encode alpha: %w", err)
 	}

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -6,7 +6,7 @@ import (
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/crypto/random"
 	chunkmodels "github.com/onflow/flow-go/model/chunks"
-	"github.com/onflow/flow-go/model/encoding"
+	"github.com/onflow/flow-go/model/encoding/json"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/indices"
@@ -168,7 +168,7 @@ func fingerPrint(blockID flow.Identifier, resultID flow.Identifier, alpha int) (
 	hasher := hash.NewSHA3_256()
 
 	// encodes alpha parameteer
-	encAlpha, err := encoding.DefaultEncoder.Encode(alpha)
+	encAlpha, err := json.NewMarshaler.Marshal(alpha)
 	if err != nil {
 		return nil, fmt.Errorf("could not encode alpha: %w", err)
 	}

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -167,7 +167,7 @@ func chunkAssignment(ids flow.IdentifierList, chunks flow.ChunkList, rng random.
 func fingerPrint(blockID flow.Identifier, resultID flow.Identifier, alpha int) (hash.Hash, error) {
 	hasher := hash.NewSHA3_256()
 
-	// encodes alpha parameteer
+	// encodes alpha parameter
 	encAlpha, err := json.NewMarshaler().Marshal(alpha)
 	if err != nil {
 		return nil, fmt.Errorf("could not encode alpha: %w", err)

--- a/network/compressor/lz4Compressor.go
+++ b/network/compressor/lz4Compressor.go
@@ -1,0 +1,39 @@
+package compressor
+
+import (
+	"io"
+
+	"github.com/pierrec/lz4"
+
+	"github.com/onflow/flow-go/network"
+)
+
+type Lz4Compressor struct{}
+
+func NewLz4Compressor() *Lz4Compressor {
+	return &Lz4Compressor{}
+}
+
+func (lz4Comp Lz4Compressor) NewReader(r io.Reader) (io.Reader, error) {
+	return lz4.NewReader(r), nil
+}
+
+func (lz4Comp Lz4Compressor) NewWriter(w io.Writer) (network.WriteCloseFlusher, error) {
+	return &lz4WriteCloseFlusher{w: lz4.NewWriter(w)}, nil
+}
+
+type lz4WriteCloseFlusher struct {
+	w *lz4.Writer
+}
+
+func (lz4W *lz4WriteCloseFlusher) Write(p []byte) (int, error) {
+	return lz4W.w.Write(p)
+}
+
+func (lz4W *lz4WriteCloseFlusher) Close() error {
+	return lz4W.w.Close()
+}
+
+func (lz4W *lz4WriteCloseFlusher) Flush() error {
+	return lz4W.w.Flush()
+}

--- a/network/compressor/lz4Compressor.go
+++ b/network/compressor/lz4Compressor.go
@@ -2,11 +2,14 @@ package compressor
 
 import (
 	"io"
+	"io/ioutil"
 
 	"github.com/pierrec/lz4"
 
 	"github.com/onflow/flow-go/network"
 )
+
+var _ network.Compressor = (*Lz4Compressor)(nil)
 
 type Lz4Compressor struct{}
 
@@ -14,8 +17,8 @@ func NewLz4Compressor() *Lz4Compressor {
 	return &Lz4Compressor{}
 }
 
-func (lz4Comp Lz4Compressor) NewReader(r io.Reader) (io.Reader, error) {
-	return lz4.NewReader(r), nil
+func (lz4Comp Lz4Compressor) NewReader(r io.Reader) (io.ReadCloser, error) {
+	return ioutil.NopCloser(lz4.NewReader(r)), nil
 }
 
 func (lz4Comp Lz4Compressor) NewWriter(w io.Writer) (network.WriteCloseFlusher, error) {

--- a/network/stub/hash.go
+++ b/network/stub/hash.go
@@ -5,24 +5,26 @@ import (
 	"fmt"
 
 	"github.com/onflow/flow-go/crypto/hash"
-	"github.com/onflow/flow-go/model/encoding"
+	"github.com/onflow/flow-go/model/encoding/json"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/network"
 )
 
 // eventKey generates a unique fingerprint for the tuple of (sender, event, type of event, channel)
 func eventKey(from flow.Identifier, channel network.Channel, event interface{}) (string, error) {
-	tag, err := encoding.DefaultEncoder.Encode([]byte(fmt.Sprintf("testthenetwork %s %T", channel, event)))
+	marshaler := json.NewMarshaler()
+
+	tag, err := marshaler.Marshal([]byte(fmt.Sprintf("testthenetwork %s %T", channel, event)))
 	if err != nil {
 		return "", fmt.Errorf("could not encode the tag: %w", err)
 	}
 
-	payload, err := encoding.DefaultEncoder.Encode(event)
+	payload, err := marshaler.Marshal(event)
 	if err != nil {
 		return "", fmt.Errorf("could not encode event: %w", err)
 	}
 
-	sender, err := encoding.DefaultEncoder.Encode(from)
+	sender, err := marshaler.Marshal(from)
 	if err != nil {
 		return "", fmt.Errorf("could not encode sender: %w", err)
 	}

--- a/network/test/block_exchange_test.go
+++ b/network/test/block_exchange_test.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
-	"testing"
 	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	datastore "github.com/ipfs/go-datastore/examples"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/rs/zerolog"
@@ -51,7 +48,7 @@ func (suite *BlockExchangeTestSuite) SetupTest() {
 	blockExchangeChannel := network.Channel("block-exchange")
 
 	for i, net := range networks {
-		bstore, cleanupFunc := makeBlockstore(suite.T(), fmt.Sprintf("bs%v", i))
+		bstore, cleanupFunc := MakeBlockstore(suite.T(), fmt.Sprintf("bs%v", i))
 		suite.cleanupFuncs = append(suite.cleanupFuncs, cleanupFunc)
 		block := blocks.NewBlock([]byte(fmt.Sprintf("foo%v", i)))
 		suite.blockCids = append(suite.blockCids, block.Cid())
@@ -171,19 +168,5 @@ func (suite *BlockExchangeTestSuite) TestHas() {
 		for c, received := range cids {
 			assert.True(suite.T(), received, "block %v not received by node %v", c, i)
 		}
-	}
-}
-
-func makeBlockstore(t *testing.T, name string) (blockstore.Blockstore, func()) {
-	dsDir := filepath.Join(os.TempDir(), name)
-	require.NoError(t, os.RemoveAll(dsDir))
-	err := os.Mkdir(dsDir, os.ModeDir)
-	require.NoError(t, err)
-
-	ds, err := datastore.NewDatastore(dsDir)
-	require.NoError(t, err)
-
-	return blockstore.NewBlockstore(ds.(*datastore.Datastore)), func() {
-		require.NoError(t, os.RemoveAll(dsDir))
 	}
 }

--- a/network/test/testUtil.go
+++ b/network/test/testUtil.go
@@ -3,6 +3,8 @@ package test
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
@@ -10,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	datastore "github.com/ipfs/go-datastore/examples"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/libp2p/go-libp2p-core/peer"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/rs/zerolog"
@@ -419,4 +423,18 @@ func networkPayloadFixture(t *testing.T, size uint) []byte {
 	require.InDelta(t, len(encodedEvent), int(size), float64(overhead))
 
 	return payload
+}
+
+func MakeBlockstore(t *testing.T, name string) (blockstore.Blockstore, func()) {
+	dsDir := filepath.Join(os.TempDir(), name)
+	require.NoError(t, os.RemoveAll(dsDir))
+	err := os.Mkdir(dsDir, os.ModeDir)
+	require.NoError(t, err)
+
+	ds, err := datastore.NewDatastore(dsDir)
+	require.NoError(t, err)
+
+	return blockstore.NewBlockstore(ds.(*datastore.Datastore)), func() {
+		require.NoError(t, os.RemoveAll(dsDir))
+	}
 }

--- a/network/topology/topology_utils.go
+++ b/network/topology/topology_utils.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/onflow/flow-go-sdk/crypto"
 
-	"github.com/onflow/flow-go/model/encoding"
+	"github.com/onflow/flow-go/model/encoding/json"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
 )
@@ -42,7 +42,7 @@ func byteSeedFromID(id flow.Identifier) ([]byte, error) {
 		return nil, fmt.Errorf("could not generate hasher: %w", err)
 	}
 
-	encodedId, err := encoding.DefaultEncoder.Encode(id)
+	encodedId, err := json.NewMarshaler().Marshal(id)
 	if err != nil {
 		return nil, fmt.Errorf("could not encode id: %w", err)
 	}


### PR DESCRIPTION
### Commit https://github.com/onflow/flow-go/pull/1483/commits/c7b930ae840c119c232f337d3b43a57a2e12028c

The entire test run for a ~360 MB state diff takes ~26 seconds, of which the most time consuming is the assertion at the very end to check that there is no discrepancy between the stored and loaded state diff.

The time needed to actually store / load the state diff to / from disk is minimal (~2.5 and ~1.5 seconds, respectively). Note however that the blockstore used in this test is a dummy blockstore which simply writes files directly to the filesystem. Performance may vary with the eventual production blockstore, which will probably be using Badger.

```bash
smnzhu@Simons-MacBook-Pro ~/Documents/GitHub/flow-go % ls -la ~/Downloads/8aeb01b08a446434ea4746aaaec1c458fd24922e26a13e94842bafb74e681670.cbor
-rw-r--r--@ 1 smnzhu  staff  359949597 Oct  8 11:55 
smnzhu@Simons-MacBook-Pro ~/Documents/GitHub/flow-go % sudo /usr/local/Cellar/go/1.16.5/libexec/bin/go test -v -timeout 30s -tags relic -run ^TestStateDiffStorer$ github.com/onflow/flow-go/engine/execution/state_synchronization
=== RUN   TestStateDiffStorer
    state_diff_storer_test.go:68: time to store state diff: 2.483088392s
    state_diff_storer_test.go:74: time to load state diff: 1.484808883s
--- PASS: TestStateDiffStorer (25.27s)
PASS
ok      github.com/onflow/flow-go/engine/execution/state_synchronization        25.713s
```

### Commit https://github.com/onflow/flow-go/pull/1483/commits/5e1ec7a40c8c56e419cef3930ab91311ad7fca33

Updated test to run over entire mainnet bucket. Was able to do every file successfully, 