### PR TITLE
fixed decoding error for signer indices at epoch switchover

### DIFF
--- a/consensus/hotstuff/signature/block_signer_decoder.go
+++ b/consensus/hotstuff/signature/block_signer_decoder.go
@@ -35,15 +35,16 @@ func (b *BlockSignerDecoder) DecodeSignerIDs(header *flow.Header) (flow.Identifi
 		return []flow.Identifier{}, nil
 	}
 
-	id := header.ID()
-	members, err := b.Identities(id)
+	// The block header contains the signatures for the parents. Hence, we need to get the
+	// identities that were authorized to sign the parent block, to decode the signer indices.
+	members, err := b.Identities(header.ParentID)
 	if err != nil {
 		// TODO: this potentially needs to be updated when we implement and document proper error handling for
 		//       `hotstuff.Committee` and underlying code (such as `protocol.Snapshot`)
 		if errors.Is(err, storage.ErrNotFound) {
-			return nil, state.WrapAsUnknownBlockError(id, err)
+			return nil, state.WrapAsUnknownBlockError(header.ID(), err)
 		}
-		return nil, fmt.Errorf("fail to retrieve identities for block %v: %w", id, err)
+		return nil, fmt.Errorf("fail to retrieve identities for block %v: %w", header.ID(), err)
 	}
 	signerIDs, err := signature.DecodeSignerIndicesToIdentifiers(members.NodeIDs(), header.ParentVoterIndices)
 	if err != nil {

--- a/consensus/hotstuff/signature/block_signer_decoder_test.go
+++ b/consensus/hotstuff/signature/block_signer_decoder_test.go
@@ -34,15 +34,15 @@ func (s *blockSignerDecoderSuite) SetupTest() {
 	// the default header fixture creates signerIDs for a committee of 10 nodes, so we prepare a committee same as that
 	s.allConsensus = unittest.IdentityListFixture(40, unittest.WithRole(flow.RoleConsensus)).Sort(order.Canonical)
 
-	// mock consensus committee
-	s.committee = new(hotstuff.Committee)
-	s.committee.On("Identities", mock.Anything).Return(s.allConsensus, nil)
-
 	// prepare valid test block:
 	voterIndices, err := signature.EncodeSignersToIndices(s.allConsensus.NodeIDs(), s.allConsensus.NodeIDs())
 	require.NoError(s.T(), err)
 	s.block = unittest.BlockFixture()
 	s.block.Header.ParentVoterIndices = voterIndices
+
+	// mock consensus committee
+	s.committee = new(hotstuff.Committee)
+	s.committee.On("Identities", s.block.Header.ParentID).Return(s.allConsensus, nil)
 
 	s.decoder = NewBlockSignerDecoder(s.committee)
 }


### PR DESCRIPTION
* follow up to PR https://github.com/onflow/flow-go/pull/2789
* changes in this PR are identical to fix for `master`: https://github.com/onflow/flow-go/pull/2830

## Description of revisions:
For block `44f..a`, the access API fails to decode the signer indices:
```
could not decode signer indices for block 44ff570d66aeac087da261e7bac13247fa96bbb0792ee65cf8714e3632da034a: signer indices' checkum is invalid: decoder sees a canonical list [...], which has a different checksum eb94d50f than the encoder's checksum ef2c778c: index vector's checksum is invalid
```

I think it the culprit is this line in the code:
https://github.com/onflow/flow-go/blob/01fae8ea3b6658715880aa014866e9b8b61233bb/consensus/hotstuff/signature/block_signer_decoder.go#L38-L39
* because a block includes the signatures for the _parent_
* but we are retrieving the entities that are allowed to sign the block itself (not the parent)

This breaks exactly at epoch switchover

