### PR TITLE
[Benchmark] Follow sealed blocks

### DIFF
--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -55,7 +55,7 @@ const (
 	metricport                  = uint(8080)
 	accessNodeAddress           = "127.0.0.1:3569"
 	pushgateway                 = "127.0.0.1:9091"
-	accountMultiplier           = 50
+	accountMultiplier           = 100
 	feedbackEnabled             = true
 	serviceAccountPrivateKeyHex = unittest.ServiceAccountPrivateKeyHex
 )

--- a/integration/benchmark/cmd/manual/main.go
+++ b/integration/benchmark/cmd/manual/main.go
@@ -43,7 +43,7 @@ func main() {
 	pushgateway := flag.String("pushgateway", "127.0.0.1:9091", "host:port for pushgateway")
 	profilerEnabled := flag.Bool("profiler-enabled", false, "whether to enable the auto-profiler")
 	_ = flag.Bool("track-txs", false, "deprecated")
-	accountMultiplierFlag := flag.Int("account-multiplier", 50, "number of accounts to create per load tps")
+	accountMultiplierFlag := flag.Int("account-multiplier", 100, "number of accounts to create per load tps")
 	feedbackEnabled := flag.Bool("feedback-enabled", true, "wait for trannsaction execution before submitting new transaction")
 	maxConstExecTxSizeInBytes := flag.Uint("const-exec-max-tx-size", flow.DefaultMaxTransactionByteSize/10, "max byte size of constant exec transaction size to generate")
 	authAccNumInConstExecTx := flag.Uint("const-exec-num-authorizer", 1, "num of authorizer for each constant exec transaction to generate")

--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -155,14 +155,16 @@ func (f *txFollowerImpl) run() {
 			f.logger.Error().Err(err).Msg("failed to get latest block header")
 			continue
 		}
-		if hdr.Height < f.height+1 {
-			f.logger.Trace().Uint64("want", f.height+1).Uint64("got", hdr.Height).
+
+		nextHeight := f.Height() + 1
+		if hdr.Height < nextHeight {
+			f.logger.Trace().Uint64("want", nextHeight).Uint64("got", hdr.Height).
 				Msg("expected block is not yet sealed")
 			continue
 		}
 
 		getBlockByHeightTime := time.Now()
-		block, err := f.client.GetBlockByHeight(f.ctx, f.height+1)
+		block, err := f.client.GetBlockByHeight(f.ctx, nextHeight)
 		if err != nil {
 			f.logger.Trace().Err(err).Msg("next block is not yet available, retrying")
 			continue

--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -145,14 +145,14 @@ func (f *txFollowerImpl) run() {
 	defer close(f.stopped)
 
 	var totalTxs, totalUnknownTxs uint64
-	for lastBlockTime := time.Now(); ; <-t.C {
-		blockResolutionStart := time.Now()
+	for lastBlockTime := time.Now(); ; {
 
 		select {
 		case <-f.ctx.Done():
 			return
-		default:
+		case <-t.C:
 		}
+		blockResolutionStart := time.Now()
 
 		hdr, err := f.client.GetLatestBlockHeader(f.ctx, true)
 		if err != nil {

--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -41,6 +41,10 @@ func WithMetrics(m *metrics.LoaderCollector) followerOption {
 	return func(f *txFollowerImpl) { f.metrics = m }
 }
 
+// txFollowerImpl is a follower that tracks the current block height and can notify on transaction completion.
+//
+// On creation it starts a goroutine that periodically checks for new blocks.
+// Since there is only a single goroutine that is updating the latest blockID and blockHeight synchronization there pretty relaxed.
 type txFollowerImpl struct {
 	logger  zerolog.Logger
 	metrics *metrics.LoaderCollector
@@ -203,6 +207,7 @@ func (f *txFollowerImpl) run() {
 }
 
 // Follow returns a channel that will be closed when the transaction is completed.
+// If transaction is already being followed, return the existing channel.
 func (f *txFollowerImpl) Follow(txID flowsdk.Identifier) <-chan struct{} {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/integration/benchmark/follower_test.go
+++ b/integration/benchmark/follower_test.go
@@ -26,6 +26,8 @@ func TestTxFollower(t *testing.T) {
 
 	nextBlockID := flowsdk.Identifier{0x6}
 	nextBlockHeight := blockHeight + 1
+	client.On("GetLatestBlockHeader", mock.Anything, mock.Anything).Return(&flowsdk.BlockHeader{ID: nextBlockID, Height: nextBlockHeight}, nil)
+
 	collectionID := flowsdk.Identifier{0x3}
 	client.On("GetBlockByHeight", mock.Anything, nextBlockHeight).Return(
 		&flowsdk.Block{


### PR DESCRIPTION
Following only sealed blocks is beneficial for the load test since it would verify the end-to-end pipeline and could find bottlenecks in verification nodes.

Sealed state is defined as:
> The verification nodes have verified the transaction (the block in which the transaction is) and the seal is included in the latest block

This also matches the flow-cli behavior: https://github.com/onflow/flow-cli/blob/7401e49afd2d7b89e15dc8f42c75fcb279f4e60f/pkg/flowkit/gateway/grpc.go#L148-L151

While here, also bump the account multiplier, since now we have more transactions inflight.