### PR TITLE
[Makefile] bump minimum golang version to 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,10 +472,17 @@ PHONY: tool-remove-execution-fork
 tool-remove-execution-fork: docker-build-remove-execution-fork
 	docker container create --name remove-execution-fork $(CONTAINER_REGISTRY)/remove-execution-fork:latest;docker container cp remove-execution-fork:/bin/app ./remove-execution-fork;docker container rm remove-execution-fork
 
-# Check if the go version is 1.16 or higher. flow-go only supports go 1.16 and up.
 .PHONY: check-go-version
 check-go-version:
-	go version | grep '1.1[6-9]'
+	@bash -c '\
+		MINGOVERSION=1.18; \
+		function ver { printf "%d%03d%03d%03d" $$(echo "$$1" | tr . " "); }; \
+		GOVER=$$(go version | sed -rne "s/.* go([0-9.]+).*/\1/p" ); \
+		if [ "$$(ver $$GOVER)" -lt "$$(ver $$MINGOVERSION)" ]; then \
+			echo "go $$GOVER is too old. flow-go only supports go $$MINGOVERSION and up."; \
+			exit 1; \
+		fi; \
+		'
 
 #----------------------------------------------------------------------
 # CD COMMANDS

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following table lists all work streams and links to their home directory and
 
 ### Install Dependencies
 
-- Install [Go](https://golang.org/doc/install) (Flow supports Go 1.16 and later)
+- Install [Go](https://golang.org/doc/install) (Flow supports Go 1.18 and later)
 - Install [CMake](https://cmake.org/install/), which is used for building the crypto library
 - Install [Docker](https://docs.docker.com/get-docker/), which is used for running a local network and integration tests
 - Make sure the [`GOPATH`](https://golang.org/cmd/go/#hdr-GOPATH_environment_variable) and `GOBIN` environment variables


### PR DESCRIPTION
This also adds support for go1.20+ since `gotip` is already on it:
```
gotip version
go version devel go1.20-f28fa95 Wed Aug 3 12:52:27 2022 darwin/arm64
```