### PR TITLE
Auto Cadence Update: Gracefully handle cadence crashes/panics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.4.1
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/onflow/atree v0.1.2-0.20211216135231-f8f0a14c7272
-	github.com/onflow/cadence v0.20.3-0.20220114235056-f8a2df8840c3
+	github.com/onflow/cadence v0.20.3-0.20220117155055-3c24a0ee6bd4
 	github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9

--- a/go.sum
+++ b/go.sum
@@ -1232,8 +1232,8 @@ github.com/onflow/atree v0.1.2-0.20211216135231-f8f0a14c7272/go.mod h1:95SqSEPgf
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.20.3-0.20220114235056-f8a2df8840c3 h1:Sn80Wgk4sCjQIdizmj6IwEUyO4HYiGUcuQXcZ2ZmclA=
-github.com/onflow/cadence v0.20.3-0.20220114235056-f8a2df8840c3/go.mod h1:zrJ8Fdv6d26e0YXLZPyTUUfNPDSU3qVcRxu5KUwPcTY=
+github.com/onflow/cadence v0.20.3-0.20220117155055-3c24a0ee6bd4 h1:+hcRr/++ADJIVl2waIO67NoMVfgyGKZxp3BpAcmHTM8=
+github.com/onflow/cadence v0.20.3-0.20220117155055-3c24a0ee6bd4/go.mod h1:zrJ8Fdv6d26e0YXLZPyTUUfNPDSU3qVcRxu5KUwPcTY=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7 h1:rDsoaE08eNwDGeIH++1Nk9iUxB7dhILnmgvVPNq9DU8=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.20.3-0.20220114235056-f8a2df8840c3
+	github.com/onflow/cadence v0.20.3-0.20220117155055-3c24a0ee6bd4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1353,8 +1353,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.20.3-0.20220114235056-f8a2df8840c3 h1:Sn80Wgk4sCjQIdizmj6IwEUyO4HYiGUcuQXcZ2ZmclA=
-github.com/onflow/cadence v0.20.3-0.20220114235056-f8a2df8840c3/go.mod h1:zrJ8Fdv6d26e0YXLZPyTUUfNPDSU3qVcRxu5KUwPcTY=
+github.com/onflow/cadence v0.20.3-0.20220117155055-3c24a0ee6bd4 h1:+hcRr/++ADJIVl2waIO67NoMVfgyGKZxp3BpAcmHTM8=
+github.com/onflow/cadence v0.20.3-0.20220117155055-3c24a0ee6bd4/go.mod h1:zrJ8Fdv6d26e0YXLZPyTUUfNPDSU3qVcRxu5KUwPcTY=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7 h1:rDsoaE08eNwDGeIH++1Nk9iUxB7dhILnmgvVPNq9DU8=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=


### PR DESCRIPTION
Auto generated PR to update Cadence version.

References: https://github.com/onflow/cadence/pull/1362