### PR TITLE
Make ContractHandler Commit produce deterministic errors

### DIFF
--- a/fvm/handler/contract.go
+++ b/fvm/handler/contract.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"sync"
@@ -101,11 +102,17 @@ func (h *ContractHandler) RemoveContract(address runtime.Address, name string, s
 
 type contractUpdateList []programs.ContractUpdate
 
-func (a contractUpdateList) Len() int      { return len(a) }
-func (a contractUpdateList) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a contractUpdateList) Less(i, j int) bool {
-	return a[i].Address.String() < a[j].Address.String() ||
-		(a[i].Address.String() == a[j].Address.String() && a[i].Name < a[j].Name)
+func (l contractUpdateList) Len() int      { return len(l) }
+func (l contractUpdateList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l contractUpdateList) Less(i, j int) bool {
+	switch bytes.Compare(l[i].Address[:], l[j].Address[:]) {
+	case -1:
+		return true
+	case 0:
+		return l[i].Name < l[j].Name
+	default:
+		return false
+	}
 }
 
 func (h *ContractHandler) Commit() ([]programs.ContractUpdateKey, error) {

--- a/fvm/handler/contract_test.go
+++ b/fvm/handler/contract_test.go
@@ -2,15 +2,15 @@ package handler_test
 
 import (
 	"fmt"
-	stateMock "github.com/onflow/flow-go/fvm/mock/state"
-	"github.com/stretchr/testify/mock"
 	"testing"
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm/handler"
+	stateMock "github.com/onflow/flow-go/fvm/mock/state"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"


### PR DESCRIPTION
`h.draftUpdates` is a dictionary.

It was possible that in the for loop an error was hit, which topped the for loop. This could produce a non-deterministic error.


this PR changes the iteration to an ordered list.