### PR TITLE
Enforce structural validity for messages in decoder

### DIFF
--- a/model/cluster/block.go
+++ b/model/cluster/block.go
@@ -3,6 +3,9 @@
 package cluster
 
 import (
+	"fmt"
+
+	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -29,6 +32,19 @@ func Genesis() *Block {
 type Block struct {
 	Header  *flow.Header
 	Payload *Payload
+}
+
+func (b *Block) StructureValid() error {
+	if b == nil {
+		return model.NewStructureInvalidError("nil cluster block")
+	}
+	if err := b.Header.StructureValid(); err != nil {
+		return fmt.Errorf("invalid cluster header: %w", err)
+	}
+	if err := b.Payload.StructureValid(); err != nil {
+		return fmt.Errorf("invalid cluster payload: %w", err)
+	}
+	return nil
 }
 
 // ID returns the ID of the underlying block header.

--- a/model/cluster/payload.go
+++ b/model/cluster/payload.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/fingerprint"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -25,6 +26,18 @@ type Payload struct {
 	// members. It is invalid for any non-root block to have an empty reference
 	// block ID.
 	ReferenceBlockID flow.Identifier
+}
+
+func (p *Payload) StructureValid() error {
+	if p == nil {
+		return model.NewStructureInvalidError("nil cluster payload")
+	}
+	for _, tx := range p.Collection.Transactions {
+		if tx == nil {
+			return model.NewStructureInvalidError("nil transaction")
+		}
+	}
+	return nil
 }
 
 // EmptyPayload returns a payload with an empty collection and the given

--- a/model/events/synchronization.go
+++ b/model/events/synchronization.go
@@ -19,13 +19,7 @@ var _ model.StructureValidator = (*SyncedBlock)(nil)
 
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *SyncedBlock) StructureValid() error {
-	if m.Block.Header == nil {
-		return model.NewStructureInvalidError("nil block header")
-	}
-	if m.Block.Payload == nil {
-		return model.NewStructureInvalidError("nil block payload")
-	}
-	return nil
+	return m.Block.StructureValid()
 }
 
 // SyncedClusterBlock is an internal message passed from the chainsync engine to the consensus message hub.
@@ -41,11 +35,5 @@ var _ model.StructureValidator = (*SyncedClusterBlock)(nil)
 
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *SyncedClusterBlock) StructureValid() error {
-	if m.Block.Header == nil {
-		return model.NewStructureInvalidError("nil block header")
-	}
-	if m.Block.Payload == nil {
-		return model.NewStructureInvalidError("nil block payload")
-	}
-	return nil
+	return m.Block.StructureValid()
 }

--- a/model/events/synchronization.go
+++ b/model/events/synchronization.go
@@ -15,6 +15,8 @@ type SyncedBlock struct {
 	Block    *flow.Block
 }
 
+var _ model.StructureValidator = (*SyncedBlock)(nil)
+
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *SyncedBlock) StructureValid() error {
 	if m.Block.Header == nil {
@@ -34,6 +36,8 @@ type SyncedClusterBlock struct {
 	OriginID flow.Identifier
 	Block    *cluster.Block
 }
+
+var _ model.StructureValidator = (*SyncedClusterBlock)(nil)
 
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *SyncedClusterBlock) StructureValid() error {

--- a/model/events/synchronization.go
+++ b/model/events/synchronization.go
@@ -1,16 +1,47 @@
 package events
 
 import (
+	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 )
 
+// SyncedBlock is an internal message passed from the chainsync engine to the consensus message hub.
+// It contains a block obtained through the chainsync protocol.
+// These blocks have not been validated and should be considered untrusted inputs,
+// however they are guaranteed to be structurally valid: StructureValid()==nil
 type SyncedBlock struct {
 	OriginID flow.Identifier
 	Block    *flow.Block
 }
 
+// StructureValid checks basic structural validity of the message and ensures no required fields are nil.
+func (m *SyncedBlock) StructureValid() error {
+	if m.Block.Header == nil {
+		return model.NewStructureInvalidError("nil block header")
+	}
+	if m.Block.Payload == nil {
+		return model.NewStructureInvalidError("nil block payload")
+	}
+	return nil
+}
+
+// SyncedClusterBlock is an internal message passed from the chainsync engine to the consensus message hub.
+// It contains a block obtained through the chainsync protocol.
+// These blocks have not been validated and should be considered untrusted inputs,
+// however they are guaranteed to be structurally valid: StructureValid()==nil
 type SyncedClusterBlock struct {
 	OriginID flow.Identifier
 	Block    *cluster.Block
+}
+
+// StructureValid checks basic structural validity of the message and ensures no required fields are nil.
+func (m *SyncedClusterBlock) StructureValid() error {
+	if m.Block.Header == nil {
+		return model.NewStructureInvalidError("nil block header")
+	}
+	if m.Block.Payload == nil {
+		return model.NewStructureInvalidError("nil block payload")
+	}
+	return nil
 }

--- a/model/flow/block.go
+++ b/model/flow/block.go
@@ -2,6 +2,12 @@
 
 package flow
 
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/model"
+)
+
 func Genesis(chainID ChainID) *Block {
 
 	// create the raw content for the genesis block
@@ -34,6 +40,19 @@ func Genesis(chainID ChainID) *Block {
 type Block struct {
 	Header  *Header
 	Payload *Payload
+}
+
+func (b *Block) StructureValid() error {
+	if b == nil {
+		return model.NewStructureInvalidError("nil block")
+	}
+	if err := b.Header.StructureValid(); err != nil {
+		return fmt.Errorf("invalid block header: %w", err)
+	}
+	if err := b.Payload.StructureValid(); err != nil {
+		return fmt.Errorf("invalid block payload: %w", err)
+	}
+	return nil
 }
 
 // SetPayload sets the payload and updates the payload hash.

--- a/model/flow/header.go
+++ b/model/flow/header.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/vmihailenco/msgpack/v4"
 
+	"github.com/onflow/flow-go/model"
 	cborcodec "github.com/onflow/flow-go/model/encoding/cbor"
 	"github.com/onflow/flow-go/model/fingerprint"
 )
@@ -74,6 +75,13 @@ func (h Header) Body() interface{} {
 		ProposerID:         h.ProposerID,
 		LastViewTCID:       h.LastViewTC.ID(),
 	}
+}
+
+func (h *Header) StructureValid() error {
+	if h == nil {
+		return model.NewStructureInvalidError("nil header")
+	}
+	return nil
 }
 
 func (h Header) Fingerprint() []byte {

--- a/model/flow/payload.go
+++ b/model/flow/payload.go
@@ -2,6 +2,8 @@ package flow
 
 import (
 	"encoding/json"
+
+	"github.com/onflow/flow-go/model"
 )
 
 // Payload is the actual content of each block.
@@ -38,6 +40,33 @@ func (p Payload) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct{ payloadAlias }{
 		payloadAlias: payloadAlias(p),
 	})
+}
+
+func (p *Payload) StructureValid() error {
+	if p == nil {
+		return model.NewStructureInvalidError("nil payload")
+	}
+	for _, guarantee := range p.Guarantees {
+		if guarantee == nil {
+			return model.NewStructureInvalidError("contains nil guarantee")
+		}
+	}
+	for _, seal := range p.Seals {
+		if seal == nil {
+			return model.NewStructureInvalidError("contains nil seal")
+		}
+	}
+	for _, receipt := range p.Receipts {
+		if receipt == nil {
+			return model.NewStructureInvalidError("contains nil receipt")
+		}
+	}
+	for _, result := range p.Results {
+		if result == nil {
+			return model.NewStructureInvalidError("contains nil result")
+		}
+	}
+	return nil
 }
 
 // Hash returns the root hash of the payload.

--- a/model/flow/seal.go
+++ b/model/flow/seal.go
@@ -2,7 +2,9 @@
 
 package flow
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // A Seal is produced when an Execution Result (referenced by `ResultID`) for
 // particular block (referenced by `BlockID`) is committed into the chain.

--- a/model/messages/collection.go
+++ b/model/messages/collection.go
@@ -33,6 +33,8 @@ type ClusterBlockProposal struct {
 	Payload *cluster.Payload
 }
 
+var _ model.StructureValidator = (*ClusterBlockProposal)(nil)
+
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *ClusterBlockProposal) StructureValid() error {
 	if m.Header == nil {

--- a/model/messages/collection.go
+++ b/model/messages/collection.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -30,6 +31,17 @@ type CollectionResponse struct {
 type ClusterBlockProposal struct {
 	Header  *flow.Header
 	Payload *cluster.Payload
+}
+
+// StructureValid checks basic structural validity of the message and ensures no required fields are nil.
+func (m *ClusterBlockProposal) StructureValid() error {
+	if m.Header == nil {
+		return model.NewStructureInvalidError("nil block header")
+	}
+	if m.Payload == nil {
+		return model.NewStructureInvalidError("nil block payload")
+	}
+	return nil
 }
 
 // ClusterBlockVote is a vote for a proposed block in collection node cluster

--- a/model/messages/collection.go
+++ b/model/messages/collection.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
@@ -37,11 +39,11 @@ var _ model.StructureValidator = (*ClusterBlockProposal)(nil)
 
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *ClusterBlockProposal) StructureValid() error {
-	if m.Header == nil {
-		return model.NewStructureInvalidError("nil block header")
+	if err := m.Header.StructureValid(); err != nil {
+		return fmt.Errorf("invalid cluster block header: %w", err)
 	}
-	if m.Payload == nil {
-		return model.NewStructureInvalidError("nil block payload")
+	if err := m.Payload.StructureValid(); err != nil {
+		return fmt.Errorf("invalid cluster block payload: %w", err)
 	}
 	return nil
 }

--- a/model/messages/consensus.go
+++ b/model/messages/consensus.go
@@ -1,14 +1,26 @@
 package messages
 
 import (
+	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// BlockProposal is part of the consensus protocol and represents the the leader
+// BlockProposal is part of the consensus protocol and represents the leader
 // of a consensus round pushing a new proposal to the network.
 type BlockProposal struct {
 	Header  *flow.Header
 	Payload *flow.Payload
+}
+
+// StructureValid checks basic structural validity of the message and ensures no required fields are nil.
+func (m *BlockProposal) StructureValid() error {
+	if m.Header == nil {
+		return model.NewStructureInvalidError("nil block header")
+	}
+	if m.Payload == nil {
+		return model.NewStructureInvalidError("nil block payload")
+	}
+	return nil
 }
 
 // BlockVote is part of the consensus protocol and represents a consensus node

--- a/model/messages/consensus.go
+++ b/model/messages/consensus.go
@@ -14,11 +14,11 @@ type BlockProposal struct {
 
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *BlockProposal) StructureValid() error {
-	if m.Header == nil {
-		return model.NewStructureInvalidError("nil block header")
+	if err := m.Header.StructureValid(); err != nil {
+		return err
 	}
-	if m.Payload == nil {
-		return model.NewStructureInvalidError("nil block payload")
+	if err := m.Payload.StructureValid(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/model/messages/consensus.go
+++ b/model/messages/consensus.go
@@ -23,6 +23,8 @@ func (m *BlockProposal) StructureValid() error {
 	return nil
 }
 
+var _ model.StructureValidator = (*BlockProposal)(nil)
+
 // BlockVote is part of the consensus protocol and represents a consensus node
 // voting on the proposal of the leader of a given round.
 type BlockVote struct {

--- a/model/messages/synchronization.go
+++ b/model/messages/synchronization.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"fmt"
+
 	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
@@ -52,15 +54,12 @@ var _ model.StructureValidator = (*BlockResponse)(nil)
 
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *BlockResponse) StructureValid() error {
+	if len(m.Blocks) == 0 {
+		return model.NewStructureInvalidError("empty block response")
+	}
 	for _, b := range m.Blocks {
-		if b == nil {
-			return model.NewStructureInvalidError("nil block")
-		}
-		if b.Header == nil {
-			return model.NewStructureInvalidError("nil block header")
-		}
-		if b.Payload == nil {
-			return model.NewStructureInvalidError("nil block payload")
+		if err := b.StructureValid(); err != nil {
+			return fmt.Errorf("response contains invalid block: %w", err)
 		}
 	}
 	return nil
@@ -76,15 +75,12 @@ var _ model.StructureValidator = (*ClusterBlockResponse)(nil)
 
 // StructureValid checks basic structural validity of the message and ensures no required fields are nil.
 func (m *ClusterBlockResponse) StructureValid() error {
+	if len(m.Blocks) == 0 {
+		return model.NewStructureInvalidError("empty block response")
+	}
 	for _, b := range m.Blocks {
-		if b == nil {
-			return model.NewStructureInvalidError("nil block")
-		}
-		if b.Header == nil {
-			return model.NewStructureInvalidError("nil block header")
-		}
-		if b.Payload == nil {
-			return model.NewStructureInvalidError("nil block payload")
+		if err := b.StructureValid(); err != nil {
+			return fmt.Errorf("response contains invalid block: %w", err)
 		}
 	}
 	return nil

--- a/model/messages/synchronization.go
+++ b/model/messages/synchronization.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"github.com/onflow/flow-go/model"
 	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -47,9 +48,44 @@ type BlockResponse struct {
 	Blocks []*flow.Block
 }
 
-// ClusterBlockResponse is the same thing as BlockResponse, but for cluster
-// consensus.
+var _ model.StructureValidator = (*BlockResponse)(nil)
+
+// StructureValid checks basic structural validity of the message and ensures no required fields are nil.
+func (m *BlockResponse) StructureValid() error {
+	for _, b := range m.Blocks {
+		if b == nil {
+			return model.NewStructureInvalidError("nil block")
+		}
+		if b.Header == nil {
+			return model.NewStructureInvalidError("nil block header")
+		}
+		if b.Payload == nil {
+			return model.NewStructureInvalidError("nil block payload")
+		}
+	}
+	return nil
+}
+
+// ClusterBlockResponse is the same thing as BlockResponse, but for cluster consensus.
 type ClusterBlockResponse struct {
 	Nonce  uint64
 	Blocks []*cluster.Block
+}
+
+var _ model.StructureValidator = (*ClusterBlockResponse)(nil)
+
+// StructureValid checks basic structural validity of the message and ensures no required fields are nil.
+func (m *ClusterBlockResponse) StructureValid() error {
+	for _, b := range m.Blocks {
+		if b == nil {
+			return model.NewStructureInvalidError("nil block")
+		}
+		if b.Header == nil {
+			return model.NewStructureInvalidError("nil block header")
+		}
+		if b.Payload == nil {
+			return model.NewStructureInvalidError("nil block payload")
+		}
+	}
+	return nil
 }

--- a/model/validity.go
+++ b/model/validity.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+)
+
+// StructureInvalidError is returned by a StructureValidator if the
+type StructureInvalidError struct {
+	err error
+}
+
+func NewStructureInvalidError(msg string, args ...interface{}) error {
+	return StructureInvalidError{
+		err: fmt.Errorf(msg, args...),
+	}
+}
+
+func (e StructureInvalidError) Unwrap() error {
+	return e.err
+}
+
+func (e StructureInvalidError) Error() string {
+	return e.err.Error()
+}
+
+func IsStructureInvalidError(err error) bool {
+	var structureInvalidErr StructureInvalidError
+	return errors.As(err, &structureInvalidErr)
+}
+
+// StructureValidator is a model type which exposes a method to validate basic structural
+// validity of a message or model. This DOES NOT enforce business logic rules,
+// it only enforces that required fields are non-nil and no fields are malformed.
+type StructureValidator interface {
+	// StructureValid validates the model's basic structural validity: all required fields
+	// are non-nil and well-formed. It does NOT enforce business logic rules.
+	// Implementations must be non-blocking and computationally inexpensive, because
+	// structural validity is enforced early in the message processing flow.
+	// Returns StructureInvalidError if the model is structurally invalid.
+	StructureValid() error
+}

--- a/model/validity.go
+++ b/model/validity.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 )
 
-// StructureInvalidError is returned by a StructureValidator if the
+// StructureInvalidError is returned by a model implementing StructureValidator
+// if the model is structurally or syntactically invalid. For example, if a
+// required field is nil or malformed.
 type StructureInvalidError struct {
 	err error
 }
@@ -32,6 +34,7 @@ func IsStructureInvalidError(err error) bool {
 // StructureValidator is a model type which exposes a method to validate basic structural
 // validity of a message or model. This DOES NOT enforce business logic rules,
 // it only enforces that required fields are non-nil and no fields are malformed.
+// If a message fails structure validation, the sender can be slashed.
 type StructureValidator interface {
 	// StructureValid validates the model's basic structural validity: all required fields
 	// are non-nil and well-formed. It does NOT enforce business logic rules.

--- a/model/validity_test.go
+++ b/model/validity_test.go
@@ -1,0 +1,12 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsStructureInvalidError(t *testing.T) {
+	err := NewStructureInvalidError("")
+	assert.True(t, IsStructureInvalidError(err))
+}

--- a/network/codec.go
+++ b/network/codec.go
@@ -6,28 +6,40 @@ import (
 	"io"
 )
 
-// Codec provides factory functions for encoders and decoders.
+// Codec provides factory functions for encoders and decoders and utility functions
+// for encoding and decoding.
 type Codec interface {
+	// NewEncoder returns a new encoder instance which encodes into the input writer w.
 	NewEncoder(w io.Writer) Encoder
+	// NewDecoder returns a new decoder instance which decodes into the input reader r.
 	NewDecoder(r io.Reader) Decoder
+	// Encode encodes the input value and returns the encoded bytes.
+	// No errors are expected during normal operation
 	Encode(v interface{}) ([]byte, error)
-
-	// Decode decodes a message.
+	// Decode decodes from the input bytes and returns the decoded value.
 	// Expected error returns during normal operations:
-	//  * codec.UnknownMsgCodeErr if message code byte does not match any of the configured message codes.
-	//  * codec.ErrMsgUnmarshal if the codec fails to unmarshal the data to the message type denoted by the message code.
+	//   - codec.ErrUnknownMsgCode if message code byte does not match any of the configured message codes.
+	//   - codec.ErrMsgUnmarshal if the codec fails to unmarshal the data to the message type denoted by the message code.
 	Decode(data []byte) (interface{}, error)
 }
 
 // Encoder encodes the given message into the underlying writer.
 type Encoder interface {
+	// Encode encodes the input value into the underlying writer.
+	// No errors are expected during normal operation
 	Encode(v interface{}) error
 }
 
 // Decoder decodes from the underlying reader into the given message.
+// Decoder implementations must enforce structural validity for any decoded Go types
+// which implement model.StructureValidator.
 // Expected error returns during normal operations:
-//   - codec.UnknownMsgCodeErr if message code byte does not match any of the configured message codes.
+//   - codec.ErrUnknownMsgCode if message code byte does not match any of the configured message codes.
 //   - codec.ErrMsgUnmarshal if the codec fails to unmarshal the data to the message type denoted by the message code.
 type Decoder interface {
+	// Decode decodes a message and validates the resulting type's structural validity, if possible.
+	// Expected error returns during normal operations:
+	//  * codec.ErrUnknownMsgCode if message code byte does not match any of the configured message codes.
+	//  * codec.ErrMsgUnmarshal if the codec fails to unmarshal the data to the message type denoted by the message code.
 	Decode() (interface{}, error)
 }

--- a/network/codec/cbor/codec.go
+++ b/network/codec/cbor/codec.go
@@ -107,9 +107,6 @@ func (c *Codec) Decode(data []byte) (interface{}, error) {
 		return nil, codec.NewMsgUnmarshalErr(data[0], what, err)
 	}
 
-	// TODO consider downsides of having this here:
-	//  - performance?
-	//  - surface area for unexpected errors from many StructureValidator impls?
 	if validatable, ok := msgInterface.(model.StructureValidator); ok {
 		if err := validatable.StructureValid(); err != nil {
 			if model.IsStructureInvalidError(err) {

--- a/network/codec/cbor/codec_test.go
+++ b/network/codec/cbor/codec_test.go
@@ -1,0 +1,70 @@
+package cbor_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model"
+	"github.com/onflow/flow-go/model/messages"
+	pkgcodec "github.com/onflow/flow-go/network/codec"
+	"github.com/onflow/flow-go/network/codec/cbor"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestEncodeDecode_Nil ensures that, if the codec successfully decodes a message,
+// the return value is not nil.
+func TestEncodeDecode_Nil(t *testing.T) {
+	codec := cbor.NewCodec()
+	msg := (*messages.BlockProposal)(nil)
+	encoded, err := codec.Encode(msg)
+	require.NoError(t, err)
+	decoded, err := codec.Decode(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, decoded)
+}
+
+// TestEncodeDecode_StructureValid ensures that the codec enforces structural validity
+// rules for a successfully decoded message, when the underlying Go type implements
+// model.StructureValidator.
+func TestEncodeDecode_StructureValid(t *testing.T) {
+	codec := cbor.NewCodec()
+
+	// message with valid structure should be decoded as usual
+	t.Run("valid structure", func(t *testing.T) {
+		msg := &messages.BlockResponse{
+			Nonce:  rand.Uint64(),
+			Blocks: unittest.BlockFixtures(5),
+		}
+		// sanity check - ensure message type is a model.StructureValidator and passes validation
+		var _ model.StructureValidator = msg
+		require.NoError(t, msg.StructureValid())
+
+		encoded, err := codec.Encode(msg)
+		require.NoError(t, err)
+		decoded, err := codec.Decode(encoded)
+		require.NoError(t, err)
+		require.Equal(t, msg, decoded)
+	})
+	// otherwise decodable message with invalid structure should return codec.ErrMsgUnmarshal
+	t.Run("invalid structure", func(t *testing.T) {
+		msg := &messages.BlockResponse{
+			Nonce:  rand.Uint64(),
+			Blocks: unittest.BlockFixtures(5),
+		}
+		msg.Blocks[3].Payload = nil // a nil required field is an invalid structure
+
+		// sanity check - ensure message type is a model.StructureValidator and fails validation
+		var _ model.StructureValidator = msg
+		err := msg.StructureValid()
+		require.Error(t, err)
+		require.True(t, model.IsStructureInvalidError(err))
+
+		encoded, err := codec.Encode(msg)
+		require.NoError(t, err)
+		_, err = codec.Decode(encoded)
+		require.Error(t, err)
+		require.True(t, pkgcodec.IsErrMsgUnmarshal(err))
+	})
+}

--- a/network/codec/cbor/decoder.go
+++ b/network/codec/cbor/decoder.go
@@ -47,9 +47,6 @@ func (d *Decoder) Decode() (interface{}, error) {
 		return nil, codec.NewMsgUnmarshalErr(data[0], what, err)
 	}
 
-	// TODO consider downsides of having this here:
-	//  - performance?
-	//  - surface area for unexpected errors from many StructureValidator impls?
 	if validatable, ok := msgInterface.(model.StructureValidator); ok {
 		if err := validatable.StructureValid(); err != nil {
 			if model.IsStructureInvalidError(err) {

--- a/network/engine.go
+++ b/network/engine.go
@@ -40,11 +40,12 @@ type Engine interface {
 	Process(channel channels.Channel, originID flow.Identifier, event interface{}) error
 }
 
-// MessageProcessor represents a component which receives messages from the
-// networking layer. Since these messages come from other nodes, which may
-// be Byzantine, implementations must expect and handle arbitrary message inputs
-// (including invalid message types, malformed messages, etc.). Because of this,
-// node-internal messages should NEVER be submitted to a component using Process.
+// MessageProcessor represents a component which receives messages from the networking layer.
+// Since these messages come from other nodes, which may be Byzantine, implementations must expect
+// and handle arbitrary message inputs (including invalid message types, malformed messages, etc.).
+// Because of this, node-internal messages should NEVER be submitted to a component using Process.
+// If a message type implements model.StructureValidator, MessageProcessor implementations may
+// assume that Process will only be invoked for messages which pass structural validation checks.
 type MessageProcessor interface {
 	Process(channel channels.Channel, originID flow.Identifier, message interface{}) error
 }

--- a/state/cluster/badger/mutator.go
+++ b/state/cluster/badger/mutator.go
@@ -44,8 +44,11 @@ func NewMutableState(state *State, tracer module.Tracer, headers storage.Headers
 //   - state.InvalidExtensionError if the candidate block is invalid
 func (m *MutableState) Extend(block *cluster.Block) error {
 
-	blockID := block.ID()
+	if err := block.StructureValid(); err != nil {
+		return state.NewInvalidExtensionErrorf("invalid block structure: %w", err)
+	}
 
+	blockID := block.ID()
 	span, ctx, _ := m.tracer.StartCollectionSpan(context.Background(), blockID, trace.COLClusterStateMutatorExtend)
 	defer span.End()
 

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -247,6 +247,12 @@ func (suite *MutatorSuite) TestExtend_InvalidChainID() {
 	suite.Assert().Error(err)
 }
 
+func (suite *MutatorSuite) TestExtend_InvalidStructure() {
+	err := suite.state.Extend(nil)
+	suite.Assert().Error(err)
+	suite.Assert().True(state.IsInvalidExtensionError(err))
+}
+
 func (suite *MutatorSuite) TestExtend_InvalidBlockNumber() {
 	block := suite.Block()
 	// change the block height

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -336,6 +336,25 @@ func TestExtendMissingParent(t *testing.T) {
 	})
 }
 
+func TestExtend_StructureInvalid(t *testing.T) {
+	rootSnapshot := unittest.RootSnapshotFixture(participants)
+
+	t.Run("mutable state", func(t *testing.T) {
+		util.RunWithFullProtocolState(t, rootSnapshot, func(db *badger.DB, state *protocol.MutableState) {
+			err := state.Extend(context.Background(), nil)
+			require.Error(t, err)
+			require.True(t, st.IsInvalidExtensionError(err))
+		})
+	})
+	t.Run("follower state", func(t *testing.T) {
+		util.RunWithFollowerProtocolState(t, rootSnapshot, func(db *badger.DB, state *protocol.FollowerState) {
+			err := state.Extend(context.Background(), nil)
+			require.Error(t, err)
+			require.True(t, st.IsInvalidExtensionError(err))
+		})
+	})
+}
+
 func TestExtendHeightTooSmall(t *testing.T) {
 	rootSnapshot := unittest.RootSnapshotFixture(participants)
 	util.RunWithFullProtocolState(t, rootSnapshot, func(db *badger.DB, state *protocol.MutableState) {


### PR DESCRIPTION
Based on https://github.com/onflow/flow-go/issues/3374 (1, 2 - nil message field checking).

* Adds interface for basic message structural validity: `model.StructureValidator`
* Modifies `network.Codec` to enforce structural validity for messages implementing this interface during decoding. This way we can assume any message which passes the network layer (once it arrives at `MessageProcessor.Process`) passes basic structural/syntactic validation
* Implements `StructureValidator` for consensus-related messages 
* Adds structural validity checks to protocol state and cluster state