### PR TITLE
Update localnet TARGET paths after recent dockerfile changes

### DIFF
--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -363,7 +363,7 @@ func prepareService(container testnet.ContainerConfig, i int, n int) Service {
 			Context:    "../../",
 			Dockerfile: "cmd/Dockerfile",
 			Args: map[string]string{
-				"TARGET":  container.Role.String(),
+				"TARGET":  fmt.Sprintf("./cmd/%s", container.Role.String()),
 				"VERSION": build.Semver(),
 				"COMMIT":  build.Commit(),
 				"GOARCH":  runtime.GOARCH,
@@ -717,7 +717,7 @@ func prepareObserverService(i int, observerName string, agPublicKey string, prof
 			Context:    "../../",
 			Dockerfile: "cmd/Dockerfile",
 			Args: map[string]string{
-				"TARGET":  "access", // hardcoded to access for now until we make it a separate cmd
+				"TARGET":  "./cmd/access", // hardcoded to access for now until we make it a separate cmd
 				"VERSION": build.Semver(),
 				"COMMIT":  build.Commit(),
 				"GOARCH":  runtime.GOARCH,


### PR DESCRIPTION
https://github.com/onflow/flow-go/pull/2308 updated the dockerfile to accept a path instead of a command name as the `TARGET`.

This PR adds the corresponding change for localnet