### PR TITLE
[FVM] Remove old FVM functions

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -914,7 +914,7 @@ func getContractEpochCounter(vm computer.VirtualMachine, vmCtx fvm.Context, view
 	script := fvm.Script(scriptCode)
 
 	// execute the script
-	err = vm.RunV2(vmCtx, script, view)
+	err = vm.Run(vmCtx, script, view)
 	if err != nil {
 		return 0, fmt.Errorf("could not read epoch counter, internal error while executing script: %w", err)
 	}

--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -320,7 +320,7 @@ func (c *balanceProcessor) balance(address flow.Address) (uint64, bool, error) {
 		jsoncdc.MustEncode(cadence.NewAddress(address)),
 	)
 
-	err := c.vm.RunV2(c.ctx, script, c.view)
+	err := c.vm.Run(c.ctx, script, c.view)
 	if err != nil {
 		return 0, false, err
 	}
@@ -341,7 +341,7 @@ func (c *balanceProcessor) fusdBalance(address flow.Address) (uint64, error) {
 		jsoncdc.MustEncode(cadence.NewAddress(address)),
 	)
 
-	err := c.vm.RunV2(c.ctx, script, c.view)
+	err := c.vm.Run(c.ctx, script, c.view)
 	if err != nil {
 		return 0, err
 	}
@@ -358,7 +358,7 @@ func (c *balanceProcessor) moments(address flow.Address) (int, error) {
 		jsoncdc.MustEncode(cadence.NewAddress(address)),
 	)
 
-	err := c.vm.RunV2(c.ctx, script, c.view)
+	err := c.vm.Run(c.ctx, script, c.view)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -46,7 +46,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply),
 	}
 
-	err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOptions...), view)
+	err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOptions...), view)
 	require.NoError(t, err)
 
 	// deploy wrapper resource
@@ -82,7 +82,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		AddAuthorizer(chain.ServiceAddress())
 
 	tx := fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
-	err = vm.RunV2(ctx, tx, view)
+	err = vm.Run(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 
@@ -108,7 +108,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		AddAuthorizer(chain.ServiceAddress())
 
 	tx = fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
-	err = vm.RunV2(ctx, tx, view)
+	err = vm.Run(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -33,19 +33,8 @@ const (
 
 // VirtualMachine runs procedures
 type VirtualMachine interface {
-	// DEPRECATED. DO NOT USE
-	//
-	// TODO(patrick): remove after emulator is updated.
-	Run(fvm.Context, fvm.Procedure, state.View, *programs.Programs) error
-
-	RunV2(fvm.Context, fvm.Procedure, state.View) error
-
-	// DEPRECATED. DO NOT USE
-	//
-	// TODO(patrick): remove after emulator is updated.
-	GetAccount(fvm.Context, flow.Address, state.View, *programs.Programs) (*flow.Account, error)
-
-	GetAccountV2(fvm.Context, flow.Address, state.View) (*flow.Account, error)
+	Run(fvm.Context, fvm.Procedure, state.View) error
+	GetAccount(fvm.Context, flow.Address, state.View) (*flow.Account, error)
 }
 
 // ViewCommitter commits views's deltas to the ledger and collects the proofs
@@ -433,7 +422,7 @@ func (e *blockComputer) executeTransaction(
 			Bool("system_chunk", isSystemChunk).
 			Logger()),
 	)
-	err := e.vm.RunV2(childCtx, tx, txView)
+	err := e.vm.Run(childCtx, tx, txView)
 	if err != nil {
 		return fmt.Errorf("failed to execute transaction %v for block %v at height %v: %w",
 			txID.String(),

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -58,10 +58,10 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		execCtx := fvm.NewContext()
 
 		vm := new(computermock.VirtualMachine)
-		vm.On("RunV2", mock.Anything, mock.Anything, mock.Anything).
+		vm.On("Run", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
 			Run(func(args mock.Arguments) {
-				//ctx := args[0].(fvm.Context)
+				// ctx := args[0].(fvm.Context)
 				tx := args[1].(*fvm.TransactionProcedure)
 
 				tx.Events = generateEvents(1, tx.TxIndex)
@@ -144,7 +144,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		block := generateBlock(0, 0, rag)
 		programs := programs.NewEmptyBlockPrograms()
 
-		vm.On("RunV2", mock.Anything, mock.Anything, mock.Anything).
+		vm.On("Run", mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
 			Once() // just system chunk
 
@@ -204,7 +204,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply),
 		}
 		bootstrapOpts := append(baseBootstrapOpts, bootstrapOptions...)
-		err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
+		err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
 		require.NoError(t, err)
 
 		comm := new(computermock.ViewCommitter)
@@ -269,14 +269,14 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		transactionsPerCollection := 2
 		eventsPerTransaction := 2
 		eventsPerCollection := eventsPerTransaction * transactionsPerCollection
-		totalTransactionCount := (collectionCount * transactionsPerCollection) + 1 //+1 for system chunk
-		//totalEventCount := eventsPerTransaction * totalTransactionCount
+		totalTransactionCount := (collectionCount * transactionsPerCollection) + 1 // +1 for system chunk
+		// totalEventCount := eventsPerTransaction * totalTransactionCount
 
 		// create a block with 2 collections with 2 transactions each
 		block := generateBlock(collectionCount, transactionsPerCollection, rag)
 		programs := programs.NewEmptyBlockPrograms()
 
-		vm.On("RunV2", mock.Anything, mock.Anything, mock.Anything).
+		vm.On("Run", mock.Anything, mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				tx := args[1].(*fvm.TransactionProcedure)
 
@@ -335,7 +335,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 				expectedResults = append(expectedResults, txResult)
 			}
 		}
-		assert.ElementsMatch(t, expectedResults, result.TransactionResults[0:len(result.TransactionResults)-1]) //strip system chunk
+		assert.ElementsMatch(t, expectedResults, result.TransactionResults[0:len(result.TransactionResults)-1]) // strip system chunk
 
 		assertEventHashesMatch(t, collectionCount+1, result)
 
@@ -346,7 +346,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		execCtx := fvm.NewContext(
 			fvm.WithServiceEventCollectionEnabled(),
 			fvm.WithTransactionProcessors(
-				//we don't need to check signatures or sequence numbers
+				// we don't need to check signatures or sequence numbers
 				fvm.NewTransactionInvoker(),
 			),
 		)
@@ -354,7 +354,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		collectionCount := 2
 		transactionsPerCollection := 2
 
-		totalTransactionCount := (collectionCount * transactionsPerCollection) + 1 //+1 for system chunk
+		totalTransactionCount := (collectionCount * transactionsPerCollection) + 1 // +1 for system chunk
 
 		// create a block with 2 collections with 2 transactions each
 		block := generateBlock(collectionCount, transactionsPerCollection, rag)
@@ -386,7 +386,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			},
 		}
 
-		//events to emit for each iteration/transaction
+		// events to emit for each iteration/transaction
 		events := make([][]cadence.Event, totalTransactionCount)
 		events[0] = nil
 		events[1] = []cadence.Event{serviceEventA, ordinaryEvent}

--- a/engine/execution/computation/computer/mock/virtual_machine.go
+++ b/engine/execution/computation/computer/mock/virtual_machine.go
@@ -8,8 +8,6 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
-	programs "github.com/onflow/flow-go/fvm/programs"
-
 	state "github.com/onflow/flow-go/fvm/state"
 )
 
@@ -18,31 +16,8 @@ type VirtualMachine struct {
 	mock.Mock
 }
 
-// GetAccount provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *VirtualMachine) GetAccount(_a0 fvm.Context, _a1 flow.Address, _a2 state.View, _a3 *programs.Programs) (*flow.Account, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3)
-
-	var r0 *flow.Account
-	if rf, ok := ret.Get(0).(func(fvm.Context, flow.Address, state.View, *programs.Programs) *flow.Account); ok {
-		r0 = rf(_a0, _a1, _a2, _a3)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*flow.Account)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(fvm.Context, flow.Address, state.View, *programs.Programs) error); ok {
-		r1 = rf(_a0, _a1, _a2, _a3)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetAccountV2 provides a mock function with given fields: _a0, _a1, _a2
-func (_m *VirtualMachine) GetAccountV2(_a0 fvm.Context, _a1 flow.Address, _a2 state.View) (*flow.Account, error) {
+// GetAccount provides a mock function with given fields: _a0, _a1, _a2
+func (_m *VirtualMachine) GetAccount(_a0 fvm.Context, _a1 flow.Address, _a2 state.View) (*flow.Account, error) {
 	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 *flow.Account
@@ -64,22 +39,8 @@ func (_m *VirtualMachine) GetAccountV2(_a0 fvm.Context, _a1 flow.Address, _a2 st
 	return r0, r1
 }
 
-// Run provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *VirtualMachine) Run(_a0 fvm.Context, _a1 fvm.Procedure, _a2 state.View, _a3 *programs.Programs) error {
-	ret := _m.Called(_a0, _a1, _a2, _a3)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(fvm.Context, fvm.Procedure, state.View, *programs.Programs) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// RunV2 provides a mock function with given fields: _a0, _a1, _a2
-func (_m *VirtualMachine) RunV2(_a0 fvm.Context, _a1 fvm.Procedure, _a2 state.View) error {
+// Run provides a mock function with given fields: _a0, _a1, _a2
+func (_m *VirtualMachine) Run(_a0 fvm.Context, _a1 fvm.Procedure, _a2 state.View) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 error

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -244,7 +244,7 @@ func (e *Manager) ExecuteScript(
 			}
 		}()
 
-		return e.vm.RunV2(blockCtx, script, view)
+		return e.vm.Run(blockCtx, script, view)
 	}()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute script (internal error): %w", err)
@@ -337,7 +337,7 @@ func (e *Manager) GetAccount(address flow.Address, blockHeader *flow.Header, vie
 		fvm.WithBlockPrograms(
 			e.programsCache.NewBlockProgramsForScript(blockHeader.ID())))
 
-	account, err := e.vm.GetAccountV2(blockCtx, address, view)
+	account, err := e.vm.GetAccount(blockCtx, address, view)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get account (%s) at block (%s): %w", address.String(), blockHeader.ID(), err)
 	}

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -88,7 +88,7 @@ func mustFundAccounts(
 		tx := fvm.Transaction(
 			transferTx,
 			blockPrograms.NextTxIndexForTestingOnly())
-		err = vm.RunV2(execCtx, tx, ledger)
+		err = vm.Run(execCtx, tx, ledger)
 		require.NoError(b, err)
 		require.NoError(b, tx.Err)
 	}

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -484,19 +484,11 @@ func TestExecuteScript_ShortScriptsAreNotLogged(t *testing.T) {
 
 type PanickingVM struct{}
 
-func (p *PanickingVM) Run(f fvm.Context, procedure fvm.Procedure, view state.View, p2 *programs.Programs) error {
-	return p.RunV2(f, procedure, view)
-}
-
-func (p *PanickingVM) RunV2(f fvm.Context, procedure fvm.Procedure, view state.View) error {
+func (p *PanickingVM) Run(f fvm.Context, procedure fvm.Procedure, view state.View) error {
 	panic("panic, but expected with sentinel for test: Verunsicherung ")
 }
 
-func (p *PanickingVM) GetAccount(f fvm.Context, address flow.Address, view state.View, p2 *programs.Programs) (*flow.Account, error) {
-	panic("not expected")
-}
-
-func (p *PanickingVM) GetAccountV2(f fvm.Context, address flow.Address, view state.View) (*flow.Account, error) {
+func (p *PanickingVM) GetAccount(f fvm.Context, address flow.Address, view state.View) (*flow.Account, error) {
 	panic("not expected")
 }
 
@@ -504,11 +496,7 @@ type LongRunningVM struct {
 	duration time.Duration
 }
 
-func (l *LongRunningVM) Run(f fvm.Context, procedure fvm.Procedure, view state.View, p2 *programs.Programs) error {
-	return l.RunV2(f, procedure, view)
-}
-
-func (l *LongRunningVM) RunV2(f fvm.Context, procedure fvm.Procedure, view state.View) error {
+func (l *LongRunningVM) Run(f fvm.Context, procedure fvm.Procedure, view state.View) error {
 	time.Sleep(l.duration)
 	// satisfy value marshaller
 	if scriptProcedure, is := procedure.(*fvm.ScriptProcedure); is {
@@ -518,11 +506,7 @@ func (l *LongRunningVM) RunV2(f fvm.Context, procedure fvm.Procedure, view state
 	return nil
 }
 
-func (l *LongRunningVM) GetAccount(f fvm.Context, address flow.Address, view state.View, p2 *programs.Programs) (*flow.Account, error) {
-	panic("not expected")
-}
-
-func (l *LongRunningVM) GetAccountV2(f fvm.Context, address flow.Address, view state.View) (*flow.Account, error) {
+func (l *LongRunningVM) GetAccount(f fvm.Context, address flow.Address, view state.View) (*flow.Account, error) {
 	panic("not expected")
 }
 

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -51,7 +51,7 @@ func (b *Bootstrapper) BootstrapLedger(
 		opts...,
 	)
 
-	err := vm.RunV2(ctx, bootstrap, view)
+	err := vm.Run(ctx, bootstrap, view)
 	if err != nil {
 		return flow.DummyStateCommitment, err
 	}

--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -253,7 +253,7 @@ func CreateAccountsWithSimpleAddresses(
 			AddAuthorizer(serviceAddress)
 
 		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-		err := vm.RunV2(ctx, tx, view)
+		err := vm.Run(ctx, tx, view)
 		if err != nil {
 			return nil, err
 		}
@@ -302,7 +302,7 @@ func RootBootstrappedLedger(vm *fvm.VirtualMachine, ctx fvm.Context, additionalO
 		options...,
 	)
 
-	_ = vm.RunV2(ctx, bootstrap, view)
+	_ = vm.Run(ctx, bootstrap, view)
 	return view
 }
 

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -39,7 +39,7 @@ func createAccount(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err := vm.RunV2(ctx, tx, view)
+	err := vm.Run(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 
@@ -90,7 +90,7 @@ func addAccountKey(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err = vm.RunV2(ctx, tx, view)
+	err = vm.Run(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 
@@ -119,7 +119,7 @@ func addAccountCreator(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err := vm.RunV2(ctx, tx, view)
+	err := vm.Run(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 }
@@ -147,7 +147,7 @@ func removeAccountCreator(
 
 	tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-	err := vm.RunV2(ctx, tx, view)
+	err := vm.Run(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, tx.Err)
 }
@@ -358,7 +358,7 @@ func TestCreateAccount(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -370,7 +370,7 @@ func TestCreateAccount(t *testing.T) {
 				require.NoError(t, err)
 				address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
-				account, err := vm.GetAccountV2(ctx, address, view)
+				account, err := vm.GetAccount(ctx, address, view)
 				require.NoError(t, err)
 				require.NotNil(t, account)
 			}),
@@ -389,7 +389,7 @@ func TestCreateAccount(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -405,7 +405,7 @@ func TestCreateAccount(t *testing.T) {
 					require.NoError(t, err)
 					address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
 
-					account, err := vm.GetAccountV2(ctx, address, view)
+					account, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					require.NotNil(t, account)
 				}
@@ -433,7 +433,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.Error(t, tx.Err)
@@ -450,7 +450,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -471,7 +471,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, tx.Err)
@@ -491,7 +491,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				validTx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, validTx, view)
+				err := vm.Run(ctx, validTx, view)
 				require.NoError(t, err)
 
 				assert.NoError(t, validTx.Err)
@@ -500,7 +500,7 @@ func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 				invalidTx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, invalidTx, view)
+				err = vm.Run(ctx, invalidTx, view)
 				require.NoError(t, err)
 
 				assert.Error(t, invalidTx.Err)
@@ -554,7 +554,7 @@ func TestAddAccountKey(t *testing.T) {
 				run(func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.BlockPrograms) {
 					address := createAccount(t, vm, chain, ctx, view, programs)
 
-					before, err := vm.GetAccountV2(ctx, address, view)
+					before, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Empty(t, before.Keys)
 
@@ -570,12 +570,12 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 
 					require.Len(t, after.Keys, 1)
@@ -596,7 +596,7 @@ func TestAddAccountKey(t *testing.T) {
 
 					publicKey1 := addAccountKey(t, vm, ctx, view, programs, address, test.apiVersion)
 
-					before, err := vm.GetAccountV2(ctx, address, view)
+					before, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, before.Keys, 1)
 
@@ -612,12 +612,12 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 
 					expectedKeys := []flow.AccountPublicKey{
@@ -654,12 +654,12 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.Error(t, tx.Err)
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 
 					assert.Empty(t, after.Keys)
@@ -686,7 +686,7 @@ func TestAddAccountKey(t *testing.T) {
 				run(func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.BlockPrograms) {
 					address := createAccount(t, vm, chain, ctx, view, programs)
 
-					before, err := vm.GetAccountV2(ctx, address, view)
+					before, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Empty(t, before.Keys)
 
@@ -707,12 +707,12 @@ func TestAddAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 
 					expectedKeys := []flow.AccountPublicKey{
@@ -771,13 +771,13 @@ func TestAddAccountKey(t *testing.T) {
 
 						tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-						err = vm.RunV2(ctx, tx, view)
+						err = vm.Run(ctx, tx, view)
 						require.NoError(t, err)
 
 						require.Error(t, tx.Err)
 						assert.Contains(t, tx.Err.Error(), "hashing algorithm type not supported")
 
-						after, err := vm.GetAccountV2(ctx, address, view)
+						after, err := vm.GetAccount(ctx, address, view)
 						require.NoError(t, err)
 
 						assert.Empty(t, after.Keys)
@@ -827,7 +827,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						_ = addAccountKey(t, vm, ctx, view, programs, address, test.apiVersion)
 					}
 
-					before, err := vm.GetAccountV2(ctx, address, view)
+					before, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, before.Keys, keyCount)
 
@@ -842,7 +842,7 @@ func TestRemoveAccountKey(t *testing.T) {
 
 						tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-						err = vm.RunV2(ctx, tx, view)
+						err = vm.Run(ctx, tx, view)
 						require.NoError(t, err)
 
 						if test.expectError {
@@ -852,7 +852,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						}
 					}
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, after.Keys, keyCount)
 
@@ -874,7 +874,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						_ = addAccountKey(t, vm, ctx, view, programs, address, test.apiVersion)
 					}
 
-					before, err := vm.GetAccountV2(ctx, address, view)
+					before, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, before.Keys, keyCount)
 
@@ -888,12 +888,12 @@ func TestRemoveAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, after.Keys, keyCount)
 
@@ -925,7 +925,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						_ = addAccountKey(t, vm, ctx, view, programs, address, apiVersionForAdding)
 					}
 
-					before, err := vm.GetAccountV2(ctx, address, view)
+					before, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, before.Keys, keyCount)
 
@@ -939,12 +939,12 @@ func TestRemoveAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, after.Keys, keyCount)
 
@@ -982,7 +982,7 @@ func TestRemoveAccountKey(t *testing.T) {
 						_ = addAccountKey(t, vm, ctx, view, programs, address, test.apiVersion)
 					}
 
-					before, err := vm.GetAccountV2(ctx, address, view)
+					before, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, before.Keys, keyCount)
 
@@ -999,12 +999,12 @@ func TestRemoveAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 
 					assert.NoError(t, tx.Err)
 
-					after, err := vm.GetAccountV2(ctx, address, view)
+					after, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)
 					assert.Len(t, after.Keys, keyCount)
 
@@ -1034,7 +1034,7 @@ func TestGetAccountKey(t *testing.T) {
 					_ = addAccountKey(t, vm, ctx, view, programs, address, accountKeyAPIVersionV2)
 				}
 
-				before, err := vm.GetAccountV2(ctx, address, view)
+				before, err := vm.GetAccount(ctx, address, view)
 				require.NoError(t, err)
 				assert.Len(t, before.Keys, keyCount)
 
@@ -1049,7 +1049,7 @@ func TestGetAccountKey(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(ctx, tx, view)
+					err = vm.Run(ctx, tx, view)
 					require.NoError(t, err)
 					require.NoError(t, tx.Err)
 
@@ -1072,7 +1072,7 @@ func TestGetAccountKey(t *testing.T) {
 					keys[i] = addAccountKey(t, vm, ctx, view, programs, address, accountKeyAPIVersionV2)
 				}
 
-				before, err := vm.GetAccountV2(ctx, address, view)
+				before, err := vm.GetAccount(ctx, address, view)
 				require.NoError(t, err)
 				assert.Len(t, before.Keys, keyCount)
 
@@ -1086,7 +1086,7 @@ func TestGetAccountKey(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1124,7 +1124,7 @@ func TestGetAccountKey(t *testing.T) {
 					keys[i] = addAccountKey(t, vm, ctx, view, programs, address, accountKeyAPIVersionV1)
 				}
 
-				before, err := vm.GetAccountV2(ctx, address, view)
+				before, err := vm.GetAccount(ctx, address, view)
 				require.NoError(t, err)
 				assert.Len(t, before.Keys, keyCount)
 
@@ -1138,7 +1138,7 @@ func TestGetAccountKey(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1174,7 +1174,7 @@ func TestGetAccountKey(t *testing.T) {
 					keys[i] = addAccountKey(t, vm, ctx, view, programs, address, accountKeyAPIVersionV2)
 				}
 
-				before, err := vm.GetAccountV2(ctx, address, view)
+				before, err := vm.GetAccount(ctx, address, view)
 				require.NoError(t, err)
 				assert.Len(t, before.Keys, keyCount)
 
@@ -1191,7 +1191,7 @@ func TestGetAccountKey(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1241,7 +1241,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1251,7 +1251,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, account.Hex())))
 
-				err = vm.RunV2(ctx, script, view)
+				err = vm.Run(ctx, script, view)
 
 				assert.NoError(t, err)
 
@@ -1278,7 +1278,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, nonExistentAddress)))
 
-				err = vm.RunV2(ctx, script, view)
+				err = vm.Run(ctx, script, view)
 
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
@@ -1308,7 +1308,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					return nil, nil
 				})
 
-				err := vm.RunV2(ctx, script, view)
+				err := vm.Run(ctx, script, view)
 				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.KeyAccountStatus))
 			}),
 	)
@@ -1331,7 +1331,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1341,7 +1341,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, account.Hex())))
 
-				err = vm.RunV2(ctx, script, view)
+				err = vm.Run(ctx, script, view)
 
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
@@ -1368,7 +1368,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, nonExistentAddress)))
 
-				err = vm.RunV2(ctx, script, view)
+				err = vm.Run(ctx, script, view)
 
 				require.NoError(t, err)
 				require.Error(t, script.Err)
@@ -1395,7 +1395,7 @@ func TestAccountBalanceFields(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1405,7 +1405,7 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, account.Hex())))
 
-				err = vm.RunV2(ctx, script, view)
+				err = vm.Run(ctx, script, view)
 
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
@@ -1437,7 +1437,7 @@ func TestGetStorageCapacity(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err := vm.RunV2(ctx, tx, view)
+				err := vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				script := fvm.Script([]byte(fmt.Sprintf(`
@@ -1447,7 +1447,7 @@ func TestGetStorageCapacity(t *testing.T) {
 					}
 				`, account)))
 
-				err = vm.RunV2(ctx, script, view)
+				err = vm.Run(ctx, script, view)
 
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
@@ -1476,7 +1476,7 @@ func TestGetStorageCapacity(t *testing.T) {
 					}
 				`, nonExistentAddress)))
 
-				err = vm.RunV2(ctx, script, view)
+				err = vm.Run(ctx, script, view)
 
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
@@ -1510,7 +1510,7 @@ func TestGetStorageCapacity(t *testing.T) {
 					return nil, nil
 				})
 
-				err := vm.RunV2(ctx, script, newview)
+				err := vm.Run(ctx, script, newview)
 				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.KeyAccountStatus))
 			}),
 	)

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -127,7 +127,7 @@ func Test_Programs(t *testing.T) {
 	err = accounts.Create(nil, addressC)
 	require.NoError(t, err)
 
-	//err = stm.
+	// err = stm.
 	require.NoError(t, err)
 
 	fmt.Printf("Account created\n")
@@ -151,7 +151,7 @@ func Test_Programs(t *testing.T) {
 		procContractA0 := fvm.Transaction(
 			contractDeployTx("A", contractA0Code, addressA),
 			programs.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, procContractA0, mainView)
+		err = vm.Run(context, procContractA0, mainView)
 		require.NoError(t, err)
 
 		retrievedContractA, err = accounts.GetContract("A", addressA)
@@ -163,7 +163,7 @@ func Test_Programs(t *testing.T) {
 		procContractA := fvm.Transaction(
 			updateContractTx("A", contractACode, addressA),
 			programs.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, procContractA, mainView)
+		err = vm.Run(context, procContractA, mainView)
 		require.NoError(t, err)
 		require.NoError(t, procContractA.Err)
 
@@ -180,7 +180,7 @@ func Test_Programs(t *testing.T) {
 		procContractA := fvm.Transaction(
 			contractDeployTx("A", contractACode, addressA),
 			programs.NextTxIndexForTestingOnly())
-		err := vm.RunV2(context, procContractA, mainView)
+		err := vm.Run(context, procContractA, mainView)
 		require.NoError(t, err)
 
 		fmt.Println("---------- Real transaction here ------------")
@@ -199,7 +199,7 @@ func Test_Programs(t *testing.T) {
 			return mainView.Peek(owner, key)
 		})
 
-		err = vm.RunV2(context, procCallA, viewExecA)
+		err = vm.Run(context, procCallA, viewExecA)
 		require.NoError(t, err)
 
 		// make sure tx was really run
@@ -227,7 +227,7 @@ func Test_Programs(t *testing.T) {
 
 		// execute transaction again, this time make sure it doesn't load code
 		viewExecA2 := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-			//this time we fail if a read of code occurs
+			// this time we fail if a read of code occurs
 			require.NotEqual(t, key, environment.ContractKey("A"))
 
 			return mainView.Peek(owner, key)
@@ -237,7 +237,7 @@ func Test_Programs(t *testing.T) {
 			callTx("A", addressA),
 			programs.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(context, procCallA, viewExecA2)
+		err = vm.Run(context, procCallA, viewExecA2)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallA.Logs, "\"hello from A\"")
@@ -257,7 +257,7 @@ func Test_Programs(t *testing.T) {
 		procContractB := fvm.Transaction(
 			contractDeployTx("B", contractBCode, addressB),
 			programs.NextTxIndexForTestingOnly())
-		err := vm.RunV2(context, procContractB, mainView)
+		err := vm.Run(context, procContractB, mainView)
 		require.NoError(t, err)
 
 		_, _, hasA := programs.GetForTestingOnly(contractALocation)
@@ -280,7 +280,7 @@ func Test_Programs(t *testing.T) {
 
 		viewExecB = delta.NewView(mainView.Peek)
 
-		err = vm.RunV2(context, procCallB, viewExecB)
+		err = vm.Run(context, procCallB, viewExecB)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallB.Logs, "\"hello from B but also hello from A\"")
@@ -327,7 +327,7 @@ func Test_Programs(t *testing.T) {
 
 		// execute transaction again, this time make sure it doesn't load code
 		viewExecB2 := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-			//this time we fail if a read of code occurs
+			// this time we fail if a read of code occurs
 			require.NotEqual(t, key, environment.ContractKey("A"))
 			require.NotEqual(t, key, environment.ContractKey("B"))
 
@@ -338,7 +338,7 @@ func Test_Programs(t *testing.T) {
 			callTx("B", addressB),
 			programs.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(context, procCallB, viewExecB2)
+		err = vm.Run(context, procCallB, viewExecB2)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallB.Logs, "\"hello from B but also hello from A\"")
@@ -365,7 +365,7 @@ func Test_Programs(t *testing.T) {
 			callTx("A", addressA),
 			programs.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(context, procCallA, viewExecA)
+		err = vm.Run(context, procCallA, viewExecA)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallA.Logs, "\"hello from A\"")
@@ -384,7 +384,7 @@ func Test_Programs(t *testing.T) {
 		procContractC := fvm.Transaction(
 			contractDeployTx("C", contractCCode, addressC),
 			programs.NextTxIndexForTestingOnly())
-		err := vm.RunV2(context, procContractC, mainView)
+		err := vm.Run(context, procContractC, mainView)
 		require.NoError(t, err)
 
 		_, _, hasA := programs.GetForTestingOnly(contractALocation)
@@ -404,7 +404,7 @@ func Test_Programs(t *testing.T) {
 
 		viewExecC := delta.NewView(mainView.Peek)
 
-		err = vm.RunV2(context, procCallC, viewExecC)
+		err = vm.Run(context, procCallC, viewExecC)
 		require.NoError(t, err)
 
 		require.Contains(t, procCallC.Logs, "\"hello from C, hello from B but also hello from A\"")

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -77,20 +77,8 @@ func NewVirtualMachine(rt runtime.Runtime) *VirtualMachine {
 	}
 }
 
-// DEPRECATED.  DO NOT USE.
-//
-// TODO(patrick): remove after emulator is updated
-//
 // Run runs a procedure against a ledger in the given context.
-func (vm *VirtualMachine) Run(ctx Context, proc Procedure, v state.View, _ *programs.Programs) (err error) {
-	return vm.RunV2(ctx, proc, v)
-}
-
-// TODO(patrick): rename back to Run after emulator is fully updated (this
-// takes at least 3 sporks ...).
-//
-// Run runs a procedure against a ledger in the given context.
-func (vm *VirtualMachine) RunV2(
+func (vm *VirtualMachine) Run(
 	ctx Context,
 	proc Procedure,
 	v state.View,
@@ -171,18 +159,8 @@ func (vm *VirtualMachine) RunV2(
 	return proc.Run(ctx, txnState, txnPrograms)
 }
 
-// DEPRECATED. DO NOT USE
-//
-// TODO(patrick): remove after emulator is updated
-func (vm *VirtualMachine) GetAccount(ctx Context, address flow.Address, v state.View, programs *programs.Programs) (*flow.Account, error) {
-	return vm.GetAccountV2(ctx, address, v)
-}
-
-// TODO(patrick): rename back to GetAccount after emulator is fully updated
-// (this takes at least 3 sporks ...).
-//
-// GetAccountV2 returns an account by address or an error if none exists.
-func (vm *VirtualMachine) GetAccountV2(
+// GetAccount returns an account by address or an error if none exists.
+func (vm *VirtualMachine) GetAccount(
 	ctx Context,
 	address flow.Address,
 	v state.View,

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -161,7 +161,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 		view := testutil.RootBootstrappedLedger(vm, ctx)
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, view)
+		err = vm.Run(ctx, tx, view)
 		require.NoError(t, err)
 
 		assert.Nil(t, tx.Err)
@@ -194,7 +194,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.Error(t, tx.Err)
@@ -218,7 +218,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		require.Len(t, tx.Logs, 2)
@@ -244,7 +244,7 @@ func TestBlockContext_ExecuteTransaction(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -290,7 +290,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -320,7 +320,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -353,7 +353,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -383,7 +383,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		var parsingCheckingError *runtime.ParsingCheckingError
@@ -409,7 +409,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.Error(t, tx.Err)
@@ -448,7 +448,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
 
@@ -481,7 +481,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -509,7 +509,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -522,7 +522,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -550,7 +550,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -563,7 +563,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
 
@@ -594,7 +594,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -610,7 +610,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -636,7 +636,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		authTx := fvm.Transaction(authTxBody, 0)
 
-		err = vm.RunV2(ctx, authTx, ledger)
+		err = vm.Run(ctx, authTx, ledger)
 		require.NoError(t, err)
 		assert.NoError(t, authTx.Err)
 
@@ -649,7 +649,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 
 		tx := fvm.Transaction(txBody, 0)
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 	})
@@ -671,7 +671,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.Error(t, tx.Err)
 		assert.Contains(t, tx.Err.Error(), "deploying contracts requires authorization from specific accounts")
@@ -690,7 +690,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		authTx := fvm.Transaction(authTxBody, 0)
 
-		err = vm.RunV2(ctx, authTx, ledger)
+		err = vm.Run(ctx, authTx, ledger)
 		require.NoError(t, err)
 		assert.NoError(t, authTx.Err)
 
@@ -702,7 +702,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, err)
 		tx = fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 		assert.NoError(t, tx.Err)
 	})
@@ -793,7 +793,7 @@ func TestBlockContext_ExecuteTransaction_WithArguments(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, 0)
 
-			err = vm.RunV2(ctx, tx, ledger)
+			err = vm.Run(ctx, tx, ledger)
 			require.NoError(t, err)
 
 			tt.check(t, tx)
@@ -873,7 +873,7 @@ func TestBlockContext_ExecuteTransaction_GasLimit(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, 0)
 
-			err = vm.RunV2(ctx, tx, ledger)
+			err = vm.Run(ctx, tx, ledger)
 			require.NoError(t, err)
 
 			tt.check(t, tx)
@@ -936,7 +936,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.True(t, errors.IsStorageCapacityExceededError(tx.Err))
@@ -989,7 +989,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				require.NoError(t, tx.Err)
@@ -1050,7 +1050,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				assert.True(t, errors.IsLedgerInteractionLimitExceededError(tx.Err))
@@ -1088,7 +1088,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 			}))
@@ -1125,7 +1125,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				require.Error(t, tx.Err)
 
@@ -1163,7 +1163,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.RunV2(ctx, script, ledger)
+		err := vm.Run(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1181,7 +1181,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.RunV2(ctx, script, ledger)
+		err := vm.Run(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.Error(t, script.Err)
@@ -1200,7 +1200,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.RunV2(ctx, script, ledger)
+		err := vm.Run(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1255,7 +1255,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1275,7 +1275,7 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err = vm.RunV2(ctx, script, ledger)
+		err = vm.Run(ctx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1329,7 +1329,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(blockCtx, tx, ledger)
+		err = vm.Run(blockCtx, tx, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1374,7 +1374,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
 
 		script := fvm.Script(code)
 
-		err := vm.RunV2(blockCtx, script, ledger)
+		err := vm.Run(blockCtx, script, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, script.Err)
@@ -1420,7 +1420,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
 		ledger := testutil.RootBootstrappedLedger(vm, ctx)
 		require.NoError(t, err)
 
-		err = vm.RunV2(blockCtx, fvm.Transaction(tx, 0), ledger)
+		err = vm.Run(blockCtx, fvm.Transaction(tx, 0), ledger)
 		require.Error(t, err)
 	})
 
@@ -1433,7 +1433,7 @@ func TestBlockContext_GetBlockInfo(t *testing.T) {
         `)
 
 		ledger := testutil.RootBootstrappedLedger(vm, ctx)
-		err := vm.RunV2(blockCtx, fvm.Script(script), ledger)
+		err := vm.Run(blockCtx, fvm.Script(script), ledger)
 		require.Error(t, err)
 	})
 }
@@ -1477,7 +1477,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		// execute the transaction
 		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1516,7 +1516,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 	t.Run("get accounts", func(t *testing.T) {
 		for address, expectedKey := range accounts {
 
-			account, err := vm.GetAccountV2(ctx, address, ledger)
+			account, err := vm.GetAccount(ctx, address, ledger)
 			require.NoError(t, err)
 
 			assert.Len(t, account.Keys, 1)
@@ -1531,7 +1531,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		var account *flow.Account
-		account, err = vm.GetAccountV2(ctx, address, ledger)
+		account, err = vm.GetAccount(ctx, address, ledger)
 		assert.True(t, errors.IsAccountNotFoundError(err))
 		assert.Nil(t, account)
 	})
@@ -1570,7 +1570,7 @@ func TestBlockContext_UnsafeRandom(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, 0)
 
-		err = vm.RunV2(ctx, tx, ledger)
+		err = vm.Run(ctx, tx, ledger)
 		assert.NoError(t, err)
 
 		assert.NoError(t, tx.Err)
@@ -1604,7 +1604,7 @@ func TestBlockContext_ExecuteTransaction_CreateAccount_WithMonotonicAddresses(t 
 
 	tx := fvm.Transaction(txBody, 0)
 
-	err = vm.RunV2(ctx, tx, ledger)
+	err = vm.Run(ctx, tx, ledger)
 	assert.NoError(t, err)
 
 	assert.NoError(t, tx.Err)
@@ -1640,7 +1640,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			jsoncdc.MustEncode(cadence.NewAddress(address)),
 		)
 
-		err := vm.RunV2(ctx, script, view)
+		err := vm.Run(ctx, script, view)
 		require.NoError(t, err)
 		require.NoError(t, script.Err)
 		return script.Value.ToGoValue().(uint64)
@@ -1678,7 +1678,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			require.True(t, errors.IsStorageCapacityExceededError(tx.Err))
@@ -1726,7 +1726,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			require.True(t, errors.IsCadenceRuntimeError(tx.Err))
@@ -1767,7 +1767,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				castedErr, ok := tx.Err.(errors.InvalidProposalSeqNumberError)
 				require.True(t, ok)
@@ -1805,7 +1805,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				require.True(t, errors.IsCadenceRuntimeError(tx.Err))
@@ -1813,7 +1813,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				// send it again
 				tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 
 				castedErr, ok := tx.Err.(errors.InvalidProposalSeqNumberError)

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -55,7 +55,7 @@ func FuzzTransactionComputationLimit(f *testing.F) {
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
 			require.NotPanics(t, func() {
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 			}, "Transaction should never result in a panic.")
 			require.NoError(t, err, "Transaction should never result in an error.")
 
@@ -255,7 +255,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 
 		tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(ctx, tx, view)
+		err = vm.Run(ctx, tx, view)
 
 		require.NoError(tb, err)
 		accountCreatedEvents := filterAccountCreatedEvents(tx.Events)
@@ -284,7 +284,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 
 		tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(ctx, tx, view)
+		err = vm.Run(ctx, tx, view)
 		if err != nil {
 			return err
 		}

--- a/fvm/fvm_signature_test.go
+++ b/fvm/fvm_signature_test.go
@@ -186,7 +186,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -203,7 +203,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -225,7 +225,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -246,7 +246,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						require.NoError(t, err)
 						require.Error(t, script.Err)
 					})
@@ -294,7 +294,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -314,7 +314,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -333,7 +333,7 @@ func TestKeyListSignature(t *testing.T) {
 							jsoncdc.MustEncode(weight),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						assert.NoError(t, err)
 						assert.NoError(t, script.Err)
 
@@ -440,7 +440,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						jsoncdc.MustEncode(pop),
 					)
 
-					err = vm.RunV2(ctx, script, view)
+					err = vm.Run(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 					assert.Equal(t, cadence.NewBool(true), script.Value)
@@ -466,7 +466,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						jsoncdc.MustEncode(pop),
 					)
 
-					err = vm.RunV2(ctx, script, view)
+					err = vm.Run(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 					assert.Equal(t, cadence.NewBool(false), script.Value)
@@ -492,7 +492,7 @@ func TestBLSMultiSignature(t *testing.T) {
 							jsoncdc.MustEncode(pop),
 						)
 
-						err = vm.RunV2(ctx, script, view)
+						err = vm.Run(ctx, script, view)
 						assert.Error(t, err)
 					})
 				}
@@ -560,7 +560,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err = vm.RunV2(ctx, script, view)
+					err = vm.Run(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 
@@ -595,7 +595,7 @@ func TestBLSMultiSignature(t *testing.T) {
 					// revert the change
 					sigs[numSigs/2] = tmp
 
-					err = vm.RunV2(ctx, script, view)
+					err = vm.Run(ctx, script, view)
 					assert.NoError(t, err)
 					assert.Error(t, script.Err)
 					assert.Equal(t, nil, script.Value)
@@ -615,7 +615,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err = vm.RunV2(ctx, script, view)
+					err = vm.Run(ctx, script, view)
 					assert.NoError(t, err)
 					assert.Error(t, script.Err)
 					assert.Equal(t, nil, script.Value)
@@ -686,7 +686,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err := vm.RunV2(ctx, script, view)
+					err := vm.Run(ctx, script, view)
 					assert.NoError(t, err)
 					assert.NoError(t, script.Err)
 					expectedPk, err := crypto.AggregateBLSPublicKeys(pks)
@@ -720,7 +720,7 @@ func TestBLSMultiSignature(t *testing.T) {
 							}),
 						)
 
-						err := vm.RunV2(ctx, script, view)
+						err := vm.Run(ctx, script, view)
 						assert.Error(t, err)
 					})
 				}
@@ -739,7 +739,7 @@ func TestBLSMultiSignature(t *testing.T) {
 						}),
 					)
 
-					err := vm.RunV2(ctx, script, view)
+					err := vm.Run(ctx, script, view)
 					assert.NoError(t, err)
 					assert.Error(t, script.Err)
 					assert.Equal(t, nil, script.Value)
@@ -830,7 +830,7 @@ func TestBLSMultiSignature(t *testing.T) {
 					jsoncdc.MustEncode(cadence.String(tag)),
 				)
 
-				err := vm.RunV2(ctx, script, view)
+				err := vm.Run(ctx, script, view)
 				assert.NoError(t, err)
 				assert.NoError(t, script.Err)
 				assert.Equal(t, cadence.NewBool(true), script.Value)

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -87,7 +87,7 @@ func (vmt vmTest) run(
 
 		bootstrapOpts := append(baseBootstrapOpts, vmt.bootstrapOptions...)
 
-		err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
+		err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
 		require.NoError(t, err)
 
 		f(t, vm, chain, ctx, view, blockPrograms)
@@ -119,7 +119,7 @@ func (vmt vmTest) bootstrapWith(
 
 	bootstrapOpts := append(baseBootstrapOpts, vmt.bootstrapOptions...)
 
-	err := vm.RunV2(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
+	err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
 	if err != nil {
 		return bootstrappedVmTest{}, err
 	}
@@ -183,7 +183,7 @@ func TestPrograms(t *testing.T) {
 
 					tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-					err = vm.RunV2(txCtx, tx, view)
+					err = vm.Run(txCtx, tx, view)
 					require.NoError(t, err)
 
 					require.NoError(t, tx.Err)
@@ -207,7 +207,7 @@ func TestPrograms(t *testing.T) {
 					fvm.FungibleTokenAddress(chain).HexWithPrefix(),
 				)))
 
-				err := vm.RunV2(scriptCtx, script, view)
+				err := vm.Run(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.NoError(t, script.Err)
 			},
@@ -400,7 +400,7 @@ func TestHashing(t *testing.T) {
 				)
 			}
 
-			err := vm.RunV2(ctx, script, ledger)
+			err := vm.Run(ctx, script, ledger)
 
 			byteResult := make([]byte, 0)
 			if err == nil && script.Err == nil {
@@ -431,7 +431,7 @@ func TestHashing(t *testing.T) {
 				cadenceData,
 				jsoncdc.MustEncode(cadence.String("")),
 			)
-			err := vm.RunV2(ctx, script, ledger)
+			err := vm.Run(ctx, script, ledger)
 			require.NoError(t, err)
 			require.NoError(t, script.Err)
 
@@ -446,7 +446,7 @@ func TestHashing(t *testing.T) {
 			script = script.WithArguments(
 				cadenceData,
 			)
-			err = vm.RunV2(ctx, script, ledger)
+			err = vm.Run(ctx, script, ledger)
 			require.NoError(t, err)
 			require.NoError(t, script.Err)
 
@@ -492,7 +492,7 @@ func TestWithServiceAccount(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
 
-		err := vm.RunV2(ctxB, tx, view)
+		err := vm.Run(ctxB, tx, view)
 		require.NoError(t, err)
 
 		// transaction should fail on non-bootstrapped ledger
@@ -508,7 +508,7 @@ func TestWithServiceAccount(t *testing.T) {
 
 		tx := fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
 
-		err := vm.RunV2(ctxB, tx, view)
+		err := vm.Run(ctxB, tx, view)
 		require.NoError(t, err)
 
 		// transaction should succeed on non-bootstrapped ledger
@@ -567,7 +567,7 @@ func TestEventLimits(t *testing.T) {
 		AddAuthorizer(chain.ServiceAddress())
 
 	tx := fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
-	err := vm.RunV2(ctx, tx, ledger)
+	err := vm.Run(ctx, tx, ledger)
 	require.NoError(t, err)
 
 	txBody = flow.NewTransactionBody().
@@ -584,7 +584,7 @@ func TestEventLimits(t *testing.T) {
 	t.Run("With limits", func(t *testing.T) {
 		txBody.Payer = unittest.RandomAddressFixture()
 		tx := fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
-		err := vm.RunV2(ctx, tx, ledger)
+		err := vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		// transaction should fail due to event size limit
@@ -594,7 +594,7 @@ func TestEventLimits(t *testing.T) {
 	t.Run("With service account as payer", func(t *testing.T) {
 		txBody.Payer = chain.ServiceAddress()
 		tx := fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
-		err := vm.RunV2(ctx, tx, ledger)
+		err := vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
 		// transaction should not fail due to event size limit
@@ -631,7 +631,7 @@ func TestHappyPathTransactionSigning(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 		},
@@ -658,7 +658,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			jsoncdc.MustEncode(cadence.NewAddress(address)),
 		)
 
-		err := vm.RunV2(ctx, script, view)
+		err := vm.Run(ctx, script, view)
 		require.NoError(t, err)
 		require.NoError(t, script.Err)
 		return script.Value.ToGoValue().(uint64)
@@ -944,7 +944,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.NoError(t, tx.Err)
@@ -978,7 +978,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1009,7 +1009,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			balanceAfter := getBalance(vm, chain, ctx, view, address)
@@ -1087,7 +1087,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1136,7 +1136,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.Greater(t, tx.MemoryEstimate, uint64(20_000_000_000))
 
@@ -1172,7 +1172,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.Greater(t, tx.MemoryEstimate, uint64(20_000_000_000))
 
@@ -1238,7 +1238,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			// There are 100 breaks and each break uses 1_000_000 memory
 			require.Greater(t, tx.MemoryEstimate, uint64(100_000_000))
@@ -1274,7 +1274,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1309,7 +1309,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1343,7 +1343,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			assert.True(t, errors.IsComputationLimitExceededError(tx.Err))
@@ -1384,7 +1384,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1406,7 +1406,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 			require.NoError(t, err)
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 
 			require.ErrorContains(t, tx.Err, "computation exceeds limit (997)")
@@ -1473,7 +1473,7 @@ func TestStorageUsed(t *testing.T) {
 
 	script := fvm.Script(code)
 
-	err = vm.RunV2(ctx, script, simpleView)
+	err = vm.Run(ctx, script, simpleView)
 	require.NoError(t, err)
 
 	assert.Equal(t, cadence.NewUInt64(5), script.Value)
@@ -1582,7 +1582,7 @@ func TestEnforcingComputationLimit(t *testing.T) {
 			}
 			tx := fvm.Transaction(txBody, blockPrograms.NextTxIndexForTestingOnly())
 
-			err := vm.RunV2(ctx, tx, simpleView)
+			err := vm.Run(ctx, tx, simpleView)
 			require.NoError(t, err)
 			require.Equal(t, test.expCompUsed, tx.ComputationUsed)
 			if test.ok {
@@ -1626,7 +1626,7 @@ func TestStorageCapacity(t *testing.T) {
 				SetProposalKey(service, 0, 0).
 				SetPayer(service)
 			tx := fvm.Transaction(transferTxBody, programs.NextTxIndexForTestingOnly())
-			err := vm.RunV2(ctx, tx, view)
+			err := vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1637,7 +1637,7 @@ func TestStorageCapacity(t *testing.T) {
 				SetProposalKey(service, 0, 0).
 				SetPayer(service)
 			tx = fvm.Transaction(transferTxBody, programs.NextTxIndexForTestingOnly())
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1676,7 +1676,7 @@ func TestStorageCapacity(t *testing.T) {
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
 			require.NoError(t, tx.Err)
 
@@ -1716,7 +1716,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.RunV2(scriptCtx, script, view)
+				err = vm.Run(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.True(t, errors.IsCadenceRuntimeError(script.Err))
@@ -1760,7 +1760,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				_ = testutil.SignPayload(txBody, account, privateKey)
 				_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-				err = vm.RunV2(subCtx, tx, view)
+				err = vm.Run(subCtx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1774,7 +1774,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.RunV2(subCtx, script, view)
+				err = vm.Run(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.True(t, errors.IsCadenceRuntimeError(script.Err))
@@ -1818,7 +1818,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 				_ = testutil.SignPayload(txBody, account, privateKey)
 				_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
-				err = vm.RunV2(subCtx, tx, view)
+				err = vm.Run(subCtx, tx, view)
 				require.NoError(t, err)
 				require.NoError(t, tx.Err)
 
@@ -1831,7 +1831,7 @@ func TestScriptContractMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.RunV2(subCtx, script, view)
+				err = vm.Run(subCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.True(t, errors.IsCadenceRuntimeError(script.Err))
@@ -1878,7 +1878,7 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 					)),
 				)
 
-				err = vm.RunV2(scriptCtx, script, view)
+				err = vm.Run(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.True(t, errors.IsCadenceRuntimeError(script.Err))
@@ -1913,7 +1913,7 @@ func TestScriptAccountKeyMutationsFailure(t *testing.T) {
 					jsoncdc.MustEncode(address),
 				)
 
-				err = vm.RunV2(scriptCtx, script, view)
+				err = vm.Run(scriptCtx, script, view)
 				require.NoError(t, err)
 				require.Error(t, script.Err)
 				require.True(t, errors.IsCadenceRuntimeError(script.Err))
@@ -1992,7 +1992,7 @@ func TestInteractionLimit(t *testing.T) {
 
 			tx := fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			if err != nil {
 				return err
 			}
@@ -2029,7 +2029,7 @@ func TestInteractionLimit(t *testing.T) {
 
 			tx = fvm.Transaction(txBody, programs.NextTxIndexForTestingOnly())
 
-			err = vm.RunV2(ctx, tx, view)
+			err = vm.Run(ctx, tx, view)
 			if err != nil {
 				return err
 			}
@@ -2065,7 +2065,7 @@ func TestInteractionLimit(t *testing.T) {
 				// ==== IMPORTANT LINE ====
 				ctx.MaxStateInteractionSize = tc.interactionLimit
 
-				err = vm.RunV2(ctx, tx, view)
+				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				tc.require(t, tx)
 			}),

--- a/fvm/scriptEnv.go
+++ b/fvm/scriptEnv.go
@@ -7,23 +7,6 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 )
 
-// DEPRECATED.  DO NOT USE
-//
-// TODO(patrick): rm after emulator is updated.
-func NewScriptEnvironment(
-	reqContext context.Context,
-	fvmContext Context,
-	vm *VirtualMachine,
-	txnState *state.TransactionState,
-	programs environment.TransactionPrograms,
-) environment.Environment {
-	return NewScriptEnv(
-		reqContext,
-		fvmContext,
-		txnState,
-		programs)
-}
-
 func NewScriptEnv(
 	reqContext context.Context,
 	fvmContext Context,

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -139,7 +139,7 @@ func TestAccountFreezing(t *testing.T) {
 				fvm.NewTransactionInvoker()),
 			fvm.WithBlockPrograms(programsStorage))
 
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -160,7 +160,7 @@ func TestAccountFreezing(t *testing.T) {
 		proc = fvm.Transaction(
 			&flow.TransactionBody{Script: code(address)},
 			programsStorage.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -189,7 +189,7 @@ func TestAccountFreezing(t *testing.T) {
 		tx.AddAuthorizer(chain.ServiceAddress())
 
 		proc = fvm.Transaction(tx, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -204,7 +204,7 @@ func TestAccountFreezing(t *testing.T) {
 			&flow.TransactionBody{Script: code(address)},
 			programsStorage.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.Error(t, proc.Err)
 
@@ -272,14 +272,14 @@ func TestAccountFreezing(t *testing.T) {
 				fvm.NewTransactionInvoker()),
 			fvm.WithBlockPrograms(programsStorage))
 
-		err := vm.RunV2(context, procFrozen, st.ViewForTestingOnly())
+		err := vm.Run(context, procFrozen, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, procFrozen.Err)
 
 		procNotFrozen := fvm.Transaction(
 			&flow.TransactionBody{Script: deployContract, Authorizers: []flow.Address{notFrozenAddress}, Payer: notFrozenAddress},
 			programsStorage.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, procNotFrozen, st.ViewForTestingOnly())
+		err = vm.Run(context, procNotFrozen, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, procNotFrozen.Err)
 
@@ -302,7 +302,7 @@ func TestAccountFreezing(t *testing.T) {
 			&flow.TransactionBody{Script: code(frozenAddress), Payer: serviceAddress},
 			programsStorage.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -311,7 +311,7 @@ func TestAccountFreezing(t *testing.T) {
 		proc = fvm.Transaction(
 			&flow.TransactionBody{Script: code(notFrozenAddress)},
 			programsStorage.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 		require.Len(t, proc.Logs, 1)
@@ -331,7 +331,7 @@ func TestAccountFreezing(t *testing.T) {
 		tx.AddAuthorizer(chain.ServiceAddress())
 
 		proc = fvm.Transaction(tx, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.NoError(t, proc.Err)
 
@@ -349,7 +349,7 @@ func TestAccountFreezing(t *testing.T) {
 			&flow.TransactionBody{Script: code(frozenAddress)},
 			programsStorage.NextTxIndexForTestingOnly())
 
-		err = vm.RunV2(context, proc, st.ViewForTestingOnly())
+		err = vm.Run(context, proc, st.ViewForTestingOnly())
 		require.NoError(t, err)
 		require.Error(t, proc.Err)
 
@@ -426,7 +426,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 
 		tx := fvm.Transaction(txBody, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, tx, ledger)
+		err = vm.Run(context, tx, ledger)
 		require.NoError(t, err)
 		require.NoError(t, tx.Err)
 
@@ -457,7 +457,7 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 
 		tx = fvm.Transaction(txBody, programsStorage.NextTxIndexForTestingOnly())
-		err = vm.RunV2(context, tx, ledger)
+		err = vm.Run(context, tx, ledger)
 		require.NoError(t, err)
 		require.Error(t, tx.Err)
 
@@ -539,7 +539,7 @@ func TestAccountFreezing(t *testing.T) {
 					Payer:       notFrozenAddress},
 				blockPrograms.NextTxIndexForTestingOnly())
 			// tx run OK by nonfrozen account
-			err = vm.RunV2(context, notFrozenProc, st.ViewForTestingOnly())
+			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
@@ -550,7 +550,7 @@ func TestAccountFreezing(t *testing.T) {
 					ProposalKey: flow.ProposalKey{Address: notFrozenAddress},
 					Payer:       notFrozenAddress},
 				blockPrograms.NextTxIndexForTestingOnly())
-			err = vm.RunV2(context, frozenProc, st.ViewForTestingOnly())
+			err = vm.Run(context, frozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 
@@ -572,7 +572,7 @@ func TestAccountFreezing(t *testing.T) {
 				blockPrograms.NextTxIndexForTestingOnly())
 
 			// tx run OK by nonfrozen account
-			err = vm.RunV2(context, notFrozenProc, st.ViewForTestingOnly())
+			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
@@ -584,7 +584,7 @@ func TestAccountFreezing(t *testing.T) {
 					Payer:       notFrozenAddress,
 				},
 				blockPrograms.NextTxIndexForTestingOnly())
-			err = vm.RunV2(context, frozenProc, st.ViewForTestingOnly())
+			err = vm.Run(context, frozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 
@@ -606,7 +606,7 @@ func TestAccountFreezing(t *testing.T) {
 				blockPrograms.NextTxIndexForTestingOnly())
 
 			// tx run OK by nonfrozen account
-			err = vm.RunV2(context, notFrozenProc, st.ViewForTestingOnly())
+			err = vm.Run(context, notFrozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.NoError(t, notFrozenProc.Err)
 
@@ -618,7 +618,7 @@ func TestAccountFreezing(t *testing.T) {
 					Payer:       frozenAddress,
 				},
 				blockPrograms.NextTxIndexForTestingOnly())
-			err = vm.RunV2(context, frozenProc, st.ViewForTestingOnly())
+			err = vm.Run(context, frozenProc, st.ViewForTestingOnly())
 			require.NoError(t, err)
 			require.Error(t, frozenProc.Err)
 

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -18,9 +18,9 @@ require (
 	github.com/onflow/cadence v0.27.0
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa
-	github.com/onflow/flow-emulator v0.37.1-0.20221006153024-2170b3d853d5
+	github.com/onflow/flow-emulator v0.37.1-0.20221006165032-e302460949f7
 	github.com/onflow/flow-ft/lib/go/templates v0.2.0
-	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006152246-65158f882331
+	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221006164531-ac5e7c1492bc
 	github.com/onflow/flow-go-sdk v0.28.0
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow/protobuf/go/flow v0.3.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1345,8 +1345,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:T6yhM+kWrFxiP6F3hh8lh9DcocHfmv48P4ITnjLhKSk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa h1:0brc9iDezo2Gc7yH3p7+La1iFe4WRDg6HYT6llyP8+E=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
-github.com/onflow/flow-emulator v0.37.1-0.20221006153024-2170b3d853d5 h1:Hk+G4UQ+4xjm2cGGQhoefs3s+riek6NJbN4IPeN0Lz4=
-github.com/onflow/flow-emulator v0.37.1-0.20221006153024-2170b3d853d5/go.mod h1:REfKBGoKvD3IE6p9/uJ1zDJd3nR6uqiC/H1H5hxHd/s=
+github.com/onflow/flow-emulator v0.37.1-0.20221006165032-e302460949f7 h1:HndJESDzJgtTix0KYTmt7CH9NGARzv3N9EmhU8h/VLs=
+github.com/onflow/flow-emulator v0.37.1-0.20221006165032-e302460949f7/go.mod h1:vXJ/RTcGk+z8K3I1jvRicJkOn6evc5/q8GRx5jYwrPY=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
 github.com/onflow/flow-ft/lib/go/templates v0.2.0 h1:oQQk5UthLS9KfKLkZVJg/XAVq8CXW7HAxSTu4HwBJkU=

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -188,7 +188,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 	for i, tx := range transactions {
 		txView := chunkView.NewChild()
 
-		err := fcv.vm.RunV2(context, tx, txView)
+		err := fcv.vm.Run(context, tx, txView)
 		if err != nil {
 			// this covers unexpected and very rare cases (e.g. system memory issues...),
 			// so we shouldn't be here even if transaction naturally fails (e.g. permission, runtime ... )

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -15,7 +15,6 @@ import (
 	executionState "github.com/onflow/flow-go/engine/execution/state"
 	"github.com/onflow/flow-go/fvm"
 	fvmErrors "github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	completeLedger "github.com/onflow/flow-go/ledger/complete"
@@ -105,7 +104,7 @@ func (s *ChunkVerifierTestSuite) TestMissingRegisterTouchForUpdate() {
 	vch := GetBaselineVerifiableChunk(s.T(), "", false)
 	assert.NotNil(s.T(), vch)
 	// remove the second register touch
-	//vch.ChunkDataPack.RegisterTouches = vch.ChunkDataPack.RegisterTouches[:1]
+	// vch.ChunkDataPack.RegisterTouches = vch.ChunkDataPack.RegisterTouches[:1]
 	spockSecret, chFaults, err := s.verifier.Verify(vch)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), chFaults)
@@ -121,7 +120,7 @@ func (s *ChunkVerifierTestSuite) TestMissingRegisterTouchForRead() {
 	vch := GetBaselineVerifiableChunk(s.T(), "", false)
 	assert.NotNil(s.T(), vch)
 	// remove the second register touch
-	//vch.ChunkDataPack.RegisterTouches = vch.ChunkDataPack.RegisterTouches[1:]
+	// vch.ChunkDataPack.RegisterTouches = vch.ChunkDataPack.RegisterTouches[1:]
 	spockSecret, chFaults, err := s.verifier.Verify(vch)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), chFaults)
@@ -218,7 +217,7 @@ func (s *ChunkVerifierTestSuite) TestEmptyCollection() {
 	vch.EndState = vch.ChunkDataPack.StartState
 	emptyListHash, err := flow.EventsMerkleRootHash(flow.EventsList{})
 	assert.NoError(s.T(), err)
-	vch.Chunk.EventCollection = emptyListHash //empty collection emits no events
+	vch.Chunk.EventCollection = emptyListHash // empty collection emits no events
 	spockSecret, chFaults, err := s.verifier.Verify(vch)
 	assert.Nil(s.T(), err)
 	assert.Nil(s.T(), chFaults)
@@ -374,11 +373,7 @@ func GetBaselineVerifiableChunk(t *testing.T, script string, system bool) *verif
 
 type vmMock struct{}
 
-func (vm *vmMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, programs *programs.Programs) error {
-	return vm.RunV2(ctx, proc, led)
-}
-
-func (vm *vmMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
+func (vm *vmMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
 	tx, ok := proc.(*fvm.TransactionProcedure)
 	if !ok {
 		return fmt.Errorf("invokable is not a transaction")
@@ -413,21 +408,13 @@ func (vm *vmMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.View) err
 	return nil
 }
 
-func (vmMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View, _ *programs.Programs) (*flow.Account, error) {
-	panic("not expected")
-}
-
-func (vmMock) GetAccountV2(_ fvm.Context, _ flow.Address, _ state.View) (*flow.Account, error) {
+func (vmMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View) (*flow.Account, error) {
 	panic("not expected")
 }
 
 type vmSystemOkMock struct{}
 
-func (vm *vmSystemOkMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, programs *programs.Programs) error {
-	return vm.RunV2(ctx, proc, led)
-}
-
-func (vm *vmSystemOkMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
+func (vm *vmSystemOkMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
 	tx, ok := proc.(*fvm.TransactionProcedure)
 	if !ok {
 		return fmt.Errorf("invokable is not a transaction")
@@ -444,21 +431,13 @@ func (vm *vmSystemOkMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.V
 	return nil
 }
 
-func (vmSystemOkMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View, _ *programs.Programs) (*flow.Account, error) {
-	panic("not expected")
-}
-
-func (vmSystemOkMock) GetAccountV2(_ fvm.Context, _ flow.Address, _ state.View) (*flow.Account, error) {
+func (vmSystemOkMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View) (*flow.Account, error) {
 	panic("not expected")
 }
 
 type vmSystemBadMock struct{}
 
-func (vm *vmSystemBadMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View, programs *programs.Programs) error {
-	return vm.RunV2(ctx, proc, led)
-}
-
-func (vm *vmSystemBadMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
+func (vm *vmSystemBadMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.View) error {
 	tx, ok := proc.(*fvm.TransactionProcedure)
 	if !ok {
 		return fmt.Errorf("invokable is not a transaction")
@@ -469,10 +448,6 @@ func (vm *vmSystemBadMock) RunV2(ctx fvm.Context, proc fvm.Procedure, led state.
 	return nil
 }
 
-func (vmSystemBadMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View, _ *programs.Programs) (*flow.Account, error) {
-	panic("not expected")
-}
-
-func (vmSystemBadMock) GetAccountV2(_ fvm.Context, _ flow.Address, _ state.View) (*flow.Account, error) {
+func (vmSystemBadMock) GetAccount(_ fvm.Context, _ flow.Address, _ state.View) (*flow.Account, error) {
 	panic("not expected")
 }

--- a/utils/debug/remoteDebugger.go
+++ b/utils/debug/remoteDebugger.go
@@ -44,7 +44,7 @@ func (d *RemoteDebugger) RunTransaction(txBody *flow.TransactionBody) (txErr, pr
 	view := NewRemoteView(d.grpcAddress)
 	blockCtx := fvm.NewContextFromParent(d.ctx, fvm.WithBlockHeader(d.ctx.BlockHeader))
 	tx := fvm.Transaction(txBody, 0)
-	err := d.vm.RunV2(blockCtx, tx, view)
+	err := d.vm.Run(blockCtx, tx, view)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (d *RemoteDebugger) RunTransactionAtBlockID(txBody *flow.TransactionBody, b
 		view.Cache = newFileRegisterCache(regCachePath)
 	}
 	tx := fvm.Transaction(txBody, 0)
-	err := d.vm.RunV2(blockCtx, tx, view)
+	err := d.vm.Run(blockCtx, tx, view)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (d *RemoteDebugger) RunScript(code []byte, arguments [][]byte) (value caden
 	view := NewRemoteView(d.grpcAddress)
 	scriptCtx := fvm.NewContextFromParent(d.ctx, fvm.WithBlockHeader(d.ctx.BlockHeader))
 	script := fvm.Script(code).WithArguments(arguments...)
-	err := d.vm.RunV2(scriptCtx, script, view)
+	err := d.vm.Run(scriptCtx, script, view)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,7 +90,7 @@ func (d *RemoteDebugger) RunScriptAtBlockID(code []byte, arguments [][]byte, blo
 	view := NewRemoteView(d.grpcAddress, WithBlockID(blockID))
 	scriptCtx := fvm.NewContextFromParent(d.ctx, fvm.WithBlockHeader(d.ctx.BlockHeader))
 	script := fvm.Script(code).WithArguments(arguments...)
-	err := d.vm.RunV2(scriptCtx, script, view)
+	err := d.vm.Run(scriptCtx, script, view)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Removes the old VM functions that were only kept for emulator compatibility.

relates to https://github.com/onflow/flow-emulator/pull/211