### PR TITLE
Update to Cadence 8b113c539a2c, atree 525fbc26f40a, and CBOR ad2eae63303f

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.4
 	github.com/ef-ds/deque v1.0.4
 	github.com/ethereum/go-ethereum v1.9.13
-	github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0
+	github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f
 	github.com/gammazero/workerpool v1.1.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
@@ -53,8 +53,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
-	github.com/onflow/atree v0.3.1-0.20220519142403-b0077ba343ec
-	github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d
+	github.com/onflow/atree v0.3.1-0.20220531231935-525fbc26f40a
+	github.com/onflow/cadence v0.21.3-0.20220601002855-8b113c539a2c
 	github.com/onflow/flow v0.3.0
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220513155751-c4c1f8d59f83
@@ -296,6 +296,6 @@ require (
 
 replace mellium.im/sasl => github.com/mellium/sasl v0.2.1
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.21.1-0.20220525172553-085b0fcef7e9
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.21.1-0.20220601005416-e974acd91285
 
-replace github.com/onflow/atree => github.com/dapperlabs/atree-internal v0.3.1-0.20220525190018-9e7903687c38
+replace github.com/onflow/atree => github.com/dapperlabs/atree-internal v0.3.1-0.20220531232335-32d7f2ac0ce1

--- a/go.sum
+++ b/go.sum
@@ -284,10 +284,10 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
-github.com/dapperlabs/atree-internal v0.3.1-0.20220525190018-9e7903687c38 h1:Cc7JQN9pPAXFSNZ09ERCNu83943FvWtP45sQCkzf00I=
-github.com/dapperlabs/atree-internal v0.3.1-0.20220525190018-9e7903687c38/go.mod h1:ujKt3moaqv8Cv236rYpSoxNpHzNUy4Wih0U4GPvPZ1g=
-github.com/dapperlabs/cadence-internal v0.21.1-0.20220525172553-085b0fcef7e9 h1:HBu5JZfRAvFqAmaZYxU1SQ4PmcDv18GTVeW0LLOrv7g=
-github.com/dapperlabs/cadence-internal v0.21.1-0.20220525172553-085b0fcef7e9/go.mod h1:MfEvTq9dvGhnoyqUqsKBsZBM5V4SytllHMqHM+6Lki0=
+github.com/dapperlabs/atree-internal v0.3.1-0.20220531232335-32d7f2ac0ce1 h1:66SKJYf5tDCIh534DrkDJuWHJxiLJN09ntRALaGXD5I=
+github.com/dapperlabs/atree-internal v0.3.1-0.20220531232335-32d7f2ac0ce1/go.mod h1:PZESmRR4bI/w/9nEDCqRoWxBq/jFNUEzkfypHf0j8cw=
+github.com/dapperlabs/cadence-internal v0.21.1-0.20220601005416-e974acd91285 h1:ES+dloduMk9p+Rx4QlqKfn8BsyfZ04U5RtVGW4TVy6c=
+github.com/dapperlabs/cadence-internal v0.21.1-0.20220601005416-e974acd91285/go.mod h1:FliGP1FZLEuSemnSf8pKItDzW7E2cvPukx/SsE1+oCo=
 github.com/dapperlabs/testingdock v0.4.4 h1:nDpnEjhs2gNv7rcb70PTfHlL3yr4eQycqp0+oFuhyNg=
 github.com/dapperlabs/testingdock v0.4.4/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -390,8 +390,9 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0 h1:4i+hJzGuDJs2qYo2rFjNrEYyzQdzjJOzNUR9p20VHyo=
 github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f h1:dxTR4AaxCwuQv9LAVTAC2r1szlS+epeuPT5ClLKT6ZY=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/gammazero/deque v0.1.0 h1:f9LnNmq66VDeuAlSAapemq/U7hJ2jpIWa4c09q8Dlik=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
-	github.com/onflow/cadence v0.21.3-0.20220520204606-7b9689d79a2d
+	github.com/onflow/cadence v0.21.3-0.20220601002855-8b113c539a2c
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220513155751-c4c1f8d59f83
 	github.com/onflow/flow-emulator v0.31.2-0.20220513151845-ef7513cb1cd0
@@ -76,7 +76,7 @@ require (
 	github.com/flynn/noise v1.0.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0 // indirect
+	github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f // indirect
 	github.com/fxamacker/circlehash v0.3.0 // indirect
 	github.com/gammazero/deque v0.1.0 // indirect
 	github.com/gammazero/workerpool v1.1.2 // indirect
@@ -210,7 +210,7 @@ require (
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/onflow/atree v0.3.1-0.20220519142403-b0077ba343ec // indirect
+	github.com/onflow/atree v0.3.1-0.20220531231935-525fbc26f40a // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.5.0 // indirect
 	github.com/onflow/sdks v0.4.2 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
@@ -296,6 +296,6 @@ require (
 
 replace github.com/onflow/flow-go => ../
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.21.1-0.20220525172553-085b0fcef7e9
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.21.1-0.20220601005416-e974acd91285
 
-replace github.com/onflow/atree => github.com/dapperlabs/atree-internal v0.3.1-0.20220525190018-9e7903687c38
+replace github.com/onflow/atree => github.com/dapperlabs/atree-internal v0.3.1-0.20220531232335-32d7f2ac0ce1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -295,10 +295,10 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
-github.com/dapperlabs/atree-internal v0.3.1-0.20220525190018-9e7903687c38 h1:Cc7JQN9pPAXFSNZ09ERCNu83943FvWtP45sQCkzf00I=
-github.com/dapperlabs/atree-internal v0.3.1-0.20220525190018-9e7903687c38/go.mod h1:ujKt3moaqv8Cv236rYpSoxNpHzNUy4Wih0U4GPvPZ1g=
-github.com/dapperlabs/cadence-internal v0.21.1-0.20220525172553-085b0fcef7e9 h1:HBu5JZfRAvFqAmaZYxU1SQ4PmcDv18GTVeW0LLOrv7g=
-github.com/dapperlabs/cadence-internal v0.21.1-0.20220525172553-085b0fcef7e9/go.mod h1:MfEvTq9dvGhnoyqUqsKBsZBM5V4SytllHMqHM+6Lki0=
+github.com/dapperlabs/atree-internal v0.3.1-0.20220531232335-32d7f2ac0ce1 h1:66SKJYf5tDCIh534DrkDJuWHJxiLJN09ntRALaGXD5I=
+github.com/dapperlabs/atree-internal v0.3.1-0.20220531232335-32d7f2ac0ce1/go.mod h1:PZESmRR4bI/w/9nEDCqRoWxBq/jFNUEzkfypHf0j8cw=
+github.com/dapperlabs/cadence-internal v0.21.1-0.20220601005416-e974acd91285 h1:ES+dloduMk9p+Rx4QlqKfn8BsyfZ04U5RtVGW4TVy6c=
+github.com/dapperlabs/cadence-internal v0.21.1-0.20220601005416-e974acd91285/go.mod h1:FliGP1FZLEuSemnSf8pKItDzW7E2cvPukx/SsE1+oCo=
 github.com/dapperlabs/testingdock v0.4.4 h1:nDpnEjhs2gNv7rcb70PTfHlL3yr4eQycqp0+oFuhyNg=
 github.com/dapperlabs/testingdock v0.4.4/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
@@ -408,8 +408,9 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0 h1:4i+hJzGuDJs2qYo2rFjNrEYyzQdzjJOzNUR9p20VHyo=
 github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f h1:dxTR4AaxCwuQv9LAVTAC2r1szlS+epeuPT5ClLKT6ZY=
+github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/gammazero/deque v0.1.0 h1:f9LnNmq66VDeuAlSAapemq/U7hJ2jpIWa4c09q8Dlik=


### PR DESCRIPTION
Just like for `master` in #2525, update to the latest versions of Cadence, atree, and CBOR in the 0.26 release branch.

In addition, update to the internal version, which point to:
- https://github.com/dapperlabs/cadence-internal/pull/89
- https://github.com/dapperlabs/atree-internal/pull/4