### PR TITLE
github: fix code ownership for access

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,10 +11,9 @@
 /cmd/execution/** @m4ksio @ramtinms
 /engine/execution/** @m4ksio @ramtinms
 
-# Observation Stream
-/cmd/observation/** @psiemens
-/engine/observation/** @psiemens
-/protobuf/services/observation/** @psiemens
+# Access Stream
+/cmd/access/** @vishalchangrani
+/engine/access/** @vishalchangrani
 
 # Verification Stream
 /cmd/verification/** @ramtinms @yhassanzadeh13


### PR DESCRIPTION
"Observation" was renamed to "Access" early last year.

PS. Assigned to @vishalchangrani based on the renaming work in 654bfa76a074242495c183d8fa016c4fd09b69ac (#3170).  Feel free to re-aasign.