### PR TITLE
[BFT] Add provider engine message validation

### DIFF
--- a/engine/common/provider/internal/entityRequest.go
+++ b/engine/common/provider/internal/entityRequest.go
@@ -3,7 +3,7 @@ package internal
 import "github.com/onflow/flow-go/model/flow"
 
 type EntityRequest struct {
-	OriginId  flow.Identifier
-	EntityIds []flow.Identifier
+	OriginID  flow.Identifier
+	EntityIDs []flow.Identifier
 	Nonce     uint64
 }

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -252,7 +252,7 @@ func (e *Engine) Process(channel channels.Channel, originID flow.Identifier, eve
 		lg := e.log.With().
 			Hex("origin_id", logging.ID(originID)).
 			Str("channel", channel.String()).
-			Str("message_type", fmt.Sprintf("%T", event)).
+			Str("message_type", logging.Type(event)).
 			Logger()
 
 		if engine.IsIncompatibleInputTypeError(err) {

--- a/engine/common/synchronization/request_handler.go
+++ b/engine/common/synchronization/request_handler.go
@@ -95,7 +95,7 @@ func (r *RequestHandler) Process(channel channels.Channel, originID flow.Identif
 		lg := r.log.With().
 			Hex("origin_id", logging.ID(originID)).
 			Str("channel", channel.String()).
-			Str("message_type", fmt.Sprintf("%T", event)).
+			Str("message_type", logging.Type(event)).
 			Logger()
 
 		if engine.IsIncompatibleInputTypeError(err) {

--- a/utils/unittest/logging.go
+++ b/utils/unittest/logging.go
@@ -79,6 +79,14 @@ type LoggerHook struct {
 	mu   *sync.Mutex
 }
 
+// Reset resets the logs
+func (hook LoggerHook) Reset() {
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	hook.logs.Reset()
+}
+
 // Logs returns the logs as a string
 func (hook LoggerHook) Logs() string {
 	hook.mu.Lock()


### PR DESCRIPTION
This PR adds a `MessageHandler` validator to the common provider engine