### PR TITLE
update `deployEpoch` for new FlowEpoch function

### DIFF
--- a/cmd/util/cmd/epochs/cmd/deploy.go
+++ b/cmd/util/cmd/epochs/cmd/deploy.go
@@ -43,11 +43,13 @@ func init() {
 func addDeployCmdFlags() {
 	deployCmd.Flags().StringVar(&flagFungibleTokenAddress, "fungible-token-addr", "", "the hex address of the FungibleToken contract")
 	deployCmd.Flags().StringVar(&flagFlowTokenAddress, "flow-token-addr", "", "the hex address of the FlowToken contract")
+	deployCmd.Flags().StringVar(&flagFlowTokenAddress, "flow-fees-addr", "", "the hex address of the FlowFees contract")
 	deployCmd.Flags().StringVar(&flagIDTableAddress, "id-table-addr", "", "the hex address of the IDTable contract")
 	deployCmd.Flags().StringVar(&flagFlowSupplyIncreasePercentage, "flow-supply-increase-percentage", "0.0", "the FLOW supply increase percentage")
 
 	_ = deployCmd.MarkFlagRequired("fungible-token-addr")
 	_ = deployCmd.MarkFlagRequired("flow-token-addr")
+	_ = deployCmd.MarkFlagRequired("flow-fees-addr")
 	_ = deployCmd.MarkFlagRequired("id-table-addr")
 	_ = deployCmd.MarkFlagRequired("flow-supply-increase-percentage")
 }
@@ -264,6 +266,7 @@ func getDeployEpochTransactionText(snapshot *inmem.Snapshot) []byte {
 		flagIDTableAddress,
 		systemContracts.ClusterQC.Address.Hex(),
 		systemContracts.DKG.Address.Hex(),
+		flagFlowFeesAddress,
 	)
 
 	// convert the epoch contract code to an [UInt8] literal string that can be

--- a/cmd/util/cmd/epochs/cmd/flags.go
+++ b/cmd/util/cmd/epochs/cmd/flags.go
@@ -11,5 +11,6 @@ var (
 	// contract address flags
 	flagFungibleTokenAddress string
 	flagFlowTokenAddress     string
+	flagFlowFeesAddress      string
 	flagIDTableAddress       string
 )

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -47,7 +47,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("dba7feaa41f742a86f2dcd5b48ce6e774b5d9c0bedb23f3697a7b81feeeebdea")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("19f4114aa047b17707aa77f49880e9456df035c84c2b61c0d14b11300e9afc51")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -214,7 +214,7 @@ func (b *BootstrapProcedure) Run(vm *VirtualMachine, ctx Context, sth *state.Sta
 	// set the list of nodes which are allowed to stake in this network
 	b.setStakingAllowlist(service, b.identities.NodeIDs())
 
-	b.deployEpoch(service, fungibleToken, flowToken)
+	b.deployEpoch(service, fungibleToken, flowToken, feeContract)
 
 	// deploy staking proxy contract to the service account
 	b.deployStakingProxyContract(service)
@@ -386,7 +386,7 @@ func (b *BootstrapProcedure) deployIDTableStaking(service, fungibleToken, flowTo
 	panicOnMetaInvokeErrf("failed to deploy IDTableStaking contract: %s", txError, err)
 }
 
-func (b *BootstrapProcedure) deployEpoch(service, fungibleToken, flowToken flow.Address) {
+func (b *BootstrapProcedure) deployEpoch(service, fungibleToken, flowToken, flowFees flow.Address) {
 
 	contract := contracts.FlowEpoch(
 		fungibleToken.HexWithPrefix(),
@@ -394,6 +394,7 @@ func (b *BootstrapProcedure) deployEpoch(service, fungibleToken, flowToken flow.
 		service.HexWithPrefix(),
 		service.HexWithPrefix(),
 		service.HexWithPrefix(),
+		flowFees.HexWithPrefix(),
 	)
 
 	context := NewContextFromParent(b.ctx,

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/onflow/atree v0.1.1
 	github.com/onflow/cadence v0.20.3
 	github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7
-	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
+	github.com/onflow/flow-core-contracts/lib/go/contracts v0.8.1-0.20220118003757-62d8157aac94
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3
 	github.com/onflow/flow-go-sdk v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1237,8 +1237,8 @@ github.com/onflow/cadence v0.20.3/go.mod h1:KBxn7AyO+R2RFpFHjsWKJFAokyJaCZXc9Hr9
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7 h1:rDsoaE08eNwDGeIH++1Nk9iUxB7dhILnmgvVPNq9DU8=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=
-github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
-github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.8.1-0.20220118003757-62d8157aac94 h1:yFKxkE8ld79qnH8px4FhL88mwNqqlqRe2fkXhvARIYE=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.8.1-0.20220118003757-62d8157aac94/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9 h1:4Yk0ucsLhdh/TxYcCcE+2xXxsTqynvADAZ3d5tmTxVQ=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9/go.mod h1:ckE1lQ18DQVLH9gI63JnGLmBJL/Bo8FPsgYefcWpWhg=
 github.com/onflow/flow-emulator v0.20.3 h1:qsxKp8oty1glaqEyUfRWtsY0qRgTZfejwGiFix2MYzI=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/onflow/cadence v0.20.3
-	github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9
+	github.com/onflow/flow-core-contracts/lib/go/contracts v0.8.1-0.20220118003757-62d8157aac94
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9
 	github.com/onflow/flow-emulator v0.20.3
 	github.com/onflow/flow-ft/lib/go/templates v0.2.0

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1357,8 +1357,8 @@ github.com/onflow/cadence v0.20.3 h1:eyh1vrFbnaGA/oDbJ+3aylwBwJep1zpamH+jTGFN2QQ
 github.com/onflow/cadence v0.20.3/go.mod h1:KBxn7AyO+R2RFpFHjsWKJFAokyJaCZXc9Hr9MlEOq9g=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7 h1:rDsoaE08eNwDGeIH++1Nk9iUxB7dhILnmgvVPNq9DU8=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
-github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9 h1:bn+uytePyRKRXt9+mHOANoV4hoTfJWCEBAoemZjeXDk=
-github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.9/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.8.1-0.20220118003757-62d8157aac94 h1:yFKxkE8ld79qnH8px4FhL88mwNqqlqRe2fkXhvARIYE=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.8.1-0.20220118003757-62d8157aac94/go.mod h1:MSNt2rodpRXm1n0iGQWL6ltDoJCtXEzlPw9nhE/zQmk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9 h1:4Yk0ucsLhdh/TxYcCcE+2xXxsTqynvADAZ3d5tmTxVQ=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.7.9/go.mod h1:ckE1lQ18DQVLH9gI63JnGLmBJL/Bo8FPsgYefcWpWhg=
 github.com/onflow/flow-emulator v0.20.3 h1:qsxKp8oty1glaqEyUfRWtsY0qRgTZfejwGiFix2MYzI=

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -24,7 +24,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "040b1f9aab1281259ced8b35c60ddef24c427fe2a1747798d2cd9ec6eac44f60"
+const GenesisStateCommitmentHex = "e8f76120b674be01198e8ad346b633bb382aabb0ddad0fe5c399c32ebd7db51f"
 
 var GenesisStateCommitment flow.StateCommitment
 


### PR DESCRIPTION
Pin the commit from https://github.com/onflow/flow-core-contracts/pull/267 which adds FlowFees to FlowEpoch and create a commit to pin from test code of `core-contracts` which updates usages of `contracts.FlowEpoch`. 

After we merge this we can update the pin on `core-contracts`, merge https://github.com/onflow/flow-core-contracts/pull/267, and make a release for auto-rewards.