### PR TITLE
[Fix] Adding sync request message as a cluster type message

### DIFF
--- a/network/validator/pubsub/authorized_sender_validator.go
+++ b/network/validator/pubsub/authorized_sender_validator.go
@@ -101,7 +101,10 @@ func getRoles(channel network.Channel, msgTypeCode uint8) (flow.RoleList, error)
 	}
 
 	// cluster channels have a dynamic channel name
-	if msgTypeCode == cborcodec.CodeClusterBlockProposal || msgTypeCode == cborcodec.CodeClusterBlockVote || msgTypeCode == cborcodec.CodeClusterBlockResponse {
+	if msgTypeCode == cborcodec.CodeClusterBlockProposal ||
+		msgTypeCode == cborcodec.CodeClusterBlockVote ||
+		msgTypeCode == cborcodec.CodeClusterBlockResponse ||
+		msgTypeCode == cborcodec.CodeSyncRequest {
 		return channels.ClusterChannelRoles(channel), nil
 	}
 


### PR DESCRIPTION
This PR fixes the false-negative validation for `SyncRequest` messages over `sync-cluster` channel. 

```
{"level":"warn","node_role":"collection","node_id":"54696d204e616e00d85454bc12a4c48169c5e9e773b412ae200577d23f54271f","engine":"cluster_synchronization","error":"failed to multicast on channel sync-cluster-cluster-32-9424dedf7dfe01ff04e8d443185f3a2a7e3139738f27a6e3383f26101190938a: failed to send message on channel sync-cluster-cluster-32-9424dedf7dfe01ff04e8d443185f3a2a7e3139738f27a6e3383f26101190938a: failed to publish the message: could not publish to topic (sync-cluster-cluster-32-9424dedf7dfe01ff04e8d443185f3a2a7e3139738f27a6e3383f26101190938a): validation failed","time":"2022-05-26T17:29:39Z","message":"sending sync request to poll heights failed"}
```