### PR TITLE
Increase logger's time resolution from seconds to nanoseconds

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -462,6 +462,7 @@ func (fnb *FlowNodeBuilder) initNodeInfo() {
 
 func (fnb *FlowNodeBuilder) initLogger() {
 	// configure logger with standard level, node ID and UTC timestamp
+	zerolog.TimeFieldFormat = time.RFC3339Nano
 	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
 	log := fnb.Logger.With().
 		Timestamp().


### PR DESCRIPTION
Currently, it is very hard to use logs for any performance-sensitive troubleshooting because of low logs' time resolution.  Bump it by 9 orders of magnitude:
```
	RFC3339     = "2006-01-02T15:04:05Z07:00"
	RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
```