### PR TITLE
Rename EnvContext to Tracer + Reduce dependency on Context

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -76,11 +76,12 @@ type AccountInterface interface {
 // Parts of the environment that are common to all transaction and script
 // executions.
 type commonEnv struct {
-	// TODO(patrick): convert ctx to anonymous field once the rest of env
-	// is broken up into coherent pieces.
-	ctx *EnvContext
+	*Tracer
 	*ProgramLogger
 	*UnsafeRandomGenerator
+
+	// TODO(patrick): rm
+	ctx Context
 
 	MeterInterface
 	AccountInterface
@@ -114,21 +115,12 @@ func (env *commonEnv) MemoryEstimate() uint64 {
 	return uint64(env.sth.State().TotalMemoryEstimate())
 }
 
-// TODO(patrick): rm once ctx becomes an anonymous field.
 func (env *commonEnv) Context() *Context {
-	return env.ctx.Context()
+	return &env.ctx
 }
 
 func (env *commonEnv) AccountFreezeEnabled() bool {
 	return env.ctx.AccountFreezeEnabled
-}
-
-func (env *commonEnv) StartSpanFromRoot(name trace.SpanName) otelTrace.Span {
-	return env.ctx.StartSpanFromRoot(name)
-}
-
-func (env *commonEnv) StartExtensiveTracingSpanFromRoot(name trace.SpanName) otelTrace.Span {
-	return env.ctx.StartExtensiveTracingSpanFromRoot(name)
 }
 
 func (env *commonEnv) VM() *VirtualMachine {

--- a/fvm/program_logger.go
+++ b/fvm/program_logger.go
@@ -11,24 +11,31 @@ import (
 )
 
 type ProgramLogger struct {
-	ctx *EnvContext
+	tracer *Tracer
 
-	logs     []string
+	cadenceLoggingEnabled bool
+	logs                  []string
+
 	reporter handler.MetricsReporter
 }
 
-func NewProgramLogger(ctx *EnvContext) *ProgramLogger {
+func NewProgramLogger(
+	tracer *Tracer,
+	reporter handler.MetricsReporter,
+	cadenceLoggingEnabled bool,
+) *ProgramLogger {
 	return &ProgramLogger{
-		ctx:      ctx,
-		logs:     nil,
-		reporter: ctx.Metrics,
+		tracer:                tracer,
+		cadenceLoggingEnabled: cadenceLoggingEnabled,
+		logs:                  nil,
+		reporter:              reporter,
 	}
 }
 
 func (logger *ProgramLogger) ProgramLog(message string) error {
-	defer logger.ctx.StartExtensiveTracingSpanFromRoot(trace.FVMEnvProgramLog).End()
+	defer logger.tracer.StartExtensiveTracingSpanFromRoot(trace.FVMEnvProgramLog).End()
 
-	if logger.ctx.CadenceLoggingEnabled {
+	if logger.cadenceLoggingEnabled {
 		logger.logs = append(logger.logs, message)
 	}
 	return nil
@@ -42,7 +49,7 @@ func (logger *ProgramLogger) RecordTrace(operation string, location common.Locat
 	if location != nil {
 		attrs = append(attrs, attribute.String("location", location.String()))
 	}
-	logger.ctx.RecordSpanFromRoot(
+	logger.tracer.RecordSpanFromRoot(
 		trace.FVMCadenceTrace.Child(operation),
 		duration,
 		attrs)

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -41,19 +41,27 @@ func NewScriptEnvironment(
 	uuidGenerator := state.NewUUIDGenerator(sth)
 	programsHandler := handler.NewProgramsHandler(programs, sth)
 	accountKeys := handler.NewAccountKeyHandler(accounts)
+	tracer := NewTracer(fvmContext.Tracer, nil, fvmContext.ExtensiveTracing)
 
-	ctx := NewEnvContext(fvmContext, nil)
 	env := &ScriptEnv{
 		commonEnv: commonEnv{
-			ctx:                   ctx,
-			ProgramLogger:         NewProgramLogger(ctx),
-			UnsafeRandomGenerator: NewUnsafeRandomGenerator(ctx),
-			sth:                   sth,
-			vm:                    vm,
-			programs:              programsHandler,
-			accounts:              accounts,
-			accountKeys:           accountKeys,
-			uuidGenerator:         uuidGenerator,
+			Tracer: tracer,
+			ProgramLogger: NewProgramLogger(
+				tracer,
+				fvmContext.Metrics,
+				fvmContext.CadenceLoggingEnabled,
+			),
+			UnsafeRandomGenerator: NewUnsafeRandomGenerator(
+				tracer,
+				fvmContext.BlockHeader,
+			),
+			ctx:           fvmContext,
+			sth:           sth,
+			vm:            vm,
+			programs:      programsHandler,
+			accounts:      accounts,
+			accountKeys:   accountKeys,
+			uuidGenerator: uuidGenerator,
 		},
 		reqContext: reqContext,
 	}

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -57,19 +57,27 @@ func NewTransactionEnvironment(
 		ctx.EventCollectionByteSizeLimit,
 	)
 	accountKeys := handler.NewAccountKeyHandler(accounts)
+	tracer := NewTracer(ctx.Tracer, traceSpan, ctx.ExtensiveTracing)
 
-	envCtx := NewEnvContext(ctx, traceSpan)
 	env := &TransactionEnv{
 		commonEnv: commonEnv{
-			ctx:                   envCtx,
-			ProgramLogger:         NewProgramLogger(envCtx),
-			UnsafeRandomGenerator: NewUnsafeRandomGenerator(envCtx),
-			sth:                   sth,
-			vm:                    vm,
-			programs:              programsHandler,
-			accounts:              accounts,
-			accountKeys:           accountKeys,
-			uuidGenerator:         uuidGenerator,
+			Tracer: tracer,
+			ProgramLogger: NewProgramLogger(
+				tracer,
+				ctx.Metrics,
+				ctx.CadenceLoggingEnabled,
+			),
+			UnsafeRandomGenerator: NewUnsafeRandomGenerator(
+				tracer,
+				ctx.BlockHeader,
+			),
+			ctx:           ctx,
+			sth:           sth,
+			vm:            vm,
+			programs:      programsHandler,
+			accounts:      accounts,
+			accountKeys:   accountKeys,
+			uuidGenerator: uuidGenerator,
 		},
 
 		addressGenerator: generator,


### PR DESCRIPTION
1. Renamed EnvContext to Tracer
2. Stop passing Context into program logger / tracer / rand gen.  Only pass
   in what's necessary.