### PR TITLE
Fix loader 0.23.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ tool-transit: docker-build-bootstrap-transit
 
 .PHONY: docker-build-loader
 docker-build-loader:
-	docker build -f ./integration/loader/Dockerfile  --build-arg TARGET=loader --target production \
+	docker build -f ./integration/loader/Dockerfile --ssh default --build-arg TARGET=loader --target production \
 		-t "$(CONTAINER_REGISTRY)/loader:latest" -t "$(CONTAINER_REGISTRY)/loader:$(SHORT_COMMIT)" -t "$(CONTAINER_REGISTRY)/loader:$(IMAGE_TAG)" .
 
 .PHONY: docker-build-flow

--- a/integration/loader/Dockerfile
+++ b/integration/loader/Dockerfile
@@ -21,6 +21,12 @@ RUN cd ./crypto/ && go generate
 ## (2) Build the app binary
 FROM build-setup AS build-env
 
+# add the pubkey of github.com to knownhosts, so ssh-agent doesn't bark
+RUN mkdir -p /root/.ssh && ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
+RUN git config --global 'url.ssh://git@github.com/.insteadOf' https://github.com/
+
+ENV GOPRIVATE=github.com/dapperlabs/*
+
 # Build the app binary in /app
 RUN mkdir /app
 WORKDIR /app

--- a/integration/utils/batchLoadGenerator.go
+++ b/integration/utils/batchLoadGenerator.go
@@ -80,7 +80,7 @@ func NewBatchLoadGenerator(fclient *client.Client,
 
 	// TODO get these params hooked to the top level
 	stTracker := NewTxStatsTracker(&StatsConfig{1, 1, 1, 1, 1, numberOfAccounts})
-	txTracker, err := NewTxTracker(zerolog.New(os.Stderr), 5000, 100, accessNodeAddress, time.Second/10, stTracker)
+	txTracker, err := NewTxTracker(zerolog.New(os.Stderr), 5000, 50, accessNodeAddress, time.Second/10, stTracker)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/utils/contLoadGenerator.go
+++ b/integration/utils/contLoadGenerator.go
@@ -26,8 +26,8 @@ const (
 	LedgerHeavyLoadType   LoadType = "ledger-heavy"
 )
 
-const accountCreationBatchSize = 100
-const tokensPerTransfer = 0.01 // flow testnets only have 10e6 total supply, so we choose a small amount here
+const accountCreationBatchSize = 50 // a higher number would hit max storage interaction limit
+const tokensPerTransfer = 0.01      // flow testnets only have 10e6 total supply, so we choose a small amount here
 
 // ContLoadGenerator creates a continuous load of transactions to the network
 // by creating many accounts and transfer flow tokens between them


### PR DESCRIPTION
Fix the following issue by reducing from 100 to 50:

```
Jan 14 19:19:07 loader-001 docker[873237]: 7:19PM INF created 0 accounts
Jan 14 19:19:07 loader-001 docker[873237]: 7:19PM INF creating and funding 100 accounts...
Jan 14 19:19:16 loader-001 docker[873237]: 7:19PM ERR account creation tx failed error="[Error Code: 1106] max interaction with storage has exceeded the limit (used: 20000000, limit 20000000)"
Jan 14 19:19:16 loader-001 docker[873237]: 7:19PM INF created 0 accounts
Jan 14 19:19:16 loader-001 docker[873237]: 7:19PM INF creating and funding 100 accounts...
Jan 14 19:19:23 loader-001 docker[873237]: 7:19PM ERR account creation tx failed error="[Error Code: 1106] max interaction with storage has exceeded the limit (used: 20000000, limit 20000000)"
```

Also fix an issue that the loader was not able to build with internal cadence