### PR TITLE
fix import badger for go 1.18

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	madns "github.com/multiformats/go-multiaddr-dns"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"

--- a/cmd/util/cmd/common/state.go
+++ b/cmd/util/cmd/common/state.go
@@ -3,7 +3,7 @@ package common
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/state/protocol"

--- a/cmd/util/cmd/common/storage.go
+++ b/cmd/util/cmd/common/storage.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog/log"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/cmd/util/cmd/read-badger/cmd/storages.go
+++ b/cmd/util/cmd/read-badger/cmd/storages.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/storage"

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/engine/execution/state"

--- a/consensus/hotstuff/persister/persister.go
+++ b/consensus/hotstuff/persister/persister.go
@@ -1,7 +1,7 @@
 package persister
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage/badger/operation"

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/gammazero/workerpool"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"

--- a/consensus/recovery/protocol/state_test.go
+++ b/consensus/recovery/protocol/state_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	recovery "github.com/onflow/flow-go/consensus/recovery/protocol"

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
 	entitiesproto "github.com/onflow/flow/protobuf/go/flow/entities"
 	execproto "github.com/onflow/flow/protobuf/go/flow/execution"

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
 	entitiesproto "github.com/onflow/flow/protobuf/go/flow/entities"
 	execproto "github.com/onflow/flow/protobuf/go/flow/execution"

--- a/engine/collection/epochmgr/factories/builder.go
+++ b/engine/collection/epochmgr/factories/builder.go
@@ -3,7 +3,7 @@ package factories
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/module"
 	builder "github.com/onflow/flow-go/module/builder/collection"

--- a/engine/collection/epochmgr/factories/cluster_state.go
+++ b/engine/collection/epochmgr/factories/cluster_state.go
@@ -3,7 +3,7 @@ package factories
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/module"
 	clusterkv "github.com/onflow/flow-go/state/cluster/badger"

--- a/engine/collection/epochmgr/factories/hotstuff.go
+++ b/engine/collection/epochmgr/factories/hotstuff.go
@@ -3,7 +3,7 @@ package factories
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/consensus"

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/engine/execution/state"

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/ledger"

--- a/engine/execution/state/state_test.go
+++ b/engine/execution/state/state_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"

--- a/engine/testutil/mock/nodes.go
+++ b/engine/testutil/mock/nodes.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 

--- a/engine/verification/assigner/blockconsumer/consumer_test.go
+++ b/engine/verification/assigner/blockconsumer/consumer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/model"

--- a/engine/verification/assigner/blockconsumer/reader_test.go
+++ b/engine/verification/assigner/blockconsumer/reader_test.go
@@ -3,7 +3,7 @@ package blockconsumer_test
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/engine/testutil"

--- a/engine/verification/fetcher/chunkconsumer/consumer_test.go
+++ b/engine/verification/fetcher/chunkconsumer/consumer_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/cmd"

--- a/integration/testnet/container.go
+++ b/integration/testnet/container.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
 	"github.com/rs/zerolog"

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/onflow/flow-go/model/cluster"

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/module/finalizer/collection/finalizer.go
+++ b/module/finalizer/collection/finalizer.go
@@ -3,7 +3,7 @@ package collection
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/module/finalizer/consensus/finalizer.go
+++ b/module/finalizer/consensus/finalizer.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/module/finalizer/consensus/finalizer_test.go
+++ b/module/finalizer/consensus/finalizer_test.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/module/mempool/consensus/exec_fork_suppressor.go
+++ b/module/mempool/consensus/exec_fork_suppressor.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 

--- a/module/mempool/consensus/exec_fork_suppressor_test.go
+++ b/module/mempool/consensus/exec_fork_suppressor_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/module/metrics/badger.go
+++ b/module/metrics/badger.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	// _ "github.com/dgraph-io/badger/v2" // TODO this might be needed for servers just testing metrics
+	// _ badger "github.com/dgraph-io/badger/v2" // TODO this might be needed for servers just testing metrics
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"

--- a/state/cluster/badger/mutator.go
+++ b/state/cluster/badger/mutator.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/state/cluster/badger/snapshot.go
+++ b/state/cluster/badger/snapshot.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"

--- a/state/cluster/badger/snapshot_test.go
+++ b/state/cluster/badger/snapshot_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/state/cluster/badger/state.go
+++ b/state/cluster/badger/state.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/model/flow"

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/state/protocol/inmem/convert_test.go
+++ b/state/protocol/inmem/convert_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/state/protocol/util/testing.go
+++ b/state/protocol/util/testing.go
@@ -3,7 +3,7 @@ package util
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/all.go
+++ b/storage/badger/all.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/storage"

--- a/storage/badger/approvals.go
+++ b/storage/badger/approvals.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/approvals_test.go
+++ b/storage/badger/approvals_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/batch.go
+++ b/storage/badger/batch.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"sync"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 )
 
 type Batch struct {

--- a/storage/badger/blocks.go
+++ b/storage/badger/blocks.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"

--- a/storage/badger/blocks_test.go
+++ b/storage/badger/blocks_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/cache.go
+++ b/storage/badger/cache.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/chunkDataPacks.go
+++ b/storage/badger/chunkDataPacks.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/chunk_data_pack_test.go
+++ b/storage/badger/chunk_data_pack_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/chunks_queue.go
+++ b/storage/badger/chunks_queue.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/cleaner.go
+++ b/storage/badger/cleaner.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/cluster_blocks.go
+++ b/storage/badger/cluster_blocks.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/cluster_payloads.go
+++ b/storage/badger/cluster_payloads.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/cluster_payloads_test.go
+++ b/storage/badger/cluster_payloads_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/collections.go
+++ b/storage/badger/collections.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"

--- a/storage/badger/collections_test.go
+++ b/storage/badger/collections_test.go
@@ -3,7 +3,7 @@ package badger_test
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/commit_test.go
+++ b/storage/badger/commit_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/commits.go
+++ b/storage/badger/commits.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/common.go
+++ b/storage/badger/common.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/storage"
 )

--- a/storage/badger/consumer_progress.go
+++ b/storage/badger/consumer_progress.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/storage/badger/operation"
 )

--- a/storage/badger/dkg_state.go
+++ b/storage/badger/dkg_state.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/encodable"

--- a/storage/badger/dkg_state_test.go
+++ b/storage/badger/dkg_state_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/epoch_commits.go
+++ b/storage/badger/epoch_commits.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/epoch_setups.go
+++ b/storage/badger/epoch_setups.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/epoch_setups_test.go
+++ b/storage/badger/epoch_setups_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/epoch_statuses.go
+++ b/storage/badger/epoch_statuses.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/epoch_statuses_test.go
+++ b/storage/badger/epoch_statuses_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/events.go
+++ b/storage/badger/events.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/events_test.go
+++ b/storage/badger/events_test.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm/systemcontracts"

--- a/storage/badger/guarantees.go
+++ b/storage/badger/guarantees.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/guarantees_test.go
+++ b/storage/badger/guarantees_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -5,7 +5,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/headers_test.go
+++ b/storage/badger/headers_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/onflow/flow-go/storage/badger/operation"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/index.go
+++ b/storage/badger/index.go
@@ -3,7 +3,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/index_test.go
+++ b/storage/badger/index_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/init.go
+++ b/storage/badger/init.go
@@ -3,7 +3,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/storage/badger/operation"
 )

--- a/storage/badger/init_test.go
+++ b/storage/badger/init_test.go
@@ -3,7 +3,7 @@ package badger_test
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	bstorage "github.com/onflow/flow-go/storage/badger"

--- a/storage/badger/my_receipts.go
+++ b/storage/badger/my_receipts.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/my_receipts_test.go
+++ b/storage/badger/my_receipts_test.go
@@ -3,7 +3,7 @@ package badger_test
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/operation/approvals.go
+++ b/storage/badger/operation/approvals.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/children.go
+++ b/storage/badger/operation/children.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/children_test.go
+++ b/storage/badger/operation/children_test.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/chunkDataPacks.go
+++ b/storage/badger/operation/chunkDataPacks.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	badgermodel "github.com/onflow/flow-go/storage/badger/model"

--- a/storage/badger/operation/chunkDataPacks_test.go
+++ b/storage/badger/operation/chunkDataPacks_test.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/chunk_locators.go
+++ b/storage/badger/operation/chunk_locators.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/operation/cluster.go
+++ b/storage/badger/operation/cluster.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/cluster_test.go
+++ b/storage/badger/operation/cluster_test.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/collections.go
+++ b/storage/badger/operation/collections.go
@@ -3,7 +3,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/collections_test.go
+++ b/storage/badger/operation/collections_test.go
@@ -5,7 +5,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/commits.go
+++ b/storage/badger/operation/commits.go
@@ -3,7 +3,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/commits_test.go
+++ b/storage/badger/operation/commits_test.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/common.go
+++ b/storage/badger/operation/common.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/vmihailenco/msgpack/v4"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/operation/common_test.go
+++ b/storage/badger/operation/common_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmihailenco/msgpack/v4"

--- a/storage/badger/operation/dkg.go
+++ b/storage/badger/operation/dkg.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"errors"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/operation/dkg_test.go
+++ b/storage/badger/operation/dkg_test.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/flow-go/model/encodable"

--- a/storage/badger/operation/epoch.go
+++ b/storage/badger/operation/epoch.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"errors"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"

--- a/storage/badger/operation/epoch_test.go
+++ b/storage/badger/operation/epoch_test.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/operation/events.go
+++ b/storage/badger/operation/events.go
@@ -3,7 +3,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/events_test.go
+++ b/storage/badger/operation/events_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/operation/guarantees.go
+++ b/storage/badger/operation/guarantees.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/guarantees_test.go
+++ b/storage/badger/operation/guarantees_test.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/headers.go
+++ b/storage/badger/operation/headers.go
@@ -3,7 +3,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/headers_test.go
+++ b/storage/badger/operation/headers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -3,7 +3,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 )
 
 func InsertRootHeight(height uint64) func(*badger.Txn) error {

--- a/storage/badger/operation/heights_test.go
+++ b/storage/badger/operation/heights_test.go
@@ -5,7 +5,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/init.go
+++ b/storage/badger/operation/init.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/storage"
 )

--- a/storage/badger/operation/init_test.go
+++ b/storage/badger/operation/init_test.go
@@ -3,7 +3,7 @@ package operation_test
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/storage/badger/operation"

--- a/storage/badger/operation/interactions.go
+++ b/storage/badger/operation/interactions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/model/flow"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 )
 
 func InsertExecutionStateInteractions(blockID flow.Identifier, interactions []*delta.Snapshot) func(*badger.Txn) error {

--- a/storage/badger/operation/interactions_test.go
+++ b/storage/badger/operation/interactions_test.go
@@ -5,7 +5,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/jobs.go
+++ b/storage/badger/operation/jobs.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/max.go
+++ b/storage/badger/operation/max.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/storage"
 )

--- a/storage/badger/operation/modifiers.go
+++ b/storage/badger/operation/modifiers.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"errors"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage"

--- a/storage/badger/operation/modifiers_test.go
+++ b/storage/badger/operation/modifiers_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmihailenco/msgpack/v4"

--- a/storage/badger/operation/receipts.go
+++ b/storage/badger/operation/receipts.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/receipts_test.go
+++ b/storage/badger/operation/receipts_test.go
@@ -5,7 +5,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/results.go
+++ b/storage/badger/operation/results.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/results_test.go
+++ b/storage/badger/operation/results_test.go
@@ -5,7 +5,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/root_qc.go
+++ b/storage/badger/operation/root_qc.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/root_qc_test.go
+++ b/storage/badger/operation/root_qc_test.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/seals.go
+++ b/storage/badger/operation/seals.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/seals_test.go
+++ b/storage/badger/operation/seals_test.go
@@ -5,7 +5,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/spork.go
+++ b/storage/badger/operation/spork.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/spork_test.go
+++ b/storage/badger/operation/spork_test.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/transaction_results.go
+++ b/storage/badger/operation/transaction_results.go
@@ -5,7 +5,7 @@ package operation
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/transactions.go
+++ b/storage/badger/operation/transactions.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/operation/transactions_test.go
+++ b/storage/badger/operation/transactions_test.go
@@ -3,7 +3,7 @@ package operation
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/badger/operation/views.go
+++ b/storage/badger/operation/views.go
@@ -1,7 +1,7 @@
 package operation
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/storage/badger/payloads.go
+++ b/storage/badger/payloads.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"

--- a/storage/badger/payloads_test.go
+++ b/storage/badger/payloads_test.go
@@ -5,7 +5,7 @@ import (
 
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/procedure/children.go
+++ b/storage/badger/procedure/children.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"

--- a/storage/badger/procedure/children_test.go
+++ b/storage/badger/procedure/children_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/procedure/cluster.go
+++ b/storage/badger/procedure/cluster.go
@@ -3,7 +3,7 @@ package procedure
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/procedure/cluster_test.go
+++ b/storage/badger/procedure/cluster_test.go
@@ -3,7 +3,7 @@ package procedure
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/cluster"

--- a/storage/badger/procedure/index.go
+++ b/storage/badger/procedure/index.go
@@ -3,7 +3,7 @@ package procedure
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage/badger/operation"

--- a/storage/badger/procedure/index_test.go
+++ b/storage/badger/procedure/index_test.go
@@ -3,7 +3,7 @@ package procedure
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/receipts.go
+++ b/storage/badger/receipts.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/receipts_test.go
+++ b/storage/badger/receipts_test.go
@@ -3,7 +3,7 @@ package badger_test
 import (
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/results.go
+++ b/storage/badger/results.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/results_test.go
+++ b/storage/badger/results_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/seals.go
+++ b/storage/badger/seals.go
@@ -5,7 +5,7 @@ package badger
 import (
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/seals_test.go
+++ b/storage/badger/seals_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/storage/badger/transaction/tx.go
+++ b/storage/badger/transaction/tx.go
@@ -1,11 +1,11 @@
 package transaction
 
 import (
-	dbbadger "github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 )
 
 type Tx struct {
-	DBTxn     *dbbadger.Txn
+	DBTxn     *badger.Txn
 	callbacks []func()
 }
 
@@ -20,7 +20,7 @@ func (b *Tx) OnSucceed(callback func()) {
 // Update creates a badger transaction, passing it to a chain of functions,
 // if all succeed. Useful to use callback to update cache in order to ensure data
 // in badgerDB and cache are consistent.
-func Update(db *dbbadger.DB, f func(*Tx) error) error {
+func Update(db *badger.DB, f func(*Tx) error) error {
 	dbTxn := db.NewTransaction(true)
 	defer dbTxn.Discard()
 
@@ -42,7 +42,7 @@ func Update(db *dbbadger.DB, f func(*Tx) error) error {
 }
 
 // WithTx is useful when transaction is used without adding callback.
-func WithTx(f func(*dbbadger.Txn) error) func(*Tx) error {
+func WithTx(f func(*badger.Txn) error) func(*Tx) error {
 	return func(tx *Tx) error {
 		return f(tx.DBTxn)
 	}

--- a/storage/badger/transaction_results.go
+++ b/storage/badger/transaction_results.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/transaction_results_test.go
+++ b/storage/badger/transaction_results_test.go
@@ -5,7 +5,7 @@ import (
 	mathRand "math/rand"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"

--- a/storage/badger/transactions.go
+++ b/storage/badger/transactions.go
@@ -1,7 +1,7 @@
 package badger
 
 import (
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/badger/transactions_test.go
+++ b/storage/badger/transactions_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/storage/batch.go
+++ b/storage/batch.go
@@ -1,6 +1,6 @@
 package storage
 
-import "github.com/dgraph-io/badger/v2"
+import badger "github.com/dgraph-io/badger/v2"
 
 type Transaction interface {
 	Set(key, val []byte) error

--- a/storage/util/testing.go
+++ b/storage/util/testing.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/onflow/flow-go/model/flow"
 
-	"github.com/dgraph-io/badger/v2"
+	badger "github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
When switching to go 1.18, I noticed the linter starts to complain about badger.  For instance:
```
testing.go:92:129: undeclared name: `badger` (typecheck)
func RunWithFullProtocolStateAndMetrics(t testing.TB, rootSnapshot protocol.Snapshot, metrics module.ComplianceMetrics, f func(*badger.DB, *pbadger.MutableState)) {
                                                                                                                                ^
testing.go:6:2: "github.com/dgraph-io/badger/v2" imported but not used (typecheck)
        "github.com/dgraph-io/badger/v2"
```

This is used to work in go 1.17 that [github.com/dgraph-io/badger/v2](http://github.com/dgraph-io/badger/v2) could be referred as badger in the code, but in 1.18 it will complain badger/v2 imported not used, and badger is undeclared.

One way to solve is to add an alias:
```
        badger "github.com/dgraph-io/badger/v2"
```