### PR TITLE
Get account storage

### DIFF
--- a/utils/debug/debug_test.go
+++ b/utils/debug/debug_test.go
@@ -1,0 +1,53 @@
+package debug_test
+
+import (
+	"fmt"
+
+	"math"
+	"testing"
+
+	cadenceRuntime "github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
+	metering "github.com/onflow/flow-go/fvm/meter"
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/debug"
+)
+
+func TestDebugger_RunTransaction(t *testing.T) {
+
+	grpcAddress := "X.X.X.X:9000"
+	address, _ := common.HexToAddress("0xe467b9dd11fa00df")
+	blockID, _ := flow.HexStringToIdentifier("88563f69d7394f2658871f09d467d8c14af4023369932f0f10b403be4053f6ab")
+
+	view := debug.NewRemoteView(grpcAddress, debug.WithBlockID(blockID))
+	meter := metering.NewMeter(math.MaxUint64, math.MaxUint64)
+	st := state.NewState(view, meter)
+	sth := state.NewStateHolder(st)
+	accounts := state.NewAccounts(sth)
+	storage := cadenceRuntime.NewStorage(
+		&migrations.AccountsAtreeLedger{Accounts: accounts},
+		nil,
+	)
+	sm := storage.GetStorageMap(address, common.PathDomainStorage.Identifier(), false)
+
+	iter := sm.Iterator(nil)
+
+	fmt.Println("key", "staticType")
+	for key, value := iter.Next(); key != ""; key, value = iter.Next() {
+		fmt.Println(key, safelyGetStaticType(value))
+	}
+}
+
+func safelyGetStaticType(value interpreter.Value) (st string) {
+	defer func() {
+		if r := recover(); r != nil {
+			st = "unknown"
+		}
+	}()
+	st = value.StaticType(nil).String()
+	return
+}


### PR DESCRIPTION
Do not merge! This is just an example. This will be obsolete with cadence storage iteration.

This can be used to figure out what a specific account is storing. For example the service account:

```
key staticType
FlowContractAudits_auditors_flowSE A.e467b9dd11fa00df.FlowContractAudits.Auditor
FlowContractAudits_auditors_QS_Jan A.e467b9dd11fa00df.FlowContractAudits.Auditor
executionMemoryLimit UInt64
flowTokenVault A.1654653399040a61.FlowToken.Vault
FlowContractAudits_auditors_JoshHannan A.e467b9dd11fa00df.FlowContractAudits.Auditor
isContractDeploymentRestricted Bool
FlowContractAudits_auditors_SatyamAgrawal A.e467b9dd11fa00df.FlowContractAudits.Auditor
authorizedAddressesToDeployContracts [Address]
FlowContractAudits_auditors_OS_Richie A.e467b9dd11fa00df.FlowContractAudits.Auditor
storageFeesAdmin A.e467b9dd11fa00df.FlowStorageFees.Administrator
executionEffortWeights {UInt64: UInt64}
flowStakingAdmin Capability<&A.8624b52f9ddcd04a.FlowIDTableStaking.Admin>
flowServiceAdmin A.e467b9dd11fa00df.FlowServiceAccount.Administrator
isAccountCreationRestricted Bool
flowTokenAdmin A.1654653399040a61.FlowToken.Administrator
flowContractAuditVouchersAdmin A.e467b9dd11fa00df.FlowContractAudits.Administrator
```