### PR TITLE
remove unused test util

### DIFF
--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -444,18 +444,3 @@ func bytesToCadenceArray(l []byte) cadence.Array {
 
 	return cadence.NewArray(values)
 }
-
-// CreateRemoveAccountKeyTransaction generates a tx that removes a key from an account.
-func CreateRemoveAccountKeyTransaction(index int) *flow.TransactionBody {
-	script := fmt.Sprintf(`
-		transaction {
-		  prepare(signer: AuthAccount) {
-	    	signer.removePublicKey(%d)
-		  }
-		}
-	`, index)
-
-	return &flow.TransactionBody{
-		Script: []byte(script),
-	}
-}


### PR DESCRIPTION
The removeKey function is gone now. This function, `CreateRemoveAccountKeyTransaction` isn't used anywhere but uses the removeKey function. It's easier to just remove it than update it.