### PR TITLE
Allow registering custom node shutdown handlers

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -70,6 +70,11 @@ type NodeBuilder interface {
 	// and the node will wait for the component to exit gracefully.
 	Component(name string, f ReadyDoneFactory) NodeBuilder
 
+	// ShutdownFunc adds a callback function that is called after all components have exited.
+	// All shutdown functions are called regardless of errors returned by previous callbacks. Any
+	// errors returned are captured and passed to the caller.
+	ShutdownFunc(fn func() error) NodeBuilder
+
 	// AdminCommand registers a new admin command with the admin server
 	AdminCommand(command string, f func(config *NodeConfig) commands.AdminCommand) NodeBuilder
 

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1091,17 +1091,15 @@ func (fnb *FlowNodeBuilder) onStart() error {
 // postShutdown is called by the node before exiting
 // put any cleanup code here that should be run after all components have stopped
 func (fnb *FlowNodeBuilder) postShutdown() error {
+	// close the DBs last
+	fnb.ShutdownFunc(fnb.closeDatabase)
+
 	var errs *multierror.Error
 	for _, fn := range fnb.postShutdownFns {
 		err := fn()
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
-	}
-
-	err := fnb.closeDatabase()
-	if err != nil {
-		errs = multierror.Append(errs, err)
 	}
 
 	return errs.ErrorOrNil()

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1018,6 +1018,9 @@ func (fnb *FlowNodeBuilder) RegisterDefaultAdminCommands() {
 }
 
 func (fnb *FlowNodeBuilder) Build() (Node, error) {
+	// setup db close handlers to run last
+	fnb.ShutdownFunc(fnb.closeDatabase)
+
 	// Run the prestart initialization. This includes anything that should be done before
 	// starting the components.
 	if err := fnb.onStart(); err != nil {
@@ -1091,10 +1094,8 @@ func (fnb *FlowNodeBuilder) onStart() error {
 // postShutdown is called by the node before exiting
 // put any cleanup code here that should be run after all components have stopped
 func (fnb *FlowNodeBuilder) postShutdown() error {
-	// close the DBs last
-	fnb.ShutdownFunc(fnb.closeDatabase)
-
 	var errs *multierror.Error
+
 	for _, fn := range fnb.postShutdownFns {
 		err := fn()
 		if err != nil {

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -184,8 +184,13 @@ func TestPostShutdown(t *testing.T) {
 	nb := FlowNode("scaffold test")
 	nb.componentBuilder = component.NewComponentManagerBuilder()
 
-	nb.DB, _ = unittest.TempBadgerDB(t)
-	nb.SecretsDB, _ = unittest.TempBadgerDB(t)
+	var dbDir, secretsDBDir string
+	nb.DB, dbDir = unittest.TempBadgerDB(t)
+	nb.SecretsDB, secretsDBDir = unittest.TempBadgerDB(t)
+	defer func() {
+		_ = os.RemoveAll(dbDir)
+		_ = os.RemoveAll(secretsDBDir)
+	}()
 
 	logger := testLog{}
 

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -181,15 +181,6 @@ func TestComponentsRunSerially(t *testing.T) {
 
 func TestPostShutdown(t *testing.T) {
 	nb := FlowNode("scaffold test")
-	nb.componentBuilder = component.NewComponentManagerBuilder()
-
-	var dbDir, secretsDBDir string
-	nb.DB, dbDir = unittest.TempBadgerDB(t)
-	nb.SecretsDB, secretsDBDir = unittest.TempBadgerDB(t)
-	defer func() {
-		_ = os.RemoveAll(dbDir)
-		_ = os.RemoveAll(secretsDBDir)
-	}()
 
 	logger := testLog{}
 
@@ -215,7 +206,7 @@ func TestPostShutdown(t *testing.T) {
 
 	logs := logger.logs
 	assert.Len(t, logs, 3)
-	assert.ElementsMatch(t, []string{
+	assert.Equal(t, []string{
 		"shutdown 1",
 		"shutdown 2",
 		"shutdown 3",

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,11 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/cmd/bootstrap/utils"
-	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/component"
@@ -176,4 +177,43 @@ func TestComponentsRunSerially(t *testing.T) {
 		"component 2 done",
 		"component 3 done",
 	}, doneLogs)
+}
+
+func TestPostShutdown(t *testing.T) {
+
+	nb := FlowNode("scaffold test")
+	nb.componentBuilder = component.NewComponentManagerBuilder()
+
+	nb.DB, _ = unittest.TempBadgerDB(t)
+	nb.SecretsDB, _ = unittest.TempBadgerDB(t)
+
+	logger := testLog{}
+
+	err1 := errors.New("error 1")
+	err3 := errors.New("error 3")
+	errExpected := multierror.Append(&multierror.Error{}, err1, err3)
+	nb.
+		ShutdownFunc(func() error {
+			logger.Log("shutdown 1")
+			return err1
+		}).
+		ShutdownFunc(func() error {
+			logger.Log("shutdown 2")
+			return nil
+		}).
+		ShutdownFunc(func() error {
+			logger.Log("shutdown 3")
+			return err3
+		})
+
+	err := nb.postShutdown()
+	assert.EqualError(t, err, errExpected.Error())
+
+	logs := logger.logs
+	assert.Len(t, logs, 3)
+	assert.ElementsMatch(t, []string{
+		"shutdown 1",
+		"shutdown 2",
+		"shutdown 3",
+	}, logs)
 }

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -180,7 +180,6 @@ func TestComponentsRunSerially(t *testing.T) {
 }
 
 func TestPostShutdown(t *testing.T) {
-
 	nb := FlowNode("scaffold test")
 	nb.componentBuilder = component.NewComponentManagerBuilder()
 


### PR DESCRIPTION
Add a new method to scaffold that allows registering custom shutdown handlers to run after all components have stopped.