### PR TITLE
[voting V2] Use the crypto package constant for signature length

### DIFF
--- a/consensus/hotstuff/signature/type_encoder.go
+++ b/consensus/hotstuff/signature/type_encoder.go
@@ -37,22 +37,24 @@ func DecodeSingleSig(sigData []byte) (hotstuff.SigType, crypto.Signature, error)
 }
 
 // DecodeDoubleSig decodes the signature data into a staking signature and an optional
-// random beacon signature. Cryptographic validity of signatures is _not_ checked.
+// random beacon signature. The decoding assumes BLS with BLS12-381 is used.
+// Cryptographic validity of signatures is _not_ checked.
 // Decomposition of the sigData is purely done based on length.
 // It returns:
 //  - staking signature, random beacon signature, nil:
-//    if sigData is 96 bytes long, we use the leading 48 bytes as staking signature
-//    and the tailing 48 bytes as random beacon sig
+//    if sigData is twice the size of a BLS signature bytes long, we use the leading half as staking signature
+//    and the tailing half random beacon sig
 //  - staking signature, nil, nil:
-//    if sigData is 48 bytes long, we interpret sigData entirely as staking signature
+//    if sigData is the size of a BLS signature, we interpret sigData entirely as staking signature
 //  - nil, nil, ErrInvalidFormat if the sig type is invalid (covers nil or empty sigData)
 func DecodeDoubleSig(sigData []byte) (crypto.Signature, crypto.Signature, error) {
 	sigLength := len(sigData)
+	blsSigLen := crypto.SignatureLenBLSBLS12381
 	switch sigLength {
-	case 48:
+	case blsSigLen:
 		return sigData, nil, nil
-	case 96:
-		return sigData[:48], sigData[48:], nil
+	case 2 * blsSigLen:
+		return sigData[:blsSigLen], sigData[blsSigLen:], nil
 	}
 
 	return nil, nil, fmt.Errorf("invalid sig data length %d: %w", sigLength, msig.ErrInvalidFormat)

--- a/consensus/hotstuff/signature/type_encoder.go
+++ b/consensus/hotstuff/signature/type_encoder.go
@@ -8,7 +8,7 @@ import (
 	msig "github.com/onflow/flow-go/module/signature"
 )
 
-SigLen := crypto.SignatureLenBLSBLS12381
+const SigLen = crypto.SignatureLenBLSBLS12381
 
 // EncodeSingleSig encodes a single signature into signature data as required by the consensus design.
 func EncodeSingleSig(sigType hotstuff.SigType, sig crypto.Signature) []byte {

--- a/consensus/hotstuff/signature/type_encoder.go
+++ b/consensus/hotstuff/signature/type_encoder.go
@@ -8,6 +8,8 @@ import (
 	msig "github.com/onflow/flow-go/module/signature"
 )
 
+SigLen := crypto.SignatureLenBLSBLS12381
+
 // EncodeSingleSig encodes a single signature into signature data as required by the consensus design.
 func EncodeSingleSig(sigType hotstuff.SigType, sig crypto.Signature) []byte {
 	t := byte(sigType)
@@ -49,12 +51,11 @@ func DecodeSingleSig(sigData []byte) (hotstuff.SigType, crypto.Signature, error)
 //  - nil, nil, ErrInvalidFormat if the sig type is invalid (covers nil or empty sigData)
 func DecodeDoubleSig(sigData []byte) (crypto.Signature, crypto.Signature, error) {
 	sigLength := len(sigData)
-	blsSigLen := crypto.SignatureLenBLSBLS12381
 	switch sigLength {
-	case blsSigLen:
+	case SigLen:
 		return sigData, nil, nil
-	case 2 * blsSigLen:
-		return sigData[:blsSigLen], sigData[blsSigLen:], nil
+	case 2 * SigLen:
+		return sigData[:SigLen], sigData[SigLen:], nil
 	}
 
 	return nil, nil, fmt.Errorf("invalid sig data length %d: %w", sigLength, msig.ErrInvalidFormat)

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/helper"
 	mockhotstuff "github.com/onflow/flow-go/consensus/hotstuff/mocks"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	hsig "github.com/onflow/flow-go/consensus/hotstuff/signature"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
 	msig "github.com/onflow/flow-go/module/signature"
@@ -97,16 +98,13 @@ func (s *CombinedVoteProcessorV2TestSuite) TestProcess_VoteNotForProposal() {
 	s.reconstructor.AssertNotCalled(s.T(), "Verify")
 }
 
-// BLS signature length
-const blsSigLen = crypto.SignatureLenBLSBLS12381
-
 // TestProcess_InvalidSignatureFormat ensures that we process signatures only with valid format.
 // If we have received vote with signature in invalid format we should return with sentinel error
 func (s *CombinedVoteProcessorV2TestSuite) TestProcess_InvalidSignatureFormat() {
 
-	// valid length is blsSigLen or 2*blsSigLen
+	// valid length is SigLen or 2*SigLen
 	generator := rapid.IntRange(0, 128).Filter(func(value int) bool {
-		return value != blsSigLen && value != 2*blsSigLen
+		return value != hsig.SigLen && value != 2*hsig.SigLen
 	})
 	rapid.Check(s.T(), func(t *rapid.T) {
 		// create a signature with invalid length
@@ -151,7 +149,7 @@ func (s *CombinedVoteProcessorV2TestSuite) TestProcess_InvalidSignature() {
 	})
 	s.Run("staking-double-sig", func() {
 		doubleSigVote := unittest.VoteForBlockFixture(s.proposal.Block, VoteWithDoubleSig())
-		stakingSig := crypto.Signature(doubleSigVote.SigData[:blsSigLen])
+		stakingSig := crypto.Signature(doubleSigVote.SigData[:hsig.SigLen])
 
 		s.stakingAggregator.On("Verify", doubleSigVote.SignerID, stakingSig).Return(msig.ErrInvalidFormat).Once()
 
@@ -176,8 +174,8 @@ func (s *CombinedVoteProcessorV2TestSuite) TestProcess_InvalidSignature() {
 	// test same cases for beacon signature
 	s.Run("beacon-sig", func() {
 		doubleSigVote := unittest.VoteForBlockFixture(s.proposal.Block, VoteWithDoubleSig())
-		stakingSig := crypto.Signature(doubleSigVote.SigData[:blsSigLen])
-		beaconSig := crypto.Signature(doubleSigVote.SigData[blsSigLen:])
+		stakingSig := crypto.Signature(doubleSigVote.SigData[:hsig.SigLen])
+		beaconSig := crypto.Signature(doubleSigVote.SigData[hsig.SigLen:])
 
 		// staking sig valid, beacon sig invalid
 		s.stakingAggregator.On("Verify", doubleSigVote.SignerID, stakingSig).Return(nil).Once()
@@ -527,7 +525,7 @@ func TestCombinedVoteProcessorV2_PropertyCreatingQCCorrectness(testifyT *testing
 		votes := make([]*model.Vote, 0, stakingSignersCount+beaconSignersCount)
 
 		expectStakingAggregatorCalls := func(vote *model.Vote) {
-			expectedSig := crypto.Signature(vote.SigData[:blsSigLen])
+			expectedSig := crypto.Signature(vote.SigData[:hsig.SigLen])
 			stakingAggregator.On("Verify", vote.SignerID, expectedSig).Return(nil).Maybe()
 			stakingAggregator.On("TrustedAdd", vote.SignerID, expectedSig).Run(func(args mock.Arguments) {
 				signerID := args.Get(0).(flow.Identifier)
@@ -550,7 +548,7 @@ func TestCombinedVoteProcessorV2_PropertyCreatingQCCorrectness(testifyT *testing
 			vote := unittest.VoteForBlockFixture(processor.Block(), VoteWithDoubleSig())
 			vote.SignerID = signer
 			expectStakingAggregatorCalls(vote)
-			expectedSig := crypto.Signature(vote.SigData[blsSigLen:])
+			expectedSig := crypto.Signature(vote.SigData[hsig.SigLen:])
 			reconstructor.On("Verify", vote.SignerID, expectedSig).Return(nil).Maybe()
 			reconstructor.On("TrustedAdd", vote.SignerID, expectedSig).Run(func(args mock.Arguments) {
 				collectedShares.Inc()
@@ -677,7 +675,7 @@ func TestCombinedVoteProcessorV2_PropertyCreatingQCLiveness(testifyT *testing.T)
 		votes := make([]*model.Vote, 0, stakingSignersCount+beaconSignersCount)
 
 		expectStakingAggregatorCalls := func(vote *model.Vote, stake uint64) {
-			expectedSig := crypto.Signature(vote.SigData[:blsSigLen])
+			expectedSig := crypto.Signature(vote.SigData[:hsig.SigLen])
 			stakingAggregator.On("Verify", vote.SignerID, expectedSig).Return(nil).Maybe()
 			stakingAggregator.On("TrustedAdd", vote.SignerID, expectedSig).Run(func(args mock.Arguments) {
 				stakingTotalWeight.Add(stake)
@@ -695,7 +693,7 @@ func TestCombinedVoteProcessorV2_PropertyCreatingQCLiveness(testifyT *testing.T)
 			vote := unittest.VoteForBlockFixture(processor.Block(), VoteWithDoubleSig())
 			vote.SignerID = signer.ID()
 			expectStakingAggregatorCalls(vote, signer.Stake)
-			expectedSig := crypto.Signature(vote.SigData[blsSigLen:])
+			expectedSig := crypto.Signature(vote.SigData[hsig.SigLen:])
 			reconstructor.On("Verify", vote.SignerID, expectedSig).Return(nil).Maybe()
 			reconstructor.On("TrustedAdd", vote.SignerID, expectedSig).Run(func(args mock.Arguments) {
 				collectedShares.Inc()
@@ -739,7 +737,7 @@ func TestCombinedVoteProcessorV2_PropertyCreatingQCLiveness(testifyT *testing.T)
 
 func VoteWithStakingSig() func(*model.Vote) {
 	return func(vote *model.Vote) {
-		vote.SigData = unittest.RandomBytes(blsSigLen)
+		vote.SigData = unittest.RandomBytes(hsig.SigLen)
 	}
 }
 


### PR DESCRIPTION
This PR replaces `48` by the crypto constant for BLS signature length (the constant should not be assumed to be always 48).