### PR TITLE
[Network] Stop sending unused message.Message fields

### DIFF
--- a/network/internal/messageutils/utils.go
+++ b/network/internal/messageutils/utils.go
@@ -9,14 +9,19 @@ import (
 	libp2pmessage "github.com/onflow/flow-go/model/libp2p/message"
 	"github.com/onflow/flow-go/network/channels"
 	"github.com/onflow/flow-go/network/message"
+	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-func CreateMessage(t *testing.T, targetID flow.Identifier, channel channels.Channel, msg string) (*message.Message, interface{}) {
+func CreateMessage(t *testing.T, originID flow.Identifier, targetID flow.Identifier, channel channels.Channel, msg string) (*message.Message, *message.Message, interface{}) {
 	payload := &libp2pmessage.TestMessage{
 		Text: msg,
 	}
 
+	return CreateMessageWithPayload(t, originID, targetID, channel, payload)
+}
+
+func CreateMessageWithPayload(t *testing.T, originID flow.Identifier, targetID flow.Identifier, channel channels.Channel, payload interface{}) (*message.Message, *message.Message, interface{}) {
 	codec := unittest.NetworkCodec()
 	b, err := codec.Encode(payload)
 	require.NoError(t, err)
@@ -27,5 +32,18 @@ func CreateMessage(t *testing.T, targetID flow.Identifier, channel channels.Chan
 		Payload:   b,
 	}
 
-	return m, payload
+	eventID, err := p2p.EventId(channel, m.Payload)
+	require.NoError(t, err)
+
+	// this is the message after all network processing. i.e. what is passed to network.Receive
+	outputMsg := &message.Message{
+		ChannelID: m.ChannelID,
+		TargetIDs: m.TargetIDs,
+		Payload:   m.Payload,
+		EventID:   eventID,
+		OriginID:  originID[:],
+		Type:      p2p.MessageType(payload),
+	}
+
+	return m, outputMsg, payload
 }

--- a/network/internal/messageutils/utils.go
+++ b/network/internal/messageutils/utils.go
@@ -9,11 +9,10 @@ import (
 	libp2pmessage "github.com/onflow/flow-go/model/libp2p/message"
 	"github.com/onflow/flow-go/network/channels"
 	"github.com/onflow/flow-go/network/message"
-	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-func CreateMessage(t *testing.T, originID flow.Identifier, targetID flow.Identifier, channel channels.Channel, msg string) (*message.Message, interface{}) {
+func CreateMessage(t *testing.T, targetID flow.Identifier, channel channels.Channel, msg string) (*message.Message, interface{}) {
 	payload := &libp2pmessage.TestMessage{
 		Text: msg,
 	}
@@ -22,16 +21,10 @@ func CreateMessage(t *testing.T, originID flow.Identifier, targetID flow.Identif
 	b, err := codec.Encode(payload)
 	require.NoError(t, err)
 
-	eventID, err := p2p.EventId(channel, b)
-	require.NoError(t, err)
-
 	m := &message.Message{
 		ChannelID: channel.String(),
-		EventID:   eventID,
-		OriginID:  originID[:],
 		TargetIDs: [][]byte{targetID[:]},
 		Payload:   b,
-		Type:      p2p.MessageType(payload),
 	}
 
 	return m, payload

--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -378,34 +378,17 @@ func (n *Network) genNetworkMessage(channel channels.Channel, event interface{},
 	//bs := binstat.EnterTimeVal(binstat.BinNet+":wire<3payload2message", int64(len(payload)))
 	//defer binstat.Leave(bs)
 
-	eventId, err := EventId(channel, payload)
-	if err != nil {
-		return nil, fmt.Errorf("could not generate event id for message: %x", err)
-	}
-
 	var emTargets [][]byte
 	for _, targetID := range targetIDs {
 		tempID := targetID // avoid capturing loop variable
 		emTargets = append(emTargets, tempID[:])
 	}
 
-	// get origin ID
-	selfID := n.me.NodeID()
-	originID := selfID[:]
-
-	// get message type from event type and remove the asterisk prefix if present
-	msgType := MessageType(event)
-
 	// cast event to a libp2p.Message
 	msg := &message.Message{
 		ChannelID: channel.String(),
 		TargetIDs: emTargets,
 		Payload:   payload,
-
-		// TODO: these fields should be derived by the receiver and removed from the message
-		EventID:  eventId,
-		OriginID: originID,
-		Type:     msgType,
 	}
 
 	return msg, nil

--- a/network/p2p/test/sporking_test.go
+++ b/network/p2p/test/sporking_test.go
@@ -15,12 +15,11 @@ import (
 
 	"github.com/onflow/flow-go/network/p2p/utils"
 
-	libp2pmessage "github.com/onflow/flow-go/model/libp2p/message"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/network/channels"
+	"github.com/onflow/flow-go/network/internal/messageutils"
 	"github.com/onflow/flow-go/network/internal/p2pfixtures"
-	"github.com/onflow/flow-go/network/message"
 	flowpubsub "github.com/onflow/flow-go/network/validator/pubsub"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -304,15 +303,8 @@ func testOneToKMessagingFails(ctx context.Context,
 }
 
 func createTestMessage(t *testing.T) []byte {
-	b, err := unittest.NetworkCodec().Encode(&libp2pmessage.TestMessage{
-		Text: "hello",
-	})
-	require.NoError(t, err)
+	msg, _, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), unittest.IdentifierFixture(), channels.TestNetworkChannel, "hello")
 
-	msg := &message.Message{
-		ChannelID: channels.TestNetworkChannel.String(),
-		Payload:   b,
-	}
 	payload, err := msg.Marshal()
 	require.NoError(t, err)
 

--- a/network/p2p/unicast/ratelimit/bandwidth_rate_limiter_test.go
+++ b/network/p2p/unicast/ratelimit/bandwidth_rate_limiter_test.go
@@ -33,7 +33,7 @@ func TestBandWidthRateLimiter_Allow(t *testing.T) {
 		b[i] = byte('X')
 	}
 
-	msg, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
+	msg, _, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
 
 	allowed := bandwidthRateLimiter.Allow(peerID, msg)
 	require.True(t, allowed)
@@ -78,7 +78,7 @@ func TestBandWidthRateLimiter_IsRateLimited(t *testing.T) {
 
 	require.False(t, bandwidthRateLimiter.IsRateLimited(peerID))
 
-	msg, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
+	msg, _, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
 	allowed := bandwidthRateLimiter.Allow(peerID, msg)
 	require.False(t, allowed)
 	require.True(t, bandwidthRateLimiter.IsRateLimited(peerID))

--- a/network/p2p/unicast/ratelimit/bandwidth_rate_limiter_test.go
+++ b/network/p2p/unicast/ratelimit/bandwidth_rate_limiter_test.go
@@ -33,7 +33,7 @@ func TestBandWidthRateLimiter_Allow(t *testing.T) {
 		b[i] = byte('X')
 	}
 
-	msg, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
+	msg, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
 
 	allowed := bandwidthRateLimiter.Allow(peerID, msg)
 	require.True(t, allowed)
@@ -78,7 +78,7 @@ func TestBandWidthRateLimiter_IsRateLimited(t *testing.T) {
 
 	require.False(t, bandwidthRateLimiter.IsRateLimited(peerID))
 
-	msg, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
+	msg, _ := messageutils.CreateMessage(t, unittest.IdentifierFixture(), channels.TestNetworkChannel, string(b))
 	allowed := bandwidthRateLimiter.Allow(peerID, msg)
 	require.False(t, allowed)
 	require.True(t, bandwidthRateLimiter.IsRateLimited(peerID))

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -167,7 +167,7 @@ func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
 	// needed to enable ID translation
 	m.providers[0].SetIdentities(idList)
 
-	msg, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, newId.NodeID, testChannel, "hello")
+	msg, _ := messageutils.CreateMessage(m.T(), newId.NodeID, testChannel, "hello")
 
 	// message should fail to send because no address is known yet
 	// for the new identity
@@ -264,7 +264,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 		// a message is sent every 167 milliseconds which equates to around 6 req/sec surpassing our limit
 		testtime.Advance(168 * time.Millisecond)
 
-		msg, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, newId.NodeID, testChannel, fmt.Sprintf("hello-%s", testtime.Now().String()))
+		msg, _ := messageutils.CreateMessage(m.T(), newId.NodeID, testChannel, fmt.Sprintf("hello-%s", testtime.Now().String()))
 		err := m.mws[0].SendDirect(msg, newId.NodeID)
 		require.NoError(m.T(), err)
 	}
@@ -346,7 +346,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 		b[i] = byte('X')
 	}
 
-	msg, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, newId.NodeID, testChannel, string(b))
+	msg, _ := messageutils.CreateMessage(m.T(), newId.NodeID, testChannel, string(b))
 
 	// update the addresses
 	m.mws[0].UpdateNodeAddresses()
@@ -414,14 +414,14 @@ func (m *MiddlewareTestSuite) TestPingTypeReception() {
 // and content of the payload of the event upon reception at the receiver side
 // it does not evaluate the actual value of the sender ID
 func (m *MiddlewareTestSuite) TestPingIDType() {
-	msg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, m.ids[1].NodeID, testChannel, "hello")
+	msg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[1].NodeID, testChannel, "hello")
 	m.Ping(mockery.AnythingOfType("flow.Identifier"), msg, decodedPayload)
 }
 
 // TestPingContentReception tests the middleware against both
 // the payload and sender ID of the event upon reception at the receiver side
 func (m *MiddlewareTestSuite) TestPingContentReception() {
-	msg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, m.ids[1].NodeID, testChannel, "hello")
+	msg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[1].NodeID, testChannel, "hello")
 	m.Ping(m.ids[0].NodeID, msg, decodedPayload)
 }
 
@@ -454,7 +454,7 @@ func (m *MiddlewareTestSuite) Ping(expectID, expectedMessage, expectedPayload in
 			ch <- struct{}{}
 		})
 
-	msg, _ := messageutils.CreateMessage(m.T(), m.ids[firstNode].NodeID, m.ids[lastNode].NodeID, testChannel, "hello")
+	msg, _ := messageutils.CreateMessage(m.T(), m.ids[lastNode].NodeID, testChannel, "hello")
 
 	// sends a direct message from first node to the last node
 	err = m.mws[firstNode].SendDirect(msg, m.ids[lastNode].NodeID)
@@ -485,7 +485,7 @@ func (m *MiddlewareTestSuite) MultiPing(count int) {
 	for i := 0; i < count; i++ {
 		receiveWG.Add(1)
 		sendWG.Add(1)
-		msg, expectedPayload := messageutils.CreateMessage(m.T(), m.ids[firstNode].NodeID, m.ids[lastNode].NodeID, testChannel, fmt.Sprintf("hello from: %d", i))
+		msg, expectedPayload := messageutils.CreateMessage(m.T(), m.ids[lastNode].NodeID, testChannel, fmt.Sprintf("hello from: %d", i))
 
 		m.ov[lastNode].On("Receive", m.ids[firstNode].NodeID, msg, expectedPayload).Return(nil).Once().
 			Run(func(args mockery.Arguments) {
@@ -527,10 +527,10 @@ func (m *MiddlewareTestSuite) TestEcho() {
 	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	sendMsg, sendPayload := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "hello")
+	sendMsg, sendPayload := messageutils.CreateMessage(m.T(), lastNode, testChannel, "hello")
 	expectedSendPayload := sendPayload.(*libp2pmessage.TestMessage)
 
-	replyMsg, replyPayload := messageutils.CreateMessage(m.T(), lastNode, firstNode, testChannel, "hello back")
+	replyMsg, replyPayload := messageutils.CreateMessage(m.T(), firstNode, testChannel, "hello back")
 
 	expectedReplyPayload := replyPayload.(*libp2pmessage.TestMessage)
 
@@ -571,10 +571,9 @@ func (m *MiddlewareTestSuite) TestEcho() {
 func (m *MiddlewareTestSuite) TestMaxMessageSize_SendDirect() {
 	first := 0
 	last := m.size - 1
-	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	msg, _ := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "")
+	msg, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "")
 
 	// creates a network payload beyond the maximum message size
 	// Note: networkPayloadFixture considers 1000 bytes as the overhead of the encoded message,
@@ -605,7 +604,7 @@ func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
 	sourceNode := m.ids[sourceIndex].NodeID
 	targetNode := m.ids[targetIndex].NodeID
 
-	msg, _ := messageutils.CreateMessage(m.T(), sourceNode, targetNode, testChannel, "")
+	msg, _ := messageutils.CreateMessage(m.T(), targetNode, testChannel, "")
 
 	// creates a network payload with a size greater than the default max size using a known large message type
 	targetSize := uint64(middleware.DefaultMaxUnicastMsgSize) + 1000
@@ -648,7 +647,7 @@ func (m *MiddlewareTestSuite) TestMessageFieldsOverriden_SendDirect() {
 	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	expected, event := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "test message")
+	expected, event := messageutils.CreateMessage(m.T(), lastNode, testChannel, "test message")
 
 	fakeID := unittest.IdentifierFixture()
 	msg := &message.Message{
@@ -682,10 +681,9 @@ func (m *MiddlewareTestSuite) TestMessageFieldsOverriden_SendDirect() {
 func (m *MiddlewareTestSuite) TestMaxMessageSize_Publish() {
 	first := 0
 	last := m.size - 1
-	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	msg, _ := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "")
+	msg, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "")
 
 	// adds another node as the target id to imitate publishing
 	msg.TargetIDs = append(msg.TargetIDs, lastNode[:])
@@ -719,7 +717,7 @@ func (m *MiddlewareTestSuite) TestMessageFieldsOverriden_Publish() {
 	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	expected, event := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "test message")
+	expected, event := messageutils.CreateMessage(m.T(), lastNode, testChannel, "test message")
 
 	// adds another node as the target id to imitate publishing
 	expected.TargetIDs = append(expected.TargetIDs, lastNode[:])
@@ -794,7 +792,7 @@ func (m *MiddlewareTestSuite) TestUnsubscribe() {
 	msgRcvdFun := func() {
 		<-msgRcvd
 	}
-	message1, _ := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "hello1")
+	message1, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "hello1")
 
 	m.ov[last].On("Receive", firstNode, mockery.Anything, mockery.Anything).Return(nil).Run(func(_ mockery.Arguments) {
 		msgRcvd <- struct{}{}
@@ -811,7 +809,7 @@ func (m *MiddlewareTestSuite) TestUnsubscribe() {
 	assert.NoError(m.T(), err)
 
 	// create and send a new message on the channel from the origin node
-	message2, _ := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "hello2")
+	message2, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "hello2")
 
 	err = m.mws[first].Publish(message2, testChannel)
 	assert.NoError(m.T(), err)
@@ -820,21 +818,15 @@ func (m *MiddlewareTestSuite) TestUnsubscribe() {
 	unittest.RequireNeverReturnBefore(m.T(), msgRcvdFun, 2*time.Second, "message received unexpectedly")
 }
 
-func createMessageWithPayload(t *testing.T, originID flow.Identifier, targetID flow.Identifier, channel channels.Channel, payload interface{}) (*message.Message, interface{}) {
+func createMessageWithPayload(t *testing.T, targetID flow.Identifier, channel channels.Channel, payload interface{}) (*message.Message, interface{}) {
 	codec := unittest.NetworkCodec()
 	b, err := codec.Encode(payload)
 	require.NoError(t, err)
 
-	eventID, err := p2p.EventId(channel, b)
-	require.NoError(t, err)
-
 	m := &message.Message{
 		ChannelID: channel.String(),
-		EventID:   eventID,
-		OriginID:  originID[:],
 		TargetIDs: [][]byte{targetID[:]},
 		Payload:   b,
-		Type:      p2p.MessageType(payload),
 	}
 
 	return m, payload

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -167,7 +167,7 @@ func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
 	// needed to enable ID translation
 	m.providers[0].SetIdentities(idList)
 
-	msg, _ := messageutils.CreateMessage(m.T(), newId.NodeID, testChannel, "hello")
+	msg, _, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, newId.NodeID, testChannel, "TestUpdateNodeAddresses")
 
 	// message should fail to send because no address is known yet
 	// for the new identity
@@ -264,7 +264,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 		// a message is sent every 167 milliseconds which equates to around 6 req/sec surpassing our limit
 		testtime.Advance(168 * time.Millisecond)
 
-		msg, _ := messageutils.CreateMessage(m.T(), newId.NodeID, testChannel, fmt.Sprintf("hello-%s", testtime.Now().String()))
+		msg, _, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, newId.NodeID, testChannel, fmt.Sprintf("hello-%s", testtime.Now().String()))
 		err := m.mws[0].SendDirect(msg, newId.NodeID)
 		require.NoError(m.T(), err)
 	}
@@ -346,7 +346,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 		b[i] = byte('X')
 	}
 
-	msg, _ := messageutils.CreateMessage(m.T(), newId.NodeID, testChannel, string(b))
+	msg, _, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, newId.NodeID, testChannel, string(b))
 
 	// update the addresses
 	m.mws[0].UpdateNodeAddresses()
@@ -399,7 +399,8 @@ func (m *MiddlewareTestSuite) TearDownTest() {
 // reception of a single ping message by a node that is sent from another node
 // it does not evaluate the type and content of the message
 func (m *MiddlewareTestSuite) TestPingRawReception() {
-	m.Ping(mockery.Anything, mockery.Anything, mockery.Anything)
+	msg, _, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, m.ids[1].NodeID, testChannel, "TestPingRawReception")
+	m.Ping(msg, mockery.Anything, mockery.Anything, mockery.Anything)
 }
 
 // TestPingTypeReception tests the middleware against type of received payload
@@ -407,22 +408,23 @@ func (m *MiddlewareTestSuite) TestPingRawReception() {
 // it does not evaluate content of the payload
 // it does not evaluate anything related to the sender id
 func (m *MiddlewareTestSuite) TestPingTypeReception() {
-	m.Ping(mockery.Anything, mockery.AnythingOfType("*message.Message"), mockery.Anything)
+	msg, _, _ := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, m.ids[1].NodeID, testChannel, "TestPingTypeReception")
+	m.Ping(msg, mockery.Anything, mockery.AnythingOfType("*message.Message"), mockery.Anything)
 }
 
 // TestPingIDType tests the middleware against both the type of sender id
 // and content of the payload of the event upon reception at the receiver side
 // it does not evaluate the actual value of the sender ID
 func (m *MiddlewareTestSuite) TestPingIDType() {
-	msg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[1].NodeID, testChannel, "hello")
-	m.Ping(mockery.AnythingOfType("flow.Identifier"), msg, decodedPayload)
+	msg, expectedMsg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, m.ids[1].NodeID, testChannel, "TestPingIDType")
+	m.Ping(msg, mockery.AnythingOfType("flow.Identifier"), expectedMsg, decodedPayload)
 }
 
 // TestPingContentReception tests the middleware against both
 // the payload and sender ID of the event upon reception at the receiver side
 func (m *MiddlewareTestSuite) TestPingContentReception() {
-	msg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[1].NodeID, testChannel, "hello")
-	m.Ping(m.ids[0].NodeID, msg, decodedPayload)
+	msg, expectedMsg, decodedPayload := messageutils.CreateMessage(m.T(), m.ids[0].NodeID, m.ids[1].NodeID, testChannel, "TestPingContentReception")
+	m.Ping(msg, m.ids[0].NodeID, expectedMsg, decodedPayload)
 }
 
 // TestMultiPing tests the middleware against type of received payload
@@ -441,7 +443,7 @@ func (m *MiddlewareTestSuite) TestMultiPing() {
 // Ping sends a message from the first middleware of the test suit to the last one
 // expectID and expectPayload are what we expect the receiver side to evaluate the
 // incoming ping against, it can be mocked or typed data
-func (m *MiddlewareTestSuite) Ping(expectID, expectedMessage, expectedPayload interface{}) {
+func (m *MiddlewareTestSuite) Ping(msg *message.Message, expectID, expectedMessage, expectedPayload interface{}) {
 
 	ch := make(chan struct{})
 	// extracts sender id based on the mock option
@@ -453,8 +455,6 @@ func (m *MiddlewareTestSuite) Ping(expectID, expectedMessage, expectedPayload in
 		Run(func(args mockery.Arguments) {
 			ch <- struct{}{}
 		})
-
-	msg, _ := messageutils.CreateMessage(m.T(), m.ids[lastNode].NodeID, testChannel, "hello")
 
 	// sends a direct message from first node to the last node
 	err = m.mws[firstNode].SendDirect(msg, m.ids[lastNode].NodeID)
@@ -485,9 +485,9 @@ func (m *MiddlewareTestSuite) MultiPing(count int) {
 	for i := 0; i < count; i++ {
 		receiveWG.Add(1)
 		sendWG.Add(1)
-		msg, expectedPayload := messageutils.CreateMessage(m.T(), m.ids[lastNode].NodeID, testChannel, fmt.Sprintf("hello from: %d", i))
+		msg, expectedMsg, expectedPayload := messageutils.CreateMessage(m.T(), m.ids[firstNode].NodeID, m.ids[lastNode].NodeID, testChannel, fmt.Sprintf("hello from: %d", i))
 
-		m.ov[lastNode].On("Receive", m.ids[firstNode].NodeID, msg, expectedPayload).Return(nil).Once().
+		m.ov[lastNode].On("Receive", m.ids[firstNode].NodeID, expectedMsg, expectedPayload).Return(nil).Once().
 			Run(func(args mockery.Arguments) {
 				payload := args.Get(2).(*libp2pmessage.TestMessage)
 				require.Equal(m.T(), expectedPayload.(*libp2pmessage.TestMessage), payload)
@@ -527,15 +527,15 @@ func (m *MiddlewareTestSuite) TestEcho() {
 	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	sendMsg, sendPayload := messageutils.CreateMessage(m.T(), lastNode, testChannel, "hello")
+	sendMsg, expectedSendMsg, sendPayload := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "TestEcho")
 	expectedSendPayload := sendPayload.(*libp2pmessage.TestMessage)
 
-	replyMsg, replyPayload := messageutils.CreateMessage(m.T(), firstNode, testChannel, "hello back")
+	replyMsg, expectedReplyMsg, replyPayload := messageutils.CreateMessage(m.T(), lastNode, firstNode, testChannel, "TestEcho response")
 
 	expectedReplyPayload := replyPayload.(*libp2pmessage.TestMessage)
 
 	// last node
-	m.ov[last].On("Receive", firstNode, sendMsg, sendPayload).Return(nil).Once().
+	m.ov[last].On("Receive", firstNode, expectedSendMsg, sendPayload).Return(nil).Once().
 		Run(func(args mockery.Arguments) {
 			wg.Done()
 			// echos back the same message back to the sender
@@ -547,7 +547,7 @@ func (m *MiddlewareTestSuite) TestEcho() {
 		})
 
 	// first node
-	m.ov[first].On("Receive", lastNode, replyMsg, replyPayload).Return(nil).Once().
+	m.ov[first].On("Receive", lastNode, expectedReplyMsg, replyPayload).Return(nil).Once().
 		Run(func(args mockery.Arguments) {
 			wg.Done()
 			payload := args.Get(2).(*libp2pmessage.TestMessage)
@@ -571,9 +571,8 @@ func (m *MiddlewareTestSuite) TestEcho() {
 func (m *MiddlewareTestSuite) TestMaxMessageSize_SendDirect() {
 	first := 0
 	last := m.size - 1
+	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
-
-	msg, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "")
 
 	// creates a network payload beyond the maximum message size
 	// Note: networkPayloadFixture considers 1000 bytes as the overhead of the encoded message,
@@ -585,14 +584,10 @@ func (m *MiddlewareTestSuite) TestMaxMessageSize_SendDirect() {
 		Text: string(payload),
 	}
 
-	codec := unittest.NetworkCodec()
-	encodedEvent, err := codec.Encode(event)
-	require.NoError(m.T(), err)
-
-	msg.Payload = encodedEvent
+	msg, _, _ := messageutils.CreateMessageWithPayload(m.T(), firstNode, lastNode, testChannel, event)
 
 	// sends a direct message from first node to the last node
-	err = m.mws[first].SendDirect(msg, lastNode)
+	err := m.mws[first].SendDirect(msg, lastNode)
 	require.Error(m.Suite.T(), err)
 }
 
@@ -604,32 +599,21 @@ func (m *MiddlewareTestSuite) TestLargeMessageSize_SendDirect() {
 	sourceNode := m.ids[sourceIndex].NodeID
 	targetNode := m.ids[targetIndex].NodeID
 
-	msg, _ := messageutils.CreateMessage(m.T(), targetNode, testChannel, "")
-
 	// creates a network payload with a size greater than the default max size using a known large message type
 	targetSize := uint64(middleware.DefaultMaxUnicastMsgSize) + 1000
 	event := unittest.ChunkDataResponseMsgFixture(unittest.IdentifierFixture(), unittest.WithApproximateSize(targetSize))
-	msg.Type = "messages.ChunkDataResponse"
-	msg.ChannelID = channels.ProvideChunks.String()
 
-	codec := unittest.NetworkCodec()
-	encodedEvent, err := codec.Encode(event)
-	require.NoError(m.T(), err)
-
-	// set the message payload as the large message
-	msg.Payload = encodedEvent
-	msg.EventID, err = p2p.EventId(channels.Channel(msg.ChannelID), encodedEvent)
-	require.NoError(m.T(), err)
+	msg, expectedMsg, _ := messageutils.CreateMessageWithPayload(m.T(), sourceNode, targetNode, channels.ProvideChunks, event)
 
 	// expect one message to be received by the target
 	ch := make(chan struct{})
-	m.ov[targetIndex].On("Receive", sourceNode, msg, event).Return(nil).Once().
+	m.ov[targetIndex].On("Receive", sourceNode, expectedMsg, event).Return(nil).Once().
 		Run(func(args mockery.Arguments) {
 			close(ch)
 		})
 
 	// sends a direct message from source node to the target node
-	err = m.mws[sourceIndex].SendDirect(msg, targetNode)
+	err := m.mws[sourceIndex].SendDirect(msg, targetNode)
 	// SendDirect should not error since this is a known large message
 	require.NoError(m.Suite.T(), err)
 
@@ -647,17 +631,12 @@ func (m *MiddlewareTestSuite) TestMessageFieldsOverriden_SendDirect() {
 	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	expected, event := messageutils.CreateMessage(m.T(), lastNode, testChannel, "test message")
+	msg, expected, event := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "test message")
 
 	fakeID := unittest.IdentifierFixture()
-	msg := &message.Message{
-		OriginID:  fakeID[:],
-		EventID:   fakeID[:],
-		Type:      "messages.ChunkDataResponse",
-		ChannelID: expected.ChannelID,
-		Payload:   expected.Payload,
-		TargetIDs: expected.TargetIDs,
-	}
+	msg.OriginID = fakeID[:]
+	msg.EventID = fakeID[:]
+	msg.Type = "messages.ChunkDataResponse"
 
 	// should receive the expected message, not msg
 	ch := make(chan struct{})
@@ -681,9 +660,10 @@ func (m *MiddlewareTestSuite) TestMessageFieldsOverriden_SendDirect() {
 func (m *MiddlewareTestSuite) TestMaxMessageSize_Publish() {
 	first := 0
 	last := m.size - 1
+	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	msg, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "")
+	msg, _, _ := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "")
 
 	// adds another node as the target id to imitate publishing
 	msg.TargetIDs = append(msg.TargetIDs, lastNode[:])
@@ -717,21 +697,16 @@ func (m *MiddlewareTestSuite) TestMessageFieldsOverriden_Publish() {
 	firstNode := m.ids[first].NodeID
 	lastNode := m.ids[last].NodeID
 
-	expected, event := messageutils.CreateMessage(m.T(), lastNode, testChannel, "test message")
+	msg, expected, event := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "test message")
 
 	// adds another node as the target id to imitate publishing
 	expected.TargetIDs = append(expected.TargetIDs, lastNode[:])
+	msg.TargetIDs = expected.TargetIDs
 
 	fakeID := unittest.IdentifierFixture()
-
-	msg := &message.Message{
-		OriginID:  fakeID[:],
-		EventID:   fakeID[:],
-		Type:      "messages.ChunkDataResponse",
-		ChannelID: expected.ChannelID,
-		Payload:   expected.Payload,
-		TargetIDs: expected.TargetIDs,
-	}
+	msg.OriginID = fakeID[:]
+	msg.EventID = fakeID[:]
+	msg.Type = "messages.ChunkDataResponse"
 
 	// should receive the expected message, not msg
 	ch := make(chan struct{})
@@ -792,7 +767,7 @@ func (m *MiddlewareTestSuite) TestUnsubscribe() {
 	msgRcvdFun := func() {
 		<-msgRcvd
 	}
-	message1, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "hello1")
+	message1, _, _ := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "hello1")
 
 	m.ov[last].On("Receive", firstNode, mockery.Anything, mockery.Anything).Return(nil).Run(func(_ mockery.Arguments) {
 		msgRcvd <- struct{}{}
@@ -809,27 +784,13 @@ func (m *MiddlewareTestSuite) TestUnsubscribe() {
 	assert.NoError(m.T(), err)
 
 	// create and send a new message on the channel from the origin node
-	message2, _ := messageutils.CreateMessage(m.T(), lastNode, testChannel, "hello2")
+	message2, _, _ := messageutils.CreateMessage(m.T(), firstNode, lastNode, testChannel, "hello2")
 
 	err = m.mws[first].Publish(message2, testChannel)
 	assert.NoError(m.T(), err)
 
 	// assert that the new message is not received by the target node
 	unittest.RequireNeverReturnBefore(m.T(), msgRcvdFun, 2*time.Second, "message received unexpectedly")
-}
-
-func createMessageWithPayload(t *testing.T, targetID flow.Identifier, channel channels.Channel, payload interface{}) (*message.Message, interface{}) {
-	codec := unittest.NetworkCodec()
-	b, err := codec.Encode(payload)
-	require.NoError(t, err)
-
-	m := &message.Message{
-		ChannelID: channel.String(),
-		TargetIDs: [][]byte{targetID[:]},
-		Payload:   b,
-	}
-
-	return m, payload
 }
 
 func (m *MiddlewareTestSuite) stopMiddlewares() {

--- a/network/test/unicast_authorization_test.go
+++ b/network/test/unicast_authorization_test.go
@@ -146,7 +146,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnstakedPeer() 
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
+	msg, _, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
 
 	// send message via unicast
 	err = u.senderMW.SendDirect(msg, u.receiverID.NodeID)
@@ -196,7 +196,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_EjectedPeer() {
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
+	msg, _, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
 
 	// send message via unicast
 	err = u.senderMW.SendDirect(msg, u.receiverID.NodeID)
@@ -244,7 +244,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnauthorizedPee
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
+	msg, _, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
 
 	// set channel ID to an unauthorized channel for TestMessage
 	msg.ChannelID = channels.ConsensusCommittee.String()
@@ -299,7 +299,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnknownMsgCode(
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
+	msg, _, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
 
 	// manipulate message code byte
 	msg.Payload[0] = invalidMessageCode
@@ -355,7 +355,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_WrongMsgCode() 
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
+	msg, _, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
 
 	// manipulate message code byte
 	msg.Payload[0] = modifiedMessageCode
@@ -374,7 +374,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_PublicChannel()
 	slashingViolationsConsumer := mocknetwork.NewViolationsConsumer(u.T())
 	u.setupMiddlewaresAndProviders(slashingViolationsConsumer)
 
-	msg, payload := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
+	msg, expectedMsg, payload := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
 
 	overlay := mocknetwork.NewOverlay(u.T())
 	overlay.On("Identities").Maybe().Return(func() flow.IdentityList {
@@ -386,7 +386,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_PublicChannel()
 	overlay.On("Identity", mock.AnythingOfType("peer.ID")).Return(u.senderID, true)
 
 	// we should receive the message on our overlay, at this point close the waitCh
-	overlay.On("Receive", u.senderID.NodeID, msg, payload).Return(nil).
+	overlay.On("Receive", u.senderID.NodeID, expectedMsg, payload).Return(nil).
 		Once().
 		Run(func(args mockery.Arguments) {
 			close(u.waitCh)
@@ -446,7 +446,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnauthorizedUni
 
 	// messages.BlockProposal is not authorized to be sent via unicast over the ConsensusCommittee channel
 	payload := unittest.ProposalFixture()
-	msg, _ := createMessageWithPayload(u.T(), u.receiverID.NodeID, channels.ConsensusCommittee, payload)
+	msg, _, _ := messageutils.CreateMessageWithPayload(u.T(), u.senderID.NodeID, u.receiverID.NodeID, channels.ConsensusCommittee, payload)
 
 	// send message via unicast
 	err = u.senderMW.SendDirect(msg, u.receiverID.NodeID)

--- a/network/test/unicast_authorization_test.go
+++ b/network/test/unicast_authorization_test.go
@@ -146,7 +146,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnstakedPeer() 
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
+	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
 
 	// send message via unicast
 	err = u.senderMW.SendDirect(msg, u.receiverID.NodeID)
@@ -196,7 +196,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_EjectedPeer() {
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
+	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
 
 	// send message via unicast
 	err = u.senderMW.SendDirect(msg, u.receiverID.NodeID)
@@ -244,7 +244,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnauthorizedPee
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
+	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
 
 	// set channel ID to an unauthorized channel for TestMessage
 	msg.ChannelID = channels.ConsensusCommittee.String()
@@ -299,7 +299,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnknownMsgCode(
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
+	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
 
 	// manipulate message code byte
 	msg.Payload[0] = invalidMessageCode
@@ -355,7 +355,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_WrongMsgCode() 
 
 	u.startMiddlewares(overlay)
 
-	msg, _ := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
+	msg, _ := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
 
 	// manipulate message code byte
 	msg.Payload[0] = modifiedMessageCode
@@ -374,7 +374,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_PublicChannel()
 	slashingViolationsConsumer := mocknetwork.NewViolationsConsumer(u.T())
 	u.setupMiddlewaresAndProviders(slashingViolationsConsumer)
 
-	msg, payload := messageutils.CreateMessage(u.T(), u.senderID.NodeID, u.receiverID.NodeID, testChannel, "hello")
+	msg, payload := messageutils.CreateMessage(u.T(), u.receiverID.NodeID, testChannel, "hello")
 
 	overlay := mocknetwork.NewOverlay(u.T())
 	overlay.On("Identities").Maybe().Return(func() flow.IdentityList {
@@ -446,7 +446,7 @@ func (u *UnicastAuthorizationTestSuite) TestUnicastAuthorization_UnauthorizedUni
 
 	// messages.BlockProposal is not authorized to be sent via unicast over the ConsensusCommittee channel
 	payload := unittest.ProposalFixture()
-	msg, _ := createMessageWithPayload(u.T(), u.senderID.NodeID, u.receiverID.NodeID, channels.ConsensusCommittee, payload)
+	msg, _ := createMessageWithPayload(u.T(), u.receiverID.NodeID, channels.ConsensusCommittee, payload)
 
 	// send message via unicast
 	err = u.senderMW.SendDirect(msg, u.receiverID.NodeID)


### PR DESCRIPTION
These fields are deprecated, and will be removed in a future PR. For now, don't include them when sending a new message.