### PR TITLE
Enforce weight/ejection requirements in cluster committee

### DIFF
--- a/consensus/hotstuff/committees/cluster_committee.go
+++ b/consensus/hotstuff/committees/cluster_committee.go
@@ -45,11 +45,15 @@ func NewClusterCommittee(
 	}
 
 	com := &Cluster{
-		state:                 state,
-		payloads:              payloads,
-		me:                    me,
-		selection:             selection,
-		clusterMemberFilter:   cluster.Members().Selector(),
+		state:     state,
+		payloads:  payloads,
+		me:        me,
+		selection: selection,
+		clusterMemberFilter: filter.And(
+			cluster.Members().Selector(),
+			filter.Not(filter.Ejected),
+			filter.HasStake(true),
+		),
 		initialClusterMembers: cluster.Members(),
 	}
 	return com, nil


### PR DESCRIPTION
HotStuff committees should ensure committee members have [non-zero weight and are not ejected](https://github.com/dapperlabs/flow-go/blob/2aa2e402d8adc0d921605a17d4abaffc2017e9d0/consensus/hotstuff/committee.go#L23). This PR adds these constraints to the cluster committee. 