### PR TITLE
[Execution] Use generic slice algorithms instead of interfaces

### DIFF
--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -5,10 +5,10 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/onflow/cadence/runtime/common"
+	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
@@ -284,10 +284,6 @@ func (s *State) MergeState(other *State) error {
 
 type sortedAddresses []flow.Address
 
-func (a sortedAddresses) Len() int           { return len(a) }
-func (a sortedAddresses) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a sortedAddresses) Less(i, j int) bool { return bytes.Compare(a[i][:], a[j][:]) >= 0 }
-
 // UpdatedAddresses returns a sorted list of addresses that were updated (at least 1 register update)
 func (s *State) UpdatedAddresses() []flow.Address {
 	addresses := make(sortedAddresses, len(s.updatedAddresses))
@@ -298,7 +294,9 @@ func (s *State) UpdatedAddresses() []flow.Address {
 		i++
 	}
 
-	sort.Sort(addresses)
+	slices.SortFunc(addresses, func(a, b flow.Address) bool {
+		return bytes.Compare(a[:], b[:]) < 0
+	})
 
 	return addresses
 }

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -282,20 +282,17 @@ func (s *State) MergeState(other *State) error {
 	return nil
 }
 
-type sortedAddresses []flow.Address
-
 // UpdatedAddresses returns a sorted list of addresses that were updated (at least 1 register update)
 func (s *State) UpdatedAddresses() []flow.Address {
-	addresses := make(sortedAddresses, len(s.updatedAddresses))
+	addresses := make([]flow.Address, 0, len(s.updatedAddresses))
 
-	i := 0
 	for k := range s.updatedAddresses {
-		addresses[i] = k
-		i++
+		addresses = append(addresses, k)
 	}
 
 	slices.SortFunc(addresses, func(a, b flow.Address) bool {
-		return bytes.Compare(a[:], b[:]) < 0
+		// reverse order to maintain compatibility with previous implementation.
+		return bytes.Compare(a[:], b[:]) >= 0
 	})
 
 	return addresses

--- a/model/flow/identity.go
+++ b/model/flow/identity.go
@@ -1,15 +1,16 @@
 package flow
 
 import (
-	"encoding/binary"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math"
 	"math/rand"
 	"regexp"
-	"sort"
 	"strconv"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/fxamacker/cbor/v2"
@@ -368,22 +369,13 @@ func (il IdentityList) Lookup() map[Identifier]*Identity {
 // in place for best performance, and don't use this function.
 func (il IdentityList) Sort(less IdentityOrder) IdentityList {
 	dup := il.Copy()
-	sort.Slice(dup, func(i int, j int) bool {
-		return less(dup[i], dup[j])
-	})
+	slices.SortFunc(dup, less)
 	return dup
 }
 
 // Sorted returns whether the list is sorted by the input ordering.
 func (il IdentityList) Sorted(less IdentityOrder) bool {
-	for i := 0; i < len(il)-1; i++ {
-		a := il[i]
-		b := il[i+1]
-		if !less(a, b) {
-			return false
-		}
-	}
-	return true
+	return slices.IsSortedFunc(il, less)
 }
 
 // NodeIDs returns the NodeIDs of the nodes in the list.
@@ -466,6 +458,7 @@ func (il IdentityList) Sample(size uint) IdentityList {
 }
 
 // DeterministicSample returns deterministic random sample from the `IdentityList` using the given seed
+// TODO(rbtz): fix race condition
 func (il IdentityList) DeterministicSample(size uint, seed int64) IdentityList {
 	rand.Seed(seed)
 	return il.Sample(size)
@@ -507,76 +500,33 @@ func (il IdentityList) SamplePct(pct float64) IdentityList {
 // where duplicates are identities with the same node ID.
 // The returned IdentityList is sorted
 func (il IdentityList) Union(other IdentityList) IdentityList {
-	lenUnion := len(il) + len(other)
-	// stores the output, the union of the two lists
-	if lenUnion == 0 {
-		return IdentityList{}
-	}
+	maxLen := len(il) + len(other)
 
-	// add all identities together
-	union := make(IdentityList, 0, lenUnion)
-	union = append(union, il[:]...)
-	union = append(union, other[:]...)
+	union := make(IdentityList, 0, maxLen)
+	set := make(map[Identifier]struct{}, maxLen)
 
-	// sort by node id.  This will enable duplicate checks later
-	sort.Slice(union, func(p, q int) bool {
-		num1 := union[p].NodeID[:]
-		num2 := union[q].NodeID[:]
-		lenID := len(num1)
-
-		// assume the length is a multiple of 8, for performance.  it's 32 bytes
-		for i := 0; ; i += 8 {
-			chunk1 := binary.BigEndian.Uint64(num1[i:])
-			chunk2 := binary.BigEndian.Uint64(num2[i:])
-
-			if chunk1 < chunk2 {
-				return true
-			} else if chunk1 > chunk2 {
-				return false
-			} else if i >= lenID-8 {
-				// we're on the last chunk of 8 bytes, the nodeid's are equal
-				return false
+	for _, list := range []IdentityList{il, other} {
+		for _, id := range list {
+			if _, isDuplicate := set[id.NodeID]; !isDuplicate {
+				set[id.NodeID] = struct{}{}
+				union = append(union, id)
 			}
 		}
-	})
-	// At this point, 'union' has a sorted slice of identities, potentially with duplicates.
-	// We know that len(union) ≥ 1.
-
-	// Deduplicate elements by scanning over union; we keep two index values:
-	// * lastUnique: largest index of the already de-duplicated portion of the slice
-	// * i: index of the element that we are inspecting whether it is a duplicate
-	// Example:
-	//   [▓,▓,▓,▓,▓,☐,☐,☐,☐,░ ,░,░,░,░]
-	//            ↑           ↑
-	//        lastUnique      i
-	//   ▓ deduplicated elements in ascending order
-	//   ☐ duplicated
-	//   ░ elements to be inspected
-	// We start with lastUnique=0 and i=1. Throughout the algorithm, we always
-	// have lastUnique < i. Whenever we find that union[lastUnique] != union[i],
-	// we have found the next unique element and move it at index union[lastUnique+1].
-	lastUnique := 0
-	for i := 1; i < lenUnion; i++ {
-		if union[lastUnique].NodeID != union[i].NodeID {
-			lastUnique++
-			union[lastUnique] = union[i]
-		}
 	}
-	return union[:lastUnique+1]
+
+	slices.SortFunc(union, func(a, b *Identity) bool {
+		return bytes.Compare(a.NodeID[:], b.NodeID[:]) < 0
+	})
+
+	return union
 }
 
 // EqualTo checks if the other list if the same, that it contains the same elements
 // in the same order
 func (il IdentityList) EqualTo(other IdentityList) bool {
-	if len(il) != len(other) {
-		return false
-	}
-	for i, identity := range il {
-		if !identity.EqualTo(other[i]) {
-			return false
-		}
-	}
-	return true
+	return slices.EqualFunc(il, other, func(a, b *Identity) bool {
+		return a.EqualTo(b)
+	})
 }
 
 // Exists takes a previously sorted Identity list and searches it for the target value
@@ -591,66 +541,20 @@ func (il IdentityList) Exists(target *Identity) bool {
 // target:  value to search for
 // CAUTION:  The identity list MUST be sorted prior to calling this method
 func (il IdentityList) IdentifierExists(target Identifier) bool {
-	left := 0
-	lenList := len(il)
-	if lenList == 0 {
-		return false
-	}
-
-	right := lenList - 1
-	mid := right >> 1
-	num2 := target[:]
-
-	// pre-calculate these 4 values for comparisons later
-	var tgt [4]uint64
-	tgt[0] = binary.BigEndian.Uint64(num2[:])
-	tgt[1] = binary.BigEndian.Uint64(num2[8:])
-	tgt[2] = binary.BigEndian.Uint64(num2[16:])
-	tgt[3] = binary.BigEndian.Uint64(num2[24:])
-
-	for {
-		num1 := il[mid].NodeID[:]
-		lenID := len(num1)
-		i := 0
-
-		for {
-			chunk1 := binary.BigEndian.Uint64(num1[i:])
-			chunk2 := tgt[i/8]
-
-			if chunk1 < chunk2 {
-				left = mid + 1
-				break
-			} else if chunk1 > chunk2 {
-				right = mid - 1
-				break
-			} else if i >= lenID-8 {
-				// we're on the last chunk of 8 bytes, and
-				// so return true if equal -- it exists
-				return true
-			}
-
-			// these 8 bytes were equal, so increment index by 8 bytes
-			i += 8
-		}
-		if left > right {
-			return false
-		}
-		mid = (left + right) >> 1
-	}
+	_, ok := slices.BinarySearchFunc(il, &Identity{NodeID: target}, func(a, b *Identity) int {
+		return bytes.Compare(a.NodeID[:], b.NodeID[:])
+	})
+	return ok
 }
 
 // GetIndex returns the index of the identifier in the IdentityList and true
 // if the identifier is found.
-func (il IdentityList) GetIndex(identifier Identifier) (uint, bool) {
-	index := 0
-	ok := false
-	for i, id := range il.NodeIDs() {
-		if id == identifier {
-			index = i
-			ok = true
-			break
-		}
+func (il IdentityList) GetIndex(target Identifier) (uint, bool) {
+	i := slices.IndexFunc(il, func(a *Identity) bool {
+		return a.NodeID == target
+	})
+	if i == -1 {
+		return 0, false
 	}
-
-	return uint(index), ok
+	return uint(i), true
 }


### PR DESCRIPTION
Generic version is faster than the interface-based one.  While here, also:
* Simplify `RegisterUpdates` -- no need to roundtrip data through `RegisterEntries` just for sorting.
(Followup from #3529)
* Simplify `Union` -- a roundtrip through map is negligible compared to O(n*log(n)) sorting.
* Simplify the rest of `IdentityList` methods to remove the custom binary searches and equality functions.

While here, also mark a race in `DeterministicSample`. 

This also replaces custom implementation of byte comparisons with a standard `Bytes.Compare()` that supports both AVX and [AVX2 on x86_64](https://cs.opensource.google/go/go/+/refs/tags/go1.19.3:src/internal/bytealg/compare_amd64.s;l=194), hence using `VPCMPEQB` to do 64-byte compares.

Side note about `IdentityList`: looking at the code, it should really be a `IdentityOrderedSet` and internally be represented by a `map[Identiy]struct{}` and a list for keeping track of the order. This is outside of the scope of this diff though.