### PR TITLE
Replace error/failure structs with CodedError/CodedFailure (Part 2)

### DIFF
--- a/fvm/environment/account_key_updater_test.go
+++ b/fvm/environment/account_key_updater_test.go
@@ -1,7 +1,6 @@
 package environment
 
 import (
-	errors2 "errors"
 	"fmt"
 	"testing"
 	"unicode/utf8"
@@ -51,7 +50,6 @@ func TestAddEncodedAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 	err = akh.addEncodedAccountKey(runtime.Address(address), encodedPublicKey)
 	require.Error(t, err)
 
-	err = errors2.Unwrap(err)
 	require.True(t, errors.IsValueError(err))
 
 	errorString := err.Error()
@@ -79,7 +77,6 @@ func TestNewAccountKey_error_handling_produces_valid_utf8_and_sign_algo(t *testi
 
 	_, err := NewAccountPublicKey(publicKey, sema.HashAlgorithmSHA2_384, 0, 0)
 
-	err = errors2.Unwrap(err)
 	require.True(t, errors.IsValueError(err))
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidSignAlgo))
@@ -110,7 +107,6 @@ func TestNewAccountKey_error_handling_produces_valid_utf8_and_hash_algo(t *testi
 
 	_, err := NewAccountPublicKey(publicKey, invalidHashAlgo, 0, 0)
 
-	err = errors2.Unwrap(err)
 	require.True(t, errors.IsValueError(err))
 
 	require.Contains(t, err.Error(), fmt.Sprintf("%d", invalidHashAlgo))
@@ -139,8 +135,7 @@ func TestNewAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 
 	_, err := NewAccountPublicKey(publicKey, runtime.HashAlgorithmSHA2_256, 0, 0)
 
-	err = errors2.Unwrap(err)
-	require.IsType(t, errors.ValueError{}, err)
+	require.True(t, errors.IsValueError(err))
 
 	errorString := err.Error()
 	assert.True(t, utf8.ValidString(errorString))

--- a/fvm/errors/accounts.go
+++ b/fvm/errors/accounts.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -31,35 +30,22 @@ func NewAccountAlreadyExistsError(address flow.Address) *CodedError {
 		address)
 }
 
-// AccountPublicKeyNotFoundError is returned when a public key not found for the given address and key index
-type AccountPublicKeyNotFoundError struct {
-	address  flow.Address
-	keyIndex uint64
-}
-
-// NewAccountPublicKeyNotFoundError constructs a new AccountPublicKeyNotFoundError
-func NewAccountPublicKeyNotFoundError(address flow.Address, keyIndex uint64) AccountPublicKeyNotFoundError {
-	return AccountPublicKeyNotFoundError{address: address, keyIndex: keyIndex}
+// NewAccountPublicKeyNotFoundError constructs a new CodedError. It is returned
+// when a public key not found for the given address and key index.
+func NewAccountPublicKeyNotFoundError(
+	address flow.Address,
+	keyIndex uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountPublicKeyNotFoundError,
+		"account public key not found for address %s and key index %d",
+		address,
+		keyIndex)
 }
 
 // IsAccountAccountPublicKeyNotFoundError returns true if error has this type
 func IsAccountAccountPublicKeyNotFoundError(err error) bool {
-	var t AccountPublicKeyNotFoundError
-	return errors.As(err, &t)
-}
-
-func (e AccountPublicKeyNotFoundError) Error() string {
-	return fmt.Sprintf(
-		"%s account public key not found for address %s and key index %d",
-		e.Code().String(),
-		e.address,
-		e.keyIndex,
-	)
-}
-
-// Code returns the error code for this error type
-func (e AccountPublicKeyNotFoundError) Code() ErrorCode {
-	return ErrCodeAccountPublicKeyNotFoundError
+	return HasErrorCode(err, ErrCodeAccountPublicKeyNotFoundError)
 }
 
 // FrozenAccountError is returned when a frozen account signs a transaction

--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -1,8 +1,6 @@
 package errors
 
 import (
-	"fmt"
-
 	"github.com/onflow/cadence/runtime"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -22,30 +20,17 @@ func NewInvalidAddressErrorf(
 		append([]interface{}{address.String()}, args...)...)
 }
 
-// InvalidArgumentError indicates that a transaction includes invalid arguments.
-// this error is the result of failure in any of the following conditions:
+// NewInvalidArgumentErrorf constructs a new CodedError which indicates that a
+// transaction includes invalid arguments. This error is the result of failure
+// in any of the following conditions:
 // - number of arguments doesn't match the template
+//
 // TODO add more cases like argument size
-type InvalidArgumentError struct {
-	errorWrapper
-}
-
-// NewInvalidArgumentErrorf constructs a new InvalidArgumentError
-func NewInvalidArgumentErrorf(msg string, args ...interface{}) InvalidArgumentError {
-	return InvalidArgumentError{
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e InvalidArgumentError) Error() string {
-	return fmt.Sprintf("%s transaction arguments are invalid: (%s)", e.Code().String(), e.err.Error())
-}
-
-// Code returns the error code for this error type
-func (e InvalidArgumentError) Code() ErrorCode {
-	return ErrCodeInvalidArgumentError
+func NewInvalidArgumentErrorf(msg string, args ...interface{}) *CodedError {
+	return NewCodedError(
+		ErrCodeInvalidArgumentError,
+		"transaction arguments are invalid: ("+msg+")",
+		args...)
 }
 
 // NewInvalidLocationErrorf constructs a new CodedError which indicates an
@@ -66,38 +51,21 @@ func NewInvalidLocationErrorf(
 		append([]interface{}{locationStr}, args...)...)
 }
 
-// ValueError indicates a value is not valid value.
-type ValueError struct {
-	errorWrapper
-
-	valueStr string
-}
-
-// NewValueErrorf constructs a new ValueError
-func NewValueErrorf(valueStr string, msg string, args ...interface{}) ValueError {
-	return ValueError{valueStr: valueStr,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-func (e ValueError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-	return fmt.Sprintf("%s invalid value (%s): %s", e.Code().String(), e.valueStr, errMsg)
-}
-
-// Code returns the error code for this error type
-func (e ValueError) Code() ErrorCode {
-	return ErrCodeValueError
+// NewValueErrorf constructs a new CodedError which indicates a value is not
+// valid value.
+func NewValueErrorf(
+	valueStr string,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeValueError,
+		"invalid value (%s): "+msg,
+		append([]interface{}{valueStr}, args...)...)
 }
 
 func IsValueError(err error) bool {
-	var valErr ValueError
-	return As(err, &valErr)
+	return HasErrorCode(err, ErrCodeValueError)
 }
 
 // NewOperationAuthorizationErrorf constructs a new CodedError which indicates
@@ -114,45 +82,19 @@ func NewOperationAuthorizationErrorf(
 		append([]interface{}{operation}, args...)...)
 }
 
-// AccountAuthorizationError indicates that an authorization issues
-// either a transaction is missing a required signature to
-// authorize access to an account or a transaction doesn't have authorization
-// to performe some operations like account creation.
-type AccountAuthorizationError struct {
-	errorWrapper
-
-	address flow.Address
-}
-
-// NewAccountAuthorizationErrorf constructs a new AccountAuthorizationError
-func NewAccountAuthorizationErrorf(address flow.Address, msg string, args ...interface{}) AccountAuthorizationError {
-	return AccountAuthorizationError{
-		address: address,
-		errorWrapper: errorWrapper{
-			err: fmt.Errorf(msg, args...),
-		},
-	}
-}
-
-// Address returns the address of an account without enough authorization
-func (e AccountAuthorizationError) Address() flow.Address {
-	return e.address
-}
-
-func (e AccountAuthorizationError) Error() string {
-	errMsg := ""
-	if e.err != nil {
-		errMsg = e.err.Error()
-	}
-	return fmt.Sprintf(
-		"%s authorization failed for account %s: %s",
-		e.Code().String(),
-		e.address,
-		errMsg,
-	)
-}
-
-// Code returns the error code for this error type
-func (e AccountAuthorizationError) Code() ErrorCode {
-	return ErrCodeAccountAuthorizationError
+// NewAccountAuthorizationErrorf constructs a new CodedError which indicates
+// that an authorization issue either:
+//   - a transaction is missing a required signature to authorize access to an
+//     account, or
+//   - a transaction doesn't have authorization to performe some operations like
+//     account creation.
+func NewAccountAuthorizationErrorf(
+	address flow.Address,
+	msg string,
+	args ...interface{},
+) *CodedError {
+	return NewCodedError(
+		ErrCodeAccountAuthorizationError,
+		"authorization failed for account %s: "+msg,
+		append([]interface{}{address}, args...)...)
 }

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -46,67 +45,34 @@ func IsCadenceRuntimeError(err error) bool {
 	return As(err, &t)
 }
 
-// An TransactionFeeDeductionFailedError indicates that a there was an error deducting transaction fees from the transaction Payer
-type TransactionFeeDeductionFailedError struct {
-	errorWrapper
-
-	Payer  flow.Address
-	TxFees uint64
-}
-
-// NewTransactionFeeDeductionFailedError constructs a new TransactionFeeDeductionFailedError
+// NewTransactionFeeDeductionFailedError constructs a new CodedError which
+// indicates that a there was an error deducting transaction fees from the
+// transaction Payer
 func NewTransactionFeeDeductionFailedError(
 	payer flow.Address,
 	txFees uint64,
 	err error,
-) TransactionFeeDeductionFailedError {
-	return TransactionFeeDeductionFailedError{
-		Payer:  payer,
-		TxFees: txFees,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeTransactionFeeDeductionFailedError,
+		err,
+		"failed to deduct %d transaction fees from %s",
+		txFees,
+		payer)
 }
 
-func (e TransactionFeeDeductionFailedError) Error() string {
-	return fmt.Sprintf("%s failed to deduct %d transaction fees from %s: %s", e.Code().String(), e.TxFees, e.Payer, e.err)
+// NewComputationLimitExceededError constructs a new CodedError which indicates
+// that computation has exceeded its limit.
+func NewComputationLimitExceededError(limit uint64) *CodedError {
+	return NewCodedError(
+		ErrCodeComputationLimitExceededError,
+		"computation exceeds limit (%d)",
+		limit)
 }
 
-// Code returns the error code for this error
-func (e TransactionFeeDeductionFailedError) Code() ErrorCode {
-	return ErrCodeTransactionFeeDeductionFailedError
-}
-
-// An ComputationLimitExceededError indicates that computation has exceeded its limit.
-type ComputationLimitExceededError struct {
-	limit uint64
-}
-
-// NewComputationLimitExceededError constructs a new ComputationLimitExceededError
-func NewComputationLimitExceededError(limit uint64) ComputationLimitExceededError {
-	return ComputationLimitExceededError{
-		limit: limit,
-	}
-}
-
-// Code returns the error code for this error
-func (e ComputationLimitExceededError) Code() ErrorCode {
-	return ErrCodeComputationLimitExceededError
-}
-
-func (e ComputationLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"%s computation exceeds limit (%d)",
-		e.Code().String(),
-		e.limit,
-	)
-}
-
-// IsComputationLimitExceededError returns true if error has this type
+// IsComputationLimitExceededError returns true if error has this code.
 func IsComputationLimitExceededError(err error) bool {
-	var t ComputationLimitExceededError
-	return errors.As(err, &t)
+	return HasErrorCode(err, ErrCodeComputationLimitExceededError)
 }
 
 // NewMemoryLimitExceededError constructs a new CodedError which indicates
@@ -123,62 +89,37 @@ func IsMemoryLimitExceededError(err error) bool {
 	return HasErrorCode(err, ErrCodeMemoryLimitExceededError)
 }
 
-// An StorageCapacityExceededError indicates that an account used more storage than it has storage capacity.
-type StorageCapacityExceededError struct {
-	address         flow.Address
-	storageUsed     uint64
-	storageCapacity uint64
-}
-
-// NewStorageCapacityExceededError constructs a new StorageCapacityExceededError
-func NewStorageCapacityExceededError(address flow.Address, storageUsed, storageCapacity uint64) StorageCapacityExceededError {
-	return StorageCapacityExceededError{
-		address:         address,
-		storageUsed:     storageUsed,
-		storageCapacity: storageCapacity,
-	}
-}
-
-func (e StorageCapacityExceededError) Error() string {
-	return fmt.Sprintf("%s The account with address (%s) uses %d bytes of storage which is over its capacity (%d bytes). Capacity can be increased by adding FLOW tokens to the account.", e.Code().String(), e.address, e.storageUsed, e.storageCapacity)
-}
-
-// Code returns the error code for this error
-func (e StorageCapacityExceededError) Code() ErrorCode {
-	return ErrCodeStorageCapacityExceeded
+// NewStorageCapacityExceededError constructs a new CodedError which indicates
+// that an account used more storage than it has storage capacity.
+func NewStorageCapacityExceededError(
+	address flow.Address,
+	storageUsed uint64,
+	storageCapacity uint64,
+) *CodedError {
+	return NewCodedError(
+		ErrCodeStorageCapacityExceeded,
+		"The account with address (%s) uses %d bytes of storage which is "+
+			"over its capacity (%d bytes). Capacity can be increased by "+
+			"adding FLOW tokens to the account.",
+		address,
+		storageUsed,
+		storageCapacity)
 }
 
 func IsStorageCapacityExceededError(err error) bool {
-	var t StorageCapacityExceededError
-	return As(err, &t)
+	return HasErrorCode(err, ErrCodeStorageCapacityExceeded)
 }
 
-// EventLimitExceededError indicates that the transaction has produced events with size more than limit.
-type EventLimitExceededError struct {
-	totalByteSize uint64
-	limit         uint64
-}
-
-// NewEventLimitExceededError constructs a EventLimitExceededError
-func NewEventLimitExceededError(totalByteSize, limit uint64) EventLimitExceededError {
-	return EventLimitExceededError{
-		totalByteSize: totalByteSize,
-		limit:         limit,
-	}
-}
-
-func (e EventLimitExceededError) Error() string {
-	return fmt.Sprintf(
-		"%s total event byte size (%d) exceeds limit (%d)",
-		e.Code().String(),
-		e.totalByteSize,
-		e.limit,
-	)
-}
-
-// Code returns the error code for this error
-func (e EventLimitExceededError) Code() ErrorCode {
-	return ErrCodeEventLimitExceededError
+// NewEventLimitExceededError constructs a CodedError which indicates that the
+// transaction has produced events with size more than limit.
+func NewEventLimitExceededError(
+	totalByteSize uint64,
+	limit uint64) *CodedError {
+	return NewCodedError(
+		ErrCodeEventLimitExceededError,
+		"total event byte size (%d) exceeds limit (%d)",
+		totalByteSize,
+		limit)
 }
 
 // NewStateKeySizeLimitError constructs a CodedError which indicates that the
@@ -197,37 +138,27 @@ func NewStateKeySizeLimitError(
 		limit)
 }
 
-// A StateValueSizeLimitError indicates that the provided value has exceeded the size limit allowed by the storage
-type StateValueSizeLimitError struct {
-	value flow.RegisterValue
-	size  uint64
-	limit uint64
-}
-
-// NewStateValueSizeLimitError constructs a StateValueSizeLimitError
-func NewStateValueSizeLimitError(value flow.RegisterValue, size, limit uint64) StateValueSizeLimitError {
-	return StateValueSizeLimitError{
-		value: value,
-		size:  size,
-		limit: limit,
-	}
-}
-
-func (e StateValueSizeLimitError) Error() string {
+// NewStateValueSizeLimitError constructs a CodedError which indicates that the
+// provided value has exceeded the size limit allowed by the storage.
+func NewStateValueSizeLimitError(
+	value flow.RegisterValue,
+	size uint64,
+	limit uint64,
+) *CodedError {
 	valueStr := ""
-	if len(e.value) > 23 {
-		valueStr = string(e.value[0:10]) + "..." + string(e.value[len(e.value)-10:])
+	if len(value) > 23 {
+		valueStr = string(value[0:10]) + "..." + string(value[len(value)-10:])
 	} else {
-		valueStr = string(e.value)
+		valueStr = string(value)
 	}
 
-	return fmt.Sprintf("%s value %s has size %d which is higher than storage value size limit %d.",
-		e.Code().String(), valueStr, e.size, e.limit)
-}
-
-// Code returns the error code for this error
-func (e StateValueSizeLimitError) Code() ErrorCode {
-	return ErrCodeStateValueSizeLimitError
+	return NewCodedError(
+		ErrCodeStateValueSizeLimitError,
+		"value %s has size %d which is higher than storage value size "+
+			"limit %d.",
+		valueStr,
+		size,
+		limit)
 }
 
 // NewLedgerInteractionLimitExceededError constructs a CodeError. It is
@@ -248,31 +179,18 @@ func IsLedgerInteractionLimitExceededError(err error) bool {
 	return HasErrorCode(err, ErrCodeLedgerInteractionLimitExceededError)
 }
 
-// OperationNotSupportedError is generated when an operation (e.g. getting block info) is
-// not supported in the current environment.
-type OperationNotSupportedError struct {
-	operation string
-}
-
-// NewOperationNotSupportedError construct a new OperationNotSupportedError
-func NewOperationNotSupportedError(operation string) OperationNotSupportedError {
-	return OperationNotSupportedError{
-		operation: operation,
-	}
-}
-
-func (e OperationNotSupportedError) Error() string {
-	return fmt.Sprintf("%s operation (%s) is not supported in this environment", e.Code().String(), e.operation)
-}
-
-// Code returns the error code for this error
-func (e OperationNotSupportedError) Code() ErrorCode {
-	return ErrCodeOperationNotSupportedError
+// NewOperationNotSupportedError construct a new CodedError. It is generated
+// when an operation (e.g. getting block info) is not supported in the current
+// environment.
+func NewOperationNotSupportedError(operation string) *CodedError {
+	return NewCodedError(
+		ErrCodeOperationNotSupportedError,
+		"operation (%s) is not supported in this environment",
+		operation)
 }
 
 func IsOperationNotSupportedError(err error) bool {
-	var t OperationNotSupportedError
-	return As(err, &t)
+	return HasErrorCode(err, ErrCodeOperationNotSupportedError)
 }
 
 // NewScriptExecutionCancelledError construct a new CodedError which indicates
@@ -288,29 +206,16 @@ func NewScriptExecutionCancelledError(err error) *CodedError {
 		"script execution is cancelled")
 }
 
-// ScriptExecutionTimedOutError indicates that Cadence Script execution
-// has been taking more time than what is allowed.
+// NewScriptExecutionTimedOutError construct a new CodedError which indicates
+// that Cadence Script execution has been taking more time than what is allowed.
 //
-// note: this error is used by scripts only and
-// won't be emitted for transactions since transaction execution has to be deterministic.
-type ScriptExecutionTimedOutError struct {
-}
-
-// NewScriptExecutionTimedOutError construct a new ScriptExecutionTimedOutError
-func NewScriptExecutionTimedOutError() ScriptExecutionTimedOutError {
-	return ScriptExecutionTimedOutError{}
-}
-
-func (e ScriptExecutionTimedOutError) Error() string {
-	return fmt.Sprintf(
-		"%s script execution is timed out and did not finish executing within the maximum execution time allowed",
-		e.Code().String(),
-	)
-}
-
-// Code returns the error code for this error
-func (e ScriptExecutionTimedOutError) Code() ErrorCode {
-	return ErrCodeScriptExecutionTimedOutError
+// note: this error is used by scripts only and won't be emitted for
+// transactions since transaction execution has to be deterministic.
+func NewScriptExecutionTimedOutError() *CodedError {
+	return NewCodedError(
+		ErrCodeScriptExecutionTimedOutError,
+		"script execution is timed out and did not finish executing within "+
+			"the maximum execution time allowed")
 }
 
 // NewCouldNotGetExecutionParameterFromStateError constructs a new CodedError

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -1,10 +1,5 @@
 package errors
 
-import (
-	"errors"
-	"fmt"
-)
-
 func NewUnknownFailure(err error) *CodedFailure {
 	return WrapCodedFailure(
 		FailureCodeUnknownFailure,
@@ -12,8 +7,12 @@ func NewUnknownFailure(err error) *CodedFailure {
 		"unknown failure")
 }
 
-// NewEncodingFailure formats and returns a new CodedFailure which
-// captures an fatal error sourced from encoding issues
+// EncodingFailure captures an fatal error sourced from encoding issues
+type EncodingFailure struct {
+	errorWrapper
+}
+
+// NewEncodingFailuref formats and returns a new EncodingFailure
 func NewEncodingFailuref(
 	err error,
 	msg string,
@@ -26,52 +25,28 @@ func NewEncodingFailuref(
 		args...)
 }
 
-// LedgerFailure captures a fatal error cause by ledger failures
-type LedgerFailure struct {
-	errorWrapper
+// NewLedgerFailure constructs a new CodedFailure which captures a fatal error
+// cause by ledger failures.
+func NewLedgerFailure(err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeLedgerFailure,
+		err,
+		"ledger returns unsuccessful")
 }
 
-// NewLedgerFailure constructs a new LedgerFailure
-func NewLedgerFailure(err error) LedgerFailure {
-	return LedgerFailure{
-		errorWrapper: errorWrapper{err: err},
-	}
-}
-
-func (e LedgerFailure) Error() string {
-	return fmt.Sprintf("%s ledger returns unsuccessful: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e LedgerFailure) FailureCode() ErrorCode {
-	return FailureCodeLedgerFailure
-}
-
-// IsALedgerFailure returns true if the error or any of the wrapped errors is a ledger failure
+// IsALedgerFailure returns true if the error or any of the wrapped errors is
+// a ledger failure
 func IsALedgerFailure(err error) bool {
-	var t LedgerFailure
-	return errors.As(err, &t)
+	return HasErrorCode(err, FailureCodeLedgerFailure)
 }
 
-// StateMergeFailure captures a fatal caused by state merge
-type StateMergeFailure struct {
-	errorWrapper
-}
-
-// NewStateMergeFailure constructs a new StateMergeFailure
-func NewStateMergeFailure(err error) StateMergeFailure {
-	return StateMergeFailure{
-		errorWrapper: errorWrapper{err: err},
-	}
-}
-
-func (e StateMergeFailure) Error() string {
-	return fmt.Sprintf("%s can not merge the state: %s", e.FailureCode().String(), e.err.Error())
-}
-
-// FailureCode returns the failure code
-func (e StateMergeFailure) FailureCode() ErrorCode {
-	return FailureCodeStateMergeFailure
+// NewStateMergeFailure constructs a new CodedFailure which captures a fatal
+// caused by state merge.
+func NewStateMergeFailure(err error) *CodedFailure {
+	return WrapCodedFailure(
+		FailureCodeStateMergeFailure,
+		err,
+		"can not merge the state")
 }
 
 // NewBlockFinderFailure constructs a new CodedFailure which captures a fatal

--- a/fvm/errors/todo_rm_emulator_hack.go
+++ b/fvm/errors/todo_rm_emulator_hack.go
@@ -23,10 +23,10 @@ type InvalidEnvelopeSignatureError struct{ CodedError }
 //type InvalidProposalSeqNumberError struct{ CodedError }
 
 // DO NOT USE.
-//type InvalidPayloadSignatureError struct{ CodedError }
+type InvalidPayloadSignatureError struct{ CodedError }
 
 // DO NOT USE.
-//type AccountAuthorizationError struct{ CodedError }
+type AccountAuthorizationError struct{ CodedError }
 
 // DO NOT USE.
-//type AccountPublicKeyNotFoundError struct{ CodedError }
+type AccountPublicKeyNotFoundError struct{ CodedError }

--- a/fvm/errors/txVerifier.go
+++ b/fvm/errors/txVerifier.go
@@ -64,47 +64,28 @@ func (e InvalidProposalSeqNumberError) Code() ErrorCode {
 	return ErrCodeInvalidProposalSeqNumberError
 }
 
-// InvalidPayloadSignatureError indicates that signature verification for a key in this transaction has failed.
-// this error is the result of failure in any of the following conditions:
+// NewInvalidPayloadSignatureError constructs a new CodedError which indicates
+// that signature verification for a key in this transaction has failed. This
+// error is the result of failure in any of the following conditions:
 // - provided hashing method is not supported
 // - signature size or format is invalid
 // - signature verification failed
-type InvalidPayloadSignatureError struct {
-	errorWrapper
-
-	address  flow.Address
-	keyIndex uint64
-}
-
-// NewInvalidPayloadSignatureError constructs a new InvalidPayloadSignatureError
-func NewInvalidPayloadSignatureError(address flow.Address, keyIndex uint64, err error) InvalidPayloadSignatureError {
-	return InvalidPayloadSignatureError{
-		address:  address,
-		keyIndex: keyIndex,
-		errorWrapper: errorWrapper{
-			err: err,
-		},
-	}
-}
-
-func (e InvalidPayloadSignatureError) Error() string {
-	return fmt.Sprintf(
-		"%s invalid payload signature: public key %d on account %s does not have a valid signature: %s",
-		e.Code().String(),
-		e.keyIndex,
-		e.address,
-		e.err.Error(),
-	)
-}
-
-// Code returns the error code for this error type
-func (e InvalidPayloadSignatureError) Code() ErrorCode {
-	return ErrCodeInvalidPayloadSignatureError
+func NewInvalidPayloadSignatureError(
+	address flow.Address,
+	keyIndex uint64,
+	err error,
+) *CodedError {
+	return WrapCodedError(
+		ErrCodeInvalidPayloadSignatureError,
+		err,
+		"invalid payload signature: public key %d on account %s does not have"+
+			" a valid signature",
+		keyIndex,
+		address)
 }
 
 func IsInvalidPayloadSignatureError(err error) bool {
-	var t InvalidPayloadSignatureError
-	return As(err, &t)
+	return HasErrorCode(err, ErrCodeInvalidPayloadSignatureError)
 }
 
 // NewInvalidEnvelopeSignatureError constructs a new CodedError which indicates


### PR DESCRIPTION
Note that I've left CadenceRuntimeError, FrozenAccountError and InvalidProposalSeqNumberError alone since these require special handling. (I'll deal with these in a followup PR)