### PR TITLE
Permissionless contract updates

### DIFF
--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -549,7 +549,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		assert.Error(t, tx.Err)
 
-		assert.Contains(t, tx.Err.Error(), "setting contracts requires authorization from specific accounts")
+		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
 		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
 	})
 
@@ -576,7 +576,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		assert.Error(t, tx.Err)
 
-		assert.Contains(t, tx.Err.Error(), "setting contracts requires authorization from specific accounts")
+		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
 		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
 	})
 
@@ -639,7 +639,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
-		assert.Contains(t, tx.Err.Error(), "setting contracts requires authorization from specific accounts")
+		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
 		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
 
 		// Generate an audit voucher

--- a/fvm/handler/accountKey_test.go
+++ b/fvm/handler/accountKey_test.go
@@ -188,6 +188,7 @@ func (f FakeAccounts) SetPublicKey(_ flow.Address, _ uint64, _ flow.AccountPubli
 }
 func (f FakeAccounts) GetContractNames(_ flow.Address) ([]string, error)             { return nil, nil }
 func (f FakeAccounts) GetContract(_ string, _ flow.Address) ([]byte, error)          { return nil, nil }
+func (f FakeAccounts) ContractExists(_ string, _ flow.Address) (bool, error)         { return false, nil }
 func (f FakeAccounts) SetContract(_ string, _ flow.Address, _ []byte) error          { return nil }
 func (f FakeAccounts) DeleteContract(_ string, _ flow.Address) error                 { return nil }
 func (f FakeAccounts) Create(_ []flow.AccountPublicKey, _ flow.Address) error        { return nil }

--- a/fvm/handler/contract.go
+++ b/fvm/handler/contract.go
@@ -38,7 +38,8 @@ type ContractHandler struct {
 func NewContractHandler(accounts state.Accounts,
 	restrictedDeploymentEnabled bool,
 	authorizedAccounts AuthorizedAccountsForContractDeploymentFunc,
-	useContractAuditVoucher UseContractAuditVoucherFunc) *ContractHandler {
+	useContractAuditVoucher UseContractAuditVoucherFunc,
+) *ContractHandler {
 	return &ContractHandler{
 		accounts:                    accounts,
 		draftUpdates:                make(map[programs.ContractUpdateKey]programs.ContractUpdate),
@@ -58,26 +59,57 @@ func (h *ContractHandler) GetContract(address runtime.Address, name string) (cod
 	return
 }
 
-func (h *ContractHandler) SetContract(address runtime.Address, name string, code []byte, signingAccounts []runtime.Address) (err error) {
-	// check if authorized
-	if !h.isAuthorized(signingAccounts) {
+func (h *ContractHandler) SetContract(
+	address runtime.Address,
+	name string,
+	code []byte,
+	signingAccounts []runtime.Address,
+) (err error) {
+
+	flowAddress := flow.Address(address)
+
+	// Initial contract deployments must be authorized by signing accounts,
+	// or there must be an audit voucher available.
+	//
+	// Contract updates are always allowed.
+
+	var exists bool
+	exists, err = h.accounts.ContractExists(name, flowAddress)
+	if err != nil {
+		return err
+	}
+
+	if !exists && !h.isAuthorized(signingAccounts) {
 		// check if there's an audit voucher for the contract
 		voucherAvailable, err := h.useContractAuditVoucher(address, code)
 		if err != nil {
-			errInner := errors.NewOperationAuthorizationErrorf("SetContract", "failed to check audit vouchers")
+			errInner := errors.NewOperationAuthorizationErrorf(
+				"SetContract",
+				"failed to check audit vouchers",
+			)
 			return fmt.Errorf("setting contract failed: %w - %s", errInner, err)
 		}
 		if !voucherAvailable {
-			err = errors.NewOperationAuthorizationErrorf("SetContract", "setting contracts requires authorization from specific accounts")
-			return fmt.Errorf("setting contract failed: %w", err)
+			err = errors.NewOperationAuthorizationErrorf(
+				"SetContract",
+				"deploying contracts requires authorization from specific accounts",
+			)
+			return fmt.Errorf("deploying contract failed: %w", err)
 		}
 	}
-	add := flow.Address(address)
+
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	uk := programs.ContractUpdateKey{Address: add, Name: name}
-	u := programs.ContractUpdate{ContractUpdateKey: uk, Code: code}
-	h.draftUpdates[uk] = u
+
+	contractUpdateKey := programs.ContractUpdateKey{
+		Address: flowAddress,
+		Name:    name,
+	}
+
+	h.draftUpdates[contractUpdateKey] = programs.ContractUpdate{
+		ContractUpdateKey: contractUpdateKey,
+		Code:              code,
+	}
 
 	return nil
 }

--- a/fvm/handler/contract_test.go
+++ b/fvm/handler/contract_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/fvm/programs"
 
 	"github.com/onflow/flow-go/fvm/handler"
 	stateMock "github.com/onflow/flow-go/fvm/mock/state"

--- a/fvm/handler/contract_test.go
+++ b/fvm/handler/contract_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -98,6 +99,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 }
 
 func TestContract_DeploymentVouchers(t *testing.T) {
+
 	sth := state.NewStateHolder(state.NewState(utils.NewSimpleView()))
 	accounts := state.NewAccounts(sth)
 
@@ -111,9 +113,12 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 	err = accounts.Create(nil, addressNoVoucher)
 	require.NoError(t, err)
 
-	contractHandler := handler.NewContractHandler(accounts,
+	contractHandler := handler.NewContractHandler(
+		accounts,
 		true,
-		func() []common.Address { return []common.Address{} },
+		func() []common.Address {
+			return []common.Address{}
+		},
 		func(address runtime.Address, code []byte) (bool, error) {
 			if address.String() == addressWithVoucher.String() {
 				return true, nil
@@ -122,12 +127,92 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 		})
 
 	// set contract without voucher
-	err = contractHandler.SetContract(addressNoVoucherRuntime, "testContract1", []byte("ABC"), []common.Address{addressNoVoucherRuntime})
+	err = contractHandler.SetContract(
+		addressNoVoucherRuntime,
+		"TestContract1",
+		[]byte("pub contract TestContract1 {}"),
+		[]common.Address{
+			addressNoVoucherRuntime,
+		},
+	)
 	require.Error(t, err)
 	require.False(t, contractHandler.HasUpdates())
 
 	// try to set contract with voucher
-	err = contractHandler.SetContract(addressWithVoucherRuntime, "testContract2", []byte("ABC"), []common.Address{addressWithVoucherRuntime})
+	err = contractHandler.SetContract(
+		addressWithVoucherRuntime,
+		"TestContract2",
+		[]byte("pub contract TestContract2 {}"),
+		[]common.Address{
+			addressWithVoucherRuntime,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, contractHandler.HasUpdates())
+}
+
+func TestContract_ContractUpdate(t *testing.T) {
+
+	sth := state.NewStateHolder(state.NewState(utils.NewSimpleView()))
+	accounts := state.NewAccounts(sth)
+
+	flowAddress := flow.HexToAddress("01")
+	runtimeAddress := runtime.Address(flowAddress)
+	err := accounts.Create(nil, flowAddress)
+	require.NoError(t, err)
+
+	var authorizationChecked bool
+
+	contractHandler := handler.NewContractHandler(
+		accounts,
+		true,
+		func() []common.Address {
+			return []common.Address{}
+		},
+		func(address runtime.Address, code []byte) (bool, error) {
+			// Ensure the voucher check is only called once,
+			// for the initial contract deployment,
+			// and not for the subsequent update
+			require.False(t, authorizationChecked)
+			authorizationChecked = true
+			return true, nil
+		},
+	)
+
+	// deploy contract with voucher
+	err = contractHandler.SetContract(
+		runtimeAddress,
+		"TestContract",
+		[]byte("pub contract TestContract {}"),
+		[]common.Address{
+			runtimeAddress,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, contractHandler.HasUpdates())
+
+	contractUpdateKeys, err := contractHandler.Commit()
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]programs.ContractUpdateKey{
+			{
+				Address: flowAddress,
+				Name:    "TestContract",
+			},
+		},
+		contractUpdateKeys,
+	)
+
+	// try to update contract without voucher
+	err = contractHandler.SetContract(
+		runtimeAddress,
+		"TestContract",
+		[]byte("pub contract TestContract {}"),
+		[]common.Address{
+			runtimeAddress,
+		},
+	)
 	require.NoError(t, err)
 	require.True(t, contractHandler.HasUpdates())
 }
@@ -135,14 +220,20 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 	mockAccounts := &stateMock.Accounts{}
 
-	mockAccounts.On("SetContract", mock.Anything, mock.Anything, mock.Anything).Return(func(contractName string, address flow.Address, contract []byte) error {
-		return fmt.Errorf("%s %s", contractName, address.Hex())
-	})
+	mockAccounts.On("ContractExists", mock.Anything, mock.Anything).
+		Return(false, nil)
 
-	contractHandler := handler.NewContractHandler(mockAccounts,
+	mockAccounts.On("SetContract", mock.Anything, mock.Anything, mock.Anything).
+		Return(func(contractName string, address flow.Address, contract []byte) error {
+			return fmt.Errorf("%s %s", contractName, address.Hex())
+		})
+
+	contractHandler := handler.NewContractHandler(
+		mockAccounts,
 		false,
 		nil,
-		nil)
+		nil,
+	)
 
 	address1 := runtime.Address(flow.HexToAddress("0000000000000001"))
 	address2 := runtime.Address(flow.HexToAddress("0000000000000002"))

--- a/fvm/mock/state/accounts.go
+++ b/fvm/mock/state/accounts.go
@@ -65,6 +65,27 @@ func (_m *Accounts) CheckAccountNotFrozen(address flow.Address) error {
 	return r0
 }
 
+// ContractExists provides a mock function with given fields: contractName, address
+func (_m *Accounts) ContractExists(contractName string, address flow.Address) (bool, error) {
+	ret := _m.Called(contractName, address)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, flow.Address) bool); ok {
+		r0 = rf(contractName, address)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, flow.Address) error); ok {
+		r1 = rf(contractName, address)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Create provides a mock function with given fields: publicKeys, newAddress
 func (_m *Accounts) Create(publicKeys []flow.AccountPublicKey, newAddress flow.Address) error {
 	ret := _m.Called(publicKeys, newAddress)

--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -42,6 +42,7 @@ type Accounts interface {
 	SetPublicKey(address flow.Address, keyIndex uint64, publicKey flow.AccountPublicKey) ([]byte, error)
 	GetContractNames(address flow.Address) ([]string, error)
 	GetContract(contractName string, address flow.Address) ([]byte, error)
+	ContractExists(contractName string, address flow.Address) (bool, error)
 	SetContract(contractName string, address flow.Address, contract []byte) error
 	DeleteContract(contractName string, address flow.Address) error
 	Create(publicKeys []flow.AccountPublicKey, newAddress flow.Address) error
@@ -542,12 +543,20 @@ func (a *StatefulAccounts) getContractNames(address flow.Address) (contractNames
 	return identifiers, nil
 }
 
-func (a *StatefulAccounts) GetContract(contractName string, address flow.Address) ([]byte, error) {
+func (a *StatefulAccounts) ContractExists(contractName string, address flow.Address) (bool, error) {
 	contractNames, err := a.getContractNames(address)
+	if err != nil {
+		return false, err
+	}
+	return contractNames.Has(contractName), nil
+}
+
+func (a *StatefulAccounts) GetContract(contractName string, address flow.Address) ([]byte, error) {
+	exists, err := a.ContractExists(contractName, address)
 	if err != nil {
 		return nil, err
 	}
-	if !contractNames.Has(contractName) {
+	if !exists {
 		return nil, nil
 	}
 	return a.getContract(contractName, address)


### PR DESCRIPTION
We are planning to enable permissionless deployment (disable `restrictedDeploymentEnabled`) after a test period after the Secure Cadence spork.

However, Secure Cadence will also make breaking changes. To allow developers with existing contracts to update their contracts we will allow *updates* to always be permissionless, and have `restrictedDeploymentEnabled` only contract *new* deployments.