### PR TITLE
Limit range queries for sync engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following table lists all work streams and links to their home directory and
 
 ### Install Dependencies
 
-- Install [Go](https://golang.org/doc/install) (Flow supports Go 1.13 and later)
+- Install [Go](https://golang.org/doc/install) (Flow supports Go 1.16 and later)
 - Install [CMake](https://cmake.org/install/), which is used for building the crypto library
 - Install [Docker](https://docs.docker.com/get-docker/), which is used for running
   a local network and integration tests

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -4,7 +4,6 @@ package synchronization
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"time"
 
@@ -293,17 +292,11 @@ func (e *Engine) onSyncResponse(originID flow.Identifier, res *messages.SyncResp
 // onBlockResponse processes a response containing a specifically requested block.
 func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.BlockResponse) {
 	// process the blocks one by one
+	min := res.Blocks[0].Header.Height
+	max := res.Blocks[len(res.Blocks)-1].Header.Height
+	e.log.Debug().Uint64("min", min).Uint64("max", max).Msg("received block response")
 
-	min, max := uint64(math.MaxUint64), uint64(0)
 	for _, block := range res.Blocks {
-		if e.log.GetLevel() <= zerolog.DebugLevel {
-			if block.Header.Height > max {
-				max = block.Header.Height
-			}
-			if block.Header.Height < min {
-				min = block.Header.Height
-			}
-		}
 		if !e.core.HandleBlock(block.Header) {
 			e.log.Debug().Uint64("height", block.Header.Height).Msg("block handler rejected")
 			continue
@@ -314,7 +307,6 @@ func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.BlockRe
 		}
 		e.comp.SubmitLocal(synced)
 	}
-	e.log.Debug().Uint64("min", min).Uint64("max", max).Msg("received block response")
 }
 
 // checkLoop will regularly scan for items that need requesting.

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -292,6 +292,11 @@ func (e *Engine) onSyncResponse(originID flow.Identifier, res *messages.SyncResp
 // onBlockResponse processes a response containing a specifically requested block.
 func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.BlockResponse) {
 	// process the blocks one by one
+	if len(res.Blocks) == 0 {
+		e.log.Debug().Msg("received empty block response")
+		return
+	}
+
 	min := res.Blocks[0].Header.Height
 	max := res.Blocks[len(res.Blocks)-1].Header.Height
 	e.log.Debug().Uint64("min", min).Uint64("max", max).Msg("received block response")

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -297,9 +297,9 @@ func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.BlockRe
 		return
 	}
 
-	min := res.Blocks[0].Header.Height
-	max := res.Blocks[len(res.Blocks)-1].Header.Height
-	e.log.Debug().Uint64("min", min).Uint64("max", max).Msg("received block response")
+	first := res.Blocks[0].Header.Height
+	last := res.Blocks[len(res.Blocks)-1].Header.Height
+	e.log.Debug().Uint64("first", first).Uint64("last", last).Msg("received block response")
 
 	for _, block := range res.Blocks {
 		if !e.core.HandleBlock(block.Header) {

--- a/module/synchronization/core.go
+++ b/module/synchronization/core.go
@@ -105,6 +105,15 @@ func (c *Core) HandleHeight(final *flow.Header, height uint64) {
 	if height > final.Height {
 		c.mu.Lock()
 		defer c.mu.Unlock()
+
+		// limit to request up to 2*MaxSize blocks from the peer.
+		// without this limit, then if we are falling far behind,
+		// we would queue up too many heights.
+		heightLimit := final.Height + 2*uint64(c.Config.MaxSize)
+		if height > heightLimit {
+			height = heightLimit
+		}
+
 		for h := final.Height + 1; h <= height; h++ {
 			c.requeueHeight(h)
 		}


### PR DESCRIPTION
Limits requesting blocks rages to 2*max range size from latest finalized - this prevents spamming large amounts of requests for very distant blocks. Limit grows naturally with finalization spreading the load.