### PR TITLE
[Testing] Minor improvements to crash test

### DIFF
--- a/insecure/corruptible/network_common_test.go
+++ b/insecure/corruptible/network_common_test.go
@@ -43,7 +43,7 @@ func TestProcessAttackerMessage_EmptyEgressIngressMessage_Exit(t *testing.T) {
 	f := func(t *testing.T) {
 		processAttackerMessage_EmptyEgressIngressMessage_Exit(t)
 	}
-	unittest.CrashTest(t, f, "both ingress and egress messages can't be nil", "TestProcessAttackerMessage_EmptyEgressIngressMessage_Exit")
+	unittest.CrashTest(t, f, "both ingress and egress messages can't be nil")
 }
 
 func processAttackerMessage_EmptyEgressIngressMessage_Exit(t *testing.T) {
@@ -84,7 +84,7 @@ func TestProcessAttackerMessage_NotEmptyEgressIngressMessage_Exit(t *testing.T) 
 	f := func(t *testing.T) {
 		processAttackerMessage_NotEmptyEgressIngressMessage_Exit(t)
 	}
-	unittest.CrashTest(t, f, "both ingress and egress messages can't be set", "TestProcessAttackerMessage_NotEmptyEgressIngressMessage_Exit")
+	unittest.CrashTest(t, f, "both ingress and egress messages can't be set")
 }
 
 func processAttackerMessage_NotEmptyEgressIngressMessage_Exit(t *testing.T) {

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -414,7 +414,7 @@ func CrashTest(
 
 	if len(expectedStatus) == 0 {
 		// any non-zero status is expected
-		require.Greater(t, cmd.ProcessState.ExitCode(), 0)
+		require.NotEqual(t, cmd.ProcessState.ExitCode(), 0)
 	} else {
 		// expect specific status
 		require.Contains(t, expectedStatus, cmd.ProcessState.ExitCode())

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -406,7 +406,7 @@ func CrashTest(t *testing.T, scenario func(*testing.T), expectedErrorMsg string)
 	outBytes, err := cmd.Output()
 	// expect error from run
 	require.Error(t, err)
-	require.Contains(t, "exit status 1", err.Error())
+	require.Contains(t, err.Error(), "exit status ")
 
 	// expect logger.Fatal() message to be pushed to stdout
 	outStr := string(outBytes)

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -405,6 +405,9 @@ func CrashTestWithExpectedStatus(
 	expectedErrorMsg string,
 	expectedStatus ...int,
 ) {
+	require.NotNil(t, scenario)
+	require.NotEmpty(t, expectedStatus)
+
 	if os.Getenv("CRASH_TEST") == "1" {
 		scenario(t)
 		return
@@ -417,13 +420,8 @@ func CrashTestWithExpectedStatus(
 	// expect error from run
 	require.Error(t, err)
 
-	if len(expectedStatus) == 0 {
-		// any non-zero status is expected
-		require.NotEqual(t, cmd.ProcessState.ExitCode(), 0)
-	} else {
-		// expect specific status
-		require.Contains(t, expectedStatus, cmd.ProcessState.ExitCode())
-	}
+	// expect specific status codes
+	require.Contains(t, expectedStatus, cmd.ProcessState.ExitCode())
 
 	// expect logger.Fatal() message to be pushed to stdout
 	outStr := string(outBytes)

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -394,13 +394,13 @@ func NetworkTopology() network.Topology {
 
 // CrashTest safely tests functions that crash (as the expected behavior) by checking that running the function creates an error and
 // an expected error message.
-func CrashTest(t *testing.T, scenario func(*testing.T), expectedErrorMsg string, testName string) {
+func CrashTest(t *testing.T, scenario func(*testing.T), expectedErrorMsg string) {
 	if os.Getenv("CRASH_TEST") == "1" {
 		scenario(t)
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run="+testName)
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
 	cmd.Env = append(os.Environ(), "CRASH_TEST=1")
 
 	outBytes, err := cmd.Output()

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -417,14 +417,7 @@ func CrashTest(
 		require.Greater(t, cmd.ProcessState.ExitCode(), 0)
 	} else {
 		// expect specific status
-		anyStatus := false
-		for _, status := range expectedStatus {
-			if cmd.ProcessState.ExitCode() == status {
-				anyStatus = true
-				break
-			}
-		}
-		require.True(t, anyStatus, "expected status %+v, got %v", expectedStatus, cmd.ProcessState.ExitCode())
+		require.Contains(t, expectedStatus, cmd.ProcessState.ExitCode())
 	}
 
 	// expect logger.Fatal() message to be pushed to stdout

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -394,7 +394,12 @@ func NetworkTopology() network.Topology {
 
 // CrashTest safely tests functions that crash (as the expected behavior) by checking that running the function creates an error and
 // an expected error message.
-func CrashTest(
+func CrashTest(t *testing.T, scenario func(*testing.T), expectedErrorMsg string) {
+	CrashTestWithExpectedStatus(t, scenario, expectedErrorMsg, 1)
+}
+
+// CrashTestWithExpectedStatus checks for the test crashing with a specific exit code.
+func CrashTestWithExpectedStatus(
 	t *testing.T,
 	scenario func(*testing.T),
 	expectedErrorMsg string,

--- a/utils/unittest/unittest_test.go
+++ b/utils/unittest/unittest_test.go
@@ -23,6 +23,14 @@ func TestCrashTest_ErrorMessage(t *testing.T) {
 	CrashTest(t, f, "about to crash")
 }
 
+// TestCrashTest_ExitCode tests that CrashTest() catches exit codes other than 1.
+func TestCrashTest_ExitCode(t *testing.T) {
+	f := func(t *testing.T) {
+		crash_ExitCode()
+	}
+	CrashTest(t, f, "exit code != 1")
+}
+
 // TestCrashTest_Logger tests that CrashTest() can read fatal logger messages from stdout before a crash. This test
 // assumes that the logger uses a hook to send fatal messages to stdout.
 func TestCrashTest_Logger(t *testing.T) {
@@ -39,6 +47,11 @@ func crash_NoMessage() {
 func crash_ErrorMessage() {
 	fmt.Println("about to crash... crashing in 3...2...1...")
 	os.Exit(1)
+}
+
+func crash_ExitCode() {
+	fmt.Println("crashing with a exit code != 1")
+	os.Exit(2)
 }
 
 func crash_LoggerFatal() {

--- a/utils/unittest/unittest_test.go
+++ b/utils/unittest/unittest_test.go
@@ -12,7 +12,7 @@ func TestCrashTest_NoMessage(t *testing.T) {
 		crash_NoMessage()
 	}
 
-	CrashTest(t, f, "", "TestCrashTest_NoMessage")
+	CrashTest(t, f, "")
 }
 
 // TestCrashTest_ErrorMessage tests that CrashTest() can read standard messages from stdout before a crash.
@@ -20,7 +20,7 @@ func TestCrashTest_ErrorMessage(t *testing.T) {
 	f := func(t *testing.T) {
 		crash_ErrorMessage()
 	}
-	CrashTest(t, f, "about to crash", "TestCrashTest_ErrorMessage")
+	CrashTest(t, f, "about to crash")
 }
 
 // TestCrashTest_Logger tests that CrashTest() can read fatal logger messages from stdout before a crash. This test
@@ -29,7 +29,7 @@ func TestCrashTest_Logger(t *testing.T) {
 	f := func(t *testing.T) {
 		crash_LoggerFatal()
 	}
-	CrashTest(t, f, "fatal crash from logger", "TestCrashTest_Logger")
+	CrashTest(t, f, "fatal crash from logger")
 }
 
 func crash_NoMessage() {

--- a/utils/unittest/unittest_test.go
+++ b/utils/unittest/unittest_test.go
@@ -26,17 +26,17 @@ func TestCrashTest_ErrorMessage(t *testing.T) {
 // TestCrashTest_ExitCode tests that CrashTest() catches exit codes other than 1.
 func TestCrashTest_ExitCode(t *testing.T) {
 	f := func(t *testing.T) {
-		crash_ExitCode()
+		crash_ExitCode2()
 	}
-	CrashTest(t, f, "exit code != 1")
+	CrashTestWithExpectedStatus(t, f, "exit code == 2", 2)
 }
 
 // TestCrashTest_ExitCodeExplicit tests that CrashTest() catches exit codes other than 1 w/ an explicit exit code.
 func TestCrashTest_ExitCodeExplicit(t *testing.T) {
 	f := func(t *testing.T) {
-		crash_ExitCode()
+		crash_ExitCode2()
 	}
-	CrashTest(t, f, "exit code != 1", 4, 3, 2)
+	CrashTestWithExpectedStatus(t, f, "exit code == 2", 4, 3, 2)
 }
 
 // TestCrashTest_Logger tests that CrashTest() can read fatal logger messages from stdout before a crash. This test
@@ -57,8 +57,8 @@ func crash_ErrorMessage() {
 	os.Exit(1)
 }
 
-func crash_ExitCode() {
-	fmt.Println("crashing with a exit code != 1")
+func crash_ExitCode2() {
+	fmt.Println("crashing with a exit code == 2")
 	os.Exit(2)
 }
 

--- a/utils/unittest/unittest_test.go
+++ b/utils/unittest/unittest_test.go
@@ -31,6 +31,14 @@ func TestCrashTest_ExitCode(t *testing.T) {
 	CrashTest(t, f, "exit code != 1")
 }
 
+// TestCrashTest_ExitCodeExplicit tests that CrashTest() catches exit codes other than 1 w/ an explicit exit code.
+func TestCrashTest_ExitCodeExplicit(t *testing.T) {
+	f := func(t *testing.T) {
+		crash_ExitCode()
+	}
+	CrashTest(t, f, "exit code != 1", 4, 3, 2)
+}
+
 // TestCrashTest_Logger tests that CrashTest() can read fatal logger messages from stdout before a crash. This test
 // assumes that the logger uses a hook to send fatal messages to stdout.
 func TestCrashTest_Logger(t *testing.T) {


### PR DESCRIPTION
In this PR:
* Remove the need to pass test name and rely on `t.Name()` instead.
* Add ability to catch error codes > 1. (This may happen in libraries that conform to  BSD's [sysexits.h](https://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+14.0-current&arch=default&format=html) or command-line utils, that frequently use `os.Exit(2)`)
* Add ability to catch explicit set of error codes.
* Switch from text parsing to using `cmd.ProcessState.ExitCode()`.

Ref: #2941