### PR TITLE
[FVM] Adding storage metering to Meter

### DIFF
--- a/fvm/meter/meter.go
+++ b/fvm/meter/meter.go
@@ -1,6 +1,10 @@
 package meter
 
-import "github.com/onflow/cadence/runtime/common"
+import (
+	"github.com/onflow/cadence/runtime/common"
+
+	"github.com/onflow/flow-go/model/flow"
+)
 
 type MetringOperationType uint
 
@@ -41,6 +45,7 @@ const (
 
 type MeteredComputationIntensities map[common.ComputationKind]uint
 type MeteredMemoryIntensities map[common.MemoryKind]uint
+type MeteredStorageInteractionMap map[StorageInteractionKey]uint64
 
 type Meter interface {
 	// merge child funcionality
@@ -59,10 +64,17 @@ type Meter interface {
 	TotalMemoryEstimate() uint64
 	TotalMemoryLimit() uint64
 
-	// TODO move storage metering to here
-	// MeterStorageRead(byteSize uint) error
-	// MeterStorageWrite(byteSize uint) error
-	// TotalBytesReadFromStorage() int
-	// TotalBytesWroteToStorage() int
-	// TotalBytesOfStorageInteractions() int
+	// storage metering
+	MeterStorageRead(storageKey StorageInteractionKey, value flow.RegisterValue, enforceLimit bool) error
+	MeterStorageWrite(storageKey StorageInteractionKey, value flow.RegisterValue, enforceLimit bool) error
+	StorageUpdateSizeMap() MeteredStorageInteractionMap
+	TotalBytesReadFromStorage() uint64
+	TotalBytesWrittenToStorage() uint64
+	TotalStorageReadCount() uint64
+	TotalStorageWriteCount() uint64
+	TotalBytesOfStorageInteractions() uint64
+}
+
+type StorageInteractionKey struct {
+	Owner, Key string
 }

--- a/fvm/meter/meter.go
+++ b/fvm/meter/meter.go
@@ -70,8 +70,6 @@ type Meter interface {
 	StorageUpdateSizeMap() MeteredStorageInteractionMap
 	TotalBytesReadFromStorage() uint64
 	TotalBytesWrittenToStorage() uint64
-	TotalStorageReadCount() uint64
-	TotalStorageWriteCount() uint64
 	TotalBytesOfStorageInteractions() uint64
 }
 

--- a/fvm/meter/weighted_meter.go
+++ b/fvm/meter/weighted_meter.go
@@ -389,7 +389,7 @@ func (m *WeightedMeter) MergeMeter(child Meter) {
 
 	// merge storage meters
 	for key, value := range child.StorageUpdateSizeMap() {
-		m.storageUpdateSizeMap[key] += value
+		m.storageUpdateSizeMap[key] = value
 	}
 	m.totalStorageBytesRead += child.TotalBytesReadFromStorage()
 	m.totalStorageBytesWritten += child.TotalBytesWrittenToStorage()

--- a/fvm/meter/weighted_meter.go
+++ b/fvm/meter/weighted_meter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 // MeterExecutionInternalPrecisionBytes are the amount of bytes that are used internally by the WeigthedMeter
@@ -254,16 +255,19 @@ type MeterParameters struct {
 
 	memoryLimit   uint64
 	memoryWeights ExecutionMemoryWeights
+
+	storageInteractionLimit uint64
 }
 
 func DefaultParameters() MeterParameters {
 	// This is needed to work around golang's compiler bug
 	umax := uint(math.MaxUint)
 	return MeterParameters{
-		computationLimit:   uint64(umax) << MeterExecutionInternalPrecisionBytes,
-		memoryLimit:        math.MaxUint64,
-		computationWeights: DefaultComputationWeights,
-		memoryWeights:      DefaultMemoryWeights,
+		computationLimit:        uint64(umax) << MeterExecutionInternalPrecisionBytes,
+		memoryLimit:             math.MaxUint64,
+		computationWeights:      DefaultComputationWeights,
+		memoryWeights:           DefaultMemoryWeights,
+		storageInteractionLimit: math.MaxUint64,
 	}
 }
 
@@ -292,6 +296,14 @@ func (params MeterParameters) WithMemoryWeights(
 ) MeterParameters {
 	newParams := params
 	newParams.memoryWeights = weights
+	return newParams
+}
+
+func (params MeterParameters) WithStorageInteractionLimit(
+	maxStorageInteractionLimit uint64,
+) MeterParameters {
+	newParams := params
+	newParams.storageInteractionLimit = maxStorageInteractionLimit
 	return newParams
 }
 
@@ -324,6 +336,12 @@ type WeightedMeter struct {
 
 	computationIntensities MeteredComputationIntensities
 	memoryIntensities      MeteredMemoryIntensities
+
+	storageUpdateSizeMap     map[StorageInteractionKey]uint64
+	storageReadCounter       uint64
+	storageWriteCounter      uint64
+	totalStorageBytesRead    uint64
+	totalStorageBytesWritten uint64
 }
 
 type WeightedMeterOptions func(*WeightedMeter)
@@ -334,6 +352,7 @@ func NewMeter(params MeterParameters) Meter {
 		MeterParameters:        params,
 		computationIntensities: make(MeteredComputationIntensities),
 		memoryIntensities:      make(MeteredMemoryIntensities),
+		storageUpdateSizeMap:   make(MeteredStorageInteractionMap),
 	}
 
 	return m
@@ -345,6 +364,7 @@ func (m *WeightedMeter) NewChild() Meter {
 		MeterParameters:        m.MeterParameters,
 		computationIntensities: make(MeteredComputationIntensities),
 		memoryIntensities:      make(MeteredMemoryIntensities),
+		storageUpdateSizeMap:   make(MeteredStorageInteractionMap),
 	}
 }
 
@@ -368,6 +388,15 @@ func (m *WeightedMeter) MergeMeter(child Meter) {
 	for key, intensity := range child.MemoryIntensities() {
 		m.memoryIntensities[key] += intensity
 	}
+
+	// merge storage meters
+	for key, value := range child.StorageUpdateSizeMap() {
+		m.storageUpdateSizeMap[key] += value
+	}
+	m.storageReadCounter += child.TotalStorageReadCount()
+	m.storageWriteCounter += child.TotalStorageWriteCount()
+	m.totalStorageBytesRead += child.TotalBytesReadFromStorage()
+	m.totalStorageBytesWritten += child.TotalBytesWrittenToStorage()
 }
 
 // MeterComputation captures computation usage and returns an error if it goes beyond the limit
@@ -416,4 +445,96 @@ func (m *WeightedMeter) MemoryIntensities() MeteredMemoryIntensities {
 // TotalMemoryEstimate returns the total memory used
 func (m *WeightedMeter) TotalMemoryEstimate() uint64 {
 	return m.memoryEstimate
+}
+
+// MeterStorageRead captures storage read bytes count and returns an error
+// if it goes beyond the total interaction limit and limit is enforced
+func (m *WeightedMeter) MeterStorageRead(storageKey StorageInteractionKey,
+	value flow.RegisterValue,
+	enforceLimit bool) error {
+
+	// all reads are on a View which only read from storage at the first read of a given key
+	if _, ok := m.storageUpdateSizeMap[storageKey]; !ok {
+		m.storageReadCounter++
+		readByteSize := getStorageKeyValueSize(storageKey, value)
+		m.totalStorageBytesRead += readByteSize
+		m.storageUpdateSizeMap[storageKey] = readByteSize
+	}
+
+	if enforceLimit &&
+		m.TotalBytesOfStorageInteractions() > m.storageInteractionLimit {
+		return errors.NewStorageCapacityExceededError(
+			flow.EmptyAddress, // we don't care about account address for now
+			m.TotalBytesOfStorageInteractions(),
+			m.storageInteractionLimit)
+	}
+
+	return nil
+}
+
+// MeterStorageRead captures storage written bytes count and returns an error
+// if it goes beyond the total interaction limit and limit is enforced
+func (m *WeightedMeter) MeterStorageWrite(storageKey StorageInteractionKey,
+	value flow.RegisterValue,
+	enforceLimit bool) error {
+	// all writes are on a View which only writes the latest updated value to storage at commit
+	if old, ok := m.storageUpdateSizeMap[storageKey]; ok {
+		m.storageWriteCounter--
+		m.totalStorageBytesWritten -= old
+	}
+
+	m.storageWriteCounter++
+	updateSize := getStorageKeyValueSize(storageKey, value)
+	m.totalStorageBytesWritten += updateSize
+	m.storageUpdateSizeMap[storageKey] = updateSize
+
+	if enforceLimit &&
+		m.TotalBytesOfStorageInteractions() > m.storageInteractionLimit {
+		return errors.NewStorageCapacityExceededError(
+			flow.EmptyAddress, // we don't care about account address for now
+			m.TotalBytesOfStorageInteractions(),
+			m.storageInteractionLimit)
+	}
+
+	return nil
+}
+
+// TotalBytesReadFromStorage returns total number of byte read from storage
+func (m *WeightedMeter) TotalBytesReadFromStorage() uint64 {
+	return m.totalStorageBytesRead
+}
+
+// TotalStorageReadCount returns the total count of storage read
+func (m *WeightedMeter) TotalStorageReadCount() uint64 {
+	return m.storageReadCounter
+}
+
+// TotalBytesReadFromStorage returns total number of byte written to storage
+func (m *WeightedMeter) TotalBytesWrittenToStorage() uint64 {
+	return m.totalStorageBytesWritten
+}
+
+// TotalStorageWriteCount returns the total count of storage write
+func (m *WeightedMeter) TotalStorageWriteCount() uint64 {
+	return m.storageWriteCounter
+}
+
+// TotalBytesOfStorageInteractions returns total number of byte read and written from/to storage
+func (m *WeightedMeter) TotalBytesOfStorageInteractions() uint64 {
+	return m.TotalBytesReadFromStorage() + m.TotalBytesWrittenToStorage()
+}
+
+// StorageUpdateSizeMap returns all the measured storage meters
+func (m *WeightedMeter) StorageUpdateSizeMap() MeteredStorageInteractionMap {
+	return m.storageUpdateSizeMap
+}
+
+func getStorageKeyValueSize(storageKey StorageInteractionKey,
+	value flow.RegisterValue) uint64 {
+	return uint64(len(storageKey.Owner) + len(storageKey.Key) + len(value))
+}
+
+func GetStorageKeyValueSizeForTesting(storageKey StorageInteractionKey,
+	value flow.RegisterValue) uint64 {
+	return getStorageKeyValueSize(storageKey, value)
 }

--- a/fvm/meter/weighted_meter_test.go
+++ b/fvm/meter/weighted_meter_test.go
@@ -615,7 +615,7 @@ func TestStorageLimits(t *testing.T) {
 		storageUpdateSizeMap := meter1.StorageUpdateSizeMap()
 		readKey1Val, ok := storageUpdateSizeMap[readKey1]
 		require.True(t, ok)
-		require.Equal(t, readKey1Val, readSize1*2)
+		require.Equal(t, readKey1Val, readSize1) // meter merge only takes child values for rw bookkeeping
 		writeKey1Val, ok := storageUpdateSizeMap[writeKey1]
 		require.True(t, ok)
 		require.Equal(t, writeKey1Val, writeSize1)

--- a/fvm/meter/weighted_meter_test.go
+++ b/fvm/meter/weighted_meter_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func TestWeightedComputationMetering(t *testing.T) {
@@ -375,4 +376,269 @@ func TestMemoryWeights(t *testing.T) {
 			),
 		)
 	}
+}
+
+func TestStorageLimits(t *testing.T) {
+	t.Run("metering storage read - within limit", func(t *testing.T) {
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters(),
+		)
+
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		val1 := []byte{0x1, 0x2, 0x3}
+		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
+
+		// first read of key1
+		err := meter1.MeterStorageRead(key1, val1, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
+
+		// second read of key1
+		err = meter1.MeterStorageRead(key1, val1, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
+
+		// first read of key2
+		key2 := meter.StorageInteractionKey{Owner: "", Key: "2"}
+		val2 := []byte{0x3, 0x2, 0x1}
+		size2 := meter.GetStorageKeyValueSizeForTesting(key2, val2)
+
+		err = meter1.MeterStorageRead(key2, val2, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(2))
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1+size2)
+	})
+
+	t.Run("metering storage written - within limit", func(t *testing.T) {
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters(),
+		)
+
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		val1 := []byte{0x1, 0x2, 0x3}
+		val2 := []byte{0x1, 0x2, 0x3, 0x4}
+
+		// first write of key1
+		err := meter1.MeterStorageWrite(key1, val1, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesWrittenToStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val1))
+
+		// second write of key1 with val2
+		err = meter1.MeterStorageWrite(key1, val2, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesWrittenToStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val2))
+
+		// first write of key2
+		key2 := meter.StorageInteractionKey{Owner: "", Key: "2"}
+		err = meter1.MeterStorageWrite(key2, val2, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(2))
+		require.Equal(t, meter1.TotalBytesWrittenToStorage(),
+			meter.GetStorageKeyValueSizeForTesting(key1, val2)+meter.GetStorageKeyValueSizeForTesting(key2, val2))
+	})
+
+	t.Run("metering storage read - exceeding limit - not enforced", func(t *testing.T) {
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters().WithStorageInteractionLimit(1),
+		)
+
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		val1 := []byte{0x1, 0x2, 0x3}
+
+		err := meter1.MeterStorageRead(key1, val1, false /* not enforced */)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val1))
+	})
+
+	t.Run("metering storage read - exceeding limit - enforced", func(t *testing.T) {
+		testLimit := uint64(1)
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
+		)
+
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		val1 := []byte{0x1, 0x2, 0x3}
+
+		err := meter1.MeterStorageRead(key1, val1, true /* enforced */)
+
+		storageCapExceedError := errors.NewStorageCapacityExceededError(
+			flow.EmptyAddress,
+			meter.GetStorageKeyValueSizeForTesting(key1, val1),
+			testLimit,
+		)
+		require.ErrorAs(t, err, &storageCapExceedError)
+	})
+
+	t.Run("metering storage written - exceeding limit - not enforced", func(t *testing.T) {
+		testLimit := uint64(1)
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
+		)
+
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		val1 := []byte{0x1, 0x2, 0x3}
+
+		err := meter1.MeterStorageWrite(key1, val1, false /* not enforced */)
+		require.NoError(t, err)
+	})
+
+	t.Run("metering storage written - exceeding limit - enforced", func(t *testing.T) {
+		testLimit := uint64(1)
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
+		)
+
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		val1 := []byte{0x1, 0x2, 0x3}
+
+		err := meter1.MeterStorageWrite(key1, val1, true /* enforced */)
+
+		storageCapExceedError := errors.NewStorageCapacityExceededError(
+			flow.EmptyAddress,
+			meter.GetStorageKeyValueSizeForTesting(key1, val1),
+			testLimit,
+		)
+		require.ErrorAs(t, err, &storageCapExceedError)
+	})
+
+	t.Run("metering storage read and written - within limit", func(t *testing.T) {
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters(),
+		)
+
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		key2 := meter.StorageInteractionKey{Owner: "", Key: "2"}
+		val1 := []byte{0x1, 0x2, 0x3}
+		val2 := []byte{0x1, 0x2, 0x3, 0x4}
+		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
+		size2 := meter.GetStorageKeyValueSizeForTesting(key2, val2)
+
+		// read of key1
+		err := meter1.MeterStorageRead(key1, val1, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
+		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1)
+
+		// write of key2
+		err = meter1.MeterStorageWrite(key2, val2, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesWrittenToStorage(), size2)
+		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1+size2)
+	})
+
+	t.Run("metering storage read and written - exceeding limit - not enforced", func(t *testing.T) {
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		key2 := meter.StorageInteractionKey{Owner: "", Key: "2"}
+		val1 := []byte{0x1, 0x2, 0x3}
+		val2 := []byte{0x1, 0x2, 0x3, 0x4}
+		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
+		size2 := meter.GetStorageKeyValueSizeForTesting(key2, val2)
+
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters().WithStorageInteractionLimit(size1 + size2 - 1),
+		)
+
+		// read of key1
+		err := meter1.MeterStorageRead(key1, val1, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
+		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1)
+
+		// write of key2
+		err = meter1.MeterStorageWrite(key2, val2, false)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesWrittenToStorage(), size2)
+		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1+size2)
+	})
+
+	t.Run("metering storage read and written - exceeding limit - enforced", func(t *testing.T) {
+		key1 := meter.StorageInteractionKey{Owner: "", Key: "1"}
+		key2 := meter.StorageInteractionKey{Owner: "", Key: "2"}
+		val1 := []byte{0x1, 0x2, 0x3}
+		val2 := []byte{0x1, 0x2, 0x3, 0x4}
+		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
+		size2 := meter.GetStorageKeyValueSizeForTesting(key2, val2)
+		testLimit := size1 + size2 - 1
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
+		)
+
+		// read of key1
+		err := meter1.MeterStorageRead(key1, val1, true)
+		require.NoError(t, err)
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
+		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1)
+
+		// write of key2
+		err = meter1.MeterStorageWrite(key2, val2, true)
+		storageCapExceedError := errors.NewStorageCapacityExceededError(
+			flow.EmptyAddress,
+			size1+size2,
+			testLimit,
+		)
+		require.ErrorAs(t, err, &storageCapExceedError)
+	})
+
+	t.Run("merge storage metering", func(t *testing.T) {
+		// meter 1
+		meter1 := meter.NewMeter(
+			meter.DefaultParameters(),
+		)
+		readKey1 := meter.StorageInteractionKey{Owner: "", Key: "r1"}
+		readVal1 := []byte{0x1, 0x2, 0x3}
+		readSize1 := meter.GetStorageKeyValueSizeForTesting(readKey1, readVal1)
+		err := meter1.MeterStorageRead(readKey1, readVal1, false)
+		require.NoError(t, err)
+
+		writeKey1 := meter.StorageInteractionKey{Owner: "", Key: "w1"}
+		writeVal1 := []byte{0x1, 0x2, 0x3, 0x4}
+		writeSize1 := meter.GetStorageKeyValueSizeForTesting(writeKey1, writeVal1)
+		err = meter1.MeterStorageWrite(writeKey1, writeVal1, false)
+		require.NoError(t, err)
+
+		// meter 2
+		meter2 := meter.NewMeter(
+			meter.DefaultParameters(),
+		)
+
+		// read the same key value as meter1
+		err = meter2.MeterStorageRead(readKey1, readVal1, false)
+		require.NoError(t, err)
+
+		writeKey2 := meter.StorageInteractionKey{Owner: "", Key: "w2"}
+		writeVal2 := []byte{0x1, 0x2, 0x3, 0x4, 0x5}
+		writeSize2 := meter.GetStorageKeyValueSizeForTesting(writeKey2, writeVal2)
+		err = meter2.MeterStorageWrite(writeKey2, writeVal2, false)
+		require.NoError(t, err)
+
+		// merge
+		meter1.MergeMeter(meter2)
+
+		require.Equal(t, meter1.TotalStorageReadCount(), uint64(2))
+		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(2))
+		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), readSize1*2+writeSize1+writeSize2)
+		require.Equal(t, meter1.TotalBytesReadFromStorage(), readSize1*2)
+		require.Equal(t, meter1.TotalBytesWrittenToStorage(), writeSize1+writeSize2)
+
+		storageUpdateSizeMap := meter1.StorageUpdateSizeMap()
+		readKey1Val, ok := storageUpdateSizeMap[readKey1]
+		require.True(t, ok)
+		require.Equal(t, readKey1Val, readSize1*2)
+		writeKey1Val, ok := storageUpdateSizeMap[writeKey1]
+		require.True(t, ok)
+		require.Equal(t, writeKey1Val, writeSize1)
+		writeKey2Val, ok := storageUpdateSizeMap[writeKey2]
+		require.True(t, ok)
+		require.Equal(t, writeKey2Val, writeSize2)
+	})
 }

--- a/fvm/meter/weighted_meter_test.go
+++ b/fvm/meter/weighted_meter_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
-	"github.com/onflow/flow-go/model/flow"
 )
 
 func TestWeightedComputationMetering(t *testing.T) {
@@ -466,12 +465,11 @@ func TestStorageLimits(t *testing.T) {
 
 		err := meter1.MeterStorageRead(key1, val1, true /* enforced */)
 
-		storageCapExceedError := errors.NewStorageCapacityExceededError(
-			flow.EmptyAddress,
+		ledgerInteractionLimitExceedError := errors.NewLedgerInteractionLimitExceededError(
 			meter.GetStorageKeyValueSizeForTesting(key1, val1),
 			testLimit,
 		)
-		require.ErrorAs(t, err, &storageCapExceedError)
+		require.ErrorAs(t, err, &ledgerInteractionLimitExceedError)
 	})
 
 	t.Run("metering storage written - exceeding limit - not enforced", func(t *testing.T) {
@@ -498,12 +496,11 @@ func TestStorageLimits(t *testing.T) {
 
 		err := meter1.MeterStorageWrite(key1, val1, true /* enforced */)
 
-		storageCapExceedError := errors.NewStorageCapacityExceededError(
-			flow.EmptyAddress,
+		ledgerInteractionLimitExceedError := errors.NewLedgerInteractionLimitExceededError(
 			meter.GetStorageKeyValueSizeForTesting(key1, val1),
 			testLimit,
 		)
-		require.ErrorAs(t, err, &storageCapExceedError)
+		require.ErrorAs(t, err, &ledgerInteractionLimitExceedError)
 	})
 
 	t.Run("metering storage read and written - within limit", func(t *testing.T) {
@@ -581,12 +578,11 @@ func TestStorageLimits(t *testing.T) {
 
 		// write of key2
 		err = meter1.MeterStorageWrite(key2, val2, true)
-		storageCapExceedError := errors.NewStorageCapacityExceededError(
-			flow.EmptyAddress,
+		ledgerInteractionLimitExceedError := errors.NewLedgerInteractionLimitExceededError(
 			size1+size2,
 			testLimit,
 		)
-		require.ErrorAs(t, err, &storageCapExceedError)
+		require.ErrorAs(t, err, &ledgerInteractionLimitExceedError)
 	})
 
 	t.Run("merge storage metering", func(t *testing.T) {

--- a/fvm/meter/weighted_meter_test.go
+++ b/fvm/meter/weighted_meter_test.go
@@ -390,13 +390,11 @@ func TestStorageLimits(t *testing.T) {
 		// first read of key1
 		err := meter1.MeterStorageRead(key1, val1, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
 
 		// second read of key1
 		err = meter1.MeterStorageRead(key1, val1, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
 
 		// first read of key2
@@ -406,7 +404,6 @@ func TestStorageLimits(t *testing.T) {
 
 		err = meter1.MeterStorageRead(key2, val2, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(2))
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1+size2)
 	})
 
@@ -422,20 +419,17 @@ func TestStorageLimits(t *testing.T) {
 		// first write of key1
 		err := meter1.MeterStorageWrite(key1, val1, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val1))
 
 		// second write of key1 with val2
 		err = meter1.MeterStorageWrite(key1, val2, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val2))
 
 		// first write of key2
 		key2 := meter.StorageInteractionKey{Owner: "", Key: "2"}
 		err = meter1.MeterStorageWrite(key2, val2, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(2))
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(),
 			meter.GetStorageKeyValueSizeForTesting(key1, val2)+meter.GetStorageKeyValueSizeForTesting(key2, val2))
 	})
@@ -450,7 +444,6 @@ func TestStorageLimits(t *testing.T) {
 
 		err := meter1.MeterStorageRead(key1, val1, false /* not enforced */)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val1))
 	})
 
@@ -518,14 +511,12 @@ func TestStorageLimits(t *testing.T) {
 		// read of key1
 		err := meter1.MeterStorageRead(key1, val1, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
 		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1)
 
 		// write of key2
 		err = meter1.MeterStorageWrite(key2, val2, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(), size2)
 		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1+size2)
 	})
@@ -545,14 +536,12 @@ func TestStorageLimits(t *testing.T) {
 		// read of key1
 		err := meter1.MeterStorageRead(key1, val1, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
 		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1)
 
 		// write of key2
 		err = meter1.MeterStorageWrite(key2, val2, false)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(), size2)
 		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1+size2)
 	})
@@ -572,7 +561,6 @@ func TestStorageLimits(t *testing.T) {
 		// read of key1
 		err := meter1.MeterStorageRead(key1, val1, true)
 		require.NoError(t, err)
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(1))
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
 		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), size1)
 
@@ -620,8 +608,6 @@ func TestStorageLimits(t *testing.T) {
 		// merge
 		meter1.MergeMeter(meter2)
 
-		require.Equal(t, meter1.TotalStorageReadCount(), uint64(2))
-		require.Equal(t, meter1.TotalStorageWriteCount(), uint64(2))
 		require.Equal(t, meter1.TotalBytesOfStorageInteractions(), readSize1*2+writeSize1+writeSize2)
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), readSize1*2)
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(), writeSize1+writeSize2)


### PR DESCRIPTION
#3103 - we want to move existing storage metering logic in `state.go` into `Meter` interface.

As the first step, now adding storage read\write byte count metering interface to `Meter` interface. Next PR will replace related logic in `state.go` with the new Meter interface.