### PR TITLE
[Execution] Fix TestScriptStorageMutationsDiscarded timeout

### DIFF
--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -622,7 +622,7 @@ func TestExecuteScriptCancelled(t *testing.T) {
 
 func TestScriptStorageMutationsDiscarded(t *testing.T) {
 
-	timeout := 1 * time.Millisecond
+	timeout := 10 * time.Second
 	vm := fvm.NewVirtualMachine(fvm.NewInterpreterRuntime(runtime.Config{}))
 	chain := flow.Mainnet.Chain()
 	ctx := fvm.NewContext(zerolog.Nop(), fvm.WithChain(chain))


### PR DESCRIPTION
1ms is enough to pass the test most of the times but it gets really flaky with race detector on.

Ref: #3034