### PR TITLE
[BFT Testing] Crash Test utility

### DIFF
--- a/utils/unittest/logging.go
+++ b/utils/unittest/logging.go
@@ -2,6 +2,7 @@ package unittest
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -66,6 +67,12 @@ func (hook LoggerHook) Logs() string {
 }
 
 // Run implements zerolog.Hook and appends the log message to the log.
-func (hook LoggerHook) Run(_ *zerolog.Event, _ zerolog.Level, msg string) {
+func (hook LoggerHook) Run(_ *zerolog.Event, level zerolog.Level, msg string) {
 	hook.logs.WriteString(msg)
+
+	// for tests that need to test logger.Fatal(), this is useful because the parent test process will read from stdout
+	// to determine if the test sub-process (that generated the logger.Fatal() call) called logger.Fatal() with the expected message
+	if level == zerolog.FatalLevel {
+		fmt.Println(msg)
+	}
 }

--- a/utils/unittest/unittest_test.go
+++ b/utils/unittest/unittest_test.go
@@ -1,0 +1,50 @@
+package unittest
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// TestCrashTest_ErrorMessage tests that CrashTest() can check a function that crashed without any messages.
+func TestCrashTest_NoMessage(t *testing.T) {
+	f := func(t *testing.T) {
+		crash_NoMessage()
+	}
+
+	CrashTest(t, f, "", "TestCrashTest_NoMessage")
+}
+
+// TestCrashTest_ErrorMessage tests that CrashTest() can read standard messages from stdout before a crash.
+func TestCrashTest_ErrorMessage(t *testing.T) {
+	f := func(t *testing.T) {
+		crash_ErrorMessage()
+	}
+	CrashTest(t, f, "about to crash", "TestCrashTest_ErrorMessage")
+}
+
+// TestCrashTest_Logger tests that CrashTest() can read fatal logger messages from stdout before a crash. This test
+// assumes that the logger uses a hook to send fatal messages to stdout.
+func TestCrashTest_Logger(t *testing.T) {
+	f := func(t *testing.T) {
+		crash_LoggerFatal()
+	}
+	CrashTest(t, f, "fatal crash from logger", "TestCrashTest_Logger")
+}
+
+func crash_NoMessage() {
+	os.Exit(1)
+}
+
+func crash_ErrorMessage() {
+	fmt.Println("about to crash... crashing in 3...2...1...")
+	os.Exit(1)
+}
+
+func crash_LoggerFatal() {
+	// hook sends fatal messages to stdout, so they can be checked by CrashTest()
+	logger, _ := HookedLogger()
+
+	// calling Fatal() causes the process to exit
+	logger.Fatal().Msg("fatal crash from logger... crashing in 3...2...1...")
+}


### PR DESCRIPTION
Currently, we don't have a way of testing for situations that cause fatal log messages because `zerolog` calls `os.Exit(1)` on a call to `Fatal()`. As part of the ingress message implementation for BFT Testing, we have 2 situations that cause a fatal error: 

- when both ingress and egress message are nil
- when both ingress and egress message are not nil

In order to test for these conditions we want to have a mechanism that allows us to test that a fatal error occurred but without exiting the test run while it's running.

This PR was originally part of https://github.com/onflow/flow-go/pull/2811 but got extracted so it's a stand alone PR because it is a generic utility that can be used by other parts of the code to test for crash conditions.