### PR TITLE
Relaxing ledger interaction limit for service and system transactions

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -26,9 +26,9 @@ import (
 	"github.com/onflow/flow-go/utils/logging"
 )
 
-const SystemChunkEventCollectionMaxSize = 256_000_000 // ~256MB
-const SystemChunkLedgerIntractionLimit = 500_000_000  // ~500MB
-const MaxTransactionErrorStringSize = 1000            // 1000 chars
+const SystemChunkEventCollectionMaxSize = 256_000_000  // ~256MB
+const SystemChunkLedgerIntractionLimit = 1_000_000_000 // ~1GB
+const MaxTransactionErrorStringSize = 1000             // 1000 chars
 
 // VirtualMachine runs procedures
 type VirtualMachine interface {

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -27,6 +27,7 @@ import (
 )
 
 const SystemChunkEventCollectionMaxSize = 256_000_000 // ~256MB
+const SystemChunkLedgerIntractionLimit = 500_000_000  // ~500MB
 const MaxTransactionErrorStringSize = 1000            // 1000 chars
 
 // VirtualMachine runs procedures
@@ -62,6 +63,7 @@ func SystemChunkContext(vmCtx fvm.Context, logger zerolog.Logger) fvm.Context {
 		fvm.WithTransactionFeesEnabled(false),
 		fvm.WithServiceEventCollectionEnabled(),
 		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker(logger)),
+		fvm.WithMaxStateInteractionSize(SystemChunkLedgerIntractionLimit),
 		fvm.WithEventCollectionSizeLimit(SystemChunkEventCollectionMaxSize),
 	)
 }

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -103,7 +103,7 @@ func NewStorageCapacityExceededError(address flow.Address, storageUsed, storageC
 }
 
 func (e StorageCapacityExceededError) Error() string {
-	return fmt.Sprintf("%s address %s storage %d is over capacity %d", e.Code().String(), e.address, e.storageUsed, e.storageCapacity)
+	return fmt.Sprintf("%s account with address (%s) uses %d bytes of storage which is over its capacity (%d bytes). Capacity can be increased by adding FLOW tokens to the account.", e.Code().String(), e.address, e.storageUsed, e.storageCapacity)
 }
 
 // Code returns the error code for this error
@@ -193,7 +193,7 @@ func NewLedgerIntractionLimitExceededError(used, limit uint64) *LedgerIntraction
 }
 
 func (e *LedgerIntractionLimitExceededError) Error() string {
-	return fmt.Sprintf("%s max interaction with storage has exceeded the limit (used: %d, limit %d)", e.Code().String(), e.used, e.limit)
+	return fmt.Sprintf("%s max interaction with storage has exceeded the limit (used: %d bytes, limit %d bytes)", e.Code().String(), e.used, e.limit)
 }
 
 // Code returns the error code for this error

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -103,7 +103,7 @@ func NewStorageCapacityExceededError(address flow.Address, storageUsed, storageC
 }
 
 func (e StorageCapacityExceededError) Error() string {
-	return fmt.Sprintf("%s account with address (%s) uses %d bytes of storage which is over its capacity (%d bytes). Capacity can be increased by adding FLOW tokens to the account.", e.Code().String(), e.address, e.storageUsed, e.storageCapacity)
+	return fmt.Sprintf("%s The account with address (%s) uses %d bytes of storage which is over its capacity (%d bytes). Capacity can be increased by adding FLOW tokens to the account.", e.Code().String(), e.address, e.storageUsed, e.storageCapacity)
 }
 
 // Code returns the error code for this error

--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -431,7 +431,7 @@ func (a *StatefulAccounts) SetValue(address flow.Address, key string, value flow
 func (a *StatefulAccounts) setValue(address flow.Address, isController bool, key string, value flow.RegisterValue) error {
 	err := a.updateRegisterSizeChange(address, isController, key, value)
 	if err != nil {
-		return fmt.Errorf("failed to update storage used by key %s on account %s: %w", key, address, err)
+		return fmt.Errorf("failed to update storage used by key %s on account %s: %w", PrintableKey(key), address, err)
 	}
 
 	if isController {
@@ -468,7 +468,7 @@ func (a *StatefulAccounts) updateRegisterSizeChange(address flow.Address, isCont
 		absChange := uint64(-sizeChange)
 		if absChange > oldSize {
 			// should never happen
-			return fmt.Errorf("storage used by key %s on account %s would be negative", key, address.Hex())
+			return fmt.Errorf("storage used by key %s on account %s would be negative", PrintableKey(key), address.Hex())
 		}
 		newSize = oldSize - absChange
 	} else {

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -2,9 +2,12 @@ package state
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/model/flow"
@@ -108,7 +111,7 @@ func (s *State) Get(owner, controller, key string, enforceLimit bool) (flow.Regi
 		// wrap error into a fatal error
 		getError := errors.NewLedgerFailure(err)
 		// wrap with more info
-		return nil, fmt.Errorf("failed to read key %s on account %s: %w", key, hex.EncodeToString([]byte(owner)), getError)
+		return nil, fmt.Errorf("failed to read key %s on account %s: %w", PrintableKey(key), hex.EncodeToString([]byte(owner)), getError)
 	}
 
 	// if not part of recent updates count them as read
@@ -137,7 +140,7 @@ func (s *State) Set(owner, controller, key string, value flow.RegisterValue, enf
 		// wrap error into a fatal error
 		setError := errors.NewLedgerFailure(err)
 		// wrap with more info
-		return fmt.Errorf("failed to update key %s on account %s: %w", key, hex.EncodeToString([]byte(owner)), setError)
+		return fmt.Errorf("failed to update key %s on account %s: %w", PrintableKey(key), hex.EncodeToString([]byte(owner)), setError)
 	}
 
 	if enforceLimit {
@@ -311,4 +314,17 @@ func IsFVMStateKey(owner, controller, key string) bool {
 	}
 
 	return false
+}
+
+// PrintableKey formats slabs properly and avoids invalid utf8s
+func PrintableKey(key string) string {
+	// slab
+	if key[0] == '$' && len(key) == 9 {
+		i := uint64(binary.LittleEndian.Uint64([]byte(key)))
+		return fmt.Sprintf("$%d", i)
+	}
+	if !utf8.ValidString(key) {
+		return strings.ToValidUTF8(key, "?")
+	}
+	return key
 }

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -7,6 +7,7 @@ package state
 // a state manager instead of a state itself.
 type StateHolder struct {
 	enforceInteractionLimits bool
+	payerIsServiceAccount    bool
 	startState               *State
 	activeState              *State
 }
@@ -28,6 +29,11 @@ func (s *StateHolder) State() *State {
 // SetActiveState sets active state
 func (s *StateHolder) SetActiveState(st *State) {
 	s.activeState = st
+}
+
+// SetActiveState sets active state
+func (s *StateHolder) SetPayerIsServiceAccount() {
+	s.payerIsServiceAccount = true
 }
 
 // EnableLimitEnforcement sets that the interaction limit should be enforced
@@ -52,5 +58,8 @@ func (s *StateHolder) NewChild() *State {
 
 // EnforceInteractionLimits returns if the interaction limits should be enforced or not
 func (s *StateHolder) EnforceInteractionLimits() bool {
+	if s.payerIsServiceAccount {
+		return false
+	}
 	return s.enforceInteractionLimits
 }

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"
+
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 )

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -2,9 +2,11 @@ package state_test
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/atree"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 )
@@ -207,4 +209,19 @@ func TestState_IsFVMStateKey(t *testing.T) {
 	require.True(t, state.IsFVMStateKey("Address", "", state.KeyAccountFrozen))
 
 	require.False(t, state.IsFVMStateKey("Address", "", "anything else"))
+}
+
+func TestAccounts_PrintableKey(t *testing.T) {
+	// slab with 189 should result in \\xbd
+	slabIndex := atree.StorageIndex([8]byte{0, 0, 0, 0, 0, 0, 0, 189})
+	key := string(atree.SlabIndexToLedgerKey(slabIndex))
+	require.False(t, utf8.ValidString(key))
+	printable := state.PrintableKey(key)
+	require.True(t, utf8.ValidString(printable))
+
+	// non slab invalid utf-8
+	key = "a\xc5z"
+	require.False(t, utf8.ValidString(key))
+	printable = state.PrintableKey(key)
+	require.True(t, utf8.ValidString(printable))
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -57,6 +57,10 @@ func (proc *TransactionProcedure) Run(vm *VirtualMachine, ctx Context, st *state
 		}
 	}()
 
+	if proc.Transaction.Payer == ctx.Chain.ServiceAddress() {
+		st.SetPayerIsServiceAccount()
+	}
+
 	for _, p := range ctx.TransactionProcessors {
 		err := p.Process(vm, &ctx, proc, st, programs)
 		txErr, failure := errors.SplitErrorTypes(err)

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -51,12 +51,6 @@ func (i *TransactionInvoker) Process(
 		defer span.Finish()
 	}
 
-	payerIsServiceAccount := proc.Transaction.Payer == ctx.Chain.ServiceAddress()
-	// if service account is the payer, disable interaction limit
-	if payerIsServiceAccount {
-		sth.DisableLimitEnforcement()
-	}
-
 	var blockHeight uint64
 	if ctx.BlockHeader != nil {
 		blockHeight = ctx.BlockHeader.Height
@@ -164,9 +158,8 @@ func (i *TransactionInvoker) Process(
 	if feesError != nil {
 		txError = feesError
 	}
-	if !payerIsServiceAccount {
-		sth.EnableLimitEnforcement()
-	}
+
+	sth.EnableLimitEnforcement()
 
 	// applying contract changes
 	// this writes back the contract contents to accounts


### PR DESCRIPTION
This PR:
 - disables ledger interaction limits when a transaction is signed by the service account. this enables the network to support operations like end-epoch to be applicable even when node counts are growing. 
 - let the service chunk uses more ledger interaction and available space on chunk data pack size since it would be the only transaction inside that chunk.