### PR TITLE
chore(tests): fix load test

### DIFF
--- a/integration/utils/contLoadGenerator.go
+++ b/integration/utils/contLoadGenerator.go
@@ -288,7 +288,7 @@ func (lg *ContLoadGenerator) createAccounts(num int) error {
 		AddAuthorizer(*lg.serviceAccount.address).
 		SetPayer(*lg.serviceAccount.address)
 
-	publicKey := bytesToCadenceArray(accountKey.Encode())
+	publicKey := bytesToCadenceArray(accountKey.PublicKey.Encode())
 	count := cadence.NewInt(num)
 
 	initialTokenAmount, err := cadence.NewUFix64FromParts(


### PR DESCRIPTION
Currently, test fails with the following error:
```
5:21PM ERR account creation tx failed error="[Error Code: 1101] cadence runtime error Execution failed:
error: invalid public key: [248, 71, 184, 64, 62, 118, 6, 35, 180, 178, 53, 126, 38, 116, 202, 182, 91, 243, 157, 205, 89, 77, 199, 235, 192, 117, 38, 122, 5, 166, 65, 116, 192, 67, 8, 190, 19, 100, 174, 246, 253, 218, 181, 121, 11, 79, 74, 202, 139, 156, 247, 215, 109, 152, 90, 162, 48, 116, 13, 180, 101, 48, 1, 40, 106, 13, 47, 226, 2, 3, 130, 3, 232]
  --> 9d665e105234216749b51b3a301153c069b5c1047a1cf3f55e2ea38a5aa2c033:13:23
   |\n13 |       let publicKey2 = PublicKey(\n   |                        ^\n"
```

It looks like it tries to pass the encoded public key (along w/ algo, hash, and weight) to a function that expects a raw public key.  Fix it by using the underlying PublicKey.

cc: @janezpodhostnik 