### PR TITLE
Suggestion for PR #2462

### DIFF
--- a/consensus/hotstuff/signature/packer.go
+++ b/consensus/hotstuff/signature/packer.go
@@ -1,7 +1,6 @@
 package signature
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
@@ -77,10 +76,10 @@ func (p *ConsensusSigDataPacker) Unpack(signerIdentities flow.IdentityList, sigD
 
 	stakingSigners, randomBeaconSigners, err := signature.DecodeSigTypeToStakingAndBeaconSigners(signerIdentities, data.SigType)
 	if err != nil {
-		if errors.Is(err, signature.ErrIllegallyPaddedBitVector) || errors.Is(err, signature.ErrIncompatibleBitVectorLength) {
-			return nil, model.NewInvalidFormatErrorf("invalid SigType vector: %w", err)
+		if signature.IsInvalidSigTypesError(err) {
+			return nil, model.NewInvalidFormatErrorf("invalid signer indices: %w", err)
 		}
-		return nil, fmt.Errorf("could not decode signer indices and sig type: %w", err)
+		return nil, fmt.Errorf("unexpected exception decoding signer data: %w", err)
 	}
 
 	return &hotstuff.BlockSignatureData{

--- a/consensus/hotstuff/validator/validator.go
+++ b/consensus/hotstuff/validator/validator.go
@@ -55,7 +55,7 @@ func (v *Validator) ValidateQC(qc *flow.QuorumCertificate, block *model.Block) e
 
 	signers, err := signature.DecodeSignerIndicesToIdentities(allParticipants, qc.SignerIndices)
 	if err != nil {
-		if signature.IsDecodeSignerIndicesError(err) {
+		if signature.IsInvalidSignerIndicesError(err) {
 			return newInvalidBlockError(block, fmt.Errorf("invalid signer indices: %w", err))
 		}
 		// unexpected error

--- a/engine/consensus/ingestion/core.go
+++ b/engine/consensus/ingestion/core.go
@@ -172,7 +172,7 @@ func (e *Core) validateGuarantors(guarantee *flow.CollectionGuarantee) error {
 	// find guarantors by signer indices
 	guarantors, err := signature.DecodeSignerIndicesToIdentities(clusterMembers, guarantee.SignerIndices)
 	if err != nil {
-		if signature.IsDecodeSignerIndicesError(err) {
+		if signature.IsInvalidSignerIndicesError(err) {
 			return engine.NewInvalidInputErrorf("could not decode guarantor indices: %v", err)
 		}
 		// unexpected error

--- a/engine/consensus/ingestion/core_test.go
+++ b/engine/consensus/ingestion/core_test.go
@@ -253,7 +253,7 @@ func (suite *IngestionCoreSuite) TestOnGuaranteeInvalidGuarantor() {
 	err := suite.core.OnGuarantee(suite.collID, guarantee)
 	suite.Assert().Error(err, "should error with invalid guarantor")
 	suite.Assert().True(engine.IsInvalidInputError(err), err)
-	suite.Assert().True(signature.IsDecodeSignerIndicesError(err), err)
+	suite.Assert().True(signature.IsInvalidSignerIndicesError(err), err)
 
 	// check that the guarantee has _not_ been added to the mempool
 	suite.pool.AssertNotCalled(suite.T(), "Add", guarantee)

--- a/module/signature/errors.go
+++ b/module/signature/errors.go
@@ -109,9 +109,46 @@ func IsInsufficientSignaturesError(err error) bool {
 	return errors.As(err, &e)
 }
 
-// IsDecodeSignerIndicesError returns whether err is about decoding signer indices
-func IsDecodeSignerIndicesError(err error) bool {
-	return errors.As(err, &ErrIllegallyPaddedBitVector) ||
-		errors.As(err, &ErrIncompatibleBitVectorLength) ||
-		errors.As(err, &ErrInvalidChecksum)
+/* ********************** InvalidSignerIndicesError ********************** */
+
+// InvalidSignerIndicesError indicates that a bit vector does not encode a valid set of signers
+type InvalidSignerIndicesError struct {
+	err error
+}
+
+func NewInvalidSignerIndicesErrorf(msg string, args ...interface{}) error {
+	return InvalidSignerIndicesError{
+		err: fmt.Errorf(msg, args...),
+	}
+}
+
+func (e InvalidSignerIndicesError) Error() string { return e.err.Error() }
+func (e InvalidSignerIndicesError) Unwrap() error { return e.err }
+
+// IsInvalidSignerIndicesError returns whether err is an InvalidSignerIndicesError
+func IsInvalidSignerIndicesError(err error) bool {
+	var e InvalidSignerIndicesError
+	return errors.As(err, &e)
+}
+
+/* ********************** InvalidSignerIndicesError ********************** */
+
+// InvalidSigTypesError indicates that the given data not encode valid signature types
+type InvalidSigTypesError struct {
+	err error
+}
+
+func NewInvalidSigTypesErrorf(msg string, args ...interface{}) error {
+	return InvalidSigTypesError{
+		err: fmt.Errorf(msg, args...),
+	}
+}
+
+func (e InvalidSigTypesError) Error() string { return e.err.Error() }
+func (e InvalidSigTypesError) Unwrap() error { return e.err }
+
+// IsInvalidSigTypesError returns whether err is an InvalidSigTypesError
+func IsInvalidSigTypesError(err error) bool {
+	var e InvalidSigTypesError
+	return errors.As(err, &e)
 }

--- a/module/signature/signer_indices.go
+++ b/module/signature/signer_indices.go
@@ -235,7 +235,7 @@ func DecodeSignerIndicesToIdentifiers(
 	err = validPadding(signerIndices, numberCanonicalNodes)
 	if err != nil {
 		if errors.Is(err, ErrIncompatibleBitVectorLength) || errors.Is(err, ErrIllegallyPaddedBitVector) {
-			return nil, NewInvalidSigTypesErrorf("invalid padding of signerIndices: %w", err)
+			return nil, NewInvalidSignerIndicesErrorf("invalid padding of signerIndices: %w", err)
 		}
 		return nil, fmt.Errorf("unexpected exception while checking padding of signer indices: %w", err)
 	}
@@ -304,7 +304,6 @@ func validPadding(bitVector []byte, numUsedBits int) error {
 	if l != bitutils.MinimalByteSliceLength(numUsedBits) {
 		e := fmt.Errorf("the bit vector contains a payload of %d used bits, so it should have %d bytes but has %d bytes: %w",
 			numUsedBits, bitutils.MinimalByteSliceLength(numUsedBits), l, ErrIncompatibleBitVectorLength)
-		fmt.Println(errors.Is(e, ErrIncompatibleBitVectorLength))
 		return e
 	}
 	// Condition 1 implies that the number of padded bits must be strictly smaller than 8. Otherwise, the vector

--- a/module/signature/signer_indices.go
+++ b/module/signature/signer_indices.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/ledger/common/bitutils"
@@ -118,20 +119,22 @@ func EncodeSignerToIndicesAndSigType(
 //  * The input `signers` must be the set of signers in their canonical order.
 //
 // Expected Error returns during normal operations:
-//  * ErrIncompatibleBitVectorLength indicates that `signerIndices` has the wrong length
-//  * ErrIllegallyPaddedBitVector is the vector is padded with bits other than 0
+//  * signature.IsInvalidSigTypesError if the given `sigType` does not encode a valid sequence of signature types
 func DecodeSigTypeToStakingAndBeaconSigners(
 	signers flow.IdentityList,
 	sigType []byte,
-) (stakingSigners flow.IdentityList, beaconSigners flow.IdentityList, err error) {
+) (flow.IdentityList, flow.IdentityList, error) {
 	numberSigners := len(signers)
-	if e := validPadding(sigType, numberSigners); e != nil {
-		return nil, nil, fmt.Errorf("sigType is invalid: %w", e)
+	if err := validPadding(sigType, numberSigners); err != nil {
+		if errors.Is(err, ErrIncompatibleBitVectorLength) || errors.Is(err, ErrIllegallyPaddedBitVector) {
+			return nil, nil, NewInvalidSigTypesErrorf("invalid padding of sigTypes: %w", err)
+		}
+		return nil, nil, fmt.Errorf("unexpected exception while checking padding of sigTypes: %w", err)
 	}
 
 	// decode bits to Identities
-	stakingSigners = make(flow.IdentityList, 0, numberSigners)
-	beaconSigners = make(flow.IdentityList, 0, numberSigners)
+	stakingSigners := make(flow.IdentityList, 0, numberSigners)
+	beaconSigners := make(flow.IdentityList, 0, numberSigners)
 	for i, signer := range signers {
 		if bitutils.ReadBit(sigType, i) == 0 {
 			stakingSigners = append(stakingSigners, signer)
@@ -211,9 +214,7 @@ func EncodeSignersToIndices(
 //  * The input `canonicalIdentifiers` must exhaustively list the set of authorized signers in their canonical order.
 //
 // Expected Error returns during normal operations:
-//  * ErrIncompatibleBitVectorLength indicates that `signerIndices` has the wrong length
-//  * ErrIllegallyPaddedBitVector is the vector is padded with bits other than 0
-//  * ErrInvalidChecksum if the input is shorter than the expected checksum contained therein
+// * signature.InvalidSignerIndicesError if the given index vector `prefixed` does not encode a valid set of signers
 func DecodeSignerIndicesToIdentifiers(
 	canonicalIdentifiers flow.IdentifierList,
 	prefixed []byte,
@@ -224,13 +225,19 @@ func DecodeSignerIndicesToIdentifiers(
 	// the signerIndices creator and validator see the same list.
 	signerIndices, err := CompareAndExtract(canonicalIdentifiers, prefixed)
 	if err != nil {
-		return nil, fmt.Errorf("could not extract signer indices from prefixed data: %w", err)
+		if errors.Is(err, ErrInvalidChecksum) {
+			return nil, NewInvalidSignerIndicesErrorf("signer indices' checkum is invalid: %w", err)
+		}
+		return nil, fmt.Errorf("unexpected exception while checking signer indices: %w", err)
 	}
 
 	numberCanonicalNodes := len(canonicalIdentifiers)
 	err = validPadding(signerIndices, numberCanonicalNodes)
 	if err != nil {
-		return nil, fmt.Errorf("signerIndices are invalid: %w", err)
+		if errors.Is(err, ErrIncompatibleBitVectorLength) || errors.Is(err, ErrIllegallyPaddedBitVector) {
+			return nil, NewInvalidSigTypesErrorf("invalid padding of signerIndices: %w", err)
+		}
+		return nil, fmt.Errorf("unexpected exception while checking padding of signer indices: %w", err)
 	}
 
 	// decode bits to Identifiers
@@ -248,9 +255,7 @@ func DecodeSignerIndicesToIdentifiers(
 //  * The input `canonicalIdentifiers` must exhaustively list the set of authorized signers in their canonical order.
 //
 // Expected Error returns during normal operations:
-//  * ErrIncompatibleBitVectorLength indicates that `signerIndices` has the wrong length
-//  * ErrIllegallyPaddedBitVector is the vector is padded with bits other than 0
-//  * ErrInvalidChecksum if the input is shorter than the expected checksum contained therein
+// * signature.InvalidSignerIndicesError if the given index vector `prefixed` does not encode a valid set of signers
 func DecodeSignerIndicesToIdentities(
 	canonicalIdentities flow.IdentityList,
 	prefixed []byte,
@@ -261,12 +266,18 @@ func DecodeSignerIndicesToIdentities(
 	// the signerIndices creator and validator see the same list.
 	signerIndices, err := CompareAndExtract(canonicalIdentities.NodeIDs(), prefixed)
 	if err != nil {
-		return nil, fmt.Errorf("could not extract signer indices from prefixed data: %w", err)
+		if errors.Is(err, ErrInvalidChecksum) {
+			return nil, NewInvalidSignerIndicesErrorf("signer indices' checkum is invalid: %w", err)
+		}
+		return nil, fmt.Errorf("unexpected exception while checking signer indices: %w", err)
 	}
 
 	numberCanonicalNodes := len(canonicalIdentities)
 	if e := validPadding(signerIndices, numberCanonicalNodes); e != nil {
-		return nil, fmt.Errorf("signerIndices padding are invalid: %w", e)
+		if errors.Is(err, ErrIncompatibleBitVectorLength) || errors.Is(err, ErrIllegallyPaddedBitVector) {
+			return nil, NewInvalidSigTypesErrorf("invalid padding of signerIndices: %w", err)
+		}
+		return nil, fmt.Errorf("unexpected exception while checking padding of signer indices: %w", err)
 	}
 
 	// decode bits to Identities
@@ -284,13 +295,17 @@ func DecodeSignerIndicesToIdentities(
 //    `numUsedBits` number of bits. Otherwise, we return an `ErrIncompatibleBitVectorLength`.
 //  2. If `numUsedBits` is _not_ an integer-multiple of 8, `bitVector` is padded with tailing bits. Per
 //     convention, these bits must be zero. Otherwise, we return an `ErrIllegallyPaddedBitVector`.
-// All errors represent expected failure cases for byzantine inputs. There are _no unexpected_ error returns.
+// Expected Error returns during normal operations:
+//  * ErrIncompatibleBitVectorLength if the vector has the wrong length
+//  * ErrIllegallyPaddedBitVector if the vector is padded with bits other than 0
 func validPadding(bitVector []byte, numUsedBits int) error {
 	// Verify condition 1:
 	l := len(bitVector)
 	if l != bitutils.MinimalByteSliceLength(numUsedBits) {
-		return fmt.Errorf("the bit vector contains a payload of %d used bits, so it should have %d bytes but has %d bytes: %w",
+		e := fmt.Errorf("the bit vector contains a payload of %d used bits, so it should have %d bytes but has %d bytes: %w",
 			numUsedBits, bitutils.MinimalByteSliceLength(numUsedBits), l, ErrIncompatibleBitVectorLength)
+		fmt.Println(errors.Is(e, ErrIncompatibleBitVectorLength))
+		return e
 	}
 	// Condition 1 implies that the number of padded bits must be strictly smaller than 8. Otherwise, the vector
 	// could have fewer bytes and still have enough room to store `numUsedBits`.

--- a/module/signature/signer_indices_test.go
+++ b/module/signature/signer_indices_test.go
@@ -5,16 +5,14 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
 	"github.com/onflow/flow-go/ledger/common/bitutils"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/flow/filter/id"
 	"github.com/onflow/flow-go/model/flow/order"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -160,13 +158,13 @@ func Test_ValidPaddingErrIncompatibleBitVectorLength(t *testing.T) {
 
 	// 1 byte less
 	_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(255)})
-	require.Error(t, err)
-	require.ErrorAs(t, err, &signature.ErrIncompatibleBitVectorLength)
+	require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+	require.ErrorIs(t, err, signature.ErrIncompatibleBitVectorLength, "low-level error representing the failure should be ErrIncompatibleBitVectorLength")
 
 	// 1 byte more
 	_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{})
-	require.Error(t, err)
-	require.ErrorAs(t, err, &signature.ErrIncompatibleBitVectorLength)
+	require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+	require.ErrorIs(t, err, signature.ErrIncompatibleBitVectorLength, "low-level error representing the failure should be ErrIncompatibleBitVectorLength")
 
 	// if bits is not multiply of 8, then padding is needed
 	signers = unittest.IdentityListFixture(15)
@@ -175,32 +173,32 @@ func Test_ValidPaddingErrIncompatibleBitVectorLength(t *testing.T) {
 
 	// 1 byte more
 	_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(255), byte(255), byte(254)})
-	require.Error(t, err)
-	require.ErrorAs(t, err, &signature.ErrIncompatibleBitVectorLength)
+	require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+	require.ErrorIs(t, err, signature.ErrIncompatibleBitVectorLength, "low-level error representing the failure should be ErrIncompatibleBitVectorLength")
 
 	// 1 byte less
 	_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(254)})
-	require.Error(t, err)
-	require.ErrorAs(t, err, &signature.ErrIncompatibleBitVectorLength)
+	require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+	require.ErrorIs(t, err, signature.ErrIncompatibleBitVectorLength, "low-level error representing the failure should be ErrIncompatibleBitVectorLength")
 
 	// if bits is not multiply of 8,
 	// 1 byte more
 	signers = unittest.IdentityListFixture(0)
 	_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(255)})
-	require.Error(t, err)
-	require.ErrorAs(t, err, &signature.ErrIncompatibleBitVectorLength)
+	require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+	require.ErrorIs(t, err, signature.ErrIncompatibleBitVectorLength, "low-level error representing the failure should be ErrIncompatibleBitVectorLength")
 
 	// 1 byte more
 	signers = unittest.IdentityListFixture(1)
 	_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(0), byte(0)})
-	require.Error(t, err)
-	require.ErrorAs(t, err, &signature.ErrIncompatibleBitVectorLength)
+	require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+	require.ErrorIs(t, err, signature.ErrIncompatibleBitVectorLength, "low-level error representing the failure should be ErrIncompatibleBitVectorLength")
 
 	// 1 byte less
 	signers = unittest.IdentityListFixture(7)
 	_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{})
-	require.Error(t, err)
-	require.ErrorAs(t, err, &signature.ErrIncompatibleBitVectorLength)
+	require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+	require.ErrorIs(t, err, signature.ErrIncompatibleBitVectorLength, "low-level error representing the failure should be ErrIncompatibleBitVectorLength")
 }
 
 func TestValidPaddingErrIllegallyPaddedBitVector(t *testing.T) {
@@ -210,23 +208,23 @@ func TestValidPaddingErrIllegallyPaddedBitVector(t *testing.T) {
 	for count := 1; count < 8; count++ {
 		signers = unittest.IdentityListFixture(count)
 		_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(255)}) // last bit should be 0, but 1
-		require.Error(t, err)
-		require.ErrorAs(t, err, &signature.ErrIllegallyPaddedBitVector)
+		require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+		require.ErrorIs(t, err, signature.ErrIllegallyPaddedBitVector, "low-level error representing the failure should be ErrIllegallyPaddedBitVector")
 
 		_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(1)}) // last bit should be 0, but 1
-		require.Error(t, err)
-		require.ErrorAs(t, err, &signature.ErrIllegallyPaddedBitVector)
+		require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+		require.ErrorIs(t, err, signature.ErrIllegallyPaddedBitVector, "low-level error representing the failure should be ErrIllegallyPaddedBitVector")
 	}
 
 	for count := 9; count < 16; count++ {
 		signers = unittest.IdentityListFixture(count)
 		_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(255), byte(255)}) // last bit should be 0, but 1
-		require.Error(t, err)
-		require.ErrorAs(t, err, &signature.ErrIllegallyPaddedBitVector)
+		require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+		require.ErrorIs(t, err, signature.ErrIllegallyPaddedBitVector, "low-level error representing the failure should be ErrIllegallyPaddedBitVector")
 
 		_, _, err = signature.DecodeSigTypeToStakingAndBeaconSigners(signers, []byte{byte(1), byte(1)}) // last bit should be 0, but 1
-		require.Error(t, err)
-		require.ErrorAs(t, err, &signature.ErrIllegallyPaddedBitVector)
+		require.True(t, signature.IsInvalidSigTypesError(err), "API-level error should be InvalidSigTypesError")
+		require.ErrorIs(t, err, signature.ErrIllegallyPaddedBitVector, "low-level error representing the failure should be ErrIllegallyPaddedBitVector")
 	}
 }
 

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -330,9 +330,9 @@ func (m *MutableState) guaranteeExtend(ctx context.Context, candidate *flow.Bloc
 		// check the guarantors are correct
 		_, err = protocol.FindGuarantors(m, guarantee)
 		if err != nil {
-			if signature.IsDecodeSignerIndicesError(err) ||
-				errors.As(err, &protocol.ErrEpochNotCommitted) ||
-				errors.As(err, &protocol.ErrClusterNotFound) {
+			if signature.IsInvalidSignerIndicesError(err) ||
+				errors.Is(err, protocol.ErrEpochNotCommitted) ||
+				errors.Is(err, protocol.ErrClusterNotFound) {
 				return state.NewInvalidExtensionErrorf("guarantee %v contains invalid guarantors: %w", guarantee.ID(), err)
 			}
 			return fmt.Errorf("could not find guarantor for guarantee %v: %w", guarantee.ID(), err)

--- a/state/protocol/util.go
+++ b/state/protocol/util.go
@@ -73,7 +73,7 @@ func IsSporkRootSnapshot(snapshot Snapshot) (bool, error) {
 
 // FindGuarantors decodes the signer indices from the guarantee, and finds the guarantor identifiers from protocol state
 // Expected Error returns during normal operations:
-//  * signature.InvalidSignerIndicesError is `signerIndices` does not encode a valid set of collection guarantors
+//  * signature.InvalidSignerIndicesError if `signerIndices` does not encode a valid set of collection guarantors
 //  * storage.ErrNotFound if the guarantee's ReferenceBlockID is not found
 //  * protocol.ErrEpochNotCommitted if epoch has not been committed yet
 //  * protocol.ErrClusterNotFound if cluster is not found by the given chainID

--- a/state/protocol/util.go
+++ b/state/protocol/util.go
@@ -73,9 +73,7 @@ func IsSporkRootSnapshot(snapshot Snapshot) (bool, error) {
 
 // FindGuarantors decodes the signer indices from the guarantee, and finds the guarantor identifiers from protocol state
 // Expected Error returns during normal operations:
-//  * signature.ErrIncompatibleBitVectorLength indicates that `signerIndices` has the wrong length
-//  * signature.ErrIllegallyPaddedBitVector is the vector is padded with bits other than 0
-//  * signature.ErrInvalidChecksum if the input is shorter than the expected checksum contained in the guarantee.SignerIndices
+//  * signature.InvalidSignerIndicesError is `signerIndices` does not encode a valid set of collection guarantors
 //  * storage.ErrNotFound if the guarantee's ReferenceBlockID is not found
 //  * protocol.ErrEpochNotCommitted if epoch has not been committed yet
 //  * protocol.ErrClusterNotFound if cluster is not found by the given chainID


### PR DESCRIPTION
## Suggestion for PR https://github.com/onflow/flow-go/pull/

_Context_
I consider methods like the following as generally unsafe 
https://github.com/onflow/flow-go/blob/632d86098f05e025d52c27692a580d67cf49c9d4/module/signature/errors.go#L112-L117
reasoning:
* In my experience they incentivise engineers to so skip expected byzantine paths in the protocol. For example, the engineer extend method [`DecodeSignerIndicesToIdentifiers`](https://github.com/onflow/flow-go/blob/632d86098f05e025d52c27692a580d67cf49c9d4/module/signature/signer_indices.go#L217) and introduce another sentinel error `X`. For their particular use case, `X` is expected during normal operations, so they add it to `IsDecodeSignerIndicesError`. However, in other segments of the code, this error might not be expected. But by adding `X` to `IsDecodeSignerIndicesError`, the engineer has now broken the Byzantine resilience of other parts of the protocol implementation. In my experience, methods like `IsDecodeSignerIndicesError` create the false impression that certain errors are expected/unexpected irrespective of their content. 
  
  Btw, a while back _exactly_ the situation described happened. Newer team members commonly struggle with internalizing the different engineering requirement for Flow, specifically that they do give enough considerations to the recovery paths from expected byzantine failures and just treat them as errors. Therefore, it is important to me to avoid pattens entirely that of incentivise engineers to rush through error handling logic, including the pattern of "introduce a function that universally classifies errors into expected and unexpected". 

* Having said all this, there are cases, where some set of sentinel errors _universally_ indicate a byzantine input. I think this is the case for [`DecodeSignerIndicesToIdentifiers`](https://github.com/onflow/flow-go/blob/632d86098f05e025d52c27692a580d67cf49c9d4/module/signature/signer_indices.go#L217). In this case, I would suggest to have the implementation already consolidate the errors. 


_Suggested Solution_

In our current example, we have 3 errors that all signal that the input violates protocol rules: https://github.com/onflow/flow-go/blob/632d86098f05e025d52c27692a580d67cf49c9d4/module/signature/signer_indices.go#L214-L217 The higher-level code is essentially only interested whether this is a broken input or not (highlighted by the existence of function `IsDecodeSignerIndicesError`). So why not have `DecodeSignerIndicesToIdentifiers` return a higher-level error (called `InvalidSignerIndicesError`)? 
* Thereby we avoid adding patters to the code base that we know incentivise new engineers to unsafe designs. 
* The API of `DecodeSignerIndicesToIdentifiers` becomes thinner, because we reduce the number of cases that the higher-level implementations have to handle when calling into `DecodeSignerIndicesToIdentifiers`.


This PR implements the suggestion ☝️: for [`DecodeSigTypeToStakingAndBeaconSigners`](https://github.com/onflow/flow-go/blob/4fbfb368a5c7b6b776121762acb657aeeca0c5d2/module/signature/signer_indices.go#L123), [`DecodeSignerIndicesToIdentifiers`](https://github.com/onflow/flow-go/blob/4fbfb368a5c7b6b776121762acb657aeeca0c5d2/module/signature/signer_indices.go#L218) and [`DecodeSignerIndicesToIdentities`](https://github.com/onflow/flow-go/blob/4fbfb368a5c7b6b776121762acb657aeeca0c5d2/module/signature/signer_indices.go#L259) the error handling is integrated into the functions themselves. They now wrap the lower-level errors into `signature.InvalidSignerIndicesError` and `signature.IsInvalidSigTypesError` respectively. Higher-level code now has to check only for these errors, which eliminates the need for `IsDecodeSignerIndicesError`. Tests are updated. 
