### PR TITLE
removing rlp-encoded private key string to use flow.AccountPrivateKey

### DIFF
--- a/integration/benchmark/tx_per_second_test.go
+++ b/integration/benchmark/tx_per_second_test.go
@@ -110,8 +110,12 @@ func (gs *TransactionsPerSecondSuite) privateKey() string {
 		panic("error while hex decoding hardcoded root key")
 	}
 
-	// RLP decode the key
-	ServiceAccountPrivateKey, err := flow.DecodeAccountPrivateKey(serviceAccountPrivateKeyBytes)
+	ServiceAccountPrivateKey := flow.AccountPrivateKey{
+		SignAlgo: unittest.ServiceAccountPrivateKeySignAlgo,
+		HashAlgo: unittest.ServiceAccountPrivateKeyHashAlgo,
+	}
+	ServiceAccountPrivateKey.PrivateKey, err = crypto.DecodePrivateKey(
+		ServiceAccountPrivateKey.SignAlgo, serviceAccountPrivateKeyBytes)
 	if err != nil {
 		panic("error while decoding hardcoded root key bytes")
 	}

--- a/integration/loader/main.go
+++ b/integration/loader/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/integration/utils"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
@@ -70,8 +71,12 @@ func main() {
 		log.Fatal().Err(err).Msgf("error while hex decoding hardcoded root key")
 	}
 
-	// RLP decode the key
-	ServiceAccountPrivateKey, err := flow.DecodeAccountPrivateKey(serviceAccountPrivateKeyBytes)
+	ServiceAccountPrivateKey := flow.AccountPrivateKey{
+		SignAlgo: unittest.ServiceAccountPrivateKeySignAlgo,
+		HashAlgo: unittest.ServiceAccountPrivateKeyHashAlgo,
+	}
+	ServiceAccountPrivateKey.PrivateKey, err = crypto.DecodePrivateKey(
+		ServiceAccountPrivateKey.SignAlgo, serviceAccountPrivateKeyBytes)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("error while decoding hardcoded root key bytes")
 	}

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -4,6 +4,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/crypto/hash"
+
 	"github.com/onflow/cadence"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -16,7 +19,9 @@ import (
 //	 HashAlgo:   hash.SHA2_256,
 // }
 
-const ServiceAccountPrivateKeyHex = "e3a08ae3d0461cfed6d6f49bfc25fa899351c39d1bd21fdba8c87595b6c49bb4cc430201"
+const ServiceAccountPrivateKeyHex = "8ae3d0461cfed6d6f49bfc25fa899351c39d1bd21fdba8c87595b6c49bb4cc43"
+const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
+const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
 const GenesisStateCommitmentHex = "0a05e884b52abd732a09a917b24138dffc1f83d1e92f9f6e2f2fb115381292af"
@@ -51,7 +56,10 @@ func init() {
 		panic("error while hex decoding hardcoded root key")
 	}
 
-	ServiceAccountPrivateKey, err = flow.DecodeAccountPrivateKey(serviceAccountPrivateKeyBytes)
+	ServiceAccountPrivateKey.SignAlgo = ServiceAccountPrivateKeySignAlgo
+	ServiceAccountPrivateKey.HashAlgo = ServiceAccountPrivateKeyHashAlgo
+	ServiceAccountPrivateKey.PrivateKey, err = crypto.DecodePrivateKey(
+		ServiceAccountPrivateKey.SignAlgo, serviceAccountPrivateKeyBytes)
 	if err != nil {
 		panic("error while decoding hardcoded root key bytes")
 	}


### PR DESCRIPTION

Testing performed:
- running unit tests locally
- running integration tests locally
- running integration load test