### PR TITLE
Refactor transaction invoker.

### DIFF
--- a/fvm/errors/errors_collector.go
+++ b/fvm/errors/errors_collector.go
@@ -1,0 +1,60 @@
+package errors
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// Utility object for collecting Processor errors.
+type ErrorsCollector struct {
+	errors  error
+	failure error
+}
+
+func NewErrorsCollector() *ErrorsCollector {
+	return &ErrorsCollector{}
+}
+
+func (collector *ErrorsCollector) CollectedFailure() bool {
+	return collector.failure != nil
+}
+
+func (collector *ErrorsCollector) CollectedError() bool {
+	return collector.errors != nil || collector.failure != nil
+}
+
+func (collector *ErrorsCollector) ErrorOrNil() error {
+	if collector.failure == nil {
+		return collector.errors
+	}
+
+	if collector.errors == nil {
+		return collector.failure
+	}
+
+	return fmt.Errorf(
+		"%w (additional errors: %v)",
+		collector.failure,
+		collector.errors)
+}
+
+// This returns collector for chaining purposes.
+func (collector *ErrorsCollector) Collect(err error) *ErrorsCollector {
+	if err == nil {
+		return collector
+	}
+
+	if collector.failure != nil {
+		collector.errors = multierror.Append(collector.errors, err)
+		return collector
+	}
+
+	if IsFailure(err) {
+		collector.failure = err
+		return collector
+	}
+
+	collector.errors = multierror.Append(collector.errors, err)
+	return collector
+}

--- a/fvm/errors/errors_collector_test.go
+++ b/fvm/errors/errors_collector_test.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorsCollector(t *testing.T) {
+	t.Run("basic collection", func(t *testing.T) {
+		collector := ErrorsCollector{}
+
+		// Collecting nil is ok
+		require.False(t, collector.Collect(nil).CollectedFailure())
+		require.False(t, collector.CollectedError())
+		require.Nil(t, collector.ErrorOrNil())
+
+		// Collected non-fatal errors
+		require.False(
+			t,
+			collector.Collect(NewOperationNotSupportedError("op1")).
+				CollectedFailure())
+
+		require.True(t, collector.CollectedError())
+		err := collector.ErrorOrNil()
+		require.NotNil(t, err)
+		require.ErrorContains(t, err, "op1")
+		require.False(t, IsFailure(err))
+
+		require.False(
+			t,
+			collector.Collect(NewOperationNotSupportedError("op2")).
+				CollectedFailure())
+
+		require.True(t, collector.CollectedError())
+		err = collector.ErrorOrNil()
+		require.NotNil(t, err)
+		require.ErrorContains(t, err, "op1")
+		require.ErrorContains(t, err, "op2")
+		require.False(t, IsFailure(err))
+
+		// Collected fatal error
+		require.True(
+			t,
+			collector.Collect(fmt.Errorf("fatal1")).CollectedFailure())
+
+		require.True(t, collector.CollectedError())
+		err = collector.ErrorOrNil()
+		require.NotNil(t, err)
+		require.ErrorContains(t, err, "op1")
+		require.ErrorContains(t, err, "op2")
+		require.ErrorContains(t, err, "fatal1")
+		require.True(t, IsFailure(err))
+
+		// Collecting a non-fatal error after a fatal error should still be
+		// fatal
+		require.True(
+			t,
+			collector.Collect(NewOperationNotSupportedError("op3")).
+				CollectedFailure())
+
+		require.True(t, collector.CollectedError())
+		err = collector.ErrorOrNil()
+		require.NotNil(t, err)
+		require.ErrorContains(t, err, "op1")
+		require.ErrorContains(t, err, "op2")
+		require.ErrorContains(t, err, "op3")
+		require.ErrorContains(t, err, "fatal1")
+		require.True(t, IsFailure(err))
+
+		// Collected multiple fatal errors (This should never happen, but just
+		// in case)
+		require.True(t, collector.Collect(fmt.Errorf("fatal2")).
+			CollectedFailure())
+
+		require.True(t, collector.CollectedError())
+		err = collector.ErrorOrNil()
+		require.NotNil(t, err)
+		require.ErrorContains(t, err, "op1")
+		require.ErrorContains(t, err, "op2")
+		require.ErrorContains(t, err, "op3")
+		require.ErrorContains(t, err, "fatal1")
+		require.ErrorContains(t, err, "fatal2")
+		require.True(t, IsFailure(err))
+	})
+
+	t.Run("failure only", func(t *testing.T) {
+		collector := ErrorsCollector{}
+
+		require.True(
+			t,
+			collector.Collect(fmt.Errorf("fatal1")).CollectedFailure())
+
+		require.True(t, collector.CollectedError())
+		err := collector.ErrorOrNil()
+		require.NotNil(t, err)
+		require.ErrorContains(t, err, "fatal1")
+		require.True(t, IsFailure(err))
+
+	})
+}

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -100,7 +100,7 @@ func (s *TransactionState) BeginNestedTransaction() (
 ) {
 	if s.IsParseRestricted() {
 		return NestedTransactionId{}, fmt.Errorf(
-			"cannot beinga a unrestricted nested transaction inside a " +
+			"cannot begin a unrestricted nested transaction inside a " +
 				"program restricted nested transaction",
 		)
 	}
@@ -240,7 +240,8 @@ func (s *TransactionState) RestartNestedTransaction(
 	}
 
 	if !found {
-		return fmt.Errorf("nested transaction not found")
+		return fmt.Errorf(
+			"cannot restart nested transaction: nested transaction not found")
 	}
 
 	for s.currentState() != id.state {

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/rs/zerolog"
@@ -30,7 +29,7 @@ func (i TransactionInvoker) Process(
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
 	programs *programsCache.TransactionPrograms,
-) (processErr error) {
+) error {
 
 	txIDStr := proc.ID.String()
 	span := proc.StartSpanFromProcTraceSpan(ctx.Tracer, trace.FVMExecuteTransaction)
@@ -45,129 +44,29 @@ func (i TransactionInvoker) Process(
 	}
 
 	var modifiedSets programsCache.ModifiedSetsInvalidator
-	defer func() {
-		if errors.IsFailure(processErr) {
-			// Just immediately halt if the error is a unrecoverable failure.
-			return
-		}
 
-		if txnState.NumNestedTransactions() > 1 {
-			if processErr == nil {
-				// This is a fvm internal programming error.  We forgot to
-				// call Commit somewhere in the control flow.  We should halt.
-				processErr = fmt.Errorf(
-					"successfully executed transaction has unexpected " +
-						"nested transactions.")
-				return
-			} else {
-				restartErr := txnState.RestartNestedTransaction(nestedTxnId)
-				if restartErr != nil {
-					// This should never happen since merging views should
-					// never fail.
-					processErr = fmt.Errorf(
-						"cannot restart nested transaction on error: %w "+
-							"(original processErr: %v)",
-						restartErr,
-						processErr)
-					return
-				}
-
-				ctx.Logger.Warn().Msg(
-					"transaction had unexpected nested transactions, " +
-						"which have been restarted.")
-
-				// Note: proc.Err is set by TransactionProcedure.
-				proc.Logs = make([]string, 0)
-				proc.Events = make([]flow.Event, 0)
-				proc.ServiceEvents = make([]flow.Event, 0)
-			}
-		}
-
-		// based on the contract and frozen account updates we decide how to
-		// clean up the programs for failed transactions we also do the same as
-		// transaction without any deployed contracts
-		programs.AddInvalidator(modifiedSets)
-
-		commitErr := txnState.Commit(nestedTxnId)
-		if commitErr != nil {
-			processErr = fmt.Errorf(
-				"transaction invocation failed when merging state: %w "+
-					"(original processErr: %v)",
-				commitErr,
-				processErr)
-		}
-	}()
-
-	mergeErrorShouldEarlyExit := func(err error) bool {
-		if err == nil {
-			return false
-		}
-
-		if errors.IsFailure(err) {
-			if processErr == nil {
-				processErr = err
-			} else {
-				processErr = fmt.Errorf(
-					"%w (collected errors: %v)",
-					err,
-					processErr)
-			}
-			return true
-		}
-
-		processErr = multierror.Append(processErr, err)
-		return false
-	}
+	errs := errors.NewErrorsCollector()
 
 	env := NewTransactionEnvironment(ctx, txnState, programs, proc.Transaction, proc.TxIndex, span)
 
 	var txError error
 	modifiedSets, txError = i.normalExecution(proc, txnState, env)
-	if mergeErrorShouldEarlyExit(txError) {
-		return
+	if errs.Collect(txError).CollectedFailure() {
+		return errs.ErrorOrNil()
 	}
 
-	// it there was any transaction error clear changes and try to deduct fees again
-	if processErr != nil {
-		txnState.DisableAllLimitEnforcements()
-		defer txnState.EnableAllLimitEnforcements()
-
-		// log transaction as failed
-		ctx.Logger.Info().
-			Err(processErr).
-			Msg("transaction executed with error")
-
+	if errs.CollectedError() {
 		modifiedSets = programsCache.ModifiedSetsInvalidator{}
-		env.Reset()
 
-		// drop delta since transaction failed
-		restartErr := txnState.RestartNestedTransaction(nestedTxnId)
-		if restartErr != nil {
-			return fmt.Errorf(
-				"cannot restart nested transaction: %w "+
-					"(original processErr: %v)",
-				restartErr,
-				processErr)
-		}
-
-		// try to deduct fees again, to get the fee deduction events
-		feesError := i.deductTransactionFees(proc, txnState, env)
-
-		// if fee deduction fails just do clean up and exit
-		if feesError != nil {
-			ctx.Logger.Info().
-				Err(feesError).
-				Msg("transaction fee deduction executed with error")
-
-			if mergeErrorShouldEarlyExit(feesError) {
-				return
-			}
-
-			// drop delta
-			_ = txnState.RestartNestedTransaction(nestedTxnId)
+		fatalErr := i.errorExecution(proc, txnState, nestedTxnId, env, errs)
+		if fatalErr != nil {
+			return fatalErr
 		}
 	}
 
+	// TODO(patrick): tighten validateCommit check and move proc result
+	// population into commit
+	//
 	// if tx failed this will only contain fee deduction logs
 	proc.Logs = append(proc.Logs, env.Logs()...)
 	proc.ComputationUsed = proc.ComputationUsed + env.ComputationUsed()
@@ -180,7 +79,24 @@ func (i TransactionInvoker) Process(
 	proc.Events = append(proc.Events, env.Events()...)
 	proc.ServiceEvents = append(proc.ServiceEvents, env.ServiceEvents()...)
 
-	return
+	processErr := errs.ErrorOrNil()
+
+	fatalErr := i.validateCommit(
+		proc,
+		txnState,
+		nestedTxnId,
+		env,
+		processErr)
+	if fatalErr != nil {
+		return fatalErr
+	}
+
+	return i.commit(
+		txnState,
+		nestedTxnId,
+		programs,
+		modifiedSets,
+		processErr)
 }
 
 func (i TransactionInvoker) deductTransactionFees(
@@ -298,4 +214,114 @@ func (i TransactionInvoker) normalExecution(
 	})
 
 	return
+}
+
+// Clear changes and try to deduct fees again.
+func (i TransactionInvoker) errorExecution(
+	proc *TransactionProcedure,
+	txnState *state.TransactionState,
+	nestedTxnId state.NestedTransactionId,
+	env environment.Environment,
+	errs *errors.ErrorsCollector,
+) error {
+	txnState.DisableAllLimitEnforcements()
+	defer txnState.EnableAllLimitEnforcements()
+
+	// log transaction as failed
+	env.Logger().Info().
+		Err(errs.ErrorOrNil()).
+		Msg("transaction executed with error")
+
+	env.Reset()
+
+	// drop delta since transaction failed
+	restartErr := txnState.RestartNestedTransaction(nestedTxnId)
+	if errs.Collect(restartErr).CollectedFailure() {
+		return errs.ErrorOrNil()
+	}
+
+	// try to deduct fees again, to get the fee deduction events
+	feesError := i.deductTransactionFees(proc, txnState, env)
+
+	// if fee deduction fails just do clean up and exit
+	if feesError != nil {
+		env.Logger().Info().
+			Err(feesError).
+			Msg("transaction fee deduction executed with error")
+
+		if errs.Collect(feesError).CollectedFailure() {
+			return errs.ErrorOrNil()
+		}
+
+		// drop delta
+		restartErr = txnState.RestartNestedTransaction(nestedTxnId)
+		if errs.Collect(restartErr).CollectedFailure() {
+			return errs.ErrorOrNil()
+		}
+	}
+
+	return nil
+}
+
+func (i TransactionInvoker) validateCommit(
+	proc *TransactionProcedure,
+	txnState *state.TransactionState,
+	nestedTxnId state.NestedTransactionId,
+	env environment.Environment,
+	processErr error,
+) error {
+	if txnState.NumNestedTransactions() > 1 {
+		if processErr == nil {
+			// This is a fvm internal programming error.  We forgot to
+			// call Commit somewhere in the control flow.  We should halt.
+			return fmt.Errorf(
+				"successfully executed transaction has unexpected " +
+					"nested transactions.")
+		} else {
+			restartErr := txnState.RestartNestedTransaction(nestedTxnId)
+			if restartErr != nil {
+				// This should never happen since merging views should
+				// never fail.
+				return fmt.Errorf(
+					"cannot restart nested transaction on error: %w "+
+						"(original processErr: %v)",
+					restartErr,
+					processErr)
+			}
+
+			env.Logger().Warn().Msg(
+				"transaction had unexpected nested transactions, " +
+					"which have been restarted.")
+
+			// Note: proc.Err is set by TransactionProcedure.
+			proc.Logs = make([]string, 0)
+			proc.Events = make([]flow.Event, 0)
+			proc.ServiceEvents = make([]flow.Event, 0)
+		}
+	}
+	return nil
+}
+
+func (i TransactionInvoker) commit(
+	txnState *state.TransactionState,
+	nestedTxnId state.NestedTransactionId,
+	programs *programsCache.TransactionPrograms,
+	modifiedSets programsCache.ModifiedSetsInvalidator,
+	processErr error,
+) error {
+	// based on the contract and frozen account updates we decide how to
+	// clean up the programs for failed transactions we also do the same as
+	// transaction without any deployed contracts
+	programs.AddInvalidator(modifiedSets)
+
+	commitErr := txnState.Commit(nestedTxnId)
+	if commitErr != nil {
+		return fmt.Errorf(
+			"transaction invocation failed when merging state: %w "+
+				"(original processErr: %v)",
+			commitErr,
+			processErr)
+	}
+
+	return processErr
 }


### PR DESCRIPTION
1. move errors collection out of the invoker + added test
2. don't commit transaction using defer.  The original defer commit function is also split into validateCommit and commit.  This is prep work for converting the Process() into continuation passing style executor.
3. move error execution path into a method