### PR TITLE
Update to latest flow-go/crypto, 7b31c98

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3
 	github.com/onflow/flow-go-sdk v0.24.0
-	github.com/onflow/flow-go/crypto v0.21.3
+	github.com/onflow/flow-go/crypto v0.21.4-0.20211125190211-7b31c986316e
 	github.com/onflow/flow/protobuf/go/flow v0.2.3
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pelletier/go-toml v1.9.4 // indirect

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/onflow/flow-ft/lib/go/templates v0.2.0
 	github.com/onflow/flow-go v0.18.0 // replaced by version on-disk
 	github.com/onflow/flow-go-sdk v0.24.0
-	github.com/onflow/flow-go/crypto v0.21.3 // replaced by version on-disk
+	github.com/onflow/flow-go/crypto v0.21.4-0.20211125190211-7b31c986316e // replaced by version on-disk
 	github.com/onflow/flow/protobuf/go/flow v0.2.3
 	github.com/plus3it/gorecurcopy v0.0.1
 	github.com/prometheus/common v0.20.0 // indirect


### PR DESCRIPTION
`flow-go` currently does not build when using it as a dependency:

```
../../../go/pkg/mod/github.com/onflow/flow-go@v0.23.2-0.20211125190211-7b31c986316e/model/flow/identifier.go:115:2: undefined: "github.com/onflow/flow-go/crypto/hash".ComputeSHA3_256
../../../go/pkg/mod/github.com/onflow/flow-go@v0.23.2-0.20211125190211-7b31c986316e/model/flow/identifier.go:124:2: undefined: "github.com/onflow/flow-go/crypto/hash".ComputeSHA3_256
```

Update the `flow-go/crypto` dependency to the latest version. This is effectively the same as if the `replace` statement would be effective.

Also see https://axiomzen.slack.com/archives/C015G65HR2P/p1637867663058600