### PR TITLE
Fix incorrectly skipped test

### DIFF
--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -131,5 +131,6 @@ func TestFungibleTokenTracker(t *testing.T) {
 	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"7e60df042a9c0868","balance":100000,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
 	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"912d5440f7e3769e","balance":100000,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
 
+	// do not remove this line, see https://github.com/onflow/flow-go/pull/2237
 	t.Log("success")
 }

--- a/network/test/epochtransition_test.go
+++ b/network/test/epochtransition_test.go
@@ -117,9 +117,10 @@ func (t *testNodeList) networks() []network.Network {
 	return nets
 }
 
-func TestEpochTransitionTestSuite(t *testing.T) {
+func TestMutableIdentityTable(t *testing.T) {
 	// Test is flaky, print it in order to avoid the unused linting error
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, fmt.Sprintf("test is flaky: %v", &MutableIdentityTableSuite{}))
+	unittest.SkipUnless(t, unittest.TEST_FLAKY, "flaky")
+	suite.Run(t, new(MutableIdentityTableSuite))
 }
 
 // signalIdentityChanged update IDs for all the current set of nodes (simulating an epoch)


### PR DESCRIPTION
When a test is skipped, we must still retain the call to `suite.Run`, otherwise it defeats the purpose of skipping it.

Also, added a comment as followup to https://github.com/onflow/flow-go/pull/2237