### PR TITLE
Fix output of fungible token tracker test

### DIFF
--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -131,4 +131,5 @@ func TestFungibleTokenTracker(t *testing.T) {
 	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"7e60df042a9c0868","balance":100000,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
 	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"912d5440f7e3769e","balance":100000,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
 
+	t.Log("success")
 }


### PR DESCRIPTION
The progress bar messes up the test output when running tests in JSON mode:

```
{"Time":"2022-03-30T23:50:56.76655-07:00","Action":"run","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker"}
{"Time":"2022-03-30T23:50:56.768101-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Output":"=== RUN   TestFungibleTokenTracker\n"}
{"Time":"2022-03-30T23:50:56.961114-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Output":"\r\r\rProcessing: 100% |██████████████████████████████████| (5/5, 18045 it/s)\n"}
{"Time":"2022-03-30T23:50:56.962618-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Output":"\r\r--- PASS: TestFungibleTokenTracker (0.20s)\n"}
{"Time":"2022-03-30T23:50:56.962658-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Output":"PASS\n"}
{"Time":"2022-03-30T23:50:56.966469-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Output":"ok  \tgithub.com/onflow/flow-go/cmd/util/ledger/reporters\t0.624s\n"}
{"Time":"2022-03-30T23:50:56.969615-07:00","Action":"pass","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Elapsed":0.628}
{"Time":"2022-03-30T23:50:56.972771-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters/mock","Output":"?   \tgithub.com/onflow/flow-go/cmd/util/ledger/reporters/mock\t[no test files]\n"}
{"Time":"2022-03-30T23:50:56.972813-07:00","Action":"skip","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters/mock","Elapsed":0}
```

Note the output line 
```
\r\r--- PASS: TestFungibleTokenTracker (0.20s)\n
```
is prefixed with two carriage returns. This confuses Go's output parser (arguably a bug), which leads to the "pass" action not being outputted.

With this change, we get:
```
{"Time":"2022-03-30T23:47:56.142532-07:00","Action":"run","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker"}
{"Time":"2022-03-30T23:47:56.142892-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Output":"=== RUN   TestFungibleTokenTracker\n"}
{"Time":"2022-03-30T23:47:56.336911-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Output":"\r\r\rProcessing: 100% |██████████████████████████████████| (5/5, 12321 it/s)\n"}
{"Time":"2022-03-30T23:47:56.337543-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Output":"\r\r    fungible_token_tracker_test.go:134: success\n"}
{"Time":"2022-03-30T23:47:56.33824-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Output":"--- PASS: TestFungibleTokenTracker (0.20s)\n"}
{"Time":"2022-03-30T23:47:56.338264-07:00","Action":"pass","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Elapsed":0.2}
{"Time":"2022-03-30T23:47:56.338297-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Output":"PASS\n"}
{"Time":"2022-03-30T23:47:56.340726-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Output":"ok  \tgithub.com/onflow/flow-go/cmd/util/ledger/reporters\t0.582s\n"}
{"Time":"2022-03-30T23:47:56.346183-07:00","Action":"pass","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Elapsed":0.589}
{"Time":"2022-03-30T23:47:56.349234-07:00","Action":"output","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters/mock","Output":"?   \tgithub.com/onflow/flow-go/cmd/util/ledger/reporters/mock\t[no test files]\n"}
{"Time":"2022-03-30T23:47:56.349295-07:00","Action":"skip","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters/mock","Elapsed":0}
```

Note that this time, the "pass" action is emitted after the last output line:
```
{"Time":"2022-03-30T23:47:56.338264-07:00","Action":"pass","Package":"github.com/onflow/flow-go/cmd/util/ledger/reporters","Test":"TestFungibleTokenTracker","Elapsed":0.2}
```

This is needed in order for the flaky test monitor to parse the results correctly.

Long story short, this is needed for the flaky test monitor, and if all of this still doesn't make sense then just trust me 😎