### PR TITLE
[Execution] Break blobservice out to own component in en builder

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -424,6 +424,10 @@ func (exeNode *ExecutionNode) LoadProviderEngine(
 	module.ReadyDoneAware,
 	error,
 ) {
+	if exeNode.blobService == nil {
+		return nil, errors.New("blob service is not initialized")
+	}
+
 	var providerMetrics module.ExecutionDataProviderMetrics = metrics.NewNoopCollector()
 	if node.MetricsEnabled {
 		providerMetrics = metrics.NewExecutionDataProviderCollector()

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -191,9 +191,10 @@ func (builder *ExecutionNodeBuilder) LoadComponentsAndModules() {
 		Component("stop control", exeNode.LoadStopControl).
 		Component("execution state ledger WAL compactor", exeNode.LoadExecutionStateLedgerWALCompactor).
 		Component("execution data pruner", exeNode.LoadExecutionDataPruner).
-		Component("provider engine", exeNode.LoadProviderEngine).
+		Component("blob service", exeNode.LoadBlobService).
 		Component("GCP block data uploader", exeNode.LoadGCPBlockDataUploader).
 		Component("S3 block data uploader", exeNode.LoadS3BlockDataUploader).
+		Component("provider engine", exeNode.LoadProviderEngine).
 		Component("checker engine", exeNode.LoadCheckerEngine).
 		Component("ingestion engine", exeNode.LoadIngestionEngine).
 		Component("follower engine", exeNode.LoadFollowerEngine).
@@ -254,6 +255,67 @@ func (exeNode *ExecutionNode) LoadExecutionReceiptsStorage(
 func (exeNode *ExecutionNode) LoadPendingBlockCache(node *NodeConfig) error {
 	exeNode.pendingBlocks = buffer.NewPendingBlocks() // for following main chain consensus
 	return nil
+}
+
+func (exeNode *ExecutionNode) LoadBlobService(
+	node *NodeConfig,
+) (
+	module.ReadyDoneAware,
+	error,
+) {
+	// build list of Access nodes that are allowed to request execution data from this node
+	var allowedANs map[flow.Identifier]bool
+	if exeNode.exeConf.executionDataAllowedPeers != "" {
+		ids := strings.Split(exeNode.exeConf.executionDataAllowedPeers, ",")
+		allowedANs = make(map[flow.Identifier]bool, len(ids))
+		for _, idHex := range ids {
+			anID, err := flow.HexStringToIdentifier(idHex)
+			if err != nil {
+				return nil, fmt.Errorf("invalid node ID %s: %w", idHex, err)
+			}
+
+			id, ok := exeNode.builder.IdentityProvider.ByNodeID(anID)
+			if !ok {
+				return nil, fmt.Errorf("allowed node ID %s is not in identity list", idHex)
+			}
+
+			if id.Role != flow.RoleAccess {
+				return nil, fmt.Errorf("allowed node ID %s is not an access node", id.NodeID.String())
+			}
+
+			if id.Ejected {
+				return nil, fmt.Errorf("allowed node ID %s is ejected", id.NodeID.String())
+			}
+
+			allowedANs[anID] = true
+		}
+	}
+
+	opts := []network.BlobServiceOption{
+		blob.WithBitswapOptions(
+			// Only allow block requests from staked ENs and ANs on the allowedANs list (if set)
+			bitswap.WithPeerBlockRequestFilter(
+				blob.AuthorizedRequester(allowedANs, exeNode.builder.IdentityProvider, exeNode.builder.Logger),
+			),
+		),
+	}
+
+	if exeNode.exeConf.blobstoreRateLimit > 0 && exeNode.exeConf.blobstoreBurstLimit > 0 {
+		opts = append(opts, blob.WithRateLimit(float64(exeNode.exeConf.blobstoreRateLimit), exeNode.exeConf.blobstoreBurstLimit))
+	}
+
+	bs, err := node.Network.RegisterBlobService(channels.ExecutionDataService, exeNode.executionDataDatastore, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register blob service: %w", err)
+	}
+	exeNode.blobService = bs
+
+	// add blobservice into ReadyDoneAware dependency passed to peer manager
+	// this configures peer manager to wait for the blobservice to be ready before starting
+	exeNode.blobserviceDependable.Init(bs)
+
+	// blob service's lifecycle is managed by the network layer
+	return &module.NoopReadyDoneAware{}, nil
 }
 
 func (exeNode *ExecutionNode) LoadGCPBlockDataUploader(
@@ -359,60 +421,6 @@ func (exeNode *ExecutionNode) LoadProviderEngine(
 	module.ReadyDoneAware,
 	error,
 ) {
-	// build list of Access nodes that are allowed to request execution data from this node
-	var allowedANs map[flow.Identifier]bool
-	if exeNode.exeConf.executionDataAllowedPeers != "" {
-		ids := strings.Split(exeNode.exeConf.executionDataAllowedPeers, ",")
-		allowedANs = make(map[flow.Identifier]bool, len(ids))
-		for _, idHex := range ids {
-			anID, err := flow.HexStringToIdentifier(idHex)
-			if err != nil {
-				return nil, fmt.Errorf("invalid node ID %s: %w", idHex, err)
-			}
-
-			id, ok := exeNode.builder.IdentityProvider.ByNodeID(anID)
-			if !ok {
-				return nil, fmt.Errorf("allowed node ID %s is not in identity list", idHex)
-			}
-
-			if id.Role != flow.RoleAccess {
-				return nil, fmt.Errorf("allowed node ID %s is not an access node", id.NodeID.String())
-			}
-
-			if id.Ejected {
-				return nil, fmt.Errorf("allowed node ID %s is ejected", id.NodeID.String())
-			}
-
-			allowedANs[anID] = true
-		}
-	}
-
-	opts := []network.BlobServiceOption{
-		blob.WithBitswapOptions(
-			// Only allow block requests from staked ENs and ANs on the allowedANs list (if set)
-			bitswap.WithPeerBlockRequestFilter(
-				blob.AuthorizedRequester(allowedANs, exeNode.builder.IdentityProvider, exeNode.builder.Logger),
-			),
-			bitswap.WithTracer(
-				blob.NewTracer(node.Logger.With().Str("blob_service", channels.ExecutionDataService.String()).Logger()),
-			),
-		),
-	}
-
-	if exeNode.exeConf.blobstoreRateLimit > 0 && exeNode.exeConf.blobstoreBurstLimit > 0 {
-		opts = append(opts, blob.WithRateLimit(float64(exeNode.exeConf.blobstoreRateLimit), exeNode.exeConf.blobstoreBurstLimit))
-	}
-
-	bs, err := node.Network.RegisterBlobService(channels.ExecutionDataService, exeNode.executionDataDatastore, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to register blob service: %w", err)
-	}
-	exeNode.blobService = bs
-
-	// add blobservice into ReadyDoneAware dependency passed to peer manager
-	// this configures peer manager to wait for the blobservice to be ready before starting
-	exeNode.blobserviceDependable.Init(bs)
-
 	var providerMetrics module.ExecutionDataProviderMetrics = metrics.NewNoopCollector()
 	if node.MetricsEnabled {
 		providerMetrics = metrics.NewExecutionDataProviderCollector()
@@ -422,7 +430,7 @@ func (exeNode *ExecutionNode) LoadProviderEngine(
 		node.Logger,
 		providerMetrics,
 		execution_data.DefaultSerializer,
-		bs,
+		exeNode.blobService,
 		exeNode.executionDataTracker,
 	)
 

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -297,6 +297,9 @@ func (exeNode *ExecutionNode) LoadBlobService(
 			bitswap.WithPeerBlockRequestFilter(
 				blob.AuthorizedRequester(allowedANs, exeNode.builder.IdentityProvider, exeNode.builder.Logger),
 			),
+			bitswap.WithTracer(
+				blob.NewTracer(node.Logger.With().Str("blob_service", channels.ExecutionDataService.String()).Logger()),
+			),
 		),
 	}
 


### PR DESCRIPTION
Backports https://github.com/onflow/flow-go/pull/3497 from v0.28 to master

This fixes the initialization order of the blobservice and uploaders in the execution node builder. Blobservice is needed by both the provider engine and GCP uploader, and the uploaders are also needed by the provider