### PR TITLE
[FVM] Change restricted contract deployment env setting on testnet

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -859,7 +859,17 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 	}
 	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Canary || fnb.RootChainID == flow.Localnet || fnb.RootChainID == flow.Benchnet {
 		vmOpts = append(vmOpts,
-			fvm.WithContractDeploymentRestricted(false),
+			// restricted deployment of contracts will still be false even though this is set to true because the
+			// setting from the state takes precedence over the setting here.
+			// This can be seen in `fvm.GetIsContractDeploymentRestricted`.
+			// the reason this is set to true and not simply removed,
+			// is to test that this behaviour is in fact working properly.
+			// see doc for more info:
+			// https://www.notion.so/dapperlabs/Enable-Permissionless-Contract-Deployment-On-mainnet-3a9ff010423444c0975ed6052e028968
+			// Transient networks (Localnet/Benchnet) will also use the setting from the state set at bootstrapping.
+			// see: `fvm.Bootstrap`
+			// TODO: Remove WithContractDeploymentRestricted and related constants after this is deployed.
+			fvm.WithContractDeploymentRestricted(true),
 		)
 	}
 	fnb.FvmOptions = vmOpts

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -47,7 +47,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("cae2f2d6c53582503dad30dba8a8bba098ff8654d19b820a49e1961c1f459a41")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("da520b1e4d2ab60037624ebf2ef67efae775d7ab461d30bc4a51cc5cf44a9367")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -208,10 +208,13 @@ func Bootstrap(
 	serviceAccountPublicKey flow.AccountPublicKey,
 	opts ...BootstrapProcedureOption,
 ) *BootstrapProcedure {
+	// transient networks (or new networks) don't have restrictedContractDeployment
+	restrictedContractDeployment := false
 	bootstrapProcedure := &BootstrapProcedure{
-		serviceAccountPublicKey: serviceAccountPublicKey,
-		transactionFees:         BootstrapProcedureFeeParameters{0, 0, 0},
-		epochConfig:             epochs.DefaultEpochConfig(),
+		serviceAccountPublicKey:      serviceAccountPublicKey,
+		transactionFees:              BootstrapProcedureFeeParameters{0, 0, 0},
+		epochConfig:                  epochs.DefaultEpochConfig(),
+		restrictedContractDeployment: &restrictedContractDeployment,
 	}
 
 	for _, applyOption := range opts {

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -270,7 +270,10 @@ func TestBlockContext_DeployContract(t *testing.T) {
 	)
 
 	t.Run("account update with set code succeeds as service account", func(t *testing.T) {
-		ledger := testutil.RootBootstrappedLedger(vm, ctx)
+		restricted := true
+		ledger := testutil.RootBootstrappedLedger(vm, ctx,
+			fvm.WithRestrictedContractDeployment(&restricted),
+		)
 
 		// Create an account private key.
 		privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
@@ -300,7 +303,10 @@ func TestBlockContext_DeployContract(t *testing.T) {
 	})
 
 	t.Run("account with deployed contract has `contracts.names` filled", func(t *testing.T) {
-		ledger := testutil.RootBootstrappedLedger(vm, ctx)
+		restricted := true
+		ledger := testutil.RootBootstrappedLedger(vm, ctx,
+			fvm.WithRestrictedContractDeployment(&restricted),
+		)
 
 		// Create an account private key.
 		privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
@@ -395,7 +401,10 @@ func TestBlockContext_DeployContract(t *testing.T) {
 	})
 
 	t.Run("account update with set code fails if not signed by service account", func(t *testing.T) {
-		ledger := testutil.RootBootstrappedLedger(vm, ctx)
+		restricted := true
+		ledger := testutil.RootBootstrappedLedger(vm, ctx,
+			fvm.WithRestrictedContractDeployment(&restricted),
+		)
 
 		// Create an account private key.
 		privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
@@ -659,7 +668,10 @@ func TestBlockContext_DeployContract(t *testing.T) {
 	})
 
 	t.Run("account update with set code succeeds when there is a matching audit voucher", func(t *testing.T) {
-		ledger := testutil.RootBootstrappedLedger(vm, ctx)
+		restricted := true
+		ledger := testutil.RootBootstrappedLedger(vm, ctx,
+			fvm.WithRestrictedContractDeployment(&restricted),
+		)
 
 		// Create an account private key.
 		privateKeys, err := testutil.GenerateAccountPrivateKeys(1)

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -24,7 +24,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "5b8f8283d5e719672cb53c0e20a822bf0782f4345d09df076c14fba4d9e21da0"
+const GenesisStateCommitmentHex = "6b0c742c1c66571057b8a5ab4a69e317623efd4ca823e0d2979b3c57da8e0aa4"
 
 var GenesisStateCommitment flow.StateCommitment
 


### PR DESCRIPTION
This is a temporary change.

See comments in the code, and the doc here: https://www.notion.so/dapperlabs/Enable-Permissionless-Contract-Deployment-On-mainnet-3a9ff010423444c0975ed6052e028968

The state commitment change is due to the flag now being set in the state at bootstrapping.
The test change is due to the flag being false by default.