### PR TITLE
Fully initialize meter parameters before transaction execution

### DIFF
--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -148,10 +148,7 @@ func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 	sth := state.NewStateHolder(st)
 	accounts := state.NewAccounts(sth)
 
-	env, err := fvm.NewScriptEnvironment(context.Background(), ctx, vm, sth, prog)
-	if err != nil {
-		panic(err)
-	}
+	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, sth, prog)
 
 	return &balanceProcessor{
 		vm:       vm,

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -646,8 +646,7 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 	programs := programs.NewEmptyPrograms()
 	st := state.NewState(view, meter.NewMeter(meter.DefaultParameters()), state.DefaultParameters())
 	sth := state.NewStateHolder(st)
-	env, err := fvm.NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
-	require.NoError(t, err)
+	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
 
 	// Create an account private key.
 	privateKeys, err := testutil.GenerateAccountPrivateKeys(1)

--- a/fvm/account.go
+++ b/fvm/account.go
@@ -25,10 +25,7 @@ func getAccount(
 	}
 
 	if ctx.ServiceAccountEnabled {
-		env, err := NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
-		if err != nil {
-			return nil, err
-		}
+		env := NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
 
 		balance, err := env.GetAccountBalance(common.Address(address))
 		if err != nil {

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -45,12 +45,21 @@ func NewVirtualMachine(rt runtime.Runtime) *VirtualMachine {
 
 // Run runs a procedure against a ledger in the given context.
 func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, programs *programs.Programs) (err error) {
+	meterParams, err := getEnvironmentMeterParameters(
+		vm,
+		ctx,
+		v,
+		programs,
+		uint(proc.ComputationLimit(ctx)),
+		proc.MemoryLimit(ctx),
+	)
+	if err != nil {
+		return fmt.Errorf("error gettng environment meter parameters: %w", err)
+	}
+
 	st := state.NewState(
 		v,
-		meter.NewMeter(
-			meter.DefaultParameters().
-				WithComputationLimit(uint(proc.ComputationLimit(ctx))).
-				WithMemoryLimit(proc.MemoryLimit(ctx))),
+		meter.NewMeter(meterParams),
 		state.DefaultParameters().
 			WithMaxKeySizeAllowed(ctx.MaxStateKeySize).
 			WithMaxValueSizeAllowed(ctx.MaxStateValueSize).

--- a/fvm/meter/meter.go
+++ b/fvm/meter/meter.go
@@ -56,12 +56,7 @@ type Meter interface {
 	MeterMemory(kind common.MemoryKind, intensity uint) error
 	MemoryIntensities() MeteredMemoryIntensities
 	TotalMemoryEstimate() uint
-	TotalMemoryLimit() uint
-
-	// TODO(patrick): make these non-optional arguments to NewMeter
-	SetComputationWeights(weights ExecutionEffortWeights)
-	SetMemoryWeights(weights ExecutionMemoryWeights)
-	SetTotalMemoryLimit(limit uint64)
+	TotalMemoryLimit() uint64
 
 	// TODO move storage metering to here
 	// MeterStorageRead(byteSize uint) error

--- a/fvm/meter/weighted_meter.go
+++ b/fvm/meter/weighted_meter.go
@@ -295,6 +295,24 @@ func (params MeterParameters) WithMemoryWeights(
 	return newParams
 }
 
+func (params MeterParameters) ComputationWeights() ExecutionEffortWeights {
+	return params.computationWeights
+}
+
+// TotalComputationLimit returns the total computation limit
+func (params MeterParameters) TotalComputationLimit() uint {
+	return uint(params.computationLimit >> MeterExecutionInternalPrecisionBytes)
+}
+
+func (params MeterParameters) MemoryWeights() ExecutionMemoryWeights {
+	return params.memoryWeights
+}
+
+// TotalMemoryLimit returns the total memory limit
+func (params MeterParameters) TotalMemoryLimit() uint64 {
+	return params.memoryLimit
+}
+
 // WeightedMeter collects memory and computation usage and enforces limits
 // for any each memory/computation usage call it sums intensity multiplied by the weight of the intensity to the total
 // memory/computation usage metrics and returns error if limits are not met.
@@ -365,11 +383,6 @@ func (m *WeightedMeter) MergeMeter(child Meter, enforceLimits bool) error {
 	return nil
 }
 
-// SetComputationWeights sets the computation weights
-func (m *WeightedMeter) SetComputationWeights(weights ExecutionEffortWeights) {
-	m.computationWeights = weights
-}
-
 // MeterComputation captures computation usage and returns an error if it goes beyond the limit
 func (m *WeightedMeter) MeterComputation(kind common.ComputationKind, intensity uint) error {
 	m.computationIntensities[kind] += intensity
@@ -394,16 +407,6 @@ func (m *WeightedMeter) TotalComputationUsed() uint {
 	return uint(m.computationUsed >> MeterExecutionInternalPrecisionBytes)
 }
 
-// TotalComputationLimit returns the total computation limit
-func (m *WeightedMeter) TotalComputationLimit() uint {
-	return uint(m.computationLimit >> MeterExecutionInternalPrecisionBytes)
-}
-
-// SetMemoryWeights sets the memory weights
-func (m *WeightedMeter) SetMemoryWeights(weights ExecutionMemoryWeights) {
-	m.memoryWeights = weights
-}
-
 // MeterMemory captures memory usage and returns an error if it goes beyond the limit
 func (m *WeightedMeter) MeterMemory(kind common.MemoryKind, intensity uint) error {
 	m.memoryIntensities[kind] += intensity
@@ -426,14 +429,4 @@ func (m *WeightedMeter) MemoryIntensities() MeteredMemoryIntensities {
 // TotalMemoryEstimate returns the total memory used
 func (m *WeightedMeter) TotalMemoryEstimate() uint {
 	return uint(m.memoryEstimate)
-}
-
-// TotalMemoryLimit returns the total memory limit
-func (m *WeightedMeter) TotalMemoryLimit() uint {
-	return uint(m.memoryLimit)
-}
-
-// SetTotalMemoryLimit sets the total memory limit
-func (m *WeightedMeter) SetTotalMemoryLimit(limit uint64) {
-	m.memoryLimit = limit
 }

--- a/fvm/meter/weighted_meter_test.go
+++ b/fvm/meter/weighted_meter_test.go
@@ -23,7 +23,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				WithMemoryLimit(2),
 		)
 		require.Equal(t, uint(1), m.TotalComputationLimit())
-		require.Equal(t, uint(2), m.TotalMemoryLimit())
+		require.Equal(t, uint64(2), m.TotalMemoryLimit())
 	})
 
 	t.Run("get limits max", func(t *testing.T) {
@@ -33,7 +33,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 				WithMemoryLimit(math.MaxUint32),
 		)
 		require.Equal(t, uint(math.MaxUint32), m.TotalComputationLimit())
-		require.Equal(t, uint(math.MaxUint32), m.TotalMemoryLimit())
+		require.Equal(t, uint64(math.MaxUint32), m.TotalMemoryLimit())
 	})
 
 	t.Run("meter computation and memory", func(t *testing.T) {

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -120,10 +120,7 @@ func (i ScriptInvoker) Process(
 	sth *state.StateHolder,
 	programs *programs.Programs,
 ) error {
-	env, err := NewScriptEnvironment(proc.RequestContext, ctx, vm, sth, programs)
-	if err != nil {
-		return err
-	}
+	env := NewScriptEnvironment(proc.RequestContext, ctx, vm, sth, programs)
 
 	location := common.ScriptLocation(proc.ID)
 	value, err := vm.Runtime.ExecuteScript(

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -35,7 +35,7 @@ func NewScriptEnvironment(
 	vm *VirtualMachine,
 	sth *state.StateHolder,
 	programs *programs.Programs,
-) (*ScriptEnv, error) {
+) *ScriptEnv {
 
 	accounts := state.NewAccounts(sth)
 	uuidGenerator := state.NewUUIDGenerator(sth)
@@ -80,9 +80,7 @@ func NewScriptEnvironment(
 		func() []common.Address { return []common.Address{} },
 		func(address runtime.Address, code []byte) (bool, error) { return false, nil })
 
-	err := setMeterParameters(&env.commonEnv)
-
-	return env, err
+	return env
 }
 
 func (e *ScriptEnv) GetStorageCapacity(address common.Address) (value uint64, err error) {

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -219,7 +219,7 @@ func (s *State) TotalMemoryEstimate() uint {
 
 // TotalMemoryLimit returns total memory limit
 func (s *State) TotalMemoryLimit() uint {
-	return s.meter.TotalMemoryLimit()
+	return uint(s.meter.TotalMemoryLimit())
 }
 
 // NewChild generates a new child state

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -65,12 +65,6 @@ func (s *StateHolder) UpdatedAddresses() []flow.Address {
 	return s.activeState.UpdatedAddresses()
 }
 
-// TODO(patrick): remove once we no longer support updating limit/weights after
-// meter initialization.
-func (s *StateHolder) Meter() meter.Meter {
-	return s.activeState.Meter()
-}
-
 func (s *StateHolder) MeterComputation(
 	kind common.ComputationKind,
 	intensity uint,

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -44,7 +44,7 @@ func NewTransactionEnvironment(
 	tx *flow.TransactionBody,
 	txIndex uint32,
 	traceSpan otelTrace.Span,
-) (*TransactionEnv, error) {
+) *TransactionEnv {
 
 	accounts := state.NewAccounts(sth)
 	generator := state.NewStateBoundAddressGenerator(sth, ctx.Chain)
@@ -113,9 +113,7 @@ func NewTransactionEnvironment(
 		env.useContractAuditVoucher,
 	)
 
-	err := setMeterParameters(&env.commonEnv)
-
-	return env, err
+	return env
 }
 
 func (e *TransactionEnv) TxIndex() uint32 {

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -78,16 +78,13 @@ func (i *TransactionInvoker) Process(
 		sth.SetActiveState(parentState)
 	}()
 
-	env, err := NewTransactionEnvironment(*ctx, vm, sth, programs, proc.Transaction, proc.TxIndex, span)
-	if err != nil {
-		return fmt.Errorf("error creating new environment: %w", err)
-	}
+	env := NewTransactionEnvironment(*ctx, vm, sth, programs, proc.Transaction, proc.TxIndex, span)
 	predeclaredValues := valueDeclarations(env)
 
 	location := common.TransactionLocation(proc.ID)
 
 	var txError error
-	err = vm.Runtime.ExecuteTransaction(
+	err := vm.Runtime.ExecuteTransaction(
 		runtime.Script{
 			Source:    proc.Transaction.Script,
 			Arguments: proc.Transaction.Arguments,
@@ -163,10 +160,7 @@ func (i *TransactionInvoker) Process(
 			Msg("transaction executed with error")
 
 		// reset env
-		env, err = NewTransactionEnvironment(*ctx, vm, sth, programs, proc.Transaction, proc.TxIndex, span)
-		if err != nil {
-			return fmt.Errorf("error creating new environment: %w", err)
-		}
+		env = NewTransactionEnvironment(*ctx, vm, sth, programs, proc.Transaction, proc.TxIndex, span)
 
 		// try to deduct fees again, to get the fee deduction events
 		feesError = i.deductTransactionFees(env, proc, sth, computationUsed)


### PR DESCRIPTION
This ensures that all meter parameters are set in one place, which enables us
to safely remove PayerIsServiceAccount special casing (in future PR).