### PR TITLE
Add missing metric label. 

### DIFF
--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -126,3 +126,5 @@ const (
 )
 
 const ExecutionDataRequestRetryable = "retryable"
+
+const LabelViolationReason = "reason"

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -211,7 +211,7 @@ func NewNetworkCollector(opts ...NetworkCollectorOpt) *NetworkCollector {
 			Subsystem: subsystemAuth,
 			Name:      nc.prefix + "unauthorized_messages_count",
 			Help:      "number of messages that failed authorization validation",
-		}, []string{LabelNodeRole, LabelMessage, LabelChannel},
+		}, []string{LabelNodeRole, LabelMessage, LabelChannel, LabelViolationReason},
 	)
 
 	nc.rateLimitedUnicastMessagesCount = promauto.NewCounterVec(


### PR DESCRIPTION
Adds missing label _LabelViolationReason_ to OnUnauthorizedMessage metric. 