### PR TITLE
Alter chainIDs to comply with  the CAIP-2 standard

### DIFF
--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -20,20 +20,20 @@ const (
 	// Long-lived test networks
 
 	// Testnet is the chain ID for the testnet chain.
-	Testnet ChainID = "flow-testnet"
+	Testnet ChainID = "flow:testnet"
 	// Stagingnet is the chain ID for internal stagingnet chain.
-	Stagingnet ChainID = "flow-stagingnet"
+	Stagingnet ChainID = "flow:stagingnet"
 
 	// Transient test networks
 
 	// Benchnet is the chain ID for the transient benchmarking chain.
-	Benchnet ChainID = "flow-benchnet"
+	Benchnet ChainID = "flow:benchnet"
 	// Localnet is the chain ID for the local development chain.
-	Localnet ChainID = "flow-localnet"
+	Localnet ChainID = "flow:localnet"
 	// Emulator is the chain ID for the emulated chain.
-	Emulator ChainID = "flow-emulator"
+	Emulator ChainID = "flow:emulator"
 	// BftTestnet is the chain ID for testing attack vector scenarios.
-	BftTestnet ChainID = "flow-bft-test-net"
+	BftTestnet ChainID = "flow:bft-test-net"
 
 	// MonotonicEmulator is the chain ID for the emulated node chain with monotonic address generation.
 	MonotonicEmulator ChainID = "flow-emulator-monotonic"

--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -36,7 +36,7 @@ const (
 	BftTestnet ChainID = "flow:bft-test-net"
 
 	// MonotonicEmulator is the chain ID for the emulated node chain with monotonic address generation.
-	MonotonicEmulator ChainID = "flow-emulator-monotonic"
+	MonotonicEmulator ChainID = "flow:emulator-monotonic"
 )
 
 // Transient returns whether the chain ID is for a transient network.


### PR DESCRIPTION
Problem
-----
WalletConnect expects network IDs to be in a certain standardized format. I am hoping this PR will spark off a conversation on the downstream effects of this change.

See:  https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md