### PR TITLE
security: replace nbsp with normal spaces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,6 @@ We really appreciate the community's help. Responsible disclosure of vulnerabili
 
 If you care about making a difference, please follow the guidelines below.
 
-# **Guidelines For Responsible Disclosure**
+# **Guidelines For Responsible Disclosure**
 
-We ask that all researchers adhere to these guidelines [here](https://docs.onflow.org/bounties/responsible-disclosure/)
+We ask that all researchers adhere to these guidelines [here](https://docs.onflow.org/bounties/responsible-disclosure/)


### PR DESCRIPTION
For some reason this file has Non-Breaking-Spaces (U+00A0) instead of normal spaces:
```
00000190: 6964 656c 696e 6573 c2a0 466f 72c2 a052  idelines..For..R
000001a0: 6573 706f 6e73 6962 6c65 c2a0 4469 7363  esponsible..Disc
000001b0: 6c6f 7375 7265 2a2a 0a0a 5765 c2a0 6173  losure**..We..as
000001c0: 6bc2 a074 6861 74c2 a061 6c6c c2a0 7265  k..that..all..re
000001d0: 7365 6172 6368 6572 73c2 a061 6468 6572  searchers..adher
000001e0: 65c2 a074 6fc2 a074 6865 7365 c2a0 6775  e..to..these..gu
```
(Note all these `c2a0` instead of `0x20`)

PS. Also note that a subset of links on https://docs.onflow.org/bounties/responsible-disclosure/ are currently broken.