### PR TITLE
[Execution Node] [POC] Reduce operational RAM by 152+ GB and checkpoint duration by 24 mins by reusing ledger state

### DIFF
--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -745,9 +745,9 @@ func TestWALUpdateIsRunInParallel(t *testing.T) {
 	wg.Add(1)
 
 	w := &LongRunningDummyWAL{
-		updateFn: func(update *ledger.TrieUpdate) error {
+		updateFn: func(update *ledger.TrieUpdate) (int, error) {
 			wg.Wait() //wg will let work after the trie has been updated
-			return nil
+			return 0, nil
 		},
 	}
 
@@ -795,8 +795,8 @@ func TestWALUpdateFailuresBubbleUp(t *testing.T) {
 	theError := fmt.Errorf("error error")
 
 	w := &LongRunningDummyWAL{
-		updateFn: func(update *ledger.TrieUpdate) error {
-			return theError
+		updateFn: func(update *ledger.TrieUpdate) (int, error) {
+			return 0, theError
 		},
 	}
 
@@ -849,10 +849,10 @@ func migrationByValue(p []ledger.Payload) ([]ledger.Payload, error) {
 
 type LongRunningDummyWAL struct {
 	fixtures.NoopWAL
-	updateFn func(update *ledger.TrieUpdate) error
+	updateFn func(update *ledger.TrieUpdate) (int, error)
 }
 
-func (w *LongRunningDummyWAL) RecordUpdate(update *ledger.TrieUpdate) error {
+func (w *LongRunningDummyWAL) RecordUpdate(update *ledger.TrieUpdate) (int, error) {
 	return w.updateFn(update)
 }
 

--- a/ledger/complete/wal/cached_compactor.go
+++ b/ledger/complete/wal/cached_compactor.go
@@ -1,0 +1,435 @@
+package wal
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/onflow/flow-go/ledger/complete/mtrie"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+	"github.com/onflow/flow-go/module/lifecycle"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/observable"
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	defaultSegmentTrieSize             = 500
+	defaultTrieUpdateChannelBufSize    = 500
+	defaultSegmentUpdateChannelBufSize = 500
+)
+
+// SegmentTrie contains trie and WAL segment number it was recorded in.
+type SegmentTrie struct {
+	Trie       *trie.MTrie
+	SegmentNum int
+}
+
+// segmentTries contains tries that were recorded in given WAL segment.
+type segmentTries struct {
+	tries      []*trie.MTrie
+	segmentNum int
+}
+
+// newSegmentTries creates a segment with given segment number and tries recorded in given segment.
+func newSegmentTries(segmentNum int, tries ...*trie.MTrie) *segmentTries {
+	segmentTries := &segmentTries{
+		tries:      make([]*trie.MTrie, 0, defaultSegmentTrieSize),
+		segmentNum: segmentNum,
+	}
+	segmentTries.tries = append(segmentTries.tries, tries...)
+	return segmentTries
+}
+
+func (s *segmentTries) add(trie *trie.MTrie) {
+	s.tries = append(s.tries, trie)
+}
+
+// activeSegmentTrieCompactor contains cached mtries in active segment.
+// It receives and gathers updated trie and segment number for ledger update through trieUpdateCh channel.
+// It sends batched trie updates for finalized segment through segmentUpdateCh channel.
+type activeSegmentTrieCompactor struct {
+	sync.Mutex
+	logger          zerolog.Logger
+	tries           *segmentTries
+	trieUpdateCh    <-chan *SegmentTrie
+	segmentUpdateCh chan<- *segmentTries
+	stopCh          chan struct{}
+}
+
+func newActiveSegmentTrieCompactor(
+	logger zerolog.Logger,
+	trieUpdateCh <-chan *SegmentTrie,
+	segmentUpdateCh chan<- *segmentTries,
+) *activeSegmentTrieCompactor {
+	return &activeSegmentTrieCompactor{
+		logger:          logger,
+		stopCh:          make(chan struct{}),
+		trieUpdateCh:    trieUpdateCh,
+		segmentUpdateCh: segmentUpdateCh,
+	}
+}
+
+func (c *activeSegmentTrieCompactor) stop() {
+	c.stopCh <- struct{}{}
+}
+
+func (c *activeSegmentTrieCompactor) start() {
+Loop:
+	for {
+		select {
+		case <-c.stopCh:
+			break Loop
+		case update := <-c.trieUpdateCh:
+			prevSegmentTries, err := c.update(update.Trie, update.SegmentNum)
+			if err != nil {
+				c.logger.Error().Err(err).Msg("error updating active segment trie")
+				continue
+			}
+			if prevSegmentTries != nil {
+				c.segmentUpdateCh <- prevSegmentTries
+			}
+		}
+	}
+
+	// Drain remaining trie updates to remove trie references.
+	for range c.trieUpdateCh {
+	}
+}
+
+func (c *activeSegmentTrieCompactor) update(trie *trie.MTrie, segmentNum int) (*segmentTries, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.tries == nil {
+		c.tries = newSegmentTries(segmentNum, trie)
+		return nil, nil
+	}
+
+	// Add to active segment tries cache
+	if segmentNum == c.tries.segmentNum {
+		c.tries.add(trie)
+		return nil, nil
+	}
+
+	// New segment is created
+	if segmentNum != c.tries.segmentNum+1 {
+		return nil, fmt.Errorf("got segment number %d, want %d", segmentNum, c.tries.segmentNum+1)
+	}
+
+	// Save previous segment tries
+	prevSegmentTries := c.tries
+
+	// Create new segment tries
+	c.tries = newSegmentTries(segmentNum, trie)
+
+	return prevSegmentTries, nil
+}
+
+// segmentsTrieCompactor contains mtrie forest in finalized segments.
+// When enough segments are accumulated, a new goroutine is created to create checkpoints async.
+// At most one checkpoint goroutine is run at any given time.
+// It receives and gathers updated tries in segment through segmentUpdateCh channel.
+// It sends created checkpoint number through checkpointCh channel.
+type segmentsTrieCompactor struct {
+	sync.Mutex
+	checkpointer       *Checkpointer
+	logger             zerolog.Logger
+	checkpointDistance uint
+	lastCheckpointNum  int
+
+	// forest contains mtries up to and including tries in forestSegmentNum.
+	forest           *mtrie.Forest
+	forestSegmentNum int
+
+	segmentUpdateCh <-chan *segmentTries
+	stopCh          chan struct{}
+	checkpointCh    chan<- int
+}
+
+func newSegmentsTrieCompactor(
+	logger zerolog.Logger,
+	checkpointer *Checkpointer,
+	segmentUpdateCh <-chan *segmentTries,
+	checkpointCh chan<- int,
+	tries []*trie.MTrie,
+	segmentNum int,
+	checkpointForestCapacity int,
+	checkpointDistance uint,
+) (*segmentsTrieCompactor, error) {
+
+	forest, err := mtrie.NewForest(checkpointForestCapacity, &metrics.NoopCollector{}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create Forest: %w", err)
+	}
+	err = forest.AddTries(tries)
+	if err != nil {
+		return nil, fmt.Errorf("cannot add tries to forest: %w", err)
+	}
+
+	lastCheckpointNum, err := checkpointer.LatestCheckpoint()
+	if err != nil {
+		return nil, fmt.Errorf("cannot get last checkpointed number: %w", err)
+	}
+
+	return &segmentsTrieCompactor{
+		checkpointer:       checkpointer,
+		logger:             logger,
+		checkpointDistance: checkpointDistance,
+		lastCheckpointNum:  lastCheckpointNum,
+		forest:             forest,
+		forestSegmentNum:   segmentNum,
+		segmentUpdateCh:    segmentUpdateCh,
+		checkpointCh:       checkpointCh,
+		stopCh:             make(chan struct{}),
+	}, nil
+}
+
+type checkpointResult struct {
+	checkpointNum int
+	err           error
+}
+
+func (c *segmentsTrieCompactor) stop() {
+	c.stopCh <- struct{}{}
+}
+
+func (c *segmentsTrieCompactor) start() {
+
+	checkpointSem := semaphore.NewWeighted(1) // limit to 1 checkpointing goroutine
+	checkpointResultChan := make(chan checkpointResult)
+
+Loop:
+	for {
+		select {
+
+		case <-c.stopCh:
+			break Loop
+
+		case tries := <-c.segmentUpdateCh:
+			triesToBeCheckpointed, checkpointNum, err := c.update(tries.tries, tries.segmentNum)
+			if err != nil {
+				c.logger.Error().Err(err).Msg("error updating cache")
+				continue
+			}
+
+			if len(triesToBeCheckpointed) > 0 {
+				if checkpointSem.TryAcquire(1) {
+					go func() {
+						defer checkpointSem.Release(1)
+						err := createCheckpoint(c.checkpointer, c.logger, triesToBeCheckpointed, checkpointNum)
+						checkpointResultChan <- checkpointResult{checkpointNum, err}
+					}()
+				}
+			}
+
+		case cpResult := <-checkpointResultChan:
+			if cpResult.err != nil {
+				c.logger.Error().Err(cpResult.err).Msg("error checkpointing")
+				continue
+			}
+
+			c.Lock()
+			c.lastCheckpointNum = cpResult.checkpointNum
+			c.Unlock()
+
+			c.checkpointCh <- cpResult.checkpointNum
+		}
+	}
+
+	// Drain remaining segment updates to remove trie references.
+	for range c.segmentUpdateCh {
+	}
+}
+
+// update adds tries in given segment to forest, and returns tries to be checkpointed
+// with checkpoint number if enough segments are finalized.
+func (c *segmentsTrieCompactor) update(tries []*trie.MTrie, segmentNum int) ([]*trie.MTrie, int, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	err := c.forest.AddTries(tries)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error adding trie %w", err)
+	}
+	c.forestSegmentNum = segmentNum
+
+	uncheckpointedSegmentCount := segmentNum - c.lastCheckpointNum
+	if uncheckpointedSegmentCount < int(c.checkpointDistance) {
+		return nil, 0, nil
+	}
+
+	triesToBeCheckpointed, err := c.forest.GetTries()
+	if err != nil {
+		return nil, 0, err
+	}
+	return triesToBeCheckpointed, c.forestSegmentNum, nil
+}
+
+// CachedCompactor creates and manages segmentsTrieCompactor and activeSegmentTrieCompactor.
+type CachedCompactor struct {
+	checkpointer      *Checkpointer
+	logger            zerolog.Logger
+	lm                *lifecycle.LifecycleManager
+	observers         map[observable.Observer]struct{}
+	checkpointsToKeep uint
+
+	activeSegmentTrieCompactor *activeSegmentTrieCompactor
+	segmentsTrieCompactor      *segmentsTrieCompactor
+
+	stopCh       chan struct{}
+	checkpointCh <-chan int
+}
+
+func NewCachedCompactor(
+	checkpointer *Checkpointer,
+	trieUpdateCh <-chan *SegmentTrie,
+	tries []*trie.MTrie,
+	segmentNum int,
+	checkpointForestCapacity int,
+	checkpointDistance uint,
+	checkpointsToKeep uint,
+	logger zerolog.Logger,
+) (*CachedCompactor, error) {
+	if checkpointDistance < 1 {
+		checkpointDistance = 1
+	}
+
+	segmentUpdateCh := make(chan *segmentTries, defaultSegmentUpdateChannelBufSize)
+	checkpointCh := make(chan int)
+
+	activeSegmentTrieCompactor := newActiveSegmentTrieCompactor(
+		logger,
+		trieUpdateCh,
+		segmentUpdateCh,
+	)
+
+	segmentsTrieCompactor, err := newSegmentsTrieCompactor(
+		logger,
+		checkpointer,
+		segmentUpdateCh,
+		checkpointCh,
+		tries,
+		segmentNum,
+		checkpointForestCapacity,
+		checkpointDistance,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CachedCompactor{
+		checkpointer:               checkpointer,
+		logger:                     logger,
+		observers:                  make(map[observable.Observer]struct{}),
+		lm:                         lifecycle.NewLifecycleManager(),
+		checkpointsToKeep:          checkpointsToKeep,
+		activeSegmentTrieCompactor: activeSegmentTrieCompactor,
+		segmentsTrieCompactor:      segmentsTrieCompactor,
+		checkpointCh:               checkpointCh,
+		stopCh:                     make(chan struct{}),
+	}, nil
+}
+
+func (c *CachedCompactor) Subscribe(observer observable.Observer) {
+	var void struct{}
+	c.observers[observer] = void
+}
+
+func (c *CachedCompactor) Unsubscribe(observer observable.Observer) {
+	delete(c.observers, observer)
+}
+
+func (c *CachedCompactor) Ready() <-chan struct{} {
+	c.lm.OnStart(func() {
+		go c.activeSegmentTrieCompactor.start()
+		go c.segmentsTrieCompactor.start()
+		go c.start()
+	})
+	return c.lm.Started()
+}
+
+func (c *CachedCompactor) Done() <-chan struct{} {
+	c.lm.OnStop(func() {
+		for observer := range c.observers {
+			observer.OnComplete()
+		}
+		c.activeSegmentTrieCompactor.stop()
+		c.segmentsTrieCompactor.stop()
+		c.stopCh <- struct{}{}
+	})
+	return c.lm.Stopped()
+}
+
+func (c *CachedCompactor) start() {
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case checkpointNum := <-c.checkpointCh:
+
+			for observer := range c.observers {
+				observer.OnNext(checkpointNum)
+			}
+
+			err := cleanupCheckpoints(c.checkpointer, int(c.checkpointsToKeep))
+			if err != nil {
+				c.logger.Error().Err(err).Msg("cannot cleanup checkpoints")
+			}
+		}
+	}
+}
+
+func createCheckpoint(checkpointer *Checkpointer, logger zerolog.Logger, tries []*trie.MTrie, checkpointNum int) error {
+
+	logger.Info().Msgf("serializing checkpoint %d with %d tries", checkpointNum, len(tries))
+
+	startTime := time.Now()
+
+	writer, err := checkpointer.CheckpointWriter(checkpointNum)
+	if err != nil {
+		return fmt.Errorf("cannot generate writer: %w", err)
+	}
+	defer func() {
+		closeErr := writer.Close()
+		// Return close error if there isn't any prior error to return.
+		if err == nil {
+			err = closeErr
+		}
+	}()
+
+	err = StoreCheckpoint(writer, tries...)
+	if err != nil {
+		return fmt.Errorf("error serializing checkpoint (%d): %w", checkpointNum, err)
+	}
+
+	logger.Info().Msgf("created checkpoint %d with %d tries", checkpointNum, len(tries))
+
+	duration := time.Since(startTime)
+	logger.Info().Float64("total_time_s", duration.Seconds()).Msgf("created checkpoint %d with %d tries", checkpointNum, len(tries))
+
+	return nil
+}
+
+func cleanupCheckpoints(checkpointer *Checkpointer, checkpointsToKeep int) error {
+	// don't bother listing checkpoints if we keep them all
+	if checkpointsToKeep == 0 {
+		return nil
+	}
+	checkpoints, err := checkpointer.Checkpoints()
+	if err != nil {
+		return fmt.Errorf("cannot list checkpoints: %w", err)
+	}
+	if len(checkpoints) > int(checkpointsToKeep) {
+		checkpointsToRemove := checkpoints[:len(checkpoints)-int(checkpointsToKeep)] // if condition guarantees this never fails
+
+		for _, checkpoint := range checkpointsToRemove {
+			err := checkpointer.RemoveCheckpoint(checkpoint)
+			if err != nil {
+				return fmt.Errorf("cannot remove checkpoint %d: %w", checkpoint, err)
+			}
+		}
+	}
+	return nil
+}

--- a/ledger/complete/wal/checkpointer_test.go
+++ b/ledger/complete/wal/checkpointer_test.go
@@ -148,7 +148,7 @@ func Test_Checkpointing(t *testing.T) {
 				trieUpdate, err := pathfinder.UpdateToTrieUpdate(update, pathFinderVersion)
 				require.NoError(t, err)
 
-				err = wal.RecordUpdate(trieUpdate)
+				_, err = wal.RecordUpdate(trieUpdate)
 				require.NoError(t, err)
 
 				rootHash, err := f.Update(trieUpdate)
@@ -277,7 +277,7 @@ func Test_Checkpointing(t *testing.T) {
 			trieUpdate, err := pathfinder.UpdateToTrieUpdate(update, pathFinderVersion)
 			require.NoError(t, err)
 
-			err = wal4.RecordUpdate(trieUpdate)
+			_, err = wal4.RecordUpdate(trieUpdate)
 			require.NoError(t, err)
 
 			rootHash, err = f.Update(trieUpdate)
@@ -448,7 +448,7 @@ func TestCheckpointFileError(t *testing.T) {
 		trieUpdate, err := pathfinder.UpdateToTrieUpdate(update, pathFinderVersion)
 		require.NoError(t, err)
 
-		err = wal.RecordUpdate(trieUpdate)
+		_, err = wal.RecordUpdate(trieUpdate)
 		require.NoError(t, err)
 
 		// some buffer time of the checkpointer to run

--- a/ledger/complete/wal/fixtures/noopwal.go
+++ b/ledger/complete/wal/fixtures/noopwal.go
@@ -29,7 +29,7 @@ func (w *NoopWAL) PauseRecord() {}
 
 func (w *NoopWAL) UnpauseRecord() {}
 
-func (w *NoopWAL) RecordUpdate(update *ledger.TrieUpdate) error { return nil }
+func (w *NoopWAL) RecordUpdate(update *ledger.TrieUpdate) (int, error) { return 0, nil }
 
 func (w *NoopWAL) RecordDelete(rootHash ledger.RootHash) error { return nil }
 

--- a/ledger/complete/wal/wal.go
+++ b/ledger/complete/wal/wal.go
@@ -56,17 +56,20 @@ func (w *DiskWAL) UnpauseRecord() {
 	w.paused = false
 }
 
-func (w *DiskWAL) RecordUpdate(update *ledger.TrieUpdate) error {
+// RecordUpdate writes serialized trie update to WAL and returns WAL segment number and error.
+func (w *DiskWAL) RecordUpdate(update *ledger.TrieUpdate) (int, error) {
 	if w.paused {
-		return nil
+		return 0, nil
 	}
 
 	bytes := EncodeUpdate(update)
 
-	_, err := w.wal.Log(bytes)
-
+	locations, err := w.wal.Log(bytes)
 	if err != nil {
-		return fmt.Errorf("error while recording update in LedgerWAL: %w", err)
+		return 0, fmt.Errorf("error while recording update in LedgerWAL: %w", err)
+	}
+	if len(locations) != 1 {
+		return 0, fmt.Errorf("error while recording update in LedgerWAL: got %d location, expect 1 location", len(locations))
 	}
 
 	select {
@@ -80,7 +83,7 @@ func (w *DiskWAL) RecordUpdate(update *ledger.TrieUpdate) error {
 	default: //don't block
 	}
 
-	return nil
+	return locations[0].Segment, nil
 }
 
 // DiskSize returns the amount of disk space used by the storage (in bytes)
@@ -337,7 +340,7 @@ type LedgerWAL interface {
 	NewCheckpointer() (*Checkpointer, error)
 	PauseRecord()
 	UnpauseRecord()
-	RecordUpdate(update *ledger.TrieUpdate) error
+	RecordUpdate(update *ledger.TrieUpdate) (int, error)
 	RecordDelete(rootHash ledger.RootHash) error
 	ReplayOnForest(forest *mtrie.Forest) error
 	Segments() (first, last int, err error)


### PR DESCRIPTION
### Changes

Avoid creating separate ledger state during checkpointing.

⚠️ DO NOT REVIEW YET, this PR is work in progress POC that might be replaced with new PR.  I will open another PR using an alternate approach the has more loose coupling between layers and fewer edge cases to handle but it requires locks. ⚠️

Updates #2286

Big thanks to @ramtinms for taking a look and providing useful insights.

### Impact

Based on EN2 logs (July 8, 2022), reusing ledger state should:
- reduce operational memory by at least 152GB
- reduce memory allocations (TBD)
- reduce checkpoint duration by 24 mins (more than half)

### Context

Recent increase in transactions is causing WAL files to get created more frequently, which causes checkpoints to happen more frequently, increases checkpoint file size, and increases ledger state size in memory.

Earlier this year:
- checkpoint frequency: about 0-2 times per day
- checkpoint file size: **53GB** (if using today's file format)

As of July 8, 2022:
- checkpoint frequency: about every 2 hours
- checkpoint file size: **126GB**

### Design

Goal is to reduce operational RAM, reduce allocations, and speed up checkpointing by not creating a separate ledger state.

To achieve these goals, this PR doesn't create a separate ledger state and: 
- avoids blocking with communications between main ledger state and cached ledger state
- avoids blocking with time-consuming tasks such as creating checkpoint 
- retains as few cached mtries as possible before checkpointing

Three new goroutines are used by this PR:

`activeSegmentTrieCompactor`:
* receives updated mtrie and segment number from `Ledger` 
* caches mtries for active segment
* sends batched mtries to `segmentsTrieCompactor` when active segment is finalized (new segment is created)

`segmentsTrieCompactor`:
* receives batched mtries for finalized segment
* caches mtries in forest for finalized segments
* lauch checkpointing goroutine when enough finalized segments are accumulated

`CachedCompactor`:
- starts and stops `activeSegmentTrieCompactor` and `segmentsTrieCompactor`
- calls observers when needed
- deletes extra checkpoint files

### Other Approaches

I will open a separate PR with a different approach.  It will have looser coupling between layers and fewer edge cases to handle, but the tradeoff is the introduction of one or two locks.

### TODO:
- [ ] add more tests
- [ ] handle edge cases 
- [ ] handle errors