### PR TITLE
Refactor AccountKeyUpdater

### DIFF
--- a/fvm/env.go
+++ b/fvm/env.go
@@ -47,14 +47,14 @@ type commonEnv struct {
 	*environment.SystemContracts
 
 	handler.ContractUpdater
+	handler.AccountKeyUpdater
 
 	// TODO(patrick): rm
 	ctx Context
 
-	sth         *state.StateHolder
-	programs    *handler.ProgramsHandler
-	accounts    environment.Accounts
-	accountKeys *handler.AccountKeyHandler
+	sth      *state.StateHolder
+	programs *handler.ProgramsHandler
+	accounts environment.Accounts
 
 	// TODO(patrick): rm once fully refactored
 	fullEnv environment.Environment

--- a/fvm/handler/accountKey.go
+++ b/fvm/handler/accountKey.go
@@ -12,39 +12,55 @@ import (
 	"github.com/onflow/flow-go/fvm/crypto"
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/trace"
 )
 
-// AccountKeyHandler handles all interaction
-// with account keys such as get/set/revoke
-type AccountKeyHandler struct {
-	accounts environment.Accounts
-}
-
-// NewAccountPublicKey construct an account public key given a runtime public key.
+// NewAccountPublicKey construct an account public key given a runtime
+// public key.
 func NewAccountPublicKey(publicKey *runtime.PublicKey,
 	hashAlgo sema.HashAlgorithm,
 	keyIndex int,
 	weight int,
-) (*flow.AccountPublicKey, error) {
+) (
+	*flow.AccountPublicKey,
+	error,
+) {
 
 	var err error
 	signAlgorithm := crypto.RuntimeToCryptoSigningAlgorithm(publicKey.SignAlgo)
-	if signAlgorithm != fgcrypto.ECDSAP256 && signAlgorithm != fgcrypto.ECDSASecp256k1 {
-		err = errors.NewValueErrorf(fmt.Sprintf("%d", publicKey.SignAlgo), "signature algorithm type not supported")
-		return nil, fmt.Errorf("adding account key failed: %w", err)
+	if signAlgorithm != fgcrypto.ECDSAP256 &&
+		signAlgorithm != fgcrypto.ECDSASecp256k1 {
+
+		return nil, fmt.Errorf(
+			"adding account key failed: %w",
+			errors.NewValueErrorf(
+				fmt.Sprintf("%d", publicKey.SignAlgo),
+				"signature algorithm type not supported"))
 	}
 
 	hashAlgorithm := crypto.RuntimeToCryptoHashingAlgorithm(hashAlgo)
-	if hashAlgorithm != fghash.SHA2_256 && hashAlgorithm != fghash.SHA3_256 {
-		err = errors.NewValueErrorf(fmt.Sprintf("%d", hashAlgo), "hashing algorithm type not supported")
-		return nil, fmt.Errorf("adding account key failed: %w", err)
+	if hashAlgorithm != fghash.SHA2_256 &&
+		hashAlgorithm != fghash.SHA3_256 {
+
+		return nil, fmt.Errorf(
+			"adding account key failed: %w",
+			errors.NewValueErrorf(
+				fmt.Sprintf("%d", hashAlgo),
+				"hashing algorithm type not supported"))
 	}
 
-	decodedPublicKey, err := fgcrypto.DecodePublicKey(signAlgorithm, publicKey.PublicKey)
+	decodedPublicKey, err := fgcrypto.DecodePublicKey(
+		signAlgorithm,
+		publicKey.PublicKey)
 	if err != nil {
-		err = errors.NewValueErrorf(hex.EncodeToString(publicKey.PublicKey), "cannot decode public key: %w", err)
-		return nil, fmt.Errorf("adding account key failed: %w", err)
+		return nil, fmt.Errorf(
+			"adding account key failed: %w",
+			errors.NewValueErrorf(
+				hex.EncodeToString(publicKey.PublicKey),
+				"cannot decode public key: %w",
+				err))
 	}
 
 	return &flow.AccountPublicKey{
@@ -58,9 +74,131 @@ func NewAccountPublicKey(publicKey *runtime.PublicKey,
 	}, nil
 }
 
-func NewAccountKeyHandler(accounts environment.Accounts) *AccountKeyHandler {
-	return &AccountKeyHandler{
+// AccountKeyUpdater handles all account keys modification.
+//
+// Note that scripts cannot modify account keys, but must expose the API in
+// compliance with the runtime environment interface.
+type AccountKeyUpdater interface {
+	// AddEncodedAccountKey adds an encoded public key to an existing account.
+	//
+	// This function returns an error if the specified account does not exist or
+	// if the key insertion fails.
+	//
+	// Note that the script variant will return OperationNotSupportedError.
+	AddEncodedAccountKey(address runtime.Address, publicKey []byte) error
+
+	// RevokeEncodedAccountKey revokes a public key by index from an existing
+	// account.
+	//
+	// This function returns an error if the specified account does not exist,
+	// the provided key is invalid, or if key revoking fails.
+	//
+	// Note that the script variant will return OperationNotSupportedError.
+	RevokeEncodedAccountKey(
+		address runtime.Address,
+		index int,
+	) (
+		[]byte,
+		error,
+	)
+
+	// AddAccountKey adds a public key to an existing account.
+	//
+	// This function returns an error if the specified account does not exist or
+	// if the key insertion fails.
+	//
+	// Note that the script variant will return OperationNotSupportedError.
+	AddAccountKey(
+		address runtime.Address,
+		publicKey *runtime.PublicKey,
+		hashAlgo runtime.HashAlgorithm,
+		weight int,
+	) (
+		*runtime.AccountKey,
+		error,
+	)
+
+	// RevokeAccountKey revokes a public key by index from an existing account,
+	// and returns the revoked key.
+	//
+	// This function returns a nil key with no errors, if a key doesn't exist
+	// at the given index.  An error is returned if the specified account does
+	// not exist, the provided index is not valid, or if the key revoking
+	// fails.
+	//
+	// Note that the script variant will return OperationNotSupportedError.
+	RevokeAccountKey(
+		address runtime.Address,
+		keyIndex int,
+	) (
+		*runtime.AccountKey,
+		error,
+	)
+}
+
+type NoAccountKeyUpdater struct{}
+
+func (NoAccountKeyUpdater) AddEncodedAccountKey(
+	address runtime.Address,
+	publicKey []byte,
+) error {
+	return errors.NewOperationNotSupportedError("AddEncodedAccountKey")
+}
+
+func (NoAccountKeyUpdater) RevokeEncodedAccountKey(
+	address runtime.Address,
+	index int,
+) (
+	[]byte,
+	error,
+) {
+	return nil, errors.NewOperationNotSupportedError("RevokeEncodedAccountKey")
+}
+
+func (NoAccountKeyUpdater) AddAccountKey(
+	address runtime.Address,
+	publicKey *runtime.PublicKey,
+	hashAlgo runtime.HashAlgorithm,
+	weight int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
+	return nil, errors.NewOperationNotSupportedError("AddAccountKey")
+}
+
+func (NoAccountKeyUpdater) RevokeAccountKey(
+	address runtime.Address,
+	keyIndex int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
+	return nil, errors.NewOperationNotSupportedError("RevokeAccountKey")
+}
+
+type accountKeyUpdater struct {
+	tracer *environment.Tracer
+	meter  environment.Meter
+
+	accounts environment.Accounts
+	stTxn    *state.StateHolder
+	env      environment.Environment
+}
+
+func NewAccountKeyUpdater(
+	tracer *environment.Tracer,
+	meter environment.Meter,
+	accounts environment.Accounts,
+	stTxn *state.StateHolder,
+	env environment.Environment,
+) *accountKeyUpdater {
+	return &accountKeyUpdater{
+		tracer:   tracer,
+		meter:    meter,
 		accounts: accounts,
+		stTxn:    stTxn,
+		env:      env,
 	}
 }
 
@@ -68,7 +206,8 @@ func NewAccountKeyHandler(accounts environment.Accounts) *AccountKeyHandler {
 //
 // This function returns an error if the specified account does not exist or
 // if the key insertion fails.
-func (h *AccountKeyHandler) AddAccountKey(address runtime.Address,
+func (updater *accountKeyUpdater) addAccountKey(
+	address runtime.Address,
 	publicKey *runtime.PublicKey,
 	hashAlgo runtime.HashAlgorithm,
 	weight int,
@@ -78,26 +217,31 @@ func (h *AccountKeyHandler) AddAccountKey(address runtime.Address,
 ) {
 	accountAddress := flow.Address(address)
 
-	ok, err := h.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(accountAddress)
 	if err != nil {
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
 	if !ok {
-		issue := errors.NewAccountNotFoundError(accountAddress)
-		return nil, fmt.Errorf("adding account key failed: %w", issue)
+		return nil, fmt.Errorf(
+			"adding account key failed: %w",
+			errors.NewAccountNotFoundError(accountAddress))
 	}
 
-	keyIndex, err := h.accounts.GetPublicKeyCount(accountAddress)
+	keyIndex, err := updater.accounts.GetPublicKeyCount(accountAddress)
 	if err != nil {
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
 
-	accountPublicKey, err := NewAccountPublicKey(publicKey, hashAlgo, int(keyIndex), weight)
+	accountPublicKey, err := NewAccountPublicKey(
+		publicKey,
+		hashAlgo,
+		int(keyIndex),
+		weight)
 	if err != nil {
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
 
-	err = h.accounts.AppendPublicKey(accountAddress, *accountPublicKey)
+	err = updater.accounts.AppendPublicKey(accountAddress, *accountPublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
@@ -114,21 +258,30 @@ func (h *AccountKeyHandler) AddAccountKey(address runtime.Address,
 // RevokeAccountKey revokes a public key by index from an existing account,
 // and returns the revoked key.
 //
-// This function returns a nil key with no errors, if a key doesn't exist at the given index.
-// An error is returned if the specified account does not exist, the provided index is not valid,
-// or if the key revoking fails.
-// TODO (ramtin) do we have to return runtime.AccountKey for this method or can be separated into another method
-func (h *AccountKeyHandler) RevokeAccountKey(address runtime.Address, keyIndex int) (*runtime.AccountKey, error) {
+// This function returns a nil key with no errors, if a key doesn't exist at
+// the given index. An error is returned if the specified account does not
+// exist, the provided index is not valid, or if the key revoking fails.
+//
+// TODO (ramtin) do we have to return runtime.AccountKey for this method or
+// can be separated into another method
+func (updater *accountKeyUpdater) revokeAccountKey(
+	address runtime.Address,
+	keyIndex int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
 	accountAddress := flow.Address(address)
 
-	ok, err := h.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(accountAddress)
 	if err != nil {
 		return nil, fmt.Errorf("revoking account key failed: %w", err)
 	}
 
 	if !ok {
-		issue := errors.NewAccountNotFoundError(accountAddress)
-		return nil, fmt.Errorf("revoking account key failed: %w", issue)
+		return nil, fmt.Errorf(
+			"revoking account key failed: %w",
+			errors.NewAccountNotFoundError(accountAddress))
 	}
 
 	// Don't return an error for invalid key indices
@@ -137,11 +290,14 @@ func (h *AccountKeyHandler) RevokeAccountKey(address runtime.Address, keyIndex i
 	}
 
 	var publicKey flow.AccountPublicKey
-	publicKey, err = h.accounts.GetPublicKey(accountAddress, uint64(keyIndex))
+	publicKey, err = updater.accounts.GetPublicKey(
+		accountAddress,
+		uint64(keyIndex))
 	if err != nil {
-		// If a key is not found at a given index, then return a nil key with no errors.
-		// This is to be inline with the Cadence runtime. Otherwise Cadence runtime cannot
-		// distinguish between a 'key not found error' vs other internal errors.
+		// If a key is not found at a given index, then return a nil key with
+		// no errors.  This is to be inline with the Cadence runtime. Otherwise
+		// Cadence runtime cannot distinguish between a 'key not found error'
+		// vs other internal errors.
 		if errors.IsAccountAccountPublicKeyNotFoundError(err) {
 			return nil, nil
 		}
@@ -151,7 +307,10 @@ func (h *AccountKeyHandler) RevokeAccountKey(address runtime.Address, keyIndex i
 	// mark this key as revoked
 	publicKey.Revoked = true
 
-	_, err = h.accounts.SetPublicKey(accountAddress, uint64(keyIndex), publicKey)
+	_, err = updater.accounts.SetPublicKey(
+		accountAddress,
+		uint64(keyIndex),
+		publicKey)
 	if err != nil {
 		return nil, fmt.Errorf("revoking account key failed: %w", err)
 	}
@@ -159,14 +318,20 @@ func (h *AccountKeyHandler) RevokeAccountKey(address runtime.Address, keyIndex i
 	// Prepare account key to return
 	signAlgo := crypto.CryptoToRuntimeSigningAlgorithm(publicKey.SignAlgo)
 	if signAlgo == runtime.SignatureAlgorithmUnknown {
-		err = errors.NewValueErrorf(publicKey.SignAlgo.String(), "signature algorithm type not found")
-		return nil, fmt.Errorf("revoking account key failed: %w", err)
+		return nil, fmt.Errorf(
+			"revoking account key failed: %w",
+			errors.NewValueErrorf(
+				publicKey.SignAlgo.String(),
+				"signature algorithm type not found"))
 	}
 
 	hashAlgo := crypto.CryptoToRuntimeHashingAlgorithm(publicKey.HashAlgo)
 	if hashAlgo == runtime.HashAlgorithmUnknown {
-		err = errors.NewValueErrorf(publicKey.HashAlgo.String(), "hashing algorithm type not found")
-		return nil, fmt.Errorf("revoking account key failed: %w", err)
+		return nil, fmt.Errorf(
+			"revoking account key failed: %w",
+			errors.NewValueErrorf(
+				publicKey.HashAlgo.String(),
+				"hashing algorithm type not found"))
 	}
 
 	return &runtime.AccountKey{
@@ -186,10 +351,13 @@ func (h *AccountKeyHandler) RevokeAccountKey(address runtime.Address, keyIndex i
 // This function returns following error
 // * NewAccountNotFoundError - if the specified account does not exist
 // * ValueError - if the provided encodedPublicKey is not valid public key
-func (e *AccountKeyHandler) AddEncodedAccountKey(address runtime.Address, encodedPublicKey []byte) (err error) {
+func (updater *accountKeyUpdater) addEncodedAccountKey(
+	address runtime.Address,
+	encodedPublicKey []byte,
+) error {
 	accountAddress := flow.Address(address)
 
-	ok, err := e.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(accountAddress)
 	if err != nil {
 		return fmt.Errorf("adding encoded account key failed: %w", err)
 	}
@@ -203,11 +371,15 @@ func (e *AccountKeyHandler) AddEncodedAccountKey(address runtime.Address, encode
 	publicKey, err = flow.DecodeRuntimeAccountPublicKey(encodedPublicKey, 0)
 	if err != nil {
 		hexEncodedPublicKey := hex.EncodeToString(encodedPublicKey)
-		err = errors.NewValueErrorf(hexEncodedPublicKey, "invalid encoded public key value: %w", err)
-		return fmt.Errorf("adding encoded account key failed: %w", err)
+		return fmt.Errorf(
+			"adding encoded account key failed: %w",
+			errors.NewValueErrorf(
+				hexEncodedPublicKey,
+				"invalid encoded public key value: %w",
+				err))
 	}
 
-	err = e.accounts.AppendPublicKey(accountAddress, publicKey)
+	err = updater.accounts.AppendPublicKey(accountAddress, publicKey)
 	if err != nil {
 		return fmt.Errorf("adding encoded account key failed: %w", err)
 	}
@@ -219,10 +391,16 @@ func (e *AccountKeyHandler) AddEncodedAccountKey(address runtime.Address, encode
 //
 // This function returns an error if the specified account does not exist, the
 // provided key is invalid, or if key revoking fails.
-func (e *AccountKeyHandler) RemoveAccountKey(address runtime.Address, keyIndex int) (encodedPublicKey []byte, err error) {
+func (updater *accountKeyUpdater) removeAccountKey(
+	address runtime.Address,
+	keyIndex int,
+) (
+	[]byte,
+	error,
+) {
 	accountAddress := flow.Address(address)
 
-	ok, err := e.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(accountAddress)
 	if err != nil {
 		return nil, fmt.Errorf("remove account key failed: %w", err)
 	}
@@ -233,12 +411,16 @@ func (e *AccountKeyHandler) RemoveAccountKey(address runtime.Address, keyIndex i
 	}
 
 	if keyIndex < 0 {
-		err = errors.NewValueErrorf(fmt.Sprint(keyIndex), "key index must be positive")
+		err = errors.NewValueErrorf(
+			fmt.Sprint(keyIndex),
+			"key index must be positive")
 		return nil, fmt.Errorf("remove account key failed: %w", err)
 	}
 
 	var publicKey flow.AccountPublicKey
-	publicKey, err = e.accounts.GetPublicKey(accountAddress, uint64(keyIndex))
+	publicKey, err = updater.accounts.GetPublicKey(
+		accountAddress,
+		uint64(keyIndex))
 	if err != nil {
 		return nil, fmt.Errorf("remove account key failed: %w", err)
 	}
@@ -246,10 +428,123 @@ func (e *AccountKeyHandler) RemoveAccountKey(address runtime.Address, keyIndex i
 	// mark this key as revoked
 	publicKey.Revoked = true
 
-	encodedPublicKey, err = e.accounts.SetPublicKey(accountAddress, uint64(keyIndex), publicKey)
+	encodedPublicKey, err := updater.accounts.SetPublicKey(
+		accountAddress,
+		uint64(keyIndex),
+		publicKey)
 	if err != nil {
 		return nil, fmt.Errorf("remove account key failed: %w", err)
 	}
 
 	return encodedPublicKey, nil
+}
+
+func (updater *accountKeyUpdater) AddEncodedAccountKey(
+	address runtime.Address,
+	publicKey []byte,
+) error {
+	defer updater.tracer.StartSpanFromRoot(trace.FVMEnvAddAccountKey).End()
+
+	err := updater.meter.MeterComputation(
+		environment.ComputationKindAddEncodedAccountKey,
+		1)
+	if err != nil {
+		return fmt.Errorf("add encoded account key failed: %w", err)
+	}
+
+	// TODO do a call to track the computation usage and memory usage
+	//
+	// don't enforce limit during adding a key
+	updater.stTxn.DisableAllLimitEnforcements()
+	defer updater.stTxn.EnableAllLimitEnforcements()
+
+	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	if err != nil {
+		return fmt.Errorf("add encoded account key failed: %w", err)
+	}
+
+	err = updater.addEncodedAccountKey(address, publicKey)
+
+	if err != nil {
+		return fmt.Errorf("add encoded account key failed: %w", err)
+	}
+	return nil
+}
+
+func (updater *accountKeyUpdater) RevokeEncodedAccountKey(
+	address runtime.Address,
+	index int,
+) (
+	[]byte,
+	error,
+) {
+	defer updater.tracer.StartSpanFromRoot(trace.FVMEnvRemoveAccountKey).End()
+
+	err := updater.meter.MeterComputation(
+		environment.ComputationKindRevokeEncodedAccountKey,
+		1)
+	if err != nil {
+		return nil, fmt.Errorf("revoke encoded account key failed: %w", err)
+	}
+
+	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	if err != nil {
+		return nil, fmt.Errorf("revoke encoded account key failed: %w", err)
+	}
+
+	encodedKey, err := updater.removeAccountKey(address, index)
+	if err != nil {
+		return nil, fmt.Errorf("revoke encoded account key failed: %w", err)
+	}
+
+	return encodedKey, nil
+}
+
+func (updater *accountKeyUpdater) AddAccountKey(
+	address runtime.Address,
+	publicKey *runtime.PublicKey,
+	hashAlgo runtime.HashAlgorithm,
+	weight int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
+	defer updater.tracer.StartSpanFromRoot(trace.FVMEnvAddAccountKey).End()
+
+	err := updater.meter.MeterComputation(
+		environment.ComputationKindAddAccountKey,
+		1)
+	if err != nil {
+		return nil, fmt.Errorf("add account key failed: %w", err)
+	}
+
+	accKey, err := updater.addAccountKey(
+		address,
+		publicKey,
+		hashAlgo,
+		weight)
+	if err != nil {
+		return nil, fmt.Errorf("add account key failed: %w", err)
+	}
+
+	return accKey, nil
+}
+
+func (updater *accountKeyUpdater) RevokeAccountKey(
+	address runtime.Address,
+	keyIndex int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
+	defer updater.tracer.StartSpanFromRoot(trace.FVMEnvRemoveAccountKey).End()
+
+	err := updater.meter.MeterComputation(
+		environment.ComputationKindRevokeAccountKey,
+		1)
+	if err != nil {
+		return nil, fmt.Errorf("revoke account key failed: %w", err)
+	}
+
+	return updater.revokeAccountKey(address, keyIndex)
 }

--- a/fvm/handler/accountKey_test.go
+++ b/fvm/handler/accountKey_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestAddEncodedAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 
-	akh := &AccountKeyHandler{accounts: FakeAccounts{}}
+	akh := &accountKeyUpdater{accounts: FakeAccounts{}}
 
 	address := cadence.BytesToAddress([]byte{1, 2, 3, 4})
 
@@ -48,7 +48,7 @@ func TestAddEncodedAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 	encodedPublicKey, err := flow.EncodeRuntimeAccountPublicKey(accountPublicKey)
 	require.NoError(t, err)
 
-	err = akh.AddEncodedAccountKey(runtime.Address(address), encodedPublicKey)
+	err = akh.addEncodedAccountKey(runtime.Address(address), encodedPublicKey)
 	require.Error(t, err)
 
 	err = errors2.Unwrap(err)

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -6,7 +6,6 @@ import (
 	"github.com/onflow/cadence/runtime"
 
 	"github.com/onflow/flow-go/fvm/environment"
-	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/handler"
 	"github.com/onflow/flow-go/fvm/state"
 )
@@ -47,28 +46,10 @@ func NewScriptEnvironment(
 	env.SystemContracts.SetEnvironment(env)
 
 	env.ContractUpdater = handler.NoContractUpdater{}
+	env.AccountKeyUpdater = handler.NoAccountKeyUpdater{}
 
 	// TODO(patrick): remove this hack
-	env.accountKeys = handler.NewAccountKeyHandler(env.accounts)
 	env.fullEnv = env
 
 	return env
-}
-
-// Block Environment Functions
-
-func (e *ScriptEnv) AddEncodedAccountKey(_ runtime.Address, _ []byte) error {
-	return errors.NewOperationNotSupportedError("AddEncodedAccountKey")
-}
-
-func (e *ScriptEnv) RevokeEncodedAccountKey(_ runtime.Address, _ int) (publicKey []byte, err error) {
-	return nil, errors.NewOperationNotSupportedError("RevokeEncodedAccountKey")
-}
-
-func (e *ScriptEnv) AddAccountKey(_ runtime.Address, _ *runtime.PublicKey, _ runtime.HashAlgorithm, _ int) (*runtime.AccountKey, error) {
-	return nil, errors.NewOperationNotSupportedError("AddAccountKey")
-}
-
-func (e *ScriptEnv) RevokeAccountKey(_ runtime.Address, _ int) (*runtime.AccountKey, error) {
-	return nil, errors.NewOperationNotSupportedError("RevokeAccountKey")
 }


### PR DESCRIPTION
1. Added AccountKeyUpdater interface, and NoAccountKeyUpdater for script
2. renamed (_ *AccountKeyHandler) to (updater *accountKeyUpdater)
3. convert original AccountKeyHandler methods to private
4. move TransactionEnv's account key methods to accountKeyUpdater
5. also some reformatting