### PR TITLE
Separate permission setting of contract deploy/update and removal

### DIFF
--- a/fvm/blueprints/contracts.go
+++ b/fvm/blueprints/contracts.go
@@ -14,6 +14,9 @@ import (
 const ContractDeploymentAuthorizedAddressesPathDomain = "storage"
 const ContractDeploymentAuthorizedAddressesPathIdentifier = "authorizedAddressesToDeployContracts"
 
+const ContractRemovalAuthorizedAddressesPathDomain = "storage"
+const ContractRemovalAuthorizedAddressesPathIdentifier = "authorizedAddressesToRemoveContracts"
+
 const IsContractDeploymentRestrictedPathDomain = "storage"
 const IsContractDeploymentRestrictedPathIdentifier = "isContractDeploymentRestricted"
 
@@ -36,6 +39,28 @@ func SetContractDeploymentAuthorizersTransaction(serviceAccount flow.Address, au
 	arg2, err := jsoncdc.Encode(cadence.Path{
 		Domain:     ContractDeploymentAuthorizedAddressesPathDomain,
 		Identifier: ContractDeploymentAuthorizedAddressesPathIdentifier,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return flow.NewTransactionBody().
+		SetScript([]byte(setContractDeploymentAuthorizersTransactionTemplate)).
+		AddAuthorizer(serviceAccount).
+		AddArgument(arg1).
+		AddArgument(arg2), nil
+}
+
+// SetContractRemovalAuthorizersTransaction returns a transaction for updating list of authorized accounts allowed to remove contracts
+func SetContractRemovalAuthorizersTransaction(serviceAccount flow.Address, authorized []flow.Address) (*flow.TransactionBody, error) {
+	arg1, err := jsoncdc.Encode(utils.AddressSliceToCadenceValue(utils.FlowAddressSliceToCadenceAddressSlice(authorized)))
+	if err != nil {
+		return nil, err
+	}
+
+	arg2, err := jsoncdc.Encode(cadence.Path{
+		Domain:     ContractRemovalAuthorizedAddressesPathDomain,
+		Identifier: ContractRemovalAuthorizedAddressesPathIdentifier,
 	})
 	if err != nil {
 		return nil, err

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -91,6 +91,7 @@ func NewScriptEnvironment(
 			return true
 		},
 		func() []common.Address { return []common.Address{} },
+		func() []common.Address { return []common.Address{} },
 		func(address runtime.Address, code []byte) (bool, error) { return false, nil })
 
 	if fvmContext.BlockHeader != nil {


### PR DESCRIPTION
Closes https://github.com/dapperlabs/cadence-private-issues/issues/40

Contracts can be deployed, updated, or removed by the service account and accounts it authorizes to do so. That authorization applies to all three operations but we want to permit more fine-grained control: deploy/update and removal should be two separate permissions.

This is somewhat related to https://github.com/onflow/flow-go/pull/2346.