### PR TITLE
Move non address programs tracking to environment.

### DIFF
--- a/fvm/environment/mock/transaction_programs.go
+++ b/fvm/environment/mock/transaction_programs.go
@@ -18,11 +18,11 @@ type TransactionPrograms struct {
 }
 
 // Get provides a mock function with given fields: loc
-func (_m *TransactionPrograms) Get(loc common.Location) (*interpreter.Program, *state.State, bool) {
+func (_m *TransactionPrograms) Get(loc common.AddressLocation) (*interpreter.Program, *state.State, bool) {
 	ret := _m.Called(loc)
 
 	var r0 *interpreter.Program
-	if rf, ok := ret.Get(0).(func(common.Location) *interpreter.Program); ok {
+	if rf, ok := ret.Get(0).(func(common.AddressLocation) *interpreter.Program); ok {
 		r0 = rf(loc)
 	} else {
 		if ret.Get(0) != nil {
@@ -31,7 +31,7 @@ func (_m *TransactionPrograms) Get(loc common.Location) (*interpreter.Program, *
 	}
 
 	var r1 *state.State
-	if rf, ok := ret.Get(1).(func(common.Location) *state.State); ok {
+	if rf, ok := ret.Get(1).(func(common.AddressLocation) *state.State); ok {
 		r1 = rf(loc)
 	} else {
 		if ret.Get(1) != nil {
@@ -40,7 +40,7 @@ func (_m *TransactionPrograms) Get(loc common.Location) (*interpreter.Program, *
 	}
 
 	var r2 bool
-	if rf, ok := ret.Get(2).(func(common.Location) bool); ok {
+	if rf, ok := ret.Get(2).(func(common.AddressLocation) bool); ok {
 		r2 = rf(loc)
 	} else {
 		r2 = ret.Get(2).(bool)
@@ -50,7 +50,7 @@ func (_m *TransactionPrograms) Get(loc common.Location) (*interpreter.Program, *
 }
 
 // Set provides a mock function with given fields: loc, prog, _a2
-func (_m *TransactionPrograms) Set(loc common.Location, prog *interpreter.Program, _a2 *state.State) {
+func (_m *TransactionPrograms) Set(loc common.AddressLocation, prog *interpreter.Program, _a2 *state.State) {
 	_m.Called(loc, prog, _a2)
 }
 

--- a/fvm/programs/block_programs_test.go
+++ b/fvm/programs/block_programs_test.go
@@ -627,42 +627,6 @@ func TestTxnProgsCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
 	require.Equal(t, 0, len(block.EntriesForTestingOnly()))
 }
 
-func TestTxnProgsCommitNonAddressPrograms(t *testing.T) {
-	block := NewEmptyBlockPrograms()
-
-	expectedTime := LogicalTime(121)
-	testTxn, err := block.NewTransactionPrograms(0, expectedTime)
-	require.NoError(t, err)
-
-	location := common.IdentifierLocation("non-address")
-
-	actualProg, actualState, ok := testTxn.Get(location)
-	require.False(t, ok)
-	require.Nil(t, actualProg)
-	require.Nil(t, actualState)
-
-	expectedProg := &interpreter.Program{}
-
-	testTxn.Set(location, expectedProg, nil)
-
-	actualProg, actualState, ok = testTxn.Get(location)
-	require.True(t, ok)
-	require.Same(t, expectedProg, actualProg)
-	require.Nil(t, actualState)
-
-	err = testTxn.Commit()
-	require.NoError(t, err)
-
-	// Sanity Check
-
-	require.Equal(
-		t,
-		expectedTime,
-		block.LatestCommitExecutionTimeForTestingOnly())
-	require.Equal(t, 0, len(block.InvalidatorsForTestingOnly()))
-	require.Equal(t, 0, len(block.EntriesForTestingOnly()))
-}
-
 func TestTxnProgsCommitValidateError(t *testing.T) {
 	block := NewEmptyBlockPrograms()
 

--- a/fvm/programs/programs.go
+++ b/fvm/programs/programs.go
@@ -55,20 +55,20 @@ func (p *Programs) NextTxIndexForTestingOnly() uint32 {
 	return p.block.NextTxIndexForTestingOnly()
 }
 
-func (p *Programs) GetForTestingOnly(location common.Location) (*interpreter.Program, *state.State, bool) {
+func (p *Programs) GetForTestingOnly(location common.AddressLocation) (*interpreter.Program, *state.State, bool) {
 	return p.Get(location)
 }
 
 // Get returns stored program, state which contains changes which correspond to loading this program,
 // and boolean indicating if the value was found
-func (p *Programs) Get(location common.Location) (*interpreter.Program, *state.State, bool) {
+func (p *Programs) Get(location common.AddressLocation) (*interpreter.Program, *state.State, bool) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
 	return p.currentTxn.Get(location)
 }
 
-func (p *Programs) Set(location common.Location, program *interpreter.Program, state *state.State) {
+func (p *Programs) Set(location common.AddressLocation, program *interpreter.Program, state *state.State) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 


### PR DESCRIPTION
Since we're generalizing BlockPrograms into a schema-ed database for storing all sorts of derived data, it no longer make sense to keep track of non address programs inside of the database.

gh: #3102