### PR TITLE
[Metrics] Report finalized height and executed height on startup

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -76,6 +76,7 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 	badgerState "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/blocktimer"
+	storageerr "github.com/onflow/flow-go/storage"
 	storage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/storage/badger/procedure"
 )
@@ -243,6 +244,10 @@ func (exeNode *ExecutionNode) LoadExecutionMetrics(node *NodeConfig) error {
 	var blockID flow.Identifier
 	err := node.DB.View(procedure.GetHighestExecutedBlock(&height, &blockID))
 	if err != nil {
+		// database has not been bootstrapped yet
+		if errors.Is(err, storageerr.ErrNotFound) {
+			return nil
+		}
 		return fmt.Errorf("could not get highest executed block: %w", err)
 	}
 

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -77,6 +77,7 @@ import (
 	badgerState "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/blocktimer"
 	storage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/storage/badger/procedure"
 )
 
 const (
@@ -234,6 +235,18 @@ func (exeNode *ExecutionNode) LoadSystemSpecs(node *NodeConfig) error {
 
 func (exeNode *ExecutionNode) LoadExecutionMetrics(node *NodeConfig) error {
 	exeNode.collector = metrics.NewExecutionCollector(node.Tracer)
+
+	// report the highest executed block height as soon as possible
+	// this is guaranteed to exist because LoadBootstrapper has inserted
+	// the root block as executed block
+	var height uint64
+	var blockID flow.Identifier
+	err := node.DB.View(procedure.GetHighestExecutedBlock(&height, &blockID))
+	if err != nil {
+		return fmt.Errorf("could not get highest executed block: %w", err)
+	}
+
+	exeNode.collector.ExecutionLastExecutedBlockHeight(height)
 	return nil
 }
 

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/onflow/flow-go/storage"
 	badgerstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/storage/badger/operation"
+	"github.com/onflow/flow-go/storage/badger/procedure"
 )
 
 // ReadOnlyExecutionState allows to read the execution state
@@ -508,50 +509,18 @@ func (s *state) UpdateHighestExecutedBlockIfHigher(ctx context.Context, header *
 		defer span.End()
 	}
 
-	return operation.RetryOnConflict(s.db.Update, func(txn *badger.Txn) error {
-		var blockID flow.Identifier
-		err := operation.RetrieveExecutedBlock(&blockID)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot lookup executed block: %w", err)
-		}
-
-		var highest flow.Header
-		err = operation.RetrieveHeader(blockID, &highest)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot retrieve executed header: %w", err)
-		}
-
-		if header.Height <= highest.Height {
-			return nil
-		}
-		err = operation.UpdateExecutedBlock(header.ID())(txn)
-		if err != nil {
-			return fmt.Errorf("cannot update highest executed block: %w", err)
-		}
-
-		return nil
-	})
+	return operation.RetryOnConflict(s.db.Update, procedure.UpdateHighestExecutedBlockIfHigher(header))
 }
 
 func (s *state) GetHighestExecutedBlockID(ctx context.Context) (uint64, flow.Identifier, error) {
 	var blockID flow.Identifier
-	var highest flow.Header
-	err := s.db.View(func(tx *badger.Txn) error {
-		err := operation.RetrieveExecutedBlock(&blockID)(tx)
-		if err != nil {
-			return fmt.Errorf("could not lookup executed block %v: %w", blockID, err)
-		}
-		err = operation.RetrieveHeader(blockID, &highest)(tx)
-		if err != nil {
-			return fmt.Errorf("could not retrieve executed header %v: %w", blockID, err)
-		}
-		return nil
-	})
+	var height uint64
+	err := s.db.View(procedure.GetHighestExecutedBlock(&height, &blockID))
 	if err != nil {
 		return 0, flow.ZeroID, err
 	}
 
-	return highest.Height, blockID, nil
+	return height, blockID, nil
 }
 
 // IsBlockExecuted returns whether the block has been executed.

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -458,7 +458,19 @@ func OpenState(
 	}
 	state := newState(metrics, db, headers, seals, results, blocks, setups, commits, statuses)
 
+	// report last finalized and sealed block height
 	finalSnapshot := state.Final()
+	head, err := finalSnapshot.Head()
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error to get finalized block: %w", err)
+	}
+	metrics.FinalizedHeight(head.Height)
+
+	sealed, err := state.Sealed().Head()
+	if err != nil {
+		return nil, fmt.Errorf("could not get latest sealed block: %w", err)
+	}
+	metrics.SealedHeight(sealed.Height)
 
 	// update all epoch related metrics
 	err = state.updateEpochMetrics(finalSnapshot)

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
+
 	"github.com/stretchr/testify/assert"
+	testmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
-	mock "github.com/onflow/flow-go/module/mock"
+	"github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/state/protocol"
 	bprotocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/inmem"
@@ -50,6 +52,8 @@ func TestBootstrapAndOpen(t *testing.T) {
 		complianceMetrics.On("CurrentEpochCounter", counter).Once()
 		complianceMetrics.On("CurrentEpochPhase", phase).Once()
 		complianceMetrics.On("CurrentEpochFinalView", finalView).Once()
+		complianceMetrics.On("FinalizedHeight", testmock.Anything).Once()
+		complianceMetrics.On("SealedHeight", testmock.Anything).Once()
 
 		dkgPhase1FinalView, dkgPhase2FinalView, dkgPhase3FinalView, err := protocol.DKGPhaseViews(epoch)
 		require.NoError(t, err)
@@ -124,6 +128,8 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 		complianceMetrics.On("CurrentDKGPhase1FinalView", dkgPhase1FinalView).Once()
 		complianceMetrics.On("CurrentDKGPhase2FinalView", dkgPhase2FinalView).Once()
 		complianceMetrics.On("CurrentDKGPhase3FinalView", dkgPhase3FinalView).Once()
+		complianceMetrics.On("FinalizedHeight", testmock.Anything).Once()
+		complianceMetrics.On("SealedHeight", testmock.Anything).Once()
 
 		noopMetrics := new(metrics.NoopCollector)
 		all := storagebadger.InitAll(noopMetrics, db)

--- a/storage/badger/procedure/executed.go
+++ b/storage/badger/procedure/executed.go
@@ -1,14 +1,20 @@
 package procedure
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
 )
 
+// UpdateHighestExecutedBlockIfHigher updates the latest executed block to be the input block
+// if the input block has a greater height than the currently stored latest executed block.
+// The executed block index must have been initialized before calling this function.
+// Returns storage.ErrNotFound if the input block does not exist in storage.
 func UpdateHighestExecutedBlockIfHigher(header *flow.Header) func(txn *badger.Txn) error {
 	return func(txn *badger.Txn) error {
 		var blockID flow.Identifier
@@ -35,6 +41,8 @@ func UpdateHighestExecutedBlockIfHigher(header *flow.Header) func(txn *badger.Tx
 	}
 }
 
+// GetHighestExecutedBlock retrieves the height and ID of the latest block executed by this node.
+// Returns storage.ErrNotFound if no latest executed block has been stored.
 func GetHighestExecutedBlock(height *uint64, blockID *flow.Identifier) func(tx *badger.Txn) error {
 	return func(tx *badger.Txn) error {
 		var highest flow.Header
@@ -44,6 +52,9 @@ func GetHighestExecutedBlock(height *uint64, blockID *flow.Identifier) func(tx *
 		}
 		err = operation.RetrieveHeader(*blockID, &highest)(tx)
 		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return fmt.Errorf("unexpected: latest executed block does not exist in storage: %s", err.Error())
+			}
 			return fmt.Errorf("could not retrieve executed header %v: %w", blockID, err)
 		}
 		*height = highest.Height

--- a/storage/badger/procedure/executed.go
+++ b/storage/badger/procedure/executed.go
@@ -1,0 +1,52 @@
+package procedure
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/badger/v2"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage/badger/operation"
+)
+
+func UpdateHighestExecutedBlockIfHigher(header *flow.Header) func(txn *badger.Txn) error {
+	return func(txn *badger.Txn) error {
+		var blockID flow.Identifier
+		err := operation.RetrieveExecutedBlock(&blockID)(txn)
+		if err != nil {
+			return fmt.Errorf("cannot lookup executed block: %w", err)
+		}
+
+		var highest flow.Header
+		err = operation.RetrieveHeader(blockID, &highest)(txn)
+		if err != nil {
+			return fmt.Errorf("cannot retrieve executed header: %w", err)
+		}
+
+		if header.Height <= highest.Height {
+			return nil
+		}
+		err = operation.UpdateExecutedBlock(header.ID())(txn)
+		if err != nil {
+			return fmt.Errorf("cannot update highest executed block: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func GetHighestExecutedBlock(height *uint64, blockID *flow.Identifier) func(tx *badger.Txn) error {
+	return func(tx *badger.Txn) error {
+		var highest flow.Header
+		err := operation.RetrieveExecutedBlock(blockID)(tx)
+		if err != nil {
+			return fmt.Errorf("could not lookup executed block %v: %w", blockID, err)
+		}
+		err = operation.RetrieveHeader(*blockID, &highest)(tx)
+		if err != nil {
+			return fmt.Errorf("could not retrieve executed header %v: %w", blockID, err)
+		}
+		*height = highest.Height
+		return nil
+	}
+}

--- a/storage/badger/procedure/executed_test.go
+++ b/storage/badger/procedure/executed_test.go
@@ -1,0 +1,91 @@
+package procedure
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage/badger/operation"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestInsertExecuted(t *testing.T) {
+	chain, _, _ := unittest.ChainFixture(6)
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		t.Run("setup and bootstrap", func(t *testing.T) {
+			for _, block := range chain {
+				require.NoError(t, db.Update(operation.InsertHeader(block.Header.ID(), block.Header)))
+			}
+
+			root := chain[0].Header
+			require.NoError(t,
+				db.Update(operation.InsertExecutedBlock(root.ID())),
+			)
+
+			var height uint64
+			var blockID flow.Identifier
+			require.NoError(t,
+				db.View(GetHighestExecutedBlock(&height, &blockID)),
+			)
+
+			require.Equal(t, root.ID(), blockID)
+			require.Equal(t, root.Height, height)
+		})
+
+		t.Run("insert and get", func(t *testing.T) {
+			header1 := chain[1].Header
+			require.NoError(t,
+				db.Update(UpdateHighestExecutedBlockIfHigher(header1)),
+			)
+
+			var height uint64
+			var blockID flow.Identifier
+			require.NoError(t,
+				db.View(GetHighestExecutedBlock(&height, &blockID)),
+			)
+
+			require.Equal(t, header1.ID(), blockID)
+			require.Equal(t, header1.Height, height)
+		})
+
+		t.Run("insert more and get highest", func(t *testing.T) {
+			header2 := chain[2].Header
+			header3 := chain[3].Header
+			require.NoError(t,
+				db.Update(UpdateHighestExecutedBlockIfHigher(header2)),
+			)
+			require.NoError(t,
+				db.Update(UpdateHighestExecutedBlockIfHigher(header3)),
+			)
+			var height uint64
+			var blockID flow.Identifier
+			require.NoError(t,
+				db.View(GetHighestExecutedBlock(&height, &blockID)),
+			)
+
+			require.Equal(t, header3.ID(), blockID)
+			require.Equal(t, header3.Height, height)
+		})
+
+		t.Run("insert lower height later and get highest", func(t *testing.T) {
+			header5 := chain[5].Header
+			header4 := chain[4].Header
+			require.NoError(t,
+				db.Update(UpdateHighestExecutedBlockIfHigher(header5)),
+			)
+			require.NoError(t,
+				db.Update(UpdateHighestExecutedBlockIfHigher(header4)),
+			)
+			var height uint64
+			var blockID flow.Identifier
+			require.NoError(t,
+				db.View(GetHighestExecutedBlock(&height, &blockID)),
+			)
+
+			require.Equal(t, header5.ID(), blockID)
+			require.Equal(t, header5.Height, height)
+		})
+	})
+}


### PR DESCRIPTION
This PR fixes an issue that the finalized height and executed height metrics is not reported on startup until there is block being finalized and executed.

For EN which takes a while to load the execution state, the finalized height and executed height is not shown on metrics.

This PR fixes it by reporting finalized height and executed height on startup.