### PR TITLE
Fix flaky TestUnstakedAccessSuite/TestReceiveBlocks tests

### DIFF
--- a/engine/common/synchronization/finalized_snapshot.go
+++ b/engine/common/synchronization/finalized_snapshot.go
@@ -117,12 +117,13 @@ func (f *FinalizedHeaderCache) onFinalizedBlock(blockID flow.Identifier) {
 
 // finalizationProcessingLoop is a separate goroutine that performs processing of finalization events
 func (f *FinalizedHeaderCache) finalizationProcessingLoop() {
+	defer close(f.stopped)
+
 	f.log.Debug().Msg("starting finalization processing loop")
 	notifier := f.finalizationEventNotifier.Channel()
 	for {
 		select {
 		case <-f.lm.ShutdownSignal():
-			close(f.stopped)
 			return
 		case <-notifier:
 			err := f.updateHeader()

--- a/engine/common/synchronization/finalized_snapshot.go
+++ b/engine/common/synchronization/finalized_snapshot.go
@@ -23,7 +23,8 @@ type FinalizedHeaderCache struct {
 	lastFinalizedHeader       *flow.Header
 	finalizationEventNotifier engine.Notifier // notifier for finalization events
 
-	lm *lifecycle.LifecycleManager
+	lm      *lifecycle.LifecycleManager
+	stopped chan struct{}
 }
 
 // NewFinalizedHeaderCache creates a new finalized header cache.
@@ -33,6 +34,7 @@ func NewFinalizedHeaderCache(log zerolog.Logger, state protocol.State, finalizat
 		lm:                        lifecycle.NewLifecycleManager(),
 		log:                       log.With().Str("component", "finalized_snapshot_cache").Logger(),
 		finalizationEventNotifier: engine.NewNotifier(),
+		stopped:                   make(chan struct{}),
 	}
 
 	snapshot, err := cache.getHeader()
@@ -97,7 +99,9 @@ func (f *FinalizedHeaderCache) Ready() <-chan struct{} {
 }
 
 func (f *FinalizedHeaderCache) Done() <-chan struct{} {
-	f.lm.OnStop()
+	f.lm.OnStop(func() {
+		<-f.stopped
+	})
 	return f.lm.Stopped()
 }
 
@@ -118,6 +122,7 @@ func (f *FinalizedHeaderCache) finalizationProcessingLoop() {
 	for {
 		select {
 		case <-f.lm.ShutdownSignal():
+			close(f.stopped)
 			return
 		case <-notifier:
 			err := f.updateHeader()

--- a/integration/tests/access/unstaked_node_test.go
+++ b/integration/tests/access/unstaked_node_test.go
@@ -166,7 +166,7 @@ func (suite *UnstakedAccessSuite) buildNetworkConfig() {
 	suite.followerMgr1, err = newFollowerManager(suite.T(), follower1)
 	require.NoError(suite.T(), err)
 
-	follower2 := suite.net.ConsensusFollowerByID(followerConfigs[0].NodeID)
+	follower2 := suite.net.ConsensusFollowerByID(followerConfigs[1].NodeID)
 	suite.followerMgr2, err = newFollowerManager(suite.T(), follower2)
 	require.NoError(suite.T(), err)
 }

--- a/integration/tests/access/unstaked_node_test.go
+++ b/integration/tests/access/unstaked_node_test.go
@@ -166,7 +166,7 @@ func (suite *UnstakedAccessSuite) buildNetworkConfig() {
 	suite.followerMgr1, err = newFollowerManager(suite.T(), follower1)
 	require.NoError(suite.T(), err)
 
-	follower2 := suite.net.ConsensusFollowerByID(followerConfigs[1].NodeID)
+	follower2 := suite.net.ConsensusFollowerByID(followerConfigs[0].NodeID)
 	suite.followerMgr2, err = newFollowerManager(suite.T(), follower2)
 	require.NoError(suite.T(), err)
 }


### PR DESCRIPTION
Closes https://github.com/dapperlabs/flow-internal/issues/1614

These tests were disabled due to flakiness. See [this example failure](https://github.com/onflow/flow-go/runs/3974629291?check_suite_focus=true#step:6:4707)

The issue stemmed from indicating that the `FinalizedHeaderCache` component had finished shutting down by closing its `Done` channel without waiting for the actual worker routine to stop. This resulted in the node thinking all of the components were completely shut down and proceeding to close badger DB. Depending on the timing of the shutdown signals and new block headers, `FinalizedHeaderCache` may not be finished writing new data resulting in a segfault.

Fixed by explicitly waiting for the worker routine to finish before closing the `Done` channel.