### PR TITLE
[Performance] initialize profiler after the state init

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1364,8 +1364,6 @@ func (fnb *FlowNodeBuilder) onStart() error {
 
 	fnb.initLogger()
 
-	fnb.initProfiler()
-
 	fnb.initDB()
 	fnb.initSecretsDB()
 
@@ -1380,6 +1378,8 @@ func (fnb *FlowNodeBuilder) onStart() error {
 	}
 
 	fnb.initState()
+
+	fnb.initProfiler()
 
 	fnb.initFvmOptions()
 


### PR DESCRIPTION
Profiler is using `fnb.RootChainID` which is initialized in `initState`.

This leads to servicename being `unknown-execution` instead of `devnet-execution`.

Fixes: #2903