### PR TITLE
Split env context, unsafe rand gen, and program logger into logical units

### DIFF
--- a/fvm/env_context.go
+++ b/fvm/env_context.go
@@ -1,0 +1,76 @@
+package fvm
+
+import (
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/onflow/flow-go/module/trace"
+)
+
+type Span interface {
+	// TODO(patrick/rbtz): switch to opentelemtry
+	opentracing.Span
+
+	// TODO(patrick/rbtz): remove once switched to opentelemtry (#2823)
+	End()
+
+	IsNoOp() bool
+}
+
+type noOpSpan struct {
+	trace.NoopSpan
+}
+
+func (noOpSpan) IsNoOp() bool { return true }
+
+func (noOpSpan) End() {}
+
+type realSpan struct {
+	opentracing.Span
+}
+
+func (realSpan) IsNoOp() bool { return false }
+
+// TODO(patrick/rbtz): remove once switched to opentelemtry (#2823)
+func (span *realSpan) End() {
+	span.Finish()
+}
+
+// NOTE: This dummy struct is used to avoid naming collision between
+// Context() and anonymous field in EnvContext
+type nestedContext struct {
+	Context
+}
+
+type EnvContext struct {
+	nestedContext
+
+	rootSpan opentracing.Span
+}
+
+func (ctx *EnvContext) Context() *Context {
+	return &ctx.nestedContext.Context
+}
+
+func (ctx *EnvContext) isTraceable() bool {
+	return ctx.Tracer != nil && ctx.rootSpan != nil
+}
+
+func (ctx *EnvContext) StartSpanFromRoot(name trace.SpanName) Span {
+	if ctx.isTraceable() {
+		return &realSpan{
+			ctx.Tracer.StartSpanFromParent(ctx.rootSpan, name),
+		}
+	}
+
+	return &noOpSpan{}
+}
+
+func (ctx *EnvContext) StartExtensiveTracingSpanFromRoot(name trace.SpanName) Span {
+	if ctx.isTraceable() && ctx.ExtensiveTracing {
+		return &realSpan{
+			ctx.Tracer.StartSpanFromParent(ctx.rootSpan, name),
+		}
+	}
+
+	return &noOpSpan{}
+}

--- a/fvm/program_logger.go
+++ b/fvm/program_logger.go
@@ -1,0 +1,31 @@
+package fvm
+
+import (
+	"github.com/onflow/flow-go/module/trace"
+)
+
+type ProgramLogger struct {
+	ctx *EnvContext
+
+	logs []string
+}
+
+func NewProgramLogger(ctx *EnvContext) *ProgramLogger {
+	return &ProgramLogger{
+		ctx:  ctx,
+		logs: nil,
+	}
+}
+
+func (logger *ProgramLogger) ProgramLog(message string) error {
+	defer logger.ctx.StartExtensiveTracingSpanFromRoot(trace.FVMEnvProgramLog).End()
+
+	if logger.ctx.CadenceLoggingEnabled {
+		logger.logs = append(logger.logs, message)
+	}
+	return nil
+}
+
+func (logger *ProgramLogger) Logs() []string {
+	return logger.logs
+}

--- a/fvm/unsafe_random_generator.go
+++ b/fvm/unsafe_random_generator.go
@@ -1,0 +1,47 @@
+package fvm
+
+import (
+	"encoding/binary"
+	"math/rand"
+
+	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/module/trace"
+)
+
+type UnsafeRandomGenerator struct {
+	ctx *EnvContext
+	rng *rand.Rand
+}
+
+func NewUnsafeRandomGenerator(ctx *EnvContext) *UnsafeRandomGenerator {
+	gen := &UnsafeRandomGenerator{
+		ctx: ctx,
+	}
+
+	if ctx.BlockHeader != nil {
+		// Seed the random number generator with entropy created from the block
+		// header ID. The random number generator will be used by the
+		// UnsafeRandom function.
+		id := ctx.BlockHeader.ID()
+		source := rand.NewSource(int64(binary.BigEndian.Uint64(id[:])))
+		gen.rng = rand.New(source)
+	}
+
+	return gen
+}
+
+// UnsafeRandom returns a random uint64, where the process of random number
+// derivation is not cryptographically secure.
+func (gen *UnsafeRandomGenerator) UnsafeRandom() (uint64, error) {
+	defer gen.ctx.StartExtensiveTracingSpanFromRoot(trace.FVMEnvUnsafeRandom).End()
+
+	if gen.rng == nil {
+		return 0, errors.NewOperationNotSupportedError("UnsafeRandom")
+	}
+
+	// TODO (ramtin) return errors this assumption that this always succeeds
+	// might not be true
+	buf := make([]byte, 8)
+	_, _ = gen.rng.Read(buf) // Always succeeds, no need to check error
+	return binary.LittleEndian.Uint64(buf), nil
+}


### PR DESCRIPTION
Once env is fully dedup-ed, I plan to split env into coherent units, leaving
env as a facade interface for cadence, with almost no code.

I've split out a few easy pieces in this PR as proof of concept to get some
feedbacks.