### PR TITLE
Add config to limit caching of new proposals while syncing

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/model/bootstrap"
+	modulecompliance "github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/mempool/herocache"
 
 	"github.com/onflow/flow-go-sdk/client"
@@ -68,9 +69,11 @@ func main() {
 		startupTimeString                      string
 		startupTime                            time.Time
 
-		followerState protocol.MutableState
-		ingestConf    = ingest.DefaultConfig()
-		rpcConf       rpc.Config
+		followerState    protocol.MutableState
+		ingestConf       = ingest.DefaultConfig()
+		rpcConf          rpc.Config
+		followerConfig   modulecompliance.Config
+		complianceConfig modulecompliance.Config
 
 		pools                   *epochpool.TransactionPools // epoch-scoped transaction pools
 		followerBuffer          *buffer.PendingBlocks       // pending block cache for follower
@@ -140,6 +143,10 @@ func main() {
 			"additional fraction of replica timeout that the primary will wait for votes")
 		flags.DurationVar(&blockRateDelay, "block-rate-delay", 250*time.Millisecond,
 			"the delay to broadcast block proposal in order to control block production rate")
+		flags.Uint64Var(&followerConfig.SkipNewProposalsThreshold,
+			"follower-skip-proposals-threshold", modulecompliance.DefaultConfig().SkipNewProposalsThreshold, "threshold at which new proposals are discarded rather than cached, if their height is this much above local finalized height (follower engine)")
+		flags.Uint64Var(&followerConfig.SkipNewProposalsThreshold,
+			"compliance-skip-proposals-threshold", modulecompliance.DefaultConfig().SkipNewProposalsThreshold, "threshold at which new proposals are discarded rather than cached, if their height is this much above local finalized height (cluster compliance engine)")
 		flags.StringVar(&startupTimeString, "hotstuff-startup-time", cmd.NotSet, "specifies date and time (in ISO 8601 format) after which the consensus participant may enter the first view (e.g (e.g 1996-04-24T15:04:05-07:00))")
 
 		// epoch qc contract flags

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -145,7 +145,7 @@ func main() {
 			"the delay to broadcast block proposal in order to control block production rate")
 		flags.Uint64Var(&followerConfig.SkipNewProposalsThreshold,
 			"follower-skip-proposals-threshold", modulecompliance.DefaultConfig().SkipNewProposalsThreshold, "threshold at which new proposals are discarded rather than cached, if their height is this much above local finalized height (follower engine)")
-		flags.Uint64Var(&followerConfig.SkipNewProposalsThreshold,
+		flags.Uint64Var(&complianceConfig.SkipNewProposalsThreshold,
 			"compliance-skip-proposals-threshold", modulecompliance.DefaultConfig().SkipNewProposalsThreshold, "threshold at which new proposals are discarded rather than cached, if their height is this much above local finalized height (cluster compliance engine)")
 		flags.StringVar(&startupTimeString, "hotstuff-startup-time", cmd.NotSet, "specifies date and time (in ISO 8601 format) after which the consensus participant may enter the first view (e.g (e.g 1996-04-24T15:04:05-07:00))")
 
@@ -313,6 +313,7 @@ func main() {
 				followerCore,
 				mainChainSyncCore,
 				node.Tracer,
+				modulecompliance.WithSkipNewProposalsThreshold(followerConfig.SkipNewProposalsThreshold),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("could not create follower engine: %w", err)

--- a/cmd/verification/main.go
+++ b/cmd/verification/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/buffer"
 	"github.com/onflow/flow-go/module/chunks"
+	"github.com/onflow/flow-go/module/compliance"
 	finalizer "github.com/onflow/flow-go/module/finalizer/consensus"
 	"github.com/onflow/flow-go/module/mempool"
 	"github.com/onflow/flow-go/module/mempool/stdmap"
@@ -50,6 +51,7 @@ func main() {
 		backoffMaxInterval time.Duration // maximum time interval a chunk data pack request waits before dispatching.
 		backoffMultiplier  float64       // base of exponent in exponential backoff multiplier for backing off requests for chunk data packs.
 		requestTargets     uint64        // maximum number of execution nodes a chunk data pack request is dispatched to.
+		followerConfig     compliance.Config
 
 		blockWorkers uint64 // number of blocks processed in parallel.
 		chunkWorkers uint64 // number of chunks processed in parallel.
@@ -87,6 +89,7 @@ func main() {
 		flags.Uint64Var(&requestTargets, "request-targets", vereq.DefaultRequestTargets, "maximum number of execution nodes a chunk data pack request is dispatched to")
 		flags.Uint64Var(&blockWorkers, "block-workers", blockconsumer.DefaultBlockWorkers, "maximum number of blocks being processed in parallel")
 		flags.Uint64Var(&chunkWorkers, "chunk-workers", chunkconsumer.DefaultChunkWorkers, "maximum number of execution nodes a chunk data pack request is dispatched to")
+		flags.Uint64Var(&followerConfig.SkipNewProposalsThreshold, "follower-skip-proposals-threshold", compliance.DefaultConfig().SkipNewProposalsThreshold, "threshold at which new proposals are discarded rather than cached, if their height is this much above local finalized height")
 
 	})
 
@@ -328,6 +331,7 @@ func main() {
 				followerCore,
 				syncCore,
 				node.Tracer,
+				compliance.WithSkipNewProposalsThreshold(followerConfig.SkipNewProposalsThreshold),
 			)
 			if err != nil {
 				return nil, fmt.Errorf("could not create follower engine: %w", err)

--- a/engine/collection/compliance/core_test.go
+++ b/engine/collection/compliance/core_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 	realbuffer "github.com/onflow/flow-go/module/buffer"
+	"github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/metrics"
 	module "github.com/onflow/flow-go/module/mock"
 	clusterint "github.com/onflow/flow-go/state/cluster"
@@ -195,6 +196,22 @@ func (cs *ComplianceCoreSuite) TestOnBlockProposalValidParent() {
 
 	// we should submit the proposal to hotstuff
 	cs.hotstuff.AssertExpectations(cs.T())
+}
+
+func (cs *ComplianceCoreSuite) TestOnBlockProposalSkipProposalThreshold() {
+
+	// create a proposal which is far enough ahead to be dropped
+	originID := unittest.IdentifierFixture()
+	block := unittest.ClusterBlockFixture()
+	block.Header.Height = cs.head.Header.Height + compliance.DefaultConfig().SkipNewProposalsThreshold + 1
+	proposal := unittest.ClusterProposalFromBlock(&block)
+
+	err := cs.core.OnBlockProposal(originID, proposal)
+	require.NoError(cs.T(), err)
+
+	// block should be dropped - not added to state or cache
+	cs.state.AssertNotCalled(cs.T(), "Extend", mock.Anything)
+	cs.pending.AssertNotCalled(cs.T(), "Add", originID, mock.Anything)
 }
 
 func (cs *ComplianceCoreSuite) TestOnBlockProposalValidAncestor() {

--- a/engine/collection/epochmgr/factories/proposal.go
+++ b/engine/collection/epochmgr/factories/proposal.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onflow/flow-go/engine/collection/compliance"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/buffer"
+	modulecompliance "github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/state/cluster"
 	"github.com/onflow/flow-go/state/protocol"
@@ -24,6 +25,7 @@ type ProposalEngineFactory struct {
 	mempoolMetrics module.MempoolMetrics
 	protoState     protocol.State
 	transactions   storage.Transactions
+	complianceOpts []modulecompliance.Opt
 }
 
 // NewFactory returns a new collection proposal engine factory.
@@ -36,6 +38,7 @@ func NewProposalEngineFactory(
 	mempoolMetrics module.MempoolMetrics,
 	protoState protocol.State,
 	transactions storage.Transactions,
+	complianceOpts ...modulecompliance.Opt,
 ) (*ProposalEngineFactory, error) {
 
 	factory := &ProposalEngineFactory{
@@ -47,6 +50,7 @@ func NewProposalEngineFactory(
 		mempoolMetrics: mempoolMetrics,
 		protoState:     protoState,
 		transactions:   transactions,
+		complianceOpts: complianceOpts,
 	}
 	return factory, nil
 }
@@ -68,6 +72,7 @@ func (f *ProposalEngineFactory) Create(
 		clusterState,
 		cache,
 		voteAggregator,
+		f.complianceOpts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could create cluster compliance core: %w", err)

--- a/engine/common/follower/engine.go
+++ b/engine/common/follower/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/network"
@@ -25,6 +26,7 @@ import (
 type Engine struct {
 	unit           *engine.Unit
 	log            zerolog.Logger
+	config         compliance.Config
 	me             module.Local
 	engMetrics     module.EngineMetrics
 	mempoolMetrics module.MempoolMetrics
@@ -53,11 +55,18 @@ func New(
 	follower module.HotStuffFollower,
 	sync module.BlockRequester,
 	tracer module.Tracer,
+	opts ...compliance.Opt,
 ) (*Engine, error) {
+
+	config := compliance.DefaultConfig()
+	for _, apply := range opts {
+		apply(&config)
+	}
 
 	e := &Engine{
 		unit:           engine.NewUnit(),
 		log:            log.With().Str("engine", "follower").Logger(),
+		config:         config,
 		me:             me,
 		engMetrics:     engMetrics,
 		mempoolMetrics: mempoolMetrics,
@@ -213,6 +222,18 @@ func (e *Engine) onBlockProposal(originID flow.Identifier, proposal *messages.Bl
 	}
 	if !errors.Is(err, storage.ErrNotFound) {
 		return fmt.Errorf("could not check proposal: %w", err)
+	}
+
+	// ignore proposals which are too far ahead of our local finalized state
+	final, err := e.state.Final().Head()
+	if err != nil {
+		return fmt.Errorf("could not get latest finalized header: %w", err)
+	}
+	if header.Height > final.Height && header.Height-final.Height > e.config.SkipNewProposalsThreshold {
+		log.Debug().
+			Uint64("final_height", final.Height).
+			Msg("dropping block too far ahead of locally finalized height")
+		return nil
 	}
 
 	// there are two possibilities if the proposal is neither already pending

--- a/engine/common/follower/engine_test.go
+++ b/engine/common/follower/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/engine/common/follower"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/compliance"
 	metrics "github.com/onflow/flow-go/module/metrics"
 	module "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/module/trace"
@@ -148,6 +149,31 @@ func (suite *Suite) TestHandleProposal() {
 	assert.Nil(suite.T(), err)
 
 	suite.follower.AssertExpectations(suite.T())
+}
+
+func (suite *Suite) TestHandleProposalSkipProposalThreshold() {
+
+	// mock latest finalized state
+	final := unittest.BlockHeaderFixture()
+	suite.snapshot.On("Head").Return(&final, nil)
+
+	originID := unittest.IdentifierFixture()
+	block := unittest.BlockFixture()
+
+	block.Header.Height = final.Height + compliance.DefaultConfig().SkipNewProposalsThreshold + 1
+
+	// not in cache or storage
+	suite.cache.On("ByID", block.ID()).Return(nil, false).Once()
+	suite.headers.On("ByBlockID", block.ID()).Return(nil, realstorage.ErrNotFound).Once()
+
+	// submit the block
+	proposal := unittest.ProposalFromBlock(&block)
+	err := suite.engine.Process(engine.ReceiveBlocks, originID, proposal)
+	assert.NoError(suite.T(), err)
+
+	// block should be dropped - not added to state or cache
+	suite.state.AssertNotCalled(suite.T(), "Extend", mock.Anything)
+	suite.cache.AssertNotCalled(suite.T(), "Add", originID, mock.Anything)
 }
 
 func (suite *Suite) TestHandleProposalWithPendingChildren() {

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -18,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state"
@@ -32,6 +33,7 @@ import (
 // user of this object needs to ensure single thread access.
 type Core struct {
 	log               zerolog.Logger // used to log relevant actions with context
+	config            compliance.Config
 	metrics           module.EngineMetrics
 	tracer            module.Tracer
 	mempool           module.MempoolMetrics
@@ -60,10 +62,17 @@ func NewCore(
 	pending module.PendingBlockBuffer,
 	sync module.BlockRequester,
 	voteAggregator hotstuff.VoteAggregator,
+	opts ...compliance.Opt,
 ) (*Core, error) {
+
+	config := compliance.DefaultConfig()
+	for _, apply := range opts {
+		apply(&config)
+	}
 
 	e := &Core{
 		log:               log.With().Str("compliance", "core").Logger(),
+		config:            config,
 		metrics:           collector,
 		tracer:            tracer,
 		mempool:           mempool,
@@ -135,6 +144,18 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Bloc
 	}
 	if !errors.Is(err, storage.ErrNotFound) {
 		return fmt.Errorf("could not check proposal: %w", err)
+	}
+
+	// ignore proposals which are too far ahead of our local finalized state
+	final, err := c.state.Final().Head()
+	if err != nil {
+		return fmt.Errorf("could not get latest finalized header: %w", err)
+	}
+	if header.Height > final.Height && header.Height-final.Height > c.config.SkipNewProposalsThreshold {
+		log.Debug().
+			Uint64("final_height", final.Height).
+			Msg("dropping block too far ahead of locally finalized height")
+		return nil
 	}
 
 	// there are two possibilities if the proposal is neither already pending

--- a/engine/consensus/compliance/core_test.go
+++ b/engine/consensus/compliance/core_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onflow/flow-go/model/messages"
 	realModule "github.com/onflow/flow-go/module"
 	real "github.com/onflow/flow-go/module/buffer"
+	"github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/metrics"
 	module "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/module/trace"
@@ -310,6 +311,22 @@ func (cs *ComplianceCoreSuite) TestOnBlockProposalValidAncestor() {
 
 	// we should submit the proposal to hotstuff
 	cs.hotstuff.AssertExpectations(cs.T())
+}
+
+func (cs *ComplianceCoreSuite) TestOnBlockProposalSkipProposalThreshold() {
+
+	// create a proposal which is far enough ahead to be dropped
+	originID := cs.participants[1].NodeID
+	block := unittest.BlockFixture()
+	block.Header.Height = cs.head.Height + compliance.DefaultConfig().SkipNewProposalsThreshold + 1
+	proposal := unittest.ProposalFromBlock(&block)
+
+	err := cs.core.OnBlockProposal(originID, proposal)
+	require.NoError(cs.T(), err)
+
+	// block should be dropped - not added to state or cache
+	cs.state.AssertNotCalled(cs.T(), "Extend", mock.Anything)
+	cs.pending.AssertNotCalled(cs.T(), "Add", originID, mock.Anything)
 }
 
 func (cs *ComplianceCoreSuite) TestOnBlockProposalInvalidExtension() {

--- a/module/compliance/config.go
+++ b/module/compliance/config.go
@@ -1,0 +1,24 @@
+package compliance
+
+// Config is shared config for consensus and collection compliance engines, and
+// the consensus follower engine.
+type Config struct {
+	// SkipNewProposalsThreshold defines the threshold where, if we observe a new
+	// proposal which is this far behind our local latest finalized, we drop the
+	// proposal rather than cache it.
+	SkipNewProposalsThreshold uint64
+}
+
+func DefaultConfig() Config {
+	return Config{
+		SkipNewProposalsThreshold: 100_000,
+	}
+}
+
+type Opt func(*Config)
+
+func WithSkipNewProposalsThreshold(threshold uint64) Opt {
+	return func(config *Config) {
+		config.SkipNewProposalsThreshold = threshold
+	}
+}

--- a/module/compliance/config.go
+++ b/module/compliance/config.go
@@ -1,5 +1,7 @@
 package compliance
 
+const MinSkipNewProposalsThreshold = 1000
+
 // Config is shared config for consensus and collection compliance engines, and
 // the consensus follower engine.
 type Config struct {
@@ -17,8 +19,15 @@ func DefaultConfig() Config {
 
 type Opt func(*Config)
 
+// WithSkipNewProposalsThreshold returns an option to set the skip new proposals
+// threshold. For inputs less than the minimum threshold, the minimum threshold
+// will be set instead.
 func WithSkipNewProposalsThreshold(threshold uint64) Opt {
 	return func(config *Config) {
+		// sanity check: small values are dangerous and can cause finalization halt
+		if threshold < MinSkipNewProposalsThreshold {
+			threshold = MinSkipNewProposalsThreshold
+		}
 		config.SkipNewProposalsThreshold = threshold
 	}
 }

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 	bprotocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/inmem"
+	"github.com/onflow/flow-go/state/protocol/util"
 	protoutil "github.com/onflow/flow-go/state/protocol/util"
 	storagebadger "github.com/onflow/flow-go/storage/badger"
 	storutil "github.com/onflow/flow-go/storage/util"
@@ -462,6 +463,30 @@ func assertSealingSegmentBlocksQueryableAfterBootstrap(t *testing.T, snapshot pr
 			snap := state.AtBlockID(block.ID())
 			_, err := snap.SealingSegment()
 			assert.ErrorIs(t, err, protocol.ErrSealingSegmentBelowRootBlock)
+		}
+	})
+}
+
+// BenchmarkFinal benchmarks retrieving the latest finalized block from storage.
+func BenchmarkFinal(b *testing.B) {
+	util.RunWithBootstrapState(b, unittest.RootSnapshotFixture(unittest.CompleteIdentitySet()), func(db *badger.DB, state *bprotocol.State) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			header, err := state.Final().Head()
+			assert.NoError(b, err)
+			assert.NotNil(b, header)
+		}
+	})
+}
+
+// BenchmarkFinal benchmarks retrieving the block by height from storage.
+func BenchmarkByHeight(b *testing.B) {
+	util.RunWithBootstrapState(b, unittest.RootSnapshotFixture(unittest.CompleteIdentitySet()), func(db *badger.DB, state *bprotocol.State) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			header, err := state.AtHeight(0).Head()
+			assert.NoError(b, err)
+			assert.NotNil(b, header)
 		}
 	})
 }

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -197,6 +197,14 @@ func ProposalFromBlock(block *flow.Block) *messages.BlockProposal {
 	return proposal
 }
 
+func ClusterProposalFromBlock(block *cluster.Block) *messages.ClusterBlockProposal {
+	proposal := &messages.ClusterBlockProposal{
+		Header:  block.Header,
+		Payload: block.Payload,
+	}
+	return proposal
+}
+
 func PendingFromBlock(block *flow.Block) *flow.PendingBlock {
 	pending := flow.PendingBlock{
 		OriginID: block.Header.ProposerID,


### PR DESCRIPTION
Adds a new config which will cause consensus followers and participants to drop new proposals if the proposal is sufficiently ahead of the node's locally finalized state. This is a simple way to prevent memory exhaustion when a node is synchronizing from a very old state.