### PR TITLE
No-op refactoring.  s/&flow.Header{...}/flow.NewHeader(...)/g

### DIFF
--- a/cmd/bootstrap/run/block.go
+++ b/cmd/bootstrap/run/block.go
@@ -12,21 +12,20 @@ func GenerateRootBlock(chainID flow.ChainID, parentID flow.Identifier, height ui
 		Guarantees: nil,
 		Seals:      nil,
 	}
-	header := flow.Header{
-		ChainID:            chainID,
-		ParentID:           parentID,
-		Height:             height,
-		PayloadHash:        payload.Hash(),
-		Timestamp:          timestamp,
-		View:               0,
-		ParentVoterIndices: nil,
-		ParentVoterSigData: nil,
-		ProposerID:         flow.ZeroID,
-		ProposerSigData:    nil,
-	}
+	header := flow.NewHeader(
+		chainID,
+		parentID,
+		height,
+		payload.Hash(),
+		timestamp,
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	return &flow.Block{
-		Header:  &header,
+		Header:  header,
 		Payload: &payload,
 	}
 }

--- a/cmd/bootstrap/run/cluster_qc_test.go
+++ b/cmd/bootstrap/run/cluster_qc_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 

--- a/cmd/bootstrap/run/cluster_qc_test.go
+++ b/cmd/bootstrap/run/cluster_qc_test.go
@@ -24,10 +24,17 @@ func TestGenerateClusterRootQC(t *testing.T) {
 	block.Header.PayloadHash = block.Payload.Hash()
 
 	clusterBlock := cluster.Block{
-		Header: &flow.Header{
-			ParentID: flow.ZeroID,
-			View:     42,
-		},
+		Header: flow.NewHeader(
+			"",
+			flow.ZeroID,
+			0,
+			flow.ZeroID,
+			time.Time{},
+			42,
+			nil,
+			nil,
+			flow.ZeroID,
+			nil),
 	}
 	payload := cluster.EmptyPayload(flow.ZeroID)
 	clusterBlock.SetPayload(payload)

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -24,7 +24,7 @@ func TestReExecuteBlock(t *testing.T) {
 		// bootstrap to init highest executed height
 		bootstrapper := bootstrap.NewBootstrapper(unittest.Logger())
 		genesis := unittest.BlockHeaderFixture()
-		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(), &genesis)
+		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(), genesis)
 		require.NoError(t, err)
 
 		// create all modules
@@ -42,7 +42,7 @@ func TestReExecuteBlock(t *testing.T) {
 		transactions := bstorage.NewTransactions(metrics, db)
 		collections := bstorage.NewCollections(db, transactions)
 
-		err = headers.Store(&genesis)
+		err = headers.Store(genesis)
 		require.NoError(t, err)
 
 		// create execution state module
@@ -64,7 +64,7 @@ func TestReExecuteBlock(t *testing.T) {
 		require.NotNil(t, es)
 
 		// prepare data
-		header := unittest.BlockHeaderWithParentFixture(&genesis) // make sure the height is higher than genesis
+		header := unittest.BlockHeaderWithParentFixture(genesis) // make sure the height is higher than genesis
 		executionReceipt := unittest.ExecutionReceiptFixture()
 		executionReceipt.ExecutionResult.BlockID = header.ID()
 		cdp := make([]*flow.ChunkDataPack, 0, len(executionReceipt.ExecutionResult.Chunks))
@@ -78,13 +78,13 @@ func TestReExecuteBlock(t *testing.T) {
 		se := unittest.BlockEventsFixture(header, 8)
 		tes := unittest.TransactionResultsFixture(4)
 
-		err = headers.Store(&header)
+		err = headers.Store(header)
 		require.NoError(t, err)
 
 		// save execution results
 		err = es.SaveExecutionResults(
 			context.Background(),
-			&header,
+			header,
 			endState,
 			cdp,
 			executionReceipt,
@@ -113,7 +113,7 @@ func TestReExecuteBlock(t *testing.T) {
 		// re execute result
 		err = es.SaveExecutionResults(
 			context.Background(),
-			&header,
+			header,
 			endState,
 			cdp,
 			executionReceipt,
@@ -134,7 +134,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		// bootstrap to init highest executed height
 		bootstrapper := bootstrap.NewBootstrapper(unittest.Logger())
 		genesis := unittest.BlockHeaderFixture()
-		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(), &genesis)
+		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(),&genesis)
 		require.NoError(t, err)
 
 		// create all modules
@@ -152,7 +152,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		transactions := bstorage.NewTransactions(metrics, db)
 		collections := bstorage.NewCollections(db, transactions)
 
-		err = headers.Store(&genesis)
+		err = headers.Store(genesis)
 		require.NoError(t, err)
 
 		// create execution state module
@@ -174,7 +174,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		require.NotNil(t, es)
 
 		// prepare data
-		header := unittest.BlockHeaderWithParentFixture(&genesis) // make sure the height is higher than genesis
+		header := unittest.BlockHeaderWithParentFixture(genesis) // make sure the height is higher than genesis
 		executionReceipt := unittest.ExecutionReceiptFixture()
 		executionReceipt.ExecutionResult.BlockID = header.ID()
 		cdp := make([]*flow.ChunkDataPack, 0, len(executionReceipt.ExecutionResult.Chunks))
@@ -188,13 +188,13 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		se := unittest.BlockEventsFixture(header, 8)
 		tes := unittest.TransactionResultsFixture(4)
 
-		err = headers.Store(&header)
+		err = headers.Store(header)
 		require.NoError(t, err)
 
 		// save execution results
 		err = es.SaveExecutionResults(
 			context.Background(),
-			&header,
+			header,
 			endState,
 			cdp,
 			executionReceipt,
@@ -232,7 +232,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		// re execute result
 		err = es.SaveExecutionResults(
 			context.Background(),
-			&header,
+			header,
 			endState2,
 			cdp2,
 			executionReceipt2,

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -134,7 +134,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		// bootstrap to init highest executed height
 		bootstrapper := bootstrap.NewBootstrapper(unittest.Logger())
 		genesis := unittest.BlockHeaderFixture()
-		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(),&genesis)
+		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(), genesis)
 		require.NoError(t, err)
 
 		// create all modules

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -73,9 +73,9 @@ func TestReExecuteBlock(t *testing.T) {
 		}
 		endState, err := executionReceipt.ExecutionResult.FinalStateCommitment()
 		require.NoError(t, err)
-		blockEvents := unittest.BlockEventsFixture(header, 3)
+		blockEvents := unittest.BlockEventsFixture(*header, 3)
 		// se := unittest.ServiceEventsFixture(2)
-		se := unittest.BlockEventsFixture(header, 8)
+		se := unittest.BlockEventsFixture(*header, 8)
 		tes := unittest.TransactionResultsFixture(4)
 
 		err = headers.Store(header)
@@ -183,9 +183,9 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		}
 		endState, err := executionReceipt.ExecutionResult.FinalStateCommitment()
 		require.NoError(t, err)
-		blockEvents := unittest.BlockEventsFixture(header, 3)
+		blockEvents := unittest.BlockEventsFixture(*header, 3)
 		// se := unittest.ServiceEventsFixture(2)
-		se := unittest.BlockEventsFixture(header, 8)
+		se := unittest.BlockEventsFixture(*header, 8)
 		tes := unittest.TransactionResultsFixture(4)
 
 		err = headers.Store(header)

--- a/consensus/follower_test.go
+++ b/consensus/follower_test.go
@@ -347,5 +347,5 @@ func (mc *MockConsensus) extendBlock(blockView uint64, parent *flow.Header) *flo
 	nextBlock.ProposerID = mc.identities[int(blockView)%len(mc.identities)].NodeID
 	signerIndices, _ := signature.EncodeSignersToIndices(mc.identities.NodeIDs(), mc.identities.NodeIDs())
 	nextBlock.ParentVoterIndices = signerIndices
-	return &nextBlock
+	return nextBlock
 }

--- a/consensus/follower_test.go
+++ b/consensus/follower_test.go
@@ -101,12 +101,17 @@ func (s *HotStuffFollowerSuite) SetupTest() {
 	// root block and QC
 	parentID, err := flow.HexStringToIdentifier("aa7693d498e9a087b1cadf5bfe9a1ff07829badc1915c210e482f369f9a00a70")
 	require.NoError(s.T(), err)
-	s.rootHeader = &flow.Header{
-		ParentID:  parentID,
-		Timestamp: time.Now().UTC(),
-		Height:    21053,
-		View:      52078,
-	}
+	s.rootHeader = flow.NewHeader(
+		"",
+		parentID,
+		21053,
+		flow.ZeroID,
+		time.Now().UTC(),
+		52078,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	signerIndices, err := signature.EncodeSignersToIndices(identities.NodeIDs(), identities.NodeIDs()[:3])
 	require.NoError(s.T(), err)

--- a/consensus/hotstuff/eventloop/event_loop_test.go
+++ b/consensus/hotstuff/eventloop/event_loop_test.go
@@ -73,12 +73,12 @@ func (s *EventLoopTestSuite) TestReadyDone() {
 // Test_SubmitQC tests that submitted proposal is eventually sent to event handler for processing
 func (s *EventLoopTestSuite) Test_SubmitProposal() {
 	proposal := unittest.BlockHeaderFixture()
-	expectedProposal := model.ProposalFromFlow(&proposal, proposal.View-1)
+	expectedProposal := model.ProposalFromFlow(proposal, proposal.View-1)
 	processed := atomic.NewBool(false)
 	s.eh.On("OnReceiveProposal", expectedProposal).Run(func(args mock.Arguments) {
 		processed.Store(true)
 	}).Return(nil).Once()
-	s.eventLoop.SubmitProposal(&proposal, proposal.View-1)
+	s.eventLoop.SubmitProposal(proposal, proposal.View-1)
 	require.Eventually(s.T(), processed.Load, time.Millisecond*100, time.Millisecond*10)
 	s.eh.AssertExpectations(s.T())
 }
@@ -136,7 +136,7 @@ func TestEventLoop_Timeout(t *testing.T) {
 		defer wg.Done()
 		for !processed.Load() {
 			proposal := unittest.BlockHeaderFixture()
-			eventLoop.SubmitProposal(&proposal, proposal.View-1)
+			eventLoop.SubmitProposal(proposal, proposal.View-1)
 		}
 	}()
 
@@ -177,8 +177,8 @@ func TestReadyDoneWithStartTime(t *testing.T) {
 	unittest.RequireCloseBefore(t, eventLoop.Ready(), 100*time.Millisecond, "event loop not started")
 
 	parentBlock := unittest.BlockHeaderFixture()
-	block := unittest.BlockHeaderWithParentFixture(&parentBlock)
-	eventLoop.SubmitProposal(&block, parentBlock.View)
+	block := unittest.BlockHeaderWithParentFixture(parentBlock)
+	eventLoop.SubmitProposal(block, parentBlock.View)
 
 	unittest.RequireCloseBefore(t, done, startTimeDuration+100*time.Millisecond, "proposal wasn't received")
 	cancel()

--- a/consensus/hotstuff/integration/defaults_test.go
+++ b/consensus/hotstuff/integration/defaults_test.go
@@ -8,14 +8,17 @@ import (
 )
 
 func DefaultRoot() *flow.Header {
-	header := &flow.Header{
-		ChainID:     "chain",
-		ParentID:    flow.ZeroID,
-		Height:      0,
-		PayloadHash: unittest.IdentifierFixture(),
-		Timestamp:   time.Now().UTC(),
-	}
-	return header
+	return flow.NewHeader(
+		"chain",
+		flow.ZeroID,
+		0,
+		unittest.IdentifierFixture(),
+		time.Now().UTC(),
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 }
 
 func DefaultStart() uint64 {

--- a/consensus/hotstuff/integration/instance_test.go
+++ b/consensus/hotstuff/integration/instance_test.go
@@ -164,13 +164,17 @@ func NewInstance(t require.TestingT, options ...Option) *Instance {
 			if !ok {
 				return nil
 			}
-			header := &flow.Header{
-				ChainID:     "chain",
-				ParentID:    parentID,
-				Height:      parent.Height + 1,
-				PayloadHash: unittest.IdentifierFixture(),
-				Timestamp:   time.Now().UTC(),
-			}
+			header := flow.NewHeader(
+				"chain",
+				parentID,
+				parent.Height+1,
+				unittest.IdentifierFixture(),
+				time.Now().UTC(),
+				0,
+				nil,
+				nil,
+				flow.ZeroID,
+				nil)
 			require.NoError(t, setter(header))
 			in.headers[header.ID()] = header
 			return header

--- a/consensus/hotstuff/model/proposal.go
+++ b/consensus/hotstuff/model/proposal.go
@@ -39,16 +39,15 @@ func ProposalFromFlow(header *flow.Header, parentView uint64) *Proposal {
 func ProposalToFlow(proposal *Proposal) *flow.Header {
 
 	block := proposal.Block
-	header := flow.Header{
-		ParentID:           block.QC.BlockID,
-		PayloadHash:        block.PayloadHash,
-		Timestamp:          block.Timestamp,
-		View:               block.View,
-		ParentVoterIndices: block.QC.SignerIndices,
-		ParentVoterSigData: block.QC.SigData,
-		ProposerID:         block.ProposerID,
-		ProposerSigData:    proposal.SigData,
-	}
-
-	return &header
+	return flow.NewHeader(
+		"",
+		block.QC.BlockID,
+		0,
+		block.PayloadHash,
+		block.Timestamp,
+		block.View,
+		block.QC.SignerIndices,
+		block.QC.SigData,
+		block.ProposerID,
+		proposal.SigData)
 }

--- a/consensus/hotstuff/verification/combined_signer_v2_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v2_test.go
@@ -195,7 +195,7 @@ func Test_VerifyQC_EmptySigners(t *testing.T) {
 	verifier := NewCombinedVerifier(committee, packer)
 
 	header := unittest.BlockHeaderFixture()
-	block := model.BlockFromFlow(&header, header.View-1)
+	block := model.BlockFromFlow(header, header.View-1)
 	sigData := unittest.QCSigDataFixture()
 
 	err := verifier.VerifyQC([]*flow.Identity{}, sigData, block)

--- a/consensus/hotstuff/verification/combined_signer_v3_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v3_test.go
@@ -268,7 +268,7 @@ func Test_VerifyQC_EmptySignersV3(t *testing.T) {
 	verifier := NewCombinedVerifier(committee, packer)
 
 	header := unittest.BlockHeaderFixture()
-	block := model.BlockFromFlow(&header, header.View-1)
+	block := model.BlockFromFlow(header, header.View-1)
 	sigData := unittest.QCSigDataFixture()
 
 	err := verifier.VerifyQC([]*flow.Identity{}, sigData, block)

--- a/consensus/hotstuff/verification/combined_signer_v3_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v3_test.go
@@ -155,7 +155,7 @@ func TestCombinedSignWithNoDKGKeyV3(t *testing.T) {
 // Test_VerifyQC checks that a QC where either signer list is empty is rejected as invalid
 func Test_VerifyQCV3(t *testing.T) {
 	header := unittest.BlockHeaderFixture()
-	block := model.BlockFromFlow(&header, header.View-1)
+	block := model.BlockFromFlow(header, header.View-1)
 	msg := MakeVoteMessage(block.View, block.BlockID)
 
 	// generate some BLS key as a stub of the random beacon group key and use it to generate a reconstructed beacon sig

--- a/consensus/hotstuff/verification/staking_signer_test.go
+++ b/consensus/hotstuff/verification/staking_signer_test.go
@@ -110,7 +110,7 @@ func TestStakingSigner_CreateVote(t *testing.T) {
 // TestStakingSigner_VerifyQC checks that a QC without any signers is rejected right away without calling into any sub-components
 func TestStakingSigner_VerifyQC(t *testing.T) {
 	header := unittest.BlockHeaderFixture()
-	block := model.BlockFromFlow(&header, header.View-1)
+	block := model.BlockFromFlow(header, header.View-1)
 	sigData := unittest.RandomBytes(127)
 
 	verifier := NewStakingVerifier()

--- a/consensus/hotstuff/voteaggregator/vote_aggregator_test.go
+++ b/consensus/hotstuff/voteaggregator/vote_aggregator_test.go
@@ -72,7 +72,7 @@ func (s *VoteAggregatorTestSuite) TearDownTest() {
 func (s *VoteAggregatorTestSuite) TestOnFinalizedBlock() {
 	finalizedBlock := unittest.BlockHeaderFixture(unittest.HeaderWithView(100))
 	s.collectors.On("PruneUpToView", finalizedBlock.View).Once()
-	s.aggregator.OnFinalizedBlock(model.BlockFromFlow(&finalizedBlock, finalizedBlock.View-1))
+	s.aggregator.OnFinalizedBlock(model.BlockFromFlow(finalizedBlock, finalizedBlock.View-1))
 	require.Eventually(s.T(),
 		func() bool {
 			return s.collectors.AssertCalled(s.T(), "PruneUpToView", finalizedBlock.View)

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
@@ -934,7 +934,7 @@ func TestReadRandomSourceFromPackedQCV2(t *testing.T) {
 
 	// making a mock block
 	header := unittest.BlockHeaderFixture()
-	block := model.BlockFromFlow(&header, header.View-1)
+	block := model.BlockFromFlow(header, header.View-1)
 
 	// create a packer
 	committee := &mockhotstuff.Committee{}

--- a/consensus/recovery/recover_test.go
+++ b/consensus/recovery/recover_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRecover(t *testing.T) {
 	finalized := unittest.BlockHeaderFixture()
-	blocks := unittest.ChainFixtureFrom(100, &finalized)
+	blocks := unittest.ChainFixtureFrom(100, finalized)
 
 	pending := make([]*flow.Header, 0)
 	for _, b := range blocks {
@@ -47,7 +47,7 @@ func TestRecover(t *testing.T) {
 		return nil
 	})
 
-	err := Recover(unittest.Logger(), &finalized, pending, validator, onProposal)
+	err := Recover(unittest.Logger(), finalized, pending, validator, onProposal)
 	require.NoError(t, err)
 
 	// only pending blocks are valid

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -145,12 +145,12 @@ func (suite *Suite) TestSendAndGetTransaction() {
 
 		refSnapshot.
 			On("Head").
-			Return(&referenceBlock, nil).
+			Return(referenceBlock, nil).
 			Twice()
 
 		suite.snapshot.
 			On("Head").
-			Return(&referenceBlock, nil).
+			Return(referenceBlock, nil).
 			Once()
 
 		expected := convert.TransactionToMessage(transaction.TransactionBody)
@@ -203,12 +203,12 @@ func (suite *Suite) TestSendExpiredTransaction() {
 
 		refSnapshot.
 			On("Head").
-			Return(&referenceBlock, nil).
+			Return(referenceBlock, nil).
 			Twice()
 
 		suite.snapshot.
 			On("Head").
-			Return(&latestBlock, nil).
+			Return(latestBlock, nil).
 			Once()
 
 		req := &accessproto.SendTransactionRequest{
@@ -236,7 +236,7 @@ func (suite *Suite) TestSendTransactionToRandomCollectionNode() {
 
 		// setup the state and snapshot mock expectations
 		suite.state.On("AtBlockID", referenceBlock.ID()).Return(suite.snapshot, nil)
-		suite.snapshot.On("Head").Return(&referenceBlock, nil)
+		suite.snapshot.On("Head").Return(referenceBlock, nil)
 
 		// create storage
 		metrics := metrics.NewNoopCollector()

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -76,7 +76,7 @@ func (suite *Suite) SetupTest() {
 	suite.snapshot.On("Epochs").Return(suite.epochQuery).Maybe()
 	header := unittest.BlockHeaderFixture()
 	params := new(protocol.Params)
-	params.On("Root").Return(&header, nil)
+	params.On("Root").Return(header, nil)
 	suite.state.On("Params").Return(params).Maybe()
 
 	suite.collClient = new(accessmock.AccessAPIClient)

--- a/engine/access/rest/accounts_test.go
+++ b/engine/access/rest/accounts_test.go
@@ -45,7 +45,7 @@ func TestGetAccount(t *testing.T) {
 
 		backend.Mock.
 			On("GetLatestBlockHeader", mocktestify.Anything, true).
-			Return(&block, nil)
+			Return(block, nil)
 
 		backend.Mock.
 			On("GetAccountAtBlockHeight", mocktestify.Anything, account.Address, height).
@@ -66,7 +66,7 @@ func TestGetAccount(t *testing.T) {
 		req := getAccountRequest(t, account, finalHeightQueryParam, expandableFieldKeys, expandableFieldContracts)
 		backend.Mock.
 			On("GetLatestBlockHeader", mocktestify.Anything, false).
-			Return(&block, nil)
+			Return(block, nil)
 		backend.Mock.
 			On("GetAccountAtBlockHeight", mocktestify.Anything, account.Address, height).
 			Return(account, nil)

--- a/engine/access/rest/events_test.go
+++ b/engine/access/rest/events_test.go
@@ -180,7 +180,7 @@ func generateEventsMocks(backend *mock.API, n int) []flow.BlockEvents {
 
 	backend.Mock.
 		On("GetLatestBlockHeader", mocks.Anything, true).
-		Return(&latestBlock, nil)
+		Return(latestBlock, nil)
 
 	return events
 }

--- a/engine/access/rest/events_test.go
+++ b/engine/access/rest/events_test.go
@@ -147,7 +147,7 @@ func generateEventsMocks(backend *mock.API, n int) []flow.BlockEvents {
 		header := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(uint64(i)))
 		ids[i] = header.ID()
 
-		events[i] = unittest.BlockEventsFixture(header, 2)
+		events[i] = unittest.BlockEventsFixture(*header, 2)
 
 		backend.Mock.
 			On("GetEventsForBlockIDs", mocks.Anything, mocks.Anything, []flow.Identifier{header.ID()}).

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -118,7 +118,7 @@ func (suite *Suite) TestGetLatestFinalizedBlockHeader() {
 	// setup the mocks
 	block := unittest.BlockHeaderFixture()
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
-	suite.snapshot.On("Head").Return(&block, nil).Once()
+	suite.snapshot.On("Head").Return(block, nil).Once()
 
 	backend := New(
 		suite.state,
@@ -484,7 +484,7 @@ func (suite *Suite) TestGetLatestSealedBlockHeader() {
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
 
 	block := unittest.BlockHeaderFixture()
-	suite.snapshot.On("Head").Return(&block, nil).Once()
+	suite.snapshot.On("Head").Return(block, nil).Once()
 
 	backend := New(
 		suite.state,
@@ -666,7 +666,7 @@ func (suite *Suite) TestGetTransactionResultByIndex() {
 func (suite *Suite) TestGetTransactionResultsByBlockID() {
 	head := unittest.BlockHeaderFixture()
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
-	suite.snapshot.On("Head").Return(&head, nil)
+	suite.snapshot.On("Head").Return(head, nil)
 
 	ctx := context.Background()
 	block := unittest.BlockFixture()
@@ -1548,7 +1548,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 
 	rootHeader := unittest.BlockHeaderFixture()
 	params := new(protocol.Params)
-	params.On("Root").Return(&rootHeader, nil)
+	params.On("Root").Return(rootHeader, nil)
 	state.On("Params").Return(params).Maybe()
 
 	// mock snapshot to return head backend

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -1579,7 +1579,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 	setupHeadHeight := func(height uint64) {
 		header := unittest.BlockHeaderFixture() // create a mock header
 		header.Height = height                  // set the header height
-		head = &header
+		head = header
 	}
 
 	setupStorage := func(min uint64, max uint64) ([]*flow.Header, []*flow.ExecutionReceipt, flow.IdentityList) {

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -64,7 +64,7 @@ func (suite *Suite) SetupTest() {
 	suite.snapshot = new(protocol.Snapshot)
 	header := unittest.BlockHeaderFixture()
 	params := new(protocol.Params)
-	params.On("Root").Return(&header, nil)
+	params.On("Root").Return(header, nil)
 	suite.state.On("Params").Return(params).Maybe()
 	suite.blocks = new(storagemock.Blocks)
 	suite.headers = new(storagemock.Headers)

--- a/engine/collection/epochmgr/engine_test.go
+++ b/engine/collection/epochmgr/engine_test.go
@@ -261,7 +261,7 @@ func (suite *Suite) TestRespondToPhaseChange() {
 	first := unittest.BlockHeaderFixture()
 	suite.state.On("AtBlockID", first.ID()).Return(suite.snap)
 
-	suite.engine.EpochSetupPhaseStarted(0, &first)
+	suite.engine.EpochSetupPhaseStarted(0, first)
 	unittest.AssertClosesBefore(suite.T(), called, time.Second)
 
 	suite.voter.AssertExpectations(suite.T())
@@ -291,7 +291,7 @@ func (suite *Suite) TestRespondToEpochTransition() {
 	// mock the epoch transition
 	suite.TransitionEpoch()
 	// notify the engine of the epoch transition
-	suite.engine.EpochTransition(suite.counter, &first)
+	suite.engine.EpochTransition(suite.counter, first)
 	unittest.AssertClosesBefore(suite.T(), done, time.Second)
 	suite.Assert().NotNil(expiryCallback)
 

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -63,7 +63,7 @@ func (ss *SyncSuite) SetupTest() {
 
 	// generate a header for the final state
 	header := unittest.BlockHeaderFixture()
-	ss.head = &header
+	ss.head = header
 
 	// create maps to enable block returns
 	ss.heights = make(map[uint64]*clustermodel.Block)

--- a/engine/common/follower/engine_test.go
+++ b/engine/common/follower/engine_test.go
@@ -155,7 +155,7 @@ func (suite *Suite) TestHandleProposalSkipProposalThreshold() {
 
 	// mock latest finalized state
 	final := unittest.BlockHeaderFixture()
-	suite.snapshot.On("Head").Return(&final, nil)
+	suite.snapshot.On("Head").Return(final, nil)
 
 	originID := unittest.IdentifierFixture()
 	block := unittest.BlockFixture()

--- a/engine/common/rpc/convert/convert.go
+++ b/engine/common/rpc/convert/convert.go
@@ -162,18 +162,18 @@ func MessageToBlockHeader(m *entities.BlockHeader) (*flow.Header, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert ChainId: %w", err)
 	}
-	return &flow.Header{
-		ParentID:           MessageToIdentifier(m.ParentId),
-		Height:             m.Height,
-		PayloadHash:        MessageToIdentifier(m.PayloadHash),
-		Timestamp:          m.Timestamp.AsTime(),
-		View:               m.View,
-		ParentVoterIndices: m.ParentVoterIndices,
-		ParentVoterSigData: m.ParentVoterSigData,
-		ProposerID:         MessageToIdentifier(m.ProposerId),
-		ProposerSigData:    m.ProposerSigData,
-		ChainID:            *chainId,
-	}, nil
+	return flow.NewHeader(
+		*chainId,
+		MessageToIdentifier(m.ParentId),
+		m.Height,
+		MessageToIdentifier(m.PayloadHash),
+		m.Timestamp.AsTime(),
+		m.View,
+		m.ParentVoterIndices,
+		m.ParentVoterSigData,
+		MessageToIdentifier(m.ProposerId),
+		m.ProposerSigData,
+	), nil
 }
 
 // MessageToChainId checks chainId from enumeration to prevent a panic on Chain() being called

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -70,7 +70,7 @@ func (ss *SyncSuite) SetupTest() {
 
 	// generate a header for the final state
 	header := unittest.BlockHeaderFixture()
-	ss.head = &header
+	ss.head = header
 
 	// create maps to enable block returns
 	ss.heights = make(map[uint64]*flow.Block)
@@ -518,7 +518,7 @@ func (ss *SyncSuite) TestProcessingMultipleItems() {
 func (ss *SyncSuite) TestOnFinalizedBlock() {
 	finalizedBlock := unittest.BlockHeaderWithParentFixture(ss.head)
 	// change head
-	ss.head = &finalizedBlock
+	ss.head = finalizedBlock
 
 	err := ss.e.finalizedHeader.updateHeader()
 	require.NoError(ss.T(), err)

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -524,7 +524,7 @@ func (ss *SyncSuite) TestOnFinalizedBlock() {
 	require.NoError(ss.T(), err)
 	actualHeader := ss.e.finalizedHeader.Get()
 	require.ElementsMatch(ss.T(), ss.e.participantsProvider.Identifiers(), ss.participants[1:].NodeIDs())
-	require.Equal(ss.T(), actualHeader, &finalizedBlock)
+	require.Equal(ss.T(), actualHeader, finalizedBlock)
 }
 
 // TestProcessUnsupportedMessageType tests that Process and ProcessLocal correctly handle a case where invalid message type

--- a/engine/consensus/approvals/approval_collector_test.go
+++ b/engine/consensus/approvals/approval_collector_test.go
@@ -34,7 +34,7 @@ func (s *ApprovalCollectorTestSuite) SetupTest() {
 	s.sealsPL = &mempool.IncorporatedResultSeals{}
 
 	var err error
-	s.collector, err = NewApprovalCollector(unittest.Logger(), s.IncorporatedResult, &s.IncorporatedBlock, &s.Block, s.ChunksAssignment, s.sealsPL, uint(len(s.AuthorizedVerifiers)))
+	s.collector, err = NewApprovalCollector(unittest.Logger(), s.IncorporatedResult, s.IncorporatedBlock, s.Block, s.ChunksAssignment, s.sealsPL, uint(len(s.AuthorizedVerifiers)))
 	require.NoError(s.T(), err)
 }
 

--- a/engine/consensus/approvals/assignment_collector_statemachine_test.go
+++ b/engine/consensus/approvals/assignment_collector_statemachine_test.go
@@ -39,7 +39,7 @@ func (s *AssignmentCollectorStateMachineTestSuite) SetupTest() {
 		approvalConduit:                      s.Conduit,
 		requestTracker:                       s.RequestTracker,
 		requiredApprovalsForSealConstruction: 5,
-		executedBlock:                        &s.Block,
+		executedBlock:                        s.Block,
 		result:                               s.IncorporatedResult.Result,
 		resultID:                             s.IncorporatedResult.Result.ID(),
 	})
@@ -54,8 +54,8 @@ func (s *AssignmentCollectorStateMachineTestSuite) TestChangeProcessingStatus_Ca
 	s.PublicKey.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 
 	for i := range results {
-		block := unittest.BlockHeaderWithParentFixture(&s.Block)
-		s.Blocks[block.ID()] = &block
+		block := unittest.BlockHeaderWithParentFixture(s.Block)
+		s.Blocks[block.ID()] = block
 		result := unittest.IncorporatedResult.Fixture(
 			unittest.IncorporatedResult.WithIncorporatedBlockID(block.ID()),
 			unittest.IncorporatedResult.WithResult(s.IncorporatedResult.Result),

--- a/engine/consensus/approvals/assignment_collector_tree_test.go
+++ b/engine/consensus/approvals/assignment_collector_tree_test.go
@@ -52,7 +52,7 @@ func (s *AssignmentCollectorTreeSuite) SetupTest() {
 	}
 
 	s.mockedCollectors = make(map[flow.Identifier]*mockedCollectorWrapper)
-	s.collectorTree = approvals.NewAssignmentCollectorTree(&s.ParentBlock, s.Headers, s.factoryMethod)
+	s.collectorTree = approvals.NewAssignmentCollectorTree(s.ParentBlock, s.Headers, s.factoryMethod)
 
 	s.prepareMockedCollector(s.IncorporatedResult.Result)
 }
@@ -96,7 +96,7 @@ func requireStateTransition(wrapper *mockedCollectorWrapper, oldState, newState 
 func (s *AssignmentCollectorTreeSuite) TestGetSize_ConcurrentAccess() {
 	numberOfWorkers := 10
 	batchSize := 10
-	chain := unittest.ChainFixtureFrom(numberOfWorkers*batchSize, &s.IncorporatedBlock)
+	chain := unittest.ChainFixtureFrom(numberOfWorkers*batchSize, s.IncorporatedBlock)
 	result0 := unittest.ExecutionResultFixture()
 	receipts := unittest.ReceiptChainFor(chain, result0)
 	for _, block := range chain {
@@ -144,7 +144,7 @@ func (s *AssignmentCollectorTreeSuite) TestGetCollector() {
 // TestGetCollectorsByInterval tests that GetCollectorsByInterval returns a slice
 // with the AssignmentCollectors from the requested interval
 func (s *AssignmentCollectorTreeSuite) TestGetCollectorsByInterval() {
-	chain := unittest.ChainFixtureFrom(10, &s.ParentBlock)
+	chain := unittest.ChainFixtureFrom(10, s.ParentBlock)
 	receipts := unittest.ReceiptChainFor(chain, s.IncorporatedResult.Result)
 	for _, block := range chain {
 		s.Blocks[block.ID()] = block.Header
@@ -225,7 +225,7 @@ func (s *AssignmentCollectorTreeSuite) TestGetOrCreateCollector_CollectorParentI
 // TestGetOrCreateCollector_AddingSealedCollector tests a case when we are trying to add collector which is already sealed.
 // Leveled forest doesn't accept vertexes lower than the lowest height.
 func (s *AssignmentCollectorTreeSuite) TestGetOrCreateCollector_AddingSealedCollector() {
-	block := unittest.BlockWithParentFixture(&s.ParentBlock)
+	block := unittest.BlockWithParentFixture(s.ParentBlock)
 	s.Blocks[block.ID()] = block.Header
 	result := unittest.ExecutionResultFixture(unittest.WithBlock(block))
 	s.prepareMockedCollector(result)
@@ -234,8 +234,8 @@ func (s *AssignmentCollectorTreeSuite) TestGetOrCreateCollector_AddingSealedColl
 	prevSealedBlock := block.Header
 	for i := 0; i < 5; i++ {
 		sealedBlock := unittest.BlockHeaderWithParentFixture(prevSealedBlock)
-		s.MarkFinalized(&sealedBlock)
-		_ = s.collectorTree.FinalizeForkAtLevel(&sealedBlock, &sealedBlock)
+		s.MarkFinalized(sealedBlock)
+		_ = s.collectorTree.FinalizeForkAtLevel(sealedBlock, sealedBlock)
 	}
 
 	// now adding a collector which is lower than sealed height should result in error
@@ -268,7 +268,7 @@ func (s *AssignmentCollectorTreeSuite) TestFinalizeForkAtLevel_ProcessableAfterS
 		unittest.WithExecutionResultBlockID(s.IncorporatedBlock.ID()))
 	s.prepareMockedCollector(firstResult)
 	for i := 0; i < len(forks); i++ {
-		fork := unittest.ChainFixtureFrom(3, &s.IncorporatedBlock)
+		fork := unittest.ChainFixtureFrom(3, s.IncorporatedBlock)
 		forks[i] = fork
 		prevResult := firstResult
 		// create execution results for all blocks except last one, since it won't be valid by definition
@@ -302,7 +302,7 @@ func (s *AssignmentCollectorTreeSuite) TestFinalizeForkAtLevel_ProcessableAfterS
 
 	finalized := forks[0][0].Header
 
-	s.MarkFinalized(&s.IncorporatedBlock)
+	s.MarkFinalized(s.IncorporatedBlock)
 	s.MarkFinalized(finalized)
 
 	// at this point collectors for forks[0] should be processable and for forks[1] not
@@ -322,7 +322,7 @@ func (s *AssignmentCollectorTreeSuite) TestFinalizeForkAtLevel_ProcessableAfterS
 	}
 
 	// A becomes sealed, B becomes finalized
-	err := s.collectorTree.FinalizeForkAtLevel(finalized, &s.Block)
+	err := s.collectorTree.FinalizeForkAtLevel(finalized, s.Block)
 	require.NoError(s.T(), err)
 
 	for forkIndex := range forks {

--- a/engine/consensus/approvals/caching_assignment_collector_test.go
+++ b/engine/consensus/approvals/caching_assignment_collector_test.go
@@ -16,7 +16,7 @@ import (
 type CachingAssignmentCollectorTestSuite struct {
 	suite.Suite
 
-	executedBlock flow.Header
+	executedBlock *flow.Header
 	result        *flow.ExecutionResult
 	collector     *CachingAssignmentCollector
 }
@@ -31,7 +31,7 @@ func (s *CachingAssignmentCollectorTestSuite) SetupTest() {
 		result.BlockID = s.executedBlock.ID()
 	})
 	s.collector = NewCachingAssignmentCollector(AssignmentCollectorBase{
-		executedBlock: &s.executedBlock,
+		executedBlock: s.executedBlock,
 		result:        s.result,
 		resultID:      s.result.ID(),
 	})

--- a/engine/consensus/approvals/testutil.go
+++ b/engine/consensus/approvals/testutil.go
@@ -25,9 +25,9 @@ import (
 type BaseApprovalsTestSuite struct {
 	suite.Suite
 
-	ParentBlock         flow.Header     // parent of sealing candidate
-	Block               flow.Header     // candidate for sealing
-	IncorporatedBlock   flow.Header     // block that incorporated result
+	ParentBlock         *flow.Header    // parent of sealing candidate
+	Block               *flow.Header    // candidate for sealing
+	IncorporatedBlock   *flow.Header    // block that incorporated result
 	VerID               flow.Identifier // for convenience, node id of first verifier
 	Chunks              flow.ChunkList  // list of chunks of execution result
 	ChunksAssignment    *chunks.Assignment
@@ -39,7 +39,7 @@ type BaseApprovalsTestSuite struct {
 
 func (s *BaseApprovalsTestSuite) SetupTest() {
 	s.ParentBlock = unittest.BlockHeaderFixture()
-	s.Block = unittest.BlockHeaderWithParentFixture(&s.ParentBlock)
+	s.Block = unittest.BlockHeaderWithParentFixture(s.ParentBlock)
 	verifiers := make(flow.IdentifierList, 0)
 	s.AuthorizedVerifiers = make(map[flow.Identifier]*flow.Identity)
 	s.ChunksAssignment = chunks.NewAssignment()
@@ -67,7 +67,7 @@ func (s *BaseApprovalsTestSuite) SetupTest() {
 	result.BlockID = s.Block.ID()
 	result.Chunks = s.Chunks
 
-	s.IncorporatedBlock = unittest.BlockHeaderWithParentFixture(&s.Block)
+	s.IncorporatedBlock = unittest.BlockHeaderWithParentFixture(s.Block)
 
 	// compose incorporated result
 	s.IncorporatedResult = unittest.IncorporatedResult.Fixture(
@@ -106,14 +106,14 @@ func (s *BaseAssignmentCollectorTestSuite) SetupTest() {
 	s.RequestTracker = NewRequestTracker(s.Headers, 1, 3)
 
 	s.FinalizedAtHeight = make(map[uint64]*flow.Header)
-	s.FinalizedAtHeight[s.ParentBlock.Height] = &s.ParentBlock
-	s.FinalizedAtHeight[s.Block.Height] = &s.Block
+	s.FinalizedAtHeight[s.ParentBlock.Height] = s.ParentBlock
+	s.FinalizedAtHeight[s.Block.Height] = s.Block
 
 	// setup blocks cache for protocol state
 	s.Blocks = make(map[flow.Identifier]*flow.Header)
-	s.Blocks[s.ParentBlock.ID()] = &s.ParentBlock
-	s.Blocks[s.Block.ID()] = &s.Block
-	s.Blocks[s.IncorporatedBlock.ID()] = &s.IncorporatedBlock
+	s.Blocks[s.ParentBlock.ID()] = s.ParentBlock
+	s.Blocks[s.Block.ID()] = s.Block
+	s.Blocks[s.IncorporatedBlock.ID()] = s.IncorporatedBlock
 	s.Snapshots = make(map[flow.Identifier]*protocol.Snapshot)
 
 	// setup identities for each block

--- a/engine/consensus/approvals/verifying_assignment_collector_test.go
+++ b/engine/consensus/approvals/verifying_assignment_collector_test.go
@@ -127,8 +127,8 @@ func (s *AssignmentCollectorTestSuite) TestProcessIncorporatedResult_ReusingCach
 		}
 	}
 
-	incorporatedBlock := unittest.BlockHeaderWithParentFixture(&s.Block)
-	s.Blocks[incorporatedBlock.ID()] = &incorporatedBlock
+	incorporatedBlock := unittest.BlockHeaderWithParentFixture(s.Block)
+	s.Blocks[incorporatedBlock.ID()] = incorporatedBlock
 
 	// at this point we have proposed a seal, let's construct new incorporated result with same assignment
 	// but different incorporated block ID resulting in new seal.
@@ -217,7 +217,7 @@ func (s *AssignmentCollectorTestSuite) TestProcessIncorporatedResult() {
 	s.Run("invalid-verifier-identities", func() {
 		// delete identities for Result.BlockID
 		delete(s.IdentitiesCache, s.IncorporatedResult.Result.BlockID)
-		s.Snapshots[s.IncorporatedResult.Result.BlockID] = unittest.StateSnapshotForKnownBlock(&s.Block, nil)
+		s.Snapshots[s.IncorporatedResult.Result.BlockID] = unittest.StateSnapshotForKnownBlock(s.Block, nil)
 		collector, err := newVerifyingAssignmentCollector(unittest.Logger(), s.WorkerPool, s.IncorporatedResult.Result, s.State, s.Headers,
 			s.Assigner, s.SealsPL, s.SigHasher, s.Conduit, s.RequestTracker, 1)
 		require.Error(s.T(), err)
@@ -237,7 +237,7 @@ func (s *AssignmentCollectorTestSuite) TestProcessIncorporatedResult_InvalidIden
 		state.On("AtBlockID", mock.Anything).Return(
 			func(blockID flow.Identifier) realproto.Snapshot {
 				return unittest.StateSnapshotForKnownBlock(
-					&s.Block,
+					s.Block,
 					map[flow.Identifier]*flow.Identity{identity.NodeID: identity},
 				)
 			},
@@ -257,7 +257,7 @@ func (s *AssignmentCollectorTestSuite) TestProcessIncorporatedResult_InvalidIden
 		state.On("AtBlockID", mock.Anything).Return(
 			func(blockID flow.Identifier) realproto.Snapshot {
 				return unittest.StateSnapshotForKnownBlock(
-					&s.Block,
+					s.Block,
 					map[flow.Identifier]*flow.Identity{identity.NodeID: identity},
 				)
 			},
@@ -276,7 +276,7 @@ func (s *AssignmentCollectorTestSuite) TestProcessIncorporatedResult_InvalidIden
 		state.On("AtBlockID", mock.Anything).Return(
 			func(blockID flow.Identifier) realproto.Snapshot {
 				return unittest.StateSnapshotForKnownBlock(
-					&s.Block,
+					s.Block,
 					map[flow.Identifier]*flow.Identity{identity.NodeID: identity},
 				)
 			},
@@ -323,8 +323,8 @@ func (s *AssignmentCollectorTestSuite) TestRequestMissingApprovals() {
 		incorporatedBlock.Height = lastHeight
 		lastHeight++
 
-		s.Blocks[incorporatedBlock.ID()] = &incorporatedBlock
-		incorporatedBlocks = append(incorporatedBlocks, &incorporatedBlock)
+		s.Blocks[incorporatedBlock.ID()] = incorporatedBlock
+		incorporatedBlocks = append(incorporatedBlocks, incorporatedBlock)
 	}
 
 	incorporatedResults := make([]*flow.IncorporatedResult, 0, len(incorporatedBlocks))

--- a/engine/consensus/compliance/engine_test.go
+++ b/engine/consensus/compliance/engine_test.go
@@ -90,10 +90,10 @@ func (cs *ComplianceSuite) TestBroadcastProposalWithDelay() {
 	parent := unittest.BlockHeaderFixture()
 	parent.ChainID = "test"
 	parent.Height = 10
-	cs.headerDB[parent.ID()] = &parent
+	cs.headerDB[parent.ID()] = parent
 
 	// create a block with the parent and store the payload with correct ID
-	block := unittest.BlockWithParentFixture(&parent)
+	block := unittest.BlockWithParentFixture(parent)
 	block.Header.ProposerID = cs.myID
 	cs.payloadDB[block.ID()] = block.Payload
 
@@ -217,12 +217,12 @@ func (cs *ComplianceSuite) TestProcessUnsupportedMessageType() {
 // Tests the whole processing pipeline.
 func (cs *ComplianceSuite) TestOnFinalizedBlock() {
 	finalizedBlock := unittest.BlockHeaderFixture()
-	cs.head = &finalizedBlock
+	cs.head = finalizedBlock
 
 	*cs.pending = modulemock.PendingBlockBuffer{}
 	cs.pending.On("PruneByView", finalizedBlock.View).Return(nil).Once()
 	cs.pending.On("Size").Return(uint(0)).Once()
-	cs.engine.OnFinalizedBlock(model.BlockFromFlow(&finalizedBlock, finalizedBlock.View-1))
+	cs.engine.OnFinalizedBlock(model.BlockFromFlow(finalizedBlock, finalizedBlock.View-1))
 
 	require.Eventually(cs.T(),
 		func() bool {

--- a/engine/consensus/dkg/reactor_engine_test.go
+++ b/engine/consensus/dkg/reactor_engine_test.go
@@ -345,7 +345,7 @@ func (suite *ReactorEngineSuite_CommittedPhase) SetupTest() {
 	epochQuery.Add(nextEpoch)
 
 	firstBlock := unittest.BlockHeaderFixture(unittest.HeaderWithView(100))
-	suite.firstBlock = &firstBlock
+	suite.firstBlock = firstBlock
 
 	suite.snap = new(protocol.Snapshot)
 	suite.snap.On("Epochs").Return(epochQuery)

--- a/engine/consensus/dkg/reactor_engine_test.go
+++ b/engine/consensus/dkg/reactor_engine_test.go
@@ -106,7 +106,7 @@ func (suite *ReactorEngineSuite_SetupPhase) SetupTest() {
 	suite.blocksByView = make(map[uint64]*flow.Header)
 	for view := suite.dkgStartView; view <= suite.dkgPhase3FinalView; view += dkg.DefaultPollStep {
 		header := unittest.BlockHeaderFixture(unittest.HeaderWithView(view))
-		suite.blocksByView[view] = &header
+		suite.blocksByView[view] = header
 	}
 	suite.firstBlock = suite.blocksByView[100]
 

--- a/engine/consensus/ingestion/core_test.go
+++ b/engine/consensus/ingestion/core_test.go
@@ -135,7 +135,7 @@ func (suite *IngestionCoreSuite) SetupTest() {
 
 	ingest := NewCore(unittest.Logger(), tracer, metrics, state, headers, pool)
 
-	suite.head = &head
+	suite.head = head
 	suite.final = final
 	suite.ref = ref
 	suite.headers = headers

--- a/engine/consensus/ingestion/core_test.go
+++ b/engine/consensus/ingestion/core_test.go
@@ -128,7 +128,7 @@ func (suite *IngestionCoreSuite) SetupTest() {
 	)
 
 	// we need to return the head as it's also used as reference block
-	headers.On("ByBlockID", head.ID()).Return(&head, nil)
+	headers.On("ByBlockID", head.ID()).Return(head, nil)
 
 	// only used for metrics, nobody cares
 	pool.On("Size").Return(uint(0))

--- a/engine/consensus/ingestion/core_test.go
+++ b/engine/consensus/ingestion/core_test.go
@@ -87,7 +87,7 @@ func (suite *IngestionCoreSuite) SetupTest() {
 	// returning everything correctly, using the created header
 	// as head of the protocol state
 	state.On("Final").Return(final)
-	final.On("Head").Return(&head, nil)
+	final.On("Head").Return(head, nil)
 	final.On("Identity", mock.Anything).Return(
 		func(nodeID flow.Identifier) *flow.Identity {
 			identity, _ := suite.finalIdentities.ByNodeID(nodeID)
@@ -219,7 +219,7 @@ func (suite *IngestionCoreSuite) TestOnGuaranteeExpired() {
 	// create an alternative block
 	header := unittest.BlockHeaderFixture()
 	header.Height = suite.head.Height - flow.DefaultTransactionExpiry - 1
-	suite.headers.On("ByBlockID", header.ID()).Return(&header, nil)
+	suite.headers.On("ByBlockID", header.ID()).Return(header, nil)
 
 	// create a guarantee signed by the collection node and referencing the
 	// current head of the protocol state

--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -65,9 +65,9 @@ func (s *MatchingEngineSuite) SetupTest() {
 func (s *MatchingEngineSuite) TestOnFinalizedBlock() {
 
 	finalizedBlock := unittest.BlockHeaderFixture()
-	s.state.On("Final").Return(unittest.StateSnapshotForKnownBlock(&finalizedBlock, nil))
+	s.state.On("Final").Return(unittest.StateSnapshotForKnownBlock(finalizedBlock, nil))
 	s.core.On("OnBlockFinalization").Return(nil).Once()
-	s.engine.OnFinalizedBlock(model.BlockFromFlow(&finalizedBlock, finalizedBlock.View-1))
+	s.engine.OnFinalizedBlock(model.BlockFromFlow(finalizedBlock, finalizedBlock.View-1))
 
 	// matching engine has at least 100ms ticks for processing events
 	time.Sleep(1 * time.Second)
@@ -93,7 +93,7 @@ func (s *MatchingEngineSuite) TestOnBlockIncorporated() {
 	}
 	s.index.On("ByBlockID", incorporatedBlockID).Return(index, nil)
 
-	s.engine.OnBlockIncorporated(model.BlockFromFlow(&incorporatedBlock, incorporatedBlock.View-1))
+	s.engine.OnBlockIncorporated(model.BlockFromFlow(incorporatedBlock, incorporatedBlock.View-1))
 
 	// matching engine has at least 100ms ticks for processing events
 	time.Sleep(1 * time.Second)

--- a/engine/consensus/sealing/core_test.go
+++ b/engine/consensus/sealing/core_test.go
@@ -58,7 +58,7 @@ func (s *ApprovalProcessingCoreTestSuite) SetupTest() {
 
 	s.rootHeader = unittest.GenesisFixture().Header
 	params := new(mockstate.Params)
-	s.State.On("Sealed").Return(unittest.StateSnapshotForKnownBlock(&s.ParentBlock, nil)).Maybe()
+	s.State.On("Sealed").Return(unittest.StateSnapshotForKnownBlock(s.ParentBlock, nil)).Maybe()
 	s.State.On("Params").Return(params)
 	params.On("Root").Return(
 		func() *flow.Header { return s.rootHeader },
@@ -84,7 +84,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectOutdatedApp
 	err := s.core.processApproval(approval)
 	require.NoError(s.T(), err)
 
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.Block))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.Block))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
 
 	err = s.core.ProcessFinalizedBlock(s.Block.ID())
@@ -98,7 +98,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectOutdatedApp
 // TestOnBlockFinalized_RejectOutdatedExecutionResult tests that incorporated result will be rejected as outdated
 // if the block which is targeted by execution result is already sealed.
 func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectOutdatedExecutionResult() {
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.Block))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.Block))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
 
 	err := s.core.ProcessFinalizedBlock(s.Block.ID())
@@ -131,11 +131,11 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectUnverifiabl
 // 	 <- B_2
 // B_1 is finalized rendering B_2 as orphan, submitting IR[ER[A], B_1] is a success, submitting IR[ER[A], B_2] is an outdated incorporated result
 func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectOrphanIncorporatedResults() {
-	blockB1 := unittest.BlockHeaderWithParentFixture(&s.Block)
-	blockB2 := unittest.BlockHeaderWithParentFixture(&s.Block)
+	blockB1 := unittest.BlockHeaderWithParentFixture(s.Block)
+	blockB2 := unittest.BlockHeaderWithParentFixture(s.Block)
 
-	s.Blocks[blockB1.ID()] = &blockB1
-	s.Blocks[blockB2.ID()] = &blockB2
+	s.Blocks[blockB1.ID()] = blockB1
+	s.Blocks[blockB2.ID()] = blockB2
 
 	IR1 := unittest.IncorporatedResult.Fixture(
 		unittest.IncorporatedResult.WithIncorporatedBlockID(blockB1.ID()),
@@ -145,9 +145,9 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectOrphanIncor
 		unittest.IncorporatedResult.WithIncorporatedBlockID(blockB2.ID()),
 		unittest.IncorporatedResult.WithResult(s.IncorporatedResult.Result))
 
-	s.MarkFinalized(&blockB1)
+	s.MarkFinalized(blockB1)
 
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.ParentBlock))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.ParentBlock))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
 
 	// blockB1 becomes finalized
@@ -163,17 +163,17 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectOrphanIncor
 }
 
 func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_RejectOldFinalizedBlock() {
-	blockB1 := unittest.BlockHeaderWithParentFixture(&s.Block)
-	blockB2 := unittest.BlockHeaderWithParentFixture(&blockB1)
+	blockB1 := unittest.BlockHeaderWithParentFixture(s.Block)
+	blockB2 := unittest.BlockHeaderWithParentFixture(blockB1)
 
-	s.Blocks[blockB1.ID()] = &blockB1
-	s.Blocks[blockB2.ID()] = &blockB2
+	s.Blocks[blockB1.ID()] = blockB1
+	s.Blocks[blockB2.ID()] = blockB2
 
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.Block))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.Block))
 	// should only call it once
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
-	s.MarkFinalized(&blockB1)
-	s.MarkFinalized(&blockB2)
+	s.MarkFinalized(blockB1)
+	s.MarkFinalized(blockB2)
 
 	// blockB1 becomes finalized
 	err := s.core.ProcessFinalizedBlock(blockB2.ID())
@@ -190,8 +190,8 @@ func (s *ApprovalProcessingCoreTestSuite) TestProcessFinalizedBlock_CollectorsCl
 	numResults := uint(10)
 	for i := uint(0); i < numResults; i++ {
 		// all results incorporated in different blocks
-		incorporatedBlock := unittest.BlockHeaderWithParentFixture(&s.IncorporatedBlock)
-		s.Blocks[incorporatedBlock.ID()] = &incorporatedBlock
+		incorporatedBlock := unittest.BlockHeaderWithParentFixture(s.IncorporatedBlock)
+		s.Blocks[incorporatedBlock.ID()] = incorporatedBlock
 		// create different incorporated results for same block ID
 		result := unittest.ExecutionResultFixture()
 		result.BlockID = blockID
@@ -204,15 +204,15 @@ func (s *ApprovalProcessingCoreTestSuite) TestProcessFinalizedBlock_CollectorsCl
 	}
 	require.Equal(s.T(), uint64(numResults), s.core.collectorTree.GetSize())
 
-	candidate := unittest.BlockHeaderWithParentFixture(&s.Block)
-	s.Blocks[candidate.ID()] = &candidate
+	candidate := unittest.BlockHeaderWithParentFixture(s.Block)
+	s.Blocks[candidate.ID()] = candidate
 
 	// candidate becomes new sealed and finalized block, it means that
 	// we will need to cleanup our tree till new height, removing all outdated collectors
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&candidate))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(candidate))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
 
-	s.MarkFinalized(&candidate)
+	s.MarkFinalized(candidate)
 	err := s.core.ProcessFinalizedBlock(candidate.ID())
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), uint64(0), s.core.collectorTree.GetSize())
@@ -338,22 +338,22 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_EmergencySealing(
 		},
 	).Return(true, nil).Once()
 
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.ParentBlock))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.ParentBlock))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Times(approvals.DefaultEmergencySealingThreshold)
-	s.State.On("Sealed").Return(unittest.StateSnapshotForKnownBlock(&s.ParentBlock, nil))
+	s.State.On("Sealed").Return(unittest.StateSnapshotForKnownBlock(s.ParentBlock, nil))
 
 	err = s.core.ProcessIncorporatedResult(s.IncorporatedResult)
 	require.NoError(s.T(), err)
 
-	lastFinalizedBlock := &s.IncorporatedBlock
+	lastFinalizedBlock := s.IncorporatedBlock
 	s.MarkFinalized(lastFinalizedBlock)
 	for i := 0; i < approvals.DefaultEmergencySealingThreshold; i++ {
 		finalizedBlock := unittest.BlockHeaderWithParentFixture(lastFinalizedBlock)
-		s.Blocks[finalizedBlock.ID()] = &finalizedBlock
-		s.MarkFinalized(&finalizedBlock)
+		s.Blocks[finalizedBlock.ID()] = finalizedBlock
+		s.MarkFinalized(finalizedBlock)
 		err := s.core.ProcessFinalizedBlock(finalizedBlock.ID())
 		require.NoError(s.T(), err)
-		lastFinalizedBlock = &finalizedBlock
+		lastFinalizedBlock = finalizedBlock
 	}
 
 	s.SealsPL.AssertExpectations(s.T())
@@ -369,7 +369,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_ProcessingOrphanA
 	forkResults := make([][]*flow.ExecutionResult, len(forks))
 
 	for forkIndex := range forks {
-		forks[forkIndex] = unittest.ChainFixtureFrom(forkIndex+2, &s.ParentBlock)
+		forks[forkIndex] = unittest.ChainFixtureFrom(forkIndex+2, s.ParentBlock)
 		fork := forks[forkIndex]
 
 		previousResult := s.IncorporatedResult.Result
@@ -398,7 +398,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_ProcessingOrphanA
 	}
 
 	// same block sealed
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.ParentBlock))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.ParentBlock))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
 
 	// block B_1 becomes finalized
@@ -437,7 +437,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_ExtendingUnproces
 	forks := make([][]*flow.Block, 2)
 
 	for forkIndex := range forks {
-		forks[forkIndex] = unittest.ChainFixtureFrom(forkIndex+3, &s.Block)
+		forks[forkIndex] = unittest.ChainFixtureFrom(forkIndex+3, s.Block)
 		fork := forks[forkIndex]
 		for _, block := range fork {
 			s.Blocks[block.ID()] = block.Header
@@ -448,7 +448,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_ExtendingUnproces
 	finalized := forks[1][0].Header
 
 	s.MarkFinalized(finalized)
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.ParentBlock))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.ParentBlock))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
 
 	// finalize block B
@@ -487,21 +487,21 @@ func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_ExtendingUnproces
 
 // TestOnBlockFinalized_ExtendingSealedResult tests if assignment collector tree accepts collector which extends sealed result
 func (s *ApprovalProcessingCoreTestSuite) TestOnBlockFinalized_ExtendingSealedResult() {
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.Block))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.Block))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil).Once()
 
-	unsealedBlock := unittest.BlockHeaderWithParentFixture(&s.Block)
-	s.Blocks[unsealedBlock.ID()] = &unsealedBlock
+	unsealedBlock := unittest.BlockHeaderWithParentFixture(s.Block)
+	s.Blocks[unsealedBlock.ID()] = unsealedBlock
 	s.IdentitiesCache[unsealedBlock.ID()] = s.AuthorizedVerifiers
 	result := unittest.ExecutionResultFixture(unittest.WithPreviousResult(*s.IncorporatedResult.Result))
 	result.BlockID = unsealedBlock.ID()
 
-	s.MarkFinalized(&unsealedBlock)
+	s.MarkFinalized(unsealedBlock)
 	err := s.core.ProcessFinalizedBlock(unsealedBlock.ID())
 	require.NoError(s.T(), err)
 
-	incorporatedBlock := unittest.BlockHeaderWithParentFixture(&unsealedBlock)
-	s.Blocks[incorporatedBlock.ID()] = &incorporatedBlock
+	incorporatedBlock := unittest.BlockHeaderWithParentFixture(unsealedBlock)
+	s.Blocks[incorporatedBlock.ID()] = incorporatedBlock
 	s.IdentitiesCache[incorporatedBlock.ID()] = s.AuthorizedVerifiers
 	IR := unittest.IncorporatedResult.Fixture(
 		unittest.IncorporatedResult.WithIncorporatedBlockID(incorporatedBlock.ID()),
@@ -526,7 +526,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestRequestPendingApprovals() {
 
 	// create blocks
 	unsealedFinalizedBlocks := make([]flow.Block, 0, n)
-	parentBlock := &s.ParentBlock
+	parentBlock := s.ParentBlock
 	for i := 0; i < n; i++ {
 		block := unittest.BlockWithParentFixture(parentBlock)
 		s.Blocks[block.ID()] = block.Header
@@ -603,10 +603,10 @@ func (s *ApprovalProcessingCoreTestSuite) TestRequestPendingApprovals() {
 	}
 
 	// sealed block doesn't change
-	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(&s.ParentBlock))
+	seal := unittest.Seal.Fixture(unittest.Seal.WithBlock(s.ParentBlock))
 	s.sealsDB.On("HighestInFork", mock.Anything).Return(seal, nil)
 
-	s.State.On("Sealed").Return(unittest.StateSnapshotForKnownBlock(&s.ParentBlock, nil))
+	s.State.On("Sealed").Return(unittest.StateSnapshotForKnownBlock(s.ParentBlock, nil))
 
 	// start delivering finalization events
 	lastProcessedIndex := 0
@@ -679,7 +679,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestRepopulateAssignmentCollectorTree(
 
 	s.sealsDB.On("HighestInFork", s.IncorporatedBlock.ID()).Return(
 		unittest.Seal.Fixture(
-			unittest.Seal.WithBlock(&s.ParentBlock)), nil)
+			unittest.Seal.WithBlock(s.ParentBlock)), nil)
 
 	// the incorporated block contains the result for the sealing candidate block
 	incorporatedBlockPayload := unittest.PayloadFixture(
@@ -697,7 +697,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestRepopulateAssignmentCollectorTree(
 
 	// two forks
 	for i := 0; i < 2; i++ {
-		fork := unittest.ChainFixtureFrom(i+3, &s.IncorporatedBlock)
+		fork := unittest.ChainFixtureFrom(i+3, s.IncorporatedBlock)
 		prevResult := s.IncorporatedResult.Result
 		// create execution results for all blocks except last one, since it won't be valid by definition
 		for blockIndex, block := range fork {
@@ -736,7 +736,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestRepopulateAssignmentCollectorTree(
 	}
 
 	// ValidDescendants has to return all valid descendants from finalized block
-	finalSnapShot := unittest.StateSnapshotForKnownBlock(&s.IncorporatedBlock, nil)
+	finalSnapShot := unittest.StateSnapshotForKnownBlock(s.IncorporatedBlock, nil)
 	finalSnapShot.On("ValidDescendants").Return(blockChildren, nil)
 	s.State.On("Final").Return(finalSnapShot)
 
@@ -772,12 +772,12 @@ func (s *ApprovalProcessingCoreTestSuite) TestRepopulateAssignmentCollectorTree_
 	payloads := &storage.Payloads{}
 
 	// setup mocks
-	s.rootHeader = &s.IncorporatedBlock
+	s.rootHeader = s.IncorporatedBlock
 	expectedResults := []*flow.IncorporatedResult{s.IncorporatedResult}
 
 	s.sealsDB.On("HighestInFork", s.IncorporatedBlock.ID()).Return(
 		unittest.Seal.Fixture(
-			unittest.Seal.WithBlock(&s.ParentBlock)), nil)
+			unittest.Seal.WithBlock(s.ParentBlock)), nil)
 
 	// the incorporated block contains the result for the sealing candidate block
 	incorporatedBlockPayload := unittest.PayloadFixture(
@@ -808,13 +808,13 @@ func (s *ApprovalProcessingCoreTestSuite) TestRepopulateAssignmentCollectorTree_
 	finalSnapShot.On("SealingSegment").Return(
 		&flow.SealingSegment{
 			Blocks: []*flow.Block{{
-				Header:  &s.Block,
+				Header:  s.Block,
 				Payload: &candidatePayload,
 			}, {
-				Header:  &s.ParentBlock,
+				Header:  s.ParentBlock,
 				Payload: &flow.Payload{},
 			}, {
-				Header:  &s.IncorporatedBlock,
+				Header:  s.IncorporatedBlock,
 				Payload: &incorporatedBlockPayload,
 			}},
 		}, nil)

--- a/engine/consensus/sealing/engine_test.go
+++ b/engine/consensus/sealing/engine_test.go
@@ -118,7 +118,7 @@ func (s *SealingEngineSuite) TestOnBlockIncorporated() {
 
 	// setup headers storage
 	headers := &mockstorage.Headers{}
-	headers.On("ByBlockID", incorporatedBlockID).Return(&incorporatedBlock, nil).Once()
+	headers.On("ByBlockID", incorporatedBlockID).Return(incorporatedBlock, nil).Once()
 	s.engine.headers = headers
 
 	s.engine.OnBlockIncorporated(model.BlockFromFlow(incorporatedBlock, incorporatedBlock.View-1))

--- a/engine/consensus/sealing/engine_test.go
+++ b/engine/consensus/sealing/engine_test.go
@@ -87,9 +87,9 @@ func (s *SealingEngineSuite) TestOnFinalizedBlock() {
 	finalizedBlock := unittest.BlockHeaderFixture()
 	finalizedBlockID := finalizedBlock.ID()
 
-	s.state.On("Final").Return(unittest.StateSnapshotForKnownBlock(&finalizedBlock, nil))
+	s.state.On("Final").Return(unittest.StateSnapshotForKnownBlock(finalizedBlock, nil))
 	s.core.On("ProcessFinalizedBlock", finalizedBlockID).Return(nil).Once()
-	s.engine.OnFinalizedBlock(model.BlockFromFlow(&finalizedBlock, finalizedBlock.View-1))
+	s.engine.OnFinalizedBlock(model.BlockFromFlow(finalizedBlock, finalizedBlock.View-1))
 
 	// matching engine has at least 100ms ticks for processing events
 	time.Sleep(1 * time.Second)
@@ -101,7 +101,7 @@ func (s *SealingEngineSuite) TestOnFinalizedBlock() {
 // Tests the whole processing pipeline.
 func (s *SealingEngineSuite) TestOnBlockIncorporated() {
 	parentBlock := unittest.BlockHeaderFixture()
-	incorporatedBlock := unittest.BlockHeaderWithParentFixture(&parentBlock)
+	incorporatedBlock := unittest.BlockHeaderWithParentFixture(parentBlock)
 	incorporatedBlockID := incorporatedBlock.ID()
 	// setup payload fixture
 	payload := unittest.PayloadFixture(unittest.WithAllTheFixins)
@@ -121,7 +121,7 @@ func (s *SealingEngineSuite) TestOnBlockIncorporated() {
 	headers.On("ByBlockID", incorporatedBlockID).Return(&incorporatedBlock, nil).Once()
 	s.engine.headers = headers
 
-	s.engine.OnBlockIncorporated(model.BlockFromFlow(&incorporatedBlock, incorporatedBlock.View-1))
+	s.engine.OnBlockIncorporated(model.BlockFromFlow(incorporatedBlock, incorporatedBlock.View-1))
 
 	// matching engine has at least 100ms ticks for processing events
 	time.Sleep(1 * time.Second)

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -717,11 +717,17 @@ func generateBlockWithVisitor(collectionCount, transactionCount int, addressGene
 	}
 
 	block := flow.Block{
-		Header: &flow.Header{
-			Timestamp: flow.GenesisTime,
-			Height:    42,
-			View:      42,
-		},
+		Header: flow.NewHeader(
+			"",
+			flow.ZeroID,
+			42,
+			flow.ZeroID,
+			flow.GenesisTime,
+			42,
+			nil,
+			nil,
+			flow.ZeroID,
+			nil),
 		Payload: &flow.Payload{
 			Guarantees: guarantees,
 		},

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -174,10 +174,17 @@ func createBlock(b *testing.B, parentBlock *flow.Block, accs *testAccounts, colN
 	}
 
 	block := flow.Block{
-		Header: &flow.Header{
-			ParentID: parentBlock.ID(),
-			View:     parentBlock.Header.Height + 1,
-		},
+		Header: flow.NewHeader(
+			"",
+			parentBlock.ID(),
+			0,
+			flow.ZeroID,
+			time.Time{},
+			parentBlock.Header.Height+1,
+			nil,
+			nil,
+			flow.ZeroID,
+			nil),
 		Payload: &flow.Payload{
 			Guarantees: guarantees,
 		},

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -91,9 +91,17 @@ func TestComputeBlockWithStorage(t *testing.T) {
 	}
 
 	block := flow.Block{
-		Header: &flow.Header{
-			View: 42,
-		},
+		Header: flow.NewHeader(
+			"",
+			flow.ZeroID,
+			0,
+			flow.ZeroID,
+			time.Time{},
+			42,
+			nil,
+			nil,
+			flow.ZeroID,
+			nil),
 		Payload: &flow.Payload{
 			Guarantees: []*flow.CollectionGuarantee{&guarantee},
 		},

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -254,7 +254,7 @@ func TestExecuteScript(t *testing.T) {
 	require.NoError(t, err)
 
 	header := unittest.BlockHeaderFixture()
-	_, err = engine.ExecuteScript(context.Background(), script, nil, &header, scriptView)
+	_, err = engine.ExecuteScript(context.Background(), script, nil, header, scriptView)
 	require.NoError(t, err)
 }
 
@@ -288,7 +288,7 @@ func TestExecuteScripPanicsAreHandled(t *testing.T) {
 		edCache)
 	require.NoError(t, err)
 
-	_, err = manager.ExecuteScript(context.Background(), []byte("whatever"), nil, &header, noopView())
+	_, err = manager.ExecuteScript(context.Background(), []byte("whatever"), nil, header, noopView())
 
 	require.Error(t, err)
 
@@ -325,7 +325,7 @@ func TestExecuteScript_LongScriptsAreLogged(t *testing.T) {
 		edCache)
 	require.NoError(t, err)
 
-	_, err = manager.ExecuteScript(context.Background(), []byte("whatever"), nil, &header, noopView())
+	_, err = manager.ExecuteScript(context.Background(), []byte("whatever"), nil, header, noopView())
 
 	require.NoError(t, err)
 
@@ -362,7 +362,7 @@ func TestExecuteScript_ShortScriptsAreNotLogged(t *testing.T) {
 		edCache)
 	require.NoError(t, err)
 
-	_, err = manager.ExecuteScript(context.Background(), []byte("whatever"), nil, &header, noopView())
+	_, err = manager.ExecuteScript(context.Background(), []byte("whatever"), nil, header, noopView())
 
 	require.NoError(t, err)
 
@@ -455,7 +455,7 @@ func TestExecuteScriptTimeout(t *testing.T) {
 	`)
 
 	header := unittest.BlockHeaderFixture()
-	value, err := manager.ExecuteScript(context.Background(), script, nil, &header, noopView())
+	value, err := manager.ExecuteScript(context.Background(), script, nil, header, noopView())
 
 	require.Error(t, err)
 	require.Nil(t, value)
@@ -501,7 +501,7 @@ func TestExecuteScriptCancelled(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		header := unittest.BlockHeaderFixture()
-		value, err = manager.ExecuteScript(reqCtx, script, nil, &header, noopView())
+		value, err = manager.ExecuteScript(reqCtx, script, nil, header, noopView())
 		wg.Done()
 	}()
 	cancel()
@@ -557,7 +557,7 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 
 	header := unittest.BlockHeaderFixture()
 	scriptView := view.NewChild()
-	_, err = manager.ExecuteScript(context.Background(), script, [][]byte{jsoncdc.MustEncode(address)}, &header, scriptView)
+	_, err = manager.ExecuteScript(context.Background(), script, [][]byte{jsoncdc.MustEncode(address)}, header, scriptView)
 
 	require.NoError(t, err)
 

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -81,9 +81,17 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 	}
 
 	block := flow.Block{
-		Header: &flow.Header{
-			View: 26,
-		},
+		Header: flow.NewHeader(
+			"",
+			flow.ZeroID,
+			0,
+			flow.ZeroID,
+			time.Time{},
+			26,
+			nil,
+			nil,
+			flow.ZeroID,
+			nil),
 		Payload: &flow.Payload{
 			Guarantees: []*flow.CollectionGuarantee{&guarantee},
 		},
@@ -231,9 +239,17 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 
 	t.Run("executing block1 (no collection)", func(t *testing.T) {
 		block1 = &flow.Block{
-			Header: &flow.Header{
-				View: 1,
-			},
+			Header: flow.NewHeader(
+				"",
+				flow.ZeroID,
+				0,
+				flow.ZeroID,
+				time.Time{},
+				1,
+				nil,
+				nil,
+				flow.ZeroID,
+				nil),
 			Payload: &flow.Payload{
 				Guarantees: []*flow.CollectionGuarantee{},
 			},
@@ -405,11 +421,17 @@ func createTestBlockAndRun(t *testing.T, engine *Manager, parentBlock *flow.Bloc
 	}
 
 	block := &flow.Block{
-		Header: &flow.Header{
-			ParentID:  parentBlock.ID(),
-			View:      parentBlock.Header.Height + 1,
-			Timestamp: time.Now(),
-		},
+		Header: flow.NewHeader(
+			"",
+			parentBlock.ID(),
+			0,
+			flow.ZeroID,
+			time.Now(),
+			parentBlock.Header.Height+1,
+			nil,
+			nil,
+			flow.ZeroID,
+			nil),
 		Payload: &flow.Payload{
 			Guarantees: []*flow.CollectionGuarantee{&guarantee},
 		},

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -519,7 +519,7 @@ func Test_OnlyHeadOfTheQueueIsExecuted(t *testing.T) {
 		ctx.executionState.On("StateCommitmentByBlockID", mock.Anything, mock.Anything).Return(nil, storageerr.ErrNotFound)
 
 		ctx.state.On("Sealed").Return(ctx.snapshot)
-		ctx.snapshot.On("Head").Return(&blockA, nil)
+		ctx.snapshot.On("Head").Return(blockA, nil)
 
 		wgB := sync.WaitGroup{}
 		wgB.Add(1)
@@ -633,7 +633,7 @@ func TestBlocksArentExecutedMultipleTimes_multipleBlockEnqueue(t *testing.T) {
 		ctx.mockStateCommitsWithMap(commits)
 
 		ctx.state.On("Sealed").Return(ctx.snapshot)
-		ctx.snapshot.On("Head").Return(&blockA, nil)
+		ctx.snapshot.On("Head").Return(blockA, nil)
 
 		// wait finishing execution until all the blocks are sent to execution
 		wgPut := sync.WaitGroup{}
@@ -759,7 +759,7 @@ func TestBlocksArentExecutedMultipleTimes_collectionArrival(t *testing.T) {
 		ctx.mockSnapshot(blockD.Block.Header, ctx.identities)
 
 		ctx.state.On("Sealed").Return(ctx.snapshot)
-		ctx.snapshot.On("Head").Return(&blockA, nil)
+		ctx.snapshot.On("Head").Return(blockA, nil)
 
 		// wait to control parent (block B) execution until we are ready
 		wgB := sync.WaitGroup{}

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -415,7 +415,7 @@ func TestExecuteOneBlock(t *testing.T) {
 
 		// A <- B
 		blockA := unittest.BlockHeaderFixture()
-		blockB := unittest.ExecutableBlockFixtureWithParent(nil, &blockA)
+		blockB := unittest.ExecutableBlockFixtureWithParent(nil, blockA)
 		blockB.StartState = unittest.StateCommitmentPointerFixture()
 
 		ctx.mockHasWeightAtBlockID(blockA.ID(), true)
@@ -430,7 +430,7 @@ func TestExecuteOneBlock(t *testing.T) {
 		ctx.mockStateCommitsWithMap(commits)
 
 		ctx.state.On("Sealed").Return(ctx.snapshot)
-		ctx.snapshot.On("Head").Return(&blockA, nil)
+		ctx.snapshot.On("Head").Return(blockA, nil)
 
 		ctx.assertSuccessfulBlockComputation(commits, func(blockID flow.Identifier, commit flow.StateCommitment) {
 			wg.Done()
@@ -476,7 +476,7 @@ func Test_OnlyHeadOfTheQueueIsExecuted(t *testing.T) {
 		})
 
 		// last executed block - it will be re-queued regardless of state commit
-		blockB := unittest.ExecutableBlockFixtureWithParent(nil, &blockA)
+		blockB := unittest.ExecutableBlockFixtureWithParent(nil, blockA)
 		blockB.StartState = unittest.StateCommitmentPointerFixture()
 
 		// finalized block - it can be executed in parallel, as blockB has been executed
@@ -611,7 +611,7 @@ func TestBlocksArentExecutedMultipleTimes_multipleBlockEnqueue(t *testing.T) {
 
 		// A <- B <- C
 		blockA := unittest.BlockHeaderFixture()
-		blockB := unittest.ExecutableBlockFixtureWithParent(nil, &blockA)
+		blockB := unittest.ExecutableBlockFixtureWithParent(nil, blockA)
 		blockB.StartState = unittest.StateCommitmentPointerFixture()
 
 		//blockCstartState := unittest.StateCommitmentFixture()
@@ -716,7 +716,7 @@ func TestBlocksArentExecutedMultipleTimes_collectionArrival(t *testing.T) {
 
 		// A (0 collection) <- B (0 collection) <- C (0 collection) <- D (1 collection)
 		blockA := unittest.BlockHeaderFixture()
-		blockB := unittest.ExecutableBlockFixtureWithParent(nil, &blockA)
+		blockB := unittest.ExecutableBlockFixtureWithParent(nil, blockA)
 		blockB.StartState = unittest.StateCommitmentPointerFixture()
 
 		collectionIdentities := ctx.identities.Filter(filter.HasRole(flow.RoleCollection))
@@ -854,7 +854,7 @@ func TestExecuteBlockInOrder(t *testing.T) {
 		blockSealed := unittest.BlockHeaderFixture()
 
 		blocks := make(map[string]*entity.ExecutableBlock)
-		blocks["A"] = unittest.ExecutableBlockFixtureWithParent(nil, &blockSealed)
+		blocks["A"] = unittest.ExecutableBlockFixtureWithParent(nil, blockSealed)
 		blocks["A"].StartState = unittest.StateCommitmentPointerFixture()
 
 		blocks["B"] = unittest.ExecutableBlockFixtureWithParent(nil, blocks["A"].Block.Header)
@@ -880,7 +880,7 @@ func TestExecuteBlockInOrder(t *testing.T) {
 		ctx.mockHasWeightAtBlockID(blocks["A"].ID(), true)
 		ctx.state.On("Sealed").Return(ctx.snapshot)
 		// a receipt for sealed block won't be broadcasted
-		ctx.snapshot.On("Head").Return(&blockSealed, nil)
+		ctx.snapshot.On("Head").Return(blockSealed, nil)
 		ctx.mockSnapshot(blocks["A"].Block.Header, unittest.IdentityListFixture(1))
 		ctx.mockSnapshot(blocks["B"].Block.Header, unittest.IdentityListFixture(1))
 		ctx.mockSnapshot(blocks["C"].Block.Header, unittest.IdentityListFixture(1))
@@ -1062,7 +1062,7 @@ func TestUnauthorizedNodeDoesNotBroadcastReceipts(t *testing.T) {
 		blockSealed := unittest.BlockHeaderFixture()
 
 		blocks := make(map[string]*entity.ExecutableBlock)
-		blocks["A"] = unittest.ExecutableBlockFixtureWithParent(nil, &blockSealed)
+		blocks["A"] = unittest.ExecutableBlockFixtureWithParent(nil, blockSealed)
 		blocks["A"].StartState = unittest.StateCommitmentPointerFixture()
 
 		blocks["B"] = unittest.ExecutableBlockFixtureWithParent(nil, blocks["A"].Block.Header)
@@ -1091,7 +1091,7 @@ func TestUnauthorizedNodeDoesNotBroadcastReceipts(t *testing.T) {
 		// will be executed.
 		ctx.state.On("Sealed").Return(ctx.snapshot)
 		// a receipt for sealed block won't be broadcasted
-		ctx.snapshot.On("Head").Return(&blockSealed, nil)
+		ctx.snapshot.On("Head").Return(blockSealed, nil)
 
 		ctx.mockHasWeightAtBlockID(blocks["A"].ID(), true)
 		identity := *ctx.identity

--- a/engine/verification/assigner/engine_test.go
+++ b/engine/verification/assigner/engine_test.go
@@ -96,7 +96,7 @@ func createContainerBlock(options ...func(result *flow.ExecutionResult, assignme
 	// container block
 	header := unittest.BlockHeaderFixture()
 	block := &flow.Block{
-		Header: &header,
+		Header: header,
 		Payload: &flow.Payload{
 			Receipts: []*flow.ExecutionReceiptMeta{receipt.Meta()},
 			Results:  []*flow.ExecutionResult{&receipt.ExecutionResult},

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -439,7 +439,7 @@ func ExecutionReceiptsFromParentBlockFixture(t *testing.T, parent *flow.Header, 
 func ExecutionResultFromParentBlockFixture(t *testing.T, parent *flow.Header, builder *CompleteExecutionReceiptBuilder) (*flow.ExecutionResult,
 	*ExecutionReceiptData) {
 	refBlkHeader := unittest.BlockHeaderWithParentFixture(parent)
-	return ExecutionResultFixture(t, builder.chunksCount, builder.chain, &refBlkHeader, builder.clusterCommittee)
+	return ExecutionResultFixture(t, builder.chunksCount, builder.chain, refBlkHeader, builder.clusterCommittee)
 }
 
 // ContainerBlockFixture builds and returns a block that contains input execution receipts.

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -410,7 +410,7 @@ func MockLastSealedHeight(state *mockprotocol.State, height uint64) {
 	header := unittest.BlockHeaderFixture()
 	header.Height = height
 	state.On("Sealed").Return(snapshot)
-	snapshot.On("Head").Return(&header, nil)
+	snapshot.On("Head").Return(header, nil)
 }
 
 func NewVerificationHappyPathTest(t *testing.T,

--- a/fvm/blocks_test.go
+++ b/fvm/blocks_test.go
@@ -65,7 +65,7 @@ func Test_BlockFinder_ReturnsHeaderIfSameHeight(t *testing.T) {
 
 		heightFrom, err := blockFinder.ByHeightFrom(0, header5)
 		require.NoError(t, err)
-		require.Equal(t, header0, *heightFrom)
+		require.Equal(t, *header0, *heightFrom)
 	}))
 
 	t.Run("skips heights once it get to finalized chain", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header *flow.Header) {
@@ -78,15 +78,15 @@ func Test_BlockFinder_ReturnsHeaderIfSameHeight(t *testing.T) {
 		header4 := unittest.BlockHeaderWithParentFixture(header3)
 		header5 := unittest.BlockHeaderWithParentFixture(header4)
 
-		headers.On("ByBlockID", header4.ID()).Return(&header4, nil)
+		headers.On("ByBlockID", header4.ID()).Return(header4, nil)
 		headers.On("ByHeight", uint64(4)).Return(nil, storage.ErrNotFound)
-		headers.On("ByBlockID", header3.ID()).Return(&header3, nil)
-		headers.On("ByHeight", uint64(3)).Return(&header3, nil)
-		headers.On("ByHeight", uint64(0)).Return(&header0, nil)
+		headers.On("ByBlockID", header3.ID()).Return(header3, nil)
+		headers.On("ByHeight", uint64(3)).Return(header3, nil)
+		headers.On("ByHeight", uint64(0)).Return(header0, nil)
 
 		heightFrom, err := blockFinder.ByHeightFrom(0, header5)
 		require.NoError(t, err)
-		require.Equal(t, header0, *heightFrom)
+		require.Equal(t, *header0, *heightFrom)
 	}))
 
 }

--- a/fvm/blocks_test.go
+++ b/fvm/blocks_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-func doTest(t *testing.T, f func(*testing.T, *storageMock.Headers, Blocks, flow.Header)) func(*testing.T) {
+func doTest(t *testing.T, f func(*testing.T, *storageMock.Headers, Blocks, *flow.Header)) func(*testing.T) {
 	return func(t *testing.T) {
 
 		headers := new(storageMock.Headers)
@@ -27,56 +27,56 @@ func doTest(t *testing.T, f func(*testing.T, *storageMock.Headers, Blocks, flow.
 
 func Test_BlockFinder_ReturnsHeaderIfSameHeight(t *testing.T) {
 
-	t.Run("returns header is height is the same", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header flow.Header) {
-		heightFrom, err := blockFinder.ByHeightFrom(10, &header)
+	t.Run("returns header is height is the same", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header *flow.Header) {
+		heightFrom, err := blockFinder.ByHeightFrom(10, header)
 		require.NoError(t, err)
-		require.Equal(t, header, *heightFrom)
+		require.Equal(t, *header, *heightFrom)
 	}))
 
-	t.Run("nil header defaults to ByHeight", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header flow.Header) {
+	t.Run("nil header defaults to ByHeight", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header *flow.Header) {
 
-		headers.On("ByHeight", uint64(10)).Return(&header, nil)
+		headers.On("ByHeight", uint64(10)).Return(header, nil)
 
 		heightFrom, err := blockFinder.ByHeightFrom(10, nil)
 		require.NoError(t, err)
-		require.Equal(t, header, *heightFrom)
+		require.Equal(t, *header, *heightFrom)
 	}))
 
-	t.Run("follows blocks chain", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header flow.Header) {
+	t.Run("follows blocks chain", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header *flow.Header) {
 
 		header0 := unittest.BlockHeaderFixture()
 		header0.Height = 0
-		header1 := unittest.BlockHeaderWithParentFixture(&header0)
-		header2 := unittest.BlockHeaderWithParentFixture(&header1)
-		header3 := unittest.BlockHeaderWithParentFixture(&header2)
-		header4 := unittest.BlockHeaderWithParentFixture(&header3)
-		header5 := unittest.BlockHeaderWithParentFixture(&header4)
+		header1 := unittest.BlockHeaderWithParentFixture(header0)
+		header2 := unittest.BlockHeaderWithParentFixture(header1)
+		header3 := unittest.BlockHeaderWithParentFixture(header2)
+		header4 := unittest.BlockHeaderWithParentFixture(header3)
+		header5 := unittest.BlockHeaderWithParentFixture(header4)
 
-		headers.On("ByBlockID", header4.ID()).Return(&header4, nil)
+		headers.On("ByBlockID", header4.ID()).Return(header4, nil)
 		headers.On("ByHeight", uint64(4)).Return(nil, storage.ErrNotFound)
-		headers.On("ByBlockID", header3.ID()).Return(&header3, nil)
+		headers.On("ByBlockID", header3.ID()).Return(header3, nil)
 		headers.On("ByHeight", uint64(3)).Return(nil, storage.ErrNotFound)
-		headers.On("ByBlockID", header2.ID()).Return(&header2, nil)
+		headers.On("ByBlockID", header2.ID()).Return(header2, nil)
 		headers.On("ByHeight", uint64(2)).Return(nil, storage.ErrNotFound)
-		headers.On("ByBlockID", header1.ID()).Return(&header1, nil)
+		headers.On("ByBlockID", header1.ID()).Return(header1, nil)
 		headers.On("ByHeight", uint64(1)).Return(nil, storage.ErrNotFound)
-		headers.On("ByBlockID", header0.ID()).Return(&header0, nil)
+		headers.On("ByBlockID", header0.ID()).Return(header0, nil)
 		//headers.On("ByHeight", uint64(0)).Return(nil, storage.ErrNotFound)
 
-		heightFrom, err := blockFinder.ByHeightFrom(0, &header5)
+		heightFrom, err := blockFinder.ByHeightFrom(0, header5)
 		require.NoError(t, err)
 		require.Equal(t, header0, *heightFrom)
 	}))
 
-	t.Run("skips heights once it get to finalized chain", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header flow.Header) {
+	t.Run("skips heights once it get to finalized chain", doTest(t, func(t *testing.T, headers *storageMock.Headers, blockFinder Blocks, header *flow.Header) {
 
 		header0 := unittest.BlockHeaderFixture()
 		header0.Height = 0
-		header1 := unittest.BlockHeaderWithParentFixture(&header0)
-		header2 := unittest.BlockHeaderWithParentFixture(&header1)
-		header3 := unittest.BlockHeaderWithParentFixture(&header2)
-		header4 := unittest.BlockHeaderWithParentFixture(&header3)
-		header5 := unittest.BlockHeaderWithParentFixture(&header4)
+		header1 := unittest.BlockHeaderWithParentFixture(header0)
+		header2 := unittest.BlockHeaderWithParentFixture(header1)
+		header3 := unittest.BlockHeaderWithParentFixture(header2)
+		header4 := unittest.BlockHeaderWithParentFixture(header3)
+		header5 := unittest.BlockHeaderWithParentFixture(header4)
 
 		headers.On("ByBlockID", header4.ID()).Return(&header4, nil)
 		headers.On("ByHeight", uint64(4)).Return(nil, storage.ErrNotFound)
@@ -84,7 +84,7 @@ func Test_BlockFinder_ReturnsHeaderIfSameHeight(t *testing.T) {
 		headers.On("ByHeight", uint64(3)).Return(&header3, nil)
 		headers.On("ByHeight", uint64(0)).Return(&header0, nil)
 
-		heightFrom, err := blockFinder.ByHeightFrom(0, &header5)
+		heightFrom, err := blockFinder.ByHeightFrom(0, header5)
 		require.NoError(t, err)
 		require.Equal(t, header0, *heightFrom)
 	}))

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 
@@ -1551,12 +1552,22 @@ func TestBlockContext_UnsafeRandom(t *testing.T) {
 
 	chain, vm := createChainAndVm(flow.Mainnet)
 
-	header := flow.Header{Height: 42}
+	header := flow.NewHeader(
+		"",
+		flow.ZeroID,
+		42,
+		flow.ZeroID,
+		time.Time{},
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	ctx := fvm.NewContext(
 		zerolog.Nop(),
 		fvm.WithChain(chain),
-		fvm.WithBlockHeader(&header),
+		fvm.WithBlockHeader(header),
 		fvm.WithCadenceLogging(true),
 	)
 

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -285,7 +285,7 @@ func TestSafetyCheck(t *testing.T) {
 
 		view := utils.NewSimpleView()
 		header := unittest.BlockHeaderFixture()
-		context := fvm.NewContext(log, fvm.WithBlockHeader(&header))
+		context := fvm.NewContext(log, fvm.WithBlockHeader(header))
 
 		sth := state.NewStateHolder(state.NewState(view))
 

--- a/integration/dkg/dkg_emulator_test.go
+++ b/integration/dkg/dkg_emulator_test.go
@@ -63,7 +63,17 @@ func (s *DKGSuite) runTest(goodNodes int, emulatorProblems bool) {
 		FinalView:    600,
 	}
 
-	firstBlock := &flow.Header{View: 100}
+	firstBlock := flow.NewHeader(
+		"",
+		flow.ZeroID,
+		0,
+		flow.ZeroID,
+		time.Time{},
+		100,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	for _, node := range nodes {
 		node.setEpochs(s.T(), currentEpochSetup, nextEpochSetup, firstBlock)

--- a/integration/dkg/dkg_whiteboard_test.go
+++ b/integration/dkg/dkg_whiteboard_test.go
@@ -209,7 +209,17 @@ func TestWithWhiteboard(t *testing.T) {
 	blocks := make(map[uint64]*flow.Header)
 	var view uint64
 	for view = 100; view <= 250; view += dkgeng.DefaultPollStep {
-		blocks[view] = &flow.Header{View: view}
+		blocks[view] = flow.NewHeader(
+			"",
+			flow.ZeroID,
+			0,
+			flow.ZeroID,
+			time.Time{},
+			view,
+			nil,
+			nil,
+			flow.ZeroID,
+			nil)
 	}
 	firstBlock := blocks[100]
 

--- a/model/cluster/block.go
+++ b/model/cluster/block.go
@@ -7,12 +7,17 @@ import (
 )
 
 func Genesis() *Block {
-	header := &flow.Header{
-		View:      0,
-		ChainID:   "cluster",
-		Timestamp: flow.GenesisTime,
-		ParentID:  flow.ZeroID,
-	}
+	header := flow.NewHeader(
+		"cluster",
+		flow.ZeroID,
+		0,
+		flow.ZeroID,
+		flow.GenesisTime,
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	payload := EmptyPayload(flow.ZeroID)
 

--- a/model/flow/header.go
+++ b/model/flow/header.go
@@ -43,6 +43,32 @@ type Header struct {
 	// signature since the data represents cryptographic signatures serialized in some way (concatenation or other)
 }
 
+func NewHeader(
+	chainID ChainID,
+	parentID Identifier,
+	height uint64,
+	payloadHash Identifier,
+	timestamp time.Time,
+	view uint64,
+	parentVoterIndices []byte,
+	parentVoterSigData []byte,
+	proposerID Identifier,
+	proposerSigData []byte) *Header {
+
+	return &Header{
+		ChainID:            chainID,
+		ParentID:           parentID,
+		Height:             height,
+		PayloadHash:        payloadHash,
+		Timestamp:          timestamp,
+		View:               view,
+		ParentVoterIndices: parentVoterIndices,
+		ParentVoterSigData: parentVoterSigData,
+		ProposerID:         proposerID,
+		ProposerSigData:    proposerSigData,
+	}
+}
+
 // Body returns the immutable part of the block header.
 func (h Header) Body() interface{} {
 	return struct {

--- a/model/flow/header_test.go
+++ b/model/flow/header_test.go
@@ -45,22 +45,22 @@ func TestHeaderFingerprint(t *testing.T) {
 		ProposerID         flow.Identifier
 	}
 	rlp.NewMarshaler().MustUnmarshal(data, &decoded)
-	decHeader := flow.Header{
-		ChainID:            decoded.ChainID,
-		ParentID:           decoded.ParentID,
-		Height:             decoded.Height,
-		PayloadHash:        decoded.PayloadHash,
-		Timestamp:          time.Unix(0, int64(decoded.Timestamp)).UTC(),
-		View:               decoded.View,
-		ParentVoterIndices: decoded.ParentVoterIndices,
-		ParentVoterSigData: decoded.ParentVoterSigData,
-		ProposerID:         decoded.ProposerID,
-		ProposerSigData:    header.ProposerSigData, // since this field is not encoded/decoded, just set it to the original
+	decHeader := flow.NewHeader(
+		decoded.ChainID,
+		decoded.ParentID,
+		decoded.Height,
+		decoded.PayloadHash,
+		time.Unix(0, int64(decoded.Timestamp)).UTC(),
+		decoded.View,
+		decoded.ParentVoterIndices,
+		decoded.ParentVoterSigData,
+		decoded.ProposerID,
+		// since this field is not encoded/decoded, just set it to the original
 		// value to pass test
-	}
+		header.ProposerSigData)
 	decodedID := decHeader.ID()
 	assert.Equal(t, headerID, decodedID)
-	assert.Equal(t, header, decHeader)
+	assert.Equal(t, header, *decHeader)
 }
 
 func TestHeaderEncodingMsgpack(t *testing.T) {

--- a/model/flow/header_test.go
+++ b/model/flow/header_test.go
@@ -26,7 +26,7 @@ func TestHeaderEncodingJSON(t *testing.T) {
 	require.NoError(t, err)
 	decodedID := decoded.ID()
 	assert.Equal(t, headerID, decodedID)
-	assert.Equal(t, header, decoded)
+	assert.Equal(t, *header, decoded)
 }
 
 func TestHeaderFingerprint(t *testing.T) {
@@ -60,7 +60,7 @@ func TestHeaderFingerprint(t *testing.T) {
 		header.ProposerSigData)
 	decodedID := decHeader.ID()
 	assert.Equal(t, headerID, decodedID)
-	assert.Equal(t, header, *decHeader)
+	assert.Equal(t, *header, *decHeader)
 }
 
 func TestHeaderEncodingMsgpack(t *testing.T) {
@@ -73,7 +73,7 @@ func TestHeaderEncodingMsgpack(t *testing.T) {
 	require.NoError(t, err)
 	decodedID := decoded.ID()
 	assert.Equal(t, headerID, decodedID)
-	assert.Equal(t, header, decoded)
+	assert.Equal(t, *header, decoded)
 }
 
 func TestHeaderEncodingCBOR(t *testing.T) {
@@ -86,7 +86,7 @@ func TestHeaderEncodingCBOR(t *testing.T) {
 	require.NoError(t, err)
 	decodedID := decoded.ID()
 	assert.Equal(t, headerID, decodedID)
-	assert.Equal(t, header, decoded)
+	assert.Equal(t, *header, decoded)
 }
 
 func TestNonUTCTimestampSameHashAsUTC(t *testing.T) {

--- a/module/buffer/backend_test.go
+++ b/module/buffer/backend_test.go
@@ -25,13 +25,13 @@ func (suite *BackendSuite) SetupTest() {
 
 func (suite *BackendSuite) Item() *item {
 	parent := unittest.BlockHeaderFixture()
-	return suite.ItemWithParent(&parent)
+	return suite.ItemWithParent(parent)
 }
 
 func (suite *BackendSuite) ItemWithParent(parent *flow.Header) *item {
 	header := unittest.BlockHeaderWithParentFixture(parent)
 	return &item{
-		header:   &header,
+		header:   header,
 		payload:  unittest.IdentifierFixture(),
 		originID: unittest.IdentifierFixture(),
 	}

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -298,25 +298,29 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	// build the payload from the transactions
 	payload := cluster.PayloadFromTransactions(minRefID, transactions...)
 
-	header := flow.Header{
-		ChainID:     parent.ChainID,
-		ParentID:    parentID,
-		Height:      parent.Height + 1,
-		PayloadHash: payload.Hash(),
-		Timestamp:   time.Now().UTC(),
+	header := flow.NewHeader(
+		parent.ChainID,
+		parentID,
+		parent.Height+1,
+		payload.Hash(),
+		time.Now().UTC(),
 
 		// NOTE: we rely on the HotStuff-provided setter to set the other
 		// fields, which are related to signatures and HotStuff internals
-	}
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	// set fields specific to the consensus algorithm
-	err = setter(&header)
+	err = setter(header)
 	if err != nil {
 		return nil, fmt.Errorf("could not set fields to header: %w", err)
 	}
 
 	proposal = cluster.Block{
-		Header:  &header,
+		Header:  header,
 		Payload: &payload,
 	}
 

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -621,22 +621,21 @@ func (b *Builder) createProposal(parentID flow.Identifier,
 	timestamp := b.cfg.blockTimer.Build(parent.Timestamp)
 
 	// construct default block on top of the provided parent
-	header := &flow.Header{
-		ChainID:     parent.ChainID,
-		ParentID:    parentID,
-		Height:      parent.Height + 1,
-		Timestamp:   timestamp,
-		PayloadHash: payload.Hash(),
+	header := flow.NewHeader(
+		parent.ChainID,
+		parentID,
+		parent.Height+1,
+		payload.Hash(),
+		timestamp,
 
 		// the following fields should be set by the custom function as needed
 		// NOTE: we could abstract all of this away into an interface{} field,
 		// but that would be over the top as we will probably always use hotstuff
-		View:               0,
-		ParentVoterIndices: nil,
-		ParentVoterSigData: nil,
-		ProposerID:         flow.ZeroID,
-		ProposerSigData:    nil,
-	}
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	// apply the custom fields setter of the consensus algorithm
 	err = setter(header)

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -498,7 +498,7 @@ func (bs *BuilderSuite) TestPayloadGuaranteeReferenceExpired() {
 	// create 4 expired guarantees
 	header := unittest.BlockHeaderFixture()
 	header.Height = bs.headers[bs.finalID].Height - 12
-	bs.headers[header.ID()] = &header
+	bs.headers[header.ID()] = header
 	expired := unittest.CollectionGuaranteesFixture(4, unittest.WithCollRef(header.ID()))
 
 	// add all guarantees to the pool

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -245,7 +245,7 @@ func GetBaselineVerifiableChunk(t *testing.T, script string, system bool) *verif
 	header := unittest.BlockHeaderFixture()
 	header.PayloadHash = payload.Hash()
 	block := flow.Block{
-		Header:  &header,
+		Header:  header,
 		Payload: &payload,
 	}
 	blockID := block.ID()
@@ -354,7 +354,7 @@ func GetBaselineVerifiableChunk(t *testing.T, script string, system bool) *verif
 	verifiableChunkData = verification.VerifiableChunkData{
 		IsSystemChunk: system,
 		Chunk:         &chunk,
-		Header:        &header,
+		Header:        header,
 		Result:        &result,
 		ChunkDataPack: &chunkDataPack,
 		EndState:      flow.StateCommitment(endState),

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -57,7 +57,7 @@ func TestFinalizer(t *testing.T) {
 			require.NoError(t, err)
 			state, err = cluster.Bootstrap(db, stateRoot)
 			require.NoError(t, err)
-			err = db.Update(operation.InsertHeader(refBlock.ID(), &refBlock))
+			err = db.Update(operation.InsertHeader(refBlock.ID(), refBlock))
 			require.NoError(t, err)
 		}
 

--- a/module/finalizer/consensus/finalizer_test.go
+++ b/module/finalizer/consensus/finalizer_test.go
@@ -49,15 +49,15 @@ func TestMakeFinalValidChain(t *testing.T) {
 	final.Height = uint64(rand.Uint32())
 
 	// generate a couple of children that are pending
-	parent := &final
+	parent := final
 	var pending []*flow.Header
 	total := 8
 	for i := 0; i < total; i++ {
 		header := unittest.BlockHeaderFixture()
 		header.Height = parent.Height + 1
 		header.ParentID = parent.ID()
-		pending = append(pending, &header)
-		parent = &header
+		pending = append(pending, header)
+		parent = header
 	}
 
 	// create a mock protocol state to check finalize calls
@@ -85,7 +85,7 @@ func TestMakeFinalValidChain(t *testing.T) {
 		require.NoError(t, err)
 
 		// insert the finalized block header into the DB
-		err = db.Update(operation.InsertHeader(final.ID(), &final))
+		err = db.Update(operation.InsertHeader(final.ID(), final))
 		require.NoError(t, err)
 
 		// insert all of the pending blocks into the DB
@@ -143,11 +143,11 @@ func TestMakeFinalInvalidHeight(t *testing.T) {
 		require.NoError(t, err)
 
 		// insert the finalized block header into the DB
-		err = db.Update(operation.InsertHeader(final.ID(), &final))
+		err = db.Update(operation.InsertHeader(final.ID(), final))
 		require.NoError(t, err)
 
 		// insert all of the pending header into DB
-		err = db.Update(operation.InsertHeader(pending.ID(), &pending))
+		err = db.Update(operation.InsertHeader(pending.ID(), pending))
 		require.NoError(t, err)
 
 		// initialize the finalizer with the dependencies and make the call
@@ -195,7 +195,7 @@ func TestMakeFinalDuplicate(t *testing.T) {
 		require.NoError(t, err)
 
 		// insert the finalized block header into the DB
-		err = db.Update(operation.InsertHeader(final.ID(), &final))
+		err = db.Update(operation.InsertHeader(final.ID(), final))
 		require.NoError(t, err)
 
 		// initialize the finalizer with the dependencies and make the call

--- a/module/jobqueue/jobs_test.go
+++ b/module/jobqueue/jobs_test.go
@@ -46,7 +46,7 @@ func TestBlockJob(t *testing.T) {
 
 func TestBlockHeaderJob(t *testing.T) {
 	block := unittest.BlockHeaderFixture()
-	job := jobqueue.BlockHeaderToJob(&block)
+	job := jobqueue.BlockHeaderToJob(block)
 
 	t.Run("job is correct type", func(t *testing.T) {
 		assert.IsType(t, &jobqueue.BlockHeaderJob{}, job, "job is not a block job")

--- a/module/jobqueue/jobs_test.go
+++ b/module/jobqueue/jobs_test.go
@@ -60,7 +60,7 @@ func TestBlockHeaderJob(t *testing.T) {
 	t.Run("job converts to header", func(t *testing.T) {
 		b, err := jobqueue.JobToBlockHeader(job)
 		assert.NoError(t, err, "unexpected error converting notify job to header")
-		assert.Equal(t, block, *b, "converted header is not the same as the original header")
+		assert.Equal(t, *block, *b, "converted header is not the same as the original header")
 	})
 
 	t.Run("incorrect job type fails to convert to header", func(t *testing.T) {

--- a/module/state_synchronization/execution_data_cid_cache_test.go
+++ b/module/state_synchronization/execution_data_cid_cache_test.go
@@ -17,7 +17,7 @@ func TestCacheHit(t *testing.T) {
 	header := unittest.BlockHeaderFixture()
 	var blobTree state_synchronization.BlobTree
 	blobTree = append(blobTree, []cid.Cid{unittest.CidFixture(), unittest.CidFixture()}, []cid.Cid{unittest.CidFixture()})
-	cache.Insert(&header, blobTree)
+	cache.Insert(header, blobTree)
 
 	for height, cids := range blobTree {
 		for index, cid := range cids {
@@ -47,10 +47,10 @@ func TestCacheEviction(t *testing.T) {
 
 	for i := uint(0); i < 2*size; i++ {
 		header := unittest.BlockHeaderFixture()
-		headers = append(headers, &header)
+		headers = append(headers, header)
 		root := unittest.CidFixture()
 		cids = append(cids, root)
-		cache.Insert(&header, [][]cid.Cid{{root}})
+		cache.Insert(header, [][]cid.Cid{{root}})
 
 		expectedSize := i + 1
 		if expectedSize > size {
@@ -86,8 +86,8 @@ func TestDuplicateCID(t *testing.T) {
 	header1 := unittest.BlockHeaderFixture()
 	header2 := unittest.BlockHeaderFixture()
 
-	cache.Insert(&header1, [][]cid.Cid{{c}})
-	cache.Insert(&header2, [][]cid.Cid{{c}})
+	cache.Insert(header1, [][]cid.Cid{{c}})
+	cache.Insert(header2, [][]cid.Cid{{c}})
 
 	assert.Equal(t, cache.BlobRecords(), uint(1))
 	assert.Equal(t, cache.BlobTreeRecords(), uint(2))
@@ -117,9 +117,9 @@ func TestCacheEvictionWithDuplicateCID(t *testing.T) {
 	var blobTree3 state_synchronization.BlobTree
 	blobTree3 = append(blobTree3, []cid.Cid{unittest.CidFixture()})
 
-	cache.Insert(&header1, blobTree1)
-	cache.Insert(&header2, blobTree2)
-	cache.Insert(&header3, blobTree3)
+	cache.Insert(header1, blobTree1)
+	cache.Insert(header2, blobTree2)
+	cache.Insert(header3, blobTree3)
 
 	assert.Equal(t, cache.BlobRecords(), uint(2))
 	assert.Equal(t, cache.BlobTreeRecords(), uint(2))

--- a/module/state_synchronization/requester/jobs/execution_data_reader_test.go
+++ b/module/state_synchronization/requester/jobs/execution_data_reader_test.go
@@ -51,7 +51,7 @@ func (suite *ExecutionDataReaderSuite) SetupTest() {
 	suite.executionDataID = unittest.IdentifierFixture()
 
 	parent := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(1))
-	suite.block = unittest.BlockWithParentFixture(&parent)
+	suite.block = unittest.BlockWithParentFixture(parent)
 	suite.blocksByHeight = map[uint64]*flow.Block{
 		suite.block.Header.Height: suite.block,
 	}

--- a/module/synchronization/core_rapid_test.go
+++ b/module/synchronization/core_rapid_test.go
@@ -21,8 +21,8 @@ const NUM_BLOCKS int = 100
 
 // This returns a forest of blocks, some of which are in a parent relationship
 // It should include forks
-func populatedBlockStore(t *rapid.T) []flow.Header {
-	store := []flow.Header{unittest.BlockHeaderFixture()}
+func populatedBlockStore(t *rapid.T) []*flow.Header {
+	store := []*flow.Header{unittest.BlockHeaderFixture()}
 	for i := 1; i < NUM_BLOCKS; i++ {
 		// we sample from the store 2/3 times to get deeper trees
 		b := rapid.OneOf(rapid.Just(unittest.BlockHeaderFixture()), rapid.SampledFrom(store), rapid.SampledFrom(store)).Draw(t, "parent").(flow.Header)
@@ -32,7 +32,7 @@ func populatedBlockStore(t *rapid.T) []flow.Header {
 }
 
 type rapidSync struct {
-	store          []flow.Header
+	store          []*flow.Header
 	core           *Core
 	idRequests     map[flow.Identifier]bool // depth 1 pushdown automaton to track ID requests
 	heightRequests map[uint64]bool          // depth 1 pushdown automaton to track height requests
@@ -52,7 +52,7 @@ func (r *rapidSync) Init(t *rapid.T) {
 
 // RequestByID is an action that requests a block by its ID.
 func (r *rapidSync) RequestByID(t *rapid.T) {
-	b := rapid.SampledFrom(r.store).Draw(t, "id_request").(flow.Header)
+	b := rapid.SampledFrom(r.store).Draw(t, "id_request").(*flow.Header)
 	r.core.RequestBlock(b.ID(), b.Height)
 	// Re-queueing by ID should always succeed
 	r.idRequests[b.ID()] = true
@@ -62,7 +62,7 @@ func (r *rapidSync) RequestByID(t *rapid.T) {
 
 // RequestByHeight is an action that requests a specific height
 func (r *rapidSync) RequestByHeight(t *rapid.T) {
-	b := rapid.SampledFrom(r.store).Draw(t, "height_request").(flow.Header)
+	b := rapid.SampledFrom(r.store).Draw(t, "height_request").(*flow.Header)
 	r.core.RequestHeight(b.Height)
 	// Re-queueing by height should always succeed
 	r.heightRequests[b.Height] = true
@@ -71,10 +71,10 @@ func (r *rapidSync) RequestByHeight(t *rapid.T) {
 // HandleHeight is an action that requests a heights
 // upon receiving an argument beyond a certain tolerance
 func (r *rapidSync) HandleHeight(t *rapid.T) {
-	b := rapid.SampledFrom(r.store).Draw(t, "height_hint_request").(flow.Header)
+	b := rapid.SampledFrom(r.store).Draw(t, "height_hint_request").(*flow.Header)
 	incr := rapid.IntRange(0, (int)(DefaultConfig().Tolerance)+1).Draw(t, "height increment").(int)
 	requestHeight := b.Height + (uint64)(incr)
-	r.core.HandleHeight(&b, requestHeight)
+	r.core.HandleHeight(b, requestHeight)
 	// Re-queueing by height should always succeed if beyond tolerance
 	if (uint)(incr) > DefaultConfig().Tolerance {
 		for h := b.Height + 1; h <= requestHeight; h++ {
@@ -85,8 +85,8 @@ func (r *rapidSync) HandleHeight(t *rapid.T) {
 
 // HandleByID is an action that provides a block header to the sync engine
 func (r *rapidSync) HandleByID(t *rapid.T) {
-	b := rapid.SampledFrom(r.store).Draw(t, "id_handling").(flow.Header)
-	success := r.core.HandleBlock(&b)
+	b := rapid.SampledFrom(r.store).Draw(t, "id_handling").(*flow.Header)
+	success := r.core.HandleBlock(b)
 	assert.True(t, success || r.idRequests[b.ID()] == false)
 
 	// we decrease the pending requests iff we have already requested this block
@@ -101,15 +101,15 @@ func (r *rapidSync) HandleByID(t *rapid.T) {
 // Check runs after every action and verifies that all required invariants hold.
 func (r *rapidSync) Check(t *rapid.T) {
 	// we collect the received blocks as determined above
-	var receivedBlocks []flow.Header
+	var receivedBlocks []*flow.Header
 	// we also collect the pending blocks
-	var activeBlocks []flow.Header
+	var activeBlocks []*flow.Header
 
 	// we check the validity of our pushdown automaton for ID requests and populate activeBlocks / receivedBlocks
 	for id, requested := range r.idRequests {
 		s, foundID := r.core.blockIDs[id]
 
-		block, foundBlock := findHeader(r.store, func(h flow.Header) bool {
+		block, foundBlock := findHeader(r.store, func(h *flow.Header) bool {
 			return h.ID() == id
 		})
 		require.True(t, foundBlock, "incorrect management of idRequests in the tests: all added IDs are supposed to be from the store")
@@ -119,12 +119,12 @@ func (r *rapidSync) Check(t *rapid.T) {
 
 			assert.True(t, s.WasQueued(), "ID %v was expected to be Queued and is %v", id, s.StatusString())
 			assert.False(t, s.WasReceived(), "ID %v was expected to be Queued and is %v", id, s.StatusString())
-			activeBlocks = append(activeBlocks, *block)
+			activeBlocks = append(activeBlocks, block)
 		} else {
 			if foundID {
 				// if a block is known with 0 pendings, it's because it was received
 				assert.True(t, s.WasReceived(), "ID %v was expected to be Received and is %v", id, s.StatusString())
-				receivedBlocks = append(receivedBlocks, *block)
+				receivedBlocks = append(receivedBlocks, block)
 			}
 		}
 	}
@@ -147,10 +147,10 @@ func (r *rapidSync) Check(t *rapid.T) {
 			// - or because a request for a block at that height made us "forget" the prior height reception (clobberedByID)
 			if ok {
 				wasReceived := s.WasReceived()
-				_, blockAtHeightWasReceived := findHeader(receivedBlocks, func(header flow.Header) bool {
+				_, blockAtHeightWasReceived := findHeader(receivedBlocks, func(header *flow.Header) bool {
 					return header.Height == h
 				})
-				_, clobberedByID := findHeader(activeBlocks, func(header flow.Header) bool {
+				_, clobberedByID := findHeader(activeBlocks, func(header *flow.Header) bool {
 					return header.Height == h
 				})
 				heightWasCanceled := wasReceived || blockAtHeightWasReceived || clobberedByID
@@ -178,10 +178,10 @@ func TestRapidSync(t *testing.T) {
 }
 
 // utility functions
-func findHeader(store []flow.Header, predicate func(flow.Header) bool) (*flow.Header, bool) {
+func findHeader(store []*flow.Header, predicate func(*flow.Header) bool) (*flow.Header, bool) {
 	for _, b := range store {
 		if predicate(b) {
-			return &b, true
+			return b, true
 		}
 	}
 	return nil, false

--- a/module/synchronization/core_test.go
+++ b/module/synchronization/core_test.go
@@ -153,29 +153,29 @@ func (ss *SyncSuite) TestHandleBlock() {
 	requestedByID := unittest.BlockHeaderFixture()
 	ss.core.blockIDs[requestedByID.ID()] = ss.RequestedStatus()
 	received := unittest.BlockHeaderFixture()
-	ss.core.heights[received.Height] = ss.ReceivedStatus(&received)
-	ss.core.blockIDs[received.ID()] = ss.ReceivedStatus(&received)
+	ss.core.heights[received.Height] = ss.ReceivedStatus(received)
+	ss.core.blockIDs[received.ID()] = ss.ReceivedStatus(received)
 
 	// should ignore un-requested blocks
-	shouldProcess := ss.core.HandleBlock(&unrequested)
+	shouldProcess := ss.core.HandleBlock(unrequested)
 	ss.Assert().False(shouldProcess, "should not process un-requested block")
 	ss.Assert().NotContains(ss.core.heights, unrequested.Height)
 	ss.Assert().NotContains(ss.core.blockIDs, unrequested.ID())
 
 	// should mark queued blocks as received, and process them
-	shouldProcess = ss.core.HandleBlock(&queuedByHeight)
+	shouldProcess = ss.core.HandleBlock(queuedByHeight)
 	ss.Assert().True(shouldProcess, "should process queued block")
 	ss.Assert().True(ss.core.blockIDs[queuedByHeight.ID()].WasReceived(), "status should be reflected in block ID map")
 	ss.Assert().True(ss.core.heights[queuedByHeight.Height].WasReceived(), "status should be reflected in height map")
 
 	// should mark requested block as received, and process them
-	shouldProcess = ss.core.HandleBlock(&requestedByID)
+	shouldProcess = ss.core.HandleBlock(requestedByID)
 	ss.Assert().True(shouldProcess, "should process requested block")
 	ss.Assert().True(ss.core.blockIDs[requestedByID.ID()].WasReceived(), "status should be reflected in block ID map")
 	ss.Assert().True(ss.core.heights[requestedByID.Height].WasReceived(), "status should be reflected in height map")
 
 	// should leave received blocks, and not process them
-	shouldProcess = ss.core.HandleBlock(&received)
+	shouldProcess = ss.core.HandleBlock(received)
 	ss.Assert().False(shouldProcess, "should not process already received block")
 	ss.Assert().True(ss.core.blockIDs[received.ID()].WasReceived(), "status should remain reflected in block ID map")
 	ss.Assert().True(ss.core.heights[received.Height].WasReceived(), "status should remain reflected in height map")
@@ -189,15 +189,15 @@ func (ss *SyncSuite) TestHandleHeight() {
 	aboveOutsideTolerance := final.Height + uint64(ss.core.Config.Tolerance+1)
 
 	// a height lower than finalized should be a no-op
-	ss.core.HandleHeight(&final, lower)
+	ss.core.HandleHeight(final, lower)
 	ss.Assert().Len(ss.core.heights, 0)
 
 	// a height higher than finalized, but within tolerance, should be a no-op
-	ss.core.HandleHeight(&final, aboveWithinTolerance)
+	ss.core.HandleHeight(final, aboveWithinTolerance)
 	ss.Assert().Len(ss.core.heights, 0)
 
 	// a height higher than finalized and outside tolerance should queue missing heights
-	ss.core.HandleHeight(&final, aboveOutsideTolerance)
+	ss.core.HandleHeight(final, aboveOutsideTolerance)
 	ss.Assert().Len(ss.core.heights, int(aboveOutsideTolerance-final.Height))
 	for height := final.Height + 1; height <= aboveOutsideTolerance; height++ {
 		ss.Assert().Contains(ss.core.heights, height)
@@ -433,7 +433,7 @@ func (ss *SyncSuite) TestPrune() {
 	blockIDsBefore := len(ss.core.blockIDs)
 
 	// prune the pending requests
-	ss.core.prune(&final)
+	ss.core.prune(final)
 
 	assert.Equal(ss.T(), heightsBefore-len(prunableHeights), len(ss.core.heights))
 	assert.Equal(ss.T(), blockIDsBefore-len(prunableBlockIDs), len(ss.core.blockIDs))

--- a/network/p2p/topic_validator_test.go
+++ b/network/p2p/topic_validator_test.go
@@ -81,7 +81,7 @@ func TestTopicValidator_Unstaked(t *testing.T) {
 	defer cancel5s()
 	// create a dummy block proposal to publish from our SN node
 	header := unittest.BlockHeaderFixture()
-	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: &header})
+	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: header})
 
 	err = sn2.Publish(timedCtx, topic, data1)
 	require.NoError(t, err)
@@ -224,7 +224,7 @@ func TestAuthorizedSenderValidator_Unauthorized(t *testing.T) {
 	defer cancel5s()
 	// create a dummy block proposal to publish from our SN node
 	header := unittest.BlockHeaderFixture()
-	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: &header})
+	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: header})
 
 	// sn2 publishes the block proposal, sn1 and an1 should receive the message because
 	// SN nodes are authorized to send block proposals
@@ -243,7 +243,7 @@ func TestAuthorizedSenderValidator_Unauthorized(t *testing.T) {
 	timedCtx, cancel2s := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel2s()
 	header = unittest.BlockHeaderFixture()
-	data2 := getMsgFixtureBz(t, &messages.BlockProposal{Header: &header})
+	data2 := getMsgFixtureBz(t, &messages.BlockProposal{Header: header})
 
 	// the access node now publishes the block proposal message, AN are not authorized to publish block proposals
 	// the message should be rejected by the topic validator on sn1
@@ -325,7 +325,7 @@ func TestAuthorizedSenderValidator_InvalidMsg(t *testing.T) {
 	defer cancel5s()
 	// create a dummy block proposal to publish from our SN node
 	header := unittest.BlockHeaderFixture()
-	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: &header})
+	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: header})
 
 	// sn2 publishes the block proposal on the sync committee channel
 	err = sn2.Publish(timedCtx, topic, data1)
@@ -404,7 +404,7 @@ func TestAuthorizedSenderValidator_Ejected(t *testing.T) {
 	defer cancel5s()
 	// create a dummy block proposal to publish from our SN node
 	header := unittest.BlockHeaderFixture()
-	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: &header})
+	data1 := getMsgFixtureBz(t, &messages.BlockProposal{Header: header})
 
 	// sn2 publishes the block proposal, sn1 and an1 should receive the message because
 	// SN nodes are authorized to send block proposals
@@ -424,7 +424,7 @@ func TestAuthorizedSenderValidator_Ejected(t *testing.T) {
 	// "eject" sn2 to ensure messages published by ejected nodes get rejected
 	identity2.Ejected = true
 	header = unittest.BlockHeaderFixture()
-	data3 := getMsgFixtureBz(t, &messages.BlockProposal{Header: &header})
+	data3 := getMsgFixtureBz(t, &messages.BlockProposal{Header: header})
 	timedCtx, cancel2s := context.WithTimeout(context.Background(), time.Second)
 	defer cancel2s()
 	err = sn2.Publish(timedCtx, topic, data3)

--- a/state/cluster/root_block.go
+++ b/state/cluster/root_block.go
@@ -22,18 +22,17 @@ var rootBlockPayloadHash = rootBlockPayload.Hash()
 func CanonicalRootBlock(epoch uint64, participants flow.IdentityList) *cluster.Block {
 	chainID := CanonicalClusterID(epoch, participants)
 
-	header := &flow.Header{
-		ChainID:            chainID,
-		ParentID:           flow.ZeroID,
-		Height:             0,
-		PayloadHash:        rootBlockPayloadHash,
-		Timestamp:          flow.GenesisTime,
-		View:               0,
-		ParentVoterIndices: nil,
-		ParentVoterSigData: nil,
-		ProposerID:         flow.ZeroID,
-		ProposerSigData:    nil,
-	}
+	header := flow.NewHeader(
+		chainID,
+		flow.ZeroID,
+		0,
+		rootBlockPayloadHash,
+		flow.GenesisTime,
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	return &cluster.Block{
 		Header:  header,

--- a/state/fork/traversal_test.go
+++ b/state/fork/traversal_test.go
@@ -23,7 +23,7 @@ type TraverseSuite struct {
 	byID     map[flow.Identifier]*flow.Header
 	byHeight map[uint64]*flow.Header
 	headers  *mockstorage.Headers
-	genesis  flow.Header
+	genesis  *flow.Header
 }
 
 func (s *TraverseSuite) SetupTest() {
@@ -46,16 +46,16 @@ func (s *TraverseSuite) SetupTest() {
 	// populate the mocked header storage with genesis and 10 child blocks
 	genesis := unittest.BlockHeaderFixture()
 	genesis.Height = 0
-	s.byID[genesis.ID()] = &genesis
-	s.byHeight[genesis.Height] = &genesis
+	s.byID[genesis.ID()] = genesis
+	s.byHeight[genesis.Height] = genesis
 	s.genesis = genesis
 
-	parent := &genesis
+	parent := genesis
 	for i := 0; i < 10; i++ {
 		child := unittest.BlockHeaderWithParentFixture(parent)
-		s.byID[child.ID()] = &child
-		s.byHeight[child.Height] = &child
-		parent = &child
+		s.byID[child.ID()] = child
+		s.byHeight[child.Height] = child
+		parent = child
 	}
 }
 
@@ -506,13 +506,13 @@ func (s *TraverseSuite) TestTraverse_OnDifferentForkThanTerminalBlock() {
 	noopVisitor := func(header *flow.Header) error { return nil }
 
 	// make other fork
-	otherForkHead := &s.genesis
+	otherForkHead := s.genesis
 	otherForkByHeight := make(map[uint64]*flow.Header)
 	for i := 0; i < 10; i++ {
 		child := unittest.BlockHeaderWithParentFixture(otherForkHead)
-		s.byID[child.ID()] = &child
-		otherForkByHeight[child.Height] = &child
-		otherForkHead = &child
+		s.byID[child.ID()] = child
+		otherForkByHeight[child.Height] = child
+		otherForkHead = child
 	}
 	terminalBlockID := otherForkByHeight[2].ID()
 

--- a/state/protocol/events/gadgets/heights_test.go
+++ b/state/protocol/events/gadgets/heights_test.go
@@ -28,7 +28,7 @@ func TestHeights(t *testing.T) {
 	for height := uint64(2); height <= 4; height++ {
 		block := unittest.BlockHeaderFixture()
 		block.Height = height
-		heights.BlockFinalized(&block)
+		heights.BlockFinalized(block)
 	}
 
 	// ensure callbacks were invoked correctly

--- a/state/protocol/events/gadgets/views_test.go
+++ b/state/protocol/events/gadgets/views_test.go
@@ -41,7 +41,7 @@ func (m *viewsMachine) BlockFinalized(t *rapid.T) {
 
 	block := unittest.BlockHeaderFixture()
 	block.View = view
-	m.views.BlockFinalized(&block)
+	m.views.BlockFinalized(block)
 
 	// increase the number of expected calls and remove those callbacks from our model
 	for indexedView, nCallbacks := range m.callbacks {

--- a/storage/badger/operation/headers_test.go
+++ b/storage/badger/operation/headers_test.go
@@ -17,26 +17,27 @@ import (
 
 func TestHeaderInsertCheckRetrieve(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		expected := flow.Header{
-			View:               1337,
-			Timestamp:          time.Now().UTC(),
-			ParentID:           flow.Identifier{0x11},
-			PayloadHash:        flow.Identifier{0x22},
-			ParentVoterIndices: []byte{0x44},
-			ParentVoterSigData: []byte{0x88},
-			ProposerID:         flow.Identifier{0x33},
-			ProposerSigData:    crypto.Signature{0x77},
-		}
+		expected := flow.NewHeader(
+			"",
+			flow.Identifier{0x11},
+			0,
+			flow.Identifier{0x22},
+			time.Now().UTC(),
+			1337,
+			[]byte{0x44},
+			[]byte{0x88},
+			flow.Identifier{0x33},
+			crypto.Signature{0x77})
 		blockID := expected.ID()
 
-		err := db.Update(InsertHeader(expected.ID(), &expected))
+		err := db.Update(InsertHeader(expected.ID(), expected))
 		require.Nil(t, err)
 
 		var actual flow.Header
 		err = db.View(RetrieveHeader(blockID, &actual))
 		require.Nil(t, err)
 
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, *expected, actual)
 	})
 }
 

--- a/utils/debug/remoteView.go
+++ b/utils/debug/remoteView.go
@@ -92,10 +92,17 @@ func (v *RemoteView) getLatestBlockID() ([]byte, *flow.Header, error) {
 	}
 
 	// TODO set chainID and parentID
-	header := &flow.Header{
-		Height:    resp.Block.Height,
-		Timestamp: resp.Block.Timestamp.AsTime(),
-	}
+	header := flow.NewHeader(
+		"",
+		flow.ZeroID,
+		resp.Block.Height,
+		flow.ZeroID,
+		resp.Block.Timestamp.AsTime(),
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	return resp.Block.Id, header, nil
 }
@@ -111,10 +118,17 @@ func (v *RemoteView) getBlockHeader(blockID flow.Identifier) (*flow.Header, erro
 	}
 
 	// TODO set chainID and parentID
-	header := &flow.Header{
-		Height:    resp.Block.Height,
-		Timestamp: resp.Block.Timestamp.AsTime(),
-	}
+	header := flow.NewHeader(
+		"",
+		flow.ZeroID,
+		resp.Block.Height,
+		flow.ZeroID,
+		resp.Block.Timestamp.AsTime(),
+		0,
+		nil,
+		nil,
+		flow.ZeroID,
+		nil)
 
 	return header, nil
 }

--- a/utils/unittest/incorporated_results_seals.go
+++ b/utils/unittest/incorporated_results_seals.go
@@ -20,7 +20,7 @@ func (f *incorporatedResultSealFactory) Fixture(opts ...func(*flow.IncorporatedR
 	irSeal := &flow.IncorporatedResultSeal{
 		IncorporatedResult: ir,
 		Seal:               seal,
-		Header:             &header,
+		Header:             header,
 	}
 
 	for _, apply := range opts {


### PR DESCRIPTION
prep work for privatizing Header's fields / caching Header's hash id