### PR TITLE
[FVM] Change payer balance check error to a failure

### DIFF
--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -24,6 +24,7 @@ const (
 	// Deprecated: No longer used.
 	FailureCodeHasherFailure                           ErrorCode = 2005
 	FailureCodeParseRestrictedModeInvalidAccessFailure ErrorCode = 2006
+	FailureCodePayerBalanceCheckFailure                ErrorCode = 2007
 	// Deprecated: No longer used.
 	FailureCodeMetaTransactionFailure ErrorCode = 2100
 )
@@ -79,8 +80,8 @@ const (
 	ErrCodeScriptExecutionTimedOutError              ErrorCode = 1113
 	ErrCodeEventEncodingError                        ErrorCode = 1115
 	ErrCodeInvalidFVMStateAccessError                ErrorCode = 1116
-	ErrCodePayerBalanceCheckError                    ErrorCode = 1117
-	ErrCodeInsufficientPayerBalance                  ErrorCode = 1118
+	// 1117 was never deployed and is free to use
+	ErrCodeInsufficientPayerBalance ErrorCode = 1118
 
 	// accounts errors 1200 - 1250
 	// Deprecated: No longer used.

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -62,14 +62,16 @@ func NewInsufficientPayerBalanceError(
 	)
 }
 
-// NewPayerBalanceCheckError constructs a new CodedError which
+// NewPayerBalanceCheckFailure constructs a new CodedError which
 // indicates that a there was an error checking the payers balance.
-func NewPayerBalanceCheckError(
+// This is an implementation error most likely between the smart contract and FVM interaction
+// and should not happen in regular execution.
+func NewPayerBalanceCheckFailure(
 	payer flow.Address,
 	err error,
 ) CodedError {
 	return WrapCodedError(
-		ErrCodePayerBalanceCheckError,
+		FailureCodePayerBalanceCheckFailure,
 		err,
 		"failed to check if the payer %s has sufficient balance",
 		payer)

--- a/fvm/transactionPayerBalanceChecker.go
+++ b/fvm/transactionPayerBalanceChecker.go
@@ -38,7 +38,7 @@ func (_ TransactionPayerBalanceChecker) CheckPayerBalanceAndReturnMaxFees(
 		)
 	})
 	if err != nil {
-		return 0, errors.NewPayerBalanceCheckError(proc.Transaction.Payer, err)
+		return 0, errors.NewPayerBalanceCheckFailure(proc.Transaction.Payer, err)
 	}
 
 	// parse expected result from the Cadence runtime
@@ -57,5 +57,5 @@ func (_ TransactionPayerBalanceChecker) CheckPayerBalanceAndReturnMaxFees(
 		}
 	}
 
-	return 0, errors.NewPayerBalanceCheckError(proc.Transaction.Payer, fmt.Errorf("invalid result type"))
+	return 0, errors.NewPayerBalanceCheckFailure(proc.Transaction.Payer, fmt.Errorf("invalid result type"))
 }

--- a/fvm/transactionPayerBalanceChecker_test.go
+++ b/fvm/transactionPayerBalanceChecker_test.go
@@ -57,7 +57,7 @@ func TestTransactionPayerBalanceChecker(t *testing.T) {
 		d := fvm.TransactionPayerBalanceChecker{}
 		maxFees, err := d.CheckPayerBalanceAndReturnMaxFees(proc, txnState, env)
 		require.Error(t, err)
-		require.True(t, errors.HasErrorCode(err, errors.ErrCodePayerBalanceCheckError))
+		require.True(t, errors.HasErrorCode(err, errors.FailureCodePayerBalanceCheckFailure))
 		require.ErrorIs(t, err, someError)
 		require.Equal(t, uint64(0), maxFees)
 	})
@@ -80,7 +80,7 @@ func TestTransactionPayerBalanceChecker(t *testing.T) {
 		d := fvm.TransactionPayerBalanceChecker{}
 		maxFees, err := d.CheckPayerBalanceAndReturnMaxFees(proc, txnState, env)
 		require.Error(t, err)
-		require.True(t, errors.HasErrorCode(err, errors.ErrCodePayerBalanceCheckError))
+		require.True(t, errors.HasErrorCode(err, errors.FailureCodePayerBalanceCheckFailure))
 		require.Equal(t, uint64(0), maxFees)
 	})
 


### PR DESCRIPTION
This should be a failure because it can only happen if the communication between the core contract and FVM is faulty, which means something isn't set up correctly.