### PR TITLE
chore(tests): add trace benchmark

### DIFF
--- a/module/trace/trace_test.go
+++ b/module/trace/trace_test.go
@@ -1,0 +1,66 @@
+package trace
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func BenchmarkStartSpanFromParent(b *testing.B) {
+	tracer, err := NewTracer(zerolog.Logger{}, "test", string(flow.Localnet), 0)
+	require.NoError(b, err)
+
+	tracer.Ready()
+	defer tracer.Done()
+
+	span, _, sampled := tracer.StartTransactionSpan(context.Background(), flow.Identifier{}, "test")
+	require.True(b, sampled)
+	defer span.Finish()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s := tracer.StartSpanFromParent(span, SpanName("test"))
+		s.Finish()
+	}
+	b.StopTimer()
+}
+
+func BenchmarkStartTransactionSpan(b *testing.B) {
+	tracer, err := NewTracer(zerolog.Logger{}, "test", string(flow.Localnet), 0)
+	require.NoError(b, err)
+
+	tracer.Ready()
+	defer tracer.Done()
+
+	for _, t := range []struct {
+		name string
+		n    int
+	}{
+		{name: "cacheHit", n: 100},
+		{name: "cacheMiss", n: 100000},
+	} {
+		t := t
+		b.Run(t.name, func(b *testing.B) {
+			randomIDs := make([]flow.Identifier, 0, t.n)
+			for i := 0; i < t.n; i++ {
+				var randomBytes [flow.IdentifierLen]byte
+				_, err := rand.Read(randomBytes[:])
+				require.NoError(b, err)
+				randomIDs = append(randomIDs, flow.Identifier(randomBytes))
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				span, _, sampled := tracer.StartTransactionSpan(context.Background(), randomIDs[i%t.n], "test")
+				require.True(b, sampled)
+				span.Finish()
+			}
+			b.StopTimer()
+		})
+	}
+}


### PR DESCRIPTION
This adds simple benchmarks for root and parent span creation.

This will be useful for estimating testing perf difference between opentracing and opentelemetry.

```
name                              time/op
StartSpanFromParent-8              469ns ± 5%
StartTransactionSpan/cacheHit-8   1.01µs ± 5%
StartTransactionSpan/cacheMiss-8  2.25µs ± 4%

name                              alloc/op
StartSpanFromParent-8               577B ± 0%
StartTransactionSpan/cacheHit-8     775B ± 1%
StartTransactionSpan/cacheMiss-8  2.15kB ± 2%

name                              allocs/op
StartSpanFromParent-8               7.00 ± 0%
StartTransactionSpan/cacheHit-8     10.0 ± 0%
StartTransactionSpan/cacheMiss-8    35.2 ± 3%
```