### PR TITLE
[Profiler] Add heap allocation diffs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.8
+	github.com/google/pprof v0.0.0-20220818150347-1763105d910c
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -400,8 +400,6 @@ github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dT
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
-github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
-github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -518,6 +516,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20220412212628-83db2b799d1f/go.mod h1:Pt31oes+eGImORns3McJn8zHefuQl2rG8l6xQjGYB4U=
+github.com/google/pprof v0.0.0-20220818150347-1763105d910c h1:jk3Bnv5QzOSJil2OC6EQBoqy+lj/Kw56nrkEzvrQm2w=
+github.com/google/pprof v0.0.0-20220818150347-1763105d910c/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
+	github.com/google/pprof v0.0.0-20220818150347-1763105d910c // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/googleapis/go-type-adapters v1.0.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -432,10 +432,6 @@ github.com/go-openapi/errors v0.19.8/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpX
 github.com/go-openapi/strfmt v0.20.1 h1:1VgxvehFne1mbChGeCmZ5pc0LxUf6yaACVSIYAR91Xc=
 github.com/go-openapi/strfmt v0.20.1/go.mod h1:43urheQI9dNtE5lTZQfuFJvjYJKPrxicATpEfZwHUNk=
 github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
-github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
-github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
-github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -550,7 +546,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
@@ -583,10 +578,11 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20220818150347-1763105d910c h1:jk3Bnv5QzOSJil2OC6EQBoqy+lj/Kw56nrkEzvrQm2w=
+github.com/google/pprof v0.0.0-20220818150347-1763105d910c/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/module/profiler/profiler.go
+++ b/module/profiler/profiler.go
@@ -167,7 +167,6 @@ func (p *AutoProfiler) goHeapProfile(sampleTypes ...string) (*profile.Profile, e
 	}
 	prof.TimeNanos = time.Now().UnixNano()
 
-	// TODO(rbtz): add tests.
 	selectedSampleTypes := make([]int, 0, len(sampleTypes))
 	for _, name := range sampleTypes {
 		for i, sampleType := range prof.SampleType {

--- a/module/profiler/profiler_internal_test.go
+++ b/module/profiler/profiler_internal_test.go
@@ -1,0 +1,80 @@
+package profiler
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/pprof/profile"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestGoHeapProfile(t *testing.T) {
+	t.Parallel()
+	t.Run("goHeapProfile", func(t *testing.T) {
+		unittest.RunWithTempDir(t, func(tempDir string) {
+			p, err := New(zerolog.Nop(), &NoopUploader{}, tempDir, time.Millisecond*100, time.Millisecond*100, false)
+			require.NoError(t, err)
+			unittest.AssertClosesBefore(t, p.Ready(), 5*time.Second)
+			t.Logf("profiler ready %s", tempDir)
+
+			prof, err := p.goHeapProfile("inuse_objects", "alloc_space")
+			require.NoError(t, err)
+			require.NotEmpty(t, prof)
+
+			require.Equal(t, "inuse_objects", prof.DefaultSampleType)
+			require.Equal(t, 2, len(prof.SampleType))
+			require.Equal(t, "inuse_objects", prof.SampleType[0].Type)
+			require.Equal(t, "alloc_space", prof.SampleType[1].Type)
+			require.NotZero(t, len(prof.Sample))
+			require.Equal(t, 2, len(prof.Sample[0].Value))
+			require.NotZero(t, prof.Sample[0].Value[0]+prof.Sample[0].Value[1])
+
+			unittest.AssertClosesBefore(t, p.Done(), 5*time.Second)
+		})
+	})
+}
+
+func TestGoAllocsProfile(t *testing.T) {
+	t.Parallel()
+	t.Run("pprofAllocs", func(t *testing.T) {
+		unittest.RunWithTempDir(t, func(tempDir string) {
+			p, err := New(zerolog.Nop(), &NoopUploader{}, tempDir, time.Hour, time.Second*1, false)
+			require.NoError(t, err)
+			unittest.AssertClosesBefore(t, p.Ready(), 5*time.Second)
+			t.Logf("profiler ready %s", tempDir)
+
+			ticker := time.NewTicker(time.Millisecond * 10)
+			defer ticker.Stop()
+
+			// do some allocations in the background
+			go func() {
+				for range ticker.C {
+					var m runtime.MemStats
+					runtime.ReadMemStats(&m)
+				}
+			}()
+
+			buf := &bytes.Buffer{}
+			err = p.pprofAllocs(buf)
+			require.NoError(t, err)
+
+			prof, err := profile.Parse(buf)
+			require.NoError(t, err)
+
+			require.Equal(t, "alloc_objects", prof.DefaultSampleType)
+			require.Equal(t, 2, len(prof.SampleType))
+			require.Equal(t, "alloc_objects", prof.SampleType[0].Type)
+			require.Equal(t, "alloc_space", prof.SampleType[1].Type)
+			require.NotZero(t, len(prof.Sample))
+			require.Equal(t, 2, len(prof.Sample[0].Value))
+			require.NotZero(t, prof.Sample[0].Value[0]+prof.Sample[0].Value[1])
+
+			unittest.AssertClosesBefore(t, p.Done(), 5*time.Second)
+		})
+	})
+}

--- a/module/profiler/profiler_test.go
+++ b/module/profiler/profiler_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestProfiler(t *testing.T) {
-	t.Parallel()
+	// profiler depends on the shared state, hence only one enabled=true test can run at a time.
 	t.Run("profilerEnabled", func(t *testing.T) {
 		unittest.RunWithTempDir(t, func(tempDir string) {
 			p, err := profiler.New(zerolog.Nop(), &profiler.NoopUploader{}, tempDir, time.Millisecond*100, time.Millisecond*100, true)


### PR DESCRIPTION
Switch `ALLOC_HEAP` to upload "allocs" diff within the profiling duration, while `HEAP` only uploads the "inuse" objects.

Aside from being more consistent with both `pprof` http endpoint and `cloudprofiler` reference library, it also workarounds some of GCP API limits since it greatly reduces profile sizes:

```
Failed to create offline profile: rpc error: code = ResourceExhausted desc = Received message larger than max (46449079 vs. 16777216)
```