### PR TITLE
[FVM] Move HandleRuntimeError to ContractFunctionInvoker

### DIFF
--- a/fvm/contractFunctionInvoker.go
+++ b/fvm/contractFunctionInvoker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/module/trace"
 )
 
@@ -59,6 +60,8 @@ func (i *ContractFunctionInvoker) Invoke(env Environment) (cadence.Value, error)
 	)
 
 	if err != nil {
+		// this is an error coming from Cadendce runtime, so it must be handled first.
+		err = errors.HandleRuntimeError(err)
 		i.logger.
 			Info().
 			Err(err).

--- a/fvm/contractFunctionInvoker_test.go
+++ b/fvm/contractFunctionInvoker_test.go
@@ -1,0 +1,132 @@
+package fvm_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	runtimeerrors "github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/sema"
+
+	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/errors"
+	fvmMock "github.com/onflow/flow-go/fvm/mock"
+	"github.com/onflow/flow-go/module/trace"
+)
+
+func TestContractInvoker(t *testing.T) {
+
+	type testCase struct {
+		name             string
+		contractFunction func(
+			a common.AddressLocation,
+			s string,
+			values []cadence.Value,
+			types []sema.Type,
+			ctx runtime.Context,
+		) (cadence.Value, error)
+		require func(t *testing.T, v cadence.Value, err error)
+	}
+
+	testCases := []testCase{
+		{
+			name: "noop",
+			contractFunction: func(a common.AddressLocation, s string, values []cadence.Value, types []sema.Type, ctx runtime.Context) (cadence.Value, error) {
+				return nil, nil
+			},
+			require: func(t *testing.T, v cadence.Value, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "value gets returned as is",
+			contractFunction: func(a common.AddressLocation, s string, values []cadence.Value, types []sema.Type, ctx runtime.Context) (cadence.Value, error) {
+				return cadence.String("value"), nil
+			},
+			require: func(t *testing.T, v cadence.Value, err error) {
+				require.NoError(t, err)
+				require.Equal(t, cadence.String("value"), v)
+			},
+		},
+		{
+			name: "unknown error from contract function is handled",
+			contractFunction: func(a common.AddressLocation, s string, values []cadence.Value, types []sema.Type, ctx runtime.Context) (cadence.Value, error) {
+				return nil, fmt.Errorf("non-runtime error")
+			},
+			require: func(t *testing.T, v cadence.Value, err error) {
+				require.Error(t, err)
+
+				var failure errors.Failure
+				require.ErrorAs(t, err, &failure)
+
+				errors.As(err, &failure)
+
+				require.Equal(t, errors.FailureCodeUnknownFailure, failure.FailureCode())
+			},
+		},
+		{
+			name: "known error from contract function is handled",
+			contractFunction: func(a common.AddressLocation, s string, values []cadence.Value, types []sema.Type, ctx runtime.Context) (cadence.Value, error) {
+				return nil, runtime.Error{
+					Err:      fmt.Errorf("some error"),
+					Location: common.AddressLocation{},
+				}
+			},
+			require: func(t *testing.T, v cadence.Value, err error) {
+				require.Error(t, err)
+
+				var rterr *errors.CadenceRuntimeError
+				require.ErrorAs(t, err, &rterr)
+			},
+		},
+		{
+			name: "external error from contract function is unwrapped",
+			contractFunction: func(a common.AddressLocation, s string, values []cadence.Value, types []sema.Type, ctx runtime.Context) (cadence.Value, error) {
+				return nil, runtime.Error{
+					Err: runtimeerrors.ExternalError{
+						Recovered: &errors.ContractNotFoundError{},
+					},
+					Location: common.AddressLocation{},
+				}
+			},
+			require: func(t *testing.T, v cadence.Value, err error) {
+				require.Error(t, err)
+
+				var someFVMerr *errors.ContractNotFoundError
+				require.ErrorAs(t, err, &someFVMerr)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			invoker := fvm.NewContractFunctionInvoker(
+				common.AddressLocation{},
+				"functionName",
+				[]cadence.Value{},
+				[]sema.Type{},
+				zerolog.Nop())
+
+			env := &fvmMock.Environment{}
+			vm := &fvm.VirtualMachine{
+				Runtime: &TestInterpreterRuntime{
+					invokeContractFunction: tc.contractFunction,
+				},
+			}
+
+			env.On("StartSpanFromRoot", mock.Anything).Return(trace.NoopSpan)
+			env.On("VM").Return(vm)
+
+			value, err := invoker.Invoke(env)
+
+			tc.require(t, value, err)
+		})
+	}
+}

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -274,7 +274,7 @@ func (env *commonEnv) GetStorageCapacity(
 		env.fullEnv,
 		address)
 	if invokeErr != nil {
-		return 0, errors.HandleRuntimeError(invokeErr)
+		return 0, invokeErr
 	}
 
 	// Return type is actually a UFix64 with the unit of megabytes so some
@@ -298,7 +298,7 @@ func (env *commonEnv) GetAccountBalance(
 
 	result, invokeErr := InvokeAccountBalanceContract(env.fullEnv, address)
 	if invokeErr != nil {
-		return 0, errors.HandleRuntimeError(invokeErr)
+		return 0, invokeErr
 	}
 	return result.ToGoValue().(uint64), nil
 }
@@ -321,7 +321,7 @@ func (env *commonEnv) GetAccountAvailableBalance(
 		address)
 
 	if invokeErr != nil {
-		return 0, errors.HandleRuntimeError(invokeErr)
+		return 0, invokeErr
 	}
 	return result.ToGoValue().(uint64), nil
 }

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -297,7 +297,7 @@ func (e *TransactionEnv) CreateAccount(payer runtime.Address) (address runtime.A
 			flowAddress,
 			payer)
 		if invokeErr != nil {
-			return address, errors.HandleRuntimeError(invokeErr)
+			return address, invokeErr
 		}
 	}
 


### PR DESCRIPTION
...so we don't forget to call it somewhere, as was the case already (with the storage check).