### PR TITLE
[Observer] Support running observer standalone using standard AN image

### DIFF
--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -15,18 +15,18 @@ func main() {
 	}
 
 	// choose a staked or an unstaked node builder based on anb.staked
-	var nodeBuilder nodebuilder.AccessNodeBuilder
+	var builder nodebuilder.AccessNodeBuilder
 	if anb.IsStaked() {
-		nodeBuilder = nodebuilder.NewStakedAccessNodeBuilder(anb)
+		builder = nodebuilder.NewStakedAccessNodeBuilder(anb)
 	} else {
-		nodeBuilder = nodebuilder.NewUnstakedAccessNodeBuilder(anb)
+		builder = nodebuilder.NewUnstakedAccessNodeBuilder(anb)
 	}
 
-	if err := nodeBuilder.Initialize(); err != nil {
+	if err := builder.Initialize(); err != nil {
 		anb.Logger.Fatal().Err(err).Send()
 	}
 
-	node, err := nodeBuilder.Build()
+	node, err := builder.Build()
 	if err != nil {
 		anb.Logger.Fatal().Err(err).Send()
 	}

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -78,6 +78,7 @@ type AccessNodeConfig struct {
 	staked                       bool
 	bootstrapNodeAddresses       []string
 	bootstrapNodePublicKeys      []string
+	observerNetworkingKeyPath    string
 	bootstrapIdentities          flow.IdentityList // the identity list of bootstrap peers the node uses to discover other nodes
 	NetworkKey                   crypto.PrivateKey // the networking key passed in by the caller when being used as a library
 	supportsUnstakedFollower     bool              // True if this is a staked Access node which also supports unstaked access nodes/unstaked consensus follower engines
@@ -143,6 +144,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 			BindAddress: cmd.NotSet,
 			Metrics:     metrics.NewNoopCollector(),
 		},
+		observerNetworkingKeyPath: cmd.NotSet,
 	}
 }
 
@@ -191,10 +193,12 @@ func (builder *FlowAccessNodeBuilder) deriveBootstrapPeerIdentities() error {
 	if builder.bootstrapIdentities != nil {
 		return nil
 	}
+
 	ids, err := BootstrapIdentities(builder.bootstrapNodeAddresses, builder.bootstrapNodePublicKeys)
 	if err != nil {
 		return fmt.Errorf("failed to derive bootstrap peer identities: %w", err)
 	}
+
 	builder.bootstrapIdentities = ids
 
 	return nil
@@ -447,6 +451,7 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 		flags.StringToIntVar(&builder.apiRatelimits, "api-rate-limits", defaultConfig.apiRatelimits, "per second rate limits for Access API methods e.g. Ping=300,GetTransaction=500 etc.")
 		flags.StringToIntVar(&builder.apiBurstlimits, "api-burst-limits", defaultConfig.apiBurstlimits, "burst limits for Access API methods e.g. Ping=100,GetTransaction=100 etc.")
 		flags.BoolVar(&builder.staked, "staked", defaultConfig.staked, "whether this node is a staked access node or not")
+		flags.StringVar(&builder.observerNetworkingKeyPath, "observer-networking-key-path", defaultConfig.observerNetworkingKeyPath, "path to the networking key for observer")
 		flags.StringSliceVar(&builder.bootstrapNodeAddresses, "bootstrap-node-addresses", defaultConfig.bootstrapNodeAddresses, "the network addresses of the bootstrap access node if this is an unstaked access node e.g. access-001.mainnet.flow.org:9653,access-002.mainnet.flow.org:9653")
 		flags.StringSliceVar(&builder.bootstrapNodePublicKeys, "bootstrap-node-public-keys", defaultConfig.bootstrapNodePublicKeys, "the networking public key of the bootstrap access node if this is an unstaked access node (in the same order as the bootstrap node addresses) e.g. \"d57a5e9c5.....\",\"44ded42d....\"")
 		flags.BoolVar(&builder.supportsUnstakedFollower, "supports-unstaked-node", defaultConfig.supportsUnstakedFollower, "true if this staked access node supports unstaked node")
@@ -516,8 +521,8 @@ func BootstrapIdentities(addresses []string, keys []string) (flow.IdentityList, 
 
 	ids := make([]*flow.Identity, len(addresses))
 	for i, address := range addresses {
-
 		key := keys[i]
+
 		// json unmarshaller needs a quotes before and after the string
 		// the pflags.StringSliceVar does not retain quotes for the command line arg even if escaped with \"
 		// hence this additional check to ensure the key is indeed quoted
@@ -532,14 +537,12 @@ func BootstrapIdentities(addresses []string, keys []string) (flow.IdentityList, 
 		}
 
 		// create the identity of the peer by setting only the relevant fields
-		id := &flow.Identity{
+		ids[i] = &flow.Identity{
 			NodeID:        flow.ZeroID, // the NodeID is the hash of the staking key and for the unstaked network it does not apply
 			Address:       address,
 			Role:          flow.RoleAccess, // the upstream node has to be an access node
 			NetworkPubKey: networkKey,
 		}
-
-		ids = append(ids, id)
 	}
 	return ids, nil
 }

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -2,8 +2,10 @@ package node_builder
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -24,6 +26,7 @@ import (
 	"github.com/onflow/flow-go/network/p2p/keyutils"
 	"github.com/onflow/flow-go/network/p2p/unicast"
 	"github.com/onflow/flow-go/state/protocol/events/gadgets"
+	"github.com/onflow/flow-go/utils/io"
 )
 
 type UnstakedAccessNodeBuilder struct {
@@ -41,8 +44,16 @@ func NewUnstakedAccessNodeBuilder(builder *FlowAccessNodeBuilder) *UnstakedAcces
 }
 
 func (builder *UnstakedAccessNodeBuilder) initNodeInfo() error {
-	// use the networking key that has been passed in the config
+	// use the networking key that has been passed in the config, or load from the configured file
 	networkingKey := builder.AccessNodeConfig.NetworkKey
+	if networkingKey == nil {
+		var err error
+		networkingKey, err = loadNetworkingKey(builder.observerNetworkingKeyPath)
+		if err != nil {
+			return fmt.Errorf("could not load networking private key: %w", err)
+		}
+	}
+
 	pubKey, err := keyutils.LibP2PPublicKeyFromFlow(networkingKey.PublicKey())
 	if err != nil {
 		return fmt.Errorf("could not load networking public key: %w", err)
@@ -80,7 +91,7 @@ func (builder *UnstakedAccessNodeBuilder) InitIDProviders() {
 			return id.NewCustomIdentifierProvider(func() flow.IdentifierList {
 				var result flow.IdentifierList
 
-				pids := builder.LibP2PNode.GetPeersForProtocol(unicast.FlowProtocolID(builder.RootBlock.ID()))
+				pids := builder.LibP2PNode.GetPeersForProtocol(unicast.FlowProtocolID(builder.SporkID))
 
 				for _, pid := range pids {
 					// exclude own Identifier
@@ -133,7 +144,7 @@ func (builder *UnstakedAccessNodeBuilder) validateParams() error {
 	if builder.BaseConfig.BindAddr == cmd.NotSet || builder.BaseConfig.BindAddr == "" {
 		return errors.New("bind address not specified")
 	}
-	if builder.AccessNodeConfig.NetworkKey == nil {
+	if builder.AccessNodeConfig.NetworkKey == nil && builder.AccessNodeConfig.observerNetworkingKeyPath == cmd.NotSet {
 		return errors.New("networking key not provided")
 	}
 	if len(builder.bootstrapIdentities) > 0 {
@@ -302,4 +313,23 @@ func (builder *UnstakedAccessNodeBuilder) initMiddleware(nodeID flow.Identifier,
 	)
 
 	return builder.Middleware
+}
+
+func loadNetworkingKey(path string) (crypto.PrivateKey, error) {
+	data, err := io.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read networking key (path=%s): %w", path, err)
+	}
+
+	keyBytes, err := hex.DecodeString(strings.Trim(string(data), "\n "))
+	if err != nil {
+		return nil, fmt.Errorf("could not hex decode networking key (path=%s): %w", path, err)
+	}
+
+	networkingKey, err := crypto.DecodePrivateKey(crypto.ECDSASecp256k1, keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode networking key (path=%s): %w", path, err)
+	}
+
+	return networkingKey, nil
 }


### PR DESCRIPTION
This PR adds support for running an observer as a standalone process using the standard Access Node image.

Example usage:
```
docker run -p 9000:9000 -p 3569:3569 -p 8080:8080  -p 8000:8000 \
    -v /tmp/observer/bootstrap:/bootstrap \
    -v /tmp/observer/data:/data \
    "gcr.io/flow-container-registry/access:latest" \
    --staked=false \
    --bootstrapdir=/bootstrap \
    --datadir=/data/protocol \
    --secretsdir=/data/secret \
    --loglevel=DEBUG \
    --rpc-addr=0.0.0.0:9000 \
    --secure-rpc-addr=0.0.0.0:9001 \
    --http-addr=0.0.0.0:8000 \
    --collection-ingress-port=9000 \
    --log-tx-time-to-finalized \
    --log-tx-time-to-executed \
    --log-tx-time-to-finalized-executed \
    --bind 0.0.0.0:0 \
    --bootstrap-node-addresses=access-007.mainnet16.nodes.onflow.org:3570 \
    --bootstrap-node-public-keys=28a0d9edd0de3f15866dfe4aea1560c4504fe313fc6ca3f63a63e4f98d0e295144692a58ebe7f7894349198613f65b2d960abf99ec2625e247b1c78ba5bf2eae \
    --observer-networking-key-path=/bootstrap/private-root-information/network-key
```