### PR TITLE
DKG Storage Pt II: Update components using `DKGState` storage

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -274,7 +274,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			err = dkgState.InsertMyBeaconPrivateKey(epochCounter, beaconPrivateKey)
+			err = dkgState.InsertMyBeaconPrivateKey(epochCounter, beaconPrivateKey.PrivateKey)
 			if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
 				return err
 			}

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -254,8 +254,8 @@ func main() {
 
 			// if the node is not part of the current epoch identities, we do
 			// not need to load the key
-			epoch := node.State.AtBlockID(node.RootBlock.ID()).Epochs().Current()
-			initialIdentities, err := epoch.InitialIdentities()
+			rootEpoch := node.State.AtBlockID(node.RootBlock.ID()).Epochs().Current()
+			initialIdentities, err := rootEpoch.InitialIdentities()
 			if err != nil {
 				return err
 			}
@@ -270,7 +270,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			epochCounter, err := epoch.Counter()
+			epochCounter, err := rootEpoch.Counter()
 			if err != nil {
 				return err
 			}
@@ -288,12 +288,12 @@ func main() {
 			// participant in the epoch and we don't have the corresponding DKG
 			// key in the database.
 			checkEpochKey := func(protocol.Epoch) error {
-				identities, err := epoch.InitialIdentities()
+				identities, err := rootEpoch.InitialIdentities()
 				if err != nil {
 					return err
 				}
 				if _, ok := identities.ByNodeID(node.NodeID); ok {
-					counter, err := epoch.Counter()
+					counter, err := rootEpoch.Counter()
 					if err != nil {
 						return err
 					}

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -115,7 +115,8 @@ func main() {
 		dkgBrokerTunnel         *dkgmodule.BrokerTunnel
 		blockTimer              protocol.BlockTimer
 		finalizedHeader         *synceng.FinalizedHeaderCache
-		dkgKeyStore             *bstorage.BeaconPrivateKeys
+		dkgState                *bstorage.DKGState
+		safeBeaconKeys          *bstorage.SafeBeaconPrivateKeys
 	)
 
 	nodeBuilder := cmd.FlowNode(flow.RoleConsensus.String())
@@ -169,8 +170,12 @@ func main() {
 			conMetrics = metrics.NewConsensusCollector(node.Tracer, node.MetricsRegisterer)
 			return nil
 		}).
-		Module("dkg key storage", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
-			dkgKeyStore, err = bstorage.NewBeaconPrivateKeys(node.Metrics.Cache, node.SecretsDB)
+		Module("dkg state", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+			dkgState, err = bstorage.NewDKGState(node.Metrics.Cache, node.SecretsDB)
+			return err
+		}).
+		Module("beacon keys", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
+			safeBeaconKeys, err = bstorage.NewSafeBeaconPrivateKeys(dkgState)
 			return err
 		}).
 		Module("mutable follower state", func(builder cmd.NodeBuilder, node *cmd.NodeConfig) error {
@@ -269,7 +274,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			err = dkgKeyStore.InsertMyBeaconPrivateKey(epochCounter, beaconPrivateKey)
+			err = dkgState.InsertMyBeaconPrivateKey(epochCounter, beaconPrivateKey)
 			if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
 				return err
 			}
@@ -287,7 +292,7 @@ func main() {
 					if err != nil {
 						return err
 					}
-					_, err = dkgKeyStore.RetrieveMyBeaconPrivateKey(counter)
+					_, err = dkgState.RetrieveMyBeaconPrivateKey(counter)
 					if err != nil {
 						return err
 					}
@@ -604,7 +609,7 @@ func main() {
 
 			epochLookup := epochs.NewEpochLookup(node.State)
 
-			thresholdSignerStore := signature.NewEpochAwareSignerStore(epochLookup, dkgKeyStore)
+			thresholdSignerStore := signature.NewEpochAwareSignerStore(epochLookup, safeBeaconKeys)
 
 			// initialize the combined signer for hotstuff
 			var signer hotstuff.SignerVerifier
@@ -743,7 +748,7 @@ func main() {
 				node.Logger,
 				node.Me,
 				node.State,
-				dkgKeyStore,
+				dkgState,
 				dkgmodule.NewControllerFactory(
 					node.Logger,
 					node.Me,

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -278,6 +278,11 @@ func main() {
 			if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
 				return err
 			}
+			// mark the root DKG as successful, so it is considered safe
+			err = dkgState.SetDKGEndState(epochCounter, flow.DKGEndStateSuccess)
+			if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
+				return err
+			}
 
 			// Given an epoch, checkEpochKey returns an error if we are a
 			// participant in the epoch and we don't have the corresponding DKG

--- a/crypto/dkg.go
+++ b/crypto/dkg.go
@@ -73,7 +73,7 @@ func dkgFailureErrorf(msg string, args ...interface{}) error {
 	}
 }
 
-// IsInvalidInputsError checks if the input error is of a dkgFailureError type.
+// IsDKGFailureError checks if the input error is of a dkgFailureError type.
 // dkgFailureError is an error returned when a participant
 // detects a failure in the protocol and is not able to compute output keys.
 func IsDKGFailureError(err error) bool {

--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -143,7 +143,8 @@ func (e *ReactorEngine) startDKGForEpoch(currentEpochCounter uint64, first *flow
 	firstID := first.ID()
 	nextEpochCounter := currentEpochCounter + 1
 	log := e.log.With().
-		Uint64("current_epoch", currentEpochCounter).
+		Uint64("cur_epoch", currentEpochCounter). // the epoch we are in the middle of
+		Uint64("next_epoch", nextEpochCounter).   // the epoch we are running the DKG for
 		Uint64("view", first.View).
 		Hex("block", firstID[:]).
 		Logger()
@@ -241,7 +242,10 @@ func (e *ReactorEngine) handleEpochCommittedPhaseStarted(currentEpochCounter uin
 	// the epoch counter the DKG just completed is for
 	dkgEpochCounter := currentEpochCounter + 1
 
-	log := e.log.With().Uint64("cur_epoch", currentEpochCounter).Logger()
+	log := e.log.With().
+		Uint64("cur_epoch", currentEpochCounter). // the epoch we are in the middle of
+		Uint64("dkg_for_epoch", dkgEpochCounter). // the epoch the just-finished DKG was preparing for
+		Logger()
 
 	// TODO - first check whether we've already stored the dkg end state, since
 	// we need to handle multiple calls to this method

--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine"
-	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/module"
@@ -290,7 +289,7 @@ func (e *ReactorEngine) handleEpochCommittedPhaseStarted(currentEpochCounter uin
 		}
 	}
 
-	log.Info().Msgf("successfully ended DKG for epoch %d - my beacon pub key is %x", dkgEpochCounter, localPubKey.Encode())
+	log.Info().Msgf("successfully ended DKG, my beacon pub key for epoch %d is %x", dkgEpochCounter, localPubKey.Encode())
 }
 
 func (e *ReactorEngine) getDKGInfo(firstBlockID flow.Identifier) (*dkgInfo, error) {
@@ -387,10 +386,7 @@ func (e *ReactorEngine) end(epochCounter uint64) func() error {
 
 		privateShare, _, _ := e.controller.GetArtifacts()
 
-		privKeyInfo := encodable.RandomBeaconPrivKey{
-			PrivateKey: privateShare,
-		}
-		err = e.dkgState.InsertMyBeaconPrivateKey(epochCounter, &privKeyInfo)
+		err = e.dkgState.InsertMyBeaconPrivateKey(epochCounter, privateShare)
 		if err != nil {
 			return fmt.Errorf("couldn't save DKG private key in db: %w", err)
 		}

--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -289,6 +289,8 @@ func (e *ReactorEngine) handleEpochCommittedPhaseStarted(currentEpochCounter uin
 			log.Fatal().Err(err).Msg("failed to set dkg end state")
 		}
 	}
+
+	log.Info().Msgf("successfully ended DKG for epoch %d - my beacon pub key is %x", dkgEpochCounter, localPubKey.Encode())
 }
 
 func (e *ReactorEngine) getDKGInfo(firstBlockID flow.Identifier) (*dkgInfo, error) {

--- a/integration/dkg/dkg_emulator_suite.go
+++ b/integration/dkg/dkg_emulator_suite.go
@@ -408,11 +408,9 @@ func (s *DKGSuite) initEngines(node *node, ids flow.IdentityList) {
 	viewsObserver := gadgets.NewViews()
 	core.ProtocolEvents.AddConsumer(viewsObserver)
 
-	// keyKeys is used to store the private key resulting from the node's
+	// dkgState is used to store the private key resulting from the node's
 	// participation in the DKG run
-	dkgKeys, err := badger.NewBeaconPrivateKeys(core.Metrics, core.SecretsDB)
-	s.Require().NoError(err)
-	dkgState, err := badger.NewDKGState(core.PublicDB)
+	dkgState, err := badger.NewDKGState(core.Metrics, core.SecretsDB)
 	s.Require().NoError(err)
 
 	// brokerTunnel is used to communicate between the messaging engine and the
@@ -453,7 +451,6 @@ func (s *DKGSuite) initEngines(node *node, ids flow.IdentityList) {
 		core.Log,
 		core.Me,
 		core.State,
-		dkgKeys,
 		dkgState,
 		dkg.NewControllerFactory(
 			controllerFactoryLogger,
@@ -469,8 +466,8 @@ func (s *DKGSuite) initEngines(node *node, ids flow.IdentityList) {
 	core.ProtocolEvents.AddConsumer(reactorEngine)
 
 	node.GenericNode = core
-	node.keyStorage = dkgKeys
 	node.messagingEngine = messagingEngine
+	node.dkgState = dkgState
 	node.reactorEngine = reactorEngine
 }
 

--- a/integration/dkg/dkg_emulator_suite.go
+++ b/integration/dkg/dkg_emulator_suite.go
@@ -412,6 +412,8 @@ func (s *DKGSuite) initEngines(node *node, ids flow.IdentityList) {
 	// participation in the DKG run
 	dkgKeys, err := badger.NewBeaconPrivateKeys(core.Metrics, core.SecretsDB)
 	s.Require().NoError(err)
+	dkgState, err := badger.NewDKGState(core.PublicDB)
+	s.Require().NoError(err)
 
 	// brokerTunnel is used to communicate between the messaging engine and the
 	// DKG broker/controller
@@ -452,6 +454,7 @@ func (s *DKGSuite) initEngines(node *node, ids flow.IdentityList) {
 		core.Me,
 		core.State,
 		dkgKeys,
+		dkgState,
 		dkg.NewControllerFactory(
 			controllerFactoryLogger,
 			core.Me,

--- a/integration/dkg/dkg_emulator_test.go
+++ b/integration/dkg/dkg_emulator_test.go
@@ -148,9 +148,8 @@ func (s *DKGSuite) runTest(goodNodes int, emulatorProblems bool) {
 	signatures := []crypto.Signature{}
 	indices := []uint{}
 	for i, n := range nodes {
-		priv, safe, err := n.keyStorage.RetrieveMyBeaconPrivateKey(nextEpochSetup.Counter)
+		priv, err := n.dkgState.RetrieveMyBeaconPrivateKey(nextEpochSetup.Counter)
 		require.NoError(s.T(), err)
-		require.True(s.T(), safe)
 
 		signer := signature.NewThresholdProvider("TAG", priv)
 		signers = append(signers, signer)

--- a/integration/dkg/dkg_emulator_test.go
+++ b/integration/dkg/dkg_emulator_test.go
@@ -148,8 +148,9 @@ func (s *DKGSuite) runTest(goodNodes int, emulatorProblems bool) {
 	signatures := []crypto.Signature{}
 	indices := []uint{}
 	for i, n := range nodes {
-		priv, err := n.keyStorage.RetrieveMyBeaconPrivateKey(nextEpochSetup.Counter)
+		priv, safe, err := n.keyStorage.RetrieveMyBeaconPrivateKey(nextEpochSetup.Counter)
 		require.NoError(s.T(), err)
+		require.True(s.T(), safe)
 
 		signer := signature.NewThresholdProvider("TAG", priv)
 		signers = append(signers, signer)

--- a/integration/dkg/dkg_whiteboard_test.go
+++ b/integration/dkg/dkg_whiteboard_test.go
@@ -1,11 +1,12 @@
 package dkg
 
 import (
-	"github.com/onflow/flow-go/module"
 	"math/rand"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/onflow/flow-go/module"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
@@ -82,7 +83,9 @@ func createNode(
 
 	// keyKeys is used to store the private key resulting from the node's
 	// participation in the DKG run
-	dkgKeys, err := badger.NewBeaconPrivateKeys(core.Metrics, core.SecretsDB)
+	dkgState, err := badger.NewDKGState(core.Metrics, core.SecretsDB)
+	require.NoError(t, err)
+	dkgKeys, err := badger.NewSafeBeaconPrivateKeys(dkgState)
 	require.NoError(t, err)
 
 	// configure the state snapthost at firstBlock to return the desired
@@ -105,8 +108,11 @@ func createNode(
 	epochQuery.Add(nextEpoch)
 	snapshot := new(protocolmock.Snapshot)
 	snapshot.On("Epochs").Return(epochQuery)
+	snapshot.On("Phase").Return(flow.EpochPhaseStaking, nil)
+	snapshot.On("Head").Return(firstBlock, nil)
 	state := new(protocolmock.MutableState)
 	state.On("AtBlockID", firstBlock).Return(snapshot)
+	state.On("Final").Return(snapshot)
 	core.State = state
 
 	// brokerTunnel is used to communicate between the messaging engine and the
@@ -144,7 +150,7 @@ func createNode(
 		core.Log,
 		core.Me,
 		core.State,
-		dkgKeys,
+		dkgState,
 		dkg.NewControllerFactory(
 			controllerFactoryLogger,
 			core.Me,
@@ -278,8 +284,9 @@ func TestWithWhiteboard(t *testing.T) {
 	signatures := []crypto.Signature{}
 	indices := []uint{}
 	for i, n := range nodes {
-		priv, err := n.keyStorage.RetrieveMyBeaconPrivateKey(nextEpochSetup.Counter)
+		priv, safe, err := n.keyStorage.RetrieveMyBeaconPrivateKey(nextEpochSetup.Counter)
 		require.NoError(t, err)
+		require.True(t, safe)
 
 		signer := signature.NewThresholdProvider("TAG", priv)
 		signers = append(signers, signer)

--- a/integration/dkg/node.go
+++ b/integration/dkg/node.go
@@ -33,7 +33,7 @@ type node struct {
 	testmock.GenericNode
 	account           *nodeAccount
 	dkgContractClient *DKGClientWrapper
-	keyStorage        storage.BeaconPrivateKeys
+	keyStorage        storage.SafeBeaconKeys
 	messagingEngine   *dkg.MessagingEngine
 	reactorEngine     *dkg.ReactorEngine
 }
@@ -70,8 +70,11 @@ func (n *node) setEpochs(t *testing.T, currentSetup flow.EpochSetup, nextSetup f
 	epochQuery.Add(nextEpoch)
 	snapshot := new(protocolmock.Snapshot)
 	snapshot.On("Epochs").Return(epochQuery)
+	snapshot.On("Phase").Return(flow.EpochPhaseStaking, nil)
+	snapshot.On("Head").Return(firstBlock, nil)
 	state := new(protocolmock.MutableState)
 	state.On("AtBlockID", firstBlock.ID()).Return(snapshot)
+	state.On("Final").Return(snapshot)
 	n.GenericNode.State = state
 	n.reactorEngine.State = state
 }

--- a/integration/dkg/node.go
+++ b/integration/dkg/node.go
@@ -33,7 +33,7 @@ type node struct {
 	testmock.GenericNode
 	account           *nodeAccount
 	dkgContractClient *DKGClientWrapper
-	keyStorage        storage.SafeBeaconKeys
+	dkgState          storage.DKGState
 	messagingEngine   *dkg.MessagingEngine
 	reactorEngine     *dkg.ReactorEngine
 }

--- a/module/dkg/state.go
+++ b/module/dkg/state.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// State captures the state of a DKG engine
+// State captures the state of an in-progress DKG.
 type State uint32
 
 const (

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -78,7 +78,7 @@ const (
 
 	ResourceClusterBlockProposalQueue = "cluster_compliance_proposal_queue" // collection node, compliance engine
 	ResourceClusterBlockVoteQueue     = "cluster_compliance_vote_queue"     // collection node, compliance engine
-	ResourceBeaconKey                 = "dkg-key"                           // consensus node, DKG engine
+	ResourceBeaconKey                 = "beacon-key"                        // consensus node, DKG engine
 	ResourceApprovalQueue             = "sealing_approval_queue"            // consensus node, sealing engine
 	ResourceReceiptQueue              = "sealing_receipt_queue"             // consensus node, sealing engine
 	ResourceApprovalResponseQueue     = "sealing_approval_response_queue"   // consensus node, sealing engine

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -78,7 +78,7 @@ const (
 
 	ResourceClusterBlockProposalQueue = "cluster_compliance_proposal_queue" // collection node, compliance engine
 	ResourceClusterBlockVoteQueue     = "cluster_compliance_vote_queue"     // collection node, compliance engine
-	ResourceDKGKey                    = "dkg-key"                           // consensus node, DKG engine
+	ResourceBeaconKey                 = "dkg-key"                           // consensus node, DKG engine
 	ResourceApprovalQueue             = "sealing_approval_queue"            // consensus node, sealing engine
 	ResourceReceiptQueue              = "sealing_receipt_queue"             // consensus node, sealing engine
 	ResourceApprovalResponseQueue     = "sealing_approval_response_queue"   // consensus node, sealing engine

--- a/module/signature/signer_store.go
+++ b/module/signature/signer_store.go
@@ -1,7 +1,6 @@
 package signature
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/model/encoding"
@@ -14,12 +13,12 @@ import (
 // using the database to retrieve the relevant DKG keys.
 type EpochAwareSignerStore struct {
 	epochLookup module.EpochLookup                // used to fetch epoch counter by view
-	keys        storage.BeaconPrivateKeys         // used to fetch DKG private key by epoch
+	keys        storage.SafeBeaconKeys            // used to fetch DKG private key by epoch
 	signers     map[uint64]module.ThresholdSigner // cache of signers by epoch
 }
 
 // NewEpochAwareSignerStore instantiates a new EpochAwareSignerStore
-func NewEpochAwareSignerStore(epochLookup module.EpochLookup, keys storage.BeaconPrivateKeys) *EpochAwareSignerStore {
+func NewEpochAwareSignerStore(epochLookup module.EpochLookup, keys storage.SafeBeaconKeys) *EpochAwareSignerStore {
 	return &EpochAwareSignerStore{
 		epochLookup: epochLookup,
 		keys:        keys,
@@ -40,16 +39,24 @@ func (s *EpochAwareSignerStore) GetThresholdSigner(view uint64) (module.Threshol
 		return signer, nil
 	}
 
-	privDKGData, err := s.keys.RetrieveMyBeaconPrivateKey(epoch)
-	if errors.Is(err, storage.ErrNotFound) {
-		signer = NewThresholdProvider(encoding.RandomBeaconTag, nil)
-	} else if err != nil {
+	privDKGData, safe, err := s.keys.RetrieveMyBeaconPrivateKey(epoch)
+	if err != nil {
+		// there are no expected errors here
 		return nil, fmt.Errorf("could not retrieve DKG private key for epoch counter: %v, at view: %v, err: %w", epoch, view, err)
+	}
+
+	if !safe {
+		// we do not have a consistent beacon key which is safe for signing
+		// CAUTION: for now, we produce explicitly invalid signatures
+		// TODO: in Crypto V2, we will fallback to using staking signatures
+		signer = NewThresholdProvider(encoding.RandomBeaconTag, nil)
 	} else {
+		// we have a beacon key which has been explicitly marked safe for use
+		// by the DKG process
 		signer = NewThresholdProvider(encoding.RandomBeaconTag, privDKGData)
 	}
-	s.signers[epoch] = signer
 
+	s.signers[epoch] = signer
 	return signer, nil
 }
 

--- a/module/signature/signer_store_test.go
+++ b/module/signature/signer_store_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	modmocks "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/module/signature"
@@ -17,28 +17,59 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-// TestGetThresholdSignerWithNilPrivateKey tests that without a random beacon private key
-// the signer always returns a invalid BLS signature
-func TestGetThresholdSignerWithNilPrivateKey(t *testing.T) {
+// TestGetThresholdSigner tests that without a valid random beacon private key
+// the signer always returns an invalid BLS signature
+func TestGetThresholdSigner(t *testing.T) {
 
-	// epoch counter
-	epoch := uint64(1)
-
+	epochCounter := uint64(1)
 	// build epoch lookup mock
 	epochLookup := new(modmocks.EpochLookup)
-	epochLookup.On("EpochForViewWithFallback", mock.Anything).Return(epoch, nil)
+	epochLookup.On("EpochForViewWithFallback", mock.Anything).Return(epochCounter, nil)
 
-	unittest.RunWithTypedBadgerDB(t, storage.InitSecret, func(db *badger.DB) {
+	t.Run("without key - failed dkg", func(t *testing.T) {
+		unittest.RunWithTypedBadgerDB(t, storage.InitSecret, func(db *badger.DB) {
+			metrics := metrics.NewNoopCollector()
+			dkgState, err := storage.NewDKGState(metrics, db)
+			require.NoError(t, err)
+			dkgKeys, err := storage.NewSafeBeaconPrivateKeys(dkgState)
+			require.NoError(t, err)
 
-		dkgKeys, err := storage.NewBeaconPrivateKeys(metrics.NewNoopCollector(), db)
-		assert.NoError(t, err)
-		signerStore := signature.NewEpochAwareSignerStore(epochLookup, dkgKeys)
+			err = dkgState.SetDKGEndState(epochCounter, flow.DKGEndStateDKGFailure)
+			require.NoError(t, err)
 
-		signer, err := signerStore.GetThresholdSigner(uint64(1))
-		require.NoError(t, err)
+			signerStore := signature.NewEpochAwareSignerStore(epochLookup, dkgKeys)
 
-		signed, err := signer.Sign([]byte{})
-		require.NoError(t, err)
-		assert.Equal(t, signed, crypto.BLSInvalidSignature())
+			signer, err := signerStore.GetThresholdSigner(uint64(1))
+			require.NoError(t, err)
+
+			signed, err := signer.Sign([]byte{})
+			require.NoError(t, err)
+			assert.Equal(t, signed, crypto.BLSInvalidSignature())
+		})
+	})
+
+	t.Run("key not marked valid", func(t *testing.T) {
+		unittest.RunWithTypedBadgerDB(t, storage.InitSecret, func(db *badger.DB) {
+			metrics := metrics.NewNoopCollector()
+			dkgState, err := storage.NewDKGState(metrics, db)
+			require.NoError(t, err)
+			dkgKeys, err := storage.NewSafeBeaconPrivateKeys(dkgState)
+			require.NoError(t, err)
+
+			// store a key, mark the DKG as failed
+			err = dkgState.InsertMyBeaconPrivateKey(epochCounter, unittest.RandomBeaconPriv().PrivateKey)
+			require.NoError(t, err)
+			err = dkgState.SetDKGEndState(epochCounter, flow.DKGEndStateInconsistentKey)
+			require.NoError(t, err)
+
+			signerStore := signature.NewEpochAwareSignerStore(epochLookup, dkgKeys)
+
+			signer, err := signerStore.GetThresholdSigner(uint64(1))
+			require.NoError(t, err)
+
+			signed, err := signer.Sign([]byte{})
+			require.NoError(t, err)
+			assert.Equal(t, signed, crypto.BLSInvalidSignature())
+		})
 	})
 }

--- a/storage/badger/dkg_state.go
+++ b/storage/badger/dkg_state.go
@@ -77,6 +77,9 @@ func (ds *DKGState) retrieveKeyTx(epochCounter uint64) func(tx *badger.Txn) (*en
 // canonical key vector and may not be valid for use in signing. Use SafeBeaconKeys
 // to guarantee only keys safe for signing are returned
 func (ds *DKGState) InsertMyBeaconPrivateKey(epochCounter uint64, key crypto.PrivateKey) error {
+	if key == nil {
+		return fmt.Errorf("will not store nil beacon key")
+	}
 	encodableKey := &encodable.RandomBeaconPrivKey{PrivateKey: key}
 	return operation.RetryOnConflictTx(ds.db, transaction.Update, ds.storeKeyTx(epochCounter, encodableKey))
 }

--- a/storage/badger/dkg_state_test.go
+++ b/storage/badger/dkg_state_test.go
@@ -92,7 +92,7 @@ func TestSafeBeaconPrivateKeys(t *testing.T) {
 		safeKeys, err := bstorage.NewSafeBeaconPrivateKeys(dkgState)
 		require.NoError(t, err)
 
-		t.Run("non-existent key", func(t *testing.T) {
+		t.Run("non-existent key - should error", func(t *testing.T) {
 			epochCounter := rand.Uint64()
 			key, safe, err := safeKeys.RetrieveMyBeaconPrivateKey(epochCounter)
 			assert.Nil(t, key)
@@ -100,7 +100,7 @@ func TestSafeBeaconPrivateKeys(t *testing.T) {
 			assert.Error(t, err)
 		})
 
-		t.Run("existent key, non-existent dkg end state", func(t *testing.T) {
+		t.Run("existent key, non-existent dkg end state - should error", func(t *testing.T) {
 			epochCounter := rand.Uint64()
 
 			// store a key
@@ -114,7 +114,7 @@ func TestSafeBeaconPrivateKeys(t *testing.T) {
 			assert.Error(t, err)
 		})
 
-		t.Run("existent key, unsuccessful dkg", func(t *testing.T) {
+		t.Run("existent key, unsuccessful dkg - not safe", func(t *testing.T) {
 			epochCounter := rand.Uint64()
 
 			// store a key
@@ -128,10 +128,10 @@ func TestSafeBeaconPrivateKeys(t *testing.T) {
 			key, safe, err := safeKeys.RetrieveMyBeaconPrivateKey(epochCounter)
 			assert.Nil(t, key)
 			assert.False(t, safe)
-			assert.Error(t, err)
+			assert.NoError(t, err)
 		})
 
-		t.Run("existent key, successful dkg", func(t *testing.T) {
+		t.Run("existent key, successful dkg - safe", func(t *testing.T) {
 			epochCounter := rand.Uint64()
 
 			// store a key

--- a/storage/badger/dkg_state_test.go
+++ b/storage/badger/dkg_state_test.go
@@ -62,6 +62,12 @@ func TestDKGState_BeaconKeys(t *testing.T) {
 			assert.True(t, errors.Is(err, storage.ErrNotFound))
 		})
 
+		// attempt to store a nil key should fail (use DKGState.SetEndState(flow.DKGEndStateNoKey)
+		t.Run("should fail to store a nil key instead)", func(t *testing.T) {
+			err = store.InsertMyBeaconPrivateKey(epochCounter, nil)
+			assert.Error(t, err)
+		})
+
 		// store a key in db
 		expected := unittest.RandomBeaconPriv()
 		t.Run("should be able to store and read a key", func(t *testing.T) {

--- a/storage/dkg.go
+++ b/storage/dkg.go
@@ -2,14 +2,8 @@ package storage
 
 import (
 	"github.com/onflow/flow-go/crypto"
-	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
 )
-
-type BeaconPrivateKeys interface {
-	InsertMyBeaconPrivateKey(epochCounter uint64, key *encodable.RandomBeaconPrivKey) error
-	RetrieveMyBeaconPrivateKey(epochCounter uint64) (*encodable.RandomBeaconPrivKey, error)
-}
 
 // DKGState is the storage interface for storing all artifacts and state
 // related to the DKG process, including the latest state of a running or
@@ -48,7 +42,7 @@ type SafeBeaconKeys interface {
 	//
 	// Returns:
 	// * (key, true, nil) if the key is present and confirmed valid
-	// * (nil, false, nil) if the key has been marked invalid (by SetDKGEnded)
+	// * (nil, false, nil) if there is no key, or the key has been marked invalid (by SetDKGEnded)
 	// * (nil, false, error) for any other condition, or exception
 	RetrieveMyBeaconPrivateKey(epochCounter uint64) (key crypto.PrivateKey, safe bool, err error)
 }

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -350,6 +350,12 @@ func WithHeaderHeight(height uint64) func(header *flow.Header) {
 	}
 }
 
+func HeaderWithView(view uint64) func(*flow.Header) {
+	return func(header *flow.Header) {
+		header.View = view
+	}
+}
+
 func BlockHeaderFixture(opts ...func(header *flow.Header)) flow.Header {
 	height := uint64(rand.Uint32())
 	view := height + uint64(rand.Intn(1000))


### PR DESCRIPTION
This PR is Pt. II of an update to DKG state storage.
* updates components using DKG state storage to use `DKGState` and `SafeBeaconKeys`

⚠️ Depends on #1720

Pt III (https://github.com/onflow/flow-go/pull/1732) updates the beacon key checking to occur atomically with the transition to `EpochCommitted` phase. 