### PR TITLE
Set last full block height in ingestion engine component startup

### DIFF
--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -187,6 +187,43 @@ func New(
 	return e, nil
 }
 
+func (e *Engine) Start(parent irrecoverable.SignalerContext) {
+	rootBlock, err := e.state.Params().Root()
+	if err != nil {
+		parent.Throw(fmt.Errorf("failed to get root block: %w", err))
+	}
+
+	// if spork root snapshot
+	rootSnapshot := e.state.AtBlockID(rootBlock.ID())
+
+	isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
+	if err != nil {
+		parent.Throw(fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err))
+	}
+
+	// This is useful for dynamically bootstrapped access node, they will request missing collections. In order to ensure all txs
+	// from the missing collections can be verified, we must ensure they are referencing to known blocks.
+	// That's why we set the full block height to be rootHeight + TransactionExpiry, so that we only request missing collections
+	// in blocks above that height.
+	if isSporkRootSnapshot {
+		// for snapshot with a single block in the sealing segment the first full block is the root block.
+		err := e.blocks.InsertLastFullBlockHeightIfNotExists(rootBlock.Height)
+		if err != nil {
+			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+		}
+	} else {
+		// for midspork snapshots with a sealing segment that has more than 1 block add the transaction expiry to the root block height to avoid
+		// requesting resources for blocks below the expiry.
+		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
+		err := e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
+		if err != nil {
+			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+		}
+	}
+
+	e.ComponentManager.Start(parent)
+}
+
 func (e *Engine) processBackground(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 	// context with timeout
 	requestCtx, cancel := context.WithTimeout(ctx, defaultCollectionCatchupTimeout)
@@ -375,6 +412,19 @@ func (e *Engine) processFinalizedBlock(blockID flow.Identifier) error {
 		if err != nil {
 			return fmt.Errorf("could not index block for execution result: %w", err)
 		}
+	}
+
+	// skip requesting collections, if this block is below the last full block height
+	// this means that either we have already received these collections, or the block
+	// may contain unverifiable guarantees (in case this node has just joined the network)
+	lastFullBlockHeight, err := e.blocks.GetLastFullBlockHeight()
+	if err != nil {
+		return fmt.Errorf("could not get last full block height: %w", err)
+	}
+
+	if block.Header.Height <= lastFullBlockHeight {
+		e.log.Info().Msgf("skipping requesting collections for finalized block below last full block height (%d<=%d)", block.Header.Height, lastFullBlockHeight)
+		return nil
 	}
 
 	// queue requesting each of the collections from the collection node

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -417,15 +417,15 @@ func (e *Engine) processFinalizedBlock(blockID flow.Identifier) error {
 	// skip requesting collections, if this block is below the last full block height
 	// this means that either we have already received these collections, or the block
 	// may contain unverifiable guarantees (in case this node has just joined the network)
-	lastFullBlockHeight, err := e.blocks.GetLastFullBlockHeight()
-	if err != nil {
-		return fmt.Errorf("could not get last full block height: %w", err)
-	}
-
-	if block.Header.Height <= lastFullBlockHeight {
-		e.log.Info().Msgf("skipping requesting collections for finalized block below last full block height (%d<=%d)", block.Header.Height, lastFullBlockHeight)
-		return nil
-	}
+	//lastFullBlockHeight, err := e.blocks.GetLastFullBlockHeight()
+	//if err != nil {
+	//	return fmt.Errorf("could not get last full block height: %w", err)
+	//}
+	//
+	//if block.Header.Height <= lastFullBlockHeight {
+	//	e.log.Info().Msgf("skipping requesting collections for finalized block below last full block height (%d<=%d)", block.Header.Height, lastFullBlockHeight)
+	//	return nil
+	//}
 
 	// queue requesting each of the collections from the collection node
 	e.requestCollectionsInFinalizedBlock(block.Payload.Guarantees)

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -188,40 +188,40 @@ func New(
 }
 
 func (e *Engine) Start(parent irrecoverable.SignalerContext) {
-	rootBlock, err := e.state.Params().Root()
-	if err != nil {
-		parent.Throw(fmt.Errorf("failed to get root block: %w", err))
-	}
-
-	// if spork root snapshot
-	rootSnapshot := e.state.AtBlockID(rootBlock.ID())
-
-	isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
-	if err != nil {
-		parent.Throw(fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err))
-	}
-
-	// This is useful for dynamically bootstrapped access node, they will request missing collections. In order to ensure all txs
-	// from the missing collections can be verified, we must ensure they are referencing to known blocks.
-	// That's why we set the full block height to be rootHeight + TransactionExpiry, so that we only request missing collections
-	// in blocks above that height.
-	if isSporkRootSnapshot {
-		// for snapshot with a single block in the sealing segment the first full block is the root block.
-		err := e.blocks.InsertLastFullBlockHeightIfNotExists(rootBlock.Height)
-		if err != nil {
-			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
-		}
-	} else {
-		// for midspork snapshots with a sealing segment that has more than 1 block add the transaction expiry to the root block height to avoid
-		// requesting resources for blocks below the expiry.
-		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
-		err := e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
-		if err != nil {
-			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
-		}
-	}
-
-	e.ComponentManager.Start(parent)
+	//rootBlock, err := e.state.Params().Root()
+	//if err != nil {
+	//	parent.Throw(fmt.Errorf("failed to get root block: %w", err))
+	//}
+	//
+	//// if spork root snapshot
+	//rootSnapshot := e.state.AtBlockID(rootBlock.ID())
+	//
+	//isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
+	//if err != nil {
+	//	parent.Throw(fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err))
+	//}
+	//
+	//// This is useful for dynamically bootstrapped access node, they will request missing collections. In order to ensure all txs
+	//// from the missing collections can be verified, we must ensure they are referencing to known blocks.
+	//// That's why we set the full block height to be rootHeight + TransactionExpiry, so that we only request missing collections
+	//// in blocks above that height.
+	//if isSporkRootSnapshot {
+	//	// for snapshot with a single block in the sealing segment the first full block is the root block.
+	//	err := e.blocks.InsertLastFullBlockHeightIfNotExists(rootBlock.Height)
+	//	if err != nil {
+	//		parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+	//	}
+	//} else {
+	//	// for midspork snapshots with a sealing segment that has more than 1 block add the transaction expiry to the root block height to avoid
+	//	// requesting resources for blocks below the expiry.
+	//	firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
+	//	err := e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
+	//	if err != nil {
+	//		parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
+	//	}
+	//}
+	//
+	//e.ComponentManager.Start(parent)
 }
 
 func (e *Engine) processBackground(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {

--- a/storage/badger/blocks.go
+++ b/storage/badger/blocks.go
@@ -108,6 +108,17 @@ func (b *Blocks) IndexBlockForCollections(blockID flow.Identifier, collIDs []flo
 	return nil
 }
 
+// InsertLastFullBlockHeightIfNotExists inserts the last full block height
+func (b *Blocks) InsertLastFullBlockHeightIfNotExists(height uint64) error {
+	return operation.RetryOnConflict(b.db.Update, func(tx *badger.Txn) error {
+		err := operation.InsertLastCompleteBlockHeightIfNotExists(height)(tx)
+		if err != nil {
+			return fmt.Errorf("could not set LastFullBlockHeight: %w", err)
+		}
+		return nil
+	})
+}
+
 // UpdateLastFullBlockHeight upsert (update or insert) the last full block height
 func (b *Blocks) UpdateLastFullBlockHeight(height uint64) error {
 	return operation.RetryOnConflict(b.db.Update, func(tx *badger.Txn) error {

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -42,6 +42,12 @@ func InsertLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
 	return insert(makePrefix(codeLastCompleteBlockHeight), height)
 }
 
+// InsertLastCompleteBlockHeightIfNotExists inserts the last full block height if it is not already set.
+// Calling this function multiple times is a no-op and returns no expected errors.
+func InsertLastCompleteBlockHeightIfNotExists(height uint64) func(*badger.Txn) error {
+	return SkipDuplicates(InsertLastCompleteBlockHeight(height))
+}
+
 func UpdateLastCompleteBlockHeight(height uint64) func(*badger.Txn) error {
 	return update(makePrefix(codeLastCompleteBlockHeight), height)
 }

--- a/storage/blocks.go
+++ b/storage/blocks.go
@@ -32,6 +32,10 @@ type Blocks interface {
 	// included in.
 	IndexBlockForCollections(blockID flow.Identifier, collIDs []flow.Identifier) error
 
+	// InsertLastFullBlockHeightIfNotExists inserts the FullBlockHeight index if it does not already exist.
+	// Calling this function multiple times is a no-op and returns no expected errors.
+	InsertLastFullBlockHeightIfNotExists(height uint64) error
+
 	// UpdateLastFullBlockHeight updates the FullBlockHeight index
 	// The FullBlockHeight index indicates that block for which all collections have been received
 	UpdateLastFullBlockHeight(height uint64) error


### PR DESCRIPTION
This pull requests updates the LastFullBlockHeight in the ingestion engine component startup so that we only request missing collections in blocks above that height. In the processFinalizedBlock func we skip requesting collections for blocks under the lastFullBlockHeight.