### PR TITLE
Small improvements to error types and messages in block extension logic

### DIFF
--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -269,15 +269,20 @@ func (c *Core) processBlockProposal(proposal *messages.ClusterBlockProposal) err
 	err := c.state.Extend(block)
 	// if the block proposes an invalid extension of the protocol state, then the block is invalid
 	if state.IsInvalidExtensionError(err) {
-		return engine.NewInvalidInputErrorf("invalid extension of protocol state (block: %x, height: %d): %w",
+		return engine.NewInvalidInputErrorf("invalid extension of cluster state (block_id: %x, height: %d): %w",
 			header.ID(), header.Height, err)
 	}
 	// protocol state aborted processing of block as it is on an abandoned fork: block is outdated
 	if state.IsOutdatedExtensionError(err) {
-		return engine.NewOutdatedInputErrorf("outdated extension of protocol state: %w", err)
+		return engine.NewOutdatedInputErrorf("outdated extension of cluster state (block_id: %x, height: %d): %w",
+			header.ID(), header.Height, err)
+	}
+	if state.IsUnverifiableExtensionError(err) {
+		return engine.NewUnverifiableInputError("unverifiable extension of cluster state (block_id: %x, height: %d): %w",
+			header.ID(), header.Height, err)
 	}
 	if err != nil {
-		return fmt.Errorf("could not extend protocol state (block: %x, height: %d): %w", header.ID(), header.Height, err)
+		return fmt.Errorf("unexpected error while updating cluster state (block_id: %x, height: %d): %w", header.ID(), header.Height, err)
 	}
 
 	// retrieve the parent

--- a/state/cluster/badger/mutator.go
+++ b/state/cluster/badger/mutator.go
@@ -109,7 +109,7 @@ func (m *MutableState) Extend(block *cluster.Block) error {
 			// if its height is below current boundary, the block does not connect
 			// to the finalized protocol state and would break database consistency
 			if ancestor.Height < finalizedClusterBlock.Height {
-				return state.NewUnverifiableExtensionError("block doesn't connect to finalized state. ancestor.Height (%d), final.Height (%d)",
+				return state.NewOutdatedExtensionErrorf("block doesn't connect to finalized state. ancestor.Height (%d), final.Height (%d)",
 					ancestor.Height, finalizedClusterBlock.Height)
 			}
 

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/trace"
+	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/cluster"
 	"github.com/onflow/flow-go/state/protocol"
 	pbadger "github.com/onflow/flow-go/state/protocol/badger"
@@ -244,6 +245,7 @@ func (suite *MutatorSuite) TestExtend_InvalidChainID() {
 
 	err := suite.state.Extend(&block)
 	suite.Assert().Error(err)
+	suite.Assert().True(state.IsInvalidExtensionError(err))
 }
 
 func (suite *MutatorSuite) TestExtend_InvalidBlockNumber() {
@@ -253,6 +255,7 @@ func (suite *MutatorSuite) TestExtend_InvalidBlockNumber() {
 
 	err := suite.state.Extend(&block)
 	suite.Assert().Error(err)
+	suite.Assert().True(state.IsInvalidExtensionError(err))
 }
 
 func (suite *MutatorSuite) TestExtend_DuplicateTxInPayload() {
@@ -265,6 +268,7 @@ func (suite *MutatorSuite) TestExtend_DuplicateTxInPayload() {
 	// should fail to extend block with invalid payload
 	err := suite.state.Extend(&block)
 	suite.Assert().Error(err)
+	suite.Assert().True(state.IsInvalidExtensionError(err))
 }
 
 func (suite *MutatorSuite) TestExtend_OnParentOfFinalized() {
@@ -283,6 +287,7 @@ func (suite *MutatorSuite) TestExtend_OnParentOfFinalized() {
 	// try to extend with the invalid block
 	err = suite.state.Extend(&block2)
 	suite.Assert().Error(err)
+	suite.Assert().True(state.IsOutdatedExtensionError(err))
 }
 
 func (suite *MutatorSuite) TestExtend_Success() {
@@ -312,7 +317,7 @@ func (suite *MutatorSuite) TestExtend_WithEmptyCollection() {
 	suite.Assert().Nil(err)
 }
 
-// an unknown reference block is invalid
+// an unknown reference block is unverifiable
 func (suite *MutatorSuite) TestExtend_WithNonExistentReferenceBlock() {
 	block := suite.Block()
 	tx := suite.Tx()
@@ -322,9 +327,10 @@ func (suite *MutatorSuite) TestExtend_WithNonExistentReferenceBlock() {
 	block.SetPayload(payload)
 	err := suite.state.Extend(&block)
 	suite.Assert().Error(err)
+	suite.Assert().True(state.IsUnverifiableExtensionError(err))
 }
 
-// a collection with an expired reference block is a VALID extensino of chain state
+// a collection with an expired reference block is a VALID extension of chain state
 func (suite *MutatorSuite) TestExtend_WithExpiredReferenceBlock() {
 	// build enough blocks so that using genesis as a reference block causes
 	// the collection to be expired
@@ -378,6 +384,7 @@ func (suite *MutatorSuite) TestExtend_UnfinalizedBlockWithDupeTx() {
 	// should be unable to extend block 2, as it contains a dupe transaction
 	err = suite.state.Extend(&block2)
 	suite.Assert().Error(err)
+	suite.Assert().True(state.IsInvalidExtensionError(err))
 }
 
 func (suite *MutatorSuite) TestExtend_FinalizedBlockWithDupeTx() {
@@ -404,6 +411,7 @@ func (suite *MutatorSuite) TestExtend_FinalizedBlockWithDupeTx() {
 	// should be unable to extend block 2, as it contains a dupe transaction
 	err = suite.state.Extend(&block2)
 	suite.Assert().Error(err)
+	suite.Assert().True(state.IsInvalidExtensionError(err))
 }
 
 func (suite *MutatorSuite) TestExtend_ConflictingForkWithDupeTx() {
@@ -510,5 +518,6 @@ func (suite *MutatorSuite) TestExtend_LargeHistory() {
 		block.SetPayload(payload)
 		err = suite.state.Extend(&block)
 		assert.Error(t, err)
+		suite.Assert().True(state.IsInvalidExtensionError(err))
 	})
 }

--- a/state/errors.go
+++ b/state/errors.go
@@ -18,7 +18,7 @@ var (
 // extension is distinct from outdated or unverifiable extensions, in that it indicates
 // a malicious input.
 type InvalidExtensionError struct {
-	err error
+	error
 }
 
 func NewInvalidExtensionError(msg string) error {
@@ -27,16 +27,12 @@ func NewInvalidExtensionError(msg string) error {
 
 func NewInvalidExtensionErrorf(msg string, args ...interface{}) error {
 	return InvalidExtensionError{
-		err: fmt.Errorf(msg, args...),
+		error: fmt.Errorf(msg, args...),
 	}
 }
 
 func (e InvalidExtensionError) Unwrap() error {
-	return e.err
-}
-
-func (e InvalidExtensionError) Error() string {
-	return e.err.Error()
+	return e.error
 }
 
 // IsInvalidExtensionError returns whether the given error is an InvalidExtensionError error
@@ -49,7 +45,7 @@ func IsInvalidExtensionError(err error) bool {
 // Knowing whether an outdated extension is an invalid extension or not would
 // take more state queries.
 type OutdatedExtensionError struct {
-	err error
+	error
 }
 
 func NewOutdatedExtensionError(msg string) error {
@@ -58,16 +54,12 @@ func NewOutdatedExtensionError(msg string) error {
 
 func NewOutdatedExtensionErrorf(msg string, args ...interface{}) error {
 	return OutdatedExtensionError{
-		err: fmt.Errorf(msg, args...),
+		error: fmt.Errorf(msg, args...),
 	}
 }
 
 func (e OutdatedExtensionError) Unwrap() error {
-	return e.err
-}
-
-func (e OutdatedExtensionError) Error() string {
-	return e.err.Error()
+	return e.error
 }
 
 func IsOutdatedExtensionError(err error) bool {
@@ -80,21 +72,17 @@ func IsOutdatedExtensionError(err error) bool {
 // Unlike InvalidExtensionError, this error is only used when the failure CANNOT be
 // attributed to a malicious input, therefore this error can be treated as a benign failure.
 type UnverifiableExtensionError struct {
-	err error
+	error
 }
 
 func NewUnverifiableExtensionError(msg string, args ...interface{}) error {
 	return UnverifiableExtensionError{
-		err: fmt.Errorf(msg, args...),
+		error: fmt.Errorf(msg, args...),
 	}
 }
 
 func (e UnverifiableExtensionError) Unwrap() error {
-	return e.err
-}
-
-func (e UnverifiableExtensionError) Error() string {
-	return e.err.Error()
+	return e.error
 }
 
 func IsUnverifiableExtensionError(err error) bool {
@@ -105,12 +93,12 @@ func IsUnverifiableExtensionError(err error) bool {
 // NoValidChildBlockError is a sentinel error when the case where a certain block has
 // no valid child.
 type NoValidChildBlockError struct {
-	err error
+	error
 }
 
 func NewNoValidChildBlockError(msg string) error {
 	return NoValidChildBlockError{
-		err: fmt.Errorf(msg),
+		error: fmt.Errorf(msg),
 	}
 }
 
@@ -119,11 +107,7 @@ func NewNoValidChildBlockErrorf(msg string, args ...interface{}) error {
 }
 
 func (e NoValidChildBlockError) Unwrap() error {
-	return e.err
-}
-
-func (e NoValidChildBlockError) Error() string {
-	return e.err.Error()
+	return e.error
 }
 
 func IsNoValidChildBlockError(err error) bool {
@@ -134,26 +118,25 @@ func IsNoValidChildBlockError(err error) bool {
 // has not been ingested yet.
 type UnknownBlockError struct {
 	blockID flow.Identifier
-	err     error
+	error
 }
 
 // WrapAsUnknownBlockError wraps a given error as UnknownBlockError
 func WrapAsUnknownBlockError(blockID flow.Identifier, err error) error {
 	return UnknownBlockError{
 		blockID: blockID,
-		err:     fmt.Errorf("block %v has not been processed yet: %w", blockID, err),
+		error:   fmt.Errorf("block %v has not been processed yet: %w", blockID, err),
 	}
 }
 
 func NewUnknownBlockError(blockID flow.Identifier) error {
 	return UnknownBlockError{
 		blockID: blockID,
-		err:     fmt.Errorf("block %v has not been processed yet", blockID),
+		error:   fmt.Errorf("block %v has not been processed yet", blockID),
 	}
 }
 
-func (e UnknownBlockError) Unwrap() error { return e.err }
-func (e UnknownBlockError) Error() string { return e.err.Error() }
+func (e UnknownBlockError) Unwrap() error { return e.error }
 
 func IsUnknownBlockError(err error) bool {
 	var e UnknownBlockError

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -116,13 +116,13 @@ func (m *FollowerState) Extend(ctx context.Context, candidate *flow.Block) error
 	// check if the block header is a valid extension of the finalized state
 	err := m.headerExtend(candidate)
 	if err != nil {
-		return fmt.Errorf("header does not compliance the chain state: %w", err)
+		return fmt.Errorf("header not compliant with chain state: %w", err)
 	}
 
 	// find the last seal at the parent block
 	last, err := m.lastSealed(candidate)
 	if err != nil {
-		return fmt.Errorf("seal in parent block does not compliance the chain state: %w", err)
+		return fmt.Errorf("payload seal(s) not compliant with chain state: %w", err)
 	}
 
 	// insert the block and index the last seal for the block
@@ -144,26 +144,26 @@ func (m *MutableState) Extend(ctx context.Context, candidate *flow.Block) error 
 	// check if the block header is a valid extension of the finalized state
 	err := m.headerExtend(candidate)
 	if err != nil {
-		return fmt.Errorf("header does not compliance the chain state: %w", err)
+		return fmt.Errorf("header not compliant with chain state: %w", err)
 	}
 
 	// check if the guarantees in the payload is a valid extension of the finalized state
 	err = m.guaranteeExtend(ctx, candidate)
 	if err != nil {
-		return fmt.Errorf("guarantee does not compliance the chain state: %w", err)
+		return fmt.Errorf("payload guarantee(s) not compliant with chain state: %w", err)
 	}
 
 	// check if the receipts in the payload are valid
 	err = m.receiptExtend(ctx, candidate)
 	if err != nil {
-		return fmt.Errorf("payload receipts not compliant with chain state: %w", err)
+		return fmt.Errorf("payload receipt(s) not compliant with chain state: %w", err)
 	}
 
 	// check if the seals in the payload is a valid extension of the finalized
 	// state
 	lastSeal, err := m.sealExtend(ctx, candidate)
 	if err != nil {
-		return fmt.Errorf("seal in parent block does not compliance the chain state: %w", err)
+		return fmt.Errorf("payload seal(s) not compliant with chain state: %w", err)
 	}
 
 	// insert the block and index the last seal for the block
@@ -240,8 +240,8 @@ func (m *FollowerState) headerExtend(candidate *flow.Block) error {
 			// for instance:
 			// A (Finalized) <- B (Finalized) <- C (Finalized) <- D <- E <- F
 			//                  ^- G             ^- H             ^- I
-			// block G is not a valid block, because it does not include C which has been finalized.
-			// block H and I are a valid, because its their includes C.
+			// block G is not a valid block, because it does not have C (which has been finalized) as an ancestor
+			// block H and I are valid, because they do have C as an ancestor
 			return state.NewOutdatedExtensionErrorf(
 				"candidate block (height: %d) conflicts with finalized state (ancestor: %d final: %d)",
 				header.Height, ancestor.Height, finalizedHeight)

--- a/state/protocol/errors.go
+++ b/state/protocol/errors.go
@@ -44,15 +44,15 @@ func IsIdentityNotFound(err error) bool {
 }
 
 type InvalidBlockTimestampError struct {
-	err error
+	error
 }
 
 func (e InvalidBlockTimestampError) Unwrap() error {
-	return e.err
+	return e.error
 }
 
 func (e InvalidBlockTimestampError) Error() string {
-	return e.err.Error()
+	return e.error.Error()
 }
 
 func IsInvalidBlockTimestampError(err error) bool {
@@ -62,21 +62,17 @@ func IsInvalidBlockTimestampError(err error) bool {
 
 func NewInvalidBlockTimestamp(msg string, args ...interface{}) error {
 	return InvalidBlockTimestampError{
-		err: fmt.Errorf(msg, args...),
+		error: fmt.Errorf(msg, args...),
 	}
 }
 
 // InvalidServiceEventError indicates an invalid service event was processed.
 type InvalidServiceEventError struct {
-	err error
+	error
 }
 
 func (e InvalidServiceEventError) Unwrap() error {
-	return e.err
-}
-
-func (e InvalidServiceEventError) Error() string {
-	return e.err.Error()
+	return e.error
 }
 
 func IsInvalidServiceEventError(err error) bool {
@@ -91,7 +87,7 @@ func NewInvalidServiceEventError(msg string, args ...interface{}) error {
 	return state.NewInvalidExtensionErrorf(
 		"cannot extend state with invalid service event: %w",
 		InvalidServiceEventError{
-			err: fmt.Errorf(msg, args...),
+			error: fmt.Errorf(msg, args...),
 		},
 	)
 }


### PR DESCRIPTION
* Adds `UnverifiableExtensionError` to differentiate extensions which aren't certainly invalid, and cannot be processed (for cluster consensus `ReferenceBlockID`
* Updates some error message and documentation wording