### PR TITLE
REST: Add improvements and tests to handlers

### DIFF
--- a/engine/access/rest/collections.go
+++ b/engine/access/rest/collections.go
@@ -15,5 +15,5 @@ func getCollectionByID(r *requestDecorator, backend access.API, link LinkGenerat
 		return nil, err
 	}
 
-	return collectionResponse(collection), nil
+	return collectionResponse(collection, link), nil
 }

--- a/engine/access/rest/collections_test.go
+++ b/engine/access/rest/collections_test.go
@@ -56,7 +56,13 @@ func TestGetCollections(t *testing.T) {
 			rr := executeRequest(req, backend)
 
 			bx, _ := json.Marshal(col.Transactions)
-			expected := fmt.Sprintf(`{"id":"%s","transactions":%s}`, col.ID().String(), bx) // todo missing link
+			expected := fmt.Sprintf(`{
+				"id":"%s",
+				"transactions":%s, 	
+				"_links": {
+					"_self": "/v1/collections/%s"
+				}
+			}`, col.ID().String(), bx, col.ID())
 
 			assert.Equal(t, http.StatusOK, rr.Code)
 			assert.JSONEq(t, expected, rr.Body.String())

--- a/engine/access/rest/converter.go
+++ b/engine/access/rest/converter.go
@@ -364,12 +364,10 @@ func transactionResponse(tx *flow.TransactionBody, txr *access.TransactionResult
 	}
 	// todo(sideninja) discuss if we still need this expandable
 	if !expands[expandable.PayloadSignatures] {
-		fmt.Println("###1")
 		txResponse.PayloadSignatures = nil
 	}
 	// todo(sideninja) discuss if we still need this expandable
 	if !expands[expandable.EnvelopeSignatures] {
-		fmt.Println("###2")
 		txResponse.EnvelopeSignatures = nil
 	}
 

--- a/engine/access/rest/converter.go
+++ b/engine/access/rest/converter.go
@@ -510,11 +510,13 @@ func idsResponse(ids []flow.Identifier) []string {
 	return res
 }
 
-func collectionResponse(flowCollection *flow.LightCollection) generated.Collection {
+func collectionResponse(flowCollection *flow.LightCollection, link LinkGenerator) generated.Collection {
+	self, _ := selfLink(flowCollection.ID(), link.CollectionLink)
+
 	return generated.Collection{
 		Id:           flowCollection.ID().String(),
 		Transactions: idsResponse(flowCollection.Transactions),
-		Links:        nil,
+		Links:        self,
 	}
 }
 

--- a/engine/access/rest/converter.go
+++ b/engine/access/rest/converter.go
@@ -311,7 +311,7 @@ func transactionSignatureResponse(signatures []flow.TransactionSignature) []gene
 	return sigs
 }
 
-func transactionResponse(tx *flow.TransactionBody, link LinkGenerator) *generated.Transaction {
+func transactionResponse(tx *flow.TransactionBody, txr *access.TransactionResult, link LinkGenerator) *generated.Transaction {
 	var args []string
 	for _, arg := range tx.Arguments {
 		args = append(args, toBase64(arg))
@@ -325,6 +325,11 @@ func transactionResponse(tx *flow.TransactionBody, link LinkGenerator) *generate
 	resultLink, _ := link.TransactionResultLink(tx.ID())
 	self, _ := selfLink(tx.ID(), link.TransactionLink)
 
+	var result *generated.TransactionResult
+	if txr != nil {
+		result = transactionResultResponse(txr, tx.ID(), link)
+	}
+
 	return &generated.Transaction{
 		Id:                 tx.ID().String(),
 		Script:             toBase64(tx.Script),
@@ -336,7 +341,7 @@ func transactionResponse(tx *flow.TransactionBody, link LinkGenerator) *generate
 		Authorizers:        auths,
 		PayloadSignatures:  transactionSignatureResponse(tx.PayloadSignatures),
 		EnvelopeSignatures: transactionSignatureResponse(tx.EnvelopeSignatures),
-		Result:             nil, // todo(sideninja) should we provide result, maybe have a wait for result http long pulling system would be super helpful (with reasonable timeout) but careful about resources and dos
+		Result:             result,
 		Links:              self,
 		Expandable: &generated.TransactionExpandable{
 			ProposalKey:        "proposal_key",

--- a/engine/access/rest/converter_test.go
+++ b/engine/access/rest/converter_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/onflow/flow-go/access/mock"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func linkFixture() LinkGenerator {

--- a/engine/access/rest/converter_test.go
+++ b/engine/access/rest/converter_test.go
@@ -42,42 +42,32 @@ func TestTransactions(t *testing.T) {
 		   "reference_block_id":"%s",
 		   "gas_limit":10,
 		   "payer":"8c5303eaa26202d6",
+           "authorizers":[
+				  "8c5303eaa26202d6"
+			   ],
+           "proposal_key":{
+               "address":"8c5303eaa26202d6",
+               "key_index":1,
+               "sequence_number":0
+            },
+           "envelope_signatures":[
+               {
+                  "address":"8c5303eaa26202d6",
+                  "signer_index":0,
+                  "key_index":1,
+                  "signature":"%s"
+				  }
+            ],
+           "payload_signatures":[],
 		   "_expandable":{
-			  "proposal_key":"proposal_key",
-			  "authorizers":"authorizers",
-			  "payload_signatures":"payload_signatures",
-			  "envelope_signatures":"envelope_signatures",
 			  "result":"/v1/transaction_results/%s"
 		   },
 		   "_links":{
 			  "_self":"/v1/transactions/%s"
 		   }
-		}`, tx.ID().String(), tx.ReferenceBlockID.String(), tx.ID().String(), tx.ID().String())
+		}`, tx.ID().String(), tx.ReferenceBlockID.String(), toBase64(tx.EnvelopeSignatures[0].Signature), tx.ID().String(), tx.ID().String())
 
 		assert.JSONEq(t, expected, string(res))
-	})
-
-	t.Run("response expands", func(t *testing.T) {
-		tx := unittest.TransactionFixture()
-		tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()} // add payload to fixture
-
-		tests := []map[string]bool{
-			{"proposal_key": true},
-			{"authorizers": true},
-			{"envelope_signatures": true},
-			{"payload_signatures": true},
-		}
-
-		for _, test := range tests {
-			response := responseToMap(
-				transactionResponse(&tx.TransactionBody, nil, linkFixture(), test),
-			)
-
-			for expand := range test {
-				assert.NotNilf(t, response[expand], fmt.Sprintf("shouldn't be nil: %s", expand))
-			}
-		}
-
 	})
 
 	t.Run("response with result", func(t *testing.T) {

--- a/engine/access/rest/converter_test.go
+++ b/engine/access/rest/converter_test.go
@@ -52,4 +52,16 @@ func TestTransactions(t *testing.T) {
 
 	})
 
+	t.Run("transaction response with result", func(t *testing.T) {
+		tx := unittest.TransactionFixture()
+		txr := transactionResultFixture(tx)
+		tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()} // add payload to fixture
+
+		response := responseToMap(
+			transactionResponse(&tx.TransactionBody, txr, linkFixture(), map[string]bool{"result": true}),
+		)
+
+		assert.NotNilf(t, response["result"], "result shouldn't be nil")
+	})
+
 }

--- a/engine/access/rest/converter_test.go
+++ b/engine/access/rest/converter_test.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/onflow/flow-go/access/mock"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
 )
 
 func linkFixture() LinkGenerator {
@@ -53,7 +54,7 @@ func TestTransactions(t *testing.T) {
 		   }
 		}`, tx.ID().String(), tx.ReferenceBlockID.String(), tx.ID().String(), tx.ID().String())
 
-		assert.JSONEq(t, expected, fmt.Sprintf("%s", res))
+		assert.JSONEq(t, expected, string(res))
 	})
 
 	t.Run("response expands", func(t *testing.T) {

--- a/engine/access/rest/converter_test.go
+++ b/engine/access/rest/converter_test.go
@@ -29,7 +29,34 @@ func responseToMap(response interface{}) map[string]interface{} {
 
 func TestTransactions(t *testing.T) {
 
-	t.Run("transaction response", func(t *testing.T) {
+	t.Run("response", func(t *testing.T) {
+		tx := unittest.TransactionFixture()
+		response := transactionResponse(&tx.TransactionBody, nil, linkFixture(), nil)
+
+		res, _ := json.Marshal(response)
+		expected := fmt.Sprintf(`{
+		   "id":"%s",
+		   "script":"cHViIGZ1biBtYWluKCkge30=",
+		   "arguments":null,
+		   "reference_block_id":"%s",
+		   "gas_limit":10,
+		   "payer":"8c5303eaa26202d6",
+		   "_expandable":{
+			  "proposal_key":"proposal_key",
+			  "authorizers":"authorizers",
+			  "payload_signatures":"payload_signatures",
+			  "envelope_signatures":"envelope_signatures",
+			  "result":"/v1/transaction_results/%s"
+		   },
+		   "_links":{
+			  "_self":"/v1/transactions/%s"
+		   }
+		}`, tx.ID().String(), tx.ReferenceBlockID.String(), tx.ID().String(), tx.ID().String())
+
+		assert.JSONEq(t, expected, fmt.Sprintf("%s", res))
+	})
+
+	t.Run("response expands", func(t *testing.T) {
 		tx := unittest.TransactionFixture()
 		tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()} // add payload to fixture
 
@@ -52,7 +79,7 @@ func TestTransactions(t *testing.T) {
 
 	})
 
-	t.Run("transaction response with result", func(t *testing.T) {
+	t.Run("response with result", func(t *testing.T) {
 		tx := unittest.TransactionFixture()
 		txr := transactionResultFixture(tx)
 		tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()} // add payload to fixture

--- a/engine/access/rest/converter_test.go
+++ b/engine/access/rest/converter_test.go
@@ -1,0 +1,54 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/onflow/flow-go/access/mock"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func linkFixture() LinkGenerator {
+	backend := &mock.API{}
+	var log []byte
+	r := initRouter(backend, zerolog.New(bytes.NewBuffer(log)))
+	return NewLinkGeneratorImpl(r)
+}
+
+func responseToMap(response interface{}) map[string]interface{} {
+	j, _ := json.Marshal(response)
+	var res map[string]interface{}
+	_ = json.Unmarshal(j, &res)
+	return res
+}
+
+func TestTransactions(t *testing.T) {
+
+	t.Run("transaction response", func(t *testing.T) {
+		tx := unittest.TransactionFixture()
+		tx.PayloadSignatures = []flow.TransactionSignature{unittest.TransactionSignatureFixture()} // add payload to fixture
+
+		tests := []map[string]bool{
+			{"proposal_key": true},
+			{"authorizers": true},
+			{"envelope_signatures": true},
+			{"payload_signatures": true},
+		}
+
+		for _, test := range tests {
+			response := responseToMap(
+				transactionResponse(&tx.TransactionBody, nil, linkFixture(), test),
+			)
+
+			for expand := range test {
+				assert.NotNilf(t, response[expand], fmt.Sprintf("shouldn't be nil: %s", expand))
+			}
+		}
+
+	})
+
+}

--- a/engine/access/rest/generated/model_collection.go
+++ b/engine/access/rest/generated/model_collection.go
@@ -11,7 +11,7 @@ package generated
 type Collection struct {
 	Id string `json:"id"`
 
-	Transactions []string `json:"transactions"`
+	Transactions []Transaction `json:"transactions"`
 
 	Links *Links `json:"_links,omitempty"`
 }

--- a/engine/access/rest/generated/model_transaction.go
+++ b/engine/access/rest/generated/model_transaction.go
@@ -21,13 +21,13 @@ type Transaction struct {
 
 	Payer string `json:"payer"`
 
-	ProposalKey *ProposalKey `json:"proposal_key,omitempty"`
+	ProposalKey *ProposalKey `json:"proposal_key"`
 
-	Authorizers []string `json:"authorizers,omitempty"`
+	Authorizers []string `json:"authorizers"`
 
-	PayloadSignatures []TransactionSignature `json:"payload_signatures,omitempty"`
+	PayloadSignatures []TransactionSignature `json:"payload_signatures"`
 
-	EnvelopeSignatures []TransactionSignature `json:"envelope_signatures,omitempty"`
+	EnvelopeSignatures []TransactionSignature `json:"envelope_signatures"`
 
 	Result *TransactionResult `json:"result,omitempty"`
 

--- a/engine/access/rest/generated/model_transaction__expandable.go
+++ b/engine/access/rest/generated/model_transaction__expandable.go
@@ -9,13 +9,5 @@
 package generated
 
 type TransactionExpandable struct {
-	ProposalKey string `json:"proposal_key,omitempty"`
-
-	Authorizers string `json:"authorizers,omitempty"`
-
-	PayloadSignatures string `json:"payload_signatures,omitempty"`
-
-	EnvelopeSignatures string `json:"envelope_signatures,omitempty"`
-
 	Result string `json:"result,omitempty"`
 }

--- a/engine/access/rest/generated/model_transaction_result.go
+++ b/engine/access/rest/generated/model_transaction_result.go
@@ -17,9 +17,7 @@ type TransactionResult struct {
 
 	ComputationUsed int32 `json:"computation_used"`
 
-	Events []Event `json:"events,omitempty"`
-
-	Expandable *TransactionResultExpandable `json:"_expandable,omitempty"`
+	Events []Event `json:"events"`
 
 	Links *Links `json:"_links,omitempty"`
 }

--- a/engine/access/rest/link_generator.go
+++ b/engine/access/rest/link_generator.go
@@ -48,7 +48,7 @@ func (generator *LinkGeneratorImpl) TransactionResultLink(id flow.Identifier) (s
 }
 
 func (generator *LinkGeneratorImpl) CollectionLink(id flow.Identifier) (string, error) {
-	return generator.link(getCollectionByIDRoute, id)
+	return generator.linkForID(getCollectionByIDRoute, id)
 }
 
 func (generator *LinkGeneratorImpl) AccountLink(address string) (string, error) {

--- a/engine/access/rest/link_generator.go
+++ b/engine/access/rest/link_generator.go
@@ -15,6 +15,7 @@ type LinkGenerator interface {
 	TransactionResultLink(id flow.Identifier) (string, error)
 	PayloadLink(id flow.Identifier) (string, error)
 	ExecutionResultLink(id flow.Identifier) (string, error)
+	CollectionLink(id flow.Identifier) (string, error)
 }
 
 type LinkGeneratorImpl struct {
@@ -43,6 +44,10 @@ func (generator *LinkGeneratorImpl) TransactionLink(id flow.Identifier) (string,
 
 func (generator *LinkGeneratorImpl) TransactionResultLink(id flow.Identifier) (string, error) {
 	return generator.link(getTransactionResultByIDRoute, id)
+}
+
+func (generator *LinkGeneratorImpl) CollectionLink(id flow.Identifier) (string, error) {
+	return generator.link(getCollectionByIDRoute, id)
 }
 
 func selfLink(id flow.Identifier, linkFun LinkFun) (*generated.Links, error) {

--- a/engine/access/rest/scripts.go
+++ b/engine/access/rest/scripts.go
@@ -11,9 +11,11 @@ func executeScript(r *requestDecorator, backend access.API, _ LinkGenerator) (in
 	blockID := r.getQueryParam("block_id")
 	blockHeight := r.getQueryParam("block_height")
 
+	if blockID == "" && blockHeight == "" {
+		return nil, NewBadRequestError(fmt.Errorf("either block ID or block height must be provided"))
+	}
 	if blockID != "" && blockHeight != "" {
-		err := fmt.Errorf("can not provide both block ID and block height")
-		return nil, NewBadRequestError(err)
+		return nil, NewBadRequestError(fmt.Errorf("can not provide both block ID and block height"))
 	}
 
 	var scriptBody generated.ScriptsBody
@@ -32,37 +34,6 @@ func executeScript(r *requestDecorator, backend access.API, _ LinkGenerator) (in
 		return nil, NewBadRequestError(err)
 	}
 
-	if blockHeight == "latest" || blockHeight == "sealed" {
-		result, err := backend.ExecuteScriptAtLatestBlock(r.Context(), code, args)
-		if err != nil {
-			return nil, err
-		}
-		return result, nil
-	}
-
-	if blockHeight == "final" {
-		finalBlock, err := backend.GetLatestBlockHeader(r.Context(), false)
-		if err != nil {
-			return nil, err
-		}
-		blockHeight = fmt.Sprintf("%d", finalBlock.Height)
-	}
-
-	if blockHeight != "" {
-		height, err := toHeight(blockHeight)
-		if err != nil {
-			return nil, NewBadRequestError(err)
-		}
-
-		result, err := backend.ExecuteScriptAtBlockHeight(r.Context(), height, code, args)
-		fmt.Println(err, result, "######")
-		if err != nil {
-			return nil, err
-		}
-
-		return result, nil
-	}
-
 	if blockID != "" {
 		id, err := toID(blockID)
 		if err != nil {
@@ -77,5 +48,32 @@ func executeScript(r *requestDecorator, backend access.API, _ LinkGenerator) (in
 		return result, nil
 	}
 
-	return nil, NewBadRequestError(fmt.Errorf("either block ID or block height must be provided"))
+	if blockHeight == sealedHeightQueryParam {
+		result, err := backend.ExecuteScriptAtLatestBlock(r.Context(), code, args)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	var height uint64
+	if blockHeight == finalHeightQueryParam {
+		finalBlock, err := backend.GetLatestBlockHeader(r.Context(), false)
+		if err != nil {
+			return nil, err
+		}
+		height = finalBlock.Height
+	} else {
+		height, err = toHeight(blockHeight)
+		if err != nil {
+			return nil, NewBadRequestError(err)
+		}
+	}
+
+	result, err := backend.ExecuteScriptAtBlockHeight(r.Context(), height, code, args)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/engine/access/rest/scripts.go
+++ b/engine/access/rest/scripts.go
@@ -55,6 +55,7 @@ func executeScript(r *requestDecorator, backend access.API, _ LinkGenerator) (in
 		}
 
 		result, err := backend.ExecuteScriptAtBlockHeight(r.Context(), height, code, args)
+		fmt.Println(err, result, "######")
 		if err != nil {
 			return nil, err
 		}

--- a/engine/access/rest/scripts_test.go
+++ b/engine/access/rest/scripts_test.go
@@ -44,7 +44,7 @@ func TestScripts(t *testing.T) {
 	})
 
 	t.Run("get by Latest height", func(t *testing.T) {
-		req, _ := http.NewRequest("POST", scriptsURL("", "latest"), bytes.NewBuffer(validBody))
+		req, _ := http.NewRequest("POST", scriptsURL("", sealedHeightQueryParam), bytes.NewBuffer(validBody))
 
 		backend.Mock.
 			On("ExecuteScriptAtLatestBlock", mocks.Anything, validCode, [][]byte{validArgs}).

--- a/engine/access/rest/transactions.go
+++ b/engine/access/rest/transactions.go
@@ -5,6 +5,8 @@ import (
 	"github.com/onflow/flow-go/engine/access/rest/generated"
 )
 
+const transactionResult = "result"
+
 // getTransactionByID gets a transaction by requested ID.
 func getTransactionByID(r *requestDecorator, backend access.API, link LinkGenerator) (interface{}, error) {
 	id, err := r.id()
@@ -17,7 +19,16 @@ func getTransactionByID(r *requestDecorator, backend access.API, link LinkGenera
 		return nil, err
 	}
 
-	return transactionResponse(tx, link), nil
+	if r.expands(transactionResult) {
+		txr, err := backend.GetTransactionResult(r.Context(), id)
+		if err != nil {
+			return nil, err
+		}
+
+		return transactionResponse(tx, txr, link), nil
+	}
+
+	return transactionResponse(tx, nil, link), nil
 }
 
 func getTransactionResultByID(r *requestDecorator, backend access.API, link LinkGenerator) (interface{}, error) {
@@ -52,5 +63,5 @@ func createTransaction(r *requestDecorator, backend access.API, link LinkGenerat
 		return nil, err
 	}
 
-	return transactionResponse(&tx, link), nil
+	return transactionResponse(&tx, nil, link), nil
 }

--- a/engine/access/rest/transactions.go
+++ b/engine/access/rest/transactions.go
@@ -25,10 +25,10 @@ func getTransactionByID(r *requestDecorator, backend access.API, link LinkGenera
 			return nil, err
 		}
 
-		return transactionResponse(tx, txr, link), nil
+		return transactionResponse(tx, txr, link, r.expandFields), nil
 	}
 
-	return transactionResponse(tx, nil, link), nil
+	return transactionResponse(tx, nil, link, r.expandFields), nil
 }
 
 func getTransactionResultByID(r *requestDecorator, backend access.API, link LinkGenerator) (interface{}, error) {
@@ -63,5 +63,5 @@ func createTransaction(r *requestDecorator, backend access.API, link LinkGenerat
 		return nil, err
 	}
 
-	return transactionResponse(&tx, nil, link), nil
+	return transactionResponse(&tx, nil, link, r.expandFields), nil
 }

--- a/engine/access/rest/transactions.go
+++ b/engine/access/rest/transactions.go
@@ -19,16 +19,16 @@ func getTransactionByID(r *requestDecorator, backend access.API, link LinkGenera
 		return nil, err
 	}
 
+	var txr *access.TransactionResult
+	// only lookup result if transaction result is to be expanded
 	if r.expands(transactionResult) {
-		txr, err := backend.GetTransactionResult(r.Context(), id)
+		txr, err = backend.GetTransactionResult(r.Context(), id)
 		if err != nil {
 			return nil, err
 		}
-
-		return transactionResponse(tx, txr, link, r.expandFields), nil
 	}
 
-	return transactionResponse(tx, nil, link, r.expandFields), nil
+	return transactionResponse(tx, txr, link, r.expandFields), nil
 }
 
 func getTransactionResultByID(r *requestDecorator, backend access.API, link LinkGenerator) (interface{}, error) {

--- a/engine/access/rest/transactions_test.go
+++ b/engine/access/rest/transactions_test.go
@@ -130,7 +130,6 @@ func TestGetTransactionResult(t *testing.T) {
 			Return(txr, nil)
 
 		rr := executeRequest(req, backend)
-
 		expected := fmt.Sprintf(`{
 			"block_id": "%s",
 			"status": "Executed",
@@ -145,6 +144,9 @@ func TestGetTransactionResult(t *testing.T) {
 					"payload": ""
 				}
 			],
+			"_expandable": {
+				"events": "events"
+			},
 			"_links": {
 				"_self": "/v1/transaction_results/%s"
 			}
@@ -159,7 +161,7 @@ func TestGetTransactionResult(t *testing.T) {
 		rr := executeRequest(req, backend)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
-		assert.JSONEq(t, `{"code":400, "message":"invalid ID"}`, rr.Body.String())
+		assert.JSONEq(t, `{"code":400, "message":"invalid ID format"}`, rr.Body.String())
 	})
 }
 
@@ -227,6 +229,13 @@ func TestCreateTransaction(t *testing.T) {
 					 "signature":"%s"
 				  }
 			   ],
+				"_expandable": {
+					"proposal_key": "proposal_key",
+					"authorizers": "authorizers",
+					"payload_signatures": "payload_signatures",
+					"envelope_signatures": "envelope_signatures",
+					"result": "/v1/transaction_results/%s"
+				},
 			   "_links":{
 				  "_self":"%s"
 			   }
@@ -234,6 +243,7 @@ func TestCreateTransaction(t *testing.T) {
 			tx.ID().String(),
 			tx.ReferenceBlockID.String(),
 			toBase64(tx.EnvelopeSignatures[0].Signature),
+			tx.ID().String(),
 			transactionURL(tx.ID().String()),
 		)
 
@@ -249,13 +259,13 @@ func TestCreateTransaction(t *testing.T) {
 		}{
 			{"reference_block_id", "-1", `{"code":400, "message":"invalid ID format"}`},
 			{"reference_block_id", "", `{"code":400, "message":"reference block not provided"}`},
-			{"gas_limit", "-1", `{"code":400, "message":"Request body contains an invalid value for the \"gas_limit\" field (at position 256)"}`},
+			{"gas_limit", "-1", `{"code":400, "message":"request body contains an invalid value for the \"gas_limit\" field (at position 256)"}`},
 			{"payer", "yo", `{"code":400, "message":"invalid address"}`},
-			{"proposal_key", "yo", `{"code":400, "message":"Request body contains an invalid value for the \"proposal_key\" field (at position 301)"}`},
-			{"authorizers", "", `{"code":400, "message":"Request body contains an invalid value for the \"authorizers\" field (at position 32)"}`},
-			{"authorizers", "yo", `{"code":400, "message":"Request body contains an invalid value for the \"authorizers\" field (at position 34)"}`},
-			{"envelope_signatures", "", `{"code":400, "message":"Request body contains an invalid value for the \"envelope_signatures\" field (at position 75)"}`},
-			{"payload_signatures", "", `{"code":400, "message":"Request body contains an invalid value for the \"payload_signatures\" field (at position 305)"}`},
+			{"proposal_key", "yo", `{"code":400, "message":"request body contains an invalid value for the \"proposal_key\" field (at position 301)"}`},
+			{"authorizers", "", `{"code":400, "message":"request body contains an invalid value for the \"authorizers\" field (at position 32)"}`},
+			{"authorizers", "yo", `{"code":400, "message":"request body contains an invalid value for the \"authorizers\" field (at position 34)"}`},
+			{"envelope_signatures", "", `{"code":400, "message":"request body contains an invalid value for the \"envelope_signatures\" field (at position 75)"}`},
+			{"payload_signatures", "", `{"code":400, "message":"request body contains an invalid value for the \"payload_signatures\" field (at position 305)"}`},
 		}
 
 		for i, test := range tests {

--- a/engine/access/rest/transactions_test.go
+++ b/engine/access/rest/transactions_test.go
@@ -73,12 +73,20 @@ func TestGetTransactions(t *testing.T) {
 			   ],
 			   "_links":{
 				  "_self":"%s"
-			   }
+			   },
+				"_expandable": {
+					"proposal_key": "proposal_key",
+					"authorizers": "authorizers",
+					"payload_signatures": "payload_signatures",
+					"envelope_signatures": "envelope_signatures",
+					"result": "/v1/transaction_results/%s"
+				}
 			}`,
 			tx.ID().String(),
 			tx.ReferenceBlockID.String(),
 			toBase64(tx.EnvelopeSignatures[0].Signature),
 			transactionURL(tx.ID().String()),
+			tx.ID().String(),
 		)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
@@ -90,7 +98,7 @@ func TestGetTransactions(t *testing.T) {
 		rr := executeRequest(req, backend)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
-		assert.JSONEq(t, `{"code":400, "message":"invalid ID"}`, rr.Body.String())
+		assert.JSONEq(t, `{"code":400, "message":"invalid ID format"}`, rr.Body.String())
 	})
 
 	t.Run("get by ID Non-existing", func(t *testing.T) {

--- a/engine/access/rest/transactions_test.go
+++ b/engine/access/rest/transactions_test.go
@@ -233,9 +233,6 @@ func TestGetTransactionResult(t *testing.T) {
 					"payload": ""
 				}
 			],
-			"_expandable": {
-				"events": "events"
-			},
 			"_links": {
 				"_self": "/v1/transaction_results/%s"
 			}
@@ -318,11 +315,8 @@ func TestCreateTransaction(t *testing.T) {
 					 "signature":"%s"
 				  }
 			   ],
+                "payload_signatures":[],
 				"_expandable": {
-					"proposal_key": "proposal_key",
-					"authorizers": "authorizers",
-					"payload_signatures": "payload_signatures",
-					"envelope_signatures": "envelope_signatures",
 					"result": "/v1/transaction_results/%s"
 				},
 			   "_links":{

--- a/go.sum
+++ b/go.sum
@@ -1127,8 +1127,6 @@ github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFc
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1 h1:SwUuFzIz9sepzbE3yOfjhifKRCxwTnCr+Kdh4BmXoiY=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/flow v0.2.3-0.20211124175618-139cd856b0ee h1:a0UJfmkK/JTPAZbqAz51HToyxjxu1o4Ubv75I24tS5Y=
-github.com/onflow/flow v0.2.3-0.20211124175618-139cd856b0ee/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow v0.2.3-0.20211126025920-28e602de8f8b h1:+FL4IQLLIVGbhpQupbNlTZQu4sz7+EYaX0t+MeIBgnM=
 github.com/onflow/flow v0.2.3-0.20211126025920-28e602de8f8b/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=


### PR DESCRIPTION
This PR implements handlers for expand fields and adding more tests. Converter tests were added with implementing expendables and links as part of that functionality which allows us to test different combinations of response generation without handlers.