### PR TITLE
adding status_code to transaction result response in the REST API

### DIFF
--- a/engine/access/rest/models/model_transaction_result.go
+++ b/engine/access/rest/models/model_transaction_result.go
@@ -13,6 +13,8 @@ type TransactionResult struct {
 
 	Status *TransactionStatus `json:"status"`
 
+	StatusCode int32 `json:"status_code"`
+
 	ErrorMessage string `json:"error_message"`
 
 	ComputationUsed string `json:"computation_used"`

--- a/engine/access/rest/models/transaction.go
+++ b/engine/access/rest/models/transaction.go
@@ -96,6 +96,7 @@ func (t *TransactionResult) Build(txr *access.TransactionResult, txID flow.Ident
 	}
 
 	t.Status = &status
+	t.StatusCode = int32(txr.StatusCode)
 	t.ErrorMessage = txr.ErrorMessage
 	t.ComputationUsed = util.FromUint64(0)
 	t.Events = events

--- a/engine/access/rest/transactions_test.go
+++ b/engine/access/rest/transactions_test.go
@@ -165,6 +165,7 @@ func TestGetTransactions(t *testing.T) {
 				"result": {
 					"block_id": "%s",
 					"status": "Sealed",
+					"status_code": 1,
 					"error_message": "",
 					"computation_used": "0",
 					"events": [
@@ -236,6 +237,7 @@ func TestGetTransactionResult(t *testing.T) {
 		expected := fmt.Sprintf(`{
 			"block_id": "%s",
 			"status": "Executed",
+			"status_code": 10,
 			"error_message": "",
 			"computation_used": "0",
 			"events": [


### PR DESCRIPTION
closes: https://github.com/dapperlabs/flow-go/issues/6133

Corresponding change to the Open API spec: https://github.com/onflow/flow/pull/802