### PR TITLE
[FVM] Removing unused VM param from NewScript\TransationEnvironment()

### DIFF
--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -150,7 +150,7 @@ func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 	)
 	accounts := environment.NewAccounts(stTxn)
 
-	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, stTxn, progs)
+	env := fvm.NewScriptEnvironment(context.Background(), ctx, stTxn, progs)
 
 	return &balanceProcessor{
 		vm:       vm,

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -658,7 +658,7 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 	view := testutil.RootBootstrappedLedger(vm, ctx)
 	programs := programs.NewEmptyPrograms()
 	stTxn := state.NewStateTransaction(view, state.DefaultParameters())
-	env := fvm.NewScriptEnvironment(context.Background(), ctx, vm, stTxn, programs)
+	env := fvm.NewScriptEnvironment(context.Background(), ctx, stTxn, programs)
 
 	// Create an account private key.
 	privateKeys, err := testutil.GenerateAccountPrivateKeys(1)

--- a/fvm/account.go
+++ b/fvm/account.go
@@ -12,7 +12,6 @@ import (
 )
 
 func getAccount(
-	vm *VirtualMachine,
 	ctx Context,
 	sth *state.StateHolder,
 	programs *programs.Programs,
@@ -26,7 +25,7 @@ func getAccount(
 	}
 
 	if ctx.ServiceAccountEnabled {
-		env := NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
+		env := NewScriptEnvironment(context.Background(), ctx, sth, programs)
 
 		balance, err := env.GetAccountBalance(common.Address(address))
 		if err != nil {

--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -17,7 +17,6 @@ import (
 )
 
 func getEnvironmentMeterParameters(
-	vm *VirtualMachine,
 	ctx Context,
 	view state.View,
 	programs *programs.Programs,
@@ -35,7 +34,7 @@ func getEnvironmentMeterParameters(
 
 	sth.DisableAllLimitEnforcements()
 
-	env := NewScriptEnvironment(context.Background(), ctx, vm, sth, programs)
+	env := NewScriptEnvironment(context.Background(), ctx, sth, programs)
 
 	return fillEnvironmentMeterParameters(ctx, env, params)
 }

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -76,7 +76,6 @@ func (vm *VirtualMachine) RunV2(
 		WithMemoryLimit(proc.MemoryLimit(ctx))
 
 	meterParams, err := getEnvironmentMeterParameters(
-		vm,
 		ctx,
 		v,
 		blockPrograms,
@@ -114,7 +113,7 @@ func (vm *VirtualMachine) GetAccount(ctx Context, address flow.Address, v state.
 			WithMaxInteractionSizeAllowed(ctx.MaxStateInteractionSize),
 	)
 
-	account, err := getAccount(vm, ctx, stTxn, programs, address)
+	account, err := getAccount(ctx, stTxn, programs, address)
 	if err != nil {
 		if errors.IsALedgerFailure(err) {
 			return nil, fmt.Errorf("cannot get account, this error usually happens if the reference block for this query is not set to a recent block: %w", err)

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -126,7 +126,7 @@ func (i ScriptInvoker) Process(
 	sth *state.StateHolder,
 	programs *programs.Programs,
 ) error {
-	env := NewScriptEnvironment(proc.RequestContext, ctx, vm, sth, programs)
+	env := NewScriptEnvironment(proc.RequestContext, ctx, sth, programs)
 
 	rt := env.BorrowCadenceRuntime()
 	defer env.ReturnCadenceRuntime(rt)

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -22,7 +22,6 @@ type ScriptEnv struct {
 func NewScriptEnvironment(
 	reqContext context.Context,
 	fvmContext Context,
-	vm *VirtualMachine,
 	sth *state.StateHolder,
 	programs handler.TransactionPrograms,
 ) *ScriptEnv {

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -31,7 +31,6 @@ type TransactionEnv struct {
 
 func NewTransactionEnvironment(
 	ctx Context,
-	vm *VirtualMachine,
 	sth *state.StateHolder,
 	programs handler.TransactionPrograms,
 	tx *flow.TransactionBody,

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -80,7 +80,7 @@ func (i TransactionInvoker) Process(
 		}
 	}()
 
-	env := NewTransactionEnvironment(ctx, vm, sth, programs, proc.Transaction, proc.TxIndex, span)
+	env := NewTransactionEnvironment(ctx, sth, programs, proc.Transaction, proc.TxIndex, span)
 
 	rt := env.BorrowCadenceRuntime()
 	defer env.ReturnCadenceRuntime(rt)


### PR DESCRIPTION
As a prep work for #3102. 

At present the `vm` param is not used in either `NewScriptEnvironment()` or `NewTransactionEnvironment()` method, also given that VirtualMachine is not part of `commonEnv`, it should be safe to remove it from the two functions. 

Didn't continue this removal to `Process()` of `ScriptProcessor` and `TransactionProcessor` because according to my understanding these two functions might need to use VirtualMachine.