### PR TITLE
[Benchmark] Fix crash on stats pusher exit

### DIFF
--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -100,7 +100,7 @@ func main() {
 	defer cancel()
 
 	sp := benchmark.NewStatsPusher(ctx, log, pushgateway, "loader", prometheus.DefaultGatherer)
-	defer sp.Close()
+	defer sp.Stop()
 
 	tps, err := strconv.ParseInt(*tpsFlag, 0, 32)
 	if err != nil {

--- a/integration/benchmark/cmd/manual/main.go
+++ b/integration/benchmark/cmd/manual/main.go
@@ -69,7 +69,7 @@ func main() {
 	defer cancel()
 
 	sp := benchmark.NewStatsPusher(ctx, log, *pushgateway, "loader", prometheus.DefaultGatherer)
-	defer sp.Close()
+	defer sp.Stop()
 
 	accessNodeAddrs := strings.Split(*access, ",")
 

--- a/integration/benchmark/prometheus.go
+++ b/integration/benchmark/prometheus.go
@@ -27,6 +27,7 @@ func NewStatsPusher(
 	localCtx, cancel := context.WithCancel(ctx)
 	sp := &statsPusherImpl{
 		pusher: push.New(pushgateway, job).Gatherer(gatherer),
+		done:   make(chan struct{}),
 		cancel: cancel,
 	}
 
@@ -58,8 +59,8 @@ func NewStatsPusher(
 	return sp
 }
 
-// Close stops the stats pusher and waits for it to finish.
-func (sp *statsPusherImpl) Close() {
+// Stop the stats pusher and waits for it to finish.
+func (sp *statsPusherImpl) Stop() {
 	sp.cancel()
 	<-sp.done
 }

--- a/integration/benchmark/prometheus_test.go
+++ b/integration/benchmark/prometheus_test.go
@@ -1,0 +1,23 @@
+package benchmark
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestNewStatsPusher is a simple test that starts and stops a pusher.
+func TestNewStatsPusher(t *testing.T) {
+	t.Parallel()
+
+	p := NewStatsPusher(context.Background(), zerolog.Logger{}, "", "test", prometheus.DefaultGatherer)
+	require.NotNil(t, p)
+
+	unittest.RequireReturnsBefore(t, p.Stop, 1*time.Second, "pusher did not close in time")
+}


### PR DESCRIPTION
Zero initialized channel is unusable in go, even if the only action taken is close.  Fix this and add a basic test for the `NewStatsPusher` to cover this.

While here, also rename `Close` to `Stop` to be consistent with the rest of benchmark code.