### PR TITLE
[Consensus Follower] Handle fatal errors

### DIFF
--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -24,5 +24,8 @@ func main() {
 		anb.Logger.Fatal().Err(err).Send()
 	}
 
-	nodeBuilder.Build().Run()
+	nodeBuilder.
+		SerialStart().
+		Build().
+		Run()
 }

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -314,7 +314,8 @@ func (builder *FlowAccessNodeBuilder) buildSyncEngine() *FlowAccessNodeBuilder {
 	builder.Component("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 		network, _ := lookup("unstaked network")
 		snapshot, _ := lookup("finalized snapshot")
-		if err := util.WaitReady(ctx, util.AllReady(network, snapshot)); err != nil || util.CheckClosed(ctx.Done()) {
+		followerEngine, _ := lookup("follower engine")
+		if err := util.WaitReady(ctx, util.AllReady(network, followerEngine, snapshot)); err != nil || util.CheckClosed(ctx.Done()) {
 			return nil, ctx.Err()
 		}
 

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -232,7 +232,7 @@ func (builder *FlowAccessNodeBuilder) buildLatestHeader() *FlowAccessNodeBuilder
 }
 
 func (builder *FlowAccessNodeBuilder) buildFollowerCore() *FlowAccessNodeBuilder {
-	builder.CriticalComponent("follower core", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	builder.Component("follower core", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 		// create a finalizer that will handle updating the protocol
 		// state when the follower detects newly finalized blocks
 		final := finalizer.NewFinalizer(node.DB, node.Storage.Headers, builder.FollowerState, node.Tracer)
@@ -259,7 +259,7 @@ func (builder *FlowAccessNodeBuilder) buildFollowerCore() *FlowAccessNodeBuilder
 }
 
 func (builder *FlowAccessNodeBuilder) buildFollowerEngine() *FlowAccessNodeBuilder {
-	builder.CriticalComponent("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	builder.Component("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 		network, _ := lookup("unstaked network")
 		followerCore, _ := lookup("follower core")
@@ -300,7 +300,7 @@ func (builder *FlowAccessNodeBuilder) buildFollowerEngine() *FlowAccessNodeBuild
 }
 
 func (builder *FlowAccessNodeBuilder) buildFinalizedHeader() *FlowAccessNodeBuilder {
-	builder.CriticalComponent("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	builder.Component("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 		finalizedHeader, err := synceng.NewFinalizedHeaderCache(node.Logger, node.State, builder.FinalizationDistributor)
 		if err != nil {
 			return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -314,7 +314,7 @@ func (builder *FlowAccessNodeBuilder) buildFinalizedHeader() *FlowAccessNodeBuil
 }
 
 func (builder *FlowAccessNodeBuilder) buildSyncEngine() *FlowAccessNodeBuilder {
-	builder.CriticalComponent("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	builder.Component("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 		network, _ := lookup("unstaked network")
 		snapshot, _ := lookup("finalized snapshot")

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -260,12 +260,9 @@ func (builder *FlowAccessNodeBuilder) buildFollowerCore() *FlowAccessNodeBuilder
 
 func (builder *FlowAccessNodeBuilder) buildFollowerEngine() *FlowAccessNodeBuilder {
 	builder.Component("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
-
 		network, _ := lookup("unstaked network")
 		followerCore, _ := lookup("follower core")
-		select {
-		case <-util.AllReady(network, followerCore):
-		case <-ctx.Done():
+		if err := util.WaitReady(ctx, util.AllReady(network, followerCore)); err != nil || util.CheckClosed(ctx.Done()) {
 			return nil, ctx.Err()
 		}
 
@@ -315,12 +312,9 @@ func (builder *FlowAccessNodeBuilder) buildFinalizedHeader() *FlowAccessNodeBuil
 
 func (builder *FlowAccessNodeBuilder) buildSyncEngine() *FlowAccessNodeBuilder {
 	builder.Component("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
-
 		network, _ := lookup("unstaked network")
 		snapshot, _ := lookup("finalized snapshot")
-		select {
-		case <-util.AllReady(network, snapshot):
-		case <-ctx.Done():
+		if err := util.WaitReady(ctx, util.AllReady(network, snapshot)); err != nil || util.CheckClosed(ctx.Done()) {
 			return nil, ctx.Err()
 		}
 

--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/onflow/flow/protobuf/go/flow/access"
+
 	"github.com/onflow/flow-go/cmd"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine"
@@ -36,7 +38,6 @@ import (
 	"github.com/onflow/flow-go/network/topology"
 	"github.com/onflow/flow-go/state/protocol/events/gadgets"
 	"github.com/onflow/flow-go/utils/grpcutils"
-	"github.com/onflow/flow/protobuf/go/flow/access"
 )
 
 // StakedAccessNodeBuilder builds a staked access node. The staked access node can optionally participate in the

--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -185,7 +185,7 @@ func (anb *StakedAccessNodeBuilder) Build() cmd.Node {
 			anb.rpcConf.TransportCredentials = credentials.NewTLS(tlsConfig)
 			return nil
 		}).
-		CriticalComponent("RPC engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("RPC engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			anb.RpcEng = rpc.New(
 				node.Logger,
 				node.State,
@@ -209,7 +209,7 @@ func (anb *StakedAccessNodeBuilder) Build() cmd.Node {
 			)
 			return anb.RpcEng, nil
 		}).
-		CriticalComponent("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			var err error
 
 			anb.RequestEng, err = requester.New(
@@ -236,7 +236,7 @@ func (anb *StakedAccessNodeBuilder) Build() cmd.Node {
 
 			return anb.IngestEng, nil
 		}).
-		CriticalComponent("requester engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("requester engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			// We initialize the requester engine inside the ingestion engine due to the mutual dependency. However, in
 			// order for it to properly start and shut down, we should still return it as its own engine here, so it can
 			// be handled by the scaffold.
@@ -248,7 +248,7 @@ func (anb *StakedAccessNodeBuilder) Build() cmd.Node {
 		var proxyEngine *splitter.Engine
 
 		anb.
-			CriticalComponent("unstaked sync request proxy", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+			Component("unstaked sync request proxy", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 				proxyEngine = splitter.New(node.Logger, engine.PublicSyncCommittee)
 
 				// register the proxy engine with the unstaked network
@@ -260,7 +260,7 @@ func (anb *StakedAccessNodeBuilder) Build() cmd.Node {
 
 				return proxyEngine, nil
 			}).
-			CriticalComponent("unstaked sync request handler", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+			Component("unstaked sync request handler", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 				syncRequestHandler := synceng.NewRequestHandlerEngine(
 					node.Logger.With().Bool("unstaked", true).Logger(),
 					unstaked.NewUnstakedEngineCollector(node.Metrics.Engine),
@@ -281,7 +281,7 @@ func (anb *StakedAccessNodeBuilder) Build() cmd.Node {
 			})
 	}
 
-	anb.CriticalComponent("ping engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	anb.Component("ping engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 		ping, err := pingeng.New(
 			node.Logger,
 			node.State,
@@ -303,7 +303,7 @@ func (anb *StakedAccessNodeBuilder) Build() cmd.Node {
 // enqueueUnstakedNetworkInit enqueues the unstaked network component initialized for the staked node
 func (builder *StakedAccessNodeBuilder) enqueueUnstakedNetworkInit() {
 
-	builder.CriticalComponent("unstaked network", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	builder.Component("unstaked network", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 		libP2PFactory := builder.initLibP2PFactory(builder.NodeID, builder.NodeConfig.NetworkKey)
 

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -80,6 +80,7 @@ func (anb *UnstakedAccessNodeBuilder) InitIDProviders() {
 
 		// use the default identifier provider
 		anb.SyncEngineParticipantsProviderFactory = func() id.IdentifierProvider {
+<<<<<<< HEAD
 			return id.NewCustomIdentifierProvider(func() flow.IdentifierList {
 				var result flow.IdentifierList
 
@@ -100,6 +101,16 @@ func (anb *UnstakedAccessNodeBuilder) InitIDProviders() {
 
 				return result
 			})
+=======
+
+			// use the middleware that should have now been initialized
+			middleware, ok := anb.Middleware.(*p2p.Middleware)
+			if !ok {
+				// TODO: this shouldn't throw a fatal error, but this also isn't a runtime error
+				anb.Logger.Fatal().Msg("middleware was of unexpected type")
+			}
+			return middleware.IdentifierProvider()
+>>>>>>> 90f86d0a6 (provide a simpler api for safely handling errors and read/done signals)
 		}
 
 		return nil
@@ -255,7 +266,9 @@ func (anb *UnstakedAccessNodeBuilder) initUnstakedLocal() func(ctx irrecoverable
 		}
 
 		me, err := local.New(self, nil)
-		anb.MustNot(err).Msg("could not initialize local")
+		if err != nil {
+			ctx.Throw(fmt.Errorf("could not initialize local identity: %w", err))
+		}
 		node.Me = me
 	}
 }

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -80,7 +80,6 @@ func (anb *UnstakedAccessNodeBuilder) InitIDProviders() {
 
 		// use the default identifier provider
 		anb.SyncEngineParticipantsProviderFactory = func() id.IdentifierProvider {
-<<<<<<< HEAD
 			return id.NewCustomIdentifierProvider(func() flow.IdentifierList {
 				var result flow.IdentifierList
 
@@ -101,16 +100,6 @@ func (anb *UnstakedAccessNodeBuilder) InitIDProviders() {
 
 				return result
 			})
-=======
-
-			// use the middleware that should have now been initialized
-			middleware, ok := anb.Middleware.(*p2p.Middleware)
-			if !ok {
-				// TODO: this shouldn't throw a fatal error, but this also isn't a runtime error
-				anb.Logger.Fatal().Msg("middleware was of unexpected type")
-			}
-			return middleware.IdentifierProvider()
->>>>>>> 90f86d0a6 (provide a simpler api for safely handling errors and read/done signals)
 		}
 
 		return nil

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -342,7 +342,6 @@ func (anb *UnstakedAccessNodeBuilder) enqueueConnectWithStakedAN() {
 			time.Sleep(time.Duration(attempts*retryBackoffSeconds) * time.Second)
 			return component.ErrorHandlingRestart
 		}
-
 		return component.ErrorHandlingStop
 	}
 

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/util"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/converter"
 	"github.com/onflow/flow-go/network/p2p"
@@ -330,9 +331,7 @@ func (anb *UnstakedAccessNodeBuilder) enqueueUnstakedNetworkInit() {
 func (anb *UnstakedAccessNodeBuilder) enqueueConnectWithStakedAN() {
 	anb.Component("upstream connector", func(ctx irrecoverable.SignalerContext, _ *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 		network, _ := lookup("unstaked network")
-		select {
-		case <-network.Ready():
-		case <-ctx.Done():
+		if err := util.WaitReady(ctx, network.Ready()); err != nil || util.CheckClosed(ctx.Done()) {
 			return nil, ctx.Err()
 		}
 

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -298,7 +298,7 @@ func (anb *UnstakedAccessNodeBuilder) Build() cmd.Node {
 // enqueueUnstakedNetworkInit enqueues the unstaked network component initialized for the unstaked node
 func (anb *UnstakedAccessNodeBuilder) enqueueUnstakedNetworkInit() {
 
-	anb.Component("unstaked network", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (component.Component, error) {
+	anb.CriticalComponent("unstaked network", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 		// Network Metrics
 		// for now we use the empty metrics NoopCollector till we have defined the new unstaked network metrics
@@ -318,7 +318,7 @@ func (anb *UnstakedAccessNodeBuilder) enqueueUnstakedNetworkInit() {
 		anb.ProtocolEvents.AddConsumer(idEvents)
 
 		return anb.Network, nil
-	}, nil)
+	})
 }
 
 // enqueueConnectWithStakedAN enqueues the upstream connector component which connects the libp2p host of the unstaked

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -298,7 +298,7 @@ func (anb *UnstakedAccessNodeBuilder) Build() cmd.Node {
 // enqueueUnstakedNetworkInit enqueues the unstaked network component initialized for the unstaked node
 func (anb *UnstakedAccessNodeBuilder) enqueueUnstakedNetworkInit() {
 
-	anb.CriticalComponent("unstaked network", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	anb.Component("unstaked network", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 		// Network Metrics
 		// for now we use the empty metrics NoopCollector till we have defined the new unstaked network metrics
@@ -328,7 +328,7 @@ func (anb *UnstakedAccessNodeBuilder) enqueueUnstakedNetworkInit() {
 // discovered by other unstaked ANs if it subscribes to a topic before connecting to the staked AN. Hence, the need
 // of an explicit connect to the staked AN before the node attempts to subscribe to topics.
 func (anb *UnstakedAccessNodeBuilder) enqueueConnectWithStakedAN() {
-	anb.CriticalComponent("upstream connector", func(ctx irrecoverable.SignalerContext, _ *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+	anb.Component("upstream connector", func(ctx irrecoverable.SignalerContext, _ *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 		network, _ := lookup("unstaked network")
 		select {
 		case <-network.Ready():

--- a/cmd/access/node_builder/upstream_connector.go
+++ b/cmd/access/node_builder/upstream_connector.go
@@ -39,8 +39,7 @@ func newUpstreamConnector(bootstrapIdentities flow.IdentityList, unstakedNode *p
 			default:
 			}
 
-			go connector.onStart(ctx)
-
+			connector.onStart(ctx)
 			ready()
 		}).Build()
 

--- a/cmd/access/node_builder/upstream_connector.go
+++ b/cmd/access/node_builder/upstream_connector.go
@@ -57,8 +57,8 @@ func (connector *upstreamConnector) onStart(parent irrecoverable.SignalerContext
 	defer close(resultChan)
 
 	// a shorter context for the connection worker
-	workerCtx, workerCancel := context.WithTimeout(parent, 30*time.Second)
-	defer workerCancel()
+	workerCtx, cancel := context.WithTimeout(parent, 30*time.Second)
+	defer cancel()
 
 	// spawn a connect worker for each bootstrap node
 	for _, b := range connector.bootstrapIdentities {

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -217,7 +217,7 @@ func main() {
 
 			return nil
 		}).
-		CriticalComponent("machine account config validator", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("machine account config validator", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			//@TODO use fallback logic for flowClient similar to DKG/QC contract clients
 			flowClient, err := common.FlowClient(flowClientConfigs[0])
 			if err != nil {
@@ -233,7 +233,7 @@ func main() {
 
 			return validator, err
 		}).
-		CriticalComponent("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// initialize cleaner for DB
 			cleaner := storagekv.NewCleaner(node.Logger, node.DB, node.Metrics.CleanCollector, flow.DefaultValueLogGCFrequency)
@@ -303,7 +303,7 @@ func main() {
 
 			return followerEng, nil
 		}).
-		CriticalComponent("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = consync.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -311,7 +311,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		CriticalComponent("main chain sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("main chain sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// create a block synchronization engine to handle follower getting out of sync
 			sync, err := consync.New(
@@ -331,7 +331,7 @@ func main() {
 
 			return sync, nil
 		}).
-		CriticalComponent("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			ing, err = ingest.New(
 				node.Logger,
 				node.Network,
@@ -345,11 +345,11 @@ func main() {
 			)
 			return ing, err
 		}).
-		CriticalComponent("transaction ingress server", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("transaction ingress server", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			server := ingress.New(ingressConf, ing, node.RootChainID)
 			return server, nil
 		}).
-		CriticalComponent("provider engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("provider engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			retrieve := func(collID flow.Identifier) (flow.Entity, error) {
 				coll, err := node.Storage.Collections.ByID(collID)
 				return coll, err
@@ -360,7 +360,7 @@ func main() {
 				retrieve,
 			)
 		}).
-		CriticalComponent("pusher engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("pusher engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			push, err = pusher.New(
 				node.Logger,
 				node.Network,
@@ -375,7 +375,7 @@ func main() {
 		}).
 		// Epoch manager encapsulates and manages epoch-dependent engines as we
 		// transition between epochs
-		CriticalComponent("epoch manager", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("epoch manager", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			clusterStateFactory, err := factories.NewClusterStateFactory(node.DB, node.Metrics.Cache, node.Tracer)
 			if err != nil {
 				return nil, err

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -508,7 +508,9 @@ func main() {
 
 			return manager, err
 		}).
-		Build().Run()
+		SerialStart().
+		Build().
+		Run()
 }
 
 // createQCContractClient creates QC contract client

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -215,7 +215,7 @@ func main() {
 
 			return nil
 		}).
-		Component("machine account config validator", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("machine account config validator", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			//@TODO use fallback logic for flowClient similar to DKG/QC contract clients
 			flowClient, err := common.FlowClient(flowClientConfigs[0])
 			if err != nil {
@@ -231,7 +231,7 @@ func main() {
 
 			return validator, err
 		}).
-		Component("follower engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("follower engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 
 			// initialize cleaner for DB
 			cleaner := storagekv.NewCleaner(node.Logger, node.DB, node.Metrics.CleanCollector, flow.DefaultValueLogGCFrequency)
@@ -301,7 +301,7 @@ func main() {
 
 			return followerEng, nil
 		}).
-		Component("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = consync.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -309,7 +309,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		Component("main chain sync engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("main chain sync engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 
 			// create a block synchronization engine to handle follower getting out of sync
 			sync, err := consync.New(
@@ -329,7 +329,7 @@ func main() {
 
 			return sync, nil
 		}).
-		Component("ingestion engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("ingestion engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			ing, err = ingest.New(
 				node.Logger,
 				node.Network,
@@ -343,11 +343,11 @@ func main() {
 			)
 			return ing, err
 		}).
-		Component("transaction ingress server", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("transaction ingress server", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			server := ingress.New(ingressConf, ing, node.RootChainID)
 			return server, nil
 		}).
-		Component("provider engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("provider engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			retrieve := func(collID flow.Identifier) (flow.Entity, error) {
 				coll, err := node.Storage.Collections.ByID(collID)
 				return coll, err
@@ -358,7 +358,7 @@ func main() {
 				retrieve,
 			)
 		}).
-		Component("pusher engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("pusher engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			push, err = pusher.New(
 				node.Logger,
 				node.Network,
@@ -373,7 +373,7 @@ func main() {
 		}).
 		// Epoch manager encapsulates and manages epoch-dependent engines as we
 		// transition between epochs
-		Component("epoch manager", func(_ cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("epoch manager", func(_ cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			clusterStateFactory, err := factories.NewClusterStateFactory(node.DB, node.Metrics.Cache, node.Tracer)
 			if err != nil {
 				return nil, err
@@ -506,7 +506,7 @@ func main() {
 
 			return manager, err
 		}).
-		Run()
+		Build().Run()
 }
 
 // createQCContractClient creates QC contract client

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -35,9 +35,11 @@ import (
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/buffer"
 	builder "github.com/onflow/flow-go/module/builder/collection"
+	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/epochs"
 	confinalizer "github.com/onflow/flow-go/module/finalizer/consensus"
 	"github.com/onflow/flow-go/module/ingress"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/mempool"
 	epochpool "github.com/onflow/flow-go/module/mempool/epochs"
 	"github.com/onflow/flow-go/module/mempool/stdmap"
@@ -163,7 +165,7 @@ func main() {
 	}
 
 	nodeBuilder.
-		Module("mutable follower state", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("mutable follower state", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			// For now, we only support state implementations from package badger.
 			// If we ever support different implementations, the following can be replaced by a type-aware factory
 			state, ok := node.State.(*badgerState.State)
@@ -180,29 +182,29 @@ func main() {
 			)
 			return err
 		}).
-		Module("transactions mempool", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("transactions mempool", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			create := func() mempool.Transactions { return stdmap.NewTransactions(txLimit) }
 			pools = epochpool.NewTransactionPools(create)
 			err := node.Metrics.Mempool.Register(metrics.ResourceTransaction, pools.CombinedSize)
 			return err
 		}).
-		Module("pending block cache", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("pending block cache", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			followerBuffer = buffer.NewPendingBlocks()
 			return nil
 		}).
-		Module("metrics", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("metrics", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			colMetrics = metrics.NewCollectionCollector(node.Tracer)
 			return nil
 		}).
-		Module("main chain sync core", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("main chain sync core", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			mainChainSyncCore, err = synchronization.New(node.Logger, synchronization.DefaultConfig())
 			return err
 		}).
-		Module("machine account config", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("machine account config", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			machineAccountInfo, err = cmd.LoadNodeMachineAccountInfoFile(node.BootstrapDir, node.NodeID)
 			return err
 		}).
-		Module("sdk client connection options", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("sdk client connection options", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			anIDS, err := common.ValidateAccessNodeIDSFlag(accessNodeIDS, node.RootChainID, node.State.Sealed())
 			if err != nil {
 				return fmt.Errorf("failed to validate flag --access-node-ids %w", err)
@@ -215,7 +217,7 @@ func main() {
 
 			return nil
 		}).
-		CriticalComponent("machine account config validator", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("machine account config validator", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			//@TODO use fallback logic for flowClient similar to DKG/QC contract clients
 			flowClient, err := common.FlowClient(flowClientConfigs[0])
 			if err != nil {
@@ -231,7 +233,7 @@ func main() {
 
 			return validator, err
 		}).
-		CriticalComponent("follower engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// initialize cleaner for DB
 			cleaner := storagekv.NewCleaner(node.Logger, node.DB, node.Metrics.CleanCollector, flow.DefaultValueLogGCFrequency)
@@ -301,7 +303,7 @@ func main() {
 
 			return followerEng, nil
 		}).
-		CriticalComponent("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = consync.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -309,7 +311,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		CriticalComponent("main chain sync engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("main chain sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// create a block synchronization engine to handle follower getting out of sync
 			sync, err := consync.New(
@@ -329,7 +331,7 @@ func main() {
 
 			return sync, nil
 		}).
-		CriticalComponent("ingestion engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			ing, err = ingest.New(
 				node.Logger,
 				node.Network,
@@ -343,11 +345,11 @@ func main() {
 			)
 			return ing, err
 		}).
-		CriticalComponent("transaction ingress server", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("transaction ingress server", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			server := ingress.New(ingressConf, ing, node.RootChainID)
 			return server, nil
 		}).
-		CriticalComponent("provider engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("provider engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			retrieve := func(collID flow.Identifier) (flow.Entity, error) {
 				coll, err := node.Storage.Collections.ByID(collID)
 				return coll, err
@@ -358,7 +360,7 @@ func main() {
 				retrieve,
 			)
 		}).
-		CriticalComponent("pusher engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("pusher engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			push, err = pusher.New(
 				node.Logger,
 				node.Network,
@@ -373,7 +375,7 @@ func main() {
 		}).
 		// Epoch manager encapsulates and manages epoch-dependent engines as we
 		// transition between epochs
-		CriticalComponent("epoch manager", func(_ cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("epoch manager", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			clusterStateFactory, err := factories.NewClusterStateFactory(node.DB, node.Metrics.Cache, node.Tracer)
 			if err != nil {
 				return nil, err

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -381,7 +381,7 @@ func main() {
 
 			return nil
 		}).
-		CriticalComponent("machine account config validator", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("machine account config validator", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			//@TODO use fallback logic for flowClient similar to DKG/QC contract clients
 			flowClient, err := common.FlowClient(flowClientConfigs[0])
 			if err != nil {
@@ -396,7 +396,7 @@ func main() {
 			)
 			return validator, err
 		}).
-		CriticalComponent("sealing engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("sealing engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			resultApprovalSigVerifier := signature.NewAggregationVerifier(encoding.ResultApprovalTag)
 			sealingTracker := tracker.NewSealingTracker(node.Logger, node.Storage.Headers, node.Storage.Receipts, seals)
@@ -432,7 +432,7 @@ func main() {
 
 			return e, err
 		}).
-		CriticalComponent("matching engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("matching engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			receiptRequester, err = requester.New(
 				node.Logger,
 				node.Metrics.Engine,
@@ -487,7 +487,7 @@ func main() {
 
 			return e, err
 		}).
-		CriticalComponent("provider engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("provider engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			prov, err = provider.New(
 				node.Logger,
 				node.Metrics.Engine,
@@ -498,7 +498,7 @@ func main() {
 			)
 			return prov, err
 		}).
-		CriticalComponent("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			ing, err := ingestion.New(
 				node.Logger,
 				node.Tracer,
@@ -513,7 +513,7 @@ func main() {
 			)
 			return ing, err
 		}).
-		CriticalComponent("consensus components", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("consensus components", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// TODO: we should probably find a way to initialize mutually dependent engines separately
 
@@ -676,7 +676,7 @@ func main() {
 			comp = comp.WithConsensus(hot)
 			return comp, nil
 		}).
-		CriticalComponent("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = synceng.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -684,7 +684,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		CriticalComponent("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			sync, err := synceng.New(
 				node.Logger,
 				node.Metrics.Engine,
@@ -702,11 +702,11 @@ func main() {
 
 			return sync, nil
 		}).
-		CriticalComponent("receipt requester engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("receipt requester engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			// created with sealing engine
 			return receiptRequester, nil
 		}).
-		CriticalComponent("DKG messaging engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("DKG messaging engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// brokerTunnel is used to forward messages between the DKG
 			// messaging engine and the DKG broker/controller
@@ -726,7 +726,7 @@ func main() {
 
 			return messagingEngine, nil
 		}).
-		CriticalComponent("DKG reactor engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("DKG reactor engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			// the viewsObserver is used by the reactor engine to subscribe to
 			// new views being finalized
 			viewsObserver := gadgets.NewViews()

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -379,7 +379,7 @@ func main() {
 
 			return nil
 		}).
-		Component("machine account config validator", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("machine account config validator", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			//@TODO use fallback logic for flowClient similar to DKG/QC contract clients
 			flowClient, err := common.FlowClient(flowClientConfigs[0])
 			if err != nil {
@@ -394,7 +394,7 @@ func main() {
 			)
 			return validator, err
 		}).
-		Component("sealing engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("sealing engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 
 			resultApprovalSigVerifier := signature.NewAggregationVerifier(encoding.ResultApprovalTag)
 			sealingTracker := tracker.NewSealingTracker(node.Logger, node.Storage.Headers, node.Storage.Receipts, seals)
@@ -430,7 +430,7 @@ func main() {
 
 			return e, err
 		}).
-		Component("matching engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("matching engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			receiptRequester, err = requester.New(
 				node.Logger,
 				node.Metrics.Engine,
@@ -485,7 +485,7 @@ func main() {
 
 			return e, err
 		}).
-		Component("provider engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("provider engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			prov, err = provider.New(
 				node.Logger,
 				node.Metrics.Engine,
@@ -496,7 +496,7 @@ func main() {
 			)
 			return prov, err
 		}).
-		Component("ingestion engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("ingestion engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			ing, err := ingestion.New(
 				node.Logger,
 				node.Tracer,
@@ -511,7 +511,7 @@ func main() {
 			)
 			return ing, err
 		}).
-		Component("consensus components", func(nodebuilder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("consensus components", func(nodebuilder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 
 			// TODO: we should probably find a way to initialize mutually dependent engines separately
 
@@ -674,7 +674,7 @@ func main() {
 			comp = comp.WithConsensus(hot)
 			return comp, nil
 		}).
-		Component("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = synceng.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -682,7 +682,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		Component("sync engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("sync engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			sync, err := synceng.New(
 				node.Logger,
 				node.Metrics.Engine,
@@ -700,11 +700,11 @@ func main() {
 
 			return sync, nil
 		}).
-		Component("receipt requester engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("receipt requester engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			// created with sealing engine
 			return receiptRequester, nil
 		}).
-		Component("DKG messaging engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("DKG messaging engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 
 			// brokerTunnel is used to forward messages between the DKG
 			// messaging engine and the DKG broker/controller
@@ -724,7 +724,7 @@ func main() {
 
 			return messagingEngine, nil
 		}).
-		Component("DKG reactor engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("DKG reactor engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			// the viewsObserver is used by the reactor engine to subscribe to
 			// new views being finalized
 			viewsObserver := gadgets.NewViews()
@@ -758,7 +758,7 @@ func main() {
 
 			return reactorEngine, nil
 		}).
-		Run()
+		Build().Run()
 }
 
 func loadDKGPrivateData(dir string, myID flow.Identifier) (*dkg.DKGParticipantPriv, error) {

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -760,7 +760,9 @@ func main() {
 
 			return reactorEngine, nil
 		}).
-		Build().Run()
+		SerialStart().
+		Build().
+		Run()
 }
 
 func loadDKGPrivateData(dir string, myID flow.Identifier) (*dkg.DKGParticipantPriv, error) {

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -46,7 +46,9 @@ import (
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/buffer"
+	"github.com/onflow/flow-go/module/component"
 	finalizer "github.com/onflow/flow-go/module/finalizer/consensus"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/signature"
 	chainsync "github.com/onflow/flow-go/module/synchronization"
@@ -154,7 +156,7 @@ func main() {
 	}
 
 	nodeBuilder.
-		Module("mutable follower state", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("mutable follower state", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			// For now, we only support state implementations from package badger.
 			// If we ever support different implementations, the following can be replaced by a type-aware factory
 			state, ok := node.State.(*badgerState.State)
@@ -171,24 +173,24 @@ func main() {
 			)
 			return err
 		}).
-		Module("execution metrics", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("execution metrics", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			collector = metrics.NewExecutionCollector(node.Tracer, node.MetricsRegisterer)
 			return nil
 		}).
-		Module("sync core", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("sync core", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			syncCore, err = chainsync.New(node.Logger, chainsync.DefaultConfig())
 			return err
 		}).
-		Module("execution receipts storage", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("execution receipts storage", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			results = storage.NewExecutionResults(node.Metrics.Cache, node.DB)
 			myReceipts = storage.NewMyExecutionReceipts(node.Metrics.Cache, node.DB, node.Storage.Receipts)
 			return nil
 		}).
-		Module("pending block cache", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("pending block cache", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			pendingBlocks = buffer.NewPendingBlocks() // for following main chain consensus
 			return nil
 		}).
-		CriticalComponent("GCP block data uploader", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("GCP block data uploader", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			if enableBlockDataUpload && gcpBucketName != "" {
 				logger := node.Logger.With().Str("component_name", "gcp_block_data_uploader").Logger()
 				gcpBucketUploader, err := uploader.NewGCPBucketUploader(
@@ -218,7 +220,7 @@ func main() {
 			// blockDataUploader will stay nil and disable calling uploader at all
 			return &module.NoopReadDoneAware{}, nil
 		}).
-		CriticalComponent("S3 block data uploader", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("S3 block data uploader", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			if enableBlockDataUpload && s3BucketName != "" {
 				logger := node.Logger.With().Str("component_name", "s3_block_data_uploader").Logger()
 
@@ -252,21 +254,21 @@ func main() {
 			// blockDataUploader will stay nil and disable calling uploader at all
 			return &module.NoopReadDoneAware{}, nil
 		}).
-		Module("state deltas mempool", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("state deltas mempool", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			deltas, err = ingestion.NewDeltas(stateDeltasLimit)
 			return err
 		}).
-		Module("stake checking function", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("stake checking function", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			checkStakedAtBlock = func(blockID flow.Identifier) (bool, error) {
 				return protocol.IsNodeStakedAt(node.State.AtBlockID(blockID), node.Me.NodeID())
 			}
 			return nil
 		}).
-		CriticalComponent("Write-Ahead Log", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("Write-Ahead Log", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			diskWAL, err = wal.NewDiskWAL(node.Logger.With().Str("subcomponent", "wal").Logger(), node.MetricsRegisterer, collector, triedir, int(mTrieCacheSize), pathfinder.PathByteSize, wal.SegmentSize)
 			return diskWAL, err
 		}).
-		CriticalComponent("execution state ledger", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("execution state ledger", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// check if the execution database already exists
 			bootstrapper := bootstrap.NewBootstrapper(node.Logger)
@@ -304,7 +306,7 @@ func main() {
 			ledgerStorage, err = ledger.NewLedger(diskWAL, int(mTrieCacheSize), collector, node.Logger.With().Str("subcomponent", "ledger").Logger(), ledger.DefaultPathFinderVersion)
 			return ledgerStorage, err
 		}).
-		CriticalComponent("execution state ledger WAL compactor", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("execution state ledger WAL compactor", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			checkpointer, err := ledgerStorage.Checkpointer()
 			if err != nil {
@@ -314,7 +316,7 @@ func main() {
 
 			return compactor, nil
 		}).
-		CriticalComponent("provider engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("provider engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			extraLogPath := path.Join(triedir, "extralogs")
 			err := os.MkdirAll(extraLogPath, 0777)
 			if err != nil {
@@ -387,7 +389,7 @@ func main() {
 
 			return providerEngine, err
 		}).
-		CriticalComponent("checker engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("checker engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			checkerEng = checker.New(
 				node.Logger,
 				node.State,
@@ -396,7 +398,7 @@ func main() {
 			)
 			return checkerEng, nil
 		}).
-		CriticalComponent("ingestion engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("ingestion engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			collectionRequester, err = requester.New(node.Logger, node.Metrics.Engine, node.Network, node.Me, node.State,
 				engine.RequestCollections,
 				filter.Any,
@@ -450,7 +452,7 @@ func main() {
 
 			return ingestionEng, err
 		}).
-		CriticalComponent("follower engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// initialize cleaner for DB
 			cleaner := storage.NewCleaner(node.Logger, node.DB, node.Metrics.CleanCollector, flow.DefaultValueLogGCFrequency)
@@ -511,13 +513,13 @@ func main() {
 
 			return followerEng, nil
 		}).
-		CriticalComponent("collection requester engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("collection requester engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			// We initialize the requester engine inside the ingestion engine due to the mutual dependency. However, in
 			// order for it to properly start and shut down, we should still return it as its own engine here, so it can
 			// be handled by the scaffold.
 			return collectionRequester, nil
 		}).
-		CriticalComponent("receipt provider engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("receipt provider engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			retrieve := func(blockID flow.Identifier) (flow.Entity, error) { return myReceipts.MyReceipt(blockID) }
 			eng, err := provider.New(
 				node.Logger,
@@ -531,7 +533,7 @@ func main() {
 			)
 			return eng, err
 		}).
-		CriticalComponent("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = synchronization.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -539,7 +541,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		CriticalComponent("synchronization engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("synchronization engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			// initialize the synchronization engine
 			syncEngine, err = synchronization.New(
 				node.Logger,
@@ -558,7 +560,7 @@ func main() {
 
 			return syncEngine, nil
 		}).
-		CriticalComponent("grpc server", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("grpc server", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			rpcEng := rpc.New(node.Logger, rpcConf, ingestionEng, node.Storage.Blocks, events, results, txResults, node.RootChainID)
 			return rpcEng, nil
 		}).

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -218,7 +218,7 @@ func main() {
 			// Since we don't have conditional component creation, we just use Noop one.
 			// It's functions will be once per startup/shutdown - non-measurable performance penalty
 			// blockDataUploader will stay nil and disable calling uploader at all
-			return &module.NoopReadDoneAware{}, nil
+			return &module.NoopReadyDoneAware{}, nil
 		}).
 		CriticalComponent("S3 block data uploader", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			if enableBlockDataUpload && s3BucketName != "" {
@@ -252,7 +252,7 @@ func main() {
 			// Since we don't have conditional component creation, we just use Noop one.
 			// It's functions will be once per startup/shutdown - non-measurable performance penalty
 			// blockDataUploader will stay nil and disable calling uploader at all
-			return &module.NoopReadDoneAware{}, nil
+			return &module.NoopReadyDoneAware{}, nil
 		}).
 		Module("state deltas mempool", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			deltas, err = ingestion.NewDeltas(stateDeltasLimit)

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -564,7 +564,9 @@ func main() {
 			rpcEng := rpc.New(node.Logger, rpcConf, ingestionEng, node.Storage.Blocks, events, results, txResults, node.RootChainID)
 			return rpcEng, nil
 		}).
-		Build().Run()
+		SerialStart().
+		Build().
+		Run()
 }
 
 // copy the checkpoint files from the bootstrap folder to the execution state folder

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -34,9 +34,9 @@ func main() {
 			node.MsgValidators = validators
 			return nil
 		}).
-		Component("RPC engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("RPC engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			rpcEng, err := engine.New(node.Network, node.Logger, node.Me, node.State, rpcConf)
 			return rpcEng, err
 		}).
-		Run()
+		Build().Run()
 }

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -36,7 +36,7 @@ func main() {
 			node.MsgValidators = validators
 			return nil
 		}).
-		CriticalComponent("RPC engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("RPC engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			rpcEng, err := engine.New(node.Network, node.Logger, node.Me, node.State, rpcConf)
 			return rpcEng, err
 		}).

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -40,5 +40,7 @@ func main() {
 			rpcEng, err := engine.New(node.Network, node.Logger, node.Me, node.State, rpcConf)
 			return rpcEng, err
 		}).
-		Build().Run()
+		SerialStart().
+		Build().
+		Run()
 }

--- a/cmd/ghost/main.go
+++ b/cmd/ghost/main.go
@@ -6,6 +6,8 @@ import (
 	"github.com/onflow/flow-go/cmd"
 	"github.com/onflow/flow-go/engine/ghost/engine"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/validator"
 )
@@ -25,7 +27,7 @@ func main() {
 	}
 
 	nodeBuilder.
-		Module("message validators", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+		Module("message validators", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig) error {
 			validators := []network.MessageValidator{
 				// filter out messages sent by this node itself
 				validator.ValidateNotSender(node.Me.NodeID()),
@@ -34,7 +36,7 @@ func main() {
 			node.MsgValidators = validators
 			return nil
 		}).
-		CriticalComponent("RPC engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("RPC engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			rpcEng, err := engine.New(node.Network, node.Logger, node.Me, node.State, rpcConf)
 			return rpcEng, err
 		}).

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/rs/zerolog"
+)
+
+type Node interface {
+	component.Component
+
+	// Run initiates all common components (logger, database, protocol state etc.)
+	// then starts each component. It also sets up a channel to gracefully shut
+	// down each component if a SIGINT is received.
+	Run()
+	ShutdownSignal() <-chan struct{}
+}
+
+type FlowNodeImp struct {
+	*component.ComponentManager
+	NodeRole string
+	Logger   zerolog.Logger
+}
+
+// Run calls Start() to start all the node modules and components. It also sets up a channel to gracefully shut
+// down each component if a SIGINT is received. Until a SIGINT is received, Run will block.
+// Since, Run is a blocking call it should only be used when running a node as it's own independent process.
+// Any unhandled irrecoverable errors thrown in child components will bubble up to here and result in a fatal
+// error
+func (node *FlowNodeImp) Run() {
+
+	// initialize signal catcher
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	signalerCtx, errChan := irrecoverable.WithSignaler(ctx)
+	go node.Start(signalerCtx)
+
+	go func() {
+		select {
+		case <-node.Ready():
+			node.Logger.Info().Msgf("%s node startup complete", node.NodeRole)
+		case <-ctx.Done():
+		}
+	}()
+
+	// block till a SIGINT is received or a fatal error is encountered
+	select {
+	case <-sig:
+		// address race condition caused by random selection when both select conditions
+		// are met at the same time
+		select {
+		case err := <-errChan:
+			node.Logger.Fatal().Err(err).Msg("unhandled irrecoverable error")
+		default:
+		}
+	case err := <-errChan:
+		node.Logger.Fatal().Err(err).Msg("unhandled irrecoverable error")
+	}
+
+	node.Logger.Info().Msgf("%s node shutting down", node.NodeRole)
+	cancel()
+
+	select {
+	case <-node.Done():
+	case err := <-errChan:
+		node.Logger.Fatal().Err(err).Msg("unhandled irrecoverable error during shutdown")
+	case <-sig:
+		node.Logger.Fatal().Msg("node shutdown aborted")
+	}
+
+	node.Logger.Info().Msgf("%s node shutdown complete", node.NodeRole)
+	os.Exit(0)
+}

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -6,9 +6,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/rs/zerolog"
+
 	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/rs/zerolog"
 )
 
 type Node interface {
@@ -18,6 +19,8 @@ type Node interface {
 	// then starts each component. It also sets up a channel to gracefully shut
 	// down each component if a SIGINT is received.
 	Run()
+
+	// ShutdownSignal returns a channel that is closed when shutdown has commenced.
 	ShutdownSignal() <-chan struct{}
 }
 

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -62,15 +62,22 @@ type NodeBuilder interface {
 	// Module enables setting up dependencies of the engine with the builder context
 	Module(name string, f func(builder NodeBuilder, node *NodeConfig) error) NodeBuilder
 
-	// Component adds a new component to the node that conforms to the ReadyDone
-	// interface.
+	// CriticalComponent adds a new component to the node that conforms to the ReadyDone
+	// interface, and throws a Fatal() when an irrecoverable error is encountered
+	// Use CriticalComponent if the component cannot be restarted when an irrecoverable error is encountered
+	// and the node should crash.
 	//
 	// When the node is run, this component will be started with `Ready`. When the
 	// node is stopped, we will wait for the component to exit gracefully with
 	// `Done`.
-	Component(name string, f func(builder NodeBuilder, node *NodeConfig) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder
-
 	CriticalComponent(name string, f func(builder NodeBuilder, node *NodeConfig) (module.ReadyDoneAware, error)) NodeBuilder
+
+	// Component adds a new component to the node that conforms to the ReadyDone
+	// interface, and calls the provided error handler when an irrecoverable error is encountered.
+	// Use Component if the component can/should be restarted when an irrecoverable error is encountered
+	//
+	// Any irrecoverable errors thrown by the component will be passed to the provided error handler.
+	Component(name string, f func(builder NodeBuilder, node *NodeConfig) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder
 
 	// AdminCommand registers a new admin command with the admin server
 	AdminCommand(command string, handler admin.CommandHandler, validator admin.CommandValidator) NodeBuilder

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/id"
 	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/network"
@@ -67,7 +68,9 @@ type NodeBuilder interface {
 	// When the node is run, this component will be started with `Ready`. When the
 	// node is stopped, we will wait for the component to exit gracefully with
 	// `Done`.
-	Component(name string, f func(builder NodeBuilder, node *NodeConfig) (module.ReadyDoneAware, error)) NodeBuilder
+	Component(name string, f func(builder NodeBuilder, node *NodeConfig) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder
+
+	CriticalComponent(name string, f func(builder NodeBuilder, node *NodeConfig) (module.ReadyDoneAware, error)) NodeBuilder
 
 	// AdminCommand registers a new admin command with the admin server
 	AdminCommand(command string, handler admin.CommandHandler, validator admin.CommandValidator) NodeBuilder
@@ -76,6 +79,10 @@ type NodeBuilder interface {
 	// If the error is nil, returns a nil log event (which acts as a no-op).
 	// If the error is not nil, returns a fatal log event containing the error.
 	MustNot(err error) *zerolog.Event
+
+	// Build finalizes the node configuration in preparation for start.
+	// this signals that all components are registered.
+	Build() NodeBuilder
 
 	// Run initiates all common components (logger, database, protocol state etc.)
 	// then starts each component. It also sets up a channel to gracefully shut

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -61,22 +61,23 @@ type NodeBuilder interface {
 	// Module enables setting up dependencies of the engine with the builder context
 	Module(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig) error) NodeBuilder
 
-	// CriticalComponent adds a new component to the node that conforms to the ReadyDone
+	// Component adds a new component to the node that conforms to the ReadyDoneAware
 	// interface, and throws a Fatal() when an irrecoverable error is encountered
-	// Use CriticalComponent if the component cannot be restarted when an irrecoverable error is encountered
+	// Use Component if the component cannot be restarted when an irrecoverable error is encountered
 	// and the node should crash.
 	//
 	// When the node is run, this component will be started with `Ready`. When the
 	// node is stopped, we will wait for the component to exit gracefully with
 	// `Done`.
-	CriticalComponent(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error)) NodeBuilder
+	Component(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error)) NodeBuilder
 
-	// Component adds a new component to the node that conforms to the ReadyDone
+	// BackgroundComponent adds a new component to the node that conforms to the ReadyDoneAware
 	// interface, and calls the provided error handler when an irrecoverable error is encountered.
-	// Use Component if the component can/should be restarted when an irrecoverable error is encountered
+	// Use BackgroundComponent if the component is not critical to the node's safe operation and
+	// can/should be independently restarted when an irrecoverable error is encountered.
 	//
 	// Any irrecoverable errors thrown by the component will be passed to the provided error handler.
-	Component(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig, lookup component.LookupFunc) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder
+	BackgroundComponent(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig, lookup component.LookupFunc) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder
 
 	// AdminCommand registers a new admin command with the admin server
 	AdminCommand(command string, handler admin.CommandHandler, validator admin.CommandValidator) NodeBuilder

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/id"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/p2p"
@@ -30,8 +31,6 @@ const NotSet = "not set"
 
 // NodeBuilder declares the initialization methods needed to bootstrap up a Flow node
 type NodeBuilder interface {
-	module.ReadyDoneAware
-
 	// BaseFlags reads the command line arguments common to all nodes
 	BaseFlags()
 
@@ -60,7 +59,7 @@ type NodeBuilder interface {
 	EnqueueTracer()
 
 	// Module enables setting up dependencies of the engine with the builder context
-	Module(name string, f func(builder NodeBuilder, node *NodeConfig) error) NodeBuilder
+	Module(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig) error) NodeBuilder
 
 	// CriticalComponent adds a new component to the node that conforms to the ReadyDone
 	// interface, and throws a Fatal() when an irrecoverable error is encountered
@@ -70,14 +69,14 @@ type NodeBuilder interface {
 	// When the node is run, this component will be started with `Ready`. When the
 	// node is stopped, we will wait for the component to exit gracefully with
 	// `Done`.
-	CriticalComponent(name string, f func(builder NodeBuilder, node *NodeConfig) (module.ReadyDoneAware, error)) NodeBuilder
+	CriticalComponent(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error)) NodeBuilder
 
 	// Component adds a new component to the node that conforms to the ReadyDone
 	// interface, and calls the provided error handler when an irrecoverable error is encountered.
 	// Use Component if the component can/should be restarted when an irrecoverable error is encountered
 	//
 	// Any irrecoverable errors thrown by the component will be passed to the provided error handler.
-	Component(name string, f func(builder NodeBuilder, node *NodeConfig) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder
+	Component(name string, f func(ctx irrecoverable.SignalerContext, node *NodeConfig, lookup component.LookupFunc) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder
 
 	// AdminCommand registers a new admin command with the admin server
 	AdminCommand(command string, handler admin.CommandHandler, validator admin.CommandValidator) NodeBuilder
@@ -87,23 +86,18 @@ type NodeBuilder interface {
 	// If the error is not nil, returns a fatal log event containing the error.
 	MustNot(err error) *zerolog.Event
 
-	// Build finalizes the node configuration in preparation for start.
-	// this signals that all components are registered.
-	Build() NodeBuilder
-
-	// Run initiates all common components (logger, database, protocol state etc.)
-	// then starts each component. It also sets up a channel to gracefully shut
-	// down each component if a SIGINT is received.
-	Run()
+	// Build finalizes the node configuration in preparation for start and returns a Node
+	// object that can be run
+	Build() Node
 
 	// PreInit registers a new PreInit function.
 	// PreInit functions run before the protocol state is initialized or any other modules or components are initialized
-	PreInit(f func(builder NodeBuilder, node *NodeConfig)) NodeBuilder
+	PreInit(f func(ctx irrecoverable.SignalerContext, node *NodeConfig)) NodeBuilder
 
 	// PostInit registers a new PreInit function.
 	// PostInit functions run after the protocol state has been initialized but before any other modules or components
 	// are initialized
-	PostInit(f func(builder NodeBuilder, node *NodeConfig)) NodeBuilder
+	PostInit(f func(ctx irrecoverable.SignalerContext, node *NodeConfig)) NodeBuilder
 
 	// RegisterBadgerMetrics registers all badger related metrics
 	RegisterBadgerMetrics() error

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -87,6 +87,11 @@ type NodeBuilder interface {
 	// If the error is not nil, returns a fatal log event containing the error.
 	MustNot(err error) *zerolog.Event
 
+	// SerialStart configures the node to start components serially
+	// By default, components are started in parallel and must have explicit dependency checks.
+	// This allows using the order components were added to manage dependencies implicitly
+	SerialStart() NodeBuilder
+
 	// Build finalizes the node configuration in preparation for start and returns a Node
 	// object that can be run
 	Build() Node

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -743,9 +743,6 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 }
 
 func (fnb *FlowNodeBuilder) handleModule(ctx irrecoverable.SignalerContext, v namedModuleFunc) {
-	log := fnb.Logger.With().Str("module", v.name).Logger()
-	log.Debug().Msgf("running module")
-
 	if err := v.fn(fnb, fnb.NodeConfig); err != nil {
 		ctx.Throw(fmt.Errorf("module %s initialization failed: %w", v.name, err))
 	}
@@ -839,7 +836,6 @@ func (fnb *FlowNodeBuilder) CriticalComponent(name string, f func(builder NodeBu
 func (fnb *FlowNodeBuilder) Component(name string, f func(builder NodeBuilder, node *NodeConfig) (component.Component, error), errHandler func(err error) component.ErrorHandlingResult) NodeBuilder {
 
 	fnb.componentBuilder.AddWorker(func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
-
 		log := fnb.Logger.With().Str("component", name).Logger()
 
 		componentFactory := func() (component.Component, error) {
@@ -1001,7 +997,6 @@ func (fnb *FlowNodeBuilder) InitComponentBuilder() {
 			// run pre-start initializations
 			fnb.onStart(ctx)
 			ready()
-			// don't wait for fnb.Done(). it's redundant
 		})
 }
 
@@ -1026,7 +1021,7 @@ func (fnb *FlowNodeBuilder) Run() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx, errChan := irrecoverable.WithSignaler(ctx)
 	go fnb.Start(signalerCtx)
 

--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -174,7 +174,7 @@ func main() {
 			syncCore, err = synchronization.New(node.Logger, synchronization.DefaultConfig())
 			return err
 		}).
-		CriticalComponent("verifier engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("verifier engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			rt := fvm.NewInterpreterRuntime()
 			vm := fvm.NewVirtualMachine(rt)
 			vmCtx := fvm.NewContext(node.Logger, node.FvmOptions...)
@@ -191,7 +191,7 @@ func main() {
 				approvalStorage)
 			return verifierEng, err
 		}).
-		CriticalComponent("chunk consumer, requester, and fetcher engines", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("chunk consumer, requester, and fetcher engines", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			requesterEngine, err = vereq.New(
 				node.Logger,
 				node.State,
@@ -233,7 +233,7 @@ func main() {
 
 			return chunkConsumer, nil
 		}).
-		CriticalComponent("assigner engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("assigner engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			var chunkAssigner module.ChunkAssigner
 			chunkAssigner, err = chunks.NewChunkAssigner(chunkAlpha, node.State)
 			if err != nil {
@@ -252,7 +252,7 @@ func main() {
 
 			return assignerEngine, nil
 		}).
-		CriticalComponent("block consumer", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("block consumer", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			var initBlockHeight uint64
 
 			blockConsumer, initBlockHeight, err = blockconsumer.NewBlockConsumer(
@@ -280,7 +280,7 @@ func main() {
 
 			return blockConsumer, nil
 		}).
-		CriticalComponent("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("follower engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 
 			// initialize cleaner for DB
 			cleaner := storage.NewCleaner(node.Logger, node.DB, node.Metrics.CleanCollector, flow.DefaultValueLogGCFrequency)
@@ -342,7 +342,7 @@ func main() {
 
 			return followerEng, nil
 		}).
-		CriticalComponent("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("finalized snapshot", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = synceng.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -350,7 +350,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		CriticalComponent("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
+		Component("sync engine", func(ctx irrecoverable.SignalerContext, node *cmd.NodeConfig, lookup component.LookupFunc) (module.ReadyDoneAware, error) {
 			sync, err := synceng.New(
 				node.Logger,
 				node.Metrics.Engine,

--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -368,5 +368,7 @@ func main() {
 
 			return sync, nil
 		}).
-		Build().Run()
+		SerialStart().
+		Build().
+		Run()
 }

--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -172,7 +172,7 @@ func main() {
 			syncCore, err = synchronization.New(node.Logger, synchronization.DefaultConfig())
 			return err
 		}).
-		Component("verifier engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("verifier engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			rt := fvm.NewInterpreterRuntime()
 			vm := fvm.NewVirtualMachine(rt)
 			vmCtx := fvm.NewContext(node.Logger, node.FvmOptions...)
@@ -189,7 +189,7 @@ func main() {
 				approvalStorage)
 			return verifierEng, err
 		}).
-		Component("chunk consumer, requester, and fetcher engines", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("chunk consumer, requester, and fetcher engines", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			requesterEngine, err = vereq.New(
 				node.Logger,
 				node.State,
@@ -231,7 +231,7 @@ func main() {
 
 			return chunkConsumer, nil
 		}).
-		Component("assigner engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("assigner engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			var chunkAssigner module.ChunkAssigner
 			chunkAssigner, err = chunks.NewChunkAssigner(chunkAlpha, node.State)
 			if err != nil {
@@ -250,7 +250,7 @@ func main() {
 
 			return assignerEngine, nil
 		}).
-		Component("block consumer", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("block consumer", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			var initBlockHeight uint64
 
 			blockConsumer, initBlockHeight, err = blockconsumer.NewBlockConsumer(
@@ -278,7 +278,7 @@ func main() {
 
 			return blockConsumer, nil
 		}).
-		Component("follower engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("follower engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 
 			// initialize cleaner for DB
 			cleaner := storage.NewCleaner(node.Logger, node.DB, node.Metrics.CleanCollector, flow.DefaultValueLogGCFrequency)
@@ -340,7 +340,7 @@ func main() {
 
 			return followerEng, nil
 		}).
-		Component("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("finalized snapshot", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			finalizedHeader, err = synceng.NewFinalizedHeaderCache(node.Logger, node.State, finalizationDistributor)
 			if err != nil {
 				return nil, fmt.Errorf("could not create finalized snapshot cache: %w", err)
@@ -348,7 +348,7 @@ func main() {
 
 			return finalizedHeader, nil
 		}).
-		Component("sync engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+		CriticalComponent("sync engine", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			sync, err := synceng.New(
 				node.Logger,
 				node.Metrics.Engine,
@@ -366,5 +366,5 @@ func main() {
 
 			return sync, nil
 		}).
-		Run()
+		Build().Run()
 }

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -217,7 +217,8 @@ func (cf *ConsensusFollowerImpl) Run(ctx context.Context) {
 		log.Info().Msg("Access node shutdown complete")
 	}()
 
-	if err := util.WaitError(errChan, cf.Done()); err != nil {
+	// Wait for errors up until the follower is done. we don't care about the context here
+	if err := util.WaitError(context.Background(), errChan, cf.Done()); err != nil {
 		log.Fatal().Err(err).Msg("A fatal error was encountered in consensus follower")
 	}
 }

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -217,8 +217,10 @@ func (cf *ConsensusFollowerImpl) Run(ctx context.Context) {
 		log.Info().Msg("Access node shutdown complete")
 	}()
 
-	// Wait for errors up until the follower is done. we don't care about the context here
-	if err := util.WaitError(context.Background(), errChan, cf.Done()); err != nil {
+	// Wait for errors up until the follower is done. we don't care about context cancellation
+	// since that will trigger shutting down the follower then closing the Done channel.
+	doneCtx, _ := util.WithDone(context.Background(), cf.Done())
+	if err := util.WaitError(doneCtx, errChan); err != nil {
 		log.Fatal().Err(err).Msg("A fatal error was encountered in consensus follower")
 	}
 }

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -139,7 +139,6 @@ type ConsensusFollowerImpl struct {
 	NodeBuilder *access.UnstakedAccessNodeBuilder
 	consumersMu sync.RWMutex
 	consumers   []pubsub.OnBlockFinalizedConsumer
-	node        cmd.Node
 }
 
 // NewConsensusFollower creates a new consensus follower.

--- a/integration/tests/access/unstaked_node_test.go
+++ b/integration/tests/access/unstaked_node_test.go
@@ -209,10 +209,8 @@ func (fm *followerManager) startFollower(ctx context.Context) {
 	go func() {
 		fm.follower.Run(ctx)
 	}()
-	// get the underlying node builder
-	node := fm.follower.NodeBuilder
 	// wait for the follower to have completely started
-	unittest.RequireCloseBefore(fm.t, node.Ready(), 10*time.Second,
+	unittest.RequireCloseBefore(fm.t, fm.follower.Ready(), 10*time.Second,
 		"timed out while waiting for consensus follower to start")
 }
 

--- a/integration/tests/access/unstaked_node_test.go
+++ b/integration/tests/access/unstaked_node_test.go
@@ -61,8 +61,6 @@ func (suite *UnstakedAccessSuite) TestReceiveBlocks() {
 	receivedBlocks := make(map[flow.Identifier]struct{}, blockCount)
 
 	suite.Run("consensus follower follows the chain", func() {
-		suite.T().Skip("flaky test")
-
 		// kick off the first follower
 		suite.followerMgr1.startFollower(ctx)
 		var err error
@@ -90,7 +88,6 @@ func (suite *UnstakedAccessSuite) TestReceiveBlocks() {
 	})
 
 	suite.Run("consensus follower sync up with the chain", func() {
-		suite.T().Skip("flaky test")
 		// kick off the second follower
 		suite.followerMgr2.startFollower(ctx)
 
@@ -169,7 +166,7 @@ func (suite *UnstakedAccessSuite) buildNetworkConfig() {
 	suite.followerMgr1, err = newFollowerManager(suite.T(), follower1)
 	require.NoError(suite.T(), err)
 
-	follower2 := suite.net.ConsensusFollowerByID(followerConfigs[0].NodeID)
+	follower2 := suite.net.ConsensusFollowerByID(followerConfigs[1].NodeID)
 	suite.followerMgr2, err = newFollowerManager(suite.T(), follower2)
 	require.NoError(suite.T(), err)
 }

--- a/module/component/component_manager_test.go
+++ b/module/component/component_manager_test.go
@@ -216,7 +216,7 @@ func ComponentWorker(t *rapid.T, id int, next WSTProvider) component.ComponentWo
 		t.Logf("[worker %v] %v\n", id, msg)
 	}
 
-	return func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+	return func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc, lookup component.LookupFunc) {
 		var state WorkerState
 		goto startingUp
 
@@ -509,7 +509,7 @@ func (c *ComponentManagerMachine) Init(t *rapid.T) {
 	for i := 0; i < numWorkers; i++ {
 		wtc, wtp := MakeWorkerTransitionFuncs()
 		c.workerTransitionConsumers[i] = wtc
-		cmb.AddWorker(ComponentWorker(t, i, wtp))
+		cmb.AddWorker("main", ComponentWorker(t, i, wtp))
 	}
 
 	c.cm = cmb.Build()

--- a/module/irrecoverable/errors.go
+++ b/module/irrecoverable/errors.go
@@ -1,23 +1,25 @@
 package irrecoverable
 
+import "fmt"
+
 // RecoverableError is an error that is fatal (i.e. the application should not continue) but is also
 // temporary and may be recoverable by restarting a component or taking some other recovery action.
 //
 // This is intended to be use in in conjunction with irrecoverable error handling to differentiate
 // errors that can be recovered by an error handler, and those that cannot (e.g. configuration issues)
 type RecoverableError struct {
+	msg string
 	err error
 }
 
-func NewRecoverableError(err error) *RecoverableError {
-	return &RecoverableError{
-		err: err,
-	}
+func WrapRecoverable(msg string, err error) *RecoverableError {
+	return &RecoverableError{msg, err}
 }
 
 func (e *RecoverableError) Error() string {
-	return e.err.Error()
+	return fmt.Errorf(e.msg, e.err).Error()
 }
+
 func (e *RecoverableError) Unwrap() error {
 	return e.err
 }

--- a/module/irrecoverable/errors.go
+++ b/module/irrecoverable/errors.go
@@ -1,0 +1,23 @@
+package irrecoverable
+
+// RecoverableError is an error that is fatal (i.e. the application should not continue) but is also
+// temporary and may be recoverable by restarting a component or taking some other recovery action.
+//
+// This is intended to be use in in conjunction with irrecoverable error handling to differentiate
+// errors that can be recovered by an error handler, and those that cannot (e.g. configuration issues)
+type RecoverableError struct {
+	err error
+}
+
+func NewRecoverableError(err error) *RecoverableError {
+	return &RecoverableError{
+		err: err,
+	}
+}
+
+func (e *RecoverableError) Error() string {
+	return e.err.Error()
+}
+func (e *RecoverableError) Unwrap() error {
+	return e.err
+}

--- a/module/irrecoverable/errors.go
+++ b/module/irrecoverable/errors.go
@@ -5,7 +5,7 @@ import "fmt"
 // RecoverableError is an error that is fatal (i.e. the application should not continue) but is also
 // temporary and may be recoverable by restarting a component or taking some other recovery action.
 //
-// This is intended to be use in in conjunction with irrecoverable error handling to differentiate
+// This is intended to be use in conjunction with irrecoverable error handling to differentiate
 // errors that can be recovered by an error handler, and those that cannot (e.g. configuration issues)
 type RecoverableError struct {
 	msg string

--- a/module/util/util.go
+++ b/module/util/util.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"context"
+	"os"
+	"os/signal"
 	"sync"
 
 	"github.com/onflow/flow-go/module"
@@ -47,5 +50,82 @@ func AllDone(components ...module.ReadyDoneAware) <-chan struct{} {
 		close(done)
 	}()
 
+	return done
+}
+
+// WaitReady waits for either a signal/close on the ready channel or for the context to be cancelled
+// Returns nil if the channel was signalled/closed before returning, otherwise, it returns the context
+// error.
+//
+// This handles the corner case where the context is cancelled at the exact same time that components
+// were marked ready, and reduces boilerplate code.
+// This is intended for situations where ignoring a ready signal can cause safety issues.
+func WaitReady(ctx context.Context, ready <-chan struct{}) error {
+	select {
+	case <-ctx.Done():
+		select {
+		case <-ready:
+			return nil
+		default:
+		}
+		return ctx.Err()
+	case <-ready:
+		return nil
+	}
+}
+
+// CheckClosed checks if the provided channel has a signal or was closed.
+// Returns true if the channel was signaled/closed, otherwise, returns false.
+//
+// This is intended to reduce boilerplate code when multiple channel checks are required because
+// missed signals could cause safety issues.
+func CheckClosed(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}
+
+// WaitError waits for either an error on the error channel or for the channel to be signalled/closed
+// Returns an error from the error channel if one was received, otherwise it returns nil
+//
+// Without the additional select, there is a race condition here where the done channel
+// could be closed right after an irrecoverable error is thrown, so that when the scheduler
+// yields control back to this goroutine, both channels are available to read from. If this
+// second case happens to be chosen at random to proceed, then we would return and silently
+// ignore the error.
+func WaitError(errChan <-chan error, done <-chan struct{}) error {
+	select {
+	case err := <-errChan:
+		return err
+	case <-done:
+		select {
+		case err := <-errChan:
+			return err
+		default:
+		}
+	}
+	return nil
+}
+
+// WrapSignal wraps a os.Signal channel with a struct{} channel, and closes the channel when a
+// signal is received.
+//
+// This is intended to make signals compatible with the other util channel methods.
+func WrapSignal(signals ...os.Signal) <-chan struct{} {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, signals...)
+
+	done := make(chan struct{})
+	go func() {
+		<-sig
+		close(done)
+
+		// cleanup since we can't use this channel again
+		signal.Stop(sig)
+		close(sig)
+	}()
 	return done
 }

--- a/network/p2p/connManager.go
+++ b/network/p2p/connManager.go
@@ -70,7 +70,7 @@ func (c *ConnManager) ListenNotifee(n network.Network, m multiaddr.Multiaddr) {
 // * This is never called back by libp2p currently and may be a bug on their side
 func (c *ConnManager) ListenCloseNotifee(n network.Network, m multiaddr.Multiaddr) {
 	// just log the multiaddress  on which we listen
-	c.log.Debug().Str("multiaddress", m.String()).Msg("listen stopped ")
+	c.log.Debug().Str("multiaddress", m.String()).Msg("listen stopped")
 }
 
 // Connected is called by libp2p when a connection opened

--- a/network/p2p/libp2pUtils.go
+++ b/network/p2p/libp2pUtils.go
@@ -178,7 +178,7 @@ func generatePingProtcolID(rootBlockID flow.Identifier) protocol.ID {
 func PeerAddressInfo(identity flow.Identity) (peer.AddrInfo, error) {
 	ip, port, key, err := networkingInfo(identity)
 	if err != nil {
-		return peer.AddrInfo{}, fmt.Errorf("could not get translate identity to networking info %s: %w", identity.NodeID.String(), err)
+		return peer.AddrInfo{}, fmt.Errorf("could not translate identity to networking info %s: %w", identity.NodeID.String(), err)
 	}
 
 	addr := MultiAddressStr(ip, port)

--- a/network/p2p/middleware.go
+++ b/network/p2p/middleware.go
@@ -139,7 +139,7 @@ func NewMiddleware(
 	}
 
 	mw.ComponentManager = component.NewComponentManagerBuilder().
-		AddWorker(func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+		AddWorker("main", func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc, lookup component.LookupFunc) {
 			// TODO: refactor to avoid storing ctx altogether
 			mw.ctx = ctx
 

--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -105,7 +105,7 @@ func NewNetwork(
 	o.mw.SetOverlay(o)
 
 	o.ComponentManager = component.NewComponentManagerBuilder().
-		AddWorker(func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+		AddWorker("start middleware", func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc, lookup component.LookupFunc) {
 			// setup the message queue
 			// create priority queue
 			o.queue = queue.NewMessageQueue(ctx, queue.GetEventPriority, metrics)
@@ -118,7 +118,7 @@ func NewNetwork(
 
 			ready()
 		}).
-		AddWorker(func(parent irrecoverable.SignalerContext, ready component.ReadyFunc) {
+		AddWorker("register request handler", func(parent irrecoverable.SignalerContext, ready component.ReadyFunc, lookup component.LookupFunc) {
 			ready()
 
 			for {


### PR DESCRIPTION
# This PR is being replaced by another that breaks the changes into smaller chunks for easier review.

Throughout the codebase irrecoverable errors are handled by calling zerolog `Fatal()` which then calls `os.Exit(1)`. This is ok when running the code as a node, since it can just restart. However, this is awkward when running code as a library, like with the consensus follower.

This PR updates the consensus follower library to make use of the `irrecoverable` methods to handle irrecoverable errors where possible by restarting the component. It also converts errors that previously called `Fatal()` to use the `Throw` method to propagate the error up so the caller can restart the library without crashing their application.