### PR TITLE
[Routing Attacks] Push Access Nodes To Edge (#3379)

### DIFF
--- a/network/p2p/internal/p2pfixtures/fixtures.go
+++ b/network/p2p/internal/p2pfixtures/fixtures.go
@@ -1,6 +1,7 @@
 package p2pfixtures
 
 import (
+	"bytes"
 	"context"
 	"net"
 	"testing"
@@ -32,6 +33,7 @@ import (
 	"github.com/onflow/flow-go/network/p2p/keyutils"
 	"github.com/onflow/flow-go/network/p2p/p2pbuilder"
 	"github.com/onflow/flow-go/network/p2p/p2pnode"
+	"github.com/onflow/flow-go/network/p2p/scoring"
 	"github.com/onflow/flow-go/network/p2p/unicast"
 	"github.com/onflow/flow-go/network/p2p/utils"
 	"github.com/onflow/flow-go/network/test"
@@ -108,7 +110,11 @@ func NodeFixture(
 	}
 
 	if parameters.PeerScoringEnabled {
-		builder.EnableGossipSubPeerScoring(parameters.IdProvider)
+		scoreOptionParams := make([]scoring.PeerScoreParamsOption, 0)
+		if parameters.AppSpecificScore != nil {
+			scoreOptionParams = append(scoreOptionParams, scoring.WithAppSpecificScoreFunction(parameters.AppSpecificScore))
+		}
+		builder.EnableGossipSubPeerScoring(parameters.IdProvider, scoreOptionParams...)
 	}
 
 	n, err := builder.Build()
@@ -135,6 +141,7 @@ type NodeFixtureParameters struct {
 	Logger             zerolog.Logger
 	PeerScoringEnabled bool
 	IdProvider         module.IdentityProvider
+	AppSpecificScore   func(peer.ID) float64 // overrides GossipSub scoring for sake of testing.
 }
 
 type NodeFixtureParameterOption func(*NodeFixtureParameters)
@@ -185,6 +192,12 @@ func WithPeerFilter(filter p2p.PeerFilter) NodeFixtureParameterOption {
 func WithRole(role flow.Role) NodeFixtureParameterOption {
 	return func(p *NodeFixtureParameters) {
 		p.Role = role
+	}
+}
+
+func WithAppSpecificScore(score func(peer.ID) float64) NodeFixtureParameterOption {
+	return func(p *NodeFixtureParameters) {
+		p.AppSpecificScore = score
 	}
 }
 
@@ -394,6 +407,30 @@ func SubMustNeverReceiveAnyMessage(t *testing.T, ctx context.Context, sub *pubsu
 	// on a happy path the timeout never happens, and short enough to make sure that
 	// the test doesn't take too long in case of a failure.
 	unittest.RequireCloseBefore(t, timeouted, 10*time.Second, "timeout did not happen on receiving expected pubsub message")
+}
+
+// HasSubReceivedMessage checks that the subscription have received the given message within the given timeout by the context.
+// It returns true if the subscription has received the message, false otherwise.
+func HasSubReceivedMessage(t *testing.T, ctx context.Context, expectedMessage []byte, sub *pubsub.Subscription) bool {
+	received := make(chan struct{})
+	go func() {
+		msg, err := sub.Next(ctx)
+		if err != nil {
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			return
+		}
+		if !bytes.Equal(expectedMessage, msg.Data) {
+			return
+		}
+		close(received)
+	}()
+
+	select {
+	case <-received:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // SubsMustNeverReceiveAnyMessage checks that all subscriptions never receive any message within the given timeout by the context.

--- a/network/p2p/p2pbuilder/libp2pNodeBuilder.go
+++ b/network/p2p/p2pbuilder/libp2pNodeBuilder.go
@@ -111,26 +111,27 @@ type NodeBuilder interface {
 	SetConnectionManager(connmgr.ConnManager) NodeBuilder
 	SetConnectionGater(connmgr.ConnectionGater) NodeBuilder
 	SetRoutingSystem(func(context.Context, host.Host) (routing.Routing, error)) NodeBuilder
-	EnableGossipSubPeerScoring(module.IdentityProvider) NodeBuilder
 	SetPeerManagerOptions(connectionPruning bool, updateInterval time.Duration) NodeBuilder
+	EnableGossipSubPeerScoring(module.IdentityProvider, ...scoring.PeerScoreParamsOption) NodeBuilder
 	Build() (*p2pnode.Node, error)
 }
 
 type LibP2PNodeBuilder struct {
-	sporkID                   flow.Identifier
-	addr                      string
-	networkKey                fcrypto.PrivateKey
-	logger                    zerolog.Logger
-	basicResolver             madns.BasicResolver
-	subscriptionFilter        pubsub.SubscriptionFilter
-	resourceManager           network.ResourceManager
-	connManager               connmgr.ConnManager
-	connGater                 connmgr.ConnectionGater
-	idProvider                module.IdentityProvider
-	gossipSubPeerScoring      bool // whether to enable gossipsub peer scoring
-	routingFactory            func(context.Context, host.Host) (routing.Routing, error)
-	peerManagerEnablePruning  bool
-	peerManagerUpdateInterval time.Duration
+	sporkID                     flow.Identifier
+	addr                        string
+	networkKey                  fcrypto.PrivateKey
+	logger                      zerolog.Logger
+	basicResolver               madns.BasicResolver
+	subscriptionFilter          pubsub.SubscriptionFilter
+	resourceManager             network.ResourceManager
+	connManager                 connmgr.ConnManager
+	connGater                   connmgr.ConnectionGater
+	idProvider                  module.IdentityProvider
+	gossipSubPeerScoring        bool // whether to enable gossipsub peer scoring
+	routingFactory              func(context.Context, host.Host) (routing.Routing, error)
+	peerManagerEnablePruning    bool
+	peerManagerUpdateInterval   time.Duration
+	peerScoringParameterOptions []scoring.PeerScoreParamsOption
 }
 
 func NewNodeBuilder(
@@ -183,13 +184,13 @@ func (builder *LibP2PNodeBuilder) SetRoutingSystem(f func(context.Context, host.
 	return builder
 }
 
-func (builder *LibP2PNodeBuilder) EnableGossipSubPeerScoring(provider module.IdentityProvider) NodeBuilder {
+func (builder *LibP2PNodeBuilder) EnableGossipSubPeerScoring(provider module.IdentityProvider, ops ...scoring.PeerScoreParamsOption) NodeBuilder {
 	builder.gossipSubPeerScoring = true
 	builder.idProvider = provider
+	builder.peerScoringParameterOptions = ops
 	return builder
 }
 
-// SetPeerManagerFactory sets the peer manager factory function.
 func (builder *LibP2PNodeBuilder) SetPeerManagerOptions(connectionPruning bool, updateInterval time.Duration) NodeBuilder {
 	builder.peerManagerEnablePruning = connectionPruning
 	builder.peerManagerUpdateInterval = updateInterval
@@ -276,7 +277,7 @@ func (builder *LibP2PNodeBuilder) Build() (*p2pnode.Node, error) {
 
 			var scoreOpt *scoring.ScoreOption
 			if builder.gossipSubPeerScoring {
-				scoreOpt = scoring.NewScoreOption(builder.logger, builder.idProvider)
+				scoreOpt = scoring.NewScoreOption(builder.logger, builder.idProvider, builder.peerScoringParameterOptions...)
 				psOpts = append(psOpts, scoreOpt.BuildFlowPubSubScoreOption())
 			}
 

--- a/network/p2p/scoring/app_score_test.go
+++ b/network/p2p/scoring/app_score_test.go
@@ -1,0 +1,225 @@
+package scoring_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	mocktestify "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/id"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/module/mock"
+	"github.com/onflow/flow-go/network/channels"
+	"github.com/onflow/flow-go/network/p2p/internal/p2pfixtures"
+	"github.com/onflow/flow-go/network/p2p/p2pnode"
+	"github.com/onflow/flow-go/network/p2p/scoring"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestFullGossipSubConnectivity tests that when the entire network is running by honest nodes,
+// pushing access nodes to the edges of the network (i.e., the access nodes are not in the mesh of any honest nodes)
+// will not cause the network to partition, i.e., all honest nodes can still communicate with each other through GossipSub.
+func TestFullGossipSubConnectivity(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
+	sporkId := unittest.IdentifierFixture()
+	idProvider := mock.NewIdentityProvider(t)
+
+	// two groups of non-access nodes and one group of access nodes.
+	groupOneNodes, groupOneIds := p2pfixtures.NodesFixture(t, sporkId, t.Name(), 5,
+		p2pfixtures.WithRole(flow.RoleConsensus),
+		p2pfixtures.WithPeerScoringEnabled(idProvider))
+	groupTwoNodes, groupTwoIds := p2pfixtures.NodesFixture(t, sporkId, t.Name(), 5,
+		p2pfixtures.WithRole(flow.RoleCollection),
+		p2pfixtures.WithPeerScoringEnabled(idProvider))
+	accessNodeGroup, accessNodeIds := p2pfixtures.NodesFixture(t, sporkId, t.Name(), 5,
+		p2pfixtures.WithRole(flow.RoleAccess),
+		p2pfixtures.WithPeerScoringEnabled(idProvider))
+
+	ids := append(append(groupOneIds, groupTwoIds...), accessNodeIds...)
+	nodes := append(append(groupOneNodes, groupTwoNodes...), accessNodeGroup...)
+
+	provider := id.NewFixedIdentityProvider(ids)
+	idProvider.On("ByPeerID", mocktestify.Anything).Return(
+		func(peerId peer.ID) *flow.Identity {
+			identity, _ := provider.ByPeerID(peerId)
+			return identity
+		}, func(peerId peer.ID) bool {
+			_, ok := provider.ByPeerID(peerId)
+			return ok
+		})
+	p2pfixtures.StartNodes(t, signalerCtx, nodes, 100*time.Millisecond)
+	defer p2pfixtures.StopNodes(t, nodes, cancel, 2*time.Second)
+
+	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
+	slashingViolationsConsumer := unittest.NetworkSlashingViolationsConsumer(unittest.Logger(), metrics.NewNoopCollector())
+
+	// all nodes subscribe to block topic (common topic among all roles)
+	// group one
+	groupOneSubs := make([]*pubsub.Subscription, len(groupOneNodes))
+	var err error
+	for i, node := range groupOneNodes {
+		groupOneSubs[i], err = node.Subscribe(blockTopic, unittest.NetworkCodec(), unittest.AllowAllPeerFilter(), slashingViolationsConsumer)
+		require.NoError(t, err)
+	}
+	// group two
+	groupTwoSubs := make([]*pubsub.Subscription, len(groupTwoNodes))
+	for i, node := range groupTwoNodes {
+		groupTwoSubs[i], err = node.Subscribe(blockTopic, unittest.NetworkCodec(), unittest.AllowAllPeerFilter(), slashingViolationsConsumer)
+		require.NoError(t, err)
+	}
+	// access node group
+	accessNodeSubs := make([]*pubsub.Subscription, len(accessNodeGroup))
+	for i, node := range accessNodeGroup {
+		accessNodeSubs[i], err = node.Subscribe(blockTopic, unittest.NetworkCodec(), unittest.AllowAllPeerFilter(), slashingViolationsConsumer)
+		require.NoError(t, err)
+	}
+
+	// creates a topology as follows:
+	// groupOneNodes <--> accessNodeGroup <--> groupTwoNodes
+	p2pfixtures.LetNodesDiscoverEachOther(t, ctx, append(groupOneNodes, accessNodeGroup...), append(groupOneIds, accessNodeIds...))
+	p2pfixtures.LetNodesDiscoverEachOther(t, ctx, append(groupTwoNodes, accessNodeGroup...), append(groupTwoIds, accessNodeIds...))
+
+	// checks end-to-end message delivery works
+	// each node sends a distinct message to all and checks that all nodes receive it.
+	for _, node := range nodes {
+		proposalMsg := p2pfixtures.MustEncodeEvent(t, unittest.ProposalFixture())
+		require.NoError(t, node.Publish(ctx, blockTopic, proposalMsg))
+
+		// checks that the message is received by all nodes.
+		ctx1s, cancel1s := context.WithTimeout(ctx, 5*time.Second)
+		p2pfixtures.SubsMustReceiveMessage(t, ctx1s, proposalMsg, groupOneSubs)
+		p2pfixtures.SubsMustReceiveMessage(t, ctx1s, proposalMsg, accessNodeSubs)
+		p2pfixtures.SubsMustReceiveMessage(t, ctx1s, proposalMsg, groupTwoSubs)
+
+		cancel1s()
+	}
+}
+
+// TestFullGossipSubConnectivityAmongHonestNodesWithMaliciousMajority is part two of testing pushing access nodes to the edges of the network.
+// This test proves that if access nodes are PUSHED to the edge of the network, even their malicious majority cannot partition
+// the network of honest nodes.
+func TestFullGossipSubConnectivityAmongHonestNodesWithMaliciousMajority(t *testing.T) {
+	total := 10
+	for i := 0; i < total; i++ {
+		if !testGossipSubMessageDeliveryUnderNetworkPartition(t, true) {
+			// even one failure should not happen, as it means that malicious majority can partition the network
+			// with our peer scoring parameters.
+			require.Fail(t, "honest nodes could not exchange message on GossipSub")
+		}
+	}
+}
+
+// TestNetworkPartitionWithNoHonestPeerScoringInFullTopology is part one of testing pushing access nodes to the edges of the network.
+// This test proves that if access nodes are NOT pushed to the edge of network, a malicious majority of them can
+// partition the network by disconnecting honest nodes from each other even when the network topology is a complete graph (i.e., full topology).
+func TestNetworkPartitionWithNoHonestPeerScoringInFullTopology(t *testing.T) {
+	total := 30
+	for i := 0; i < total; i++ {
+		// false means no honest peer scoring.
+		if !testGossipSubMessageDeliveryUnderNetworkPartition(t, false) {
+			return // partition is successful
+		}
+	}
+	require.Fail(t, "expected at least one network partition")
+}
+
+// testGossipSubMessageDeliveryUnderNetworkPartition tests that whether two honest nodes can exchange messages on GossipSub
+// when the network topology is a complete graph (i.e., full topology) and a malicious majority of access nodes are present.
+// If honestPeerScoring is true, then the honest nodes are enabled with peer scoring.
+// A true return value means that the two honest nodes can exchange messages.
+// A false return value means that the two honest nodes cannot exchange messages within the given timeout.
+func testGossipSubMessageDeliveryUnderNetworkPartition(t *testing.T, honestPeerScoring bool) bool {
+	ctx, cancel := context.WithCancel(context.Background())
+	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
+	sporkId := unittest.IdentifierFixture()
+
+	idProvider := mock.NewIdentityProvider(t)
+	// two (honest) consensus nodes
+	opts := []p2pfixtures.NodeFixtureParameterOption{p2pfixtures.WithRole(flow.RoleConsensus)}
+	if honestPeerScoring {
+		opts = append(opts, p2pfixtures.WithPeerScoringEnabled(idProvider))
+	}
+	con1Node, con1Id := p2pfixtures.NodeFixture(t, sporkId, t.Name(), opts...)
+	con2Node, con2Id := p2pfixtures.NodeFixture(t, sporkId, t.Name(), opts...)
+
+	// create > 2 * 12 malicious access nodes
+	// 12 is the maximum size of default GossipSub mesh.
+	// We want to make sure that it is unlikely for honest nodes to be in the same mesh (hence messages from
+	// one honest node to the other is routed through the malicious nodes).
+	accessNodeGroup, accessNodeIds := p2pfixtures.NodesFixture(t, sporkId, t.Name(), 30,
+		p2pfixtures.WithRole(flow.RoleAccess),
+		p2pfixtures.WithPeerScoringEnabled(idProvider),
+		// overrides the default peer scoring parameters to mute GossipSub traffic from/to honest nodes.
+		p2pfixtures.WithAppSpecificScore(maliciousAppSpecificScore(flow.IdentityList{&con1Id, &con2Id})))
+
+	allNodes := append([]*p2pnode.Node{con1Node, con2Node}, accessNodeGroup...)
+	allIds := append([]*flow.Identity{&con1Id, &con2Id}, accessNodeIds...)
+
+	provider := id.NewFixedIdentityProvider(allIds)
+	idProvider.On("ByPeerID", mocktestify.Anything).Return(
+		func(peerId peer.ID) *flow.Identity {
+			identity, _ := provider.ByPeerID(peerId)
+			return identity
+		}, func(peerId peer.ID) bool {
+			_, ok := provider.ByPeerID(peerId)
+			return ok
+		}).Maybe()
+
+	p2pfixtures.StartNodes(t, signalerCtx, allNodes, 100*time.Millisecond)
+	defer p2pfixtures.StopNodes(t, allNodes, cancel, 2*time.Second)
+
+	blockTopic := channels.TopicFromChannel(channels.PushBlocks, sporkId)
+	slashingViolationsConsumer := unittest.NetworkSlashingViolationsConsumer(unittest.Logger(), metrics.NewNoopCollector())
+
+	// all nodes subscribe to block topic (common topic among all roles)
+	_, err := con1Node.Subscribe(blockTopic, unittest.NetworkCodec(), unittest.AllowAllPeerFilter(), slashingViolationsConsumer)
+	require.NoError(t, err)
+
+	con2Sub, err := con2Node.Subscribe(blockTopic, unittest.NetworkCodec(), unittest.AllowAllPeerFilter(), slashingViolationsConsumer)
+	require.NoError(t, err)
+
+	// access node group
+	accessNodeSubs := make([]*pubsub.Subscription, len(accessNodeGroup))
+	for i, node := range accessNodeGroup {
+		accessNodeSubs[i], err = node.Subscribe(blockTopic, unittest.NetworkCodec(), unittest.AllowAllPeerFilter(), slashingViolationsConsumer)
+		require.NoError(t, err)
+	}
+
+	// let nodes reside on a full topology, hence no partition is caused by the topology.
+	p2pfixtures.LetNodesDiscoverEachOther(t, ctx, allNodes, allIds)
+
+	proposalMsg := p2pfixtures.MustEncodeEvent(t, unittest.ProposalFixture())
+	require.NoError(t, con1Node.Publish(ctx, blockTopic, proposalMsg))
+
+	// we check that whether within a one-second window the message is received by the other honest consensus node.
+	// the one-second window is important because it triggers the heartbeat of the con1Node to perform a lazy pull (iHave).
+	// And con1Node may randomly choose con2Node as the peer to perform the lazy pull.
+	// However, under a network partition con2Node is not in the mesh of con1Node, and hence is deprived of the eager push from con1Node.
+	//
+	// If no honest peer scoring is enabled, then con1Node and con2Node are less-likely to be in the same mesh, and hence the message is not delivered.
+	// If honest peer scoring is enabled, then con1Node and con2Node are certainly in the same mesh, and hence the message is delivered.
+	ctx1s, cancel1s := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel1s()
+	return p2pfixtures.HasSubReceivedMessage(t, ctx1s, proposalMsg, con2Sub)
+}
+
+// maliciousAppSpecificScore returns a malicious app specific score function that rewards the malicious node and
+// punishes the honest nodes.
+func maliciousAppSpecificScore(honestIds flow.IdentityList) func(peer.ID) float64 {
+	honestIdProvider := id.NewFixedIdentityProvider(honestIds)
+	return func(p peer.ID) float64 {
+		_, isHonest := honestIdProvider.ByPeerID(p)
+		if isHonest {
+			return scoring.MaxAppSpecificPenalty
+		}
+
+		return scoring.MaxAppSpecificReward
+	}
+}

--- a/network/p2p/scoring/score_option.go
+++ b/network/p2p/scoring/score_option.go
@@ -7,7 +7,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/rs/zerolog"
 
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/utils/logging"
 )
 
 const (
@@ -15,6 +17,7 @@ const (
 
 	DefaultAppSpecificScoreWeight = 1
 	MaxAppSpecificPenalty         = -100
+	MinAppSpecificPenalty         = -1
 	MaxAppSpecificReward          = 100
 
 	// DefaultGossipThreshold when a peer's score drops below this threshold,
@@ -64,23 +67,43 @@ const (
 	// Validation Constraint: must be non-negative.
 	//
 	// How we use it:
-	// We set it to 0 so that we can opportunistically graft peers when half of the mesh is penalized.
-	DefaultOpportunisticGraftThreshold = 0
+	// We set it to the MaxAppSpecificReward + 1 so that we only opportunistically graft peers that are not access nodes (i.e., with MinAppSpecificPenalty),
+	// or penalized peers (i.e., with MaxAppSpecificPenalty).
+	DefaultOpportunisticGraftThreshold = MaxAppSpecificReward + 1
 )
 
 // ScoreOption is a functional option for configuring the peer scoring system.
 type ScoreOption struct {
-	logger              zerolog.Logger
-	validator           *SubscriptionValidator
-	peerScoreParams     *pubsub.PeerScoreParams
-	peerThresholdParams *pubsub.PeerScoreThresholds
+	logger                   zerolog.Logger
+	validator                *SubscriptionValidator
+	idProvider               module.IdentityProvider
+	peerScoreParams          *pubsub.PeerScoreParams
+	peerThresholdParams      *pubsub.PeerScoreThresholds
+	appSpecificScoreFunction func(peer.ID) float64
 }
 
-func NewScoreOption(logger zerolog.Logger, idProvider module.IdentityProvider) *ScoreOption {
-	return &ScoreOption{
-		logger:    logger.With().Str("module", "pubsub_score_option").Logger(),
-		validator: NewSubscriptionValidator(idProvider),
+type PeerScoreParamsOption func(option *ScoreOption)
+
+func WithAppSpecificScoreFunction(appSpecificScoreFunction func(peer.ID) float64) PeerScoreParamsOption {
+	return func(s *ScoreOption) {
+		s.appSpecificScoreFunction = appSpecificScoreFunction
 	}
+}
+
+func NewScoreOption(logger zerolog.Logger, idProvider module.IdentityProvider, opts ...PeerScoreParamsOption) *ScoreOption {
+	validator := NewSubscriptionValidator()
+	s := &ScoreOption{
+		logger:                   logger.With().Str("module", "pubsub_score_option").Logger(),
+		validator:                validator,
+		idProvider:               idProvider,
+		appSpecificScoreFunction: defaultAppSpecificScoreFunction(logger, idProvider, validator),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
 }
 
 func (s *ScoreOption) SetSubscriptionProvider(provider *SubscriptionProvider) {
@@ -136,20 +159,65 @@ func (s *ScoreOption) preparePeerScoreParams() {
 
 		// AppSpecificScore is a function that takes a peer ID and returns an application specific score.
 		// At the current stage, we only use it to penalize and reward the peers based on their subscriptions.
-		AppSpecificScore: func(pid peer.ID) float64 {
-			if err := s.validator.CheckSubscribedToAllowedTopics(pid); err != nil {
-				s.logger.Error().
-					Err(err).
-					Str("peer_id", pid.String()).
-					Msg("invalid subscription detected, penalizing peer")
-				return MaxAppSpecificPenalty
-			}
-			s.logger.Trace().
-				Str("peer_id", pid.String()).
-				Msg("subscribed topics for peer validated, rewarding peer")
-			return MaxAppSpecificReward
-		},
+		AppSpecificScore: s.appSpecificScoreFunction,
 		// AppSpecificWeight is the weight of the application specific score.
 		AppSpecificWeight: DefaultAppSpecificScoreWeight,
+	}
+}
+
+func (s *ScoreOption) BuildGossipSubScoreOption() pubsub.Option {
+	s.preparePeerScoreParams()
+	s.preparePeerScoreThresholds()
+
+	s.logger.Info().
+		Float64("gossip_threshold", s.peerThresholdParams.GossipThreshold).
+		Float64("publish_threshold", s.peerThresholdParams.PublishThreshold).
+		Float64("graylist_threshold", s.peerThresholdParams.GraylistThreshold).
+		Float64("accept_px_threshold", s.peerThresholdParams.AcceptPXThreshold).
+		Float64("opportunistic_graft_threshold", s.peerThresholdParams.OpportunisticGraftThreshold).
+		Msg("peer score thresholds configured")
+
+	return pubsub.WithPeerScore(
+		s.peerScoreParams,
+		s.peerThresholdParams,
+	)
+}
+
+func defaultAppSpecificScoreFunction(logger zerolog.Logger, idProvider module.IdentityProvider, validator *SubscriptionValidator) func(peer.ID) float64 {
+	return func(pid peer.ID) float64 {
+		lg := logger.With().Str("peer_id", pid.String()).Logger()
+
+		// checks if peer has a valid Flow protocol identity.
+		flowId, err := HasValidFlowIdentity(idProvider, pid)
+		if err != nil {
+			lg.Error().
+				Err(err).
+				Msg("invalid peer identity, penalizing peer")
+			return MaxAppSpecificPenalty
+		}
+
+		lg = lg.With().
+			Hex("flow_id", logging.ID(flowId.NodeID)).
+			Str("role", flowId.Role.String()).
+			Logger()
+
+		// checks if peer has any subscription violation.
+		if err := validator.CheckSubscribedToAllowedTopics(pid, flowId.Role); err != nil {
+			lg.Err(err).
+				Msg("invalid subscription detected, penalizing peer")
+			return MaxAppSpecificPenalty
+		}
+
+		// checks if peer is an access node, and if so, pushes it to the
+		// edges of the network by giving the minimum penalty.
+		if flowId.Role == flow.RoleAccess {
+			lg.Debug().
+				Msg("pushing access node to edge by penalizing with minimum penalty value")
+			return MinAppSpecificPenalty
+		}
+
+		logger.Debug().
+			Msg("rewarding well-behaved non-access node peer with maximum reward value")
+		return MaxAppSpecificReward
 	}
 }

--- a/network/p2p/scoring/subscription_validator.go
+++ b/network/p2p/scoring/subscription_validator.go
@@ -3,20 +3,17 @@ package scoring
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/network/p2p"
 	p2putils "github.com/onflow/flow-go/network/p2p/utils"
 )
 
 type SubscriptionValidator struct {
-	idProvider           module.IdentityProvider
 	subscriptionProvider p2p.SubscriptionProvider
 }
 
-func NewSubscriptionValidator(idProvider module.IdentityProvider) *SubscriptionValidator {
-	return &SubscriptionValidator{
-		idProvider: idProvider,
-	}
+func NewSubscriptionValidator() *SubscriptionValidator {
+	return &SubscriptionValidator{}
 }
 
 func (v *SubscriptionValidator) RegisterSubscriptionProvider(provider p2p.SubscriptionProvider) {
@@ -25,22 +22,12 @@ func (v *SubscriptionValidator) RegisterSubscriptionProvider(provider p2p.Subscr
 
 // CheckSubscribedToAllowedTopics validates all subscriptions a peer has with respect to all Flow topics.
 // All errors returned by this method are benign:
-// - InvalidPeerIDError: the subscribed peer is unauthorized (unknown) or ejected.
 // - InvalidSubscriptionError: the peer is subscribed to a topic that is not allowed for its role.
-func (v *SubscriptionValidator) CheckSubscribedToAllowedTopics(pid peer.ID) error {
+func (v *SubscriptionValidator) CheckSubscribedToAllowedTopics(pid peer.ID, role flow.Role) error {
 	topics := v.subscriptionProvider.GetSubscribedTopics(pid)
 
-	flowId, ok := v.idProvider.ByPeerID(pid)
-	if !ok {
-		return NewInvalidPeerIDError(pid, PeerIdStatusUnknown)
-	}
-
-	if flowId.Ejected {
-		return NewInvalidPeerIDError(pid, PeerIdStatusEjected)
-	}
-
 	for _, topic := range topics {
-		if !p2putils.AllowedSubscription(flowId.Role, topic) {
+		if !p2putils.AllowedSubscription(role, topic) {
 			return NewInvalidSubscriptionError(topic)
 		}
 	}

--- a/network/p2p/scoring/utils.go
+++ b/network/p2p/scoring/utils.go
@@ -1,0 +1,22 @@
+package scoring
+
+import (
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+)
+
+// HasValidFlowIdentity checks if the peer has a valid Flow identity.
+func HasValidFlowIdentity(idProvider module.IdentityProvider, pid peer.ID) (*flow.Identity, error) {
+	flowId, ok := idProvider.ByPeerID(pid)
+	if !ok {
+		return nil, NewInvalidPeerIDError(pid, PeerIdStatusUnknown)
+	}
+
+	if flowId.Ejected {
+		return nil, NewInvalidPeerIDError(pid, PeerIdStatusEjected)
+	}
+
+	return flowId, nil
+}

--- a/network/p2p/scoring/utils_test.go
+++ b/network/p2p/scoring/utils_test.go
@@ -1,0 +1,54 @@
+package scoring_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/module/mock"
+	"github.com/onflow/flow-go/network/p2p/internal/p2pfixtures"
+	"github.com/onflow/flow-go/network/p2p/scoring"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestHasValidIdentity_Unknown tests that when a peer has an unknown identity, the HasValidIdentity returns InvalidPeerIDError
+func TestHasValidIdentity_Unknown(t *testing.T) {
+	peerId := p2pfixtures.PeerIdFixture(t)
+	idProvider := mock.NewIdentityProvider(t)
+	idProvider.On("ByPeerID", peerId).Return(nil, false)
+
+	identity, err := scoring.HasValidFlowIdentity(idProvider, peerId)
+	require.Nil(t, identity)
+	require.Error(t, err)
+	require.True(t, scoring.IsInvalidPeerIDError(err))
+	require.Contains(t, err.Error(), scoring.PeerIdStatusUnknown)
+}
+
+// TestHasValidIdentity_Ejected tests that when a peer has been ejected, the HasValidIdentity returns an InvalidPeerIDError.
+func TestHasValidIdentity_Ejected(t *testing.T) {
+	idProvider := mock.NewIdentityProvider(t)
+
+	ejectedIdentity := unittest.IdentityFixture()
+	ejectedIdentity.Ejected = true
+	peerId := p2pfixtures.PeerIdFixture(t)
+	idProvider.On("ByPeerID", peerId).Return(ejectedIdentity, true)
+
+	identity, err := scoring.HasValidFlowIdentity(idProvider, peerId)
+	require.Error(t, err)
+	require.True(t, scoring.IsInvalidPeerIDError(err))
+	require.Contains(t, err.Error(), scoring.PeerIdStatusEjected)
+	require.Nil(t, identity)
+}
+
+// TestHasValidIdentity_valid tests that when a peer has a valid identity, the HasValidIdentity returns that identity.
+func TestHasValidIdentity_Valid(t *testing.T) {
+	idProvider := mock.NewIdentityProvider(t)
+
+	trueID := unittest.IdentityFixture()
+	peerId := p2pfixtures.PeerIdFixture(t)
+	idProvider.On("ByPeerID", peerId).Return(trueID, true)
+
+	identity, err := scoring.HasValidFlowIdentity(idProvider, peerId)
+	require.NoError(t, err)
+	require.Equal(t, trueID, identity)
+}


### PR DESCRIPTION
* refactors go libp2p core dependency

* lint fix

* lint fix

* lint

* re-generates mocks

* implements subscription provider

* exports allowed subscription method

* fix

* implements subscription validator

* renames a file

* refactors packaging

* lint fix

* updates subscription validator

* implements score options

* removes set pubsub sytem

* adds enabling gossipsub peer scoring

* Adds enabling peer scoring for gossipsub to the builder

* wires up identity provider

* adds subscription provider interface

* generates p2p mock

* adds fixtures

* adds topic provider mock

* refactors subscription provider with topic provider

* adds subscription provider

* repackages translator

* refactors translator and connector

* lint fix

* fixes import cycle

* lint fix

* fixes compile errors

* fixes compile errors

* fixes compile issues

* lint fix

* moves dht to its own package

* lint fix

* fix lint

* wip

* wip

* fixes cyclic dependency due to libp2p utils

* fixes internal dependencies

* fixes cyclic dependency

* fixes build issues

* fixes compile issues

* fixes build tests

* fixes access builder

* fixes observer node

* fixes compile issues

* fixes compile issues

* fixes complie issues

* fixes import cycle

* lint fix

* fix imports

* renames node package

* renames implementation

* package renaming

* lint fix

* lint fix

* lint fix

* lint fix

* lint fix

* lint fix

* lint fix

* lint fix

* lint fix

* lint fix

* resolves merge conflicts

* lint fix

* fix lint

* fixes peer id fixture

* adds godoc

* moves identity provider interface to module package

* generates mocks for module

* generates mocks for network package

* adds test with no subscribed topic

* adds test for unknown subscription

* adds test contain and exclude

* adds godoc

* adds helper methods

* adds subscription validator tests

* adds filter

* adds filter test

* refactors tests with filter

* refactors valid subscription

* refactors filter to exclude

* adds test for subscription to all topics

* adds exclude pattern tests

* adds test for subscription validator

* fixes builder issue with pubsub factory

* lays out structure of integration test

* migrates fixture

* updates test

* exports and moves a fixture

* adds mvp subscription validator test

* refactors test helpers

* adds enable gossip sub peer scoring to node fixture

* refactors missing score options

* wip

* resolves deadlock in libp2p

* refactors with atomic

* adds documentation

* adds godoc

* adds utils for slices

* fixes tests

* reverts a change

* changes a log level

* refactors a few test helpers

* flips log level

* adds godoc

* refactors a method

* adds godoc

* adds godoc

* lint fix

* lint fix

* lint fix

* fix timeout

* lint fix

* lint fix

* lint fix

* lint fix

* lint fix

* sort imports

* adds peer scoring as a flag

* lint fix

* adds test for excluding all elements

* are string slices equal handles multiset

* implements sentinel error

* extends sentinel errors

* Update network/p2p/scoring/subscription_provider.go

Co-authored-by: Peter Argue <89119817+peterargue@users.noreply.github.com>

* adds comment for peer scoring

* renames a function

* adds a todo

* removes maybe off the mocks

* extends test comment

* adds role check for access node

* adds test

* refactors subscription validation

* adds util tests

* adds injectable app specific score

* adds malicious AN tests

* implements a helper

* refactors test malicious access node

* renames a test

* fixes build errors

* fixes tests

* cosmotic

* remove unused test helpers

* adds full gossipsub connectivity test

* refactors tests

* adds godoc

* lint fix

* consolidates test helpers into one

* refactors log level

* increases a test size

Co-authored-by: Peter Argue <89119817+peterargue@users.noreply.github.com>
Co-authored-by: Vishal <1117327+vishalchangrani@users.noreply.github.com>