### PR TITLE
[Access] Remove unused builder options

### DIFF
--- a/cmd/access/main.go
+++ b/cmd/access/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"github.com/onflow/flow-go/cmd"
 	nodebuilder "github.com/onflow/flow-go/cmd/access/node_builder"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func main() {
-	builder := nodebuilder.FlowAccessNode() // use the Access Node builder
+	builder := nodebuilder.FlowAccessNode(cmd.FlowNode(flow.RoleAccess.String()))
 
 	builder.PrintBuildVersionDetails()
 

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -117,7 +117,6 @@ type AccessNodeConfig struct {
 	executionDataDir             string
 	executionDataStartHeight     uint64
 	executionDataConfig          edrequester.ExecutionDataConfig
-	baseOptions                  []cmd.Option
 
 	PublicNetworkConfig PublicNetworkConfig
 }
@@ -523,17 +522,10 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 	return builder
 }
 
-type Option func(*AccessNodeConfig)
-
-func FlowAccessNode(opts ...Option) *FlowAccessNodeBuilder {
-	config := DefaultAccessNodeConfig()
-	for _, opt := range opts {
-		opt(config)
-	}
-
+func FlowAccessNode(nodeBuilder *cmd.FlowNodeBuilder) *FlowAccessNodeBuilder {
 	return &FlowAccessNodeBuilder{
-		AccessNodeConfig:        config,
-		FlowNodeBuilder:         cmd.FlowNode(flow.RoleAccess.String(), config.baseOptions...),
+		AccessNodeConfig:        DefaultAccessNodeConfig(),
+		FlowNodeBuilder:         nodeBuilder,
 		FinalizationDistributor: consensuspubsub.NewFinalizationDistributor(),
 	}
 }


### PR DESCRIPTION
The access node builder options were leftover from when the consensus follower library instantiated an AN. That has since been refactored, so this can now be simplified. Adjust the setup to align with the execution and verification nodes.