### PR TITLE
Add Pause/Resume functionality to TransactionState

### DIFF
--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -94,8 +94,7 @@ func (programs *Programs) get(
 	program, state, has := programs.transactionPrograms.Get(location)
 	if has {
 		if state != nil {
-			err := programs.txnState.AttachAndCommitParseRestricted(
-				state)
+			err := programs.txnState.AttachAndCommit(state)
 			if err != nil {
 				panic(fmt.Sprintf(
 					"merge error while getting program, panic: %s",

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -314,7 +314,7 @@ func (i TransactionInvoker) commit(
 	// transaction without any deployed contracts
 	programs.AddInvalidator(modifiedSets)
 
-	commitErr := txnState.Commit(nestedTxnId)
+	_, commitErr := txnState.Commit(nestedTxnId)
 	if commitErr != nil {
 		return fmt.Errorf(
 			"transaction invocation failed when merging state: %w "+

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -45,7 +45,7 @@ func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	}
 
 	defer func() {
-		commitError := txnState.Commit(nestedTxnId)
+		_, commitError := txnState.Commit(nestedTxnId)
 		if commitError != nil {
 			panic(commitError)
 		}


### PR DESCRIPTION
These will be used for implementing continuation passing style executors (The nested transaction will pause after preprocessing, and resume on actual execution).

Also made a bunch of improvements to support caching result (These should be useful for implementing meter weight prefetching):
 1. added guard to prevent modification on committed state
 2. Commit returns the committed state
 3. renamed AttachAndCommitParseRestricted to AttachAndCommit