### PR TITLE
Switch transaction invoker to directly use cadence txn executor

### DIFF
--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -133,11 +133,11 @@ func (reusable *ReusableCadenceRuntime) InvokeContractFunction(
 	)
 }
 
-func (reusable *ReusableCadenceRuntime) ExecuteTransaction(
+func (reusable *ReusableCadenceRuntime) NewTransactionExecutor(
 	script runtime.Script,
 	location common.Location,
-) error {
-	return reusable.Runtime.ExecuteTransaction(
+) runtime.Executor {
+	return reusable.Runtime.NewTransactionExecutor(
 		script,
 		runtime.Context{
 			Interface:   reusable.fvmEnv,

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
 	programsCache "github.com/onflow/flow-go/fvm/programs"
+	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/module/trace"
 )
@@ -46,6 +47,9 @@ type invocationExecutor struct {
 	errs *errors.ErrorsCollector
 
 	nestedTxnId state.NestedTransactionId
+
+	cadenceRuntime  *reusableRuntime.ReusableCadenceRuntime
+	txnBodyExecutor runtime.Executor
 }
 
 func newInvocationExecutor(
@@ -68,16 +72,18 @@ func newInvocationExecutor(
 		span)
 
 	return &invocationExecutor{
-		proc:     proc,
-		txnState: txnState,
-		programs: programs,
-		span:     span,
-		env:      env,
-		errs:     errors.NewErrorsCollector(),
+		proc:           proc,
+		txnState:       txnState,
+		programs:       programs,
+		span:           span,
+		env:            env,
+		errs:           errors.NewErrorsCollector(),
+		cadenceRuntime: env.BorrowCadenceRuntime(),
 	}
 }
 
 func (executor *invocationExecutor) Cleanup() {
+	executor.env.ReturnCadenceRuntime(executor.cadenceRuntime)
 	executor.span.End()
 }
 
@@ -159,16 +165,22 @@ func (executor *invocationExecutor) normalExecution() (
 	modifiedSets programsCache.ModifiedSetsInvalidator,
 	err error,
 ) {
-	rt := executor.env.BorrowCadenceRuntime()
-	defer executor.env.ReturnCadenceRuntime(rt)
-
-	err = rt.ExecuteTransaction(
+	executor.txnBodyExecutor = executor.cadenceRuntime.NewTransactionExecutor(
 		runtime.Script{
 			Source:    executor.proc.Transaction.Script,
 			Arguments: executor.proc.Transaction.Arguments,
 		},
 		common.TransactionLocation(executor.proc.ID))
 
+	err = executor.txnBodyExecutor.Preprocess()
+	if err != nil {
+		err = fmt.Errorf(
+			"transaction invocation failed when executing transaction: %w",
+			err)
+		return
+	}
+
+	err = executor.txnBodyExecutor.Execute()
 	if err != nil {
 		err = fmt.Errorf(
 			"transaction invocation failed when executing transaction: %w",


### PR DESCRIPTION
Note: This change uses more memory because the executor now hold on to the cadence runtime used for executing the body until the very end (fees deduction, etc will end up using a second cadence runtime).  This is ok in steady state because the runtimes are still recycled.