### PR TITLE
[Benchmark] Faster account creation

### DIFF
--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -415,18 +415,18 @@ func (lg *ContLoadGenerator) createAccounts(num int) error {
 		return err
 	}
 
-	ch, err := lg.sendTx(-1, createAccountTx)
+	// Do not wait for the transaction to be sealed.
+	_, err = lg.sendTx(-1, createAccountTx)
 	if err != nil {
 		return err
 	}
-	<-ch
-	lg.workerStatsTracker.IncTxExecuted()
 
 	log := lg.log.With().Str("tx_id", createAccountTx.ID().String()).Logger()
 	result, err := WaitForTransactionResult(context.Background(), lg.flowClient, createAccountTx.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transactions result: %w", err)
 	}
+	lg.workerStatsTracker.IncTxExecuted()
 
 	log.Trace().Str("status", result.Status.String()).Msg("account creation tx executed")
 	if result.Error != nil {

--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -421,13 +421,13 @@ func (lg *ContLoadGenerator) createAccounts(num int) error {
 		return err
 	}
 
-	log := lg.log.With().Str("tx_id", createAccountTx.ID().String()).Logger()
 	result, err := WaitForTransactionResult(context.Background(), lg.flowClient, createAccountTx.ID())
 	if err != nil {
 		return fmt.Errorf("failed to get transactions result: %w", err)
 	}
 	lg.workerStatsTracker.IncTxExecuted()
 
+	log := lg.log.With().Str("tx_id", createAccountTx.ID().String()).Logger()
 	log.Trace().Str("status", result.Status.String()).Msg("account creation tx executed")
 	if result.Error != nil {
 		log.Error().Err(result.Error).Msg("account creation tx failed")

--- a/integration/benchmark/tx_result.go
+++ b/integration/benchmark/tx_result.go
@@ -14,9 +14,8 @@ import (
 // WaitForTransactionResult waits for the transaction to get into the terminal state and returns the result.
 func WaitForTransactionResult(ctx context.Context, client access.Client, txID flowsdk.Identifier) (*flowsdk.TransactionResult, error) {
 	var b retry.Backoff
-	b = retry.NewFibonacci(100 * time.Millisecond)
+	b = retry.NewConstant(500 * time.Millisecond)
 	b = retry.WithMaxDuration(60*time.Second, b)
-	b = retry.WithCappedDuration(10*time.Second, b)
 
 	var result *flowsdk.TransactionResult
 	err := retry.Do(ctx, b, func(ctx context.Context) (err error) {


### PR DESCRIPTION
No need to wait for account creation transactions being sealed.

Ref: https://github.com/onflow/flow-go/issues/3548