### PR TITLE
Expose more StateHolder methods

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -102,7 +102,7 @@ func (env *commonEnv) MeterComputation(kind common.ComputationKind, intensity ui
 
 // TODO(patrick): rm once Meter object has been refactored
 func (env *commonEnv) ComputationUsed() uint64 {
-	return uint64(env.sth.State().TotalComputationUsed())
+	return uint64(env.sth.TotalComputationUsed())
 }
 
 // TODO(patrick): rm once Meter object has been refactored
@@ -112,7 +112,7 @@ func (env *commonEnv) MeterMemory(usage common.MemoryUsage) error {
 
 // TODO(patrick): rm once Meter object has been refactored
 func (env *commonEnv) MemoryEstimate() uint64 {
-	return uint64(env.sth.State().TotalMemoryEstimate())
+	return uint64(env.sth.TotalMemoryEstimate())
 }
 
 func (env *commonEnv) Context() *Context {

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -119,7 +119,7 @@ func (e *ScriptEnv) setExecutionParameters() error {
 		return nil
 	}
 
-	meter := e.sth.State().Meter()
+	meter := e.sth.Meter()
 
 	computationWeights, err := GetExecutionEffortWeights(e, service)
 	err = setIfOk(
@@ -309,14 +309,14 @@ func (e *ScriptEnv) Meter(kind common.ComputationKind, intensity uint) error {
 	}
 
 	if e.sth.EnforceComputationLimits() {
-		return e.sth.State().MeterComputation(kind, intensity)
+		return e.sth.MeterComputation(kind, intensity)
 	}
 	return nil
 }
 
 func (e *ScriptEnv) meterMemory(kind common.MemoryKind, intensity uint) error {
 	if e.sth.EnforceMemoryLimits() {
-		return e.sth.State().MeterMemory(kind, intensity)
+		return e.sth.MeterMemory(kind, intensity)
 	}
 	return nil
 }

--- a/fvm/state/accounts.go
+++ b/fvm/state/accounts.go
@@ -71,7 +71,7 @@ func (a *StatefulAccounts) AllocateStorageIndex(address flow.Address) (atree.Sto
 	// and won't do ledger getValue for every new slabs (currently happening to compute storage size changes)
 	// this way the getValue would load this value from deltas
 	key := atree.SlabIndexToLedgerKey(index)
-	err = a.stateHolder.State().Set(string(address.Bytes()), string(key), []byte{}, false)
+	err = a.stateHolder.Set(string(address.Bytes()), string(key), []byte{}, false)
 	if err != nil {
 		return atree.StorageIndex{}, fmt.Errorf("failed to allocate an storage index: %w", err)
 	}
@@ -410,7 +410,7 @@ func (a *StatefulAccounts) setStorageUsed(address flow.Address, used uint64) err
 }
 
 func (a *StatefulAccounts) GetValue(address flow.Address, key string) (flow.RegisterValue, error) {
-	return a.stateHolder.State().Get(string(address.Bytes()), key, a.stateHolder.EnforceInteractionLimits())
+	return a.stateHolder.Get(string(address.Bytes()), key, a.stateHolder.EnforceInteractionLimits())
 }
 
 // SetValue sets a value in address' storage
@@ -419,7 +419,7 @@ func (a *StatefulAccounts) SetValue(address flow.Address, key string, value flow
 	if err != nil {
 		return fmt.Errorf("failed to update storage used by key %s on account %s: %w", PrintableKey(key), address, err)
 	}
-	return a.stateHolder.State().Set(string(address.Bytes()), key, value, a.stateHolder.EnforceInteractionLimits())
+	return a.stateHolder.Set(string(address.Bytes()), key, value, a.stateHolder.EnforceInteractionLimits())
 
 }
 
@@ -481,7 +481,7 @@ func RegisterSize(address flow.Address, key string, value flow.RegisterValue) in
 // TODO replace with touch
 // TODO handle errors
 func (a *StatefulAccounts) touch(address flow.Address, key string) {
-	_, _ = a.stateHolder.State().Get(string(address.Bytes()), key, a.stateHolder.EnforceInteractionLimits())
+	_, _ = a.stateHolder.Get(string(address.Bytes()), key, a.stateHolder.EnforceInteractionLimits())
 }
 
 func (a *StatefulAccounts) TouchContract(contractName string, address flow.Address) {

--- a/fvm/state/address_generator.go
+++ b/fvm/state/address_generator.go
@@ -27,7 +27,7 @@ func NewStateBoundAddressGenerator(stateHolder *StateHolder, chain flow.Chain) *
 // this requires changes outside of fvm since the type is defined on flow model
 // and emulator and others might be dependent on that
 func (g *StateBoundAddressGenerator) Bytes() []byte {
-	stateBytes, err := g.stateHolder.State().Get("", keyAddressState, g.stateHolder.EnforceInteractionLimits())
+	stateBytes, err := g.stateHolder.Get("", keyAddressState, g.stateHolder.EnforceInteractionLimits())
 	if err != nil {
 		panic(err)
 	}
@@ -35,8 +35,7 @@ func (g *StateBoundAddressGenerator) Bytes() []byte {
 }
 
 func (g *StateBoundAddressGenerator) constructAddressGen() (flow.AddressGenerator, error) {
-	st := g.stateHolder.State()
-	stateBytes, err := st.Get("", keyAddressState, g.stateHolder.EnforceInteractionLimits())
+	stateBytes, err := g.stateHolder.Get("", keyAddressState, g.stateHolder.EnforceInteractionLimits())
 	if err != nil {
 		return nil, fmt.Errorf("failed to read address generator state from the state: %w", err)
 	}
@@ -57,7 +56,7 @@ func (g *StateBoundAddressGenerator) NextAddress() (flow.Address, error) {
 	}
 
 	// update the ledger state
-	err = g.stateHolder.State().Set("", keyAddressState, addressGenerator.Bytes(), g.stateHolder.EnforceInteractionLimits())
+	err = g.stateHolder.Set("", keyAddressState, addressGenerator.Bytes(), g.stateHolder.EnforceInteractionLimits())
 	if err != nil {
 		return address, fmt.Errorf("failed to update the state with address generator state: %w", err)
 	}

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -1,5 +1,13 @@
 package state
 
+import (
+	"github.com/onflow/cadence/runtime/common"
+
+	"github.com/onflow/flow-go/fvm/meter"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// TODO(patrick): rename to StateTransaction
 // StateHolder provides active states
 // and facilitates common state management operations
 // in order to make services such as accounts not worry about
@@ -21,14 +29,88 @@ func NewStateHolder(startState *State) *StateHolder {
 	}
 }
 
+// TODO(patrick): remove
 // State returns the active state
 func (s *StateHolder) State() *State {
 	return s.activeState
 }
 
+// TODO(patrick): remove
 // SetActiveState sets active state
 func (s *StateHolder) SetActiveState(st *State) {
 	s.activeState = st
+}
+
+func (s *StateHolder) Get(
+	owner string,
+	key string,
+	enforceLimit bool,
+) (
+	flow.RegisterValue,
+	error,
+) {
+	return s.activeState.Get(owner, key, enforceLimit)
+}
+
+func (s *StateHolder) Set(
+	owner string,
+	key string,
+	value flow.RegisterValue,
+	enforceLimit bool,
+) error {
+	return s.activeState.Set(owner, key, value, enforceLimit)
+}
+
+func (s *StateHolder) UpdatedAddresses() []flow.Address {
+	return s.activeState.UpdatedAddresses()
+}
+
+// TODO(patrick): remove once we no longer support updating limit/weights after
+// meter initialization.
+func (s *StateHolder) Meter() meter.Meter {
+	return s.activeState.Meter()
+}
+
+func (s *StateHolder) MeterComputation(
+	kind common.ComputationKind,
+	intensity uint,
+) error {
+	return s.activeState.MeterComputation(kind, intensity)
+}
+
+func (s *StateHolder) MeterMemory(
+	kind common.MemoryKind,
+	intensity uint,
+) error {
+	return s.activeState.MeterMemory(kind, intensity)
+}
+
+func (s *StateHolder) ComputationIntensities() meter.MeteredComputationIntensities {
+	return s.activeState.ComputationIntensities()
+}
+
+func (s *StateHolder) TotalComputationLimit() uint {
+	return s.activeState.TotalComputationLimit()
+}
+
+func (s *StateHolder) TotalComputationUsed() uint {
+	return s.activeState.TotalComputationUsed()
+}
+
+func (s *StateHolder) MemoryIntensities() meter.MeteredMemoryIntensities {
+	return s.activeState.MemoryIntensities()
+}
+
+func (s *StateHolder) TotalMemoryEstimate() uint {
+	return s.activeState.TotalMemoryEstimate()
+}
+
+func (s *StateHolder) InteractionUsed() uint64 {
+	return s.activeState.InteractionUsed()
+}
+
+func (s *StateHolder) ViewForTestingOnly() View {
+	return s.activeState.View()
 }
 
 // SetPayerIsServiceAccount sets if the payer is the service account

--- a/fvm/state/uuids.go
+++ b/fvm/state/uuids.go
@@ -21,7 +21,7 @@ func NewUUIDGenerator(stateHolder *StateHolder) *UUIDGenerator {
 
 // GetUUID reads uint64 byte value for uuid from the state
 func (u *UUIDGenerator) GetUUID() (uint64, error) {
-	stateBytes, err := u.stateHolder.State().Get("", keyUUID, u.stateHolder.EnforceInteractionLimits())
+	stateBytes, err := u.stateHolder.Get("", keyUUID, u.stateHolder.EnforceInteractionLimits())
 	if err != nil {
 		return 0, fmt.Errorf("cannot get uuid byte from state: %w", err)
 	}
@@ -34,7 +34,7 @@ func (u *UUIDGenerator) GetUUID() (uint64, error) {
 func (u *UUIDGenerator) SetUUID(uuid uint64) error {
 	bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, uuid)
-	err := u.stateHolder.State().Set("", keyUUID, bytes, u.stateHolder.EnforceInteractionLimits())
+	err := u.stateHolder.Set("", keyUUID, bytes, u.stateHolder.EnforceInteractionLimits())
 	if err != nil {
 		return fmt.Errorf("cannot set uuid byte to state: %w", err)
 	}

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -153,7 +153,7 @@ func (e *TransactionEnv) setExecutionParameters() error {
 		return nil
 	}
 
-	meter := e.sth.State().Meter()
+	meter := e.sth.Meter()
 
 	computationWeights, err := GetExecutionEffortWeights(e, service)
 	err = setIfOk(
@@ -437,14 +437,14 @@ func (e *TransactionEnv) ServiceEvents() []flow.Event {
 
 func (e *TransactionEnv) Meter(kind common.ComputationKind, intensity uint) error {
 	if e.sth.EnforceComputationLimits() {
-		return e.sth.State().MeterComputation(kind, intensity)
+		return e.sth.MeterComputation(kind, intensity)
 	}
 	return nil
 }
 
 func (e *TransactionEnv) meterMemory(kind common.MemoryKind, intensity uint) error {
 	if e.sth.EnforceMemoryLimits() {
-		return e.sth.State().MeterMemory(kind, intensity)
+		return e.sth.MeterMemory(kind, intensity)
 	}
 	return nil
 }

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -145,7 +145,7 @@ func (i *TransactionInvoker) Process(
 		// so we don't error from computation/memory limits on this part.
 		// We cannot charge the user for this part, since fee deduction already happened.
 		sth.DisableAllLimitEnforcements()
-		txError = NewTransactionStorageLimiter().CheckLimits(env, sth.State().UpdatedAddresses())
+		txError = NewTransactionStorageLimiter().CheckLimits(env, sth.UpdatedAddresses())
 		sth.EnableAllLimitEnforcements()
 	}
 
@@ -218,8 +218,8 @@ func (i *TransactionInvoker) deductTransactionFees(
 		return nil
 	}
 
-	if computationUsed > uint64(sth.State().TotalComputationLimit()) {
-		computationUsed = uint64(sth.State().TotalComputationLimit())
+	if computationUsed > uint64(sth.TotalComputationLimit()) {
+		computationUsed = uint64(sth.TotalComputationLimit())
 	}
 
 	// Hardcoded inclusion effort (of 1.0 UFix). Eventually this will be
@@ -306,18 +306,18 @@ func valueDeclarations(env Environment) []runtime.ValueDeclaration {
 func (i *TransactionInvoker) logExecutionIntensities(sth *state.StateHolder, txHash string) {
 	if i.logger.Debug().Enabled() {
 		computation := zerolog.Dict()
-		for s, u := range sth.State().ComputationIntensities() {
+		for s, u := range sth.ComputationIntensities() {
 			computation.Uint(strconv.FormatUint(uint64(s), 10), u)
 		}
 		memory := zerolog.Dict()
-		for s, u := range sth.State().MemoryIntensities() {
+		for s, u := range sth.MemoryIntensities() {
 			memory.Uint(strconv.FormatUint(uint64(s), 10), u)
 		}
 		i.logger.Info().
 			Str("txHash", txHash).
-			Uint64("ledgerInteractionUsed", sth.State().InteractionUsed()).
-			Uint("computationUsed", sth.State().TotalComputationUsed()).
-			Uint("memoryEstimate", sth.State().TotalMemoryEstimate()).
+			Uint64("ledgerInteractionUsed", sth.InteractionUsed()).
+			Uint("computationUsed", sth.TotalComputationUsed()).
+			Uint("memoryEstimate", sth.TotalMemoryEstimate()).
 			Dict("computationIntensities", computation).
 			Dict("memoryIntensities", memory).
 			Msg("transaction execution data")

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -132,11 +132,11 @@ func TestAccountFreezing(t *testing.T) {
 			fvm.WithTransactionProcessors( // run with limited processor to test just core of freezing, but still inside FVM
 				fvm.NewTransactionInvoker(zerolog.Nop())))
 
-		err := vm.Run(context, procFrozen, st.State().View(), programsStorage)
+		err := vm.Run(context, procFrozen, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, procFrozen.Err)
 
-		err = vm.Run(context, procNotFrozen, st.State().View(), programsStorage)
+		err = vm.Run(context, procNotFrozen, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, procNotFrozen.Err)
 
@@ -157,14 +157,14 @@ func TestAccountFreezing(t *testing.T) {
 		// code from not frozen loads fine
 		proc := fvm.Transaction(&flow.TransactionBody{Script: code(frozenAddress), Payer: serviceAddress}, 0)
 
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
 		require.Contains(t, proc.Logs[0], "\"D\\u{fc}sseldorf\"")
 
 		proc = fvm.Transaction(&flow.TransactionBody{Script: code(notFrozenAddress)}, 0)
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -186,7 +186,7 @@ func TestAccountFreezing(t *testing.T) {
 		// loading code from frozen account triggers error
 		proc = fvm.Transaction(&flow.TransactionBody{Script: code(frozenAddress)}, 0)
 
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.Error(t, proc.Err)
 
@@ -361,11 +361,11 @@ func TestAccountFreezing(t *testing.T) {
 				Payer:       notFrozenAddress},
 				0)
 			// tx run OK by nonfrozen account
-			err = vm.Run(context, notFrozenProc, st.State().View(), programsStorage)
+			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly(), programsStorage)
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
-			err = vm.Run(context, frozenProc, st.State().View(), programsStorage)
+			err = vm.Run(context, frozenProc, st.ViewForTestingOnly(), programsStorage)
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 
@@ -391,11 +391,11 @@ func TestAccountFreezing(t *testing.T) {
 			}, 0)
 
 			// tx run OK by nonfrozen account
-			err = vm.Run(context, notFrozenProc, st.State().View(), programsStorage)
+			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly(), programsStorage)
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
-			err = vm.Run(context, frozenProc, st.State().View(), programsStorage)
+			err = vm.Run(context, frozenProc, st.ViewForTestingOnly(), programsStorage)
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 
@@ -421,11 +421,11 @@ func TestAccountFreezing(t *testing.T) {
 			}, 0)
 
 			// tx run OK by nonfrozen account
-			err = vm.Run(context, notFrozenProc, st.State().View(), programsStorage)
+			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly(), programsStorage)
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
-			err = vm.Run(context, frozenProc, st.State().View(), programsStorage)
+			err = vm.Run(context, frozenProc, st.ViewForTestingOnly(), programsStorage)
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 


### PR DESCRIPTION
Stop directly accessing State (aka sub-transaction).  In future PRs, I'll
standardize how sub-transactions are created / merge / dropped / etc.