### PR TITLE
[FVM] Execution effort weights option for bootstrap - v0.25

### DIFF
--- a/fvm/blueprints/fees.go
+++ b/fvm/blueprints/fees.go
@@ -3,6 +3,7 @@ package blueprints
 import (
 	"encoding/hex"
 	"fmt"
+	weightedMeter "github.com/onflow/flow-go/fvm/meter/weighted"
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
@@ -188,7 +189,7 @@ transaction(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCos
 // SetExecutionEffortWeightsTransaction creates a transaction that sets up weights for the weighted Meter.
 func SetExecutionEffortWeightsTransaction(
 	service flow.Address,
-	weights map[uint]uint64,
+	weights weightedMeter.ExecutionWeights,
 ) (*flow.TransactionBody, error) {
 	return setExecutionWeightsTransaction(
 		service,
@@ -200,7 +201,7 @@ func SetExecutionEffortWeightsTransaction(
 
 func setExecutionWeightsTransaction(
 	service flow.Address,
-	weights map[uint]uint64,
+	weights weightedMeter.ExecutionWeights,
 	domain string,
 	identifier string,
 ) (*flow.TransactionBody, error) {

--- a/fvm/blueprints/fees.go
+++ b/fvm/blueprints/fees.go
@@ -3,12 +3,12 @@ package blueprints
 import (
 	"encoding/hex"
 	"fmt"
-	weightedMeter "github.com/onflow/flow-go/fvm/meter/weighted"
 
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-core-contracts/lib/go/contracts"
 
+	weightedMeter "github.com/onflow/flow-go/fvm/meter/weighted"
 	"github.com/onflow/flow-go/model/flow"
 )
 

--- a/fvm/blueprints/fees.go
+++ b/fvm/blueprints/fees.go
@@ -8,7 +8,6 @@ import (
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow-core-contracts/lib/go/contracts"
 
-	weightedMeter "github.com/onflow/flow-go/fvm/meter/weighted"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -189,7 +188,7 @@ transaction(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCos
 // SetExecutionEffortWeightsTransaction creates a transaction that sets up weights for the weighted Meter.
 func SetExecutionEffortWeightsTransaction(
 	service flow.Address,
-	weights weightedMeter.ExecutionWeights,
+	weights map[uint]uint64,
 ) (*flow.TransactionBody, error) {
 	return setExecutionWeightsTransaction(
 		service,
@@ -201,7 +200,7 @@ func SetExecutionEffortWeightsTransaction(
 
 func setExecutionWeightsTransaction(
 	service flow.Address,
-	weights weightedMeter.ExecutionWeights,
+	weights map[uint]uint64,
 	domain string,
 	identifier string,
 ) (*flow.TransactionBody, error) {

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -235,9 +235,7 @@ func (b *BootstrapProcedure) Run(vm *VirtualMachine, ctx Context, sth *state.Sta
 		b.transactionFees.ExecutionEffortCost,
 	)
 
-	if b.executionEffortWeights != nil {
-		b.setupExecutionEffortWeights(service, b.executionEffortWeights)
-	}
+	b.setupExecutionEffortWeights(service, b.executionEffortWeights)
 
 	b.setupStorageForServiceAccounts(service, fungibleToken, flowToken, feeContract)
 
@@ -571,8 +569,17 @@ func (b *BootstrapProcedure) setupFees(service, flowFees flow.Address, surgeFact
 }
 
 func (b *BootstrapProcedure) setupExecutionEffortWeights(service flow.Address, weights weightedMeter.ExecutionWeights) {
+	// if executionEffortWeights were not set skip this part and just use the defaults.
+	if b.executionEffortWeights == nil {
+		return
+	}
 
-	tb, err := blueprints.SetExecutionEffortWeightsTransaction(service, weights)
+	uintWeights := make(map[uint]uint64, len(weights))
+	for i, weight := range weights {
+		uintWeights[uint(i)] = weight
+	}
+
+	tb, err := blueprints.SetExecutionEffortWeightsTransaction(service, uintWeights)
 	if err != nil {
 		panic(fmt.Sprintf("failed to setup execution effort weights %s", err.Error()))
 	}

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -2,7 +2,6 @@ package fvm
 
 import (
 	"fmt"
-	weightedMeter "github.com/onflow/flow-go/fvm/meter/weighted"
 	"math"
 
 	"github.com/onflow/cadence"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/fvm/errors"
+	weightedMeter "github.com/onflow/flow-go/fvm/meter/weighted"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"


### PR DESCRIPTION
Port of [[FVM] Execution effort weights option for bootstrap](https://github.com/onflow/flow-go/pull/2228)

This PR introduces a `WithExecutionEffortWeights` option for the bootstrapping procedure, which allows setting the Execution effort weights during bootstrapping.

This option makes testing setup easier but more importantly, it makes the needed Emulator change easier.

This does not change any transaction code and is safe to be ported to v0.25.