### PR TITLE
avoid race condition in validating blocks

### DIFF
--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -310,6 +310,9 @@ func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.BlockRe
 			OriginID: originID,
 			Block:    block,
 		}
+		// tempfix: to help nodes falling far behind to catch up.
+		// it avoids the race condition in compliance engine and hotstuff to validate blocks
+		time.Sleep(150 * time.Millisecond)
 		e.comp.SubmitLocal(synced)
 	}
 }


### PR DESCRIPTION
When sync engine delivers a range of blocks to compliance engine, compliance engine will process each of them, once it finishes validating the payload, it will forward to hotstuff for validating the block header. 

However, this creates a race for hotstuff to validate current block's header and compliance engine validate the next block's payload. 

If compliance engine starts to validate the next block before hotstuff finish validating the first block's header, then compliance engine will hit an error saying the next block is unverifiable. 

To resolve, we need to ask compliance engine to wait until hotstuff finishes validating the header, we estimated the avg wait time needed is about `150ms`. it should cover 99.9% cases, and allow nodes to catch up at a max of 6.6 blocks/second.

Note, even if hotstuff actually need longer than than `150ms`, which is rare, the sync engine will request the block again, by the time it receive the block again, hotstuff must have finished validating the header. So block syncing speed will be resumed again.