### PR TITLE
Fix copy checkpoint on bootstrap

### DIFF
--- a/ledger/complete/wal/checkpoint_v5_test.go
+++ b/ledger/complete/wal/checkpoint_v5_test.go
@@ -1,0 +1,26 @@
+package wal
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyCheckpointFileV5(t *testing.T) {
+	unittest.RunWithTempDir(t, func(dir string) {
+		tries := createSimpleTrie(t)
+		fileName := "checkpoint"
+		logger := unittest.Logger()
+		require.NoErrorf(t, StoreCheckpointV5(dir, fileName, &logger, tries...), "fail to store checkpoint")
+		to := filepath.Join(dir, "newfolder")
+		newPaths, err := CopyCheckpointFile(fileName, dir, to)
+		require.NoError(t, err)
+		log.Info().Msgf("copied to :%v", newPaths)
+		decoded, err := LoadCheckpoint(filepath.Join(to, fileName), &logger)
+		require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
+		requireTriesEqual(t, tries, decoded)
+	})
+}

--- a/ledger/complete/wal/checkpoint_v5_test.go
+++ b/ledger/complete/wal/checkpoint_v5_test.go
@@ -4,9 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/onflow/flow-go/utils/unittest"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestCopyCheckpointFileV5(t *testing.T) {

--- a/ledger/complete/wal/checkpoint_v6_reader.go
+++ b/ledger/complete/wal/checkpoint_v6_reader.go
@@ -121,7 +121,7 @@ func partFileName(fileName string, index int) string {
 	return fmt.Sprintf("%v.%03d", fileName, index)
 }
 
-func FilePathPattern(dir string, fileName string) string {
+func filePathPattern(dir string, fileName string) string {
 	return fmt.Sprintf("%v*", filePathCheckpointHeader(dir, fileName))
 }
 
@@ -221,7 +221,7 @@ func allPartFileExist(dir string, fileName string, totalSubtrieFiles int) error 
 // - it return the matching part files, note it might not contains all the part files.
 // - it return error if running any exception
 func findCheckpointPartFiles(dir string, fileName string) ([]string, error) {
-	pattern := FilePathPattern(dir, fileName)
+	pattern := filePathPattern(dir, fileName)
 	matched, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("could not find checkpoint files: %w", err)

--- a/ledger/complete/wal/checkpoint_v6_reader.go
+++ b/ledger/complete/wal/checkpoint_v6_reader.go
@@ -121,7 +121,7 @@ func partFileName(fileName string, index int) string {
 	return fmt.Sprintf("%v.%03d", fileName, index)
 }
 
-func filePathPattern(dir string, fileName string) string {
+func FilePathPattern(dir string, fileName string) string {
 	return fmt.Sprintf("%v*", filePathCheckpointHeader(dir, fileName))
 }
 
@@ -221,7 +221,7 @@ func allPartFileExist(dir string, fileName string, totalSubtrieFiles int) error 
 // - it return the matching part files, note it might not contains all the part files.
 // - it return error if running any exception
 func findCheckpointPartFiles(dir string, fileName string) ([]string, error) {
-	pattern := filePathPattern(dir, fileName)
+	pattern := FilePathPattern(dir, fileName)
 	matched, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("could not find checkpoint files: %w", err)

--- a/ledger/complete/wal/checkpoint_v6_writer.go
+++ b/ledger/complete/wal/checkpoint_v6_writer.go
@@ -723,7 +723,7 @@ func decodeSubtrieCount(encoded []byte) (uint16, error) {
 //	) {
 //		def func() {
 //			// good, because the error to returned is only updated here, and guaranteed to be returned
-//			errToReturn = closeAndMergeError(closable, err)
+//			errToReturn = closeAndMergeError(closable, errToReturn)
 //		}()
 func closeAndMergeError(closable io.Closer, err error) error {
 	var merr *multierror.Error

--- a/ledger/complete/wal/checkpoint_v6_writer.go
+++ b/ledger/complete/wal/checkpoint_v6_writer.go
@@ -580,7 +580,7 @@ func storeTries(
 
 // deleteCheckpointFiles removes any checkpoint files with given checkpoint prefix in the outputDir.
 func deleteCheckpointFiles(outputDir string, outputFile string) error {
-	pattern := filePathPattern(outputDir, outputFile)
+	pattern := FilePathPattern(outputDir, outputFile)
 	filesToRemove, err := filepath.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("could not glob checkpoint files to delete with pattern %v: %w",

--- a/ledger/complete/wal/checkpoint_v6_writer.go
+++ b/ledger/complete/wal/checkpoint_v6_writer.go
@@ -580,7 +580,7 @@ func storeTries(
 
 // deleteCheckpointFiles removes any checkpoint files with given checkpoint prefix in the outputDir.
 func deleteCheckpointFiles(outputDir string, outputFile string) error {
-	pattern := FilePathPattern(outputDir, outputFile)
+	pattern := filePathPattern(outputDir, outputFile)
 	filesToRemove, err := filepath.Glob(pattern)
 	if err != nil {
 		return fmt.Errorf("could not glob checkpoint files to delete with pattern %v: %w",


### PR DESCRIPTION
During spork, the EN has to copy the root checkpoint file from bootstrap folder. This PR fixes an issue that instead of copying only one checkpoint file, it also copy other part files to support checkpoint V6