### PR TITLE
chore(tests): cleanup worker and add tests

### DIFF
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/plus3it/gorecurcopy v0.0.1
 	github.com/rs/zerolog v1.26.1
 	github.com/stretchr/testify v1.7.1
+	go.uber.org/atomic v1.9.0
 	google.golang.org/grpc v1.45.0
 )
 
@@ -264,7 +265,6 @@ require (
 	github.com/zeebo/blake3 v0.2.3 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect

--- a/integration/utils/worker.go
+++ b/integration/utils/worker.go
@@ -11,7 +11,6 @@ type Worker struct {
 	workerID int
 	interval time.Duration
 	work     workFunc
-	ticker   *time.Ticker
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -30,11 +29,10 @@ func NewWorker(workerID int, interval time.Duration, work workFunc) Worker {
 }
 
 func (w *Worker) Start() {
-	w.ticker = time.NewTicker(w.interval)
-	defer w.ticker.Stop()
-
 	go func() {
-		for ; ; <-w.ticker.C {
+		t := time.NewTicker(w.interval)
+		defer t.Stop()
+		for ; ; <-t.C {
 			select {
 			case <-w.ctx.Done():
 				return

--- a/integration/utils/worker.go
+++ b/integration/utils/worker.go
@@ -22,9 +22,6 @@ type Worker struct {
 func NewWorker(workerID int, interval time.Duration, work workFunc) Worker {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-
 	return Worker{
 		workerID: workerID,
 		interval: interval,
@@ -33,11 +30,13 @@ func NewWorker(workerID int, interval time.Duration, work workFunc) Worker {
 		ctx:    ctx,
 		cancel: cancel,
 
-		wg: wg,
+		wg: &sync.WaitGroup{},
 	}
 }
 
 func (w *Worker) Start() {
+	w.wg.Add(1)
+
 	go func() {
 		defer w.wg.Done()
 

--- a/integration/utils/worker_test.go
+++ b/integration/utils/worker_test.go
@@ -42,3 +42,17 @@ func TestWorker(t *testing.T) {
 		w.Stop()
 	})
 }
+
+// TestWorkerStartStop tests that worker can be started and stopped.
+func TestWorkerStartStop(t *testing.T) {
+	t.Parallel()
+	t.Run("stop w/o start", func(t *testing.T) {
+		w := NewWorker(0, time.Second, func(workerID int) {})
+		w.Stop()
+	})
+	t.Run("stop and start", func(t *testing.T) {
+		w := NewWorker(0, time.Second, func(workerID int) {})
+		w.Start()
+		w.Stop()
+	})
+}

--- a/integration/utils/worker_test.go
+++ b/integration/utils/worker_test.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestWorker creates a new worker and test that it runs once and stops.
+func TestWorker(t *testing.T) {
+	done := make(chan struct{})
+	w := NewWorker(0, time.Hour, func(workerID int) { close(done) })
+	w.Start()
+
+	unittest.AssertClosesBefore(t, done, 5*time.Second)
+	w.Stop()
+}

--- a/integration/utils/worker_test.go
+++ b/integration/utils/worker_test.go
@@ -13,7 +13,7 @@ func TestWorkerImmediate(t *testing.T) {
 	t.Parallel()
 	t.Run("immediate", func(t *testing.T) {
 		done := make(chan struct{})
-		w := NewWorker(0, time.Hour, func(workerID int) { close(done) })
+		w := NewWorker(0, time.Millisecond, func(workerID int) { close(done) })
 		w.Start()
 
 		unittest.AssertClosesBefore(t, done, 5*time.Second)


### PR DESCRIPTION
Following changes:
* switch from channel close to a cancelation through context: this would allow context propagation in the future.
* start the first job immediately on Start() instead of waiting for the first Tick.
* add basic test to prevent accidental breakage.