### PR TITLE
Move Context fields into EnvironmentParams (Part 1)

### DIFF
--- a/fvm/context.go
+++ b/fvm/context.go
@@ -16,7 +16,6 @@ import (
 
 // A Context defines a set of execution parameters used by the virtual machine.
 type Context struct {
-	Chain   flow.Chain
 	Blocks  environment.Blocks
 	Metrics environment.MetricsReporter
 	Tracer  module.Tracer
@@ -28,25 +27,19 @@ type Context struct {
 	MaxStateKeySize                   uint64
 	MaxStateValueSize                 uint64
 	MaxStateInteractionSize           uint64
-	EventCollectionByteSizeLimit      uint64
 	BlockHeader                       *flow.Header
 	// NOTE: The ServiceAccountEnabled option is used by the playground
 	// https://github.com/onflow/flow-playground-api/blob/1ad967055f31db8f1ce88e008960e5fc14a9fbd1/compute/computer.go#L76
-	ServiceAccountEnabled bool
-	// Depricated: RestrictedDeploymentEnabled is deprecated use SetIsContractDeploymentRestrictedTransaction instead.
-	// Can be removed after all networks are migrated to SetIsContractDeploymentRestrictedTransaction
-	RestrictContractDeployment    bool
-	RestrictContractRemoval       bool
-	LimitAccountStorage           bool
-	TransactionFeesEnabled        bool
-	CadenceLoggingEnabled         bool
-	ServiceEventCollectionEnabled bool
-	ExtensiveTracing              bool
-	TransactionProcessors         []TransactionProcessor
-	ScriptProcessors              []ScriptProcessor
-	Logger                        zerolog.Logger
-	ReusableCadenceRuntimePool    reusableRuntime.ReusableCadenceRuntimePool
-	BlockPrograms                 *programs.Programs
+	ServiceAccountEnabled      bool
+	CadenceLoggingEnabled      bool
+	ExtensiveTracing           bool
+	TransactionProcessors      []TransactionProcessor
+	ScriptProcessors           []ScriptProcessor
+	Logger                     zerolog.Logger
+	ReusableCadenceRuntimePool reusableRuntime.ReusableCadenceRuntimePool
+	BlockPrograms              *programs.Programs
+
+	EnvironmentParams
 }
 
 // NewContext initializes a new execution context with the provided options.
@@ -70,14 +63,12 @@ func newContext(ctx Context, opts ...Option) Context {
 const AccountKeyWeightThreshold = 1000
 
 const (
-	DefaultComputationLimit             = 100_000        // 100K
-	DefaultMemoryLimit                  = math.MaxUint64 //
-	DefaultEventCollectionByteSizeLimit = 256_000        // 256KB
+	DefaultComputationLimit = 100_000        // 100K
+	DefaultMemoryLimit      = math.MaxUint64 //
 )
 
 func defaultContext() Context {
 	return Context{
-		Chain:                             flow.Mainnet.Chain(),
 		Blocks:                            nil,
 		Metrics:                           environment.NoopMetricsReporter{},
 		Tracer:                            nil,
@@ -87,13 +78,9 @@ func defaultContext() Context {
 		MaxStateKeySize:                   state.DefaultMaxKeySize,
 		MaxStateValueSize:                 state.DefaultMaxValueSize,
 		MaxStateInteractionSize:           state.DefaultMaxInteractionSize,
-		EventCollectionByteSizeLimit:      DefaultEventCollectionByteSizeLimit,
 		BlockHeader:                       nil,
 		ServiceAccountEnabled:             true,
-		RestrictContractDeployment:        true,
-		RestrictContractRemoval:           true,
 		CadenceLoggingEnabled:             false,
-		ServiceEventCollectionEnabled:     false,
 		ExtensiveTracing:                  false,
 		TransactionProcessors: []TransactionProcessor{
 			NewTransactionVerifier(AccountKeyWeightThreshold),
@@ -107,6 +94,7 @@ func defaultContext() Context {
 		ReusableCadenceRuntimePool: reusableRuntime.NewReusableCadenceRuntimePool(
 			0,
 			runtime.Config{}),
+		EnvironmentParams: DefaultEnvironmentParams(),
 	}
 }
 

--- a/fvm/env.go
+++ b/fvm/env.go
@@ -7,10 +7,30 @@ import (
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 // TODO(patrick): rm after emulator is updated
 type Environment = environment.Environment
+
+type EnvironmentParams struct {
+	Chain flow.Chain
+
+	environment.EventEmitterParams
+
+	environment.TransactionInfoParams
+
+	environment.ContractUpdaterParams
+}
+
+func DefaultEnvironmentParams() EnvironmentParams {
+	return EnvironmentParams{
+		Chain:                 flow.Mainnet.Chain(),
+		EventEmitterParams:    environment.DefaultEventEmitterParams(),
+		TransactionInfoParams: environment.DefaultTransactionInfoParams(),
+		ContractUpdaterParams: environment.DefaultContractUpdaterParams(),
+	}
+}
 
 var _ environment.Environment = &facadeEnvironment{}
 

--- a/fvm/transactionEnv.go
+++ b/fvm/transactionEnv.go
@@ -48,11 +48,10 @@ func NewTransactionEnv(
 		environment.NewMeter(sth),
 	)
 
+	ctx.TxIndex = txIndex
+	ctx.TxId = txID
 	env.TransactionInfo = environment.NewTransactionInfo(
-		txIndex,
-		txID,
-		ctx.TransactionFeesEnabled,
-		ctx.LimitAccountStorage,
+		ctx.TransactionInfoParams,
 		env.Tracer,
 		tx.Authorizers,
 		ctx.Chain.ServiceAddress(),
@@ -64,8 +63,7 @@ func NewTransactionEnv(
 		txID,
 		txIndex,
 		tx.Payer,
-		ctx.ServiceEventCollectionEnabled,
-		ctx.EventCollectionByteSizeLimit,
+		ctx.EventEmitterParams,
 	)
 	env.AccountCreator = environment.NewAccountCreator(
 		sth,
@@ -86,8 +84,7 @@ func NewTransactionEnv(
 		env.accounts,
 		env.TransactionInfo,
 		ctx.Chain,
-		ctx.RestrictContractDeployment,
-		ctx.RestrictContractRemoval,
+		ctx.ContractUpdaterParams,
 		env.ProgramLogger,
 		env.SystemContracts,
 		env.Runtime)


### PR DESCRIPTION
I want to move facadeEnvironment into environment/ as well.  To do this, we need to decouple facadeEnvironment from Context.  This is the first step.

Most parameters are logically be assoicated with a module; I've place those parameters next to the module whenever possible.  Some Parameters, such as Chain, are used by multiple modules; I'm keeping these in EnvironmentParams for now.

Note that I'm migrating the parameters a few modules at a time rather than wholesale to make the PRs more reviewable.