### PR TITLE
[Consensus Voting] Test QC pack and unpack

### DIFF
--- a/consensus/hotstuff/packer/packer.go
+++ b/consensus/hotstuff/packer/packer.go
@@ -42,11 +42,9 @@ func (p *SigDataPacker) Decode(data []byte) (*SignatureData, error) {
 	return &sigData, err
 }
 
-// UnpackRandomBeaconSigForV2 takes sigData previously packed by packer,
+// UnpackRandomBeaconSig takes sigData previously packed by packer,
 // decodes it and extracts random beacon signature
-// TODO: to be removed in V3. Remove it when the combined vote processor
-// uses ConsensusSigDataPacker to pack the the signature
-func UnpackRandomBeaconSigForV2(sigData []byte) (crypto.Signature, error) {
+func UnpackRandomBeaconSig(sigData []byte) (crypto.Signature, error) {
 	// decode into typed data
 	packer := SigDataPacker{}
 	sig, err := packer.Decode(sigData)

--- a/consensus/hotstuff/packer/packer.go
+++ b/consensus/hotstuff/packer/packer.go
@@ -42,8 +42,11 @@ func (p *SigDataPacker) Decode(data []byte) (*SignatureData, error) {
 	return &sigData, err
 }
 
-// UnpackRandomBeaconSig takes sigData previously packed by packer, decodes it and extracts random beacon signature
-func UnpackRandomBeaconSig(sigData []byte) (crypto.Signature, error) {
+// UnpackRandomBeaconSigForV2 takes sigData previously packed by packer,
+// decodes it and extracts random beacon signature
+// TODO: to be removed in V3. Remove it when the combined vote processor
+// uses ConsensusSigDataPacker to pack the the signature
+func UnpackRandomBeaconSigForV2(sigData []byte) (crypto.Signature, error) {
 	// decode into typed data
 	packer := SigDataPacker{}
 	sig, err := packer.Decode(sigData)

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
@@ -259,20 +259,43 @@ func (p *CombinedVoteProcessorV2) buildQC() (*flow.QuorumCertificate, error) {
 		return nil, fmt.Errorf("could not reconstruct random beacon group signature: %w", err)
 	}
 
-	blockSigData := &hotstuff.BlockSignatureData{
+	blockSigData := buildBlockSignatureDataForV2(stakingSigners, aggregatedStakingSig, reconstructedBeaconSig)
+
+	qc, err := buildQCWithPackerAndSigData(p.packer, p.block, blockSigData)
+	if err != nil {
+		return nil, err
+	}
+
+	return qc, nil
+}
+
+// buildBlockSignatureDataForV2 build a block sig data for V2
+// It reuses the hotstuff.BlockSignatureData type to create the sig data without filling the RandomBeaconSigners field and
+// the AggregatedRandomBeaconSig field, so that the packer can be reused by both V2 and V3 to pack QC's sig data.
+func buildBlockSignatureDataForV2(
+	stakingSigners []flow.Identifier,
+	aggregatedStakingSig []byte,
+	reconstructedBeaconSig crypto.Signature) *hotstuff.BlockSignatureData {
+	return &hotstuff.BlockSignatureData{
 		StakingSigners:               stakingSigners,
 		AggregatedStakingSig:         aggregatedStakingSig,
 		ReconstructedRandomBeaconSig: reconstructedBeaconSig,
 	}
+}
 
-	signerIDs, sigData, err := p.packer.Pack(p.block.BlockID, blockSigData)
+// buildQCWithPackerAndSigData builds the QC with the given packer and blockSigData
+func buildQCWithPackerAndSigData(
+	packer hotstuff.Packer,
+	block *model.Block,
+	blockSigData *hotstuff.BlockSignatureData) (*flow.QuorumCertificate, error) {
+	signerIDs, sigData, err := packer.Pack(block.BlockID, blockSigData)
 	if err != nil {
 		return nil, fmt.Errorf("could not pack the block sig data: %w", err)
 	}
 
 	return &flow.QuorumCertificate{
-		View:      p.block.View,
-		BlockID:   p.block.BlockID,
+		View:      block.View,
+		BlockID:   block.BlockID,
 		SignerIDs: signerIDs,
 		SigData:   sigData,
 	}, nil

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
@@ -887,7 +887,7 @@ func VoteWithDoubleSig() func(*model.Vote) {
 	}
 }
 
-// Test that a constructed QC can be unpacked and from which the random source can be
+// TestReadRandomSourceFromPackedQCV2 tests that a constructed QC can be unpacked and from which the random source can be
 // retrieved
 func TestReadRandomSourceFromPackedQCV2(t *testing.T) {
 

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/helper"
 	mockhotstuff "github.com/onflow/flow-go/consensus/hotstuff/mocks"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/consensus/hotstuff/signature"
 	hsig "github.com/onflow/flow-go/consensus/hotstuff/signature"
 	hotstuffvalidator "github.com/onflow/flow-go/consensus/hotstuff/validator"
 	"github.com/onflow/flow-go/consensus/hotstuff/verification"
@@ -28,6 +29,7 @@ import (
 	modulemock "github.com/onflow/flow-go/module/mock"
 	msig "github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/state/protocol/inmem"
+	"github.com/onflow/flow-go/state/protocol/seed"
 	storagemock "github.com/onflow/flow-go/storage/mock"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -883,4 +885,41 @@ func VoteWithDoubleSig() func(*model.Vote) {
 	return func(vote *model.Vote) {
 		vote.SigData = unittest.RandomBytes(96)
 	}
+}
+
+// Test that a constructed QC can be unpacked and from which the random source can be
+// retrieved
+func TestReadRandomSourceFromPackedQCV2(t *testing.T) {
+
+	// for V2 there is no aggregated random beacon sig or random beacon signers
+	allSigners := unittest.IdentityListFixture(5)
+	// staking signers are only subset of all signers
+	stakingSigners := allSigners.NodeIDs()[:3]
+
+	aggregatedStakingSig := unittest.SignatureFixture()
+	reconstructedBeaconSig := unittest.SignatureFixture()
+
+	blockSigData := buildBlockSignatureDataForV2(stakingSigners, aggregatedStakingSig, reconstructedBeaconSig)
+
+	// making a mock block
+	header := unittest.BlockHeaderFixture()
+	block := model.BlockFromFlow(&header, header.View-1)
+
+	// create a packer
+	committee := &mockhotstuff.Committee{}
+	committee.On("Identities", block.BlockID, mock.Anything).Return(allSigners, nil)
+	packer := signature.NewConsensusSigDataPacker(committee)
+
+	qc, err := buildQCWithPackerAndSigData(packer, block, blockSigData)
+	require.NoError(t, err)
+
+	indices := []uint32{1, 2, 3, 4}
+	randomSource, err := seed.FromParentSignature(indices, qc.SigData)
+	require.NoError(t, err)
+
+	randomSourceAgain, err := seed.FromParentSignature(indices, qc.SigData)
+	require.NoError(t, err)
+
+	// verify the randomness is deterministic
+	require.Equal(t, randomSource, randomSourceAgain)
 }

--- a/state/protocol/seed/seed.go
+++ b/state/protocol/seed/seed.go
@@ -11,9 +11,11 @@ import (
 // FromParentSignature reads the raw random seed from a QC sigData.
 // The sigData is an RLP encoded structure that is part of QuorumCertificate.
 // The indices can be used to  generate task-specific seeds from the same signature.
+// TODO: this only works for consensus V2 where a V2 packer is used to unpack the sig data
+// 			 in consensus V3, the ConsensusSigDataPacker should be used instead
 func FromParentSignature(indices []uint32, sigData []byte) ([]byte, error) {
 	// unpack sig data to extract random beacon sig
-	randomBeaconSig, err := packer.UnpackRandomBeaconSig(sigData)
+	randomBeaconSig, err := packer.UnpackRandomBeaconSigForV2(sigData)
 	if err != nil {
 		return nil, fmt.Errorf("could not unpack block signature: %w", err)
 	}

--- a/state/protocol/seed/seed.go
+++ b/state/protocol/seed/seed.go
@@ -11,11 +11,9 @@ import (
 // FromParentSignature reads the raw random seed from a QC sigData.
 // The sigData is an RLP encoded structure that is part of QuorumCertificate.
 // The indices can be used to  generate task-specific seeds from the same signature.
-// TODO: this only works for consensus V2 where a V2 packer is used to unpack the sig data
-// 			 in consensus V3, the ConsensusSigDataPacker should be used instead
 func FromParentSignature(indices []uint32, sigData []byte) ([]byte, error) {
 	// unpack sig data to extract random beacon sig
-	randomBeaconSig, err := packer.UnpackRandomBeaconSigForV2(sigData)
+	randomBeaconSig, err := packer.UnpackRandomBeaconSig(sigData)
 	if err != nil {
 		return nil, fmt.Errorf("could not unpack block signature: %w", err)
 	}


### PR DESCRIPTION
Adding a test to check the integration between the protocol state and combined vote processor. 

The combined vote processor packs the block sig data type into QC's sigData field, and protocol state's `Seed` method unpacks QC's sigData. This test case verifies the pair of Pack and Unpack methods used in the two difference places are integrated well.

Also added some comments for future clean up and moving to V3.