### PR TITLE
FVM error detection

### DIFF
--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -47,7 +47,7 @@ func (proc *TransactionProcedure) Run(vm *VirtualMachine, ctx Context, st *state
 	defer func() {
 		if r := recover(); r != nil {
 
-			if strings.Contains(fmt.Sprintf("%v", r), "[Error Code: 1106]") {
+			if strings.Contains(fmt.Sprintf("%v", r), errors.ErrCodeLedgerIntractionLimitExceededError.String()) {
 				ctx.Logger.Error().Str("trace", string(debug.Stack())).Msg("VM LedgerIntractionLimitExceeded panic")
 				proc.Err = errors.NewLedgerIntractionLimitExceededError(state.DefaultMaxInteractionSize, state.DefaultMaxInteractionSize)
 				return


### PR DESCRIPTION
This is a small refactor of the logic for error detection, instead of using a literal string value it references the error definition.