### PR TITLE
[Execution] Fixing improper use of WaitGroup in a goroutine for upload retry

### DIFF
--- a/engine/execution/computation/computer/uploader/retryable_uploader_wrapper.go
+++ b/engine/execution/computation/computer/uploader/retryable_uploader_wrapper.go
@@ -138,6 +138,8 @@ func (b *BadgerRetryableUploaderWrapper) RetryUpload() error {
 	for _, blockID := range blockIDs {
 		wg.Add(1)
 		go func(blockID flow.Identifier) {
+			defer wg.Done()
+
 			var cr_err error
 			retComputationResult, err := b.reconstructComputationResult(blockID)
 			if err != nil {
@@ -155,8 +157,6 @@ func (b *BadgerRetryableUploaderWrapper) RetryUpload() error {
 			}
 
 			b.metrics.ExecutionComputationResultUploadRetried()
-
-			wg.Done()
 		}(blockID)
 	}
 	wg.Wait()


### PR DESCRIPTION
`wg.Done()` should be called by a `defer` in a goroutine. Thanks @peterargue for finding out this naive bug I made.

Test
- [X] artificially made reconstructing computation result fail and reboot EN and make sure nothing was dead locked.

Will port this PR to `v0.27` after merged.