### PR TITLE
Update Epoch Collection Node Join/Leave Integration Test

### DIFF
--- a/integration/tests/epochs/epoch_join_and_leave_ln_test.go
+++ b/integration/tests/epochs/epoch_join_and_leave_ln_test.go
@@ -6,11 +6,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestEpochJoinAndLeaveLN(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "epochs join/leave tests should be run on an machine with adequate resources")
 	suite.Run(t, new(EpochJoinAndLeaveLNSuite))
 }
 

--- a/integration/tests/epochs/epoch_static_transition_test.go
+++ b/integration/tests/epochs/epoch_static_transition_test.go
@@ -7,11 +7,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestEpochStaticTransition(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "epochs join/leave tests should be run on an machine with adequate resources")
 	suite.Run(t, new(StaticEpochTransitionSuite))
 }
 

--- a/module/epochs.go
+++ b/module/epochs.go
@@ -16,7 +16,7 @@ type ClusterRootQCVoter interface {
 	// smart contract, and verifying submission. It is safe to run Vote multiple
 	// times within a single setup phase.
 	// Error returns:
-	//   - epochs.ErrWontVote if we fail to vote for a benign reason
+	//   - epochs.ClusterQCNoVoteError if we fail to vote for a benign reason
 	//   - generic error in case of critical unexpected failure
 	Vote(context.Context, protocol.Epoch) error
 }

--- a/module/epochs/qc_voter.go
+++ b/module/epochs/qc_voter.go
@@ -90,7 +90,8 @@ func (voter *RootQCVoter) Vote(ctx context.Context, epoch protocol.Epoch) error 
 	}
 	cluster, clusterIndex, ok := clusters.ByNodeID(voter.me.NodeID())
 	if !ok {
-		return fmt.Errorf("could not find self in clustering")
+		voter.log.Warn().Msgf("could not find self in clustering: %s", clusters.Assignments())
+		return NewClusterQCNoVoteErrorf("could not find self in clustering")
 	}
 
 	log := voter.log.With().

--- a/module/epochs/qc_voter.go
+++ b/module/epochs/qc_voter.go
@@ -90,7 +90,6 @@ func (voter *RootQCVoter) Vote(ctx context.Context, epoch protocol.Epoch) error 
 	}
 	cluster, clusterIndex, ok := clusters.ByNodeID(voter.me.NodeID())
 	if !ok {
-		voter.log.Warn().Msgf("could not find self in clustering: %s", clusters.Assignments())
 		return NewClusterQCNoVoteErrorf("could not find self in clustering")
 	}
 

--- a/module/epochs/qc_voter_test.go
+++ b/module/epochs/qc_voter_test.go
@@ -2,7 +2,6 @@ package epochs_test
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"math/rand"
 	"testing"
@@ -78,7 +77,7 @@ func (suite *Suite) SetupTest() {
 	var err error
 	assignments := unittest.ClusterAssignment(2, suite.nodes)
 	suite.clustering, err = factory.NewClusterList(assignments, suite.nodes)
-	suite.Require().Nil(err)
+	suite.Require().NoError(err)
 
 	suite.epoch.On("Counter").Return(suite.counter, nil)
 	suite.epoch.On("Clustering").Return(suite.clustering, nil)
@@ -97,8 +96,8 @@ func (suite *Suite) TestNonClusterParticipant() {
 	// change our identity so we aren't in the cluster assignment
 	suite.me = unittest.IdentityFixture(unittest.WithRole(flow.RoleCollection))
 	err := suite.voter.Vote(context.Background(), suite.epoch)
-	fmt.Println(err)
 	suite.Assert().Error(err)
+	suite.Assert().True(epochs.IsClusterQCNoVoteError(err))
 }
 
 // should fail if we are not in setup phase
@@ -106,8 +105,8 @@ func (suite *Suite) TestInvalidPhase() {
 
 	suite.phase = flow.EpochPhaseStaking
 	err := suite.voter.Vote(context.Background(), suite.epoch)
-	fmt.Println(err)
 	suite.Assert().Error(err)
+	suite.Assert().True(epochs.IsClusterQCNoVoteError(err))
 }
 
 // should succeed and exit if we've already voted
@@ -115,12 +114,11 @@ func (suite *Suite) TestAlreadyVoted() {
 
 	suite.voted = true
 	err := suite.voter.Vote(context.Background(), suite.epoch)
-	fmt.Println(err)
-	suite.Assert().Nil(err)
+	suite.Assert().NoError(err)
 }
 
 // should succeed and exit if voting succeeds
 func (suite *Suite) TestVoting() {
 	err := suite.voter.Vote(context.Background(), suite.epoch)
-	suite.Assert().Nil(err)
+	suite.Assert().NoError(err)
 }


### PR DESCRIPTION
This PR updates and re-enables the `TestEpochStaticTransition` and `TestEpochJoinAndLeaveLN` integration tests.
* The static test was already passing and required no changes
* The LN test was failing due to an unhandled error when a node submits a vote in the epoch before it leaves the network
  * This is fixed by returning the appropriate error type in this case
  * Also updates the relevant unit tests to check for the error type
  * Created an issue for another scenario which arises in this test case, but doesn't impact the test result https://github.com/dapperlabs/flow-go/issues/6435