### PR TITLE
Bootstrap to single address

### DIFF
--- a/cmd/bootstrap/cmd/partner_infos.go
+++ b/cmd/bootstrap/cmd/partner_infos.go
@@ -131,10 +131,7 @@ func getFlowClient() *client.Client {
 
 // executeGetProposedNodesInfosScript executes the get node info for each ID in the proposed table
 func executeGetProposedNodesInfosScript(ctx context.Context, client *client.Client) (cadence.Value, error) {
-	script, err := common.GetNodeInfoForProposedNodesScript(flagNetworkEnv)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get cadence script: %w", err)
-	}
+	script := common.GetNodeInfoForProposedNodesScript(flagNetworkEnv)
 
 	infos, err := client.ExecuteScriptAtLatestBlock(ctx, script, []cadence.Value{})
 	if err != nil {

--- a/cmd/bootstrap/utils/key_generation.go
+++ b/cmd/bootstrap/utils/key_generation.go
@@ -175,7 +175,7 @@ func WriteMachineAccountFiles(chainID flow.ChainID, nodeInfos []bootstrap.NodeIn
 	//
 	// for the machine account key, we keep track of the address index to map
 	// the Flow address of the machine account to the key.
-	addressIndex := uint64(4)
+	addressIndex := uint64(1)
 	for _, nodeInfo := range nodeInfos {
 
 		// retrieve private representation of the node

--- a/cmd/bootstrap/utils/key_generation_test.go
+++ b/cmd/bootstrap/utils/key_generation_test.go
@@ -61,7 +61,7 @@ func TestWriteMachineAccountFiles(t *testing.T) {
 	expected := make(map[string]bootstrap.NodeMachineAccountInfo)
 	for i, node := range nodes {
 		// See comments in WriteMachineAccountFiles for why addresses take this form
-		addr, err := chain.AddressAtIndex(uint64(6 + i*2))
+		addr, err := chain.AddressAtIndex(uint64(3 + i*2))
 		require.NoError(t, err)
 		private, err := node.Private()
 		require.NoError(t, err)

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -549,10 +549,7 @@ func createQCContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.
 
 	var qcContractClient module.QCContractClient
 
-	contracts, err := systemcontracts.SystemContractsForChain(node.RootChainID)
-	if err != nil {
-		return nil, err
-	}
+	contracts := systemcontracts.SystemContractsForChain(node.RootChainID)
 	qcContractAddress := contracts.ClusterQC.Address.Hex()
 
 	// construct signer from private key

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -829,10 +829,7 @@ func loadBeaconPrivateKey(dir string, myID flow.Identifier) (*encodable.RandomBe
 func createDKGContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClient *client.Client, anID flow.Identifier) (module.DKGContractClient, error) {
 	var dkgClient module.DKGContractClient
 
-	contracts, err := systemcontracts.SystemContractsForChain(node.RootChainID)
-	if err != nil {
-		return nil, err
-	}
+	contracts := systemcontracts.SystemContractsForChain(node.RootChainID)
 	dkgContractAddress := contracts.DKG.Address.Hex()
 
 	// construct signer from private key

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -900,10 +900,7 @@ func (exeNode *ExecutionNode) LoadGrpcServer(
 // getContractEpochCounter Gets the epoch counters from the FlowEpoch smart contract from the view provided.
 func getContractEpochCounter(vm computer.VirtualMachine, vmCtx fvm.Context, view *delta.View) (uint64, error) {
 	// Get the address of the FlowEpoch smart contract
-	sc, err := systemcontracts.SystemContractsForChain(vmCtx.Chain.ChainID())
-	if err != nil {
-		return 0, fmt.Errorf("could not get system contracts: %w", err)
-	}
+	sc := systemcontracts.SystemContractsForChain(vmCtx.Chain.ChainID())
 	address := sc.Epoch.Address
 
 	// Generate the script to get the epoch counter from the FlowEpoch smart contract
@@ -913,7 +910,7 @@ func getContractEpochCounter(vm computer.VirtualMachine, vmCtx fvm.Context, view
 	script := fvm.Script(scriptCode)
 
 	// execute the script
-	err = vm.RunV2(vmCtx, script, view)
+	err := vm.RunV2(vmCtx, script, view)
 	if err != nil {
 		return 0, fmt.Errorf("could not read epoch counter, internal error while executing script: %w", err)
 	}

--- a/cmd/util/cmd/common/transactions.go
+++ b/cmd/util/cmd/common/transactions.go
@@ -25,12 +25,9 @@ const (
 
 // GetNodeInfoForProposedNodesScript returns a script that will return an array of FlowIDTableStaking.NodeInfo for each
 // node in the proposed table.
-func GetNodeInfoForProposedNodesScript(network string) ([]byte, error) {
-	contracts, err := systemcontracts.SystemContractsForChain(flow.ChainID(fmt.Sprintf("flow-%s", network)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get system contracts for network (%s): %w", network, err)
-	}
+func GetNodeInfoForProposedNodesScript(network string) []byte {
+	contracts := systemcontracts.SystemContractsForChain(flow.ChainID(fmt.Sprintf("flow-%s", network)))
 
 	//NOTE: The FlowIDTableStaking contract is deployed to the same account as the Epoch contract
-	return []byte(fmt.Sprintf(getInfoForProposedNodesScript, contracts.Epoch.Address)), nil
+	return []byte(fmt.Sprintf(getInfoForProposedNodesScript, contracts.Epoch.Address))
 }

--- a/cmd/util/cmd/epochs/cmd/deploy.go
+++ b/cmd/util/cmd/epochs/cmd/deploy.go
@@ -254,10 +254,7 @@ func getDeployEpochTransactionText(snapshot *inmem.Snapshot) []byte {
 
 	// root chain id and system contractsRegister
 	chainID := head.ChainID
-	systemContracts, err := systemcontracts.SystemContractsForChain(chainID)
-	if err != nil {
-		log.Fatal().Err(err).Str("chain_id", chainID.String()).Msgf("could not get system contracts for chainID")
-	}
+	systemContracts := systemcontracts.SystemContractsForChain(chainID)
 
 	// epoch contract name and get code for contract
 	epochContractCode := contracts.FlowEpoch(

--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -25,7 +25,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 
 	// bootstrap ledger
 	payloads := []ledger.Payload{}
-	chain := flow.Testnet.Chain()
+	chain := flow.Emulator.Chain()
 	view := migrations.NewView(payloads)
 
 	vm := fvm.NewVM()
@@ -123,12 +123,9 @@ func TestFungibleTokenTracker(t *testing.T) {
 	require.NoError(t, err)
 
 	// wrappedToken
-	require.True(t, strings.Contains(string(data), `{"path":"storage/wrappedToken/vault","address":"8c5303eaa26202d6","balance":105,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
+	require.True(t, strings.Contains(string(data), `{"path":"storage/wrappedToken/vault","address":"f8d6e0586b0a20c7","balance":105,"type_id":"A.f8d6e0586b0a20c7.FlowToken.Vault"}`))
 	// flowTokenVaults
-	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"8c5303eaa26202d6","balance":99999999999699895,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
-	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"9a0766d93b6608b7","balance":100000,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
-	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"7e60df042a9c0868","balance":100000,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
-	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"912d5440f7e3769e","balance":100000,"type_id":"A.7e60df042a9c0868.FlowToken.Vault"}`))
+	require.True(t, strings.Contains(string(data), `{"path":"storage/flowTokenVault","address":"f8d6e0586b0a20c7","balance":99999999999999895,"type_id":"A.f8d6e0586b0a20c7.FlowToken.Vault"}`))
 
 	// do not remove this line, see https://github.com/onflow/flow-go/pull/2237
 	t.Log("success")

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -101,7 +101,7 @@ func (suite *Suite) SetupTest() {
 		On("NodeID").
 		Return(accessIdentity.NodeID)
 
-	suite.chainID = flow.Testnet
+	suite.chainID = flow.Emulator
 	suite.metrics = metrics.NewNoopCollector()
 }
 

--- a/engine/access/rest/request/transaction_test.go
+++ b/engine/access/rest/request/transaction_test.go
@@ -126,7 +126,7 @@ func TestTransaction_ValidParse(t *testing.T) {
 	input := transactionToReader(tx)
 
 	var transaction Transaction
-	err := transaction.Parse(input, flow.Testnet.Chain())
+	err := transaction.Parse(input, flow.Emulator.Chain())
 
 	assert.NoError(t, err)
 	assert.Equal(t, tx["payer"], transaction.Flow().Payer.String())

--- a/engine/access/rest/test_helpers.go
+++ b/engine/access/rest/test_helpers.go
@@ -28,7 +28,7 @@ const (
 func executeRequest(req *http.Request, backend *mock.API) (*httptest.ResponseRecorder, error) {
 	var b bytes.Buffer
 	logger := zerolog.New(&b)
-	router, err := newRouter(backend, logger, flow.Testnet.Chain())
+	router, err := newRouter(backend, logger, flow.Emulator.Chain())
 	if err != nil {
 		return nil, err
 	}

--- a/engine/access/rest/transactions_test.go
+++ b/engine/access/rest/transactions_test.go
@@ -97,19 +97,19 @@ func TestGetTransactions(t *testing.T) {
                "arguments": [],
 			   "reference_block_id":"%s",
 			   "gas_limit":"10",
-			   "payer":"8c5303eaa26202d6",
+			   "payer":"f8d6e0586b0a20c7",
 			   "proposal_key":{
-				  "address":"8c5303eaa26202d6",
+				  "address":"f8d6e0586b0a20c7",
 				  "key_index":"1",
 				  "sequence_number":"0"
 			   },
 			   "authorizers":[
-				  "8c5303eaa26202d6"
+				  "f8d6e0586b0a20c7"
 			   ],
                "payload_signatures": [],
 			   "envelope_signatures":[
 				  {
-					 "address":"8c5303eaa26202d6",
+					 "address":"f8d6e0586b0a20c7",
 					 "key_index":"1",
 					 "signature":"%s"
 				  }
@@ -148,19 +148,19 @@ func TestGetTransactions(t *testing.T) {
                "arguments": [],
 			   "reference_block_id":"%s",
 			   "gas_limit":"10",
-			   "payer":"8c5303eaa26202d6",
+			   "payer":"f8d6e0586b0a20c7",
 			   "proposal_key":{
-				  "address":"8c5303eaa26202d6",
+				  "address":"f8d6e0586b0a20c7",
 				  "key_index":"1",
 				  "sequence_number":"0"
 			   },
 			   "authorizers":[
-				  "8c5303eaa26202d6"
+				  "f8d6e0586b0a20c7"
 			   ],
                "payload_signatures": [],
 			   "envelope_signatures":[
 				  {
-					 "address":"8c5303eaa26202d6",
+					 "address":"f8d6e0586b0a20c7",
 					 "key_index":"1",
 					 "signature":"%s"
 				  }
@@ -340,25 +340,25 @@ func TestCreateTransaction(t *testing.T) {
 			   "arguments": [],
 			   "reference_block_id":"%s",
 			   "gas_limit":"10",
-			   "payer":"8c5303eaa26202d6",
+			   "payer":"f8d6e0586b0a20c7",
 			   "proposal_key":{
-				  "address":"8c5303eaa26202d6",
+				  "address":"f8d6e0586b0a20c7",
 				  "key_index":"1",
 				  "sequence_number":"0"
 			   },
 			   "authorizers":[
-				  "8c5303eaa26202d6"
+				  "f8d6e0586b0a20c7"
 			   ],
                "payload_signatures":[
 				  {
-					 "address":"8c5303eaa26202d6",
+					 "address":"f8d6e0586b0a20c7",
 					 "key_index":"1",
 					 "signature":"%s"
 				  }
 			   ],
 			   "envelope_signatures":[
 				  {
-					 "address":"8c5303eaa26202d6",
+					 "address":"f8d6e0586b0a20c7",
 					 "key_index":"1",
 					 "signature":"%s"
 				  }

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -74,7 +74,7 @@ func (suite *Suite) SetupTest() {
 	suite.results = new(storagemock.ExecutionResults)
 	suite.colClient = new(access.AccessAPIClient)
 	suite.execClient = new(access.ExecutionAPIClient)
-	suite.chainID = flow.Testnet
+	suite.chainID = flow.Emulator
 	suite.historicalAccessClient = new(access.AccessAPIClient)
 	suite.connectionFactory = new(backendmock.ConnectionFactory)
 }

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -219,10 +219,7 @@ func (b *backendTransactions) GetTransactionsByBlockID(
 		transactions = append(transactions, collection.Transactions...)
 	}
 
-	systemTx, err := blueprints.SystemChunkTransaction(b.chainID.Chain())
-	if err != nil {
-		return nil, fmt.Errorf("could not get system chunk transaction: %w", err)
-	}
+	systemTx := blueprints.SystemChunkTransaction(b.chainID.Chain())
 
 	transactions = append(transactions, systemTx)
 
@@ -380,10 +377,7 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 			return nil, status.Errorf(codes.Internal, "number of transaction results returned by execution node is more than the number of transactions in the block")
 		}
 
-		systemTx, err := blueprints.SystemChunkTransaction(b.chainID.Chain())
-		if err != nil {
-			return nil, fmt.Errorf("could not get system chunk transaction: %w", err)
-		}
+		systemTx := blueprints.SystemChunkTransaction(b.chainID.Chain())
 		systemTxResult := resp.TransactionResults[len(resp.TransactionResults)-1]
 		systemTxStatus, err := b.deriveTransactionStatus(systemTx, true, block)
 		if err != nil {

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -124,7 +124,7 @@ func (suite *Suite) SetupTest() {
 	suite.epochQuery = mocks.NewEpochQuery(suite.T(), 1, epoch)
 
 	suite.conf = DefaultConfig()
-	chain := flow.Testnet.Chain()
+	chain := flow.Emulator.Chain()
 	suite.engine, err = New(log, net, suite.state, metrics, metrics, metrics, suite.me, chain, suite.pools, suite.conf)
 	suite.Require().NoError(err)
 }

--- a/engine/collection/rpc/engine_test.go
+++ b/engine/collection/rpc/engine_test.go
@@ -20,7 +20,7 @@ func TestSubmitTransaction(t *testing.T) {
 	backend := new(rpcmock.Backend)
 
 	h := handler{
-		chainID: flow.Testnet,
+		chainID: flow.Emulator,
 		backend: backend,
 	}
 

--- a/engine/common/rpc/convert/convert_test.go
+++ b/engine/common/rpc/convert/convert_test.go
@@ -17,7 +17,7 @@ func TestConvertTransaction(t *testing.T) {
 	tx := unittest.TransactionBodyFixture()
 
 	msg := convert.TransactionToMessage(tx)
-	converted, err := convert.MessageToTransaction(msg, flow.Testnet.Chain())
+	converted, err := convert.MessageToTransaction(msg, flow.Emulator.Chain())
 	assert.Nil(t, err)
 
 	assert.Equal(t, tx, converted)

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -292,12 +292,9 @@ func (e *blockComputer) executeSystemCollection(
 	colSpan := e.tracer.StartSpanFromParent(blockSpan, trace.EXEComputeSystemCollection)
 	defer colSpan.End()
 
-	tx, err := blueprints.SystemChunkTransaction(e.vmCtx.Chain)
-	if err != nil {
-		return nil, fmt.Errorf("could not get system chunk transaction: %w", err)
-	}
+	tx := blueprints.SystemChunkTransaction(e.vmCtx.Chain)
 
-	err = e.executeTransaction(tx, colSpan, collectionView, systemChunkCtx, collectionIndex, txIndex, res, true)
+	err := e.executeTransaction(tx, colSpan, collectionView, systemChunkCtx, collectionIndex, txIndex, res, true)
 
 	if err != nil {
 		return nil, err

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -366,8 +366,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			},
 		}
 
-		serviceEvents, err := systemcontracts.ServiceEventsForChain(execCtx.Chain.ChainID())
-		require.NoError(t, err)
+		serviceEvents := systemcontracts.ServiceEventsForChain(execCtx.Chain.ChainID())
 
 		serviceEventA := cadence.Event{
 			EventType: &cadence.EventType{

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -161,7 +161,7 @@ func Test_ExecutionMatchesVerification(t *testing.T) {
 		accountPrivKey, createAccountTx := testutil.CreateAccountCreationTransaction(t, chain)
 
 		// this should return the address of newly created account
-		accountAddress, err := chain.AddressAtIndex(5)
+		accountAddress, err := chain.AddressAtIndex(2)
 		require.NoError(t, err)
 
 		err = testutil.SignTransactionAsServiceAccount(createAccountTx, 0, chain)
@@ -196,7 +196,7 @@ func Test_ExecutionMatchesVerification(t *testing.T) {
 	t.Run("with failed transaction fee deduction", func(t *testing.T) {
 		accountPrivKey, createAccountTx := testutil.CreateAccountCreationTransaction(t, chain)
 		// this should return the address of newly created account
-		accountAddress, err := chain.AddressAtIndex(5)
+		accountAddress, err := chain.AddressAtIndex(2)
 		require.NoError(t, err)
 
 		err = testutil.SignTransactionAsServiceAccount(createAccountTx, 0, chain)
@@ -549,7 +549,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			privateKey, createAccountTx := testutil.CreateAccountCreationTransaction(t, chain)
 
 			// this should return the address of newly created account
-			address, err := chain.AddressAtIndex(5)
+			address, err := chain.AddressAtIndex(2)
 			require.NoError(t, err)
 
 			err = testutil.SignTransactionAsServiceAccount(createAccountTx, 0, chain)

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -212,7 +212,10 @@ func TestExecuteScript(t *testing.T) {
 
 	logger := zerolog.Nop()
 
-	execCtx := fvm.NewContext(fvm.WithLogger(logger))
+	execCtx := fvm.NewContext(
+		fvm.WithLogger(logger),
+		fvm.WithChain(flow.Emulator.Chain()),
+	)
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("57c6944485f220b5be606121b86dd7cf105f102c7d2888d93f774c02f388a82d,")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("2863229f2324bdaa840ac2467b61966e193a6b2f21739b3d5b8bcfbeacc7c778")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -1243,6 +1243,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				err := vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
+				require.NoError(t, tx.Err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
 					pub fun main(): UFix64 {
@@ -1345,7 +1346,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
-				assert.Equal(t, cadence.UFix64(9999_3120), script.Value)
+				assert.Equal(t, cadence.UFix64(9999_3130), script.Value)
 			}),
 	)
 

--- a/fvm/blueprints/system.go
+++ b/fvm/blueprints/system.go
@@ -2,7 +2,6 @@ package blueprints
 
 import (
 	_ "embed"
-	"fmt"
 
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
 
@@ -19,12 +18,9 @@ var systemChunkTransactionTemplate string
 
 // SystemChunkTransaction creates and returns the transaction corresponding to the system chunk
 // for the given chain.
-func SystemChunkTransaction(chain flow.Chain) (*flow.TransactionBody, error) {
+func SystemChunkTransaction(chain flow.Chain) *flow.TransactionBody {
 
-	contracts, err := systemcontracts.SystemContractsForChain(chain.ChainID())
-	if err != nil {
-		return nil, fmt.Errorf("could not get system contracts for chain: %w", err)
-	}
+	contracts := systemcontracts.SystemContractsForChain(chain.ChainID())
 
 	tx := flow.NewTransactionBody().
 		SetScript([]byte(templates.ReplaceAddresses(systemChunkTransactionTemplate,
@@ -35,5 +31,5 @@ func SystemChunkTransaction(chain flow.Chain) (*flow.TransactionBody, error) {
 		AddAuthorizer(contracts.Epoch.Address).
 		SetGasLimit(SystemChunkTransactionGasLimit)
 
-	return tx, nil
+	return tx
 }

--- a/fvm/environment/event_emitter.go
+++ b/fvm/environment/event_emitter.go
@@ -205,10 +205,7 @@ func (collection *EventCollection) TotalByteSize() uint64 {
 func IsServiceEvent(event cadence.Event, chain flow.ChainID) (bool, error) {
 
 	// retrieve the service event information for this chain
-	events, err := systemcontracts.ServiceEventsForChain(chain)
-	if err != nil {
-		return false, fmt.Errorf("unknown system contracts for chain (%s): %w", chain.String(), err)
-	}
+	events := systemcontracts.ServiceEventsForChain(chain)
 
 	eventType := flow.EventType(event.EventType.ID())
 	for _, serviceEvent := range events.All() {

--- a/fvm/environment/event_emitter_test.go
+++ b/fvm/environment/event_emitter_test.go
@@ -17,8 +17,7 @@ import (
 func Test_IsServiceEvent(t *testing.T) {
 
 	chain := flow.Emulator
-	events, err := systemcontracts.ServiceEventsForChain(chain)
-	require.NoError(t, err)
+	events := systemcontracts.ServiceEventsForChain(chain)
 
 	t.Run("correct", func(t *testing.T) {
 		for _, event := range events.All() {

--- a/fvm/environment/system_contracts.go
+++ b/fvm/environment/system_contracts.go
@@ -84,8 +84,8 @@ func (sys *SystemContracts) Invoke(
 }
 
 func FlowFeesAddress(chain flow.Chain) flow.Address {
-	address, _ := chain.AddressAtIndex(FlowFeesAccountIndex)
-	return address
+	sc := systemcontracts.SystemContractsForChain(chain.ChainID())
+	return sc.Fees.Address
 }
 
 func ServiceAddress(chain flow.Chain) flow.Address {

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -21,7 +21,8 @@ const (
 	FailureCodeStateMergeFailure  FailureCode = 2003
 	FailureCodeBlockFinderFailure FailureCode = 2004
 	// Deprecated: No longer used.
-	FailureCodeHasherFailure FailureCode = 2005
+	FailureCodeHasherFailure            FailureCode = 2005
+	FailureCannotGetCoreContractAddress FailureCode = 2006
 	// Deprecated: No longer used.
 	FailureCodeMetaTransactionFailure FailureCode = 2100
 )

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -139,7 +139,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 
 	t.Parallel()
 
-	chain, vm := createChainAndVm(flow.Testnet)
+	chain, vm := createChainAndVm(flow.Emulator)
 
 	ctx := fvm.NewContext(
 		fvm.WithChain(chain),
@@ -1495,8 +1495,8 @@ func TestBlockContext_GetAccount(t *testing.T) {
 	}
 
 	addressGen := chain.NewAddressGenerator()
-	// skip the addresses of 4 reserved accounts
-	for i := 0; i < 4; i++ {
+	// skip the addresses of 1 reserved account
+	for i := 0; i < 1; i++ {
 		_, err := addressGen.NextAddress()
 		require.NoError(t, err)
 	}
@@ -1617,7 +1617,7 @@ func TestBlockContext_ExecuteTransaction_CreateAccount_WithMonotonicAddresses(t 
 	require.NoError(t, err)
 	address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
-	assert.Equal(t, flow.HexToAddress("05"), address)
+	assert.Equal(t, flow.HexToAddress("02"), address)
 }
 
 func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {

--- a/fvm/systemcontracts/system_contracts_test.go
+++ b/fvm/systemcontracts/system_contracts_test.go
@@ -13,45 +13,51 @@ import (
 // TestSystemContract_Address tests that we can retrieve a canonical address
 // for all accepted chains and contracts.
 func TestSystemContracts(t *testing.T) {
-	chains := []flow.ChainID{flow.Mainnet, flow.Testnet, flow.Stagingnet, flow.Benchnet, flow.Localnet, flow.Emulator}
+	chains := []flow.ChainID{
+		flow.Mainnet, flow.Testnet, flow.Stagingnet,
+		flow.Benchnet, flow.Localnet, flow.Emulator,
+		flow.BftTestnet, flow.MonotonicEmulator}
 
 	for _, chain := range chains {
-		_, err := SystemContractsForChain(chain)
-		require.NoError(t, err)
+		_ = SystemContractsForChain(chain)
 		checkSystemContracts(t, chain)
 	}
 }
 
-// TestSystemContract_InvalidChainID tests that we get an error if querying by an
-// invalid chain ID.
+// TestSystemContract_InvalidChainID tests that we panic when trying to get system contracts for an unknown chain
 func TestSystemContract_InvalidChainID(t *testing.T) {
 	invalidChain := flow.ChainID("invalid-chain")
 
-	_, err := SystemContractsForChain(invalidChain)
-	assert.Error(t, err)
+	require.Panics(t, func() {
+		_ = SystemContractsForChain(invalidChain)
+	})
 }
 
 // TestServiceEvents tests that we can retrieve service events for all accepted
 // chains and contracts.
 func TestServiceEvents(t *testing.T) {
-	chains := []flow.ChainID{flow.Mainnet, flow.Testnet, flow.Stagingnet, flow.Benchnet, flow.Localnet, flow.Emulator}
+	chains := []flow.ChainID{
+		flow.Mainnet, flow.Testnet, flow.Stagingnet,
+		flow.Benchnet, flow.Localnet, flow.Emulator,
+		flow.BftTestnet, flow.MonotonicEmulator}
 
 	for _, chain := range chains {
-		_, err := ServiceEventsForChain(chain)
+		_ = ServiceEventsForChain(chain)
 		checkServiceEvents(t, chain)
-		require.NoError(t, err)
 	}
 }
 
 // TestServiceEventLookup_Consistency sanity checks consistency of the lookup
 // method, in case an update to ServiceEvents forgets to update the lookup.
 func TestServiceEventAll_Consistency(t *testing.T) {
-	chains := []flow.ChainID{flow.Mainnet, flow.Testnet, flow.Stagingnet, flow.Benchnet, flow.Localnet, flow.Emulator}
+	chains := []flow.ChainID{
+		flow.Mainnet, flow.Testnet, flow.Stagingnet,
+		flow.Benchnet, flow.Localnet, flow.Emulator,
+		flow.BftTestnet, flow.MonotonicEmulator}
 
 	fields := reflect.TypeOf(ServiceEvents{}).NumField()
 	for _, chain := range chains {
-		events, err := ServiceEventsForChain(chain)
-		require.NoError(t, err)
+		events := ServiceEventsForChain(chain)
 
 		// ensure all events are returns
 		all := events.All()
@@ -59,18 +65,17 @@ func TestServiceEventAll_Consistency(t *testing.T) {
 	}
 }
 
-// TestServiceEvents_InvalidChainID tests that we get an error if querying by an
-// invalid chain ID.
+// TestServiceEvents_InvalidChainID tests that we panic when trying to get system contracts for an unknown chain
 func TestServiceEvents_InvalidChainID(t *testing.T) {
 	invalidChain := flow.ChainID("invalid-chain")
 
-	_, err := ServiceEventsForChain(invalidChain)
-	assert.Error(t, err)
+	require.Panics(t, func() {
+		_ = ServiceEventsForChain(invalidChain)
+	})
 }
 
 func checkSystemContracts(t *testing.T, chainID flow.ChainID) {
-	contracts, err := SystemContractsForChain(chainID)
-	require.NoError(t, err)
+	contracts := SystemContractsForChain(chainID)
 
 	addresses, ok := contractAddressesByChainID[chainID]
 	require.True(t, ok, "missing chain %s", chainID.String())
@@ -79,16 +84,21 @@ func checkSystemContracts(t *testing.T, chainID flow.ChainID) {
 	assert.NotEqual(t, flow.EmptyAddress, addresses[ContractNameEpoch])
 	assert.NotEqual(t, flow.EmptyAddress, addresses[ContractNameClusterQC])
 	assert.NotEqual(t, flow.EmptyAddress, addresses[ContractNameDKG])
+	assert.NotEqual(t, flow.EmptyAddress, addresses[ContractNameFlowFees])
+	assert.NotEqual(t, flow.EmptyAddress, addresses[ContractNameFungibleToken])
+	assert.NotEqual(t, flow.EmptyAddress, addresses[ContractNameFlowToken])
 
 	// entries must match internal mapping
 	assert.Equal(t, addresses[ContractNameEpoch], contracts.Epoch.Address)
 	assert.Equal(t, addresses[ContractNameClusterQC], contracts.ClusterQC.Address)
 	assert.Equal(t, addresses[ContractNameDKG], contracts.DKG.Address)
+	assert.Equal(t, addresses[ContractNameFlowFees], contracts.Fees.Address)
+	assert.Equal(t, addresses[ContractNameFungibleToken], contracts.FungibleToken.Address)
+	assert.Equal(t, addresses[ContractNameFlowToken], contracts.FlowToken.Address)
 }
 
 func checkServiceEvents(t *testing.T, chainID flow.ChainID) {
-	events, err := ServiceEventsForChain(chainID)
-	require.NoError(t, err)
+	events := ServiceEventsForChain(chainID)
 
 	addresses, ok := contractAddressesByChainID[chainID]
 	require.True(t, ok, "missing chain %w", chainID.String())

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -167,7 +167,7 @@ func (s *Suite) StakeNode(ctx context.Context, env templates.Environment, role f
 	nodeID := flow.MakeID(stakingKey.PublicKey().Encode())
 	fullAccountKey := sdk.NewAccountKey().
 		SetPublicKey(stakingAccountKey.PublicKey()).
-		SetHashAlgo(sdkcrypto.SHA2_256).
+		SetHashAlgo(sdkcrypto.SHA3_256).
 		SetWeight(sdk.AccountKeyWeightThreshold)
 
 	// create staking account
@@ -211,6 +211,8 @@ func (s *Suite) StakeNode(ctx context.Context, env templates.Environment, role f
 		fmt.Sprintf("%f", stakeAmount),
 		machineAccountPubKey,
 	)
+
+	s.log.Info().Str("machineAccountAddr", machineAccountAddr.Hex()).Msgf("machineAccountAddr")
 
 	require.NoError(s.T(), err)
 	require.NoError(s.T(), result.Error)
@@ -328,7 +330,7 @@ func (s *Suite) createStakingCollection(ctx context.Context, env templates.Envir
 	latestBlockID, err := s.client.GetLatestBlockID(ctx)
 	require.NoError(s.T(), err)
 
-	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA2_256)
+	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA3_256)
 	require.NoError(s.T(), err)
 
 	createStakingCollectionTx, err := utils.MakeCreateStakingCollectionTx(
@@ -368,7 +370,7 @@ func (s *Suite) SubmitStakingCollectionRegisterNodeTx(
 	latestBlockID, err := s.client.GetLatestBlockID(ctx)
 	require.NoError(s.T(), err)
 
-	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA2_256)
+	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA3_256)
 	require.NoError(s.T(), err)
 
 	registerNodeTx, err := utils.MakeStakingCollectionRegisterNodeTx(
@@ -404,7 +406,7 @@ func (s *Suite) SubmitStakingCollectionRegisterNodeTx(
 				break
 			}
 		}
-
+		s.log.Info().Str("address", machineAccountAddr.Hex()).Msgf("created machine account")
 		require.NotZerof(s.T(), machineAccountAddr, "failed to create the machine account: %s", machineAccountAddr)
 		return result, machineAccountAddr, nil
 	}
@@ -423,7 +425,7 @@ func (s *Suite) SubmitStakingCollectionCloseStakeTx(
 	latestBlockID, err := s.client.GetLatestBlockID(ctx)
 	require.NoError(s.T(), err)
 
-	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA2_256)
+	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA3_256)
 	require.NoError(s.T(), err)
 
 	closeStakeTx, err := utils.MakeStakingCollectionCloseStakeTx(
@@ -571,7 +573,7 @@ func (s *Suite) newTestContainerOnNetwork(role flow.Role, info *StakedNodeOperat
 	err := testContainerConfig.WriteKeyFiles(s.net.BootstrapDir, info.MachineAccountAddress, encodable.MachineAccountPrivKey{PrivateKey: info.MachineAccountKey}, role)
 	require.NoError(s.T(), err)
 
-	//add our container to the network
+	// add our container to the network
 	err = s.net.AddNode(s.T(), s.net.BootstrapDir, testContainerConfig)
 	require.NoError(s.T(), err, "failed to add container to network")
 
@@ -657,7 +659,7 @@ func (s *Suite) assertLatestFinalizedBlockHeightHigher(ctx context.Context, snap
 func (s *Suite) submitSmokeTestTransaction(ctx context.Context) {
 	fullAccountKey := sdk.NewAccountKey().
 		SetPublicKey(unittest.PrivateKeyFixture(crypto.ECDSAP256, crypto.KeyGenSeedMinLenECDSAP256).PublicKey()).
-		SetHashAlgo(sdkcrypto.SHA2_256).
+		SetHashAlgo(sdkcrypto.SHA3_256).
 		SetWeight(sdk.AccountKeyWeightThreshold)
 
 	// createAccount will submit a create account transaction and wait for it to be sealed

--- a/integration/utils/transactions.go
+++ b/integration/utils/transactions.go
@@ -16,8 +16,8 @@ import (
 func LocalnetEnv() templates.Environment {
 	return templates.Environment{
 		IDTableAddress:           "f8d6e0586b0a20c7",
-		FungibleTokenAddress:     "ee82856bf20e2aa6",
-		FlowTokenAddress:         "0ae53cb6e3f42a79",
+		FungibleTokenAddress:     "f8d6e0586b0a20c7",
+		FlowTokenAddress:         "f8d6e0586b0a20c7",
 		LockedTokensAddress:      "f8d6e0586b0a20c7",
 		StakingProxyAddress:      "f8d6e0586b0a20c7",
 		DkgAddress:               "f8d6e0586b0a20c7",
@@ -44,7 +44,7 @@ func MakeCreateStakingCollectionTx(
 		SetPayer(payerAddress).
 		AddAuthorizer(stakingAccount.Address)
 
-	//signing the payload as used AddAuthorizer
+	// signing the payload as used AddAuthorizer
 	err := tx.SignPayload(stakingAccount.Address, stakingAccountKeyID, stakingSigner)
 	if err != nil {
 		return nil, fmt.Errorf("could not sign payload: %w", err)

--- a/model/convert/fixtures/fixture.go
+++ b/model/convert/fixtures/fixture.go
@@ -13,10 +13,7 @@ import (
 // EpochSetupFixtureByChainID returns an EpochSetup service event as a Cadence event
 // representation and as a protocol model representation.
 func EpochSetupFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochSetup) {
-	events, err := systemcontracts.ServiceEventsForChain(chain)
-	if err != nil {
-		panic(err)
-	}
+	events := systemcontracts.ServiceEventsForChain(chain)
 
 	event := unittest.EventFixture(events.EpochSetup.EventType(), 1, 1, unittest.IdentifierFixture(), 0)
 	event.Payload = []byte(epochSetupFixtureJSON)
@@ -112,10 +109,7 @@ func EpochSetupFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochSetu
 // representation and as a protocol model representation.
 func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
 
-	events, err := systemcontracts.ServiceEventsForChain(chain)
-	if err != nil {
-		panic(err)
-	}
+	events := systemcontracts.ServiceEventsForChain(chain)
 
 	event := unittest.EventFixture(events.EpochCommit.EventType(), 1, 1, unittest.IdentifierFixture(), 0)
 	event.Payload = []byte(epochCommitFixtureJSON)

--- a/model/convert/fixtures_test.go
+++ b/model/convert/fixtures_test.go
@@ -13,10 +13,7 @@ import (
 // EpochSetupFixture returns an EpochSetup service event as a Cadence event
 // representation and as a protocol model representation.
 func EpochSetupFixture(chain flow.ChainID) (flow.Event, *flow.EpochSetup) {
-	events, err := systemcontracts.ServiceEventsForChain(chain)
-	if err != nil {
-		panic(err)
-	}
+	events := systemcontracts.ServiceEventsForChain(chain)
 
 	event := unittest.EventFixture(events.EpochSetup.EventType(), 1, 1, unittest.IdentifierFixture(), 0)
 	event.Payload = []byte(epochSetupFixtureJSON)
@@ -112,10 +109,7 @@ func EpochSetupFixture(chain flow.ChainID) (flow.Event, *flow.EpochSetup) {
 // representation and as a protocol model representation.
 func EpochCommitFixture(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
 
-	events, err := systemcontracts.ServiceEventsForChain(chain)
-	if err != nil {
-		panic(err)
-	}
+	events := systemcontracts.ServiceEventsForChain(chain)
 
 	event := unittest.EventFixture(events.EpochCommit.EventType(), 1, 1, unittest.IdentifierFixture(), 0)
 	event.Payload = []byte(epochCommitFixtureJSON)

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -19,10 +19,7 @@ import (
 // state. This acts as the conversion from the Cadence type to the flow-go type.
 func ServiceEvent(chainID flow.ChainID, event flow.Event) (*flow.ServiceEvent, error) {
 
-	events, err := systemcontracts.ServiceEventsForChain(chainID)
-	if err != nil {
-		return nil, fmt.Errorf("could not get service event info: %w", err)
-	}
+	events := systemcontracts.ServiceEventsForChain(chainID)
 
 	// depending on type of service event construct Go type
 	switch event.Type {

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -68,10 +68,7 @@ func (fcv *ChunkVerifier) SystemChunkVerify(vc *verification.VerifiableChunkData
 	}
 
 	// transaction body of system chunk
-	txBody, err := blueprints.SystemChunkTransaction(fcv.vmCtx.Chain)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not get system chunk transaction: %w", err)
-	}
+	txBody := blueprints.SystemChunkTransaction(fcv.vmCtx.Chain)
 
 	tx := fvm.Transaction(txBody, vc.TransactionOffset+uint32(0))
 	transactions := []*fvm.TransactionProcedure{tx}

--- a/storage/badger/events_test.go
+++ b/storage/badger/events_test.go
@@ -60,8 +60,7 @@ func TestEventStoreRetrieve(t *testing.T) {
 		require.Len(t, actual, 1)
 		require.Contains(t, actual, evt2_1)
 
-		events, err := systemcontracts.ServiceEventsForChain(flow.Emulator)
-		require.NoError(t, err)
+		events := systemcontracts.ServiceEventsForChain(flow.Emulator)
 
 		actual, err = store.ByBlockIDEventType(blockID, events.EpochSetup.EventType())
 		require.NoError(t, err)

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -24,7 +24,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "58934da9e4e8d15dae050a07a840f57d569a0c51c8060e41db66b48bfe67d559"
+const GenesisStateCommitmentHex = "d8d07fb8316ed96bab0f2990d94dbc53c32d1731ae9fae3e2649a46cd6fcd43b"
 
 var GenesisStateCommitment flow.StateCommitment
 

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -44,13 +44,13 @@ const (
 )
 
 func AddressFixture() flow.Address {
-	return flow.Testnet.Chain().ServiceAddress()
+	return flow.Emulator.Chain().ServiceAddress()
 }
 
 func RandomAddressFixture() flow.Address {
 	// we use a 32-bit index - since the linear address generator uses 45 bits,
 	// this won't error
-	addr, err := flow.Testnet.Chain().AddressAtIndex(uint64(rand.Uint32()))
+	addr, err := flow.Emulator.Chain().AddressAtIndex(uint64(rand.Uint32()))
 	if err != nil {
 		panic(err)
 	}
@@ -67,7 +67,7 @@ func RandomSDKAddressFixture() sdk.Address {
 func InvalidAddressFixture() flow.Address {
 	addr := AddressFixture()
 	addr[0] ^= 1 // alter one bit to obtain an invalid address
-	if flow.Testnet.Chain().IsValid(addr) {
+	if flow.Emulator.Chain().IsValid(addr) {
 		panic("invalid address fixture generated valid address")
 	}
 	return addr


### PR DESCRIPTION
This changes bootstrapping to bootstrap all core contracts to one address (the service account address)

The benefit is that all contracts are on one account which makes it easier for all transient chain users to manage stuff. Transient chains being: Benchnet, Emulator, (Playground), ...

the drawback is that the bootstrapped account structure is not the same as on mainnet or testnet or canary or Sandboxnet. But that was already the case for the epoch part of bootstrapping.  