### PR TITLE
refactor program logging

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -3,7 +3,6 @@ package fvm
 import (
 	"encoding/hex"
 	"fmt"
-	"time"
 
 	"github.com/onflow/atree"
 	"github.com/onflow/cadence"
@@ -84,7 +83,6 @@ type commonEnv struct {
 	accountKeys   *handler.AccountKeyHandler
 	contracts     *handler.ContractHandler
 	uuidGenerator *state.UUIDGenerator
-	metrics       *handler.MetricsHandler
 }
 
 // TODO(patrick): rm once Meter object has been refactored
@@ -410,40 +408,6 @@ func (env *commonEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value, e
 	}
 
 	return v, err
-}
-func (env *commonEnv) RecordTrace(operation string, location common.Location, duration time.Duration, attrs []attribute.KeyValue) {
-	if location != nil {
-		attrs = append(attrs, attribute.String("location", location.String()))
-	}
-	env.ctx.RecordSpanFromRoot(
-		trace.FVMCadenceTrace.Child(operation),
-		duration,
-		attrs)
-}
-
-func (env *commonEnv) ProgramParsed(location common.Location, duration time.Duration) {
-	env.RecordTrace("parseProgram", location, duration, nil)
-	env.metrics.ProgramParsed(location, duration)
-}
-
-func (env *commonEnv) ProgramChecked(location common.Location, duration time.Duration) {
-	env.RecordTrace("checkProgram", location, duration, nil)
-	env.metrics.ProgramChecked(location, duration)
-}
-
-func (env *commonEnv) ProgramInterpreted(location common.Location, duration time.Duration) {
-	env.RecordTrace("interpretProgram", location, duration, nil)
-	env.metrics.ProgramInterpreted(location, duration)
-}
-
-func (env *commonEnv) ValueEncoded(duration time.Duration) {
-	env.RecordTrace("encodeValue", nil, duration, nil)
-	env.metrics.ValueEncoded(duration)
-}
-
-func (env *commonEnv) ValueDecoded(duration time.Duration) {
-	env.RecordTrace("decodeValue", nil, duration, nil)
-	env.metrics.ValueDecoded(duration)
 }
 
 // Commit commits changes and return a list of updated keys

--- a/fvm/handler/metrics.go
+++ b/fvm/handler/metrics.go
@@ -2,8 +2,6 @@ package handler
 
 import (
 	"time"
-
-	"github.com/onflow/cadence/runtime/common"
 )
 
 // MetricsReporter captures and reports metrics to back to the execution environment
@@ -13,75 +11,6 @@ type MetricsReporter interface {
 	RuntimeTransactionChecked(time.Duration)
 	RuntimeTransactionInterpreted(time.Duration)
 	RuntimeSetNumberOfAccounts(count uint64)
-}
-
-// A MetricsHandler accumulates performance metrics reported by the Cadence runtime.
-type MetricsHandler struct {
-	Reporter                 MetricsReporter
-	TimeSpentOnParsing       time.Duration
-	TimeSpentOnChecking      time.Duration
-	TimeSpentOnInterpreting  time.Duration
-	TimeSpentOnValueEncoding time.Duration
-	TimeSpentOnValueDecoding time.Duration
-}
-
-// NewMetricsHandler constructs a MetricsHandler
-func NewMetricsHandler(reporter MetricsReporter) *MetricsHandler {
-	return &MetricsHandler{Reporter: reporter}
-}
-
-// ProgramParsed captures time spent on parsing a code at specific location
-func (m *MetricsHandler) ProgramParsed(location common.Location, duration time.Duration) {
-	// These checks prevent re-reporting durations, the metrics collection is a bit counter-intuitive:
-	// The three functions (parsing, checking, interpretation) are not called in sequence, but in some cases as part of each other.
-	// We basically only measure the durations reported for the entry-point (the transaction), and not for child locations,
-	// because they might be already part of the duration for the entry-point.
-	if location == nil {
-		return
-	}
-	if _, ok := location.(common.TransactionLocation); ok {
-		m.TimeSpentOnParsing = duration
-		m.Reporter.RuntimeTransactionParsed(duration)
-	}
-}
-
-// ProgramChecked captures time spent on checking a code at specific location
-func (m *MetricsHandler) ProgramChecked(location common.Location, duration time.Duration) {
-	// see the comment for ProgramParsed
-	if location == nil {
-		return
-	}
-	if _, ok := location.(common.TransactionLocation); ok {
-		m.TimeSpentOnChecking = duration
-		m.Reporter.RuntimeTransactionChecked(duration)
-	}
-}
-
-// ProgramInterpreted captures time spent on interpreting a code at specific location
-func (m *MetricsHandler) ProgramInterpreted(location common.Location, duration time.Duration) {
-	// see the comment for ProgramInterpreted
-	if location == nil {
-		return
-	}
-	if _, ok := location.(common.TransactionLocation); ok {
-		m.TimeSpentOnInterpreting = duration
-		m.Reporter.RuntimeTransactionInterpreted(duration)
-	}
-}
-
-// SetNumberOfAccounts captures total number of accounts on the network
-func (m *MetricsHandler) SetNumberOfAccounts(count uint64) {
-	m.Reporter.RuntimeSetNumberOfAccounts(count)
-}
-
-// ValueEncoded accumulates time spend on runtime value encoding
-func (m *MetricsHandler) ValueEncoded(duration time.Duration) {
-	m.TimeSpentOnValueEncoding += duration
-}
-
-// ValueDecoded accumulates time spend on runtime value decoding
-func (m *MetricsHandler) ValueDecoded(duration time.Duration) {
-	m.TimeSpentOnValueDecoding += duration
 }
 
 // NoopMetricsReporter is a MetricReporter that does nothing.

--- a/fvm/program_logger.go
+++ b/fvm/program_logger.go
@@ -1,19 +1,27 @@
 package fvm
 
 import (
+	"time"
+
+	"github.com/onflow/cadence/runtime/common"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/onflow/flow-go/fvm/handler"
 	"github.com/onflow/flow-go/module/trace"
 )
 
 type ProgramLogger struct {
 	ctx *EnvContext
 
-	logs []string
+	logs     []string
+	reporter handler.MetricsReporter
 }
 
 func NewProgramLogger(ctx *EnvContext) *ProgramLogger {
 	return &ProgramLogger{
-		ctx:  ctx,
-		logs: nil,
+		ctx:      ctx,
+		logs:     nil,
+		reporter: ctx.Metrics,
 	}
 }
 
@@ -28,4 +36,69 @@ func (logger *ProgramLogger) ProgramLog(message string) error {
 
 func (logger *ProgramLogger) Logs() []string {
 	return logger.logs
+}
+
+func (logger *ProgramLogger) RecordTrace(operation string, location common.Location, duration time.Duration, attrs []attribute.KeyValue) {
+	if location != nil {
+		attrs = append(attrs, attribute.String("location", location.String()))
+	}
+	logger.ctx.RecordSpanFromRoot(
+		trace.FVMCadenceTrace.Child(operation),
+		duration,
+		attrs)
+}
+
+// ProgramParsed captures time spent on parsing a code at specific location
+func (logger *ProgramLogger) ProgramParsed(location common.Location, duration time.Duration) {
+	logger.RecordTrace("parseProgram", location, duration, nil)
+
+	// These checks prevent re-reporting durations, the metrics collection is
+	// a bit counter-intuitive:
+	// The three functions (parsing, checking, interpretation) are not called
+	// in sequence, but in some cases as part of each other. We basically only
+	// measure the durations reported for the entry-point (the transaction),
+	// and not for child locations, because they might be already part of the
+	// duration for the entry-point.
+	if location == nil {
+		return
+	}
+	if _, ok := location.(common.TransactionLocation); ok {
+		logger.reporter.RuntimeTransactionParsed(duration)
+	}
+}
+
+// ProgramChecked captures time spent on checking a code at specific location
+func (logger *ProgramLogger) ProgramChecked(location common.Location, duration time.Duration) {
+	logger.RecordTrace("checkProgram", location, duration, nil)
+
+	// see the comment for ProgramParsed
+	if location == nil {
+		return
+	}
+	if _, ok := location.(common.TransactionLocation); ok {
+		logger.reporter.RuntimeTransactionChecked(duration)
+	}
+}
+
+// ProgramInterpreted captures time spent on interpreting a code at specific location
+func (logger *ProgramLogger) ProgramInterpreted(location common.Location, duration time.Duration) {
+	logger.RecordTrace("interpretProgram", location, duration, nil)
+
+	// see the comment for ProgramInterpreted
+	if location == nil {
+		return
+	}
+	if _, ok := location.(common.TransactionLocation); ok {
+		logger.reporter.RuntimeTransactionInterpreted(duration)
+	}
+}
+
+// ValueEncoded accumulates time spend on runtime value encoding
+func (logger *ProgramLogger) ValueEncoded(duration time.Duration) {
+	logger.RecordTrace("encodeValue", nil, duration, nil)
+}
+
+// ValueDecoded accumulates time spend on runtime value decoding
+func (logger *ProgramLogger) ValueDecoded(duration time.Duration) {
+	logger.RecordTrace("decodeValue", nil, duration, nil)
 }

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -42,7 +42,6 @@ func NewScriptEnvironment(
 	uuidGenerator := state.NewUUIDGenerator(sth)
 	programsHandler := handler.NewProgramsHandler(programs, sth)
 	accountKeys := handler.NewAccountKeyHandler(accounts)
-	metrics := handler.NewMetricsHandler(fvmContext.Metrics)
 
 	ctx := NewEnvContext(fvmContext, nil)
 	env := &ScriptEnv{
@@ -56,7 +55,6 @@ func NewScriptEnvironment(
 			accounts:              accounts,
 			accountKeys:           accountKeys,
 			uuidGenerator:         uuidGenerator,
-			metrics:               metrics,
 		},
 		reqContext: reqContext,
 	}

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -58,7 +58,6 @@ func NewTransactionEnvironment(
 		ctx.EventCollectionByteSizeLimit,
 	)
 	accountKeys := handler.NewAccountKeyHandler(accounts)
-	metrics := handler.NewMetricsHandler(ctx.Metrics)
 
 	envCtx := NewEnvContext(ctx, traceSpan)
 	env := &TransactionEnv{
@@ -72,7 +71,6 @@ func NewTransactionEnvironment(
 			accounts:              accounts,
 			accountKeys:           accountKeys,
 			uuidGenerator:         uuidGenerator,
-			metrics:               metrics,
 		},
 
 		addressGenerator: generator,


### PR DESCRIPTION
1. Move program logging related api from commonEnv to ProgramLogger
2. Combine MetricsHandler logic into ProgramLogger

NOTE: I plan to do the same thing with the other handlers, and then move all env
related code into a separate package.