### PR TITLE
Reduce environment circular dependency

### DIFF
--- a/fvm/environment/runtime.go
+++ b/fvm/environment/runtime.go
@@ -1,0 +1,32 @@
+package environment
+
+import (
+	"github.com/onflow/flow-go/fvm/runtime"
+)
+
+// Runtime expose the cadence runtime to the rest of the envionment package.
+type Runtime struct {
+	pool runtime.ReusableCadenceRuntimePool
+
+	env Environment
+}
+
+func NewRuntime(pool runtime.ReusableCadenceRuntimePool) *Runtime {
+	return &Runtime{
+		pool: pool,
+	}
+}
+
+func (runtime *Runtime) SetEnvironment(env Environment) {
+	runtime.env = env
+}
+
+func (runtime *Runtime) BorrowCadenceRuntime() *runtime.ReusableCadenceRuntime {
+	return runtime.pool.Borrow(runtime.env)
+}
+
+func (runtime *Runtime) ReturnCadenceRuntime(
+	reusable *runtime.ReusableCadenceRuntime,
+) {
+	runtime.pool.Return(reusable)
+}

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -43,10 +43,10 @@ func NewScriptEnvironment(
 	env.EventEmitter = environment.NoEventEmitter{}
 	env.AccountCreator = environment.NoAccountCreator{}
 	env.AccountFreezer = environment.NoAccountFreezer{}
-	env.SystemContracts.SetEnvironment(env)
-
 	env.ContractUpdater = handler.NoContractUpdater{}
 	env.AccountKeyUpdater = handler.NoAccountKeyUpdater{}
+
+	env.Runtime.SetEnvironment(env)
 
 	// TODO(patrick): remove this hack
 	env.fullEnv = env

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -82,7 +82,6 @@ func NewTransactionEnvironment(
 		ctx.Chain.ServiceAddress(),
 		env.accounts,
 		env.TransactionInfo)
-	env.SystemContracts.SetEnvironment(env)
 	env.ContractUpdater = handler.NewContractUpdater(
 		tracer,
 		meter,
@@ -107,13 +106,14 @@ func NewTransactionEnvironment(
 		env.GetAccountsAuthorizedForContractRemoval,
 		env.useContractAuditVoucher,
 	)
-
 	env.AccountKeyUpdater = handler.NewAccountKeyUpdater(
 		tracer,
 		meter,
 		env.accounts,
 		sth,
 		env)
+
+	env.Runtime.SetEnvironment(env)
 
 	// TODO(patrick): rm this hack
 	env.fullEnv = env


### PR DESCRIPTION
Only the runtime needs access to the full environment.  Nothing else in the environment package needs to directly access the full environment.