### PR TITLE
Events non-determinism fix

### DIFF
--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/onflow/flow-go/access"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/state/protocol"

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -376,7 +376,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		rt := &testRuntime{
 			executeTransaction: func(script runtime.Script, r runtime.Context) error {
-
+				//nolint:staticcheck // SA1004: ignore
 				program, err := r.Interface.GetProgram(contractLocation)
 				require.NoError(t, err)
 				require.Nil(t, program)
@@ -441,7 +441,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 				executionCalls++
 
 				// NOTE: set a program and revert all transactions but the system chunk transaction
-
+				//nolint:staticcheck // SA1004
 				program, err := r.Interface.GetProgram(contractLocation)
 				require.NoError(t, err)
 

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -305,9 +305,9 @@ func Test_ExecutionMatchesVerification(t *testing.T) {
 
 		// ensure event is emitted
 		require.Empty(t, cr.TransactionResults[0].ErrorMessage)
-		require.Empty(t, cr.TransactionResults[2].ErrorMessage)
-		require.Len(t, cr.Events[0], 4)
-		require.Len(t, cr.Events[2], 4)
+		require.Empty(t, cr.TransactionResults[1].ErrorMessage)
+		require.Len(t, cr.Events[0], 8)
+		require.Len(t, cr.Events[1], 4)
 	})
 }
 

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -2,6 +2,7 @@ package computation
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"testing"
 
@@ -246,7 +247,68 @@ func Test_ExecutionMatchesVerification(t *testing.T) {
 		}
 		require.Equal(t, 3, transactionEvents)
 	})
+	t.Run("with contract deploy and update", func(t *testing.T) {
 
+		deployTx := blueprints.DeployContractTransaction(chain.ServiceAddress(), []byte(""+
+			`pub contract Foo {
+				pub event FooEvent(x: Int, y: Int)
+
+				pub fun event() { 
+					emit FooEvent(x: 2, y: 1)
+				}
+			}`), "Foo")
+
+		emitTx := &flow.TransactionBody{
+			Script: []byte(fmt.Sprintf(`
+			import Foo from 0x%s
+			transaction {
+				prepare() {}
+				execute {
+					Foo.event()
+				}
+			}`, chain.ServiceAddress())),
+		}
+
+		updateTx := flow.NewTransactionBody().SetScript([]byte(fmt.Sprintf(""+
+			`transaction {
+				prepare(signer: AuthAccount) {
+					signer.contracts.update__experimental(name: "%s", code: "%s".decodeHex())
+				}
+			}`, "Foo", hex.EncodeToString([]byte(""+
+			`pub contract Foo {
+				pub event FooEvent(x: Int, y: Int)
+
+				pub fun event2() { 
+					emit FooEvent(x: 2, y: 1)
+				}
+			}
+			`))))).AddAuthorizer(chain.ServiceAddress())
+
+		err := testutil.SignTransactionAsServiceAccount(deployTx, 0, chain)
+		require.NoError(t, err)
+
+		err = testutil.SignTransactionAsServiceAccount(emitTx, 1, chain)
+		require.NoError(t, err)
+
+		err = testutil.SignTransactionAsServiceAccount(updateTx, 2, chain)
+		require.NoError(t, err)
+
+		cr := executeBlockAndVerify(t, [][]*flow.TransactionBody{
+			{
+				deployTx,
+				emitTx, // this tx loads the contract into the programs cache
+			},
+			{
+				updateTx,
+			},
+		}, fvm.DefaultTransactionFees, fvm.DefaultMinimumStorageReservation)
+
+		// ensure event is emitted
+		require.Empty(t, cr.TransactionResults[0].ErrorMessage)
+		require.Empty(t, cr.TransactionResults[2].ErrorMessage)
+		require.Len(t, cr.Events[0], 4)
+		require.Len(t, cr.Events[2], 4)
+	})
 }
 
 func TestTransactionFeeDeduction(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.3
 	github.com/ef-ds/deque v1.0.4
 	github.com/ethereum/go-ethereum v1.9.13
-	github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41
+	github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0
 	github.com/gammazero/workerpool v1.1.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
@@ -58,7 +58,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.2.0
-	github.com/onflow/cadence v0.23.3
+	github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105
 	github.com/onflow/flow v0.2.5
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.0

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.2.0
-	github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105
+	github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487
 	github.com/onflow/flow v0.2.5
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.0

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.2.0
-	github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487
+	github.com/onflow/cadence v0.23.3-patch.1
 	github.com/onflow/flow v0.2.5
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -1302,8 +1302,8 @@ github.com/onflow/atree v0.2.0/go.mod h1:f4/LWn5dJiD63/BK35gnw8sNYWAXHapuekslfrm
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105 h1:ZlW6MzTymr9E9XOSeS7tkDar1prOj9nVJQNsJDc+Vx0=
-github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
+github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487 h1:BjpVRmPMLDPekcTA3L2pdIgA6ymaJrDBdD9e6eJoVx8=
+github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
 github.com/onflow/flow v0.2.5 h1:d1LCeE+w+ef4QAC0zEAxfJn+N09bNKL8zXnfrihiSrs=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=

--- a/go.sum
+++ b/go.sum
@@ -1302,8 +1302,8 @@ github.com/onflow/atree v0.2.0/go.mod h1:f4/LWn5dJiD63/BK35gnw8sNYWAXHapuekslfrm
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487 h1:BjpVRmPMLDPekcTA3L2pdIgA6ymaJrDBdD9e6eJoVx8=
-github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
+github.com/onflow/cadence v0.23.3-patch.1 h1:Tw4UOxK67T6qA+t10Ug2kD0APV6IdHUnZALGYpvAdPs=
+github.com/onflow/cadence v0.23.3-patch.1/go.mod h1:Y++seAx3qsNjjZYTQhClD86D5aF951cMHVPL94Z64J8=
 github.com/onflow/flow v0.2.5 h1:d1LCeE+w+ef4QAC0zEAxfJn+N09bNKL8zXnfrihiSrs=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,9 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41 h1:adk2SdM72B9LVdNPVgLDO+UBdGW5JmDIJEdzlI2ZYC8=
 github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0 h1:4i+hJzGuDJs2qYo2rFjNrEYyzQdzjJOzNUR9p20VHyo=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.1.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/fxamacker/circlehash v0.2.0 h1:IFBaLm/4NChHcIptw/A7Ha/DemC8M9jGbjWzsN6XDrc=
 github.com/fxamacker/circlehash v0.2.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
@@ -1301,8 +1302,8 @@ github.com/onflow/atree v0.2.0/go.mod h1:f4/LWn5dJiD63/BK35gnw8sNYWAXHapuekslfrm
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.23.3 h1:Hau2tiEyXkEt/9ZdQw+sr8CBofXwJ6rBqT7iWi/7vrM=
-github.com/onflow/cadence v0.23.3/go.mod h1:Y++seAx3qsNjjZYTQhClD86D5aF951cMHVPL94Z64J8=
+github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105 h1:ZlW6MzTymr9E9XOSeS7tkDar1prOj9nVJQNsJDc+Vx0=
+github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
 github.com/onflow/flow v0.2.5 h1:d1LCeE+w+ef4QAC0zEAxfJn+N09bNKL8zXnfrihiSrs=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.7.3-0.20210527134022-58c25247091a/go.mod h1:IZ2e7UyLCYmpQ8Kd7k0A32uXqdqfiV1r2sKs5/riblo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487
+	github.com/onflow/cadence v0.23.3-patch.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.0
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.23.3
+	github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.0
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-test/deep v1.0.7 // indirect
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105
+	github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.0
 	github.com/onflow/flow-emulator v0.20.3

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1414,8 +1414,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487 h1:BjpVRmPMLDPekcTA3L2pdIgA6ymaJrDBdD9e6eJoVx8=
-github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
+github.com/onflow/cadence v0.23.3-patch.1 h1:Tw4UOxK67T6qA+t10Ug2kD0APV6IdHUnZALGYpvAdPs=
+github.com/onflow/cadence v0.23.3-patch.1/go.mod h1:Y++seAx3qsNjjZYTQhClD86D5aF951cMHVPL94Z64J8=
 github.com/onflow/flow v0.2.5 h1:d1LCeE+w+ef4QAC0zEAxfJn+N09bNKL8zXnfrihiSrs=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0 h1:S8UxLG4H2bAx9YjRjVY2/pYIFwrzlg2Q/kbFVQmkql0=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1414,8 +1414,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105 h1:ZlW6MzTymr9E9XOSeS7tkDar1prOj9nVJQNsJDc+Vx0=
-github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
+github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487 h1:BjpVRmPMLDPekcTA3L2pdIgA6ymaJrDBdD9e6eJoVx8=
+github.com/onflow/cadence v0.23.5-0.20220511132510-d9169fa0b487/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
 github.com/onflow/flow v0.2.5 h1:d1LCeE+w+ef4QAC0zEAxfJn+N09bNKL8zXnfrihiSrs=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0 h1:S8UxLG4H2bAx9YjRjVY2/pYIFwrzlg2Q/kbFVQmkql0=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -387,8 +387,9 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41 h1:adk2SdM72B9LVdNPVgLDO+UBdGW5JmDIJEdzlI2ZYC8=
 github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0 h1:4i+hJzGuDJs2qYo2rFjNrEYyzQdzjJOzNUR9p20VHyo=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.1.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/fxamacker/circlehash v0.2.0 h1:IFBaLm/4NChHcIptw/A7Ha/DemC8M9jGbjWzsN6XDrc=
 github.com/fxamacker/circlehash v0.2.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
@@ -1413,8 +1414,8 @@ github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.17.0/go.mod h1:iR/tZpP+1YhM8iRnOBPiBIs7on5dE3hk2ZfunCRQswE=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.23.3 h1:Hau2tiEyXkEt/9ZdQw+sr8CBofXwJ6rBqT7iWi/7vrM=
-github.com/onflow/cadence v0.23.3/go.mod h1:Y++seAx3qsNjjZYTQhClD86D5aF951cMHVPL94Z64J8=
+github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105 h1:ZlW6MzTymr9E9XOSeS7tkDar1prOj9nVJQNsJDc+Vx0=
+github.com/onflow/cadence v0.23.5-0.20220510154848-5d59150b6105/go.mod h1:9aMe+SF+4xIeBWUED6DlJbx50O5ez9lApJKiT0Nqlmw=
 github.com/onflow/flow v0.2.5 h1:d1LCeE+w+ef4QAC0zEAxfJn+N09bNKL8zXnfrihiSrs=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.0 h1:S8UxLG4H2bAx9YjRjVY2/pYIFwrzlg2Q/kbFVQmkql0=


### PR DESCRIPTION
The fix is here https://github.com/onflow/cadence/pull/1642.

This patch was backported to Cadence `v0.23.3`, which is currently used in flow-go `v0.25`, as `v0.23.3-patch.1`, i.e. these have the same commits:
- https://github.com/onflow/cadence/pull/1642/commits
- https://github.com/onflow/cadence/compare/v0.23.3...v0.23.3-patch.1

This only imports the new cadence version and adds a test for this scenario.