### PR TITLE
fix Windows build

### DIFF
--- a/utils/io/file.go
+++ b/utils/io/file.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
 // ReadFile reads the file from path, if not found, it will print the absolute path, instead of
@@ -48,11 +47,6 @@ func CopyDirectory(scrDir, dest string) error {
 			return err
 		}
 
-		stat, ok := fileInfo.Sys().(*syscall.Stat_t)
-		if !ok {
-			return fmt.Errorf("failed to get raw syscall.Stat_t data for '%s'", sourcePath)
-		}
-
 		switch fileInfo.Mode() & os.ModeType {
 		case os.ModeDir:
 			if err := CreateIfNotExists(destPath, 0755); err != nil {
@@ -71,7 +65,7 @@ func CopyDirectory(scrDir, dest string) error {
 			}
 		}
 
-		if err := os.Lchown(destPath, int(stat.Uid), int(stat.Gid)); err != nil {
+		if err := chown(destPath, fileInfo); err != nil {
 			return err
 		}
 

--- a/utils/io/file_unix.go
+++ b/utils/io/file_unix.go
@@ -1,4 +1,4 @@
-//go:build unix || (js && wasm)
+//go:build !windows
 
 package io
 

--- a/utils/io/file_unix.go
+++ b/utils/io/file_unix.go
@@ -1,0 +1,19 @@
+//go:build unix || (js && wasm)
+
+package io
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+func chown(path string, fileInfo fs.FileInfo) error {
+	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("failed to get raw syscall.Stat_t data for '%s'", path)
+	}
+
+	return os.Lchown(path, int(stat.Uid), int(stat.Gid))
+}

--- a/utils/io/file_windows.go
+++ b/utils/io/file_windows.go
@@ -1,0 +1,9 @@
+package io
+
+import (
+	"io/fs"
+)
+
+func chown(path string, fileInfo fs.FileInfo) error {
+	return nil
+}


### PR DESCRIPTION
`syscall.Stat_t` is linux-only and would fail on Windows and Plan9.  Separate codepaths into unix/windows.

Verified with:
```
GOOS=windows GOARCH=amd64 go build ./utils/io/...
```

PS. @gomisha given that `flow-cli` [depends on windows builds](https://github.com/onflow/flow-cli/actions/runs/3136555718/jobs/5093616496#step:4:227) maybe we can add a windows build on CI?