### PR TITLE
[consensus V3] update weighted aggregator interface

### DIFF
--- a/consensus/hotstuff/signature/weighted_signature_aggregator.go
+++ b/consensus/hotstuff/signature/weighted_signature_aggregator.go
@@ -41,7 +41,7 @@ var _ hotstuff.WeightedSignatureAggregator = &WeightedSignatureAggregator{}
 // A weighted aggregator is used for one aggregation only. A new instance should be used for each use.
 func NewWeightedSignatureAggregator(
 	ids flow.IdentityList, // list of all possible signers
-	pks []crypto.PublicKey, // list of corresponding public keys
+	pks []crypto.PublicKey, // list of corresponding public keys used for signature verifications
 	message []byte, // message to get an aggregated signature for
 	dsTag string, // domain separation tag used by the signature
 ) (*WeightedSignatureAggregator, error) {

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/consensus/hotstuff/signature"
 	"github.com/onflow/flow-go/consensus/hotstuff/verification"
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -46,7 +47,13 @@ func (f *combinedVoteProcessorFactoryBaseV2) Create(block *model.Block) (hotstuf
 	// message that has to be verified against aggregated signature
 	msg := verification.MakeVoteMessage(block.View, block.BlockID)
 
-	stakingSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, msg, encoding.ConsensusVoteTag)
+	// prepare the staking public keys of participants
+	stakingKeys := make([]crypto.PublicKey, 0, len(allParticipants))
+	for _, participant := range allParticipants {
+		stakingKeys = append(stakingKeys, participant.StakingPubKey)
+	}
+
+	stakingSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, stakingKeys, msg, encoding.ConsensusVoteTag)
 	if err != nil {
 		return nil, fmt.Errorf("could not create aggregator for staking signatures: %w", err)
 	}

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/consensus/hotstuff/signature"
 	"github.com/onflow/flow-go/consensus/hotstuff/verification"
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -48,12 +49,33 @@ func (f *combinedVoteProcessorFactoryBaseV3) Create(block *model.Block) (hotstuf
 	// message that has to be verified against aggregated signature
 	msg := verification.MakeVoteMessage(block.View, block.BlockID)
 
-	stakingSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, msg, encoding.ConsensusVoteTag)
+	// prepare the staking public keys of participants
+	stakingKeys := make([]crypto.PublicKey, 0, len(allParticipants))
+	for _, participant := range allParticipants {
+		stakingKeys = append(stakingKeys, participant.StakingPubKey)
+	}
+
+	stakingSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, stakingKeys, msg, encoding.ConsensusVoteTag)
 	if err != nil {
 		return nil, fmt.Errorf("could not create aggregator for staking signatures: %w", err)
 	}
 
-	rbSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, msg, encoding.ConsensusVoteTag)
+	dkg, err := f.committee.DKG(block.BlockID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get DKG info at block %v: %w", block.BlockID, err)
+	}
+
+	// prepare the random beacon public keys of participants
+	beaconKeys := make([]crypto.PublicKey, 0, len(allParticipants))
+	for _, participant := range allParticipants {
+		pk, err := dkg.KeyShare(participant.NodeID)
+		if err != nil {
+			return nil, fmt.Errorf("could not get random beacon key share for %x: %w", participant.NodeID, err)
+		}
+		beaconKeys = append(beaconKeys, pk)
+	}
+
+	rbSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, beaconKeys, msg, encoding.ConsensusVoteTag)
 	if err != nil {
 		return nil, fmt.Errorf("could not create aggregator for thershold signatures: %w", err)
 	}

--- a/consensus/hotstuff/votecollector/staking_vote_processor.go
+++ b/consensus/hotstuff/votecollector/staking_vote_processor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/consensus/hotstuff/signature"
 	"github.com/onflow/flow-go/consensus/hotstuff/verification"
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -45,7 +46,13 @@ func (f *stakingVoteProcessorFactoryBase) Create(block *model.Block) (hotstuff.V
 	// message that has to be verified against aggregated signature
 	msg := verification.MakeVoteMessage(block.View, block.BlockID)
 
-	stakingSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, msg, encoding.CollectorVoteTag)
+	// prepare the staking public keys of participants
+	stakingKeys := make([]crypto.PublicKey, 0, len(allParticipants))
+	for _, participant := range allParticipants {
+		stakingKeys = append(stakingKeys, participant.StakingPubKey)
+	}
+
+	stakingSigAggtor, err := signature.NewWeightedSignatureAggregator(allParticipants, stakingKeys, msg, encoding.CollectorVoteTag)
 	if err != nil {
 		return nil, fmt.Errorf("could not create aggregator for staking signatures: %w", err)
 	}


### PR DESCRIPTION
There is a mistake in the current `NewWeightedSignatureAggregator` interface: it takes node identifiers as inputs and uses their staking keys as the low level verification keys. This is not correct because `WeightedSignatureAggregator` should also be used for random beacon keys. 

The PR updates the interface of `NewWeightedSignatureAggregator` to accept public keys as inputs. 