### PR TITLE
Improve DKG & QC contract logging

### DIFF
--- a/cmd/bootstrap/cmd/partner_infos.go
+++ b/cmd/bootstrap/cmd/partner_infos.go
@@ -116,7 +116,7 @@ func getFlowClient() *client.Client {
 		insecureClient = false
 	}
 
-	config, err := common.NewFlowClientConfig(flagANAddress, strings.TrimPrefix(flagANNetworkKey, "0x"), insecureClient)
+	config, err := common.NewFlowClientConfig(flagANAddress, strings.TrimPrefix(flagANNetworkKey, "0x"), flow.ZeroID, insecureClient)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not get flow client config with address (%s) and network key (%s)", flagANAddress, flagANNetworkKey)
 	}

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -526,7 +526,7 @@ func main() {
 }
 
 // createQCContractClient creates QC contract client
-func createQCContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClient *client.Client) (module.QCContractClient, error) {
+func createQCContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClient *client.Client, anID flow.Identifier) (module.QCContractClient, error) {
 
 	var qcContractClient module.QCContractClient
 
@@ -544,7 +544,7 @@ func createQCContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.
 	txSigner := sdkcrypto.NewInMemorySigner(sk, machineAccountInfo.HashAlgorithm)
 
 	// create actual qc contract client, all flags and machine account info file found
-	qcContractClient = epochs.NewQCContractClient(node.Logger, flowClient, node.Me.NodeID(), machineAccountInfo.Address, machineAccountInfo.KeyIndex, qcContractAddress, txSigner)
+	qcContractClient = epochs.NewQCContractClient(node.Logger, flowClient, anID, node.Me.NodeID(), machineAccountInfo.Address, machineAccountInfo.KeyIndex, qcContractAddress, txSigner)
 
 	return qcContractClient, nil
 }
@@ -559,7 +559,7 @@ func createQCContractClients(node *cmd.NodeConfig, machineAccountInfo *bootstrap
 			return nil, fmt.Errorf("failed to create flow client for qc contract client with options: %s %w", flowClientOpts, err)
 		}
 
-		qcClient, err := createQCContractClient(node, machineAccountInfo, flowClient)
+		qcClient, err := createQCContractClient(node, machineAccountInfo, flowClient, opt.AccessNodeID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create qc contract client with flow client options: %s %w", flowClientOpts, err)
 		}

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -795,7 +795,7 @@ func loadBeaconPrivateKey(dir string, myID flow.Identifier) (*encodable.RandomBe
 }
 
 // createDKGContractClient creates an dkgContractClient
-func createDKGContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClient *client.Client) (module.DKGContractClient, error) {
+func createDKGContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClient *client.Client, anID flow.Identifier) (module.DKGContractClient, error) {
 	var dkgClient module.DKGContractClient
 
 	contracts, err := systemcontracts.SystemContractsForChain(node.RootChainID)
@@ -815,6 +815,7 @@ func createDKGContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap
 	dkgClient = dkgmodule.NewClient(
 		node.Logger,
 		flowClient,
+		anID,
 		txSigner,
 		dkgContractAddress,
 		machineAccountInfo.Address,
@@ -835,7 +836,7 @@ func createDKGContractClients(node *cmd.NodeConfig, machineAccountInfo *bootstra
 		}
 
 		node.Logger.Info().Msgf("created dkg contract client with opts: %s", opt.String())
-		dkgClient, err := createDKGContractClient(node, machineAccountInfo, flowClient)
+		dkgClient, err := createDKGContractClient(node, machineAccountInfo, flowClient, opt.AccessNodeID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create dkg contract client with flow client options: %s %w", flowClientOpts, err)
 		}

--- a/cmd/dynamic_startup.go
+++ b/cmd/dynamic_startup.go
@@ -174,7 +174,7 @@ func DynamicStartPreInit(nodeConfig *NodeConfig) error {
 	}
 
 	// get flow client with secure client connection to download protocol snapshot from access node
-	config, err := common.NewFlowClientConfig(nodeConfig.DynamicStartupANAddress, nodeConfig.DynamicStartupANPubkey, false)
+	config, err := common.NewFlowClientConfig(nodeConfig.DynamicStartupANAddress, nodeConfig.DynamicStartupANPubkey, flow.ZeroID, false)
 	if err != nil {
 		return fmt.Errorf("failed to create flow client config for node dynamic startup pre-init: %w", err)
 	}

--- a/cmd/util/cmd/common/flow_client.go
+++ b/cmd/util/cmd/common/flow_client.go
@@ -22,6 +22,7 @@ const (
 type FlowClientConfig struct {
 	AccessAddress    string
 	AccessNodePubKey string
+	AccessNodeID     flow.Identifier
 	Insecure         bool
 }
 
@@ -30,7 +31,7 @@ func (f *FlowClientConfig) String() string {
 }
 
 // NewFlowClientConfig returns *FlowClientConfig
-func NewFlowClientConfig(accessAddress, accessApiNodePubKey string, insecure bool) (*FlowClientConfig, error) {
+func NewFlowClientConfig(accessAddress, accessApiNodePubKey string, accessNodeID flow.Identifier, insecure bool) (*FlowClientConfig, error) {
 	if accessAddress == "" {
 		return nil, fmt.Errorf("failed to create  flow client connection option invalid access address: %s", accessAddress)
 	}
@@ -41,7 +42,7 @@ func NewFlowClientConfig(accessAddress, accessApiNodePubKey string, insecure boo
 		}
 	}
 
-	return &FlowClientConfig{accessAddress, accessApiNodePubKey, insecure}, nil
+	return &FlowClientConfig{accessAddress, accessApiNodePubKey, accessNodeID, insecure}, nil
 }
 
 // FlowClient will return a secure or insecure flow client depending on *FlowClientConfig.Insecure
@@ -102,7 +103,7 @@ func FlowClientConfigs(accessNodeIDS []flow.Identifier, insecureAccessAPI bool, 
 		// remove the 0x prefix from network public keys
 		networkingPubKey := strings.TrimPrefix(identity.NetworkPubKey.String(), "0x")
 
-		opt, err := NewFlowClientConfig(accessAddress, networkingPubKey, insecureAccessAPI)
+		opt, err := NewFlowClientConfig(accessAddress, networkingPubKey, identity.NodeID, insecureAccessAPI)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get flow client connection option for access node ID (%d): %s %w", i, identity, err)
 		}

--- a/integration/dkg/dkg_emulator_suite.go
+++ b/integration/dkg/dkg_emulator_suite.go
@@ -146,6 +146,7 @@ func (s *DKGSuite) deployDKGContract() {
 	s.adminDKGContractClient = dkg.NewClient(
 		zerolog.Nop(),
 		s.adminEmulatorClient,
+		flow.ZeroID,
 		s.dkgSigner,
 		s.dkgAddress.String(),
 		s.dkgAddress.String(), 0)
@@ -267,6 +268,7 @@ func (s *DKGSuite) createNode(account *nodeAccount) *node {
 	contractClient := dkg.NewClient(
 		zerolog.Nop(),
 		emulatorClient,
+		flow.ZeroID,
 		account.accountSigner,
 		s.dkgAddress.String(),
 		account.accountAddress.String(),

--- a/integration/epochs/epoch_qc_test.go
+++ b/integration/epochs/epoch_qc_test.go
@@ -74,7 +74,7 @@ func (s *Suite) TestEpochQuorumCertificate() {
 		address, err := s.blockchain.CreateAccount([]*sdk.AccountKey{key}, []sdktemplates.Contract{})
 		s.Require().NoError(err)
 
-		client := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, nodeID, address.String(), 0, s.qcAddress.String(), signer)
+		client := epochs.NewQCContractClient(zerolog.Nop(), s.emulatorClient, flow.ZeroID, nodeID, address.String(), 0, s.qcAddress.String(), signer)
 		s.Require().NoError(err)
 
 		local := &modulemock.Local{}

--- a/module/dkg/client.go
+++ b/module/dkg/client.go
@@ -33,13 +33,17 @@ type Client struct {
 func NewClient(
 	log zerolog.Logger,
 	flowClient module.SDKClientWrapper,
+	flowClientANID flow.Identifier,
 	signer sdkcrypto.Signer,
 	dkgContractAddress,
 	accountAddress string,
 	accountKeyIndex uint,
 ) *Client {
 
-	log = log.With().Str("component", "dkg_contract_client").Logger()
+	log = log.With().
+		Str("component", "dkg_contract_client").
+		Str("flow-client-an-id", flowClientANID.String()).
+		Logger()
 	base := epochs.NewBaseClient(log, flowClient, accountAddress, accountKeyIndex, signer, dkgContractAddress)
 
 	env := templates.Environment{DkgAddress: dkgContractAddress}

--- a/module/dkg/client.go
+++ b/module/dkg/client.go
@@ -42,7 +42,7 @@ func NewClient(
 
 	log = log.With().
 		Str("component", "dkg_contract_client").
-		Str("flow-client-an-id", flowClientANID.String()).
+		Str("flow_client_an_id", flowClientANID.String()).
 		Logger()
 	base := epochs.NewBaseClient(log, flowClient, accountAddress, accountKeyIndex, signer, dkgContractAddress)
 

--- a/module/dkg/client_test.go
+++ b/module/dkg/client_test.go
@@ -57,7 +57,7 @@ func (s *ClientSuite) SetupTest() {
 	// deploy contract
 	s.deployDKGContract()
 
-	s.contractClient = NewClient(zerolog.Nop(), s.emulatorClient, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
+	s.contractClient = NewClient(zerolog.Nop(), s.emulatorClient, flow.ZeroID, s.dkgSigner, s.dkgAddress.String(), s.dkgAddress.String(), 0)
 }
 
 func (s *ClientSuite) deployDKGContract() {
@@ -219,7 +219,7 @@ func (s *ClientSuite) prepareDKG(participants []flow.Identifier) []*Client {
 	// create clients for each participant
 	clients := make([]*Client, len(participants))
 	for index := range participants {
-		clients[index] = NewClient(zerolog.Nop(), s.emulatorClient, signers[index], s.dkgAddress.String(), addresses[index].String(), 0)
+		clients[index] = NewClient(zerolog.Nop(), s.emulatorClient, flow.ZeroID, signers[index], s.dkgAddress.String(), addresses[index].String(), 0)
 	}
 
 	return clients

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -52,7 +52,7 @@ func NewQCContractClient(
 
 	log = log.With().
 		Str("component", "qc_contract_client").
-		Str("flow-client-an-id", flowClientANID.String()).
+		Str("flow_client_an_id", flowClientANID.String()).
 		Logger()
 	base := NewBaseClient(log, flowClient, accountAddress, accountKeyIndex, signer, qcContractAddress)
 

--- a/module/epochs/qc_client.go
+++ b/module/epochs/qc_client.go
@@ -42,6 +42,7 @@ type QCContractClient struct {
 func NewQCContractClient(
 	log zerolog.Logger,
 	flowClient module.SDKClientWrapper,
+	flowClientANID flow.Identifier,
 	nodeID flow.Identifier,
 	accountAddress string,
 	accountKeyIndex uint,
@@ -49,7 +50,10 @@ func NewQCContractClient(
 	signer sdkcrypto.Signer,
 ) *QCContractClient {
 
-	log = log.With().Str("component", "qc_contract_client").Logger()
+	log = log.With().
+		Str("component", "qc_contract_client").
+		Str("flow-client-an-id", flowClientANID.String()).
+		Logger()
 	base := NewBaseClient(log, flowClient, accountAddress, accountKeyIndex, signer, qcContractAddress)
 
 	// set QCContractAddress to the contract address given


### PR DESCRIPTION
This PR updates the DKG and QC contract client logger initialization to include the node ID of the AN that the flow client being used is connecting to.