### PR TITLE
[FVM] Adding state-replay cache implementation

### DIFF
--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -296,6 +296,12 @@ func (s *State) UpdatedAddresses() []flow.Address {
 	return addresses
 }
 
+// UpdatedRegisters return a list of registers that were updated.
+func (s *State) UpdatedRegisters() []flow.RegisterID {
+	updatedRegisters, _ := s.view.RegisterUpdates()
+	return updatedRegisters
+}
+
 func (s *State) checkSize(owner, key string, value flow.RegisterValue) error {
 	keySize := uint64(len(owner) + len(key))
 	valueSize := uint64(len(value))

--- a/fvm/state/state_replay_cache.go
+++ b/fvm/state/state_replay_cache.go
@@ -1,0 +1,95 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// StateReplayCache caches value read from state together with all register touches triggered
+// when reading that value from state. These register touches will be re/played on the target
+// view in every GetOrRetrieveValue value call.
+type StateReplayCache[T any] struct {
+	cachedValue            T
+	cachedState            *State
+	cachedUpdatedRegisters map[string]bool
+}
+
+func NewStateReplayCache[T any]() *StateReplayCache[T] {
+	return &StateReplayCache[T]{
+		cachedUpdatedRegisters: make(map[string]bool),
+	}
+}
+
+// GetOrRetrieveValue returns a state value. When value is not cached, `retriever` closure will be
+// called to retrieve the value and the state delta will be captured and cached too; when value is
+// cached the cached one will be returned, and the cached state delta will be replayed on `view`.
+func (stateReplayCache *StateReplayCache[T]) GetOrRetrieveValue(
+	view View,
+	retriever func(*TransactionState) (T, error),
+	stateParams StateParameters,
+) (T, error) {
+	if view == nil {
+		return stateReplayCache.cachedValue, fmt.Errorf("view parameter should not be nil")
+	}
+	if retriever == nil {
+		return stateReplayCache.cachedValue, fmt.Errorf("retriever closure should not be nil")
+	}
+
+	transactionState := NewTransactionState(view, stateParams)
+
+	if stateReplayCache.cachedState == nil {
+		nestedTxId, err := transactionState.BeginNestedTransaction()
+		if err != nil {
+			return stateReplayCache.cachedValue, fmt.Errorf("failed to start a nested tx: %w", err)
+		}
+
+		// retrieve state value by calling retriever closure
+		stateReplayCache.cachedValue, err = retriever(transactionState)
+		if err != nil {
+			return stateReplayCache.cachedValue, fmt.Errorf("failed to retrieve value: %w", err)
+		}
+
+		// apply reg touches on the target view and cache the delta state for replay purposes
+		stateReplayCache.cachedState, err = transactionState.Commit(nestedTxId)
+		if err != nil {
+			stateReplayCache.cachedState = nil
+			return stateReplayCache.cachedValue, fmt.Errorf("failed to commit state: %w", err)
+		}
+
+		stateReplayCache.refreshUpdatedRegisters()
+	} else {
+		// if value/state is cached already, simply replay it on the target view.
+		err := transactionState.AttachAndCommit(stateReplayCache.cachedState)
+		if err != nil {
+			return stateReplayCache.cachedValue, fmt.Errorf("failed to replay cached state: %w", err)
+		}
+	}
+
+	return stateReplayCache.cachedValue, nil
+}
+
+// Invalidate clears the cached state so next GetOrRetrieveValue() call will do
+// actual state read again to retrieve latest value in state.
+func (stateReplayCache *StateReplayCache[T]) Invalidate(
+	updatedRegiestersInTx []flow.RegisterID,
+) bool {
+	// detect register collision
+	for _, reg := range updatedRegiestersInTx {
+		_, found := stateReplayCache.cachedUpdatedRegisters[reg.String()]
+		if found {
+			stateReplayCache.cachedState = nil
+			stateReplayCache.cachedUpdatedRegisters = make(map[string]bool)
+			return true
+		}
+	}
+
+	return false
+}
+
+func (stateReplayCache *StateReplayCache[T]) refreshUpdatedRegisters() {
+	stateReplayCache.cachedUpdatedRegisters = make(map[string]bool)
+	for _, reg := range stateReplayCache.cachedState.UpdatedRegisters() {
+		stateReplayCache.cachedUpdatedRegisters[reg.String()] = true
+	}
+}

--- a/fvm/state/state_replay_cache_test.go
+++ b/fvm/state/state_replay_cache_test.go
@@ -1,0 +1,219 @@
+package state_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/utils"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestStateReplayCache(t *testing.T) {
+
+	t.Run("retriever closure called at first read", func(t *testing.T) {
+		view := utils.NewSimpleView()
+		cache1 := state.NewStateReplayCache[int]()
+
+		testValue := int(123)
+		testRegsToBeTouched := []flow.RegisterID{
+			{
+				Owner: "owner1",
+				Key:   "key1",
+			},
+			{
+				Owner: "owner2",
+				Key:   "key2",
+			},
+		}
+		retrievedValue, err := cache1.GetOrRetrieveValue(
+			view,
+			func(ts *state.TransactionState) (int, error) {
+				for _, reg := range testRegsToBeTouched {
+					_ = view.Set(reg.Owner, reg.Key, flow.RegisterValue{})
+				}
+				return testValue, nil
+			},
+			state.DefaultParameters(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, testValue, retrievedValue)
+		updatedRegs, _ := view.RegisterUpdates()
+		require.True(t, registerIdSliceDeepEqual(testRegsToBeTouched, updatedRegs))
+	})
+
+	t.Run("retriever closure not called with cached value", func(t *testing.T) {
+		view := utils.NewSimpleView()
+		cache1 := state.NewStateReplayCache[int]()
+
+		testValue := int(123)
+		closureCalledCount := 0
+		retriever := func(ts *state.TransactionState) (int, error) {
+			closureCalledCount++
+			return testValue, nil
+		}
+
+		// 1st read
+		retrievedValue, err := cache1.GetOrRetrieveValue(
+			view,
+			retriever,
+			state.DefaultParameters(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, testValue, retrievedValue)
+		require.Equal(t, 1, closureCalledCount)
+
+		// 2nd read
+		retrievedValue, err = cache1.GetOrRetrieveValue(
+			view,
+			retriever,
+			state.DefaultParameters(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, testValue, retrievedValue)
+		require.Equal(t, 1, closureCalledCount) // counter should not increase
+	})
+
+	t.Run("retriever closure returns error", func(t *testing.T) {
+		view := utils.NewSimpleView()
+		cache1 := state.NewStateReplayCache[int]()
+
+		closureCalledCount := 0
+		retrieverError := func(ts *state.TransactionState) (int, error) {
+			closureCalledCount++
+			return 0, errors.New("closure failure")
+		}
+
+		// 1st call
+		_, err := cache1.GetOrRetrieveValue(
+			view,
+			retrieverError,
+			state.DefaultParameters(),
+		)
+		require.Error(t, err)
+		require.Equal(t, 1, closureCalledCount)
+
+		// 2nd call
+		_, err = cache1.GetOrRetrieveValue(
+			view,
+			retrieverError,
+			state.DefaultParameters(),
+		)
+		require.Error(t, err)
+		require.Equal(t, 2, closureCalledCount)
+
+		// 3rd call with working retriever
+		retrieverOk := func(ts *state.TransactionState) (int, error) {
+			closureCalledCount++
+			return 0, nil
+		}
+		_, err = cache1.GetOrRetrieveValue(
+			view,
+			retrieverOk,
+			state.DefaultParameters(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 3, closureCalledCount)
+	})
+
+	t.Run("cache invalidation", func(t *testing.T) {
+		cache1 := state.NewStateReplayCache[int]()
+
+		testValue := int(123)
+		testRegsToBeTouched := []flow.RegisterID{
+			{
+				Owner: "owner1",
+				Key:   "key1",
+			},
+			{
+				Owner: "owner2",
+				Key:   "key2",
+			},
+		}
+		closureCalledCount := 0
+		retriever := func(ts *state.TransactionState) (int, error) {
+			closureCalledCount++
+			for _, reg := range testRegsToBeTouched {
+				_ = ts.Set(reg.Owner, reg.Key, flow.RegisterValue{}, false)
+			}
+			return testValue, nil
+		}
+
+		// 1st read
+		viewToReplayOn := utils.NewSimpleView()
+		retrievedValue, err := cache1.GetOrRetrieveValue(
+			viewToReplayOn,
+			retriever,
+			state.DefaultParameters(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, testValue, retrievedValue)
+		require.Equal(t, 1, closureCalledCount)
+		regsReplayed, _ := viewToReplayOn.RegisterUpdates()
+		require.True(t, registerIdSliceDeepEqual(testRegsToBeTouched, regsReplayed))
+
+		// Invalidate - no detection found
+		testRegs1 := []flow.RegisterID{
+			{
+				Owner: "owner3",
+				Key:   "key3",
+			},
+		}
+		invalidated := cache1.Invalidate(testRegs1)
+		require.False(t, invalidated)
+
+		// Invalidate - detection found
+		invalidated = cache1.Invalidate(testRegsToBeTouched)
+		require.True(t, invalidated)
+
+		retrievedValue, err = cache1.GetOrRetrieveValue(
+			viewToReplayOn,
+			retriever,
+			state.DefaultParameters(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, testValue, retrievedValue)
+		require.Equal(t, 2, closureCalledCount)
+		regsReplayed, _ = viewToReplayOn.RegisterUpdates()
+		require.True(t, registerIdSliceDeepEqual(testRegsToBeTouched, regsReplayed))
+	})
+
+	t.Run("nil parameter checks", func(t *testing.T) {
+		view := utils.NewSimpleView()
+		cache1 := state.NewStateReplayCache[int]()
+
+		testValue := int(123)
+		retriever := func(ts *state.TransactionState) (int, error) {
+			return testValue, nil
+		}
+
+		_, err := cache1.GetOrRetrieveValue(
+			nil,
+			retriever,
+			state.DefaultParameters(),
+		)
+		require.Error(t, err)
+
+		_, err = cache1.GetOrRetrieveValue(
+			view,
+			nil,
+			state.DefaultParameters(),
+		)
+		require.Error(t, err)
+	})
+}
+
+func registerIdSliceDeepEqual(regs1 []flow.RegisterID, regs2 []flow.RegisterID) bool {
+	regMap1 := make(map[string]bool)
+	for _, reg := range regs1 {
+		regMap1[reg.String()] = true
+	}
+	regMap2 := make(map[string]bool)
+	for _, reg := range regs2 {
+		regMap2[reg.String()] = true
+	}
+	return reflect.DeepEqual(regMap1, regMap2)
+}


### PR DESCRIPTION
As the first step for #3102 , now adding a generic state-replay cache to be used for meter settings, protocol version number later.

Assumption: value retrieval can be wrapped up in a closure. Existing Cadence Get\SetProgram() call pattern is not wrap-able since code is in Cadence side, so for now `BlockProgram` is not able to utilize this cache, until Cadence switches to "GetOrRetrieve" call pattern.

**Test**
- [X] new UT cases