### PR TITLE
Combined Error and CodedError interface.

### DIFF
--- a/engine/access/rest/handler.go
+++ b/engine/access/rest/handler.go
@@ -100,8 +100,8 @@ func (h *Handler) errorHandler(w http.ResponseWriter, err error, errorLogger zer
 	}
 
 	// handle cadence errors
-	var cadenceError *fvmErrors.CadenceRuntimeError
-	if fvmErrors.As(err, &cadenceError) {
+	cadenceError := fvmErrors.Find(err, fvmErrors.ErrCodeCadenceRunTimeError)
+	if cadenceError != nil {
 		msg := fmt.Sprintf("Cadence error: %s", cadenceError.Error())
 		h.errorResponse(w, http.StatusBadRequest, msg, errorLogger)
 		return

--- a/fvm/errors/accounts.go
+++ b/fvm/errors/accounts.go
@@ -1,12 +1,10 @@
 package errors
 
 import (
-	"fmt"
-
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func NewAccountNotFoundError(address flow.Address) *CodedError {
+func NewAccountNotFoundError(address flow.Address) CodedError {
 	return NewCodedError(
 		ErrCodeAccountNotFoundError,
 		"account not found for address %s",
@@ -23,7 +21,7 @@ func IsAccountNotFoundError(err error) bool {
 // address.
 //
 // TODO maybe this should be failure since user has no control over this
-func NewAccountAlreadyExistsError(address flow.Address) *CodedError {
+func NewAccountAlreadyExistsError(address flow.Address) CodedError {
 	return NewCodedError(
 		ErrCodeAccountAlreadyExistsError,
 		"account with address %s already exists",
@@ -35,7 +33,7 @@ func NewAccountAlreadyExistsError(address flow.Address) *CodedError {
 func NewAccountPublicKeyNotFoundError(
 	address flow.Address,
 	keyIndex uint64,
-) *CodedError {
+) CodedError {
 	return NewCodedError(
 		ErrCodeAccountPublicKeyNotFoundError,
 		"account public key not found for address %s and key index %d",
@@ -51,25 +49,24 @@ func IsAccountAccountPublicKeyNotFoundError(err error) bool {
 // FrozenAccountError is returned when a frozen account signs a transaction
 type FrozenAccountError struct {
 	address flow.Address
+
+	CodedError
 }
 
 // NewFrozenAccountError constructs a new FrozenAccountError
-func NewFrozenAccountError(address flow.Address) FrozenAccountError {
-	return FrozenAccountError{address: address}
+func NewFrozenAccountError(address flow.Address) CodedError {
+	return FrozenAccountError{
+		address: address,
+		CodedError: NewCodedError(
+			ErrCodeFrozenAccountError,
+			"account %s is frozen",
+			address),
+	}
 }
 
 // Address returns the address of frozen account
 func (e FrozenAccountError) Address() flow.Address {
 	return e.address
-}
-
-func (e FrozenAccountError) Error() string {
-	return fmt.Sprintf("%s account %s is frozen", e.Code().String(), e.address)
-}
-
-// Code returns the error code for this error type
-func (e FrozenAccountError) Code() ErrorCode {
-	return ErrCodeFrozenAccountError
 }
 
 // NewAccountPublicKeyLimitError constructs a new CodedError.  It is returned
@@ -78,7 +75,7 @@ func NewAccountPublicKeyLimitError(
 	address flow.Address,
 	counts uint64,
 	limit uint64,
-) *CodedError {
+) CodedError {
 	return NewCodedError(
 		ErrCodeAccountPublicKeyLimitError,
 		"account's (%s) public key count (%d) exceeded the limit (%d)",

--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -13,7 +13,7 @@ func NewInvalidAddressErrorf(
 	address flow.Address,
 	msg string,
 	args ...interface{},
-) *CodedError {
+) CodedError {
 	return NewCodedError(
 		ErrCodeInvalidAddressError,
 		"invalid address (%s): "+msg,
@@ -26,7 +26,7 @@ func NewInvalidAddressErrorf(
 // - number of arguments doesn't match the template
 //
 // TODO add more cases like argument size
-func NewInvalidArgumentErrorf(msg string, args ...interface{}) *CodedError {
+func NewInvalidArgumentErrorf(msg string, args ...interface{}) CodedError {
 	return NewCodedError(
 		ErrCodeInvalidArgumentError,
 		"transaction arguments are invalid: ("+msg+")",
@@ -39,7 +39,7 @@ func NewInvalidLocationErrorf(
 	location runtime.Location,
 	msg string,
 	args ...interface{},
-) *CodedError {
+) CodedError {
 	locationStr := ""
 	if location != nil {
 		locationStr = location.String()
@@ -57,7 +57,7 @@ func NewValueErrorf(
 	valueStr string,
 	msg string,
 	args ...interface{},
-) *CodedError {
+) CodedError {
 	return NewCodedError(
 		ErrCodeValueError,
 		"invalid value (%s): "+msg,
@@ -75,7 +75,7 @@ func NewOperationAuthorizationErrorf(
 	operation string,
 	msg string,
 	args ...interface{},
-) *CodedError {
+) CodedError {
 	return NewCodedError(
 		ErrCodeOperationAuthorizationError,
 		"(%s) is not authorized: "+msg,
@@ -92,7 +92,7 @@ func NewAccountAuthorizationErrorf(
 	address flow.Address,
 	msg string,
 	args ...interface{},
-) *CodedError {
+) CodedError {
 	return NewCodedError(
 		ErrCodeAccountAuthorizationError,
 		"authorization failed for account %s: "+msg,

--- a/fvm/errors/contracts.go
+++ b/fvm/errors/contracts.go
@@ -8,7 +8,7 @@ import (
 func NewContractNotFoundError(
 	address flow.Address,
 	contract string,
-) *CodedError {
+) CodedError {
 	return NewCodedError(
 		ErrCodeContractNotFoundError,
 		"contract %s not found for address %s",

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -7,11 +7,6 @@ func NewUnknownFailure(err error) *CodedFailure {
 		"unknown failure")
 }
 
-// EncodingFailure captures an fatal error sourced from encoding issues
-type EncodingFailure struct {
-	errorWrapper
-}
-
 // NewEncodingFailuref formats and returns a new EncodingFailure
 func NewEncodingFailuref(
 	err error,

--- a/fvm/errors/todo_rm_emulator_hack.go
+++ b/fvm/errors/todo_rm_emulator_hack.go
@@ -20,9 +20,6 @@ type InvalidAddressError struct{ CodedError }
 type InvalidEnvelopeSignatureError struct{ CodedError }
 
 // DO NOT USE.
-//type InvalidProposalSeqNumberError struct{ CodedError }
-
-// DO NOT USE.
 type InvalidPayloadSignatureError struct{ CodedError }
 
 // DO NOT USE.

--- a/fvm/errors/txVerifier.go
+++ b/fvm/errors/txVerifier.go
@@ -1,8 +1,6 @@
 package errors
 
 import (
-	"fmt"
-
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -12,7 +10,7 @@ func NewInvalidProposalSignatureError(
 	address flow.Address,
 	keyIndex uint64,
 	err error,
-) *CodedError {
+) CodedError {
 	return WrapCodedError(
 		ErrCodeInvalidProposalSignatureError,
 		err,
@@ -24,18 +22,31 @@ func NewInvalidProposalSignatureError(
 
 // InvalidProposalSeqNumberError indicates that proposal key sequence number does not match the on-chain value.
 type InvalidProposalSeqNumberError struct {
-	address           flow.Address
-	keyIndex          uint64
 	currentSeqNumber  uint64
 	providedSeqNumber uint64
+
+	CodedError
 }
 
 // NewInvalidProposalSeqNumberError constructs a new InvalidProposalSeqNumberError
-func NewInvalidProposalSeqNumberError(address flow.Address, keyIndex uint64, currentSeqNumber uint64, providedSeqNumber uint64) InvalidProposalSeqNumberError {
-	return InvalidProposalSeqNumberError{address: address,
-		keyIndex:          keyIndex,
+func NewInvalidProposalSeqNumberError(
+	address flow.Address,
+	keyIndex uint64,
+	currentSeqNumber uint64,
+	providedSeqNumber uint64,
+) CodedError {
+	return InvalidProposalSeqNumberError{
 		currentSeqNumber:  currentSeqNumber,
-		providedSeqNumber: providedSeqNumber}
+		providedSeqNumber: providedSeqNumber,
+		CodedError: NewCodedError(
+			ErrCodeInvalidProposalSeqNumberError,
+			"invalid proposal key: public key %d on account %s has sequence "+
+				"number %d, but given %d",
+			keyIndex,
+			address.String(),
+			currentSeqNumber,
+			providedSeqNumber),
+	}
 }
 
 // CurrentSeqNumber returns the current sequence number
@@ -48,22 +59,6 @@ func (e InvalidProposalSeqNumberError) ProvidedSeqNumber() uint64 {
 	return e.providedSeqNumber
 }
 
-func (e InvalidProposalSeqNumberError) Error() string {
-	return fmt.Sprintf(
-		"%s invalid proposal key: public key %d on account %s has sequence number %d, but given %d",
-		e.Code().String(),
-		e.keyIndex,
-		e.address.String(),
-		e.currentSeqNumber,
-		e.providedSeqNumber,
-	)
-}
-
-// Code returns the error code for this error type
-func (e InvalidProposalSeqNumberError) Code() ErrorCode {
-	return ErrCodeInvalidProposalSeqNumberError
-}
-
 // NewInvalidPayloadSignatureError constructs a new CodedError which indicates
 // that signature verification for a key in this transaction has failed. This
 // error is the result of failure in any of the following conditions:
@@ -74,7 +69,7 @@ func NewInvalidPayloadSignatureError(
 	address flow.Address,
 	keyIndex uint64,
 	err error,
-) *CodedError {
+) CodedError {
 	return WrapCodedError(
 		ErrCodeInvalidPayloadSignatureError,
 		err,
@@ -99,7 +94,7 @@ func NewInvalidEnvelopeSignatureError(
 	address flow.Address,
 	keyIndex uint64,
 	err error,
-) *CodedError {
+) CodedError {
 	return WrapCodedError(
 		ErrCodeInvalidEnvelopeSignatureError,
 		err,

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1769,8 +1769,9 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
-				require.Equal(t, (errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())
-				require.Equal(t, uint64(0), tx.Err.(errors.InvalidProposalSeqNumberError).CurrentSeqNumber())
+				castedErr, ok := tx.Err.(errors.InvalidProposalSeqNumberError)
+				require.True(t, ok)
+				require.Equal(t, uint64(0), castedErr.CurrentSeqNumber())
 			}),
 	)
 
@@ -1815,8 +1816,9 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = vm.RunV2(ctx, tx, view)
 				require.NoError(t, err)
 
-				require.Equal(t, (errors.InvalidProposalSeqNumberError{}).Code(), tx.Err.Code())
-				require.Equal(t, uint64(1), tx.Err.(errors.InvalidProposalSeqNumberError).CurrentSeqNumber())
+				castedErr, ok := tx.Err.(errors.InvalidProposalSeqNumberError)
+				require.True(t, ok)
+				require.Equal(t, uint64(1), castedErr.CurrentSeqNumber())
 			}),
 	)
 }


### PR DESCRIPTION
Error is renamed to CodedError in order to support anonymous field composition. (`type Error interface` conflicts with `Error() string`)

Also added Find(err, code) and converted remaining errors to CodedError