### PR TITLE
[Benchmark] Speedup benchmark convergence

### DIFF
--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -59,8 +59,8 @@ const (
 	serviceAccountPrivateKeyHex = unittest.ServiceAccountPrivateKeyHex
 
 	// Auto TPS scaling constants
-	additiveIncrease       = 50
-	multiplicativeDecrease = 0.8
+	additiveIncrease       = 100
+	multiplicativeDecrease = 0.9
 	adjustInterval         = 20 * time.Second
 )
 

--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -186,7 +186,7 @@ func (f *txFollowerImpl) run() {
 }
 
 func (f *txFollowerImpl) pollCollections() (*flowsdk.Block, []flowsdk.Collection, error) {
-	ctx, cancel := context.WithTimeout(f.ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(f.ctx, 1*time.Second)
 	defer cancel()
 
 	hdr, err := f.client.GetLatestBlockHeader(ctx, true)


### PR DESCRIPTION
This speeds up the convergence to maximum sustainable TPS (`additiveIncrease` increase) and reduces variance of the results (`multiplicativeDecrease` increase.)

Also reduce timeout on `pollCollections` to 1s: a value that is closer to our block generation time.

Ref: https://github.com/onflow/flow-go/issues/3548