### PR TITLE
Fix tests to use correct increasing tx index (attempt #2)

### DIFF
--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -21,7 +21,14 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-func createAccount(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) flow.Address {
+func createAccount(
+	t *testing.T,
+	vm *fvm.VirtualMachine,
+	chain flow.Chain,
+	ctx fvm.Context,
+	view state.View,
+	programs *programs.Programs,
+) flow.Address {
 	ctx = fvm.NewContextFromParent(
 		ctx,
 		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker(zerolog.Nop())),
@@ -31,7 +38,7 @@ func createAccount(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx f
 		SetScript([]byte(createAccountTransaction)).
 		AddAuthorizer(chain.ServiceAddress())
 
-	tx := fvm.Transaction(txBody, 0)
+	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 	err := vm.Run(ctx, tx, view, programs)
 	require.NoError(t, err)
@@ -82,7 +89,7 @@ func addAccountKey(
 		AddArgument(cadencePublicKey).
 		AddAuthorizer(address)
 
-	tx := fvm.Transaction(txBody, 0)
+	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 	err = vm.Run(ctx, tx, view, programs)
 	require.NoError(t, err)
@@ -111,7 +118,7 @@ func addAccountCreator(
 		SetScript(script).
 		AddAuthorizer(chain.ServiceAddress())
 
-	tx := fvm.Transaction(txBody, 0)
+	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 	err := vm.Run(ctx, tx, view, programs)
 	require.NoError(t, err)
@@ -139,7 +146,7 @@ func removeAccountCreator(
 		SetScript(script).
 		AddAuthorizer(chain.ServiceAddress())
 
-	tx := fvm.Transaction(txBody, 0)
+	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 	err := vm.Run(ctx, tx, view, programs)
 	require.NoError(t, err)
@@ -350,7 +357,7 @@ func TestCreateAccount(t *testing.T) {
 					SetScript([]byte(createAccountTransaction)).
 					AddAuthorizer(payer)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -381,7 +388,7 @@ func TestCreateAccount(t *testing.T) {
 					SetScript([]byte(createMultipleAccountsTransaction)).
 					AddAuthorizer(payer)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -425,7 +432,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 					SetScript([]byte(createAccountTransaction)).
 					AddAuthorizer(payer)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -442,7 +449,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 					SetScript([]byte(createAccountTransaction)).
 					AddAuthorizer(chain.ServiceAddress())
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -463,7 +470,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 					SetPayer(payer).
 					AddAuthorizer(payer)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -483,7 +490,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 					SetScript([]byte(createAccountTransaction)).
 					AddAuthorizer(payer)
 
-				validTx := fvm.Transaction(txBody, 0)
+				validTx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, validTx, view, programs)
 				require.NoError(t, err)
@@ -492,7 +499,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				removeAccountCreator(t, vm, chain, ctx, view, programs, payer)
 
-				invalidTx := fvm.Transaction(txBody, 0)
+				invalidTx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, invalidTx, view, programs)
 				require.NoError(t, err)
@@ -562,7 +569,7 @@ func TestAddAccountKey(t *testing.T) {
 						AddArgument(cadencePublicKey).
 						AddAuthorizer(address)
 
-					tx := fvm.Transaction(txBody, 0)
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -604,7 +611,7 @@ func TestAddAccountKey(t *testing.T) {
 						AddArgument(publicKey2Arg).
 						AddAuthorizer(address)
 
-					tx := fvm.Transaction(txBody, 0)
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -646,7 +653,7 @@ func TestAddAccountKey(t *testing.T) {
 						AddArgument(invalidPublicKeyArg).
 						AddAuthorizer(address)
 
-					tx := fvm.Transaction(txBody, 0)
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -699,7 +706,7 @@ func TestAddAccountKey(t *testing.T) {
 						AddArgument(publicKey2Arg).
 						AddAuthorizer(address)
 
-					tx := fvm.Transaction(txBody, 0)
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -763,7 +770,7 @@ func TestAddAccountKey(t *testing.T) {
 							AddArgument(publicKeyArg).
 							AddAuthorizer(address)
 
-						tx := fvm.Transaction(txBody, 0)
+						tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 						err = vm.Run(ctx, tx, view, programs)
 						require.NoError(t, err)
@@ -825,7 +832,7 @@ func TestRemoveAccountKey(t *testing.T) {
 					require.NoError(t, err)
 					assert.Len(t, before.Keys, keyCount)
 
-					for i, keyIndex := range []int{-1, keyCount, keyCount + 1} {
+					for _, keyIndex := range []int{-1, keyCount, keyCount + 1} {
 						keyIndexArg, err := jsoncdc.Encode(cadence.NewInt(keyIndex))
 						require.NoError(t, err)
 
@@ -834,7 +841,7 @@ func TestRemoveAccountKey(t *testing.T) {
 							AddArgument(keyIndexArg).
 							AddAuthorizer(address)
 
-						tx := fvm.Transaction(txBody, uint32(i))
+						tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 						err = vm.Run(ctx, tx, view, programs)
 						require.NoError(t, err)
@@ -880,7 +887,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						AddArgument(keyIndexArg).
 						AddAuthorizer(address)
 
-					tx := fvm.Transaction(txBody, 0)
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -931,7 +938,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						AddArgument(keyIndexArg).
 						AddAuthorizer(address)
 
-					tx := fvm.Transaction(txBody, 0)
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -991,7 +998,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						txBody.AddArgument(keyIndexArg)
 					}
 
-					tx := fvm.Transaction(txBody, 0)
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -1032,7 +1039,7 @@ func TestGetAccountKey(t *testing.T) {
 				require.NoError(t, err)
 				assert.Len(t, before.Keys, keyCount)
 
-				for i, keyIndex := range []int{-1, keyCount, keyCount + 1} {
+				for _, keyIndex := range []int{-1, keyCount, keyCount + 1} {
 					keyIndexArg, err := jsoncdc.Encode(cadence.NewInt(keyIndex))
 					require.NoError(t, err)
 
@@ -1041,7 +1048,7 @@ func TestGetAccountKey(t *testing.T) {
 						AddArgument(keyIndexArg).
 						AddAuthorizer(address)
 
-					tx := fvm.Transaction(txBody, uint32(i))
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(ctx, tx, view, programs)
 					require.NoError(t, err)
@@ -1078,7 +1085,7 @@ func TestGetAccountKey(t *testing.T) {
 					AddArgument(keyIndexArg).
 					AddAuthorizer(address)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1130,7 +1137,7 @@ func TestGetAccountKey(t *testing.T) {
 					AddArgument(keyIndexArg).
 					AddAuthorizer(address)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1183,7 +1190,7 @@ func TestGetAccountKey(t *testing.T) {
 					txBody.AddArgument(keyIndexArg)
 				}
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1233,7 +1240,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					AddArgument(jsoncdc.MustEncode(cadence.Address(account))).
 					AddAuthorizer(chain.ServiceAddress())
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1323,7 +1330,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					AddArgument(jsoncdc.MustEncode(cadence.Address(account))).
 					AddAuthorizer(chain.ServiceAddress())
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1387,7 +1394,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					AddArgument(jsoncdc.MustEncode(cadence.Address(account))).
 					AddAuthorizer(chain.ServiceAddress())
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1429,7 +1436,7 @@ func TestGetStorageCapacity(t *testing.T) {
 					AddArgument(jsoncdc.MustEncode(cadence.Address(account))).
 					AddAuthorizer(chain.ServiceAddress())
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err := vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -940,7 +940,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -993,7 +993,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1054,7 +1054,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1092,7 +1092,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1129,7 +1129,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1483,7 +1483,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		// execute the transaction
-		tx := fvm.Transaction(txBody, 0)
+		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 		err = vm.Run(ctx, tx, ledger, programs)
 		require.NoError(t, err)
@@ -1686,7 +1686,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
@@ -1734,7 +1734,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
@@ -1775,7 +1775,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1812,7 +1812,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)
@@ -1820,7 +1820,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				require.IsType(t, &errors.CadenceRuntimeError{}, tx.Err)
 
 				// send it again
-				tx = fvm.Transaction(txBody, 0)
+				tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 				err = vm.Run(ctx, tx, view, programs)
 				require.NoError(t, err)

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -118,7 +118,7 @@ func TestPrograms(t *testing.T) {
 					)
 					require.NoError(t, err)
 
-					tx := fvm.Transaction(txBody, uint32(i))
+					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 					err = vm.Run(txCtx, tx, view, programs)
 					require.NoError(t, err)
@@ -505,7 +505,7 @@ func TestEventLimits(t *testing.T) {
 
 	programs := programs.NewEmptyPrograms()
 
-	tx := fvm.Transaction(txBody, 0)
+	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 	err := vm.Run(ctx, tx, ledger, programs)
 	require.NoError(t, err)
 
@@ -522,7 +522,7 @@ func TestEventLimits(t *testing.T) {
 
 	t.Run("With limits", func(t *testing.T) {
 		txBody.Payer = unittest.RandomAddressFixture()
-		tx := fvm.Transaction(txBody, 0)
+		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 		err := vm.Run(ctx, tx, ledger, programs)
 		require.NoError(t, err)
 
@@ -532,7 +532,7 @@ func TestEventLimits(t *testing.T) {
 
 	t.Run("With service account as payer", func(t *testing.T) {
 		txBody.Payer = chain.ServiceAddress()
-		tx := fvm.Transaction(txBody, 0)
+		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 		err := vm.Run(ctx, tx, ledger, programs)
 		require.NoError(t, err)
 
@@ -568,7 +568,7 @@ func TestHappyPathTransactionSigning(t *testing.T) {
 			require.NoError(t, err)
 			txBody.AddEnvelopeSignature(accounts[0], 0, sig)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
@@ -881,7 +881,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
@@ -915,7 +915,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			tx = fvm.Transaction(txBody, 0)
+			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
@@ -946,7 +946,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			tx = fvm.Transaction(txBody, 1)
+			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
@@ -1021,7 +1021,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 
@@ -1070,7 +1070,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err = testutil.SignTransaction(txBody, accounts[0], privateKeys[0], 0)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 			require.Greater(t, tx.MemoryEstimate, uint64(20_000_000_000))
@@ -1106,7 +1106,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 			require.Greater(t, tx.MemoryEstimate, uint64(20_000_000_000))
@@ -1172,7 +1172,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err = testutil.SignTransaction(txBody, accounts[0], privateKeys[0], 0)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 			// There are 100 breaks and each break uses 1_000_000 memory
@@ -1209,7 +1209,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 
@@ -1244,7 +1244,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 
@@ -1278,7 +1278,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 
@@ -1319,7 +1319,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err := testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, 0)
+			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
@@ -1341,7 +1341,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			err = testutil.SignTransactionAsServiceAccount(txBody, 1, chain)
 			require.NoError(t, err)
 
-			tx = fvm.Transaction(txBody, 0)
+			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 			err = vm.Run(ctx, tx, view, programs)
 			require.NoError(t, err)
 
@@ -1606,7 +1606,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 
 				_ = testutil.SignPayload(txBody, account, privateKey)
 				_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 				err = vm.Run(subCtx, tx, view, programs)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
@@ -1665,7 +1665,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 
 				_ = testutil.SignPayload(txBody, account, privateKey)
 				_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
-				tx := fvm.Transaction(txBody, 0)
+				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 				err = vm.Run(subCtx, tx, view, programs)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)

--- a/fvm/handler/programs_test.go
+++ b/fvm/handler/programs_test.go
@@ -149,7 +149,9 @@ func Test_Programs(t *testing.T) {
 		require.Empty(t, retrievedContractA)
 
 		// deploy contract A0
-		procContractA0 := fvm.Transaction(contractDeployTx("A", contractA0Code, addressA), 0)
+		procContractA0 := fvm.Transaction(
+			contractDeployTx("A", contractA0Code, addressA),
+			programs.NextTxIndexForTestingOnly())
 		err = vm.Run(context, procContractA0, mainView, programs)
 		require.NoError(t, err)
 
@@ -159,7 +161,9 @@ func Test_Programs(t *testing.T) {
 		require.Equal(t, contractA0Code, string(retrievedContractA))
 
 		// deploy contract A
-		procContractA := fvm.Transaction(updateContractTx("A", contractACode, addressA), 1)
+		procContractA := fvm.Transaction(
+			updateContractTx("A", contractACode, addressA),
+			programs.NextTxIndexForTestingOnly())
 		err = vm.Run(context, procContractA, mainView, programs)
 		require.NoError(t, err)
 		require.NoError(t, procContractA.Err)
@@ -174,14 +178,18 @@ func Test_Programs(t *testing.T) {
 	t.Run("register touches are captured for simple contract A", func(t *testing.T) {
 
 		// deploy contract A
-		procContractA := fvm.Transaction(contractDeployTx("A", contractACode, addressA), 0)
+		procContractA := fvm.Transaction(
+			contractDeployTx("A", contractACode, addressA),
+			programs.NextTxIndexForTestingOnly())
 		err := vm.Run(context, procContractA, mainView, programs)
 		require.NoError(t, err)
 
 		fmt.Println("---------- Real transaction here ------------")
 
 		// run a TX using contract A
-		procCallA := fvm.Transaction(callTx("A", addressA), 1)
+		procCallA := fvm.Transaction(
+			callTx("A", addressA),
+			programs.NextTxIndexForTestingOnly())
 
 		loadedCode := false
 		viewExecA := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
@@ -201,7 +209,7 @@ func Test_Programs(t *testing.T) {
 		// Make sure the code has been loaded from storage
 		require.True(t, loadedCode)
 
-		_, programState, has := programs.Get(contractALocation)
+		_, programState, has := programs.GetForTestingOnly(contractALocation)
 		require.True(t, has)
 
 		// type assertion for further inspections
@@ -226,7 +234,9 @@ func Test_Programs(t *testing.T) {
 			return mainView.Peek(owner, key)
 		})
 
-		procCallA = fvm.Transaction(callTx("A", addressA), 2)
+		procCallA = fvm.Transaction(
+			callTx("A", addressA),
+			programs.NextTxIndexForTestingOnly())
 
 		err = vm.Run(context, procCallA, viewExecA2, programs)
 		require.NoError(t, err)
@@ -245,12 +255,14 @@ func Test_Programs(t *testing.T) {
 	t.Run("deploying another contract cleans programs storage", func(t *testing.T) {
 
 		// deploy contract B
-		procContractB := fvm.Transaction(contractDeployTx("B", contractBCode, addressB), 3)
+		procContractB := fvm.Transaction(
+			contractDeployTx("B", contractBCode, addressB),
+			programs.NextTxIndexForTestingOnly())
 		err := vm.Run(context, procContractB, mainView, programs)
 		require.NoError(t, err)
 
-		_, _, hasA := programs.Get(contractALocation)
-		_, _, hasB := programs.Get(contractBLocation)
+		_, _, hasA := programs.GetForTestingOnly(contractALocation)
+		_, _, hasB := programs.GetForTestingOnly(contractBLocation)
 
 		require.False(t, hasA)
 		require.False(t, hasB)
@@ -263,7 +275,9 @@ func Test_Programs(t *testing.T) {
 		// programs should have no entries for A and B, as per previous test
 
 		// run a TX using contract B
-		procCallB := fvm.Transaction(callTx("B", addressB), 4)
+		procCallB := fvm.Transaction(
+			callTx("B", addressB),
+			programs.NextTxIndexForTestingOnly())
 
 		viewExecB = delta.NewView(mainView.Peek)
 
@@ -272,7 +286,7 @@ func Test_Programs(t *testing.T) {
 
 		require.Contains(t, procCallB.Logs, "\"hello from B but also hello from A\"")
 
-		_, programAState, has := programs.Get(contractALocation)
+		_, programAState, has := programs.GetForTestingOnly(contractALocation)
 		require.True(t, has)
 
 		// state should be essentially the same as one which we got in tx with contract A
@@ -281,7 +295,7 @@ func Test_Programs(t *testing.T) {
 
 		compareViews(t, contractAView, deltaA)
 
-		_, programBState, has := programs.Get(contractBLocation)
+		_, programBState, has := programs.GetForTestingOnly(contractBLocation)
 		require.True(t, has)
 
 		// program B should contain all the registers used by program A, as it depends on it
@@ -321,7 +335,9 @@ func Test_Programs(t *testing.T) {
 			return mainView.Peek(owner, key)
 		})
 
-		procCallB = fvm.Transaction(callTx("B", addressB), 5)
+		procCallB = fvm.Transaction(
+			callTx("B", addressB),
+			programs.NextTxIndexForTestingOnly())
 
 		err = vm.Run(context, procCallB, viewExecB2, programs)
 		require.NoError(t, err)
@@ -346,7 +362,9 @@ func Test_Programs(t *testing.T) {
 		})
 
 		// run a TX using contract A
-		procCallA := fvm.Transaction(callTx("A", addressA), 6)
+		procCallA := fvm.Transaction(
+			callTx("A", addressA),
+			programs.NextTxIndexForTestingOnly())
 
 		err = vm.Run(context, procCallA, viewExecA, programs)
 		require.NoError(t, err)
@@ -364,13 +382,15 @@ func Test_Programs(t *testing.T) {
 		require.NotNil(t, contractBView)
 
 		// deploy contract C
-		procContractC := fvm.Transaction(contractDeployTx("C", contractCCode, addressC), 7)
+		procContractC := fvm.Transaction(
+			contractDeployTx("C", contractCCode, addressC),
+			programs.NextTxIndexForTestingOnly())
 		err := vm.Run(context, procContractC, mainView, programs)
 		require.NoError(t, err)
 
-		_, _, hasA := programs.Get(contractALocation)
-		_, _, hasB := programs.Get(contractBLocation)
-		_, _, hasC := programs.Get(contractCLocation)
+		_, _, hasA := programs.GetForTestingOnly(contractALocation)
+		_, _, hasB := programs.GetForTestingOnly(contractBLocation)
+		_, _, hasC := programs.GetForTestingOnly(contractCLocation)
 
 		require.False(t, hasA)
 		require.False(t, hasB)
@@ -379,7 +399,9 @@ func Test_Programs(t *testing.T) {
 	})
 
 	t.Run("importing C should chain-import B and A", func(t *testing.T) {
-		procCallC := fvm.Transaction(callTx("C", addressC), 8)
+		procCallC := fvm.Transaction(
+			callTx("C", addressC),
+			programs.NextTxIndexForTestingOnly())
 
 		viewExecC := delta.NewView(mainView.Peek)
 
@@ -389,7 +411,7 @@ func Test_Programs(t *testing.T) {
 		require.Contains(t, procCallC.Logs, "\"hello from C, hello from B but also hello from A\"")
 
 		// program A is the same
-		_, programAState, has := programs.Get(contractALocation)
+		_, programAState, has := programs.GetForTestingOnly(contractALocation)
 		require.True(t, has)
 
 		require.IsType(t, programAState.View(), &delta.View{})
@@ -397,7 +419,7 @@ func Test_Programs(t *testing.T) {
 		compareViews(t, contractAView, deltaA)
 
 		// program B is the same
-		_, programBState, has := programs.Get(contractBLocation)
+		_, programBState, has := programs.GetForTestingOnly(contractBLocation)
 		require.True(t, has)
 
 		require.IsType(t, programBState.View(), &delta.View{})

--- a/fvm/programs/programs.go
+++ b/fvm/programs/programs.go
@@ -41,6 +41,8 @@ type Programs struct {
 	programs map[common.LocationID]*ProgramEntry
 	parent   *Programs
 	cleaned  bool
+
+	txIndex uint32
 }
 
 func NewEmptyPrograms() *Programs {
@@ -54,6 +56,17 @@ func (p *Programs) ChildPrograms() *Programs {
 		programs: map[common.LocationID]*ProgramEntry{},
 		parent:   p,
 	}
+}
+
+func (p *Programs) NextTxIndexForTestingOnly() uint32 {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.txIndex
+}
+
+func (p *Programs) GetForTestingOnly(location common.AddressLocation) (*interpreter.Program, *state.State, bool) {
+	return p.Get(location)
 }
 
 // Get returns stored program, state which contains changes which correspond to loading this program,
@@ -106,6 +119,8 @@ func (p *Programs) Cleanup(modifiedSets ModifiedSets) {
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
+	p.txIndex++
 
 	// In mature system, we would track dependencies between contracts
 	// and invalidate only affected ones, possibly setting them to


### PR DESCRIPTION
(This is identical to #3084.  I accidently destroy the both local/upstream branch rebasing)

The upcoming changes to program cache will use txIndex as logical time for
optimistic concurrency control.

Fixing the tests up front / in a separate PR since the program cache changes
are massive enough by themselves.