### PR TITLE
[Benchmark] Notify on slow transactions

### DIFF
--- a/module/metrics/loader.go
+++ b/module/metrics/loader.go
@@ -9,6 +9,7 @@ import (
 
 type LoaderCollector struct {
 	transactionsSent prometheus.Counter
+	transactionsLost prometheus.Counter
 	tpsConfigured    prometheus.Gauge
 
 	transactionsExecuted prometheus.Counter
@@ -22,6 +23,11 @@ func NewLoaderCollector() *LoaderCollector {
 			Name:      "transactions_sent",
 			Namespace: namespaceLoader,
 			Help:      "transactions sent by the loader",
+		}),
+		transactionsLost: promauto.NewCounter(prometheus.CounterOpts{
+			Name:      "transactions_lost",
+			Namespace: namespaceLoader,
+			Help:      "transaction that took too long to return",
 		}),
 		tpsConfigured: promauto.NewGauge(prometheus.GaugeOpts{
 			Name:      "transactions_per_second_configured",
@@ -46,6 +52,10 @@ func NewLoaderCollector() *LoaderCollector {
 
 func (cc *LoaderCollector) TransactionSent() {
 	cc.transactionsSent.Inc()
+}
+
+func (cc *LoaderCollector) TransactionLost() {
+	cc.transactionsLost.Inc()
 }
 
 func (cc *LoaderCollector) SetTPSConfigured(tps uint) {


### PR DESCRIPTION
Sometimes at high TPS we never receive a notification from a transaction being executed/sealed.  This leads to feedback loop stalling since it waits for ongoing transactions to finish.

While we are figuring out where and why this happens let's unblock the benchmarking by proceeding and logging such events.  Later we can cross-correlate logs for these transaction IDs.

Ref: https://github.com/onflow/flow-go/issues/3548