### PR TITLE
[Testing] Enable unit-testing of the benchmark directory

### DIFF
--- a/integration/Makefile
+++ b/integration/Makefile
@@ -15,7 +15,7 @@ ci-integration-test: access-tests ghost-tests mvp-tests epochs-tests consensus-t
 # Run unit tests for test utilities in this module
 .PHONY: test
 test:
-	go test $(if $(VERBOSE),-v,) -tags relic -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) `go list ./... | grep -v -e integration/tests -e integration/benchmark`
+	go test $(if $(VERBOSE),-v,) -tags relic -coverprofile=$(COVER_PROFILE) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) `go list ./... | grep -v -e integration/tests`
 
 .PHONY: access-tests
 access-tests:


### PR DESCRIPTION
Previously it contained TPS test and was explicitly skipped by CI.  Nowadays it contains legitimate unit tests for the end-to-end TPS benchmark.