### PR TITLE
Use latest finalized (not sealed) reference block

### DIFF
--- a/module/dkg/client.go
+++ b/module/dkg/client.go
@@ -67,7 +67,7 @@ func (c *Client) Broadcast(msg model.BroadcastDKGMessage) error {
 	}
 
 	// get latest sealed block to execute transaction
-	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, true)
+	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, false)
 	if err != nil {
 		return fmt.Errorf("could not get latest block from node: %w", err)
 	}
@@ -171,7 +171,7 @@ func (c *Client) SubmitResult(groupPublicKey crypto.PublicKey, publicKeys []cryp
 	}
 
 	// get latest sealed block to execute transaction
-	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, true)
+	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, false)
 	if err != nil {
 		return fmt.Errorf("could not get latest block from node: %w", err)
 	}

--- a/module/dkg/client.go
+++ b/module/dkg/client.go
@@ -66,7 +66,7 @@ func (c *Client) Broadcast(msg model.BroadcastDKGMessage) error {
 		return fmt.Errorf("could not get account details: %w", err)
 	}
 
-	// get latest sealed block to execute transaction
+	// get latest finalized block to execute transaction
 	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, false)
 	if err != nil {
 		return fmt.Errorf("could not get latest block from node: %w", err)
@@ -170,7 +170,7 @@ func (c *Client) SubmitResult(groupPublicKey crypto.PublicKey, publicKeys []cryp
 		return fmt.Errorf("could not get account details: %w", err)
 	}
 
-	// get latest sealed block to execute transaction
+	// get latest finalized block to execute transaction
 	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, false)
 	if err != nil {
 		return fmt.Errorf("could not get latest block from node: %w", err)

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -83,7 +83,7 @@ func (c *QCContractClient) SubmitVote(ctx context.Context, vote *model.Vote) err
 	}
 
 	// get latest sealed block to execute transaction
-	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, true)
+	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, false)
 	if err != nil {
 		return fmt.Errorf("could not get latest block from node: %w", err)
 	}

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -82,7 +82,7 @@ func (c *QCContractClient) SubmitVote(ctx context.Context, vote *model.Vote) err
 		return fmt.Errorf("could not get account: %w", err)
 	}
 
-	// get latest sealed block to execute transaction
+	// get latest finalized block to execute transaction
 	latestBlock, err := c.FlowClient.GetLatestBlock(ctx, false)
 	if err != nil {
 		return fmt.Errorf("could not get latest block from node: %w", err)


### PR DESCRIPTION
In cases where sealing is behind, using the latest sealed block can result in generating immediately-expired transactions. It is safe to use the latest finalized block for the purposes of the tx reference block.