### PR TITLE
[fvm] separate deployment removal restriction flags

### DIFF
--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -69,6 +69,29 @@ func UpdateContractUnathorizedDeploymentTransaction(contractName string, contrac
 		AddAuthorizer(authorizer)
 }
 
+func RemoveContractDeploymentTransaction(contractName string, authorizer flow.Address, chain flow.Chain) *flow.TransactionBody {
+	return flow.NewTransactionBody().
+		SetScript([]byte(fmt.Sprintf(`transaction {
+              prepare(signer: AuthAccount, service: AuthAccount) {
+                signer.contracts.remove(name: "%s")
+              }
+            }`, contractName)),
+		).
+		AddAuthorizer(authorizer).
+		AddAuthorizer(chain.ServiceAddress())
+}
+
+func RemoveContractUnathorizedDeploymentTransaction(contractName string, authorizer flow.Address) *flow.TransactionBody {
+	return flow.NewTransactionBody().
+		SetScript([]byte(fmt.Sprintf(`transaction {
+              prepare(signer: AuthAccount) {
+                signer.contracts.remove(name: "%s")
+              }
+            }`, contractName)),
+		).
+		AddAuthorizer(authorizer)
+}
+
 func CreateUnauthorizedContractDeploymentTransaction(contractName string, contract string, authorizer flow.Address) *flow.TransactionBody {
 	encoded := hex.EncodeToString([]byte(contract))
 

--- a/engine/execution/testutil/fixtures_counter.go
+++ b/engine/execution/testutil/fixtures_counter.go
@@ -58,6 +58,14 @@ func UpdateUnauthorizedCounterContractTransaction(authorizer flow.Address) *flow
 	return UpdateContractUnathorizedDeploymentTransaction("Container", CounterContractV2, authorizer)
 }
 
+func RemoveUnauthorizedCounterContractTransaction(authorizer flow.Address) *flow.TransactionBody {
+	return RemoveContractUnathorizedDeploymentTransaction("Container", authorizer)
+}
+
+func RemoveCounterContractTransaction(authorizer flow.Address, chain flow.Chain) *flow.TransactionBody {
+	return RemoveContractDeploymentTransaction("Container", authorizer, chain)
+}
+
 func CreateCounterTransaction(counter, signer flow.Address) *flow.TransactionBody {
 	return flow.NewTransactionBody().
 		SetScript([]byte(fmt.Sprintf(`

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -28,17 +28,18 @@ type Context struct {
 	ServiceAccountEnabled        bool
 	// Depricated: RestrictedDeploymentEnabled is deprecated use SetIsContractDeploymentRestrictedTransaction instead.
 	// Can be removed after all networks are migrated to SetIsContractDeploymentRestrictedTransaction
-	RestrictedDeploymentEnabled   bool
-	LimitAccountStorage           bool
-	TransactionFeesEnabled        bool
-	CadenceLoggingEnabled         bool
-	EventCollectionEnabled        bool
-	ServiceEventCollectionEnabled bool
-	AccountFreezeAvailable        bool
-	ExtensiveTracing              bool
-	TransactionProcessors         []TransactionProcessor
-	ScriptProcessors              []ScriptProcessor
-	Logger                        zerolog.Logger
+	RestrictedDeploymentEnabled      bool
+	RestrictedContractRemovalEnabled bool
+	LimitAccountStorage              bool
+	TransactionFeesEnabled           bool
+	CadenceLoggingEnabled            bool
+	EventCollectionEnabled           bool
+	ServiceEventCollectionEnabled    bool
+	AccountFreezeAvailable           bool
+	ExtensiveTracing                 bool
+	TransactionProcessors            []TransactionProcessor
+	ScriptProcessors                 []ScriptProcessor
+	Logger                           zerolog.Logger
 }
 
 // NewContext initializes a new execution context with the provided options.
@@ -70,25 +71,26 @@ const (
 
 func defaultContext(logger zerolog.Logger) Context {
 	return Context{
-		Chain:                         flow.Mainnet.Chain(),
-		Blocks:                        nil,
-		Metrics:                       &handler.NoopMetricsReporter{},
-		Tracer:                        nil,
-		ComputationLimit:              DefaultComputationLimit,
-		MemoryLimit:                   DefaultMemoryLimit,
-		MaxStateKeySize:               state.DefaultMaxKeySize,
-		MaxStateValueSize:             state.DefaultMaxValueSize,
-		MaxStateInteractionSize:       state.DefaultMaxInteractionSize,
-		EventCollectionByteSizeLimit:  DefaultEventCollectionByteSizeLimit,
-		MaxNumOfTxRetries:             DefaultMaxNumOfTxRetries,
-		BlockHeader:                   nil,
-		ServiceAccountEnabled:         true,
-		RestrictedDeploymentEnabled:   true,
-		CadenceLoggingEnabled:         false,
-		EventCollectionEnabled:        true,
-		ServiceEventCollectionEnabled: false,
-		AccountFreezeAvailable:        false,
-		ExtensiveTracing:              false,
+		Chain:                            flow.Mainnet.Chain(),
+		Blocks:                           nil,
+		Metrics:                          &handler.NoopMetricsReporter{},
+		Tracer:                           nil,
+		ComputationLimit:                 DefaultComputationLimit,
+		MemoryLimit:                      DefaultMemoryLimit,
+		MaxStateKeySize:                  state.DefaultMaxKeySize,
+		MaxStateValueSize:                state.DefaultMaxValueSize,
+		MaxStateInteractionSize:          state.DefaultMaxInteractionSize,
+		EventCollectionByteSizeLimit:     DefaultEventCollectionByteSizeLimit,
+		MaxNumOfTxRetries:                DefaultMaxNumOfTxRetries,
+		BlockHeader:                      nil,
+		ServiceAccountEnabled:            true,
+		RestrictedDeploymentEnabled:      true,
+		RestrictedContractRemovalEnabled: true,
+		CadenceLoggingEnabled:            false,
+		EventCollectionEnabled:           true,
+		ServiceEventCollectionEnabled:    false,
+		AccountFreezeAvailable:           false,
+		ExtensiveTracing:                 false,
 		TransactionProcessors: []TransactionProcessor{
 			NewTransactionAccountFrozenChecker(),
 			NewTransactionSignatureVerifier(AccountKeyWeightThreshold),
@@ -258,10 +260,20 @@ func WithServiceAccount(enabled bool) Option {
 }
 
 // WithRestrictedDeployment enables or disables restricted contract deployment for a
-// virtual machine context.
+// virtual machine context. Warning! this would be overridden with the flag stored on chain.
+// this is just a fallback value
 func WithRestrictedDeployment(enabled bool) Option {
 	return func(ctx Context) Context {
 		ctx.RestrictedDeploymentEnabled = enabled
+		return ctx
+	}
+}
+
+// WithRestrictedContractRemovalEnabled enables or disables restricted contract removal for a
+// virtual machine context.
+func WithRestrictedContractRemovalEnabled(enabled bool) Option {
+	return func(ctx Context) Context {
+		ctx.RestrictedContractRemovalEnabled = enabled
 		return ctx
 	}
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -667,6 +667,94 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, tx.Err)
 	})
 
+	t.Run("account update with code removal fails if not signed by service account", func(t *testing.T) {
+		ledger := testutil.RootBootstrappedLedger(vm, ctx)
+
+		// Create an account private key.
+		privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
+		require.NoError(t, err)
+
+		// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
+		accounts, err := testutil.CreateAccounts(vm, ledger, programs.NewEmptyPrograms(), privateKeys, chain)
+		require.NoError(t, err)
+
+		txBody := testutil.DeployCounterContractTransaction(accounts[0], chain)
+		txBody.SetProposalKey(chain.ServiceAddress(), 0, 0)
+		txBody.SetPayer(chain.ServiceAddress())
+
+		err = testutil.SignPayload(txBody, accounts[0], privateKeys[0])
+		require.NoError(t, err)
+
+		err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
+		require.NoError(t, err)
+
+		tx := fvm.Transaction(txBody, 0)
+
+		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		require.NoError(t, err)
+		require.NoError(t, tx.Err)
+
+		txBody = testutil.RemoveUnauthorizedCounterContractTransaction(accounts[0])
+		txBody.SetProposalKey(accounts[0], 0, 0)
+		txBody.SetPayer(accounts[0])
+
+		err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
+		require.NoError(t, err)
+
+		tx = fvm.Transaction(txBody, 0)
+
+		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		require.NoError(t, err)
+		assert.Error(t, tx.Err)
+
+		assert.Contains(t, tx.Err.Error(), "removing contracts requires authorization from specific accounts")
+		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
+	})
+
+	t.Run("account update with code removal succeeds if signed by service account", func(t *testing.T) {
+		ledger := testutil.RootBootstrappedLedger(vm, ctx)
+
+		// Create an account private key.
+		privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
+		require.NoError(t, err)
+
+		// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
+		accounts, err := testutil.CreateAccounts(vm, ledger, programs.NewEmptyPrograms(), privateKeys, chain)
+		require.NoError(t, err)
+
+		txBody := testutil.DeployCounterContractTransaction(accounts[0], chain)
+		txBody.SetProposalKey(chain.ServiceAddress(), 0, 0)
+		txBody.SetPayer(chain.ServiceAddress())
+
+		err = testutil.SignPayload(txBody, accounts[0], privateKeys[0])
+		require.NoError(t, err)
+
+		err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
+		require.NoError(t, err)
+
+		tx := fvm.Transaction(txBody, 0)
+
+		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		require.NoError(t, err)
+		require.NoError(t, tx.Err)
+
+		txBody = testutil.RemoveCounterContractTransaction(accounts[0], chain)
+		txBody.SetProposalKey(accounts[0], 0, 0)
+		txBody.SetPayer(chain.ServiceAddress())
+
+		err = testutil.SignPayload(txBody, accounts[0], privateKeys[0])
+		require.NoError(t, err)
+
+		err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
+		require.NoError(t, err)
+
+		tx = fvm.Transaction(txBody, 0)
+
+		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		require.NoError(t, err)
+		require.NoError(t, tx.Err)
+	})
+
 	t.Run("account update with set code succeeds when account is added as authorized account", func(t *testing.T) {
 		ledger := testutil.RootBootstrappedLedger(vm, ctx)
 

--- a/fvm/handler/contract_test.go
+++ b/fvm/handler/contract_test.go
@@ -26,7 +26,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	err := accounts.Create(nil, address)
 	require.NoError(t, err)
 
-	contractHandler := handler.NewContractHandler(accounts, func() bool { return false }, nil, nil, nil)
+	contractHandler := handler.NewContractHandler(accounts, func() bool { return false }, func() bool { return false }, nil, nil, nil)
 
 	// no contract initially
 	names, err := contractHandler.GetContractNames(rAdd)
@@ -114,6 +114,7 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 
 	makeHandler := func() *handler.ContractHandler {
 		return handler.NewContractHandler(accounts,
+			func() bool { return true },
 			func() bool { return true },
 			func() []common.Address { return []common.Address{rAdd, rBoth} },
 			func() []common.Address { return []common.Address{rRemove, rBoth} },
@@ -223,6 +224,7 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 	contractHandler := handler.NewContractHandler(
 		accounts,
 		func() bool { return true },
+		func() bool { return true },
 		func() []common.Address {
 			return []common.Address{}
 		},
@@ -275,6 +277,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 
 	contractHandler := handler.NewContractHandler(
 		accounts,
+		func() bool { return true },
 		func() bool { return true },
 		func() []common.Address {
 			return []common.Address{}
@@ -330,6 +333,161 @@ func TestContract_ContractUpdate(t *testing.T) {
 	require.True(t, contractHandler.HasUpdates())
 }
 
+func TestContract_ContractRemoval(t *testing.T) {
+
+	sth := state.NewStateHolder(state.NewState(utils.NewSimpleView()))
+	accounts := state.NewAccounts(sth)
+
+	flowAddress := flow.HexToAddress("01")
+	runtimeAddress := runtime.Address(flowAddress)
+	err := accounts.Create(nil, flowAddress)
+	require.NoError(t, err)
+
+	t.Run("contract removal with restriction", func(t *testing.T) {
+		var authorizationChecked bool
+
+		contractHandler := handler.NewContractHandler(
+			accounts,
+			func() bool { return false },
+			func() bool { return true },
+			func() []common.Address {
+				return []common.Address{}
+			},
+			func() []common.Address {
+				return []common.Address{}
+			},
+			func(address runtime.Address, code []byte) (bool, error) {
+				// Ensure the voucher check is only called once,
+				// for the initial contract deployment,
+				// and not for the subsequent update
+				require.False(t, authorizationChecked)
+				authorizationChecked = true
+				return true, nil
+			},
+		)
+
+		// deploy contract with voucher
+		err = contractHandler.SetContract(
+			runtimeAddress,
+			"TestContract",
+			[]byte("pub contract TestContract {}"),
+			[]common.Address{
+				runtimeAddress,
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, contractHandler.HasUpdates())
+
+		contractUpdateKeys, err := contractHandler.Commit()
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			[]programs.ContractUpdateKey{
+				{
+					Address: flowAddress,
+					Name:    "TestContract",
+				},
+			},
+			contractUpdateKeys,
+		)
+
+		// update should work
+		err = contractHandler.SetContract(
+			runtimeAddress,
+			"TestContract",
+			[]byte("pub contract TestContract {}"),
+			[]common.Address{
+				runtimeAddress,
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, contractHandler.HasUpdates())
+
+		// try remove contract should fail
+		err = contractHandler.RemoveContract(
+			runtimeAddress,
+			"TestContract",
+			[]common.Address{
+				runtimeAddress,
+			},
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("contract removal without restriction", func(t *testing.T) {
+		var authorizationChecked bool
+
+		contractHandler := handler.NewContractHandler(
+			accounts,
+			func() bool { return false },
+			func() bool { return false },
+			func() []common.Address {
+				return []common.Address{}
+			},
+			func() []common.Address {
+				return []common.Address{}
+			},
+			func(address runtime.Address, code []byte) (bool, error) {
+				// Ensure the voucher check is only called once,
+				// for the initial contract deployment,
+				// and not for the subsequent update
+				require.False(t, authorizationChecked)
+				authorizationChecked = true
+				return true, nil
+			},
+		)
+
+		// deploy contract with voucher
+		err = contractHandler.SetContract(
+			runtimeAddress,
+			"TestContract",
+			[]byte("pub contract TestContract {}"),
+			[]common.Address{
+				runtimeAddress,
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, contractHandler.HasUpdates())
+
+		contractUpdateKeys, err := contractHandler.Commit()
+		require.NoError(t, err)
+		require.Equal(
+			t,
+			[]programs.ContractUpdateKey{
+				{
+					Address: flowAddress,
+					Name:    "TestContract",
+				},
+			},
+			contractUpdateKeys,
+		)
+
+		// update should work
+		err = contractHandler.SetContract(
+			runtimeAddress,
+			"TestContract",
+			[]byte("pub contract TestContract {}"),
+			[]common.Address{
+				runtimeAddress,
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, contractHandler.HasUpdates())
+
+		// try remove contract should fail
+		err = contractHandler.RemoveContract(
+			runtimeAddress,
+			"TestContract",
+			[]common.Address{
+				runtimeAddress,
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, contractHandler.HasUpdates())
+
+	})
+}
+
 func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 	mockAccounts := &stateMock.Accounts{}
 
@@ -343,6 +501,7 @@ func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 
 	contractHandler := handler.NewContractHandler(
 		mockAccounts,
+		func() bool { return false },
 		func() bool { return false },
 		nil,
 		nil,

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -90,6 +90,9 @@ func NewScriptEnvironment(
 		func() bool {
 			return true
 		},
+		func() bool {
+			return true
+		},
 		func() []common.Address { return []common.Address{} },
 		func() []common.Address { return []common.Address{} },
 		func(address runtime.Address, code []byte) (bool, error) { return false, nil })

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -108,6 +108,11 @@ func NewTransactionEnvironment(
 			}
 			return enabled
 		},
+		func() bool {
+			// TODO read this from the chain similar to the contract deployment
+			// but for now we would honor the fallback context flag
+			return ctx.RestrictedContractRemovalEnabled
+		},
 		env.GetAccountsAuthorizedForContractUpdate,
 		env.GetAccountsAuthorizedForContractRemoval,
 		env.useContractAuditVoucher,


### PR DESCRIPTION
This PR separates the context flag for contract removal and contract updates. 
the flag for contract updates is re-writable by the service account state, contract removals are only can be set by flags for now, since there is no plan to disable it anytime soon. 

This should keep removals restricted even when we open up deployments.