### PR TITLE
[Access node] Add random en lookup on receipt lookup failure

### DIFF
--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -396,11 +396,11 @@ func executionNodesForBlockID(
 		receiptCnt := len(executorIDs)
 		// if less than minExecutionNodesCnt execution receipts have been received so far, then return random ENs
 		if receiptCnt < minExecutionNodesCnt {
-			executorIdentities, err := state.Final().Identities(filter.HasRole(flow.RoleExecution))
+			executionNodes, err := state.AtBlockID(blockID).Identities(filter.HasRole(flow.RoleExecution))
 			if err != nil {
 				return nil, fmt.Errorf("failed to retreive execution IDs for block ID %v: %w", blockID, err)
 			}
-			return executorIdentities.Sample(minExecutionNodesCnt), nil
+			return executionNodes.Sample(maxExecutionNodesCnt), nil
 		}
 	}
 

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -394,9 +394,13 @@ func executionNodesForBlockID(
 		}
 
 		receiptCnt := len(executorIDs)
-		// if less than minExecutionNodesCnt execution receipts have been received so far, then throw an error
+		// if less than minExecutionNodesCnt execution receipts have been received so far, then return random ENs
 		if receiptCnt < minExecutionNodesCnt {
-			return flow.IdentityList{}, InsufficientExecutionReceipts{blockID: blockID, receiptCount: receiptCnt}
+			executorIdentities, err := state.Final().Identities(filter.HasRole(flow.RoleExecution))
+			if err != nil {
+				return nil, fmt.Errorf("failed to retreive execution IDs for block ID %v: %w", blockID, err)
+			}
+			return executorIdentities.Sample(minExecutionNodesCnt), nil
 		}
 	}
 
@@ -424,7 +428,7 @@ func findAllExecutionNodes(
 	executionReceipts storage.ExecutionReceipts,
 	log zerolog.Logger) (flow.IdentifierList, error) {
 
-	// lookup the receipts storage with the block ID
+	// lookup the receipt's storage with the block ID
 	allReceipts, err := executionReceipts.ByBlockID(blockID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retreive execution receipts for block ID %v: %w", blockID, err)

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -396,11 +396,11 @@ func executionNodesForBlockID(
 		receiptCnt := len(executorIDs)
 		// if less than minExecutionNodesCnt execution receipts have been received so far, then return random ENs
 		if receiptCnt < minExecutionNodesCnt {
-			executionNodes, err := state.AtBlockID(blockID).Identities(filter.HasRole(flow.RoleExecution))
+			newExecutorIDs, err := state.AtBlockID(blockID).Identities(filter.HasRole(flow.RoleExecution))
 			if err != nil {
 				return nil, fmt.Errorf("failed to retreive execution IDs for block ID %v: %w", blockID, err)
 			}
-			return executionNodes.Sample(maxExecutionNodesCnt), nil
+			executorIDs = newExecutorIDs.NodeIDs()
 		}
 	}
 
@@ -415,7 +415,7 @@ func executionNodesForBlockID(
 
 	if len(executionIdentitiesRandom) == 0 {
 		return flow.IdentityList{},
-			fmt.Errorf("no matching execution node could for block ID %v", blockID)
+			fmt.Errorf("no matching execution node found for block ID %v", blockID)
 	}
 
 	return executionIdentitiesRandom, nil

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -2078,6 +2078,20 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 		expectedList := preferredENs
 		testExecutionNodesForBlockID(preferredENs, nil, expectedList)
 	})
+
+	suite.Run("insufficient receipts return random ENs in state", func() {
+		// return no receipts at all attempts
+		totalENs := 5
+		attempt1Receipts = flow.ExecutionReceiptList{}
+		attempt2Receipts = flow.ExecutionReceiptList{}
+		attempt3Receipts = flow.ExecutionReceiptList{}
+		availableExecNodes := unittest.IdentityListFixture(totalENs, unittest.WithRole(flow.RoleExecution))
+		suite.snapshot.On("Identities", mock.Anything).Return(availableExecNodes)
+		suite.state.On("AtBlockID", mock.Anything).Return(suite.snapshot)
+		actualList, err := executionNodesForBlockID(context.Background(), block.ID(), suite.receipts, suite.state, suite.log)
+		require.NoError(suite.T(), err)
+		require.Equal(suite.T(), len(actualList), maxExecutionNodesCnt)
+	})
 }
 
 // TestExecuteScriptOnExecutionNode tests the method backend.scripts.executeScriptOnExecutionNode for script execution

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -2023,6 +2023,18 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 			require.ElementsMatch(suite.T(), actualList, expectedENs)
 		}
 	}
+	// if we don't find sufficient receipts, executionNodesForBlockID should return a list of random ENs
+	suite.Run("insufficient receipts return random ENs in state", func() {
+		// return no receipts at all attempts
+		attempt1Receipts = flow.ExecutionReceiptList{}
+		attempt2Receipts = flow.ExecutionReceiptList{}
+		attempt3Receipts = flow.ExecutionReceiptList{}
+		suite.state.On("AtBlockID", mock.Anything).Return(suite.snapshot)
+		actualList, err := executionNodesForBlockID(context.Background(), block.ID(), suite.receipts, suite.state, suite.log)
+		require.NoError(suite.T(), err)
+		require.Equal(suite.T(), len(actualList), maxExecutionNodesCnt)
+	})
+
 	// if no preferred or fixed ENs are specified, the ExecutionNodesForBlockID function should
 	// return the exe node list without a filter
 	suite.Run("no preferred or fixed ENs", func() {
@@ -2077,20 +2089,6 @@ func (suite *Suite) TestExecutionNodesForBlockID() {
 		preferredENs := allExecutionNodes[0:2]
 		expectedList := preferredENs
 		testExecutionNodesForBlockID(preferredENs, nil, expectedList)
-	})
-
-	suite.Run("insufficient receipts return random ENs in state", func() {
-		// return no receipts at all attempts
-		totalENs := 5
-		attempt1Receipts = flow.ExecutionReceiptList{}
-		attempt2Receipts = flow.ExecutionReceiptList{}
-		attempt3Receipts = flow.ExecutionReceiptList{}
-		availableExecNodes := unittest.IdentityListFixture(totalENs, unittest.WithRole(flow.RoleExecution))
-		suite.snapshot.On("Identities", mock.Anything).Return(availableExecNodes)
-		suite.state.On("AtBlockID", mock.Anything).Return(suite.snapshot)
-		actualList, err := executionNodesForBlockID(context.Background(), block.ID(), suite.receipts, suite.state, suite.log)
-		require.NoError(suite.T(), err)
-		require.Equal(suite.T(), len(actualList), maxExecutionNodesCnt)
 	})
 }
 


### PR DESCRIPTION
Add logic to lookup random execution nodes on insufficient receipts instead of a blank list/custom error