### PR TITLE
Remove read last trie

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -3,14 +3,12 @@ package extract
 import (
 	"encoding/hex"
 	"fmt"
-	"os"
 	"path"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
-	"github.com/onflow/flow-go/ledger/complete/wal"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
@@ -118,23 +116,7 @@ func run(*cobra.Command, []string) {
 	}
 
 	if len(flagBlockHash) == 0 && len(flagStateCommitment) == 0 {
-		// read state commitment from root checkpoint
-
-		f, err := os.Open(path.Join(flagExecutionStateDir, bootstrap.FilenameWALRootCheckpoint))
-		if err != nil {
-			log.Fatal().Err(err).Msg("invalid root checkpoint")
-		}
-		defer f.Close()
-
-		rootHash, err := wal.ReadLastTrieRootHashFromCheckpoint(f)
-		if err != nil {
-			log.Fatal().Err(err).Msgf("failed to read last root hash in root checkpoint: %s", err.Error())
-		}
-
-		stateCommitment, err = flow.ToStateCommitment(rootHash[:])
-		if err != nil {
-			log.Fatal().Err(err).Msg("failed to convert state commitment from last root hash in root checkpoint")
-		}
+		log.Fatal().Msg("no --block-hash or --state-commitment was specified")
 	}
 
 	log.Info().Msgf("Extracting state from %s, exporting root checkpoint to %s, version: %v",

--- a/ledger/complete/wal/checkpointer.go
+++ b/ledger/complete/wal/checkpointer.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,7 +17,6 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/onflow/flow-go/ledger"
-	"github.com/onflow/flow-go/ledger/common/hash"
 	"github.com/onflow/flow-go/ledger/complete/mtrie"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/flattener"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
@@ -1020,50 +1018,6 @@ func readCheckpointV5(f *os.File, logger *zerolog.Logger) ([]*trie.MTrie, error)
 	}
 
 	return tries, nil
-}
-
-// ReadLastTrieRootHashFromCheckpoint returns last trie's root hash from checkpoint file f.
-// All returned errors indicate that the given checkpoint file is eiter corrupted or
-// incompatible.  As the function is side-effect free, all failures are simple a no-op.
-func ReadLastTrieRootHashFromCheckpoint(f *os.File) (hash.Hash, error) {
-
-	// read checkpoint version
-	header := make([]byte, headerSize)
-	n, err := f.Read(header)
-	if err != nil || n != headerSize {
-		return hash.DummyHash, errors.New("failed to read checkpoint header")
-	}
-
-	magic := binary.BigEndian.Uint16(header)
-	version := binary.BigEndian.Uint16(header[encMagicSize:])
-
-	if magic != MagicBytesCheckpointHeader {
-		return hash.DummyHash, errors.New("invalid magic bytes in checkpoint")
-	}
-
-	if version > MaxVersion {
-		return hash.DummyHash, fmt.Errorf("unsupported version %d in checkpoint", version)
-	}
-
-	if version <= 3 {
-		_, err = f.Seek(-(hash.HashLen + crc32SumSize), 2 /* relative from end */)
-		if err != nil {
-			return hash.DummyHash, errors.New("invalid checkpoint")
-		}
-	} else {
-		_, err = f.Seek(-(hash.HashLen + encNodeCountSize + encTrieCountSize + crc32SumSize), 2 /* relative from end */)
-		if err != nil {
-			return hash.DummyHash, errors.New("invalid checkpoint")
-		}
-	}
-
-	var lastTrieRootHash hash.Hash
-	n, err = f.Read(lastTrieRootHash[:])
-	if err != nil || n != hash.HashLen {
-		return hash.DummyHash, errors.New("failed to read last trie root hash from checkpoint")
-	}
-
-	return lastTrieRootHash, nil
 }
 
 // EvictAllCheckpointsFromLinuxPageCache advises Linux to evict all checkpoint files


### PR DESCRIPTION
The `ReadLastTrieRootHashFromCheckpoint` is incorrect for checkpoint V6. 

Since state extraction will always specify block hash, we could simply remove this function. 