### PR TITLE
[BFT Testing] Only build corrupted images when required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
     - name: Build relic
       run: make crypto_setup_gopath
     - name: Docker build
-      run: make docker-build-flow
+      run: make docker-build-flow docker-build-flow-corrupted
     - name: Run tests
       if: github.actor != 'bors[bot]'
       run: ${{ matrix.make }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
     - name: Build relic
       run: make crypto_setup_gopath
     - name: Docker build
-      run: make docker-build-flow docker-build-flow-corrupted
+      run: make docker-build-flow docker-build-flow-corrupt
     - name: Run tests
       if: github.actor != 'bors[bot]'
       run: ${{ matrix.make }}

--- a/.github/workflows/flaky-test-debug.yml
+++ b/.github/workflows/flaky-test-debug.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Build relic
         run: make crypto_setup_gopath
       - name: Docker build
-        run: make docker-build-flow
+        run: make docker-build-flow docker-build-flow-corrupted
       - name: Run tests
         if: github.actor != 'bors[bot]'
         run: ${{ matrix.make }}

--- a/.github/workflows/flaky-test-debug.yml
+++ b/.github/workflows/flaky-test-debug.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Build relic
         run: make crypto_setup_gopath
       - name: Docker build
-        run: make docker-build-flow docker-build-flow-corrupted
+        run: make docker-build-flow docker-build-flow-corrupt
       - name: Run tests
         if: github.actor != 'bors[bot]'
         run: ${{ matrix.make }}

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ docker-build-loader:
 		-t "$(CONTAINER_REGISTRY)/loader:latest" -t "$(CONTAINER_REGISTRY)/loader:$(SHORT_COMMIT)" -t "$(CONTAINER_REGISTRY)/loader:$(IMAGE_TAG)" .
 
 .PHONY: docker-build-flow
-docker-build-flow: docker-build-flow-corrupt docker-build-collection docker-build-consensus docker-build-execution docker-build-verification docker-build-access docker-build-observer docker-build-ghost
+docker-build-flow: docker-build-collection docker-build-consensus docker-build-execution docker-build-verification docker-build-access docker-build-observer docker-build-ghost
 
 .PHONY: docker-build-flow-corrupt
 docker-build-flow-corrupt: docker-build-execution-corrupt docker-build-verification-corrupt docker-build-access-corrupt

--- a/tools/test_monitor/run-tests.sh
+++ b/tools/test_monitor/run-tests.sh
@@ -24,7 +24,7 @@ then
 
   echo "preparing $TEST_CATEGORY tests">&2
   make crypto_setup_gopath
-  make docker-build-flow
+  make docker-build-flow docker-build-flow-corrupted
   echo "running $TEST_CATEGORY tests">&2
   make -C integration -s ${BASH_REMATCH[1]}-tests > test-output
 else

--- a/tools/test_monitor/run-tests.sh
+++ b/tools/test_monitor/run-tests.sh
@@ -24,7 +24,7 @@ then
 
   echo "preparing $TEST_CATEGORY tests">&2
   make crypto_setup_gopath
-  make docker-build-flow docker-build-flow-corrupted
+  make docker-build-flow docker-build-flow-corrupt
   echo "running $TEST_CATEGORY tests">&2
   make -C integration -s ${BASH_REMATCH[1]}-tests > test-output
 else


### PR DESCRIPTION
`docker-build-flow` is the primary make target for building flow-go docker images. The corrupted images are only needed when running the BFT tests, so remove the `docker-build-flow-corrupt` from the main target and only added it when needed