### PR TITLE
[Testing] Add proper mock-based TxFollower tests

### DIFF
--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -28,10 +28,6 @@ type TxFollower interface {
 
 type followerOption func(f *txFollowerImpl)
 
-func WithBlockHeight(height uint64) followerOption {
-	return func(f *txFollowerImpl) { f.height = height }
-}
-
 func WithLogger(logger zerolog.Logger) followerOption {
 	return func(f *txFollowerImpl) { f.logger = logger }
 }
@@ -91,13 +87,11 @@ func NewTxFollower(ctx context.Context, client access.Client, opts ...followerOp
 		opt(f)
 	}
 
-	if f.height == 0 {
-		hdr, err := client.GetLatestBlockHeader(newCtx, false)
-		if err != nil {
-			return nil, err
-		}
-		f.updateFromBlockHeader(*hdr)
+	hdr, err := client.GetLatestBlockHeader(newCtx, false)
+	if err != nil {
+		return nil, err
 	}
+	f.updateFromBlockHeader(*hdr)
 
 	go f.run()
 

--- a/integration/benchmark/follower_test.go
+++ b/integration/benchmark/follower_test.go
@@ -2,65 +2,96 @@ package benchmark
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	flowsdk "github.com/onflow/flow-go-sdk"
+	mockClient "github.com/onflow/flow-go/integration/benchmark/mock"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-// TestTxFollower creates new follower with a fixed block height and stops it.
+// TestTxFollower creates new follower and stops it.
 func TestTxFollower(t *testing.T) {
-	// TODO(rbtz): test against a mock client, but for now we just expire
-	// the context so that the followere wont be able to progress.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	t.Parallel()
+
+	client := mockClient.NewClient(t)
+
+	blockHeight := uint64(2)
+	blockID := flowsdk.Identifier{0x1}
+	client.On("GetLatestBlockHeader", mock.Anything, mock.Anything).Return(&flowsdk.BlockHeader{ID: blockID, Height: blockHeight}, nil).Once()
+
+	nextBlockID := flowsdk.Identifier{0x6}
+	nextBlockHeight := blockHeight + 1
+	collectionID := flowsdk.Identifier{0x3}
+	client.On("GetBlockByHeight", mock.Anything, nextBlockHeight).Return(
+		&flowsdk.Block{
+			BlockHeader: flowsdk.BlockHeader{ID: nextBlockID, Height: nextBlockHeight},
+			BlockPayload: flowsdk.BlockPayload{
+				CollectionGuarantees: []*flowsdk.CollectionGuarantee{{CollectionID: collectionID}},
+			},
+		}, nil).Once()
+
+	transactionID := flowsdk.Identifier{0x2}
+	client.On("GetCollection", mock.Anything, collectionID).Return(
+		&flowsdk.Collection{
+			TransactionIDs: []flowsdk.Identifier{{0x98}, transactionID, {0x99}},
+		}, nil).Once()
+
+	client.On("GetBlockByHeight", mock.Anything, mock.Anything).Return(nil, errors.New("not found"))
 
 	f, err := NewTxFollower(
-		ctx,
-		nil,
-		WithBlockHeight(2),
-		WithInteval(1*time.Hour),
+		context.Background(),
+		client,
+		WithInteval(100*time.Millisecond),
 	)
 	require.NoError(t, err)
-	f.Stop()
-}
 
-// TestTxFollowerFollowAfterStop creates new follower with a fixed block height and stops it.
-func TestTxFollowerFollowAfterStop(t *testing.T) {
-	// TODO(rbtz): test against a mock client, but for now we just expire
-	// the context so that the followere wont be able to progress.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	// test that follower fetched the latest block header
+	require.EqualValues(t, blockHeight, f.Height())
+	require.Equal(t, blockID, f.BlockID())
 
-	f, err := NewTxFollower(
-		ctx,
-		nil,
-		WithBlockHeight(2),
-		WithInteval(1*time.Hour),
-	)
-	require.NoError(t, err)
+	// test that transactionID is eventually discovered
+	unittest.AssertClosesBefore(t, f.Follow(transactionID), 1*time.Second)
+	// test that random transaction is not found
+	unittest.AssertNotClosesBefore(t, f.Follow(flowsdk.Identifier{0x7}), 200*time.Millisecond)
+
+	// once transactionID is discovered, block height should be updated
+	require.EqualValues(t, nextBlockHeight, f.Height())
+	require.Equal(t, nextBlockID, f.BlockID())
+
+	// test that multiple Stops are safe
 	f.Stop()
+	f.Stop()
+
+	// test that all further Follow calls return immediately
+	unittest.AssertClosesBefore(t, f.Follow(transactionID), 1*time.Second)
 	unittest.AssertClosesBefore(t, f.Follow(flowsdk.Identifier{}), 1*time.Second)
 }
 
-// TestNopTxFollower creates a new follower with a fixed block height and
-// verifies that it does not block.
+// TestNopTxFollower creates a new follower and verifies that it does not block.
 func TestNopTxFollower(t *testing.T) {
-	// TODO(rbtz): test against a mock client, but for now we just expire
-	// the context so that the followere wont be able to progress.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	t.Parallel()
+
+	client := mockClient.NewClient(t)
+	client.On("GetLatestBlockHeader", mock.Anything, mock.Anything).Return(&flowsdk.BlockHeader{}, nil).Once()
+	client.On("GetBlockByHeight", mock.Anything, mock.Anything).Return(nil, errors.New("not found")).Maybe()
 
 	f, err := NewNopTxFollower(
-		ctx,
-		nil,
-		WithBlockHeight(1),
+		context.Background(),
+		client,
 		WithInteval(1*time.Hour),
 	)
 	require.NoError(t, err)
 	unittest.AssertClosesBefore(t, f.Follow(flowsdk.Identifier{}), 1*time.Second)
+
+	// test that multiple Stops are safe
 	f.Stop()
+	f.Stop()
+
+	// test that all further Follow calls return immediately
+	unittest.AssertClosesBefore(t, f.Follow(flowsdk.Identifier{}), 1*time.Second)
 }


### PR DESCRIPTION
This fixes a bunch of TODOs that were complaining that tests were mostly noops.

While here, also remove the `WithBlockHeight` option: it is unused and testing showed that it was broken.