### PR TITLE
[util] update cmd to get seal for sealed block

### DIFF
--- a/cmd/util/cmd/read-badger/cmd/seals.go
+++ b/cmd/util/cmd/read-badger/cmd/seals.go
@@ -14,7 +14,7 @@ func init() {
 	rootCmd.AddCommand(sealsCmd)
 
 	sealsCmd.Flags().StringVarP(&flagSealID, "id", "i", "", "the id of the seal")
-	sealsCmd.Flags().StringVarP(&flagBlockID, "block-id", "b", "", "the block id of which to query the seal")
+	sealsCmd.Flags().StringVarP(&flagBlockID, "block-id", "b", "", "the sealed block id of which to query the seal for")
 }
 
 var sealsCmd = &cobra.Command{
@@ -57,7 +57,7 @@ var sealsCmd = &cobra.Command{
 			}
 
 			log.Info().Msgf("getting seal by block id: %v", blockID)
-			seal, err := storages.Seals.HighestInFork(blockID)
+			seal, err := storages.Seals.FinalizedSealForBlock(blockID)
 			if err != nil {
 				log.Error().Err(err).Msgf("could not get seal for block id: %v", blockID)
 				return


### PR DESCRIPTION
With the new seal index added, when using util cmd to query seals by block ID, it's more useful to query the seal for the given block , instead of the highest in fork seal.