### PR TITLE
SignatureAlgorithm's indexes to match its Cadence definition

### DIFF
--- a/crypto/types.go
+++ b/crypto/types.go
@@ -17,17 +17,17 @@ type SigningAlgorithm int
 const (
 	// Supported signing algorithms
 	UnknownSigningAlgorithm SigningAlgorithm = iota
-	// BLSBLS12381 is BLS on BLS 12-381 curve
-	BLSBLS12381
 	// ECDSAP256 is ECDSA on NIST P-256 curve
 	ECDSAP256
 	// ECDSASecp256k1 is ECDSA on secp256k1 curve
 	ECDSASecp256k1
+	// BLSBLS12381 is BLS on BLS 12-381 curve
+	BLSBLS12381
 )
 
 // String returns the string representation of this signing algorithm.
 func (f SigningAlgorithm) String() string {
-	return [...]string{"UNKNOWN", "BLS_BLS12381", "ECDSA_P256", "ECDSA_secp256k1"}[f]
+	return [...]string{"UNKNOWN", "ECDSA_P256", "ECDSA_secp256k1", "BLS_BLS12381"}[f]
 }
 
 const (


### PR DESCRIPTION
SignatureAlgorithm's indexes to match its Cadence definition at https://developers.flow.com/cadence/language/crypto#signing-algorithms

Currently causing issue on https://github.com/onflow/flow-go-sdk/blob/7c53dc1/crypto/crypto.go#L45 `crypto.StringToSignatureAlgorithm("ECDSA_P256")` resulting into 2 instead of 1. And then using the result for https://github.com/onflow/cadence `SignatureAlgorithm(rawValue: 2)` giving us back `SignatureAlgorithm.ECDSA_secp256k1` instead of `SignatureAlgorithm.ECDSA_P256`.