### PR TITLE
Internalize state/meter creation

### DIFF
--- a/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
+++ b/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
@@ -12,7 +12,6 @@ import (
 
 	executionState "github.com/onflow/flow-go/engine/execution/state"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
-	metering "github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -98,10 +97,9 @@ func run(*cobra.Command, []string) {
 		return values[0], nil
 	})
 
-	meter := metering.NewMeter(metering.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(ldg, meter, state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
-	finalGenerator := state.NewStateBoundAddressGenerator(sth, chain)
+	stTxn := state.NewStateTransaction(ldg, state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
+	finalGenerator := state.NewStateBoundAddressGenerator(stTxn, chain)
 	finalState := finalGenerator.Bytes()
 
 	generator := chain.NewAddressGenerator()

--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
 	"github.com/onflow/flow-go/fvm"
-	metering "github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
@@ -67,10 +66,11 @@ func (r *AccountReporter) Report(payload []ledger.Payload, commit ledger.State) 
 	defer rwm.Close()
 
 	l := migrations.NewView(payload)
-	meter := metering.NewMeter(metering.DefaultParameters())
-	st := state.NewState(l, meter, state.DefaultParameters().WithMaxInteractionSizeAllowed(math.MaxUint64))
-	sth := state.NewStateHolder(st)
-	gen := state.NewStateBoundAddressGenerator(sth, r.Chain)
+	stTxn := state.NewStateTransaction(
+		l,
+		state.DefaultParameters().WithMaxInteractionSizeAllowed(math.MaxUint64),
+	)
+	gen := state.NewStateBoundAddressGenerator(stTxn, r.Chain)
 
 	progress := progressbar.Default(int64(gen.AddressCount()), "Processing:")
 
@@ -128,7 +128,6 @@ type balanceProcessor struct {
 	momentsScript []byte
 
 	accounts state.Accounts
-	st       *state.State
 
 	rwa        ReportWriter
 	rwc        ReportWriter
@@ -143,19 +142,19 @@ func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 	prog := programs.NewEmptyPrograms()
 
 	v := view.NewChild()
-	meter := metering.NewMeter(metering.DefaultParameters())
-	st := state.NewState(v, meter, state.DefaultParameters().WithMaxInteractionSizeAllowed(math.MaxUint64))
-	sth := state.NewStateHolder(st)
-	accounts := state.NewAccounts(sth)
+	stTxn := state.NewStateTransaction(
+		v,
+		state.DefaultParameters().WithMaxInteractionSizeAllowed(math.MaxUint64),
+	)
+	accounts := state.NewAccounts(stTxn)
 
-	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, sth, prog)
+	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, stTxn, prog)
 
 	return &balanceProcessor{
 		vm:       vm,
 		ctx:      ctx,
 		view:     v,
 		accounts: accounts,
-		st:       st,
 		prog:     prog,
 		intf:     env,
 	}

--- a/cmd/util/ledger/reporters/fungible_token_tracker.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
 	"github.com/onflow/flow-go/fvm"
-	metering "github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
@@ -142,10 +141,8 @@ func (r *FungibleTokenTracker) worker(
 	for j := range jobs {
 
 		view := migrations.NewView(j.payloads)
-		meter := metering.NewMeter(metering.DefaultParameters())
-		st := state.NewState(view, meter, state.DefaultParameters())
-		sth := state.NewStateHolder(st)
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		storage := cadenceRuntime.NewStorage(
 			&migrations.AccountsAtreeLedger{Accounts: accounts},
 			nil,

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -800,8 +800,8 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 	view := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
 		return ledger.Get(owner, key)
 	})
-	sth := state.NewStateHolder(state.NewState(view, meter.NewMeter(meter.DefaultParameters()), state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 
 	// account creation, signing of transaction and bootstrapping ledger should not be required for this test
 	// as freeze check should happen before a transaction signature is checked

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
 	fvmErrors "github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -644,9 +643,8 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 	)
 	view := testutil.RootBootstrappedLedger(vm, ctx)
 	programs := programs.NewEmptyPrograms()
-	st := state.NewState(view, meter.NewMeter(meter.DefaultParameters()), state.DefaultParameters())
-	sth := state.NewStateHolder(st)
-	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, stTxn, programs)
 
 	// Create an account private key.
 	privateKeys, err := testutil.GenerateAccountPrivateKeys(1)

--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -32,18 +32,16 @@ func getEnvironmentMeterParameters(
 
 	var err error
 	if ctx.AllowContextOverrideByExecutionState {
-		sth := state.NewStateHolder(
-			state.NewState(
-				view,
-				meter.NewMeter(meter.DefaultParameters()),
-				state.DefaultParameters().
-					WithMaxKeySizeAllowed(ctx.MaxStateKeySize).
-					WithMaxValueSizeAllowed(ctx.MaxStateValueSize).
-					WithMaxInteractionSizeAllowed(ctx.MaxStateInteractionSize)))
+		stTxn := state.NewStateTransaction(
+			view,
+			state.DefaultParameters().
+				WithMaxKeySizeAllowed(ctx.MaxStateKeySize).
+				WithMaxValueSizeAllowed(ctx.MaxStateValueSize).
+				WithMaxInteractionSizeAllowed(ctx.MaxStateInteractionSize))
 
-		sth.DisableAllLimitEnforcements()
+		stTxn.DisableAllLimitEnforcements()
 
-		env := NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
+		env := NewScriptEnvironment(context.Background(), ctx, vm, stTxn, programs)
 
 		params, err = fillEnvironmentMeterParameters(ctx, env, params)
 	}

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rs/zerolog"
 
 	errors "github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -57,17 +56,16 @@ func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, program
 		return fmt.Errorf("error gettng environment meter parameters: %w", err)
 	}
 
-	st := state.NewState(
+	stTxn := state.NewStateTransaction(
 		v,
-		meter.NewMeter(meterParams),
 		state.DefaultParameters().
+			WithMeterParameters(meterParams).
 			WithMaxKeySizeAllowed(ctx.MaxStateKeySize).
 			WithMaxValueSizeAllowed(ctx.MaxStateValueSize).
 			WithMaxInteractionSizeAllowed(ctx.MaxStateInteractionSize),
 	)
-	sth := state.NewStateHolder(st)
 
-	err = proc.Run(vm, ctx, sth, programs)
+	err = proc.Run(vm, ctx, stTxn, programs)
 	if err != nil {
 		return err
 	}
@@ -77,17 +75,15 @@ func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, program
 
 // GetAccount returns an account by address or an error if none exists.
 func (vm *VirtualMachine) GetAccount(ctx Context, address flow.Address, v state.View, programs *programs.Programs) (*flow.Account, error) {
-	st := state.NewState(
+	stTxn := state.NewStateTransaction(
 		v,
-		meter.NewMeter(meter.DefaultParameters()),
 		state.DefaultParameters().
 			WithMaxKeySizeAllowed(ctx.MaxStateKeySize).
 			WithMaxValueSizeAllowed(ctx.MaxStateValueSize).
 			WithMaxInteractionSizeAllowed(ctx.MaxStateInteractionSize),
 	)
 
-	sth := state.NewStateHolder(st)
-	account, err := getAccount(vm, ctx, sth, programs, address)
+	account, err := getAccount(vm, ctx, stTxn, programs, address)
 	if err != nil {
 		if errors.IsALedgerFailure(err) {
 			return nil, fmt.Errorf("cannot get account, this error usually happens if the reference block for this query is not set to a recent block: %w", err)
@@ -101,7 +97,7 @@ func (vm *VirtualMachine) GetAccount(ctx Context, address flow.Address, v state.
 //
 // Errors that occur in a meta transaction are propagated as a single error that can be
 // captured by the Cadence runtime and eventually disambiguated by the parent context.
-func (vm *VirtualMachine) invokeMetaTransaction(parentCtx Context, tx *TransactionProcedure, sth *state.StateHolder, programs *programs.Programs) (errors.Error, error) {
+func (vm *VirtualMachine) invokeMetaTransaction(parentCtx Context, tx *TransactionProcedure, stTxn *state.StateHolder, programs *programs.Programs) (errors.Error, error) {
 	invoker := NewTransactionInvoker(zerolog.Nop())
 
 	// do not deduct fees or check storage in meta transactions
@@ -110,7 +106,7 @@ func (vm *VirtualMachine) invokeMetaTransaction(parentCtx Context, tx *Transacti
 		WithTransactionFeesEnabled(false),
 	)
 
-	err := invoker.Process(vm, &ctx, tx, sth, programs)
+	err := invoker.Process(vm, &ctx, tx, stTxn, programs)
 	txErr, fatalErr := errors.SplitErrorTypes(err)
 	return txErr, fatalErr
 }

--- a/fvm/handler/contract_test.go
+++ b/fvm/handler/contract_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/onflow/flow-go/fvm/programs"
 
 	"github.com/onflow/flow-go/fvm/handler"
-	"github.com/onflow/flow-go/fvm/meter"
 	stateMock "github.com/onflow/flow-go/fvm/mock/state"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -20,11 +19,10 @@ import (
 )
 
 func TestContract_ChildMergeFunctionality(t *testing.T) {
-	sth := state.NewStateHolder(state.NewState(
+	stTxn := state.NewStateTransaction(
 		utils.NewSimpleView(),
-		meter.NewMeter(meter.DefaultParameters()),
-		state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+		state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 	address := flow.HexToAddress("01")
 	rAdd := runtime.Address(address)
 	err := accounts.Create(nil, address)
@@ -97,11 +95,10 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 }
 
 func TestContract_AuthorizationFunctionality(t *testing.T) {
-	sth := state.NewStateHolder(state.NewState(
+	stTxn := state.NewStateTransaction(
 		utils.NewSimpleView(),
-		meter.NewMeter(meter.DefaultParameters()),
-		state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+		state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 
 	authAdd := flow.HexToAddress("01")
 	rAdd := runtime.Address(authAdd)
@@ -219,11 +216,10 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 
 func TestContract_DeploymentVouchers(t *testing.T) {
 
-	sth := state.NewStateHolder(state.NewState(
+	stTxn := state.NewStateTransaction(
 		utils.NewSimpleView(),
-		meter.NewMeter(meter.DefaultParameters()),
-		state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+		state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 
 	addressWithVoucher := flow.HexToAddress("01")
 	addressWithVoucherRuntime := runtime.Address(addressWithVoucher)
@@ -279,11 +275,10 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 
 func TestContract_ContractUpdate(t *testing.T) {
 
-	sth := state.NewStateHolder(state.NewState(
+	stTxn := state.NewStateTransaction(
 		utils.NewSimpleView(),
-		meter.NewMeter(meter.DefaultParameters()),
-		state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+		state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 
 	flowAddress := flow.HexToAddress("01")
 	runtimeAddress := runtime.Address(flowAddress)
@@ -388,11 +383,10 @@ func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 
 func TestContract_ContractRemoval(t *testing.T) {
 
-	sth := state.NewStateHolder(state.NewState(
+	stTxn := state.NewStateTransaction(
 		utils.NewSimpleView(),
-		meter.NewMeter(meter.DefaultParameters()),
-		state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+		state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 
 	flowAddress := flow.HexToAddress("01")
 	runtimeAddress := runtime.Address(flowAddress)

--- a/fvm/handler/programs_test.go
+++ b/fvm/handler/programs_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/meter"
 	programsStorage "github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -112,16 +111,13 @@ func Test_Programs(t *testing.T) {
 		return nil, nil
 	})
 
-	sth := state.NewStateHolder(state.NewState(
-		mainView,
-		meter.NewMeter(meter.DefaultParameters()),
-		state.DefaultParameters()))
+	stTxn := state.NewStateTransaction(mainView, state.DefaultParameters())
 
 	rt := fvm.NewInterpreterRuntime()
 	vm := fvm.NewVirtualMachine(rt)
 	programs := programsStorage.NewEmptyPrograms()
 
-	accounts := state.NewAccounts(sth)
+	accounts := state.NewAccounts(stTxn)
 
 	err := accounts.Create(nil, addressA)
 	require.NoError(t, err)

--- a/fvm/programs/programs_test.go
+++ b/fvm/programs/programs_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 )
@@ -26,7 +25,6 @@ func Test_Programs(t *testing.T) {
 
 	newState := state.NewState(
 		utils.NewSimpleView(),
-		meter.NewMeter(meter.DefaultParameters()),
 		state.DefaultParameters(),
 	)
 

--- a/fvm/state/accounts_test.go
+++ b/fvm/state/accounts_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
@@ -16,9 +15,8 @@ import (
 func TestAccounts_Create(t *testing.T) {
 	t.Run("Sets registers", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 
 		address := flow.HexToAddress("01")
 
@@ -31,9 +29,8 @@ func TestAccounts_Create(t *testing.T) {
 
 	t.Run("Fails if account exists", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -47,9 +44,8 @@ func TestAccounts_Create(t *testing.T) {
 
 func TestAccounts_GetWithNoKeys(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(meter.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 	address := flow.HexToAddress("01")
 
 	err := accounts.Create(nil, address)
@@ -77,9 +73,8 @@ func TestAccounts_GetPublicKey(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			meter := meter.NewMeter(meter.DefaultParameters())
-			sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-			accounts := state.NewAccounts(sth)
+			stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+			accounts := state.NewAccounts(stTxn)
 
 			err = accounts.Create(nil, address)
 			require.NoError(t, err)
@@ -106,9 +101,8 @@ func TestAccounts_GetPublicKeyCount(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			meter := meter.NewMeter(meter.DefaultParameters())
-			sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-			accounts := state.NewAccounts(sth)
+			stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+			accounts := state.NewAccounts(stTxn)
 
 			err = accounts.Create(nil, address)
 			require.NoError(t, err)
@@ -136,9 +130,8 @@ func TestAccounts_GetPublicKeys(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			meter := meter.NewMeter(meter.DefaultParameters())
-			sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-			accounts := state.NewAccounts(sth)
+			stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+			accounts := state.NewAccounts(stTxn)
 
 			err = accounts.Create(nil, address)
 			require.NoError(t, err)
@@ -155,9 +148,8 @@ func TestAccounts_GetPublicKeys(t *testing.T) {
 func TestAccounts_GetWithNoKeysCounter(t *testing.T) {
 	view := utils.NewSimpleView()
 
-	meter := meter.NewMeter(meter.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 	address := flow.HexToAddress("01")
 
 	err := accounts.Create(nil, address)
@@ -180,9 +172,8 @@ func TestAccounts_SetContracts(t *testing.T) {
 
 	t.Run("Setting a contract puts it in Contracts", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		a := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		a := state.NewAccounts(stTxn)
 		err := a.Create(nil, address)
 		require.NoError(t, err)
 
@@ -197,9 +188,8 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Setting a contract again, does not add it to contracts", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		a := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		a := state.NewAccounts(stTxn)
 		err := a.Create(nil, address)
 		require.NoError(t, err)
 
@@ -217,9 +207,8 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Setting more contracts always keeps them sorted", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		a := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		a := state.NewAccounts(stTxn)
 		err := a.Create(nil, address)
 		require.NoError(t, err)
 
@@ -242,9 +231,8 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Removing a contract does not fail if there is none", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		a := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		a := state.NewAccounts(stTxn)
 		err := a.Create(nil, address)
 		require.NoError(t, err)
 
@@ -253,9 +241,8 @@ func TestAccounts_SetContracts(t *testing.T) {
 	})
 	t.Run("Removing a contract removes it", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		a := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		a := state.NewAccounts(stTxn)
 		err := a.Create(nil, address)
 		require.NoError(t, err)
 
@@ -276,9 +263,8 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used on account creation is deterministic", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -291,9 +277,8 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used on register set increases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -309,9 +294,8 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, set twice on same register to same value, stays the same", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -329,9 +313,8 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, set twice on same register to larger value, increases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -349,9 +332,8 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, set twice on same register to smaller value, decreases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -369,9 +351,8 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used, after register deleted, decreases", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -389,9 +370,8 @@ func TestAccount_StorageUsed(t *testing.T) {
 
 	t.Run("Storage used on a complex scenario has correct value", func(t *testing.T) {
 		view := utils.NewSimpleView()
-		meter := meter.NewMeter(meter.DefaultParameters())
-		sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 		address := flow.HexToAddress("01")
 
 		err := accounts.Create(nil, address)
@@ -428,10 +408,9 @@ func createByteArray(size int) []byte {
 
 func TestAccounts_AllocateStorageIndex(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(meter.DefaultParameters())
 
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	accounts := state.NewAccounts(sth)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 	address := flow.HexToAddress("01")
 
 	err := accounts.Create(nil, address)

--- a/fvm/state/address_generator_test.go
+++ b/fvm/state/address_generator_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
@@ -14,18 +13,16 @@ import (
 func Test_NewStateBoundAddressGenerator_NoError(t *testing.T) {
 	view := utils.NewSimpleView()
 	chain := flow.MonotonicEmulator.Chain()
-	meter := meter.NewMeter(meter.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	env := state.NewStateBoundAddressGenerator(sth, chain)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	env := state.NewStateBoundAddressGenerator(stTxn, chain)
 	require.NotNil(t, env)
 }
 
 func Test_NewStateBoundAddressGenerator_GeneratingUpdatesState(t *testing.T) {
 	view := utils.NewSimpleView()
 	chain := flow.MonotonicEmulator.Chain()
-	meter := meter.NewMeter(meter.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	generator := state.NewStateBoundAddressGenerator(sth, chain)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	generator := state.NewStateBoundAddressGenerator(stTxn, chain)
 	_, err := generator.NextAddress()
 	require.NoError(t, err)
 
@@ -41,9 +38,8 @@ func Test_NewStateBoundAddressGenerator_UsesLedgerState(t *testing.T) {
 	require.NoError(t, err)
 
 	chain := flow.MonotonicEmulator.Chain()
-	meter := meter.NewMeter(meter.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	generator := state.NewStateBoundAddressGenerator(sth, chain)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	generator := state.NewStateBoundAddressGenerator(stTxn, chain)
 
 	_, err = generator.NextAddress()
 	require.NoError(t, err)

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -32,26 +32,43 @@ type State struct {
 	meter            meter.Meter
 	updatedAddresses map[flow.Address]struct{}
 	updateSize       map[mapKey]uint64
-	StateParameters
+	stateLimits
 	ReadCounter       uint64
 	WriteCounter      uint64
 	TotalBytesRead    uint64
 	TotalBytesWritten uint64
 }
 
-type StateParameters struct {
-	// TODO(patrick): nest meter parameters into this
+type stateLimits struct {
 	maxKeySizeAllowed     uint64
 	maxValueSizeAllowed   uint64
 	maxInteractionAllowed uint64
 }
 
+type StateParameters struct {
+	meter.MeterParameters
+
+	stateLimits
+}
+
 func DefaultParameters() StateParameters {
 	return StateParameters{
-		maxKeySizeAllowed:     DefaultMaxKeySize,
-		maxValueSizeAllowed:   DefaultMaxValueSize,
-		maxInteractionAllowed: DefaultMaxInteractionSize,
+		MeterParameters: meter.DefaultParameters(),
+		stateLimits: stateLimits{
+			maxKeySizeAllowed:     DefaultMaxKeySize,
+			maxValueSizeAllowed:   DefaultMaxValueSize,
+			maxInteractionAllowed: DefaultMaxInteractionSize,
+		},
 	}
+}
+
+// WithMeterParameters sets the state's meter parameters
+func (params StateParameters) WithMeterParameters(
+	meterParams meter.MeterParameters,
+) StateParameters {
+	newParams := params
+	newParams.MeterParameters = meterParams
+	return newParams
 }
 
 // WithMaxKeySizeAllowed sets limit on max key size
@@ -85,15 +102,26 @@ func (s *State) Meter() meter.Meter {
 
 type StateOption func(st *State) *State
 
-// TODO(patrick): stop passing in meter.  Create meter internally.
 // NewState constructs a new state
-func NewState(view View, meter meter.Meter, params StateParameters) *State {
+func NewState(view View, params StateParameters) *State {
+	m := meter.NewMeter(params.MeterParameters)
 	return &State{
 		view:             view,
-		meter:            meter,
+		meter:            m,
 		updatedAddresses: make(map[flow.Address]struct{}),
 		updateSize:       make(map[mapKey]uint64),
-		StateParameters:  params,
+		stateLimits:      params.stateLimits,
+	}
+}
+
+// NewChild generates a new child state
+func (s *State) NewChild() *State {
+	return &State{
+		view:             s.view.NewChild(),
+		meter:            s.meter.NewChild(),
+		updatedAddresses: make(map[flow.Address]struct{}),
+		updateSize:       make(map[mapKey]uint64),
+		stateLimits:      s.stateLimits,
 	}
 }
 
@@ -220,15 +248,6 @@ func (s *State) TotalMemoryEstimate() uint64 {
 // TotalMemoryLimit returns total memory limit
 func (s *State) TotalMemoryLimit() uint {
 	return uint(s.meter.TotalMemoryLimit())
-}
-
-// NewChild generates a new child state
-func (s *State) NewChild() *State {
-	return NewState(
-		s.view.NewChild(),
-		s.meter.NewChild(),
-		s.StateParameters,
-	)
 }
 
 // MergeState applies the changes from a the given view to this view.

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -20,8 +20,10 @@ type StateHolder struct {
 	activeState           *State
 }
 
-// NewStateHolder constructs a new state manager
-func NewStateHolder(startState *State) *StateHolder {
+// NewStateTransaction constructs a new state transaction which manages nested
+// transactions.
+func NewStateTransaction(startView View, params StateParameters) *StateHolder {
+	startState := NewState(startView, params)
 	return &StateHolder{
 		enforceLimits: true,
 		startState:    startState,

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -8,15 +8,13 @@ import (
 
 	"github.com/onflow/atree"
 
-	metering "github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 )
 
 func TestState_ChildMergeFunctionality(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(metering.DefaultParameters())
-	st := state.NewState(view, meter, state.DefaultParameters())
+	st := state.NewState(view, state.DefaultParameters())
 
 	t.Run("test read from parent state (backoff)", func(t *testing.T) {
 		key := "key1"
@@ -88,8 +86,7 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 
 func TestState_InteractionMeasuring(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(metering.DefaultParameters())
-	st := state.NewState(view, meter, state.DefaultParameters())
+	st := state.NewState(view, state.DefaultParameters())
 
 	key := "key1"
 	value := createByteArray(1)
@@ -119,8 +116,7 @@ func TestState_InteractionMeasuring(t *testing.T) {
 
 func TestState_MaxValueSize(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(metering.DefaultParameters())
-	st := state.NewState(view, meter, state.DefaultParameters().WithMaxValueSizeAllowed(6))
+	st := state.NewState(view, state.DefaultParameters().WithMaxValueSizeAllowed(6))
 
 	// update should pass
 	value := createByteArray(5)
@@ -135,8 +131,7 @@ func TestState_MaxValueSize(t *testing.T) {
 
 func TestState_MaxKeySize(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(metering.DefaultParameters())
-	st := state.NewState(view, meter, state.DefaultParameters().WithMaxKeySizeAllowed(4))
+	st := state.NewState(view, state.DefaultParameters().WithMaxKeySizeAllowed(4))
 
 	// read
 	_, err := st.Get("1", "2", true)
@@ -158,8 +153,7 @@ func TestState_MaxKeySize(t *testing.T) {
 
 func TestState_MaxInteraction(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := metering.NewMeter(metering.DefaultParameters())
-	st := state.NewState(view, meter, state.DefaultParameters().WithMaxInteractionSizeAllowed(12))
+	st := state.NewState(view, state.DefaultParameters().WithMaxInteractionSizeAllowed(12))
 
 	// read - interaction 2
 	_, err := st.Get("1", "2", true)
@@ -176,8 +170,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Equal(t, st.InteractionUsed(), uint64(14))
 	require.Error(t, err)
 
-	meter = metering.NewMeter(metering.DefaultParameters())
-	st = state.NewState(view, meter, state.DefaultParameters().WithMaxInteractionSizeAllowed(6))
+	st = state.NewState(view, state.DefaultParameters().WithMaxInteractionSizeAllowed(6))
 	stChild := st.NewChild()
 
 	// update - 0

--- a/fvm/state/uuids_test.go
+++ b/fvm/state/uuids_test.go
@@ -5,16 +5,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 )
 
 func TestUUIDs_GetAndSetUUID(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(meter.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	uuidsA := state.NewUUIDGenerator(sth)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	uuidsA := state.NewUUIDGenerator(stTxn)
 
 	uuid, err := uuidsA.GetUUID() // start from zero
 	require.NoError(t, err)
@@ -24,7 +22,7 @@ func TestUUIDs_GetAndSetUUID(t *testing.T) {
 	require.NoError(t, err)
 
 	// create new UUIDs instance
-	uuidsB := state.NewUUIDGenerator(sth)
+	uuidsB := state.NewUUIDGenerator(stTxn)
 	uuid, err = uuidsB.GetUUID() // should read saved value
 	require.NoError(t, err)
 
@@ -33,9 +31,8 @@ func TestUUIDs_GetAndSetUUID(t *testing.T) {
 
 func Test_GenerateUUID(t *testing.T) {
 	view := utils.NewSimpleView()
-	meter := meter.NewMeter(meter.DefaultParameters())
-	sth := state.NewStateHolder(state.NewState(view, meter, state.DefaultParameters()))
-	genA := state.NewUUIDGenerator(sth)
+	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
+	genA := state.NewUUIDGenerator(stTxn)
 
 	uuidA, err := genA.GenerateUUID()
 	require.NoError(t, err)
@@ -49,7 +46,7 @@ func Test_GenerateUUID(t *testing.T) {
 	require.Equal(t, uint64(2), uuidC)
 
 	// Create new generator instance from same ledger
-	genB := state.NewUUIDGenerator(sth)
+	genB := state.NewUUIDGenerator(stTxn)
 
 	uuidD, err := genB.GenerateUUID()
 	require.NoError(t, err)

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -39,16 +38,15 @@ func TestSafetyCheck(t *testing.T) {
 		view := utils.NewSimpleView()
 		context := fvm.NewContext(log)
 
-		sth := state.NewStateHolder(state.NewState(
+		stTxn := state.NewStateTransaction(
 			view,
-			meter.NewMeter(meter.DefaultParameters()),
 			state.DefaultParameters().
 				WithMaxKeySizeAllowed(context.MaxStateKeySize).
 				WithMaxValueSizeAllowed(context.MaxStateValueSize).
 				WithMaxInteractionSizeAllowed(context.MaxStateInteractionSize),
-		))
+		)
 
-		err := txInvoker.Process(vm, &context, proc, sth, programs.NewEmptyPrograms())
+		err := txInvoker.Process(vm, &context, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 
 		require.NotContains(t, buffer.String(), "programs")
@@ -73,16 +71,15 @@ func TestSafetyCheck(t *testing.T) {
 		view := utils.NewSimpleView()
 		context := fvm.NewContext(log)
 
-		sth := state.NewStateHolder(state.NewState(
+		stTxn := state.NewStateTransaction(
 			view,
-			meter.NewMeter(meter.DefaultParameters()),
 			state.DefaultParameters().
 				WithMaxKeySizeAllowed(context.MaxStateKeySize).
 				WithMaxValueSizeAllowed(context.MaxStateValueSize).
 				WithMaxInteractionSizeAllowed(context.MaxStateInteractionSize),
-		))
+		)
 
-		err := txInvoker.Process(vm, &context, proc, sth, programs.NewEmptyPrograms())
+		err := txInvoker.Process(vm, &context, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 
 		require.NotContains(t, buffer.String(), "programs")

--- a/fvm/transactionSequenceNum_test.go
+++ b/fvm/transactionSequenceNum_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -18,12 +17,8 @@ import (
 func TestTransactionSequenceNumProcess(t *testing.T) {
 	t.Run("sequence number update (happy path)", func(t *testing.T) {
 		ledger := utils.NewSimpleView()
-		sth := state.NewStateHolder(state.NewState(
-			ledger,
-			meter.NewMeter(meter.DefaultParameters()),
-			state.DefaultParameters(),
-		))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(ledger, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 
 		// create an account
 		address := flow.HexToAddress("1234")
@@ -37,7 +32,7 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = seqChecker.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.NoError(t, err)
 
 		// get fetch the sequence number and it should be updated
@@ -47,12 +42,8 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 	})
 	t.Run("invalid sequence number", func(t *testing.T) {
 		ledger := utils.NewSimpleView()
-		sth := state.NewStateHolder(state.NewState(
-			ledger,
-			meter.NewMeter(meter.DefaultParameters()),
-			state.DefaultParameters(),
-		))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(ledger, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 
 		// create an account
 		address := flow.HexToAddress("1234")
@@ -67,7 +58,7 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = seqChecker.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 		require.Equal(t, err.(errors.Error).Code(), errors.ErrCodeInvalidProposalSeqNumberError)
 
@@ -78,12 +69,8 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 	})
 	t.Run("invalid address", func(t *testing.T) {
 		ledger := utils.NewSimpleView()
-		sth := state.NewStateHolder(state.NewState(
-			ledger,
-			meter.NewMeter(meter.DefaultParameters()),
-			state.DefaultParameters(),
-		))
-		accounts := state.NewAccounts(sth)
+		stTxn := state.NewStateTransaction(ledger, state.DefaultParameters())
+		accounts := state.NewAccounts(stTxn)
 
 		// create an account
 		address := flow.HexToAddress("1234")
@@ -98,7 +85,7 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = seqChecker.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 
 		// get fetch the sequence number and check it to be unchanged

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/crypto"
 	"github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -19,12 +18,8 @@ import (
 
 func TestTransactionVerification(t *testing.T) {
 	ledger := utils.NewSimpleView()
-	sth := state.NewStateHolder(state.NewState(
-		ledger,
-		meter.NewMeter(meter.DefaultParameters()),
-		state.DefaultParameters(),
-	))
-	accounts := state.NewAccounts(sth)
+	stTxn := state.NewStateTransaction(ledger, state.DefaultParameters())
+	accounts := state.NewAccounts(stTxn)
 
 	// create 2 accounts
 	address1 := flow.HexToAddress("1234")
@@ -58,7 +53,7 @@ func TestTransactionVerification(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		txVerifier := fvm.NewTransactionVerifier(1000)
-		err = txVerifier.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = txVerifier.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 		require.True(t, strings.Contains(err.Error(), "duplicate signatures are provided for the same key"))
 	})
@@ -78,7 +73,7 @@ func TestTransactionVerification(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		txVerifier := fvm.NewTransactionVerifier(1000)
-		err = txVerifier.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = txVerifier.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 		require.True(t, strings.Contains(err.Error(), "duplicate signatures are provided for the same key"))
 	})
@@ -112,7 +107,7 @@ func TestTransactionVerification(t *testing.T) {
 
 		proc := fvm.Transaction(&tx, 0)
 		txVerifier := fvm.NewTransactionVerifier(1000)
-		err = txVerifier.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = txVerifier.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 
 		var envelopeError *errors.InvalidEnvelopeSignatureError
@@ -148,7 +143,7 @@ func TestTransactionVerification(t *testing.T) {
 
 		proc := fvm.Transaction(&tx, 0)
 		txVerifier := fvm.NewTransactionVerifier(1000)
-		err = txVerifier.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = txVerifier.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 
 		var payloadError *errors.InvalidPayloadSignatureError
@@ -181,7 +176,7 @@ func TestTransactionVerification(t *testing.T) {
 
 		proc := fvm.Transaction(&tx, 0)
 		txVerifier := fvm.NewTransactionVerifier(1000)
-		err = txVerifier.Process(nil, &fvm.Context{}, proc, sth, programs.NewEmptyPrograms())
+		err = txVerifier.Process(nil, &fvm.Context{}, proc, stTxn, programs.NewEmptyPrograms())
 		require.Error(t, err)
 
 		// TODO: update to InvalidEnvelopeSignatureError once FVM verifier is updated.

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -24,24 +23,22 @@ import (
 
 func makeTwoAccounts(t *testing.T, aPubKeys []flow.AccountPublicKey, bPubKeys []flow.AccountPublicKey) (flow.Address, flow.Address, *state.StateHolder) {
 
-	ledger := utils.NewSimpleView()
-	sth := state.NewStateHolder(state.NewState(
-		ledger,
-		meter.NewMeter(meter.DefaultParameters()),
+	stTxn := state.NewStateTransaction(
+		utils.NewSimpleView(),
 		state.DefaultParameters(),
-	))
+	)
 
 	a := flow.HexToAddress("1234")
 	b := flow.HexToAddress("5678")
 
 	//create accounts
-	accounts := state.NewAccounts(sth)
+	accounts := state.NewAccounts(stTxn)
 	err := accounts.Create(aPubKeys, a)
 	require.NoError(t, err)
 	err = accounts.Create(bPubKeys, b)
 	require.NoError(t, err)
 
-	return a, b, sth
+	return a, b, stTxn
 }
 
 func TestAccountFreezing(t *testing.T) {
@@ -406,11 +403,10 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
-		accountsService := state.NewAccounts(state.NewStateHolder(state.NewState(
+		accountsService := state.NewAccounts(state.NewStateTransaction(
 			ledger,
-			meter.NewMeter(meter.DefaultParameters()),
 			state.DefaultParameters(),
-		)))
+		))
 
 		frozen, err := accountsService.GetAccountFrozen(address)
 		require.NoError(t, err)
@@ -438,11 +434,10 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 		require.Error(t, tx.Err)
 
-		accountsService = state.NewAccounts(state.NewStateHolder(state.NewState(
+		accountsService = state.NewAccounts(state.NewStateTransaction(
 			ledger,
-			meter.NewMeter(meter.DefaultParameters()),
 			state.DefaultParameters(),
-		)))
+		))
 
 		frozen, err = accountsService.GetAccountFrozen(serviceAddress)
 		require.NoError(t, err)


### PR DESCRIPTION
Also renamed NewStateHolder to NewStateTransaction in preparation for renaming
the struct.