### PR TITLE
Create one cadence runtime per ReusableCadenceRuntime object

### DIFF
--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/rs/zerolog"
@@ -30,8 +28,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 	chain := flow.Testnet.Chain()
 	view := migrations.NewView(payloads)
 
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 	opts := []fvm.Option{
 		fvm.WithChain(chain),
 		fvm.WithTransactionProcessors(

--- a/cmd/verification_builder.go
+++ b/cmd/verification_builder.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/spf13/pflag"
 
 	flowconsensus "github.com/onflow/flow-go/consensus"
@@ -194,8 +192,7 @@ func (v *VerificationNodeBuilder) LoadComponentsAndModules() {
 		Component("verifier engine", func(node *NodeConfig) (module.ReadyDoneAware, error) {
 			var err error
 
-			rt := fvm.NewInterpreterRuntime(runtime.Config{})
-			vm := fvm.NewVirtualMachine(rt)
+			vm := fvm.NewVM()
 			fvmOptions := append(
 				[]fvm.Option{fvm.WithLogger(node.Logger)},
 				node.FvmOptions...,

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -185,9 +185,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithEpochConfig(epochConfig),
 		}
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
 		chain := flow.Localnet.Chain()
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 		baseOpts := []fvm.Option{
 			fvm.WithChain(chain),
 		}
@@ -342,9 +341,13 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 	})
 
 	t.Run("service events are emitted", func(t *testing.T) {
-		execCtx := fvm.NewContext(fvm.WithServiceEventCollectionEnabled(), fvm.WithTransactionProcessors(
-			fvm.NewTransactionInvoker(), //we don't need to check signatures or sequence numbers
-		))
+		execCtx := fvm.NewContext(
+			fvm.WithServiceEventCollectionEnabled(),
+			fvm.WithTransactionProcessors(
+				//we don't need to check signatures or sequence numbers
+				fvm.NewTransactionInvoker(),
+			),
+		)
 
 		collectionCount := 2
 		transactionsPerCollection := 2
@@ -405,7 +408,16 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			},
 		}
 
-		vm := fvm.NewVirtualMachine(emittingRuntime)
+		execCtx = fvm.NewContextFromParent(
+			execCtx,
+			fvm.WithReusableCadenceRuntimePool(
+				fvm.NewCustomReusableCadenceRuntimePool(
+					0,
+					func() runtime.Runtime {
+						return emittingRuntime
+					})))
+
+		vm := fvm.NewVM()
 
 		bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 		trackerStorage := new(mocktracker.Storage)
@@ -473,7 +485,16 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			},
 		}
 
-		vm := fvm.NewVirtualMachine(rt)
+		execCtx = fvm.NewContextFromParent(
+			execCtx,
+			fvm.WithReusableCadenceRuntimePool(
+				fvm.NewCustomReusableCadenceRuntimePool(
+					0,
+					func() runtime.Runtime {
+						return rt
+					})))
+
+		vm := fvm.NewVM()
 
 		bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 		trackerStorage := new(mocktracker.Storage)
@@ -560,7 +581,16 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			},
 		}
 
-		vm := fvm.NewVirtualMachine(rt)
+		execCtx = fvm.NewContextFromParent(
+			execCtx,
+			fvm.WithReusableCadenceRuntimePool(
+				fvm.NewCustomReusableCadenceRuntimePool(
+					0,
+					func() runtime.Runtime {
+						return rt
+					})))
+
+		vm := fvm.NewVM()
 
 		bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 		trackerStorage := new(mocktracker.Storage)
@@ -726,8 +756,7 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 	address := flow.HexToAddress("1234")
 	fag := &FixedAddressGenerator{Address: address}
 
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 	execCtx := fvm.NewContext()
 
 	ledger := testutil.RootBootstrappedLedger(vm, execCtx)
@@ -791,8 +820,7 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 		fvm.WithBlocks(&environment.NoopBlockFinder{}),
 	)
 
-	runtime := fvm.NewInterpreterRuntime(runtime.Config{})
-	vm := fvm.NewVirtualMachine(runtime)
+	vm := fvm.NewVM()
 
 	rag := &RandomAddressGenerator{}
 

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 
@@ -634,8 +632,7 @@ func executeBlockAndVerifyWithParameters(t *testing.T,
 	txs [][]*flow.TransactionBody,
 	opts []fvm.Option,
 	bootstrapOpts []fvm.BootstrapProcedureOption) *execution.ComputationResult {
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 
 	logger := zerolog.Nop()
 

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -75,7 +75,7 @@ type ComputationConfig struct {
 	ScriptExecutionTimeLimit time.Duration
 
 	// When NewCustomVirtualMachine is nil, the manager will create a standard
-	// fvm virtual machine via fvm.NewVirtualMachine.  Otherwise, the manager
+	// fvm virtual machine via fvm.NewVM.  Otherwise, the manager
 	// will create a virtual machine using this function.
 	//
 	// Note that this is primarily used for testing.
@@ -118,17 +118,16 @@ func New(
 	if params.NewCustomVirtualMachine != nil {
 		vm = params.NewCustomVirtualMachine()
 	} else {
-		rt := runtime.NewInterpreterRuntime(
-			runtime.Config{
-				TracingEnabled: params.CadenceTracing,
-			})
-
-		vm = fvm.NewVirtualMachine(rt)
+		vm = fvm.NewVM()
 	}
 
 	options := []fvm.Option{
 		fvm.WithReusableCadenceRuntimePool(
-			fvm.NewReusableCadenceRuntimePool(ReusableCadenceRuntimePoolSize)),
+			fvm.NewReusableCadenceRuntimePool(
+				ReusableCadenceRuntimePoolSize,
+				runtime.Config{
+					TracingEnabled: params.CadenceTracing,
+				})),
 	}
 	if params.ExtensiveTracing {
 		options = append(options, fvm.WithExtensiveTracing())

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -7,7 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/onflow/cadence/runtime"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/engine/execution/computation/committer"
 	"github.com/onflow/flow-go/engine/execution/computation/computer"
@@ -27,14 +34,6 @@ import (
 	requesterunit "github.com/onflow/flow-go/module/state_synchronization/requester/unittest"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/utils/unittest"
-
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-datastore"
-	dssync "github.com/ipfs/go-datastore/sync"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 type testAccount struct {
@@ -87,7 +86,7 @@ func BenchmarkComputeBlock(b *testing.B) {
 	tracer, err := trace.NewTracer(zerolog.Nop(), "", "", 4)
 	require.NoError(b, err)
 
-	vm := fvm.NewVirtualMachine(fvm.NewInterpreterRuntime(runtime.Config{}))
+	vm := fvm.NewVM()
 
 	chain := flow.Emulator.Chain()
 	execCtx := fvm.NewContext(
@@ -96,7 +95,9 @@ func BenchmarkComputeBlock(b *testing.B) {
 		fvm.WithTransactionFeesEnabled(true),
 		fvm.WithTracer(tracer),
 		fvm.WithReusableCadenceRuntimePool(
-			fvm.NewReusableCadenceRuntimePool(ReusableCadenceRuntimePoolSize)),
+			fvm.NewReusableCadenceRuntimePool(
+				ReusableCadenceRuntimePoolSize,
+				runtime.Config{})),
 	)
 	ledger := testutil.RootBootstrappedLedger(
 		vm,

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -41,9 +39,8 @@ import (
 )
 
 func TestPrograms_TestContractUpdates(t *testing.T) {
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
 	chain := flow.Mainnet.Chain()
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 	execCtx := fvm.NewContext(fvm.WithChain(chain))
 
 	privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
@@ -193,9 +190,8 @@ func (b blockProvider) ByHeightFrom(height uint64, _ *flow.Header) (*flow.Header
 //	            -> Block1211 (emit event - version should be 2)
 func TestPrograms_TestBlockForks(t *testing.T) {
 	block := unittest.BlockFixture()
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
 	chain := flow.Emulator.Chain()
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 	execCtx := fvm.NewContext(
 		fvm.WithBlockHeader(block.Header),
 		fvm.WithBlocks(blockProvider{map[uint64]*flow.Block{0: &block}}),

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
 
@@ -42,8 +40,7 @@ func (b *Bootstrapper) BootstrapLedger(
 	view := delta.NewView(state.LedgerGetRegister(ledger, flow.StateCommitment(ledger.InitialState())))
 	programs := programs.NewEmptyPrograms()
 
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 
 	ctx := fvm.NewContext(
 		fvm.WithLogger(b.logger),

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -872,9 +870,7 @@ func VerificationNode(t testing.TB,
 	}
 
 	if node.VerifierEngine == nil {
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 
 		blockFinder := environment.NewBlockFinder(node.Headers)
 

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -5,8 +5,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -254,9 +252,7 @@ func ExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Chain, refB
 		)
 		require.NoError(t, err)
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 
 		blocks := new(fvmMock.Blocks)
 

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -3,6 +3,7 @@ package fvm
 import (
 	"math"
 
+	"github.com/onflow/cadence/runtime"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm/environment"
@@ -99,8 +100,10 @@ func defaultContext() Context {
 		ScriptProcessors: []ScriptProcessor{
 			NewScriptInvoker(),
 		},
-		Logger:                     zerolog.Nop(),
-		ReusableCadenceRuntimePool: NewReusableCadenceRuntimePool(0),
+		Logger: zerolog.Nop(),
+		ReusableCadenceRuntimePool: NewReusableCadenceRuntimePool(
+			0,
+			runtime.Config{}),
 	}
 }
 

--- a/fvm/contractFunctionInvoker.go
+++ b/fvm/contractFunctionInvoker.go
@@ -2,7 +2,6 @@ package fvm
 
 import (
 	"github.com/onflow/cadence"
-	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"go.opentelemetry.io/otel/attribute"
@@ -54,20 +53,15 @@ func (sys *SystemContracts) Invoke(
 			contractLocation.String()+"."+spec.FunctionName))
 	defer span.End()
 
-	runtimeEnv := sys.env.BorrowCadenceRuntime()
-	defer sys.env.ReturnCadenceRuntime(runtimeEnv)
+	runtime := sys.env.BorrowCadenceRuntime()
+	defer sys.env.ReturnCadenceRuntime(runtime)
 
-	value, err := sys.env.VM().Runtime.InvokeContractFunction(
+	value, err := runtime.InvokeContractFunction(
 		contractLocation,
 		spec.FunctionName,
 		arguments,
 		spec.ArgumentTypes,
-		runtime.Context{
-			Interface:   sys.env,
-			Environment: runtimeEnv,
-		},
 	)
-
 	if err != nil {
 		// this is an error coming from Cadendce runtime, so it must be handled first.
 		err = errors.HandleRuntimeError(err)

--- a/fvm/contractFunctionInvoker_test.go
+++ b/fvm/contractFunctionInvoker_test.go
@@ -107,20 +107,17 @@ func TestSystemContractsInvoke(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := &fvmMock.Environment{}
-			vm := &fvm.VirtualMachine{
-				Runtime: &TestInterpreterRuntime{
-					invokeContractFunction: tc.contractFunction,
-				},
-			}
 			logger := zerolog.Logger{}
 			chain := flow.Mainnet.Chain()
 
 			env.On("StartSpanFromRoot", mock.Anything).Return(trace.NoopSpan)
-			env.On("VM").Return(vm)
 			env.On("Chain").Return(chain)
 			env.On("Logger").Return(&logger)
 			env.On("BorrowCadenceRuntime", mock.Anything).Return(
-				fvm.NewReusableCadenceRuntime())
+				fvm.NewReusableCadenceRuntime(
+					&TestInterpreterRuntime{
+						invokeContractFunction: tc.contractFunction,
+					}))
 			env.On("ReturnCadenceRuntime", mock.Anything).Return()
 
 			invoker := fvm.NewSystemContracts()

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -23,7 +23,6 @@ import (
 // Environment accepts a context and a virtual machine instance and provides
 // cadence runtime interface methods to the runtime.
 type Environment interface {
-	VM() *VirtualMachine
 	runtime.Interface
 
 	Chain() flow.Chain
@@ -143,10 +142,6 @@ func (env *commonEnv) Chain() flow.Chain {
 
 func (env *commonEnv) LimitAccountStorage() bool {
 	return env.ctx.LimitAccountStorage
-}
-
-func (env *commonEnv) VM() *VirtualMachine {
-	return env.vm
 }
 
 func (env *commonEnv) BorrowCadenceRuntime() *ReusableCadenceRuntime {

--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -120,17 +120,10 @@ func getExecutionWeights[KindType common.ComputationKind | common.MemoryKind](
 	map[KindType]uint64,
 	error,
 ) {
-	runtimeEnv := env.BorrowCadenceRuntime()
-	defer env.ReturnCadenceRuntime(runtimeEnv)
+	runtime := env.BorrowCadenceRuntime()
+	defer env.ReturnCadenceRuntime(runtime)
 
-	value, err := env.VM().Runtime.ReadStored(
-		service,
-		path,
-		runtime.Context{
-			Interface:   env,
-			Environment: runtimeEnv,
-		},
-	)
+	value, err := runtime.ReadStored(service, path)
 
 	if err != nil {
 		// this might be fatal, return as is
@@ -199,17 +192,12 @@ func GetExecutionMemoryLimit(
 	memoryLimit uint64,
 	err error,
 ) {
-	runtimeEnv := env.BorrowCadenceRuntime()
-	defer env.ReturnCadenceRuntime(runtimeEnv)
+	runtime := env.BorrowCadenceRuntime()
+	defer env.ReturnCadenceRuntime(runtime)
 
-	value, err := env.VM().Runtime.ReadStored(
+	value, err := runtime.ReadStored(
 		service,
-		blueprints.TransactionFeesExecutionMemoryLimitPath,
-		runtime.Context{
-			Interface:   env,
-			Environment: runtimeEnv,
-		},
-	)
+		blueprints.TransactionFeesExecutionMemoryLimitPath)
 	if err != nil {
 		// this might be fatal, return as is
 		return 0, err

--- a/fvm/executionParameters_test.go
+++ b/fvm/executionParameters_test.go
@@ -28,18 +28,12 @@ func TestGetExecutionMemoryWeights(t *testing.T) {
 		path cadence.Path,
 		context runtime.Context,
 	) (cadence.Value, error)) fvm.Environment {
-		r := &TestInterpreterRuntime{
-			readStored: readStored,
-		}
-		vm := fvm.VirtualMachine{
-			Runtime: r,
-		}
 		envMock := &fvmmock.Environment{}
-		envMock.On("VM").
-			Return(&vm).
-			Once()
 		envMock.On("BorrowCadenceRuntime", mock.Anything).Return(
-			fvm.NewReusableCadenceRuntime())
+			fvm.NewReusableCadenceRuntime(
+				&TestInterpreterRuntime{
+					readStored: readStored,
+				}))
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}
@@ -161,18 +155,12 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 		path cadence.Path,
 		context runtime.Context,
 	) (cadence.Value, error)) fvm.Environment {
-		r := &TestInterpreterRuntime{
-			readStored: readStored,
-		}
-		vm := fvm.VirtualMachine{
-			Runtime: r,
-		}
 		envMock := &fvmmock.Environment{}
-		envMock.On("VM").
-			Return(&vm).
-			Once()
 		envMock.On("BorrowCadenceRuntime", mock.Anything).Return(
-			fvm.NewReusableCadenceRuntime())
+			fvm.NewReusableCadenceRuntime(
+				&TestInterpreterRuntime{
+					readStored: readStored,
+				}))
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -27,11 +27,21 @@ func NewInterpreterRuntime(config runtime.Config) runtime.Runtime {
 
 // A VirtualMachine augments the Cadence runtime with Flow host functionality.
 type VirtualMachine struct {
-	// TODO(patrick): move this into ReusableCadenceRuntime
-	Runtime runtime.Runtime
+	Runtime runtime.Runtime // DEPRECATED.  DO NOT USE.
 }
 
-// NewVirtualMachine creates a new virtual machine instance with the provided runtime.
+func NewVM() *VirtualMachine {
+	return &VirtualMachine{}
+}
+
+// DEPRECATED.  DO NOT USE.
+//
+// TODO(patrick): remove after emulator is updated.
+//
+// Emulator is a special snowflake which prevents fvm from every changing its
+// APIs (integration test uses a pinned version of the emulator, which in turn
+// uses a pinned non-master version of flow-go).  This method is expose to break
+// the ridiculous circular dependency between the two builds.
 func NewVirtualMachine(rt runtime.Runtime) *VirtualMachine {
 	return &VirtualMachine{
 		Runtime: rt,

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -144,8 +142,7 @@ type BasicBlockExecutor struct {
 }
 
 func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logger) *BasicBlockExecutor {
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 
 	opts := []fvm.Option{
 		fvm.WithTransactionFeesEnabled(true),

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -60,8 +60,7 @@ func (vmt vmTest) withContextOptions(opts ...fvm.Option) vmTest {
 }
 
 func createChainAndVm(chainID flow.ChainID) (flow.Chain, *fvm.VirtualMachine) {
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-	return chainID.Chain(), fvm.NewVirtualMachine(rt)
+	return chainID.Chain(), fvm.NewVM()
 }
 
 func (vmt vmTest) run(
@@ -145,7 +144,7 @@ func (vmt bootstrappedVmTest) run(
 	f func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs),
 ) func(t *testing.T) {
 	return func(t *testing.T) {
-		f(t, fvm.NewVirtualMachine(fvm.NewInterpreterRuntime(runtime.Config{})), vmt.chain, vmt.ctx, vmt.view.NewChild(), vmt.programs.ChildPrograms())
+		f(t, fvm.NewVM(), vmt.chain, vmt.ctx, vmt.view.NewChild(), vmt.programs.ChildPrograms())
 	}
 }
 

--- a/fvm/handler/programs_test.go
+++ b/fvm/handler/programs_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onflow/cadence/runtime"
-
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/stretchr/testify/require"
 
@@ -115,8 +113,7 @@ func Test_Programs(t *testing.T) {
 
 	stTxn := state.NewStateTransaction(mainView, state.DefaultParameters())
 
-	rt := fvm.NewInterpreterRuntime(runtime.Config{})
-	vm := fvm.NewVirtualMachine(rt)
+	vm := fvm.NewVM()
 	programs := programsStorage.NewEmptyPrograms()
 
 	accounts := environment.NewAccounts(stTxn)

--- a/fvm/mock/environment.go
+++ b/fvm/mock/environment.go
@@ -911,22 +911,6 @@ func (_m *Environment) UpdateAccountContractCode(address common.Address, name st
 	return r0
 }
 
-// VM provides a mock function with given fields:
-func (_m *Environment) VM() *fvm.VirtualMachine {
-	ret := _m.Called()
-
-	var r0 *fvm.VirtualMachine
-	if rf, ok := ret.Get(0).(func() *fvm.VirtualMachine); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*fvm.VirtualMachine)
-		}
-	}
-
-	return r0
-}
-
 // ValidatePublicKey provides a mock function with given fields: key
 func (_m *Environment) ValidatePublicKey(key *stdlib.PublicKey) error {
 	ret := _m.Called(key)

--- a/fvm/reusable_cadence_runtime_test.go
+++ b/fvm/reusable_cadence_runtime_test.go
@@ -3,11 +3,12 @@ package fvm
 import (
 	"testing"
 
+	"github.com/onflow/cadence/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func TestReusableCadanceRuntimePoolUnbuffered(t *testing.T) {
-	pool := NewReusableCadenceRuntimePool(0)
+	pool := NewReusableCadenceRuntimePool(0, runtime.Config{})
 	require.Nil(t, pool.pool)
 
 	entry := pool.Borrow(nil)
@@ -22,7 +23,7 @@ func TestReusableCadanceRuntimePoolUnbuffered(t *testing.T) {
 }
 
 func TestReusableCadanceRuntimePoolBuffered(t *testing.T) {
-	pool := NewReusableCadenceRuntimePool(100)
+	pool := NewReusableCadenceRuntimePool(100, runtime.Config{})
 	require.NotNil(t, pool.pool)
 
 	select {
@@ -49,7 +50,7 @@ func TestReusableCadanceRuntimePoolBuffered(t *testing.T) {
 }
 
 func TestReusableCadanceRuntimePoolSharing(t *testing.T) {
-	pool := NewReusableCadenceRuntimePool(100)
+	pool := NewReusableCadenceRuntimePool(100, runtime.Config{})
 	require.NotNil(t, pool.pool)
 
 	select {

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -128,17 +128,15 @@ func (i ScriptInvoker) Process(
 ) error {
 	env := NewScriptEnvironment(proc.RequestContext, ctx, vm, sth, programs)
 
-	location := common.ScriptLocation(proc.ID)
-	value, err := vm.Runtime.ExecuteScript(
+	rt := env.BorrowCadenceRuntime()
+	defer env.ReturnCadenceRuntime(rt)
+
+	value, err := rt.ExecuteScript(
 		runtime.Script{
 			Source:    proc.Script,
 			Arguments: proc.Arguments,
 		},
-		runtime.Context{
-			Interface: env,
-			Location:  location,
-		},
-	)
+		common.ScriptLocation(proc.ID))
 
 	if err != nil {
 		return errors.HandleRuntimeError(err)

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -138,17 +138,10 @@ func (e *TransactionEnv) GetAuthorizedAccounts(path cadence.Path) []common.Addre
 	service := runtime.Address(e.ctx.Chain.ServiceAddress())
 	defaultAccounts := []runtime.Address{service}
 
-	runtimeEnv := e.BorrowCadenceRuntime()
-	defer e.ReturnCadenceRuntime(runtimeEnv)
+	runtime := e.BorrowCadenceRuntime()
+	defer e.ReturnCadenceRuntime(runtime)
 
-	value, err := e.vm.Runtime.ReadStored(
-		service,
-		path,
-		runtime.Context{
-			Interface:   e,
-			Environment: runtimeEnv,
-		},
-	)
+	value, err := runtime.ReadStored(service, path)
 
 	const warningMsg = "failed to read contract authorized accounts from service account. using default behaviour instead."
 
@@ -169,17 +162,12 @@ func (e *TransactionEnv) GetIsContractDeploymentRestricted() (restricted bool, d
 	restricted, defined = false, false
 	service := runtime.Address(e.ctx.Chain.ServiceAddress())
 
-	runtimeEnv := e.BorrowCadenceRuntime()
-	defer e.ReturnCadenceRuntime(runtimeEnv)
+	runtime := e.BorrowCadenceRuntime()
+	defer e.ReturnCadenceRuntime(runtime)
 
-	value, err := e.vm.Runtime.ReadStored(
+	value, err := runtime.ReadStored(
 		service,
-		blueprints.IsContractDeploymentRestrictedPath,
-		runtime.Context{
-			Interface:   e,
-			Environment: runtimeEnv,
-		},
-	)
+		blueprints.IsContractDeploymentRestrictedPath)
 	if err != nil {
 		e.ctx.Logger.
 			Debug().

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -82,23 +82,17 @@ func (i TransactionInvoker) Process(
 
 	env := NewTransactionEnvironment(*ctx, vm, sth, programs, proc.Transaction, proc.TxIndex, span)
 
-	location := common.TransactionLocation(proc.ID)
-
-	runtimeEnv := env.BorrowCadenceRuntime()
-	defer env.ReturnCadenceRuntime(runtimeEnv)
+	rt := env.BorrowCadenceRuntime()
+	defer env.ReturnCadenceRuntime(rt)
 
 	var txError error
-	err = vm.Runtime.ExecuteTransaction(
+	err = rt.ExecuteTransaction(
 		runtime.Script{
 			Source:    proc.Transaction.Script,
 			Arguments: proc.Transaction.Arguments,
 		},
-		runtime.Context{
-			Interface:   env,
-			Location:    location,
-			Environment: runtimeEnv,
-		},
-	)
+		common.TransactionLocation(proc.ID))
+
 	if err != nil {
 		var interactionLimitExceededErr *errors.LedgerInteractionLimitExceededError
 		if errors.As(err, &interactionLimitExceededErr) {

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -23,13 +23,11 @@ func TestSafetyCheck(t *testing.T) {
 
 	t.Run("parsing error in transaction", func(t *testing.T) {
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-
 		buffer := &bytes.Buffer{}
 		log := zerolog.New(buffer)
 		txInvoker := fvm.NewTransactionInvoker()
 
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 
 		code := `X`
 
@@ -56,13 +54,11 @@ func TestSafetyCheck(t *testing.T) {
 
 	t.Run("checking error in transaction", func(t *testing.T) {
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-
 		buffer := &bytes.Buffer{}
 		log := zerolog.New(buffer)
 		txInvoker := fvm.NewTransactionInvoker()
 
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 
 		code := `transaction(arg: X) { }`
 

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -29,9 +29,6 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 			}),
 			nil,
 		)
-		env.On("BorrowCadenceRuntime", mock.Anything).Return(
-			fvm.NewReusableCadenceRuntime())
-		env.On("ReturnCadenceRuntime", mock.Anything).Return()
 
 		d := &fvm.TransactionStorageLimiter{}
 		err := d.CheckLimits(env, []flow.Address{owner})
@@ -50,9 +47,6 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 			}),
 			nil,
 		)
-		env.On("BorrowCadenceRuntime", mock.Anything).Return(
-			fvm.NewReusableCadenceRuntime())
-		env.On("ReturnCadenceRuntime", mock.Anything).Return()
 
 		d := &fvm.TransactionStorageLimiter{}
 		err := d.CheckLimits(env, []flow.Address{owner})
@@ -71,9 +65,6 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 			}),
 			nil,
 		)
-		env.On("BorrowCadenceRuntime", mock.Anything).Return(
-			fvm.NewReusableCadenceRuntime())
-		env.On("ReturnCadenceRuntime", mock.Anything).Return()
 
 		d := &fvm.TransactionStorageLimiter{}
 		err := d.CheckLimits(env, []flow.Address{owner})
@@ -93,9 +84,6 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 			}),
 			nil,
 		)
-		env.On("BorrowCadenceRuntime", mock.Anything).Return(
-			fvm.NewReusableCadenceRuntime())
-		env.On("ReturnCadenceRuntime", mock.Anything).Return()
 
 		d := &fvm.TransactionStorageLimiter{}
 		err := d.CheckLimits(env, []flow.Address{owner})
@@ -114,9 +102,6 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 			}),
 			nil,
 		)
-		env.On("BorrowCadenceRuntime", mock.Anything).Return(
-			fvm.NewReusableCadenceRuntime())
-		env.On("ReturnCadenceRuntime", mock.Anything).Return()
 
 		d := &fvm.TransactionStorageLimiter{}
 		err := d.CheckLimits(env, []flow.Address{owner})

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -57,8 +57,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, frozen)
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 		txInvoker := fvm.NewTransactionInvoker()
 
 		code := fmt.Sprintf(`
@@ -94,8 +93,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, frozen)
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 
 		// deploy code to account
 
@@ -227,9 +225,7 @@ func TestAccountFreezing(t *testing.T) {
 		accounts := environment.NewAccounts(st)
 		programsStorage := programs.NewEmptyPrograms()
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 
 		// deploy code to accounts
 		whateverContractCode := `
@@ -368,8 +364,7 @@ func TestAccountFreezing(t *testing.T) {
 
 	t.Run("service account cannot freeze itself", func(t *testing.T) {
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 		// create default context
 		context := fvm.NewContext()
 		programsStorage := programs.NewEmptyPrograms()
@@ -464,8 +459,7 @@ func TestAccountFreezing(t *testing.T) {
 		accounts := environment.NewAccounts(st)
 		programsStorage := programs.NewEmptyPrograms()
 
-		rt := fvm.NewInterpreterRuntime(runtime.Config{})
-		vm := fvm.NewVirtualMachine(rt)
+		vm := fvm.NewVM()
 
 		// deploy code to accounts
 		whateverCode := []byte(`

--- a/utils/debug/remoteDebugger.go
+++ b/utils/debug/remoteDebugger.go
@@ -2,7 +2,6 @@ package debug
 
 import (
 	"github.com/onflow/cadence"
-	"github.com/onflow/cadence/runtime"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm"
@@ -21,7 +20,7 @@ type RemoteDebugger struct {
 func NewRemoteDebugger(grpcAddress string,
 	chain flow.Chain,
 	logger zerolog.Logger) *RemoteDebugger {
-	vm := fvm.NewVirtualMachine(fvm.NewInterpreterRuntime(runtime.Config{}))
+	vm := fvm.NewVM()
 
 	// no signature processor here
 	// TODO Maybe we add fee-deduction step as well


### PR DESCRIPTION
Since cadence runtime is not reentrant safe, each parallel runtime invocation
must have its own runtime.