### PR TITLE
[Profiler] Start profiler asynchronously

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -313,6 +313,12 @@ type DependencyList struct {
 	components []module.ReadyDoneAware
 }
 
+func NewDependencyList(components ...module.ReadyDoneAware) *DependencyList {
+	return &DependencyList{
+		components: components,
+	}
+}
+
 // Add adds a new ReadyDoneAware implementation to the list of dependencies.
 func (d *DependencyList) Add(component module.ReadyDoneAware) {
 	d.components = append(d.components, component)

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -711,7 +711,7 @@ func (fnb *FlowNodeBuilder) initProfiler() {
 			func() uint { return uint(runtime.MemProfileRate) },
 			func(r uint) error { runtime.MemProfileRate = int(r); return nil }),
 	).Msg("could not register profiler setting")
-	// There is no way to get the current block progile rate so we keep track of it ourselves.
+	// There is no way to get the current block profile rate so we keep track of it ourselves.
 	currentRate := new(uint)
 	fnb.MustNot(
 		fnb.ConfigManager.RegisterUintConfig(
@@ -726,9 +726,10 @@ func (fnb *FlowNodeBuilder) initProfiler() {
 			func(r uint) error { _ = runtime.SetMutexProfileFraction(int(r)); return nil }),
 	).Msg("could not register profiler setting")
 
-	fnb.Component("profiler", func(node *NodeConfig) (module.ReadyDoneAware, error) {
+	// registering as a DependableComponent with no dependencies so that it's started immediately on startup
+	fnb.DependableComponent("profiler", func(node *NodeConfig) (module.ReadyDoneAware, error) {
 		return profiler, nil
-	})
+	}, NewDependencyList())
 }
 
 func (fnb *FlowNodeBuilder) initDB() {
@@ -1113,7 +1114,7 @@ func (fnb *FlowNodeBuilder) handleComponents() error {
 	// Run all components
 	for _, f := range fnb.components {
 		// Components with explicit dependencies are not started serially
-		if f.dependencies != nil && len(f.dependencies.components) > 0 {
+		if f.dependencies != nil {
 			asyncComponents = append(asyncComponents, f)
 			continue
 		}
@@ -1336,6 +1337,8 @@ func (fnb *FlowNodeBuilder) Component(name string, f ReadyDoneFactory) NodeBuild
 // dependencies must be initialized outside of the ReadyDoneFactory, and their `Ready()` method
 // MUST be idempotent.
 func (fnb *FlowNodeBuilder) DependableComponent(name string, f ReadyDoneFactory, dependencies *DependencyList) NodeBuilder {
+	// Note: dependencies are passed as a struct to allow updating the list after calling this method.
+	// Passing a slice instead would result in out of sync metadata since slices are passed by reference
 	fnb.components = append(fnb.components, namedComponentFunc{
 		fn:           f,
 		name:         name,
@@ -1486,7 +1489,7 @@ func FlowNode(role string, opts ...Option) *FlowNodeBuilder {
 		NodeConfig: &NodeConfig{
 			BaseConfig:              *config,
 			Logger:                  zerolog.New(os.Stderr),
-			PeerManagerDependencies: &DependencyList{},
+			PeerManagerDependencies: NewDependencyList(),
 			ConfigManager:           updatable_configs.NewManager(),
 		},
 		flags:                    pflag.CommandLine,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -727,6 +727,7 @@ func (fnb *FlowNodeBuilder) initProfiler() {
 	).Msg("could not register profiler setting")
 
 	// registering as a DependableComponent with no dependencies so that it's started immediately on startup
+	// without being blocked by other component's Ready()
 	fnb.DependableComponent("profiler", func(node *NodeConfig) (module.ReadyDoneAware, error) {
 		return profiler, nil
 	}, NewDependencyList())

--- a/module/util/util.go
+++ b/module/util/util.go
@@ -35,6 +35,11 @@ func AllDone(components ...module.ReadyDoneAware) <-chan struct{} {
 // AllClosed returns a channel that is closed when all input channels are closed.
 func AllClosed(channels ...<-chan struct{}) <-chan struct{} {
 	done := make(chan struct{})
+	if len(channels) == 0 {
+		close(done)
+		return done
+	}
+
 	var wg sync.WaitGroup
 
 	for _, ch := range channels {


### PR DESCRIPTION
This is a revision of https://github.com/onflow/flow-go/pull/3503 which updated `scaffold.go` to start the profiler as one of the first components. Due to changes needed for the admin command, this PR changes the implementation to use `DependableComponent` so the profiler will start asynchronously.

Before this PR, the profiler was started as a `Component` that was added after all other node specific components. This meant that the profiler would delay startup until after all other components were loaded. On nodes that perform a lot of startup logic like execution nodes, the profiler would not be able to capture any of that data.