### PR TITLE
chore(tests): fix init-light for localnet

### DIFF
--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -38,7 +38,7 @@ init:
 # Creates a light version of the localnet with just 1 instance for each node type
 .PHONY: init-light
 init-light:
-	$(MAKE) -e COLLECTION=1 CONSENSUS=1 EXECUTION=1 VERIFICATION=1 ACCESS=1 NCLUSTERS=1 init
+	$(MAKE) -e COLLECTION=1 CONSENSUS=2 EXECUTION=1 VERIFICATION=1 ACCESS=1 NCLUSTERS=1 init
 
 # Creates a version of localnet configured with short epochs
 .PHONY: init-short-epochs


### PR DESCRIPTION
Currently, the minimum number of consensus nodes is 2, otherwise the threshold signature construction fails:
```
Bootstrapping a new self-contained, self-connected Flow network...
Flow node counts:
- Collection: 1
- Consensus: 1
- Execution: 1
- Verification: 1
- Access: 1
Network config:
- Clusters: 1
- Epoch Length: 10000
- Staking Phase Length: 2000
- DKG Phase Length: 2000
Number of staked consensus nodes:  1
generating votes from consensus participants:  a3402415f828e985a059bc73761799566fc03beb9a5c46fe6e0756eff89acf4c consensus_1:2137 0xb9747f913c0ddf4519b6c9ab77cb355bc6f663d331f5fb8e38174a1c7b8a2032f63554742712046a0f8373cbe56f9d250cc1a81f108b90a495c7c8a01b4dfc118ee114a033c9741e3a23339671ad9b8c153eb99010ab33853d49a23b3a6b7351
panic: could not CombinedVoteProcessor processor: could not create random beacon inspector at block 63de690c83bcf0b39f31ff294351593d29ebc2d2f619d4e86b678460fd8926eb: invalid parametrization for BLS Threshold Signature Inspector: size should be between 2 and 254, got 1

goroutine 1 [running]:
main.generateBootstrapData({{0x14000d93600, 0x5, 0x8}, {0x0, 0x0, 0x0}, {0x101be47bd, 0x8}, 0x1, 0x7d0, ...})
        /Users/rbtz/src/flow-go/integration/localnet/bootstrap.go:95 +0x108
```