### PR TITLE
[`v0.26`] Extend consensus follower config to support compliance settings

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/id"
 	"github.com/onflow/flow-go/module/irrecoverable"
@@ -1173,6 +1174,12 @@ func WithMetricsEnabled(enabled bool) Option {
 func WithSyncCoreConfig(syncConfig synchronization.Config) Option {
 	return func(config *BaseConfig) {
 		config.SyncCoreConfig = syncConfig
+	}
+}
+
+func WithComplianceConfig(complianceConfig compliance.Config) Option {
+	return func(config *BaseConfig) {
+		config.ComplianceConfig = complianceConfig
 	}
 }
 

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications/pubsub"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/synchronization"
@@ -33,15 +34,16 @@ type ConsensusFollower interface {
 
 // Config contains the configurable fields for a `ConsensusFollower`.
 type Config struct {
-	networkPrivKey crypto.PrivateKey       // the network private key of this node
-	bootstrapNodes []BootstrapNodeInfo     // the bootstrap nodes to use
-	bindAddr       string                  // address to bind on
-	db             *badger.DB              // the badger DB storage to use for the protocol state
-	dataDir        string                  // directory to store the protocol state (if the badger storage is not provided)
-	bootstrapDir   string                  // path to the bootstrap directory
-	logLevel       string                  // log level
-	exposeMetrics  bool                    // whether to expose metrics
-	syncConfig     *synchronization.Config // sync core configuration
+	networkPrivKey   crypto.PrivateKey       // the network private key of this node
+	bootstrapNodes   []BootstrapNodeInfo     // the bootstrap nodes to use
+	bindAddr         string                  // address to bind on
+	db               *badger.DB              // the badger DB storage to use for the protocol state
+	dataDir          string                  // directory to store the protocol state (if the badger storage is not provided)
+	bootstrapDir     string                  // path to the bootstrap directory
+	logLevel         string                  // log level
+	exposeMetrics    bool                    // whether to expose metrics
+	syncConfig       *synchronization.Config // sync core configuration
+	complianceConfig *compliance.Config      // follower engine configuration
 }
 
 type Option func(c *Config)
@@ -86,6 +88,12 @@ func WithExposeMetrics(expose bool) Option {
 func WithSyncCoreConfig(config *synchronization.Config) Option {
 	return func(c *Config) {
 		c.syncConfig = config
+	}
+}
+
+func WithComplianceConfig(config *compliance.Config) Option {
+	return func(c *Config) {
+		c.complianceConfig = config
 	}
 }
 
@@ -143,6 +151,9 @@ func getBaseOptions(config *Config) []cmd.Option {
 	}
 	if config.syncConfig != nil {
 		options = append(options, cmd.WithSyncCoreConfig(*config.syncConfig))
+	}
+	if config.complianceConfig != nil {
+		options = append(options, cmd.WithComplianceConfig(*config.complianceConfig))
 	}
 
 	return options


### PR DESCRIPTION
The consensus follower has its own `Config` struct which limits the scope of what can be configured by passing in configuration arguments to the constructor. This PR adds compliance config to the Follower's Config, so it is configurable when instantiating a Follower instance. 

Port of https://github.com/onflow/flow-go/pull/2697