### PR TITLE
[Consensus] SignerIndices Optimization Interface changes

### DIFF
--- a/consensus/hotstuff/blockproducer/block_producer.go
+++ b/consensus/hotstuff/blockproducer/block_producer.go
@@ -33,7 +33,7 @@ func (bp *BlockProducer) MakeBlockProposal(qc *flow.QuorumCertificate, view uint
 	// in hotstuff, we use this for view number and signature-related fields
 	setHotstuffFields := func(header *flow.Header) error {
 		header.View = view
-		header.ParentVoterIDs = qc.SignerIDs
+		header.ParentVoterIndices = qc.SignerIndices
 		header.ParentVoterSigData = qc.SigData
 		header.ProposerID = bp.committee.Self()
 

--- a/consensus/hotstuff/committee.go
+++ b/consensus/hotstuff/committee.go
@@ -24,6 +24,7 @@ type Committee interface {
 	//   * is ordered in the canonical order
 	//   * contains no duplicates.
 	// The list of all legitimate HotStuff participants for the specified block can be obtained by using `filter.Any`
+	// TODO: selector can be removed
 	Identities(blockID flow.Identifier, selector flow.IdentityFilter) (flow.IdentityList, error)
 
 	// Identity returns the full Identity for specified HotStuff participant.
@@ -31,6 +32,8 @@ type Committee interface {
 	// ERROR conditions:
 	//  * model.InvalidSignerError if participantID does NOT correspond to a _staked_ HotStuff participant at the specified block.
 	Identity(blockID flow.Identifier, participantID flow.Identifier) (*flow.Identity, error)
+
+	IdentitiesByIndices(blockID flow.Identifier, indices []int) (flow.IdentityList, error)
 
 	// LeaderForView returns the identity of the leader for a given view.
 	// CAUTION: per liveness requirement of HotStuff, the leader must be fork-independent.

--- a/consensus/hotstuff/committees/consensus_committee.go
+++ b/consensus/hotstuff/committees/consensus_committee.go
@@ -68,12 +68,13 @@ func NewConsensusCommittee(state protocol.State, me flow.Identifier) (*Consensus
 	return com, nil
 }
 
-func (c *Consensus) Identities(blockID flow.Identifier, selector flow.IdentityFilter) (flow.IdentityList, error) {
-	il, err := c.state.AtBlockID(blockID).Identities(filter.And(
-		filter.IsVotingConsensusCommitteeMember,
-		selector,
-	))
+func (c *Consensus) Identities(blockID flow.Identifier) (flow.IdentityList, error) {
+	il, err := c.state.AtBlockID(blockID).Identities(filter.IsVotingConsensusCommitteeMember)
 	return il, err
+}
+
+func (c *Consensus) IdentitiesByIndices(blockID flow.Identifier, indices []int) (flow.IdentityList, error) {
+	panic("to be implemented")
 }
 
 func (c *Consensus) Identity(blockID flow.Identifier, nodeID flow.Identifier) (*flow.Identity, error) {

--- a/consensus/hotstuff/helper/block.go
+++ b/consensus/hotstuff/helper/block.go
@@ -44,9 +44,10 @@ func WithParentBlock(parent *model.Block) func(*model.Block) {
 	}
 }
 
-func WithParentSigners(signerIDs []flow.Identifier) func(*model.Block) {
+// TODO: to fix
+func WithParentSigners(signerIndices []flow.Identifier) func(*model.Block) {
 	return func(block *model.Block) {
-		block.QC.SignerIDs = signerIDs
+		block.QC.SignerIndices = nil
 	}
 }
 

--- a/consensus/hotstuff/helper/quorum_certificate.go
+++ b/consensus/hotstuff/helper/quorum_certificate.go
@@ -10,10 +10,10 @@ import (
 
 func MakeQC(options ...func(*flow.QuorumCertificate)) *flow.QuorumCertificate {
 	qc := flow.QuorumCertificate{
-		View:      rand.Uint64(),
-		BlockID:   unittest.IdentifierFixture(),
-		SignerIDs: unittest.IdentityListFixture(7).NodeIDs(),
-		SigData:   unittest.SignatureFixture(),
+		View:          rand.Uint64(),
+		BlockID:       unittest.IdentifierFixture(),
+		SignerIndices: unittest.SignerIndicesFixture(3),
+		SigData:       unittest.SignatureFixture(),
 	}
 	for _, option := range options {
 		option(&qc)
@@ -30,7 +30,8 @@ func WithQCBlock(block *model.Block) func(*flow.QuorumCertificate) {
 
 func WithQCSigners(signerIDs []flow.Identifier) func(*flow.QuorumCertificate) {
 	return func(qc *flow.QuorumCertificate) {
-		qc.SignerIDs = signerIDs
+		// TODO: fix
+		qc.SignerIndices = nil
 	}
 }
 

--- a/consensus/hotstuff/model/block.go
+++ b/consensus/hotstuff/model/block.go
@@ -21,10 +21,10 @@ type Block struct {
 func BlockFromFlow(header *flow.Header, parentView uint64) *Block {
 
 	qc := flow.QuorumCertificate{
-		BlockID:   header.ParentID,
-		View:      parentView,
-		SignerIDs: header.ParentVoterIDs,
-		SigData:   header.ParentVoterSigData,
+		BlockID:       header.ParentID,
+		View:          parentView,
+		SignerIndices: header.ParentVoterIndices,
+		SigData:       header.ParentVoterSigData,
 	}
 
 	block := Block{

--- a/consensus/hotstuff/model/proposal.go
+++ b/consensus/hotstuff/model/proposal.go
@@ -44,7 +44,7 @@ func ProposalToFlow(proposal *Proposal) *flow.Header {
 		PayloadHash:        block.PayloadHash,
 		Timestamp:          block.Timestamp,
 		View:               block.View,
-		ParentVoterIDs:     block.QC.SignerIDs,
+		ParentVoterIndices: block.QC.SignerIndices,
 		ParentVoterSigData: block.QC.SigData,
 		ProposerID:         block.ProposerID,
 		ProposerSigData:    proposal.SigData,

--- a/consensus/hotstuff/packer/indices.go
+++ b/consensus/hotstuff/packer/indices.go
@@ -1,0 +1,9 @@
+package packer
+
+func DecodeSignerIndices(indices []byte) ([]int, error) {
+	panic("to be implemented")
+}
+
+func EncodeSignerIndices(indices []int, count int) []byte {
+	panic("to be implemented")
+}

--- a/consensus/hotstuff/signature.go
+++ b/consensus/hotstuff/signature.go
@@ -124,7 +124,7 @@ type Packer interface {
 	// sig is the aggregated signature data.
 	// Expected error returns during normal operations:
 	//  * none; all errors are symptoms of inconsistent input data or corrupted internal state.
-	Pack(blockID flow.Identifier, sig *BlockSignatureData) ([]flow.Identifier, []byte, error)
+	Pack(blockID flow.Identifier, sig *BlockSignatureData) ([]byte, []byte, error)
 
 	// Unpack de-serializes the provided signature data.
 	// blockID is the block that the aggregated sig is signed for

--- a/consensus/hotstuff/signature/packer.go
+++ b/consensus/hotstuff/signature/packer.go
@@ -29,7 +29,7 @@ func NewConsensusSigDataPacker(committees hotstuff.Committee) *ConsensusSigDataP
 // To pack the block signature data, we first build a compact data type, and then encode it into bytes.
 // Expected error returns during normal operations:
 //  * none; all errors are symptoms of inconsistent input data or corrupted internal state.
-func (p *ConsensusSigDataPacker) Pack(blockID flow.Identifier, sig *hotstuff.BlockSignatureData) ([]flow.Identifier, []byte, error) {
+func (p *ConsensusSigDataPacker) Pack(blockID flow.Identifier, sig *hotstuff.BlockSignatureData) ([]byte, []byte, error) {
 	// breaking staking and random beacon signers into signerIDs and sig type for compaction
 	// each signer must have its signerID and sig type stored at the same index in the two slices
 	count := len(sig.StakingSigners) + len(sig.RandomBeaconSigners)
@@ -85,7 +85,8 @@ func (p *ConsensusSigDataPacker) Pack(blockID flow.Identifier, sig *hotstuff.Blo
 		return nil, nil, fmt.Errorf("could not encode data %v, %w", data, err)
 	}
 
-	return signerIDs, encoded, nil
+	// return signerIDs, encoded, nil
+	panic(fmt.Sprintf("%v to be implemented", encoded))
 }
 
 // Unpack de-serializes the provided signature data.

--- a/consensus/hotstuff/validator/validator.go
+++ b/consensus/hotstuff/validator/validator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/consensus/hotstuff/packer"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 )
@@ -46,13 +47,24 @@ func (v *Validator) ValidateQC(qc *flow.QuorumCertificate, block *model.Block) e
 
 	// Retrieve full Identities of all legitimate consensus participants and the Identities of the qc's signers
 	// IdentityList returned by hotstuff.Committee contains only legitimate consensus participants for the specified block (must have positive stake)
+	// TODO: filter.Any can be removed
+	// TODO: we query allParticipants only to get the TotalStake, we could query committee for TotalStake directly,
+	// and commitee could cache the total stake. But caching the total stake for a block won't save us too much.
+	// Instead, caching total stake by view would be used more often, because the total stake is fixed when the committee
+	// of epoch is fixed, and the epoch is determined by a view range. so we can easy find the epoch by view range.
 	allParticipants, err := v.committee.Identities(block.BlockID, filter.Any)
 	if err != nil {
 		return fmt.Errorf("could not get consensus participants for block %s: %w", block.BlockID, err)
 	}
-	signers := allParticipants.Filter(filter.HasNodeID(qc.SignerIDs...)) // resulting IdentityList contains no duplicates
-	if len(signers) != len(qc.SignerIDs) {
-		return newInvalidBlockError(block, model.NewInvalidSignerErrorf("some qc signers are duplicated or invalid consensus participants at block %x", block.BlockID))
+
+	signerIndices, err := packer.DecodeSignerIndices(qc.SignerIndices)
+	if err != nil {
+		return newInvalidBlockError(block, fmt.Errorf("qc.SignerIndices is invalid: %w", err))
+	}
+
+	signers, err := v.committee.IdentitiesByIndices(block.BlockID, signerIndices)
+	if err != nil {
+		return fmt.Errorf("could not get signers by indices: %w", err)
 	}
 
 	// determine whether signers reach minimally required stake threshold for consensus

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
@@ -256,7 +256,7 @@ func (p *CombinedVoteProcessorV2) Process(vote *model.Vote) error {
 
 	p.log.Info().
 		Uint64("view", qc.View).
-		Int("num_signers", len(qc.SignerIDs)).
+		// Int("num_signers", len(qc.SignerIndices)).
 		Msg("new qc has been created")
 
 	p.onQCCreated(qc)
@@ -307,15 +307,15 @@ func buildQCWithPackerAndSigData(
 	block *model.Block,
 	blockSigData *hotstuff.BlockSignatureData,
 ) (*flow.QuorumCertificate, error) {
-	signerIDs, sigData, err := packer.Pack(block.BlockID, blockSigData)
+	signerIndices, sigData, err := packer.Pack(block.BlockID, blockSigData)
 	if err != nil {
 		return nil, fmt.Errorf("could not pack the block sig data: %w", err)
 	}
 
 	return &flow.QuorumCertificate{
-		View:      block.View,
-		BlockID:   block.BlockID,
-		SignerIDs: signerIDs,
-		SigData:   sigData,
+		View:          block.View,
+		BlockID:       block.BlockID,
+		SignerIndices: signerIndices,
+		SigData:       sigData,
 	}, nil
 }

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
@@ -254,7 +254,7 @@ func (p *CombinedVoteProcessorV3) Process(vote *model.Vote) error {
 
 	p.log.Info().
 		Uint64("view", qc.View).
-		Int("num_signers", len(qc.SignerIDs)).
+		// Int("num_signers", len(qc.SignerIDs)).
 		Msg("new qc has been created")
 
 	p.onQCCreated(qc)
@@ -305,15 +305,15 @@ func (p *CombinedVoteProcessorV3) buildQC() (*flow.QuorumCertificate, error) {
 		AggregatedRandomBeaconSig:    aggregatedRandomBeaconSig,
 		ReconstructedRandomBeaconSig: reconstructedBeaconSig,
 	}
-	signerIDs, sigData, err := p.packer.Pack(p.block.BlockID, blockSigData)
+	signerIndices, sigData, err := p.packer.Pack(p.block.BlockID, blockSigData)
 	if err != nil {
 		return nil, fmt.Errorf("could not pack the block sig data: %w", err)
 	}
 
 	return &flow.QuorumCertificate{
-		View:      p.block.View,
-		BlockID:   p.block.BlockID,
-		SignerIDs: signerIDs,
-		SigData:   sigData,
+		View:          p.block.View,
+		BlockID:       p.block.BlockID,
+		SignerIndices: signerIndices,
+		SigData:       sigData,
 	}, nil
 }

--- a/consensus/hotstuff/votecollector/staking_vote_processor.go
+++ b/consensus/hotstuff/votecollector/staking_vote_processor.go
@@ -163,10 +163,17 @@ func (p *StakingVoteProcessor) buildQC() (*flow.QuorumCertificate, error) {
 		return nil, fmt.Errorf("could not aggregate staking signature: %w", err)
 	}
 
+	// TODO: maybe Aggregate could return signer indices directly?
+	signerIndices := p.signerIndicesFromIdentities(stakingSigners)
+
 	return &flow.QuorumCertificate{
-		View:      p.block.View,
-		BlockID:   p.block.BlockID,
-		SignerIDs: stakingSigners,
-		SigData:   aggregatedStakingSig,
+		View:          p.block.View,
+		BlockID:       p.block.BlockID,
+		SignerIndices: signerIndices,
+		SigData:       aggregatedStakingSig,
 	}, nil
+}
+
+func (p *StakingVoteProcessor) signerIndicesFromIdentities(signerIDs []flow.Identifier) []byte {
+	panic("to be implemented")
 }

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -128,23 +128,13 @@ type EpochCommit struct {
 // gathered by the ClusterQC smart contract. It contains the aggregated
 // signature over the root block for the cluster as well as the set of voters.
 type ClusterQCVoteData struct {
-	SigData  crypto.Signature // the aggregated signature over all the votes
-	VoterIDs []Identifier     // the set of voters that contributed to the qc
+	SigData      crypto.Signature // the aggregated signature over all the votes
+	VoterIndices []byte           // the set of voters that contributed to the qc
 }
 
 func (c *ClusterQCVoteData) EqualTo(other *ClusterQCVoteData) bool {
-	if len(c.VoterIDs) != len(other.VoterIDs) {
-		return false
-	}
-	if !bytes.Equal(c.SigData, other.SigData) {
-		return false
-	}
-	for i, v := range c.VoterIDs {
-		if v != other.VoterIDs[i] {
-			return false
-		}
-	}
-	return true
+	return bytes.Equal(c.VoterIndices, other.VoterIndices) &&
+		bytes.Equal(c.SigData, other.SigData)
 }
 
 // ClusterQCVoteDataFromQC converts a quorum certificate to the representation
@@ -152,8 +142,8 @@ func (c *ClusterQCVoteData) EqualTo(other *ClusterQCVoteData) bool {
 // (which are protocol-defined given the EpochSetup event).
 func ClusterQCVoteDataFromQC(qc *QuorumCertificate) ClusterQCVoteData {
 	return ClusterQCVoteData{
-		SigData:  qc.SigData,
-		VoterIDs: qc.SignerIDs,
+		SigData:      qc.SigData,
+		VoterIndices: qc.SignerIndices,
 	}
 }
 

--- a/model/flow/epoch_test.go
+++ b/model/flow/epoch_test.go
@@ -3,6 +3,7 @@ package flow_test
 import (
 	"testing"
 
+	"github.com/onflow/flow-go/consensus/hotstuff/packer"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -25,12 +26,12 @@ func TestClusterQCVoteData_Equality(t *testing.T) {
 
 	t.Run("sig data triggers", func(t *testing.T) {
 		a := &flow.ClusterQCVoteData{
-			SigData:  []byte{1, 2},
-			VoterIDs: nil,
+			SigData:      []byte{1, 2},
+			VoterIndices: nil,
 		}
 		b := &flow.ClusterQCVoteData{
-			SigData:  []byte{1, 3},
-			VoterIDs: nil,
+			SigData:      []byte{1, 3},
+			VoterIndices: nil,
 		}
 		require.False(t, a.EqualTo(b))
 		require.False(t, b.EqualTo(a))
@@ -38,12 +39,12 @@ func TestClusterQCVoteData_Equality(t *testing.T) {
 
 	t.Run("VoterID len difference triggers", func(t *testing.T) {
 		a := &flow.ClusterQCVoteData{
-			SigData:  nil,
-			VoterIDs: []flow.Identifier{flow.HashToID([]byte{1, 2, 3})},
+			SigData:      nil,
+			VoterIndices: packer.EncodeSignerIndices([]int{1}, 10),
 		}
 		b := &flow.ClusterQCVoteData{
-			SigData:  nil,
-			VoterIDs: []flow.Identifier{},
+			SigData:      nil,
+			VoterIndices: packer.EncodeSignerIndices([]int{}, 10),
 		}
 		require.False(t, a.EqualTo(b))
 		require.False(t, b.EqualTo(a))
@@ -51,12 +52,12 @@ func TestClusterQCVoteData_Equality(t *testing.T) {
 
 	t.Run("VoterID len values triggers", func(t *testing.T) {
 		a := &flow.ClusterQCVoteData{
-			SigData:  nil,
-			VoterIDs: []flow.Identifier{flow.HashToID([]byte{1, 2, 3})},
+			SigData:      nil,
+			VoterIndices: packer.EncodeSignerIndices([]int{1, 2, 3}, 10),
 		}
 		b := &flow.ClusterQCVoteData{
-			SigData:  nil,
-			VoterIDs: []flow.Identifier{flow.HashToID([]byte{3, 2, 1})},
+			SigData:      nil,
+			VoterIndices: packer.EncodeSignerIndices([]int{1, 2, 6}, 10),
 		}
 		require.False(t, a.EqualTo(b))
 		require.False(t, b.EqualTo(a))
@@ -64,12 +65,12 @@ func TestClusterQCVoteData_Equality(t *testing.T) {
 
 	t.Run("filled structures match with same data", func(t *testing.T) {
 		a := &flow.ClusterQCVoteData{
-			SigData:  []byte{3, 3, 3},
-			VoterIDs: []flow.Identifier{flow.HashToID([]byte{1, 2, 3}), flow.HashToID([]byte{3, 2, 1})},
+			SigData:      []byte{3, 3, 3},
+			VoterIndices: packer.EncodeSignerIndices([]int{1, 2, 3}, 10),
 		}
 		b := &flow.ClusterQCVoteData{
-			SigData:  []byte{3, 3, 3},
-			VoterIDs: []flow.Identifier{flow.HashToID([]byte{1, 2, 3}), flow.HashToID([]byte{3, 2, 1})},
+			SigData:      []byte{3, 3, 3},
+			VoterIndices: packer.EncodeSignerIndices([]int{1, 2, 3}, 10),
 		}
 		require.True(t, a.EqualTo(b))
 		require.True(t, b.EqualTo(a))
@@ -79,13 +80,13 @@ func TestClusterQCVoteData_Equality(t *testing.T) {
 func TestEpochCommit_EqualTo(t *testing.T) {
 
 	qcA := flow.ClusterQCVoteData{
-		SigData:  []byte{3, 3, 3},
-		VoterIDs: []flow.Identifier{flow.HashToID([]byte{1, 2, 3}), flow.HashToID([]byte{3, 2, 1})},
+		SigData:      []byte{3, 3, 3},
+		VoterIndices: packer.EncodeSignerIndices([]int{1, 2, 3}, 10),
 	}
 
 	qcB := flow.ClusterQCVoteData{
-		SigData:  []byte{1, 1, 1},
-		VoterIDs: []flow.Identifier{flow.HashToID([]byte{1, 2, 3}), flow.HashToID([]byte{3, 2, 1})},
+		SigData:      []byte{1, 1, 1},
+		VoterIndices: packer.EncodeSignerIndices([]int{1, 2, 3}, 10),
 	}
 
 	pks := unittest.PublicKeysFixture(2, crypto.BLSBLS12381)

--- a/model/flow/quorum_certificate.go
+++ b/model/flow/quorum_certificate.go
@@ -14,7 +14,7 @@ type QuorumCertificate struct {
 	// In order to distinguish the signature types, the SigData has to be deserialized. Specifically,
 	// the field `SigData.SigType` (bit vector) indicates for each signer which sig type they provided.
 	// For collection cluster, the SignerIDs includes all the staking sig signers.
-	SignerIDs []Identifier
+	SignerIndices []byte
 
 	// For consensus cluster, the SigData is a serialization of the following fields
 	// - SigType []byte, bit-vector indicating the type of sig produced by the signer.

--- a/state/cluster/root_block.go
+++ b/state/cluster/root_block.go
@@ -26,7 +26,7 @@ func CanonicalRootBlock(epoch uint64, participants flow.IdentityList) *cluster.B
 		PayloadHash:        payload.Hash(),
 		Timestamp:          flow.GenesisTime,
 		View:               0,
-		ParentVoterIDs:     nil,
+		ParentVoterIndices: nil,
 		ParentVoterSigData: nil,
 		ProposerID:         flow.ZeroID,
 		ProposerSigData:    nil,

--- a/state/protocol/inmem/epoch.go
+++ b/state/protocol/inmem/epoch.go
@@ -168,10 +168,10 @@ func (es *committedEpoch) Cluster(index uint) (protocol.Cluster, error) {
 
 	rootBlock := cluster.CanonicalRootBlock(epochCounter, members)
 	rootQC := &flow.QuorumCertificate{
-		View:      rootBlock.Header.View,
-		BlockID:   rootBlock.ID(),
-		SignerIDs: rootQCVoteData.VoterIDs,
-		SigData:   rootQCVoteData.SigData,
+		View:          rootBlock.Header.View,
+		BlockID:       rootBlock.ID(),
+		SignerIndices: rootQCVoteData.VoterIndices,
+		SigData:       rootQCVoteData.SigData,
 	}
 
 	cluster, err := ClusterFromEncodable(EncodableCluster{


### PR DESCRIPTION
For https://github.com/dapperlabs/flow-go/issues/6147

The base branch is the latest master.

This PR made changes to the interfaces in order to present as a proposal for the signer indices optimization.

The main change is to change QuorumCertificate's SignerID field into SignerIndices.

See details and reasonings in comments.

Note: The test cases are still broken, and linting errors are everywhere. They will be addressed once the interface changes are confirmed.