### PR TITLE
Optimize Ledger.Get() by making Forest.Read() use ~5x fewer allocs/op and run ~20% faster

### DIFF
--- a/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
+++ b/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
@@ -89,12 +89,12 @@ func run(*cobra.Command, []string) {
 			},
 		}
 
-		payload, err := forest.Read(read)
+		values, err := forest.Read(read)
 		if err != nil {
 			return nil, err
 		}
 
-		return payload[0].Value, nil
+		return values[0], nil
 	})
 
 	sth := state.NewStateHolder(state.NewState(ldg))

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -140,8 +140,8 @@ func (l *Ledger) GetSingleValue(query *ledger.QuerySingleValue) (value ledger.Va
 	if err != nil {
 		return nil, err
 	}
-	trieRead := &ledger.TrieReadSinglePayload{RootHash: ledger.RootHash(query.State()), Path: path}
-	payload, err := l.forest.ReadSinglePayload(trieRead)
+	trieRead := &ledger.TrieReadSingleValue{RootHash: ledger.RootHash(query.State()), Path: path}
+	value, err = l.forest.ReadSingleValue(trieRead)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (l *Ledger) GetSingleValue(query *ledger.QuerySingleValue) (value ledger.Va
 	durationPerValue := time.Duration(readDuration.Nanoseconds()) * time.Nanosecond
 	l.metrics.ReadDurationPerItem(durationPerValue)
 
-	return payload.Value, nil
+	return value, nil
 }
 
 // Get read the values of the given keys at the given state

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -165,11 +165,7 @@ func (l *Ledger) Get(query *ledger.Query) (values []ledger.Value, err error) {
 		return nil, err
 	}
 	trieRead := &ledger.TrieRead{RootHash: ledger.RootHash(query.State()), Paths: paths}
-	payloads, err := l.forest.Read(trieRead)
-	if err != nil {
-		return nil, err
-	}
-	values, err = pathfinder.PayloadsToValues(payloads)
+	values, err = l.forest.Read(trieRead)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/complete/mtrie/forest.go
+++ b/ledger/complete/mtrie/forest.go
@@ -123,8 +123,8 @@ func (f *Forest) ValueSizes(r *ledger.TrieRead) ([]int, error) {
 	return orderedValueSizes, nil
 }
 
-// ReadSinglePayload reads value for a single path and returns value and error (if any)
-func (f *Forest) ReadSinglePayload(r *ledger.TrieReadSinglePayload) (*ledger.Payload, error) {
+// ReadSingleValue reads value for a single path and returns value and error (if any)
+func (f *Forest) ReadSingleValue(r *ledger.TrieReadSingleValue) (ledger.Value, error) {
 	// lookup the trie by rootHash
 	trie, err := f.GetTrie(r.RootHash)
 	if err != nil {
@@ -132,7 +132,7 @@ func (f *Forest) ReadSinglePayload(r *ledger.TrieReadSinglePayload) (*ledger.Pay
 	}
 
 	payload := trie.ReadSinglePayload(r.Path)
-	return payload.DeepCopy(), nil
+	return payload.Value.DeepCopy(), nil
 }
 
 // Read reads values for an slice of paths and returns values and error (if any)
@@ -152,7 +152,7 @@ func (f *Forest) Read(r *ledger.TrieRead) ([]ledger.Value, error) {
 	// call ReadSinglePayload if there is only one path
 	if len(r.Paths) == 1 {
 		payload := trie.ReadSinglePayload(r.Paths[0])
-		return []*ledger.Payload{payload.DeepCopy()}, nil
+		return []ledger.Value{payload.Value.DeepCopy()}, nil
 	}
 
 	// deduplicate keys:

--- a/ledger/complete/mtrie/forest.go
+++ b/ledger/complete/mtrie/forest.go
@@ -137,10 +137,10 @@ func (f *Forest) ReadSinglePayload(r *ledger.TrieReadSinglePayload) (*ledger.Pay
 
 // Read reads values for an slice of paths and returns values and error (if any)
 // TODO: can be optimized further if we don't care about changing the order of the input r.Paths
-func (f *Forest) Read(r *ledger.TrieRead) ([]*ledger.Payload, error) {
+func (f *Forest) Read(r *ledger.TrieRead) ([]ledger.Value, error) {
 
 	if len(r.Paths) == 0 {
-		return []*ledger.Payload{}, nil
+		return []ledger.Value{}, nil
 	}
 
 	// lookup the trie by rootHash
@@ -174,20 +174,20 @@ func (f *Forest) Read(r *ledger.TrieRead) ([]*ledger.Payload, error) {
 	payloads := trie.UnsafeRead(deduplicatedPaths) // this sorts deduplicatedPaths IN-PLACE
 
 	// reconstruct the payloads in the same key order that called the method
-	orderedPayloads := make([]*ledger.Payload, len(r.Paths))
+	orderedValues := make([]ledger.Value, len(r.Paths))
 	totalPayloadSize := 0
 	for i, p := range deduplicatedPaths {
 		payload := payloads[i]
 		indices := pathOrgIndex[p]
 		for _, j := range indices {
-			orderedPayloads[j] = payload.DeepCopy()
+			orderedValues[j] = payload.Value.DeepCopy()
 		}
 		totalPayloadSize += len(indices) * payload.Size()
 	}
 	// TODO rename the metrics
 	f.metrics.ReadValuesSize(uint64(totalPayloadSize))
 
-	return orderedPayloads, nil
+	return orderedValues, nil
 }
 
 // Update updates the Values for the registers and returns rootHash and error (if any).

--- a/ledger/complete/mtrie/forest_test.go
+++ b/ledger/complete/mtrie/forest_test.go
@@ -614,25 +614,25 @@ func TestReadSinglePayload(t *testing.T) {
 	// Batch read one payload at a time (less efficient)
 	for path, payload := range expectedPayloads {
 		read := &ledger.TrieRead{RootHash: baseRoot, Paths: []ledger.Path{path}}
-		retPayloads, err := forest.Read(read)
+		retValues, err := forest.Read(read)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(retPayloads))
+		require.Equal(t, 1, len(retValues))
 		if payload.IsEmpty() {
-			require.True(t, retPayloads[0].IsEmpty())
+			require.Equal(t, 0, len(retValues[0]))
 		} else {
-			require.Equal(t, payload, retPayloads[0])
+			require.Equal(t, payload.Value, retValues[0])
 		}
 	}
 
-	// Read single payload
+	// Read single value
 	for path, payload := range expectedPayloads {
-		read := &ledger.TrieReadSinglePayload{RootHash: baseRoot, Path: path}
-		retPayload, err := forest.ReadSinglePayload(read)
+		read := &ledger.TrieReadSingleValue{RootHash: baseRoot, Path: path}
+		retValue, err := forest.ReadSingleValue(read)
 		require.NoError(t, err)
 		if payload.IsEmpty() {
-			require.True(t, retPayload.IsEmpty())
+			require.Equal(t, 0, len(retValue))
 		} else {
-			require.Equal(t, payload, retPayload)
+			require.Equal(t, payload.Value, retValue)
 		}
 	}
 }

--- a/ledger/complete/mtrie/forest_test.go
+++ b/ledger/complete/mtrie/forest_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/ledger"
-	"github.com/onflow/flow-go/ledger/common/encoding"
 	prf "github.com/onflow/flow-go/ledger/common/proof"
 	"github.com/onflow/flow-go/ledger/common/utils"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
@@ -67,9 +66,9 @@ func TestTrieUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
-	require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[0]), encoding.EncodePayload(payloads[0])))
+	require.Equal(t, retValues[0], payloads[0].Value)
 }
 
 // TestLeftEmptyInsert tests inserting a new value into an empty sub-trie:
@@ -122,10 +121,10 @@ func TestLeftEmptyInsert(t *testing.T) {
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValues[i], payloads[i].Value)
 	}
 }
 
@@ -180,10 +179,10 @@ func TestRightEmptyInsert(t *testing.T) {
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValues[i], payloads[i].Value)
 	}
 }
 
@@ -236,10 +235,10 @@ func TestExpansionInsert(t *testing.T) {
 	paths = []ledger.Path{p1, p2}
 	payloads = []*ledger.Payload{v1, v2}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValues[i], payloads[i].Value)
 	}
 }
 
@@ -304,10 +303,10 @@ func TestFullHouseInsert(t *testing.T) {
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValues[i], payloads[i].Value)
 	}
 }
 
@@ -346,10 +345,10 @@ func TestLeafInsert(t *testing.T) {
 	require.Equal(t, uint64(v1.Size()+v2.Size()), updatedTrie.AllocatedRegSize())
 
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValues[i], payloads[i].Value)
 	}
 }
 
@@ -384,9 +383,9 @@ func TestOverrideValue(t *testing.T) {
 	require.NoError(t, err)
 
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
-	require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[0]), encoding.EncodePayload(payloads[0])))
+	require.Equal(t, retValues[0], payloads[0].Value)
 
 }
 
@@ -417,9 +416,9 @@ func TestDuplicateOverride(t *testing.T) {
 
 	paths = []ledger.Path{p0}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
-	require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[0]), encoding.EncodePayload(v2)))
+	require.Equal(t, retValues[0], v2.Value)
 
 }
 
@@ -443,16 +442,16 @@ func TestReadSafety(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, data, 1)
-	require.Equal(t, v0, data[0])
+	require.Equal(t, v0.Value, data[0])
 
 	// modify returned slice
-	data[0].Value = []byte("new value")
+	data[0] = []byte("new value")
 
 	// read again
 	data2, err := forest.Read(read)
 	require.NoError(t, err)
 	require.Len(t, data2, 1)
-	require.Equal(t, v0, data2[0])
+	require.Equal(t, v0.Value, data2[0])
 }
 
 // TestReadOrder tests that payloads from reading a trie are delivered in the order as specified by the paths
@@ -474,18 +473,18 @@ func TestReadOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	read := &ledger.TrieRead{RootHash: testRoot, Paths: []ledger.Path{p1, p2}}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retPayloads))
-	require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[0]), encoding.EncodePayload(payloads[0])))
-	require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[1]), encoding.EncodePayload(payloads[1])))
+	require.Equal(t, len(read.Paths), len(retValues))
+	require.Equal(t, retValues[0], payloads[0].Value)
+	require.Equal(t, retValues[1], payloads[1].Value)
 
 	read = &ledger.TrieRead{RootHash: testRoot, Paths: []ledger.Path{p2, p1}}
-	retPayloads, err = forest.Read(read)
+	retValues, err = forest.Read(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retPayloads))
-	require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[1]), encoding.EncodePayload(payloads[0])))
-	require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[0]), encoding.EncodePayload(payloads[1])))
+	require.Equal(t, len(read.Paths), len(retValues))
+	require.Equal(t, retValues[1], payloads[0].Value)
+	require.Equal(t, retValues[0], payloads[1].Value)
 }
 
 // TestMixRead tests reading a mixture of set and unset registers.
@@ -521,10 +520,10 @@ func TestMixRead(t *testing.T) {
 	expectedPayloads := []*ledger.Payload{v1, v2, v3, v4}
 
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: readPaths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(expectedPayloads[i])))
+		require.Equal(t, retValues[i], expectedPayloads[i].Value)
 	}
 }
 
@@ -549,11 +548,11 @@ func TestReadWithDuplicatedKeys(t *testing.T) {
 	paths = []ledger.Path{p1, p2, p3}
 	expectedPayloads := []*ledger.Payload{v1, v2, v1}
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: paths}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
-	require.Equal(t, len(read.Paths), len(retPayloads))
+	require.Equal(t, len(read.Paths), len(retValues))
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(expectedPayloads[i])))
+		require.Equal(t, retValues[i], expectedPayloads[i].Value)
 	}
 }
 
@@ -573,9 +572,9 @@ func TestReadNonExistingPath(t *testing.T) {
 
 	p2 := pathByUint8s([]uint8{uint8(116), uint8(129)})
 	read := &ledger.TrieRead{RootHash: updatedRoot, Paths: []ledger.Path{p2}}
-	retPayloads, err := forest.Read(read)
+	retValues, err := forest.Read(read)
 	require.NoError(t, err)
-	require.True(t, retPayloads[0].IsEmpty())
+	require.Equal(t, 0, len(retValues[0]))
 }
 
 // TestReadSinglePayload tests reading a single payload of set/unset register.
@@ -677,24 +676,24 @@ func TestForkingUpdates(t *testing.T) {
 
 	// Verify payloads are preserved
 	read := &ledger.TrieRead{RootHash: baseRoot, Paths: paths}
-	retPayloads, err := forest.Read(read) // reading from original Trie
+	retValues, err := forest.Read(read) // reading from original Trie
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValues[i], payloads[i].Value)
 	}
 
 	readA := &ledger.TrieRead{RootHash: updatedRootA, Paths: pathsA}
-	retPayloads, err = forest.Read(readA) // reading from updatedTrieA
+	retValues, err = forest.Read(readA) // reading from updatedTrieA
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloadsA[i])))
+		require.Equal(t, retValues[i], payloadsA[i].Value)
 	}
 
 	readB := &ledger.TrieRead{RootHash: updatedRootB, Paths: pathsB}
-	retPayloads, err = forest.Read(readB) // reading from updatedTrieB
+	retValues, err = forest.Read(readB) // reading from updatedTrieB
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloadsB[i])))
+		require.Equal(t, retValues[i], payloadsB[i].Value)
 	}
 }
 
@@ -728,17 +727,17 @@ func TestIdenticalUpdateAppliedTwice(t *testing.T) {
 	paths = []ledger.Path{p1, p2, p3}
 	payloads = []*ledger.Payload{v1, v2, v3}
 	read := &ledger.TrieRead{RootHash: updatedRootA, Paths: paths}
-	retPayloadsA, err := forest.Read(read)
+	retValuesA, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloadsA[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValuesA[i], payloads[i].Value)
 	}
 
 	read = &ledger.TrieRead{RootHash: updatedRootB, Paths: paths}
-	retPayloadsB, err := forest.Read(read)
+	retValuesB, err := forest.Read(read)
 	require.NoError(t, err)
 	for i := range paths {
-		require.True(t, bytes.Equal(encoding.EncodePayload(retPayloadsB[i]), encoding.EncodePayload(payloads[i])))
+		require.Equal(t, retValuesB[i], payloads[i].Value)
 	}
 }
 
@@ -780,10 +779,10 @@ func TestRandomUpdateReadProofValueSizes(t *testing.T) {
 			}
 		}
 		read := &ledger.TrieRead{RootHash: activeRoot, Paths: nonExistingPaths}
-		retPayloads, err := forest.Read(read)
+		retValues, err := forest.Read(read)
 		require.NoError(t, err, "error reading - non existing paths")
-		for _, p := range retPayloads {
-			require.True(t, p.IsEmpty())
+		for _, p := range retValues {
+			require.Equal(t, 0, len(p))
 		}
 
 		// test value sizes for non-existent keys
@@ -801,10 +800,10 @@ func TestRandomUpdateReadProofValueSizes(t *testing.T) {
 
 		// test read
 		read = &ledger.TrieRead{RootHash: activeRoot, Paths: paths}
-		retPayloads, err = forest.Read(read)
+		retValues, err = forest.Read(read)
 		require.NoError(t, err, "error reading")
 		for i := range payloads {
-			require.True(t, bytes.Equal(encoding.EncodePayload(retPayloads[i]), encoding.EncodePayload(payloads[i])))
+			require.Equal(t, retValues[i], payloads[i].Value)
 		}
 
 		// test value sizes for existing keys
@@ -852,10 +851,10 @@ func TestRandomUpdateReadProofValueSizes(t *testing.T) {
 		}
 
 		read = &ledger.TrieRead{RootHash: activeRoot, Paths: allPaths}
-		retPayloads, err = forest.Read(read)
+		retValues, err = forest.Read(read)
 		require.NoError(t, err)
 		for i, v := range allPayloads {
-			assert.True(t, v.Equals(retPayloads[i]))
+			assert.Equal(t, retValues[i], v.Value)
 		}
 
 		// check value sizes for all existing paths

--- a/ledger/complete/wal/checkpointer_test.go
+++ b/ledger/complete/wal/checkpointer_test.go
@@ -242,19 +242,19 @@ func Test_Checkpointing(t *testing.T) {
 					paths = append(paths, path)
 				}
 
-				payloads1, err := f.Read(&ledger.TrieRead{RootHash: rootHash, Paths: paths})
+				values1, err := f.Read(&ledger.TrieRead{RootHash: rootHash, Paths: paths})
 				require.NoError(t, err)
 
-				payloads2, err := f2.Read(&ledger.TrieRead{RootHash: rootHash, Paths: paths})
+				values2, err := f2.Read(&ledger.TrieRead{RootHash: rootHash, Paths: paths})
 				require.NoError(t, err)
 
-				payloads3, err := f3.Read(&ledger.TrieRead{RootHash: rootHash, Paths: paths})
+				values3, err := f3.Read(&ledger.TrieRead{RootHash: rootHash, Paths: paths})
 				require.NoError(t, err)
 
 				for i, path := range paths {
-					require.True(t, data[path].Equals(payloads1[i]))
-					require.True(t, data[path].Equals(payloads2[i]))
-					require.True(t, data[path].Equals(payloads3[i]))
+					require.Equal(t, data[path].Value, values1[i])
+					require.Equal(t, data[path].Value, values2[i])
+					require.Equal(t, data[path].Value, values3[i])
 				}
 			}
 		})
@@ -325,15 +325,15 @@ func Test_Checkpointing(t *testing.T) {
 			trieRead, err := pathfinder.QueryToTrieRead(query, pathFinderVersion)
 			require.NoError(t, err)
 
-			payloads, err := f.Read(trieRead)
+			values, err := f.Read(trieRead)
 			require.NoError(t, err)
 
-			payloads5, err := f5.Read(trieRead)
+			values5, err := f5.Read(trieRead)
 			require.NoError(t, err)
 
 			for i := range keys2 {
-				require.Equal(t, values2[i], payloads[i].Value)
-				require.Equal(t, values2[i], payloads5[i].Value)
+				require.Equal(t, values2[i], values[i])
+				require.Equal(t, values2[i], values5[i])
 			}
 		})
 
@@ -415,15 +415,15 @@ func Test_Checkpointing(t *testing.T) {
 			trieRead, err := pathfinder.QueryToTrieRead(query, pathFinderVersion)
 			require.NoError(t, err)
 
-			payloads, err := f.Read(trieRead)
+			values, err := f.Read(trieRead)
 			require.NoError(t, err)
 
-			payloads6, err := f6.Read(trieRead)
+			values6, err := f6.Read(trieRead)
 			require.NoError(t, err)
 
 			for i := range keys2 {
-				require.Equal(t, values2[i], payloads[i].Value)
-				require.Equal(t, values2[i], payloads6[i].Value)
+				require.Equal(t, values2[i], values[i])
+				require.Equal(t, values2[i], values6[i])
 			}
 
 		})

--- a/ledger/complete/wal/compactor_test.go
+++ b/ledger/complete/wal/compactor_test.go
@@ -194,15 +194,15 @@ func Test_Compactor(t *testing.T) {
 				}
 
 				read := &ledger.TrieRead{RootHash: rootHash, Paths: paths}
-				payloads, err := f.Read(read)
+				values, err := f.Read(read)
 				require.NoError(t, err)
 
-				payloads2, err := f2.Read(read)
+				values2, err := f2.Read(read)
 				require.NoError(t, err)
 
 				for i, path := range paths {
-					require.True(t, data[path].Equals(payloads[i]))
-					require.True(t, data[path].Equals(payloads2[i]))
+					require.Equal(t, data[path].Value, values[i])
+					require.Equal(t, data[path].Value, values2[i])
 				}
 			}
 

--- a/ledger/trie.go
+++ b/ledger/trie.go
@@ -90,7 +90,7 @@ type TrieRead struct {
 }
 
 // TrieReadSinglePayload contains trie read query for a single payload
-type TrieReadSinglePayload struct {
+type TrieReadSingleValue struct {
 	RootHash RootHash
 	Path     Path
 }


### PR DESCRIPTION
### Changes

Change `Forest.Read()` and `Forest.ReadSingleValue()` to return `[]ledger.Value` without deep copying payload keys.  This avoids 4 heap allocation per key.

This change doesn't affect `Ledger.Get()` (the caller) because it discards the payload keys.

Closes #2475 

### Benchmark Comparisons (includes PR #2473 + this PR)

Bench comparison of master `Ledger.Get()` vs `Ledger.GetSingleValue()` reading a single value.

```
name          old time/op    new time/op    delta
LedgerGet1-4    6.77µs ± 1%    4.30µs ± 1%  -36.47%  (p=0.000 n=9+9)

name          old alloc/op   new alloc/op   delta
LedgerGet1-4    1.74kB ± 0%    0.69kB ± 0%  -60.55%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
LedgerGet1-4      21.0 ± 0%       3.0 ± 0%  -85.71%  (p=0.000 n=10+10)
```

Bench comparison of master `Ledger.Get()` vs new `Ledger.Get()` reading 100 values.
```
name            old time/op    new time/op    delta
LedgerGet100-4     519µs ± 0%     410µs ± 1%  -21.02%  (p=0.000 n=10+9)

name            old alloc/op   new alloc/op   delta
LedgerGet100-4     190kB ± 0%      95kB ± 0%  -50.04%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
LedgerGet100-4     1.52k ± 0%     0.32k ± 0%  -79.17%  (p=0.000 n=10+10)
```

Benchmarks used Go 1.17 on linux_amd64 (Haswell).