### PR TITLE
Fix race in epoch switchover handling

### DIFF
--- a/engine/collection/epochmgr/engine.go
+++ b/engine/collection/epochmgr/engine.go
@@ -192,7 +192,7 @@ func (e *Engine) Ready() <-chan struct{} {
 		finalSnapshot := e.state.Final()
 		phase, err := finalSnapshot.Phase()
 		if err != nil {
-			e.log.Error().Err(err).Msg("could not check phase")
+			e.log.Fatal().Err(err).Msg("could not check phase")
 			return
 		}
 		if phase == flow.EpochPhaseSetup {

--- a/engine/collection/epochmgr/engine.go
+++ b/engine/collection/epochmgr/engine.go
@@ -189,13 +189,16 @@ func (e *Engine) Ready() <-chan struct{} {
 	}, func() {
 		// check the current phase on startup, in case we are in setup phase
 		// and haven't yet voted for the next root QC
-		phase, err := e.state.Final().Phase()
+		finalSnapshot := e.state.Final()
+		phase, err := finalSnapshot.Phase()
 		if err != nil {
 			e.log.Error().Err(err).Msg("could not check phase")
 			return
 		}
 		if phase == flow.EpochPhaseSetup {
-			e.unit.Launch(e.onEpochSetupPhaseStarted)
+			e.unit.Launch(func() {
+				e.onEpochSetupPhaseStarted(finalSnapshot.Epochs().Next())
+			})
 		}
 	})
 }
@@ -241,8 +244,11 @@ func (e *Engine) EpochTransition(_ uint64, first *flow.Header) {
 }
 
 // EpochSetupPhaseStarted handles the epoch setup phase started protocol event.
-func (e *Engine) EpochSetupPhaseStarted(_ uint64, _ *flow.Header) {
-	e.unit.Launch(e.onEpochSetupPhaseStarted)
+func (e *Engine) EpochSetupPhaseStarted(_ uint64, first *flow.Header) {
+	e.unit.Launch(func() {
+		nextEpoch := e.state.AtBlockID(first.ID()).Epochs().Next()
+		e.onEpochSetupPhaseStarted(nextEpoch)
+	})
 }
 
 // onEpochTransition is called when we transition to a new epoch. It arranges
@@ -251,7 +257,7 @@ func (e *Engine) onEpochTransition(first *flow.Header) error {
 	e.unit.Lock()
 	defer e.unit.Unlock()
 
-	epoch := e.state.Final().Epochs().Current()
+	epoch := e.state.AtBlockID(first.ID()).Epochs().Current()
 	counter, err := epoch.Counter()
 	if err != nil {
 		return fmt.Errorf("could not get epoch counter: %w", err)
@@ -262,8 +268,8 @@ func (e *Engine) onEpochTransition(first *flow.Header) error {
 	lastEpochMaxHeight := first.Height - 1
 
 	log := e.log.With().
-		Uint64("epoch_max_height", lastEpochMaxHeight).
-		Uint64("epoch_counter", counter).
+		Uint64("last_epoch_max_height", lastEpochMaxHeight).
+		Uint64("cur_epoch_counter", counter).
 		Logger()
 
 	// exit early and log if the epoch already exists
@@ -318,13 +324,13 @@ func (e *Engine) prepareToStopEpochComponents(epochCounter, epochMaxHeight uint6
 	stopAtHeight := epochMaxHeight + flow.DefaultTransactionExpiry + 1
 
 	log := e.log.With().
-		Uint64("epoch_max_height", epochMaxHeight).
-		Uint64("epoch_counter", epochCounter).
+		Uint64("stopping_epoch_max_height", epochMaxHeight).
+		Uint64("stopping_epoch_counter", epochCounter).
 		Uint64("stop_at_height", stopAtHeight).
 		Str("step", "epoch_transition").
 		Logger()
 
-	log.Debug().Msgf("preparing to stop epoch components at height %d", stopAtHeight)
+	log.Info().Msgf("preparing to stop epoch components at height %d", stopAtHeight)
 
 	e.heightEvents.OnHeight(stopAtHeight, func() {
 		e.unit.Launch(func() {
@@ -348,13 +354,11 @@ func (e *Engine) prepareToStopEpochComponents(epochCounter, epochMaxHeight uint6
 // setup phase, or when the node is restarted during the epoch setup phase. It
 // kicks off setup tasks for the phase, in particular submitting a vote for the
 // next epoch's root cluster QC.
-func (e *Engine) onEpochSetupPhaseStarted() {
-
-	epoch := e.state.Final().Epochs().Next()
+func (e *Engine) onEpochSetupPhaseStarted(nextEpoch protocol.Epoch) {
 
 	ctx, cancel := context.WithCancel(e.unit.Ctx())
 	defer cancel()
-	err := e.voter.Vote(ctx, epoch)
+	err := e.voter.Vote(ctx, nextEpoch)
 	if err != nil {
 		e.log.Error().Err(err).Msg("failed to submit QC vote for next epoch")
 	}

--- a/engine/collection/epochmgr/engine_test.go
+++ b/engine/collection/epochmgr/engine_test.go
@@ -259,7 +259,10 @@ func (suite *Suite) TestRespondToPhaseChange() {
 			called = true
 		}).Once()
 
-	suite.engine.EpochSetupPhaseStarted(0, nil)
+	first := unittest.BlockHeaderFixture()
+	suite.state.On("AtBlockID", first.ID()).Return(suite.snap)
+
+	suite.engine.EpochSetupPhaseStarted(0, &first)
 	suite.Assert().Eventually(func() bool {
 		return called
 	}, time.Second, time.Millisecond)
@@ -276,6 +279,7 @@ func (suite *Suite) TestRespondToEpochTransition() {
 	unittest.AssertClosesBefore(suite.T(), suite.engine.Ready(), time.Second)
 
 	first := unittest.BlockHeaderFixture()
+	suite.state.On("AtBlockID", first.ID()).Return(suite.snap)
 
 	// should set up callback for height at which previous epoch expires
 	var expiryCallback func()


### PR DESCRIPTION
There is a race in `epochmgr` when responding to epoch transition events, because the event handler used `state.Final` rather than `state.AtBlockID` with the block ID in the event. More details in [testing doc](https://www.notion.so/dapperlabs/Test-21-Dynamic-Startup-Collection-Node-d0bf044632fe4ab78e5c814b78d853b1#8fa9538d5c094ea089ac57dd99814d66)