### PR TITLE
[Performance] run computation benchmarks on commit

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,7 +7,9 @@ on:
       - "feature/**"
       - "v[0-9]+.[0-9]+"
     paths:
+      - ".github/workflows/bench.yml"
       - "fvm/**"
+      - "engine/execution/**"
       - "go.sum"
 
 jobs:
@@ -22,28 +24,29 @@ jobs:
         id: settings
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: "^1.18"
+          go-version: "1.18"
+          cache: true
 
       - name: Build relic
         run: make crypto_setup_gopath
 
       - name: Run benchmark on current branch
         run: |
-          (for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./fvm --bench . --tags relic -shuffle=on --benchmem --run ^$; done) | tee new.txt
+          (for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./fvm ./engine/execution/computation --bench . --tags relic -shuffle=on --benchmem --run ^$; done) | tee new.txt
 
       - name: Checkout base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
 
       - name: Run benchmark on base branch
         run: |
-          (for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./fvm --bench . --tags relic -shuffle=on --benchmem --run ^$; done) | tee old.txt
+          (for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./fvm ./engine/execution/computation --bench . --tags relic -shuffle=on --benchmem --run ^$; done) | tee old.txt
 
       # see https://trstringer.com/github-actions-multiline-strings/ to see why this part is complex
       - name: Use benchstat for comparison
@@ -72,9 +75,7 @@ jobs:
 
             This branch with compared with the base branch ${{  github.event.pull_request.base.label }} commit ${{ github.event.pull_request.base.sha }}
 
-            The command `(for i in {1..N}; do go test ./fvm --bench . --tags relic -shuffle=on --benchmem --run ^$; done)` was used.
-
-            Bench tests were run a total of ${{ steps.settings.outputs.benchmark_repetitions }} times on each branch.
+            The command `(for i in {1..${{ steps.settings.outputs.benchmark_repetitions }}}; do go test ./fvm ./engine/execution/computation --bench . --tags relic -shuffle=on --benchmem --run ^$; done)` was used.
 
             <details>
             <summary>Collapsed results for better readability</summary>


### PR DESCRIPTION
This diff:
* Adds `BenchmarkComputeBlock` from `./engine/execution/computation` to the auto-benchstat
* Switches from the `^1.18` (i.e. >= `1.18` < `2.0`) to stricter `1.18`.  This unbreaks benchmark w/ go 1.19 release.
* Adds `.github/workflows/bench.yml` itself to the set of files being tracked.

While here, bump checkout and setup-go versions, and cleanup the comment a bit.