### PR TITLE
Fail state extract early

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage"
+	utilsio "github.com/onflow/flow-go/utils/io"
 )
 
 func getStateCommitment(commits storage.Commits, blockHash flow.Identifier) (flow.StateCommitment, error) {
@@ -30,6 +31,9 @@ func extractExecutionState(
 	migrate bool,
 	report bool,
 ) error {
+	if utilsio.FileExists(bootstrap.FilenameWALRootCheckpoint) {
+		return fmt.Errorf("checkpoint file %s already exists", bootstrap.FilenameWALRootCheckpoint)
+	}
 
 	diskWal, err := wal.NewDiskWAL(
 		zerolog.Nop(),

--- a/module/state_synchronization/execution_data.go
+++ b/module/state_synchronization/execution_data.go
@@ -5,10 +5,15 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// ExecutionData represents the execution data of a block
-type ExecutionData struct {
-	BlockID     flow.Identifier
-	Collections []*flow.Collection
-	Events      []flow.EventsList
-	TrieUpdates []*ledger.TrieUpdate
+// ChunkExecutionData represents the execution data of a chunk
+type ChunkExecutionData struct {
+	Collection *flow.Collection
+	Events     flow.EventsList
+	TrieUpdate *ledger.TrieUpdate
+}
+
+type ExecutionDataRoot struct {
+	BlockID                     flow.Identifier
+	PreviousExecutionDataRootID flow.Identifier
+	ChunkExecutionDataIDs       []flow.Identifier
 }

--- a/module/state_synchronization/fetcher.go
+++ b/module/state_synchronization/fetcher.go
@@ -1,0 +1,4 @@
+package state_synchronization
+
+type Fetcher struct {
+}

--- a/module/state_synchronization/storage.go
+++ b/module/state_synchronization/storage.go
@@ -1,0 +1,35 @@
+package state_synchronization
+
+import "github.com/onflow/flow-go/model/flow"
+
+type Storage struct {
+}
+
+func (s *Storage) Queue(rootID flow.Identifier) {
+
+}
+
+func (s *Storage) StartTransfer(rootID flow.Identifier) {
+
+}
+
+func (s *Storage) FinishTransfer(rootID flow.Identifier) {
+
+}
+
+// TODO: we need to add the refcount before we start the request
+// This prevents the race condition of requesting a block, then it being deleted,
+// then we update the refcount
+
+// what happens on the very first request?
+// maybe we can define a datastore that knows 
+
+func (s *Storage) ReceivedRoot(rootID flow.Identifier, chunkExecutionDataIDs []flow.Identifier) {
+
+}
+
+func (s *Storage) ReceivedLevel(parentLevel, level []cid.Cid){
+
+}
+
+func (s *Storage) 


### PR DESCRIPTION
if the root checkpoint file already exists, we should fail early instead of waiting until the very end after all the work has already been done