### PR TITLE
Open metrics port on 8080

### DIFF
--- a/integration/benchnet2/automate/templates/helm-values-all-nodes.yml
+++ b/integration/benchnet2/automate/templates/helm-values-all-nodes.yml
@@ -149,6 +149,8 @@ verification:
 {{define "defaults"}}
     imagePullPolicy: Always
     containerPorts:
+      - name: metrics
+        containerPort: 8080
       - name: ptp
         containerPort: 3569
       - name: grpc


### PR DESCRIPTION
## Description
The following PR opens port 8080 so that the metrics can be scraped by Prometheus within the cluster