### PR TITLE
Bump golangci-lint action from v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.47
+        version: v1.45.2
         args: -v --build-tags relic
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-pkg-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.45.2
+        version: v1.45
         args: -v --build-tags relic
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-pkg-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.48
+        version: v1.47
         args: -v --build-tags relic
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-pkg-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
     - name: Build relic
       run: make crypto_setup_gopath
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.45
+        version: v1.48
         args: -v --build-tags relic
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-pkg-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.45
+        version: v1.46
         args: -v --build-tags relic
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-pkg-cache: true


### PR DESCRIPTION
### Changes
- bump golangci-lint action from v2 to v3
- bump golangci-lint from 1.45 to 1.46

This fix is based on [changes](https://github.com/onflow/flow-go/pull/2935/files/f4c69ca5f0457012fe2da9ac7106e902c5a892a4..383e69a17f1c918f33276b48ed4cd3e235645071) in a branch by @durkmurder.  Many thanks Yurii!

This unblocks several PRs including PR [2930](https://github.com/onflow/flow-go/pull/2930).

### Caveats

Unfortunately, golangci-lint 1.47 and 1.48 didn't work.  There were lint errors reported on lines untouched for 2 years, etc.