### PR TITLE
[Profiler] Automatic pprof profile uploads to Google Cloud Profiler.

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -147,6 +147,7 @@ type BaseConfig struct {
 	UnicastMessageTimeout           time.Duration
 	DNSCacheTTL                     time.Duration
 	profilerEnabled                 bool
+	uploaderEnabled                 bool
 	profilerDir                     string
 	profilerInterval                time.Duration
 	profilerDuration                time.Duration
@@ -239,6 +240,7 @@ func DefaultBaseConfig() *BaseConfig {
 		UnicastMessageTimeout:           p2p.DefaultUnicastTimeout,
 		metricsPort:                     8080,
 		profilerEnabled:                 false,
+		uploaderEnabled:                 false,
 		profilerDir:                     "profiler",
 		profilerInterval:                15 * time.Minute,
 		profilerDuration:                10 * time.Second,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
+	"google.golang.org/api/option"
 
 	gcemd "cloud.google.com/go/compute/metadata"
 
@@ -538,7 +539,7 @@ func (fnb *FlowNodeBuilder) initMetrics() {
 	}
 }
 
-func (fnb *FlowNodeBuilder) createUploader(client *gcemd.Client) (profiler.Uploader, error) {
+func (fnb *FlowNodeBuilder) createUploader(client *gcemd.Client, opts ...option.ClientOption) (profiler.Uploader, error) {
 	projectID, err := client.ProjectID()
 	if err != nil {
 		fnb.Logger.Warn().Err(err).Msg("could not get CGE project ID")
@@ -567,7 +568,7 @@ func (fnb *FlowNodeBuilder) createUploader(client *gcemd.Client) (profiler.Uploa
 
 	fnb.Logger.Info().Msgf("creating pprof profile uploader with params: %+v", params)
 
-	return profiler.NewUploader(fnb.Logger, params)
+	return profiler.NewUploader(fnb.Logger, params, opts...)
 }
 
 func (fnb *FlowNodeBuilder) initProfiler() {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -14,14 +14,13 @@ import (
 	"strings"
 	"time"
 
+	gcemd "cloud.google.com/go/compute/metadata"
 	"github.com/dgraph-io/badger/v2"
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 	"google.golang.org/api/option"
-
-	gcemd "cloud.google.com/go/compute/metadata"
 
 	"github.com/onflow/flow-go/admin"
 	"github.com/onflow/flow-go/admin/commands"
@@ -130,12 +129,12 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 	fnb.flags.DurationVar(&fnb.BaseConfig.UnicastMessageTimeout, "unicast-timeout", defaultConfig.UnicastMessageTimeout, "how long a unicast transmission can take to complete")
 	fnb.flags.UintVarP(&fnb.BaseConfig.metricsPort, "metricport", "m", defaultConfig.metricsPort, "port for /metrics endpoint")
 	fnb.flags.BoolVar(&fnb.BaseConfig.profilerEnabled, "profiler-enabled", defaultConfig.profilerEnabled, "whether to enable the auto-profiler")
-	// Note: for autoupload to work forllowing should be true:
-	// * -profiler-enabled=true.
-	// * -profile-uploader-enabled=true.
-	// * node is running in GCE.
-	// * server or user has https://www.googleapis.com/auth/monitoring.write scope.
-	fnb.flags.BoolVar(&fnb.BaseConfig.uploaderEnabled, "profile-uploader-enabled", defaultConfig.uploaderEnabled, "whether to enable automatic profile upload to Google Cloud Profiler")
+	fnb.flags.BoolVar(&fnb.BaseConfig.uploaderEnabled, "profile-uploader-enabled", defaultConfig.uploaderEnabled,
+		"whether to enable automatic profile upload to Google Cloud Profiler. "+
+			"For autoupload to work forllowing should be true: "+
+			"1) both -profiler-enabled=true and -profile-uploader-enabled=true need to be set. "+
+			"2) node is running in GCE. "+
+			"3) server or user has https://www.googleapis.com/auth/monitoring.write scope. ")
 	fnb.flags.StringVar(&fnb.BaseConfig.profilerDir, "profiler-dir", defaultConfig.profilerDir, "directory to create auto-profiler profiles")
 	fnb.flags.DurationVar(&fnb.BaseConfig.profilerInterval, "profiler-interval", defaultConfig.profilerInterval,
 		"the interval between auto-profiler runs")
@@ -539,7 +538,7 @@ func (fnb *FlowNodeBuilder) initMetrics() {
 	}
 }
 
-func (fnb *FlowNodeBuilder) createUploader(client *gcemd.Client, opts ...option.ClientOption) (profiler.Uploader, error) {
+func (fnb *FlowNodeBuilder) createGCEProfileUploader(client *gcemd.Client, opts ...option.ClientOption) (profiler.Uploader, error) {
 	projectID, err := client.ProjectID()
 	if err != nil {
 		fnb.Logger.Warn().Err(err).Msg("could not get CGE project ID")
@@ -554,6 +553,7 @@ func (fnb *FlowNodeBuilder) createUploader(client *gcemd.Client, opts ...option.
 
 	chainID := fnb.RootChainID.String()
 	if chainID == "" {
+		fnb.Logger.Warn().Msg("RootChainID is not set, using default value")
 		chainID = "unknown"
 	}
 
@@ -565,26 +565,28 @@ func (fnb *FlowNodeBuilder) createUploader(client *gcemd.Client, opts ...option.
 		Commit:    build.Commit(),
 		Instance:  instance,
 	}
-
 	fnb.Logger.Info().Msgf("creating pprof profile uploader with params: %+v", params)
 
 	return profiler.NewUploader(fnb.Logger, params, opts...)
+}
+
+func (fnb *FlowNodeBuilder) createProfileUploader() (profiler.Uploader, error) {
+	switch {
+	case fnb.BaseConfig.uploaderEnabled && gcemd.OnGCE():
+		return fnb.createGCEProfileUploader(gcemd.NewClient(nil))
+	default:
+		fnb.Logger.Info().Msg("not running on GCE, setting pprof uploader to noop")
+		return &profiler.NoopUploader{}, nil
+	}
 }
 
 func (fnb *FlowNodeBuilder) initProfiler() {
 	// note: by default the Golang heap profiling rate is on and can be set even if the profiler is NOT enabled
 	runtime.MemProfileRate = fnb.BaseConfig.profilerMemProfileRate
 
-	var err error
-	var uploader profiler.Uploader
-	if fnb.BaseConfig.uploaderEnabled && gcemd.OnGCE() {
-		gcemdClient := gcemd.NewClient(nil)
-		uploader, err = fnb.createUploader(gcemdClient)
-		if err != nil {
-			fnb.Logger.Warn().Err(err).Msg("failed to create pprof uploader, falling back to noop")
-		}
-	} else {
-		fnb.Logger.Info().Msg("not running on GCE, setting pprof uploader to noop")
+	uploader, err := fnb.createProfileUploader()
+	if err != nil {
+		fnb.Logger.Warn().Err(err).Msg("failed to create pprof uploader, falling back to noop")
 		uploader = &profiler.NoopUploader{}
 	}
 

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -541,14 +541,12 @@ func (fnb *FlowNodeBuilder) initMetrics() {
 func (fnb *FlowNodeBuilder) createGCEProfileUploader(client *gcemd.Client, opts ...option.ClientOption) (profiler.Uploader, error) {
 	projectID, err := client.ProjectID()
 	if err != nil {
-		fnb.Logger.Warn().Err(err).Msg("could not get CGE project ID")
-		projectID = "unknown"
+		return &profiler.NoopUploader{}, fmt.Errorf("failed to get project ID: %w", err)
 	}
 
 	instance, err := client.InstanceID()
 	if err != nil {
-		fnb.Logger.Warn().Err(err).Msg("could not get CGE instance ID")
-		instance = "unknown"
+		return &profiler.NoopUploader{}, fmt.Errorf("failed to get instance ID: %w", err)
 	}
 
 	chainID := fnb.RootChainID.String()

--- a/cmd/scaffold_test.go
+++ b/cmd/scaffold_test.go
@@ -644,7 +644,7 @@ func TestCreateUploader(t *testing.T) {
 		nb := FlowNode("scaffold_uploader")
 
 		testClient := gcemd.NewClient(nil)
-		uploader, err := nb.createUploader(
+		uploader, err := nb.createGCEProfileUploader(
 			testClient,
 
 			option.WithoutAuthentication(),
@@ -675,7 +675,7 @@ func TestCreateUploader(t *testing.T) {
 		}
 
 		testClient := gcemd.NewClient(mockHttp)
-		uploader, err := nb.createUploader(
+		uploader, err := nb.createGCEProfileUploader(
 			testClient,
 
 			option.WithoutAuthentication(),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/onflow/flow-go
 go 1.18
 
 require (
+	cloud.google.com/go/compute v1.6.1
 	cloud.google.com/go/storage v1.16.0
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go-v2/config v1.8.0
@@ -98,7 +99,6 @@ require (
 
 require (
 	cloud.google.com/go v0.100.2 // indirect
-	cloud.google.com/go/compute v1.6.1 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.18
 
 require (
 	cloud.google.com/go/compute v1.6.1
-	cloud.google.com/go/storage v1.16.0
+	cloud.google.com/go/profiler v0.3.0
+	cloud.google.com/go/storage v1.22.1
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go-v2/config v1.8.0
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.5.1
@@ -161,6 +162,7 @@ require (
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
+	github.com/googleapis/go-type-adapters v1.0.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
 cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
+cloud.google.com/go/profiler v0.3.0 h1:R6y/xAeifaUXxd2x6w+jIwKxoKl8Cv5HJvcvASTPWJo=
+cloud.google.com/go/profiler v0.3.0/go.mod h1:9wYk9eY4iZHsev8TQb61kh3wiOiSyz/xOYixWPzweCU=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -60,8 +62,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
-cloud.google.com/go/storage v1.16.0 h1:1UwAux2OZP4310YXg5ohqBEpV16Y93uZG4+qOX7K2Kg=
-cloud.google.com/go/storage v1.16.0/go.mod h1:ieKBmUyzcftN5tbxwnXClMKH00CfcQ+xL6NN0r5QfmE=
+cloud.google.com/go/storage v1.22.1 h1:F6IlQJZrZM++apn9V5/VfS3gbTUYg98PS3EMQAzqtfg=
+cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
 dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl+fi1br7+Rr3LqpNJf1/uxUdtRUV+Tnj0o93V2B9MU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
@@ -520,6 +522,7 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f/go.mod h1:Pt31oes+eGImORns3McJn8zHefuQl2rG8l6xQjGYB4U=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -537,6 +540,8 @@ github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/Oth
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR82awk=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
+github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
+github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -613,6 +618,7 @@ github.com/huin/goupnp v1.0.3/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixH
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/improbable-eng/grpc-web v0.12.0 h1:GlCS+lMZzIkfouf7CNqY+qqpowdKuJLSLLcKVfM1oLc=
 github.com/improbable-eng/grpc-web v0.12.0/go.mod h1:6hRR09jOEG81ADP5wCQju1z71g6OL4eEvELdran/3cs=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -1901,7 +1907,6 @@ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210615190721-d04028783cf1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -2033,6 +2038,7 @@ golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025112917-711f33c9992c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2191,7 +2197,6 @@ google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBz
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
 google.golang.org/api v0.47.0/go.mod h1:Wbvgpq1HddcWVtzsVLyfLp8lDg6AA241LmgIL59tHXo=
 google.golang.org/api v0.48.0/go.mod h1:71Pr1vy+TAZRPkPs/xlCf5SsU8WjuAWv1Pfjbtukyy4=
-google.golang.org/api v0.49.0/go.mod h1:BECiH72wsfwUvOVn3+btPD5WHi0LzavZReBndi42L18=
 google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNefaw=
 google.golang.org/api v0.51.0/go.mod h1:t4HdrdoNgyN5cbEfm7Lum0lcLDLiise1F8qDKX00sOU=
 google.golang.org/api v0.54.0/go.mod h1:7C4bFFOvVDGXjfDTAsgGwDgAxRDeQ4X8NvUedIt6z3k=
@@ -2265,13 +2270,12 @@ google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210329143202-679c6ae281ee/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
-google.golang.org/genproto v0.0.0-20210617175327-b9e0b3197ced/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
-google.golang.org/genproto v0.0.0-20210624174822-c5cf32407d0a/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
 google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
 google.golang.org/genproto v0.0.0-20210713002101-d411969a0d9a/go.mod h1:AxrInvYm1dci+enl5hChSFPOmmUF1+uAa/UsgNRWd7k=
 google.golang.org/genproto v0.0.0-20210716133855-ce7ef5c701ea/go.mod h1:AxrInvYm1dci+enl5hChSFPOmmUF1+uAa/UsgNRWd7k=
@@ -2301,6 +2305,7 @@ google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd h1:e0TwkXOdbnH/1x5rc5MZ/VYyiZ4v+RdVfrGMqEwT68I=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -36,7 +36,7 @@ require (
 	cloud.google.com/go v0.100.2 // indirect
 	cloud.google.com/go/compute v1.6.1 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
-	cloud.google.com/go/storage v1.16.0 // indirect
+	cloud.google.com/go/storage v1.22.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
@@ -110,6 +110,7 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
+	github.com/googleapis/go-type-adapters v1.0.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -106,6 +106,7 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -53,6 +53,7 @@ cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
 cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
+cloud.google.com/go/profiler v0.3.0 h1:R6y/xAeifaUXxd2x6w+jIwKxoKl8Cv5HJvcvASTPWJo=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -63,8 +64,8 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
-cloud.google.com/go/storage v1.16.0 h1:1UwAux2OZP4310YXg5ohqBEpV16Y93uZG4+qOX7K2Kg=
-cloud.google.com/go/storage v1.16.0/go.mod h1:ieKBmUyzcftN5tbxwnXClMKH00CfcQ+xL6NN0r5QfmE=
+cloud.google.com/go/storage v1.22.1 h1:F6IlQJZrZM++apn9V5/VfS3gbTUYg98PS3EMQAzqtfg=
+cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl+fi1br7+Rr3LqpNJf1/uxUdtRUV+Tnj0o93V2B9MU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -605,6 +606,8 @@ github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/Oth
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR82awk=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
+github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
+github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -2043,7 +2046,6 @@ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210615190721-d04028783cf1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -2345,7 +2347,6 @@ google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBz
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
 google.golang.org/api v0.47.0/go.mod h1:Wbvgpq1HddcWVtzsVLyfLp8lDg6AA241LmgIL59tHXo=
 google.golang.org/api v0.48.0/go.mod h1:71Pr1vy+TAZRPkPs/xlCf5SsU8WjuAWv1Pfjbtukyy4=
-google.golang.org/api v0.49.0/go.mod h1:BECiH72wsfwUvOVn3+btPD5WHi0LzavZReBndi42L18=
 google.golang.org/api v0.50.0/go.mod h1:4bNT5pAuq5ji4SRZm+5QIkjny9JAyVD/3gaSihNefaw=
 google.golang.org/api v0.51.0/go.mod h1:t4HdrdoNgyN5cbEfm7Lum0lcLDLiise1F8qDKX00sOU=
 google.golang.org/api v0.54.0/go.mod h1:7C4bFFOvVDGXjfDTAsgGwDgAxRDeQ4X8NvUedIt6z3k=
@@ -2421,13 +2422,12 @@ google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20210329143202-679c6ae281ee/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210608205507-b6d2f5bf0d7d/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
-google.golang.org/genproto v0.0.0-20210617175327-b9e0b3197ced/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
-google.golang.org/genproto v0.0.0-20210624174822-c5cf32407d0a/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
 google.golang.org/genproto v0.0.0-20210624195500-8bfb893ecb84/go.mod h1:SzzZ/N+nwJDaO1kznhnlzqS8ocJICar6hYhVyhi++24=
 google.golang.org/genproto v0.0.0-20210713002101-d411969a0d9a/go.mod h1:AxrInvYm1dci+enl5hChSFPOmmUF1+uAa/UsgNRWd7k=
 google.golang.org/genproto v0.0.0-20210716133855-ce7ef5c701ea/go.mod h1:AxrInvYm1dci+enl5hChSFPOmmUF1+uAa/UsgNRWd7k=
@@ -2457,6 +2457,7 @@ google.golang.org/genproto v0.0.0-20220414192740-2d67ff6cf2b4/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd h1:e0TwkXOdbnH/1x5rc5MZ/VYyiZ4v+RdVfrGMqEwT68I=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/module/profiler/profiler_test.go
+++ b/module/profiler/profiler_test.go
@@ -16,7 +16,7 @@ func TestProfiler(t *testing.T) {
 	t.Parallel()
 	t.Run("profilerEnabled", func(t *testing.T) {
 		unittest.RunWithTempDir(t, func(tempDir string) {
-			p, err := profiler.New(zerolog.Nop(), tempDir, time.Millisecond*100, time.Millisecond*100, true)
+			p, err := profiler.New(zerolog.Nop(), &profiler.NoopUploader{}, tempDir, time.Millisecond*100, time.Millisecond*100, true)
 			require.NoError(t, err)
 
 			unittest.AssertClosesBefore(t, p.Ready(), 5*time.Second)

--- a/module/profiler/uploader.go
+++ b/module/profiler/uploader.go
@@ -1,0 +1,117 @@
+package profiler
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/api/option"
+	gtransport "google.golang.org/api/transport/grpc"
+	pb "google.golang.org/genproto/googleapis/devtools/cloudprofiler/v2"
+	"google.golang.org/grpc"
+)
+
+const (
+	apiAddress = "cloudprofiler.googleapis.com:443"
+	scope      = "https://www.googleapis.com/auth/monitoring.write"
+
+	maxMsgSize = 1 << 30 // 1GB
+)
+
+type NoopUploader struct{}
+
+func (u *NoopUploader) Upload(ctx context.Context, filename string, pt pb.ProfileType) error {
+	return nil
+}
+
+type Uploader interface {
+	Upload(ctx context.Context, filename string, pt pb.ProfileType) error
+}
+
+type Params struct {
+	ProjectID string
+	ChainID   string
+	Role      string
+	Version   string
+	Commit    string
+	Instance  string
+}
+
+type UploaderImpl struct {
+	log    zerolog.Logger
+	client pb.ProfilerServiceClient
+
+	ProjectId  string
+	Deployment *pb.Deployment
+}
+
+func NewUploader(log zerolog.Logger, params Params) (Uploader, error) {
+	log = log.With().Str("component", "profile_uploader").Logger()
+
+	connPool, err := gtransport.DialPool(
+		context.Background(),
+
+		option.WithEndpoint(apiAddress),
+		option.WithScopes(scope),
+		option.WithUserAgent("OfflinePprofUploader"),
+		option.WithTelemetryDisabled(),
+		option.WithGRPCDialOption(
+			grpc.WithDefaultCallOptions(
+				grpc.MaxCallSendMsgSize(maxMsgSize),
+			),
+		),
+	)
+	if err != nil {
+		return &NoopUploader{}, fmt.Errorf("failed to create connection pool: %w", err)
+	}
+
+	version := fmt.Sprintf("%s-%s", params.Version, params.Commit)
+	targetName := fmt.Sprintf("%s-%s", params.ChainID, params.Role)
+	deployment := &pb.Deployment{
+		ProjectId: params.ProjectID,
+		Target:    targetName,
+		Labels: map[string]string{
+			"language": "go",
+			"version":  version,
+			"instance": params.Instance,
+		},
+	}
+
+	u := &UploaderImpl{
+		log:    log,
+		client: pb.NewProfilerServiceClient(connPool),
+
+		ProjectId:  params.ProjectID,
+		Deployment: deployment,
+	}
+
+	return u, nil
+}
+
+func (u *UploaderImpl) Upload(ctx context.Context, filename string, pt pb.ProfileType) error {
+	profileBytes, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read profile: %w", err)
+	}
+
+	req := pb.CreateOfflineProfileRequest{
+		Parent: u.ProjectId,
+		Profile: &pb.Profile{
+			ProfileType:  pt,
+			Deployment:   u.Deployment,
+			ProfileBytes: profileBytes,
+		},
+	}
+
+	resp, err := u.client.CreateOfflineProfile(ctx, &req)
+	if err != nil {
+		return fmt.Errorf("failed to create offline profile: %w", err)
+	}
+	u.log.Info().
+		Str("file_name", filename).
+		Str("profile_name", resp.GetName()).
+		Int("profile_size", len(profileBytes)).
+		Msg("uploaded profile")
+	return nil
+}

--- a/module/profiler/uploader.go
+++ b/module/profiler/uploader.go
@@ -46,12 +46,10 @@ type UploaderImpl struct {
 	Deployment *pb.Deployment
 }
 
-func NewUploader(log zerolog.Logger, params Params) (Uploader, error) {
+func NewUploader(log zerolog.Logger, params Params, opts ...option.ClientOption) (Uploader, error) {
 	log = log.With().Str("component", "profile_uploader").Logger()
 
-	connPool, err := gtransport.DialPool(
-		context.Background(),
-
+	defaultOpts := []option.ClientOption{
 		option.WithEndpoint(apiAddress),
 		option.WithScopes(scope),
 		option.WithUserAgent("OfflinePprofUploader"),
@@ -61,6 +59,12 @@ func NewUploader(log zerolog.Logger, params Params) (Uploader, error) {
 				grpc.MaxCallSendMsgSize(maxMsgSize),
 			),
 		),
+	}
+	opts = append(defaultOpts, opts...)
+
+	connPool, err := gtransport.DialPool(
+		context.Background(),
+		opts...,
 	)
 	if err != nil {
 		return &NoopUploader{}, fmt.Errorf("failed to create connection pool: %w", err)

--- a/module/profiler/uploader_test.go
+++ b/module/profiler/uploader_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
 	pb "google.golang.org/genproto/googleapis/devtools/cloudprofiler/v2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestProfilerUpload(t *testing.T) {
@@ -22,7 +24,13 @@ func TestProfilerUpload(t *testing.T) {
 		Commit:    "commit",
 		Instance:  "instance",
 	}
-	uploader, err := NewUploader(zerolog.Nop(), params)
+	uploader, err := NewUploader(
+		zerolog.Nop(),
+		params,
+
+		option.WithoutAuthentication(),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+	)
 	require.NoError(t, err)
 
 	uploaderImpl, ok := uploader.(*UploaderImpl)

--- a/module/profiler/uploader_test.go
+++ b/module/profiler/uploader_test.go
@@ -1,0 +1,56 @@
+package profiler
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/profiler/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	pb "google.golang.org/genproto/googleapis/devtools/cloudprofiler/v2"
+	"google.golang.org/grpc"
+)
+
+func TestProfilerUpload(t *testing.T) {
+	params := Params{
+		ProjectID: "project_id",
+		ChainID:   "chain_id",
+		Role:      "role",
+		Version:   "version",
+		Commit:    "commit",
+		Instance:  "instance",
+	}
+	uploader, err := NewUploader(zerolog.Nop(), params)
+	require.NoError(t, err)
+
+	uploaderImpl, ok := uploader.(*UploaderImpl)
+	require.True(t, ok)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := mocks.NewMockProfilerServiceClient(ctrl)
+	uploaderImpl.client = mock
+
+	mock.EXPECT().CreateOfflineProfile(gomock.Any(), gomock.Any()).
+		Return(&pb.Profile{Name: "test"}, nil).
+		Times(1).
+		Do(func(ctx context.Context, req *pb.CreateOfflineProfileRequest, opts ...grpc.CallOption) {
+			require.Equal(t, "project_id", req.Parent)
+			require.Equal(t, "project_id", req.Profile.Deployment.GetProjectId())
+			require.Equal(t, "chain_id-role", req.Profile.Deployment.GetTarget())
+			require.Equal(t, "version-commit", req.Profile.Deployment.GetLabels()["version"])
+		})
+
+	f, err := os.CreateTemp("", "example")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	err = uploader.Upload(context.Background(), f.Name(), pb.ProfileType_CPU)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This diffs adds an ability to upload AutoProfiler pprof files to [Cloud Profiler](https://cloud.google.com/profiler/docs/about-profiler).

For this to work VM should be running in GCE, have access to `cloudprofiler.googleapis.com:443`, and have the `https://www.googleapis.com/auth/monitoring.write` scope.  Also, one should check their "Create offline requests per day" quota.

Note that, this functionality is currently hidden behind both `-profiler-enabled` and `-profile-uploader-enabled` feature flags.

While here, also:
* Removed Mutex profiling, since [Block profiling is better](https://github.com/DataDog/go-profiler-notes/blob/main/block.md) for our usecase. 
* Switched from heap to alloc profile.  These only differ in the default sample name but identical otherwise.

Issue: https://github.com/dapperlabs/flow-go/issues/6310

Followup diffs:
- [ ] Add metrics.
- [ ] Add localnet support for uploading pprof data.