### PR TITLE
REST: Response decorator

### DIFF
--- a/engine/access/rest/accounts.go
+++ b/engine/access/rest/accounts.go
@@ -1,21 +1,14 @@
 package rest
 
 import (
-	"net/http"
-
-	"github.com/rs/zerolog"
-
 	"github.com/onflow/flow-go/access"
 )
 
-func getAccount(
-	w http.ResponseWriter,
-	r *http.Request,
-	vars map[string]string,
-	backend access.API,
-	logger zerolog.Logger,
-) (interface{}, StatusError) {
-	address, err := toAddress(vars["address"])
+const ExpandableFieldContracts = "contracts"
+const ExpandableFieldKeys = "keys"
+
+func getAccount(r *requestDecorator, backend access.API, link LinkGenerator) (interface{}, StatusError) {
+	address, err := toAddress(r.getParam("address"))
 	if err != nil {
 		return nil, NewBadRequestError("invalid address", err)
 	}

--- a/engine/access/rest/converter.go
+++ b/engine/access/rest/converter.go
@@ -463,7 +463,7 @@ func accountKeysResponse(keys []flow.AccountPublicKey) []generated.AccountPublic
 }
 
 func accountResponse(account *flow.Account) generated.Account {
-	contracts := make(map[string]string, len(account.Contracts))
+	contracts := make(map[string]string)
 	for name, code := range account.Contracts {
 		contracts[name] = string(code)
 	}
@@ -475,5 +475,11 @@ func accountResponse(account *flow.Account) generated.Account {
 		Contracts:  contracts,
 		Expandable: nil,
 		Links:      nil,
+	}
+}
+
+func LinkResponse(link string) *generated.Links {
+	return &generated.Links{
+		Self: link,
 	}
 }

--- a/engine/access/rest/link_generator.go
+++ b/engine/access/rest/link_generator.go
@@ -15,6 +15,9 @@ type LinkGenerator interface {
 	TransactionResultLink(id flow.Identifier) (string, error)
 	PayloadLink(id flow.Identifier) (string, error)
 	ExecutionResultLink(id flow.Identifier) (string, error)
+	AccountLink(address string) (string, error)
+	AccountContractLink(address string) (string, error)
+	AccountKeysLink(address string) (string, error)
 }
 
 type LinkGeneratorImpl struct {
@@ -45,6 +48,18 @@ func (generator *LinkGeneratorImpl) TransactionResultLink(id flow.Identifier) (s
 	return generator.link(getTransactionResultByIDRoute, id)
 }
 
+func (generator *LinkGeneratorImpl) AccountLink(address string) (string, error) {
+	return generator.linkAddress(getAccountRoute, address)
+}
+
+func (generator *LinkGeneratorImpl) AccountContractLink(address string) (string, error) {
+	return generator.linkAddress(getAccountContractsRoute, address)
+}
+
+func (generator *LinkGeneratorImpl) AccountKeysLink(address string) (string, error) {
+	return generator.linkAddress(getAccountKeysRoute, address)
+}
+
 func selfLink(id flow.Identifier, linkFun LinkFun) (*generated.Links, error) {
 	url, err := linkFun(id)
 	if err != nil {
@@ -61,5 +76,13 @@ func (generator *LinkGeneratorImpl) link(route string, id flow.Identifier) (stri
 		return "", err
 	}
 	// TODO: remove the leading '/v1' from the generated link
+	return url.String(), nil
+}
+
+func (generator *LinkGeneratorImpl) linkAddress(route string, address string) (string, error) {
+	url, err := generator.router.Get(route).URLPath("address", address)
+	if err != nil {
+		return "", err
+	}
 	return url.String(), nil
 }

--- a/engine/access/rest/response_decorator.go
+++ b/engine/access/rest/response_decorator.go
@@ -1,0 +1,77 @@
+package rest
+
+import (
+	"encoding/json"
+	"github.com/onflow/flow-go/engine/access/rest/generated"
+)
+
+type responseDecorator struct {
+	response interface{}
+	request  *requestDecorator
+	link     LinkGenerator
+}
+
+func newResponseDecorator(req *requestDecorator, response interface{}, link LinkGenerator) (*responseDecorator, error) {
+	res := &responseDecorator{
+		response: response,
+		request:  req,
+		link:     link,
+	}
+	err := res.process()
+
+	return res, err
+}
+
+// process finds out what is the response type and applies correct decorators
+func (r *responseDecorator) process() error {
+	switch res := r.response.(type) {
+	case generated.Account:
+		return r.account(res)
+	}
+
+	return nil
+}
+
+// JSON serializer
+func (r *responseDecorator) JSON() ([]byte, error) {
+	err := r.process()
+
+	serialised, err := json.Marshal(r.response)
+	if err != nil {
+		return nil, err
+	}
+
+	return serialised, nil
+}
+
+func (r *responseDecorator) account(account generated.Account) error {
+	link, err := r.link.AccountLink(account.Address)
+	if err != nil {
+		return err
+	}
+	account.Links = LinkResponse(link)
+
+	account.Expandable = &generated.AccountExpandable{}
+
+	if !r.request.expands(ExpandableFieldContracts) {
+		contractLink, err := r.link.AccountContractLink(account.Address)
+		if err != nil {
+			return err
+		}
+		account.Contracts = nil
+		account.Expandable.Contracts = contractLink
+	}
+
+	if !r.request.expands(ExpandableFieldKeys) {
+		keysLink, err := r.link.AccountKeysLink(account.Address)
+		if err != nil {
+			return err
+		}
+		account.Keys = nil
+		account.Expandable.Keys = keysLink
+	}
+
+	// todo here we can handle selection
+
+	return nil
+}

--- a/engine/access/rest/server.go
+++ b/engine/access/rest/server.go
@@ -22,6 +22,9 @@ const (
 	executeScriptRoute            = "executeScript"
 	getBlockPayloadByIDRoute      = "getBlockPayloadByID"
 	getExecutionResultByIDRoute   = "getExecutionResultByID"
+	getAccountRoute               = "getAccount"
+	getAccountContractsRoute      = "getAccountContracts"
+	getAccountKeysRoute           = "getAccountKeys"
 )
 
 // NewServer returns an HTTP server initialized with the REST API handler


### PR DESCRIPTION
This PR implements response decorator in a similar way to the request decorator. The purpose of this is mainly to isolate and decouple the logic for handling responses like filtering out data with `?select` query but also to filter out what isn't included with `?expandable` query as well as link generation whenever that is needed in accordance with expendables. 

Biggest reason for this is to have handlers that are light and not complicated with a lot of if/else blocks handling expandable, selects and links.

Each response can have a function handling that now as seen here:
https://github.com/onflow/flow-go/blob/gregor/account-handler/engine/access/rest/response_decorator.go#L47

This is just a proof of concept and was implemented on a single account resource. I want to have a consensus before applying to others.