### PR TITLE
[Execution] Fixed EN debug docker image build failure

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -58,7 +58,7 @@ RUN chmod a+x /app/app
 
 FROM golang:1.18-bullseye as debug
 
-RUN go get -u github.com/go-delve/delve/cmd/dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 COPY --from=build-debug /app/app /bin/app
 


### PR DESCRIPTION
#2707 

Summary
`make docker-build-execution-debug` now under flow-go master fails with error of `go get` failure of https://github.com/go-delve/delve/cmd/dlv. Error is gone after using `go install` instead of `go get`

Test Plan
[X] run `make docker-build-execution-debug` to see build passing
[X] run built docker image to see it running fine
[X] ssh into the running docker image with `docker exec -it <DOCKER_ID> /bin/bash`
