### PR TITLE
add admin tool for triggering checkpoint

### DIFF
--- a/admin/commands/execution/checkpoint_trigger.go
+++ b/admin/commands/execution/checkpoint_trigger.go
@@ -1,0 +1,39 @@
+package execution
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	"go.uber.org/atomic"
+
+	"github.com/onflow/flow-go/admin"
+	"github.com/onflow/flow-go/admin/commands"
+)
+
+var _ commands.AdminCommand = (*TriggerCheckpointCommand)(nil)
+
+// TriggerCheckpointCommand will send a signal to compactor to trigger checkpoint
+// once finishing writing the current WAL segment file
+type TriggerCheckpointCommand struct {
+	trigger *atomic.Bool
+}
+
+func NewTriggerCheckpointCommand(trigger *atomic.Bool) *TriggerCheckpointCommand {
+	return &TriggerCheckpointCommand{
+		trigger: trigger,
+	}
+}
+
+func (s *TriggerCheckpointCommand) Handler(ctx context.Context, req *admin.CommandRequest) (interface{}, error) {
+	if s.trigger.CAS(false, true) {
+		log.Info().Msgf("admintool: trigger checkpoint as soon as finishing writing the current segment file. you can find log about 'compactor' to check the checkpointing progress")
+	} else {
+		log.Info().Msgf("admintool: checkpoint is already set to be triggered")
+	}
+
+	return "ok", nil
+}
+
+func (s *TriggerCheckpointCommand) Validator(req *admin.CommandRequest) error {
+	return nil
+}

--- a/cmd/bootstrap/run/execution_state.go
+++ b/cmd/bootstrap/run/execution_state.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/rs/zerolog"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
@@ -56,7 +57,7 @@ func GenerateExecutionState(
 		return flow.DummyStateCommitment, err
 	}
 
-	compactor, err := complete.NewCompactor(ledgerStorage, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+	compactor, err := complete.NewCompactor(ledgerStorage, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	if err != nil {
 		return flow.DummyStateCommitment, err
 	}

--- a/cmd/util/cmd/exec-data-json-export/ledger_exporter.go
+++ b/cmd/util/cmd/exec-data-json-export/ledger_exporter.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -33,7 +34,8 @@ func ExportLedger(ledgerPath string, targetstate string, outputPath string) erro
 	if err != nil {
 		return fmt.Errorf("cannot create ledger from write-a-head logs and checkpoints: %w", err)
 	}
-	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), complete.DefaultCacheSize, checkpointDistance, checkpointsToKeep)
+
+	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), complete.DefaultCacheSize, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	if err != nil {
 		return fmt.Errorf("cannot create compactor: %w", err)
 	}

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/rs/zerolog"
+	"go.uber.org/atomic"
 
 	mgr "github.com/onflow/flow-go/cmd/util/ledger/migrations"
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
@@ -59,7 +60,8 @@ func extractExecutionState(
 		checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
 		checkpointsToKeep  = 1
 	)
-	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), complete.DefaultCacheSize, checkpointDistance, checkpointsToKeep)
+
+	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), complete.DefaultCacheSize, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	if err != nil {
 		return fmt.Errorf("cannot create compactor: %w", err)
 	}

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/ledger"
@@ -90,7 +91,7 @@ func TestExtractExecutionState(t *testing.T) {
 			require.NoError(t, err)
 			f, err := complete.NewLedger(diskWal, size*10, metr, zerolog.Nop(), complete.DefaultPathFinderVersion)
 			require.NoError(t, err)
-			compactor, err := complete.NewCompactor(f, diskWal, zerolog.Nop(), uint(size), checkpointDistance, checkpointsToKeep)
+			compactor, err := complete.NewCompactor(f, diskWal, zerolog.Nop(), uint(size), checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 			require.NoError(t, err)
 			<-compactor.Ready()
 
@@ -166,7 +167,7 @@ func TestExtractExecutionState(t *testing.T) {
 						checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
 						checkpointsToKeep  = 1
 					)
-					compactor, err := complete.NewCompactor(storage, diskWal, zerolog.Nop(), uint(size), checkpointDistance, checkpointsToKeep)
+					compactor, err := complete.NewCompactor(storage, diskWal, zerolog.Nop(), uint(size), checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 					require.NoError(t, err)
 
 					<-compactor.Ready()

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/consensus"
 	"github.com/onflow/flow-go/consensus/hotstuff"
@@ -521,7 +522,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 	ls, err := completeLedger.NewLedger(diskWal, capacity, metricsCollector, node.Log.With().Str("compontent", "ledger").Logger(), completeLedger.DefaultPathFinderVersion)
 	require.NoError(t, err)
 
-	compactor, err := completeLedger.NewCompactor(ls, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+	compactor, err := completeLedger.NewCompactor(ls, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	require.NoError(t, err)
 
 	<-compactor.Ready() // Need to start compactor here because BootstrapLedger() updates ledger state.

--- a/ledger/complete/compactor.go
+++ b/ledger/complete/compactor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"go.uber.org/atomic"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/onflow/flow-go/ledger"
@@ -45,16 +46,17 @@ type checkpointResult struct {
 // This will be resolved automaticaly after the forest LRU Cache
 // (code outside checkpointing) is replaced by something like a FIFO queue.
 type Compactor struct {
-	checkpointer       *realWAL.Checkpointer
-	wal                realWAL.LedgerWAL
-	trieQueue          *realWAL.TrieQueue
-	logger             zerolog.Logger
-	lm                 *lifecycle.LifecycleManager
-	observers          map[observable.Observer]struct{}
-	checkpointDistance uint
-	checkpointsToKeep  uint
-	stopCh             chan chan struct{}
-	trieUpdateCh       <-chan *WALTrieUpdate
+	checkpointer                         *realWAL.Checkpointer
+	wal                                  realWAL.LedgerWAL
+	trieQueue                            *realWAL.TrieQueue
+	logger                               zerolog.Logger
+	lm                                   *lifecycle.LifecycleManager
+	observers                            map[observable.Observer]struct{}
+	checkpointDistance                   uint
+	checkpointsToKeep                    uint
+	stopCh                               chan chan struct{}
+	trieUpdateCh                         <-chan *WALTrieUpdate
+	triggerCheckpointOnNextSegmentFinish *atomic.Bool // to trigger checkpoint manually
 }
 
 // NewCompactor creates new Compactor which writes WAL record and triggers
@@ -73,6 +75,7 @@ func NewCompactor(
 	checkpointCapacity uint,
 	checkpointDistance uint,
 	checkpointsToKeep uint,
+	triggerCheckpointOnNextSegmentFinish *atomic.Bool,
 ) (*Compactor, error) {
 	if checkpointDistance < 1 {
 		checkpointDistance = 1
@@ -100,16 +103,17 @@ func NewCompactor(
 	trieQueue := realWAL.NewTrieQueueWithValues(checkpointCapacity, tries)
 
 	return &Compactor{
-		checkpointer:       checkpointer,
-		wal:                w,
-		trieQueue:          trieQueue,
-		logger:             logger,
-		stopCh:             make(chan chan struct{}),
-		trieUpdateCh:       trieUpdateCh,
-		observers:          make(map[observable.Observer]struct{}),
-		lm:                 lifecycle.NewLifecycleManager(),
-		checkpointDistance: checkpointDistance,
-		checkpointsToKeep:  checkpointsToKeep,
+		checkpointer:                         checkpointer,
+		wal:                                  w,
+		trieQueue:                            trieQueue,
+		logger:                               logger,
+		stopCh:                               make(chan chan struct{}),
+		trieUpdateCh:                         trieUpdateCh,
+		observers:                            make(map[observable.Observer]struct{}),
+		lm:                                   lifecycle.NewLifecycleManager(),
+		checkpointDistance:                   checkpointDistance,
+		checkpointsToKeep:                    checkpointsToKeep,
+		triggerCheckpointOnNextSegmentFinish: triggerCheckpointOnNextSegmentFinish,
 	}, nil
 }
 
@@ -220,6 +224,19 @@ Loop:
 				continue
 			}
 
+			// listen to signals from admin tool in order to trigger a checkpoint when the current segment file is finished
+			if c.triggerCheckpointOnNextSegmentFinish.CAS(true, false) {
+				// sanity checking, usually the nextCheckpointNum is a segment number in the future that when the activeSegmentNum
+				// finishes and reaches the nextCheckpointNum, then checkpoint will be triggered.
+				if nextCheckpointNum >= activeSegmentNum {
+					originalNextCheckpointNum := nextCheckpointNum
+					nextCheckpointNum = activeSegmentNum
+					c.logger.Info().Msgf("compactor will trigger once finish writing segment %v, originalNextCheckpointNum: %v", nextCheckpointNum, originalNextCheckpointNum)
+				} else {
+					c.logger.Warn().Msgf("could not force triggering checkpoint, nextCheckpointNum %v is smaller than activeSegmentNum %v", nextCheckpointNum, activeSegmentNum)
+				}
+			}
+
 			var checkpointNum int
 			var checkpointTries []*trie.MTrie
 			activeSegmentNum, checkpointNum, checkpointTries =
@@ -310,7 +327,7 @@ func (c *Compactor) checkpoint(ctx context.Context, tries []*trie.MTrie, checkpo
 // Caller should handle returned errors by retrying checkpointing when appropriate.
 func createCheckpoint(checkpointer *realWAL.Checkpointer, logger zerolog.Logger, tries []*trie.MTrie, checkpointNum int) error {
 
-	logger.Info().Msgf("serializing checkpoint %d", checkpointNum)
+	logger.Info().Msgf("serializing checkpoint %d with %v tries", checkpointNum, len(tries))
 
 	startTime := time.Now()
 
@@ -419,6 +436,9 @@ func (c *Compactor) processTrieUpdate(
 	// Update activeSegmentNum
 	prevSegmentNum := activeSegmentNum
 	activeSegmentNum = segmentNum
+
+	c.logger.Info().Msgf("finish writing segment file %v, trie update is writing to segment file %v, checkpoint will trigger when segment %v is finished",
+		prevSegmentNum, activeSegmentNum, nextCheckpointNum)
 
 	if nextCheckpointNum > prevSegmentNum {
 		// Not enough segments for checkpointing

--- a/ledger/complete/compactor_test.go
+++ b/ledger/complete/compactor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/testutils"
@@ -33,9 +34,10 @@ type CompactorObserver struct {
 func (co *CompactorObserver) OnNext(val interface{}) {
 	res, ok := val.(int)
 	if ok {
-		new := res
-		fmt.Printf("Compactor observer received checkpoint num %d\n", new)
-		if new >= co.fromBound {
+		newCheckpoint := res
+		fmt.Printf("Compactor observer received checkpoint num %d, will stop when checkpoint num (%v) >= %v\n",
+			newCheckpoint, newCheckpoint, co.fromBound)
+		if newCheckpoint >= co.fromBound {
 			co.done <- struct{}{}
 		}
 	}
@@ -80,7 +82,7 @@ func TestCompactor(t *testing.T) {
 			// WAL segments are 32kB, so here we generate 2 keys 64kB each, times `size`
 			// so we should get at least `size` segments
 
-			compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep)
+			compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 			require.NoError(t, err)
 
 			co := CompactorObserver{fromBound: 8, done: make(chan struct{})}
@@ -281,7 +283,7 @@ func TestCompactorSkipCheckpointing(t *testing.T) {
 		// WAL segments are 32kB, so here we generate 2 keys 64kB each, times `size`
 		// so we should get at least `size` segments
 
-		compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep)
+		compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 		require.NoError(t, err)
 
 		co := CompactorObserver{fromBound: 8, done: make(chan struct{})}
@@ -401,7 +403,7 @@ func TestCompactorAccuracy(t *testing.T) {
 			l, err := NewLedger(wal, forestCapacity, metricsCollector, zerolog.Logger{}, DefaultPathFinderVersion)
 			require.NoError(t, err)
 
-			compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep)
+			compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 			require.NoError(t, err)
 
 			fromBound := lastCheckpointNum + (size / 2)
@@ -479,6 +481,98 @@ func TestCompactorAccuracy(t *testing.T) {
 	})
 }
 
+// TestCompactorTriggeredByAdminTool tests that the compactor will listen to the signal from admin tool
+// to trigger checkpoint when current segment file is finished.
+func TestCompactorTriggeredByAdminTool(t *testing.T) {
+
+	const (
+		numInsPerStep      = 2 // the number of payloads in each trie update
+		pathByteSize       = 32
+		minPayloadByteSize = 2<<11 - 256 // 3840 bytes
+		maxPayloadByteSize = 2 << 11     // 4096 bytes
+		size               = 20
+		checkpointDistance = 5   // create checkpoint on every 5 segment files
+		checkpointsToKeep  = 0   // keep all
+		forestCapacity     = 500 // the number of tries to be included in a checkpoint file
+	)
+
+	metricsCollector := &metrics.NoopCollector{}
+
+	unittest.RunWithTempDir(t, func(dir string) {
+
+		rootHash := trie.EmptyTrieRootHash()
+
+		// Create DiskWAL and Ledger repeatedly to test rebuilding ledger state at restart.
+
+		wal, err := realWAL.NewDiskWAL(unittest.LoggerWithName("wal"), nil, metrics.NewNoopCollector(), dir, forestCapacity, pathByteSize, 32*1024)
+		require.NoError(t, err)
+
+		l, err := NewLedger(wal, forestCapacity, metricsCollector, unittest.LoggerWithName("ledger"), DefaultPathFinderVersion)
+		require.NoError(t, err)
+
+		compactor, err := NewCompactor(l, wal, unittest.LoggerWithName("compactor"), forestCapacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(true))
+		require.NoError(t, err)
+
+		fmt.Println("should stop as soon as segment 5 is generated, which should trigger checkpoint 5 to be created")
+		fmt.Println("note checkpoint 0 will be be notified to the CompactorObserver because checkpoint 0 is the root checkpoint")
+		fmt.Println("Why fromBound =5? because without forcing checkpoint to trigger, it won't trigger until segment 4 is finished, with ")
+		fmt.Println("forcing checkpoint to trigger, it will trigger when segment 0 and 5 is finished")
+		fromBound := 5
+
+		co := CompactorObserver{fromBound: fromBound, done: make(chan struct{})}
+		compactor.Subscribe(&co)
+
+		// Run Compactor in background.
+		<-compactor.Ready()
+
+		fmt.Println("generate the tree and create WAL")
+		fmt.Println("2 trie updates will fill a segment file, and 12 trie updates will fill 6 segment files")
+		fmt.Println("13 trie updates in total will trigger segment 5 to be finished, which should trigger checkpoint 5")
+		for i := 0; i < 13; i++ {
+
+			payloads := testutils.RandomPayloads(numInsPerStep, minPayloadByteSize, maxPayloadByteSize)
+
+			keys := make([]ledger.Key, len(payloads))
+			values := make([]ledger.Value, len(payloads))
+			for i, p := range payloads {
+				k, err := p.Key()
+				require.NoError(t, err)
+				keys[i] = k
+				values[i] = p.Value()
+			}
+
+			update, err := ledger.NewUpdate(ledger.State(rootHash), keys, values)
+			require.NoError(t, err)
+
+			newState, _, err := l.Set(update)
+			require.NoError(t, err)
+
+			rootHash = ledger.RootHash(newState)
+		}
+
+		// wait for the bound-checking observer to confirm checkpoints have been made
+		select {
+		case <-co.done:
+			// continue
+		case <-time.After(60 * time.Second):
+			assert.FailNow(t, "timed out")
+		}
+
+		// Shutdown ledger and compactor
+		<-l.Done()
+		<-compactor.Done()
+
+		checkpointer, err := wal.NewCheckpointer()
+		require.NoError(t, err)
+
+		nums, err := checkpointer.Checkpoints()
+		require.NoError(t, err)
+		// 0 is the first checkpoint triggered because of the force triggering
+		// 5 is triggered after 4 segments are filled.
+		require.Equal(t, []int{0, 5}, nums)
+	})
+}
+
 // TestCompactorConcurrency expects checkpointed tries to
 // match replayed tries in sequence with concurrent updates.
 // Replayed tries are tries updated by replaying all WAL segments
@@ -517,7 +611,7 @@ func TestCompactorConcurrency(t *testing.T) {
 		l, err := NewLedger(wal, forestCapacity, metricsCollector, zerolog.Logger{}, DefaultPathFinderVersion)
 		require.NoError(t, err)
 
-		compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep)
+		compactor, err := NewCompactor(l, wal, zerolog.Nop(), forestCapacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 		require.NoError(t, err)
 
 		fromBound := lastCheckpointNum + (size / 2 * numGoroutine)

--- a/ledger/complete/ledger_benchmark_test.go
+++ b/ledger/complete/ledger_benchmark_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -52,7 +53,7 @@ func benchmarkStorage(steps int, b *testing.B) {
 	led, err := complete.NewLedger(diskWal, steps+1, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 	require.NoError(b, err)
 
-	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), uint(steps+1), checkpointDistance, checkpointsToKeep)
+	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), uint(steps+1), checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	require.NoError(b, err)
 
 	<-compactor.Ready()
@@ -171,7 +172,7 @@ func BenchmarkTrieUpdate(b *testing.B) {
 	led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 	require.NoError(b, err)
 
-	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	require.NoError(b, err)
 
 	<-compactor.Ready()
@@ -229,7 +230,7 @@ func BenchmarkTrieRead(b *testing.B) {
 	led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 	require.NoError(b, err)
 
-	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	require.NoError(b, err)
 
 	<-compactor.Ready()
@@ -296,7 +297,7 @@ func BenchmarkLedgerGetOneValue(b *testing.B) {
 	led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 	require.NoError(b, err)
 
-	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	require.NoError(b, err)
 
 	<-compactor.Ready()
@@ -380,7 +381,7 @@ func BenchmarkTrieProve(b *testing.B) {
 	led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 	require.NoError(b, err)
 
-	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+	compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 	require.NoError(b, err)
 
 	<-compactor.Ready()

--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -513,7 +514,7 @@ func Test_WAL(t *testing.T) {
 		led, err := complete.NewLedger(diskWal, size, metricsCollector, logger, complete.DefaultPathFinderVersion)
 		require.NoError(t, err)
 
-		compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), size, checkpointDistance, checkpointsToKeep)
+		compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), size, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 		require.NoError(t, err)
 
 		<-compactor.Ready()
@@ -550,7 +551,7 @@ func Test_WAL(t *testing.T) {
 		led2, err := complete.NewLedger(diskWal2, size+10, metricsCollector, logger, complete.DefaultPathFinderVersion)
 		require.NoError(t, err)
 
-		compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), uint(size), checkpointDistance, checkpointsToKeep)
+		compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), uint(size), checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 		require.NoError(t, err)
 
 		<-compactor2.Ready()
@@ -613,7 +614,7 @@ func TestLedgerFunctionality(t *testing.T) {
 			require.NoError(t, err)
 			led, err := complete.NewLedger(diskWal, activeTries, metricsCollector, logger, complete.DefaultPathFinderVersion)
 			assert.NoError(t, err)
-			compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), uint(activeTries), checkpointDistance, checkpointsToKeep)
+			compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), uint(activeTries), checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 			require.NoError(t, err)
 			<-compactor.Ready()
 
@@ -724,7 +725,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				require.NoError(t, err)
 				led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 				require.NoError(t, err)
-				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 				require.NoError(t, err)
 				<-compactor.Ready()
 
@@ -743,7 +744,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				require.NoError(t, err)
 				led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 				require.NoError(t, err)
-				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 				require.NoError(t, err)
 				<-compactor2.Ready()
 
@@ -782,7 +783,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				require.NoError(t, err)
 				led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 				require.NoError(t, err)
-				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 				require.NoError(t, err)
 				<-compactor.Ready()
 
@@ -800,7 +801,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				require.NoError(t, err)
 				led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 				require.NoError(t, err)
-				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 				require.NoError(t, err)
 				<-compactor2.Ready()
 
@@ -838,7 +839,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				require.NoError(t, err)
 				led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 				require.NoError(t, err)
-				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 				require.NoError(t, err)
 				<-compactor.Ready()
 
@@ -856,7 +857,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				require.NoError(t, err)
 				led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 				require.NoError(t, err)
-				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 				require.NoError(t, err)
 				<-compactor2.Ready()
 
@@ -904,7 +905,7 @@ func TestWALUpdateFailuresBubbleUp(t *testing.T) {
 		led, err := complete.NewLedger(w, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
 		require.NoError(t, err)
 
-		compactor, err := complete.NewCompactor(led, w, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep)
+		compactor, err := complete.NewCompactor(led, w, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 		require.NoError(t, err)
 
 		<-compactor.Ready()

--- a/ledger/complete/wal/checkpointer_test.go
+++ b/ledger/complete/wal/checkpointer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -62,7 +63,7 @@ func Test_WAL(t *testing.T) {
 		led, err := complete.NewLedger(diskWal, size*10, metricsCollector, logger, complete.DefaultPathFinderVersion)
 		require.NoError(t, err)
 
-		compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), size, checkpointDistance, checkpointsToKeep)
+		compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), size, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
 		require.NoError(t, err)
 
 		<-compactor.Ready()

--- a/utils/unittest/logging.go
+++ b/utils/unittest/logging.go
@@ -43,6 +43,10 @@ func LoggerWithLevel(level zerolog.Level) zerolog.Logger {
 	return LoggerWithWriterAndLevel(os.Stderr, level)
 }
 
+func LoggerWithName(mod string) zerolog.Logger {
+	return Logger().With().Str("module", mod).Logger()
+}
+
 func NewLoggerHook() LoggerHook {
 	return LoggerHook{
 		logs: &strings.Builder{},


### PR DESCRIPTION
This PR adds an admintool to force checkpoint to be triggered as soon as finish writing the current segment WAL file.