### PR TITLE
use nil to verify implementation

### DIFF
--- a/consensus/hotstuff/forks/forkchoice/forks_test.go
+++ b/consensus/hotstuff/forks/forkchoice/forks_test.go
@@ -19,12 +19,6 @@ import (
 	mockfinalizer "github.com/onflow/flow-go/module/mock"
 )
 
-// TestForks_ImplementsInterface tests that forks.Forks implements hotstuff.Forks
-// (compile-time test)
-func TestForks_ImplementsInterface(t *testing.T) {
-	var _ hotstuff.Forks = &forks.Forks{}
-}
-
 // TestForks_Initialization tests that Forks correctly reports trusted Root
 func TestForks_Initialization(t *testing.T) {
 	forks, _, _, root := initForks(t, 1)

--- a/consensus/hotstuff/forks/forks.go
+++ b/consensus/hotstuff/forks/forks.go
@@ -3,6 +3,7 @@ package forks
 import (
 	"fmt"
 
+	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -12,6 +13,8 @@ type Forks struct {
 	finalizer  Finalizer
 	forkchoice ForkChoice
 }
+
+var _ hotstuff.Forks = (*Forks)(nil)
 
 // New creates a Forks instance
 func New(finalizer Finalizer, forkchoice ForkChoice) *Forks {

--- a/consensus/hotstuff/notifications/log_consumer.go
+++ b/consensus/hotstuff/notifications/log_consumer.go
@@ -15,7 +15,7 @@ type LogConsumer struct {
 	log zerolog.Logger
 }
 
-var _ hotstuff.Consumer = &LogConsumer{}
+var _ hotstuff.Consumer = (*LogConsumer)(nil)
 
 func NewLogConsumer(log zerolog.Logger) *LogConsumer {
 	lc := &LogConsumer{

--- a/consensus/hotstuff/notifications/noop_consumer.go
+++ b/consensus/hotstuff/notifications/noop_consumer.go
@@ -10,7 +10,7 @@ import (
 // doesn't do anything.
 type NoopConsumer struct{}
 
-var _ hotstuff.Consumer = &NoopConsumer{}
+var _ hotstuff.Consumer = (*NoopConsumer)(nil)
 
 func NewNoopConsumer() *NoopConsumer {
 	nc := &NoopConsumer{}

--- a/consensus/hotstuff/notifications/pubsub/distributor.go
+++ b/consensus/hotstuff/notifications/pubsub/distributor.go
@@ -16,7 +16,7 @@ type Distributor struct {
 	lock        sync.RWMutex
 }
 
-var _ hotstuff.Consumer = &Distributor{}
+var _ hotstuff.Consumer = (*Distributor)(nil)
 
 func (p *Distributor) OnEventProcessed() {
 	p.lock.RLock()

--- a/consensus/hotstuff/notifications/pubsub/finalization_distributor.go
+++ b/consensus/hotstuff/notifications/pubsub/finalization_distributor.go
@@ -19,7 +19,7 @@ type FinalizationDistributor struct {
 	lock                          sync.RWMutex
 }
 
-var _ hotstuff.Consumer = &FinalizationDistributor{}
+var _ hotstuff.Consumer = (*FinalizationDistributor)(nil)
 
 func NewFinalizationDistributor() *FinalizationDistributor {
 	return &FinalizationDistributor{

--- a/consensus/hotstuff/signature/randombeacon_reconstructor.go
+++ b/consensus/hotstuff/signature/randombeacon_reconstructor.go
@@ -16,7 +16,7 @@ type RandomBeaconReconstructor struct {
 	dkg                            hotstuff.DKG // to lookup signer index by signer ID
 }
 
-var _ hotstuff.RandomBeaconReconstructor = &RandomBeaconReconstructor{}
+var _ hotstuff.RandomBeaconReconstructor = (*RandomBeaconReconstructor)(nil)
 
 func NewRandomBeaconReconstructor(dkg hotstuff.DKG, randomBeaconInspector hotstuff.RandomBeaconInspector) *RandomBeaconReconstructor {
 	return &RandomBeaconReconstructor{

--- a/consensus/hotstuff/signature/weighted_signature_aggregator.go
+++ b/consensus/hotstuff/signature/weighted_signature_aggregator.go
@@ -27,7 +27,7 @@ type WeightedSignatureAggregator struct {
 	lock         sync.RWMutex                              // lock for atomic updates to totalWeight and collectedIDs
 }
 
-var _ hotstuff.WeightedSignatureAggregator = &WeightedSignatureAggregator{}
+var _ hotstuff.WeightedSignatureAggregator = (*WeightedSignatureAggregator)(nil)
 
 // NewWeightedSignatureAggregator returns a weighted aggregator initialized with a list of flow
 // identities, their respective public keys, a message and a domain separation tag. The identities

--- a/consensus/hotstuff/voteaggregator/vote_aggregator_v2.go
+++ b/consensus/hotstuff/voteaggregator/vote_aggregator_v2.go
@@ -36,9 +36,9 @@ type VoteAggregatorV2 struct {
 	queuedVotes         *fifoqueue.FifoQueue
 }
 
-var _ hotstuff.VoteAggregatorV2 = &VoteAggregatorV2{}
-var _ module.ReadyDoneAware = &VoteAggregatorV2{}
-var _ module.Startable = &VoteAggregatorV2{}
+var _ hotstuff.VoteAggregatorV2 = (*VoteAggregatorV2)(nil)
+var _ module.ReadyDoneAware = (*VoteAggregatorV2)(nil)
+var _ module.Startable = (*VoteAggregatorV2)(nil)
 
 // NewVoteAggregatorV2 creates an instance of vote aggregator
 // Note: verifyingProcessorFactory is injected. Thereby, the code is agnostic to the

--- a/consensus/hotstuff/voteaggregator/vote_collectors.go
+++ b/consensus/hotstuff/voteaggregator/vote_collectors.go
@@ -22,7 +22,7 @@ type VoteCollectors struct {
 	createCollector NewCollectorFactoryMethod         // factory method for creating collectors
 }
 
-var _ hotstuff.VoteCollectors = &VoteCollectors{}
+var _ hotstuff.VoteCollectors = (*VoteCollectors)(nil)
 
 func NewVoteCollectors(lowestView uint64, factoryMethod NewCollectorFactoryMethod) *VoteCollectors {
 	return &VoteCollectors{

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
@@ -113,7 +113,7 @@ type CombinedVoteProcessorV2 struct {
 	done             atomic.Bool
 }
 
-var _ hotstuff.VoteProcessor = &CombinedVoteProcessorV2{}
+var _ hotstuff.VoteProcessor = (*CombinedVoteProcessorV2)(nil)
 
 // Block returns block that is part of proposal that we are processing votes for.
 func (p *CombinedVoteProcessorV2) Block() *model.Block {

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
@@ -122,7 +122,7 @@ type CombinedVoteProcessorV3 struct {
 	done             atomic.Bool
 }
 
-var _ hotstuff.VoteProcessor = &CombinedVoteProcessorV3{}
+var _ hotstuff.VoteProcessor = (*CombinedVoteProcessorV3)(nil)
 
 // Block returns block that is part of proposal that we are processing votes for.
 func (p *CombinedVoteProcessorV3) Block() *model.Block {

--- a/consensus/hotstuff/votecollector/factory.go
+++ b/consensus/hotstuff/votecollector/factory.go
@@ -34,7 +34,7 @@ type VoteProcessorFactory struct {
 	baseFactory baseFactory
 }
 
-var _ hotstuff.VoteProcessorFactory = &VoteProcessorFactory{}
+var _ hotstuff.VoteProcessorFactory = (*VoteProcessorFactory)(nil)
 
 // Create instantiates a VerifyingVoteProcessor for the given block proposal.
 // A VerifyingVoteProcessor are only created for proposals with valid proposer votes.

--- a/consensus/hotstuff/votecollector/statemachine.go
+++ b/consensus/hotstuff/votecollector/statemachine.go
@@ -32,7 +32,7 @@ type VoteCollector struct {
 	votesProcessor atomic.Value
 }
 
-var _ hotstuff.VoteCollector = &VoteCollector{}
+var _ hotstuff.VoteCollector = (*VoteCollector)(nil)
 
 func (m *VoteCollector) atomicLoadProcessor() hotstuff.VoteProcessor {
 	return m.votesProcessor.Load().(*atomicValueWrapper).processor


### PR DESCRIPTION
batch update from:
```
var _ YYY = &XXX{}
```
to
```
var _ YYY = (*XXX)(nil)
```

in order to verify the implementation of interface without allocating memory