### PR TITLE
[Crypto] make test cleanup

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,7 +33,7 @@ jobs:
           go-version: "^1.17"
 
       - name: Build relic
-        run: make crypto/relic/build
+        run: make crypto_setup_gopath
 
       - name: Run benchmark on current branch
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Build relic
-      run: make crypto/relic/build
+      run: make crypto_setup_gopath
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
     - name: Docker login

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Build relic
-      run: make crypto/relic/build
+      run: make crypto_setup_gopath
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
@@ -92,7 +92,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Build relic
-      run: make crypto/relic/build
+      run: make crypto_setup_gopath
     - name: Docker build
       run: make docker-build-flow
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,15 @@ K8S_YAMLS_LOCATION_STAGING=./k8s/staging
 export CONTAINER_REGISTRY := gcr.io/flow-container-registry
 export DOCKER_BUILDKIT := 1
 
-.PHONY: crypto/relic/build
-crypto/relic/build:
-# setup the crypto package under the GOPATH, needed to test packages importing flow-go/crypto
+# setup the crypto package under the GOPATH: needed to test packages importing flow-go/crypto
+.PHONY: crypto_setup_gopath
+crypto_setup_gopath:
 	bash crypto_setup.sh
+
+# setup the crypto package in the current repo folder: needed to test the crypto package itself in `unittest` target
+.PHONY: crypto_setup
+crypto_setup:
+    $(MAKE) -C crypto setup
 
 cmd/collection/collection:
 	go build -o cmd/collection/collection cmd/collection/main.go

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ crypto_setup_gopath:
 	bash crypto_setup.sh
 
 # setup the crypto package in the current repo folder: needed to test the crypto package itself in `unittest` target
-.PHONY: crypto_setup
-crypto_setup:
+.PHONY: crypto_setup_tests
+crypto_setup_tests:
     $(MAKE) -C crypto setup
 
 cmd/collection/collection:
@@ -65,7 +65,7 @@ install-mock-generators:
 ############################################################################################
 
 .PHONY: install-tools
-install-tools: crypto/relic/build check-go-version install-mock-generators
+install-tools: crypto_setup_tests crypto_setup_gopath check-go-version install-mock-generators
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.41.1; \
 	cd ${GOPATH}; \
 	GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go@v1.3.2; \
@@ -180,7 +180,7 @@ ci: install-tools tidy test # lint coverage
 
 # Runs integration tests
 .PHONY: ci-integration
-ci-integration: crypto/relic/build
+ci-integration: crypto_setup_gopath
 	$(MAKE) -C integration ci-integration-test
 
 # Runs benchmark tests

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    make crypto/relic/build
+    make crypto_setup_gopath
 
 FROM build-env as build-production
 WORKDIR /app

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -32,11 +32,6 @@ non_relic_tests:
 .PHONY: test
 test: relic_tests non_relic_tests
 
-# target used by the flakey test monitor 
-# CAUTION: modifying the target name will break the flaky test monitor)
-.PHONY: test-main
-test-main: test
-
 .PHONY: docker-build
 docker-build:
 	docker build -t gcr.io/dl-flow/golang-cmake:latest -t gcr.io/dl-flow/golang-cmake:$(IMAGE_TAG) .

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -11,7 +11,7 @@ setup:
 
 # test BLS-related functionalities requiring the Relic library (and hence relic Go build flag)
 .PHONY: relic_tests
-relic_tests: setup
+relic_tests:
 ifeq ($(ADX_SUPPORT), 1)
 	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) --tags relic $(if $(VERBOSE),-v,)
 else

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -5,26 +5,37 @@ IMAGE_TAG := v0.0.7
 
 ADX_SUPPORT := $(shell if ([ -f "/proc/cpuinfo" ] && grep -q -e '^flags.*\badx\b' /proc/cpuinfo); then echo 1; else echo 0; fi)
 
-############################################################################################
-# CAUTION: DO NOT MODIFY THESE TARGETS! DOING SO WILL BREAK THE FLAKY TEST MONITOR
-
-.PHONY: test-main
-test-main:
-	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(if $(VERBOSE),-v,) ./...
-
-############################################################################################
-
 .PHONY: setup
 setup:
 	go generate
-	
-.PHONY: test
-test: setup test-main
+
+# test BLS-related functionalities requiring the Relic library (and hence relic Go build flag)
+.PHONY: relic_tests
+relic_tests: setup
 ifeq ($(ADX_SUPPORT), 1)
 	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) --tags relic $(if $(VERBOSE),-v,)
 else
 	CGO_CFLAGS="-D__BLST_PORTABLE__" GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) --tags relic $(if $(VERBOSE),-v,)
 endif
+
+# test all packages that do not require Relic library (all functionalities except the BLS-related ones)
+.PHONY: non_relic_tests
+non_relic_tests:
+# root package without relic 
+	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(if $(VERBOSE),-v,)
+# sub packages
+	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(if $(VERBOSE),-v,) ./hash
+	GO111MODULE=on go test -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(if $(VERBOSE),-v,) ./random
+
+
+# runs all tests of the crypto package 
+.PHONY: test
+test: relic_tests non_relic_tests
+
+# target used by the flakey test monitor 
+# CAUTION: modifying the target name will break the flaky test monitor)
+.PHONY: test-main
+test-main: test
 
 .PHONY: docker-build
 docker-build:

--- a/crypto/ecdsa_test.go
+++ b/crypto/ecdsa_test.go
@@ -1,3 +1,6 @@
+//go:build !relic
+// +build !relic
+
 package crypto
 
 import (

--- a/tools/flaky_test_monitor/run-tests.sh
+++ b/tools/flaky_test_monitor/run-tests.sh
@@ -19,7 +19,7 @@ else
             # TODO: add this back > $TEST_OUTPUT_FILE
         ;;
         unit-crypto)
-            make -C crypto -s test-main > $TEST_OUTPUT_FILE
+            make -C crypto -s test > $TEST_OUTPUT_FILE
         ;;
         unit-integration)
             make -C integration -s test > $TEST_OUTPUT_FILE

--- a/tools/flaky_test_monitor/test-setup.sh
+++ b/tools/flaky_test_monitor/test-setup.sh
@@ -14,9 +14,6 @@ else
             make install-mock-generators
             make generate-mocks
         ;;
-        unit-crypto)
-            make -C crypto setup
-        ;;
         unit-integration)
         ;;
     esac

--- a/tools/flaky_test_monitor/test-setup.sh
+++ b/tools/flaky_test_monitor/test-setup.sh
@@ -3,7 +3,7 @@
 set -e
 shopt -s extglob
 
-make crypto/relic/build
+make crypto_setup_gopath
 
 if [[ $TEST_CATEGORY =~ integration-(common|network|epochs|access|collection|consensus|execution|verification)$ ]]
 then

--- a/tools/flaky_test_monitor/test-setup.sh
+++ b/tools/flaky_test_monitor/test-setup.sh
@@ -14,6 +14,9 @@ else
             make install-mock-generators
             make generate-mocks
         ;;
+        unit-crypto)
+            make crypto_setup_tests
+        ;;
         unit-integration)
         ;;
     esac


### PR DESCRIPTION
 - add `!relic` from non-relic test files to make sure they are not run when `tags=relic` is added (avoids running tests twice in the flakey-test monitor)
 - refactor crypto tests under relic tests and non-relic tests
 - update `crypto/relic/build` target misleading name: the target updates the `GOPATH` and not the `crypto/relic/build` folder. Add a new target `crypto_setup` that actually updates `crypto/relic/build`.
 - remove one call to `make crypto setup` since the setup is called during `make crypto test` later anyway.