### PR TITLE
Add migrations back to v0.25

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -61,19 +61,19 @@ func extractExecutionState(
 	var rs []ledger.Reporter
 
 	if migrate {
-		//storageUsedUpdateMigration := mgr.StorageUsedUpdateMigration{
-		//	Log:       log,
-		//	OutputDir: outputDir,
-		//}
-		//
-		//orderedMapMigration := mgr.OrderedMapMigration{
-		//	Log:       log,
-		//	OutputDir: dir,
-		//}
+		storageUsedUpdateMigration := mgr.StorageUsedUpdateMigration{
+			Log:       log,
+			OutputDir: outputDir,
+		}
+
+		orderedMapMigration := mgr.OrderedMapMigration{
+			Log:       log,
+			OutputDir: dir,
+		}
 
 		migrations = []ledger.Migration{
-			//orderedMapMigration.Migrate,
-			//storageUsedUpdateMigration.Migrate,
+			orderedMapMigration.Migrate,
+			storageUsedUpdateMigration.Migrate,
 			mgr.PruneMigration,
 		}
 


### PR DESCRIPTION
Undo changes from https://github.com/onflow/flow-go/pull/2195

Migrations had to be removed, because they were already applied on canary during the first canary spork.

They have to be re-added before the testnet and mainnet sporks, as they have not been run there yet.

⚠️ DO NOT MERGE BEFORE THE CANARY SPORK IS OVER