### PR TITLE
[Execution] patch ledger interaction limit error when hit on programs

### DIFF
--- a/fvm/handler/programs.go
+++ b/fvm/handler/programs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 )
@@ -90,7 +91,10 @@ func (h *ProgramsHandler) Get(location common.Location) (*interpreter.Program, b
 		if view != nil { // handle view not set (ie. for non-address locations
 			err := h.mergeState(view)
 			if err != nil {
-				panic(fmt.Sprintf("merge error while getting program, panic: %s", err))
+				// ignore LedgerIntractionLimitExceededError errors
+				if !errors.As(err, &errors.LedgerIntractionLimitExceededError{}) {
+					panic(fmt.Sprintf("merge error while getting program, panic: %s", err))
+				}
 			}
 		}
 		return program, true


### PR DESCRIPTION
This is a rare edge case, when we hit the ledger interaction limit on loading a contract, while long term we should adjust the program handler to properly return an error, in this patch we only panic on fatal errors and ignore the rest.