### PR TITLE
update AN builders and scaffold to use spork id for mw

### DIFF
--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -242,7 +242,7 @@ func (builder *StakedAccessNodeBuilder) initMiddleware(nodeID flow.Identifier,
 		factoryFunc,
 		nodeID,
 		networkMetrics,
-		builder.RootBlock.ID(),
+		builder.SporkID,
 		p2p.DefaultUnicastTimeout,
 		false, // no connection gating to allow unstaked nodes to connect
 		builder.IDTranslator,

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -337,7 +337,7 @@ func (anb *UnstakedAccessNodeBuilder) initMiddleware(nodeID flow.Identifier,
 		factoryFunc,
 		nodeID,
 		networkMetrics,
-		anb.RootBlock.ID(),
+		anb.SporkID,
 		p2p.DefaultUnicastTimeout,
 		false, // no connection gating for the unstaked nodes
 		anb.IDTranslator,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -222,7 +222,7 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit() {
 			libP2PNodeFactory,
 			fnb.Me.NodeID(),
 			fnb.Metrics.Network,
-			fnb.RootBlock.ID(),
+			fnb.SporkID,
 			fnb.BaseConfig.UnicastMessageTimeout,
 			true,
 			fnb.IDTranslator,


### PR DESCRIPTION
This PR updates the usages of [p2p.NewMiddleware](https://github.com/onflow/flow-go/blob/923546c75a80e6078283d8adf6ef78dbb03b651a/network/p2p/middleware.go#L114) to use SporkID() not RootBlockID