### PR TITLE
Allow bench-net permissionless contract deployment

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -766,7 +766,7 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 			fvm.WithTransactionFeesEnabled(true),
 		)
 	}
-	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary || fnb.RootChainID == flow.Localnet {
+	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary || fnb.RootChainID == flow.Localnet || fnb.RootChainID == flow.Benchnet {
 		vmOpts = append(vmOpts,
 			fvm.WithRestrictedDeployment(false),
 		)


### PR DESCRIPTION
ref: https://github.com/onflow/flow-go/issues/1931

During fix https://github.com/onflow/flow-go/pull/1933 I have forgotten that bench-net is a separate network. Permissionless contract deployment needs to be enabled there too. 