### PR TITLE
Override cbor DecMode config in execution data requester

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -462,8 +462,11 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 				MaxMapPairs:      math.MaxInt64,
 				MaxNestedLevels:  math.MaxInt16,
 			}.DecMode()
+			if err != nil {
+				return nil, fmt.Errorf("could not create cbor decoder: %w", err)
+			}
 
-			codec := cbor.NewCodec(nil, decMode)
+			codec := cbor.NewCodec(cbor.WithDecMode(decMode))
 
 			builder.ExecutionDataService = state_synchronization.NewExecutionDataService(
 				codec,

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	cborlib "github.com/fxamacker/cbor/v2"
 	badger "github.com/ipfs/go-ds-badger2"
 	"github.com/onflow/flow/protobuf/go/flow/access"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
-
-	cborcodec "github.com/onflow/flow-go/network/codec/cbor"
 
 	"github.com/onflow/flow-go/cmd"
 	"github.com/onflow/flow-go/consensus"
@@ -48,6 +48,7 @@ import (
 	"github.com/onflow/flow-go/module/synchronization"
 	"github.com/onflow/flow-go/network"
 	netcache "github.com/onflow/flow-go/network/cache"
+	cborcodec "github.com/onflow/flow-go/network/codec/cbor"
 	"github.com/onflow/flow-go/network/compressor"
 	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/network/validator"
@@ -456,8 +457,16 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 				return nil, fmt.Errorf("could not register blob service: %w", err)
 			}
 
+			decMode, err := cborlib.DecOptions{
+				MaxArrayElements: math.MaxInt64,
+				MaxMapPairs:      math.MaxInt64,
+				MaxNestedLevels:  math.MaxInt16,
+			}.DecMode()
+
+			codec := cbor.NewCodec(nil, decMode)
+
 			builder.ExecutionDataService = state_synchronization.NewExecutionDataService(
-				new(cbor.Codec),
+				codec,
 				compressor.NewLz4Compressor(),
 				bs,
 				metrics.NewExecutionDataServiceCollector(),

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -459,7 +459,7 @@ func (e *ExecutionNodeBuilder) LoadComponentsAndModules() {
 			}
 
 			eds := state_synchronization.NewExecutionDataService(
-				&cbor.Codec{},
+				cbor.NewCodec(),
 				compressor.NewLz4Compressor(),
 				bs,
 				executionDataServiceCollector,

--- a/cmd/util/cmd/execution-data-blobstore/cmd/get.go
+++ b/cmd/util/cmd/execution-data-blobstore/cmd/get.go
@@ -40,7 +40,7 @@ func run(*cobra.Command, []string) {
 	logger := zerolog.New(os.Stdout)
 
 	eds := state_synchronization.NewExecutionDataService(
-		&cbor.Codec{},
+		cbor.NewCodec(),
 		compressor.NewLz4Compressor(),
 		bs,
 		metrics.NewNoopCollector(),

--- a/integration/tests/access/execution_state_sync_test.go
+++ b/integration/tests/access/execution_state_sync_test.go
@@ -199,7 +199,7 @@ func (s *ExecutionStateSyncSuite) nodeExecutionDataService(node *testnet.Contain
 	blobService.Start(ctx)
 
 	return state_synchronization.NewExecutionDataService(
-		new(cbor.Codec),
+		cbor.NewCodec(),
 		compressor.NewLz4Compressor(),
 		blobService,
 		metrics.NewNoopCollector(),

--- a/model/encoding/cbor/codec.go
+++ b/model/encoding/cbor/codec.go
@@ -57,12 +57,33 @@ func (m *Marshaler) MustUnmarshal(b []byte, val interface{}) {
 
 var _ encoding.Codec = (*Codec)(nil)
 
-type Codec struct{}
+type Codec struct {
+	encMode cbor.EncMode
+	decMode cbor.DecMode
+}
+
+// NewCodec returns a new cbor Codec with the provided EncMode and DecMode.
+// If either is nil, the default cbor EncMode/DecMode will be used.
+func NewCodec(encMode cbor.EncMode, decMode cbor.DecMode) *Codec {
+	return &Codec{
+		encMode: encMode,
+		decMode: decMode,
+	}
+}
 
 func (c *Codec) NewEncoder(w io.Writer) encoding.Encoder {
+	if c.encMode != nil {
+		return c.encMode.NewEncoder(w)
+	}
+
 	return EncMode.NewEncoder(w)
 }
 
 func (c *Codec) NewDecoder(r io.Reader) encoding.Decoder {
+	if c.decMode != nil {
+		return c.decMode.NewDecoder(r)
+	}
+
+	// use cbor defaultDecMode
 	return cbor.NewDecoder(r)
 }

--- a/model/encoding/cbor/codec.go
+++ b/model/encoding/cbor/codec.go
@@ -57,6 +57,20 @@ func (m *Marshaler) MustUnmarshal(b []byte, val interface{}) {
 
 var _ encoding.Codec = (*Codec)(nil)
 
+type Option func(*Codec)
+
+func WithEncMode(encMode cbor.EncMode) Option {
+	return func(c *Codec) {
+		c.encMode = encMode
+	}
+}
+
+func WithDecMode(decMode cbor.DecMode) Option {
+	return func(c *Codec) {
+		c.decMode = decMode
+	}
+}
+
 type Codec struct {
 	encMode cbor.EncMode
 	decMode cbor.DecMode
@@ -64,11 +78,14 @@ type Codec struct {
 
 // NewCodec returns a new cbor Codec with the provided EncMode and DecMode.
 // If either is nil, the default cbor EncMode/DecMode will be used.
-func NewCodec(encMode cbor.EncMode, decMode cbor.DecMode) *Codec {
-	return &Codec{
-		encMode: encMode,
-		decMode: decMode,
+func NewCodec(opts ...Option) *Codec {
+	c := &Codec{}
+
+	for _, opt := range opts {
+		opt(c)
 	}
+
+	return c
 }
 
 func (c *Codec) NewEncoder(w io.Writer) encoding.Encoder {

--- a/module/state_synchronization/execution_data_service_test.go
+++ b/module/state_synchronization/execution_data_service_test.go
@@ -171,7 +171,7 @@ func allKeys(t *testing.T, bs blockstore.Blockstore, timeout time.Duration) []ci
 }
 
 func executionDataService(bs network.BlobService) *executionDataServiceImpl {
-	codec := new(cbor.Codec)
+	codec := cbor.NewCodec()
 	compressor := compressor.NewLz4Compressor()
 	return NewExecutionDataService(codec, compressor, bs, metrics.NewNoopCollector(), zerolog.Nop())
 }

--- a/module/state_synchronization/requester/execution_data_requester_test.go
+++ b/module/state_synchronization/requester/execution_data_requester_test.go
@@ -644,7 +644,7 @@ func (suite *ExecutionDataRequesterSuite) generateTestData(blockCount int, speci
 
 	// instantiate ExecutionDataService to generate correct CIDs
 	eds := state_synchronization.NewExecutionDataService(
-		new(cbor.Codec),
+		cbor.NewCodec(),
 		compressor.NewLz4Compressor(),
 		suite.blobservice,
 		metrics.NewNoopCollector(),


### PR DESCRIPTION
Execution nodes may produce `ExecutionData` blobs with very large cbor encoded data structures. This PR sets the limits to max for Access Node `ExecutionDataRequest` and adds configuration to the cbor codec to allow providing custom `EncMode`/`DecMode` settings.