### PR TITLE
remove sudo from crypto setup

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:1.17-bullseye AS build-setup
 
 RUN apt-get update
-RUN apt-get -y install cmake zip sudo
+RUN apt-get -y install cmake zip
 
 ## (2) Build the app binary
 FROM build-setup AS build-env

--- a/crypto/Dockerfile
+++ b/crypto/Dockerfile
@@ -2,8 +2,7 @@
 
 FROM golang:1.17-buster
 RUN apt-get update
-RUN apt-get -y install cmake zip sudo
+RUN apt-get -y install cmake zip
 RUN go get github.com/axw/gocov/gocov
 RUN go get github.com/matm/gocov-html
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 WORKDIR /go/src/flow

--- a/crypto/build_dependency.sh
+++ b/crypto/build_dependency.sh
@@ -8,7 +8,7 @@ RELIC_DIR="${PKG_DIR}/${RELIC_DIR_NAME}"
 
 # grant permissions if not existant
 if [[ ! -r ${PKG_DIR}  || ! -w ${PKG_DIR} || ! -x ${PKG_DIR} ]]; then
-   sudo chmod -R 755 "${PKG_DIR}"
+   chmod -R 755 "${PKG_DIR}"
 fi
 
 rm -rf "${RELIC_DIR}"

--- a/crypto_setup.sh
+++ b/crypto_setup.sh
@@ -22,7 +22,7 @@ fi
 
 # grant permissions if not existant
 if [[ ! -r ${PKG_DIR}  || ! -w ${PKG_DIR} || ! -x ${PKG_DIR} ]]; then
-   sudo chmod -R 755 "${PKG_DIR}"
+   chmod -R 755 "${PKG_DIR}"
 fi
 
 # get into the package directory and set up the external dependencies

--- a/integration/loader/Dockerfile
+++ b/integration/loader/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:1.17-buster AS build-setup
 
 RUN apt-get update
-RUN apt-get -y install cmake zip sudo
+RUN apt-get -y install cmake zip
 
 ## (1) Build Relic first to maximize caching
 FROM build-setup AS build-relic


### PR DESCRIPTION
- Remove `sudo` when using `chmod` to grant permissions to write under the `GOPATH`.
- update Docker images to drop `sudo`.