### PR TITLE
[Testing] Fix races in network unittests

### DIFF
--- a/network/internal/testutils/testUtil.go
+++ b/network/internal/testutils/testUtil.go
@@ -334,8 +334,8 @@ func StartNodes(ctx irrecoverable.SignalerContext, t *testing.T, nodes []p2p.Lib
 // duration.
 func StopComponents[R module.ReadyDoneAware](t *testing.T, rda []R, duration time.Duration) {
 	comps := make([]module.ReadyDoneAware, 0, len(rda))
-	for _, net := range comps {
-		comps = append(comps, net)
+	for _, c := range rda {
+		comps = append(comps, c)
 	}
 
 	unittest.RequireComponentsDoneBefore(t, duration, comps...)

--- a/network/internal/testutils/testUtil.go
+++ b/network/internal/testutils/testUtil.go
@@ -330,6 +330,17 @@ func StartNodes(ctx irrecoverable.SignalerContext, t *testing.T, nodes []p2p.Lib
 	}
 }
 
+// StopComponents stops ReadyDoneAware instances in parallel and fails the test if they could not be stopped within the
+// duration.
+func StopComponents[R module.ReadyDoneAware](t *testing.T, rda []R, duration time.Duration) {
+	comps := make([]module.ReadyDoneAware, 0, len(rda))
+	for _, net := range comps {
+		comps = append(comps, net)
+	}
+
+	unittest.RequireComponentsDoneBefore(t, duration, comps...)
+}
+
 type nodeBuilderOption func(p2pbuilder.NodeBuilder)
 
 func withDHT(prefix string, dhtOpts ...dht.Option) nodeBuilderOption {
@@ -396,28 +407,6 @@ func GenerateSubscriptionManagers(t *testing.T, mws []network.Middleware) []netw
 		sms[i] = subscription.NewChannelSubscriptionManager(mw)
 	}
 	return sms
-}
-
-// StopNetworks stops network instances in parallel and fails the test if they could not be stopped within the
-// duration.
-func StopNetworks(t *testing.T, nets []network.Network, duration time.Duration) {
-	// casts nets instances into ReadyDoneAware components
-	comps := make([]module.ReadyDoneAware, 0, len(nets))
-	for _, net := range nets {
-		comps = append(comps, net)
-	}
-
-	unittest.RequireComponentsDoneBefore(t, duration, comps...)
-}
-
-func StopMiddlewares(t *testing.T, mws []network.Middleware, duration time.Duration) {
-	// casts mws instances into ReadyDoneAware components
-	comps := make([]module.ReadyDoneAware, 0, len(mws))
-	for _, net := range mws {
-		comps = append(comps, net)
-	}
-
-	unittest.RequireComponentsDoneBefore(t, duration, comps...)
 }
 
 // NetworkPayloadFixture creates a blob of random bytes with the given size (in bytes) and returns it.

--- a/network/test/echoengine_test.go
+++ b/network/test/echoengine_test.go
@@ -72,8 +72,8 @@ func (suite *EchoEngineTestSuite) SetupTest() {
 // TearDownTest closes the networks within a specified timeout
 func (suite *EchoEngineTestSuite) TearDownTest() {
 	suite.cancel()
-	testutils.StopNetworks(suite.T(), suite.nets, 3*time.Second)
-	testutils.StopMiddlewares(suite.T(), suite.mws, 3*time.Second)
+	testutils.StopComponents(suite.T(), suite.nets, 3*time.Second)
+	testutils.StopComponents(suite.T(), suite.mws, 3*time.Second)
 }
 
 // TestUnknownChannel evaluates that registering an engine with an unknown channel returns an error.

--- a/network/test/epochtransition_test.go
+++ b/network/test/epochtransition_test.go
@@ -156,7 +156,7 @@ func (suite *MutableIdentityTableSuite) TearDownTest() {
 		cancel()
 	}
 	networks := append(suite.testNodes.networks(), suite.removedTestNodes.networks()...)
-	testutils.StopNetworks(suite.T(), networks, 3*time.Second)
+	testutils.StopComponents(suite.T(), networks, 3*time.Second)
 }
 
 // setupStateMock setup state related mocks (all networks share the same state mock)

--- a/network/test/meshengine_test.go
+++ b/network/test/meshengine_test.go
@@ -94,8 +94,8 @@ func (suite *MeshEngineTestSuite) SetupTest() {
 // TearDownTest closes the networks within a specified timeout
 func (suite *MeshEngineTestSuite) TearDownTest() {
 	suite.cancel()
-	testutils.StopNetworks(suite.T(), suite.nets, 3*time.Second)
-	testutils.StopMiddlewares(suite.T(), suite.mws, 3*time.Second)
+	testutils.StopComponents(suite.T(), suite.nets, 3*time.Second)
+	testutils.StopComponents(suite.T(), suite.mws, 3*time.Second)
 }
 
 // TestAllToAll_Publish evaluates the network of mesh engines against allToAllScenario scenario.

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -142,9 +142,25 @@ func (m *MiddlewareTestSuite) SetupTest() {
 	}
 }
 
+func (m *MiddlewareTestSuite) TearDownTest() {
+	m.mwCancel()
+
+	testutils.StopComponents(m.T(), m.mws, 100*time.Millisecond)
+	testutils.StopComponents(m.T(), m.nodes, 100*time.Millisecond)
+
+	m.mws = nil
+	m.nodes = nil
+	m.ov = nil
+	m.ids = nil
+	m.size = 0
+}
+
 // TestUpdateNodeAddresses tests that the UpdateNodeAddresses method correctly updates
 // the addresses of the staked network participants.
 func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
+	ctx, cancel := context.WithCancel(m.mwCtx)
+	irrecoverableCtx := irrecoverable.NewMockSignalerContext(m.T(), ctx)
+
 	// create a new staked identity
 	ids, libP2PNodes, _ := testutils.GenerateIDs(m.T(), m.logger, 1)
 
@@ -158,11 +174,14 @@ func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
 	overlay := m.createOverlay(providers[0])
 	overlay.On("Receive", m.ids[0].NodeID, mockery.AnythingOfType("*message.Message")).Return(nil)
 	newMw.SetOverlay(overlay)
-	newMw.Start(m.mwCtx)
-	unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, newMw)
 
 	// start up nodes and peer managers
-	testutils.StartNodes(m.mwCtx, m.T(), libP2PNodes, 100*time.Millisecond)
+	testutils.StartNodes(irrecoverableCtx, m.T(), libP2PNodes, 100*time.Millisecond)
+	defer testutils.StopComponents(m.T(), libP2PNodes, 100*time.Millisecond)
+
+	newMw.Start(irrecoverableCtx)
+	defer testutils.StopComponents(m.T(), mws, 100*time.Millisecond)
+	unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, newMw)
 
 	idList := flow.IdentityList(append(m.ids, newId))
 
@@ -182,6 +201,9 @@ func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
 	// now the message should send successfully
 	err = m.mws[0].SendDirect(msg, newId.NodeID)
 	require.NoError(m.T(), err)
+
+	cancel()
+	unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, newMw)
 }
 
 func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
@@ -254,9 +276,11 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	newMw.SetOverlay(overlay)
 
 	ctx, cancel := context.WithCancel(m.mwCtx)
-	irrecoverableCtx, _ := irrecoverable.WithSignaler(ctx)
+	irrecoverableCtx := irrecoverable.NewMockSignalerContext(m.T(), ctx)
 
 	testutils.StartNodes(irrecoverableCtx, m.T(), libP2PNodes, 100*time.Millisecond)
+	defer testutils.StopComponents(m.T(), libP2PNodes, 100*time.Millisecond)
+
 	newMw.Start(irrecoverableCtx)
 	unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, newMw)
 
@@ -347,9 +371,11 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 	newMw.SetOverlay(overlay)
 
 	ctx, cancel := context.WithCancel(m.mwCtx)
-	irrecoverableCtx, _ := irrecoverable.WithSignaler(ctx)
+	irrecoverableCtx := irrecoverable.NewMockSignalerContext(m.T(), ctx)
 
 	testutils.StartNodes(irrecoverableCtx, m.T(), libP2PNodes, 100*time.Millisecond)
+	defer testutils.StopComponents(m.T(), libP2PNodes, 100*time.Millisecond)
+
 	newMw.Start(irrecoverableCtx)
 	unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, newMw)
 
@@ -389,7 +415,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 
 	// shutdown our middleware so that each message can be processed
 	cancel()
-	unittest.RequireCloseBefore(m.T(), newMw.Done(), 100*time.Millisecond, "could not stop middleware on time")
+	unittest.RequireComponentsDoneBefore(m.T(), 100*time.Millisecond, newMw)
 
 	// expect our rate limited peer callback to be invoked once
 	require.Equal(m.T(), uint64(1), rateLimits.Load())
@@ -409,10 +435,6 @@ func (m *MiddlewareTestSuite) createOverlay(provider *testutils.UpdatableIDProvi
 	identityOpts := unittest.WithRole(flow.RoleExecution)
 	overlay.On("Identity", mockery.AnythingOfType("peer.ID")).Maybe().Return(unittest.IdentityFixture(identityOpts), true)
 	return overlay
-}
-
-func (m *MiddlewareTestSuite) TearDownTest() {
-	m.stopMiddlewares()
 }
 
 // TestPingRawReception tests the middleware for solely the
@@ -807,19 +829,4 @@ func (m *MiddlewareTestSuite) TestUnsubscribe() {
 
 	// assert that the new message is not received by the target node
 	unittest.RequireNeverReturnBefore(m.T(), msgRcvdFun, 2*time.Second, "message received unexpectedly")
-}
-
-func (m *MiddlewareTestSuite) stopMiddlewares() {
-	m.mwCancel()
-
-	for i := 0; i < m.size; i++ {
-		unittest.RequireCloseBefore(m.T(), m.mws[i].Done(), 100*time.Millisecond, "could not stop middleware on time")
-		unittest.RequireCloseBefore(m.T(), m.nodes[i].Done(), 100*time.Millisecond, "could not stop libp2p node on time")
-	}
-
-	m.mws = nil
-	m.nodes = nil
-	m.ov = nil
-	m.ids = nil
-	m.size = 0
 }

--- a/utils/unittest/protected_map.go
+++ b/utils/unittest/protected_map.go
@@ -1,0 +1,59 @@
+package unittest
+
+import "sync"
+
+// ProtectedMap is a thread-safe map.
+type ProtectedMap[K comparable, V any] struct {
+	mu sync.RWMutex
+	m  map[K]V
+}
+
+// NewProtectedMap returns a new ProtectedMap with the given types
+func NewProtectedMap[K comparable, V any]() *ProtectedMap[K, V] {
+	return &ProtectedMap[K, V]{
+		m: make(map[K]V),
+	}
+}
+
+// Add adds a key-value pair to the map
+func (p *ProtectedMap[K, V]) Add(key K, value V) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.m[key] = value
+}
+
+// Remove removes a key-value pair from the map
+func (p *ProtectedMap[K, V]) Remove(key K) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.m, key)
+}
+
+// Has returns true if the map contains the given key
+func (p *ProtectedMap[K, V]) Has(key K) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	_, ok := p.m[key]
+	return ok
+}
+
+// Get returns the value for the given key and a boolean indicating if the key was found
+func (p *ProtectedMap[K, V]) Get(key K) (V, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	value, ok := p.m[key]
+	return value, ok
+}
+
+// ForEach iterates over the map and calls the given function for each key-value pair.
+// If the function returns an error, the iteration is stopped and the error is returned.
+func (p *ProtectedMap[K, V]) ForEach(fn func(k K, v V) error) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for k, v := range p.m {
+		if err := fn(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes unittests under `network` flagged by the race detector. Mostly races within the tests themselves, but there was also a race in the peer manager.