### PR TITLE
Prevent cadence from directly accessing fvm internal state

### DIFF
--- a/cmd/util/ledger/migrations/storage_used_update_migration.go
+++ b/cmd/util/ledger/migrations/storage_used_update_migration.go
@@ -123,7 +123,7 @@ func (m *StorageUsedUpdateMigration) Migrate(payload []ledger.Payload) ([]ledger
 					// not an address
 					continue
 				}
-				if id.Key == state.KeyAccountStatus {
+				if id.Key == state.AccountStatusKey {
 					storageUsedPayloadChan <- accountStorageUsedPayload{
 						Address: id.Owner,
 						Index:   p.Index,
@@ -187,7 +187,7 @@ Loop:
 			log.Error().Err(err).Msg("error converting key to register ID")
 			return nil, err
 		}
-		if id.Key != state.KeyAccountStatus {
+		if id.Key != state.AccountStatusKey {
 			return nil, fmt.Errorf("this is not a status register")
 		}
 

--- a/cmd/util/ledger/migrations/storage_used_update_migration_test.go
+++ b/cmd/util/ledger/migrations/storage_used_update_migration_test.go
@@ -29,7 +29,7 @@ func TestStorageUsedUpdateMigrationMigration(t *testing.T) {
 		payload := []ledger.Payload{
 			// TODO (ramtin) add more registers
 			*ledger.NewPayload(
-				createAccountPayloadKey(address1, state2.KeyAccountStatus),
+				createAccountPayloadKey(address1, state2.AccountStatusKey),
 				status.ToBytes(),
 			),
 		}
@@ -48,7 +48,7 @@ func TestStorageUsedUpdateMigrationMigration(t *testing.T) {
 		status.SetStorageUsed(10000)
 		payload := []ledger.Payload{
 			*ledger.NewPayload(
-				createAccountPayloadKey(address1, state2.KeyAccountStatus),
+				createAccountPayloadKey(address1, state2.AccountStatusKey),
 				status.ToBytes(),
 			),
 		}
@@ -67,7 +67,7 @@ func TestStorageUsedUpdateMigrationMigration(t *testing.T) {
 		status.SetStorageUsed(40)
 		payload := []ledger.Payload{
 			*ledger.NewPayload(
-				createAccountPayloadKey(address1, state2.KeyAccountStatus),
+				createAccountPayloadKey(address1, state2.AccountStatusKey),
 				status.ToBytes(),
 			),
 		}
@@ -84,7 +84,7 @@ func TestStorageUsedUpdateMigrationMigration(t *testing.T) {
 	t.Run("error is storage used does not exist", func(t *testing.T) {
 		payload := []ledger.Payload{
 			*ledger.NewPayload(
-				createAccountPayloadKey(address1, state2.KeyAccountStatus),
+				createAccountPayloadKey(address1, state2.AccountStatusKey),
 				[]byte{1},
 			),
 		}

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -543,7 +543,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			return nil, nil
 		})
 
-		err = view.Set(string(address.Bytes()), state.KeyAccountStatus, environment.NewAccountStatus().ToBytes())
+		err = view.Set(string(address.Bytes()), state.AccountStatusKey, environment.NewAccountStatus().ToBytes())
 		require.NoError(t, err)
 
 		result, err := exe.ExecuteBlock(context.Background(), block, view, programs.NewEmptyBlockPrograms())
@@ -637,7 +637,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			return nil, nil
 		})
 
-		err = view.Set(string(address.Bytes()), state.KeyAccountStatus, environment.NewAccountStatus().ToBytes())
+		err = view.Set(string(address.Bytes()), state.AccountStatusKey, environment.NewAccountStatus().ToBytes())
 		require.NoError(t, err)
 
 		result, err := exe.ExecuteBlock(context.Background(), block, view, programs.NewEmptyBlockPrograms())
@@ -828,7 +828,7 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 	// make sure check for account status has been registered
 	id := flow.RegisterID{
 		Owner: string(address.Bytes()),
-		Key:   state.KeyAccountStatus,
+		Key:   state.AccountStatusKey,
 	}
 
 	require.Contains(t, registerTouches, id.String())

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -1302,14 +1302,14 @@ func TestAccountBalanceFields(t *testing.T) {
 				`, address)))
 
 				view := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-					if key == state.KeyAccountStatus {
+					if key == state.AccountStatusKey {
 						return nil, fmt.Errorf("error getting register %s, %s", flow.BytesToAddress([]byte(owner)).Hex(), key)
 					}
 					return nil, nil
 				})
 
 				err := vm.Run(ctx, script, view)
-				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.KeyAccountStatus))
+				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.AccountStatusKey))
 			}),
 	)
 
@@ -1504,14 +1504,14 @@ func TestGetStorageCapacity(t *testing.T) {
 				`, address)))
 
 				newview := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-					if key == state.KeyAccountStatus {
+					if key == state.AccountStatusKey {
 						return nil, fmt.Errorf("error getting register %s, %s", flow.BytesToAddress([]byte(owner)).Hex(), key)
 					}
 					return nil, nil
 				})
 
 				err := vm.Run(ctx, script, newview)
-				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.KeyAccountStatus))
+				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.AccountStatusKey))
 			}),
 	)
 }

--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -13,8 +13,6 @@ import (
 )
 
 const (
-	keyAddressState = "account_address_state"
-
 	FungibleTokenAccountIndex = 2
 	FlowTokenAccountIndex     = 3
 	FlowFeesAccountIndex      = 4
@@ -150,7 +148,7 @@ func NewAccountCreator(
 func (creator *accountCreator) bytes() ([]byte, error) {
 	stateBytes, err := creator.txnState.Get(
 		"",
-		keyAddressState,
+		state.AddressStateKey,
 		creator.txnState.EnforceLimits())
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -197,7 +195,7 @@ func (creator *accountCreator) NextAddress() (flow.Address, error) {
 	// update the ledger state
 	err = creator.txnState.Set(
 		"",
-		keyAddressState,
+		state.AddressStateKey,
 		addressGenerator.Bytes(),
 		creator.txnState.EnforceLimits())
 	if err != nil {

--- a/fvm/environment/account_creator_test.go
+++ b/fvm/environment/account_creator_test.go
@@ -27,7 +27,7 @@ func Test_NewAccountCreator_GeneratingUpdatesState(t *testing.T) {
 	_, err := creator.NextAddress()
 	require.NoError(t, err)
 
-	stateBytes, err := view.Get("", "account_address_state")
+	stateBytes, err := view.Get("", state.AddressStateKey)
 	require.NoError(t, err)
 
 	require.Equal(t, flow.BytesToAddress(stateBytes), flow.HexToAddress("01"))
@@ -35,7 +35,7 @@ func Test_NewAccountCreator_GeneratingUpdatesState(t *testing.T) {
 
 func Test_NewAccountCreator_UsesLedgerState(t *testing.T) {
 	view := utils.NewSimpleView()
-	err := view.Set("", "account_address_state", flow.HexToAddress("01").Bytes())
+	err := view.Set("", state.AddressStateKey, flow.HexToAddress("01").Bytes())
 	require.NoError(t, err)
 
 	chain := flow.MonotonicEmulator.Chain()
@@ -45,7 +45,7 @@ func Test_NewAccountCreator_UsesLedgerState(t *testing.T) {
 	_, err = creator.NextAddress()
 	require.NoError(t, err)
 
-	stateBytes, err := view.Get("", "account_address_state")
+	stateBytes, err := view.Get("", state.AddressStateKey)
 	require.NoError(t, err)
 
 	require.Equal(t, flow.BytesToAddress(stateBytes), flow.HexToAddress("02"))

--- a/fvm/environment/uuids.go
+++ b/fvm/environment/uuids.go
@@ -9,8 +9,6 @@ import (
 	"github.com/onflow/flow-go/utils/slices"
 )
 
-const keyUUID = "uuid"
-
 type UUIDGenerator interface {
 	GenerateUUID() (uint64, error)
 }
@@ -60,7 +58,7 @@ func NewUUIDGenerator(
 func (generator *uUIDGenerator) getUUID() (uint64, error) {
 	stateBytes, err := generator.txnState.Get(
 		"",
-		keyUUID,
+		state.UUIDKey,
 		generator.txnState.EnforceLimits())
 	if err != nil {
 		return 0, fmt.Errorf("cannot get uuid byte from state: %w", err)
@@ -76,7 +74,7 @@ func (generator *uUIDGenerator) setUUID(uuid uint64) error {
 	binary.BigEndian.PutUint64(bytes, uuid)
 	err := generator.txnState.Set(
 		"",
-		keyUUID,
+		state.UUIDKey,
 		bytes,
 		generator.txnState.EnforceLimits())
 	if err != nil {

--- a/fvm/environment/value_store.go
+++ b/fvm/environment/value_store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onflow/atree"
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/trace"
@@ -110,24 +111,34 @@ func NewValueStore(tracer *Tracer, meter Meter, accounts Accounts) ValueStore {
 	}
 }
 
-func (store *valueStore) GetValue(owner []byte, key []byte) ([]byte, error) {
+func (store *valueStore) GetValue(
+	owner []byte,
+	keyBytes []byte,
+) (
+	[]byte,
+	error,
+) {
+	key := string(keyBytes)
+
 	var valueByteSize int
 	span := store.tracer.StartSpanFromRoot(trace.FVMEnvGetValue)
 	defer func() {
 		if !trace.IsSampled(span) {
 			span.SetAttributes(
 				attribute.String("owner", hex.EncodeToString(owner)),
-				attribute.String("key", string(key)),
+				attribute.String("key", key),
 				attribute.Int("valueByteSize", valueByteSize),
 			)
 		}
 		span.End()
 	}()
 
-	v, err := store.accounts.GetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-	)
+	address := flow.BytesToAddress(owner)
+	if state.IsFVMStateKey(string(owner), key) {
+		return nil, errors.NewInvalidFVMStateAccessError(address, key, "read")
+	}
+
+	v, err := store.accounts.GetValue(address, key)
 	if err != nil {
 		return nil, fmt.Errorf("get value failed: %w", err)
 	}
@@ -145,17 +156,24 @@ func (store *valueStore) GetValue(owner []byte, key []byte) ([]byte, error) {
 // TODO disable SetValue for scripts, right now the view changes are discarded
 func (store *valueStore) SetValue(
 	owner []byte,
-	key []byte,
+	keyBytes []byte,
 	value []byte,
 ) error {
+	key := string(keyBytes)
+
 	span := store.tracer.StartSpanFromRoot(trace.FVMEnvSetValue)
 	if !trace.IsSampled(span) {
 		span.SetAttributes(
 			attribute.String("owner", hex.EncodeToString(owner)),
-			attribute.String("key", string(key)),
+			attribute.String("key", key),
 		)
 	}
 	defer span.End()
+
+	address := flow.BytesToAddress(owner)
+	if state.IsFVMStateKey(string(owner), key) {
+		return errors.NewInvalidFVMStateAccessError(address, key, "modify")
+	}
 
 	err := store.meter.MeterComputation(
 		ComputationKindSetValue,
@@ -164,11 +182,7 @@ func (store *valueStore) SetValue(
 		return fmt.Errorf("set value failed: %w", err)
 	}
 
-	err = store.accounts.SetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-		value,
-	)
+	err = store.accounts.SetValue(address, key, value)
 	if err != nil {
 		return fmt.Errorf("set value failed: %w", err)
 	}

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -78,6 +78,7 @@ const (
 	ErrCodeScriptExecutionCancelledError             ErrorCode = 1114
 	ErrCodeScriptExecutionTimedOutError              ErrorCode = 1113
 	ErrCodeEventEncodingError                        ErrorCode = 1115
+	ErrCodeInvalidFVMStateAccessError                ErrorCode = 1116
 
 	// accounts errors 1200 - 1250
 	// Deprecated: No longer used.

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -217,3 +217,18 @@ func NewCouldNotGetExecutionParameterFromStateError(
 		address,
 		path)
 }
+
+// NewInvalidFVMStateAccessError constructs a new CodedError which indicates
+// that the cadence program attempted to directly access fvm's internal state.
+func NewInvalidFVMStateAccessError(
+	address flow.Address,
+	path string,
+	opType string,
+) CodedError {
+	return NewCodedError(
+		ErrCodeInvalidFVMStateAccessError,
+		"could not directly %s fvm internal state (address: %s: path: %s)",
+		opType,
+		address,
+		path)
+}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1495,7 +1495,7 @@ func TestStorageUsed(t *testing.T) {
 	simpleView := utils.NewSimpleView()
 	status := environment.NewAccountStatus()
 	status.SetStorageUsed(5)
-	err = simpleView.Set(string(address), state.KeyAccountStatus, status.ToBytes())
+	err = simpleView.Set(string(address), state.AccountStatusKey, status.ToBytes())
 	require.NoError(t, err)
 
 	script := fvm.Script(code)

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -178,11 +178,15 @@ func TestState_MaxInteraction(t *testing.T) {
 }
 
 func TestState_IsFVMStateKey(t *testing.T) {
-	require.True(t, state.IsFVMStateKey("", "uuid"))
+	require.True(t, state.IsFVMStateKey("", state.UUIDKey))
+	require.True(t, state.IsFVMStateKey("", state.AddressStateKey))
+	require.False(t, state.IsFVMStateKey("", "other"))
+	require.False(t, state.IsFVMStateKey("Address", state.UUIDKey))
+	require.False(t, state.IsFVMStateKey("Address", state.AddressStateKey))
 	require.True(t, state.IsFVMStateKey("Address", "public_key_12"))
-	require.True(t, state.IsFVMStateKey("Address", state.KeyContractNames))
+	require.True(t, state.IsFVMStateKey("Address", state.ContractNamesKey))
 	require.True(t, state.IsFVMStateKey("Address", "code.MYCODE"))
-	require.True(t, state.IsFVMStateKey("Address", state.KeyAccountStatus))
+	require.True(t, state.IsFVMStateKey("Address", state.AccountStatusKey))
 	require.False(t, state.IsFVMStateKey("Address", "anything else"))
 }
 

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -231,14 +231,11 @@ func (s *TransactionState) CommitParseRestricted(
 // transaction may be resume via Resume.
 //
 // WARNING: Pause and Resume are intended for implementing continuation passing
-// style behavior for the transaction invoker, with the assumption that no
-// other transaction processor modify the state (other than the spock and
-// metering). The paused nested transaction should not be reused across
-// transactions.  IT IS NOT SAFE TO PAUSE A NESTED TRANSACTION IN GENERAL SINCE
-// THAT COULD LEAD TO PHANTOM READS.
-//
-// TODO(patrick): Sequence number is modified by the verify tx processor.  Make
-// sure it doesn't interfere with transaction invoker pause / resumption.
+// style behavior for the transaction invoker, with the assumption that the
+// transaction processors access disjoint sets of states prior to transaction
+// invoker resumption.  The paused nested transaction should not be reused
+// across transactions.  IT IS NOT SAFE TO PAUSE A NESTED TRANSACTION IN
+// GENERAL SINCE THAT COULD LEAD TO PHANTOM READS.
 func (s *TransactionState) Pause(
 	expectedId NestedTransactionId,
 ) (


### PR DESCRIPTION
Cadence shouldn't have access to fvm internal state via the value store.  The cadence runtime api as defined today allows arbitrary/unlimited access.