### PR TITLE
Auto Cadence Update: Include dependencies in contributing doc, plus gitignore.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-multiaddr v0.3.3
 	github.com/multiformats/go-multiaddr-dns v0.3.1
-	github.com/onflow/cadence v0.20.0-beta9.0.20211122235138-4c670116c0e4
+	github.com/onflow/cadence v0.20.0-beta9.0.20211122235358-424f81401332
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3

--- a/go.sum
+++ b/go.sum
@@ -1109,8 +1109,8 @@ github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
-github.com/onflow/cadence v0.20.0-beta9.0.20211122235138-4c670116c0e4 h1:2qaVsVb/Qo5HTilwkHJWeou8V8LFS89jJ8dCGwfIulo=
-github.com/onflow/cadence v0.20.0-beta9.0.20211122235138-4c670116c0e4/go.mod h1:0V1+biR2YQmEZMZa8wKtTlbcCid4/9kW89YMvi4h7/M=
+github.com/onflow/cadence v0.20.0-beta9.0.20211122235358-424f81401332 h1:+k9uXqto9vAIYfYy1zDWqedmv0Noqf4obaIyzG6tPe4=
+github.com/onflow/cadence v0.20.0-beta9.0.20211122235358-424f81401332/go.mod h1:0V1+biR2YQmEZMZa8wKtTlbcCid4/9kW89YMvi4h7/M=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.20.0-beta9.0.20211122235138-4c670116c0e4
+	github.com/onflow/cadence v0.20.0-beta9.0.20211122235358-424f81401332
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1235,8 +1235,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.18.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
-github.com/onflow/cadence v0.20.0-beta9.0.20211122235138-4c670116c0e4 h1:2qaVsVb/Qo5HTilwkHJWeou8V8LFS89jJ8dCGwfIulo=
-github.com/onflow/cadence v0.20.0-beta9.0.20211122235138-4c670116c0e4/go.mod h1:0V1+biR2YQmEZMZa8wKtTlbcCid4/9kW89YMvi4h7/M=
+github.com/onflow/cadence v0.20.0-beta9.0.20211122235358-424f81401332 h1:+k9uXqto9vAIYfYy1zDWqedmv0Noqf4obaIyzG6tPe4=
+github.com/onflow/cadence v0.20.0-beta9.0.20211122235358-424f81401332/go.mod h1:0V1+biR2YQmEZMZa8wKtTlbcCid4/9kW89YMvi4h7/M=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9 h1:4Yk0ucsLhdh/TxYcCcE+2xXxsTqynvADAZ3d5tmTxVQ=


### PR DESCRIPTION
Auto generated PR to update Cadence version.

References: https://github.com/onflow/cadence/pull/1270