### PR TITLE
Add observer integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           - integration-consensus
           - integration-execution
           - integration-verification
+          - integration-observer
     env:
       TEST_CATEGORY: ${{ matrix.test-category }}
     runs-on: ubuntu-latest

--- a/.github/workflows/flaky-test-monitor-integration.yml
+++ b/.github/workflows/flaky-test-monitor-integration.yml
@@ -34,6 +34,7 @@ jobs:
           - integration-consensus
           - integration-execution
           - integration-verification
+          - integration-observer
     env:
       TEST_CATEGORY: ${{ matrix.test-category }}
       COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/flaky-test-monitor.yml
+++ b/.github/workflows/flaky-test-monitor.yml
@@ -32,6 +32,7 @@ jobs:
           - integration-consensus
           - integration-execution
           - integration-verification
+          - integration-observer
     env:
       TEST_CATEGORY: ${{ matrix.test-category }}
       COMMIT_SHA: ${{ github.sha }} 

--- a/.github/workflows/skipped-test-tracker-integration.yml
+++ b/.github/workflows/skipped-test-tracker-integration.yml
@@ -32,6 +32,7 @@ jobs:
           - integration-consensus
           - integration-execution
           - integration-verification
+          - integration-observer
     env:
       TEST_CATEGORY: ${{ matrix.test-category }}
       COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/skipped-test-tracker.yml
+++ b/.github/workflows/skipped-test-tracker.yml
@@ -30,6 +30,7 @@ jobs:
           - integration-consensus
           - integration-execution
           - integration-verification
+          - integration-observer
     env:
       TEST_CATEGORY: ${{ matrix.test-category }}
       COMMIT_SHA: ${{ github.sha }}

--- a/bors.toml
+++ b/bors.toml
@@ -13,6 +13,7 @@ status = [
   "Integration Tests (integration-consensus)",
   "Integration Tests (integration-execution)",
   "Integration Tests (integration-verification)",
+  "Integration Tests (integration-observer)",
   "Generate Flaky Test Summary (unit)",
   "Generate Flaky Test Summary (unit-crypto)",
   "Generate Flaky Test Summary (unit-integration)",
@@ -25,6 +26,7 @@ status = [
   "Generate Flaky Test Summary (integration-consensus)",
   "Generate Flaky Test Summary (integration-execution)",
   "Generate Flaky Test Summary (integration-verification)",
+  "Generate Flaky Test Summary (integration-observer)",
   "Generate Skipped Test Summary (unit)",
   "Generate Skipped Test Summary (unit-crypto)",
   "Generate Skipped Test Summary (unit-integration)",
@@ -37,6 +39,7 @@ status = [
   "Generate Skipped Test Summary (integration-consensus)",
   "Generate Skipped Test Summary (integration-execution)",
   "Generate Skipped Test Summary (integration-verification)",
+  "Generate Skipped Test Summary (integration-observer)",
 ]
 
 delete_merged_branches = true

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -63,7 +63,7 @@ network-tests:
 
 .PHONY: observer-tests
 observer-tests:
-	GO111MODULE=on go test $(if $(VERBOSE),-v,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/observer/...
+	go test $(if $(VERBOSE),-v,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/observer/...
 
 # BFT tests need to be run sequentially (-p 1) due to interference between different Docker networks when tests are run in parallel
 .PHONY: bft-tests

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -61,6 +61,10 @@ verification-tests:
 network-tests:
 	go test $(if $(VERBOSE),-v,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/network/...
 
+.PHONY: observer-tests
+observer-tests:
+	GO111MODULE=on go test $(if $(VERBOSE),-v,) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/observer/...
+
 # BFT tests need to be run sequentially (-p 1) due to interference between different Docker networks when tests are run in parallel
 .PHONY: bft-tests
 bft-tests:

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -666,16 +666,6 @@ func openAndTruncate(filename string) (*os.File, error) {
 // Observer functions
 //
 
-func getAccessGatewayPublicKey(flowNodeContainerConfigs []testnet.ContainerConfig) (string, error) {
-	for _, container := range flowNodeContainerConfigs {
-		if container.ContainerName == DefaultAccessGatewayName {
-			// remove the "0x"..0000 portion of the key
-			return container.NetworkPubKey().String()[2:], nil
-		}
-	}
-	return "", fmt.Errorf("Unable to find public key for Access Gateway expected in container '%s'", DefaultAccessGatewayName)
-}
-
 func writeObserverPrivateKey(observerName string) {
 	// make the observer private key for named observer
 	// only used for localnet, not for use with production
@@ -712,7 +702,7 @@ func prepareObserverServices(dockerServices Services, flowNodeContainerConfigs [
 		panic(fmt.Sprintf("No more than %d observers are permitted within localnet", DefaultMaxObservers))
 	}
 
-	agPublicKey, err := getAccessGatewayPublicKey(flowNodeContainerConfigs)
+	agPublicKey, err := testnet.GetAccessGatewayPublicKey(flowNodeContainerConfigs)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -552,8 +552,8 @@ func AsBootstrap() func(config *NodeConfig) {
 func AsObserver() func(config *NodeConfig) {
 	return func(config *NodeConfig) {
 		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
-		//config.AdditionalFlags = append(config.AdditionalFlags,
-		//	fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
+		config.AdditionalFlags = append(config.AdditionalFlags,
+			fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
 		//observerName := fmt.Sprintf("%s_%d", DefaultObserverName, 1)
 		//config.AdditionalFlags = append(config.AdditionalFlags,
 		//	fmt.Sprintf("--observer-networking-key-path=/bootstrap/private-root-information/%s_key", observerName))

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -551,20 +551,20 @@ func AsBootstrap() func(config *NodeConfig) {
 
 func AsObserver() func(config *NodeConfig) {
 	return func(config *NodeConfig) {
-		observerName := fmt.Sprintf("%s_%d", DefaultObserverName, 1)
 		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
-		config.AdditionalFlags = append(config.AdditionalFlags,
-			fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
-		config.AdditionalFlags = append(config.AdditionalFlags,
-			fmt.Sprintf("--observer-networking-key-path=/bootstrap/private-root-information/%s_key", observerName))
-		config.AdditionalFlags = append(config.AdditionalFlags,
-			fmt.Sprintf("--bind=0.0.0.0:0"))
-		agPublicKey, err := GetAccessGatewayPublicKeyString("0xffffffff")
-		if err != nil {
-			panic(err)
-		}
-		config.AdditionalFlags = append(config.AdditionalFlags,
-			fmt.Sprintf("--bootstrap-node-public-keys=%s", agPublicKey))
+		//config.AdditionalFlags = append(config.AdditionalFlags,
+		//	fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
+		//observerName := fmt.Sprintf("%s_%d", DefaultObserverName, 1)
+		//config.AdditionalFlags = append(config.AdditionalFlags,
+		//	fmt.Sprintf("--observer-networking-key-path=/bootstrap/private-root-information/%s_key", observerName))
+		//config.AdditionalFlags = append(config.AdditionalFlags,
+		//	fmt.Sprintf("--bind=0.0.0.0:0"))
+		//agPublicKey, err := GetAccessGatewayPublicKeyString("0xffffffff")
+		//if err != nil {
+		//	panic(err)
+		//}
+		//config.AdditionalFlags = append(config.AdditionalFlags,
+		//	fmt.Sprintf("--bootstrap-node-public-keys=%s", agPublicKey))
 	}
 }
 

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -466,7 +466,6 @@ type NodeConfig struct {
 	AdditionalFlags       []string
 	Debug                 bool
 	SupportsUnstakedNodes bool // only applicable to Access node
-	Observer              bool
 }
 
 func NewNodeConfig(role flow.Role, opts ...func(*NodeConfig)) NodeConfig {
@@ -475,7 +474,6 @@ func NewNodeConfig(role flow.Role, opts ...func(*NodeConfig)) NodeConfig {
 		Weight:     flow.DefaultInitialWeight,
 		Identifier: unittest.IdentifierFixture(), // default random ID
 		LogLevel:   zerolog.DebugLevel,           // log at debug by default
-		Observer:   false,
 	}
 
 	for _, apply := range opts {
@@ -542,25 +540,6 @@ const (
 	DefaultAccessGatewayName = "access_1"
 	DefaultObserverName      = "observer"
 )
-
-func AsBootstrap() func(config *NodeConfig) {
-	return func(config *NodeConfig) {
-		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
-		config.AdditionalFlags = append(config.AdditionalFlags, "--supports-observer=true")
-		config.AdditionalFlags = append(config.AdditionalFlags, fmt.Sprintf("--public-network-address=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
-	}
-}
-
-func AsObserver() func(config *NodeConfig) {
-	return func(config *NodeConfig) {
-		config.Observer = true
-		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
-		config.AdditionalFlags = append(config.AdditionalFlags,
-			fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
-		config.AdditionalFlags = append(config.AdditionalFlags,
-			fmt.Sprintf("--bind=0.0.0.0:0"))
-	}
-}
 
 // AsCorrupted sets the configuration of a node as corrupted, hence the node is pulling
 // the corrupted image of its role at the build time.

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -554,11 +554,11 @@ func AsObserver() func(config *NodeConfig) {
 		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
 		config.AdditionalFlags = append(config.AdditionalFlags,
 			fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
+		config.AdditionalFlags = append(config.AdditionalFlags,
+			fmt.Sprintf("--bind=0.0.0.0:0"))
 		//observerName := fmt.Sprintf("%s_%d", DefaultObserverName, 1)
 		//config.AdditionalFlags = append(config.AdditionalFlags,
 		//	fmt.Sprintf("--observer-networking-key-path=/bootstrap/private-root-information/%s_key", observerName))
-		//config.AdditionalFlags = append(config.AdditionalFlags,
-		//	fmt.Sprintf("--bind=0.0.0.0:0"))
 		//agPublicKey, err := GetAccessGatewayPublicKeyString("0xffffffff")
 		//if err != nil {
 		//	panic(err)

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -466,6 +466,7 @@ type NodeConfig struct {
 	AdditionalFlags       []string
 	Debug                 bool
 	SupportsUnstakedNodes bool // only applicable to Access node
+	Observer              bool
 }
 
 func NewNodeConfig(role flow.Role, opts ...func(*NodeConfig)) NodeConfig {
@@ -474,6 +475,7 @@ func NewNodeConfig(role flow.Role, opts ...func(*NodeConfig)) NodeConfig {
 		Weight:     flow.DefaultInitialWeight,
 		Identifier: unittest.IdentifierFixture(), // default random ID
 		LogLevel:   zerolog.DebugLevel,           // log at debug by default
+		Observer:   false,
 	}
 
 	for _, apply := range opts {
@@ -551,20 +553,12 @@ func AsBootstrap() func(config *NodeConfig) {
 
 func AsObserver() func(config *NodeConfig) {
 	return func(config *NodeConfig) {
+		config.Observer = true
 		config.AdditionalFlags = append(config.AdditionalFlags, "--topology=fully-connected")
 		config.AdditionalFlags = append(config.AdditionalFlags,
 			fmt.Sprintf("--bootstrap-node-addresses=%s:%d", DefaultAccessGatewayName, AccessPubNetworkPort))
 		config.AdditionalFlags = append(config.AdditionalFlags,
 			fmt.Sprintf("--bind=0.0.0.0:0"))
-		//observerName := fmt.Sprintf("%s_%d", DefaultObserverName, 1)
-		//config.AdditionalFlags = append(config.AdditionalFlags,
-		//	fmt.Sprintf("--observer-networking-key-path=/bootstrap/private-root-information/%s_key", observerName))
-		//agPublicKey, err := GetAccessGatewayPublicKeyString("0xffffffff")
-		//if err != nil {
-		//	panic(err)
-		//}
-		//config.AdditionalFlags = append(config.AdditionalFlags,
-		//	fmt.Sprintf("--bootstrap-node-public-keys=%s", agPublicKey))
 	}
 }
 

--- a/integration/tests/follower/consensus_follower_test.go
+++ b/integration/tests/follower/consensus_follower_test.go
@@ -1,4 +1,4 @@
-package access
+package follower
 
 import (
 	"context"

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -228,7 +228,7 @@ func (s *ExecutionStateSyncSuite) startObserver(ctx context.Context) {
 		panic(err)
 	}
 
-	time.Sleep(time.Second * 5) // needs breathing room for the observer to start listening
+	time.Sleep(time.Second * 3) // needs breathing room for the observer to start listening
 
 	// extend the teardown function removing observer first
 	s.cancelObserver = func() {

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -1,0 +1,208 @@
+package access
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	badgerds "github.com/ipfs/go-ds-badger2"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/onflow/flow-go/engine/ghost/client"
+	"github.com/onflow/flow-go/integration/testnet"
+	"github.com/onflow/flow-go/integration/tests/lib"
+	"github.com/onflow/flow-go/integration/utils"
+	"github.com/onflow/flow-go/model/encoding/cbor"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/state_synchronization"
+	"github.com/onflow/flow-go/network/compressor"
+	storage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestExecutionStateSync(t *testing.T) {
+	suite.Run(t, new(ExecutionStateSyncSuite))
+}
+
+type ExecutionStateSyncSuite struct {
+	suite.Suite
+	lib.TestnetStateTracker
+
+	log zerolog.Logger
+
+	bridgeID flow.Identifier
+	ghostID  flow.Identifier
+
+	// root context for the current test
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	net *testnet.FlowNetwork
+}
+
+func (s *ExecutionStateSyncSuite) SetupTest() {
+	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
+		Str("testfile", "execution_state_sync_test.go").
+		Str("testcase", s.T().Name()).
+		Logger()
+
+	s.log = logger
+	s.log.Info().Msg("================> SetupTest")
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
+	s.buildNetworkConfig()
+
+	// start the network
+	s.net.Start(s.ctx)
+
+	s.Track(s.T(), s.ctx, s.Ghost())
+}
+
+func (s *ExecutionStateSyncSuite) TearDownTest() {
+	s.log.Info().Msg("================> Start TearDownTest")
+	s.net.Remove()
+	s.cancel()
+	s.log.Info().Msgf("================> Finish TearDownTest")
+}
+
+func (s *ExecutionStateSyncSuite) Ghost() *client.GhostClient {
+	ghost := s.net.ContainerByID(s.ghostID)
+	client, err := lib.GetGhostClient(ghost)
+	require.NoError(s.T(), err, "could not get ghost client")
+	return client
+}
+
+func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
+	// access node
+	s.bridgeID = unittest.IdentifierFixture()
+	bridgeANConfig := testnet.NewNodeConfig(
+		flow.RoleAccess,
+		testnet.WithID(s.bridgeID),
+		testnet.SupportsUnstakedNodes(),
+		testnet.WithLogLevel(zerolog.DebugLevel),
+		testnet.WithAdditionalFlag("--execution-data-sync-enabled=true"),
+		testnet.WithAdditionalFlag(fmt.Sprintf("--execution-data-dir=%s", testnet.DefaultExecutionDataServiceDir)),
+		testnet.WithAdditionalFlag("--execution-data-retry-delay=1s"),
+	)
+
+	// add the ghost (access) node config
+	s.ghostID = unittest.IdentifierFixture()
+	ghostNode := testnet.NewNodeConfig(
+		flow.RoleAccess,
+		testnet.WithID(s.ghostID),
+		testnet.WithLogLevel(zerolog.FatalLevel),
+		testnet.AsGhost())
+
+	consensusConfigs := []func(config *testnet.NodeConfig){
+		testnet.WithAdditionalFlag("--hotstuff-timeout=12s"),
+		testnet.WithAdditionalFlag("--block-rate-delay=100ms"),
+		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", 1)),
+		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", 1)),
+		testnet.WithLogLevel(zerolog.FatalLevel),
+	}
+
+	net := []testnet.NodeConfig{
+		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel)),
+		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel)),
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel)),
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel)),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(flow.RoleVerification, testnet.WithLogLevel(zerolog.FatalLevel)),
+		bridgeANConfig,
+		ghostNode,
+		// TODO: add observer
+	}
+
+	conf := testnet.NewNetworkConfig("execution state sync test", net)
+	s.net = testnet.PrepareFlowNetwork(s.T(), conf, flow.Localnet)
+}
+
+// TestHappyPath tests that Execution Nodes generate execution data, and Access Nodes are able to
+// successfully sync the data
+func (s *ExecutionStateSyncSuite) TestHappyPath() {
+	// Let the network run for this many blocks
+	runBlocks := uint64(20)
+
+	// We will check that execution data was downloaded for this many blocks
+	// It has to be less than runBlocks since it's not possible to see which height the AN stopped
+	// downloading execution data for
+	checkBlocks := runBlocks / 2
+
+	// get the first block height
+	blockA := s.BlockState.WaitForHighestFinalizedProgress(s.T())
+	s.T().Logf("got block height %v ID %v", blockA.Header.Height, blockA.Header.ID())
+
+	// wait for the requested number of sealed blocks, then pause the network so we can inspect the dbs
+	s.BlockState.WaitForSealed(s.T(), blockA.Header.Height+runBlocks)
+	s.net.StopContainers()
+
+	// start an execution data service using the Access Node's execution data db
+	an := s.net.ContainerByID(s.bridgeID)
+	eds, ctx := s.getTestExecutionDataServiceNode(an)
+
+	// setup storage objects needed to get the execution data id
+	db, err := an.DB()
+	require.NoError(s.T(), err, "could not open db")
+
+	metrics := metrics.NewNoopCollector()
+	headers := storage.NewHeaders(metrics, db)
+	results := storage.NewExecutionResults(metrics, db)
+
+	// Loop through checkBlocks and verify the execution data was downloaded correctly
+	for i := blockA.Header.Height; i <= blockA.Header.Height+checkBlocks; i++ {
+		header, err := headers.ByHeight(i)
+		require.NoError(s.T(), err, "could not get header")
+
+		result, err := results.ByBlockID(header.ID())
+		require.NoError(s.T(), err, "could not get sealed result")
+
+		s.T().Logf("getting execution data for height %d, block %s, execution_data %s", header.Height, header.ID(), result.ExecutionDataID)
+
+		ed, err := eds.Get(ctx, result.ExecutionDataID)
+		assert.NoError(s.T(), err, "could not get execution data for height %v", i)
+
+		s.T().Logf("got execution data for height %d", i)
+		assert.Equal(s.T(), header.ID(), ed.BlockID)
+	}
+}
+
+func (s *ExecutionStateSyncSuite) getTestExecutionDataServiceNode(node *testnet.Container) (state_synchronization.ExecutionDataService, irrecoverable.SignalerContext) {
+	ctx, errChan := irrecoverable.WithSignaler(s.ctx)
+	go func() {
+		select {
+		case <-s.ctx.Done():
+			return
+		case err := <-errChan:
+			s.T().Errorf("irrecoverable error: %v", err)
+		}
+	}()
+
+	ds, err := badgerds.NewDatastore(node.ExecutionDataDBPath(), &badgerds.DefaultOptions)
+	require.NoError(s.T(), err, "could not get execution datastore")
+
+	go func() {
+		<-s.ctx.Done()
+		if err := ds.Close(); err != nil {
+			s.T().Logf("could not close execution data datastore: %v", err)
+		}
+	}()
+
+	blobService := utils.NewLocalBlobService(ds, utils.WithHashOnRead(true))
+	blobService.Start(ctx)
+
+	return state_synchronization.NewExecutionDataService(
+		cbor.NewCodec(),
+		compressor.NewLz4Compressor(),
+		blobService,
+		metrics.NewNoopCollector(),
+		zerolog.New(os.Stdout).With().Str("test", "execution-state-sync").Logger(),
+	), ctx
+}

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -122,12 +122,12 @@ func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
 	}
 
 	// Add an access node for observer access
-	bsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsBootstrap())
-	net = append(net, bsConfig)
-
-	// Add an observer node
-	obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
-	net = append(net, obsConfig)
+	//bsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsBootstrap())
+	//net = append(net, bsConfig)
+	//
+	//// Add an observer node
+	//obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
+	//net = append(net, obsConfig)
 
 	conf := testnet.NewNetworkConfig("execution state sync test", net)
 	s.net = testnet.PrepareFlowNetwork(s.T(), conf, flow.Localnet)

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -122,12 +122,12 @@ func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
 	}
 
 	// Add an access node for observer access
-	//bsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsBootstrap())
-	//net = append(net, bsConfig)
-	//
-	//// Add an observer node
-	//obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
-	//net = append(net, obsConfig)
+	bsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsBootstrap())
+	net = append(net, bsConfig)
+
+	// Add an extra observer node for testing
+	obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
+	net = append(net, obsConfig)
 
 	conf := testnet.NewNetworkConfig("execution state sync test", net)
 	s.net = testnet.PrepareFlowNetwork(s.T(), conf, flow.Localnet)

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -1,4 +1,4 @@
-package access
+package observer
 
 import (
 	"context"
@@ -120,6 +120,14 @@ func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
 		ghostNode,
 		// TODO: add observer
 	}
+
+	// Add an access node for observer access
+	bsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsBootstrap())
+	net = append(net, bsConfig)
+
+	// Add an observer node
+	obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
+	net = append(net, obsConfig)
 
 	conf := testnet.NewNetworkConfig("execution state sync test", net)
 	s.net = testnet.PrepareFlowNetwork(s.T(), conf, flow.Localnet)

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -65,11 +65,13 @@ func (s *ExecutionStateSyncSuite) SetupTest() {
 	s.startObserver(s.ctx)
 
 	s.Track(s.T(), s.ctx, s.Ghost())
+
+	s.cancelObserver()
 }
 
 func (s *ExecutionStateSyncSuite) TearDownTest() {
 	s.log.Info().Msg("================> Start TearDownTest")
-	s.cancelObserver()
+	//s.cancelObserver()
 	s.net.Remove()
 	s.cancel()
 	s.log.Info().Msgf("================> Finish TearDownTest")
@@ -230,7 +232,6 @@ func (s *ExecutionStateSyncSuite) startObserver(ctx context.Context) {
 
 	// extend the teardown function removing observer first
 	s.cancelObserver = func() {
-		//stop()
+		stop()
 	}
-	stop()
 }

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-func TestExecutionStateSync(t *testing.T) {
+func _TestExecutionStateSync(t *testing.T) {
 	suite.Run(t, new(ExecutionStateSyncSuite))
 }
 
@@ -128,7 +128,7 @@ func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
 
 // TestHappyPath tests that Execution Nodes generate execution data, and Access Nodes are able to
 // successfully sync the data
-func (s *ExecutionStateSyncSuite) TestHappyPath() {
+func (s *ExecutionStateSyncSuite) _TestHappyPath() {
 	// Let the network run for this many blocks
 	runBlocks := uint64(20)
 

--- a/integration/tests/observer/execution_state_sync_test.go
+++ b/integration/tests/observer/execution_state_sync_test.go
@@ -226,10 +226,11 @@ func (s *ExecutionStateSyncSuite) startObserver(ctx context.Context) {
 		panic(err)
 	}
 
-	time.Sleep(time.Second * 3) // needs breathing room for the observer to start listening
+	time.Sleep(time.Second * 5) // needs breathing room for the observer to start listening
 
 	// extend the teardown function removing observer first
 	s.cancelObserver = func() {
-		stop()
+		//stop()
 	}
+	stop()
 }

--- a/integration/tests/observer/observer_test.go
+++ b/integration/tests/observer/observer_test.go
@@ -1,0 +1,108 @@
+package access
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/onflow/flow-go/integration/testnet"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestObserver(t *testing.T) {
+	suite.Run(t, new(ObserverSuite))
+}
+
+type ObserverSuite struct {
+	suite.Suite
+
+	log zerolog.Logger
+
+	// root context for the current test
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	net *testnet.FlowNetwork
+}
+
+func (s *ObserverSuite) TearDownTest() {
+	s.log.Info().Msg("================> Start TearDownTest")
+	s.net.Remove()
+	s.cancel()
+	s.log.Info().Msg("================> Finish TearDownTest")
+}
+
+func (suite *ObserverSuite) SetupTest() {
+	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
+		Str("testfile", "api.go").
+		Str("testcase", suite.T().Name()).
+		Logger()
+	suite.log = logger
+	suite.log.Info().Msg("================> SetupTest")
+	defer func() {
+		suite.log.Info().Msg("================> Finish SetupTest")
+	}()
+
+	nodeConfigs := []testnet.NodeConfig{
+		testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel)),
+	}
+
+	// Add an access node for observer access
+	bsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsBootstrap())
+	nodeConfigs = append(nodeConfigs, bsConfig)
+
+	// Add an observer node
+	//obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
+	//nodeConfigs = append(nodeConfigs, obsConfig)
+
+	// need one dummy execution node (unused ghost)
+	exeConfig := testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost())
+	nodeConfigs = append(nodeConfigs, exeConfig)
+
+	// need one dummy verification node (unused ghost)
+	verConfig := testnet.NewNodeConfig(flow.RoleVerification, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost())
+	nodeConfigs = append(nodeConfigs, verConfig)
+
+	// need one controllable collection node (unused ghost)
+	collConfig := testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost())
+	nodeConfigs = append(nodeConfigs, collConfig)
+
+	// need three consensus nodes (unused ghost)
+	for n := 0; n < 3; n++ {
+		conID := unittest.IdentifierFixture()
+		nodeConfig := testnet.NewNodeConfig(flow.RoleConsensus,
+			testnet.WithLogLevel(zerolog.FatalLevel),
+			testnet.WithID(conID),
+			testnet.AsGhost())
+		nodeConfigs = append(nodeConfigs, nodeConfig)
+	}
+
+	conf := testnet.NewNetworkConfig("access_api_test", nodeConfigs)
+	suite.net = testnet.PrepareFlowNetwork(suite.T(), conf, flow.Localnet)
+
+	// start the network
+	suite.T().Logf("starting flow network with docker containers")
+	suite.ctx, suite.cancel = context.WithCancel(context.Background())
+	suite.net.Start(suite.ctx)
+}
+
+func (suite *ObserverSuite) _TestHTTPProxyPortOpen() {
+	httpProxyAddress := fmt.Sprintf(":%s", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
+	conn, err := net.DialTimeout("tcp", httpProxyAddress, 1*time.Second)
+	require.NoError(suite.T(), err, "http proxy port not open on the access node")
+	conn.Close()
+}
+
+func (suite *ObserverSuite) _TestObserverPortOpen() {
+	httpProxyAddress := fmt.Sprintf(":%s", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
+	conn, err := net.DialTimeout("tcp", httpProxyAddress, 1*time.Second)
+	require.NoError(suite.T(), err, "http proxy port not open on the observer node")
+	conn.Close()
+}

--- a/integration/tests/observer/observer_test.go
+++ b/integration/tests/observer/observer_test.go
@@ -59,8 +59,8 @@ func (suite *ObserverSuite) SetupTest() {
 	nodeConfigs = append(nodeConfigs, bsConfig)
 
 	// Add an observer node
-	//obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
-	//nodeConfigs = append(nodeConfigs, obsConfig)
+	obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
+	nodeConfigs = append(nodeConfigs, obsConfig)
 
 	// need one dummy execution node (unused ghost)
 	exeConfig := testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost())

--- a/integration/tests/observer/observer_test.go
+++ b/integration/tests/observer/observer_test.go
@@ -1,19 +1,20 @@
-package access
+package observer
 
 import (
 	"context"
 	"fmt"
-	"net"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
 
 	"github.com/onflow/flow-go/integration/testnet"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
+	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
 )
 
 func TestObserver(t *testing.T) {
@@ -22,57 +23,27 @@ func TestObserver(t *testing.T) {
 
 type ObserverSuite struct {
 	suite.Suite
-
-	log zerolog.Logger
-
-	// root context for the current test
-	ctx    context.Context
-	cancel context.CancelFunc
-
-	net *testnet.FlowNetwork
+	net      *testnet.FlowNetwork
+	teardown func()
 }
 
-func (s *ObserverSuite) TearDownTest() {
-	s.log.Info().Msg("================> Start TearDownTest")
-	s.net.Remove()
-	s.cancel()
-	s.log.Info().Msg("================> Finish TearDownTest")
+func (suite *ObserverSuite) TearDownTest() {
+	suite.teardown()
 }
 
 func (suite *ObserverSuite) SetupTest() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "api.go").
-		Str("testcase", suite.T().Name()).
-		Logger()
-	suite.log = logger
-	suite.log.Info().Msg("================> SetupTest")
-	defer func() {
-		suite.log.Info().Msg("================> Finish SetupTest")
-	}()
-
 	nodeConfigs := []testnet.NodeConfig{
-		testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel)),
+		// access node with unstaked nodes supported
+		testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), func(nc *testnet.NodeConfig) {
+			nc.SupportsUnstakedNodes = true
+		}),
+		// need one dummy execution node (unused ghost)
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost()),
+		// need one dummy verification node (unused ghost)
+		testnet.NewNodeConfig(flow.RoleVerification, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost()),
+		// need one controllable collection node (unused ghost)
+		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost()),
 	}
-
-	// Add an access node for observer access
-	bsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsBootstrap())
-	nodeConfigs = append(nodeConfigs, bsConfig)
-
-	// Add an observer node
-	obsConfig := testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.InfoLevel), testnet.AsObserver())
-	nodeConfigs = append(nodeConfigs, obsConfig)
-
-	// need one dummy execution node (unused ghost)
-	exeConfig := testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost())
-	nodeConfigs = append(nodeConfigs, exeConfig)
-
-	// need one dummy verification node (unused ghost)
-	verConfig := testnet.NewNodeConfig(flow.RoleVerification, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost())
-	nodeConfigs = append(nodeConfigs, verConfig)
-
-	// need one controllable collection node (unused ghost)
-	collConfig := testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.AsGhost())
-	nodeConfigs = append(nodeConfigs, collConfig)
 
 	// need three consensus nodes (unused ghost)
 	for n := 0; n < 3; n++ {
@@ -84,25 +55,220 @@ func (suite *ObserverSuite) SetupTest() {
 		nodeConfigs = append(nodeConfigs, nodeConfig)
 	}
 
-	conf := testnet.NewNetworkConfig("access_api_test", nodeConfigs)
+	// prepare the network
+	conf := testnet.NewNetworkConfig("observer_api_test", nodeConfigs)
 	suite.net = testnet.PrepareFlowNetwork(suite.T(), conf, flow.Localnet)
 
 	// start the network
-	suite.T().Logf("starting flow network with docker containers")
-	suite.ctx, suite.cancel = context.WithCancel(context.Background())
-	suite.net.Start(suite.ctx)
+	ctx := context.Background()
+	suite.net.Start(ctx)
+
+	stop, err := suite.net.AddObserver(ctx, &testnet.ObserverConfig{
+		ObserverName:            "observer_1",
+		ObserverImage:           "gcr.io/flow-container-registry/observer:latest",
+		AccessName:              "access_1",
+		AccessPublicNetworkPort: fmt.Sprint(testnet.AccessNodePublicNetworkPort),
+		AccessGRPCSecurePort:    fmt.Sprint(testnet.DefaultSecureGRPCPort),
+	})
+
+	if err != nil {
+		// this can happen occaisionally...
+		// usually it's because docker didn't remove the observer container during the previous test.
+		// the observer container is removed by an "AutoRemove" flag in AddObserver.
+		panic(err)
+	}
+
+	time.Sleep(time.Second * 3) // needs breathing room for the observer to start listening
+
+	// set the teardown function
+	suite.teardown = func() {
+		stop()
+		suite.net.Remove()
+	}
 }
 
-func (suite *ObserverSuite) _TestHTTPProxyPortOpen() {
-	httpProxyAddress := fmt.Sprintf(":%s", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
-	conn, err := net.DialTimeout("tcp", httpProxyAddress, 1*time.Second)
-	require.NoError(suite.T(), err, "http proxy port not open on the access node")
-	conn.Close()
+func (suite *ObserverSuite) TestObserverConnection() {
+	// tests that the observer can be pinged successfully but returns an error when the upstream access node is stopped
+	ctx := context.Background()
+	t := suite.T()
+
+	// get an observer client
+	observer, err := suite.getClient("0.0.0.0:9000")
+	assert.NoError(t, err)
+
+	// ping the observer while the access container is running
+	_, err = observer.Ping(ctx, &accessproto.PingRequest{})
+	assert.NoError(t, err)
+
+	// stop the upstream access container
+	err = suite.net.StopContainerByName(ctx, "access_1")
+	assert.NoError(t, err)
+
+	// ping the observer when access container is stopped
+	_, err = observer.Ping(ctx, &accessproto.PingRequest{})
+	assert.Error(t, err)
 }
 
-func (suite *ObserverSuite) _TestObserverPortOpen() {
-	httpProxyAddress := fmt.Sprintf(":%s", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
-	conn, err := net.DialTimeout("tcp", httpProxyAddress, 1*time.Second)
-	require.NoError(suite.T(), err, "http proxy port not open on the observer node")
-	conn.Close()
+func (suite *ObserverSuite) TestObserverWithoutAccess() {
+	// tests that the observer returns errors when the access node is stopped
+	ctx := context.Background()
+	t := suite.T()
+
+	// get an observer client
+	observer, err := suite.getClient("0.0.0.0:9000")
+	assert.NoError(t, err)
+
+	// stop the upstream access container
+	err = suite.net.StopContainerByName(ctx, "access_1")
+	assert.NoError(t, err)
+
+	// verify that we receive errors from all rpcs
+	for _, rpc := range suite.getRPCs() {
+		t.Run(rpc.name, func(t *testing.T) {
+			err := rpc.call(ctx, observer)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func (suite *ObserverSuite) TestObserverCompareRPCs() {
+	ctx := context.Background()
+	t := suite.T()
+
+	// get an observer and access client
+	observer, err := suite.getClient("0.0.0.0:9000")
+	assert.NoError(t, err)
+
+	access, err := suite.getClient(fmt.Sprintf("0.0.0.0:%s", suite.net.AccessPorts[testnet.AccessNodeAPIPort]))
+	assert.NoError(t, err)
+
+	// verify that both clients return the same errors
+	for _, rpc := range suite.getRPCs() {
+		t.Run(rpc.name, func(t *testing.T) {
+			accessErr := rpc.call(ctx, access)
+			observerErr := rpc.call(ctx, observer)
+			assert.Equal(t, accessErr, observerErr)
+		})
+	}
+}
+
+func (suite *ObserverSuite) getClient(address string) (accessproto.AccessAPIClient, error) {
+	// helper func to create an access client
+	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+
+	client := accessproto.NewAccessAPIClient(conn)
+	return client, nil
+}
+
+type RPCTest struct {
+	name string
+	call func(ctx context.Context, client accessproto.AccessAPIClient) error
+}
+
+func (suite *ObserverSuite) getRPCs() []RPCTest {
+	return []RPCTest{
+		{name: "Ping", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.Ping(ctx, &accessproto.PingRequest{})
+			return err
+		}},
+		{name: "GetLatestBlockHeader", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetLatestBlockHeader(ctx, &accessproto.GetLatestBlockHeaderRequest{})
+			return err
+		}},
+		{name: "GetBlockHeaderByID", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetBlockHeaderByID(ctx, &accessproto.GetBlockHeaderByIDRequest{})
+			return err
+		}},
+		{name: "GetBlockHeaderByHeight", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetBlockHeaderByHeight(ctx, &accessproto.GetBlockHeaderByHeightRequest{})
+			return err
+		}},
+		{name: "GetLatestBlock", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetLatestBlock(ctx, &accessproto.GetLatestBlockRequest{})
+			return err
+		}},
+		{name: "GetBlockByID", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetBlockByID(ctx, &accessproto.GetBlockByIDRequest{})
+			return err
+		}},
+		{name: "GetBlockByHeight", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetBlockByHeight(ctx, &accessproto.GetBlockByHeightRequest{})
+			return err
+		}},
+		{name: "GetCollectionByID", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetCollectionByID(ctx, &accessproto.GetCollectionByIDRequest{})
+			return err
+		}},
+		{name: "SendTransaction", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.SendTransaction(ctx, &accessproto.SendTransactionRequest{})
+			return err
+		}},
+		{name: "GetTransaction", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetTransaction(ctx, &accessproto.GetTransactionRequest{})
+			return err
+		}},
+		{name: "GetTransactionResult", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetTransactionResult(ctx, &accessproto.GetTransactionRequest{})
+			return err
+		}},
+		{name: "GetTransactionResultByIndex", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetTransactionResultByIndex(ctx, &accessproto.GetTransactionByIndexRequest{})
+			return err
+		}},
+		{name: "GetTransactionResultsByBlockID", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetTransactionResultsByBlockID(ctx, &accessproto.GetTransactionsByBlockIDRequest{})
+			return err
+		}},
+		{name: "GetTransactionsByBlockID", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetTransactionsByBlockID(ctx, &accessproto.GetTransactionsByBlockIDRequest{})
+			return err
+		}},
+		{name: "GetAccount", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetAccount(ctx, &accessproto.GetAccountRequest{})
+			return err
+		}},
+		{name: "GetAccountAtLatestBlock", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetAccountAtLatestBlock(ctx, &accessproto.GetAccountAtLatestBlockRequest{})
+			return err
+		}},
+		{name: "GetAccountAtBlockHeight", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetAccountAtBlockHeight(ctx, &accessproto.GetAccountAtBlockHeightRequest{})
+			return err
+		}},
+		{name: "ExecuteScriptAtLatestBlock", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.ExecuteScriptAtLatestBlock(ctx, &accessproto.ExecuteScriptAtLatestBlockRequest{})
+			return err
+		}},
+		{name: "ExecuteScriptAtBlockID", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.ExecuteScriptAtBlockID(ctx, &accessproto.ExecuteScriptAtBlockIDRequest{})
+			return err
+		}},
+		{name: "ExecuteScriptAtBlockHeight", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.ExecuteScriptAtBlockHeight(ctx, &accessproto.ExecuteScriptAtBlockHeightRequest{})
+			return err
+		}},
+		{name: "GetEventsForHeightRange", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetEventsForHeightRange(ctx, &accessproto.GetEventsForHeightRangeRequest{})
+			return err
+		}},
+		{name: "GetEventsForBlockIDs", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetEventsForBlockIDs(ctx, &accessproto.GetEventsForBlockIDsRequest{})
+			return err
+		}},
+		{name: "GetNetworkParameters", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetNetworkParameters(ctx, &accessproto.GetNetworkParametersRequest{})
+			return err
+		}},
+		{name: "GetLatestProtocolStateSnapshot", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetLatestProtocolStateSnapshot(ctx, &accessproto.GetLatestProtocolStateSnapshotRequest{})
+			return err
+		}},
+		{name: "GetExecutionResultForBlockID", call: func(ctx context.Context, client accessproto.AccessAPIClient) error {
+			_, err := client.GetExecutionResultForBlockID(ctx, &accessproto.GetExecutionResultForBlockIDRequest{})
+			return err
+		}},
+	}
 }

--- a/tools/test_monitor/run-tests.sh
+++ b/tools/test_monitor/run-tests.sh
@@ -11,7 +11,7 @@ echo "test category (run-tests):" $TEST_CATEGORY>&2
 
 # run tests and process results
 
-if [[ $TEST_CATEGORY =~ integration-(bft|ghost|mvp|network|epochs|access|collection|consensus|execution|verification)$ ]]
+if [[ $TEST_CATEGORY =~ integration-(bft|ghost|mvp|network|epochs|access|collection|consensus|execution|verification|observer)$ ]]
 then
   echo "killing and removing orphaned containers from previous run">&2
     # kill and remove orphaned containers from previous run

--- a/tools/test_monitor/test-setup.sh
+++ b/tools/test_monitor/test-setup.sh
@@ -11,7 +11,7 @@ make crypto_setup_gopath
 
 echo "test category (test-setup):" $TEST_CATEGORY>&2
 
-case $TEST_CATEGORY in integration-ghost|integration-mvp|integration-network|integration-epochs|integration-access|integration-collection|integration-consensus|integration-execution|integration-verification)
+case $TEST_CATEGORY in integration-ghost|integration-mvp|integration-network|integration-epochs|integration-access|integration-collection|integration-consensus|integration-execution|integration-verification|integration-observer)
   echo "running make docker-build-flow">&2
   make docker-build-flow
  ;;


### PR DESCRIPTION
This is an addition to `https://github.com/onflow/flow-go/pull/2886` cleaning up the observer integration test suite.