### PR TITLE
Remove header caching

### DIFF
--- a/model/flow/header.go
+++ b/model/flow/header.go
@@ -1,9 +1,7 @@
 package flow
 
 import (
-	"bytes"
 	"encoding/json"
-	"sync"
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
@@ -72,54 +70,10 @@ func (h Header) Fingerprint() []byte {
 	return fingerprint.Fingerprint(h.Body())
 }
 
-var mutexHeader sync.Mutex
-var previdHeader Identifier
-var prevHeader Header
-
 // ID returns a unique ID to singularly identify the header and its block
 // within the flow system.
 func (h Header) ID() Identifier {
-	// NOTE: this is just a sanity check to make sure that we don't get
-	// different block IDs if someone forgets to use UTC timestamps
-	if h.Timestamp.Location() != time.UTC {
-		h.Timestamp = h.Timestamp.UTC()
-	}
-
-	mutexHeader.Lock()
-
-	// unlock at the return
-	defer mutexHeader.Unlock()
-
-	// compare these elements individually
-	if prevHeader.ParentVoterIndices != nil &&
-		prevHeader.ParentVoterSigData != nil &&
-		prevHeader.ProposerSigData != nil &&
-		len(h.ParentVoterIndices) == len(prevHeader.ParentVoterIndices) &&
-		len(h.ParentVoterSigData) == len(prevHeader.ParentVoterSigData) &&
-		len(h.ProposerSigData) == len(prevHeader.ProposerSigData) {
-
-		if h.ChainID == prevHeader.ChainID &&
-			h.Timestamp == prevHeader.Timestamp &&
-			h.Height == prevHeader.Height &&
-			h.ParentID == prevHeader.ParentID &&
-			h.View == prevHeader.View &&
-			h.PayloadHash == prevHeader.PayloadHash &&
-			bytes.Equal(h.ProposerSigData, prevHeader.ProposerSigData) &&
-			bytes.Equal(h.ParentVoterIndices, prevHeader.ParentVoterIndices) &&
-			bytes.Equal(h.ParentVoterSigData, prevHeader.ParentVoterSigData) &&
-			h.ProposerID == prevHeader.ProposerID {
-
-			// cache hit, return the previous identifier
-			return previdHeader
-		}
-	}
-
-	previdHeader = MakeID(h)
-
-	// store a reference to the Header entity data
-	prevHeader = h
-
-	return previdHeader
+	return MakeID(h)
 }
 
 // Checksum returns the checksum of the header.


### PR DESCRIPTION
This 1 item caching introduces global lock.  Also code is quite brittle and can cause bugs if `Header` struct changes.

This diff is no-op on Skylake:
```
name                              old us/tx    new us/tx    delta
ComputeBlock/1/cols/16/txes-16     1.44k ± 0%   1.46k ± 3%    ~     (p=0.099 n=9+10)
ComputeBlock/1/cols/32/txes-16     1.37k ± 1%   1.38k ± 1%  +0.60%  (p=0.007 n=9+10)
ComputeBlock/1/cols/64/txes-16     1.36k ± 1%   1.35k ± 0%  -0.51%  (p=0.014 n=10+8)
ComputeBlock/1/cols/128/txes-16    1.34k ± 1%   1.34k ± 0%    ~     (p=0.673 n=10+9)
ComputeBlock/4/cols/16/txes-16     1.36k ± 2%   1.36k ± 1%    ~     (p=0.237 n=10+10)
ComputeBlock/4/cols/32/txes-16     1.34k ± 1%   1.34k ± 1%    ~     (p=0.329 n=10+10)
ComputeBlock/4/cols/64/txes-16     1.35k ± 1%   1.34k ± 2%    ~     (p=0.117 n=9+10)
ComputeBlock/4/cols/128/txes-16    1.36k ± 2%   1.35k ± 2%    ~     (p=0.287 n=9+10)
ComputeBlock/16/cols/16/txes-16    1.33k ± 1%   1.32k ± 1%    ~     (p=0.643 n=10+10)
ComputeBlock/16/cols/32/txes-16    1.32k ± 1%   1.32k ± 1%    ~     (p=0.202 n=9+10)
ComputeBlock/16/cols/64/txes-16    1.35k ± 1%   1.35k ± 1%    ~     (p=0.957 n=10+10)
ComputeBlock/16/cols/128/txes-16   1.32k ± 1%   1.32k ± 2%    ~     (p=0.643 n=10+10)
```

And a 3% improvement on M1 Pro:
```
$ go test -tags relic -bench='BenchmarkComputeBlock' -count 10 -run='^$' ./engine/execution/computation/.
...
$ benchstat old new
name                             old us/tx    new us/tx     delta
ComputeBlock/1/cols/16/txes-8       590 ± 3%      803 ±62%    ~     (p=0.404 n=10+10)
ComputeBlock/1/cols/32/txes-8       554 ± 2%      559 ± 2%  +0.93%  (p=0.043 n=9+8)
ComputeBlock/1/cols/64/txes-8       557 ± 4%      538 ± 2%  -3.46%  (p=0.000 n=10+10)
ComputeBlock/1/cols/128/txes-8      560 ± 1%      538 ± 2%  -3.92%  (p=0.000 n=7+9)
ComputeBlock/4/cols/16/txes-8       558 ± 3%      539 ± 1%  -3.51%  (p=0.000 n=10+10)
ComputeBlock/4/cols/32/txes-8       555 ± 1%      540 ± 1%  -2.81%  (p=0.000 n=10+10)
ComputeBlock/4/cols/64/txes-8       556 ± 2%      538 ± 2%  -3.13%  (p=0.000 n=10+10)
ComputeBlock/4/cols/128/txes-8      546 ± 1%      527 ± 2%  -3.50%  (p=0.000 n=10+10)
ComputeBlock/16/cols/16/txes-8      552 ± 3%      533 ± 2%  -3.44%  (p=0.000 n=10+10)
ComputeBlock/16/cols/32/txes-8      548 ± 1%      527 ± 2%  -3.68%  (p=0.000 n=9+10)
ComputeBlock/16/cols/64/txes-8      548 ± 1%      530 ± 1%  -3.34%  (p=0.000 n=10+10)
ComputeBlock/16/cols/128/txes-8     522 ± 1%      519 ± 2%    ~     (p=0.327 n=9+9)
```

cc: @zhangchiqing since he was also looking at it here https://github.com/onflow/flow-go/pull/1279#discussion_r712510891