### PR TITLE
Add checksum to signer indices

### DIFF
--- a/cmd/bootstrap/run/cluster_qc.go
+++ b/cmd/bootstrap/run/cluster_qc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/local"
 )
 
@@ -29,7 +30,8 @@ func GenerateClusterRootQC(signers []bootstrap.NodeInfo, allCommitteeMembers flo
 	}
 
 	// STEP 2: create VoteProcessor
-	committee, err := committees.NewStaticCommittee(allCommitteeMembers, flow.Identifier{}, nil, nil)
+	ordered := allCommitteeMembers.Sort(order.Canonical)
+	committee, err := committees.NewStaticCommittee(ordered, flow.Identifier{}, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bootstrap/run/qc_test.go
+++ b/cmd/bootstrap/run/qc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -32,7 +33,7 @@ func TestGenerateRootQC(t *testing.T) {
 }
 
 func createSignerData(t *testing.T, n int) *ParticipantData {
-	identities := unittest.IdentityListFixture(n)
+	identities := unittest.IdentityListFixture(n).Sort(order.Canonical)
 
 	networkingKeys := unittest.NetworkingKeys(n)
 	stakingKeys := unittest.StakingKeys(n)

--- a/consensus/hotstuff/committees/static.go
+++ b/consensus/hotstuff/committees/static.go
@@ -6,24 +6,26 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/state/protocol"
 )
 
 // NewStaticCommittee returns a new committee with a static participant set.
 func NewStaticCommittee(participants flow.IdentityList, myID flow.Identifier, dkgParticipants map[flow.Identifier]flow.DKGParticipant, dkgGroupKey crypto.PublicKey) (*Static, error) {
-	static := &Static{
-		participants: participants,
-		myID:         myID,
-		dkg: staticDKG{
-			dkgParticipants: dkgParticipants,
-			dkgGroupKey:     dkgGroupKey,
-		},
-	}
-	return static, nil
+
+	return NewStaticCommitteeWithDKG(participants, myID, staticDKG{
+		dkgParticipants: dkgParticipants,
+		dkgGroupKey:     dkgGroupKey,
+	})
 }
 
 // NewStaticCommitteeWithDKG returns a new committee with a static participant set.
 func NewStaticCommitteeWithDKG(participants flow.IdentityList, myID flow.Identifier, dkg protocol.DKG) (*Static, error) {
+	valid := order.IdentityListCanonical(participants)
+	if !valid {
+		return nil, fmt.Errorf("participants %v is not in Canonical order", participants)
+	}
+
 	static := &Static{
 		participants: participants,
 		myID:         myID,

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -2,7 +2,6 @@ package ingestion
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -126,7 +125,6 @@ func (suite *Suite) TestOnFinalizedBlock() {
 		indices, err := signature.EncodeSignersToIndices(clusterCommittee.NodeIDs(), clusterCommittee.NodeIDs())
 		require.NoError(suite.T(), err)
 		guarantee.SignerIndices = indices
-		fmt.Println("guarantee ID: ", guarantee.ID())
 	}
 
 	hotstuffBlock := hotmodel.Block{

--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -2,6 +2,7 @@ package execution_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/onflow/flow-go/engine/testutil"
 	testmock "github.com/onflow/flow-go/engine/testutil/mock"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/network/mocknetwork"
@@ -58,6 +60,7 @@ func TestExecutionFlow(t *testing.T) {
 	)
 
 	identities := unittest.CompleteIdentitySet(colID, conID, exeID, verID)
+	identities.Sort(order.Canonical)
 
 	// create execution node
 	exeNode := testutil.ExecutionNode(t, hub, exeID, identities, 21, chainID)
@@ -95,8 +98,14 @@ func TestExecutionFlow(t *testing.T) {
 
 	// signed by the only collector
 	block := unittest.BlockWithParentAndProposerFixture(genesis, conID.NodeID, 1)
-	block.Header.ParentVoterIndices = unittest.SignerIndicesByIndices(1, []int{0})
-	signerIndices := unittest.SignerIndicesByIndices(1, []int{0})
+	voterIndices, err := signature.EncodeSignersToIndices(
+		[]flow.Identifier{conID.NodeID}, []flow.Identifier{conID.NodeID})
+	require.NoError(t, err)
+	block.Header.ParentVoterIndices = voterIndices
+	signerIndices, err := signature.EncodeSignersToIndices(
+		[]flow.Identifier{colID.NodeID}, []flow.Identifier{colID.NodeID})
+	require.NoError(t, err)
+	fmt.Println("===========", fmt.Sprintf("%x", voterIndices))
 	block.SetPayload(flow.Payload{
 		Guarantees: []*flow.CollectionGuarantee{
 			{
@@ -117,7 +126,8 @@ func TestExecutionFlow(t *testing.T) {
 	child := unittest.BlockWithParentAndProposerFixture(block.Header, conID.NodeID, 1)
 	// the default signer indices is 2 bytes, but in this test cases
 	// we need 1 byte
-	child.Header.ParentVoterIndices = unittest.SignerIndicesByIndices(1, []int{0})
+	child.Header.ParentVoterIndices = voterIndices
+
 	log.Info().Msgf("child block ID: %v, indices: %v", child.Header.ID(), child.Header.ParentVoterIndices)
 
 	collectionNode := testutil.GenericNodeFromParticipants(t, hub, colID, identities, chainID)
@@ -241,7 +251,10 @@ func deployContractBlock(t *testing.T, conID *flow.Identity, colID *flow.Identit
 
 	// make block
 	block := unittest.BlockWithParentAndProposerFixture(parent, conID.NodeID, 1)
-	block.Header.ParentVoterIndices = unittest.SignerIndicesByIndices(1, []int{0})
+	voterIndices, err := signature.EncodeSignersToIndices(
+		[]flow.Identifier{conID.NodeID}, []flow.Identifier{conID.NodeID})
+	require.NoError(t, err)
+	block.Header.ParentVoterIndices = voterIndices
 	block.SetPayload(flow.Payload{
 		Guarantees: []*flow.CollectionGuarantee{
 			{
@@ -275,7 +288,10 @@ func makePanicBlock(t *testing.T, conID *flow.Identity, colID *flow.Identity, ch
 	clusterChainID := cluster.CanonicalClusterID(1, flow.IdentityList{colID})
 	// make block
 	block := unittest.BlockWithParentAndProposerFixture(parent, conID.NodeID, 1)
-	block.Header.ParentVoterIndices = unittest.SignerIndicesByIndices(1, []int{0})
+	voterIndices, err := signature.EncodeSignersToIndices(
+		[]flow.Identifier{conID.NodeID}, []flow.Identifier{conID.NodeID})
+	require.NoError(t, err)
+	block.Header.ParentVoterIndices = voterIndices
 	block.SetPayload(flow.Payload{
 		Guarantees: []*flow.CollectionGuarantee{
 			{CollectionID: col.ID(), SignerIndices: signerIndices, ChainID: clusterChainID, ReferenceBlockID: ref.ID()},
@@ -300,7 +316,10 @@ func makeSuccessBlock(t *testing.T, conID *flow.Identity, colID *flow.Identity, 
 
 	col := &flow.Collection{Transactions: []*flow.TransactionBody{tx}}
 	block := unittest.BlockWithParentAndProposerFixture(parent, conID.NodeID, 1)
-	block.Header.ParentVoterIndices = unittest.SignerIndicesByIndices(1, []int{0})
+	voterIndices, err := signature.EncodeSignersToIndices(
+		[]flow.Identifier{conID.NodeID}, []flow.Identifier{conID.NodeID})
+	require.NoError(t, err)
+	block.Header.ParentVoterIndices = voterIndices
 	block.SetPayload(flow.Payload{
 		Guarantees: []*flow.CollectionGuarantee{
 			{CollectionID: col.ID(), SignerIndices: signerIndices, ChainID: clusterChainID, ReferenceBlockID: ref.ID()},
@@ -515,13 +534,16 @@ func TestBroadcastToMultipleVerificationNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	block := unittest.BlockWithParentAndProposerFixture(genesis, conID.NodeID, 1)
-	block.Header.ParentVoterIndices = unittest.SignerIndicesByIndices(1, []int{0})
+	voterIndices, err := signature.EncodeSignersToIndices(
+		[]flow.Identifier{conID.NodeID}, []flow.Identifier{conID.NodeID})
+	require.NoError(t, err)
+	block.Header.ParentVoterIndices = voterIndices
 	block.Header.View = 42
 	block.SetPayload(flow.Payload{})
 	proposal := unittest.ProposalFromBlock(&block)
 
 	child := unittest.BlockWithParentAndProposerFixture(block.Header, conID.NodeID, 1)
-	child.Header.ParentVoterIndices = unittest.SignerIndicesByIndices(1, []int{0})
+	child.Header.ParentVoterIndices = voterIndices
 
 	actualCalls := 0
 

--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -59,8 +59,7 @@ func TestExecutionFlow(t *testing.T) {
 		unittest.WithKeys,
 	)
 
-	identities := unittest.CompleteIdentitySet(colID, conID, exeID, verID)
-	identities.Sort(order.Canonical)
+	identities := unittest.CompleteIdentitySet(colID, conID, exeID, verID).Sort(order.Canonical)
 
 	// create execution node
 	exeNode := testutil.ExecutionNode(t, hub, exeID, identities, 21, chainID)

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -390,7 +390,7 @@ func (e *Engine) reloadBlock(
 	err = e.enqueueBlockAndCheckExecutable(blockByCollection, executionQueues, block, false)
 
 	if err != nil {
-		return fmt.Errorf("could not enqueue block on reloading: %w", err)
+		return fmt.Errorf("could not enqueue block %x on reloading: %w", blockID, err)
 	}
 
 	return nil
@@ -455,7 +455,7 @@ func (e *Engine) handleBlock(ctx context.Context, block *flow.Block) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("could not enqueue block: %w", err)
+		return fmt.Errorf("could not enqueue block %v: %w", blockID, err)
 	}
 
 	return nil

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -118,8 +118,8 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 		providerEngine.AssertExpectations(t)
 	}()
 
-	identityList := flow.IdentityList{myIdentity, collection1Identity, collection2Identity, collection3Identity}
-	identityList.Sort(order.Canonical)
+	identityListUnsorted := flow.IdentityList{myIdentity, collection1Identity, collection2Identity, collection3Identity}
+	identityList := identityListUnsorted.Sort(order.Canonical)
 
 	executionState.On("DiskSize").Return(int64(1024*1024), nil).Maybe()
 

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -24,9 +25,11 @@ import (
 	"github.com/onflow/flow-go/engine/testutil/mocklocal"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/metrics"
 	module "github.com/onflow/flow-go/module/mocks"
+	"github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/network/mocknetwork"
 	stateProtocol "github.com/onflow/flow-go/state/protocol"
@@ -66,6 +69,7 @@ type testingContext struct {
 	identity            *flow.Identity
 	broadcastedReceipts map[flow.Identifier]*flow.ExecutionReceipt
 	collectionRequester *module.MockRequester
+	identities          flow.IdentityList
 }
 
 func runWithEngine(t *testing.T, f func(testingContext)) {
@@ -115,6 +119,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 	}()
 
 	identityList := flow.IdentityList{myIdentity, collection1Identity, collection2Identity, collection3Identity}
+	identityList.Sort(order.Canonical)
 
 	executionState.On("DiskSize").Return(int64(1024*1024), nil).Maybe()
 
@@ -189,6 +194,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 		snapshot:            snapshot,
 		identity:            myIdentity,
 		broadcastedReceipts: make(map[flow.Identifier]*flow.ExecutionReceipt),
+		identities:          identityList,
 	})
 
 	<-engine.Done()
@@ -334,7 +340,8 @@ func (ctx testingContext) mockSnapshot(header *flow.Header, identities flow.Iden
 
 func (ctx testingContext) mockSnapshotWithBlockID(blockID flow.Identifier, identities flow.IdentityList) {
 	cluster := new(protocol.Cluster)
-	cluster.On("Members").Return(identities)
+	// filter only collections as cluster members
+	cluster.On("Members").Return(identities.Filter(filter.HasRole(flow.RoleCollection)))
 
 	epoch := new(protocol.Epoch)
 	epoch.On("ClusterByChainID", mock.Anything).Return(cluster, nil)
@@ -706,18 +713,24 @@ func TestBlocksArentExecutedMultipleTimes_collectionArrival(t *testing.T) {
 		// It should rather not occur during normal execution because StartState won't be set
 		// before parent has finished, but we should handle this edge case that it is set as well.
 
-		// A <- B <- C <- D
+		// A (0 collection) <- B (0 collection) <- C (0 collection) <- D (1 collection)
 		blockA := unittest.BlockHeaderFixture()
 		blockB := unittest.ExecutableBlockFixtureWithParent(nil, &blockA)
 		blockB.StartState = unittest.StateCommitmentPointerFixture()
 
-		colSigner := unittest.IdentifierFixture()
+		collectionIdentities := ctx.identities.Filter(filter.HasRole(flow.RoleCollection))
+		colSigner := collectionIdentities[0].ID()
 		blockC := unittest.ExecutableBlockFixtureWithParent([][]flow.Identifier{{colSigner}}, blockB.Block.Header)
 		blockC.StartState = blockB.StartState //blocks are empty, so no state change is expected
 		// the default fixture uses a 10 collectors committee, but in this test case, there are only 4,
 		// so we need to update the signer indices.
 		// set the first identity as signer
-		blockC.Block.Payload.Guarantees[0].SignerIndices = unittest.SignerIndicesByIndices(4, []int{0})
+		log.Info().Msgf("canonical collection list %v", collectionIdentities.NodeIDs())
+		log.Info().Msgf("full list %v", ctx.identities)
+		indices, err :=
+			signature.EncodeSignersToIndices(collectionIdentities.NodeIDs(), []flow.Identifier{colSigner})
+		require.NoError(t, err)
+		blockC.Block.Payload.Guarantees[0].SignerIndices = indices
 
 		// block D to make sure execution resumes after block C multiple execution has been prevented
 		blockD := unittest.ExecutableBlockFixtureWithParent(nil, blockC.Block.Header)
@@ -737,10 +750,12 @@ func TestBlocksArentExecutedMultipleTimes_collectionArrival(t *testing.T) {
 		wg := sync.WaitGroup{}
 		ctx.mockStateCommitsWithMap(commits)
 
-		ctx.mockSnapshotWithBlockID(unittest.FixedReferenceBlockID(), unittest.IdentityListFixture(1))
-		ctx.mockSnapshot(blockB.Block.Header, unittest.IdentityListFixture(1))
-		ctx.mockSnapshot(blockC.Block.Header, unittest.IdentityListFixture(1))
-		ctx.mockSnapshot(blockD.Block.Header, unittest.IdentityListFixture(1))
+		// mock the cluster canonical list at the collection guarantee's reference block
+		// use the same canonical list as used for building signer indices
+		ctx.mockSnapshotWithBlockID(unittest.FixedReferenceBlockID(), ctx.identities)
+		ctx.mockSnapshot(blockB.Block.Header, ctx.identities)
+		ctx.mockSnapshot(blockC.Block.Header, ctx.identities)
+		ctx.mockSnapshot(blockD.Block.Header, ctx.identities)
 
 		ctx.state.On("Sealed").Return(ctx.snapshot)
 		ctx.snapshot.On("Head").Return(&blockA, nil)
@@ -794,7 +809,7 @@ func TestBlocksArentExecutedMultipleTimes_collectionArrival(t *testing.T) {
 		}).Times(1)
 
 		wg.Add(1) // wait for block B to be executed
-		err := ctx.engine.handleBlock(context.Background(), blockB.Block)
+		err = ctx.engine.handleBlock(context.Background(), blockB.Block)
 		require.NoError(t, err)
 
 		wg.Add(1) // wait for block C to be executed

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1329,19 +1329,23 @@ func setupClusterGenesisBlockQCs(nClusters uint, epochCounter uint64, confs []Co
 		}
 
 		// gather cluster participants
-		clusterCommittee := make([]bootstrap.NodeInfo, 0, len(cluster))
+		clusterNodeInfos := make([]bootstrap.NodeInfo, 0, len(cluster))
 		for _, conf := range confs {
 			_, exists := lookup[conf.NodeID]
 			if exists {
-				clusterCommittee = append(clusterCommittee, conf.NodeInfo)
+				clusterNodeInfos = append(clusterNodeInfos, conf.NodeInfo)
 			}
 		}
-		if len(cluster) != len(clusterCommittee) { // sanity check
+		if len(cluster) != len(clusterNodeInfos) { // sanity check
 			return nil, nil, nil, fmt.Errorf("requiring a node info for each cluster participant")
 		}
 
 		// generate qc for root cluster block
-		qc, err := run.GenerateClusterRootQC(clusterCommittee, bootstrap.ToIdentityList(clusterCommittee), block)
+		fmt.Println("clusterNodeInfos", clusterNodeInfos)
+		clusterCommittee := bootstrap.ToIdentityList(clusterNodeInfos)
+		// must order in canonical ordering otherwise decoding signer indices from cluster QC would fail
+		clusterCommittee.Sort(order.Canonical)
+		qc, err := run.GenerateClusterRootQC(clusterNodeInfos, clusterCommittee, block)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1112,7 +1112,7 @@ func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string) (*Bootstra
 		members := clusterAssignments[i]
 		signerIDs, err := signature.DecodeSignerIndicesToIdentifiers(members, clusterQC.SignerIndices)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not decode cluster QC signer indices: %w", err)
 		}
 		qcsWithSignerIDs = append(qcsWithSignerIDs, &flow.QuorumCertificateWithSignerIDs{
 			View:      clusterQC.View,

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -44,6 +44,7 @@ import (
 	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/network/p2p/keyutils"
 	clusterstate "github.com/onflow/flow-go/state/cluster"
+	"github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/inmem"
 	"github.com/onflow/flow-go/utils/io"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -1196,6 +1197,11 @@ func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string) (*Bootstra
 	snapshot, err := inmem.SnapshotFromBootstrapState(root, result, seal, qc)
 	if err != nil {
 		return nil, fmt.Errorf("could not create bootstrap state snapshot: %w", err)
+	}
+
+	err = badger.IsValidRootSnapshotQCs(snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("invalid root snapshot qcs: %w", err)
 	}
 
 	err = WriteJSON(filepath.Join(bootstrapDir, bootstrap.PathRootProtocolStateSnapshot), snapshot.Encodable())

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1308,7 +1308,8 @@ func runDKG(confs []ContainerConfig) (dkgmod.DKGData, error) {
 //   * a cluster-specific root QC
 func setupClusterGenesisBlockQCs(nClusters uint, epochCounter uint64, confs []ContainerConfig) ([]*cluster.Block, flow.AssignmentList, []*flow.QuorumCertificate, error) {
 
-	participants := toParticipants(confs)
+	participantsUnsorted := toParticipants(confs)
+	participants := participantsUnsorted.Sort(order.Canonical)
 	collectors := participants.Filter(filter.HasRole(flow.RoleCollection))
 	assignments := unittest.ClusterAssignment(nClusters, collectors)
 	clusters, err := factory.NewClusterList(assignments, collectors)

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1343,9 +1343,8 @@ func setupClusterGenesisBlockQCs(nClusters uint, epochCounter uint64, confs []Co
 
 		// generate qc for root cluster block
 		fmt.Println("clusterNodeInfos", clusterNodeInfos)
-		clusterCommittee := bootstrap.ToIdentityList(clusterNodeInfos)
 		// must order in canonical ordering otherwise decoding signer indices from cluster QC would fail
-		clusterCommittee.Sort(order.Canonical)
+		clusterCommittee := bootstrap.ToIdentityList(clusterNodeInfos).Sort(order.Canonical)
 		qc, err := run.GenerateClusterRootQC(clusterNodeInfos, clusterCommittee, block)
 		if err != nil {
 			return nil, nil, nil, err

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1341,13 +1341,12 @@ func setupClusterGenesisBlockQCs(nClusters uint, epochCounter uint64, confs []Co
 			return nil, nil, nil, fmt.Errorf("requiring a node info for each cluster participant")
 		}
 
-		// generate qc for root cluster block
-		fmt.Println("clusterNodeInfos", clusterNodeInfos)
 		// must order in canonical ordering otherwise decoding signer indices from cluster QC would fail
 		clusterCommittee := bootstrap.ToIdentityList(clusterNodeInfos).Sort(order.Canonical)
 		qc, err := run.GenerateClusterRootQC(clusterNodeInfos, clusterCommittee, block)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, fmt.Errorf("fail to generate cluster root QC with clusterNodeInfos %v, %w",
+				clusterNodeInfos, err)
 		}
 
 		// add block and qc to list

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1323,19 +1323,19 @@ func setupClusterGenesisBlockQCs(nClusters uint, epochCounter uint64, confs []Co
 		}
 
 		// gather cluster participants
-		participants := make([]bootstrap.NodeInfo, 0, len(cluster))
+		clusterCommittee := make([]bootstrap.NodeInfo, 0, len(cluster))
 		for _, conf := range confs {
 			_, exists := lookup[conf.NodeID]
 			if exists {
-				participants = append(participants, conf.NodeInfo)
+				clusterCommittee = append(clusterCommittee, conf.NodeInfo)
 			}
 		}
-		if len(cluster) != len(participants) { // sanity check
+		if len(cluster) != len(clusterCommittee) { // sanity check
 			return nil, nil, nil, fmt.Errorf("requiring a node info for each cluster participant")
 		}
 
 		// generate qc for root cluster block
-		qc, err := run.GenerateClusterRootQC(participants, bootstrap.ToIdentityList(participants), block)
+		qc, err := run.GenerateClusterRootQC(clusterCommittee, bootstrap.ToIdentityList(clusterCommittee), block)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/integration/tests/consensus/inclusion_test.go
+++ b/integration/tests/consensus/inclusion_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onflow/flow-go/integration/tests/lib"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
+	"github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -121,7 +122,10 @@ func (is *InclusionSuite) TestCollectionGuaranteeIncluded() {
 	// generate a sentinel collection guarantee
 	sentinel := unittest.CollectionGuaranteeFixture()
 	// there is only one collection node in the cluster
-	sentinel.SignerIndices = unittest.SignerIndicesByIndices(1, []int{0})
+	clusterCommittee := flow.IdentifierList{is.collID}
+	signerIndices, err := signature.EncodeSignersToIndices(clusterCommittee, clusterCommittee)
+	require.NoError(t, err)
+	sentinel.SignerIndices = signerIndices
 	sentinel.ReferenceBlockID = is.net.Root().ID()
 	sentinel.ChainID = is.net.BootstrapData.ClusterRootBlocks[0].Header.ChainID
 	colID := sentinel.CollectionID

--- a/model/flow/order/identity.go
+++ b/model/flow/order/identity.go
@@ -24,3 +24,19 @@ func ByReferenceOrder(nodeIDs []flow.Identifier) func(*flow.Identity, *flow.Iden
 		return indices[identity1.NodeID] < indices[identity2.NodeID]
 	}
 }
+
+func IdentityListCanonical(identities flow.IdentityList) bool {
+	if len(identities) == 0 {
+		return true
+	}
+
+	prev := identities[0].ID()
+	for i := 1; i < len(identities); i++ {
+		id := identities[i].ID()
+		if !IdentifierCanonical(prev, id) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/model/flow/order/identity.go
+++ b/model/flow/order/identity.go
@@ -36,6 +36,7 @@ func IdentityListCanonical(identities flow.IdentityList) bool {
 		if !IdentifierCanonical(prev, id) {
 			return false
 		}
+		prev = id
 	}
 
 	return true

--- a/module/signature/checksum.go
+++ b/module/signature/checksum.go
@@ -67,11 +67,10 @@ func SplitCheckSum(checkSumPrefixedSignerIndices []byte) ([CheckSumLen]byte, []b
 	return sum, signerIndices, nil
 }
 
-// CompareAndExtract reads the checksum from the given checkSumPrefixedSIgnerIndices
+// CompareAndExtract reads the checksum from the given checkSumPrefixedSignerIndices
 // bytes, and compare with the checksum of the given identifier list.
 // it returns the signer indices if the checksum matches.
-// it returns error if splitting the checksum fails or
-// 										 the splitted checksum doesn't match
+// it returns error if splitting the checksum fails or the splitted checksum doesn't match
 // - canonicalList is the canonical list from decoder's view
 // - checkSumPrefixedSignerIndices is the signer indices created by the encoder,
 //   and prefixed with the checksum of the canonical list from encoder's view.

--- a/module/signature/checksum.go
+++ b/module/signature/checksum.go
@@ -1,24 +1,74 @@
 package signature
 
 import (
-	"crypto/md5"
+	"bytes"
+	"fmt"
 
 	"github.com/onflow/flow-go/model/flow"
 )
 
 // CheckSumLen is fixed to be 16 bytes, which is also md5.Size
-const CheckSumLen = 16
+const CheckSumLen = 32
 
 // CheckSumFromIdentities returns checksum for the given identities
 func CheckSumFromIdentities(identities []flow.Identifier) [CheckSumLen]byte {
-	return md5.Sum(EncodeIdentities(identities))
+	return flow.MakeID(EncodeIdentities(identities))
 }
 
 // EncodeIdentities will concatenation all the identities into bytes
 func EncodeIdentities(identities []flow.Identifier) []byte {
+	// a simple concatenation is determinsitic, since each identifier has fixed length.
 	encoded := make([]byte, len(identities)*flow.IdentifierLen)
 	for i, id := range identities {
 		copy(encoded[i*flow.IdentifierLen:(i+1)*flow.IdentifierLen], id[:])
 	}
 	return encoded
+}
+
+// PrefixCheckSum prefix the given data with the checksum of the given identifier list
+func PrefixCheckSum(identities []flow.Identifier, data []byte) []byte {
+	sum := CheckSumFromIdentities(identities)
+	prefixed := make([]byte, len(sum)+len(data))
+	copy(prefixed[0:len(sum)], sum[:])
+	copy(prefixed[len(sum):], data[:])
+	return prefixed
+}
+
+// SplitCheckSum splits the given bytes into two parts: prefixed checksum of the identifier list
+// and the data.
+func SplitCheckSum(prefixed []byte) ([CheckSumLen]byte, []byte, error) {
+	if len(prefixed) < CheckSumLen {
+		return [CheckSumLen]byte{}, nil,
+			fmt.Errorf("expect at least %v bytes, but got %v", CheckSumLen, len(prefixed))
+	}
+
+	var sum [CheckSumLen]byte
+	copy(sum[:], prefixed[:CheckSumLen])
+	data := prefixed[CheckSumLen:]
+	return sum, data, nil
+}
+
+// CompareChecksum compares if the given checksum matches with the checksum of the given identifier list
+func CompareChecksum(sum [CheckSumLen]byte, identities []flow.Identifier) bool {
+	computedSum := CheckSumFromIdentities(identities)
+	return bytes.Equal(sum[:], computedSum[:])
+}
+
+// CompareAndExtract reads the checksum from the given prefixed data bytes, and compare with the checksum
+// of the given identifier list.
+// it returns the data if the checksum matches.
+// it returns error if the checksum doesn't match
+func CompareAndExtract(identities []flow.Identifier, prefixed []byte) ([]byte, error) {
+	// the prefixed bytes contains both the checksum and the signer indices, split them
+	sum, data, err := SplitCheckSum(prefixed)
+	if err != nil {
+		return nil, fmt.Errorf("could not split checksum: %w", err)
+	}
+
+	match := CompareChecksum(sum, identities)
+	if !match {
+		return nil, fmt.Errorf("data %v does not match with checksum %v", data, sum)
+	}
+
+	return data, nil
 }

--- a/module/signature/checksum.go
+++ b/module/signature/checksum.go
@@ -2,6 +2,7 @@ package signature
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"hash/crc32"
 
@@ -16,12 +17,9 @@ func checksum(data []byte) [CheckSumLen]byte {
 	// crc32 is enough
 	sum := crc32.ChecksumIEEE(data)
 	// converting the uint32 checksum value into [4]byte
-	return [CheckSumLen]byte{
-		byte(sum >> 24),
-		byte(sum >> 16),
-		byte(sum >> 8),
-		byte(sum),
-	}
+	var sumBytes [CheckSumLen]byte
+	binary.BigEndian.PutUint32(sumBytes[:], sum)
+	return sumBytes
 }
 
 // CheckSumFromIdentities returns checksum for the given identities

--- a/module/signature/checksum.go
+++ b/module/signature/checksum.go
@@ -3,15 +3,25 @@ package signature
 import (
 	"bytes"
 	"fmt"
+	"hash/crc32"
 
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// CheckSumLen is fixed to be 16 bytes, which is also md5.Size
-const CheckSumLen = 32
+// CheckSumLen is fixed to be 4 bytes
+const CheckSumLen = 4
 
 func checksum(data []byte) [CheckSumLen]byte {
-	return flow.MakeID(data)
+	// since the checksum is only for detecting honest mistake,
+	// crc32 is enough
+	sum := crc32.ChecksumIEEE(data)
+	// converting the uint32 checksum value into [4]byte
+	return [CheckSumLen]byte{
+		byte(sum >> 24),
+		byte(sum >> 16),
+		byte(sum >> 8),
+		byte(sum),
+	}
 }
 
 // CheckSumFromIdentities returns checksum for the given identities

--- a/module/signature/checksum.go
+++ b/module/signature/checksum.go
@@ -67,7 +67,7 @@ func CompareAndExtract(identities []flow.Identifier, prefixed []byte) ([]byte, e
 
 	match := CompareChecksum(sum, identities)
 	if !match {
-		return nil, fmt.Errorf("data %v does not match with checksum %v", data, sum)
+		return nil, fmt.Errorf("data %x does not match with checksum %x", data, sum)
 	}
 
 	return data, nil

--- a/module/signature/checksum.go
+++ b/module/signature/checksum.go
@@ -1,0 +1,24 @@
+package signature
+
+import (
+	"crypto/md5"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// CheckSumLen is fixed to be 16 bytes, which is also md5.Size
+const CheckSumLen = 16
+
+// CheckSumFromIdentities returns checksum for the given identities
+func CheckSumFromIdentities(identities []flow.Identifier) [CheckSumLen]byte {
+	return md5.Sum(EncodeIdentities(identities))
+}
+
+// EncodeIdentities will concatenation all the identities into bytes
+func EncodeIdentities(identities []flow.Identifier) []byte {
+	encoded := make([]byte, len(identities)*flow.IdentifierLen)
+	for i, id := range identities {
+		copy(encoded[i*flow.IdentifierLen:(i+1)*flow.IdentifierLen], id[:])
+	}
+	return encoded
+}

--- a/module/signature/checksum_test.go
+++ b/module/signature/checksum_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+// Test that the CheckSumFromIdentities method is able to produce checksum for empty identity list,
+// and produce the correct checksum
 func TestCheckSum(t *testing.T) {
 	t.Run("no identity", func(t *testing.T) {
 		require.Equal(t, signature.CheckSumFromIdentities(nil), signature.CheckSumFromIdentities(nil))
@@ -42,6 +44,9 @@ func TestCheckSum(t *testing.T) {
 	})
 }
 
+// Test that if an encoder generates a checksum with a committee and added to some random data
+// using PrefixCheckSum method, then an decoder using the same committee to call CompareAndExtract
+// is able to extract the same data as the encoder.
 func TestPrefixCheckSum(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		committeeSize := rapid.IntRange(0, 300).Draw(t, "committeeSize").(int)

--- a/module/signature/checksum_test.go
+++ b/module/signature/checksum_test.go
@@ -32,7 +32,7 @@ func TestCheckSum(t *testing.T) {
 		require.NotEqual(t, signature.CheckSumFromIdentities(ids[:2]), signature.CheckSumFromIdentities(ids[2:])) // no overlap
 	})
 
-	t.Run("checksum length always 16", func(t *testing.T) {
+	t.Run("checksum length always constant", func(t *testing.T) {
 		ids := unittest.IdentifierListFixture(4)
 		require.Len(t, signature.CheckSumFromIdentities(nil), signature.CheckSumLen)
 		require.Len(t, signature.CheckSumFromIdentities(ids), signature.CheckSumLen)

--- a/module/signature/checksum_test.go
+++ b/module/signature/checksum_test.go
@@ -1,40 +1,56 @@
-package signature
+package signature_test
 
 import (
 	"testing"
 
-	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/signature"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestCheckSum(t *testing.T) {
 	t.Run("no identity", func(t *testing.T) {
-		require.Equal(t, CheckSumFromIdentities(nil), CheckSumFromIdentities(nil))
-		require.Equal(t, CheckSumFromIdentities([]flow.Identifier{}), CheckSumFromIdentities([]flow.Identifier{}))
-		require.Equal(t, CheckSumFromIdentities(nil), CheckSumFromIdentities([]flow.Identifier{}))
+		require.Equal(t, signature.CheckSumFromIdentities(nil), signature.CheckSumFromIdentities(nil))
+		require.Equal(t, signature.CheckSumFromIdentities([]flow.Identifier{}), signature.CheckSumFromIdentities([]flow.Identifier{}))
+		require.Equal(t, signature.CheckSumFromIdentities(nil), signature.CheckSumFromIdentities([]flow.Identifier{}))
 	})
 
 	t.Run("same identities, same checksum", func(t *testing.T) {
 		ids := unittest.IdentifierListFixture(3)
-		require.Equal(t, CheckSumFromIdentities(ids), CheckSumFromIdentities(ids))
-		require.Equal(t, CheckSumFromIdentities(ids[1:]), CheckSumFromIdentities(ids[1:]))
-		require.Equal(t, CheckSumFromIdentities(ids[2:]), CheckSumFromIdentities(ids[2:]))
+		require.Equal(t, signature.CheckSumFromIdentities(ids), signature.CheckSumFromIdentities(ids))
+		require.Equal(t, signature.CheckSumFromIdentities(ids[1:]), signature.CheckSumFromIdentities(ids[1:]))
+		require.Equal(t, signature.CheckSumFromIdentities(ids[2:]), signature.CheckSumFromIdentities(ids[2:]))
 	})
 
 	t.Run("different identities, different checksum", func(t *testing.T) {
 		ids := unittest.IdentifierListFixture(4)
-		require.NotEqual(t, CheckSumFromIdentities(ids), CheckSumFromIdentities(ids[1:]))     // subset
-		require.NotEqual(t, CheckSumFromIdentities(ids[1:]), CheckSumFromIdentities(ids[:2])) // overlap
-		require.NotEqual(t, CheckSumFromIdentities(ids[:2]), CheckSumFromIdentities(ids[2:])) // no overlap
+		require.NotEqual(t, signature.CheckSumFromIdentities(ids), signature.CheckSumFromIdentities(ids[1:]))     // subset
+		require.NotEqual(t, signature.CheckSumFromIdentities(ids[1:]), signature.CheckSumFromIdentities(ids[:2])) // overlap
+		require.NotEqual(t, signature.CheckSumFromIdentities(ids[:2]), signature.CheckSumFromIdentities(ids[2:])) // no overlap
 	})
 
 	t.Run("checksum length always 16", func(t *testing.T) {
 		ids := unittest.IdentifierListFixture(4)
-		require.Len(t, CheckSumFromIdentities(nil), CheckSumLen)
-		require.Len(t, CheckSumFromIdentities(ids), CheckSumLen)
-		require.Len(t, CheckSumFromIdentities(ids[1:]), CheckSumLen)
-		require.Len(t, CheckSumFromIdentities(ids[2:]), CheckSumLen)
-		require.Len(t, CheckSumFromIdentities(ids[3:]), CheckSumLen)
+		require.Len(t, signature.CheckSumFromIdentities(nil), signature.CheckSumLen)
+		require.Len(t, signature.CheckSumFromIdentities(ids), signature.CheckSumLen)
+		require.Len(t, signature.CheckSumFromIdentities(ids[1:]), signature.CheckSumLen)
+		require.Len(t, signature.CheckSumFromIdentities(ids[2:]), signature.CheckSumLen)
+		require.Len(t, signature.CheckSumFromIdentities(ids[3:]), signature.CheckSumLen)
+	})
+}
+
+func TestPrefixCheckSum(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		committeeSize := rapid.IntRange(0, 300).Draw(t, "committeeSize").(int)
+		committee := unittest.IdentifierListFixture(committeeSize)
+		data := rapid.IntRange(0, 200).Map(func(count int) []byte {
+			return unittest.RandomBytes(count)
+		}).Draw(t, "data").([]byte)
+		extracted, err := signature.CompareAndExtract(committee, signature.PrefixCheckSum(committee, data))
+		require.NoError(t, err)
+		require.Equal(t, data, extracted)
 	})
 }

--- a/module/signature/checksum_test.go
+++ b/module/signature/checksum_test.go
@@ -1,0 +1,40 @@
+package signature
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckSum(t *testing.T) {
+	t.Run("no identity", func(t *testing.T) {
+		require.Equal(t, CheckSumFromIdentities(nil), CheckSumFromIdentities(nil))
+		require.Equal(t, CheckSumFromIdentities([]flow.Identifier{}), CheckSumFromIdentities([]flow.Identifier{}))
+		require.Equal(t, CheckSumFromIdentities(nil), CheckSumFromIdentities([]flow.Identifier{}))
+	})
+
+	t.Run("same identities, same checksum", func(t *testing.T) {
+		ids := unittest.IdentifierListFixture(3)
+		require.Equal(t, CheckSumFromIdentities(ids), CheckSumFromIdentities(ids))
+		require.Equal(t, CheckSumFromIdentities(ids[1:]), CheckSumFromIdentities(ids[1:]))
+		require.Equal(t, CheckSumFromIdentities(ids[2:]), CheckSumFromIdentities(ids[2:]))
+	})
+
+	t.Run("different identities, different checksum", func(t *testing.T) {
+		ids := unittest.IdentifierListFixture(4)
+		require.NotEqual(t, CheckSumFromIdentities(ids), CheckSumFromIdentities(ids[1:]))     // subset
+		require.NotEqual(t, CheckSumFromIdentities(ids[1:]), CheckSumFromIdentities(ids[:2])) // overlap
+		require.NotEqual(t, CheckSumFromIdentities(ids[:2]), CheckSumFromIdentities(ids[2:])) // no overlap
+	})
+
+	t.Run("checksum length always 16", func(t *testing.T) {
+		ids := unittest.IdentifierListFixture(4)
+		require.Len(t, CheckSumFromIdentities(nil), CheckSumLen)
+		require.Len(t, CheckSumFromIdentities(ids), CheckSumLen)
+		require.Len(t, CheckSumFromIdentities(ids[1:]), CheckSumLen)
+		require.Len(t, CheckSumFromIdentities(ids[2:]), CheckSumLen)
+		require.Len(t, CheckSumFromIdentities(ids[3:]), CheckSumLen)
+	})
+}

--- a/module/signature/signer_indices.go
+++ b/module/signature/signer_indices.go
@@ -57,6 +57,9 @@ import (
 //    - Again, we right-pad with zeros to full bytes, As we only had 7 signers, the sigType slice is 1byte long
 //             01011110
 //
+// the signer indices is prefixed with a checksum of the canonicalIdentifiers, which can be used by the decoder
+// to verify if the decoder is using the same canonicalIdentifiers as the encoder to decode the signer indices.
+//
 // ERROR RETURNS
 // During normal operations, no error returns are expected. This is because encoding signer sets is generally
 // part of the node's internal work to generate messages. Hence, the inputs to this method come from other
@@ -104,7 +107,9 @@ func EncodeSignerToIndicesAndSigType(
 		return nil, nil, fmt.Errorf("unknown or duplicated beacon signers %v", beaconSignersLookup)
 	}
 
-	return signerIndices, sigTypes, nil
+	prefixed := PrefixCheckSum(canonicalIdentifiers, signerIndices)
+
+	return prefixed, sigTypes, nil
 }
 
 // DecodeSigTypeToStakingAndBeaconSigners decodes the bit-vector `sigType` to the set of
@@ -173,6 +178,8 @@ func DecodeSigTypeToStakingAndBeaconSigners(
 // identities who are ineligible to sign the given resource. For example, canonicalIdentifiers in the context
 // of a cluster consensus quorum certificate would include authorized members of the cluster and
 // exclude ejected members of the cluster, or unejected collection nodes from a different cluster.
+// the signer indices is prefixed with a checksum of the canonicalIdentifiers, which can be used by the decoder
+// to verify if the decoder is using the same canonicalIdentifiers as the encoder to decode the signer indices.
 func EncodeSignersToIndices(
 	canonicalIdentifiers flow.IdentifierList,
 	signerIDs flow.IdentifierList,
@@ -194,7 +201,9 @@ func EncodeSignersToIndices(
 		return nil, fmt.Errorf("unknown signers %v", signersLookup)
 	}
 
-	return signerIndices, nil
+	prefixed := PrefixCheckSum(canonicalIdentifiers, signerIndices)
+
+	return prefixed, nil
 }
 
 // DecodeSignerIndicesToIdentifiers decodes the given compacted bit vector into signerIDs
@@ -206,10 +215,19 @@ func EncodeSignersToIndices(
 //  * IllegallyPaddedIndexSliceError is the vector is padded with bits other than 0
 func DecodeSignerIndicesToIdentifiers(
 	canonicalIdentifiers flow.IdentifierList,
-	signerIndices []byte,
+	prefixed []byte,
 ) (flow.IdentifierList, error) {
+	// the prefixed contains the checksum of the canonicalIdentifiers that the signerIndices
+	// creator saw.
+	// extract the checksum and compare with the canonicalIdentifiers to see if both
+	// the signerIndices creator and validator see the same list.
+	signerIndices, err := CompareAndExtract(canonicalIdentifiers, prefixed)
+	if err != nil {
+		return nil, fmt.Errorf("could not extract signer indices from prefixed data: %w", err)
+	}
+
 	numberCanonicalNodes := len(canonicalIdentifiers)
-	err := validPadding(signerIndices, numberCanonicalNodes)
+	err = validPadding(signerIndices, numberCanonicalNodes)
 	if err != nil {
 		return nil, fmt.Errorf("signerIndices are invalid: %w", err)
 	}
@@ -233,8 +251,17 @@ func DecodeSignerIndicesToIdentifiers(
 //  * IllegallyPaddedIndexSliceError is the vector is padded with bits other than 0
 func DecodeSignerIndicesToIdentities(
 	canonicalIdentities flow.IdentityList,
-	signerIndices []byte,
+	prefixed []byte,
 ) (flow.IdentityList, error) {
+	// the prefixed contains the checksum of the canonicalIdentifiers that the signerIndices
+	// creator saw.
+	// extract the checksum and compare with the canonicalIdentifiers to see if both
+	// the signerIndices creator and validator see the same list.
+	signerIndices, err := CompareAndExtract(canonicalIdentities.NodeIDs(), prefixed)
+	if err != nil {
+		return nil, fmt.Errorf("could not extract signer indices from prefixed data: %w", err)
+	}
+
 	numberCanonicalNodes := len(canonicalIdentities)
 	if e := validPadding(signerIndices, numberCanonicalNodes); e != nil {
 		return nil, fmt.Errorf("signerIndices padding are invalid: %w", e)

--- a/module/signature/signer_indices.go
+++ b/module/signature/signer_indices.go
@@ -198,7 +198,7 @@ func EncodeSignersToIndices(
 		}
 	}
 	if len(signersLookup) > 0 {
-		return nil, fmt.Errorf("unknown signers %v", signersLookup)
+		return nil, fmt.Errorf("unknown signers IDs in the keys of %v", signersLookup)
 	}
 
 	prefixed := PrefixCheckSum(canonicalIdentifiers, signerIndices)


### PR DESCRIPTION
Close https://github.com/dapperlabs/flow-go/issues/6179

This PR adds checksum to signer indices. 

### Why adding checksum?
After using signer indices to replace signer IDs, we lose certain level of debuggability. If we run into invalid QC issue, we can't exclude the case where the Committee.Identities had a bug that not always return the same list for the same block.
The checksum could provide the same debuggability as when signerIDs was used. Since for the above case, it's easy to confirm if the same list of signerIDs were used before matching sig type and verifying the signatures.

### How checksum is added
Checksum is first computed from the canonical list of identities that are used for generating signer indices.
The computed checksum will be prefixed to the generated signer indices, so that the decoder can use it to compare with it's own canonical list to check if both the encoder and decoder see the same canonical identity list