### PR TITLE
Tweak FVM bench to be more stable

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,14 +37,14 @@ jobs:
 
       - name: Run benchmark on current branch
         run: |
-          go test ./fvm --bench . --tags relic -shuffle=on -count ${{ steps.settings.outputs.benchmark_repetitions }} | tee new.txt
+          (for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./fvm --bench . --tags relic -shuffle=on; done) | tee new.txt
 
       - name: Checkout base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
       - name: Run benchmark on base branch
         run: |
-          go test ./fvm --bench . --tags relic -shuffle=on  -count ${{ steps.settings.outputs.benchmark_repetitions }} | tee old.txt
+          (for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./fvm --bench . --tags relic -shuffle=on; done) | tee old.txt
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison
@@ -73,7 +73,7 @@ jobs:
 
             This branch with compared with the base branch ${{  github.event.pull_request.base.label }} commit ${{ github.event.pull_request.base.sha }}
 
-            The command `go test ./fvm --bench . --tags relic -shuffle=on -count N` was used.
+            The command `(for i in {1..N}; do go test ./fvm --bench . --tags relic -shuffle=on; done)` was used.
 
             Bench tests were run a total of ${{ steps.settings.outputs.benchmark_repetitions }} times on each branch.
 


### PR DESCRIPTION
Bench tests were being run grouped. Given test A and B with shuffle on and count 3 they would either run like this AAA BBB or like this BBB AAA.

This fix changes the use of the -count flag into a for loop. Which means all test are ran once in a shuffled order, and then this repeats N times.

This tweak causes the uncertainty in the results to go up, which in turn causes the prediction of how much the performance changes to be more conservative.

Example:
```
name                                                                old time/op  new time/op  delta
RuntimeTransaction/reference_tx-8                                   25.0ms ± 9%  23.9ms ± 1%   ~     (p=0.905 n=5+4)
RuntimeTransaction/convert_int_to_string-8                          25.5ms ± 3%  26.6ms ± 5%   ~     (p=0.310 n=5+5)
RuntimeTransaction/convert_int_to_string_and_concatenate_it-8       26.9ms ± 4%  26.6ms ± 1%   ~     (p=0.905 n=5+4)
RuntimeTransaction/get_signer_address-8                             25.5ms ± 7%  26.1ms ±16%   ~     (p=0.690 n=5+5)
RuntimeTransaction/get_public_account-8                             28.1ms ±14%  28.2ms ± 8%   ~     (p=0.548 n=5+5)
RuntimeTransaction/get_account_and_get_balance-8                     372ms ±13%   378ms ±10%   ~     (p=0.421 n=5+5)
RuntimeTransaction/get_account_and_get_available_balance-8           326ms ±19%   326ms ±21%   ~     (p=0.421 n=5+5)
RuntimeTransaction/get_account_and_get_storage_used-8               36.7ms ±19%  37.3ms ±17%   ~     (p=1.000 n=5+5)
RuntimeTransaction/get_account_and_get_storage_capacity-8            287ms ±11%   289ms ± 5%   ~     (p=1.000 n=5+5)
RuntimeTransaction/get_signer_vault-8                               33.3ms ± 9%  32.3ms ± 9%   ~     (p=0.310 n=5+5)
RuntimeTransaction/get_signer_receiver-8                            42.3ms ±13%  41.0ms ±13%   ~     (p=0.421 n=5+5)
RuntimeTransaction/transfer_tokens-8                                 151ms ±18%   144ms ±12%   ~     (p=0.548 n=5+5)
RuntimeTransaction/load_and_save_empty_string_on_signers_address-8  30.2ms ±10%  31.3ms ± 8%   ~     (p=0.421 n=5+5)
RuntimeTransaction/load_and_save_long_string_on_signers_address-8   31.3ms ± 7%  31.0ms ± 1%   ~     (p=0.286 n=5+4)
RuntimeTransaction/create_new_account-8                              779ms ± 6%   838ms ±23%   ~     (p=0.421 n=5+5)
RuntimeTransaction/call_empty_contract_function-8                   28.2ms ± 6%  28.8ms ± 3%   ~     (p=0.421 n=5+5)
RuntimeTransaction/emit_event-8                                     33.0ms ± 5%  35.7ms ±23%   ~     (p=0.310 n=5+5)
RuntimeNFTBatchTransfer-8                                           88.2ms ±10%  85.1ms ± 2%   ~     (p=0.690 n=5+5)
```