### PR TITLE
chore(tests): cleanup unused fields from loader

### DIFF
--- a/integration/utils/contLoadGenerator.go
+++ b/integration/utils/contLoadGenerator.go
@@ -42,7 +42,6 @@ type ContLoadGenerator struct {
 	numberOfAccounts     int
 	trackTxs             bool
 	flowClient           *client.Client
-	supervisorClient     *client.Client
 	serviceAccount       *flowAccount
 	flowTokenAddress     *flowsdk.Address
 	fungibleTokenAddress *flowsdk.Address
@@ -51,7 +50,6 @@ type ContLoadGenerator struct {
 	availableAccounts    chan *flowAccount                             // queue with accounts available for   workers
 	happeningAccounts    chan func() (*flowAccount, string, time.Time) // queue with accounts happening after worker processing
 	txTracker            *TxTracker
-	txStatsTracker       *TxStatsTracker
 	workerStatsTracker   *WorkerStatsTracker
 	workers              []*Worker
 	blockRef             BlockRef
@@ -104,7 +102,6 @@ func NewContLoadGenerator(
 		numberOfAccounts:     numberOfAccounts,
 		trackTxs:             false,
 		flowClient:           flowClient,
-		supervisorClient:     supervisorClient,
 		serviceAccount:       servAcc,
 		fungibleTokenAddress: fungibleTokenAddress,
 		flowTokenAddress:     flowTokenAddress,
@@ -112,7 +109,6 @@ func NewContLoadGenerator(
 		availableAccounts:    make(chan *flowAccount, numberOfAccounts),
 		happeningAccounts:    make(chan func() (*flowAccount, string, time.Time), numberOfAccounts),
 		txTracker:            txTracker,
-		txStatsTracker:       txStatsTracker,
 		workerStatsTracker:   NewWorkerStatsTracker(),
 		blockRef:             NewBlockRef(supervisorClient),
 		loadType:             loadType,


### PR DESCRIPTION
`txStatsTracker` already dependency injected into the `txTracker` so there is no ned to keep it in an already way too bloated struct.
`supervisorClient` is not used used outside of dep. injection.