### PR TITLE
Fix bootstrap cluster qc generation

### DIFF
--- a/cmd/bootstrap/cmd/clusters.go
+++ b/cmd/bootstrap/cmd/clusters.go
@@ -59,7 +59,7 @@ func constructRootQCsForClusters(
 	for i, cluster := range clusterList {
 		signers := filterClusterSigners(cluster, nodeInfos)
 
-		qc, err := run.GenerateClusterRootQC(signers, clusterBlocks[i])
+		qc, err := run.GenerateClusterRootQC(signers, cluster, clusterBlocks[i])
 		if err != nil {
 			log.Fatal().Err(err).Int("cluster index", i).Msg("generating collector cluster root QC failed")
 		}

--- a/cmd/bootstrap/run/cluster_qc.go
+++ b/cmd/bootstrap/run/cluster_qc.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GenerateClusterRootQC creates votes and generates a QC based on participant data
-func GenerateClusterRootQC(participants []bootstrap.NodeInfo, clusterBlock *cluster.Block) (*flow.QuorumCertificate, error) {
+func GenerateClusterRootQC(signers []bootstrap.NodeInfo, allCommitteeMembers flow.IdentityList, clusterBlock *cluster.Block) (*flow.QuorumCertificate, error) {
 	clusterRootBlock := &model.Block{
 		BlockID:     clusterBlock.ID(),
 		View:        clusterBlock.Header.View,
@@ -30,14 +30,13 @@ func GenerateClusterRootQC(participants []bootstrap.NodeInfo, clusterBlock *clus
 	}
 
 	// STEP 1: create votes for cluster root block
-	votes, err := createRootBlockVotes(participants, clusterRootBlock)
+	votes, err := createRootBlockVotes(signers, clusterRootBlock)
 	if err != nil {
 		return nil, err
 	}
 
 	// STEP 2: create VoteProcessor
-	identities := bootstrap.ToIdentityList(participants)
-	committee, err := committees.NewStaticCommittee(identities, flow.Identifier{}, nil, nil)
+	committee, err := committees.NewStaticCommittee(allCommitteeMembers, flow.Identifier{}, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bootstrap/run/cluster_qc_test.go
+++ b/cmd/bootstrap/run/cluster_qc_test.go
@@ -32,7 +32,7 @@ func TestGenerateClusterRootQC(t *testing.T) {
 	payload := cluster.EmptyPayload(flow.ZeroID)
 	clusterBlock.SetPayload(payload)
 
-	_, err := GenerateClusterRootQC(participants, &clusterBlock)
+	_, err := GenerateClusterRootQC(participants, model.ToIdentityList(participants), &clusterBlock)
 	require.NoError(t, err)
 }
 

--- a/engine/collection/test/cluster_switchover_test.go
+++ b/engine/collection/test/cluster_switchover_test.go
@@ -70,7 +70,7 @@ func NewClusterSwitchoverTestCase(t *testing.T, conf ClusterSwitchoverTestConf) 
 				signers = append(signers, identity)
 			}
 		}
-		qc, err := run.GenerateClusterRootQC(signers, rootClusterBlocks[i])
+		qc, err := run.GenerateClusterRootQC(signers, model.ToIdentityList(signers), rootClusterBlocks[i])
 		require.NoError(t, err)
 		rootClusterQCs[i] = flow.ClusterQCVoteDataFromQC(qc)
 	}
@@ -133,7 +133,7 @@ func NewClusterSwitchoverTestCase(t *testing.T, conf ClusterSwitchoverTestConf) 
 			// generate root cluster block
 			rootClusterBlock := cluster.CanonicalRootBlock(commit.Counter, model.ToIdentityList(signers))
 			// generate cluster root qc
-			qc, err := run.GenerateClusterRootQC(signers, rootClusterBlock)
+			qc, err := run.GenerateClusterRootQC(signers, model.ToIdentityList(signers), rootClusterBlock)
 			require.NoError(t, err)
 			commit.ClusterQCs[i] = flow.ClusterQCVoteDataFromQC(qc)
 		}

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1278,7 +1278,7 @@ func setupClusterGenesisBlockQCs(nClusters uint, epochCounter uint64, confs []Co
 		}
 
 		// generate qc for root cluster block
-		qc, err := run.GenerateClusterRootQC(participants, block)
+		qc, err := run.GenerateClusterRootQC(participants, bootstrap.ToIdentityList(participants), block)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Previously we passed in only node infos for which we had private keys (internal nodes) to generate the cluster QCs. The previous logic would make use of all nodes to produce a QC.

With changes in Consensus V2, this logic now only uses 2/3 of these node votes (assuming the passed in list is the full cluster committee), which causes QC generation failure in the presence of partners.

This commit separately provides the cluster signers and the full cluster committee.