### PR TITLE
Flatten transaction processor loop.

### DIFF
--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -32,9 +32,8 @@ func TestFungibleTokenTracker(t *testing.T) {
 	blockPrograms := programs.NewEmptyBlockPrograms()
 	opts := []fvm.Option{
 		fvm.WithChain(chain),
-		fvm.WithTransactionProcessors(
-			fvm.NewTransactionInvoker(),
-		),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		fvm.WithBlockPrograms(blockPrograms),
 	}
 	ctx := fvm.NewContext(opts...)

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -72,9 +72,10 @@ func SystemChunkContext(vmCtx fvm.Context, logger zerolog.Logger) fvm.Context {
 		vmCtx,
 		fvm.WithContractDeploymentRestricted(false),
 		fvm.WithContractRemovalRestricted(false),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		fvm.WithTransactionFeesEnabled(false),
 		fvm.WithServiceEventCollectionEnabled(),
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
 		fvm.WithEventCollectionSizeLimit(SystemChunkEventCollectionMaxSize),
 		fvm.WithMemoryAndInteractionLimitsDisabled(),
 	)

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -360,10 +360,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 	t.Run("service events are emitted", func(t *testing.T) {
 		execCtx := fvm.NewContext(
 			fvm.WithServiceEventCollectionEnabled(),
-			fvm.WithTransactionProcessors(
-				// we don't need to check signatures or sequence numbers
-				fvm.NewTransactionInvoker(),
-			),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		)
 
 		collectionCount := 2
@@ -553,9 +551,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 	t.Run("failing transactions do not store programs", func(t *testing.T) {
 		execCtx := fvm.NewContext(
-			fvm.WithTransactionProcessors(
-				fvm.NewTransactionInvoker(),
-			),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		)
 
 		address := common.Address{0x1}

--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -206,9 +206,8 @@ func CreateAccountsWithSimpleAddresses(
 ) ([]flow.Address, error) {
 	ctx := fvm.NewContext(
 		fvm.WithChain(chain),
-		fvm.WithTransactionProcessors(
-			fvm.NewTransactionInvoker(),
-		),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		fvm.WithBlockPrograms(programs),
 	)
 

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -30,7 +30,8 @@ func createAccount(
 ) flow.Address {
 	ctx = fvm.NewContextFromParent(
 		ctx,
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 	)
 
 	txBody := flow.NewTransactionBody().
@@ -344,7 +345,8 @@ func newAccountKey(
 func TestCreateAccount(t *testing.T) {
 
 	options := []fvm.Option{
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 	}
 
 	t.Run("Single account",
@@ -417,7 +419,8 @@ func TestCreateAccount(t *testing.T) {
 func TestCreateAccount_WithRestrictedAccountCreation(t *testing.T) {
 
 	options := []fvm.Option{
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 	}
 
 	t.Run("Unauthorized account payer",
@@ -526,7 +529,8 @@ func TestUpdateAccountCode(t *testing.T) {
 func TestAddAccountKey(t *testing.T) {
 
 	options := []fvm.Option{
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 	}
 
 	type addKeyTest struct {
@@ -790,7 +794,8 @@ func TestAddAccountKey(t *testing.T) {
 func TestRemoveAccountKey(t *testing.T) {
 
 	options := []fvm.Option{
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 	}
 
 	type removeKeyTest struct {
@@ -1019,7 +1024,8 @@ func TestRemoveAccountKey(t *testing.T) {
 func TestGetAccountKey(t *testing.T) {
 
 	options := []fvm.Option{
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		fvm.WithCadenceLogging(true),
 	}
 
@@ -1228,7 +1234,8 @@ func byteSliceToCadenceArrayLiteral(bytes []byte) string {
 func TestAccountBalanceFields(t *testing.T) {
 	t.Run("Get balance works",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 		).
 			run(func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.BlockPrograms) {
@@ -1264,7 +1271,8 @@ func TestAccountBalanceFields(t *testing.T) {
 	// this behavior needs to addressed on Cadence side
 	t.Run("Get balance returns 0 for accounts that don't exist",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 		).
 			run(func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.BlockPrograms) {
@@ -1288,7 +1296,8 @@ func TestAccountBalanceFields(t *testing.T) {
 
 	t.Run("Get balance fails if view returns an error",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 		).
 			run(func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, _ state.View, programs *programs.BlockPrograms) {
@@ -1315,7 +1324,8 @@ func TestAccountBalanceFields(t *testing.T) {
 
 	t.Run("Get available balance works",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 			fvm.WithAccountStorageLimit(false),
 		).withBootstrapProcedureOptions(
@@ -1351,7 +1361,8 @@ func TestAccountBalanceFields(t *testing.T) {
 
 	t.Run("Get available balance fails for accounts that don't exist",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 			fvm.WithAccountStorageLimit(false),
 		).withBootstrapProcedureOptions(
@@ -1377,7 +1388,8 @@ func TestAccountBalanceFields(t *testing.T) {
 
 	t.Run("Get available balance works with minimum balance",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 			fvm.WithAccountStorageLimit(false),
 		).withBootstrapProcedureOptions(
@@ -1419,7 +1431,8 @@ func TestAccountBalanceFields(t *testing.T) {
 func TestGetStorageCapacity(t *testing.T) {
 	t.Run("Get storage capacity",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 			fvm.WithAccountStorageLimit(false),
 		).withBootstrapProcedureOptions(
@@ -1457,7 +1470,8 @@ func TestGetStorageCapacity(t *testing.T) {
 	)
 	t.Run("Get storage capacity returns 0 for accounts that don't exist",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 			fvm.WithAccountStorageLimit(false),
 		).withBootstrapProcedureOptions(
@@ -1485,7 +1499,8 @@ func TestGetStorageCapacity(t *testing.T) {
 	)
 	t.Run("Get storage capacity fails if view returns an error",
 		newVMTest().withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 			fvm.WithAccountStorageLimit(false),
 		).withBootstrapProcedureOptions(

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -24,7 +24,18 @@ type Context struct {
 	MaxStateValueSize                 uint64
 	MaxStateInteractionSize           uint64
 
-	TransactionProcessors []TransactionProcessor
+	AuthorizationChecksEnabled bool
+
+	SequenceNumberCheckAndIncrementEnabled bool
+
+	// If AccountKeyWeightThreshold is set to a negative number, signature
+	// verification is skipped during authorization checks.
+	//
+	// Note: This is set only by tests
+	AccountKeyWeightThreshold int
+
+	// Note: This is disabled only by tests
+	TransactionBodyExecutionEnabled bool
 
 	BlockPrograms *programs.BlockPrograms
 
@@ -58,18 +69,17 @@ const (
 
 func defaultContext() Context {
 	return Context{
-		DisableMemoryAndInteractionLimits: false,
-		ComputationLimit:                  DefaultComputationLimit,
-		MemoryLimit:                       DefaultMemoryLimit,
-		MaxStateKeySize:                   state.DefaultMaxKeySize,
-		MaxStateValueSize:                 state.DefaultMaxValueSize,
-		MaxStateInteractionSize:           state.DefaultMaxInteractionSize,
-		TransactionProcessors: []TransactionProcessor{
-			NewTransactionVerifier(AccountKeyWeightThreshold),
-			NewTransactionSequenceNumberChecker(),
-			NewTransactionInvoker(),
-		},
-		EnvironmentParams: environment.DefaultEnvironmentParams(),
+		DisableMemoryAndInteractionLimits:      false,
+		ComputationLimit:                       DefaultComputationLimit,
+		MemoryLimit:                            DefaultMemoryLimit,
+		MaxStateKeySize:                        state.DefaultMaxKeySize,
+		MaxStateValueSize:                      state.DefaultMaxValueSize,
+		MaxStateInteractionSize:                state.DefaultMaxInteractionSize,
+		AuthorizationChecksEnabled:             true,
+		SequenceNumberCheckAndIncrementEnabled: true,
+		AccountKeyWeightThreshold:              AccountKeyWeightThreshold,
+		TransactionBodyExecutionEnabled:        true,
+		EnvironmentParams:                      environment.DefaultEnvironmentParams(),
 	}
 }
 
@@ -217,11 +227,35 @@ func WithTracer(tr module.Tracer) Option {
 	}
 }
 
+// TODO(patrick): remove after emulator has been updated.
+//
 // WithTransactionProcessors sets the transaction processors for a
 // virtual machine context.
-func WithTransactionProcessors(processors ...TransactionProcessor) Option {
+func WithTransactionProcessors(processors ...interface{}) Option {
 	return func(ctx Context) Context {
-		ctx.TransactionProcessors = processors
+		authCheck := false
+		keyWeightThreshold := 0
+		seqNumCheck := false
+		executeBody := false
+
+		for _, p := range processors {
+			switch processor := p.(type) {
+			case *TransactionVerifier:
+				authCheck = true
+				keyWeightThreshold = processor.KeyWeightThreshold
+			case *TransactionSequenceNumberChecker:
+				seqNumCheck = true
+			case *TransactionInvoker:
+				executeBody = true
+			default:
+				panic("Unexpected transaction processor")
+			}
+		}
+
+		ctx.AuthorizationChecksEnabled = authCheck
+		ctx.SequenceNumberCheckAndIncrementEnabled = seqNumCheck
+		ctx.AccountKeyWeightThreshold = keyWeightThreshold
+		ctx.TransactionBodyExecutionEnabled = executeBody
 		return ctx
 	}
 }
@@ -275,6 +309,47 @@ func WithCadenceLogging(enabled bool) Option {
 func WithAccountStorageLimit(enabled bool) Option {
 	return func(ctx Context) Context {
 		ctx.LimitAccountStorage = enabled
+		return ctx
+	}
+}
+
+// WithAuthorizationCheckxEnabled enables or disables pre-execution
+// authorization checks.
+func WithAuthorizationChecksEnabled(enabled bool) Option {
+	return func(ctx Context) Context {
+		ctx.AuthorizationChecksEnabled = enabled
+		return ctx
+	}
+}
+
+// WithSequenceNumberCheckAndIncrementEnabled enables or disables pre-execution
+// sequence number check / increment.
+func WithSequenceNumberCheckAndIncrementEnabled(enabled bool) Option {
+	return func(ctx Context) Context {
+		ctx.SequenceNumberCheckAndIncrementEnabled = enabled
+		return ctx
+	}
+}
+
+// WithAccountKeyWeightThreshold sets the key weight threshold used for
+// authorization checks.  If the threshold is a negative number, signature
+// verification is skipped.
+//
+// Note: This is set only by tests
+func WithAccountKeyWeightThreshold(threshold int) Option {
+	return func(ctx Context) Context {
+		ctx.AccountKeyWeightThreshold = threshold
+		return ctx
+	}
+}
+
+// WithTransactionBodyExecutionEnabled enables or disables the transaction body
+// execution.
+//
+// Note: This is disabled only by tests
+func WithTransactionBodyExecutionEnabled(enabled bool) Option {
+	return func(ctx Context) Context {
+		ctx.TransactionBodyExecutionEnabled = enabled
 		return ctx
 	}
 }

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -134,7 +134,8 @@ func Test_Programs(t *testing.T) {
 
 	context := fvm.NewContext(
 		fvm.WithContractDeploymentRestricted(false),
-		fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		fvm.WithCadenceLogging(true),
 		fvm.WithBlockPrograms(programs))
 

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1095,9 +1095,8 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 	t.Run("Using to much interaction fails but does not panic", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		withContextOptions(
-			fvm.WithTransactionProcessors(
-				fvm.NewTransactionInvoker(),
-			),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		).
 		run(
 			func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, programs *programs.BlockPrograms) {

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -474,9 +474,8 @@ func TestWithServiceAccount(t *testing.T) {
 
 	ctxA := fvm.NewContext(
 		fvm.WithChain(chain),
-		fvm.WithTransactionProcessors(
-			fvm.NewTransactionInvoker(),
-		),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 	)
 
 	view := utils.NewSimpleView()
@@ -523,9 +522,8 @@ func TestEventLimits(t *testing.T) {
 
 	ctx := fvm.NewContext(
 		fvm.WithChain(chain),
-		fvm.WithTransactionProcessors(
-			fvm.NewTransactionInvoker(),
-		),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		fvm.WithBlockPrograms(blockPrograms),
 	)
 
@@ -1580,9 +1578,8 @@ func TestEnforcingComputationLimit(t *testing.T) {
 
 			ctx := fvm.NewContext(
 				fvm.WithChain(chain),
-				fvm.WithTransactionProcessors(
-					fvm.NewTransactionInvoker(),
-				),
+				fvm.WithAuthorizationChecksEnabled(false),
+				fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 				fvm.WithBlockPrograms(blockPrograms),
 			)
 
@@ -1625,7 +1622,8 @@ func TestEnforcingComputationLimit(t *testing.T) {
 func TestStorageCapacity(t *testing.T) {
 	t.Run("Storage capacity updates on FLOW transfer", newVMTest().
 		withContextOptions(
-			fvm.WithTransactionProcessors(fvm.NewTransactionInvoker()),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithCadenceLogging(true),
 		).
 		withBootstrapProcedureOptions(

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -21,8 +21,8 @@ import (
 type TransactionInvoker struct {
 }
 
-func NewTransactionInvoker() TransactionInvoker {
-	return TransactionInvoker{}
+func NewTransactionInvoker() *TransactionInvoker {
+	return &TransactionInvoker{}
 }
 
 func (i TransactionInvoker) Process(

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -135,8 +135,9 @@ func TestAccountFreezing(t *testing.T) {
 			fvm.WithServiceAccount(false),
 			fvm.WithContractDeploymentRestricted(false),
 			fvm.WithCadenceLogging(true),
-			fvm.WithTransactionProcessors( // run with limited processor to test just core of freezing, but still inside FVM
-				fvm.NewTransactionInvoker()),
+			// run with limited processor to test just core of freezing, but still inside FVM
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithBlockPrograms(programsStorage))
 
 		err = vm.Run(context, proc, st.ViewForTestingOnly())
@@ -268,8 +269,9 @@ func TestAccountFreezing(t *testing.T) {
 			fvm.WithServiceAccount(false),
 			fvm.WithContractDeploymentRestricted(false),
 			fvm.WithCadenceLogging(true),
-			fvm.WithTransactionProcessors( // run with limited processor to test just core of freezing, but still inside FVM
-				fvm.NewTransactionInvoker()),
+			// run with limited processor to test just core of freezing, but still inside FVM
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithBlockPrograms(programsStorage))
 
 		err := vm.Run(context, procFrozen, st.ViewForTestingOnly())
@@ -492,9 +494,9 @@ func TestAccountFreezing(t *testing.T) {
 			fvm.WithServiceAccount(false),
 			fvm.WithContractDeploymentRestricted(false),
 			fvm.WithCadenceLogging(true),
-			fvm.WithTransactionProcessors( // run with limited processor to test just core of freezing, but still inside FVM
-				fvm.NewTransactionVerifier(-1),
-				fvm.NewTransactionInvoker()),
+			// run with limited processor to test just core of freezing, but still inside FVM
+			fvm.WithAccountKeyWeightThreshold(-1),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithBlockPrograms(blockPrograms))
 
 		// freeze account

--- a/utils/debug/remoteDebugger.go
+++ b/utils/debug/remoteDebugger.go
@@ -26,10 +26,7 @@ func NewRemoteDebugger(grpcAddress string,
 	ctx := fvm.NewContext(
 		fvm.WithLogger(logger),
 		fvm.WithChain(chain),
-		fvm.WithTransactionProcessors(
-			fvm.NewTransactionSequenceNumberChecker(),
-			fvm.NewTransactionInvoker(),
-		),
+		fvm.WithAuthorizationChecksEnabled(false),
 	)
 
 	return &RemoteDebugger{


### PR DESCRIPTION
I'm going to move all of procedure's Run logic into transaction invoker as follow up.  The TransactionProcessor concept will be replace by a single TransactionExecutor CPS object.  TransactionVerifer and TransactionSeqNumChecker will become like StorageLimitChecker.