### PR TITLE
[Verification] Removes less and swap methods of chunk list

### DIFF
--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -111,16 +111,3 @@ func (cl ChunkList) ByIndex(i uint64) (*Chunk, bool) {
 func (cl ChunkList) Len() int {
 	return len(cl)
 }
-
-// Less returns true if element i in the ChunkList is less than j based on its chunk ID.
-// Otherwise it returns true.
-// It satisfies the sort.Interface making the ChunkList sortable.
-func (cl ChunkList) Less(i, j int) bool {
-	return cl[i].ID().String() < cl[j].ID().String()
-}
-
-// Swap swaps the element i and j in the ChunkList.
-// It satisfies the sort.Interface making the ChunkList sortable.
-func (cl ChunkList) Swap(i, j int) {
-	cl[j], cl[i] = cl[i], cl[j]
-}

--- a/model/flow/entity.go
+++ b/model/flow/entity.go
@@ -2,9 +2,9 @@ package flow
 
 // Entity defines how flow entities should be defined
 // Entities are flat data structures holding multiple data fields.
-// Entities don't includes nested entities, they only include pointers to
-// other entities. for example they keep an slice of entity commits instead
-// of keeping an slice of entity object itself. This simplifies storage, signature and validation
+// Entities don't include nested entities, they only include pointers to
+// other entities. For example, they keep a slice of entity commits instead
+// of keeping a slice of entity object itself. This simplifies storage, signature and validation
 // of entities.
 type Entity interface {
 


### PR DESCRIPTION
This PR was originally meant to optimize the `Less` method of `ChunkList` with respect to `ID` method invocations (see this issue https://github.com/dapperlabs/flow-go/issues/5946). `Less` method of `ChunkList` was introduced earlier [by me](https://github.com/onflow/flow-go/commit/2a14fd5e92b8f28e6e3bb8ea6c52f33795720900) at the time we develop the very first version of the verification node. At that time, the purpose was to make the `ChunkList` implement the `sort` interface, hence, being sortable. 

However, after reviewing the use cases of `ChunkList` in our current codebase, we no longer require such sorting capability. This is also supported by the fact that chunks are uniquely addressed by their index within an execution result, so there is no longer a need for sorting them based on their `ID`. 

To resolve the ambiguities around `ChunkList` being sortable and its _inefficient_ `Less` method implementation, this PR removes the `Less` and `Swap` methods of `ChunkList` hence disabling its sortable capability that no longer is needed.