### PR TITLE
minor cleanup of sealing segment and fixing typos

### DIFF
--- a/storage/badger/operation/seals.go
+++ b/storage/badger/operation/seals.go
@@ -52,9 +52,9 @@ func LookupLatestSealAtBlock(blockID flow.Identifier, sealID *flow.Identifier) f
 	return retrieve(makePrefix(codeBlockIDToLatestSealID, blockID), &sealID)
 }
 
-// IndexFinalizedSealByBlockID index a the _finalized_ seal by the sealed block ID.
-// A <- B <- C(SealA)
-// Example: when block C is finalized, we create the index `A.ID->SealA.ID`
+// IndexFinalizedSealByBlockID indexes the _finalized_ seal by the sealed block ID.
+// Example: A <- B <- C(SealA)
+// when block C is finalized, we create the index `A.ID->SealA.ID`
 func IndexFinalizedSealByBlockID(sealedBlockID flow.Identifier, sealID flow.Identifier) func(*badger.Txn) error {
 	return insert(makePrefix(codeBlockIDToFinalizedSeal, sealedBlockID), sealID)
 }


### PR DESCRIPTION
follow up to [PR #2551](https://github.com/onflow/flow-go/pull/2551): 
* minor extension of sealing segment's documentation
* fixed some typos
