### PR TITLE
Adding new load test type for constant sized transactions

### DIFF
--- a/integration/loader/main.go
+++ b/integration/loader/main.go
@@ -33,7 +33,7 @@ type LoadCase struct {
 
 func main() {
 	sleep := flag.Duration("sleep", 0, "duration to sleep before benchmarking starts")
-	loadTypeFlag := flag.String("load-type", "token-transfer", "type of loads (\"token-transfer\", \"add-keys\", \"computation-heavy\", \"event-heavy\", \"ledger-heavy\")")
+	loadTypeFlag := flag.String("load-type", "token-transfer", "type of loads (\"token-transfer\", \"add-keys\", \"computation-heavy\", \"event-heavy\", \"ledger-heavy\", \"const-exec\")")
 	tpsFlag := flag.String("tps", "1", "transactions per second (TPS) to send, accepts a comma separated list of values if used in conjunction with `tps-durations`")
 	tpsDurationsFlag := flag.String("tps-durations", "0", "duration that each load test will run, accepts a comma separted list that will be applied to multiple values of the `tps` flag (defaults to infinite if not provided, meaning only the first tps case will be tested; additional values will be ignored)")
 	chainIDStr := flag.String("chain", string(flowsdk.Emulator), "chain ID")
@@ -46,6 +46,10 @@ func main() {
 	_ = flag.Bool("track-txs", false, "deprecated")
 	accountMultiplierFlag := flag.Int("account-multiplier", 50, "number of accounts to create per load tps")
 	feedbackEnabled := flag.Bool("feedback-enabled", true, "wait for trannsaction execution before submitting new transaction")
+	maxConstExecTxSizeInBytes := flag.Uint("const-exec-max-tx-size", flow.DefaultMaxTransactionByteSize/10, "max byte size of constant exec transaction size to generate")
+	authAccNumInConstExecTx := flag.Uint("const-exec-num-authorizer", 1, "num of authorizer for each constant exec transaction to generate")
+	argSizeInByteInConstExecTx := flag.Uint("const-exec-arg-size", 100, "byte size of tx argument for each constant exec transaction to generate")
+	payerKeyCountInConstExecTx := flag.Uint("const-exec-payer-key-count", 2, "num of payer keys for each constant exec transaction to generate")
 	flag.Parse()
 
 	chainID := flowsdk.ChainID([]byte(*chainIDStr))
@@ -160,6 +164,12 @@ func main() {
 					*accountMultiplierFlag,
 					utils.LoadType(*loadTypeFlag),
 					*feedbackEnabled,
+					utils.ConstExecParam{
+						MaxTxSizeInByte: *maxConstExecTxSizeInBytes,
+						AuthAccountNum:  *authAccNumInConstExecTx,
+						ArgSizeInByte:   *argSizeInByteInConstExecTx,
+						PayerKeyCount:   *payerKeyCountInConstExecTx,
+					},
 				)
 				if err != nil {
 					log.Fatal().Err(err).Msgf("unable to create new cont load generator")

--- a/integration/utils/accounts.go
+++ b/integration/utils/accounts.go
@@ -38,6 +38,17 @@ func (acc *flowAccount) signCreateAccountTx(createAccountTx *flowsdk.Transaction
 	return nil
 }
 
+func (acc *flowAccount) signPayload(tx *flowsdk.Transaction, keyID int) error {
+	acc.signerLock.Lock()
+	defer acc.signerLock.Unlock()
+	err := tx.SignPayload(*acc.address, keyID, acc.signer)
+	if err != nil {
+		return err
+	}
+	acc.seqNumber++
+	return nil
+}
+
 func (acc *flowAccount) signTx(tx *flowsdk.Transaction, keyID int) error {
 	acc.signerLock.Lock()
 	defer acc.signerLock.Unlock()

--- a/integration/utils/contLoadGenerator.go
+++ b/integration/utils/contLoadGenerator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"unsafe"
 
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/access"
 	"github.com/onflow/flow-go-sdk/crypto"
+	flowCrypto "github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -28,7 +30,7 @@ const (
 	CompHeavyLoadType     LoadType = "computation-heavy"
 	EventHeavyLoadType    LoadType = "event-heavy"
 	LedgerHeavyLoadType   LoadType = "ledger-heavy"
-	ConstExecCostLoadType LoadType = "const-exec"
+	ConstExecCostLoadType LoadType = "const-exec" // for an empty transactions with various tx arguments
 )
 
 const slowTransactionThreshold = 30 * time.Second
@@ -105,8 +107,7 @@ func NewContLoadGenerator(
 	// check and cap params for const-exec mode
 	if loadType == ConstExecCostLoadType {
 		if constExecParam.MaxTxSizeInByte > flow.DefaultMaxTransactionByteSize {
-			errMsg := fmt.Sprintf("MaxTxSizeInByte(%d) is larger than DefaultMaxTransactionByteSize."+
-				"Resetting it back to DefaultMaxTransactionByteSize(%d).",
+			errMsg := fmt.Sprintf("MaxTxSizeInByte(%d) is larger than DefaultMaxTransactionByteSize(%d).",
 				constExecParam.MaxTxSizeInByte,
 				flow.DefaultMaxTransactionByteSize)
 			log.Error().Msg(errMsg)
@@ -116,9 +117,8 @@ func NewContLoadGenerator(
 
 		// accounts[0] will be used as the proposer\payer
 		if constExecParam.AuthAccountNum > uint(numberOfAccounts-1) {
-			errMsg := fmt.Sprintf("Number of authorizer(%d) is larger than max possible(%d). Resetting it back to %d.",
+			errMsg := fmt.Sprintf("Number of authorizer(%d) is larger than max possible(%d).",
 				constExecParam.AuthAccountNum,
-				numberOfAccounts-1,
 				numberOfAccounts-1)
 			log.Error().Msg(errMsg)
 
@@ -126,10 +126,9 @@ func NewContLoadGenerator(
 		}
 
 		if constExecParam.ArgSizeInByte > flow.DefaultMaxTransactionByteSize {
-			errMsg := fmt.Sprintf("ArgSizeInByte(%d) is larger than DefaultMaxTransactionByteSize."+
-				"Resetting it back to DefaultMaxTransactionByteSize / 2(%d).",
+			errMsg := fmt.Sprintf("ArgSizeInByte(%d) is larger than DefaultMaxTransactionByteSize(%d).",
 				constExecParam.ArgSizeInByte,
-				flow.DefaultMaxTransactionByteSize/2)
+				flow.DefaultMaxTransactionByteSize)
 			log.Error().Msg(errMsg)
 			return nil, errors.New(errMsg)
 		}
@@ -173,10 +172,22 @@ func (lg *ContLoadGenerator) Init() error {
 			return err
 		}
 	}
-	err := lg.setupFavContract()
-	if err != nil {
-		lg.log.Error().Err(err).Msg("failed to setup fav contract")
-		return err
+	if lg.loadType != ConstExecCostLoadType {
+		err := lg.setupFavContract()
+		if err != nil {
+			lg.log.Error().Err(err).Msg("failed to setup fav contract")
+			return err
+		}
+	} else {
+		lg.log.Info().Int("numberOfAccountsCreated", len(lg.accounts)).
+			Msg("new accounts created. Grabbing the first as the proposer/payer " +
+				"and adding multiple keys to that account")
+
+		err := lg.addKeysToProposerAccount(lg.accounts[0])
+		if err != nil {
+			lg.log.Error().Msg("failed to create add-key transaction for const-exec")
+			return err
+		}
 	}
 
 	return nil
@@ -229,6 +240,8 @@ func (lg *ContLoadGenerator) Start() {
 			worker = NewWorker(i, 1*time.Second, lg.sendTokenTransferTx)
 		case TokenAddKeysLoadType:
 			worker = NewWorker(i, 1*time.Second, lg.sendAddKeyTx)
+		case ConstExecCostLoadType:
+			worker = NewWorker(i, 1*time.Second, lg.sendConstExecCostTx)
 		// other types
 		default:
 			worker = NewWorker(i, 1*time.Second, lg.sendFavContractTx)
@@ -364,9 +377,9 @@ func (lg *ContLoadGenerator) createAccounts(num int) error {
 	return nil
 }
 
-func (lg *ContLoadGenerator) createAddKeyTx(accountAddress flowsdk.Address, numberOfKeysToAdd int) (*flowsdk.Transaction, error) {
+func (lg *ContLoadGenerator) createAddKeyTx(accountAddress flowsdk.Address, numberOfKeysToAdd uint) (*flowsdk.Transaction, error) {
 	cadenceKeys := make([]cadence.Value, numberOfKeysToAdd)
-	for i := 0; i < numberOfKeysToAdd; i++ {
+	for i := uint(0); i < numberOfKeysToAdd; i++ {
 		cadenceKeys[i] = bytesToCadenceArray(lg.serviceAccount.accountKey.Encode())
 	}
 	cadenceKeysArray := cadence.NewArray(cadenceKeys)
@@ -403,7 +416,7 @@ func (lg *ContLoadGenerator) sendAddKeyTx(workerID int) {
 	log := lg.log.With().Int("workerID", workerID).Logger()
 
 	// TODO move this as a configurable parameter
-	numberOfKeysToAdd := 40
+	numberOfKeysToAdd := uint(40)
 
 	log.Trace().Msg("getting next available account")
 
@@ -437,6 +450,126 @@ func (lg *ContLoadGenerator) sendAddKeyTx(workerID int) {
 		return
 	}
 	<-ch
+}
+
+func (lg *ContLoadGenerator) addKeysToProposerAccount(proposerPayerAccount *flowAccount) error {
+	if proposerPayerAccount == nil {
+		return errors.New("proposerPayerAccount is nil")
+	}
+
+	addKeysToPayerTx, err := lg.createAddKeyTx(*lg.accounts[0].address, lg.constExecParam.PayerKeyCount)
+	if err != nil {
+		lg.log.Error().Msg("failed to create add-key transaction for const-exec")
+		return err
+	}
+	addKeysToPayerTx.SetReferenceBlockID(lg.follower.BlockID()).
+		SetProposalKey(*lg.accounts[0].address, 0, lg.accounts[0].seqNumber).
+		SetPayer(*lg.accounts[0].address)
+
+	lg.log.Info().Msg("signing the add-key transaction for const-exec")
+	err = lg.accounts[0].signTx(addKeysToPayerTx, 0)
+	if err != nil {
+		lg.log.Error().Err(err).Msg("error signing the add-key transaction for const-exec")
+		return err
+	}
+
+	lg.log.Info().Msg("issuing the add-key transaction for const-exec")
+	ch, err := lg.sendTx(0, addKeysToPayerTx)
+	if err != nil {
+		return err
+	}
+	<-ch
+
+	lg.log.Info().Msg("the add-key transaction for const-exec is done")
+	return nil
+}
+
+func (lg *ContLoadGenerator) getConstExecCostTxSizeWithoutComment() uint {
+	authorizerListStr := generateAuthAccountParamList(lg.constExecParam.AuthAccountNum)
+	oneSignatureLen := uint(flow.AddressLength) + flowCrypto.SignatureLenECDSAP256 + 8 /* keyId is uint64 */
+
+	// The invariant part of one tx (tx without any parameters) will not be
+	// included here since the size of that part is small and we are not looking
+	// for byte-accurate size calculation here.
+	return lg.constExecParam.ArgSizeInByte +
+		uint(len(authorizerListStr)) +
+		uint(len(constExecTransactionTemplate)) +
+		lg.constExecParam.AuthAccountNum*oneSignatureLen +
+		lg.constExecParam.PayerKeyCount*oneSignatureLen
+}
+
+func (lg *ContLoadGenerator) sendConstExecCostTx(workerID int) {
+	log := lg.log.With().Int("workerID", workerID).Logger()
+
+	emptyTxEstimatedSize := uint(unsafe.Sizeof(flow.TransactionBody{}))
+
+	txSizeWithoutComment := lg.getConstExecCostTxSizeWithoutComment()
+	if lg.constExecParam.MaxTxSizeInByte < (txSizeWithoutComment + emptyTxEstimatedSize) {
+		log.Error().Msg(fmt.Sprintf("current tx size(%d) without comment "+
+			"is larger than max tx size configured(%d)",
+			txSizeWithoutComment, lg.constExecParam.MaxTxSizeInByte))
+		return
+	}
+
+	commentSizeInByte := lg.constExecParam.MaxTxSizeInByte - txSizeWithoutComment
+
+	log.Trace().Uint("Max Tx Size", lg.constExecParam.MaxTxSizeInByte).
+		Uint("Tx Arg Size", lg.constExecParam.ArgSizeInByte).
+		Uint("Num of Authorizers", lg.constExecParam.AuthAccountNum).
+		Uint("Num of payer keys", lg.constExecParam.PayerKeyCount).
+		Uint("Script comment length", commentSizeInByte).
+		Msg("Generating one const-exec transaction")
+
+	txScript := ConstExecCostTransaction(lg.constExecParam.AuthAccountNum, commentSizeInByte)
+
+	tx := flowsdk.NewTransaction().
+		SetReferenceBlockID(lg.follower.BlockID()).
+		SetScript(txScript).
+		SetGasLimit(10). // const-exec tx has empty transaction
+		SetProposalKey(*lg.accounts[0].address, 0, lg.accounts[0].seqNumber).
+		SetPayer(*lg.accounts[0].address)
+	lg.accounts[0].seqNumber += 1
+
+	txArgStr := generateRandomStringWithLen(lg.constExecParam.ArgSizeInByte)
+	txArg, err := cadence.NewString(txArgStr)
+	if err != nil {
+		log.Trace().Msg("Failed to generate cadence String parameter. Using empty string.")
+	}
+	tx.AddArgument(txArg)
+
+	// Add authorizers. lg.accounts[0] used as proposer\payer
+	log.Trace().Msg("Adding tx authorizers")
+	for i := uint(1); i < lg.constExecParam.AuthAccountNum+1; i++ {
+		tx = tx.AddAuthorizer(*lg.accounts[i].address)
+	}
+
+	log.Trace().Msg("Authorizers signing tx")
+	for i := uint(1); i < lg.constExecParam.AuthAccountNum+1; i++ {
+		err := lg.accounts[i].signPayload(tx, 0)
+		if err != nil {
+			log.Error().Err(err).Msg("error signing payload")
+			return
+		}
+	}
+
+	log.Trace().Msg("Payer signing tx")
+	for i := uint(0); i < lg.constExecParam.PayerKeyCount; i++ {
+		err = lg.accounts[0].signTx(tx, int(i))
+		if err != nil {
+			log.Error().Err(err).Msg("error signing transaction")
+			return
+		}
+	}
+
+	log.Trace().Msg("Issuing tx")
+	ch, err := lg.sendTx(workerID, tx)
+	if err != nil {
+		log.Error().Err(err).Msg("const-exec tx failed")
+		return
+	}
+	<-ch
+
+	log.Trace().Msg("const-exec tx suceeded")
 }
 
 func (lg *ContLoadGenerator) sendTokenTransferTx(workerID int) {

--- a/integration/utils/scripts.go
+++ b/integration/utils/scripts.go
@@ -91,13 +91,13 @@ func LedgerHeavyScript(favContractAddress flowsdk.Address) []byte {
 //go:embed scripts/constExecCostTransaction.cdc
 var constExecTransactionTemplate string
 
-func generateCadenceCommentWithLen(commentLen uint) string {
+func generateRandomStringWithLen(commentLen uint) string {
 	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	bytes := make([]byte, commentLen)
 	for i := range bytes {
 		bytes[i] = letterBytes[rand.Intn(len(letterBytes))]
 	}
-	return "//" + string(bytes)
+	return string(bytes)
 }
 
 func generateAuthAccountParamList(authAccountNum uint) string {
@@ -110,7 +110,7 @@ func generateAuthAccountParamList(authAccountNum uint) string {
 
 // ConstExecCostTransaction returns a transaction script for constant execution size (0)
 func ConstExecCostTransaction(numOfAuthorizer, commentSizeInByte uint) []byte {
-	commentStr := generateCadenceCommentWithLen(commentSizeInByte)
+	commentStr := generateRandomStringWithLen(commentSizeInByte)
 	authAccountListStr := generateAuthAccountParamList(numOfAuthorizer)
 
 	// the transaction template has two `%s`: #1 is for comment; #2 is for AuthAccount param list

--- a/integration/utils/scripts.go
+++ b/integration/utils/scripts.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/onflow/cadence"
@@ -85,6 +86,35 @@ var ledgerHeavyScriptTemplate string
 
 func LedgerHeavyScript(favContractAddress flowsdk.Address) []byte {
 	return []byte(fmt.Sprintf(ledgerHeavyScriptTemplate, favContractAddress))
+}
+
+//go:embed scripts/constExecCostTransaction.cdc
+var constExecTransactionTemplate string
+
+func generateCadenceCommentWithLen(commentLen uint) string {
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	bytes := make([]byte, commentLen)
+	for i := range bytes {
+		bytes[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return "//" + string(bytes)
+}
+
+func generateAuthAccountParamList(authAccountNum uint) string {
+	authAccountList := []string{}
+	for i := uint(0); i < authAccountNum; i++ {
+		authAccountList = append(authAccountList, fmt.Sprintf("acct%d: AuthAccount", i+1))
+	}
+	return strings.Join(authAccountList, ", ")
+}
+
+// ConstExecCostTransaction returns a transaction script for constant execution size (0)
+func ConstExecCostTransaction(numOfAuthorizer, commentSizeInByte uint) []byte {
+	commentStr := generateCadenceCommentWithLen(commentSizeInByte)
+	authAccountListStr := generateAuthAccountParamList(numOfAuthorizer)
+
+	// the transaction template has two `%s`: #1 is for comment; #2 is for AuthAccount param list
+	return []byte(fmt.Sprintf(constExecTransactionTemplate, commentStr, authAccountListStr))
 }
 
 func bytesToCadenceArray(l []byte) cadence.Array {

--- a/integration/utils/scripts/constExecCostTransaction.cdc
+++ b/integration/utils/scripts/constExecCostTransaction.cdc
@@ -1,4 +1,4 @@
-%s
+// %s
 transaction(arg: String) {
     prepare(%s) {}
 }

--- a/integration/utils/scripts/constExecCostTransaction.cdc
+++ b/integration/utils/scripts/constExecCostTransaction.cdc
@@ -1,0 +1,4 @@
+%s
+transaction(arg: String) {
+    prepare(%s) {}
+}


### PR DESCRIPTION
#2785 

#### Summary

As part of Dynamic Inclusion Fee feature development (more details can be found at https://www.notion.so/dapperlabs/Variable-Transaction-Fees-Inclusion-Effort-I-20c849105a3945879824e386cc9c3ebf by @janezpodhostnik ), we will need to get proper co-efficient values for the new inclusion fee equation that can fit well with our production transactions with different sizes. Before we do that in production, we will need to be able to create tx with given sizes sent to devnet\testnet to get initial metrics. 

This PR adds a new loader test type that allows us to create and send tx with given size.

#### Test Plan

- [X] launch localnet and launch loader with the new test type. monitor dashboards and EN logs to make sure tx went through.
<img width="1187" alt="Screen Shot 2022-07-18 at 9 40 10 AM" src="https://user-images.githubusercontent.com/5504323/179567018-2e723f91-13ec-41bf-9e3c-15596831858b.png">

- [X] set different tx size parameters and monitor actual tx size
![Screen Shot 2022-07-20 at 2 05 09 PM](https://user-images.githubusercontent.com/5504323/180083601-8af63169-886d-40ff-9a26-510cc0287745.png)
![Screen Shot 2022-07-20 at 2 09 56 PM](https://user-images.githubusercontent.com/5504323/180083614-54044487-4714-4d26-a1ae-f203c5ad8185.png)

