### PR TITLE
[FVM] Keeping event counter inside EventEmitter

### DIFF
--- a/fvm/environment/event_emitter.go
+++ b/fvm/environment/event_emitter.go
@@ -175,6 +175,7 @@ func (emitter *eventEmitter) ServiceEvents() []flow.Event {
 type EventCollection struct {
 	events        flow.EventsList
 	serviceEvents flow.EventsList
+	eventCounter  uint32
 	meter         Meter
 }
 
@@ -182,6 +183,7 @@ func NewEventCollection(meter Meter) *EventCollection {
 	return &EventCollection{
 		events:        make([]flow.Event, 0, 10),
 		serviceEvents: make([]flow.Event, 0, 10),
+		eventCounter:  uint32(0),
 		meter:         meter,
 	}
 }
@@ -192,6 +194,7 @@ func (collection *EventCollection) Events() []flow.Event {
 
 func (collection *EventCollection) AppendEvent(event flow.Event, size uint64) error {
 	collection.events = append(collection.events, event)
+	collection.eventCounter++
 	return collection.meter.MeterEmittedEvent(size)
 }
 
@@ -204,6 +207,7 @@ func (collection *EventCollection) AppendServiceEvent(
 	size uint64,
 ) error {
 	collection.serviceEvents = append(collection.serviceEvents, event)
+	collection.eventCounter++
 	return collection.meter.MeterEmittedEvent(size)
 }
 
@@ -212,7 +216,7 @@ func (collection *EventCollection) TotalByteSize() uint64 {
 }
 
 func (collection *EventCollection) TotalEventCounter() uint32 {
-	return collection.meter.TotalEventCounter()
+	return collection.eventCounter
 }
 
 // IsServiceEvent determines whether or not an emitted Cadence event is

--- a/fvm/environment/meter.go
+++ b/fvm/environment/meter.go
@@ -52,7 +52,6 @@ type Meter interface {
 
 	MeterEmittedEvent(byteSize uint64) error
 	TotalEmittedEventBytes() uint64
-	TotalEventCounter() uint32
 }
 
 type meterImpl struct {
@@ -99,10 +98,6 @@ func (meter *meterImpl) MeterEmittedEvent(byteSize uint64) error {
 
 func (meter *meterImpl) TotalEmittedEventBytes() uint64 {
 	return meter.txnState.TotalEmittedEventBytes()
-}
-
-func (meter *meterImpl) TotalEventCounter() uint32 {
-	return meter.txnState.TotalEventCounter()
 }
 
 type cancellableMeter struct {

--- a/fvm/environment/mock/environment.go
+++ b/fvm/environment/mock/environment.go
@@ -1050,20 +1050,6 @@ func (_m *Environment) TotalEmittedEventBytes() uint64 {
 	return r0
 }
 
-// TotalEventCounter provides a mock function with given fields:
-func (_m *Environment) TotalEventCounter() uint32 {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	return r0
-}
-
 // TransactionFeesEnabled provides a mock function with given fields:
 func (_m *Environment) TransactionFeesEnabled() bool {
 	ret := _m.Called()

--- a/fvm/environment/mock/meter.go
+++ b/fvm/environment/mock/meter.go
@@ -97,20 +97,6 @@ func (_m *Meter) TotalEmittedEventBytes() uint64 {
 	return r0
 }
 
-// TotalEventCounter provides a mock function with given fields:
-func (_m *Meter) TotalEventCounter() uint32 {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	return r0
-}
-
 type mockConstructorTestingTNewMeter interface {
 	mock.TestingT
 	Cleanup(func())

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -198,6 +198,12 @@ var fuzzTransactionTypes = []transactionType{
 			fees, deducted := getDeductedFees(t, tctx, results)
 			require.True(t, deducted, "Fees should be deducted.")
 			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
+			// event indices have to be an increasing uint sequence (0, 1, 2 ...)
+			expectedEventIndex := uint32(0)
+			for _, event := range results.tx.Events {
+				require.Equal(t, expectedEventIndex, event.EventIndex)
+				expectedEventIndex++
+			}
 		},
 	},
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -698,6 +698,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				var deposits []flow.Event
 				var withdraws []flow.Event
 
+				expectedEventIndex := uint32(0)
 				for _, e := range tx.Events {
 					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
 						deposits = append(deposits, e)
@@ -705,6 +706,9 @@ func TestTransactionFeeDeduction(t *testing.T) {
 					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
 						withdraws = append(withdraws, e)
 					}
+					// event index numbers have to be an increasing uint sequence (0,1,2...)
+					require.Equal(t, expectedEventIndex, e.EventIndex)
+					expectedEventIndex++
 				}
 
 				require.Len(t, deposits, 2)

--- a/fvm/meter/meter.go
+++ b/fvm/meter/meter.go
@@ -394,7 +394,6 @@ type Meter struct {
 	totalStorageBytesRead    uint64
 	totalStorageBytesWritten uint64
 
-	eventCounter           uint32
 	totalEmittedEventBytes uint64
 }
 
@@ -448,7 +447,6 @@ func (m *Meter) MergeMeter(child *Meter) {
 	m.totalStorageBytesRead += child.TotalBytesReadFromStorage()
 	m.totalStorageBytesWritten += child.TotalBytesWrittenToStorage()
 
-	m.eventCounter += child.TotalEventCounter()
 	m.totalEmittedEventBytes += child.TotalEmittedEventBytes()
 }
 
@@ -576,7 +574,6 @@ func (m *Meter) GetStorageUpdateSizeMapForTesting() MeteredStorageInteractionMap
 
 func (m *Meter) MeterEmittedEvent(byteSize uint64) error {
 	m.totalEmittedEventBytes += uint64(byteSize)
-	m.eventCounter++
 
 	if m.totalEmittedEventBytes > m.eventEmitByteLimit {
 		return errors.NewEventLimitExceededError(
@@ -588,8 +585,4 @@ func (m *Meter) MeterEmittedEvent(byteSize uint64) error {
 
 func (m *Meter) TotalEmittedEventBytes() uint64 {
 	return m.totalEmittedEventBytes
-}
-
-func (m *Meter) TotalEventCounter() uint32 {
-	return m.eventCounter
 }

--- a/fvm/meter/meter_test.go
+++ b/fvm/meter/meter_test.go
@@ -636,12 +636,10 @@ func TestEventLimits(t *testing.T) {
 		err := meter1.MeterEmittedEvent(testSize1)
 		require.NoError(t, err)
 		require.Equal(t, testSize1, meter1.TotalEmittedEventBytes())
-		require.Equal(t, uint32(1), meter1.TotalEventCounter())
 
 		err = meter1.MeterEmittedEvent(testSize2)
 		require.NoError(t, err)
 		require.Equal(t, testSize1+testSize2, meter1.TotalEmittedEventBytes())
-		require.Equal(t, uint32(2), meter1.TotalEventCounter())
 	})
 
 	t.Run("metering event emit - exceeding limit", func(t *testing.T) {
@@ -654,7 +652,6 @@ func TestEventLimits(t *testing.T) {
 		err := meter1.MeterEmittedEvent(testSize1)
 		require.NoError(t, err)
 		require.Equal(t, testSize1, meter1.TotalEmittedEventBytes())
-		require.Equal(t, uint32(1), meter1.TotalEventCounter())
 
 		err = meter1.MeterEmittedEvent(testSize2)
 		eventLimitExceededError := errors.NewEventLimitExceededError(
@@ -683,6 +680,5 @@ func TestEventLimits(t *testing.T) {
 		// merge
 		meter1.MergeMeter(meter2)
 		require.Equal(t, testSize1+testSize2, meter1.TotalEmittedEventBytes())
-		require.Equal(t, uint32(2), meter1.TotalEventCounter())
 	})
 }

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -237,10 +237,6 @@ func (s *State) TotalEmittedEventBytes() uint64 {
 	return s.meter.TotalEmittedEventBytes()
 }
 
-func (s *State) TotalEventCounter() uint32 {
-	return s.meter.TotalEventCounter()
-}
-
 // MergeState applies the changes from a the given view to this view.
 func (s *State) MergeState(other *State) error {
 	err := s.view.MergeView(other.view)

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -324,10 +324,6 @@ func (s *TransactionState) TotalEmittedEventBytes() uint64 {
 	return s.currentState().TotalEmittedEventBytes()
 }
 
-func (s *TransactionState) TotalEventCounter() uint32 {
-	return s.currentState().TotalEventCounter()
-}
-
 func (s *TransactionState) ViewForTestingOnly() View {
 	return s.currentState().View()
 }


### PR DESCRIPTION
In PR #3268 the event counter was also moved into meter interface. It caused a problem in event index ([slack thread](https://dapperlabs.slack.com/archives/C01ANSMH5FF/p1665462723443849)) because meter itself has `enforceLimit` condition which event index should not be applied. Event index should increase unconditionally.
Fixed by keeping the event counter inside EventEmitter as usual.

Test
- [X] existing and patched UTs