### PR TITLE
Set the memory-metering threshold to 1 GB

### DIFF
--- a/fvm/context.go
+++ b/fvm/context.go
@@ -1,8 +1,6 @@
 package fvm
 
 import (
-	"math"
-
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm/handler"
@@ -62,9 +60,9 @@ func newContext(ctx Context, opts ...Option) Context {
 const AccountKeyWeightThreshold = 1000
 
 const (
-	DefaultComputationLimit             = 100_000        // 100K
-	DefaultMemoryLimit                  = math.MaxUint64 //
-	DefaultEventCollectionByteSizeLimit = 256_000        // 256KB
+	DefaultComputationLimit             = 100_000       // 100KB
+	DefaultMemoryLimit                  = 1_000_000_000 // 1GB
+	DefaultEventCollectionByteSizeLimit = 256_000       // 256KB
 	DefaultMaxNumOfTxRetries            = 3
 )
 


### PR DESCRIPTION
This sets the memory metering threshold to 1 Gigabyte