### PR TITLE
hotfix for consensus memory leak

### DIFF
--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -318,4 +318,7 @@ func (c *Core) prunePendingCache() {
 
 	// always record the metric
 	c.mempoolMetrics.MempoolEntries(metrics.ResourceClusterProposal, c.pending.Size())
+
+	// HOTFIX
+	c.voteAggregator.PruneUpToView(final.View)
 }

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -371,4 +371,7 @@ func (c *Core) prunePendingCache() {
 
 	// always record the metric
 	c.mempool.MempoolEntries(metrics.ResourceProposal, c.pending.Size())
+
+	// HOTFIX
+	c.voteAggregator.PruneUpToView(final.View)
 }


### PR DESCRIPTION
we forgot to prune the VoteAggregator (`voteAggregator.PruneUpToView` is never called by the business logic; except at startup)