### PR TITLE
Add ComputationMeter interface to facilitate env code dedup-ing

### DIFF
--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -88,6 +88,9 @@ func NewTransactionEnvironment(
 		txID:             tx.ID(),
 	}
 
+	// TODO(patrick): rm this hack after merging #2800
+	env.ComputationMeter = env
+
 	env.contracts = handler.NewContractHandler(accounts,
 		func() bool {
 			enabled, defined := env.GetIsContractDeploymentRestricted()
@@ -323,7 +326,7 @@ func (e *TransactionEnv) GetValue(owner, key []byte) ([]byte, error) {
 	}
 	valueByteSize = len(v)
 
-	err = e.meterComputation(meter.ComputationKindGetValue, uint(valueByteSize))
+	err = e.Meter(meter.ComputationKindGetValue, uint(valueByteSize))
 	if err != nil {
 		return nil, fmt.Errorf("get value failed: %w", err)
 	}
@@ -340,7 +343,7 @@ func (e *TransactionEnv) SetValue(owner, key, value []byte) error {
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindSetValue, uint(len(value)))
+	err := e.Meter(meter.ComputationKindSetValue, uint(len(value)))
 	if err != nil {
 		return fmt.Errorf("set value failed: %w", err)
 	}
@@ -362,7 +365,7 @@ func (e *TransactionEnv) ValueExists(owner, key []byte) (exists bool, err error)
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindValueExists, 1)
+	err = e.Meter(meter.ComputationKindValueExists, 1)
 	if err != nil {
 		return false, fmt.Errorf("checking value existence failed: %w", err)
 	}
@@ -377,7 +380,7 @@ func (e *TransactionEnv) ValueExists(owner, key []byte) (exists bool, err error)
 
 // AllocateStorageIndex allocates new storage index under the owner accounts to store a new register
 func (e *TransactionEnv) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
-	err := e.meterComputation(meter.ComputationKindAllocateStorageIndex, 1)
+	err := e.Meter(meter.ComputationKindAllocateStorageIndex, 1)
 	if err != nil {
 		return atree.StorageIndex{}, fmt.Errorf("allocate storage index failed: %w", err)
 	}
@@ -395,7 +398,7 @@ func (e *TransactionEnv) GetStorageUsed(address common.Address) (value uint64, e
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindGetStorageUsed, 1)
+	err = e.Meter(meter.ComputationKindGetStorageUsed, 1)
 	if err != nil {
 		return value, fmt.Errorf("get storage used failed: %w", err)
 	}
@@ -414,7 +417,7 @@ func (e *TransactionEnv) GetStorageCapacity(address common.Address) (value uint6
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindGetStorageCapacity, 1)
+	err = e.Meter(meter.ComputationKindGetStorageCapacity, 1)
 	if err != nil {
 		return value, fmt.Errorf("get storage capacity failed: %w", err)
 	}
@@ -443,7 +446,7 @@ func (e *TransactionEnv) GetAccountBalance(address common.Address) (value uint64
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindGetAccountBalance, 1)
+	err = e.Meter(meter.ComputationKindGetAccountBalance, 1)
 	if err != nil {
 		return value, fmt.Errorf("get account balance failed: %w", err)
 	}
@@ -461,7 +464,7 @@ func (e *TransactionEnv) GetAccountAvailableBalance(address common.Address) (val
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindGetAccountAvailableBalance, 1)
+	err = e.Meter(meter.ComputationKindGetAccountAvailableBalance, 1)
 	if err != nil {
 		return value, fmt.Errorf("get account available balance failed: %w", err)
 	}
@@ -486,7 +489,7 @@ func (e *TransactionEnv) ResolveLocation(
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindResolveLocation, 1)
+	err := e.Meter(meter.ComputationKindResolveLocation, 1)
 	if err != nil {
 		return nil, fmt.Errorf("resolve location failed: %w", err)
 	}
@@ -558,7 +561,7 @@ func (e *TransactionEnv) GetCode(location runtime.Location) ([]byte, error) {
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindGetCode, 1)
+	err := e.Meter(meter.ComputationKindGetCode, 1)
 	if err != nil {
 		return nil, fmt.Errorf("get code failed: %w", err)
 	}
@@ -589,7 +592,7 @@ func (e *TransactionEnv) GetAccountContractNames(address runtime.Address) ([]str
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindGetAccountContractNames, 1)
+	err := e.Meter(meter.ComputationKindGetAccountContractNames, 1)
 	if err != nil {
 		return nil, fmt.Errorf("get account contract names failed: %w", err)
 	}
@@ -610,7 +613,7 @@ func (e *TransactionEnv) GetProgram(location common.Location) (*interpreter.Prog
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindGetProgram, 1)
+	err := e.Meter(meter.ComputationKindGetProgram, 1)
 	if err != nil {
 		return nil, fmt.Errorf("get program failed: %w", err)
 	}
@@ -638,7 +641,7 @@ func (e *TransactionEnv) SetProgram(location common.Location, program *interpret
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindSetProgram, 1)
+	err := e.Meter(meter.ComputationKindSetProgram, 1)
 	if err != nil {
 		return fmt.Errorf("set program failed: %w", err)
 	}
@@ -673,7 +676,7 @@ func (e *TransactionEnv) EmitEvent(event cadence.Event) error {
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindEmitEvent, 1)
+	err := e.Meter(meter.ComputationKindEmitEvent, 1)
 	if err != nil {
 		return fmt.Errorf("emit event failed: %w", err)
 	}
@@ -695,7 +698,7 @@ func (e *TransactionEnv) GenerateUUID() (uint64, error) {
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindGenerateUUID, 1)
+	err := e.Meter(meter.ComputationKindGenerateUUID, 1)
 	if err != nil {
 		return 0, fmt.Errorf("generate uuid failed: %w", err)
 	}
@@ -711,7 +714,7 @@ func (e *TransactionEnv) GenerateUUID() (uint64, error) {
 	return uuid, err
 }
 
-func (e *TransactionEnv) meterComputation(kind common.ComputationKind, intensity uint) error {
+func (e *TransactionEnv) Meter(kind common.ComputationKind, intensity uint) error {
 	if e.sth.EnforceComputationLimits {
 		return e.sth.State().MeterComputation(kind, intensity)
 	}
@@ -719,7 +722,7 @@ func (e *TransactionEnv) meterComputation(kind common.ComputationKind, intensity
 }
 
 func (e *TransactionEnv) MeterComputation(kind common.ComputationKind, intensity uint) error {
-	return e.meterComputation(kind, intensity)
+	return e.Meter(kind, intensity)
 }
 
 func (e *TransactionEnv) ComputationUsed() uint64 {
@@ -781,21 +784,6 @@ func (e *TransactionEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value
 	return v, err
 }
 
-func (e *TransactionEnv) Hash(data []byte, tag string, hashAlgorithm runtime.HashAlgorithm) ([]byte, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvHash)
-		defer sp.Finish()
-	}
-
-	err := e.meterComputation(meter.ComputationKindHash, 1)
-	if err != nil {
-		return nil, fmt.Errorf("hash failed: %w", err)
-	}
-
-	hashAlgo := crypto.RuntimeToCryptoHashingAlgorithm(hashAlgorithm)
-	return crypto.HashWithTag(hashAlgo, tag, data)
-}
-
 func (e *TransactionEnv) VerifySignature(
 	signature []byte,
 	tag string,
@@ -809,7 +797,7 @@ func (e *TransactionEnv) VerifySignature(
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindVerifySignature, 1)
+	err := e.Meter(meter.ComputationKindVerifySignature, 1)
 	if err != nil {
 		return false, fmt.Errorf("verify signature failed: %w", err)
 	}
@@ -831,7 +819,7 @@ func (e *TransactionEnv) VerifySignature(
 }
 
 func (e *TransactionEnv) ValidatePublicKey(pk *runtime.PublicKey) error {
-	err := e.meterComputation(meter.ComputationKindValidatePublicKey, 1)
+	err := e.Meter(meter.ComputationKindValidatePublicKey, 1)
 	if err != nil {
 		return fmt.Errorf("validate public key failed: %w", err)
 	}
@@ -848,7 +836,7 @@ func (e *TransactionEnv) GetCurrentBlockHeight() (uint64, error) {
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindGetCurrentBlockHeight, 1)
+	err := e.Meter(meter.ComputationKindGetCurrentBlockHeight, 1)
 	if err != nil {
 		return 0, fmt.Errorf("get current block height failed: %w", err)
 	}
@@ -884,7 +872,7 @@ func (e *TransactionEnv) GetBlockAtHeight(height uint64) (runtime.Block, bool, e
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindGetBlockAtHeight, 1)
+	err := e.Meter(meter.ComputationKindGetBlockAtHeight, 1)
 	if err != nil {
 		return runtime.Block{}, false, fmt.Errorf("get block at height failed: %w", err)
 	}
@@ -915,7 +903,7 @@ func (e *TransactionEnv) CreateAccount(payer runtime.Address) (address runtime.A
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindCreateAccount, 1)
+	err = e.Meter(meter.ComputationKindCreateAccount, 1)
 	if err != nil {
 		return address, err
 	}
@@ -958,7 +946,7 @@ func (e *TransactionEnv) AddEncodedAccountKey(address runtime.Address, publicKey
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindAddEncodedAccountKey, 1)
+	err := e.Meter(meter.ComputationKindAddEncodedAccountKey, 1)
 	if err != nil {
 		return fmt.Errorf("add encoded account key failed: %w", err)
 	}
@@ -990,7 +978,7 @@ func (e *TransactionEnv) RevokeEncodedAccountKey(address runtime.Address, index 
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindRevokeEncodedAccountKey, 1)
+	err = e.Meter(meter.ComputationKindRevokeEncodedAccountKey, 1)
 	if err != nil {
 		return publicKey, fmt.Errorf("revoke encoded account key failed: %w", err)
 	}
@@ -1026,7 +1014,7 @@ func (e *TransactionEnv) AddAccountKey(
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindAddAccountKey, 1)
+	err := e.Meter(meter.ComputationKindAddAccountKey, 1)
 	if err != nil {
 		return nil, fmt.Errorf("add account key failed: %w", err)
 	}
@@ -1050,7 +1038,7 @@ func (e *TransactionEnv) GetAccountKey(address runtime.Address, keyIndex int) (*
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindGetAccountKey, 1)
+	err := e.Meter(meter.ComputationKindGetAccountKey, 1)
 	if err != nil {
 		return nil, fmt.Errorf("get account key failed: %w", err)
 	}
@@ -1074,7 +1062,7 @@ func (e *TransactionEnv) RevokeAccountKey(address runtime.Address, keyIndex int)
 		defer sp.Finish()
 	}
 
-	err := e.meterComputation(meter.ComputationKindRevokeAccountKey, 1)
+	err := e.Meter(meter.ComputationKindRevokeAccountKey, 1)
 	if err != nil {
 		return nil, fmt.Errorf("revoke account key failed: %w", err)
 	}
@@ -1088,7 +1076,7 @@ func (e *TransactionEnv) UpdateAccountContractCode(address runtime.Address, name
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindUpdateAccountContractCode, 1)
+	err = e.Meter(meter.ComputationKindUpdateAccountContractCode, 1)
 	if err != nil {
 		return fmt.Errorf("update account contract code failed: %w", err)
 	}
@@ -1112,7 +1100,7 @@ func (e *TransactionEnv) GetAccountContractCode(address runtime.Address, name st
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindGetAccountContractCode, 1)
+	err = e.Meter(meter.ComputationKindGetAccountContractCode, 1)
 	if err != nil {
 		return nil, fmt.Errorf("get account contract code failed: %w", err)
 	}
@@ -1134,7 +1122,7 @@ func (e *TransactionEnv) RemoveAccountContractCode(address runtime.Address, name
 		defer sp.Finish()
 	}
 
-	err = e.meterComputation(meter.ComputationKindRemoveAccountContractCode, 1)
+	err = e.Meter(meter.ComputationKindRemoveAccountContractCode, 1)
 	if err != nil {
 		return fmt.Errorf("remove account contract code failed: %w", err)
 	}


### PR DESCRIPTION
This enables to us to continue with the dedup-ing effort while waiting on #2800.

I've dedup `Hash()` in the same commit as proof of concept.

Per usual, I've renamed the environment variable `e` to `env` to improve searchability.