### PR TITLE
Isolate TestEpochJoinAndLeaveVN

### DIFF
--- a/.github/workflows/bft-tests.yml
+++ b/.github/workflows/bft-tests.yml
@@ -8,7 +8,7 @@ name: BFT Tests
 on:
   push:
     branches:
-      - '**/*bft*'
+      - '**/2776*'
 
 env:
   GO_VERSION: 1.18
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         test-category:
-          - integration-bft
+          - integration-epochs
     env:
       TEST_CATEGORY: ${{ matrix.test-category }}
     runs-on: ubuntu-latest
@@ -63,11 +63,11 @@ jobs:
         run: make docker-build-flow
       - name: Run tests
         if: github.actor != 'bors[bot]'
-        run: ./tools/test_monitor/run-tests.sh
+        run: make epochs-tests-VN
       - name: Run tests (Bors)
         if: github.actor == 'bors[bot]'
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 15
           max_attempts: 2
-          command: ./tools/test_monitor/run-tests.sh
+          command: make epochs-tests-VN

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -41,6 +41,11 @@ consensus-tests:
 epochs-tests:
 	GO111MODULE=on go test $(if $(VERBOSE),-v,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/epochs/...
 
+.PHONY: epochs-tests-VN
+epochs-tests:
+	GO111MODULE=on go test -v $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/epochs/... -run TestEpochJoinAndLeaveVN
+
+
 .PHONY: ghost-tests
 ghost-tests:
 	GO111MODULE=on go test $(if $(VERBOSE),-v,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/ghost/...


### PR DESCRIPTION
Set up an isolated make target to run TestEpochJoinAndLeaveVN verbosely on its own. Update bft-tests.yml to check github actions and verify test in CI