### PR TITLE
Add state migration for Flow Core Contracts

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -69,7 +69,9 @@ func extractExecutionState(
 		}
 
 		coreContractMigration := mgr.CoreContractsMigration{
-			Log: log,
+			Log:       log,
+			Chain:     chain,
+			OutputDir: outputDir,
 		}
 
 		migrations = []ledger.Migration{

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -68,7 +68,12 @@ func extractExecutionState(
 			OutputDir: outputDir,
 		}
 
+		coreContractMigration := mgr.CoreContractsMigration{
+			Log: log,
+		}
+
 		migrations = []ledger.Migration{
+			coreContractMigration.Migrate,
 			storageUsedUpdateMigration.Migrate,
 			mgr.PruneMigration,
 		}

--- a/cmd/util/ledger/migrations/core_contracts_migration.go
+++ b/cmd/util/ledger/migrations/core_contracts_migration.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -225,13 +226,13 @@ func (m *CoreContractsMigration) Migrate(payloads []ledger.Payload) ([]ledger.Pa
 	addresses := coreContractAddresses(m.Chain)
 	codes := coreContractCodes(addresses)
 
-	for _, payload := range payloads {
+	for i, payload := range payloads {
 		key := string(payload.Key.KeyParts[2].Value)
 		if !strings.HasPrefix(key, codeKeyPrefix) {
 			continue
 		}
 
-		owner := string(payload.Key.KeyParts[0].Value)
+		owner := hex.EncodeToString(payload.Key.KeyParts[0].Value)
 
 		addressCodes, ok := codes[owner]
 		if !ok {
@@ -246,7 +247,7 @@ func (m *CoreContractsMigration) Migrate(payloads []ledger.Payload) ([]ledger.Pa
 			continue
 		}
 
-		payload.Value = newCode
+		payloads[i].Value = newCode
 
 		m.Log.Info().Msgf("Updated core contract: %s.%s", owner, contractName)
 

--- a/cmd/util/ledger/migrations/core_contracts_migration.go
+++ b/cmd/util/ledger/migrations/core_contracts_migration.go
@@ -1,0 +1,264 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog"
+
+	coreContracts "github.com/onflow/flow-core-contracts/lib/go/contracts"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+type ContractLocation struct {
+	address, contractName string
+}
+
+type CoreContractsMigration struct {
+	Log     zerolog.Logger
+	Chain   flow.ChainID
+	Updates map[ContractLocation]struct{}
+}
+
+type networkAddresses struct {
+	fungibleToken     string
+	flowToken         string
+	contractAudits    string
+	serviceAccount    string
+	fees              string
+	storageFees       string
+	qc                string
+	epoch             string
+	dkg               string
+	stakingTable      string
+	lockedTokens      string
+	stakingProxy      string
+	stakingCollection string
+}
+
+func coreContractAddresses(chain flow.ChainID) networkAddresses {
+	switch chain {
+	case flow.Testnet:
+		return networkAddresses{
+			fungibleToken:     "9a0766d93b6608b7",
+			flowToken:         "7e60df042a9c0868",
+			contractAudits:    "8c5303eaa26202d6",
+			serviceAccount:    "8c5303eaa26202d6",
+			storageFees:       "8c5303eaa26202d6",
+			fees:              "912d5440f7e3769e",
+			qc:                "9eca2b38b18b5dfe",
+			epoch:             "9eca2b38b18b5dfe",
+			dkg:               "9eca2b38b18b5dfe",
+			stakingTable:      "9eca2b38b18b5dfe",
+			lockedTokens:      "95e019a17d0e23d7",
+			stakingCollection: "95e019a17d0e23d7",
+			stakingProxy:      "7aad92e5a0715d21",
+		}
+	case flow.Mainnet:
+		// TODO:
+		panic("TODO")
+	default:
+		panic(fmt.Errorf("unsupported chain: %s", chain))
+	}
+}
+
+func coreContractCodes(addresses networkAddresses) map[string]map[string][]byte {
+	codes := map[string]map[string][]byte{}
+
+	addCode := func(address, name string, code []byte) {
+		addressCodes, ok := codes[address]
+		if !ok {
+			addressCodes = map[string][]byte{}
+			codes[address] = addressCodes
+		}
+		addressCodes[name] = code
+	}
+
+	addCode(
+		addresses.contractAudits,
+		"FlowContractAudits",
+		coreContracts.FlowContractAudits(),
+	)
+	addCode(
+		addresses.serviceAccount,
+		"FlowServiceAccount",
+		coreContracts.FlowServiceAccount(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
+			// flowFeesAddress:
+			addresses.fees,
+			// storageFeesAddress:
+			addresses.storageFees,
+		),
+	)
+	addCode(
+		addresses.storageFees,
+		"FlowStorageFees",
+		coreContracts.FlowStorageFees(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
+		),
+	)
+	addCode(
+		addresses.fees,
+		"FlowFees",
+		coreContracts.FlowFees(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
+		),
+	)
+	addCode(
+		addresses.qc,
+		"FlowClusterQC",
+		coreContracts.FlowQC(),
+	)
+	addCode(
+		addresses.dkg,
+		"FlowDKG",
+		coreContracts.FlowDKG(),
+	)
+	addCode(
+		addresses.epoch,
+		"FlowEpoch",
+		coreContracts.FlowEpoch(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
+			// idTableAddress:
+			addresses.stakingTable,
+			// qcAddress:
+			addresses.qc,
+			// dkgAddress:
+			addresses.dkg,
+			// flowFeesAddress:
+			addresses.fees,
+		),
+	)
+	addCode(
+		addresses.stakingTable,
+		"FlowIDTableStaking",
+		coreContracts.FlowIDTableStaking(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
+			// flowFeesAddress:
+			addresses.fees,
+			// latest:
+			true,
+		),
+	)
+	addCode(
+		addresses.lockedTokens,
+		"LockedTokens",
+		coreContracts.FlowLockedTokens(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
+			// idTableAddress:
+			addresses.stakingTable,
+			// stakingProxyAddress:
+			addresses.stakingProxy,
+			// storageFeesAddress:
+			addresses.storageFees,
+		),
+	)
+	addCode(
+		addresses.stakingCollection,
+		"FlowStakingCollection",
+		coreContracts.FlowStakingCollection(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
+			// idTableAddress:
+			addresses.stakingTable,
+			// stakingProxyAddress:
+			addresses.stakingProxy,
+			// lockedTokensAddress:
+			addresses.lockedTokens,
+			// storageFeesAddress:
+			addresses.storageFees,
+			// qcAddress:
+			addresses.qc,
+			// dkgAddress:
+			addresses.dkg,
+			// epochAddress:
+			addresses.epoch,
+		),
+	)
+	addCode(
+		addresses.flowToken,
+		"FlowToken",
+		coreContracts.FlowToken(
+			// fungibleTokenAddress:
+			addresses.fungibleToken,
+		),
+	)
+	addCode(
+		addresses.stakingProxy,
+		"StakingProxy",
+		coreContracts.FlowStakingProxy(),
+	)
+
+	return codes
+}
+
+const codeKeyPrefix = "code."
+
+func (m *CoreContractsMigration) Migrate(payloads []ledger.Payload) ([]ledger.Payload, error) {
+
+	m.Updates = map[ContractLocation]struct{}{}
+
+	m.Log.Info().Msgf("Running Core Contracts migration")
+
+	addresses := coreContractAddresses(m.Chain)
+	codes := coreContractCodes(addresses)
+
+	for _, payload := range payloads {
+		key := string(payload.Key.KeyParts[2].Value)
+		if !strings.HasPrefix(key, codeKeyPrefix) {
+			continue
+		}
+
+		owner := string(payload.Key.KeyParts[0].Value)
+
+		addressCodes, ok := codes[owner]
+		if !ok {
+			continue
+		}
+
+		contractName := strings.TrimPrefix(key, codeKeyPrefix)
+
+		newCode, ok := addressCodes[contractName]
+		if !ok {
+			m.Log.Warn().Msgf("unknown contract: %s", contractName)
+			continue
+		}
+
+		payload.Value = newCode
+
+		m.Log.Info().Msgf("Updated core contract: %s.%s", owner, contractName)
+
+		location := ContractLocation{
+			address:      owner,
+			contractName: contractName,
+		}
+
+		m.Updates[location] = struct{}{}
+	}
+
+	m.Log.Info().Msg("Core Contracts update complete.")
+
+	return payloads, nil
+}

--- a/cmd/util/ledger/migrations/core_contracts_migration.go
+++ b/cmd/util/ledger/migrations/core_contracts_migration.go
@@ -259,6 +259,20 @@ func (m *CoreContractsMigration) Migrate(payloads []ledger.Payload) ([]ledger.Pa
 		m.Updates[location] = struct{}{}
 	}
 
+	// Validate all contracts were updated
+
+	for address, addressCodes := range codes {
+		for contractName := range addressCodes {
+			location := ContractLocation{
+				address:      address,
+				contractName: contractName,
+			}
+			if _, ok := m.Updates[location]; !ok {
+				m.Log.Warn().Msgf("Core Contract was not found and not updated: %s.%s", address, contractName)
+			}
+		}
+	}
+
 	m.Log.Info().Msg("Core Contracts update complete.")
 
 	return payloads, nil

--- a/cmd/util/ledger/migrations/core_contracts_migration.go
+++ b/cmd/util/ledger/migrations/core_contracts_migration.go
@@ -23,7 +23,7 @@ type ContractLocation struct {
 
 type CoreContractsMigration struct {
 	Log       zerolog.Logger
-	Chain     flow.ChainID
+	Chain     flow.Chain
 	OutputDir string
 	Updates   map[ContractLocation]struct{}
 }
@@ -44,8 +44,8 @@ type networkAddresses struct {
 	stakingCollection string
 }
 
-func coreContractAddresses(chain flow.ChainID) networkAddresses {
-	switch chain {
+func coreContractAddresses(chain flow.Chain) networkAddresses {
+	switch chain.ChainID() {
 	case flow.Testnet:
 		return networkAddresses{
 			fungibleToken:     "9a0766d93b6608b7",

--- a/cmd/util/ledger/migrations/core_contracts_migration.go
+++ b/cmd/util/ledger/migrations/core_contracts_migration.go
@@ -83,11 +83,6 @@ func coreContractCodes(addresses networkAddresses) map[string]map[string][]byte 
 	}
 
 	addCode(
-		addresses.contractAudits,
-		"FlowContractAudits",
-		coreContracts.FlowContractAudits(),
-	)
-	addCode(
 		addresses.serviceAccount,
 		"FlowServiceAccount",
 		coreContracts.FlowServiceAccount(
@@ -102,54 +97,6 @@ func coreContractCodes(addresses networkAddresses) map[string]map[string][]byte 
 		),
 	)
 	addCode(
-		addresses.storageFees,
-		"FlowStorageFees",
-		coreContracts.FlowStorageFees(
-			// fungibleTokenAddress:
-			addresses.fungibleToken,
-			// flowTokenAddress:
-			addresses.flowToken,
-		),
-	)
-	addCode(
-		addresses.fees,
-		"FlowFees",
-		coreContracts.FlowFees(
-			// fungibleTokenAddress:
-			addresses.fungibleToken,
-			// flowTokenAddress:
-			addresses.flowToken,
-		),
-	)
-	addCode(
-		addresses.qc,
-		"FlowClusterQC",
-		coreContracts.FlowQC(),
-	)
-	addCode(
-		addresses.dkg,
-		"FlowDKG",
-		coreContracts.FlowDKG(),
-	)
-	addCode(
-		addresses.epoch,
-		"FlowEpoch",
-		coreContracts.FlowEpoch(
-			// fungibleTokenAddress:
-			addresses.fungibleToken,
-			// flowTokenAddress:
-			addresses.flowToken,
-			// idTableAddress:
-			addresses.stakingTable,
-			// qcAddress:
-			addresses.qc,
-			// dkgAddress:
-			addresses.dkg,
-			// flowFeesAddress:
-			addresses.fees,
-		),
-	)
-	addCode(
 		addresses.stakingTable,
 		"FlowIDTableStaking",
 		coreContracts.FlowIDTableStaking(
@@ -161,22 +108,6 @@ func coreContractCodes(addresses networkAddresses) map[string]map[string][]byte 
 			addresses.fees,
 			// latest:
 			true,
-		),
-	)
-	addCode(
-		addresses.lockedTokens,
-		"LockedTokens",
-		coreContracts.FlowLockedTokens(
-			// fungibleTokenAddress:
-			addresses.fungibleToken,
-			// flowTokenAddress:
-			addresses.flowToken,
-			// idTableAddress:
-			addresses.stakingTable,
-			// stakingProxyAddress:
-			addresses.stakingProxy,
-			// storageFeesAddress:
-			addresses.storageFees,
 		),
 	)
 	addCode(
@@ -204,18 +135,91 @@ func coreContractCodes(addresses networkAddresses) map[string]map[string][]byte 
 		),
 	)
 	addCode(
-		addresses.flowToken,
-		"FlowToken",
-		coreContracts.FlowToken(
+		addresses.storageFees,
+		"FlowStorageFees",
+		coreContracts.FlowStorageFees(
 			// fungibleTokenAddress:
 			addresses.fungibleToken,
+			// flowTokenAddress:
+			addresses.flowToken,
 		),
 	)
 	addCode(
-		addresses.stakingProxy,
-		"StakingProxy",
-		coreContracts.FlowStakingProxy(),
+		addresses.qc,
+		"FlowClusterQC",
+		coreContracts.FlowQC(),
 	)
+
+	//// Other contracts which were not updated:
+
+	//addCode(
+	//	addresses.contractAudits,
+	//	"FlowContractAudits",
+	//	coreContracts.FlowContractAudits(),
+	//)
+	//addCode(
+	//	addresses.fees,
+	//	"FlowFees",
+	//	coreContracts.FlowFees(
+	//		// fungibleTokenAddress:
+	//		addresses.fungibleToken,
+	//		// flowTokenAddress:
+	//		addresses.flowToken,
+	//	),
+	//)
+	//addCode(
+	//	addresses.dkg,
+	//	"FlowDKG",
+	//	coreContracts.FlowDKG(),
+	//)
+	//addCode(
+	//	addresses.epoch,
+	//	"FlowEpoch",
+	//	coreContracts.FlowEpoch(
+	//		// fungibleTokenAddress:
+	//		addresses.fungibleToken,
+	//		// flowTokenAddress:
+	//		addresses.flowToken,
+	//		// idTableAddress:
+	//		addresses.stakingTable,
+	//		// qcAddress:
+	//		addresses.qc,
+	//		// dkgAddress:
+	//		addresses.dkg,
+	//		// flowFeesAddress:
+	//		addresses.fees,
+	//	),
+	//)
+	//addCode(
+	//	addresses.lockedTokens,
+	//	"LockedTokens",
+	//	coreContracts.FlowLockedTokens(
+	//		// fungibleTokenAddress:
+	//		addresses.fungibleToken,
+	//		// flowTokenAddress:
+	//		addresses.flowToken,
+	//		// idTableAddress:
+	//		addresses.stakingTable,
+	//		// stakingProxyAddress:
+	//		addresses.stakingProxy,
+	//		// storageFeesAddress:
+	//		addresses.storageFees,
+	//	),
+	//)
+	//
+	//addCode(
+	//	addresses.flowToken,
+	//	"FlowToken",
+	//	coreContracts.FlowToken(
+	//		// fungibleTokenAddress:
+	//		addresses.fungibleToken,
+	//	),
+	//)
+	//addCode(
+	//	addresses.stakingProxy,
+	//	"StakingProxy",
+	//	coreContracts.FlowStakingProxy(),
+	//)
 
 	return codes
 }

--- a/cmd/util/ledger/migrations/core_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/core_contracts_migration_test.go
@@ -1,0 +1,43 @@
+package migrations_test
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestCoreContractsMigration(t *testing.T) {
+
+	t.Run("other payloads are not modified", func(t *testing.T) {
+
+		migration := migrations.CoreContractsMigration{
+			Log:   zerolog.Logger{},
+			Chain: flow.Testnet,
+		}
+
+		input := []ledger.Payload{
+			{
+				Key: ledger.Key{
+					KeyParts: []ledger.KeyPart{
+						{Value: []byte{}},
+						{},
+						{Value: []byte("otherKey")},
+					},
+				},
+				Value: []byte("other"),
+			},
+		}
+
+		output, err := migration.Migrate(input)
+		require.NoError(t, err)
+
+		require.Len(t, output, 1)
+		require.Equal(t, ledger.Value("other"), output[0].Value)
+	})
+
+}

--- a/cmd/util/ledger/migrations/core_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/core_contracts_migration_test.go
@@ -16,9 +16,12 @@ func TestCoreContractsMigration(t *testing.T) {
 
 	t.Run("other payloads are not modified", func(t *testing.T) {
 
+		dir := t.TempDir()
+
 		migration := migrations.CoreContractsMigration{
-			Log:   zerolog.Logger{},
-			Chain: flow.Testnet,
+			Log:       zerolog.Logger{},
+			Chain:     flow.Testnet,
+			OutputDir: dir,
 		}
 
 		input := []ledger.Payload{
@@ -43,9 +46,11 @@ func TestCoreContractsMigration(t *testing.T) {
 
 	t.Run("DKG contract is migrated", func(t *testing.T) {
 
+		dir := t.TempDir()
 		migration := migrations.CoreContractsMigration{
-			Log:   zerolog.Logger{},
-			Chain: flow.Testnet,
+			Log:       zerolog.Logger{},
+			Chain:     flow.Testnet,
+			OutputDir: dir,
 		}
 
 		dkgAddress := flow.HexToAddress("0x9eca2b38b18b5dfe")


### PR DESCRIPTION
With the update to Secure Cadence (0.24), which introduces breaking changes, the Core Contracts were updated in:
- https://github.com/onflow/flow-core-contracts/pull/287
- https://github.com/onflow/flow-core-contracts/pull/278

We cannot update these contracts on the current networks as they are incompatible with the currently deployed version of Cadence (deployment will fail with type checks), and we cannot deploy them after the network upgrade, as the core contracts are used during the startup of the Execution Node, before we could send contract update transactions.

Add a state migration which updates the core contracts directly in the execution state.