### PR TITLE
Fix state to only count bytes written/read when enforceLimit is enabled

### DIFF
--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1107,8 +1107,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 		).
 		run(
 			func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
-				ctx.MaxStateInteractionSize = 500_000
-				//ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
+				ctx.MaxStateInteractionSize = 1000
 
 				// Create an account private key.
 				privateKeys, err := testutil.GenerateAccountPrivateKeys(1)


### PR DESCRIPTION
TotalBytesRead/TotalBytesWritten are only used for interaction metering and
should not be updated when metering (aka enforceLimit) is disabled.

NOTE: I'll refactor the logic into meter in a follow up PR (looks like there's
already a TODO in the meter interface)