### PR TITLE
[FVM] Deduct fees and limit storage in synthetic benchmarks

### DIFF
--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -74,11 +74,27 @@ func mustFundAccounts(b *testing.B, vm *fvm.VirtualMachine, ledger state.View, e
 func BenchmarkComputeBlock(b *testing.B) {
 	b.StopTimer()
 
+	tracer, err := trace.NewTracer(zerolog.Nop(), "", "", 4)
+	require.NoError(b, err)
+
 	vm := fvm.NewVirtualMachine(fvm.NewInterpreterRuntime())
 
 	chain := flow.Emulator.Chain()
-	execCtx := fvm.NewContext(zerolog.Nop(), fvm.WithChain(chain))
-	ledger := testutil.RootBootstrappedLedger(vm, execCtx)
+	execCtx := fvm.NewContext(
+		zerolog.Nop(),
+		fvm.WithChain(chain),
+		fvm.WithAccountStorageLimit(true),
+		fvm.WithTransactionFeesEnabled(true),
+		fvm.WithTracer(tracer),
+	)
+	ledger := testutil.RootBootstrappedLedger(
+		vm,
+		execCtx,
+		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
+		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
+		fvm.WithTransactionFee(fvm.DefaultTransactionFees),
+		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
+	)
 	accs := createAccounts(b, vm, ledger, 1000)
 	mustFundAccounts(b, vm, ledger, execCtx, accs)
 
@@ -86,7 +102,7 @@ func BenchmarkComputeBlock(b *testing.B) {
 	me.On("NodeID").Return(flow.ZeroID)
 
 	// TODO(rbtz): add real ledger
-	blockComputer, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter())
+	blockComputer, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), tracer, zerolog.Nop(), committer.NewNoopViewCommitter())
 	require.NoError(b, err)
 
 	programsCache, err := NewProgramsCache(1000)
@@ -100,7 +116,7 @@ func BenchmarkComputeBlock(b *testing.B) {
 
 	engine := &Manager{
 		blockComputer: blockComputer,
-		tracer:        trace.NewNoopTracer(),
+		tracer:        tracer,
 		me:            me,
 		programsCache: programsCache,
 		eds:           eds,


### PR DESCRIPTION
This diff enables `AccountStorageLimit` and `TransactionFees` for transactions in synthetic tests.  While here it also uses real tracer instead of a `NoopTracer` one to capture its overhead.  This more than doubles execution time and memory usage.

```
$ benchstat old new
name                             old time/op    new time/op    delta
ComputeBlock/1/cols/16/txes-8      10.1ms ± 3%    18.4ms ± 3%   +82.04%  (p=0.000 n=8+10)
ComputeBlock/1/cols/32/txes-8      18.4ms ± 5%    34.5ms ± 1%   +87.19%  (p=0.000 n=9+10)
ComputeBlock/1/cols/64/txes-8      35.2ms ± 7%    67.5ms ± 0%   +91.77%  (p=0.000 n=10+8)
ComputeBlock/1/cols/128/txes-8     67.4ms ± 1%   134.4ms ± 1%   +99.36%  (p=0.000 n=9+10)
ComputeBlock/4/cols/16/txes-8      34.8ms ± 3%    66.8ms ± 1%   +92.20%  (p=0.000 n=10+9)
ComputeBlock/4/cols/32/txes-8      69.5ms ± 4%   137.7ms ± 5%   +98.14%  (p=0.000 n=10+10)
ComputeBlock/4/cols/64/txes-8       132ms ± 2%     296ms ± 7%  +124.05%  (p=0.000 n=9+10)
ComputeBlock/4/cols/128/txes-8      262ms ± 6%     575ms ± 1%  +119.86%  (p=0.000 n=9+10)
ComputeBlock/16/cols/16/txes-8      135ms ± 4%     289ms ± 4%  +114.58%  (p=0.000 n=10+10)
ComputeBlock/16/cols/32/txes-8      280ms ±12%     569ms ± 3%  +102.99%  (p=0.000 n=10+10)
ComputeBlock/16/cols/64/txes-8      586ms ± 1%    1145ms ± 3%   +95.33%  (p=0.000 n=10+10)
ComputeBlock/16/cols/128/txes-8     1.20s ± 2%     2.16s ± 8%   +79.97%  (p=0.000 n=8+10)

name                             old us/tx      new us/tx      delta
ComputeBlock/1/cols/16/txes-8         630 ± 3%      1148 ± 3%   +82.11%  (p=0.000 n=8+10)
ComputeBlock/1/cols/32/txes-8         575 ± 5%      1076 ± 1%   +87.29%  (p=0.000 n=9+10)
ComputeBlock/1/cols/64/txes-8         549 ± 7%      1054 ± 0%   +91.87%  (p=0.000 n=10+8)
ComputeBlock/1/cols/128/txes-8        526 ± 1%      1050 ± 1%   +99.46%  (p=0.000 n=9+10)
ComputeBlock/4/cols/16/txes-8         543 ± 3%      1044 ± 1%   +92.32%  (p=0.000 n=10+9)
ComputeBlock/4/cols/32/txes-8         542 ± 4%      1076 ± 5%   +98.29%  (p=0.000 n=10+10)
ComputeBlock/4/cols/64/txes-8         515 ± 2%      1156 ± 7%  +124.18%  (p=0.000 n=9+10)
ComputeBlock/4/cols/128/txes-8        511 ± 6%      1123 ± 1%  +119.92%  (p=0.000 n=9+10)
ComputeBlock/16/cols/16/txes-8        526 ± 4%      1129 ± 4%  +114.68%  (p=0.000 n=10+10)
ComputeBlock/16/cols/32/txes-8        547 ±12%      1111 ± 3%  +103.07%  (p=0.000 n=10+10)
ComputeBlock/16/cols/64/txes-8        572 ± 1%      1118 ± 3%   +95.44%  (p=0.000 n=10+10)
ComputeBlock/16/cols/128/txes-8       586 ± 2%      1055 ± 8%   +80.06%  (p=0.000 n=8+10)

name                             old alloc/op   new alloc/op   delta
ComputeBlock/1/cols/16/txes-8      6.42MB ± 1%   13.59MB ± 0%  +111.71%  (p=0.000 n=10+10)
ComputeBlock/1/cols/32/txes-8      12.0MB ± 0%    26.3MB ± 0%  +119.22%  (p=0.000 n=10+10)
ComputeBlock/1/cols/64/txes-8      23.3MB ± 0%    51.8MB ± 0%  +122.43%  (p=0.000 n=10+9)
ComputeBlock/1/cols/128/txes-8     45.8MB ± 0%   103.2MB ± 0%  +125.07%  (p=0.000 n=10+9)
ComputeBlock/4/cols/16/txes-8      23.2MB ± 0%    52.0MB ± 0%  +123.86%  (p=0.000 n=10+10)
ComputeBlock/4/cols/32/txes-8      45.8MB ± 0%   103.6MB ± 0%  +126.44%  (p=0.000 n=10+10)
ComputeBlock/4/cols/64/txes-8      90.8MB ± 0%   205.6MB ± 0%  +126.39%  (p=0.000 n=10+10)
ComputeBlock/4/cols/128/txes-8      181MB ± 0%     410MB ± 0%  +126.28%  (p=0.000 n=10+10)
ComputeBlock/16/cols/16/txes-8     90.8MB ± 0%   206.4MB ± 0%  +127.32%  (p=0.000 n=10+10)
ComputeBlock/16/cols/32/txes-8      181MB ± 0%     412MB ± 0%  +127.36%  (p=0.000 n=9+9)
ComputeBlock/16/cols/64/txes-8      362MB ± 0%     820MB ± 0%  +126.52%  (p=0.000 n=7+10)
ComputeBlock/16/cols/128/txes-8     723MB ± 0%    1637MB ± 0%  +126.25%  (p=0.000 n=10+9)

name                             old allocs/op  new allocs/op  delta
ComputeBlock/1/cols/16/txes-8        100k ± 0%      236k ± 0%  +135.19%  (p=0.000 n=10+10)
ComputeBlock/1/cols/32/txes-8        194k ± 0%      465k ± 0%  +139.68%  (p=0.000 n=10+10)
ComputeBlock/1/cols/64/txes-8        381k ± 0%      923k ± 0%  +142.04%  (p=0.000 n=7+9)
ComputeBlock/1/cols/128/txes-8       755k ± 0%     1844k ± 0%  +144.10%  (p=0.000 n=10+9)
ComputeBlock/4/cols/16/txes-8        381k ± 0%      926k ± 0%  +142.76%  (p=0.000 n=10+10)
ComputeBlock/4/cols/32/txes-8        756k ± 0%     1844k ± 0%  +143.96%  (p=0.000 n=10+10)
ComputeBlock/4/cols/64/txes-8       1.51M ± 0%     3.68M ± 0%  +144.46%  (p=0.000 n=9+10)
ComputeBlock/4/cols/128/txes-8      3.00M ± 0%     7.35M ± 0%  +144.85%  (p=0.000 n=10+10)
ComputeBlock/16/cols/16/txes-8      1.51M ± 0%     3.68M ± 0%  +144.46%  (p=0.000 n=10+10)
ComputeBlock/16/cols/32/txes-8      3.00M ± 0%     7.35M ± 0%  +144.72%  (p=0.000 n=10+9)
ComputeBlock/16/cols/64/txes-8      6.00M ± 0%    14.69M ± 0%  +144.87%  (p=0.000 n=9+10)
ComputeBlock/16/cols/128/txes-8     12.0M ± 0%     29.4M ± 0%  +145.01%  (p=0.000 n=10+9)
```

This makes synthetic `pprof` graphs closely mirror the production EN ones (for the `BenchmarkComputeBlock`):
<img width="1366" alt="Screen Shot 2022-07-28 at 1 18 52 PM" src="https://user-images.githubusercontent.com/169976/181629823-3773a93a-e4dc-4faa-8a4f-f8afaa2ee34f.png">

Issue: https://github.com/dapperlabs/flow-go/issues/6310
Ref: https://github.com/onflow/flow-go/pull/2668