### PR TITLE
Log epoch number on execution node startup

### DIFF
--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -578,7 +578,7 @@ func logEpochNumber(vm *fvm.VirtualMachine, vmCtx fvm.Context, executionState st
 
 	// Get the epoch counter form the protocol state
 	protocolStateEpoch, err := node.State.
-		AtBlockID(node.RootBlock.ID()).
+		Final().
 		Epochs().
 		Current().
 		Counter()

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"io"
 	"os"
 	"path"
@@ -36,6 +35,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/rpc"
 	"github.com/onflow/flow-go/engine/execution/state"
 	"github.com/onflow/flow-go/engine/execution/state/bootstrap"
+	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/extralog"
 	"github.com/onflow/flow-go/fvm/programs"

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -14,9 +14,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 
-	"github.com/onflow/flow-go/engine/execution/computation/computer/uploader"
-
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
+
 	"github.com/onflow/flow-go/cmd"
 	"github.com/onflow/flow-go/consensus"
 	"github.com/onflow/flow-go/consensus/hotstuff/committees"
@@ -31,6 +30,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/checker"
 	"github.com/onflow/flow-go/engine/execution/computation"
 	"github.com/onflow/flow-go/engine/execution/computation/committer"
+	"github.com/onflow/flow-go/engine/execution/computation/computer/uploader"
 	"github.com/onflow/flow-go/engine/execution/ingestion"
 	exeprovider "github.com/onflow/flow-go/engine/execution/provider"
 	"github.com/onflow/flow-go/engine/execution/rpc"

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -570,11 +570,13 @@ func main() {
 		}).Run()
 }
 
+// Get and log the epoch counters from the protocol state and from the FlowEpoch smart contract.
 func logEpochNumber(vm *fvm.VirtualMachine, vmCtx fvm.Context, executionState state.ExecutionState, node *cmd.NodeConfig, log zerolog.Logger) {
 	logFail := func(err error) {
 		log.Error().Err(err).Msg("could not log epoch number")
 	}
 
+	// Get the epoch counter form the protocol state
 	protocolStateEpoch, err := node.State.
 		AtBlockID(node.RootBlock.ID()).
 		Epochs().

--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -633,7 +633,7 @@ func logEpochNumber(vm *fvm.VirtualMachine, vmCtx fvm.Context, executionState st
 			Uint64("contractEpochCounter", epochCounter).
 			Uint64("protocolStateEpochCounter", protocolStateEpoch).
 			Str("flowEpochAddress", address.HexWithPrefix()).
-			Msg("Fetched epoch counter from the FlowEpoch smart contract")
+			Msg("Fetched epoch counter from the FlowEpoch smart contract and from the protocol state.")
 		return
 	}
 


### PR DESCRIPTION
closes: https://github.com/dapperlabs/flow-go/issues/5999

This change logs the epoch number from the FlowEpoch smart contract and from the protocol state on execution node startup.

Excerpt from the logs:

```json
[
  {
    "level": "info",
    "node_role": "execution",
    "node_id": "385341c8b20cd5ad80c84092693279185cb0144465a4af56b2ea43990a780a8a",
    "component": "provider engine",
    "contractEpochCounter": 0,
    "protocolStateEpochCounter": 0,
    "flowEpochAddress": "0xf8d6e0586b0a20c7",
    "time": "2021-12-06T15:57:10Z",
    "message": "Fetched epoch counter from the FlowEpoch smart contract"
  },
  {
    "level": "info",
    "node_role": "execution",
    "node_id": "385341c8b20cd5ad80c84092693279185cb0144465a4af56b2ea43990a780a8a",
    "component": "provider engine",
    "time": "2021-12-06T15:57:10Z",
    "message": "component initialization complete"
  },
  {
    "level": "info",
    "node_role": "execution",
    "node_id": "385341c8b20cd5ad80c84092693279185cb0144465a4af56b2ea43990a780a8a",
    "component": "provider engine",
    "time": "2021-12-06T15:57:10Z",
    "message": "component startup complete"
  }
]
```

Since it is only meant for logging, it does not fail if an error is encountered.

I am not sure this is the right location for this code, but I could not find a better one.