### PR TITLE
Fix reversed numbers for script metrics

### DIFF
--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -232,7 +232,7 @@ func (e *Manager) ExecuteScript(
 	runtime.ReadMemStats(&m)
 	memAllocAfter := m.TotalAlloc
 
-	e.metrics.ExecutionScriptExecuted(time.Since(startedAt), script.GasUsed, script.MemoryUsed, memAllocBefore-memAllocAfter)
+	e.metrics.ExecutionScriptExecuted(time.Since(startedAt), script.GasUsed, memAllocAfter-memAllocBefore, script.MemoryUsed)
 
 	return encodedValue, nil
 }


### PR DESCRIPTION
We were passing these values to these logging functions in the wrong order