### PR TITLE
Use go 1.18 to build and run binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
       - 'v[0-9]+.[0-9]+'
 
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
 jobs:
   golangci:

--- a/.github/workflows/flaky-test-monitor-integration.yml
+++ b/.github/workflows/flaky-test-monitor-integration.yml
@@ -12,7 +12,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
 jobs:
   generate-flaky-test-summary:

--- a/.github/workflows/flaky-test-monitor.yml
+++ b/.github/workflows/flaky-test-monitor.yml
@@ -10,7 +10,7 @@ on:
 env:
   BIGQUERY_DATASET: production_src_flow_test_metrics
   BIGQUERY_TABLE: test_results
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
 jobs:
   upload-flaky-test-summary:

--- a/.github/workflows/skipped-test-tracker-integration.yml
+++ b/.github/workflows/skipped-test-tracker-integration.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
 jobs:
   generate-skipped-test-summary:

--- a/.github/workflows/skipped-test-tracker.yml
+++ b/.github/workflows/skipped-test-tracker.yml
@@ -8,7 +8,7 @@ on:
 env:
   BIGQUERY_DATASET: production_src_flow_test_metrics
   BIGQUERY_TABLE: skipped_tests
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
 jobs:
   upload-skipped-test-summary:

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 # NOTE: Must be run in the context of the repo's root directory
 
-FROM golang:1.17-bullseye AS build-setup
+FROM golang:1.18-bullseye AS build-setup
 
 RUN apt-get update
 RUN apt-get -y install cmake zip
@@ -56,7 +56,7 @@ RUN --mount=type=ssh \
 
 RUN chmod a+x /app/app
 
-FROM golang:1.17-bullseye as debug
+FROM golang:1.18-bullseye as debug
 
 RUN go get -u github.com/go-delve/delve/cmd/dlv
 

--- a/crypto/Dockerfile
+++ b/crypto/Dockerfile
@@ -1,6 +1,6 @@
 # gcr.io/dl-flow/golang-cmake
 
-FROM golang:1.17-buster
+FROM golang:1.18-buster
 RUN apt-get update
 RUN apt-get -y install cmake zip
 RUN go get github.com/axw/gocov/gocov

--- a/integration/loader/Dockerfile
+++ b/integration/loader/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 # NOTE: Must be run in the context of the repo's root directory
 
-FROM golang:1.17-buster AS build-setup
+FROM golang:1.18-buster AS build-setup
 
 RUN apt-get update
 RUN apt-get -y install cmake zip


### PR DESCRIPTION
Recently, had a discussion about moving up to 1.18, as there are some optimizations, plus enables the ability to explore generics for future features.