### PR TITLE
Adding Event Index Sequence checking to UTs

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -445,6 +445,11 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		result, err := exe.ExecuteBlock(context.Background(), block, view, programs.NewEmptyBlockPrograms())
 		require.NoError(t, err)
 
+		// make sure event index sequence are valid
+		for _, eventsList := range result.Events {
+			ensureEventsIndexSeq(t, eventsList, execCtx.Chain.ChainID())
+		}
+
 		// all events should have been collected
 		require.Len(t, result.ServiceEvents, 2)
 
@@ -946,4 +951,16 @@ func generateEvents(eventCount int, txIndex uint32) []flow.Event {
 		events[i] = event
 	}
 	return events
+}
+
+func ensureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainID) {
+	expectedEventIndex := uint32(0)
+	for _, event := range events {
+		require.Equal(t, expectedEventIndex, event.EventIndex)
+		if testutil.IsServiceEvent(event, chainID) {
+			expectedEventIndex += 2
+		} else {
+			expectedEventIndex++
+		}
+	}
 }

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -447,7 +447,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		// make sure event index sequence are valid
 		for _, eventsList := range result.Events {
-			ensureEventsIndexSeq(t, eventsList, execCtx.Chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, eventsList, execCtx.Chain.ChainID())
 		}
 
 		// all events should have been collected
@@ -951,16 +951,4 @@ func generateEvents(eventCount int, txIndex uint32) []flow.Event {
 		events[i] = event
 	}
 	return events
-}
-
-func ensureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainID) {
-	expectedEventIndex := uint32(0)
-	for _, event := range events {
-		require.Equal(t, expectedEventIndex, event.EventIndex)
-		if testutil.IsServiceEvent(event, chainID) {
-			expectedEventIndex += 2
-		} else {
-			expectedEventIndex++
-		}
-	}
 }

--- a/engine/execution/testutil/fixtures_event.go
+++ b/engine/execution/testutil/fixtures_event.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"fmt"
 
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -46,14 +45,4 @@ func CreateEmitEventTransaction(contractAccount, signer flow.Address) *flow.Tran
 			}`, contractAccount)),
 		).
 		AddAuthorizer(signer)
-}
-
-func IsServiceEvent(event flow.Event, chainID flow.ChainID) bool {
-	serviceEvents, _ := systemcontracts.ServiceEventsForChain(chainID)
-	for _, serviceEvent := range serviceEvents.All() {
-		if serviceEvent.EventType() == event.Type {
-			return true
-		}
-	}
-	return false
 }

--- a/engine/execution/testutil/fixtures_event.go
+++ b/engine/execution/testutil/fixtures_event.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"fmt"
 
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -45,4 +46,14 @@ func CreateEmitEventTransaction(contractAccount, signer flow.Address) *flow.Tran
 			}`, contractAccount)),
 		).
 		AddAuthorizer(signer)
+}
+
+func IsServiceEvent(event flow.Event, chainID flow.ChainID) bool {
+	serviceEvents, _ := systemcontracts.ServiceEventsForChain(chainID)
+	for _, serviceEvent := range serviceEvents.All() {
+		if serviceEvent.EventType() == event.Type {
+			return true
+		}
+	}
+	return false
 }

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -103,7 +102,7 @@ var fuzzTransactionTypes = []transactionType{
 			// if there is an error, it should be computation exceeded
 			if results.tx.Err != nil {
 				require.Len(t, results.tx.Events, 3)
-				ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 				codes := []errors.ErrorCode{
 					errors.ErrCodeComputationLimitExceededError,
 					errors.ErrCodeCadenceRunTimeError,
@@ -116,7 +115,7 @@ var fuzzTransactionTypes = []transactionType{
 			fees, deducted := getDeductedFees(t, tctx, results)
 			require.True(t, deducted, "Fees should be deducted.")
 			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
-			ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 		},
 	},
 	{
@@ -136,7 +135,7 @@ var fuzzTransactionTypes = []transactionType{
 		require: func(t *testing.T, tctx transactionTypeContext, results fuzzResults) {
 			require.Error(t, results.tx.Err)
 			require.Len(t, results.tx.Events, 3)
-			ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 			codes := []errors.ErrorCode{
 				errors.ErrCodeComputationLimitExceededError,
 				errors.ErrCodeCadenceRunTimeError, // because of the failed transfer
@@ -148,7 +147,7 @@ var fuzzTransactionTypes = []transactionType{
 			fees, deducted := getDeductedFees(t, tctx, results)
 			require.True(t, deducted, "Fees should be deducted.")
 			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
-			ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 		},
 	},
 	{
@@ -165,7 +164,7 @@ var fuzzTransactionTypes = []transactionType{
 		require: func(t *testing.T, tctx transactionTypeContext, results fuzzResults) {
 			require.Error(t, results.tx.Err)
 			require.Len(t, results.tx.Events, 3)
-			ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 			codes := []errors.ErrorCode{
 				errors.ErrCodeComputationLimitExceededError,
 				errors.ErrCodeCadenceRunTimeError, // because of the panic
@@ -177,7 +176,7 @@ var fuzzTransactionTypes = []transactionType{
 			fees, deducted := getDeductedFees(t, tctx, results)
 			require.True(t, deducted, "Fees should be deducted.")
 			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
-			ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 		},
 	},
 	{
@@ -193,7 +192,7 @@ var fuzzTransactionTypes = []transactionType{
 			// if there is an error, it should be computation exceeded
 			if results.tx.Err != nil {
 				require.Len(t, results.tx.Events, 3)
-				ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 				codes := []errors.ErrorCode{
 					errors.ErrCodeComputationLimitExceededError,
 					errors.ErrCodeCadenceRunTimeError,
@@ -206,7 +205,7 @@ var fuzzTransactionTypes = []transactionType{
 			fees, deducted := getDeductedFees(t, tctx, results)
 			require.True(t, deducted, "Fees should be deducted.")
 			require.GreaterOrEqual(t, fees.ToGoValue().(uint64), fuzzTestsInclusionFees)
-			ensureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, results.tx.Events, tctx.chain.ChainID())
 		},
 	},
 }
@@ -309,26 +308,4 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 			privateKey:   privateKey,
 			chain:        bootstrappedVMTest.chain,
 		}
-}
-
-func ensureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainID) {
-	expectedEventIndex := uint32(0)
-	for _, event := range events {
-		require.Equal(t, expectedEventIndex, event.EventIndex)
-		if isServiceEvent(event, chainID) {
-			expectedEventIndex += 2
-		} else {
-			expectedEventIndex++
-		}
-	}
-}
-
-func isServiceEvent(event flow.Event, chainID flow.ChainID) bool {
-	serviceEvents, _ := systemcontracts.ServiceEventsForChain(chainID)
-	for _, serviceEvent := range serviceEvents.All() {
-		if serviceEvent.EventType() == event.Type {
-			return true
-		}
-	}
-	return false
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -598,6 +598,8 @@ func TestEventLimits(t *testing.T) {
 		err := vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
+		ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+
 		// transaction should not fail due to event size limit
 		assert.NoError(t, tx.Err)
 	})
@@ -698,19 +700,17 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				var deposits []flow.Event
 				var withdraws []flow.Event
 
-				expectedEventIndex := uint32(0)
+				chain := flow.Testnet.Chain()
 				for _, e := range tx.Events {
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(chain)) {
 						deposits = append(deposits, e)
 					}
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(chain)) {
 						withdraws = append(withdraws, e)
 					}
-					// event index numbers have to be an increasing uint sequence (0,1,2...)
-					require.Equal(t, expectedEventIndex, e.EventIndex)
-					expectedEventIndex++
 				}
 
+				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 2)
 				require.Len(t, withdraws, 2)
 			},
@@ -725,18 +725,21 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			},
 		},
 		{
-			name:          "Transaction fees are deducted and fe deduction is emitted",
+			name:          "Transaction fees are deducted and fee deduction is emitted",
 			fundWith:      fundingAmount,
 			tryToTransfer: transferAmount,
 			checkResult: func(t *testing.T, balanceBefore uint64, balanceAfter uint64, tx *fvm.TransactionProcedure) {
 				require.NoError(t, tx.Err)
+				chain := flow.Testnet.Chain()
+
 				var feeDeduction flow.Event // fee deduction event
 				for _, e := range tx.Events {
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowFees.FeesDeducted", environment.FlowFeesAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowFees.FeesDeducted", environment.FlowFeesAddress(chain)) {
 						feeDeduction = e
 						break
 					}
 				}
+				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.NotEmpty(t, feeDeduction.Payload)
 
 				payload, err := jsoncdc.Decode(nil, feeDeduction.Payload)
@@ -791,15 +794,18 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				var deposits []flow.Event
 				var withdraws []flow.Event
 
+				chain := flow.Testnet.Chain()
+
 				for _, e := range tx.Events {
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(chain)) {
 						deposits = append(deposits, e)
 					}
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(chain)) {
 						withdraws = append(withdraws, e)
 					}
 				}
 
+				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -815,15 +821,18 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				var deposits []flow.Event
 				var withdraws []flow.Event
 
+				chain := flow.Testnet.Chain()
+
 				for _, e := range tx.Events {
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(chain)) {
 						deposits = append(deposits, e)
 					}
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(chain)) {
 						withdraws = append(withdraws, e)
 					}
 				}
 
+				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -850,15 +859,18 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				var deposits []flow.Event
 				var withdraws []flow.Event
 
+				chain := flow.Testnet.Chain()
+
 				for _, e := range tx.Events {
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(chain)) {
 						deposits = append(deposits, e)
 					}
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(chain)) {
 						withdraws = append(withdraws, e)
 					}
 				}
 
+				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 2)
 				require.Len(t, withdraws, 2)
 			},
@@ -900,15 +912,18 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				var deposits []flow.Event
 				var withdraws []flow.Event
 
+				chain := flow.Testnet.Chain()
+
 				for _, e := range tx.Events {
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(chain)) {
 						deposits = append(deposits, e)
 					}
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(chain)) {
 						withdraws = append(withdraws, e)
 					}
 				}
 
+				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -924,15 +939,18 @@ func TestTransactionFeeDeduction(t *testing.T) {
 				var deposits []flow.Event
 				var withdraws []flow.Event
 
+				chain := flow.Testnet.Chain()
+
 				for _, e := range tx.Events {
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensDeposited", fvm.FlowTokenAddress(chain)) {
 						deposits = append(deposits, e)
 					}
-					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(flow.Testnet.Chain())) {
+					if string(e.Type) == fmt.Sprintf("A.%s.FlowToken.TokensWithdrawn", fvm.FlowTokenAddress(chain)) {
 						withdraws = append(withdraws, e)
 					}
 				}
 
+				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -955,6 +973,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			assert.NoError(t, tx.Err)
 
 			assert.Len(t, tx.Events, 10)
+			ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 
 			accountCreatedEvents := filterAccountCreatedEvents(tx.Events)
 
@@ -1428,6 +1447,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 					assert.Equal(t, maxExecutionEffort, ev.(cadence.Event).Fields[2].ToGoValue().(uint64))
 				}
 			}
+			ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
 		},
 	))
 }
@@ -1953,6 +1973,7 @@ func TestInteractionLimit(t *testing.T) {
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.NoError(t, tx.Err)
 				require.Len(t, tx.Events, 5)
+				ensureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
 			},
 		},
 		{
@@ -1961,6 +1982,7 @@ func TestInteractionLimit(t *testing.T) {
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.NoError(t, tx.Err)
 				require.Len(t, tx.Events, 5)
+				ensureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
 			},
 		},
 		{
@@ -1969,6 +1991,7 @@ func TestInteractionLimit(t *testing.T) {
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.Error(t, tx.Err)
 				require.Len(t, tx.Events, 3)
+				ensureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
 			},
 		},
 	}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -598,7 +598,7 @@ func TestEventLimits(t *testing.T) {
 		err := vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
 
-		ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+		unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 
 		// transaction should not fail due to event size limit
 		assert.NoError(t, tx.Err)
@@ -710,7 +710,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 					}
 				}
 
-				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 2)
 				require.Len(t, withdraws, 2)
 			},
@@ -739,7 +739,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 						break
 					}
 				}
-				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.NotEmpty(t, feeDeduction.Payload)
 
 				payload, err := jsoncdc.Decode(nil, feeDeduction.Payload)
@@ -805,7 +805,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 					}
 				}
 
-				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -832,7 +832,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 					}
 				}
 
-				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -870,7 +870,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 					}
 				}
 
-				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 2)
 				require.Len(t, withdraws, 2)
 			},
@@ -923,7 +923,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 					}
 				}
 
-				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -950,7 +950,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 					}
 				}
 
-				ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 				require.Len(t, deposits, 1)
 				require.Len(t, withdraws, 1)
 			},
@@ -973,7 +973,7 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			assert.NoError(t, tx.Err)
 
 			assert.Len(t, tx.Events, 10)
-			ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 
 			accountCreatedEvents := filterAccountCreatedEvents(tx.Events)
 
@@ -1447,7 +1447,7 @@ func TestSettingExecutionWeights(t *testing.T) {
 					assert.Equal(t, maxExecutionEffort, ev.(cadence.Event).Fields[2].ToGoValue().(uint64))
 				}
 			}
-			ensureEventsIndexSeq(t, tx.Events, chain.ChainID())
+			unittest.EnsureEventsIndexSeq(t, tx.Events, chain.ChainID())
 		},
 	))
 }
@@ -1973,7 +1973,7 @@ func TestInteractionLimit(t *testing.T) {
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.NoError(t, tx.Err)
 				require.Len(t, tx.Events, 5)
-				ensureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
 			},
 		},
 		{
@@ -1982,7 +1982,7 @@ func TestInteractionLimit(t *testing.T) {
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.NoError(t, tx.Err)
 				require.Len(t, tx.Events, 5)
-				ensureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
 			},
 		},
 		{
@@ -1991,7 +1991,7 @@ func TestInteractionLimit(t *testing.T) {
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.Error(t, tx.Err)
 				require.Len(t, tx.Events, 3)
-				ensureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
+				unittest.EnsureEventsIndexSeq(t, tx.Events, flow.Testnet.Chain().ChainID())
 			},
 		},
 	}

--- a/utils/unittest/fvm.go
+++ b/utils/unittest/fvm.go
@@ -1,0 +1,35 @@
+package unittest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func IsServiceEvent(event flow.Event, chainID flow.ChainID) bool {
+	serviceEvents, _ := systemcontracts.ServiceEventsForChain(chainID)
+	for _, serviceEvent := range serviceEvents.All() {
+		if serviceEvent.EventType() == event.Type {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureEventsIndexSeq checks if values of given event index sequence are monotonically increasing.
+func EnsureEventsIndexSeq(t *testing.T, events []flow.Event, chainID flow.ChainID) {
+	expectedEventIndex := uint32(0)
+	for _, event := range events {
+		require.Equal(t, expectedEventIndex, event.EventIndex)
+		if IsServiceEvent(event, chainID) {
+			// TODO: we will need to address the double counting issue for service events.
+			//		 https://github.com/onflow/flow-go/issues/3393
+			expectedEventIndex += 2
+		} else {
+			expectedEventIndex++
+		}
+	}
+}


### PR DESCRIPTION
Adding new checking in UT cases to make sure numbers in event index sequence are unique and increasing. As a follow-up to https://github.com/onflow/flow-go/pull/3371#pullrequestreview-1139592903

changes to FVM and execution computer UT are split into separate commits.