### PR TITLE
Validate the saved root snapshot

### DIFF
--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/epochs"
+	"github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/inmem"
 	"github.com/onflow/flow-go/utils/io"
 )
@@ -204,6 +205,13 @@ func finalize(cmd *cobra.Command, args []string) {
 		log.Fatal().Err(err).Msg("unable to generate root protocol snapshot")
 	}
 
+	// validate the generated root snapshot is valid
+	verifyResultID := true
+	err = badger.IsValidRootSnapshot(snapshot, verifyResultID)
+	if err != nil {
+		log.Fatal().Err(err).Msg("the generated root snapshot is invalid")
+	}
+
 	// write snapshot to disk
 	writeJSON(model.PathRootProtocolStateSnapshot, snapshot.Encodable())
 	log.Info().Msg("")
@@ -232,6 +240,12 @@ func finalize(cmd *cobra.Command, args []string) {
 	}
 
 	log.Info().Msg("saved result and seal are matching")
+
+	err = badger.IsValidRootSnapshot(rootSnapshot, verifyResultID)
+	if err != nil {
+		log.Fatal().Err(err).Msg("saved snapshot is invalid")
+	}
+	log.Info().Msgf("saved root snapshot is valid")
 
 	// copy files only if the directories differ
 	log.Info().Str("private_dir", flagInternalNodePrivInfoDir).Str("output_dir", flagOutdir).Msg("attempting to copy private key files")

--- a/cmd/bootstrap/cmd/finalize_test.go
+++ b/cmd/bootstrap/cmd/finalize_test.go
@@ -38,6 +38,7 @@ const finalizeHappyPathLogs = "^deterministic bootstrapping random seed" +
 	`constructing root protocol snapshot` +
 	`wrote file \S+/root-protocol-state-snapshot.json` +
 	`saved result and seal are matching` +
+	`saved root snapshot is valid` +
 	`attempting to copy private key files` +
 	`skipping copy of private keys to output dir` +
 	`created keys for \d+ consensus nodes` +

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -78,7 +78,7 @@ func Bootstrap(
 
 	state := newState(metrics, db, headers, seals, results, blocks, setups, commits, statuses)
 
-	if err := isValidRootSnapshot(root, !config.SkipNetworkAddressValidation); err != nil {
+	if err := IsValidRootSnapshot(root, !config.SkipNetworkAddressValidation); err != nil {
 		return nil, fmt.Errorf("cannot bootstrap invalid root snapshot: %w", err)
 	}
 

--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -190,9 +190,9 @@ func isValidEpochCommit(commit *flow.EpochCommit, setup *flow.EpochSetup) error 
 	return nil
 }
 
-// isValidRootSnapshot checks internal consistency of root state snapshot
+// IsValidRootSnapshot checks internal consistency of root state snapshot
 // if verifyResultID allows/disallows Result ID verification
-func isValidRootSnapshot(snap protocol.Snapshot, verifyResultID bool) error {
+func IsValidRootSnapshot(snap protocol.Snapshot, verifyResultID bool) error {
 
 	segment, err := snap.SealingSegment()
 	if err != nil {


### PR DESCRIPTION
This PR adds the validation on the saved root snapshot to add extra safety, as this validation is what all nodes will perform when they receive the finalized root snapshot and try to bootstrap with it.