### PR TITLE
Auto Cadence Update: Commit storage before getting account storage capacity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.3.0
-	github.com/onflow/cadence v0.21.3-0.20220323224900-6d5d6888bf3e
+	github.com/onflow/cadence v0.21.3-0.20220323232138-8846b7d0ba0b
 	github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.2-0.20220211010218-ef36227fc493
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.10.1

--- a/go.sum
+++ b/go.sum
@@ -1296,8 +1296,8 @@ github.com/onflow/atree v0.3.0/go.mod h1:tSPKjdmbNOQyVrSvcxKZG8+EDL4jdjoJBGAjNVk
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.21.3-0.20220323224900-6d5d6888bf3e h1:k5fTxnMtQ2QUpgJW96LbG56AkQkYekxMsiaBBYYqL5I=
-github.com/onflow/cadence v0.21.3-0.20220323224900-6d5d6888bf3e/go.mod h1:04MIHEGi0jlTsKlMyp1bvjuiY+hGHuI1pPqb5UWwhLo=
+github.com/onflow/cadence v0.21.3-0.20220323232138-8846b7d0ba0b h1:JzgUoWhfiQ2tUUJsBptUcioBR4MqGzfRYtJI8Mbtr08=
+github.com/onflow/cadence v0.21.3-0.20220323232138-8846b7d0ba0b/go.mod h1:04MIHEGi0jlTsKlMyp1bvjuiY+hGHuI1pPqb5UWwhLo=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7 h1:rDsoaE08eNwDGeIH++1Nk9iUxB7dhILnmgvVPNq9DU8=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.21.3-0.20220323224900-6d5d6888bf3e
+	github.com/onflow/cadence v0.21.3-0.20220323232138-8846b7d0ba0b
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.2-0.20220211010218-ef36227fc493
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.10.1
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1410,8 +1410,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.21.3-0.20220323224900-6d5d6888bf3e h1:k5fTxnMtQ2QUpgJW96LbG56AkQkYekxMsiaBBYYqL5I=
-github.com/onflow/cadence v0.21.3-0.20220323224900-6d5d6888bf3e/go.mod h1:04MIHEGi0jlTsKlMyp1bvjuiY+hGHuI1pPqb5UWwhLo=
+github.com/onflow/cadence v0.21.3-0.20220323232138-8846b7d0ba0b h1:JzgUoWhfiQ2tUUJsBptUcioBR4MqGzfRYtJI8Mbtr08=
+github.com/onflow/cadence v0.21.3-0.20220323232138-8846b7d0ba0b/go.mod h1:04MIHEGi0jlTsKlMyp1bvjuiY+hGHuI1pPqb5UWwhLo=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7 h1:rDsoaE08eNwDGeIH++1Nk9iUxB7dhILnmgvVPNq9DU8=
 github.com/onflow/flow v0.2.3-0.20211203180137-d6c902ccc3a7/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.10.2-0.20220211010218-ef36227fc493 h1:rXUomP6CdDWt+eKkdPnIt4GcFY1CKFRIdmP6eTJtJEQ=


### PR DESCRIPTION
Auto generated PR to update Cadence version.

References: https://github.com/onflow/cadence/pull/1525