### PR TITLE
Cleanup ComputationResult

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -351,14 +351,7 @@ func (e *blockComputer) executeCollection(
 		collection,
 		collectionView)
 
-	// TODO(patrick): refactor
-	e.metrics.ExecutionCollectionExecuted(time.Since(startedAt),
-		stats.ComputationUsed, stats.MemoryUsed,
-		stats.EventCounts, stats.EventSize,
-		stats.NumberOfRegistersTouched,
-		stats.NumberOfBytesWrittenToRegisters,
-		stats.NumberOfTransactions,
-	)
+	e.metrics.ExecutionCollectionExecuted(time.Since(startedAt), stats)
 	return txIndex, nil
 }
 

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/epochs"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/module/executiondatasync/provider"
@@ -75,14 +76,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		exemetrics := new(modulemock.ExecutionMetrics)
 		exemetrics.On("ExecutionCollectionExecuted",
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything).
+			mock.Anything,  // duration
+			mock.Anything). // stats
 			Return(nil).
 			Times(2) // 1 collection + system collection
 
@@ -879,14 +874,8 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 	expectedNumberOfEvents := 2
 	expectedEventSize := 912
 	metrics.On("ExecutionCollectionExecuted",
-		mock.Anything, // duration
-		mock.Anything, // computation used
-		mock.Anything, // memory used
-		expectedNumberOfEvents,
-		expectedEventSize,
-		49,   // expected number of registers touched
-		3404, // expected number of bytes written
-		1).   // expected number of transactions
+		mock.Anything,  // duration
+		mock.Anything). // stats
 		Return(nil).
 		Times(1) // system collection
 
@@ -929,6 +918,23 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 	assert.Len(t, result.TransactionResults, 1)
 
 	assert.Empty(t, result.TransactionResults[0].ErrorMessage)
+
+	stats := result.CollectionStats(0)
+	// ignore computation and memory used
+	stats.ComputationUsed = 0
+	stats.MemoryUsed = 0
+
+	assert.Equal(
+		t,
+		module.ExecutionResultStats{
+			EventCounts:                     expectedNumberOfEvents,
+			EventSize:                       expectedEventSize,
+			NumberOfRegistersTouched:        49,
+			NumberOfBytesWrittenToRegisters: 3404,
+			NumberOfCollections:             1,
+			NumberOfTransactions:            1,
+		},
+		stats)
 
 	committer.AssertExpectations(t)
 }

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -156,9 +156,9 @@ func TestComputeBlockWithStorage(t *testing.T) {
 	require.NotEmpty(t, blockView.(*delta.View).Delta())
 	require.Len(t, returnedComputationResult.StateSnapshots, 1+1) // 1 coll + 1 system chunk
 	assert.NotEmpty(t, returnedComputationResult.StateSnapshots[0].Delta)
-	compUsed, memUsed := returnedComputationResult.BlockComputationAndMemoryUsed()
-	assert.True(t, compUsed > 0)
-	assert.True(t, memUsed > 0)
+	stats := returnedComputationResult.BlockStats()
+	assert.True(t, stats.ComputationUsed > 0)
+	assert.True(t, stats.MemoryUsed > 0)
 }
 
 func TestComputeBlock_Uploader(t *testing.T) {

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -674,14 +674,9 @@ func (e *Engine) executeBlock(ctx context.Context, executableBlock *entity.Execu
 		Int64("timeSpentInMS", time.Since(startedAt).Milliseconds()).
 		Msg("block executed")
 
-	compUsed, memUsed := computationResult.BlockComputationAndMemoryUsed()
-	eventCounts, eventSize := computationResult.BlockEventCountsAndSize()
-	e.metrics.ExecutionBlockExecuted(time.Since(startedAt),
-		compUsed, memUsed,
-		eventCounts, eventSize,
-		len(computationResult.TransactionResults),
-		len(computationResult.ExecutableBlock.CompleteCollections),
-	)
+	e.metrics.ExecutionBlockExecuted(
+		time.Since(startedAt),
+		computationResult.BlockStats())
 
 	for computationKind, intensity := range computationResult.ComputationIntensities {
 		e.metrics.ExecutionBlockExecutionEffortVectorComponent(computationKind.String(), intensity)

--- a/engine/execution/messages.go
+++ b/engine/execution/messages.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/mempool/entity"
 )
 
@@ -34,26 +35,28 @@ type ComputationResult struct {
 }
 
 func NewEmptyComputationResult(block *entity.ExecutableBlock) *ComputationResult {
-	numberOfChunks := len(block.CompleteCollections) + 1
+	numCollections := len(block.CompleteCollections) + 1
 	return &ComputationResult{
 		ExecutableBlock:        block,
-		Events:                 make([]flow.EventsList, numberOfChunks),
+		Events:                 make([]flow.EventsList, numCollections),
 		ServiceEvents:          make(flow.EventsList, 0),
 		TransactionResults:     make([]flow.TransactionResult, 0),
 		TransactionResultIndex: make([]int, 0),
-		StateCommitments:       make([]flow.StateCommitment, 0, numberOfChunks),
-		Proofs:                 make([][]byte, 0, numberOfChunks),
-		TrieUpdates:            make([]*ledger.TrieUpdate, 0, numberOfChunks),
-		EventsHashes:           make([]flow.Identifier, 0, numberOfChunks),
+		StateCommitments:       make([]flow.StateCommitment, 0, numCollections),
+		Proofs:                 make([][]byte, 0, numCollections),
+		TrieUpdates:            make([]*ledger.TrieUpdate, 0, numCollections),
+		EventsHashes:           make([]flow.Identifier, 0, numCollections),
 		ComputationIntensities: make(meter.MeteredComputationIntensities),
 	}
 }
 
 func (cr *ComputationResult) AddTransactionResult(
-	chunkIndex int,
+	collectionIndex int,
 	txn *fvm.TransactionProcedure,
 ) {
-	cr.Events[chunkIndex] = append(cr.Events[chunkIndex], txn.Events...)
+	cr.Events[collectionIndex] = append(
+		cr.Events[collectionIndex],
+		txn.Events...)
 	cr.ServiceEvents = append(cr.ServiceEvents, txn.ServiceEvents...)
 
 	txnResult := flow.TransactionResult{
@@ -74,56 +77,48 @@ func (cr *ComputationResult) AddTransactionResult(
 	}
 }
 
-// TODO(patrick): compute this in a loop in computer after cleaning up system
-// collection execution.
-func (cr *ComputationResult) UpdateTransactionResultIndex(txCounts int) {
-	lastIndex := 0
-	if len(cr.TransactionResultIndex) > 0 {
-		lastIndex = cr.TransactionResultIndex[len(cr.TransactionResultIndex)-1]
-	}
-	cr.TransactionResultIndex = append(cr.TransactionResultIndex, lastIndex+txCounts)
+func (cr *ComputationResult) AddCollection(snapshot *delta.SpockSnapshot) {
+	cr.TransactionResultIndex = append(
+		cr.TransactionResultIndex,
+		len(cr.TransactionResults))
+	cr.StateSnapshots = append(cr.StateSnapshots, snapshot)
 }
 
-func (cr *ComputationResult) AddStateSnapshot(inp *delta.SpockSnapshot) {
-	cr.StateSnapshots = append(cr.StateSnapshots, inp)
+func (cr *ComputationResult) CollectionStats(
+	collectionIndex int,
+) module.ExecutionResultStats {
+	var startTxnIndex int
+	if collectionIndex > 0 {
+		startTxnIndex = cr.TransactionResultIndex[collectionIndex-1]
+	}
+	endTxnIndex := cr.TransactionResultIndex[collectionIndex]
+
+	var computationUsed uint64
+	var memoryUsed uint64
+	for _, txn := range cr.TransactionResults[startTxnIndex:endTxnIndex] {
+		computationUsed += txn.ComputationUsed
+		memoryUsed += txn.MemoryUsed
+	}
+
+	events := cr.Events[collectionIndex]
+	snapshot := cr.StateSnapshots[collectionIndex]
+	return module.ExecutionResultStats{
+		ComputationUsed:                 computationUsed,
+		MemoryUsed:                      memoryUsed,
+		EventCounts:                     len(events),
+		EventSize:                       events.ByteSize(),
+		NumberOfRegistersTouched:        snapshot.NumberOfRegistersTouched,
+		NumberOfBytesWrittenToRegisters: snapshot.NumberOfBytesWrittenToRegisters,
+		NumberOfCollections:             1,
+		NumberOfTransactions:            endTxnIndex - startTxnIndex,
+	}
 }
 
-func (cr *ComputationResult) ChunkEventCountsAndSize(chunkIndex int) (int, int) {
-	return len(cr.Events[chunkIndex]), cr.Events[chunkIndex].ByteSize()
-}
-
-func (cr *ComputationResult) BlockEventCountsAndSize() (int, int) {
-	totalSize := cr.ServiceEvents.ByteSize()
-	totalCounts := len(cr.ServiceEvents)
-	for _, events := range cr.Events {
-		totalSize += events.ByteSize()
-		totalCounts += len(events)
+func (cr *ComputationResult) BlockStats() module.ExecutionResultStats {
+	stats := module.ExecutionResultStats{}
+	for idx := 0; idx < len(cr.StateCommitments); idx++ {
+		stats.Merge(cr.CollectionStats(idx))
 	}
-	return totalCounts, totalSize
-}
 
-func (cr *ComputationResult) ChunkComputationAndMemoryUsed(chunkIndex int) (uint64, uint64) {
-	var startTxIndex int
-	if chunkIndex > 0 {
-		startTxIndex = cr.TransactionResultIndex[chunkIndex-1]
-	}
-	endTxIndex := cr.TransactionResultIndex[chunkIndex]
-
-	var totalComputationUsed uint64
-	var totalMemoryUsed uint64
-	for i := startTxIndex; i < endTxIndex; i++ {
-		totalComputationUsed += cr.TransactionResults[i].ComputationUsed
-		totalMemoryUsed += cr.TransactionResults[i].MemoryUsed
-	}
-	return totalComputationUsed, totalMemoryUsed
-}
-
-func (cr *ComputationResult) BlockComputationAndMemoryUsed() (uint64, uint64) {
-	var totalComputationUsed uint64
-	var totalMemoryUsed uint64
-	for i := 0; i < len(cr.TransactionResults); i++ {
-		totalComputationUsed += cr.TransactionResults[i].ComputationUsed
-		totalMemoryUsed += cr.TransactionResults[i].MemoryUsed
-	}
-	return totalComputationUsed, totalMemoryUsed
+	return stats
 }

--- a/engine/execution/state/unittest/fixtures.go
+++ b/engine/execution/state/unittest/fixtures.go
@@ -13,33 +13,23 @@ func StateInteractionsFixture() *delta.SpockSnapshot {
 }
 
 func ComputationResultFixture(collectionsSignerIDs [][]flow.Identifier) *execution.ComputationResult {
-	stateViews := make([]*delta.SpockSnapshot, len(collectionsSignerIDs)+1) //+1 for system chunk
-	stateCommitments := make([]flow.StateCommitment, len(collectionsSignerIDs)+1)
-	eventHashes := make([]flow.Identifier, len(collectionsSignerIDs)+1)
-	proofs := make([][]byte, len(collectionsSignerIDs)+1)
-	for i := 0; i < len(collectionsSignerIDs)+1; i++ {
-		stateViews[i] = StateInteractionsFixture()
-		stateCommitments[i] = unittest.StateCommitmentFixture()
-		eventHashes[i] = unittest.IdentifierFixture()
-		proofs[i] = unittest.RandomBytes(2)
-	}
-	return &execution.ComputationResult{
-		ExecutableBlock:  unittest.ExecutableBlockFixture(collectionsSignerIDs),
-		StateSnapshots:   stateViews,
-		StateCommitments: stateCommitments,
-		EventsHashes:     eventHashes,
-		Proofs:           proofs,
-	}
+	block := unittest.ExecutableBlockFixture(collectionsSignerIDs)
+	startState := unittest.StateCommitmentFixture()
+	block.StartState = &startState
+
+	return ComputationResultForBlockFixture(block)
 }
 
-func ComputationResultForBlockFixture(completeBlock *entity.ExecutableBlock) *execution.ComputationResult {
-	n := len(completeBlock.CompleteCollections) + 1
-	stateViews := make([]*delta.SpockSnapshot, n)
-	stateCommitments := make([]flow.StateCommitment, n)
-	proofs := make([][]byte, n)
-	events := make([]flow.EventsList, n)
-	eventHashes := make([]flow.Identifier, n)
-	for i := 0; i < n; i++ {
+func ComputationResultForBlockFixture(
+	completeBlock *entity.ExecutableBlock,
+) *execution.ComputationResult {
+	numChunks := len(completeBlock.CompleteCollections) + 1
+	stateViews := make([]*delta.SpockSnapshot, numChunks)
+	stateCommitments := make([]flow.StateCommitment, numChunks)
+	proofs := make([][]byte, numChunks)
+	events := make([]flow.EventsList, numChunks)
+	eventHashes := make([]flow.Identifier, numChunks)
+	for i := 0; i < numChunks; i++ {
 		stateViews[i] = StateInteractionsFixture()
 		stateCommitments[i] = *completeBlock.StartState
 		proofs[i] = unittest.RandomBytes(6)
@@ -47,11 +37,12 @@ func ComputationResultForBlockFixture(completeBlock *entity.ExecutableBlock) *ex
 		eventHashes[i] = unittest.IdentifierFixture()
 	}
 	return &execution.ComputationResult{
-		ExecutableBlock:  completeBlock,
-		StateSnapshots:   stateViews,
-		StateCommitments: stateCommitments,
-		Proofs:           proofs,
-		Events:           events,
-		EventsHashes:     eventHashes,
+		TransactionResultIndex: make([]int, numChunks),
+		ExecutableBlock:        completeBlock,
+		StateSnapshots:         stateViews,
+		StateCommitments:       stateCommitments,
+		Proofs:                 proofs,
+		Events:                 events,
+		EventsHashes:           eventHashes,
 	}
 }

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -463,6 +463,28 @@ type AccessMetrics interface {
 	ConnectionFromPoolEvicted()
 }
 
+type ExecutionResultStats struct {
+	ComputationUsed                 uint64
+	MemoryUsed                      uint64
+	EventCounts                     int
+	EventSize                       int
+	NumberOfRegistersTouched        int
+	NumberOfBytesWrittenToRegisters int
+	NumberOfCollections             int
+	NumberOfTransactions            int
+}
+
+func (stats *ExecutionResultStats) Merge(other ExecutionResultStats) {
+	stats.ComputationUsed += other.ComputationUsed
+	stats.MemoryUsed += other.MemoryUsed
+	stats.EventCounts += other.EventCounts
+	stats.EventSize += other.EventSize
+	stats.NumberOfRegistersTouched += other.NumberOfRegistersTouched
+	stats.NumberOfBytesWrittenToRegisters += other.NumberOfBytesWrittenToRegisters
+	stats.NumberOfCollections += other.NumberOfCollections
+	stats.NumberOfTransactions += other.NumberOfTransactions
+}
+
 type ExecutionMetrics interface {
 	LedgerMetrics
 	RuntimeMetrics
@@ -484,20 +506,13 @@ type ExecutionMetrics interface {
 	ExecutionLastExecutedBlockHeight(height uint64)
 
 	// ExecutionBlockExecuted reports the total time and computation spent on executing a block
-	ExecutionBlockExecuted(dur time.Duration,
-		compUsed, memoryUsed uint64,
-		eventCounts, eventSize int,
-		txCounts, colCounts int)
+	ExecutionBlockExecuted(dur time.Duration, stats ExecutionResultStats)
 
 	// ExecutionBlockExecutionEffortVectorComponent reports the unweighted effort of given ComputationKind at block level
 	ExecutionBlockExecutionEffortVectorComponent(string, uint)
 
 	// ExecutionCollectionExecuted reports the total time and computation spent on executing a collection
-	ExecutionCollectionExecuted(dur time.Duration,
-		compUsed, memoryUsed uint64,
-		eventCounts, eventSize int,
-		numberOfRegistersTouched, totalBytesWrittenToRegisters int,
-		txCounts int)
+	ExecutionCollectionExecuted(dur time.Duration, stats ExecutionResultStats)
 
 	// ExecutionTransactionExecuted reports stats on executing a single transaction
 	ExecutionTransactionExecuted(dur time.Duration,

--- a/module/metrics/example/execution/main.go
+++ b/module/metrics/example/execution/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/metrics/example"
 	"github.com/onflow/flow-go/module/trace"
@@ -38,7 +39,16 @@ func main() {
 			// adds a random delay for execution duration, between 0 and 2 seconds
 			time.Sleep(duration)
 
-			collector.ExecutionBlockExecuted(duration, uint64(rand.Int63n(1e6)), uint64(rand.Int63n(1e6)), 2, 100, 1, 1)
+			collector.ExecutionBlockExecuted(
+				duration,
+				module.ExecutionResultStats{
+					ComputationUsed:      uint64(rand.Int63n(1e6)),
+					MemoryUsed:           uint64(rand.Int63n(1e6)),
+					EventCounts:          2,
+					EventSize:            100,
+					NumberOfCollections:  1,
+					NumberOfTransactions: 1,
+				})
 
 			diskIncrease := rand.Int63n(1024 * 1024)
 			diskTotal += diskIncrease

--- a/module/metrics/execution.go
+++ b/module/metrics/execution.go
@@ -674,37 +674,32 @@ func (ec *ExecutionCollector) FinishBlockReceivedToExecuted(blockID flow.Identif
 // ExecutionBlockExecuted reports execution meta data after executing a block
 func (ec *ExecutionCollector) ExecutionBlockExecuted(
 	dur time.Duration,
-	compUsed, memoryUsed uint64,
-	eventCounts, eventSize int,
-	txCounts, colCounts int,
+	stats module.ExecutionResultStats,
 ) {
 	ec.totalExecutedBlocksCounter.Inc()
 	ec.blockExecutionTime.Observe(float64(dur.Milliseconds()))
-	ec.blockComputationUsed.Observe(float64(compUsed))
-	ec.blockMemoryUsed.Observe(float64(memoryUsed))
-	ec.blockEventCounts.Observe(float64(eventCounts))
-	ec.blockEventSize.Observe(float64(eventSize))
-	ec.blockTransactionCounts.Observe(float64(txCounts))
-	ec.blockCollectionCounts.Observe(float64(colCounts))
+	ec.blockComputationUsed.Observe(float64(stats.ComputationUsed))
+	ec.blockMemoryUsed.Observe(float64(stats.MemoryUsed))
+	ec.blockEventCounts.Observe(float64(stats.EventCounts))
+	ec.blockEventSize.Observe(float64(stats.EventSize))
+	ec.blockTransactionCounts.Observe(float64(stats.NumberOfTransactions))
+	ec.blockCollectionCounts.Observe(float64(stats.NumberOfCollections))
 }
 
 // ExecutionCollectionExecuted reports stats for executing a collection
 func (ec *ExecutionCollector) ExecutionCollectionExecuted(
 	dur time.Duration,
-	compUsed, memoryUsed uint64,
-	eventCounts, eventSize int,
-	numberOfRegistersTouched, totalBytesWrittenToRegisters int,
-	txCounts int,
+	stats module.ExecutionResultStats,
 ) {
 	ec.totalExecutedCollectionsCounter.Inc()
 	ec.collectionExecutionTime.Observe(float64(dur.Milliseconds()))
-	ec.collectionComputationUsed.Observe(float64(compUsed))
-	ec.collectionMemoryUsed.Observe(float64(memoryUsed))
-	ec.collectionEventCounts.Observe(float64(eventCounts))
-	ec.collectionEventSize.Observe(float64(eventSize))
-	ec.collectionNumberOfRegistersTouched.Observe(float64(numberOfRegistersTouched))
-	ec.collectionTotalBytesWrittenToRegisters.Observe(float64(totalBytesWrittenToRegisters))
-	ec.collectionTransactionCounts.Observe(float64(txCounts))
+	ec.collectionComputationUsed.Observe(float64(stats.ComputationUsed))
+	ec.collectionMemoryUsed.Observe(float64(stats.MemoryUsed))
+	ec.collectionEventCounts.Observe(float64(stats.EventCounts))
+	ec.collectionEventSize.Observe(float64(stats.EventSize))
+	ec.collectionNumberOfRegistersTouched.Observe(float64(stats.NumberOfRegistersTouched))
+	ec.collectionTotalBytesWrittenToRegisters.Observe(float64(stats.NumberOfBytesWrittenToRegisters))
+	ec.collectionTransactionCounts.Observe(float64(stats.NumberOfTransactions))
 }
 
 func (ec *ExecutionCollector) ExecutionBlockExecutionEffortVectorComponent(compKind string, value uint) {

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -101,33 +101,33 @@ func (nc *NoopCollector) OnVerifiableChunkReceivedAtVerifierEngine()            
 func (nc *NoopCollector) OnResultApprovalDispatchedInNetworkByVerifier()                         {}
 func (nc *NoopCollector) SetMaxChunkDataPackAttemptsForNextUnsealedHeightAtRequester(attempts uint64) {
 }
-func (nc *NoopCollector) OnFinalizedBlockArrivedAtAssigner(height uint64)                      {}
-func (nc *NoopCollector) OnChunksAssignmentDoneAtAssigner(chunks int)                          {}
-func (nc *NoopCollector) OnAssignedChunkProcessedAtAssigner()                                  {}
-func (nc *NoopCollector) OnAssignedChunkReceivedAtFetcher()                                    {}
-func (nc *NoopCollector) OnChunkDataPackRequestDispatchedInNetworkByRequester()                {}
-func (nc *NoopCollector) OnChunkDataPackRequestSentByFetcher()                                 {}
-func (nc *NoopCollector) OnChunkDataPackRequestReceivedByRequester()                           {}
-func (nc *NoopCollector) OnChunkDataPackArrivedAtFetcher()                                     {}
-func (nc *NoopCollector) OnChunkDataPackSentToFetcher()                                        {}
-func (nc *NoopCollector) OnVerifiableChunkSentToVerifier()                                     {}
-func (nc *NoopCollector) OnBlockConsumerJobDone(uint64)                                        {}
-func (nc *NoopCollector) OnChunkConsumerJobDone(uint64)                                        {}
-func (nc *NoopCollector) OnChunkDataPackResponseReceivedFromNetworkByRequester()               {}
-func (nc *NoopCollector) TotalConnectionsInPool(connectionCount uint, connectionPoolSize uint) {}
-func (nc *NoopCollector) ConnectionFromPoolReused()                                            {}
-func (nc *NoopCollector) ConnectionAddedToPool()                                               {}
-func (nc *NoopCollector) NewConnectionEstablished()                                            {}
-func (nc *NoopCollector) ConnectionFromPoolInvalidated()                                       {}
-func (nc *NoopCollector) ConnectionFromPoolUpdated()                                           {}
-func (nc *NoopCollector) ConnectionFromPoolEvicted()                                           {}
-func (nc *NoopCollector) StartBlockReceivedToExecuted(blockID flow.Identifier)                 {}
-func (nc *NoopCollector) FinishBlockReceivedToExecuted(blockID flow.Identifier)                {}
-func (nc *NoopCollector) ExecutionComputationUsedPerBlock(computation uint64)                  {}
-func (nc *NoopCollector) ExecutionStorageStateCommitment(bytes int64)                          {}
-func (nc *NoopCollector) ExecutionLastExecutedBlockHeight(height uint64)                       {}
-func (nc *NoopCollector) ExecutionBlockExecuted(_ time.Duration, _, _ uint64, _, _, _, _ int)  {}
-func (nc *NoopCollector) ExecutionCollectionExecuted(_ time.Duration, _, _ uint64, _, _, _, _, _ int) {
+func (nc *NoopCollector) OnFinalizedBlockArrivedAtAssigner(height uint64)                       {}
+func (nc *NoopCollector) OnChunksAssignmentDoneAtAssigner(chunks int)                           {}
+func (nc *NoopCollector) OnAssignedChunkProcessedAtAssigner()                                   {}
+func (nc *NoopCollector) OnAssignedChunkReceivedAtFetcher()                                     {}
+func (nc *NoopCollector) OnChunkDataPackRequestDispatchedInNetworkByRequester()                 {}
+func (nc *NoopCollector) OnChunkDataPackRequestSentByFetcher()                                  {}
+func (nc *NoopCollector) OnChunkDataPackRequestReceivedByRequester()                            {}
+func (nc *NoopCollector) OnChunkDataPackArrivedAtFetcher()                                      {}
+func (nc *NoopCollector) OnChunkDataPackSentToFetcher()                                         {}
+func (nc *NoopCollector) OnVerifiableChunkSentToVerifier()                                      {}
+func (nc *NoopCollector) OnBlockConsumerJobDone(uint64)                                         {}
+func (nc *NoopCollector) OnChunkConsumerJobDone(uint64)                                         {}
+func (nc *NoopCollector) OnChunkDataPackResponseReceivedFromNetworkByRequester()                {}
+func (nc *NoopCollector) TotalConnectionsInPool(connectionCount uint, connectionPoolSize uint)  {}
+func (nc *NoopCollector) ConnectionFromPoolReused()                                             {}
+func (nc *NoopCollector) ConnectionAddedToPool()                                                {}
+func (nc *NoopCollector) NewConnectionEstablished()                                             {}
+func (nc *NoopCollector) ConnectionFromPoolInvalidated()                                        {}
+func (nc *NoopCollector) ConnectionFromPoolUpdated()                                            {}
+func (nc *NoopCollector) ConnectionFromPoolEvicted()                                            {}
+func (nc *NoopCollector) StartBlockReceivedToExecuted(blockID flow.Identifier)                  {}
+func (nc *NoopCollector) FinishBlockReceivedToExecuted(blockID flow.Identifier)                 {}
+func (nc *NoopCollector) ExecutionComputationUsedPerBlock(computation uint64)                   {}
+func (nc *NoopCollector) ExecutionStorageStateCommitment(bytes int64)                           {}
+func (nc *NoopCollector) ExecutionLastExecutedBlockHeight(height uint64)                        {}
+func (nc *NoopCollector) ExecutionBlockExecuted(_ time.Duration, _ module.ExecutionResultStats) {}
+func (nc *NoopCollector) ExecutionCollectionExecuted(_ time.Duration, _ module.ExecutionResultStats) {
 }
 func (nc *NoopCollector) ExecutionBlockExecutionEffortVectorComponent(_ string, _ uint) {}
 func (nc *NoopCollector) ExecutionTransactionExecuted(_ time.Duration, _, _, _ uint64, _, _ int, _ bool) {

--- a/module/mock/execution_metrics.go
+++ b/module/mock/execution_metrics.go
@@ -6,6 +6,8 @@ import (
 	flow "github.com/onflow/flow-go/model/flow"
 	mock "github.com/stretchr/testify/mock"
 
+	module "github.com/onflow/flow-go/module"
+
 	time "time"
 )
 
@@ -29,9 +31,9 @@ func (_m *ExecutionMetrics) ExecutionBlockDataUploadStarted() {
 	_m.Called()
 }
 
-// ExecutionBlockExecuted provides a mock function with given fields: dur, compUsed, memoryUsed, eventCounts, eventSize, txCounts, colCounts
-func (_m *ExecutionMetrics) ExecutionBlockExecuted(dur time.Duration, compUsed uint64, memoryUsed uint64, eventCounts int, eventSize int, txCounts int, colCounts int) {
-	_m.Called(dur, compUsed, memoryUsed, eventCounts, eventSize, txCounts, colCounts)
+// ExecutionBlockExecuted provides a mock function with given fields: dur, stats
+func (_m *ExecutionMetrics) ExecutionBlockExecuted(dur time.Duration, stats module.ExecutionResultStats) {
+	_m.Called(dur, stats)
 }
 
 // ExecutionBlockExecutionEffortVectorComponent provides a mock function with given fields: _a0, _a1
@@ -44,9 +46,9 @@ func (_m *ExecutionMetrics) ExecutionChunkDataPackGenerated(proofSize int, numbe
 	_m.Called(proofSize, numberOfTransactions)
 }
 
-// ExecutionCollectionExecuted provides a mock function with given fields: dur, compUsed, memoryUsed, eventCounts, eventSize, numberOfRegistersTouched, totalBytesWrittenToRegisters, txCounts
-func (_m *ExecutionMetrics) ExecutionCollectionExecuted(dur time.Duration, compUsed uint64, memoryUsed uint64, eventCounts int, eventSize int, numberOfRegistersTouched int, totalBytesWrittenToRegisters int, txCounts int) {
-	_m.Called(dur, compUsed, memoryUsed, eventCounts, eventSize, numberOfRegistersTouched, totalBytesWrittenToRegisters, txCounts)
+// ExecutionCollectionExecuted provides a mock function with given fields: dur, stats
+func (_m *ExecutionMetrics) ExecutionCollectionExecuted(dur time.Duration, stats module.ExecutionResultStats) {
+	_m.Called(dur, stats)
 }
 
 // ExecutionCollectionRequestRetried provides a mock function with given fields:


### PR DESCRIPTION
1. consistently use collection for naming, instead of using collection/chunk interchangeably
2. simplify adding collection to the result
3. return all collection/block stats as a struct using a single api call
4. clean up collection/block stats metric logging

gh: #3547