### PR TITLE
Refactor generic derived data implementation.

### DIFF
--- a/fvm/programs/block_derived_data.go
+++ b/fvm/programs/block_derived_data.go
@@ -3,10 +3,13 @@ package programs
 import (
 	"fmt"
 	"sync"
+
+	"github.com/onflow/flow-go/fvm/state"
 )
 
 type invalidatableEntry[TVal any] struct {
-	Entry TVal // Immutable after initialization.
+	Value TVal         // immutable after initialization.
+	State *state.State // immutable after initialization.
 
 	isInvalid bool // Guarded by BlockDerivedData' lock.
 }
@@ -28,7 +31,7 @@ type BlockDerivedData[TKey comparable, TVal any] struct {
 
 	latestCommitExecutionTime LogicalTime
 
-	invalidators chainedDerivedDataInvalidators[TVal] // Guarded by lock.
+	invalidators chainedDerivedDataInvalidators[TKey, TVal] // Guarded by lock.
 }
 
 type TransactionDerivedData[TKey comparable, TVal any] struct {
@@ -42,11 +45,11 @@ type TransactionDerivedData[TKey comparable, TVal any] struct {
 	executionTime LogicalTime
 
 	readSet  map[TKey]*invalidatableEntry[TVal]
-	writeSet map[TKey]TVal
+	writeSet map[TKey]*invalidatableEntry[TVal]
 
 	// When isSnapshotReadTransaction is true, invalidators must be empty.
 	isSnapshotReadTransaction bool
-	invalidators              chainedDerivedDataInvalidators[TVal]
+	invalidators              chainedDerivedDataInvalidators[TKey, TVal]
 }
 
 func newEmptyBlockDerivedData[TKey comparable, TVal any](latestCommit LogicalTime) *BlockDerivedData[TKey, TVal] {
@@ -76,8 +79,12 @@ func (block *BlockDerivedData[TKey, TVal]) NewChildBlockDerivedData() *BlockDeri
 		len(block.items))
 
 	for key, entry := range block.items {
+		// Note: We need to deep copy the invalidatableEntry here since the
+		// entry may be valid in the parent block, but invalid in the child
+		// block.
 		items[key] = &invalidatableEntry[TVal]{
-			Entry:     entry.Entry,
+			Value:     entry.Value,
+			State:     entry.State,
 			isInvalid: false,
 		}
 	}
@@ -114,7 +121,7 @@ func (block *BlockDerivedData[TKey, TVal]) EntriesForTestingOnly() map[TKey]*inv
 	return entries
 }
 
-func (block *BlockDerivedData[TKey, TVal]) InvalidatorsForTestingOnly() chainedDerivedDataInvalidators[TVal] {
+func (block *BlockDerivedData[TKey, TVal]) InvalidatorsForTestingOnly() chainedDerivedDataInvalidators[TKey, TVal] {
 	block.lock.RLock()
 	defer block.lock.RUnlock()
 
@@ -123,12 +130,8 @@ func (block *BlockDerivedData[TKey, TVal]) InvalidatorsForTestingOnly() chainedD
 
 func (block *BlockDerivedData[TKey, TVal]) GetForTestingOnly(
 	key TKey,
-) *TVal {
-	entry := block.get(key)
-	if entry != nil {
-		return &entry.Entry
-	}
-	return nil
+) *invalidatableEntry[TVal] {
+	return block.get(key)
 }
 
 func (block *BlockDerivedData[TKey, TVal]) get(
@@ -177,8 +180,8 @@ func (block *BlockDerivedData[TKey, TVal]) unsafeValidate(
 	applicable := block.invalidators.ApplicableInvalidators(
 		item.snapshotTime)
 	if applicable.ShouldInvalidateEntries() {
-		for _, entry := range item.writeSet {
-			if applicable.ShouldInvalidateEntry(entry) {
+		for key, entry := range item.writeSet {
+			if applicable.ShouldInvalidateEntry(key, entry.Value, entry.State) {
 				return newRetryableError(
 					"invalid TransactionDerivedDatas. outdated write set")
 			}
@@ -198,19 +201,19 @@ func (block *BlockDerivedData[TKey, TVal]) validate(
 }
 
 func (block *BlockDerivedData[TKey, TVal]) commit(
-	item *TransactionDerivedData[TKey, TVal],
+	txn *TransactionDerivedData[TKey, TVal],
 ) RetryableError {
 	block.lock.Lock()
 	defer block.lock.Unlock()
 
 	// NOTE: Instead of throwing out all the write entries, we can commit
 	// the valid write entries then return error.
-	err := block.unsafeValidate(item)
+	err := block.unsafeValidate(txn)
 	if err != nil {
 		return err
 	}
 
-	for key, entry := range item.writeSet {
+	for key, entry := range txn.writeSet {
 		_, ok := block.items[key]
 		if ok {
 			// A previous transaction already committed an equivalent TransactionDerivedData
@@ -219,16 +222,15 @@ func (block *BlockDerivedData[TKey, TVal]) commit(
 			continue
 		}
 
-		block.items[key] = &invalidatableEntry[TVal]{
-			Entry:     entry,
-			isInvalid: false,
-		}
+		block.items[key] = entry
 	}
 
-	if item.invalidators.ShouldInvalidateEntries() {
+	if txn.invalidators.ShouldInvalidateEntries() {
 		for key, entry := range block.items {
-			if item.invalidators.ShouldInvalidateEntry(
-				entry.Entry) {
+			if txn.invalidators.ShouldInvalidateEntry(
+				key,
+				entry.Value,
+				entry.State) {
 
 				entry.isInvalid = true
 				delete(block.items, key)
@@ -237,15 +239,15 @@ func (block *BlockDerivedData[TKey, TVal]) commit(
 
 		block.invalidators = append(
 			block.invalidators,
-			item.invalidators...)
+			txn.invalidators...)
 	}
 
 	// NOTE: We cannot advance commit time when we encounter a snapshot read
 	// (aka script) transaction since these transactions don't generate new
 	// snapshots.  It is safe to commit the entries since snapshot read
 	// transactions never invalidate entries.
-	if !item.isSnapshotReadTransaction {
-		block.latestCommitExecutionTime = item.executionTime
+	if !txn.isSnapshotReadTransaction {
+		block.latestCommitExecutionTime = txn.executionTime
 	}
 	return nil
 }
@@ -277,7 +279,7 @@ func (block *BlockDerivedData[TKey, TVal]) newTransactionDerivedData(
 		snapshotTime:              snapshotTime,
 		executionTime:             executionTime,
 		readSet:                   map[TKey]*invalidatableEntry[TVal]{},
-		writeSet:                  map[TKey]TVal{},
+		writeSet:                  map[TKey]*invalidatableEntry[TVal]{},
 		isSnapshotReadTransaction: isSnapshotReadTransaction,
 	}, nil
 }
@@ -310,49 +312,63 @@ func (block *BlockDerivedData[TKey, TVal]) NewTransactionDerivedData(
 		false)
 }
 
-func (item *TransactionDerivedData[TKey, TVal]) Get(key TKey) *TVal {
-	writeEntry, ok := item.writeSet[key]
+func (txn *TransactionDerivedData[TKey, TVal]) Get(key TKey) (
+	TVal,
+	*state.State,
+	bool,
+) {
+
+	writeEntry, ok := txn.writeSet[key]
 	if ok {
-		return &writeEntry
+		return writeEntry.Value, writeEntry.State, true
 	}
 
-	readEntry := item.readSet[key]
+	readEntry := txn.readSet[key]
 	if readEntry != nil {
-		return &readEntry.Entry
+		return readEntry.Value, readEntry.State, true
 	}
 
-	readEntry = item.block.get(key)
+	readEntry = txn.block.get(key)
 	if readEntry != nil {
-		item.readSet[key] = readEntry
-		return &readEntry.Entry
+		txn.readSet[key] = readEntry
+		return readEntry.Value, readEntry.State, true
 	}
 
-	return nil
+	var defaultValue TVal
+	return defaultValue, nil, false
 }
 
-func (item *TransactionDerivedData[TKey, TVal]) Set(key TKey, val TVal) {
-	item.writeSet[key] = val
+func (txn *TransactionDerivedData[TKey, TVal]) Set(
+	key TKey,
+	value TVal,
+	state *state.State,
+) {
+	txn.writeSet[key] = &invalidatableEntry[TVal]{
+		Value:     value,
+		State:     state,
+		isInvalid: false,
+	}
 }
 
-func (item *TransactionDerivedData[TKey, TVal]) AddInvalidator(
-	invalidator DerivedDataInvalidator[TVal],
+func (txn *TransactionDerivedData[TKey, TVal]) AddInvalidator(
+	invalidator DerivedDataInvalidator[TKey, TVal],
 ) {
 	if invalidator == nil || !invalidator.ShouldInvalidateEntries() {
 		return
 	}
 
-	item.invalidators = append(
-		item.invalidators,
-		derivedDataInvalidatorAtTime[TVal]{
+	txn.invalidators = append(
+		txn.invalidators,
+		derivedDataInvalidatorAtTime[TKey, TVal]{
 			DerivedDataInvalidator: invalidator,
-			executionTime:          item.executionTime,
+			executionTime:          txn.executionTime,
 		})
 }
 
-func (item *TransactionDerivedData[TKey, TVal]) Validate() RetryableError {
-	return item.block.validate(item)
+func (txn *TransactionDerivedData[TKey, TVal]) Validate() RetryableError {
+	return txn.block.validate(txn)
 }
 
-func (item *TransactionDerivedData[TKey, TVal]) Commit() RetryableError {
-	return item.block.commit(item)
+func (txn *TransactionDerivedData[TKey, TVal]) Commit() RetryableError {
+	return txn.block.commit(txn)
 }

--- a/fvm/programs/block_derived_data_invalidator.go
+++ b/fvm/programs/block_derived_data_invalidator.go
@@ -1,26 +1,30 @@
 package programs
 
-type DerivedDataInvalidator[TVal any] interface {
+import (
+	"github.com/onflow/flow-go/fvm/state"
+)
+
+type DerivedDataInvalidator[TKey comparable, TVal any] interface {
 	// This returns true if the this invalidates any data
 	ShouldInvalidateEntries() bool
 
 	// This returns true if the data entry should be invalidated.
-	ShouldInvalidateEntry(TVal) bool
+	ShouldInvalidateEntry(TKey, TVal, *state.State) bool
 }
 
-type derivedDataInvalidatorAtTime[TVal any] struct {
-	DerivedDataInvalidator[TVal]
+type derivedDataInvalidatorAtTime[TKey comparable, TVal any] struct {
+	DerivedDataInvalidator[TKey, TVal]
 
 	executionTime LogicalTime
 }
 
 // NOTE: chainedInvalidator assumes that the entries are order by non-decreasing
 // execution time.
-type chainedDerivedDataInvalidators[TVal any] []derivedDataInvalidatorAtTime[TVal]
+type chainedDerivedDataInvalidators[TKey comparable, TVal any] []derivedDataInvalidatorAtTime[TKey, TVal]
 
-func (chained chainedDerivedDataInvalidators[TVal]) ApplicableInvalidators(
+func (chained chainedDerivedDataInvalidators[TKey, TVal]) ApplicableInvalidators(
 	snapshotTime LogicalTime,
-) chainedDerivedDataInvalidators[TVal] {
+) chainedDerivedDataInvalidators[TKey, TVal] {
 	// NOTE: switch to bisection search (or reverse iteration) if the list
 	// is long.
 	for idx, entry := range chained {
@@ -32,7 +36,7 @@ func (chained chainedDerivedDataInvalidators[TVal]) ApplicableInvalidators(
 	return nil
 }
 
-func (chained chainedDerivedDataInvalidators[TVal]) ShouldInvalidateEntries() bool {
+func (chained chainedDerivedDataInvalidators[TKey, TVal]) ShouldInvalidateEntries() bool {
 	for _, invalidator := range chained {
 		if invalidator.ShouldInvalidateEntries() {
 			return true
@@ -42,11 +46,13 @@ func (chained chainedDerivedDataInvalidators[TVal]) ShouldInvalidateEntries() bo
 	return false
 }
 
-func (chained chainedDerivedDataInvalidators[TVal]) ShouldInvalidateEntry(
-	entry TVal,
+func (chained chainedDerivedDataInvalidators[TKey, TVal]) ShouldInvalidateEntry(
+	key TKey,
+	value TVal,
+	state *state.State,
 ) bool {
 	for _, invalidator := range chained {
-		if invalidator.ShouldInvalidateEntry(entry) {
+		if invalidator.ShouldInvalidateEntry(key, value, state) {
 			return true
 		}
 	}

--- a/fvm/programs/block_programs.go
+++ b/fvm/programs/block_programs.go
@@ -10,17 +10,17 @@ import (
 // BlockPrograms is a simple fork-aware OCC database for "caching" programs
 // for a particular block.
 type BlockPrograms struct {
-	*BlockDerivedData[common.AddressLocation, ProgramEntry]
+	*BlockDerivedData[common.AddressLocation, *interpreter.Program]
 }
 
 // TransactionPrograms is the scratch space for programs of a single transaction.
 type TransactionPrograms struct {
-	*TransactionDerivedData[common.AddressLocation, ProgramEntry]
+	*TransactionDerivedData[common.AddressLocation, *interpreter.Program]
 }
 
 func NewEmptyBlockPrograms() *BlockPrograms {
 	return &BlockPrograms{
-		NewEmptyBlockDerivedData[common.AddressLocation, ProgramEntry](),
+		NewEmptyBlockDerivedData[common.AddressLocation, *interpreter.Program](),
 	}
 }
 
@@ -28,7 +28,7 @@ func NewEmptyBlockPrograms() *BlockPrograms {
 // beginning of the block.
 func NewEmptyBlockProgramsWithTransactionOffset(offset uint32) *BlockPrograms {
 	return &BlockPrograms{
-		NewEmptyBlockDerivedDataWithOffset[common.AddressLocation, ProgramEntry](offset),
+		NewEmptyBlockDerivedDataWithOffset[common.AddressLocation, *interpreter.Program](offset),
 	}
 }
 
@@ -81,12 +81,7 @@ func (transaction *TransactionPrograms) Get(
 	*state.State,
 	bool,
 ) {
-	programEntry := transaction.TransactionDerivedData.Get(addressLocation)
-	if programEntry == nil {
-		return nil, nil, false
-	}
-
-	return programEntry.Program, programEntry.State, true
+	return transaction.TransactionDerivedData.Get(addressLocation)
 }
 
 func (transaction *TransactionPrograms) Set(
@@ -94,15 +89,11 @@ func (transaction *TransactionPrograms) Set(
 	program *interpreter.Program,
 	state *state.State,
 ) {
-	transaction.TransactionDerivedData.Set(addressLocation, ProgramEntry{
-		Location: addressLocation,
-		Program:  program,
-		State:    state,
-	})
+	transaction.TransactionDerivedData.Set(addressLocation, program, state)
 }
 
 func (transaction *TransactionPrograms) AddInvalidator(
-	invalidator DerivedDataInvalidator[ProgramEntry],
+	invalidator DerivedDataInvalidator[common.AddressLocation, *interpreter.Program],
 ) {
 	transaction.TransactionDerivedData.AddInvalidator(invalidator)
 }

--- a/fvm/programs/block_programs_test.go
+++ b/fvm/programs/block_programs_test.go
@@ -345,9 +345,8 @@ func TestTxnProgsCommitWriteOnlyTransactionNoInvalidation(t *testing.T) {
 	entry, ok := entries[location]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, location, entry.Entry.Location)
-	require.Same(t, expectedProg, entry.Entry.Program)
-	require.Same(t, expectedState, entry.Entry.State)
+	require.Same(t, expectedProg, entry.Value)
+	require.Same(t, expectedState, entry.State)
 }
 
 func TestTxnProgsCommitWriteOnlyTransactionWithInvalidation(t *testing.T) {
@@ -393,7 +392,10 @@ func TestTxnProgsCommitWriteOnlyTransactionWithInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedDerivedDataInvalidators[ProgramEntry]{
+		chainedDerivedDataInvalidators[
+			common.AddressLocation,
+			*interpreter.Program,
+		]{
 			{
 				DerivedDataInvalidator: invalidator,
 				executionTime:          testTxnTime,
@@ -447,11 +449,10 @@ func TestTxnProgsCommitUseOriginalEntryOnDuplicateWriteEntries(t *testing.T) {
 
 	require.Same(t, expectedEntry, actualEntry)
 	require.False(t, actualEntry.isInvalid)
-	require.Equal(t, location, actualEntry.Entry.Location)
-	require.Same(t, expectedProg, actualEntry.Entry.Program)
-	require.Same(t, expectedState, actualEntry.Entry.State)
-	require.NotSame(t, otherProg, actualEntry.Entry.Program)
-	require.NotSame(t, otherState, actualEntry.Entry.State)
+	require.Same(t, expectedProg, actualEntry.Value)
+	require.Same(t, expectedState, actualEntry.State)
+	require.NotSame(t, otherProg, actualEntry.Value)
+	require.NotSame(t, otherState, actualEntry.State)
 }
 
 func TestTxnProgsCommitReadOnlyTransactionNoInvalidation(t *testing.T) {
@@ -523,16 +524,14 @@ func TestTxnProgsCommitReadOnlyTransactionNoInvalidation(t *testing.T) {
 	entry, ok := entries[loc1]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, loc1, entry.Entry.Location)
-	require.Same(t, expectedProg1, entry.Entry.Program)
-	require.Same(t, expectedState1, entry.Entry.State)
+	require.Same(t, expectedProg1, entry.Value)
+	require.Same(t, expectedState1, entry.State)
 
 	entry, ok = entries[loc2]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, loc2, entry.Entry.Location)
-	require.Same(t, expectedProg2, entry.Entry.Program)
-	require.Same(t, expectedState2, entry.Entry.State)
+	require.Same(t, expectedProg2, entry.Value)
+	require.Same(t, expectedState2, entry.State)
 }
 
 func TestTxnProgsCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
@@ -612,7 +611,10 @@ func TestTxnProgsCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedDerivedDataInvalidators[ProgramEntry]{
+		chainedDerivedDataInvalidators[
+			common.AddressLocation,
+			*interpreter.Program,
+		]{
 			{
 				DerivedDataInvalidator: testSetupTxn1Invalidator,
 				executionTime:          testSetupTxn1Time,
@@ -767,7 +769,10 @@ func TestTxnProgsCommitFineGrainInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedDerivedDataInvalidators[ProgramEntry]{
+		chainedDerivedDataInvalidators[
+			common.AddressLocation,
+			*interpreter.Program,
+		]{
 			{
 				DerivedDataInvalidator: invalidator1,
 				executionTime:          testTxnTime,
@@ -785,16 +790,14 @@ func TestTxnProgsCommitFineGrainInvalidation(t *testing.T) {
 	entry, ok := entries[readLoc2]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, readLoc2, entry.Entry.Location)
-	require.Same(t, readProg2, entry.Entry.Program)
-	require.Same(t, readState2, entry.Entry.State)
+	require.Same(t, readProg2, entry.Value)
+	require.Same(t, readState2, entry.State)
 
 	entry, ok = entries[writeLoc2]
 	require.True(t, ok)
 	require.False(t, entry.isInvalid)
-	require.Equal(t, writeLoc2, entry.Entry.Location)
-	require.Same(t, writeProg2, entry.Entry.Program)
-	require.Same(t, writeState2, entry.Entry.State)
+	require.Same(t, writeProg2, entry.Value)
+	require.Same(t, writeState2, entry.State)
 }
 
 func TestBlockProgsNewChildBlockPrograms(t *testing.T) {
@@ -845,9 +848,8 @@ func TestBlockProgsNewChildBlockPrograms(t *testing.T) {
 	parentEntry, ok := parentEntries[location]
 	require.True(t, ok)
 	require.False(t, parentEntry.isInvalid)
-	require.Equal(t, location, parentEntry.Entry.Location)
-	require.Same(t, prog, parentEntry.Entry.Program)
-	require.Same(t, state, parentEntry.Entry.State)
+	require.Same(t, prog, parentEntry.Value)
+	require.Same(t, state, parentEntry.State)
 
 	// Verify child is correctly initialized
 
@@ -866,9 +868,8 @@ func TestBlockProgsNewChildBlockPrograms(t *testing.T) {
 	childEntry, ok := childEntries[location]
 	require.True(t, ok)
 	require.False(t, childEntry.isInvalid)
-	require.Equal(t, location, childEntry.Entry.Location)
-	require.Same(t, prog, childEntry.Entry.Program)
-	require.Same(t, state, childEntry.Entry.State)
+	require.Same(t, prog, childEntry.Value)
+	require.Same(t, state, childEntry.State)
 
 	require.NotSame(t, parentEntry, childEntry)
 }

--- a/fvm/programs/chain_programs_test.go
+++ b/fvm/programs/chain_programs_test.go
@@ -48,7 +48,7 @@ func TestChainPrograms(t *testing.T) {
 
 	entry := block1.GetForTestingOnly(loc1)
 	require.NotNil(t, entry)
-	require.Same(t, prog1, entry.Program)
+	require.Same(t, prog1, entry.Value)
 
 	//
 	// Creating a BlockPrograms from parent
@@ -72,11 +72,11 @@ func TestChainPrograms(t *testing.T) {
 
 	entry = block2.GetForTestingOnly(loc1)
 	require.NotNil(t, entry)
-	require.Same(t, prog1, entry.Program)
+	require.Same(t, prog1, entry.Value)
 
 	entry = block2.GetForTestingOnly(loc2)
 	require.NotNil(t, entry)
-	require.Same(t, prog2, entry.Program)
+	require.Same(t, prog2, entry.Value)
 
 	//
 	// Reuse exising BlockPrograms in cache
@@ -90,7 +90,7 @@ func TestChainPrograms(t *testing.T) {
 
 	entry = block1.GetForTestingOnly(loc1)
 	require.NotNil(t, entry)
-	require.Same(t, prog1, entry.Program)
+	require.Same(t, prog1, entry.Value)
 
 	// writes to block2 did't poplute block1.
 	entry = block1.GetForTestingOnly(loc2)
@@ -110,11 +110,11 @@ func TestChainPrograms(t *testing.T) {
 
 	entry = block3.GetForTestingOnly(loc1)
 	require.NotNil(t, entry)
-	require.Same(t, prog1, entry.Program)
+	require.Same(t, prog1, entry.Value)
 
 	entry = block3.GetForTestingOnly(loc2)
 	require.NotNil(t, entry)
-	require.Same(t, prog2, entry.Program)
+	require.Same(t, prog2, entry.Value)
 
 	// block1 forces block2 to evict
 	foundBlock = programs.GetOrCreateBlockPrograms(blockId1, flow.ZeroID)
@@ -140,11 +140,11 @@ func TestChainPrograms(t *testing.T) {
 
 	entry = scriptBlock.GetForTestingOnly(loc1)
 	require.NotNil(t, entry)
-	require.Same(t, prog1, entry.Program)
+	require.Same(t, prog1, entry.Value)
 
 	entry = scriptBlock.GetForTestingOnly(loc2)
 	require.NotNil(t, entry)
-	require.Same(t, prog2, entry.Program)
+	require.Same(t, prog2, entry.Value)
 
 	foundBlock = programs.Get(blockId3)
 	require.Same(t, block3, foundBlock)

--- a/fvm/programs/invalidator.go
+++ b/fvm/programs/invalidator.go
@@ -8,11 +8,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-type ProgramEntry struct {
-	Location common.AddressLocation
-	Program  *interpreter.Program
-	State    *state.State
-}
 type ContractUpdateKey struct {
 	Address flow.Address
 	Name    string
@@ -23,7 +18,10 @@ type ContractUpdate struct {
 	Code []byte
 }
 
-var _ DerivedDataInvalidator[ProgramEntry] = ModifiedSetsInvalidator{}
+var _ DerivedDataInvalidator[
+	common.AddressLocation,
+	*interpreter.Program,
+] = ModifiedSetsInvalidator{}
 
 type ModifiedSetsInvalidator struct {
 	ContractUpdateKeys []ContractUpdateKey
@@ -35,7 +33,9 @@ func (sets ModifiedSetsInvalidator) ShouldInvalidateEntries() bool {
 }
 
 func (sets ModifiedSetsInvalidator) ShouldInvalidateEntry(
-	entry ProgramEntry,
+	location common.AddressLocation,
+	program *interpreter.Program,
+	state *state.State,
 ) bool {
 	// TODO(rbtz): switch to fine grain invalidation.
 	return sets.ShouldInvalidateEntries()


### PR DESCRIPTION
1. Remove ProgramEntry struct.  This was used by the original programs cache implementation and is no longer needed.  The cached Value and State are now directly define in invalidatableEntry.
2. minor changes to the TransactionDerivedData Get api
3. s/item *TransactionDerivedData/txn *TransactionDerivedData/g

gh: #3102