### PR TITLE
Fix Cadence code

### DIFF
--- a/fvm/blueprints/epochs.go
+++ b/fvm/blueprints/epochs.go
@@ -35,7 +35,7 @@ transaction(clusterWeights: [{String: UInt64}]) {
     let clusters: [FlowClusterQC.Cluster] = []
     var clusterIndex: UInt16 = 0
     for weightMapping in clusterWeights {
-      let cluster = FlowClusterQC.Cluster(clusterIndex, weightMapping)
+      let cluster = FlowClusterQC.Cluster(index: clusterIndex, nodeWeights: weightMapping)
       clusterIndex = clusterIndex + 1
     }
 

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/onflow/atree v0.3.1-0.20220531231935-525fbc26f40a
 	github.com/onflow/cadence v0.24.1
 	github.com/onflow/flow v0.3.1
-	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83
+	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220619024549-c6edf007737c
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220513155751-c4c1f8d59f83
 	github.com/onflow/flow-emulator v0.33.0
 	github.com/onflow/flow-go-sdk v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -1348,8 +1348,8 @@ github.com/onflow/cadence v0.24.1 h1:ERWaKaNXyeUwJkVp+66Yfp/DsojrzQ0btvY3D6XK9sY
 github.com/onflow/cadence v0.24.1/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/flow v0.3.1 h1:kL/tNvCXeBw4yCVPys/m9rxvKxrO7Ck/mVNqHFtkTrI=
 github.com/onflow/flow v0.3.1/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
-github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83 h1:mpJirFu/JWMLV0IhKDZleVrVdN5B8QERV4gSXDef5bA=
-github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220513155751-c4c1f8d59f83/go.mod h1:T6yhM+kWrFxiP6F3hh8lh9DcocHfmv48P4ITnjLhKSk=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220619024549-c6edf007737c h1:Ysp7W3vzRRs+ric702YSCW5aLaxfPGG+tr3zgRXXNAA=
+github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220619024549-c6edf007737c/go.mod h1:T6yhM+kWrFxiP6F3hh8lh9DcocHfmv48P4ITnjLhKSk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220513155751-c4c1f8d59f83 h1:w4uXFTvjQmLtA/X50H4YXVlzbdsoL3vDI3Y86jtJOMM=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220513155751-c4c1f8d59f83/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
 github.com/onflow/flow-emulator v0.33.0 h1:6vzaHlb7nPjlIBUCrkNZviFYYprnYfOWG1z0GCn5ltY=


### PR DESCRIPTION
Depends on onflow/flow-core-contracts#293 

In github.com/onflow/cadence#1717, the check of argument labels for nested constructors was fixed.
Fix the previously accepted code, which is now rejected:
- Update to the fixed core contracts
- Add the missing argument label

TODO: update to tag