### PR TITLE
wip

### DIFF
--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -172,9 +172,14 @@ func (e *ReactorEngine) EpochCommittedPhaseStarted(currentEpochCounter uint64, f
 		return
 	}
 
-	dkgPrivInfo, err := e.keyStorage.RetrieveMyBeaconPrivateKey(currentEpochCounter + 1)
+	beaconPrivateKey, err := e.keyStorage.RetrieveMyBeaconPrivateKey(currentEpochCounter + 1)
 	if err != nil {
 		e.log.Err(err).Msg("checking DKG key consistency: could not retrieve DKG private info for next epoch")
+		return
+	}
+
+	if beaconPrivateKey == nil {
+		e.log.Warn().Msg("locally computed private key for next epoch is nil")
 		return
 	}
 
@@ -184,7 +189,7 @@ func (e *ReactorEngine) EpochCommittedPhaseStarted(currentEpochCounter uint64, f
 		return
 	}
 
-	localPubKey := dkgPrivInfo.PublicKey()
+	localPubKey := beaconPrivateKey.PublicKey()
 
 	if !nextDKGPubKey.Equals(localPubKey) {
 		e.log.Warn().Msg("checking DKG key consistency: locally computed dkg public key does not match dkg public key for next epoch")

--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -283,10 +283,16 @@ func (e *ReactorEngine) end(epochCounter uint64) func() error {
 
 		privateShare, _, _ := e.controller.GetArtifacts()
 
-		privKeyInfo := encodable.RandomBeaconPrivKey{
-			PrivateKey: privateShare,
+		var beaconPrivateKey encodable.RandomBeaconPrivKey
+		// if privateShare (DKG output) is nil, store nil in the key storage,
+		// otherwise, wrap it as a RandomBeaconPrivKey instance and store it in the key storage.
+		if privateShare != nil {
+			beaconPrivateKey = encodable.RandomBeaconPrivKey{
+				PrivateKey: privateShare,
+			}
 		}
-		err = e.keyStorage.InsertMyBeaconPrivateKey(epochCounter, &privKeyInfo)
+
+		err = e.keyStorage.InsertMyBeaconPrivateKey(epochCounter, &beaconPrivateKey)
 		if err != nil {
 			return fmt.Errorf("couldn't save DKG private key in db: %w", err)
 		}

--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -168,13 +168,13 @@ func (e *ReactorEngine) EpochSetupPhaseStarted(currentEpochCounter uint64, first
 func (e *ReactorEngine) EpochCommittedPhaseStarted(currentEpochCounter uint64, first *flow.Header) {
 	nextDKG, err := e.State.Final().Epochs().Next().DKG()
 	if err != nil {
-		e.log.Err(err).Msg("checking DKG key consistency: could not retrieve next DKG info")
+		e.log.Err(err).Msg("checking random beacon key consistency: could not retrieve next DKG info")
 		return
 	}
 
 	beaconPrivateKey, err := e.keyStorage.RetrieveMyBeaconPrivateKey(currentEpochCounter + 1)
 	if err != nil {
-		e.log.Err(err).Msg("checking DKG key consistency: could not retrieve DKG private info for next epoch")
+		e.log.Err(err).Msg("checking random beacon key consistency: could not retrieve beacon private key for next epoch")
 		return
 	}
 
@@ -183,16 +183,16 @@ func (e *ReactorEngine) EpochCommittedPhaseStarted(currentEpochCounter uint64, f
 		return
 	}
 
-	nextDKGPubKey, err := nextDKG.KeyShare(e.me.NodeID())
+	nextBeaconPubKey, err := nextDKG.KeyShare(e.me.NodeID())
 	if err != nil {
-		e.log.Err(err).Msg("checking DKG key consistency: could not retrieve DKG public key for next epoch")
+		e.log.Err(err).Msg("checking random beacon key consistency: could not retrieve beacon public key for next epoch")
 		return
 	}
 
 	localPubKey := beaconPrivateKey.PublicKey()
 
-	if !nextDKGPubKey.Equals(localPubKey) {
-		e.log.Warn().Msg("checking DKG key consistency: locally computed dkg public key does not match dkg public key for next epoch")
+	if !nextBeaconPubKey.Equals(localPubKey) {
+		e.log.Warn().Msg("checking random beacon key consistency: locally computed public key does not match public key for next epoch")
 	}
 }
 


### PR DESCRIPTION
In DKG fails locally, the output private key is `nil`. There are two issues with accessing `a nil` pointer in that case:
- [Checking key consistency](https://github.com/onflow/flow-go/blob/792ef25bb27d24cbc112459d35f1ebb31cd9d5d4/engine/consensus/dkg/reactor_engine.go#L187) by computing the public key.  
- `nil` is [wrapped](https://github.com/onflow/flow-go/blob/792ef25bb27d24cbc112459d35f1ebb31cd9d5d4/engine/consensus/dkg/reactor_engine.go#L287) and stored in the key stored, and used to later to sign as it's not caught by this [check](https://github.com/onflow/flow-go/blob/792ef25bb27d24cbc112459d35f1ebb31cd9d5d4/module/signature/threshold.go#L80).

This PR solves these 2 issues:
 - if the DKG output is `nil`, `nil` is stored in the key store instead of a wrapped `nil` (this also solves an issue in V2)
 - when checking the key consistency, do not compute the public key of a `nil` private key. 
 

