### PR TITLE
Standardize nested transaction creation/restart/commitment

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -457,12 +457,6 @@ func (env *commonEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value, e
 
 // Commit commits changes and return a list of updated keys
 func (env *commonEnv) Commit() (programs.ModifiedSets, error) {
-	// commit changes and return a list of updated keys
-	err := env.programs.Cleanup()
-	if err != nil {
-		return programs.ModifiedSets{}, err
-	}
-
 	keys, err := env.contracts.Commit()
 	return programs.ModifiedSets{
 		ContractUpdateKeys: keys,

--- a/fvm/handler/programs.go
+++ b/fvm/handler/programs.go
@@ -10,11 +10,6 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 )
 
-type stackEntry struct {
-	state    *state.State
-	location common.Location
-}
-
 // ProgramsHandler manages operations using Programs storage.
 // It's separation of concern for hostEnv
 // Cadence contract guarantees that Get/Set methods will be called in a LIFO manner,
@@ -22,10 +17,8 @@ type stackEntry struct {
 // naturally, making cleanup method essentially no-op. But if something goes wrong, all nested
 // views must be merged in order to make sure they are recorded
 type ProgramsHandler struct {
-	masterState  *state.StateHolder
-	viewsStack   []stackEntry
-	Programs     *programs.Programs
-	initialState *state.State
+	masterState *state.StateHolder
+	Programs    *programs.Programs
 
 	// NOTE: non-address programs are not reusable across transactions, hence
 	// they are kept out of the shared program cache.
@@ -36,9 +29,7 @@ type ProgramsHandler struct {
 func NewProgramsHandler(programs *programs.Programs, stateHolder *state.StateHolder) *ProgramsHandler {
 	return &ProgramsHandler{
 		masterState:        stateHolder,
-		viewsStack:         nil,
 		Programs:           programs,
-		initialState:       stateHolder.State(),
 		nonAddressPrograms: map[common.LocationID]*interpreter.Program{},
 	}
 }
@@ -58,34 +49,13 @@ func (h *ProgramsHandler) Set(location common.Location, program *interpreter.Pro
 		return nil
 	}
 
-	if len(h.viewsStack) == 0 {
-		return fmt.Errorf("views stack empty while set called, for location %s", location.String())
+	state, err := h.masterState.CommitParseRestricted(address)
+	if err != nil {
+		return err
 	}
 
-	// pop
-	last := h.viewsStack[len(h.viewsStack)-1]
-	h.viewsStack = h.viewsStack[0 : len(h.viewsStack)-1]
-
-	if last.location.ID() != location.ID() {
-		return fmt.Errorf("set called for type %s while last get was for %s", location.String(), last.location.String())
-	}
-
-	h.Programs.Set(address, program, last.state)
-
-	err := h.mergeState(last.state, h.masterState.EnforceLimits())
-
-	return err
-}
-
-func (h *ProgramsHandler) mergeState(state *state.State, enforceLimits bool) error {
-	if len(h.viewsStack) == 0 {
-		// if this was last item, merge to the master state
-		h.masterState.SetActiveState(h.initialState)
-	} else {
-		h.masterState.SetActiveState(h.viewsStack[len(h.viewsStack)-1].state)
-	}
-
-	return h.masterState.State().MergeState(state, enforceLimits)
+	h.Programs.Set(address, program, state)
+	return nil
 }
 
 func (h *ProgramsHandler) Get(location common.Location) (*interpreter.Program, bool) {
@@ -102,58 +72,18 @@ func (h *ProgramsHandler) Get(location common.Location) (*interpreter.Program, b
 		return prog, ok
 	}
 
-	program, view, has := h.Programs.Get(address)
+	program, state, has := h.Programs.Get(address)
 	if has {
-		if view != nil { // handle view not set (ie. for non-address locations
-			// don't enforce limits while merging a cached view
-			enforceLimits := false
-			err := h.mergeState(view, enforceLimits)
-			if err != nil {
-				panic(fmt.Sprintf("merge error while getting program, panic: %s", err))
-			}
+		err := h.masterState.AttachAndCommitParseRestricted(state)
+		if err != nil {
+			panic(fmt.Sprintf("merge error while getting program, panic: %s", err))
 		}
 		return program, true
 	}
 
-	parentState := h.masterState.State()
-	if len(h.viewsStack) > 0 {
-		parentState = h.viewsStack[len(h.viewsStack)-1].state
-	}
-
-	childState := parentState.NewChild()
-
-	h.viewsStack = append(h.viewsStack, stackEntry{
-		state:    childState,
-		location: location,
-	})
-
-	h.masterState.SetActiveState(childState)
-
-	return nil, false
-}
-
-func (h *ProgramsHandler) Cleanup() error {
-	stackLen := len(h.viewsStack)
-
-	if stackLen == 0 {
-		return nil
-	}
-
-	for i := stackLen - 1; i > 0; i-- {
-		entry := h.viewsStack[i]
-		err := h.viewsStack[i-1].state.MergeState(entry.state, h.masterState.EnforceLimits())
-		if err != nil {
-			return fmt.Errorf("cannot merge state while cleanup: %w", err)
-		}
-	}
-
-	err := h.initialState.MergeState(h.viewsStack[0].state, h.masterState.EnforceLimits())
+	_, err := h.masterState.BeginParseRestrictedNestedTransaction(address)
 	if err != nil {
-		return err
+		panic(err)
 	}
-
-	// reset the stack
-	h.viewsStack = nil
-	h.masterState.SetActiveState(h.initialState)
-	return nil
+	return nil, false
 }

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -1,11 +1,25 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/model/flow"
 )
+
+type nestedTransactionStackFrame struct {
+	state *State
+
+	// When nil, the subtransaction will have unrestricted access to the runtime
+	// environment.  When non-nil, the subtransaction will only have access to
+	// the parts of the runtime environment necessary for importing/parsing the
+	// program.
+	//
+	// TODO(patrick): restrict environment method access
+	parseRestriction *common.AddressLocation
+}
 
 // TODO(patrick): rename to StateTransaction
 // StateHolder provides active states
@@ -15,8 +29,19 @@ import (
 // a state manager instead of a state itself.
 type StateHolder struct {
 	enforceLimits bool
-	startState    *State
-	activeState   *State
+
+	// NOTE: The first frame is always the main transaction, and is not
+	// poppable during the course of the transaction.
+	nestedTransactions []nestedTransactionStackFrame
+}
+
+// Opaque identifier used for Restarting nested transactions
+type NestedTransactionId struct {
+	state *State
+}
+
+func (id NestedTransactionId) StateForTestingOnly() *State {
+	return id.state
 }
 
 // NewStateTransaction constructs a new state transaction which manages nested
@@ -25,21 +50,209 @@ func NewStateTransaction(startView View, params StateParameters) *StateHolder {
 	startState := NewState(startView, params)
 	return &StateHolder{
 		enforceLimits: true,
-		startState:    startState,
-		activeState:   startState,
+		nestedTransactions: []nestedTransactionStackFrame{
+			nestedTransactionStackFrame{
+				state:            startState,
+				parseRestriction: nil,
+			},
+		},
 	}
 }
 
-// TODO(patrick): remove
-// State returns the active state
-func (s *StateHolder) State() *State {
-	return s.activeState
+func (s *StateHolder) current() nestedTransactionStackFrame {
+	return s.nestedTransactions[s.NumNestedTransactions()]
 }
 
-// TODO(patrick): remove
-// SetActiveState sets active state
-func (s *StateHolder) SetActiveState(st *State) {
-	s.activeState = st
+func (s *StateHolder) currentState() *State {
+	return s.current().state
+}
+
+// NumNestedTransactions returns the number of uncommitted nested transactions.
+// Note that the main transaction is not considered a nested transaction.
+func (s *StateHolder) NumNestedTransactions() int {
+	return len(s.nestedTransactions) - 1
+}
+
+// IsParseRestricted returns true if the current nested transaction is in
+// parse resticted access mode.
+func (s *StateHolder) IsParseRestricted() bool {
+	return s.current().parseRestriction != nil
+}
+
+func (s *StateHolder) MainTransactionId() NestedTransactionId {
+	return NestedTransactionId{
+		state: s.nestedTransactions[0].state,
+	}
+}
+
+// IsCurrent returns true if the provide id refers to the current (nested)
+// transaction.
+func (s *StateHolder) IsCurrent(id NestedTransactionId) bool {
+	return s.currentState() == id.state
+}
+
+// BeginNestedTransaction creates a unrestricted nested transaction within the
+// current unrestricted (nested) transaction.  This returns error if the current
+// nested transaction is program restricted.
+func (s *StateHolder) BeginNestedTransaction() (NestedTransactionId, error) {
+	if s.IsParseRestricted() {
+		return NestedTransactionId{}, fmt.Errorf(
+			"cannot beinga a unrestricted nested transaction inside a " +
+				"program restricted nested transaction",
+		)
+	}
+
+	child := s.currentState().NewChild()
+
+	s.nestedTransactions = append(
+		s.nestedTransactions,
+		nestedTransactionStackFrame{
+			state:            child,
+			parseRestriction: nil,
+		},
+	)
+
+	return NestedTransactionId{
+		state: child,
+	}, nil
+}
+
+// BeginParseRestrictedNestedTransaction creates a restricted nested
+// transaction within the current (nested) transaction.
+func (s *StateHolder) BeginParseRestrictedNestedTransaction(
+	location common.AddressLocation,
+) (
+	NestedTransactionId,
+	error,
+) {
+	child := s.currentState().NewChild()
+
+	s.nestedTransactions = append(
+		s.nestedTransactions,
+		nestedTransactionStackFrame{
+			state:            child,
+			parseRestriction: &location,
+		},
+	)
+
+	return NestedTransactionId{
+		state: child,
+	}, nil
+}
+
+func (s *StateHolder) mergeIntoParent(
+	enforceLimits bool,
+) error {
+	if len(s.nestedTransactions) < 2 {
+		return fmt.Errorf("cannot commit the main transaction")
+	}
+
+	child := s.current()
+	s.nestedTransactions = s.nestedTransactions[:len(s.nestedTransactions)-1]
+	parent := s.current()
+
+	return parent.state.MergeState(child.state, enforceLimits)
+}
+
+// Commit commits the changes in the current unrestricted nested transaction
+// to the parent (nested) transaction.  This returns error if the expectedId
+// does not match the current nested transaction.
+func (s *StateHolder) Commit(
+	expectedId NestedTransactionId,
+) error {
+	if !s.IsCurrent(expectedId) {
+		return fmt.Errorf(
+			"cannot commit unexpected nested transaction: id mismatch",
+		)
+	}
+
+	if s.IsParseRestricted() {
+		// This is due to a programming error.
+		return fmt.Errorf(
+			"cannot commit unexpected nested transaction: parse restricted",
+		)
+	}
+
+	return s.mergeIntoParent(s.EnforceLimits())
+}
+
+// CommitParseRestricted commits the changes in the current restricted nested
+// transaction to the parent (nested) transaction.  This returns error if the
+// specified location does not match the tracked location.
+func (s *StateHolder) CommitParseRestricted(
+	location common.AddressLocation,
+) (
+	*State,
+	error,
+) {
+	currentFrame := s.current()
+	if currentFrame.parseRestriction == nil ||
+		currentFrame.parseRestriction.ID() != location.ID() {
+
+		// This is due to a programming error.
+		return nil, fmt.Errorf(
+			"cannot commit unexpected nested transaction %v != %v",
+			currentFrame.parseRestriction,
+			location,
+		)
+	}
+
+	err := s.mergeIntoParent(s.EnforceLimits())
+	if err != nil {
+		return nil, err
+	}
+
+	return currentFrame.state, nil
+}
+
+// AttachAndCommitParseRestricted commits the changes in the cached nested
+// transaction to the current (nested) transaction.
+func (s *StateHolder) AttachAndCommitParseRestricted(
+	cachedNestedTransaction *State,
+) error {
+	s.nestedTransactions = append(
+		s.nestedTransactions,
+		nestedTransactionStackFrame{
+			state:            cachedNestedTransaction,
+			parseRestriction: nil,
+		},
+	)
+
+	// NOTE: limit enforcement is disabled here because cadence environment's
+	// Get() does not support returning error.
+	return s.mergeIntoParent(false)
+}
+
+// RestartNestedTransaction merges all changes that belongs to the nested
+// transaction about to be restart (for spock/meter bookkeeping), then
+// wipes its view changes.
+func (s *StateHolder) RestartNestedTransaction(
+	id NestedTransactionId,
+) error {
+
+	// NOTE: We need to verify the id is valid before any merge operation or
+	// else we would accidently merge everything into the main transaction.
+	found := false
+	for _, frame := range s.nestedTransactions {
+		if frame.state == id.state {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("nested transaction not found")
+	}
+
+	for s.currentState() != id.state {
+		err := s.mergeIntoParent(s.EnforceLimits())
+		if err != nil {
+			return fmt.Errorf("cannot restart nested transaction: %w", err)
+		}
+	}
+
+	s.currentState().View().DropDelta()
+	return nil
 }
 
 func (s *StateHolder) Get(
@@ -50,7 +263,7 @@ func (s *StateHolder) Get(
 	flow.RegisterValue,
 	error,
 ) {
-	return s.activeState.Get(owner, key, enforceLimit)
+	return s.currentState().Get(owner, key, enforceLimit)
 }
 
 func (s *StateHolder) Set(
@@ -59,63 +272,53 @@ func (s *StateHolder) Set(
 	value flow.RegisterValue,
 	enforceLimit bool,
 ) error {
-	return s.activeState.Set(owner, key, value, enforceLimit)
+	return s.currentState().Set(owner, key, value, enforceLimit)
 }
 
 func (s *StateHolder) UpdatedAddresses() []flow.Address {
-	return s.activeState.UpdatedAddresses()
+	return s.currentState().UpdatedAddresses()
 }
 
 func (s *StateHolder) MeterComputation(
 	kind common.ComputationKind,
 	intensity uint,
 ) error {
-	return s.activeState.MeterComputation(kind, intensity)
+	return s.currentState().MeterComputation(kind, intensity)
 }
 
 func (s *StateHolder) MeterMemory(
 	kind common.MemoryKind,
 	intensity uint,
 ) error {
-	return s.activeState.MeterMemory(kind, intensity)
+	return s.currentState().MeterMemory(kind, intensity)
 }
 
 func (s *StateHolder) ComputationIntensities() meter.MeteredComputationIntensities {
-	return s.activeState.ComputationIntensities()
+	return s.currentState().ComputationIntensities()
 }
 
 func (s *StateHolder) TotalComputationLimit() uint {
-	return s.activeState.TotalComputationLimit()
+	return s.currentState().TotalComputationLimit()
 }
 
 func (s *StateHolder) TotalComputationUsed() uint {
-	return s.activeState.TotalComputationUsed()
+	return s.currentState().TotalComputationUsed()
 }
 
 func (s *StateHolder) MemoryIntensities() meter.MeteredMemoryIntensities {
-	return s.activeState.MemoryIntensities()
+	return s.currentState().MemoryIntensities()
 }
 
 func (s *StateHolder) TotalMemoryEstimate() uint64 {
-	return s.activeState.TotalMemoryEstimate()
+	return s.currentState().TotalMemoryEstimate()
 }
 
 func (s *StateHolder) InteractionUsed() uint64 {
-	return s.activeState.InteractionUsed()
+	return s.currentState().InteractionUsed()
 }
 
 func (s *StateHolder) ViewForTestingOnly() View {
-	return s.activeState.View()
-}
-
-// NewChild constructs a new child of active state
-// and set it as active state and return it
-// this is basically a utility function for common
-// operations
-func (s *StateHolder) NewChild() *State {
-	child := s.activeState.NewChild()
-	s.activeState = child
-	return s.activeState
+	return s.currentState().View()
 }
 
 // EnableAllLimitEnforcements enables all the limits

--- a/fvm/state/state_transaction_test.go
+++ b/fvm/state/state_transaction_test.go
@@ -1,0 +1,449 @@
+package state_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/utils"
+)
+
+func newTestStateTransaction() *state.StateHolder {
+	return state.NewStateTransaction(
+		utils.NewSimpleView(),
+		state.DefaultParameters(),
+	)
+}
+
+func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	mainState := txn.MainTransactionId().StateForTestingOnly()
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+	require.False(t, txn.IsParseRestricted())
+
+	id1, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.False(t, txn.IsParseRestricted())
+
+	require.True(t, txn.IsCurrent(id1))
+
+	nestedState1 := id1.StateForTestingOnly()
+
+	id2, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	require.Equal(t, 2, txn.NumNestedTransactions())
+	require.False(t, txn.IsParseRestricted())
+
+	require.False(t, txn.IsCurrent(id1))
+	require.True(t, txn.IsCurrent(id2))
+
+	nestedState2 := id2.StateForTestingOnly()
+
+	// Ensure the values are written to the correctly nested state
+
+	addr := "address"
+	key := "key"
+	val := createByteArray(2)
+
+	err = txn.Set(addr, key, val, true)
+	require.NoError(t, err)
+
+	v, err := nestedState2.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+
+	v, err = nestedState1.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	// Ensure nested transactions are merged correctly
+
+	err = txn.Commit(id2)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id1))
+
+	v, err = nestedState1.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	err = txn.Commit(id1)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(txn.MainTransactionId()))
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+}
+
+func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	mainId := txn.MainTransactionId()
+	mainState := mainId.StateForTestingOnly()
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+	require.False(t, txn.IsParseRestricted())
+
+	id1, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.False(t, txn.IsParseRestricted())
+
+	nestedState := id1.StateForTestingOnly()
+
+	loc1 := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 1, 1}),
+		Name:    "loc1",
+	}
+
+	restrictedId1, err := txn.BeginParseRestrictedNestedTransaction(loc1)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, txn.NumNestedTransactions())
+	require.True(t, txn.IsParseRestricted())
+
+	restrictedNestedState1 := restrictedId1.StateForTestingOnly()
+
+	loc2 := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{2, 2, 2}),
+		Name:    "loc2",
+	}
+
+	restrictedId2, err := txn.BeginParseRestrictedNestedTransaction(loc2)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, txn.NumNestedTransactions())
+	require.True(t, txn.IsParseRestricted())
+
+	restrictedNestedState2 := restrictedId2.StateForTestingOnly()
+
+	// Sanity check
+
+	addr := "address"
+	key := "key"
+
+	v, err := restrictedNestedState2.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = restrictedNestedState1.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = nestedState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	// Ensures attaching and committing cached nested transaction works
+
+	val := createByteArray(2)
+
+	cachedState := state.NewState(
+		utils.NewSimpleView(),
+		state.DefaultParameters(),
+	)
+
+	err = cachedState.Set(addr, key, val, true)
+	require.NoError(t, err)
+
+	err = txn.AttachAndCommitParseRestricted(cachedState)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(restrictedId2))
+
+	v, err = restrictedNestedState2.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+
+	v, err = restrictedNestedState1.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = nestedState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	// Ensure nested transactions are merged correctly
+
+	state, err := txn.CommitParseRestricted(loc2)
+	require.NoError(t, err)
+	require.Equal(t, restrictedNestedState2, state)
+
+	require.Equal(t, 2, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(restrictedId1))
+
+	v, err = restrictedNestedState1.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+
+	v, err = nestedState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	state, err = txn.CommitParseRestricted(loc1)
+	require.NoError(t, err)
+	require.Equal(t, restrictedNestedState1, state)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id1))
+
+	v, err = nestedState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	err = txn.Commit(id1)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(mainId))
+
+	v, err = mainState.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+}
+
+func TestRestartNestedTransaction(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+
+	id, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	addr := "address"
+	key := "key"
+	val := createByteArray(2)
+
+	for i := 0; i < 10; i++ {
+		_, err := txn.BeginNestedTransaction()
+		require.NoError(t, err)
+
+		err = txn.Set(addr, key, val, true)
+		require.NoError(t, err)
+	}
+
+	loc := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 1, 1}),
+		Name:    "loc",
+	}
+
+	for i := 0; i < 5; i++ {
+		_, err := txn.BeginParseRestrictedNestedTransaction(loc)
+		require.NoError(t, err)
+
+		err = txn.Set(addr, key, val, true)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, 16, txn.NumNestedTransactions())
+
+	state := id.StateForTestingOnly()
+	require.Equal(t, uint64(0), state.InteractionUsed())
+
+	// Restart will merge the meter stat, but not the view delta
+
+	err = txn.RestartNestedTransaction(id)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id))
+
+	require.Greater(t, state.InteractionUsed(), uint64(0))
+
+	v, err := state.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Nil(t, v)
+}
+
+func TestRestartNestedTransactionWithInvalidId(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+
+	id, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	addr := "address"
+	key := "key"
+	val := createByteArray(2)
+
+	err = txn.Set(addr, key, val, true)
+	require.NoError(t, err)
+
+	var otherId state.NestedTransactionId
+	for i := 0; i < 10; i++ {
+		otherId, err = txn.BeginNestedTransaction()
+		require.NoError(t, err)
+
+		err = txn.Commit(otherId)
+		require.NoError(t, err)
+	}
+
+	require.True(t, txn.IsCurrent(id))
+
+	err = txn.RestartNestedTransaction(otherId)
+	require.Error(t, err)
+
+	require.True(t, txn.IsCurrent(id))
+
+	v, err := txn.Get(addr, key, true)
+	require.NoError(t, err)
+	require.Equal(t, val, v)
+}
+
+func TestUnrestrictedCannotCommitParseRestricted(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	loc := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 1, 1}),
+		Name:    "loc",
+	}
+
+	id, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.False(t, txn.IsParseRestricted())
+
+	_, err = txn.CommitParseRestricted(loc)
+	require.Error(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id))
+}
+
+func TestUnrestrictedCannotCommitMainTransaction(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	id1, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	id2, err := txn.BeginNestedTransaction()
+	require.NoError(t, err)
+
+	require.Equal(t, 2, txn.NumNestedTransactions())
+
+	err = txn.Commit(id1)
+	require.Error(t, err)
+
+	require.Equal(t, 2, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id2))
+}
+
+func TestUnrestrictedCannotCommitUnexpectedNested(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	mainId := txn.MainTransactionId()
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+
+	err := txn.Commit(mainId)
+	require.Error(t, err)
+
+	require.Equal(t, 0, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(mainId))
+}
+
+func TestParseRestrictedCannotBeginUnrestrictedNestedTransaction(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	loc := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 1, 1}),
+		Name:    "loc",
+	}
+
+	id1, err := txn.BeginParseRestrictedNestedTransaction(loc)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+
+	id2, err := txn.BeginNestedTransaction()
+	require.Error(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id1))
+	require.False(t, txn.IsCurrent(id2))
+}
+
+func TestParseRestrictedCannotCommitUnrestricted(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	loc := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 1, 1}),
+		Name:    "loc",
+	}
+
+	id, err := txn.BeginParseRestrictedNestedTransaction(loc)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+
+	err = txn.Commit(id)
+	require.Error(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id))
+}
+
+func TestParseRestrictedCannotCommitLocationMismatch(t *testing.T) {
+	txn := newTestStateTransaction()
+
+	loc := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 1, 1}),
+		Name:    "loc",
+	}
+
+	id, err := txn.BeginParseRestrictedNestedTransaction(loc)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+
+	other := common.AddressLocation{
+		Address: common.MustBytesToAddress([]byte{1, 1, 1}),
+		Name:    "other",
+	}
+
+	cacheableState, err := txn.CommitParseRestricted(other)
+	require.Error(t, err)
+	require.Nil(t, cacheableState)
+
+	require.Equal(t, 1, txn.NumNestedTransactions())
+	require.True(t, txn.IsCurrent(id))
+}

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -36,13 +36,16 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 		defer span.End()
 	}
 
-	parentState := sth.State()
-	childState := sth.NewChild()
+	nestedTxnId, err := sth.BeginNestedTransaction()
+	if err != nil {
+		return err
+	}
+
 	defer func() {
-		if mergeError := parentState.MergeState(childState, sth.EnforceLimits()); mergeError != nil {
+		mergeError := sth.Commit(nestedTxnId)
+		if mergeError != nil {
 			panic(mergeError)
 		}
-		sth.SetActiveState(parentState)
 	}()
 
 	accounts := state.NewAccounts(sth)
@@ -72,8 +75,13 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 
 	_, err = accounts.SetPublicKey(proposalKey.Address, proposalKey.KeyIndex, accountKey)
 	if err != nil {
-		childState.View().DropDelta()
+		// NOTE: we need to disable limits during restart or else restart may
+		// fail on merging.
+		sth.DisableAllLimitEnforcements()
+		_ = sth.RestartNestedTransaction(nestedTxnId)
+		sth.EnableAllLimitEnforcements()
 		return fmt.Errorf("checking sequence number failed: %w", err)
 	}
+
 	return nil
 }

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -128,7 +128,7 @@ func TestAccountFreezing(t *testing.T) {
 			fvm.WithTransactionProcessors( // run with limited processor to test just core of freezing, but still inside FVM
 				fvm.NewTransactionInvoker(zerolog.Nop())))
 
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -149,7 +149,7 @@ func TestAccountFreezing(t *testing.T) {
 		proc = fvm.Transaction(
 			&flow.TransactionBody{Script: code(address)},
 			programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -178,7 +178,7 @@ func TestAccountFreezing(t *testing.T) {
 		tx.AddAuthorizer(chain.ServiceAddress())
 
 		proc = fvm.Transaction(tx, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -193,7 +193,7 @@ func TestAccountFreezing(t *testing.T) {
 			&flow.TransactionBody{Script: code(address)},
 			programsStorage.NextTxIndexForTestingOnly())
 
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.Error(t, proc.Err)
 
@@ -320,7 +320,7 @@ func TestAccountFreezing(t *testing.T) {
 		tx.AddAuthorizer(chain.ServiceAddress())
 
 		proc = fvm.Transaction(tx, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, proc, st.State().View(), programsStorage)
+		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 


### PR DESCRIPTION
1. Refactor program handler's state stack into StateHolder.
2. Switch transaction invoker and seq num verifier to the new api

In a future PR, I'll restrict access to Environment methods (if cadence accesses
anything besides GetCode, we need to know about it, and invalidate the programs
cache accordingly).