### PR TITLE
Add mutex around script tracking map

### DIFF
--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -106,7 +106,7 @@ func New(
 			connFactory:       connFactory,
 			state:             state,
 			log:               log,
-			seenScripts: scriptMap{
+			seenScripts: &scriptMap{
 				scripts: make(map[[md5.Size]byte]time.Time),
 				lock:    sync.RWMutex{},
 			},

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -108,7 +108,7 @@ func New(
 			log:               log,
 			seenScripts: scriptMap{
 				scripts: make(map[[md5.Size]byte]time.Time),
-				lock:    sync.Mutex{},
+				lock:    sync.RWMutex{},
 			},
 		},
 		backendTransactions: backendTransactions{

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5" //nolint:gosec
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
@@ -105,7 +106,10 @@ func New(
 			connFactory:       connFactory,
 			state:             state,
 			log:               log,
-			seenScripts:       make(map[[md5.Size]byte]time.Time),
+			seenScripts: scriptMap{
+				scripts: make(map[[md5.Size]byte]time.Time),
+				lock:    sync.Mutex{},
+			},
 		},
 		backendTransactions: backendTransactions{
 			staticCollectionRPC:  collectionRPC,

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -26,12 +26,25 @@ type backendScripts struct {
 	state             protocol.State
 	connFactory       ConnectionFactory
 	log               zerolog.Logger
-	seenScripts       scriptMap
+	seenScripts       *scriptMap
 }
 
 type scriptMap struct {
 	scripts map[[md5.Size]byte]time.Time // to keep track of unique scripts sent by clients. bounded to 1MB (2^16*2*8) due to fixed key size
 	lock    sync.RWMutex
+}
+
+func (s *scriptMap) getLastSeen(scriptId [md5.Size]byte) (time.Time, bool) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	timestamp, seen := s.scripts[scriptId]
+	return timestamp, seen
+}
+
+func (s *scriptMap) setLastSeenToTime(scriptId [md5.Size]byte, execTime time.Time) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.scripts[scriptId] = execTime
 }
 
 func (b *backendScripts) ExecuteScriptAtLatestBlock(
@@ -113,9 +126,7 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 		if err == nil {
 			if b.log.GetLevel() == zerolog.DebugLevel {
 				executionTime := time.Now()
-				b.seenScripts.lock.RLock()
-				timestamp, seen := b.seenScripts.scripts[encodedScript]
-				b.seenScripts.lock.RUnlock()
+				timestamp, seen := b.seenScripts.getLastSeen(encodedScript)
 				// log if the script is unique in the time window
 				if !seen || executionTime.Sub(timestamp) >= uniqueScriptLoggingTimeWindow {
 					b.log.Debug().
@@ -124,9 +135,7 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 						Hex("script_hash", encodedScript[:]).
 						Str("script", string(script)).
 						Msg("Successfully executed script")
-					b.seenScripts.lock.Lock()
-					b.seenScripts.scripts[encodedScript] = executionTime
-					b.seenScripts.lock.Unlock()
+					b.seenScripts.setLastSeenToTime(encodedScript, executionTime)
 				}
 			}
 			return result, nil

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -31,7 +31,7 @@ type backendScripts struct {
 
 type scriptMap struct {
 	scripts map[[md5.Size]byte]time.Time // to keep track of unique scripts sent by clients. bounded to 1MB (2^16*2*8) due to fixed key size
-	lock    sync.Mutex
+	lock    sync.RWMutex
 }
 
 func (b *backendScripts) ExecuteScriptAtLatestBlock(
@@ -113,9 +113,9 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 		if err == nil {
 			if b.log.GetLevel() == zerolog.DebugLevel {
 				executionTime := time.Now()
-				b.seenScripts.lock.Lock()
+				b.seenScripts.lock.RLock()
 				timestamp, seen := b.seenScripts.scripts[encodedScript]
-				b.seenScripts.lock.Unlock()
+				b.seenScripts.lock.RUnlock()
 				// log if the script is unique in the time window
 				if !seen || executionTime.Sub(timestamp) >= uniqueScriptLoggingTimeWindow {
 					b.log.Debug().


### PR DESCRIPTION
unhandled concurrency issue when one routine writes while another reads from the map:
```
Apr 08 19:04:03 access-002 docker[226817]: fatal error: concurrent map writes
Apr 08 19:04:03 access-002 docker[226817]: goroutine 900422 [running]:
Apr 08 19:04:03 access-002 docker[226817]: runtime.throw({0x1b781c6, 0x7f05dc00b5b8})
Apr 08 19:04:03 access-002 docker[226817]:     /usr/local/go/src/runtime/panic.go:1198 +0x71 fp=0xc00290efe8 sp=0xc00290efb8 pc=0x4379b1
Apr 08 19:04:03 access-002 docker[226817]: runtime.mapassign(0x520994dac107a40c, 0x1a41f7b, 0x98c)
Apr 08 19:04:03 access-002 docker[226817]:     /usr/local/go/src/runtime/map.go:585 +0x4d6 fp=0xc00290f068 sp=0xc00290efe8 pc=0x410dd6
Apr 08 19:04:03 access-002 docker[226817]: github.com/onflow/flow-go/engine/access/rpc/backend.(*backendScripts).executeScriptOnExecutionNode(0xc00ab79400, {0x1f0d0b8, 0xc025c5a420}, {0xf4, 0x1d, 0xf0, 0xf2, 0x93, 0x3c, 0xc5, ...}, ...)
Apr 08 19:04:03 access-002 docker[226817]:     /app/engine/access/rpc/backend/backend_scripts.go:119 +0x869 fp=0xc00290f458 sp=0xc00290f068 pc=0x14233a9
```

added mutex locks around read/write operations