### PR TITLE
[FVM] Error Cleanup

### DIFF
--- a/fvm/crypto/crypto_test.go
+++ b/fvm/crypto/crypto_test.go
@@ -505,7 +505,7 @@ func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_inval
 		nil, "", nil, nil, invalidSignatureAlgo, 0,
 	)
 
-	require.IsType(t, &errors.ValueError{}, err)
+	require.IsType(t, errors.ValueError{}, err)
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidSignatureAlgo))
 
@@ -532,7 +532,7 @@ func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_inval
 		nil, "", nil, nil, runtime.SignatureAlgorithmECDSA_P256, invalidHashAlgo,
 	)
 
-	require.IsType(t, &errors.ValueError{}, err)
+	require.IsType(t, errors.ValueError{}, err)
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidHashAlgo))
 
@@ -553,13 +553,13 @@ func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_inval
 
 func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_invalid_public_key(t *testing.T) {
 
-	invalidPublicKey := []byte{0xc3, 0x28} //some invalid UTF8
+	invalidPublicKey := []byte{0xc3, 0x28} // some invalid UTF8
 
 	_, err := crypto.VerifySignatureFromRuntime(
 		nil, "random_tag", nil, invalidPublicKey, runtime.SignatureAlgorithmECDSA_P256, runtime.HashAlgorithmSHA2_256,
 	)
 
-	require.IsType(t, &errors.ValueError{}, err)
+	require.IsType(t, errors.ValueError{}, err)
 	errorString := err.Error()
 
 	require.Contains(t, errorString, fmt.Sprintf("%x", invalidPublicKey))

--- a/fvm/errors/accounts.go
+++ b/fvm/errors/accounts.go
@@ -13,8 +13,8 @@ type AccountNotFoundError struct {
 }
 
 // NewAccountNotFoundError constructs a new AccountNotFoundError
-func NewAccountNotFoundError(address flow.Address) error {
-	return &AccountNotFoundError{
+func NewAccountNotFoundError(address flow.Address) AccountNotFoundError {
+	return AccountNotFoundError{
 		address: address,
 	}
 }
@@ -34,7 +34,7 @@ func (e AccountNotFoundError) Code() ErrorCode {
 
 // IsAccountNotFoundError returns true if error has this type
 func IsAccountNotFoundError(err error) bool {
-	var t *AccountNotFoundError
+	var t AccountNotFoundError
 	return errors.As(err, &t)
 }
 
@@ -46,8 +46,8 @@ type AccountAlreadyExistsError struct {
 }
 
 // NewAccountAlreadyExistsError constructs a new AccountAlreadyExistsError
-func NewAccountAlreadyExistsError(address flow.Address) error {
-	return &AccountAlreadyExistsError{address: address}
+func NewAccountAlreadyExistsError(address flow.Address) AccountAlreadyExistsError {
+	return AccountAlreadyExistsError{address: address}
 }
 
 func (e AccountAlreadyExistsError) Error() string {
@@ -70,13 +70,13 @@ type AccountPublicKeyNotFoundError struct {
 }
 
 // NewAccountPublicKeyNotFoundError constructs a new AccountPublicKeyNotFoundError
-func NewAccountPublicKeyNotFoundError(address flow.Address, keyIndex uint64) *AccountPublicKeyNotFoundError {
-	return &AccountPublicKeyNotFoundError{address: address, keyIndex: keyIndex}
+func NewAccountPublicKeyNotFoundError(address flow.Address, keyIndex uint64) AccountPublicKeyNotFoundError {
+	return AccountPublicKeyNotFoundError{address: address, keyIndex: keyIndex}
 }
 
 // IsAccountAccountPublicKeyNotFoundError returns true if error has this type
 func IsAccountAccountPublicKeyNotFoundError(err error) bool {
-	var t *AccountPublicKeyNotFoundError
+	var t AccountPublicKeyNotFoundError
 	return errors.As(err, &t)
 }
 
@@ -100,8 +100,8 @@ type FrozenAccountError struct {
 }
 
 // NewFrozenAccountError constructs a new FrozenAccountError
-func NewFrozenAccountError(address flow.Address) error {
-	return &FrozenAccountError{address: address}
+func NewFrozenAccountError(address flow.Address) FrozenAccountError {
+	return FrozenAccountError{address: address}
 }
 
 // Address returns the address of frozen account
@@ -126,8 +126,8 @@ type AccountPublicKeyLimitError struct {
 }
 
 // NewAccountPublicKeyLimitError constructs a new AccountPublicKeyLimitError
-func NewAccountPublicKeyLimitError(address flow.Address, counts, limit uint64) error {
-	return &AccountPublicKeyLimitError{
+func NewAccountPublicKeyLimitError(address flow.Address, counts, limit uint64) AccountPublicKeyLimitError {
+	return AccountPublicKeyLimitError{
 		address: address,
 		counts:  counts,
 		limit:   limit,

--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -11,8 +11,9 @@ import (
 // InvalidAddressError indicates that a transaction references an invalid flow Address
 // in either the Authorizers or Payer field.
 type InvalidAddressError struct {
+	errorWrapper
+
 	address flow.Address
-	err     error
 }
 
 // Address returns the invalid address
@@ -21,8 +22,13 @@ func (e InvalidAddressError) Address() flow.Address {
 }
 
 // NewInvalidAddressErrorf constructs a new InvalidAddressError
-func NewInvalidAddressErrorf(address flow.Address, msg string, args ...interface{}) *InvalidAddressError {
-	return &InvalidAddressError{address: address, err: fmt.Errorf(msg, args...)}
+func NewInvalidAddressErrorf(address flow.Address, msg string, args ...interface{}) InvalidAddressError {
+	return InvalidAddressError{
+		address: address,
+		errorWrapper: errorWrapper{
+			err: fmt.Errorf(msg, args...),
+		},
+	}
 }
 
 func (e InvalidAddressError) Error() string {
@@ -34,22 +40,21 @@ func (e InvalidAddressError) Code() ErrorCode {
 	return ErrCodeInvalidAddressError
 }
 
-// Unwrap unwraps the error
-func (e InvalidAddressError) Unwrap() error {
-	return e.err
-}
-
 // InvalidArgumentError indicates that a transaction includes invalid arguments.
 // this error is the result of failure in any of the following conditions:
 // - number of arguments doesn't match the template
 // TODO add more cases like argument size
 type InvalidArgumentError struct {
-	err error
+	errorWrapper
 }
 
 // NewInvalidArgumentErrorf constructs a new InvalidArgumentError
-func NewInvalidArgumentErrorf(msg string, args ...interface{}) *InvalidArgumentError {
-	return &InvalidArgumentError{err: fmt.Errorf(msg, args...)}
+func NewInvalidArgumentErrorf(msg string, args ...interface{}) InvalidArgumentError {
+	return InvalidArgumentError{
+		errorWrapper: errorWrapper{
+			err: fmt.Errorf(msg, args...),
+		},
+	}
 }
 
 func (e InvalidArgumentError) Error() string {
@@ -61,20 +66,20 @@ func (e InvalidArgumentError) Code() ErrorCode {
 	return ErrCodeInvalidArgumentError
 }
 
-// Unwrap unwraps the error
-func (e InvalidArgumentError) Unwrap() error {
-	return e.err
-}
-
 // InvalidLocationError indicates an invalid location is passed
 type InvalidLocationError struct {
+	errorWrapper
+
 	location runtime.Location
-	err      error
 }
 
 // NewInvalidLocationErrorf constructs a new InvalidLocationError
-func NewInvalidLocationErrorf(location runtime.Location, msg string, args ...interface{}) *InvalidLocationError {
-	return &InvalidLocationError{location: location, err: fmt.Errorf(msg, args...)}
+func NewInvalidLocationErrorf(location runtime.Location, msg string, args ...interface{}) InvalidLocationError {
+	return InvalidLocationError{location: location,
+		errorWrapper: errorWrapper{
+			err: fmt.Errorf(msg, args...),
+		},
+	}
 }
 
 func (e InvalidLocationError) Error() string {
@@ -101,20 +106,20 @@ func (e InvalidLocationError) Code() ErrorCode {
 	return ErrCodeInvalidLocationError
 }
 
-// Unwrap unwraps the error
-func (e InvalidLocationError) Unwrap() error {
-	return e.err
-}
-
 // ValueError indicates a value is not valid value.
 type ValueError struct {
+	errorWrapper
+
 	valueStr string
-	err      error
 }
 
 // NewValueErrorf constructs a new ValueError
-func NewValueErrorf(valueStr string, msg string, args ...interface{}) *ValueError {
-	return &ValueError{valueStr: valueStr, err: fmt.Errorf(msg, args...)}
+func NewValueErrorf(valueStr string, msg string, args ...interface{}) ValueError {
+	return ValueError{valueStr: valueStr,
+		errorWrapper: errorWrapper{
+			err: fmt.Errorf(msg, args...),
+		},
+	}
 }
 
 func (e ValueError) Error() string {
@@ -130,21 +135,22 @@ func (e ValueError) Code() ErrorCode {
 	return ErrCodeValueError
 }
 
-// Unwrap unwraps the error
-func (e ValueError) Unwrap() error {
-	return e.err
-}
-
 // OperationAuthorizationError indicates not enough authorization
 // to perform an operations like account creation or smart contract deployment.
 type OperationAuthorizationError struct {
+	errorWrapper
+
 	operation string
-	err       error
 }
 
 // NewOperationAuthorizationErrorf constructs a new OperationAuthorizationError
-func NewOperationAuthorizationErrorf(operation string, msg string, args ...interface{}) *OperationAuthorizationError {
-	return &OperationAuthorizationError{operation: operation, err: fmt.Errorf(msg, args...)}
+func NewOperationAuthorizationErrorf(operation string, msg string, args ...interface{}) OperationAuthorizationError {
+	return OperationAuthorizationError{
+		operation: operation,
+		errorWrapper: errorWrapper{
+			err: fmt.Errorf(msg, args...),
+		},
+	}
 }
 
 func (e OperationAuthorizationError) Error() string {
@@ -165,23 +171,24 @@ func (e OperationAuthorizationError) Code() ErrorCode {
 	return ErrCodeOperationAuthorizationError
 }
 
-// Unwrap unwraps the error
-func (e OperationAuthorizationError) Unwrap() error {
-	return e.err
-}
-
 // AccountAuthorizationError indicates that an authorization issues
 // either a transaction is missing a required signature to
 // authorize access to an account or a transaction doesn't have authorization
 // to performe some operations like account creation.
 type AccountAuthorizationError struct {
+	errorWrapper
+
 	address flow.Address
-	err     error
 }
 
 // NewAccountAuthorizationErrorf constructs a new AccountAuthorizationError
-func NewAccountAuthorizationErrorf(address flow.Address, msg string, args ...interface{}) *AccountAuthorizationError {
-	return &AccountAuthorizationError{address: address, err: fmt.Errorf(msg, args...)}
+func NewAccountAuthorizationErrorf(address flow.Address, msg string, args ...interface{}) AccountAuthorizationError {
+	return AccountAuthorizationError{
+		address: address,
+		errorWrapper: errorWrapper{
+			err: fmt.Errorf(msg, args...),
+		},
+	}
 }
 
 // Address returns the address of an account without enough authorization
@@ -207,27 +214,27 @@ func (e AccountAuthorizationError) Code() ErrorCode {
 	return ErrCodeAccountAuthorizationError
 }
 
-// Unwrap unwraps the error
-func (e AccountAuthorizationError) Unwrap() error {
-	return e.err
-}
-
 // FVMInternalError indicates that an internal error occurs during tx execution.
 type FVMInternalError struct {
+	errorWrapper
+
 	msg string
-	err error
 }
 
 // NewFVMInternalErrorf constructs a new FVMInternalError
-func NewFVMInternalErrorf(msg string, args ...interface{}) *FVMInternalError {
-	return &FVMInternalError{err: fmt.Errorf(msg, args...)}
+func NewFVMInternalErrorf(msg string, args ...interface{}) FVMInternalError {
+	return FVMInternalError{
+		errorWrapper: errorWrapper{
+			err: fmt.Errorf(msg, args...),
+		},
+	}
 }
 
-func (e *FVMInternalError) Error() string {
+func (e FVMInternalError) Error() string {
 	return e.msg
 }
 
 // Code returns the error code for this error type
-func (e *FVMInternalError) Code() ErrorCode {
+func (e FVMInternalError) Code() ErrorCode {
 	return ErrCodeFVMInternalError
 }

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -15,23 +15,30 @@ func (fc FailureCode) String() string {
 }
 
 const (
-	FailureCodeUnknownFailure         FailureCode = 2000
-	FailureCodeEncodingFailure        FailureCode = 2001
-	FailureCodeLedgerFailure          FailureCode = 2002
-	FailureCodeStateMergeFailure      FailureCode = 2003
-	FailureCodeBlockFinderFailure     FailureCode = 2004
-	FailureCodeHasherFailure          FailureCode = 2005
+	FailureCodeUnknownFailure     FailureCode = 2000
+	FailureCodeEncodingFailure    FailureCode = 2001
+	FailureCodeLedgerFailure      FailureCode = 2002
+	FailureCodeStateMergeFailure  FailureCode = 2003
+	FailureCodeBlockFinderFailure FailureCode = 2004
+	// Deprecated: No longer used.
+	FailureCodeHasherFailure FailureCode = 2005
+	// Deprecated: No longer used.
 	FailureCodeMetaTransactionFailure FailureCode = 2100
 )
 
 const (
 	// tx validation errors 1000 - 1049
-	// ErrCodeTxValidationError         ErrorCode = 1000 - reserved
-	ErrCodeInvalidTxByteSizeError     ErrorCode = 1001
+	// Deprecated: no longer in use
+	ErrCodeTxValidationError ErrorCode = 1000
+	// Deprecated: No longer used.
+	ErrCodeInvalidTxByteSizeError ErrorCode = 1001
+	// Deprecated: No longer used.
 	ErrCodeInvalidReferenceBlockError ErrorCode = 1002
-	// Deprecated: ErrCodeExpiredTransactionError
-	ErrCodeExpiredTransactionError       ErrorCode = 1003
-	ErrCodeInvalidScriptError            ErrorCode = 1004
+	// Deprecated: No longer used.
+	ErrCodeExpiredTransactionError ErrorCode = 1003
+	// Deprecated: No longer used.
+	ErrCodeInvalidScriptError ErrorCode = 1004
+	// Deprecated: No longer used.
 	ErrCodeInvalidGasLimitError          ErrorCode = 1005
 	ErrCodeInvalidProposalSignatureError ErrorCode = 1006
 	ErrCodeInvalidProposalSeqNumberError ErrorCode = 1007
@@ -49,11 +56,14 @@ const (
 	ErrCodeOperationNotSupportedError  ErrorCode = 1057
 
 	// execution errors 1100 - 1200
-	// ErrCodeExecutionError                 ErrorCode = 1100 - reserved
-	ErrCodeCadenceRunTimeError      ErrorCode = 1101
+	// Deprecated: No longer used.
+	ErrCodeExecutionError      ErrorCode = 1100
+	ErrCodeCadenceRunTimeError ErrorCode = 1101
+	// Deprecated: No longer used.
 	ErrCodeEncodingUnsupportedValue ErrorCode = 1102
 	ErrCodeStorageCapacityExceeded  ErrorCode = 1103
-	//  Deprecated: ErrCodeGasLimitExceededError  ErrorCode = 1104
+	// Deprecated: No longer used.
+	ErrCodeGasLimitExceededError                     ErrorCode = 1104
 	ErrCodeEventLimitExceededError                   ErrorCode = 1105
 	ErrCodeLedgerInteractionLimitExceededError       ErrorCode = 1106
 	ErrCodeStateKeySizeLimitError                    ErrorCode = 1107
@@ -66,16 +76,20 @@ const (
 	ErrCodeScriptExecutionTimedOutError              ErrorCode = 1113
 
 	// accounts errors 1200 - 1250
-	// ErrCodeAccountError              ErrorCode = 1200 - reserved
-	ErrCodeAccountNotFoundError              ErrorCode = 1201
-	ErrCodeAccountPublicKeyNotFoundError     ErrorCode = 1202
-	ErrCodeAccountAlreadyExistsError         ErrorCode = 1203
-	ErrCodeFrozenAccountError                ErrorCode = 1204
+	// Deprecated: No longer used.
+	ErrCodeAccountError                  ErrorCode = 1200
+	ErrCodeAccountNotFoundError          ErrorCode = 1201
+	ErrCodeAccountPublicKeyNotFoundError ErrorCode = 1202
+	ErrCodeAccountAlreadyExistsError     ErrorCode = 1203
+	ErrCodeFrozenAccountError            ErrorCode = 1204
+	// Deprecated: No longer used.
 	ErrCodeAccountStorageNotInitializedError ErrorCode = 1205
 	ErrCodeAccountPublicKeyLimitError        ErrorCode = 1206
 
 	// contract errors 1250 - 1300
-	// ErrCodeContractError          ErrorCode = 1250 - reserved
-	ErrCodeContractNotFoundError      ErrorCode = 1251
+	// Deprecated: No longer used.
+	ErrCodeContractError         ErrorCode = 1250
+	ErrCodeContractNotFoundError ErrorCode = 1251
+	// Deprecated: No longer used.
 	ErrCodeContractNamesNotFoundError ErrorCode = 1252
 )

--- a/fvm/errors/contracts.go
+++ b/fvm/errors/contracts.go
@@ -13,14 +13,14 @@ type ContractNotFoundError struct {
 }
 
 // NewContractNotFoundError constructs a new ContractNotFoundError
-func NewContractNotFoundError(address flow.Address, contract string) error {
-	return &ContractNotFoundError{
+func NewContractNotFoundError(address flow.Address, contract string) ContractNotFoundError {
+	return ContractNotFoundError{
 		address:  address,
 		contract: contract,
 	}
 }
 
-func (e *ContractNotFoundError) Error() string {
+func (e ContractNotFoundError) Error() string {
 	return fmt.Sprintf(
 		"%s contract %s not found for address %s",
 		e.Code().String(),
@@ -30,31 +30,6 @@ func (e *ContractNotFoundError) Error() string {
 }
 
 // Code returns the error code for this error type
-func (e *ContractNotFoundError) Code() ErrorCode {
+func (e ContractNotFoundError) Code() ErrorCode {
 	return ErrCodeContractNotFoundError
-}
-
-// ContractNamesNotFoundError is returned when fetching a list of contract names under an account
-type ContractNamesNotFoundError struct {
-	address flow.Address
-}
-
-// NewContractNamesNotFoundError constructs a new ContractNamesNotFoundError
-func NewContractNamesNotFoundError(address flow.Address) error {
-	return &ContractNamesNotFoundError{
-		address: address,
-	}
-}
-
-func (e *ContractNamesNotFoundError) Error() string {
-	return fmt.Sprintf(
-		"%s cannot retrieve current contract names for account %s",
-		e.Code().String(),
-		e.address,
-	)
-}
-
-// Code returns the error code for this error type
-func (e *ContractNamesNotFoundError) Code() ErrorCode {
-	return ErrCodeContractNamesNotFoundError
 }

--- a/fvm/errors/errors.go
+++ b/fvm/errors/errors.go
@@ -28,6 +28,14 @@ type Failure interface {
 	error
 }
 
+type errorWrapper struct {
+	err error
+}
+
+func (e errorWrapper) Unwrap() error {
+	return e.err
+}
+
 // Is is a utility function to call std error lib `Is` function for instance equality checks.
 func Is(err error, target error) bool {
 	return stdErrors.Is(err, target)
@@ -87,5 +95,5 @@ func HandleRuntimeError(err error) error {
 	}
 
 	// All other errors are non-fatal Cadence errors.
-	return NewCadenceRuntimeError(&runErr)
+	return NewCadenceRuntimeError(runErr)
 }

--- a/fvm/errors/errors_test.go
+++ b/fvm/errors/errors_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func TestErrorHandling(t *testing.T) {
@@ -12,7 +14,7 @@ func TestErrorHandling(t *testing.T) {
 	t.Run("test nonfatal error detection", func(t *testing.T) {
 		e1 := &OperationNotSupportedError{"some operations"}
 		e2 := fmt.Errorf("some other errors: %w", e1)
-		e3 := &InvalidProposalSignatureError{err: e2}
+		e3 := NewInvalidProposalSignatureError(flow.EmptyAddress, 0, e2)
 
 		txErr, vmErr := SplitErrorTypes(e3)
 		require.Nil(t, vmErr)
@@ -21,9 +23,9 @@ func TestErrorHandling(t *testing.T) {
 
 	t.Run("test fatal error detection", func(t *testing.T) {
 		e1 := &OperationNotSupportedError{"some operations"}
-		e2 := &LedgerFailure{e1}
+		e2 := NewLedgerFailure(e1)
 		e3 := fmt.Errorf("some other errors: %w", e2)
-		e4 := &InvalidProposalSignatureError{err: e3}
+		e4 := NewInvalidProposalSignatureError(flow.EmptyAddress, 0, e3)
 
 		txErr, vmErr := SplitErrorTypes(e4)
 		require.Nil(t, txErr)

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/onflow/cadence/runtime"
-	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -27,19 +26,18 @@ type ExecutionError interface {
 // DestroyedCompositeError,  ForceAssignmentToNonNilResourceError, ForceNilError,
 // TypeMismatchError, InvalidPathDomainError, OverwriteError, CyclicLinkError,
 // ArrayIndexOutOfBoundsError, ...
+// The Cadence error might have occurred because of an inner fvm Error.
 type CadenceRuntimeError struct {
-	err *runtime.Error
+	errorWrapper
 }
 
 // NewCadenceRuntimeError constructs a new CadenceRuntimeError and wraps a cadence runtime error
-func NewCadenceRuntimeError(err *runtime.Error) *CadenceRuntimeError {
-	return &CadenceRuntimeError{err: err}
-}
-
-// IsCadenceRuntimeError returns true if error has this type
-func IsCadenceRuntimeError(err error) bool {
-	var t *CadenceRuntimeError
-	return errors.As(err, &t)
+func NewCadenceRuntimeError(err runtime.Error) CadenceRuntimeError {
+	return CadenceRuntimeError{
+		errorWrapper: errorWrapper{
+			err: err,
+		},
+	}
 }
 
 func (e CadenceRuntimeError) Error() string {
@@ -51,23 +49,21 @@ func (e CadenceRuntimeError) Code() ErrorCode {
 	return ErrCodeCadenceRunTimeError
 }
 
-// Unwrap returns the wrapped err
-func (e CadenceRuntimeError) Unwrap() error {
-	return e.err
-}
-
 // An TransactionFeeDeductionFailedError indicates that a there was an error deducting transaction fees from the transaction Payer
 type TransactionFeeDeductionFailedError struct {
+	errorWrapper
+
 	Payer  flow.Address
 	TxFees uint64
-	err    error
 }
 
 // NewTransactionFeeDeductionFailedError constructs a new TransactionFeeDeductionFailedError
-func NewTransactionFeeDeductionFailedError(payer flow.Address, err error) *TransactionFeeDeductionFailedError {
-	return &TransactionFeeDeductionFailedError{
+func NewTransactionFeeDeductionFailedError(payer flow.Address, err error) TransactionFeeDeductionFailedError {
+	return TransactionFeeDeductionFailedError{
 		Payer: payer,
-		err:   err,
+		errorWrapper: errorWrapper{
+			err: err,
+		},
 	}
 }
 
@@ -80,19 +76,14 @@ func (e TransactionFeeDeductionFailedError) Code() ErrorCode {
 	return ErrCodeTransactionFeeDeductionFailedError
 }
 
-// Unwrap returns the wrapped err
-func (e TransactionFeeDeductionFailedError) Unwrap() error {
-	return e.err
-}
-
 // An ComputationLimitExceededError indicates that computation has exceeded its limit.
 type ComputationLimitExceededError struct {
 	limit uint64
 }
 
 // NewComputationLimitExceededError constructs a new ComputationLimitExceededError
-func NewComputationLimitExceededError(limit uint64) *ComputationLimitExceededError {
-	return &ComputationLimitExceededError{
+func NewComputationLimitExceededError(limit uint64) ComputationLimitExceededError {
+	return ComputationLimitExceededError{
 		limit: limit,
 	}
 }
@@ -112,7 +103,7 @@ func (e ComputationLimitExceededError) Error() string {
 
 // IsComputationLimitExceededError returns true if error has this type
 func IsComputationLimitExceededError(err error) bool {
-	var t *ComputationLimitExceededError
+	var t ComputationLimitExceededError
 	return errors.As(err, &t)
 }
 
@@ -122,8 +113,8 @@ type MemoryLimitExceededError struct {
 }
 
 // NewMemoryLimitExceededError constructs a new MemoryLimitExceededError
-func NewMemoryLimitExceededError(limit uint64) *MemoryLimitExceededError {
-	return &MemoryLimitExceededError{
+func NewMemoryLimitExceededError(limit uint64) MemoryLimitExceededError {
+	return MemoryLimitExceededError{
 		limit: limit,
 	}
 }
@@ -143,7 +134,7 @@ func (e MemoryLimitExceededError) Error() string {
 
 // IsMemoryLimitExceededError returns true if error has this type
 func IsMemoryLimitExceededError(err error) bool {
-	var t *MemoryLimitExceededError
+	var t MemoryLimitExceededError
 	return errors.As(err, &t)
 }
 
@@ -155,8 +146,8 @@ type StorageCapacityExceededError struct {
 }
 
 // NewStorageCapacityExceededError constructs a new StorageCapacityExceededError
-func NewStorageCapacityExceededError(address flow.Address, storageUsed, storageCapacity uint64) *StorageCapacityExceededError {
-	return &StorageCapacityExceededError{
+func NewStorageCapacityExceededError(address flow.Address, storageUsed, storageCapacity uint64) StorageCapacityExceededError {
+	return StorageCapacityExceededError{
 		address:         address,
 		storageUsed:     storageUsed,
 		storageCapacity: storageCapacity,
@@ -179,8 +170,11 @@ type EventLimitExceededError struct {
 }
 
 // NewEventLimitExceededError constructs a EventLimitExceededError
-func NewEventLimitExceededError(totalByteSize, limit uint64) *EventLimitExceededError {
-	return &EventLimitExceededError{totalByteSize: totalByteSize, limit: limit}
+func NewEventLimitExceededError(totalByteSize, limit uint64) EventLimitExceededError {
+	return EventLimitExceededError{
+		totalByteSize: totalByteSize,
+		limit:         limit,
+	}
 }
 
 func (e EventLimitExceededError) Error() string {
@@ -206,8 +200,13 @@ type StateKeySizeLimitError struct {
 }
 
 // NewStateKeySizeLimitError constructs a StateKeySizeLimitError
-func NewStateKeySizeLimitError(owner, key string, size, limit uint64) *StateKeySizeLimitError {
-	return &StateKeySizeLimitError{owner: owner, key: key, size: size, limit: limit}
+func NewStateKeySizeLimitError(owner, key string, size, limit uint64) StateKeySizeLimitError {
+	return StateKeySizeLimitError{
+		owner: owner,
+		key:   key,
+		size:  size,
+		limit: limit,
+	}
 }
 
 func (e StateKeySizeLimitError) Error() string {
@@ -227,8 +226,12 @@ type StateValueSizeLimitError struct {
 }
 
 // NewStateValueSizeLimitError constructs a StateValueSizeLimitError
-func NewStateValueSizeLimitError(value flow.RegisterValue, size, limit uint64) *StateValueSizeLimitError {
-	return &StateValueSizeLimitError{value: value, size: size, limit: limit}
+func NewStateValueSizeLimitError(value flow.RegisterValue, size, limit uint64) StateValueSizeLimitError {
+	return StateValueSizeLimitError{
+		value: value,
+		size:  size,
+		limit: limit,
+	}
 }
 
 func (e StateValueSizeLimitError) Error() string {
@@ -248,16 +251,19 @@ type LedgerInteractionLimitExceededError struct {
 }
 
 // NewLedgerInteractionLimitExceededError constructs a LedgerInteractionLimitExceededError
-func NewLedgerInteractionLimitExceededError(used, limit uint64) *LedgerInteractionLimitExceededError {
-	return &LedgerInteractionLimitExceededError{used: used, limit: limit}
+func NewLedgerInteractionLimitExceededError(used, limit uint64) LedgerInteractionLimitExceededError {
+	return LedgerInteractionLimitExceededError{
+		used:  used,
+		limit: limit,
+	}
 }
 
-func (e *LedgerInteractionLimitExceededError) Error() string {
+func (e LedgerInteractionLimitExceededError) Error() string {
 	return fmt.Sprintf("%s max interaction with storage has exceeded the limit (used: %d bytes, limit %d bytes)", e.Code().String(), e.used, e.limit)
 }
 
 // Code returns the error code for this error
-func (e *LedgerInteractionLimitExceededError) Code() ErrorCode {
+func (e LedgerInteractionLimitExceededError) Code() ErrorCode {
 	return ErrCodeLedgerInteractionLimitExceededError
 }
 
@@ -268,43 +274,19 @@ type OperationNotSupportedError struct {
 }
 
 // NewOperationNotSupportedError construct a new OperationNotSupportedError
-func NewOperationNotSupportedError(operation string) *OperationNotSupportedError {
-	return &OperationNotSupportedError{operation: operation}
+func NewOperationNotSupportedError(operation string) OperationNotSupportedError {
+	return OperationNotSupportedError{
+		operation: operation,
+	}
 }
 
-func (e *OperationNotSupportedError) Error() string {
+func (e OperationNotSupportedError) Error() string {
 	return fmt.Sprintf("%s operation (%s) is not supported in this environment", e.Code().String(), e.operation)
 }
 
 // Code returns the error code for this error
-func (e *OperationNotSupportedError) Code() ErrorCode {
+func (e OperationNotSupportedError) Code() ErrorCode {
 	return ErrCodeOperationNotSupportedError
-}
-
-// EncodingUnsupportedValueError indicates that Cadence attempted
-// to encode a value that is not supported.
-type EncodingUnsupportedValueError struct {
-	value interpreter.Value
-	path  []string
-}
-
-// NewEncodingUnsupportedValueError construct a new EncodingUnsupportedValueError
-func NewEncodingUnsupportedValueError(value interpreter.Value, path []string) *EncodingUnsupportedValueError {
-	return &EncodingUnsupportedValueError{value: value, path: path}
-}
-
-func (e *EncodingUnsupportedValueError) Error() string {
-	return fmt.Sprintf(
-		"%s encoding unsupported value to path [%s]: %[1]T, %[1]v",
-		e.Code().String(),
-		strings.Join(e.path, ","),
-		e.value,
-	)
-}
-
-// Code returns the error code for this error
-func (e *EncodingUnsupportedValueError) Code() ErrorCode {
-	return ErrCodeEncodingUnsupportedValue
 }
 
 // ScriptExecutionCancelledError indicates that Cadence Script execution
@@ -313,15 +295,19 @@ func (e *EncodingUnsupportedValueError) Code() ErrorCode {
 // note: this error is used by scripts only and
 // won't be emitted for transactions since transaction execution has to be deterministic.
 type ScriptExecutionCancelledError struct {
-	err error
+	errorWrapper
 }
 
 // NewScriptExecutionCancelledError construct a new ScriptExecutionCancelledError
-func NewScriptExecutionCancelledError(err error) *ScriptExecutionCancelledError {
-	return &ScriptExecutionCancelledError{err: err}
+func NewScriptExecutionCancelledError(err error) ScriptExecutionCancelledError {
+	return ScriptExecutionCancelledError{
+		errorWrapper: errorWrapper{
+			err: err,
+		},
+	}
 }
 
-func (e *ScriptExecutionCancelledError) Error() string {
+func (e ScriptExecutionCancelledError) Error() string {
 	return fmt.Sprintf(
 		"%s script execution is cancelled: %s",
 		e.Code().String(),
@@ -330,7 +316,7 @@ func (e *ScriptExecutionCancelledError) Error() string {
 }
 
 // Code returns the error code for this error
-func (e *ScriptExecutionCancelledError) Code() ErrorCode {
+func (e ScriptExecutionCancelledError) Code() ErrorCode {
 	return ErrCodeScriptExecutionCancelledError
 }
 
@@ -343,11 +329,11 @@ type ScriptExecutionTimedOutError struct {
 }
 
 // NewScriptExecutionTimedOutError construct a new ScriptExecutionTimedOutError
-func NewScriptExecutionTimedOutError() *ScriptExecutionTimedOutError {
-	return &ScriptExecutionTimedOutError{}
+func NewScriptExecutionTimedOutError() ScriptExecutionTimedOutError {
+	return ScriptExecutionTimedOutError{}
 }
 
-func (e *ScriptExecutionTimedOutError) Error() string {
+func (e ScriptExecutionTimedOutError) Error() string {
 	return fmt.Sprintf(
 		"%s script execution is timed out and did not finish executing within the maximum execution time allowed",
 		e.Code().String(),
@@ -355,7 +341,7 @@ func (e *ScriptExecutionTimedOutError) Error() string {
 }
 
 // Code returns the error code for this error
-func (e *ScriptExecutionTimedOutError) Code() ErrorCode {
+func (e ScriptExecutionTimedOutError) Code() ErrorCode {
 	return ErrCodeScriptExecutionTimedOutError
 }
 
@@ -366,8 +352,8 @@ type CouldNotGetExecutionParameterFromStateError struct {
 }
 
 // NewCouldNotGetExecutionParameterFromStateError constructs a new CouldNotGetExecutionParameterFromStateError
-func NewCouldNotGetExecutionParameterFromStateError(address, path string) *CouldNotGetExecutionParameterFromStateError {
-	return &CouldNotGetExecutionParameterFromStateError{
+func NewCouldNotGetExecutionParameterFromStateError(address, path string) CouldNotGetExecutionParameterFromStateError {
+	return CouldNotGetExecutionParameterFromStateError{
 		address: address,
 		path:    path,
 	}
@@ -385,10 +371,4 @@ func (e CouldNotGetExecutionParameterFromStateError) Error() string {
 		e.address,
 		e.path,
 	)
-}
-
-// IsCouldNotGetExecutionParameterFromStateError returns true if error has this type
-func IsCouldNotGetExecutionParameterFromStateError(err error) bool {
-	var t *CouldNotGetExecutionParameterFromStateError
-	return errors.As(err, &t)
 }

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -7,92 +7,83 @@ import (
 
 // UnknownFailure captures an unknown vm fatal error
 type UnknownFailure struct {
-	err error
+	errorWrapper
 }
 
 // NewUnknownFailure constructs a new UnknownFailure
-func NewUnknownFailure(err error) *UnknownFailure {
-	return &UnknownFailure{err: err}
+func NewUnknownFailure(err error) UnknownFailure {
+	return UnknownFailure{
+		errorWrapper: errorWrapper{err: err},
+	}
 }
 
-func (e *UnknownFailure) Error() string {
+func (e UnknownFailure) Error() string {
 	return fmt.Sprintf("%s unknown failure: %s", e.FailureCode().String(), e.err.Error())
 }
 
 // FailureCode returns the failure code
-func (e *UnknownFailure) FailureCode() FailureCode {
+func (e UnknownFailure) FailureCode() FailureCode {
 	return FailureCodeUnknownFailure
-}
-
-// Unwrap unwraps the error
-func (e UnknownFailure) Unwrap() error {
-	return e.err
 }
 
 // EncodingFailure captures an fatal error sourced from encoding issues
 type EncodingFailure struct {
-	err error
+	errorWrapper
 }
 
 // NewEncodingFailuref formats and returns a new EncodingFailure
-func NewEncodingFailuref(msg string, err error) *EncodingFailure {
-	return &EncodingFailure{
-		err: fmt.Errorf(msg, err),
+func NewEncodingFailuref(msg string, err error) EncodingFailure {
+	return EncodingFailure{
+		errorWrapper: errorWrapper{err: fmt.Errorf(msg, err)},
 	}
 }
 
-func (e *EncodingFailure) Error() string {
+func (e EncodingFailure) Error() string {
 	return fmt.Sprintf("%s encoding failed: %s", e.FailureCode().String(), e.err.Error())
 }
 
 // FailureCode returns the failure code
-func (e *EncodingFailure) FailureCode() FailureCode {
+func (e EncodingFailure) FailureCode() FailureCode {
 	return FailureCodeEncodingFailure
-}
-
-// Unwrap unwraps the error
-func (e EncodingFailure) Unwrap() error {
-	return e.err
 }
 
 // LedgerFailure captures a fatal error cause by ledger failures
 type LedgerFailure struct {
-	err error
+	errorWrapper
 }
 
 // NewLedgerFailure constructs a new LedgerFailure
-func NewLedgerFailure(err error) *LedgerFailure {
-	return &LedgerFailure{err: err}
+func NewLedgerFailure(err error) LedgerFailure {
+	return LedgerFailure{
+		errorWrapper: errorWrapper{err: err},
+	}
 }
 
-func (e *LedgerFailure) Error() string {
+func (e LedgerFailure) Error() string {
 	return fmt.Sprintf("%s ledger returns unsuccessful: %s", e.FailureCode().String(), e.err.Error())
 }
 
 // FailureCode returns the failure code
-func (e *LedgerFailure) FailureCode() FailureCode {
+func (e LedgerFailure) FailureCode() FailureCode {
 	return FailureCodeLedgerFailure
-}
-
-// Unwrap unwraps the error
-func (e LedgerFailure) Unwrap() error {
-	return e.err
 }
 
 // IsALedgerFailure returns true if the error or any of the wrapped errors is a ledger failure
 func IsALedgerFailure(err error) bool {
-	var t *LedgerFailure
+	var t LedgerFailure
 	return errors.As(err, &t)
 }
 
 // StateMergeFailure captures a fatal caused by state merge
 type StateMergeFailure struct {
-	err error
+	errorWrapper
 }
 
 // NewStateMergeFailure constructs a new StateMergeFailure
-func NewStateMergeFailure(err error) *StateMergeFailure {
-	return &StateMergeFailure{err: err}
+func NewStateMergeFailure(err error) StateMergeFailure {
+	return StateMergeFailure{
+		errorWrapper: errorWrapper{err: err},
+	}
 }
 
 func (e StateMergeFailure) Error() string {
@@ -104,19 +95,16 @@ func (e StateMergeFailure) FailureCode() FailureCode {
 	return FailureCodeStateMergeFailure
 }
 
-// Unwrap unwraps the error
-func (e StateMergeFailure) Unwrap() error {
-	return e.err
-}
-
 // BlockFinderFailure captures a fatal caused by block finder
 type BlockFinderFailure struct {
-	err error
+	errorWrapper
 }
 
 // NewBlockFinderFailure constructs a new BlockFinderFailure
-func NewBlockFinderFailure(err error) *BlockFinderFailure {
-	return &BlockFinderFailure{err: err}
+func NewBlockFinderFailure(err error) BlockFinderFailure {
+	return BlockFinderFailure{
+		errorWrapper: errorWrapper{err: err},
+	}
 }
 
 func (e BlockFinderFailure) Error() string {
@@ -126,57 +114,4 @@ func (e BlockFinderFailure) Error() string {
 // FailureCode returns the failure code
 func (e BlockFinderFailure) FailureCode() FailureCode {
 	return FailureCodeBlockFinderFailure
-}
-
-// Unwrap unwraps the error
-func (e BlockFinderFailure) Unwrap() error {
-	return e.err
-}
-
-// HasherFailure captures a fatal caused by hasher
-type HasherFailure struct {
-	err error
-}
-
-// NewHasherFailuref constructs a new hasherFailure
-func NewHasherFailuref(msg string, args ...interface{}) *HasherFailure {
-	return &HasherFailure{err: fmt.Errorf(msg, args...)}
-}
-
-func (e HasherFailure) Error() string {
-	return fmt.Sprintf("%s hasher failed: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e HasherFailure) FailureCode() FailureCode {
-	return FailureCodeHasherFailure
-}
-
-// Unwrap unwraps the error
-func (e HasherFailure) Unwrap() error {
-	return e.err
-}
-
-// MetaTransactionFailure captures a fatal caused by invoking a meta transaction
-type MetaTransactionFailure struct {
-	err error
-}
-
-// NewMetaTransactionFailuref constructs a new hasherFailure
-func NewMetaTransactionFailuref(msg string, args ...interface{}) *MetaTransactionFailure {
-	return &MetaTransactionFailure{err: fmt.Errorf(msg, args...)}
-}
-
-func (e MetaTransactionFailure) Error() string {
-	return fmt.Sprintf("%s meta transaction failed: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e MetaTransactionFailure) FailureCode() FailureCode {
-	return FailureCodeMetaTransactionFailure
-}
-
-// Unwrap unwraps the error
-func (e MetaTransactionFailure) Unwrap() error {
-	return e.err
 }

--- a/fvm/errors/txVerifier.go
+++ b/fvm/errors/txVerifier.go
@@ -6,129 +6,23 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// InvalidTxByteSizeError indicates that a transaction byte size exceeds the maximum limit.
-// this error is the result of failure in any of the following conditions:
-// - the total tx byte size is bigger than the limit set by the network
-type InvalidTxByteSizeError struct {
-	txByteSize uint64
-	maximum    uint64
-}
-
-// NewInvalidTxByteSizeError constructs a new InvalidTxByteSizeError
-func NewInvalidTxByteSizeError(txByteSize, maximum uint64) *InvalidTxByteSizeError {
-	return &InvalidTxByteSizeError{txByteSize: txByteSize, maximum: maximum}
-}
-
-func (e InvalidTxByteSizeError) Error() string {
-	return fmt.Sprintf("%s transaction byte size (%d) exceeds the maximum byte size allowed for a transaction (%d)", e.Code().String(), e.txByteSize, e.maximum)
-}
-
-// Code returns the error code for this error type
-func (e InvalidTxByteSizeError) Code() ErrorCode {
-	return ErrCodeInvalidTxByteSizeError
-}
-
-// InvalidReferenceBlockError indicates that the transaction's ReferenceBlockID is not acceptable.
-// this error is the result of failure in any of the following conditions:
-// - ReferenceBlockID refer to a non-existing block
-// - ReferenceBlockID == ZeroID (if configured by the network)
-type InvalidReferenceBlockError struct {
-	referenceBlockID string
-}
-
-// NewInvalidReferenceBlockError constructs a new InvalidReferenceBlockError
-func NewInvalidReferenceBlockError(referenceBlockID string) *InvalidReferenceBlockError {
-	return &InvalidReferenceBlockError{referenceBlockID: referenceBlockID}
-}
-
-func (e InvalidReferenceBlockError) Error() string {
-	return fmt.Sprintf("%s reference block is pointing to an invalid block: %s", e.Code().String(), e.referenceBlockID)
-}
-
-// Code returns the error code for this error type
-func (e InvalidReferenceBlockError) Code() ErrorCode {
-	return ErrCodeInvalidReferenceBlockError
-}
-
-// ExpiredTransactionError indicates that a transaction has expired.
-// this error is the result of failure in any of the following conditions:
-// - ReferenceBlock.Height - CurrentBlock.Height < Expiry Limit (Transaction is Expired)
-type ExpiredTransactionError struct {
-	refHeight, finalHeight uint64
-}
-
-// NewExpiredTransactionError constructs a new ExpiredTransactionError
-func NewExpiredTransactionError(refHeight, finalHeight uint64) *ExpiredTransactionError {
-	return &ExpiredTransactionError{refHeight: refHeight, finalHeight: finalHeight}
-}
-
-func (e ExpiredTransactionError) Error() string {
-	return fmt.Sprintf("%s transaction is expired: ref_height=%d final_height=%d", e.Code().String(), e.refHeight, e.finalHeight)
-}
-
-// Code returns the error code for this error type
-func (e ExpiredTransactionError) Code() ErrorCode {
-	return ErrCodeInvalidReferenceBlockError
-}
-
-// InvalidScriptError indicates that a transaction contains an invalid Cadence script.
-// this error is the result of failure in any of the following conditions:
-// - script is empty
-// - script can not be parsed by the cadence parser
-// - comment-only script, len(program.Declarations) == 0
-type InvalidScriptError struct {
-	err error
-}
-
-// NewInvalidScriptError constructs a new InvalidScriptError
-func NewInvalidScriptError(err error) *InvalidScriptError {
-	return &InvalidScriptError{err: err}
-}
-
-func (e InvalidScriptError) Error() string {
-	return fmt.Sprintf("%s failed to parse transaction Cadence script: %s", e.Code().String(), e.err.Error())
-}
-
-// Code returns the error code for this error type
-func (e InvalidScriptError) Code() ErrorCode {
-	return ErrCodeInvalidScriptError
-}
-
-// Unwrap unwraps the error
-func (e InvalidScriptError) Unwrap() error {
-	return e.err
-}
-
-// InvalidGasLimitError indicates that a transaction specifies a gas limit that exceeds the maximum allowed by the network.
-type InvalidGasLimitError struct {
-	actual  uint64
-	maximum uint64
-}
-
-// NewInvalidGasLimitError constructs a new InvalidGasLimitError
-func NewInvalidGasLimitError(actual, maximum uint64) *InvalidGasLimitError {
-	return &InvalidGasLimitError{actual: actual, maximum: maximum}
-}
-
-func (e InvalidGasLimitError) Error() string {
-	return fmt.Sprintf("%s transaction gas limit (%d) exceeds the maximum gas limit (%d)", e.Code().String(), e.actual, e.maximum)
-}
-
-// Code returns the error code for this error type
-func (e InvalidGasLimitError) Code() ErrorCode {
-	return ErrCodeInvalidGasLimitError
-}
-
 // InvalidProposalSignatureError indicates that no valid signature is provided for the proposal key.
 type InvalidProposalSignatureError struct {
+	errorWrapper
+
 	address  flow.Address
 	keyIndex uint64
-	err      error
 }
 
 // NewInvalidProposalSignatureError constructs a new InvalidProposalSignatureError
-func NewInvalidProposalSignatureError(address flow.Address, keyIndex uint64, err error) *InvalidProposalSignatureError {
-	return &InvalidProposalSignatureError{address: address, keyIndex: keyIndex, err: err}
+func NewInvalidProposalSignatureError(address flow.Address, keyIndex uint64, err error) InvalidProposalSignatureError {
+	return InvalidProposalSignatureError{
+		address:  address,
+		keyIndex: keyIndex,
+		errorWrapper: errorWrapper{
+			err: err,
+		},
+	}
 }
 
 func (e InvalidProposalSignatureError) Error() string {
@@ -146,11 +40,6 @@ func (e InvalidProposalSignatureError) Code() ErrorCode {
 	return ErrCodeInvalidProposalSignatureError
 }
 
-// Unwrap unwraps the error
-func (e InvalidProposalSignatureError) Unwrap() error {
-	return e.err
-}
-
 // InvalidProposalSeqNumberError indicates that proposal key sequence number does not match the on-chain value.
 type InvalidProposalSeqNumberError struct {
 	address           flow.Address
@@ -160,8 +49,8 @@ type InvalidProposalSeqNumberError struct {
 }
 
 // NewInvalidProposalSeqNumberError constructs a new InvalidProposalSeqNumberError
-func NewInvalidProposalSeqNumberError(address flow.Address, keyIndex uint64, currentSeqNumber uint64, providedSeqNumber uint64) *InvalidProposalSeqNumberError {
-	return &InvalidProposalSeqNumberError{address: address,
+func NewInvalidProposalSeqNumberError(address flow.Address, keyIndex uint64, currentSeqNumber uint64, providedSeqNumber uint64) InvalidProposalSeqNumberError {
+	return InvalidProposalSeqNumberError{address: address,
 		keyIndex:          keyIndex,
 		currentSeqNumber:  currentSeqNumber,
 		providedSeqNumber: providedSeqNumber}
@@ -199,14 +88,21 @@ func (e InvalidProposalSeqNumberError) Code() ErrorCode {
 // - signature size or format is invalid
 // - signature verification failed
 type InvalidPayloadSignatureError struct {
+	errorWrapper
+
 	address  flow.Address
 	keyIndex uint64
-	err      error
 }
 
 // NewInvalidPayloadSignatureError constructs a new InvalidPayloadSignatureError
-func NewInvalidPayloadSignatureError(address flow.Address, keyIndex uint64, err error) *InvalidPayloadSignatureError {
-	return &InvalidPayloadSignatureError{address: address, keyIndex: keyIndex, err: err}
+func NewInvalidPayloadSignatureError(address flow.Address, keyIndex uint64, err error) InvalidPayloadSignatureError {
+	return InvalidPayloadSignatureError{
+		address:  address,
+		keyIndex: keyIndex,
+		errorWrapper: errorWrapper{
+			err: err,
+		},
+	}
 }
 
 func (e InvalidPayloadSignatureError) Error() string {
@@ -224,25 +120,27 @@ func (e InvalidPayloadSignatureError) Code() ErrorCode {
 	return ErrCodeInvalidPayloadSignatureError
 }
 
-// Unwrap unwraps the error
-func (e InvalidPayloadSignatureError) Unwrap() error {
-	return e.err
-}
-
 // InvalidEnvelopeSignatureError indicates that signature verification for a envelope key in this transaction has failed.
 // this error is the result of failure in any of the following conditions:
 // - provided hashing method is not supported
 // - signature size or format is invalid
 // - signature verification failed
 type InvalidEnvelopeSignatureError struct {
+	errorWrapper
+
 	address  flow.Address
 	keyIndex uint64
-	err      error
 }
 
 // NewInvalidEnvelopeSignatureError constructs a new InvalidEnvelopeSignatureError
-func NewInvalidEnvelopeSignatureError(address flow.Address, keyIndex uint64, err error) *InvalidEnvelopeSignatureError {
-	return &InvalidEnvelopeSignatureError{address: address, keyIndex: keyIndex, err: err}
+func NewInvalidEnvelopeSignatureError(address flow.Address, keyIndex uint64, err error) InvalidEnvelopeSignatureError {
+	return InvalidEnvelopeSignatureError{
+		address:  address,
+		keyIndex: keyIndex,
+		errorWrapper: errorWrapper{
+			err: err,
+		},
+	}
 }
 
 func (e InvalidEnvelopeSignatureError) Error() string {
@@ -258,9 +156,4 @@ func (e InvalidEnvelopeSignatureError) Error() string {
 // Code returns the error code for this error type
 func (e InvalidEnvelopeSignatureError) Code() ErrorCode {
 	return ErrCodeInvalidEnvelopeSignatureError
-}
-
-// Unwrap unwraps the error
-func (e InvalidEnvelopeSignatureError) Unwrap() error {
-	return e.err
 }

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1061,7 +1061,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 		run(
 			func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
 				ctx.MaxStateInteractionSize = 500_000
-				//ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
+				// ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
 
 				// Create an account private key.
 				privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
@@ -1102,7 +1102,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 		run(
 			func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.Programs) {
 				ctx.MaxStateInteractionSize = 500_000
-				//ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
+				// ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
 
 				// Create an account private key.
 				privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
@@ -1769,8 +1769,8 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
-				require.Equal(t, (&errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())
-				require.Equal(t, uint64(0), tx.Err.(*errors.InvalidProposalSeqNumberError).CurrentSeqNumber())
+				require.Equal(t, (errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())
+				require.Equal(t, uint64(0), tx.Err.(errors.InvalidProposalSeqNumberError).CurrentSeqNumber())
 			}),
 	)
 
@@ -1807,7 +1807,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
-				require.IsType(t, &errors.CadenceRuntimeError{}, tx.Err)
+				require.IsType(t, errors.CadenceRuntimeError{}, tx.Err)
 
 				// send it again
 				tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
@@ -1815,8 +1815,8 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
-				require.Equal(t, (&errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())
-				require.Equal(t, uint64(1), tx.Err.(*errors.InvalidProposalSeqNumberError).CurrentSeqNumber())
+				require.Equal(t, (errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())
+				require.Equal(t, uint64(1), tx.Err.(errors.InvalidProposalSeqNumberError).CurrentSeqNumber())
 			}),
 	)
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -725,7 +725,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			tryToTransfer: transferAmount,
 			checkResult: func(t *testing.T, balanceBefore uint64, balanceAfter uint64, tx *fvm.TransactionProcedure) {
 				require.NoError(t, tx.Err)
-				var feeDeduction flow.Event //fee deduction event
+				var feeDeduction flow.Event // fee deduction event
 				for _, e := range tx.Events {
 					if string(e.Type) == fmt.Sprintf("A.%s.FlowFees.FeesDeducted", environment.FlowFeesAddress(flow.Testnet.Chain())) {
 						feeDeduction = e
@@ -1243,7 +1243,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			// There are 100 breaks and each break uses 1_000_000 memory
 			require.Greater(t, tx.MemoryEstimate, uint64(100_000_000))
 
-			var memoryLimitExceededError *errors.MemoryLimitExceededError
+			var memoryLimitExceededError errors.MemoryLimitExceededError
 			assert.ErrorAs(t, tx.Err, &memoryLimitExceededError)
 		},
 	))
@@ -1720,9 +1720,9 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
+				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
 				// modifications to contracts are not supported in scripts
-				unsupportedOperationError := &errors.OperationNotSupportedError{}
+				unsupportedOperationError := errors.OperationNotSupportedError{}
 				require.ErrorAs(t, script.Err, &unsupportedOperationError)
 			},
 		),
@@ -1779,9 +1779,9 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				err = vm.RunV2(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
+				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
 				// modifications to contracts are not supported in scripts
-				unsupportedOperationError := &errors.OperationNotSupportedError{}
+				unsupportedOperationError := errors.OperationNotSupportedError{}
 				require.ErrorAs(t, script.Err, &unsupportedOperationError)
 			},
 		),
@@ -1837,9 +1837,9 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				err = vm.RunV2(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
+				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
 				// modifications to contracts are not supported in scripts
-				unsupportedOperationError := &errors.OperationNotSupportedError{}
+				unsupportedOperationError := errors.OperationNotSupportedError{}
 				require.ErrorAs(t, script.Err, &unsupportedOperationError)
 			},
 		),
@@ -1885,9 +1885,9 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
+				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
 				// modifications to public keys are not supported in scripts
-				unsupportedOperationError := &errors.OperationNotSupportedError{}
+				unsupportedOperationError := errors.OperationNotSupportedError{}
 				require.ErrorAs(t, script.Err, &unsupportedOperationError)
 			},
 		),
@@ -1921,9 +1921,9 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, &errors.CadenceRuntimeError{}, script.Err)
+				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
 				// modifications to public keys are not supported in scripts
-				unsupportedOperationError := &errors.OperationNotSupportedError{}
+				unsupportedOperationError := errors.OperationNotSupportedError{}
 				require.ErrorAs(t, script.Err, &unsupportedOperationError)
 			},
 		),

--- a/fvm/handler/accountKey_test.go
+++ b/fvm/handler/accountKey_test.go
@@ -52,7 +52,7 @@ func TestAddEncodedAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 	require.Error(t, err)
 
 	err = errors2.Unwrap(err)
-	require.IsType(t, &errors.ValueError{}, err)
+	require.IsType(t, errors.ValueError{}, err)
 
 	errorString := err.Error()
 	assert.True(t, utf8.ValidString(errorString))
@@ -80,7 +80,7 @@ func TestNewAccountKey_error_handling_produces_valid_utf8_and_sign_algo(t *testi
 	_, err := NewAccountPublicKey(publicKey, sema.HashAlgorithmSHA2_384, 0, 0)
 
 	err = errors2.Unwrap(err)
-	require.IsType(t, &errors.ValueError{}, err)
+	require.IsType(t, errors.ValueError{}, err)
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidSignAlgo))
 
@@ -111,7 +111,7 @@ func TestNewAccountKey_error_handling_produces_valid_utf8_and_hash_algo(t *testi
 	_, err := NewAccountPublicKey(publicKey, invalidHashAlgo, 0, 0)
 
 	err = errors2.Unwrap(err)
-	require.IsType(t, &errors.ValueError{}, err)
+	require.IsType(t, errors.ValueError{}, err)
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidHashAlgo))
 
@@ -133,14 +133,14 @@ func TestNewAccountKey_error_handling_produces_valid_utf8_and_hash_algo(t *testi
 func TestNewAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 
 	publicKey := &runtime.PublicKey{
-		PublicKey: []byte{0xc3, 0x28}, //some invalid UTF8
+		PublicKey: []byte{0xc3, 0x28}, // some invalid UTF8
 		SignAlgo:  runtime.SignatureAlgorithmECDSA_P256,
 	}
 
 	_, err := NewAccountPublicKey(publicKey, runtime.HashAlgorithmSHA2_256, 0, 0)
 
 	err = errors2.Unwrap(err)
-	require.IsType(t, &errors.ValueError{}, err)
+	require.IsType(t, errors.ValueError{}, err)
 
 	errorString := err.Error()
 	assert.True(t, utf8.ValidString(errorString))

--- a/fvm/meter/weighted_meter_test.go
+++ b/fvm/meter/weighted_meter_test.go
@@ -57,7 +57,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(10).Error())
+		require.Equal(t, err.(errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(10).Error())
 
 		err = m.MeterMemory(0, 2)
 		require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(10).Error())
+		require.Equal(t, err.(errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(10).Error())
 	})
 
 	t.Run("meter computation and memory with weights", func(t *testing.T) {
@@ -159,7 +159,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(compKind, 0)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.(*errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(9).Error())
+		require.Equal(t, err.(errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(9).Error())
 	})
 
 	t.Run("merge meters - ignore limits", func(t *testing.T) {
@@ -227,7 +227,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 0)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.(*errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
+		require.Equal(t, err.(errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
 	})
 
 	t.Run("add intensity - test limits - computation", func(t *testing.T) {

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -111,7 +111,7 @@ func TestTransactionVerification(t *testing.T) {
 		err = txVerifier.Process(fvm.Context{}, proc, stTxn, nil)
 		require.Error(t, err)
 
-		var envelopeError *errors.InvalidEnvelopeSignatureError
+		var envelopeError errors.InvalidEnvelopeSignatureError
 		require.ErrorAs(t, err, &envelopeError)
 	})
 
@@ -147,7 +147,7 @@ func TestTransactionVerification(t *testing.T) {
 		err = txVerifier.Process(fvm.Context{}, proc, stTxn, nil)
 		require.Error(t, err)
 
-		var payloadError *errors.InvalidPayloadSignatureError
+		var payloadError errors.InvalidPayloadSignatureError
 		require.ErrorAs(t, err, &payloadError)
 	})
 
@@ -181,7 +181,7 @@ func TestTransactionVerification(t *testing.T) {
 		require.Error(t, err)
 
 		// TODO: update to InvalidEnvelopeSignatureError once FVM verifier is updated.
-		var payloadError *errors.InvalidPayloadSignatureError
+		var payloadError errors.InvalidPayloadSignatureError
 		require.ErrorAs(t, err, &payloadError)
 	})
 

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -31,7 +31,7 @@ func makeTwoAccounts(t *testing.T, aPubKeys []flow.AccountPublicKey, bPubKeys []
 	a := flow.HexToAddress("1234")
 	b := flow.HexToAddress("5678")
 
-	//create accounts
+	// create accounts
 	accounts := environment.NewAccounts(stTxn)
 	err := accounts.Create(aPubKeys, a)
 	require.NoError(t, err)
@@ -197,11 +197,11 @@ func TestAccountFreezing(t *testing.T) {
 		require.Error(t, proc.Err)
 
 		// find frozen account specific error
-		require.IsType(t, &errors.CadenceRuntimeError{}, proc.Err)
-		err = proc.Err.(*errors.CadenceRuntimeError).Unwrap()
+		require.IsType(t, errors.CadenceRuntimeError{}, proc.Err)
+		err = proc.Err.(errors.CadenceRuntimeError).Unwrap()
 
-		require.IsType(t, &runtime.Error{}, err)
-		err = err.(*runtime.Error).Err
+		require.IsType(t, runtime.Error{}, err)
+		err = err.(runtime.Error).Err
 
 		require.IsType(t, &runtime.ParsingCheckingError{}, err)
 		err = err.(*runtime.ParsingCheckingError).Err
@@ -215,7 +215,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.IsType(t, &sema.ImportedProgramError{}, checkerErrors[0])
 
 		importedCheckerError := checkerErrors[0].(*sema.ImportedProgramError).Err
-		accountFrozenError := &errors.FrozenAccountError{}
+		accountFrozenError := errors.FrozenAccountError{}
 
 		require.True(t, errors.As(importedCheckerError, &accountFrozenError))
 		require.Equal(t, address, accountFrozenError.Address())
@@ -341,11 +341,11 @@ func TestAccountFreezing(t *testing.T) {
 		require.Error(t, proc.Err)
 
 		// find frozen account specific error
-		require.IsType(t, &errors.CadenceRuntimeError{}, proc.Err)
-		err = proc.Err.(*errors.CadenceRuntimeError).Unwrap()
+		require.IsType(t, errors.CadenceRuntimeError{}, proc.Err)
+		err = proc.Err.(errors.CadenceRuntimeError).Unwrap()
 
-		require.IsType(t, &runtime.Error{}, err)
-		err = err.(*runtime.Error).Err
+		require.IsType(t, runtime.Error{}, err)
+		err = err.(runtime.Error).Err
 
 		require.IsType(t, &runtime.ParsingCheckingError{}, err)
 		err = err.(*runtime.ParsingCheckingError).Err
@@ -359,7 +359,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.IsType(t, &sema.ImportedProgramError{}, checkerErrors[0])
 
 		importedCheckerError := checkerErrors[0].(*sema.ImportedProgramError).Err
-		accountFrozenError := &errors.FrozenAccountError{}
+		accountFrozenError := errors.FrozenAccountError{}
 
 		require.True(t, errors.As(importedCheckerError, &accountFrozenError))
 		require.Equal(t, frozenAddress, accountFrozenError.Address())
@@ -538,8 +538,8 @@ func TestAccountFreezing(t *testing.T) {
 			require.Error(t, frozenProc.Err)
 
 			// find frozen account specific error
-			require.IsType(t, &errors.FrozenAccountError{}, frozenProc.Err)
-			accountFrozenError := frozenProc.Err.(*errors.FrozenAccountError)
+			require.IsType(t, errors.FrozenAccountError{}, frozenProc.Err)
+			accountFrozenError := frozenProc.Err.(errors.FrozenAccountError)
 			require.Equal(t, frozenAddress, accountFrozenError.Address())
 		})
 
@@ -572,8 +572,8 @@ func TestAccountFreezing(t *testing.T) {
 			require.Error(t, frozenProc.Err)
 
 			// find frozen account specific error
-			require.IsType(t, &errors.FrozenAccountError{}, frozenProc.Err)
-			accountFrozenError := frozenProc.Err.(*errors.FrozenAccountError)
+			require.IsType(t, errors.FrozenAccountError{}, frozenProc.Err)
+			accountFrozenError := frozenProc.Err.(errors.FrozenAccountError)
 			require.Equal(t, frozenAddress, accountFrozenError.Address())
 		})
 
@@ -606,8 +606,8 @@ func TestAccountFreezing(t *testing.T) {
 			require.Error(t, frozenProc.Err)
 
 			// find frozen account specific error
-			require.IsType(t, &errors.FrozenAccountError{}, frozenProc.Err)
-			accountFrozenError := frozenProc.Err.(*errors.FrozenAccountError)
+			require.IsType(t, errors.FrozenAccountError{}, frozenProc.Err)
+			accountFrozenError := frozenProc.Err.(errors.FrozenAccountError)
 			require.Equal(t, frozenAddress, accountFrozenError.Address())
 		})
 


### PR DESCRIPTION
Remove unused errors and introduce an `errorWrapper` that provides an Unwrap function to errors, which we were constantly forgetting.

