### PR TITLE
[Benchmark] Ability to dynamically adjust TPS

### DIFF
--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -168,8 +168,10 @@ func New(
 		lg.workFunc = lg.sendAddKeyTx
 	case ConstExecCostLoadType:
 		lg.workFunc = lg.sendConstExecCostTx
-	default:
+	case CompHeavyLoadType, EventHeavyLoadType, LedgerHeavyLoadType:
 		lg.workFunc = lg.sendFavContractTx
+	default:
+		return nil, fmt.Errorf("unknown load type: %s", loadParams.LoadType)
 	}
 
 	return lg, nil

--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -262,7 +262,6 @@ func (lg *ContLoadGenerator) startWorkers(numWorkers, diff int) {
 		worker.Start()
 		lg.workers = append(lg.workers, worker)
 	}
-	lg.workerStatsTracker.AddWorkers(diff)
 }
 
 func (lg *ContLoadGenerator) stopWorkers(numWorkers, diff int) {
@@ -280,7 +279,6 @@ func (lg *ContLoadGenerator) stopWorkers(numWorkers, diff int) {
 	wg.Wait()
 
 	lg.workers = lg.workers[:start]
-	lg.workerStatsTracker.AddWorkers(-diff)
 }
 
 func (lg *ContLoadGenerator) SetTPS(num uint) error {
@@ -296,6 +294,7 @@ func (lg *ContLoadGenerator) SetTPS(num uint) error {
 	case diff < 0:
 		lg.stopWorkers(numWorkers, -diff)
 	}
+	lg.workerStatsTracker.AddWorkers(diff)
 	return nil
 }
 

--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -281,18 +281,22 @@ func (lg *ContLoadGenerator) stopWorkers(numWorkers, diff int) {
 	lg.workers = lg.workers[:start]
 }
 
-func (lg *ContLoadGenerator) SetTPS(num uint) error {
+// SetTPS compares the given TPS to the current TPS to determine whether to increase
+// or decrease the load.
+// It increases/decreases the load by adjusting the number of workers, since each worker
+// is responsible for sending the load at 1 TPS.
+func (lg *ContLoadGenerator) SetTPS(desired uint) error {
 	lg.mu.Lock()
 	defer lg.mu.Unlock()
 
-	numWorkers := len(lg.workers)
-	diff := int(num) - numWorkers
+	currentTPS := len(lg.workers)
+	diff := int(desired) - currentTPS
 
 	switch {
 	case diff > 0:
-		lg.startWorkers(numWorkers, diff)
+		lg.startWorkers(currentTPS, diff)
 	case diff < 0:
-		lg.stopWorkers(numWorkers, -diff)
+		lg.stopWorkers(currentTPS, -diff)
 	}
 	lg.workerStatsTracker.AddWorkers(diff)
 	return nil

--- a/integration/benchmark/worker.go
+++ b/integration/benchmark/worker.go
@@ -19,10 +19,10 @@ type Worker struct {
 	wg *sync.WaitGroup
 }
 
-func NewWorker(workerID int, interval time.Duration, work workFunc) Worker {
+func NewWorker(workerID int, interval time.Duration, work workFunc) *Worker {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return Worker{
+	return &Worker{
 		workerID: workerID,
 		interval: interval,
 		work:     work,

--- a/integration/benchmark/worker_stats_tracker.go
+++ b/integration/benchmark/worker_stats_tracker.go
@@ -33,7 +33,7 @@ func NewWorkerStatsTracker() *WorkerStatsTracker {
 // StartPrinting starts reporting of worker stats
 func (st *WorkerStatsTracker) StartPrinting(interval time.Duration) {
 	printer := NewWorker(0, interval, func(_ int) { fmt.Println(st.Digest()) })
-	st.printer = &printer
+	st.printer = printer
 	st.printer.Start()
 }
 
@@ -57,11 +57,11 @@ func (st *WorkerStatsTracker) GetTxExecuted() int {
 	return st.stats.txsExecuted
 }
 
-func (st *WorkerStatsTracker) AddWorker() {
+func (st *WorkerStatsTracker) AddWorkers(i int) {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	st.stats.workers++
+	st.stats.workers += i
 }
 
 func (st *WorkerStatsTracker) AddTxSent() {

--- a/integration/benchmark/worker_stats_tracker_test.go
+++ b/integration/benchmark/worker_stats_tracker_test.go
@@ -14,7 +14,7 @@ func TestWorkerStatsTracker(t *testing.T) {
 	st.StartPrinting(time.Second)
 	defer st.StopPrinting()
 
-	st.AddWorker()
+	st.AddWorkers(1)
 
 	startTime := time.Now()
 	endTime := startTime.Add(time.Second)

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -76,7 +76,7 @@ stop:
 
 .PHONY: load
 load:
-	go run --tags relic ../benchmark/cmd/manual -log-level info -tps 1,0,10,0,100 -tps-durations 30s,10s,30s,10s
+	go run --tags relic ../benchmark/cmd/manual -log-level info -tps 1,10,100 -tps-durations 30s,30s
 
 .PHONY: tps-test
 tps-test:

--- a/module/metrics/loader.go
+++ b/module/metrics/loader.go
@@ -48,7 +48,7 @@ func (cc *LoaderCollector) TransactionSent() {
 	cc.transactionsSent.Inc()
 }
 
-func (cc *LoaderCollector) SetTPSConfigured(tps int) {
+func (cc *LoaderCollector) SetTPSConfigured(tps uint) {
 	cc.tpsConfigured.Set(float64(tps))
 }
 


### PR DESCRIPTION
Added `SetTPS` API that can be used to adjust the load on the fly.  Switched `manual` loader to using this instead of re-creating benchmark client on every run.

[It's better to review this PR w/o whitespace](https://github.com/onflow/flow-go/pull/3246/files?diff=split&w=1).