### PR TITLE
Fix flakey test: `TestComponentShutdown`

### DIFF
--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -293,7 +293,7 @@ func (suite *Suite) TestComponentShutdown() {
 	suite.engine.Start(ctx)
 	unittest.AssertClosesBefore(suite.T(), suite.engine.Ready(), 10*time.Millisecond)
 	cancel()
-	unittest.AssertClosesBefore(suite.T(), suite.engine.Done(), 10*time.Millisecond)
+	unittest.AssertClosesBefore(suite.T(), suite.engine.ShutdownSignal(), 10*time.Millisecond)
 
 	err := suite.engine.ProcessTransaction(&tx)
 	suite.Assert().ErrorIs(err, component.ErrComponentShutdown)


### PR DESCRIPTION
There is a race in the `ComponentManager` where `Done` may be closed before `ShutdownSignal`. This fixes the test case (not the race) by making it wait on the same channel as the function being tested. 

Issue to address the race: https://github.com/dapperlabs/flow-go/issues/6220