### PR TITLE
WIP: Add MTrie.regCount and MTrie.regSize to reduce memory use, file size, and fix Payload.Equals() bugs

### DIFF
--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -178,7 +178,6 @@ func (l *Ledger) Set(update *ledger.Update) (newState ledger.State, trieUpdate *
 	}
 
 	l.metrics.UpdateCount()
-	l.metrics.UpdateValuesNumber(uint64(len(trieUpdate.Paths)))
 
 	walChan := make(chan error)
 
@@ -345,7 +344,7 @@ func (l *Ledger) ExportCheckpointAt(
 
 	// no need to prune the data since it has already been prunned through migrations
 	applyPruning := false
-	newTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, applyPruning)
+	newTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, applyPruning)
 	if err != nil {
 		return ledger.State(hash.DummyHash), fmt.Errorf("constructing updated trie failed: %w", err)
 	}

--- a/ledger/complete/mtrie/flattener/encoding.go
+++ b/ledger/complete/mtrie/flattener/encoding.go
@@ -22,19 +22,19 @@ const (
 const (
 	encNodeTypeSize      = 1
 	encHeightSize        = 2
-	encMaxDepthSize      = 2
 	encRegCountSize      = 8
+	encRegSizeSize       = 8
 	encHashSize          = hash.HashLen
 	encPathSize          = ledger.PathLen
 	encNodeIndexSize     = 8
 	encPayloadLengthSize = 4
+
+	encodedTrieSize = encNodeIndexSize + encRegCountSize + encRegSizeSize + encHashSize
 )
 
 // encodeLeafNode encodes leaf node in the following format:
 // - node type (1 byte)
 // - height (2 bytes)
-// - max depth (2 bytes)
-// - reg count (8 bytes)
 // - hash (32 bytes)
 // - path (32 bytes)
 // - payload (4 bytes + n bytes)
@@ -52,8 +52,6 @@ func encodeLeafNode(n *node.Node, scratch []byte) []byte {
 
 	encodedNodeSize := encNodeTypeSize +
 		encHeightSize +
-		encMaxDepthSize +
-		encRegCountSize +
 		encHashSize +
 		encPathSize +
 		encPayloadLengthSize +
@@ -77,14 +75,6 @@ func encodeLeafNode(n *node.Node, scratch []byte) []byte {
 	// Encode height (2 bytes Big Endian)
 	binary.BigEndian.PutUint16(buf[pos:], uint16(n.Height()))
 	pos += encHeightSize
-
-	// Encode max depth (2 bytes Big Endian)
-	binary.BigEndian.PutUint16(buf[pos:], n.MaxDepth())
-	pos += encMaxDepthSize
-
-	// Encode reg count (8 bytes Big Endian)
-	binary.BigEndian.PutUint64(buf[pos:], n.RegCount())
-	pos += encRegCountSize
 
 	// Encode hash (32 bytes hashValue)
 	hash := n.Hash()
@@ -110,8 +100,6 @@ func encodeLeafNode(n *node.Node, scratch []byte) []byte {
 // encodeInterimNode encodes interim node in the following format:
 // - node type (1 byte)
 // - height (2 bytes)
-// - max depth (2 bytes)
-// - reg count (8 bytes)
 // - hash (32 bytes)
 // - lchild index (8 bytes)
 // - rchild index (8 bytes)
@@ -126,8 +114,6 @@ func encodeInterimNode(n *node.Node, lchildIndex uint64, rchildIndex uint64, scr
 
 	const encodedNodeSize = encNodeTypeSize +
 		encHeightSize +
-		encMaxDepthSize +
-		encRegCountSize +
 		encHashSize +
 		encNodeIndexSize +
 		encNodeIndexSize
@@ -150,14 +136,6 @@ func encodeInterimNode(n *node.Node, lchildIndex uint64, rchildIndex uint64, scr
 	// Encode height (2 bytes Big Endian)
 	binary.BigEndian.PutUint16(buf[pos:], uint16(n.Height()))
 	pos += encHeightSize
-
-	// Encode max depth (2 bytes Big Endian)
-	binary.BigEndian.PutUint16(buf[pos:], n.MaxDepth())
-	pos += encMaxDepthSize
-
-	// Encode reg count (8 bytes Big Endian)
-	binary.BigEndian.PutUint64(buf[pos:], n.RegCount())
-	pos += encRegCountSize
 
 	// Encode hash (32 bytes hashValue)
 	h := n.Hash()
@@ -204,11 +182,7 @@ func ReadNode(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 	}
 
 	// fixLengthSize is the size of shared data of leaf node and interim node
-	const fixLengthSize = encNodeTypeSize +
-		encHeightSize +
-		encMaxDepthSize +
-		encRegCountSize +
-		encHashSize
+	const fixLengthSize = encNodeTypeSize + encHeightSize + encHashSize
 
 	_, err := io.ReadFull(reader, scratch[:fixLengthSize])
 	if err != nil {
@@ -228,14 +202,6 @@ func ReadNode(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 	// Decode height (2 bytes)
 	height := binary.BigEndian.Uint16(scratch[pos:])
 	pos += encHeightSize
-
-	// Decode max depth (2 bytes)
-	maxDepth := binary.BigEndian.Uint16(scratch[pos:])
-	pos += encMaxDepthSize
-
-	// Decode reg count (8 bytes)
-	regCount := binary.BigEndian.Uint64(scratch[pos:])
-	pos += encRegCountSize
 
 	// Decode and create hash.Hash (32 bytes)
 	nodeHash, err := hash.ToHash(scratch[pos : pos+encHashSize])
@@ -264,7 +230,7 @@ func ReadNode(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 			return nil, fmt.Errorf("failed to read and decode payload of serialized node: %w", err)
 		}
 
-		node := node.NewNode(int(height), nil, nil, path, payload, nodeHash, maxDepth, regCount)
+		node := node.NewNode(int(height), nil, nil, path, payload, nodeHash)
 		return node, nil
 	}
 
@@ -297,52 +263,49 @@ func ReadNode(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 		return nil, fmt.Errorf("failed to find right child node of serialized node: %w", err)
 	}
 
-	n := node.NewNode(int(height), lchild, rchild, ledger.DummyPath, nil, nodeHash, maxDepth, regCount)
+	n := node.NewNode(int(height), lchild, rchild, ledger.DummyPath, nil, nodeHash)
 	return n, nil
 }
 
 // EncodeTrie encodes trie in the following format:
 // - root node index (8 byte)
+// - allocated reg count (8 byte)
+// - allocated reg size (8 byte)
 // - root node hash (32 bytes)
 // Scratch buffer is used to avoid allocs.
 // WARNING: The returned buffer is likely to share the same underlying array as
 // the scratch buffer. Caller is responsible for copying or using returned buffer
 // before scratch buffer is used again.
-func EncodeTrie(rootNode *node.Node, rootIndex uint64, scratch []byte) []byte {
-
-	const encodedTrieSize = encNodeIndexSize + encHashSize
-
-	// Get root hash
-	var rootHash ledger.RootHash
-	if rootNode == nil {
-		rootHash = trie.EmptyTrieRootHash()
-	} else {
-		rootHash = ledger.RootHash(rootNode.Hash())
-	}
-
+func EncodeTrie(trie *trie.MTrie, rootIndex uint64, scratch []byte) []byte {
+	buf := scratch
 	if len(scratch) < encodedTrieSize {
-		scratch = make([]byte, encodedTrieSize)
+		buf = make([]byte, encodedTrieSize)
 	}
 
 	pos := 0
 
 	// Encode root node index (8 bytes Big Endian)
-	binary.BigEndian.PutUint64(scratch, rootIndex)
+	binary.BigEndian.PutUint64(buf, rootIndex)
 	pos += encNodeIndexSize
 
+	// Encode trie reg count (8 bytes Big Endian)
+	binary.BigEndian.PutUint64(buf[pos:], trie.AllocatedRegCount())
+	pos += encRegCountSize
+
+	// Encode trie reg size (8 bytes Big Endian)
+	binary.BigEndian.PutUint64(buf[pos:], trie.AllocatedRegSize())
+	pos += encRegSizeSize
+
 	// Encode hash (32-bytes hashValue)
-	copy(scratch[pos:], rootHash[:])
+	rootHash := trie.RootHash()
+	copy(buf[pos:], rootHash[:])
 	pos += encHashSize
 
-	return scratch[:pos]
+	return buf[:pos]
 }
 
 // ReadTrie reconstructs a trie from data read from reader.
 func ReadTrie(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (*node.Node, error)) (*trie.MTrie, error) {
-
-	// encodedTrieSize is a failsafe and is only used when len(scratch) is much smaller
-	// than expected (4096 by default).
-	const encodedTrieSize = encNodeIndexSize + encHashSize
 
 	if len(scratch) < encodedTrieSize {
 		scratch = make([]byte, encodedTrieSize)
@@ -360,6 +323,14 @@ func ReadTrie(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 	rootIndex := binary.BigEndian.Uint64(scratch)
 	pos += encNodeIndexSize
 
+	// Decode trie reg count (8 bytes)
+	regCount := binary.BigEndian.Uint64(scratch[pos:])
+	pos += encRegCountSize
+
+	// Decode trie reg size (8 bytes)
+	regSize := binary.BigEndian.Uint64(scratch[pos:])
+	pos += encRegSizeSize
+
 	// Decode root node hash
 	readRootHash, err := hash.ToHash(scratch[pos : pos+encHashSize])
 	if err != nil {
@@ -371,7 +342,7 @@ func ReadTrie(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 		return nil, fmt.Errorf("failed to find root node of serialized trie: %w", err)
 	}
 
-	mtrie, err := trie.NewMTrie(rootNode)
+	mtrie, err := trie.NewMTrie(rootNode, regCount, regSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to restore serialized trie: %w", err)
 	}

--- a/ledger/complete/mtrie/flattener/encoding_test.go
+++ b/ledger/complete/mtrie/flattener/encoding_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onflow/flow-go/ledger/common/utils"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/flattener"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 )
 
 func TestLeafNodeEncodingDecoding(t *testing.T) {
@@ -23,26 +24,24 @@ func TestLeafNodeEncodingDecoding(t *testing.T) {
 	path1 := utils.PathByUint8(0)
 	payload1 := (*ledger.Payload)(nil)
 	hashValue1 := hash.Hash([32]byte{1, 1, 1})
-	leafNodeNilPayload := node.NewNode(255, nil, nil, ledger.Path(path1), payload1, hashValue1, 0, 1)
+	leafNodeNilPayload := node.NewNode(255, nil, nil, ledger.Path(path1), payload1, hashValue1)
 
 	// Leaf node with empty payload (not nil)
 	// EmptyPayload() not used because decoded playload's value is empty slice (not nil)
 	path2 := utils.PathByUint8(1)
 	payload2 := &ledger.Payload{Value: []byte{}}
 	hashValue2 := hash.Hash([32]byte{2, 2, 2})
-	leafNodeEmptyPayload := node.NewNode(255, nil, nil, ledger.Path(path2), payload2, hashValue2, 0, 1)
+	leafNodeEmptyPayload := node.NewNode(255, nil, nil, ledger.Path(path2), payload2, hashValue2)
 
 	// Leaf node with payload
 	path3 := utils.PathByUint8(2)
 	payload3 := utils.LightPayload8('A', 'a')
 	hashValue3 := hash.Hash([32]byte{3, 3, 3})
-	leafNodePayload := node.NewNode(255, nil, nil, ledger.Path(path3), payload3, hashValue3, 0, 1)
+	leafNodePayload := node.NewNode(255, nil, nil, ledger.Path(path3), payload3, hashValue3)
 
 	encodedLeafNodeNilPayload := []byte{
 		0x00,       // node type
 		0x00, 0xff, // height
-		0x00, 0x00, // max depth
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // reg count
 		0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -57,8 +56,6 @@ func TestLeafNodeEncodingDecoding(t *testing.T) {
 	encodedLeafNodeEmptyPayload := []byte{
 		0x00,       // node type
 		0x00, 0xff, // height
-		0x00, 0x00, // max depth
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // reg count
 		0x02, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -75,8 +72,6 @@ func TestLeafNodeEncodingDecoding(t *testing.T) {
 	encodedLeafNodePayload := []byte{
 		0x00,       // node type
 		0x00, 0xff, // height
-		0x00, 0x00, // max depth
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // reg count
 		0x03, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -167,7 +162,7 @@ func TestRandomLeafNodeEncodingDecoding(t *testing.T) {
 		var hashValue hash.Hash
 		rand.Read(hashValue[:])
 
-		n := node.NewNode(height, nil, nil, paths[i], payloads[i], hashValue, 0, 1)
+		n := node.NewNode(height, nil, nil, paths[i], payloads[i], hashValue)
 
 		encodedNode := flattener.EncodeNode(n, 0, 0, writeScratch)
 
@@ -198,23 +193,21 @@ func TestInterimNodeEncodingDecoding(t *testing.T) {
 	path1 := utils.PathByUint8(0)
 	payload1 := utils.LightPayload8('A', 'a')
 	hashValue1 := hash.Hash([32]byte{1, 1, 1})
-	leafNode1 := node.NewNode(255, nil, nil, ledger.Path(path1), payload1, hashValue1, 0, 1)
+	leafNode1 := node.NewNode(255, nil, nil, ledger.Path(path1), payload1, hashValue1)
 
 	// Child node
 	path2 := utils.PathByUint8(1)
 	payload2 := utils.LightPayload8('B', 'b')
 	hashValue2 := hash.Hash([32]byte{2, 2, 2})
-	leafNode2 := node.NewNode(255, nil, nil, ledger.Path(path2), payload2, hashValue2, 0, 1)
+	leafNode2 := node.NewNode(255, nil, nil, ledger.Path(path2), payload2, hashValue2)
 
 	// Interim node
 	hashValue3 := hash.Hash([32]byte{3, 3, 3})
-	interimNode := node.NewNode(256, leafNode1, leafNode2, ledger.DummyPath, nil, hashValue3, 1, 2)
+	interimNode := node.NewNode(256, leafNode1, leafNode2, ledger.DummyPath, nil, hashValue3)
 
 	encodedInterimNode := []byte{
 		0x01,       // node type
 		0x01, 0x00, // height
-		0x00, 0x01, // max depth
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // reg count
 		0x03, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -277,25 +270,29 @@ func TestInterimNodeEncodingDecoding(t *testing.T) {
 }
 
 func TestTrieEncodingDecoding(t *testing.T) {
-	// Nil root node
-	rootNodeNil := (*node.Node)(nil)
 	rootNodeNilIndex := uint64(20)
 
-	// Not nil root node
 	hashValue := hash.Hash([32]byte{2, 2, 2})
-	rootNode := node.NewNode(256, nil, nil, ledger.DummyPath, nil, hashValue, 7, 5000)
+	rootNode := node.NewNode(256, nil, nil, ledger.DummyPath, nil, hashValue)
 	rootNodeIndex := uint64(21)
 
+	mtrie, err := trie.NewMTrie(rootNode, 7, 1234)
+	require.NoError(t, err)
+
 	encodedNilTrie := []byte{
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, // RootIndex
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, // root index
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reg count
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // reg size
 		0x56, 0x8f, 0x4e, 0xc7, 0x40, 0xfe, 0x3b, 0x5d,
 		0xe8, 0x80, 0x34, 0xcb, 0x7b, 0x1f, 0xbd, 0xdb,
 		0x41, 0x54, 0x8b, 0x06, 0x8f, 0x31, 0xae, 0xbc,
-		0x8a, 0xe9, 0x18, 0x9e, 0x42, 0x9c, 0x57, 0x49, // RootHash data
+		0x8a, 0xe9, 0x18, 0x9e, 0x42, 0x9c, 0x57, 0x49, // hash data
 	}
 
 	encodedTrie := []byte{
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15, // RootIndex
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x15, // root index
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, // reg count
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0xd2, // reg size
 		0x02, 0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -304,12 +301,12 @@ func TestTrieEncodingDecoding(t *testing.T) {
 
 	testCases := []struct {
 		name          string
-		rootNode      *node.Node
+		trie          *trie.MTrie
 		rootNodeIndex uint64
 		encodedTrie   []byte
 	}{
-		{"nil trie", rootNodeNil, rootNodeNilIndex, encodedNilTrie},
-		{"trie", rootNode, rootNodeIndex, encodedTrie},
+		{"empty trie", trie.NewEmptyMTrie(), rootNodeNilIndex, encodedNilTrie},
+		{"trie", mtrie, rootNodeIndex, encodedTrie},
 	}
 
 	for _, tc := range testCases {
@@ -323,7 +320,7 @@ func TestTrieEncodingDecoding(t *testing.T) {
 			}
 
 			for _, scratch := range scratchBuffers {
-				encodedTrie := flattener.EncodeTrie(tc.rootNode, tc.rootNodeIndex, scratch)
+				encodedTrie := flattener.EncodeTrie(tc.trie, tc.rootNodeIndex, scratch)
 				assert.Equal(t, tc.encodedTrie, encodedTrie)
 
 				if len(scratch) > 0 {
@@ -352,10 +349,12 @@ func TestTrieEncodingDecoding(t *testing.T) {
 					if nodeIndex != tc.rootNodeIndex {
 						return nil, fmt.Errorf("unexpected root node index %d ", nodeIndex)
 					}
-					return tc.rootNode, nil
+					return tc.trie.RootNode(), nil
 				})
 				require.NoError(t, err)
-				assert.Equal(t, tc.rootNode, trie.RootNode())
+				assert.Equal(t, tc.trie, trie)
+				assert.Equal(t, tc.trie.AllocatedRegCount(), trie.AllocatedRegCount())
+				assert.Equal(t, tc.trie.AllocatedRegSize(), trie.AllocatedRegSize())
 				assert.Equal(t, 0, reader.Len())
 			}
 		})

--- a/ledger/complete/mtrie/flattener/iterator_test.go
+++ b/ledger/complete/mtrie/flattener/iterator_test.go
@@ -40,7 +40,7 @@ func TestPopulatedTrie(t *testing.T) {
 	paths := []ledger.Path{p1, p2}
 	payloads := []ledger.Payload{*v1, *v2}
 
-	testTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+	testTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 	require.NoError(t, err)
 
 	for itr := flattener.NewNodeIterator(testTrie); itr.Next(); {
@@ -105,7 +105,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		paths := []ledger.Path{p1, p2}
 		payloads := []ledger.Payload{*v1, *v2}
 
-		updatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 		require.NoError(t, err)
 
 		//              n4
@@ -167,7 +167,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		paths := []ledger.Path{p1, p2}
 		payloads := []ledger.Payload{*v1, *v2}
 
-		trie1, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		trie1, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 		require.NoError(t, err)
 
 		// trie1
@@ -195,7 +195,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		paths = []ledger.Path{p3, p4}
 		payloads = []ledger.Payload{*v3, *v4}
 
-		trie2, err := trie.NewTrieWithUpdatedRegisters(trie1, paths, payloads, true)
+		trie2, _, err := trie.NewTrieWithUpdatedRegisters(trie1, paths, payloads, true)
 		require.NoError(t, err)
 
 		// trie2
@@ -218,7 +218,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		paths = []ledger.Path{p1}
 		payloads = []ledger.Payload{*v5}
 
-		trie3, err := trie.NewTrieWithUpdatedRegisters(trie2, paths, payloads, true)
+		trie3, _, err := trie.NewTrieWithUpdatedRegisters(trie2, paths, payloads, true)
 		require.NoError(t, err)
 
 		// trie3

--- a/ledger/complete/mtrie/forest_test.go
+++ b/ledger/complete/mtrie/forest_test.go
@@ -2,7 +2,6 @@ package mtrie
 
 import (
 	"bytes"
-	"fmt"
 	"math/rand"
 	"sort"
 	"testing"
@@ -31,7 +30,7 @@ func TestTrieOperations(t *testing.T) {
 	p1 := pathByUint8s([]uint8{uint8(53), uint8(74)})
 	v1 := payloadBySlices([]byte{'A'}, []byte{'A'})
 
-	updatedTrie, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, []ledger.Payload{*v1}, true)
+	updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(nt, []ledger.Path{p1}, []ledger.Payload{*v1}, true)
 	require.NoError(t, err)
 
 	// Add trie
@@ -104,10 +103,8 @@ func TestLeftEmptyInsert(t *testing.T) {
 
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(2), baseTrie.MaxDepth())
 	require.Equal(t, uint64(2), baseTrie.AllocatedRegCount())
-	fmt.Println("BASE TRIE:")
-	fmt.Println(baseTrie.String())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
 
 	p3 := pathByUint8s([]uint8{uint8(1), uint8(1)})
 	v3 := payloadBySlices([]byte{'C'}, []byte{'C'})
@@ -120,10 +117,8 @@ func TestLeftEmptyInsert(t *testing.T) {
 
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(2), updatedTrie.MaxDepth())
 	require.Equal(t, uint64(3), updatedTrie.AllocatedRegCount())
-	fmt.Println("UPDATED TRIE:")
-	fmt.Println(updatedTrie.String())
+	require.Equal(t, uint64(v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
@@ -164,10 +159,8 @@ func TestRightEmptyInsert(t *testing.T) {
 
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(2), baseTrie.MaxDepth())
 	require.Equal(t, uint64(2), baseTrie.AllocatedRegCount())
-	fmt.Println("BASE TRIE:")
-	fmt.Println(baseTrie.String())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
 
 	// path: 1000...
 	p3 := pathByUint8s([]uint8{uint8(129), uint8(1)})
@@ -181,10 +174,8 @@ func TestRightEmptyInsert(t *testing.T) {
 
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(2), updatedTrie.MaxDepth())
 	require.Equal(t, uint64(3), updatedTrie.AllocatedRegCount())
-	fmt.Println("UPDATED TRIE:")
-	fmt.Println(updatedTrie.String())
+	require.Equal(t, uint64(v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
 
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
@@ -224,10 +215,8 @@ func TestExpansionInsert(t *testing.T) {
 
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(0), baseTrie.MaxDepth())
 	require.Equal(t, uint64(1), baseTrie.AllocatedRegCount())
-	fmt.Println("BASE TRIE:")
-	fmt.Println(baseTrie.String())
+	require.Equal(t, uint64(v1.Size()), baseTrie.AllocatedRegSize())
 
 	// path: 1000001...
 	p2 := pathByUint8s([]uint8{uint8(130), uint8(1)})
@@ -241,10 +230,8 @@ func TestExpansionInsert(t *testing.T) {
 
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(7), updatedTrie.MaxDepth())
 	require.Equal(t, uint64(2), updatedTrie.AllocatedRegCount())
-	fmt.Println("UPDATED TRIE:")
-	fmt.Println(updatedTrie.String())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), updatedTrie.AllocatedRegSize())
 
 	paths = []ledger.Path{p1, p2}
 	payloads = []*ledger.Payload{v1, v2}
@@ -293,10 +280,8 @@ func TestFullHouseInsert(t *testing.T) {
 
 	baseTrie, err := forest.GetTrie(baseRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(2), baseTrie.MaxDepth())
 	require.Equal(t, uint64(3), baseTrie.AllocatedRegCount())
-	fmt.Println("BASE TRIE:")
-	fmt.Println(baseTrie.String())
+	require.Equal(t, uint64(v0.Size()+v1.Size()+v2.Size()), baseTrie.AllocatedRegSize())
 
 	// we update value for path p1 and in addition add p3 that has the same prefix `10` as p1
 	v1 = payloadBySlices([]byte{'X'}, []byte{'X'})
@@ -313,10 +298,8 @@ func TestFullHouseInsert(t *testing.T) {
 
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(3), updatedTrie.MaxDepth())
 	require.Equal(t, uint64(4), updatedTrie.AllocatedRegCount())
-	fmt.Println("UPDATED TRIE:")
-	fmt.Println(updatedTrie.String())
+	require.Equal(t, uint64(v0.Size()+v1.Size()+v2.Size()+v3.Size()), updatedTrie.AllocatedRegSize())
 
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
@@ -359,10 +342,8 @@ func TestLeafInsert(t *testing.T) {
 
 	updatedTrie, err := forest.GetTrie(updatedRoot)
 	require.NoError(t, err)
-	require.Equal(t, uint16(256), updatedTrie.MaxDepth())
 	require.Equal(t, uint64(2), updatedTrie.AllocatedRegCount())
-	fmt.Println("TRIE:")
-	fmt.Println(updatedTrie.String())
+	require.Equal(t, uint64(v1.Size()+v2.Size()), updatedTrie.AllocatedRegSize())
 
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
 	retPayloads, err := forest.Read(read)

--- a/ledger/complete/mtrie/node/node_test.go
+++ b/ledger/complete/mtrie/node/node_test.go
@@ -92,31 +92,6 @@ func Test_InterimNodeWithBothChildren(t *testing.T) {
 	require.Equal(t, expectedRootHashHex, hashToString(n.Hash()))
 }
 
-func Test_MaxDepth(t *testing.T) {
-	path := utils.PathByUint16(1)
-	payload := utils.LightPayload(2, 3)
-
-	n1 := node.NewLeaf(path, payload, 0)
-	n2 := node.NewLeaf(path, payload, 0)
-	n3 := node.NewLeaf(path, payload, 1)
-
-	n4 := node.NewInterimNode(1, n1, n2)
-	n5 := node.NewInterimNode(2, n4, n3)
-	require.Equal(t, uint16(2), n5.MaxDepth())
-}
-
-func Test_RegCount(t *testing.T) {
-	path := utils.PathByUint16(1)
-	payload := utils.LightPayload(2, 3)
-	n1 := node.NewLeaf(path, payload, 0)
-	n2 := node.NewLeaf(path, payload, 0)
-	n3 := node.NewLeaf(path, payload, 1)
-
-	n4 := node.NewInterimNode(1, n1, n2)
-	n5 := node.NewInterimNode(2, n4, n3)
-	require.Equal(t, uint64(3), n5.RegCount())
-}
-
 func Test_AllPayloads(t *testing.T) {
 	path := utils.PathByUint16(1)
 	payload := utils.LightPayload(2, 3)
@@ -239,8 +214,6 @@ func Test_Compactify_EmptyChild(t *testing.T) {
 		require.Nil(t, nn5.RightChild())
 		require.True(t, nn5.VerifyCachedHash())
 		require.Equal(t, n5.Hash(), nn5.Hash())
-		require.Equal(t, uint16(2), nn5.MaxDepth())
-		require.Equal(t, uint64(2), nn5.RegCount())
 	})
 
 	t.Run("left child empty", func(t *testing.T) {
@@ -263,8 +236,6 @@ func Test_Compactify_EmptyChild(t *testing.T) {
 		require.Equal(t, n4, nn5.RightChild())
 		require.True(t, nn5.VerifyCachedHash())
 		require.Equal(t, n5.Hash(), nn5.Hash())
-		require.Equal(t, uint16(2), nn5.MaxDepth())
-		require.Equal(t, uint64(2), nn5.RegCount())
 	})
 
 }
@@ -297,16 +268,12 @@ func Test_Compactify_BothChildrenPopulated(t *testing.T) {
 	require.Equal(t, n2, nn3.RightChild())
 	require.True(t, nn3.VerifyCachedHash())
 	require.Equal(t, n3.Hash(), nn3.Hash())
-	require.Equal(t, uint16(1), nn3.MaxDepth())
-	require.Equal(t, uint64(2), nn3.RegCount())
 
 	nn5 := node.NewInterimCompactifiedNode(6, nn3, n4)
 	require.Equal(t, nn3, nn5.LeftChild())
 	require.Equal(t, n4, nn5.RightChild())
 	require.True(t, nn5.VerifyCachedHash())
 	require.Equal(t, n5.Hash(), nn5.Hash())
-	require.Equal(t, uint16(2), nn5.MaxDepth())
-	require.Equal(t, uint64(3), nn5.RegCount())
 }
 
 func hashToString(hash hash.Hash) string {
@@ -324,8 +291,6 @@ func hashToString(hash hash.Hash) string {
 func requireIsLeafWithHash(t *testing.T, node *node.Node, expectedHash hash.Hash) {
 	require.Nil(t, node.LeftChild())
 	require.Nil(t, node.RightChild())
-	require.Equal(t, uint16(0), node.MaxDepth())
-	require.Equal(t, uint64(1), node.RegCount())
 	require.Equal(t, expectedHash, node.Hash())
 	require.True(t, node.VerifyCachedHash())
 	require.True(t, node.IsLeaf())

--- a/ledger/complete/mtrie/trie/trie_test.go
+++ b/ledger/complete/mtrie/trie/trie_test.go
@@ -44,8 +44,11 @@ func Test_TrieWithLeftRegister(t *testing.T) {
 	emptyTrie := trie.NewEmptyMTrie()
 	path := utils.PathByUint16LeftPadded(0)
 	payload := utils.LightPayload(11, 12345)
-	leftPopulatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
+	leftPopulatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(0), maxDepthTouched)
+	require.Equal(t, uint64(1), leftPopulatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(payload.Size()), leftPopulatedTrie.AllocatedRegSize())
 	expectedRootHashHex := "b30c99cc3e027a6ff463876c638041b1c55316ed935f1b3699e52a2c3e3eaaab"
 	require.Equal(t, expectedRootHashHex, hashToString(leftPopulatedTrie.RootHash()))
 }
@@ -62,8 +65,11 @@ func Test_TrieWithRightRegister(t *testing.T) {
 		path[i] = uint8(255)
 	}
 	payload := utils.LightPayload(12346, 54321)
-	rightPopulatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
+	rightPopulatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(0), maxDepthTouched)
+	require.Equal(t, uint64(1), rightPopulatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(payload.Size()), rightPopulatedTrie.AllocatedRegSize())
 	expectedRootHashHex := "4313d22bcabbf21b1cfb833d38f1921f06a91e7198a6672bc68fa24eaaa1a961"
 	require.Equal(t, expectedRootHashHex, hashToString(rightPopulatedTrie.RootHash()))
 }
@@ -77,7 +83,10 @@ func Test_TrieWithMiddleRegister(t *testing.T) {
 
 	path := utils.PathByUint16LeftPadded(56809)
 	payload := utils.LightPayload(12346, 59656)
-	leftPopulatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
+	leftPopulatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
+	require.Equal(t, uint16(0), maxDepthTouched)
+	require.Equal(t, uint64(1), leftPopulatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(payload.Size()), leftPopulatedTrie.AllocatedRegSize())
 	require.NoError(t, err)
 	expectedRootHashHex := "4a29dad0b7ae091a1f035955e0c9aab0692b412f60ae83290b6290d4bf3eb296"
 	require.Equal(t, expectedRootHashHex, hashToString(leftPopulatedTrie.RootHash()))
@@ -92,8 +101,15 @@ func Test_TrieWithManyRegisters(t *testing.T) {
 	// allocate single random register
 	rng := &LinearCongruentialGenerator{seed: 0}
 	paths, payloads := deduplicateWrites(sampleRandomRegisterWrites(rng, 12001))
-	updatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+	var totalPayloadSize uint64
+	for _, p := range payloads {
+		totalPayloadSize += uint64(p.Size())
+	}
+	updatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(255), maxDepthTouched)
+	require.Equal(t, uint64(12001), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize, updatedTrie.AllocatedRegSize())
 	expectedRootHashHex := "74f748dbe563bb5819d6c09a34362a048531fd9647b4b2ea0b6ff43f200198aa"
 	require.Equal(t, expectedRootHashHex, hashToString(updatedTrie.RootHash()))
 }
@@ -110,14 +126,19 @@ func Test_FullTrie(t *testing.T) {
 	rng := &LinearCongruentialGenerator{seed: 0}
 	paths := make([]ledger.Path, 0, numberRegisters)
 	payloads := make([]ledger.Payload, 0, numberRegisters)
+	var totalPayloadSize uint64
 	for i := 0; i < numberRegisters; i++ {
 		paths = append(paths, utils.PathByUint16LeftPadded(uint16(i)))
 		temp := rng.next()
 		payload := utils.LightPayload(temp, temp)
 		payloads = append(payloads, *payload)
+		totalPayloadSize += uint64(payload.Size())
 	}
-	updatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+	updatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(256), maxDepthTouched)
+	require.Equal(t, uint64(numberRegisters), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize, updatedTrie.AllocatedRegSize())
 	expectedRootHashHex := "6b3a48d672744f5586c571c47eae32d7a4a3549c1d4fa51a0acfd7b720471de9"
 	require.Equal(t, expectedRootHashHex, hashToString(updatedTrie.RootHash()))
 }
@@ -156,22 +177,47 @@ func Test_UpdateTrie(t *testing.T) {
 	path := utils.PathByUint16LeftPadded(rng.next())
 	temp := rng.next()
 	payload := utils.LightPayload(temp, temp)
-	updatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
+	updatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, []ledger.Path{path}, []ledger.Payload{*payload}, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(0), maxDepthTouched)
+	require.Equal(t, uint64(1), updatedTrie.AllocatedRegCount())
+	require.Equal(t, uint64(payload.Size()), updatedTrie.AllocatedRegSize())
 	expectedRootHashHex := "08db9aeed2b9fcc66b63204a26a4c28652e44e3035bd87ba0ed632a227b3f6dd"
 	require.Equal(t, expectedRootHashHex, hashToString(updatedTrie.RootHash()))
 
 	var paths []ledger.Path
 	var payloads []ledger.Payload
+	parentTrieRegCount := updatedTrie.AllocatedRegCount()
+	parentTrieRegSize := updatedTrie.AllocatedRegSize()
 	for r := 0; r < 20; r++ {
 		paths, payloads = deduplicateWrites(sampleRandomRegisterWrites(rng, r*100))
-		updatedTrie, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, paths, payloads, true)
+		var totalPayloadSize uint64
+		for _, p := range payloads {
+			totalPayloadSize += uint64(p.Size())
+		}
+		updatedTrie, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, paths, payloads, true)
 		require.NoError(t, err)
+		switch r {
+		case 0:
+			require.Equal(t, uint16(0), maxDepthTouched)
+		case 1:
+			require.Equal(t, uint16(254), maxDepthTouched)
+		default:
+			require.Equal(t, uint16(255), maxDepthTouched)
+		}
+		require.Equal(t, parentTrieRegCount+uint64(len(payloads)), updatedTrie.AllocatedRegCount())
+		require.Equal(t, parentTrieRegSize+totalPayloadSize, updatedTrie.AllocatedRegSize())
 		require.Equal(t, expectedRootHashes[r], hashToString(updatedTrie.RootHash()))
+
+		parentTrieRegCount = updatedTrie.AllocatedRegCount()
+		parentTrieRegSize = updatedTrie.AllocatedRegSize()
 	}
 	// update with the same registers with the same values
-	newTrie, err := trie.NewTrieWithUpdatedRegisters(updatedTrie, paths, payloads, true)
+	newTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(updatedTrie, paths, payloads, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(255), maxDepthTouched)
+	require.Equal(t, updatedTrie.AllocatedRegCount(), newTrie.AllocatedRegCount())
+	require.Equal(t, updatedTrie.AllocatedRegSize(), newTrie.AllocatedRegSize())
 	require.Equal(t, expectedRootHashes[19], hashToString(updatedTrie.RootHash()))
 	// check the root node pointers are equal
 	require.True(t, updatedTrie.RootNode() == newTrie.RootNode())
@@ -186,23 +232,43 @@ func Test_UnallocateRegisters(t *testing.T) {
 
 	// we first draw 99 random key-value pairs that will be first allocated and later unallocated:
 	paths1, payloads1 := deduplicateWrites(sampleRandomRegisterWrites(rng, 99))
-	updatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths1, payloads1, true)
+	var totalPayloadSize1 uint64
+	for _, p := range payloads1 {
+		totalPayloadSize1 += uint64(p.Size())
+	}
+	updatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths1, payloads1, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(254), maxDepthTouched)
+	require.Equal(t, uint64(len(payloads1)), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize1, updatedTrie.AllocatedRegSize())
 
 	// we then write an additional 117 registers
 	paths2, payloads2 := deduplicateWrites(sampleRandomRegisterWrites(rng, 117))
-	updatedTrie, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, paths2, payloads2, true)
+	var totalPayloadSize2 uint64
+	for _, p := range payloads2 {
+		totalPayloadSize2 += uint64(p.Size())
+	}
+	updatedTrie, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, paths2, payloads2, true)
+	require.Equal(t, uint16(254), maxDepthTouched)
+	require.Equal(t, uint64(len(payloads1)+len(payloads2)), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize1+totalPayloadSize2, updatedTrie.AllocatedRegSize())
 	require.NoError(t, err)
 
 	// and now we override the first 99 registers with default values, i.e. unallocate them
 	payloads0 := make([]ledger.Payload, len(payloads1))
-	updatedTrie, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, paths1, payloads0, true)
+	updatedTrie, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, paths1, payloads0, true)
+	require.Equal(t, uint16(254), maxDepthTouched)
+	require.Equal(t, uint64(len(payloads2)), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize2, updatedTrie.AllocatedRegSize())
 	require.NoError(t, err)
 
 	// this should be identical to the first 99 registers never been written
 	expectedRootHashHex := "d81e27a93f2bef058395f70e00fb5d3c8e426e22b3391d048b34017e1ecb483e"
-	comparisonTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths2, payloads2, true)
+	comparisonTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths2, payloads2, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(254), maxDepthTouched)
+	require.Equal(t, uint64(len(payloads2)), comparisonTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize2, comparisonTrie.AllocatedRegSize())
 	require.Equal(t, expectedRootHashHex, hashToString(comparisonTrie.RootHash()))
 	require.Equal(t, expectedRootHashHex, hashToString(updatedTrie.RootHash()))
 }
@@ -336,7 +402,7 @@ func TestSplitByPath(t *testing.T) {
 }
 
 // Test_DifferentiateEmptyVsLeaf tests correct behaviour for a very specific edge case for pruning:
-//  * By convention, a node in the trie is a leaf iff both children are nil.
+//  * By convention, a node in the trie is a leaf if both children are nil.
 //  * Therefore, we consider a completely unallocated subtrie also as a potential leaf.
 // An edge case can now arise when unallocating a previously allocated leaf (see vertex '■' in the illustration below):
 //  * Before the update, both children of the leaf are nil (because it is a leaf)
@@ -377,8 +443,18 @@ func Test_DifferentiateEmptyVsLeaf(t *testing.T) {
 	// initialize Trie to the depicted state
 	paths := append(leftSubTriePath, rightSubTriePath...)
 	payloads := append(leftSubTriePayload, rightSubTriePayload...)
-	startTrie, err := trie.NewTrieWithUpdatedRegisters(trie.NewEmptyMTrie(), paths, payloads, true)
+	var leftSubTriePayloadSize, rightSubTriePayloadSize uint64
+	for _, p := range leftSubTriePayload {
+		leftSubTriePayloadSize += uint64(p.Size())
+	}
+	for _, p := range rightSubTriePayload {
+		rightSubTriePayloadSize += uint64(p.Size())
+	}
+	startTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(trie.NewEmptyMTrie(), paths, payloads, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(241), maxDepthTouched)
+	require.Equal(t, uint64(len(payloads)), startTrie.AllocatedRegCount())
+	require.Equal(t, leftSubTriePayloadSize+rightSubTriePayloadSize, startTrie.AllocatedRegSize())
 	expectedRootHashHex := "8cf6659db0af7626ab0991e2a49019353d549aa4a8c4be1b33e8953d1a9b7fdd"
 	require.Equal(t, expectedRootHashHex, hashToString(startTrie.RootHash()))
 
@@ -389,14 +465,20 @@ func Test_DifferentiateEmptyVsLeaf(t *testing.T) {
 	unallocatedRegister[len(unallocatedRegister)-1] ^= 1 // path differs only in the last byte, i.e. register is also in the left Sub-Trie
 	updatedPaths := append(leftSubTriePath, unallocatedRegister)
 	updatedPayloads := []ledger.Payload{*ledger.EmptyPayload(), *ledger.EmptyPayload()}
-	updatedTrie, err := trie.NewTrieWithUpdatedRegisters(startTrie, updatedPaths, updatedPayloads, true)
+	updatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(startTrie, updatedPaths, updatedPayloads, true)
+	require.Equal(t, uint16(256), maxDepthTouched)
+	require.Equal(t, uint64(len(rightSubTriePayload)), updatedTrie.AllocatedRegCount())
+	require.Equal(t, rightSubTriePayloadSize, updatedTrie.AllocatedRegSize())
 	require.NoError(t, err)
 
 	// The updated trie should equal to a trie containing only the right sub-Trie
 	expectedUpdatedRootHashHex := "576e12a7ef5c760d5cc808ce50e9297919b21b87656b0cc0d9fe8a1a589cf42c"
 	require.Equal(t, expectedUpdatedRootHashHex, hashToString(updatedTrie.RootHash()))
-	referenceTrie, err := trie.NewTrieWithUpdatedRegisters(trie.NewEmptyMTrie(), rightSubTriePath, rightSubTriePayload, true)
+	referenceTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(trie.NewEmptyMTrie(), rightSubTriePath, rightSubTriePayload, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(241), maxDepthTouched)
+	require.Equal(t, uint64(len(rightSubTriePayload)), referenceTrie.AllocatedRegCount())
+	require.Equal(t, rightSubTriePayloadSize, referenceTrie.AllocatedRegSize())
 	require.Equal(t, expectedUpdatedRootHashHex, hashToString(referenceTrie.RootHash()))
 }
 
@@ -417,6 +499,11 @@ func Test_Pruning(t *testing.T) {
 	paths := []ledger.Path{path1, path2, path4, path6}
 	payloads := []ledger.Payload{*payload1, *payload2, *payload4, *payload6}
 
+	var totalPayloadSize uint64
+	for _, p := range payloads {
+		totalPayloadSize += uint64(p.Size())
+	}
+
 	//                    n7
 	//                   / \
 	//                 /     \
@@ -431,15 +518,27 @@ func Test_Pruning(t *testing.T) {
 	// n1 (path1,       n2 (path2)
 	//     payload1)        /payload2)
 
-	baseTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+	baseTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(3), maxDepthTouched)
+	require.Equal(t, uint64(len(payloads)), baseTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize, baseTrie.AllocatedRegSize())
 
 	t.Run("leaf update with pruning test", func(t *testing.T) {
-		trie1, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path1}, []ledger.Payload{*emptyPayload}, false)
-		require.NoError(t, err)
+		expectedRegCount := baseTrie.AllocatedRegCount() - 1
+		expectedRegSize := baseTrie.AllocatedRegSize() - uint64(payload1.Size())
 
-		trie1withpruning, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path1}, []ledger.Payload{*emptyPayload}, true)
+		trie1, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path1}, []ledger.Payload{*emptyPayload}, false)
 		require.NoError(t, err)
+		require.Equal(t, uint16(3), maxDepthTouched)
+		require.Equal(t, expectedRegCount, trie1.AllocatedRegCount())
+		require.Equal(t, expectedRegSize, trie1.AllocatedRegSize())
+
+		trie1withpruning, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path1}, []ledger.Payload{*emptyPayload}, true)
+		require.NoError(t, err)
+		require.Equal(t, uint16(3), maxDepthTouched)
+		require.Equal(t, expectedRegCount, trie1withpruning.AllocatedRegCount())
+		require.Equal(t, expectedRegSize, trie1withpruning.AllocatedRegSize())
 		require.True(t, trie1withpruning.RootNode().VerifyCachedHash())
 
 		// after pruning
@@ -453,28 +552,44 @@ func Test_Pruning(t *testing.T) {
 		//     n3 (path2       n4 (path4
 		//        /payload2)      /payload4) // 01100...
 		require.Equal(t, trie1.RootHash(), trie1withpruning.RootHash())
-		require.Equal(t, trie1.MaxDepth()-1, trie1withpruning.MaxDepth())
 	})
 
 	t.Run("leaf update with two level pruning test", func(t *testing.T) {
+		expectedRegCount := baseTrie.AllocatedRegCount() - 1
+		expectedRegSize := baseTrie.AllocatedRegSize() - uint64(payload4.Size())
+
 		// setting path4 to zero from baseTrie
-		trie2, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path4}, []ledger.Payload{*emptyPayload}, false)
+		trie2, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path4}, []ledger.Payload{*emptyPayload}, false)
 		require.NoError(t, err)
+		require.Equal(t, uint16(2), maxDepthTouched)
+		require.Equal(t, expectedRegCount, trie2.AllocatedRegCount())
+		require.Equal(t, expectedRegSize, trie2.AllocatedRegSize())
 
 		// pruning is not activated here because n3 is not a leaf node
-		trie2withpruning, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path4}, []ledger.Payload{*emptyPayload}, true)
+		trie2withpruning, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path4}, []ledger.Payload{*emptyPayload}, true)
 		require.NoError(t, err)
+		require.Equal(t, uint16(2), maxDepthTouched)
+		require.Equal(t, expectedRegCount, trie2withpruning.AllocatedRegCount())
+		require.Equal(t, expectedRegSize, trie2withpruning.AllocatedRegSize())
 		require.True(t, trie2withpruning.RootNode().VerifyCachedHash())
 
 		require.Equal(t, trie2.RootHash(), trie2withpruning.RootHash())
-		require.Equal(t, trie2.MaxDepth(), trie2withpruning.MaxDepth())
 
 		// now setting path2 to zero should do the pruning for two levels
-		trie22, err := trie.NewTrieWithUpdatedRegisters(trie2, []ledger.Path{path2}, []ledger.Payload{*emptyPayload}, false)
-		require.NoError(t, err)
+		expectedRegCount -= 1
+		expectedRegSize -= uint64(payload2.Size())
 
-		trie22withpruning, err := trie.NewTrieWithUpdatedRegisters(trie2withpruning, []ledger.Path{path2}, []ledger.Payload{*emptyPayload}, true)
+		trie22, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(trie2, []ledger.Path{path2}, []ledger.Payload{*emptyPayload}, false)
 		require.NoError(t, err)
+		require.Equal(t, uint16(3), maxDepthTouched)
+		require.Equal(t, expectedRegCount, trie22.AllocatedRegCount())
+		require.Equal(t, expectedRegSize, trie22.AllocatedRegSize())
+
+		trie22withpruning, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(trie2withpruning, []ledger.Path{path2}, []ledger.Payload{*emptyPayload}, true)
+		require.NoError(t, err)
+		require.Equal(t, uint16(3), maxDepthTouched)
+		require.Equal(t, expectedRegCount, trie22withpruning.AllocatedRegCount())
+		require.Equal(t, expectedRegSize, trie22withpruning.AllocatedRegSize())
 
 		// after pruning
 		//                     n7
@@ -485,24 +600,28 @@ func Test_Pruning(t *testing.T) {
 
 		require.Equal(t, trie22.RootHash(), trie22withpruning.RootHash())
 		require.True(t, trie22withpruning.RootNode().VerifyCachedHash())
-		require.Equal(t, trie22.MaxDepth()-2, trie22withpruning.MaxDepth())
 
 	})
 
 	t.Run("several updates at the same time", func(t *testing.T) {
 		// setting path4 to zero from baseTrie
-		trie3, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path2, path4, path6}, []ledger.Payload{*emptyPayload, *emptyPayload, *emptyPayload}, false)
+		trie3, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path2, path4, path6}, []ledger.Payload{*emptyPayload, *emptyPayload, *emptyPayload}, false)
 		require.NoError(t, err)
+		require.Equal(t, uint16(3), maxDepthTouched)
+		require.Equal(t, uint64(1), trie3.AllocatedRegCount())
+		require.Equal(t, uint64(payload1.Size()), trie3.AllocatedRegSize())
 
 		// this should prune two levels
-		trie3withpruning, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path2, path4, path6}, []ledger.Payload{*emptyPayload, *emptyPayload, *emptyPayload}, true)
+		trie3withpruning, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(baseTrie, []ledger.Path{path2, path4, path6}, []ledger.Payload{*emptyPayload, *emptyPayload, *emptyPayload}, true)
 		require.NoError(t, err)
+		require.Equal(t, uint16(3), maxDepthTouched)
+		require.Equal(t, uint64(1), trie3withpruning.AllocatedRegCount())
+		require.Equal(t, uint64(payload1.Size()), trie3withpruning.AllocatedRegSize())
 
 		// after pruning
 		//       n7  (path1/payload1)
 		require.Equal(t, trie3.RootHash(), trie3withpruning.RootHash())
 		require.True(t, trie3withpruning.RootNode().VerifyCachedHash())
-		require.Equal(t, trie3.MaxDepth()-3, trie3withpruning.MaxDepth())
 	})
 
 	t.Run("smoke testing trie pruning", func(t *testing.T) {
@@ -516,11 +635,16 @@ func Test_Pruning(t *testing.T) {
 		activeTrie := trie.NewEmptyMTrie()
 		activeTrieWithPruning := trie.NewEmptyMTrie()
 		allPaths := make(map[ledger.Path]ledger.Payload)
+		var maxDepthTouched, maxDepthTouchedWithPruning uint16
+		var parentTrieRegCount, parentTrieRegSize uint64
 
 		for step := 0; step < numberOfSteps; step++ {
 
 			updatePaths := make([]ledger.Path, 0)
 			updatePayloads := make([]ledger.Payload, 0)
+
+			var expectedRegCountDelta int64
+			var expectedRegSizeDelta int64
 
 			for i := 0; i < numberOfUpdates; {
 				var path ledger.Path
@@ -530,15 +654,19 @@ func Test_Pruning(t *testing.T) {
 					payload := utils.RandomPayload(1, 100)
 					updatePaths = append(updatePaths, path)
 					updatePayloads = append(updatePayloads, *payload)
+					expectedRegCountDelta++
+					expectedRegSizeDelta += int64(payload.Size())
 					i++
 				}
 			}
 
 			i := 0
 			samplesNeeded := int(math.Min(float64(numberOfRemovals), float64(len(allPaths))))
-			for p := range allPaths {
+			for p, pl := range allPaths {
 				updatePaths = append(updatePaths, p)
 				updatePayloads = append(updatePayloads, *emptyPayload)
+				expectedRegCountDelta--
+				expectedRegSizeDelta -= int64(pl.Size())
 				delete(allPaths, p)
 				i++
 				if i > samplesNeeded {
@@ -551,13 +679,21 @@ func Test_Pruning(t *testing.T) {
 				allPaths[updatePaths[i]] = updatePayloads[i]
 			}
 
-			activeTrie, err = trie.NewTrieWithUpdatedRegisters(activeTrie, updatePaths, updatePayloads, false)
+			activeTrie, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(activeTrie, updatePaths, updatePayloads, false)
 			require.NoError(t, err)
+			require.Equal(t, uint64(int64(parentTrieRegCount)+expectedRegCountDelta), activeTrie.AllocatedRegCount())
+			require.Equal(t, uint64(int64(parentTrieRegSize)+expectedRegSizeDelta), activeTrie.AllocatedRegSize())
 
-			activeTrieWithPruning, err = trie.NewTrieWithUpdatedRegisters(activeTrieWithPruning, updatePaths, updatePayloads, true)
+			activeTrieWithPruning, maxDepthTouchedWithPruning, err = trie.NewTrieWithUpdatedRegisters(activeTrieWithPruning, updatePaths, updatePayloads, true)
 			require.NoError(t, err)
+			require.True(t, maxDepthTouched >= maxDepthTouchedWithPruning)
+			require.Equal(t, uint64(int64(parentTrieRegCount)+expectedRegCountDelta), activeTrieWithPruning.AllocatedRegCount())
+			require.Equal(t, uint64(int64(parentTrieRegSize)+expectedRegSizeDelta), activeTrieWithPruning.AllocatedRegSize())
 
 			require.Equal(t, activeTrie.RootHash(), activeTrieWithPruning.RootHash())
+
+			parentTrieRegCount = activeTrie.AllocatedRegCount()
+			parentTrieRegSize = activeTrie.AllocatedRegSize()
 
 			// fetch all values and compare
 			queryPaths := make([]ledger.Path, 0)
@@ -578,7 +714,6 @@ func Test_Pruning(t *testing.T) {
 			}
 
 		}
-		require.Greater(t, activeTrie.MaxDepth(), activeTrieWithPruning.MaxDepth())
 	})
 }
 
@@ -611,8 +746,9 @@ func TestValueSizes(t *testing.T) {
 		paths := []ledger.Path{path1}
 		payloads := []ledger.Payload{*payload1}
 
-		newTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		newTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 		require.NoError(t, err)
+		require.Equal(t, uint16(0), maxDepthTouched)
 
 		pathsToGetValueSize := []ledger.Path{path1, path2}
 
@@ -634,8 +770,9 @@ func TestValueSizes(t *testing.T) {
 		payloads := []ledger.Payload{*payload1, *payload2}
 
 		// Create a new trie with 2 leaf nodes (n1 and n2) at height 253.
-		newTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		newTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 		require.NoError(t, err)
+		require.Equal(t, uint16(3), maxDepthTouched)
 
 		//                  n5
 		//                 /
@@ -698,8 +835,9 @@ func TestValueSizesWithDuplicatePaths(t *testing.T) {
 	payloads := []ledger.Payload{*payload1, *payload2}
 
 	emptyTrie := trie.NewEmptyMTrie()
-	newTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+	newTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 	require.NoError(t, err)
+	require.Equal(t, uint16(16), maxDepthTouched)
 
 	// pathsToGetValueSize is a mix of duplicate existent and nonexistent paths.
 	pathsToGetValueSize := []ledger.Path{
@@ -720,4 +858,151 @@ func TestValueSizesWithDuplicatePaths(t *testing.T) {
 			require.Equal(t, 0, sizes[i])
 		}
 	}
+}
+
+func TestTrieRegCountRegSize(t *testing.T) {
+
+	rng := &LinearCongruentialGenerator{seed: 0}
+
+	// allocate 255 registers
+	numberRegisters := 255
+	paths := make([]ledger.Path, numberRegisters)
+	payloads := make([]ledger.Payload, numberRegisters)
+	var totalPayloadSize uint64
+	for i := 0; i < numberRegisters; i++ {
+		var p ledger.Path
+		p[0] = byte(i)
+
+		payload := utils.LightPayload(rng.next(), rng.next())
+		paths[i] = p
+		payloads[i] = *payload
+
+		totalPayloadSize += uint64(payload.Size())
+	}
+
+	// Update trie with registers to test reg count and size with new registers.
+	updatedTrie, maxDepthTouched, err := trie.NewTrieWithUpdatedRegisters(trie.NewEmptyMTrie(), paths, payloads, true)
+	require.NoError(t, err)
+	require.True(t, maxDepthTouched <= 256)
+	require.Equal(t, uint64(len(payloads)), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize, updatedTrie.AllocatedRegSize())
+
+	// Update trie with existing paths and updated payloads
+	// to test reg count and size with updated registers
+	// (old payload size > 0 and new payload size > 0).
+	for i := 0; i < len(payloads); i += 2 {
+		newPayload := utils.LightPayload(rng.next(), rng.next())
+		oldPayload := payloads[i]
+		payloads[i] = *newPayload
+		totalPayloadSize += uint64(newPayload.Size()) - uint64(oldPayload.Size())
+	}
+
+	updatedTrie, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, paths, payloads, true)
+	require.NoError(t, err)
+	require.True(t, maxDepthTouched <= 256)
+	require.Equal(t, uint64(len(payloads)), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize, updatedTrie.AllocatedRegSize())
+
+	rootHash := updatedTrie.RootHash()
+
+	// Update trie with new paths and empty payloads
+	// to test reg count and size with new empty registers.
+	newPaths := []ledger.Path{}
+	newPayloads := []ledger.Payload{}
+	for i := 0; i < len(paths); i++ {
+		oldPath := paths[i]
+		p1, _ := ledger.ToPath(oldPath[:])
+		p1[1] = 1
+		p2, _ := ledger.ToPath(oldPath[:])
+		p2[1] = 2
+
+		newPaths = append(newPaths, oldPath, p1, p2)
+		newPayloads = append(newPayloads, payloads[i], *ledger.EmptyPayload(), *ledger.EmptyPayload())
+	}
+
+	updatedTrie, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrie, newPaths, newPayloads, true)
+	require.NoError(t, err)
+	require.Equal(t, rootHash, updatedTrie.RootHash())
+	require.True(t, maxDepthTouched <= 256)
+	require.Equal(t, uint64(len(payloads)), updatedTrie.AllocatedRegCount())
+	require.Equal(t, totalPayloadSize, updatedTrie.AllocatedRegSize())
+
+	t.Run("pruning", func(t *testing.T) {
+		expectedRegCount := uint64(len(payloads))
+		expectedRegSize := totalPayloadSize
+
+		updatedTrieWithPruning := updatedTrie
+
+		// Remove register one by one to test reg count and size with empty registers
+		// (old payload size > 0 and new payload size == 0)
+		for i := 0; i < len(paths); i++ {
+			newPaths := []ledger.Path{paths[i]}
+			newPayloads := []ledger.Payload{*ledger.EmptyPayload()}
+
+			expectedRegCount--
+			expectedRegSize -= uint64(payloads[i].Size())
+
+			updatedTrieWithPruning, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrieWithPruning, newPaths, newPayloads, true)
+			require.NoError(t, err)
+			require.True(t, maxDepthTouched <= 256)
+			require.Equal(t, expectedRegCount, updatedTrieWithPruning.AllocatedRegCount())
+			require.Equal(t, expectedRegSize, updatedTrieWithPruning.AllocatedRegSize())
+		}
+
+		// After all registered are removed, reg count and size should be 0.
+		require.Equal(t, trie.EmptyTrieRootHash(), updatedTrieWithPruning.RootHash())
+		require.Equal(t, uint64(0), updatedTrieWithPruning.AllocatedRegSize())
+		require.Equal(t, uint64(0), updatedTrieWithPruning.AllocatedRegSize())
+	})
+
+	t.Run("no pruning", func(t *testing.T) {
+		expectedRegCount := uint64(len(payloads))
+		expectedRegSize := totalPayloadSize
+
+		updatedTrieNoPruning := updatedTrie
+
+		// Remove register one by one to test reg count and size with empty registers
+		// (old payload size > 0 and new payload size == 0)
+		for i := 0; i < len(paths); i++ {
+			newPaths := []ledger.Path{paths[i]}
+			newPayloads := []ledger.Payload{*ledger.EmptyPayload()}
+
+			expectedRegCount--
+			expectedRegSize -= uint64(payloads[i].Size())
+
+			updatedTrieNoPruning, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrieNoPruning, newPaths, newPayloads, false)
+			require.NoError(t, err)
+			require.True(t, maxDepthTouched <= 256)
+			require.Equal(t, expectedRegCount, updatedTrieNoPruning.AllocatedRegCount())
+			require.Equal(t, expectedRegSize, updatedTrieNoPruning.AllocatedRegSize())
+		}
+
+		// After all registered are removed, reg count and size should be 0.
+		require.Equal(t, trie.EmptyTrieRootHash(), updatedTrieNoPruning.RootHash())
+		require.Equal(t, uint64(0), updatedTrieNoPruning.AllocatedRegCount())
+		require.Equal(t, uint64(0), updatedTrieNoPruning.AllocatedRegSize())
+
+		// Update with removed paths and empty payloads
+		// (old payload size == 0 and new payload size == 0)
+		newPayloads := make([]ledger.Payload, len(paths))
+		for i := 0; i < len(paths); i++ {
+			newPayloads[i] = *ledger.EmptyPayload()
+		}
+
+		updatedTrieNoPruning, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrieNoPruning, paths, newPayloads, false)
+		require.NoError(t, err)
+		require.True(t, maxDepthTouched <= 256)
+		require.Equal(t, trie.EmptyTrieRootHash(), updatedTrieNoPruning.RootHash())
+		require.Equal(t, uint64(0), updatedTrieNoPruning.AllocatedRegCount())
+		require.Equal(t, uint64(0), updatedTrieNoPruning.AllocatedRegSize())
+
+		// Update with removed paths and non-empty payloads
+		// (old payload size == 0 and new payload size > 0)
+		updatedTrieNoPruning, maxDepthTouched, err = trie.NewTrieWithUpdatedRegisters(updatedTrieNoPruning, paths, payloads, false)
+		require.NoError(t, err)
+		require.Equal(t, rootHash, updatedTrie.RootHash())
+		require.True(t, maxDepthTouched <= 256)
+		require.Equal(t, uint64(len(payloads)), updatedTrieNoPruning.AllocatedRegCount())
+		require.Equal(t, totalPayloadSize, updatedTrieNoPruning.AllocatedRegSize())
+	})
 }

--- a/ledger/complete/wal/checkpointer_test.go
+++ b/ledger/complete/wal/checkpointer_test.go
@@ -519,7 +519,7 @@ func Test_StoringLoadingCheckpoints(t *testing.T) {
 		paths := []ledger.Path{p1, p2}
 		payloads := []ledger.Payload{*v1, *v2}
 
-		updatedTrie, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 		require.NoError(t, err)
 
 		someHash := updatedTrie.RootNode().LeftChild().Hash() // Hash of left child

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -231,7 +231,11 @@ func (k *Key) DeepCopy() Key {
 }
 
 // Equals compares this key to another key
+// A nil key is equivalent to an empty key.
 func (k *Key) Equals(other *Key) bool {
+	if k == nil || len(k.KeyParts) == 0 {
+		return other == nil || len(other.KeyParts) == 0
+	}
 	if other == nil {
 		return false
 	}
@@ -305,10 +309,8 @@ func (v Value) DeepCopy() Value {
 }
 
 // Equals compares a ledger Value to another one
+// A nil value is equivalent to an empty value.
 func (v Value) Equals(other Value) bool {
-	if other == nil {
-		return false
-	}
 	return bytes.Equal(v, other)
 }
 

--- a/ledger/ledger_test.go
+++ b/ledger/ledger_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // this benchmark can run with this command:
@@ -53,4 +55,289 @@ func BenchmarkOriginalCanonicalForm(b *testing.B) {
 	for _, kp := range keyParts {
 		ret += fmt.Sprintf("/%d/%v", kp.Type, string(kp.Value))
 	}
+}
+
+func TestPayloadKeyEquals(t *testing.T) {
+
+	nilKey := (*Key)(nil)
+	emptyKey := &Key{}
+
+	t.Run("nil vs empty", func(t *testing.T) {
+		require.True(t, nilKey.Equals(emptyKey))
+		require.True(t, emptyKey.Equals(nilKey))
+	})
+
+	t.Run("nil vs nil", func(t *testing.T) {
+		require.True(t, nilKey.Equals(nilKey))
+	})
+
+	t.Run("empty vs empty", func(t *testing.T) {
+		require.True(t, emptyKey.Equals(emptyKey))
+	})
+
+	t.Run("empty vs not-empty", func(t *testing.T) {
+		k := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+			},
+		}
+		require.False(t, emptyKey.Equals(k))
+		require.False(t, k.Equals(emptyKey))
+	})
+
+	t.Run("nil vs not-empty", func(t *testing.T) {
+		k := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+			},
+		}
+		require.False(t, nilKey.Equals(k))
+		require.False(t, k.Equals(nilKey))
+	})
+
+	t.Run("num of KeyParts different", func(t *testing.T) {
+		k1 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+			},
+		}
+		k2 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+				{1, []byte{0x03, 0x04}},
+			},
+		}
+		require.False(t, k1.Equals(k2))
+		require.False(t, k2.Equals(k1))
+	})
+
+	t.Run("KeyPart different", func(t *testing.T) {
+		k := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+				{1, []byte{0x03, 0x04}},
+			},
+		}
+		// k1.KeyParts[1].Type is different.
+		k1 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+				{2, []byte{0x03, 0x04}},
+			},
+		}
+		// k2.KeyParts[1].Value is different (same length).
+		k2 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+				{1, []byte{0x03, 0x05}},
+			},
+		}
+		// k3.KeyParts[1].Value is different (different length).
+		k3 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+				{1, []byte{0x03}},
+			},
+		}
+		// k4.KeyParts has different order.
+		k4 := &Key{
+			KeyParts: []KeyPart{
+				{1, []byte{0x03, 0x04}},
+				{0, []byte{0x01, 0x02}},
+			},
+		}
+		require.False(t, k.Equals(k1))
+		require.False(t, k.Equals(k2))
+		require.False(t, k.Equals(k3))
+		require.False(t, k.Equals(k4))
+	})
+
+	t.Run("same", func(t *testing.T) {
+		k1 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+			},
+		}
+		k2 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+			},
+		}
+		require.True(t, k1.Equals(k2))
+		require.True(t, k2.Equals(k1))
+
+		k3 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+				{1, []byte{0x03, 0x04}},
+			},
+		}
+		k4 := &Key{
+			KeyParts: []KeyPart{
+				{0, []byte{0x01, 0x02}},
+				{1, []byte{0x03, 0x04}},
+			},
+		}
+		require.True(t, k3.Equals(k4))
+		require.True(t, k4.Equals(k3))
+	})
+}
+
+func TestPayloadValueEquals(t *testing.T) {
+
+	nilValue := (Value)(nil)
+	emptyValue := Value{}
+
+	t.Run("nil vs empty", func(t *testing.T) {
+		require.True(t, nilValue.Equals(emptyValue))
+		require.True(t, emptyValue.Equals(nilValue))
+	})
+
+	t.Run("nil vs nil", func(t *testing.T) {
+		require.True(t, nilValue.Equals(nilValue))
+	})
+
+	t.Run("empty vs empty", func(t *testing.T) {
+		require.True(t, emptyValue.Equals(emptyValue))
+	})
+
+	t.Run("empty vs non-empty", func(t *testing.T) {
+		v := Value{0x01, 0x02}
+		require.False(t, emptyValue.Equals(v))
+		require.False(t, v.Equals(emptyValue))
+	})
+
+	t.Run("nil vs non-empty", func(t *testing.T) {
+		v := Value{0x01, 0x02}
+		require.False(t, nilValue.Equals(v))
+		require.False(t, v.Equals(nilValue))
+	})
+
+	t.Run("length different", func(t *testing.T) {
+		v1 := Value{0x01, 0x02}
+		v2 := Value{0x01, 0x02, 0x03}
+		require.False(t, v1.Equals(v2))
+		require.False(t, v2.Equals(v1))
+	})
+
+	t.Run("data different", func(t *testing.T) {
+		v1 := Value{0x01, 0x02}
+		v2 := Value{0x01, 0x03}
+		require.False(t, v1.Equals(v2))
+		require.False(t, v2.Equals(v1))
+	})
+
+	t.Run("same", func(t *testing.T) {
+		v1 := Value{0x01, 0x02}
+		v2 := Value{0x01, 0x02}
+		require.True(t, v1.Equals(v2))
+		require.True(t, v2.Equals(v1))
+	})
+}
+
+func TestPayloadEquals(t *testing.T) {
+	nilPayload := (*Payload)(nil)
+	emptyPayload := EmptyPayload()
+
+	t.Run("nil vs empty", func(t *testing.T) {
+		require.True(t, nilPayload.Equals(emptyPayload))
+		require.True(t, emptyPayload.Equals(nilPayload))
+	})
+
+	t.Run("nil vs nil", func(t *testing.T) {
+		require.True(t, nilPayload.Equals(nilPayload))
+	})
+
+	t.Run("empty vs empty", func(t *testing.T) {
+		require.True(t, emptyPayload.Equals(emptyPayload))
+	})
+
+	t.Run("empty vs non-empty", func(t *testing.T) {
+		p := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		require.False(t, emptyPayload.Equals(p))
+		require.False(t, p.Equals(emptyPayload))
+	})
+
+	t.Run("nil vs non-empty", func(t *testing.T) {
+		p := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		require.False(t, nilPayload.Equals(p))
+		require.False(t, p.Equals(nilPayload))
+	})
+
+	t.Run("different key", func(t *testing.T) {
+		p := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		// p1.Key.KeyParts[0].Type is different
+		p1 := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{2, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		// p2.Key.KeyParts[0].Value is different
+		p2 := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02, 0x03}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		// len(p3.Key.KeyParts) is different
+		p3 := &Payload{
+			Key: Key{KeyParts: []KeyPart{
+				{1, []byte{0x01, 0x02}},
+				{2, []byte{0x03, 0x04}}},
+			},
+			Value: []byte{0x03, 0x04},
+		}
+		require.False(t, p.Equals(p1))
+		require.False(t, p.Equals(p2))
+		require.False(t, p.Equals(p3))
+	})
+
+	t.Run("different value", func(t *testing.T) {
+		p := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		// p1.Value is nil
+		p1 := &Payload{
+			Key: Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+		}
+		// p2.Value is empty
+		p2 := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{},
+		}
+		// p3.Value length is different
+		p3 := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03},
+		}
+		// p4.Value data is different
+		p4 := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x05},
+		}
+		require.False(t, p.Equals(p1))
+		require.False(t, p.Equals(p2))
+		require.False(t, p.Equals(p3))
+		require.False(t, p.Equals(p4))
+	})
+
+	t.Run("same", func(t *testing.T) {
+		p1 := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		p2 := &Payload{
+			Key:   Key{KeyParts: []KeyPart{{1, []byte{0x01, 0x02}}}},
+			Value: []byte{0x03, 0x04},
+		}
+		require.True(t, p1.Equals(p2))
+		require.True(t, p2.Equals(p1))
+	})
 }

--- a/ledger/trie.go
+++ b/ledger/trie.go
@@ -224,7 +224,11 @@ func (p *Payload) String() string {
 }
 
 // Equals compares this payload to another payload
+// A nil payload is equivalent to an empty payload.
 func (p *Payload) Equals(other *Payload) bool {
+	if p == nil || (len(p.Key.KeyParts) == 0 && len(p.Value) == 0) {
+		return other == nil || (len(other.Key.KeyParts) == 0 && len(other.Value) == 0)
+	}
 	if other == nil {
 		return false
 	}

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -274,13 +274,16 @@ type LedgerMetrics interface {
 	LatestTrieRegCount(number uint64)
 
 	// LatestTrieRegCountDiff records the difference between the number of unique register allocated of the latest created trie and parent trie
-	LatestTrieRegCountDiff(number uint64)
+	LatestTrieRegCountDiff(number int64)
 
-	// LatestTrieMaxDepth records the maximum depth of the last created trie
-	LatestTrieMaxDepth(number uint64)
+	// LatestTrieRegSize records the size of unique register allocated (the latest created trie)
+	LatestTrieRegSize(size uint64)
 
-	// LatestTrieMaxDepthDiff records the difference between the max depth of the latest created trie and parent trie
-	LatestTrieMaxDepthDiff(number uint64)
+	// LatestTrieRegSizeDiff records the difference between the size of unique register allocated of the latest created trie and parent trie
+	LatestTrieRegSizeDiff(size int64)
+
+	// LatestTrieMaxDepthTouched records the maximum depth touched of the lastest created trie
+	LatestTrieMaxDepthTouched(maxDepth uint16)
 
 	// UpdateCount increase a counter of performed updates
 	UpdateCount()

--- a/module/metrics/execution.go
+++ b/module/metrics/execution.go
@@ -25,8 +25,9 @@ type ExecutionCollector struct {
 	forestNumberOfTrees              prometheus.Gauge
 	latestTrieRegCount               prometheus.Gauge
 	latestTrieRegCountDiff           prometheus.Gauge
-	latestTrieMaxDepth               prometheus.Gauge
-	latestTrieMaxDepthDiff           prometheus.Gauge
+	latestTrieRegSize                prometheus.Gauge
+	latestTrieRegSizeDiff            prometheus.Gauge
+	latestTrieMaxDepthTouched        prometheus.Gauge
 	updated                          prometheus.Counter
 	proofSize                        prometheus.Gauge
 	updatedValuesNumber              prometheus.Counter
@@ -92,18 +93,25 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 		Help:      "the difference between number of unique register allocated of the latest created trie and parent trie",
 	})
 
-	latestTrieMaxDepth := promauto.NewGauge(prometheus.GaugeOpts{
+	latestTrieRegSize := promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespaceExecution,
 		Subsystem: subsystemMTrie,
-		Name:      "latest_trie_max_depth",
-		Help:      "the maximum depth of the latest created trie",
+		Name:      "latest_trie_reg_size",
+		Help:      "the size of allocated registers (latest created trie)",
 	})
 
-	latestTrieMaxDepthDiff := promauto.NewGauge(prometheus.GaugeOpts{
+	latestTrieRegSizeDiff := promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespaceExecution,
 		Subsystem: subsystemMTrie,
-		Name:      "latest_trie_max_depth_diff",
-		Help:      "the the difference between the max depth of the latest created trie and parent trie",
+		Name:      "latest_trie_reg_size_diff",
+		Help:      "the difference between size of unique register allocated of the latest created trie and parent trie",
+	})
+
+	latestTrieMaxDepthTouched := promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespaceExecution,
+		Subsystem: subsystemMTrie,
+		Name:      "latest_trie_max_depth_touched",
+		Help:      "the maximum depth touched of the latest created trie",
 	})
 
 	updatedCount := promauto.NewCounter(prometheus.CounterOpts{
@@ -336,8 +344,9 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 		forestNumberOfTrees:         forestNumberOfTrees,
 		latestTrieRegCount:          latestTrieRegCount,
 		latestTrieRegCountDiff:      latestTrieRegCountDiff,
-		latestTrieMaxDepth:          latestTrieMaxDepth,
-		latestTrieMaxDepthDiff:      latestTrieMaxDepthDiff,
+		latestTrieRegSize:           latestTrieRegSize,
+		latestTrieRegSizeDiff:       latestTrieRegSizeDiff,
+		latestTrieMaxDepthTouched:   latestTrieMaxDepthTouched,
 		updated:                     updatedCount,
 		proofSize:                   proofSize,
 		updatedValuesNumber:         updatedValuesNumber,
@@ -539,18 +548,23 @@ func (ec *ExecutionCollector) LatestTrieRegCount(number uint64) {
 }
 
 // LatestTrieRegCountDiff records the difference between the number of unique register allocated of the latest created trie and parent trie
-func (ec *ExecutionCollector) LatestTrieRegCountDiff(number uint64) {
+func (ec *ExecutionCollector) LatestTrieRegCountDiff(number int64) {
 	ec.latestTrieRegCountDiff.Set(float64(number))
 }
 
-// LatestTrieMaxDepth records the maximum depth of the last created trie
-func (ec *ExecutionCollector) LatestTrieMaxDepth(number uint64) {
-	ec.latestTrieMaxDepth.Set(float64(number))
+// LatestTrieRegSize records the size of unique register allocated (the lastest created trie)
+func (ec *ExecutionCollector) LatestTrieRegSize(size uint64) {
+	ec.latestTrieRegSize.Set(float64(size))
 }
 
-// LatestTrieMaxDepthDiff records the difference between the max depth of the latest created trie and parent trie
-func (ec *ExecutionCollector) LatestTrieMaxDepthDiff(number uint64) {
-	ec.latestTrieMaxDepthDiff.Set(float64(number))
+// LatestTrieRegSizeDiff records the difference between the size of unique register allocated of the latest created trie and parent trie
+func (ec *ExecutionCollector) LatestTrieRegSizeDiff(size int64) {
+	ec.latestTrieRegSizeDiff.Set(float64(size))
+}
+
+// LatestTrieMaxDepthTouched records the maximum depth touched of the last created trie
+func (ec *ExecutionCollector) LatestTrieMaxDepthTouched(maxDepth uint16) {
+	ec.latestTrieMaxDepthTouched.Set(float64(maxDepth))
 }
 
 // UpdateCount increase a counter of performed updates

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -122,9 +122,10 @@ func (nc *NoopCollector) ExecutionScriptExecuted(dur time.Duration, compUsed uin
 func (nc *NoopCollector) ForestApproxMemorySize(bytes uint64)                                   {}
 func (nc *NoopCollector) ForestNumberOfTrees(number uint64)                                     {}
 func (nc *NoopCollector) LatestTrieRegCount(number uint64)                                      {}
-func (nc *NoopCollector) LatestTrieRegCountDiff(number uint64)                                  {}
-func (nc *NoopCollector) LatestTrieMaxDepth(number uint64)                                      {}
-func (nc *NoopCollector) LatestTrieMaxDepthDiff(number uint64)                                  {}
+func (nc *NoopCollector) LatestTrieRegCountDiff(number int64)                                   {}
+func (nc *NoopCollector) LatestTrieRegSize(size uint64)                                         {}
+func (nc *NoopCollector) LatestTrieRegSizeDiff(size int64)                                      {}
+func (nc *NoopCollector) LatestTrieMaxDepthTouched(maxDepth uint16)                             {}
 func (nc *NoopCollector) UpdateCount()                                                          {}
 func (nc *NoopCollector) ProofSize(bytes uint32)                                                {}
 func (nc *NoopCollector) UpdateValuesNumber(number uint64)                                      {}

--- a/module/mock/execution_metrics.go
+++ b/module/mock/execution_metrics.go
@@ -99,14 +99,9 @@ func (_m *ExecutionMetrics) ForestNumberOfTrees(number uint64) {
 	_m.Called(number)
 }
 
-// LatestTrieMaxDepth provides a mock function with given fields: number
-func (_m *ExecutionMetrics) LatestTrieMaxDepth(number uint64) {
-	_m.Called(number)
-}
-
-// LatestTrieMaxDepthDiff provides a mock function with given fields: number
-func (_m *ExecutionMetrics) LatestTrieMaxDepthDiff(number uint64) {
-	_m.Called(number)
+// LatestTrieMaxDepthTouched provides a mock function with given fields: maxDepth
+func (_m *ExecutionMetrics) LatestTrieMaxDepthTouched(maxDepth uint16) {
+	_m.Called(maxDepth)
 }
 
 // LatestTrieRegCount provides a mock function with given fields: number
@@ -115,8 +110,18 @@ func (_m *ExecutionMetrics) LatestTrieRegCount(number uint64) {
 }
 
 // LatestTrieRegCountDiff provides a mock function with given fields: number
-func (_m *ExecutionMetrics) LatestTrieRegCountDiff(number uint64) {
+func (_m *ExecutionMetrics) LatestTrieRegCountDiff(number int64) {
 	_m.Called(number)
+}
+
+// LatestTrieRegSize provides a mock function with given fields: size
+func (_m *ExecutionMetrics) LatestTrieRegSize(size uint64) {
+	_m.Called(size)
+}
+
+// LatestTrieRegSizeDiff provides a mock function with given fields: size
+func (_m *ExecutionMetrics) LatestTrieRegSizeDiff(size int64) {
+	_m.Called(size)
 }
 
 // ProofSize provides a mock function with given fields: bytes

--- a/module/mock/ledger_metrics.go
+++ b/module/mock/ledger_metrics.go
@@ -23,14 +23,9 @@ func (_m *LedgerMetrics) ForestNumberOfTrees(number uint64) {
 	_m.Called(number)
 }
 
-// LatestTrieMaxDepth provides a mock function with given fields: number
-func (_m *LedgerMetrics) LatestTrieMaxDepth(number uint64) {
-	_m.Called(number)
-}
-
-// LatestTrieMaxDepthDiff provides a mock function with given fields: number
-func (_m *LedgerMetrics) LatestTrieMaxDepthDiff(number uint64) {
-	_m.Called(number)
+// LatestTrieMaxDepthTouched provides a mock function with given fields: maxDepth
+func (_m *LedgerMetrics) LatestTrieMaxDepthTouched(maxDepth uint16) {
+	_m.Called(maxDepth)
 }
 
 // LatestTrieRegCount provides a mock function with given fields: number
@@ -39,8 +34,18 @@ func (_m *LedgerMetrics) LatestTrieRegCount(number uint64) {
 }
 
 // LatestTrieRegCountDiff provides a mock function with given fields: number
-func (_m *LedgerMetrics) LatestTrieRegCountDiff(number uint64) {
+func (_m *LedgerMetrics) LatestTrieRegCountDiff(number int64) {
 	_m.Called(number)
+}
+
+// LatestTrieRegSize provides a mock function with given fields: size
+func (_m *LedgerMetrics) LatestTrieRegSize(size uint64) {
+	_m.Called(size)
+}
+
+// LatestTrieRegSizeDiff provides a mock function with given fields: size
+func (_m *LedgerMetrics) LatestTrieRegSizeDiff(size int64) {
+	_m.Called(size)
 }
 
 // ProofSize provides a mock function with given fields: bytes


### PR DESCRIPTION
Reduce checkpoint file size by over 4GB and RAM usage by a similar amount.  Speed will also benefit from these change.

Benchmarks comparisons are WIP (coming soon).

Closes #1747 #1748 #2125 

### Note

lowestHeightTouched returned by update() is the lowest height reached during recursive update.  Unlike maxDepth, lowestHeightTouched isn't affected by prune flag.  It's mostly new/updated node height.  It can also be height of new node created from compact leaf at a higher height.

### Changes include:

- remove Node.regCount (8 bytes) and Node.maxDepth (2 bytes)

- remove regCount (8 bytes) and maxDepth (2 bytes) from checkpoint node serialization

- add MTrie.regCount (8 bytes) and MTrie.regSize (8 bytes)

- add regCount (8 bytes) and regSize (b bytes) to checkpoint trie serialization

- modify trie update() to return regCountDelta, regSizeDelta, and lowestHeightTouched so that NewTrieWithUpdatedRegisters()
can compute regCount, regSize, and maxDepthTouched for the updated trie

- fix Payload.Equals() crash bug when p is nil

- fix Payload.Equals() bug when comparing nil payload with empty payload

### TODO

- [ ] file format conversion required for benchmarks
- [ ] benchmark comparisons