### PR TITLE
Upgrade Cadence to secure-cadence-m8

### DIFF
--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -525,7 +525,9 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
 		require.NoError(t, err)
 
-		assert.ErrorContains(t, tx.Err, "program too ambiguous")
+		var parsingCheckingError *runtime.ParsingCheckingError
+		assert.ErrorAs(t, tx.Err, &parsingCheckingError)
+		assert.ErrorContains(t, tx.Err, "program too ambiguous, local replay limit of 64 tokens exceeded")
 	})
 
 	t.Run("account update with set code fails if not signed by service account", func(t *testing.T) {

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -525,7 +525,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
 		require.NoError(t, err)
 
-		assert.NoError(t, tx.Err)
+		assert.ErrorContains(t, tx.Err, "program too ambiguous")
 	})
 
 	t.Run("account update with set code fails if not signed by service account", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.3.1-0.20220519142403-b0077ba343ec
-	github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d
+	github.com/onflow/cadence v0.21.3-0.20220524232221-b4a37c41632f
 	github.com/onflow/flow v0.3.0
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220513155751-c4c1f8d59f83

--- a/go.sum
+++ b/go.sum
@@ -1398,8 +1398,8 @@ github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk
 github.com/onflow/cadence v0.21.3-0.20220419065337-d5202c162010/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/cadence v0.21.3-0.20220511225809-808fe14141df/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/cadence v0.21.3-0.20220513161637-08b93d4bb7b9/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
-github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d h1:awygOtrnwFSURPyGjTmnULme4tjSFFjPbJ/04RWez8s=
-github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d/go.mod h1:MfEvTq9dvGhnoyqUqsKBsZBM5V4SytllHMqHM+6Lki0=
+github.com/onflow/cadence v0.21.3-0.20220524232221-b4a37c41632f h1:QDuneQdHDebIwvHOlfFgUc/QR6kv3QUPjBFvXvOcD80=
+github.com/onflow/cadence v0.21.3-0.20220524232221-b4a37c41632f/go.mod h1:MfEvTq9dvGhnoyqUqsKBsZBM5V4SytllHMqHM+6Lki0=
 github.com/onflow/flow v0.2.4/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow v0.3.0 h1:qDKHFXh5HVZRxw+MpHdENXrqA2gVhmCq0CRW7X3ObLA=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d
+	github.com/onflow/cadence v0.21.3-0.20220524232221-b4a37c41632f
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220513155751-c4c1f8d59f83
 	github.com/onflow/flow-emulator v0.31.2-0.20220513151845-ef7513cb1cd0

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1489,8 +1489,8 @@ github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFc
 github.com/onflow/cadence v0.21.3-0.20220419065337-d5202c162010/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/cadence v0.21.3-0.20220511225809-808fe14141df/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/cadence v0.21.3-0.20220513161637-08b93d4bb7b9/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
-github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d h1:awygOtrnwFSURPyGjTmnULme4tjSFFjPbJ/04RWez8s=
-github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d/go.mod h1:MfEvTq9dvGhnoyqUqsKBsZBM5V4SytllHMqHM+6Lki0=
+github.com/onflow/cadence v0.21.3-0.20220524232221-b4a37c41632f h1:QDuneQdHDebIwvHOlfFgUc/QR6kv3QUPjBFvXvOcD80=
+github.com/onflow/cadence v0.21.3-0.20220524232221-b4a37c41632f/go.mod h1:MfEvTq9dvGhnoyqUqsKBsZBM5V4SytllHMqHM+6Lki0=
 github.com/onflow/flow v0.3.0/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83 h1:mpJirFu/JWMLV0IhKDZleVrVdN5B8QERV4gSXDef5bA=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83/go.mod h1:T6yhM+kWrFxiP6F3hh8lh9DcocHfmv48P4ITnjLhKSk=


### PR DESCRIPTION
A simple bump in cadence version to [secure-cadence-m8](https://github.com/onflow/cadence/releases/tag/secure-cadence-m8)