### PR TITLE
[Consensus] Continue recover block when hitting invalid block

### DIFF
--- a/consensus/recovery/recover.go
+++ b/consensus/recovery/recover.go
@@ -44,7 +44,7 @@ func Recover(log zerolog.Logger, finalized *flow.Header, pending []*flow.Header,
 				Hex("block_id", logging.ID(proposal.Block.BlockID)).
 				Err(err).
 				Msg("invalid proposal")
-			return nil
+			continue
 		}
 		if errors.Is(err, model.ErrUnverifiableBlock) {
 			log.Warn().

--- a/consensus/recovery/recover_test.go
+++ b/consensus/recovery/recover_test.go
@@ -1,0 +1,54 @@
+package recovery
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/consensus/hotstuff/mocks"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecover(t *testing.T) {
+	finalized := unittest.BlockHeaderFixture()
+	blocks := unittest.ChainFixtureFrom(100, &finalized)
+
+	pending := make([]*flow.Header, 0)
+	for _, b := range blocks {
+		pending = append(pending, b.Header)
+	}
+	recovered := make([]*model.Proposal, 0)
+	onProposal := func(block *model.Proposal) error {
+		recovered = append(recovered, block)
+		return nil
+	}
+
+	// make 3 invalid blocks extend from the last valid block
+	invalidblocks := unittest.ChainFixtureFrom(3, pending[len(pending)-1])
+	invalid := make(map[flow.Identifier]struct{})
+	for _, b := range invalidblocks {
+		invalid[b.ID()] = struct{}{}
+		pending = append(pending, b.Header)
+	}
+
+	validator := &mocks.Validator{}
+	validator.On("ValidateProposal", mock.Anything).Return(func(proposal *model.Proposal) error {
+		header := model.ProposalToFlow(proposal)
+		_, isInvalid := invalid[header.ID()]
+		if isInvalid {
+			return &model.InvalidBlockError{
+				BlockID: header.ID(),
+				View:    header.View,
+			}
+		}
+		return nil
+	})
+
+	err := Recover(unittest.Logger(), &finalized, pending, validator, onProposal)
+	require.NoError(t, err)
+
+	// only pending blocks are valid
+	require.Len(t, recovered, len(pending))
+}

--- a/consensus/recovery/recover_test.go
+++ b/consensus/recovery/recover_test.go
@@ -3,12 +3,13 @@ package recovery
 import (
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/flow-go/consensus/hotstuff/mocks"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRecover(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug that when hitting an invalid block during recovery, it should continue recover other blocks rather than stop