### PR TITLE
[Engine] Require explicit capacity for Fifo queue

### DIFF
--- a/consensus/hotstuff/voteaggregator/vote_aggregator.go
+++ b/consensus/hotstuff/voteaggregator/vote_aggregator.go
@@ -51,7 +51,7 @@ func NewVoteAggregator(
 	collectors hotstuff.VoteCollectors,
 ) (*VoteAggregator, error) {
 
-	queuedVotes, err := fifoqueue.NewFifoQueue(fifoqueue.WithCapacity(defaultVoteQueueCapacity))
+	queuedVotes, err := fifoqueue.NewFifoQueue(defaultVoteQueueCapacity)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize votes queue")
 	}

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -105,18 +105,14 @@ func New(
 	blocksToMarkExecuted *stdmap.Times,
 	rpcEngine *rpc.Engine,
 ) (*Engine, error) {
-	executionReceiptsRawQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultQueueCapacity),
-	)
+	executionReceiptsRawQueue, err := fifoqueue.NewFifoQueue(defaultQueueCapacity)
 	if err != nil {
 		return nil, fmt.Errorf("could not create execution receipts queue: %w", err)
 	}
 
 	executionReceiptsQueue := &engine.FifoMessageStore{FifoQueue: executionReceiptsRawQueue}
 
-	finalizedBlocksRawQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultQueueCapacity),
-	)
+	finalizedBlocksRawQueue, err := fifoqueue.NewFifoQueue(defaultQueueCapacity)
 	if err != nil {
 		return nil, fmt.Errorf("could not create finalized block queue: %w", err)
 	}

--- a/engine/collection/compliance/engine.go
+++ b/engine/collection/compliance/engine.go
@@ -79,7 +79,7 @@ func NewEngine(
 
 	// FIFO queue for block proposals
 	blocksQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultBlockQueueCapacity),
+		defaultBlockQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) {
 			core.mempoolMetrics.MempoolEntries(metrics.ResourceClusterBlockProposalQueue, uint(len))
 		}),
@@ -93,7 +93,7 @@ func NewEngine(
 
 	// FIFO queue for block votes
 	votesQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultVoteQueueCapacity),
+		defaultVoteQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { core.mempoolMetrics.MempoolEntries(metrics.ResourceClusterBlockVoteQueue, uint(len)) }),
 	)
 	if err != nil {

--- a/engine/collection/ingest/engine.go
+++ b/engine/collection/ingest/engine.go
@@ -74,7 +74,7 @@ func New(
 
 	// FIFO queue for transactions
 	queue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(int(config.MaxMessageQueueSize)),
+		int(config.MaxMessageQueueSize),
 		fifoqueue.WithLengthObserver(func(len int) {
 			mempoolMetrics.MempoolEntries(metrics.ResourceTransactionIngestQueue, uint(len))
 		}),

--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -119,8 +119,7 @@ func New(
 
 // setupResponseMessageHandler initializes the inbound queues and the MessageHandler for UNTRUSTED responses.
 func (e *Engine) setupResponseMessageHandler() error {
-	syncResponseQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultSyncResponseQueueCapacity))
+	syncResponseQueue, err := fifoqueue.NewFifoQueue(defaultSyncResponseQueueCapacity)
 	if err != nil {
 		return fmt.Errorf("failed to create queue for sync responses: %w", err)
 	}
@@ -129,8 +128,7 @@ func (e *Engine) setupResponseMessageHandler() error {
 		FifoQueue: syncResponseQueue,
 	}
 
-	blockResponseQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultBlockResponseQueueCapacity))
+	blockResponseQueue, err := fifoqueue.NewFifoQueue(defaultBlockResponseQueueCapacity)
 	if err != nil {
 		return fmt.Errorf("failed to create queue for block responses: %w", err)
 	}

--- a/engine/common/fifoqueue/fifoqueue.go
+++ b/engine/common/fifoqueue/fifoqueue.go
@@ -8,6 +8,10 @@ import (
 	"github.com/ef-ds/deque"
 )
 
+// CapacityUnlimited specifies the largest possible capacity for a FifoQueue.
+// maximum value for platform-specific int: https://yourbasic.org/golang/max-min-int-uint/
+const CapacityUnlimited = 1<<(mathbits.UintSize-1) - 1
+
 // FifoQueue implements a FIFO queue with max capacity and length observer.
 // Elements that exceeds the queue's max capacity are silently dropped.
 // By default, the theoretical capacity equals to the largest `int` value
@@ -35,21 +39,6 @@ type ConstructorOption func(*FifoQueue) error
 // the `NewFifoQueue` constructor (via `WithLengthObserver` option).
 type QueueLengthObserver func(int)
 
-// WithCapacity is a constructor option for NewFifoQueue. It specifies the
-// max number of elements the queue can hold. By default, the theoretical
-// capacity equals to the largest `int` value (platform dependent).
-// The WithCapacity option overrides the previous value (default value or
-// value specified by previous option).
-func WithCapacity(capacity int) ConstructorOption {
-	return func(queue *FifoQueue) error {
-		if capacity < 1 {
-			return fmt.Errorf("capacity for Fifo queue must be positive")
-		}
-		queue.maxCapacity = capacity
-		return nil
-	}
-}
-
 // WithLengthObserver is a constructor option for NewFifoQueue. Each time the
 // queue's length changes, the queue calls the provided callback with the new
 // length. By default, the QueueLengthObserver is a NoOp.
@@ -70,12 +59,13 @@ func WithLengthObserver(callback QueueLengthObserver) ConstructorOption {
 }
 
 // NewFifoQueue is the Constructor for FifoQueue
-func NewFifoQueue(options ...ConstructorOption) (*FifoQueue, error) {
-	// maximum value for platform-specific int: https://yourbasic.org/golang/max-min-int-uint/
-	maxInt := 1<<(mathbits.UintSize-1) - 1
+func NewFifoQueue(maxCapacity int, options ...ConstructorOption) (*FifoQueue, error) {
+	if maxCapacity < 1 {
+		return nil, fmt.Errorf("capacity for Fifo queue must be positive")
+	}
 
 	queue := &FifoQueue{
-		maxCapacity:    maxInt,
+		maxCapacity:    maxCapacity,
 		lengthObserver: func(int) { /* noop */ },
 	}
 	for _, opt := range options {

--- a/engine/common/fifoqueue/fifoqueue_test.go
+++ b/engine/common/fifoqueue/fifoqueue_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPushAndPull(t *testing.T) {
-	queue, err := NewFifoQueue()
+	queue, err := NewFifoQueue(CapacityUnlimited)
 	require.NoError(t, err)
 	for i := 0; i < 10; i++ {
 		queue.Push(i)
@@ -28,7 +28,7 @@ func TestPushAndPull(t *testing.T) {
 }
 
 func TestConcurrentPushPull(t *testing.T) {
-	queue, err := NewFifoQueue()
+	queue, err := NewFifoQueue(CapacityUnlimited)
 	require.NoError(t, err)
 
 	count := 100

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -112,8 +112,7 @@ func New(
 
 // setupResponseMessageHandler initializes the inbound queues and the MessageHandler for UNTRUSTED responses.
 func (e *Engine) setupResponseMessageHandler() error {
-	syncResponseQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultSyncResponseQueueCapacity))
+	syncResponseQueue, err := fifoqueue.NewFifoQueue(defaultSyncResponseQueueCapacity)
 	if err != nil {
 		return fmt.Errorf("failed to create queue for sync responses: %w", err)
 	}
@@ -122,8 +121,7 @@ func (e *Engine) setupResponseMessageHandler() error {
 		FifoQueue: syncResponseQueue,
 	}
 
-	blockResponseQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultBlockResponseQueueCapacity))
+	blockResponseQueue, err := fifoqueue.NewFifoQueue(defaultBlockResponseQueueCapacity)
 	if err != nil {
 		return fmt.Errorf("failed to create queue for block responses: %w", err)
 	}

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -69,7 +69,7 @@ func NewEngine(
 	core *Core) (*Engine, error) {
 
 	rangeResponseQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultRangeResponseQueueCapacity),
+		defaultRangeResponseQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { core.mempool.MempoolEntries(metrics.ResourceBlockResponseQueue, uint(len)) }),
 	)
 
@@ -83,7 +83,7 @@ func NewEngine(
 
 	// FIFO queue for block proposals
 	blocksQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultBlockQueueCapacity),
+		defaultBlockQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { core.mempool.MempoolEntries(metrics.ResourceBlockProposalQueue, uint(len)) }),
 	)
 	if err != nil {
@@ -96,7 +96,7 @@ func NewEngine(
 
 	// FIFO queue for block votes
 	votesQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultVoteQueueCapacity),
+		defaultVoteQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { core.mempool.MempoolEntries(metrics.ResourceBlockVoteQueue, uint(len)) }),
 	)
 	if err != nil {

--- a/engine/consensus/ingestion/engine.go
+++ b/engine/consensus/ingestion/engine.go
@@ -51,7 +51,7 @@ func New(
 	logger := log.With().Str("ingestion", "engine").Logger()
 
 	guaranteesQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultGuaranteeQueueCapacity),
+		defaultGuaranteeQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { core.mempool.MempoolEntries(metrics.ResourceCollectionGuaranteesQueue, uint(len)) }),
 	)
 	if err != nil {

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -55,15 +55,14 @@ func NewEngine(
 
 	// FIFO queue for execution receipts
 	receiptsQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultReceiptQueueCapacity),
+		defaultReceiptQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { mempool.MempoolEntries(metrics.ResourceBlockProposalQueue, uint(len)) }),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create queue for inbound receipts: %w", err)
 	}
 
-	pendingIncorporatedBlocks, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultIncorporatedBlockQueueCapacity))
+	pendingIncorporatedBlocks, err := fifoqueue.NewFifoQueue(defaultIncorporatedBlockQueueCapacity)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create queue for incorporated block events: %w", err)
 	}

--- a/engine/consensus/sealing/engine.go
+++ b/engine/consensus/sealing/engine.go
@@ -43,6 +43,9 @@ const defaultAssignmentCollectorsWorkerPoolCapacity = 4
 // defaultIncorporatedBlockQueueCapacity maximum capacity of block incorporated events queue
 const defaultIncorporatedBlockQueueCapacity = 1000
 
+// defaultIncorporatedResultQueueCapacity maximum capacity of result incorporated events queue
+const defaultIncorporatedResultQueueCapacity = 1000
+
 type (
 	EventSink chan *Event // Channel to push pending events
 )
@@ -159,12 +162,11 @@ func (e *Engine) setupTrustedInboundQueues() error {
 	e.finalizationEventsNotifier = engine.NewNotifier()
 	e.blockIncorporatedNotifier = engine.NewNotifier()
 	var err error
-	e.pendingIncorporatedResults, err = fifoqueue.NewFifoQueue()
+	e.pendingIncorporatedResults, err = fifoqueue.NewFifoQueue(defaultIncorporatedResultQueueCapacity)
 	if err != nil {
 		return fmt.Errorf("failed to create queue for incorporated results: %w", err)
 	}
-	e.pendingIncorporatedBlocks, err = fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultIncorporatedBlockQueueCapacity))
+	e.pendingIncorporatedBlocks, err = fifoqueue.NewFifoQueue(defaultIncorporatedBlockQueueCapacity)
 	if err != nil {
 		return fmt.Errorf("failed to create queue for incorporated blocks: %w", err)
 	}
@@ -175,7 +177,7 @@ func (e *Engine) setupTrustedInboundQueues() error {
 func (e *Engine) setupMessageHandler(getSealingConfigs module.SealingConfigsGetter) error {
 	// FIFO queue for broadcasted approvals
 	pendingApprovalsQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultApprovalQueueCapacity),
+		defaultApprovalQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { e.cacheMetrics.MempoolEntries(metrics.ResourceApprovalQueue, uint(len)) }),
 	)
 	if err != nil {
@@ -187,7 +189,7 @@ func (e *Engine) setupMessageHandler(getSealingConfigs module.SealingConfigsGett
 
 	// FiFo queue for requested approvals
 	pendingRequestedApprovalsQueue, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(defaultApprovalResponseQueueCapacity),
+		defaultApprovalResponseQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { e.cacheMetrics.MempoolEntries(metrics.ResourceApprovalResponseQueue, uint(len)) }),
 	)
 	if err != nil {

--- a/engine/enqueue_test.go
+++ b/engine/enqueue_test.go
@@ -43,16 +43,12 @@ type messageC struct {
 }
 
 func NewEngine(log zerolog.Logger, capacity int) (*TestEngine, error) {
-	fifoQueueA, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(capacity),
-	)
+	fifoQueueA, err := fifoqueue.NewFifoQueue(capacity)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create queue A: %w", err)
 	}
 
-	fifoQueueB, err := fifoqueue.NewFifoQueue(
-		fifoqueue.WithCapacity(capacity),
-	)
+	fifoQueueB, err := fifoqueue.NewFifoQueue(capacity)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create queue B: %w", err)
 	}


### PR DESCRIPTION
Previously, the `FifoQueue`'s constructor took an optional argument that specified the queue's capacity, and defaulted to `maxint`. While all instantiations did specify a capacity, this pattern makes it easy to unintentionally omit the capacity override and configure an unlimited queue.

Update the `NewFifoQueue` constructor to take a required `maxCapacity` argument.