### PR TITLE
dedup code in script/transaction environment (part 2 of many)

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -2,10 +2,14 @@ package fvm
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"time"
 
+	"github.com/onflow/atree"
+	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -13,12 +17,14 @@ import (
 	traceLog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/onflow/flow-go/fvm/crypto"
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/handler"
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/trace"
+	"github.com/onflow/flow-go/storage"
 )
 
 // Environment accepts a context and a virtual machine instance and provides
@@ -29,15 +35,44 @@ type Environment interface {
 	runtime.Interface
 }
 
-// TODO(patrick): refactor this into an object after merging #2800
-type ComputationMeter interface {
+// TODO(patrick): refactor this into an object.
+// TODO(patrick): rename the method names to match meter.Meter interface.
+type MeterInterface interface {
 	Meter(common.ComputationKind, uint) error
+
+	meterMemory(kind common.MemoryKind, intensity uint) error
+}
+
+// TODO(patrick): refactor this into an object
+// Set of account api that do not have shared implementation.
+type AccountInterface interface {
+	CreateAccount(address runtime.Address) (runtime.Address, error)
+
+	AddAccountKey(
+		address runtime.Address,
+		publicKey *runtime.PublicKey,
+		hashAlgo runtime.HashAlgorithm,
+		weight int,
+	) (
+		*runtime.AccountKey,
+		error,
+	)
+
+	GetAccountKey(address runtime.Address, keyIndex int) (*runtime.AccountKey, error)
+
+	RevokeAccountKey(address runtime.Address, keyIndex int) (*runtime.AccountKey, error)
+
+	AddEncodedAccountKey(address runtime.Address, publicKey []byte) error
+
+	// TODO(patrick): figure out where this belongs
+	GetSigningAccounts() ([]runtime.Address, error)
 }
 
 // Parts of the environment that are common to all transaction and script
 // executions.
 type commonEnv struct {
-	ComputationMeter
+	MeterInterface
+	AccountInterface
 
 	ctx           Context
 	sth           *state.StateHolder
@@ -51,6 +86,26 @@ type commonEnv struct {
 	logs          []string
 	rng           *rand.Rand
 	traceSpan     opentracing.Span
+}
+
+// TODO(patrick): rm once Meter object has been refactored
+func (env *commonEnv) MeterComputation(kind common.ComputationKind, intensity uint) error {
+	return env.Meter(kind, intensity)
+}
+
+// TODO(patrick): rm once Meter object has been refactored
+func (env *commonEnv) ComputationUsed() uint64 {
+	return uint64(env.sth.State().TotalComputationUsed())
+}
+
+// TODO(patrick): rm once Meter object has been refactored
+func (env *commonEnv) MeterMemory(usage common.MemoryUsage) error {
+	return env.meterMemory(usage.Kind, uint(usage.Amount))
+}
+
+// TODO(patrick): rm once Meter object has been refactored
+func (env *commonEnv) MemoryEstimate() uint64 {
+	return uint64(env.sth.State().TotalMemoryEstimate())
 }
 
 func (env *commonEnv) Context() *Context {
@@ -70,8 +125,318 @@ func (env *commonEnv) seedRNG(header *flow.Header) {
 	env.rng = rand.New(source)
 }
 
+// UnsafeRandom returns a random uint64, where the process of random number derivation is not cryptographically
+// secure.
+func (env *commonEnv) UnsafeRandom() (uint64, error) {
+	if env.isTraceable() && env.ctx.ExtensiveTracing {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvUnsafeRandom)
+		defer sp.Finish()
+	}
+
+	if env.rng == nil {
+		return 0, errors.NewOperationNotSupportedError("UnsafeRandom")
+	}
+
+	// TODO (ramtin) return errors this assumption that this always succeeds might not be true
+	buf := make([]byte, 8)
+	_, _ = env.rng.Read(buf) // Always succeeds, no need to check error
+	return binary.LittleEndian.Uint64(buf), nil
+}
+
 func (env *commonEnv) isTraceable() bool {
 	return env.ctx.Tracer != nil && env.traceSpan != nil
+}
+
+func (env *commonEnv) GenerateUUID() (uint64, error) {
+	if env.isTraceable() && env.ctx.ExtensiveTracing {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGenerateUUID)
+		defer sp.Finish()
+	}
+
+	if env.uuidGenerator == nil {
+		return 0, errors.NewOperationNotSupportedError("GenerateUUID")
+	}
+
+	err := env.Meter(meter.ComputationKindGenerateUUID, 1)
+	if err != nil {
+		return 0, fmt.Errorf("generate uuid failed: %w", err)
+	}
+
+	uuid, err := env.uuidGenerator.GenerateUUID()
+	if err != nil {
+		return 0, fmt.Errorf("generate uuid failed: %w", err)
+	}
+	return uuid, err
+}
+
+// GetCurrentBlockHeight returns the current block height.
+func (env *commonEnv) GetCurrentBlockHeight() (uint64, error) {
+	if env.isTraceable() && env.ctx.ExtensiveTracing {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetCurrentBlockHeight)
+		defer sp.Finish()
+	}
+
+	err := env.Meter(meter.ComputationKindGetCurrentBlockHeight, 1)
+	if err != nil {
+		return 0, fmt.Errorf("get current block height failed: %w", err)
+	}
+
+	if env.ctx.BlockHeader == nil {
+		return 0, errors.NewOperationNotSupportedError("GetCurrentBlockHeight")
+	}
+	return env.ctx.BlockHeader.Height, nil
+}
+
+// GetBlockAtHeight returns the block at the given height.
+func (env *commonEnv) GetBlockAtHeight(height uint64) (runtime.Block, bool, error) {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetBlockAtHeight)
+		defer sp.Finish()
+	}
+
+	err := env.Meter(meter.ComputationKindGetBlockAtHeight, 1)
+	if err != nil {
+		return runtime.Block{}, false, fmt.Errorf("get block at height failed: %w", err)
+	}
+
+	if env.ctx.Blocks == nil {
+		return runtime.Block{}, false, errors.NewOperationNotSupportedError("GetBlockAtHeight")
+	}
+
+	if env.ctx.BlockHeader != nil && height == env.ctx.BlockHeader.Height {
+		return runtimeBlockFromHeader(env.ctx.BlockHeader), true, nil
+	}
+
+	header, err := env.ctx.Blocks.ByHeightFrom(height, env.ctx.BlockHeader)
+	// TODO (ramtin): remove dependency on storage and move this if condition to blockfinder
+	if errors.Is(err, storage.ErrNotFound) {
+		return runtime.Block{}, false, nil
+	} else if err != nil {
+		return runtime.Block{}, false, fmt.Errorf("get block at height failed for height %v: %w", height, err)
+	}
+
+	return runtimeBlockFromHeader(header), true, nil
+}
+
+func (env *commonEnv) GetValue(owner, key []byte) ([]byte, error) {
+	var valueByteSize int
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetValue)
+		defer func() {
+			sp.LogFields(
+				traceLog.String("owner", hex.EncodeToString(owner)),
+				traceLog.String("key", string(key)),
+				traceLog.Int("valueByteSize", valueByteSize),
+			)
+			sp.Finish()
+		}()
+	}
+
+	v, err := env.accounts.GetValue(
+		flow.BytesToAddress(owner),
+		string(key),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get value failed: %w", err)
+	}
+	valueByteSize = len(v)
+
+	err = env.Meter(meter.ComputationKindGetValue, uint(valueByteSize))
+	if err != nil {
+		return nil, fmt.Errorf("get value failed: %w", err)
+	}
+	return v, nil
+}
+
+// TODO disable SetValue for scripts, right now the view changes are discarded
+func (env *commonEnv) SetValue(owner, key, value []byte) error {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvSetValue)
+		sp.LogFields(
+			traceLog.String("owner", hex.EncodeToString(owner)),
+			traceLog.String("key", string(key)),
+		)
+		defer sp.Finish()
+	}
+	err := env.Meter(meter.ComputationKindSetValue, uint(len(value)))
+	if err != nil {
+		return fmt.Errorf("set value failed: %w", err)
+	}
+
+	err = env.accounts.SetValue(
+		flow.BytesToAddress(owner),
+		string(key),
+		value,
+	)
+	if err != nil {
+		return fmt.Errorf("set value failed: %w", err)
+	}
+	return nil
+}
+
+func (env *commonEnv) ValueExists(owner, key []byte) (exists bool, err error) {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvValueExists)
+		defer sp.Finish()
+	}
+
+	err = env.Meter(meter.ComputationKindValueExists, 1)
+	if err != nil {
+		return false, fmt.Errorf("check value existence failed: %w", err)
+	}
+
+	v, err := env.GetValue(owner, key)
+	if err != nil {
+		return false, fmt.Errorf("check value existence failed: %w", err)
+	}
+
+	return len(v) > 0, nil
+}
+
+func (env *commonEnv) GetStorageUsed(address common.Address) (value uint64, err error) {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetStorageUsed)
+		defer sp.Finish()
+	}
+
+	err = env.Meter(meter.ComputationKindGetStorageUsed, 1)
+	if err != nil {
+		return value, fmt.Errorf("get storage used failed: %w", err)
+	}
+
+	value, err = env.accounts.GetStorageUsed(flow.Address(address))
+	if err != nil {
+		return value, fmt.Errorf("get storage used failed: %w", err)
+	}
+
+	return value, nil
+}
+
+// storageMBUFixToBytesUInt converts the return type of storage capacity which is a UFix64 with the unit of megabytes to
+// UInt with the unit of bytes
+func storageMBUFixToBytesUInt(result cadence.Value) uint64 {
+	// Divide the unsigned int by (1e8 (the scale of Fix64) / 1e6 (for mega)) to get bytes (rounded down)
+	return result.ToGoValue().(uint64) / 100
+}
+
+func (env *commonEnv) GetAccountContractNames(address runtime.Address) ([]string, error) {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetAccountContractNames)
+		defer sp.Finish()
+	}
+
+	err := env.Meter(meter.ComputationKindGetAccountContractNames, 1)
+	if err != nil {
+		return nil, fmt.Errorf("get account contract names failed: %w", err)
+	}
+
+	a := flow.Address(address)
+
+	freezeError := env.accounts.CheckAccountNotFrozen(a)
+	if freezeError != nil {
+		return nil, fmt.Errorf("get account contract names failed: %w", freezeError)
+	}
+
+	return env.accounts.GetContractNames(a)
+}
+
+func (env *commonEnv) GetCode(location runtime.Location) ([]byte, error) {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetCode)
+		defer sp.Finish()
+	}
+
+	err := env.Meter(meter.ComputationKindGetCode, 1)
+	if err != nil {
+		return nil, fmt.Errorf("get code failed: %w", err)
+	}
+
+	contractLocation, ok := location.(common.AddressLocation)
+	if !ok {
+		return nil, errors.NewInvalidLocationErrorf(location, "expecting an AddressLocation, but other location types are passed")
+	}
+
+	address := flow.Address(contractLocation.Address)
+
+	err = env.accounts.CheckAccountNotFrozen(address)
+	if err != nil {
+		return nil, fmt.Errorf("get code failed: %w", err)
+	}
+
+	add, err := env.contracts.GetContract(contractLocation.Address, contractLocation.Name)
+	if err != nil {
+		return nil, fmt.Errorf("get code failed: %w", err)
+	}
+
+	return add, nil
+}
+
+func (env *commonEnv) GetAccountContractCode(address runtime.Address, name string) (code []byte, err error) {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetAccountContractCode)
+		defer sp.Finish()
+	}
+
+	err = env.Meter(meter.ComputationKindGetAccountContractCode, 1)
+	if err != nil {
+		return nil, fmt.Errorf("get account contract code failed: %w", err)
+	}
+
+	code, err = env.GetCode(common.AddressLocation{
+		Address: address,
+		Name:    name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get account contract code failed: %w", err)
+	}
+
+	return code, nil
+}
+
+func (env *commonEnv) GetProgram(location common.Location) (*interpreter.Program, error) {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvGetProgram)
+		defer sp.Finish()
+	}
+
+	err := env.Meter(meter.ComputationKindGetProgram, 1)
+	if err != nil {
+		return nil, fmt.Errorf("get program failed: %w", err)
+	}
+
+	if addressLocation, ok := location.(common.AddressLocation); ok {
+		address := flow.Address(addressLocation.Address)
+
+		freezeError := env.accounts.CheckAccountNotFrozen(address)
+		if freezeError != nil {
+			return nil, fmt.Errorf("get program failed: %w", freezeError)
+		}
+	}
+
+	program, has := env.programs.Get(location)
+	if has {
+		return program, nil
+	}
+
+	return nil, nil
+}
+
+func (env *commonEnv) SetProgram(location common.Location, program *interpreter.Program) error {
+	if env.isTraceable() {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvSetProgram)
+		defer sp.Finish()
+	}
+
+	err := env.Meter(meter.ComputationKindSetProgram, 1)
+	if err != nil {
+		return fmt.Errorf("set program failed: %w", err)
+	}
+
+	err = env.programs.Set(location, program)
+	if err != nil {
+		return fmt.Errorf("set program failed: %w", err)
+	}
+	return nil
 }
 
 func (env *commonEnv) ImplementationDebugLog(message string) error {
@@ -96,6 +461,21 @@ func (env *commonEnv) Hash(
 
 	hashAlgo := crypto.RuntimeToCryptoHashingAlgorithm(hashAlgorithm)
 	return crypto.HashWithTag(hashAlgo, tag, data)
+}
+
+func (env *commonEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value, error) {
+	if env.isTraceable() && env.ctx.ExtensiveTracing {
+		sp := env.ctx.Tracer.StartSpanFromParent(env.traceSpan, trace.FVMEnvDecodeArgument)
+		defer sp.Finish()
+	}
+
+	v, err := jsoncdc.Decode(env, b)
+	if err != nil {
+		err = errors.NewInvalidArgumentErrorf("argument is not json decodable: %w", err)
+		return nil, fmt.Errorf("decodeing argument failed: %w", err)
+	}
+
+	return v, err
 }
 
 func (env *commonEnv) RecordTrace(operation string, location common.Location, duration time.Duration, logs []opentracing.LogRecord) {
@@ -170,4 +550,18 @@ func (commonEnv) ResourceOwnerChanged(
 	common.Address,
 	common.Address,
 ) {
+}
+
+// AllocateStorageIndex allocates new storage index under the owner accounts to store a new register
+func (env *commonEnv) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
+	err := env.Meter(meter.ComputationKindAllocateStorageIndex, 1)
+	if err != nil {
+		return atree.StorageIndex{}, fmt.Errorf("allocate storage index failed: %w", err)
+	}
+
+	v, err := env.accounts.AllocateStorageIndex(flow.BytesToAddress(owner))
+	if err != nil {
+		return atree.StorageIndex{}, fmt.Errorf("storage address allocation failed: %w", err)
+	}
+	return v, nil
 }

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -2,19 +2,12 @@ package fvm
 
 import (
 	"context"
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 
-	"github.com/onflow/atree"
-	traceLog "github.com/opentracing/opentracing-go/log"
-
 	"github.com/onflow/cadence"
-	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/onflow/flow-go/fvm/crypto"
 	"github.com/onflow/flow-go/fvm/errors"
@@ -25,7 +18,6 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/trace"
-	"github.com/onflow/flow-go/storage"
 )
 
 var _ runtime.Interface = &ScriptEnv{}
@@ -68,8 +60,9 @@ func NewScriptEnvironment(
 		reqContext: reqContext,
 	}
 
-	// TODO(patrick): remove this hack after merging #2800
-	env.ComputationMeter = env
+	// TODO(patrick): remove this hack
+	env.MeterInterface = env
+	env.AccountInterface = env
 
 	env.contracts = handler.NewContractHandler(
 		accounts,
@@ -155,100 +148,6 @@ func (e *ScriptEnv) setExecutionParameters() {
 	if err != nil {
 		return
 	}
-}
-
-func (e *ScriptEnv) GetValue(owner, key []byte) ([]byte, error) {
-	var valueByteSize int
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetValue)
-		defer func() {
-			sp.LogFields(
-				traceLog.String("owner", hex.EncodeToString(owner)),
-				traceLog.String("key", string(key)),
-				traceLog.Int("valueByteSize", valueByteSize),
-			)
-			sp.Finish()
-		}()
-	}
-
-	v, err := e.accounts.GetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("get value failed: %w", err)
-	}
-	valueByteSize = len(v)
-
-	err = e.Meter(meter.ComputationKindGetValue, uint(valueByteSize))
-	if err != nil {
-		return nil, fmt.Errorf("get value failed: %w", err)
-	}
-	return v, nil
-}
-
-// TODO disable SetValue for scripts, right now the view changes are discarded
-func (e *ScriptEnv) SetValue(owner, key, value []byte) error {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvSetValue)
-		sp.LogFields(
-			traceLog.String("owner", hex.EncodeToString(owner)),
-			traceLog.String("key", string(key)),
-		)
-		defer sp.Finish()
-	}
-	err := e.Meter(meter.ComputationKindSetValue, uint(len(value)))
-	if err != nil {
-		return fmt.Errorf("set value failed: %w", err)
-	}
-
-	err = e.accounts.SetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-		value,
-	)
-	if err != nil {
-		return fmt.Errorf("set value failed: %w", err)
-	}
-	return nil
-}
-
-func (e *ScriptEnv) ValueExists(owner, key []byte) (exists bool, err error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvValueExists)
-		defer sp.Finish()
-	}
-
-	err = e.Meter(meter.ComputationKindValueExists, 1)
-	if err != nil {
-		return false, fmt.Errorf("check value existence failed: %w", err)
-	}
-
-	v, err := e.GetValue(owner, key)
-	if err != nil {
-		return false, fmt.Errorf("check value existence failed: %w", err)
-	}
-
-	return len(v) > 0, nil
-}
-
-func (e *ScriptEnv) GetStorageUsed(address common.Address) (value uint64, err error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetStorageUsed)
-		defer sp.Finish()
-	}
-
-	err = e.Meter(meter.ComputationKindGetStorageUsed, 1)
-	if err != nil {
-		return value, fmt.Errorf("get storage used failed: %w", err)
-	}
-
-	value, err = e.accounts.GetStorageUsed(flow.Address(address))
-	if err != nil {
-		return value, fmt.Errorf("get storage used failed: %w", err)
-	}
-
-	return value, nil
 }
 
 func (e *ScriptEnv) GetStorageCapacity(address common.Address) (value uint64, err error) {
@@ -390,104 +289,6 @@ func (e *ScriptEnv) ResolveLocation(
 	return resolvedLocations, nil
 }
 
-func (e *ScriptEnv) GetAccountContractNames(address runtime.Address) ([]string, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetAccountContractNames)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetAccountContractNames, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get account contract names failed: %w", err)
-	}
-
-	a := flow.Address(address)
-
-	freezeError := e.accounts.CheckAccountNotFrozen(a)
-	if freezeError != nil {
-		return nil, fmt.Errorf("get account contract names failed: %w", freezeError)
-	}
-
-	return e.accounts.GetContractNames(a)
-}
-
-func (e *ScriptEnv) GetCode(location runtime.Location) ([]byte, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetCode)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetCode, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get code failed: %w", err)
-	}
-
-	contractLocation, ok := location.(common.AddressLocation)
-	if !ok {
-		return nil, errors.NewInvalidLocationErrorf(location, "expecting an AddressLocation, but other location types are passed")
-	}
-
-	address := flow.Address(contractLocation.Address)
-
-	err = e.accounts.CheckAccountNotFrozen(address)
-	if err != nil {
-		return nil, fmt.Errorf("get code failed: %w", err)
-	}
-
-	add, err := e.contracts.GetContract(contractLocation.Address, contractLocation.Name)
-	if err != nil {
-		return nil, fmt.Errorf("get code failed: %w", err)
-	}
-
-	return add, nil
-}
-
-func (e *ScriptEnv) GetProgram(location common.Location) (*interpreter.Program, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetProgram)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetProgram, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get program failed: %w", err)
-	}
-
-	if addressLocation, ok := location.(common.AddressLocation); ok {
-		address := flow.Address(addressLocation.Address)
-
-		freezeError := e.accounts.CheckAccountNotFrozen(address)
-		if freezeError != nil {
-			return nil, fmt.Errorf("get program failed: %w", freezeError)
-		}
-	}
-
-	program, has := e.programs.Get(location)
-	if has {
-		return program, nil
-	}
-
-	return nil, nil
-}
-
-func (e *ScriptEnv) SetProgram(location common.Location, program *interpreter.Program) error {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvSetProgram)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindSetProgram, 1)
-	if err != nil {
-		return fmt.Errorf("set program failed: %w", err)
-	}
-
-	err = e.programs.Set(location, program)
-	if err != nil {
-		return fmt.Errorf("set program failed: %w", err)
-	}
-	return nil
-}
-
 func (e *ScriptEnv) ProgramLog(message string) error {
 	if e.isTraceable() && e.ctx.ExtensiveTracing {
 		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvProgramLog)
@@ -510,28 +311,6 @@ func (e *ScriptEnv) EmitEvent(_ cadence.Event) error {
 
 func (e *ScriptEnv) Events() []flow.Event {
 	return []flow.Event{}
-}
-
-func (e *ScriptEnv) GenerateUUID() (uint64, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGenerateUUID)
-		defer sp.Finish()
-	}
-
-	if e.uuidGenerator == nil {
-		return 0, errors.NewOperationNotSupportedError("GenerateUUID")
-	}
-
-	err := e.Meter(meter.ComputationKindGenerateUUID, 1)
-	if err != nil {
-		return 0, fmt.Errorf("generate uuid failed: %w", err)
-	}
-
-	uuid, err := e.uuidGenerator.GenerateUUID()
-	if err != nil {
-		return 0, fmt.Errorf("generate uuid failed: %w", err)
-	}
-	return uuid, err
 }
 
 func (e *ScriptEnv) checkContext() error {
@@ -564,42 +343,11 @@ func (e *ScriptEnv) Meter(kind common.ComputationKind, intensity uint) error {
 	return nil
 }
 
-func (e *ScriptEnv) MeterComputation(kind common.ComputationKind, intensity uint) error {
-	return e.Meter(kind, intensity)
-}
-
-func (e *ScriptEnv) ComputationUsed() uint64 {
-	return uint64(e.sth.State().TotalComputationUsed())
-}
-
 func (e *ScriptEnv) meterMemory(kind common.MemoryKind, intensity uint) error {
 	if e.sth.EnforceMemoryLimits() {
 		return e.sth.State().MeterMemory(kind, intensity)
 	}
 	return nil
-}
-
-func (e *ScriptEnv) MeterMemory(usage common.MemoryUsage) error {
-	return e.meterMemory(usage.Kind, uint(usage.Amount))
-}
-
-func (e *ScriptEnv) MemoryEstimate() uint64 {
-	return uint64(e.sth.State().TotalMemoryEstimate())
-}
-
-func (e *ScriptEnv) DecodeArgument(b []byte, t cadence.Type) (cadence.Value, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvDecodeArgument)
-		defer sp.Finish()
-	}
-
-	v, err := jsoncdc.Decode(e, b)
-	if err != nil {
-		err = errors.NewInvalidArgumentErrorf("argument is not json decodable: %w", err)
-		return nil, fmt.Errorf("decodeing argument failed: %w", err)
-	}
-
-	return v, err
 }
 
 func (e *ScriptEnv) VerifySignature(
@@ -647,73 +395,6 @@ func (e *ScriptEnv) ValidatePublicKey(pk *runtime.PublicKey) error {
 
 // Block Environment Functions
 
-// GetCurrentBlockHeight returns the current block height.
-func (e *ScriptEnv) GetCurrentBlockHeight() (uint64, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetCurrentBlockHeight)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetCurrentBlockHeight, 1)
-	if err != nil {
-		return 0, fmt.Errorf("get current block height failed: %w", err)
-	}
-
-	if e.ctx.BlockHeader == nil {
-		return 0, errors.NewOperationNotSupportedError("GetCurrentBlockHeight")
-	}
-	return e.ctx.BlockHeader.Height, nil
-}
-
-// UnsafeRandom returns a random uint64, where the process of random number derivation is not cryptographically
-// secure.
-func (e *ScriptEnv) UnsafeRandom() (uint64, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvUnsafeRandom)
-		defer sp.Finish()
-	}
-
-	if e.rng == nil {
-		return 0, errors.NewOperationNotSupportedError("UnsafeRandom")
-	}
-
-	// TODO (ramtin) return errors this assumption that this always succeeds might not be true
-	buf := make([]byte, 8)
-	_, _ = e.rng.Read(buf) // Always succeeds, no need to check error
-	return binary.LittleEndian.Uint64(buf), nil
-}
-
-// GetBlockAtHeight returns the block at the given height.
-func (e *ScriptEnv) GetBlockAtHeight(height uint64) (runtime.Block, bool, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetBlockAtHeight)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetBlockAtHeight, 1)
-	if err != nil {
-		return runtime.Block{}, false, fmt.Errorf("get block at height failed: %w", err)
-	}
-
-	if e.ctx.Blocks == nil {
-		return runtime.Block{}, false, errors.NewOperationNotSupportedError("GetBlockAtHeight")
-	}
-
-	if e.ctx.BlockHeader != nil && height == e.ctx.BlockHeader.Height {
-		return runtimeBlockFromHeader(e.ctx.BlockHeader), true, nil
-	}
-
-	header, err := e.ctx.Blocks.ByHeightFrom(height, e.ctx.BlockHeader)
-	// TODO (ramtin): remove dependency on storage and move this if condition to blockfinder
-	if errors.Is(err, storage.ErrNotFound) {
-		return runtime.Block{}, false, nil
-	} else if err != nil {
-		return runtime.Block{}, false, fmt.Errorf("get block at height failed for height %v: %w", height, err)
-	}
-
-	return runtimeBlockFromHeader(header), true, nil
-}
-
 func (e *ScriptEnv) CreateAccount(_ runtime.Address) (address runtime.Address, err error) {
 	return runtime.Address{}, errors.NewOperationNotSupportedError("CreateAccount")
 }
@@ -760,46 +441,10 @@ func (e *ScriptEnv) UpdateAccountContractCode(_ runtime.Address, _ string, _ []b
 	return errors.NewOperationNotSupportedError("UpdateAccountContractCode")
 }
 
-func (e *ScriptEnv) GetAccountContractCode(address runtime.Address, name string) (code []byte, err error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetAccountContractCode)
-		defer sp.Finish()
-	}
-
-	err = e.Meter(meter.ComputationKindGetAccountContractCode, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get account contract code failed: %w", err)
-	}
-
-	code, err = e.GetCode(common.AddressLocation{
-		Address: address,
-		Name:    name,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get account contract code failed: %w", err)
-	}
-
-	return code, nil
-}
-
 func (e *ScriptEnv) RemoveAccountContractCode(_ runtime.Address, _ string) (err error) {
 	return errors.NewOperationNotSupportedError("RemoveAccountContractCode")
 }
 
 func (e *ScriptEnv) GetSigningAccounts() ([]runtime.Address, error) {
 	return nil, errors.NewOperationNotSupportedError("GetSigningAccounts")
-}
-
-// AllocateStorageIndex allocates new storage index under the owner accounts to store a new register
-func (e *ScriptEnv) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
-	err := e.Meter(meter.ComputationKindAllocateStorageIndex, 1)
-	if err != nil {
-		return atree.StorageIndex{}, fmt.Errorf("storage address allocation failed: %w", err)
-	}
-
-	v, err := e.accounts.AllocateStorageIndex(flow.BytesToAddress(owner))
-	if err != nil {
-		return atree.StorageIndex{}, fmt.Errorf("storage address allocation failed: %w", err)
-	}
-	return v, nil
 }

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -1,19 +1,13 @@
 package fvm
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 
-	"github.com/onflow/atree"
 	"github.com/onflow/cadence"
-	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/opentracing/opentracing-go"
-	traceLog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/fvm/crypto"
@@ -26,7 +20,6 @@ import (
 	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/trace"
-	"github.com/onflow/flow-go/storage"
 )
 
 var _ runtime.Interface = &TransactionEnv{}
@@ -88,8 +81,9 @@ func NewTransactionEnvironment(
 		txID:             tx.ID(),
 	}
 
-	// TODO(patrick): rm this hack after merging #2800
-	env.ComputationMeter = env
+	// TODO(patrick): rm this hack
+	env.MeterInterface = env
+	env.AccountInterface = env
 
 	env.contracts = handler.NewContractHandler(accounts,
 		func() bool {
@@ -303,114 +297,6 @@ func (e *TransactionEnv) isAuthorizer(address runtime.Address) bool {
 	return false
 }
 
-func (e *TransactionEnv) GetValue(owner, key []byte) ([]byte, error) {
-	var valueByteSize int
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetValue)
-		defer func() {
-			sp.LogFields(
-				traceLog.String("owner", hex.EncodeToString(owner)),
-				traceLog.String("key", string(key)),
-				traceLog.Int("valueByteSize", valueByteSize),
-			)
-			sp.Finish()
-		}()
-	}
-
-	v, err := e.accounts.GetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("get value failed: %w", err)
-	}
-	valueByteSize = len(v)
-
-	err = e.Meter(meter.ComputationKindGetValue, uint(valueByteSize))
-	if err != nil {
-		return nil, fmt.Errorf("get value failed: %w", err)
-	}
-	return v, nil
-}
-
-func (e *TransactionEnv) SetValue(owner, key, value []byte) error {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvSetValue)
-		sp.LogFields(
-			traceLog.String("owner", hex.EncodeToString(owner)),
-			traceLog.String("key", string(key)),
-		)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindSetValue, uint(len(value)))
-	if err != nil {
-		return fmt.Errorf("set value failed: %w", err)
-	}
-
-	err = e.accounts.SetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-		value,
-	)
-	if err != nil {
-		return fmt.Errorf("set value failed: %w", err)
-	}
-	return nil
-}
-
-func (e *TransactionEnv) ValueExists(owner, key []byte) (exists bool, err error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvValueExists)
-		defer sp.Finish()
-	}
-
-	err = e.Meter(meter.ComputationKindValueExists, 1)
-	if err != nil {
-		return false, fmt.Errorf("checking value existence failed: %w", err)
-	}
-
-	v, err := e.GetValue(owner, key)
-	if err != nil {
-		return false, fmt.Errorf("checking value existence failed: %w", err)
-	}
-
-	return len(v) > 0, nil
-}
-
-// AllocateStorageIndex allocates new storage index under the owner accounts to store a new register
-func (e *TransactionEnv) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
-	err := e.Meter(meter.ComputationKindAllocateStorageIndex, 1)
-	if err != nil {
-		return atree.StorageIndex{}, fmt.Errorf("allocate storage index failed: %w", err)
-	}
-
-	v, err := e.accounts.AllocateStorageIndex(flow.BytesToAddress(owner))
-	if err != nil {
-		return atree.StorageIndex{}, fmt.Errorf("storage address allocation failed: %w", err)
-	}
-	return v, nil
-}
-
-func (e *TransactionEnv) GetStorageUsed(address common.Address) (value uint64, err error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetStorageUsed)
-		defer sp.Finish()
-	}
-
-	err = e.Meter(meter.ComputationKindGetStorageUsed, 1)
-	if err != nil {
-		return value, fmt.Errorf("get storage used failed: %w", err)
-	}
-
-	value, err = e.accounts.GetStorageUsed(flow.Address(address))
-	if err != nil {
-		return value, fmt.Errorf("get storage used failed: %w", err)
-	}
-
-	return value, nil
-}
-
 func (e *TransactionEnv) GetStorageCapacity(address common.Address) (value uint64, err error) {
 	if e.isTraceable() {
 		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetStorageCapacity)
@@ -431,13 +317,6 @@ func (e *TransactionEnv) GetStorageCapacity(address common.Address) (value uint6
 	}
 
 	return storageMBUFixToBytesUInt(result), nil
-}
-
-// storageMBUFixToBytesUInt converts the return type of storage capacity which is a UFix64 with the unit of megabytes to
-// UInt with the unit of bytes
-func storageMBUFixToBytesUInt(result cadence.Value) uint64 {
-	// Divide the unsigned int by (1e8 (the scale of Fix64) / 1e6 (for mega)) to get bytes (rounded down)
-	return result.ToGoValue().(uint64) / 100
 }
 
 func (e *TransactionEnv) GetAccountBalance(address common.Address) (value uint64, err error) {
@@ -555,104 +434,6 @@ func (e *TransactionEnv) ResolveLocation(
 	return resolvedLocations, nil
 }
 
-func (e *TransactionEnv) GetCode(location runtime.Location) ([]byte, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetCode)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetCode, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get code failed: %w", err)
-	}
-
-	contractLocation, ok := location.(common.AddressLocation)
-	if !ok {
-		return nil, errors.NewInvalidLocationErrorf(location, "expecting an AddressLocation, but other location types are passed")
-	}
-
-	address := flow.Address(contractLocation.Address)
-
-	err = e.accounts.CheckAccountNotFrozen(address)
-	if err != nil {
-		return nil, fmt.Errorf("get code failed: %w", err)
-	}
-
-	add, err := e.contracts.GetContract(contractLocation.Address, contractLocation.Name)
-	if err != nil {
-		return nil, fmt.Errorf("get code failed: %w", err)
-	}
-
-	return add, nil
-}
-
-func (e *TransactionEnv) GetAccountContractNames(address runtime.Address) ([]string, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetAccountContractNames)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetAccountContractNames, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get account contract names failed: %w", err)
-	}
-
-	a := flow.Address(address)
-
-	freezeError := e.accounts.CheckAccountNotFrozen(a)
-	if freezeError != nil {
-		return nil, fmt.Errorf("get account contract names failed: %w", freezeError)
-	}
-
-	return e.accounts.GetContractNames(a)
-}
-
-func (e *TransactionEnv) GetProgram(location common.Location) (*interpreter.Program, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetProgram)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetProgram, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get program failed: %w", err)
-	}
-
-	if addressLocation, ok := location.(common.AddressLocation); ok {
-		address := flow.Address(addressLocation.Address)
-
-		freezeError := e.accounts.CheckAccountNotFrozen(address)
-		if freezeError != nil {
-			return nil, fmt.Errorf("get program failed: %w", freezeError)
-		}
-	}
-
-	program, has := e.programs.Get(location)
-	if has {
-		return program, nil
-	}
-
-	return nil, nil
-}
-
-func (e *TransactionEnv) SetProgram(location common.Location, program *interpreter.Program) error {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvSetProgram)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindSetProgram, 1)
-	if err != nil {
-		return fmt.Errorf("set program failed: %w", err)
-	}
-
-	err = e.programs.Set(location, program)
-	if err != nil {
-		return fmt.Errorf("set program failed: %w", err)
-	}
-	return nil
-}
-
 func (e *TransactionEnv) ProgramLog(message string) error {
 	if e.isTraceable() && e.ctx.ExtensiveTracing {
 		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvProgramLog)
@@ -692,28 +473,6 @@ func (e *TransactionEnv) ServiceEvents() []flow.Event {
 	return e.eventHandler.ServiceEvents()
 }
 
-func (e *TransactionEnv) GenerateUUID() (uint64, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGenerateUUID)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGenerateUUID, 1)
-	if err != nil {
-		return 0, fmt.Errorf("generate uuid failed: %w", err)
-	}
-
-	if e.uuidGenerator == nil {
-		return 0, errors.NewOperationNotSupportedError("GenerateUUID")
-	}
-
-	uuid, err := e.uuidGenerator.GenerateUUID()
-	if err != nil {
-		return 0, fmt.Errorf("generate uuid failed: %w", err)
-	}
-	return uuid, err
-}
-
 func (e *TransactionEnv) Meter(kind common.ComputationKind, intensity uint) error {
 	if e.sth.EnforceComputationLimits {
 		return e.sth.State().MeterComputation(kind, intensity)
@@ -721,27 +480,11 @@ func (e *TransactionEnv) Meter(kind common.ComputationKind, intensity uint) erro
 	return nil
 }
 
-func (e *TransactionEnv) MeterComputation(kind common.ComputationKind, intensity uint) error {
-	return e.Meter(kind, intensity)
-}
-
-func (e *TransactionEnv) ComputationUsed() uint64 {
-	return uint64(e.sth.State().TotalComputationUsed())
-}
-
 func (e *TransactionEnv) meterMemory(kind common.MemoryKind, intensity uint) error {
 	if e.sth.EnforceMemoryLimits() {
 		return e.sth.State().MeterMemory(kind, intensity)
 	}
 	return nil
-}
-
-func (e *TransactionEnv) MeterMemory(usage common.MemoryUsage) error {
-	return e.meterMemory(usage.Kind, uint(usage.Amount))
-}
-
-func (e *TransactionEnv) MemoryEstimate() uint64 {
-	return uint64(e.sth.State().TotalMemoryEstimate())
 }
 
 func (e *TransactionEnv) SetAccountFrozen(address common.Address, frozen bool) error {
@@ -767,21 +510,6 @@ func (e *TransactionEnv) SetAccountFrozen(address common.Address, frozen bool) e
 		return fmt.Errorf("setting account frozen failed: %w", err)
 	}
 	return nil
-}
-
-func (e *TransactionEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvDecodeArgument)
-		defer sp.Finish()
-	}
-
-	v, err := jsoncdc.Decode(e, b)
-	if err != nil {
-		err = errors.NewInvalidArgumentErrorf("argument is not json decodable: %w", err)
-		return nil, fmt.Errorf("decodeing argument failed: %w", err)
-	}
-
-	return v, err
 }
 
 func (e *TransactionEnv) VerifySignature(
@@ -828,73 +556,6 @@ func (e *TransactionEnv) ValidatePublicKey(pk *runtime.PublicKey) error {
 }
 
 // Block Environment Functions
-
-// GetCurrentBlockHeight returns the current block height.
-func (e *TransactionEnv) GetCurrentBlockHeight() (uint64, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetCurrentBlockHeight)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetCurrentBlockHeight, 1)
-	if err != nil {
-		return 0, fmt.Errorf("get current block height failed: %w", err)
-	}
-
-	if e.ctx.BlockHeader == nil {
-		return 0, errors.NewOperationNotSupportedError("GetCurrentBlockHeight")
-	}
-	return e.ctx.BlockHeader.Height, nil
-}
-
-// UnsafeRandom returns a random uint64, where the process of random number derivation is not cryptographically
-// secure.
-func (e *TransactionEnv) UnsafeRandom() (uint64, error) {
-	if e.isTraceable() && e.ctx.ExtensiveTracing {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvUnsafeRandom)
-		defer sp.Finish()
-	}
-
-	if e.rng == nil {
-		return 0, errors.NewOperationNotSupportedError("UnsafeRandom")
-	}
-
-	// TODO (ramtin) return errors this assumption that this always succeeds might not be true
-	buf := make([]byte, 8)
-	_, _ = e.rng.Read(buf) // Always succeeds, no need to check error
-	return binary.LittleEndian.Uint64(buf), nil
-}
-
-// GetBlockAtHeight returns the block at the given height.
-func (e *TransactionEnv) GetBlockAtHeight(height uint64) (runtime.Block, bool, error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetBlockAtHeight)
-		defer sp.Finish()
-	}
-
-	err := e.Meter(meter.ComputationKindGetBlockAtHeight, 1)
-	if err != nil {
-		return runtime.Block{}, false, fmt.Errorf("get block at height failed: %w", err)
-	}
-
-	if e.ctx.Blocks == nil {
-		return runtime.Block{}, false, errors.NewOperationNotSupportedError("GetBlockAtHeight")
-	}
-
-	if e.ctx.BlockHeader != nil && height == e.ctx.BlockHeader.Height {
-		return runtimeBlockFromHeader(e.ctx.BlockHeader), true, nil
-	}
-
-	header, err := e.ctx.Blocks.ByHeightFrom(height, e.ctx.BlockHeader)
-	// TODO (ramtin): remove dependency on storage and move this if condition to blockfinder
-	if errors.Is(err, storage.ErrNotFound) {
-		return runtime.Block{}, false, nil
-	} else if err != nil {
-		return runtime.Block{}, false, fmt.Errorf("get block at height failed for height %v: %w", height, err)
-	}
-
-	return runtimeBlockFromHeader(header), true, nil
-}
 
 func (e *TransactionEnv) CreateAccount(payer runtime.Address) (address runtime.Address, err error) {
 
@@ -1092,28 +753,6 @@ func (e *TransactionEnv) UpdateAccountContractCode(address runtime.Address, name
 	}
 
 	return nil
-}
-
-func (e *TransactionEnv) GetAccountContractCode(address runtime.Address, name string) (code []byte, err error) {
-	if e.isTraceable() {
-		sp := e.ctx.Tracer.StartSpanFromParent(e.traceSpan, trace.FVMEnvGetAccountContractCode)
-		defer sp.Finish()
-	}
-
-	err = e.Meter(meter.ComputationKindGetAccountContractCode, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get account contract code failed: %w", err)
-	}
-
-	code, err = e.GetCode(common.AddressLocation{
-		Address: address,
-		Name:    name,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get account contract code failed: %w", err)
-	}
-
-	return code, nil
 }
 
 func (e *TransactionEnv) RemoveAccountContractCode(address runtime.Address, name string) (err error) {


### PR DESCRIPTION
NOTE:
1. There were slight differences between the two GenerateUUID implementation.
   ScriptEnv's check for nil first before metering whereas TransactionEnv meter
   first before checking for nil.  I've pick the ScriptEnv's implementation as
   the common implementation since that seem more correct.
2. The environment variable e has been renamed to env since it's more
   searchable.