### PR TITLE
chore(docker): fix parallel image builds

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -19,7 +19,7 @@ ARG VERSION
 
 COPY . .
 
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     make crypto_setup_gopath
 
@@ -28,7 +28,7 @@ WORKDIR /app
 ARG GOARCH=amd64
 # Keep Go's build cache between builds.
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build --tags "relic,netgo" -ldflags "-extldflags -static \
     -X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' -X  'github.com/onflow/flow-go/cmd/build.semver=${VERSION}'" \
@@ -48,7 +48,7 @@ FROM build-env as build-debug
 WORKDIR /app
 ARG GOARCH=amd64
 RUN --mount=type=ssh \
-    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,sharing=locked,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     GO111MODULE=on CGO_ENABLED=1 GOOS=linux go build --tags "relic,netgo" -ldflags "-extldflags -static \
     -X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' -X  'github.com/onflow/flow-go/cmd/build.semver=${VERSION}'" \

--- a/integration/loader/Dockerfile
+++ b/integration/loader/Dockerfile
@@ -44,7 +44,7 @@ WORKDIR /app
 # Keep Go's build cache between builds.
 # https://github.com/golang/go/issues/27719#issuecomment-514747274
 # Also, allow ssh access
-RUN --mount=type=cache,target=/go/pkg/mod \
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=ssh \
     cd integration && \

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -48,7 +48,8 @@ init-short-epochs:
 .PHONY: start
 start:
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.metrics.yml up -d --remove-orphans
-	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml up --build -d
+	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml build
+	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml up -d
 
 .PHONY: logs
 logs:


### PR DESCRIPTION
Right now, for some reason `--build` flag for docker-compose is broken so build needs to be ran manually.

```
$ docker image prune -a
$ make stop && make init && make start
...
DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml up --build -d
[+] Running 0/6
 ⠿ collection_3 Error                                                                                                                           2.5s
 ⠿ execution_2 Error                                                                                                                            2.5s
 ⠿ consensus_2 Error                                                                                                                            2.5s
 ⠿ consensus_3 Error                                                                                                                            2.5s
 ⠿ collection_2 Error                                                                                                                           2.5s
 ⠿ access_2 Error                                                                                                                               2.5s
Error response from daemon: pull access denied for localnet-consensus, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

The second problem is that cache in `/go/pkg/mod` is non-atomic, which means it can not be used in parallel by multiple builds (and `integration/localnet` build 4 in parallel):
```
#0 1.530 make: *** [Makefile:37: crypto_setup_gopath] Error 1
------
------
 > [localnet-collection build-env 4/4] RUN --mount=type=cache,target=/go/pkg/mod     --mount=type=cache,target=/root/.cache/go-build     make crypto_setup_gopath:
#0 0.444 bash crypto_setup.sh
#0 1.523 fatal: could not create work tree dir 'relic': File exists
#0 1.524 git clone failed
#0 1.525 types.go:11: running "bash": exit status 1
#0 1.549 make: *** [Makefile:37: crypto_setup_gopath] Error 1
```
As you can see, multiple processes tries to execute `crypto_setup.sh` concurrently on the same cache, which breaks badly.  Thankfully buildkit has a `sharing` argument for cache, which allows us to [serialize cache access](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypecache) without fully disabling it.