### PR TITLE
Refactor GetAccountKey into AccountKeyReader

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -43,28 +43,6 @@ type Environment interface {
 	AccountsStorageCapacity(addresses []common.Address) (cadence.Value, error)
 }
 
-// TODO(patrick): refactor this into an object
-// Set of account api that do not have shared implementation.
-type AccountInterface interface {
-	CreateAccount(address runtime.Address) (runtime.Address, error)
-
-	AddAccountKey(
-		address runtime.Address,
-		publicKey *runtime.PublicKey,
-		hashAlgo runtime.HashAlgorithm,
-		weight int,
-	) (
-		*runtime.AccountKey,
-		error,
-	)
-
-	GetAccountKey(address runtime.Address, keyIndex int) (*runtime.AccountKey, error)
-
-	RevokeAccountKey(address runtime.Address, keyIndex int) (*runtime.AccountKey, error)
-
-	AddEncodedAccountKey(address runtime.Address, publicKey []byte) error
-}
-
 // Parts of the environment that are common to all transaction and script
 // executions.
 type commonEnv struct {
@@ -79,13 +57,12 @@ type commonEnv struct {
 	environment.EventEmitter
 	*environment.ValueStore
 	*environment.ContractReader
+	*environment.AccountKeyReader
 
 	*SystemContracts
 
 	// TODO(patrick): rm
 	ctx Context
-
-	AccountInterface
 
 	sth         *state.StateHolder
 	vm          *VirtualMachine
@@ -98,6 +75,66 @@ type commonEnv struct {
 
 	// TODO(patrick): rm once fully refactored
 	fullEnv Environment
+}
+
+func newCommonEnv(
+	ctx Context,
+	vm *VirtualMachine,
+	stateTransaction *state.StateHolder,
+	programs *programs.Programs,
+	tracer *environment.Tracer,
+	meter environment.Meter,
+) commonEnv {
+	accounts := environment.NewAccounts(stateTransaction)
+	programsHandler := handler.NewProgramsHandler(programs, stateTransaction)
+
+	return commonEnv{
+		Tracer: tracer,
+		Meter:  meter,
+		ProgramLogger: environment.NewProgramLogger(
+			tracer,
+			ctx.Logger,
+			ctx.Metrics,
+			ctx.CadenceLoggingEnabled,
+		),
+		UUIDGenerator: environment.NewUUIDGenerator(
+			tracer,
+			meter,
+			stateTransaction),
+		UnsafeRandomGenerator: environment.NewUnsafeRandomGenerator(
+			tracer,
+			ctx.BlockHeader,
+		),
+		CryptoLibrary: environment.NewCryptoLibrary(tracer, meter),
+		BlockInfo: environment.NewBlockInfo(
+			tracer,
+			meter,
+			ctx.BlockHeader,
+			ctx.Blocks,
+		),
+		ValueStore: environment.NewValueStore(
+			tracer,
+			meter,
+			accounts,
+		),
+		ContractReader: environment.NewContractReader(
+			tracer,
+			meter,
+			accounts,
+		),
+		AccountKeyReader: environment.NewAccountKeyReader(
+			tracer,
+			meter,
+			accounts,
+		),
+		SystemContracts: NewSystemContracts(),
+		ctx:             ctx,
+		sth:             stateTransaction,
+		vm:              vm,
+		programs:        programsHandler,
+		accounts:        accounts,
+		frozenAccounts:  nil,
+	}
 }
 
 func (env *commonEnv) Chain() flow.Chain {
@@ -274,30 +311,4 @@ func (commonEnv) ResourceOwnerChanged(
 	common.Address,
 	common.Address,
 ) {
-}
-
-// GetAccountKey retrieves a public key by index from an existing account.
-//
-// This function returns a nil key with no errors, if a key doesn't exist at
-// the given index. An error is returned if the specified account does not
-// exist, the provided index is not valid, or if the key retrieval fails.
-func (env *commonEnv) GetAccountKey(
-	address runtime.Address,
-	keyIndex int,
-) (
-	*runtime.AccountKey,
-	error,
-) {
-	defer env.StartSpanFromRoot(trace.FVMEnvGetAccountKey).End()
-
-	err := env.MeterComputation(environment.ComputationKindGetAccountKey, 1)
-	if err != nil {
-		return nil, fmt.Errorf("get account key failed: %w", err)
-	}
-
-	accKey, err := env.accountKeys.GetAccountKey(address, keyIndex)
-	if err != nil {
-		return nil, fmt.Errorf("get account key failed: %w", err)
-	}
-	return accKey, err
 }

--- a/fvm/environment/account_key_reader.go
+++ b/fvm/environment/account_key_reader.go
@@ -1,0 +1,114 @@
+package environment
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/runtime"
+
+	"github.com/onflow/flow-go/fvm/crypto"
+	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/trace"
+)
+
+// AccountKeyReader provide read access to account keys.
+type AccountKeyReader struct {
+	tracer *Tracer
+	meter  Meter
+
+	accounts Accounts
+}
+
+func NewAccountKeyReader(
+	tracer *Tracer,
+	meter Meter,
+	accounts Accounts,
+) *AccountKeyReader {
+	return &AccountKeyReader{
+		tracer:   tracer,
+		meter:    meter,
+		accounts: accounts,
+	}
+}
+
+// GetAccountKey retrieves a public key by index from an existing account.
+//
+// This function returns a nil key with no errors, if a key doesn't exist at
+// the given index. An error is returned if the specified account does not
+// exist, the provided index is not valid, or if the key retrieval fails.
+func (reader *AccountKeyReader) GetAccountKey(
+	address runtime.Address,
+	keyIndex int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
+	defer reader.tracer.StartSpanFromRoot(trace.FVMEnvGetAccountKey).End()
+
+	err := reader.meter.MeterComputation(ComputationKindGetAccountKey, 1)
+	if err != nil {
+		return nil, fmt.Errorf("get account key failed: %w", err)
+	}
+
+	accountAddress := flow.Address(address)
+
+	ok, err := reader.accounts.Exists(accountAddress)
+	if err != nil {
+		return nil, fmt.Errorf("getting account key failed: %w", err)
+	}
+
+	if !ok {
+		issue := errors.NewAccountNotFoundError(accountAddress)
+		return nil, fmt.Errorf("getting account key failed: %w", issue)
+	}
+
+	// Don't return an error for invalid key indices
+	if keyIndex < 0 {
+		return nil, nil
+	}
+
+	var publicKey flow.AccountPublicKey
+	publicKey, err = reader.accounts.GetPublicKey(
+		accountAddress,
+		uint64(keyIndex))
+	if err != nil {
+		// If a key is not found at a given index, then return a nil key with
+		// no errors.  This is to be inline with the Cadence runtime. Otherwise,
+		// Cadence runtime cannot distinguish between a 'key not found error'
+		// vs other internal errors.
+		if errors.IsAccountAccountPublicKeyNotFoundError(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("getting account key failed: %w", err)
+	}
+
+	// Prepare the account key to return
+
+	signAlgo := crypto.CryptoToRuntimeSigningAlgorithm(publicKey.SignAlgo)
+	if signAlgo == runtime.SignatureAlgorithmUnknown {
+		err = errors.NewValueErrorf(
+			publicKey.SignAlgo.String(),
+			"signature algorithm type not found")
+		return nil, fmt.Errorf("getting account key failed: %w", err)
+	}
+
+	hashAlgo := crypto.CryptoToRuntimeHashingAlgorithm(publicKey.HashAlgo)
+	if hashAlgo == runtime.HashAlgorithmUnknown {
+		err = errors.NewValueErrorf(
+			publicKey.HashAlgo.String(),
+			"hashing algorithm type not found")
+		return nil, fmt.Errorf("getting account key failed: %w", err)
+	}
+
+	return &runtime.AccountKey{
+		KeyIndex: publicKey.Index,
+		PublicKey: &runtime.PublicKey{
+			PublicKey: publicKey.PublicKey.Encode(),
+			SignAlgo:  signAlgo,
+		},
+		HashAlgo:  hashAlgo,
+		Weight:    publicKey.Weight,
+		IsRevoked: publicKey.Revoked,
+	}, nil
+}


### PR DESCRIPTION
1. split GetAccountKey out of handler/AccountKeyHandler into
   environment/AccountKeyReader
2. combined env's tracer / meter logic into the new reader
3. also dedup commonEnv initialization code (and rm AccountInterface)