### PR TITLE
Log Execution Data IDs

### DIFF
--- a/engine/consensus/matching/core.go
+++ b/engine/consensus/matching/core.go
@@ -157,6 +157,7 @@ func (c *Core) processReceipt(receipt *flow.ExecutionReceipt) (bool, error) {
 	log := c.log.With().
 		Hex("receipt_id", logging.Entity(receipt)).
 		Hex("result_id", logging.Entity(receipt.ExecutionResult)).
+		Hex("execution_data_id", receipt.ExecutionResult.ExecutionDataID[:]).
 		Hex("previous_result", receipt.ExecutionResult.PreviousResultID[:]).
 		Hex("block_id", receipt.ExecutionResult.BlockID[:]).
 		Hex("executor_id", receipt.ExecutorID[:]).
@@ -185,7 +186,7 @@ func (c *Core) processReceipt(receipt *flow.ExecutionReceipt) (bool, error) {
 		Uint64("block_view", executedBlock.View).
 		Uint64("block_height", executedBlock.Height).
 		Logger()
-	log.Debug().Msg("execution receipt received")
+	log.Info().Msg("execution receipt received")
 
 	// if Execution Receipt is for block whose height is lower or equal to already sealed height
 	//  => drop Receipt

--- a/engine/consensus/matching/core.go
+++ b/engine/consensus/matching/core.go
@@ -186,7 +186,7 @@ func (c *Core) processReceipt(receipt *flow.ExecutionReceipt) (bool, error) {
 		Uint64("block_view", executedBlock.View).
 		Uint64("block_height", executedBlock.Height).
 		Logger()
-	log.Info().Msg("execution receipt received")
+	log.Debug().Msg("execution receipt received")
 
 	// if Execution Receipt is for block whose height is lower or equal to already sealed height
 	//  => drop Receipt

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -3,7 +3,6 @@ package computer
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -28,7 +27,6 @@ import (
 
 const SystemChunkEventCollectionMaxSize = 256_000_000  // ~256MB
 const SystemChunkLedgerIntractionLimit = 1_000_000_000 // ~1GB
-const MaxTransactionErrorStringSize = 1000             // 1000 chars
 
 // VirtualMachine runs procedures
 type VirtualMachine interface {
@@ -381,17 +379,7 @@ func (e *blockComputer) executeTransaction(
 	}
 
 	if tx.Err != nil {
-		// limit the size of transaction error that is going to be captured
-		errorMsg := tx.Err.Error()
-		if len(errorMsg) > MaxTransactionErrorStringSize {
-			split := int(MaxTransactionErrorStringSize/2) - 1
-			var sb strings.Builder
-			sb.WriteString(errorMsg[:split])
-			sb.WriteString(" ... ")
-			sb.WriteString(errorMsg[len(errorMsg)-split:])
-			errorMsg = sb.String()
-		}
-		txResult.ErrorMessage = errorMsg
+		txResult.ErrorMessage = tx.Err.Error()
 	}
 
 	mergeSpan := e.tracer.StartSpanFromParent(txSpan, trace.EXEMergeTransactionView)

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -626,6 +626,7 @@ func (e *Engine) executeBlock(ctx context.Context, executableBlock *entity.Execu
 		Hex("final_state", finalState[:]).
 		Hex("receipt_id", logging.Entity(receipt)).
 		Hex("result_id", logging.Entity(receipt.ExecutionResult)).
+		Hex("execution_data_id", receipt.ExecutionResult.ExecutionDataID[:]).
 		Bool("sealed", isExecutedBlockSealed).
 		Bool("broadcasted", broadcasted).
 		Int64("timeSpentInMS", time.Since(startedAt).Milliseconds()).


### PR DESCRIPTION
add log for execution data id

Also removes transaction error message truncation, since cadence will be changing to only return first error.