### PR TITLE
[Networking] Reduce debug-level log spam

### DIFF
--- a/network/p2p/scoring/score_option.go
+++ b/network/p2p/scoring/score_option.go
@@ -213,12 +213,12 @@ func defaultAppSpecificScoreFunction(logger zerolog.Logger, idProvider module.Id
 		// checks if peer is an access node, and if so, pushes it to the
 		// edges of the network by giving the minimum penalty.
 		if flowId.Role == flow.RoleAccess {
-			lg.Debug().
+			lg.Trace().
 				Msg("pushing access node to edge by penalizing with minimum penalty value")
 			return MinAppSpecificPenalty
 		}
 
-		logger.Debug().
+		lg.Trace().
 			Msg("rewarding well-behaved non-access node peer with maximum reward value")
 		return MaxAppSpecificReward
 	}


### PR DESCRIPTION
Here is an example of spam in the logs:

```
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.192478776Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.192814542Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.192931518Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.193271088Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.197084515Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.197579049Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.199760817Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.199905952Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.20009399Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.200127314Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.200243837Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.200527917Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.2005875Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.200636675Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.200680877Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.2007219Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
Nov 03 20:51:06 execution-001 docker[44381]: {"level":"debug","node_role":"execution","node_id":"9686399a8a5418a12e762cfaeff2ea348c2137f554560917760e0d47acf2cda4","time":"2022-11-03T20:51:06.20167467Z","message":"rewarding well-behaved non-access node peer with maximum reward value"}
```