### PR TITLE
Override cbor DecMode config in execution data requester v0.26

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -447,7 +447,7 @@ func (e *ExecutionNodeBuilder) LoadComponentsAndModules() {
 			}
 
 			eds := state_synchronization.NewExecutionDataService(
-				&cbor.Codec{},
+				cbor.NewCodec(),
 				compressor.NewLz4Compressor(),
 				bs,
 				executionDataServiceCollector,

--- a/cmd/util/cmd/execution-data-blobstore/cmd/get.go
+++ b/cmd/util/cmd/execution-data-blobstore/cmd/get.go
@@ -40,7 +40,7 @@ func run(*cobra.Command, []string) {
 	logger := zerolog.New(os.Stdout)
 
 	eds := state_synchronization.NewExecutionDataService(
-		&cbor.Codec{},
+		cbor.NewCodec(),
 		compressor.NewLz4Compressor(),
 		bs,
 		metrics.NewNoopCollector(),

--- a/integration/tests/access/execution_state_sync_test.go
+++ b/integration/tests/access/execution_state_sync_test.go
@@ -199,7 +199,7 @@ func (s *ExecutionStateSyncSuite) nodeExecutionDataService(node *testnet.Contain
 	blobService.Start(ctx)
 
 	return state_synchronization.NewExecutionDataService(
-		new(cbor.Codec),
+		cbor.NewCodec(),
 		compressor.NewLz4Compressor(),
 		blobService,
 		metrics.NewNoopCollector(),

--- a/model/encoding/cbor/codec.go
+++ b/model/encoding/cbor/codec.go
@@ -17,9 +17,10 @@ func NewMarshaler() *Marshaler {
 	return &Marshaler{}
 }
 
-// "For best performance, reuse EncMode and DecMode after creating them." [1]
-// [1] https://github.com/fxamacker/cbor
+// EncMode is the default EncMode to use when creating a new cbor Encoder
 var EncMode = func() cbor.EncMode {
+	// "For best performance, reuse EncMode and DecMode after creating them." [1]
+	// [1] https://github.com/fxamacker/cbor
 	options := cbor.CoreDetEncOptions() // CBOR deterministic options
 	// default: "2021-07-06 21:20:00 +0000 UTC" <- unwanted
 	// option : "2021-07-06 21:20:00.820603 +0000 UTC" <- wanted
@@ -30,6 +31,9 @@ var EncMode = func() cbor.EncMode {
 	}
 	return encMode
 }()
+
+// DecMode is the default DecMode to use when creating a new cbor Decoder
+var DecMode, _ = cbor.DecOptions{}.DecMode()
 
 func (m *Marshaler) Marshal(val interface{}) ([]byte, error) {
 	return EncMode.Marshal(val)
@@ -57,12 +61,46 @@ func (m *Marshaler) MustUnmarshal(b []byte, val interface{}) {
 
 var _ encoding.Codec = (*Codec)(nil)
 
-type Codec struct{}
+type Option func(*Codec)
+
+// WithEncMode sets the EncMode to use when creating a new cbor Encoder.
+func WithEncMode(encMode cbor.EncMode) Option {
+	return func(c *Codec) {
+		c.encMode = encMode
+	}
+}
+
+// WithDecMode sets the DecMode to use when creating a new cbor Decoder.
+func WithDecMode(decMode cbor.DecMode) Option {
+	return func(c *Codec) {
+		c.decMode = decMode
+	}
+}
+
+type Codec struct {
+	encMode cbor.EncMode
+	decMode cbor.DecMode
+}
+
+// NewCodec returns a new cbor Codec with the provided EncMode and DecMode.
+// If either is nil, the default cbor EncMode/DecMode will be used.
+func NewCodec(opts ...Option) *Codec {
+	c := &Codec{
+		encMode: EncMode,
+		decMode: DecMode,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
 
 func (c *Codec) NewEncoder(w io.Writer) encoding.Encoder {
-	return EncMode.NewEncoder(w)
+	return c.encMode.NewEncoder(w)
 }
 
 func (c *Codec) NewDecoder(r io.Reader) encoding.Decoder {
-	return cbor.NewDecoder(r)
+	return c.decMode.NewDecoder(r)
 }

--- a/module/state_synchronization/execution_data_service_test.go
+++ b/module/state_synchronization/execution_data_service_test.go
@@ -171,7 +171,7 @@ func allKeys(t *testing.T, bs blockstore.Blockstore, timeout time.Duration) []ci
 }
 
 func executionDataService(bs network.BlobService) *executionDataServiceImpl {
-	codec := new(cbor.Codec)
+	codec := cbor.NewCodec()
 	compressor := compressor.NewLz4Compressor()
 	return NewExecutionDataService(codec, compressor, bs, metrics.NewNoopCollector(), zerolog.Nop())
 }

--- a/module/state_synchronization/requester/execution_data_requester_test.go
+++ b/module/state_synchronization/requester/execution_data_requester_test.go
@@ -644,7 +644,7 @@ func (suite *ExecutionDataRequesterSuite) generateTestData(blockCount int, speci
 
 	// instantiate ExecutionDataService to generate correct CIDs
 	eds := state_synchronization.NewExecutionDataService(
-		new(cbor.Codec),
+		cbor.NewCodec(),
 		compressor.NewLz4Compressor(),
 		suite.blobservice,
 		metrics.NewNoopCollector(),


### PR DESCRIPTION
Port https://github.com/onflow/flow-go/pull/2674: Override cbor DecMode config in execution data requester

Execution nodes may produce `ExecutionData` blobs with very large cbor encoded data structures. This PR sets the limits to max for Access Node `ExecutionDataRequest` and adds configuration to the cbor codec to allow providing custom `EncMode`/`DecMode` settings.