### PR TITLE
Revert "[Execution] Aggressive collection retries"

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -731,11 +731,8 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 		channels.RequestCollections,
 		filter.Any,
 		func() flow.Entity { return &flow.Collection{} },
-		// we are manually triggering batches in execution, but lets still send off a batch once a in a while, as a safety net for the sake of retries.
+		// we are manually triggering batches in execution, but lets still send off a batch once a minute, as a safety net for the sake of retries
 		requester.WithBatchInterval(exeNode.exeConf.requestInterval),
-		requester.WithRetryFunction(requester.RetryLinear(exeNode.exeConf.requestRetryIncrementalDelay)),
-		requester.WithRetryInitial(exeNode.exeConf.requestRetryInitialDelay),
-		requester.WithRetryMaximum(exeNode.exeConf.requestRetryMaximumDelay),
 		// consistency of collection can be checked by checking hash, and hash comes from trusted source (blocks from consensus follower)
 		// hence we not need to check origin
 		requester.WithValidateStaking(false),

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -34,9 +34,6 @@ type ExecutionConfig struct {
 	chunkDataPackCacheSize               uint
 	chunkDataPackRequestsCacheSize       uint32
 	requestInterval                      time.Duration
-	requestRetryInitialDelay             time.Duration
-	requestRetryIncrementalDelay         time.Duration
-	requestRetryMaximumDelay             time.Duration
 	preferredExeNodeIDStr                string
 	syncByBlocks                         bool
 	syncFast                             bool
@@ -81,12 +78,7 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&exeConf.computationConfig.CadenceTracing, "cadence-tracing", false, "enables cadence runtime level tracing")
 	flags.UintVar(&exeConf.chunkDataPackCacheSize, "chdp-cache", storage.DefaultCacheSize, "cache size for chunk data packs")
 	flags.Uint32Var(&exeConf.chunkDataPackRequestsCacheSize, "chdp-request-queue", mempool.DefaultChunkDataPackRequestQueueSize, "queue size for chunk data pack requests")
-	flags.DurationVar(&exeConf.requestInterval, "request-interval", 10*time.Second, "the interval between requests for the requester engine")
-	// collection retry parameters: these are chosen to have a balance between retrying too fast to DDoS the collection node
-	// and retrying too slow to stall execution in presense of a network partition (or transient collection node failure).
-	flags.DurationVar(&exeConf.requestRetryInitialDelay, "request-retry-initial-delay", 1*time.Second, "initial retry delay for the requester engine")
-	flags.DurationVar(&exeConf.requestRetryIncrementalDelay, "request-retry-incremental-delay", 1*time.Second, "linear delay increase between retries for the requester engine")
-	flags.DurationVar(&exeConf.requestRetryMaximumDelay, "request-retry-maximum-delay", 5*time.Second, "maximum retry delay for the requester engine")
+	flags.DurationVar(&exeConf.requestInterval, "request-interval", 60*time.Second, "the interval between requests for the requester engine")
 	flags.Uint32Var(&exeConf.receiptRequestsCacheSize, "receipt-request-cache", provider.DefaultEntityRequestCacheSize, "queue size for entity requests at common provider engine")
 	flags.UintVar(&exeConf.receiptRequestWorkers, "receipt-request-workers", provider.DefaultRequestProviderWorkers, "number of workers for entity requests at common provider engine")
 	flags.DurationVar(&exeConf.computationConfig.ScriptLogThreshold, "script-log-threshold", computation.DefaultScriptLogThreshold,


### PR DESCRIPTION
Following diffs are reverted (#3406):

Revert "[Execution] Add comments to the default collection retry parameters"
This reverts commit 1fff25896f9f9221c06d483e66ad672e781c4e86.

Revert "[Execution] Improve variable naming"
This reverts commit eb07fcef5bda45323d19814546209a5623a7410a.

Revert "[Execution] Aggressive collection retries"
This reverts commit 6d9ad5e051bcec65de9e69a829615a8c196368c2.

Ref: https://github.com/onflow/flow-go/issues/3455