### PR TITLE
Add vars for TPS values

### DIFF
--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -24,6 +24,8 @@ COMMIT=$(shell git rev-parse HEAD)
 VERSION=localnetbuild
 
 CURRENT_DIRECTORY=$(shell pwd)
+TPS_INIT=25
+TPS_MAX=500
 
 .PHONY: init
 init:
@@ -99,7 +101,7 @@ tps-ci-smoke:
 tps-test-ci:
 	$(MAKE) -e COLLECTION=5 VERIFICATION=5 NCLUSTERS=5 init
 	$(MAKE) start-thin
-	go run --tags relic ../benchmark/cmd/ci -log-level info -initial-tps 25 -max-tps 500 -duration 30m
+	go run --tags relic ../benchmark/cmd/ci -log-level info -initial-tps $(TPS_INIT) -max-tps $(TPS_MAX) -duration 30m
 	$(MAKE) stop
 
 .PHONY: clean-data


### PR DESCRIPTION
Adds the ability to overwrite the TPS values at time of make command, this makes updating external commands and running the command by hand simpler.