### PR TITLE
[Testing] Use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/bootstrap/run/execution_state_test.go
+++ b/cmd/bootstrap/run/execution_state_test.go
@@ -2,7 +2,6 @@ package run
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -22,8 +21,7 @@ func TestGenerateExecutionState(t *testing.T) {
 	require.NoError(t, err)
 
 	pk := sk.PublicKey(42)
-	bootstrapDir, err := os.MkdirTemp("/tmp", "flow-integration-bootstrap")
-	require.NoError(t, err)
+	bootstrapDir := t.TempDir()
 	trieDir := filepath.Join(bootstrapDir, bootstrap.DirnameExecutionState)
 	commit, err := GenerateExecutionState(
 		trieDir,

--- a/cmd/bootstrap/transit/cmd/crypto_test.go
+++ b/cmd/bootstrap/transit/cmd/crypto_test.go
@@ -16,18 +16,14 @@ const nodeID string = "000000000000000000000000000000000000000000000000000000000
 func TestEndToEnd(t *testing.T) {
 
 	// Create a temp directory to work as "bootstrap"
-	bootdir, err := os.MkdirTemp("", "bootstrap.*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(bootdir)
+	bootdir := t.TempDir()
 
 	t.Logf("Created dir %s", bootdir)
 
 	// Create test files
 	//bootcmd.WriteText(filepath.Join(bootdir, bootstrap.PathNodeId), []byte(nodeID)
 	randomBeaconPath := filepath.Join(bootdir, fmt.Sprintf(bootstrap.PathRandomBeaconPriv, nodeID))
-	err = os.MkdirAll(filepath.Dir(randomBeaconPath), 0755)
+	err := os.MkdirAll(filepath.Dir(randomBeaconPath), 0755)
 	if err != nil {
 		t.Fatalf("Failed to write dir for random beacon file: %s", err)
 	}

--- a/ledger/complete/ledger_benchmark_test.go
+++ b/ledger/complete/ledger_benchmark_test.go
@@ -3,7 +3,6 @@ package complete_test
 import (
 	"math"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -43,11 +42,7 @@ func benchmarkStorage(steps int, b *testing.B) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	dir, err := os.MkdirTemp("", "test-mtrie-")
-	defer os.RemoveAll(dir)
-	if err != nil {
-		b.Fatal(err)
-	}
+	dir := b.TempDir()
 
 	diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir, steps+1, pathfinder.PathByteSize, wal.SegmentSize)
 	require.NoError(b, err)
@@ -162,11 +157,7 @@ func BenchmarkTrieUpdate(b *testing.B) {
 
 	rand.Seed(1)
 
-	dir, err := os.MkdirTemp("", "test-mtrie-")
-	defer os.RemoveAll(dir)
-	if err != nil {
-		b.Fatal(err)
-	}
+	dir := b.TempDir()
 
 	diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
 	require.NoError(b, err)
@@ -220,11 +211,7 @@ func BenchmarkTrieRead(b *testing.B) {
 
 	rand.Seed(1)
 
-	dir, err := os.MkdirTemp("", "test-mtrie-")
-	defer os.RemoveAll(dir)
-	if err != nil {
-		b.Fatal(err)
-	}
+	dir := b.TempDir()
 
 	diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
 	require.NoError(b, err)
@@ -287,11 +274,7 @@ func BenchmarkLedgerGetOneValue(b *testing.B) {
 
 	rand.Seed(1)
 
-	dir, err := os.MkdirTemp("", "test-mtrie-")
-	defer os.RemoveAll(dir)
-	if err != nil {
-		b.Fatal(err)
-	}
+	dir := b.TempDir()
 
 	diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
 	require.NoError(b, err)
@@ -371,11 +354,7 @@ func BenchmarkTrieProve(b *testing.B) {
 
 	rand.Seed(1)
 
-	dir, err := os.MkdirTemp("", "test-mtrie-")
-	defer os.RemoveAll(dir)
-	if err != nil {
-		b.Fatal(err)
-	}
+	dir := b.TempDir()
 
 	diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
 	require.NoError(b, err)

--- a/module/executiondatasync/tracker/storage_test.go
+++ b/module/executiondatasync/tracker/storage_test.go
@@ -2,7 +2,6 @@ package tracker
 
 import (
 	"crypto/rand"
-	"os"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -24,8 +23,7 @@ func randomCid() cid.Cid {
 // height, and their associated tracking data, should be removed from the database.
 func TestPrune(t *testing.T) {
 	expectedPrunedCIDs := make(map[cid.Cid]struct{})
-	storageDir, err := os.MkdirTemp("/tmp", "prune_test")
-	require.NoError(t, err)
+	storageDir := t.TempDir()
 	storage, err := OpenStorage(storageDir, 0, zerolog.Nop(), WithPruneCallback(func(c cid.Cid) error {
 		_, ok := expectedPrunedCIDs[c]
 		assert.True(t, ok, "unexpected CID pruned: %s", c.String())
@@ -84,8 +82,7 @@ func TestPrune(t *testing.T) {
 // TestPruneNonLatestHeight test that when pruning a height at which a CID exists,
 // if that CID also exists at another height above the pruned height, the CID should not be pruned.
 func TestPruneNonLatestHeight(t *testing.T) {
-	storageDir, err := os.MkdirTemp("/tmp", "prune_test")
-	require.NoError(t, err)
+	storageDir := t.TempDir()
 	storage, err := OpenStorage(storageDir, 0, zerolog.Nop(), WithPruneCallback(func(c cid.Cid) error {
 		assert.Fail(t, "unexpected CID pruned: %s", c.String())
 		return nil


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```