### PR TITLE
[Don't Merge] Debugging Flaky Epoch Tests

### DIFF
--- a/integration/tests/epochs/epoch_join_and_leave_an_test.go
+++ b/integration/tests/epochs/epoch_join_and_leave_an_test.go
@@ -6,11 +6,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestEpochJoinAndLeaveAN(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "epochs join/leave tests should be run on an machine with adequate resources")
 	suite.Run(t, new(EpochJoinAndLeaveANSuite))
 }
 

--- a/integration/tests/epochs/epoch_join_and_leave_sn_test.go
+++ b/integration/tests/epochs/epoch_join_and_leave_sn_test.go
@@ -6,11 +6,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestEpochJoinAndLeaveSN(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "epochs join/leave tests should be run on an machine with adequate resources")
 	suite.Run(t, new(EpochJoinAndLeaveSNSuite))
 }
 

--- a/integration/tests/epochs/epoch_join_and_leave_vn_test.go
+++ b/integration/tests/epochs/epoch_join_and_leave_vn_test.go
@@ -6,11 +6,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestEpochJoinAndLeaveVN(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "epochs join/leave tests should be run on an machine with adequate resources")
 	suite.Run(t, new(EpochJoinAndLeaveVNSuite))
 }
 

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -79,8 +79,8 @@ func (s *Suite) SetupTest() {
 	consensusConfigs := []func(config *testnet.NodeConfig){
 		testnet.WithAdditionalFlag("--hotstuff-timeout=12s"),
 		testnet.WithAdditionalFlag("--block-rate-delay=100ms"),
-		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", 1)),
-		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", 1)),
+		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", 0)),
+		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", 0)),
 		testnet.WithLogLevel(zerolog.WarnLevel),
 	}
 


### PR DESCRIPTION
@durkmurder noticed that periodic halts to approval production were causing flakiness in the static epoch test. Applying the same change here, to disable requiring approvals, to see if it will impact test flakiness on the other test cases. 