### PR TITLE
[FVM] Adding IsMemoryLimitSet() to MeterParameters

### DIFF
--- a/fvm/meter/weighted_meter.go
+++ b/fvm/meter/weighted_meter.go
@@ -252,8 +252,9 @@ type MeterParameters struct {
 	computationLimit   uint64
 	computationWeights ExecutionEffortWeights
 
-	memoryLimit   uint64
-	memoryWeights ExecutionMemoryWeights
+	isMemoryLimitSet bool
+	memoryLimit      uint64
+	memoryWeights    ExecutionMemoryWeights
 }
 
 func DefaultParameters() MeterParameters {
@@ -284,6 +285,7 @@ func (params MeterParameters) WithComputationWeights(
 func (params MeterParameters) WithMemoryLimit(limit uint64) MeterParameters {
 	newParams := params
 	newParams.memoryLimit = limit
+	newParams.isMemoryLimitSet = true
 	return newParams
 }
 
@@ -306,6 +308,13 @@ func (params MeterParameters) TotalComputationLimit() uint {
 
 func (params MeterParameters) MemoryWeights() ExecutionMemoryWeights {
 	return params.memoryWeights
+}
+
+// IsMemoryLimitSet returns if memory limit has been set by WithMemoryLimit()
+// It is useful when metering parameters are loaded from state. We need to
+// know if state has this value available to decide whether to override existing value.
+func (params MeterParameters) IsMemoryLimitSet() bool {
+	return params.isMemoryLimitSet
 }
 
 // TotalMemoryLimit returns the total memory limit

--- a/fvm/meter/weighted_meter_test.go
+++ b/fvm/meter/weighted_meter_test.go
@@ -376,3 +376,18 @@ func TestMemoryWeights(t *testing.T) {
 		)
 	}
 }
+
+func TestMeterParameters(t *testing.T) {
+	t.Run("IsMemoryLimitSet return false - without WithMemoryLimit() called", func(t *testing.T) {
+		meterParams := meter.DefaultParameters()
+		require.False(t, meterParams.IsMemoryLimitSet())
+		require.Equal(t, uint64(math.MaxUint64), meterParams.TotalMemoryLimit())
+	})
+
+	t.Run("IsMemoryLimitSet return true - with WithMemoryLimit() called", func(t *testing.T) {
+		testMemoryLimit := uint64(123)
+		meterParams := meter.DefaultParameters().WithMemoryLimit(testMemoryLimit)
+		require.True(t, meterParams.IsMemoryLimitSet())
+		require.Equal(t, testMemoryLimit, meterParams.TotalMemoryLimit())
+	})
+}


### PR DESCRIPTION
For `MeterParameters`, memoryLimit is [overridden](https://github.com/onflow/flow-go/blob/master/fvm/fvm.go#L86) only when state returns valid value ([code](https://github.com/onflow/flow-go/blob/master/fvm/executionParameters.go#L106)).

As a prep work for #3102, we will be moving out state reading for MeterParameters out of `fvm.RunV2()` and will do the read before each collection execution, then passing in the read meter parameters into `fvm.RunV2()`, so if we still want to treat memoryLimit from state as higher priority, we would need to know that with a given MeterParameters obj, if memoryLimit value has been set, as the condition to override existing value from [Procedures](https://github.com/onflow/flow-go/blob/master/fvm/fvm.go#L84).

Adding a new interface to serve this purpose.