### PR TITLE
Switch adding key and creating account to RunWithAllLimitsDisabled

### DIFF
--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -241,9 +241,21 @@ func (creator *accountCreator) CreateAccount(
 		return common.Address{}, err
 	}
 
-	creator.stateTransaction.DisableAllLimitEnforcements() // don't enforce limit during account creation
-	defer creator.stateTransaction.EnableAllLimitEnforcements()
+	// don't enforce limit during account creation
+	var addr runtime.Address
+	creator.stateTransaction.RunWithAllLimitsDisabled(func() {
+		addr, err = creator.createAccount(payer)
+	})
 
+	return addr, err
+}
+
+func (creator *accountCreator) createAccount(
+	payer runtime.Address,
+) (
+	runtime.Address,
+	error,
+) {
 	flowAddress, err := creator.createBasicAccount(nil)
 	if err != nil {
 		return common.Address{}, err

--- a/fvm/handler/accountKey.go
+++ b/fvm/handler/accountKey.go
@@ -452,18 +452,17 @@ func (updater *accountKeyUpdater) AddEncodedAccountKey(
 		return fmt.Errorf("add encoded account key failed: %w", err)
 	}
 
-	// TODO do a call to track the computation usage and memory usage
-	//
-	// don't enforce limit during adding a key
-	updater.stTxn.DisableAllLimitEnforcements()
-	defer updater.stTxn.EnableAllLimitEnforcements()
-
 	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
 	if err != nil {
 		return fmt.Errorf("add encoded account key failed: %w", err)
 	}
 
-	err = updater.addEncodedAccountKey(address, publicKey)
+	// TODO do a call to track the computation usage and memory usage
+	//
+	// don't enforce limit during adding a key
+	updater.stTxn.RunWithAllLimitsDisabled(func() {
+		err = updater.addEncodedAccountKey(address, publicKey)
+	})
 
 	if err != nil {
 		return fmt.Errorf("add encoded account key failed: %w", err)


### PR DESCRIPTION
This is a bit more correct then using Disable/Enable-AllLimitEnforcements since RunWithAllLimitsDisabled resets the enforcement bool back to the original value, instead of forcing it to true.