### PR TITLE
Use block ID from seal

### DIFF
--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -231,7 +231,7 @@ func (e *Engine) processFinalizedBlock(blockID flow.Identifier) error {
 
 	// loop through seals and index ID -> result ID
 	for _, seal := range block.Payload.Seals {
-		err := e.executionResults.Index(blockID, seal.ResultID)
+		err := e.executionResults.Index(seal.BlockID, seal.ResultID)
 		if err != nil {
 			return fmt.Errorf("could not index block for execution result: %w", err)
 		}


### PR DESCRIPTION
index against the block id in the seal, rather than the current block ID