### PR TITLE
Adding install-mock-generators as dep to generate-mocks in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ verfiy-mocks: generate-mocks
 	git diff --exit-code
 
 .PHONY: generate-mocks
-generate-mocks:
+generate-mocks: install-mock-generators
 	mockery --name '(Connector|PingInfoProvider)' --dir=network/p2p --case=underscore --output="./network/mocknetwork" --outpkg="mocknetwork"
 	mockgen -destination=storage/mocks/storage.go -package=mocks github.com/onflow/flow-go/storage Blocks,Headers,Payloads,Collections,Commits,Events,ServiceEvents,TransactionResults
 	mockgen -destination=module/mocks/network.go -package=mocks github.com/onflow/flow-go/module Local,Requester


### PR DESCRIPTION
To make sure every call to `make generate-mocks` use the proper version of mock generator, now adding `install-mock-generators` as target dependency of `generate-mocks`.

One-liner change. 
