### PR TITLE
update cadence to use beta8-patch2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.3.3
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/onflow/atree v0.1.0-beta1.0.20211008214020-61661a17afed
-	github.com/onflow/cadence v0.20.0-beta8.0.20211008215159-65b39a750a8c
+	github.com/onflow/cadence v0.20.0-beta8.0.20211102191142-022a7ba2780c
 	github.com/onflow/cadence/v19 v19.0.0-00010101000000-000000000000
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9

--- a/go.sum
+++ b/go.sum
@@ -1075,6 +1075,8 @@ github.com/onflow/cadence v0.19.0 h1:xpz3Cl57FMHgu3DuvxJa4869g6kDOTSU07pCPrddxSk
 github.com/onflow/cadence v0.19.0/go.mod h1:ZXcJOh7LZkgqoArtvKx8UYcYQ0cC71zNffP6R1HGGB8=
 github.com/onflow/cadence v0.20.0-beta8.0.20211008215159-65b39a750a8c h1:lX9FA4tbVYOaoL+STC3EzDnYLK1M4DHNxWz8kFxe/rc=
 github.com/onflow/cadence v0.20.0-beta8.0.20211008215159-65b39a750a8c/go.mod h1:f1ddUw3IkKHegks/WBhP6NmR+L7ckpDeIMfUJvAil80=
+github.com/onflow/cadence v0.20.0-beta8.0.20211102191142-022a7ba2780c h1:qkeou+uMV/BrOQpS5RQEkyg17/OVp1dC8HCyIdOGMLU=
+github.com/onflow/cadence v0.20.0-beta8.0.20211102191142-022a7ba2780c/go.mod h1:f1ddUw3IkKHegks/WBhP6NmR+L7ckpDeIMfUJvAil80=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.20.0-beta8.0.20211008215159-65b39a750a8c
+	github.com/onflow/cadence v0.20.0-beta8.0.20211102191142-022a7ba2780c
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1194,6 +1194,8 @@ github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2Zfu
 github.com/onflow/cadence v0.19.0/go.mod h1:ZXcJOh7LZkgqoArtvKx8UYcYQ0cC71zNffP6R1HGGB8=
 github.com/onflow/cadence v0.20.0-beta8.0.20211008215159-65b39a750a8c h1:lX9FA4tbVYOaoL+STC3EzDnYLK1M4DHNxWz8kFxe/rc=
 github.com/onflow/cadence v0.20.0-beta8.0.20211008215159-65b39a750a8c/go.mod h1:f1ddUw3IkKHegks/WBhP6NmR+L7ckpDeIMfUJvAil80=
+github.com/onflow/cadence v0.20.0-beta8.0.20211102191142-022a7ba2780c h1:qkeou+uMV/BrOQpS5RQEkyg17/OVp1dC8HCyIdOGMLU=
+github.com/onflow/cadence v0.20.0-beta8.0.20211102191142-022a7ba2780c/go.mod h1:f1ddUw3IkKHegks/WBhP6NmR+L7ckpDeIMfUJvAil80=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9 h1:4Yk0ucsLhdh/TxYcCcE+2xXxsTqynvADAZ3d5tmTxVQ=


### PR DESCRIPTION
This patches cadence to handle some type checking cases with user error.