### PR TITLE
[Benchmark] Add ability to auto-detect maximum TPS

### DIFF
--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -329,6 +329,7 @@ func adjustTPS(
 			currentTxs := uint(lg.GetTxExecuted())
 			inflight := currentSentTxs - int(currentTxs)
 			currentTPS := float64(currentTxs-lastTxs) / now.Sub(lastTs).Seconds()
+			inflightPerWorker := inflight / int(targetTPS)
 
 			unboundedTPS := uint(math.Ceil(currentTPS))
 
@@ -347,6 +348,7 @@ func adjustTPS(
 						Float64("lastTPS", lastTPS).
 						Float64("currentTPS", currentTPS).
 						Int("inflight", inflight).
+						Int("inflightPerWorker", inflightPerWorker).
 						Msg("skipped adjusting TPS")
 
 					lastTxs = currentTxs
@@ -367,6 +369,7 @@ func adjustTPS(
 				Uint("unboundedTPS", unboundedTPS).
 				Uint("targetTPS", boundedTPS).
 				Int("inflight", inflight).
+				Int("inflightPerWorker", inflightPerWorker).
 				Msg("adjusting TPS")
 
 			err := lg.SetTPS(boundedTPS)

--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"math"
@@ -203,7 +204,7 @@ func main() {
 			uint(*maxTPSFlag),
 			uint(maxInflight/2),
 		)
-		if err != nil {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			log.Fatal().Err(err).Msgf("unable to adjust tps")
 		}
 	}()
@@ -214,7 +215,10 @@ func main() {
 		// TODO(rbtz): the loader currently doesn't ever cancel the context.
 		log.Warn().Err(ctx.Err()).Msg("loader context canceled")
 	}
+
+	log.Info().Msg("Stopping load generator")
 	lg.Stop()
+	log.Info().Msg("Waiting for workers to finish")
 	wg.Wait()
 
 	if len(dataSlices) == 0 {

--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -53,7 +53,7 @@ const (
 	metricport                  = uint(8080)
 	accessNodeAddress           = "127.0.0.1:3569"
 	pushgateway                 = "127.0.0.1:9091"
-	accountMultiplier           = 100
+	accountMultiplier           = 50
 	feedbackEnabled             = true
 	serviceAccountPrivateKeyHex = unittest.ServiceAccountPrivateKeyHex
 

--- a/integration/benchmark/cmd/ci/main_test.go
+++ b/integration/benchmark/cmd/ci/main_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_computeTPS(t *testing.T) {
+	now := time.Now()
+
+	type args struct {
+		lastTxs     uint
+		currentTxs  uint
+		lastTs      time.Time
+		nowTs       time.Time
+		lastTPS     float64
+		targetTPS   uint
+		inflight    int
+		maxInflight uint
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantSkip         bool
+		wantCurrentTPS   float64
+		wantUnboundedTPS uint
+	}{
+		{
+			"empty",
+			args{},
+			true, 0, 0,
+		},
+		{
+			"current TPS is equal or higher than target and inflight is higher than max",
+			args{lastTxs: 1, currentTxs: 11, lastTs: now, nowTs: now.Add(time.Second), lastTPS: 1, targetTPS: 10, inflight: 1000, maxInflight: 100},
+			false, 10, 10 + additiveIncrease,
+		},
+		{
+			"current TPS is within the target and inflight is higher than max",
+			args{lastTxs: 1, currentTxs: 10, lastTs: now, nowTs: now.Add(time.Second), lastTPS: 1, targetTPS: 10, inflight: 1000, maxInflight: 100},
+			false, 9, 10 * multiplicativeDecrease,
+		},
+		{
+			"current TPS is within the target and inflight is lower than max",
+			args{lastTxs: 1, currentTxs: 10, lastTs: now, nowTs: now.Add(time.Second), lastTPS: 1, targetTPS: 10, inflight: 10, maxInflight: 100},
+			false, 9, 10 + additiveIncrease,
+		},
+		{
+			"current TPS is lower than target TPS but increasing and within max inflight",
+			args{lastTxs: 1, currentTxs: 10, lastTs: now, nowTs: now.Add(time.Second), lastTPS: 1, targetTPS: 100, inflight: 10, maxInflight: 100},
+			true, 9, 0,
+		},
+		{
+			"current TPS is lower than target TPS and NOT increasing and within max inflight",
+			args{lastTxs: 1, currentTxs: 10, lastTs: now, nowTs: now.Add(time.Second), lastTPS: 100, targetTPS: 100, inflight: 10, maxInflight: 100},
+			false, 9, 100 * multiplicativeDecrease,
+		},
+		{
+			"current TPS is lower than target TPS but increasing and NOT within max inflight",
+			args{lastTxs: 1, currentTxs: 10, lastTs: now, nowTs: now.Add(time.Second), lastTPS: 1, targetTPS: 100, inflight: 1000, maxInflight: 100},
+			false, 9, 100 * multiplicativeDecrease,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotSkip, gotCurrentTPS, gotUnboundedTPS := computeTPS(tt.args.lastTxs, tt.args.currentTxs, tt.args.lastTs, tt.args.nowTs, tt.args.lastTPS, tt.args.targetTPS, tt.args.inflight, tt.args.maxInflight)
+			assert.Equal(t, tt.wantSkip, gotSkip)
+			assert.Equal(t, tt.wantCurrentTPS, gotCurrentTPS)
+			assert.Equal(t, tt.wantUnboundedTPS, gotUnboundedTPS)
+		})
+	}
+}

--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -346,11 +346,11 @@ func (lg *ContLoadGenerator) Stop() {
 
 	defer lg.log.Debug().Msg("stopped generator")
 
+	lg.log.Debug().Msg("stopping follower")
+	lg.follower.Stop()
 	lg.log.Debug().Msg("stopping workers")
 	_ = lg.unsafeSetTPS(0)
 	lg.workerStatsTracker.StopPrinting()
-	lg.log.Debug().Msg("stopping follower")
-	lg.follower.Stop()
 	close(lg.stoppedChannel)
 }
 

--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -722,7 +722,8 @@ func (lg *ContLoadGenerator) sendTokenTransferTx(workerID int) {
 			lg.workerStatsTracker.IncTxExecuted()
 			return
 		case <-time.After(slowTransactionThreshold):
-			log.Warn().
+			// TODO(rbtz): add a counter for slow transactions
+			log.Trace().
 				Hex("txID", transferTx.ID().Bytes()).
 				Dur("duration", time.Since(startTime)).
 				Int("availableAccounts", len(lg.availableAccounts)).

--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -347,6 +347,10 @@ func (lg *ContLoadGenerator) Done() <-chan struct{} {
 	return lg.stoppedChannel
 }
 
+func (lg *ContLoadGenerator) GetTxSent() int {
+	return lg.workerStatsTracker.GetTxSent()
+}
+
 func (lg *ContLoadGenerator) GetTxExecuted() int {
 	return lg.workerStatsTracker.GetTxExecuted()
 }

--- a/integration/benchmark/worker_stats_tracker.go
+++ b/integration/benchmark/worker_stats_tracker.go
@@ -74,6 +74,13 @@ func (st *WorkerStatsTracker) AddTxSent() {
 	st.txsSentPerSecond[now]++
 }
 
+func (st *WorkerStatsTracker) GetTxSent() int {
+	st.mux.Lock()
+	defer st.mux.Unlock()
+
+	return st.stats.txsSent
+}
+
 func (st *WorkerStatsTracker) GetStats() WorkerStats {
 	st.mux.Lock()
 	defer st.mux.Unlock()

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -1,10 +1,10 @@
 COLLECTION = 3
-CONSENSUS = 3
+CONSENSUS = 2
 VALID_CONSENSUS := $(shell test $(CONSENSUS) -ge 2; echo $$?)
 EXECUTION = 2
 VALID_EXECUTION := $(shell test $(EXECUTION) -ge 2; echo $$?)
 VERIFICATION = 1
-ACCESS = 2
+ACCESS = 1
 OBSERVER = 0
 NCLUSTERS=1
 EPOCHLEN=10000   # 0 means use default
@@ -55,9 +55,10 @@ else
 endif
 
 # Creates a light version of the localnet with just 1 instance for each node type
+# (Except for consensus and execution nodes, which are set to 2)
 .PHONY: init-light
 init-light:
-	$(MAKE) -e COLLECTION=1 CONSENSUS=2 EXECUTION=1 VERIFICATION=1 ACCESS=1 NCLUSTERS=1 init
+	$(MAKE) -e COLLECTION=1 CONSENSUS=2 EXECUTION=2 VERIFICATION=1 ACCESS=1 NCLUSTERS=1 init
 
 # Creates a version of localnet configured with short epochs
 .PHONY: init-short-epochs
@@ -88,7 +89,7 @@ tps-ci-smoke:
 
 .PHONY: tps-test-ci
 tps-test-ci:
-	make init
-	make start
-	go run --tags relic ../benchmark/cmd/ci -log-level info -initial-tps 25 -max-tps 300 -duration 30m
-	make stop
+	$(MAKE) -e COLLECTION=5 VERIFICATION=5 NCLUSTERS=5 init
+	$(MAKE) start
+	go run --tags relic ../benchmark/cmd/ci -log-level info -initial-tps 25 -max-tps 500 -duration 30m
+	$(MAKE) stop


### PR DESCRIPTION
This PR adds an ability of finding the maximum TPS that the network can handle to the `ci` benchmark
It is currently using a simple AIMD (additive increase/multiplicative decrease) algorithm.

The algorithm starts with `-initial-tps` as a target.  Each time it is able to reach the target TPS, it increases the target by `additiveIncrease`. Each time it fails to reach the target TPS, it decreases the target by `multiplicativeDecrease` factor.  

There are two optimizations on top:
* To avoid oscillation and speedup conversion we skip the adjustment stage if TPS grew compared to the last round.  
* We do not shrink target TPS if it would bring them below the current TPS.

(We disable both optimizations if inflight transactions are above `maxInflight`)

Target TPS is always bounded by [`-initial-tps`, `-max-tps`].

Result wise, it is quite aggressive but reliably backs off once TPS "in" gets much higher than TPS "out":
<img width="1429" alt="Screen Shot 2022-10-05 at 11 10 31 PM 1" src="https://user-images.githubusercontent.com/169976/194227528-6450e185-110c-438b-94bc-3af16277b0bd.png">

Depends on: #3292