### PR TITLE
[FVM] Fix metering limits

### DIFF
--- a/fvm/meter/basic/meter.go
+++ b/fvm/meter/basic/meter.go
@@ -43,9 +43,9 @@ func (m *Meter) NewChild() interfaceMeter.Meter {
 }
 
 // MergeMeter merges the input meter into the current meter and checks for the limits
-func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
+func (m *Meter) MergeMeter(child interfaceMeter.Meter, enforceLimits bool) error {
 	m.computationUsed = m.computationUsed + child.TotalComputationUsed()
-	if m.computationUsed > m.computationLimit {
+	if enforceLimits && m.computationUsed > m.computationLimit {
 		return errors.NewComputationLimitExceededError(uint64(m.computationLimit))
 	}
 	for key, intensity := range child.ComputationIntensities() {
@@ -53,7 +53,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 
 	m.memoryUsed = m.memoryUsed + child.TotalMemoryUsed()
-	if m.memoryUsed > m.memoryLimit {
+	if enforceLimits && m.memoryUsed > m.memoryLimit {
 		return errors.NewMemoryLimitExceededError(uint64(m.memoryLimit))
 	}
 	for key, intensity := range child.MemoryIntensities() {

--- a/fvm/meter/meter.go
+++ b/fvm/meter/meter.go
@@ -43,7 +43,7 @@ type MeteredIntensities map[common.ComputationKind]uint
 type Meter interface {
 	// merge child funcionality
 	NewChild() Meter
-	MergeMeter(child Meter) error
+	MergeMeter(child Meter, enforceLimits bool) error
 
 	// computation metering
 	MeterComputation(kind common.ComputationKind, intensity uint) error

--- a/fvm/meter/noop/meter.go
+++ b/fvm/meter/noop/meter.go
@@ -22,7 +22,7 @@ func (m *Meter) NewChild() interfaceMeter.Meter {
 }
 
 // MergeMeter merges two noop meters
-func (m *Meter) MergeMeter(_ interfaceMeter.Meter) error {
+func (m *Meter) MergeMeter(child interfaceMeter.Meter, enforceLimits bool) error {
 	return nil
 }
 

--- a/fvm/meter/weighted/meter.go
+++ b/fvm/meter/weighted/meter.go
@@ -102,7 +102,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.computationUsed = m.computationUsed + childComputationUsed
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit)
+		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
 	}
 
 	for key, intensity := range child.ComputationIntensities() {
@@ -117,7 +117,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.memoryUsed = m.memoryUsed + childMemoryUsed
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.memoryLimit)
+		return errors.NewMemoryLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
 	}
 
 	for key, intensity := range child.MemoryIntensities() {
@@ -140,7 +140,7 @@ func (m *Meter) MeterComputation(kind common.ComputationKind, intensity uint) er
 	}
 	m.computationUsed += w * uint64(intensity)
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit)
+		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
 	}
 	return nil
 }
@@ -174,7 +174,7 @@ func (m *Meter) MeterMemory(kind common.ComputationKind, intensity uint) error {
 	}
 	m.memoryUsed += w * uint64(intensity)
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.memoryLimit)
+		return errors.NewMemoryLimitExceededError(m.memoryLimit >> MeterInternalPrecisionBytes)
 	}
 	return nil
 }

--- a/fvm/meter/weighted/meter.go
+++ b/fvm/meter/weighted/meter.go
@@ -102,7 +102,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.computationUsed = m.computationUsed + childComputationUsed
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
+		return errors.NewComputationLimitExceededError(uint64(m.TotalComputationLimit()))
 	}
 
 	for key, intensity := range child.ComputationIntensities() {
@@ -117,7 +117,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 	}
 	m.memoryUsed = m.memoryUsed + childMemoryUsed
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
+		return errors.NewMemoryLimitExceededError(uint64(m.TotalMemoryLimit()))
 	}
 
 	for key, intensity := range child.MemoryIntensities() {
@@ -140,7 +140,7 @@ func (m *Meter) MeterComputation(kind common.ComputationKind, intensity uint) er
 	}
 	m.computationUsed += w * uint64(intensity)
 	if m.computationUsed > m.computationLimit {
-		return errors.NewComputationLimitExceededError(m.computationLimit >> MeterInternalPrecisionBytes)
+		return errors.NewComputationLimitExceededError(uint64(m.TotalComputationLimit()))
 	}
 	return nil
 }
@@ -174,7 +174,7 @@ func (m *Meter) MeterMemory(kind common.ComputationKind, intensity uint) error {
 	}
 	m.memoryUsed += w * uint64(intensity)
 	if m.memoryUsed > m.memoryLimit {
-		return errors.NewMemoryLimitExceededError(m.memoryLimit >> MeterInternalPrecisionBytes)
+		return errors.NewMemoryLimitExceededError(uint64(m.TotalMemoryLimit()))
 	}
 	return nil
 }

--- a/fvm/meter/weighted/meter.go
+++ b/fvm/meter/weighted/meter.go
@@ -92,7 +92,7 @@ func (m *Meter) NewChild() interfaceMeter.Meter {
 }
 
 // MergeMeter merges the input meter into the current meter and checks for the limits
-func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
+func (m *Meter) MergeMeter(child interfaceMeter.Meter, enforceLimits bool) error {
 
 	var childComputationUsed uint64
 	if basic, ok := child.(*Meter); ok {
@@ -101,7 +101,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 		childComputationUsed = uint64(child.TotalComputationUsed()) << MeterInternalPrecisionBytes
 	}
 	m.computationUsed = m.computationUsed + childComputationUsed
-	if m.computationUsed > m.computationLimit {
+	if enforceLimits && m.computationUsed > m.computationLimit {
 		return errors.NewComputationLimitExceededError(uint64(m.TotalComputationLimit()))
 	}
 
@@ -116,7 +116,7 @@ func (m *Meter) MergeMeter(child interfaceMeter.Meter) error {
 		childMemoryUsed = uint64(child.TotalMemoryUsed()) << MeterInternalPrecisionBytes
 	}
 	m.memoryUsed = m.memoryUsed + childMemoryUsed
-	if m.memoryUsed > m.memoryLimit {
+	if enforceLimits && m.memoryUsed > m.memoryLimit {
 		return errors.NewMemoryLimitExceededError(uint64(m.TotalMemoryLimit()))
 	}
 

--- a/fvm/meter/weighted/meter_test.go
+++ b/fvm/meter/weighted/meter_test.go
@@ -53,7 +53,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(math.MaxUint32).Error())
+		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(10).Error())
 
 		err = m.MeterMemory(0, 2)
 		require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
+		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(10).Error())
 	})
 
 	t.Run("meter computation and memory with weights", func(t *testing.T) {

--- a/fvm/meter/weighted/meter_test.go
+++ b/fvm/meter/weighted/meter_test.go
@@ -53,6 +53,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
+		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(math.MaxUint32).Error())
 
 		err = m.MeterMemory(0, 2)
 		require.NoError(t, err)
@@ -65,6 +66,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
+		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
 	})
 
 	t.Run("meter computation and memory with weights", func(t *testing.T) {
@@ -155,6 +157,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MergeMeter(child3)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
+		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(9).Error())
 	})
 
 	t.Run("merge meters - large values - computation", func(t *testing.T) {
@@ -194,7 +197,10 @@ func TestWeightedComputationMetering(t *testing.T) {
 		require.NoError(t, err)
 
 		err = m.MergeMeter(child1)
+
+		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
+		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
 	})
 
 	t.Run("add intensity - test limits - computation", func(t *testing.T) {

--- a/fvm/meter/weighted/meter_test.go
+++ b/fvm/meter/weighted/meter_test.go
@@ -143,21 +143,43 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = child3.MeterComputation(compKind, 4)
 		require.NoError(t, err)
 
-		err = m.MergeMeter(child1)
+		err = m.MergeMeter(child1, true)
 		require.NoError(t, err)
 		require.Equal(t, uint(1+2), m.TotalComputationUsed())
 		require.Equal(t, uint(1+2), m.ComputationIntensities()[compKind])
 
-		err = m.MergeMeter(child2)
+		err = m.MergeMeter(child2, true)
 		require.NoError(t, err)
 		require.Equal(t, uint(1+2+3), m.TotalComputationUsed())
 		require.Equal(t, uint(1+2+3), m.ComputationIntensities()[compKind])
 
 		// error on merge (hitting limit)
-		err = m.MergeMeter(child3)
+		err = m.MergeMeter(child3, true)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
 		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(9).Error())
+	})
+
+	t.Run("merge meters - ignore limits", func(t *testing.T) {
+		compKind := common.ComputationKind(0)
+		m := weighted.NewMeter(
+			9,
+			0,
+			weighted.WithComputationWeights(map[common.ComputationKind]uint64{0: 1 << weighted.MeterInternalPrecisionBytes}),
+		)
+
+		err := m.MeterComputation(compKind, 1)
+		require.NoError(t, err)
+
+		child := m.NewChild()
+		err = child.MeterComputation(compKind, 1)
+		require.NoError(t, err)
+
+		// hitting limit and ignoring it
+		err = m.MergeMeter(child, false)
+		require.NoError(t, err)
+		require.Equal(t, uint(1+1), m.TotalComputationUsed())
+		require.Equal(t, uint(1+1), m.ComputationIntensities()[compKind])
 	})
 
 	t.Run("merge meters - large values - computation", func(t *testing.T) {
@@ -176,7 +198,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = child1.MeterComputation(0, 1)
 		require.NoError(t, err)
 
-		err = m.MergeMeter(child1)
+		err = m.MergeMeter(child1, true)
 		require.True(t, errors.IsComputationLimitExceededError(err))
 	})
 
@@ -196,7 +218,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = child1.MeterMemory(0, 1)
 		require.NoError(t, err)
 
-		err = m.MergeMeter(child1)
+		err = m.MergeMeter(child1, true)
 
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -248,7 +248,7 @@ func (s *State) MergeState(other *State, enforceLimit bool) error {
 		return errors.NewStateMergeFailure(err)
 	}
 
-	err = s.meter.MergeMeter(other.meter)
+	err = s.meter.MergeMeter(other.meter, enforceLimit)
 	if err != nil {
 		return err
 	}

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -823,6 +823,9 @@ func (e *TransactionEnv) CreateAccount(payer runtime.Address) (address runtime.A
 	}
 
 	err = e.meterComputation(meter.ComputationKindCreateAccount, 1)
+	if err != nil {
+		return address, err
+	}
 
 	e.sth.DisableAllLimitEnforcements() // don't enforce limit during account creation
 	defer e.sth.EnableAllLimitEnforcements()

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -188,7 +188,12 @@ func (i *TransactionInvoker) Process(
 
 	// if there is still no error check if all account storage limits are ok
 	if txError == nil {
+		// disable the computation/memory limit checks on storage checks,
+		// so we don't error from computation/memory limits on this part.
+		// We cannot charge the user for this part, since fee deduction already happened.
+		sth.DisableAllLimitEnforcements()
 		txError = NewTransactionStorageLimiter().CheckLimits(env, sth.State().UpdatedAddresses())
+		sth.EnableAllLimitEnforcements()
 	}
 
 	// it there was any transaction error clear changes and try to deduct fees again


### PR DESCRIPTION
[v0.25](https://github.com/onflow/flow-go/pull/2216) version

This fixes three things:

1. During testing with the emulator, I discovered that the metering "limit reached" error text did not include the correct limit. The error used the limit at the meters internal precision, instead of the actual limit. (now covered in the weighted meter tests)

2. When testing I noticed that setting a gas limit of 999 I was only able to get a transaction to 941 execution effort before it failed. This was due to the limit enforcement happening after the fee deduction which added computation and potentially failed the transaction.

3. When the transaction failed, the fee deduction code also failed due to `meter.MergeMeter` still emitting an error even though limit enforcement was off.

The new `fvm/fvm_test.go` test covers 2. and 3. It also makes sure that if the limit is reached (or overshot) the user is only charged up to their gas limit.