### PR TITLE
Convert programs.Programs into an optional argument for fvm.Run(V2)

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -42,6 +42,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/checker"
 	"github.com/onflow/flow-go/engine/execution/computation"
 	"github.com/onflow/flow-go/engine/execution/computation/committer"
+	"github.com/onflow/flow-go/engine/execution/computation/computer"
 	"github.com/onflow/flow-go/engine/execution/computation/computer/uploader"
 	"github.com/onflow/flow-go/engine/execution/ingestion"
 	exeprovider "github.com/onflow/flow-go/engine/execution/provider"
@@ -50,7 +51,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state/bootstrap"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
 	ledger "github.com/onflow/flow-go/ledger/complete"
@@ -898,7 +898,7 @@ func (exeNode *ExecutionNode) LoadGrpcServer(
 }
 
 // getContractEpochCounter Gets the epoch counters from the FlowEpoch smart contract from the view provided.
-func getContractEpochCounter(vm computation.VirtualMachine, vmCtx fvm.Context, view *delta.View) (uint64, error) {
+func getContractEpochCounter(vm computer.VirtualMachine, vmCtx fvm.Context, view *delta.View) (uint64, error) {
 	// Get the address of the FlowEpoch smart contract
 	sc, err := systemcontracts.SystemContractsForChain(vmCtx.Chain.ChainID())
 	if err != nil {
@@ -912,11 +912,8 @@ func getContractEpochCounter(vm computation.VirtualMachine, vmCtx fvm.Context, v
 	})
 	script := fvm.Script(scriptCode)
 
-	// Create empty programs cache
-	p := programs.NewEmptyPrograms()
-
 	// execute the script
-	err = vm.Run(vmCtx, script, view, p)
+	err = vm.RunV2(vmCtx, script, view)
 	if err != nil {
 		return 0, fmt.Errorf("could not read epoch counter, internal error while executing script: %w", err)
 	}

--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -122,7 +122,6 @@ type balanceProcessor struct {
 	vm            *fvm.VirtualMachine
 	ctx           fvm.Context
 	view          state.View
-	prog          *programs.Programs
 	env           fvm.Environment
 	balanceScript []byte
 	momentsScript []byte
@@ -138,10 +137,11 @@ type balanceProcessor struct {
 
 func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 	vm := fvm.NewVM()
+	progs := programs.NewEmptyPrograms()
 	ctx := fvm.NewContext(
 		fvm.WithChain(chain),
-		fvm.WithMemoryAndInteractionLimitsDisabled())
-	prog := programs.NewEmptyPrograms()
+		fvm.WithMemoryAndInteractionLimitsDisabled(),
+		fvm.WithBlockPrograms(progs))
 
 	v := view.NewChild()
 	stTxn := state.NewStateTransaction(
@@ -150,14 +150,13 @@ func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 	)
 	accounts := environment.NewAccounts(stTxn)
 
-	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, stTxn, prog)
+	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, stTxn, progs)
 
 	return &balanceProcessor{
 		vm:       vm,
 		ctx:      ctx,
 		view:     v,
 		accounts: accounts,
-		prog:     prog,
 		env:      env,
 	}
 }
@@ -316,7 +315,7 @@ func (c *balanceProcessor) balance(address flow.Address) (uint64, bool, error) {
 		jsoncdc.MustEncode(cadence.NewAddress(address)),
 	)
 
-	err := c.vm.Run(c.ctx, script, c.view, c.prog)
+	err := c.vm.RunV2(c.ctx, script, c.view)
 	if err != nil {
 		return 0, false, err
 	}
@@ -337,7 +336,7 @@ func (c *balanceProcessor) fusdBalance(address flow.Address) (uint64, error) {
 		jsoncdc.MustEncode(cadence.NewAddress(address)),
 	)
 
-	err := c.vm.Run(c.ctx, script, c.view, c.prog)
+	err := c.vm.RunV2(c.ctx, script, c.view)
 	if err != nil {
 		return 0, err
 	}
@@ -354,7 +353,7 @@ func (c *balanceProcessor) moments(address flow.Address) (int, error) {
 		jsoncdc.MustEncode(cadence.NewAddress(address)),
 	)
 
-	err := c.vm.Run(c.ctx, script, c.view, c.prog)
+	err := c.vm.RunV2(c.ctx, script, c.view)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -34,6 +34,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		fvm.WithTransactionProcessors(
 			fvm.NewTransactionInvoker(),
 		),
+		fvm.WithBlockPrograms(programs.NewEmptyPrograms()),
 	}
 	ctx := fvm.NewContext(opts...)
 	bootstrapOptions := []fvm.BootstrapProcedureOption{
@@ -43,9 +44,8 @@ func TestFungibleTokenTracker(t *testing.T) {
 		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply),
 	}
-	programs := programs.NewEmptyPrograms()
 
-	err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOptions...), view, programs)
+	err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOptions...), view)
 	require.NoError(t, err)
 
 	// deploy wrapper resource
@@ -81,7 +81,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		AddAuthorizer(chain.ServiceAddress())
 
 	tx := fvm.Transaction(txBody, 0)
-	err = vm.Run(ctx, tx, view, programs)
+	err = vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 
@@ -107,7 +107,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		AddAuthorizer(chain.ServiceAddress())
 
 	tx = fvm.Transaction(txBody, 0)
-	err = vm.Run(ctx, tx, view, programs)
+	err = vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -33,7 +33,14 @@ const (
 
 // VirtualMachine runs procedures
 type VirtualMachine interface {
+	// DEPRECATED. DO NOT USE
+	//
+	// TODO(patrick): remove after emulator is updated.
 	Run(fvm.Context, fvm.Procedure, state.View, *programs.Programs) error
+
+	RunV2(fvm.Context, fvm.Procedure, state.View) error
+
+	GetAccount(fvm.Context, flow.Address, state.View, *programs.Programs) (*flow.Account, error)
 }
 
 // ViewCommitter commits views's deltas to the ledger and collects the proofs
@@ -132,10 +139,12 @@ func (e *blockComputer) executeBlock(
 
 	blockCtx := fvm.NewContextFromParent(
 		e.vmCtx,
-		fvm.WithBlockHeader(block.Block.Header))
+		fvm.WithBlockHeader(block.Block.Header),
+		fvm.WithBlockPrograms(programs))
 	systemChunkCtx := fvm.NewContextFromParent(
 		e.systemChunkCtx,
-		fvm.WithBlockHeader(block.Block.Header))
+		fvm.WithBlockHeader(block.Block.Header),
+		fvm.WithBlockPrograms(programs))
 	collections := block.Collections()
 
 	chunksSize := len(collections) + 1 // + 1 system chunk
@@ -188,7 +197,7 @@ func (e *blockComputer) executeBlock(
 
 	for i, collection := range collections {
 		colView := stateView.NewChild()
-		txIndex, err = e.executeCollection(blockSpan, collectionIndex, txIndex, blockCtx, colView, programs, collection, res)
+		txIndex, err = e.executeCollection(blockSpan, collectionIndex, txIndex, blockCtx, colView, collection, res)
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute collection at txIndex %v: %w", txIndex, err)
 		}
@@ -205,7 +214,7 @@ func (e *blockComputer) executeBlock(
 	// executing system chunk
 	e.log.Debug().Hex("block_id", logging.Entity(block)).Msg("executing system chunk")
 	colView := stateView.NewChild()
-	systemCol, err := e.executeSystemCollection(blockSpan, collectionIndex, txIndex, systemChunkCtx, colView, programs, res)
+	systemCol, err := e.executeSystemCollection(blockSpan, collectionIndex, txIndex, systemChunkCtx, colView, res)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute system chunk transaction: %w", err)
 	}
@@ -273,7 +282,6 @@ func (e *blockComputer) executeSystemCollection(
 	txIndex uint32,
 	systemChunkCtx fvm.Context,
 	collectionView state.View,
-	programs *programs.Programs,
 	res *execution.ComputationResult,
 ) (*flow.Collection, error) {
 	colSpan := e.tracer.StartSpanFromParent(blockSpan, trace.EXEComputeSystemCollection)
@@ -284,7 +292,7 @@ func (e *blockComputer) executeSystemCollection(
 		return nil, fmt.Errorf("could not get system chunk transaction: %w", err)
 	}
 
-	err = e.executeTransaction(tx, colSpan, collectionView, programs, systemChunkCtx, collectionIndex, txIndex, res, true)
+	err = e.executeTransaction(tx, colSpan, collectionView, systemChunkCtx, collectionIndex, txIndex, res, true)
 
 	if err != nil {
 		return nil, err
@@ -316,7 +324,6 @@ func (e *blockComputer) executeCollection(
 	txIndex uint32,
 	blockCtx fvm.Context,
 	collectionView state.View,
-	programs *programs.Programs,
 	collection *entity.CompleteCollection,
 	res *execution.ComputationResult,
 ) (uint32, error) {
@@ -340,7 +347,7 @@ func (e *blockComputer) executeCollection(
 
 	txCtx := fvm.NewContextFromParent(blockCtx, fvm.WithMetricsReporter(e.metrics), fvm.WithTracer(e.tracer))
 	for _, txBody := range collection.Transactions {
-		err := e.executeTransaction(txBody, colSpan, collectionView, programs, txCtx, collectionIndex, txIndex, res, false)
+		err := e.executeTransaction(txBody, colSpan, collectionView, txCtx, collectionIndex, txIndex, res, false)
 		txIndex++
 		if err != nil {
 			return txIndex, err
@@ -363,7 +370,6 @@ func (e *blockComputer) executeTransaction(
 	txBody *flow.TransactionBody,
 	colSpan otelTrace.Span,
 	collectionView state.View,
-	programs *programs.Programs,
 	ctx fvm.Context,
 	collectionIndex int,
 	txIndex uint32,
@@ -414,7 +420,7 @@ func (e *blockComputer) executeTransaction(
 			Bool("system_chunk", isSystemChunk).
 			Logger()),
 	)
-	err := e.vm.Run(childCtx, tx, txView, programs)
+	err := e.vm.RunV2(childCtx, tx, txView)
 	if err != nil {
 		return fmt.Errorf("failed to execute transaction %v for block %v at height %v: %w",
 			txID.String(),

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -57,7 +57,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		execCtx := fvm.NewContext()
 
 		vm := new(computermock.VirtualMachine)
-		vm.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		vm.On("RunV2", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
 			Run(func(args mock.Arguments) {
 				//ctx := args[0].(fvm.Context)
@@ -143,7 +143,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		block := generateBlock(0, 0, rag)
 		programs := programs.NewEmptyPrograms()
 
-		vm.On("Run", mock.Anything, mock.Anything, mock.Anything, programs).
+		vm.On("RunV2", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
 			Once() // just system chunk
 
@@ -187,8 +187,10 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		chain := flow.Localnet.Chain()
 		vm := fvm.NewVM()
+		progs := programs.NewEmptyPrograms()
 		baseOpts := []fvm.Option{
 			fvm.WithChain(chain),
+			fvm.WithBlockPrograms(progs),
 		}
 
 		opts := append(baseOpts, contextOptions...)
@@ -200,9 +202,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		baseBootstrapOpts := []fvm.BootstrapProcedureOption{
 			fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply),
 		}
-		progs := programs.NewEmptyPrograms()
 		bootstrapOpts := append(baseBootstrapOpts, bootstrapOptions...)
-		err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view, progs)
+		err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
 		require.NoError(t, err)
 
 		comm := new(computermock.ViewCommitter)
@@ -274,7 +275,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		block := generateBlock(collectionCount, transactionsPerCollection, rag)
 		programs := programs.NewEmptyPrograms()
 
-		vm.On("Run", mock.Anything, mock.Anything, mock.Anything, programs).
+		vm.On("RunV2", mock.Anything, mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				tx := args[1].(*fvm.TransactionProcedure)
 

--- a/engine/execution/computation/computer/mock/virtual_machine.go
+++ b/engine/execution/computation/computer/mock/virtual_machine.go
@@ -4,6 +4,8 @@ package mock
 
 import (
 	fvm "github.com/onflow/flow-go/fvm"
+	flow "github.com/onflow/flow-go/model/flow"
+
 	mock "github.com/stretchr/testify/mock"
 
 	programs "github.com/onflow/flow-go/fvm/programs"
@@ -16,6 +18,29 @@ type VirtualMachine struct {
 	mock.Mock
 }
 
+// GetAccount provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *VirtualMachine) GetAccount(_a0 fvm.Context, _a1 flow.Address, _a2 state.View, _a3 *programs.Programs) (*flow.Account, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
+
+	var r0 *flow.Account
+	if rf, ok := ret.Get(0).(func(fvm.Context, flow.Address, state.View, *programs.Programs) *flow.Account); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*flow.Account)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(fvm.Context, flow.Address, state.View, *programs.Programs) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Run provides a mock function with given fields: _a0, _a1, _a2, _a3
 func (_m *VirtualMachine) Run(_a0 fvm.Context, _a1 fvm.Procedure, _a2 state.View, _a3 *programs.Programs) error {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
@@ -23,6 +48,20 @@ func (_m *VirtualMachine) Run(_a0 fvm.Context, _a1 fvm.Procedure, _a2 state.View
 	var r0 error
 	if rf, ok := ret.Get(0).(func(fvm.Context, fvm.Procedure, state.View, *programs.Programs) error); ok {
 		r0 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// RunV2 provides a mock function with given fields: _a0, _a1, _a2
+func (_m *VirtualMachine) RunV2(_a0 fvm.Context, _a1 fvm.Procedure, _a2 state.View) error {
+	ret := _m.Called(_a0, _a1, _a2)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(fvm.Context, fvm.Procedure, state.View) error); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -52,11 +52,6 @@ func GetUploaderEnabled() bool {
 	return uploadEnabled
 }
 
-type VirtualMachine interface {
-	Run(fvm.Context, fvm.Procedure, state.View, *programs.Programs) error
-	GetAccount(fvm.Context, flow.Address, state.View, *programs.Programs) (*flow.Account, error)
-}
-
 type ComputationManager interface {
 	ExecuteScript(context.Context, []byte, [][]byte, *flow.Header, state.View) ([]byte, error)
 	ComputeBlock(
@@ -79,7 +74,7 @@ type ComputationConfig struct {
 	// will create a virtual machine using this function.
 	//
 	// Note that this is primarily used for testing.
-	NewCustomVirtualMachine func() VirtualMachine
+	NewCustomVirtualMachine func() computer.VirtualMachine
 }
 
 // Manager manages computation and execution
@@ -89,7 +84,7 @@ type Manager struct {
 	metrics                  module.ExecutionMetrics
 	me                       module.Local
 	protoState               protocol.State
-	vm                       VirtualMachine
+	vm                       computer.VirtualMachine
 	vmCtx                    fvm.Context
 	blockComputer            computer.BlockComputer
 	programsCache            *ProgramsCache
@@ -114,7 +109,7 @@ func New(
 ) (*Manager, error) {
 	log := logger.With().Str("engine", "computation").Logger()
 
-	var vm VirtualMachine
+	var vm computer.VirtualMachine
 	if params.NewCustomVirtualMachine != nil {
 		vm = params.NewCustomVirtualMachine()
 	} else {
@@ -174,7 +169,7 @@ func New(
 	return &e, nil
 }
 
-func (e *Manager) VM() VirtualMachine {
+func (e *Manager) VM() computer.VirtualMachine {
 	return e.vm
 }
 
@@ -216,8 +211,10 @@ func (e *Manager) ExecuteScript(
 	defer cancel()
 
 	script := fvm.NewScriptWithContextAndArgs(code, requestCtx, arguments...)
-	blockCtx := fvm.NewContextFromParent(e.vmCtx, fvm.WithBlockHeader(blockHeader))
-	programs := e.getChildProgramsOrEmpty(blockHeader.ID())
+	blockCtx := fvm.NewContextFromParent(
+		e.vmCtx,
+		fvm.WithBlockHeader(blockHeader),
+		fvm.WithBlockPrograms(e.getChildProgramsOrEmpty(blockHeader.ID())))
 
 	err := func() (err error) {
 
@@ -253,7 +250,7 @@ func (e *Manager) ExecuteScript(
 			}
 		}()
 
-		return e.vm.Run(blockCtx, script, view, programs)
+		return e.vm.RunV2(blockCtx, script, view)
 	}()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute script (internal error): %w", err)

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -74,7 +74,7 @@ func mustFundAccounts(b *testing.B, vm *fvm.VirtualMachine, ledger state.View, e
 		accs.seq++
 
 		tx := fvm.Transaction(transferTx, uint32(i))
-		err = vm.Run(execCtx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(execCtx, tx, ledger)
 		require.NoError(b, err)
 		require.NoError(b, tx.Err)
 	}

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -368,7 +368,7 @@ func TestExecuteScripPanicsAreHandled(t *testing.T) {
 			ProgramsCacheSize:        DefaultProgramsCacheSize,
 			ScriptLogThreshold:       scriptLogThreshold,
 			ScriptExecutionTimeLimit: DefaultScriptExecutionTimeLimit,
-			NewCustomVirtualMachine: func() VirtualMachine {
+			NewCustomVirtualMachine: func() computer.VirtualMachine {
 				return &PanickingVM{}
 			},
 		},
@@ -418,7 +418,7 @@ func TestExecuteScript_LongScriptsAreLogged(t *testing.T) {
 			ProgramsCacheSize:        DefaultProgramsCacheSize,
 			ScriptLogThreshold:       1 * time.Millisecond,
 			ScriptExecutionTimeLimit: DefaultScriptExecutionTimeLimit,
-			NewCustomVirtualMachine: func() VirtualMachine {
+			NewCustomVirtualMachine: func() computer.VirtualMachine {
 				return &LongRunningVM{duration: 2 * time.Millisecond}
 			},
 		},
@@ -468,7 +468,7 @@ func TestExecuteScript_ShortScriptsAreNotLogged(t *testing.T) {
 			ProgramsCacheSize:        DefaultProgramsCacheSize,
 			ScriptLogThreshold:       1 * time.Second,
 			ScriptExecutionTimeLimit: DefaultScriptExecutionTimeLimit,
-			NewCustomVirtualMachine: func() VirtualMachine {
+			NewCustomVirtualMachine: func() computer.VirtualMachine {
 				return &LongRunningVM{duration: 0}
 			},
 		},
@@ -485,6 +485,10 @@ func TestExecuteScript_ShortScriptsAreNotLogged(t *testing.T) {
 type PanickingVM struct{}
 
 func (p *PanickingVM) Run(f fvm.Context, procedure fvm.Procedure, view state.View, p2 *programs.Programs) error {
+	return p.RunV2(f, procedure, view)
+}
+
+func (p *PanickingVM) RunV2(f fvm.Context, procedure fvm.Procedure, view state.View) error {
 	panic("panic, but expected with sentinel for test: Verunsicherung ")
 }
 
@@ -497,6 +501,10 @@ type LongRunningVM struct {
 }
 
 func (l *LongRunningVM) Run(f fvm.Context, procedure fvm.Procedure, view state.View, p2 *programs.Programs) error {
+	return l.RunV2(f, procedure, view)
+}
+
+func (l *LongRunningVM) RunV2(f fvm.Context, procedure fvm.Procedure, view state.View) error {
 	time.Sleep(l.duration)
 	// satisfy value marshaller
 	if scriptProcedure, is := procedure.(*fvm.ScriptProcedure); is {

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -10,7 +10,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/storage"
@@ -38,7 +37,6 @@ func (b *Bootstrapper) BootstrapLedger(
 	opts ...fvm.BootstrapProcedureOption,
 ) (flow.StateCommitment, error) {
 	view := delta.NewView(state.LedgerGetRegister(ledger, flow.StateCommitment(ledger.InitialState())))
-	programs := programs.NewEmptyPrograms()
 
 	vm := fvm.NewVM()
 
@@ -53,7 +51,7 @@ func (b *Bootstrapper) BootstrapLedger(
 		opts...,
 	)
 
-	err := vm.Run(ctx, bootstrap, view, programs)
+	err := vm.RunV2(ctx, bootstrap, view)
 	if err != nil {
 		return flow.DummyStateCommitment, err
 	}

--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -209,6 +209,7 @@ func CreateAccountsWithSimpleAddresses(
 		fvm.WithTransactionProcessors(
 			fvm.NewTransactionInvoker(),
 		),
+		fvm.WithBlockPrograms(programs),
 	)
 
 	var accounts []flow.Address
@@ -252,7 +253,7 @@ func CreateAccountsWithSimpleAddresses(
 			AddAuthorizer(serviceAddress)
 
 		tx := fvm.Transaction(txBody, uint32(i))
-		err := vm.Run(ctx, tx, view, programs)
+		err := vm.RunV2(ctx, tx, view)
 		if err != nil {
 			return nil, err
 		}
@@ -284,7 +285,6 @@ func CreateAccountsWithSimpleAddresses(
 
 func RootBootstrappedLedger(vm *fvm.VirtualMachine, ctx fvm.Context, additionalOptions ...fvm.BootstrapProcedureOption) state.View {
 	view := fvmUtils.NewSimpleView()
-	programs := programs.NewEmptyPrograms()
 
 	// set 0 clusters to pass n_collectors >= n_clusters check
 	epochConfig := epochs.DefaultEpochConfig()
@@ -302,13 +302,7 @@ func RootBootstrappedLedger(vm *fvm.VirtualMachine, ctx fvm.Context, additionalO
 		options...,
 	)
 
-	_ = vm.Run(
-		ctx,
-		bootstrap,
-		view,
-		programs,
-	)
-
+	_ = vm.RunV2(ctx, bootstrap, view)
 	return view
 }
 

--- a/engine/testutil/mock/nodes.go
+++ b/engine/testutil/mock/nodes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onflow/flow-go/engine/consensus/sealing"
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/engine/execution/computation"
+	"github.com/onflow/flow-go/engine/execution/computation/computer"
 	"github.com/onflow/flow-go/engine/execution/ingestion"
 	executionprovider "github.com/onflow/flow-go/engine/execution/provider"
 	"github.com/onflow/flow-go/engine/execution/state"
@@ -205,7 +206,7 @@ type ExecutionNode struct {
 	SyncEngine          *synchronization.Engine
 	Compactor           *complete.Compactor
 	BadgerDB            *badger.DB
-	VM                  computation.VirtualMachine
+	VM                  computer.VirtualMachine
 	ExecutionState      state.ExecutionState
 	Ledger              ledger.Ledger
 	LevelDbDir          string

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -39,7 +39,7 @@ func createAccount(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err := vm.Run(ctx, tx, view, programs)
+	err := vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 
@@ -90,7 +90,7 @@ func addAccountKey(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err = vm.Run(ctx, tx, view, programs)
+	err = vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 
@@ -119,7 +119,7 @@ func addAccountCreator(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err := vm.Run(ctx, tx, view, programs)
+	err := vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 }
@@ -147,7 +147,7 @@ func removeAccountCreator(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err := vm.Run(ctx, tx, view, programs)
+	err := vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 }
@@ -358,7 +358,7 @@ func TestCreateAccount(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -389,7 +389,7 @@ func TestCreateAccount(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -433,7 +433,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.Error(t, tx.Err)
@@ -450,7 +450,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -471,7 +471,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -491,7 +491,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				validTx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, validTx, view, programs)
+				err := vm.RunV2(ctx, validTx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, validTx.Err)
@@ -500,7 +500,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				invalidTx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, invalidTx, view, programs)
+				err = vm.RunV2(ctx, invalidTx, view)
 				require.NoError(t, err)
 
 				assert.Error(t, invalidTx.Err)
@@ -570,7 +570,7 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
@@ -612,7 +612,7 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
@@ -654,7 +654,7 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.Error(t, tx.Err)
@@ -707,7 +707,7 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
@@ -771,7 +771,7 @@ func TestAddAccountKey(t *testing.T) {
 
 						tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-						err = vm.Run(ctx, tx, view, programs)
+						err = vm.RunV2(ctx, tx, view)
 						require.NoError(t, err)
 
 						require.Error(t, tx.Err)
@@ -842,7 +842,7 @@ func TestRemoveAccountKey(t *testing.T) {
 
 						tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-						err = vm.Run(ctx, tx, view, programs)
+						err = vm.RunV2(ctx, tx, view)
 						require.NoError(t, err)
 
 						if test.expectError {
@@ -888,7 +888,7 @@ func TestRemoveAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
@@ -939,7 +939,7 @@ func TestRemoveAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
@@ -999,7 +999,7 @@ func TestRemoveAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
@@ -1049,7 +1049,7 @@ func TestGetAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(ctx, tx, view, programs)
+					err = vm.RunV2(ctx, tx, view)
 					require.NoError(t, err)
 					require.NoError(t, tx.Err)
 
@@ -1086,7 +1086,7 @@ func TestGetAccountKey(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1138,7 +1138,7 @@ func TestGetAccountKey(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1191,7 +1191,7 @@ func TestGetAccountKey(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1241,7 +1241,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1251,7 +1251,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, account.Hex())))
 
-				err = vm.Run(ctx, script, view, programs)
+				err = vm.RunV2(ctx, script, view)
 
 				assert.NoError(t, err)
 
@@ -1278,7 +1278,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, nonExistentAddress)))
 
-				err = vm.Run(ctx, script, view, programs)
+				err = vm.RunV2(ctx, script, view)
 
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
@@ -1308,7 +1308,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					return nil, nil
 				})
 
-				err := vm.Run(ctx, script, view, programs)
+				err := vm.RunV2(ctx, script, view)
 				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.KeyAccountStatus))
 			}),
 	)
@@ -1331,7 +1331,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1341,7 +1341,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, account.Hex())))
 
-				err = vm.Run(ctx, script, view, programs)
+				err = vm.RunV2(ctx, script, view)
 
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
@@ -1368,7 +1368,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, nonExistentAddress)))
 
-				err = vm.Run(ctx, script, view, programs)
+				err = vm.RunV2(ctx, script, view)
 
 				require.NoError(t, err)
 				require.Error(t, script.Err)
@@ -1395,7 +1395,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1405,7 +1405,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, account.Hex())))
 
-				err = vm.Run(ctx, script, view, programs)
+				err = vm.RunV2(ctx, script, view)
 
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
@@ -1437,7 +1437,7 @@ func TestGetStorageCapacity(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.Run(ctx, tx, view, programs)
+				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1447,7 +1447,7 @@ func TestGetStorageCapacity(t *testing.T) {
 					}
 				`, account)))
 
-				err = vm.Run(ctx, script, view, programs)
+				err = vm.RunV2(ctx, script, view)
 
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
@@ -1476,7 +1476,7 @@ func TestGetStorageCapacity(t *testing.T) {
 					}
 				`, nonExistentAddress)))
 
-				err = vm.Run(ctx, script, view, programs)
+				err = vm.RunV2(ctx, script, view)
 
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
@@ -1510,7 +1510,7 @@ func TestGetStorageCapacity(t *testing.T) {
 					return nil, nil
 				})
 
-				err := vm.Run(ctx, script, newview, programs)
+				err := vm.RunV2(ctx, script, newview)
 				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.KeyAccountStatus))
 			}),
 	)

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
@@ -44,6 +45,7 @@ type Context struct {
 	ScriptProcessors              []ScriptProcessor
 	Logger                        zerolog.Logger
 	ReusableCadenceRuntimePool    ReusableCadenceRuntimePool
+	BlockPrograms                 *programs.Programs
 }
 
 // NewContext initializes a new execution context with the provided options.
@@ -326,6 +328,15 @@ func WithTransactionFeesEnabled(enabled bool) Option {
 func WithReusableCadenceRuntimePool(pool ReusableCadenceRuntimePool) Option {
 	return func(ctx Context) Context {
 		ctx.ReusableCadenceRuntimePool = pool
+		return ctx
+	}
+}
+
+// WithBlockPrograms sets the programs cache storage to be used by the
+// transaction/script.
+func WithBlockPrograms(programs *programs.Programs) Option {
+	return func(ctx Context) Context {
+		ctx.BlockPrograms = programs
 		return ctx
 	}
 }

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -48,17 +48,38 @@ func NewVirtualMachine(rt runtime.Runtime) *VirtualMachine {
 	}
 }
 
+// DEPRECATED.  DO NOT USE.
+//
+// TODO(patrick): remove after emulator is updated
+//
 // Run runs a procedure against a ledger in the given context.
-func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, programs *programs.Programs) (err error) {
+func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, _ *programs.Programs) (err error) {
+	return vm.RunV2(ctx, proc, v)
+}
+
+// TODO(patrick): rename back to Run after emulator is fully updated (this
+// takes at least 3 sporks ...).
+//
+// Run runs a procedure against a ledger in the given context.
+func (vm *VirtualMachine) RunV2(
+	ctx Context,
+	proc Procedure,
+	v state.View,
+) error {
+	blockPrograms := ctx.BlockPrograms
+	if blockPrograms == nil {
+		blockPrograms = programs.NewEmptyPrograms()
+	}
+
 	meterParams := meter.DefaultParameters().
 		WithComputationLimit(uint(proc.ComputationLimit(ctx))).
 		WithMemoryLimit(proc.MemoryLimit(ctx))
 
-	meterParams, err = getEnvironmentMeterParameters(
+	meterParams, err := getEnvironmentMeterParameters(
 		vm,
 		ctx,
 		v,
-		programs,
+		blockPrograms,
 		meterParams,
 	)
 	if err != nil {
@@ -80,7 +101,7 @@ func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, program
 			WithMaxInteractionSizeAllowed(interactionLimit),
 	)
 
-	err = proc.Run(vm, ctx, stTxn, programs)
+	err = proc.Run(vm, ctx, stTxn, blockPrograms)
 	if err != nil {
 		return err
 	}

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -161,7 +161,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 		view := testutil.RootBootstrappedLedger(vm, ctx)
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, view, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, view)
 		require.NoError(t, err)
 
 		assert.Nil(t, tx.Err)
@@ -194,7 +194,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.Error(t, tx.Err)
@@ -218,7 +218,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		require.Len(t, tx.Logs, 2)
@@ -244,7 +244,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -290,7 +290,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -320,7 +320,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -353,7 +353,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -383,7 +383,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		var parsingCheckingError *runtime.ParsingCheckingError
@@ -409,7 +409,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.Error(t, tx.Err)
@@ -448,7 +448,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
 
@@ -481,7 +481,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -509,7 +509,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -522,7 +522,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -550,7 +550,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -563,7 +563,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
 
@@ -594,7 +594,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -610,7 +610,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -636,7 +636,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		authTx := fvm.Transaction(authTxBody, 0)
 
-		err = vm.Run(ctx, authTx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, authTx, ledger)
 		require.NoError(t, err)
 		assert.NoError(t, authTx.Err)
 
@@ -649,7 +649,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 
 		tx := fvm.Transaction(txBody, 0)
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -671,7 +671,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
 		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
@@ -690,7 +690,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		authTx := fvm.Transaction(authTxBody, 0)
 
-		err = vm.Run(ctx, authTx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, authTx, ledger)
 		require.NoError(t, err)
 		assert.NoError(t, authTx.Err)
 
@@ -702,7 +702,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.NoError(t, tx.Err)
 	})
@@ -793,7 +793,7 @@ func TestBlockContext_ExecuteTransaction_WithArguments(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, 0)
 
-			err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+			err = vm.RunV2(ctx, tx, ledger)
 			require.NoError(t, err)
 
 			tt.check(t, tx)
@@ -873,7 +873,7 @@ func TestBlockContext_ExecuteTransaction_GasLimit(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, 0)
 
-			err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+			err = vm.RunV2(ctx, tx, ledger)
 			require.NoError(t, err)
 
 			tt.check(t, tx)
@@ -936,7 +936,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.Equal(t, (&errors.StorageCapacityExceededError{}).Code(), tx.Err.Code())
@@ -989,7 +989,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				require.NoError(t, tx.Err)
@@ -1050,7 +1050,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.Equal(t, (&errors.LedgerInteractionLimitExceededError{}).Code(), tx.Err.Code())
@@ -1088,7 +1088,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 			}))
@@ -1125,7 +1125,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 				require.Error(t, tx.Err)
 				assert.Equal(t, (&errors.LedgerInteractionLimitExceededError{}).Code(), tx.Err.Code())
@@ -1162,7 +1162,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.Run(ctx, script, ledger, programs.NewEmptyPrograms())
+		err := vm.RunV2(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1180,7 +1180,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.Run(ctx, script, ledger, programs.NewEmptyPrograms())
+		err := vm.RunV2(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.Error(t, script.Err)
@@ -1199,7 +1199,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.Run(ctx, script, ledger, programs.NewEmptyPrograms())
+		err := vm.RunV2(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1254,7 +1254,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1274,7 +1274,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err = vm.Run(ctx, script, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1328,7 +1328,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(blockCtx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(blockCtx, tx, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1373,7 +1373,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.Run(blockCtx, script, ledger, programs.NewEmptyPrograms())
+		err := vm.RunV2(blockCtx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1419,7 +1419,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
 		ledger := testutil.RootBootstrappedLedger(vm, ctx)
 		require.NoError(t, err)
 
-		err = vm.Run(blockCtx, fvm.Transaction(tx, 0), ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(blockCtx, fvm.Transaction(tx, 0), ledger)
 		require.Error(t, err)
 	})
 
@@ -1432,7 +1432,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
         `)
 
 		ledger := testutil.RootBootstrappedLedger(vm, ctx)
-		err := vm.Run(blockCtx, fvm.Script(script), ledger, programs.NewEmptyPrograms())
+		err := vm.RunV2(blockCtx, fvm.Script(script), ledger)
 		require.Error(t, err)
 	})
 }
@@ -1476,7 +1476,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		// execute the transaction
 		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-		err = vm.Run(ctx, tx, ledger, programs)
+		err = vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1569,7 +1569,7 @@ func TestBlockContext_UnsafeRandom(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+		err = vm.RunV2(ctx, tx, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1603,7 +1603,7 @@ func TestBlockContext_ExecuteTransaction_CreateAccount_WithMonotonicAddresses(t 
 
 	tx := fvm.Transaction(txBody, 0)
 
-	err = vm.Run(ctx, tx, ledger, programs.NewEmptyPrograms())
+	err = vm.RunV2(ctx, tx, ledger)
 	assert.NoError(t, err)
 
 	assert.NoError(t, tx.Err)
@@ -1639,7 +1639,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			jsoncdc.MustEncode(cadence.NewAddress(address)),
 		)
 
-		err := vm.Run(ctx, script, view, programs.NewEmptyPrograms())
+		err := vm.RunV2(ctx, script, view)
 		require.NoError(t, err)
 		require.NoError(t, script.Err)
 		return script.Value.ToGoValue().(uint64)
@@ -1677,7 +1677,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			require.Equal(t, (&errors.StorageCapacityExceededError{}).Code(), tx.Err.Code())
@@ -1725,7 +1725,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			require.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
@@ -1766,7 +1766,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 				require.Equal(t, (&errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())
 				require.Equal(t, uint64(0), tx.Err.(*errors.InvalidProposalSeqNumberError).CurrentSeqNumber())
@@ -1803,7 +1803,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				require.IsType(t, &errors.CadenceRuntimeError{}, tx.Err)
@@ -1811,7 +1811,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				// send it again
 				tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
 				require.Equal(t, (&errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -54,7 +54,7 @@ func FuzzTransactionComputationLimit(f *testing.F) {
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			require.NotPanics(t, func() {
-				err = vm.Run(ctx, tx, view, programs)
+				err = vm.RunV2(ctx, tx, view)
 			}, "Transaction should never result in a panic.")
 			require.NoError(t, err, "Transaction should never result in an error.")
 
@@ -250,7 +250,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 
 		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-		err = vm.Run(ctx, tx, view, programs)
+		err = vm.RunV2(ctx, tx, view)
 
 		require.NoError(tb, err)
 		accountCreatedEvents := filterAccountCreatedEvents(tx.Events)
@@ -279,7 +279,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 
 		tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-		err = vm.Run(ctx, tx, view, programs)
+		err = vm.RunV2(ctx, tx, view)
 		if err != nil {
 			return err
 		}

--- a/fvm/fvm_signature_test.go
+++ b/fvm/fvm_signature_test.go
@@ -186,7 +186,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -203,7 +203,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -225,7 +225,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -246,7 +246,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						require.NoError(t, err)
 						require.Error(t, script.Err)
 					})
@@ -294,7 +294,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -314,7 +314,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -333,7 +333,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -440,7 +440,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						jsoncdc.MustEncode(pop),
 					)
 
-					err = vm.Run(ctx, script, view, programs)
+					err = vm.RunV2(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 					assert.Equal(t, cadence.NewBool(true), script.Value)
@@ -466,7 +466,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						jsoncdc.MustEncode(pop),
 					)
 
-					err = vm.Run(ctx, script, view, programs)
+					err = vm.RunV2(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 					assert.Equal(t, cadence.NewBool(false), script.Value)
@@ -492,7 +492,7 @@ func TestBLSMultiSignature(t *testing.T) {
 							jsoncdc.MustEncode(pop),
 						)
 
-						err = vm.Run(ctx, script, view, programs)
+						err = vm.RunV2(ctx, script, view)
 						assert.Error(t, err)
 					})
 				}
@@ -560,7 +560,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err = vm.Run(ctx, script, view, programs)
+					err = vm.RunV2(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 
@@ -595,7 +595,7 @@ func TestBLSMultiSignature(t *testing.T) {
 					// revert the change
 					sigs[numSigs/2] = tmp
 
-					err = vm.Run(ctx, script, view, programs)
+					err = vm.RunV2(ctx, script, view)
 					assert.NoError(t, err)
 					assert.Error(t, script.Err)
 					assert.Equal(t, nil, script.Value)
@@ -615,7 +615,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err = vm.Run(ctx, script, view, programs)
+					err = vm.RunV2(ctx, script, view)
 					assert.NoError(t, err)
 					assert.Error(t, script.Err)
 					assert.Equal(t, nil, script.Value)
@@ -686,7 +686,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err := vm.Run(ctx, script, view, programs)
+					err := vm.RunV2(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 					expectedPk, err := crypto.AggregateBLSPublicKeys(pks)
@@ -720,7 +720,7 @@ func TestBLSMultiSignature(t *testing.T) {
 							}),
 						)
 
-						err := vm.Run(ctx, script, view, programs)
+						err := vm.RunV2(ctx, script, view)
 						assert.Error(t, err)
 					})
 				}
@@ -739,7 +739,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err := vm.Run(ctx, script, view, programs)
+					err := vm.RunV2(ctx, script, view)
 					assert.NoError(t, err)
 					assert.Error(t, script.Err)
 					assert.Equal(t, nil, script.Value)
@@ -830,7 +830,7 @@ func TestBLSMultiSignature(t *testing.T) {
 					jsoncdc.MustEncode(cadence.String(tag)),
 				)
 
-				err := vm.Run(ctx, script, view, programs)
+				err := vm.RunV2(ctx, script, view)
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
 				assert.Equal(t, cadence.NewBool(true), script.Value)

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -87,7 +87,7 @@ func (vmt vmTest) run(
 
 		bootstrapOpts := append(baseBootstrapOpts, vmt.bootstrapOptions...)
 
-		err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view, programs)
+		err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
 		require.NoError(t, err)
 
 		f(t, vm, chain, ctx, view, programs)
@@ -119,7 +119,7 @@ func (vmt vmTest) bootstrapWith(
 
 	bootstrapOpts := append(baseBootstrapOpts, vmt.bootstrapOptions...)
 
-	err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view, programs)
+	err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
 	if err != nil {
 		return bootstrappedVmTest{}, err
 	}
@@ -183,7 +183,7 @@ func TestPrograms(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.Run(txCtx, tx, view, programs)
+					err = vm.RunV2(txCtx, tx, view)
 					require.NoError(t, err)
 
 					require.NoError(t, tx.Err)
@@ -207,7 +207,7 @@ func TestPrograms(t *testing.T) {
 					fvm.FungibleTokenAddress(chain).HexWithPrefix(),
 				)))
 
-				err := vm.Run(scriptCtx, script, view, programs)
+				err := vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
 			},
@@ -400,7 +400,7 @@ func TestHashing(t *testing.T) {
 				)
 			}
 
-			err := vm.Run(ctx, script, ledger, programs.NewEmptyPrograms())
+			err := vm.RunV2(ctx, script, ledger)
 
 			byteResult := make([]byte, 0)
 			if err == nil && script.Err == nil {
@@ -431,7 +431,7 @@ func TestHashing(t *testing.T) {
 				cadenceData,
 				jsoncdc.MustEncode(cadence.String("")),
 			)
-			err := vm.Run(ctx, script, ledger, programs.NewEmptyPrograms())
+			err := vm.RunV2(ctx, script, ledger)
 			require.NoError(t, err)
 			require.NoError(t, script.Err)
 
@@ -446,7 +446,7 @@ func TestHashing(t *testing.T) {
 			script = script.WithArguments(
 				cadenceData,
 			)
-			err = vm.Run(ctx, script, ledger, programs.NewEmptyPrograms())
+			err = vm.RunV2(ctx, script, ledger)
 			require.NoError(t, err)
 			require.NoError(t, script.Err)
 
@@ -487,7 +487,7 @@ func TestWithServiceAccount(t *testing.T) {
 	t.Run("With service account enabled", func(t *testing.T) {
 		tx := fvm.Transaction(txBody, 0)
 
-		err := vm.Run(ctxA, tx, view, programs.NewEmptyPrograms())
+		err := vm.RunV2(ctxA, tx, view)
 		require.NoError(t, err)
 
 		// transaction should fail on non-bootstrapped ledger
@@ -499,7 +499,7 @@ func TestWithServiceAccount(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err := vm.Run(ctxB, tx, view, programs.NewEmptyPrograms())
+		err := vm.RunV2(ctxB, tx, view)
 		require.NoError(t, err)
 
 		// transaction should succeed on non-bootstrapped ledger
@@ -565,7 +565,7 @@ func TestEventLimits(t *testing.T) {
 	programs := programs.NewEmptyPrograms()
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-	err := vm.Run(ctx, tx, ledger, programs)
+	err := vm.RunV2(ctx, tx, ledger)
 	require.NoError(t, err)
 
 	txBody = flow.NewTransactionBody().
@@ -582,7 +582,7 @@ func TestEventLimits(t *testing.T) {
 	t.Run("With limits", func(t *testing.T) {
 		txBody.Payer = unittest.RandomAddressFixture()
 		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-		err := vm.Run(ctx, tx, ledger, programs)
+		err := vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		// transaction should fail due to event size limit
@@ -592,7 +592,7 @@ func TestEventLimits(t *testing.T) {
 	t.Run("With service account as payer", func(t *testing.T) {
 		txBody.Payer = chain.ServiceAddress()
 		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-		err := vm.Run(ctx, tx, ledger, programs)
+		err := vm.RunV2(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		// transaction should not fail due to event size limit
@@ -629,7 +629,7 @@ func TestHappyPathTransactionSigning(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 		},
@@ -656,7 +656,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			jsoncdc.MustEncode(cadence.NewAddress(address)),
 		)
 
-		err := vm.Run(ctx, script, view, programs.NewEmptyPrograms())
+		err := vm.RunV2(ctx, script, view)
 		require.NoError(t, err)
 		require.NoError(t, script.Err)
 		return script.Value.ToGoValue().(uint64)
@@ -942,7 +942,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.NoError(t, tx.Err)
@@ -976,7 +976,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1007,7 +1007,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			balanceAfter := getBalance(vm, chain, ctx, view, address)
@@ -1085,7 +1085,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1134,7 +1134,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.Greater(t, tx.MemoryEstimate, uint64(20_000_000_000))
 
@@ -1170,7 +1170,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.Greater(t, tx.MemoryEstimate, uint64(20_000_000_000))
 
@@ -1236,7 +1236,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			// There are 100 breaks and each break uses 1_000_000 memory
 			require.Greater(t, tx.MemoryEstimate, uint64(100_000_000))
@@ -1273,7 +1273,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1308,7 +1308,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1342,7 +1342,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1383,7 +1383,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1405,7 +1405,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
 			require.ErrorContains(t, tx.Err, "computation exceeds limit (997)")
@@ -1472,7 +1472,7 @@ func TestStorageUsed(t *testing.T) {
 
 	script := fvm.Script(code)
 
-	err = vm.Run(ctx, script, simpleView, programs.NewEmptyPrograms())
+	err = vm.RunV2(ctx, script, simpleView)
 	require.NoError(t, err)
 
 	assert.Equal(t, cadence.NewUInt64(5), script.Value)
@@ -1580,7 +1580,7 @@ func TestEnforcingComputationLimit(t *testing.T) {
 			}
 			tx := fvm.Transaction(txBody, 0)
 
-			err := vm.Run(ctx, tx, simpleView, programs.NewEmptyPrograms())
+			err := vm.RunV2(ctx, tx, simpleView)
 			require.NoError(t, err)
 			require.Equal(t, test.expCompUsed, tx.ComputationUsed)
 			if test.ok {
@@ -1624,7 +1624,7 @@ func TestStorageCapacity(t *testing.T) {
 				SetProposalKey(service, 0, 0).
 				SetPayer(service)
 			tx := fvm.Transaction(transferTxBody, 0)
-			err := vm.Run(ctx, tx, view, programs)
+			err := vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1635,7 +1635,7 @@ func TestStorageCapacity(t *testing.T) {
 				SetProposalKey(service, 0, 0).
 				SetPayer(service)
 			tx = fvm.Transaction(transferTxBody, 0)
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1674,7 +1674,7 @@ func TestStorageCapacity(t *testing.T) {
 
 			tx = fvm.Transaction(txBody, 0)
 
-			err = vm.Run(ctx, tx, view, programs)
+			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1714,7 +1714,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.Run(scriptCtx, script, view, programs)
+				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
@@ -1759,7 +1759,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				_ = testutil.SignPayload(txBody, account, privateKey)
 				_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-				err = vm.Run(subCtx, tx, view, programs)
+				err = vm.RunV2(subCtx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1773,7 +1773,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.Run(subCtx, script, view, programs)
+				err = vm.RunV2(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
@@ -1818,7 +1818,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				_ = testutil.SignPayload(txBody, account, privateKey)
 				_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-				err = vm.Run(subCtx, tx, view, programs)
+				err = vm.RunV2(subCtx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1831,7 +1831,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.Run(subCtx, script, view, programs)
+				err = vm.RunV2(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
@@ -1879,7 +1879,7 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 					)),
 				)
 
-				err = vm.Run(scriptCtx, script, view, programs)
+				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
@@ -1915,7 +1915,7 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.Run(scriptCtx, script, view, programs)
+				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)

--- a/fvm/handler/programs_test.go
+++ b/fvm/handler/programs_test.go
@@ -135,7 +135,8 @@ func Test_Programs(t *testing.T) {
 	context := fvm.NewContext(
 		fvm.WithContractDeploymentRestricted(false),
 		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
-		fvm.WithCadenceLogging(true))
+		fvm.WithCadenceLogging(true),
+		fvm.WithBlockPrograms(programs))
 
 	var contractAView *delta.View = nil
 	var contractBView *delta.View = nil
@@ -150,7 +151,7 @@ func Test_Programs(t *testing.T) {
 		procContractA0 := fvm.Transaction(
 			contractDeployTx("A", contractA0Code, addressA),
 			programs.NextTxIndexForTestingOnly())
-		err = vm.Run(context, procContractA0, mainView, programs)
+		err = vm.RunV2(context, procContractA0, mainView)
 		require.NoError(t, err)
 
 		retrievedContractA, err = accounts.GetContract("A", addressA)
@@ -162,7 +163,7 @@ func Test_Programs(t *testing.T) {
 		procContractA := fvm.Transaction(
 			updateContractTx("A", contractACode, addressA),
 			programs.NextTxIndexForTestingOnly())
-		err = vm.Run(context, procContractA, mainView, programs)
+		err = vm.RunV2(context, procContractA, mainView)
 		require.NoError(t, err)
 		require.NoError(t, procContractA.Err)
 
@@ -179,7 +180,7 @@ func Test_Programs(t *testing.T) {
 		procContractA := fvm.Transaction(
 			contractDeployTx("A", contractACode, addressA),
 			programs.NextTxIndexForTestingOnly())
-		err := vm.Run(context, procContractA, mainView, programs)
+		err := vm.RunV2(context, procContractA, mainView)
 		require.NoError(t, err)
 
 		fmt.Println("---------- Real transaction here ------------")
@@ -198,7 +199,7 @@ func Test_Programs(t *testing.T) {
 			return mainView.Peek(owner, key)
 		})
 
-		err = vm.Run(context, procCallA, viewExecA, programs)
+		err = vm.RunV2(context, procCallA, viewExecA)
 		require.NoError(t, err)
 
 		// make sure tx was really run
@@ -236,7 +237,7 @@ func Test_Programs(t *testing.T) {
 			callTx("A", addressA),
 			programs.NextTxIndexForTestingOnly())
 
-		err = vm.Run(context, procCallA, viewExecA2, programs)
+		err = vm.RunV2(context, procCallA, viewExecA2)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallA.Logs, "\"hello from A\"")
@@ -256,7 +257,7 @@ func Test_Programs(t *testing.T) {
 		procContractB := fvm.Transaction(
 			contractDeployTx("B", contractBCode, addressB),
 			programs.NextTxIndexForTestingOnly())
-		err := vm.Run(context, procContractB, mainView, programs)
+		err := vm.RunV2(context, procContractB, mainView)
 		require.NoError(t, err)
 
 		_, _, hasA := programs.GetForTestingOnly(contractALocation)
@@ -279,7 +280,7 @@ func Test_Programs(t *testing.T) {
 
 		viewExecB = delta.NewView(mainView.Peek)
 
-		err = vm.Run(context, procCallB, viewExecB, programs)
+		err = vm.RunV2(context, procCallB, viewExecB)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallB.Logs, "\"hello from B but also hello from A\"")
@@ -337,7 +338,7 @@ func Test_Programs(t *testing.T) {
 			callTx("B", addressB),
 			programs.NextTxIndexForTestingOnly())
 
-		err = vm.Run(context, procCallB, viewExecB2, programs)
+		err = vm.RunV2(context, procCallB, viewExecB2)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallB.Logs, "\"hello from B but also hello from A\"")
@@ -364,7 +365,7 @@ func Test_Programs(t *testing.T) {
 			callTx("A", addressA),
 			programs.NextTxIndexForTestingOnly())
 
-		err = vm.Run(context, procCallA, viewExecA, programs)
+		err = vm.RunV2(context, procCallA, viewExecA)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallA.Logs, "\"hello from A\"")
@@ -383,7 +384,7 @@ func Test_Programs(t *testing.T) {
 		procContractC := fvm.Transaction(
 			contractDeployTx("C", contractCCode, addressC),
 			programs.NextTxIndexForTestingOnly())
-		err := vm.Run(context, procContractC, mainView, programs)
+		err := vm.RunV2(context, procContractC, mainView)
 		require.NoError(t, err)
 
 		_, _, hasA := programs.GetForTestingOnly(contractALocation)
@@ -403,7 +404,7 @@ func Test_Programs(t *testing.T) {
 
 		viewExecC := delta.NewView(mainView.Peek)
 
-		err = vm.Run(context, procCallC, viewExecC, programs)
+		err = vm.RunV2(context, procCallC, viewExecC)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallC.Logs, "\"hello from C, hello from B but also hello from A\"")

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -123,9 +123,10 @@ func TestAccountFreezing(t *testing.T) {
 			fvm.WithContractDeploymentRestricted(false),
 			fvm.WithCadenceLogging(true),
 			fvm.WithTransactionProcessors( // run with limited processor to test just core of freezing, but still inside FVM
-				fvm.NewTransactionInvoker()))
+				fvm.NewTransactionInvoker()),
+			fvm.WithBlockPrograms(programsStorage))
 
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -146,7 +147,7 @@ func TestAccountFreezing(t *testing.T) {
 		proc = fvm.Transaction(
 			&flow.TransactionBody{Script: code(address)},
 			programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -175,7 +176,7 @@ func TestAccountFreezing(t *testing.T) {
 		tx.AddAuthorizer(chain.ServiceAddress())
 
 		proc = fvm.Transaction(tx, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -190,7 +191,7 @@ func TestAccountFreezing(t *testing.T) {
 			&flow.TransactionBody{Script: code(address)},
 			programsStorage.NextTxIndexForTestingOnly())
 
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.Error(t, proc.Err)
 
@@ -256,14 +257,14 @@ func TestAccountFreezing(t *testing.T) {
 			fvm.WithTransactionProcessors( // run with limited processor to test just core of freezing, but still inside FVM
 				fvm.NewTransactionInvoker()))
 
-		err := vm.Run(context, procFrozen, st.ViewForTestingOnly(), programsStorage)
+		err := vm.RunV2(context, procFrozen, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, procFrozen.Err)
 
 		procNotFrozen := fvm.Transaction(
 			&flow.TransactionBody{Script: deployContract, Authorizers: []flow.Address{notFrozenAddress}, Payer: notFrozenAddress},
 			programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, procNotFrozen, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, procNotFrozen, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, procNotFrozen.Err)
 
@@ -286,7 +287,7 @@ func TestAccountFreezing(t *testing.T) {
 			&flow.TransactionBody{Script: code(frozenAddress), Payer: serviceAddress},
 			programsStorage.NextTxIndexForTestingOnly())
 
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -295,7 +296,7 @@ func TestAccountFreezing(t *testing.T) {
 		proc = fvm.Transaction(
 			&flow.TransactionBody{Script: code(notFrozenAddress)},
 			programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -315,7 +316,7 @@ func TestAccountFreezing(t *testing.T) {
 		tx.AddAuthorizer(chain.ServiceAddress())
 
 		proc = fvm.Transaction(tx, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -333,7 +334,7 @@ func TestAccountFreezing(t *testing.T) {
 			&flow.TransactionBody{Script: code(frozenAddress)},
 			programsStorage.NextTxIndexForTestingOnly())
 
-		err = vm.Run(context, proc, st.ViewForTestingOnly(), programsStorage)
+		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.Error(t, proc.Err)
 
@@ -408,7 +409,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 
 		tx := fvm.Transaction(txBody, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, tx, ledger, programsStorage)
+		err = vm.RunV2(context, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -439,7 +440,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 
 		tx = fvm.Transaction(txBody, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.Run(context, tx, ledger, programsStorage)
+		err = vm.RunV2(context, tx, ledger)
 		require.NoError(t, err)
 		require.Error(t, tx.Err)
 
@@ -516,7 +517,7 @@ func TestAccountFreezing(t *testing.T) {
 					Payer:       notFrozenAddress},
 				programsStorage.NextTxIndexForTestingOnly())
 			// tx run OK by nonfrozen account
-			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly(), programsStorage)
+			err = vm.RunV2(context, notFrozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
@@ -527,7 +528,7 @@ func TestAccountFreezing(t *testing.T) {
 					ProposalKey: flow.ProposalKey{Address: notFrozenAddress},
 					Payer:       notFrozenAddress},
 				programsStorage.NextTxIndexForTestingOnly())
-			err = vm.Run(context, frozenProc, st.ViewForTestingOnly(), programsStorage)
+			err = vm.RunV2(context, frozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 
@@ -549,7 +550,7 @@ func TestAccountFreezing(t *testing.T) {
 				programsStorage.NextTxIndexForTestingOnly())
 
 			// tx run OK by nonfrozen account
-			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly(), programsStorage)
+			err = vm.RunV2(context, notFrozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
@@ -561,7 +562,7 @@ func TestAccountFreezing(t *testing.T) {
 					Payer:       notFrozenAddress,
 				},
 				programsStorage.NextTxIndexForTestingOnly())
-			err = vm.Run(context, frozenProc, st.ViewForTestingOnly(), programsStorage)
+			err = vm.RunV2(context, frozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 
@@ -583,7 +584,7 @@ func TestAccountFreezing(t *testing.T) {
 				programsStorage.NextTxIndexForTestingOnly())
 
 			// tx run OK by nonfrozen account
-			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly(), programsStorage)
+			err = vm.RunV2(context, notFrozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
@@ -595,7 +596,7 @@ func TestAccountFreezing(t *testing.T) {
 					Payer:       frozenAddress,
 				},
 				programsStorage.NextTxIndexForTestingOnly())
-			err = vm.Run(context, frozenProc, st.ViewForTestingOnly(), programsStorage)
+			err = vm.RunV2(context, frozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -7,8 +7,6 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm/blueprints"
-	"github.com/onflow/flow-go/fvm/programs"
-	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/convert"
 	"github.com/onflow/flow-go/model/verification"
 
@@ -22,20 +20,16 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-type VirtualMachine interface {
-	Run(fvm.Context, fvm.Procedure, state.View, *programs.Programs) error
-}
-
 // ChunkVerifier is a verifier based on the current definitions of the flow network
 type ChunkVerifier struct {
-	vm             VirtualMachine
+	vm             computer.VirtualMachine
 	vmCtx          fvm.Context
 	systemChunkCtx fvm.Context
 	logger         zerolog.Logger
 }
 
 // NewChunkVerifier creates a chunk verifier containing a flow virtual machine
-func NewChunkVerifier(vm VirtualMachine, vmCtx fvm.Context, logger zerolog.Logger) *ChunkVerifier {
+func NewChunkVerifier(vm computer.VirtualMachine, vmCtx fvm.Context, logger zerolog.Logger) *ChunkVerifier {
 	return &ChunkVerifier{
 		vm:             vm,
 		vmCtx:          vmCtx,
@@ -118,10 +112,6 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 			nil
 	}
 
-	// transactions in chunk can reuse the same cache, but its unknown
-	// if there were changes between chunks, so we always start with a new one
-	programs := programs.NewEmptyPrograms()
-
 	// chunk view construction
 	// unknown register tracks access to parts of the partial trie which
 	// are not expanded and values are unknown.
@@ -167,7 +157,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(context fvm.Context, chunk
 	for i, tx := range transactions {
 		txView := chunkView.NewChild()
 
-		err := fcv.vm.Run(context, tx, txView, programs)
+		err := fcv.vm.RunV2(context, tx, txView)
 		if err != nil {
 			// this covers unexpected and very rare cases (e.g. system memory issues...),
 			// so we shouldn't be here even if transaction naturally fails (e.g. permission, runtime ... )

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -374,7 +374,10 @@ func GetBaselineVerifiableChunk(t *testing.T, script string, system bool) *verif
 type vmMock struct{}
 
 func (vm *vmMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, programs *programs.Programs) error {
+	return vm.RunV2(ctx, proc, led)
+}
 
+func (vm *vmMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
 	tx, ok := proc.(*fvm.TransactionProcedure)
 	if !ok {
 		return fmt.Errorf("invokable is not a transaction")
@@ -409,9 +412,17 @@ func (vm *vmMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, progr
 	return nil
 }
 
+func (vmMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View, _ *programs.Programs) (*flow.Account, error) {
+	panic("not expected")
+}
+
 type vmSystemOkMock struct{}
 
 func (vm *vmSystemOkMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, programs *programs.Programs) error {
+	return vm.RunV2(ctx, proc, led)
+}
+
+func (vm *vmSystemOkMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
 	tx, ok := proc.(*fvm.TransactionProcedure)
 	if !ok {
 		return fmt.Errorf("invokable is not a transaction")
@@ -428,9 +439,17 @@ func (vm *vmSystemOkMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.Vie
 	return nil
 }
 
+func (vmSystemOkMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View, _ *programs.Programs) (*flow.Account, error) {
+	panic("not expected")
+}
+
 type vmSystemBadMock struct{}
 
 func (vm *vmSystemBadMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, programs *programs.Programs) error {
+	return vm.RunV2(ctx, proc, led)
+}
+
+func (vm *vmSystemBadMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
 	tx, ok := proc.(*fvm.TransactionProcedure)
 	if !ok {
 		return fmt.Errorf("invokable is not a transaction")
@@ -439,4 +458,8 @@ func (vm *vmSystemBadMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.Vi
 	tx.ServiceEvents = []flow.Event{epochCommitEvent}
 
 	return nil
+}
+
+func (vmSystemBadMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View, _ *programs.Programs) (*flow.Account, error) {
+	panic("not expected")
 }

--- a/utils/debug/remoteDebugger.go
+++ b/utils/debug/remoteDebugger.go
@@ -5,7 +5,6 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -45,7 +44,7 @@ func (d *RemoteDebugger) RunTransaction(txBody *flow.TransactionBody) (txErr, pr
 	view := NewRemoteView(d.grpcAddress)
 	blockCtx := fvm.NewContextFromParent(d.ctx, fvm.WithBlockHeader(d.ctx.BlockHeader))
 	tx := fvm.Transaction(txBody, 0)
-	err := d.vm.Run(blockCtx, tx, view, programs.NewEmptyPrograms())
+	err := d.vm.RunV2(blockCtx, tx, view)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +64,7 @@ func (d *RemoteDebugger) RunTransactionAtBlockID(txBody *flow.TransactionBody, b
 		view.Cache = newFileRegisterCache(regCachePath)
 	}
 	tx := fvm.Transaction(txBody, 0)
-	err := d.vm.Run(blockCtx, tx, view, programs.NewEmptyPrograms())
+	err := d.vm.RunV2(blockCtx, tx, view)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +79,7 @@ func (d *RemoteDebugger) RunScript(code []byte, arguments [][]byte) (value caden
 	view := NewRemoteView(d.grpcAddress)
 	scriptCtx := fvm.NewContextFromParent(d.ctx, fvm.WithBlockHeader(d.ctx.BlockHeader))
 	script := fvm.Script(code).WithArguments(arguments...)
-	err := d.vm.Run(scriptCtx, script, view, programs.NewEmptyPrograms())
+	err := d.vm.RunV2(scriptCtx, script, view)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -91,7 +90,7 @@ func (d *RemoteDebugger) RunScriptAtBlockID(code []byte, arguments [][]byte, blo
 	view := NewRemoteView(d.grpcAddress, WithBlockID(blockID))
 	scriptCtx := fvm.NewContextFromParent(d.ctx, fvm.WithBlockHeader(d.ctx.BlockHeader))
 	script := fvm.Script(code).WithArguments(arguments...)
-	err := d.vm.Run(scriptCtx, script, view, programs.NewEmptyPrograms())
+	err := d.vm.RunV2(scriptCtx, script, view)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Prep work for fully integrating programs.BlockPrograms

Note: Because we're in a circular dependency hell (flow-go depends on emulator, which in turn depends on an older version of flow-go), we cannot simply change the Run method's signature.  Instead, we need to create a new RunV2 method to deal with backwards compatibility.  (Full migration to RunV2 / cleanup will requires at least 3 sporks ...)