### PR TITLE
[Testing] Bump golangci-lint to v1.47.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-        version: v1.46
+        version: v1.47
         args: -v --build-tags relic
         working-directory: ${{ matrix.dir }}
         # https://github.com/golangci/golangci-lint-action/issues/244

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install-mock-generators:
 
 .PHONY: install-tools
 install-tools: crypto_setup_tests crypto_setup_gopath check-go-version install-mock-generators
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.46.2; \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.47.3; \
 	cd ${GOPATH}; \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.2; \
 	go install github.com/uber/prototool/cmd/prototool@v1.9.0; \

--- a/crypto/spock.go
+++ b/crypto/spock.go
@@ -1,3 +1,4 @@
+//go:build relic
 // +build relic
 
 package crypto

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/access"
+	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/factory"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -157,7 +158,7 @@ func (suite *Suite) TestInvalidTransaction() {
 
 		err := suite.engine.ProcessTransaction(&tx)
 		suite.Assert().Error(err)
-		suite.Assert().True(errors.As(err, &access.ErrUnknownReferenceBlock))
+		suite.Assert().True(errors.As(err, &engine.UnverifiableInputError{}))
 	})
 
 	suite.Run("un-parseable script", func() {

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -1794,7 +1794,7 @@ func TestExtendInvalidGuarantee(t *testing.T) {
 		block := unittest.BlockWithParentFixture(head)
 		payload := flow.EmptyPayload()
 		payload.Guarantees = []*flow.CollectionGuarantee{
-			&flow.CollectionGuarantee{
+			{
 				ChainID:          cluster.ChainID(),
 				ReferenceBlockID: head.ID(),
 				SignerIndices:    validSignerIndices,
@@ -1813,7 +1813,7 @@ func TestExtendInvalidGuarantee(t *testing.T) {
 		err = state.Extend(context.Background(), block)
 		require.Error(t, err)
 		require.True(t, signature.IsInvalidSignerIndicesError(err), err)
-		require.True(t, errors.As(err, &signature.ErrInvalidChecksum), err)
+		require.True(t, errors.Is(err, signature.ErrInvalidChecksum), err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
 
 		// now the guarantee has invalid signer indices: the checksum should have 4 bytes, but it only has 1
@@ -1827,7 +1827,7 @@ func TestExtendInvalidGuarantee(t *testing.T) {
 		err = state.Extend(context.Background(), block)
 		require.Error(t, err)
 		require.True(t, signature.IsInvalidSignerIndicesError(err), err)
-		require.True(t, errors.As(err, &signature.ErrInvalidChecksum), err)
+		require.True(t, errors.Is(err, signature.ErrInvalidChecksum), err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
 
 		// let's test even if the checksum is correct, but signer indices is still wrong because the tailing are not 0,
@@ -1840,7 +1840,7 @@ func TestExtendInvalidGuarantee(t *testing.T) {
 		err = state.Extend(context.Background(), block)
 		require.Error(t, err)
 		require.True(t, signature.IsInvalidSignerIndicesError(err), err)
-		require.True(t, errors.As(err, &signature.ErrIllegallyPaddedBitVector), err)
+		require.True(t, errors.Is(err, signature.ErrIllegallyPaddedBitVector), err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
 
 		// test imcompatible bit vector length
@@ -1849,7 +1849,7 @@ func TestExtendInvalidGuarantee(t *testing.T) {
 		err = state.Extend(context.Background(), block)
 		require.Error(t, err)
 		require.True(t, signature.IsInvalidSignerIndicesError(err), err)
-		require.True(t, errors.As(err, &signature.ErrIncompatibleBitVectorLength), err)
+		require.True(t, errors.Is(err, signature.ErrIncompatibleBitVectorLength), err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
 
 		// revert back to good value
@@ -1859,7 +1859,7 @@ func TestExtendInvalidGuarantee(t *testing.T) {
 		payload.Guarantees[0].ReferenceBlockID = flow.ZeroID
 		err = state.Extend(context.Background(), block)
 		require.Error(t, err)
-		require.True(t, errors.As(err, &storage.ErrNotFound), err)
+		require.True(t, errors.Is(err, storage.ErrNotFound), err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
 
 		// revert back to good value
@@ -1874,7 +1874,7 @@ func TestExtendInvalidGuarantee(t *testing.T) {
 		payload.Guarantees[0].ChainID = flow.ChainID("some_bad_chain_ID")
 		err = state.Extend(context.Background(), block)
 		require.Error(t, err)
-		require.True(t, errors.As(err, &realprotocol.ErrClusterNotFound), err)
+		require.True(t, errors.Is(err, realprotocol.ErrClusterNotFound), err)
 		require.True(t, st.IsInvalidExtensionError(err), err)
 	})
 }


### PR DESCRIPTION
Factors out `go vet` changes from #2988 and bumps the CI version.