### PR TITLE
[v0.24] [HOTFIX] Remove corrupt collection data for execution node

### DIFF
--- a/storage/badger/operation/collections.go
+++ b/storage/badger/operation/collections.go
@@ -20,8 +20,9 @@ func RetrieveCollection(collID flow.Identifier, collection *flow.LightCollection
 	return retrieve(makePrefix(codeCollection, collID), collection)
 }
 
+// HOTFIX: modifying this to use removeUnchecked (not used anywhere currently)
 func RemoveCollection(collID flow.Identifier) func(*badger.Txn) error {
-	return remove(makePrefix(codeCollection, collID))
+	return removeUnchecked(makePrefix(codeCollection, collID))
 }
 
 // IndexCollectionPayload indexes the transactions within the collection payload

--- a/storage/badger/operation/common.go
+++ b/storage/badger/operation/common.go
@@ -156,6 +156,18 @@ func remove(key []byte) func(*badger.Txn) error {
 	}
 }
 
+// HOTFIX: adding this method which will delete a key without first reading it
+// since reading a corrupt key causes an error.
+func removeUnchecked(key []byte) func(*badger.Txn) error {
+	return func(tx *badger.Txn) error {
+		err := tx.Delete(key)
+		if err != nil {
+			return fmt.Errorf("could not remove key (unchecked): %w", err)
+		}
+		return nil
+	}
+}
+
 // retrieve will retrieve the binary data under the given key from the badger DB
 // and decode it into the given entity. The provided entity needs to be a
 // pointer to an initialized entity of the correct type.

--- a/storage/badger/operation/transactions.go
+++ b/storage/badger/operation/transactions.go
@@ -15,3 +15,8 @@ func InsertTransaction(txID flow.Identifier, tx *flow.TransactionBody) func(*bad
 func RetrieveTransaction(txID flow.Identifier, tx *flow.TransactionBody) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeTransaction, txID), tx)
 }
+
+// HOTFIX: adding this to remove transactions without first checking existence.
+func RemoveTransactionUnchecked(txID flow.Identifier) func(*badger.Txn) error {
+	return removeUnchecked(makePrefix(codeTransaction, txID))
+}


### PR DESCRIPTION
* EN2 on Testnet encounters an error when reading collections, after its disk was exhausted
```
{"level":"fatal","node_role":"execution","node_id":"a1f059a3e00347e585658e4c400be1580ba2e2f6d1f39387ad62e33f3f4d246d","engine":"ingestion","error":"could not reload block: 79105872451a52cad6843be34a6f17c59f9119522570cc8421b681b207d4b09f, could not enqueue block on reloading: cannot send collection requests: error while querying for collection: could not retrieve transaction: could not retrieve resource: could not decode entity: Invalid read: Len: 2107 read at:[1181425:1183111]","time":"2022-03-31T04:34:34Z","message":"failed to load all unexecuted blocks"}
```
* The fatal error is preceded by:
```
{"level":"error","node_role":"execution","node_id":"a1f059a3e00347e585658e4c400be1580ba2e2f6d1f39387ad62e33f3f4d246d","component":"badger","time":"2022-03-31T04:53:26Z","message":"Unable to read: Key: [34 19 49 66 150 122 158 132 178 53 55 36 133 94 96 233 217 231 132 125 245 68 69 204 160 82 158 149 186 79 9 203 120], Version : 26845631,\n\t\t\t\tmeta: 66, userMeta: 0"}
{"level":"error","node_role":"execution","node_id":"a1f059a3e00347e585658e4c400be1580ba2e2f6d1f39387ad62e33f3f4d246d","component":"badger","time":"2022-03-31T04:53:26Z","message":"Invalid read: vp: {Fid:2587 Len:2119 Offset:383311220}"}
```
* Truncating the database does not address the issue