### PR TITLE
Update Cadence version to secure-cadence-m1

### DIFF
--- a/fvm/contract_function_invokers.go
+++ b/fvm/contract_function_invokers.go
@@ -29,7 +29,7 @@ func DeductTransactionFeesInvocation(
 			},
 			systemcontracts.ContractServiceAccountFunction_deductTransactionFee,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(common.Address(payer)),
+				interpreter.NewAddressValue(env, common.Address(payer)),
 			},
 			deductTransactionFeesInvocationArgumentTypes,
 			env.Context().Logger,
@@ -57,8 +57,8 @@ func SetupNewAccountInvocation(
 			},
 			systemcontracts.ContractServiceAccountFunction_setupNewAccount,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(common.Address(flowAddress)),
-				interpreter.NewAddressValue(payer),
+				interpreter.NewAddressValue(env, common.Address(flowAddress)),
+				interpreter.NewAddressValue(env, payer),
 			},
 			setupNewAccountInvocationArgumentTypes,
 			env.Context().Logger,
@@ -84,7 +84,7 @@ func AccountAvailableBalanceInvocation(
 			},
 			systemcontracts.ContractStorageFeesFunction_defaultTokenAvailableBalance,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
+				interpreter.NewAddressValue(env, address),
 			},
 			accountAvailableBalanceInvocationArgumentTypes,
 			env.Context().Logger,
@@ -109,7 +109,7 @@ func AccountBalanceInvocation(
 				Name:    systemcontracts.ContractServiceAccount},
 			systemcontracts.ContractServiceAccountFunction_defaultTokenBalance,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
+				interpreter.NewAddressValue(env, address),
 			},
 			accountBalanceInvocationArgumentTypes,
 			env.Context().Logger,
@@ -135,7 +135,7 @@ func AccountStorageCapacityInvocation(
 			},
 			systemcontracts.ContractStorageFeesFunction_calculateAccountCapacity,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
+				interpreter.NewAddressValue(env, address),
 			},
 			accountStorageCapacityInvocationArgumentTypes,
 			env.Context().Logger,
@@ -162,7 +162,7 @@ func UseContractAuditVoucherInvocation(
 			},
 			systemcontracts.ContractDeploymentAuditsFunction_useVoucherForDeploy,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
+				interpreter.NewAddressValue(env, address),
 				interpreter.NewUnmeteredStringValue(code),
 			},
 			useContractAuditVoucherInvocationArgumentTypes,

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.3.0
-	github.com/onflow/cadence v0.21.3-0.20220316204141-2e995e2195c8
+	github.com/onflow/cadence v0.21.3-0.20220317173919-b23d45bcd67d
 	github.com/onflow/flow v0.2.3-0.20220131193101-d4e2ca43a621
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.2-0.20220316181225-1ae94da816da
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -1303,8 +1303,8 @@ github.com/onflow/atree v0.3.0/go.mod h1:tSPKjdmbNOQyVrSvcxKZG8+EDL4jdjoJBGAjNVk
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.21.3-0.20220316204141-2e995e2195c8 h1:gn+ydwKMEsRq3e/YgLrUaTZxsQtLBcFNebdAlM9UNaY=
-github.com/onflow/cadence v0.21.3-0.20220316204141-2e995e2195c8/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
+github.com/onflow/cadence v0.21.3-0.20220317173919-b23d45bcd67d h1:86Xb5fORUwvzZpZ0B/phwq7h25SVWPGqBhMu8IehKsU=
+github.com/onflow/cadence v0.21.3-0.20220317173919-b23d45bcd67d/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/flow v0.2.3-0.20220131193101-d4e2ca43a621 h1:owMor9/wFpw3fua47UkUeDaFwyySK/dIPiNCCyhoO7c=
 github.com/onflow/flow v0.2.3-0.20220131193101-d4e2ca43a621/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.21.3-0.20220316204141-2e995e2195c8
+	github.com/onflow/cadence v0.21.3-0.20220317173919-b23d45bcd67d
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.2-0.20220316181225-1ae94da816da
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.10.1
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1414,8 +1414,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.21.3-0.20220316204141-2e995e2195c8 h1:gn+ydwKMEsRq3e/YgLrUaTZxsQtLBcFNebdAlM9UNaY=
-github.com/onflow/cadence v0.21.3-0.20220316204141-2e995e2195c8/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
+github.com/onflow/cadence v0.21.3-0.20220317173919-b23d45bcd67d h1:86Xb5fORUwvzZpZ0B/phwq7h25SVWPGqBhMu8IehKsU=
+github.com/onflow/cadence v0.21.3-0.20220317173919-b23d45bcd67d/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/flow v0.2.3-0.20220131193101-d4e2ca43a621 h1:owMor9/wFpw3fua47UkUeDaFwyySK/dIPiNCCyhoO7c=
 github.com/onflow/flow v0.2.3-0.20220131193101-d4e2ca43a621/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.2-0.20220316181225-1ae94da816da h1:j9ZmZPeOEOx0QR12EZpsbvvbJoedrRWGyz772PTlsj4=


### PR DESCRIPTION
Uses the https://github.com/onflow/cadence/tree/secure-cadence-m1 tag