### PR TITLE
Fix ledger-heavy load generator

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -753,7 +753,7 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 			fvm.WithTransactionFeesEnabled(true),
 		)
 	}
-	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary {
+	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary || fnb.RootChainID == flow.Localnet {
 		vmOpts = append(vmOpts,
 			fvm.WithRestrictedDeployment(false),
 		)

--- a/integration/utils/scripts.go
+++ b/integration/utils/scripts.go
@@ -180,7 +180,7 @@ access(all) contract MyFavContract {
     }
 
     access(all) fun LedgerInteractionHeavy() {
-        MyFavContract.AddManyRandomItems(800)
+        MyFavContract.AddManyRandomItems(700)
     }
 }
 `


### PR DESCRIPTION
references: https://github.com/onflow/flow-go/issues/1931

Changes made:
- reduced ledger heavy interaction size because it was hitting the gas limit
- removed restricted contract deployment from the localnet
- added returning an error if the contract used for load testing fails to deploy