### PR TITLE
Port #2141 to secure cadence branch

### DIFF
--- a/cmd/access/node_builder/staked_access_node_builder.go
+++ b/cmd/access/node_builder/staked_access_node_builder.go
@@ -97,8 +97,6 @@ func (builder *StakedAccessNodeBuilder) Initialize() error {
 		return err
 	}
 
-	builder.EnqueueAdminServerInit()
-
 	builder.EnqueueTracer()
 	builder.PreInit(cmd.DynamicStartPreInit)
 	return nil

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -335,10 +335,7 @@ func prepareService(container testnet.ContainerConfig, i int, n int) Service {
 		},
 	}
 
-	// TODO: having trouble enabling admin tool for access node. skip Access node for now.
-	if container.Role != flow.RoleAccess {
-		service.Command = append(service.Command, fmt.Sprintf("--admin-addr=:%v", AdminToolPort))
-	}
+	service.Command = append(service.Command, fmt.Sprintf("--admin-addr=:%v", AdminToolPort))
 
 	// only specify build config for first service of each role
 	if i == 0 {


### PR DESCRIPTION
Porting https://github.com/onflow/flow-go/pull/2141 to the secure-cadence branch