### PR TITLE
Only override meter parameters for transaction/script body execution

### DIFF
--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -18,6 +18,9 @@ import (
 	"github.com/onflow/flow-go/fvm/utils"
 )
 
+// getBasicMeterParameters returns the set of meter parameters used for
+// general procedure execution.  Subparts of the procedure execution may
+// specify custom meter parameters via nested transactions.
 func getBasicMeterParameters(
 	ctx Context,
 	proc Procedure,
@@ -38,10 +41,12 @@ func getBasicMeterParameters(
 	return params
 }
 
-func getMeterParameters(
+// getBodyMeterParameters returns the set of meter parameters used for
+// transaction/script body execution.
+func getBodyMeterParameters(
 	ctx Context,
 	proc Procedure,
-	view state.View,
+	txnState *state.TransactionState,
 	derivedTxnData *programs.DerivedTransactionData,
 ) (
 	meter.MeterParameters,
@@ -49,14 +54,6 @@ func getMeterParameters(
 ) {
 	procParams := getBasicMeterParameters(ctx, proc)
 
-	txnState := state.NewTransactionState(
-		view,
-		state.DefaultParameters().
-			WithMaxKeySizeAllowed(ctx.MaxStateKeySize).
-			WithMaxValueSizeAllowed(ctx.MaxStateValueSize).
-			WithMeterParameters(procParams))
-
-	// TODO(patrick): cache meter param overrides
 	overrides, err := derivedTxnData.GetMeterParamOverrides(
 		txnState,
 		meterParamOverridesComputer{ctx, derivedTxnData})

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -110,17 +110,10 @@ func (vm *VirtualMachine) Run(
 		return fmt.Errorf("error creating derived transaction data: %w", err)
 	}
 
-	// TODO(patrick): move this into transaction executor (and maybe also script
-	// executor)
-	meterParams, err := getMeterParameters(ctx, proc, v, derivedTxnData)
-	if err != nil {
-		return fmt.Errorf("error gettng meter parameters: %w", err)
-	}
-
 	txnState := state.NewTransactionState(
 		v,
 		state.DefaultParameters().
-			WithMeterParameters(meterParams).
+			WithMeterParameters(getBasicMeterParameters(ctx, proc)).
 			WithMaxKeySizeAllowed(ctx.MaxStateKeySize).
 			WithMaxValueSizeAllowed(ctx.MaxStateValueSize))
 

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -15,7 +15,6 @@ import (
 	programsCache "github.com/onflow/flow-go/fvm/programs"
 	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
 	"github.com/onflow/flow-go/fvm/state"
-	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/trace"
 )
 
@@ -79,9 +78,7 @@ type transactionExecutor struct {
 	TransactionSequenceNumberChecker
 	TransactionStorageLimiter
 
-	tracer module.Tracer
-	logger zerolog.Logger
-
+	ctx            Context
 	proc           *TransactionProcedure
 	txnState       *state.TransactionState
 	derivedTxnData *programsCache.DerivedTransactionData
@@ -120,8 +117,7 @@ func newTransactionExecutor(
 
 	return &transactionExecutor{
 		TransactionExecutorParams: ctx.TransactionExecutorParams,
-		tracer:                    ctx.Tracer,
-		logger:                    ctx.Logger,
+		ctx:                       ctx,
 		proc:                      proc,
 		txnState:                  txnState,
 		derivedTxnData:            derivedTxnData,
@@ -147,7 +143,8 @@ func (executor *transactionExecutor) Execute() error {
 	txErr, failure := errors.SplitErrorTypes(err)
 	if failure != nil {
 		// log the full error path
-		executor.logger.Err(err).Msg("fatal error when execution a transaction")
+		executor.ctx.Logger.Err(err).
+			Msg("fatal error when executing a transaction")
 		return failure
 	}
 
@@ -161,7 +158,7 @@ func (executor *transactionExecutor) Execute() error {
 func (executor *transactionExecutor) execute() error {
 	if executor.AuthorizationChecksEnabled {
 		err := executor.CheckAuthorization(
-			executor.tracer,
+			executor.ctx.Tracer,
 			executor.proc,
 			executor.txnState,
 			executor.AccountKeyWeightThreshold)
@@ -172,7 +169,7 @@ func (executor *transactionExecutor) execute() error {
 
 	if executor.SequenceNumberCheckAndIncrementEnabled {
 		err := executor.CheckAndIncrementSequenceNumber(
-			executor.tracer,
+			executor.ctx.Tracer,
 			executor.proc,
 			executor.txnState)
 		if err != nil {
@@ -191,8 +188,18 @@ func (executor *transactionExecutor) execute() error {
 }
 
 func (executor *transactionExecutor) ExecuteTransactionBody() error {
+	meterParams, err := getBodyMeterParameters(
+		executor.ctx,
+		executor.proc,
+		executor.txnState,
+		executor.derivedTxnData)
+	if err != nil {
+		return fmt.Errorf("error gettng meter parameters: %w", err)
+	}
+
 	var beginErr error
-	executor.nestedTxnId, beginErr = executor.txnState.BeginNestedTransaction()
+	executor.nestedTxnId, beginErr = executor.txnState.BeginNestedTransactionWithMeterParams(
+		meterParams)
 	if beginErr != nil {
 		return beginErr
 	}


### PR DESCRIPTION
The transaction (/script) procedure originally uses two separate transaction state to process a single request.  This merges the two transaction states into one, and only override the meter params for body execution.  The rest of the transaction (i.e., auth check, seq num check, meter override parsing) uses basic/non-overridden meter setting.

gh: #3547 #3102