### PR TITLE
Move transaction procedure Run logic into transaction executor.

### DIFF
--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -897,6 +897,8 @@ func (b *bootstrapExecutor) invokeMetaTransaction(
 	ctx := NewContextFromParent(parentCtx,
 		WithAccountStorageLimit(false),
 		WithTransactionFeesEnabled(false),
+		WithAuthorizationChecksEnabled(false),
+		WithSequenceNumberCheckAndIncrementEnabled(false),
 	)
 
 	// use new derived transaction data for each meta transaction.

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -62,56 +62,7 @@ func (proc *TransactionProcedure) Run(
 	txnState *state.TransactionState,
 	derivedTxnData *programs.DerivedTransactionData,
 ) error {
-	err := proc.run(ctx, txnState, derivedTxnData)
-	txErr, failure := errors.SplitErrorTypes(err)
-	if failure != nil {
-		// log the full error path
-		ctx.Logger.Err(err).Msg("fatal error when execution a transaction")
-		return failure
-	}
-
-	if txErr != nil {
-		proc.Err = txErr
-	}
-
-	return nil
-}
-
-func (proc *TransactionProcedure) run(
-	ctx Context,
-	txnState *state.TransactionState,
-	derivedTxnData *programs.DerivedTransactionData,
-) error {
-	if ctx.AuthorizationChecksEnabled {
-		err := NewTransactionVerifier(ctx.AccountKeyWeightThreshold).Process(
-			ctx,
-			proc,
-			txnState,
-			derivedTxnData)
-		if err != nil {
-			return err
-		}
-	}
-
-	if ctx.SequenceNumberCheckAndIncrementEnabled {
-		err := NewTransactionSequenceNumberChecker().Process(
-			ctx,
-			proc,
-			txnState,
-			derivedTxnData)
-		if err != nil {
-			return err
-		}
-	}
-
-	if ctx.TransactionBodyExecutionEnabled {
-		err := NewTransactionInvoker().Process(ctx, proc, txnState, derivedTxnData)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return NewTransactionInvoker().Process(ctx, proc, txnState, derivedTxnData)
 }
 
 func (proc *TransactionProcedure) ComputationLimit(ctx Context) uint64 {

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -32,7 +32,10 @@ func TestSafetyCheck(t *testing.T) {
 		proc := fvm.Transaction(&flow.TransactionBody{Script: []byte(code)}, 0)
 
 		view := utils.NewSimpleView()
-		context := fvm.NewContext(fvm.WithLogger(log))
+		context := fvm.NewContext(
+			fvm.WithLogger(log),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false))
 
 		txnState := state.NewTransactionState(
 			view,
@@ -47,7 +50,8 @@ func TestSafetyCheck(t *testing.T) {
 		require.NoError(t, err)
 
 		err = txInvoker.Process(context, proc, txnState, derivedTxnData)
-		require.Error(t, err)
+		require.Nil(t, err)
+		require.Error(t, proc.Err)
 
 		require.NotContains(t, buffer.String(), "programs")
 		require.NotContains(t, buffer.String(), "codes")
@@ -65,7 +69,10 @@ func TestSafetyCheck(t *testing.T) {
 		proc := fvm.Transaction(&flow.TransactionBody{Script: []byte(code)}, 0)
 
 		view := utils.NewSimpleView()
-		context := fvm.NewContext(fvm.WithLogger(log))
+		context := fvm.NewContext(
+			fvm.WithLogger(log),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false))
 
 		txnState := state.NewTransactionState(
 			view,
@@ -80,7 +87,8 @@ func TestSafetyCheck(t *testing.T) {
 		require.NoError(t, err)
 
 		err = txInvoker.Process(context, proc, txnState, derivedTxnData)
-		require.Error(t, err)
+		require.Nil(t, err)
+		require.Error(t, proc.Err)
 
 		require.NotContains(t, buffer.String(), "programs")
 		require.NotContains(t, buffer.String(), "codes")

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -5,28 +5,23 @@ import (
 
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/trace"
 )
 
 type TransactionSequenceNumberChecker struct{}
 
-func NewTransactionSequenceNumberChecker() *TransactionSequenceNumberChecker {
-	return &TransactionSequenceNumberChecker{}
-}
-
-func (c *TransactionSequenceNumberChecker) Process(
-	ctx Context,
+func (c TransactionSequenceNumberChecker) CheckAndIncrementSequenceNumber(
+	tracer module.Tracer,
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
-	_ *programs.DerivedTransactionData,
 ) error {
 	// TODO(Janez): verification is part of inclusion fees, not execution fees.
 	var err error
 	txnState.RunWithAllLimitsDisabled(func() {
-		err = c.checkAndIncrementSequenceNumber(proc, ctx, txnState)
+		err = c.checkAndIncrementSequenceNumber(tracer, proc, txnState)
 	})
 
 	if err != nil {
@@ -36,13 +31,15 @@ func (c *TransactionSequenceNumberChecker) Process(
 	return nil
 }
 
-func (c *TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
+func (c TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
+	tracer module.Tracer,
 	proc *TransactionProcedure,
-	ctx Context,
 	txnState *state.TransactionState,
 ) error {
 
-	defer proc.StartSpanFromProcTraceSpan(ctx.Tracer, trace.FVMSeqNumCheckTransaction).End()
+	defer proc.StartSpanFromProcTraceSpan(
+		tracer,
+		trace.FVMSeqNumCheckTransaction).End()
 
 	nestedTxnId, err := txnState.BeginNestedTransaction()
 	if err != nil {

--- a/fvm/transactionSequenceNum_test.go
+++ b/fvm/transactionSequenceNum_test.go
@@ -31,8 +31,8 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		tx.SetProposalKey(address, 0, 0)
 		proc := fvm.Transaction(&tx, 0)
 
-		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(fvm.Context{}, proc, txnState, nil)
+		seqChecker := fvm.TransactionSequenceNumberChecker{}
+		err = seqChecker.CheckAndIncrementSequenceNumber(nil, proc, txnState)
 		require.NoError(t, err)
 
 		// get fetch the sequence number and it should be updated
@@ -57,8 +57,8 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		tx.SetProposalKey(address, 0, 2)
 		proc := fvm.Transaction(&tx, 0)
 
-		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(fvm.Context{}, proc, txnState, nil)
+		seqChecker := fvm.TransactionSequenceNumberChecker{}
+		err = seqChecker.CheckAndIncrementSequenceNumber(nil, proc, txnState)
 		require.Error(t, err)
 		require.True(t, errors.HasErrorCode(err, errors.ErrCodeInvalidProposalSeqNumberError))
 
@@ -85,7 +85,7 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.Process(fvm.Context{}, proc, txnState, nil)
+		err = seqChecker.CheckAndIncrementSequenceNumber(nil, proc, txnState)
 		require.Error(t, err)
 
 		// get fetch the sequence number and check it to be unchanged

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -18,7 +18,7 @@ func NewTransactionStorageLimiter() TransactionStorageLimiter {
 	return TransactionStorageLimiter{}
 }
 
-func (d TransactionStorageLimiter) CheckLimits(
+func (d TransactionStorageLimiter) CheckStorageLimits(
 	env environment.Environment,
 	addresses []flow.Address,
 ) error {

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -31,7 +31,7 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckLimits(env, []flow.Address{owner})
+		err := d.CheckStorageLimits(env, []flow.Address{owner})
 		require.NoError(t, err, "Transaction with higher capacity than storage used should work")
 	})
 	t.Run("capacity = storage -> OK", func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckLimits(env, []flow.Address{owner})
+		err := d.CheckStorageLimits(env, []flow.Address{owner})
 		require.NoError(t, err, "Transaction with equal capacity than storage used should work")
 	})
 	t.Run("capacity < storage -> Not OK", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckLimits(env, []flow.Address{owner})
+		err := d.CheckStorageLimits(env, []flow.Address{owner})
 		require.Error(t, err, "Transaction with lower capacity than storage used should fail")
 	})
 	t.Run("if ctx LimitAccountStorage false-> OK", func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckLimits(env, []flow.Address{owner})
+		err := d.CheckStorageLimits(env, []flow.Address{owner})
 		require.NoError(t, err, "Transaction with higher capacity than storage used should work")
 	})
 	t.Run("non existing accounts or any other errors on fetching storage used -> Not OK", func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestTransactionStorageLimiter_Process(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckLimits(env, []flow.Address{owner})
+		err := d.CheckStorageLimits(env, []flow.Address{owner})
 		require.Error(t, err, "check storage used on non existing account (not general registers) should fail")
 	})
 }

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -8,9 +8,9 @@ import (
 	"github.com/onflow/flow-go/fvm/crypto"
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/trace"
 )
 
@@ -22,25 +22,18 @@ import (
 //
 // if KeyWeightThreshold is set to a negative number, signature verification is skipped
 type TransactionVerifier struct {
-	KeyWeightThreshold int
 }
 
-func NewTransactionVerifier(keyWeightThreshold int) *TransactionVerifier {
-	return &TransactionVerifier{
-		KeyWeightThreshold: keyWeightThreshold,
-	}
-}
-
-func (v *TransactionVerifier) Process(
-	ctx Context,
+func (v *TransactionVerifier) CheckAuthorization(
+	tracer module.Tracer,
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
-	_ *programs.DerivedTransactionData,
+	keyWeightThreshold int,
 ) error {
 	// TODO(Janez): verification is part of inclusion fees, not execution fees.
 	var err error
 	txnState.RunWithAllLimitsDisabled(func() {
-		err = v.verifyTransaction(proc, ctx, txnState)
+		err = v.verifyTransaction(tracer, proc, txnState, keyWeightThreshold)
 	})
 	if err != nil {
 		return fmt.Errorf("transaction verification failed: %w", err)
@@ -50,11 +43,12 @@ func (v *TransactionVerifier) Process(
 }
 
 func (v *TransactionVerifier) verifyTransaction(
+	tracer module.Tracer,
 	proc *TransactionProcedure,
-	ctx Context,
 	txnState *state.TransactionState,
+	keyWeightThreshold int,
 ) error {
-	span := proc.StartSpanFromProcTraceSpan(ctx.Tracer, trace.FVMVerifyTransaction)
+	span := proc.StartSpanFromProcTraceSpan(tracer, trace.FVMVerifyTransaction)
 	span.SetAttributes(
 		attribute.String("transaction.ID", proc.ID.String()),
 	)
@@ -80,7 +74,7 @@ func (v *TransactionVerifier) verifyTransaction(
 		return err
 	}
 
-	if v.KeyWeightThreshold < 0 {
+	if keyWeightThreshold < 0 {
 		return nil
 	}
 
@@ -126,22 +120,22 @@ func (v *TransactionVerifier) verifyTransaction(
 			continue
 		}
 		// hasSufficientKeyWeight
-		if !v.hasSufficientKeyWeight(payloadWeights, addr) {
+		if !v.hasSufficientKeyWeight(payloadWeights, addr, keyWeightThreshold) {
 			return errors.NewAccountAuthorizationErrorf(
 				addr,
 				"authorizer account does not have sufficient signatures (%d < %d)",
 				payloadWeights[addr],
-				v.KeyWeightThreshold)
+				keyWeightThreshold)
 		}
 	}
 
-	if !v.hasSufficientKeyWeight(envelopeWeights, tx.Payer) {
+	if !v.hasSufficientKeyWeight(envelopeWeights, tx.Payer, keyWeightThreshold) {
 		// TODO change this to payer error (needed for fees)
 		return errors.NewAccountAuthorizationErrorf(
 			tx.Payer,
 			"payer account does not have sufficient signatures (%d < %d)",
 			envelopeWeights[tx.Payer],
-			v.KeyWeightThreshold)
+			keyWeightThreshold)
 	}
 
 	return nil
@@ -219,8 +213,9 @@ func (v *TransactionVerifier) verifyAccountSignature(
 func (v *TransactionVerifier) hasSufficientKeyWeight(
 	weights map[flow.Address]int,
 	address flow.Address,
+	keyWeightThreshold int,
 ) bool {
-	return weights[address] >= v.KeyWeightThreshold
+	return weights[address] >= keyWeightThreshold
 }
 
 func (v *TransactionVerifier) sigIsForProposalKey(

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -81,6 +81,8 @@ func TestAccountFreezing(t *testing.T) {
 
 		context := fvm.NewContext(
 			fvm.WithChain(chain),
+			fvm.WithAuthorizationChecksEnabled(false),
+			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 			fvm.WithDerivedBlockData(derivedBlockData))
 
 		derivedBlockData = programs.NewEmptyDerivedBlockData()
@@ -89,6 +91,7 @@ func TestAccountFreezing(t *testing.T) {
 
 		err = txInvoker.Process(context, proc, st, derivedTxnData)
 		require.NoError(t, err)
+		require.NoError(t, proc.Err)
 
 		// account should be frozen now
 		frozen, err = accounts.GetAccountFrozen(address)
@@ -518,8 +521,16 @@ func TestAccountFreezing(t *testing.T) {
 		require.NoError(t, err)
 
 		txInvoker := fvm.NewTransactionInvoker()
-		err = txInvoker.Process(context, proc, st, derivedTxnData)
+		err = txInvoker.Process(
+			fvm.NewContextFromParent(
+				context,
+				fvm.WithAuthorizationChecksEnabled(false),
+			),
+			proc,
+			st,
+			derivedTxnData)
 		require.NoError(t, err)
+		require.NoError(t, proc.Err)
 
 		// make sure freeze status is correct
 		var frozen bool


### PR DESCRIPTION
1. moved TransactionProcedure.Run into transaction executor
2. made txn verifier stateless to improve composability.
3. replace verifier and seq num checker's Process methods with more descriptive name since they no longer need to implement the Process interface.
4. renamed CheckLimits to CheckStorageLimits
5. renamed invocationExecutor to transactionExecutor

gh: #3547