### PR TITLE
Only read and write checkpoint in v6

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -631,10 +631,6 @@ func (exeNode *ExecutionNode) LoadExecutionStateLedger(
 		return nil, fmt.Errorf("failed to initialize wal: %w", err)
 	}
 
-	if exeNode.exeConf.outputCheckpointV5 {
-		exeNode.diskWAL.UseCheckpointVersion5()
-	}
-
 	exeNode.ledgerStorage, err = ledger.NewLedger(exeNode.diskWAL, int(exeNode.exeConf.mTrieCacheSize), exeNode.collector, node.Logger.With().Str("subcomponent",
 		"ledger").Logger(), ledger.DefaultPathFinderVersion)
 	return exeNode.ledgerStorage, err

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -29,7 +29,6 @@ type ExecutionConfig struct {
 	transactionResultsCacheSize          uint
 	checkpointDistance                   uint
 	checkpointsToKeep                    uint
-	outputCheckpointV5                   bool
 	stateDeltasLimit                     uint
 	chunkDataPackCacheSize               uint
 	chunkDataPackRequestsCacheSize       uint32
@@ -70,7 +69,6 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.Uint32Var(&exeConf.mTrieCacheSize, "mtrie-cache-size", 500, "cache size for MTrie")
 	flags.UintVar(&exeConf.checkpointDistance, "checkpoint-distance", 20, "number of WAL segments between checkpoints")
 	flags.UintVar(&exeConf.checkpointsToKeep, "checkpoints-to-keep", 5, "number of recent checkpoints to keep (0 to keep all)")
-	flags.BoolVar(&exeConf.outputCheckpointV5, "outputCheckpointV5", false, "output checkpoint file in v5")
 	flags.UintVar(&exeConf.stateDeltasLimit, "state-deltas-limit", 100, "maximum number of state deltas in the memory pool")
 	flags.UintVar(&exeConf.computationConfig.DerivedDataCacheSize, "cadence-execution-cache", programs.DefaultDerivedDataCacheSize,
 		"cache size for Cadence execution")

--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -134,9 +134,10 @@ func run(*cobra.Command, []string) {
 		}
 	}
 
-	log.Info().Msgf("Extracting state from %s, exporting root checkpoint to %s, version: 6",
+	log.Info().Msgf("Extracting state from %s, exporting root checkpoint to %s, version: %v",
 		flagExecutionStateDir,
 		path.Join(flagOutputDir, bootstrap.FilenameWALRootCheckpoint),
+		6,
 	)
 
 	log.Info().Msgf("Block state commitment: %s from %v, output dir: %s",

--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -26,7 +26,6 @@ var (
 	flagChain             string
 	flagNoMigration       bool
 	flagNoReport          bool
-	flagVersion           int
 )
 
 func getChain(chainName string) (chain flow.Chain, err error) {
@@ -71,8 +70,6 @@ func init() {
 
 	Cmd.Flags().BoolVar(&flagNoReport, "no-report", false,
 		"don't report the state")
-
-	Cmd.Flags().IntVar(&flagVersion, "version", 6, "checkpoint version")
 }
 
 func run(*cobra.Command, []string) {
@@ -137,10 +134,10 @@ func run(*cobra.Command, []string) {
 		}
 	}
 
-	log.Info().Msgf("Extracting state from %s, exporting root checkpoint to %s, version: %v",
+	log.Info().Msgf("Extracting state from %s, exporting root checkpoint to %s, version: 6",
 		flagExecutionStateDir,
 		path.Join(flagOutputDir, bootstrap.FilenameWALRootCheckpoint),
-		flagVersion)
+	)
 
 	log.Info().Msgf("Block state commitment: %s from %v, output dir: %s",
 		hex.EncodeToString(stateCommitment[:]),
@@ -163,7 +160,6 @@ func run(*cobra.Command, []string) {
 		flagOutputDir,
 		log.Logger,
 		chain,
-		flagVersion,
 		!flagNoMigration,
 		!flagNoReport,
 	)

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -28,7 +28,6 @@ func extractExecutionState(
 	outputDir string,
 	log zerolog.Logger,
 	chain flow.Chain,
-	version int, // to be removed after next spork
 	migrate bool,
 	report bool,
 ) error {
@@ -125,7 +124,6 @@ func extractExecutionState(
 		complete.DefaultPathFinderVersion,
 		outputDir,
 		bootstrap.FilenameWALRootCheckpoint,
-		version,
 	)
 	if err != nil {
 		return fmt.Errorf("cannot generate the output checkpoint: %w", err)

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -65,7 +65,6 @@ func TestExtractExecutionState(t *testing.T) {
 				outdir,
 				zerolog.Nop(),
 				flow.Emulator.Chain(),
-				6,
 				false,
 				false,
 			)

--- a/ledger/complete/compactor.go
+++ b/ledger/complete/compactor.go
@@ -332,7 +332,7 @@ func createCheckpoint(checkpointer *realWAL.Checkpointer, logger zerolog.Logger,
 	startTime := time.Now()
 
 	fileName := realWAL.NumberToFilename(checkpointNum)
-	err := realWAL.StoreCheckpointByVersion(checkpointer.OutputVersion(), tries, checkpointer.Dir(), fileName, &logger)
+	err := realWAL.StoreCheckpointV6SingleThread(tries, checkpointer.Dir(), fileName, &logger)
 	if err != nil {
 		return fmt.Errorf("error serializing checkpoint (%d): %w", checkpointNum, err)
 	}

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -336,7 +336,6 @@ func (l *Ledger) ExportCheckpointAt(
 	postCheckpointReporters []ledger.Reporter,
 	targetPathFinderVersion uint8,
 	outputDir, outputFile string,
-	version int,
 ) (ledger.State, error) {
 
 	l.logger.Info().Msgf(
@@ -448,14 +447,7 @@ func (l *Ledger) ExportCheckpointAt(
 		return ledger.State(hash.DummyHash), fmt.Errorf("could not create output dir %s: %w", outputDir, err)
 	}
 
-	switch version {
-	case 5:
-		err = realWAL.StoreCheckpointV5(outputDir, outputFile, &l.logger, newTrie)
-	case 6:
-		err = realWAL.StoreCheckpointV6Concurrently([]*trie.MTrie{newTrie}, outputDir, outputFile, &l.logger)
-	default:
-		return ledger.State(hash.DummyHash), fmt.Errorf("invalid version:%v", version)
-	}
+	err = realWAL.StoreCheckpointV6Concurrently([]*trie.MTrie{newTrie}, outputDir, outputFile, &l.logger)
 
 	// Writing the checkpoint takes time to write and copy.
 	// Without relying on an exit code or stdout, we need to know when the copy is complete.

--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -706,179 +706,177 @@ func TestLedgerFunctionality(t *testing.T) {
 }
 
 func Test_ExportCheckpointAt(t *testing.T) {
-	for _, version := range []int{6} {
-		t.Run(fmt.Sprintf("noop migration version %v", version), func(t *testing.T) {
-			// the exported state has two key/value pairs
-			// (/1/1/22/2, "A") and (/1/3/22/4, "B")
-			// this tests the migration at the specific state
-			// without any special migration so we expect both
-			// register to show up in the new trie and with the same values
-			unittest.RunWithTempDir(t, func(dbDir string) {
-				unittest.RunWithTempDir(t, func(dir2 string) {
+	t.Run("noop migration", func(t *testing.T) {
+		// the exported state has two key/value pairs
+		// (/1/1/22/2, "A") and (/1/3/22/4, "B")
+		// this tests the migration at the specific state
+		// without any special migration so we expect both
+		// register to show up in the new trie and with the same values
+		unittest.RunWithTempDir(t, func(dbDir string) {
+			unittest.RunWithTempDir(t, func(dir2 string) {
 
-					const (
-						capacity           = 100
-						checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
-						checkpointsToKeep  = 1
-					)
+				const (
+					capacity           = 100
+					checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
+					checkpointsToKeep  = 1
+				)
 
-					diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dbDir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
-					require.NoError(t, err)
-					led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
-					require.NoError(t, err)
-					compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
-					require.NoError(t, err)
-					<-compactor.Ready()
+				diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dbDir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
+				require.NoError(t, err)
+				led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
+				require.NoError(t, err)
+				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
+				require.NoError(t, err)
+				<-compactor.Ready()
 
-					state := led.InitialState()
-					u := testutils.UpdateFixture()
-					u.SetState(state)
+				state := led.InitialState()
+				u := testutils.UpdateFixture()
+				u.SetState(state)
 
-					state, _, err = led.Set(u)
-					require.NoError(t, err)
+				state, _, err = led.Set(u)
+				require.NoError(t, err)
 
-					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{noOpMigration}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
-					require.NoError(t, err)
-					assert.Equal(t, newState, state)
+				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{noOpMigration}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
+				require.NoError(t, err)
+				assert.Equal(t, newState, state)
 
-					diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
-					require.NoError(t, err)
-					led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
-					require.NoError(t, err)
-					compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
-					require.NoError(t, err)
-					<-compactor2.Ready()
+				diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
+				require.NoError(t, err)
+				led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
+				require.NoError(t, err)
+				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
+				require.NoError(t, err)
+				<-compactor2.Ready()
 
-					q, err := ledger.NewQuery(state, u.Keys())
-					require.NoError(t, err)
+				q, err := ledger.NewQuery(state, u.Keys())
+				require.NoError(t, err)
 
-					retValues, err := led2.Get(q)
-					require.NoError(t, err)
+				retValues, err := led2.Get(q)
+				require.NoError(t, err)
 
-					for i, v := range u.Values() {
-						assert.Equal(t, v, retValues[i])
-					}
+				for i, v := range u.Values() {
+					assert.Equal(t, v, retValues[i])
+				}
 
-					<-led.Done()
-					<-compactor.Done()
-					<-led2.Done()
-					<-compactor2.Done()
-				})
+				<-led.Done()
+				<-compactor.Done()
+				<-led2.Done()
+				<-compactor2.Done()
 			})
 		})
-		t.Run(fmt.Sprintf("migration by value: version %v", version), func(t *testing.T) {
-			// the exported state has two key/value pairs
-			// ("/1/1/22/2", "A") and ("/1/3/22/4", "B")
-			// during the migration we change all keys with value "A" to "C"
-			// so in this case the resulting exported trie is ("/1/1/22/2", "C"), ("/1/3/22/4", "B")
-			unittest.RunWithTempDir(t, func(dbDir string) {
-				unittest.RunWithTempDir(t, func(dir2 string) {
+	})
+	t.Run("migration by value", func(t *testing.T) {
+		// the exported state has two key/value pairs
+		// ("/1/1/22/2", "A") and ("/1/3/22/4", "B")
+		// during the migration we change all keys with value "A" to "C"
+		// so in this case the resulting exported trie is ("/1/1/22/2", "C"), ("/1/3/22/4", "B")
+		unittest.RunWithTempDir(t, func(dbDir string) {
+			unittest.RunWithTempDir(t, func(dir2 string) {
 
-					const (
-						capacity           = 100
-						checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
-						checkpointsToKeep  = 1
-					)
+				const (
+					capacity           = 100
+					checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
+					checkpointsToKeep  = 1
+				)
 
-					diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dbDir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
-					require.NoError(t, err)
-					led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
-					require.NoError(t, err)
-					compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
-					require.NoError(t, err)
-					<-compactor.Ready()
+				diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dbDir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
+				require.NoError(t, err)
+				led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
+				require.NoError(t, err)
+				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
+				require.NoError(t, err)
+				<-compactor.Ready()
 
-					state := led.InitialState()
-					u := testutils.UpdateFixture()
-					u.SetState(state)
+				state := led.InitialState()
+				u := testutils.UpdateFixture()
+				u.SetState(state)
 
-					state, _, err = led.Set(u)
-					require.NoError(t, err)
+				state, _, err = led.Set(u)
+				require.NoError(t, err)
 
-					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByValue}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
-					require.NoError(t, err)
+				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByValue}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
+				require.NoError(t, err)
 
-					diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
-					require.NoError(t, err)
-					led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
-					require.NoError(t, err)
-					compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
-					require.NoError(t, err)
-					<-compactor2.Ready()
+				diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
+				require.NoError(t, err)
+				led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
+				require.NoError(t, err)
+				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
+				require.NoError(t, err)
+				<-compactor2.Ready()
 
-					q, err := ledger.NewQuery(newState, u.Keys())
-					require.NoError(t, err)
+				q, err := ledger.NewQuery(newState, u.Keys())
+				require.NoError(t, err)
 
-					retValues, err := led2.Get(q)
-					require.NoError(t, err)
+				retValues, err := led2.Get(q)
+				require.NoError(t, err)
 
-					assert.Equal(t, retValues[0], ledger.Value([]byte{'C'}))
-					assert.Equal(t, retValues[1], ledger.Value([]byte{'B'}))
+				assert.Equal(t, retValues[0], ledger.Value([]byte{'C'}))
+				assert.Equal(t, retValues[1], ledger.Value([]byte{'B'}))
 
-					<-led.Done()
-					<-compactor.Done()
-					<-led2.Done()
-					<-compactor2.Done()
-				})
+				<-led.Done()
+				<-compactor.Done()
+				<-led2.Done()
+				<-compactor2.Done()
 			})
 		})
-		t.Run(fmt.Sprintf("migration by key: version %v", version), func(t *testing.T) {
-			// the exported state has two key/value pairs
-			// ("/1/1/22/2", "A") and ("/1/3/22/4", "B")
-			// during the migration we change the value to "D" for key "zero"
-			// so in this case the resulting exported trie is ("/1/1/22/2", "D"), ("/1/3/22/4", "B")
-			unittest.RunWithTempDir(t, func(dbDir string) {
-				unittest.RunWithTempDir(t, func(dir2 string) {
+	})
+	t.Run("migration by key", func(t *testing.T) {
+		// the exported state has two key/value pairs
+		// ("/1/1/22/2", "A") and ("/1/3/22/4", "B")
+		// during the migration we change the value to "D" for key "zero"
+		// so in this case the resulting exported trie is ("/1/1/22/2", "D"), ("/1/3/22/4", "B")
+		unittest.RunWithTempDir(t, func(dbDir string) {
+			unittest.RunWithTempDir(t, func(dir2 string) {
 
-					const (
-						capacity           = 100
-						checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
-						checkpointsToKeep  = 1
-					)
+				const (
+					capacity           = 100
+					checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
+					checkpointsToKeep  = 1
+				)
 
-					diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dbDir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
-					require.NoError(t, err)
-					led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
-					require.NoError(t, err)
-					compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
-					require.NoError(t, err)
-					<-compactor.Ready()
+				diskWal, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dbDir, capacity, pathfinder.PathByteSize, wal.SegmentSize)
+				require.NoError(t, err)
+				led, err := complete.NewLedger(diskWal, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
+				require.NoError(t, err)
+				compactor, err := complete.NewCompactor(led, diskWal, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
+				require.NoError(t, err)
+				<-compactor.Ready()
 
-					state := led.InitialState()
-					u := testutils.UpdateFixture()
-					u.SetState(state)
+				state := led.InitialState()
+				u := testutils.UpdateFixture()
+				u.SetState(state)
 
-					state, _, err = led.Set(u)
-					require.NoError(t, err)
+				state, _, err = led.Set(u)
+				require.NoError(t, err)
 
-					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByKey}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
-					require.NoError(t, err)
+				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByKey}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
+				require.NoError(t, err)
 
-					diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
-					require.NoError(t, err)
-					led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
-					require.NoError(t, err)
-					compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
-					require.NoError(t, err)
-					<-compactor2.Ready()
+				diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
+				require.NoError(t, err)
+				led2, err := complete.NewLedger(diskWal2, capacity, &metrics.NoopCollector{}, zerolog.Logger{}, complete.DefaultPathFinderVersion)
+				require.NoError(t, err)
+				compactor2, err := complete.NewCompactor(led2, diskWal2, zerolog.Nop(), capacity, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
+				require.NoError(t, err)
+				<-compactor2.Ready()
 
-					q, err := ledger.NewQuery(newState, u.Keys())
-					require.NoError(t, err)
+				q, err := ledger.NewQuery(newState, u.Keys())
+				require.NoError(t, err)
 
-					retValues, err := led2.Get(q)
-					require.NoError(t, err)
+				retValues, err := led2.Get(q)
+				require.NoError(t, err)
 
-					assert.Equal(t, retValues[0], ledger.Value([]byte{'D'}))
-					assert.Equal(t, retValues[1], ledger.Value([]byte{'B'}))
+				assert.Equal(t, retValues[0], ledger.Value([]byte{'D'}))
+				assert.Equal(t, retValues[1], ledger.Value([]byte{'B'}))
 
-					<-led.Done()
-					<-compactor.Done()
-					<-led2.Done()
-					<-compactor2.Done()
-				})
+				<-led.Done()
+				<-compactor.Done()
+				<-led2.Done()
+				<-compactor2.Done()
 			})
 		})
-	}
+	})
 }
 
 func TestWALUpdateFailuresBubbleUp(t *testing.T) {

--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -706,7 +706,7 @@ func TestLedgerFunctionality(t *testing.T) {
 }
 
 func Test_ExportCheckpointAt(t *testing.T) {
-	for _, version := range []int{5, 6} {
+	for _, version := range []int{6} {
 		t.Run(fmt.Sprintf("noop migration version %v", version), func(t *testing.T) {
 			// the exported state has two key/value pairs
 			// (/1/1/22/2, "A") and (/1/3/22/4, "B")
@@ -737,7 +737,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 					state, _, err = led.Set(u)
 					require.NoError(t, err)
 
-					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{noOpMigration}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint", version)
+					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{noOpMigration}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
 					require.NoError(t, err)
 					assert.Equal(t, newState, state)
 
@@ -795,7 +795,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 					state, _, err = led.Set(u)
 					require.NoError(t, err)
 
-					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByValue}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint", version)
+					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByValue}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
 					require.NoError(t, err)
 
 					diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
@@ -851,7 +851,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 					state, _, err = led.Set(u)
 					require.NoError(t, err)
 
-					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByKey}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint", version)
+					newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByKey}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
 					require.NoError(t, err)
 
 					diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)

--- a/ledger/complete/wal/wal.go
+++ b/ledger/complete/wal/wal.go
@@ -23,7 +23,6 @@ type DiskWAL struct {
 	pathByteSize   int
 	log            zerolog.Logger
 	dir            string
-	outputVersion  uint16
 }
 
 // TODO use real logger and metrics, but that would require passing them to Trie storage
@@ -39,7 +38,6 @@ func NewDiskWAL(logger zerolog.Logger, reg prometheus.Registerer, metrics module
 		pathByteSize:   pathByteSize,
 		log:            logger.With().Str("ledger_mod", "diskwal").Logger(),
 		dir:            dir,
-		outputVersion:  MaxVersion,
 	}, nil
 }
 
@@ -49,10 +47,6 @@ func (w *DiskWAL) PauseRecord() {
 
 func (w *DiskWAL) UnpauseRecord() {
 	w.paused = false
-}
-
-func (w *DiskWAL) UseCheckpointVersion5() {
-	w.outputVersion = VersionV5
 }
 
 // RecordUpdate writes the trie update to the write ahead log on disk.
@@ -316,7 +310,7 @@ func getPossibleCheckpoints(allCheckpoints []int, from, to int) []int {
 
 // NewCheckpointer returns a Checkpointer for this WAL
 func (w *DiskWAL) NewCheckpointer() (*Checkpointer, error) {
-	return NewCheckpointer(w, w.pathByteSize, w.forestCapacity, w.outputVersion), nil
+	return NewCheckpointer(w, w.pathByteSize, w.forestCapacity), nil
 }
 
 func (w *DiskWAL) Ready() <-chan struct{} {


### PR DESCRIPTION
From the next spork, the checkpoint V5 will be deprecated, and we will only support reading and generating checkpoint V6