### PR TITLE
Deprecate/delete FVMInternalError

### DIFF
--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -213,28 +213,3 @@ func (e AccountAuthorizationError) Error() string {
 func (e AccountAuthorizationError) Code() ErrorCode {
 	return ErrCodeAccountAuthorizationError
 }
-
-// FVMInternalError indicates that an internal error occurs during tx execution.
-type FVMInternalError struct {
-	errorWrapper
-
-	msg string
-}
-
-// NewFVMInternalErrorf constructs a new FVMInternalError
-func NewFVMInternalErrorf(msg string, args ...interface{}) FVMInternalError {
-	return FVMInternalError{
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e FVMInternalError) Error() string {
-	return e.msg
-}
-
-// Code returns the error code for this error type
-func (e FVMInternalError) Code() ErrorCode {
-	return ErrCodeFVMInternalError
-}

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -47,6 +47,7 @@ const (
 	ErrCodeInvalidEnvelopeSignatureError ErrorCode = 1009
 
 	// base errors 1050 - 1100
+	// Deprecated: No longer used.
 	ErrCodeFVMInternalError            ErrorCode = 1050
 	ErrCodeValueError                  ErrorCode = 1051
 	ErrCodeInvalidArgumentError        ErrorCode = 1052


### PR DESCRIPTION
it's no longer used and is wrong (fvm internal error should be treated as failure)