### PR TITLE
[Consensus] Switch to generic binary search

### DIFF
--- a/consensus/hotstuff/committees/leader/leader_selection.go
+++ b/consensus/hotstuff/committees/leader/leader_selection.go
@@ -157,11 +157,11 @@ func weightedRandomSelection(
 
 	leaders := make([]uint16, 0, count)
 	for i := 0; i < count; i++ {
-		// pick a random number from 0 (inclusive) to cumsum (exclusive). Or [0, cumsum)
-		randomness := rng.UintN(cumsum)
+		// pick a random number [1, cumsum]
+		randomness := rng.UintN(cumsum) + 1
 
 		// binary search to find the leader index by the random number
-		leader, _ := slices.BinarySearch(weightSums, randomness+1)
+		leader, _ := slices.BinarySearch(weightSums, randomness)
 		leaders = append(leaders, uint16(leader))
 	}
 	return leaders, nil

--- a/consensus/hotstuff/committees/leader/leader_selection.go
+++ b/consensus/hotstuff/committees/leader/leader_selection.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/onflow/flow-go/crypto/random"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -159,35 +161,8 @@ func weightedRandomSelection(
 		randomness := rng.UintN(cumsum)
 
 		// binary search to find the leader index by the random number
-		leader := binarySearchStrictlyBigger(randomness, weightSums)
-
+		leader, _ := slices.BinarySearch(weightSums, randomness+1)
 		leaders = append(leaders, uint16(leader))
 	}
 	return leaders, nil
-}
-
-// binarySearchStriclyBigger finds the index of the first item in the given array that is
-// strictly bigger to the given value.
-// There are a few assumptions on inputs:
-// - `arr` must be non-empty
-// - items in `arr` must be in non-decreasing order
-// - `value` must be less than the last item in `arr`
-func binarySearchStrictlyBigger(value uint64, arr []uint64) int {
-	left := 0
-	arrayLen := len(arr)
-	right := arrayLen - 1
-	mid := arrayLen >> 1
-	for {
-		if arr[mid] <= value {
-			left = mid + 1
-		} else {
-			right = mid
-		}
-
-		if left >= right {
-			return left
-		}
-
-		mid = int(left+right) >> 1
-	}
 }

--- a/consensus/hotstuff/committees/leader/leader_selection_test.go
+++ b/consensus/hotstuff/committees/leader/leader_selection_test.go
@@ -3,7 +3,6 @@ package leader
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,86 +31,6 @@ func TestSingleConsensusNode(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, identity.NodeID, leaderID)
 	}
-}
-
-// compare this binary search method with sort.Search()
-func TestBsearchVSsortSearch(t *testing.T) {
-	weights := []uint64{1, 2, 3, 4, 5, 6, 7, 9, 12, 21, 32}
-	weights2 := []int{1, 2, 3, 4, 5, 6, 7, 9, 12, 21, 32}
-	var sum uint64
-	var sum2 int
-	sums := make([]uint64, 0)
-	sums2 := make([]int, 0)
-	for i := 0; i < len(weights); i++ {
-		sum += weights[i]
-		sum2 += weights2[i]
-		sums = append(sums, sum)
-		sums2 = append(sums2, sum2)
-	}
-	sel := make([]int, 0, 10)
-	for i := 0; i < 10; i++ {
-		index := binarySearchStrictlyBigger(uint64(i), sums)
-		sel = append(sel, index)
-	}
-
-	sel2 := make([]int, 0, 10)
-	for i2 := 1; i2 < 11; i2++ {
-		index := sort.SearchInts(sums2, i2)
-		sel2 = append(sel2, index)
-	}
-
-	require.Equal(t, sel, sel2)
-}
-
-// Test binary search implementation
-func TestBsearch(t *testing.T) {
-	weights := []uint64{1, 2, 3, 4}
-	var sum uint64
-	sums := make([]uint64, 0)
-	for i := 0; i < len(weights); i++ {
-		sum += weights[i]
-		sums = append(sums, sum)
-	}
-	sel := make([]int, 0, 10)
-	for i := 0; i < 10; i++ {
-		index := binarySearchStrictlyBigger(uint64(i), sums)
-		sel = append(sel, index)
-	}
-	require.Equal(t, []int{0, 1, 1, 2, 2, 2, 3, 3, 3, 3}, sel)
-}
-
-// compare the result of binary search with the brute force search,
-// should be the same.
-func TestBsearchWithNormalSearch(t *testing.T) {
-	count := 100
-	sums := make([]uint64, 0, count)
-	sum := 0
-	for i := 0; i < count; i++ {
-		sum += i
-		sums = append(sums, uint64(sum))
-	}
-
-	var value uint64
-	total := sums[len(sums)-1]
-	for value = 0; value < total; value++ {
-		expected, err := bruteSearch(value, sums)
-		require.NoError(t, err)
-
-		actual := binarySearchStrictlyBigger(value, sums)
-		require.NoError(t, err)
-
-		require.Equal(t, expected, actual)
-	}
-}
-
-func bruteSearch(value uint64, arr []uint64) (int, error) {
-	// value ranges from [arr[0], arr[len(arr) -1 ]) exclusive
-	for i, a := range arr {
-		if a > value {
-			return i, nil
-		}
-	}
-	return 0, fmt.Errorf("not found")
 }
 
 func prg(t testing.TB, seed []byte) random.Rand {


### PR DESCRIPTION
Let's not support a custom `bsearch(3)` implementation.  As a side benefit new generic-based version is slightly faster:
```
$ benchstat old.txt new.txt                                                                                           
name               old time/op    new time/op    delta
LeaderSelection-8     520ms ± 0%     508ms ± 1%  -2.27%  (p=0.000 n=9+10)

name               old alloc/op   new alloc/op   delta
LeaderSelection-8    30.0MB ± 0%    30.0MB ± 0%    ~     (p=0.797 n=9+10)

name               old allocs/op  new allocs/op  delta
LeaderSelection-8      99.0 ± 0%      99.0 ± 0%    ~     (all equal)
```