### PR TITLE
Add CodedError / CodedFailure to the errors package

### DIFF
--- a/fvm/errors/accounts.go
+++ b/fvm/errors/accounts.go
@@ -7,35 +7,16 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// AccountNotFoundError is returned when account doesn't exist for the given address
-type AccountNotFoundError struct {
-	address flow.Address
-}
-
-// NewAccountNotFoundError constructs a new AccountNotFoundError
-func NewAccountNotFoundError(address flow.Address) AccountNotFoundError {
-	return AccountNotFoundError{
-		address: address,
-	}
-}
-
-func (e AccountNotFoundError) Error() string {
-	return fmt.Sprintf(
-		"%s account not found for address %s",
-		e.Code().String(),
-		e.address.String(),
-	)
-}
-
-// Code returns the error code for this error type
-func (e AccountNotFoundError) Code() ErrorCode {
-	return ErrCodeAccountNotFoundError
+func NewAccountNotFoundError(address flow.Address) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountNotFoundError,
+		"account not found for address %s",
+		address.String())
 }
 
 // IsAccountNotFoundError returns true if error has this type
 func IsAccountNotFoundError(err error) bool {
-	var t AccountNotFoundError
-	return errors.As(err, &t)
+	return HasErrorCode(err, ErrCodeAccountNotFoundError)
 }
 
 // AccountAlreadyExistsError is returned when account creation fails because

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -4,26 +4,27 @@ import "fmt"
 
 type ErrorCode uint16
 
+func (ec ErrorCode) IsFailure() bool {
+	return ec >= FailureCodeUnknownFailure
+}
+
 func (ec ErrorCode) String() string {
+	if ec.IsFailure() {
+		return fmt.Sprintf("[Failure Code: %d]", ec)
+	}
 	return fmt.Sprintf("[Error Code: %d]", ec)
 }
 
-type FailureCode uint16
-
-func (fc FailureCode) String() string {
-	return fmt.Sprintf("[Failure Code: %d]", fc)
-}
-
 const (
-	FailureCodeUnknownFailure     FailureCode = 2000
-	FailureCodeEncodingFailure    FailureCode = 2001
-	FailureCodeLedgerFailure      FailureCode = 2002
-	FailureCodeStateMergeFailure  FailureCode = 2003
-	FailureCodeBlockFinderFailure FailureCode = 2004
+	FailureCodeUnknownFailure     ErrorCode = 2000
+	FailureCodeEncodingFailure    ErrorCode = 2001
+	FailureCodeLedgerFailure      ErrorCode = 2002
+	FailureCodeStateMergeFailure  ErrorCode = 2003
+	FailureCodeBlockFinderFailure ErrorCode = 2004
 	// Deprecated: No longer used.
-	FailureCodeHasherFailure FailureCode = 2005
+	FailureCodeHasherFailure ErrorCode = 2005
 	// Deprecated: No longer used.
-	FailureCodeMetaTransactionFailure FailureCode = 2100
+	FailureCodeMetaTransactionFailure ErrorCode = 2100
 )
 
 const (

--- a/fvm/errors/errors.go
+++ b/fvm/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	stdErrors "errors"
+	"fmt"
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/errors"
@@ -23,7 +24,7 @@ type Error interface {
 // execution.
 type Failure interface {
 	// FailureCode returns the failure code for this error
-	FailureCode() FailureCode
+	FailureCode() ErrorCode
 	// and anything else that is needed to be an error
 	error
 }
@@ -96,4 +97,93 @@ func HandleRuntimeError(err error) error {
 
 	// All other errors are non-fatal Cadence errors.
 	return NewCadenceRuntimeError(runErr)
+}
+
+// TODO(patrick): combine ErrorCodeChecker, Error and Failure interface.
+// We can also combine CodedError and CodedFailure once the interface is
+// unified.
+type ErrorCodeChecker interface {
+	// TODO(patrick): add Code() ErrorCode
+	// TODO(patrick): add IsFailure() bool
+
+	HasErrorCode(code ErrorCode) bool
+
+	error
+}
+
+func HasErrorCode(err error, code ErrorCode) bool {
+	var checker ErrorCodeChecker
+	return As(err, &checker) && checker.HasErrorCode(code)
+}
+
+type codedError struct {
+	code ErrorCode
+
+	errorWrapper
+}
+
+func wrapError(
+	code ErrorCode,
+	rootCause error,
+) codedError {
+	// TODO(patrick): check if rootCause is a failure, and if so, invert the
+	// error nesting (convert the new code into an additional error).
+	return codedError{
+		code:         code,
+		errorWrapper: errorWrapper{rootCause},
+	}
+}
+
+func newError(
+	code ErrorCode,
+	format string,
+	formatArguments ...interface{},
+) codedError {
+	return wrapError(code, fmt.Errorf(format, formatArguments...))
+}
+
+func (err codedError) Error() string {
+	return fmt.Sprintf("%v %v", err.code, err.err)
+}
+
+// This returns true if the codedError's code is set to the specified code, or
+// if any one of the codeError's errors has the error code.
+func (err codedError) HasErrorCode(code ErrorCode) bool {
+	if err.code == code {
+		return true
+	}
+
+	return HasErrorCode(err.err, code)
+}
+
+type CodedError struct {
+	codedError
+}
+
+func NewCodedError(
+	code ErrorCode,
+	format string,
+	arguments ...interface{},
+) *CodedError {
+	return &CodedError{
+		codedError: newError(code, format, arguments...),
+	}
+}
+
+func (err CodedError) Code() ErrorCode {
+	return err.code
+}
+
+type CodedFailure struct {
+	codedError
+}
+
+func WrapCodedFailure(code ErrorCode, err error) *CodedFailure {
+	return &CodedFailure{
+		codedError: wrapError(code, err),
+	}
+}
+
+func (err CodedFailure) FailureCode() ErrorCode {
+	return err.code
 }

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -5,25 +5,10 @@ import (
 	"fmt"
 )
 
-// UnknownFailure captures an unknown vm fatal error
-type UnknownFailure struct {
-	errorWrapper
-}
-
-// NewUnknownFailure constructs a new UnknownFailure
-func NewUnknownFailure(err error) UnknownFailure {
-	return UnknownFailure{
-		errorWrapper: errorWrapper{err: err},
-	}
-}
-
-func (e UnknownFailure) Error() string {
-	return fmt.Sprintf("%s unknown failure: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e UnknownFailure) FailureCode() FailureCode {
-	return FailureCodeUnknownFailure
+func NewUnknownFailure(err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeUnknownFailure,
+		fmt.Errorf("unknown failure: %w", err))
 }
 
 // EncodingFailure captures an fatal error sourced from encoding issues
@@ -43,7 +28,7 @@ func (e EncodingFailure) Error() string {
 }
 
 // FailureCode returns the failure code
-func (e EncodingFailure) FailureCode() FailureCode {
+func (e EncodingFailure) FailureCode() ErrorCode {
 	return FailureCodeEncodingFailure
 }
 
@@ -64,7 +49,7 @@ func (e LedgerFailure) Error() string {
 }
 
 // FailureCode returns the failure code
-func (e LedgerFailure) FailureCode() FailureCode {
+func (e LedgerFailure) FailureCode() ErrorCode {
 	return FailureCodeLedgerFailure
 }
 
@@ -91,7 +76,7 @@ func (e StateMergeFailure) Error() string {
 }
 
 // FailureCode returns the failure code
-func (e StateMergeFailure) FailureCode() FailureCode {
+func (e StateMergeFailure) FailureCode() ErrorCode {
 	return FailureCodeStateMergeFailure
 }
 
@@ -112,6 +97,6 @@ func (e BlockFinderFailure) Error() string {
 }
 
 // FailureCode returns the failure code
-func (e BlockFinderFailure) FailureCode() FailureCode {
+func (e BlockFinderFailure) FailureCode() ErrorCode {
 	return FailureCodeBlockFinderFailure
 }


### PR DESCRIPTION
We can replace most (if not all) of our error / failure structs with CodedError and CodedFailure.

I've converted one error struct to CodedError, and one failure struct to CodeFailure.  I'll convert the rest if we're happy with this approach.