### PR TITLE
Improve transaction invoker error handling

### DIFF
--- a/fvm/errors/errors.go
+++ b/fvm/errors/errors.go
@@ -66,6 +66,17 @@ func findImportantCodedError(err error) (CodedError, bool) {
 	}
 }
 
+// IsFailure returns true if the error is un-coded, or if the error contains
+// a failure code.
+func IsFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	coded, isUnknown := findImportantCodedError(err)
+	return isUnknown || coded.Code().IsFailure()
+}
+
 // SplitErrorTypes splits the error into fatal (failures) and non-fatal errors
 func SplitErrorTypes(inp error) (err CodedError, failure CodedError) {
 	if inp == nil {

--- a/fvm/errors/errors_test.go
+++ b/fvm/errors/errors_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestErrorHandling(t *testing.T) {
+	require.False(t, IsFailure(nil))
 
 	t.Run("test nonfatal error detection", func(t *testing.T) {
 		e1 := NewOperationNotSupportedError("some operations")
@@ -20,6 +21,8 @@ func TestErrorHandling(t *testing.T) {
 		txErr, vmErr := SplitErrorTypes(e4)
 		require.Nil(t, vmErr)
 		require.Equal(t, e3, txErr)
+
+		require.False(t, IsFailure(e4))
 	})
 
 	t.Run("test fatal error detection", func(t *testing.T) {
@@ -33,6 +36,8 @@ func TestErrorHandling(t *testing.T) {
 		txErr, vmErr := SplitErrorTypes(e6)
 		require.Nil(t, txErr)
 		require.Equal(t, e3, vmErr)
+
+		require.True(t, IsFailure(e6))
 	})
 
 	t.Run("unknown error", func(t *testing.T) {
@@ -40,5 +45,7 @@ func TestErrorHandling(t *testing.T) {
 		txErr, vmErr := SplitErrorTypes(e1)
 		require.Nil(t, txErr)
 		require.NotNil(t, vmErr)
+
+		require.True(t, IsFailure(e1))
 	})
 }

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/rs/zerolog"
@@ -42,13 +43,18 @@ func (i TransactionInvoker) Process(
 		defer span.End()
 	}
 
-	nestedTxnId, err := txnState.BeginNestedTransaction()
-	if err != nil {
-		return err
+	nestedTxnId, beginErr := txnState.BeginNestedTransaction()
+	if beginErr != nil {
+		return beginErr
 	}
 
 	var modifiedSets programsCache.ModifiedSetsInvalidator
 	defer func() {
+		if errors.IsFailure(processErr) {
+			// Just immediately halt if the error is a unrecoverable failure.
+			return
+		}
+
 		if txnState.NumNestedTransactions() > 1 {
 			if processErr == nil {
 				// This is a fvm internal programming error.  We forgot to
@@ -58,14 +64,14 @@ func (i TransactionInvoker) Process(
 						"nested transactions.")
 				return
 			} else {
-				err := txnState.RestartNestedTransaction(nestedTxnId)
-				if err != nil {
+				restartErr := txnState.RestartNestedTransaction(nestedTxnId)
+				if restartErr != nil {
 					// This should never happen since merging views should
 					// never fail.
 					processErr = fmt.Errorf(
 						"cannot restart nested transaction on error: %w "+
-							"(original txError: %v)",
-						err,
+							"(original processErr: %v)",
+						restartErr,
 						processErr)
 					return
 				}
@@ -86,30 +92,57 @@ func (i TransactionInvoker) Process(
 		// transaction without any deployed contracts
 		programs.AddInvalidator(modifiedSets)
 
-		err := txnState.Commit(nestedTxnId)
-		if err != nil {
-			processErr = fmt.Errorf("transaction invocation failed when merging state: %w", err)
+		commitErr := txnState.Commit(nestedTxnId)
+		if commitErr != nil {
+			processErr = fmt.Errorf(
+				"transaction invocation failed when merging state: %w "+
+					"(original processErr: %v)",
+				commitErr,
+				processErr)
 		}
 	}()
+
+	mergeErrorShouldEarlyExit := func(err error) bool {
+		if err == nil {
+			return false
+		}
+
+		if errors.IsFailure(err) {
+			if processErr == nil {
+				processErr = err
+			} else {
+				processErr = fmt.Errorf(
+					"%w (collected errors: %v)",
+					err,
+					processErr)
+			}
+			return true
+		}
+
+		processErr = multierror.Append(processErr, err)
+		return false
+	}
 
 	env := NewTransactionEnv(ctx, txnState, programs, proc.Transaction, proc.TxIndex, span)
 
 	rt := env.BorrowCadenceRuntime()
 	defer env.ReturnCadenceRuntime(rt)
 
-	var txError error
-	err = rt.ExecuteTransaction(
+	txError := rt.ExecuteTransaction(
 		runtime.Script{
 			Source:    proc.Transaction.Script,
 			Arguments: proc.Transaction.Arguments,
 		},
 		common.TransactionLocation(proc.ID))
 
-	if err != nil {
+	if txError != nil {
 		txError = fmt.Errorf(
 			"transaction invocation failed when executing transaction: %w",
-			err,
-		)
+			txError)
+
+		if mergeErrorShouldEarlyExit(txError) {
+			return
+		}
 	}
 
 	// read computationUsed from the environment. This will be used to charge fees.
@@ -120,67 +153,84 @@ func (i TransactionInvoker) Process(
 	// transaction deduction, because the payer is not charged for those.
 	i.logExecutionIntensities(ctx, txnState, txIDStr)
 
-	// disable the limit checks on states
-	txnState.DisableAllLimitEnforcements()
-	// try to deduct fees even if there is an error.
-	// disable the limit checks on states
-	feesError := i.deductTransactionFees(env, proc, txnState, computationUsed)
-	if feesError != nil {
-		txError = feesError
+	if processErr == nil {
+		// disable the limit checks on states
+		txnState.DisableAllLimitEnforcements()
+		// try to deduct fees even if there is an error.
+		// disable the limit checks on states
+		feesError := i.deductTransactionFees(env, proc, txnState, computationUsed)
+		if mergeErrorShouldEarlyExit(feesError) {
+			return
+		}
+
+		txnState.EnableAllLimitEnforcements()
 	}
 
-	txnState.EnableAllLimitEnforcements()
+	// Before checking storage limits, we must applying all pending changes
+	// that may modify storage usage.
+	if processErr == nil {
+		var flushErr error
+		modifiedSets, flushErr = env.FlushPendingUpdates()
+		if flushErr != nil {
+			flushErr = fmt.Errorf(
+				"transaction invocation failed to flush pending changes from "+
+					"environment: %w",
+				flushErr)
 
-	// applying contract changes
-	// this writes back the contract contents to accounts
-	// if any error occurs we fail the tx
-	// this needs to happen before checking limits, so that contract changes are committed to the state
-	modifiedSets, err = env.FlushPendingUpdates()
-	if err != nil && txError == nil {
-		txError = fmt.Errorf("transaction invocation failed when committing Environment: %w", err)
+			if mergeErrorShouldEarlyExit(flushErr) {
+				return
+			}
+		}
 	}
 
 	// if there is still no error check if all account storage limits are ok
-	if txError == nil {
+	if processErr == nil {
 		// disable the computation/memory limit checks on storage checks,
 		// so we don't error from computation/memory limits on this part.
 		// We cannot charge the user for this part, since fee deduction already happened.
 		txnState.DisableAllLimitEnforcements()
-		txError = NewTransactionStorageLimiter().CheckLimits(env, txnState.UpdatedAddresses())
+		checkLimitErr := NewTransactionStorageLimiter().CheckLimits(env, txnState.UpdatedAddresses())
+		if mergeErrorShouldEarlyExit(checkLimitErr) {
+			return
+		}
+
 		txnState.EnableAllLimitEnforcements()
 	}
 
 	// it there was any transaction error clear changes and try to deduct fees again
-	if txError != nil {
+	if processErr != nil {
 		txnState.DisableAllLimitEnforcements()
 		defer txnState.EnableAllLimitEnforcements()
 
 		// log transaction as failed
 		ctx.Logger.Info().
-			Err(txError).
+			Err(processErr).
 			Msg("transaction executed with error")
 
 		modifiedSets = programsCache.ModifiedSetsInvalidator{}
 		env.Reset()
 
 		// drop delta since transaction failed
-		err := txnState.RestartNestedTransaction(nestedTxnId)
-		if err != nil {
+		restartErr := txnState.RestartNestedTransaction(nestedTxnId)
+		if restartErr != nil {
 			return fmt.Errorf(
-				"cannot restart nested transaction: %w",
-				err,
-			)
+				"cannot restart nested transaction: %w "+
+					"(original processErr: %v)",
+				restartErr,
+				processErr)
 		}
 
 		// try to deduct fees again, to get the fee deduction events
-		feesError = i.deductTransactionFees(env, proc, txnState, computationUsed)
+		feesError := i.deductTransactionFees(env, proc, txnState, computationUsed)
 
 		// if fee deduction fails just do clean up and exit
 		if feesError != nil {
 			ctx.Logger.Info().
 				Msg("transaction fee deduction executed with error")
 
-			txError = feesError
+			if mergeErrorShouldEarlyExit(feesError) {
+				return
+			}
 
 			// drop delta
 			_ = txnState.RestartNestedTransaction(nestedTxnId)
@@ -196,7 +246,7 @@ func (i TransactionInvoker) Process(
 	proc.Events = append(proc.Events, env.Events()...)
 	proc.ServiceEvents = append(proc.ServiceEvents, env.ServiceEvents()...)
 
-	return txError
+	return
 }
 
 func (i TransactionInvoker) deductTransactionFees(


### PR DESCRIPTION
1. early exit transaction on unrecoverable failure.
2. merge non-failure errors using multierror, rather than dropping one of the error, to expose more information (When combined with #3332, this enables access to the original root cause error code).
3. only flush pending updates when there's no error.
4. on non-error path, only deduct fee when there's no transaction error
