### PR TITLE
Use Connection Pool Logic

### DIFF
--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -144,12 +144,10 @@ func (b *backendTransactions) sendTransactionToCollector(ctx context.Context,
 	tx *flow.TransactionBody,
 	collectionNodeAddr string) error {
 
-	// TODO: Use a connection pool to cache connections
-	collectionRPC, conn, err := b.connFactory.GetAccessAPIClient(collectionNodeAddr)
+	collectionRPC, _, err := b.connFactory.GetAccessAPIClient(collectionNodeAddr)
 	if err != nil {
 		return fmt.Errorf("failed to connect to collection node at %s: %w", collectionNodeAddr, err)
 	}
-	defer conn.Close()
 
 	err = b.grpcTxSend(ctx, collectionRPC, tx)
 	if err != nil {

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -138,7 +138,9 @@ func New(log zerolog.Logger,
 	if cacheSize == 0 {
 		cacheSize = backend.DefaultConnectionPoolSize
 	}
-	cache, err := lru.New(int(cacheSize))
+	cache, err := lru.NewWithEvict(int(cacheSize), func(_, evictedValue interface{}) {
+		evictedValue.(*grpc.ClientConn).Close()
+	})
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize connection pool cache: %w", err)
 	}


### PR DESCRIPTION
https://github.com/onflow/flow-go/pull/2412 left the closer logic untouched, preventing the connections cached from being reused. This PR removes the closer logic in place.