### PR TITLE
Reduce default checkpoint distance flag from 40 to 20 to speedup EN startup

### DIFF
--- a/cmd/execution/main.go
+++ b/cmd/execution/main.go
@@ -145,7 +145,7 @@ func main() {
 			flags.StringVar(&triedir, "triedir", datadir, "directory to store the execution State")
 			flags.StringVar(&executionDataDir, "execution-data-dir", filepath.Join(homedir, ".flow", "execution_data_blobstore"), "directory to use for Execution Data blobstore")
 			flags.Uint32Var(&mTrieCacheSize, "mtrie-cache-size", 500, "cache size for MTrie")
-			flags.UintVar(&checkpointDistance, "checkpoint-distance", 40, "number of WAL segments between checkpoints")
+			flags.UintVar(&checkpointDistance, "checkpoint-distance", 20, "number of WAL segments between checkpoints")
 			flags.UintVar(&checkpointsToKeep, "checkpoints-to-keep", 5, "number of recent checkpoints to keep (0 to keep all)")
 			flags.UintVar(&stateDeltasLimit, "state-deltas-limit", 100, "maximum number of state deltas in the memory pool")
 			flags.UintVar(&cadenceExecutionCache, "cadence-execution-cache", computation.DefaultProgramsCacheSize, "cache size for Cadence execution")


### PR DESCRIPTION
Reduce checkpoint distance flag to trigger creation of checkpoints more frequently.

Prior to #1944 checkpoint creation took 11-15+ hours so it wasn't feasible to run checkpoints more frequently.

This change will cause fewer WAL segments to trigger checkpoint creation, which will speedup EN startup by having fewer WALs to replay during startup.

On benchnet, replaying 20 WALs is 3.5 minutes faster than replaying 40 WALs.

This change will also speedup checkpoint file creation by the same duration because that also requires replaying WALs.

closes #2207 
updates https://github.com/dapperlabs/flow-go/issues/6114