### PR TITLE
[Integration] Upgrading flow-emulator to v0.38.1

### DIFF
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -18,9 +18,9 @@ require (
 	github.com/onflow/cadence v0.28.0
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa
-	github.com/onflow/flow-emulator v0.37.1-0.20221011164624-afe73d1b9316
+	github.com/onflow/flow-emulator v0.38.1
 	github.com/onflow/flow-ft/lib/go/templates v0.2.0
-	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221007235929-a3f3a871c5ce
+	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221012204608-ed91c80fee2b
 	github.com/onflow/flow-go-sdk v0.29.0
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow/protobuf/go/flow v0.3.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1366,8 +1366,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:T6yhM+kWrFxiP6F3hh8lh9DcocHfmv48P4ITnjLhKSk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa h1:0brc9iDezo2Gc7yH3p7+La1iFe4WRDg6HYT6llyP8+E=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:JB2hWVxUjhMshUDNVQKfn4dzhhawOO+i3XjlhLMV5MM=
-github.com/onflow/flow-emulator v0.37.1-0.20221011164624-afe73d1b9316 h1:qehPmTyqwQxqSO1Nu48eG/tOezz4lAUGWjHDLSod4vM=
-github.com/onflow/flow-emulator v0.37.1-0.20221011164624-afe73d1b9316/go.mod h1:76z+25my76oKYaZobWU537gTY2fsvZ9ntrRjAsYnHkQ=
+github.com/onflow/flow-emulator v0.38.1 h1:ZfkbhCe2TA4tiZTuhGjuuzUCg+9Z4VWzh40dCtykSZk=
+github.com/onflow/flow-emulator v0.38.1/go.mod h1:EK8PWAwcCV5eEP1V1f0ummHW2QZSbeGmb42+SztmE2U=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
 github.com/onflow/flow-ft/lib/go/templates v0.2.0 h1:oQQk5UthLS9KfKLkZVJg/XAVq8CXW7HAxSTu4HwBJkU=


### PR DESCRIPTION
https://github.com/onflow/flow-emulator/releases/tag/v0.38.1

**Test**
- [X] `make test`
- [X] build and run load test to localnet