### PR TITLE
[Metrics] Adding metrics interface for block computation effort vector

### DIFF
--- a/module/metrics.go
+++ b/module/metrics.go
@@ -448,6 +448,9 @@ type ExecutionMetrics interface {
 	// ExecutionBlockExecuted reports the total time and computation spent on executing a block
 	ExecutionBlockExecuted(dur time.Duration, compUsed uint64, txCounts int, colCounts int)
 
+	// ExecutionBlockExecutionEffortVectorComponent reports the unweighted effort of given ComputationKind at block level
+	ExecutionBlockExecutionEffortVectorComponent(string, uint)
+
 	// ExecutionCollectionExecuted reports the total time and computation spent on executing a collection
 	ExecutionCollectionExecuted(dur time.Duration, compUsed uint64, txCounts int)
 

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -1,18 +1,19 @@
 package metrics
 
 const (
-	LabelChannel     = "topic"
-	LabelChain       = "chain"
-	LabelProposer    = "proposer"
-	EngineLabel      = "engine"
-	LabelResource    = "resource"
-	LabelMessage     = "message"
-	LabelNodeID      = "nodeid"
-	LabelNodeAddress = "nodeaddress"
-	LabelNodeRole    = "noderole"
-	LabelNodeInfo    = "nodeinfo"
-	LabelNodeVersion = "nodeversion"
-	LabelPriority    = "priority"
+	LabelChannel         = "topic"
+	LabelChain           = "chain"
+	LabelProposer        = "proposer"
+	EngineLabel          = "engine"
+	LabelResource        = "resource"
+	LabelMessage         = "message"
+	LabelNodeID          = "nodeid"
+	LabelNodeAddress     = "nodeaddress"
+	LabelNodeRole        = "noderole"
+	LabelNodeInfo        = "nodeinfo"
+	LabelNodeVersion     = "nodeversion"
+	LabelPriority        = "priority"
+	LabelComputationKind = "computationKind"
 )
 
 const (

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -133,6 +133,7 @@ func (nc *NoopCollector) ExecutionStateReadsPerBlock(reads uint64)              
 func (nc *NoopCollector) ExecutionStorageStateCommitment(bytes int64)                          {}
 func (nc *NoopCollector) ExecutionLastExecutedBlockHeight(height uint64)                       {}
 func (nc *NoopCollector) ExecutionBlockExecuted(_ time.Duration, _ uint64, _ int, _ int)       {}
+func (nc *NoopCollector) ExecutionBlockExecutionEffortVectorComponent(_ string, _ uint)        {}
 func (nc *NoopCollector) ExecutionCollectionExecuted(_ time.Duration, _ uint64, _ int)         {}
 func (nc *NoopCollector) ExecutionTransactionExecuted(_ time.Duration, _, _, _ uint64, _ int, _ bool) {
 }

--- a/module/mock/execution_metrics.go
+++ b/module/mock/execution_metrics.go
@@ -34,6 +34,11 @@ func (_m *ExecutionMetrics) ExecutionBlockExecuted(dur time.Duration, compUsed u
 	_m.Called(dur, compUsed, txCounts, colCounts)
 }
 
+// ExecutionBlockExecutionEffortVectorComponent provides a mock function with given fields: _a0, _a1
+func (_m *ExecutionMetrics) ExecutionBlockExecutionEffortVectorComponent(_a0 string, _a1 uint) {
+	_m.Called(_a0, _a1)
+}
+
 // ExecutionCollectionExecuted provides a mock function with given fields: dur, compUsed, txCounts
 func (_m *ExecutionMetrics) ExecutionCollectionExecuted(dur time.Duration, compUsed uint64, txCounts int) {
 	_m.Called(dur, compUsed, txCounts)


### PR DESCRIPTION
As the first step for #3312 - now we add metrics interface for the new unweighted computation effort of each block.