### PR TITLE
[SyncEngine] not request pending ancestors

### DIFF
--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -135,38 +135,22 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Clus
 
 	// there are two possibilities if the proposal is neither already pending
 	// processing in the cache, nor has already been processed:
-	// 1) the proposal is unverifiable because parent or ancestor is unknown
-	// => we cache the proposal and request the missing link
+	// 1) the proposal is unverifiable because parent is also unknown
+	// => we cache the proposal
 	// 2) the proposal is connected to finalized state through an unbroken chain
 	// => we verify the proposal and forward it to hotstuff if valid
 
-	// if we can connect the proposal to an ancestor in the cache, it means
-	// there is a missing link; we cache it and request the missing link
-	ancestor, found := c.pending.ByID(header.ParentID)
+	// if the parent is a pending block (unknown block), we cache this block as well.
+	// we don't have to request its parent block or its ancestor again, because as a
+	// pending block, its parent block must have been requested.
+	// if there was problem requesting its parent or ancestors, the sync engine's forward
+	// syncing with range requests for finalized blocks will request for the blocks.
+	_, found := c.pending.ByID(header.ParentID)
 	if found {
 
 		// add the block to the cache
 		_ = c.pending.Add(originID, proposal)
 		c.mempoolMetrics.MempoolEntries(metrics.ResourceClusterProposal, c.pending.Size())
-
-		// go to the first missing ancestor
-		ancestorID := ancestor.Header.ParentID
-		ancestorHeight := ancestor.Header.Height - 1
-		for {
-			ancestor, found := c.pending.ByID(ancestorID)
-			if !found {
-				break
-			}
-			ancestorID = ancestor.Header.ParentID
-			ancestorHeight = ancestor.Header.Height - 1
-		}
-
-		log.Debug().
-			Uint64("ancestor_height", ancestorHeight).
-			Hex("ancestor_id", ancestorID[:]).
-			Msg("requesting missing ancestor for proposal")
-
-		c.sync.RequestBlock(ancestorID, ancestorHeight)
 
 		return nil
 	}

--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -135,12 +135,12 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Clus
 
 	// there are two possibilities if the proposal is neither already pending
 	// processing in the cache, nor has already been processed:
-	// 1) the proposal is unverifiable because parent is also unknown
+	// 1) the proposal is unverifiable because the parent is unknown
 	// => we cache the proposal
 	// 2) the proposal is connected to finalized state through an unbroken chain
 	// => we verify the proposal and forward it to hotstuff if valid
 
-	// if the parent is a pending block (unknown block), we cache this block as well.
+	// if the parent is a pending block (disconnected from the incorporated state), we cache this block as well.
 	// we don't have to request its parent block or its ancestor again, because as a
 	// pending block, its parent block must have been requested.
 	// if there was problem requesting its parent or ancestors, the sync engine's forward

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -159,12 +159,12 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Bloc
 
 	// there are two possibilities if the proposal is neither already pending
 	// processing in the cache, nor has already been processed:
-	// 1) the proposal is unverifiable because parent is also unknown
+	// 1) the proposal is unverifiable because the parent is unknown
 	// => we cache the proposal
 	// 2) the proposal is connected to finalized state through an unbroken chain
 	// => we verify the proposal and forward it to hotstuff if valid
 
-	// if the parent is a pending block (unknown block), we cache this block as well.
+	// if the parent is a pending block (disconnected from the incorporated state), we cache this block as well.
 	// we don't have to request its parent block or its ancestor again, because as a
 	// pending block, its parent block must have been requested.
 	// if there was problem requesting its parent or ancestors, the sync engine's forward

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -159,38 +159,22 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Bloc
 
 	// there are two possibilities if the proposal is neither already pending
 	// processing in the cache, nor has already been processed:
-	// 1) the proposal is unverifiable because parent or ancestor is unknown
-	// => we cache the proposal and request the missing link
+	// 1) the proposal is unverifiable because parent is also unknown
+	// => we cache the proposal
 	// 2) the proposal is connected to finalized state through an unbroken chain
 	// => we verify the proposal and forward it to hotstuff if valid
 
-	// if we can connect the proposal to an ancestor in the cache, it means
-	// there is a missing link; we cache it and request the missing link
-	ancestor, found := c.pending.ByID(header.ParentID)
+	// if the parent is a pending block (unknown block), we cache this block as well.
+	// we don't have to request its parent block or its ancestor again, because as a
+	// pending block, its parent block must have been requested.
+	// if there was problem requesting its parent or ancestors, the sync engine's forward
+	// syncing with range requests for finalized blocks will request for the blocks.
+	_, found := c.pending.ByID(header.ParentID)
 	if found {
 
 		// add the block to the cache
 		_ = c.pending.Add(originID, proposal)
 		c.mempool.MempoolEntries(metrics.ResourceProposal, c.pending.Size())
-
-		// go to the first missing ancestor
-		ancestorID := ancestor.Header.ParentID
-		ancestorHeight := ancestor.Header.Height - 1
-		for {
-			ancestor, found := c.pending.ByID(ancestorID)
-			if !found {
-				break
-			}
-			ancestorID = ancestor.Header.ParentID
-			ancestorHeight = ancestor.Header.Height - 1
-		}
-
-		log.Debug().
-			Uint64("ancestor_height", ancestorHeight).
-			Hex("ancestor_id", ancestorID[:]).
-			Msg("requesting missing ancestor for proposal")
-
-		c.sync.RequestBlock(ancestorID, ancestorHeight)
 
 		return nil
 	}


### PR DESCRIPTION
This PR removes a O(N^2) loop in processing block proposals. See reasoning in comments.

The loop would cause a unnecessary O(N^2) operation when processing a range of blocks from sync engine and the first block is pending. 