### PR TITLE
Khalil/1761 

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/onflow/flow-go/module/irrecoverable"
 	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
 	entitiesproto "github.com/onflow/flow/protobuf/go/flow/entities"
 	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
@@ -16,6 +15,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/onflow/flow-go/module/irrecoverable"
 
 	"github.com/onflow/flow-go/crypto"
 

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -82,7 +82,8 @@ func (suite *Suite) SetupTest() {
 	params := new(protocol.Params)
 	params.On("Root").Return(header, nil)
 	suite.state.On("Params").Return(params).Maybe()
-
+	suite.state.On("AtBlockID", header.ID()).Return(suite.snapshot).Maybe()
+	suite.snapshot.On("SealingSegment").Return(&flow.SealingSegment{Blocks: unittest.BlockFixtures(1)}, nil).Maybe()
 	suite.collClient = new(accessmock.AccessAPIClient)
 	suite.execClient = new(accessmock.ExecutionAPIClient)
 

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -74,6 +74,7 @@ func (suite *Suite) SetupTest() {
 	suite.net = new(mocknetwork.Network)
 	suite.state = new(protocol.State)
 	suite.snapshot = new(protocol.Snapshot)
+	suite.snapshot.On("SealingSegment").Return(&flow.SealingSegment{Blocks: unittest.BlockFixtures(2)}, nil).Maybe()
 
 	suite.epochQuery = new(protocol.EpochQuery)
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
@@ -555,6 +556,8 @@ func (suite *Suite) TestGetSealedTransaction() {
 		receipts := storage.NewExecutionReceipts(suite.metrics, db, results, storage.DefaultCacheSize)
 		enIdentities := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
 		enNodeIDs := flow.IdentifierList(enIdentities.NodeIDs())
+
+		suite.state.On("AtBlockID", mock.Anything).Return(suite.snapshot, nil)
 
 		// create block -> collection -> transactions
 		block, collection := suite.createChain()

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -206,7 +206,7 @@ func (e *Engine) Start(parent irrecoverable.SignalerContext) {
 	// in blocks above that height.
 	if !isSporkRootSnapshot {
 		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
-		err := e.blocks.InsertLastFullBlockHeight(firstFullHeight)
+		err := e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
 		if err != nil {
 			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
 		}

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -193,23 +193,14 @@ func (e *Engine) Start(parent irrecoverable.SignalerContext) {
 		parent.Throw(fmt.Errorf("failed to get root block: %w", err))
 	}
 
-	rootSnapshot := e.state.AtBlockID(rootBlock.ID())
-
-	isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
-	if err != nil {
-		parent.Throw(fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err))
-	}
-
 	// This is useful for dynamically bootstrapped access node, they will request missing collections. In order to ensure all txs
 	// from the missing collections can be verified, we must ensure they are referencing to known blocks.
 	// That's why we set the full block height to be rootHeight + TransactionExpiry, so that we only request missing collections
 	// in blocks above that height.
-	if !isSporkRootSnapshot {
-		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
-		err := e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
-		if err != nil {
-			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
-		}
+	firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
+	err = e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
+	if err != nil {
+		parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
 	}
 
 	e.ComponentManager.Start(parent)

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -187,6 +187,34 @@ func New(
 	return e, nil
 }
 
+func (e *Engine) Start(parent irrecoverable.SignalerContext) {
+	rootBlock, err := e.state.Params().Root()
+	if err != nil {
+		parent.Throw(fmt.Errorf("failed to get root block: %w", err))
+	}
+
+	rootSnapshot := e.state.AtBlockID(rootBlock.ID())
+
+	isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
+	if err != nil {
+		parent.Throw(fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err))
+	}
+
+	// This is useful for dynamically bootstrapped access node, they will request missing collections. In order to ensure all txs
+	// from the missing collections can be verified, we must ensure they are referencing to known blocks.
+	// That's why we set the full block height to be rootHeight + TransactionExpiry, so that we only request missing collections
+	// in blocks above that height.
+	if !isSporkRootSnapshot {
+		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
+		err := e.blocks.UpdateLastFullBlockHeight(firstFullHeight)
+		if err != nil {
+			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+		}
+	}
+
+	e.ComponentManager.Start(parent)
+}
+
 func (e *Engine) processBackground(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 	// context with timeout
 	requestCtx, cancel := context.WithTimeout(ctx, defaultCollectionCatchupTimeout)
@@ -375,6 +403,19 @@ func (e *Engine) processFinalizedBlock(blockID flow.Identifier) error {
 		if err != nil {
 			return fmt.Errorf("could not index block for execution result: %w", err)
 		}
+	}
+
+	// skip requesting collections, if this block is below the last full block height
+	// this means that either we have already received these collections, or the block
+	// may contain unverifiable guarantees (in case this node has just joined the network)
+	lastFullBlockHeight, err := e.blocks.GetLastFullBlockHeight()
+	if err != nil {
+		return fmt.Errorf("could not get last full block height: %w", err)
+	}
+
+	if block.Header.Height <= lastFullBlockHeight {
+		e.log.Info().Msgf("skipping requesting collections for finalized block below last full block height (%d<=%d)", block.Header.Height, lastFullBlockHeight)
+		return nil
 	}
 
 	// queue requesting each of the collections from the collection node

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -206,7 +206,7 @@ func (e *Engine) Start(parent irrecoverable.SignalerContext) {
 	// in blocks above that height.
 	if !isSporkRootSnapshot {
 		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
-		err := e.blocks.UpdateLastFullBlockHeight(firstFullHeight)
+		err := e.blocks.InsertLastFullBlockHeight(firstFullHeight)
 		if err != nil {
 			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
 		}

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -193,14 +193,32 @@ func (e *Engine) Start(parent irrecoverable.SignalerContext) {
 		parent.Throw(fmt.Errorf("failed to get root block: %w", err))
 	}
 
+	// if spork root snapshot
+	rootSnapshot := e.state.AtBlockID(rootBlock.ID())
+
+	isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
+	if err != nil {
+		parent.Throw(fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err))
+	}
+
 	// This is useful for dynamically bootstrapped access node, they will request missing collections. In order to ensure all txs
 	// from the missing collections can be verified, we must ensure they are referencing to known blocks.
 	// That's why we set the full block height to be rootHeight + TransactionExpiry, so that we only request missing collections
 	// in blocks above that height.
-	firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
-	err = e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
-	if err != nil {
-		parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+	if isSporkRootSnapshot {
+		// for snapshot with a single block in the sealing segment the first full block is the root block.
+		err := e.blocks.UpdateLastFullBlockHeight(rootBlock.Height)
+		if err != nil {
+			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+		}
+	} else {
+		// for midspork snapshots with a sealing segment that has more than 1 block add the transaction expiry to the root block height to avoid
+		// requesting resources for blocks below the expiry.
+		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
+		err := e.blocks.UpdateLastFullBlockHeight(firstFullHeight)
+		if err != nil {
+			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+		}
 	}
 
 	e.ComponentManager.Start(parent)

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -207,7 +207,7 @@ func (e *Engine) Start(parent irrecoverable.SignalerContext) {
 	// in blocks above that height.
 	if isSporkRootSnapshot {
 		// for snapshot with a single block in the sealing segment the first full block is the root block.
-		err := e.blocks.UpdateLastFullBlockHeight(rootBlock.Height)
+		err := e.blocks.InsertLastFullBlockHeightIfNotExists(rootBlock.Height)
 		if err != nil {
 			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
 		}
@@ -215,7 +215,7 @@ func (e *Engine) Start(parent irrecoverable.SignalerContext) {
 		// for midspork snapshots with a sealing segment that has more than 1 block add the transaction expiry to the root block height to avoid
 		// requesting resources for blocks below the expiry.
 		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
-		err := e.blocks.UpdateLastFullBlockHeight(firstFullHeight)
+		err := e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
 		if err != nil {
 			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
 		}

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -113,7 +113,7 @@ func (suite *Suite) SetupTest() {
 	require.NoError(suite.T(), err)
 
 	suite.blocks.On("GetLastFullBlockHeight").Once().Return(uint64(0), errors.New("do nothing"))
-	
+
 	ctx, cancel := context.WithCancel(context.Background())
 	irrecoverableCtx, _ := irrecoverable.WithSignaler(ctx)
 	eng.ComponentManager.Start(irrecoverableCtx)

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -467,20 +467,24 @@ func (q *EpochQuery) Current() protocol.Epoch {
 
 	status, err := q.snap.state.epoch.statuses.ByBlockID(q.snap.blockID)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get epoch statuses for block ID %s: %w",
+			q.snap.blockID, err))
 	}
 	setup, err := q.snap.state.epoch.setups.ByID(status.CurrentEpoch.SetupID)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get epoch setups for setup ID %s at block %v: %w",
+			status.CurrentEpoch.SetupID, q.snap.blockID, err))
 	}
 	commit, err := q.snap.state.epoch.commits.ByID(status.CurrentEpoch.CommitID)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get epoch commits for commit ID %s at block %v: %w",
+			status.CurrentEpoch.CommitID, q.snap.blockID, err))
 	}
 
 	epoch, err := inmem.NewCommittedEpoch(setup, commit)
 	if err != nil {
-		return invalid.NewEpoch(err)
+		return invalid.NewEpoch(fmt.Errorf("failed to get new committed epoch with setup (%s) and commit (%s) at block %v: %w",
+			setup.ID(), commit.ID(), q.snap.blockID, err))
 	}
 	return epoch
 }

--- a/storage/badger/blocks.go
+++ b/storage/badger/blocks.go
@@ -118,6 +118,10 @@ func (b *Blocks) UpdateLastFullBlockHeight(height uint64) error {
 			return nil
 		}
 
+		if errors.Is(err, storage.ErrAlreadyExists) {
+			return nil
+		}
+
 		if !errors.Is(err, storage.ErrNotFound) {
 			return fmt.Errorf("could not update LastFullBlockHeight: %w", err)
 		}

--- a/storage/badger/blocks.go
+++ b/storage/badger/blocks.go
@@ -108,8 +108,8 @@ func (b *Blocks) IndexBlockForCollections(blockID flow.Identifier, collIDs []flo
 	return nil
 }
 
-// InsertLastFullBlockHeight inserts the last full block height
-func (b *Blocks) InsertLastFullBlockHeight(height uint64) error {
+// InsertLastFullBlockHeightIfNotExists inserts the last full block height
+func (b *Blocks) InsertLastFullBlockHeightIfNotExists(height uint64) error {
 	return operation.RetryOnConflict(b.db.Update, func(tx *badger.Txn) error {
 		err := operation.SetLastCompleteBlockHeight(height)(tx)
 		if err != nil {

--- a/storage/badger/blocks.go
+++ b/storage/badger/blocks.go
@@ -111,7 +111,7 @@ func (b *Blocks) IndexBlockForCollections(blockID flow.Identifier, collIDs []flo
 // InsertLastFullBlockHeightIfNotExists inserts the last full block height
 func (b *Blocks) InsertLastFullBlockHeightIfNotExists(height uint64) error {
 	return operation.RetryOnConflict(b.db.Update, func(tx *badger.Txn) error {
-		err := operation.SetLastCompleteBlockHeight(height)(tx)
+		err := operation.InsertLastCompleteBlockHeightIfNotExists(height)(tx)
 		if err != nil {
 			return fmt.Errorf("could not set LastFullBlockHeight: %w", err)
 		}

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -38,9 +38,9 @@ func RetrieveSealedHeight(height *uint64) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeSealedHeight), height)
 }
 
-// SetLastCompleteBlockHeight inserts the last full block height if it is not already set.
+// InsertLastCompleteBlockHeightIfNotExists inserts the last full block height if it is not already set.
 // Calling this function multiple times is a no-op and returns no expected errors.
-func SetLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
+func InsertLastCompleteBlockHeightIfNotExists(height uint64) func(*badger.Txn) error {
 	return SkipDuplicates(insert(makePrefix(codeLastCompleteBlockHeight), height))
 }
 

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -41,7 +41,7 @@ func RetrieveSealedHeight(height *uint64) func(*badger.Txn) error {
 // SetLastCompleteBlockHeight inserts the last full block height if it is not already set.
 // Calling this function multiple times is a no-op and returns no expected errors.
 func SetLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
-	return SkipDuplicates(update(makePrefix(codeLastCompleteBlockHeight), height))
+	return SkipDuplicates(insert(makePrefix(codeLastCompleteBlockHeight), height))
 }
 
 func InsertLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -43,6 +43,7 @@ func InsertLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
 }
 
 func UpdateLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
+	//return SkipDuplicates(update(makePrefix(codeLastCompleteBlockHeight), height))
 	return update(makePrefix(codeLastCompleteBlockHeight), height)
 }
 

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -41,7 +41,7 @@ func RetrieveSealedHeight(height *uint64) func(*badger.Txn) error {
 // InsertLastCompleteBlockHeightIfNotExists inserts the last full block height if it is not already set.
 // Calling this function multiple times is a no-op and returns no expected errors.
 func InsertLastCompleteBlockHeightIfNotExists(height uint64) func(*badger.Txn) error {
-	return SkipDuplicates(insert(makePrefix(codeLastCompleteBlockHeight), height))
+	return SkipDuplicates(InsertLastCompleteBlockHeight(height))
 }
 
 func InsertLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -49,7 +49,6 @@ func InsertLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
 }
 
 func UpdateLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
-	SkipDuplicates(update(makePrefix(codeLastCompleteBlockHeight), height))
 	return update(makePrefix(codeLastCompleteBlockHeight), height)
 }
 

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -38,12 +38,18 @@ func RetrieveSealedHeight(height *uint64) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeSealedHeight), height)
 }
 
+// SetLastCompleteBlockHeight inserts the last full block height if it is not already set.
+// Calling this function multiple times is a no-op and returns no expected errors.
+func SetLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
+	return SkipDuplicates(update(makePrefix(codeLastCompleteBlockHeight), height))
+}
+
 func InsertLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
 	return insert(makePrefix(codeLastCompleteBlockHeight), height)
 }
 
 func UpdateLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
-	//return SkipDuplicates(update(makePrefix(codeLastCompleteBlockHeight), height))
+	SkipDuplicates(update(makePrefix(codeLastCompleteBlockHeight), height))
 	return update(makePrefix(codeLastCompleteBlockHeight), height)
 }
 

--- a/storage/badger/operation/heights_test.go
+++ b/storage/badger/operation/heights_test.go
@@ -83,3 +83,27 @@ func TestLastCompleteBlockHeightInsertUpdateRetrieve(t *testing.T) {
 		assert.Equal(t, retrieved, height)
 	})
 }
+
+func TestLastCompleteBlockHeightInsertIfNotExists(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		height1 := uint64(1337)
+
+		err := db.Update(InsertLastCompleteBlockHeightIfNotExists(height1))
+		require.Nil(t, err)
+
+		var retrieved uint64
+		err = db.View(RetrieveLastCompleteBlockHeight(&retrieved))
+		require.Nil(t, err)
+
+		assert.Equal(t, retrieved, height1)
+
+		height2 := uint64(9999)
+		err = db.Update(InsertLastCompleteBlockHeightIfNotExists(height2))
+		require.Nil(t, err)
+
+		err = db.View(RetrieveLastCompleteBlockHeight(&retrieved))
+		require.Nil(t, err)
+
+		assert.Equal(t, retrieved, height1)
+	})
+}

--- a/storage/blocks.go
+++ b/storage/blocks.go
@@ -32,6 +32,10 @@ type Blocks interface {
 	// included in.
 	IndexBlockForCollections(blockID flow.Identifier, collIDs []flow.Identifier) error
 
+	// InsertLastFullBlockHeight inserts the FullBlockHeight index if it does not already exist.
+	// Calling this function multiple times is a no-op and returns no expected errors.
+	InsertLastFullBlockHeight(height uint64) error
+
 	// UpdateLastFullBlockHeight updates the FullBlockHeight index
 	// The FullBlockHeight index indicates that block for which all collections have been received
 	UpdateLastFullBlockHeight(height uint64) error

--- a/storage/blocks.go
+++ b/storage/blocks.go
@@ -32,9 +32,9 @@ type Blocks interface {
 	// included in.
 	IndexBlockForCollections(blockID flow.Identifier, collIDs []flow.Identifier) error
 
-	// InsertLastFullBlockHeight inserts the FullBlockHeight index if it does not already exist.
+	// InsertLastFullBlockHeightIfNotExists inserts the FullBlockHeight index if it does not already exist.
 	// Calling this function multiple times is a no-op and returns no expected errors.
-	InsertLastFullBlockHeight(height uint64) error
+	InsertLastFullBlockHeightIfNotExists(height uint64) error
 
 	// UpdateLastFullBlockHeight updates the FullBlockHeight index
 	// The FullBlockHeight index indicates that block for which all collections have been received

--- a/storage/mock/blocks.go
+++ b/storage/mock/blocks.go
@@ -118,8 +118,8 @@ func (_m *Blocks) IndexBlockForCollections(blockID flow.Identifier, collIDs []fl
 	return r0
 }
 
-// InsertLastFullBlockHeight provides a mock function with given fields: height
-func (_m *Blocks) InsertLastFullBlockHeight(height uint64) error {
+// InsertLastFullBlockHeightIfNotExists provides a mock function with given fields: height
+func (_m *Blocks) InsertLastFullBlockHeightIfNotExists(height uint64) error {
 	ret := _m.Called(height)
 
 	var r0 error

--- a/storage/mock/blocks.go
+++ b/storage/mock/blocks.go
@@ -118,6 +118,20 @@ func (_m *Blocks) IndexBlockForCollections(blockID flow.Identifier, collIDs []fl
 	return r0
 }
 
+// InsertLastFullBlockHeight provides a mock function with given fields: height
+func (_m *Blocks) InsertLastFullBlockHeight(height uint64) error {
+	ret := _m.Called(height)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uint64) error); ok {
+		r0 = rf(height)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Store provides a mock function with given fields: block
 func (_m *Blocks) Store(block *flow.Block) error {
 	ret := _m.Called(block)

--- a/storage/mocks/storage.go
+++ b/storage/mocks/storage.go
@@ -109,18 +109,18 @@ func (mr *MockBlocksMockRecorder) IndexBlockForCollections(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexBlockForCollections", reflect.TypeOf((*MockBlocks)(nil).IndexBlockForCollections), arg0, arg1)
 }
 
-// InsertLastFullBlockHeight mocks base method
-func (m *MockBlocks) InsertLastFullBlockHeight(arg0 uint64) error {
+// InsertLastFullBlockHeightIfNotExists mocks base method
+func (m *MockBlocks) InsertLastFullBlockHeightIfNotExists(arg0 uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertLastFullBlockHeight", arg0)
+	ret := m.ctrl.Call(m, "InsertLastFullBlockHeightIfNotExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// InsertLastFullBlockHeight indicates an expected call of InsertLastFullBlockHeight
-func (mr *MockBlocksMockRecorder) InsertLastFullBlockHeight(arg0 interface{}) *gomock.Call {
+// InsertLastFullBlockHeightIfNotExists indicates an expected call of InsertLastFullBlockHeightIfNotExists
+func (mr *MockBlocksMockRecorder) InsertLastFullBlockHeightIfNotExists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertLastFullBlockHeight", reflect.TypeOf((*MockBlocks)(nil).InsertLastFullBlockHeight), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertLastFullBlockHeightIfNotExists", reflect.TypeOf((*MockBlocks)(nil).InsertLastFullBlockHeightIfNotExists), arg0)
 }
 
 // Store mocks base method

--- a/storage/mocks/storage.go
+++ b/storage/mocks/storage.go
@@ -109,6 +109,20 @@ func (mr *MockBlocksMockRecorder) IndexBlockForCollections(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexBlockForCollections", reflect.TypeOf((*MockBlocks)(nil).IndexBlockForCollections), arg0, arg1)
 }
 
+// InsertLastFullBlockHeight mocks base method
+func (m *MockBlocks) InsertLastFullBlockHeight(arg0 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertLastFullBlockHeight", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertLastFullBlockHeight indicates an expected call of InsertLastFullBlockHeight
+func (mr *MockBlocksMockRecorder) InsertLastFullBlockHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertLastFullBlockHeight", reflect.TypeOf((*MockBlocks)(nil).InsertLastFullBlockHeight), arg0)
+}
+
 // Store mocks base method
 func (m *MockBlocks) Store(arg0 *flow.Block) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This pull requests updates the LastFullBlockHeight in the ingestion engine component startup so that we only request missing collections in blocks above that height. In the processFinalizedBlock func we skip requesting collections for blocks under the lastFullBlockHeight.