### PR TITLE
[Logging] Add log throttle for debug/trace level events

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -281,7 +281,7 @@ func DefaultBaseConfig() *BaseConfig {
 		secretsdir:       NotSet,
 		secretsDBEnabled: true,
 		level:            "info",
-		debugLogLimit:    1000,
+		debugLogLimit:    2000,
 
 		metricsPort:         8080,
 		tracerEnabled:       false,

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -151,6 +151,7 @@ type BaseConfig struct {
 	secretsDBEnabled            bool
 	InsecureSecretsDB           bool
 	level                       string
+	debugLogLimit               uint
 	metricsPort                 uint
 	BootstrapDir                string
 	profilerConfig              profiler.ProfilerConfig
@@ -280,6 +281,7 @@ func DefaultBaseConfig() *BaseConfig {
 		secretsdir:       NotSet,
 		secretsDBEnabled: true,
 		level:            "info",
+		debugLogLimit:    1000,
 
 		metricsPort:         8080,
 		tracerEnabled:       false,

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -151,7 +151,7 @@ type BaseConfig struct {
 	secretsDBEnabled            bool
 	InsecureSecretsDB           bool
 	level                       string
-	debugLogLimit               uint
+	debugLogLimit               uint32
 	metricsPort                 uint
 	BootstrapDir                string
 	profilerConfig              profiler.ProfilerConfig

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -583,10 +583,7 @@ func (fnb *FlowNodeBuilder) initLogger() error {
 	zerolog.TimestampFunc = func() time.Time { return time.Now().UTC() }
 
 	// Drop all log events that exceed this rate limit
-	throttledSampler := &zerolog.BurstSampler{
-		Burst:  fnb.BaseConfig.debugLogLimit,
-		Period: time.Second,
-	}
+	throttledSampler := logging.BurstSampler(fnb.BaseConfig.debugLogLimit, time.Second)
 
 	log := fnb.Logger.With().
 		Timestamp().

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -139,7 +139,7 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 	fnb.flags.StringVarP(&fnb.BaseConfig.datadir, "datadir", "d", defaultConfig.datadir, "directory to store the public database (protocol state)")
 	fnb.flags.StringVar(&fnb.BaseConfig.secretsdir, "secretsdir", defaultConfig.secretsdir, "directory to store private database (secrets)")
 	fnb.flags.StringVarP(&fnb.BaseConfig.level, "loglevel", "l", defaultConfig.level, "level for logging output")
-	fnb.flags.UintVarP(&fnb.BaseConfig.debugLogLimit, "debug-log-limit", defaultConfig.debugLogLimit, "max number of debug/trace log events per second")
+	fnb.flags.Uint32Var(&fnb.BaseConfig.debugLogLimit, "debug-log-limit", defaultConfig.debugLogLimit, "max number of debug/trace log events per second")
 	fnb.flags.DurationVar(&fnb.BaseConfig.PeerUpdateInterval, "peerupdate-interval", defaultConfig.PeerUpdateInterval, "how often to refresh the peer connections for the node")
 	fnb.flags.DurationVar(&fnb.BaseConfig.UnicastMessageTimeout, "unicast-timeout", defaultConfig.UnicastMessageTimeout, "how long a unicast transmission can take to complete")
 	fnb.flags.UintVarP(&fnb.BaseConfig.metricsPort, "metricport", "m", defaultConfig.metricsPort, "port for /metrics endpoint")
@@ -584,7 +584,7 @@ func (fnb *FlowNodeBuilder) initLogger() error {
 
 	// Drop all log events that exceed this rate limit
 	throttledSampler := &zerolog.BurstSampler{
-		Burst:  uint32(fnb.BaseConfig.debugLogLimit),
+		Burst:  fnb.BaseConfig.debugLogLimit,
 		Period: time.Second,
 	}
 

--- a/utils/logging/samplers.go
+++ b/utils/logging/samplers.go
@@ -1,0 +1,31 @@
+package logging
+
+import (
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type BurstSamplerOption func(*zerolog.BurstSampler)
+
+// WithNextSampler adds a sampler that is applied after exceeding the burst limit
+func WithNextSampler(sampler zerolog.Sampler) BurstSamplerOption {
+	return func(s *zerolog.BurstSampler) {
+		s.NextSampler = sampler
+	}
+}
+
+// BurstSampler returns a zerolog.BurstSampler with the provided burst and interval.
+// Logs emitted beyond the burst limit are dropped
+func BurstSampler(burst uint32, interval time.Duration, opts ...BurstSamplerOption) *zerolog.BurstSampler {
+	s := &zerolog.BurstSampler{
+		Burst:  burst,
+		Period: interval,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}


### PR DESCRIPTION
This PR uses `zerolog.BurstSampler`s to rate limit `Debug` and `Trace` level events. Any events that exceed the limit will be dropped. This helps protect nodes from significant performance issues when debug logging is enabled.

Note: This is being added to avoid liveness issues when a large volume of logs are generated. It may result in lost log events which would require further changes to logging to prevent.

This PR also sets the min log level to `Trace` which allows enabling trace events via the `--loglevel` flag or admin command.