### PR TITLE
[Benchmark] Faster stopping of workers

### DIFF
--- a/integration/benchmark/worker.go
+++ b/integration/benchmark/worker.go
@@ -42,18 +42,18 @@ func (w *Worker) Start() {
 
 		t := time.NewTicker(w.interval)
 		defer t.Stop()
-		for ; ; <-t.C {
-			select {
-			case <-w.ctx.Done():
-				return
-			default:
-			}
-
+		for {
 			w.wg.Add(1)
 			go func() {
 				defer w.wg.Done()
 				w.work(w.workerID)
 			}()
+
+			select {
+			case <-w.ctx.Done():
+				return
+			case <-t.C:
+			}
 		}
 	}()
 }

--- a/integration/benchmark/worker_test.go
+++ b/integration/benchmark/worker_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-// TestWorkerImmediate tests that first job is executed immeediately.
+// TestWorkerImmediate tests that first job is executed immeediately
+// and stops in the middle of waiting for the interval.
 func TestWorkerImmediate(t *testing.T) {
 	t.Parallel()
 	t.Run("immediate", func(t *testing.T) {
 		done := make(chan struct{})
-		w := NewWorker(0, time.Millisecond, func(workerID int) { close(done) })
+		w := NewWorker(0, time.Hour, func(workerID int) { close(done) })
 		w.Start()
 
 		unittest.AssertClosesBefore(t, done, 5*time.Second)


### PR DESCRIPTION
Do not block on channel at the start of the loop.  This removes delay on `Stop()`.  While here, also add a test case that would verify that.