### PR TITLE
Refactor contract updater

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -61,6 +61,7 @@ type commonEnv struct {
 	*environment.AccountKeyReader
 
 	*SystemContracts
+	handler.ContractUpdater
 
 	// TODO(patrick): rm
 	ctx Context
@@ -70,7 +71,6 @@ type commonEnv struct {
 	programs    *handler.ProgramsHandler
 	accounts    environment.Accounts
 	accountKeys *handler.AccountKeyHandler
-	contracts   *handler.ContractHandler
 
 	// TODO(patrick): rm once fully refactored
 	fullEnv Environment
@@ -296,7 +296,7 @@ func (env *commonEnv) DecodeArgument(b []byte, _ cadence.Type) (cadence.Value, e
 
 // Commit commits changes and return a list of updated keys
 func (env *commonEnv) Commit() (programs.ModifiedSets, error) {
-	keys, err := env.contracts.Commit()
+	keys, err := env.ContractUpdater.Commit()
 	return programs.ModifiedSets{
 		ContractUpdateKeys: keys,
 		FrozenAccounts:     env.FrozenAccounts(),

--- a/fvm/handler/contract.go
+++ b/fvm/handler/contract.go
@@ -12,20 +12,91 @@ import (
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/trace"
 )
+
+type sortableContractUpdates struct {
+	keys    []programs.ContractUpdateKey
+	updates []programs.ContractUpdate
+}
+
+func (lists *sortableContractUpdates) Len() int {
+	return len(lists.keys)
+}
+
+func (lists *sortableContractUpdates) Swap(i, j int) {
+	lists.keys[i], lists.keys[j] = lists.keys[j], lists.keys[i]
+	lists.updates[i], lists.updates[j] = lists.updates[j], lists.updates[i]
+}
+
+func (lists *sortableContractUpdates) Less(i, j int) bool {
+	switch bytes.Compare(lists.keys[i].Address[:], lists.keys[j].Address[:]) {
+	case -1:
+		return true
+	case 0:
+		return lists.keys[i].Name < lists.keys[j].Name
+	default:
+		return false
+	}
+}
+
+// ContractUpdater handles all smart contracts modification. It also captures
+// all changes as deltas and only commit them when called so smart contract
+// updates can be delayed until end of the tx execution.
+//
+// Note that scripts cannot modify smart contracts, but must expose the API in
+// compliance with the runtime environment interface.
+type ContractUpdater interface {
+	UpdateAccountContractCode(
+		address runtime.Address,
+		name string,
+		code []byte,
+	) error
+
+	RemoveAccountContractCode(address runtime.Address, name string) error
+
+	Commit() ([]programs.ContractUpdateKey, error)
+
+	Reset()
+}
+
+type NoContractUpdater struct{}
+
+func (NoContractUpdater) UpdateAccountContractCode(
+	address runtime.Address,
+	name string,
+	code []byte,
+) error {
+	return errors.NewOperationNotSupportedError("UpdateAccountContractCode")
+}
+
+func (NoContractUpdater) RemoveAccountContractCode(
+	address runtime.Address,
+	name string,
+) error {
+	return errors.NewOperationNotSupportedError("RemoveAccountContractCode")
+}
+
+func (NoContractUpdater) Commit() ([]programs.ContractUpdateKey, error) {
+	return nil, nil
+}
+
+func (NoContractUpdater) Reset() {
+}
 
 type RestrictionIsEnabledFunc func() bool
 type AuthorizedAccountsFunc func() []common.Address
 type UseContractAuditVoucherFunc func(address runtime.Address, code []byte) (bool, error)
 
-// ContractHandler handles all interaction
-// with smart contracts such as get/set/update
-// it also captures all changes as deltas and
-// only commit them when called so smart contract
-// updates can be delayed until end of the tx execution
-type ContractHandler struct {
-	accounts                     environment.Accounts
-	draftUpdates                 map[programs.ContractUpdateKey]programs.ContractUpdate
+type contractUpdater struct {
+	tracer          *environment.Tracer
+	meter           environment.Meter
+	accounts        environment.Accounts
+	transactionInfo environment.TransactionInfo
+
+	draftUpdates map[programs.ContractUpdateKey]programs.ContractUpdate
+
+	// TODO(patrick): convert these into normal methods.
 	restrictedDeploymentEnabled  RestrictionIsEnabledFunc
 	restrictedRemovalEnabled     RestrictionIsEnabledFunc
 	authorizedDeploymentAccounts AuthorizedAccountsFunc
@@ -33,26 +104,98 @@ type ContractHandler struct {
 	useContractAuditVoucher      UseContractAuditVoucherFunc
 }
 
-func NewContractHandler(
+var _ ContractUpdater = &contractUpdater{}
+
+func NewContractUpdater(
+	tracer *environment.Tracer,
+	meter environment.Meter,
 	accounts environment.Accounts,
+	transactionInfo environment.TransactionInfo,
 	restrictedDeploymentEnabled RestrictionIsEnabledFunc,
 	restrictedRemovalEnabled RestrictionIsEnabledFunc,
 	authorizedDeploymentAccounts AuthorizedAccountsFunc,
 	authorizedRemovalAccounts AuthorizedAccountsFunc,
 	useContractAuditVoucher UseContractAuditVoucherFunc,
-) *ContractHandler {
-	return &ContractHandler{
+) *contractUpdater {
+	updater := &contractUpdater{
+		tracer:                       tracer,
+		meter:                        meter,
 		accounts:                     accounts,
-		draftUpdates:                 make(map[programs.ContractUpdateKey]programs.ContractUpdate),
+		transactionInfo:              transactionInfo,
 		restrictedDeploymentEnabled:  restrictedDeploymentEnabled,
 		restrictedRemovalEnabled:     restrictedRemovalEnabled,
 		authorizedDeploymentAccounts: authorizedDeploymentAccounts,
 		authorizedRemovalAccounts:    authorizedRemovalAccounts,
 		useContractAuditVoucher:      useContractAuditVoucher,
 	}
+
+	updater.Reset()
+	return updater
 }
 
-func (h *ContractHandler) SetContract(
+func (updater *contractUpdater) UpdateAccountContractCode(
+	address runtime.Address,
+	name string,
+	code []byte,
+) error {
+	defer updater.tracer.StartSpanFromRoot(
+		trace.FVMEnvUpdateAccountContractCode).End()
+
+	err := updater.meter.MeterComputation(
+		environment.ComputationKindUpdateAccountContractCode,
+		1)
+	if err != nil {
+		return fmt.Errorf("update account contract code failed: %w", err)
+	}
+
+	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	if err != nil {
+		return fmt.Errorf("update account contract code failed: %w", err)
+	}
+
+	err = updater.setContract(
+		address,
+		name,
+		code,
+		updater.transactionInfo.SigningAccounts())
+	if err != nil {
+		return fmt.Errorf("updating account contract code failed: %w", err)
+	}
+
+	return nil
+}
+
+func (updater *contractUpdater) RemoveAccountContractCode(
+	address runtime.Address,
+	name string,
+) error {
+	defer updater.tracer.StartSpanFromRoot(
+		trace.FVMEnvRemoveAccountContractCode).End()
+
+	err := updater.meter.MeterComputation(
+		environment.ComputationKindRemoveAccountContractCode,
+		1)
+	if err != nil {
+		return fmt.Errorf("remove account contract code failed: %w", err)
+	}
+
+	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	if err != nil {
+		return fmt.Errorf("remove account contract code failed: %w", err)
+	}
+
+	err = updater.removeContract(
+		address,
+		name,
+		updater.transactionInfo.SigningAccounts())
+	if err != nil {
+		return fmt.Errorf("remove account contract code failed: %w", err)
+	}
+
+	return nil
+}
+
+func (updater *contractUpdater) setContract(
 	address runtime.Address,
 	name string,
 	code []byte,
@@ -67,14 +210,14 @@ func (h *ContractHandler) SetContract(
 	// Contract updates are always allowed.
 
 	var exists bool
-	exists, err = h.accounts.ContractExists(name, flowAddress)
+	exists, err = updater.accounts.ContractExists(name, flowAddress)
 	if err != nil {
 		return err
 	}
 
-	if !exists && !h.isAuthorizedForDeployment(signingAccounts) {
+	if !exists && !updater.isAuthorizedForDeployment(signingAccounts) {
 		// check if there's an audit voucher for the contract
-		voucherAvailable, err := h.useContractAuditVoucher(address, code)
+		voucherAvailable, err := updater.useContractAuditVoucher(address, code)
 		if err != nil {
 			errInner := errors.NewOperationAuthorizationErrorf(
 				"SetContract",
@@ -83,11 +226,12 @@ func (h *ContractHandler) SetContract(
 			return fmt.Errorf("setting contract failed: %w - %s", errInner, err)
 		}
 		if !voucherAvailable {
-			err = errors.NewOperationAuthorizationErrorf(
-				"SetContract",
-				"deploying contracts requires authorization from specific accounts",
-			)
-			return fmt.Errorf("deploying contract failed: %w", err)
+			return fmt.Errorf(
+				"deploying contract failed: %w",
+				errors.NewOperationAuthorizationErrorf(
+					"SetContract",
+					"deploying contracts requires authorization from specific "+
+						"accounts"))
 		}
 	}
 
@@ -96,7 +240,7 @@ func (h *ContractHandler) SetContract(
 		Name:    name,
 	}
 
-	h.draftUpdates[contractUpdateKey] = programs.ContractUpdate{
+	updater.draftUpdates[contractUpdateKey] = programs.ContractUpdate{
 		ContractUpdateKey: contractUpdateKey,
 		Code:              code,
 	}
@@ -104,62 +248,41 @@ func (h *ContractHandler) SetContract(
 	return nil
 }
 
-func (h *ContractHandler) RemoveContract(
+func (updater *contractUpdater) removeContract(
 	address runtime.Address,
 	name string,
 	signingAccounts []runtime.Address,
 ) (err error) {
 	// check if authorized
-	if !h.isAuthorizedForRemoval(signingAccounts) {
-		err = errors.NewOperationAuthorizationErrorf("RemoveContract", "removing contracts requires authorization from specific accounts")
-		return fmt.Errorf("removing contract failed: %w", err)
+	if !updater.isAuthorizedForRemoval(signingAccounts) {
+		return fmt.Errorf("removing contract failed: %w",
+			errors.NewOperationAuthorizationErrorf(
+				"RemoveContract",
+				"removing contracts requires authorization from specific "+
+					"accounts"))
 	}
 
 	add := flow.Address(address)
 	uk := programs.ContractUpdateKey{Address: add, Name: name}
 	u := programs.ContractUpdate{ContractUpdateKey: uk}
-	h.draftUpdates[uk] = u
+	updater.draftUpdates[uk] = u
 
 	return nil
 }
 
-type contractUpdateList []programs.ContractUpdate
-
-func (l contractUpdateList) Len() int      { return len(l) }
-func (l contractUpdateList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
-func (l contractUpdateList) Less(i, j int) bool {
-	switch bytes.Compare(l[i].Address[:], l[j].Address[:]) {
-	case -1:
-		return true
-	case 0:
-		return l[i].Name < l[j].Name
-	default:
-		return false
-	}
-}
-
-func (h *ContractHandler) Commit() ([]programs.ContractUpdateKey, error) {
-	updatedKeys := h.UpdateKeys()
-	updateList := make(contractUpdateList, 0)
-
-	for k, uk := range h.draftUpdates {
-		updateList = append(updateList, uk)
-
-		// delete as we go to clear h.draftUpdates
-		delete(h.draftUpdates, k)
-	}
-	// sort does not need to be stable as the contract update key is unique
-	sort.Sort(updateList)
+func (updater *contractUpdater) Commit() ([]programs.ContractUpdateKey, error) {
+	updatedKeys, updateList := updater.updates()
+	updater.Reset()
 
 	var err error
 	for _, v := range updateList {
 		if len(v.Code) > 0 {
-			err = h.accounts.SetContract(v.Name, v.Address, v.Code)
+			err = updater.accounts.SetContract(v.Name, v.Address, v.Code)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			err = h.accounts.DeleteContract(v.Name, v.Address)
+			err = updater.accounts.DeleteContract(v.Name, v.Address)
 			if err != nil {
 				return nil, err
 			}
@@ -169,58 +292,58 @@ func (h *ContractHandler) Commit() ([]programs.ContractUpdateKey, error) {
 	return updatedKeys, nil
 }
 
-func (h *ContractHandler) Rollback() error {
-	h.draftUpdates = make(map[programs.ContractUpdateKey]programs.ContractUpdate)
-	return nil
+func (updater *contractUpdater) Reset() {
+	updater.draftUpdates = make(map[programs.ContractUpdateKey]programs.ContractUpdate)
 }
 
-func (h *ContractHandler) HasUpdates() bool {
-	return len(h.draftUpdates) > 0
+func (updater *contractUpdater) hasUpdates() bool {
+	return len(updater.draftUpdates) > 0
 }
 
-type contractUpdateKeyList []programs.ContractUpdateKey
-
-func (l contractUpdateKeyList) Len() int      { return len(l) }
-func (l contractUpdateKeyList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
-func (l contractUpdateKeyList) Less(i, j int) bool {
-	switch bytes.Compare(l[i].Address[:], l[j].Address[:]) {
-	case -1:
-		return true
-	case 0:
-		return l[i].Name < l[j].Name
-	default:
-		return false
+func (updater *contractUpdater) updates() (
+	[]programs.ContractUpdateKey,
+	[]programs.ContractUpdate,
+) {
+	if len(updater.draftUpdates) == 0 {
+		return nil, nil
 	}
-}
-
-func (h *ContractHandler) UpdateKeys() []programs.ContractUpdateKey {
-	if len(h.draftUpdates) == 0 {
-		return nil
-	}
-	keys := make(contractUpdateKeyList, 0, len(h.draftUpdates))
-	for k := range h.draftUpdates {
-		keys = append(keys, k)
+	keys := make([]programs.ContractUpdateKey, 0, len(updater.draftUpdates))
+	updates := make([]programs.ContractUpdate, 0, len(updater.draftUpdates))
+	for key, update := range updater.draftUpdates {
+		keys = append(keys, key)
+		updates = append(updates, update)
 	}
 
-	sort.Sort(keys)
-	return keys
+	sort.Sort(&sortableContractUpdates{keys: keys, updates: updates})
+	return keys, updates
 }
 
-func (h *ContractHandler) isAuthorizedForDeployment(signingAccounts []runtime.Address) bool {
-	if h.restrictedDeploymentEnabled() {
-		return h.isAuthorized(signingAccounts, h.authorizedDeploymentAccounts)
+func (updater *contractUpdater) isAuthorizedForDeployment(
+	signingAccounts []runtime.Address,
+) bool {
+	if updater.restrictedDeploymentEnabled() {
+		return updater.isAuthorized(
+			signingAccounts,
+			updater.authorizedDeploymentAccounts)
 	}
 	return true
 }
 
-func (h *ContractHandler) isAuthorizedForRemoval(signingAccounts []runtime.Address) bool {
-	if h.restrictedRemovalEnabled() {
-		return h.isAuthorized(signingAccounts, h.authorizedRemovalAccounts)
+func (updater *contractUpdater) isAuthorizedForRemoval(
+	signingAccounts []runtime.Address,
+) bool {
+	if updater.restrictedRemovalEnabled() {
+		return updater.isAuthorized(
+			signingAccounts,
+			updater.authorizedRemovalAccounts)
 	}
 	return true
 }
 
-func (h *ContractHandler) isAuthorized(signingAccounts []runtime.Address, authorizedAccounts AuthorizedAccountsFunc) bool {
+func (updater *contractUpdater) isAuthorized(
+	signingAccounts []runtime.Address,
+	authorizedAccounts AuthorizedAccountsFunc,
+) bool {
 	accts := authorizedAccounts()
 	for _, authorized := range accts {
 		for _, signer := range signingAccounts {

--- a/fvm/handler/contract_test.go
+++ b/fvm/handler/contract_test.go
@@ -1,4 +1,4 @@
-package handler_test
+package handler
 
 import (
 	"fmt"
@@ -12,7 +12,6 @@ import (
 	"github.com/onflow/flow-go/fvm/programs"
 
 	"github.com/onflow/flow-go/fvm/environment"
-	"github.com/onflow/flow-go/fvm/handler"
 	stateMock "github.com/onflow/flow-go/fvm/mock/state"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -29,8 +28,11 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	err := accounts.Create(nil, address)
 	require.NoError(t, err)
 
-	contractHandler := handler.NewContractHandler(
+	contractUpdater := NewContractUpdater(
+		nil,
+		nil,
 		accounts,
+		nil,
 		func() bool { return false },
 		func() bool { return false },
 		nil, nil, nil)
@@ -41,9 +43,9 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	require.Equal(t, len(names), 0)
 
 	// set contract no need for signing accounts
-	err = contractHandler.SetContract(rAdd, "testContract", []byte("ABC"), nil)
+	err = contractUpdater.setContract(rAdd, "testContract", []byte("ABC"), nil)
 	require.NoError(t, err)
-	require.True(t, contractHandler.HasUpdates())
+	require.True(t, contractUpdater.hasUpdates())
 
 	// should not be readable from draft
 	cont, err := accounts.GetContract("testContract", address)
@@ -51,19 +53,18 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	require.Equal(t, len(cont), 0)
 
 	// commit
-	_, err = contractHandler.Commit()
+	_, err = contractUpdater.Commit()
 	require.NoError(t, err)
 	cont, err = accounts.GetContract("testContract", address)
 	require.NoError(t, err)
 	require.Equal(t, cont, []byte("ABC"))
 
 	// rollback
-	err = contractHandler.SetContract(rAdd, "testContract2", []byte("ABC"), nil)
+	err = contractUpdater.setContract(rAdd, "testContract2", []byte("ABC"), nil)
 	require.NoError(t, err)
-	err = contractHandler.Rollback()
-	require.NoError(t, err)
-	require.False(t, contractHandler.HasUpdates())
-	_, err = contractHandler.Commit()
+	contractUpdater.Reset()
+	require.False(t, contractUpdater.hasUpdates())
+	_, err = contractUpdater.Commit()
 	require.NoError(t, err)
 
 	// test contract shouldn't be there
@@ -77,7 +78,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	require.Equal(t, cont, []byte("ABC"))
 
 	// remove
-	err = contractHandler.RemoveContract(rAdd, "testContract", nil)
+	err = contractUpdater.removeContract(rAdd, "testContract", nil)
 	require.NoError(t, err)
 
 	// contract still there because no commit yet
@@ -86,7 +87,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	require.Equal(t, cont, []byte("ABC"))
 
 	// commit removal
-	_, err = contractHandler.Commit()
+	_, err = contractUpdater.Commit()
 	require.NoError(t, err)
 
 	// contract should no longer be there
@@ -121,8 +122,12 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	err = accounts.Create(nil, unAuth)
 	require.NoError(t, err)
 
-	makeHandler := func() *handler.ContractHandler {
-		return handler.NewContractHandler(accounts,
+	makeUpdater := func() *contractUpdater {
+		return NewContractUpdater(
+			nil,
+			nil,
+			accounts,
+			nil,
 			func() bool { return true },
 			func() bool { return true },
 			func() []common.Address { return []common.Address{rAdd, rBoth} },
@@ -131,87 +136,87 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	}
 
 	t.Run("try to set contract with unauthorized account", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{unAuthR})
+		err = contractUpdater.setContract(rAdd, "testContract1", []byte("ABC"), []common.Address{unAuthR})
 		require.Error(t, err)
-		require.False(t, contractHandler.HasUpdates())
+		require.False(t, contractUpdater.hasUpdates())
 	})
 
 	t.Run("try to set contract with account only authorized for removal", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rRemove})
+		err = contractUpdater.setContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rRemove})
 		require.Error(t, err)
-		require.False(t, contractHandler.HasUpdates())
+		require.False(t, contractUpdater.hasUpdates())
 	})
 
 	t.Run("set contract with account authorized for adding", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract2", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.setContract(rAdd, "testContract2", []byte("ABC"), []common.Address{rAdd})
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 	})
 
 	t.Run("set contract with account authorized for adding and removing", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract2", []byte("ABC"), []common.Address{rBoth})
+		err = contractUpdater.setContract(rAdd, "testContract2", []byte("ABC"), []common.Address{rBoth})
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 	})
 
 	t.Run("try to remove contract with unauthorized account", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.setContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
 		require.NoError(t, err)
-		_, err = contractHandler.Commit()
+		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractHandler.RemoveContract(unAuthR, "testContract2", []common.Address{unAuthR})
+		err = contractUpdater.removeContract(unAuthR, "testContract2", []common.Address{unAuthR})
 		require.Error(t, err)
-		require.False(t, contractHandler.HasUpdates())
+		require.False(t, contractUpdater.hasUpdates())
 	})
 
 	t.Run("remove contract account authorized for removal", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.setContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
 		require.NoError(t, err)
-		_, err = contractHandler.Commit()
+		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractHandler.RemoveContract(rRemove, "testContract2", []common.Address{rRemove})
+		err = contractUpdater.removeContract(rRemove, "testContract2", []common.Address{rRemove})
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 	})
 
 	t.Run("try to remove contract with account only authorized for adding", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.setContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
 		require.NoError(t, err)
-		_, err = contractHandler.Commit()
+		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractHandler.RemoveContract(rAdd, "testContract2", []common.Address{rAdd})
+		err = contractUpdater.removeContract(rAdd, "testContract2", []common.Address{rAdd})
 		require.Error(t, err)
-		require.False(t, contractHandler.HasUpdates())
+		require.False(t, contractUpdater.hasUpdates())
 	})
 
 	t.Run("remove contract with account authorized for adding and removing", func(t *testing.T) {
-		contractHandler := makeHandler()
+		contractUpdater := makeUpdater()
 
-		err = contractHandler.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.setContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
 		require.NoError(t, err)
-		_, err = contractHandler.Commit()
+		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractHandler.RemoveContract(rBoth, "testContract2", []common.Address{rBoth})
+		err = contractUpdater.removeContract(rBoth, "testContract2", []common.Address{rBoth})
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 	})
 }
 
@@ -232,8 +237,11 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 	err = accounts.Create(nil, addressNoVoucher)
 	require.NoError(t, err)
 
-	contractHandler := handler.NewContractHandler(
+	contractUpdater := NewContractUpdater(
+		nil,
+		nil,
 		accounts,
+		nil,
 		func() bool { return true },
 		func() bool { return true },
 		func() []common.Address {
@@ -250,7 +258,7 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 		})
 
 	// set contract without voucher
-	err = contractHandler.SetContract(
+	err = contractUpdater.setContract(
 		addressNoVoucherRuntime,
 		"TestContract1",
 		[]byte("pub contract TestContract1 {}"),
@@ -259,10 +267,10 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	require.False(t, contractHandler.HasUpdates())
+	require.False(t, contractUpdater.hasUpdates())
 
 	// try to set contract with voucher
-	err = contractHandler.SetContract(
+	err = contractUpdater.setContract(
 		addressWithVoucherRuntime,
 		"TestContract2",
 		[]byte("pub contract TestContract2 {}"),
@@ -271,7 +279,7 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.True(t, contractHandler.HasUpdates())
+	require.True(t, contractUpdater.hasUpdates())
 }
 
 func TestContract_ContractUpdate(t *testing.T) {
@@ -288,8 +296,11 @@ func TestContract_ContractUpdate(t *testing.T) {
 
 	var authorizationChecked bool
 
-	contractHandler := handler.NewContractHandler(
+	contractUpdater := NewContractUpdater(
+		nil,
+		nil,
 		accounts,
+		nil,
 		func() bool { return true },
 		func() bool { return true },
 		func() []common.Address {
@@ -309,7 +320,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 	)
 
 	// deploy contract with voucher
-	err = contractHandler.SetContract(
+	err = contractUpdater.setContract(
 		runtimeAddress,
 		"TestContract",
 		[]byte("pub contract TestContract {}"),
@@ -318,9 +329,9 @@ func TestContract_ContractUpdate(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.True(t, contractHandler.HasUpdates())
+	require.True(t, contractUpdater.hasUpdates())
 
-	contractUpdateKeys, err := contractHandler.Commit()
+	contractUpdateKeys, err := contractUpdater.Commit()
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -334,7 +345,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 	)
 
 	// try to update contract without voucher
-	err = contractHandler.SetContract(
+	err = contractUpdater.setContract(
 		runtimeAddress,
 		"TestContract",
 		[]byte("pub contract TestContract {}"),
@@ -343,7 +354,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	require.True(t, contractHandler.HasUpdates())
+	require.True(t, contractUpdater.hasUpdates())
 }
 
 func TestContract_DeterministicErrorOnCommit(t *testing.T) {
@@ -357,8 +368,11 @@ func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 			return fmt.Errorf("%s %s", contractName, address.Hex())
 		})
 
-	contractHandler := handler.NewContractHandler(
+	contractUpdater := NewContractUpdater(
+		nil,
+		nil,
 		mockAccounts,
+		nil,
 		func() bool { return false },
 		func() bool { return false },
 		nil,
@@ -369,16 +383,16 @@ func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 	address1 := runtime.Address(flow.HexToAddress("0000000000000001"))
 	address2 := runtime.Address(flow.HexToAddress("0000000000000002"))
 
-	err := contractHandler.SetContract(address2, "A", []byte("ABC"), nil)
+	err := contractUpdater.setContract(address2, "A", []byte("ABC"), nil)
 	require.NoError(t, err)
 
-	err = contractHandler.SetContract(address1, "B", []byte("ABC"), nil)
+	err = contractUpdater.setContract(address1, "B", []byte("ABC"), nil)
 	require.NoError(t, err)
 
-	err = contractHandler.SetContract(address1, "A", []byte("ABC"), nil)
+	err = contractUpdater.setContract(address1, "A", []byte("ABC"), nil)
 	require.NoError(t, err)
 
-	_, err = contractHandler.Commit()
+	_, err = contractUpdater.Commit()
 	require.EqualError(t, err, "A 0000000000000001")
 }
 
@@ -397,8 +411,11 @@ func TestContract_ContractRemoval(t *testing.T) {
 	t.Run("contract removal with restriction", func(t *testing.T) {
 		var authorizationChecked bool
 
-		contractHandler := handler.NewContractHandler(
+		contractUpdater := NewContractUpdater(
+			nil,
+			nil,
 			accounts,
+			nil,
 			func() bool { return false },
 			func() bool { return true },
 			func() []common.Address {
@@ -418,7 +435,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 		)
 
 		// deploy contract with voucher
-		err = contractHandler.SetContract(
+		err = contractUpdater.setContract(
 			runtimeAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
@@ -427,9 +444,9 @@ func TestContract_ContractRemoval(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 
-		contractUpdateKeys, err := contractHandler.Commit()
+		contractUpdateKeys, err := contractUpdater.Commit()
 		require.NoError(t, err)
 		require.Equal(
 			t,
@@ -443,7 +460,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 		)
 
 		// update should work
-		err = contractHandler.SetContract(
+		err = contractUpdater.setContract(
 			runtimeAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
@@ -452,10 +469,10 @@ func TestContract_ContractRemoval(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 
 		// try remove contract should fail
-		err = contractHandler.RemoveContract(
+		err = contractUpdater.removeContract(
 			runtimeAddress,
 			"TestContract",
 			[]common.Address{
@@ -468,8 +485,11 @@ func TestContract_ContractRemoval(t *testing.T) {
 	t.Run("contract removal without restriction", func(t *testing.T) {
 		var authorizationChecked bool
 
-		contractHandler := handler.NewContractHandler(
+		contractUpdater := NewContractUpdater(
+			nil,
+			nil,
 			accounts,
+			nil,
 			func() bool { return false },
 			func() bool { return false },
 			func() []common.Address {
@@ -489,7 +509,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 		)
 
 		// deploy contract with voucher
-		err = contractHandler.SetContract(
+		err = contractUpdater.setContract(
 			runtimeAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
@@ -498,9 +518,9 @@ func TestContract_ContractRemoval(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 
-		contractUpdateKeys, err := contractHandler.Commit()
+		contractUpdateKeys, err := contractUpdater.Commit()
 		require.NoError(t, err)
 		require.Equal(
 			t,
@@ -514,7 +534,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 		)
 
 		// update should work
-		err = contractHandler.SetContract(
+		err = contractUpdater.setContract(
 			runtimeAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
@@ -523,10 +543,10 @@ func TestContract_ContractRemoval(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 
 		// try remove contract should fail
-		err = contractHandler.RemoveContract(
+		err = contractUpdater.removeContract(
 			runtimeAddress,
 			"TestContract",
 			[]common.Address{
@@ -534,7 +554,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		require.True(t, contractHandler.HasUpdates())
+		require.True(t, contractUpdater.hasUpdates())
 
 	})
 }

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -47,6 +47,8 @@ func NewScriptEnvironment(
 	env.AccountFreezer = environment.NoAccountFreezer{}
 	env.SystemContracts.SetEnvironment(env)
 
+	env.ContractUpdater = handler.NoContractUpdater{}
+
 	// TODO(patrick): remove this hack
 	env.accountKeys = handler.NewAccountKeyHandler(env.accounts)
 	env.fullEnv = env
@@ -74,12 +76,4 @@ func (e *ScriptEnv) AddAccountKey(_ runtime.Address, _ *runtime.PublicKey, _ run
 
 func (e *ScriptEnv) RevokeAccountKey(_ runtime.Address, _ int) (*runtime.AccountKey, error) {
 	return nil, errors.NewOperationNotSupportedError("RevokeAccountKey")
-}
-
-func (e *ScriptEnv) UpdateAccountContractCode(_ runtime.Address, _ string, _ []byte) (err error) {
-	return errors.NewOperationNotSupportedError("UpdateAccountContractCode")
-}
-
-func (e *ScriptEnv) RemoveAccountContractCode(_ runtime.Address, _ string) (err error) {
-	return errors.NewOperationNotSupportedError("RemoveAccountContractCode")
 }

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -82,13 +82,11 @@ func NewTransactionEnvironment(
 		env.accounts,
 		env.TransactionInfo)
 	env.SystemContracts.SetEnvironment(env)
-
-	// TODO(patrick): rm this hack
-	env.accountKeys = handler.NewAccountKeyHandler(env.accounts)
-	env.fullEnv = env
-
-	env.contracts = handler.NewContractHandler(
+	env.ContractUpdater = handler.NewContractUpdater(
+		tracer,
+		meter,
 		env.accounts,
+		env.TransactionInfo,
 		func() bool {
 			enabled, defined := env.GetIsContractDeploymentRestricted()
 			if !defined {
@@ -108,6 +106,10 @@ func NewTransactionEnvironment(
 		env.GetAccountsAuthorizedForContractRemoval,
 		env.useContractAuditVoucher,
 	)
+
+	// TODO(patrick): rm this hack
+	env.accountKeys = handler.NewAccountKeyHandler(env.accounts)
+	env.fullEnv = env
 
 	return env
 }
@@ -334,46 +336,4 @@ func (e *TransactionEnv) RevokeAccountKey(address runtime.Address, keyIndex int)
 	}
 
 	return e.accountKeys.RevokeAccountKey(address, keyIndex)
-}
-
-func (e *TransactionEnv) UpdateAccountContractCode(address runtime.Address, name string, code []byte) (err error) {
-	defer e.StartSpanFromRoot(trace.FVMEnvUpdateAccountContractCode).End()
-
-	err = e.MeterComputation(environment.ComputationKindUpdateAccountContractCode, 1)
-	if err != nil {
-		return fmt.Errorf("update account contract code failed: %w", err)
-	}
-
-	err = e.accounts.CheckAccountNotFrozen(flow.Address(address))
-	if err != nil {
-		return fmt.Errorf("update account contract code failed: %w", err)
-	}
-
-	err = e.contracts.SetContract(address, name, code, e.SigningAccounts())
-	if err != nil {
-		return fmt.Errorf("updating account contract code failed: %w", err)
-	}
-
-	return nil
-}
-
-func (e *TransactionEnv) RemoveAccountContractCode(address runtime.Address, name string) (err error) {
-	defer e.StartSpanFromRoot(trace.FVMEnvRemoveAccountContractCode).End()
-
-	err = e.MeterComputation(environment.ComputationKindRemoveAccountContractCode, 1)
-	if err != nil {
-		return fmt.Errorf("remove account contract code failed: %w", err)
-	}
-
-	err = e.accounts.CheckAccountNotFrozen(flow.Address(address))
-	if err != nil {
-		return fmt.Errorf("remove account contract code failed: %w", err)
-	}
-
-	err = e.contracts.RemoveContract(address, name, e.SigningAccounts())
-	if err != nil {
-		return fmt.Errorf("remove account contract code failed: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
1. added ContractUpdater interface & NoContractUpdater for script
2. renamed (h *ContractHandler) to (updater *contractUpdater)
3. moved contract update methods from env to updater
4. moved ContractUpdateKeyList and ContractUpdateList into programs/
5. simplified Commit a bit

Note: we can't move the contract updater into environment/ yet since there are still some circular dependencies.