### PR TITLE
chore(loader): wait for account creation results

### DIFF
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/plus3it/gorecurcopy v0.0.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/rs/zerolog v1.26.1
+	github.com/sethvargo/go-retry v0.2.3
 	github.com/stretchr/testify v1.7.5
 	go.uber.org/atomic v1.9.0
 	google.golang.org/grpc v1.45.0
@@ -230,7 +231,6 @@ require (
 	github.com/raulk/clock v1.1.0 // indirect
 	github.com/raulk/go-watchdog v1.2.0 // indirect
 	github.com/rivo/uniseg v0.2.1-0.20211004051800-57c86be7915a // indirect
-	github.com/sethvargo/go-retry v0.2.3 // indirect
 	github.com/shirou/gopsutil/v3 v3.22.2 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect

--- a/integration/utils/contLoadGenerator.go
+++ b/integration/utils/contLoadGenerator.go
@@ -276,7 +276,7 @@ func (lg *ContLoadGenerator) createAccounts(num int) error {
 	<-ch
 
 	log := lg.log.With().Str("tx_id", createAccountTx.ID().String()).Logger()
-	result, err := GetTransactionResult(context.Background(), lg.flowClient, createAccountTx.ID())
+	result, err := WaitForTransactionResult(context.Background(), lg.flowClient, createAccountTx.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transactions result: %w", err)
 	}

--- a/integration/utils/contLoadGenerator.go
+++ b/integration/utils/contLoadGenerator.go
@@ -276,9 +276,9 @@ func (lg *ContLoadGenerator) createAccounts(num int) error {
 	<-ch
 
 	log := lg.log.With().Str("tx_id", createAccountTx.ID().String()).Logger()
-	result, err := lg.flowClient.GetTransactionResult(context.Background(), createAccountTx.ID())
-	if err != nil {
-		return fmt.Errorf("failed to get transactions result: %w", err)
+	result := GetTransactionResult(context.Background(), lg.flowClient, createAccountTx.ID())
+	if result.Error != nil {
+		return fmt.Errorf("failed to get transactions result: %w", result.Error)
 	}
 
 	log.Trace().Str("status", result.Status.String()).Msg("account creation tx executed")

--- a/integration/utils/contLoadGenerator.go
+++ b/integration/utils/contLoadGenerator.go
@@ -276,9 +276,9 @@ func (lg *ContLoadGenerator) createAccounts(num int) error {
 	<-ch
 
 	log := lg.log.With().Str("tx_id", createAccountTx.ID().String()).Logger()
-	result := GetTransactionResult(context.Background(), lg.flowClient, createAccountTx.ID())
-	if result.Error != nil {
-		return fmt.Errorf("failed to get transactions result: %w", result.Error)
+	result, err := GetTransactionResult(context.Background(), lg.flowClient, createAccountTx.ID())
+	if err != nil {
+		return fmt.Errorf("failed to get transactions result: %w", err)
 	}
 
 	log.Trace().Str("status", result.Status.String()).Msg("account creation tx executed")

--- a/integration/utils/tx_result.go
+++ b/integration/utils/tx_result.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetTransactionResult waits for the transaction to get into the terminal state and returns the result.
-func GetTransactionResult(ctx context.Context, client access.Client, txID flowsdk.Identifier) *flowsdk.TransactionResult {
+func GetTransactionResult(ctx context.Context, client access.Client, txID flowsdk.Identifier) (*flowsdk.TransactionResult, error) {
 	var b retry.Backoff
 	b = retry.NewFibonacci(100 * time.Millisecond)
 	b = retry.WithMaxDuration(60*time.Second, b)
@@ -38,7 +38,7 @@ func GetTransactionResult(ctx context.Context, client access.Client, txID flowsd
 		}
 	})
 	if err != nil {
-		return &flowsdk.TransactionResult{Error: err}
+		return &flowsdk.TransactionResult{Error: err}, err
 	}
-	return result
+	return result, result.Error
 }

--- a/integration/utils/tx_result.go
+++ b/integration/utils/tx_result.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sethvargo/go-retry"
+
+	flowsdk "github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go-sdk/access"
+)
+
+// GetTransactionResult waits for the transaction to get into the terminal state and returns the result.
+func GetTransactionResult(ctx context.Context, client access.Client, txID flowsdk.Identifier) *flowsdk.TransactionResult {
+	var b retry.Backoff
+	b = retry.NewFibonacci(100 * time.Millisecond)
+	b = retry.WithMaxDuration(60*time.Second, b)
+	b = retry.WithCappedDuration(10*time.Second, b)
+
+	var result *flowsdk.TransactionResult
+	err := retry.Do(ctx, b, func(ctx context.Context) (err error) {
+		result, err = client.GetTransactionResult(ctx, txID)
+		if err != nil {
+			return err
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+
+		switch result.Status {
+		case flowsdk.TransactionStatusExecuted, flowsdk.TransactionStatusSealed:
+			return nil
+		case flowsdk.TransactionStatusPending, flowsdk.TransactionStatusFinalized:
+			return retry.RetryableError(fmt.Errorf("waiting for transaction execution: %s", txID))
+		default:
+			return fmt.Errorf("unexpected transaction status: %s", result.Status)
+		}
+	})
+	if err != nil {
+		return &flowsdk.TransactionResult{Error: err}
+	}
+	return result
+}

--- a/integration/utils/tx_result.go
+++ b/integration/utils/tx_result.go
@@ -11,8 +11,8 @@ import (
 	"github.com/onflow/flow-go-sdk/access"
 )
 
-// GetTransactionResult waits for the transaction to get into the terminal state and returns the result.
-func GetTransactionResult(ctx context.Context, client access.Client, txID flowsdk.Identifier) (*flowsdk.TransactionResult, error) {
+// WaitForTransactionResult waits for the transaction to get into the terminal state and returns the result.
+func WaitForTransactionResult(ctx context.Context, client access.Client, txID flowsdk.Identifier) (*flowsdk.TransactionResult, error) {
 	var b retry.Backoff
 	b = retry.NewFibonacci(100 * time.Millisecond)
 	b = retry.WithMaxDuration(60*time.Second, b)


### PR DESCRIPTION
Flow API does not guarantee that `GetTransactionResult` is synchronized with the `GetBlockByHeight` results, hence we can get into a situation where after Follower reports successful execution of the transaction a subsequent `GetTransactionResult` still reports it being only in a `Finalized` state.  Hence, added `GetTransactionResult` that can gently spin on txID waiting for it to get into a terminal state.