### PR TITLE
[Sporking] Improve state extraction

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -72,7 +72,11 @@ func extractExecutionState(
 		}
 
 	}
+
+	// generating reports at the end, so that the checkpoint file can be used
+	// for sporking as soon as it's generated.
 	if report {
+		log.Info().Msgf("preparing reporter files")
 		reportFileWriterFactory := reporters.NewReportFileWriterFactory(outputDir, log)
 
 		rs = []ledger.Reporter{
@@ -92,6 +96,7 @@ func extractExecutionState(
 			},
 		}
 	}
+
 	newState, err := led.ExportCheckpointAt(
 		ledger.State(targetHash),
 		migrations,

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -305,26 +305,6 @@ func (l *Ledger) ExportCheckpointAt(
 		payloadSize = newPayloadSize
 	}
 
-	// run reporters
-	for _, reporter := range reporters {
-		l.logger.Info().
-			Str("name", reporter.Name()).
-			Msg("starting reporter")
-
-		start := time.Now()
-		err = reporter.Report(payloads)
-		elapsed := time.Since(start)
-
-		l.logger.Info().
-			Str("timeTaken", elapsed.String()).
-			Str("name", reporter.Name()).
-			Msg("reporter done")
-		if err != nil {
-			return ledger.State(hash.DummyHash),
-				fmt.Errorf("error running reporter (%s): %w", reporter.Name(), err)
-		}
-	}
-
 	l.logger.Info().Msgf("constructing a new trie with migrated payloads (count: %d)...", len(payloads))
 
 	// get paths
@@ -341,6 +321,10 @@ func (l *Ledger) ExportCheckpointAt(
 	if err != nil {
 		return ledger.State(hash.DummyHash), fmt.Errorf("constructing updated trie failed: %w", err)
 	}
+
+	statecommitment := ledger.State(newTrie.RootHash())
+
+	l.logger.Info().Msgf("successfully built new trie. NEW ROOT STATECOMMIEMENT: %v", statecommitment.String())
 
 	l.logger.Info().Msg("creating a checkpoint for the new trie")
 
@@ -362,7 +346,33 @@ func (l *Ledger) ExportCheckpointAt(
 	}
 	writer.Close()
 
-	return ledger.State(newTrie.RootHash()), nil
+	l.logger.Info().Msgf("checkpoint file successfully stored at: %v %v", outputDir, outputFile)
+
+	l.logger.Info().Msgf("generating reports")
+
+	// run reporters
+	for _, reporter := range reporters {
+		l.logger.Info().
+			Str("name", reporter.Name()).
+			Msg("starting reporter")
+
+		start := time.Now()
+		err = reporter.Report(payloads)
+		elapsed := time.Since(start)
+
+		l.logger.Info().
+			Str("timeTaken", elapsed.String()).
+			Str("name", reporter.Name()).
+			Msg("reporter done")
+		if err != nil {
+			return ledger.State(hash.DummyHash),
+				fmt.Errorf("error running reporter (%s): %w", reporter.Name(), err)
+		}
+	}
+
+	l.logger.Info().Msgf("all reports genereated")
+
+	return statecommitment, nil
 }
 
 // MostRecentTouchedState returns a state which is most recently touched.


### PR DESCRIPTION
Address https://github.com/dapperlabs/flow-go/issues/6062

In order to print the state commitment earlier, this PR

- defer writing the checkpoint file to disk
- defer the report generations, like account reports, storage reports, etc.