### PR TITLE
[Fix] Adding sync request message as a cluster type message

### DIFF
--- a/network/validator/pubsub/authorized_sender_validator.go
+++ b/network/validator/pubsub/authorized_sender_validator.go
@@ -101,7 +101,15 @@ func getRoles(channel network.Channel, msgTypeCode uint8) (flow.RoleList, error)
 	}
 
 	// cluster channels have a dynamic channel name
-	if msgTypeCode == cborcodec.CodeClusterBlockProposal || msgTypeCode == cborcodec.CodeClusterBlockVote || msgTypeCode == cborcodec.CodeClusterBlockResponse {
+	if msgTypeCode == cborcodec.CodeClusterBlockProposal ||
+		msgTypeCode == cborcodec.CodeClusterBlockVote ||
+		msgTypeCode == cborcodec.CodeClusterBlockResponse {
+		return channels.ClusterChannelRoles(channel), nil
+	}
+
+	// check if msg is cluster sync request. The sync request message is used on
+	// sync-cluster prefixed channels as well as the SyncCommittee channel.
+	if msgTypeCode == cborcodec.CodeSyncRequest && channels.IsClusterChannel(channel) {
 		return channels.ClusterChannelRoles(channel), nil
 	}
 


### PR DESCRIPTION
This PR adds a fix for handling message validation on messages sent on cluster prefixed channels