### PR TITLE
Unittest fixtures fix signing algorithm

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -425,7 +425,7 @@ func (suite *Suite) TestGetExecutionResultByBlockID() {
 
 		er := unittest.ExecutionResultFixture(
 			unittest.WithExecutionResultBlockID(blockID),
-			unittest.WIthServiceEvents(2))
+			unittest.WithServiceEvents(2))
 
 		require.NoError(suite.T(), executionResults.Store(er))
 		require.NoError(suite.T(), executionResults.Index(blockID, er.ID()))

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -881,7 +881,7 @@ func (suite *Suite) TestGetExecutionResultByBlockID() {
 	blockID := unittest.IdentifierFixture()
 	executionResult := unittest.ExecutionResultFixture(
 		unittest.WithExecutionResultBlockID(blockID),
-		unittest.WIthServiceEvents(2))
+		unittest.WithServiceEvents(2))
 
 	ctx := context.Background()
 

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -683,7 +683,7 @@ func WithExecutionResultBlockID(blockID flow.Identifier) func(*flow.ExecutionRes
 	}
 }
 
-func WIthServiceEvents(n int) func(result *flow.ExecutionResult) {
+func WithServiceEvents(n int) func(result *flow.ExecutionResult) {
 	return func(result *flow.ExecutionResult) {
 		result.ServiceEvents = ServiceEventsFixture(n)
 	}
@@ -746,12 +746,6 @@ func WithBlockID(id flow.Identifier) func(*flow.ResultApproval) {
 func WithChunk(chunkIdx uint64) func(*flow.ResultApproval) {
 	return func(approval *flow.ResultApproval) {
 		approval.Body.ChunkIndex = chunkIdx
-	}
-}
-
-func WithServiveEvents(events ...flow.ServiceEvent) func(*flow.ExecutionResult) {
-	return func(result *flow.ExecutionResult) {
-		result.ServiceEvents = events
 	}
 }
 
@@ -1624,8 +1618,8 @@ func EpochCommitFixture(opts ...func(*flow.EpochCommit)) *flow.EpochCommit {
 	commit := &flow.EpochCommit{
 		Counter:            uint64(rand.Uint32()),
 		ClusterQCs:         flow.ClusterQCVoteDatasFromQCs(QuorumCertificatesFixtures(1)),
-		DKGGroupKey:        KeyFixture(crypto.BLSBLS12381).PublicKey(),
-		DKGParticipantKeys: PublicKeysFixture(2, crypto.BLSBLS12381),
+		DKGGroupKey:        KeyFixture(crypto.ECDSAP256).PublicKey(),
+		DKGParticipantKeys: PublicKeysFixture(2, crypto.ECDSAP256),
 	}
 	for _, apply := range opts {
 		apply(commit)
@@ -1789,7 +1783,7 @@ func PrivateKeyFixtureByIdentifier(algo crypto.SigningAlgorithm, seedLength int,
 }
 
 func StakingPrivKeyByIdentifier(id flow.Identifier) crypto.PrivateKey {
-	return PrivateKeyFixtureByIdentifier(crypto.BLSBLS12381, crypto.KeyGenSeedMinLenBLSBLS12381, id)
+	return PrivateKeyFixtureByIdentifier(crypto.ECDSAP256, crypto.KeyGenSeedMinLenECDSAP256, id)
 }
 
 // NetworkingPrivKeyFixture returns random ECDSAP256 private key


### PR DESCRIPTION
The unittest fixture `WithServiceEvents` had a typo in the name and also was using a method that contained an unsupported signing algorithm `BLSBLS12381` which caused a panic. I changed the signing algorithm to `ECDSAP256` and fix usage of that method in tests.

This branch is also used in the rest API implementation #1666 as we were blocked in the test suite by this panic.