### PR TITLE
[Execution] disable block uploads by default

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -361,6 +361,8 @@ func (exeNode *ExecutionNode) LoadGCPBlockDataUploader(
 			return nil, errors.New("failed to create ComputationResult upload status store")
 		}
 
+		computation.SetUploaderEnabled(true)
+
 		exeNode.blockDataUploaders = append(exeNode.blockDataUploaders, retryableUploader)
 
 		return retryableUploader, nil
@@ -405,6 +407,8 @@ func (exeNode *ExecutionNode) LoadS3BlockDataUploader(
 		// We are not enabling RetryableUploader for S3 uploader for now. When we need upload
 		// retry for multiple uploaders, we will need to use different BadgerDB key prefix.
 		exeNode.blockDataUploaders = append(exeNode.blockDataUploaders, asyncUploader)
+
+		computation.SetUploaderEnabled(true)
 
 		return asyncUploader, nil
 	}

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -361,9 +361,9 @@ func (exeNode *ExecutionNode) LoadGCPBlockDataUploader(
 			return nil, errors.New("failed to create ComputationResult upload status store")
 		}
 
-		computation.SetUploaderEnabled(true)
-
 		exeNode.blockDataUploaders = append(exeNode.blockDataUploaders, retryableUploader)
+
+		computation.SetUploaderEnabled(true)
 
 		return retryableUploader, nil
 	}

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -41,7 +41,7 @@ const (
 	ReusableCadenceRuntimePoolSize = 1000
 )
 
-var uploadEnabled = true
+var uploadEnabled = false
 
 func SetUploaderEnabled(enabled bool) {
 	uploadEnabled = enabled


### PR DESCRIPTION
Currently, the uploader is enabled by default on all nodes, and only skipped because there are no configure uploaders. This causes nodes that don't have uploads enabled to check all blocks in their dbs for blocks to upload