### PR TITLE
[Testing] Add LoggerForTest to avoid hardcoding Caller

### DIFF
--- a/integration/tests/access/access_test.go
+++ b/integration/tests/access/access_test.go
@@ -44,11 +44,7 @@ func (s *AccessSuite) TearDownTest() {
 }
 
 func (suite *AccessSuite) SetupTest() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "api.go").
-		Str("testcase", suite.T().Name()).
-		Logger()
-	suite.log = logger
+	suite.log = unittest.LoggerForTest(suite.Suite.T(), zerolog.InfoLevel)
 	suite.log.Info().Msg("================> SetupTest")
 	defer func() {
 		suite.log.Info().Msg("================> Finish SetupTest")

--- a/integration/tests/access/consensus_follower_test.go
+++ b/integration/tests/access/consensus_follower_test.go
@@ -50,11 +50,7 @@ func (s *ConsensusFollowerSuite) TearDownTest() {
 }
 
 func (suite *ConsensusFollowerSuite) SetupTest() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "unstaked.go").
-		Str("testcase", suite.T().Name()).
-		Logger()
-	suite.log = logger
+	suite.log = unittest.LoggerForTest(suite.Suite.T(), zerolog.InfoLevel)
 	suite.log.Info().Msg("================> SetupTest")
 	suite.ctx, suite.cancel = context.WithCancel(context.Background())
 	suite.buildNetworkConfig()

--- a/integration/tests/access/execution_state_sync_test.go
+++ b/integration/tests/access/execution_state_sync_test.go
@@ -44,12 +44,7 @@ type ExecutionStateSyncSuite struct {
 }
 
 func (s *ExecutionStateSyncSuite) SetupTest() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "execution_state_sync_test.go").
-		Str("testcase", s.T().Name()).
-		Logger()
-
-	s.log = logger
+	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 	s.log.Info().Msg("================> SetupTest")
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 

--- a/integration/tests/bft/passthrough/suite.go
+++ b/integration/tests/bft/passthrough/suite.go
@@ -60,11 +60,7 @@ func (s *Suite) AccessClient() *testnet.Client {
 // - One corrupted verification node
 // - One ghost node (as an execution node)
 func (s *Suite) SetupSuite() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", s.T().Name()).
-		Logger()
-	s.log = logger
+	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 
 	s.nodeConfigs = append(s.nodeConfigs, testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.FatalLevel)))
 
@@ -146,7 +142,7 @@ func (s *Suite) SetupSuite() {
 	// starts tracking blocks by the ghost node
 	s.Track(s.T(), ctx, s.Ghost())
 
-	s.Orchestrator = NewDummyOrchestrator(logger)
+	s.Orchestrator = NewDummyOrchestrator(s.log)
 
 	// start orchestrator network
 	codec := unittest.NetworkCodec()

--- a/integration/tests/bft/wintermute/suite.go
+++ b/integration/tests/bft/wintermute/suite.go
@@ -73,11 +73,7 @@ func (s *Suite) AccessClient() *testnet.Client {
 // This guarantees that each chunk is assigned to at least two corrupted verification nodes, and they are
 // enough to approve and seal the chunk.
 func (s *Suite) SetupSuite() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", s.T().Name()).
-		Logger()
-	s.log = logger
+	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 
 	chunkAlpha := "--chunk-alpha=3" // each chunk is assigned to 3 VNs.
 
@@ -176,7 +172,7 @@ func (s *Suite) SetupSuite() {
 	s.cancel = cancel
 	s.net.Start(ctx)
 
-	s.Orchestrator = wintermute.NewOrchestrator(logger, s.net.CorruptedIdentities().NodeIDs(), s.net.Identities())
+	s.Orchestrator = wintermute.NewOrchestrator(s.log, s.net.CorruptedIdentities().NodeIDs(), s.net.Identities())
 
 	// start orchestrator network
 	codec := unittest.NetworkCodec()

--- a/integration/tests/collection/suite.go
+++ b/integration/tests/collection/suite.go
@@ -61,13 +61,9 @@ type CollectorSuite struct {
 // and clusters and starts the network.
 //
 // NOTE: This must be called explicitly by each test, since nodes/clusters vary
-//       between test cases.
+// between test cases.
 func (suite *CollectorSuite) SetupTest(name string, nNodes, nClusters uint) {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", suite.T().Name()).
-		Logger()
-	suite.log = logger
+	suite.log = unittest.LoggerForTest(suite.Suite.T(), zerolog.InfoLevel)
 	suite.log.Info().Msg("================> SetupTest")
 
 	var (

--- a/integration/tests/consensus/inclusion_test.go
+++ b/integration/tests/consensus/inclusion_test.go
@@ -43,11 +43,7 @@ func (is *InclusionSuite) Collection() *client.GhostClient {
 }
 
 func (is *InclusionSuite) SetupTest() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "inclusion.go").
-		Str("testcase", is.T().Name()).
-		Logger()
-	is.log = logger
+	is.log = unittest.LoggerForTest(is.Suite.T(), zerolog.InfoLevel)
 	is.log.Info().Msgf("================> SetupTest")
 
 	// seed random generator

--- a/integration/tests/consensus/sealing_test.go
+++ b/integration/tests/consensus/sealing_test.go
@@ -63,11 +63,7 @@ func (ss *SealingSuite) Verification() *client.GhostClient {
 }
 
 func (ss *SealingSuite) SetupTest() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "sealing.go").
-		Str("testcase", ss.T().Name()).
-		Logger()
-	ss.log = logger
+	ss.log = unittest.LoggerForTest(ss.Suite.T(), zerolog.InfoLevel)
 	ss.log.Info().Msgf("================> SetupTest")
 
 	// seed random generator

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -59,11 +59,7 @@ func (s *Suite) SetupTest() {
 	require.Greater(s.T(), s.EpochLen, s.StakingAuctionLen+s.DKGPhaseLen*3)
 
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", s.T().Name()).
-		Logger()
-	s.log = logger
+	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 	s.log.Info().Msg("================> SetupTest")
 	defer func() {
 		s.log.Info().Msg("================> Finish SetupTest")

--- a/integration/tests/execution/suite.go
+++ b/integration/tests/execution/suite.go
@@ -59,11 +59,7 @@ func (s *Suite) MetricsPort() string {
 }
 
 func (s *Suite) SetupTest() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", s.T().Name()).
-		Logger()
-	s.log = logger
+	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 	s.log.Info().Msg("================> SetupTest")
 
 	blockRateFlag := "--block-rate-delay=1ms"

--- a/integration/tests/ghost/ghost_node_example_test.go
+++ b/integration/tests/ghost/ghost_node_example_test.go
@@ -21,10 +21,7 @@ import (
 
 // TestGhostNodeExample_Send demonstrates how to emulate a node and send an event from it
 func TestGhostNodeExample_Send(t *testing.T) {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "ghost_node_send/main_test.go").
-		Str("testcase", t.Name()).
-		Logger()
+	logger := unittest.LoggerForTest(t, zerolog.InfoLevel)
 	logger.Info().Msgf("================> START TESTING")
 
 	var (
@@ -77,10 +74,7 @@ func TestGhostNodeExample_Send(t *testing.T) {
 
 // TestGhostNodeExample_Subscribe demonstrates how to emulate a node and receive all inbound events for it
 func TestGhostNodeExample_Subscribe(t *testing.T) {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "ghost_node_subscribe/main_test.go").
-		Str("testcase", t.Name()).
-		Logger()
+	logger := unittest.LoggerForTest(t, zerolog.InfoLevel)
 	logger.Info().Msgf("================> START TESTING")
 
 	var (

--- a/integration/tests/mvp/mvp_test.go
+++ b/integration/tests/mvp/mvp_test.go
@@ -28,10 +28,7 @@ import (
 const defaultTimeout = time.Second * 10
 
 func TestMVP_Network(t *testing.T) {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", t.Name()).
-		Logger()
+	logger := unittest.LoggerForTest(t, zerolog.InfoLevel)
 	logger.Info().Msgf("================> START TESTING")
 	flowNetwork := testnet.PrepareFlowNetwork(t, buildMVPNetConfig(), flow.Localnet)
 
@@ -49,10 +46,7 @@ func TestMVP_Network(t *testing.T) {
 }
 
 func TestMVP_Bootstrap(t *testing.T) {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", t.Name()).
-		Logger()
+	logger := unittest.LoggerForTest(t, zerolog.InfoLevel)
 	logger.Info().Msgf("================> START TESTING")
 	unittest.SkipUnless(t, unittest.TEST_TODO, "skipping to be re-visited in https://github.com/dapperlabs/flow-go/issues/5451")
 

--- a/integration/tests/verification/suite.go
+++ b/integration/tests/verification/suite.go
@@ -64,11 +64,7 @@ func (s *Suite) MetricsPort() string {
 // - One verification node
 // - One ghost node (as an execution node)
 func (s *Suite) SetupSuite() {
-	logger := unittest.LoggerWithLevel(zerolog.InfoLevel).With().
-		Str("testfile", "suite.go").
-		Str("testcase", s.T().Name()).
-		Logger()
-	s.log = logger
+	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 	s.log.Info().Msg("================> SetupTest")
 
 	blockRateFlag := "--block-rate-delay=1ms"

--- a/utils/unittest/logging.go
+++ b/utils/unittest/logging.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -43,12 +44,12 @@ func LoggerWithWriterAndLevel(writer io.Writer, level zerolog.Level) zerolog.Log
 
 // go:noinline
 func LoggerForTest(t *testing.T, level zerolog.Level) zerolog.Logger {
-	_, file, _, ok := runtime.Caller(0)
+	_, file, _, ok := runtime.Caller(1)
 	if !ok {
-		file = "unknown"
+		file = "???"
 	}
 	return LoggerWithLevel(level).With().
-		Str("testfile", file).Str("testcase", t.Name()).Logger()
+		Str("testfile", filepath.Base(file)).Str("testcase", t.Name()).Logger()
 }
 
 func LoggerWithLevel(level zerolog.Level) zerolog.Logger {

--- a/utils/unittest/logging.go
+++ b/utils/unittest/logging.go
@@ -6,8 +6,10 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -37,6 +39,16 @@ func LoggerWithWriterAndLevel(writer io.Writer, level zerolog.Level) zerolog.Log
 	})
 	log := zerolog.New(writer).Level(level).With().Timestamp().Logger()
 	return log
+}
+
+// go:noinline
+func LoggerForTest(t *testing.T, level zerolog.Level) zerolog.Logger {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		file = "unknown"
+	}
+	return LoggerWithLevel(level).With().
+		Str("testfile", file).Str("testcase", t.Name()).Logger()
 }
 
 func LoggerWithLevel(level zerolog.Level) zerolog.Logger {


### PR DESCRIPTION
Noticed during access integration test troubleshooting.  Most of these hardcoded callers are wrong.