### PR TITLE
[Networking] Reduce test flakes

### DIFF
--- a/network/p2p/dht_test.go
+++ b/network/p2p/dht_test.go
@@ -149,13 +149,13 @@ func TestPubSubWithDHTDiscovery(t *testing.T) {
 		s, err := n.Subscribe(topic, codec, unittest.AllowAllPeerFilter())
 		require.NoError(t, err)
 
-		go func(s *pubsub.Subscription, n *p2p.Node) {
+		go func(s *pubsub.Subscription, nodeID peer.ID) {
 			msg, err := s.Next(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, msg)
 			assert.Equal(t, data, msg.Data)
-			ch <- n.Host().ID()
-		}(s, n)
+			ch <- nodeID
+		}(s, n.Host().ID())
 	}
 
 	// fullyConnectedGraph checks that each node is directly connected to all the other nodes

--- a/network/p2p/dht_test.go
+++ b/network/p2p/dht_test.go
@@ -146,22 +146,16 @@ func TestPubSubWithDHTDiscovery(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, n := range nodes {
-		// defines a func to read from the subscription
-		subReader := func(s *pubsub.Subscription) {
+		s, err := n.Subscribe(topic, codec, unittest.AllowAllPeerFilter())
+		require.NoError(t, err)
+
+		go func(s *pubsub.Subscription, n *p2p.Node) {
 			msg, err := s.Next(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, msg)
 			assert.Equal(t, data, msg.Data)
 			ch <- n.Host().ID()
-		}
-
-		// Subscribes to the test topic
-		s, err := n.Subscribe(topic, codec, unittest.AllowAllPeerFilter())
-		require.NoError(t, err)
-
-		// kick off the reader
-		go subReader(s)
-
+		}(s, n)
 	}
 
 	// fullyConnectedGraph checks that each node is directly connected to all the other nodes
@@ -197,7 +191,7 @@ loop:
 					missing = append(missing, n.Host().ID())
 				}
 			}
-			assert.Fail(t, "messages not received by some nodes", "%v", missing)
+			assert.Failf(t, "messages not received by some nodes", "%+v", missing)
 			break loop
 		}
 	}

--- a/network/p2p/libp2pStream_test.go
+++ b/network/p2p/libp2pStream_test.go
@@ -153,8 +153,11 @@ func testCreateStream(t *testing.T, sporkId flow.Identifier, unicasts []unicast.
 	// Assert that there is no outbound stream to the target yet
 	require.Equal(t, 0, p2p.CountStream(nodes[0].Host(), nodes[1].Host().ID(), protocolID, network.DirOutbound))
 
-	// Now attempt to create another 100 outbound stream to the same destination by calling CreateStream
-	streamCount := 100
+	// Now attempt to create another 50 outbound stream to the same destination by calling CreateStream
+	//
+	// NB! This number must be lower than default limits in libp2p:
+	// See: https://github.com/libp2p/go-libp2p/blob/master/limits.go
+	streamCount := 50
 	var streams []network.Stream
 	for i := 0; i < streamCount; i++ {
 		pInfo, err := p2p.PeerAddressInfo(*id2)

--- a/network/p2p/libp2pStream_test.go
+++ b/network/p2p/libp2pStream_test.go
@@ -600,18 +600,18 @@ func TestConnectionGating(t *testing.T) {
 		_, ok := node1Peers[p]
 		return ok
 	}))
+	defer stopNode(t, node1)
 
 	node2Peers := make(map[peer.ID]struct{})
 	node2, node2Id := nodeFixture(t, ctx, sporkID, "test_connection_gating", withPeerFilter(func(p peer.ID) bool {
 		_, ok := node2Peers[p]
 		return ok
 	}))
+	defer stopNode(t, node2)
 
-	defer stopNode(t, node1)
 	node1Info, err := p2p.PeerAddressInfo(node1Id)
 	assert.NoError(t, err)
 
-	defer stopNode(t, node2)
 	node2Info, err := p2p.PeerAddressInfo(node2Id)
 	assert.NoError(t, err)
 

--- a/network/p2p/sporking_test.go
+++ b/network/p2p/sporking_test.go
@@ -146,7 +146,6 @@ func TestOneToKCrosstalkPrevention(t *testing.T) {
 		previousSporkId,
 		"test_one_to_k_crosstalk_prevention",
 	)
-
 	defer stopNode(t, node1)
 
 	// create and start node 2 on localhost and random port with the same root block ID
@@ -155,9 +154,9 @@ func TestOneToKCrosstalkPrevention(t *testing.T) {
 		previousSporkId,
 		"test_one_to_k_crosstalk_prevention",
 	)
+	defer stopNode(t, node2)
 
 	pInfo2, err := p2p.PeerAddressInfo(id2)
-	defer stopNode(t, node2)
 	require.NoError(t, err)
 
 	// spork topic is derived by suffixing the channel with the root block ID

--- a/network/p2p/topic_validator_test.go
+++ b/network/p2p/topic_validator_test.go
@@ -31,8 +31,11 @@ func TestTopicValidator_Unstaked(t *testing.T) {
 	nodeFixtureCtx, nodeFixtureCtxCancel := context.WithCancel(context.Background())
 	defer nodeFixtureCtxCancel()
 
-	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "TestAuthorizedSenderValidator_Unauthorized", withRole(flow.RoleConsensus), withLogger(logger))
-	sn2, _ := nodeFixture(t, nodeFixtureCtx, sporkId, "TestAuthorizedSenderValidator_Unauthorized", withRole(flow.RoleConsensus), withLogger(logger))
+	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
+	sn2, _ := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
+	defer func() {
+		stopNodes(t, []*p2p.Node{sn1, sn2})
+	}()
 
 	channel := channels.ConsensusCommittee
 	topic := channels.TopicFromChannel(channel, sporkId)
@@ -100,8 +103,11 @@ func TestTopicValidator_PublicChannel(t *testing.T) {
 	nodeFixtureCtx, nodeFixtureCtxCancel := context.WithCancel(context.Background())
 	defer nodeFixtureCtxCancel()
 
-	sn1, _ := nodeFixture(t, nodeFixtureCtx, sporkId, "TestTopicValidator_PublicChannel", withRole(flow.RoleConsensus), withLogger(logger))
-	sn2, _ := nodeFixture(t, nodeFixtureCtx, sporkId, "TestTopicValidator_PublicChannel", withRole(flow.RoleConsensus), withLogger(logger))
+	sn1, _ := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
+	sn2, _ := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
+	defer func() {
+		stopNodes(t, []*p2p.Node{sn1, sn2})
+	}()
 
 	// unauthenticated messages should not be dropped on public channels
 	channel := channels.PublicSyncCommittee
@@ -156,9 +162,12 @@ func TestAuthorizedSenderValidator_Unauthorized(t *testing.T) {
 	nodeFixtureCtx, nodeFixtureCtxCancel := context.WithCancel(context.Background())
 	defer nodeFixtureCtxCancel()
 
-	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "TestAuthorizedSenderValidator_InvalidMsg", withRole(flow.RoleConsensus))
-	sn2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, "TestAuthorizedSenderValidator_InvalidMsg", withRole(flow.RoleConsensus))
-	an1, identity3 := nodeFixture(t, nodeFixtureCtx, sporkId, "TestAuthorizedSenderValidator_InvalidMsg", withRole(flow.RoleAccess))
+	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus))
+	sn2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus))
+	an1, identity3 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleAccess))
+	defer func() {
+		stopNodes(t, []*p2p.Node{sn1, sn2, an1})
+	}()
 
 	channel := channels.ConsensusCommittee
 	topic := channels.TopicFromChannel(channel, sporkId)
@@ -261,6 +270,9 @@ func TestAuthorizedSenderValidator_InvalidMsg(t *testing.T) {
 
 	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_1", withRole(flow.RoleConsensus))
 	sn2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_2", withRole(flow.RoleConsensus))
+	defer func() {
+		stopNodes(t, []*p2p.Node{sn1, sn2})
+	}()
 
 	// try to publish BlockProposal on invalid SyncCommittee channel
 	channel := channels.SyncCommittee
@@ -331,6 +343,9 @@ func TestAuthorizedSenderValidator_Ejected(t *testing.T) {
 	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_1", withRole(flow.RoleConsensus))
 	sn2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_2", withRole(flow.RoleConsensus))
 	an1, identity3 := nodeFixture(t, nodeFixtureCtx, sporkId, "access_1", withRole(flow.RoleAccess))
+	defer func() {
+		stopNodes(t, []*p2p.Node{sn1, sn2, an1})
+	}()
 
 	channel := channels.ConsensusCommittee
 	topic := channels.TopicFromChannel(channel, sporkId)
@@ -419,6 +434,9 @@ func TestAuthorizedSenderValidator_ClusterChannel(t *testing.T) {
 	ln1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "collection_1", withRole(flow.RoleCollection))
 	ln2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, "collection_2", withRole(flow.RoleCollection))
 	ln3, identity3 := nodeFixture(t, nodeFixtureCtx, sporkId, "collection_3", withRole(flow.RoleCollection))
+	defer func() {
+		stopNodes(t, []*p2p.Node{ln1, ln2, ln3})
+	}()
 
 	channel := channels.SyncCluster(flow.Testnet)
 	topic := channels.TopicFromChannel(channel, sporkId)

--- a/network/p2p/topic_validator_test.go
+++ b/network/p2p/topic_validator_test.go
@@ -33,9 +33,7 @@ func TestTopicValidator_Unstaked(t *testing.T) {
 
 	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
 	sn2, _ := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
-	defer func() {
-		stopNodes(t, []*p2p.Node{sn1, sn2})
-	}()
+	defer stopNodes(t, []*p2p.Node{sn1, sn2})
 
 	channel := channels.ConsensusCommittee
 	topic := channels.TopicFromChannel(channel, sporkId)
@@ -105,9 +103,7 @@ func TestTopicValidator_PublicChannel(t *testing.T) {
 
 	sn1, _ := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
 	sn2, _ := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus), withLogger(logger))
-	defer func() {
-		stopNodes(t, []*p2p.Node{sn1, sn2})
-	}()
+	defer stopNodes(t, []*p2p.Node{sn1, sn2})
 
 	// unauthenticated messages should not be dropped on public channels
 	channel := channels.PublicSyncCommittee
@@ -165,9 +161,7 @@ func TestAuthorizedSenderValidator_Unauthorized(t *testing.T) {
 	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus))
 	sn2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleConsensus))
 	an1, identity3 := nodeFixture(t, nodeFixtureCtx, sporkId, t.Name(), withRole(flow.RoleAccess))
-	defer func() {
-		stopNodes(t, []*p2p.Node{sn1, sn2, an1})
-	}()
+	defer stopNodes(t, []*p2p.Node{sn1, sn2, an1})
 
 	channel := channels.ConsensusCommittee
 	topic := channels.TopicFromChannel(channel, sporkId)
@@ -270,9 +264,7 @@ func TestAuthorizedSenderValidator_InvalidMsg(t *testing.T) {
 
 	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_1", withRole(flow.RoleConsensus))
 	sn2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_2", withRole(flow.RoleConsensus))
-	defer func() {
-		stopNodes(t, []*p2p.Node{sn1, sn2})
-	}()
+	defer stopNodes(t, []*p2p.Node{sn1, sn2})
 
 	// try to publish BlockProposal on invalid SyncCommittee channel
 	channel := channels.SyncCommittee
@@ -343,9 +335,7 @@ func TestAuthorizedSenderValidator_Ejected(t *testing.T) {
 	sn1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_1", withRole(flow.RoleConsensus))
 	sn2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, "consensus_2", withRole(flow.RoleConsensus))
 	an1, identity3 := nodeFixture(t, nodeFixtureCtx, sporkId, "access_1", withRole(flow.RoleAccess))
-	defer func() {
-		stopNodes(t, []*p2p.Node{sn1, sn2, an1})
-	}()
+	defer stopNodes(t, []*p2p.Node{sn1, sn2, an1})
 
 	channel := channels.ConsensusCommittee
 	topic := channels.TopicFromChannel(channel, sporkId)
@@ -434,9 +424,7 @@ func TestAuthorizedSenderValidator_ClusterChannel(t *testing.T) {
 	ln1, identity1 := nodeFixture(t, nodeFixtureCtx, sporkId, "collection_1", withRole(flow.RoleCollection))
 	ln2, identity2 := nodeFixture(t, nodeFixtureCtx, sporkId, "collection_2", withRole(flow.RoleCollection))
 	ln3, identity3 := nodeFixture(t, nodeFixtureCtx, sporkId, "collection_3", withRole(flow.RoleCollection))
-	defer func() {
-		stopNodes(t, []*p2p.Node{ln1, ln2, ln3})
-	}()
+	defer stopNodes(t, []*p2p.Node{ln1, ln2, ln3})
 
 	channel := channels.SyncCluster(flow.Testnet)
 	topic := channels.TopicFromChannel(channel, sporkId)


### PR DESCRIPTION
Factor out test changes from #2988

* fix `TestPubSubWithDHTDiscovery` race.
* remove hardcoded test names from DHTPrefix.
* always wait for nodes to be stopped.
* lower number of streams in test to 50 to be within [libp2p limits](https://github.com/libp2p/go-libp2p/blob/master/limits.go).

@yhassanzadeh13 you may consider returning stopNode closure from `nodeFixture` since stopping is always required.

Ref: #3034
Ref: #2988