### PR TITLE
Fix undefined: sha3State errors when building on arm64

### DIFF
--- a/crypto/hash/xor_generic.go
+++ b/crypto/hash/xor_generic.go
@@ -45,7 +45,7 @@ func (b *storageBuf) asBytes() *[maxRate]byte {
 // xorIn xors the bytes in buf into the state; it
 // makes no non-portable assumptions about memory layout
 // or alignment.
-func xorIn(d *sha3State, buf []byte) {
+func xorIn(d *spongeState, buf []byte) {
 	n := len(buf) / 8
 
 	for i := 0; i < n; i++ {
@@ -56,7 +56,7 @@ func xorIn(d *sha3State, buf []byte) {
 }
 
 // copyOut copies ulint64s to a byte buffer.
-func copyOut(b []byte, d *sha3State) {
+func copyOut(b []byte, d *spongeState) {
 	for i := 0; len(b) >= 8; i++ {
 		binary.LittleEndian.PutUint64(b, d.a[i])
 		b = b[8:]


### PR DESCRIPTION
After https://github.com/onflow/flow-go/pull/1865 was merged, we started seeing the following error while building flow on arm64 machines:
```
 => ERROR [build-production 2/3] RUN --mount=type=cache,target=/go/pkg/mod     --mount=type=cache,target=/root/.cache/go-build     GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build --tags "relic,netg  0.6s
------
 > [build-production 2/3] RUN --mount=type=cache,target=/go/pkg/mod     --mount=type=cache,target=/root/.cache/go-build     GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build --tags "relic,netgo" -ldflags "-extldflags -static     -X 'github.com/onflow/flow-go/cmd/build.commit=cedf6df37c81c5c82a199cd640aa0b503c5b96b7' -X  'github.com/onflow/flow-go/cmd/build.semver=v0.23.1-1557-gcedf6'"     -o ./app ./cmd/collection:
#21 0.593 # github.com/onflow/flow-go/crypto/hash
#21 0.593 crypto/hash/xor_generic.go:48:15: undefined: sha3State
#21 0.593 crypto/hash/xor_generic.go:59:27: undefined: sha3State
------
executor failed running [/bin/sh -c GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build --tags "relic,netgo" -ldflags "-extldflags -static     -X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' -X  'github.com/onflow/flow-go/cmd/build.semver=${VERSION}'"     -o ./app ./cmd/${TARGET}]: exit code: 2
make: *** [docker-build-collection] Error 1
```

This appears to be because the `sha3State` struct was replaced by `spongeState`, but the refactor missed this one file.