### PR TITLE
Preallocate slices in mtrie

### DIFF
--- a/ledger/common/pathfinder/pathfinder.go
+++ b/ledger/common/pathfinder/pathfinder.go
@@ -45,13 +45,13 @@ func KeyToPath(key ledger.Key, version uint8) (ledger.Path, error) {
 
 // KeysToPaths converts an slice of keys into a paths
 func KeysToPaths(keys []ledger.Key, version uint8) ([]ledger.Path, error) {
-	paths := make([]ledger.Path, 0)
-	for _, k := range keys {
+	paths := make([]ledger.Path, len(keys))
+	for i, k := range keys {
 		p, err := KeyToPath(k, version)
 		if err != nil {
 			return nil, err
 		}
-		paths = append(paths, p)
+		paths[i] = p
 	}
 	return paths, nil
 }
@@ -89,22 +89,22 @@ func QueryToTrieRead(q *ledger.Query, version uint8) (*ledger.TrieRead, error) {
 
 // PayloadsToValues extracts values from an slice of payload
 func PayloadsToValues(payloads []*ledger.Payload) ([]ledger.Value, error) {
-	ret := make([]ledger.Value, 0)
-	for _, p := range payloads {
-		ret = append(ret, p.Value)
+	ret := make([]ledger.Value, len(payloads))
+	for i, p := range payloads {
+		ret[i] = p.Value
 	}
 	return ret, nil
 }
 
 // PathsFromPayloads constructs paths from an slice of payload
 func PathsFromPayloads(payloads []ledger.Payload, version uint8) ([]ledger.Path, error) {
-	paths := make([]ledger.Path, 0)
-	for _, pay := range payloads {
+	paths := make([]ledger.Path, len(payloads))
+	for i, pay := range payloads {
 		p, err := KeyToPath(pay.Key, version)
 		if err != nil {
 			return nil, err
 		}
-		paths = append(paths, p)
+		paths[i] = p
 	}
 	return paths, nil
 }
@@ -113,10 +113,10 @@ func PathsFromPayloads(payloads []ledger.Payload, version uint8) ([]ledger.Path,
 func UpdateToPayloads(update *ledger.Update) ([]*ledger.Payload, error) {
 	keys := update.Keys()
 	values := update.Values()
-	payloads := make([]*ledger.Payload, 0)
+	payloads := make([]*ledger.Payload, len(keys))
 	for i := range keys {
 		payload := &ledger.Payload{Key: keys[i], Value: values[i]}
-		payloads = append(payloads, payload)
+		payloads[i] = payload
 	}
 	return payloads, nil
 }

--- a/ledger/complete/mtrie/forest.go
+++ b/ledger/complete/mtrie/forest.go
@@ -257,8 +257,8 @@ func (f *Forest) GetTrie(rootHash ledger.RootHash) (*trie.MTrie, error) {
 func (f *Forest) GetTries() ([]*trie.MTrie, error) {
 	// ToDo needs concurrency safety
 	keys := f.tries.Keys()
-	tries := make([]*trie.MTrie, 0, len(keys))
-	for _, key := range keys {
+	tries := make([]*trie.MTrie, len(keys))
+	for i, key := range keys {
 		t, ok := f.tries.Get(key)
 		if !ok {
 			return nil, errors.New("concurrent Forest modification")
@@ -267,7 +267,7 @@ func (f *Forest) GetTries() ([]*trie.MTrie, error) {
 		if !ok {
 			return nil, errors.New("forest contains an element of a wrong type")
 		}
-		tries = append(tries, trie)
+		tries[i] = trie
 	}
 	return tries, nil
 }

--- a/ledger/complete/wal/encoding.go
+++ b/ledger/complete/wal/encoding.go
@@ -36,17 +36,17 @@ The code here is deliberately simple, for performance.
 
 func EncodeUpdate(update *ledger.TrieUpdate) []byte {
 	encUpdate := encoding.EncodeTrieUpdate(update)
-	buf := make([]byte, 0, len(encUpdate)+1)
+	buf := make([]byte, len(encUpdate)+1)
 	// set WAL type
-	buf = append(buf, byte(WALUpdate))
+	buf[0] = byte(WALUpdate)
 	// TODO use 2 bytes for encoding length
 	// the rest is encoded update
-	buf = append(buf, encUpdate...)
+	copy(buf[1:], encUpdate)
 	return buf
 }
 
 func EncodeDelete(rootHash ledger.RootHash) []byte {
-	buf := make([]byte, 0)
+	buf := make([]byte, 0, 1+2+len(rootHash))
 	buf = append(buf, byte(WALDelete))
 	buf = utils.AppendShortData(buf, rootHash[:])
 	return buf

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -200,9 +200,9 @@ func (k *Key) String() string {
 
 // DeepCopy returns a deep copy of the key
 func (k *Key) DeepCopy() Key {
-	newKPs := make([]KeyPart, 0, len(k.KeyParts))
-	for _, kp := range k.KeyParts {
-		newKPs = append(newKPs, *kp.DeepCopy())
+	newKPs := make([]KeyPart, len(k.KeyParts))
+	for i, kp := range k.KeyParts {
+		newKPs[i] = *kp.DeepCopy()
 	}
 	return Key{KeyParts: newKPs}
 }
@@ -247,8 +247,8 @@ func (kp *KeyPart) Equals(other *KeyPart) bool {
 
 // DeepCopy returns a deep copy of the key part
 func (kp *KeyPart) DeepCopy() *KeyPart {
-	newV := make([]byte, 0, len(kp.Value))
-	newV = append(newV, kp.Value...)
+	newV := make([]byte, len(kp.Value))
+	copy(newV, kp.Value)
 	return &KeyPart{Type: kp.Type, Value: newV}
 }
 
@@ -276,8 +276,8 @@ func (v Value) String() string {
 
 // DeepCopy returns a deep copy of the value
 func (v Value) DeepCopy() Value {
-	newV := make([]byte, 0, len(v))
-	newV = append(newV, []byte(v)...)
+	newV := make([]byte, len(v))
+	copy(newV, v)
 	return newV
 }
 

--- a/ledger/partial/ledger.go
+++ b/ledger/partial/ledger.go
@@ -82,9 +82,9 @@ func (l *Ledger) Get(query *ledger.Query) (values []ledger.Value, err error) {
 				pathToKey[path] = key
 			}
 
-			keys := make([]ledger.Key, 0, len(pErr.Paths))
-			for _, path := range pErr.Paths {
-				keys = append(keys, pathToKey[path])
+			keys := make([]ledger.Key, len(pErr.Paths))
+			for i, path := range pErr.Paths {
+				keys[i] = pathToKey[path]
 			}
 			return nil, &ledger.ErrMissingKeys{Keys: keys}
 		}

--- a/ledger/partial/ptrie/partialTrie.go
+++ b/ledger/partial/ptrie/partialTrie.go
@@ -31,16 +31,15 @@ func (p *PSMT) RootHash() ledger.RootHash {
 // TODO return list of indecies instead of paths
 func (p *PSMT) Get(paths []ledger.Path) ([]*ledger.Payload, error) {
 	var failedPaths []ledger.Path
-	payloads := make([]*ledger.Payload, 0)
-	for _, path := range paths {
+	payloads := make([]*ledger.Payload, len(paths))
+	for i, path := range paths {
 		// lookup the path for the payload
 		node, found := p.pathLookUp[path]
 		if !found {
-			payloads = append(payloads, nil)
 			failedPaths = append(failedPaths, path)
 			continue
 		}
-		payloads = append(payloads, node.payload)
+		payloads[i] = node.payload
 	}
 	if len(failedPaths) > 0 {
 		return nil, &ErrMissingPath{Paths: failedPaths}

--- a/ledger/trie.go
+++ b/ledger/trie.go
@@ -337,9 +337,10 @@ func NewTrieBatchProof() *TrieBatchProof {
 // NewTrieBatchProofWithEmptyProofs creates an instance of Batchproof
 // filled with n newly created proofs (empty)
 func NewTrieBatchProofWithEmptyProofs(numberOfProofs int) *TrieBatchProof {
-	bp := NewTrieBatchProof()
+	bp := new(TrieBatchProof)
+	bp.Proofs = make([]*TrieProof, numberOfProofs)
 	for i := 0; i < numberOfProofs; i++ {
-		bp.AppendProof(NewTrieProof())
+		bp.Proofs[i] = NewTrieProof()
 	}
 	return bp
 }
@@ -351,18 +352,18 @@ func (bp *TrieBatchProof) Size() int {
 
 // Paths returns the slice of paths for this batch proof
 func (bp *TrieBatchProof) Paths() []Path {
-	paths := make([]Path, 0)
-	for _, p := range bp.Proofs {
-		paths = append(paths, p.Path)
+	paths := make([]Path, len(bp.Proofs))
+	for i, p := range bp.Proofs {
+		paths[i] = p.Path
 	}
 	return paths
 }
 
 // Payloads returns the slice of paths for this batch proof
 func (bp *TrieBatchProof) Payloads() []*Payload {
-	payloads := make([]*Payload, 0)
-	for _, p := range bp.Proofs {
-		payloads = append(payloads, p.Payload)
+	payloads := make([]*Payload, len(bp.Proofs))
+	for i, p := range bp.Proofs {
+		payloads[i] = p.Payload
 	}
 	return payloads
 }


### PR DESCRIPTION
Closes #1820 

Preallocate some of the slices used in mtrie in order to reduce allocs.

This PR was kept simple and limited so it can be merged before more complex optimizations.  Additional optimizations for mtrie serialization will be provided in a separate PR.