### PR TITLE
Adding Upsert for BadgerDB operations

### DIFF
--- a/storage/badger/operation/common.go
+++ b/storage/badger/operation/common.go
@@ -115,6 +115,35 @@ func update(key []byte, entity interface{}) func(*badger.Txn) error {
 	}
 }
 
+// upsert will encode the given entity with MsgPack and upsert the binary data
+// under the given key in the badger DB.
+func upsert(key []byte, entity interface{}) func(*badger.Txn) error {
+	return func(tx *badger.Txn) error {
+		// update the maximum key size if the inserted key is bigger
+		if uint32(len(key)) > max {
+			max = uint32(len(key))
+			err := SetMax(tx)
+			if err != nil {
+				return fmt.Errorf("could not update max tracker: %w", err)
+			}
+		}
+
+		// serialize the entity data
+		val, err := msgpack.Marshal(entity)
+		if err != nil {
+			return fmt.Errorf("could not encode entity: %w", err)
+		}
+
+		// persist the entity data into the DB
+		err = tx.Set(key, val)
+		if err != nil {
+			return fmt.Errorf("could not upsert data: %w", err)
+		}
+
+		return nil
+	}
+}
+
 // remove removes the entity with the given key, if it exists. If it doesn't
 // exist, this is a no-op.
 func remove(key []byte) func(*badger.Txn) error {


### PR DESCRIPTION
Adding `upsert` operation to BadgerDB operation list. 

Existing `insert()` errs out when key already exists, `update()` errs out when there's no given key already existed. `upsert` can be useful in certain use cases so that we will not have to `get()->insert()` which is unnecessarily slow.

Ref discussion: https://github.com/onflow/flow-go/pull/2743#discussion_r949695662

**Test**
- [X] new unit test cases