### PR TITLE
Fix storage interaction limit setup

### DIFF
--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -3,7 +3,6 @@ package reporters
 import (
 	"context"
 	"fmt"
-	"math"
 	goRuntime "runtime"
 	"sync"
 
@@ -66,10 +65,7 @@ func (r *AccountReporter) Report(payload []ledger.Payload, commit ledger.State) 
 	defer rwm.Close()
 
 	l := migrations.NewView(payload)
-	txnState := state.NewTransactionState(
-		l,
-		state.DefaultParameters().WithMaxInteractionSizeAllowed(math.MaxUint64),
-	)
+	txnState := state.NewTransactionState(l, state.DefaultParameters())
 	gen := environment.NewAddressGenerator(txnState, r.Chain)
 
 	progress := progressbar.Default(int64(gen.AddressCount()), "Processing:")
@@ -144,10 +140,7 @@ func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 		fvm.WithDerivedBlockData(derivedBlockData))
 
 	v := view.NewChild()
-	txnState := state.NewTransactionState(
-		v,
-		state.DefaultParameters().WithMaxInteractionSizeAllowed(math.MaxUint64),
-	)
+	txnState := state.NewTransactionState(v, state.DefaultParameters())
 	accounts := environment.NewAccounts(txnState)
 
 	derivedTxnData, err := derivedBlockData.NewSnapshotReadDerivedTransactionData(0, 0)

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -13,6 +13,14 @@ import (
 	"github.com/onflow/flow-go/module"
 )
 
+const (
+	AccountKeyWeightThreshold = 1000
+
+	DefaultComputationLimit   = 100_000 // 100K
+	DefaultMemoryLimit        = math.MaxUint64
+	DefaultMaxInteractionSize = 20_000_000 // ~20MB
+)
+
 // A Context defines a set of execution parameters used by the virtual machine.
 type Context struct {
 	// DisableMemoryAndInteractionLimits will override memory and interaction
@@ -49,13 +57,6 @@ func newContext(ctx Context, opts ...Option) Context {
 	return ctx
 }
 
-const AccountKeyWeightThreshold = 1000
-
-const (
-	DefaultComputationLimit = 100_000        // 100K
-	DefaultMemoryLimit      = math.MaxUint64 //
-)
-
 func defaultContext() Context {
 	return Context{
 		DisableMemoryAndInteractionLimits: false,
@@ -63,7 +64,7 @@ func defaultContext() Context {
 		MemoryLimit:                       DefaultMemoryLimit,
 		MaxStateKeySize:                   state.DefaultMaxKeySize,
 		MaxStateValueSize:                 state.DefaultMaxValueSize,
-		MaxStateInteractionSize:           state.DefaultMaxInteractionSize,
+		MaxStateInteractionSize:           DefaultMaxInteractionSize,
 		TransactionExecutorParams:         DefaultTransactionExecutorParams(),
 		EnvironmentParams:                 environment.DefaultEnvironmentParams(),
 	}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1967,7 +1967,7 @@ func TestInteractionLimit(t *testing.T) {
 		},
 		{
 			name:             "default limit succeeds",
-			interactionLimit: state.DefaultMaxInteractionSize,
+			interactionLimit: fvm.DefaultMaxInteractionSize,
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.NoError(t, tx.Err)
 				require.Len(t, tx.Events, 5)

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -16,9 +16,8 @@ import (
 )
 
 const (
-	DefaultMaxKeySize         = 16_000      // ~16KB
-	DefaultMaxValueSize       = 256_000_000 // ~256MB
-	DefaultMaxInteractionSize = 20_000_000  // ~20MB
+	DefaultMaxKeySize   = 16_000      // ~16KB
+	DefaultMaxValueSize = 256_000_000 // ~256MB
 
 	// Service level keys (owner is empty):
 	UUIDKey         = "uuid"
@@ -91,6 +90,9 @@ func (params StateParameters) WithMaxValueSizeAllowed(limit uint64) StateParamet
 	return newParams
 }
 
+// TODO(patrick): rm once https://github.com/onflow/flow-emulator/pull/245
+// is integrated.
+//
 // WithMaxInteractionSizeAllowed sets limit on total byte interaction with ledger
 func (params StateParameters) WithMaxInteractionSizeAllowed(limit uint64) StateParameters {
 	newParams := params

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onflow/atree"
 
+	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 )
@@ -131,7 +132,11 @@ func TestState_MaxKeySize(t *testing.T) {
 
 func TestState_MaxInteraction(t *testing.T) {
 	view := utils.NewSimpleView()
-	st := state.NewState(view, state.DefaultParameters().WithMaxInteractionSizeAllowed(12))
+	st := state.NewState(
+		view,
+		state.DefaultParameters().
+			WithMeterParameters(
+				meter.DefaultParameters().WithStorageInteractionLimit(12)))
 
 	// read - interaction 2
 	_, err := st.Get("1", "2", true)
@@ -148,7 +153,11 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Equal(t, st.InteractionUsed(), uint64(14))
 	require.Error(t, err)
 
-	st = state.NewState(view, state.DefaultParameters().WithMaxInteractionSizeAllowed(6))
+	st = state.NewState(
+		view,
+		state.DefaultParameters().
+			WithMeterParameters(
+				meter.DefaultParameters().WithStorageInteractionLimit(6)))
 	stChild := st.NewChild()
 
 	// update - 0

--- a/fvm/transactionInvoker_test.go
+++ b/fvm/transactionInvoker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/programs"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
@@ -42,8 +43,9 @@ func TestSafetyCheck(t *testing.T) {
 			state.DefaultParameters().
 				WithMaxKeySizeAllowed(context.MaxStateKeySize).
 				WithMaxValueSizeAllowed(context.MaxStateValueSize).
-				WithMaxInteractionSizeAllowed(context.MaxStateInteractionSize),
-		)
+				WithMeterParameters(
+					meter.DefaultParameters().WithStorageInteractionLimit(
+						context.MaxStateInteractionSize)))
 
 		derivedBlockData := programs.NewEmptyDerivedBlockData()
 		derivedTxnData, err := derivedBlockData.NewDerivedTransactionData(0, 0)
@@ -79,8 +81,9 @@ func TestSafetyCheck(t *testing.T) {
 			state.DefaultParameters().
 				WithMaxKeySizeAllowed(context.MaxStateKeySize).
 				WithMaxValueSizeAllowed(context.MaxStateValueSize).
-				WithMaxInteractionSizeAllowed(context.MaxStateInteractionSize),
-		)
+				WithMeterParameters(
+					meter.DefaultParameters().WithStorageInteractionLimit(
+						context.MaxStateInteractionSize)))
 
 		derivedBlockData := programs.NewEmptyDerivedBlockData()
 		derivedTxnData, err := derivedBlockData.NewDerivedTransactionData(0, 0)


### PR DESCRIPTION
Storage interaction limit is part of meter parameters and should be set along the other meter parameters.

gh: #3102