### PR TITLE
localnet: switch from docker log driver to promtail

### DIFF
--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -53,21 +53,14 @@ init-light:
 init-short-epochs:
 	$(MAKE) -e EPOCHLEN=200 STAKINGLEN=10 DKGLEN=50 init
 
-# Installs logging plugin
-.PHONY: install-docker-plugin
-install-docker-plugin:
-	docker plugin inspect loki || \
-		docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
-
-# Update docker plugin
-.PHONY: update-docker-plugin
-update-docker-plugin:
-	docker plugin disable loki
-	docker plugin upgrade --grant-all-permissions loki
-	docker plugin enable loki
+# Uninstall logging plugin
+.PHONY: uninstall-docker-plugin
+uninstall-docker-plugin:
+	$(shell docker plugin inspect loki >/dev/null 2>&1 && \
+		(docker plugin disable loki; docker plugin rm loki))
 
 .PHONY: start
-start: install-docker-plugin
+start: uninstall-docker-plugin
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.metrics.yml up -d --remove-orphans
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml build
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -f docker-compose.nodes.yml up -d

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -109,18 +109,6 @@ func generateBootstrapData(flowNetworkConf testnet.NetworkConfig) []testnet.Cont
 	return bootstrapData.StakedConfs
 }
 
-func defaultLokiLoggingOptions(role string, num int) Logging {
-	return Logging{
-		Driver: "loki",
-		Options: Options{
-			LokiURL:            "http://127.0.0.1:3100/loki/api/v1/push",
-			LokiRetries:        "1",
-			LokiMaxBackoff:     time.Second.String(),
-			LokiExternalLabels: fmt.Sprintf(`container_name={{.Name}},role=%s,num=%03d`, role, num),
-		},
-	}
-}
-
 // localnet/bootstrap.go generates a docker compose file with images configured for a
 // self-contained Flow network, and other peripheral services, such as Observer services.
 // Private/Public keys and data are removed and re-created for the self-contained localnet
@@ -283,7 +271,7 @@ type Service struct {
 	Environment []string `yaml:"environment,omitempty"`
 	Volumes     []string
 	Ports       []string `yaml:"ports,omitempty"`
-	Logging     Logging  `yaml:"logging,omitempty"`
+	Labels      map[string]string
 }
 
 // Build ...
@@ -292,18 +280,6 @@ type Build struct {
 	Dockerfile string
 	Args       map[string]string
 	Target     string
-}
-
-type Logging struct {
-	Driver  string  `yaml:"driver"`
-	Options Options `yaml:"options"`
-}
-
-type Options struct {
-	LokiURL            string `yaml:"loki-url"`
-	LokiMaxBackoff     string `yaml:"loki-max-backoff,omitempty"`
-	LokiRetries        string `yaml:"loki-retries,omitempty"`
-	LokiExternalLabels string `yaml:"loki-external-labels,omitempty"`
 }
 
 func prepareFlowServices(services Services, containers []testnet.ContainerConfig) Services {
@@ -387,6 +363,10 @@ func prepareService(container testnet.ContainerConfig, i int, n int) Service {
 			"BINSTAT_DMP_NAME",
 			"BINSTAT_DMP_PATH",
 		},
+		Labels: map[string]string{
+			"com.dapperlabs.role": container.Role.String(),
+			"com.dapperlabs.num":  fmt.Sprintf("%03d", i+1),
+		},
 	}
 
 	service.Command = append(service.Command, fmt.Sprintf("--admin-addr=:%v", AdminToolPort))
@@ -416,8 +396,6 @@ func prepareService(container testnet.ContainerConfig, i int, n int) Service {
 			fmt.Sprintf("%s_1", container.Role),
 		}
 	}
-
-	service.Logging = defaultLokiLoggingOptions(container.Role.String(), i+1)
 
 	return service
 }
@@ -761,8 +739,6 @@ func prepareObserverService(i int, observerName string, agPublicKey string, prof
 		fmt.Sprintf("%d:%d", (accessCount*2)+AccessAPIPort+(2*i), RPCPort),
 		fmt.Sprintf("%d:%d", (accessCount*2)+AccessAPIPort+(2*i)+1, SecuredRPCPort),
 	}
-
-	observerService.Logging = defaultLokiLoggingOptions("observer", i)
 
 	return observerService
 }

--- a/integration/localnet/conf/promtail-config.yaml
+++ b/integration/localnet/conf/promtail-config.yaml
@@ -1,0 +1,26 @@
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+server:
+  log_level: info
+
+positions:
+  filename: /tmp/positions.yaml
+
+scrape_configs:
+- job_name: containers
+  docker_sd_configs:
+    - host: unix:///var/run/docker.sock
+      refresh_interval: 5s
+      # Only keep containers that have a `com.dapperlabs.role` label.
+      filters:
+        - name: "label"
+          values:
+            - 'com.dapperlabs.role'
+  relabel_configs:
+    - regex: "__meta_docker_container_label_com_dapperlabs_(.+)"
+      action: labelmap
+      replacement: "$1"
+    - source_labels: ['__meta_docker_container_name']
+      regex: "/(.*)"
+      target_label: "container_name"

--- a/integration/localnet/docker-compose.metrics.yml
+++ b/integration/localnet/docker-compose.metrics.yml
@@ -10,12 +10,19 @@ services:
       - "14268"
 
   loki:
-    image: grafana/loki:main-f52fc9d
+    image: grafana/loki:main-9218e46
     command: [ "-config.file=/etc/loki/local-config.yaml" ]
     volumes:
       - ./data/loki:/loki:z
     ports:
       - "3100:3100"
+
+  promtail:
+    image: grafana/promtail:main-9218e46
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    volumes:
+      - ./conf/promtail-config.yaml:/etc/promtail/promtail-config.yaml:z
+      - /var/run/docker.sock:/var/run/docker.sock:z
 
   prometheus:
     image: prom/prometheus:v2.36.0
@@ -38,7 +45,7 @@ services:
       - "9100:9100"
 
   grafana:
-    image: grafana/grafana:9.0.0-beta2
+    image: grafana/grafana:9.0.0-beta3
     volumes:
       - ./conf/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:z
       - ./conf/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:z


### PR DESCRIPTION
This should allow both perf automation and loki to use logs at the same time.

Fixes: #2510