### PR TITLE
[Checpoint V6] Revert "Refactor load checkpoint"

### DIFF
--- a/cmd/util/cmd/checkpoint-list-tries/cmd.go
+++ b/cmd/util/cmd/checkpoint-list-tries/cmd.go
@@ -2,7 +2,6 @@ package checkpoint_list_tries
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -30,8 +29,7 @@ func init() {
 func run(*cobra.Command, []string) {
 
 	log.Info().Msgf("loading checkpoint %v", flagCheckpoint)
-	dir, file := filepath.Split(flagCheckpoint)
-	tries, err := wal.LoadCheckpoint(dir, file, &log.Logger)
+	tries, err := wal.LoadCheckpoint(flagCheckpoint, &log.Logger)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error while loading checkpoint")
 	}

--- a/ledger/complete/wal/checkpointer.go
+++ b/ledger/complete/wal/checkpointer.go
@@ -555,13 +555,13 @@ func getNodesAtLevel(root *node.Node, level uint) []*node.Node {
 }
 
 func (c *Checkpointer) LoadCheckpoint(checkpoint int) ([]*trie.MTrie, error) {
-	filename := NumberToFilename(checkpoint)
-	return LoadCheckpoint(c.dir, filename, &c.wal.log)
+	filepath := path.Join(c.dir, NumberToFilename(checkpoint))
+	return LoadCheckpoint(filepath, &c.wal.log)
 }
 
 func (c *Checkpointer) LoadRootCheckpoint() ([]*trie.MTrie, error) {
-	filename := bootstrap.FilenameWALRootCheckpoint
-	return LoadCheckpoint(c.dir, filename, &c.wal.log)
+	filepath := path.Join(c.dir, bootstrap.FilenameWALRootCheckpoint)
+	return LoadCheckpoint(filepath, &c.wal.log)
 }
 
 func (c *Checkpointer) HasRootCheckpoint() (bool, error) {
@@ -578,8 +578,7 @@ func (c *Checkpointer) RemoveCheckpoint(checkpoint int) error {
 	return os.Remove(path.Join(c.dir, NumberToFilename(checkpoint)))
 }
 
-func LoadCheckpoint(dir string, filename string, logger *zerolog.Logger) ([]*trie.MTrie, error) {
-	filepath := path.Join(dir, filename)
+func LoadCheckpoint(filepath string, logger *zerolog.Logger) ([]*trie.MTrie, error) {
 	file, err := os.Open(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open checkpoint file %s: %w", filepath, err)

--- a/ledger/complete/wal/checkpointer_test.go
+++ b/ledger/complete/wal/checkpointer_test.go
@@ -525,7 +525,7 @@ func randomlyModifyFile(t *testing.T, filename string) {
 
 func Test_StoringLoadingCheckpoints(t *testing.T) {
 
-	unittest.RunWithTempDirWithoutRemove(t, func(dir string) {
+	unittest.RunWithTempDir(t, func(dir string) {
 		// some hash will be literally encoded in output file
 		// so we can find it and modify - to make sure we get a different checksum
 		// but not fail process by, for example, modifying saved data length causing EOF
@@ -546,11 +546,9 @@ func Test_StoringLoadingCheckpoints(t *testing.T) {
 
 		someHash := updatedTrie.RootNode().LeftChild().Hash() // Hash of left child
 
-		filePrefix := "temp-checkpoint"
-		file, err := os.CreateTemp(dir, filePrefix)
+		file, err := os.CreateTemp(dir, "temp-checkpoint")
 		filepath := file.Name()
 		require.NoError(t, err)
-		_, fileName := path.Split(filepath)
 
 		err = realWAL.StoreCheckpoint(file, updatedTrie)
 		require.NoError(t, err)
@@ -559,7 +557,7 @@ func Test_StoringLoadingCheckpoints(t *testing.T) {
 
 		t.Run("works without data modification", func(t *testing.T) {
 			logger := zerolog.Nop()
-			tries, err := realWAL.LoadCheckpoint(dir, fileName, &logger)
+			tries, err := realWAL.LoadCheckpoint(filepath, &logger)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(tries))
 			require.Equal(t, updatedTrie, tries[0])
@@ -577,7 +575,7 @@ func Test_StoringLoadingCheckpoints(t *testing.T) {
 			require.NoError(t, err)
 
 			logger := zerolog.Nop()
-			tries, err := realWAL.LoadCheckpoint(dir, fileName, &logger)
+			tries, err := realWAL.LoadCheckpoint(filepath, &logger)
 			require.Error(t, err)
 			require.Nil(t, tries)
 			require.Contains(t, err.Error(), "checksum")

--- a/ledger/complete/wal/checkpointer_versioning_test.go
+++ b/ledger/complete/wal/checkpointer_versioning_test.go
@@ -20,7 +20,7 @@ func TestLoadCheckpointV1(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	tries, err := LoadCheckpoint("test_data", "checkpoint.v1", &logger)
+	tries, err := LoadCheckpoint("test_data/checkpoint.v1", &logger)
 	require.NoError(t, err)
 	require.Equal(t, len(expectedRootHash), len(tries))
 
@@ -40,7 +40,7 @@ func TestLoadCheckpointV3(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	tries, err := LoadCheckpoint("test_data", "checkpoint.v3", &logger)
+	tries, err := LoadCheckpoint("test_data/checkpoint.v3", &logger)
 	require.NoError(t, err)
 	require.Equal(t, len(expectedRootHash), len(tries))
 
@@ -60,7 +60,7 @@ func TestLoadCheckpointV4(t *testing.T) {
 	}
 
 	logger := zerolog.Nop()
-	tries, err := LoadCheckpoint("test_data", "checkpoint.v4", &logger)
+	tries, err := LoadCheckpoint("test_data/checkpoint.v4", &logger)
 	require.NoError(t, err)
 	require.Equal(t, len(expectedRootHash), len(tries))
 

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -318,12 +318,6 @@ func RunWithTempDir(t testing.TB, f func(string)) {
 	f(dbDir)
 }
 
-// Useful for debugging purpose
-func RunWithTempDirWithoutRemove(t testing.TB, f func(string)) {
-	dbDir := TempDir(t)
-	f(dbDir)
-}
-
 func badgerDB(t testing.TB, dir string, create func(badger.Options) (*badger.DB, error)) *badger.DB {
 	opts := badger.
 		DefaultOptions(dir).


### PR DESCRIPTION
Reverts onflow/flow-go#3310

Reverting this change, because:

1. We could [split the directory and filename from a file path](https://github.com/onflow/flow-go/pull/3336/files#diff-2ff6507ee260a1e37156b4cae4cc259e7688bbd0007993b20fa193824073105aR31)
2. [DPS depends on a single full path of the checkpoint file](https://github.com/onflow/flow-dps/blob/d119e8c713e9f058dc82d57048a186e7533b529f/service/loader/checkpoint.go#L47), they can keep passing a single path