### PR TITLE
Fix copylocks in TestOnBlockProposal_RemoteOrigin

### DIFF
--- a/engine/consensus/provider/engine_test.go
+++ b/engine/consensus/provider/engine_test.go
@@ -61,7 +61,7 @@ func (suite *Suite) SetupTest() {
 }
 
 // proposals submitted by remote nodes should not be accepted.
-func (suite Suite) TestOnBlockProposal_RemoteOrigin() {
+func (suite *Suite) TestOnBlockProposal_RemoteOrigin() {
 
 	proposal := unittest.ProposalFixture()
 	// message submitted by remote node


### PR DESCRIPTION
`Suite` shouldn't be passed by value because it contains `sync.RWMutex`.

Use `*Suite` instead of `Suite` in `TestOnBlockProposal_RemoteOrigin` to pass `sync.RWMutex` lock by reference.

