### PR TITLE
[Collection] Log collection proposer

### DIFF
--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -89,7 +89,9 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Clus
 		Uint64("block_view", header.View).
 		Hex("block_id", logging.Entity(header)).
 		Hex("parent_id", header.ParentID[:]).
-		Hex("payload_hash", header.PayloadHash[:]).
+		Hex("ref_block_id", proposal.Payload.ReferenceBlockID[:]).
+		Hex("collection_id", logging.Entity(proposal.Payload.Collection)).
+		Int("tx_count", proposal.Payload.Collection.Len()).
 		Time("timestamp", header.Timestamp).
 		Hex("proposer", header.ProposerID[:]).
 		Int("num_signers", len(header.ParentVoterIDs)).


### PR DESCRIPTION
This PR helps to answer the question: who created the cluster block that later turns into a collection guarantee.

To answer this, we need a log that ties the cluster block ID and the collection guarantee ID, and this PR adds it.