### PR TITLE
[Networking] Override timeout for unicast Connect

### DIFF
--- a/network/p2p/unicast/manager.go
+++ b/network/p2p/unicast/manager.go
@@ -157,6 +157,9 @@ func (m *Manager) rawStreamWithProtocol(ctx context.Context,
 
 		err := m.streamFactory.Connect(connectCtx, peer.AddrInfo{ID: peerID})
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				err = fmt.Errorf("connect timeout reached. peer: %s, addr: %s: %w", peerID, dialAddr, err)
+			}
 
 			// if the connection was rejected due to invalid node id, skip the re-attempt
 			if strings.Contains(err.Error(), "failed to negotiate security protocol") {

--- a/network/p2p/unicast/manager.go
+++ b/network/p2p/unicast/manager.go
@@ -19,8 +19,13 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// MaxConnectAttemptSleepDuration is the maximum number of milliseconds to wait between attempts for a 1-1 direct connection
-const MaxConnectAttemptSleepDuration = 5
+const (
+	// MaxConnectAttemptSleepDuration is the maximum number of milliseconds to wait between attempts for a 1-1 direct connection
+	MaxConnectAttemptSleepDuration = 5
+
+	// defaultConnectTimeout is the default timeout for establishing a connection to a peer
+	defaultConnectTimeout = 1 * time.Second
+)
 
 // Manager manages libp2p stream negotiation and creation, which is utilized for unicast dispatches.
 type Manager struct {
@@ -147,7 +152,10 @@ func (m *Manager) rawStreamWithProtocol(ctx context.Context,
 			time.Sleep(time.Duration(r) * time.Millisecond)
 		}
 
-		err := m.streamFactory.Connect(ctx, peer.AddrInfo{ID: peerID})
+		connectCtx, cancel := context.WithTimeout(ctx, defaultConnectTimeout)
+		defer cancel()
+
+		err := m.streamFactory.Connect(connectCtx, peer.AddrInfo{ID: peerID})
 		if err != nil {
 
 			// if the connection was rejected due to invalid node id, skip the re-attempt


### PR DESCRIPTION
Connect would eventually call dial that can block.  At the same time `CreateStream` can use a pretty aggressive timeout of up to 16 minutes: https://github.com/onflow/flow-go/blob/8efd7b31b112e8e54f2ae7e1148084afd51ff5ef/network/p2p/middleware/middleware.go#L377

Connection timeout is currently set to 1s which is up for debate, but should be enough for ~5-10 roundtrips around the world.