### PR TITLE
Update to Cadence v0.21.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.1.1
-	github.com/onflow/cadence v0.21.0
+	github.com/onflow/cadence v0.21.2
 	github.com/onflow/flow v0.2.3-0.20220207221328-d1ffd1c3053e
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -1295,8 +1295,8 @@ github.com/onflow/atree v0.1.1/go.mod h1:95SqSEPgfijF1ZkLKbVgYVrfQzvP0fhayh555v1
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.21.0 h1:t4e3Rb8298NjK6pyM+2cnPSAjVeKZdqu91X34lRCu0o=
-github.com/onflow/cadence v0.21.0/go.mod h1:KBxn7AyO+R2RFpFHjsWKJFAokyJaCZXc9Hr9MlEOq9g=
+github.com/onflow/cadence v0.21.2 h1:LsYsCjpf9zBVU2B5Zuby96bHO5VdmX4dUZ88YY2ZnYI=
+github.com/onflow/cadence v0.21.2/go.mod h1:KBxn7AyO+R2RFpFHjsWKJFAokyJaCZXc9Hr9MlEOq9g=
 github.com/onflow/flow v0.2.3-0.20220207221328-d1ffd1c3053e h1:BZdWgblB8mKKEq/UltES6y/L5Zqr+LFtiuatNwCTt7w=
 github.com/onflow/flow v0.2.3-0.20220207221328-d1ffd1c3053e/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.21.0
+	github.com/onflow/cadence v0.21.2
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.10.1
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1409,8 +1409,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.21.0 h1:t4e3Rb8298NjK6pyM+2cnPSAjVeKZdqu91X34lRCu0o=
-github.com/onflow/cadence v0.21.0/go.mod h1:KBxn7AyO+R2RFpFHjsWKJFAokyJaCZXc9Hr9MlEOq9g=
+github.com/onflow/cadence v0.21.2 h1:LsYsCjpf9zBVU2B5Zuby96bHO5VdmX4dUZ88YY2ZnYI=
+github.com/onflow/cadence v0.21.2/go.mod h1:KBxn7AyO+R2RFpFHjsWKJFAokyJaCZXc9Hr9MlEOq9g=
 github.com/onflow/flow v0.2.3-0.20220207221328-d1ffd1c3053e h1:BZdWgblB8mKKEq/UltES6y/L5Zqr+LFtiuatNwCTt7w=
 github.com/onflow/flow v0.2.3-0.20220207221328-d1ffd1c3053e/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.1 h1:W0zlLxatN88pC+U2eJ7F517KiI4B+kk3lpguyp8rEsQ=


### PR DESCRIPTION
Update to Cadence [v0.21.2](https://github.com/onflow/cadence/releases/tag/v0.21.2). 

Includes the [fix for making contract update validation error reporting deterministic](https://github.com/onflow/cadence/pull/1420).