### PR TITLE
[Execution] Adding more logging and a fix to block upload retry

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -277,8 +277,8 @@ func (exeNode *ExecutionNode) LoadGCPBlockDataUploader(
 		exeNode.events = storage.NewEvents(node.Metrics.Cache, node.DB)
 		exeNode.commits = storage.NewCommits(node.Metrics.Cache, node.DB)
 		exeNode.computationResultUploadStatus = storage.NewComputationResultUploadStatus(node.DB)
-		exeNode.collections = storage.NewCollections(node.DB, exeNode.transactions)
 		exeNode.transactions = storage.NewTransactions(node.Metrics.Cache, node.DB)
+		exeNode.collections = storage.NewCollections(node.DB, exeNode.transactions)
 		exeNode.txResults = storage.NewTransactionResults(node.Metrics.Cache, node.DB, exeNode.exeConf.transactionResultsCacheSize)
 
 		// Setting up RetryableUploader for GCP uploader

--- a/engine/execution/computation/computer/uploader/retryable_uploader_wrapper.go
+++ b/engine/execution/computation/computer/uploader/retryable_uploader_wrapper.go
@@ -140,6 +140,8 @@ func (b *BadgerRetryableUploaderWrapper) RetryUpload() error {
 		go func(blockID flow.Identifier) {
 			defer wg.Done()
 
+			log.Debug().Msgf("retrying upload for computation result of block %s", blockID.String())
+
 			var cr_err error
 			retComputationResult, err := b.reconstructComputationResult(blockID)
 			if err != nil {
@@ -152,8 +154,10 @@ func (b *BadgerRetryableUploaderWrapper) RetryUpload() error {
 			// Do Upload
 			if cr_err = b.uploader.Upload(retComputationResult); cr_err != nil {
 				log.Error().Err(cr_err).Msgf(
-					"Failed to update ComputationResult with BlockID %s", blockID)
+					"Failed to re-upload ComputationResult with BlockID %s", blockID)
 				retErr = cr_err
+			} else {
+				log.Debug().Msgf("computation result of block %s was successfully re-uploaded", blockID.String())
 			}
 
 			b.metrics.ExecutionComputationResultUploadRetried()

--- a/engine/execution/computation/computer/uploader/retryable_uploader_wrapper_test.go
+++ b/engine/execution/computation/computer/uploader/retryable_uploader_wrapper_test.go
@@ -228,7 +228,10 @@ func Test_ReconstructComputationResultFromStorage(t *testing.T) {
 // AsyncUploader instance and proper mock storage and EDS interfaces.
 func createTestBadgerRetryableUploaderWrapper(asyncUploader *AsyncUploader) *BadgerRetryableUploaderWrapper {
 	mockBlocksStorage := new(storageMock.Blocks)
-	mockBlocksStorage.On("ByID", mock.Anything).Return(nil, nil)
+	mockBlocksStorage.On("ByID", mock.Anything).Return(&flow.Block{
+		Header:  &flow.Header{},
+		Payload: nil,
+	}, nil)
 
 	mockCommitsStorage := new(storageMock.Commits)
 	mockCommitsStorage.On("ByBlockID", mock.Anything).Return(nil, nil)

--- a/engine/execution/computation/computer/uploader/uploader.go
+++ b/engine/execution/computation/computer/uploader/uploader.go
@@ -69,6 +69,9 @@ func (a *AsyncUploader) Upload(computationResult *execution.ComputationResult) e
 		a.metrics.ExecutionBlockDataUploadStarted()
 		start := time.Now()
 
+		a.log.Debug().Msgf("computation result of block %s is being uploaded",
+			computationResult.ExecutableBlock.ID().String())
+
 		err := retry.Do(a.unit.Ctx(), backoff, func(ctx context.Context) error {
 			err := a.uploader.Upload(computationResult)
 			if err != nil {
@@ -81,6 +84,9 @@ func (a *AsyncUploader) Upload(computationResult *execution.ComputationResult) e
 			a.log.Error().Err(err).
 				Hex("block_id", logging.Entity(computationResult.ExecutableBlock)).
 				Msg("failed to upload block data")
+		} else {
+			a.log.Debug().Msgf("computation result of block %s was successfully uploaded",
+				computationResult.ExecutableBlock.ID().String())
 		}
 
 		a.metrics.ExecutionBlockDataUploadFinished(time.Since(start))


### PR DESCRIPTION
Some minor tunings to block upload retry logic:

- adding more logging to upload behavior for easier tracking for DPS debugging purposes
- fixing the improper badger obj init order (thanks @peterargue)