### PR TITLE
Memory metering

### DIFF
--- a/access/validator.go
+++ b/access/validator.go
@@ -229,7 +229,7 @@ func (v *TransactionValidator) checkExpiry(tx *flow.TransactionBody) error {
 
 func (v *TransactionValidator) checkCanBeParsed(tx *flow.TransactionBody) error {
 	if v.options.CheckScriptsParse {
-		_, err := parser2.ParseProgram(string(tx.Script))
+		_, err := parser2.ParseProgram(string(tx.Script), nil)
 		if err != nil {
 			return InvalidScriptError{ParserErr: err}
 		}

--- a/cmd/util/ledger/reporters/fungible_token_tracker.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker.go
@@ -142,6 +142,7 @@ func (r *FungibleTokenTracker) worker(
 		accounts := state.NewAccounts(sth)
 		storage := cadenceRuntime.NewStorage(
 			&migrations.AccountsAtreeLedger{Accounts: accounts},
+			nil,
 		)
 
 		owner, err := common.BytesToAddress(j.owner[:])
@@ -151,7 +152,7 @@ func (r *FungibleTokenTracker) worker(
 
 		for _, domain := range domains {
 			storageMap := storage.GetStorageMap(owner, domain)
-			itr := storageMap.Iterator()
+			itr := storageMap.Iterator(nil)
 			key, value := itr.Next()
 			for value != nil {
 				r.iterateChildren(append([]string{domain}, key), j.owner, value)
@@ -192,7 +193,7 @@ func (r *FungibleTokenTracker) iterateChildren(tr trace, addr flow.Address, valu
 		}
 
 		// iterate over fields of the composite value (skip the ones that are not resource typed)
-		compValue.ForEachField(func(key string, value interpreter.Value) {
+		compValue.ForEachField(nil, func(key string, value interpreter.Value) {
 			r.iterateChildren(append(tr, key), addr, value)
 		})
 	}

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -425,7 +425,7 @@ func prepareTx(t *testing.T,
 }
 
 func hasValidEventValue(t *testing.T, event flow.Event, value int) {
-	data, err := jsoncdc.Decode(event.Payload)
+	data, err := jsoncdc.Decode(nil, event.Payload)
 	require.NoError(t, err)
 	assert.Equal(t, int16(value), data.(cadence.Event).Fields[0].ToGoValue())
 }

--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -215,7 +215,7 @@ func CreateAccountsWithSimpleAddresses(
 
 		for _, event := range tx.Events {
 			if event.Type == flow.EventAccountCreated {
-				data, err := jsoncdc.Decode(event.Payload)
+				data, err := jsoncdc.Decode(nil, event.Payload)
 				if err != nil {
 					return nil, errors.New("error decoding events")
 				}

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -40,7 +40,7 @@ func createAccount(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx f
 
 	require.Len(t, accountCreatedEvents, 1)
 
-	data, err := jsoncdc.Decode(accountCreatedEvents[0].Payload)
+	data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 	require.NoError(t, err)
 	address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
@@ -359,7 +359,7 @@ func TestCreateAccount(t *testing.T) {
 				accountCreatedEvents := filterAccountCreatedEvents(tx.Events)
 				require.Len(t, accountCreatedEvents, 1)
 
-				data, err := jsoncdc.Decode(accountCreatedEvents[0].Payload)
+				data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 				require.NoError(t, err)
 				address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
@@ -394,7 +394,7 @@ func TestCreateAccount(t *testing.T) {
 					}
 					accountCreatedEventCount += 1
 
-					data, err := jsoncdc.Decode(tx.Events[i].Payload)
+					data, err := jsoncdc.Decode(nil, tx.Events[i].Payload)
 					require.NoError(t, err)
 					address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 

--- a/fvm/contractFunctionInvocations.go
+++ b/fvm/contractFunctionInvocations.go
@@ -33,7 +33,7 @@ func DeductTransactionFeesInvocation(
 			},
 			systemcontracts.ContractServiceAccountFunction_deductTransactionFee,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(common.Address(payer)),
+				interpreter.NewAddressValue(env, common.Address(payer)),
 				interpreter.UFix64Value(inclusionEffort),
 				interpreter.UFix64Value(executionEffort),
 			},
@@ -63,8 +63,8 @@ func SetupNewAccountInvocation(
 			},
 			systemcontracts.ContractServiceAccountFunction_setupNewAccount,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(common.Address(flowAddress)),
-				interpreter.NewAddressValue(payer),
+				interpreter.NewAddressValue(env, common.Address(flowAddress)),
+				interpreter.NewAddressValue(env, payer),
 			},
 			setupNewAccountInvocationArgumentTypes,
 			env.Context().Logger,
@@ -90,7 +90,7 @@ func AccountAvailableBalanceInvocation(
 			},
 			systemcontracts.ContractStorageFeesFunction_defaultTokenAvailableBalance,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
+				interpreter.NewAddressValue(env, address),
 			},
 			accountAvailableBalanceInvocationArgumentTypes,
 			env.Context().Logger,
@@ -115,7 +115,7 @@ func AccountBalanceInvocation(
 				Name:    systemcontracts.ContractServiceAccount},
 			systemcontracts.ContractServiceAccountFunction_defaultTokenBalance,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
+				interpreter.NewAddressValue(env, address),
 			},
 			accountBalanceInvocationArgumentTypes,
 			env.Context().Logger,
@@ -141,7 +141,7 @@ func AccountStorageCapacityInvocation(
 			},
 			systemcontracts.ContractStorageFeesFunction_calculateAccountCapacity,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
+				interpreter.NewAddressValue(env, address),
 			},
 			accountStorageCapacityInvocationArgumentTypes,
 			env.Context().Logger,
@@ -168,8 +168,11 @@ func UseContractAuditVoucherInvocation(
 			},
 			systemcontracts.ContractDeploymentAuditsFunction_useVoucherForDeploy,
 			[]interpreter.Value{
-				interpreter.NewAddressValue(address),
-				interpreter.NewStringValue(code),
+				interpreter.NewAddressValue(env, address),
+				interpreter.NewStringValue(
+					env,
+					common.NewStringMemoryUsage(len(code)),
+					func() string { return code }),
 			},
 			useContractAuditVoucherInvocationArgumentTypes,
 			env.Context().Logger,

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -245,7 +245,7 @@ func (b *BasicBlockExecutor) SetupAccounts(tb testing.TB, privateKeys []flow.Acc
 		for _, eventList := range computationResult.Events {
 			for _, event := range eventList {
 				if event.Type == flow.EventAccountCreated {
-					data, err := jsoncdc.Decode(event.Payload)
+					data, err := jsoncdc.Decode(nil, event.Payload)
 					if err != nil {
 						tb.Fatal("setup account failed, error decoding events")
 					}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1477,7 +1477,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		require.Len(t, accountCreatedEvents, 1)
 
 		// read the address of the account created (e.g. "0x01" and convert it to flow.address)
-		data, err := jsoncdc.Decode(accountCreatedEvents[0].Payload)
+		data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 		require.NoError(t, err)
 		address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
@@ -1613,7 +1613,7 @@ func TestBlockContext_ExecuteTransaction_CreateAccount_WithMonotonicAddresses(t 
 
 	require.Len(t, accountCreatedEvents, 1)
 
-	data, err := jsoncdc.Decode(accountCreatedEvents[0].Payload)
+	data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 	require.NoError(t, err)
 	address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
@@ -3151,7 +3151,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				}
 				require.NotEmpty(t, feeDeduction.Payload)
 
-				payload, err := jsoncdc.Decode(feeDeduction.Payload)
+				payload, err := jsoncdc.Decode(nil, feeDeduction.Payload)
 				require.NoError(t, err)
 
 				event := payload.(cadence.Event)
@@ -3373,7 +3373,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			require.Len(t, accountCreatedEvents, 1)
 
 			// read the address of the account created (e.g. "0x01" and convert it to flow.address)
-			data, err := jsoncdc.Decode(accountCreatedEvents[0].Payload)
+			data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 			require.NoError(t, err)
 			address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
@@ -3668,7 +3668,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			for _, event := range tx.Events {
 				// the fee deduction event should only contain the max gas worth of execution effort.
 				if strings.Contains(string(event.Type), "FlowFees.FeesDeducted") {
-					ev, err := jsoncdc.Decode(event.Payload)
+					ev, err := jsoncdc.Decode(nil, event.Payload)
 					require.NoError(t, err)
 					assert.Equal(t, maxExecutionEffort, ev.(cadence.Event).Fields[2].ToGoValue().(uint64))
 				}

--- a/fvm/meter/memory/memory_meter.go
+++ b/fvm/meter/memory/memory_meter.go
@@ -1,0 +1,1 @@
+package memory_meter

--- a/fvm/meter/memory/memory_meter.go
+++ b/fvm/meter/memory/memory_meter.go
@@ -1,1 +1,76 @@
-package memory_meter
+package meter
+
+import (
+	"github.com/onflow/cadence/runtime/common"
+)
+
+var memory_weights = [...]uint64{
+	/* MemoryKindUnknown */ 0,
+	/* MemoryKindBool */ 0,
+	/* MemoryKindAddress */ 0,
+	/* MemoryKindString */ 0,
+	/* MemoryKindCharacter */ 0,
+	/* MemoryKindMetaType */ 0,
+	/* MemoryKindNumber */ 0,
+	/* MemoryKindArray */ 0,
+	/* MemoryKindDictionary */ 0,
+	/* MemoryKindComposite */ 0,
+	/* MemoryKindOptional */ 0,
+	/* MemoryKindNil */ 0,
+	/* MemoryKindVoid */ 0,
+	/* MemoryKindTypeValue */ 0,
+	/* MemoryKindPathValue */ 0,
+	/* MemoryKindCapabilityValue */ 0,
+	/* MemoryKindLinkValue */ 0,
+	/* MemoryKindStorageReferenceValue */ 0,
+	/* MemoryKindEphemeralReferenceValue */ 0,
+	/* MemoryKindInterpretedFunction */ 0,
+	/* MemoryKindHostFunction */ 0,
+	/* MemoryKindBoundFunction */ 0,
+	/* MemoryKindBigInt */ 0,
+
+	/* MemoryKindRawString */ 0,
+	/* MemoryKindAddressLocation */ 0,
+	/* MemoryKindBytes */ 0,
+	/* MemoryKindVariable */ 0,
+
+	/* MemoryKindTokenIdentifier */ 0,
+	/* MemoryKindTokenComment */ 0,
+	/* MemoryKindTokenNumericLiteral */ 0,
+	/* MemoryKindTokenSyntax */ 0,
+}
+
+const MaximumMemoryAllowance uint64 = 0
+
+func _() {
+	// A compiler error signifies that we have not accounted for all memory kinds
+	var x [1]struct{}
+	_ = x[int(common.MemoryKindTokenSyntax)+1-len(memory_weights)]
+}
+
+type OutOfMemoryError struct {
+}
+
+func (e *OutOfMemoryError) Error() string {
+	return "Ran out of memory"
+
+}
+
+type MemoryMeter struct {
+	totalMemoryUsed uint64
+}
+
+func NewMemoryMeter() MemoryMeter {
+	return MemoryMeter{
+		totalMemoryUsed: 0,
+	}
+}
+
+func (m MemoryMeter) ConsumeMemory(usage common.MemoryUsage) error {
+	consumed := usage.Amount * memory_weights[usage.Kind]
+	m.totalMemoryUsed = m.totalMemoryUsed + consumed
+	if m.totalMemoryUsed > MaximumMemoryAllowance {
+		return &OutOfMemoryError{}
+	}
+	return nil
+}

--- a/fvm/mock/environment.go
+++ b/fvm/mock/environment.go
@@ -599,6 +599,20 @@ func (_m *Environment) MeterComputation(operationType common.ComputationKind, in
 	return r0
 }
 
+// MeterMemory provides a mock function with given fields: usage
+func (_m *Environment) MeterMemory(usage common.MemoryUsage) error {
+	ret := _m.Called(usage)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(common.MemoryUsage) error); ok {
+		r0 = rf(usage)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ProgramLog provides a mock function with given fields: _a0
 func (_m *Environment) ProgramLog(_a0 string) error {
 	ret := _m.Called(_a0)
@@ -653,6 +667,11 @@ func (_m *Environment) ResolveLocation(identifiers []ast.Identifier, location co
 	}
 
 	return r0, r1
+}
+
+// ResourceOwnerChanged provides a mock function with given fields: _a0, resource, oldOwner, newOwner
+func (_m *Environment) ResourceOwnerChanged(_a0 *interpreter.Interpreter, resource *interpreter.CompositeValue, oldOwner common.Address, newOwner common.Address) {
+	_m.Called(_a0, resource, oldOwner, newOwner)
 }
 
 // RevokeAccountKey provides a mock function with given fields: address, index

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -47,6 +47,7 @@ type ScriptEnv struct {
 	logs          []string
 	rng           *rand.Rand
 	traceSpan     opentracing.Span
+	meter         meter.MemoryMeter
 }
 
 func (e *ScriptEnv) Context() *Context {
@@ -79,6 +80,7 @@ func NewScriptEnvironment(
 		accountKeys:   accountKeys,
 		uuidGenerator: uuidGenerator,
 		programs:      programsHandler,
+		meter:         meter.NewMemoryMeter(),
 	}
 
 	env.contracts = handler.NewContractHandler(
@@ -835,5 +837,5 @@ func (e *ScriptEnv) BLSAggregatePublicKeys(keys []*runtime.PublicKey) (*runtime.
 }
 
 func (e *ScriptEnv) MeterMemory(usage common.MemoryUsage) error {
-	return nil
+	return e.meter.ConsumeMemory(usage)
 }

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -118,7 +118,7 @@ func (e *ScriptEnv) setMeteringWeights() {
 	m.SetMemoryWeights(memoryWeights)
 }
 
-func (e *ScriptEnv) ResourceOwnerChanged(_ *interpreter.CompositeValue, _ common.Address, _ common.Address) {
+func (e *ScriptEnv) ResourceOwnerChanged(_ *interpreter.Interpreter, _ *interpreter.CompositeValue, _ common.Address, _ common.Address) {
 }
 
 func (e *ScriptEnv) seedRNG(header *flow.Header) {
@@ -539,7 +539,7 @@ func (e *ScriptEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value, err
 		defer sp.Finish()
 	}
 
-	v, err := jsoncdc.Decode(b)
+	v, err := jsoncdc.Decode(e, b)
 	if err != nil {
 		err = errors.NewInvalidArgumentErrorf("argument is not json decodable: %w", err)
 		return nil, fmt.Errorf("decodeing argument failed: %w", err)
@@ -832,4 +832,8 @@ func (e *ScriptEnv) BLSAggregateSignatures(sigs [][]byte) ([]byte, error) {
 
 func (e *ScriptEnv) BLSAggregatePublicKeys(keys []*runtime.PublicKey) (*runtime.PublicKey, error) {
 	return crypto.AggregatePublicKeys(keys)
+}
+
+func (e *ScriptEnv) MeterMemory(usage common.MemoryUsage) error {
+	return nil
 }

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -53,6 +53,7 @@ type TransactionEnv struct {
 	txID             flow.Identifier
 	traceSpan        opentracing.Span
 	authorizers      []runtime.Address
+	meter            meter.MemoryMeter
 }
 
 func NewTransactionEnvironment(
@@ -93,6 +94,7 @@ func NewTransactionEnvironment(
 		txIndex:          txIndex,
 		txID:             tx.ID(),
 		traceSpan:        traceSpan,
+		meter:            meter.NewMemoryMeter(),
 	}
 
 	env.contracts = handler.NewContractHandler(accounts,
@@ -1149,5 +1151,5 @@ func (e *TransactionEnv) ResourceOwnerChanged(_ *interpreter.Interpreter, _ *int
 }
 
 func (e *TransactionEnv) MeterMemory(usage common.MemoryUsage) error {
-	return nil
+	return e.meter.ConsumeMemory(usage)
 }

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -678,7 +678,7 @@ func (e *TransactionEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value
 		defer sp.Finish()
 	}
 
-	v, err := jsoncdc.Decode(b)
+	v, err := jsoncdc.Decode(e, b)
 	if err != nil {
 		err = errors.NewInvalidArgumentErrorf("argument is not json decodable: %w", err)
 		return nil, fmt.Errorf("decodeing argument failed: %w", err)
@@ -1145,5 +1145,9 @@ func (e *TransactionEnv) BLSAggregatePublicKeys(keys []*runtime.PublicKey) (*run
 	return crypto.AggregatePublicKeys(keys)
 }
 
-func (e *TransactionEnv) ResourceOwnerChanged(_ *interpreter.CompositeValue, _ common.Address, _ common.Address) {
+func (e *TransactionEnv) ResourceOwnerChanged(_ *interpreter.Interpreter, _ *interpreter.CompositeValue, _ common.Address, _ common.Address) {
+}
+
+func (e *TransactionEnv) MeterMemory(usage common.MemoryUsage) error {
+	return nil
 }

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -315,6 +315,7 @@ func valueDeclarations(ctx *Context, env Environment) []runtime.ValueDeclaration
 			IsConstant:     true,
 			ArgumentLabels: nil,
 			Value: interpreter.NewHostFunctionValue(
+				env,
 				func(invocation interpreter.Invocation) interpreter.Value {
 					address, ok := invocation.Arguments[0].(interpreter.AddressValue)
 					if !ok {

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -336,6 +336,10 @@ func (e *ErrorReturningRuntime) SetTracingEnabled(_ bool) {
 	panic("SetTracingEnabled not expected")
 }
 
+func (e *ErrorReturningRuntime) SetInvalidatedResourceValidationEnabled(_ bool) {
+	panic("SetInvalidatedResourceValidationEnabled not expected")
+}
+
 func encodeContractNames(contractNames []string) ([]byte, error) {
 	sort.Strings(contractNames)
 	var buf bytes.Buffer

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -39,7 +39,7 @@ func ServiceEvent(chainID flow.ChainID, event flow.Event) (*flow.ServiceEvent, e
 func convertServiceEventEpochSetup(event flow.Event) (*flow.ServiceEvent, error) {
 
 	// decode bytes using jsoncdc
-	payload, err := json.Decode(event.Payload)
+	payload, err := json.Decode(nil, event.Payload)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal event payload: %w", err)
 	}
@@ -135,7 +135,7 @@ func convertServiceEventEpochSetup(event flow.Event) (*flow.ServiceEvent, error)
 func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error) {
 
 	// decode bytes using jsoncdc
-	payload, err := json.Decode(event.Payload)
+	payload, err := json.Decode(nil, event.Payload)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal event payload: %w", err)
 	}


### PR DESCRIPTION
Work on https://github.com/dapperlabs/cadence-private-issues/issues/36

For the upcoming Cadence changes (not yet released) to add memory metering, we need the FVM to actually do something with the recorded memory usage. In this PR, the FVM tracks the total used memory so far by multiplying the amount of abstract memory consumed by a weight (not yet computed) to produce a total, and then throws an error if that total exceeds the maximum allowed usage. 