### PR TITLE
v0.22 testnet merge to master fixes

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -123,6 +123,7 @@ func run(*cobra.Command, []string) {
 		log.Logger,
 		!flagNoMigration,
 		!flagNoReport,
+		false,
 	)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("error extracting the execution state: %s", err.Error())

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -87,10 +87,10 @@ func extractExecutionState(
 				Log:       log,
 				OutputDir: outputDir,
 			},
-			&mgr.BalanceReporter{
-				Log:       log,
-				OutputDir: outputDir,
-			},
+			//&mgr.BalanceReporter{
+			//	Log:       log,
+			//	OutputDir: outputDir,
+			//},
 		}
 	}
 	newState, err := led.ExportCheckpointAt(

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -66,6 +66,7 @@ func TestExtractExecutionState(t *testing.T) {
 				zerolog.Nop(),
 				false,
 				false,
+				false,
 			)
 			require.Error(t, err)
 		})

--- a/cmd/util/ledger/migrations/storage_reporter.go
+++ b/cmd/util/ledger/migrations/storage_reporter.go
@@ -106,7 +106,7 @@ func (r StorageReporter) isDapper(address flow.Address, st *state.State) (bool, 
 			Identifier: "dapperUtilityCoinReceiver",
 		})
 
-	receiver, err := st.Get(id.Owner, id.Controller, id.Key)
+	receiver, err := st.Get(id.Owner, id.Controller, id.Key, false)
 	if err != nil {
 		return false, fmt.Errorf("could not load dapper receiver at %s: %w", address, err)
 	}
@@ -120,7 +120,7 @@ func (r StorageReporter) hasReceiver(address flow.Address, st *state.State) (boo
 			Identifier: "flowTokenReceiver",
 		})
 
-	receiver, err := st.Get(id.Owner, id.Controller, id.Key)
+	receiver, err := st.Get(id.Owner, id.Controller, id.Key, false)
 	if err != nil {
 		return false, fmt.Errorf("could not load receiver at %s: %w", address, err)
 	}
@@ -140,12 +140,12 @@ func (r StorageReporter) balance(address flow.Address, st *state.State) (balance
 			Identifier: "flowTokenBalance",
 		})
 
-	balanceCapability, err := st.Get(balanceId.Owner, balanceId.Controller, balanceId.Key)
+	balanceCapability, err := st.Get(balanceId.Owner, balanceId.Controller, balanceId.Key, false)
 	if err != nil {
 		return 0, false, fmt.Errorf("could not load capability at %s: %w", address, err)
 	}
 
-	vaultResource, err := st.Get(vaultId.Owner, vaultId.Controller, vaultId.Key)
+	vaultResource, err := st.Get(vaultId.Owner, vaultId.Controller, vaultId.Key, false)
 	if err != nil {
 		return 0, false, fmt.Errorf("could not load resource at %s: %w", address, err)
 	}

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -1,7 +1,6 @@
 package migrations
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/onflow/atree"
@@ -46,33 +45,33 @@ func registerIDToKey(registerID flow.RegisterID) ledger.Key {
 	return newKey
 }
 
-func splitPayloads(inp []ledger.Payload) (fvmPayloads []ledger.Payload, storagePayloads []ledger.Payload, slabPayloads []ledger.Payload) {
-	for _, p := range inp {
-		if fvmState.IsFVMStateKey(
-			string(p.Key.KeyParts[0].Value),
-			string(p.Key.KeyParts[1].Value),
-			string(p.Key.KeyParts[2].Value),
-		) {
-			fvmPayloads = append(fvmPayloads, p)
-			continue
-		}
-		if bytes.HasPrefix(p.Key.KeyParts[2].Value, []byte(atree.LedgerBaseStorageSlabPrefix)) {
-			slabPayloads = append(slabPayloads, p)
-			continue
-		}
-		// otherwise this is a storage payload
-		storagePayloads = append(storagePayloads, p)
-	}
-	return
-}
+//func splitPayloads(inp []ledger.Payload) (fvmPayloads []ledger.Payload, storagePayloads []ledger.Payload, slabPayloads []ledger.Payload) {
+//	for _, p := range inp {
+//		if fvmState.IsFVMStateKey(
+//			string(p.Key.KeyParts[0].Value),
+//			string(p.Key.KeyParts[1].Value),
+//			string(p.Key.KeyParts[2].Value),
+//		) {
+//			fvmPayloads = append(fvmPayloads, p)
+//			continue
+//		}
+//		if bytes.HasPrefix(p.Key.KeyParts[2].Value, []byte(atree.LedgerBaseStorageSlabPrefix)) {
+//			slabPayloads = append(slabPayloads, p)
+//			continue
+//		}
+//		// otherwise this is a storage payload
+//		storagePayloads = append(storagePayloads, p)
+//	}
+//	return
+//}
 
 type accountsAtreeLedger struct {
 	accounts fvmState.Accounts
 }
 
-func newAccountsAtreeLedger(accounts fvmState.Accounts) *accountsAtreeLedger {
-	return &accountsAtreeLedger{accounts: accounts}
-}
+//func newAccountsAtreeLedger(accounts fvmState.Accounts) *accountsAtreeLedger {
+//	return &accountsAtreeLedger{accounts: accounts}
+//}
 
 var _ atree.Ledger = &accountsAtreeLedger{}
 

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -47,7 +47,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("309941bd785dce8c88973ac6cad3cf8a3e8be159cc2174507562aef167247ac1")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("e8db7461cb4abc886a64ad9ea5f2f1ae2bfeddea91a75a16a7f04ba9dea4ab37")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -1286,7 +1286,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
-				assert.Equal(t, cadence.UFix64(9999_3930), script.Value)
+				assert.Equal(t, cadence.UFix64(9999_5070), script.Value)
 			}),
 	)
 

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -24,7 +24,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "09c48daae12a1a23fe9c41f9d836a56785a89404d7c792d99c37289981f5c56f"
+const GenesisStateCommitmentHex = "0a05e884b52abd732a09a917b24138dffc1f83d1e92f9f6e2f2fb115381292af"
 
 var GenesisStateCommitment flow.StateCommitment
 


### PR DESCRIPTION
- commented out `BalanceReporter` as it needs https://github.com/onflow/flow-go/pull/1410 to be reenabled, but that is not critical, and can just be commented out for now.
- not sure about the `execution-state-extract/cmd.go` cleanup storage parameter, I set it to false, but someone needs to check this.
- there were some unused functions in `cmd/util/ledger/migrations/utils.go` I commented them out, but I don't know why they are unused.
- expected state commitment changed, but I think this is expected due to storage changes.
- the available balance test changed, but this is ok. It is due to the storage changes.