### PR TITLE
[Testing] Enable Lint for ./crypto and ./integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,42 +24,58 @@ concurrency:
 
 jobs:
   golangci:
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: [./, ./integration/, ./crypto/]
     name: Lint
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Checkout repo
-      uses: actions/checkout@v2
+        cache: true
     - name: Build relic
       run: make crypto_setup_gopath
+    - name: Run go generate
+      run: go generate
+      working-directory: ${{ matrix.dir }}
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.46
-        args: -v --build-tags relic
+        args: -v --build-tags relic --timeout=10m
+        working-directory: ${{ matrix.dir }}
         # https://github.com/golangci/golangci-lint-action/issues/244
-        skip-pkg-cache: true
-        # Make sure we get accurate results
-        # Some of these may be needed if observer code is integrated: only-new-issues: true, skip-build-cache: true
+        skip-cache: true
+
+  shell-check:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      uses: ludeeus/action-shellcheck@203a3fd018dfe73f8ae7e3aa8da2c149a5f41c33
       with:
         scandir: './crypto'
         ignore: 'relic'
+
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Checkout repo
-      uses: actions/checkout@v2
+        cache: true
     - name: Run tests
       if: github.actor != 'bors[bot]'
       run: make ci
@@ -71,7 +87,7 @@ jobs:
         max_attempts: 3
         command: make ci
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.txt
         flags: unittests
@@ -97,12 +113,13 @@ jobs:
       TEST_CATEGORY: ${{ matrix.test-category }}
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Checkout repo
-      uses: actions/checkout@v2
+        cache: true
     - name: Build relic
       run: make crypto_setup_gopath
     - name: Docker build
@@ -117,18 +134,20 @@ jobs:
         timeout_minutes: 15
         max_attempts: 2
         command: ./tools/test_monitor/run-tests.sh
+
   localnet-test:
     name: Localnet Compatibility Tests With Flow-CLI Client and Observer
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
     - name: Setup Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Checkout repo
-      uses: actions/checkout@v2
+        cache: true
     - name: Build relic and other tools
       run: make install-tools
     - name: Install Flow Client In Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.46
-        args: -v --build-tags relic --timeout=10m
+        args: -v --build-tags relic
         working-directory: ${{ matrix.dir }}
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
 
 linters-settings:
   goimports:

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,9 @@
 # for why we need to explicitly list all statuses
 
 status = [
-  "Lint",
+  "Lint (./)",
+  "Lint (./integration/)",
+  "Lint (./crypto/)",
   "Unit Tests",
   "Integration Tests (integration-mvp)",
   "Integration Tests (integration-ghost)",

--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 
 	"github.com/btcsuite/btcd/btcec"
+
 	"github.com/onflow/flow-go/crypto/hash"
 )
 
@@ -26,7 +27,8 @@ type ecdsaAlgo struct {
 	algo SigningAlgorithm
 }
 
-//  ECDSA contexts for each supported curve
+// ECDSA contexts for each supported curve
+//
 // NIST P-256 curve
 var p256Instance *ecdsaAlgo
 


### PR DESCRIPTION
Main change is enabled linting in sub-packages: `integration` and `crypto`.

While here:
* bumped `actions/setup-go` and `actions/checkout` to v3.
* bumped timeout for golangci to 10m due to recently increased failure rate.
* pin `shellcheck` to `203a3fd018dfe73f8ae7e3aa8da2c149a5f41c33` and move it out of `golangci`.
* moved shellcheck to a separate step.
* run `go generate` before ci lint.
* enable caching for go builds.
* checkout before setup go: caching depends on go.mod being available.

Depends on: #2970 #3007