### PR TITLE
[Flakey Test] Handle registering node without machine account

### DIFF
--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
-	sdk "github.com/onflow/flow-go-sdk"
-	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	sdk "github.com/onflow/flow-go-sdk"
+	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine/ghost/client"
@@ -138,16 +139,17 @@ func (s *Suite) TearDownTest() {
 // StakedNodeOperationInfo struct contains all the node information needed to
 // start a node after it is onboarded (staked and registered).
 type StakedNodeOperationInfo struct {
-	NodeID                  flow.Identifier
-	Role                    flow.Role
-	StakingAccountAddress   sdk.Address
-	FullAccountKey          *sdk.AccountKey
-	StakingAccountKey       sdkcrypto.PrivateKey
-	NetworkingKey           sdkcrypto.PrivateKey
-	StakingKey              sdkcrypto.PrivateKey
+	NodeID                flow.Identifier
+	Role                  flow.Role
+	StakingAccountAddress sdk.Address
+	FullAccountKey        *sdk.AccountKey
+	StakingAccountKey     sdkcrypto.PrivateKey
+	NetworkingKey         sdkcrypto.PrivateKey
+	StakingKey            sdkcrypto.PrivateKey
+	// machine account info defined only for consensus/collection nodes
 	MachineAccountAddress   sdk.Address
 	MachineAccountKey       sdkcrypto.PrivateKey
-	MachineAccountPublicKey sdk.AccountKey
+	MachineAccountPublicKey *sdk.AccountKey
 	ContainerName           string
 }
 
@@ -283,7 +285,7 @@ func (s *Suite) generateAccountKeys(role flow.Role) (
 	networkingKey,
 	stakingKey,
 	machineAccountKey crypto.PrivateKey,
-	machineAccountPubKey sdk.AccountKey,
+	machineAccountPubKey *sdk.AccountKey,
 ) {
 	operatorAccountKey = unittest.PrivateKeyFixture(crypto.ECDSAP256, crypto.KeyGenSeedMinLenECDSAP256)
 	networkingKey = unittest.NetworkingPrivKeyFixture()
@@ -293,7 +295,7 @@ func (s *Suite) generateAccountKeys(role flow.Role) (
 	if role == flow.RoleConsensus || role == flow.RoleCollection {
 		machineAccountKey = unittest.PrivateKeyFixture(crypto.ECDSAP256, crypto.KeyGenSeedMinLenECDSAP256)
 
-		machineAccountPubKey = sdk.AccountKey{
+		machineAccountPubKey = &sdk.AccountKey{
 			PublicKey: machineAccountKey.PublicKey(),
 			SigAlgo:   machineAccountKey.PublicKey().Algorithm(),
 			HashAlgo:  bootstrap.DefaultMachineAccountHashAlgo,
@@ -359,7 +361,7 @@ func (s *Suite) SubmitStakingCollectionRegisterNodeTx(
 	networkingKey string,
 	stakingKey string,
 	amount string,
-	machineKey sdk.AccountKey,
+	machineKey *sdk.AccountKey,
 ) (*sdk.TransactionResult, sdk.Address, error) {
 	latestBlockID, err := s.client.GetLatestBlockID(ctx)
 	require.NoError(s.T(), err)

--- a/integration/utils/transactions.go
+++ b/integration/utils/transactions.go
@@ -2,9 +2,11 @@ package utils
 
 import (
 	"fmt"
+
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
 	fttemplates "github.com/onflow/flow-ft/lib/go/templates"
+
 	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	sdktemplates "github.com/onflow/flow-go-sdk/templates"
@@ -64,7 +66,7 @@ func MakeStakingCollectionRegisterNodeTx(
 	networkingKey string,
 	stakingKey string,
 	amount string,
-	machineKey sdk.AccountKey,
+	machineKey *sdk.AccountKey,
 ) (*sdk.Transaction, error) {
 	accountKey := stakingAccount.Keys[stakingAccountKeyID]
 	tx := sdk.NewTransaction().
@@ -111,17 +113,24 @@ func MakeStakingCollectionRegisterNodeTx(
 		return nil, err
 	}
 
-	publicKeys := make([]cadence.Value, 1)
-	publicKey, err := sdktemplates.AccountKeyToCadenceCryptoKey(&machineKey)
-	if err != nil {
-		return nil, err
-	}
-	publicKeys[0] = publicKey
-	publicKeysCDC := cadence.NewArray(publicKeys)
+	if machineKey != nil {
+		// for collection/consensus nodes, register the machine account key
+		publicKey, err := sdktemplates.AccountKeyToCadenceCryptoKey(machineKey)
+		if err != nil {
+			return nil, err
+		}
+		publicKeysCDC := cadence.NewArray([]cadence.Value{publicKey})
 
-	err = tx.AddArgument(cadence.NewOptional(publicKeysCDC))
-	if err != nil {
-		return nil, err
+		err = tx.AddArgument(cadence.NewOptional(publicKeysCDC))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// for other nodes, pass nil to avoid registering any machine account key
+		err = tx.AddArgument(cadence.NewOptional(nil))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = tx.SignPayload(stakingAccount.Address, stakingAccountKeyID, stakingSigner)


### PR DESCRIPTION
Previously the epoch tests would pass in an argument representing a machine account key, even for nodes which had no machine account. This worked because the SDK accepted an empty account key and the argument was ignored.

An SDK API change caused this to no longer work, because the SDK will not accept empty account keys.

Instead, we handle the case of an empty machine account explicitly by passing in a nil optional for this parameter. This should address the 0% success rate for AN/VN tests, which do not use machine accounts. 