### PR TITLE
Make memory/interaction metering consistent for all accounts.

### DIFF
--- a/fvm/context.go
+++ b/fvm/context.go
@@ -30,18 +30,19 @@ type Context struct {
 	ServiceAccountEnabled                bool
 	// Depricated: RestrictedDeploymentEnabled is deprecated use SetIsContractDeploymentRestrictedTransaction instead.
 	// Can be removed after all networks are migrated to SetIsContractDeploymentRestrictedTransaction
-	RestrictContractDeployment    bool
-	RestrictContractRemoval       bool
-	LimitAccountStorage           bool
-	TransactionFeesEnabled        bool
-	CadenceLoggingEnabled         bool
-	EventCollectionEnabled        bool
-	ServiceEventCollectionEnabled bool
-	AccountFreezeEnabled          bool
-	ExtensiveTracing              bool
-	TransactionProcessors         []TransactionProcessor
-	ScriptProcessors              []ScriptProcessor
-	Logger                        zerolog.Logger
+	RestrictContractDeployment        bool
+	RestrictContractRemoval           bool
+	LimitAccountStorage               bool
+	TransactionFeesEnabled            bool
+	CadenceLoggingEnabled             bool
+	EventCollectionEnabled            bool
+	ServiceEventCollectionEnabled     bool
+	AccountFreezeEnabled              bool
+	ExtensiveTracing                  bool
+	TransactionProcessors             []TransactionProcessor
+	ScriptProcessors                  []ScriptProcessor
+	Logger                            zerolog.Logger
+	DisableMemoryAndInteractionLimits bool
 }
 
 // NewContext initializes a new execution context with the provided options.
@@ -102,7 +103,8 @@ func defaultContext(logger zerolog.Logger) Context {
 		ScriptProcessors: []ScriptProcessor{
 			NewScriptInvoker(),
 		},
-		Logger: logger,
+		Logger:                            logger,
+		DisableMemoryAndInteractionLimits: false,
 	}
 }
 
@@ -317,6 +319,15 @@ func WithAccountStorageLimit(enabled bool) Option {
 func WithTransactionFeesEnabled(enabled bool) Option {
 	return func(ctx Context) Context {
 		ctx.TransactionFeesEnabled = enabled
+		return ctx
+	}
+}
+
+// WithMemoryAndInteractionLimitsDisabled sets memory and interaction limits to
+// MaxUint64, effectively disabling these limits.
+func WithMemoryAndInteractionLimitsDisabled() Option {
+	return func(ctx Context) Context {
+		ctx.DisableMemoryAndInteractionLimits = true
 		return ctx
 	}
 }

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -93,6 +93,9 @@ type commonEnv struct {
 	accountKeys   *handler.AccountKeyHandler
 	contracts     *handler.ContractHandler
 	uuidGenerator *state.UUIDGenerator
+
+	// TODO(patrick): rm once fully refactored
+	fullEnv Environment
 }
 
 // TODO(patrick): rm once Meter object has been refactored

--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -11,6 +11,91 @@ import (
 	"github.com/onflow/flow-go/fvm/utils"
 )
 
+func setMeterParameters(env *commonEnv) error {
+	// Don't enforce limits while setting up limits.
+	env.sth.DisableAllLimitEnforcements()
+	defer env.sth.EnableAllLimitEnforcements()
+
+	if env.ctx.AllowContextOverrideByExecutionState {
+		err := setExecutionParameters(env)
+		if err != nil {
+			return err
+		}
+	}
+
+	if env.ctx.DisableMemoryAndInteractionLimits {
+		env.sth.DisableMemoryAndInteractionLimits()
+	}
+
+	return nil
+}
+
+func setExecutionParameters(env *commonEnv) error {
+	// Check that the service account exists because all the settings are
+	// stored in it
+	serviceAddress := env.Context().Chain.ServiceAddress()
+	service := runtime.Address(serviceAddress)
+
+	// set the property if no error, but if the error is a fatal error then
+	// return it
+	setIfOk := func(prop string, err error, setter func()) (fatal error) {
+		err, fatal = errors.SplitErrorTypes(err)
+		if fatal != nil {
+			// this is a fatal error. return it
+			env.ctx.Logger.
+				Error().
+				Err(fatal).
+				Msgf("error getting %s", prop)
+			return fatal
+		}
+		if err != nil {
+			// this is a general error.
+			// could be that no setting was present in the state,
+			// or that the setting was not parseable,
+			// or some other deterministic thing.
+			env.ctx.Logger.
+				Debug().
+				Err(err).
+				Msgf("could not set %s. Using defaults", prop)
+			return nil
+		}
+		// everything is ok. do the setting
+		setter()
+		return nil
+	}
+
+	meter := env.sth.State().Meter()
+
+	computationWeights, err := GetExecutionEffortWeights(env.fullEnv, service)
+	err = setIfOk(
+		"execution effort weights",
+		err,
+		func() { meter.SetComputationWeights(computationWeights) })
+	if err != nil {
+		return err
+	}
+
+	memoryWeights, err := GetExecutionMemoryWeights(env.fullEnv, service)
+	err = setIfOk(
+		"execution memory weights",
+		err,
+		func() { meter.SetMemoryWeights(memoryWeights) })
+	if err != nil {
+		return err
+	}
+
+	memoryLimit, err := GetExecutionMemoryLimit(env.fullEnv, service)
+	err = setIfOk(
+		"execution memory limit",
+		err,
+		func() { meter.SetTotalMemoryLimit(memoryLimit) })
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func getExecutionWeights[KindType common.ComputationKind | common.MemoryKind](
 	env Environment,
 	service runtime.Address,

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1109,7 +1109,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			tx := fvm.Transaction(txBody, 0)
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
-			require.Equal(t, uint64(0), tx.MemoryEstimate)
+			require.Greater(t, tx.MemoryEstimate, uint64(20_000_000_000))
 
 			require.NoError(t, tx.Err)
 		},

--- a/fvm/handler/programs.go
+++ b/fvm/handler/programs.go
@@ -72,7 +72,7 @@ func (h *ProgramsHandler) Set(location common.Location, program *interpreter.Pro
 
 	h.Programs.Set(address, program, last.state)
 
-	err := h.mergeState(last.state, h.masterState.EnforceInteractionLimits())
+	err := h.mergeState(last.state, h.masterState.EnforceLimits())
 
 	return err
 }
@@ -141,13 +141,13 @@ func (h *ProgramsHandler) Cleanup() error {
 
 	for i := stackLen - 1; i > 0; i-- {
 		entry := h.viewsStack[i]
-		err := h.viewsStack[i-1].state.MergeState(entry.state, h.masterState.EnforceInteractionLimits())
+		err := h.viewsStack[i-1].state.MergeState(entry.state, h.masterState.EnforceLimits())
 		if err != nil {
 			return fmt.Errorf("cannot merge state while cleanup: %w", err)
 		}
 	}
 
-	err := h.initialState.MergeState(h.viewsStack[0].state, h.masterState.EnforceInteractionLimits())
+	err := h.initialState.MergeState(h.viewsStack[0].state, h.masterState.EnforceLimits())
 	if err != nil {
 		return err
 	}

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -69,6 +69,7 @@ func NewScriptEnvironment(
 	// TODO(patrick): remove this hack
 	env.MeterInterface = env
 	env.AccountInterface = env
+	env.fullEnv = env
 
 	env.contracts = handler.NewContractHandler(
 		accounts,
@@ -78,77 +79,9 @@ func NewScriptEnvironment(
 		func() []common.Address { return []common.Address{} },
 		func(address runtime.Address, code []byte) (bool, error) { return false, nil })
 
-	var err error
-	// set the execution parameters from the state
-	if fvmContext.AllowContextOverrideByExecutionState {
-		err = env.setExecutionParameters()
-	}
+	err := setMeterParameters(&env.commonEnv)
 
 	return env, err
-}
-
-func (e *ScriptEnv) setExecutionParameters() error {
-	// Check that the service account exists because all the settings are stored in it
-	serviceAddress := e.Context().Chain.ServiceAddress()
-	service := runtime.Address(serviceAddress)
-
-	// set the property if no error, but if the error is a fatal error then return it
-	setIfOk := func(prop string, err error, setter func()) (fatal error) {
-		err, fatal = errors.SplitErrorTypes(err)
-		if fatal != nil {
-			// this is a fatal error. return it
-			e.ctx.Logger.
-				Error().
-				Err(fatal).
-				Msgf("error getting %s", prop)
-			return fatal
-		}
-		if err != nil {
-			// this is a general error.
-			// could be that no setting was present in the state,
-			// or that the setting was not parseable,
-			// or some other deterministic thing.
-			e.ctx.Logger.
-				Debug().
-				Err(err).
-				Msgf("could not set %s. Using defaults", prop)
-			return nil
-		}
-		// everything is ok. do the setting
-		setter()
-		return nil
-	}
-
-	meter := e.sth.State().Meter()
-
-	computationWeights, err := GetExecutionEffortWeights(e, service)
-	err = setIfOk(
-		"execution effort weights",
-		err,
-		func() { meter.SetComputationWeights(computationWeights) })
-	if err != nil {
-		return err
-	}
-
-	memoryWeights, err := GetExecutionMemoryWeights(e, service)
-	err = setIfOk(
-		"execution memory weights",
-		err,
-		func() { meter.SetMemoryWeights(memoryWeights) })
-	if err != nil {
-		return err
-	}
-
-	memoryLimit, err := GetExecutionMemoryLimit(e, service)
-	err = setIfOk(
-		"execution memory limit",
-		err,
-		func() { meter.SetTotalMemoryLimit(memoryLimit) })
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (e *ScriptEnv) GetStorageCapacity(address common.Address) (value uint64, err error) {
@@ -308,14 +241,14 @@ func (e *ScriptEnv) Meter(kind common.ComputationKind, intensity uint) error {
 		return err
 	}
 
-	if e.sth.EnforceComputationLimits() {
+	if e.sth.EnforceLimits() {
 		return e.sth.State().MeterComputation(kind, intensity)
 	}
 	return nil
 }
 
 func (e *ScriptEnv) meterMemory(kind common.MemoryKind, intensity uint) error {
-	if e.sth.EnforceMemoryLimits() {
+	if e.sth.EnforceLimits() {
 		return e.sth.State().MeterMemory(kind, intensity)
 	}
 	return nil

--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -410,7 +410,7 @@ func (a *StatefulAccounts) setStorageUsed(address flow.Address, used uint64) err
 }
 
 func (a *StatefulAccounts) GetValue(address flow.Address, key string) (flow.RegisterValue, error) {
-	return a.stateHolder.State().Get(string(address.Bytes()), key, a.stateHolder.EnforceInteractionLimits())
+	return a.stateHolder.State().Get(string(address.Bytes()), key, a.stateHolder.EnforceLimits())
 }
 
 // SetValue sets a value in address' storage
@@ -419,7 +419,7 @@ func (a *StatefulAccounts) SetValue(address flow.Address, key string, value flow
 	if err != nil {
 		return fmt.Errorf("failed to update storage used by key %s on account %s: %w", PrintableKey(key), address, err)
 	}
-	return a.stateHolder.State().Set(string(address.Bytes()), key, value, a.stateHolder.EnforceInteractionLimits())
+	return a.stateHolder.State().Set(string(address.Bytes()), key, value, a.stateHolder.EnforceLimits())
 
 }
 
@@ -481,7 +481,7 @@ func RegisterSize(address flow.Address, key string, value flow.RegisterValue) in
 // TODO replace with touch
 // TODO handle errors
 func (a *StatefulAccounts) touch(address flow.Address, key string) {
-	_, _ = a.stateHolder.State().Get(string(address.Bytes()), key, a.stateHolder.EnforceInteractionLimits())
+	_, _ = a.stateHolder.State().Get(string(address.Bytes()), key, a.stateHolder.EnforceLimits())
 }
 
 func (a *StatefulAccounts) TouchContract(contractName string, address flow.Address) {

--- a/fvm/state/address_generator.go
+++ b/fvm/state/address_generator.go
@@ -27,7 +27,7 @@ func NewStateBoundAddressGenerator(stateHolder *StateHolder, chain flow.Chain) *
 // this requires changes outside of fvm since the type is defined on flow model
 // and emulator and others might be dependent on that
 func (g *StateBoundAddressGenerator) Bytes() []byte {
-	stateBytes, err := g.stateHolder.State().Get("", keyAddressState, g.stateHolder.EnforceInteractionLimits())
+	stateBytes, err := g.stateHolder.State().Get("", keyAddressState, g.stateHolder.EnforceLimits())
 	if err != nil {
 		panic(err)
 	}
@@ -36,7 +36,7 @@ func (g *StateBoundAddressGenerator) Bytes() []byte {
 
 func (g *StateBoundAddressGenerator) constructAddressGen() (flow.AddressGenerator, error) {
 	st := g.stateHolder.State()
-	stateBytes, err := st.Get("", keyAddressState, g.stateHolder.EnforceInteractionLimits())
+	stateBytes, err := st.Get("", keyAddressState, g.stateHolder.EnforceLimits())
 	if err != nil {
 		return nil, fmt.Errorf("failed to read address generator state from the state: %w", err)
 	}
@@ -57,7 +57,7 @@ func (g *StateBoundAddressGenerator) NextAddress() (flow.Address, error) {
 	}
 
 	// update the ledger state
-	err = g.stateHolder.State().Set("", keyAddressState, addressGenerator.Bytes(), g.stateHolder.EnforceInteractionLimits())
+	err = g.stateHolder.State().Set("", keyAddressState, addressGenerator.Bytes(), g.stateHolder.EnforceLimits())
 	if err != nil {
 		return address, fmt.Errorf("failed to update the state with address generator state: %w", err)
 	}

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -91,7 +91,7 @@ func WithMaxValueSizeAllowed(limit uint64) func(st *State) *State {
 // WithMaxInteractionSizeAllowed sets limit on total byte interaction with ledger
 func WithMaxInteractionSizeAllowed(limit uint64) func(st *State) *State {
 	return func(st *State) *State {
-		st.maxInteractionAllowed = limit
+		st.SetTotalInteractionLimit(limit)
 		return st
 	}
 }
@@ -181,6 +181,10 @@ func (s *State) Touch(owner, key string) error {
 	return s.view.Touch(owner, key)
 }
 
+func (s *State) SetTotalInteractionLimit(limit uint64) {
+	s.maxInteractionAllowed = limit
+}
+
 // MeterComputation meters computation usage
 func (s *State) MeterComputation(kind common.ComputationKind, intensity uint) error {
 	return s.meter.MeterComputation(kind, intensity)
@@ -199,6 +203,10 @@ func (s *State) ComputationIntensities() meter.MeteredComputationIntensities {
 // TotalComputationLimit returns total computation limit
 func (s *State) TotalComputationLimit() uint {
 	return s.meter.TotalComputationLimit()
+}
+
+func (s *State) SetTotalMemoryLimit(limit uint64) {
+	s.meter.SetTotalMemoryLimit(limit)
 }
 
 // MeterMemory meters memory usage

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -1,15 +1,18 @@
 package state
 
+import (
+	"math"
+)
+
 // StateHolder provides active states
 // and facilitates common state management operations
 // in order to make services such as accounts not worry about
 // the state it is recommended that such services wraps
 // a state manager instead of a state itself.
 type StateHolder struct {
-	enforceLimits         bool
-	payerIsServiceAccount bool
-	startState            *State
-	activeState           *State
+	enforceLimits bool
+	startState    *State
+	activeState   *State
 }
 
 // NewStateHolder constructs a new state manager
@@ -31,9 +34,11 @@ func (s *StateHolder) SetActiveState(st *State) {
 	s.activeState = st
 }
 
-// SetPayerIsServiceAccount sets if the payer is the service account
-func (s *StateHolder) SetPayerIsServiceAccount() {
-	s.payerIsServiceAccount = true
+// DisableMemoryAndInteractionLimits sets the memory and interaction limits to
+// MaxUint64, effectively disabling these limits
+func (s *StateHolder) DisableMemoryAndInteractionLimits() {
+	s.activeState.SetTotalMemoryLimit(math.MaxUint64)
+	s.activeState.SetTotalInteractionLimit(math.MaxUint64)
 }
 
 // NewChild constructs a new child of active state
@@ -56,18 +61,7 @@ func (s *StateHolder) DisableAllLimitEnforcements() {
 	s.enforceLimits = false
 }
 
-// EnforceComputationLimits returns if the computation limits should be enforced
-// or not.
-func (s *StateHolder) EnforceComputationLimits() bool {
+// EnforceLimits returns if limits should be enforced or not
+func (s *StateHolder) EnforceLimits() bool {
 	return s.enforceLimits
-}
-
-// EnforceInteractionLimits returns if the interaction limits should be enforced or not
-func (s *StateHolder) EnforceInteractionLimits() bool {
-	return !s.payerIsServiceAccount && s.enforceLimits
-}
-
-// EnforceMemoryLimits returns if the memory limits should be enforced or not
-func (s *StateHolder) EnforceMemoryLimits() bool {
-	return !s.payerIsServiceAccount && s.enforceLimits
 }

--- a/fvm/state/uuids.go
+++ b/fvm/state/uuids.go
@@ -21,7 +21,7 @@ func NewUUIDGenerator(stateHolder *StateHolder) *UUIDGenerator {
 
 // GetUUID reads uint64 byte value for uuid from the state
 func (u *UUIDGenerator) GetUUID() (uint64, error) {
-	stateBytes, err := u.stateHolder.State().Get("", keyUUID, u.stateHolder.EnforceInteractionLimits())
+	stateBytes, err := u.stateHolder.State().Get("", keyUUID, u.stateHolder.EnforceLimits())
 	if err != nil {
 		return 0, fmt.Errorf("cannot get uuid byte from state: %w", err)
 	}
@@ -34,7 +34,7 @@ func (u *UUIDGenerator) GetUUID() (uint64, error) {
 func (u *UUIDGenerator) SetUUID(uuid uint64) error {
 	bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, uuid)
-	err := u.stateHolder.State().Set("", keyUUID, bytes, u.stateHolder.EnforceInteractionLimits())
+	err := u.stateHolder.State().Set("", keyUUID, bytes, u.stateHolder.EnforceLimits())
 	if err != nil {
 		return fmt.Errorf("cannot set uuid byte to state: %w", err)
 	}

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -58,7 +58,7 @@ func (proc *TransactionProcedure) Run(vm *VirtualMachine, ctx Context, st *state
 	}()
 
 	if proc.Transaction.Payer == ctx.Chain.ServiceAddress() {
-		st.SetPayerIsServiceAccount()
+		ctx.DisableMemoryAndInteractionLimits = true
 	}
 
 	for _, p := range ctx.TransactionProcessors {

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -90,6 +90,7 @@ func NewTransactionEnvironment(
 	// TODO(patrick): rm this hack
 	env.MeterInterface = env
 	env.AccountInterface = env
+	env.fullEnv = env
 
 	env.contracts = handler.NewContractHandler(accounts,
 		func() bool {
@@ -112,77 +113,9 @@ func NewTransactionEnvironment(
 		env.useContractAuditVoucher,
 	)
 
-	var err error
-	// set the execution parameters from the state
-	if ctx.AllowContextOverrideByExecutionState {
-		err = env.setExecutionParameters()
-	}
+	err := setMeterParameters(&env.commonEnv)
 
 	return env, err
-}
-
-func (e *TransactionEnv) setExecutionParameters() error {
-	// Check that the service account exists because all the settings are stored in it
-	serviceAddress := e.Context().Chain.ServiceAddress()
-	service := runtime.Address(serviceAddress)
-
-	// set the property if no error, but if the error is a fatal error then return it
-	setIfOk := func(prop string, err error, setter func()) (fatal error) {
-		err, fatal = errors.SplitErrorTypes(err)
-		if fatal != nil {
-			// this is a fatal error. return it
-			e.ctx.Logger.
-				Error().
-				Err(fatal).
-				Msgf("error getting %s", prop)
-			return fatal
-		}
-		if err != nil {
-			// this is a general error.
-			// could be that no setting was present in the state,
-			// or that the setting was not parseable,
-			// or some other deterministic thing.
-			e.ctx.Logger.
-				Debug().
-				Err(err).
-				Msgf("could not set %s. Using defaults", prop)
-			return nil
-		}
-		// everything is ok. do the setting
-		setter()
-		return nil
-	}
-
-	meter := e.sth.State().Meter()
-
-	computationWeights, err := GetExecutionEffortWeights(e, service)
-	err = setIfOk(
-		"execution effort weights",
-		err,
-		func() { meter.SetComputationWeights(computationWeights) })
-	if err != nil {
-		return err
-	}
-
-	memoryWeights, err := GetExecutionMemoryWeights(e, service)
-	err = setIfOk(
-		"execution memory weights",
-		err,
-		func() { meter.SetMemoryWeights(memoryWeights) })
-	if err != nil {
-		return err
-	}
-
-	memoryLimit, err := GetExecutionMemoryLimit(e, service)
-	err = setIfOk(
-		"execution memory limit",
-		err,
-		func() { meter.SetTotalMemoryLimit(memoryLimit) })
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (e *TransactionEnv) TxIndex() uint32 {
@@ -436,14 +369,14 @@ func (e *TransactionEnv) ServiceEvents() []flow.Event {
 }
 
 func (e *TransactionEnv) Meter(kind common.ComputationKind, intensity uint) error {
-	if e.sth.EnforceComputationLimits() {
+	if e.sth.EnforceLimits() {
 		return e.sth.State().MeterComputation(kind, intensity)
 	}
 	return nil
 }
 
 func (e *TransactionEnv) meterMemory(kind common.MemoryKind, intensity uint) error {
-	if e.sth.EnforceMemoryLimits() {
+	if e.sth.EnforceLimits() {
 		return e.sth.State().MeterMemory(kind, intensity)
 	}
 	return nil

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -39,7 +39,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	parentState := sth.State()
 	childState := sth.NewChild()
 	defer func() {
-		if mergeError := parentState.MergeState(childState, sth.EnforceInteractionLimits()); mergeError != nil {
+		if mergeError := parentState.MergeState(childState, sth.EnforceLimits()); mergeError != nil {
 			panic(mergeError)
 		}
 		sth.SetActiveState(parentState)


### PR DESCRIPTION
Previously, the cached meter state differed depending on which payer account
loaded the program into the cache, resulting in non-deterministic execution.

Note: the cached usage limits are "incorrect", but they does not impact the
final execution result.

Non-deterministic execution due to frozen account, weight updates, service
account metering are all manifestation of the same underlying problem.  In the
long run, we should stop caching transaction state as part of program cache.