### PR TITLE
[FVM] Replacing existing metering in state.go with new interface

### DIFF
--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -25,10 +25,6 @@ const (
 	KeyContractNames = "contract_names"
 )
 
-type mapKey struct {
-	owner, key string
-}
-
 // State represents the execution state
 // it holds draft of updates and captures
 // all register touches
@@ -36,18 +32,12 @@ type State struct {
 	view             View
 	meter            meter.Meter
 	updatedAddresses map[flow.Address]struct{}
-	updateSize       map[mapKey]uint64
 	stateLimits
-	ReadCounter       uint64
-	WriteCounter      uint64
-	TotalBytesRead    uint64
-	TotalBytesWritten uint64
 }
 
 type stateLimits struct {
-	maxKeySizeAllowed     uint64
-	maxValueSizeAllowed   uint64
-	maxInteractionAllowed uint64
+	maxKeySizeAllowed   uint64
+	maxValueSizeAllowed uint64
 }
 
 type StateParameters struct {
@@ -60,9 +50,8 @@ func DefaultParameters() StateParameters {
 	return StateParameters{
 		MeterParameters: meter.DefaultParameters(),
 		stateLimits: stateLimits{
-			maxKeySizeAllowed:     DefaultMaxKeySize,
-			maxValueSizeAllowed:   DefaultMaxValueSize,
-			maxInteractionAllowed: DefaultMaxInteractionSize,
+			maxKeySizeAllowed:   DefaultMaxKeySize,
+			maxValueSizeAllowed: DefaultMaxValueSize,
 		},
 	}
 }
@@ -93,7 +82,7 @@ func (params StateParameters) WithMaxValueSizeAllowed(limit uint64) StateParamet
 // WithMaxInteractionSizeAllowed sets limit on total byte interaction with ledger
 func (params StateParameters) WithMaxInteractionSizeAllowed(limit uint64) StateParameters {
 	newParams := params
-	newParams.maxInteractionAllowed = limit
+	newParams.MeterParameters = newParams.MeterParameters.WithStorageInteractionLimit(limit)
 	return newParams
 }
 
@@ -114,7 +103,6 @@ func NewState(view View, params StateParameters) *State {
 		view:             view,
 		meter:            m,
 		updatedAddresses: make(map[flow.Address]struct{}),
-		updateSize:       make(map[mapKey]uint64),
 		stateLimits:      params.stateLimits,
 	}
 }
@@ -125,14 +113,13 @@ func (s *State) NewChild() *State {
 		view:             s.view.NewChild(),
 		meter:            s.meter.NewChild(),
 		updatedAddresses: make(map[flow.Address]struct{}),
-		updateSize:       make(map[mapKey]uint64),
 		stateLimits:      s.stateLimits,
 	}
 }
 
 // InteractionUsed returns the amount of ledger interaction (total ledger byte read + total ledger byte written)
 func (s *State) InteractionUsed() uint64 {
-	return s.TotalBytesRead + s.TotalBytesWritten
+	return s.meter.TotalBytesOfStorageInteractions()
 }
 
 // Get returns a register value given owner and key
@@ -153,17 +140,12 @@ func (s *State) Get(owner, key string, enforceLimit bool) (flow.RegisterValue, e
 		return nil, fmt.Errorf("failed to read key %s on account %s: %w", PrintableKey(key), hex.EncodeToString([]byte(owner)), getError)
 	}
 
-	// if not part of recent updates count them as read
-	if _, ok := s.updateSize[mapKey{owner, key}]; !ok {
-		s.ReadCounter++
-		s.TotalBytesRead += uint64(len(owner) + len(key) + len(value))
-	}
+	err = s.meter.MeterStorageRead(
+		meter.StorageInteractionKey{Owner: owner, Key: key},
+		value,
+		enforceLimit)
 
-	if enforceLimit {
-		return value, s.checkMaxInteraction()
-	}
-
-	return value, nil
+	return value, err
 }
 
 // Set updates state delta with a register update
@@ -181,26 +163,18 @@ func (s *State) Set(owner, key string, value flow.RegisterValue, enforceLimit bo
 		return fmt.Errorf("failed to update key %s on account %s: %w", PrintableKey(key), hex.EncodeToString([]byte(owner)), setError)
 	}
 
-	if enforceLimit {
-		if err := s.checkMaxInteraction(); err != nil {
-			return err
-		}
+	err := s.meter.MeterStorageWrite(
+		meter.StorageInteractionKey{Owner: owner, Key: key},
+		value,
+		enforceLimit,
+	)
+	if err != nil {
+		return err
 	}
 
 	if address, isAddress := addressFromOwner(owner); isAddress {
 		s.updatedAddresses[address] = struct{}{}
 	}
-
-	mapKey := mapKey{owner, key}
-	if old, ok := s.updateSize[mapKey]; ok {
-		s.WriteCounter--
-		s.TotalBytesWritten -= old
-	}
-
-	updateSize := uint64(len(owner) + len(key) + len(value))
-	s.WriteCounter++
-	s.TotalBytesWritten += updateSize
-	s.updateSize[mapKey] = updateSize
 
 	return nil
 }
@@ -269,17 +243,6 @@ func (s *State) MergeState(other *State) error {
 		s.updatedAddresses[k] = v
 	}
 
-	// apply update sizes
-	for k, v := range other.updateSize {
-		s.updateSize[k] = v
-	}
-
-	// update ledger interactions
-	s.ReadCounter += other.ReadCounter
-	s.WriteCounter += other.WriteCounter
-	s.TotalBytesRead += other.TotalBytesRead
-	s.TotalBytesWritten += other.TotalBytesWritten
-
 	return nil
 }
 
@@ -302,13 +265,6 @@ func (s *State) UpdatedAddresses() []flow.Address {
 	sort.Sort(addresses)
 
 	return addresses
-}
-
-func (s *State) checkMaxInteraction() error {
-	if s.InteractionUsed() > s.maxInteractionAllowed {
-		return errors.NewLedgerInteractionLimitExceededError(s.InteractionUsed(), s.maxInteractionAllowed)
-	}
-	return nil
 }
 
 func (s *State) checkSize(owner, key string, value flow.RegisterValue) error {

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -92,36 +92,6 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 
 }
 
-func TestState_InteractionMeasuring(t *testing.T) {
-	view := utils.NewSimpleView()
-	st := state.NewState(view, state.DefaultParameters())
-
-	key := "key1"
-	value := createByteArray(1)
-	err := st.Set("address", key, value, true)
-	keySize := uint64(len("address") + len(key))
-	size := keySize + uint64(len(value))
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), st.ReadCounter)
-	require.Equal(t, uint64(0), st.TotalBytesRead)
-	require.Equal(t, uint64(1), st.WriteCounter)
-	require.Equal(t, size, st.TotalBytesWritten)
-
-	// should read from the delta
-	// should not impact totalBytesRead
-	v, err := st.Get("address", key, true)
-	require.NoError(t, err)
-	require.Equal(t, v, value)
-	require.Equal(t, uint64(0), st.TotalBytesRead)
-
-	// non existing key
-	// should be counted towards reading from the ledger
-	key2 := "key2"
-	_, err = st.Get("address", key2, true)
-	require.NoError(t, err)
-	require.Equal(t, keySize, st.TotalBytesRead)
-}
-
 func TestState_MaxValueSize(t *testing.T) {
 	view := utils.NewSimpleView()
 	st := state.NewState(view, state.DefaultParameters().WithMaxValueSizeAllowed(6))


### PR DESCRIPTION
It replaces existing storage metering functions in state.go with the new interface from #3236 