### PR TITLE
[State Sync] Lookup ExecutionResult directly instead of using index (v0.26)

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -504,6 +504,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 				builder.State,
 				builder.Storage.Headers,
 				builder.Storage.Results,
+				builder.Storage.Seals,
 				builder.executionDataConfig,
 			)
 

--- a/module/jobqueue/sealed_header_reader.go
+++ b/module/jobqueue/sealed_header_reader.go
@@ -3,7 +3,6 @@ package jobqueue
 import (
 	"fmt"
 
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
@@ -26,11 +25,6 @@ func NewSealedBlockHeaderReader(state protocol.State, headers storage.Headers) *
 // AtIndex returns the block header job at the given index.
 // The block header job at an index is just the finalized block header at that index (i.e., height).
 func (r SealedBlockHeaderReader) AtIndex(index uint64) (module.Job, error) {
-	header, err := r.blockByHeight(index)
-	if err != nil {
-		return nil, fmt.Errorf("could not get block by index %v: %w", index, err)
-	}
-
 	sealed, err := r.Head()
 	if err != nil {
 		return nil, fmt.Errorf("could not get last sealed block height: %w", err)
@@ -38,21 +32,16 @@ func (r SealedBlockHeaderReader) AtIndex(index uint64) (module.Job, error) {
 
 	if index > sealed {
 		// return not found error to indicate there is no job available at this height
-		return nil, fmt.Errorf("block at index %v is not sealed: %w", index, storage.ErrNotFound)
+		return nil, fmt.Errorf("block at index %d is not sealed: %w", index, storage.ErrNotFound)
+	}
+
+	header, err := r.headers.ByHeight(index)
+	if err != nil {
+		return nil, fmt.Errorf("could not get block by height %d: %w", index, err)
 	}
 
 	// the block at height index is sealed
 	return BlockHeaderToJob(header), nil
-}
-
-// blockByHeight returns the block at the given height.
-func (r SealedBlockHeaderReader) blockByHeight(height uint64) (*flow.Header, error) {
-	block, err := r.headers.ByHeight(height)
-	if err != nil {
-		return nil, fmt.Errorf("could not get block by height %d: %w", height, err)
-	}
-
-	return block, nil
 }
 
 // Head returns the last sealed height as job index.

--- a/module/jobqueue/sealed_header_reader_test.go
+++ b/module/jobqueue/sealed_header_reader_test.go
@@ -73,7 +73,7 @@ func RunWithReader(
 		}
 
 		snapshot := synctest.MockProtocolStateSnapshot(synctest.WithHead(seals[0]))
-		state := synctest.MockProtocolState(synctest.WithSnapshot(snapshot))
+		state := synctest.MockProtocolState(synctest.WithSealedSnapshot(snapshot))
 		headerStorage := synctest.MockBlockHeaderStorage(synctest.WithByHeight(blocksByHeight))
 
 		reader := jobqueue.NewSealedBlockHeaderReader(state, headerStorage)

--- a/module/state_synchronization/requester/execution_data_requester_test.go
+++ b/module/state_synchronization/requester/execution_data_requester_test.go
@@ -34,8 +34,7 @@ import (
 	"github.com/onflow/flow-go/network/mocknetwork"
 	"github.com/onflow/flow-go/state/protocol"
 	statemock "github.com/onflow/flow-go/state/protocol/mock"
-	storage "github.com/onflow/flow-go/storage/badger"
-	storagemock "github.com/onflow/flow-go/storage/mock"
+	bstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -45,9 +44,7 @@ type ExecutionDataRequesterSuite struct {
 	blobservice *mocknetwork.BlobService
 	datastore   datastore.Batching
 	db          *badger.DB
-	headers     *storagemock.Headers
-
-	eds *syncmock.ExecutionDataService
+	eds         *syncmock.ExecutionDataService
 
 	run edTestRun
 
@@ -296,7 +293,7 @@ func (suite *ExecutionDataRequesterSuite) TestRequesterPausesAndResumes() {
 	})
 }
 
-// TestRequesterHalts tests that the requester handles halting correctly when it encouters an
+// TestRequesterHalts tests that the requester handles halting correctly when it encounters an
 // invalid block
 func (suite *ExecutionDataRequesterSuite) TestRequesterHalts() {
 	unittest.RunWithBadgerDB(suite.T(), func(db *badger.DB) {
@@ -395,15 +392,23 @@ func generatePauseResume(pauseHeight uint64) (specialBlockGenerator, func()) {
 }
 
 func (suite *ExecutionDataRequesterSuite) prepareRequesterTest(cfg *fetchTestRun) (state_synchronization.ExecutionDataRequester, *pubsub.FinalizationDistributor) {
-	suite.headers = synctest.MockBlockHeaderStorage(synctest.WithByID(cfg.blocksByID), synctest.WithByHeight(cfg.blocksByHeight))
-	results := synctest.MockResultsStorage(synctest.WithByBlockID(cfg.resultsByID))
+	headers := synctest.MockBlockHeaderStorage(
+		synctest.WithByID(cfg.blocksByID),
+		synctest.WithByHeight(cfg.blocksByHeight),
+	)
+	results := synctest.MockResultsStorage(
+		synctest.WithResultByID(cfg.resultsByID),
+	)
+	seals := synctest.MockSealsStorage(
+		synctest.WithSealsByBlockID(cfg.sealsByBlockID),
+	)
 	state := suite.mockProtocolState(cfg.blocksByHeight)
 
 	suite.eds = mockExecutionDataService(cfg.executionDataEntries)
 
 	finalizationDistributor := pubsub.NewFinalizationDistributor()
-	processedHeight := storage.NewConsumerProgress(suite.db, module.ConsumeProgressExecutionDataRequesterBlockHeight)
-	processedNotification := storage.NewConsumerProgress(suite.db, module.ConsumeProgressExecutionDataRequesterNotification)
+	processedHeight := bstorage.NewConsumerProgress(suite.db, module.ConsumeProgressExecutionDataRequesterBlockHeight)
+	processedNotification := bstorage.NewConsumerProgress(suite.db, module.ConsumeProgressExecutionDataRequesterNotification)
 
 	edr := requester.New(
 		zerolog.New(os.Stdout).With().Timestamp().Logger(),
@@ -412,8 +417,9 @@ func (suite *ExecutionDataRequesterSuite) prepareRequesterTest(cfg *fetchTestRun
 		processedHeight,
 		processedNotification,
 		state,
-		suite.headers,
+		headers,
 		results,
+		seals,
 		requester.ExecutionDataConfig{
 			InitialBlockHeight: cfg.startHeight - 1,
 			MaxSearchAhead:     cfg.maxSearchAhead,
@@ -573,6 +579,8 @@ type fetchTestRun struct {
 	blocksByHeight           map[uint64]*flow.Block
 	blocksByID               map[flow.Identifier]*flow.Block
 	resultsByID              map[flow.Identifier]*flow.ExecutionResult
+	resultsByBlockID         map[flow.Identifier]*flow.ExecutionResult
+	sealsByBlockID           map[flow.Identifier]*flow.Seal
 	executionDataByID        map[flow.Identifier]*state_synchronization.ExecutionData
 	executionDataEntries     map[flow.Identifier]*testExecutionDataServiceEntry
 	executionDataIDByBlockID map[flow.Identifier]flow.Identifier
@@ -622,6 +630,8 @@ func (suite *ExecutionDataRequesterSuite) generateTestData(blockCount int, speci
 	blocksByHeight := map[uint64]*flow.Block{}
 	blocksByID := map[flow.Identifier]*flow.Block{}
 	resultsByID := map[flow.Identifier]*flow.ExecutionResult{}
+	resultsByBlockID := map[flow.Identifier]*flow.ExecutionResult{}
+	sealsByBlockID := map[flow.Identifier]*flow.Seal{}
 	executionDataByID := map[flow.Identifier]*state_synchronization.ExecutionData{}
 	executionDataIDByBlockID := map[flow.Identifier]flow.Identifier{}
 
@@ -647,9 +657,16 @@ func (suite *ExecutionDataRequesterSuite) generateTestData(blockCount int, speci
 		var seals []*flow.Header
 
 		if i >= firstSeal {
+			sealedBlock := blocksByHeight[uint64(i-firstSeal+1)]
 			seals = []*flow.Header{
-				blocksByHeight[uint64(i-firstSeal+1)].Header, // block 0 doesn't get sealed (it's pre-sealed in the genesis state)
+				sealedBlock.Header, // block 0 doesn't get sealed (it's pre-sealed in the genesis state)
 			}
+
+			sealsByBlockID[sealedBlock.ID()] = unittest.Seal.Fixture(
+				unittest.Seal.WithBlockID(sealedBlock.ID()),
+				unittest.Seal.WithResult(resultsByBlockID[sealedBlock.ID()]),
+			)
+
 			suite.T().Logf("block %d has seals for %d", i, seals[0].Height)
 		}
 
@@ -665,7 +682,8 @@ func (suite *ExecutionDataRequesterSuite) generateTestData(blockCount int, speci
 
 		blocksByHeight[height] = block
 		blocksByID[block.ID()] = block
-		resultsByID[block.ID()] = result
+		resultsByBlockID[block.ID()] = result
+		resultsByID[result.ID()] = result
 
 		// ignore all the data we don't need to verify the test
 		if i > 0 && i <= sealedCount {
@@ -688,7 +706,9 @@ func (suite *ExecutionDataRequesterSuite) generateTestData(blockCount int, speci
 		endHeight:                endHeight,
 		blocksByHeight:           blocksByHeight,
 		blocksByID:               blocksByID,
+		resultsByBlockID:         resultsByBlockID,
 		resultsByID:              resultsByID,
+		sealsByBlockID:           sealsByBlockID,
 		executionDataByID:        executionDataByID,
 		executionDataEntries:     edsEntries,
 		executionDataIDByBlockID: executionDataIDByBlockID,

--- a/module/state_synchronization/requester/jobs/execution_data_reader_test.go
+++ b/module/state_synchronization/requester/jobs/execution_data_reader_test.go
@@ -29,6 +29,7 @@ type ExecutionDataReaderSuite struct {
 	eds          *syncmock.ExecutionDataService
 	headers      *storagemock.Headers
 	results      *storagemock.ExecutionResults
+	seals        *storagemock.Seals
 	fetchTimeout time.Duration
 
 	executionDataID flow.Identifier
@@ -51,6 +52,9 @@ func (suite *ExecutionDataReaderSuite) SetupTest() {
 
 	parent := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(1))
 	suite.block = unittest.BlockWithParentFixture(&parent)
+	suite.blocksByHeight = map[uint64]*flow.Block{
+		suite.block.Header.Height: suite.block,
+	}
 
 	suite.executionData = synctest.ExecutionDataFixture(suite.block.ID())
 
@@ -65,19 +69,29 @@ func (suite *ExecutionDataReaderSuite) reset() {
 		unittest.WithExecutionDataID(suite.executionDataID),
 	)
 
-	suite.blocksByHeight = map[uint64]*flow.Block{
-		suite.block.Header.Height: suite.block,
-	}
+	seal := unittest.Seal.Fixture(
+		unittest.Seal.WithBlockID(suite.block.ID()),
+		unittest.Seal.WithResult(result),
+	)
+
 	suite.headers = synctest.MockBlockHeaderStorage(synctest.WithByHeight(suite.blocksByHeight))
-	suite.results = synctest.MockResultsStorage(synctest.WithByBlockID(map[flow.Identifier]*flow.ExecutionResult{
-		suite.block.ID(): result,
-	}))
+	suite.results = synctest.MockResultsStorage(
+		synctest.WithResultByID(map[flow.Identifier]*flow.ExecutionResult{
+			result.ID(): result,
+		}),
+	)
+	suite.seals = synctest.MockSealsStorage(
+		synctest.WithSealsByBlockID(map[flow.Identifier]*flow.Seal{
+			suite.block.ID(): seal,
+		}),
+	)
 
 	suite.eds = new(syncmock.ExecutionDataService)
 	suite.reader = NewExecutionDataReader(
 		suite.eds,
 		suite.headers,
 		suite.results,
+		suite.seals,
 		suite.fetchTimeout,
 		func() uint64 {
 			return suite.highestAvailableHeight()
@@ -133,12 +147,12 @@ func (suite *ExecutionDataReaderSuite) TestAtIndex() {
 		suite.reset()
 		suite.runTest(func() {
 			// return an error while getting the execution data
-			expecteErr := errors.New("expected error: get failed")
-			setExecutionDataGet(nil, expecteErr)
+			expectedErr := errors.New("expected error: get failed")
+			setExecutionDataGet(nil, expectedErr)
 
 			job, err := suite.reader.AtIndex(suite.block.Header.Height)
 			assert.Nil(suite.T(), job, "job should be nil")
-			assert.ErrorIs(suite.T(), err, expecteErr)
+			assert.ErrorIs(suite.T(), err, expectedErr)
 		})
 	})
 


### PR DESCRIPTION
This pulls https://github.com/onflow/flow-go/pull/2566 into the v0.26 branch