### PR TITLE
Fix linting

### DIFF
--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -1497,14 +1497,14 @@ func TestGetStorageCapacity(t *testing.T) {
 					}
 				`, address)))
 
-				view = delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
+				newview := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
 					if key == state.KeyAccountStatus {
 						return nil, fmt.Errorf("error getting register %s, %s", flow.BytesToAddress([]byte(owner)).Hex(), key)
 					}
 					return nil, nil
 				})
 
-				err := vm.Run(ctx, script, view, programs)
+				err := vm.Run(ctx, script, newview, programs)
 				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.KeyAccountStatus))
 			}),
 	)

--- a/network/p2p/dns/resolver.go
+++ b/network/p2p/dns/resolver.go
@@ -30,14 +30,12 @@ func runtimeNano() int64
 //     - Detecting expired cached domain triggers async DNS lookup to refresh cached entry.
 // [1] https://en.wikipedia.org/wiki/Name_server#Caching_name_server
 type Resolver struct {
-	c              *cache
-	res            madns.BasicResolver // underlying resolver
-	collector      module.ResolverMetrics
-	processingIPs  map[string]struct{} // ongoing ip lookups through underlying resolver
-	processingTXTs map[string]struct{} // ongoing txt lookups through underlying resolver
-	ipRequests     chan *lookupIPRequest
-	txtRequests    chan *lookupTXTRequest
-	logger         zerolog.Logger
+	c           *cache
+	res         madns.BasicResolver // underlying resolver
+	collector   module.ResolverMetrics
+	ipRequests  chan *lookupIPRequest
+	txtRequests chan *lookupTXTRequest
+	logger      zerolog.Logger
 	component.Component
 	cm *component.ComponentManager
 }


### PR DESCRIPTION
Fixing the following linting error
```
network/p2p/dns/resolver.go:37:2: field `processingTXTs` is unused (unused)
        processingTXTs map[string]struct{} // ongoing txt lookups through underlying resolver
        ^
network/p2p/dns/resolver.go:36:2: field `processingIPs` is unused (unused)
        processingIPs  map[string]struct{} // ongoing ip lookups through underlying resolver
        ^

fvm/accounts_test.go:1490:86: SA4009: argument view is overwritten before first use (staticcheck)
                        run(func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
                                                                                                          ^
fvm/accounts_test.go:1500:5: SA4009(related information): assignment to view (staticcheck)
                                view = delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
                                ^
```