### PR TITLE
Prep work for converting transaction invoker into continuation passing style executor

### DIFF
--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
+	otelTrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
@@ -29,73 +30,102 @@ func (i TransactionInvoker) Process(
 	txnState *state.TransactionState,
 	programs *programsCache.TransactionPrograms,
 ) error {
+	executor := newInvocationExecutor(ctx, proc, txnState, programs)
+	defer executor.Cleanup()
+	return executor.Process()
+}
 
-	txIDStr := proc.ID.String()
-	span := proc.StartSpanFromProcTraceSpan(ctx.Tracer, trace.FVMExecuteTransaction)
-	span.SetAttributes(
-		attribute.String("transaction_id", txIDStr),
-	)
-	defer span.End()
+type invocationExecutor struct {
+	proc     *TransactionProcedure
+	txnState *state.TransactionState
+	programs *programsCache.TransactionPrograms
 
-	nestedTxnId, beginErr := txnState.BeginNestedTransaction()
+	span otelTrace.Span
+	env  environment.Environment
+
+	errs *errors.ErrorsCollector
+
+	nestedTxnId state.NestedTransactionId
+}
+
+func newInvocationExecutor(
+	ctx Context,
+	proc *TransactionProcedure,
+	txnState *state.TransactionState,
+	programs *programsCache.TransactionPrograms,
+) *invocationExecutor {
+	span := proc.StartSpanFromProcTraceSpan(
+		ctx.Tracer,
+		trace.FVMExecuteTransaction)
+	span.SetAttributes(attribute.String("transaction_id", proc.ID.String()))
+
+	env := NewTransactionEnvironment(
+		ctx,
+		txnState,
+		programs,
+		proc.Transaction,
+		proc.TxIndex,
+		span)
+
+	return &invocationExecutor{
+		proc:     proc,
+		txnState: txnState,
+		programs: programs,
+		span:     span,
+		env:      env,
+		errs:     errors.NewErrorsCollector(),
+	}
+}
+
+func (executor *invocationExecutor) Cleanup() {
+	executor.span.End()
+}
+
+func (executor *invocationExecutor) Process() error {
+	var beginErr error
+	executor.nestedTxnId, beginErr = executor.txnState.BeginNestedTransaction()
 	if beginErr != nil {
 		return beginErr
 	}
 
 	var modifiedSets programsCache.ModifiedSetsInvalidator
-
-	errs := errors.NewErrorsCollector()
-
-	env := NewTransactionEnvironment(ctx, txnState, programs, proc.Transaction, proc.TxIndex, span)
-
 	var txError error
-	modifiedSets, txError = i.normalExecution(proc, txnState, env)
-	if errs.Collect(txError).CollectedFailure() {
-		return errs.ErrorOrNil()
+	modifiedSets, txError = executor.normalExecution()
+	if executor.errs.Collect(txError).CollectedFailure() {
+		return executor.errs.ErrorOrNil()
 	}
 
-	if errs.CollectedError() {
+	if executor.errs.CollectedError() {
 		modifiedSets = programsCache.ModifiedSetsInvalidator{}
-
-		fatalErr := i.errorExecution(proc, txnState, nestedTxnId, env, errs)
-		if fatalErr != nil {
-			return fatalErr
+		executor.errorExecution()
+		if executor.errs.CollectedFailure() {
+			return executor.errs.ErrorOrNil()
 		}
 	}
 
-	errs.Collect(i.commit(
-		proc,
-		txnState,
-		nestedTxnId,
-		env,
-		programs,
-		modifiedSets))
+	executor.errs.Collect(executor.commit(modifiedSets))
 
-	return errs.ErrorOrNil()
+	return executor.errs.ErrorOrNil()
 }
 
-func (i TransactionInvoker) deductTransactionFees(
-	proc *TransactionProcedure,
-	txnState *state.TransactionState,
-	env environment.Environment,
-) (err error) {
-	if !env.TransactionFeesEnabled() {
+func (executor *invocationExecutor) deductTransactionFees() (err error) {
+	if !executor.env.TransactionFeesEnabled() {
 		return nil
 	}
 
-	computationUsed := env.ComputationUsed()
-	if computationUsed > uint64(txnState.TotalComputationLimit()) {
-		computationUsed = uint64(txnState.TotalComputationLimit())
+	computationUsed := executor.env.ComputationUsed()
+	if computationUsed > uint64(executor.txnState.TotalComputationLimit()) {
+		computationUsed = uint64(executor.txnState.TotalComputationLimit())
 	}
 
-	_, err = env.DeductTransactionFees(
-		proc.Transaction.Payer,
-		proc.Transaction.InclusionEffort(),
+	_, err = executor.env.DeductTransactionFees(
+		executor.proc.Transaction.Payer,
+		executor.proc.Transaction.InclusionEffort(),
 		computationUsed)
 
 	if err != nil {
 		return errors.NewTransactionFeeDeductionFailedError(
-			proc.Transaction.Payer,
+			executor.proc.Transaction.Payer,
 			computationUsed,
 			err)
 	}
@@ -103,48 +133,41 @@ func (i TransactionInvoker) deductTransactionFees(
 }
 
 // logExecutionIntensities logs execution intensities of the transaction
-func (i TransactionInvoker) logExecutionIntensities(
-	txnState *state.TransactionState,
-	env environment.Environment,
-) {
-	if !env.Logger().Debug().Enabled() {
+func (executor *invocationExecutor) logExecutionIntensities() {
+	if !executor.env.Logger().Debug().Enabled() {
 		return
 	}
 
 	computation := zerolog.Dict()
-	for s, u := range txnState.ComputationIntensities() {
+	for s, u := range executor.txnState.ComputationIntensities() {
 		computation.Uint(strconv.FormatUint(uint64(s), 10), u)
 	}
 	memory := zerolog.Dict()
-	for s, u := range txnState.MemoryIntensities() {
+	for s, u := range executor.txnState.MemoryIntensities() {
 		memory.Uint(strconv.FormatUint(uint64(s), 10), u)
 	}
-	env.Logger().Info().
-		Uint64("ledgerInteractionUsed", txnState.InteractionUsed()).
-		Uint64("computationUsed", txnState.TotalComputationUsed()).
-		Uint64("memoryEstimate", txnState.TotalMemoryEstimate()).
+	executor.env.Logger().Info().
+		Uint64("ledgerInteractionUsed", executor.txnState.InteractionUsed()).
+		Uint64("computationUsed", executor.txnState.TotalComputationUsed()).
+		Uint64("memoryEstimate", executor.txnState.TotalMemoryEstimate()).
 		Dict("computationIntensities", computation).
 		Dict("memoryIntensities", memory).
 		Msg("transaction execution data")
 }
 
-func (i TransactionInvoker) normalExecution(
-	proc *TransactionProcedure,
-	txnState *state.TransactionState,
-	env environment.Environment,
-) (
+func (executor *invocationExecutor) normalExecution() (
 	modifiedSets programsCache.ModifiedSetsInvalidator,
 	err error,
 ) {
-	rt := env.BorrowCadenceRuntime()
-	defer env.ReturnCadenceRuntime(rt)
+	rt := executor.env.BorrowCadenceRuntime()
+	defer executor.env.ReturnCadenceRuntime(rt)
 
 	err = rt.ExecuteTransaction(
 		runtime.Script{
-			Source:    proc.Transaction.Script,
-			Arguments: proc.Transaction.Arguments,
+			Source:    executor.proc.Transaction.Script,
+			Arguments: executor.proc.Transaction.Arguments,
 		},
-		common.TransactionLocation(proc.ID))
+		common.TransactionLocation(executor.proc.ID))
 
 	if err != nil {
 		err = fmt.Errorf(
@@ -155,7 +178,7 @@ func (i TransactionInvoker) normalExecution(
 
 	// Before checking storage limits, we must applying all pending changes
 	// that may modify storage usage.
-	modifiedSets, err = env.FlushPendingUpdates()
+	modifiedSets, err = executor.env.FlushPendingUpdates()
 	if err != nil {
 		err = fmt.Errorf(
 			"transaction invocation failed to flush pending changes from "+
@@ -167,10 +190,10 @@ func (i TransactionInvoker) normalExecution(
 	// log the execution intensities here, so that they do not contain data
 	// from storage limit checks and transaction deduction, because the payer
 	// is not charged for those.
-	i.logExecutionIntensities(txnState, env)
+	executor.logExecutionIntensities()
 
-	txnState.RunWithAllLimitsDisabled(func() {
-		err = i.deductTransactionFees(proc, txnState, env)
+	executor.txnState.RunWithAllLimitsDisabled(func() {
+		err = executor.deductTransactionFees()
 	})
 	if err != nil {
 		return
@@ -181,69 +204,56 @@ func (i TransactionInvoker) normalExecution(
 	// disable the computation/memory limit checks on storage checks,
 	// so we don't error from computation/memory limits on this part.
 	// We cannot charge the user for this part, since fee deduction already happened.
-	txnState.RunWithAllLimitsDisabled(func() {
-		err = NewTransactionStorageLimiter().CheckLimits(env, txnState.UpdatedAddresses())
+	executor.txnState.RunWithAllLimitsDisabled(func() {
+		err = NewTransactionStorageLimiter().CheckLimits(
+			executor.env,
+			executor.txnState.UpdatedAddresses())
 	})
 
 	return
 }
 
 // Clear changes and try to deduct fees again.
-func (i TransactionInvoker) errorExecution(
-	proc *TransactionProcedure,
-	txnState *state.TransactionState,
-	nestedTxnId state.NestedTransactionId,
-	env environment.Environment,
-	errs *errors.ErrorsCollector,
-) error {
-	txnState.DisableAllLimitEnforcements()
-	defer txnState.EnableAllLimitEnforcements()
+func (executor *invocationExecutor) errorExecution() {
+	executor.txnState.DisableAllLimitEnforcements()
+	defer executor.txnState.EnableAllLimitEnforcements()
 
 	// log transaction as failed
-	env.Logger().Info().
-		Err(errs.ErrorOrNil()).
+	executor.env.Logger().Info().
+		Err(executor.errs.ErrorOrNil()).
 		Msg("transaction executed with error")
 
-	env.Reset()
+	executor.env.Reset()
 
 	// drop delta since transaction failed
-	restartErr := txnState.RestartNestedTransaction(nestedTxnId)
-	if errs.Collect(restartErr).CollectedFailure() {
-		return errs.ErrorOrNil()
+	restartErr := executor.txnState.RestartNestedTransaction(executor.nestedTxnId)
+	if executor.errs.Collect(restartErr).CollectedFailure() {
+		return
 	}
 
 	// try to deduct fees again, to get the fee deduction events
-	feesError := i.deductTransactionFees(proc, txnState, env)
+	feesError := executor.deductTransactionFees()
 
 	// if fee deduction fails just do clean up and exit
 	if feesError != nil {
-		env.Logger().Info().
+		executor.env.Logger().Info().
 			Err(feesError).
 			Msg("transaction fee deduction executed with error")
 
-		if errs.Collect(feesError).CollectedFailure() {
-			return errs.ErrorOrNil()
+		if executor.errs.Collect(feesError).CollectedFailure() {
+			return
 		}
 
 		// drop delta
-		restartErr = txnState.RestartNestedTransaction(nestedTxnId)
-		if errs.Collect(restartErr).CollectedFailure() {
-			return errs.ErrorOrNil()
-		}
+		executor.errs.Collect(
+			executor.txnState.RestartNestedTransaction(executor.nestedTxnId))
 	}
-
-	return nil
 }
 
-func (i TransactionInvoker) commit(
-	proc *TransactionProcedure,
-	txnState *state.TransactionState,
-	nestedTxnId state.NestedTransactionId,
-	env environment.Environment,
-	programs *programsCache.TransactionPrograms,
+func (executor *invocationExecutor) commit(
 	modifiedSets programsCache.ModifiedSetsInvalidator,
 ) error {
-	if txnState.NumNestedTransactions() > 1 {
+	if executor.txnState.NumNestedTransactions() > 1 {
 		// This is a fvm internal programming error.  We forgot to call Commit
 		// somewhere in the control flow.  We should halt.
 		return fmt.Errorf(
@@ -252,23 +262,25 @@ func (i TransactionInvoker) commit(
 	}
 
 	// if tx failed this will only contain fee deduction logs
-	proc.Logs = append(proc.Logs, env.Logs()...)
-	proc.ComputationUsed = proc.ComputationUsed + env.ComputationUsed()
-	proc.MemoryEstimate = proc.MemoryEstimate + env.MemoryEstimate()
-	if proc.IsSampled() {
-		proc.ComputationIntensities = env.ComputationIntensities()
+	executor.proc.Logs = append(executor.proc.Logs, executor.env.Logs()...)
+	executor.proc.ComputationUsed += executor.env.ComputationUsed()
+	executor.proc.MemoryEstimate += executor.env.MemoryEstimate()
+	if executor.proc.IsSampled() {
+		executor.proc.ComputationIntensities = executor.env.ComputationIntensities()
 	}
 
 	// if tx failed this will only contain fee deduction events
-	proc.Events = append(proc.Events, env.Events()...)
-	proc.ServiceEvents = append(proc.ServiceEvents, env.ServiceEvents()...)
+	executor.proc.Events = append(executor.proc.Events, executor.env.Events()...)
+	executor.proc.ServiceEvents = append(
+		executor.proc.ServiceEvents,
+		executor.env.ServiceEvents()...)
 
 	// based on the contract and frozen account updates we decide how to
 	// clean up the programs for failed transactions we also do the same as
 	// transaction without any deployed contracts
-	programs.AddInvalidator(modifiedSets)
+	executor.programs.AddInvalidator(modifiedSets)
 
-	_, commitErr := txnState.Commit(nestedTxnId)
+	_, commitErr := executor.txnState.Commit(executor.nestedTxnId)
 	if commitErr != nil {
 		return fmt.Errorf(
 			"transaction invocation failed when merging state: %w",


### PR DESCRIPTION
Added an executor object and converted variables that span the entire workflow (preprocessing, actual execution) into fields.  Variables that do not span the entire workflow (e.g., modifiedSets) are left unmodified.

Note that I've also made a few no-op stylistic changes.