### PR TITLE
Ensure cadence don't access unexpected operations while parsing (part 2)

### DIFF
--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -59,12 +59,11 @@ func (creator ParseRestrictedAccountCreator) CreateAccount(
 	runtime.Address,
 	error,
 ) {
-	if creator.txnState.IsParseRestricted() {
-		return runtime.Address{}, errors.NewParseRestrictedModeInvalidAccessFailure(
-			"CreateAccount")
-	}
-
-	return creator.impl.CreateAccount(payer)
+	return parseRestrict1Arg1Ret(
+		creator.txnState,
+		"CreateAccount",
+		creator.impl.CreateAccount,
+		payer)
 }
 
 type AccountCreator interface {

--- a/fvm/environment/account_freezer.go
+++ b/fvm/environment/account_freezer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -20,6 +21,41 @@ type AccountFreezer interface {
 	FrozenAccounts() []common.Address
 
 	Reset()
+}
+
+type ParseRestrictedAccountFreezer struct {
+	txnState *state.TransactionState
+	impl     AccountFreezer
+}
+
+func NewParseRestrictedAccountFreezer(
+	txnState *state.TransactionState,
+	impl AccountFreezer,
+) AccountFreezer {
+	return ParseRestrictedAccountFreezer{
+		txnState: txnState,
+		impl:     impl,
+	}
+}
+
+func (freezer ParseRestrictedAccountFreezer) SetAccountFrozen(
+	address common.Address,
+	frozen bool,
+) error {
+	return parseRestrict2Arg(
+		freezer.txnState,
+		"SetAccountFrozen",
+		freezer.impl.SetAccountFrozen,
+		address,
+		frozen)
+}
+
+func (freezer ParseRestrictedAccountFreezer) FrozenAccounts() []common.Address {
+	return freezer.impl.FrozenAccounts()
+}
+
+func (freezer ParseRestrictedAccountFreezer) Reset() {
+	freezer.impl.Reset()
 }
 
 type NoAccountFreezer struct{}

--- a/fvm/environment/account_key_updater.go
+++ b/fvm/environment/account_key_updater.go
@@ -135,6 +135,82 @@ type AccountKeyUpdater interface {
 	)
 }
 
+type ParseRestrictedAccountKeyUpdater struct {
+	txnState *state.TransactionState
+	impl     AccountKeyUpdater
+}
+
+func NewParseRestrictedAccountKeyUpdater(
+	txnState *state.TransactionState,
+	impl AccountKeyUpdater,
+) ParseRestrictedAccountKeyUpdater {
+	return ParseRestrictedAccountKeyUpdater{
+		txnState: txnState,
+		impl:     impl,
+	}
+}
+
+func (updater ParseRestrictedAccountKeyUpdater) AddEncodedAccountKey(
+	address runtime.Address,
+	publicKey []byte,
+) error {
+	return parseRestrict2Arg(
+		updater.txnState,
+		"AddEncodedAccountKey",
+		updater.impl.AddEncodedAccountKey,
+		address,
+		publicKey)
+}
+
+func (updater ParseRestrictedAccountKeyUpdater) RevokeEncodedAccountKey(
+	address runtime.Address,
+	index int,
+) (
+	[]byte,
+	error,
+) {
+	return parseRestrict2Arg1Ret(
+		updater.txnState,
+		"RevokeEncodedAccountKey",
+		updater.impl.RevokeEncodedAccountKey,
+		address,
+		index)
+}
+
+func (updater ParseRestrictedAccountKeyUpdater) AddAccountKey(
+	address runtime.Address,
+	publicKey *runtime.PublicKey,
+	hashAlgo runtime.HashAlgorithm,
+	weight int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
+	return parseRestrict4Arg1Ret(
+		updater.txnState,
+		"AddAccountKey",
+		updater.impl.AddAccountKey,
+		address,
+		publicKey,
+		hashAlgo,
+		weight)
+}
+
+func (updater ParseRestrictedAccountKeyUpdater) RevokeAccountKey(
+	address runtime.Address,
+	keyIndex int,
+) (
+	*runtime.AccountKey,
+	error,
+) {
+	return parseRestrict2Arg1Ret(
+		updater.txnState,
+		"RevokeAccountKey",
+		updater.impl.RevokeAccountKey,
+		address,
+		keyIndex)
+}
+
 type NoAccountKeyUpdater struct{}
 
 func (NoAccountKeyUpdater) AddEncodedAccountKey(

--- a/fvm/environment/facade_env.go
+++ b/fvm/environment/facade_env.go
@@ -26,7 +26,7 @@ type facadeEnvironment struct {
 	*CryptoLibrary
 
 	*BlockInfo
-	*AccountInfo
+	AccountInfo
 	TransactionInfo
 
 	*ValueStore
@@ -218,10 +218,28 @@ func newTransactionFacadeEnvironment(
 }
 
 func (env *facadeEnvironment) addParseRestrictedChecks() {
+	// NOTE: Cadence can access Programs, ContractReader and Meter while it is
+	// parsing programs; all other access are unexpected and are potentially
+	// program cache invalidation bugs.
+
 	env.AccountCreator = NewParseRestrictedAccountCreator(
 		env.txnState,
 		env.AccountCreator)
-
+	env.AccountFreezer = NewParseRestrictedAccountFreezer(
+		env.txnState,
+		env.AccountFreezer)
+	env.AccountInfo = NewParseRestrictedAccountInfo(
+		env.txnState,
+		env.AccountInfo)
+	env.AccountKeyUpdater = NewParseRestrictedAccountKeyUpdater(
+		env.txnState,
+		env.AccountKeyUpdater)
+	env.ContractUpdater = NewParseRestrictedContractUpdater(
+		env.txnState,
+		env.ContractUpdater)
+	env.TransactionInfo = NewParseRestrictedTransactionInfo(
+		env.txnState,
+		env.TransactionInfo)
 	// TODO(patrick): check other API
 }
 

--- a/fvm/environment/parse_restricted_checker.go
+++ b/fvm/environment/parse_restricted_checker.go
@@ -1,0 +1,135 @@
+package environment
+
+import (
+	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/state"
+)
+
+func parseRestricted(txnState *state.TransactionState, opCode string) error {
+	if txnState.IsParseRestricted() {
+		return errors.NewParseRestrictedModeInvalidAccessFailure(opCode)
+	}
+
+	return nil
+}
+
+// Utility functions used for checking unexpected operation access while
+// cadence is parsing programs.
+//
+// The generic functions are of the form
+//      parseRestrict<x>Arg<y>Ret(txnState, opCode, callback, arg1, ..., argX)
+// where the callback expects <x> number of arguments, and <y> number of
+// return values (not counting error). If the callback expects no argument,
+// `<x>Arg` is omitted, and similarly for return value.
+
+func parseRestrict2Arg[Arg1T any, Arg2T any](
+	txnState *state.TransactionState,
+	opCode string,
+	callback func(Arg1T, Arg2T) error,
+	arg1 Arg1T,
+	arg2 Arg2T,
+) error {
+	err := parseRestricted(txnState, opCode)
+	if err != nil {
+		return err
+	}
+
+	return callback(arg1, arg2)
+}
+
+func parseRestrict3Arg[Arg1T any, Arg2T any, Arg3T any](
+	txnState *state.TransactionState,
+	opCode string,
+	callback func(Arg1T, Arg2T, Arg3T) error,
+	arg1 Arg1T,
+	arg2 Arg2T,
+	arg3 Arg3T,
+) error {
+	err := parseRestricted(txnState, opCode)
+	if err != nil {
+		return err
+	}
+
+	return callback(arg1, arg2, arg3)
+}
+
+func parseRestrict1Ret[RetT any](
+	txnState *state.TransactionState,
+	opCode string,
+	callback func() (RetT, error),
+) (
+	RetT,
+	error,
+) {
+	err := parseRestricted(txnState, opCode)
+	if err != nil {
+		var value RetT
+		return value, err
+	}
+
+	return callback()
+}
+
+func parseRestrict1Arg1Ret[ArgT any, RetT any](
+	txnState *state.TransactionState,
+	opCode string,
+	callback func(ArgT) (RetT, error),
+	arg ArgT,
+) (
+	RetT,
+	error,
+) {
+	err := parseRestricted(txnState, opCode)
+	if err != nil {
+		var value RetT
+		return value, err
+	}
+
+	return callback(arg)
+}
+
+func parseRestrict2Arg1Ret[Arg1T any, Arg2T any, RetT any](
+	txnState *state.TransactionState,
+	opCode string,
+	callback func(Arg1T, Arg2T) (RetT, error),
+	arg1 Arg1T,
+	arg2 Arg2T,
+) (
+	RetT,
+	error,
+) {
+	err := parseRestricted(txnState, opCode)
+	if err != nil {
+		var value RetT
+		return value, err
+	}
+
+	return callback(arg1, arg2)
+}
+
+func parseRestrict4Arg1Ret[
+	Arg1T any,
+	Arg2T any,
+	Arg3T any,
+	Arg4T any,
+	RetT any,
+](
+	txnState *state.TransactionState,
+	opCode string,
+	callback func(Arg1T, Arg2T, Arg3T, Arg4T) (RetT, error),
+	arg1 Arg1T,
+	arg2 Arg2T,
+	arg3 Arg3T,
+	arg4 Arg4T,
+) (
+	RetT,
+	error,
+) {
+	err := parseRestricted(txnState, opCode)
+	if err != nil {
+		var value RetT
+		return value, err
+	}
+
+	return callback(arg1, arg2, arg3, arg4)
+}

--- a/fvm/environment/transaction_info.go
+++ b/fvm/environment/transaction_info.go
@@ -4,6 +4,7 @@ import (
 	"github.com/onflow/cadence/runtime"
 
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/trace"
 )
@@ -45,6 +46,55 @@ type TransactionInfo interface {
 	// Cadence's runtime API.  Note that the script variant will return
 	// OperationNotSupportedError.
 	GetSigningAccounts() ([]runtime.Address, error)
+}
+
+type ParseRestrictedTransactionInfo struct {
+	txnState *state.TransactionState
+	impl     TransactionInfo
+}
+
+func NewParseRestrictedTransactionInfo(
+	txnState *state.TransactionState,
+	impl TransactionInfo,
+) TransactionInfo {
+	return ParseRestrictedTransactionInfo{
+		txnState: txnState,
+		impl:     impl,
+	}
+}
+
+func (info ParseRestrictedTransactionInfo) TxIndex() uint32 {
+	return info.impl.TxIndex()
+}
+
+func (info ParseRestrictedTransactionInfo) TxID() flow.Identifier {
+	return info.impl.TxID()
+}
+
+func (info ParseRestrictedTransactionInfo) TransactionFeesEnabled() bool {
+	return info.impl.TransactionFeesEnabled()
+}
+
+func (info ParseRestrictedTransactionInfo) LimitAccountStorage() bool {
+	return info.impl.LimitAccountStorage()
+}
+
+func (info ParseRestrictedTransactionInfo) SigningAccounts() []runtime.Address {
+	return info.impl.SigningAccounts()
+}
+
+func (info ParseRestrictedTransactionInfo) IsServiceAccountAuthorizer() bool {
+	return info.impl.IsServiceAccountAuthorizer()
+}
+
+func (info ParseRestrictedTransactionInfo) GetSigningAccounts() (
+	[]runtime.Address,
+	error,
+) {
+	return parseRestrict1Ret(
+		info.txnState,
+		"GetSigningAccounts",
+		info.impl.GetSigningAccounts)
 }
 
 type transactionInfo struct {


### PR DESCRIPTION
Added utility generic functions for checking parse restriction.

Sorry for the poor `parseRestrict<x>Arg<y>Ret` naming, but I can't think of anything better.

The generic functions are of the form
    `parseRestrict<x>Arg<y>Ret(txnState, opCode, callback, arg1, ..., argX)`
where the callback expects `<x>` number of arguments, and `<y>` number of return values (not counting error). If the callback expects no argument, `<x>Arg` is omitted, and similarly for return value.