### PR TITLE
[`v0.26`] Add dry-run option for collection rate limiting

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -116,9 +116,9 @@ func main() {
 			"how many additional cluster members we propagate transactions to")
 		flags.UintVar(&builderExpiryBuffer, "builder-expiry-buffer", builder.DefaultExpiryBuffer,
 			"expiry buffer for transactions in proposed collections")
-		flags.BoolVar(&builderPayerRateLimitDryRun, "builder-rate-limit-dry-run", false,
+		flags.BoolVar(&builderPayerRateLimitDryRun, "builder-rate-limit-dry-run", true, // dry-run rate limiting
 			"determines whether rate limit configuration should be enforced (false), or only logged (true)")
-		flags.Float64Var(&builderPayerRateLimit, "builder-rate-limit", builder.DefaultMaxPayerTransactionRate, // no rate limiting
+		flags.Float64Var(&builderPayerRateLimit, "builder-rate-limit", 1.0, // 1 tx/collection
 			"rate limit for each payer (transactions/collection)")
 		flags.StringSliceVar(&builderUnlimitedPayers, "builder-unlimited-payers", []string{}, // no unlimited payers
 			"set of payer addresses which are omitted from rate limiting")

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -58,6 +58,7 @@ func main() {
 		maxCollectionByteSize                  uint64
 		maxCollectionTotalGas                  uint64
 		builderExpiryBuffer                    uint
+		builderPayerRateLimitDryRun            bool
 		builderPayerRateLimit                  float64
 		builderUnlimitedPayers                 []string
 		hotstuffTimeout                        time.Duration
@@ -115,6 +116,8 @@ func main() {
 			"how many additional cluster members we propagate transactions to")
 		flags.UintVar(&builderExpiryBuffer, "builder-expiry-buffer", builder.DefaultExpiryBuffer,
 			"expiry buffer for transactions in proposed collections")
+		flags.BoolVar(&builderPayerRateLimitDryRun, "builder-rate-limit-dry-run", false,
+			"determines whether rate limit configuration should be enforced (false), or only logged (true)")
 		flags.Float64Var(&builderPayerRateLimit, "builder-rate-limit", builder.DefaultMaxPayerTransactionRate, // no rate limiting
 			"rate limit for each payer (transactions/collection)")
 		flags.StringSliceVar(&builderUnlimitedPayers, "builder-unlimited-payers", []string{}, // no unlimited payers
@@ -408,10 +411,12 @@ func main() {
 				node.Tracer,
 				colMetrics,
 				push,
+				node.Logger,
 				builder.WithMaxCollectionSize(maxCollectionSize),
 				builder.WithMaxCollectionByteSize(maxCollectionByteSize),
 				builder.WithMaxCollectionTotalGas(maxCollectionTotalGas),
 				builder.WithExpiryBuffer(builderExpiryBuffer),
+				builder.WithRateLimitDryRun(builderPayerRateLimitDryRun),
 				builder.WithMaxPayerTransactionRate(builderPayerRateLimit),
 				builder.WithUnlimitedPayers(unlimitedPayers...),
 			)

--- a/engine/collection/epochmgr/factories/builder.go
+++ b/engine/collection/epochmgr/factories/builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/module"
 	builder "github.com/onflow/flow-go/module/builder/collection"
@@ -20,6 +21,7 @@ type BuilderFactory struct {
 	opts             []builder.Opt
 	metrics          module.CollectionMetrics
 	pusher           network.Engine // engine for pushing finalized collection to consensus committee
+	log              zerolog.Logger
 }
 
 func NewBuilderFactory(
@@ -28,6 +30,7 @@ func NewBuilderFactory(
 	trace module.Tracer,
 	metrics module.CollectionMetrics,
 	pusher network.Engine,
+	log zerolog.Logger,
 	opts ...builder.Opt,
 ) (*BuilderFactory, error) {
 
@@ -37,6 +40,7 @@ func NewBuilderFactory(
 		trace:            trace,
 		metrics:          metrics,
 		pusher:           pusher,
+		log:              log,
 		opts:             opts,
 	}
 	return factory, nil
@@ -55,6 +59,7 @@ func (f *BuilderFactory) Create(
 		clusterHeaders,
 		clusterPayloads,
 		pool,
+		f.log,
 		f.opts...,
 	)
 	if err != nil {

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -280,6 +280,7 @@ func CollectionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ro
 		node.Tracer,
 		node.Metrics,
 		pusherEngine,
+		node.Log,
 	)
 	require.NoError(t, err)
 

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -285,11 +285,16 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 			if b.config.DryRunRateLimit {
 				// log that this transaction would have been rate-limited, but we will still include it in the collection
 				b.log.Info().
-					Hex("tx_id", logging.Entity(tx)).
+					Hex("tx_id", logging.ID(txID)).
 					Str("payer_addr", tx.Payer.String()).
 					Float64("rate_limit", b.config.MaxPayerTransactionRate).
 					Msg("dry-run: observed transaction that would have been rate limited")
 			} else {
+				b.log.Debug().
+					Hex("tx_id", logging.ID(txID)).
+					Str("payer_addr", tx.Payer.String()).
+					Float64("rate_limit", b.config.MaxPayerTransactionRate).
+					Msg("transaction is rate-limited")
 				continue
 			}
 		}

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/opentracing/opentracing-go"
+	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
@@ -19,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
 	"github.com/onflow/flow-go/storage/badger/procedure"
+	"github.com/onflow/flow-go/utils/logging"
 )
 
 // Builder is the builder for collection block payloads. Upon providing a
@@ -35,9 +37,10 @@ type Builder struct {
 	transactions   mempool.Transactions
 	tracer         module.Tracer
 	config         Config
+	log            zerolog.Logger
 }
 
-func NewBuilder(db *badger.DB, tracer module.Tracer, mainHeaders storage.Headers, clusterHeaders storage.Headers, payloads storage.ClusterPayloads, transactions mempool.Transactions, opts ...Opt) (*Builder, error) {
+func NewBuilder(db *badger.DB, tracer module.Tracer, mainHeaders storage.Headers, clusterHeaders storage.Headers, payloads storage.ClusterPayloads, transactions mempool.Transactions, log zerolog.Logger, opts ...Opt) (*Builder, error) {
 
 	b := Builder{
 		db:             db,
@@ -47,6 +50,7 @@ func NewBuilder(db *badger.DB, tracer module.Tracer, mainHeaders storage.Headers
 		payloads:       payloads,
 		transactions:   transactions,
 		config:         DefaultConfig(),
+		log:            log.With().Str("component", "cluster_builder").Logger(),
 	}
 
 	for _, apply := range opts {
@@ -137,6 +141,14 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	if minPossibleRefHeight > refChainFinalizedHeight {
 		minPossibleRefHeight = 0 // overflow check
 	}
+
+	log := b.log.With().
+		Hex("parent_id", parentID[:]).
+		Str("chain_id", parent.ChainID.String()).
+		Uint64("final_ref_height", refChainFinalizedHeight).
+		Logger()
+
+	log.Debug().Msg("building new cluster block")
 
 	// TODO (ramtin): enable this again
 	// b.tracer.FinishSpan(parentID, trace.COLBuildOnSetup)
@@ -270,7 +282,16 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 
 		// enforce rate limiting rules
 		if limiter.shouldRateLimit(tx) {
-			continue
+			if b.config.DryRunRateLimit {
+				// log that this transaction would have been rate-limited, but we will still include it in the collection
+				b.log.Info().
+					Hex("tx_id", logging.Entity(tx)).
+					Str("payer_addr", tx.Payer.String()).
+					Float64("rate_limit", b.config.MaxPayerTransactionRate).
+					Msg("dry-run: observed transaction that would have been rate limited")
+			} else {
+				continue
+			}
 		}
 
 		// ensure we find the lowest reference block height

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -115,7 +115,7 @@ func (suite *BuilderSuite) SetupTest() {
 		suite.Assert().True(added)
 	}
 
-	suite.builder, _ = builder.NewBuilder(suite.db, tracer, suite.headers, suite.headers, suite.payloads, suite.pool)
+	suite.builder, _ = builder.NewBuilder(suite.db, tracer, suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger())
 }
 
 // runs after each test finishes
@@ -467,7 +467,7 @@ func (suite *BuilderSuite) TestBuildOn_LargeHistory() {
 
 	// use a mempool with 2000 transactions, one per block
 	suite.pool = herocache.NewTransactions(2000, unittest.Logger(), metrics.NewNoopCollector())
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, builder.WithMaxCollectionSize(10000))
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(), builder.WithMaxCollectionSize(10000))
 
 	// get a valid reference block ID
 	final, err := suite.protoState.Final().Head()
@@ -547,7 +547,7 @@ func (suite *BuilderSuite) TestBuildOn_LargeHistory() {
 
 func (suite *BuilderSuite) TestBuildOn_MaxCollectionSize() {
 	// set the max collection size to 1
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, builder.WithMaxCollectionSize(1))
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(), builder.WithMaxCollectionSize(1))
 
 	// build a block
 	header, err := suite.builder.BuildOn(suite.genesis.ID(), noopSetter)
@@ -565,7 +565,7 @@ func (suite *BuilderSuite) TestBuildOn_MaxCollectionSize() {
 
 func (suite *BuilderSuite) TestBuildOn_MaxCollectionByteSize() {
 	// set the max collection byte size to 400 (each tx is about 150 bytes)
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, builder.WithMaxCollectionByteSize(400))
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(), builder.WithMaxCollectionByteSize(400))
 
 	// build a block
 	header, err := suite.builder.BuildOn(suite.genesis.ID(), noopSetter)
@@ -583,7 +583,7 @@ func (suite *BuilderSuite) TestBuildOn_MaxCollectionByteSize() {
 
 func (suite *BuilderSuite) TestBuildOn_MaxCollectionTotalGas() {
 	// set the max gas to 20,000
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, builder.WithMaxCollectionTotalGas(20000))
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(), builder.WithMaxCollectionTotalGas(20000))
 
 	// build a block
 	header, err := suite.builder.BuildOn(suite.genesis.ID(), noopSetter)
@@ -620,7 +620,7 @@ func (suite *BuilderSuite) TestBuildOn_ExpiredTransaction() {
 
 	// reset the pool and builder
 	suite.pool = herocache.NewTransactions(10, unittest.Logger(), metrics.NewNoopCollector())
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool)
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger())
 
 	// insert a transaction referring genesis (now expired)
 	tx1 := unittest.TransactionBodyFixture(func(tx *flow.TransactionBody) {
@@ -662,7 +662,7 @@ func (suite *BuilderSuite) TestBuildOn_EmptyMempool() {
 
 	// start with an empty mempool
 	suite.pool = herocache.NewTransactions(1000, unittest.Logger(), metrics.NewNoopCollector())
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool)
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger())
 
 	header, err := suite.builder.BuildOn(suite.genesis.ID(), noopSetter)
 	suite.Require().NoError(err)
@@ -689,7 +689,7 @@ func (suite *BuilderSuite) TestBuildOn_NoRateLimiting() {
 	suite.ClearPool()
 
 	// create builder with no rate limit and max 10 tx/collection
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool,
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(),
 		builder.WithMaxCollectionSize(10),
 		builder.WithMaxPayerTransactionRate(0),
 	)
@@ -730,7 +730,7 @@ func (suite *BuilderSuite) TestBuildOn_RateLimitNonPayer() {
 	suite.ClearPool()
 
 	// create builder with 5 tx/payer and max 10 tx/collection
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool,
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(),
 		builder.WithMaxCollectionSize(10),
 		builder.WithMaxPayerTransactionRate(5),
 	)
@@ -774,7 +774,7 @@ func (suite *BuilderSuite) TestBuildOn_HighRateLimit() {
 	suite.ClearPool()
 
 	// create builder with 5 tx/payer and max 10 tx/collection
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool,
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(),
 		builder.WithMaxCollectionSize(10),
 		builder.WithMaxPayerTransactionRate(5),
 	)
@@ -812,7 +812,7 @@ func (suite *BuilderSuite) TestBuildOn_LowRateLimit() {
 	suite.ClearPool()
 
 	// create builder with .5 tx/payer and max 10 tx/collection
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool,
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(),
 		builder.WithMaxCollectionSize(10),
 		builder.WithMaxPayerTransactionRate(.5),
 	)
@@ -854,7 +854,7 @@ func (suite *BuilderSuite) TestBuildOn_UnlimitedPayer() {
 	// create builder with 5 tx/payer and max 10 tx/collection
 	// configure an unlimited payer
 	payer := unittest.RandomAddressFixture()
-	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool,
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(),
 		builder.WithMaxCollectionSize(10),
 		builder.WithMaxPayerTransactionRate(5),
 		builder.WithUnlimitedPayers(payer),
@@ -882,6 +882,46 @@ func (suite *BuilderSuite) TestBuildOn_UnlimitedPayer() {
 		suite.Assert().NoError(err)
 		suite.Assert().Len(built.Payload.Collection.Transactions, 10)
 
+	}
+}
+
+// TestBuildOn_RateLimitDryRun tests that rate limiting rules aren't enforced
+// if dry-run is enabled.
+func (suite *BuilderSuite) TestBuildOn_RateLimitDryRun() {
+
+	// start with an empty mempool
+	suite.ClearPool()
+
+	// create builder with 5 tx/payer and max 10 tx/collection
+	// configure an unlimited payer
+	payer := unittest.RandomAddressFixture()
+	suite.builder, _ = builder.NewBuilder(suite.db, trace.NewNoopTracer(), suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger(),
+		builder.WithMaxCollectionSize(10),
+		builder.WithMaxPayerTransactionRate(5),
+		builder.WithRateLimitDryRun(true),
+	)
+
+	// fill the pool with 100 transactions from the same payer
+	create := func() *flow.TransactionBody {
+		tx := unittest.TransactionBodyFixture()
+		tx.ReferenceBlockID = suite.ProtoStateRoot().ID()
+		tx.Payer = payer
+		return &tx
+	}
+	suite.FillPool(100, create)
+
+	// rate-limiting should not be applied, since dry-run setting is enabled
+	parentID := suite.genesis.ID()
+	for i := 0; i < 10; i++ {
+		header, err := suite.builder.BuildOn(parentID, noopSetter)
+		suite.Require().NoError(err)
+		parentID = header.ID()
+
+		// each collection should be full with 10 transactions
+		var built model.Block
+		err = suite.db.View(procedure.RetrieveClusterBlock(header.ID(), &built))
+		suite.Assert().NoError(err)
+		suite.Assert().Len(built.Payload.Collection.Transactions, 10)
 	}
 }
 
@@ -959,7 +999,7 @@ func benchmarkBuildOn(b *testing.B, size int) {
 		}
 
 		// create the builder
-		suite.builder, _ = builder.NewBuilder(suite.db, tracer, suite.headers, suite.headers, suite.payloads, suite.pool)
+		suite.builder, _ = builder.NewBuilder(suite.db, tracer, suite.headers, suite.headers, suite.payloads, suite.pool, unittest.Logger())
 	}
 
 	// create a block history to test performance against

--- a/module/builder/collection/config.go
+++ b/module/builder/collection/config.go
@@ -22,6 +22,11 @@ type Config struct {
 	// block.
 	ExpiryBuffer uint
 
+	// DryRunRateLimit will, when enabled, log when a transaction would have
+	// been omitted from a collection due to rate limiting settings. Rate
+	// limiting settings are not actually enforced while dry-run is true.
+	DryRunRateLimit bool
+
 	// MaxPayerTransactionRate is the maximum number of transactions per payer
 	// per collection. Fractional values greater than 1 are rounded down.
 	// Fractional values 0<k<1 mean that only 1 transaction every ceil(1/k)
@@ -45,6 +50,7 @@ func DefaultConfig() Config {
 	return Config{
 		MaxCollectionSize:       flow.DefaultMaxCollectionSize,
 		ExpiryBuffer:            DefaultExpiryBuffer,
+		DryRunRateLimit:         false,
 		MaxPayerTransactionRate: DefaultMaxPayerTransactionRate,
 		UnlimitedPayers:         make(map[flow.Address]struct{}), // no unlimited payers
 		MaxCollectionByteSize:   flow.DefaultMaxCollectionByteSize,
@@ -63,6 +69,12 @@ func WithMaxCollectionSize(size uint) Opt {
 func WithExpiryBuffer(buf uint) Opt {
 	return func(c *Config) {
 		c.ExpiryBuffer = buf
+	}
+}
+
+func WithRateLimitDryRun(dryRun bool) Opt {
+	return func(c *Config) {
+		c.DryRunRateLimit = dryRun
 	}
 }
 


### PR DESCRIPTION
https://github.com/onflow/flow-go/pull/2615 targeting `v0.26`

> Implement outcome from [TPM discussion](https://www.notion.so/dapperlabs/Technical-Product-Meeting-with-Dete-054824f0be334392806e1e39641afe48#6147b5a1c83a4842822c9202e8dbf6de). Adds an option to dry-run rate limiting, which will log each time a transaction would have been rate limited (but won't actually rate limit it).

In addition, adjusts default config:
* enables rate limit @ 1tx/collection
* enables dry-run for rate limit