### PR TITLE
[FVM] Merge default execution/memory weights and state weights

### DIFF
--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -151,7 +151,15 @@ func getExecutionEffortWeights(
 			blueprints.TransactionFeesExecutionEffortWeightsPathIdentifier)
 	}
 
+	// Merge the default weights with the weights from the state.
+	// This allows for weights that are not set in the state, to be set by default.
+	// In case the network is stuck because of a transaction using an FVM feature that has 0 weight
+	// (or is not metered at all), the defaults can be changed and the network restarted
+	// instead of trying to change the weights with a transaction.
 	computationWeights = make(weighted.ExecutionEffortWeights)
+	for k, v := range weighted.DefaultComputationWeights {
+		computationWeights[k] = v
+	}
 	for k, v := range computationWeightsRaw {
 		computationWeights[common.ComputationKind(k)] = v
 	}
@@ -208,7 +216,15 @@ func getExecutionMemoryWeights(
 			blueprints.TransactionFeesExecutionMemoryWeightsPathIdentifier)
 	}
 
+	// Merge the default weights with the weights from the state.
+	// This allows for weights that are not set in the state, to be set by default.
+	// In case the network is stuck because of a transaction using an FVM feature that has 0 weight
+	// (or is not metered at all), the defaults can be changed and the network restarted
+	// instead of trying to change the weights with a transaction.
 	memoryWeights = make(weighted.ExecutionMemoryWeights)
+	for k, v := range weighted.DefaultMemoryWeights {
+		memoryWeights[k] = v
+	}
 	for k, v := range memoryWeightsRaw {
 		memoryWeights[common.MemoryKind(k)] = v
 	}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -3652,7 +3652,9 @@ func TestSettingExecutionWeights(t *testing.T) {
 		fvm.WithTransactionFee(fvm.DefaultTransactionFees),
 		fvm.WithExecutionEffortWeights(
 			weightedMeter.ExecutionEffortWeights{
-				common.ComputationKindStatement: 1 << weightedMeter.MeterExecutionInternalPrecisionBytes,
+				common.ComputationKindStatement:          1 << weightedMeter.MeterExecutionInternalPrecisionBytes,
+				common.ComputationKindLoop:               0,
+				common.ComputationKindFunctionInvocation: 0,
 			},
 		),
 	).withContextOptions(


### PR DESCRIPTION
This concerns both Memory and Execution weights.

The default weights dictionary is hardcoded in the FVM in `fvm/meter/weighted/meter.go`.
The state weights dictionary is in the service account's storage: https://github.com/onflow/flow-core-contracts/blob/master/transactions/FlowServiceAccount/set_execution_effort_weights.cdc

Current logic is:
- In each transaction
- Check if the weights dictionary in the state exists
- If it does take the dictionary from state
- If not take the default dictionary

The change in this PR is:
- In each transaction
- Check if the weights dictionary in the state exists
- If it does, take the default weights dictionary and update it with all the entries from the state dictionary (merging them)
- If not take the default dictionary

The reasoning behind this is a very special scenario that might occur:
If someone sends a lot of transaction exploiting something that has a 0 weight (or no weight at all) and this causes a crash loop on the execution nodes (at the same height), one way out of this is to update the default weights and redeploy the nodes.