### PR TITLE
Convert bootstrap procedure into executor

### DIFF
--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -22,6 +22,23 @@ const (
 	ScriptProcedureType      = ProcedureType("script")
 )
 
+type ProcedureExecutor interface {
+	Preprocess() error
+	Execute() error
+	Cleanup()
+}
+
+func run(executor ProcedureExecutor) error {
+	defer executor.Cleanup()
+
+	err := executor.Preprocess()
+	if err != nil {
+		return err
+	}
+
+	return executor.Execute()
+}
+
 // An Procedure is an operation (or set of operations) that reads or writes ledger state.
 type Procedure interface {
 	Run(

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -73,13 +73,11 @@ func NewScriptWithContextAndArgs(
 	}
 }
 
-// TODO(patrick): add ProcedureExecutor interface (superset of
-// TransactionExecutor api).
 func (proc *ScriptProcedure) NewExecutor(
 	ctx Context,
 	txnState *state.TransactionState,
 	programs *programs.TransactionPrograms,
-) *scriptExecutor {
+) ProcedureExecutor {
 	return newScriptExecutor(ctx, proc, txnState, programs)
 }
 
@@ -88,8 +86,7 @@ func (proc *ScriptProcedure) Run(
 	txnState *state.TransactionState,
 	programs *programs.TransactionPrograms,
 ) error {
-	// TODO(patrick): switch to run(proc.NewExecutor(ctx, txnState, programs)
-	return proc.NewExecutor(ctx, txnState, programs).Execute()
+	return run(proc.NewExecutor(ctx, txnState, programs))
 }
 
 func (proc *ScriptProcedure) ComputationLimit(ctx Context) uint64 {


### PR DESCRIPTION
Similar to script procedure, bootstrap procedure only needs to expose the NewExecutor method to conform to the Procedure interface.

gh: #3547