### PR TITLE
Simplify blockCommitter/eventHasher

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -135,8 +135,10 @@ func (e *blockComputer) executeBlock(
 		Events:             make([]flow.EventsList, chunksSize),
 		ServiceEvents:      make(flow.EventsList, 0),
 		TransactionResults: make([]flow.TransactionResult, 0),
-		StateCommitments:   make([]flow.StateCommitment, 0),
-		Proofs:             make([][]byte, 0),
+		StateCommitments:   make([]flow.StateCommitment, 0, chunksSize),
+		Proofs:             make([][]byte, 0, chunksSize),
+		TrieUpdates:        make([]*ledger.TrieUpdate, 0, chunksSize),
+		EventsHashes:       make([]flow.Identifier, 0, chunksSize),
 	}
 
 	var txIndex uint32
@@ -144,37 +146,21 @@ func (e *blockComputer) executeBlock(
 	var wg sync.WaitGroup
 	wg.Add(2) // block commiter and event hasher
 
-	stateCommitments := make([]flow.StateCommitment, 0, len(collections)+1)
-	proofs := make([][]byte, 0, len(collections)+1)
-	trieUpdates := make([]*ledger.TrieUpdate, 0, len(collections)+1)
-
 	bc := blockCommitter{
 		committer: e.committer,
 		blockSpan: blockSpan,
 		tracer:    e.tracer,
 		state:     *block.StartState,
-		views:     make(chan state.View, len(collections)+1),
-		callBack: func(state flow.StateCommitment, proof []byte, trieUpdate *ledger.TrieUpdate, err error) {
-			if err != nil {
-				panic(err)
-			}
-			stateCommitments = append(stateCommitments, state)
-			proofs = append(proofs, proof)
-			trieUpdates = append(trieUpdates, trieUpdate)
-		},
+		views:     make(chan state.View, chunksSize),
+		res:       res,
 	}
 	defer bc.Close()
 
 	eh := eventHasher{
 		tracer:    e.tracer,
-		data:      make(chan flow.EventsList, len(collections)+1),
+		data:      make(chan flow.EventsList, chunksSize),
 		blockSpan: blockSpan,
-		callBack: func(hash flow.Identifier, err error) {
-			if err != nil {
-				panic(err)
-			}
-			res.EventsHashes = append(res.EventsHashes, hash)
-		},
+		res:       res,
 	}
 	defer eh.Close()
 
@@ -226,9 +212,6 @@ func (e *blockComputer) executeBlock(
 
 	wg.Wait()
 	res.StateReads = stateView.(*delta.View).ReadsCount()
-	res.StateCommitments = stateCommitments
-	res.Proofs = proofs
-	res.TrieUpdates = trieUpdates
 
 	return res, nil
 }
@@ -458,18 +441,26 @@ func (e *blockComputer) mergeView(
 type blockCommitter struct {
 	tracer    module.Tracer
 	committer ViewCommitter
-	callBack  func(state flow.StateCommitment, proof []byte, update *ledger.TrieUpdate, err error)
 	state     flow.StateCommitment
 	views     chan state.View
 	closeOnce sync.Once
 	blockSpan opentracing.Span
+
+	res *execution.ComputationResult
 }
 
 func (bc *blockCommitter) Run() {
 	for view := range bc.views {
 		span := bc.tracer.StartSpanFromParent(bc.blockSpan, trace.EXECommitDelta)
 		stateCommit, proof, trieUpdate, err := bc.committer.CommitView(view, bc.state)
-		bc.callBack(stateCommit, proof, trieUpdate, err)
+		if err != nil {
+			panic(err)
+		}
+
+		bc.res.StateCommitments = append(bc.res.StateCommitments, stateCommit)
+		bc.res.Proofs = append(bc.res.Proofs, proof)
+		bc.res.TrieUpdates = append(bc.res.TrieUpdates, trieUpdate)
+
 		bc.state = stateCommit
 		span.Finish()
 	}
@@ -485,17 +476,23 @@ func (bc *blockCommitter) Close() {
 
 type eventHasher struct {
 	tracer    module.Tracer
-	callBack  func(hash flow.Identifier, err error)
 	data      chan flow.EventsList
 	closeOnce sync.Once
 	blockSpan opentracing.Span
+
+	res *execution.ComputationResult
 }
 
 func (eh *eventHasher) Run() {
 	for data := range eh.data {
 		span := eh.tracer.StartSpanFromParent(eh.blockSpan, trace.EXEHashEvents)
 		rootHash, err := flow.EventsMerkleRootHash(data)
-		eh.callBack(rootHash, err)
+		if err != nil {
+			panic(err)
+		}
+
+		eh.res.EventsHashes = append(eh.res.EventsHashes, rootHash)
+
 		span.Finish()
 	}
 }


### PR DESCRIPTION
The callbacks make the code less readable