### PR TITLE
potential bug?

### DIFF
--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -276,6 +276,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				require.Empty(t, cr.TransactionResults[0].ErrorMessage)
 				require.Empty(t, cr.TransactionResults[1].ErrorMessage)
 				require.Empty(t, cr.TransactionResults[2].ErrorMessage)
+				require.Empty(t, cr.TransactionResults[3].ErrorMessage)
 
 				var deposits []flow.Event
 				var withdraws []flow.Event


### PR DESCRIPTION
I was looking into reproducing https://github.com/onflow/cadence/issues/1367 when I found that the test I was modeling off of throws an error that might be overlooked.

```
=== RUN   TestTransactionFeeDeduction/Transaction_Fees_without_storage_0:_Transaction_fee_deduction_emits_events
    execution_verification_test.go:279: 
        	Error Trace:	execution_verification_test.go:279
        	            				execution_verification_test.go:583
        	Error:      	Should be empty, but was [Error Code: 1101] cadence runtime error Execution failed:
        	            	error: cannot find declaration `FlowEpoch` in `8624b52f9ddcd04a.FlowEpoch`
        	            	 --> b4fc3d14db4df4040e530f63d9debbecab0a587e20a039320e286d42261522e5:2:7
        	            	  |
        	            	2 | import FlowEpoch from 0x8624b52f9ddcd04a
        	            	  |        ^^^^^^^^^ available exported declarations are:
        	            	
        	            	
        	            	error: cannot infer type parameter: `T`
        	            	 --> b4fc3d14db4df4040e530f63d9debbecab0a587e20a039320e286d42261522e5:6:17
        	            	  |
        	            	6 | 	let heartbeat = serviceAccount.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath)
        	            	  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        	Test:       	TestTransactionFeeDeduction/Transaction_Fees_without_storage_0:_Transaction_fee_deduction_emits_events
    --- FAIL: TestTransactionFeeDeduction/Transaction_Fees_without_storage_0:_Transaction_fee_deduction_emits_events (0.17s)
```