### PR TITLE
[Integration] Topology Factory

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/onflow/flow-go/module/id"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/p2p"
+	"github.com/onflow/flow-go/network/topology"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/state/protocol/events"
 	bstorage "github.com/onflow/flow-go/storage/badger"
@@ -130,6 +131,7 @@ type BaseConfig struct {
 	db                              *badger.DB
 	PreferredUnicastProtocols       []string
 	NetworkReceivedMessageCacheSize int
+	topology                        string
 }
 
 // NodeConfig contains all the derived parameters such the NodeID, private keys etc. and initialized instances of
@@ -200,5 +202,6 @@ func DefaultBaseConfig() *BaseConfig {
 		receiptsCacheSize:               bstorage.DefaultCacheSize,
 		guaranteesCacheSize:             bstorage.DefaultCacheSize,
 		NetworkReceivedMessageCacheSize: p2p.DefaultCacheSize,
+		topology:                        string(topology.TopicBased),
 	}
 }

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -131,7 +131,8 @@ type BaseConfig struct {
 	db                              *badger.DB
 	PreferredUnicastProtocols       []string
 	NetworkReceivedMessageCacheSize int
-	topology                        string
+	topologyProtocolName            string
+	topologyEdgeProbability         float64
 }
 
 // NodeConfig contains all the derived parameters such the NodeID, private keys etc. and initialized instances of
@@ -202,6 +203,7 @@ func DefaultBaseConfig() *BaseConfig {
 		receiptsCacheSize:               bstorage.DefaultCacheSize,
 		guaranteesCacheSize:             bstorage.DefaultCacheSize,
 		NetworkReceivedMessageCacheSize: p2p.DefaultCacheSize,
-		topology:                        string(topology.TopicBased),
+		topologyProtocolName:            string(topology.TopicBased),
+		topologyEdgeProbability:         topology.MaximumEdgeProbability,
 	}
 }

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -222,11 +222,11 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit() {
 
 		subscriptionManager := p2p.NewChannelSubscriptionManager(fnb.Middleware)
 
-		top, err := topology.NewTopicBasedTopology(
-			fnb.NodeID,
-			fnb.Logger,
-			fnb.State,
-		)
+		topologyFactory, err := topology.Factory(topology.Name(fnb.topology))
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve topology factory for %s: %w", fnb.topology, err)
+		}
+		top, err := topologyFactory(fnb.NodeID, fnb.Logger, fnb.State, 1)
 		if err != nil {
 			return nil, fmt.Errorf("could not create topology: %w", err)
 		}

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -132,7 +132,8 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 		"incoming message cache size at networking layer")
 	fnb.flags.UintVar(&fnb.BaseConfig.guaranteesCacheSize, "guarantees-cache-size", bstorage.DefaultCacheSize, "collection guarantees cache size")
 	fnb.flags.UintVar(&fnb.BaseConfig.receiptsCacheSize, "receipts-cache-size", bstorage.DefaultCacheSize, "receipts cache size")
-	fnb.flags.StringVar(&fnb.BaseConfig.topology, "topology", defaultConfig.topology, "networking overlay topology")
+	fnb.flags.StringVar(&fnb.BaseConfig.topologyProtocolName, "topology", defaultConfig.topologyProtocolName, "networking overlay topology")
+	fnb.flags.Float64Var(&fnb.BaseConfig.topologyEdgeProbability, "topology-edge-probability", defaultConfig.topologyEdgeProbability, "pariwise edge probability between nodes in topology")
 }
 
 func (fnb *FlowNodeBuilder) EnqueueNetworkInit() {
@@ -222,11 +223,11 @@ func (fnb *FlowNodeBuilder) EnqueueNetworkInit() {
 
 		subscriptionManager := p2p.NewChannelSubscriptionManager(fnb.Middleware)
 
-		topologyFactory, err := topology.Factory(topology.Name(fnb.topology))
+		topologyFactory, err := topology.Factory(topology.Name(fnb.topologyProtocolName))
 		if err != nil {
-			return nil, fmt.Errorf("could not retrieve topology factory for %s: %w", fnb.topology, err)
+			return nil, fmt.Errorf("could not retrieve topology factory for %s: %w", fnb.topologyProtocolName, err)
 		}
-		top, err := topologyFactory(fnb.NodeID, fnb.Logger, fnb.State, 1)
+		top, err := topologyFactory(fnb.NodeID, fnb.Logger, fnb.State, fnb.topologyEdgeProbability)
 		if err != nil {
 			return nil, fmt.Errorf("could not create topology: %w", err)
 		}

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -133,7 +133,8 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 	fnb.flags.UintVar(&fnb.BaseConfig.guaranteesCacheSize, "guarantees-cache-size", bstorage.DefaultCacheSize, "collection guarantees cache size")
 	fnb.flags.UintVar(&fnb.BaseConfig.receiptsCacheSize, "receipts-cache-size", bstorage.DefaultCacheSize, "receipts cache size")
 	fnb.flags.StringVar(&fnb.BaseConfig.topologyProtocolName, "topology", defaultConfig.topologyProtocolName, "networking overlay topology")
-	fnb.flags.Float64Var(&fnb.BaseConfig.topologyEdgeProbability, "topology-edge-probability", defaultConfig.topologyEdgeProbability, "pariwise edge probability between nodes in topology")
+	fnb.flags.Float64Var(&fnb.BaseConfig.topologyEdgeProbability, "topology-edge-probability", defaultConfig.topologyEdgeProbability,
+		"pairwise edge probability between nodes in topology")
 }
 
 func (fnb *FlowNodeBuilder) EnqueueNetworkInit() {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -132,6 +132,7 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 		"incoming message cache size at networking layer")
 	fnb.flags.UintVar(&fnb.BaseConfig.guaranteesCacheSize, "guarantees-cache-size", bstorage.DefaultCacheSize, "collection guarantees cache size")
 	fnb.flags.UintVar(&fnb.BaseConfig.receiptsCacheSize, "receipts-cache-size", bstorage.DefaultCacheSize, "receipts cache size")
+	fnb.flags.StringVar(&fnb.BaseConfig.topology, "topology", defaultConfig.topology, "networking overlay topology")
 }
 
 func (fnb *FlowNodeBuilder) EnqueueNetworkInit() {

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -466,7 +466,7 @@ func WithDebugImage(debug bool) func(config *NodeConfig) {
 func AsGhost() func(config *NodeConfig) {
 	return func(config *NodeConfig) {
 		config.Ghost = true
-                 // using the fully-connectred topology to ensure a ghost node is always connected to all other nodes in the network, 
+		// using the fully-connectred topology to ensure a ghost node is always connected to all other nodes in the network,
 		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
 	}
 }

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -466,6 +466,7 @@ func WithDebugImage(debug bool) func(config *NodeConfig) {
 func AsGhost() func(config *NodeConfig) {
 	return func(config *NodeConfig) {
 		config.Ghost = true
+		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
 	}
 }
 

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -634,7 +634,7 @@ func (s *Suite) assertDKGSuccessful(ctx context.Context, env templates.Environme
 
 // assertLatestFinalizedBlockHeightHigher will assert that the difference between snapshot height and latest finalized height
 // is greater than numOfBlocks.
-func (s *Suite) assertLatestFinalizedBlockHeightHigher(ctx context.Context, snapshot *inmem.Snapshot, numOfBlocks uint64)  {
+func (s *Suite) assertLatestFinalizedBlockHeightHigher(ctx context.Context, snapshot *inmem.Snapshot, numOfBlocks uint64) {
 	bootstrapHead, err := snapshot.Head()
 	require.NoError(s.T(), err)
 
@@ -647,7 +647,7 @@ func (s *Suite) assertLatestFinalizedBlockHeightHigher(ctx context.Context, snap
 
 // submitSmokeTestTransaction will submit a create account transaction to smoke test network
 // This ensures a single transaction can be sealed by the network.
-func (s *Suite) submitSmokeTestTransaction(ctx context.Context)  {
+func (s *Suite) submitSmokeTestTransaction(ctx context.Context) {
 	fullAccountKey := sdk.NewAccountKey().
 		SetPublicKey(unittest.PrivateKeyFixture(crypto.ECDSAP256, crypto.KeyGenSeedMinLenECDSAP256).PublicKey()).
 		SetHashAlgo(sdkcrypto.SHA2_256).

--- a/network/topology/factory.go
+++ b/network/topology/factory.go
@@ -1,6 +1,8 @@
 package topology
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -22,5 +24,7 @@ func Factory(name Name) (FactoryFunction, error) {
 		return RandomizedTopologyFactory(), nil
 	case TopicBased:
 		return TopicBasedTopologyFactory(), nil
+	default:
+		return nil, fmt.Errorf("unknown topology name: %s", name)
 	}
 }

--- a/network/topology/factory.go
+++ b/network/topology/factory.go
@@ -10,6 +10,8 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 )
 
+// MaximumEdgeProbability defines the maximum value of probability for existing an edge between any arbitrary pair of nodes.
+// Edge probability is utilized selectively in some topology protocols, e.g., RandomizedTopology.
 const MaximumEdgeProbability = float64(1)
 
 type Name string

--- a/network/topology/factory.go
+++ b/network/topology/factory.go
@@ -10,6 +10,8 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 )
 
+const MaximumEdgeProbability = float64(1)
+
 type Name string
 
 type FactoryFunction func(flow.Identifier, zerolog.Logger, protocol.State, float64) (network.Topology, error)

--- a/network/topology/factory.go
+++ b/network/topology/factory.go
@@ -1,0 +1,26 @@
+package topology
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/network"
+	"github.com/onflow/flow-go/state/protocol"
+)
+
+type Name string
+
+type FactoryFunction func(flow.Identifier, zerolog.Logger, protocol.State, float64) (network.Topology, error)
+
+func Factory(name Name) (FactoryFunction, error) {
+	switch name {
+	case FullyConnected:
+		return FullyConnectedTopologyFactory(), nil
+	case FixedList:
+		return FixedListTopologyFactory(), nil
+	case Randomized:
+		return RandomizedTopologyFactory(), nil
+	case TopicBased:
+		return TopicBasedTopologyFactory(), nil
+	}
+}

--- a/network/topology/fixedListTopology.go
+++ b/network/topology/fixedListTopology.go
@@ -1,10 +1,21 @@
 package topology
 
 import (
+	"github.com/rs/zerolog"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/network"
+	"github.com/onflow/flow-go/state/protocol"
 )
+
+const FixedList = Name("fixed-list")
+
+func FixedListTopologyFactory() FactoryFunction {
+	return func(nodeId flow.Identifier, _ zerolog.Logger, _ protocol.State, _ float64) (network.Topology, error) {
+		return NewFixedListTopology(nodeId), nil
+	}
+}
 
 // FixedListTopology always returns the same node ID as the fanout
 type FixedListTopology struct {

--- a/network/topology/fullyConnectedTopology.go
+++ b/network/topology/fullyConnectedTopology.go
@@ -1,12 +1,23 @@
 package topology
 
 import (
+	"github.com/rs/zerolog"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/network"
+	"github.com/onflow/flow-go/state/protocol"
 )
+
+const FullyConnected = Name("fully-connected")
 
 // FullyConnectedTopology returns all nodes as a fanout.
 type FullyConnectedTopology struct{}
+
+func FullyConnectedTopologyFactory() FactoryFunction {
+	return func(_ flow.Identifier, _r zerolog.Logger, _ protocol.State, _ float64) (network.Topology, error) {
+		return NewFullyConnectedTopology(), nil
+	}
+}
 
 func NewFullyConnectedTopology() network.Topology {
 	return &FullyConnectedTopology{}

--- a/network/topology/randomizedTopology.go
+++ b/network/topology/randomizedTopology.go
@@ -13,6 +13,14 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 )
 
+const Randomized = Name("randomized")
+
+func RandomizedTopologyFactory() FactoryFunction {
+	return func(nodeId flow.Identifier, logger zerolog.Logger, state protocol.State, edgeProb float64) (network.Topology, error) {
+		return NewRandomizedTopology(nodeId, logger, edgeProb, state)
+	}
+}
+
 // RandomizedTopology generates a random topology per channel.
 // By random topology we mean a node is connected to any other co-channel nodes with some
 // edge probability.

--- a/network/topology/topicBasedTopology.go
+++ b/network/topology/topicBasedTopology.go
@@ -12,6 +12,14 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 )
 
+const TopicBased = Name("topic-based")
+
+func TopicBasedTopologyFactory() FactoryFunction {
+	return func(nodeId flow.Identifier, logger zerolog.Logger, state protocol.State, _ float64) (network.Topology, error) {
+		return NewTopicBasedTopology(nodeId, logger, state)
+	}
+}
+
 // TopicBasedTopology is a deterministic topology mapping that creates a connected graph component among the nodes
 // involved in each topic.
 type TopicBasedTopology struct {


### PR DESCRIPTION
This PR addresses the `ghost` node topology impairment by decoupling the ghost node topology from the real node ones:

Proposed solution is to decouple the topology protocol of `ghost` nodes from other nodes: 
- A `ghost` node is running on a fully-connected topology, meaning it picks all nodes of the test as its fanout, regardless of its role and subscribed channels. This saves the ghost nodes from dealing with constraints governed by the `topic-based` topology regarding the valid roles. 
- All other nodes than `ghost` node are running on the default `topic-based` topology. 

# Context:

At the networking layer of Flow, we use a topology protocol to construct a P2P overlay network graph. Flow nodes use this overlay graph to disseminate epidemic messages through `publish` and `multicast`. 

The default topology of a Flow node is a `topic-based` topology that constructs a separate overlay graph per subscription channel on the pubsub overlay. On the other hand, solely for sake of testing, we have a `ghost` node role that subscribes to every pubsub channel so that it can send and receive message through arbitrary channels. 

This poses an issue with the topology construction:
(1) Some channels are known as cluster-based channels, where only certain roles can be part of, i.e., consensus and collection. 
(2) As part of its mission, a ghost node tries subscribing to _all channels_, including those cluster-based channels. 
(3) When a ghost node is running in any role than consensus or collection, it hits an error on subscribing to cluster-based channels. The reason is a node can only subscribe to the channel of its corresponding cluster. However, only consensus and collection nodes belong to a cluster. Hence, when a `ghost` node is running other than these two roles, it is not part of any cluster, and `topic-based` topology fails to construct its part of overlay graph (i.e., fanout) for cluster-based topics. Fanout generation is an all-or-nothing operation. Hence, if it fails for one channel, 
it fails for all channels of the node. In this situation the `ghost` node remains with no fanout. 

When a node does not have a fanout it cannot send or receive any message through the pubsub protocol. The connectivity of the networking overlay graph may also be damaged affected by zero-fanout nodes. Hence, `ghost` nodes running any role other than consensus or collection node end up with no fanout at all. Running multiple instances of such nodes may even disconnect the entire networking graph with several partitions, hence imparing the message delivery. 

# Evidence: 

Following log entry is taken from a `ghost` node running as an `execution` node. As the log shows, the node fails to generate any fanout for itself due an error while generating a cluster-based fanout subset. 

```
··· DOCK: (clogs ) execution_1               (3d7a5ccfd207cc8c0adc124454aa7b13add0dc2788761de535c0996cda2ebc4b) - �����={"level":"error","node_role":"ghost","node_id":"e416b0622dc4ec439a1c3b2054c643973b6ee3835b62c849d0d4561d3e48b4fc","error":"could not generate topology: could not generate fanout for topic consensus-cluster-cluster-0-1832762ff87fae977450ccbce106f00afee32fadfac40a2f7928ea5cd633dc7d: failed to find cluster peers for node e416b0622dc4ec439a1c3b2054c643973b6ee3835b62c849d0d4561d3e48b4fc: failed to find the cluster for node ID e416b0622dc4ec439a1c3b2054c643973b6ee3835b62c849d0d4561d3e48b4fc, subscribed: 12","time":"2022-01-21T00:46:11Z","message":"failed to update peers"}
```

This error message means that the ghost node is unable to generate fanout topology for itself. The fanout is the set of nodes that a node "talks" over the pub/sub overlay. Since the topology generation hits an error, the ghost node is left with "no fanout", hence cannot _talk_ with other nodes on pubsub and cannot receive messages. Further investigations show that this error _happens all the time even when the tests are passing!_. However, in those cases that the tests are passing, although the ghost node does not have any fanout, it is selected by other nodes of the system as part of their fanout. We found three cases for this situation that lead to different behavior: 
1. Ghost node does not have fanout, but it is selected by other nodes on _every_ channel it is subscribing to.
    - Tests are passing. 
    - This happens rarely in tests that have a super majority of ghost nodes. 
2. Ghost node does not have fanout, and it is not selected by _any_ node on channels it is subscribing to.
    - Happens frequently. 
    - Tests are failing, hence flaky behavior. 
3. Ghost node does not have fanout, and it is not selected by nodes on _some_ channels it is subscribing to.
    - Happens very often. 
    - Ghost node cannot receive messages from those channels it missed subscription.

