### PR TITLE
Fix flow-go failing to cross compile

### DIFF
--- a/crypto/thresholdsign.go
+++ b/crypto/thresholdsign.go
@@ -1,7 +1,5 @@
 package crypto
 
-import "C"
-
 import (
 	"errors"
 	"fmt"


### PR DESCRIPTION
The cli build failed when building for different architectures that the current one.

I am not sure why this fixes it, but it does.