### PR TITLE
Enable nested transaction to use a different set of meter parameters

### DIFF
--- a/fvm/meter/meter.go
+++ b/fvm/meter/meter.go
@@ -384,16 +384,6 @@ func NewMeter(params MeterParameters) *Meter {
 	return m
 }
 
-// NewChild construct a new Meter instance with the same limits as parent
-func (m *Meter) NewChild() *Meter {
-	return &Meter{
-		MeterParameters:        m.MeterParameters,
-		computationIntensities: make(MeteredComputationIntensities),
-		memoryIntensities:      make(MeteredMemoryIntensities),
-		storageUpdateSizeMap:   make(MeteredStorageInteractionMap),
-	}
-}
-
 // MergeMeter merges the input meter into the current meter and checks for the limits
 func (m *Meter) MergeMeter(child *Meter) {
 	if child == nil {

--- a/fvm/meter/meter_test.go
+++ b/fvm/meter/meter_test.go
@@ -130,15 +130,15 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err := m.MeterComputation(compKind, 1)
 		require.NoError(t, err)
 
-		child1 := m.NewChild()
+		child1 := meter.NewMeter(m.MeterParameters)
 		err = child1.MeterComputation(compKind, 2)
 		require.NoError(t, err)
 
-		child2 := m.NewChild()
+		child2 := meter.NewMeter(m.MeterParameters)
 		err = child2.MeterComputation(compKind, 3)
 		require.NoError(t, err)
 
-		child3 := m.NewChild()
+		child3 := meter.NewMeter(m.MeterParameters)
 		err = child3.MeterComputation(compKind, 4)
 		require.NoError(t, err)
 
@@ -174,7 +174,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err := m.MeterComputation(compKind, 1)
 		require.NoError(t, err)
 
-		child := m.NewChild()
+		child := meter.NewMeter(m.MeterParameters)
 		err = child.MeterComputation(compKind, 1)
 		require.NoError(t, err)
 
@@ -196,7 +196,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err := m.MeterComputation(0, 1)
 		require.NoError(t, err)
 
-		child1 := m.NewChild()
+		child1 := meter.NewMeter(m.MeterParameters)
 		err = child1.MeterComputation(0, 1)
 		require.NoError(t, err)
 
@@ -218,7 +218,7 @@ func TestWeightedComputationMetering(t *testing.T) {
 		err := m.MeterMemory(0, 1)
 		require.NoError(t, err)
 
-		child1 := m.NewChild()
+		child1 := meter.NewMeter(m.MeterParameters)
 		err = child1.MeterMemory(0, 1)
 		require.NoError(t, err)
 

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -120,15 +120,23 @@ func NewState(view View, params StateParameters) *State {
 	}
 }
 
-// NewChild generates a new child state
-func (s *State) NewChild() *State {
+// NewChildWithMeterParams generates a new child state using the provide meter
+// parameters.
+func (s *State) NewChildWithMeterParams(
+	params meter.MeterParameters,
+) *State {
 	return &State{
 		committed:        false,
 		view:             s.view.NewChild(),
-		meter:            s.meter.NewChild(),
+		meter:            meter.NewMeter(params),
 		updatedAddresses: make(map[flow.Address]struct{}),
 		stateLimits:      s.stateLimits,
 	}
+}
+
+// NewChild generates a new child state using the parent's meter parameters.
+func (s *State) NewChild() *State {
+	return s.NewChildWithMeterParams(s.meter.MeterParameters)
 }
 
 // InteractionUsed returns the amount of ledger interaction (total ledger byte read + total ledger byte written)

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -90,7 +90,8 @@ func (s *TransactionState) IsCurrent(id NestedTransactionId) bool {
 }
 
 // BeginNestedTransaction creates a unrestricted nested transaction within the
-// current unrestricted (nested) transaction.  This returns error if the current
+// current unrestricted (nested) transaction.  The meter parameters are
+// inherited from the current transaction.  This returns error if the current
 // nested transaction is program restricted.
 func (s *TransactionState) BeginNestedTransaction() (
 	NestedTransactionId,
@@ -111,8 +112,34 @@ func (s *TransactionState) BeginNestedTransaction() (
 	}, nil
 }
 
+// BeginNestedTransactionWithMeterParams creates a unrestricted nested
+// transaction within the current unrestricted (nested) transaction, using the
+// provided meter parameters. This returns error if the current nested
+// transaction is program restricted.
+func (s *TransactionState) BeginNestedTransactionWithMeterParams(
+	params meter.MeterParameters,
+) (
+	NestedTransactionId,
+	error,
+) {
+	if s.IsParseRestricted() {
+		return NestedTransactionId{}, fmt.Errorf(
+			"cannot begin a unrestricted nested transaction inside a " +
+				"program restricted nested transaction",
+		)
+	}
+
+	child := s.currentState().NewChildWithMeterParams(params)
+	s.push(child, nil)
+
+	return NestedTransactionId{
+		state: child,
+	}, nil
+}
+
 // BeginParseRestrictedNestedTransaction creates a restricted nested
-// transaction within the current (nested) transaction.
+// transaction within the current (nested) transaction.  The meter parameters
+// are inherited from the current transaction.
 func (s *TransactionState) BeginParseRestrictedNestedTransaction(
 	location common.AddressLocation,
 ) (
@@ -231,11 +258,11 @@ func (s *TransactionState) CommitParseRestricted(
 // transaction may be resume via Resume.
 //
 // WARNING: Pause and Resume are intended for implementing continuation passing
-// style behavior for the transaction invoker, with the assumption that the
-// transaction processors access disjoint sets of states prior to transaction
-// invoker resumption.  The paused nested transaction should not be reused
-// across transactions.  IT IS NOT SAFE TO PAUSE A NESTED TRANSACTION IN
-// GENERAL SINCE THAT COULD LEAD TO PHANTOM READS.
+// style behavior for the transaction executor, with the assumption that the
+// states accessed prior to pausing remain valid after resumption.  The paused
+// nested transaction should not be reused across transactions.  IT IS NOT
+// SAFE TO PAUSE A NESTED TRANSACTION IN GENERAL SINCE THAT COULD LEAD TO
+// PHANTOM READS.
 func (s *TransactionState) Pause(
 	expectedId NestedTransactionId,
 ) (


### PR DESCRIPTION
This allows nested transaction to use a different set of meter parameters that are not inherited from the parent transaction, and allows us to meter different parts of the transaction using different parameters. (See discussion in #2922 for additional context)

gh: #3102