### PR TITLE
[Execution] Do not depend on string conversion in register set tracking

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -852,8 +852,7 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 		Key:   state.AccountStatusKey,
 	}
 
-	require.Contains(t, registerTouches, id.String())
-	require.Equal(t, id, registerTouches[id.String()])
+	require.Contains(t, registerTouches, id)
 }
 
 func Test_ExecutingSystemCollection(t *testing.T) {

--- a/engine/execution/state/delta/delta.go
+++ b/engine/execution/state/delta/delta.go
@@ -10,19 +10,14 @@ import (
 
 // A Delta is a record of ledger mutations.
 type Delta struct {
-	Data map[string]flow.RegisterEntry
+	Data map[flow.RegisterID]flow.RegisterEntry
 }
 
 // NewDelta returns an empty ledger delta.
 func NewDelta() Delta {
 	return Delta{
-		Data: make(map[string]flow.RegisterEntry),
+		Data: make(map[flow.RegisterID]flow.RegisterEntry),
 	}
-}
-
-func toString(owner, key string) string {
-	register := flow.NewRegisterID(owner, key)
-	return register.String()
 }
 
 // Get reads a register value from this delta.
@@ -30,15 +25,15 @@ func toString(owner, key string) string {
 // This function will return nil if the given key has been deleted in this delta.
 // Second return parameters indicated if the value has been set/deleted in this delta
 func (d Delta) Get(owner, key string) (flow.RegisterValue, bool) {
-	value, set := d.Data[toString(owner, key)]
+	value, set := d.Data[flow.NewRegisterID(owner, key)]
 	return value.Value, set
 }
 
 // Set records an update in this delta.
 func (d Delta) Set(owner, key string, value flow.RegisterValue) {
-	k := toString(owner, key)
+	k := flow.NewRegisterID(owner, key)
 	d.Data[k] = flow.RegisterEntry{
-		Key:   flow.NewRegisterID(owner, key),
+		Key:   k,
 		Value: value,
 	}
 }
@@ -97,10 +92,10 @@ func (d *Delta) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("cannot umarshal Delta: %w", err)
 	}
-	dd := make(map[string]flow.RegisterEntry, len(m))
+	dd := make(map[flow.RegisterID]flow.RegisterEntry, len(m))
 
 	for _, value := range m {
-		dd[value.Key.String()] = value
+		dd[value.Key] = value
 	}
 
 	d.Data = dd

--- a/engine/execution/state/delta/view.go
+++ b/engine/execution/state/delta/view.go
@@ -65,15 +65,15 @@ func NewView(readFunc GetRegisterFunc) *View {
 func (v *View) Interactions() *SpockSnapshot {
 
 	var delta = Delta{
-		Data: make(map[flow.RegisterID]flow.RegisterEntry, len(v.delta.Data)),
+		Data: make(map[flow.RegisterID]flow.RegisterValue, len(v.delta.Data)),
 	}
 	var reads = make(map[flow.RegisterID]struct{}, len(v.regTouchSet))
 
 	bytesWrittenToRegisters := 0
-	//copy data
+	// copy data
 	for s, value := range v.delta.Data {
 		delta.Data[s] = value
-		bytesWrittenToRegisters += len(value.Value)
+		bytesWrittenToRegisters += len(value)
 	}
 
 	for k := range v.regTouchSet {

--- a/engine/execution/state/delta/view_test.go
+++ b/engine/execution/state/delta/view_test.go
@@ -413,10 +413,10 @@ func TestViewMergeView(t *testing.T) {
 		r2 := flow.NewRegisterID(registerID2, "")
 		r3 := flow.NewRegisterID(registerID3, "")
 
-		assert.Equal(t, map[string]flow.RegisterID{
-			r1.String(): r1,
-			r2.String(): r2,
-			r3.String(): r3,
+		assert.Equal(t, map[flow.RegisterID]struct{}{
+			r1: struct{}{},
+			r2: struct{}{},
+			r3: struct{}{},
 		}, reads)
 	})
 
@@ -570,9 +570,9 @@ func TestView_Reads(t *testing.T) {
 		r1 := flow.NewRegisterID(registerID1, "")
 		r2 := flow.NewRegisterID(registerID2, "")
 
-		assert.Equal(t, map[string]flow.RegisterID{
-			r1.String(): r1,
-			r2.String(): r2,
+		assert.Equal(t, map[flow.RegisterID]struct{}{
+			r1: struct{}{},
+			r2: struct{}{},
 		}, touches)
 	})
 }

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -14,22 +14,11 @@ type RegisterID struct {
 	Key   string
 }
 
-// this function returns a string format of a RegisterID in the form '%x/%x'
-// it has been optimized to avoid the memory allocations inside Sprintf
+// String returns formatted string representation of the RegisterID.
+// TODO(rbtz): remove after the merge of https://github.com/onflow/flow-emulator/pull/235
+// Deprecated: used only by emultor.
 func (r *RegisterID) String() string {
-	ownerLen := len(r.Owner)
-
-	requiredLen := ((ownerLen + len(r.Key)) * 2) + 1
-
-	arr := make([]byte, requiredLen)
-
-	hex.Encode(arr, []byte(r.Owner))
-
-	arr[2*ownerLen] = byte('/')
-
-	hex.Encode(arr[(2*ownerLen)+1:], []byte(r.Key))
-
-	return string(arr)
+	return fmt.Sprintf("%x/%x", r.Owner, r.Key)
 }
 
 // Bytes returns a bytes representation of the RegisterID.

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -146,7 +146,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 	// chunk view construction
 	// unknown register tracks access to parts of the partial trie which
 	// are not expanded and values are unknown.
-	unknownRegTouch := make(map[string]*ledger.Key)
+	unknownRegTouch := make(map[flow.RegisterID]*ledger.Key)
 	var problematicTx flow.Identifier
 	getRegister := func(owner, key string) (flow.RegisterValue, error) {
 		// check if register has been provided in the chunk data pack
@@ -164,7 +164,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 		if err != nil {
 			if errors.Is(err, ledger.ErrMissingKeys{}) {
 
-				unknownRegTouch[registerID.String()] = &registerKey
+				unknownRegTouch[registerID] = &registerKey
 
 				// don't send error just return empty byte slice
 				// we always assume empty value for missing registers (which might cause the transaction to fail)


### PR DESCRIPTION
This PR:
* converts `map[string]flow.RegisterID` to `map[flow.RegisterID]struct{}` to represent sets.
* switches Delta from `map[string]flow.RegisterEntry` to `map[flow.RegisterID]flow.RegisterValue` to save a bit of space.

Currently these are responsible for ~15% of memory allocations:
<img width="1474" alt="Screen Shot 2022-11-07 at 9 50 17 PM" src="https://user-images.githubusercontent.com/169976/200485702-6487a242-2c06-4636-bb57-2750cce63e5f.png">


```
name                             old time/op    new time/op    delta
ComputeBlock/16/cols/128/txes-8     1.83s ± 3%     1.69s ± 2%   -7.59%  (p=0.000 n=10+10)

name                             old alloc/op   new alloc/op   delta
ComputeBlock/16/cols/128/txes-8    1.34GB ± 1%    1.21GB ± 2%   -9.38%  (p=0.000 n=9+10)

name                             old allocs/op  new allocs/op  delta
ComputeBlock/16/cols/128/txes-8     19.8M ± 0%     17.1M ± 0%  -13.48%  (p=0.000 n=8+8)
```