### PR TITLE
[Execution] Disable block uploads by default

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -301,6 +301,8 @@ func (exeNode *ExecutionNode) LoadGCPBlockDataUploader(
 
 		exeNode.blockDataUploaders = append(exeNode.blockDataUploaders, retryableUploader)
 
+		computation.SetUploaderEnabled(true)
+
 		return retryableUploader, nil
 	}
 
@@ -343,6 +345,8 @@ func (exeNode *ExecutionNode) LoadS3BlockDataUploader(
 		// We are not enabling RetryableUploader for S3 uploader for now. When we need upload
 		// retry for multiple uploaders, we will need to use different BadgerDB key prefix.
 		exeNode.blockDataUploaders = append(exeNode.blockDataUploaders, asyncUploader)
+
+		computation.SetUploaderEnabled(true)
 
 		return asyncUploader, nil
 	}

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -41,7 +41,7 @@ const (
 	ReusableCadenceRuntimePoolSize = 1000
 )
 
-var uploadEnabled = true
+var uploadEnabled = false
 
 func SetUploaderEnabled(enabled bool) {
 	uploadEnabled = enabled

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -200,6 +200,9 @@ func TestComputeBlock_Uploader(t *testing.T) {
 		tracer:           trace.NewNoopTracer(),
 	}
 
+	SetUploaderEnabled(true)
+	defer SetUploaderEnabled(false)
+
 	view := delta.NewView(state2.LedgerGetRegister(ledger, flow.StateCommitment(ledger.InitialState())))
 	blockView := view.NewChild()
 


### PR DESCRIPTION
Backports github.com/onflow/flow-go/pull/3504 and https://github.com/onflow/flow-go/pull/3518 from `v0.28`

Currently, the uploader is enabled by default on all nodes, and only skipped because there are no configured uploaders. This causes nodes that don't have uploads enabled to check all blocks in their dbs for blocks to upload