### PR TITLE
Adding a block height threshold to re-request missing collections 

### DIFF
--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -35,10 +35,14 @@ const fullBlockUpdateInterval = 1 * time.Minute
 // a threshold of number of blocks with missing collections beyond which collections should be re-requested
 const missingCollsForBlkThreshold = 100
 
+// a threshold of block height beyond which collections should be re-requested
+const missingCollsForHeightThreshold = 100
+
 var defaultCollectionCatchupTimeout = collectionCatchupTimeout
 var defaultCollectionCatchupDBPollInterval = collectionCatchupDBPollInterval
 var defaultFullBlockUpdateInterval = fullBlockUpdateInterval
 var defaultMissingCollsForBlkThreshold = missingCollsForBlkThreshold
+var defaultMissingCollsForHeightThreshold = missingCollsForHeightThreshold
 
 // Engine represents the ingestion engine, used to funnel data from other nodes
 // to a centralized location that can be queried by a user
@@ -569,8 +573,8 @@ func (e *Engine) updateLastFullBlockReceivedIndex() {
 		}
 	}
 
-	// additionally, if more than threshold blocks have missing collection, re-request those collections
-	if incompleteBlksCnt >= defaultMissingCollsForBlkThreshold {
+	// additionally, if more than threshold blocks have missing collection OR collections are missing since defaultMissingCollsForHeightThreshold, re-request those collections
+	if incompleteBlksCnt >= defaultMissingCollsForBlkThreshold  || (finalizedHeight - lastFullHeight) > uint64(defaultMissingCollsForHeightThreshold) {
 		// warn log since this should generally not happen
 		e.log.Warn().
 			Int("missing_collection_blk_count", incompleteBlksCnt).

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -38,13 +38,13 @@ const missingCollsForBlkThreshold = 100
 
 // a threshold of block height beyond which collections should be re-requested (regardless of the number of blocks for which collection are missing)
 // this is to ensure that if a collection is missing for a long time (in terms of block height) it is eventually re-requested
-const missingCollsForHeightThreshold = 100
+const missingCollsForAgeThreshold = 100
 
 var defaultCollectionCatchupTimeout = collectionCatchupTimeout
 var defaultCollectionCatchupDBPollInterval = collectionCatchupDBPollInterval
 var defaultFullBlockUpdateInterval = fullBlockUpdateInterval
 var defaultMissingCollsForBlkThreshold = missingCollsForBlkThreshold
-var defaultMissingCollsForHeightThreshold = missingCollsForHeightThreshold
+var defaultMissingCollsForAgeThreshold = missingCollsForAgeThreshold
 
 // Engine represents the ingestion engine, used to funnel data from other nodes
 // to a centralized location that can be queried by a user
@@ -575,8 +575,8 @@ func (e *Engine) updateLastFullBlockReceivedIndex() {
 		}
 	}
 
-	// additionally, if more than threshold blocks have missing collection OR collections are missing since defaultMissingCollsForHeightThreshold, re-request those collections
-	if incompleteBlksCnt >= defaultMissingCollsForBlkThreshold || (finalizedHeight-lastFullHeight) > uint64(defaultMissingCollsForHeightThreshold) {
+	// additionally, if more than threshold blocks have missing collection OR collections are missing since defaultMissingCollsForAgeThreshold, re-request those collections
+	if incompleteBlksCnt >= defaultMissingCollsForBlkThreshold || (finalizedHeight-lastFullHeight) > uint64(defaultMissingCollsForAgeThreshold) {
 		// warn log since this should generally not happen
 		e.log.Warn().
 			Int("missing_collection_blk_count", incompleteBlksCnt).

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -33,9 +33,11 @@ const collectionCatchupDBPollInterval = 10 * time.Millisecond
 const fullBlockUpdateInterval = 1 * time.Minute
 
 // a threshold of number of blocks with missing collections beyond which collections should be re-requested
+// this is to prevent spamming the collection nodes with request
 const missingCollsForBlkThreshold = 100
 
-// a threshold of block height beyond which collections should be re-requested
+// a threshold of block height beyond which collections should be re-requested (regardless of the number of blocks for which collection are missing)
+// this is to ensure that if a collection is missing for a long time (in terms of block height) it is eventually re-requested
 const missingCollsForHeightThreshold = 100
 
 var defaultCollectionCatchupTimeout = collectionCatchupTimeout
@@ -574,7 +576,7 @@ func (e *Engine) updateLastFullBlockReceivedIndex() {
 	}
 
 	// additionally, if more than threshold blocks have missing collection OR collections are missing since defaultMissingCollsForHeightThreshold, re-request those collections
-	if incompleteBlksCnt >= defaultMissingCollsForBlkThreshold  || (finalizedHeight - lastFullHeight) > uint64(defaultMissingCollsForHeightThreshold) {
+	if incompleteBlksCnt >= defaultMissingCollsForBlkThreshold || (finalizedHeight-lastFullHeight) > uint64(defaultMissingCollsForHeightThreshold) {
 		// warn log since this should generally not happen
 		e.log.Warn().
 			Int("missing_collection_blk_count", incompleteBlksCnt).

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -550,10 +550,10 @@ func (suite *Suite) TestUpdateLastFullBlockReceivedIndex() {
 		lastFullBlockHeight = rootBlkHeight
 
 		// lower the height threshold to request missing collections
-		defaultMissingCollsForHeightThreshold = 2
+		defaultMissingCollsForHeightThreshold = 1
 
 		// raise the block threshold to ensure it does not trigger missing collection request
-		defaultMissingCollsForBlkThreshold = blkCnt + 100
+		defaultMissingCollsForBlkThreshold = blkCnt + 1
 
 		// mark all blocks beyond the root block as incomplete
 		for i := 1; i < blkCnt; i++ {
@@ -578,7 +578,8 @@ func (suite *Suite) TestUpdateLastFullBlockReceivedIndex() {
 		rtnErr = nil
 		lastFullBlockHeight = rootBlkHeight
 
-		// raise the height threshold to avoid requesting missing collections
+		// raise the thresholds to avoid requesting missing collections
+		defaultMissingCollsForHeightThreshold = 3
 		defaultMissingCollsForBlkThreshold = 3
 
 		// mark all blocks beyond the root block as incomplete

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -544,13 +544,13 @@ func (suite *Suite) TestUpdateLastFullBlockReceivedIndex() {
 		suite.blocks.AssertExpectations(suite.T()) // no new call to UpdateLastFullBlockHeight should be made
 	})
 
-	suite.Run("missing collections are requested when count exceeds defaultMissingCollsForHeightThreshold", func() {
+	suite.Run("missing collections are requested when count exceeds defaultMissingCollsForAgeThreshold", func() {
 		// root block is the last complete block
 		rtnErr = nil
 		lastFullBlockHeight = rootBlkHeight
 
 		// lower the height threshold to request missing collections
-		defaultMissingCollsForHeightThreshold = 1
+		defaultMissingCollsForAgeThreshold = 1
 
 		// raise the block threshold to ensure it does not trigger missing collection request
 		defaultMissingCollsForBlkThreshold = blkCnt + 1
@@ -579,7 +579,7 @@ func (suite *Suite) TestUpdateLastFullBlockReceivedIndex() {
 		lastFullBlockHeight = rootBlkHeight
 
 		// raise the thresholds to avoid requesting missing collections
-		defaultMissingCollsForHeightThreshold = 3
+		defaultMissingCollsForAgeThreshold = 3
 		defaultMissingCollsForBlkThreshold = 3
 
 		// mark all blocks beyond the root block as incomplete

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -518,13 +518,42 @@ func (suite *Suite) TestUpdateLastFullBlockReceivedIndex() {
 		suite.blocks.AssertExpectations(suite.T()) // not new call to UpdateLastFullBlockHeight should be made
 	})
 
-	suite.Run("missing collections are requested", func() {
+	suite.Run("missing collections are requested when count exceeds defaultMissingCollsForBlkThreshold", func() {
+		// root block is the last complete block
+		rtnErr = nil
+		lastFullBlockHeight = rootBlkHeight
+
+		// lower the block threshold to request missing collections
+		defaultMissingCollsForBlkThreshold = 2
+
+		// mark all blocks beyond the root block as incomplete
+		for i := 1; i < blkCnt; i++ {
+			blkMissingColl[i] = true
+			// setup receive engine expectations
+			for _, cg := range blocks[i].Payload.Guarantees {
+				suite.request.On("EntityByID", cg.CollectionID, mock.Anything).Return().Once()
+			}
+		}
+
+		suite.eng.updateLastFullBlockReceivedIndex()
+
+		// assert that missing collections are requested
+		suite.request.AssertExpectations(suite.T())
+
+		// last full blk index is not advanced
+		suite.blocks.AssertExpectations(suite.T()) // no new call to UpdateLastFullBlockHeight should be made
+	})
+
+	suite.Run("missing collections are requested when count exceeds defaultMissingCollsForHeightThreshold", func() {
 		// root block is the last complete block
 		rtnErr = nil
 		lastFullBlockHeight = rootBlkHeight
 
 		// lower the height threshold to request missing collections
-		defaultMissingCollsForBlkThreshold = 2
+		defaultMissingCollsForHeightThreshold = 2
+
+		// raise the block threshold to ensure it does not trigger missing collection request
+		defaultMissingCollsForBlkThreshold = blkCnt + 100
 
 		// mark all blocks beyond the root block as incomplete
 		for i := 1; i < blkCnt; i++ {
@@ -543,7 +572,8 @@ func (suite *Suite) TestUpdateLastFullBlockReceivedIndex() {
 		// last full blk index is not advanced
 		suite.blocks.AssertExpectations(suite.T()) // not new call to UpdateLastFullBlockHeight should be made
 	})
-	suite.Run("missing collections are not requested if threshold not reached", func() {
+
+	suite.Run("missing collections are not requested if defaultMissingCollsForBlkThreshold not reached", func() {
 		// root block is the last complete block
 		rtnErr = nil
 		lastFullBlockHeight = rootBlkHeight


### PR DESCRIPTION
Fixes: https://github.com/onflow/flow-go/issues/1623