### PR TITLE
[Fix] add explicit mapping of cluster prefix -> message codes

### DIFF
--- a/engine/channels.go
+++ b/engine/channels.go
@@ -114,11 +114,11 @@ const (
 
 	// Channels for consensus protocols
 	ConsensusCommittee     = network.Channel("consensus-committee")
-	consensusClusterPrefix = "consensus-cluster" // dynamic channel, use ChannelConsensusCluster function
+	ConsensusClusterPrefix = "consensus-cluster" // dynamic channel, use ChannelConsensusCluster function
 
 	// Channels for protocols actively synchronizing state across nodes
 	SyncCommittee     = network.Channel("sync-committee")
-	syncClusterPrefix = "sync-cluster" // dynamic channel, use ChannelSyncCluster function
+	SyncClusterPrefix = "sync-cluster" // dynamic channel, use ChannelSyncCluster function
 	SyncExecution     = network.Channel("sync-execution")
 
 	// Channels for dkg communication
@@ -208,20 +208,21 @@ func initializeChannelRoleMap() {
 
 	clusterChannelPrefixRoleMap = make(map[string]flow.RoleList)
 
-	clusterChannelPrefixRoleMap[syncClusterPrefix] = flow.RoleList{flow.RoleCollection}
-	clusterChannelPrefixRoleMap[consensusClusterPrefix] = flow.RoleList{flow.RoleCollection}
+	clusterChannelPrefixRoleMap[SyncClusterPrefix] = flow.RoleList{flow.RoleCollection}
+	clusterChannelPrefixRoleMap[ConsensusClusterPrefix] = flow.RoleList{flow.RoleCollection}
 }
 
 // ClusterChannelRoles returns the list of roles that are involved in the given cluster-based channel.
 func ClusterChannelRoles(clusterChannel network.Channel) flow.RoleList {
-	if prefix, ok := clusterChannelPrefix(clusterChannel); ok {
+	if prefix, ok := ClusterChannelPrefix(clusterChannel); ok {
 		return clusterChannelPrefixRoleMap[prefix]
 	}
 
 	return flow.RoleList{}
 }
 
-func clusterChannelPrefix(clusterChannel network.Channel) (string, bool) {
+// ClusterChannelPrefix returns the cluster channel prefix and true if clusterChannel exists inclusterChannelPrefixRoleMap
+func ClusterChannelPrefix(clusterChannel network.Channel) (string, bool) {
 	for prefix := range clusterChannelPrefixRoleMap {
 		if strings.HasPrefix(clusterChannel.String(), prefix) {
 			return prefix, true
@@ -234,7 +235,7 @@ func clusterChannelPrefix(clusterChannel network.Channel) (string, bool) {
 // IsClusterChannel returns true if channel is cluster-based.
 // Currently, only collection nodes are involved in a cluster-based channels.
 func IsClusterChannel(channel network.Channel) bool {
-	_, ok := clusterChannelPrefix(channel)
+	_, ok := ClusterChannelPrefix(channel)
 	return ok
 }
 
@@ -265,11 +266,11 @@ func ChannelFromTopic(topic network.Topic) (network.Channel, bool) {
 // ChannelConsensusCluster returns a dynamic cluster consensus channel based on
 // the chain ID of the cluster in question.
 func ChannelConsensusCluster(clusterID flow.ChainID) network.Channel {
-	return network.Channel(fmt.Sprintf("%s-%s", consensusClusterPrefix, clusterID))
+	return network.Channel(fmt.Sprintf("%s-%s", ConsensusClusterPrefix, clusterID))
 }
 
 // ChannelSyncCluster returns a dynamic cluster sync channel based on the chain
 // ID of the cluster in question.
 func ChannelSyncCluster(clusterID flow.ChainID) network.Channel {
-	return network.Channel(fmt.Sprintf("%s-%s", syncClusterPrefix, clusterID))
+	return network.Channel(fmt.Sprintf("%s-%s", SyncClusterPrefix, clusterID))
 }

--- a/network/codec/cbor/msg_channel_mapping.go
+++ b/network/codec/cbor/msg_channel_mapping.go
@@ -55,4 +55,8 @@ func initializeChannelToMsgCodesMap() {
 
 	// dkg
 	ChannelToMsgCodes[channels.DKGCommittee] = []uint8{CodeDKGMessage}
+
+	// cluster based channels
+	ChannelToMsgCodes[channels.SyncClusterPrefix] = []uint8{CodeSyncRequest, CodeSyncResponse, CodeRangeRequest, CodeBatchRequest, CodeBlockResponse}
+	ChannelToMsgCodes[channels.ConsensusClusterPrefix] = []uint8{CodeClusterBlockProposal, CodeClusterBlockVote, CodeClusterBlockResponse}
 }

--- a/network/p2p/topic_validator_test.go
+++ b/network/p2p/topic_validator_test.go
@@ -423,7 +423,7 @@ func TestAuthorizedSenderValidator_ClusterChannel(t *testing.T) {
 	timedCtx, cancel5s := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel5s()
 	// create a dummy sync request to publish from our LN node
-	data := getMsgFixtureBz(t, &messages.SyncRequest{})
+	data := getMsgFixtureBz(t, &messages.RangeRequest{})
 
 	// ln2 publishes the sync request on the cluster channel
 	err = ln2.Publish(timedCtx, topic, data)

--- a/network/validator/pubsub/authorized_sender_validator.go
+++ b/network/validator/pubsub/authorized_sender_validator.go
@@ -100,21 +100,8 @@ func getRoles(channel network.Channel, msgTypeCode uint8) (flow.RoleList, error)
 		return flow.Roles(), nil
 	}
 
-	// cluster channels have a dynamic channel name
-	if msgTypeCode == cborcodec.CodeClusterBlockProposal ||
-		msgTypeCode == cborcodec.CodeClusterBlockVote ||
-		msgTypeCode == cborcodec.CodeClusterBlockResponse {
-		return channels.ClusterChannelRoles(channel), nil
-	}
-
-	// check if msg is cluster sync request. The sync request message is used on
-	// sync-cluster prefixed channels as well as the SyncCommittee channel.
-	if msgTypeCode == cborcodec.CodeSyncRequest && channels.IsClusterChannel(channel) {
-		return channels.ClusterChannelRoles(channel), nil
-	}
-
 	// get message type codes for all messages communicated on the channel
-	codes, ok := cborcodec.ChannelToMsgCodes[channel]
+	codes, ok := getCodes(channel)
 	if !ok {
 		return nil, fmt.Errorf("could not get message codes for unknown channel: %s", channel)
 	}
@@ -131,6 +118,17 @@ func getRoles(channel network.Channel, msgTypeCode uint8) (flow.RoleList, error)
 	}
 
 	return roles, nil
+}
+
+// getCodes checks if channel is a cluster prefixed channel before returning msg codes
+func getCodes(channel network.Channel) ([]uint8, bool) {
+	if prefix, ok := channels.ClusterChannelPrefix(channel); ok {
+		codes, ok := cborcodec.ChannelToMsgCodes[network.Channel(prefix)]
+		return codes, ok
+	}
+
+	codes, ok := cborcodec.ChannelToMsgCodes[channel]
+	return codes, ok
 }
 
 func containsCode(codes []uint8, code uint8) bool {


### PR DESCRIPTION
This PR fixes missing message codes sent on cluster prefixed channels  causing false-negative validations in the libP2P authorized sender validator. 