### PR TITLE
[FVM] Log err on TX failure

### DIFF
--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -143,6 +143,11 @@ func (i TransactionInvoker) Process(
 		sth.DisableAllLimitEnforcements()
 		defer sth.EnableAllLimitEnforcements()
 
+		// log transaction as failed
+		ctx.Logger.Info().
+			Err(txError).
+			Msg("transaction executed with error")
+
 		modifiedSets = programsCache.ModifiedSets{}
 		env.Reset()
 
@@ -154,10 +159,6 @@ func (i TransactionInvoker) Process(
 				err,
 			)
 		}
-
-		// log transaction as failed
-		ctx.Logger.Info().
-			Msg("transaction executed with error")
 
 		// try to deduct fees again, to get the fee deduction events
 		feesError = i.deductTransactionFees(env, proc, sth, computationUsed)


### PR DESCRIPTION
port of https://github.com/onflow/flow-go/pull/3228.

Ideally we wouldn't just log it, but this is an improvement.