### PR TITLE
Fixture small code cleanup

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -425,7 +425,7 @@ func (suite *Suite) TestGetExecutionResultByBlockID() {
 
 		er := unittest.ExecutionResultFixture(
 			unittest.WithExecutionResultBlockID(blockID),
-			unittest.WIthServiceEvents(2))
+			unittest.WithServiceEvents(2))
 
 		require.NoError(suite.T(), executionResults.Store(er))
 		require.NoError(suite.T(), executionResults.Index(blockID, er.ID()))

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -881,7 +881,7 @@ func (suite *Suite) TestGetExecutionResultByBlockID() {
 	blockID := unittest.IdentifierFixture()
 	executionResult := unittest.ExecutionResultFixture(
 		unittest.WithExecutionResultBlockID(blockID),
-		unittest.WIthServiceEvents(2))
+		unittest.WithServiceEvents(2))
 
 	ctx := context.Background()
 

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -683,7 +683,7 @@ func WithExecutionResultBlockID(blockID flow.Identifier) func(*flow.ExecutionRes
 	}
 }
 
-func WIthServiceEvents(n int) func(result *flow.ExecutionResult) {
+func WithServiceEvents(n int) func(result *flow.ExecutionResult) {
 	return func(result *flow.ExecutionResult) {
 		result.ServiceEvents = ServiceEventsFixture(n)
 	}
@@ -722,12 +722,6 @@ func ExecutionResultFixture(opts ...func(*flow.ExecutionResult)) *flow.Execution
 func WithApproverID(approverID flow.Identifier) func(*flow.ResultApproval) {
 	return func(ra *flow.ResultApproval) {
 		ra.Body.ApproverID = approverID
-	}
-}
-
-func WithAttestationBlock(block *flow.Block) func(*flow.ResultApproval) {
-	return func(ra *flow.ResultApproval) {
-		ra.Body.Attestation.BlockID = block.ID()
 	}
 }
 


### PR DESCRIPTION
Small cleanup of fixtures. The unit test fixture method typo was fixed `WIthServiceEvents` and removed an unused method called `WithServiveEvents`. 