### PR TITLE
[FVM] Events in scripts do nothing instead of causing errors

### DIFF
--- a/fvm/environment/event_emitter.go
+++ b/fvm/environment/event_emitter.go
@@ -29,11 +29,11 @@ type EventEmitter interface {
 var _ EventEmitter = NoEventEmitter{}
 
 // NoEventEmitter is usually used in the environment for script execution,
-// where no event should be emitted.
+// where emitting an event does nothing.
 type NoEventEmitter struct{}
 
 func (NoEventEmitter) EmitEvent(event cadence.Event) error {
-	return errors.NewOperationNotSupportedError("EmitEvent")
+	return nil
 }
 
 func (NoEventEmitter) Events() []flow.Event {

--- a/fvm/environment/event_emitter_test.go
+++ b/fvm/environment/event_emitter_test.go
@@ -61,3 +61,10 @@ func Test_IsServiceEvent(t *testing.T) {
 		assert.False(t, isServiceEvent)
 	})
 }
+
+func Test_ScriptEventEmitter(t *testing.T) {
+	// scripts use the NoEventEmitter
+	emitter := environment.NoEventEmitter{}
+	err := emitter.EmitEvent(cadence.Event{})
+	require.NoError(t, err, "script should not error when emitting events")
+}


### PR DESCRIPTION
ref: https://github.com/onflow/flow-go/issues/2813

# Important Note

This is not a breaking change. Scripts can now call emit event, but nothing will happen instead of causing an error. This allows for scripts to call contract functions that would normally emit events.