### PR TITLE
[FVM] Fix transactions with low gas

### DIFF
--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -326,7 +326,7 @@ func BytesToCadenceArray(l []byte) cadence.Array {
 // CreateAccountCreationTransaction creates a transaction which will create a new account.
 //
 // This function returns a randomly generated private key and the transaction.
-func CreateAccountCreationTransaction(t *testing.T, chain flow.Chain) (flow.AccountPrivateKey, *flow.TransactionBody) {
+func CreateAccountCreationTransaction(t testing.TB, chain flow.Chain) (flow.AccountPrivateKey, *flow.TransactionBody) {
 	accountKey, err := GenerateAccountPrivateKey()
 	require.NoError(t, err)
 	encPublicKey := accountKey.PublicKey(1000).PublicKey.Encode()

--- a/fvm/errors/errors.go
+++ b/fvm/errors/errors.go
@@ -69,7 +69,7 @@ func HandleRuntimeError(err error) error {
 	// if is not a runtime error return as vm error
 	// this should never happen unless a bug in the code
 	if runErr, ok = err.(runtime.Error); !ok {
-		return NewUnknownFailure(runErr)
+		return NewUnknownFailure(err)
 	}
 
 	// External errors are reported by the runtime but originate from the VM.

--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -27,8 +27,8 @@ func getExecutionWeights[KindType common.ComputationKind | common.MemoryKind](
 	)
 
 	if err != nil {
-		// this might be fatal, return as is
-		return nil, err
+		// this might be fatal, handle it and return it
+		return nil, errors.HandleRuntimeError(err)
 	}
 
 	weightsRaw, ok := utils.CadenceValueToWeights(value)

--- a/fvm/executionParameters_test.go
+++ b/fvm/executionParameters_test.go
@@ -77,7 +77,7 @@ func TestGetExecutionMemoryWeights(t *testing.T) {
 				})
 			_, err := fvm.GetExecutionMemoryWeights(envMock, address)
 			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
+			require.ErrorIs(t, err, someErr)
 		},
 	)
 	t.Run("return error if get stored returns error",
@@ -89,7 +89,7 @@ func TestGetExecutionMemoryWeights(t *testing.T) {
 				})
 			_, err := fvm.GetExecutionMemoryWeights(envMock, address)
 			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
+			require.ErrorIs(t, err, someErr)
 		},
 	)
 	t.Run("no error if a dictionary is stored",
@@ -209,7 +209,7 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				})
 			_, err := fvm.GetExecutionEffortWeights(envMock, address)
 			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
+			require.ErrorIs(t, err, someErr)
 		},
 	)
 	t.Run("return error if get stored returns error",
@@ -221,7 +221,7 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 				})
 			_, err := fvm.GetExecutionEffortWeights(envMock, address)
 			require.Error(t, err)
-			require.EqualError(t, err, someErr.Error())
+			require.ErrorIs(t, err, someErr)
 		},
 	)
 	t.Run("no error if a dictionary is stored",

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -1,0 +1,262 @@
+package fvm_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+
+	"github.com/onflow/flow-go/engine/execution/testutil"
+	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/meter"
+	"github.com/onflow/flow-go/fvm/programs"
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func FuzzTransactionComputationLimit(f *testing.F) {
+	// setup initial state
+	vmt, tctx := bootstrapFuzzStateAndTxContext(f)
+
+	f.Add(uint64(0), uint(0))
+	f.Add(uint64(5), uint(0))
+	f.Fuzz(func(t *testing.T, computationLimit uint64, transactionType uint) {
+		computationLimit %= flow.DefaultMaxTransactionGasLimit
+		transactionType %= uint(len(fuzzTransactionTypes))
+
+		tt := fuzzTransactionTypes[transactionType]
+
+		vmt.run(func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
+			// create the transaction
+			txBody := tt.createTxBody(t, tctx)
+			// set the computation limit
+			txBody.SetGasLimit(computationLimit)
+
+			// sign the transaction
+			err := testutil.SignEnvelope(
+				txBody,
+				tctx.address,
+				tctx.privateKey,
+			)
+			require.NoError(t, err)
+
+			// run th transaction
+			tx := fvm.Transaction(txBody, 1)
+
+			require.NotPanics(t, func() {
+				err = vm.Run(ctx, tx, view, programs)
+			}, "Transaction should never result in a panic.")
+			require.NoError(t, err, "Transaction should never result in an error.")
+
+			// check if results are expected
+			tt.require(t, tctx, fuzzResults{
+				tx: tx,
+			})
+		})(t)
+	})
+}
+
+type fuzzParameters struct {
+	computationLimit uint64
+}
+
+type fuzzResults struct {
+	tx *fvm.TransactionProcedure
+}
+
+type transactionTypeContext struct {
+	address      flow.Address
+	addressFunds uint64
+	privateKey   flow.AccountPrivateKey
+	chain        flow.Chain
+}
+
+type transactionType struct {
+	parameters   fuzzParameters
+	createTxBody func(t *testing.T, tctx transactionTypeContext) *flow.TransactionBody
+	require      func(t *testing.T, tctx transactionTypeContext, results fuzzResults)
+}
+
+var fuzzTransactionTypes = []transactionType{
+	{
+		createTxBody: func(t *testing.T, tctx transactionTypeContext) *flow.TransactionBody {
+			// token transfer
+			txBody := transferTokensTx(tctx.chain).
+				AddAuthorizer(tctx.address).
+				AddArgument(jsoncdc.MustEncode(cadence.UFix64(0))). // 0 value transferred
+				AddArgument(jsoncdc.MustEncode(cadence.NewAddress(tctx.chain.ServiceAddress())))
+
+			txBody.SetProposalKey(tctx.address, 0, 0)
+			txBody.SetPayer(tctx.address)
+			return txBody
+		},
+		require: func(t *testing.T, tctx transactionTypeContext, results fuzzResults) {
+			// if there is an error, it should be computation exceeded
+			if results.tx.Err != nil {
+				codes := []errors.ErrorCode{
+					errors.ErrCodeComputationLimitExceededError,
+					errors.ErrCodeCadenceRunTimeError,
+				}
+				require.Contains(t, codes, results.tx.Err.Code(), results.tx.Err.Error())
+			}
+
+			// fees should be deducted no matter the input
+			fees, deducted := getDeductedFees(t, tctx, results)
+			require.True(t, deducted, "Fees should be deducted.")
+			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
+		},
+	},
+	{
+		createTxBody: func(t *testing.T, tctx transactionTypeContext) *flow.TransactionBody {
+			// failed token transfer
+			txBody := transferTokensTx(tctx.chain).
+				AddAuthorizer(tctx.address).
+				AddArgument(jsoncdc.MustEncode(cadence.UFix64(2 * tctx.addressFunds))). // too much value transferred
+				AddArgument(jsoncdc.MustEncode(cadence.NewAddress(tctx.chain.ServiceAddress())))
+
+			txBody.SetProposalKey(tctx.address, 0, 0)
+			txBody.SetPayer(tctx.address)
+			return txBody
+		},
+		require: func(t *testing.T, tctx transactionTypeContext, results fuzzResults) {
+			require.Error(t, results.tx.Err)
+			codes := []errors.ErrorCode{
+				errors.ErrCodeComputationLimitExceededError,
+				errors.ErrCodeCadenceRunTimeError, // because of the failed transfer
+			}
+			require.Contains(t, codes, results.tx.Err.Code(), results.tx.Err.Error())
+
+			// fees should be deducted no matter the input
+			fees, deducted := getDeductedFees(t, tctx, results)
+			require.True(t, deducted, "Fees should be deducted.")
+			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
+		},
+	},
+	{
+		createTxBody: func(t *testing.T, tctx transactionTypeContext) *flow.TransactionBody {
+			txBody := flow.NewTransactionBody().SetScript([]byte("transaction(){prepare(){};execute{panic(\"some panic\")}}"))
+			txBody.SetProposalKey(tctx.address, 0, 0)
+			txBody.SetPayer(tctx.address)
+			return txBody
+		},
+		require: func(t *testing.T, tctx transactionTypeContext, results fuzzResults) {
+			require.Error(t, results.tx.Err)
+			codes := []errors.ErrorCode{
+				errors.ErrCodeComputationLimitExceededError,
+				errors.ErrCodeCadenceRunTimeError, // because of the panic
+			}
+			require.Contains(t, codes, results.tx.Err.Code(), results.tx.Err.Error())
+
+			// fees should be deducted no matter the input
+			fees, deducted := getDeductedFees(t, tctx, results)
+			require.True(t, deducted, "Fees should be deducted.")
+			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
+		},
+	},
+}
+
+const fuzzTestsInclusionFees = uint64(1_000)
+
+// checks fee deduction happened and returns the amount of funds deducted
+func getDeductedFees(tb testing.TB, tctx transactionTypeContext, results fuzzResults) (fees cadence.UFix64, deducted bool) {
+	tb.Helper()
+
+	var ok bool
+	var feesDeductedEvent cadence.Event
+	for _, e := range results.tx.Events {
+		if string(e.Type) == fmt.Sprintf("A.%s.FlowFees.FeesDeducted", fvm.FlowFeesAddress(tctx.chain)) {
+			data, err := jsoncdc.Decode(nil, e.Payload)
+			require.NoError(tb, err)
+			feesDeductedEvent, ok = data.(cadence.Event)
+			require.True(tb, ok, "Event payload should be of type cadence event.")
+		}
+	}
+	if feesDeductedEvent.Type() == nil {
+		return 0, false
+	}
+	fees, ok = feesDeductedEvent.Fields[0].(cadence.UFix64)
+	require.True(tb, ok, "FeesDeducted[0] event should be of type cadence.UFix64.")
+	return fees, true
+}
+
+func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transactionTypeContext) {
+	tb.Helper()
+
+	addressFunds := uint64(1_000_000_000)
+	var privateKey flow.AccountPrivateKey
+	var address flow.Address
+	bootstrappedVMTest, err := newVMTest().withBootstrapProcedureOptions(
+		fvm.WithTransactionFee(fvm.DefaultTransactionFees),
+		fvm.WithExecutionMemoryLimit(math.MaxUint32),
+		fvm.WithExecutionEffortWeights(mainnetExecutionEffortWeights),
+		fvm.WithExecutionMemoryWeights(meter.DefaultMemoryWeights),
+		fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
+		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
+		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
+	).withContextOptions(
+		fvm.WithTransactionFeesEnabled(true),
+		fvm.WithAccountStorageLimit(true),
+	).bootstrapWith(func(vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) error {
+		// ==== Create an account ====
+		var txBody *flow.TransactionBody
+		privateKey, txBody = testutil.CreateAccountCreationTransaction(tb, chain)
+
+		err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
+		if err != nil {
+			return err
+		}
+
+		tx := fvm.Transaction(txBody, 0)
+
+		err = vm.Run(ctx, tx, view, programs)
+
+		require.NoError(tb, err)
+		accountCreatedEvents := filterAccountCreatedEvents(tx.Events)
+
+		// read the address of the account created (e.g. "0x01" and convert it to flow.address)
+		data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
+		require.NoError(tb, err)
+
+		address = flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+
+		// ==== Transfer tokens to new account ====
+		txBody = transferTokensTx(chain).
+			AddAuthorizer(chain.ServiceAddress()).
+			AddArgument(jsoncdc.MustEncode(cadence.UFix64(1_000_000_000))). // 10 FLOW
+			AddArgument(jsoncdc.MustEncode(cadence.NewAddress(address)))
+
+		txBody.SetProposalKey(chain.ServiceAddress(), 0, 1)
+		txBody.SetPayer(chain.ServiceAddress())
+
+		err = testutil.SignEnvelope(
+			txBody,
+			chain.ServiceAddress(),
+			unittest.ServiceAccountPrivateKey,
+		)
+		require.NoError(tb, err)
+
+		tx = fvm.Transaction(txBody, 0)
+
+		err = vm.Run(ctx, tx, view, programs)
+		if err != nil {
+			return err
+		}
+
+		return tx.Err
+	})
+	require.NoError(tb, err)
+
+	return bootstrappedVMTest,
+		transactionTypeContext{
+			address:      address,
+			addressFunds: addressFunds,
+			privateKey:   privateKey,
+			chain:        bootstrappedVMTest.chain,
+		}
+}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -30,6 +30,16 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+// from 18.8.2022
+var mainnetExecutionEffortWeights = meter.ExecutionEffortWeights{
+	common.ComputationKindStatement:          1569,
+	common.ComputationKindLoop:               1569,
+	common.ComputationKindFunctionInvocation: 1569,
+	meter.ComputationKindGetValue:            808,
+	meter.ComputationKindCreateAccount:       2837670,
+	meter.ComputationKindSetValue:            765,
+}
+
 type vmTest struct {
 	bootstrapOptions []fvm.BootstrapProcedureOption
 	contextOptions   []fvm.Option
@@ -82,6 +92,60 @@ func (vmt vmTest) run(
 		require.NoError(t, err)
 
 		f(t, vm, chain, ctx, view, programs)
+	}
+}
+
+// bootstrapWith executes the bootstrap procedure and the custom bootstrap function
+// and returns a prepared bootstrappedVmTest with all the state needed
+func (vmt vmTest) bootstrapWith(
+	bootstrap func(vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) error,
+) (bootstrappedVmTest, error) {
+	chain, vm := createChainAndVm(flow.Testnet)
+
+	baseOpts := []fvm.Option{
+		fvm.WithChain(chain),
+	}
+
+	opts := append(baseOpts, vmt.contextOptions...)
+
+	ctx := fvm.NewContext(zerolog.Nop(), opts...)
+
+	view := utils.NewSimpleView()
+
+	baseBootstrapOpts := []fvm.BootstrapProcedureOption{
+		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply),
+	}
+
+	programs := programs.NewEmptyPrograms()
+
+	bootstrapOpts := append(baseBootstrapOpts, vmt.bootstrapOptions...)
+
+	err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view, programs)
+	if err != nil {
+		return bootstrappedVmTest{}, err
+	}
+
+	err = bootstrap(vm, chain, ctx, view, programs)
+	if err != nil {
+		return bootstrappedVmTest{}, err
+	}
+
+	return bootstrappedVmTest{chain, ctx, view, programs}, nil
+}
+
+type bootstrappedVmTest struct {
+	chain    flow.Chain
+	ctx      fvm.Context
+	view     state.View
+	programs *programs.Programs
+}
+
+// run Runs a test from the bootstrapped state, without changing the bootstrapped state
+func (vmt bootstrappedVmTest) run(
+	f func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs),
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		f(t, fvm.NewVirtualMachine(fvm.NewInterpreterRuntime()), vmt.chain, vmt.ctx, vmt.view.NewChild(), vmt.programs.ChildPrograms())
 	}
 }
 
@@ -742,7 +806,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			name:          "If tx fails because of gas limit reached, fee deduction events are emitted",
 			fundWith:      fundingAmount,
 			tryToTransfer: 2 * fundingAmount,
-			gasLimit:      uint64(10),
+			gasLimit:      uint64(2),
 			checkResult: func(t *testing.T, balanceBefore uint64, balanceAfter uint64, tx *fvm.TransactionProcedure) {
 				require.Error(t, tx.Err)
 
@@ -966,6 +1030,8 @@ func TestTransactionFeeDeduction(t *testing.T) {
 		t.Run(fmt.Sprintf("Transaction Fees %d: %s", i, tc.name), newVMTest().withBootstrapProcedureOptions(
 			fvm.WithTransactionFee(fvm.DefaultTransactionFees),
 			fvm.WithExecutionMemoryLimit(math.MaxUint64),
+			fvm.WithExecutionEffortWeights(mainnetExecutionEffortWeights),
+			fvm.WithExecutionMemoryWeights(meter.DefaultMemoryWeights),
 		).withContextOptions(
 			fvm.WithTransactionFeesEnabled(true),
 		).run(
@@ -980,6 +1046,8 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			fvm.WithMinimumStorageReservation(fvm.DefaultMinimumStorageReservation),
 			fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
 			fvm.WithExecutionMemoryLimit(math.MaxUint64),
+			fvm.WithExecutionEffortWeights(mainnetExecutionEffortWeights),
+			fvm.WithExecutionMemoryWeights(meter.DefaultMemoryWeights),
 		).withContextOptions(
 			fvm.WithTransactionFeesEnabled(true),
 			fvm.WithAccountStorageLimit(true),

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -121,15 +121,6 @@ func (e *ScriptEnv) setExecutionParameters() error {
 
 	meter := e.sth.State().Meter()
 
-	computationWeights, err := GetExecutionEffortWeights(e, service)
-	err = setIfOk(
-		"execution effort weights",
-		err,
-		func() { meter.SetComputationWeights(computationWeights) })
-	if err != nil {
-		return err
-	}
-
 	memoryWeights, err := GetExecutionMemoryWeights(e, service)
 	err = setIfOk(
 		"execution memory weights",
@@ -144,6 +135,15 @@ func (e *ScriptEnv) setExecutionParameters() error {
 		"execution memory limit",
 		err,
 		func() { meter.SetTotalMemoryLimit(memoryLimit) })
+	if err != nil {
+		return err
+	}
+
+	computationWeights, err := GetExecutionEffortWeights(e, service)
+	err = setIfOk(
+		"execution effort weights",
+		err,
+		func() { meter.SetComputationWeights(computationWeights) })
 	if err != nil {
 		return err
 	}

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -155,15 +155,6 @@ func (e *TransactionEnv) setExecutionParameters() error {
 
 	meter := e.sth.State().Meter()
 
-	computationWeights, err := GetExecutionEffortWeights(e, service)
-	err = setIfOk(
-		"execution effort weights",
-		err,
-		func() { meter.SetComputationWeights(computationWeights) })
-	if err != nil {
-		return err
-	}
-
 	memoryWeights, err := GetExecutionMemoryWeights(e, service)
 	err = setIfOk(
 		"execution memory weights",
@@ -178,6 +169,15 @@ func (e *TransactionEnv) setExecutionParameters() error {
 		"execution memory limit",
 		err,
 		func() { meter.SetTotalMemoryLimit(memoryLimit) })
+	if err != nil {
+		return err
+	}
+
+	computationWeights, err := GetExecutionEffortWeights(e, service)
+	err = setIfOk(
+		"execution effort weights",
+		err,
+		func() { meter.SetComputationWeights(computationWeights) })
 	if err != nil {
 		return err
 	}

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -75,8 +75,27 @@ func (i *TransactionInvoker) Process(
 			proc.Events = make([]flow.Event, 0)
 			proc.ServiceEvents = make([]flow.Event, 0)
 		}
+
 		if mergeError := parentState.MergeState(childState, sth.EnforceInteractionLimits()); mergeError != nil {
-			processErr = fmt.Errorf("transaction invocation failed when merging state: %w", mergeError)
+			if processErr != nil {
+				// An error happened while an error was already being handled!
+				// Don't hide the processErr.
+				// But do take the one that is a Failure if one of them is a Failure.
+				var fatal errors.Failure
+				if errors.Is(mergeError, fatal) && !errors.Is(processErr, fatal) {
+					i.logger.Warn().
+						Err(processErr).
+						Msg("Hiding this error because a fatal error occurred during merging state")
+					processErr = fmt.Errorf("transaction invocation failed when merging state: %w", mergeError)
+				} else {
+					i.logger.
+						Warn().
+						Err(mergeError).
+						Msg("Hiding merging state error because an error occurred during transaction processing")
+				}
+			} else {
+				processErr = fmt.Errorf("transaction invocation failed when merging state: %w", mergeError)
+			}
 		}
 		sth.SetActiveState(parentState)
 	}()


### PR DESCRIPTION
# Context

There was an error occurring on testnet with the new v0.27 ([slack link](https://axiomzen.slack.com/archives/C015G65HR2P/p1660235921269599))

```json
{
  "level": "error",
  "node_role": "execution",
  "node_id": "48601e8a1568f18ca4a574a656710342857f939f598679280a6941cc7b800b6f",
  "error": "[Failure Code: 2000] unknown failure: Execution failed:\nerror: fatal error: storage error: get value failed: [Error Code: 1110] computation exceeds limit (10)\n--> \n",
  "time": "2022-08-11T14:17:02Z",
  "message": "error getting execution memory limit"
}
```

Whats happening here is that the gas limit runs out as the state config (memory weights, execution weights and memory limit) is being loaded, before the transaction really even started execution.

There is a few issues here:
- This error should have not occurred
- This error should not have been fatal
- Because it did occur and was a `Failure` it should have crashed the node

# Severity

- Transactions with low gas limit (<~ 10) will fail like this. 
- This does not crash the node
- This **is** deterministic

We can safely assume that this is not critical. 

If not patched, the downside is that some transactions with very low case limit might fail that shouldn't (but transactions like this should be practically empty), and that the grafana logs will contain error messages like this.

# Solution

1.  Error did not crash the node because it was overridden by a non `Failure` in the defer of the transaction invoker. The simple and dirty fix is to not override if it is a  `Failure`. Fixed with [940c95f](https://github.com/onflow/flow-go/pull/3013/commits/940c95fcef97ea0dd48d6b3f43e74f3f64df06e2). A more proper solution would be to not have so much logic in the defer here.

2. Error was fatal because cadence wrapped the error in an external error which cannot be unwrapped, so the underlying cause of running out of computation was not seen by the split error types. To get around this we already have a method called `HandleRuntimeError` which unwraps the external error. Fixed with [b3565ad](https://github.com/onflow/flow-go/pull/3013/commits/b3565ad0210fa4363ddc9af36caf82aacea9d3f5). This would not be necessary if cadence external error was unwrappable.
 
3. Error happened because loading the execution weights sets them on the current meter immediately. After that loading the memory weights and limit already causes the meter to go over the computation limit. This should not happen as we should read all the settings and then set all the settings. This is already fixed in master with https://github.com/onflow/flow-go/pull/2971. Here I just changed the load order, so execution weights get loaded last [d2129df](https://github.com/onflow/flow-go/pull/3013/commits/d2129dfe003e7c83adf46a529ba3fc0cb3d81606).

4. To get through all of this, I changed an existing test, and added some fuzz tests, just to be more sure no similar edge cases exist.  [9d7d224](https://github.com/onflow/flow-go/pull/3013/commits/9d7d224259297cce715402c7181b7cdf1c4e6523)

5. The test found another bug in the HandleRuntimeError function. So that is fixed now too [90f2679](https://github.com/onflow/flow-go/pull/3013/commits/90f26794b181eee66de76d5923b553a808dbcfef)

# Merging

Everything but [d2129df](https://github.com/onflow/flow-go/pull/3013/commits/d2129dfe003e7c83adf46a529ba3fc0cb3d81606) should get merged to master. [d2129df](https://github.com/onflow/flow-go/pull/3013/commits/d2129dfe003e7c83adf46a529ba3fc0cb3d81606) is already fixed properly.
