### PR TITLE
Enable metrics for unstaked access node

### DIFF
--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -135,9 +135,11 @@ func (builder *UnstakedAccessNodeBuilder) Initialize() error {
 
 	builder.enqueueConnectWithStakedAN()
 
-	builder.EnqueueMetricsServerInit()
-	if err := builder.RegisterBadgerMetrics(); err != nil {
-		return err
+	if builder.BaseConfig.MetricsEnabled {
+		builder.EnqueueMetricsServerInit()
+		if err := builder.RegisterBadgerMetrics(); err != nil {
+			return err
+		}
 	}
 
 	builder.PreInit(builder.initUnstakedLocal())

--- a/cmd/access/node_builder/unstaked_access_node_builder.go
+++ b/cmd/access/node_builder/unstaked_access_node_builder.go
@@ -135,6 +135,11 @@ func (builder *UnstakedAccessNodeBuilder) Initialize() error {
 
 	builder.enqueueConnectWithStakedAN()
 
+	builder.EnqueueMetricsServerInit()
+	if err := builder.RegisterBadgerMetrics(); err != nil {
+		return err
+	}
+
 	builder.PreInit(builder.initUnstakedLocal())
 
 	return nil

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -136,7 +136,7 @@ type BaseConfig struct {
 	profilerDuration                time.Duration
 	tracerEnabled                   bool
 	tracerSensitivity               uint
-	metricsEnabled                  bool
+	MetricsEnabled                  bool
 	guaranteesCacheSize             uint
 	receiptsCacheSize               uint
 	db                              *badger.DB
@@ -216,7 +216,7 @@ func DefaultBaseConfig() *BaseConfig {
 		profilerDuration:                10 * time.Second,
 		tracerEnabled:                   false,
 		tracerSensitivity:               4,
-		metricsEnabled:                  true,
+		MetricsEnabled:                  true,
 		receiptsCacheSize:               bstorage.DefaultCacheSize,
 		guaranteesCacheSize:             bstorage.DefaultCacheSize,
 		NetworkReceivedMessageCacheSize: p2p.DefaultCacheSize,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -432,7 +432,7 @@ func (fnb *FlowNodeBuilder) initMetrics() {
 		Mempool:        metrics.NewNoopCollector(),
 		CleanCollector: metrics.NewNoopCollector(),
 	}
-	if fnb.BaseConfig.metricsEnabled {
+	if fnb.BaseConfig.MetricsEnabled {
 		fnb.MetricsRegisterer = prometheus.DefaultRegisterer
 
 		mempools := metrics.NewMempoolCollector(5 * time.Second)
@@ -978,7 +978,7 @@ func WithSecretsDBEnabled(enabled bool) Option {
 
 func WithMetricsEnabled(enabled bool) Option {
 	return func(config *BaseConfig) {
-		config.metricsEnabled = enabled
+		config.MetricsEnabled = enabled
 	}
 }
 
@@ -1035,7 +1035,7 @@ func (fnb *FlowNodeBuilder) Initialize() error {
 
 	fnb.EnqueuePingService()
 
-	if fnb.metricsEnabled {
+	if fnb.MetricsEnabled {
 		fnb.EnqueueMetricsServerInit()
 		if err := fnb.RegisterBadgerMetrics(); err != nil {
 			return err

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -38,6 +38,7 @@ type Config struct {
 	dataDir        string              // directory to store the protocol state (if the badger storage is not provided)
 	bootstrapDir   string              // path to the bootstrap directory
 	logLevel       string              // log level
+	exposeMetrics  bool                // whether to expose metrics
 }
 
 type Option func(c *Config)
@@ -70,6 +71,12 @@ func WithDB(db *badger.DB) Option {
 	return func(cf *Config) {
 		cf.db = db
 		cf.dataDir = ""
+	}
+}
+
+func WithExposeMetrics(expose bool) Option {
+	return func(c *Config) {
+		c.exposeMetrics = expose
 	}
 }
 
@@ -121,6 +128,9 @@ func getBaseOptions(config *Config) []cmd.Option {
 	}
 	if config.db != nil {
 		options = append(options, cmd.WithDB(config.db))
+	}
+	if config.exposeMetrics {
+		options = append(options, cmd.WithMetricsEnabled(config.exposeMetrics))
 	}
 
 	return options

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -167,6 +167,7 @@ func NewConsensusFollower(
 		bootstrapNodes: bootstapIdentities,
 		bindAddr:       bindAddr,
 		logLevel:       "info",
+		exposeMetrics:  false,
 	}
 
 	for _, opt := range opts {

--- a/module/metrics/server.go
+++ b/module/metrics/server.go
@@ -24,7 +24,9 @@ func NewServer(log zerolog.Logger, port uint, enableProfilerEndpoint bool) *Serv
 	addr := ":" + strconv.Itoa(int(port))
 
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	endpoint := "/metrics"
+	mux.Handle(endpoint, promhttp.Handler())
+	log.Info().Str("address", addr).Str("endpoint", endpoint)
 	if enableProfilerEndpoint {
 		mux.Handle("/debug/pprof/", http.DefaultServeMux)
 	}

--- a/module/metrics/server.go
+++ b/module/metrics/server.go
@@ -26,7 +26,7 @@ func NewServer(log zerolog.Logger, port uint, enableProfilerEndpoint bool) *Serv
 	mux := http.NewServeMux()
 	endpoint := "/metrics"
 	mux.Handle(endpoint, promhttp.Handler())
-	log.Info().Str("address", addr).Str("endpoint", endpoint)
+	log.Info().Str("address", addr).Str("endpoint", endpoint).Msg("metrics server started")
 	if enableProfilerEndpoint {
 		mux.Handle("/debug/pprof/", http.DefaultServeMux)
 	}


### PR DESCRIPTION
Looks like we don't use flag to enable/disable metrics for AN, they are always on for staked AN, so I made it consistent.