### PR TITLE
[Sealing Segment] Handle root sealing segment with multiple blocks

### DIFF
--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -54,10 +54,10 @@ import (
 // * results referenced by seals within segment payloads
 // * seals which represent the latest state commitment as of a segment block
 type SealingSegment struct {
-	// Blocks contains the chain segment blocks in ascending height order.
+	// Blocks contain the chain segment blocks in ascending height order.
 	Blocks []*Block
 
-	// ExecutionResults contains any results which are referenced by receipts
+	// ExecutionResults contain any results which are referenced by receipts
 	// or seals in the sealing segment, but not included in any segment block
 	// payloads.
 	//

--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -31,9 +31,10 @@ import (
 //
 // ROOT SEALING SEGMENTS:
 // Root sealing segments are sealing segments which contain the root block:
+// * the root block is a self-sealing block with an empty payload
 // * the root block must be the first block (least height) in the segment
 // * no blocks in the segment may contain any seals (by the minimality requirement)
-// * it is possible (but not necessary) for root sealing segments to contain only 1 self-sealing block
+// * it is possible (but not necessary) for root sealing segments to contain only the root block
 //
 // Example 1 - one self-sealing root block
 //   ROOT

--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -44,7 +44,7 @@ import (
 //   ROOT <- A <- B
 //
 // All non-root sealing segments contain more than one block.
-// Sealing segments is in ascending height order.
+// Sealing segments are in ascending height order.
 //
 // In addition to storing the blocks within the sealing segment, as defined above,
 // the SealingSegment structure also stores any resources which are referenced
@@ -91,7 +91,7 @@ func (segment *SealingSegment) Lowest() *Block {
 
 // FinalizedSeal returns the seal that seals the lowest block.
 // Per specification, this seal must be included in a SealingSegment.
-// The receiver SealingSegment must be validated.
+// The SealingSegment must be validated.
 // No errors are expected during normal operation.
 func (segment *SealingSegment) FinalizedSeal() (*Seal, error) {
 	if isRootSegment(segment.LatestSeals) {
@@ -358,7 +358,7 @@ func (builder *SealingSegmentBuilder) validateSegment() error {
 	// validate the latest seal is for the lowest block
 	_, err := findLatestSealForLowestBlock(builder.blocks, builder.latestSeals)
 	if err != nil {
-		return fmt.Errorf("sealing segment missing (block_id=%x) highest (block_id%x) %v: %w", builder.lowest().ID(), builder.highest().ID(), err, ErrSegmentMissingSeal)
+		return fmt.Errorf("sealing segment missing seal (lowest block id: %x) (highest block id: %x) %v: %w", builder.lowest().ID(), builder.highest().ID(), err, ErrSegmentMissingSeal)
 	}
 
 	return nil

--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -4,22 +4,12 @@ import (
 	"fmt"
 )
 
-const (
-	// expected length of a root sealing segment
-	rootSegmentBlocksLen = 1
-
-	// expected view of the block in a root sealing segment
-	rootSegmentBlockView = 0
-)
-
-// SealingSegment is the chain segment such that the last block (greatest
-// height) is this snapshot's reference block and the first (least height)
-// is the most recently sealed block as of this snapshot (ie. the block
-// referenced by LatestSeal).
+// SealingSegment is the chain segment such that the last block (greatest height)
+// is this snapshot's reference block and the first (least height) is the most
+// recently sealed block as of this snapshot (ie. the block referenced by LatestSeal).
 //
 // In other words, the most recently incorporated seal as of the highest block
-// references the lowest block. The highest block does not need to contain this
-// seal.
+// references the lowest block. The highest block does not need to contain this seal.
 //
 // Example 1 - E seals A:
 //   A <- B <- C <- D <- E(SA)
@@ -30,27 +20,41 @@ const (
 //   A <- B <- C <- D(SA) <- E
 //
 // Example 3 - E contains multiple seals
-//    B <- C <- D <- E(SA, SB)
+//   B <- C <- D <- E(SA, SB)
+//
+// MINIMALITY REQUIREMENT:
 // Note that block B is the highest sealed block as of E. Therefore, the
 // sealing segment's lowest block must be B. Essentially, this is a minimality
 // requirement for the history: it shouldn't be longer than necessary. So
 // extending the chain segment above to A <- B <- C <- D <- E(SA, SB) would
 // _not_ yield a valid SealingSegment.
 //
-// Root sealing segments contain only one self-sealing block. All other sealing
-// segments contain multiple blocks.
-// The segment is in ascending height order.
+// ROOT SEALING SEGMENTS:
+// Root sealing segments are sealing segments which contain the root block:
+// * the root block must be the first block (least height) in the segment
+// * no blocks in the segment may contain any seals (by the minimality requirement)
+// * it is possible (but not necessary) for root sealing segments to contain only 1 self-sealing block
+//
+// Example 1 - one self-sealing root block
+//   ROOT
+// The above sealing segment is the form of sealing segments within root snapshots,
+// for example those snapshots used to bootstrap a new network, or spork.
+//
+// Example 2 - one self-sealing root block followed by any number of seal-less blocks
+//   ROOT <- A <- B
+//
+// All non-root sealing segments contain more than one block.
+// Sealing segments is in ascending height order.
 //
 // In addition to storing the blocks within the sealing segment, as defined above,
 // the SealingSegment structure also stores any resources which are referenced
 // by blocks in the segment, but not included in the payloads of blocks within
 // the segment. In particular:
-// - results referenced by receipts within segment payloads
-// - results referenced by seals within segment payloads
-// - seals which represent the latest state commitment as of a segment block
-//
+// * results referenced by receipts within segment payloads
+// * results referenced by seals within segment payloads
+// * seals which represent the latest state commitment as of a segment block
 type SealingSegment struct {
-	// Blocks contains the chain segment blocks.
+	// Blocks contains the chain segment blocks in ascending height order.
 	Blocks []*Block
 
 	// ExecutionResults contains any results which are referenced by receipts
@@ -87,10 +91,10 @@ func (segment *SealingSegment) Lowest() *Block {
 
 // FinalizedSeal returns the seal that seals the lowest block.
 // Per specification, this seal must be included in a SealingSegment.
-// Under normal operations (where only a validated SealingSegment
-// is processed), no error returns are expected.
+// The receiver SealingSegment must be validated.
+// No errors are expected during normal operation.
 func (segment *SealingSegment) FinalizedSeal() (*Seal, error) {
-	if isRootSegment(segment) {
+	if isRootSegment(segment.LatestSeals) {
 		return segment.FirstSeal, nil
 	}
 
@@ -107,15 +111,11 @@ func (segment *SealingSegment) FinalizedSeal() (*Seal, error) {
 	return seal, nil
 }
 
-func isRootSegment(segment *SealingSegment) bool {
-	return len(segment.Blocks) == rootSegmentBlocksLen
-}
-
 // Validate validates the sealing segment structure and returns an error if
 // the segment isn't valid. This is done by re-building the segment from scratch,
 // re-using the validation logic already present in the SealingSegmentBuilder.
-// The node logic requires a valid sealing segment to bootstrap. There are no
-// errors expected during normal operations.
+// The node logic requires a valid sealing segment to bootstrap.
+// No errors are expected during normal operation.
 func (segment *SealingSegment) Validate() error {
 
 	// populate lookup of seals and results in the segment to satisfy builder
@@ -173,14 +173,15 @@ var (
 	ErrSegmentInvalidBlockHeight = fmt.Errorf("sealing segment failed sanity check: blocks must be in ascending order")
 	ErrSegmentResultLookup       = fmt.Errorf("failed to lookup execution result")
 	ErrSegmentSealLookup         = fmt.Errorf("failed to lookup seal")
-	ErrSegmentInvalidRootView    = fmt.Errorf("invalid root sealing segment block view")
 )
 
 // GetResultFunc is a getter function for results by ID.
+// No errors are expected during normal operation.
 type GetResultFunc func(resultID Identifier) (*ExecutionResult, error)
 
 // GetSealByBlockIDFunc is a getter function for seals by block ID, returning
 // the latest seals incorporated as of the given block.
+// No errors are expected during normal operation.
 type GetSealByBlockIDFunc func(blockID Identifier) (*Seal, error)
 
 // SealingSegmentBuilder is a utility for incrementally building a sealing segment.
@@ -198,6 +199,7 @@ type SealingSegmentBuilder struct {
 }
 
 // AddBlock appends a block to the sealing segment under construction.
+// No errors are expected during normal operation.
 func (builder *SealingSegmentBuilder) AddBlock(block *Block) error {
 	// sanity check: block should be 1 height higher than current highest
 	if !builder.isValidHeight(block) {
@@ -271,6 +273,10 @@ func (builder *SealingSegmentBuilder) addExecutionResult(result *ExecutionResult
 
 // SealingSegment completes building the sealing segment, validating the segment
 // constructed so far, and returning it as a SealingSegment if it is valid.
+//
+// All errors indicate the SealingSegmentBuilder internal state does not represent
+// a valid sealing segment.
+// No errors are expected during normal operation.
 func (builder *SealingSegmentBuilder) SealingSegment() (*SealingSegment, error) {
 	if err := builder.validateSegment(); err != nil {
 		return nil, fmt.Errorf("failed to validate sealing segment: %w", err)
@@ -284,7 +290,7 @@ func (builder *SealingSegmentBuilder) SealingSegment() (*SealingSegment, error) 
 	}, nil
 }
 
-// isValidHeight returns true iff block is exactly 1 height higher than the current highest block in the segment
+// isValidHeight returns true iff block is exactly 1 height higher than the current highest block in the segment.
 func (builder *SealingSegmentBuilder) isValidHeight(block *Block) bool {
 	if builder.highest() == nil {
 		return true
@@ -293,37 +299,66 @@ func (builder *SealingSegmentBuilder) isValidHeight(block *Block) bool {
 	return block.Header.Height == builder.highest().Header.Height+1
 }
 
-// isValidRootSegment will check that the block in the root segment has a view of 0.
-func (builder *SealingSegmentBuilder) isValidRootSegment() bool {
-	return len(builder.blocks) == rootSegmentBlocksLen &&
-		builder.highest().Header.View == rootSegmentBlockView &&
-		len(builder.results) == rootSegmentBlocksLen && // root segment has only 1 result
-		builder.firstSeal != nil && // first seal is the root seal itself and must exist
-		builder.results[0].BlockID == builder.blocks[0].ID() && // root result matches the root block
-		builder.results[0].ID() == builder.firstSeal.ResultID && // root seal matches the root result
-		builder.results[0].BlockID == builder.firstSeal.BlockID // root seal seals the root block
+// validateRootSegment will check that the current builder state represents a valid
+// root sealing segment. In particular:
+// * the root block must be the first block (least height) in the segment
+// * no blocks in the segment may contain any seals (by the minimality requirement)
+//
+// All errors indicate an invalid root segment, and either a bug in SealingSegmentBuilder
+// or a corrupted underlying protocol state.
+// No errors are expected during normal operation.
+func (builder *SealingSegmentBuilder) validateRootSegment() error {
+	if len(builder.blocks) == 0 {
+		return fmt.Errorf("root segment must have at least 1 block")
+	}
+	if builder.lowest().Header.View != 0 {
+		return fmt.Errorf("root block has unexpected view (%d != 0)", builder.lowest().Header.View)
+	}
+	if len(builder.results) != 1 {
+		return fmt.Errorf("expected %d results, got %d", 1, len(builder.results))
+	}
+	if builder.firstSeal == nil {
+		return fmt.Errorf("firstSeal must not be nil for root segment")
+	}
+	if builder.results[0].BlockID != builder.lowest().ID() {
+		return fmt.Errorf("result (block_id=%x) is not for root block (id=%x)", builder.results[0].BlockID, builder.lowest().ID())
+	}
+	if builder.results[0].ID() != builder.firstSeal.ResultID {
+		return fmt.Errorf("firstSeal (result_id=%x) is not for root result (id=%x)", builder.firstSeal.ResultID, builder.results[0].ID())
+	}
+	if builder.results[0].BlockID != builder.firstSeal.BlockID {
+		return fmt.Errorf("root seal (block_id=%x) references different block than root result (block_id=%x)", builder.firstSeal.BlockID, builder.results[0].BlockID)
+	}
+	for _, block := range builder.blocks {
+		if len(block.Payload.Seals) > 0 {
+			return fmt.Errorf("root segment cannot contain blocks with seals (minimality requirement) - block (height=%d,id=%x) has %d seals",
+				block.Header.Height, block.ID(), len(block.Payload.Seals))
+		}
+	}
+	return nil
 }
 
 // validateSegment will validate if builder satisfies conditions for a valid sealing segment.
+// No errors are expected during normal operation.
 func (builder *SealingSegmentBuilder) validateSegment() error {
 	// sealing cannot be empty
 	if len(builder.blocks) == 0 {
 		return fmt.Errorf("expect at least 2 blocks in a sealing segment or 1 block in the case of root segments, but got an empty sealing segment: %w", ErrSegmentBlocksWrongLen)
 	}
 
-	// if root sealing segment skip seal sanity check
-	if len(builder.blocks) == 1 {
-		if !builder.isValidRootSegment() {
-			return fmt.Errorf("root sealing segment block has the wrong view got (%d) expected (%d): %w", builder.highest().Header.View, rootSegmentBlockView, ErrSegmentInvalidRootView)
+	// if root sealing segment, use different validation
+	if isRootSegment(builder.latestSeals) {
+		err := builder.validateRootSegment()
+		if err != nil {
+			return fmt.Errorf("invalid root segment: %w", err)
 		}
-
 		return nil
 	}
 
 	// validate the latest seal is for the lowest block
 	_, err := findLatestSealForLowestBlock(builder.blocks, builder.latestSeals)
 	if err != nil {
-		return fmt.Errorf("sealing segment missing seal lowest (%x) highest (%x) %v: %w", builder.lowest().ID(), builder.highest().ID(), err, ErrSegmentMissingSeal)
+		return fmt.Errorf("sealing segment missing (block_id=%x) highest (block_id%x) %v: %w", builder.lowest().ID(), builder.highest().ID(), err, ErrSegmentMissingSeal)
 	}
 
 	return nil
@@ -355,9 +390,9 @@ func NewSealingSegmentBuilder(resultLookup GetResultFunc, sealLookup GetSealByBl
 	}
 }
 
-// findLatestSealForLowestBlock finds the latest seal as of the highest block.
-// As a sanity check, the method confirms that the latest seal is for lowest block, i.e.
-// the sealing segment's history is minimal.
+// findLatestSealForLowestBlock finds the seal for the lowest block.
+// As a sanity check, the method confirms that this seal is the latest seal as of the highest block.
+// In other words, this function checks that the sealing segment's history is minimal.
 // Inputs:
 //  * `blocks` is the continuous sequence of blocks that form the sealing segment
 //  * `latestSeals` holds for each block the identifier of the latest seal included in the fork as of this block
@@ -395,7 +430,7 @@ func findLatestSealForLowestBlock(blocks []*Block, latestSeals map[Identifier]Id
 			}
 		}
 
-		// the latest seal must be found in a block that has Seal when traversing blocks
+		// the latest seal must be found in a block that has a seal when traversing blocks
 		// backwards from higher height to lower height.
 		// otherwise, the sealing segment is invalid
 		if len(block.Payload.Seals) > 0 {
@@ -405,4 +440,23 @@ func findLatestSealForLowestBlock(blocks []*Block, latestSeals map[Identifier]Id
 	}
 
 	return nil, fmt.Errorf("invalid segment: seal %v not found", latestSealID)
+}
+
+// isRootSegment returns true if the input latestSeals map represents a root segment.
+// The implementation makes use of the fact that root sealing segments uniquely
+// have the same latest seal, for all blocks in the segment.
+func isRootSegment(latestSeals map[Identifier]Identifier) bool {
+	var rootSealID Identifier
+	// set root seal ID to the latest seal value for any block in the segment
+	for _, sealID := range latestSeals {
+		rootSealID = sealID
+		break
+	}
+	// then, verify all other blocks have the same latest seal
+	for _, sealID := range latestSeals {
+		if sealID != rootSealID {
+			return false
+		}
+	}
+	return true
 }

--- a/model/flow/sealing_segment_test.go
+++ b/model/flow/sealing_segment_test.go
@@ -285,7 +285,7 @@ func (suite *SealingSegmentSuite) TestBuild_RootSegmentWrongView() {
 	require.NoError(suite.T(), err)
 
 	_, err = suite.builder.SealingSegment()
-	require.ErrorIs(suite.T(), err, flow.ErrSegmentInvalidRootView)
+	require.Error(suite.T(), err)
 }
 
 // Test the case when the highest block in the segment does not contain seals but

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -263,6 +263,30 @@ func TestSealingSegment(t *testing.T) {
 		})
 	})
 
+	// test sealing segment for non-root segment where the latest seal is the
+	// root seal, but the segment contains more than the root block.
+	// ROOT <- B1
+	// Expected sealing segment: [ROOT, B1]
+	t.Run("non-root with root seal as latest seal", func(t *testing.T) {
+		util.RunWithFollowerProtocolState(t, rootSnapshot, func(db *badger.DB, state *bprotocol.FollowerState) {
+			// build an extra block on top of root
+			block1 := unittest.BlockWithParentFixture(head)
+			buildBlock(t, state, block1)
+
+			segment, err := state.AtBlockID(block1.ID()).SealingSegment()
+			require.NoError(t, err)
+
+			// build a valid child B2 to ensure we have a QC
+			buildBlock(t, state, unittest.BlockWithParentFixture(block1.Header))
+
+			// sealing segment should contain B1 and B2
+			// B2 is reference of snapshot, B1 is latest sealed
+			unittest.AssertEqualBlocksLenAndOrder(t, []*flow.Block{rootSnapshot.Encodable().SealingSegment.Lowest(), block1}, segment.Blocks)
+			assert.Len(t, segment.ExecutionResults, 1)
+			assertSealingSegmentBlocksQueryableAfterBootstrap(t, state.AtBlockID(block1.ID()))
+		})
+	})
+
 	// test sealing segment for non-root segment with simple sealing structure
 	// (no blocks in between reference block and latest sealed)
 	// ROOT <- B1 <- B2(S1)


### PR DESCRIPTION
This PR adds a test case and extends the implementation of `SealingSegment` to deal with an unhandled edge case:
* sealing segment contains the root block
* sealing segment contains more than one block 

This edge case shows up in integration tests, when we request a root snapshot immediately after the network starts up.