### PR TITLE
changing the block height range for GetEventsForBlockHeightRange REST…

### DIFF
--- a/engine/access/rest/blocks_test.go
+++ b/engine/access/rest/blocks_test.go
@@ -47,7 +47,7 @@ func TestGetBlocks(t *testing.T) {
 	invalidID := unittest.IdentifierFixture().String()
 	invalidHeight := fmt.Sprintf("%d", blkCnt+1)
 
-	maxIDs := flow.IdentifierList(unittest.IdentifierListFixture(request.MaxAllowedHeights + 1))
+	maxIDs := flow.IdentifierList(unittest.IdentifierListFixture(request.MaxAllowedBlockRequestHeightRange + 1))
 
 	testVectors := []testVector{
 		{
@@ -132,7 +132,7 @@ func TestGetBlocks(t *testing.T) {
 			description:      "Get block by more than maximum permissible number of IDs",
 			request:          getByIDsCondensedURL(t, maxIDs.Strings()), // height query param specified with no value
 			expectedStatus:   http.StatusBadRequest,
-			expectedResponse: fmt.Sprintf(`{"code":400, "message": "at most %d IDs can be requested at a time"}`, request.MaxAllowedHeights),
+			expectedResponse: fmt.Sprintf(`{"code":400, "message": "at most %d IDs can be requested at a time"}`, request.MaxAllowedBlockRequestHeightRange),
 		},
 	}
 

--- a/engine/access/rest/request/get_block.go
+++ b/engine/access/rest/request/get_block.go
@@ -9,7 +9,8 @@ import (
 const heightQuery = "height"
 const startHeightQuery = "start_height"
 const endHeightQuery = "end_height"
-const MaxAllowedHeights = 50
+const MaxAllowedBlockRequestHeightRange = 50
+const MaxAllowedEventRequestHeightRange = 250
 const idParam = "id"
 
 type GetBlock struct {
@@ -66,12 +67,12 @@ func (g *GetBlock) Parse(rawHeights []string, rawStart string, rawEnd string) er
 		return fmt.Errorf("start height must be less than or equal to end height")
 	}
 	// check if range exceeds maximum but only if end is not equal to special value which is not known yet
-	if g.EndHeight-g.StartHeight >= MaxAllowedHeights && g.EndHeight != FinalHeight && g.EndHeight != SealedHeight {
-		return fmt.Errorf("height range %d exceeds maximum allowed of %d", g.EndHeight-g.StartHeight, MaxAllowedHeights)
+	if g.EndHeight-g.StartHeight >= MaxAllowedBlockRequestHeightRange && g.EndHeight != FinalHeight && g.EndHeight != SealedHeight {
+		return fmt.Errorf("height range %d exceeds maximum allowed of %d", g.EndHeight-g.StartHeight, MaxAllowedBlockRequestHeightRange)
 	}
 
-	if len(heights) > MaxAllowedHeights {
-		return fmt.Errorf("at most %d heights can be requested at a time", MaxAllowedHeights)
+	if len(heights) > MaxAllowedBlockRequestHeightRange {
+		return fmt.Errorf("at most %d heights can be requested at a time", MaxAllowedBlockRequestHeightRange)
 	}
 
 	// check that if sealed or final are used they are provided as only value as mix and matching heights with sealed is not encouraged

--- a/engine/access/rest/request/get_block_test.go
+++ b/engine/access/rest/request/get_block_test.go
@@ -10,7 +10,7 @@ import (
 func TestGetBlock_InvalidParse(t *testing.T) {
 	var getBlock GetBlock
 
-	tooLong := make([]string, MaxAllowedHeights+1)
+	tooLong := make([]string, MaxAllowedBlockRequestHeightRange+1)
 	for i := range tooLong {
 		tooLong[i] = fmt.Sprintf("%d", i)
 	}

--- a/engine/access/rest/request/get_events.go
+++ b/engine/access/rest/request/get_events.go
@@ -76,8 +76,8 @@ func (g *GetEvents) Parse(rawType string, rawStart string, rawEnd string, rawBlo
 			return fmt.Errorf("start height must be less than or equal to end height")
 		}
 		// check if range exceeds maximum but only if end is not equal to special value which is not known yet
-		if g.EndHeight-g.StartHeight >= MaxAllowedHeights && g.EndHeight != FinalHeight && g.EndHeight != SealedHeight {
-			return fmt.Errorf("height range %d exceeds maximum allowed of %d", g.EndHeight-g.StartHeight, MaxAllowedHeights)
+		if g.EndHeight-g.StartHeight >= MaxAllowedEventRequestHeightRange && g.EndHeight != FinalHeight && g.EndHeight != SealedHeight {
+			return fmt.Errorf("height range %d exceeds maximum allowed of %d", g.EndHeight-g.StartHeight, MaxAllowedEventRequestHeightRange)
 		}
 	}
 


### PR DESCRIPTION
… API call to match with the gRPC range limit

It was [reported](https://github.com/onflow/fcl-js/issues/1135#) that the GetEventForBlockHeight REST API call had a different limit than the one for the equivalent gRPC call.

I [found](https://github.com/onflow/fcl-js/issues/1135#issuecomment-1119849049) that the block height range limit for the REST API was 50 while the one for the gRPC API was 250.

This change does the following:
1. Separate out the range limits for the GetEventsForBlockHeight and GetBlocks REST API calls.
2. Define the limit for the `GetEventsForBlockHeight` as 250 (independently of the gRPC API constant incase it is needed to make the height ranges for REST and gRPC different in the future)

