### PR TITLE
[Dynamic Bootstrap] Update FullBlockHeight on startup

### DIFF
--- a/cmd/dynamic_startup.go
+++ b/cmd/dynamic_startup.go
@@ -231,6 +231,13 @@ func DynamicStartPreInit(nodeConfig *NodeConfig, storage Storage) error {
 			root.Height, firstFullHeight, err)
 	}
 
+	log.Info().
+		Str("root_id", root.ID().String()).
+		Uint64("root_height", root.Height).
+		Uint64("transaction_expiry", flow.DefaultTransactionExpiry).
+		Uint64("last_full_block_height", firstFullHeight).
+		Msg("dynamic-bootstrap pre-init complete")
+
 	return nil
 }
 

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -36,6 +36,7 @@ import (
 const NotSet = "not set"
 
 type BuilderFunc func(nodeConfig *NodeConfig) error
+type InitBuilderFunc func(nodeConfig *NodeConfig, storage Storage) error
 type ReadyDoneFactory func(node *NodeConfig) (module.ReadyDoneAware, error)
 
 // NodeBuilder declares the initialization methods needed to bootstrap up a Flow node
@@ -105,12 +106,12 @@ type NodeBuilder interface {
 
 	// PreInit registers a new PreInit function.
 	// PreInit functions run before the protocol state is initialized or any other modules or components are initialized
-	PreInit(f BuilderFunc) NodeBuilder
+	PreInit(f InitBuilderFunc) NodeBuilder
 
 	// PostInit registers a new PreInit function.
 	// PostInit functions run after the protocol state has been initialized but before any other modules or components
 	// are initialized
-	PostInit(f BuilderFunc) NodeBuilder
+	PostInit(f InitBuilderFunc) NodeBuilder
 
 	// RegisterBadgerMetrics registers all badger related metrics
 	RegisterBadgerMetrics() error

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -868,8 +868,8 @@ func (builder *ObserverServiceBuilder) initLibP2PFactory(networkKey crypto.Priva
 // initObserverLocal initializes the observer's ID, network key and network address
 // Currently, it reads a node-info.priv.json like any other node.
 // TODO: read the node ID from the special bootstrap files
-func (builder *ObserverServiceBuilder) initObserverLocal() func(node *cmd.NodeConfig) error {
-	return func(node *cmd.NodeConfig) error {
+func (builder *ObserverServiceBuilder) initObserverLocal() func(node *cmd.NodeConfig, storage cmd.Storage) error {
+	return func(node *cmd.NodeConfig, storage cmd.Storage) error {
 		// for an observer, set the identity here explicitly since it will not be found in the protocol state
 		self := &flow.Identity{
 			NodeID:        node.NodeID,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -107,8 +107,8 @@ type FlowNodeBuilder struct {
 	modules                  []namedModuleFunc
 	components               []namedComponentFunc
 	postShutdownFns          []func() error
-	preInitFns               []BuilderFunc
-	postInitFns              []BuilderFunc
+	preInitFns               []InitBuilderFunc
+	postInitFns              []InitBuilderFunc
 	extraFlagCheck           func() error
 	adminCommandBootstrapper *admin.CommandRunnerBootstrapper
 	adminCommands            map[string]func(config *NodeConfig) commands.AdminCommand
@@ -1185,12 +1185,12 @@ func (fnb *FlowNodeBuilder) RestartableComponent(name string, f ReadyDoneFactory
 	return fnb
 }
 
-func (fnb *FlowNodeBuilder) PreInit(f BuilderFunc) NodeBuilder {
+func (fnb *FlowNodeBuilder) PreInit(f InitBuilderFunc) NodeBuilder {
 	fnb.preInitFns = append(fnb.preInitFns, f)
 	return fnb
 }
 
-func (fnb *FlowNodeBuilder) PostInit(f BuilderFunc) NodeBuilder {
+func (fnb *FlowNodeBuilder) PostInit(f InitBuilderFunc) NodeBuilder {
 	fnb.postInitFns = append(fnb.postInitFns, f)
 	return fnb
 }
@@ -1408,12 +1408,12 @@ func (fnb *FlowNodeBuilder) handleFatal(err error) {
 	fnb.Logger.Fatal().Err(err).Msg("unhandled irrecoverable error")
 }
 
-func (fnb *FlowNodeBuilder) handlePreInit(f BuilderFunc) error {
-	return f(fnb.NodeConfig)
+func (fnb *FlowNodeBuilder) handlePreInit(f InitBuilderFunc) error {
+	return f(fnb.NodeConfig, fnb.Storage)
 }
 
-func (fnb *FlowNodeBuilder) handlePostInit(f BuilderFunc) error {
-	return f(fnb.NodeConfig)
+func (fnb *FlowNodeBuilder) handlePostInit(f InitBuilderFunc) error {
+	return f(fnb.NodeConfig, fnb.Storage)
 }
 
 func (fnb *FlowNodeBuilder) extraFlagsValidation() error {

--- a/follower/follower_builder.go
+++ b/follower/follower_builder.go
@@ -598,8 +598,8 @@ func (builder *FollowerServiceBuilder) initLibP2PFactory(networkKey crypto.Priva
 // initObserverLocal initializes the observer's ID, network key and network address
 // Currently, it reads a node-info.priv.json like any other node.
 // TODO: read the node ID from the special bootstrap files
-func (builder *FollowerServiceBuilder) initObserverLocal() func(node *cmd.NodeConfig) error {
-	return func(node *cmd.NodeConfig) error {
+func (builder *FollowerServiceBuilder) initObserverLocal() func(node *cmd.NodeConfig, storage cmd.Storage) error {
+	return func(node *cmd.NodeConfig, storage cmd.Storage) error {
 		// for an observer, set the identity here explicitly since it will not be found in the protocol state
 		self := &flow.Identity{
 			NodeID:        node.NodeID,

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -467,20 +467,24 @@ func (q *EpochQuery) Current() protocol.Epoch {
 
 	status, err := q.snap.state.epoch.statuses.ByBlockID(q.snap.blockID)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get epoch statuses for block ID %s: %w",
+			q.snap.blockID, err))
 	}
 	setup, err := q.snap.state.epoch.setups.ByID(status.CurrentEpoch.SetupID)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get epoch setups for setup ID %s at block %v: %w",
+			status.CurrentEpoch.SetupID, q.snap.blockID, err))
 	}
 	commit, err := q.snap.state.epoch.commits.ByID(status.CurrentEpoch.CommitID)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get epoch commits for commit ID %s at block %v: %w",
+			status.CurrentEpoch.CommitID, q.snap.blockID, err))
 	}
 
 	epoch, err := inmem.NewCommittedEpoch(setup, commit)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get new committed epoch with setup (%s) and commit (%s) at block %v: %w",
+			setup.ID(), commit.ID(), q.snap.blockID, err))
 	}
 	return epoch
 }


### PR DESCRIPTION
This PR fixes an issue for dynamic bootstrapped node. 

When dynamic bootstrapped access node starts up from a certain block height, it will start fetching collections in finalized blocks. However, it's possible that the finalized block might have a collection which contains a transaction whose reference block height is a below the bootstrapped root block.

In order to prevent this case, we update the full block height after bootstrap so that dynamic bootstrapped access node will only  fetch missing collections for blocks starting from rootHeight + transactionExpiry. 