### PR TITLE
Recover interaction limit panic earlier - V0.23

### DIFF
--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -875,10 +875,6 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 	_, err := rand.Read(b)
 	require.NoError(t, err)
 	longString := base64.StdEncoding.EncodeToString(b) // ~1.3 times 1MB
-	b = make([]byte, 10000)                            // 10kB
-	_, err = rand.Read(b)
-	require.NoError(t, err)
-	tenKBString := base64.StdEncoding.EncodeToString(b) // 1.3 times 10kB
 
 	// save a really large contract to an account should fail because of interaction limit reached
 	script := fmt.Sprintf(`
@@ -1011,7 +1007,6 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 	t.Run("Using to much interaction fails during storage limit check - and is recovered", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		withContextOptions(
-			fvm.WithTransactionFeesEnabled(true),
 			fvm.WithTransactionProcessors(
 				fvm.NewTransactionAccountFrozenChecker(),
 				fvm.NewTransactionAccountFrozenEnabler(),
@@ -1021,85 +1016,19 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 		run(
 			func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
 
-				//ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
+				// magic number so interaction limit is reached during storage limit check
+				ctx.MaxStateInteractionSize = 6_269_169
+				ctx.LimitAccountStorage = true
 
 				// Create an account private key.
-				privateKeys, err := testutil.GenerateAccountPrivateKeys(2)
+				privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
 				accounts, err := testutil.CreateAccounts(vm, view, programs, privateKeys, chain)
 				require.NoError(t, err)
 
-				// ====== deploy contract ========
-				txBody := testutil.CreateContractDeploymentTransaction(
-					"DemoInteractionLimit",
-					fmt.Sprintf(`
-						access(all) contract DemoInteractionLimit {
-						   pub var totalSupply: UInt64
-						   pub resource NFT {
-								pub let id: UInt64
-								pub let data: String
-								init() {
-									DemoInteractionLimit.totalSupply = DemoInteractionLimit.totalSupply + UInt64(1)
-									self.id = DemoInteractionLimit.totalSupply
-									self.data = "%s"
-								}
-							}
-							pub resource interface PubCollection{
-								pub fun batchDeposit(tokens: @Collection)
-							}
-							pub resource Collection:PubCollection {
-								pub var ownedNFTs: @{UInt64: NFT}
-								init () {
-									self.ownedNFTs <- {}
-								}
-								pub fun withdraw(withdrawID: UInt64): @NFT {
-									return <-self.ownedNFTs.remove(key: withdrawID)!
-								}
-								pub fun deposit(token: @NFT) {
-									let oldToken <- self.ownedNFTs[token.id] <- token
-									destroy oldToken
-								}
-								pub fun getIDs(): [UInt64] {
-									return self.ownedNFTs.keys
-								}
-								pub fun batchDeposit(tokens: @Collection) {
-									let keys = tokens.getIDs()
-									for key in keys {
-										self.deposit(token: <-tokens.withdraw(withdrawID: key))
-									}
-									destroy tokens
-								}
-								destroy() {
-									destroy self.ownedNFTs
-								}
-							}
-							pub fun newCollection() : @Collection {
-								return <- create Collection()
-							}
-							pub fun batchMintPiece( quantity: UInt64): @Collection {
-								let newCollection <- create Collection()
-						
-								var i: UInt64 = 0
-								while i < quantity {
-									newCollection.deposit(token: <-self.mintPiece())
-									i = i + UInt64(1)
-								}
-						
-								return <-newCollection
-							}
-							pub fun mintPiece(): @NFT {
-								let newPiece: @NFT <- create NFT()
-								return <-newPiece
-							}
-							init() {
-								self.totalSupply = 0
-							}
-						}
-					`, tenKBString),
-					accounts[0],
-					chain)
+				_, txBody := testutil.CreateMultiAccountCreationTransaction(t, chain, 40)
 
 				txBody.SetProposalKey(chain.ServiceAddress(), 0, 0)
 				txBody.SetPayer(accounts[0])
@@ -1114,48 +1043,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
-				require.NoError(t, tx.Err)
-
-				// magic number so interaction limit is reached during storage limit check
-				ctx.MaxStateInteractionSize = 595_720
-				ctx.LimitAccountStorage = true
-				// ========== run transaction ============
-				txBody = flow.NewTransactionBody().
-					SetScript([]byte(fmt.Sprintf(`
-						import DemoInteractionLimit from 0x%s
-						
-						transaction() {
-							var address: Address
-							prepare(acct: AuthAccount) {
-								acct.save<@DemoInteractionLimit.Collection>(<- DemoInteractionLimit.newCollection(), to: /storage/DemoInteractionLimitCollection)
-								acct.link<&{DemoInteractionLimit.PubCollection}>(/public/PubCollection, target: /storage/DemoInteractionLimitCollection)
-								self.address = acct.address
-							}
-							execute {
-								let collection <- DemoInteractionLimit.batchMintPiece(quantity: %d)
-								let recipient = getAccount(self.address)
-								let receiverRef = recipient.getCapability(/public/PubCollection).borrow<&{DemoInteractionLimit.PubCollection}>()!
-								receiverRef.batchDeposit(tokens: <-collection)
-							}
-						}
-					`, accounts[0].Hex(), 30))).
-					AddAuthorizer(accounts[1])
-
-				txBody.SetProposalKey(chain.ServiceAddress(), 0, 1)
-				txBody.SetPayer(accounts[0])
-
-				err = testutil.SignPayload(txBody, accounts[1], privateKeys[1])
-				require.NoError(t, err)
-
-				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
-				require.NoError(t, err)
-
-				tx = fvm.Transaction(txBody, 0)
-
-				err = vm.Run(ctx, tx, view, programs)
-				require.NoError(t, err)
 				require.Error(t, tx.Err)
-
 				assert.Equal(t, (&errors.LedgerIntractionLimitExceededError{}).Code(), tx.Err.Code())
 			}))
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -1,10 +1,6 @@
 package fvm
 
 import (
-	"fmt"
-	"runtime/debug"
-	"strings"
-
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/onflow/flow-go/fvm/errors"
@@ -43,19 +39,6 @@ func (proc *TransactionProcedure) SetTraceSpan(traceSpan opentracing.Span) {
 }
 
 func (proc *TransactionProcedure) Run(vm *VirtualMachine, ctx Context, st *state.StateHolder, programs *programs.Programs) error {
-
-	defer func() {
-		if r := recover(); r != nil {
-
-			if strings.Contains(fmt.Sprintf("%v", r), "[Error Code: 1106]") {
-				ctx.Logger.Error().Str("trace", string(debug.Stack())).Msg("VM LedgerIntractionLimitExceeded panic")
-				proc.Err = errors.NewLedgerIntractionLimitExceededError(state.DefaultMaxInteractionSize, state.DefaultMaxInteractionSize)
-				return
-			}
-
-			panic(r)
-		}
-	}()
 
 	if proc.Transaction.Payer == ctx.Chain.ServiceAddress() {
 		st.SetPayerIsServiceAccount()

--- a/fvm/transactionContractFunctionInvocator.go
+++ b/fvm/transactionContractFunctionInvocator.go
@@ -55,22 +55,6 @@ func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTrace
 
 	predeclaredValues := valueDeclarations(ctx, env)
 
-	// Recover panic coming from InvokeContractFunction and return it as an error.
-	// This error will get properly handled down the line.
-	// If this panic is not caught the node will crash.
-	// Ideally ony user errors would be caught here, or better, no panics would reach this point.
-	defer func() {
-		if r := recover(); r != nil {
-			if recoveredError, ok := r.(error); ok {
-				err = recoveredError
-				i.logger.Error().Err(recoveredError).Msgf("InvokeContractFunction panic recovered")
-				return
-			}
-
-			panic(r)
-		}
-	}()
-
 	value, err = env.VM().Runtime.InvokeContractFunction(
 		i.contractLocation,
 		i.functionName,

--- a/fvm/transactionContractFunctionInvocator.go
+++ b/fvm/transactionContractFunctionInvocator.go
@@ -41,7 +41,7 @@ func NewTransactionContractFunctionInvoker(
 	}
 }
 
-func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTraceSpan opentracing.Span) (value cadence.Value, err error) {
+func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTraceSpan opentracing.Span) (cadence.Value, error) {
 	var span opentracing.Span
 
 	ctx := env.Context()
@@ -55,7 +55,7 @@ func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTrace
 
 	predeclaredValues := valueDeclarations(ctx, env)
 
-	value, err = env.VM().Runtime.InvokeContractFunction(
+	value, err := env.VM().Runtime.InvokeContractFunction(
 		i.contractLocation,
 		i.functionName,
 		i.arguments,

--- a/fvm/transactionContractFunctionInvocator.go
+++ b/fvm/transactionContractFunctionInvocator.go
@@ -41,7 +41,7 @@ func NewTransactionContractFunctionInvoker(
 	}
 }
 
-func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTraceSpan opentracing.Span) (cadence.Value, error) {
+func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTraceSpan opentracing.Span) (value cadence.Value, err error) {
 	var span opentracing.Span
 
 	ctx := env.Context()
@@ -55,7 +55,19 @@ func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTrace
 
 	predeclaredValues := valueDeclarations(ctx, env)
 
-	value, err := env.VM().Runtime.InvokeContractFunction(
+	// recover panic coming from InvokeContractFunction and return it as an error
+	defer func() {
+		if r := recover(); r != nil {
+			if recoveredError, ok := r.(error); ok {
+				err = recoveredError
+				return
+			}
+
+			panic(r)
+		}
+	}()
+
+	value, err = env.VM().Runtime.InvokeContractFunction(
 		i.contractLocation,
 		i.functionName,
 		i.arguments,

--- a/fvm/transactionContractFunctionInvocator.go
+++ b/fvm/transactionContractFunctionInvocator.go
@@ -55,11 +55,15 @@ func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTrace
 
 	predeclaredValues := valueDeclarations(ctx, env)
 
-	// recover panic coming from InvokeContractFunction and return it as an error
+	// Recover panic coming from InvokeContractFunction and return it as an error.
+	// This error will get properly handled down the line.
+	// If this panic is not caught the node will crash.
+	// Ideally ony user errors would be caught here, or better, no panics would reach this point.
 	defer func() {
 		if r := recover(); r != nil {
 			if recoveredError, ok := r.(error); ok {
 				err = recoveredError
+				i.logger.Error().Err(recoveredError).Msgf("InvokeContractFunction panic recovered")
 				return
 			}
 

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/onflow/cadence/runtime"
@@ -120,21 +122,7 @@ func (i *TransactionInvoker) Process(
 
 		location := common.TransactionLocation(proc.ID[:])
 
-		// Recover panic coming from ExecuteTransaction and return it as an error.
-		// This error will be properly handled lower down.
-		// If this panic is not caught the node will crash.
-		// Ideally ony user errors would be caught here, or better, no panics would reach this point.
-		err := func() (err error) {
-			if r := recover(); r != nil {
-				if recoveredError, ok := r.(error); ok {
-					err = recoveredError
-					i.logger.Error().Err(recoveredError).Msgf("ExecuteTransaction panic recovered")
-					return
-				}
-
-				panic(r)
-			}
-
+		err := recoverLedgerInteractionLimitExceeded(i.logger, func() error {
 			return vm.Runtime.ExecuteTransaction(
 				runtime.Script{
 					Source:    proc.Transaction.Script,
@@ -146,7 +134,7 @@ func (i *TransactionInvoker) Process(
 					PredeclaredValues: predeclaredValues,
 				},
 			)
-		}()
+		})
 
 		if err != nil {
 			txError = fmt.Errorf("transaction invocation failed: %w", errors.HandleRuntimeError(err))
@@ -189,7 +177,9 @@ func (i *TransactionInvoker) Process(
 
 	// if there is still no error check if all account storage limits are ok
 	if txError == nil {
-		txError = NewTransactionStorageLimiter().CheckLimits(env, sth.State().UpdatedAddresses())
+		txError = recoverLedgerInteractionLimitExceeded(i.logger, func() error {
+			return NewTransactionStorageLimiter().CheckLimits(env, sth.State().UpdatedAddresses())
+		})
 	}
 
 	// it there was any transaction error clear changes and try to deduct fees again
@@ -256,6 +246,30 @@ func (i *TransactionInvoker) Process(
 	return txError
 }
 
+// Recover specific panic coming from ExecuteTransaction and return it as an error.
+// This panic is documented in https://www.notion.so/dapperlabs/Testnet-31-Execution-restart-11-15-2021-2446a26f55994f73bf1e4c275d640bd2#47a0ad9c4f4443f39b109ba4c1934e3c.
+// An attempt to catch it was done in the following PR: https://github.com/onflow/flow-go/pull/1625
+// That PR caught the panic to late, and the state was potentially not roll-backed correctly
+// This panic is in an un-unwrappable error so errors.As or errors.Is will not work.
+// The proper fix is that this panic does not reach this point at all https://github.com/onflow/cadence/issues/1255.
+func recoverLedgerInteractionLimitExceeded(logger zerolog.Logger, f func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if strings.Contains(fmt.Sprintf("%v", r), "[Error Code: 1106]") {
+				logger.Error().
+					Interface("error", r).
+					Str("trace", string(debug.Stack())). // there was a problem with the stack being cut off
+					Msg("VM LedgerIntractionLimitExceeded panic")
+				err = errors.NewLedgerIntractionLimitExceededError(state.DefaultMaxInteractionSize, state.DefaultMaxInteractionSize)
+				return
+			}
+			panic(r)
+		}
+	}()
+
+	return f()
+}
+
 func (i *TransactionInvoker) deductTransactionFees(env *TransactionEnv, proc *TransactionProcedure) (err error) {
 	if !env.ctx.TransactionFeesEnabled {
 		return nil
@@ -279,7 +293,10 @@ func (i *TransactionInvoker) deductTransactionFees(env *TransactionEnv, proc *Tr
 	}()
 
 	deductTxFees := DeductTransactionFeesInvocation(env, proc.TraceSpan)
-	_, err = deductTxFees(proc.Transaction.Payer)
+	err = recoverLedgerInteractionLimitExceeded(i.logger, func() error {
+		_, err := deductTxFees(proc.Transaction.Payer)
+		return err
+	})
 
 	if err != nil {
 		// TODO: Fee value is currently a constant. this should be changed when it is not


### PR DESCRIPTION
Interaction limit was reached during storage limit check producing this call stack:

```
runtime/debug.Stack()
/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/onflow/flow-go/fvm.(*TransactionProcedure).Run.func1()
/app/fvm/transaction.go:51 +0xcf
panic({0x1a9e060, 0xfadbe17b60})
/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/onflow/cadence/runtime.(*Storage).readStorable(0xfadbdd09c0, {{0xe4, 0x67, 0xb9, 0xdd, 0x11, 0xfa, 0x0, 0xdf}, {0xfd962e84e0, ...}})
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/storage.go:156 +0x389
github.com/onflow/cadence/runtime.(*Storage).ReadValue(0x5, 0xfb7bb23cd0, {0xe4, 0x67, 0xb9, 0xdd, 0x11, 0xfa, 0x0, 0xdf}, ...)
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/storage.go:126 +0x65
github.com/onflow/cadence/runtime.(*interpreterRuntime).loadContract(0x14, 0xd, 0x3e7, 0x14, {{0x3d9, 0x14, 0xd}, {0x3e7, 0x14, 0x1b}}, ...)
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/runtime.go:1787 +0x15b
github.com/onflow/cadence/runtime.(*interpreterRuntime).newInterpreter.func3(0x2273660, 0xf8140d9e90, 0x0, {{0x3d9, 0x14, 0xd}, {0x3e7, 0x14, 0x1b}})
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/runtime.go:1100 +0x87
github.com/onflow/cadence/runtime/interpreter.(*Interpreter).declareNonEnumCompositeValue.func5()
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/interpreter/interpreter.go:1515 +0x108
github.com/onflow/cadence/runtime/interpreter.(*Variable).GetValue(...)
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/interpreter/variable.go:28
github.com/onflow/cadence/runtime/interpreter.(*Interpreter).GetContractComposite(0x0, {{0xe4, 0x67, 0xb9, 0xdd, 0x11, 0xfa, 0x0, 0xdf}, {0x1dcbcd8, ...}})
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/interpreter/interpreter.go:3469 +0x53
github.com/onflow/cadence/runtime.(*interpreterRuntime).InvokeContractFunction(0x40ebe5, {{0xe4, 0x67, 0xb9, 0xdd, 0x11, 0xfa, 0x0, 0xdf}, {0x1dcbcd8, ...}}, ...)
/go/pkg/mod/github.com/dapperlabs/cadence-internal@v0.20.2-patch.1/runtime/runtime.go:478 +0x42b
github.com/onflow/flow-go/fvm.(*TransactionContractFunctionInvoker).Invoke(0xfadbd91e10, {0x22dfa10, 0xfac5cb3b00}, {0x0, 0x0})
/app/fvm/transactionContractFunctionInvocator.go:58 +0x330
github.com/onflow/flow-go/fvm.AccountStorageCapacityInvocation.func1({0x0, 0xf4, 0xd3, 0xe4, 0xc2, 0x8f, 0x12, 0xd5})
/app/fvm/contract_function_invokers.go:143 +0x251
github.com/onflow/flow-go/fvm.(*TransactionEnv).GetStorageCapacity(0x0, {0x0, 0xf4, 0xd3, 0xe4, 0xc2, 0x8f, 0x12, 0xd5})
/app/fvm/transactionEnv.go:285 +0x11c
github.com/onflow/flow-go/fvm.(*TransactionStorageLimiter).CheckLimits(0xdac68f8240, {0x22dfa10, 0xfac5cb3b00}, {0xfa637a8800, 0x161, 0x0})
/app/fvm/transactionStorageLimiter.go:30 +0xb6
github.com/onflow/flow-go/fvm.(*TransactionInvoker).Process(0xdae1c23860, 0xd91a2271e0, 0xfac5cab560, 0xfaac9593f0, 0xfac5cb5a10, 0x7fea58ab57a8)
/app/fvm/transactionInvoker.go:175 +0xf73
github.com/onflow/flow-go/fvm.(*TransactionProcedure).Run(_, _, {{0x22c1468, 0x32dd070}, {0x2258760, 0xc011520c10}, {0x7fdbf03860f8, 0xc000457880}, {0x22ba8f0, 0xc0001b0c68}, ...}, ...)
/app/fvm/transaction.go:65 +0x202
github.com/onflow/flow-go/fvm.(*VirtualMachine).Run(_, {{0x22c1468, 0x32dd070}, {0x2258760, 0xc011520c10}, {0x7fdbf03860f8, 0xc000457880}, {0x22ba8f0, 0xc0001b0c68}, 0x186a0, ...}, ...)
/app/fvm/fvm.go:68 +0x230
github.com/onflow/flow-go/engine/execution/computation/computer.(*blockComputer).executeTransaction(_, _, {_, _}, {_, _}, _, {{0x22c1468, 0x32dd070}, {0x2258760, ...}, ...}, ...)
/app/engine/execution/computation/computer/computer.go:364 +0xb35
github.com/onflow/flow-go/engine/execution/computation/computer.(*blockComputer).executeCollection(_, {_, _}, _, _, {{0x22c1468, 0x32dd070}, {0x2258760, 0xc011520c10}, {0x2297c98, ...}, ...}, ...)
/app/engine/execution/computation/computer/computer.go:305 +0x5a6
github.com/onflow/flow-go/engine/execution/computation/computer.(*blockComputer).executeBlock(0xc01001a600, {0x22c9a80, 0xfa8e5f7388}, 0xfaaa156a80, {0x22ba890, 0xfaa968bf90}, 0xc00fd89040)
/app/engine/execution/computation/computer/computer.go:193 +0xac7
github.com/onflow/flow-go/engine/execution/computation/computer.(*blockComputer).ExecuteBlock(0xc01001a600, {0x22969c8, 0xc00fd89040}, 0xfaaa156a80, {0x22ba890, 0xfaa968bf90}, 0x300000002)
/app/engine/execution/computation/computer/computer.go:105 +0x39f
github.com/onflow/flow-go/engine/execution/computation.(*Manager).ComputeBlock(0xc06fea4000, {0x22969c8, 0xc00fd89040}, 0xfaaa156a80, {0x22ba890, 0xfaa968bf90})
/app/engine/execution/computation/manager.go:211 +0x274
github.com/onflow/flow-go/engine/execution/ingestion.(*Engine).executeBlock(0xc00fdba1c0, {0x22969c8, 0xc00fd89040}, 0xfaaa156a80)
/app/engine/execution/ingestion/engine.go:571 +0x266
github.com/onflow/flow-go/engine/execution/ingestion.(*Engine).executeBlockIfComplete.func1()
/app/engine/execution/ingestion/engine.go:775 +0x2c
github.com/onflow/flow-go/engine.(*Unit).Launch.func1()
/app/engine/unit.go:55 +0x5a
created by github.com/onflow/flow-go/engine.(*Unit).Launch
/app/engine/unit.go:53 +0xaf
```

The temporary measure that was in place to catch exactly this panic was too late in the code path. This caused events not to be emitted. 

I moved the recover panic closer to the source, which means i could make it less specific. 

The test replicates the panic (if you remove the recover).

Edit:

I was not convinced that the initial solution also caught the original error that was addressed with https://github.com/onflow/flow-go/pull/1625/ and described here https://www.notion.so/dapperlabs/Testnet-31-Execution-restart-11-15-2021-2446a26f55994f73bf1e4c275d640bd2#47a0ad9c4f4443f39b109ba4c1934e3c.

The call stack there is cut off but from what remains I am fairly certain it is coming from `Runtime.ExecuteTransaction`. I added another commit to also wrap panics from there. I do not have a reproduction for the original error.

Panics are generally not expected from cadence, but if encounter they probably should crash the node. In the case of this new bug, and the old one there is a panic where there should have been an error. With these temporary fixes all panics (from cadence runtime) will be intercepted and converted to errors, which will fail, and properly revert the transaction, but wont crash the node.

A potential improvement to this fix would be to only try to catch interaction limit exceeded error panics, but that means we might miss some other panics that should have been errors. 