### PR TITLE
[Testing] de-flake TestGenerateTestMatrix

### DIFF
--- a/utils/test_matrix/test_matrix_test.go
+++ b/utils/test_matrix/test_matrix_test.go
@@ -75,19 +75,21 @@ func TestGenerateTestMatrix(t *testing.T) {
 
 	otherPackages := listOtherPackages(getAllFlowPackages(), seenPackages)
 
-	testMatrix := generateTestMatrix(targetPackages, otherPackages)
+	matrix := generateTestMatrix(targetPackages, otherPackages)
 
 	// should be 3 groups in test matrix: abc, ghi, other
-	require.Equal(t, 3, len(testMatrix))
+	require.Equal(t, 3, len(matrix))
 
-	require.Equal(t, "abc", testMatrix[0].Name)
-	require.Equal(t, "github.com/onflow/flow-go/abc github.com/onflow/flow-go/abc/def github.com/onflow/flow-go/abc/def/ghi",
-		testMatrix[0].Packages)
-
-	require.Equal(t, "ghi", testMatrix[1].Name)
-	require.Equal(t, "github.com/onflow/flow-go/ghi", testMatrix[1].Packages)
-
-	require.Equal(t, "others", testMatrix[2].Name)
-	require.Equal(t, "github.com/onflow/flow-go/def github.com/onflow/flow-go/def/abc github.com/onflow/flow-go/jkl github.com/onflow/flow-go/mno/abc github.com/onflow/flow-go/pqr github.com/onflow/flow-go/stu github.com/onflow/flow-go/vwx github.com/onflow/flow-go/vwx/ghi github.com/onflow/flow-go/yz",
-		testMatrix[2].Packages)
+	require.Contains(t, matrix, testMatrix{
+		Name:     "abc",
+		Packages: "github.com/onflow/flow-go/abc github.com/onflow/flow-go/abc/def github.com/onflow/flow-go/abc/def/ghi"},
+	)
+	require.Contains(t, matrix, testMatrix{
+		Name:     "ghi",
+		Packages: "github.com/onflow/flow-go/ghi"},
+	)
+	require.Contains(t, matrix, testMatrix{
+		Name:     "others",
+		Packages: "github.com/onflow/flow-go/def github.com/onflow/flow-go/def/abc github.com/onflow/flow-go/jkl github.com/onflow/flow-go/mno/abc github.com/onflow/flow-go/pqr github.com/onflow/flow-go/stu github.com/onflow/flow-go/vwx github.com/onflow/flow-go/vwx/ghi github.com/onflow/flow-go/yz"},
+	)
 }

--- a/utils/test_matrix/test_matrix_test.go
+++ b/utils/test_matrix/test_matrix_test.go
@@ -77,7 +77,7 @@ func TestGenerateTestMatrix(t *testing.T) {
 
 	matrix := generateTestMatrix(targetPackages, otherPackages)
 
-	// should be 3 groups in test matrix: abc, ghi, other
+	// should be 3 groups in test matrix: abc, ghi, others
 	require.Equal(t, 3, len(matrix))
 
 	require.Contains(t, matrix, testMatrix{


### PR DESCRIPTION
Noticed in #3238

@gomisha, this is a good example of a case where CODEOWNERS-based annotation could help: in theory we would want to notify test owners of their flakes.

This is also an example of a test that should be auto-quarantined.