### PR TITLE
remove epoch counter and set it to 0

### DIFF
--- a/cmd/util/ledger/reporters/export_reporter.go
+++ b/cmd/util/ledger/reporters/export_reporter.go
@@ -2,17 +2,10 @@ package reporters
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 
 	"github.com/rs/zerolog"
 
-	"github.com/onflow/flow-core-contracts/lib/go/templates"
-
-	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
-	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/programs"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -52,44 +45,8 @@ func (e *ExportReporter) Name() string {
 }
 
 func (e *ExportReporter) Report(payload []ledger.Payload, commit ledger.State) error {
-	script, _, err := ExecuteCurrentEpochScript(e.chain, payload)
-	failedExportReport := ExportReport{
-		ReportSucceeded: false,
-	}
-	failedReport, _ := json.MarshalIndent(failedExportReport, "", " ")
-
-	if err != nil {
-		e.logger.
-			Error().
-			Err(err).
-			Msg("error running GetCurrentEpochCounter script")
-
-			// write the report with ReportSucceeded = false, so that the ansbile script can
-			// detect the failure
-		_ = ioutil.WriteFile("export_report.json", failedReport, 0644)
-		// Safely exit and move on to next reporter so we do not block other reporters
-		return nil
-	}
-
-	if script.Err != nil && script.Value == nil {
-		_ = ioutil.WriteFile("export_report.json", failedReport, 0644)
-		e.logger.
-			Error().
-			Err(script.Err).
-			Msg("Failed to get epoch counter")
-
-		// Safely exit and move on to next reporter so we do not block other reporters
-		return nil
-	}
-
-	epochCounter := script.Value.ToGoValue().(uint64)
-	e.logger.
-		Info().
-		Uint64("epochCounter", epochCounter).
-		Msg("Fetched epoch counter from the FlowEpoch smart contract")
-
 	report := ExportReport{
-		EpochCounter:            script.Value.ToGoValue().(uint64),
+		EpochCounter:            0, // it will be overwritten by external automation, and this field will be removed later.
 		PreviousStateCommitment: e.getBeforeMigrationSCFunc(),
 		CurrentStateCommitment:  flow.StateCommitment(commit),
 		ReportSucceeded:         true,
@@ -101,23 +58,4 @@ func (e *ExportReporter) Report(payload []ledger.Payload, commit ledger.State) e
 		Msg("Ledger Export has finished")
 	_ = ioutil.WriteFile("export_report.json", file, 0644)
 	return nil
-}
-
-// Executes script to get current epoch from chain
-func ExecuteCurrentEpochScript(c flow.Chain, payload []ledger.Payload) (*fvm.ScriptProcedure, flow.Address, error) {
-	l := migrations.NewView(payload)
-	prog := programs.NewEmptyPrograms()
-	vm := fvm.NewVirtualMachine(fvm.NewInterpreterRuntime())
-	ctx := fvm.NewContext(zerolog.Nop(), fvm.WithChain(c))
-
-	sc, err := systemcontracts.SystemContractsForChain(c.ChainID())
-	if err != nil {
-		return nil, flow.Address{}, fmt.Errorf("error getting SystemContracts for chain %s: %w", c.String(), err)
-	}
-	address := sc.Epoch.Address
-	scriptCode := templates.GenerateGetCurrentEpochCounterScript(templates.Environment{
-		EpochAddress: address.Hex(),
-	})
-	script := fvm.Script(scriptCode)
-	return script, address, vm.Run(ctx, script, l, prog)
 }


### PR DESCRIPTION
The export reporter no longer need to query the epoch counter from the execution state, we will query it directly from EN during spork. 

This PR removes that logic and set the epoch counter to 0 for now.