### PR TITLE
add commit sha to retrieve docker image

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,6 +1,9 @@
 # Name of the cover profile
 COVER_PROFILE := cover.out
 
+# The short Git commit hash
+export SHORT_COMMIT := $(shell git rev-parse --short HEAD)
+
 # Run unit tests for test utilities in this module
 .PHONY: test
 test:

--- a/integration/testnet/container.go
+++ b/integration/testnet/container.go
@@ -55,7 +55,11 @@ func (c *ContainerConfig) ImageName() string {
 	if c.Debug {
 		debugSuffix = "-debug"
 	}
-	return fmt.Sprintf("%s/%s%s:latest", defaultRegistry, c.Role.String(), debugSuffix)
+	commitSha := os.Getenv("SHORT_COMMIT")
+	if commitSha == "" {
+		commitSha = "latest"
+	}
+	return fmt.Sprintf("%s/%s%s:%s", defaultRegistry, c.Role.String(), debugSuffix, commitSha)
 }
 
 // Container represents a test Docker container for a generic Flow node.


### PR DESCRIPTION
We should be able to specify a specific version to run for integration tests.

Furthermore, this will need to be enabled for the flakiness detection job.