### PR TITLE
dedup code in script/transaction environment (part 1 of many)

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -1,7 +1,22 @@
 package fvm
 
 import (
+	"encoding/binary"
+	"math/rand"
+	"time"
+
 	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/opentracing/opentracing-go"
+	traceLog "github.com/opentracing/opentracing-go/log"
+
+	"github.com/onflow/flow-go/fvm/crypto"
+	"github.com/onflow/flow-go/fvm/handler"
+	"github.com/onflow/flow-go/fvm/programs"
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/trace"
 )
 
 // Environment accepts a context and a virtual machine instance and provides
@@ -10,4 +25,121 @@ type Environment interface {
 	Context() *Context
 	VM() *VirtualMachine
 	runtime.Interface
+}
+
+// Parts of the environment that are common to all transaction and script
+// executions.
+type commonEnv struct {
+	ctx           Context
+	sth           *state.StateHolder
+	vm            *VirtualMachine
+	programs      *handler.ProgramsHandler
+	accounts      state.Accounts
+	accountKeys   *handler.AccountKeyHandler
+	contracts     *handler.ContractHandler
+	uuidGenerator *state.UUIDGenerator
+	metrics       *handler.MetricsHandler
+	logs          []string
+	rng           *rand.Rand
+	traceSpan     opentracing.Span
+}
+
+func (env *commonEnv) Context() *Context {
+	return &env.ctx
+}
+
+func (env *commonEnv) VM() *VirtualMachine {
+	return env.vm
+}
+
+func (env *commonEnv) seedRNG(header *flow.Header) {
+	// Seed the random number generator with entropy created from the block
+	// header ID. The random number generator will be used by the UnsafeRandom
+	// function.
+	id := header.ID()
+	source := rand.NewSource(int64(binary.BigEndian.Uint64(id[:])))
+	env.rng = rand.New(source)
+}
+
+func (env *commonEnv) isTraceable() bool {
+	return env.ctx.Tracer != nil && env.traceSpan != nil
+}
+
+func (env *commonEnv) ImplementationDebugLog(message string) error {
+	env.ctx.Logger.Debug().Msgf("Cadence: %s", message)
+	return nil
+}
+
+func (env *commonEnv) RecordTrace(operation string, location common.Location, duration time.Duration, logs []opentracing.LogRecord) {
+	if !env.isTraceable() {
+		return
+	}
+	if location != nil {
+		if logs == nil {
+			logs = make([]opentracing.LogRecord, 0, 1)
+		}
+		logs = append(logs, opentracing.LogRecord{Timestamp: time.Now(),
+			Fields: []traceLog.Field{traceLog.String("location", location.String())},
+		})
+	}
+	spanName := trace.FVMCadenceTrace.Child(operation)
+	env.ctx.Tracer.RecordSpanFromParent(env.traceSpan, spanName, duration, logs)
+}
+
+func (env *commonEnv) ProgramParsed(location common.Location, duration time.Duration) {
+	env.RecordTrace("parseProgram", location, duration, nil)
+	env.metrics.ProgramParsed(location, duration)
+}
+
+func (env *commonEnv) ProgramChecked(location common.Location, duration time.Duration) {
+	env.RecordTrace("checkProgram", location, duration, nil)
+	env.metrics.ProgramChecked(location, duration)
+}
+
+func (env *commonEnv) ProgramInterpreted(location common.Location, duration time.Duration) {
+	env.RecordTrace("interpretProgram", location, duration, nil)
+	env.metrics.ProgramInterpreted(location, duration)
+}
+
+func (env *commonEnv) ValueEncoded(duration time.Duration) {
+	env.RecordTrace("encodeValue", nil, duration, nil)
+	env.metrics.ValueEncoded(duration)
+}
+
+func (env *commonEnv) ValueDecoded(duration time.Duration) {
+	env.RecordTrace("decodeValue", nil, duration, nil)
+	env.metrics.ValueDecoded(duration)
+}
+
+// Commit commits changes and return a list of updated keys
+func (env *commonEnv) Commit() ([]programs.ContractUpdateKey, error) {
+	// commit changes and return a list of updated keys
+	err := env.programs.Cleanup()
+	if err != nil {
+		return nil, err
+	}
+	return env.contracts.Commit()
+}
+
+func (commonEnv) BLSVerifyPOP(pk *runtime.PublicKey, sig []byte) (bool, error) {
+	return crypto.VerifyPOP(pk, sig)
+}
+
+func (commonEnv) BLSAggregateSignatures(sigs [][]byte) ([]byte, error) {
+	return crypto.AggregateSignatures(sigs)
+}
+
+func (commonEnv) BLSAggregatePublicKeys(
+	keys []*runtime.PublicKey,
+) (*runtime.PublicKey, error) {
+
+	return crypto.AggregatePublicKeys(keys)
+}
+
+func (commonEnv) ResourceOwnerChanged(
+	*interpreter.Interpreter,
+	*interpreter.CompositeValue,
+	common.Address,
+	common.Address,
+) {
 }

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -5,11 +5,8 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
-	"time"
 
 	"github.com/onflow/atree"
-	"github.com/opentracing/opentracing-go"
 	traceLog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/onflow/cadence"
@@ -36,27 +33,9 @@ var _ Environment = &ScriptEnv{}
 
 // ScriptEnv is a read-only mostly used for executing scripts.
 type ScriptEnv struct {
-	ctx           Context
-	sth           *state.StateHolder
-	vm            *VirtualMachine
-	accounts      state.Accounts
-	contracts     *handler.ContractHandler
-	programs      *handler.ProgramsHandler
-	accountKeys   *handler.AccountKeyHandler
-	metrics       *handler.MetricsHandler
-	uuidGenerator *state.UUIDGenerator
-	logs          []string
-	rng           *rand.Rand
-	traceSpan     opentracing.Span
-	reqContext    context.Context
-}
+	commonEnv
 
-func (e *ScriptEnv) Context() *Context {
-	return &e.ctx
-}
-
-func (e *ScriptEnv) VM() *VirtualMachine {
-	return e.vm
+	reqContext context.Context
 }
 
 func NewScriptEnvironment(
@@ -74,15 +53,19 @@ func NewScriptEnvironment(
 	metrics := handler.NewMetricsHandler(fvmContext.Metrics)
 
 	env := &ScriptEnv{
-		ctx:           fvmContext,
-		sth:           sth,
-		vm:            vm,
-		metrics:       metrics,
-		accounts:      accounts,
-		accountKeys:   accountKeys,
-		uuidGenerator: uuidGenerator,
-		programs:      programsHandler,
-		reqContext:    reqContext,
+		commonEnv: commonEnv{
+			ctx:           fvmContext,
+			sth:           sth,
+			vm:            vm,
+			programs:      programsHandler,
+			accounts:      accounts,
+			accountKeys:   accountKeys,
+			uuidGenerator: uuidGenerator,
+			logs:          nil,
+			rng:           nil,
+			metrics:       metrics,
+		},
+		reqContext: reqContext,
 	}
 
 	env.contracts = handler.NewContractHandler(
@@ -167,18 +150,6 @@ func (e *ScriptEnv) setExecutionParameters() {
 	if err != nil {
 		return
 	}
-}
-
-func (e *ScriptEnv) seedRNG(header *flow.Header) {
-	// Seed the random number generator with entropy created from the block header ID. The random number generator will
-	// be used by the UnsafeRandom function.
-	id := header.ID()
-	source := rand.NewSource(int64(binary.BigEndian.Uint64(id[:])))
-	e.rng = rand.New(source)
-}
-
-func (e *ScriptEnv) isTraceable() bool {
-	return e.ctx.Tracer != nil && e.traceSpan != nil
 }
 
 func (e *ScriptEnv) GetValue(owner, key []byte) ([]byte, error) {
@@ -837,62 +808,6 @@ func (e *ScriptEnv) GetSigningAccounts() ([]runtime.Address, error) {
 	return nil, errors.NewOperationNotSupportedError("GetSigningAccounts")
 }
 
-func (e *ScriptEnv) ImplementationDebugLog(message string) error {
-	e.ctx.Logger.Debug().Msgf("Cadence: %s", message)
-	return nil
-}
-
-func (e *ScriptEnv) RecordTrace(operation string, location common.Location, duration time.Duration, logs []opentracing.LogRecord) {
-	if !e.isTraceable() {
-		return
-	}
-	if location != nil {
-		if logs == nil {
-			logs = make([]opentracing.LogRecord, 0)
-		}
-		logs = append(logs, opentracing.LogRecord{Timestamp: time.Now(),
-			Fields: []traceLog.Field{traceLog.String("location", location.String())},
-		})
-	}
-	spanName := trace.FVMCadenceTrace.Child(operation)
-	e.ctx.Tracer.RecordSpanFromParent(e.traceSpan, spanName, duration, logs)
-}
-
-func (e *ScriptEnv) ProgramParsed(location common.Location, duration time.Duration) {
-	e.RecordTrace("parseProgram", location, duration, nil)
-	e.metrics.ProgramParsed(location, duration)
-}
-
-func (e *ScriptEnv) ProgramChecked(location common.Location, duration time.Duration) {
-	e.RecordTrace("checkProgram", location, duration, nil)
-	e.metrics.ProgramChecked(location, duration)
-}
-
-func (e *ScriptEnv) ProgramInterpreted(location common.Location, duration time.Duration) {
-	e.RecordTrace("interpretProgram", location, duration, nil)
-	e.metrics.ProgramInterpreted(location, duration)
-}
-
-func (e *ScriptEnv) ValueEncoded(duration time.Duration) {
-	e.RecordTrace("encodeValue", nil, duration, nil)
-	e.metrics.ValueEncoded(duration)
-}
-
-func (e *ScriptEnv) ValueDecoded(duration time.Duration) {
-	e.RecordTrace("decodeValue", nil, duration, nil)
-	e.metrics.ValueDecoded(duration)
-}
-
-// Commit commits changes and return a list of updated keys
-func (e *ScriptEnv) Commit() ([]programs.ContractUpdateKey, error) {
-	// commit changes and return a list of updated keys
-	err := e.programs.Cleanup()
-	if err != nil {
-		return nil, err
-	}
-	return e.contracts.Commit()
-}
-
 // AllocateStorageIndex allocates new storage index under the owner accounts to store a new register
 func (e *ScriptEnv) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
 	err := e.meterComputation(meter.ComputationKindAllocateStorageIndex, 1)
@@ -905,24 +820,4 @@ func (e *ScriptEnv) AllocateStorageIndex(owner []byte) (atree.StorageIndex, erro
 		return atree.StorageIndex{}, fmt.Errorf("storage address allocation failed: %w", err)
 	}
 	return v, nil
-}
-
-func (e *ScriptEnv) BLSVerifyPOP(pk *runtime.PublicKey, sig []byte) (bool, error) {
-	return crypto.VerifyPOP(pk, sig)
-}
-
-func (e *ScriptEnv) BLSAggregateSignatures(sigs [][]byte) ([]byte, error) {
-	return crypto.AggregateSignatures(sigs)
-}
-
-func (e *ScriptEnv) BLSAggregatePublicKeys(keys []*runtime.PublicKey) (*runtime.PublicKey, error) {
-	return crypto.AggregatePublicKeys(keys)
-}
-
-func (e *ScriptEnv) ResourceOwnerChanged(
-	*interpreter.Interpreter,
-	*interpreter.CompositeValue,
-	common.Address,
-	common.Address,
-) {
 }

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"math/rand"
-	"time"
 
 	"github.com/onflow/atree"
 	"github.com/onflow/cadence"
@@ -35,23 +33,13 @@ var _ runtime.Interface = &TransactionEnv{}
 
 // TransactionEnv is a read-write environment used for executing flow transactions.
 type TransactionEnv struct {
-	vm               *VirtualMachine
-	ctx              Context
-	sth              *state.StateHolder
-	programs         *handler.ProgramsHandler
-	accounts         state.Accounts
-	uuidGenerator    *state.UUIDGenerator
-	contracts        *handler.ContractHandler
-	accountKeys      *handler.AccountKeyHandler
-	metrics          *handler.MetricsHandler
+	commonEnv
+
 	eventHandler     *handler.EventHandler
 	addressGenerator flow.AddressGenerator
-	rng              *rand.Rand
-	logs             []string
 	tx               *flow.TransactionBody
 	txIndex          uint32
 	txID             flow.Identifier
-	traceSpan        opentracing.Span
 	authorizers      []runtime.Address
 }
 
@@ -79,20 +67,25 @@ func NewTransactionEnvironment(
 	metrics := handler.NewMetricsHandler(ctx.Metrics)
 
 	env := &TransactionEnv{
-		vm:               vm,
-		ctx:              ctx,
-		sth:              sth,
-		metrics:          metrics,
-		programs:         programsHandler,
-		accounts:         accounts,
-		accountKeys:      accountKeys,
+		commonEnv: commonEnv{
+			ctx:           ctx,
+			sth:           sth,
+			vm:            vm,
+			programs:      programsHandler,
+			accounts:      accounts,
+			accountKeys:   accountKeys,
+			uuidGenerator: uuidGenerator,
+			metrics:       metrics,
+			logs:          nil,
+			rng:           nil,
+			traceSpan:     traceSpan,
+		},
+
 		addressGenerator: generator,
-		uuidGenerator:    uuidGenerator,
 		eventHandler:     eventHandler,
 		tx:               tx,
 		txIndex:          txIndex,
 		txID:             tx.ID(),
-		traceSpan:        traceSpan,
 	}
 
 	env.contracts = handler.NewContractHandler(accounts,
@@ -201,26 +194,6 @@ func (e *TransactionEnv) TxIndex() uint32 {
 
 func (e *TransactionEnv) TxID() flow.Identifier {
 	return e.txID
-}
-
-func (e *TransactionEnv) Context() *Context {
-	return &e.ctx
-}
-
-func (e *TransactionEnv) VM() *VirtualMachine {
-	return e.vm
-}
-
-func (e *TransactionEnv) seedRNG(header *flow.Header) {
-	// Seed the random number generator with entropy created from the block header ID. The random number generator will
-	// be used by the UnsafeRandom function.
-	id := header.ID()
-	source := rand.NewSource(int64(binary.BigEndian.Uint64(id[:])))
-	e.rng = rand.New(source)
-}
-
-func (e *TransactionEnv) isTraceable() bool {
-	return e.ctx.Tracer != nil && e.traceSpan != nil
 }
 
 // GetAccountsAuthorizedForContractUpdate returns a list of addresses authorized to update/deploy contracts
@@ -1196,81 +1169,4 @@ func (e *TransactionEnv) getSigningAccounts() []runtime.Address {
 		}
 	}
 	return e.authorizers
-}
-
-func (e *TransactionEnv) ImplementationDebugLog(message string) error {
-	e.ctx.Logger.Debug().Msgf("Cadence: %s", message)
-	return nil
-}
-
-func (e *TransactionEnv) RecordTrace(operation string, location common.Location, duration time.Duration, logs []opentracing.LogRecord) {
-	if !e.isTraceable() {
-		return
-	}
-	if location != nil {
-		if logs == nil {
-			logs = make([]opentracing.LogRecord, 0)
-		}
-		logs = append(logs, opentracing.LogRecord{Timestamp: time.Now(),
-			Fields: []traceLog.Field{traceLog.String("location", location.String())},
-		})
-	}
-
-	spanName := trace.FVMCadenceTrace.Child(operation)
-	e.ctx.Tracer.RecordSpanFromParent(e.traceSpan, spanName, duration, logs)
-}
-
-func (e *TransactionEnv) ProgramParsed(location common.Location, duration time.Duration) {
-	e.RecordTrace("parseProgram", location, duration, nil)
-	e.metrics.ProgramParsed(location, duration)
-}
-
-func (e *TransactionEnv) ProgramChecked(location common.Location, duration time.Duration) {
-	e.RecordTrace("checkProgram", location, duration, nil)
-	e.metrics.ProgramChecked(location, duration)
-}
-
-func (e *TransactionEnv) ProgramInterpreted(location common.Location, duration time.Duration) {
-	e.RecordTrace("interpretProgram", location, duration, nil)
-	e.metrics.ProgramInterpreted(location, duration)
-}
-
-func (e *TransactionEnv) ValueEncoded(duration time.Duration) {
-	e.RecordTrace("encodeValue", nil, duration, nil)
-	e.metrics.ValueEncoded(duration)
-}
-
-func (e *TransactionEnv) ValueDecoded(duration time.Duration) {
-	e.RecordTrace("decodeValue", nil, duration, nil)
-	e.metrics.ValueDecoded(duration)
-}
-
-// Commit commits changes and return a list of updated keys
-func (e *TransactionEnv) Commit() ([]programs.ContractUpdateKey, error) {
-	// commit changes and return a list of updated keys
-	err := e.programs.Cleanup()
-	if err != nil {
-		return nil, err
-	}
-	return e.contracts.Commit()
-}
-
-func (e *TransactionEnv) BLSVerifyPOP(pk *runtime.PublicKey, sig []byte) (bool, error) {
-	return crypto.VerifyPOP(pk, sig)
-}
-
-func (e *TransactionEnv) BLSAggregateSignatures(sigs [][]byte) ([]byte, error) {
-	return crypto.AggregateSignatures(sigs)
-}
-
-func (e *TransactionEnv) BLSAggregatePublicKeys(keys []*runtime.PublicKey) (*runtime.PublicKey, error) {
-	return crypto.AggregatePublicKeys(keys)
-}
-
-func (e *TransactionEnv) ResourceOwnerChanged(
-	*interpreter.Interpreter,
-	*interpreter.CompositeValue,
-	common.Address,
-	common.Address,
-) {
 }


### PR DESCRIPTION
A big chunk of the code in ScriptEnv and TransactionEnv are copy/paste
identical.  It's easy to forget to fix bugs in both place and hard to make
improvements.

Notes:
 1. I've decided to merge the shared code piecemeal since it's scary to
    merge everything at once.
 2. The environment variable e has been renamed to env since it's more
    searchable
 3. (A real change) I've presized the array allocation in RecordTrace