### PR TITLE
[FVM] Use empty programs during bootstrapping

### DIFF
--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -22,7 +22,6 @@ import (
 type BootstrapProcedure struct {
 	ctx       Context
 	txnState  *state.TransactionState
-	programs  *programs.TransactionPrograms
 	rootBlock *flow.Header
 
 	// genesis parameters
@@ -244,14 +243,13 @@ func Bootstrap(
 func (b *BootstrapProcedure) Run(
 	ctx Context,
 	txnState *state.TransactionState,
-	programs *programs.TransactionPrograms,
+	_ *programs.TransactionPrograms,
 ) error {
 	b.ctx = NewContextFromParent(
 		ctx,
 		WithContractDeploymentRestricted(false))
 	b.rootBlock = flow.Genesis(flow.ChainID(ctx.Chain.String())).Header
 	b.txnState = txnState
-	b.programs = programs
 
 	// initialize the account addressing state
 	b.accountCreator = environment.NewBootstrapAccountCreator(
@@ -373,8 +371,6 @@ func (b *BootstrapProcedure) deployFungibleToken() flow.Address {
 		Transaction(
 			blueprints.DeployFungibleTokenContractTransaction(fungibleToken),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy fungible token contract: %s", txError, err)
 	return fungibleToken
@@ -390,8 +386,6 @@ func (b *BootstrapProcedure) deployFlowToken(service, fungibleToken flow.Address
 				fungibleToken,
 				flowToken),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy Flow token contract: %s", txError, err)
 	return flowToken
@@ -410,8 +404,6 @@ func (b *BootstrapProcedure) deployFlowFees(service, fungibleToken, flowToken fl
 				flowFees,
 			),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy fees contract: %s", txError, err)
 	return flowFees
@@ -431,8 +423,6 @@ func (b *BootstrapProcedure) deployStorageFees(service, fungibleToken, flowToken
 				service,
 				contract),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy storage fees contract: %s", txError, err)
 }
@@ -449,8 +439,6 @@ func (b *BootstrapProcedure) deployContractAuditVouchers(service flow.Address) {
 				contract,
 				"FlowContractAudits"),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy contract audit vouchers contract: %s", txError, err)
 }
@@ -463,8 +451,6 @@ func (b *BootstrapProcedure) createMinter(service, flowToken flow.Address) {
 				service,
 				flowToken),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to create flow token minter: %s", txError, err)
 }
@@ -477,8 +463,6 @@ func (b *BootstrapProcedure) deployDKG(service flow.Address) {
 			blueprints.DeployContractTransaction(service, contract, "FlowDKG"),
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy DKG contract: %s", txError, err)
 }
@@ -491,8 +475,6 @@ func (b *BootstrapProcedure) deployQC(service flow.Address) {
 			blueprints.DeployContractTransaction(service, contract, "FlowClusterQC"),
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy QC contract: %s", txError, err)
 }
@@ -514,8 +496,6 @@ func (b *BootstrapProcedure) deployIDTableStaking(service, fungibleToken, flowTo
 				b.epochConfig.RewardCut),
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy IDTableStaking contract: %s", txError, err)
 }
@@ -542,8 +522,6 @@ func (b *BootstrapProcedure) deployEpoch(service, fungibleToken, flowToken, flow
 			blueprints.DeployEpochTransaction(service, contract, b.epochConfig),
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy Epoch contract: %s", txError, err)
 }
@@ -564,8 +542,6 @@ func (b *BootstrapProcedure) deployServiceAccount(service, fungibleToken, flowTo
 				contract,
 				"FlowServiceAccount"),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy service account contract: %s", txError, err)
 }
@@ -583,8 +559,6 @@ func (b *BootstrapProcedure) mintInitialTokens(
 				service,
 				initialSupply),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to mint initial token supply: %s", txError, err)
 }
@@ -607,8 +581,6 @@ func (b *BootstrapProcedure) setupParameters(
 				restrictedAccountCreationEnabled,
 			),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to setup parameters: %s", txError, err)
 }
@@ -625,8 +597,6 @@ func (b *BootstrapProcedure) setupFees(service, flowFees flow.Address, surgeFact
 				executionEffortCost,
 			),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to setup fees: %s", txError, err)
 }
@@ -663,8 +633,6 @@ func (b *BootstrapProcedure) setupExecutionEffortWeights(service flow.Address) {
 		Transaction(
 			tb,
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to setup execution effort weights: %s", txError, err)
 }
@@ -687,8 +655,6 @@ func (b *BootstrapProcedure) setupExecutionMemoryWeights(service flow.Address) {
 		Transaction(
 			tb,
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to setup execution memory weights: %s", txError, err)
 }
@@ -705,8 +671,6 @@ func (b *BootstrapProcedure) setExecutionMemoryLimitTransaction(service flow.Add
 		Transaction(
 			tb,
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to setup execution memory limit: %s", txError, err)
 }
@@ -723,8 +687,6 @@ func (b *BootstrapProcedure) setupStorageForServiceAccounts(
 				flowToken,
 				feeContract),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to setup storage for service accounts: %s", txError, err)
 }
@@ -739,8 +701,6 @@ func (b *BootstrapProcedure) setStakingAllowlist(service flow.Address, allowedID
 				allowedIDs,
 			),
 			0),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to set staking allow-list: %s", txError, err)
 }
@@ -760,8 +720,6 @@ func (b *BootstrapProcedure) registerNodes(service, fungibleToken, flowToken flo
 					nodeAddress),
 				0,
 			),
-			b.txnState,
-			b.programs,
 		)
 		panicOnMetaInvokeErrf("failed to setup machine account: %s", txError, err)
 
@@ -773,8 +731,6 @@ func (b *BootstrapProcedure) registerNodes(service, fungibleToken, flowToken flo
 				flowToken,
 				nodeAddress),
 				0),
-			b.txnState,
-			b.programs,
 		)
 		panicOnMetaInvokeErrf("failed to fund node staking account: %s", txError, err)
 
@@ -788,8 +744,6 @@ func (b *BootstrapProcedure) registerNodes(service, fungibleToken, flowToken flo
 				nodeAddress,
 				id),
 				0),
-			b.txnState,
-			b.programs,
 		)
 		panicOnMetaInvokeErrf("failed to register node: %s", txError, err)
 	}
@@ -803,8 +757,6 @@ func (b *BootstrapProcedure) deployStakingProxyContract(service flow.Address) {
 			blueprints.DeployContractTransaction(service, contract, "StakingProxy"),
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy StakingProxy contract: %s", txError, err)
 }
@@ -830,8 +782,6 @@ func (b *BootstrapProcedure) deployLockedTokensContract(service flow.Address, fu
 			blueprints.DeployLockedTokensTransaction(service, contract, publicKeys),
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 
 	panicOnMetaInvokeErrf("failed to deploy LockedTokens contract: %s", txError, err)
@@ -854,8 +804,6 @@ func (b *BootstrapProcedure) deployStakingCollection(service flow.Address, fungi
 			blueprints.DeployContractTransaction(service, contract, "FlowStakingCollection"),
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy FlowStakingCollection contract: %s", txError, err)
 }
@@ -875,8 +823,6 @@ func (b *BootstrapProcedure) setContractDeploymentRestrictions(service flow.Addr
 			txBody,
 			0,
 		),
-		b.txnState,
-		b.programs,
 	)
 	panicOnMetaInvokeErrf("failed to deploy FlowStakingCollection contract: %s", txError, err)
 }
@@ -909,8 +855,6 @@ func FlowTokenAddress(chain flow.Chain) flow.Address {
 func (b *BootstrapProcedure) invokeMetaTransaction(
 	parentCtx Context,
 	tx *TransactionProcedure,
-	txnState *state.TransactionState,
-	programs *programs.TransactionPrograms,
 ) (
 	errors.CodedError,
 	error,
@@ -923,7 +867,18 @@ func (b *BootstrapProcedure) invokeMetaTransaction(
 		WithTransactionFeesEnabled(false),
 	)
 
-	err := invoker.Process(ctx, tx, txnState, programs)
+	// use new programs for each meta transaction.
+	// It's not necessary to use a program cache during bootstrapping and most transactions are contract deploys anyway.
+	prog, err := programs.
+		NewEmptyBlockPrograms().
+		NewTransactionPrograms(0, 0)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = invoker.Process(ctx, tx, b.txnState, prog)
 	txErr, fatalErr := errors.SplitErrorTypes(err)
+
 	return txErr, fatalErr
 }


### PR DESCRIPTION
prerequisite for: onflow/flow-go#2767

It doesn't make sense to use the programs cache during bootstrapping.
Avery transaction is a new deploy, and the speed isn't needed.