### PR TITLE
[FVM] Moving event emit size metering logic to Meter interface

### DIFF
--- a/fvm/environment/event_emitter_test.go
+++ b/fvm/environment/event_emitter_test.go
@@ -7,11 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/stdlib"
 
 	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/meter"
+	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/trace"
 )
 
 func Test_IsServiceEvent(t *testing.T) {
@@ -67,4 +73,110 @@ func Test_ScriptEventEmitter(t *testing.T) {
 	emitter := environment.NoEventEmitter{}
 	err := emitter.EmitEvent(cadence.Event{})
 	require.NoError(t, err, "script should not error when emitting events")
+}
+
+func Test_EmitEvent_Limit(t *testing.T) {
+	t.Run("emit event - service account - within limit", func(t *testing.T) {
+		cadenceEvent1 := cadence.Event{
+			EventType: &cadence.EventType{
+				Location:            stdlib.FlowLocation{},
+				QualifiedIdentifier: "test",
+			},
+		}
+
+		event1Size := getCadenceEventPayloadByteSize(cadenceEvent1)
+		eventEmitter := createTestEventEmitterWithLimit(
+			flow.Emulator,
+			flow.Emulator.Chain().ServiceAddress(),
+			event1Size+1)
+
+		err := eventEmitter.EmitEvent(cadenceEvent1)
+		require.NoError(t, err)
+	})
+
+	t.Run("emit event - service account - exceeding limit", func(t *testing.T) {
+		cadenceEvent1 := cadence.Event{
+			EventType: &cadence.EventType{
+				Location:            stdlib.FlowLocation{},
+				QualifiedIdentifier: "test",
+			},
+		}
+
+		event1Size := getCadenceEventPayloadByteSize(cadenceEvent1)
+		eventEmitter := createTestEventEmitterWithLimit(
+			flow.Emulator,
+			flow.Emulator.Chain().ServiceAddress(),
+			event1Size-1)
+
+		err := eventEmitter.EmitEvent(cadenceEvent1)
+		require.NoError(t, err) // service count doesn't have limit
+	})
+
+	t.Run("emit event - non service account - within limit", func(t *testing.T) {
+		cadenceEvent1 := cadence.Event{
+			EventType: &cadence.EventType{
+				Location:            stdlib.FlowLocation{},
+				QualifiedIdentifier: "test",
+			},
+		}
+
+		event1Size := getCadenceEventPayloadByteSize(cadenceEvent1)
+		eventEmitter := createTestEventEmitterWithLimit(
+			flow.Emulator,
+			flow.Emulator.Chain().NewAddressGenerator().CurrentAddress(),
+			event1Size+1)
+
+		err := eventEmitter.EmitEvent(cadenceEvent1)
+		require.NoError(t, err)
+	})
+
+	t.Run("emit event - non service account - exceeding limit", func(t *testing.T) {
+		cadenceEvent1 := cadence.Event{
+			EventType: &cadence.EventType{
+				Location:            stdlib.FlowLocation{},
+				QualifiedIdentifier: "test",
+			},
+		}
+
+		event1Size := getCadenceEventPayloadByteSize(cadenceEvent1)
+		eventEmitter := createTestEventEmitterWithLimit(
+			flow.Emulator,
+			flow.Emulator.Chain().NewAddressGenerator().CurrentAddress(),
+			event1Size-1)
+
+		err := eventEmitter.EmitEvent(cadenceEvent1)
+		require.Error(t, err)
+	})
+
+}
+
+func createTestEventEmitterWithLimit(chain flow.ChainID, address flow.Address, eventEmitLimit uint64) environment.EventEmitter {
+	view := utils.NewSimpleView()
+	stTxn := state.NewStateTransaction(
+		view,
+		state.DefaultParameters().WithMeterParameters(
+			meter.DefaultParameters().WithEventEmitByteLimit(eventEmitLimit),
+		))
+
+	return environment.NewEventEmitter(
+		environment.NewTracer(trace.NewNoopTracer(), trace.NoopSpan, false),
+		environment.NewMeter(stTxn),
+		chain.Chain(),
+		flow.ZeroID,
+		0,
+		address,
+		environment.EventEmitterParams{
+			ServiceEventCollectionEnabled: false,
+			EventCollectionByteSizeLimit:  eventEmitLimit,
+		},
+	)
+}
+
+func getCadenceEventPayloadByteSize(event cadence.Event) uint64 {
+	payload, err := jsoncdc.Encode(event)
+	if err != nil {
+		panic(err)
+	}
+
+	return uint64(len(payload))
 }

--- a/fvm/environment/meter.go
+++ b/fvm/environment/meter.go
@@ -49,6 +49,10 @@ type Meter interface {
 
 	MeterMemory(usage common.MemoryUsage) error
 	MemoryEstimate() uint64
+
+	MeterEmittedEvent(byteSize uint64) error
+	TotalEmittedEventBytes() uint64
+	TotalEventCounter() uint32
 }
 
 type meterImpl struct {
@@ -84,6 +88,21 @@ func (meter *meterImpl) MeterMemory(usage common.MemoryUsage) error {
 
 func (meter *meterImpl) MemoryEstimate() uint64 {
 	return meter.stTxn.TotalMemoryEstimate()
+}
+
+func (meter *meterImpl) MeterEmittedEvent(byteSize uint64) error {
+	if meter.stTxn.EnforceLimits() {
+		return meter.stTxn.MeterEmittedEvent(byteSize)
+	}
+	return nil
+}
+
+func (meter *meterImpl) TotalEmittedEventBytes() uint64 {
+	return meter.stTxn.TotalEmittedEventBytes()
+}
+
+func (meter *meterImpl) TotalEventCounter() uint32 {
+	return meter.stTxn.TotalEventCounter()
 }
 
 type cancellableMeter struct {

--- a/fvm/environment/mock/environment.go
+++ b/fvm/environment/mock/environment.go
@@ -801,6 +801,20 @@ func (_m *Environment) MeterComputation(operationType common.ComputationKind, in
 	return r0
 }
 
+// MeterEmittedEvent provides a mock function with given fields: byteSize
+func (_m *Environment) MeterEmittedEvent(byteSize uint64) error {
+	ret := _m.Called(byteSize)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uint64) error); ok {
+		r0 = rf(byteSize)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // MeterMemory provides a mock function with given fields: usage
 func (_m *Environment) MeterMemory(usage common.MemoryUsage) error {
 	ret := _m.Called(usage)
@@ -1017,6 +1031,34 @@ func (_m *Environment) StartSpanFromRoot(name trace.SpanName) oteltrace.Span {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(oteltrace.Span)
 		}
+	}
+
+	return r0
+}
+
+// TotalEmittedEventBytes provides a mock function with given fields:
+func (_m *Environment) TotalEmittedEventBytes() uint64 {
+	ret := _m.Called()
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	return r0
+}
+
+// TotalEventCounter provides a mock function with given fields:
+func (_m *Environment) TotalEventCounter() uint32 {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
 	}
 
 	return r0

--- a/fvm/environment/mock/meter.go
+++ b/fvm/environment/mock/meter.go
@@ -55,6 +55,20 @@ func (_m *Meter) MeterComputation(_a0 common.ComputationKind, _a1 uint) error {
 	return r0
 }
 
+// MeterEmittedEvent provides a mock function with given fields: byteSize
+func (_m *Meter) MeterEmittedEvent(byteSize uint64) error {
+	ret := _m.Called(byteSize)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uint64) error); ok {
+		r0 = rf(byteSize)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // MeterMemory provides a mock function with given fields: usage
 func (_m *Meter) MeterMemory(usage common.MemoryUsage) error {
 	ret := _m.Called(usage)
@@ -64,6 +78,34 @@ func (_m *Meter) MeterMemory(usage common.MemoryUsage) error {
 		r0 = rf(usage)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// TotalEmittedEventBytes provides a mock function with given fields:
+func (_m *Meter) TotalEmittedEventBytes() uint64 {
+	ret := _m.Called()
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	return r0
+}
+
+// TotalEventCounter provides a mock function with given fields:
+func (_m *Meter) TotalEventCounter() uint32 {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
 	}
 
 	return r0

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -97,6 +97,9 @@ func (vm *VirtualMachine) RunV2(
 		interactionLimit = math.MaxUint64
 	}
 
+	eventSizeLimit := ctx.EventCollectionByteSizeLimit
+	meterParams = meterParams.WithEventEmitByteLimit(eventSizeLimit)
+
 	stTxn := state.NewStateTransaction(
 		v,
 		state.DefaultParameters().

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -229,6 +229,18 @@ func (s *State) TotalMemoryLimit() uint {
 	return uint(s.meter.TotalMemoryLimit())
 }
 
+func (s *State) MeterEmittedEvent(byteSize uint64) error {
+	return s.meter.MeterEmittedEvent(byteSize)
+}
+
+func (s *State) TotalEmittedEventBytes() uint64 {
+	return s.meter.TotalEmittedEventBytes()
+}
+
+func (s *State) TotalEventCounter() uint32 {
+	return s.meter.TotalEventCounter()
+}
+
 // MergeState applies the changes from a the given view to this view.
 func (s *State) MergeState(other *State) error {
 	err := s.view.MergeView(other.view)

--- a/fvm/state/state_holder.go
+++ b/fvm/state/state_holder.go
@@ -314,6 +314,18 @@ func (s *StateHolder) InteractionUsed() uint64 {
 	return s.currentState().InteractionUsed()
 }
 
+func (s *StateHolder) MeterEmittedEvent(byteSize uint64) error {
+	return s.currentState().MeterEmittedEvent(byteSize)
+}
+
+func (s *StateHolder) TotalEmittedEventBytes() uint64 {
+	return s.currentState().TotalEmittedEventBytes()
+}
+
+func (s *StateHolder) TotalEventCounter() uint32 {
+	return s.currentState().TotalEventCounter()
+}
+
 func (s *StateHolder) ViewForTestingOnly() View {
 	return s.currentState().View()
 }


### PR DESCRIPTION
The existing event emit size metering logic in `fvm/environment/event_emitter.go` can also be moved into `Meter` interface.

Changes below are created in individual commits
- Adding new event metering interface in `fvm/meter/meter.go`
- Adding new event metering interface in `State`, `StateTransaction` and `fvm/environment/meter.go` 
   we should use environment Meter interface in environment code to avoid potential dep issue with `meter/meter.go`
- Replacing existing event metering logic in event_emitter.go with the new interface

Test

- [X] existing and new UTs
- [X] run localnet to see debug logs to make sure valid new config values passed in