### PR TITLE
[FVM] Refactoring TransactionProcedure trace span creation

### DIFF
--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -7,6 +7,8 @@ import (
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/trace"
 )
 
 // TODO(patrick): pass in initial snapshot time when we start supporting
@@ -50,6 +52,15 @@ func (proc *TransactionProcedure) SetTraceSpan(traceSpan otelTrace.Span) {
 
 func (proc *TransactionProcedure) IsSampled() bool {
 	return proc.TraceSpan != nil
+}
+
+func (proc *TransactionProcedure) StartSpanFromProcTraceSpan(
+	tracer module.Tracer,
+	spanName trace.SpanName) otelTrace.Span {
+	if tracer != nil && proc.IsSampled() {
+		return tracer.StartSpanFromParent(proc.TraceSpan, spanName)
+	}
+	return trace.NoopSpan
 }
 
 func (proc *TransactionProcedure) Run(

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -48,6 +48,10 @@ func (proc *TransactionProcedure) SetTraceSpan(traceSpan otelTrace.Span) {
 	proc.TraceSpan = traceSpan
 }
 
+func (proc *TransactionProcedure) IsSampled() bool {
+	return proc.TraceSpan != nil
+}
+
 func (proc *TransactionProcedure) Run(
 	ctx Context,
 	txnState *state.TransactionState,

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -9,7 +9,6 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
-	otelTrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
@@ -34,14 +33,11 @@ func (i TransactionInvoker) Process(
 ) (processErr error) {
 
 	txIDStr := proc.ID.String()
-	var span otelTrace.Span
-	if ctx.Tracer != nil && proc.IsSampled() {
-		span = ctx.Tracer.StartSpanFromParent(proc.TraceSpan, trace.FVMExecuteTransaction)
-		span.SetAttributes(
-			attribute.String("transaction_id", txIDStr),
-		)
-		defer span.End()
-	}
+	span := proc.StartSpanFromProcTraceSpan(ctx.Tracer, trace.FVMExecuteTransaction)
+	span.SetAttributes(
+		attribute.String("transaction_id", txIDStr),
+	)
+	defer span.End()
 
 	nestedTxnId, beginErr := txnState.BeginNestedTransaction()
 	if beginErr != nil {

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -35,7 +35,7 @@ func (i TransactionInvoker) Process(
 
 	txIDStr := proc.ID.String()
 	var span otelTrace.Span
-	if ctx.Tracer != nil && proc.TraceSpan != nil {
+	if ctx.Tracer != nil && proc.IsSampled() {
 		span = ctx.Tracer.StartSpanFromParent(proc.TraceSpan, trace.FVMExecuteTransaction)
 		span.SetAttributes(
 			attribute.String("transaction_id", txIDStr),

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -37,7 +37,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	txnState *state.TransactionState,
 ) error {
 
-	if ctx.Tracer != nil && proc.TraceSpan != nil {
+	if ctx.Tracer != nil && proc.IsSampled() {
 		span := ctx.Tracer.StartSpanFromParent(proc.TraceSpan, trace.FVMSeqNumCheckTransaction)
 		defer span.End()
 	}

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -37,10 +37,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	txnState *state.TransactionState,
 ) error {
 
-	if ctx.Tracer != nil && proc.IsSampled() {
-		span := ctx.Tracer.StartSpanFromParent(proc.TraceSpan, trace.FVMSeqNumCheckTransaction)
-		defer span.End()
-	}
+	defer proc.StartSpanFromProcTraceSpan(ctx.Tracer, trace.FVMSeqNumCheckTransaction).End()
 
 	nestedTxnId, err := txnState.BeginNestedTransaction()
 	if err != nil {

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -50,13 +50,11 @@ func (v *TransactionVerifier) verifyTransaction(
 	ctx Context,
 	txnState *state.TransactionState,
 ) error {
-	if ctx.Tracer != nil && proc.IsSampled() {
-		span := ctx.Tracer.StartSpanFromParent(proc.TraceSpan, trace.FVMVerifyTransaction)
-		span.SetAttributes(
-			attribute.String("transaction.ID", proc.ID.String()),
-		)
-		defer span.End()
-	}
+	span := proc.StartSpanFromProcTraceSpan(ctx.Tracer, trace.FVMVerifyTransaction)
+	span.SetAttributes(
+		attribute.String("transaction.ID", proc.ID.String()),
+	)
+	defer span.End()
 
 	tx := proc.Transaction
 	accounts := environment.NewAccounts(txnState)

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -50,7 +50,7 @@ func (v *TransactionVerifier) verifyTransaction(
 	ctx Context,
 	txnState *state.TransactionState,
 ) error {
-	if ctx.Tracer != nil && proc.TraceSpan != nil {
+	if ctx.Tracer != nil && proc.IsSampled() {
 		span := ctx.Tracer.StartSpanFromParent(proc.TraceSpan, trace.FVMVerifyTransaction)
 		span.SetAttributes(
 			attribute.String("transaction.ID", proc.ID.String()),


### PR DESCRIPTION
- Adding `IsSampled()` to TransactionProcedure. Taking the message from [computer.go](https://github.com/onflow/flow-go/blob/master/engine/execution/computation/computer/computer.go#L411-L413) to `TransactionProcedure` to make code slightly easier to read.
- Isolating boilerplace code for creating tracer span for TransactionProcedure into a function.

**Test**
- [X] all fvm UT