### PR TITLE
chore(tests): mark localnet and benchmarks owned by the performance team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,3 +35,9 @@
 
 # Bootstrap and transit scripts
 /cmd/bootstrap/** @vishalchangrani
+
+# Performance Stream
+/integration/localnet/** @SaveTheRbtz @simonhf @Kay-Zee @zhangchiqing
+/integration/loader/** @SaveTheRbtz @simonhf @Kay-Zee
+/integration/benchmark/** @SaveTheRbtz @simonhf @Kay-Zee
+/integration/utils/** @SaveTheRbtz @simonhf @Kay-Zee


### PR DESCRIPTION
Also, added @zhangchiqing to the localnet based on commit history.