### PR TITLE
Add consensus and sync-related message types without nil struct fields

### DIFF
--- a/engine/collection/compliance/core_test.go
+++ b/engine/collection/compliance/core_test.go
@@ -187,14 +187,13 @@ func (cs *ComplianceCoreSuite) TestOnBlockProposalValidParent() {
 	block := unittest.ClusterBlockWithParent(cs.head)
 
 	proposal := &messages.ClusterBlockProposal{
-		Header:  block.Header,
-		Payload: block.Payload,
+		Block: messages.UntrustedClusterBlockFromInternal(&block),
 	}
 
 	// store the data for retrieval
 	cs.headerDB[block.Header.ParentID] = cs.head
 
-	cs.hotstuff.On("SubmitProposal", proposal.Header, cs.head.Header.View).Return(doneChan())
+	cs.hotstuff.On("SubmitProposal", block.Header, cs.head.Header.View).Return(doneChan())
 
 	// it should be processed without error
 	err := cs.core.OnBlockProposal(originID, proposal)
@@ -228,8 +227,7 @@ func (cs *ComplianceCoreSuite) TestOnBlockProposalValidAncestor() {
 	parent := unittest.ClusterBlockWithParent(&ancestor)
 	block := unittest.ClusterBlockWithParent(&parent)
 	proposal := &messages.ClusterBlockProposal{
-		Header:  block.Header,
-		Payload: block.Payload,
+		Block: messages.UntrustedClusterBlockFromInternal(&block),
 	}
 
 	// store the data for retrieval
@@ -257,8 +255,7 @@ func (cs *ComplianceCoreSuite) TestOnBlockProposalInvalidExtension() {
 	parent := unittest.ClusterBlockWithParent(&ancestor)
 	block := unittest.ClusterBlockWithParent(&parent)
 	proposal := &messages.ClusterBlockProposal{
-		Header:  block.Header,
-		Payload: block.Payload,
+		Block: messages.UntrustedClusterBlockFromInternal(&block),
 	}
 
 	// store the data for retrieval
@@ -290,8 +287,7 @@ func (cs *ComplianceCoreSuite) TestProcessBlockAndDescendants() {
 	// create three children blocks
 	parent := unittest.ClusterBlockWithParent(cs.head)
 	proposal := &messages.ClusterBlockProposal{
-		Header:  parent.Header,
-		Payload: parent.Payload,
+		Block: messages.UntrustedClusterBlockFromInternal(&parent),
 	}
 	block1 := unittest.ClusterBlockWithParent(&parent)
 	block2 := unittest.ClusterBlockWithParent(&parent)
@@ -392,8 +388,7 @@ func (cs *ComplianceCoreSuite) TestProposalBufferingOrder() {
 		)
 
 		proposal := &messages.ClusterBlockProposal{
-			Header:  block.Header,
-			Payload: block.Payload,
+			Block: messages.UntrustedClusterBlockFromInternal(block),
 		}
 
 		// process and make sure no error occurs (as they are unverifiable)
@@ -423,8 +418,7 @@ func (cs *ComplianceCoreSuite) TestProposalBufferingOrder() {
 	).Return(doneChan())
 
 	missingProposal := &messages.ClusterBlockProposal{
-		Header:  missing.Header,
-		Payload: missing.Payload,
+		Block: messages.UntrustedClusterBlockFromInternal(missing),
 	}
 
 	proposalsLookup[missing.ID()] = missing

--- a/engine/collection/compliance/engine.go
+++ b/engine/collection/compliance/engine.go
@@ -128,8 +128,7 @@ func NewEngine(
 				msg = &engine.Message{
 					OriginID: msg.OriginID,
 					Payload: &messages.ClusterBlockProposal{
-						Header:  syncedBlock.Block.Header,
-						Payload: syncedBlock.Block.Payload,
+						Block: syncedBlock.Block,
 					},
 				}
 				return msg, true
@@ -401,9 +400,12 @@ func (e *Engine) BroadcastProposalWithDelay(header *flow.Header, delay time.Dura
 		go e.core.hotstuff.SubmitProposal(header, parent.View)
 
 		// create the proposal message for the collection
-		msg := &messages.ClusterBlockProposal{
+		block := &cluster.Block{
 			Header:  header,
 			Payload: payload,
+		}
+		msg := &messages.ClusterBlockProposal{
+			Block: messages.UntrustedClusterBlockFromInternal(block),
 		}
 
 		err := e.con.Publish(msg, recipients.NodeIDs()...)
@@ -418,10 +420,6 @@ func (e *Engine) BroadcastProposalWithDelay(header *flow.Header, delay time.Dura
 		log.Info().Msg("cluster proposal proposed")
 
 		e.metrics.MessageSent(metrics.EngineClusterCompliance, metrics.MessageClusterBlockProposal)
-		block := &cluster.Block{
-			Header:  header,
-			Payload: payload,
-		}
 		e.core.collectionMetrics.ClusterBlockProposed(block)
 	})
 

--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -300,7 +300,7 @@ func (e *Engine) onSyncResponse(originID flow.Identifier, res *messages.SyncResp
 func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.ClusterBlockResponse) {
 	// process the blocks one by one
 	for _, block := range res.Blocks {
-		if !e.core.HandleBlock(block.Header) {
+		if !e.core.HandleBlock(&block.Header) {
 			continue
 		}
 		synced := &events.SyncedClusterBlock{

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -430,18 +430,18 @@ func (ss *SyncSuite) TestOnBlockResponse() {
 	originID := unittest.IdentifierFixture()
 	res := &messages.ClusterBlockResponse{
 		Nonce:  rand.Uint64(),
-		Blocks: []*clustermodel.Block{},
+		Blocks: []messages.UntrustedClusterBlock{},
 	}
 
 	// add one block that should be processed
 	processable := unittest.ClusterBlockFixture()
 	ss.core.On("HandleBlock", processable.Header).Return(true)
-	res.Blocks = append(res.Blocks, &processable)
+	res.Blocks = append(res.Blocks, messages.UntrustedClusterBlockFromInternal(&processable))
 
 	// add one block that should not be processed
 	unprocessable := unittest.ClusterBlockFixture()
 	ss.core.On("HandleBlock", unprocessable.Header).Return(false)
-	res.Blocks = append(res.Blocks, &unprocessable)
+	res.Blocks = append(res.Blocks, messages.UntrustedClusterBlockFromInternal(&unprocessable))
 
 	ss.comp.On("SubmitLocal", mock.Anything).Run(func(args mock.Arguments) {
 		res := args.Get(0).(*events.SyncedBlock)

--- a/engine/collection/synchronization/request_handler.go
+++ b/engine/collection/synchronization/request_handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/onflow/flow-go/engine"
 	commonsync "github.com/onflow/flow-go/engine/common/synchronization"
-	clustermodel "github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
@@ -235,7 +234,7 @@ func (r *RequestHandlerEngine) onRangeRequest(originID flow.Identifier, req *mes
 	}
 
 	// get all of the blocks, one by one
-	blocks := make([]*clustermodel.Block, 0, req.ToHeight-req.FromHeight+1)
+	blocks := make([]messages.UntrustedClusterBlock, 0, req.ToHeight-req.FromHeight+1)
 	for height := req.FromHeight; height <= req.ToHeight; height++ {
 		block, err := r.blocks.ByHeight(height)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -245,7 +244,7 @@ func (r *RequestHandlerEngine) onRangeRequest(originID flow.Identifier, req *mes
 		if err != nil {
 			return fmt.Errorf("could not get block for height (%d): %w", height, err)
 		}
-		blocks = append(blocks, block)
+		blocks = append(blocks, messages.UntrustedClusterBlockFromInternal(block))
 	}
 
 	// if there are no blocks to send, skip network message
@@ -304,7 +303,7 @@ func (r *RequestHandlerEngine) onBatchRequest(originID flow.Identifier, req *mes
 	}
 
 	// try to get all the blocks by ID
-	blocks := make([]*clustermodel.Block, 0, len(blockIDs))
+	blocks := make([]messages.UntrustedClusterBlock, 0, len(blockIDs))
 	for blockID := range blockIDs {
 		block, err := r.blocks.ByID(blockID)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -314,7 +313,7 @@ func (r *RequestHandlerEngine) onBatchRequest(originID flow.Identifier, req *mes
 		if err != nil {
 			return fmt.Errorf("could not get block by ID (%s): %w", blockID, err)
 		}
-		blocks = append(blocks, block)
+		blocks = append(blocks, messages.UntrustedClusterBlockFromInternal(block))
 	}
 
 	// if there are no blocks to send, skip network message

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -302,7 +302,7 @@ func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.BlockRe
 	e.log.Debug().Uint64("first", first).Uint64("last", last).Msg("received block response")
 
 	for _, block := range res.Blocks {
-		if !e.core.HandleBlock(block.Header) {
+		if !e.core.HandleBlock(&block.Header) {
 			e.log.Debug().Uint64("height", block.Header.Height).Msg("block handler rejected")
 			continue
 		}

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -444,18 +444,18 @@ func (ss *SyncSuite) TestOnBlockResponse() {
 	originID := unittest.IdentifierFixture()
 	res := &messages.BlockResponse{
 		Nonce:  rand.Uint64(),
-		Blocks: []*flow.Block{},
+		Blocks: []messages.UntrustedBlock{},
 	}
 
 	// add one block that should be processed
 	processable := unittest.BlockFixture()
 	ss.core.On("HandleBlock", processable.Header).Return(true)
-	res.Blocks = append(res.Blocks, &processable)
+	res.Blocks = append(res.Blocks, messages.UntrustedBlockFromInternal(&processable))
 
 	// add one block that should not be processed
 	unprocessable := unittest.BlockFixture()
 	ss.core.On("HandleBlock", unprocessable.Header).Return(false)
-	res.Blocks = append(res.Blocks, &unprocessable)
+	res.Blocks = append(res.Blocks, messages.UntrustedBlockFromInternal(&unprocessable))
 
 	ss.comp.On("SubmitLocal", mock.Anything).Run(func(args mock.Arguments) {
 		res := args.Get(0).(*events.SyncedBlock)

--- a/engine/common/synchronization/request_handler.go
+++ b/engine/common/synchronization/request_handler.go
@@ -218,7 +218,7 @@ func (r *RequestHandler) onRangeRequest(originID flow.Identifier, req *messages.
 	}
 
 	// get all of the blocks, one by one
-	blocks := make([]*flow.Block, 0, req.ToHeight-req.FromHeight+1)
+	blocks := make([]messages.UntrustedBlock, 0, req.ToHeight-req.FromHeight+1)
 	for height := req.FromHeight; height <= req.ToHeight; height++ {
 		block, err := r.blocks.ByHeight(height)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -228,7 +228,7 @@ func (r *RequestHandler) onRangeRequest(originID flow.Identifier, req *messages.
 		if err != nil {
 			return fmt.Errorf("could not get block for height (%d): %w", height, err)
 		}
-		blocks = append(blocks, block)
+		blocks = append(blocks, messages.UntrustedBlockFromInternal(block))
 	}
 
 	// if there are no blocks to send, skip network message
@@ -290,7 +290,7 @@ func (r *RequestHandler) onBatchRequest(originID flow.Identifier, req *messages.
 	}
 
 	// try to get all the blocks by ID
-	blocks := make([]*flow.Block, 0, len(blockIDs))
+	blocks := make([]messages.UntrustedBlock, 0, len(blockIDs))
 	for blockID := range blockIDs {
 		block, err := r.blocks.ByID(blockID)
 		if errors.Is(err, storage.ErrNotFound) {
@@ -300,7 +300,7 @@ func (r *RequestHandler) onBatchRequest(originID flow.Identifier, req *messages.
 		if err != nil {
 			return fmt.Errorf("could not get block by ID (%s): %w", blockID, err)
 		}
-		blocks = append(blocks, block)
+		blocks = append(blocks, messages.UntrustedBlockFromInternal(block))
 	}
 
 	// if there are no blocks to send, skip network message

--- a/engine/consensus/compliance/core_test.go
+++ b/engine/consensus/compliance/core_test.go
@@ -443,7 +443,7 @@ func (cs *ComplianceCoreSuite) TestProposalBufferingOrder() {
 	var proposals []*messages.BlockProposal
 	parent := missing
 	for i := 0; i < 3; i++ {
-		descendant := unittest.BlockWithParentFixture(parent.Header)
+		descendant := unittest.BlockWithParentFixture(&parent.Block.Header)
 		proposal := unittest.ProposalFromBlock(descendant)
 		proposals = append(proposals, proposal)
 		parent = proposal
@@ -459,7 +459,7 @@ func (cs *ComplianceCoreSuite) TestProposalBufferingOrder() {
 		cs.sync.On("RequestBlock", mock.Anything, mock.Anything).Once().Run(
 			func(args mock.Arguments) {
 				ancestorID := args.Get(0).(flow.Identifier)
-				assert.Equal(cs.T(), missing.Header.ID(), ancestorID, "should always request root block")
+				assert.Equal(cs.T(), missing.Block.Header.ID(), ancestorID, "should always request root block")
 			},
 		)
 
@@ -475,10 +475,10 @@ func (cs *ComplianceCoreSuite) TestProposalBufferingOrder() {
 	*cs.hotstuff = module.HotStuff{}
 	index := 0
 	order := []flow.Identifier{
-		missing.Header.ID(),
-		proposals[0].Header.ID(),
-		proposals[1].Header.ID(),
-		proposals[2].Header.ID(),
+		missing.Block.Header.ID(),
+		proposals[0].Block.Header.ID(),
+		proposals[1].Block.Header.ID(),
+		proposals[2].Block.Header.ID(),
 	}
 	cs.hotstuff.On("SubmitProposal", mock.Anything, mock.Anything).Times(4).Run(
 		func(args mock.Arguments) {

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -141,8 +141,7 @@ func NewEngine(
 				msg = &engine.Message{
 					OriginID: msg.OriginID,
 					Payload: &messages.BlockProposal{
-						Payload: syncedBlock.Block.Payload,
-						Header:  syncedBlock.Block.Header,
+						Block: syncedBlock.Block,
 					},
 				}
 				return msg, true
@@ -301,8 +300,7 @@ func (e *Engine) processAvailableMessages() error {
 			for _, block := range blockResponse.Blocks {
 				// process each block and indicate it's from a range of blocks
 				err := e.core.OnBlockProposal(msg.OriginID, &messages.BlockProposal{
-					Header:  block.Header,
-					Payload: block.Payload,
+					Block: block,
 				}, true)
 
 				if err != nil {
@@ -427,9 +425,12 @@ func (e *Engine) BroadcastProposalWithDelay(header *flow.Header, delay time.Dura
 		// NOTE: some fields are not needed for the message
 		// - proposer ID is conveyed over the network message
 		// - the payload hash is deduced from the payload
-		proposal := &messages.BlockProposal{
+		block := &flow.Block{
 			Header:  header,
 			Payload: payload,
+		}
+		proposal := &messages.BlockProposal{
+			Block: messages.UntrustedBlockFromInternal(block),
 		}
 
 		// broadcast the proposal to consensus nodes

--- a/engine/consensus/compliance/engine_test.go
+++ b/engine/consensus/compliance/engine_test.go
@@ -115,8 +115,7 @@ func (cs *ComplianceSuite) TestBroadcastProposalWithDelay() {
 	header.ChainID = "test"
 	header.Height = 11
 	msg := &messages.BlockProposal{
-		Header:  header,
-		Payload: block.Payload,
+		Block: messages.UntrustedBlockFromInternal(block),
 	}
 
 	done := func() <-chan struct{} {

--- a/model/events/synchronization.go
+++ b/model/events/synchronization.go
@@ -1,16 +1,16 @@
 package events
 
 import (
-	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/messages"
 )
 
 type SyncedBlock struct {
 	OriginID flow.Identifier
-	Block    *flow.Block
+	Block    messages.UntrustedBlock
 }
 
 type SyncedClusterBlock struct {
 	OriginID flow.Identifier
-	Block    *cluster.Block
+	Block    messages.UntrustedClusterBlock
 }

--- a/model/messages/consensus.go
+++ b/model/messages/consensus.go
@@ -4,11 +4,103 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// BlockProposal is part of the consensus protocol and represents the the leader
+type UntrustedExecutionResult struct {
+	PreviousResultID flow.Identifier
+	BlockID          flow.Identifier
+	Chunks           []flow.Chunk
+	ServiceEvents    flow.ServiceEventList
+	ExecutionDataID  flow.Identifier
+}
+
+func (ur UntrustedExecutionResult) ToFlowResult() *flow.ExecutionResult {
+	result := flow.ExecutionResult{
+		PreviousResultID: ur.PreviousResultID,
+		BlockID:          ur.PreviousResultID,
+		Chunks:           make(flow.ChunkList, 0, len(ur.Chunks)),
+		ServiceEvents:    ur.ServiceEvents,
+		ExecutionDataID:  ur.ExecutionDataID,
+	}
+	for _, chunk := range ur.Chunks {
+		result.Chunks = append(result.Chunks, &chunk)
+	}
+	return &result
+}
+
+func UntrustedExecutionResultFromInternal(flowResult *flow.ExecutionResult) UntrustedExecutionResult {
+	result := UntrustedExecutionResult{
+		PreviousResultID: flowResult.PreviousResultID,
+		BlockID:          flowResult.BlockID,
+		Chunks:           make([]flow.Chunk, 0, flowResult.Chunks.Len()),
+		ServiceEvents:    flowResult.ServiceEvents,
+		ExecutionDataID:  flowResult.ExecutionDataID,
+	}
+	for _, chunk := range flowResult.Chunks {
+		result.Chunks = append(result.Chunks, *chunk)
+	}
+	return result
+}
+
+type UntrustedBlockPayload struct {
+	Guarantees []flow.CollectionGuarantee
+	Seals      []flow.Seal
+	Receipts   []flow.ExecutionReceiptMeta
+	Results    []UntrustedExecutionResult
+}
+
+type UntrustedBlock struct {
+	Header  flow.Header
+	Payload UntrustedBlockPayload
+}
+
+func (ub UntrustedBlock) ToInternal() *flow.Block {
+	block := flow.Block{
+		Header: &ub.Header,
+		Payload: &flow.Payload{
+			Guarantees: make([]*flow.CollectionGuarantee, 0, len(ub.Payload.Guarantees)),
+			Seals:      make([]*flow.Seal, 0, len(ub.Payload.Seals)),
+			Receipts:   make(flow.ExecutionReceiptMetaList, 0, len(ub.Payload.Receipts)),
+			Results:    make(flow.ExecutionResultList, 0, len(ub.Payload.Results)),
+		},
+	}
+	for _, guarantee := range ub.Payload.Guarantees {
+		block.Payload.Guarantees = append(block.Payload.Guarantees, &guarantee)
+	}
+	for _, seal := range ub.Payload.Seals {
+		block.Payload.Seals = append(block.Payload.Seals, &seal)
+	}
+	for _, receipt := range ub.Payload.Receipts {
+		block.Payload.Receipts = append(block.Payload.Receipts, &receipt)
+	}
+	for _, result := range ub.Payload.Results {
+		block.Payload.Results = append(block.Payload.Results, result.ToFlowResult())
+	}
+
+	return &block
+}
+
+func UntrustedBlockFromInternal(flowBlock *flow.Block) UntrustedBlock {
+	block := UntrustedBlock{
+		Header: *flowBlock.Header,
+	}
+	for _, guarantee := range flowBlock.Payload.Guarantees {
+		block.Payload.Guarantees = append(block.Payload.Guarantees, *guarantee)
+	}
+	for _, seal := range flowBlock.Payload.Seals {
+		block.Payload.Seals = append(block.Payload.Seals, *seal)
+	}
+	for _, receipt := range flowBlock.Payload.Receipts {
+		block.Payload.Receipts = append(block.Payload.Receipts, *receipt)
+	}
+	for _, result := range flowBlock.Payload.Results {
+		block.Payload.Results = append(block.Payload.Results, UntrustedExecutionResultFromInternal(result))
+	}
+	return block
+}
+
+// BlockProposal is part of the consensus protocol and represents the leader
 // of a consensus round pushing a new proposal to the network.
 type BlockProposal struct {
-	Header  *flow.Header
-	Payload *flow.Payload
+	Block UntrustedBlock
 }
 
 // BlockVote is part of the consensus protocol and represents a consensus node

--- a/model/messages/synchronization.go
+++ b/model/messages/synchronization.go
@@ -1,7 +1,6 @@
 package messages
 
 import (
-	"github.com/onflow/flow-go/model/cluster"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -44,12 +43,12 @@ type BatchRequest struct {
 // that should correspond to the request.
 type BlockResponse struct {
 	Nonce  uint64
-	Blocks []*flow.Block
+	Blocks []UntrustedBlock
 }
 
 // ClusterBlockResponse is the same thing as BlockResponse, but for cluster
 // consensus.
 type ClusterBlockResponse struct {
 	Nonce  uint64
-	Blocks []*cluster.Block
+	Blocks []UntrustedClusterBlock
 }

--- a/module/buffer/pending_blocks.go
+++ b/module/buffer/pending_blocks.go
@@ -18,7 +18,7 @@ func NewPendingBlocks() *PendingBlocks {
 }
 
 func (b *PendingBlocks) Add(originID flow.Identifier, proposal *messages.BlockProposal) bool {
-	return b.backend.add(originID, proposal.Header, proposal.Payload)
+	return b.backend.add(originID, &proposal.Block.Header, &proposal.Block.Payload)
 }
 
 func (b *PendingBlocks) ByID(blockID flow.Identifier) (*flow.PendingBlock, bool) {

--- a/module/buffer/pending_cluster_blocks.go
+++ b/module/buffer/pending_cluster_blocks.go
@@ -16,7 +16,7 @@ func NewPendingClusterBlocks() *PendingClusterBlocks {
 }
 
 func (b *PendingClusterBlocks) Add(originID flow.Identifier, proposal *messages.ClusterBlockProposal) bool {
-	return b.backend.add(originID, proposal.Header, proposal.Payload)
+	return b.backend.add(originID, &proposal.Block.Header, &proposal.Block.Payload)
 }
 
 func (b *PendingClusterBlocks) ByID(blockID flow.Identifier) (*cluster.PendingBlock, bool) {

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -199,16 +199,14 @@ func ProposalFixture() *messages.BlockProposal {
 
 func ProposalFromBlock(block *flow.Block) *messages.BlockProposal {
 	proposal := &messages.BlockProposal{
-		Header:  block.Header,
-		Payload: block.Payload,
+		Block: messages.UntrustedBlockFromInternal(block),
 	}
 	return proposal
 }
 
 func ClusterProposalFromBlock(block *cluster.Block) *messages.ClusterBlockProposal {
 	proposal := &messages.ClusterBlockProposal{
-		Header:  block.Header,
-		Payload: block.Payload,
+		Block: messages.UntrustedClusterBlockFromInternal(block),
 	}
 	return proposal
 }


### PR DESCRIPTION
This PR implements a new approach to structural validity, by adding new inbound message types without nil struct fields. Replaces https://github.com/onflow/flow-go/pull/3470.

The primary purpose is to ensure safety against nil struct fields or slice entries. The secondary purpose is to begin to separate the internal (trusted) and external (untrusted) representations of a message, to enable eg. caching the ID of a trusted entity model.

This is still a draft - I will add documentation for the new types if we're happy with the general approach. 