### PR TITLE
[FVM] Don't read context from state on system chunk

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -64,6 +64,7 @@ func SystemChunkContext(vmCtx fvm.Context, logger zerolog.Logger) fvm.Context {
 		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker(logger)),
 		fvm.WithMaxStateInteractionSize(SystemChunkLedgerIntractionLimit),
 		fvm.WithEventCollectionSizeLimit(SystemChunkEventCollectionMaxSize),
+		fvm.WithLoadContextFromState(false),
 	)
 }
 

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -65,8 +65,8 @@ func SystemChunkContext(vmCtx fvm.Context, logger zerolog.Logger) fvm.Context {
 		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker(logger)),
 		fvm.WithMaxStateInteractionSize(SystemChunkLedgerIntractionLimit),
 		fvm.WithEventCollectionSizeLimit(SystemChunkEventCollectionMaxSize),
-		fvm.WithLoadContextFromState(false), // disable reading the memory limit (and computation/memory weights) from the state
-		fvm.WithMemoryLimit(math.MaxUint64), // and set the memory limit to the maximum
+		fvm.WithAllowContextOverrideByExecutionState(false), // disable reading the memory limit (and computation/memory weights) from the state
+		fvm.WithMemoryLimit(math.MaxUint64),                 // and set the memory limit to the maximum
 	)
 }
 

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -3,6 +3,7 @@ package computer
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"sync"
 	"time"
@@ -64,7 +65,8 @@ func SystemChunkContext(vmCtx fvm.Context, logger zerolog.Logger) fvm.Context {
 		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker(logger)),
 		fvm.WithMaxStateInteractionSize(SystemChunkLedgerIntractionLimit),
 		fvm.WithEventCollectionSizeLimit(SystemChunkEventCollectionMaxSize),
-		fvm.WithLoadContextFromState(false),
+		fvm.WithLoadContextFromState(false), // disable reading the memory limit (and computation/memory weights) from the state
+		fvm.WithMemoryLimit(math.MaxUint64), // and set the memory limit to the maximum
 	)
 }
 

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
 	fvmErrors "github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/meter/weighted"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
@@ -360,6 +361,48 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		require.Equal(t, serviceEventB.EventType.ID(), string(result.ServiceEvents[1].Type))
 
 		assertEventHashesMatch(t, collectionCount+1, result)
+	})
+
+	t.Run("system transaction does not read memory limit from state", func(t *testing.T) {
+
+		weighted.DefaultMemoryWeights = weighted.ExecutionMemoryWeights{
+			0: 1, // single weight set to 1
+		}
+		execCtx := fvm.NewContext(
+			zerolog.Nop(),
+			fvm.WithMemoryLimit(10), // the context memory limit is set to 10
+		)
+
+		rt := &testRuntime{
+			executeTransaction: func(script runtime.Script, r runtime.Context) error {
+				err := r.Interface.MeterMemory(common.MemoryUsage{
+					Kind:   0,
+					Amount: 11,
+				})
+				require.NoError(t, err) // should fail if limit is taken from the default context
+
+				return nil
+			},
+			readStored: func(address common.Address, path cadence.Path, r runtime.Context) (cadence.Value, error) {
+				require.Fail(t, "system chunk should not read context from the state")
+				return nil, nil
+			},
+		}
+
+		vm := fvm.NewVirtualMachine(rt)
+
+		exe, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter())
+		require.NoError(t, err)
+
+		block := generateBlock(0, 0, rag)
+
+		view := delta.NewView(func(owner, controller, key string) (flow.RegisterValue, error) {
+			return nil, nil
+		})
+
+		result, err := exe.ExecuteBlock(context.Background(), block, view, programs.NewEmptyPrograms())
+		assert.NoError(t, err)
+		assert.Len(t, result.StateSnapshots, 1) // system chunk
 	})
 
 	t.Run("succeeding transactions store programs", func(t *testing.T) {

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -13,10 +13,12 @@ import (
 
 // A Context defines a set of execution parameters used by the virtual machine.
 type Context struct {
-	Chain                        flow.Chain
-	Blocks                       Blocks
-	Metrics                      handler.MetricsReporter
-	Tracer                       module.Tracer
+	Chain   flow.Chain
+	Blocks  Blocks
+	Metrics handler.MetricsReporter
+	Tracer  module.Tracer
+	// LoadContextFromState is a flag telling the fvm to load certain parts of the context from the state
+	LoadContextFromState         bool
 	ComputationLimit             uint64
 	MemoryLimit                  uint64
 	MaxStateKeySize              uint64
@@ -75,6 +77,7 @@ func defaultContext(logger zerolog.Logger) Context {
 		Blocks:                           nil,
 		Metrics:                          &handler.NoopMetricsReporter{},
 		Tracer:                           nil,
+		LoadContextFromState:             true,
 		ComputationLimit:                 DefaultComputationLimit,
 		MemoryLimit:                      DefaultMemoryLimit,
 		MaxStateKeySize:                  state.DefaultMaxKeySize,
@@ -121,6 +124,14 @@ func WithChain(chain flow.Chain) Option {
 func WithGasLimit(limit uint64) Option {
 	return func(ctx Context) Context {
 		ctx.ComputationLimit = limit
+		return ctx
+	}
+}
+
+// WithLoadContextFromState sets if certain context parameters get loaded from the state or not
+func WithLoadContextFromState(load bool) Option {
+	return func(ctx Context) Context {
+		ctx.LoadContextFromState = load
 		return ctx
 	}
 }

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -128,8 +128,8 @@ func WithGasLimit(limit uint64) Option {
 	}
 }
 
-// WithLoadContextFromState sets if certain context parameters get loaded from the state or not
-func WithLoadContextFromState(load bool) Option {
+// WithAllowContextOverrideByExecutionState sets if certain context parameters get loaded from the state or not
+func WithAllowContextOverrideByExecutionState(load bool) Option {
 	return func(ctx Context) Context {
 		ctx.AllowContextOverrideByExecutionState = load
 		return ctx

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -17,17 +17,17 @@ type Context struct {
 	Blocks  Blocks
 	Metrics handler.MetricsReporter
 	Tracer  module.Tracer
-	// LoadContextFromState is a flag telling the fvm to load certain parts of the context from the state
-	LoadContextFromState         bool
-	ComputationLimit             uint64
-	MemoryLimit                  uint64
-	MaxStateKeySize              uint64
-	MaxStateValueSize            uint64
-	MaxStateInteractionSize      uint64
-	EventCollectionByteSizeLimit uint64
-	MaxNumOfTxRetries            uint8
-	BlockHeader                  *flow.Header
-	ServiceAccountEnabled        bool
+	// AllowContextOverrideByExecutionState is a flag telling the fvm to override certain parts of the context from the state
+	AllowContextOverrideByExecutionState bool
+	ComputationLimit                     uint64
+	MemoryLimit                          uint64
+	MaxStateKeySize                      uint64
+	MaxStateValueSize                    uint64
+	MaxStateInteractionSize              uint64
+	EventCollectionByteSizeLimit         uint64
+	MaxNumOfTxRetries                    uint8
+	BlockHeader                          *flow.Header
+	ServiceAccountEnabled                bool
 	// Depricated: RestrictedDeploymentEnabled is deprecated use SetIsContractDeploymentRestrictedTransaction instead.
 	// Can be removed after all networks are migrated to SetIsContractDeploymentRestrictedTransaction
 	RestrictedDeploymentEnabled      bool
@@ -73,27 +73,27 @@ const (
 
 func defaultContext(logger zerolog.Logger) Context {
 	return Context{
-		Chain:                            flow.Mainnet.Chain(),
-		Blocks:                           nil,
-		Metrics:                          &handler.NoopMetricsReporter{},
-		Tracer:                           nil,
-		LoadContextFromState:             true,
-		ComputationLimit:                 DefaultComputationLimit,
-		MemoryLimit:                      DefaultMemoryLimit,
-		MaxStateKeySize:                  state.DefaultMaxKeySize,
-		MaxStateValueSize:                state.DefaultMaxValueSize,
-		MaxStateInteractionSize:          state.DefaultMaxInteractionSize,
-		EventCollectionByteSizeLimit:     DefaultEventCollectionByteSizeLimit,
-		MaxNumOfTxRetries:                DefaultMaxNumOfTxRetries,
-		BlockHeader:                      nil,
-		ServiceAccountEnabled:            true,
-		RestrictedDeploymentEnabled:      true,
-		RestrictedContractRemovalEnabled: true,
-		CadenceLoggingEnabled:            false,
-		EventCollectionEnabled:           true,
-		ServiceEventCollectionEnabled:    false,
-		AccountFreezeAvailable:           false,
-		ExtensiveTracing:                 false,
+		Chain:                                flow.Mainnet.Chain(),
+		Blocks:                               nil,
+		Metrics:                              &handler.NoopMetricsReporter{},
+		Tracer:                               nil,
+		AllowContextOverrideByExecutionState: true,
+		ComputationLimit:                     DefaultComputationLimit,
+		MemoryLimit:                          DefaultMemoryLimit,
+		MaxStateKeySize:                      state.DefaultMaxKeySize,
+		MaxStateValueSize:                    state.DefaultMaxValueSize,
+		MaxStateInteractionSize:              state.DefaultMaxInteractionSize,
+		EventCollectionByteSizeLimit:         DefaultEventCollectionByteSizeLimit,
+		MaxNumOfTxRetries:                    DefaultMaxNumOfTxRetries,
+		BlockHeader:                          nil,
+		ServiceAccountEnabled:                true,
+		RestrictedDeploymentEnabled:          true,
+		RestrictedContractRemovalEnabled:     true,
+		CadenceLoggingEnabled:                false,
+		EventCollectionEnabled:               true,
+		ServiceEventCollectionEnabled:        false,
+		AccountFreezeAvailable:               false,
+		ExtensiveTracing:                     false,
 		TransactionProcessors: []TransactionProcessor{
 			NewTransactionAccountFrozenChecker(),
 			NewTransactionSignatureVerifier(AccountKeyWeightThreshold),
@@ -131,7 +131,7 @@ func WithGasLimit(limit uint64) Option {
 // WithLoadContextFromState sets if certain context parameters get loaded from the state or not
 func WithLoadContextFromState(load bool) Option {
 	return func(ctx Context) Context {
-		ctx.LoadContextFromState = load
+		ctx.AllowContextOverrideByExecutionState = load
 		return ctx
 	}
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -3964,6 +3964,56 @@ func TestSettingExecutionWeights(t *testing.T) {
 		},
 	))
 
+	t.Run("transaction should not read context from the state if AllowContextOverrideByExecutionState if false", newVMTest().
+		withBootstrapProcedureOptions(
+			fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
+			fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
+			fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
+			fvm.WithExecutionEffortWeights(
+				weightedMeter.ExecutionEffortWeights{
+					meter.ComputationKindCreateAccount: 1_000_000_000_000 << weightedMeter.MeterExecutionInternalPrecisionBytes,
+				},
+			),
+			fvm.WithExecutionMemoryWeights(
+				weightedMeter.ExecutionMemoryWeights{
+					common.MemoryKindBreakStatement: 1_000_000_000_000,
+				},
+			),
+			fvm.WithExecutionMemoryLimit(0),
+		).withContextOptions(
+		fvm.WithAllowContextOverrideByExecutionState(false),
+		fvm.WithMemoryLimit(math.MaxUint64),
+	).run(
+		func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
+			txBody := flow.NewTransactionBody().
+				SetScript([]byte(`
+				transaction {
+                  prepare(signer: AuthAccount) {
+					while true {
+						AuthAccount(payer: signer)
+						break
+					}
+                  }
+                }
+			`)).
+				SetProposalKey(chain.ServiceAddress(), 0, 0).
+				AddAuthorizer(chain.ServiceAddress()).
+				SetPayer(chain.ServiceAddress()).
+				SetGasLimit(1_000)
+
+			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
+			require.NoError(t, err)
+
+			tx := fvm.Transaction(txBody, 0)
+			err = vm.Run(ctx, tx, view, programs)
+			// tx would fail if ExecutionEffortWeights from the state were used due to computation limit
+			// tx would fail if ExecutionMemoryWeights from the state were used due to memory limit
+			// tx would fail if MemoryLimit from the state was used due to memory limit
+			require.NoError(t, err)
+			require.NoError(t, tx.Err)
+		},
+	))
+
 	t.Run("transaction should not use up more computation that the transaction body itself", newVMTest().withBootstrapProcedureOptions(
 		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -101,7 +101,9 @@ func NewScriptEnvironment(
 		env.seedRNG(fvmContext.BlockHeader)
 	}
 
-	env.setExecutionParameters()
+	if fvmContext.LoadContextFromState {
+		env.setExecutionParameters()
+	}
 
 	return env
 }

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -101,7 +101,7 @@ func NewScriptEnvironment(
 		env.seedRNG(fvmContext.BlockHeader)
 	}
 
-	if fvmContext.LoadContextFromState {
+	if fvmContext.AllowContextOverrideByExecutionState {
 		env.setExecutionParameters()
 	}
 

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -124,7 +124,7 @@ func NewTransactionEnvironment(
 
 	var err error
 	// set the execution parameters from the state
-	if ctx.LoadContextFromState {
+	if ctx.AllowContextOverrideByExecutionState {
 		err = env.setExecutionParameters()
 	}
 

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -122,8 +122,11 @@ func NewTransactionEnvironment(
 		env.seedRNG(ctx.BlockHeader)
 	}
 
+	var err error
 	// set the execution parameters from the state
-	err := env.setExecutionParameters()
+	if ctx.LoadContextFromState {
+		err = env.setExecutionParameters()
+	}
 
 	return env, err
 }


### PR DESCRIPTION
Disable reading (mutating) the context from the state for system transaction and explicitly set a very high memory limit.