### PR TITLE
[Benchmark] Remove facades from the benchmark library

### DIFF
--- a/integration/benchmark/contLoadGenerator.go
+++ b/integration/benchmark/contLoadGenerator.go
@@ -359,18 +359,6 @@ func (lg *ContLoadGenerator) Done() <-chan struct{} {
 	return lg.stoppedChannel
 }
 
-func (lg *ContLoadGenerator) GetTxSent() int {
-	return lg.workerStatsTracker.GetTxSent()
-}
-
-func (lg *ContLoadGenerator) GetTxExecuted() int {
-	return lg.workerStatsTracker.GetTxExecuted()
-}
-
-func (lg *ContLoadGenerator) GetTxTimedout() int {
-	return lg.workerStatsTracker.GetTxTimedout()
-}
-
 func (lg *ContLoadGenerator) createAccounts(num int) error {
 	privKey := randomPrivateKey()
 	accountKey := flowsdk.NewAccountKey().

--- a/integration/benchmark/worker_stats_tracker.go
+++ b/integration/benchmark/worker_stats_tracker.go
@@ -129,7 +129,6 @@ func (st *WorkerStatsTracker) GetTxSent() int {
 	return st.stats.txsSent
 }
 
-// TODO(rbtz): make this a method public so that we can remove all getters from the ContLoadGenerator.
 func (st *WorkerStatsTracker) getStats() workerStats {
 	st.mux.Lock()
 	defer st.mux.Unlock()

--- a/integration/benchmark/worker_stats_tracker.go
+++ b/integration/benchmark/worker_stats_tracker.go
@@ -9,13 +9,13 @@ import (
 	"github.com/rs/zerolog"
 )
 
-type workerStats struct {
-	workers                  int
-	txsSent                  int
-	txsTimedout              int
-	txsExecuted              int
-	txsSentMovingAverage     float64
-	txsExecutedMovingAverage float64
+type WorkerStats struct {
+	Workers                  int
+	TxsSent                  int
+	TxsTimedout              int
+	TxsExecuted              int
+	TxsSentMovingAverage     float64
+	TxsExecutedMovingAverage float64
 }
 
 // WorkerStatsTracker keeps track of worker stats
@@ -25,7 +25,7 @@ type WorkerStatsTracker struct {
 	wg     sync.WaitGroup
 
 	mux             sync.Mutex
-	stats           workerStats
+	stats           WorkerStats
 	txsSentEWMA     ewma.MovingAverage
 	txsExecutedEWMA ewma.MovingAverage
 }
@@ -53,11 +53,11 @@ func (st *WorkerStatsTracker) updateEWMAforever() {
 	t := time.NewTicker(time.Second)
 	defer t.Stop()
 
-	lastStats := st.getStats()
+	lastStats := st.GetStats()
 	for {
 		select {
 		case <-t.C:
-			stats := st.getStats()
+			stats := st.GetStats()
 			st.updateEWMAonce(lastStats, stats)
 			lastStats = stats
 		case <-st.ctx.Done():
@@ -67,12 +67,12 @@ func (st *WorkerStatsTracker) updateEWMAforever() {
 }
 
 // updateEWMAonce updates all Exponentially Weighted Moving Averages with the given stats.
-func (st *WorkerStatsTracker) updateEWMAonce(lastStats, stats workerStats) {
+func (st *WorkerStatsTracker) updateEWMAonce(lastStats, stats WorkerStats) {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	st.txsSentEWMA.Add(float64(stats.txsSent - lastStats.txsSent))
-	st.txsExecutedEWMA.Add(float64(stats.txsExecuted - lastStats.txsExecuted))
+	st.txsSentEWMA.Add(float64(stats.TxsSent - lastStats.TxsSent))
+	st.txsExecutedEWMA.Add(float64(stats.TxsExecuted - lastStats.TxsExecuted))
 }
 
 func (st *WorkerStatsTracker) Stop() {
@@ -84,70 +84,49 @@ func (st *WorkerStatsTracker) IncTxTimedout() {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	st.stats.txsTimedout++
-}
-
-func (st *WorkerStatsTracker) GetTxTimedout() int {
-	st.mux.Lock()
-	defer st.mux.Unlock()
-
-	return st.stats.txsTimedout
+	st.stats.TxsTimedout++
 }
 
 func (st *WorkerStatsTracker) IncTxExecuted() {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	st.stats.txsExecuted++
-}
-
-func (st *WorkerStatsTracker) GetTxExecuted() int {
-	st.mux.Lock()
-	defer st.mux.Unlock()
-
-	return st.stats.txsExecuted
+	st.stats.TxsExecuted++
 }
 
 func (st *WorkerStatsTracker) AddWorkers(i int) {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	st.stats.workers += i
+	st.stats.Workers += i
 }
 
 func (st *WorkerStatsTracker) IncTxSent() {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	st.stats.txsSent++
+	st.stats.TxsSent++
 }
 
-func (st *WorkerStatsTracker) GetTxSent() int {
+func (st *WorkerStatsTracker) GetStats() WorkerStats {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	return st.stats.txsSent
-}
-
-func (st *WorkerStatsTracker) getStats() workerStats {
-	st.mux.Lock()
-	defer st.mux.Unlock()
-
-	st.stats.txsSentMovingAverage = st.txsSentEWMA.Value()
-	st.stats.txsExecutedMovingAverage = st.txsExecutedEWMA.Value()
+	st.stats.TxsSentMovingAverage = st.txsSentEWMA.Value()
+	st.stats.TxsExecutedMovingAverage = st.txsExecutedEWMA.Value()
 	return st.stats
 }
 
 func NewPeriodicStatsLogger(st *WorkerStatsTracker, log zerolog.Logger) *Worker {
 	w := NewWorker(0, 1*time.Second, func(workerID int) {
-		stats := st.getStats()
+		stats := st.GetStats()
 		log.Info().
-			Int("workers", stats.workers).
-			Int("txsSent", stats.txsSent).
-			Int("txsTimedout", stats.txsTimedout).
-			Int("txsExecuted", stats.txsExecuted).
-			Float64("txsSentEWMA", stats.txsSentMovingAverage).
-			Float64("txsExecutedEWMA", stats.txsExecutedMovingAverage).
+			Int("Workers", stats.Workers).
+			Int("TxsSent", stats.TxsSent).
+			Int("TxsTimedout", stats.TxsTimedout).
+			Int("TxsExecuted", stats.TxsExecuted).
+			Float64("TxsSentMovingAverage", stats.TxsSentMovingAverage).
+			Float64("TxsExecutedMovingAverage", stats.TxsExecutedMovingAverage).
 			Msg("worker stats")
 	})
 

--- a/integration/benchmark/worker_stats_tracker.go
+++ b/integration/benchmark/worker_stats_tracker.go
@@ -72,7 +72,9 @@ func (st *WorkerStatsTracker) updateEWMAonce(lastStats, stats WorkerStats) {
 	defer st.mux.Unlock()
 
 	st.txsSentEWMA.Add(float64(stats.TxsSent - lastStats.TxsSent))
+	st.stats.TxsSentMovingAverage = st.txsSentEWMA.Value()
 	st.txsExecutedEWMA.Add(float64(stats.TxsExecuted - lastStats.TxsExecuted))
+	st.stats.TxsExecutedMovingAverage = st.txsExecutedEWMA.Value()
 }
 
 func (st *WorkerStatsTracker) Stop() {
@@ -112,8 +114,6 @@ func (st *WorkerStatsTracker) GetStats() WorkerStats {
 	st.mux.Lock()
 	defer st.mux.Unlock()
 
-	st.stats.TxsSentMovingAverage = st.txsSentEWMA.Value()
-	st.stats.TxsExecutedMovingAverage = st.txsExecutedEWMA.Value()
 	return st.stats
 }
 

--- a/integration/benchmark/worker_stats_tracker_test.go
+++ b/integration/benchmark/worker_stats_tracker_test.go
@@ -13,18 +13,18 @@ func TestWorkerStatsTracker(t *testing.T) {
 	st := NewWorkerStatsTracker(context.Background())
 	st.AddWorkers(1)
 
-	stats := st.getStats()
-	assert.Equal(t, 0, stats.txsSent)
-	assert.Equal(t, 1, stats.workers)
+	stats := st.GetStats()
+	assert.Equal(t, 0, stats.TxsSent)
+	assert.Equal(t, 1, stats.Workers)
 
 	st.IncTxSent()
 	st.IncTxSent()
 	st.IncTxExecuted()
 
-	stats = st.getStats()
-	assert.Equal(t, 1, stats.txsExecuted)
-	assert.Equal(t, 2, stats.txsSent)
-	assert.Equal(t, 0., stats.txsSentMovingAverage)
+	stats = st.GetStats()
+	assert.Equal(t, 1, stats.TxsExecuted)
+	assert.Equal(t, 2, stats.TxsSent)
+	assert.Equal(t, 0., stats.TxsSentMovingAverage)
 
 	st.Stop()
 }


### PR DESCRIPTION
This diff mostly cleans up codebase by removing the useless facades from load generator and stats tracker.  As a side effect makes stat fetches atomic.