### PR TITLE
Rename BlockDerivedData

### DIFF
--- a/fvm/programs/block_programs.go
+++ b/fvm/programs/block_programs.go
@@ -12,31 +12,31 @@ import (
 // DerivedBlockData is a simple fork-aware OCC database for "caching" derived
 // data for a particular block.
 type DerivedBlockData struct {
-	programs *BlockDerivedData[common.AddressLocation, *interpreter.Program]
+	programs *DerivedDataTable[common.AddressLocation, *interpreter.Program]
 
-	meterParamOverrides *BlockDerivedData[struct{}, MeterParamOverrides]
+	meterParamOverrides *DerivedDataTable[struct{}, MeterParamOverrides]
 }
 
 // DerivedTransactionData is the derived data scratch space for a single
 // transaction.
 type DerivedTransactionData struct {
-	programs *TransactionDerivedData[
+	programs *TableTransaction[
 		common.AddressLocation,
 		*interpreter.Program,
 	]
 
 	// There's only a single entry in this table.  For simplicity, we'll use
 	// struct{} as the entry's key.
-	meterParamOverrides *TransactionDerivedData[struct{}, MeterParamOverrides]
+	meterParamOverrides *TableTransaction[struct{}, MeterParamOverrides]
 }
 
 func NewEmptyDerivedBlockData() *DerivedBlockData {
 	return &DerivedBlockData{
-		programs: NewEmptyBlockDerivedData[
+		programs: NewEmptyTable[
 			common.AddressLocation,
 			*interpreter.Program,
 		](),
-		meterParamOverrides: NewEmptyBlockDerivedData[
+		meterParamOverrides: NewEmptyTable[
 			struct{},
 			MeterParamOverrides,
 		](),
@@ -47,11 +47,11 @@ func NewEmptyDerivedBlockData() *DerivedBlockData {
 // beginning of the block.
 func NewEmptyDerivedBlockDataWithTransactionOffset(offset uint32) *DerivedBlockData {
 	return &DerivedBlockData{
-		programs: NewEmptyBlockDerivedDataWithOffset[
+		programs: NewEmptyTableWithOffset[
 			common.AddressLocation,
 			*interpreter.Program,
 		](offset),
-		meterParamOverrides: NewEmptyBlockDerivedDataWithOffset[
+		meterParamOverrides: NewEmptyTableWithOffset[
 			struct{},
 			MeterParamOverrides,
 		](offset),
@@ -60,8 +60,8 @@ func NewEmptyDerivedBlockDataWithTransactionOffset(offset uint32) *DerivedBlockD
 
 func (block *DerivedBlockData) NewChildDerivedBlockData() *DerivedBlockData {
 	return &DerivedBlockData{
-		programs:            block.programs.NewChildBlockDerivedData(),
-		meterParamOverrides: block.meterParamOverrides.NewChildBlockDerivedData(),
+		programs:            block.programs.NewChildTable(),
+		meterParamOverrides: block.meterParamOverrides.NewChildTable(),
 	}
 }
 
@@ -72,14 +72,14 @@ func (block *DerivedBlockData) NewSnapshotReadDerivedTransactionData(
 	*DerivedTransactionData,
 	error,
 ) {
-	txnPrograms, err := block.programs.NewSnapshotReadTransactionDerivedData(
+	txnPrograms, err := block.programs.NewSnapshotReadTableTransaction(
 		snapshotTime,
 		executionTime)
 	if err != nil {
 		return nil, err
 	}
 
-	txnMeterParamOverrides, err := block.meterParamOverrides.NewSnapshotReadTransactionDerivedData(
+	txnMeterParamOverrides, err := block.meterParamOverrides.NewSnapshotReadTableTransaction(
 		snapshotTime,
 		executionTime)
 	if err != nil {
@@ -99,14 +99,14 @@ func (block *DerivedBlockData) NewDerivedTransactionData(
 	*DerivedTransactionData,
 	error,
 ) {
-	txnPrograms, err := block.programs.NewTransactionDerivedData(
+	txnPrograms, err := block.programs.NewTableTransaction(
 		snapshotTime,
 		executionTime)
 	if err != nil {
 		return nil, err
 	}
 
-	txnMeterParamOverrides, err := block.meterParamOverrides.NewTransactionDerivedData(
+	txnMeterParamOverrides, err := block.meterParamOverrides.NewTableTransaction(
 		snapshotTime,
 		executionTime)
 	if err != nil {

--- a/fvm/programs/invalidator.go
+++ b/fvm/programs/invalidator.go
@@ -25,12 +25,12 @@ type MeterParamOverrides struct {
 	MemoryLimit        *uint64                      // nil indicates no override
 }
 
-type ProgramInvalidator DerivedDataInvalidator[
+type ProgramInvalidator TableInvalidator[
 	common.AddressLocation,
 	*interpreter.Program,
 ]
 
-type MeterParamOverridesInvalidator DerivedDataInvalidator[
+type MeterParamOverridesInvalidator TableInvalidator[
 	struct{},
 	MeterParamOverrides,
 ]

--- a/fvm/programs/logical_time.go
+++ b/fvm/programs/logical_time.go
@@ -4,12 +4,13 @@ import (
 	"math"
 )
 
-// We will use txIndex as logical time for the purpose of "caching" programs.
+// We will use txIndex as logical time for the purpose of "caching" derived
+// data.
 //
 // Execution time refers to the transaction's start time.  Snapshot time refers
 // to the time when the snapshot first becomes readable (i.e., the "snapshot
 // time - 1" transaction committed the snapshot view).  The snapshot is where
-// the program source code is read from if no cached program entry is available.
+// the derived value is computed from if no cached value is available.
 // Each transaction's snapshot time must be smaller than or equal to its
 // execution time.
 //

--- a/fvm/programs/table.go
+++ b/fvm/programs/table.go
@@ -7,8 +7,8 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 )
 
-// ValueComputer is used by BlockDerivedData's GetOrCompute to compute the
-// derived value when the value is not in BlockDerivedData (i.e., "cache miss").
+// ValueComputer is used by DerivedDataTable's GetOrCompute to compute the
+// derived value when the value is not in DerivedDataTable (i.e., "cache miss").
 type ValueComputer[TKey any, TVal any] interface {
 	Compute(txnState *state.TransactionState, key TKey) (TVal, error)
 }
@@ -17,31 +17,37 @@ type invalidatableEntry[TVal any] struct {
 	Value TVal         // immutable after initialization.
 	State *state.State // immutable after initialization.
 
-	isInvalid bool // Guarded by BlockDerivedData' lock.
+	isInvalid bool // Guarded by DerivedDataTable' lock.
 }
 
-// BlockDerivedData is a rudimentary fork-aware OCC database table for
-// "caching" a given type of data for a particular block.
+// DerivedDataTable is a rudimentary fork-aware OCC database table for
+// "caching" homogeneous (TKey, TVal) pairs for a particular block.
 //
-// Since data are derived from external source, the database need not be
-// durable and can be recreated on the fly.
+// The database table enforces atomicity and isolation, but not consistency and
+// durability.  Consistency depends on the user correctly implementing the
+// table's invalidator.  Durability is not needed since the values are derived
+// from ledger and can be computed on the fly (This assumes that recomputation
+// is idempotent).
 //
 // Furthermore, because data are derived, transaction validation looks
 // a bit unusual when compared with a textbook OCC implementation.  In
 // particular, the transaction's invalidator represents "real" writes to the
 // canonical source, whereas the transaction's readSet/writeSet entries
 // represent "real" reads from the canonical source.
-type BlockDerivedData[TKey comparable, TVal any] struct {
+//
+// Multiple tables are grouped together via Validate/Commit 2 phase commit to
+// form the complete derived data database.
+type DerivedDataTable[TKey comparable, TVal any] struct {
 	lock  sync.RWMutex
 	items map[TKey]*invalidatableEntry[TVal]
 
 	latestCommitExecutionTime LogicalTime
 
-	invalidators chainedDerivedDataInvalidators[TKey, TVal] // Guarded by lock.
+	invalidators chainedTableInvalidators[TKey, TVal] // Guarded by lock.
 }
 
-type TransactionDerivedData[TKey comparable, TVal any] struct {
-	block *BlockDerivedData[TKey, TVal]
+type TableTransaction[TKey comparable, TVal any] struct {
+	table *DerivedDataTable[TKey, TVal]
 
 	// The start time when the snapshot first becomes readable (i.e., the
 	// "snapshotTime - 1"'s transaction committed the snapshot view)
@@ -55,41 +61,41 @@ type TransactionDerivedData[TKey comparable, TVal any] struct {
 
 	// When isSnapshotReadTransaction is true, invalidators must be empty.
 	isSnapshotReadTransaction bool
-	invalidators              chainedDerivedDataInvalidators[TKey, TVal]
+	invalidators              chainedTableInvalidators[TKey, TVal]
 }
 
-func newEmptyBlockDerivedData[TKey comparable, TVal any](
+func newEmptyTable[TKey comparable, TVal any](
 	latestCommit LogicalTime,
-) *BlockDerivedData[TKey, TVal] {
-	return &BlockDerivedData[TKey, TVal]{
+) *DerivedDataTable[TKey, TVal] {
+	return &DerivedDataTable[TKey, TVal]{
 		items:                     map[TKey]*invalidatableEntry[TVal]{},
 		latestCommitExecutionTime: latestCommit,
 		invalidators:              nil,
 	}
 }
 
-func NewEmptyBlockDerivedData[TKey comparable, TVal any]() *BlockDerivedData[TKey, TVal] {
-	return newEmptyBlockDerivedData[TKey, TVal](ParentBlockTime)
+func NewEmptyTable[TKey comparable, TVal any]() *DerivedDataTable[TKey, TVal] {
+	return newEmptyTable[TKey, TVal](ParentBlockTime)
 }
 
 // This variant is needed by the chunk verifier, which does not start at the
 // beginning of the block.
-func NewEmptyBlockDerivedDataWithOffset[TKey comparable, TVal any](offset uint32) *BlockDerivedData[TKey, TVal] {
-	return newEmptyBlockDerivedData[TKey, TVal](LogicalTime(offset) - 1)
+func NewEmptyTableWithOffset[TKey comparable, TVal any](offset uint32) *DerivedDataTable[TKey, TVal] {
+	return newEmptyTable[TKey, TVal](LogicalTime(offset) - 1)
 }
 
-func (block *BlockDerivedData[TKey, TVal]) NewChildBlockDerivedData() *BlockDerivedData[TKey, TVal] {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
+func (table *DerivedDataTable[TKey, TVal]) NewChildTable() *DerivedDataTable[TKey, TVal] {
+	table.lock.RLock()
+	defer table.lock.RUnlock()
 
 	items := make(
 		map[TKey]*invalidatableEntry[TVal],
-		len(block.items))
+		len(table.items))
 
-	for key, entry := range block.items {
+	for key, entry := range table.items {
 		// Note: We need to deep copy the invalidatableEntry here since the
-		// entry may be valid in the parent block, but invalid in the child
-		// block.
+		// entry may be valid in the parent table, but invalid in the child
+		// table.
 		items[key] = &invalidatableEntry[TVal]{
 			Value:     entry.Value,
 			State:     entry.State,
@@ -97,101 +103,101 @@ func (block *BlockDerivedData[TKey, TVal]) NewChildBlockDerivedData() *BlockDeri
 		}
 	}
 
-	return &BlockDerivedData[TKey, TVal]{
+	return &DerivedDataTable[TKey, TVal]{
 		items:                     items,
 		latestCommitExecutionTime: ParentBlockTime,
 		invalidators:              nil,
 	}
 }
 
-func (block *BlockDerivedData[TKey, TVal]) NextTxIndexForTestingOnly() uint32 {
-	return uint32(block.LatestCommitExecutionTimeForTestingOnly()) + 1
+func (table *DerivedDataTable[TKey, TVal]) NextTxIndexForTestingOnly() uint32 {
+	return uint32(table.LatestCommitExecutionTimeForTestingOnly()) + 1
 }
 
-func (block *BlockDerivedData[TKey, TVal]) LatestCommitExecutionTimeForTestingOnly() LogicalTime {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
+func (table *DerivedDataTable[TKey, TVal]) LatestCommitExecutionTimeForTestingOnly() LogicalTime {
+	table.lock.RLock()
+	defer table.lock.RUnlock()
 
-	return block.latestCommitExecutionTime
+	return table.latestCommitExecutionTime
 }
 
-func (block *BlockDerivedData[TKey, TVal]) EntriesForTestingOnly() map[TKey]*invalidatableEntry[TVal] {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
+func (table *DerivedDataTable[TKey, TVal]) EntriesForTestingOnly() map[TKey]*invalidatableEntry[TVal] {
+	table.lock.RLock()
+	defer table.lock.RUnlock()
 
 	entries := make(
 		map[TKey]*invalidatableEntry[TVal],
-		len(block.items))
-	for key, entry := range block.items {
+		len(table.items))
+	for key, entry := range table.items {
 		entries[key] = entry
 	}
 
 	return entries
 }
 
-func (block *BlockDerivedData[TKey, TVal]) InvalidatorsForTestingOnly() chainedDerivedDataInvalidators[TKey, TVal] {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
+func (table *DerivedDataTable[TKey, TVal]) InvalidatorsForTestingOnly() chainedTableInvalidators[TKey, TVal] {
+	table.lock.RLock()
+	defer table.lock.RUnlock()
 
-	return block.invalidators
+	return table.invalidators
 }
 
-func (block *BlockDerivedData[TKey, TVal]) GetForTestingOnly(
+func (table *DerivedDataTable[TKey, TVal]) GetForTestingOnly(
 	key TKey,
 ) *invalidatableEntry[TVal] {
-	return block.get(key)
+	return table.get(key)
 }
 
-func (block *BlockDerivedData[TKey, TVal]) get(
+func (table *DerivedDataTable[TKey, TVal]) get(
 	key TKey,
 ) *invalidatableEntry[TVal] {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
+	table.lock.RLock()
+	defer table.lock.RUnlock()
 
-	return block.items[key]
+	return table.items[key]
 }
 
-func (block *BlockDerivedData[TKey, TVal]) unsafeValidate(
-	item *TransactionDerivedData[TKey, TVal],
+func (table *DerivedDataTable[TKey, TVal]) unsafeValidate(
+	item *TableTransaction[TKey, TVal],
 ) RetryableError {
 	if item.isSnapshotReadTransaction &&
 		item.invalidators.ShouldInvalidateEntries() {
 
 		return newNotRetryableError(
-			"invalid TransactionDerivedData: snapshot read can't invalidate")
+			"invalid TableTransaction: snapshot read can't invalidate")
 	}
 
-	if block.latestCommitExecutionTime >= item.executionTime {
+	if table.latestCommitExecutionTime >= item.executionTime {
 		return newNotRetryableError(
-			"invalid TransactionDerivedData: non-increasing time (%v >= %v)",
-			block.latestCommitExecutionTime,
+			"invalid TableTransaction: non-increasing time (%v >= %v)",
+			table.latestCommitExecutionTime,
 			item.executionTime)
 	}
 
-	if block.latestCommitExecutionTime+1 < item.snapshotTime &&
+	if table.latestCommitExecutionTime+1 < item.snapshotTime &&
 		(!item.isSnapshotReadTransaction ||
 			item.snapshotTime != EndOfBlockExecutionTime) {
 
 		return newNotRetryableError(
-			"invalid TransactionDerivedData: missing commit range [%v, %v)",
-			block.latestCommitExecutionTime+1,
+			"invalid TableTransaction: missing commit range [%v, %v)",
+			table.latestCommitExecutionTime+1,
 			item.snapshotTime)
 	}
 
 	for _, entry := range item.readSet {
 		if entry.isInvalid {
 			return newRetryableError(
-				"invalid TransactionDerivedDatas. outdated read set")
+				"invalid TableTransactions. outdated read set")
 		}
 	}
 
-	applicable := block.invalidators.ApplicableInvalidators(
+	applicable := table.invalidators.ApplicableInvalidators(
 		item.snapshotTime)
 	if applicable.ShouldInvalidateEntries() {
 		for key, entry := range item.writeSet {
 			if applicable.ShouldInvalidateEntry(key, entry.Value, entry.State) {
 				return newRetryableError(
-					"invalid TransactionDerivedDatas. outdated write set")
+					"invalid TableTransactions. outdated write set")
 			}
 		}
 	}
@@ -199,54 +205,54 @@ func (block *BlockDerivedData[TKey, TVal]) unsafeValidate(
 	return nil
 }
 
-func (block *BlockDerivedData[TKey, TVal]) validate(
-	item *TransactionDerivedData[TKey, TVal],
+func (table *DerivedDataTable[TKey, TVal]) validate(
+	item *TableTransaction[TKey, TVal],
 ) RetryableError {
-	block.lock.RLock()
-	defer block.lock.RUnlock()
+	table.lock.RLock()
+	defer table.lock.RUnlock()
 
-	return block.unsafeValidate(item)
+	return table.unsafeValidate(item)
 }
 
-func (block *BlockDerivedData[TKey, TVal]) commit(
-	txn *TransactionDerivedData[TKey, TVal],
+func (table *DerivedDataTable[TKey, TVal]) commit(
+	txn *TableTransaction[TKey, TVal],
 ) RetryableError {
-	block.lock.Lock()
-	defer block.lock.Unlock()
+	table.lock.Lock()
+	defer table.lock.Unlock()
 
 	// NOTE: Instead of throwing out all the write entries, we can commit
 	// the valid write entries then return error.
-	err := block.unsafeValidate(txn)
+	err := table.unsafeValidate(txn)
 	if err != nil {
 		return err
 	}
 
 	for key, entry := range txn.writeSet {
-		_, ok := block.items[key]
+		_, ok := table.items[key]
 		if ok {
-			// A previous transaction already committed an equivalent TransactionDerivedData
-			// entry.  Since both TransactionDerivedData entry are valid, just reuse the
+			// A previous transaction already committed an equivalent TableTransaction
+			// entry.  Since both TableTransaction entry are valid, just reuse the
 			// existing one for future transactions.
 			continue
 		}
 
-		block.items[key] = entry
+		table.items[key] = entry
 	}
 
 	if txn.invalidators.ShouldInvalidateEntries() {
-		for key, entry := range block.items {
+		for key, entry := range table.items {
 			if txn.invalidators.ShouldInvalidateEntry(
 				key,
 				entry.Value,
 				entry.State) {
 
 				entry.isInvalid = true
-				delete(block.items, key)
+				delete(table.items, key)
 			}
 		}
 
-		block.invalidators = append(
-			block.invalidators,
+		table.invalidators = append(
+			table.invalidators,
 			txn.invalidators...)
 	}
 
@@ -255,35 +261,35 @@ func (block *BlockDerivedData[TKey, TVal]) commit(
 	// snapshots.  It is safe to commit the entries since snapshot read
 	// transactions never invalidate entries.
 	if !txn.isSnapshotReadTransaction {
-		block.latestCommitExecutionTime = txn.executionTime
+		table.latestCommitExecutionTime = txn.executionTime
 	}
 	return nil
 }
 
-func (block *BlockDerivedData[TKey, TVal]) newTransactionDerivedData(
+func (table *DerivedDataTable[TKey, TVal]) newTableTransaction(
 	upperBoundExecutionTime LogicalTime,
 	snapshotTime LogicalTime,
 	executionTime LogicalTime,
 	isSnapshotReadTransaction bool,
 ) (
-	*TransactionDerivedData[TKey, TVal],
+	*TableTransaction[TKey, TVal],
 	error,
 ) {
 	if executionTime < 0 || executionTime > upperBoundExecutionTime {
 		return nil, fmt.Errorf(
-			"invalid TransactionDerivedDatas: execution time out of bound: %v",
+			"invalid TableTransactions: execution time out of bound: %v",
 			executionTime)
 	}
 
 	if snapshotTime > executionTime {
 		return nil, fmt.Errorf(
-			"invalid TransactionDerivedDatas: snapshot > execution: %v > %v",
+			"invalid TableTransactions: snapshot > execution: %v > %v",
 			snapshotTime,
 			executionTime)
 	}
 
-	return &TransactionDerivedData[TKey, TVal]{
-		block:                     block,
+	return &TableTransaction[TKey, TVal]{
+		table:                     table,
 		snapshotTime:              snapshotTime,
 		executionTime:             executionTime,
 		readSet:                   map[TKey]*invalidatableEntry[TVal]{},
@@ -292,28 +298,28 @@ func (block *BlockDerivedData[TKey, TVal]) newTransactionDerivedData(
 	}, nil
 }
 
-func (block *BlockDerivedData[TKey, TVal]) NewSnapshotReadTransactionDerivedData(
+func (table *DerivedDataTable[TKey, TVal]) NewSnapshotReadTableTransaction(
 	snapshotTime LogicalTime,
 	executionTime LogicalTime,
 ) (
-	*TransactionDerivedData[TKey, TVal],
+	*TableTransaction[TKey, TVal],
 	error,
 ) {
-	return block.newTransactionDerivedData(
+	return table.newTableTransaction(
 		LargestSnapshotReadTransactionExecutionTime,
 		snapshotTime,
 		executionTime,
 		true)
 }
 
-func (block *BlockDerivedData[TKey, TVal]) NewTransactionDerivedData(
+func (table *DerivedDataTable[TKey, TVal]) NewTableTransaction(
 	snapshotTime LogicalTime,
 	executionTime LogicalTime,
 ) (
-	*TransactionDerivedData[TKey, TVal],
+	*TableTransaction[TKey, TVal],
 	error,
 ) {
-	return block.newTransactionDerivedData(
+	return table.newTableTransaction(
 		LargestNormalTransactionExecutionTime,
 		snapshotTime,
 		executionTime,
@@ -321,7 +327,7 @@ func (block *BlockDerivedData[TKey, TVal]) NewTransactionDerivedData(
 }
 
 // Note: use GetOrCompute instead of Get/Set whenever possible.
-func (txn *TransactionDerivedData[TKey, TVal]) Get(key TKey) (
+func (txn *TableTransaction[TKey, TVal]) Get(key TKey) (
 	TVal,
 	*state.State,
 	bool,
@@ -337,7 +343,7 @@ func (txn *TransactionDerivedData[TKey, TVal]) Get(key TKey) (
 		return readEntry.Value, readEntry.State, true
 	}
 
-	readEntry = txn.block.get(key)
+	readEntry = txn.table.get(key)
 	if readEntry != nil {
 		txn.readSet[key] = readEntry
 		return readEntry.Value, readEntry.State, true
@@ -348,7 +354,7 @@ func (txn *TransactionDerivedData[TKey, TVal]) Get(key TKey) (
 }
 
 // Note: use GetOrCompute instead of Get/Set whenever possible.
-func (txn *TransactionDerivedData[TKey, TVal]) Set(
+func (txn *TableTransaction[TKey, TVal]) Set(
 	key TKey,
 	value TVal,
 	state *state.State,
@@ -367,7 +373,7 @@ func (txn *TransactionDerivedData[TKey, TVal]) Set(
 //
 // Note: valFunc must be an idempotent function and it must not modify
 // txnState's values.
-func (txn *TransactionDerivedData[TKey, TVal]) GetOrCompute(
+func (txn *TableTransaction[TKey, TVal]) GetOrCompute(
 	txnState *state.TransactionState,
 	key TKey,
 	computer ValueComputer[TKey, TVal],
@@ -409,8 +415,8 @@ func (txn *TransactionDerivedData[TKey, TVal]) GetOrCompute(
 	return val, nil
 }
 
-func (txn *TransactionDerivedData[TKey, TVal]) AddInvalidator(
-	invalidator DerivedDataInvalidator[TKey, TVal],
+func (txn *TableTransaction[TKey, TVal]) AddInvalidator(
+	invalidator TableInvalidator[TKey, TVal],
 ) {
 	if invalidator == nil || !invalidator.ShouldInvalidateEntries() {
 		return
@@ -418,16 +424,16 @@ func (txn *TransactionDerivedData[TKey, TVal]) AddInvalidator(
 
 	txn.invalidators = append(
 		txn.invalidators,
-		derivedDataInvalidatorAtTime[TKey, TVal]{
-			DerivedDataInvalidator: invalidator,
-			executionTime:          txn.executionTime,
+		tableInvalidatorAtTime[TKey, TVal]{
+			TableInvalidator: invalidator,
+			executionTime:    txn.executionTime,
 		})
 }
 
-func (txn *TransactionDerivedData[TKey, TVal]) Validate() RetryableError {
-	return txn.block.validate(txn)
+func (txn *TableTransaction[TKey, TVal]) Validate() RetryableError {
+	return txn.table.validate(txn)
 }
 
-func (txn *TransactionDerivedData[TKey, TVal]) Commit() RetryableError {
-	return txn.block.commit(txn)
+func (txn *TableTransaction[TKey, TVal]) Commit() RetryableError {
+	return txn.table.commit(txn)
 }

--- a/fvm/programs/table_invalidator.go
+++ b/fvm/programs/table_invalidator.go
@@ -4,27 +4,27 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 )
 
-type DerivedDataInvalidator[TKey comparable, TVal any] interface {
+type TableInvalidator[TKey comparable, TVal any] interface {
 	// This returns true if the this invalidates any data
 	ShouldInvalidateEntries() bool
 
-	// This returns true if the data entry should be invalidated.
+	// This returns true if the table entry should be invalidated.
 	ShouldInvalidateEntry(TKey, TVal, *state.State) bool
 }
 
-type derivedDataInvalidatorAtTime[TKey comparable, TVal any] struct {
-	DerivedDataInvalidator[TKey, TVal]
+type tableInvalidatorAtTime[TKey comparable, TVal any] struct {
+	TableInvalidator[TKey, TVal]
 
 	executionTime LogicalTime
 }
 
 // NOTE: chainedInvalidator assumes that the entries are order by non-decreasing
 // execution time.
-type chainedDerivedDataInvalidators[TKey comparable, TVal any] []derivedDataInvalidatorAtTime[TKey, TVal]
+type chainedTableInvalidators[TKey comparable, TVal any] []tableInvalidatorAtTime[TKey, TVal]
 
-func (chained chainedDerivedDataInvalidators[TKey, TVal]) ApplicableInvalidators(
+func (chained chainedTableInvalidators[TKey, TVal]) ApplicableInvalidators(
 	snapshotTime LogicalTime,
-) chainedDerivedDataInvalidators[TKey, TVal] {
+) chainedTableInvalidators[TKey, TVal] {
 	// NOTE: switch to bisection search (or reverse iteration) if the list
 	// is long.
 	for idx, entry := range chained {
@@ -36,7 +36,7 @@ func (chained chainedDerivedDataInvalidators[TKey, TVal]) ApplicableInvalidators
 	return nil
 }
 
-func (chained chainedDerivedDataInvalidators[TKey, TVal]) ShouldInvalidateEntries() bool {
+func (chained chainedTableInvalidators[TKey, TVal]) ShouldInvalidateEntries() bool {
 	for _, invalidator := range chained {
 		if invalidator.ShouldInvalidateEntries() {
 			return true
@@ -46,7 +46,7 @@ func (chained chainedDerivedDataInvalidators[TKey, TVal]) ShouldInvalidateEntrie
 	return false
 }
 
-func (chained chainedDerivedDataInvalidators[TKey, TVal]) ShouldInvalidateEntry(
+func (chained chainedTableInvalidators[TKey, TVal]) ShouldInvalidateEntry(
 	key TKey,
 	value TVal,
 	state *state.State,

--- a/fvm/programs/table_invalidator_test.go
+++ b/fvm/programs/table_invalidator_test.go
@@ -65,46 +65,46 @@ func TestModifiedSetsProgramInvalidator(t *testing.T) {
 }
 
 func TestChainedInvalidator(t *testing.T) {
-	var chain chainedDerivedDataInvalidators[string, *string]
+	var chain chainedTableInvalidators[string, *string]
 	require.False(t, chain.ShouldInvalidateEntries())
 	require.False(t, chain.ShouldInvalidateEntry("", nil, nil))
 
-	chain = chainedDerivedDataInvalidators[string, *string]{}
+	chain = chainedTableInvalidators[string, *string]{}
 	require.False(t, chain.ShouldInvalidateEntries())
 	require.False(t, chain.ShouldInvalidateEntry("", nil, nil))
 
-	chain = chainedDerivedDataInvalidators[string, *string]{
+	chain = chainedTableInvalidators[string, *string]{
 		{
-			DerivedDataInvalidator: testInvalidator{},
-			executionTime:          1,
+			TableInvalidator: testInvalidator{},
+			executionTime:    1,
 		},
 		{
-			DerivedDataInvalidator: testInvalidator{},
-			executionTime:          2,
+			TableInvalidator: testInvalidator{},
+			executionTime:    2,
 		},
 		{
-			DerivedDataInvalidator: testInvalidator{},
-			executionTime:          3,
+			TableInvalidator: testInvalidator{},
+			executionTime:    3,
 		},
 	}
 	require.False(t, chain.ShouldInvalidateEntries())
 
-	chain = chainedDerivedDataInvalidators[string, *string]{
+	chain = chainedTableInvalidators[string, *string]{
 		{
-			DerivedDataInvalidator: testInvalidator{invalidateName: "1"},
-			executionTime:          1,
+			TableInvalidator: testInvalidator{invalidateName: "1"},
+			executionTime:    1,
 		},
 		{
-			DerivedDataInvalidator: testInvalidator{invalidateName: "3a"},
-			executionTime:          3,
+			TableInvalidator: testInvalidator{invalidateName: "3a"},
+			executionTime:    3,
 		},
 		{
-			DerivedDataInvalidator: testInvalidator{invalidateName: "3b"},
-			executionTime:          3,
+			TableInvalidator: testInvalidator{invalidateName: "3b"},
+			executionTime:    3,
 		},
 		{
-			DerivedDataInvalidator: testInvalidator{invalidateName: "7"},
-			executionTime:          7,
+			TableInvalidator: testInvalidator{invalidateName: "7"},
+			executionTime:    7,
 		},
 	}
 	require.True(t, chain.ShouldInvalidateEntries())

--- a/fvm/programs/table_test.go
+++ b/fvm/programs/table_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/onflow/flow-go/fvm/utils"
 )
 
-func newEmptyTestBlock() *BlockDerivedData[string, *string] {
-	return NewEmptyBlockDerivedData[string, *string]()
+func newEmptyTestBlock() *DerivedDataTable[string, *string] {
+	return NewEmptyTable[string, *string]()
 }
 
-func TestBlockDerivedDataWithTransactionOffset(t *testing.T) {
-	block := NewEmptyBlockDerivedDataWithOffset[string, *string](18)
+func TestDerivedDataTableWithTransactionOffset(t *testing.T) {
+	block := NewEmptyTableWithOffset[string, *string](18)
 
 	require.Equal(
 		t,
@@ -26,50 +26,50 @@ func TestBlockDerivedDataWithTransactionOffset(t *testing.T) {
 func TestTxnDerivedDataNormalTransactionInvalidExecutionTimeBound(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	_, err := block.NewTransactionDerivedData(-1, -1)
+	_, err := block.NewTableTransaction(-1, -1)
 	require.ErrorContains(t, err, "execution time out of bound")
 
-	_, err = block.NewTransactionDerivedData(0, 0)
+	_, err = block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
-	_, err = block.NewTransactionDerivedData(0, EndOfBlockExecutionTime)
+	_, err = block.NewTableTransaction(0, EndOfBlockExecutionTime)
 	require.ErrorContains(t, err, "execution time out of bound")
 
-	_, err = block.NewTransactionDerivedData(0, EndOfBlockExecutionTime-1)
+	_, err = block.NewTableTransaction(0, EndOfBlockExecutionTime-1)
 	require.NoError(t, err)
 }
 
 func TestTxnDerivedDataNormalTransactionInvalidSnapshotTime(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	_, err := block.NewTransactionDerivedData(10, 0)
+	_, err := block.NewTableTransaction(10, 0)
 	require.ErrorContains(t, err, "snapshot > execution")
 
-	_, err = block.NewTransactionDerivedData(10, 10)
+	_, err = block.NewTableTransaction(10, 10)
 	require.NoError(t, err)
 
-	_, err = block.NewTransactionDerivedData(999, 998)
+	_, err = block.NewTableTransaction(999, 998)
 	require.ErrorContains(t, err, "snapshot > execution")
 
-	_, err = block.NewTransactionDerivedData(999, 999)
+	_, err = block.NewTableTransaction(999, 999)
 	require.NoError(t, err)
 }
 
 func TestTxnDerivedDataSnapshotReadTransactionInvalidExecutionTimeBound(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	_, err := block.NewSnapshotReadTransactionDerivedData(
+	_, err := block.NewSnapshotReadTableTransaction(
 		ParentBlockTime,
 		ParentBlockTime)
 	require.ErrorContains(t, err, "execution time out of bound")
 
-	_, err = block.NewSnapshotReadTransactionDerivedData(ParentBlockTime, 0)
+	_, err = block.NewSnapshotReadTableTransaction(ParentBlockTime, 0)
 	require.NoError(t, err)
 
-	_, err = block.NewSnapshotReadTransactionDerivedData(0, ChildBlockTime)
+	_, err = block.NewSnapshotReadTableTransaction(0, ChildBlockTime)
 	require.ErrorContains(t, err, "execution time out of bound")
 
-	_, err = block.NewSnapshotReadTransactionDerivedData(
+	_, err = block.NewSnapshotReadTableTransaction(
 		0,
 		EndOfBlockExecutionTime)
 	require.NoError(t, err)
@@ -78,10 +78,10 @@ func TestTxnDerivedDataSnapshotReadTransactionInvalidExecutionTimeBound(t *testi
 func TestTxnDerivedDataValidateRejectOutOfOrderCommit(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testTxn, err := block.NewTransactionDerivedData(0, 0)
+	testTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 1)
+	testSetupTxn, err := block.NewTableTransaction(0, 1)
 	require.NoError(t, err)
 
 	validateErr := testTxn.Validate()
@@ -98,13 +98,13 @@ func TestTxnDerivedDataValidateRejectOutOfOrderCommit(t *testing.T) {
 func TestTxnDerivedDataValidateRejectNonIncreasingExecutionTime(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 0)
+	testSetupTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
 	require.NoError(t, err)
 
-	testTxn, err := block.NewTransactionDerivedData(0, 0)
+	testTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
 	validateErr := testTxn.Validate()
@@ -116,7 +116,7 @@ func TestTxnDerivedDataValidateRejectCommitGapForNormalTxn(t *testing.T) {
 	block := newEmptyTestBlock()
 
 	commitTime := LogicalTime(5)
-	testSetupTxn, err := block.NewTransactionDerivedData(0, commitTime)
+	testSetupTxn, err := block.NewTableTransaction(0, commitTime)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
@@ -124,7 +124,7 @@ func TestTxnDerivedDataValidateRejectCommitGapForNormalTxn(t *testing.T) {
 
 	require.Equal(t, commitTime, block.LatestCommitExecutionTimeForTestingOnly())
 
-	testTxn, err := block.NewTransactionDerivedData(10, 10)
+	testTxn, err := block.NewTableTransaction(10, 10)
 	require.NoError(t, err)
 
 	validateErr := testTxn.Validate()
@@ -136,7 +136,7 @@ func TestTxnDerivedDataValidateRejectCommitGapForSnapshotRead(t *testing.T) {
 	block := newEmptyTestBlock()
 
 	commitTime := LogicalTime(5)
-	testSetupTxn, err := block.NewTransactionDerivedData(0, commitTime)
+	testSetupTxn, err := block.NewTableTransaction(0, commitTime)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
@@ -144,7 +144,7 @@ func TestTxnDerivedDataValidateRejectCommitGapForSnapshotRead(t *testing.T) {
 
 	require.Equal(t, commitTime, block.LatestCommitExecutionTimeForTestingOnly())
 
-	testTxn, err := block.NewSnapshotReadTransactionDerivedData(10, 10)
+	testTxn, err := block.NewSnapshotReadTableTransaction(10, 10)
 	require.NoError(t, err)
 
 	validateErr := testTxn.Validate()
@@ -155,13 +155,13 @@ func TestTxnDerivedDataValidateRejectCommitGapForSnapshotRead(t *testing.T) {
 func TestTxnDerivedDataValidateRejectOutdatedReadSet(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testSetupTxn1, err := block.NewTransactionDerivedData(0, 0)
+	testSetupTxn1, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
-	testSetupTxn2, err := block.NewTransactionDerivedData(0, 1)
+	testSetupTxn2, err := block.NewTableTransaction(0, 1)
 	require.NoError(t, err)
 
-	testTxn, err := block.NewTransactionDerivedData(0, 2)
+	testTxn, err := block.NewTableTransaction(0, 2)
 	require.NoError(t, err)
 
 	key := "abc"
@@ -200,7 +200,7 @@ func TestTxnDerivedDataValidateRejectOutdatedReadSet(t *testing.T) {
 func TestTxnDerivedDataValidateRejectOutdatedWriteSet(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 0)
+	testSetupTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
 	testSetupTxn.AddInvalidator(testInvalidator{invalidateAll: true})
@@ -210,7 +210,7 @@ func TestTxnDerivedDataValidateRejectOutdatedWriteSet(t *testing.T) {
 
 	require.Equal(t, 1, len(block.InvalidatorsForTestingOnly()))
 
-	testTxn, err := block.NewTransactionDerivedData(0, 1)
+	testTxn, err := block.NewTableTransaction(0, 1)
 	require.NoError(t, err)
 
 	value := "value"
@@ -224,7 +224,7 @@ func TestTxnDerivedDataValidateRejectOutdatedWriteSet(t *testing.T) {
 func TestTxnDerivedDataValidateIgnoreInvalidatorsOlderThanSnapshot(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 0)
+	testSetupTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
 	testSetupTxn.AddInvalidator(testInvalidator{invalidateAll: true})
@@ -233,7 +233,7 @@ func TestTxnDerivedDataValidateIgnoreInvalidatorsOlderThanSnapshot(t *testing.T)
 
 	require.Equal(t, 1, len(block.InvalidatorsForTestingOnly()))
 
-	testTxn, err := block.NewTransactionDerivedData(1, 1)
+	testTxn, err := block.NewTableTransaction(1, 1)
 	require.NoError(t, err)
 
 	value := "value"
@@ -247,7 +247,7 @@ func TestTxnDerivedDataCommitEndOfBlockSnapshotRead(t *testing.T) {
 	block := newEmptyTestBlock()
 
 	commitTime := LogicalTime(5)
-	testSetupTxn, err := block.NewTransactionDerivedData(0, commitTime)
+	testSetupTxn, err := block.NewTableTransaction(0, commitTime)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
@@ -255,7 +255,7 @@ func TestTxnDerivedDataCommitEndOfBlockSnapshotRead(t *testing.T) {
 
 	require.Equal(t, commitTime, block.LatestCommitExecutionTimeForTestingOnly())
 
-	testTxn, err := block.NewSnapshotReadTransactionDerivedData(
+	testTxn, err := block.NewSnapshotReadTableTransaction(
 		EndOfBlockExecutionTime,
 		EndOfBlockExecutionTime)
 	require.NoError(t, err)
@@ -270,7 +270,7 @@ func TestTxnDerivedDataCommitSnapshotReadDontAdvanceTime(t *testing.T) {
 	block := newEmptyTestBlock()
 
 	commitTime := LogicalTime(71)
-	testSetupTxn, err := block.NewTransactionDerivedData(0, commitTime)
+	testSetupTxn, err := block.NewTableTransaction(0, commitTime)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
@@ -278,7 +278,7 @@ func TestTxnDerivedDataCommitSnapshotReadDontAdvanceTime(t *testing.T) {
 
 	repeatedTime := commitTime + 1
 	for i := 0; i < 10; i++ {
-		txn, err := block.NewSnapshotReadTransactionDerivedData(0, repeatedTime)
+		txn, err := block.NewSnapshotReadTableTransaction(0, repeatedTime)
 		require.NoError(t, err)
 
 		err = txn.Commit()
@@ -294,7 +294,7 @@ func TestTxnDerivedDataCommitSnapshotReadDontAdvanceTime(t *testing.T) {
 func TestTxnDerivedDataCommitWriteOnlyTransactionNoInvalidation(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testTxn, err := block.NewTransactionDerivedData(0, 0)
+	testTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
 	key := "234"
@@ -343,7 +343,7 @@ func TestTxnDerivedDataCommitWriteOnlyTransactionWithInvalidation(t *testing.T) 
 	block := newEmptyTestBlock()
 
 	testTxnTime := LogicalTime(47)
-	testTxn, err := block.NewTransactionDerivedData(0, testTxnTime)
+	testTxn, err := block.NewTableTransaction(0, testTxnTime)
 	require.NoError(t, err)
 
 	key := "999"
@@ -380,10 +380,10 @@ func TestTxnDerivedDataCommitWriteOnlyTransactionWithInvalidation(t *testing.T) 
 
 	require.Equal(
 		t,
-		chainedDerivedDataInvalidators[string, *string]{
+		chainedTableInvalidators[string, *string]{
 			{
-				DerivedDataInvalidator: invalidator,
-				executionTime:          testTxnTime,
+				TableInvalidator: invalidator,
+				executionTime:    testTxnTime,
 			},
 		},
 		block.InvalidatorsForTestingOnly())
@@ -394,10 +394,10 @@ func TestTxnDerivedDataCommitWriteOnlyTransactionWithInvalidation(t *testing.T) 
 func TestTxnDerivedDataCommitUseOriginalEntryOnDuplicateWriteEntries(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 11)
+	testSetupTxn, err := block.NewTableTransaction(0, 11)
 	require.NoError(t, err)
 
-	testTxn, err := block.NewTransactionDerivedData(10, 12)
+	testTxn, err := block.NewTableTransaction(10, 12)
 	require.NoError(t, err)
 
 	key := "17"
@@ -442,10 +442,10 @@ func TestTxnDerivedDataCommitUseOriginalEntryOnDuplicateWriteEntries(t *testing.
 func TestTxnDerivedDataCommitReadOnlyTransactionNoInvalidation(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 0)
+	testSetupTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
-	testTxn, err := block.NewTransactionDerivedData(0, 1)
+	testTxn, err := block.NewTableTransaction(0, 1)
 	require.NoError(t, err)
 
 	key1 := "key1"
@@ -514,14 +514,14 @@ func TestTxnDerivedDataCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
 	block := newEmptyTestBlock()
 
 	testSetupTxn1Time := LogicalTime(2)
-	testSetupTxn1, err := block.NewTransactionDerivedData(0, testSetupTxn1Time)
+	testSetupTxn1, err := block.NewTableTransaction(0, testSetupTxn1Time)
 	require.NoError(t, err)
 
-	testSetupTxn2, err := block.NewTransactionDerivedData(0, 4)
+	testSetupTxn2, err := block.NewTableTransaction(0, 4)
 	require.NoError(t, err)
 
 	testTxnTime := LogicalTime(6)
-	testTxn, err := block.NewTransactionDerivedData(0, testTxnTime)
+	testTxn, err := block.NewTableTransaction(0, testTxnTime)
 	require.NoError(t, err)
 
 	testSetupTxn1Invalidator := testInvalidator{
@@ -579,14 +579,14 @@ func TestTxnDerivedDataCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedDerivedDataInvalidators[string, *string]{
+		chainedTableInvalidators[string, *string]{
 			{
-				DerivedDataInvalidator: testSetupTxn1Invalidator,
-				executionTime:          testSetupTxn1Time,
+				TableInvalidator: testSetupTxn1Invalidator,
+				executionTime:    testSetupTxn1Time,
 			},
 			{
-				DerivedDataInvalidator: testTxnInvalidator,
-				executionTime:          testTxnTime,
+				TableInvalidator: testTxnInvalidator,
+				executionTime:    testTxnTime,
 			},
 		},
 		block.InvalidatorsForTestingOnly())
@@ -597,13 +597,13 @@ func TestTxnDerivedDataCommitReadOnlyTransactionWithInvalidation(t *testing.T) {
 func TestTxnDerivedDataCommitValidateError(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 10)
+	testSetupTxn, err := block.NewTableTransaction(0, 10)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
 	require.NoError(t, err)
 
-	testTxn, err := block.NewTransactionDerivedData(10, 10)
+	testTxn, err := block.NewTableTransaction(10, 10)
 	require.NoError(t, err)
 
 	commitErr := testTxn.Commit()
@@ -615,13 +615,13 @@ func TestTxnDerivedDataCommitSnapshotReadDoesNotAdvanceCommitTime(t *testing.T) 
 	block := newEmptyTestBlock()
 
 	expectedTime := LogicalTime(10)
-	testSetupTxn, err := block.NewTransactionDerivedData(0, expectedTime)
+	testSetupTxn, err := block.NewTableTransaction(0, expectedTime)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
 	require.NoError(t, err)
 
-	testTxn, err := block.NewSnapshotReadTransactionDerivedData(0, 11)
+	testTxn, err := block.NewSnapshotReadTableTransaction(0, 11)
 	require.NoError(t, err)
 
 	err = testTxn.Commit()
@@ -636,7 +636,7 @@ func TestTxnDerivedDataCommitSnapshotReadDoesNotAdvanceCommitTime(t *testing.T) 
 func TestTxnDerivedDataCommitBadSnapshotReadInvalidator(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testTxn, err := block.NewSnapshotReadTransactionDerivedData(0, 42)
+	testTxn, err := block.NewSnapshotReadTableTransaction(0, 42)
 	require.NoError(t, err)
 
 	testTxn.AddInvalidator(testInvalidator{invalidateAll: true})
@@ -651,7 +651,7 @@ func TestTxnDerivedDataCommitFineGrainInvalidation(t *testing.T) {
 
 	// Setup the database with two read entries
 
-	testSetupTxn, err := block.NewTransactionDerivedData(0, 0)
+	testSetupTxn, err := block.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
 	readKey1 := "read-key-1"
@@ -674,7 +674,7 @@ func TestTxnDerivedDataCommitFineGrainInvalidation(t *testing.T) {
 	// two new ones,
 
 	testTxnTime := LogicalTime(15)
-	testTxn, err := block.NewTransactionDerivedData(1, testTxnTime)
+	testTxn, err := block.NewTableTransaction(1, testTxnTime)
 	require.NoError(t, err)
 
 	actualValue, actualState, ok := testTxn.Get(readKey1)
@@ -724,14 +724,14 @@ func TestTxnDerivedDataCommitFineGrainInvalidation(t *testing.T) {
 
 	require.Equal(
 		t,
-		chainedDerivedDataInvalidators[string, *string]{
+		chainedTableInvalidators[string, *string]{
 			{
-				DerivedDataInvalidator: invalidator1,
-				executionTime:          testTxnTime,
+				TableInvalidator: invalidator1,
+				executionTime:    testTxnTime,
 			},
 			{
-				DerivedDataInvalidator: invalidator2,
-				executionTime:          testTxnTime,
+				TableInvalidator: invalidator2,
+				executionTime:    testTxnTime,
 			},
 		},
 		block.InvalidatorsForTestingOnly())
@@ -752,7 +752,7 @@ func TestTxnDerivedDataCommitFineGrainInvalidation(t *testing.T) {
 	require.Same(t, writeState2, entry.State)
 }
 
-func TestBlockDerivedDataNewChildDerivedBlockData(t *testing.T) {
+func TestDerivedDataTableNewChildDerivedBlockData(t *testing.T) {
 	parentBlock := newEmptyTestBlock()
 
 	require.Equal(
@@ -762,7 +762,7 @@ func TestBlockDerivedDataNewChildDerivedBlockData(t *testing.T) {
 	require.Equal(t, 0, len(parentBlock.InvalidatorsForTestingOnly()))
 	require.Equal(t, 0, len(parentBlock.EntriesForTestingOnly()))
 
-	txn, err := parentBlock.NewTransactionDerivedData(0, 0)
+	txn, err := parentBlock.NewTableTransaction(0, 0)
 	require.NoError(t, err)
 
 	txn.AddInvalidator(testInvalidator{invalidateAll: true})
@@ -770,7 +770,7 @@ func TestBlockDerivedDataNewChildDerivedBlockData(t *testing.T) {
 	err = txn.Commit()
 	require.NoError(t, err)
 
-	txn, err = parentBlock.NewTransactionDerivedData(1, 1)
+	txn, err = parentBlock.NewTableTransaction(1, 1)
 	require.NoError(t, err)
 
 	key := "foo bar"
@@ -803,7 +803,7 @@ func TestBlockDerivedDataNewChildDerivedBlockData(t *testing.T) {
 
 	// Verify child is correctly initialized
 
-	childBlock := parentBlock.NewChildBlockDerivedData()
+	childBlock := parentBlock.NewChildTable()
 
 	require.Equal(
 		t,
@@ -846,7 +846,7 @@ func (computer *testValueComputer) Compute(
 }
 
 func TestTxnDerivedDataGetOrCompute(t *testing.T) {
-	blockDerivedData := NewEmptyBlockDerivedData[string, int]()
+	blockDerivedData := NewEmptyTable[string, int]()
 
 	key := "key"
 	value := 12345
@@ -855,7 +855,7 @@ func TestTxnDerivedDataGetOrCompute(t *testing.T) {
 		view := utils.NewSimpleView()
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 
-		txnDerivedData, err := blockDerivedData.NewTransactionDerivedData(0, 0)
+		txnDerivedData, err := blockDerivedData.NewTableTransaction(0, 0)
 		assert.Nil(t, err)
 
 		computer := &testValueComputer{value: value}
@@ -875,7 +875,7 @@ func TestTxnDerivedDataGetOrCompute(t *testing.T) {
 		view := utils.NewSimpleView()
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 
-		txnDerivedData, err := blockDerivedData.NewTransactionDerivedData(1, 1)
+		txnDerivedData, err := blockDerivedData.NewTableTransaction(1, 1)
 		assert.Nil(t, err)
 
 		computer := &testValueComputer{value: value}


### PR DESCRIPTION
It's confusing to have both BlockDerivedData (single table) vs DerivedBlockData (full database).  Renamed table related structs/method to reduce confusion.

gh: #3102