### PR TITLE
chore(tests): do not go through the resolver for localhost

### DIFF
--- a/integration/loader/main.go
+++ b/integration/loader/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/hex"
 	"flag"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -33,7 +34,7 @@ func main() {
 	tpsFlag := flag.String("tps", "1", "transactions per second (TPS) to send, accepts a comma separated list of values if used in conjunction with `tps-durations`")
 	tpsDurationsFlag := flag.String("tps-durations", "0", "duration that each load test will run, accepts a comma separted list that will be applied to multiple values of the `tps` flag (defaults to infinite if not provided, meaning only the first tps case will be tested; additional values will be ignored)")
 	chainIDStr := flag.String("chain", string(flowsdk.Emulator), "chain ID")
-	access := flag.String("access", "localhost:3569", "access node address")
+	access := flag.String("access", net.JoinHostPort("127.0.0.1", "3569"), "access node address")
 	serviceAccountPrivateKeyHex := flag.String("servPrivHex", unittest.ServiceAccountPrivateKeyHex, "service account private key hex")
 	logLvl := flag.String("log-level", "info", "set log level")
 	metricport := flag.Uint("metricport", 8080, "port for /metrics endpoint")


### PR DESCRIPTION
Currently, we go through the resolver codepath each time we create a local connection.  This is not too expensive for the benchmark (though it can create unexpected spikes in latencies), but it can be expensive for the docker's resolver.  To avoid DDoS'ing it, let's use `127.0.0.1` for now.  If our nodes switch to IPv6-only we can switch this to `::1`.