### PR TITLE
Add exponential backoff for execution data download timeouts - v0.26

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -167,6 +167,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 			InitialBlockHeight: 0,
 			MaxSearchAhead:     edrequester.DefaultMaxSearchAhead,
 			FetchTimeout:       edrequester.DefaultFetchTimeout,
+			MaxFetchTimeout:    edrequester.DefaultMaxFetchTimeout,
 			RetryDelay:         edrequester.DefaultRetryDelay,
 			MaxRetryDelay:      edrequester.DefaultMaxRetryDelay,
 		},
@@ -605,7 +606,8 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 		flags.StringVar(&builder.executionDataDir, "execution-data-dir", defaultConfig.executionDataDir, "directory to use for Execution Data database")
 		flags.Uint64Var(&builder.executionDataStartHeight, "execution-data-start-height", defaultConfig.executionDataStartHeight, "height of first block to sync execution data from when starting with an empty Execution Data database")
 		flags.Uint64Var(&builder.executionDataConfig.MaxSearchAhead, "execution-data-max-search-ahead", defaultConfig.executionDataConfig.MaxSearchAhead, "max number of heights to search ahead of the lowest outstanding execution data height")
-		flags.DurationVar(&builder.executionDataConfig.FetchTimeout, "execution-data-fetch-timeout", defaultConfig.executionDataConfig.FetchTimeout, "timeout to use when fetching execution data from the network e.g. 300s")
+		flags.DurationVar(&builder.executionDataConfig.FetchTimeout, "execution-data-fetch-timeout", defaultConfig.executionDataConfig.FetchTimeout, "initial timeout to use when fetching execution data from the network. timeout increases using an incremental backoff until execution-data-max-fetch-timeout. e.g. 30s")
+		flags.DurationVar(&builder.executionDataConfig.MaxFetchTimeout, "execution-data-max-fetch-timeout", defaultConfig.executionDataConfig.MaxFetchTimeout, "maximum timeout to use when fetching execution data from the network e.g. 300s")
 		flags.DurationVar(&builder.executionDataConfig.RetryDelay, "execution-data-retry-delay", defaultConfig.executionDataConfig.RetryDelay, "initial delay for exponential backoff when fetching execution data fails e.g. 10s")
 		flags.DurationVar(&builder.executionDataConfig.MaxRetryDelay, "execution-data-max-retry-delay", defaultConfig.executionDataConfig.MaxRetryDelay, "maximum delay for exponential backoff when fetching execution data fails e.g. 5m")
 	}).ValidateFlags(func() error {
@@ -616,6 +618,9 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 		if builder.executionDataSyncEnabled {
 			if builder.executionDataConfig.FetchTimeout <= 0 {
 				return errors.New("execution-data-fetch-timeout must be greater than 0")
+			}
+			if builder.executionDataConfig.MaxFetchTimeout < builder.executionDataConfig.FetchTimeout {
+				return errors.New("execution-data-max-fetch-timeout must be greater than execution-data-fetch-timeout")
 			}
 			if builder.executionDataConfig.RetryDelay <= 0 {
 				return errors.New("execution-data-retry-delay must be greater than 0")

--- a/integration/utils/blob_service.go
+++ b/integration/utils/blob_service.go
@@ -53,10 +53,7 @@ func NewLocalBlobService(
 			ready()
 
 			<-ctx.Done()
-
-			if err := bs.blockService.Close(); err != nil {
-				ctx.Throw(err)
-			}
+			// Not calling bs.blockService.Close() since exchange is not set
 		}).
 		Build()
 

--- a/module/jobqueue.go
+++ b/module/jobqueue.go
@@ -54,6 +54,9 @@ type Job interface {
 // Jobs is the reader for an ordered job queue. Job can be fetched by the index,
 // which start from 0
 type Jobs interface {
+	// AtIndex returns the job at the given index.
+	// Error returns:
+	//   * storage.ErrNotFound if a job at the provided index is not available
 	AtIndex(index uint64) (Job, error)
 
 	// Head returns the index of the last job

--- a/module/jobqueue/finalized_block_reader.go
+++ b/module/jobqueue/finalized_block_reader.go
@@ -15,6 +15,8 @@ type FinalizedBlockReader struct {
 	blocks storage.Blocks
 }
 
+var _ module.Jobs = (*FinalizedBlockReader)(nil)
+
 // NewFinalizedBlockReader creates and returns a FinalizedBlockReader.
 func NewFinalizedBlockReader(state protocol.State, blocks storage.Blocks) *FinalizedBlockReader {
 	return &FinalizedBlockReader{

--- a/module/jobqueue/sealed_header_reader.go
+++ b/module/jobqueue/sealed_header_reader.go
@@ -15,6 +15,8 @@ type SealedBlockHeaderReader struct {
 	headers storage.Headers
 }
 
+var _ module.Jobs = (*SealedBlockHeaderReader)(nil)
+
 // NewSealedBlockHeaderReader creates and returns a SealedBlockHeaderReader.
 func NewSealedBlockHeaderReader(state protocol.State, headers storage.Headers) *SealedBlockHeaderReader {
 	return &SealedBlockHeaderReader{
@@ -25,6 +27,8 @@ func NewSealedBlockHeaderReader(state protocol.State, headers storage.Headers) *
 
 // AtIndex returns the block header job at the given index.
 // The block header job at an index is just the finalized block header at that index (i.e., height).
+// Error returns:
+//   * storage.ErrNotFound if the provided index is not sealed
 func (r SealedBlockHeaderReader) AtIndex(index uint64) (module.Job, error) {
 	header, err := r.blockByHeight(index)
 	if err != nil {

--- a/module/state_synchronization/requester/execution_data_requester.go
+++ b/module/state_synchronization/requester/execution_data_requester.go
@@ -67,12 +67,16 @@ import (
 //                               +-------------+             +-------------+
 
 const (
-	// DefaultFetchTimeout is the default timeout for fetching ExecutionData from the db/network
-	DefaultFetchTimeout = 5 * time.Minute
+	// DefaultFetchTimeout is the default initial timeout for fetching ExecutionData from the
+	// db/network. The timeout is increased using an incremental backoff until FetchTimeout.
+	DefaultFetchTimeout = 10 * time.Second
+
+	// DefaultMaxFetchTimeout is the default timeout for fetching ExecutionData from the db/network
+	DefaultMaxFetchTimeout = 10 * time.Minute
 
 	// DefaultRetryDelay is the default initial delay used in the exponential backoff for failed
 	// ExecutionData download retries
-	DefaultRetryDelay = 10 * time.Second
+	DefaultRetryDelay = 1 * time.Second
 
 	// DefaultMaxRetryDelay is the default maximum delay used in the exponential backoff for failed
 	// ExecutionData download retries
@@ -97,8 +101,11 @@ type ExecutionDataConfig struct {
 	// unbounded memory use by the requester if it gets stuck fetching a specific height.
 	MaxSearchAhead uint64
 
-	// The timeout for fetching ExecutionData from the db/network
+	// The initial timeout for fetching ExecutionData from the db/network
 	FetchTimeout time.Duration
+
+	// The max timeout for fetching ExecutionData from the db/network
+	MaxFetchTimeout time.Duration
 
 	// Exponential backoff settings for download retries
 	RetryDelay    time.Duration
@@ -317,6 +324,12 @@ func (e *executionDataRequester) processSealedHeight(ctx irrecoverable.SignalerC
 	backoff = retry.WithCappedDuration(e.config.MaxRetryDelay, backoff)
 	backoff = retry.WithJitterPercent(15, backoff)
 
+	// bitswap always waits for either all data to be received or a timeout, even if it encountered an error.
+	// use an incremental backoff for the timeout so we do faster initial retries, then allow for more
+	// time in case data is large or there is network congestion.
+	timeout := retry.NewExponential(e.config.FetchTimeout)
+	timeout = retry.WithCappedDuration(e.config.MaxFetchTimeout, timeout)
+
 	attempt := 0
 	return retry.Do(ctx, backoff, func(context.Context) error {
 		if attempt > 0 {
@@ -331,7 +344,8 @@ func (e *executionDataRequester) processSealedHeight(ctx irrecoverable.SignalerC
 		attempt++
 
 		// download execution data for the block
-		err := e.processFetchRequest(ctx, blockID, height)
+		fetchTimeout, _ := timeout.Next()
+		err := e.processFetchRequest(ctx, blockID, height, fetchTimeout)
 
 		// don't retry if the blob was invalid
 		if isInvalidBlobError(err) {
@@ -342,7 +356,7 @@ func (e *executionDataRequester) processSealedHeight(ctx irrecoverable.SignalerC
 	})
 }
 
-func (e *executionDataRequester) processFetchRequest(ctx irrecoverable.SignalerContext, blockID flow.Identifier, height uint64) error {
+func (e *executionDataRequester) processFetchRequest(ctx irrecoverable.SignalerContext, blockID flow.Identifier, height uint64, fetchTimeout time.Duration) error {
 	logger := e.log.With().
 		Str("block_id", blockID.String()).
 		Uint64("height", height).
@@ -369,7 +383,7 @@ func (e *executionDataRequester) processFetchRequest(ctx irrecoverable.SignalerC
 
 	logger.Debug().Msg("downloading execution data")
 
-	_, err = e.fetchExecutionData(ctx, result.ExecutionDataID)
+	_, err = e.fetchExecutionData(ctx, result.ExecutionDataID, fetchTimeout)
 
 	e.metrics.ExecutionDataFetchFinished(time.Since(start), err == nil, height)
 
@@ -401,8 +415,8 @@ func (e *executionDataRequester) processFetchRequest(ctx irrecoverable.SignalerC
 }
 
 // fetchExecutionData fetches the ExecutionData by its ID, and times out if fetchTimeout is exceeded
-func (e *executionDataRequester) fetchExecutionData(signalerCtx irrecoverable.SignalerContext, executionDataID flow.Identifier) (*state_synchronization.ExecutionData, error) {
-	ctx, cancel := context.WithTimeout(signalerCtx, e.config.FetchTimeout)
+func (e *executionDataRequester) fetchExecutionData(signalerCtx irrecoverable.SignalerContext, executionDataID flow.Identifier, fetchTimeout time.Duration) (*state_synchronization.ExecutionData, error) {
+	ctx, cancel := context.WithTimeout(signalerCtx, fetchTimeout)
 	defer cancel()
 
 	// Get the data from the network


### PR DESCRIPTION
v0.26 Backport #2629: Add exponential backoff for execution data download timeouts

When an ExecutionData request fails, bitswap does not return until the context times out. This means if we naively wait for the full max timeout, there is a large delay whenever there's an issue with a peer or the network. However, we can't just make the timeout short either in case there is a large blob that takes a while to download.

This PR adds an incremental backoff for the timeout, and configuration to control the settings.
