### PR TITLE
[Execution] Improve locking in requester and provider engines

### DIFF
--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -133,9 +133,6 @@ func (e *Engine) process(originID flow.Identifier, message interface{}) error {
 	e.metrics.MessageReceived(e.channel.String(), metrics.MessageEntityRequest)
 	defer e.metrics.MessageHandled(e.channel.String(), metrics.MessageEntityRequest)
 
-	e.unit.Lock()
-	defer e.unit.Unlock()
-
 	switch msg := message.(type) {
 	case *messages.EntityRequest:
 		return e.onEntityRequest(originID, msg)

--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -25,6 +25,7 @@ import (
 // related entities. It is important that the retrieve function return a
 // `storage.ErrNotFound` error if the entity does not exist locally; otherwise,
 // the logic will error and not send responses when failing to retrieve entities.
+// This method must be concurrency safe.
 type RetrieveFunc func(flow.Identifier) (flow.Entity, error)
 
 // Engine is a generic provider engine, handling the fulfillment of entity

--- a/engine/common/requester/engine.go
+++ b/engine/common/requester/engine.go
@@ -286,6 +286,7 @@ func (e *Engine) dispatchRequest() (bool, error) {
 	var providerID flow.Identifier
 	var entityIDs []flow.Identifier
 
+	// Lock here, and to unlock before calling Unicast
 	e.unit.Lock()
 	e.log.Debug().Int("num_entities", len(e.items)).Msg("selecting entities")
 	for entityID, item := range e.items {

--- a/engine/common/requester/engine.go
+++ b/engine/common/requester/engine.go
@@ -275,11 +275,6 @@ PollLoop:
 
 func (e *Engine) dispatchRequest() (bool, error) {
 
-	e.unit.Lock()
-	defer e.unit.Unlock()
-
-	e.log.Debug().Int("num_entities", len(e.items)).Msg("selecting entities")
-
 	// get the current top-level set of valid providers
 	providers, err := e.state.Final().Identities(e.selector)
 	if err != nil {
@@ -290,6 +285,9 @@ func (e *Engine) dispatchRequest() (bool, error) {
 	now := time.Now().UTC()
 	var providerID flow.Identifier
 	var entityIDs []flow.Identifier
+
+	e.unit.Lock()
+	e.log.Debug().Int("num_entities", len(e.items)).Msg("selecting entities")
 	for entityID, item := range e.items {
 
 		// if the item should not be requested yet, ignore
@@ -326,6 +324,7 @@ func (e *Engine) dispatchRequest() (bool, error) {
 		if providerID == flow.ZeroID {
 			providers = providers.Filter(item.ExtraSelector)
 			if len(providers) == 0 {
+				e.unit.Unlock()
 				return false, fmt.Errorf("no valid providers available")
 			}
 			providerID = providers.Sample(1)[0].NodeID
@@ -356,6 +355,7 @@ func (e *Engine) dispatchRequest() (bool, error) {
 			break
 		}
 	}
+	e.unit.Unlock()
 
 	// if there are no items to request, return
 	if len(entityIDs) == 0 {
@@ -383,7 +383,9 @@ func (e *Engine) dispatchRequest() (bool, error) {
 	if err != nil {
 		return true, fmt.Errorf("could not send request: %w", err)
 	}
+	e.unit.Lock()
 	e.requests[req.Nonce] = req
+	e.unit.Unlock()
 
 	if e.log.Debug().Enabled() {
 		e.log.Debug().


### PR DESCRIPTION
This PR makes 2 changes:
* In the provider engine, remove the lock protecting `onEntityRequest`. This method doesn't have any shared state and shouldn't need locking
* In the requester engine, unlock before sending a request over unicast to avoid blocking the network layer if there are slow unicast requests.