### PR TITLE
[FVM BLS] add more tests

### DIFF
--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2038,7 +2038,9 @@ func TestBLSMultiSignature(t *testing.T) {
 
 					signatures := make([]cadence.Value, 0, numSigs)
 					// alter one random signature
-					sigs[numSigs/2][0] ^= 1
+					tmp := sigs[numSigs/2]
+					sigs[numSigs/2] = crypto.BLSInvalidSignature()
+
 					for _, sig := range sigs {
 						s := testutil.BytesToCadenceArray(sig)
 						signatures = append(signatures, s)
@@ -2056,7 +2058,7 @@ func TestBLSMultiSignature(t *testing.T) {
 					)
 
 					// revert the change
-					sigs[numSigs/2][0] ^= 1
+					sigs[numSigs/2] = tmp
 
 					err = vm.Run(ctx, script, view, programs)
 					assert.NoError(t, err)
@@ -2245,9 +2247,14 @@ func TestBLSMultiSignature(t *testing.T) {
 										signatureAlgorithm: SignatureAlgorithm.BLS_BLS12_381
 									))
 								}
-								let aggPk = AggregateBLSPublicKeys(pks)
-								let aggSignature = AggregateBLSSignatures(signatures)
-								return aggPk.verify(aggSignature, message, tag, KMAC128_BLS_BLS12_381)
+								let aggPk = AggregateBLSPublicKeys(pks)!
+								let aggSignature = AggregateBLSSignatures(signatures)!
+								let boo = aggPk.verify(
+									signature: aggSignature, 
+									signedData: message, 
+									domainSeparationTag: tag, 
+									hashAlgorithm: HashAlgorithm.KMAC128_BLS_BLS12_381)
+								return boo
 							}
 							`,
 					),


### PR DESCRIPTION
This PR complements the existing tests for :
 - BLS PoP verify
 - BLS aggregate signatures
 - BLS aggregate keys
 
It updates the handling of non-BLS algorithms and hashing algorithms. It also adds a full happy path test combining the 2 aggregating functions.