### PR TITLE
Log computation metering

### DIFF
--- a/fvm/handler/computation_test.go
+++ b/fvm/handler/computation_test.go
@@ -21,8 +21,7 @@ func TestComputationMeteringHandler(t *testing.T) {
 	t.Run("Set/Get Used", func(t *testing.T) {
 		h := NewComputationMeteringHandler(limit)
 
-		err := h.AddUsed(used)
-		require.NoError(t, err)
+		h.AddUsed(used, "function_or_loop_call")
 
 		u := h.Used()
 
@@ -32,11 +31,9 @@ func TestComputationMeteringHandler(t *testing.T) {
 	t.Run("Set/Get Used twice", func(t *testing.T) {
 		h := NewComputationMeteringHandler(limit)
 
-		err := h.AddUsed(used)
-		require.NoError(t, err)
+		h.AddUsed(used, "function_or_loop_call")
 
-		err = h.AddUsed(used)
-		require.NoError(t, err)
+		h.AddUsed(used, "function_or_loop_call")
 
 		u := h.Used()
 
@@ -51,12 +48,12 @@ func TestComputationMeteringHandler(t *testing.T) {
 		l := h.Limit()
 		require.Equal(t, 2*limit, l)
 
-		err := h.AddUsed(used)
-		require.NoError(t, err)
+		h.AddUsed(used, "function_or_loop_call")
+
 		u := h.Used()
 		require.Equal(t, used, u)
 
-		err = subMeter.Discard()
+		err := subMeter.Discard()
 		require.NoError(t, err)
 
 		l = h.Limit()
@@ -71,20 +68,19 @@ func TestComputationMeteringHandler(t *testing.T) {
 
 		subMeter := h.StartSubMeter(2 * limit)
 
-		err := h.AddUsed(used)
-		require.NoError(t, err)
+		h.AddUsed(used, "function_or_loop_call")
 
 		subSubMeter := h.StartSubMeter(3 * limit)
 
 		l := h.Limit()
 		require.Equal(t, 3*limit, l)
 
-		err = h.AddUsed(2 * used)
-		require.NoError(t, err)
+		h.AddUsed(2*used, "function_or_loop_call")
+
 		u := h.Used()
 		require.Equal(t, 2*used, u)
 
-		err = subSubMeter.Discard()
+		err := subSubMeter.Discard()
 		require.NoError(t, err)
 
 		l = h.Limit()

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -41,7 +41,7 @@ type ScriptEnv struct {
 	programs           *handler.ProgramsHandler
 	accountKeys        *handler.AccountKeyHandler
 	metrics            *handler.MetricsHandler
-	computationHandler handler.ComputationMeteringHandler
+	computationHandler *handler.ComputationMeteringHandler
 	uuidGenerator      *state.UUIDGenerator
 	logs               []string
 	rng                *rand.Rand
@@ -436,7 +436,8 @@ func (e *ScriptEnv) GetComputationLimit() uint64 {
 }
 
 func (e *ScriptEnv) SetComputationUsed(used uint64) error {
-	return e.computationHandler.AddUsed(used)
+	e.computationHandler.AddUsed(used, "function_or_loop_call")
+	return nil
 }
 
 func (e *ScriptEnv) GetComputationUsed() uint64 {

--- a/fvm/transactionContractFunctionInvocator.go
+++ b/fvm/transactionContractFunctionInvocator.go
@@ -44,6 +44,10 @@ func NewTransactionContractFunctionInvoker(
 func (i *TransactionContractFunctionInvoker) Invoke(env Environment, parentTraceSpan opentracing.Span) (cadence.Value, error) {
 	var span opentracing.Span
 
+	if tenv, ok := env.(*TransactionEnv); ok {
+		tenv.computationHandler.AddUsed(1, "ContractFunctionInvoke")
+	}
+
 	ctx := env.Context()
 	if ctx.Tracer != nil && parentTraceSpan != nil {
 		span = ctx.Tracer.StartSpanFromParent(parentTraceSpan, trace.FVMInvokeContractFunction)


### PR DESCRIPTION
A minimal version of https://github.com/onflow/flow-go/pull/1631
This only adds one log to each transaction.

This is needed to get mode data for variable execution fees