### PR TITLE
Add logs for MTrie checkpoint file creation

### DIFF
--- a/ledger/complete/wal/checkpointer.go
+++ b/ledger/complete/wal/checkpointer.go
@@ -185,10 +185,14 @@ func (c *Checkpointer) Checkpoint(to int, targetWriter func() (io.WriteCloser, e
 		return fmt.Errorf("cannot replay WAL: %w", err)
 	}
 
+	c.wal.log.Info().Msgf("flattening forest for checkpoint %d\n", to)
+
 	forestSequencing, err := flattener.FlattenForest(forest)
 	if err != nil {
 		return fmt.Errorf("cannot get storables: %w", err)
 	}
+
+	c.wal.log.Info().Msgf("serializing checkpoint %d\n", to)
 
 	writer, err := targetWriter()
 	if err != nil {

--- a/ledger/complete/wal/checkpointer.go
+++ b/ledger/complete/wal/checkpointer.go
@@ -185,14 +185,14 @@ func (c *Checkpointer) Checkpoint(to int, targetWriter func() (io.WriteCloser, e
 		return fmt.Errorf("cannot replay WAL: %w", err)
 	}
 
-	c.wal.log.Info().Msgf("flattening forest for checkpoint %d\n", to)
+	c.wal.log.Info().Msgf("flattening forest for checkpoint %d", to)
 
 	forestSequencing, err := flattener.FlattenForest(forest)
 	if err != nil {
 		return fmt.Errorf("cannot get storables: %w", err)
 	}
 
-	c.wal.log.Info().Msgf("serializing checkpoint %d\n", to)
+	c.wal.log.Info().Msgf("serializing checkpoint %d", to)
 
 	writer, err := targetWriter()
 	if err != nil {

--- a/ledger/complete/wal/compactor.go
+++ b/ledger/complete/wal/compactor.go
@@ -119,7 +119,7 @@ func (c *Compactor) createCheckpoints() (int, error) {
 		startTime := time.Now()
 
 		checkpointNumber := to - 1
-		c.logger.Info().Msgf("creating checkpoint %d from segment %d to segment %d\n", checkpointNumber, from, checkpointNumber)
+		c.logger.Info().Msgf("creating checkpoint %d from segment %d to segment %d", checkpointNumber, from, checkpointNumber)
 		err = c.checkpointer.Checkpoint(checkpointNumber, func() (io.WriteCloser, error) {
 			return c.checkpointer.CheckpointWriter(checkpointNumber)
 		})
@@ -129,7 +129,7 @@ func (c *Compactor) createCheckpoints() (int, error) {
 		newLatestCheckpoint = checkpointNumber
 
 		duration := time.Since(startTime)
-		c.logger.Info().Float64("total_time_s", duration.Seconds()).Msgf("created checkpoint %d from segment %d to segment %d\n", checkpointNumber, from, checkpointNumber)
+		c.logger.Info().Float64("total_time_s", duration.Seconds()).Msgf("created checkpoint %d from segment %d to segment %d", checkpointNumber, from, checkpointNumber)
 	}
 	return newLatestCheckpoint, nil
 }

--- a/ledger/complete/wal/compactor.go
+++ b/ledger/complete/wal/compactor.go
@@ -116,8 +116,10 @@ func (c *Compactor) createCheckpoints() (int, error) {
 	// more then one segment means we can checkpoint safely up to `to`-1
 	// presumably last segment is being written to
 	if to-from > int(c.checkpointDistance) {
+		startTime := time.Now()
+
 		checkpointNumber := to - 1
-		c.logger.Info().Msgf("creating a checkpoint from segment %d to segment %d\n", from, checkpointNumber)
+		c.logger.Info().Msgf("creating checkpoint %d from segment %d to segment %d\n", checkpointNumber, from, checkpointNumber)
 		err = c.checkpointer.Checkpoint(checkpointNumber, func() (io.WriteCloser, error) {
 			return c.checkpointer.CheckpointWriter(checkpointNumber)
 		})
@@ -125,6 +127,9 @@ func (c *Compactor) createCheckpoints() (int, error) {
 			return -1, fmt.Errorf("error creating checkpoint (%d): %w", checkpointNumber, err)
 		}
 		newLatestCheckpoint = checkpointNumber
+
+		duration := time.Since(startTime)
+		c.logger.Info().Float64("total_time_s", duration.Seconds()).Msgf("created checkpoint %d from segment %d to segment %d\n", checkpointNumber, from, checkpointNumber)
 	}
 	return newLatestCheckpoint, nil
 }

--- a/ledger/complete/wal/wal.go
+++ b/ledger/complete/wal/wal.go
@@ -281,7 +281,7 @@ func (w *DiskWAL) replay(
 		}
 	}
 
-	w.log.Debug().Msgf("finished replaying WAL from %d to %d", from, to)
+	w.log.Info().Msgf("finished replaying WAL from %d to %d", from, to)
 
 	return nil
 }


### PR DESCRIPTION
Updates #1884 #1750

Changes include:

Add more logs during checkpoint file creation.  Use INFO instead of DEBUG given the limited frequency and quantity of logs for checkpoint file creation.

These logs can be useful for detecting issues related to checkpoint creation.  E.g. the checkpoint duration log can be used by log monitoring programs to alert us if it exceeds a threshold.