### PR TITLE
[Execution] Improve transaction execution log

### DIFF
--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -559,6 +559,7 @@ func (e *Engine) executeBlock(ctx context.Context, executableBlock *entity.Execu
 
 	e.log.Info().
 		Hex("block_id", logging.Entity(executableBlock)).
+		Uint64("height", executableBlock.Block.Header.Height).
 		Msg("executing block")
 
 	startedAt := time.Now()

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -212,7 +212,7 @@ func (i *TransactionInvoker) Process(
 			// drop delta
 			childState.View().DropDelta()
 			programs.Cleanup(nil)
-			i.logger.Info().
+			i.logger.Warn().
 				Str("txHash", txIDStr).
 				Uint64("blockHeight", blockHeight).
 				Uint64("ledgerInteractionUsed", sth.State().InteractionUsed()).
@@ -220,14 +220,6 @@ func (i *TransactionInvoker) Process(
 
 			return feesError
 		}
-	} else {
-		// transaction is ok, log as successful
-		i.logger.Info().
-			Str("txHash", txIDStr).
-			Uint64("blockHeight", blockHeight).
-			Uint64("ledgerInteractionUsed", sth.State().InteractionUsed()).
-			Int("retried", proc.Retried).
-			Msg("transaction executed successfully")
 	}
 
 	// if tx failed this will only contain fee deduction logs and computation

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -212,7 +212,7 @@ func (i *TransactionInvoker) Process(
 			// drop delta
 			childState.View().DropDelta()
 			programs.Cleanup(nil)
-			i.logger.Warn().
+			i.logger.Info().
 				Str("txHash", txIDStr).
 				Uint64("blockHeight", blockHeight).
 				Uint64("ledgerInteractionUsed", sth.State().InteractionUsed()).


### PR DESCRIPTION
This PR updates the logs for tracing transaction execution, such that:
- We log one entry when start executing a tx, and log another entry after executing the tx with the result indicating succeeded or not. It did not increase the number of logs, since it was logging twice before after executing a tx.
- Ensure tx ID and block height are included in the log (including failed tx), so that it's easier to fetch them by the next executed block height for debugging purpose.
- Indicate whether a tx is a system chunk tx.

The log before the change for a tx:
```
{"level":"info","node_role":"execution","node_id":"b462c11e771b1ce51b808d3efdc57a75f9a1785213f0d8fdabe297423607bd66","engine":"computation","component":"block_computer","txHash":"33f84536f30f37c3df1f5ce9b5fbd7ec526b43852e3218790ca61f14b0769be1","blockHeight":1261,"ledgerInteractionUsed":655244,"retried":0,"time":"2022-01-19T21:33:22Z","message":"transaction executed successfully"}

{"level":"info","node_role":"execution","node_id":"b462c11e771b1ce51b808d3efdc57a75f9a1785213f0d8fdabe297423607bd66","engine":"computation","component":"block_computer","txHash":"33f84536f30f37c3df1f5ce9b5fbd7ec526b43852e3218790ca61f14b0769be1","traceID":"","timeSpentInMS":2845,"time":"2022-01-19T21:33:22Z","message":"transaction executed"}
```

After the change:
```
{"level":"info","node_role":"execution","node_id":"b462c11e771b1ce51b808d3efdc57a75f9a1785213f0d8fdabe297423607bd66","engine":"computation","component":"block_computer","tx_id":"33f84536f30f37c3df1f5ce9b5fbd7ec526b43852e3218790ca61f14b0769be1","tx_index":0,"block_id":"7f021f157b637c1404e234f5c1ea9f5d70f905abcbc316ae742dc0400eaee630","height":93,"system_chunk":true,"time":"2022-01-19T20:59:47Z","message":"executing transaction in fvm"}

{"level":"info","node_role":"execution","node_id":"b462c11e771b1ce51b808d3efdc57a75f9a1785213f0d8fdabe297423607bd66","engine":"computation","component":"block_computer","tx_id":"33f84536f30f37c3df1f5ce9b5fbd7ec526b43852e3218790ca61f14b0769be1","block_id":"7f021f157b637c1404e234f5c1ea9f5d70f905abcbc316ae742dc0400eaee630","traceID":"","computation_used":13,"timeSpentInMS":6,"time":"2022-01-19T20:59:47Z","message":"transaction executed successfully"}
```