### PR TITLE
Make NewMeter's parameters non-optional

### DIFF
--- a/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
+++ b/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -99,7 +98,7 @@ func run(*cobra.Command, []string) {
 		return values[0], nil
 	})
 
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(ldg, meter))
 	accounts := state.NewAccounts(sth)
 	finalGenerator := state.NewStateBoundAddressGenerator(sth, chain)

--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -67,7 +67,7 @@ func (r *AccountReporter) Report(payload []ledger.Payload, commit ledger.State) 
 	defer rwm.Close()
 
 	l := migrations.NewView(payload)
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	st := state.NewState(l, meter, state.WithMaxInteractionSizeAllowed(math.MaxUint64))
 	sth := state.NewStateHolder(st)
 	gen := state.NewStateBoundAddressGenerator(sth, r.Chain)
@@ -143,7 +143,7 @@ func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 	prog := programs.NewEmptyPrograms()
 
 	v := view.NewChild()
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	st := state.NewState(v, meter, state.WithMaxInteractionSizeAllowed(math.MaxUint64))
 	sth := state.NewStateHolder(st)
 	accounts := state.NewAccounts(sth)

--- a/cmd/util/ledger/reporters/fungible_token_tracker.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker.go
@@ -2,7 +2,6 @@ package reporters
 
 import (
 	"fmt"
-	"math"
 	"runtime"
 	"strings"
 	"sync"
@@ -139,7 +138,7 @@ func (r *FungibleTokenTracker) worker(
 	for j := range jobs {
 
 		view := migrations.NewView(j.payloads)
-		meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := metering.NewMeter(metering.DefaultParameters())
 		st := state.NewState(view, meter)
 		sth := state.NewStateHolder(st)
 		accounts := state.NewAccounts(sth)

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -3,7 +3,6 @@ package computer_test
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/rand"
 	"testing"
 
@@ -680,7 +679,7 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 	view := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
 		return ledger.Get(owner, key)
 	})
-	sth := state.NewStateHolder(state.NewState(view, meter.NewMeter(math.MaxUint64, math.MaxUint64)))
+	sth := state.NewStateHolder(state.NewState(view, meter.NewMeter(meter.DefaultParameters())))
 	accounts := state.NewAccounts(sth)
 
 	// account creation, signing of transaction and bootstrapping ledger should not be required for this test

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -587,7 +587,7 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 		nil)
 	view := testutil.RootBootstrappedLedger(vm, ctx)
 	programs := programs.NewEmptyPrograms()
-	st := state.NewState(view, meter.NewMeter(math.MaxUint64, math.MaxUint64))
+	st := state.NewState(view, meter.NewMeter(meter.DefaultParameters()))
 	sth := state.NewStateHolder(st)
 	env, err := fvm.NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
 	require.NoError(t, err)

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -2,7 +2,6 @@ package fvm
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/rs/zerolog"
@@ -49,8 +48,9 @@ func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, program
 	st := state.NewState(
 		v,
 		meter.NewMeter(
-			uint(proc.ComputationLimit(ctx)),
-			uint(proc.MemoryLimit(ctx))),
+			meter.DefaultParameters().
+				WithComputationLimit(uint(proc.ComputationLimit(ctx))).
+				WithMemoryLimit(proc.MemoryLimit(ctx))),
 		state.WithMaxKeySizeAllowed(ctx.MaxStateKeySize),
 		state.WithMaxValueSizeAllowed(ctx.MaxStateValueSize),
 		state.WithMaxInteractionSizeAllowed(ctx.MaxStateInteractionSize))
@@ -68,7 +68,7 @@ func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, program
 func (vm *VirtualMachine) GetAccount(ctx Context, address flow.Address, v state.View, programs *programs.Programs) (*flow.Account, error) {
 	st := state.NewState(
 		v,
-		meter.NewMeter(math.MaxUint64, math.MaxUint64),
+		meter.NewMeter(meter.DefaultParameters()),
 		state.WithMaxKeySizeAllowed(ctx.MaxStateKeySize),
 		state.WithMaxValueSizeAllowed(ctx.MaxStateValueSize),
 		state.WithMaxInteractionSizeAllowed(ctx.MaxStateInteractionSize))

--- a/fvm/handler/contract_test.go
+++ b/fvm/handler/contract_test.go
@@ -2,7 +2,6 @@ package handler_test
 
 import (
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/onflow/cadence/runtime"
@@ -23,7 +22,7 @@ import (
 func TestContract_ChildMergeFunctionality(t *testing.T) {
 	sth := state.NewStateHolder(state.NewState(
 		utils.NewSimpleView(),
-		meter.NewMeter(math.MaxUint64, math.MaxUint64)))
+		meter.NewMeter(meter.DefaultParameters())))
 	accounts := state.NewAccounts(sth)
 	address := flow.HexToAddress("01")
 	rAdd := runtime.Address(address)
@@ -99,7 +98,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 func TestContract_AuthorizationFunctionality(t *testing.T) {
 	sth := state.NewStateHolder(state.NewState(
 		utils.NewSimpleView(),
-		meter.NewMeter(math.MaxUint64, math.MaxUint64)))
+		meter.NewMeter(meter.DefaultParameters())))
 	accounts := state.NewAccounts(sth)
 
 	authAdd := flow.HexToAddress("01")
@@ -220,7 +219,7 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 
 	sth := state.NewStateHolder(state.NewState(
 		utils.NewSimpleView(),
-		meter.NewMeter(math.MaxUint64, math.MaxUint64)))
+		meter.NewMeter(meter.DefaultParameters())))
 	accounts := state.NewAccounts(sth)
 
 	addressWithVoucher := flow.HexToAddress("01")
@@ -279,7 +278,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 
 	sth := state.NewStateHolder(state.NewState(
 		utils.NewSimpleView(),
-		meter.NewMeter(math.MaxUint64, math.MaxUint64)))
+		meter.NewMeter(meter.DefaultParameters())))
 	accounts := state.NewAccounts(sth)
 
 	flowAddress := flow.HexToAddress("01")
@@ -387,7 +386,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 	sth := state.NewStateHolder(state.NewState(
 		utils.NewSimpleView(),
-		meter.NewMeter(math.MaxUint64, math.MaxUint64)))
+		meter.NewMeter(meter.DefaultParameters())))
 	accounts := state.NewAccounts(sth)
 
 	flowAddress := flow.HexToAddress("01")

--- a/fvm/handler/programs_test.go
+++ b/fvm/handler/programs_test.go
@@ -3,7 +3,6 @@ package handler_test
 import (
 	"encoding/hex"
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/onflow/cadence/runtime/common"
@@ -115,7 +114,7 @@ func Test_Programs(t *testing.T) {
 
 	sth := state.NewStateHolder(state.NewState(
 		mainView,
-		meter.NewMeter(math.MaxUint64, math.MaxUint64)))
+		meter.NewMeter(meter.DefaultParameters())))
 
 	rt := fvm.NewInterpreterRuntime()
 	vm := fvm.NewVirtualMachine(rt)

--- a/fvm/programs/programs_test.go
+++ b/fvm/programs/programs_test.go
@@ -1,7 +1,6 @@
 package programs
 
 import (
-	"math"
 	"testing"
 
 	"github.com/onflow/cadence/runtime/ast"
@@ -27,7 +26,7 @@ func Test_Programs(t *testing.T) {
 
 	newState := state.NewState(
 		utils.NewSimpleView(),
-		meter.NewMeter(math.MaxUint64, math.MaxUint64))
+		meter.NewMeter(meter.DefaultParameters()))
 
 	addressLocation := common.AddressLocation{
 		Address: common.MustBytesToAddress([]byte{2, 3, 4}),

--- a/fvm/state/accounts_test.go
+++ b/fvm/state/accounts_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/onflow/atree"
@@ -17,7 +16,7 @@ import (
 func TestAccounts_Create(t *testing.T) {
 	t.Run("Sets registers", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 
@@ -32,7 +31,7 @@ func TestAccounts_Create(t *testing.T) {
 
 	t.Run("Fails if account exists", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -48,7 +47,7 @@ func TestAccounts_Create(t *testing.T) {
 
 func TestAccounts_GetWithNoKeys(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	accounts := state.NewAccounts(sth)
 	address := flow.HexToAddress("01")
@@ -78,7 +77,7 @@ func TestAccounts_GetPublicKey(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+			meter := meter.NewMeter(meter.DefaultParameters())
 			sth := state.NewStateHolder(state.NewState(view, meter))
 			accounts := state.NewAccounts(sth)
 
@@ -107,7 +106,7 @@ func TestAccounts_GetPublicKeyCount(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+			meter := meter.NewMeter(meter.DefaultParameters())
 			sth := state.NewStateHolder(state.NewState(view, meter))
 			accounts := state.NewAccounts(sth)
 
@@ -137,7 +136,7 @@ func TestAccounts_GetPublicKeys(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+			meter := meter.NewMeter(meter.DefaultParameters())
 			sth := state.NewStateHolder(state.NewState(view, meter))
 			accounts := state.NewAccounts(sth)
 
@@ -156,7 +155,7 @@ func TestAccounts_GetPublicKeys(t *testing.T) {
 func TestAccounts_GetWithNoKeysCounter(t *testing.T) {
 	view := utils.NewSimpleView()
 
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	accounts := state.NewAccounts(sth)
 	address := flow.HexToAddress("01")
@@ -181,7 +180,7 @@ func TestAccounts_SetContracts(t *testing.T) {
 
 	t.Run("Setting a contract puts it in Contracts", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		a := state.NewAccounts(sth)
 		err := a.Create(nil, address)
@@ -198,7 +197,7 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Setting a contract again, does not add it to contracts", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		a := state.NewAccounts(sth)
 		err := a.Create(nil, address)
@@ -218,7 +217,7 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Setting more contracts always keeps them sorted", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		a := state.NewAccounts(sth)
 		err := a.Create(nil, address)
@@ -243,7 +242,7 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Removing a contract does not fail if there is none", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		a := state.NewAccounts(sth)
 		err := a.Create(nil, address)
@@ -254,7 +253,7 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Removing a contract removes it", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		a := state.NewAccounts(sth)
 		err := a.Create(nil, address)
@@ -277,7 +276,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used on account creation is deterministic", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -292,7 +291,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used on register set increases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -310,7 +309,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, set twice on same register to same value, stays the same", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -330,7 +329,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, set twice on same register to larger value, increases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -350,7 +349,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, set twice on same register to smaller value, decreases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -370,7 +369,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, after register deleted, decreases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -390,7 +389,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used on a complex scenario has correct value", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+		meter := meter.NewMeter(meter.DefaultParameters())
 		sth := state.NewStateHolder(state.NewState(view, meter))
 		accounts := state.NewAccounts(sth)
 		address := flow.HexToAddress("01")
@@ -429,7 +428,7 @@ func createByteArray(size int) []byte {
 
 func TestAccounts_AllocateStorageIndex(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	accounts := state.NewAccounts(sth)

--- a/fvm/state/address_generator_test.go
+++ b/fvm/state/address_generator_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +14,7 @@ import (
 func Test_NewStateBoundAddressGenerator_NoError(t *testing.T) {
 	view := utils.NewSimpleView()
 	chain := flow.MonotonicEmulator.Chain()
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	env := state.NewStateBoundAddressGenerator(sth, chain)
 	require.NotNil(t, env)
@@ -24,7 +23,7 @@ func Test_NewStateBoundAddressGenerator_NoError(t *testing.T) {
 func Test_NewStateBoundAddressGenerator_GeneratingUpdatesState(t *testing.T) {
 	view := utils.NewSimpleView()
 	chain := flow.MonotonicEmulator.Chain()
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	generator := state.NewStateBoundAddressGenerator(sth, chain)
 	_, err := generator.NextAddress()
@@ -42,7 +41,7 @@ func Test_NewStateBoundAddressGenerator_UsesLedgerState(t *testing.T) {
 	require.NoError(t, err)
 
 	chain := flow.MonotonicEmulator.Chain()
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	generator := state.NewStateBoundAddressGenerator(sth, chain)
 

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"math"
 	"testing"
 	"unicode/utf8"
 
@@ -16,7 +15,7 @@ import (
 
 func TestState_ChildMergeFunctionality(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	st := state.NewState(view, meter)
 
 	t.Run("test read from parent state (backoff)", func(t *testing.T) {
@@ -89,7 +88,7 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 
 func TestState_InteractionMeasuring(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	st := state.NewState(view, meter)
 
 	key := "key1"
@@ -120,7 +119,7 @@ func TestState_InteractionMeasuring(t *testing.T) {
 
 func TestState_MaxValueSize(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	st := state.NewState(view, meter, state.WithMaxValueSizeAllowed(6))
 
 	// update should pass
@@ -136,7 +135,7 @@ func TestState_MaxValueSize(t *testing.T) {
 
 func TestState_MaxKeySize(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	st := state.NewState(view, meter, state.WithMaxKeySizeAllowed(4))
 
 	// read
@@ -159,7 +158,7 @@ func TestState_MaxKeySize(t *testing.T) {
 
 func TestState_MaxInteraction(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := metering.NewMeter(metering.DefaultParameters())
 	st := state.NewState(view, meter, state.WithMaxInteractionSizeAllowed(12))
 
 	// read - interaction 2
@@ -177,7 +176,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Equal(t, st.InteractionUsed(), uint64(14))
 	require.Error(t, err)
 
-	meter = metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter = metering.NewMeter(metering.DefaultParameters())
 	st = state.NewState(view, meter, state.WithMaxInteractionSizeAllowed(6))
 	stChild := st.NewChild()
 

--- a/fvm/state/uuids_test.go
+++ b/fvm/state/uuids_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +12,7 @@ import (
 
 func TestUUIDs_GetAndSetUUID(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	uuidsA := state.NewUUIDGenerator(sth)
 
@@ -34,7 +33,7 @@ func TestUUIDs_GetAndSetUUID(t *testing.T) {
 
 func Test_GenerateUUID(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(math.MaxUint64, math.MaxUint64)
+	meter := meter.NewMeter(meter.DefaultParameters())
 	sth := state.NewStateHolder(state.NewState(view, meter))
 	genA := state.NewUUIDGenerator(sth)
 

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -2,7 +2,6 @@ package fvm_test
 
 import (
 	"bytes"
-	"math"
 	"testing"
 
 	"github.com/onflow/cadence"
@@ -42,7 +41,7 @@ func TestSafetyCheck(t *testing.T) {
 
 		sth := state.NewStateHolder(state.NewState(
 			view,
-			meter.NewMeter(math.MaxUint64, math.MaxUint64),
+			meter.NewMeter(meter.DefaultParameters()),
 			state.WithMaxKeySizeAllowed(context.MaxStateKeySize),
 			state.WithMaxValueSizeAllowed(context.MaxStateValueSize),
 			state.WithMaxInteractionSizeAllowed(context.MaxStateInteractionSize),
@@ -75,7 +74,7 @@ func TestSafetyCheck(t *testing.T) {
 
 		sth := state.NewStateHolder(state.NewState(
 			view,
-			meter.NewMeter(math.MaxUint64, math.MaxUint64),
+			meter.NewMeter(meter.DefaultParameters()),
 			state.WithMaxKeySizeAllowed(context.MaxStateKeySize),
 			state.WithMaxValueSizeAllowed(context.MaxStateValueSize),
 			state.WithMaxInteractionSizeAllowed(context.MaxStateInteractionSize),

--- a/fvm/transactionSequenceNum_test.go
+++ b/fvm/transactionSequenceNum_test.go
@@ -1,7 +1,6 @@
 package fvm_test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,7 +20,7 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		ledger := utils.NewSimpleView()
 		sth := state.NewStateHolder(state.NewState(
 			ledger,
-			meter.NewMeter(math.MaxUint64, math.MaxUint64),
+			meter.NewMeter(meter.DefaultParameters()),
 		))
 		accounts := state.NewAccounts(sth)
 
@@ -49,7 +48,7 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		ledger := utils.NewSimpleView()
 		sth := state.NewStateHolder(state.NewState(
 			ledger,
-			meter.NewMeter(math.MaxUint64, math.MaxUint64),
+			meter.NewMeter(meter.DefaultParameters()),
 		))
 		accounts := state.NewAccounts(sth)
 
@@ -79,7 +78,7 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		ledger := utils.NewSimpleView()
 		sth := state.NewStateHolder(state.NewState(
 			ledger,
-			meter.NewMeter(math.MaxUint64, math.MaxUint64),
+			meter.NewMeter(meter.DefaultParameters()),
 		))
 		accounts := state.NewAccounts(sth)
 

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -1,7 +1,6 @@
 package fvm_test
 
 import (
-	"math"
 	"strings"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestTransactionVerification(t *testing.T) {
 	ledger := utils.NewSimpleView()
 	sth := state.NewStateHolder(state.NewState(
 		ledger,
-		meter.NewMeter(math.MaxUint64, math.MaxUint64),
+		meter.NewMeter(meter.DefaultParameters()),
 	))
 	accounts := state.NewAccounts(sth)
 

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -3,7 +3,6 @@ package fvm_test
 import (
 	"encoding/hex"
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/onflow/cadence/runtime"
@@ -27,7 +26,7 @@ func makeTwoAccounts(t *testing.T, aPubKeys []flow.AccountPublicKey, bPubKeys []
 	ledger := utils.NewSimpleView()
 	sth := state.NewStateHolder(state.NewState(
 		ledger,
-		meter.NewMeter(math.MaxUint64, math.MaxUint64)),
+		meter.NewMeter(meter.DefaultParameters())),
 	)
 
 	a := flow.HexToAddress("1234")
@@ -269,7 +268,7 @@ func TestAccountFreezing(t *testing.T) {
 
 		accountsService := state.NewAccounts(state.NewStateHolder(state.NewState(
 			ledger,
-			meter.NewMeter(math.MaxUint64, math.MaxUint64),
+			meter.NewMeter(meter.DefaultParameters()),
 		)))
 
 		frozen, err := accountsService.GetAccountFrozen(address)
@@ -300,7 +299,7 @@ func TestAccountFreezing(t *testing.T) {
 
 		accountsService = state.NewAccounts(state.NewStateHolder(state.NewState(
 			ledger,
-			meter.NewMeter(math.MaxUint64, math.MaxUint64),
+			meter.NewMeter(meter.DefaultParameters()),
 		)))
 
 		frozen, err = accountsService.GetAccountFrozen(serviceAddress)


### PR DESCRIPTION
Prep work for plumbing fully initialized meter parameters from block computer to
transaction invoker