### PR TITLE
Replace error/failure structs with CodedError/CodedFailure

### DIFF
--- a/fvm/crypto/crypto_test.go
+++ b/fvm/crypto/crypto_test.go
@@ -505,7 +505,7 @@ func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_inval
 		nil, "", nil, nil, invalidSignatureAlgo, 0,
 	)
 
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidSignatureAlgo))
 
@@ -532,7 +532,7 @@ func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_inval
 		nil, "", nil, nil, runtime.SignatureAlgorithmECDSA_P256, invalidHashAlgo,
 	)
 
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidHashAlgo))
 
@@ -559,7 +559,7 @@ func TestVerifySignatureFromRuntime_error_handling_produces_valid_utf8_for_inval
 		nil, "random_tag", nil, invalidPublicKey, runtime.SignatureAlgorithmECDSA_P256, runtime.HashAlgorithmSHA2_256,
 	)
 
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 	errorString := err.Error()
 
 	require.Contains(t, errorString, fmt.Sprintf("%x", invalidPublicKey))

--- a/fvm/environment/account_key_updater_test.go
+++ b/fvm/environment/account_key_updater_test.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	errors2 "errors"
 	"fmt"
 	"testing"
 	"unicode/utf8"
@@ -51,8 +50,7 @@ func TestAddEncodedAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 	err = akh.addEncodedAccountKey(runtime.Address(address), encodedPublicKey)
 	require.Error(t, err)
 
-	err = errors2.Unwrap(err)
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 
 	errorString := err.Error()
 	assert.True(t, utf8.ValidString(errorString))
@@ -79,8 +77,7 @@ func TestNewAccountKey_error_handling_produces_valid_utf8_and_sign_algo(t *testi
 
 	_, err := NewAccountPublicKey(publicKey, sema.HashAlgorithmSHA2_384, 0, 0)
 
-	err = errors2.Unwrap(err)
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidSignAlgo))
 
@@ -110,8 +107,7 @@ func TestNewAccountKey_error_handling_produces_valid_utf8_and_hash_algo(t *testi
 
 	_, err := NewAccountPublicKey(publicKey, invalidHashAlgo, 0, 0)
 
-	err = errors2.Unwrap(err)
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidHashAlgo))
 
@@ -139,8 +135,7 @@ func TestNewAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 
 	_, err := NewAccountPublicKey(publicKey, runtime.HashAlgorithmSHA2_256, 0, 0)
 
-	err = errors2.Unwrap(err)
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 
 	errorString := err.Error()
 	assert.True(t, utf8.ValidString(errorString))

--- a/fvm/errors/accounts.go
+++ b/fvm/errors/accounts.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -19,62 +18,38 @@ func IsAccountNotFoundError(err error) bool {
 	return HasErrorCode(err, ErrCodeAccountNotFoundError)
 }
 
-// AccountAlreadyExistsError is returned when account creation fails because
-// another account already exist at that address
+// NewAccountAlreadyExistsError constructs a new CodedError. It is returned
+// when account creation fails because another account already exist at that
+// address.
+//
 // TODO maybe this should be failure since user has no control over this
-type AccountAlreadyExistsError struct {
-	address flow.Address
+func NewAccountAlreadyExistsError(address flow.Address) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountAlreadyExistsError,
+		"account with address %s already exists",
+		address)
 }
 
-// NewAccountAlreadyExistsError constructs a new AccountAlreadyExistsError
-func NewAccountAlreadyExistsError(address flow.Address) AccountAlreadyExistsError {
-	return AccountAlreadyExistsError{address: address}
-}
-
-func (e AccountAlreadyExistsError) Error() string {
-	return fmt.Sprintf(
-		"%s account with address %s already exists",
-		e.Code().String(),
-		e.address,
-	)
-}
-
-// Code returns the error code for this error type
-func (e AccountAlreadyExistsError) Code() ErrorCode {
-	return ErrCodeAccountAlreadyExistsError
-}
-
-// AccountPublicKeyNotFoundError is returned when a public key not found for the given address and key index
-type AccountPublicKeyNotFoundError struct {
-	address  flow.Address
-	keyIndex uint64
-}
-
-// NewAccountPublicKeyNotFoundError constructs a new AccountPublicKeyNotFoundError
-func NewAccountPublicKeyNotFoundError(address flow.Address, keyIndex uint64) AccountPublicKeyNotFoundError {
-	return AccountPublicKeyNotFoundError{address: address, keyIndex: keyIndex}
+// NewAccountPublicKeyNotFoundError constructs a new CodedError. It is returned
+// when a public key not found for the given address and key index.
+func NewAccountPublicKeyNotFoundError(
+	address flow.Address,
+	keyIndex uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountPublicKeyNotFoundError,
+		"account public key not found for address %s and key index %d",
+		address,
+		keyIndex)
 }
 
 // IsAccountAccountPublicKeyNotFoundError returns true if error has this type
 func IsAccountAccountPublicKeyNotFoundError(err error) bool {
-	var t AccountPublicKeyNotFoundError
-	return errors.As(err, &t)
+	return HasErrorCode(err, ErrCodeAccountPublicKeyNotFoundError)
 }
 
-func (e AccountPublicKeyNotFoundError) Error() string {
-	return fmt.Sprintf(
-		"%s account public key not found for address %s and key index %d",
-		e.Code().String(),
-		e.address,
-		e.keyIndex,
-	)
-}
-
-// Code returns the error code for this error type
-func (e AccountPublicKeyNotFoundError) Code() ErrorCode {
-	return ErrCodeAccountPublicKeyNotFoundError
-}
-
+// TODO(patrick): figure out how to provide additional error context.
+//
 // FrozenAccountError is returned when a frozen account signs a transaction
 type FrozenAccountError struct {
 	address flow.Address
@@ -99,36 +74,17 @@ func (e FrozenAccountError) Code() ErrorCode {
 	return ErrCodeFrozenAccountError
 }
 
-// AccountPublicKeyLimitError is returned when an account tries to add public keys over the limit
-type AccountPublicKeyLimitError struct {
-	address flow.Address
-	counts  uint64
-	limit   uint64
-}
-
-// NewAccountPublicKeyLimitError constructs a new AccountPublicKeyLimitError
-func NewAccountPublicKeyLimitError(address flow.Address, counts, limit uint64) AccountPublicKeyLimitError {
-	return AccountPublicKeyLimitError{
-		address: address,
-		counts:  counts,
-		limit:   limit,
-	}
-}
-
-// Address returns the address of frozen account
-func (e AccountPublicKeyLimitError) Address() flow.Address {
-	return e.address
-}
-
-func (e AccountPublicKeyLimitError) Error() string {
-	return fmt.Sprintf("%s account's (%s) public key count (%d) exceeded the limit (%d)",
-		e.Code().String(),
-		e.address,
-		e.counts,
-		e.limit)
-}
-
-// Code returns the error code for this error type
-func (e AccountPublicKeyLimitError) Code() ErrorCode {
-	return ErrCodeAccountPublicKeyLimitError
+// NewAccountPublicKeyLimitError constructs a new CodedError.  It is returned
+// when an account tries to add public keys over the limit.
+func NewAccountPublicKeyLimitError(
+	address flow.Address,
+	counts uint64,
+	limit uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountPublicKeyLimitError,
+		"account's (%s) public key count (%d) exceeded the limit (%d)",
+		address,
+		counts,
+		limit)
 }

--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -1,240 +1,100 @@
 package errors
 
 import (
-	"fmt"
-
 	"github.com/onflow/cadence/runtime"
 
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// InvalidAddressError indicates that a transaction references an invalid flow Address
-// in either the Authorizers or Payer field.
-type InvalidAddressError struct {
-	errorWrapper
-
-	address flow.Address
+// NewInvalidAddressErrorf constructs a new CodedError which indicates that a
+// transaction references an invalid flow Address in either the Authorizers or
+// Payer field.
+func NewInvalidAddressErrorf(
+	address flow.Address,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeInvalidAddressError,
+		"invalid address (%s): "+msg,
+		append([]interface{}{address.String()}, args...)...)
 }
 
-// Address returns the invalid address
-func (e InvalidAddressError) Address() flow.Address {
-	return e.address
-}
-
-// NewInvalidAddressErrorf constructs a new InvalidAddressError
-func NewInvalidAddressErrorf(address flow.Address, msg string, args ...interface{}) InvalidAddressError {
-	return InvalidAddressError{
-		address: address,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e InvalidAddressError) Error() string {
-	return fmt.Sprintf("%s invalid address (%s): %s", e.Code().String(), e.address.String(), e.err.Error())
-}
-
-// Code returns the error code for this error type
-func (e InvalidAddressError) Code() ErrorCode {
-	return ErrCodeInvalidAddressError
-}
-
-// InvalidArgumentError indicates that a transaction includes invalid arguments.
-// this error is the result of failure in any of the following conditions:
+// NewInvalidArgumentErrorf constructs a new CodedError which indicates that a
+// transaction includes invalid arguments. This error is the result of failure
+// in any of the following conditions:
 // - number of arguments doesn't match the template
+//
 // TODO add more cases like argument size
-type InvalidArgumentError struct {
-	errorWrapper
+func NewInvalidArgumentErrorf(msg string, args ...interface{}) *CodedError {
+	return NewCodedError(
+		ErrCodeInvalidArgumentError,
+		"transaction arguments are invalid: ("+msg+")",
+		args...)
 }
 
-// NewInvalidArgumentErrorf constructs a new InvalidArgumentError
-func NewInvalidArgumentErrorf(msg string, args ...interface{}) InvalidArgumentError {
-	return InvalidArgumentError{
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e InvalidArgumentError) Error() string {
-	return fmt.Sprintf("%s transaction arguments are invalid: (%s)", e.Code().String(), e.err.Error())
-}
-
-// Code returns the error code for this error type
-func (e InvalidArgumentError) Code() ErrorCode {
-	return ErrCodeInvalidArgumentError
-}
-
-// InvalidLocationError indicates an invalid location is passed
-type InvalidLocationError struct {
-	errorWrapper
-
-	location runtime.Location
-}
-
-// NewInvalidLocationErrorf constructs a new InvalidLocationError
-func NewInvalidLocationErrorf(location runtime.Location, msg string, args ...interface{}) InvalidLocationError {
-	return InvalidLocationError{location: location,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e InvalidLocationError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-
+// NewInvalidLocationErrorf constructs a new CodedError which indicates an
+// invalid location is passed.
+func NewInvalidLocationErrorf(
+	location runtime.Location,
+	msg string,
+	args ...interface{},
+) *CodedError {
 	locationStr := ""
-	if e.location != nil {
-		locationStr = e.location.String()
+	if location != nil {
+		locationStr = location.String()
 	}
 
-	return fmt.Sprintf(
-		"%s location (%s) is not a valid location: %s",
-		e.Code().String(),
-		locationStr,
-		errMsg,
-	)
+	return NewCodedError(
+		ErrCodeInvalidLocationError,
+		"location (%s) is not a valid location: "+msg,
+		append([]interface{}{locationStr}, args...)...)
 }
 
-// Code returns the error code for this error
-func (e InvalidLocationError) Code() ErrorCode {
-	return ErrCodeInvalidLocationError
+// NewValueErrorf constructs a new CodedError which indicates a value is not
+// valid value.
+func NewValueErrorf(
+	valueStr string,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeValueError,
+		"invalid value (%s): "+msg,
+		append([]interface{}{valueStr}, args...)...)
 }
 
-// ValueError indicates a value is not valid value.
-type ValueError struct {
-	errorWrapper
-
-	valueStr string
+func IsValueError(err error) bool {
+	return HasErrorCode(err, ErrCodeValueError)
 }
 
-// NewValueErrorf constructs a new ValueError
-func NewValueErrorf(valueStr string, msg string, args ...interface{}) ValueError {
-	return ValueError{valueStr: valueStr,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
+// NewOperationAuthorizationErrorf constructs a new CodedError which indicates
+// not enough authorization to perform an operations like account creation or
+// smart contract deployment.
+func NewOperationAuthorizationErrorf(
+	operation string,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeOperationAuthorizationError,
+		"(%s) is not authorized: "+msg,
+		append([]interface{}{operation}, args...)...)
 }
 
-func (e ValueError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-	return fmt.Sprintf("%s invalid value (%s): %s", e.Code().String(), e.valueStr, errMsg)
-}
-
-// Code returns the error code for this error type
-func (e ValueError) Code() ErrorCode {
-	return ErrCodeValueError
-}
-
-// OperationAuthorizationError indicates not enough authorization
-// to perform an operations like account creation or smart contract deployment.
-type OperationAuthorizationError struct {
-	errorWrapper
-
-	operation string
-}
-
-// NewOperationAuthorizationErrorf constructs a new OperationAuthorizationError
-func NewOperationAuthorizationErrorf(operation string, msg string, args ...interface{}) OperationAuthorizationError {
-	return OperationAuthorizationError{
-		operation: operation,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e OperationAuthorizationError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-	return fmt.Sprintf(
-		"%s (%s) is not authorized: %s",
-		e.Code().String(),
-		e.operation,
-		errMsg,
-	)
-}
-
-// Code returns the error code for this error type
-func (e OperationAuthorizationError) Code() ErrorCode {
-	return ErrCodeOperationAuthorizationError
-}
-
-// AccountAuthorizationError indicates that an authorization issues
-// either a transaction is missing a required signature to
-// authorize access to an account or a transaction doesn't have authorization
-// to performe some operations like account creation.
-type AccountAuthorizationError struct {
-	errorWrapper
-
-	address flow.Address
-}
-
-// NewAccountAuthorizationErrorf constructs a new AccountAuthorizationError
-func NewAccountAuthorizationErrorf(address flow.Address, msg string, args ...interface{}) AccountAuthorizationError {
-	return AccountAuthorizationError{
-		address: address,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-// Address returns the address of an account without enough authorization
-func (e AccountAuthorizationError) Address() flow.Address {
-	return e.address
-}
-
-func (e AccountAuthorizationError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-	return fmt.Sprintf(
-		"%s authorization failed for account %s: %s",
-		e.Code().String(),
-		e.address,
-		errMsg,
-	)
-}
-
-// Code returns the error code for this error type
-func (e AccountAuthorizationError) Code() ErrorCode {
-	return ErrCodeAccountAuthorizationError
-}
-
-// FVMInternalError indicates that an internal error occurs during tx execution.
-type FVMInternalError struct {
-	errorWrapper
-
-	msg string
-}
-
-// NewFVMInternalErrorf constructs a new FVMInternalError
-func NewFVMInternalErrorf(msg string, args ...interface{}) FVMInternalError {
-	return FVMInternalError{
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e FVMInternalError) Error() string {
-	return e.msg
-}
-
-// Code returns the error code for this error type
-func (e FVMInternalError) Code() ErrorCode {
-	return ErrCodeFVMInternalError
+// NewAccountAuthorizationErrorf constructs a new CodedError which indicates
+// that an authorization issue either:
+//   - a transaction is missing a required signature to authorize access to an
+//     account, or
+//   - a transaction doesn't have authorization to performe some operations like
+//     account creation.
+func NewAccountAuthorizationErrorf(
+	address flow.Address,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountAuthorizationError,
+		"authorization failed for account %s: "+msg,
+		append([]interface{}{address}, args...)...)
 }

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -47,6 +47,7 @@ const (
 	ErrCodeInvalidEnvelopeSignatureError ErrorCode = 1009
 
 	// base errors 1050 - 1100
+	// Deprecated: No longer used.
 	ErrCodeFVMInternalError            ErrorCode = 1050
 	ErrCodeValueError                  ErrorCode = 1051
 	ErrCodeInvalidArgumentError        ErrorCode = 1052

--- a/fvm/errors/contracts.go
+++ b/fvm/errors/contracts.go
@@ -1,35 +1,17 @@
 package errors
 
 import (
-	"fmt"
-
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// ContractNotFoundError is returned when an account contract is not found
-type ContractNotFoundError struct {
-	address  flow.Address
-	contract string
-}
-
-// NewContractNotFoundError constructs a new ContractNotFoundError
-func NewContractNotFoundError(address flow.Address, contract string) ContractNotFoundError {
-	return ContractNotFoundError{
-		address:  address,
-		contract: contract,
-	}
-}
-
-func (e ContractNotFoundError) Error() string {
-	return fmt.Sprintf(
-		"%s contract %s not found for address %s",
-		e.Code().String(),
-		e.contract,
-		e.address,
-	)
-}
-
-// Code returns the error code for this error type
-func (e ContractNotFoundError) Code() ErrorCode {
-	return ErrCodeContractNotFoundError
+// NewContractNotFoundError constructs a new ErrContractNotFoundError error
+func NewContractNotFoundError(
+	address flow.Address,
+	contract string,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeContractNotFoundError,
+		"contract %s not found for address %s",
+		contract,
+		address)
 }

--- a/fvm/errors/errors_test.go
+++ b/fvm/errors/errors_test.go
@@ -12,7 +12,7 @@ import (
 func TestErrorHandling(t *testing.T) {
 
 	t.Run("test nonfatal error detection", func(t *testing.T) {
-		e1 := &OperationNotSupportedError{"some operations"}
+		e1 := NewOperationNotSupportedError("some operations")
 		e2 := fmt.Errorf("some other errors: %w", e1)
 		e3 := NewInvalidProposalSignatureError(flow.EmptyAddress, 0, e2)
 
@@ -22,7 +22,7 @@ func TestErrorHandling(t *testing.T) {
 	})
 
 	t.Run("test fatal error detection", func(t *testing.T) {
-		e1 := &OperationNotSupportedError{"some operations"}
+		e1 := NewOperationNotSupportedError("some operations")
 		e2 := NewLedgerFailure(e1)
 		e3 := fmt.Errorf("some other errors: %w", e2)
 		e4 := NewInvalidProposalSignatureError(flow.EmptyAddress, 0, e3)

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -1,8 +1,6 @@
 package errors
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/onflow/cadence/runtime"
@@ -10,365 +8,213 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// ExecutionError captures errors when executing a transaction/script.
-// A transaction having this error has already passed validation and is included in a collection.
-// the transaction will be executed by execution nodes but the result is reverted
-// and in some cases there will be a penalty (or fees) for the payer, access nodes or collection nodes.
-type ExecutionError interface {
-	Error
-}
-
-// CadenceRuntimeError captures a collection of errors provided by cadence runtime
-// it cover cadence errors such as
-// NotDeclaredError, NotInvokableError, ArgumentCountError, TransactionNotDeclaredError,
-// ConditionError, RedeclarationError, DereferenceError,
-// OverflowError, UnderflowError, DivisionByZeroError,
-// DestroyedCompositeError,  ForceAssignmentToNonNilResourceError, ForceNilError,
-// TypeMismatchError, InvalidPathDomainError, OverwriteError, CyclicLinkError,
+// NewCadenceRuntimeError constructs a new CodedError and wraps a cadence
+// runtime error.
+//
+// It captures a collection of errors provided by cadence runtime. It cover
+// cadence errors such as NotDeclaredError, NotInvokableError,
+// ArgumentCountError, TransactionNotDeclaredError, ConditionError,
+// RedeclarationError, DereferenceError, OverflowError, UnderflowError,
+// DivisionByZeroError, DestroyedCompositeError,
+// ForceAssignmentToNonNilResourceError, ForceNilError, TypeMismatchError,
+// InvalidPathDomainError, OverwriteError, CyclicLinkError,
 // ArrayIndexOutOfBoundsError, ...
 // The Cadence error might have occurred because of an inner fvm Error.
-type CadenceRuntimeError struct {
-	errorWrapper
+func NewCadenceRuntimeError(err runtime.Error) *CodedError {
+	return WrapCodedError(
+		ErrCodeCadenceRunTimeError,
+		err,
+		"cadence runtime error")
 }
 
-// NewCadenceRuntimeError constructs a new CadenceRuntimeError and wraps a cadence runtime error
-func NewCadenceRuntimeError(err runtime.Error) CadenceRuntimeError {
-	return CadenceRuntimeError{
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
+// IsCadenceRuntimeError returns true if error has this code.
+func IsCadenceRuntimeError(err error) bool {
+	return HasErrorCode(err, ErrCodeCadenceRunTimeError)
 }
 
-func (e CadenceRuntimeError) Error() string {
-	return fmt.Sprintf("%s cadence runtime error %s", e.Code().String(), e.err.Error())
+// NewTransactionFeeDeductionFailedError constructs a new CodedError which
+// indicates that a there was an error deducting transaction fees from the
+// transaction Payer
+func NewTransactionFeeDeductionFailedError(
+	payer flow.Address,
+	txFees uint64,
+	err error,
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeTransactionFeeDeductionFailedError,
+		err,
+		"failed to deduct %d transaction fees from %s",
+		txFees,
+		payer)
 }
 
-// Code returns the error code for this error
-func (e CadenceRuntimeError) Code() ErrorCode {
-	return ErrCodeCadenceRunTimeError
+// NewComputationLimitExceededError constructs a new CodedError which indicates
+// that computation has exceeded its limit.
+func NewComputationLimitExceededError(limit uint64) *CodedError {
+	return NewCodedError(
+		ErrCodeComputationLimitExceededError,
+		"computation exceeds limit (%d)",
+		limit)
 }
 
-// An TransactionFeeDeductionFailedError indicates that a there was an error deducting transaction fees from the transaction Payer
-type TransactionFeeDeductionFailedError struct {
-	errorWrapper
-
-	Payer  flow.Address
-	TxFees uint64
-}
-
-// NewTransactionFeeDeductionFailedError constructs a new TransactionFeeDeductionFailedError
-func NewTransactionFeeDeductionFailedError(payer flow.Address, err error) TransactionFeeDeductionFailedError {
-	return TransactionFeeDeductionFailedError{
-		Payer: payer,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e TransactionFeeDeductionFailedError) Error() string {
-	return fmt.Sprintf("%s failed to deduct %d transaction fees from %s: %s", e.Code().String(), e.TxFees, e.Payer, e.err)
-}
-
-// Code returns the error code for this error
-func (e TransactionFeeDeductionFailedError) Code() ErrorCode {
-	return ErrCodeTransactionFeeDeductionFailedError
-}
-
-// An ComputationLimitExceededError indicates that computation has exceeded its limit.
-type ComputationLimitExceededError struct {
-	limit uint64
-}
-
-// NewComputationLimitExceededError constructs a new ComputationLimitExceededError
-func NewComputationLimitExceededError(limit uint64) ComputationLimitExceededError {
-	return ComputationLimitExceededError{
-		limit: limit,
-	}
-}
-
-// Code returns the error code for this error
-func (e ComputationLimitExceededError) Code() ErrorCode {
-	return ErrCodeComputationLimitExceededError
-}
-
-func (e ComputationLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"%s computation exceeds limit (%d)",
-		e.Code().String(),
-		e.limit,
-	)
-}
-
-// IsComputationLimitExceededError returns true if error has this type
+// IsComputationLimitExceededError returns true if error has this code.
 func IsComputationLimitExceededError(err error) bool {
-	var t ComputationLimitExceededError
-	return errors.As(err, &t)
+	return HasErrorCode(err, ErrCodeComputationLimitExceededError)
 }
 
-// An MemoryLimitExceededError indicates that execution has exceeded its memory limits.
-type MemoryLimitExceededError struct {
-	limit uint64
+// NewMemoryLimitExceededError constructs a new CodedError which indicates
+// that execution has exceeded its memory limits.
+func NewMemoryLimitExceededError(limit uint64) *CodedError {
+	return NewCodedError(
+		ErrCodeMemoryLimitExceededError,
+		"memory usage exceeds limit (%d)",
+		limit)
 }
 
-// NewMemoryLimitExceededError constructs a new MemoryLimitExceededError
-func NewMemoryLimitExceededError(limit uint64) MemoryLimitExceededError {
-	return MemoryLimitExceededError{
-		limit: limit,
-	}
-}
-
-// Code returns the error code for this error
-func (e MemoryLimitExceededError) Code() ErrorCode {
-	return ErrCodeMemoryLimitExceededError
-}
-
-func (e MemoryLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"%s memory usage exceeds limit (%d)",
-		e.Code().String(),
-		e.limit,
-	)
-}
-
-// IsMemoryLimitExceededError returns true if error has this type
+// IsMemoryLimitExceededError returns true if error has this code.
 func IsMemoryLimitExceededError(err error) bool {
-	var t MemoryLimitExceededError
-	return errors.As(err, &t)
+	return HasErrorCode(err, ErrCodeMemoryLimitExceededError)
 }
 
-// An StorageCapacityExceededError indicates that an account used more storage than it has storage capacity.
-type StorageCapacityExceededError struct {
-	address         flow.Address
-	storageUsed     uint64
-	storageCapacity uint64
+// NewStorageCapacityExceededError constructs a new CodedError which indicates
+// that an account used more storage than it has storage capacity.
+func NewStorageCapacityExceededError(
+	address flow.Address,
+	storageUsed uint64,
+	storageCapacity uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeStorageCapacityExceeded,
+		"The account with address (%s) uses %d bytes of storage which is "+
+			"over its capacity (%d bytes). Capacity can be increased by "+
+			"adding FLOW tokens to the account.",
+		address,
+		storageUsed,
+		storageCapacity)
 }
 
-// NewStorageCapacityExceededError constructs a new StorageCapacityExceededError
-func NewStorageCapacityExceededError(address flow.Address, storageUsed, storageCapacity uint64) StorageCapacityExceededError {
-	return StorageCapacityExceededError{
-		address:         address,
-		storageUsed:     storageUsed,
-		storageCapacity: storageCapacity,
+func IsStorageCapacityExceededError(err error) bool {
+	return HasErrorCode(err, ErrCodeStorageCapacityExceeded)
+}
+
+// NewEventLimitExceededError constructs a CodedError which indicates that the
+// transaction has produced events with size more than limit.
+func NewEventLimitExceededError(
+	totalByteSize uint64,
+	limit uint64) *CodedError {
+	return NewCodedError(
+		ErrCodeEventLimitExceededError,
+		"total event byte size (%d) exceeds limit (%d)",
+		totalByteSize,
+		limit)
+}
+
+// NewStateKeySizeLimitError constructs a CodedError which indicates that the
+// provided key has exceeded the size limit allowed by the storage.
+func NewStateKeySizeLimitError(
+	owner string,
+	key string,
+	size uint64,
+	limit uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeStateKeySizeLimitError,
+		"key %s has size %d which is higher than storage key size limit %d.",
+		strings.Join([]string{owner, key}, "/"),
+		size,
+		limit)
+}
+
+// NewStateValueSizeLimitError constructs a CodedError which indicates that the
+// provided value has exceeded the size limit allowed by the storage.
+func NewStateValueSizeLimitError(
+	value flow.RegisterValue,
+	size uint64,
+	limit uint64,
+) *CodedError {
+	valueStr := ""
+	if len(value) > 23 {
+		valueStr = string(value[0:10]) + "..." + string(value[len(value)-10:])
+	} else {
+		valueStr = string(value)
 	}
+
+	return NewCodedError(
+		ErrCodeStateValueSizeLimitError,
+		"value %s has size %d which is higher than storage value size "+
+			"limit %d.",
+		valueStr,
+		size,
+		limit)
 }
 
-func (e StorageCapacityExceededError) Error() string {
-	return fmt.Sprintf("%s The account with address (%s) uses %d bytes of storage which is over its capacity (%d bytes). Capacity can be increased by adding FLOW tokens to the account.", e.Code().String(), e.address, e.storageUsed, e.storageCapacity)
+// NewLedgerInteractionLimitExceededError constructs a CodeError. It is
+// returned when a tx hits the maximum ledger interaction limit.
+func NewLedgerInteractionLimitExceededError(
+	used uint64,
+	limit uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeLedgerInteractionLimitExceededError,
+		"max interaction with storage has exceeded the limit "+
+			"(used: %d bytes, limit %d bytes)",
+		used,
+		limit)
 }
 
-// Code returns the error code for this error
-func (e StorageCapacityExceededError) Code() ErrorCode {
-	return ErrCodeStorageCapacityExceeded
+func IsLedgerInteractionLimitExceededError(err error) bool {
+	return HasErrorCode(err, ErrCodeLedgerInteractionLimitExceededError)
 }
 
-// EventLimitExceededError indicates that the transaction has produced events with size more than limit.
-type EventLimitExceededError struct {
-	totalByteSize uint64
-	limit         uint64
+// NewOperationNotSupportedError construct a new CodedError. It is generated
+// when an operation (e.g. getting block info) is not supported in the current
+// environment.
+func NewOperationNotSupportedError(operation string) *CodedError {
+	return NewCodedError(
+		ErrCodeOperationNotSupportedError,
+		"operation (%s) is not supported in this environment",
+		operation)
 }
 
-// NewEventLimitExceededError constructs a EventLimitExceededError
-func NewEventLimitExceededError(totalByteSize, limit uint64) EventLimitExceededError {
-	return EventLimitExceededError{
-		totalByteSize: totalByteSize,
-		limit:         limit,
-	}
+func IsOperationNotSupportedError(err error) bool {
+	return HasErrorCode(err, ErrCodeOperationNotSupportedError)
 }
 
-func (e EventLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"%s total event byte size (%d) exceeds limit (%d)",
-		e.Code().String(),
-		e.totalByteSize,
-		e.limit,
-	)
-}
-
-// Code returns the error code for this error
-func (e EventLimitExceededError) Code() ErrorCode {
-	return ErrCodeEventLimitExceededError
-}
-
-// A StateKeySizeLimitError indicates that the provided key has exceeded the size limit allowed by the storage
-type StateKeySizeLimitError struct {
-	owner string
-	key   string
-	size  uint64
-	limit uint64
-}
-
-// NewStateKeySizeLimitError constructs a StateKeySizeLimitError
-func NewStateKeySizeLimitError(owner, key string, size, limit uint64) StateKeySizeLimitError {
-	return StateKeySizeLimitError{
-		owner: owner,
-		key:   key,
-		size:  size,
-		limit: limit,
-	}
-}
-
-func (e StateKeySizeLimitError) Error() string {
-	return fmt.Sprintf("%s key %s has size %d which is higher than storage key size limit %d.", e.Code().String(), strings.Join([]string{e.owner, e.key}, "/"), e.size, e.limit)
-}
-
-// Code returns the error code for this error
-func (e StateKeySizeLimitError) Code() ErrorCode {
-	return ErrCodeStateKeySizeLimitError
-}
-
-// A StateValueSizeLimitError indicates that the provided value has exceeded the size limit allowed by the storage
-type StateValueSizeLimitError struct {
-	value flow.RegisterValue
-	size  uint64
-	limit uint64
-}
-
-// NewStateValueSizeLimitError constructs a StateValueSizeLimitError
-func NewStateValueSizeLimitError(value flow.RegisterValue, size, limit uint64) StateValueSizeLimitError {
-	return StateValueSizeLimitError{
-		value: value,
-		size:  size,
-		limit: limit,
-	}
-}
-
-func (e StateValueSizeLimitError) Error() string {
-	return fmt.Sprintf("%s value %s has size %d which is higher than storage value size limit %d.",
-		e.Code().String(), string(e.value[0:10])+"..."+string(e.value[len(e.value)-10:]), e.size, e.limit)
-}
-
-// Code returns the error code for this error
-func (e StateValueSizeLimitError) Code() ErrorCode {
-	return ErrCodeStateValueSizeLimitError
-}
-
-// LedgerInteractionLimitExceededError is returned when a tx hits the maximum ledger interaction limit
-type LedgerInteractionLimitExceededError struct {
-	used  uint64
-	limit uint64
-}
-
-// NewLedgerInteractionLimitExceededError constructs a LedgerInteractionLimitExceededError
-func NewLedgerInteractionLimitExceededError(used, limit uint64) LedgerInteractionLimitExceededError {
-	return LedgerInteractionLimitExceededError{
-		used:  used,
-		limit: limit,
-	}
-}
-
-func (e LedgerInteractionLimitExceededError) Error() string {
-	return fmt.Sprintf("%s max interaction with storage has exceeded the limit (used: %d bytes, limit %d bytes)", e.Code().String(), e.used, e.limit)
-}
-
-// Code returns the error code for this error
-func (e LedgerInteractionLimitExceededError) Code() ErrorCode {
-	return ErrCodeLedgerInteractionLimitExceededError
-}
-
-// OperationNotSupportedError is generated when an operation (e.g. getting block info) is
-// not supported in the current environment.
-type OperationNotSupportedError struct {
-	operation string
-}
-
-// NewOperationNotSupportedError construct a new OperationNotSupportedError
-func NewOperationNotSupportedError(operation string) OperationNotSupportedError {
-	return OperationNotSupportedError{
-		operation: operation,
-	}
-}
-
-func (e OperationNotSupportedError) Error() string {
-	return fmt.Sprintf("%s operation (%s) is not supported in this environment", e.Code().String(), e.operation)
-}
-
-// Code returns the error code for this error
-func (e OperationNotSupportedError) Code() ErrorCode {
-	return ErrCodeOperationNotSupportedError
-}
-
-// ScriptExecutionCancelledError indicates that Cadence Script execution
-// has been cancelled (e.g. request connection has been droped)
+// NewScriptExecutionCancelledError construct a new CodedError which indicates
+// that Cadence Script execution has been cancelled (e.g. request connection
+// has been droped)
 //
-// note: this error is used by scripts only and
-// won't be emitted for transactions since transaction execution has to be deterministic.
-type ScriptExecutionCancelledError struct {
-	errorWrapper
+// note: this error is used by scripts only and won't be emitted for
+// transactions since transaction execution has to be deterministic.
+func NewScriptExecutionCancelledError(err error) *CodedError {
+	return WrapCodedError(
+		ErrCodeScriptExecutionCancelledError,
+		err,
+		"script execution is cancelled")
 }
 
-// NewScriptExecutionCancelledError construct a new ScriptExecutionCancelledError
-func NewScriptExecutionCancelledError(err error) ScriptExecutionCancelledError {
-	return ScriptExecutionCancelledError{
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e ScriptExecutionCancelledError) Error() string {
-	return fmt.Sprintf(
-		"%s script execution is cancelled: %s",
-		e.Code().String(),
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error
-func (e ScriptExecutionCancelledError) Code() ErrorCode {
-	return ErrCodeScriptExecutionCancelledError
-}
-
-// ScriptExecutionTimedOutError indicates that Cadence Script execution
-// has been taking more time than what is allowed.
+// NewScriptExecutionTimedOutError construct a new CodedError which indicates
+// that Cadence Script execution has been taking more time than what is allowed.
 //
-// note: this error is used by scripts only and
-// won't be emitted for transactions since transaction execution has to be deterministic.
-type ScriptExecutionTimedOutError struct {
+// note: this error is used by scripts only and won't be emitted for
+// transactions since transaction execution has to be deterministic.
+func NewScriptExecutionTimedOutError() *CodedError {
+	return NewCodedError(
+		ErrCodeScriptExecutionTimedOutError,
+		"script execution is timed out and did not finish executing within "+
+			"the maximum execution time allowed")
 }
 
-// NewScriptExecutionTimedOutError construct a new ScriptExecutionTimedOutError
-func NewScriptExecutionTimedOutError() ScriptExecutionTimedOutError {
-	return ScriptExecutionTimedOutError{}
-}
-
-func (e ScriptExecutionTimedOutError) Error() string {
-	return fmt.Sprintf(
-		"%s script execution is timed out and did not finish executing within the maximum execution time allowed",
-		e.Code().String(),
-	)
-}
-
-// Code returns the error code for this error
-func (e ScriptExecutionTimedOutError) Code() ErrorCode {
-	return ErrCodeScriptExecutionTimedOutError
-}
-
-// An CouldNotGetExecutionParameterFromStateError indicates that computation has exceeded its limit.
-type CouldNotGetExecutionParameterFromStateError struct {
-	address string
-	path    string
-}
-
-// NewCouldNotGetExecutionParameterFromStateError constructs a new CouldNotGetExecutionParameterFromStateError
-func NewCouldNotGetExecutionParameterFromStateError(address, path string) CouldNotGetExecutionParameterFromStateError {
-	return CouldNotGetExecutionParameterFromStateError{
-		address: address,
-		path:    path,
-	}
-}
-
-// Code returns the error code for this error
-func (e CouldNotGetExecutionParameterFromStateError) Code() ErrorCode {
-	return ErrCodeCouldNotDecodeExecutionParameterFromState
-}
-
-func (e CouldNotGetExecutionParameterFromStateError) Error() string {
-	return fmt.Sprintf(
-		"%s could not get execution parameter from the state (address: %s path: %s)",
-		e.Code().String(),
-		e.address,
-		e.path,
-	)
+// NewCouldNotGetExecutionParameterFromStateError constructs a new CodedError
+// which indicates that computation has exceeded its limit.
+func NewCouldNotGetExecutionParameterFromStateError(
+	address string,
+	path string,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeCouldNotDecodeExecutionParameterFromState,
+		"could not get execution parameter from the state "+
+			"(address: %s path: %s)",
+		address,
+		path)
 }

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -1,14 +1,10 @@
 package errors
 
-import (
-	"errors"
-	"fmt"
-)
-
 func NewUnknownFailure(err error) *CodedFailure {
 	return WrapCodedFailure(
 		FailureCodeUnknownFailure,
-		fmt.Errorf("unknown failure: %w", err))
+		err,
+		"unknown failure")
 }
 
 // EncodingFailure captures an fatal error sourced from encoding issues
@@ -17,86 +13,42 @@ type EncodingFailure struct {
 }
 
 // NewEncodingFailuref formats and returns a new EncodingFailure
-func NewEncodingFailuref(msg string, err error) EncodingFailure {
-	return EncodingFailure{
-		errorWrapper: errorWrapper{err: fmt.Errorf(msg, err)},
-	}
+func NewEncodingFailuref(msg string, err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeEncodingFailure,
+		err,
+		"encoding failed: "+msg)
 }
 
-func (e EncodingFailure) Error() string {
-	return fmt.Sprintf("%s encoding failed: %s", e.FailureCode().String(), e.err.Error())
+// NewLedgerFailure constructs a new CodedFailure which captures a fatal error
+// cause by ledger failures.
+func NewLedgerFailure(err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeLedgerFailure,
+		err,
+		"ledger returns unsuccessful")
 }
 
-// FailureCode returns the failure code
-func (e EncodingFailure) FailureCode() ErrorCode {
-	return FailureCodeEncodingFailure
-}
-
-// LedgerFailure captures a fatal error cause by ledger failures
-type LedgerFailure struct {
-	errorWrapper
-}
-
-// NewLedgerFailure constructs a new LedgerFailure
-func NewLedgerFailure(err error) LedgerFailure {
-	return LedgerFailure{
-		errorWrapper: errorWrapper{err: err},
-	}
-}
-
-func (e LedgerFailure) Error() string {
-	return fmt.Sprintf("%s ledger returns unsuccessful: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e LedgerFailure) FailureCode() ErrorCode {
-	return FailureCodeLedgerFailure
-}
-
-// IsALedgerFailure returns true if the error or any of the wrapped errors is a ledger failure
+// IsALedgerFailure returns true if the error or any of the wrapped errors is
+// a ledger failure
 func IsALedgerFailure(err error) bool {
-	var t LedgerFailure
-	return errors.As(err, &t)
+	return HasErrorCode(err, FailureCodeLedgerFailure)
 }
 
-// StateMergeFailure captures a fatal caused by state merge
-type StateMergeFailure struct {
-	errorWrapper
+// NewStateMergeFailure constructs a new CodedFailure which captures a fatal
+// caused by state merge.
+func NewStateMergeFailure(err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeStateMergeFailure,
+		err,
+		"can not merge the state")
 }
 
-// NewStateMergeFailure constructs a new StateMergeFailure
-func NewStateMergeFailure(err error) StateMergeFailure {
-	return StateMergeFailure{
-		errorWrapper: errorWrapper{err: err},
-	}
-}
-
-func (e StateMergeFailure) Error() string {
-	return fmt.Sprintf("%s can not merge the state: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e StateMergeFailure) FailureCode() ErrorCode {
-	return FailureCodeStateMergeFailure
-}
-
-// BlockFinderFailure captures a fatal caused by block finder
-type BlockFinderFailure struct {
-	errorWrapper
-}
-
-// NewBlockFinderFailure constructs a new BlockFinderFailure
-func NewBlockFinderFailure(err error) BlockFinderFailure {
-	return BlockFinderFailure{
-		errorWrapper: errorWrapper{err: err},
-	}
-}
-
-func (e BlockFinderFailure) Error() string {
-	return fmt.Sprintf("%s can not retrieve the block: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e BlockFinderFailure) FailureCode() ErrorCode {
-	return FailureCodeBlockFinderFailure
+// NewBlockFinderFailure constructs a new CodedFailure which captures a fatal
+// caused by block finder.
+func NewBlockFinderFailure(err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeBlockFinderFailure,
+		err,
+		"can not retrieve the block")
 }

--- a/fvm/errors/txVerifier.go
+++ b/fvm/errors/txVerifier.go
@@ -6,40 +6,24 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// InvalidProposalSignatureError indicates that no valid signature is provided for the proposal key.
-type InvalidProposalSignatureError struct {
-	errorWrapper
-
-	address  flow.Address
-	keyIndex uint64
+// NewInvalidProposalSignatureError constructs a new CodedError which indicates
+// that no valid signature is provided for the proposal key.
+func NewInvalidProposalSignatureError(
+	address flow.Address,
+	keyIndex uint64,
+	err error,
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeInvalidProposalSignatureError,
+		err,
+		"invalid proposal key: public key %d on account %s does not have a "+
+			"valid signature",
+		keyIndex,
+		address)
 }
 
-// NewInvalidProposalSignatureError constructs a new InvalidProposalSignatureError
-func NewInvalidProposalSignatureError(address flow.Address, keyIndex uint64, err error) InvalidProposalSignatureError {
-	return InvalidProposalSignatureError{
-		address:  address,
-		keyIndex: keyIndex,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e InvalidProposalSignatureError) Error() string {
-	return fmt.Sprintf(
-		"%s invalid proposal key: public key %d on account %s does not have a valid signature: %s",
-		e.Code().String(),
-		e.keyIndex,
-		e.address,
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error type
-func (e InvalidProposalSignatureError) Code() ErrorCode {
-	return ErrCodeInvalidProposalSignatureError
-}
-
+// TODO(patrick): figure out how to provide additional error context.
+//
 // InvalidProposalSeqNumberError indicates that proposal key sequence number does not match the on-chain value.
 type InvalidProposalSeqNumberError struct {
 	address           flow.Address
@@ -82,78 +66,43 @@ func (e InvalidProposalSeqNumberError) Code() ErrorCode {
 	return ErrCodeInvalidProposalSeqNumberError
 }
 
-// InvalidPayloadSignatureError indicates that signature verification for a key in this transaction has failed.
-// this error is the result of failure in any of the following conditions:
+// NewInvalidPayloadSignatureError constructs a new CodedError which indicates
+// that signature verification for a key in this transaction has failed. This
+// error is the result of failure in any of the following conditions:
 // - provided hashing method is not supported
 // - signature size or format is invalid
 // - signature verification failed
-type InvalidPayloadSignatureError struct {
-	errorWrapper
-
-	address  flow.Address
-	keyIndex uint64
+func NewInvalidPayloadSignatureError(
+	address flow.Address,
+	keyIndex uint64,
+	err error,
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeInvalidPayloadSignatureError,
+		err,
+		"invalid payload signature: public key %d on account %s does not have"+
+			" a valid signature",
+		keyIndex,
+		address)
 }
 
-// NewInvalidPayloadSignatureError constructs a new InvalidPayloadSignatureError
-func NewInvalidPayloadSignatureError(address flow.Address, keyIndex uint64, err error) InvalidPayloadSignatureError {
-	return InvalidPayloadSignatureError{
-		address:  address,
-		keyIndex: keyIndex,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e InvalidPayloadSignatureError) Error() string {
-	return fmt.Sprintf(
-		"%s invalid payload signature: public key %d on account %s does not have a valid signature: %s",
-		e.Code().String(),
-		e.keyIndex,
-		e.address,
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error type
-func (e InvalidPayloadSignatureError) Code() ErrorCode {
-	return ErrCodeInvalidPayloadSignatureError
-}
-
-// InvalidEnvelopeSignatureError indicates that signature verification for a envelope key in this transaction has failed.
-// this error is the result of failure in any of the following conditions:
+// NewInvalidEnvelopeSignatureError constructs a new CodedError which indicates
+// that signature verification for a envelope key in this transaction has
+// failed. Tthis error is the result of failure in any of the following
+// conditions:
 // - provided hashing method is not supported
 // - signature size or format is invalid
 // - signature verification failed
-type InvalidEnvelopeSignatureError struct {
-	errorWrapper
-
-	address  flow.Address
-	keyIndex uint64
-}
-
-// NewInvalidEnvelopeSignatureError constructs a new InvalidEnvelopeSignatureError
-func NewInvalidEnvelopeSignatureError(address flow.Address, keyIndex uint64, err error) InvalidEnvelopeSignatureError {
-	return InvalidEnvelopeSignatureError{
-		address:  address,
-		keyIndex: keyIndex,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e InvalidEnvelopeSignatureError) Error() string {
-	return fmt.Sprintf(
-		"%s invalid envelope key: public key %d on account %s does not have a valid signature: %s",
-		e.Code().String(),
-		e.keyIndex,
-		e.address,
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error type
-func (e InvalidEnvelopeSignatureError) Code() ErrorCode {
-	return ErrCodeInvalidEnvelopeSignatureError
+func NewInvalidEnvelopeSignatureError(
+	address flow.Address,
+	keyIndex uint64,
+	err error,
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeInvalidEnvelopeSignatureError,
+		err,
+		"invalid envelope key: public key %d on account %s does not have a "+
+			"valid signature",
+		keyIndex,
+		address)
 }

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -415,7 +415,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		assert.Error(t, tx.Err)
 
 		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
-		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
+		assert.True(t, errors.IsCadenceRuntimeError(tx.Err))
 	})
 
 	t.Run("account update with set code fails if not signed by service account if dis-allowed in the state", func(t *testing.T) {
@@ -453,7 +453,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		assert.Error(t, tx.Err)
 
 		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
-		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
+		assert.True(t, errors.IsCadenceRuntimeError(tx.Err))
 	})
 
 	t.Run("account update with set succeeds if not signed by service account if allowed in the state", func(t *testing.T) {
@@ -568,7 +568,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		assert.Error(t, tx.Err)
 
 		assert.Contains(t, tx.Err.Error(), "removing contracts requires authorization from specific accounts")
-		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
+		assert.True(t, errors.IsCadenceRuntimeError(tx.Err))
 	})
 
 	t.Run("account update with code removal succeeds if signed by service account", func(t *testing.T) {
@@ -675,7 +675,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
 		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
-		assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
+		assert.True(t, errors.IsCadenceRuntimeError(tx.Err))
 
 		// Generate an audit voucher
 		authTxBody, err := AuditContractForDeploymentTransaction(
@@ -939,7 +939,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
-				assert.Equal(t, (&errors.StorageCapacityExceededError{}).Code(), tx.Err.Code())
+				assert.True(t, errors.IsStorageCapacityExceededError(tx.Err))
 			}))
 	t.Run("Increasing storage capacity works", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		run(
@@ -1053,7 +1053,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
-				assert.Equal(t, (&errors.LedgerInteractionLimitExceededError{}).Code(), tx.Err.Code())
+				assert.True(t, errors.IsLedgerInteractionLimitExceededError(tx.Err))
 			}))
 
 	t.Run("Using to much interaction but not failing because of service account", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
@@ -1129,7 +1129,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				require.NoError(t, err)
 				require.Error(t, tx.Err)
 
-				assert.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
+				assert.True(t, errors.IsCadenceRuntimeError(tx.Err))
 			}))
 }
 
@@ -1681,7 +1681,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
-			require.Equal(t, (&errors.StorageCapacityExceededError{}).Code(), tx.Err.Code())
+			require.True(t, errors.IsStorageCapacityExceededError(tx.Err))
 
 			balanceAfter := getBalance(vm, chain, ctx, view, accounts[0])
 
@@ -1729,7 +1729,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			err = vm.RunV2(ctx, tx, view)
 			require.NoError(t, err)
 
-			require.Equal(t, (&errors.CadenceRuntimeError{}).Code(), tx.Err.Code())
+			require.True(t, errors.IsCadenceRuntimeError(tx.Err))
 
 			balanceAfter := getBalance(vm, chain, ctx, view, accounts[0])
 
@@ -1807,7 +1807,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
-				require.IsType(t, errors.CadenceRuntimeError{}, tx.Err)
+				require.True(t, errors.IsCadenceRuntimeError(tx.Err))
 
 				// send it again
 				tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1243,8 +1243,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			// There are 100 breaks and each break uses 1_000_000 memory
 			require.Greater(t, tx.MemoryEstimate, uint64(100_000_000))
 
-			var memoryLimitExceededError errors.MemoryLimitExceededError
-			assert.ErrorAs(t, tx.Err, &memoryLimitExceededError)
+			assert.True(t, errors.IsMemoryLimitExceededError(tx.Err))
 		},
 	))
 
@@ -1720,10 +1719,9 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
+				require.True(t, errors.IsCadenceRuntimeError(script.Err))
 				// modifications to contracts are not supported in scripts
-				unsupportedOperationError := errors.OperationNotSupportedError{}
-				require.ErrorAs(t, script.Err, &unsupportedOperationError)
+				require.True(t, errors.IsOperationNotSupportedError(script.Err))
 			},
 		),
 	)
@@ -1779,10 +1777,9 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				err = vm.RunV2(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
+				require.True(t, errors.IsCadenceRuntimeError(script.Err))
 				// modifications to contracts are not supported in scripts
-				unsupportedOperationError := errors.OperationNotSupportedError{}
-				require.ErrorAs(t, script.Err, &unsupportedOperationError)
+				require.True(t, errors.IsOperationNotSupportedError(script.Err))
 			},
 		),
 	)
@@ -1837,10 +1834,9 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				err = vm.RunV2(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
+				require.True(t, errors.IsCadenceRuntimeError(script.Err))
 				// modifications to contracts are not supported in scripts
-				unsupportedOperationError := errors.OperationNotSupportedError{}
-				require.ErrorAs(t, script.Err, &unsupportedOperationError)
+				require.True(t, errors.IsOperationNotSupportedError(script.Err))
 			},
 		),
 	)
@@ -1885,10 +1881,9 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
+				require.True(t, errors.IsCadenceRuntimeError(script.Err))
 				// modifications to public keys are not supported in scripts
-				unsupportedOperationError := errors.OperationNotSupportedError{}
-				require.ErrorAs(t, script.Err, &unsupportedOperationError)
+				require.True(t, errors.IsOperationNotSupportedError(script.Err))
 			},
 		),
 	)
@@ -1921,10 +1916,9 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 				err = vm.RunV2(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
-				require.IsType(t, errors.CadenceRuntimeError{}, script.Err)
+				require.True(t, errors.IsCadenceRuntimeError(script.Err))
 				// modifications to public keys are not supported in scripts
-				unsupportedOperationError := errors.OperationNotSupportedError{}
-				require.ErrorAs(t, script.Err, &unsupportedOperationError)
+				require.True(t, errors.IsOperationNotSupportedError(script.Err))
 			},
 		),
 	)

--- a/fvm/meter/meter_test.go
+++ b/fvm/meter/meter_test.go
@@ -57,7 +57,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.(errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(10).Error())
+		require.Equal(t, err.Error(), errors.NewComputationLimitExceededError(10).Error())
 
 		err = m.MeterMemory(0, 2)
 		require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 8)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.(errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(10).Error())
+		require.Equal(t, err.Error(), errors.NewMemoryLimitExceededError(10).Error())
 	})
 
 	t.Run("meter computation and memory with weights", func(t *testing.T) {
@@ -159,7 +159,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterComputation(compKind, 0)
 		require.Error(t, err)
 		require.True(t, errors.IsComputationLimitExceededError(err))
-		require.Equal(t, err.(errors.ComputationLimitExceededError).Error(), errors.NewComputationLimitExceededError(9).Error())
+		require.Equal(t, err.Error(), errors.NewComputationLimitExceededError(9).Error())
 	})
 
 	t.Run("merge meters - ignore limits", func(t *testing.T) {
@@ -227,7 +227,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err = m.MeterMemory(0, 0)
 		require.Error(t, err)
 		require.True(t, errors.IsMemoryLimitExceededError(err))
-		require.Equal(t, err.(errors.MemoryLimitExceededError).Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
+		require.Equal(t, err.Error(), errors.NewMemoryLimitExceededError(math.MaxUint32).Error())
 	})
 
 	t.Run("add intensity - test limits - computation", func(t *testing.T) {

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -221,7 +221,10 @@ func (i TransactionInvoker) deductTransactionFees(
 		computationUsed)
 
 	if err != nil {
-		return errors.NewTransactionFeeDeductionFailedError(proc.Transaction.Payer, err)
+		return errors.NewTransactionFeeDeductionFailedError(
+			proc.Transaction.Payer,
+			computationUsed,
+			err)
 	}
 	return nil
 }

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -110,8 +110,11 @@ func TestTransactionVerification(t *testing.T) {
 		err = txVerifier.Process(fvm.Context{}, proc, stTxn, nil)
 		require.Error(t, err)
 
-		var envelopeError errors.InvalidEnvelopeSignatureError
-		require.ErrorAs(t, err, &envelopeError)
+		require.True(
+			t,
+			errors.HasErrorCode(
+				err,
+				errors.ErrCodeInvalidEnvelopeSignatureError))
 	})
 
 	t.Run("invalid payload signature", func(t *testing.T) {
@@ -146,8 +149,11 @@ func TestTransactionVerification(t *testing.T) {
 		err = txVerifier.Process(fvm.Context{}, proc, stTxn, nil)
 		require.Error(t, err)
 
-		var payloadError errors.InvalidPayloadSignatureError
-		require.ErrorAs(t, err, &payloadError)
+		require.True(
+			t,
+			errors.HasErrorCode(
+				err,
+				errors.ErrCodeInvalidPayloadSignatureError))
 	})
 
 	t.Run("invalid payload and envelope signatures", func(t *testing.T) {
@@ -180,8 +186,11 @@ func TestTransactionVerification(t *testing.T) {
 		require.Error(t, err)
 
 		// TODO: update to InvalidEnvelopeSignatureError once FVM verifier is updated.
-		var payloadError errors.InvalidPayloadSignatureError
-		require.ErrorAs(t, err, &payloadError)
+		require.True(
+			t,
+			errors.HasErrorCode(
+				err,
+				errors.ErrCodeInvalidPayloadSignatureError))
 	})
 
 	t.Run("frozen account is rejected", func(t *testing.T) {

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/engine/execution/testutil"
@@ -201,11 +202,12 @@ func TestAccountFreezing(t *testing.T) {
 		require.Error(t, proc.Err)
 
 		// find frozen account specific error
-		require.IsType(t, errors.CadenceRuntimeError{}, proc.Err)
-		err = proc.Err.(errors.CadenceRuntimeError).Unwrap()
+		require.True(t, errors.IsCadenceRuntimeError(proc.Err))
 
-		require.IsType(t, runtime.Error{}, err)
-		err = err.(runtime.Error).Err
+		var rtErr runtime.Error
+		assert.True(t, errors.As(proc.Err, &rtErr))
+
+		err = rtErr.Err
 
 		require.IsType(t, &runtime.ParsingCheckingError{}, err)
 		err = err.(*runtime.ParsingCheckingError).Err
@@ -345,11 +347,12 @@ func TestAccountFreezing(t *testing.T) {
 		require.Error(t, proc.Err)
 
 		// find frozen account specific error
-		require.IsType(t, errors.CadenceRuntimeError{}, proc.Err)
-		err = proc.Err.(errors.CadenceRuntimeError).Unwrap()
+		require.True(t, errors.IsCadenceRuntimeError(proc.Err))
 
-		require.IsType(t, runtime.Error{}, err)
-		err = err.(runtime.Error).Err
+		var rtErr runtime.Error
+		assert.True(t, errors.As(proc.Err, &rtErr))
+
+		err = rtErr.Err
 
 		require.IsType(t, &runtime.ParsingCheckingError{}, err)
 		err = err.(*runtime.ParsingCheckingError).Err


### PR DESCRIPTION
NOTE:
- I've deprecated fvm internal error since it's no longer used and is wrong ( fvm internal error should be treated as failure)
- I've added an bound check to the valueStr in StateValueSizeLimitError (the refactor discovered a previously hidden out-of-bound panic)
- NewTransactionFeeDeductionFailedError now takes the TxFees as argument as well (We forgot to initalize the TxFees value)
- I've left FrozenAccountError and InvalidProposalSeqNumberError alone since these requires additional error context (I'll handles these in a followup PR)