### PR TITLE
[Execution] Backport collection retries to v0.28

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -730,9 +730,9 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 		func() flow.Entity { return &flow.Collection{} },
 		// we are manually triggering batches in execution, but lets still send off a batch once a minute, as a safety net for the sake of retries
 		requester.WithBatchInterval(exeNode.exeConf.requestInterval),
-		requester.WithRetryFunction(requester.RetryLinear(exeNode.exeConf.requestRetryDelay)),
-		requester.WithRetryInitial(exeNode.exeConf.requestRetryInitial),
-		requester.WithRetryMaximum(exeNode.exeConf.requestRetryMaximum),
+		requester.WithRetryFunction(requester.RetryLinear(exeNode.exeConf.requestRetryIncrementalDelay)),
+		requester.WithRetryInitial(exeNode.exeConf.requestRetryInitialDelay),
+		requester.WithRetryMaximum(exeNode.exeConf.requestRetryMaximumDelay),
 		// consistency of collection can be checked by checking hash, and hash comes from trusted source (blocks from consensus follower)
 		// hence we not need to check origin
 		requester.WithValidateStaking(false),

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -730,6 +730,9 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 		func() flow.Entity { return &flow.Collection{} },
 		// we are manually triggering batches in execution, but lets still send off a batch once a minute, as a safety net for the sake of retries
 		requester.WithBatchInterval(exeNode.exeConf.requestInterval),
+		requester.WithRetryFunction(requester.RetryLinear(exeNode.exeConf.requestRetryDelay)),
+		requester.WithRetryInitial(exeNode.exeConf.requestRetryInitial),
+		requester.WithRetryMaximum(exeNode.exeConf.requestRetryMaximum),
 		// consistency of collection can be checked by checking hash, and hash comes from trusted source (blocks from consensus follower)
 		// hence we not need to check origin
 		requester.WithValidateStaking(false),

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -728,7 +728,7 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 		channels.RequestCollections,
 		filter.Any,
 		func() flow.Entity { return &flow.Collection{} },
-		// we are manually triggering batches in execution, but lets still send off a batch once a minute, as a safety net for the sake of retries
+		// we are manually triggering batches in execution, but lets still send off a batch once a in a while, as a safety net for the sake of retries.
 		requester.WithBatchInterval(exeNode.exeConf.requestInterval),
 		requester.WithRetryFunction(requester.RetryLinear(exeNode.exeConf.requestRetryIncrementalDelay)),
 		requester.WithRetryInitial(exeNode.exeConf.requestRetryInitialDelay),

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -33,9 +33,9 @@ type ExecutionConfig struct {
 	chunkDataPackCacheSize               uint
 	chunkDataPackRequestsCacheSize       uint32
 	requestInterval                      time.Duration
-	requestRetryDelay                    time.Duration
-	requestRetryInitial                  time.Duration
-	requestRetryMaximum                  time.Duration
+	requestRetryInitialDelay             time.Duration
+	requestRetryIncrementalDelay         time.Duration
+	requestRetryMaximumDelay             time.Duration
 	preferredExeNodeIDStr                string
 	syncByBlocks                         bool
 	syncFast                             bool
@@ -79,9 +79,9 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.UintVar(&exeConf.chunkDataPackCacheSize, "chdp-cache", storage.DefaultCacheSize, "cache size for chunk data packs")
 	flags.Uint32Var(&exeConf.chunkDataPackRequestsCacheSize, "chdp-request-queue", mempool.DefaultChunkDataPackRequestQueueSize, "queue size for chunk data pack requests")
 	flags.DurationVar(&exeConf.requestInterval, "request-interval", 10*time.Second, "the interval between requests for the requester engine")
-	flags.DurationVar(&exeConf.requestRetryDelay, "request-retry-delay", 1*time.Second, "linear delay increase between retries for the requester engine")
-	flags.DurationVar(&exeConf.requestRetryInitial, "request-retry-initial", 1*time.Second, "initial retry delay for the requester engine")
-	flags.DurationVar(&exeConf.requestRetryMaximum, "request-retry-maximum", 5*time.Second, "maximum retry delay for the requester engine")
+	flags.DurationVar(&exeConf.requestRetryInitialDelay, "request-retry-initial-delay", 1*time.Second, "initial retry delay for the requester engine")
+	flags.DurationVar(&exeConf.requestRetryIncrementalDelay, "request-retry-incremental-delay", 1*time.Second, "linear delay increase between retries for the requester engine")
+	flags.DurationVar(&exeConf.requestRetryMaximumDelay, "request-retry-maximum-delay", 5*time.Second, "maximum retry delay for the requester engine")
 	flags.DurationVar(&exeConf.computationConfig.ScriptLogThreshold, "script-log-threshold", computation.DefaultScriptLogThreshold,
 		"threshold for logging script execution")
 	flags.DurationVar(&exeConf.computationConfig.ScriptExecutionTimeLimit, "script-execution-time-limit", computation.DefaultScriptExecutionTimeLimit,

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -33,6 +33,9 @@ type ExecutionConfig struct {
 	chunkDataPackCacheSize               uint
 	chunkDataPackRequestsCacheSize       uint32
 	requestInterval                      time.Duration
+	requestRetryDelay                    time.Duration
+	requestRetryInitial                  time.Duration
+	requestRetryMaximum                  time.Duration
 	preferredExeNodeIDStr                string
 	syncByBlocks                         bool
 	syncFast                             bool
@@ -75,7 +78,10 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&exeConf.computationConfig.CadenceTracing, "cadence-tracing", false, "enables cadence runtime level tracing")
 	flags.UintVar(&exeConf.chunkDataPackCacheSize, "chdp-cache", storage.DefaultCacheSize, "cache size for chunk data packs")
 	flags.Uint32Var(&exeConf.chunkDataPackRequestsCacheSize, "chdp-request-queue", mempool.DefaultChunkDataPackRequestQueueSize, "queue size for chunk data pack requests")
-	flags.DurationVar(&exeConf.requestInterval, "request-interval", 60*time.Second, "the interval between requests for the requester engine")
+	flags.DurationVar(&exeConf.requestInterval, "request-interval", 10*time.Second, "the interval between requests for the requester engine")
+	flags.DurationVar(&exeConf.requestRetryDelay, "request-retry-delay", 1*time.Second, "linear delay increase between retries for the requester engine")
+	flags.DurationVar(&exeConf.requestRetryInitial, "request-retry-initial", 1*time.Second, "initial retry delay for the requester engine")
+	flags.DurationVar(&exeConf.requestRetryMaximum, "request-retry-maximum", 5*time.Second, "maximum retry delay for the requester engine")
 	flags.DurationVar(&exeConf.computationConfig.ScriptLogThreshold, "script-log-threshold", computation.DefaultScriptLogThreshold,
 		"threshold for logging script execution")
 	flags.DurationVar(&exeConf.computationConfig.ScriptExecutionTimeLimit, "script-execution-time-limit", computation.DefaultScriptExecutionTimeLimit,

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -79,6 +79,8 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.UintVar(&exeConf.chunkDataPackCacheSize, "chdp-cache", storage.DefaultCacheSize, "cache size for chunk data packs")
 	flags.Uint32Var(&exeConf.chunkDataPackRequestsCacheSize, "chdp-request-queue", mempool.DefaultChunkDataPackRequestQueueSize, "queue size for chunk data pack requests")
 	flags.DurationVar(&exeConf.requestInterval, "request-interval", 10*time.Second, "the interval between requests for the requester engine")
+	// collection retry parameters: these are chosen to have a balance between retrying too fast to DDoS the collection node
+	// and retrying too slow to stall execution in presense of a network partition (or transient collection node failure).
 	flags.DurationVar(&exeConf.requestRetryInitialDelay, "request-retry-initial-delay", 1*time.Second, "initial retry delay for the requester engine")
 	flags.DurationVar(&exeConf.requestRetryIncrementalDelay, "request-retry-incremental-delay", 1*time.Second, "linear delay increase between retries for the requester engine")
 	flags.DurationVar(&exeConf.requestRetryMaximumDelay, "request-retry-maximum-delay", 5*time.Second, "maximum retry delay for the requester engine")


### PR DESCRIPTION
This is a backport of https://github.com/onflow/flow-go/pull/3406.