### PR TITLE
[BFT] Authorize execution data requests over bitswap

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -447,7 +447,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 
 			opts := []network.BlobServiceOption{
 				blob.WithBitswapOptions(
-					// Only allow block requests from staked ANs
+					// Only allow block requests from staked ENs and ANs
 					bitswap.WithPeerBlockRequestFilter(
 						blob.AuthorizedRequester(nil, builder.IdentityProvider, builder.Logger),
 					),

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -404,7 +404,7 @@ func (exeNode *ExecutionNode) LoadProviderEngine(
 
 	opts := []network.BlobServiceOption{
 		blob.WithBitswapOptions(
-			// Only allow block requests from staked ANs on the allowedANs list (if set)
+			// Only allow block requests from staked ENs and ANs on the allowedANs list (if set)
 			bitswap.WithPeerBlockRequestFilter(
 				blob.AuthorizedRequester(allowedANs, exeNode.builder.IdentityProvider, exeNode.builder.Logger),
 			),

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -419,6 +419,7 @@ func prepareExecutionService(container testnet.ContainerConfig, i int, n int) Se
 		fmt.Sprintf("--rpc-addr=%s:%d", container.ContainerName, RPCPort),
 		fmt.Sprintf("--cadence-tracing=%t", cadenceTracing),
 		fmt.Sprintf("--extensive-tracing=%t", extesiveTracing),
+		"--execution-data-dir=/data/execution-data",
 	)
 
 	service.Volumes = append(
@@ -448,6 +449,8 @@ func prepareAccessService(container testnet.ContainerConfig, i int, n int) Servi
 		"--log-tx-time-to-finalized",
 		"--log-tx-time-to-executed",
 		"--log-tx-time-to-finalized-executed",
+		"--execution-data-sync-enabled=true",
+		"--execution-data-dir=/data/execution-data",
 	)
 
 	service.Ports = []string{

--- a/integration/localnet/conf/grafana-exec-sync.json
+++ b/integration/localnet/conf/grafana-exec-sync.json
@@ -1,0 +1,3323 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "iteration": 1665358686842,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 206,
+            "panels": [],
+            "title": "Resources",
+            "type": "row"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 1
+            },
+            "id": 204,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "increase(network_bitswap_data_sent{network=\"localnet\", role=\"execution\"}[30d])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "EN - Data Sent (Last 30d)",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 1
+            },
+            "id": 208,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "increase(network_bitswap_data_sent{network=\"localnet\",role=\"access\"}[30d])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "AN - Data Sent (Last 30d)",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 9
+            },
+            "id": 207,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "increase(network_bitswap_data_received{network=\"localnet\",role=\"execution\"}[30d])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "EN - Data Received (Last 30d)",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 9
+            },
+            "id": 209,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "increase(network_bitswap_data_received{network=\"localnet\",role=\"access\"}[30d])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "AN - Data Received (Last 30d)",
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 17
+            },
+            "id": 16,
+            "panels": [],
+            "title": "Execution Nodes",
+            "type": "row"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 18
+            },
+            "id": 178,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "avg(execution_data_sync_provider_execution_data_sizes_bytes{network=\"localnet\", role=\"execution\"})by(quantile)",
+                    "legendFormat": "{{label_name}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Execution Data Blob Tree Size - by quantile",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 18
+            },
+            "id": 182,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "histogram_quantile(0.95, sum(rate(execution_data_sync_provider_number_of_chunks_bucket{network=\"localnet\"}[$__rate_interval])) by (le))",
+                    "legendFormat": "chunks",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Number of Chunks",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 26
+            },
+            "id": 176,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "execution_data_sync_provider_add_blobs_durations_ms{network=\"localnet\", role=\"execution\", quantile=\"0.99\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Add Blobs Duration",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 26
+            },
+            "id": 175,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "execution_data_sync_provider_compute_root_id_durations_ms{network=\"localnet\", role=\"execution\", quantile=\"0.99\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Compute Root CID Duration",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 34
+            },
+            "id": 173,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(execution_data_sync_provider_add_blobs_failed{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Add Blobs Failed",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 34
+            },
+            "id": 210,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "execution_runtime_last_executed_block_height{network=\"localnet\",role=\"execution\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Sealed Height",
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 42
+            },
+            "id": 4,
+            "panels": [],
+            "title": "Access Nodes - Requester",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 43
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(state_synchronization_execution_data_requester_execution_requester_download_duration_ms_count{network=\"localnet\"}[$__rate_interval])-rate(state_synchronization_execution_data_requester_execution_data_failed_downloads_total{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "success - {{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(state_synchronization_execution_data_requester_execution_data_failed_downloads_total{network=\"localnet\"}[$__rate_interval])",
+                    "hide": false,
+                    "legendFormat": "fail - {{role}}-{{num}}",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(state_synchronization_execution_data_requester_execution_requester_download_retries_total{network=\"localnet\"}[$__rate_interval])",
+                    "hide": false,
+                    "legendFormat": "retry - {{role}}-{{num}}",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "title": "Downloads",
+            "type": "timeseries"
+        },
+        {
+            "cards": {},
+            "color": {
+                "cardColor": "#b4ff00",
+                "colorScale": "sqrt",
+                "colorScheme": "interpolateOranges",
+                "exponent": 0.5,
+                "mode": "spectrum"
+            },
+            "dataFormat": "tsbuckets",
+            "datasource": {},
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 43
+            },
+            "heatmap": {},
+            "hideZeroBuckets": true,
+            "highlightCards": true,
+            "id": 159,
+            "legend": {
+                "show": true
+            },
+            "maxDataPoints": 25,
+            "options": {
+                "calculate": false,
+                "calculation": {},
+                "cellGap": 2,
+                "cellValues": {},
+                "color": {
+                    "exponent": 0.5,
+                    "fill": "#b4ff00",
+                    "mode": "scheme",
+                    "reverse": false,
+                    "scale": "exponential",
+                    "scheme": "Oranges",
+                    "steps": 128
+                },
+                "exemplars": {
+                    "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                    "le": 1e-9
+                },
+                "legend": {
+                    "show": true
+                },
+                "rowsFrame": {
+                    "layout": "auto"
+                },
+                "showValue": "never",
+                "tooltip": {
+                    "show": true,
+                    "yHistogram": false
+                },
+                "yAxis": {
+                    "axisPlacement": "left",
+                    "reverse": false,
+                    "unit": "ms"
+                }
+            },
+            "pluginVersion": "9.1.6-10b38e80",
+            "reverseYBuckets": false,
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(increase(state_synchronization_execution_data_requester_execution_requester_download_duration_ms_bucket{network=\"localnet\"}[$__rate_interval])) by (le)",
+                    "format": "heatmap",
+                    "interval": "",
+                    "legendFormat": "{{le}}",
+                    "refId": "A"
+                }
+            ],
+            "title": "Requester - Download Duration",
+            "tooltip": {
+                "show": true,
+                "showHistogram": false
+            },
+            "type": "heatmap",
+            "xAxis": {
+                "show": true
+            },
+            "yAxis": {
+                "format": "ms",
+                "logBase": 1,
+                "show": true
+            },
+            "yBucketBound": "auto"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 50
+            },
+            "id": 13,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "state_synchronization_execution_data_requester_execution_requester_outstanding_notifications{network=\"localnet\",role=\"access\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Unsent Notifications",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 52
+            },
+            "id": 171,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "state_synchronization_execution_data_requester_execution_requester_in_progress_downloads{network=\"localnet\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Downloads in Progress",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 58
+            },
+            "id": 8,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "state_synchronization_execution_data_requester_execution_requester_highest_download_height{network=\"localnet\",role=\"access\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Downloaded Height",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 60
+            },
+            "id": 11,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "8.5.2",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "clamp_min(sum(consensus_compliance_sealed_height{network=\"localnet\",role=\"access\"}) by (num) - sum(state_synchronization_execution_data_requester_execution_requester_highest_notification_height{network=\"localnet\",role=\"access\"}) by (num),0)",
+                    "hide": false,
+                    "legendFormat": "access-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Blocks Behind Sealed - Notifications",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 66
+            },
+            "id": 9,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.0.0-beta3",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "consensus_compliance_sealed_height{network=\"localnet\",role=\"access\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Sealed Height",
+            "type": "stat"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 68
+            },
+            "id": 14,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "pluginVersion": "8.5.2",
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "clamp_min(consensus_compliance_sealed_height{network=\"localnet\",role=\"access\"} - state_synchronization_execution_data_requester_execution_requester_highest_download_height{network=\"localnet\",role=\"access\"}, 0)",
+                    "hide": false,
+                    "legendFormat": "access-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Blocks Behind Sealed - Downloads",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 76
+            },
+            "id": 193,
+            "panels": [],
+            "title": "Bitswap",
+            "type": "row"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 77
+            },
+            "id": 202,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(network_bitswap_data_sent{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Data Sent",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 77
+            },
+            "id": 191,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true,
+                    "sortBy": "Last",
+                    "sortDesc": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "increase(network_bitswap_data_sent{network=\"localnet\"}[30d])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Data Sent (Last 30d)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 85
+            },
+            "id": 203,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(network_bitswap_data_received{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Data Received",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 85
+            },
+            "id": 190,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "last"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "increase(network_bitswap_data_received{network=\"localnet\"}[30d])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Data Received (Last 30d)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 93
+            },
+            "id": 195,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(network_bitswap_blobs_sent{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Blobs Sent",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 93
+            },
+            "id": 196,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(network_bitswap_blobs_received{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Blobs Received",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 101
+            },
+            "id": 197,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(network_bitswap_dup_blobs_received{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Duplicate Blobs Received",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 101
+            },
+            "id": 198,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(network_bitswap_dup_data_received{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Duplicate Data Received",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 109
+            },
+            "id": 199,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "rate(network_bitswap_messages_received{network=\"localnet\"}[$__rate_interval])",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Messages Received",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 109
+            },
+            "id": 200,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "network_bitswap_num_peers{network=\"localnet\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Number of Peers",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {},
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 117
+            },
+            "id": 201,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "editorMode": "code",
+                    "expr": "network_bitswap_wantlist_size{network=\"localnet\"}",
+                    "legendFormat": "{{role}}-{{num}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Want List Size",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 125
+            },
+            "id": 186,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "auto",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "ms"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 109
+                    },
+                    "id": 180,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(execution_data_sync_pruner_prune_durations_ms{network=\"localnet\", role=\"execution\"}) by (num)",
+                            "legendFormat": "execution-{{num}}",
+                            "range": true,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Pruner Duration - EN",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 109
+                    },
+                    "id": 184,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "textMode": "auto"
+                    },
+                    "pluginVersion": "9.1.2-ced290a",
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "editorMode": "code",
+                            "expr": "execution_data_sync_pruner_latest_height_pruned{network=\"localnet\", role=\"execution\"}",
+                            "legendFormat": "{{role}}-{{num}}",
+                            "range": true,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Pruned Height - EN",
+                    "type": "stat"
+                }
+            ],
+            "title": "Pruner",
+            "type": "row"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 126
+            },
+            "id": 168,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "auto",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 110
+                    },
+                    "id": 161,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(state_synchronization_execution_data_service_execution_data_add_in_progress{network=\"localnet\", role=\"execution\"}) by (role)",
+                            "legendFormat": "Add ({{role}})",
+                            "range": true,
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(state_synchronization_execution_data_service_execution_data_get_in_progress{network=\"localnet\", role=\"access\"}) by (role)",
+                            "hide": false,
+                            "legendFormat": "Get ({{role}})",
+                            "range": true,
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "Execution Data - Add/Get in Progress",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "drawStyle": "line",
+                                "fillOpacity": 0,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "lineInterpolation": "linear",
+                                "lineWidth": 1,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "auto",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green"
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 80
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 110
+                    },
+                    "id": 163,
+                    "options": {
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(rate(state_synchronization_execution_data_service_execution_data_add_fail_total{network=\"localnet\", role=\"execution\"}[$__rate_interval])) by(role)",
+                            "legendFormat": "Add ({{role}})",
+                            "range": true,
+                            "refId": "A"
+                        },
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(rate(state_synchronization_execution_data_service_execution_data_get_fail_total{network=\"localnet\", role=\"access\"}[$__rate_interval])) by(role)",
+                            "hide": false,
+                            "legendFormat": "Get ({{role}})",
+                            "range": true,
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "Execution Data - Add/Get Failed",
+                    "type": "timeseries"
+                },
+                {
+                    "cards": {},
+                    "color": {
+                        "cardColor": "#b4ff00",
+                        "colorScale": "sqrt",
+                        "colorScheme": "interpolateOranges",
+                        "exponent": 0.5,
+                        "mode": "spectrum"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                }
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 0,
+                        "y": 118
+                    },
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "id": 169,
+                    "legend": {
+                        "show": true
+                    },
+                    "maxDataPoints": 25,
+                    "options": {
+                        "calculate": false,
+                        "calculation": {},
+                        "cellGap": 2,
+                        "cellValues": {},
+                        "color": {
+                            "exponent": 0.5,
+                            "fill": "#b4ff00",
+                            "mode": "scheme",
+                            "scale": "exponential",
+                            "scheme": "Oranges",
+                            "steps": 128
+                        },
+                        "exemplars": {
+                            "color": "rgba(255,0,255,0.7)"
+                        },
+                        "filterValues": {
+                            "le": 1e-9
+                        },
+                        "legend": {
+                            "show": true
+                        },
+                        "rowsFrame": {
+                            "layout": "auto"
+                        },
+                        "showValue": "never",
+                        "tooltip": {
+                            "show": true,
+                            "yHistogram": false
+                        },
+                        "yAxis": {
+                            "axisPlacement": "left",
+                            "reverse": false,
+                            "unit": "ms"
+                        }
+                    },
+                    "pluginVersion": "9.1.2-ced290a",
+                    "reverseYBuckets": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(increase(state_synchronization_execution_data_service_execution_data_add_duration_ms_bucket{network=\"localnet\"}[$__rate_interval])) by (le)",
+                            "format": "heatmap",
+                            "interval": "",
+                            "legendFormat": "{{le}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Execution Data Add Latency",
+                    "tooltip": {
+                        "show": true,
+                        "showHistogram": false
+                    },
+                    "type": "heatmap",
+                    "xAxis": {
+                        "show": true
+                    },
+                    "yAxis": {
+                        "format": "ms",
+                        "logBase": 1,
+                        "show": true
+                    },
+                    "yBucketBound": "auto"
+                },
+                {
+                    "cards": {},
+                    "color": {
+                        "cardColor": "#b4ff00",
+                        "colorScale": "sqrt",
+                        "colorScheme": "interpolateOranges",
+                        "exponent": 0.5,
+                        "mode": "spectrum"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                }
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 12,
+                        "y": 118
+                    },
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "id": 166,
+                    "legend": {
+                        "show": true
+                    },
+                    "maxDataPoints": 25,
+                    "options": {
+                        "calculate": false,
+                        "calculation": {},
+                        "cellGap": 2,
+                        "cellValues": {},
+                        "color": {
+                            "exponent": 0.5,
+                            "fill": "#b4ff00",
+                            "mode": "scheme",
+                            "scale": "exponential",
+                            "scheme": "Oranges",
+                            "steps": 128
+                        },
+                        "exemplars": {
+                            "color": "rgba(255,0,255,0.7)"
+                        },
+                        "filterValues": {
+                            "le": 1e-9
+                        },
+                        "legend": {
+                            "show": true
+                        },
+                        "rowsFrame": {
+                            "layout": "auto"
+                        },
+                        "showValue": "never",
+                        "tooltip": {
+                            "show": true,
+                            "yHistogram": false
+                        },
+                        "yAxis": {
+                            "axisPlacement": "left",
+                            "reverse": false,
+                            "unit": "ms"
+                        }
+                    },
+                    "pluginVersion": "9.1.2-ced290a",
+                    "reverseYBuckets": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "editorMode": "code",
+                            "exemplar": false,
+                            "expr": "sum(increase(state_synchronization_execution_data_service_execution_data_add_duration_ms_bucket{network=\"localnet\"}[$__rate_interval])) by (le)",
+                            "format": "heatmap",
+                            "instant": false,
+                            "interval": "",
+                            "legendFormat": "{{le}}",
+                            "range": true,
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Execution Data Get Latency",
+                    "tooltip": {
+                        "show": true,
+                        "showHistogram": false
+                    },
+                    "type": "heatmap",
+                    "xAxis": {
+                        "show": true
+                    },
+                    "yAxis": {
+                        "format": "ms",
+                        "logBase": 1,
+                        "show": true
+                    },
+                    "yBucketBound": "auto"
+                }
+            ],
+            "title": "Execution Data Service",
+            "type": "row"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 127
+            },
+            "id": 188,
+            "panels": [
+                {
+                    "cards": {},
+                    "color": {
+                        "cardColor": "#b4ff00",
+                        "colorScale": "sqrt",
+                        "colorScheme": "interpolateOranges",
+                        "exponent": 0.5,
+                        "mode": "spectrum"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                }
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 0,
+                        "y": 111
+                    },
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "id": 140,
+                    "legend": {
+                        "show": true
+                    },
+                    "maxDataPoints": 25,
+                    "options": {
+                        "calculate": false,
+                        "calculation": {},
+                        "cellGap": 2,
+                        "cellValues": {},
+                        "color": {
+                            "exponent": 0.5,
+                            "fill": "#b4ff00",
+                            "mode": "scheme",
+                            "scale": "exponential",
+                            "scheme": "Oranges",
+                            "steps": 128
+                        },
+                        "exemplars": {
+                            "color": "rgba(255,0,255,0.7)"
+                        },
+                        "filterValues": {
+                            "le": 1e-9
+                        },
+                        "legend": {
+                            "show": true
+                        },
+                        "rowsFrame": {
+                            "layout": "auto"
+                        },
+                        "showValue": "never",
+                        "tooltip": {
+                            "show": true,
+                            "yHistogram": false
+                        },
+                        "yAxis": {
+                            "axisPlacement": "left",
+                            "reverse": false,
+                            "unit": "bytes"
+                        }
+                    },
+                    "pluginVersion": "9.1.2-ced290a",
+                    "reverseYBuckets": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(increase(state_synchronization_execution_data_service_execution_data_blob_tree_size_bucket{network=\"localnet\", role=\"execution\"}[$__interval])) by (le)",
+                            "format": "heatmap",
+                            "interval": "",
+                            "legendFormat": "{{le}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Blob Tree Size",
+                    "tooltip": {
+                        "show": true,
+                        "showHistogram": false
+                    },
+                    "type": "heatmap",
+                    "xAxis": {
+                        "show": true
+                    },
+                    "yAxis": {
+                        "format": "bytes",
+                        "logBase": 1,
+                        "show": true
+                    },
+                    "yBucketBound": "auto"
+                },
+                {
+                    "cards": {},
+                    "color": {
+                        "cardColor": "#b4ff00",
+                        "colorScale": "sqrt",
+                        "colorScheme": "interpolateOranges",
+                        "exponent": 0.5,
+                        "mode": "spectrum"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "rKhoxtiMz"
+                    },
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                }
+                            }
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 7,
+                        "w": 12,
+                        "x": 12,
+                        "y": 111
+                    },
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "id": 142,
+                    "legend": {
+                        "show": true
+                    },
+                    "maxDataPoints": 25,
+                    "options": {
+                        "calculate": false,
+                        "calculation": {},
+                        "cellGap": 2,
+                        "cellValues": {},
+                        "color": {
+                            "exponent": 0.5,
+                            "fill": "#b4ff00",
+                            "mode": "scheme",
+                            "scale": "exponential",
+                            "scheme": "Oranges",
+                            "steps": 128
+                        },
+                        "exemplars": {
+                            "color": "rgba(255,0,255,0.7)"
+                        },
+                        "filterValues": {
+                            "le": 1e-9
+                        },
+                        "legend": {
+                            "show": true
+                        },
+                        "rowsFrame": {
+                            "layout": "auto"
+                        },
+                        "showValue": "never",
+                        "tooltip": {
+                            "show": true,
+                            "yHistogram": false
+                        },
+                        "yAxis": {
+                            "axisPlacement": "left",
+                            "reverse": false,
+                            "unit": "ms"
+                        }
+                    },
+                    "pluginVersion": "9.1.2-ced290a",
+                    "reverseYBuckets": false,
+                    "targets": [
+                        {
+                            "datasource": {
+                                "type": "prometheus",
+                                "uid": "rKhoxtiMz"
+                            },
+                            "exemplar": true,
+                            "expr": "sum(increase(state_synchronization_execution_data_service_execution_data_add_duration_ms_bucket{network=\"localnet\", role=\"execution\"}[$__interval])) by (le)",
+                            "format": "heatmap",
+                            "interval": "",
+                            "legendFormat": "{{le}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Execution Data Add Latency",
+                    "tooltip": {
+                        "show": true,
+                        "showHistogram": false
+                    },
+                    "type": "heatmap",
+                    "xAxis": {
+                        "show": true
+                    },
+                    "yAxis": {
+                        "format": "ms",
+                        "logBase": 1,
+                        "show": true
+                    },
+                    "yBucketBound": "auto"
+                }
+            ],
+            "title": "Misc - Outdated",
+            "type": "row"
+        }
+    ],
+    "refresh": "10s",
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "hide": 2,
+                "name": "latest",
+                "query": "localnet",
+                "skipUrlSync": false,
+                "type": "constant"
+            },
+            {
+                "current": {
+                    "selected": true,
+                    "text": "localnet",
+                    "value": "localnet"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "multi": false,
+                "name": "network",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "localnet",
+                        "value": "localnet"
+                    }
+                ],
+                "query": "localnet",
+                "queryValue": "",
+                "skipUrlSync": false,
+                "type": "custom"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Execution Data Sync",
+    "uid": "EpoACL9nk",
+    "version": 1,
+    "weekStart": ""
+}

--- a/integration/localnet/docker-compose.metrics.yml
+++ b/integration/localnet/docker-compose.metrics.yml
@@ -53,6 +53,7 @@ services:
       - ./conf/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:z
       - ./conf/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml:z
       - ./conf/grafana-localnet.json:/etc/grafana/provisioning/dashboards/localnet.json:z
+      - ./conf/grafana-exec-sync.json:/etc/grafana/provisioning/dashboards/exec-sync.json:z
       - ./conf/grafana.ini:/etc/grafana/grafana.ini
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/network/p2p/blob/blob_service.go
+++ b/network/p2p/blob/blob_service.go
@@ -274,14 +274,15 @@ func AuthorizedRequester(
 			Logger()
 
 		// TODO: when execution data verification is enabled, add verification nodes here
-		if id.Role != flow.RoleAccess || id.Ejected {
+		if (id.Role != flow.RoleExecution && id.Role != flow.RoleAccess) || id.Ejected {
 			lg.Warn().
 				Bool(logging.KeySuspicious, true).
 				Msg("rejecting request from peer: unauthorized")
 			return false
 		}
 
-		if len(allowedNodes) > 0 && !allowedNodes[id.NodeID] {
+		// allow list is only for Access nodes
+		if id.Role == flow.RoleAccess && len(allowedNodes) > 0 && !allowedNodes[id.NodeID] {
 			lg.Warn().
 				Bool(logging.KeySuspicious, true).
 				Msg("rejecting request from peer: not in allowed list")

--- a/network/p2p/blob/blob_service.go
+++ b/network/p2p/blob/blob_service.go
@@ -14,8 +14,8 @@ import (
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	provider "github.com/ipfs/go-ipfs-provider"
 	"github.com/ipfs/go-ipfs-provider/simple"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/rs/zerolog"
@@ -281,7 +281,7 @@ func AuthorizedRequester(
 			return false
 		}
 
-		if allowedNodes != nil && len(allowedNodes) > 0 && !allowedNodes[id.NodeID] {
+		if len(allowedNodes) > 0 && !allowedNodes[id.NodeID] {
 			lg.Warn().
 				Bool(logging.KeySuspicious, true).
 				Msg("rejecting request from peer: not in allowed list")

--- a/network/p2p/blob/blob_service.go
+++ b/network/p2p/blob/blob_service.go
@@ -277,7 +277,7 @@ func AuthorizedRequester(
 		if id.Role != flow.RoleAccess || id.Ejected {
 			lg.Warn().
 				Bool(logging.KeySuspicious, true).
-				Msg("rejecting request from peer: unauthorized role")
+				Msg("rejecting request from peer: unauthorized")
 			return false
 		}
 

--- a/network/p2p/blob/blob_service.go
+++ b/network/p2p/blob/blob_service.go
@@ -283,9 +283,9 @@ func AuthorizedRequester(
 
 		// allow list is only for Access nodes
 		if id.Role == flow.RoleAccess && len(allowedNodes) > 0 && !allowedNodes[id.NodeID] {
-			lg.Warn().
-				Bool(logging.KeySuspicious, true).
-				Msg("rejecting request from peer: not in allowed list")
+			// honest peers not on the allowed list have no way to know and will continue to request
+			// blobs. therefore, these requests do not indicate suspicious behavior
+			lg.Debug().Msg("rejecting request from peer: not in allowed list")
 			return false
 		}
 

--- a/network/p2p/blob/blob_service_test.go
+++ b/network/p2p/blob/blob_service_test.go
@@ -40,7 +40,7 @@ func TestAuthorizedRequester(t *testing.T) {
 	idProvider := modmock.NewIdentityProvider(t)
 	idProvider.On("ByPeerID", mock.AnythingOfType("peer.ID")).Return(
 		func(peerId peer.ID) *flow.Identity {
-			identity, _ := providerData[peerId]
+			identity := providerData[peerId]
 			return identity
 		}, func(peerId peer.ID) bool {
 			_, ok := providerData[peerId]

--- a/network/p2p/blob/blob_service_test.go
+++ b/network/p2p/blob/blob_service_test.go
@@ -40,8 +40,7 @@ func TestAuthorizedRequester(t *testing.T) {
 	idProvider := modmock.NewIdentityProvider(t)
 	idProvider.On("ByPeerID", mock.AnythingOfType("peer.ID")).Return(
 		func(peerId peer.ID) *flow.Identity {
-			identity := providerData[peerId]
-			return identity
+			return providerData[peerId]
 		}, func(peerId peer.ID) bool {
 			_, ok := providerData[peerId]
 			return ok

--- a/network/p2p/blob/blob_service_test.go
+++ b/network/p2p/blob/blob_service_test.go
@@ -19,28 +19,20 @@ func TestAuthorizedRequester(t *testing.T) {
 	allowList := map[flow.Identifier]bool{}
 
 	// known and on allow list
-	an1, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleAccess))
-	an1PeerID, err := unittest.PeerIDFromFlowID(an1)
-	require.NoError(t, err)
+	an1, an1PeerID := identityInfo(t, flow.RoleAccess)
 	providerData[an1PeerID] = an1
 	allowList[an1.NodeID] = true
 
 	// known and not on allow list
-	an2, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleAccess))
-	an2PeerID, err := unittest.PeerIDFromFlowID(an2)
-	require.NoError(t, err)
+	an2, an2PeerID := identityInfo(t, flow.RoleAccess)
 	providerData[an2PeerID] = an2
 
 	// unknown and on the allow list
-	an3, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleAccess))
-	an3PeerID, err := unittest.PeerIDFromFlowID(an3)
-	require.NoError(t, err)
+	an3, an3PeerID := identityInfo(t, flow.RoleAccess)
 	allowList[an3.NodeID] = true // should be ignored
 
 	// known and on the allow list but not an access node
-	sn1, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleConsensus))
-	sn1PeerID, err := unittest.PeerIDFromFlowID(sn1)
-	require.NoError(t, err)
+	sn1, sn1PeerID := identityInfo(t, flow.RoleConsensus)
 	providerData[sn1PeerID] = sn1
 	allowList[sn1.NodeID] = true // should be ignored
 
@@ -104,4 +96,12 @@ func TestAuthorizedRequester(t *testing.T) {
 		authorizer := AuthorizedRequester(allowList, idProvider, unittest.Logger())
 		assert.False(t, authorizer(an3PeerID, cid.Cid{}))
 	})
+}
+
+func identityInfo(t *testing.T, role flow.Role) (*flow.Identity, peer.ID) {
+	identity, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(role))
+	peerID, err := unittest.PeerIDFromFlowID(identity)
+	require.NoError(t, err)
+
+	return identity, peerID
 }

--- a/network/p2p/blob/blob_service_test.go
+++ b/network/p2p/blob/blob_service_test.go
@@ -37,6 +37,14 @@ func TestAuthorizedRequester(t *testing.T) {
 	providerData[sn1PeerID] = sn1
 	allowList[sn1.NodeID] = true // should be ignored
 
+	// known and should always be allowed
+	en1, en1PeerID := mockIdentity(t, flow.RoleExecution)
+	providerData[en1PeerID] = en1
+
+	// unknown and should never be allowed
+	en2, en2PeerID := mockIdentity(t, flow.RoleExecution)
+	allowList[en2.NodeID] = true // should be ignored
+
 	idProvider := modmock.NewIdentityProvider(t)
 	idProvider.On("ByPeerID", mock.AnythingOfType("peer.ID")).Return(
 		func(peerId peer.ID) *flow.Identity {
@@ -46,9 +54,11 @@ func TestAuthorizedRequester(t *testing.T) {
 			return ok
 		})
 
-	t.Run("allows AN without allow list", func(t *testing.T) {
+	// Allows requests from authorized nodes
+	t.Run("allows all ANs with empty allow list", func(t *testing.T) {
 		authorizer := blob.AuthorizedRequester(nil, idProvider, unittest.Logger())
-		assert.True(t, authorizer(an1PeerID, cid.Cid{}))
+		assert.True(t, authorizer(an1PeerID, cid.Cid{}), "AN1 should be allowed")
+		assert.True(t, authorizer(an2PeerID, cid.Cid{}), "AN2 should be allowed")
 	})
 
 	t.Run("allows AN on allow list", func(t *testing.T) {
@@ -56,45 +66,59 @@ func TestAuthorizedRequester(t *testing.T) {
 		assert.True(t, authorizer(an1PeerID, cid.Cid{}))
 	})
 
+	t.Run("always allows EN", func(t *testing.T) {
+		authorizer := blob.AuthorizedRequester(nil, idProvider, unittest.Logger())
+		assert.True(t, authorizer(en1PeerID, cid.Cid{}))
+
+		authorizer = blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		assert.True(t, authorizer(en1PeerID, cid.Cid{}))
+	})
+
+	// Denies requests from nodes not on the allow list
 	t.Run("denies AN not on allow list", func(t *testing.T) {
 		authorizer := blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
 		assert.False(t, authorizer(an2PeerID, cid.Cid{}))
 	})
 
-	t.Run("denies SN without allow list", func(t *testing.T) {
+	// Denies requests from unknown nodes
+	t.Run("never allow SN", func(t *testing.T) {
 		authorizer := blob.AuthorizedRequester(nil, idProvider, unittest.Logger())
 		assert.False(t, authorizer(sn1PeerID, cid.Cid{}))
-	})
 
-	t.Run("denies SN with allow list", func(t *testing.T) {
-		authorizer := blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		authorizer = blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
 		assert.False(t, authorizer(sn1PeerID, cid.Cid{}))
 	})
 
 	an1.Ejected = true
+	en1.Ejected = true
 
 	// AN1 is on allow list (not passed) but is ejected
-	t.Run("denies ejected AN without allow list", func(t *testing.T) {
+	t.Run("always denies ejected AN", func(t *testing.T) {
 		authorizer := blob.AuthorizedRequester(nil, idProvider, unittest.Logger())
+		assert.False(t, authorizer(an1PeerID, cid.Cid{}))
+
+		authorizer = blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
 		assert.False(t, authorizer(an1PeerID, cid.Cid{}))
 	})
 
-	// AN1 is on allow list but is ejected
-	t.Run("denies ejected AN with allow list", func(t *testing.T) {
-		authorizer := blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
-		assert.False(t, authorizer(an1PeerID, cid.Cid{}))
+	// EN1 is on allow list (not passed) but is ejected
+	t.Run("always denies ejected EN", func(t *testing.T) {
+		authorizer := blob.AuthorizedRequester(nil, idProvider, unittest.Logger())
+		assert.False(t, authorizer(en1PeerID, cid.Cid{}))
+
+		authorizer = blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		assert.False(t, authorizer(en1PeerID, cid.Cid{}))
 	})
 
 	// AN3 is on allow list (not passed) but is not in identity store
-	t.Run("denies unknown peer without allow list", func(t *testing.T) {
+	t.Run("always denies unknown peer", func(t *testing.T) {
 		authorizer := blob.AuthorizedRequester(nil, idProvider, unittest.Logger())
 		assert.False(t, authorizer(an3PeerID, cid.Cid{}))
-	})
+		assert.False(t, authorizer(en2PeerID, cid.Cid{}))
 
-	// AN3 is on allow list but is not in identity store
-	t.Run("denies unknown peer with allow list", func(t *testing.T) {
-		authorizer := blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		authorizer = blob.AuthorizedRequester(allowList, idProvider, unittest.Logger())
 		assert.False(t, authorizer(an3PeerID, cid.Cid{}))
+		assert.False(t, authorizer(en2PeerID, cid.Cid{}))
 	})
 }
 

--- a/network/p2p/blob/blob_service_test.go
+++ b/network/p2p/blob/blob_service_test.go
@@ -1,0 +1,107 @@
+package blob
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	modmock "github.com/onflow/flow-go/module/mock"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestAuthorizedRequester(t *testing.T) {
+	providerData := map[peer.ID]*flow.Identity{}
+	allowList := map[flow.Identifier]bool{}
+
+	// known and on allow list
+	an1, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleAccess))
+	an1PeerID, err := unittest.PeerIDFromFlowID(an1)
+	require.NoError(t, err)
+	providerData[an1PeerID] = an1
+	allowList[an1.NodeID] = true
+
+	// known and not on allow list
+	an2, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleAccess))
+	an2PeerID, err := unittest.PeerIDFromFlowID(an2)
+	require.NoError(t, err)
+	providerData[an2PeerID] = an2
+
+	// unknown and on the allow list
+	an3, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleAccess))
+	an3PeerID, err := unittest.PeerIDFromFlowID(an3)
+	require.NoError(t, err)
+	allowList[an3.NodeID] = true // should be ignored
+
+	// known and on the allow list but not an access node
+	sn1, _ := unittest.IdentityWithNetworkingKeyFixture(unittest.WithRole(flow.RoleConsensus))
+	sn1PeerID, err := unittest.PeerIDFromFlowID(sn1)
+	require.NoError(t, err)
+	providerData[sn1PeerID] = sn1
+	allowList[sn1.NodeID] = true // should be ignored
+
+	idProvider := modmock.NewIdentityProvider(t)
+	idProvider.On("ByPeerID", mock.AnythingOfType("peer.ID")).Return(
+		func(peerId peer.ID) *flow.Identity {
+			identity, _ := providerData[peerId]
+			return identity
+		}, func(peerId peer.ID) bool {
+			_, ok := providerData[peerId]
+			return ok
+		})
+
+	t.Run("allows AN without allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(nil, idProvider, unittest.Logger())
+		assert.True(t, authorizer(an1PeerID, cid.Cid{}))
+	})
+
+	t.Run("allows AN on allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		assert.True(t, authorizer(an1PeerID, cid.Cid{}))
+	})
+
+	t.Run("denies AN not on allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		assert.False(t, authorizer(an2PeerID, cid.Cid{}))
+	})
+
+	t.Run("denies SN without allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(nil, idProvider, unittest.Logger())
+		assert.False(t, authorizer(sn1PeerID, cid.Cid{}))
+	})
+
+	t.Run("denies SN with allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		assert.False(t, authorizer(sn1PeerID, cid.Cid{}))
+	})
+
+	an1.Ejected = true
+
+	// AN1 is on allow list (not passed) but is ejected
+	t.Run("denies ejected AN without allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(nil, idProvider, unittest.Logger())
+		assert.False(t, authorizer(an1PeerID, cid.Cid{}))
+	})
+
+	// AN1 is on allow list but is ejected
+	t.Run("denies ejected AN with allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		assert.False(t, authorizer(an1PeerID, cid.Cid{}))
+	})
+
+	// AN3 is on allow list (not passed) but is not in identity store
+	t.Run("denies unknown peer without allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(nil, idProvider, unittest.Logger())
+		assert.False(t, authorizer(an3PeerID, cid.Cid{}))
+	})
+
+	// AN3 is on allow list but is not in identity store
+	t.Run("denies unknown peer with allow list", func(t *testing.T) {
+		authorizer := AuthorizedRequester(allowList, idProvider, unittest.Logger())
+		assert.False(t, authorizer(an3PeerID, cid.Cid{}))
+	})
+}


### PR DESCRIPTION
ENs and ANs use bitswap to share ExecutionData within the staked network. To support permissionless nodes, all messages must be authorized to the specific node/roles that are allowed to participate.

This PR adds an authorization check to all ExecutionData requests over bitswap. It also adds configuration to Execution nodes that allows them to specify an allow list of nodes that can request ExecutionData directly. This enable additional options for handling malicious peers, as well as scaling the execution sync protocol.