### PR TITLE
Backport PR 3050 to v0.27 to reduce memory and speedup checkpoint by splitting trie into subtries

### DIFF
--- a/ledger/complete/mtrie/flattener/iterator.go
+++ b/ledger/complete/mtrie/flattener/iterator.go
@@ -3,7 +3,6 @@ package flattener
 import (
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
-	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 )
 
 // NodeIterator is an iterator over the nodes in a trie.
@@ -76,13 +75,13 @@ type NodeIterator struct {
 // as for each node, the children have been previously encountered.
 // NodeIterator created by NewNodeIterator is safe for concurrent use
 // because visitedNodes is always nil in this case.
-func NewNodeIterator(mTrie *trie.MTrie) *NodeIterator {
+func NewNodeIterator(n *node.Node) *NodeIterator {
 	// for a Trie with height H (measured by number of edges), the longest possible path contains H+1 vertices
 	stackSize := ledger.NodeMaxHeight + 1
 	i := &NodeIterator{
 		stack: make([]*node.Node, 0, stackSize),
 	}
-	i.unprocessedRoot = mTrie.RootNode()
+	i.unprocessedRoot = n
 	return i
 }
 
@@ -98,7 +97,7 @@ func NewNodeIterator(mTrie *trie.MTrie) *NodeIterator {
 // When re-building the Trie from the sequence of nodes, one can build the trie on the fly,
 // as for each node, the children have been previously encountered.
 // WARNING: visitedNodes is not safe for concurrent use.
-func NewUniqueNodeIterator(mTrie *trie.MTrie, visitedNodes map[*node.Node]uint64) *NodeIterator {
+func NewUniqueNodeIterator(n *node.Node, visitedNodes map[*node.Node]uint64) *NodeIterator {
 	// For a Trie with height H (measured by number of edges), the longest possible path
 	// contains H+1 vertices.
 	stackSize := ledger.NodeMaxHeight + 1
@@ -106,7 +105,7 @@ func NewUniqueNodeIterator(mTrie *trie.MTrie, visitedNodes map[*node.Node]uint64
 		stack:        make([]*node.Node, 0, stackSize),
 		visitedNodes: visitedNodes,
 	}
-	i.unprocessedRoot = mTrie.RootNode()
+	i.unprocessedRoot = n
 	return i
 }
 
@@ -115,7 +114,7 @@ func (i *NodeIterator) Next() bool {
 		// initial call to Next() for a non-empty trie
 		i.dig(i.unprocessedRoot)
 		i.unprocessedRoot = nil
-		return true
+		return len(i.stack) > 0
 	}
 
 	// the current head of the stack, `n`, has been recalled

--- a/ledger/complete/mtrie/flattener/iterator_test.go
+++ b/ledger/complete/mtrie/flattener/iterator_test.go
@@ -16,7 +16,7 @@ import (
 func TestEmptyTrie(t *testing.T) {
 	emptyTrie := trie.NewEmptyMTrie()
 
-	itr := flattener.NewNodeIterator(emptyTrie)
+	itr := flattener.NewNodeIterator(emptyTrie.RootNode())
 	require.True(t, nil == itr.Value()) // initial iterator should return nil
 
 	require.False(t, itr.Next())
@@ -30,7 +30,7 @@ func TestPopulatedTrie(t *testing.T) {
 	emptyTrie := trie.NewEmptyMTrie()
 
 	// key: 0000...
-	p1 := testutils.PathByUint8(1)
+	p1 := testutils.PathByUint8(0)
 	v1 := testutils.LightPayload8('A', 'a')
 
 	// key: 0100....
@@ -43,12 +43,12 @@ func TestPopulatedTrie(t *testing.T) {
 	testTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
 	require.NoError(t, err)
 
-	for itr := flattener.NewNodeIterator(testTrie); itr.Next(); {
+	for itr := flattener.NewNodeIterator(testTrie.RootNode()); itr.Next(); {
 		fmt.Println(itr.Value().FmtStr("", ""))
 		fmt.Println()
 	}
 
-	itr := flattener.NewNodeIterator(testTrie)
+	itr := flattener.NewNodeIterator(testTrie.RootNode())
 
 	require.True(t, itr.Next())
 	p1_leaf := itr.Value()
@@ -80,13 +80,13 @@ func TestUniqueNodeIterator(t *testing.T) {
 		emptyTrie := trie.NewEmptyMTrie()
 
 		// visitedNodes is nil
-		itr := flattener.NewUniqueNodeIterator(emptyTrie, nil)
+		itr := flattener.NewUniqueNodeIterator(emptyTrie.RootNode(), nil)
 		require.False(t, itr.Next())
 		require.True(t, nil == itr.Value()) // initial iterator should return nil
 
 		// visitedNodes is empty map
 		visitedNodes := make(map[*node.Node]uint64)
-		itr = flattener.NewUniqueNodeIterator(emptyTrie, visitedNodes)
+		itr = flattener.NewUniqueNodeIterator(emptyTrie.RootNode(), visitedNodes)
 		require.False(t, itr.Next())
 		require.True(t, nil == itr.Value()) // initial iterator should return nil
 	})
@@ -95,7 +95,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		emptyTrie := trie.NewEmptyMTrie()
 
 		// key: 0000...
-		p1 := testutils.PathByUint8(1)
+		p1 := testutils.PathByUint8(0)
 		v1 := testutils.LightPayload8('A', 'a')
 
 		// key: 0100....
@@ -126,7 +126,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 
 		// visitedNodes is nil
 		i := 0
-		for itr := flattener.NewUniqueNodeIterator(updatedTrie, nil); itr.Next(); {
+		for itr := flattener.NewUniqueNodeIterator(updatedTrie.RootNode(), nil); itr.Next(); {
 			n := itr.Value()
 			require.True(t, i < len(expectedNodes))
 			require.Equal(t, expectedNodes[i], n)
@@ -138,7 +138,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		// there isn't any shared sub-trie.
 		visitedNodes := make(map[*node.Node]uint64)
 		i = 0
-		for itr := flattener.NewUniqueNodeIterator(updatedTrie, visitedNodes); itr.Next(); {
+		for itr := flattener.NewUniqueNodeIterator(updatedTrie.RootNode(), visitedNodes); itr.Next(); {
 			n := itr.Value()
 			visitedNodes[n] = uint64(i)
 
@@ -157,7 +157,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		emptyTrie := trie.NewEmptyMTrie()
 
 		// key: 0000...
-		p1 := testutils.PathByUint8(1)
+		p1 := testutils.PathByUint8(0)
 		v1 := testutils.LightPayload8('A', 'a')
 
 		// key: 0100....
@@ -254,7 +254,7 @@ func TestUniqueNodeIterator(t *testing.T) {
 		visitedNodes := make(map[*node.Node]uint64)
 		i := 0
 		for _, trie := range tries {
-			for itr := flattener.NewUniqueNodeIterator(trie, visitedNodes); itr.Next(); {
+			for itr := flattener.NewUniqueNodeIterator(trie.RootNode(), visitedNodes); itr.Next(); {
 				n := itr.Value()
 				visitedNodes[n] = uint64(i)
 
@@ -264,5 +264,134 @@ func TestUniqueNodeIterator(t *testing.T) {
 			}
 		}
 		require.Equal(t, i, len(expectedNodes))
+	})
+
+	t.Run("subtries", func(t *testing.T) {
+
+		emptyTrie := trie.NewEmptyMTrie()
+
+		// key: 0000...
+		p1 := testutils.PathByUint8(0)
+		v1 := testutils.LightPayload8('A', 'a')
+
+		// key: 0100....
+		p2 := testutils.PathByUint8(64)
+		v2 := testutils.LightPayload8('B', 'b')
+
+		paths := []ledger.Path{p1, p2}
+		payloads := []ledger.Payload{*v1, *v2}
+
+		trie1, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		require.NoError(t, err)
+
+		// trie1
+		//              n4
+		//             /
+		//            /
+		//          n3
+		//        /     \
+		//      /         \
+		//   n1 (p1/v1)     n2 (p2/v2)
+		//
+
+		// New trie reuses its parent's left sub-trie.
+
+		// key: 1000...
+		p3 := testutils.PathByUint8(128)
+		v3 := testutils.LightPayload8('C', 'c')
+
+		// key: 1100....
+		p4 := testutils.PathByUint8(192)
+		v4 := testutils.LightPayload8('D', 'd')
+
+		paths = []ledger.Path{p3, p4}
+		payloads = []ledger.Payload{*v3, *v4}
+
+		trie2, _, err := trie.NewTrieWithUpdatedRegisters(trie1, paths, payloads, true)
+		require.NoError(t, err)
+
+		// trie2
+		//              n8
+		//             /   \
+		//            /      \
+		//          n3       n7
+		//       (shared)   /   \
+		//                /       \
+		//              n5         n6
+		//            (p3/v3)    (p4/v4)
+
+		// New trie reuses its parent's right sub-trie, and left sub-trie's leaf node.
+
+		// key: 0000...
+		v5 := testutils.LightPayload8('E', 'e')
+
+		paths = []ledger.Path{p1}
+		payloads = []ledger.Payload{*v5}
+
+		trie3, _, err := trie.NewTrieWithUpdatedRegisters(trie2, paths, payloads, true)
+		require.NoError(t, err)
+
+		// trie3
+		//              n11
+		//             /   \
+		//            /      \
+		//          n10       n7
+		//         /   \    (shared)
+		//       /       \
+		//     n9         n2
+		//  (p1/v5)    (shared)
+
+		leftSubtries := []*node.Node{
+			trie1.RootNode().LeftChild(),
+			trie2.RootNode().LeftChild(),
+			trie3.RootNode().LeftChild(),
+		}
+
+		expectedNodesInLeftSubtries := []*node.Node{
+			// unique nodes from trie1
+			trie1.RootNode().LeftChild().LeftChild(),  // n1
+			trie1.RootNode().LeftChild().RightChild(), // n2
+			trie1.RootNode().LeftChild(),              // n3
+			// unique nodes from trie3
+			trie3.RootNode().LeftChild().LeftChild(), // n9
+			trie3.RootNode().LeftChild(),             // n10
+		}
+
+		rightSubtries := []*node.Node{
+			trie1.RootNode().RightChild(),
+			trie2.RootNode().RightChild(),
+			trie3.RootNode().RightChild(),
+		}
+
+		expectedNodesInRightSubtries := []*node.Node{
+			// unique nodes from trie2
+			trie2.RootNode().RightChild().LeftChild(),  // n5
+			trie2.RootNode().RightChild().RightChild(), // n6
+			trie2.RootNode().RightChild(),              // n7
+		}
+
+		testcases := []struct {
+			roots         []*node.Node
+			expectedNodes []*node.Node
+		}{
+			{leftSubtries, expectedNodesInLeftSubtries},
+			{rightSubtries, expectedNodesInRightSubtries},
+		}
+
+		for _, tc := range testcases {
+			visitedNodes := make(map[*node.Node]uint64)
+			i := 0
+			for _, n := range tc.roots {
+				for itr := flattener.NewUniqueNodeIterator(n, visitedNodes); itr.Next(); {
+					n := itr.Value()
+					visitedNodes[n] = uint64(i)
+
+					require.True(t, i < len(tc.expectedNodes))
+					require.Equal(t, tc.expectedNodes[i], n)
+					i++
+				}
+			}
+			require.Equal(t, i, len(tc.expectedNodes))
+		}
 	})
 }

--- a/ledger/complete/wal/checkpointer_serialization_test.go
+++ b/ledger/complete/wal/checkpointer_serialization_test.go
@@ -1,0 +1,305 @@
+package wal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
+	"github.com/onflow/flow-go/ledger/common/utils"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
+)
+
+func TestGetNodesAtLevel(t *testing.T) {
+
+	t.Run("nil node", func(t *testing.T) {
+		n := (*node.Node)(nil)
+		for level := uint(0); level < 6; level++ {
+			nodes := getNodesAtLevel(n, level)
+			assert.Equal(t, 1<<level, len(nodes))
+			for _, nAtLevel := range nodes {
+				require.Nil(t, nAtLevel)
+			}
+		}
+	})
+
+	t.Run("leaf node", func(t *testing.T) {
+		path := utils.PathByUint8(1)
+		payload := utils.LightPayload8('A', 'a')
+		hashValue := hash.Hash([32]byte{1, 1, 1})
+		leafNode := node.NewNode(255, nil, nil, path, payload, hashValue)
+
+		nodes := getNodesAtLevel(leafNode, 0)
+		require.Equal(t, []*node.Node{leafNode}, nodes)
+
+		for level := uint(1); level < 6; level++ {
+			nodes := getNodesAtLevel(leafNode, level)
+			require.Equal(t, 1<<level, len(nodes))
+			for _, nAtLevel := range nodes {
+				require.Nil(t, nAtLevel)
+			}
+		}
+	})
+
+	t.Run("interim node with left child", func(t *testing.T) {
+		emptyTrie := trie.NewEmptyMTrie()
+
+		// key: 0000...
+		p1 := utils.PathByUint8(0)
+		v1 := utils.LightPayload8('A', 'a')
+
+		// key: 0100....
+		p2 := utils.PathByUint8(64)
+		v2 := utils.LightPayload8('B', 'b')
+
+		paths := []ledger.Path{p1, p2}
+		payloads := []ledger.Payload{*v1, *v2}
+
+		updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		require.NoError(t, err)
+
+		//              n4
+		//             /
+		//            /
+		//          n3
+		//        /     \
+		//      /         \
+		//   n1 (p1/v1)     n2 (p2/v2)
+
+		rootNode := updatedTrie.RootNode()
+
+		nodes := getNodesAtLevel(rootNode, 0)
+		require.Equal(t, []*node.Node{updatedTrie.RootNode()}, nodes)
+
+		nodes = getNodesAtLevel(rootNode, 1)
+		require.Equal(t, []*node.Node{rootNode.LeftChild(), nil}, nodes)
+
+		nodes = getNodesAtLevel(rootNode, 2)
+		require.Equal(t, []*node.Node{rootNode.LeftChild().LeftChild(), rootNode.LeftChild().RightChild(), nil, nil}, nodes)
+
+		for level := uint(3); level < 6; level++ {
+			nodes := getNodesAtLevel(rootNode, level)
+			require.Equal(t, 1<<level, len(nodes))
+			for _, nAtLevel := range nodes {
+				require.Nil(t, nAtLevel)
+			}
+		}
+	})
+
+	t.Run("interim node with right child", func(t *testing.T) {
+		emptyTrie := trie.NewEmptyMTrie()
+
+		// key: 1000...
+		p3 := utils.PathByUint8(128)
+		v3 := utils.LightPayload8('C', 'c')
+
+		// key: 1100....
+		p4 := utils.PathByUint8(192)
+		v4 := utils.LightPayload8('D', 'd')
+
+		paths := []ledger.Path{p3, p4}
+		payloads := []ledger.Payload{*v3, *v4}
+
+		updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		require.NoError(t, err)
+
+		//              n8
+		//                 \
+		//                   \
+		//                   n7
+		//                  /   \
+		//                /       \
+		//              n5         n6
+		//            (p3/v3)    (p4/v4)
+
+		rootNode := updatedTrie.RootNode()
+
+		nodes := getNodesAtLevel(rootNode, 0)
+		require.Equal(t, []*node.Node{rootNode}, nodes)
+
+		nodes = getNodesAtLevel(rootNode, 1)
+		require.Equal(t, []*node.Node{nil, rootNode.RightChild()}, nodes)
+
+		nodes = getNodesAtLevel(rootNode, 2)
+		require.Equal(t, []*node.Node{nil, nil, rootNode.RightChild().LeftChild(), rootNode.RightChild().RightChild()}, nodes)
+
+		for level := uint(3); level < 6; level++ {
+			nodes := getNodesAtLevel(rootNode, level)
+			require.Equal(t, 1<<level, len(nodes))
+			for _, nAtLevel := range nodes {
+				require.Nil(t, nAtLevel)
+			}
+		}
+	})
+
+	t.Run("interim node with 2 children", func(t *testing.T) {
+		emptyTrie := trie.NewEmptyMTrie()
+
+		// key: 0000...
+		p1 := utils.PathByUint8(0)
+		v1 := utils.LightPayload8('A', 'a')
+
+		// key: 0100....
+		p2 := utils.PathByUint8(64)
+		v2 := utils.LightPayload8('B', 'b')
+
+		// key: 1000...
+		p3 := utils.PathByUint8(128)
+		v3 := utils.LightPayload8('C', 'c')
+
+		// key: 1100....
+		p4 := utils.PathByUint8(192)
+		v4 := utils.LightPayload8('D', 'd')
+
+		paths := []ledger.Path{p1, p2, p3, p4}
+		payloads := []ledger.Payload{*v1, *v2, *v3, *v4}
+
+		updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		require.NoError(t, err)
+
+		//                n4
+		//             /      \
+		//            /        \
+		//          n3           n5
+		//        /   \          /  \
+		//      /      \        /     \
+		//   n1        n2      n6      n7
+		//  (p1)      (p2)    (p3)    (p4)
+
+		rootNode := updatedTrie.RootNode()
+
+		nodes := getNodesAtLevel(rootNode, 0)
+		require.Equal(t, []*node.Node{rootNode}, nodes)
+
+		nodes = getNodesAtLevel(rootNode, 1)
+		require.Equal(t, []*node.Node{rootNode.LeftChild(), rootNode.RightChild()}, nodes)
+
+		nodes = getNodesAtLevel(rootNode, 2)
+		require.Equal(t, []*node.Node{rootNode.LeftChild().LeftChild(), rootNode.LeftChild().RightChild(), rootNode.RightChild().LeftChild(), rootNode.RightChild().RightChild()}, nodes)
+
+		for level := uint(3); level < 6; level++ {
+			nodes := getNodesAtLevel(rootNode, level)
+			require.Equal(t, 1<<level, len(nodes))
+			for _, nAtLevel := range nodes {
+				require.Nil(t, nAtLevel)
+			}
+		}
+	})
+
+	t.Run("sparse trie with 8 levels", func(t *testing.T) {
+
+		emptyTrie := trie.NewEmptyMTrie()
+
+		// key: 0000 0000
+		p1 := utils.PathByUint8(0)
+		v1 := utils.LightPayload8('A', 'a')
+
+		// key: 0000 0001
+		p2 := utils.PathByUint8(1)
+		v2 := utils.LightPayload8('B', 'b')
+
+		// key: 1111 1110
+		p3 := utils.PathByUint8(254)
+		v3 := utils.LightPayload8('C', 'c')
+
+		// key: 1111 1111
+		p4 := utils.PathByUint8(255)
+		v4 := utils.LightPayload8('D', 'd')
+
+		paths := []ledger.Path{p1, p2, p3, p4}
+		payloads := []ledger.Payload{*v1, *v2, *v3, *v4}
+
+		updatedTrie, _, err := trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, true)
+		require.NoError(t, err)
+
+		//                             n0
+		//                           /    \
+		//                         n1a    n1b
+		//                         /        \
+		//                       n2a        n2b
+		//                       /            \
+		//                      n3a           n3b
+		//                      /               \
+		//                     n4a              n4b
+		//                     /                  \
+		//                    n5a                 n5b
+		//                    /                     \
+		//                   n6a                    n6b
+		//                   /                        \
+		//                  n7a                       n7b
+		//                 /   \                      /  \
+		//               n8a   n8b                  n8d   n8d
+		//              (p1)   (p2)                (p3)   (p4)
+
+		n0 := updatedTrie.RootNode()
+
+		n1a := n0.LeftChild()
+		require.NotNil(t, n1a)
+		n1b := n0.RightChild()
+		require.NotNil(t, n1b)
+
+		n2a := n1a.LeftChild()
+		require.NotNil(t, n2a)
+		n2b := n1b.RightChild()
+		require.NotNil(t, n2b)
+
+		n3a := n2a.LeftChild()
+		require.NotNil(t, n3a)
+		n3b := n2b.RightChild()
+		require.NotNil(t, n3b)
+
+		n4a := n3a.LeftChild()
+		require.NotNil(t, n4a)
+		n4b := n3b.RightChild()
+		require.NotNil(t, n4b)
+
+		n5a := n4a.LeftChild()
+		require.NotNil(t, n5a)
+		n5b := n4b.RightChild()
+		require.NotNil(t, n5b)
+
+		n6a := n5a.LeftChild()
+		require.NotNil(t, n6a)
+		n6b := n5b.RightChild()
+		require.NotNil(t, n6b)
+
+		n7a := n6a.LeftChild()
+		require.NotNil(t, n7a)
+		n7b := n6b.RightChild()
+		require.NotNil(t, n7b)
+
+		n8a := n7a.LeftChild()
+		require.NotNil(t, n8a)
+		n8b := n7a.RightChild()
+		require.NotNil(t, n8b)
+		n8c := n7b.LeftChild()
+		require.NotNil(t, n8c)
+		n8d := n7b.RightChild()
+		require.NotNil(t, n8d)
+
+		testcases := []struct {
+			level         uint
+			expectedNodes []*node.Node
+		}{
+			{0, []*node.Node{n0}},
+			{1, []*node.Node{n1a, n1b}},
+			{2, []*node.Node{0: n2a, 3: n2b}},
+			{3, []*node.Node{0: n3a, 7: n3b}},
+			{4, []*node.Node{0: n4a, 15: n4b}},
+			{5, []*node.Node{0: n5a, 31: n5b}},
+			{6, []*node.Node{0: n6a, 63: n6b}},
+			{7, []*node.Node{0: n7a, 127: n7b}},
+			{8, []*node.Node{0: n8a, 1: n8b, 254: n8c, 255: n8d}},
+		}
+
+		rootNode := updatedTrie.RootNode()
+		for _, tc := range testcases {
+			nodes := getNodesAtLevel(rootNode, tc.level)
+			require.Equal(t, len(tc.expectedNodes), len(nodes))
+			require.Equal(t, tc.expectedNodes, nodes)
+		}
+	})
+}

--- a/ledger/complete/wal/checkpointer_serialization_test.go
+++ b/ledger/complete/wal/checkpointer_serialization_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/hash"
-	"github.com/onflow/flow-go/ledger/common/utils"
+	"github.com/onflow/flow-go/ledger/common/testutils"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 )
@@ -27,8 +27,8 @@ func TestGetNodesAtLevel(t *testing.T) {
 	})
 
 	t.Run("leaf node", func(t *testing.T) {
-		path := utils.PathByUint8(1)
-		payload := utils.LightPayload8('A', 'a')
+		path := testutils.PathByUint8(1)
+		payload := testutils.LightPayload8('A', 'a')
 		hashValue := hash.Hash([32]byte{1, 1, 1})
 		leafNode := node.NewNode(255, nil, nil, path, payload, hashValue)
 
@@ -48,12 +48,12 @@ func TestGetNodesAtLevel(t *testing.T) {
 		emptyTrie := trie.NewEmptyMTrie()
 
 		// key: 0000...
-		p1 := utils.PathByUint8(0)
-		v1 := utils.LightPayload8('A', 'a')
+		p1 := testutils.PathByUint8(0)
+		v1 := testutils.LightPayload8('A', 'a')
 
 		// key: 0100....
-		p2 := utils.PathByUint8(64)
-		v2 := utils.LightPayload8('B', 'b')
+		p2 := testutils.PathByUint8(64)
+		v2 := testutils.LightPayload8('B', 'b')
 
 		paths := []ledger.Path{p1, p2}
 		payloads := []ledger.Payload{*v1, *v2}
@@ -93,12 +93,12 @@ func TestGetNodesAtLevel(t *testing.T) {
 		emptyTrie := trie.NewEmptyMTrie()
 
 		// key: 1000...
-		p3 := utils.PathByUint8(128)
-		v3 := utils.LightPayload8('C', 'c')
+		p3 := testutils.PathByUint8(128)
+		v3 := testutils.LightPayload8('C', 'c')
 
 		// key: 1100....
-		p4 := utils.PathByUint8(192)
-		v4 := utils.LightPayload8('D', 'd')
+		p4 := testutils.PathByUint8(192)
+		v4 := testutils.LightPayload8('D', 'd')
 
 		paths := []ledger.Path{p3, p4}
 		payloads := []ledger.Payload{*v3, *v4}
@@ -139,20 +139,20 @@ func TestGetNodesAtLevel(t *testing.T) {
 		emptyTrie := trie.NewEmptyMTrie()
 
 		// key: 0000...
-		p1 := utils.PathByUint8(0)
-		v1 := utils.LightPayload8('A', 'a')
+		p1 := testutils.PathByUint8(0)
+		v1 := testutils.LightPayload8('A', 'a')
 
 		// key: 0100....
-		p2 := utils.PathByUint8(64)
-		v2 := utils.LightPayload8('B', 'b')
+		p2 := testutils.PathByUint8(64)
+		v2 := testutils.LightPayload8('B', 'b')
 
 		// key: 1000...
-		p3 := utils.PathByUint8(128)
-		v3 := utils.LightPayload8('C', 'c')
+		p3 := testutils.PathByUint8(128)
+		v3 := testutils.LightPayload8('C', 'c')
 
 		// key: 1100....
-		p4 := utils.PathByUint8(192)
-		v4 := utils.LightPayload8('D', 'd')
+		p4 := testutils.PathByUint8(192)
+		v4 := testutils.LightPayload8('D', 'd')
 
 		paths := []ledger.Path{p1, p2, p3, p4}
 		payloads := []ledger.Payload{*v1, *v2, *v3, *v4}
@@ -194,20 +194,20 @@ func TestGetNodesAtLevel(t *testing.T) {
 		emptyTrie := trie.NewEmptyMTrie()
 
 		// key: 0000 0000
-		p1 := utils.PathByUint8(0)
-		v1 := utils.LightPayload8('A', 'a')
+		p1 := testutils.PathByUint8(0)
+		v1 := testutils.LightPayload8('A', 'a')
 
 		// key: 0000 0001
-		p2 := utils.PathByUint8(1)
-		v2 := utils.LightPayload8('B', 'b')
+		p2 := testutils.PathByUint8(1)
+		v2 := testutils.LightPayload8('B', 'b')
 
 		// key: 1111 1110
-		p3 := utils.PathByUint8(254)
-		v3 := utils.LightPayload8('C', 'c')
+		p3 := testutils.PathByUint8(254)
+		v3 := testutils.LightPayload8('C', 'c')
 
 		// key: 1111 1111
-		p4 := utils.PathByUint8(255)
-		v4 := utils.LightPayload8('D', 'd')
+		p4 := testutils.PathByUint8(255)
+		v4 := testutils.LightPayload8('D', 'd')
 
 		paths := []ledger.Path{p1, p2, p3, p4}
 		payloads := []ledger.Payload{*v1, *v2, *v3, *v4}


### PR DESCRIPTION
Backport PR #3050 from master to branch v0.27.
