### PR TITLE
Replace error/failure structs with CodedError/CodedFailure (Part 1)

### DIFF
--- a/fvm/environment/accounts.go
+++ b/fvm/environment/accounts.go
@@ -367,8 +367,10 @@ func (a *StatefulAccounts) setContractNames(contractNames contractNames, address
 	cborEncoder := cbor.NewEncoder(&buf)
 	err = cborEncoder.Encode(contractNames)
 	if err != nil {
-		msg := fmt.Sprintf("cannot encode contract names: %s", contractNames)
-		return errors.NewEncodingFailuref(msg, err)
+		return errors.NewEncodingFailuref(
+			err,
+			"cannot encode contract names: %s",
+			contractNames)
 	}
 	newContractNames := buf.Bytes()
 

--- a/fvm/environment/event_emitter.go
+++ b/fvm/environment/event_emitter.go
@@ -124,8 +124,8 @@ func (emitter *eventEmitter) EmitEvent(event cadence.Event) error {
 	payload, err := jsoncdc.Encode(event)
 	if err != nil {
 		return errors.NewEncodingFailuref(
-			"failed to json encode a cadence event: %w",
-			err)
+			err,
+			"failed to json encode a cadence event")
 	}
 
 	payloadSize := uint64(len(payload))

--- a/fvm/errors/accounts.go
+++ b/fvm/errors/accounts.go
@@ -19,29 +19,16 @@ func IsAccountNotFoundError(err error) bool {
 	return HasErrorCode(err, ErrCodeAccountNotFoundError)
 }
 
-// AccountAlreadyExistsError is returned when account creation fails because
-// another account already exist at that address
+// NewAccountAlreadyExistsError constructs a new CodedError. It is returned
+// when account creation fails because another account already exist at that
+// address.
+//
 // TODO maybe this should be failure since user has no control over this
-type AccountAlreadyExistsError struct {
-	address flow.Address
-}
-
-// NewAccountAlreadyExistsError constructs a new AccountAlreadyExistsError
-func NewAccountAlreadyExistsError(address flow.Address) AccountAlreadyExistsError {
-	return AccountAlreadyExistsError{address: address}
-}
-
-func (e AccountAlreadyExistsError) Error() string {
-	return fmt.Sprintf(
-		"%s account with address %s already exists",
-		e.Code().String(),
-		e.address,
-	)
-}
-
-// Code returns the error code for this error type
-func (e AccountAlreadyExistsError) Code() ErrorCode {
-	return ErrCodeAccountAlreadyExistsError
+func NewAccountAlreadyExistsError(address flow.Address) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountAlreadyExistsError,
+		"account with address %s already exists",
+		address)
 }
 
 // AccountPublicKeyNotFoundError is returned when a public key not found for the given address and key index
@@ -99,36 +86,17 @@ func (e FrozenAccountError) Code() ErrorCode {
 	return ErrCodeFrozenAccountError
 }
 
-// AccountPublicKeyLimitError is returned when an account tries to add public keys over the limit
-type AccountPublicKeyLimitError struct {
-	address flow.Address
-	counts  uint64
-	limit   uint64
-}
-
-// NewAccountPublicKeyLimitError constructs a new AccountPublicKeyLimitError
-func NewAccountPublicKeyLimitError(address flow.Address, counts, limit uint64) AccountPublicKeyLimitError {
-	return AccountPublicKeyLimitError{
-		address: address,
-		counts:  counts,
-		limit:   limit,
-	}
-}
-
-// Address returns the address of frozen account
-func (e AccountPublicKeyLimitError) Address() flow.Address {
-	return e.address
-}
-
-func (e AccountPublicKeyLimitError) Error() string {
-	return fmt.Sprintf("%s account's (%s) public key count (%d) exceeded the limit (%d)",
-		e.Code().String(),
-		e.address,
-		e.counts,
-		e.limit)
-}
-
-// Code returns the error code for this error type
-func (e AccountPublicKeyLimitError) Code() ErrorCode {
-	return ErrCodeAccountPublicKeyLimitError
+// NewAccountPublicKeyLimitError constructs a new CodedError.  It is returned
+// when an account tries to add public keys over the limit.
+func NewAccountPublicKeyLimitError(
+	address flow.Address,
+	counts uint64,
+	limit uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountPublicKeyLimitError,
+		"account's (%s) public key count (%d) exceeded the limit (%d)",
+		address,
+		counts,
+		limit)
 }

--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -8,36 +8,18 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// InvalidAddressError indicates that a transaction references an invalid flow Address
-// in either the Authorizers or Payer field.
-type InvalidAddressError struct {
-	errorWrapper
-
-	address flow.Address
-}
-
-// Address returns the invalid address
-func (e InvalidAddressError) Address() flow.Address {
-	return e.address
-}
-
-// NewInvalidAddressErrorf constructs a new InvalidAddressError
-func NewInvalidAddressErrorf(address flow.Address, msg string, args ...interface{}) InvalidAddressError {
-	return InvalidAddressError{
-		address: address,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e InvalidAddressError) Error() string {
-	return fmt.Sprintf("%s invalid address (%s): %s", e.Code().String(), e.address.String(), e.err.Error())
-}
-
-// Code returns the error code for this error type
-func (e InvalidAddressError) Code() ErrorCode {
-	return ErrCodeInvalidAddressError
+// NewInvalidAddressErrorf constructs a new CodedError which indicates that a
+// transaction references an invalid flow Address in either the Authorizers or
+// Payer field.
+func NewInvalidAddressErrorf(
+	address flow.Address,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeInvalidAddressError,
+		"invalid address (%s): "+msg,
+		append([]interface{}{address.String()}, args...)...)
 }
 
 // InvalidArgumentError indicates that a transaction includes invalid arguments.
@@ -66,44 +48,22 @@ func (e InvalidArgumentError) Code() ErrorCode {
 	return ErrCodeInvalidArgumentError
 }
 
-// InvalidLocationError indicates an invalid location is passed
-type InvalidLocationError struct {
-	errorWrapper
-
-	location runtime.Location
-}
-
-// NewInvalidLocationErrorf constructs a new InvalidLocationError
-func NewInvalidLocationErrorf(location runtime.Location, msg string, args ...interface{}) InvalidLocationError {
-	return InvalidLocationError{location: location,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e InvalidLocationError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-
+// NewInvalidLocationErrorf constructs a new CodedError which indicates an
+// invalid location is passed.
+func NewInvalidLocationErrorf(
+	location runtime.Location,
+	msg string,
+	args ...interface{},
+) *CodedError {
 	locationStr := ""
-	if e.location != nil {
-		locationStr = e.location.String()
+	if location != nil {
+		locationStr = location.String()
 	}
 
-	return fmt.Sprintf(
-		"%s location (%s) is not a valid location: %s",
-		e.Code().String(),
-		locationStr,
-		errMsg,
-	)
-}
-
-// Code returns the error code for this error
-func (e InvalidLocationError) Code() ErrorCode {
-	return ErrCodeInvalidLocationError
+	return NewCodedError(
+		ErrCodeInvalidLocationError,
+		"location (%s) is not a valid location: "+msg,
+		append([]interface{}{locationStr}, args...)...)
 }
 
 // ValueError indicates a value is not valid value.
@@ -140,40 +100,18 @@ func IsValueError(err error) bool {
 	return As(err, &valErr)
 }
 
-// OperationAuthorizationError indicates not enough authorization
-// to perform an operations like account creation or smart contract deployment.
-type OperationAuthorizationError struct {
-	errorWrapper
-
-	operation string
-}
-
-// NewOperationAuthorizationErrorf constructs a new OperationAuthorizationError
-func NewOperationAuthorizationErrorf(operation string, msg string, args ...interface{}) OperationAuthorizationError {
-	return OperationAuthorizationError{
-		operation: operation,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e OperationAuthorizationError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-	return fmt.Sprintf(
-		"%s (%s) is not authorized: %s",
-		e.Code().String(),
-		e.operation,
-		errMsg,
-	)
-}
-
-// Code returns the error code for this error type
-func (e OperationAuthorizationError) Code() ErrorCode {
-	return ErrCodeOperationAuthorizationError
+// NewOperationAuthorizationErrorf constructs a new CodedError which indicates
+// not enough authorization to perform an operations like account creation or
+// smart contract deployment.
+func NewOperationAuthorizationErrorf(
+	operation string,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeOperationAuthorizationError,
+		"(%s) is not authorized: "+msg,
+		append([]interface{}{operation}, args...)...)
 }
 
 // AccountAuthorizationError indicates that an authorization issues

--- a/fvm/errors/contracts.go
+++ b/fvm/errors/contracts.go
@@ -1,35 +1,17 @@
 package errors
 
 import (
-	"fmt"
-
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// ContractNotFoundError is returned when an account contract is not found
-type ContractNotFoundError struct {
-	address  flow.Address
-	contract string
-}
-
-// NewContractNotFoundError constructs a new ContractNotFoundError
-func NewContractNotFoundError(address flow.Address, contract string) ContractNotFoundError {
-	return ContractNotFoundError{
-		address:  address,
-		contract: contract,
-	}
-}
-
-func (e ContractNotFoundError) Error() string {
-	return fmt.Sprintf(
-		"%s contract %s not found for address %s",
-		e.Code().String(),
-		e.contract,
-		e.address,
-	)
-}
-
-// Code returns the error code for this error type
-func (e ContractNotFoundError) Code() ErrorCode {
-	return ErrCodeContractNotFoundError
+// NewContractNotFoundError constructs a new ErrContractNotFoundError error
+func NewContractNotFoundError(
+	address flow.Address,
+	contract string,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeContractNotFoundError,
+		"contract %s not found for address %s",
+		contract,
+		address)
 }

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -10,14 +10,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// ExecutionError captures errors when executing a transaction/script.
-// A transaction having this error has already passed validation and is included in a collection.
-// the transaction will be executed by execution nodes but the result is reverted
-// and in some cases there will be a penalty (or fees) for the payer, access nodes or collection nodes.
-type ExecutionError interface {
-	Error
-}
-
 // CadenceRuntimeError captures a collection of errors provided by cadence runtime
 // it cover cadence errors such as
 // NotDeclaredError, NotInvokableError, ArgumentCountError, TransactionNotDeclaredError,
@@ -117,35 +109,18 @@ func IsComputationLimitExceededError(err error) bool {
 	return errors.As(err, &t)
 }
 
-// An MemoryLimitExceededError indicates that execution has exceeded its memory limits.
-type MemoryLimitExceededError struct {
-	limit uint64
+// NewMemoryLimitExceededError constructs a new CodedError which indicates
+// that execution has exceeded its memory limits.
+func NewMemoryLimitExceededError(limit uint64) *CodedError {
+	return NewCodedError(
+		ErrCodeMemoryLimitExceededError,
+		"memory usage exceeds limit (%d)",
+		limit)
 }
 
-// NewMemoryLimitExceededError constructs a new MemoryLimitExceededError
-func NewMemoryLimitExceededError(limit uint64) MemoryLimitExceededError {
-	return MemoryLimitExceededError{
-		limit: limit,
-	}
-}
-
-// Code returns the error code for this error
-func (e MemoryLimitExceededError) Code() ErrorCode {
-	return ErrCodeMemoryLimitExceededError
-}
-
-func (e MemoryLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"%s memory usage exceeds limit (%d)",
-		e.Code().String(),
-		e.limit,
-	)
-}
-
-// IsMemoryLimitExceededError returns true if error has this type
+// IsMemoryLimitExceededError returns true if error has this code.
 func IsMemoryLimitExceededError(err error) bool {
-	var t MemoryLimitExceededError
-	return errors.As(err, &t)
+	return HasErrorCode(err, ErrCodeMemoryLimitExceededError)
 }
 
 // An StorageCapacityExceededError indicates that an account used more storage than it has storage capacity.
@@ -206,31 +181,20 @@ func (e EventLimitExceededError) Code() ErrorCode {
 	return ErrCodeEventLimitExceededError
 }
 
-// A StateKeySizeLimitError indicates that the provided key has exceeded the size limit allowed by the storage
-type StateKeySizeLimitError struct {
-	owner string
-	key   string
-	size  uint64
-	limit uint64
-}
-
-// NewStateKeySizeLimitError constructs a StateKeySizeLimitError
-func NewStateKeySizeLimitError(owner, key string, size, limit uint64) StateKeySizeLimitError {
-	return StateKeySizeLimitError{
-		owner: owner,
-		key:   key,
-		size:  size,
-		limit: limit,
-	}
-}
-
-func (e StateKeySizeLimitError) Error() string {
-	return fmt.Sprintf("%s key %s has size %d which is higher than storage key size limit %d.", e.Code().String(), strings.Join([]string{e.owner, e.key}, "/"), e.size, e.limit)
-}
-
-// Code returns the error code for this error
-func (e StateKeySizeLimitError) Code() ErrorCode {
-	return ErrCodeStateKeySizeLimitError
+// NewStateKeySizeLimitError constructs a CodedError which indicates that the
+// provided key has exceeded the size limit allowed by the storage.
+func NewStateKeySizeLimitError(
+	owner string,
+	key string,
+	size uint64,
+	limit uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeStateKeySizeLimitError,
+		"key %s has size %d which is higher than storage key size limit %d.",
+		strings.Join([]string{owner, key}, "/"),
+		size,
+		limit)
 }
 
 // A StateValueSizeLimitError indicates that the provided value has exceeded the size limit allowed by the storage
@@ -266,32 +230,22 @@ func (e StateValueSizeLimitError) Code() ErrorCode {
 	return ErrCodeStateValueSizeLimitError
 }
 
-// LedgerInteractionLimitExceededError is returned when a tx hits the maximum ledger interaction limit
-type LedgerInteractionLimitExceededError struct {
-	used  uint64
-	limit uint64
-}
-
-// NewLedgerInteractionLimitExceededError constructs a LedgerInteractionLimitExceededError
-func NewLedgerInteractionLimitExceededError(used, limit uint64) LedgerInteractionLimitExceededError {
-	return LedgerInteractionLimitExceededError{
-		used:  used,
-		limit: limit,
-	}
-}
-
-func (e LedgerInteractionLimitExceededError) Error() string {
-	return fmt.Sprintf("%s max interaction with storage has exceeded the limit (used: %d bytes, limit %d bytes)", e.Code().String(), e.used, e.limit)
-}
-
-// Code returns the error code for this error
-func (e LedgerInteractionLimitExceededError) Code() ErrorCode {
-	return ErrCodeLedgerInteractionLimitExceededError
+// NewLedgerInteractionLimitExceededError constructs a CodeError. It is
+// returned when a tx hits the maximum ledger interaction limit.
+func NewLedgerInteractionLimitExceededError(
+	used uint64,
+	limit uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeLedgerInteractionLimitExceededError,
+		"max interaction with storage has exceeded the limit "+
+			"(used: %d bytes, limit %d bytes)",
+		used,
+		limit)
 }
 
 func IsLedgerInteractionLimitExceededError(err error) bool {
-	var t LedgerInteractionLimitExceededError
-	return As(err, &t)
+	return HasErrorCode(err, ErrCodeLedgerInteractionLimitExceededError)
 }
 
 // OperationNotSupportedError is generated when an operation (e.g. getting block info) is
@@ -321,35 +275,17 @@ func IsOperationNotSupportedError(err error) bool {
 	return As(err, &t)
 }
 
-// ScriptExecutionCancelledError indicates that Cadence Script execution
-// has been cancelled (e.g. request connection has been droped)
+// NewScriptExecutionCancelledError construct a new CodedError which indicates
+// that Cadence Script execution has been cancelled (e.g. request connection
+// has been droped)
 //
-// note: this error is used by scripts only and
-// won't be emitted for transactions since transaction execution has to be deterministic.
-type ScriptExecutionCancelledError struct {
-	errorWrapper
-}
-
-// NewScriptExecutionCancelledError construct a new ScriptExecutionCancelledError
-func NewScriptExecutionCancelledError(err error) ScriptExecutionCancelledError {
-	return ScriptExecutionCancelledError{
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e ScriptExecutionCancelledError) Error() string {
-	return fmt.Sprintf(
-		"%s script execution is cancelled: %s",
-		e.Code().String(),
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error
-func (e ScriptExecutionCancelledError) Code() ErrorCode {
-	return ErrCodeScriptExecutionCancelledError
+// note: this error is used by scripts only and won't be emitted for
+// transactions since transaction execution has to be deterministic.
+func NewScriptExecutionCancelledError(err error) *CodedError {
+	return WrapCodedError(
+		ErrCodeScriptExecutionCancelledError,
+		err,
+		"script execution is cancelled")
 }
 
 // ScriptExecutionTimedOutError indicates that Cadence Script execution
@@ -377,30 +313,16 @@ func (e ScriptExecutionTimedOutError) Code() ErrorCode {
 	return ErrCodeScriptExecutionTimedOutError
 }
 
-// An CouldNotGetExecutionParameterFromStateError indicates that computation has exceeded its limit.
-type CouldNotGetExecutionParameterFromStateError struct {
-	address string
-	path    string
-}
-
-// NewCouldNotGetExecutionParameterFromStateError constructs a new CouldNotGetExecutionParameterFromStateError
-func NewCouldNotGetExecutionParameterFromStateError(address, path string) CouldNotGetExecutionParameterFromStateError {
-	return CouldNotGetExecutionParameterFromStateError{
-		address: address,
-		path:    path,
-	}
-}
-
-// Code returns the error code for this error
-func (e CouldNotGetExecutionParameterFromStateError) Code() ErrorCode {
-	return ErrCodeCouldNotDecodeExecutionParameterFromState
-}
-
-func (e CouldNotGetExecutionParameterFromStateError) Error() string {
-	return fmt.Sprintf(
-		"%s could not get execution parameter from the state (address: %s path: %s)",
-		e.Code().String(),
-		e.address,
-		e.path,
-	)
+// NewCouldNotGetExecutionParameterFromStateError constructs a new CodedError
+// which indicates that computation has exceeded its limit.
+func NewCouldNotGetExecutionParameterFromStateError(
+	address string,
+	path string,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeCouldNotDecodeExecutionParameterFromState,
+		"could not get execution parameter from the state "+
+			"(address: %s path: %s)",
+		address,
+		path)
 }

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -8,28 +8,22 @@ import (
 func NewUnknownFailure(err error) *CodedFailure {
 	return WrapCodedFailure(
 		FailureCodeUnknownFailure,
-		fmt.Errorf("unknown failure: %w", err))
+		err,
+		"unknown failure")
 }
 
-// EncodingFailure captures an fatal error sourced from encoding issues
-type EncodingFailure struct {
-	errorWrapper
-}
-
-// NewEncodingFailuref formats and returns a new EncodingFailure
-func NewEncodingFailuref(msg string, err error) EncodingFailure {
-	return EncodingFailure{
-		errorWrapper: errorWrapper{err: fmt.Errorf(msg, err)},
-	}
-}
-
-func (e EncodingFailure) Error() string {
-	return fmt.Sprintf("%s encoding failed: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e EncodingFailure) FailureCode() ErrorCode {
-	return FailureCodeEncodingFailure
+// NewEncodingFailure formats and returns a new CodedFailure which
+// captures an fatal error sourced from encoding issues
+func NewEncodingFailuref(
+	err error,
+	msg string,
+	args ...interface{},
+) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeEncodingFailure,
+		err,
+		"encoding failed: "+msg,
+		args...)
 }
 
 // LedgerFailure captures a fatal error cause by ledger failures
@@ -80,23 +74,11 @@ func (e StateMergeFailure) FailureCode() ErrorCode {
 	return FailureCodeStateMergeFailure
 }
 
-// BlockFinderFailure captures a fatal caused by block finder
-type BlockFinderFailure struct {
-	errorWrapper
-}
-
-// NewBlockFinderFailure constructs a new BlockFinderFailure
-func NewBlockFinderFailure(err error) BlockFinderFailure {
-	return BlockFinderFailure{
-		errorWrapper: errorWrapper{err: err},
-	}
-}
-
-func (e BlockFinderFailure) Error() string {
-	return fmt.Sprintf("%s can not retrieve the block: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e BlockFinderFailure) FailureCode() ErrorCode {
-	return FailureCodeBlockFinderFailure
+// NewBlockFinderFailure constructs a new CodedFailure which captures a fatal
+// caused by block finder.
+func NewBlockFinderFailure(err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeBlockFinderFailure,
+		err,
+		"can not retrieve the block")
 }

--- a/fvm/errors/todo_rm_emulator_hack.go
+++ b/fvm/errors/todo_rm_emulator_hack.go
@@ -1,0 +1,32 @@
+package errors
+
+// The only purpose of this file is to enable flow-go integration test to
+// build.
+//
+// TODO(patrick): update emulator error classification
+//
+// TODO(patrick): remove this file once emulator is updated.
+
+// DO NOT USE.
+type InvalidProposalSignatureError struct{ CodedError }
+
+// DO NOT USE.
+type AccountNotFoundError struct{ CodedError }
+
+// DO NOT USE.
+type InvalidAddressError struct{ CodedError }
+
+// DO NOT USE.
+type InvalidEnvelopeSignatureError struct{ CodedError }
+
+// DO NOT USE.
+//type InvalidProposalSeqNumberError struct{ CodedError }
+
+// DO NOT USE.
+//type InvalidPayloadSignatureError struct{ CodedError }
+
+// DO NOT USE.
+//type AccountAuthorizationError struct{ CodedError }
+
+// DO NOT USE.
+//type AccountPublicKeyNotFoundError struct{ CodedError }

--- a/fvm/errors/txVerifier.go
+++ b/fvm/errors/txVerifier.go
@@ -6,38 +6,20 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// InvalidProposalSignatureError indicates that no valid signature is provided for the proposal key.
-type InvalidProposalSignatureError struct {
-	errorWrapper
-
-	address  flow.Address
-	keyIndex uint64
-}
-
-// NewInvalidProposalSignatureError constructs a new InvalidProposalSignatureError
-func NewInvalidProposalSignatureError(address flow.Address, keyIndex uint64, err error) InvalidProposalSignatureError {
-	return InvalidProposalSignatureError{
-		address:  address,
-		keyIndex: keyIndex,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e InvalidProposalSignatureError) Error() string {
-	return fmt.Sprintf(
-		"%s invalid proposal key: public key %d on account %s does not have a valid signature: %s",
-		e.Code().String(),
-		e.keyIndex,
-		e.address,
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error type
-func (e InvalidProposalSignatureError) Code() ErrorCode {
-	return ErrCodeInvalidProposalSignatureError
+// NewInvalidProposalSignatureError constructs a new CodedError which indicates
+// that no valid signature is provided for the proposal key.
+func NewInvalidProposalSignatureError(
+	address flow.Address,
+	keyIndex uint64,
+	err error,
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeInvalidProposalSignatureError,
+		err,
+		"invalid proposal key: public key %d on account %s does not have a "+
+			"valid signature",
+		keyIndex,
+		address)
 }
 
 // InvalidProposalSeqNumberError indicates that proposal key sequence number does not match the on-chain value.
@@ -125,45 +107,27 @@ func IsInvalidPayloadSignatureError(err error) bool {
 	return As(err, &t)
 }
 
-// InvalidEnvelopeSignatureError indicates that signature verification for a envelope key in this transaction has failed.
-// this error is the result of failure in any of the following conditions:
+// NewInvalidEnvelopeSignatureError constructs a new CodedError which indicates
+// that signature verification for a envelope key in this transaction has
+// failed. Tthis error is the result of failure in any of the following
+// conditions:
 // - provided hashing method is not supported
 // - signature size or format is invalid
 // - signature verification failed
-type InvalidEnvelopeSignatureError struct {
-	errorWrapper
-
-	address  flow.Address
-	keyIndex uint64
-}
-
-// NewInvalidEnvelopeSignatureError constructs a new InvalidEnvelopeSignatureError
-func NewInvalidEnvelopeSignatureError(address flow.Address, keyIndex uint64, err error) InvalidEnvelopeSignatureError {
-	return InvalidEnvelopeSignatureError{
-		address:  address,
-		keyIndex: keyIndex,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e InvalidEnvelopeSignatureError) Error() string {
-	return fmt.Sprintf(
-		"%s invalid envelope key: public key %d on account %s does not have a valid signature: %s",
-		e.Code().String(),
-		e.keyIndex,
-		e.address,
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error type
-func (e InvalidEnvelopeSignatureError) Code() ErrorCode {
-	return ErrCodeInvalidEnvelopeSignatureError
+func NewInvalidEnvelopeSignatureError(
+	address flow.Address,
+	keyIndex uint64,
+	err error,
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeInvalidEnvelopeSignatureError,
+		err,
+		"invalid envelope key: public key %d on account %s does not have a "+
+			"valid signature",
+		keyIndex,
+		address)
 }
 
 func IsInvalidEnvelopeSignatureError(err error) bool {
-	var t InvalidEnvelopeSignatureError
-	return As(err, &t)
+	return HasErrorCode(err, ErrCodeInvalidEnvelopeSignatureError)
 }


### PR DESCRIPTION
I'm going to splay the replacement across multiple PRs.  The changes are unreviewable on github if I try to replace them all in one go since that causes too many newline changes for diff-ing.

Note that I've change NewEncodingFailuref a bit.  Previously, the original encoding error was sometimes dropped from the returned error string.

Note: I've added a todo_rm_emulator_hack.go to this diff to deal with emulator circular dependency hell.  Looks like the error type classification in the emulator are incorrect even prior to my changes, so there's no point in trying to keep backwards compatibility.