### PR TITLE
Fixed docker-build-loader docker image build failure

### DIFF
--- a/integration/loader/Dockerfile
+++ b/integration/loader/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=ssh \
     cd integration && \
-    GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build --tags relic -ldflags "-extldflags -static" -o ./app ./${TARGET}
+    GO111MODULE=on CGO_ENABLED=1 go build --tags relic -ldflags "-extldflags -static" -o ./app ./${TARGET}
 
 RUN mv /app/integration/app /app/app
 


### PR DESCRIPTION
`make docker-build-loader` failed with the error below. Removed the hard-coded `GOOS` and `GOARCH` env var override from Dockerfile, then it builds again.

> [build-production 2/4] RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod     --mount=type=cache,target=/root/.cache/go-build     --mount=type=ssh     cd integration &&     GO111MODULE=on CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build --tags relic -ldflags "-extldflags -static" -o ./app ././loader:
#23 0.465 # runtime/cgo
#23 0.465 gcc: error: unrecognized command line option '-m64'