### PR TITLE
Remove unused method

### DIFF
--- a/storage/transaction_results.go
+++ b/storage/transaction_results.go
@@ -12,7 +12,4 @@ type TransactionResults interface {
 	ByBlockIDTransactionID(blockID flow.Identifier, transactionID flow.Identifier) (*flow.TransactionResult, error)
 
 	ByBlockIDTransactionIndex(blockID flow.Identifier, txIndex uint32) (*flow.TransactionResult, error)
-
-	// RemoveByBlockID removes transaction results by block ID
-	RemoveByBlockID(blockID flow.Identifier) error
 }


### PR DESCRIPTION
Leftover, unused method - probably some merge artifacts. Prevents compilation, and its not used anywhere