### PR TITLE
Kan/identifier merkle root fix

### DIFF
--- a/model/flow/identifier.go
+++ b/model/flow/identifier.go
@@ -145,8 +145,13 @@ func GetIDs(value interface{}) []Identifier {
 func MerkleRoot(ids ...Identifier) Identifier {
 	var root Identifier
 	tree := merkle.NewTree()
-	for _, id := range ids {
-		tree.Put(id[:], nil)
+	for i, id := range ids {
+		// NOTE: the id[:] passed in here will be the address of byte array
+		// that is used by Go in the loop, so it MUST be copied to a different
+		// slice if the intention is to store it's value. Otherwise,
+		// all the value will be the last item of the ids slice.
+		// This is not a problem for i, due to it being a primative (int)
+		tree.Put(id[:], i)
 	}
 	hash := tree.Hash()
 	copy(root[:], hash)
@@ -173,7 +178,7 @@ func CheckConcatSum(sum Identifier, fps ...Identifier) bool {
 }
 
 // Sample returns random sample of length 'size' of the ids
-// [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
+// [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher-Yates_shuffle).
 func Sample(size uint, ids ...Identifier) []Identifier {
 	n := uint(len(ids))
 	dup := make([]Identifier, 0, n)

--- a/model/flow/identifier_test.go
+++ b/model/flow/identifier_test.go
@@ -101,12 +101,14 @@ func TestMerkleRoot(t *testing.T) {
 
 }
 
+// We should ideally replace this with a completely different reference implementation
+// Possibly writen in another language, such as python, similar to the Ledger Trie Implementation
 func referenceMerkleRoot(ids ...flow.Identifier) flow.Identifier {
 	var root flow.Identifier
 	tree := merkle.NewTree()
-	for _, id := range ids {
-		idCopy := id
-		tree.Put(idCopy[:], nil)
+	for i, id := range ids {
+		iCopy, idCopy := i, id
+		tree.Put(idCopy[:], iCopy)
 	}
 	hash := tree.Hash()
 	copy(root[:], hash)

--- a/model/flow/identifier_test.go
+++ b/model/flow/identifier_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage/merkle"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -78,4 +79,36 @@ func TestIdentifierSample(t *testing.T) {
 		sample := flow.Sample(sampleSize, ids...)
 		require.Empty(t, sample)
 	})
+}
+
+func TestMerkleRoot(t *testing.T) {
+
+	total := 10
+	ids := make([]flow.Identifier, total)
+	for i := range ids {
+		ids[i] = unittest.IdentifierFixture()
+	}
+
+	idsBad := make([]flow.Identifier, total)
+	for i := range idsBad {
+		idsBad[i] = ids[len(ids)-1]
+	}
+	fmt.Println(ids)
+	fmt.Println(idsBad)
+
+	require.NotEqual(t, flow.MerkleRoot(ids...), flow.MerkleRoot(idsBad...))
+	require.Equal(t, referenceMerkleRoot(ids...), flow.MerkleRoot(ids...))
+
+}
+
+func referenceMerkleRoot(ids ...flow.Identifier) flow.Identifier {
+	var root flow.Identifier
+	tree := merkle.NewTree()
+	for _, id := range ids {
+		idCopy := id
+		tree.Put(idCopy[:], nil)
+	}
+	hash := tree.Hash()
+	copy(root[:], hash)
+	return root
 }

--- a/storage/merkle/tree.go
+++ b/storage/merkle/tree.go
@@ -144,8 +144,11 @@ PutLoop:
 			// if we have reached the end of the key, insert the new value
 			totalCount := uint(len(key)) * 8
 			if index == totalCount {
+				// Make a copy of the key, to ensure we have the only pointer to it
+				keyCopy := make([]byte, len(key))
+				copy(keyCopy, key)
 				*cur = &leaf{
-					key: key,
+					key: keyCopy,
 					val: val,
 				}
 				return false


### PR DESCRIPTION
This PR is to address a bug related to the generation of Hashes for the intention of making an Identifier.

The MerkleRoot function, where the bug manifests, is used for hashing the unique IDs of the contents of a block Payload together.

While we do take SOME data from each ID to generate the hash, (e.g. we follow the correct "path" down the merkle tree), the value that was saved as the key of the leaf would actually get changed due to the fact that it's making use of the same memory space that go is using for the for loop that is passing the data in.

While we don't feel like this is a security vulnerability, and we're not worried about collisions with this setup, it does mean the hashes are NOT generated how we want them to be currently, and this PR fixes that.

We also add a "value" in the node, which didn't previously exist, which will set the order of the IDs, which is a property that we wanted to add.