### PR TITLE
[Networking] Explicitly set resource limits in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.17.0
 	github.com/libp2p/go-libp2p-kbucket v0.4.7
 	github.com/libp2p/go-libp2p-pubsub v0.7.1-0.20220701163738-60cf38003244
+	github.com/libp2p/go-libp2p-resource-manager v0.5.3
 	github.com/libp2p/go-libp2p-tls v0.4.1
 	github.com/m4ksio/wal v1.0.0
 	github.com/multiformats/go-base32 v0.0.4 // indirect
@@ -196,7 +197,6 @@ require (
 	github.com/libp2p/go-libp2p-loggables v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-peerstore v0.7.1 // indirect
 	github.com/libp2p/go-libp2p-record v0.1.3 // indirect
-	github.com/libp2p/go-libp2p-resource-manager v0.5.1 // indirect
 	github.com/libp2p/go-msgio v0.2.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -959,8 +959,8 @@ github.com/libp2p/go-libp2p-record v0.1.2/go.mod h1:pal0eNcT5nqZaTV7UGhqeGqxFgGd
 github.com/libp2p/go-libp2p-record v0.1.3 h1:R27hoScIhQf/A8XJZ8lYpnqh9LatJ5YbHs28kCIfql0=
 github.com/libp2p/go-libp2p-record v0.1.3/go.mod h1:yNUff/adKIfPnYQXgp6FQmNu3gLJ6EMg7+/vv2+9pY4=
 github.com/libp2p/go-libp2p-resource-manager v0.3.0/go.mod h1:K+eCkiapf+ey/LADO4TaMpMTP9/Qde/uLlrnRqV4PLQ=
-github.com/libp2p/go-libp2p-resource-manager v0.5.1 h1:jm0mdqn7yfh7wbUzlj948BYZX0KZ3RW7OqerkGQ5rYY=
-github.com/libp2p/go-libp2p-resource-manager v0.5.1/go.mod h1:CggtV6EZb+Y0dGh41q5ezO4udcVKyhcEFpydHD8EMe0=
+github.com/libp2p/go-libp2p-resource-manager v0.5.3 h1:W8rG2abNBO52SRQYj24AvKmutTJZfoc1OrgzGQPwcRU=
+github.com/libp2p/go-libp2p-resource-manager v0.5.3/go.mod h1:CggtV6EZb+Y0dGh41q5ezO4udcVKyhcEFpydHD8EMe0=
 github.com/libp2p/go-libp2p-secio v0.1.0/go.mod h1:tMJo2w7h3+wN4pgU2LSYeiKPrfqBgkOsdiKK77hE7c8=
 github.com/libp2p/go-libp2p-secio v0.2.0/go.mod h1:2JdZepB8J5V9mBp79BmwsaPQhRPNN2NrnB2lKQcdy6g=
 github.com/libp2p/go-libp2p-secio v0.2.1/go.mod h1:cWtZpILJqkqrSkiYcDBh5lA3wbT2Q+hz3rJQq3iftD8=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -163,7 +163,7 @@ require (
 	github.com/libp2p/go-libp2p-peerstore v0.7.1 // indirect
 	github.com/libp2p/go-libp2p-pubsub v0.7.1-0.20220701163738-60cf38003244 // indirect
 	github.com/libp2p/go-libp2p-record v0.1.3 // indirect
-	github.com/libp2p/go-libp2p-resource-manager v0.5.1 // indirect
+	github.com/libp2p/go-libp2p-resource-manager v0.5.3 // indirect
 	github.com/libp2p/go-libp2p-tls v0.4.1 // indirect
 	github.com/libp2p/go-msgio v0.2.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1046,8 +1046,8 @@ github.com/libp2p/go-libp2p-record v0.1.2/go.mod h1:pal0eNcT5nqZaTV7UGhqeGqxFgGd
 github.com/libp2p/go-libp2p-record v0.1.3 h1:R27hoScIhQf/A8XJZ8lYpnqh9LatJ5YbHs28kCIfql0=
 github.com/libp2p/go-libp2p-record v0.1.3/go.mod h1:yNUff/adKIfPnYQXgp6FQmNu3gLJ6EMg7+/vv2+9pY4=
 github.com/libp2p/go-libp2p-resource-manager v0.3.0/go.mod h1:K+eCkiapf+ey/LADO4TaMpMTP9/Qde/uLlrnRqV4PLQ=
-github.com/libp2p/go-libp2p-resource-manager v0.5.1 h1:jm0mdqn7yfh7wbUzlj948BYZX0KZ3RW7OqerkGQ5rYY=
-github.com/libp2p/go-libp2p-resource-manager v0.5.1/go.mod h1:CggtV6EZb+Y0dGh41q5ezO4udcVKyhcEFpydHD8EMe0=
+github.com/libp2p/go-libp2p-resource-manager v0.5.3 h1:W8rG2abNBO52SRQYj24AvKmutTJZfoc1OrgzGQPwcRU=
+github.com/libp2p/go-libp2p-resource-manager v0.5.3/go.mod h1:CggtV6EZb+Y0dGh41q5ezO4udcVKyhcEFpydHD8EMe0=
 github.com/libp2p/go-libp2p-secio v0.1.0/go.mod h1:tMJo2w7h3+wN4pgU2LSYeiKPrfqBgkOsdiKK77hE7c8=
 github.com/libp2p/go-libp2p-secio v0.2.0/go.mod h1:2JdZepB8J5V9mBp79BmwsaPQhRPNN2NrnB2lKQcdy6g=
 github.com/libp2p/go-libp2p-secio v0.2.1/go.mod h1:cWtZpILJqkqrSkiYcDBh5lA3wbT2Q+hz3rJQq3iftD8=

--- a/network/p2p/fixture_test.go
+++ b/network/p2p/fixture_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/network/p2p/unicast"
+	"github.com/onflow/flow-go/network/test"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -126,6 +127,7 @@ func nodeFixture(
 
 	noopMetrics := metrics.NewNoopCollector()
 	connManager := p2p.NewConnManager(parameters.logger, noopMetrics)
+	resourceManager := test.NewResourceManager(t)
 
 	builder := p2p.NewNodeBuilder(parameters.logger, parameters.address, parameters.key, sporkID).
 		SetConnectionManager(connManager).
@@ -137,7 +139,8 @@ func nodeFixture(
 				noopMetrics,
 				parameters.dhtOptions...,
 			)
-		})
+		}).
+		SetResourceManager(resourceManager)
 
 	if parameters.peerFilter != nil {
 		connGater := p2p.NewConnGater(parameters.logger, parameters.peerFilter)

--- a/network/p2p/libp2pNodeBuilder.go
+++ b/network/p2p/libp2pNodeBuilder.go
@@ -9,6 +9,7 @@ import (
 	libp2p "github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 	"github.com/libp2p/go-libp2p-core/transport"
@@ -90,6 +91,7 @@ func DefaultMessageIDFunction(msg *pb.Message) string {
 type NodeBuilder interface {
 	SetBasicResolver(madns.BasicResolver) NodeBuilder
 	SetSubscriptionFilter(pubsub.SubscriptionFilter) NodeBuilder
+	SetResourceManager(network.ResourceManager) NodeBuilder
 	SetConnectionManager(connmgr.ConnManager) NodeBuilder
 	SetConnectionGater(connmgr.ConnectionGater) NodeBuilder
 	SetRoutingSystem(func(context.Context, host.Host) (routing.Routing, error)) NodeBuilder
@@ -104,6 +106,7 @@ type LibP2PNodeBuilder struct {
 	logger             zerolog.Logger
 	basicResolver      madns.BasicResolver
 	subscriptionFilter pubsub.SubscriptionFilter
+	resourceManager    network.ResourceManager
 	connManager        connmgr.ConnManager
 	connGater          connmgr.ConnectionGater
 	routingFactory     func(context.Context, host.Host) (routing.Routing, error)
@@ -131,6 +134,11 @@ func (builder *LibP2PNodeBuilder) SetBasicResolver(br madns.BasicResolver) NodeB
 
 func (builder *LibP2PNodeBuilder) SetSubscriptionFilter(filter pubsub.SubscriptionFilter) NodeBuilder {
 	builder.subscriptionFilter = filter
+	return builder
+}
+
+func (builder *LibP2PNodeBuilder) SetResourceManager(manager network.ResourceManager) NodeBuilder {
+	builder.resourceManager = manager
 	return builder
 }
 
@@ -173,6 +181,10 @@ func (builder *LibP2PNodeBuilder) Build(ctx context.Context) (*Node, error) {
 		}
 
 		opts = append(opts, libp2p.MultiaddrResolver(resolver))
+	}
+
+	if builder.resourceManager != nil {
+		opts = append(opts, libp2p.ResourceManager(builder.resourceManager))
 	}
 
 	if builder.connManager != nil {

--- a/network/p2p/libp2pStream_test.go
+++ b/network/p2p/libp2pStream_test.go
@@ -153,11 +153,8 @@ func testCreateStream(t *testing.T, sporkId flow.Identifier, unicasts []unicast.
 	// Assert that there is no outbound stream to the target yet
 	require.Equal(t, 0, p2p.CountStream(nodes[0].Host(), nodes[1].Host().ID(), protocolID, network.DirOutbound))
 
-	// Now attempt to create another 50 outbound stream to the same destination by calling CreateStream
-	//
-	// NB! This number must be lower than default limits in libp2p:
-	// See: https://github.com/libp2p/go-libp2p/blob/master/limits.go
-	streamCount := 50
+	// Now attempt to create another 100 outbound stream to the same destination by calling CreateStream
+	streamCount := 100
 	var streams []network.Stream
 	for i := 0; i < streamCount; i++ {
 		pInfo, err := p2p.PeerAddressInfo(*id2)

--- a/network/p2p/utils_test.go
+++ b/network/p2p/utils_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/network/p2p/unicast"
+	"github.com/onflow/flow-go/network/test"
 )
 
 const maxConnectAttempt = 3
@@ -32,7 +33,8 @@ func createNode(t *testing.T, nodeID flow.Identifier, networkKey crypto.PrivateK
 		SetRoutingSystem(func(c context.Context, h host.Host) (routing.Routing, error) {
 			return p2p.NewDHT(c, h, unicast.FlowDHTProtocolID(sporkID), zerolog.Nop(), metrics.NewNoopCollector())
 		}).
-		SetPubSub(pubsub.NewGossipSub)
+		SetPubSub(pubsub.NewGossipSub).
+		SetResourceManager(test.NewResourceManager(t))
 
 	for _, opt := range opts {
 		opt(builder)


### PR DESCRIPTION
By default libp2p [autoscales limits based on available system memory](https://github.com/libp2p/go-libp2p/blob/2f0d7502981e8e0806e5a47da493220becc23659/p2p/host/resource-manager/limit_defaults.go#L307-L312).  This is irrelevant in production but in tests flakes rate is inversely proportional to the amount of memory a container has. (This also makes it hard to reproduce the flake locally.)

While here also bump `github.com/libp2p/go-libp2p-resource-manager` to v0.5.3 and reset `streamCount` to 100 in `TestCreateStream.*` tests to verify the fix.

This diff should also fix some of the p2p-related "Unit test" flakes.