### PR TITLE
Collect fees on tx seq num / verify non-fatal error

### DIFF
--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -923,7 +923,7 @@ func (b *BootstrapProcedure) invokeMetaTransaction(
 		WithTransactionFeesEnabled(false),
 	)
 
-	err := invoker.Process(ctx, tx, txnState, programs)
-	txErr, fatalErr := errors.SplitErrorTypes(err)
-	return txErr, fatalErr
+	errs := errors.NewErrorsCollector()
+	invoker.Process(ctx, tx, txnState, programs, errs)
+	return errors.SplitErrorTypes(errs.ErrorOrNil())
 }

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -46,8 +47,9 @@ func TestSafetyCheck(t *testing.T) {
 		txnPrograms, err := blockPrograms.NewTransactionPrograms(0, 0)
 		require.NoError(t, err)
 
-		err = txInvoker.Process(context, proc, txnState, txnPrograms)
-		require.Error(t, err)
+		errs := errors.NewErrorsCollector()
+		txInvoker.Process(context, proc, txnState, txnPrograms, errs)
+		require.Error(t, errs.ErrorOrNil())
 
 		require.NotContains(t, buffer.String(), "programs")
 		require.NotContains(t, buffer.String(), "codes")
@@ -79,8 +81,9 @@ func TestSafetyCheck(t *testing.T) {
 		txnPrograms, err := blockPrograms.NewTransactionPrograms(0, 0)
 		require.NoError(t, err)
 
-		err = txInvoker.Process(context, proc, txnState, txnPrograms)
-		require.Error(t, err)
+		errs := errors.NewErrorsCollector()
+		txInvoker.Process(context, proc, txnState, txnPrograms, errs)
+		require.Error(t, errs.ErrorOrNil())
 
 		require.NotContains(t, buffer.String(), "programs")
 		require.NotContains(t, buffer.String(), "codes")

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -22,13 +22,13 @@ func (c *TransactionSequenceNumberChecker) Process(
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
 	_ *programs.TransactionPrograms,
-) error {
+	errorsCollector *errors.ErrorsCollector,
+) {
 	err := c.checkAndIncrementSequenceNumber(proc, ctx, txnState)
 	if err != nil {
-		return fmt.Errorf("checking sequence number failed: %w", err)
+		errorsCollector.Collect(
+			fmt.Errorf("checking sequence number failed: %w", err))
 	}
-
-	return nil
 }
 
 func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(

--- a/fvm/transactionSequenceNum_test.go
+++ b/fvm/transactionSequenceNum_test.go
@@ -31,9 +31,11 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		tx.SetProposalKey(address, 0, 0)
 		proc := fvm.Transaction(&tx, 0)
 
+		errs := errors.NewErrorsCollector()
+
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(fvm.Context{}, proc, txnState, nil)
-		require.NoError(t, err)
+		seqChecker.Process(fvm.Context{}, proc, txnState, nil, errs)
+		require.NoError(t, errs.ErrorOrNil())
 
 		// get fetch the sequence number and it should be updated
 		key, err := accounts.GetPublicKey(address, 0)
@@ -57,8 +59,11 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		tx.SetProposalKey(address, 0, 2)
 		proc := fvm.Transaction(&tx, 0)
 
+		errs := errors.NewErrorsCollector()
+
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(fvm.Context{}, proc, txnState, nil)
+		seqChecker.Process(fvm.Context{}, proc, txnState, nil, errs)
+		err = errs.ErrorOrNil()
 		require.Error(t, err)
 		require.True(t, errors.HasErrorCode(err, errors.ErrCodeInvalidProposalSeqNumberError))
 
@@ -84,9 +89,11 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		tx.SetProposalKey(flow.HexToAddress("2222"), 0, 0)
 		proc := fvm.Transaction(&tx, 0)
 
+		errs := errors.NewErrorsCollector()
+
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(fvm.Context{}, proc, txnState, nil)
-		require.Error(t, err)
+		seqChecker.Process(fvm.Context{}, proc, txnState, nil, errs)
+		require.Error(t, errs.ErrorOrNil())
 
 		// get fetch the sequence number and check it to be unchanged
 		key, err := accounts.GetPublicKey(address, 0)

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -36,13 +36,13 @@ func (v *TransactionVerifier) Process(
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
 	_ *programs.TransactionPrograms,
-) error {
+	errorsCollector *errors.ErrorsCollector,
+) {
 	err := v.verifyTransaction(proc, ctx, txnState)
 	if err != nil {
-		return fmt.Errorf("transaction verification failed: %w", err)
+		errorsCollector.Collect(
+			fmt.Errorf("transaction verification failed: %w", err))
 	}
-
-	return nil
 }
 
 func (v *TransactionVerifier) verifyTransaction(

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -87,8 +87,9 @@ func TestAccountFreezing(t *testing.T) {
 		txnPrograms, err := blockPrograms.NewTransactionPrograms(0, 0)
 		require.NoError(t, err)
 
-		err = txInvoker.Process(context, proc, st, txnPrograms)
-		require.NoError(t, err)
+		errs := errors.NewErrorsCollector()
+		txInvoker.Process(context, proc, st, txnPrograms, errs)
+		require.NoError(t, errs.ErrorOrNil())
 
 		// account should be frozen now
 		frozen, err = accounts.GetAccountFrozen(address)
@@ -515,9 +516,10 @@ func TestAccountFreezing(t *testing.T) {
 		txnPrograms, err := blockPrograms.NewTransactionPrograms(0, 0)
 		require.NoError(t, err)
 
+		errs := errors.NewErrorsCollector()
 		txInvoker := fvm.NewTransactionInvoker()
-		err = txInvoker.Process(context, proc, st, txnPrograms)
-		require.NoError(t, err)
+		txInvoker.Process(context, proc, st, txnPrograms, errs)
+		require.NoError(t, errs.ErrorOrNil())
 
 		// make sure freeze status is correct
 		var frozen bool


### PR DESCRIPTION
A single errors collector is shared by all transaction processor.  This enables the transaction invoker to detect tx seq num / verify errors and collect fees using the errorExecution path (the normalExecution path is skipped)

Note: I plan replace the processor loop in TransactionProcedure with a linear workflow.  It's hard to reason across processors.