### PR TITLE
[Execution] Moving all storage interfaces to scaffold from ExecutionNode

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -747,22 +747,30 @@ func (fnb *FlowNodeBuilder) initStorage() {
 	epochCommits := bstorage.NewEpochCommits(fnb.Metrics.Cache, fnb.DB)
 	statuses := bstorage.NewEpochStatuses(fnb.Metrics.Cache, fnb.DB)
 	commits := bstorage.NewCommits(fnb.Metrics.Cache, fnb.DB)
+	events := bstorage.NewEvents(fnb.Metrics.Cache, fnb.DB)
+	serviceEvents := bstorage.NewServiceEvents(fnb.Metrics.Cache, fnb.DB)
+	myExecutionReceipts := bstorage.NewMyExecutionReceipts(fnb.Metrics.Cache, fnb.DB, receipts)
+	transactionResults := bstorage.NewTransactionResults(fnb.Metrics.Cache, fnb.DB, bstorage.DefaultCacheSize)
 
 	fnb.Storage = Storage{
-		Headers:      headers,
-		Guarantees:   guarantees,
-		Receipts:     receipts,
-		Results:      results,
-		Seals:        seals,
-		Index:        index,
-		Payloads:     payloads,
-		Blocks:       blocks,
-		Transactions: transactions,
-		Collections:  collections,
-		Setups:       setups,
-		EpochCommits: epochCommits,
-		Statuses:     statuses,
-		Commits:      commits,
+		Headers:             headers,
+		Guarantees:          guarantees,
+		Receipts:            receipts,
+		Results:             results,
+		Seals:               seals,
+		Index:               index,
+		Payloads:            payloads,
+		Blocks:              blocks,
+		Transactions:        transactions,
+		Collections:         collections,
+		Setups:              setups,
+		EpochCommits:        epochCommits,
+		Statuses:            statuses,
+		Commits:             commits,
+		Events:              events,
+		ServiceEvents:       serviceEvents,
+		MyExecutionReceipts: myExecutionReceipts,
+		TransactionResults:  transactionResults,
 	}
 }
 

--- a/storage/all.go
+++ b/storage/all.go
@@ -2,21 +2,23 @@ package storage
 
 // All includes all the storage modules
 type All struct {
-	Headers            Headers
-	Guarantees         Guarantees
-	Seals              Seals
-	Index              Index
-	Payloads           Payloads
-	Blocks             Blocks
-	Setups             EpochSetups
-	EpochCommits       EpochCommits
-	Statuses           EpochStatuses
-	Results            ExecutionResults
-	Receipts           ExecutionReceipts
-	ChunkDataPacks     ChunkDataPacks
-	Commits            Commits
-	Transactions       Transactions
-	TransactionResults TransactionResults
-	Collections        Collections
-	Events             Events
+	Headers             Headers
+	Guarantees          Guarantees
+	Seals               Seals
+	Index               Index
+	Payloads            Payloads
+	Blocks              Blocks
+	Setups              EpochSetups
+	EpochCommits        EpochCommits
+	Statuses            EpochStatuses
+	Results             ExecutionResults
+	Receipts            ExecutionReceipts
+	MyExecutionReceipts MyExecutionReceipts
+	ChunkDataPacks      ChunkDataPacks
+	Commits             Commits
+	Transactions        Transactions
+	TransactionResults  TransactionResults
+	Collections         Collections
+	Events              Events
+	ServiceEvents       ServiceEvents
 }


### PR DESCRIPTION
To continue the effort of #3427, now all storage interfaces in ExecutionNode are moved to scaffold.go, so that storage interfaces are not duplicated and all these interfaces can be properly initialized in Component setup calls in ExecutionBuilder.

**Test**
- [X] manually adding debug code to panic if any of these storage interface is nil - on localnet