### PR TITLE
[Execution] Adding a pre and post script execution log

### DIFF
--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -133,6 +133,7 @@ func (e *Manager) ExecuteScript(code []byte, arguments [][]byte, blockHeader *fl
 
 	programs := e.getChildProgramsOrEmpty(blockHeader.ID())
 
+	e.log.Info().Hex("script_hex", code).Msg("script is sent for execution")
 	err := func() (err error) {
 
 		start := time.Now()

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -127,13 +128,19 @@ func (e *Manager) ExecuteScript(code []byte, arguments [][]byte, blockHeader *fl
 
 	startedAt := time.Now()
 
+	trackerID := rand.Uint32()
+	e.log.Info().Hex("script_hex", code).Uint32("trackerID", trackerID).Msg("script is sent for execution")
+
+	defer func() {
+		e.log.Info().Uint32("trackerID", trackerID).Msg("script execution is complete")
+	}()
+
 	blockCtx := fvm.NewContextFromParent(e.vmCtx, fvm.WithBlockHeader(blockHeader))
 
 	script := fvm.Script(code).WithArguments(arguments...)
 
 	programs := e.getChildProgramsOrEmpty(blockHeader.ID())
 
-	e.log.Info().Hex("script_hex", code).Msg("script is sent for execution")
 	err := func() (err error) {
 
 		start := time.Now()

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -128,6 +128,9 @@ func (e *Manager) ExecuteScript(code []byte, arguments [][]byte, blockHeader *fl
 
 	startedAt := time.Now()
 
+	// allocate a random ID to be able to track this script when its done,
+	// scripts might not be unique so we use this extra tracker to follow their logs
+	// TODO: this is a temporary measure, we could remove this in the future
 	trackerID := rand.Uint32()
 	e.log.Info().Hex("script_hex", code).Uint32("trackerID", trackerID).Msg("script is sent for execution")
 


### PR DESCRIPTION
Adding a pre/post-script execution logs helps to debug in case a bad script is sent.