### PR TITLE
[Profiler] move out of ./utils/debug to ./module/profiler

### DIFF
--- a/admin/commands/common/set_profiler_enabled.go
+++ b/admin/commands/common/set_profiler_enabled.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/onflow/flow-go/admin"
 	"github.com/onflow/flow-go/admin/commands"
-	"github.com/onflow/flow-go/utils/debug"
+	"github.com/onflow/flow-go/module/profiler"
 )
 
 var _ commands.AdminCommand = (*SetProfilerEnabledCommand)(nil)
@@ -15,7 +15,7 @@ type SetProfilerEnabledCommand struct{}
 
 func (s *SetProfilerEnabledCommand) Handler(ctx context.Context, req *admin.CommandRequest) (interface{}, error) {
 	enabled := req.ValidatorData.(bool)
-	debug.SetProfilerEnabled(enabled)
+	profiler.SetProfilerEnabled(enabled)
 	return "ok", nil
 }
 

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -38,6 +38,7 @@ import (
 	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/module/mempool/herocache"
 	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/profiler"
 	"github.com/onflow/flow-go/module/synchronization"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/module/util"
@@ -57,7 +58,6 @@ import (
 	bstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/storage/badger/operation"
 	sutil "github.com/onflow/flow-go/storage/util"
-	"github.com/onflow/flow-go/utils/debug"
 	"github.com/onflow/flow-go/utils/io"
 	"github.com/onflow/flow-go/utils/logging"
 )
@@ -534,7 +534,7 @@ func (fnb *FlowNodeBuilder) initProfiler() {
 	// note: by default the Golang heap profiling rate is on and can be set even if the profiler is NOT enabled
 	runtime.MemProfileRate = fnb.BaseConfig.profilerMemProfileRate
 
-	profiler, err := debug.NewAutoProfiler(
+	profiler, err := profiler.New(
 		fnb.Logger,
 		fnb.BaseConfig.profilerDir,
 		fnb.BaseConfig.profilerInterval,

--- a/module/profiler/profiler.go
+++ b/module/profiler/profiler.go
@@ -1,4 +1,4 @@
-package debug
+package profiler
 
 import (
 	"context"
@@ -34,7 +34,8 @@ type AutoProfiler struct {
 	duration time.Duration
 }
 
-func NewAutoProfiler(log zerolog.Logger, dir string, interval time.Duration, duration time.Duration, enabled bool) (*AutoProfiler, error) {
+// New creates a new AutoProfiler instance performing profiling every interval for duration.
+func New(log zerolog.Logger, dir string, interval time.Duration, duration time.Duration, enabled bool) (*AutoProfiler, error) {
 	SetProfilerEnabled(enabled)
 
 	err := os.MkdirAll(dir, os.ModePerm)

--- a/module/profiler/profiler_test.go
+++ b/module/profiler/profiler_test.go
@@ -1,4 +1,4 @@
-package debug_test
+package profiler_test
 
 import (
 	"os"
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-go/utils/debug"
+	"github.com/onflow/flow-go/module/profiler"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -16,7 +16,7 @@ func TestProfiler(t *testing.T) {
 	t.Parallel()
 	t.Run("profilerEnabled", func(t *testing.T) {
 		unittest.RunWithTempDir(t, func(tempDir string) {
-			p, err := debug.NewAutoProfiler(zerolog.Nop(), tempDir, time.Millisecond*100, time.Millisecond*100, true)
+			p, err := profiler.New(zerolog.Nop(), tempDir, time.Millisecond*100, time.Millisecond*100, true)
 			require.NoError(t, err)
 
 			unittest.AssertClosesBefore(t, p.Ready(), 5*time.Second)


### PR DESCRIPTION
While here added a comment.  Noop otherwise.

Issue: https://github.com/dapperlabs/flow-go/issues/6310