### PR TITLE
[Profiler] Add admin commands to control profiling rates

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
@@ -21,6 +20,7 @@ import (
 	"github.com/onflow/flow-go/module/chainsync"
 	"github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/profiler"
 	"github.com/onflow/flow-go/module/updatable_configs"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/codec/cbor"
@@ -157,12 +157,7 @@ type BaseConfig struct {
 	level                       string
 	metricsPort                 uint
 	BootstrapDir                string
-	profilerEnabled             bool
-	uploaderEnabled             bool
-	profilerDir                 string
-	profilerInterval            time.Duration
-	profilerDuration            time.Duration
-	profilerMemProfileRate      int
+	profilerConfig              profiler.ProfilerConfig
 	tracerEnabled               bool
 	tracerSensitivity           uint
 	MetricsEnabled              bool
@@ -289,18 +284,21 @@ func DefaultBaseConfig() *BaseConfig {
 		secretsDBEnabled: true,
 		level:            "info",
 
-		metricsPort:            8080,
-		profilerEnabled:        false,
-		uploaderEnabled:        false,
-		profilerDir:            "profiler",
-		profilerInterval:       15 * time.Minute,
-		profilerDuration:       10 * time.Second,
-		profilerMemProfileRate: runtime.MemProfileRate,
-		tracerEnabled:          false,
-		tracerSensitivity:      4,
-		MetricsEnabled:         true,
-		receiptsCacheSize:      bstorage.DefaultCacheSize,
-		guaranteesCacheSize:    bstorage.DefaultCacheSize,
+		metricsPort:         8080,
+		tracerEnabled:       false,
+		tracerSensitivity:   4,
+		MetricsEnabled:      true,
+		receiptsCacheSize:   bstorage.DefaultCacheSize,
+		guaranteesCacheSize: bstorage.DefaultCacheSize,
+
+		profilerConfig: profiler.ProfilerConfig{
+			Enabled:         false,
+			UploaderEnabled: false,
+
+			Dir:      "profiler",
+			Interval: 15 * time.Minute,
+			Duration: 10 * time.Second,
+		},
 
 		HeroCacheMetricsEnable: false,
 		SyncCoreConfig:         chainsync.DefaultConfig(),

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -142,20 +142,19 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 	fnb.flags.DurationVar(&fnb.BaseConfig.PeerUpdateInterval, "peerupdate-interval", defaultConfig.PeerUpdateInterval, "how often to refresh the peer connections for the node")
 	fnb.flags.DurationVar(&fnb.BaseConfig.UnicastMessageTimeout, "unicast-timeout", defaultConfig.UnicastMessageTimeout, "how long a unicast transmission can take to complete")
 	fnb.flags.UintVarP(&fnb.BaseConfig.metricsPort, "metricport", "m", defaultConfig.metricsPort, "port for /metrics endpoint")
-	fnb.flags.BoolVar(&fnb.BaseConfig.profilerEnabled, "profiler-enabled", defaultConfig.profilerEnabled, "whether to enable the auto-profiler")
-	fnb.flags.BoolVar(&fnb.BaseConfig.uploaderEnabled, "profile-uploader-enabled", defaultConfig.uploaderEnabled,
+	fnb.flags.BoolVar(&fnb.BaseConfig.profilerConfig.Enabled, "profiler-enabled", defaultConfig.profilerConfig.Enabled, "whether to enable the auto-profiler")
+	fnb.flags.BoolVar(&fnb.BaseConfig.profilerConfig.UploaderEnabled, "profile-uploader-enabled", defaultConfig.profilerConfig.UploaderEnabled,
 		"whether to enable automatic profile upload to Google Cloud Profiler. "+
 			"For autoupload to work forllowing should be true: "+
 			"1) both -profiler-enabled=true and -profile-uploader-enabled=true need to be set. "+
 			"2) node is running in GCE. "+
 			"3) server or user has https://www.googleapis.com/auth/monitoring.write scope. ")
-	fnb.flags.StringVar(&fnb.BaseConfig.profilerDir, "profiler-dir", defaultConfig.profilerDir, "directory to create auto-profiler profiles")
-	fnb.flags.DurationVar(&fnb.BaseConfig.profilerInterval, "profiler-interval", defaultConfig.profilerInterval,
+	fnb.flags.StringVar(&fnb.BaseConfig.profilerConfig.Dir, "profiler-dir", defaultConfig.profilerConfig.Dir, "directory to create auto-profiler profiles")
+	fnb.flags.DurationVar(&fnb.BaseConfig.profilerConfig.Interval, "profiler-interval", defaultConfig.profilerConfig.Interval,
 		"the interval between auto-profiler runs")
-	fnb.flags.DurationVar(&fnb.BaseConfig.profilerDuration, "profiler-duration", defaultConfig.profilerDuration,
+	fnb.flags.DurationVar(&fnb.BaseConfig.profilerConfig.Duration, "profiler-duration", defaultConfig.profilerConfig.Duration,
 		"the duration to run the auto-profile for")
-	fnb.flags.IntVar(&fnb.BaseConfig.profilerMemProfileRate, "profiler-mem-profile-rate", defaultConfig.profilerMemProfileRate,
-		"controls the fraction of memory allocations that are recorded and reported in the memory profile. 0 means turn off heap profiling entirely")
+
 	fnb.flags.BoolVar(&fnb.BaseConfig.tracerEnabled, "tracer-enabled", defaultConfig.tracerEnabled,
 		"whether to enable tracer")
 	fnb.flags.UintVar(&fnb.BaseConfig.tracerSensitivity, "tracer-sensitivity", defaultConfig.tracerSensitivity,
@@ -464,7 +463,7 @@ func (fnb *FlowNodeBuilder) InitFlowNetworkWithConduitFactory(node *NodeConfig, 
 
 func (fnb *FlowNodeBuilder) EnqueueMetricsServerInit() {
 	fnb.Component("metrics server", func(node *NodeConfig) (module.ReadyDoneAware, error) {
-		server := metrics.NewServer(fnb.Logger, fnb.BaseConfig.metricsPort, fnb.BaseConfig.profilerEnabled)
+		server := metrics.NewServer(fnb.Logger, fnb.BaseConfig.metricsPort)
 		return server, nil
 	})
 }
@@ -679,7 +678,7 @@ func (fnb *FlowNodeBuilder) createGCEProfileUploader(client *gcemd.Client, opts 
 
 func (fnb *FlowNodeBuilder) createProfileUploader() (profiler.Uploader, error) {
 	switch {
-	case fnb.BaseConfig.uploaderEnabled && gcemd.OnGCE():
+	case fnb.BaseConfig.profilerConfig.UploaderEnabled && gcemd.OnGCE():
 		return fnb.createGCEProfileUploader(gcemd.NewClient(nil))
 	default:
 		fnb.Logger.Info().Msg("not running on GCE, setting pprof uploader to noop")
@@ -688,23 +687,13 @@ func (fnb *FlowNodeBuilder) createProfileUploader() (profiler.Uploader, error) {
 }
 
 func (fnb *FlowNodeBuilder) initProfiler() {
-	// note: by default the Golang heap profiling rate is on and can be set even if the profiler is NOT enabled
-	runtime.MemProfileRate = fnb.BaseConfig.profilerMemProfileRate
-
 	uploader, err := fnb.createProfileUploader()
 	if err != nil {
 		fnb.Logger.Warn().Err(err).Msg("failed to create pprof uploader, falling back to noop")
 		uploader = &profiler.NoopUploader{}
 	}
 
-	profiler, err := profiler.New(
-		fnb.Logger,
-		uploader,
-		fnb.BaseConfig.profilerDir,
-		fnb.BaseConfig.profilerInterval,
-		fnb.BaseConfig.profilerDuration,
-		fnb.BaseConfig.profilerEnabled,
-	)
+	profiler, err := profiler.New(fnb.Logger, uploader, fnb.BaseConfig.profilerConfig)
 	fnb.MustNot(err).Msg("could not initialize profiler")
 
 	// register the enabled state of the profiler for dynamic configuring
@@ -712,11 +701,30 @@ func (fnb *FlowNodeBuilder) initProfiler() {
 	fnb.MustNot(err).Msg("could not register profiler-enabled config")
 	err = fnb.ConfigManager.RegisterDurationConfig(
 		"profiler-trigger",
-		func() time.Duration { return fnb.BaseConfig.profilerDuration },
-		func(d time.Duration) error {
-			return profiler.TriggerRun(d)
-		})
+		func() time.Duration { return fnb.BaseConfig.profilerConfig.Duration },
+		func(d time.Duration) error { return profiler.TriggerRun(d) })
 	fnb.MustNot(err).Msg("could not register profiler-trigger config")
+
+	fnb.MustNot(
+		fnb.ConfigManager.RegisterUintConfig(
+			"profiler-set-mem-profile-rate",
+			func() uint { return uint(runtime.MemProfileRate) },
+			func(r uint) error { runtime.MemProfileRate = int(r); return nil }),
+	).Msg("could not register profiler setting")
+	// There is no way to get the current block progile rate so we keep track of it ourselves.
+	currentRate := new(uint)
+	fnb.MustNot(
+		fnb.ConfigManager.RegisterUintConfig(
+			"profiler-set-block-profile-rate",
+			func() uint { return *currentRate },
+			func(r uint) error { currentRate = &r; runtime.SetBlockProfileRate(int(r)); return nil }),
+	).Msg("could not register profiler setting")
+	fnb.MustNot(
+		fnb.ConfigManager.RegisterUintConfig(
+			"profiler-set-mutex-profile-fraction",
+			func() uint { return uint(runtime.SetMutexProfileFraction(-1)) },
+			func(r uint) error { _ = runtime.SetMutexProfileFraction(int(r)); return nil }),
+	).Msg("could not register profiler setting")
 
 	fnb.Component("profiler", func(node *NodeConfig) (module.ReadyDoneAware, error) {
 		return profiler, nil

--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -97,7 +97,7 @@ func main() {
 	}
 	log = log.Level(lvl)
 
-	server := metrics.NewServer(log, metricport, false)
+	server := metrics.NewServer(log, metricport)
 	<-server.Ready()
 	loaderMetrics := metrics.NewLoaderCollector()
 

--- a/integration/benchmark/cmd/manual/main.go
+++ b/integration/benchmark/cmd/manual/main.go
@@ -40,7 +40,6 @@ func main() {
 	logLvl := flag.String("log-level", "info", "set log level")
 	metricport := flag.Uint("metricport", 8080, "port for /metrics endpoint")
 	pushgateway := flag.String("pushgateway", "127.0.0.1:9091", "host:port for pushgateway")
-	profilerEnabled := flag.Bool("profiler-enabled", false, "whether to enable the auto-profiler")
 	_ = flag.Bool("track-txs", false, "deprecated")
 	accountMultiplierFlag := flag.Int("account-multiplier", 100, "number of accounts to create per load tps")
 	feedbackEnabled := flag.Bool("feedback-enabled", true, "wait for trannsaction execution before submitting new transaction")
@@ -60,7 +59,7 @@ func main() {
 	}
 	log = log.Level(lvl)
 
-	server := metrics.NewServer(log, *metricport, *profilerEnabled)
+	server := metrics.NewServer(log, *metricport)
 	<-server.Ready()
 	loaderMetrics := metrics.NewLoaderCollector()
 

--- a/module/metrics/example/setup.go
+++ b/module/metrics/example/setup.go
@@ -15,7 +15,7 @@ import (
 func WithMetricsServer(f func(logger zerolog.Logger)) {
 	logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
 	port := 3030
-	server := metrics.NewServer(logger, uint(port), true)
+	server := metrics.NewServer(logger, uint(port))
 	exitSig := make(chan os.Signal, 1)
 	signal.Notify(exitSig, os.Interrupt, syscall.SIGTERM)
 

--- a/module/metrics/server.go
+++ b/module/metrics/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	_ "net/http/pprof"
 	"strconv"
 	"time"
 
@@ -20,16 +19,13 @@ type Server struct {
 
 // NewServer creates a new server that will start on the specified port,
 // and responds to only the `/metrics` endpoint
-func NewServer(log zerolog.Logger, port uint, enableProfilerEndpoint bool) *Server {
+func NewServer(log zerolog.Logger, port uint) *Server {
 	addr := ":" + strconv.Itoa(int(port))
 
 	mux := http.NewServeMux()
 	endpoint := "/metrics"
 	mux.Handle(endpoint, promhttp.Handler())
 	log.Info().Str("address", addr).Str("endpoint", endpoint).Msg("metrics server started")
-	if enableProfilerEndpoint {
-		mux.Handle("/debug/pprof/", http.DefaultServeMux)
-	}
 
 	m := &Server{
 		server: &http.Server{Addr: addr, Handler: mux},

--- a/module/profiler/profiler_internal_test.go
+++ b/module/profiler/profiler_internal_test.go
@@ -17,7 +17,15 @@ func TestGoHeapProfile(t *testing.T) {
 	t.Parallel()
 	t.Run("goHeapProfile", func(t *testing.T) {
 		unittest.RunWithTempDir(t, func(tempDir string) {
-			p, err := New(zerolog.Nop(), &NoopUploader{}, tempDir, time.Millisecond*100, time.Millisecond*100, false)
+			p, err := New(
+				zerolog.Nop(),
+				&NoopUploader{},
+				ProfilerConfig{
+					Enabled:  false,
+					Dir:      tempDir,
+					Interval: 100 * time.Millisecond,
+					Duration: 100 * time.Millisecond,
+				})
 			require.NoError(t, err)
 			unittest.AssertClosesBefore(t, p.Ready(), 5*time.Second)
 			t.Logf("profiler ready %s", tempDir)
@@ -43,7 +51,15 @@ func TestGoAllocsProfile(t *testing.T) {
 	t.Parallel()
 	t.Run("pprofAllocs", func(t *testing.T) {
 		unittest.RunWithTempDir(t, func(tempDir string) {
-			p, err := New(zerolog.Nop(), &NoopUploader{}, tempDir, time.Hour, time.Second*1, false)
+			p, err := New(
+				zerolog.Nop(),
+				&NoopUploader{},
+				ProfilerConfig{
+					Enabled:  false,
+					Dir:      tempDir,
+					Interval: time.Hour,
+					Duration: time.Second,
+				})
 			require.NoError(t, err)
 			unittest.AssertClosesBefore(t, p.Ready(), 5*time.Second)
 			t.Logf("profiler ready %s", tempDir)

--- a/module/profiler/profiler_test.go
+++ b/module/profiler/profiler_test.go
@@ -17,7 +17,15 @@ func TestProfiler(t *testing.T) {
 	// profiler depends on the shared state, hence only one enabled=true test can run at a time.
 	t.Run("profilerEnabled", func(t *testing.T) {
 		unittest.RunWithTempDir(t, func(tempDir string) {
-			p, err := profiler.New(zerolog.Nop(), &profiler.NoopUploader{}, tempDir, time.Hour, time.Millisecond*100, false)
+			p, err := profiler.New(
+				zerolog.Nop(),
+				&profiler.NoopUploader{},
+				profiler.ProfilerConfig{
+					Enabled:  false,
+					Dir:      tempDir,
+					Interval: time.Hour,
+					Duration: 100 * time.Millisecond,
+				})
 			require.NoError(t, err)
 
 			unittest.AssertClosesBefore(t, p.Ready(), 5*time.Second)


### PR DESCRIPTION
This PR adds following admin commands:
* profiler-set-mem-profile-rate
* profiler-set-block-profile-rate
* profiler-set-mutex-profile-fraction (really want to rename that to "rate", but kept for consistency w/ golang naming)

While here, also remove the `-profiler-mem-profile-rate` command line argument and `/debug/pprof` interface from the metrics port.

Ref: https://github.com/onflow/flow-go/issues/3455