### PR TITLE
[CI] Increase lint timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.49
-        args: -v --build-tags relic
+        args: -v --build-tags relic --timeout 180
         working-directory: ${{ matrix.dir }}
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.49
-        args: -v --build-tags relic --timeout 180
+        args: -v --build-tags relic --timeout 180s
         working-directory: ${{ matrix.dir }}
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.49
-        args: -v --build-tags relic --timeout 180s
+        args: -v --build-tags relic --timeout 5m
         working-directory: ${{ matrix.dir }}
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-cache: true


### PR DESCRIPTION
The lint step in CI occasionally [fails with a timeout ](https://github.com/onflow/flow-go/actions/runs/3152898274/jobs/5128702326). This PR increases the timeout to 3 minutes from the default of 1 minute.