### PR TITLE
Cancel previous workflows on the same PR

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,10 @@ on:
       - "engine/execution/**"
       - "go.sum"
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   benchstat:
     name: Performance regression check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ on:
 env:
   GO_VERSION: 1.18
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   golangci:
     name: Lint

--- a/.github/workflows/flaky-test-monitor-integration.yml
+++ b/.github/workflows/flaky-test-monitor-integration.yml
@@ -14,6 +14,10 @@ on:
 env:
   GO_VERSION: 1.18
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   generate-flaky-test-summary:
     name: Generate Flaky Test Summary

--- a/.github/workflows/flaky-test-monitor.yml
+++ b/.github/workflows/flaky-test-monitor.yml
@@ -12,6 +12,10 @@ env:
   BIGQUERY_TABLE: test_results
   GO_VERSION: 1.18
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   upload-flaky-test-summary:
     name: Upload Flaky Test Summary

--- a/.github/workflows/skipped-test-tracker-integration.yml
+++ b/.github/workflows/skipped-test-tracker-integration.yml
@@ -12,6 +12,10 @@ on:
 env:
   GO_VERSION: 1.18
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   generate-skipped-test-summary:
     name: Generate Skipped Test Summary

--- a/.github/workflows/skipped-test-tracker.yml
+++ b/.github/workflows/skipped-test-tracker.yml
@@ -10,6 +10,10 @@ env:
   BIGQUERY_TABLE: skipped_tests
   GO_VERSION: 1.18
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   upload-skipped-test-summary:
     name: Upload Skipped Test Summary


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/using-concurrency

Update the actions that are typically run on PRs to cancel themselves if a new commit has been made to that PR