### PR TITLE
[Consensus] Active Pacemaker signer indices

### DIFF
--- a/consensus/hotstuff/helper/timeout_certificate.go
+++ b/consensus/hotstuff/helper/timeout_certificate.go
@@ -14,7 +14,7 @@ func MakeTC(options ...func(*flow.TimeoutCertificate)) *flow.TimeoutCertificate 
 		View:          rand.Uint64(),
 		TOHighestQC:   qc,
 		TOHighQCViews: []uint64{qc.View},
-		SignerIDs:     unittest.IdentityListFixture(7).NodeIDs(),
+		SignerIndices: unittest.SignerIndicesFixture(3),
 		SigData:       unittest.SignatureFixture(),
 	}
 	for _, option := range options {
@@ -35,9 +35,9 @@ func WithTCHighestQC(qc *flow.QuorumCertificate) func(*flow.TimeoutCertificate) 
 	}
 }
 
-func WithTCSigners(signerIDs []flow.Identifier) func(*flow.TimeoutCertificate) {
+func WithTCSigners(signerIndices []byte) func(*flow.TimeoutCertificate) {
 	return func(tc *flow.TimeoutCertificate) {
-		tc.SignerIDs = signerIDs
+		tc.SignerIndices = signerIndices
 	}
 }
 

--- a/model/flow/timeout_certificate.go
+++ b/model/flow/timeout_certificate.go
@@ -12,7 +12,7 @@ type TimeoutCertificate struct {
 	TOHighQCViews []uint64
 	// TOHighestQC is the newest QC from all TimeoutObject that were aggregated for this certificate.
 	TOHighestQC *QuorumCertificate
-	// SignerIndices encodes the HotStuff participants whose TimeoutObject is included in this TC.
+	// SignerIndices encodes the HotStuff participants whose TimeoutObjects are included in this TC.
 	// For `n` authorized consensus nodes, `SignerIndices` is an n-bit vector (padded with tailing
 	// zeros to reach full bytes). We list the nodes in their canonical order, as defined by the protocol.
 	SignerIndices []byte

--- a/model/flow/timeout_certificate.go
+++ b/model/flow/timeout_certificate.go
@@ -12,8 +12,10 @@ type TimeoutCertificate struct {
 	TOHighQCViews []uint64
 	// TOHighestQC is the newest QC from all TimeoutObject that were aggregated for this certificate.
 	TOHighestQC *QuorumCertificate
-	// SignerIDs holds the IDs of all HotStuff participants whose TimeoutObject was included in this certificate
-	SignerIDs []Identifier
+	// SignerIndices encodes the HotStuff participants whose TimeoutObject is included in this TC.
+	// For `n` authorized consensus nodes, `SignerIndices` is an n-bit vector (padded with tailing
+	// zeros to reach full bytes). We list the nodes in their canonical order, as defined by the protocol.
+	SignerIndices []byte
 	// SigData is an aggregated signature from multiple TimeoutObjects, each from a different replica.
 	// In their TimeoutObjects, replicas sign the pair (View, HighestQCView) with their staking keys.
 	SigData crypto.Signature
@@ -25,16 +27,16 @@ func (t *TimeoutCertificate) Body() interface{} {
 	}
 
 	return struct {
-		View        uint64
-		HighQCViews []uint64
-		HighestQC   QuorumCertificate
-		SignerIDs   []Identifier
-		SigData     crypto.Signature
+		View          uint64
+		HighQCViews   []uint64
+		HighestQC     QuorumCertificate
+		SignerIndices []byte
+		SigData       crypto.Signature
 	}{
-		View:        t.View,
-		HighQCViews: t.TOHighQCViews,
-		HighestQC:   *t.TOHighestQC,
-		SignerIDs:   t.SignerIDs,
-		SigData:     t.SigData,
+		View:          t.View,
+		HighQCViews:   t.TOHighQCViews,
+		HighestQC:     *t.TOHighestQC,
+		SignerIndices: t.SignerIndices,
+		SigData:       t.SigData,
 	}
 }


### PR DESCRIPTION
### Context

This PR replaces signer ids with signer indices as it was done for QC. 
This PR is a few lines since we haven't used TC anywhere yet. 
We need this change as it's blocking https://github.com/dapperlabs/flow-go/issues/6192 since it already uses signer indices for QCs. 