### PR TITLE
Outdated blocks should not be logged as errors

### DIFF
--- a/state/protocol/state.go
+++ b/state/protocol/state.go
@@ -45,6 +45,9 @@ type MutableState interface {
 	// still checking that the given block is a valid extension of the protocol
 	// state. Depending on implementation it might be a lighter version that checks only
 	// block header.
+	// Expected errors during normal operations:
+	//  * state.OutdatedExtensionError if the candidate block is outdated (e.g. orphaned)
+	//  * state.InvalidExtensionError if the candidate block is invalid
 	Extend(ctx context.Context, candidate *flow.Block) error
 
 	// Finalize finalizes the block with the given hash.


### PR DESCRIPTION
Conceptually, this is expected during normal operations that some _other_ node has fallen behind and sending outdated messages, such as block proposals.  Despite this being an expected scenario, outdated blocks as logged as errors ([code](https://github.com/onflow/flow-go/blob/f93a31395b2b780f2cbabba1c5303e2fe43d745b/engine/common/follower/engine.go#L349-L357): errors are bubbled up the call stack, where they arrive at the networking layer, which just logs them.) We have seen that such harmless conditions can be distracting during incidents [slack](https://axiomzen.slack.com/archives/CEEGK3HGC/p1651601982120259?thread_ts=1651599613.010539&cid=CEEGK3HGC) potentially sending engineers down the wrong rabbit hole. 

This PR attempts a preliminary fix and only handle this particular case of outdated blocks. Generally, the Flower engine is older code which lacks adequate error handling, including the protocol. So there is much more work beyond this PR. 
