### PR TITLE
Suggested refactorings for Merkle Patricia Tree

### DIFF
--- a/model/flow/identifier.go
+++ b/model/flow/identifier.go
@@ -146,12 +146,15 @@ func MerkleRoot(ids ...Identifier) Identifier {
 	var root Identifier
 	tree := merkle.NewTree()
 	for i, id := range ids {
+		val := make([]byte, 8)
+		binary.BigEndian.PutUint64(val, uint64(i))
+
 		// NOTE: the id[:] passed in here will be the address of byte array
 		// that is used by Go in the loop, so it MUST be copied to a different
 		// slice if the intention is to store it's value. Otherwise,
 		// all the value will be the last item of the ids slice.
 		// This is not a problem for i, due to it being a primative (int)
-		tree.Put(id[:], i)
+		tree.Put(id[:], val)
 	}
 	hash := tree.Hash()
 	copy(root[:], hash)

--- a/storage/merkle/node.go
+++ b/storage/merkle/node.go
@@ -4,22 +4,89 @@ package merkle
 
 import (
 	"github.com/onflow/flow-go/crypto/hash"
+	"golang.org/x/crypto/blake2b"
 )
 
-type node interface{}
+// The node represents a generic vertex in the sparse Merkle trie.
+// CONVENTION:
+//  * This implementation guarantees that within the trie there are
+//    _never_ nil-references to descendants. We completely avoid this by
+//    utilizing `short nodes` that represent any path-segment without branching.
+type node interface {
+	// Hash computes recursively the hash of this respective sub trie.
+	// To simplify enforcing cryptographic security, we introduce the convention
+	// that hashing a nil node is an illegal operation, which panics.
+	Hash() []byte
+}
+
+// nodeTag encodes the type of node when hashing it. Required for cryptographic
+// safety to prevent malleability attacks (replacing a full node with a short node
+// that has identical hash would otherwise be possible).
+// Values are intended to be global constants and must be unique.
+var (
+	leafNodeTag  = [1]byte{uint8(0)}
+	fullNodeTag  = [1]byte{uint8(1)}
+	shortNodeTag = [1]byte{uint8(2)}
+)
+
+/* ******************************* Short Node ******************************* */
+// Per convention a Full node has _always_ one child, which is either
+// a full node or a leaf.
 
 type short struct {
 	path  []byte // holds the common path to the next node
 	count uint   // holds the count of bits in the path
-	child node   // holds the child after the common path
+	child node   // holds the child after the common path; never nil
 }
+
+func (n short) Hash() []byte {
+	h, _ := blake2b.New256(shortNodeTag[:])
+	_, _ = h.Write([]byte{byte(n.count)})
+	_, _ = h.Write(n.path)
+	_, _ = h.Write(n.child.Hash())
+	return h.Sum(nil)
+}
+
+/* ******************************** Full Node ******************************* */
+// Per convention a Full node has _always_ two children. Nil values not allowed.
 
 type full struct {
-	left  node // holds the left path node (bit 0)
-	right node // holds the right path node (bit 1)
+	left  node // holds the left path node (bit 0); never nil
+	right node // holds the right path node (bit 1); never nil
 }
 
+func (n full) Hash() []byte {
+	h, _ := blake2b.New256(fullNodeTag[:])
+	_, _ = h.Write(n.left.Hash())
+	_, _ = h.Write(n.right.Hash())
+	return h.Sum(nil)
+}
+
+/* ******************************** Leaf Node ******************************* */
+// Holds a key-value pair. We only hash the value, because the key is committed
+// to by the merkle path through the trie.
+
 type leaf struct {
-	key hash.Hash   // redundant copy of hash (key/path) for root hash
-	val interface{} // the concrete data we actually stored
+	key hash.Hash // copy of key
+	val []byte    // the concrete data we actually stored
+}
+
+func (n leaf) Hash() []byte {
+	h, _ := blake2b.New256(leafNodeTag[:])
+	_, _ = h.Write(n.val)
+	return h.Sum(nil)
+}
+
+/* ******************************** Dummy Node ******************************* */
+// 4th dummy node type as substitute for `nil`. Not used in the trie but as zero
+// value for auxiliary variables during trie update operations. This reduces
+// complexity of the business logic, as we can then also apply the convention of
+// "nodes are never nil" to the auxiliary variables.
+
+type dummy struct{}
+
+func (n dummy) Hash() []byte {
+	// Per convention, Hash should never be called by the business logic but
+	// is required to implement the node iterface
+	panic("dummy node has no hash")
 }

--- a/storage/merkle/node.go
+++ b/storage/merkle/node.go
@@ -24,9 +24,9 @@ type node interface {
 // that has identical hash would otherwise be possible).
 // Values are intended to be global constants and must be unique.
 var (
-	leafNodeTag  = [1]byte{uint8(0)}
-	fullNodeTag  = [1]byte{uint8(1)}
-	shortNodeTag = [1]byte{uint8(2)}
+	leafNodeTag  = []byte{0}
+	fullNodeTag  = []byte{1}
+	shortNodeTag = []byte{2}
 )
 
 /* ******************************* Short Node ******************************* */

--- a/storage/merkle/node.go
+++ b/storage/merkle/node.go
@@ -30,7 +30,7 @@ var (
 )
 
 /* ******************************* Short Node ******************************* */
-// Per convention a Full node has _always_ one child, which is either
+// Per convention a Short node has _always_ one child, which is either
 // a full node or a leaf.
 
 type short struct {


### PR DESCRIPTION
_This PR targets branch [`kan/identifier-merkle-root-fix`](https://github.com/onflow/flow-go/tree/kan/identifier-merkle-root-fix) and is an amendment to [PR #1580](https://github.com/onflow/flow-go/pull/1580/)_

## This PR addresses a couple security problems with the Patricia Tree implementation:

Fundamentally, the `Tree` implements cryptographic commitment scheme to a _set_ of key-value pairs. 

1. Currently, the values are not included in the cryptographic hash of the tree: https://github.com/onflow/flow-go/blob/4bf22f6bb2f6568005a6fd965a5b4a5dbd4a920a/storage/merkle/tree.go#L414-L416
2. The current implementation is vulnerable to a hash-collision attacks: It is possible to replace a full node with a short node. Therefore, the current implementation is not safe for providing inclusion or non-inclusion proofs. The current `Tree` is safe to verify cryptographic integrity when obtaining the _full set_ of key-value pairs, but this defeats the purpose of using a merkle trie. For the full _set of key-value pairs_, a simple hash would be sufficient as a commitment. 

## This PR addresses some code-clarity issues:

* refactored node structures to be object-oriented, thereby removing unnecessary switch statement for hash computation
* to simplify enforcing cryptographic security, we introduce the convention that hashing a nil node is an illegal operation, which panics
