### PR TITLE
Unskipping passing flaky test

### DIFF
--- a/module/jobqueue/component_consumer_test.go
+++ b/module/jobqueue/component_consumer_test.go
@@ -139,8 +139,6 @@ func (suite *ComponentConsumerSuite) TestHappyPath() {
 	}
 
 	suite.Run("runs and notifies using pre-notifier", func() {
-		unittest.SkipUnless(suite.T(), unittest.TEST_FLAKY, "flaky test")
-
 		wg.Add(int(testJobsCount))
 		consumer, workSignal := suite.prepareTest(processor, nil, notifier, jobData)
 


### PR DESCRIPTION
Unskipping TestComponentConsumerSuite/TestHappyPath/runs_and_notifies_using_pre-notifier.  Test passes according to new Grafana panel showing skipped tests that are passing 100%.

![Screen Shot 2022-06-30 at 12 17 25 PM](https://user-images.githubusercontent.com/15377420/177382486-adac2e3e-d848-4bf7-81f4-35e16269e82c.png)
