### PR TITLE
backport execution context check from ScriptEnv to TransactionEnv

### DIFF
--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -505,7 +505,7 @@ func TestExecuteScriptTimeout(t *testing.T) {
 
 	require.Error(t, err)
 	require.Nil(t, value)
-	require.Contains(t, err.Error(), fvmErrors.ErrCodeScriptExecutionTimedOutError.String())
+	require.Contains(t, err.Error(), fvmErrors.ErrCodeExecutionTimedOutError.String())
 }
 
 func TestExecuteScriptCancelled(t *testing.T) {
@@ -553,7 +553,7 @@ func TestExecuteScriptCancelled(t *testing.T) {
 	cancel()
 	wg.Wait()
 	require.Nil(t, value)
-	require.Contains(t, err.Error(), fvmErrors.ErrCodeScriptExecutionCancelledError.String())
+	require.Contains(t, err.Error(), fvmErrors.ErrCodeExecutionCancelledError.String())
 }
 
 func TestScriptStorageMutationsDiscarded(t *testing.T) {

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -62,8 +62,8 @@ const (
 	ErrCodeComputationLimitExceededError             ErrorCode = 1110
 	ErrCodeMemoryLimitExceededError                  ErrorCode = 1111
 	ErrCodeCouldNotDecodeExecutionParameterFromState ErrorCode = 1112
-	ErrCodeScriptExecutionCancelledError             ErrorCode = 1114
-	ErrCodeScriptExecutionTimedOutError              ErrorCode = 1113
+	ErrCodeExecutionCancelledError                   ErrorCode = 1114
+	ErrCodeExecutionTimedOutError                    ErrorCode = 1113
 
 	// accounts errors 1200 - 1250
 	// ErrCodeAccountError              ErrorCode = 1200 - reserved

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -308,21 +308,21 @@ func (e *EncodingUnsupportedValueError) Code() ErrorCode {
 	return ErrCodeEncodingUnsupportedValue
 }
 
-// ScriptExecutionCancelledError indicates that Cadence Script execution
-// has been cancelled (e.g. request connection has been droped)
+// ExecutionCancelledError indicates that Cadence execution has been cancelled
+// (e.g. request connection has been droped)
 //
-// note: this error is used by scripts only and
-// won't be emitted for transactions since transaction execution has to be deterministic.
-type ScriptExecutionCancelledError struct {
+// note: this error is used by scripts only and won't be emitted for
+// transactions since transaction execution has to be deterministic.
+type ExecutionCancelledError struct {
 	err error
 }
 
-// NewScriptExecutionCancelledError construct a new ScriptExecutionCancelledError
-func NewScriptExecutionCancelledError(err error) *ScriptExecutionCancelledError {
-	return &ScriptExecutionCancelledError{err: err}
+// NewExecutionCancelledError construct a new ExecutionCancelledError
+func NewExecutionCancelledError(err error) *ExecutionCancelledError {
+	return &ExecutionCancelledError{err: err}
 }
 
-func (e *ScriptExecutionCancelledError) Error() string {
+func (e *ExecutionCancelledError) Error() string {
 	return fmt.Sprintf(
 		"%s script execution is cancelled: %s",
 		e.Code().String(),
@@ -331,24 +331,24 @@ func (e *ScriptExecutionCancelledError) Error() string {
 }
 
 // Code returns the error code for this error
-func (e *ScriptExecutionCancelledError) Code() ErrorCode {
-	return ErrCodeScriptExecutionCancelledError
+func (e *ExecutionCancelledError) Code() ErrorCode {
+	return ErrCodeExecutionCancelledError
 }
 
-// ScriptExecutionTimedOutError indicates that Cadence Script execution
-// has been taking more time than what is allowed.
+// ExecutionTimedOutError indicates that Cadence execution has been taking
+// more time than what is allowed.
 //
-// note: this error is used by scripts only and
-// won't be emitted for transactions since transaction execution has to be deterministic.
-type ScriptExecutionTimedOutError struct {
+// note: this error is used by scripts only and won't be emitted for
+// transactions since transaction execution has to be deterministic.
+type ExecutionTimedOutError struct {
 }
 
-// NewScriptExecutionTimedOutError construct a new ScriptExecutionTimedOutError
-func NewScriptExecutionTimedOutError() *ScriptExecutionTimedOutError {
-	return &ScriptExecutionTimedOutError{}
+// NewExecutionTimedOutError construct a new ExecutionTimedOutError
+func NewExecutionTimedOutError() *ExecutionTimedOutError {
+	return &ExecutionTimedOutError{}
 }
 
-func (e *ScriptExecutionTimedOutError) Error() string {
+func (e *ExecutionTimedOutError) Error() string {
 	return fmt.Sprintf(
 		"%s script execution is timed out and did not finish executing within the maximum execution time allowed",
 		e.Code().String(),
@@ -356,8 +356,8 @@ func (e *ScriptExecutionTimedOutError) Error() string {
 }
 
 // Code returns the error code for this error
-func (e *ScriptExecutionTimedOutError) Code() ErrorCode {
-	return ErrCodeScriptExecutionTimedOutError
+func (e *ExecutionTimedOutError) Code() ErrorCode {
+	return ErrCodeExecutionTimedOutError
 }
 
 // An CouldNotGetExecutionParameterFromStateError indicates that computation has exceeded its limit.


### PR DESCRIPTION
prep work for deduping shared environment code

Note that I've inlined the checkContext method since golang doesn't do any
inlining optimization.