### PR TITLE
Combine Failure into CodedError

### DIFF
--- a/fvm/errors/errors_test.go
+++ b/fvm/errors/errors_test.go
@@ -15,21 +15,24 @@ func TestErrorHandling(t *testing.T) {
 		e1 := NewOperationNotSupportedError("some operations")
 		e2 := fmt.Errorf("some other errors: %w", e1)
 		e3 := NewInvalidProposalSignatureError(flow.EmptyAddress, 0, e2)
+		e4 := fmt.Errorf("wrapped: %w", e3)
 
-		txErr, vmErr := SplitErrorTypes(e3)
+		txErr, vmErr := SplitErrorTypes(e4)
 		require.Nil(t, vmErr)
 		require.Equal(t, e3, txErr)
 	})
 
 	t.Run("test fatal error detection", func(t *testing.T) {
 		e1 := NewOperationNotSupportedError("some operations")
-		e2 := NewLedgerFailure(e1)
-		e3 := fmt.Errorf("some other errors: %w", e2)
-		e4 := NewInvalidProposalSignatureError(flow.EmptyAddress, 0, e3)
+		e2 := NewEncodingFailuref(e1, "bad encoding")
+		e3 := NewLedgerFailure(e2)
+		e4 := fmt.Errorf("some other errors: %w", e3)
+		e5 := NewInvalidProposalSignatureError(flow.EmptyAddress, 0, e4)
+		e6 := fmt.Errorf("wrapped: %w", e5)
 
-		txErr, vmErr := SplitErrorTypes(e4)
+		txErr, vmErr := SplitErrorTypes(e6)
 		require.Nil(t, txErr)
-		require.Equal(t, e2, vmErr)
+		require.Equal(t, e3, vmErr)
 	})
 
 	t.Run("unknown error", func(t *testing.T) {

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -1,7 +1,7 @@
 package errors
 
-func NewUnknownFailure(err error) *CodedFailure {
-	return WrapCodedFailure(
+func NewUnknownFailure(err error) CodedError {
+	return WrapCodedError(
 		FailureCodeUnknownFailure,
 		err,
 		"unknown failure")
@@ -12,18 +12,18 @@ func NewEncodingFailuref(
 	err error,
 	msg string,
 	args ...interface{},
-) *CodedFailure {
-	return WrapCodedFailure(
+) CodedError {
+	return WrapCodedError(
 		FailureCodeEncodingFailure,
 		err,
 		"encoding failed: "+msg,
 		args...)
 }
 
-// NewLedgerFailure constructs a new CodedFailure which captures a fatal error
+// NewLedgerFailure constructs a new CodedError which captures a fatal error
 // cause by ledger failures.
-func NewLedgerFailure(err error) *CodedFailure {
-	return WrapCodedFailure(
+func NewLedgerFailure(err error) CodedError {
+	return WrapCodedError(
 		FailureCodeLedgerFailure,
 		err,
 		"ledger returns unsuccessful")
@@ -35,19 +35,19 @@ func IsALedgerFailure(err error) bool {
 	return HasErrorCode(err, FailureCodeLedgerFailure)
 }
 
-// NewStateMergeFailure constructs a new CodedFailure which captures a fatal
+// NewStateMergeFailure constructs a new CodedError which captures a fatal
 // caused by state merge.
-func NewStateMergeFailure(err error) *CodedFailure {
-	return WrapCodedFailure(
+func NewStateMergeFailure(err error) CodedError {
+	return WrapCodedError(
 		FailureCodeStateMergeFailure,
 		err,
 		"can not merge the state")
 }
 
-// NewBlockFinderFailure constructs a new CodedFailure which captures a fatal
+// NewBlockFinderFailure constructs a new CodedError which captures a fatal
 // caused by block finder.
-func NewBlockFinderFailure(err error) *CodedFailure {
-	return WrapCodedFailure(
+func NewBlockFinderFailure(err error) CodedError {
+	return WrapCodedError(
 		FailureCodeBlockFinderFailure,
 		err,
 		"can not retrieve the block")


### PR DESCRIPTION
We no longer need the distinction since we can check the code recursively