### PR TITLE
[FVM] Fix computation/memory meter error text - v0.25

### DIFF
--- a/fvm/meter/weighted/meter.go
+++ b/fvm/meter/weighted/meter.go
@@ -102,7 +102,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.computationUsed = m.computationUsed + childComputationUsed
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit)
+		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
 	}
 
 	for key, intensity := range child.ComputationIntensities() {
@@ -117,7 +117,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.memoryUsed = m.memoryUsed + childMemoryUsed
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.memoryLimit)
+		return errors.NewMemoryLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
 	}
 
 	for key, intensity := range child.MemoryIntensities() {
@@ -140,7 +140,7 @@ func (m *Meter) MeterComputation(kind common.ComputationKind, intensity uint) er
 	}
 	m.computationUsed += w * uint64(intensity)
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit)
+		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
 	}
 	return nil
 }
@@ -174,7 +174,7 @@ func (m *Meter) MeterMemory(kind common.ComputationKind, intensity uint) error {
 	}
 	m.memoryUsed += w * uint64(intensity)
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.memoryLimit)
+		return errors.NewMemoryLimitExceededError(m.memoryLimit >> MeterInternalPrecisionBytes)
 	}
 	return nil
 }

--- a/fvm/meter/weighted/meter.go
+++ b/fvm/meter/weighted/meter.go
@@ -102,7 +102,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.computationUsed = m.computationUsed + childComputationUsed
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
+		return errors.NewComputationLimitExceededError(uint64(m.TotalComputationLimit()))
 	}
 
 	for key, intensity := range child.ComputationIntensities() {
@@ -117,7 +117,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.memoryUsed = m.memoryUsed + childMemoryUsed
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
+		return errors.NewMemoryLimitExceededError(uint64(m.TotalMemoryLimit()))
 	}
 
 	for key, intensity := range child.MemoryIntensities() {
@@ -140,7 +140,7 @@ func (m *Meter) MeterComputation(kind common.ComputationKind, intensity uint) er
 	}
 	m.computationUsed += w * uint64(intensity)
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
+		return errors.NewComputationLimitExceededError(uint64(m.TotalComputationLimit()))
 	}
 	return nil
 }
@@ -174,7 +174,7 @@ func (m *Meter) MeterMemory(kind common.ComputationKind, intensity uint) error {
 	}
 	m.memoryUsed += w * uint64(intensity)
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.memoryLimit >> MeterInternalPrecisionBytes)
+		return errors.NewMemoryLimitExceededError(uint64(m.TotalMemoryLimit()))
 	}
 	return nil
 }

--- a/fvm/meter/weighted/meter_test.go
+++ b/fvm/meter/weighted/meter_test.go
@@ -53,7 +53,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(math.MaxUint32).Error())
+		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(10).Error())
 
 		err = m.MeterMemory(0, 2)
 		require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
+		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(10).Error())
 	})
 
 	t.Run("meter computation and memory with weights", func(t *testing.T) {

--- a/fvm/meter/weighted/meter_test.go
+++ b/fvm/meter/weighted/meter_test.go
@@ -53,6 +53,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
+		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(math.MaxUint32).Error())
 
 		err = m.MeterMemory(0, 2)
 		require.NoError(t, err)
@@ -65,6 +66,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
+		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
 	})
 
 	t.Run("meter computation and memory with weights", func(t *testing.T) {
@@ -155,6 +157,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MergeMeter(child3)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
+		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(9).Error())
 	})
 
 	t.Run("merge meters - large values - computation", func(t *testing.T) {
@@ -194,7 +197,10 @@ func TestWeightedComputationMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		err = m.MergeMeter(child1)
+
+		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
+		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
 	})
 
 	t.Run("add intensity - test limits - computation", func(t *testing.T) {


### PR DESCRIPTION
related: [[FVM] Fix computation/memory meter error text](https://github.com/onflow/flow-go/pull/2215)

During testing with the emulator, I discovered that the metering "limit reached" error text did not include the correct limit.

The error used the limit at the meters internal precision, instead of the actual limit.

I also changed the tests to tests for this.