### PR TITLE
De-activate schedule on Flaky Test Debug Github workflow

### DIFF
--- a/.github/workflows/flaky-test-debug.yml
+++ b/.github/workflows/flaky-test-debug.yml
@@ -1,8 +1,6 @@
 name: Flaky Test Debug
 
 on:
-  schedule:
-    - cron: '0 */1 * * *' # every 1 hour
   push:
     branches:
       - '**/*flaky-test*'


### PR DESCRIPTION
[Flaky Test Debug Github Actions](https://github.com/onflow/flow-go/actions/workflows/flaky-test-debug.yml) workflow is unnecessarily running every hour and wasting Github runner resources.

It was de-activated manually in Github in the past but has since been reactivated. The schedule is set to run every hour and that needs to be deactivated.