### PR TITLE
[Networking] Fix gzip stream closer

### DIFF
--- a/network/p2p/compressed/compressedStream.go
+++ b/network/p2p/compressed/compressedStream.go
@@ -74,6 +74,7 @@ func (c *compressedStream) Read(b []byte) (int, error) {
 func (c *compressedStream) Close() error {
 	c.writeLock.Lock()
 	defer c.writeLock.Unlock()
+	defer c.w.Close()
 
 	return c.Stream.Close()
 }

--- a/network/p2p/compressed/compressedStream.go
+++ b/network/p2p/compressed/compressedStream.go
@@ -75,5 +75,5 @@ func (c *compressedStream) Close() error {
 	c.writeLock.Lock()
 	defer c.writeLock.Unlock()
 
-	return multierr.Combine(c.w.Close(), c.Stream.Close())
+	return c.Stream.Close()
 }


### PR DESCRIPTION
With new upgrades, closing a stream also closes the writer side. So there is no need to report the writer returned error. Still closing writer on a defer to clean up resources. 