### PR TITLE
Add naive error logging for Access node downstream calls

### DIFF
--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -41,6 +42,7 @@ func (b *backendAccounts) GetAccountAtLatestBlock(ctx context.Context, address f
 
 	account, err := b.getAccountAtBlockID(ctx, address, latestBlockID)
 	if err != nil {
+		b.log.Error().Stack().Err(err).Msg(fmt.Sprintf("failed to get account at blockID: %v", latestBlockID))
 		return nil, err
 	}
 
@@ -89,6 +91,7 @@ func (b *backendAccounts) getAccountAtBlockID(
 	var exeRes *execproto.GetAccountAtBlockIDResponse
 	exeRes, err = b.getAccountFromAnyExeNode(ctx, execNodes, exeReq)
 	if err != nil {
+		b.log.Error().Stack().Err(err).Msg("")
 		return nil, err
 	}
 

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -42,7 +42,7 @@ func (b *backendAccounts) GetAccountAtLatestBlock(ctx context.Context, address f
 
 	account, err := b.getAccountAtBlockID(ctx, address, latestBlockID)
 	if err != nil {
-		b.log.Error().Stack().Err(err).Msg(fmt.Sprintf("failed to get account at blockID: %v", latestBlockID))
+		b.log.Error().Err(err).Msg(fmt.Sprintf("failed to get account at blockID: %v", latestBlockID))
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ func (b *backendAccounts) getAccountAtBlockID(
 	var exeRes *execproto.GetAccountAtBlockIDResponse
 	exeRes, err = b.getAccountFromAnyExeNode(ctx, execNodes, exeReq)
 	if err != nil {
-		b.log.Error().Stack().Err(err).Msg("")
+		b.log.Error().Err(err).Msg("failed to get account from execution nodes")
 		return nil, err
 	}
 
@@ -149,7 +149,7 @@ func (b *backendAccounts) getAccountFromAnyExeNode(ctx context.Context, execNode
 		}
 	}
 
-	// if all errors were codes.NotFound, then return a codes.NotFound error wrapping all those error
+	// if all errors were codes.NotFound, then return a codes.NotFound error wrapping all those errors
 	return nil, status.Errorf(codes.NotFound, "failed to get account from the execution node: %v", errToReturn)
 }
 

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -42,7 +41,7 @@ func (b *backendAccounts) GetAccountAtLatestBlock(ctx context.Context, address f
 
 	account, err := b.getAccountAtBlockID(ctx, address, latestBlockID)
 	if err != nil {
-		b.log.Error().Err(err).Msg(fmt.Sprintf("failed to get account at blockID: %v", latestBlockID))
+		b.log.Error().Err(err).Msgf("failed to get account at blockID: %v", latestBlockID)
 		return nil, err
 	}
 

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -128,7 +128,7 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 
 	execNodes, err := executionNodesForBlockID(ctx, lastBlockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
-		b.log.Error().Stack().Err(err).Msg("failed to retrieve events from execution node")
+		b.log.Error().Err(err).Msg("failed to retrieve events from execution node")
 		return nil, status.Errorf(codes.Internal, "failed to retrieve events from execution node: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 	var successfulNode *flow.Identity
 	resp, successfulNode, err = b.getEventsFromAnyExeNode(ctx, execNodes, req)
 	if err != nil {
-		b.log.Error().Stack().Err(err).Msg("failed to retrieve events from execution nodes")
+		b.log.Error().Err(err).Msg("failed to retrieve events from execution nodes")
 		return nil, status.Errorf(codes.Internal, "failed to retrieve events from execution nodes %s: %v", execNodes, err)
 	}
 	b.log.Trace().

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -128,6 +128,7 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 
 	execNodes, err := executionNodesForBlockID(ctx, lastBlockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
+		b.log.Error().Stack().Err(err).Msg("failed to retrieve events from execution node")
 		return nil, status.Errorf(codes.Internal, "failed to retrieve events from execution node: %v", err)
 	}
 
@@ -135,6 +136,7 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 	var successfulNode *flow.Identity
 	resp, successfulNode, err = b.getEventsFromAnyExeNode(ctx, execNodes, req)
 	if err != nil {
+		b.log.Error().Stack().Err(err).Msg("failed to retrieve events from execution nodes")
 		return nil, status.Errorf(codes.Internal, "failed to retrieve events from execution nodes %s: %v", execNodes, err)
 	}
 	b.log.Trace().

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -106,13 +106,17 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 		}
 		errors = multierror.Append(errors, err)
 	}
-	return nil, errors.ErrorOrNil()
+	errToReturn := errors.ErrorOrNil()
+	if errToReturn != nil {
+		b.log.Error().Stack().Err(err).Msg("Script execution failed for Nodes")
+	}
+	return nil, errToReturn
 }
 
 func (b *backendScripts) tryExecuteScript(ctx context.Context, execNode *flow.Identity, req execproto.ExecuteScriptAtBlockIDRequest) ([]byte, error) {
 	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to execute the script on the execution node %s: %v", execNode.String(), err)
+		return nil, status.Errorf(codes.Internal, "failed to create client for execution node %s: %v", execNode.String(), err)
 	}
 	defer closer.Close()
 	execResp, err := execRPCClient.ExecuteScriptAtBlockID(ctx, &req)

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -108,7 +108,7 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 	}
 	errToReturn := errors.ErrorOrNil()
 	if errToReturn != nil {
-		b.log.Error().Stack().Err(err).Msg("Script execution failed for Nodes")
+		b.log.Error().Err(err).Msg("script execution failed")
 	}
 	return nil, errToReturn
 }

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -469,6 +469,13 @@ func (b *backendTransactions) NotifyFinalizedBlockHeight(height uint64) {
 
 func (b *backendTransactions) getTransactionResultFromAnyExeNode(ctx context.Context, execNodes flow.IdentityList, req execproto.GetTransactionResultRequest) (*execproto.GetTransactionResultResponse, error) {
 	var errors *multierror.Error
+	logAnyError := func() {
+		errToReturn := errors.ErrorOrNil()
+		if errToReturn != nil {
+			b.log.Info().Err(errToReturn).Msg("failed to send transactions to collector nodes")
+		}
+	}
+	defer logAnyError()
 	// try to execute the script on one of the execution nodes
 	for _, execNode := range execNodes {
 		resp, err := b.tryGetTransactionResult(ctx, execNode, req)


### PR DESCRIPTION
- The engine seems to pass the `loggingInterceptor` correctly, I have removed the conditional check and included it last to ensure it is the innermost wrapper to the gRPC call. based on [this example](https://github.com/grpc-ecosystem/go-grpc-middleware/blob/880c1749170035e5a54794546dbfe0d45d10a11d/providers/zerolog/examples_test.go#L78-L105)
- I wasn't sure how to test the interceptor but saw that the backends pass around the log object that the interceptor wraps, so I added more naive error logging to all paths that make downstream calls, in case it still doesn't work