### PR TITLE
fix logging current statecommitment in execution state extraction

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -86,7 +86,6 @@ func extractExecutionState(
 			extractionReportName: reporters.NewExportReporter(log,
 				chain,
 				func() flow.StateCommitment { return targetHash },
-				func() flow.StateCommitment { return flow.StateCommitment(newState) },
 			),
 			"account": &reporters.AccountReporter{
 				Log:   log,
@@ -101,7 +100,7 @@ func extractExecutionState(
 		}
 	}
 
-	newState, err = led.ExportCheckpointAt(
+	migratedState, err := led.ExportCheckpointAt(
 		newState,
 		migrations,
 		rs,
@@ -116,8 +115,8 @@ func extractExecutionState(
 
 	log.Info().Msgf(
 		"New state commitment for the exported state is: %s (base64: %s)",
-		newState.String(),
-		newState.Base64(),
+		migratedState.String(),
+		migratedState.Base64(),
 	)
 
 	return nil

--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -57,7 +57,7 @@ type momentsRecord struct {
 	Moments int    `json:"moments"`
 }
 
-func (r *AccountReporter) Report(payload []ledger.Payload) error {
+func (r *AccountReporter) Report(payload []ledger.Payload, commit ledger.State) error {
 	rwa := r.RWF.ReportWriter("account_report")
 	rwc := r.RWF.ReportWriter("contract_report")
 	rwm := r.RWF.ReportWriter("moments_report")

--- a/cmd/util/ledger/reporters/atree_reporter.go
+++ b/cmd/util/ledger/reporters/atree_reporter.go
@@ -28,7 +28,7 @@ func (r *AtreeReporter) Name() string {
 	return "Atree Reporter"
 }
 
-func (r *AtreeReporter) Report(payloads []ledger.Payload) error {
+func (r *AtreeReporter) Report(payloads []ledger.Payload, commit ledger.State) error {
 	rwa := r.RWF.ReportWriter("atree_report")
 	defer rwa.Close()
 

--- a/cmd/util/ledger/reporters/export_reporter.go
+++ b/cmd/util/ledger/reporters/export_reporter.go
@@ -54,7 +54,7 @@ func (e *ExportReporter) Name() string {
 func (e *ExportReporter) Report(payload []ledger.Payload, commit ledger.State) error {
 	script, _, err := ExecuteCurrentEpochScript(e.chain, payload)
 	failedExportReport := ExportReport{
-		ReportSucceeded: true,
+		ReportSucceeded: false,
 	}
 	failedReport, _ := json.MarshalIndent(failedExportReport, "", " ")
 
@@ -64,6 +64,8 @@ func (e *ExportReporter) Report(payload []ledger.Payload, commit ledger.State) e
 			Err(err).
 			Msg("error running GetCurrentEpochCounter script")
 
+			// write the report with ReportSucceeded = false, so that the ansbile script can
+			// detect the failure
 		_ = ioutil.WriteFile("export_report.json", failedReport, 0644)
 		// Safely exit and move on to next reporter so we do not block other reporters
 		return nil

--- a/cmd/util/ledger/reporters/export_reporter.go
+++ b/cmd/util/ledger/reporters/export_reporter.go
@@ -33,20 +33,17 @@ type ExportReporter struct {
 	logger                   zerolog.Logger
 	chain                    flow.Chain
 	getBeforeMigrationSCFunc GetStateCommitmentFunc
-	getAfterMigrationSCFunc  GetStateCommitmentFunc
 }
 
 func NewExportReporter(
 	logger zerolog.Logger,
 	chain flow.Chain,
 	getBeforeMigrationSCFunc GetStateCommitmentFunc,
-	getAfterMigrationSCFunc GetStateCommitmentFunc,
 ) *ExportReporter {
 	return &ExportReporter{
 		logger:                   logger,
 		chain:                    chain,
 		getBeforeMigrationSCFunc: getBeforeMigrationSCFunc,
-		getAfterMigrationSCFunc:  getAfterMigrationSCFunc,
 	}
 }
 
@@ -54,7 +51,7 @@ func (e *ExportReporter) Name() string {
 	return "ExportReporter"
 }
 
-func (e *ExportReporter) Report(payload []ledger.Payload) error {
+func (e *ExportReporter) Report(payload []ledger.Payload, commit ledger.State) error {
 	script, _, err := ExecuteCurrentEpochScript(e.chain, payload)
 	failedExportReport := ExportReport{
 		ReportSucceeded: true,
@@ -92,7 +89,7 @@ func (e *ExportReporter) Report(payload []ledger.Payload) error {
 	report := ExportReport{
 		EpochCounter:            script.Value.ToGoValue().(uint64),
 		PreviousStateCommitment: e.getBeforeMigrationSCFunc(),
-		CurrentStateCommitment:  e.getAfterMigrationSCFunc(),
+		CurrentStateCommitment:  flow.StateCommitment(commit),
 		ReportSucceeded:         true,
 	}
 	file, _ := json.MarshalIndent(report, "", " ")

--- a/cmd/util/ledger/reporters/fungible_token_tracker.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker.go
@@ -84,7 +84,7 @@ type job struct {
 
 // Report creates a fungible_token_report_*.json file that contains data on all fungible token Vaults in the state commitment.
 // I recommend using gojq to browse through the data, because of the large uint64 numbers which jq won't be able to handle.
-func (r *FungibleTokenTracker) Report(payloads []ledger.Payload) error {
+func (r *FungibleTokenTracker) Report(payloads []ledger.Payload, commit ledger.State) error {
 	r.rw = r.rwf.ReportWriter(FungibleTokenTrackerReportPrefix)
 	defer r.rw.Close()
 

--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -56,7 +56,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 	pub contract WrappedToken {
 		pub resource WrappedVault {
 			pub var vault: @FungibleToken.Vault
-	
+
 			init(v: @FungibleToken.Vault) {
 				self.vault <- v
 			}
@@ -90,12 +90,12 @@ func TestFungibleTokenTracker(t *testing.T) {
 							import FungibleToken from 0x%s
 							import FlowToken from 0x%s
 							import WrappedToken from 0x%s
-							
-							transaction(amount: UFix64) {							
+
+							transaction(amount: UFix64) {
 								prepare(signer: AuthAccount) {
 									let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
 										?? panic("Could not borrow reference to the owner's Vault!")
-							
+
 									let sentVault <- vaultRef.withdraw(amount: amount)
 									let wrappedFlow <- WrappedToken.CreateWrappedVault(inp :<- sentVault)
 									signer.save(<-wrappedFlow, to: /storage/wrappedToken)
@@ -117,7 +117,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 	reporterFactory := reporters.NewReportFileWriterFactory(dir, log)
 
 	br := reporters.NewFungibleTokenTracker(log, reporterFactory, chain, []string{reporters.FlowTokenTypeID(chain)})
-	err = br.Report(view.Payloads())
+	err = br.Report(view.Payloads(), ledger.State{})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(reporterFactory.Filename(reporters.FungibleTokenTrackerReportPrefix))

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -378,7 +378,7 @@ func (l *Ledger) ExportCheckpointAt(
 	// If defined, run extraction report BEFORE writing checkpoint file
 	// This is used to optmize the spork process
 	if extractionReport, ok := reporters[extractionReportName]; ok {
-		err := runReport(extractionReport, payloads, l.logger)
+		err := runReport(extractionReport, payloads, statecommitment, l.logger)
 		if err != nil {
 			return ledger.State(hash.DummyHash), err
 		}
@@ -413,7 +413,7 @@ func (l *Ledger) ExportCheckpointAt(
 
 	// run reporters
 	for _, reporter := range reporters {
-		err := runReport(reporter, payloads, l.logger)
+		err := runReport(reporter, payloads, statecommitment, l.logger)
 		if err != nil {
 			return ledger.State(hash.DummyHash), err
 		}
@@ -461,13 +461,13 @@ func (l *Ledger) keepOnlyOneTrie(state ledger.State) error {
 	return nil
 }
 
-func runReport(r ledger.Reporter, p []ledger.Payload, l zerolog.Logger) error {
+func runReport(r ledger.Reporter, p []ledger.Payload, commit ledger.State, l zerolog.Logger) error {
 	l.Info().
 		Str("name", r.Name()).
 		Msg("starting reporter")
 
 	start := time.Now()
-	err := r.Report(p)
+	err := r.Report(p, commit)
 	elapsed := time.Since(start)
 
 	l.Info().

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -350,5 +350,5 @@ type Reporter interface {
 	// Name returns the name of the reporter. Only used for logging.
 	Name() string
 	// Report accepts slice ledger payloads and reports the state of the ledger
-	Report(payloads []Payload) error
+	Report(payloads []Payload, statecommitment State) error
 }


### PR DESCRIPTION
The state extraction util will run the migration and then generate a export-state.json file which includes the statecommitment before and after the migration. 

However, there is a bug that the statecommitment in the exported json file is wrong, it is showing the same statecommitment as the one before the migration. See comment about why it's wrong.

This PR fixes it.