### PR TITLE
Handle unverifiable input error in cluster compliance core

### DIFF
--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -214,6 +214,12 @@ func (c *Core) processBlockAndDescendants(proposal *messages.ClusterBlockProposa
 			Msg("received invalid block from other node (potential slashing evidence?)")
 		return nil
 	}
+	if engine.IsUnverifiableInputError(err) {
+		c.log.Warn().
+			Err(err).
+			Msg("received unverifiable from other node")
+		return nil
+	}
 	if err != nil {
 		// unexpected error: potentially corrupted internal state => abort processing and escalate error
 		return fmt.Errorf("failed to process block %x: %w", blockID, err)


### PR DESCRIPTION
Add missing handling for error type added in https://github.com/onflow/flow-go/pull/3577