### PR TITLE
Update Cadence version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/onflow/atree v0.4.0
-	github.com/onflow/cadence v0.24.2-0.20220725165711-427397199cef
+	github.com/onflow/cadence v0.24.2-0.20220725233315-443ea529bed1
 	github.com/onflow/flow v0.3.2
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa

--- a/go.sum
+++ b/go.sum
@@ -1314,6 +1314,10 @@ github.com/onflow/atree v0.4.0/go.mod h1:7Qe1xaW0YewvouLXrugzMFUYXNoRQ8MT/UsVAWx
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
 github.com/onflow/cadence v0.24.2-0.20220725165711-427397199cef h1:oS+jvWU7XxzV12FdpFuOPWzWYkgZeHaV4jk2subf8H4=
 github.com/onflow/cadence v0.24.2-0.20220725165711-427397199cef/go.mod h1:CPJw4aCkbWmMT7yEf8NpbEuEMKY5J9J03PPnMymbe64=
+github.com/onflow/cadence v0.24.2-0.20220725233315-443ea529bed1 h1:IFejbqDXIyX9qbftK6c7OFUnjwPH0BFYSpvhMQdqhvo=
+github.com/onflow/cadence v0.24.2-0.20220725233315-443ea529bed1/go.mod h1:CPJw4aCkbWmMT7yEf8NpbEuEMKY5J9J03PPnMymbe64=
+github.com/onflow/cadence v0.24.7 h1:0abG/NfNHv7vfwM1s/99aEMIKbyv+ePOif3Ypk50ddw=
+github.com/onflow/cadence v0.24.7/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/flow v0.3.2 h1:z3IuKOjM9Tvf0pXfloTbrLxM5nTunI47cklsDd+wxBE=
 github.com/onflow/flow v0.3.2/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa h1:hcEp3INfkLh9jFODC9PHPQeisAd9rterujabee9il8w=


### PR DESCRIPTION
**Do not merge**

This PR updates Cadence version that exposes the new storage API in the runtime environment. 