### PR TITLE
chore(tests): cleanup worker stats tracker and add tests

### DIFF
--- a/integration/utils/worker_stats_tracker_test.go
+++ b/integration/utils/worker_stats_tracker_test.go
@@ -16,8 +16,10 @@ func TestWorkerStatsTracker(t *testing.T) {
 
 	st.AddWorker()
 
-	assert.Equal(t, st.AvgTPSBetween(time.Now().Add(-time.Hour), time.Now()), 0.)
+	startTime := time.Now()
+	endTime := startTime.Add(time.Second)
+	assert.Equal(t, 0., st.AvgTPSBetween(startTime, endTime))
 	st.AddTxSent()
 	st.AddTxSent()
-	assert.Greater(t, st.AvgTPSBetween(time.Now().Add(-time.Hour), time.Now()), 0.)
+	assert.Equal(t, 2., st.AvgTPSBetween(startTime, endTime))
 }

--- a/integration/utils/worker_stats_tracker_test.go
+++ b/integration/utils/worker_stats_tracker_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWorkerStatsTracker creates a new worker stats,
+// adds a couple of transactions there and verifies that average tps is correct.
+func TestWorkerStatsTracker(t *testing.T) {
+	st := NewWorkerStatsTracker()
+	st.StartPrinting(time.Second)
+	defer st.StopPrinting()
+
+	st.AddWorker()
+
+	assert.Equal(t, st.AvgTPSBetween(time.Now().Add(-time.Hour), time.Now()), 0.)
+	st.AddTxSent()
+	st.AddTxSent()
+	assert.Greater(t, st.AvgTPSBetween(time.Now().Add(-time.Hour), time.Now()), 0.)
+}


### PR DESCRIPTION
Mostly cosmetic changes, except for the cleanup of the stale timestamp buckets that we were previously leaking.

Also while here added a basic test.