### PR TITLE
Create virtual machine / cadence runtime inside computation.Manager

### DIFF
--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -26,8 +26,6 @@ type ExecutionConfig struct {
 	checkpointDistance                   uint
 	checkpointsToKeep                    uint
 	stateDeltasLimit                     uint
-	cadenceExecutionCache                uint
-	cadenceTracing                       bool
 	chunkDataPackCacheSize               uint
 	chunkDataPackRequestsCacheSize       uint32
 	requestInterval                      time.Duration
@@ -36,10 +34,7 @@ type ExecutionConfig struct {
 	syncFast                             bool
 	syncThreshold                        int
 	extensiveLog                         bool
-	extensiveTracing                     bool
 	pauseExecution                       bool
-	scriptLogThreshold                   time.Duration
-	scriptExecutionTimeLimit             time.Duration
 	chunkDataPackQueryTimeout            time.Duration
 	chunkDataPackDeliveryTimeout         time.Duration
 	enableBlockDataUpload                bool
@@ -52,6 +47,8 @@ type ExecutionConfig struct {
 	blobstoreRateLimit                   int
 	blobstoreBurstLimit                  int
 	chunkDataPackRequestWorkers          uint
+
+	computationConfig computation.ComputationConfig
 }
 
 func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
@@ -66,16 +63,16 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.UintVar(&exeConf.checkpointDistance, "checkpoint-distance", 20, "number of WAL segments between checkpoints")
 	flags.UintVar(&exeConf.checkpointsToKeep, "checkpoints-to-keep", 5, "number of recent checkpoints to keep (0 to keep all)")
 	flags.UintVar(&exeConf.stateDeltasLimit, "state-deltas-limit", 100, "maximum number of state deltas in the memory pool")
-	flags.UintVar(&exeConf.cadenceExecutionCache, "cadence-execution-cache", computation.DefaultProgramsCacheSize,
+	flags.UintVar(&exeConf.computationConfig.ProgramsCacheSize, "cadence-execution-cache", computation.DefaultProgramsCacheSize,
 		"cache size for Cadence execution")
-	flags.BoolVar(&exeConf.extensiveTracing, "extensive-tracing", false, "adds high-overhead tracing to execution")
-	flags.BoolVar(&exeConf.cadenceTracing, "cadence-tracing", false, "enables cadence runtime level tracing")
+	flags.BoolVar(&exeConf.computationConfig.ExtensiveTracing, "extensive-tracing", false, "adds high-overhead tracing to execution")
+	flags.BoolVar(&exeConf.computationConfig.CadenceTracing, "cadence-tracing", false, "enables cadence runtime level tracing")
 	flags.UintVar(&exeConf.chunkDataPackCacheSize, "chdp-cache", storage.DefaultCacheSize, "cache size for chunk data packs")
 	flags.Uint32Var(&exeConf.chunkDataPackRequestsCacheSize, "chdp-request-queue", mempool.DefaultChunkDataPackRequestQueueSize, "queue size for chunk data pack requests")
 	flags.DurationVar(&exeConf.requestInterval, "request-interval", 60*time.Second, "the interval between requests for the requester engine")
-	flags.DurationVar(&exeConf.scriptLogThreshold, "script-log-threshold", computation.DefaultScriptLogThreshold,
+	flags.DurationVar(&exeConf.computationConfig.ScriptLogThreshold, "script-log-threshold", computation.DefaultScriptLogThreshold,
 		"threshold for logging script execution")
-	flags.DurationVar(&exeConf.scriptExecutionTimeLimit, "script-execution-time-limit", computation.DefaultScriptExecutionTimeLimit,
+	flags.DurationVar(&exeConf.computationConfig.ScriptExecutionTimeLimit, "script-execution-time-limit", computation.DefaultScriptExecutionTimeLimit,
 		"script execution time limit")
 	flags.StringVar(&exeConf.preferredExeNodeIDStr, "preferred-exe-node-id", "", "node ID for preferred execution node used for state sync")
 	flags.UintVar(&exeConf.transactionResultsCacheSize, "transaction-results-cache-size", 10000, "number of transaction results to be cached")

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	ReusableCadenceRuntimePoolSize    = 1000
 	SystemChunkEventCollectionMaxSize = 256_000_000 // ~256MB
 )
 
@@ -49,15 +48,14 @@ type BlockComputer interface {
 }
 
 type blockComputer struct {
-	vm                         VirtualMachine
-	vmCtx                      fvm.Context
-	metrics                    module.ExecutionMetrics
-	tracer                     module.Tracer
-	log                        zerolog.Logger
-	systemChunkCtx             fvm.Context
-	committer                  ViewCommitter
-	executionDataProvider      *provider.Provider
-	reusableCadenceRuntimePool fvm.ReusableCadenceRuntimePool
+	vm                    VirtualMachine
+	vmCtx                 fvm.Context
+	metrics               module.ExecutionMetrics
+	tracer                module.Tracer
+	log                   zerolog.Logger
+	systemChunkCtx        fvm.Context
+	committer             ViewCommitter
+	executionDataProvider *provider.Provider
 }
 
 func SystemChunkContext(vmCtx fvm.Context, logger zerolog.Logger) fvm.Context {
@@ -92,8 +90,6 @@ func NewBlockComputer(
 		systemChunkCtx:        SystemChunkContext(vmCtx, logger),
 		committer:             committer,
 		executionDataProvider: executionDataProvider,
-		reusableCadenceRuntimePool: fvm.NewReusableCadenceRuntimePool(
-			ReusableCadenceRuntimePoolSize),
 	}, nil
 }
 
@@ -136,12 +132,10 @@ func (e *blockComputer) executeBlock(
 
 	blockCtx := fvm.NewContextFromParent(
 		e.vmCtx,
-		fvm.WithBlockHeader(block.Block.Header),
-		fvm.WithReusableCadenceRuntimePool(e.reusableCadenceRuntimePool))
+		fvm.WithBlockHeader(block.Block.Header))
 	systemChunkCtx := fvm.NewContextFromParent(
 		e.systemChunkCtx,
-		fvm.WithBlockHeader(block.Block.Header),
-		fvm.WithReusableCadenceRuntimePool(e.reusableCadenceRuntimePool))
+		fvm.WithBlockHeader(block.Block.Header))
 	collections := block.Collections()
 
 	chunksSize := len(collections) + 1 // + 1 system chunk

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/onflow/cadence/runtime"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
@@ -28,6 +29,15 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/utils/debug"
 	"github.com/onflow/flow-go/utils/logging"
+)
+
+const (
+	DefaultScriptLogThreshold       = 1 * time.Second
+	DefaultScriptExecutionTimeLimit = 10 * time.Second
+
+	MaxScriptErrorMessageSize = 1000 // 1000 chars
+
+	ReusableCadenceRuntimePoolSize = 1000
 )
 
 var uploadEnabled = true
@@ -53,10 +63,20 @@ type ComputationManager interface {
 	GetAccount(addr flow.Address, header *flow.Header, view state.View) (*flow.Account, error)
 }
 
-var DefaultScriptLogThreshold = 1 * time.Second
-var DefaultScriptExecutionTimeLimit = 10 * time.Second
+type ComputationConfig struct {
+	CadenceTracing           bool
+	ExtensiveTracing         bool
+	ProgramsCacheSize        uint
+	ScriptLogThreshold       time.Duration
+	ScriptExecutionTimeLimit time.Duration
 
-const MaxScriptErrorMessageSize = 1000 // 1000 chars
+	// When NewCustomVirtualMachine is nil, the manager will create a standard
+	// fvm virtual machine via fvm.NewVirtualMachine.  Otherwise, the manager
+	// will create a virtual machine using this function.
+	//
+	// Note that this is primarily used for testing.
+	NewCustomVirtualMachine func() VirtualMachine
+}
 
 // Manager manages computation and execution
 type Manager struct {
@@ -82,16 +102,35 @@ func New(
 	tracer module.Tracer,
 	me module.Local,
 	protoState protocol.State,
-	vm VirtualMachine,
 	vmCtx fvm.Context,
-	programsCacheSize uint,
 	committer computer.ViewCommitter,
-	scriptLogThreshold time.Duration,
-	scriptExecutionTimeLimit time.Duration,
 	uploaders []uploader.Uploader,
 	executionDataProvider *provider.Provider,
+	params ComputationConfig,
 ) (*Manager, error) {
 	log := logger.With().Str("engine", "computation").Logger()
+
+	var vm VirtualMachine
+	if params.NewCustomVirtualMachine != nil {
+		vm = params.NewCustomVirtualMachine()
+	} else {
+		rt := runtime.NewInterpreterRuntime(
+			runtime.Config{
+				TracingEnabled: params.CadenceTracing,
+			})
+
+		vm = fvm.NewVirtualMachine(rt)
+	}
+
+	options := []fvm.Option{
+		fvm.WithReusableCadenceRuntimePool(
+			fvm.NewReusableCadenceRuntimePool(ReusableCadenceRuntimePoolSize)),
+	}
+	if params.ExtensiveTracing {
+		options = append(options, fvm.WithExtensiveTracing())
+	}
+
+	vmCtx = fvm.NewContextFromParent(vmCtx, options...)
 
 	blockComputer, err := computer.NewBlockComputer(
 		vm,
@@ -107,7 +146,7 @@ func New(
 		return nil, fmt.Errorf("cannot create block computer: %w", err)
 	}
 
-	programsCache, err := NewProgramsCache(programsCacheSize)
+	programsCache, err := NewProgramsCache(params.ProgramsCacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create programs cache: %w", err)
 	}
@@ -122,14 +161,18 @@ func New(
 		vmCtx:                    vmCtx,
 		blockComputer:            blockComputer,
 		programsCache:            programsCache,
-		scriptLogThreshold:       scriptLogThreshold,
-		scriptExecutionTimeLimit: scriptExecutionTimeLimit,
+		scriptLogThreshold:       params.ScriptLogThreshold,
+		scriptExecutionTimeLimit: params.ScriptExecutionTimeLimit,
 		uploaders:                uploaders,
 		rngLock:                  &sync.Mutex{},
 		rng:                      rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 
 	return &e, nil
+}
+
+func (e *Manager) VM() VirtualMachine {
+	return e.vm
 }
 
 func (e *Manager) getChildProgramsOrEmpty(blockID flow.Identifier) *programs.Programs {

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -95,6 +95,8 @@ func BenchmarkComputeBlock(b *testing.B) {
 		fvm.WithAccountStorageLimit(true),
 		fvm.WithTransactionFeesEnabled(true),
 		fvm.WithTracer(tracer),
+		fvm.WithReusableCadenceRuntimePool(
+			fvm.NewReusableCadenceRuntimePool(ReusableCadenceRuntimePoolSize)),
 	)
 	ledger := testutil.RootBootstrappedLedger(
 		vm,

--- a/engine/testutil/mock/nodes.go
+++ b/engine/testutil/mock/nodes.go
@@ -32,7 +32,6 @@ import (
 	"github.com/onflow/flow-go/engine/verification/fetcher/chunkconsumer"
 	verificationrequester "github.com/onflow/flow-go/engine/verification/requester"
 	"github.com/onflow/flow-go/engine/verification/verifier"
-	"github.com/onflow/flow-go/fvm"
 	fvmState "github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/complete"
@@ -206,7 +205,7 @@ type ExecutionNode struct {
 	SyncEngine          *synchronization.Engine
 	Compactor           *complete.Compactor
 	BadgerDB            *badger.DB
-	VM                  *fvm.VirtualMachine
+	VM                  computation.VirtualMachine
 	ExecutionState      state.ExecutionState
 	Ledger              ledger.Ledger
 	LevelDbDir          string

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -572,10 +572,6 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 	)
 	require.NoError(t, err)
 
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-
-	vm := fvm.NewVirtualMachine(rt)
-
 	blockFinder := environment.NewBlockFinder(node.Headers)
 
 	vmCtx := fvm.NewContext(
@@ -605,14 +601,15 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		node.Tracer,
 		node.Me,
 		node.State,
-		vm,
 		vmCtx,
-		computation.DefaultProgramsCacheSize,
 		committer,
-		computation.DefaultScriptLogThreshold,
-		computation.DefaultScriptExecutionTimeLimit,
 		nil,
 		prov,
+		computation.ComputationConfig{
+			ProgramsCacheSize:        computation.DefaultProgramsCacheSize,
+			ScriptLogThreshold:       computation.DefaultScriptLogThreshold,
+			ScriptExecutionTimeLimit: computation.DefaultScriptExecutionTimeLimit,
+		},
 	)
 	require.NoError(t, err)
 
@@ -703,7 +700,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		RequestEngine:       requestEngine,
 		ReceiptsEngine:      pusherEngine,
 		BadgerDB:            node.PublicDB,
-		VM:                  vm,
+		VM:                  computationEngine.VM(),
 		ExecutionState:      execState,
 		Ledger:              ls,
 		LevelDbDir:          dbDir,


### PR DESCRIPTION
Instead of passing the virtual machine (and implicitly the cadence runtime)
into computation.Manager's New function, this creates the virtual machine and
runtime inside the New function itself.

This is prep work for moving the cadence runtime into ReusableCadenceRuntime.