### PR TITLE
Add observer support to localnet

### DIFF
--- a/cmd/bootstrap/cmd/constraints.go
+++ b/cmd/bootstrap/cmd/constraints.go
@@ -50,12 +50,12 @@ func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 			if _, exists := internals.ByNodeID(node.NodeID); exists {
 				clusterInternalCount++
 			}
-			if clusterInternalCount <= clusterPartnerCount*2 {
-				log.Fatal().Msgf(
-					"will not bootstrap configuration without Byzantine majority within cluster: "+
-						"(partners=%d, internals=%d, min_internals=%d)",
-					clusterPartnerCount, clusterInternalCount, clusterPartnerCount*2+1)
-			}
+		}
+		if clusterInternalCount <= clusterPartnerCount*2 {
+			log.Fatal().Msgf(
+				"will not bootstrap configuration without Byzantine majority within cluster: "+
+					"(partners=%d, internals=%d, min_internals=%d)",
+				clusterPartnerCount, clusterInternalCount, clusterPartnerCount*2+1)
 		}
 		partnerCOLCount += clusterPartnerCount
 		internalCOLCount += clusterInternalCount

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.1 // indirect
 	github.com/go-openapi/strfmt v0.20.1 // indirect
 	github.com/go-test/deep v1.0.7 // indirect
+	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/onflow/cadence v0.23.3
@@ -33,7 +34,6 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	google.golang.org/grpc v1.44.0
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 // temp fix for MacOS build. See comment https://github.com/ory/dockertest/issues/208#issuecomment-686820414

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -441,6 +441,8 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
+github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
+github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -3,7 +3,7 @@ CONSENSUS = 3
 EXECUTION = 2
 VERIFICATION = 1
 ACCESS = 2
-UNSTAKED_ACCESS = 0
+OBSERVER = 0
 NCLUSTERS=1
 EPOCHLEN=10000   # 0 means use default
 STAKINGLEN=2000 # 0 means use default
@@ -26,7 +26,7 @@ init:
 		-execution=$(EXECUTION) \
 		-verification=$(VERIFICATION) \
 		-access=$(ACCESS) \
-		-unstaked-access=$(UNSTAKED_ACCESS) \
+		-observer=$(OBSERVER) \
 		-nclusters=$(NCLUSTERS) \
 		-epoch-length=$(EPOCHLEN) \
 		-epoch-staking-phase-length=$(STAKINGLEN) \

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/go-yaml/yaml"
+	"github.com/plus3it/gorecurcopy"
+
 	"github.com/onflow/flow-go/cmd/bootstrap/cmd"
 	"github.com/onflow/flow-go/cmd/bootstrap/utils"
 	"github.com/onflow/flow-go/cmd/build"
@@ -19,7 +21,6 @@ import (
 	testnet "github.com/onflow/flow-go/integration/testnet"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/plus3it/gorecurcopy"
 )
 
 const (

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/go-yaml/yaml"
-	"github.com/plus3it/gorecurcopy
-	
+	"github.com/plus3it/gorecurcopy"
+
 	"github.com/onflow/flow-go/cmd/bootstrap/cmd"
 	"github.com/onflow/flow-go/cmd/bootstrap/utils"
 	"github.com/onflow/flow-go/cmd/build"

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -43,7 +43,7 @@ const (
 	DefaultProfiler          = false
 	DefaultConsensusDelay    = 800 * time.Millisecond
 	DefaultCollectionDelay   = 950 * time.Millisecond
-	FlowAPIPort              = 3569
+	AccessAPIPort            = 3569
 	AccessPubNetworkPort     = 1234
 	ExecutionAPIPort         = 3600
 	MetricsPort              = 8080
@@ -133,7 +133,6 @@ func main() {
 		panic(err)
 	}
 
-	// Generate the Observer services docker-compose-nodes.yml
 	dockerServices = prepareObserverServices(dockerServices, flowNodeContainerConfigs)
 
 	err = writeDockerComposeConfig(dockerServices)
@@ -158,7 +157,7 @@ func displayFlowNetworkConf(flowNetworkConf testnet.NetworkConfig) {
 
 func displayPortAssignments() {
 	for i := 0; i < accessCount; i++ {
-		fmt.Printf("Access %d Flow API will be accessible at localhost:%d\n", i+1, FlowAPIPort+i)
+		fmt.Printf("Access %d Flow API will be accessible at localhost:%d\n", i+1, AccessAPIPort+i)
 		fmt.Printf("Access %d public libp2p access will be accessible at localhost:%d\n\n", i+1, AccessPubNetworkPort+i)
 	}
 	for i := 0; i < executionCount; i++ {
@@ -166,7 +165,7 @@ func displayPortAssignments() {
 	}
 	fmt.Println()
 	for i := 0; i < observerCount; i++ {
-		fmt.Printf("Observer %d Flow API will be accessible at localhost:%d\n", i+1, (accessCount*2)+(FlowAPIPort)+2*i)
+		fmt.Printf("Observer %d Flow API will be accessible at localhost:%d\n", i+1, (accessCount*2)+(AccessAPIPort)+2*i)
 	}
 }
 
@@ -500,8 +499,8 @@ func prepareAccessService(container testnet.ContainerConfig, i int, n int) Servi
 
 	service.Ports = []string{
 		fmt.Sprintf("%d:%d", AccessPubNetworkPort+i, AccessPubNetworkPort),
-		fmt.Sprintf("%d:%d", FlowAPIPort+2*i, RPCPort),
-		fmt.Sprintf("%d:%d", FlowAPIPort+(2*i+1), SecuredRPCPort),
+		fmt.Sprintf("%d:%d", AccessAPIPort+2*i, RPCPort),
+		fmt.Sprintf("%d:%d", AccessAPIPort+(2*i+1), SecuredRPCPort),
 	}
 
 	return service
@@ -624,9 +623,6 @@ func prepareObserverProfilerFolder(observerName string) string {
 }
 
 func prepareObserverDataFolder(observerName string) string {
-	//for i := 0; i < observerCount; i++ {
-	//	observerName := fmt.Sprintf("%s_%d", DefaultObserverName, i+1)
-	// Create a data folder (on the host) for the named Observer
 	dataDir := getObserverDataDir(observerName)
 	err := os.MkdirAll(dataDir, 0755)
 	if err != nil && !os.IsExist(err) {
@@ -723,16 +719,15 @@ func prepareObserverService(i int, observerName string, agPublicKey string, prof
 		// the same from the guest's perspective, the host port numbering accounts for the presence
 		// of multiple pairs of listeners on the host to avoid port collisions. Observer listener pairs
 		// are numbered just after the Access listeners on the host network by prior convention
-		fmt.Sprintf("%d:%d", (accessCount*2)+FlowAPIPort+(2*i), RPCPort),
-		fmt.Sprintf("%d:%d", (accessCount*2)+FlowAPIPort+(2*i)+1, SecuredRPCPort),
+		fmt.Sprintf("%d:%d", (accessCount*2)+AccessAPIPort+(2*i), RPCPort),
+		fmt.Sprintf("%d:%d", (accessCount*2)+AccessAPIPort+(2*i)+1, SecuredRPCPort),
 	}
 	return observerService
 }
 
 func prepareObserverServices(dockerServices Services, flowNodeContainerConfigs []testnet.ContainerConfig) Services {
-	agPublicKey, err := getAccessGatewayPublicKey(flowNodeContainerConfigs)
-	if err != nil {
-		panic(err)
+	if observerCount == 0 {
+		return dockerServices
 	}
 
 	if accessCount < 1 {
@@ -744,22 +739,26 @@ func prepareObserverServices(dockerServices Services, flowNodeContainerConfigs [
 		panic(fmt.Sprintf("No more than %d observers are permitted within localnet", DefaultMaxObservers))
 	}
 
-	if observerCount > 0 {
-		for i := 0; i < observerCount; i++ {
-			observerName := fmt.Sprintf("%s_%d", DefaultObserverName, i+1)
-			profilerDir := prepareObserverProfilerFolder(observerName)
-			dataDir := prepareObserverDataFolder(observerName)
-			observerService := prepareObserverService(i, observerName, agPublicKey, profilerDir, dataDir)
-
-			// Add a docker container for this named Observer
-			dockerServices[observerName] = observerService
-
-			// Generate observer private key (localnet only, not for production)
-			writeObserverPrivateKey(observerName)
-		}
-		fmt.Println()
-		fmt.Println("Observer services bootstrapping data generated...")
-		fmt.Printf("Access Gateway (%s) public network libp2p key: %s\n\n", DefaultAccessGatewayName, agPublicKey)
+	agPublicKey, err := getAccessGatewayPublicKey(flowNodeContainerConfigs)
+	if err != nil {
+		panic(err)
 	}
+	
+	for i := 0; i < observerCount; i++ {
+		observerName := fmt.Sprintf("%s_%d", DefaultObserverName, i+1)
+		profilerDir := prepareObserverProfilerFolder(observerName)
+		dataDir := prepareObserverDataFolder(observerName)
+		observerService := prepareObserverService(i, observerName, agPublicKey, profilerDir, dataDir)
+
+		// Add a docker container for this named Observer
+		dockerServices[observerName] = observerService
+
+		// Generate observer private key (localnet only, not for production)
+		writeObserverPrivateKey(observerName)
+	}
+	fmt.Println()
+	fmt.Println("Observer services bootstrapping data generated...")
+	fmt.Printf("Access Gateway (%s) public network libp2p key: %s\n\n", DefaultAccessGatewayName, agPublicKey)
+
 	return dockerServices
 }

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/go-yaml/yaml"
-	"github.com/plus3it/gorecurcopy"
-
+	"github.com/plus3it/gorecurcopy
+	
 	"github.com/onflow/flow-go/cmd/bootstrap/cmd"
 	"github.com/onflow/flow-go/cmd/bootstrap/utils"
 	"github.com/onflow/flow-go/cmd/build"

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -726,10 +726,6 @@ func prepareObserverService(i int, observerName string, agPublicKey string, prof
 }
 
 func prepareObserverServices(dockerServices Services, flowNodeContainerConfigs []testnet.ContainerConfig) Services {
-<<<<<<< HEAD
-=======
-
->>>>>>> ce5cc9a0a1eb703a2acf13006f5417787cd53a35
 	if observerCount == 0 {
 		return dockerServices
 	}
@@ -743,14 +739,11 @@ func prepareObserverServices(dockerServices Services, flowNodeContainerConfigs [
 		panic(fmt.Sprintf("No more than %d observers are permitted within localnet", DefaultMaxObservers))
 	}
 
-<<<<<<< HEAD
 	agPublicKey, err := getAccessGatewayPublicKey(flowNodeContainerConfigs)
 	if err != nil {
 		panic(err)
 	}
-	
-=======
->>>>>>> ce5cc9a0a1eb703a2acf13006f5417787cd53a35
+
 	for i := 0; i < observerCount; i++ {
 		observerName := fmt.Sprintf("%s_%d", DefaultObserverName, i+1)
 		profilerDir := prepareObserverProfilerFolder(observerName)

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -1,49 +1,57 @@
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"time"
 
-	"github.com/plus3it/gorecurcopy"
-	"gopkg.in/yaml.v2"
-
+	"github.com/go-yaml/yaml"
+	"github.com/onflow/flow-go/cmd/bootstrap/cmd"
+	"github.com/onflow/flow-go/cmd/bootstrap/utils"
 	"github.com/onflow/flow-go/cmd/build"
-	"github.com/onflow/flow-go/integration/testnet"
+	"github.com/onflow/flow-go/crypto"
+	testnet "github.com/onflow/flow-go/integration/testnet"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/plus3it/gorecurcopy"
 )
 
 const (
-	BootstrapDir               = "./bootstrap"
-	ProfilerDir                = "./profiler"
-	DataDir                    = "./data"
-	TrieDir                    = "./trie"
-	DockerComposeFile          = "./docker-compose.nodes.yml"
-	DockerComposeFileVersion   = "3.7"
-	PrometheusTargetsFile      = "./targets.nodes.json"
-	DefaultCollectionCount     = 3
-	DefaultConsensusCount      = 3
-	DefaultExecutionCount      = 1
-	DefaultVerificationCount   = 1
-	DefaultAccessCount         = 1
-	DefaultUnstakedAccessCount = 0
-	DefaultNClusters           = 1
-	DefaultProfiler            = false
-	DefaultConsensusDelay      = 800 * time.Millisecond
-	DefaultCollectionDelay     = 950 * time.Millisecond
-	AccessAPIPort              = 3569
-	ExecutionAPIPort           = 3600
-	MetricsPort                = 8080
-	RPCPort                    = 9000
-	SecuredRPCPort             = 9001
-	AdminToolPort              = 9002
-	AdminToolLocalPort         = 3700
-	HTTPPort                   = 8000
+	BootstrapDir             = "./bootstrap"
+	ProfilerDir              = "./profiler"
+	DataDir                  = "./data"
+	TrieDir                  = "./trie"
+	DockerComposeFile        = "./docker-compose.nodes.yml"
+	DockerComposeFileVersion = "3.7"
+	PrometheusTargetsFile    = "./targets.nodes.json"
+	DefaultAccessGatewayName = "access_1"
+	DefaultObserverName      = "observer"
+	DefaultMaxObservers      = 1000
+	DefaultCollectionCount   = 3
+	DefaultConsensusCount    = 3
+	DefaultExecutionCount    = 1
+	DefaultVerificationCount = 1
+	DefaultAccessCount       = 1
+	DefaultObserverCount     = 0
+	DefaultNClusters         = 1
+	DefaultProfiler          = false
+	DefaultConsensusDelay    = 800 * time.Millisecond
+	DefaultCollectionDelay   = 950 * time.Millisecond
+	FlowAPIPort              = 3569
+	AccessPubNetworkPort     = 1234
+	ExecutionAPIPort         = 3600
+	MetricsPort              = 8080
+	RPCPort                  = 9000
+	SecuredRPCPort           = 9001
+	AdminToolPort            = 9002
+	AdminToolLocalPort       = 3700
+	HTTPPort                 = 8000
 )
 
 var (
@@ -52,7 +60,7 @@ var (
 	executionCount         int
 	verificationCount      int
 	accessCount            int
-	unstakedAccessCount    int
+	observerCount          int
 	nClusters              uint
 	numViewsInStakingPhase uint64
 	numViewsInDKGPhase     uint64
@@ -68,7 +76,7 @@ func init() {
 	flag.IntVar(&executionCount, "execution", DefaultExecutionCount, "number of execution nodes")
 	flag.IntVar(&verificationCount, "verification", DefaultVerificationCount, "number of verification nodes")
 	flag.IntVar(&accessCount, "access", DefaultAccessCount, "number of staked access nodes")
-	flag.IntVar(&unstakedAccessCount, "unstaked-access", DefaultUnstakedAccessCount, "number of un-staked access nodes")
+	flag.IntVar(&observerCount, "observer", DefaultObserverCount, "number of observers")
 	flag.UintVar(&nClusters, "nclusters", DefaultNClusters, "number of collector clusters")
 	flag.Uint64Var(&numViewsEpoch, "epoch-length", 10000, "number of views in epoch")
 	flag.Uint64Var(&numViewsInStakingPhase, "epoch-staking-phase-length", 2000, "number of views in epoch staking phase")
@@ -78,39 +86,92 @@ func init() {
 	flag.DurationVar(&collectionDelay, "collection-delay", DefaultCollectionDelay, "delay on collection node block proposals")
 }
 
+func generateBootstrapData(flowNetworkConf testnet.NetworkConfig) []testnet.ContainerConfig {
+	// Prepare localnet host folders, mapped to Docker container volumes upon `docker compose up`
+	prepareCommonHostFolders()
+	_, _, _, flowNodeContainerConfigs, _, err := testnet.BootstrapNetwork(flowNetworkConf, BootstrapDir)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Flow test network bootstrapping data generated...")
+	return flowNodeContainerConfigs
+}
+
+// localnet/bootstrap.go generates a docker compose file with images configured for a
+// self-contained Flow network, and other peripheral services, such as Observer services.
+// Private/Public keys and data are removed and re-created for the self-contained localnet
+// environment with every invocation, and are intended solely for testing, not for production.
 func main() {
 	flag.Parse()
 
-	fmt.Println("Bootstrapping a new FLITE network...")
+	// Prepare test node configurations of each type, access, execution, verification, etc
+	flowNodes := prepareFlowNodes()
 
-	fmt.Printf("Node counts:\n")
-	fmt.Printf("- Collection: %d\n", collectionCount)
-	fmt.Printf("- Consensus: %d\n", consensusCount)
-	fmt.Printf("- Execution: %d\n", executionCount)
-	fmt.Printf("- Verification: %d\n", verificationCount)
-	fmt.Printf("- Staked Access: %d\n", accessCount)
-	fmt.Printf("- Unstaked Access: %d\n\n", unstakedAccessCount)
-
-	nodes := prepareNodes()
-
-	opts := []testnet.NetworkConfigOpt{testnet.WithClusters(nClusters)}
+	// Generate a Flow network config for localnet
+	flowNetworkOpts := []testnet.NetworkConfigOpt{testnet.WithClusters(nClusters)}
 	if numViewsEpoch != 0 {
-		opts = append(opts, testnet.WithViewsInEpoch(numViewsEpoch))
+		flowNetworkOpts = append(flowNetworkOpts, testnet.WithViewsInEpoch(numViewsEpoch))
 	}
 	if numViewsInStakingPhase != 0 {
-		opts = append(opts, testnet.WithViewsInStakingAuction(numViewsInStakingPhase))
+		flowNetworkOpts = append(flowNetworkOpts, testnet.WithViewsInStakingAuction(numViewsInStakingPhase))
 	}
 	if numViewsInDKGPhase != 0 {
-		opts = append(opts, testnet.WithViewsInDKGPhase(numViewsInDKGPhase))
+		flowNetworkOpts = append(flowNetworkOpts, testnet.WithViewsInDKGPhase(numViewsInDKGPhase))
 	}
-	conf := testnet.NewNetworkConfig("localnet", nodes, opts...)
+	flowNetworkConf := testnet.NewNetworkConfig("localnet", flowNodes, flowNetworkOpts...)
+	displayFlowNetworkConf(flowNetworkConf)
 
+	// Generate the Flow network bootstrap files for this localnet
+	flowNodeContainerConfigs := generateBootstrapData(flowNetworkConf)
+
+	// Generate Flow network services docker-compose-nodes.yml
+	dockerServices := make(Services)
+	dockerServices = prepareFlowServices(dockerServices, flowNodeContainerConfigs)
+	serviceDisc := prepareServiceDiscovery(flowNodeContainerConfigs)
+	err := writePrometheusConfig(serviceDisc)
+	if err != nil {
+		panic(err)
+	}
+
+	// Generate the Observer services docker-compose-nodes.yml
+	dockerServices = prepareObserverServices(dockerServices, flowNodeContainerConfigs)
+
+	err = writeDockerComposeConfig(dockerServices)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Print("Bootstrapping success!\n\n")
+	displayPortAssignments()
+	fmt.Println()
+
+	fmt.Print("Run \"make start\" to launch the network.\n")
+}
+
+func displayFlowNetworkConf(flowNetworkConf testnet.NetworkConfig) {
 	fmt.Printf("Network config:\n")
-	fmt.Printf("- Clusters: %d\n", conf.NClusters)
-	fmt.Printf("- Epoch Length: %d\n", conf.ViewsInEpoch)
-	fmt.Printf("- Staking Phase Length: %d\n", conf.ViewsInStakingAuction)
-	fmt.Printf("- DKG Phase Length: %d\n", conf.ViewsInDKGPhase)
+	fmt.Printf("- Clusters: %d\n", flowNetworkConf.NClusters)
+	fmt.Printf("- Epoch Length: %d\n", flowNetworkConf.ViewsInEpoch)
+	fmt.Printf("- Staking Phase Length: %d\n", flowNetworkConf.ViewsInStakingAuction)
+	fmt.Printf("- DKG Phase Length: %d\n", flowNetworkConf.ViewsInDKGPhase)
+}
 
+func displayPortAssignments() {
+	for i := 0; i < accessCount; i++ {
+		fmt.Printf("Access %d Flow API will be accessible at localhost:%d\n", i+1, FlowAPIPort+i)
+		fmt.Printf("Access %d public libp2p access will be accessible at localhost:%d\n\n", i+1, AccessPubNetworkPort+i)
+	}
+	for i := 0; i < executionCount; i++ {
+		fmt.Printf("Execution API %d will be accessible at localhost:%d\n", i+1, ExecutionAPIPort+i)
+	}
+	fmt.Println()
+	for i := 0; i < observerCount; i++ {
+		fmt.Printf("Observer %d Flow API will be accessible at localhost:%d\n", i+1, (accessCount*2)+(FlowAPIPort)+2*i)
+	}
+}
+
+func prepareCommonHostFolders() {
+	// Remove and recreate working folders
 	err := os.RemoveAll(BootstrapDir)
 	if err != nil && !os.IsNotExist(err) {
 		panic(err)
@@ -150,69 +211,32 @@ func main() {
 	if err != nil && !os.IsExist(err) {
 		panic(err)
 	}
-
-	_, _, _, containers, _, err := testnet.BootstrapNetwork(conf, BootstrapDir)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Println("Node bootstrapping data generated...")
-
-	services := prepareServices(containers)
-
-	err = writeDockerComposeConfig(services)
-	if err != nil {
-		panic(err)
-	}
-
-	serviceDisc := prepareServiceDiscovery(containers)
-
-	err = writePrometheusConfig(serviceDisc)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Print("Bootstrapping success!\n\n")
-
-	for i := 0; i < accessCount; i++ {
-		fmt.Printf("Access API %d will be accessible at localhost:%d\n", i+1, AccessAPIPort+i)
-	}
-	for i := 0; i < executionCount; i++ {
-		fmt.Printf("Execution API %d will be accessible at localhost:%d\n", i+1, ExecutionAPIPort+i)
-	}
-
-	fmt.Println()
-
-	fmt.Print("Run \"make start\" to launch the network.\n")
 }
 
-func prepareNodes() []testnet.NodeConfig {
+func prepareFlowNodes() []testnet.NodeConfig {
+	fmt.Println("Bootstrapping a new self-contained, self-connected Flow network...")
+	fmt.Printf("Flow node counts:\n")
+	fmt.Printf("- Collection: %d\n", collectionCount)
+	fmt.Printf("- Consensus: %d\n", consensusCount)
+	fmt.Printf("- Execution: %d\n", executionCount)
+	fmt.Printf("- Verification: %d\n", verificationCount)
+	fmt.Printf("- Access: %d\n", accessCount)
 	nodes := make([]testnet.NodeConfig, 0)
 
 	for i := 0; i < collectionCount; i++ {
 		nodes = append(nodes, testnet.NewNodeConfig(flow.RoleCollection))
 	}
-
 	for i := 0; i < consensusCount; i++ {
 		nodes = append(nodes, testnet.NewNodeConfig(flow.RoleConsensus))
 	}
-
 	for i := 0; i < executionCount; i++ {
 		nodes = append(nodes, testnet.NewNodeConfig(flow.RoleExecution))
 	}
-
 	for i := 0; i < verificationCount; i++ {
 		nodes = append(nodes, testnet.NewNodeConfig(flow.RoleVerification))
 	}
-
 	for i := 0; i < accessCount; i++ {
 		nodes = append(nodes, testnet.NewNodeConfig(flow.RoleAccess))
-	}
-
-	for i := 0; i < unstakedAccessCount; i++ {
-		nodes = append(nodes, testnet.NewNodeConfig(flow.RoleAccess, func(cfg *testnet.NodeConfig) {
-			cfg.SupportsUnstakedNodes = true
-		}))
 	}
 
 	return nodes
@@ -246,9 +270,7 @@ type Build struct {
 	Target     string
 }
 
-func prepareServices(containers []testnet.ContainerConfig) Services {
-	services := make(Services)
-
+func prepareFlowServices(services Services, containers []testnet.ContainerConfig) Services {
 	var (
 		numCollection   = 0
 		numConsensus    = 0
@@ -256,7 +278,6 @@ func prepareServices(containers []testnet.ContainerConfig) Services {
 		numVerification = 0
 		numAccess       = 0
 	)
-
 	for n, container := range containers {
 		switch container.Role {
 		case flow.RoleConsensus:
@@ -284,7 +305,6 @@ func prepareServices(containers []testnet.ContainerConfig) Services {
 			numAccess++
 		}
 	}
-
 	return services
 }
 
@@ -471,14 +491,17 @@ func prepareAccessService(container testnet.ContainerConfig, i int, n int) Servi
 		fmt.Sprintf("--secure-rpc-addr=%s:%d", container.ContainerName, SecuredRPCPort),
 		fmt.Sprintf("--http-addr=%s:%d", container.ContainerName, HTTPPort),
 		fmt.Sprintf("--collection-ingress-port=%d", RPCPort),
+		"--supports-unstaked-node=true",
+		fmt.Sprintf("--public-network-address=%s:%d", container.ContainerName, AccessPubNetworkPort),
 		"--log-tx-time-to-finalized",
 		"--log-tx-time-to-executed",
 		"--log-tx-time-to-finalized-executed",
 	}...)
 
 	service.Ports = []string{
-		fmt.Sprintf("%d:%d", AccessAPIPort+2*i, RPCPort),
-		fmt.Sprintf("%d:%d", AccessAPIPort+(2*i+1), SecuredRPCPort),
+		fmt.Sprintf("%d:%d", AccessPubNetworkPort+i, AccessPubNetworkPort),
+		fmt.Sprintf("%d:%d", FlowAPIPort+2*i, RPCPort),
+		fmt.Sprintf("%d:%d", FlowAPIPort+(2*i+1), SecuredRPCPort),
 	}
 
 	return service
@@ -506,16 +529,16 @@ func writeDockerComposeConfig(services Services) error {
 }
 
 // PrometheusServiceDiscovery ...
-type PrometheusServiceDiscovery []PromtheusTargetList
+type PrometheusServiceDiscovery []PrometheusTargetList
 
-// PromtheusTargetList ...
-type PromtheusTargetList struct {
+// PrometheusTargetList ...
+type PrometheusTargetList struct {
 	Targets []string          `json:"targets"`
 	Labels  map[string]string `json:"labels"`
 }
 
-func newPrometheusTargetList(role flow.Role) PromtheusTargetList {
-	return PromtheusTargetList{
+func newPrometheusTargetList(role flow.Role) PrometheusTargetList {
+	return PrometheusTargetList{
 		Targets: make([]string, 0),
 		Labels: map[string]string{
 			"job":  "flow",
@@ -525,7 +548,7 @@ func newPrometheusTargetList(role flow.Role) PromtheusTargetList {
 }
 
 func prepareServiceDiscovery(containers []testnet.ContainerConfig) PrometheusServiceDiscovery {
-	targets := map[flow.Role]PromtheusTargetList{
+	targets := map[flow.Role]PrometheusTargetList{
 		flow.RoleCollection:   newPrometheusTargetList(flow.RoleCollection),
 		flow.RoleConsensus:    newPrometheusTargetList(flow.RoleConsensus),
 		flow.RoleExecution:    newPrometheusTargetList(flow.RoleExecution),
@@ -583,4 +606,160 @@ func openAndTruncate(filename string) (*os.File, error) {
 	}
 
 	return f, nil
+}
+
+//////
+//
+// Observer functions
+//
+
+func prepareObserverProfilerFolder(observerName string) string {
+	// Create a profiler folder (on the host) for the named Observer
+	profilerDir := getObserverProfilerDir(observerName)
+	err := os.MkdirAll(profilerDir, 0755)
+	if err != nil && !os.IsExist(err) {
+		panic(err)
+	}
+	return profilerDir
+}
+
+func prepareObserverDataFolder(observerName string) string {
+	//for i := 0; i < observerCount; i++ {
+	//	observerName := fmt.Sprintf("%s_%d", DefaultObserverName, i+1)
+	// Create a data folder (on the host) for the named Observer
+	dataDir := getObserverDataDir(observerName)
+	err := os.MkdirAll(dataDir, 0755)
+	if err != nil && !os.IsExist(err) {
+		panic(err)
+	}
+	return dataDir
+}
+
+func getObserverProfilerDir(observerName string) string {
+	return "./" + filepath.Join(ProfilerDir, observerName)
+}
+
+func getObserverDataDir(observerName string) string {
+	return "./" + filepath.Join(DataDir, observerName)
+}
+
+func getAccessGatewayPublicKey(flowNodeContainerConfigs []testnet.ContainerConfig) (string, error) {
+	for _, container := range flowNodeContainerConfigs {
+		if container.ContainerName == DefaultAccessGatewayName {
+			// remove the "0x"..0000 portion of the key
+			return container.NetworkPubKey().String()[2:], nil
+		}
+	}
+	return "", fmt.Errorf("Unable to find public key for Access Gateway expected in container '%s'", DefaultAccessGatewayName)
+}
+
+func writeObserverPrivateKey(observerName string) {
+	// make the observer private key for named observer
+	// only used for localnet, not for use with production
+	networkSeed := cmd.GenerateRandomSeed(crypto.KeyGenSeedMinLenECDSASecp256k1)
+	networkKey, err := utils.GenerateUnstakedNetworkingKey(networkSeed)
+	if err != nil {
+		panic(err)
+	}
+
+	// hex encode
+	keyBytes := networkKey.Encode()
+	output := make([]byte, hex.EncodedLen(len(keyBytes)))
+	hex.Encode(output, keyBytes)
+
+	// write to file
+	outputFile := fmt.Sprintf("%s/private-root-information/%s_key", BootstrapDir, observerName)
+	err = ioutil.WriteFile(outputFile, output, 0600)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func prepareObserverService(i int, observerName string, agPublicKey string, profilerDir string, dataDir string) Service {
+	observerService := Service{
+		Image: fmt.Sprintf("localnet-%s", DefaultObserverName),
+		Command: []string{
+			fmt.Sprintf("--staked=false"),
+			fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort),
+			fmt.Sprintf("--bootstrap-node-public-keys=%s", agPublicKey),
+			fmt.Sprintf("--observer-networking-key-path=/bootstrap/private-root-information/%s_key", observerName),
+			fmt.Sprintf("--bind=0.0.0.0:0"),
+			fmt.Sprintf("--rpc-addr=%s:%d", observerName, RPCPort),
+			fmt.Sprintf("--secure-rpc-addr=%s:%d", observerName, SecuredRPCPort),
+			fmt.Sprintf("--http-addr=%s:%d", observerName, HTTPPort),
+			fmt.Sprintf("--collection-ingress-port=%d", RPCPort),
+			"--log-tx-time-to-finalized",
+			"--log-tx-time-to-executed",
+			"--log-tx-time-to-finalized-executed",
+			"--bootstrapdir=/bootstrap",
+			"--datadir=/data/protocol",
+			"--secretsdir=/data/secret",
+			"--loglevel=DEBUG",
+			fmt.Sprintf("--profiler-enabled=%t", true),
+			fmt.Sprintf("--tracer-enabled=%t", false),
+			"--profiler-dir=/profiler",
+			"--profiler-interval=2m",
+		},
+		Volumes: []string{
+			fmt.Sprintf("%s:/bootstrap:z", BootstrapDir),
+			fmt.Sprintf("%s:/profiler:z", profilerDir),
+			fmt.Sprintf("%s:/data:z", dataDir),
+		},
+		Environment: []string{
+			"JAEGER_AGENT_HOST=jaeger",
+			"JAEGER_AGENT_PORT=6831",
+			"BINSTAT_ENABLE",
+			"BINSTAT_LEN_WHAT",
+			"BINSTAT_DMP_NAME",
+			"BINSTAT_DMP_PATH",
+		},
+	}
+	// observer services rely on the access gateway
+	observerService.DependsOn = []string{
+		fmt.Sprintf(DefaultAccessGatewayName),
+	}
+	observerService.Ports = []string{
+		// Flow API ports come in pairs, open and secure. While the guest port is always
+		// the same from the guest's perspective, the host port numbering accounts for the presence
+		// of multiple pairs of listeners on the host to avoid port collisions. Observer listener pairs
+		// are numbered just after the Access listeners on the host network by prior convention
+		fmt.Sprintf("%d:%d", (accessCount*2)+FlowAPIPort+(2*i), RPCPort),
+		fmt.Sprintf("%d:%d", (accessCount*2)+FlowAPIPort+(2*i)+1, SecuredRPCPort),
+	}
+	return observerService
+}
+
+func prepareObserverServices(dockerServices Services, flowNodeContainerConfigs []testnet.ContainerConfig) Services {
+	agPublicKey, err := getAccessGatewayPublicKey(flowNodeContainerConfigs)
+	if err != nil {
+		panic(err)
+	}
+
+	if accessCount < 1 {
+		panic("Observers require at least one Access node to serve as an Access Gateway")
+	}
+
+	// Some reasonable maximum is needed to prevent conflicts with the Flow API ports
+	if observerCount > DefaultMaxObservers {
+		panic(fmt.Sprintf("No more than %d observers are permitted within localnet", DefaultMaxObservers))
+	}
+
+	if observerCount > 0 {
+		for i := 0; i < observerCount; i++ {
+			observerName := fmt.Sprintf("%s_%d", DefaultObserverName, i+1)
+			profilerDir := prepareObserverProfilerFolder(observerName)
+			dataDir := prepareObserverDataFolder(observerName)
+			observerService := prepareObserverService(i, observerName, agPublicKey, profilerDir, dataDir)
+
+			// Add a docker container for this named Observer
+			dockerServices[observerName] = observerService
+
+			// Generate observer private key (localnet only, not for production)
+			writeObserverPrivateKey(observerName)
+		}
+		fmt.Println()
+		fmt.Println("Observer services bootstrapping data generated...")
+		fmt.Printf("Access Gateway (%s) public network libp2p key: %s\n\n", DefaultAccessGatewayName, agPublicKey)
+	}
+	return dockerServices
 }


### PR DESCRIPTION
**Add Observer Support to Localnet**

Adds Observer support to integration/localnet such that setting the OBSERVER variable in localnet/Makefile will define and bootstrap the specified number of Observers with `make init`, and run them within the localnet Docker network upon a subsequent `make start`.  Once running, these observers will follow consensus from the Flow network running within localnet. 

**`make init` will now:**

- Create a self-contained, self-connected Flow network that includes zero or more functional Observers
- Create the required Observer private keys, needed to follow consensus from the localnet Flow network
- Display a libp2p public networking key that can be used to optionally connect an _external_, _standalone_ Observer that can be used to follow consensus from the localnet Flow network