### PR TITLE
[Profiler] Add selected /debug/pprof/ endpoints to admin interface

### DIFF
--- a/admin/command_runner.go
+++ b/admin/command_runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
 	pb "github.com/onflow/flow-go/admin/admin"
@@ -200,11 +202,17 @@ func (r *CommandRunner) runAdminServer(ctx irrecoverable.SignalerContext) error 
 		}
 	}()
 
-	// Register gRPC server endpoint
-	mux := runtime.NewServeMux()
-	opts := []grpc.DialOption{grpc.WithInsecure()} //nolint:staticcheck
+	// Initialize gRPC and HTTP muxers
+	gwmux := runtime.NewServeMux()
+	mux := http.NewServeMux()
+	mux.Handle("/", gwmux)
+	for _, name := range []string{"allocs", "block", "goroutine", "heap", "mutex", "threadcreate"} {
+		mux.HandleFunc(fmt.Sprintf("/debug/pprof/%s", name), pprof.Handler(name).ServeHTTP)
+	}
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
-	err = pb.RegisterAdminHandlerFromEndpoint(ctx, mux, "unix:///"+r.grpcAddress, opts)
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	err = pb.RegisterAdminHandlerFromEndpoint(ctx, gwmux, "unix:///"+r.grpcAddress, opts)
 	if err != nil {
 		return fmt.Errorf("failed to register http handlers for admin service: %w", err)
 	}

--- a/admin/command_runner.go
+++ b/admin/command_runner.go
@@ -204,18 +204,21 @@ func (r *CommandRunner) runAdminServer(ctx irrecoverable.SignalerContext) error 
 
 	// Initialize gRPC and HTTP muxers
 	gwmux := runtime.NewServeMux()
-	mux := http.NewServeMux()
-	mux.Handle("/", gwmux)
-	for _, name := range []string{"allocs", "block", "goroutine", "heap", "mutex", "threadcreate"} {
-		mux.HandleFunc(fmt.Sprintf("/debug/pprof/%s", name), pprof.Handler(name).ServeHTTP)
-	}
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 	err = pb.RegisterAdminHandlerFromEndpoint(ctx, gwmux, "unix:///"+r.grpcAddress, opts)
 	if err != nil {
 		return fmt.Errorf("failed to register http handlers for admin service: %w", err)
 	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", gwmux)
+
+	// This adds an ability to use standard go tooling for performance troubleshooting e.g.:
+	//  go tool pprof http://localhost:9002/debug/pprof/goroutine
+	for _, name := range []string{"allocs", "block", "goroutine", "heap", "mutex", "threadcreate"} {
+		mux.HandleFunc(fmt.Sprintf("/debug/pprof/%s", name), pprof.Handler(name).ServeHTTP)
+	}
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	httpServer := &http.Server{
 		Addr:      r.httpAddress,

--- a/admin/command_runner_test.go
+++ b/admin/command_runner_test.go
@@ -287,6 +287,22 @@ func (suite *CommandRunnerSuite) TestHTTPServer() {
 	suite.Equal("200 OK", resp.Status)
 }
 
+func (suite *CommandRunnerSuite) TestHTTPPProf() {
+	suite.SetupCommandRunner()
+
+	url := fmt.Sprintf("http://%s/debug/pprof/goroutine", suite.httpAddress)
+	resp, err := http.Get(url)
+	require.NoError(suite.T(), err)
+	defer func() {
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	suite.Equal(resp.Status, "200 OK")
+	suite.Equal(resp.Header.Get("Content-Type"), "application/octet-stream")
+}
+
 func (suite *CommandRunnerSuite) TestListCommands() {
 	suite.bootstrapper.RegisterHandler("foo", func(ctx context.Context, req *CommandRequest) (interface{}, error) {
 		return nil, nil


### PR DESCRIPTION
This diff adds selected `/debug/pprof/` profiling endpoints along with `/debug/pprof/trace` to the admin port.

This adds an ability to use standard go tooling for performance troubleshooting e.g.:
```
$ go tool pprof http://localhost:9002/debug/pprof/goroutine
```

Or using standard system tooling, e.g.:
```
$ curl -o trace.out localhost:9002/debug/pprof/trace
```

PS. There is also an ability to manually trigger AutoProfiler: #3520