### PR TITLE
upload log level for memory weights

### DIFF
--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -124,7 +124,7 @@ func (e *ScriptEnv) setMeteringWeights() {
 	memoryWeights, err := getExecutionMemoryWeights(e, e.accounts)
 	if err != nil {
 		e.ctx.Logger.
-			Info().
+			Debug().
 			Err(err).
 			Msg("could not set execution memory weights. Using defaults")
 	} else {

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -157,7 +157,7 @@ func (e *TransactionEnv) setMeteringWeights() error {
 	}
 	if err != nil {
 		e.ctx.Logger.
-			Info().
+			Debug().
 			Err(err).
 			Msg("could not set execution memory weights. Using defaults")
 	} else {


### PR DESCRIPTION
Execution node is producing lots of INFO logs like this, which it's better to use debug level log.
```
{"level":"info","node_role":"execution","node_id":"b5dd412056f6f0f2624550debb71d57e27f93c33d04b977ef024d11976a826bb","error":"[Error Code: 1112] could not get execution parameter from the state (address: f4527793ee68aede path: storage/executionMemoryWeights)","time":"2022-05-26T17:32:33Z","message":"could not set execution memory weights. Using defaults"}
```

If we do want to know whether the default weights was used, better to add it to an existing info log as an extra field. 
