### PR TITLE
[BFT] Error handling for engines

### DIFF
--- a/engine/collection/compliance/engine_test.go
+++ b/engine/collection/compliance/engine_test.go
@@ -289,3 +289,16 @@ func (cs *ComplianceSuite) TestSubmittingMultipleEntries() {
 	// check that submit vote was called with correct parameters
 	cs.hotstuff.AssertExpectations(cs.T())
 }
+
+// TestProcessUnsupportedMessageType tests that Process and ProcessLocal correctly handle a case where invalid message type
+// was submitted from network layer.
+func (cs *ComplianceSuite) TestProcessUnsupportedMessageType() {
+	invalidEvent := uint64(42)
+	err := cs.engine.Process("ch", unittest.IdentifierFixture(), invalidEvent)
+	// shouldn't result in error since byzantine inputs are expected
+	require.NoError(cs.T(), err)
+	// in case of local processing error cannot be consumed since all inputs are trusted
+	err = cs.engine.ProcessLocal(invalidEvent)
+	require.Error(cs.T(), err)
+	require.True(cs.T(), engine.IsIncompatibleInputTypeError(err))
+}

--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -3,7 +3,6 @@
 package synchronization
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -193,9 +192,8 @@ func (e *Engine) Done() <-chan struct{} {
 
 // SubmitLocal submits an event originating on the local node.
 func (e *Engine) SubmitLocal(event interface{}) {
-	err := e.process(e.me.NodeID(), event)
+	err := e.ProcessLocal(event)
 	if err != nil {
-		// receiving an input of incompatible type from a trusted internal component is fatal
 		e.log.Fatal().Err(err).Msg("internal error processing event")
 	}
 }
@@ -204,18 +202,9 @@ func (e *Engine) SubmitLocal(event interface{}) {
 // for processing in a non-blocking manner. It returns instantly and logs
 // a potential processing error internally when done.
 func (e *Engine) Submit(channel network.Channel, originID flow.Identifier, event interface{}) {
-	err := e.process(originID, event)
+	err := e.Process(channel, originID, event)
 	if err != nil {
-		lg := e.log.With().
-			Err(err).
-			Str("channel", channel.String()).
-			Str("origin", originID.String()).
-			Logger()
-		if errors.Is(err, engine.IncompatibleInputTypeError) {
-			lg.Error().Msg("received message with incompatible type")
-			return
-		}
-		lg.Fatal().Msg("internal error processing message")
+		e.log.Fatal().Err(err).Msg("internal error processing event")
 	}
 }
 
@@ -227,7 +216,15 @@ func (e *Engine) ProcessLocal(event interface{}) error {
 // Process processes the given event from the node with the given origin ID in
 // a blocking manner. It returns the potential processing error when done.
 func (e *Engine) Process(channel network.Channel, originID flow.Identifier, event interface{}) error {
-	return e.process(originID, event)
+	err := e.process(originID, event)
+	if err != nil {
+		if engine.IsIncompatibleInputTypeError(err) {
+			e.log.Warn().Msgf("%v delivered unsupported message %T through %v", originID, event, channel)
+			return nil
+		}
+		return fmt.Errorf("unexpected error while processing engine message: %w", err)
+	}
+	return nil
 }
 
 // process processes events for the synchronization engine.
@@ -237,6 +234,7 @@ func (e *Engine) Process(channel network.Channel, originID flow.Identifier, even
 func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 	switch event.(type) {
 	case *messages.RangeRequest, *messages.BatchRequest, *messages.SyncRequest:
+		// since we have checked type it's safe to assume we are processing local event
 		return e.requestHandler.process(originID, event)
 	case *messages.SyncResponse, *messages.ClusterBlockResponse:
 		return e.responseMessageHandler.Process(originID, event)

--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -234,7 +234,6 @@ func (e *Engine) Process(channel network.Channel, originID flow.Identifier, even
 func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 	switch event.(type) {
 	case *messages.RangeRequest, *messages.BatchRequest, *messages.SyncRequest:
-		// since we have checked type it's safe to assume we are processing local event
 		return e.requestHandler.process(originID, event)
 	case *messages.SyncResponse, *messages.ClusterBlockResponse:
 		return e.responseMessageHandler.Process(originID, event)

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -475,5 +475,4 @@ func (ss *SyncSuite) TestProcessUnsupportedMessageType() {
 		require.Error(ss.T(), err)
 		require.True(ss.T(), engine.IsIncompatibleInputTypeError(err))
 	}
-
 }

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -448,7 +448,7 @@ func (ss *SyncSuite) TestProcessingMultipleItems() {
 		}
 
 		originID := unittest.IdentifierFixture()
-		ss.core.On("WithinTolerance", mock.Anything, mock.Anything).Return(false)
+		ss.core.On("WithinTolerance", mock.Anything, mock.Anything).Return(false).Once()
 		ss.core.On("HandleHeight", mock.Anything, msg.Height).Once()
 		ss.con.On("Unicast", mock.Anything, mock.Anything).Return(nil)
 
@@ -459,4 +459,21 @@ func (ss *SyncSuite) TestProcessingMultipleItems() {
 	time.Sleep(time.Millisecond * 100)
 
 	ss.core.AssertExpectations(ss.T())
+}
+
+// TestProcessUnsupportedMessageType tests that Process and ProcessLocal correctly handle a case where invalid message type
+// was submitted from network layer.
+func (ss *SyncSuite) TestProcessUnsupportedMessageType() {
+	invalidEvent := uint64(42)
+	engines := []netint.Engine{ss.e, ss.e.requestHandler}
+	for _, e := range engines {
+		err := e.Process("ch", unittest.IdentifierFixture(), invalidEvent)
+		// shouldn't result in error since byzantine inputs are expected
+		require.NoError(ss.T(), err)
+		// in case of local processing error cannot be consumed since all inputs are trusted
+		err = e.ProcessLocal(invalidEvent)
+		require.Error(ss.T(), err)
+		require.True(ss.T(), engine.IsIncompatibleInputTypeError(err))
+	}
+
 }

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -3,7 +3,6 @@
 package synchronization
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -201,18 +200,9 @@ func (e *Engine) SubmitLocal(event interface{}) {
 // for processing in a non-blocking manner. It returns instantly and logs
 // a potential processing error internally when done.
 func (e *Engine) Submit(channel network.Channel, originID flow.Identifier, event interface{}) {
-	err := e.process(originID, event)
+	err := e.Process(channel, originID, event)
 	if err != nil {
-		lg := e.log.With().
-			Err(err).
-			Str("channel", channel.String()).
-			Str("origin", originID.String()).
-			Logger()
-		if errors.Is(err, engine.IncompatibleInputTypeError) {
-			lg.Error().Msg("received message with incompatible type")
-			return
-		}
-		lg.Fatal().Msg("internal error processing message")
+		e.log.Fatal().Err(err).Msg("internal error processing event")
 	}
 }
 
@@ -224,7 +214,15 @@ func (e *Engine) ProcessLocal(event interface{}) error {
 // Process processes the given event from the node with the given origin ID in
 // a blocking manner. It returns the potential processing error when done.
 func (e *Engine) Process(channel network.Channel, originID flow.Identifier, event interface{}) error {
-	return e.process(originID, event)
+	err := e.process(originID, event)
+	if err != nil {
+		if engine.IsIncompatibleInputTypeError(err) {
+			e.log.Warn().Msgf("%v delivered unsupported message %T through %v", originID, event, channel)
+			return nil
+		}
+		return fmt.Errorf("unexpected error while processing engine message: %w", err)
+	}
+	return nil
 }
 
 // process processes events for the synchronization engine.

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -526,3 +526,19 @@ func (ss *SyncSuite) TestOnFinalizedBlock() {
 	require.ElementsMatch(ss.T(), ss.e.participantsProvider.Identifiers(), ss.participants[1:].NodeIDs())
 	require.Equal(ss.T(), actualHeader, &finalizedBlock)
 }
+
+// TestProcessUnsupportedMessageType tests that Process and ProcessLocal correctly handle a case where invalid message type
+// was submitted from network layer.
+func (ss *SyncSuite) TestProcessUnsupportedMessageType() {
+	invalidEvent := uint64(42)
+	engines := []netint.Engine{ss.e, ss.e.requestHandler}
+	for _, e := range engines {
+		err := e.Process("ch", unittest.IdentifierFixture(), invalidEvent)
+		// shouldn't result in error since byzantine inputs are expected
+		require.NoError(ss.T(), err)
+		// in case of local processing error cannot be consumed since all inputs are trusted
+		err = e.ProcessLocal(invalidEvent)
+		require.Error(ss.T(), err)
+		require.True(ss.T(), engine.IsIncompatibleInputTypeError(err))
+	}
+}

--- a/engine/common/synchronization/request_handler.go
+++ b/engine/common/synchronization/request_handler.go
@@ -80,9 +80,8 @@ func NewRequestHandlerEngine(
 
 // SubmitLocal submits an event originating on the local node.
 func (r *RequestHandlerEngine) SubmitLocal(event interface{}) {
-	err := r.process(r.me.NodeID(), event)
+	err := r.ProcessLocal(event)
 	if err != nil {
-		// receiving an input of incompatible type from a trusted internal component is fatal
 		r.log.Fatal().Err(err).Msg("internal error processing event")
 	}
 }
@@ -91,18 +90,9 @@ func (r *RequestHandlerEngine) SubmitLocal(event interface{}) {
 // for processing in a non-blocking manner. It returns instantly and logs
 // a potential processing error internally when done.
 func (r *RequestHandlerEngine) Submit(channel network.Channel, originID flow.Identifier, event interface{}) {
-	err := r.process(originID, event)
+	err := r.Process(channel, originID, event)
 	if err != nil {
-		lg := r.log.With().
-			Err(err).
-			Str("channel", channel.String()).
-			Str("origin", originID.String()).
-			Logger()
-		if errors.Is(err, engine.IncompatibleInputTypeError) {
-			lg.Error().Msg("received message with incompatible type")
-			return
-		}
-		lg.Fatal().Msg("internal error processing message")
+		r.log.Fatal().Err(err).Msg("internal error processing event")
 	}
 }
 
@@ -114,7 +104,15 @@ func (r *RequestHandlerEngine) ProcessLocal(event interface{}) error {
 // Process processes the given event from the node with the given origin ID in
 // a blocking manner. It returns the potential processing error when done.
 func (r *RequestHandlerEngine) Process(channel network.Channel, originID flow.Identifier, event interface{}) error {
-	return r.process(originID, event)
+	err := r.process(originID, event)
+	if err != nil {
+		if engine.IsIncompatibleInputTypeError(err) {
+			r.log.Warn().Msgf("%v delivered unsupported message %T through %v", originID, event, channel)
+			return nil
+		}
+		return fmt.Errorf("unexpected error while processing engine message: %w", err)
+	}
+	return nil
 }
 
 // process processes events for the synchronization request handler engine.
@@ -122,12 +120,7 @@ func (r *RequestHandlerEngine) Process(channel network.Channel, originID flow.Id
 //  * IncompatibleInputTypeError if input has unexpected type
 //  * All other errors are potential symptoms of internal state corruption or bugs (fatal).
 func (r *RequestHandlerEngine) process(originID flow.Identifier, event interface{}) error {
-	switch event.(type) {
-	case *messages.RangeRequest, *messages.BatchRequest, *messages.SyncRequest:
-		return r.requestMessageHandler.Process(originID, event)
-	default:
-		return fmt.Errorf("received input with type %T from %x: %w", event, originID[:], engine.IncompatibleInputTypeError)
-	}
+	return r.requestMessageHandler.Process(originID, event)
 }
 
 // setupRequestMessageHandler initializes the inbound queues and the MessageHandler for UNTRUSTED requests.

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -211,8 +211,16 @@ func (e *Engine) ProcessLocal(event interface{}) error {
 
 // Process processes the given event from the node with the given origin ID in
 // a blocking manner. It returns the potential processing error when done.
-func (e *Engine) Process(_ network.Channel, originID flow.Identifier, event interface{}) error {
-	return e.messageHandler.Process(originID, event)
+func (e *Engine) Process(channel network.Channel, originID flow.Identifier, event interface{}) error {
+	err := e.messageHandler.Process(originID, event)
+	if err != nil {
+		if engine.IsIncompatibleInputTypeError(err) {
+			e.log.Warn().Msgf("%v delivered unsupported message %T through %v", originID, event, channel)
+			return nil
+		}
+		return fmt.Errorf("unexpected error while processing engine message: %w", err)
+	}
+	return nil
 }
 
 func (e *Engine) loop() {

--- a/engine/consensus/compliance/engine_test.go
+++ b/engine/consensus/compliance/engine_test.go
@@ -189,3 +189,16 @@ func (cs *ComplianceSuite) TestSubmittingMultipleEntries() {
 	// check the submit vote was called with correct parameters
 	cs.hotstuff.AssertExpectations(cs.T())
 }
+
+// TestProcessUnsupportedMessageType tests that Process and ProcessLocal correctly handle a case where invalid message type
+// was submitted from network layer.
+func (cs *ComplianceSuite) TestProcessUnsupportedMessageType() {
+	invalidEvent := uint64(42)
+	err := cs.engine.Process("ch", unittest.IdentifierFixture(), invalidEvent)
+	// shouldn't result in error since byzantine inputs are expected
+	require.NoError(cs.T(), err)
+	// in case of local processing error cannot be consumed since all inputs are trusted
+	err = cs.engine.ProcessLocal(invalidEvent)
+	require.Error(cs.T(), err)
+	require.True(cs.T(), engine.IsIncompatibleInputTypeError(err))
+}

--- a/engine/consensus/ingestion/engine.go
+++ b/engine/consensus/ingestion/engine.go
@@ -133,8 +133,16 @@ func (e *Engine) ProcessLocal(event interface{}) error {
 
 // Process processes the given event from the node with the given origin ID in
 // a blocking manner. It returns error only in unexpected scenario.
-func (e *Engine) Process(_ network.Channel, originID flow.Identifier, event interface{}) error {
-	return e.messageHandler.Process(originID, event)
+func (e *Engine) Process(channel network.Channel, originID flow.Identifier, event interface{}) error {
+	err := e.messageHandler.Process(originID, event)
+	if err != nil {
+		if engine.IsIncompatibleInputTypeError(err) {
+			e.log.Warn().Msgf("unsupported message %T was delivered through %v", event, channel)
+			return nil
+		}
+		return fmt.Errorf("unexpected error while processing engine message: %w", err)
+	}
+	return nil
 }
 
 // processAvailableMessages processes the given ingestion engine event.

--- a/engine/consensus/ingestion/engine.go
+++ b/engine/consensus/ingestion/engine.go
@@ -137,7 +137,7 @@ func (e *Engine) Process(channel network.Channel, originID flow.Identifier, even
 	err := e.messageHandler.Process(originID, event)
 	if err != nil {
 		if engine.IsIncompatibleInputTypeError(err) {
-			e.log.Warn().Msgf("unsupported message %T was delivered through %v", event, channel)
+			e.log.Warn().Msgf("%v delivered unsupported message %T through %v", originID, event, channel)
 			return nil
 		}
 		return fmt.Errorf("unexpected error while processing engine message: %w", err)

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -144,7 +144,7 @@ func (e *Engine) Process(channel network.Channel, originID flow.Identifier, even
 	return nil
 }
 
-// process processes events for the matching engine on the consensus node.
+// process events for the matching engine on the consensus node.
 func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 	receipt, ok := event.(*flow.ExecutionReceipt)
 	if !ok {

--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -133,3 +133,16 @@ func (s *MatchingEngineSuite) TestMultipleProcessingItems() {
 
 	s.core.AssertExpectations(s.T())
 }
+
+// TestProcessUnsupportedMessageType tests that Process and ProcessLocal correctly handle a case where invalid message type
+// was submitted from network layer.
+func (s *MatchingEngineSuite) TestProcessUnsupportedMessageType() {
+	invalidEvent := uint64(42)
+	err := s.engine.Process("ch", unittest.IdentifierFixture(), invalidEvent)
+	// shouldn't result in error since byzantine inputs are expected
+	require.NoError(s.T(), err)
+	// in case of local processing error cannot be consumed since all inputs are trusted
+	err = s.engine.ProcessLocal(invalidEvent)
+	require.Error(s.T(), err)
+	require.True(s.T(), engine.IsIncompatibleInputTypeError(err))
+}

--- a/engine/errors.go
+++ b/engine/errors.go
@@ -163,3 +163,7 @@ func LogErrorWithMsg(log zerolog.Logger, msg string, err error) {
 	// all other errors should just be logged as usual
 	log.Error().Str("error_type", "internal_error").Err(err).Msg(msg)
 }
+
+func IsIncompatibleInputTypeError(err error) bool {
+	return errors.Is(err, IncompatibleInputTypeError)
+}


### PR DESCRIPTION
### Context

This PR unifies error handling and they way we process message delivered from network layer or other components.
In nutshell:
- `Process/Submit` never returns `IncompatibleInputTypeError` since it expected byzantine inputs
- `ProcessLocal/SubmitLocal` doesn't tolerate `IncompatibleInputTypeError` and will propagate error to caller since input is trusted and it's unexpected. 

This PR has lots of boilerplate logic, I am trying to condense it into reusable component something like `engineBase` or `engineManager`. On other hand this can wait till we refactor `network.Engine` in favor of `network.MessageProcessor `