### PR TITLE
Invalidate Pooling Logic in AN

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -278,8 +278,8 @@ func (suite *Suite) TestSendTransactionToRandomCollectionNode() {
 
 		// create a mock connection factory
 		connFactory := new(factorymock.ConnectionFactory)
-		connFactory.On("GetAccessAPIClient", collNode1.Address).Return(col1ApiClient, &mockCloser{}, nil)
-		connFactory.On("GetAccessAPIClient", collNode2.Address).Return(col2ApiClient, &mockCloser{}, nil)
+		connFactory.On("GetAccessAPIClient", collNode1.Address).Return(col1ApiClient, nil)
+		connFactory.On("GetAccessAPIClient", collNode2.Address).Return(col2ApiClient, nil)
 
 		backend := backend.New(suite.state,
 			nil,
@@ -578,7 +578,7 @@ func (suite *Suite) TestGetSealedTransaction() {
 
 		// create a mock connection factory
 		connFactory := new(factorymock.ConnectionFactory)
-		connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+		connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
 
 		// initialize storage
 		metrics := metrics.NewNoopCollector()
@@ -680,7 +680,7 @@ func (suite *Suite) TestExecuteScript() {
 
 		// create a mock connection factory
 		connFactory := new(factorymock.ConnectionFactory)
-		connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+		connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
 
 		suite.backend = backend.New(suite.state,
 			suite.collClient,

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -153,13 +153,13 @@ func (b *backendAccounts) getAccountFromAnyExeNode(ctx context.Context, execNode
 }
 
 func (b *backendAccounts) tryGetAccount(ctx context.Context, execNode *flow.Identity, req execproto.GetAccountAtBlockIDRequest) (*execproto.GetAccountAtBlockIDResponse, error) {
-	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
+	execRPCClient, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.Close()
 	resp, err := execRPCClient.GetAccountAtBlockID(ctx, &req)
 	if err != nil {
+		b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
 		return nil, err
 	}
 	return resp, nil

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -207,13 +207,13 @@ func (b *backendEvents) getEventsFromAnyExeNode(ctx context.Context,
 func (b *backendEvents) tryGetEvents(ctx context.Context,
 	execNode *flow.Identity,
 	req execproto.GetEventsForBlockIDsRequest) (*execproto.GetEventsForBlockIDsResponse, error) {
-	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
+	execRPCClient, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.Close()
 	resp, err := execRPCClient.GetEventsForBlockIDs(ctx, &req)
 	if err != nil {
+		b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
 		return nil, err
 	}
 	return resp, nil

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -165,13 +165,13 @@ func (b *backendScripts) shouldLogScript(execTime time.Time, scriptHash [16]byte
 }
 
 func (b *backendScripts) tryExecuteScript(ctx context.Context, execNode *flow.Identity, req execproto.ExecuteScriptAtBlockIDRequest) ([]byte, error) {
-	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
+	execRPCClient, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client for execution node %s: %v", execNode.String(), err)
 	}
-	defer closer.Close()
 	execResp, err := execRPCClient.ExecuteScriptAtBlockID(ctx, &req)
 	if err != nil {
+		b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
 		return nil, status.Errorf(status.Code(err), "failed to execute the script on the execution node %s: %v", execNode.String(), err)
 	}
 	return execResp.GetValue(), nil

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -620,7 +620,7 @@ func (suite *Suite) TestGetTransactionResultByIndex() {
 
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
 
 	exeEventReq := execproto.GetTransactionByIndexRequest{
 		BlockId: blockId[:],
@@ -683,7 +683,7 @@ func (suite *Suite) TestGetTransactionResultsByBlockID() {
 
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
 
 	exeEventReq := execproto.GetTransactionsByBlockIDRequest{
 		BlockId: blockId[:],
@@ -766,7 +766,8 @@ func (suite *Suite) TestTransactionStatusTransition() {
 
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
+	connFactory.On("InvalidateExecutionAPIClient", mock.Anything).Return(false)
 
 	exeEventReq := execproto.GetTransactionResultRequest{
 		BlockId:       blockID[:],
@@ -1232,7 +1233,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
 
 	// create the expected results from execution node and access node
 	exeResults := make([]*execproto.GetEventsForBlockIDsResponse_Result, len(blockHeaders))
@@ -1865,7 +1866,7 @@ func (suite *Suite) TestGetAccount() {
 	suite.snapshot.On("Identities", mock.Anything).Return(ids, nil)
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
 
 	// create the handler with the mock
 	backend := New(
@@ -1927,7 +1928,7 @@ func (suite *Suite) TestGetAccountAtBlockHeight() {
 
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
 
 	// create the expected execution API request
 	blockID := h.ID()
@@ -2160,7 +2161,8 @@ func (suite *Suite) TestExecuteScriptOnExecutionNode() {
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
 	connFactory.On("GetExecutionAPIClient", mock.Anything).
-		Return(suite.execClient, &mockCloser{}, nil)
+		Return(suite.execClient, nil)
+	connFactory.On("InvalidateExecutionAPIClient", mock.Anything).Return(false)
 
 	// create the handler with the mock
 	backend := New(
@@ -2260,7 +2262,8 @@ func (suite *Suite) setupReceipts(block *flow.Block) ([]*flow.ExecutionReceipt, 
 func (suite *Suite) setupConnectionFactory() ConnectionFactory {
 	// create a mock connection factory
 	connFactory := new(backendmock.ConnectionFactory)
-	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, nil)
+	connFactory.On("InvalidateExecutionAPIClient", mock.Anything).Return(false)
 	return connFactory
 }
 

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -144,13 +144,14 @@ func (b *backendTransactions) sendTransactionToCollector(ctx context.Context,
 	tx *flow.TransactionBody,
 	collectionNodeAddr string) error {
 
-	collectionRPC, _, err := b.connFactory.GetAccessAPIClient(collectionNodeAddr)
+	collectionRPC, err := b.connFactory.GetAccessAPIClient(collectionNodeAddr)
 	if err != nil {
 		return fmt.Errorf("failed to connect to collection node at %s: %w", collectionNodeAddr, err)
 	}
 
 	err = b.grpcTxSend(ctx, collectionRPC, tx)
 	if err != nil {
+		b.connFactory.InvalidateAccessAPIClient(collectionNodeAddr)
 		return fmt.Errorf("failed to send transaction to collection node at %s: %v", collectionNodeAddr, err)
 	}
 	return nil
@@ -701,12 +702,15 @@ func (b *backendTransactions) tryGetTransactionResult(
 	execNode *flow.Identity,
 	req execproto.GetTransactionResultRequest,
 ) (*execproto.GetTransactionResultResponse, error) {
-	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
+	execRPCClient, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.Close()
 	resp, err := execRPCClient.GetTransactionResult(ctx, &req)
+	if err != nil {
+		b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
+		return nil, err
+	}
 	return resp, err
 }
 
@@ -745,12 +749,15 @@ func (b *backendTransactions) tryGetTransactionResultsByBlockID(
 	execNode *flow.Identity,
 	req execproto.GetTransactionsByBlockIDRequest,
 ) (*execproto.GetTransactionResultsResponse, error) {
-	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
+	execRPCClient, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.Close()
 	resp, err := execRPCClient.GetTransactionResultsByBlockID(ctx, &req)
+	if err != nil {
+		b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
+		return nil, err
+	}
 	return resp, err
 }
 
@@ -791,11 +798,14 @@ func (b *backendTransactions) tryGetTransactionResultByIndex(
 	execNode *flow.Identity,
 	req execproto.GetTransactionByIndexRequest,
 ) (*execproto.GetTransactionResultResponse, error) {
-	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
+	execRPCClient, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, err
 	}
-	defer closer.Close()
 	resp, err := execRPCClient.GetTransactionResultByIndex(ctx, &req)
+	if err != nil {
+		b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
+		return nil, err
+	}
 	return resp, err
 }

--- a/engine/access/rpc/backend/mock/connection_factory.go
+++ b/engine/access/rpc/backend/mock/connection_factory.go
@@ -7,8 +7,6 @@ import (
 
 	execution "github.com/onflow/flow/protobuf/go/flow/execution"
 
-	io "io"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -18,7 +16,7 @@ type ConnectionFactory struct {
 }
 
 // GetAccessAPIClient provides a mock function with given fields: address
-func (_m *ConnectionFactory) GetAccessAPIClient(address string) (access.AccessAPIClient, io.Closer, error) {
+func (_m *ConnectionFactory) GetAccessAPIClient(address string) (access.AccessAPIClient, error) {
 	ret := _m.Called(address)
 
 	var r0 access.AccessAPIClient
@@ -30,27 +28,18 @@ func (_m *ConnectionFactory) GetAccessAPIClient(address string) (access.AccessAP
 		}
 	}
 
-	var r1 io.Closer
-	if rf, ok := ret.Get(1).(func(string) io.Closer); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(address)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(io.Closer)
-		}
+		r1 = ret.Error(1)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(string) error); ok {
-		r2 = rf(address)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // GetExecutionAPIClient provides a mock function with given fields: address
-func (_m *ConnectionFactory) GetExecutionAPIClient(address string) (execution.ExecutionAPIClient, io.Closer, error) {
+func (_m *ConnectionFactory) GetExecutionAPIClient(address string) (execution.ExecutionAPIClient, error) {
 	ret := _m.Called(address)
 
 	var r0 execution.ExecutionAPIClient
@@ -62,23 +51,42 @@ func (_m *ConnectionFactory) GetExecutionAPIClient(address string) (execution.Ex
 		}
 	}
 
-	var r1 io.Closer
-	if rf, ok := ret.Get(1).(func(string) io.Closer); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(address)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(io.Closer)
-		}
+		r1 = ret.Error(1)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(string) error); ok {
-		r2 = rf(address)
+	return r0, r1
+}
+
+// InvalidateAccessAPIClient provides a mock function with given fields: address
+func (_m *ConnectionFactory) InvalidateAccessAPIClient(address string) bool {
+	ret := _m.Called(address)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(address)
 	} else {
-		r2 = ret.Error(2)
+		r0 = ret.Get(0).(bool)
 	}
 
-	return r0, r1, r2
+	return r0
+}
+
+// InvalidateExecutionAPIClient provides a mock function with given fields: address
+func (_m *ConnectionFactory) InvalidateExecutionAPIClient(address string) bool {
+	ret := _m.Called(address)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(address)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 type NewConnectionFactoryT interface {

--- a/module/mock/network_metrics.go
+++ b/module/mock/network_metrics.go
@@ -98,6 +98,16 @@ func (_m *NetworkMetrics) QueueDuration(duration time.Duration, priority int) {
 	_m.Called(duration, priority)
 }
 
+// RoutingTablePeerAdded provides a mock function with given fields:
+func (_m *NetworkMetrics) RoutingTablePeerAdded() {
+	_m.Called()
+}
+
+// RoutingTablePeerRemoved provides a mock function with given fields:
+func (_m *NetworkMetrics) RoutingTablePeerRemoved() {
+	_m.Called()
+}
+
 type NewNetworkMetricsT interface {
 	mock.TestingT
 	Cleanup(func())


### PR DESCRIPTION
- This change removes the use of the grpc closers from AN's connection factory

- This change allows connections to EN to be reused properly without closing the connection at the end of every call

- This change would also fix a race condition from when a request is made, and the deferred closer logic fails to close before another request is then made. For example if `ExecuteScriptAtBlockID` was called an Exec RPC Client would be cached. Before the first `ExecuteScriptAtBlockID` finishes and the deferred closer logic gets to execute, if a second ExecuteScriptAtBlockID was called, the original cached Exec RPC Client would then be reused, and before the second call gets a chance to use the client, the first call could execute the closer logic.