### PR TITLE
Merge meter (and interaction) unconditionally

### DIFF
--- a/fvm/meter/meter.go
+++ b/fvm/meter/meter.go
@@ -45,7 +45,7 @@ type MeteredMemoryIntensities map[common.MemoryKind]uint
 type Meter interface {
 	// merge child funcionality
 	NewChild() Meter
-	MergeMeter(child Meter, enforceLimits bool) error
+	MergeMeter(child Meter)
 
 	// computation metering
 	MeterComputation(kind common.ComputationKind, intensity uint) error

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -256,16 +256,13 @@ func (s *State) TotalMemoryLimit() uint {
 }
 
 // MergeState applies the changes from a the given view to this view.
-func (s *State) MergeState(other *State, enforceLimit bool) error {
+func (s *State) MergeState(other *State) error {
 	err := s.view.MergeView(other.view)
 	if err != nil {
 		return errors.NewStateMergeFailure(err)
 	}
 
-	err = s.meter.MergeMeter(other.meter, enforceLimit)
-	if err != nil {
-		return err
-	}
+	s.meter.MergeMeter(other.meter)
 
 	// apply address updates
 	for k, v := range other.updatedAddresses {
@@ -283,10 +280,6 @@ func (s *State) MergeState(other *State, enforceLimit bool) error {
 	s.TotalBytesRead += other.TotalBytesRead
 	s.TotalBytesWritten += other.TotalBytesWritten
 
-	// check max interaction as last step
-	if enforceLimit {
-		return s.checkMaxInteraction()
-	}
 	return nil
 }
 

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -141,9 +141,7 @@ func (s *StateHolder) BeginParseRestrictedNestedTransaction(
 	}, nil
 }
 
-func (s *StateHolder) mergeIntoParent(
-	enforceLimits bool,
-) error {
+func (s *StateHolder) mergeIntoParent() error {
 	if len(s.nestedTransactions) < 2 {
 		return fmt.Errorf("cannot commit the main transaction")
 	}
@@ -152,7 +150,7 @@ func (s *StateHolder) mergeIntoParent(
 	s.nestedTransactions = s.nestedTransactions[:len(s.nestedTransactions)-1]
 	parent := s.current()
 
-	return parent.state.MergeState(child.state, enforceLimits)
+	return parent.state.MergeState(child.state)
 }
 
 // Commit commits the changes in the current unrestricted nested transaction
@@ -174,7 +172,7 @@ func (s *StateHolder) Commit(
 		)
 	}
 
-	return s.mergeIntoParent(s.EnforceLimits())
+	return s.mergeIntoParent()
 }
 
 // CommitParseRestricted commits the changes in the current restricted nested
@@ -198,7 +196,7 @@ func (s *StateHolder) CommitParseRestricted(
 		)
 	}
 
-	err := s.mergeIntoParent(s.EnforceLimits())
+	err := s.mergeIntoParent()
 	if err != nil {
 		return nil, err
 	}
@@ -219,9 +217,7 @@ func (s *StateHolder) AttachAndCommitParseRestricted(
 		},
 	)
 
-	// NOTE: limit enforcement is disabled here because cadence environment's
-	// Get() does not support returning error.
-	return s.mergeIntoParent(false)
+	return s.mergeIntoParent()
 }
 
 // RestartNestedTransaction merges all changes that belongs to the nested
@@ -246,7 +242,7 @@ func (s *StateHolder) RestartNestedTransaction(
 	}
 
 	for s.currentState() != id.state {
-		err := s.mergeIntoParent(s.EnforceLimits())
+		err := s.mergeIntoParent()
 		if err != nil {
 			return fmt.Errorf("cannot restart nested transaction: %w", err)
 		}

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -68,7 +68,7 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		require.Equal(t, len(v), 0)
 
 		// merge to parent
-		err = st.MergeState(stChild, true)
+		err = st.MergeState(stChild)
 		require.NoError(t, err)
 
 		// read key3 on parent
@@ -187,7 +187,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Equal(t, st.InteractionUsed(), uint64(0))
 
 	// commit
-	err = st.MergeState(stChild, true)
+	err = st.MergeState(stChild)
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), uint64(3))
 


### PR DESCRIPTION
Nested transaction commits no longer fails due to merging meter.

The next metering call (if any) will notice that the limit is reach, so it's
generally safe to not check the limit during merging.