### PR TITLE
[Testing] Use localhost in unit tests to reduce firewall alerts

### DIFF
--- a/admin/command_runner_test.go
+++ b/admin/command_runner_test.go
@@ -55,7 +55,7 @@ func TestCommandRunner(t *testing.T) {
 }
 
 func (suite *CommandRunnerSuite) SetupTest() {
-	suite.httpAddress = fmt.Sprintf("localhost:%s", testingdock.RandomPort(suite.T()))
+	suite.httpAddress = unittest.IPPort(testingdock.RandomPort(suite.T()))
 	suite.bootstrapper = NewCommandRunnerBootstrapper()
 }
 

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -16,13 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/onflow/flow-go/module/irrecoverable"
-
-	"github.com/onflow/flow-go/crypto"
-
 	"github.com/onflow/flow-go/access"
 	hsmock "github.com/onflow/flow-go/consensus/hotstuff/mocks"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine/access/ingestion"
 	accessmock "github.com/onflow/flow-go/engine/access/mock"
 	"github.com/onflow/flow-go/engine/access/rpc"
@@ -32,6 +29,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/factory"
 	"github.com/onflow/flow-go/model/flow/filter"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/mempool/stdmap"
 	"github.com/onflow/flow-go/module/metrics"
 	module "github.com/onflow/flow-go/module/mock"

--- a/engine/access/apiproxy/access_api_proxy_test.go
+++ b/engine/access/apiproxy/access_api_proxy_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/grpcutils"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 // Methodology
@@ -128,13 +129,13 @@ func TestNewFlowCachedAccessAPIProxy(t *testing.T) {
 	done := make(chan int)
 
 	// Bring up 1st upstream server
-	charlie1, _, err := newFlowLite("tcp", "127.0.0.1:11634", done)
+	charlie1, _, err := newFlowLite("tcp", unittest.IPPort("11634"), done)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Prepare a proxy that fails due to the second connection being idle
-	l := flow.IdentityList{{Address: "127.0.0.1:11634"}, {Address: "127.0.0.1:11635"}}
+	l := flow.IdentityList{{Address: unittest.IPPort("11634")}, {Address: unittest.IPPort("11635")}}
 	c := FlowAccessAPIForwarder{}
 	err = c.setFlowAccessAPI(l, time.Second)
 	if err == nil {
@@ -142,7 +143,7 @@ func TestNewFlowCachedAccessAPIProxy(t *testing.T) {
 	}
 
 	// Bring up 2nd upstream server
-	charlie2, _, err := newFlowLite("tcp", "127.0.0.1:11635", done)
+	charlie2, _, err := newFlowLite("tcp", unittest.IPPort("11635"), done)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +151,7 @@ func TestNewFlowCachedAccessAPIProxy(t *testing.T) {
 	background := context.Background()
 
 	// Prepare a proxy
-	l = flow.IdentityList{{Address: "127.0.0.1:11634"}, {Address: "127.0.0.1:11635"}}
+	l = flow.IdentityList{{Address: unittest.IPPort("11634")}, {Address: unittest.IPPort("11635")}}
 	c = FlowAccessAPIForwarder{}
 	err = c.setFlowAccessAPI(l, time.Second)
 	if err != nil {

--- a/engine/access/rest_api_test.go
+++ b/engine/access/rest_api_test.go
@@ -92,12 +92,11 @@ func (suite *RestAPITestSuite) SetupTest() {
 	suite.chainID = flow.Testnet
 	suite.metrics = metrics.NewNoopCollector()
 
-	const anyPort = ":0" // :0 to let the OS pick a free port
 	config := rpc.Config{
-		UnsecureGRPCListenAddr: anyPort,
-		SecureGRPCListenAddr:   anyPort,
-		HTTPListenAddr:         anyPort,
-		RESTListenAddr:         anyPort,
+		UnsecureGRPCListenAddr: unittest.DefaultAddress,
+		SecureGRPCListenAddr:   unittest.DefaultAddress,
+		HTTPListenAddr:         unittest.DefaultAddress,
+		RESTListenAddr:         unittest.DefaultAddress,
 	}
 
 	rpcEngBuilder, err := rpc.NewBuilder(suite.log, suite.state, config, suite.collClient, nil, suite.blocks, suite.headers, suite.collections, suite.transactions,

--- a/engine/access/rpc/backend/connection_factory_test.go
+++ b/engine/access/rpc/backend/connection_factory_test.go
@@ -416,7 +416,7 @@ type node struct {
 
 func (n *node) setupNode(t *testing.T) {
 	n.server = grpc.NewServer()
-	listener, err := net.Listen("tcp4", ":0")
+	listener, err := net.Listen("tcp4", unittest.DefaultAddress)
 	assert.NoError(t, err)
 	n.listener = listener
 	assert.Eventually(t, func() bool {

--- a/engine/access/rpc/rate_limit_test.go
+++ b/engine/access/rpc/rate_limit_test.go
@@ -90,9 +90,9 @@ func (suite *RateLimitTestSuite) SetupTest() {
 	suite.metrics = metrics.NewNoopCollector()
 
 	config := Config{
-		UnsecureGRPCListenAddr: ":0", // :0 to let the OS pick a free port
-		SecureGRPCListenAddr:   ":0",
-		HTTPListenAddr:         ":0",
+		UnsecureGRPCListenAddr: unittest.DefaultAddress,
+		SecureGRPCListenAddr:   unittest.DefaultAddress,
+		HTTPListenAddr:         unittest.DefaultAddress,
 	}
 
 	// set the rate limit to test with

--- a/engine/access/secure_grpcr_test.go
+++ b/engine/access/secure_grpcr_test.go
@@ -86,9 +86,9 @@ func (suite *SecureGRPCTestSuite) SetupTest() {
 	suite.metrics = metrics.NewNoopCollector()
 
 	config := rpc.Config{
-		UnsecureGRPCListenAddr: ":0", // :0 to let the OS pick a free port
-		SecureGRPCListenAddr:   ":0",
-		HTTPListenAddr:         ":0",
+		UnsecureGRPCListenAddr: unittest.DefaultAddress,
+		SecureGRPCListenAddr:   unittest.DefaultAddress,
+		HTTPListenAddr:         unittest.DefaultAddress,
 	}
 
 	// generate a server certificate that will be served by the GRPC server

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -727,7 +727,7 @@ func (net *FlowNetwork) addConsensusFollower(t *testing.T, rootProtocolSnapshotP
 
 	// consensus follower
 	bindPort := testingdock.RandomPort(t)
-	bindAddr := fmt.Sprintf("0.0.0.0:%s", bindPort)
+	bindAddr := fmt.Sprintf("localhost:%s", bindPort)
 	opts := append(
 		followerConf.Opts,
 		consensus_follower.WithDataDir(dataDir),

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"math/rand"
+	gonet "net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -727,7 +728,7 @@ func (net *FlowNetwork) addConsensusFollower(t *testing.T, rootProtocolSnapshotP
 
 	// consensus follower
 	bindPort := testingdock.RandomPort(t)
-	bindAddr := fmt.Sprintf("localhost:%s", bindPort)
+	bindAddr := gonet.JoinHostPort("localhost", bindPort)
 	opts := append(
 		followerConf.Opts,
 		consensus_follower.WithDataDir(dataDir),

--- a/integration/tests/access/access_test.go
+++ b/integration/tests/access/access_test.go
@@ -2,7 +2,6 @@ package access
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -89,7 +88,7 @@ func (suite *AccessSuite) SetupTest() {
 
 func (suite *AccessSuite) TestAPIsAvailable() {
 	suite.T().Run("TestHTTPProxyPortOpen", func(t *testing.T) {
-		httpProxyAddress := fmt.Sprintf("localhost:%s", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
+		httpProxyAddress := net.JoinHostPort("localhost", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
 
 		conn, err := net.DialTimeout("tcp", httpProxyAddress, 1*time.Second)
 		require.NoError(suite.T(), err, "http proxy port not open on the access node")
@@ -98,7 +97,7 @@ func (suite *AccessSuite) TestAPIsAvailable() {
 	})
 
 	suite.T().Run("TestAccessConnection", func(t *testing.T) {
-		grpcAddress := fmt.Sprintf("localhost:%s", suite.net.AccessPorts[testnet.AccessNodeAPIPort])
+		grpcAddress := net.JoinHostPort("localhost", suite.net.AccessPorts[testnet.AccessNodeAPIPort])
 
 		ctx, cancel := context.WithTimeout(suite.ctx, 1*time.Second)
 		defer cancel()

--- a/integration/tests/access/access_test.go
+++ b/integration/tests/access/access_test.go
@@ -89,7 +89,7 @@ func (suite *AccessSuite) SetupTest() {
 
 func (suite *AccessSuite) TestAPIsAvailable() {
 	suite.T().Run("TestHTTPProxyPortOpen", func(t *testing.T) {
-		httpProxyAddress := fmt.Sprintf(":%s", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
+		httpProxyAddress := fmt.Sprintf("localhost:%s", suite.net.AccessPorts[testnet.AccessNodeAPIProxyPort])
 
 		conn, err := net.DialTimeout("tcp", httpProxyAddress, 1*time.Second)
 		require.NoError(suite.T(), err, "http proxy port not open on the access node")
@@ -98,7 +98,7 @@ func (suite *AccessSuite) TestAPIsAvailable() {
 	})
 
 	suite.T().Run("TestAccessConnection", func(t *testing.T) {
-		grpcAddress := fmt.Sprintf("0.0.0.0:%s", suite.net.AccessPorts[testnet.AccessNodeAPIPort])
+		grpcAddress := fmt.Sprintf("localhost:%s", suite.net.AccessPorts[testnet.AccessNodeAPIPort])
 
 		ctx, cancel := context.WithTimeout(suite.ctx, 1*time.Second)
 		defer cancel()

--- a/integration/tests/access/observer_test.go
+++ b/integration/tests/access/observer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -33,7 +34,9 @@ type ObserverSuite struct {
 }
 
 func (suite *ObserverSuite) TearDownTest() {
-	suite.teardown()
+	if suite.teardown != nil {
+		suite.teardown()
+	}
 }
 
 func (suite *ObserverSuite) SetupTest() {
@@ -87,13 +90,7 @@ func (suite *ObserverSuite) SetupTest() {
 		AccessPublicNetworkPort: fmt.Sprint(testnet.AccessNodePublicNetworkPort),
 		AccessGRPCSecurePort:    fmt.Sprint(testnet.DefaultSecureGRPCPort),
 	})
-
-	if err != nil {
-		// this can happen occaisionally...
-		// usually it's because docker didn't remove the observer container during the previous test.
-		// the observer container is removed by an "AutoRemove" flag in AddObserver.
-		panic(err)
-	}
+	require.NoError(suite.T(), err)
 
 	time.Sleep(time.Second * 3) // needs breathing room for the observer to start listening
 
@@ -188,11 +185,11 @@ func (suite *ObserverSuite) TestObserverCompareRPCs() {
 }
 
 func (suite *ObserverSuite) getAccessClient() (accessproto.AccessAPIClient, error) {
-	return suite.getClient(fmt.Sprintf("0.0.0.0:%s", suite.net.AccessPorts[testnet.AccessNodeAPIPort]))
+	return suite.getClient(fmt.Sprintf("localhost:%s", suite.net.AccessPorts[testnet.AccessNodeAPIPort]))
 }
 
 func (suite *ObserverSuite) getObserverClient() (accessproto.AccessAPIClient, error) {
-	return suite.getClient(fmt.Sprintf("0.0.0.0:%s", suite.net.ObserverPorts[testnet.ObserverNodeAPIPort]))
+	return suite.getClient(fmt.Sprintf("localhost:%s", suite.net.ObserverPorts[testnet.ObserverNodeAPIPort]))
 }
 
 func (suite *ObserverSuite) getClient(address string) (accessproto.AccessAPIClient, error) {

--- a/integration/tests/access/observer_test.go
+++ b/integration/tests/access/observer_test.go
@@ -3,6 +3,7 @@ package access
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -185,11 +186,11 @@ func (suite *ObserverSuite) TestObserverCompareRPCs() {
 }
 
 func (suite *ObserverSuite) getAccessClient() (accessproto.AccessAPIClient, error) {
-	return suite.getClient(fmt.Sprintf("localhost:%s", suite.net.AccessPorts[testnet.AccessNodeAPIPort]))
+	return suite.getClient(net.JoinHostPort("localhost", suite.net.AccessPorts[testnet.AccessNodeAPIPort]))
 }
 
 func (suite *ObserverSuite) getObserverClient() (accessproto.AccessAPIClient, error) {
-	return suite.getClient(fmt.Sprintf("localhost:%s", suite.net.ObserverPorts[testnet.ObserverNodeAPIPort]))
+	return suite.getClient(net.JoinHostPort("localhost", suite.net.ObserverPorts[testnet.ObserverNodeAPIPort]))
 }
 
 func (suite *ObserverSuite) getClient(address string) (accessproto.AccessAPIClient, error) {

--- a/network/internal/p2pfixtures/fixtures.go
+++ b/network/internal/p2pfixtures/fixtures.go
@@ -51,7 +51,7 @@ func NetworkingKeyFixtures(t *testing.T) crypto.PrivateKey {
 func SilentNodeFixture(t *testing.T) (net.Listener, flow.Identity) {
 	key := NetworkingKeyFixtures(t)
 
-	lst, err := net.Listen("tcp4", ":0")
+	lst, err := net.Listen("tcp4", unittest.DefaultAddress)
 	require.NoError(t, err)
 
 	addr, err := manet.FromNetAddr(lst.Addr())
@@ -98,7 +98,7 @@ func CreateNode(t *testing.T, nodeID flow.Identifier, networkKey crypto.PrivateK
 	builder := p2pbuilder.NewNodeBuilder(
 		logger,
 		metrics.NewNoopCollector(),
-		"0.0.0.0:0",
+		unittest.DefaultAddress,
 		networkKey,
 		sporkID).
 		SetRoutingSystem(func(c context.Context, h host.Host) (routing.Routing, error) {

--- a/network/internal/testutils/testUtil.go
+++ b/network/internal/testutils/testUtil.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"runtime"
 	"strings"
@@ -139,7 +138,7 @@ func GenerateIDs(t *testing.T, logger zerolog.Logger, n int, opts ...func(*optsC
 		_, port, err := libP2PNodes[i].GetIPPort()
 		require.NoError(t, err)
 
-		identities[i].Address = fmt.Sprintf("0.0.0.0:%s", port)
+		identities[i].Address = unittest.IPPort(port)
 		identities[i].NetworkPubKey = key.PublicKey()
 	}
 
@@ -359,7 +358,7 @@ func generateLibP2PNode(t *testing.T,
 	// Inject some logic to be able to observe connections of this node
 	connManager := NewTagWatchingConnManager(logger, idProvider, noopMetrics)
 
-	builder := p2pbuilder.NewNodeBuilder(logger, metrics.NewNoopCollector(), "0.0.0.0:0", key, sporkID).
+	builder := p2pbuilder.NewNodeBuilder(logger, metrics.NewNoopCollector(), unittest.DefaultAddress, key, sporkID).
 		SetConnectionManager(connManager).
 		SetResourceManager(NewResourceManager(t))
 

--- a/network/p2p/p2pnode/protocolPeerCache_test.go
+++ b/network/p2p/p2pnode/protocolPeerCache_test.go
@@ -25,13 +25,13 @@ func TestProtocolPeerCache(t *testing.T) {
 	defer cancel()
 
 	// create three hosts, and a pcache for the first
-	h1, err := p2pbuilder.DefaultLibP2PHost("0.0.0.0:0", unittest.KeyFixture(fcrypto.ECDSASecp256k1))
+	h1, err := p2pbuilder.DefaultLibP2PHost(unittest.DefaultAddress, unittest.KeyFixture(fcrypto.ECDSASecp256k1))
 	require.NoError(t, err)
 	pcache, err := p2pnode.NewProtocolPeerCache(zerolog.Nop(), h1)
 	require.NoError(t, err)
-	h2, err := p2pbuilder.DefaultLibP2PHost("0.0.0.0:0", unittest.KeyFixture(fcrypto.ECDSASecp256k1))
+	h2, err := p2pbuilder.DefaultLibP2PHost(unittest.DefaultAddress, unittest.KeyFixture(fcrypto.ECDSASecp256k1))
 	require.NoError(t, err)
-	h3, err := p2pbuilder.DefaultLibP2PHost("0.0.0.0:0", unittest.KeyFixture(fcrypto.ECDSASecp256k1))
+	h3, err := p2pbuilder.DefaultLibP2PHost(unittest.DefaultAddress, unittest.KeyFixture(fcrypto.ECDSASecp256k1))
 	require.NoError(t, err)
 
 	// register each host on a separate protocol

--- a/network/p2p/test/fixtures.go
+++ b/network/p2p/test/fixtures.go
@@ -33,11 +33,6 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-// Creating a node fixture with defaultAddress lets libp2p runs it on an
-// allocated port by OS. So after fixture created, its address would be
-// "0.0.0.0:<selected-port-by-os>
-const defaultAddress = "0.0.0.0:0"
-
 // NetworkingKeyFixtures is a test helper that generates a ECDSA flow key pair.
 func NetworkingKeyFixtures(t *testing.T) crypto.PrivateKey {
 	seed := unittest.SeedFixture(48)
@@ -59,7 +54,7 @@ func NodeFixture(
 		HandlerFunc: func(network.Stream) {},
 		Unicasts:    nil,
 		Key:         NetworkingKeyFixtures(t),
-		Address:     defaultAddress,
+		Address:     unittest.DefaultAddress,
 		Logger:      unittest.Logger().Level(zerolog.ErrorLevel),
 		Role:        flow.RoleCollection,
 	}

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -4,6 +4,7 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"math/rand"
+	"net"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ const (
 )
 
 func IPPort(port string) string {
-	return fmt.Sprintf("localhost:%s", port)
+	return net.JoinHostPort("localhost", port)
 }
 
 func AddressFixture() flow.Address {

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -42,7 +42,12 @@ import (
 
 const (
 	DefaultSeedFixtureLength = 64
+	DefaultAddress           = "localhost:0"
 )
+
+func IPPort(port string) string {
+	return fmt.Sprintf("localhost:%s", port)
+}
 
 func AddressFixture() flow.Address {
 	return flow.Testnet.Chain().ServiceAddress()


### PR DESCRIPTION
When running unit tests on a mac, there are many alert popups asking for permission to allow incoming connections. This is caused by using `0.0.0.0` as the listen address in the test setup. Update unit tests to instead use localhost.