### PR TITLE
[Consensus Voting] refactor VerifyVote

### DIFF
--- a/consensus/follower_test.go
+++ b/consensus/follower_test.go
@@ -90,7 +90,7 @@ func (s *HotStuffFollowerSuite) SetupTest() {
 
 	// mock finalization updater
 	s.verifier = &mockhotstuff.Verifier{}
-	s.verifier.On("VerifyVote", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+	s.verifier.On("VerifyVote", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	s.verifier.On("VerifyQC", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 
 	// mock consumer for finalization notifications

--- a/consensus/hotstuff/integration/instance_test.go
+++ b/consensus/hotstuff/integration/instance_test.go
@@ -217,7 +217,7 @@ func NewInstance(t require.TestingT, options ...Option) *Instance {
 	)
 
 	// program the hotstuff verifier behaviour
-	in.verifier.On("VerifyVote", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+	in.verifier.On("VerifyVote", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	in.verifier.On("VerifyQC", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 
 	// program the hotstuff communicator behaviour

--- a/consensus/hotstuff/mocks/verifier.go
+++ b/consensus/hotstuff/mocks/verifier.go
@@ -37,22 +37,15 @@ func (_m *Verifier) VerifyQC(voters flow.IdentityList, sigData []byte, block *mo
 }
 
 // VerifyVote provides a mock function with given fields: voter, sigData, block
-func (_m *Verifier) VerifyVote(voter *flow.Identity, sigData []byte, block *model.Block) (bool, error) {
+func (_m *Verifier) VerifyVote(voter *flow.Identity, sigData []byte, block *model.Block) error {
 	ret := _m.Called(voter, sigData, block)
 
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(*flow.Identity, []byte, *model.Block) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*flow.Identity, []byte, *model.Block) error); ok {
 		r0 = rf(voter, sigData, block)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(*flow.Identity, []byte, *model.Block) error); ok {
-		r1 = rf(voter, sigData, block)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }

--- a/consensus/hotstuff/validator/validator.go
+++ b/consensus/hotstuff/validator/validator.go
@@ -148,6 +148,7 @@ func (v *Validator) ValidateVote(vote *model.Vote, block *model.Block) (*flow.Id
 	if err != nil {
 		switch {
 		case errors.Is(err, signature.ErrInvalidFormat):
+			return nil, newInvalidVoteError(vote, err)
 		case errors.Is(err, model.ErrInvalidSignature):
 			return nil, newInvalidVoteError(vote, err)
 		default:

--- a/consensus/hotstuff/validator/validator.go
+++ b/consensus/hotstuff/validator/validator.go
@@ -149,7 +149,6 @@ func (v *Validator) ValidateVote(vote *model.Vote, block *model.Block) (*flow.Id
 		switch {
 		case errors.Is(err, signature.ErrInvalidFormat):
 		case errors.Is(err, model.ErrInvalidSignature):
-		case errors.Is(err, model.ErrInvalidSigner):
 			return nil, newInvalidVoteError(vote, err)
 		default:
 			return nil, fmt.Errorf("cannot verify signature for vote (%x): %w", vote.ID(), err)

--- a/consensus/hotstuff/validator/validator.go
+++ b/consensus/hotstuff/validator/validator.go
@@ -144,19 +144,16 @@ func (v *Validator) ValidateVote(vote *model.Vote, block *model.Block) (*flow.Id
 	}
 
 	// check whether the signature data is valid for the vote in the hotstuff context
-	valid, err := v.verifier.VerifyVote(voter, vote.SigData, block)
+	err = v.verifier.VerifyVote(voter, vote.SigData, block)
 	if err != nil {
 		switch {
 		case errors.Is(err, signature.ErrInvalidFormat):
-			return nil, newInvalidVoteError(vote, err)
+		case errors.Is(err, model.ErrInvalidSignature):
 		case errors.Is(err, model.ErrInvalidSigner):
 			return nil, newInvalidVoteError(vote, err)
 		default:
 			return nil, fmt.Errorf("cannot verify signature for vote (%x): %w", vote.ID(), err)
 		}
-	}
-	if !valid {
-		return nil, newInvalidVoteError(vote, model.ErrInvalidSignature)
 	}
 
 	return voter, nil

--- a/consensus/hotstuff/validator/validator_test.go
+++ b/consensus/hotstuff/validator/validator_test.go
@@ -310,6 +310,7 @@ func (vs *VoteSuite) TestVoteSignatureError() {
 	// check that the vote is no longer validated
 	_, err := vs.validator.ValidateVote(vs.vote, vs.block)
 	assert.Error(vs.T(), err, "a vote with error on signature validation should be rejected")
+	assert.False(vs.T(), model.IsInvalidVoteError(err), "internal exception should not be interpreted as invalid vote")
 }
 
 func (vs *VoteSuite) TestVoteSignatureInvalid() {
@@ -320,7 +321,7 @@ func (vs *VoteSuite) TestVoteSignatureInvalid() {
 
 	// check that the vote is no longer validated
 	_, err := vs.validator.ValidateVote(vs.vote, vs.block)
-	assert.Error(vs.T(), err, "a vote with an invalid signature should be rejected")
+	assert.True(vs.T(), model.IsInvalidVoteError(err), "a vote with an invalid signature should be rejected")
 }
 
 func TestValidateQC(t *testing.T) {

--- a/consensus/hotstuff/validator/validator_test.go
+++ b/consensus/hotstuff/validator/validator_test.go
@@ -303,9 +303,9 @@ func (vs *VoteSuite) TestVoteMismatchingView() {
 
 func (vs *VoteSuite) TestVoteSignatureError() {
 
-	// make the verification fail on signature
+	// make the verification fail on exception
 	*vs.verifier = mocks.Verifier{}
-	vs.verifier.On("VerifyVote", vs.signer, vs.vote.SigData, vs.block).Return(fmt.Errorf("staking sig is invalid: %w", model.ErrInvalidSignature))
+	vs.verifier.On("VerifyVote", vs.signer, vs.vote.SigData, vs.block).Return(fmt.Errorf("some exception"))
 
 	// check that the vote is no longer validated
 	_, err := vs.validator.ValidateVote(vs.vote, vs.block)
@@ -316,7 +316,7 @@ func (vs *VoteSuite) TestVoteSignatureInvalid() {
 
 	// make sure the signature is treated as invalid
 	*vs.verifier = mocks.Verifier{}
-	vs.verifier.On("VerifyVote", vs.signer, vs.vote.SigData, vs.block).Return(nil)
+	vs.verifier.On("VerifyVote", vs.signer, vs.vote.SigData, vs.block).Return(fmt.Errorf("staking sig is invalid: %w", model.ErrInvalidSignature))
 
 	// check that the vote is no longer validated
 	_, err := vs.validator.ValidateVote(vs.vote, vs.block)

--- a/consensus/hotstuff/verification/combined_signer_v2_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v2_test.go
@@ -1,7 +1,6 @@
 package verification
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -94,29 +93,25 @@ func TestCombinedSignWithDKGKey(t *testing.T) {
 	blockWrongID := *block
 	blockWrongID.BlockID[0]++
 	err = verifier.VerifyVote(nodeID, vote.SigData, &blockWrongID)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, model.ErrInvalidSignature))
+	require.ErrorIs(t, err, model.ErrInvalidSignature)
 
 	// vote with a wrong view should be invalid
 	blockWrongView := *block
 	blockWrongView.View++
 	err = verifier.VerifyVote(nodeID, vote.SigData, &blockWrongView)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, model.ErrInvalidSignature))
+	require.ErrorIs(t, err, model.ErrInvalidSignature)
 
 	// vote by different signer should be invalid
 	wrongVoter := identities[1]
 	wrongVoter.StakingPubKey = unittest.StakingPrivKeyFixture().PublicKey()
 	err = verifier.VerifyVote(wrongVoter, vote.SigData, block)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, model.ErrInvalidSignature))
+	require.ErrorIs(t, err, model.ErrInvalidSignature)
 
 	// vote with changed signature should be invalid
 	wrongSigData := *vote
 	wrongSigData.SigData[4]++
 	err = verifier.VerifyVote(nodeID, wrongSigData.SigData, block)
-	require.Error(t, err)
-	require.True(t, errors.Is(err, model.ErrInvalidSignature))
+	require.ErrorIs(t, err, model.ErrInvalidSignature)
 }
 
 // Test that when DKG key is not available for a view, a signed block can pass the validation

--- a/consensus/hotstuff/verification/combined_signer_v3_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v3_test.go
@@ -65,9 +65,8 @@ func TestCombinedSignWithDKGKeyV3(t *testing.T) {
 	require.NoError(t, err)
 
 	vote := proposal.ProposerVote()
-	valid, err := verifier.VerifyVote(nodeID, vote.SigData, proposal.Block)
+	err = verifier.VerifyVote(nodeID, vote.SigData, proposal.Block)
 	require.NoError(t, err)
-	require.Equal(t, true, valid)
 
 	// check that a created proposal's signature is a combined staking sig and random beacon sig
 	msg := MakeVoteMessage(block.View, block.BlockID)
@@ -129,9 +128,8 @@ func TestCombinedSignWithNoDKGKeyV3(t *testing.T) {
 	require.NoError(t, err)
 
 	vote := proposal.ProposerVote()
-	valid, err := verifier.VerifyVote(nodeID, vote.SigData, proposal.Block)
+	err = verifier.VerifyVote(nodeID, vote.SigData, proposal.Block)
 	require.NoError(t, err)
-	require.Equal(t, true, valid)
 
 	// check that a created proposal's signature is a combined staking sig and random beacon sig
 	msg := MakeVoteMessage(block.View, block.BlockID)

--- a/consensus/hotstuff/verification/combined_verifier_v2.go
+++ b/consensus/hotstuff/verification/combined_verifier_v2.go
@@ -44,9 +44,7 @@ func NewCombinedVerifier(committee hotstuff.Committee, packer hotstuff.Packer) *
 // VerifyVote verifies the validity of a combined signature from a vote.
 // Usually this method is only used to verify the proposer's vote, which is
 // the vote included in a block proposal.
-// TODO: return error only, because when the sig is invalid, the returned bool
-// can't indicate whether it's staking sig was invalid, or beacon sig was invalid.
-func (c *CombinedVerifier) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) (bool, error) {
+func (c *CombinedVerifier) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {
 
 	// create the to-be-signed message
 	msg := MakeVoteMessage(block.View, block.BlockID)
@@ -55,44 +53,44 @@ func (c *CombinedVerifier) VerifyVote(signer *flow.Identity, sigData []byte, blo
 	// TODO: to be replaced by packer
 	stakingSig, beaconShare, err := signature.DecodeDoubleSig(sigData)
 	if err != nil {
-		return false, fmt.Errorf("could not split signature: %w", modulesig.ErrInvalidFormat)
+		return fmt.Errorf("could not split signature: %w", modulesig.ErrInvalidFormat)
 	}
 
 	dkg, err := c.committee.DKG(block.BlockID)
 	if err != nil {
-		return false, fmt.Errorf("could not get dkg: %w", err)
+		return fmt.Errorf("could not get dkg: %w", err)
 	}
 
 	// verify each signature against the message
 	// TODO: check if using batch verification is faster (should be yes)
 	stakingValid, err := signer.StakingPubKey.Verify(stakingSig, msg, c.stakingHasher)
 	if err != nil {
-		return false, fmt.Errorf("internal error while verifying staking signature: %w", err)
+		return fmt.Errorf("internal error while verifying staking signature for %x: %w", signer.NodeID, err)
 	}
 	if !stakingValid {
-		return false, fmt.Errorf("invalid staking sig")
+		return fmt.Errorf("invalid staking sig for block %v: %w", block.BlockID, model.ErrInvalidSignature)
 	}
 
 	// there is no beacon share, no need to verify it
 	if beaconShare == nil {
-		return true, nil
+		return nil
 	}
 
 	// if there is beacon share, there must be beacon public key
 	beaconPubKey, err := dkg.KeyShare(signer.NodeID)
 	if err != nil {
-		return false, fmt.Errorf("could not get random beacon key share for %x: %w", signer.NodeID, err)
+		return fmt.Errorf("could not get random beacon key share for %x: %w", signer.NodeID, err)
 	}
 
 	beaconValid, err := beaconPubKey.Verify(beaconShare, msg, c.beaconHasher)
 	if err != nil {
-		return false, fmt.Errorf("internal error while verifying beacon signature: %w", err)
+		return fmt.Errorf("internal error while verifying beacon signature: %w", err)
 	}
 
 	if !beaconValid {
-		return false, fmt.Errorf("invalid beacon sig")
+		return fmt.Errorf("invalid beacon sig for block %v: %w", block.BlockID, model.ErrInvalidSignature)
 	}
-	return true, nil
+	return nil
 }
 
 // VerifyQC verifies the validity of a combined signature on a quorum certificate.

--- a/consensus/hotstuff/verification/combined_verifier_v2.go
+++ b/consensus/hotstuff/verification/combined_verifier_v2.go
@@ -44,6 +44,11 @@ func NewCombinedVerifier(committee hotstuff.Committee, packer hotstuff.Packer) *
 // VerifyVote verifies the validity of a combined signature from a vote.
 // Usually this method is only used to verify the proposer's vote, which is
 // the vote included in a block proposal.
+// * signature.ErrInvalidFormat if the signature has an incompatible format.
+// * model.ErrInvalidSignature is the signature is invalid
+// * model.ErrInvalidSigner if the signer is invalid
+// * unexpected errors should be treated as symptoms of bugs or uncovered
+//   edge cases in the logic (i.e. as fatal)
 func (c *CombinedVerifier) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {
 
 	// create the to-be-signed message

--- a/consensus/hotstuff/verification/combined_verifier_v2.go
+++ b/consensus/hotstuff/verification/combined_verifier_v2.go
@@ -46,7 +46,6 @@ func NewCombinedVerifier(committee hotstuff.Committee, packer hotstuff.Packer) *
 // the vote included in a block proposal.
 // * signature.ErrInvalidFormat if the signature has an incompatible format.
 // * model.ErrInvalidSignature is the signature is invalid
-// * model.ErrInvalidSigner if the signer is invalid
 // * unexpected errors should be treated as symptoms of bugs or uncovered
 //   edge cases in the logic (i.e. as fatal)
 func (c *CombinedVerifier) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {

--- a/consensus/hotstuff/verification/combined_verifier_v3.go
+++ b/consensus/hotstuff/verification/combined_verifier_v3.go
@@ -45,7 +45,6 @@ func NewCombinedVerifierV3(committee hotstuff.Committee, packer hotstuff.Packer)
 // the vote included in a block proposal.
 // * signature.ErrInvalidFormat if the signature has an incompatible format.
 // * model.ErrInvalidSignature is the signature is invalid
-// * model.ErrInvalidSigner if the signer is invalid
 // * unexpected errors should be treated as symptoms of bugs or uncovered
 //   edge cases in the logic (i.e. as fatal)
 func (c *CombinedVerifierV3) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {

--- a/consensus/hotstuff/verification/combined_verifier_v3.go
+++ b/consensus/hotstuff/verification/combined_verifier_v3.go
@@ -43,6 +43,11 @@ func NewCombinedVerifierV3(committee hotstuff.Committee, packer hotstuff.Packer)
 // VerifyVote verifies the validity of a combined signature from a vote.
 // Usually this method is only used to verify the proposer's vote, which is
 // the vote included in a block proposal.
+// * signature.ErrInvalidFormat if the signature has an incompatible format.
+// * model.ErrInvalidSignature is the signature is invalid
+// * model.ErrInvalidSigner if the signer is invalid
+// * unexpected errors should be treated as symptoms of bugs or uncovered
+//   edge cases in the logic (i.e. as fatal)
 func (c *CombinedVerifierV3) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {
 
 	// create the to-be-signed message

--- a/consensus/hotstuff/verification/combined_verifier_v3.go
+++ b/consensus/hotstuff/verification/combined_verifier_v3.go
@@ -43,16 +43,14 @@ func NewCombinedVerifierV3(committee hotstuff.Committee, packer hotstuff.Packer)
 // VerifyVote verifies the validity of a combined signature from a vote.
 // Usually this method is only used to verify the proposer's vote, which is
 // the vote included in a block proposal.
-// TODO: return error only, because when the sig is invalid, the returned bool
-// can't indicate whether it's staking sig was invalid, or beacon sig was invalid.
-func (c *CombinedVerifierV3) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) (bool, error) {
+func (c *CombinedVerifierV3) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {
 
 	// create the to-be-signed message
 	msg := MakeVoteMessage(block.View, block.BlockID)
 
 	sigType, sig, err := signature.DecodeSingleSig(sigData)
 	if err != nil {
-		return false, fmt.Errorf("could not decode signature for block %v: %w", block.BlockID, err)
+		return fmt.Errorf("could not decode signature for block %v: %w", block.BlockID, err)
 	}
 
 	switch sigType {
@@ -60,36 +58,36 @@ func (c *CombinedVerifierV3) VerifyVote(signer *flow.Identity, sigData []byte, b
 		// verify each signature against the message
 		stakingValid, err := signer.StakingPubKey.Verify(sig, msg, c.stakingHasher)
 		if err != nil {
-			return false, fmt.Errorf("internal error while verifying staking signature for block %v: %w", block.BlockID, err)
+			return fmt.Errorf("internal error while verifying staking signature for block %v: %w", block.BlockID, err)
 		}
 		if !stakingValid {
-			return false, fmt.Errorf("invalid staking sig for block %v: %w", block.BlockID, model.ErrInvalidSignature)
+			return fmt.Errorf("invalid staking sig for block %v: %w", block.BlockID, model.ErrInvalidSignature)
 		}
 	case hotstuff.SigTypeRandomBeacon:
 		dkg, err := c.committee.DKG(block.BlockID)
 		if err != nil {
-			return false, fmt.Errorf("could not get dkg: %w", err)
+			return fmt.Errorf("could not get dkg: %w", err)
 		}
 
 		// if there is beacon share, there must be beacon public key
 		beaconPubKey, err := dkg.KeyShare(signer.NodeID)
 		if err != nil {
-			return false, fmt.Errorf("could not get random beacon key share for %x at block %v: %w", signer.NodeID, block.BlockID, err)
+			return fmt.Errorf("could not get random beacon key share for %x at block %v: %w", signer.NodeID, block.BlockID, err)
 		}
 
 		beaconValid, err := beaconPubKey.Verify(sig, msg, c.beaconHasher)
 		if err != nil {
-			return false, fmt.Errorf("internal error while verifying beacon signature for block %v: %w", block.BlockID, err)
+			return fmt.Errorf("internal error while verifying beacon signature for block %v: %w", block.BlockID, err)
 		}
 
 		if !beaconValid {
-			return false, fmt.Errorf("invalid beacon sig for block %v: %w", block.BlockID, model.ErrInvalidSignature)
+			return fmt.Errorf("invalid beacon sig for block %v: %w", block.BlockID, model.ErrInvalidSignature)
 		}
 	default:
-		return false, fmt.Errorf("invalid signature type %d: %w", sigType, modulesig.ErrInvalidFormat)
+		return fmt.Errorf("invalid signature type %d: %w", sigType, modulesig.ErrInvalidFormat)
 	}
 
-	return true, nil
+	return nil
 }
 
 // VerifyQC verifies the validity of a combined signature on a quorum certificate.

--- a/consensus/hotstuff/verification/staking_signer_test.go
+++ b/consensus/hotstuff/verification/staking_signer_test.go
@@ -57,9 +57,8 @@ func TestStakingSigner_CreateProposal(t *testing.T) {
 		require.NotNil(t, proposal)
 
 		verifier := NewStakingVerifier()
-		valid, err := verifier.VerifyVote(signerIdentity, proposal.SigData, proposal.Block)
+		err = verifier.VerifyVote(signerIdentity, proposal.SigData, proposal.Block)
 		require.NoError(t, err)
-		require.True(t, valid)
 	})
 }
 
@@ -97,8 +96,7 @@ func TestStakingSigner_CreateVote(t *testing.T) {
 		require.NotNil(t, vote)
 
 		verifier := NewStakingVerifier()
-		valid, err := verifier.VerifyVote(signerIdentity, vote.SigData, block)
+		err = verifier.VerifyVote(signerIdentity, vote.SigData, block)
 		require.NoError(t, err)
-		require.True(t, valid)
 	})
 }

--- a/consensus/hotstuff/verification/staking_verifier.go
+++ b/consensus/hotstuff/verification/staking_verifier.go
@@ -29,8 +29,7 @@ func NewStakingVerifier() *StakingVerifier {
 // VerifyVote verifies the validity of a single signature from a vote.
 // Usually this method is only used to verify the proposer's vote, which is
 // the vote included in a block proposal.
-// TODO: return error only, because when the sig is invalid, the returned bool
-func (v *StakingVerifier) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) (bool, error) {
+func (v *StakingVerifier) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {
 
 	// create the to-be-signed message
 	msg := MakeVoteMessage(block.View, block.BlockID)
@@ -38,13 +37,13 @@ func (v *StakingVerifier) VerifyVote(signer *flow.Identity, sigData []byte, bloc
 	// verify each signature against the message
 	stakingValid, err := signer.StakingPubKey.Verify(sigData, msg, v.stakingHasher)
 	if err != nil {
-		return false, fmt.Errorf("internal error while verifying staking signature: %w", err)
+		return fmt.Errorf("internal error while verifying staking signature: %w", err)
 	}
 	if !stakingValid {
-		return false, fmt.Errorf("invalid staking sig")
+		return fmt.Errorf("invalid sig for block %v: %w", block.BlockID, model.ErrInvalidSignature)
 	}
 
-	return true, nil
+	return nil
 }
 
 // VerifyQC verifies the validity of a single signature on a quorum certificate.

--- a/consensus/hotstuff/verification/staking_verifier.go
+++ b/consensus/hotstuff/verification/staking_verifier.go
@@ -29,6 +29,11 @@ func NewStakingVerifier() *StakingVerifier {
 // VerifyVote verifies the validity of a single signature from a vote.
 // Usually this method is only used to verify the proposer's vote, which is
 // the vote included in a block proposal.
+// The implementation returns the following sentinel errors:
+// * signature.ErrInvalidFormat if the signature has an incompatible format.
+// * model.ErrInvalidSignature is the signature is invalid
+// * unexpected errors should be treated as symptoms of bugs or uncovered
+//   edge cases in the logic (i.e. as fatal)
 func (v *StakingVerifier) VerifyVote(signer *flow.Identity, sigData []byte, block *model.Block) error {
 
 	// create the to-be-signed message

--- a/consensus/hotstuff/verifier.go
+++ b/consensus/hotstuff/verifier.go
@@ -25,10 +25,12 @@ type Verifier interface {
 	// from the provided voter identity. It is the responsibility of the
 	// calling code to ensure that `voter` is authorized to vote.
 	// The implementation returns the following sentinel errors:
-	// * verification.ErrInvalidFormat if the signature has an incompatible format.
+	// * signature.ErrInvalidFormat if the signature has an incompatible format.
+	// * model.ErrInvalidSignature is the signature is invalid
+	// * model.ErrInvalidSigner if the signer is invalid
 	// * unexpected errors should be treated as symptoms of bugs or uncovered
 	//   edge cases in the logic (i.e. as fatal)
-	VerifyVote(voter *flow.Identity, sigData []byte, block *model.Block) (bool, error)
+	VerifyVote(voter *flow.Identity, sigData []byte, block *model.Block) error
 
 	// VerifyQC checks the validity of a QC for the given block.
 	// The first return value indicates whether `sigData` is a valid signature
@@ -37,7 +39,7 @@ type Verifier interface {
 	// It is the responsibility of the calling code to ensure that `voters`
 	// only contains authorized nodes (without duplicates).
 	// The implementation returns the following sentinel errors:
-	// * verification.ErrInvalidFormat if the signature has an incompatible format.
+	// * signature.ErrInvalidFormat if the signature has an incompatible format.
 	// * unexpected errors should be treated as symptoms of bugs or uncovered
 	//   edge cases in the logic (i.e. as fatal)
 	VerifyQC(voters flow.IdentityList, sigData []byte, block *model.Block) (bool, error)

--- a/consensus/hotstuff/verifier.go
+++ b/consensus/hotstuff/verifier.go
@@ -27,7 +27,6 @@ type Verifier interface {
 	// The implementation returns the following sentinel errors:
 	// * signature.ErrInvalidFormat if the signature has an incompatible format.
 	// * model.ErrInvalidSignature is the signature is invalid
-	// * model.ErrInvalidSigner if the signer is invalid
 	// * unexpected errors should be treated as symptoms of bugs or uncovered
 	//   edge cases in the logic (i.e. as fatal)
 	VerifyVote(voter *flow.Identity, sigData []byte, block *model.Block) error

--- a/consensus/integration/signer_test.go
+++ b/consensus/integration/signer_test.go
@@ -39,8 +39,8 @@ func (*Signer) CreateQC(votes []*model.Vote) (*flow.QuorumCertificate, error) {
 	return qc, nil
 }
 
-func (*Signer) VerifyVote(voterID *flow.Identity, sigData []byte, block *model.Block) (bool, error) {
-	return true, nil
+func (*Signer) VerifyVote(voterID *flow.Identity, sigData []byte, block *model.Block) error {
+	return nil
 }
 
 func (*Signer) VerifyQC(voters flow.IdentityList, sigData []byte, block *model.Block) (bool, error) {

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -739,7 +739,7 @@ func createFollowerCore(t *testing.T, node *testmock.GenericNode, followerState 
 
 	// mock finalization updater
 	verifier := &mockhotstuff.Verifier{}
-	verifier.On("VerifyVote", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+	verifier.On("VerifyVote", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	verifier.On("VerifyQC", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 
 	finalizer := confinalizer.NewFinalizer(node.PublicDB, node.Headers, followerState, trace.NewNoopTracer())


### PR DESCRIPTION
Before VerifyVote returns a bool to indicate whether the vote is valid, however, when the vote is invalid, the returned `bool` value can't carry details of why the vote is invalid. 

After changing to use sentinal error to indicate invalid vote, we could include details like the vote is invalid because the staking sig is invalid.