### PR TITLE
[Build] Update docker-build-loader target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ tool-transit: docker-build-bootstrap-transit
 
 .PHONY: docker-build-loader
 docker-build-loader:
-	docker build -f ./integration/benchmark/cmd/manual/Dockerfile --build-arg TARGET=./loader --target production \
+	docker build -f ./integration/benchmark/cmd/manual/Dockerfile --build-arg TARGET=./benchmark/cmd/manual --target production \
 		--label "git_commit=${COMMIT}" --label "git_tag=${IMAGE_TAG}" \
 		-t "$(CONTAINER_REGISTRY)/loader:latest" -t "$(CONTAINER_REGISTRY)/loader:$(SHORT_COMMIT)" -t "$(CONTAINER_REGISTRY)/loader:$(IMAGE_TAG)" .
 


### PR DESCRIPTION
The Loader files were recently moved and the target location for this makefile target became out of sync. Pointing the target to the new loader location.

These changes were tested with `sudo make docker-build-benchnet CONTAINER_REGISTRY=[gcr.io/flow-benchmark](http://gcr.io/flow-benchmark) IMAGE_TAG=benchnet1` and `sudo make docker-build-loader CONTAINER_REGISTRY=[gcr.io/flow-benchmark](http://gcr.io/flow-benchmark) IMAGE_TAG=benchnet1`. This should cover both the smallest case and the end to end case of usage. 