### PR TITLE
Fix race detector issues.

### DIFF
--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
@@ -528,8 +528,13 @@ func TestCombinedVoteProcessorV3_PropertyCreatingQCCorrectness(testifyT *testing
 			// check that aggregated signers are part of all votes signers
 			// due to concurrent processing it is possible that Aggregate will return less that we have actually aggregated
 			// but still enough to construct the QC
+			stakingAggregatorLock.Lock()
 			require.Subset(t, aggregatedStakingSigners, blockSigData.StakingSigners)
+			stakingAggregatorLock.Unlock()
+
+			beaconAggregatorLock.Lock()
 			require.Subset(t, aggregatedBeaconSigners, blockSigData.RandomBeaconSigners)
+			beaconAggregatorLock.Unlock()
 
 			// 2. CHECK: supermajority
 			// All participants have equal weights in this test. Per configuration, collecting `honestParticipants`

--- a/crypto/bls12381_utils.c
+++ b/crypto/bls12381_utils.c
@@ -99,7 +99,7 @@ ctx_t* relic_init_BLS12_381() {
     if (ALLOC != AUTO) return NULL;
 
     // initialize relic core with a new context
-    ctx_t* bls_ctx = (ctx_t*) malloc(sizeof(ctx_t));
+    ctx_t* bls_ctx = (ctx_t*) calloc(1, sizeof(ctx_t));
     core_set(bls_ctx);
     if (core_init() != RLC_OK) return NULL;
 

--- a/crypto/hash/xor_unaligned.go
+++ b/crypto/hash/xor_unaligned.go
@@ -39,6 +39,7 @@ import "unsafe"
 // A storageBuf is an aligned array of maxRate bytes.
 type storageBuf [maxRate / 8]uint64
 
+//go:nocheckptr ignore "pointer arithmetic result points to invalid allocation"
 func (b *storageBuf) asBytes() *[maxRate]byte {
 	// re-using a trick from https://github.com/golang/go/blob/master/src/runtime/stubs.go#L178:
 	// to hide the input pointer from escape analysis and avoid

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -50,15 +51,17 @@ type Config struct {
 // An unsecured GRPC server (default port 9000), a secure GRPC server (default port 9001) and an HTTP Web proxy (default
 // port 8000) are brought up.
 type Engine struct {
-	unit                *engine.Unit
-	log                 zerolog.Logger
-	backend             *backend.Backend // the gRPC service implementation
-	unsecureGrpcServer  *grpc.Server     // the unsecure gRPC server
-	secureGrpcServer    *grpc.Server     // the secure gRPC server
-	httpServer          *http.Server
-	restServer          *http.Server
-	config              Config
-	chain               flow.Chain
+	unit               *engine.Unit
+	log                zerolog.Logger
+	backend            *backend.Backend // the gRPC service implementation
+	unsecureGrpcServer *grpc.Server     // the unsecure gRPC server
+	secureGrpcServer   *grpc.Server     // the secure gRPC server
+	httpServer         *http.Server
+	restServer         *http.Server
+	config             Config
+	chain              flow.Chain
+
+	addrLock            sync.RWMutex
 	unsecureGrpcAddress net.Addr
 	secureGrpcAddress   net.Addr
 	restAPIAddress      net.Addr
@@ -242,14 +245,20 @@ func (e *Engine) SubmitLocal(event interface{}) {
 }
 
 func (e *Engine) UnsecureGRPCAddress() net.Addr {
+	e.addrLock.RLock()
+	defer e.addrLock.RUnlock()
 	return e.unsecureGrpcAddress
 }
 
 func (e *Engine) SecureGRPCAddress() net.Addr {
+	e.addrLock.RLock()
+	defer e.addrLock.RUnlock()
 	return e.secureGrpcAddress
 }
 
 func (e *Engine) RestApiAddress() net.Addr {
+	e.addrLock.RLock()
+	defer e.addrLock.RUnlock()
 	return e.restAPIAddress
 }
 
@@ -280,7 +289,9 @@ func (e *Engine) serveUnsecureGRPC() {
 
 	// save the actual address on which we are listening (may be different from e.config.UnsecureGRPCListenAddr if not port
 	// was specified)
+	e.addrLock.Lock()
 	e.unsecureGrpcAddress = l.Addr()
+	e.addrLock.Unlock()
 
 	e.log.Debug().Str("unsecure_grpc_address", e.unsecureGrpcAddress.String()).Msg("listening on port")
 
@@ -302,7 +313,9 @@ func (e *Engine) serveSecureGRPC() {
 		return
 	}
 
+	e.addrLock.Lock()
 	e.secureGrpcAddress = l.Addr()
+	e.addrLock.Unlock()
 
 	e.log.Debug().Str("secure_grpc_address", e.secureGrpcAddress.String()).Msg("listening on port")
 
@@ -345,7 +358,9 @@ func (e *Engine) serveREST() {
 		return
 	}
 
+	e.addrLock.Lock()
 	e.restAPIAddress = l.Addr()
+	e.addrLock.Unlock()
 
 	e.log.Debug().Str("rest_api_address", e.restAPIAddress.String()).Msg("listening on port")
 

--- a/engine/collection/epochmgr/engine.go
+++ b/engine/collection/epochmgr/engine.go
@@ -208,10 +208,12 @@ func (e *Engine) Done() <-chan struct{} {
 	return e.unit.Done(func() {
 		// Stop components for all epochs. This is typically a single epoch
 		// but can be multiple near epoch boundaries
+		e.unit.Lock()
 		epochs := make([]module.ReadyDoneAware, 0, len(e.epochs))
 		for _, epoch := range e.epochs {
 			epochs = append(epochs, epoch)
 		}
+		e.unit.Unlock()
 		e.stopComponents() // stop all components using parent context
 		<-util.AllDone(epochs...)
 	})

--- a/engine/consensus/approvals/assignment_collector_statemachine_test.go
+++ b/engine/consensus/approvals/assignment_collector_statemachine_test.go
@@ -105,12 +105,16 @@ func (s *AssignmentCollectorStateMachineTestSuite) TestChangeProcessingStatus_Ca
 	require.True(s.T(), ok)
 
 	for _, ir := range results {
+		verifyingCollector.lock.Lock()
 		collector, ok := verifyingCollector.collectors[ir.IncorporatedBlockID]
+		verifyingCollector.lock.Unlock()
 		require.True(s.T(), ok)
 
 		for _, approval := range approvals {
 			chunkCollector := collector.chunkCollectors[approval.Body.ChunkIndex]
+			chunkCollector.lock.Lock()
 			signed := chunkCollector.chunkApprovals.HasSigned(approval.Body.ApproverID)
+			chunkCollector.lock.Unlock()
 			require.True(s.T(), signed)
 		}
 	}

--- a/engine/consensus/approvals/caching_assignment_collector_test.go
+++ b/engine/consensus/approvals/caching_assignment_collector_test.go
@@ -46,8 +46,6 @@ func (s *CachingAssignmentCollectorTestSuite) TestCheckEmergencySealing() {
 
 // TestProcessApproval tests that collector caches approval when requested to process it
 func (s *CachingAssignmentCollectorTestSuite) TestProcessApproval() {
-	s.T().Parallel()
-
 	approval := unittest.ResultApprovalFixture()
 	err := s.collector.ProcessApproval(approval)
 	require.Error(s.T(), err)
@@ -72,8 +70,6 @@ func (s *CachingAssignmentCollectorTestSuite) TestProcessApproval() {
 
 // TestProcessIncorporatedResult tests that collector caches result when requested to processes flow.IncorporatedResult
 func (s *CachingAssignmentCollectorTestSuite) TestProcessIncorporatedResult() {
-	s.T().Parallel()
-
 	// processing invalid result should error
 	err := s.collector.ProcessIncorporatedResult(unittest.IncorporatedResult.Fixture(
 		unittest.IncorporatedResult.WithResult(unittest.ExecutionResultFixture()),

--- a/engine/enqueue_test.go
+++ b/engine/enqueue_test.go
@@ -229,10 +229,12 @@ func TestProcessMessageSameType(t *testing.T) {
 		require.NoError(t, eng.Process(id2, m4))
 
 		require.Eventuallyf(t, func() bool {
-			return len(eng.messages) == 4
+			return eng.MessageCount() == 4
 		}, 2*time.Second, 10*time.Millisecond, "expect %v messages, but go %v messages",
-			4, eng.messages)
+			4, eng.MessageCount())
 
+		eng.mu.Lock()
+		defer eng.mu.Unlock()
 		require.Equal(t, m1, eng.messages[0])
 		require.Equal(t, m2, eng.messages[1])
 		require.Equal(t, m3, eng.messages[2])
@@ -256,10 +258,12 @@ func TestProcessMessageDifferentType(t *testing.T) {
 		require.NoError(t, eng.Process(id2, m4))
 
 		require.Eventuallyf(t, func() bool {
-			return len(eng.messages) == 4
+			return eng.MessageCount() == 4
 		}, 2*time.Second, 10*time.Millisecond, "expect %v messages, but go %v messages",
-			4, eng.messages)
+			4, eng.MessageCount())
 
+		eng.mu.Lock()
+		defer eng.mu.Unlock()
 		require.Equal(t, m1, eng.messages[0])
 		require.Equal(t, m2, eng.messages[1])
 		require.Equal(t, &messageC{s: "c-3"}, eng.messages[2])
@@ -286,9 +290,11 @@ func TestProcessMessageInterval(t *testing.T) {
 		require.NoError(t, eng.Process(id2, m4))
 
 		require.Eventuallyf(t, func() bool {
-			return len(eng.messages) == 4
+			return eng.MessageCount() == 4
 		}, 2*time.Second, 10*time.Millisecond, "expect %v messages, but go %v messages",
-			4, eng.messages)
+			4, eng.MessageCount())
+		eng.mu.Lock()
+		defer eng.mu.Unlock()
 
 		require.Equal(t, m1, eng.messages[0])
 		require.Equal(t, m2, eng.messages[1])

--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -2,6 +2,7 @@ package execution_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/vmihailenco/msgpack"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/engine"
 	execTestutil "github.com/onflow/flow-go/engine/execution/testutil"
@@ -147,6 +149,7 @@ func TestExecutionFlow(t *testing.T) {
 		Once().
 		Return(nil)
 
+	var lock sync.Mutex
 	var receipt *flow.ExecutionReceipt
 
 	// create verification engine that can create approvals and send to consensus nodes
@@ -155,6 +158,8 @@ func TestExecutionFlow(t *testing.T) {
 	_, _ = verificationNode.Net.Register(engine.ReceiveReceipts, verificationEngine)
 	verificationEngine.On("Process", mock.AnythingOfType("network.Channel"), exeID.NodeID, mock.Anything).
 		Run(func(args mock.Arguments) {
+			lock.Lock()
+			defer lock.Unlock()
 			receipt, _ = args[2].(*flow.ExecutionReceipt)
 
 			assert.Equal(t, block.ID(), receipt.ExecutionResult.BlockID)
@@ -168,6 +173,9 @@ func TestExecutionFlow(t *testing.T) {
 	_, _ = consensusNode.Net.Register(engine.ReceiveReceipts, consensusEngine)
 	consensusEngine.On("Process", mock.AnythingOfType("network.Channel"), exeID.NodeID, mock.Anything).
 		Run(func(args mock.Arguments) {
+			lock.Lock()
+			defer lock.Unlock()
+
 			receipt, _ = args[2].(*flow.ExecutionReceipt)
 
 			assert.Equal(t, block.ID(), receipt.ExecutionResult.BlockID)
@@ -193,6 +201,9 @@ func TestExecutionFlow(t *testing.T) {
 		// when sendBlock returned, ingestion engine might not have processed
 		// the block yet, because the process is async. we have to wait
 		hub.DeliverAll()
+
+		lock.Lock()
+		defer lock.Unlock()
 		return receipt != nil
 	}, time.Second*10, time.Millisecond*500)
 
@@ -349,13 +360,13 @@ func TestExecutionStateSyncMultipleExecutionNodes(t *testing.T) {
 		[]*flow.Collection{col1, col2, col3},
 	)
 
-	receiptsReceived := 0
+	receiptsReceived := atomic.Uint64{}
 
 	consensusEngine := new(mocknetwork.Engine)
 	_, _ = consensusNode.Net.Register(engine.ReceiveReceipts, consensusEngine)
 	consensusEngine.On("Process", mock.AnythingOfType("network.Channel"), mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			receiptsReceived++
+			receiptsReceived.Inc()
 			originID := args[1].(flow.Identifier)
 			receipt := args[2].(*flow.ExecutionReceipt)
 			finalState, _ := receipt.ExecutionResult.FinalStateCommitment()
@@ -375,7 +386,7 @@ func TestExecutionStateSyncMultipleExecutionNodes(t *testing.T) {
 
 	// ensure block 1 has been executed
 	hub.DeliverAllEventually(t, func() bool {
-		return receiptsReceived == 1
+		return receiptsReceived.Load() == 1
 	})
 	exe1Node.AssertHighestExecutedBlock(t, block1.Header)
 
@@ -395,7 +406,7 @@ func TestExecutionStateSyncMultipleExecutionNodes(t *testing.T) {
 
 	// ensure block 1, 2 and 3 have been executed
 	hub.DeliverAllEventually(t, func() bool {
-		return receiptsReceived == 3
+		return receiptsReceived.Load() == 3
 	})
 
 	// ensure state has been synced across both nodes
@@ -488,16 +499,16 @@ func TestBroadcastToMultipleVerificationNodes(t *testing.T) {
 
 	child := unittest.BlockWithParentAndProposerFixture(block.Header, conID.NodeID)
 
-	actualCalls := 0
-
-	var receipt *flow.ExecutionReceipt
+	actualCalls := atomic.Uint64{}
 
 	verificationEngine := new(mocknetwork.Engine)
 	_, _ = verification1Node.Net.Register(engine.ReceiveReceipts, verificationEngine)
 	_, _ = verification2Node.Net.Register(engine.ReceiveReceipts, verificationEngine)
 	verificationEngine.On("Process", mock.AnythingOfType("network.Channel"), exeID.NodeID, mock.Anything).
 		Run(func(args mock.Arguments) {
-			actualCalls++
+			actualCalls.Inc()
+
+			var receipt *flow.ExecutionReceipt
 			receipt, _ = args[2].(*flow.ExecutionReceipt)
 
 			assert.Equal(t, block.ID(), receipt.ExecutionResult.BlockID)
@@ -511,7 +522,7 @@ func TestBroadcastToMultipleVerificationNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	hub.DeliverAllEventually(t, func() bool {
-		return actualCalls == 2
+		return actualCalls.Load() == 2
 	})
 
 	verificationEngine.AssertExpectations(t)

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -66,6 +66,8 @@ type testingContext struct {
 	identity            *flow.Identity
 	broadcastedReceipts map[flow.Identifier]*flow.ExecutionReceipt
 	collectionRequester *module.MockRequester
+
+	mu *sync.Mutex
 }
 
 func runWithEngine(t *testing.T, f func(testingContext)) {
@@ -189,6 +191,8 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 		snapshot:            snapshot,
 		identity:            myIdentity,
 		broadcastedReceipts: make(map[flow.Identifier]*flow.ExecutionReceipt),
+
+		mu: &sync.Mutex{},
 	})
 
 	<-engine.Done()
@@ -202,7 +206,6 @@ func (ctx *testingContext) assertSuccessfulBlockComputation(
 	expectBroadcast bool,
 	newStateCommitment flow.StateCommitment,
 	computationResult *execution.ComputationResult) *protocol.Snapshot {
-
 	if computationResult == nil {
 		computationResult = executionUnittest.ComputationResultForBlockFixture(executableBlock)
 	}
@@ -253,12 +256,12 @@ func (ctx *testingContext) assertSuccessfulBlockComputation(
 
 	mocked.RunFn =
 		func(args mock.Arguments) {
-			//lock.Lock()
-			//defer lock.Unlock()
-
 			blockID := args[1].(*flow.Header).ID()
 			commit := args[2].(flow.StateCommitment)
+
+			ctx.mu.Lock()
 			commits[blockID] = commit
+			ctx.mu.Unlock()
 			onPersisted(blockID, commit)
 		}
 
@@ -303,7 +306,9 @@ func (ctx *testingContext) assertSuccessfulBlockComputation(
 				assert.True(ctx.t, valid)
 			}
 
+			ctx.mu.Lock()
 			ctx.broadcastedReceipts[receipt.ExecutionResult.BlockID] = receipt
+			ctx.mu.Unlock()
 		}).
 		Return(nil)
 
@@ -334,25 +339,20 @@ func (ctx *testingContext) stateCommitmentExist(blockID flow.Identifier, commit 
 }
 
 func (ctx *testingContext) mockStateCommitsWithMap(commits map[flow.Identifier]flow.StateCommitment) {
-	lock := sync.Mutex{}
+	mocked := ctx.executionState.On("StateCommitmentByBlockID", mock.Anything, mock.Anything)
+	// https://github.com/stretchr/testify/issues/350#issuecomment-570478958
+	mocked.RunFn = func(args mock.Arguments) {
 
-	{
-		mocked := ctx.executionState.On("StateCommitmentByBlockID", mock.Anything, mock.Anything)
-		// https://github.com/stretchr/testify/issues/350#issuecomment-570478958
-		mocked.RunFn = func(args mock.Arguments) {
-			// prevent concurrency issue
-			lock.Lock()
-			defer lock.Unlock()
-
-			blockID := args[1].(flow.Identifier)
-			commit, ok := commits[blockID]
-			if ok {
-				mocked.ReturnArguments = mock.Arguments{commit, nil}
-				return
-			}
-
-			mocked.ReturnArguments = mock.Arguments{flow.StateCommitment{}, storageerr.ErrNotFound}
+		blockID := args[1].(flow.Identifier)
+		ctx.mu.Lock()
+		commit, ok := commits[blockID]
+		ctx.mu.Unlock()
+		if ok {
+			mocked.ReturnArguments = mock.Arguments{commit, nil}
+			return
 		}
+
+		mocked.ReturnArguments = mock.Arguments{flow.StateCommitment{}, storageerr.ErrNotFound}
 	}
 }
 

--- a/engine/execution/state/delta/view.go
+++ b/engine/execution/state/delta/view.go
@@ -24,7 +24,7 @@ type View struct {
 	// TODO we can add a flag to disable capturing spockSecret
 	// for views other than collection views to improve performance
 	spockSecret       []byte
-	spockSecretLock   sync.Mutex
+	spockSecretLock   *sync.Mutex // using pointer instead, because using value would cause mock.Called to trigger race detector
 	spockSecretHasher hash.Hasher
 	readFunc          GetRegisterFunc
 }
@@ -48,6 +48,7 @@ func AlwaysEmptyGetRegisterFunc(owner, controller, key string) (flow.RegisterVal
 func NewView(readFunc GetRegisterFunc) *View {
 	return &View{
 		delta:             NewDelta(),
+		spockSecretLock:   &sync.Mutex{},
 		regTouchSet:       make(map[string]flow.RegisterID),
 		readFunc:          readFunc,
 		spockSecretHasher: hash.NewSHA3_256(),

--- a/engine/unit_test.go
+++ b/engine/unit_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -19,13 +20,21 @@ func TestReadyDone(t *testing.T) {
 // Test that if a function is run by LaunchPeriodically and
 // takes longer than the interval, the next call will be blocked
 func TestLaunchPeriod(t *testing.T) {
+	lock := sync.Mutex{}
+
 	u := engine.NewUnit()
 	unittest.RequireCloseBefore(t, u.Ready(), time.Second, "ready did not close")
 	logs := make([]string, 0)
 	u.LaunchPeriodically(func() {
+		lock.Lock()
 		logs = append(logs, "running")
+		lock.Unlock()
+
 		time.Sleep(100 * time.Millisecond)
+
+		lock.Lock()
 		logs = append(logs, "finish")
+		lock.Unlock()
 	}, 50*time.Millisecond, 0)
 
 	// 100 * 3 is to ensure enough time for 3 periodic function to finish
@@ -34,11 +43,13 @@ func TestLaunchPeriod(t *testing.T) {
 	<-time.After((100*3 + 30) * time.Millisecond)
 
 	// This can pass
+	lock.Lock()
 	require.Equal(t, []string{
 		"running", "finish",
 		"running", "finish",
 		"running",
 	}, logs)
+	lock.Unlock()
 	unittest.RequireCloseBefore(t, u.Done(), time.Second, "done did not close")
 
 	require.Equal(t, []string{

--- a/insecure/wintermute/attackOrchestrator_test.go
+++ b/insecure/wintermute/attackOrchestrator_test.go
@@ -186,7 +186,7 @@ func testConcurrentExecutionReceipts(t *testing.T,
 		event := event // suppress loop variable
 
 		go func() {
-			err = wintermuteOrchestrator.HandleEventFromCorruptedNode(event)
+			err := wintermuteOrchestrator.HandleEventFromCorruptedNode(event)
 			require.NoError(t, err)
 
 			corruptedEnEventSendWG.Done()

--- a/module/jobqueue/consumer_behavior_test.go
+++ b/module/jobqueue/consumer_behavior_test.go
@@ -524,7 +524,7 @@ func newTestConsumer(cp storage.ConsumerProgress, jobs module.Jobs, worker jobqu
 
 // a Mock worker that stores all the jobs that it was asked to work on
 type mockWorker struct {
-	sync.Mutex
+	sync.RWMutex
 	log    zerolog.Logger
 	called []Job
 	fn     func(job Job)
@@ -553,11 +553,13 @@ func (w *mockWorker) Run(job Job) error {
 // return the IDs of the jobs
 func (w *mockWorker) AssertCalled(t *testing.T, expectCalled []int64) {
 	called := make([]int, 0)
+	w.RLock()
 	for _, c := range w.called {
 		jobID, err := strconv.Atoi(string(c.ID()))
 		require.NoError(t, err)
 		called = append(called, jobID)
 	}
+	w.RUnlock()
 	sort.Ints(called)
 
 	called64 := make([]int64, 0)

--- a/module/jobqueue/consumer_test.go
+++ b/module/jobqueue/consumer_test.go
@@ -149,10 +149,14 @@ func TestProcessedIndexDeletion(t *testing.T) {
 		require.NoError(t, c.Start(0))
 
 		require.Eventually(t, func() bool {
+			c.mu.Lock()
+			defer c.mu.Unlock()
 			return c.processedIndex == uint64(10)
 		}, 2*time.Second, 10*time.Millisecond)
 
 		// should have no processing after all jobs are processed
+		c.mu.Lock()
+		defer c.mu.Unlock()
 		require.Len(t, c.processings, 0)
 		require.Len(t, c.processingsIndex, 0)
 	})

--- a/module/lifecycle/lifecycle.go
+++ b/module/lifecycle/lifecycle.go
@@ -55,11 +55,12 @@ func (lm *LifecycleManager) OnStop(shutdownFns ...func()) {
 		return
 	}
 	lm.shutdownCommenced = true
+	waitForStartup := lm.startupCommenced
 	lm.stateTransition.Unlock()
 
 	close(lm.shutdownSignal)
 	go func() {
-		if lm.startupCommenced {
+		if waitForStartup {
 			<-lm.started
 			for _, fn := range shutdownFns {
 				fn()

--- a/module/lifecycle/lifecycle_test.go
+++ b/module/lifecycle/lifecycle_test.go
@@ -25,9 +25,10 @@ func (suite *LifecycleManagerSuite) SetupTest() {
 func (suite *LifecycleManagerSuite) TestConcurrentStart() {
 	var numStarts uint32
 
+	lm := suite.lm
 	for i := 0; i < 10; i++ {
 		go func() {
-			suite.lm.OnStart(func() {
+			lm.OnStart(func() {
 				atomic.AddUint32(&numStarts, 1)
 			})
 		}()
@@ -46,9 +47,10 @@ func (suite *LifecycleManagerSuite) TestConcurrentStop() {
 
 	var numStops uint32
 
+	lm := suite.lm
 	for i := 0; i < 10; i++ {
 		go func() {
-			suite.lm.OnStop(func() {
+			lm.OnStop(func() {
 				atomic.AddUint32(&numStops, 1)
 			})
 		}()

--- a/module/state_synchronization/execution_data_service_test.go
+++ b/module/state_synchronization/execution_data_service_test.go
@@ -224,9 +224,9 @@ func TestHappyPath(t *testing.T) {
 
 	test := func(minSerializedSize uint64) {
 		expected, _ := executionData(t, eds.serializer, minSerializedSize)
-		rootCid, err := addExecutionData(eds, expected, time.Second)
+		rootCid, err := addExecutionData(eds, expected, 5*time.Second)
 		require.NoError(t, err)
-		actual, err := getExecutionData(eds, rootCid, time.Second)
+		actual, err := getExecutionData(eds, rootCid, 5*time.Second)
 		require.NoError(t, err)
 		assert.Equal(t, true, reflect.DeepEqual(expected, actual))
 	}
@@ -242,8 +242,8 @@ func TestMalformedData(t *testing.T) {
 	eds := executionDataService(mockBlobService(bs))
 
 	test := func(data []byte) {
-		rootID := writeBlobTree(t, eds.serializer, data, bs, time.Second)
-		_, err := getExecutionData(eds, rootID, time.Second)
+		rootID := writeBlobTree(t, eds.serializer, data, bs, 5*time.Second)
+		_, err := getExecutionData(eds, rootID, 5*time.Second)
 		var malformedDataError *MalformedDataError
 		assert.ErrorAs(t, err, &malformedDataError)
 	}
@@ -266,11 +266,11 @@ func TestOversizedBlob(t *testing.T) {
 	eds := executionDataService(mockBlobService(bs))
 
 	test := func(data []byte) {
-		cid, err := putBlob(bs, data, time.Second)
+		cid, err := putBlob(bs, data, 5*time.Second)
 		require.NoError(t, err)
 		fid, err := flow.CidToId(cid)
 		require.NoError(t, err)
-		_, err = getExecutionData(eds, fid, time.Second)
+		_, err = getExecutionData(eds, fid, 5*time.Second)
 		var blobSizeLimitExceededError *BlobSizeLimitExceededError
 		assert.ErrorAs(t, err, &blobSizeLimitExceededError)
 	}
@@ -293,7 +293,7 @@ func TestOversizedBlob(t *testing.T) {
 		if i == 3 {
 			blob = data[i*blobSize:]
 		}
-		cid, err := putBlob(bs, blob, time.Second)
+		cid, err := putBlob(bs, blob, 5*time.Second)
 		require.NoError(t, err)
 		cids = append(cids, cid)
 	}
@@ -309,7 +309,7 @@ func TestOversizedBlob(t *testing.T) {
 		if i == 4 {
 			blob = data[i*defaultMaxBlobSize:]
 		}
-		cid, err := putBlob(bs, blob, time.Second)
+		cid, err := putBlob(bs, blob, 5*time.Second)
 		require.NoError(t, err)
 		cids = append(cids, cid)
 	}
@@ -325,15 +325,15 @@ func TestGetContextCanceled(t *testing.T) {
 	eds := executionDataService(mockBlobService(bs))
 
 	ed, _ := executionData(t, eds.serializer, 10*defaultMaxBlobSize)
-	rootCid, err := addExecutionData(eds, ed, time.Second)
+	rootCid, err := addExecutionData(eds, ed, 5*time.Second)
 	require.NoError(t, err)
 
-	cids := allKeys(t, bs, time.Second)
+	cids := allKeys(t, bs, 5*time.Second)
 	t.Logf("%d blobs in blob tree", len(cids))
 
-	require.NoError(t, deleteBlob(bs, cids[rand.Intn(len(cids))], time.Second))
+	require.NoError(t, deleteBlob(bs, cids[rand.Intn(len(cids))], 5*time.Second))
 
-	_, err = getExecutionData(eds, rootCid, time.Second)
+	_, err = getExecutionData(eds, rootCid, 5*time.Second)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
@@ -345,10 +345,10 @@ func TestAddContextCanceled(t *testing.T) {
 	eds := executionDataService(bex)
 
 	ed, _ := executionData(t, eds.serializer, 10*defaultMaxBlobSize)
-	_, err := addExecutionData(eds, ed, time.Second)
+	_, err := addExecutionData(eds, ed, 5*time.Second)
 	require.NoError(t, err)
 
-	cids := allKeys(t, bs, time.Second)
+	cids := allKeys(t, bs, 5*time.Second)
 	t.Logf("%d blobs in blob tree", len(cids))
 
 	blockingCid := cids[rand.Intn(len(cids))]
@@ -366,7 +366,7 @@ func TestAddContextCanceled(t *testing.T) {
 			return bs.PutMany(ctx, blobs)
 		})
 
-	_, err = addExecutionData(eds, ed, time.Second)
+	_, err = addExecutionData(eds, ed, 5*time.Second)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
@@ -378,10 +378,10 @@ func TestGetIncompleteData(t *testing.T) {
 	eds := executionDataService(bex)
 
 	ed, _ := executionData(t, eds.serializer, 10*defaultMaxBlobSize)
-	rootCid, err := addExecutionData(eds, ed, time.Second)
+	rootCid, err := addExecutionData(eds, ed, 5*time.Second)
 	require.NoError(t, err)
 
-	cids := allKeys(t, bs, time.Second)
+	cids := allKeys(t, bs, 5*time.Second)
 	t.Logf("%d blobs in blob tree", len(cids))
 
 	missingCid := cids[rand.Intn(len(cids))]
@@ -408,7 +408,7 @@ func TestGetIncompleteData(t *testing.T) {
 			return ch
 		})
 
-	_, err = getExecutionData(eds, rootCid, time.Second)
+	_, err = getExecutionData(eds, rootCid, 5*time.Second)
 	var blobNotFoundError *BlobNotFoundError
 	assert.ErrorAs(t, err, &blobNotFoundError)
 }
@@ -474,10 +474,10 @@ func TestWithNetwork(t *testing.T) {
 	eds2 := executionDataService(service2)
 
 	expected, _ := executionData(t, eds1.serializer, 10*defaultMaxBlobSize)
-	rootCid, err := addExecutionData(eds1, expected, time.Second)
+	rootCid, err := addExecutionData(eds1, expected, 5*time.Second)
 	require.NoError(t, err)
 
-	actual, err := getExecutionData(eds2, rootCid, time.Second)
+	actual, err := getExecutionData(eds2, rootCid, 5*time.Second)
 	require.NoError(t, err)
 
 	assert.Equal(t, true, reflect.DeepEqual(expected, actual))
@@ -496,7 +496,7 @@ func TestReprovider(t *testing.T) {
 	mockBs := mockBlobService(blockstore.NewBlockstore(ds))
 	mockEds := executionDataService(mockBs)
 	expected, _ := executionData(t, mockEds.serializer, 10*defaultMaxBlobSize)
-	rootCid, err := addExecutionData(mockEds, expected, time.Second)
+	rootCid, err := addExecutionData(mockEds, expected, 5*time.Second)
 	require.NoError(t, err)
 
 	h1, err := libp2p.New()
@@ -550,7 +550,7 @@ func TestReprovider(t *testing.T) {
 
 	eds := executionDataService(service3)
 
-	actual, err := getExecutionData(eds, rootCid, time.Second)
+	actual, err := getExecutionData(eds, rootCid, 5*time.Second)
 	require.NoError(t, err)
 
 	assert.Equal(t, true, reflect.DeepEqual(expected, actual))

--- a/network/p2p/topic_validator_test.go
+++ b/network/p2p/topic_validator_test.go
@@ -117,20 +117,20 @@ func TestTopicValidator(t *testing.T) {
 	// node 1 does NOT receive the message due to the topic validator
 	var wg sync.WaitGroup
 	wg.Add(1)
-	timedCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	timedCtx1, cancel1 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel1()
 	go func() {
-		msg, err = sub1.Next(timedCtx)
+		_, err := sub1.Next(timedCtx1)
 		require.Error(t, err)
 		wg.Done()
 	}()
 
 	// node 2 also does not receive the message via gossip from the node1 (event after the 1 second hearbeat)
 	wg.Add(1)
-	timedCtx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
+	timedCtx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
 	go func() {
-		msg, err = sub2.Next(timedCtx)
+		_, err := sub2.Next(timedCtx2)
 		require.Error(t, err)
 		wg.Done()
 	}()

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -120,11 +120,12 @@ func (m *MiddlewareTestSuite) SetupTest() {
 	var errChan <-chan error
 	m.mwCtx, errChan = irrecoverable.WithSignaler(ctx)
 
+	mwCtx := m.mwCtx
 	go func() {
 		select {
 		case err := <-errChan:
 			m.T().Error("middlewares encountered fatal error", err)
-		case <-m.mwCtx.Done():
+		case <-mwCtx.Done():
 			return
 		}
 	}()
@@ -425,7 +426,7 @@ func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
 	require.NoError(m.Suite.T(), err)
 
 	// check message reception on target
-	unittest.RequireCloseBefore(m.T(), ch, 15*time.Second, "source node failed to send large message to target")
+	unittest.RequireCloseBefore(m.T(), ch, 60*time.Second, "source node failed to send large message to target")
 
 	m.ov[targetIndex].AssertExpectations(m.T())
 }

--- a/network/topology/topology_test.go
+++ b/network/topology/topology_test.go
@@ -1,3 +1,6 @@
+//go:build !race
+// +build !race
+
 package topology_test
 
 import (

--- a/utils/unittest/logging.go
+++ b/utils/unittest/logging.go
@@ -6,12 +6,14 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
 )
 
 var verbose = flag.Bool("vv", false, "print debugging logs")
+var globalOnce sync.Once
 
 func LogVerbose() {
 	*verbose = true
@@ -29,7 +31,9 @@ func Logger() zerolog.Logger {
 }
 
 func LoggerWithWriterAndLevel(writer io.Writer, level zerolog.Level) zerolog.Logger {
-	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
+	globalOnce.Do(func() {
+		zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
+	})
 	log := zerolog.New(writer).Level(level).With().Timestamp().Logger()
 	return log
 }


### PR DESCRIPTION
While exploring code base I've stumbled upon a couple of race-detector problems. Most of them are harmless issues that only affect test flakiness.  Nevertheless, here is a sample of interesting ones:

* Unprotected `OnSucceed` callback access in badger batches: https://github.com/onflow/flow-go/commit/35babdbc398dbff812d7abf69054e17534623126
* Potential error clobbering in ledger migration's "storage-used" calculation: https://github.com/onflow/flow-go/commit/c42159fc719ed97414922515d362492e1b8b956a
* EpochMgr `epochs` access without lock on `Done`: https://github.com/onflow/flow-go/commit/a0c6cee65888f427a3482e81670cbb88fcce7f9b
* `BLS12_381` verification accesses uninitialized memory: https://github.com/onflow/flow-go/pull/2293#discussion_r850080079
* Unprotected global access in tests https://github.com/onflow/flow-go/commit/d26ca03a58b1eff8295b267de6a0fce845587044
* Lock being copied by value by the mock framework: https://github.com/onflow/flow-go/commit/a89101eb0ffb5aff16deea5e1a12926a44262a93
* `time.Sleep` references in tests: https://github.com/onflow/flow-go/commit/05a87c703eafc1f158851cb011d8e2da72e149ce
* Ignore `runtime.noescape` in `checkptr`: https://github.com/onflow/flow-go/pull/2293/commits/1288c1dbcfa19c4249cdc0ae88078e7f4112b4d5

I needed to disable the network topology test in `-race` since it was triggering the goroutine limit of the race detector
https://github.com/onflow/flow-go/commit/bb24d8f519cffe37f900aeb7f945e1db5f9be2c0.  For this one we'll need to wait until the support of infinite number of goroutines is released https://github.com/golang/go/commit/d6a1ffd624bd0d6dbf3a15070e378749612b35c9 is available (go likely 1.19).

Also there is a race condition in herocache that can be solved by either:
* Making Counter and Timestamp atomic: https://github.com/SaveTheRbtz/flow-go/commit/d1cc40686c5e51a4728f07305bcfea0fb2a43936
* Removing `logTelemetry` methods from the "read-only" methods protected only by `RLock`: https://github.com/SaveTheRbtz/flow-go/commit/6b0dcbdbefaaa1cb2d652b1bdbd9c5505ca298e9
What is the better approach here? (cc: @yhassanzadeh13)

Testify also has couple of nasty races in their `Suite` implementation if coupled with spawning gorouptines: https://github.com/stretchr/testify/issues/1168#issuecomment-1072082613: https://github.com/onflow/flow-go/commit/485161434ad83641a2d8b1f86f0dc74d72a30fa2 https://github.com/onflow/flow-go/commit/71b3fdc2d8d6c228042118bcdf9bdcc9960a1e88

Looking at [race detector](https://go.dev/doc/articles/race_detector)'s ability to find timing/concurrency related problems in both tests and code it looks like it should likely be a first-class citizen in the Flow's CI/CD pipeline. WDYT about its ROI?
Seems like @huitseeker did look at this problem some time ago but since then race detector work was mostly abandoned.  Maybe it is possible to make it an optional part of the CI/CD pipeline, like fuzzing and benchmarking?
