### PR TITLE
[Execution] Randomize collection fetch order

### DIFF
--- a/engine/common/requester/engine.go
+++ b/engine/common/requester/engine.go
@@ -398,7 +398,7 @@ func (e *Engine) dispatchRequest() (bool, error) {
 
 	// create a batch request, send it and store it for reference
 	req := &messages.EntityRequest{
-		Nonce:     rand.Uint64(),
+		Nonce:     e.rng.Uint64(),
 		EntityIDs: entityIDs,
 	}
 

--- a/engine/common/requester/engine_test.go
+++ b/engine/common/requester/engine_test.go
@@ -29,6 +29,7 @@ func TestEntityByID(t *testing.T) {
 	request := Engine{
 		unit:  engine.NewUnit(),
 		items: make(map[flow.Identifier]*Item),
+		rng:   rand.New(rand.NewSource(0)),
 	}
 
 	now := time.Now().UTC()
@@ -135,6 +136,7 @@ func TestDispatchRequestVarious(t *testing.T) {
 		items:    items,
 		requests: make(map[uint64]*messages.EntityRequest),
 		selector: filter.HasNodeID(targetID),
+		rng:      rand.New(rand.NewSource(0)),
 	}
 	dispatched, err := request.dispatchRequest()
 	require.NoError(t, err)
@@ -211,6 +213,7 @@ func TestDispatchRequestBatchSize(t *testing.T) {
 		items:    items,
 		requests: make(map[uint64]*messages.EntityRequest),
 		selector: filter.Any,
+		rng:      rand.New(rand.NewSource(0)),
 	}
 	dispatched, err := request.dispatchRequest()
 	require.NoError(t, err)
@@ -290,6 +293,7 @@ func TestOnEntityResponseValid(t *testing.T) {
 				close(done)
 			}
 		},
+		rng: rand.New(rand.NewSource(0)),
 	}
 
 	request.items[iwanted1.EntityID] = iwanted1
@@ -373,6 +377,7 @@ func TestOnEntityIntegrityCheck(t *testing.T) {
 		selector: filter.HasNodeID(targetID),
 		create:   func() flow.Entity { return &flow.Collection{} },
 		handle:   func(flow.Identifier, flow.Entity) { close(called) },
+		rng:      rand.New(rand.NewSource(0)),
 	}
 
 	request.items[iwanted.EntityID] = iwanted


### PR DESCRIPTION
Map iteration order is not random, but instead undefined ([as per go spec](https://go.dev/ref/spec#RangeClause)):

> The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next.

This [does not mean random and especially not uniformly random](https://go.dev/play/p/wfSzSXfVOJa). Therefore pre-randomize the order.