### PR TITLE
Switch ProgramsHandler to use TransactionPrograms interface

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -58,7 +58,7 @@ func newCommonEnv(
 	ctx Context,
 	vm *VirtualMachine,
 	stateTransaction *state.StateHolder,
-	programs *programs.Programs,
+	programs handler.TransactionPrograms,
 	tracer *environment.Tracer,
 	meter environment.Meter,
 ) commonEnv {

--- a/fvm/handler/programs.go
+++ b/fvm/handler/programs.go
@@ -6,9 +6,15 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 )
+
+// TODO(patrick): remove and switch to *programs.TransactionPrograms once
+// emulator is updated.
+type TransactionPrograms interface {
+	Get(loc common.Location) (*interpreter.Program, *state.State, bool)
+	Set(loc common.Location, prog *interpreter.Program, state *state.State)
+}
 
 // ProgramsHandler manages operations using Programs storage.
 // It's separation of concern for hostEnv
@@ -18,7 +24,7 @@ import (
 // views must be merged in order to make sure they are recorded
 type ProgramsHandler struct {
 	masterState *state.StateHolder
-	Programs    *programs.Programs
+	Programs    TransactionPrograms
 
 	// NOTE: non-address programs are not reusable across transactions, hence
 	// they are kept out of the shared program cache.
@@ -26,7 +32,7 @@ type ProgramsHandler struct {
 }
 
 // NewProgramsHandler construts a new ProgramHandler
-func NewProgramsHandler(programs *programs.Programs, stateHolder *state.StateHolder) *ProgramsHandler {
+func NewProgramsHandler(programs TransactionPrograms, stateHolder *state.StateHolder) *ProgramsHandler {
 	return &ProgramsHandler{
 		masterState:        stateHolder,
 		Programs:           programs,

--- a/fvm/programs/programs.go
+++ b/fvm/programs/programs.go
@@ -57,20 +57,20 @@ func (p *Programs) NextTxIndexForTestingOnly() uint32 {
 	return p.block.NextTxIndexForTestingOnly()
 }
 
-func (p *Programs) GetForTestingOnly(location common.AddressLocation) (*interpreter.Program, *state.State, bool) {
+func (p *Programs) GetForTestingOnly(location common.Location) (*interpreter.Program, *state.State, bool) {
 	return p.Get(location)
 }
 
 // Get returns stored program, state which contains changes which correspond to loading this program,
 // and boolean indicating if the value was found
-func (p *Programs) Get(location common.AddressLocation) (*interpreter.Program, *state.State, bool) {
+func (p *Programs) Get(location common.Location) (*interpreter.Program, *state.State, bool) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
 	return p.currentTxn.Get(location)
 }
 
-func (p *Programs) Set(location common.AddressLocation, program *interpreter.Program, state *state.State) {
+func (p *Programs) Set(location common.Location, program *interpreter.Program, state *state.State) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -8,7 +8,6 @@ import (
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/handler"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 )
 
@@ -25,7 +24,7 @@ func NewScriptEnvironment(
 	fvmContext Context,
 	vm *VirtualMachine,
 	sth *state.StateHolder,
-	programs *programs.Programs,
+	programs handler.TransactionPrograms,
 ) *ScriptEnv {
 
 	tracer := environment.NewTracer(fvmContext.Tracer, nil, fvmContext.ExtensiveTracing)

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -12,7 +12,6 @@ import (
 	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/handler"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
@@ -35,7 +34,7 @@ func NewTransactionEnvironment(
 	ctx Context,
 	vm *VirtualMachine,
 	sth *state.StateHolder,
-	programs *programs.Programs,
+	programs handler.TransactionPrograms,
 	tx *flow.TransactionBody,
 	txIndex uint32,
 	traceSpan otelTrace.Span,


### PR DESCRIPTION
This enables us to migrate to *programs.TransactionPrograms while the emulator is still stuck with using *programs.Programs.