### PR TITLE
Porting over PR - fix flag validation for access nodes #1966

### DIFF
--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -10,7 +10,9 @@ func main() {
 	anb.PrintBuildVersionDetails()
 
 	// parse all the command line args
-	anb.ParseFlags()
+	if err := anb.ParseFlags(); err != nil {
+		anb.Logger.Fatal().Err(err).Send()
+	}
 
 	// choose a staked or an unstaked node builder based on anb.staked
 	var nodeBuilder nodebuilder.AccessNodeBuilder

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -409,14 +409,13 @@ func (builder *FlowAccessNodeBuilder) IsStaked() bool {
 	return builder.staked
 }
 
-func (builder *FlowAccessNodeBuilder) ParseFlags() {
+func (builder *FlowAccessNodeBuilder) ParseFlags() error {
 
 	builder.BaseFlags()
 
 	builder.extraFlags()
 
-	builder.ParseAndPrintFlags()
-
+	return builder.ParseAndPrintFlags()
 }
 
 func (builder *FlowAccessNodeBuilder) extraFlags() {

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -40,7 +40,7 @@ type NodeBuilder interface {
 	ExtraFlags(f func(*pflag.FlagSet)) NodeBuilder
 
 	// ParseAndPrintFlags parses all the command line arguments
-	ParseAndPrintFlags()
+	ParseAndPrintFlags() error
 
 	// Initialize performs all the initialization needed at the very start of a node
 	Initialize() error

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -39,7 +39,7 @@ type NodeBuilder interface {
 	// ExtraFlags reads the node specific command line arguments and adds it to the FlagSet
 	ExtraFlags(f func(*pflag.FlagSet)) NodeBuilder
 
-	// ParseAndPrintFlags parses all the command line arguments
+	// ParseAndPrintFlags parses and validates all the command line arguments
 	ParseAndPrintFlags() error
 
 	// Initialize performs all the initialization needed at the very start of a node
@@ -100,7 +100,7 @@ type NodeBuilder interface {
 	// RegisterBadgerMetrics registers all badger related metrics
 	RegisterBadgerMetrics() error
 
-	// ValidateFlags is an extra method called after parsing flags, intended for extra check of flag validity
+	// ValidateFlags sets any custom validation rules for the command line flags,
 	// for example where certain combinations aren't allowed
 	ValidateFlags(func() error) NodeBuilder
 }

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -334,7 +334,7 @@ func (fnb *FlowNodeBuilder) EnqueueTracer() {
 	})
 }
 
-func (fnb *FlowNodeBuilder) ParseAndPrintFlags() {
+func (fnb *FlowNodeBuilder) ParseAndPrintFlags() error {
 	// parse configuration parameters
 	pflag.Parse()
 
@@ -346,6 +346,8 @@ func (fnb *FlowNodeBuilder) ParseAndPrintFlags() {
 	})
 
 	log.Msg("flags loaded")
+
+	return fnb.extraFlagsValidation()
 }
 
 func (fnb *FlowNodeBuilder) ValidateFlags(f func() error) NodeBuilder {
@@ -1013,9 +1015,7 @@ func (fnb *FlowNodeBuilder) Initialize() error {
 
 	fnb.BaseFlags()
 
-	fnb.ParseAndPrintFlags()
-
-	if err := fnb.extraFlagsValidation(); err != nil {
+	if err := fnb.ParseAndPrintFlags(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Porting over commits from this [PR](https://github.com/onflow/flow-go/pull/1966/commits) for tomorrow's mainnet spork
git cherry-pick 214e723349760dede23b61a0a572431550c1fe13
git cherry-pick 5fc5ced08a0d2c48e3a0039546f298089f0158a8
