### PR TITLE
[FVM] Fix account reporter memory limit

### DIFF
--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -139,7 +139,10 @@ type balanceProcessor struct {
 
 func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 	vm := fvm.NewVirtualMachine(fvm.NewInterpreterRuntime())
-	ctx := fvm.NewContext(zerolog.Nop(), fvm.WithChain(chain))
+	ctx := fvm.NewContext(zerolog.Nop(),
+		fvm.WithChain(chain),
+		// otherwise the memory limit gets overridden
+		fvm.WithAllowContextOverrideByExecutionState(false))
 	prog := programs.NewEmptyPrograms()
 
 	v := view.NewChild()


### PR DESCRIPTION
The account reporter was hitting the memory limit. This is because the memory limit was read from the state, instead of the config provided.

This disables the memory limit being read from the state, because it makes no sense here.