### PR TITLE
[FVM] Making BlockPrograms internals use generic OCC code

### DIFF
--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -208,14 +208,14 @@ func Test_Programs(t *testing.T) {
 		// Make sure the code has been loaded from storage
 		require.True(t, loadedCode)
 
-		_, programState, has := programs.GetForTestingOnly(contractALocation)
-		require.True(t, has)
+		entry := programs.GetForTestingOnly(contractALocation)
+		require.NotNil(t, entry)
 
 		// type assertion for further inspections
-		require.IsType(t, programState.View(), &delta.View{})
+		require.IsType(t, entry.State.View(), &delta.View{})
 
 		// assert some reads were recorded (at least loading of code)
-		deltaView := programState.View().(*delta.View)
+		deltaView := entry.State.View().(*delta.View)
 		require.NotEmpty(t, deltaView.Interactions().Reads)
 
 		contractAView = deltaView
@@ -260,11 +260,11 @@ func Test_Programs(t *testing.T) {
 		err := vm.Run(context, procContractB, mainView)
 		require.NoError(t, err)
 
-		_, _, hasA := programs.GetForTestingOnly(contractALocation)
-		_, _, hasB := programs.GetForTestingOnly(contractBLocation)
+		entryA := programs.GetForTestingOnly(contractALocation)
+		entryB := programs.GetForTestingOnly(contractBLocation)
 
-		require.False(t, hasA)
-		require.False(t, hasB)
+		require.Nil(t, entryA)
+		require.Nil(t, entryB)
 	})
 
 	var viewExecB *delta.View
@@ -285,21 +285,21 @@ func Test_Programs(t *testing.T) {
 
 		require.Contains(t, procCallB.Logs, "\"hello from B but also hello from A\"")
 
-		_, programAState, has := programs.GetForTestingOnly(contractALocation)
-		require.True(t, has)
+		entry := programs.GetForTestingOnly(contractALocation)
+		require.NotNil(t, entry)
 
 		// state should be essentially the same as one which we got in tx with contract A
-		require.IsType(t, programAState.View(), &delta.View{})
-		deltaA := programAState.View().(*delta.View)
+		require.IsType(t, entry.State.View(), &delta.View{})
+		deltaA := entry.State.View().(*delta.View)
 
 		compareViews(t, contractAView, deltaA)
 
-		_, programBState, has := programs.GetForTestingOnly(contractBLocation)
-		require.True(t, has)
+		entryB := programs.GetForTestingOnly(contractBLocation)
+		require.NotNil(t, entryB)
 
 		// program B should contain all the registers used by program A, as it depends on it
-		require.IsType(t, programBState.View(), &delta.View{})
-		deltaB := programBState.View().(*delta.View)
+		require.IsType(t, entryB.State.View(), &delta.View{})
+		deltaB := entryB.State.View().(*delta.View)
 
 		idsA, valuesA := deltaA.Delta().RegisterUpdates()
 		for i, id := range idsA {
@@ -387,13 +387,13 @@ func Test_Programs(t *testing.T) {
 		err := vm.Run(context, procContractC, mainView)
 		require.NoError(t, err)
 
-		_, _, hasA := programs.GetForTestingOnly(contractALocation)
-		_, _, hasB := programs.GetForTestingOnly(contractBLocation)
-		_, _, hasC := programs.GetForTestingOnly(contractCLocation)
+		entryA := programs.GetForTestingOnly(contractALocation)
+		entryB := programs.GetForTestingOnly(contractBLocation)
+		entryC := programs.GetForTestingOnly(contractCLocation)
 
-		require.False(t, hasA)
-		require.False(t, hasB)
-		require.False(t, hasC)
+		require.Nil(t, entryA)
+		require.Nil(t, entryB)
+		require.Nil(t, entryC)
 
 	})
 
@@ -410,19 +410,19 @@ func Test_Programs(t *testing.T) {
 		require.Contains(t, procCallC.Logs, "\"hello from C, hello from B but also hello from A\"")
 
 		// program A is the same
-		_, programAState, has := programs.GetForTestingOnly(contractALocation)
-		require.True(t, has)
+		entryA := programs.GetForTestingOnly(contractALocation)
+		require.NotNil(t, entryA)
 
-		require.IsType(t, programAState.View(), &delta.View{})
-		deltaA := programAState.View().(*delta.View)
+		require.IsType(t, entryA.State.View(), &delta.View{})
+		deltaA := entryA.State.View().(*delta.View)
 		compareViews(t, contractAView, deltaA)
 
 		// program B is the same
-		_, programBState, has := programs.GetForTestingOnly(contractBLocation)
-		require.True(t, has)
+		entryB := programs.GetForTestingOnly(contractBLocation)
+		require.NotNil(t, entryB)
 
-		require.IsType(t, programBState.View(), &delta.View{})
-		deltaB := programBState.View().(*delta.View)
+		require.IsType(t, entryB.State.View(), &delta.View{})
+		deltaB := entryB.State.View().(*delta.View)
 		compareViews(t, contractBView, deltaB)
 	})
 }

--- a/fvm/programs/block_derived_data.go
+++ b/fvm/programs/block_derived_data.go
@@ -144,7 +144,7 @@ func (block *BlockDerivedData[TKey, TVal]) unsafeValidate(
 	item *TransactionDerivedData[TKey, TVal],
 ) RetryableError {
 	if item.isSnapshotReadTransaction &&
-		item.invalidators.ShouldInvalidateItems() {
+		item.invalidators.ShouldInvalidateEntries() {
 
 		return newNotRetryableError(
 			"invalid TransactionDerivedData: snapshot read can't invalidate")
@@ -176,7 +176,7 @@ func (block *BlockDerivedData[TKey, TVal]) unsafeValidate(
 
 	applicable := block.invalidators.ApplicableInvalidators(
 		item.snapshotTime)
-	if applicable.ShouldInvalidateItems() {
+	if applicable.ShouldInvalidateEntries() {
 		for _, entry := range item.writeSet {
 			if applicable.ShouldInvalidateEntry(entry) {
 				return newRetryableError(
@@ -225,7 +225,7 @@ func (block *BlockDerivedData[TKey, TVal]) commit(
 		}
 	}
 
-	if item.invalidators.ShouldInvalidateItems() {
+	if item.invalidators.ShouldInvalidateEntries() {
 		for key, entry := range block.items {
 			if item.invalidators.ShouldInvalidateEntry(
 				entry.Entry) {
@@ -337,7 +337,7 @@ func (item *TransactionDerivedData[TKey, TVal]) Set(key TKey, val TVal) {
 func (item *TransactionDerivedData[TKey, TVal]) AddInvalidator(
 	invalidator DerivedDataInvalidator[TVal],
 ) {
-	if invalidator == nil || !invalidator.ShouldInvalidateItems() {
+	if invalidator == nil || !invalidator.ShouldInvalidateEntries() {
 		return
 	}
 

--- a/fvm/programs/block_derived_data_invalidator.go
+++ b/fvm/programs/block_derived_data_invalidator.go
@@ -2,7 +2,7 @@ package programs
 
 type DerivedDataInvalidator[TVal any] interface {
 	// This returns true if the this invalidates any data
-	ShouldInvalidateItems() bool
+	ShouldInvalidateEntries() bool
 
 	// This returns true if the data entry should be invalidated.
 	ShouldInvalidateEntry(TVal) bool
@@ -32,9 +32,9 @@ func (chained chainedDerivedDataInvalidators[TVal]) ApplicableInvalidators(
 	return nil
 }
 
-func (chained chainedDerivedDataInvalidators[TVal]) ShouldInvalidateItems() bool {
+func (chained chainedDerivedDataInvalidators[TVal]) ShouldInvalidateEntries() bool {
 	for _, invalidator := range chained {
-		if invalidator.ShouldInvalidateItems() {
+		if invalidator.ShouldInvalidateEntries() {
 			return true
 		}
 	}

--- a/fvm/programs/block_programs.go
+++ b/fvm/programs/block_programs.go
@@ -1,300 +1,46 @@
 package programs
 
 import (
-	"fmt"
-	"sync"
-
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/onflow/flow-go/fvm/state"
 )
 
-type invalidatableProgramEntry struct {
-	ProgramEntry // Immutable after initialization.
-
-	isInvalid bool // Guarded by blockPrograms' lock.
-}
-
 // BlockPrograms is a simple fork-aware OCC database for "caching" programs
 // for a particular block.
-//
-// Since programs are derived from external source, the database need not be
-// durable and can be recreated on the fly.
-//
-// Furthermore, because programs are derived data, transaction validation looks
-// a bit unusual when compared with a textbook OCC implementation.  In
-// particular, the transaction's invalidator represents "real" writes to the
-// canonical source, whereas the transaction's readSet/writeSet entries
-// represent "real" reads from the canonical source.
 type BlockPrograms struct {
-	lock     sync.RWMutex
-	programs map[common.Location]*invalidatableProgramEntry
-
-	latestCommitExecutionTime LogicalTime
-
-	invalidators chainedInvalidators // Guarded by lock.
+	*BlockDerivedData[common.AddressLocation, ProgramEntry]
 }
 
-// TransactionPrograms is the scratch space for a single transaction.
+// TransactionPrograms is the scratch space for programs of a single transaction.
 type TransactionPrograms struct {
-	block *BlockPrograms
+	*TransactionDerivedData[common.AddressLocation, ProgramEntry]
 
-	// The start time when the snapshot first becomes readable (i.e., the
-	// "snapshotTime - 1"'s transaction committed the snapshot view)
-	snapshotTime LogicalTime
-
-	// The transaction (or script)'s execution start time (aka TxIndex).
-	executionTime LogicalTime
-
-	readSet  map[common.Location]*invalidatableProgramEntry
-	writeSet map[common.Location]ProgramEntry
-
+	// TODO(patrick): to make non-address programs back in environment package.
 	// NOTE: non-address programs are not reusable across transactions, hence
 	// they are kept out of the writeSet and the BlockPrograms database.
 	nonAddressSet map[common.Location]ProgramEntry
-
-	// When isSnapshotReadTransaction is true, invalidators must be empty.
-	isSnapshotReadTransaction bool
-	invalidators              chainedInvalidators
-}
-
-func newEmptyBlockPrograms(latestCommit LogicalTime) *BlockPrograms {
-	return &BlockPrograms{
-		programs:                  map[common.Location]*invalidatableProgramEntry{},
-		latestCommitExecutionTime: latestCommit,
-		invalidators:              nil,
-	}
 }
 
 func NewEmptyBlockPrograms() *BlockPrograms {
-	return newEmptyBlockPrograms(ParentBlockTime)
+	return &BlockPrograms{
+		NewEmptyBlockDerivedData[common.AddressLocation, ProgramEntry](),
+	}
 }
 
 // This variant is needed by the chunk verifier, which does not start at the
 // beginning of the block.
 func NewEmptyBlockProgramsWithTransactionOffset(offset uint32) *BlockPrograms {
-	return newEmptyBlockPrograms(LogicalTime(offset) - 1)
+	return &BlockPrograms{
+		NewEmptyBlockDerivedDataWithOffset[common.AddressLocation, ProgramEntry](offset),
+	}
 }
 
 func (block *BlockPrograms) NewChildBlockPrograms() *BlockPrograms {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
-
-	programs := make(
-		map[common.Location]*invalidatableProgramEntry,
-		len(block.programs))
-
-	for locId, entry := range block.programs {
-		programs[locId] = &invalidatableProgramEntry{
-			ProgramEntry: entry.ProgramEntry,
-			isInvalid:    false,
-		}
-	}
-
 	return &BlockPrograms{
-		programs:                  programs,
-		latestCommitExecutionTime: ParentBlockTime,
-		invalidators:              nil,
+		block.NewChildBlockDerivedData(),
 	}
-}
-
-func (block *BlockPrograms) NextTxIndexForTestingOnly() uint32 {
-	return uint32(block.LatestCommitExecutionTimeForTestingOnly()) + 1
-}
-
-func (block *BlockPrograms) LatestCommitExecutionTimeForTestingOnly() LogicalTime {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
-
-	return block.latestCommitExecutionTime
-}
-
-func (block *BlockPrograms) EntriesForTestingOnly() map[common.Location]*invalidatableProgramEntry {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
-
-	entries := make(
-		map[common.Location]*invalidatableProgramEntry,
-		len(block.programs))
-	for locId, entry := range block.programs {
-		entries[locId] = entry
-	}
-
-	return entries
-}
-
-func (block *BlockPrograms) InvalidatorsForTestingOnly() chainedInvalidators {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
-
-	return block.invalidators
-}
-
-func (block *BlockPrograms) GetForTestingOnly(
-	location common.Location,
-) (
-	*interpreter.Program,
-	*state.State,
-	bool,
-) {
-	entry := block.get(location)
-	if entry != nil {
-		return entry.Program, entry.State, true
-	}
-	return nil, nil, false
-}
-
-func (block *BlockPrograms) get(
-	location common.Location,
-) *invalidatableProgramEntry {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
-
-	return block.programs[location]
-}
-
-func (block *BlockPrograms) unsafeValidate(
-	transaction *TransactionPrograms,
-) RetryableError {
-	if transaction.isSnapshotReadTransaction &&
-		transaction.invalidators.ShouldInvalidatePrograms() {
-
-		return newNotRetryableError(
-			"invalid TransactionProgram: snapshot read can't invalidate")
-	}
-
-	if block.latestCommitExecutionTime >= transaction.executionTime {
-		return newNotRetryableError(
-			"invalid TransactionProgram: non-increasing time (%v >= %v)",
-			block.latestCommitExecutionTime,
-			transaction.executionTime)
-	}
-
-	if block.latestCommitExecutionTime+1 < transaction.snapshotTime &&
-		(!transaction.isSnapshotReadTransaction ||
-			transaction.snapshotTime != EndOfBlockExecutionTime) {
-
-		return newNotRetryableError(
-			"invalid TransactionProgram: missing commit range [%v, %v)",
-			block.latestCommitExecutionTime+1,
-			transaction.snapshotTime)
-	}
-
-	for _, entry := range transaction.readSet {
-		if entry.isInvalid {
-			return newRetryableError(
-				"invalid TransactionPrograms. outdated read set")
-		}
-	}
-
-	applicable := block.invalidators.ApplicableInvalidators(
-		transaction.snapshotTime)
-	if applicable.ShouldInvalidatePrograms() {
-		for _, entry := range transaction.writeSet {
-			if applicable.ShouldInvalidateEntry(entry) {
-				return newRetryableError(
-					"invalid TransactionPrograms. outdated write set")
-			}
-		}
-	}
-
-	return nil
-}
-
-func (block *BlockPrograms) validate(
-	transaction *TransactionPrograms,
-) RetryableError {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
-
-	return block.unsafeValidate(transaction)
-}
-
-func (block *BlockPrograms) commit(
-	transaction *TransactionPrograms,
-) RetryableError {
-	block.lock.Lock()
-	defer block.lock.Unlock()
-
-	// NOTE: Instead of throwing out all the write entries, we can commit
-	// the valid write entries then return error.
-	err := block.unsafeValidate(transaction)
-	if err != nil {
-		return err
-	}
-
-	for locId, entry := range transaction.writeSet {
-		_, ok := block.programs[locId]
-		if ok {
-			// A previous transaction already committed an equivalent program
-			// entry.  Since both program entry are valid, just reuse the
-			// existing one for future transactions.
-			continue
-		}
-
-		block.programs[locId] = &invalidatableProgramEntry{
-			ProgramEntry: entry,
-			isInvalid:    false,
-		}
-	}
-
-	if transaction.invalidators.ShouldInvalidatePrograms() {
-		for locId, entry := range block.programs {
-			if transaction.invalidators.ShouldInvalidateEntry(
-				entry.ProgramEntry) {
-
-				entry.isInvalid = true
-				delete(block.programs, locId)
-			}
-		}
-
-		block.invalidators = append(
-			block.invalidators,
-			transaction.invalidators...)
-	}
-
-	// NOTE: We cannot advance commit time when we encounter a snapshot read
-	// (aka script) transaction since these transactions don't generate new
-	// snapshots.  It is safe to commit the entries since snapshot read
-	// transactions never invalidate entries.
-	if !transaction.isSnapshotReadTransaction {
-		block.latestCommitExecutionTime = transaction.executionTime
-	}
-	return nil
-}
-
-func (block *BlockPrograms) newTransactionPrograms(
-	upperBoundExecutionTime LogicalTime,
-	snapshotTime LogicalTime,
-	executionTime LogicalTime,
-	isSnapshotReadTransaction bool,
-) (
-	*TransactionPrograms,
-	error,
-) {
-	if executionTime < 0 || executionTime > upperBoundExecutionTime {
-		return nil, fmt.Errorf(
-			"invalid TransactionPrograms: execution time out of bound: %v",
-			executionTime)
-	}
-
-	if snapshotTime > executionTime {
-		return nil, fmt.Errorf(
-			"invalid TransactionPrograms: snapshot > execution: %v > %v",
-			snapshotTime,
-			executionTime)
-	}
-
-	return &TransactionPrograms{
-		block:                     block,
-		snapshotTime:              snapshotTime,
-		executionTime:             executionTime,
-		readSet:                   map[common.Location]*invalidatableProgramEntry{},
-		writeSet:                  map[common.Location]ProgramEntry{},
-		nonAddressSet:             map[common.Location]ProgramEntry{},
-		isSnapshotReadTransaction: isSnapshotReadTransaction,
-	}, nil
 }
 
 func (block *BlockPrograms) NewSnapshotReadTransactionPrograms(
@@ -304,11 +50,17 @@ func (block *BlockPrograms) NewSnapshotReadTransactionPrograms(
 	*TransactionPrograms,
 	error,
 ) {
-	return block.newTransactionPrograms(
-		LargestSnapshotReadTransactionExecutionTime,
+	txn, err := block.NewSnapshotReadTransactionDerivedData(
 		snapshotTime,
-		executionTime,
-		true)
+		executionTime)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TransactionPrograms{
+		TransactionDerivedData: txn,
+		nonAddressSet:          make(map[common.Location]ProgramEntry),
+	}, nil
 }
 
 func (block *BlockPrograms) NewTransactionPrograms(
@@ -318,11 +70,15 @@ func (block *BlockPrograms) NewTransactionPrograms(
 	*TransactionPrograms,
 	error,
 ) {
-	return block.newTransactionPrograms(
-		LargestNormalTransactionExecutionTime,
-		snapshotTime,
-		executionTime,
-		false)
+	txn, err := block.NewTransactionDerivedData(snapshotTime, executionTime)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TransactionPrograms{
+		TransactionDerivedData: txn,
+		nonAddressSet:          make(map[common.Location]ProgramEntry),
+	}, nil
 }
 
 func (transaction *TransactionPrograms) Get(
@@ -332,29 +88,18 @@ func (transaction *TransactionPrograms) Get(
 	*state.State,
 	bool,
 ) {
-	_, ok := location.(common.AddressLocation)
+	addressLocation, ok := location.(common.AddressLocation)
 	if !ok {
 		nonAddrEntry, ok := transaction.nonAddressSet[location]
 		return nonAddrEntry.Program, nonAddrEntry.State, ok
 	}
 
-	writeEntry, ok := transaction.writeSet[location]
-	if ok {
-		return writeEntry.Program, writeEntry.State, true
+	programEntry := transaction.TransactionDerivedData.Get(addressLocation)
+	if programEntry == nil {
+		return nil, nil, false
 	}
 
-	readEntry := transaction.readSet[location]
-	if readEntry != nil {
-		return readEntry.Program, readEntry.State, true
-	}
-
-	readEntry = transaction.block.get(location)
-	if readEntry != nil {
-		transaction.readSet[location] = readEntry
-		return readEntry.Program, readEntry.State, true
-	}
-
-	return nil, nil, false
+	return programEntry.Program, programEntry.State, true
 }
 
 func (transaction *TransactionPrograms) Set(
@@ -371,32 +116,23 @@ func (transaction *TransactionPrograms) Set(
 		return
 	}
 
-	transaction.writeSet[location] = ProgramEntry{
+	transaction.TransactionDerivedData.Set(addrLoc, ProgramEntry{
 		Location: addrLoc,
 		Program:  program,
 		State:    state,
-	}
+	})
 }
 
 func (transaction *TransactionPrograms) AddInvalidator(
-	invalidator Invalidator,
+	invalidator DerivedDataInvalidator[ProgramEntry],
 ) {
-	if invalidator == nil || !invalidator.ShouldInvalidatePrograms() {
-		return
-	}
-
-	transaction.invalidators = append(
-		transaction.invalidators,
-		invalidatorAtTime{
-			Invalidator:   invalidator,
-			executionTime: transaction.executionTime,
-		})
+	transaction.TransactionDerivedData.AddInvalidator(invalidator)
 }
 
 func (transaction *TransactionPrograms) Validate() RetryableError {
-	return transaction.block.validate(transaction)
+	return transaction.TransactionDerivedData.Validate()
 }
 
 func (transaction *TransactionPrograms) Commit() RetryableError {
-	return transaction.block.commit(transaction)
+	return transaction.TransactionDerivedData.Commit()
 }

--- a/fvm/programs/block_programs_test.go
+++ b/fvm/programs/block_programs_test.go
@@ -345,9 +345,9 @@ func TestTxnProgsCommitWriteOnlyTransactionNoInvalidation(t *testing.T) {
 	entry, ok := entries[location]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, location, entry.Location)
-	require.Same(t, expectedProg, entry.Program)
-	require.Same(t, expectedState, entry.State)
+	require.Equal(t, location, entry.Entry.Location)
+	require.Same(t, expectedProg, entry.Entry.Program)
+	require.Same(t, expectedState, entry.Entry.State)
 }
 
 func TestTxnProgsCommitWriteOnlyTransactionWithInvalidation(t *testing.T) {
@@ -393,10 +393,10 @@ func TestTxnProgsCommitWriteOnlyTransactionWithInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedInvalidators{
+		chainedDerivedDataInvalidators[ProgramEntry]{
 			{
-				Invalidator:   invalidator,
-				executionTime: testTxnTime,
+				DerivedDataInvalidator: invalidator,
+				executionTime:          testTxnTime,
 			},
 		},
 		block.InvalidatorsForTestingOnly())
@@ -447,11 +447,11 @@ func TestTxnProgsCommitUseOriginalEntryOnDuplicateWriteEntries(t *testing.T) {
 
 	require.Same(t, expectedEntry, actualEntry)
 	require.False(t, actualEntry.isInvalid)
-	require.Equal(t, location, actualEntry.Location)
-	require.Same(t, expectedProg, actualEntry.Program)
-	require.Same(t, expectedState, actualEntry.State)
-	require.NotSame(t, otherProg, actualEntry.Program)
-	require.NotSame(t, otherState, actualEntry.State)
+	require.Equal(t, location, actualEntry.Entry.Location)
+	require.Same(t, expectedProg, actualEntry.Entry.Program)
+	require.Same(t, expectedState, actualEntry.Entry.State)
+	require.NotSame(t, otherProg, actualEntry.Entry.Program)
+	require.NotSame(t, otherState, actualEntry.Entry.State)
 }
 
 func TestTxnProgsCommitReadOnlyTransactionNoInvalidation(t *testing.T) {
@@ -523,16 +523,16 @@ func TestTxnProgsCommitReadOnlyTransactionNoInvalidation(t *testing.T) {
 	entry, ok := entries[loc1]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, loc1, entry.Location)
-	require.Same(t, expectedProg1, entry.Program)
-	require.Same(t, expectedState1, entry.State)
+	require.Equal(t, loc1, entry.Entry.Location)
+	require.Same(t, expectedProg1, entry.Entry.Program)
+	require.Same(t, expectedState1, entry.Entry.State)
 
 	entry, ok = entries[loc2]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, loc2, entry.Location)
-	require.Same(t, expectedProg2, entry.Program)
-	require.Same(t, expectedState2, entry.State)
+	require.Equal(t, loc2, entry.Entry.Location)
+	require.Same(t, expectedProg2, entry.Entry.Program)
+	require.Same(t, expectedState2, entry.Entry.State)
 }
 
 func TestTxnProgsCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
@@ -612,14 +612,14 @@ func TestTxnProgsCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedInvalidators{
+		chainedDerivedDataInvalidators[ProgramEntry]{
 			{
-				Invalidator:   testSetupTxn1Invalidator,
-				executionTime: testSetupTxn1Time,
+				DerivedDataInvalidator: testSetupTxn1Invalidator,
+				executionTime:          testSetupTxn1Time,
 			},
 			{
-				Invalidator:   testTxnInvalidator,
-				executionTime: testTxnTime,
+				DerivedDataInvalidator: testTxnInvalidator,
+				executionTime:          testTxnTime,
 			},
 		},
 		block.InvalidatorsForTestingOnly())
@@ -803,14 +803,14 @@ func TestTxnProgsCommitFineGrainInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedInvalidators{
+		chainedDerivedDataInvalidators[ProgramEntry]{
 			{
-				Invalidator:   invalidator1,
-				executionTime: testTxnTime,
+				DerivedDataInvalidator: invalidator1,
+				executionTime:          testTxnTime,
 			},
 			{
-				Invalidator:   invalidator2,
-				executionTime: testTxnTime,
+				DerivedDataInvalidator: invalidator2,
+				executionTime:          testTxnTime,
 			},
 		},
 		block.InvalidatorsForTestingOnly())
@@ -821,16 +821,16 @@ func TestTxnProgsCommitFineGrainInvalidation(t *testing.T) {
 	entry, ok := entries[readLoc2]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, readLoc2, entry.Location)
-	require.Same(t, readProg2, entry.Program)
-	require.Same(t, readState2, entry.State)
+	require.Equal(t, readLoc2, entry.Entry.Location)
+	require.Same(t, readProg2, entry.Entry.Program)
+	require.Same(t, readState2, entry.Entry.State)
 
 	entry, ok = entries[writeLoc2]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, writeLoc2, entry.Location)
-	require.Same(t, writeProg2, entry.Program)
-	require.Same(t, writeState2, entry.State)
+	require.Equal(t, writeLoc2, entry.Entry.Location)
+	require.Same(t, writeProg2, entry.Entry.Program)
+	require.Same(t, writeState2, entry.Entry.State)
 }
 
 func TestBlockProgsNewChildBlockPrograms(t *testing.T) {
@@ -881,9 +881,9 @@ func TestBlockProgsNewChildBlockPrograms(t *testing.T) {
 	parentEntry, ok := parentEntries[location]
 	require.True(t, ok)
 	require.False(t, parentEntry.isInvalid)
-	require.Equal(t, location, parentEntry.Location)
-	require.Same(t, prog, parentEntry.Program)
-	require.Same(t, state, parentEntry.State)
+	require.Equal(t, location, parentEntry.Entry.Location)
+	require.Same(t, prog, parentEntry.Entry.Program)
+	require.Same(t, state, parentEntry.Entry.State)
 
 	// Verify child is correctly initialized
 
@@ -902,9 +902,9 @@ func TestBlockProgsNewChildBlockPrograms(t *testing.T) {
 	childEntry, ok := childEntries[location]
 	require.True(t, ok)
 	require.False(t, childEntry.isInvalid)
-	require.Equal(t, location, childEntry.Location)
-	require.Same(t, prog, childEntry.Program)
-	require.Same(t, state, childEntry.State)
+	require.Equal(t, location, childEntry.Entry.Location)
+	require.Same(t, prog, childEntry.Entry.Program)
+	require.Same(t, state, childEntry.Entry.State)
 
 	require.NotSame(t, parentEntry, childEntry)
 }

--- a/fvm/programs/chain_programs_test.go
+++ b/fvm/programs/chain_programs_test.go
@@ -46,9 +46,9 @@ func TestChainPrograms(t *testing.T) {
 	err = txn.Commit()
 	require.NoError(t, err)
 
-	foundProg, _, ok := block1.GetForTestingOnly(loc1)
-	require.True(t, ok)
-	require.Same(t, prog1, foundProg)
+	entry := block1.GetForTestingOnly(loc1)
+	require.NotNil(t, entry)
+	require.Same(t, prog1, entry.Program)
 
 	//
 	// Creating a BlockPrograms from parent
@@ -70,13 +70,13 @@ func TestChainPrograms(t *testing.T) {
 	err = txn.Commit()
 	require.NoError(t, err)
 
-	foundProg, _, ok = block2.GetForTestingOnly(loc1)
-	require.True(t, ok)
-	require.Same(t, prog1, foundProg)
+	entry = block2.GetForTestingOnly(loc1)
+	require.NotNil(t, entry)
+	require.Same(t, prog1, entry.Program)
 
-	foundProg, _, ok = block2.GetForTestingOnly(loc2)
-	require.True(t, ok)
-	require.Same(t, prog2, foundProg)
+	entry = block2.GetForTestingOnly(loc2)
+	require.NotNil(t, entry)
+	require.Same(t, prog2, entry.Program)
 
 	//
 	// Reuse exising BlockPrograms in cache
@@ -88,13 +88,13 @@ func TestChainPrograms(t *testing.T) {
 	foundBlock = programs.Get(blockId1)
 	require.Same(t, block1, foundBlock)
 
-	foundProg, _, ok = block1.GetForTestingOnly(loc1)
-	require.True(t, ok)
-	require.Same(t, prog1, foundProg)
+	entry = block1.GetForTestingOnly(loc1)
+	require.NotNil(t, entry)
+	require.Same(t, prog1, entry.Program)
 
 	// writes to block2 did't poplute block1.
-	_, _, ok = block1.GetForTestingOnly(loc2)
-	require.False(t, ok)
+	entry = block1.GetForTestingOnly(loc2)
+	require.Nil(t, entry)
 
 	//
 	// Test eviction
@@ -108,23 +108,23 @@ func TestChainPrograms(t *testing.T) {
 	require.NotSame(t, block1, block3)
 	require.NotSame(t, block2, block3)
 
-	foundProg, _, ok = block3.GetForTestingOnly(loc1)
-	require.True(t, ok)
-	require.Same(t, prog1, foundProg)
+	entry = block3.GetForTestingOnly(loc1)
+	require.NotNil(t, entry)
+	require.Same(t, prog1, entry.Program)
 
-	foundProg, _, ok = block3.GetForTestingOnly(loc2)
-	require.True(t, ok)
-	require.Same(t, prog2, foundProg)
+	entry = block3.GetForTestingOnly(loc2)
+	require.NotNil(t, entry)
+	require.Same(t, prog2, entry.Program)
 
 	// block1 forces block2 to evict
 	foundBlock = programs.GetOrCreateBlockPrograms(blockId1, flow.ZeroID)
 	require.NotSame(t, block1, foundBlock)
 
-	_, _, ok = foundBlock.GetForTestingOnly(loc1)
-	require.False(t, ok)
+	entry = foundBlock.GetForTestingOnly(loc1)
+	require.Nil(t, entry)
 
-	_, _, ok = foundBlock.GetForTestingOnly(loc2)
-	require.False(t, ok)
+	entry = foundBlock.GetForTestingOnly(loc2)
+	require.Nil(t, entry)
 
 	block1 = foundBlock
 
@@ -138,13 +138,13 @@ func TestChainPrograms(t *testing.T) {
 	require.NotSame(t, block2, scriptBlock)
 	require.NotSame(t, block3, scriptBlock)
 
-	foundProg, _, ok = scriptBlock.GetForTestingOnly(loc1)
-	require.True(t, ok)
-	require.Same(t, prog1, foundProg)
+	entry = scriptBlock.GetForTestingOnly(loc1)
+	require.NotNil(t, entry)
+	require.Same(t, prog1, entry.Program)
 
-	foundProg, _, ok = scriptBlock.GetForTestingOnly(loc2)
-	require.True(t, ok)
-	require.Same(t, prog2, foundProg)
+	entry = scriptBlock.GetForTestingOnly(loc2)
+	require.NotNil(t, entry)
+	require.Same(t, prog2, entry.Program)
 
 	foundBlock = programs.Get(blockId3)
 	require.Same(t, block3, foundBlock)

--- a/fvm/programs/invalidator.go
+++ b/fvm/programs/invalidator.go
@@ -13,15 +13,6 @@ type ProgramEntry struct {
 	Program  *interpreter.Program
 	State    *state.State
 }
-
-type Invalidator interface {
-	// This returns true if the this invalidates at least one program
-	ShouldInvalidatePrograms() bool
-
-	// This returns true if the program entry should be invalidated.
-	ShouldInvalidateEntry(ProgramEntry) bool
-}
-
 type ContractUpdateKey struct {
 	Address flow.Address
 	Name    string
@@ -32,14 +23,14 @@ type ContractUpdate struct {
 	Code []byte
 }
 
-var _ Invalidator = ModifiedSetsInvalidator{}
+var _ DerivedDataInvalidator[ProgramEntry] = ModifiedSetsInvalidator{}
 
 type ModifiedSetsInvalidator struct {
 	ContractUpdateKeys []ContractUpdateKey
 	FrozenAccounts     []common.Address
 }
 
-func (sets ModifiedSetsInvalidator) ShouldInvalidatePrograms() bool {
+func (sets ModifiedSetsInvalidator) ShouldInvalidateEntries() bool {
 	return len(sets.ContractUpdateKeys) > 0 || len(sets.FrozenAccounts) > 0
 }
 
@@ -47,51 +38,5 @@ func (sets ModifiedSetsInvalidator) ShouldInvalidateEntry(
 	entry ProgramEntry,
 ) bool {
 	// TODO(rbtz): switch to fine grain invalidation.
-	return sets.ShouldInvalidatePrograms()
-}
-
-type invalidatorAtTime struct {
-	Invalidator
-
-	executionTime LogicalTime
-}
-
-// NOTE: chainedInvalidator assumes that the entries are order by non-decreasing
-// execution time.
-type chainedInvalidators []invalidatorAtTime
-
-func (chained chainedInvalidators) ApplicableInvalidators(
-	snapshotTime LogicalTime,
-) chainedInvalidators {
-	// NOTE: switch to bisection search (or reverse iteration) if the list
-	// is long.
-	for idx, entry := range chained {
-		if snapshotTime <= entry.executionTime {
-			return chained[idx:]
-		}
-	}
-
-	return nil
-}
-
-func (chained chainedInvalidators) ShouldInvalidatePrograms() bool {
-	for _, invalidator := range chained {
-		if invalidator.ShouldInvalidatePrograms() {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (chained chainedInvalidators) ShouldInvalidateEntry(
-	entry ProgramEntry,
-) bool {
-	for _, invalidator := range chained {
-		if invalidator.ShouldInvalidateEntry(entry) {
-			return true
-		}
-	}
-
-	return false
+	return sets.ShouldInvalidateEntries()
 }

--- a/fvm/programs/invalidator_test.go
+++ b/fvm/programs/invalidator_test.go
@@ -12,7 +12,7 @@ type testInvalidator struct {
 	invalidateName string
 }
 
-func (invalidator testInvalidator) ShouldInvalidatePrograms() bool {
+func (invalidator testInvalidator) ShouldInvalidateEntries() bool {
 	return invalidator.invalidateAll ||
 		invalidator.invalidateName != ""
 }
@@ -27,7 +27,7 @@ func (invalidator testInvalidator) ShouldInvalidateEntry(
 func TestModifiedSetsInvalidator(t *testing.T) {
 	invalidator := ModifiedSetsInvalidator{}
 
-	require.False(t, invalidator.ShouldInvalidatePrograms())
+	require.False(t, invalidator.ShouldInvalidateEntries())
 	require.False(t, invalidator.ShouldInvalidateEntry(ProgramEntry{}))
 
 	invalidator = ModifiedSetsInvalidator{
@@ -37,7 +37,7 @@ func TestModifiedSetsInvalidator(t *testing.T) {
 		FrozenAccounts: nil,
 	}
 
-	require.True(t, invalidator.ShouldInvalidatePrograms())
+	require.True(t, invalidator.ShouldInvalidateEntries())
 	require.True(t, invalidator.ShouldInvalidateEntry(ProgramEntry{}))
 
 	invalidator = ModifiedSetsInvalidator{
@@ -47,54 +47,54 @@ func TestModifiedSetsInvalidator(t *testing.T) {
 		},
 	}
 
-	require.True(t, invalidator.ShouldInvalidatePrograms())
+	require.True(t, invalidator.ShouldInvalidateEntries())
 	require.True(t, invalidator.ShouldInvalidateEntry(ProgramEntry{}))
 }
 
 func TestChainedInvalidator(t *testing.T) {
-	var chain chainedInvalidators
-	require.False(t, chain.ShouldInvalidatePrograms())
+	var chain chainedDerivedDataInvalidators[ProgramEntry]
+	require.False(t, chain.ShouldInvalidateEntries())
 	require.False(t, chain.ShouldInvalidateEntry(ProgramEntry{}))
 
-	chain = chainedInvalidators{}
-	require.False(t, chain.ShouldInvalidatePrograms())
+	chain = chainedDerivedDataInvalidators[ProgramEntry]{}
+	require.False(t, chain.ShouldInvalidateEntries())
 	require.False(t, chain.ShouldInvalidateEntry(ProgramEntry{}))
 
-	chain = chainedInvalidators{
+	chain = chainedDerivedDataInvalidators[ProgramEntry]{
 		{
-			Invalidator:   testInvalidator{},
-			executionTime: 1,
+			DerivedDataInvalidator: testInvalidator{},
+			executionTime:          1,
 		},
 		{
-			Invalidator:   testInvalidator{},
-			executionTime: 2,
+			DerivedDataInvalidator: testInvalidator{},
+			executionTime:          2,
 		},
 		{
-			Invalidator:   testInvalidator{},
-			executionTime: 3,
+			DerivedDataInvalidator: testInvalidator{},
+			executionTime:          3,
 		},
 	}
-	require.False(t, chain.ShouldInvalidatePrograms())
+	require.False(t, chain.ShouldInvalidateEntries())
 
-	chain = chainedInvalidators{
+	chain = chainedDerivedDataInvalidators[ProgramEntry]{
 		{
-			Invalidator:   testInvalidator{invalidateName: "1"},
-			executionTime: 1,
+			DerivedDataInvalidator: testInvalidator{invalidateName: "1"},
+			executionTime:          1,
 		},
 		{
-			Invalidator:   testInvalidator{invalidateName: "3a"},
-			executionTime: 3,
+			DerivedDataInvalidator: testInvalidator{invalidateName: "3a"},
+			executionTime:          3,
 		},
 		{
-			Invalidator:   testInvalidator{invalidateName: "3b"},
-			executionTime: 3,
+			DerivedDataInvalidator: testInvalidator{invalidateName: "3b"},
+			executionTime:          3,
 		},
 		{
-			Invalidator:   testInvalidator{invalidateName: "7"},
-			executionTime: 7,
+			DerivedDataInvalidator: testInvalidator{invalidateName: "7"},
+			executionTime:          7,
 		},
 	}
-	require.True(t, chain.ShouldInvalidatePrograms())
+	require.True(t, chain.ShouldInvalidateEntries())
 
 	for _, name := range []string{"1", "3a", "3b", "7"} {
 		entry := ProgramEntry{

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -172,8 +172,8 @@ func TestAccountFreezing(t *testing.T) {
 			Address: common.MustBytesToAddress(address[:]),
 			Name:    "Whatever",
 		}
-		_, _, found := programsStorage.GetForTestingOnly(cadenceAddr)
-		require.True(t, found)
+		entry := programsStorage.GetForTestingOnly(cadenceAddr)
+		require.NotNil(t, entry)
 
 		// freeze account
 
@@ -195,8 +195,8 @@ func TestAccountFreezing(t *testing.T) {
 
 		// verify cache is evicted
 
-		_, _, found = programsStorage.GetForTestingOnly(cadenceAddr)
-		require.False(t, found)
+		entry = programsStorage.GetForTestingOnly(cadenceAddr)
+		require.Nil(t, entry)
 
 		// loading code from frozen account triggers error
 


### PR DESCRIPTION
As the follow-up change to #3484 , now BlockPrograms\TransactionPrograms\Invalidators are all using generic OCC implementation. 

Note that I'm keeping the original interfaces instead of directly exposing `BlockDerivedData` interfaces.

**Test**
- [x] all existing UT cases