### PR TITLE
Meter param overrides cache skeleton.

### DIFF
--- a/fvm/programs/block_derived_data_test.go
+++ b/fvm/programs/block_derived_data_test.go
@@ -824,49 +824,47 @@ func TestBlockDerivedDataNewChildDerivedBlockData(t *testing.T) {
 	require.NotSame(t, parentEntry, childEntry)
 }
 
+type testValueComputer struct {
+	value  int
+	called bool
+}
+
+func (computer *testValueComputer) Compute(
+	txnState *state.TransactionState,
+	key string,
+) (
+	int,
+	error,
+) {
+	computer.called = true
+	_, err := txnState.Get("addr", key, true)
+	if err != nil {
+		return 0, err
+	}
+
+	return computer.value, nil
+}
+
 func TestTxnDerivedDataGetOrCompute(t *testing.T) {
 	blockDerivedData := NewEmptyBlockDerivedData[string, int]()
 
-	derivedKey := "derivedKey"
-	derivedValue := 12345
-	addr := "addr"
 	key := "key"
+	value := 12345
 
 	t.Run("compute value", func(t *testing.T) {
 		view := utils.NewSimpleView()
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 
-		calledValFunc := false
-		valFunc := func(
-			txnState *state.TransactionState,
-			_ string,
-		) (
-			int,
-			error,
-		) {
-			calledValFunc = true
-			_, err := txnState.Get(addr, key, true)
-			if err != nil {
-				return 0, err
-			}
-
-			return derivedValue, nil
-		}
-
 		txnDerivedData, err := blockDerivedData.NewTransactionDerivedData(0, 0)
 		assert.Nil(t, err)
 
-		val, err := txnDerivedData.GetOrCompute(
-			txnState,
-			derivedKey,
-			valFunc)
+		computer := &testValueComputer{value: value}
+		val, err := txnDerivedData.GetOrCompute(txnState, key, computer)
 		assert.Nil(t, err)
-		assert.Equal(t, derivedValue, val)
-		assert.True(t, calledValFunc)
+		assert.Equal(t, value, val)
+		assert.True(t, computer.called)
 
-		assert.True(
-			t,
-			view.Ledger.RegisterTouches[utils.FullKey(addr, key)])
+		assert.True(t, view.Ledger.RegisterTouches[utils.FullKey("addr", key)])
 
 		// Commit to setup the next test.
 		err = txnDerivedData.Commit()
@@ -877,36 +875,15 @@ func TestTxnDerivedDataGetOrCompute(t *testing.T) {
 		view := utils.NewSimpleView()
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 
-		calledValFunc := false
-		valFunc := func(
-			txnState *state.TransactionState,
-			_ string,
-		) (
-			int,
-			error,
-		) {
-			calledValFunc = true
-			_, err := txnState.Get(addr, key, true)
-			if err != nil {
-				return 0, err
-			}
-
-			return derivedValue, nil
-		}
-
 		txnDerivedData, err := blockDerivedData.NewTransactionDerivedData(1, 1)
 		assert.Nil(t, err)
 
-		val, err := txnDerivedData.GetOrCompute(
-			txnState,
-			derivedKey,
-			valFunc)
+		computer := &testValueComputer{value: value}
+		val, err := txnDerivedData.GetOrCompute(txnState, key, computer)
 		assert.Nil(t, err)
-		assert.Equal(t, derivedValue, val)
-		assert.False(t, calledValFunc)
+		assert.Equal(t, value, val)
+		assert.False(t, computer.called)
 
-		assert.True(
-			t,
-			view.Ledger.RegisterTouches[utils.FullKey(addr, key)])
+		assert.True(t, view.Ledger.RegisterTouches[utils.FullKey("addr", key)])
 	})
 }

--- a/fvm/programs/invalidator.go
+++ b/fvm/programs/invalidator.go
@@ -4,6 +4,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 
+	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -18,13 +19,25 @@ type ContractUpdate struct {
 	Code []byte
 }
 
+type MeterParamOverrides struct {
+	ComputationWeights meter.ExecutionEffortWeights // nil indicates no override
+	MemoryWeights      meter.ExecutionMemoryWeights // nil indicates no override
+	MemoryLimit        *uint64                      // nil indicates no override
+}
+
 type ProgramInvalidator DerivedDataInvalidator[
 	common.AddressLocation,
 	*interpreter.Program,
 ]
 
+type MeterParamOverridesInvalidator DerivedDataInvalidator[
+	struct{},
+	MeterParamOverrides,
+]
+
 type TransactionInvalidator interface {
 	ProgramInvalidator() ProgramInvalidator
+	MeterParamOverridesInvalidator() MeterParamOverridesInvalidator
 }
 
 type ModifiedSetsInvalidator struct {
@@ -36,6 +49,10 @@ func (sets ModifiedSetsInvalidator) ProgramInvalidator() ProgramInvalidator {
 	return ModifiedSetsProgramInvalidator{sets}
 }
 
+func (sets ModifiedSetsInvalidator) MeterParamOverridesInvalidator() MeterParamOverridesInvalidator {
+	return ModifiedSetsMeterParamOverridesInvalidator{sets}
+}
+
 type ModifiedSetsProgramInvalidator struct {
 	ModifiedSetsInvalidator
 }
@@ -43,6 +60,7 @@ type ModifiedSetsProgramInvalidator struct {
 var _ ProgramInvalidator = ModifiedSetsProgramInvalidator{}
 
 func (sets ModifiedSetsProgramInvalidator) ShouldInvalidateEntries() bool {
+	// TODO(patrick): invalidate on meter param updates
 	return len(sets.ContractUpdateKeys) > 0 || len(sets.FrozenAccounts) > 0
 }
 
@@ -52,5 +70,23 @@ func (sets ModifiedSetsProgramInvalidator) ShouldInvalidateEntry(
 	state *state.State,
 ) bool {
 	// TODO(rbtz): switch to fine grain invalidation.
+	return sets.ShouldInvalidateEntries()
+}
+
+type ModifiedSetsMeterParamOverridesInvalidator struct {
+	ModifiedSetsInvalidator
+}
+
+func (sets ModifiedSetsMeterParamOverridesInvalidator) ShouldInvalidateEntries() bool {
+	// TODO(patrick): invalidate on meter param updates instead of contract
+	// updates
+	return len(sets.ContractUpdateKeys) > 0 || len(sets.FrozenAccounts) > 0
+}
+
+func (sets ModifiedSetsMeterParamOverridesInvalidator) ShouldInvalidateEntry(
+	_ struct{},
+	_ MeterParamOverrides,
+	_ *state.State,
+) bool {
 	return sets.ShouldInvalidateEntries()
 }


### PR DESCRIPTION
This adds a second (meter param overrides) table to the derived block data database.  The database is committed via Validate/Commit 2PC (For now, Validate is not called during actual execution since there are no conflicts in sequential execution)

Note that this PR triggers meter params invalidation when contracts are updated. This is incorrect, but it's no worst than before since updating meter params would also break programs invalidation.  I'll add correct meter param invalidation in a followup PR.

gh: #3102