### PR TITLE
[localnet] Adding checking to EXECUTION configuration

### DIFF
--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -1,5 +1,6 @@
 COLLECTION = 3
 CONSENSUS = 3
+VALID_CONSENSUS := $(shell test $(CONSENSUS) -ge 2; echo $$?)
 EXECUTION = 2
 VALID_EXECUTION := $(shell test $(EXECUTION) -ge 2; echo $$?)
 VERIFICATION = 1
@@ -26,6 +27,8 @@ init:
 ifeq ($(strip $(VALID_EXECUTION)), 1)
 	# multiple execution nodes are required to prevent seals being generated in case of execution forking.
 	$(error Number of Execution nodes should be no less than 2)
+else ifeq ($(strip $(VALID_CONSENSUS)), 1)
+	$(error Number of Consensus nodes should be no less than 2)
 else
 	go run -tags relic \
 		-ldflags="-X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' \

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -1,6 +1,7 @@
 COLLECTION = 3
 CONSENSUS = 3
 EXECUTION = 2
+VALID_EXECUTION := $(shell test $(EXECUTION) -ge 2; echo $$?)
 VERIFICATION = 1
 ACCESS = 2
 OBSERVER = 0
@@ -22,6 +23,10 @@ VERSION=localnetbuild
 
 .PHONY: init
 init:
+ifeq ($(strip $(VALID_EXECUTION)), 1)
+	# multiple execution nodes are required to prevent seals being generated in case of execution forking.
+	$(error Number of Execution nodes should be no less than 2)
+else
 	go run -tags relic \
 		-ldflags="-X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' \
 		-X  'github.com/onflow/flow-go/cmd/build.semver=${VERSION}'" \
@@ -42,6 +47,7 @@ init:
 		-extensive-tracing=$(EXTENSIVE_TRACING) \
 		-consensus-delay=$(CONSENSUS_DELAY) \
 		-collection-delay=$(COLLECTION_DELAY)
+endif
 
 # Creates a light version of the localnet with just 1 instance for each node type
 .PHONY: init-light

--- a/integration/localnet/README.md
+++ b/integration/localnet/README.md
@@ -48,7 +48,7 @@ Specify the number of nodes for each role:
 ```sh
 make -e COLLECTION=2 CONSENSUS=5 EXECUTION=3 VERIFICATION=2 ACCESS=2 init
 ```
-*NOTE: number of execution nodes should be no less than 2. It is to avoid seals being created in case of execution forks.*
+*NOTE: number of execution\consensus nodes should be no less than 2. It is to avoid seals being created in case of execution forks.*
 
 Specify the number of collector clusters:
 

--- a/integration/localnet/README.md
+++ b/integration/localnet/README.md
@@ -48,6 +48,7 @@ Specify the number of nodes for each role:
 ```sh
 make -e COLLECTION=2 CONSENSUS=5 EXECUTION=3 VERIFICATION=2 ACCESS=2 init
 ```
+*NOTE: number of execution nodes should be no less than 2. It is to avoid seals being created in case of execution forks.*
 
 Specify the number of collector clusters:
 


### PR DESCRIPTION
#2759 

#### Motivation
According to the change below, multiple execution nodes are required to prevent block seals to be generated in case of execution forks. Thus if there's only one EN node running, no blocks will be sealed. To avoid future confusion in localnet uses, now we put this checking into the Makefile.
https://github.com/onflow/flow-go/pull/632/files#diff-7fd319f5e35ff086e91814317aadbcb86eb3a89b904bf6a3cc38cb7a6ac40bf6R41-R42

Also applying the same check for consensus node.

#### Test
- [X] Run `make -e EXECUTION=1 init` and `make -e CONSENSUS=1 init` to see new error
- [X] Run all other EXECUTION\CONSENSUS values to see the make command to go through