### PR TITLE
add network collector from public Gater

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -165,7 +165,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		apiBurstlimits:               nil,
 		PublicNetworkConfig: PublicNetworkConfig{
 			BindAddress: cmd.NotSet,
-			Metrics:     metrics.NewNoopCollector(),
+			Metrics:     metrics.NewNetworkCollector(zerolog.Logger{}),
 		},
 		executionDataSyncEnabled: false,
 		executionDataDir:         filepath.Join(homedir, ".flow", "execution_data"),

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -165,7 +165,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		apiBurstlimits:               nil,
 		PublicNetworkConfig: PublicNetworkConfig{
 			BindAddress: cmd.NotSet,
-			Metrics:     metrics.NewNetworkCollector(zerolog.Logger{}),
+			Metrics:     metrics.NewNetworkCollector(zerolog.Nop()),
 		},
 		executionDataSyncEnabled: false,
 		executionDataDir:         filepath.Join(homedir, ".flow", "execution_data"),

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1000,7 +1000,7 @@ func (builder *FlowAccessNodeBuilder) enqueuePublicNetworkInit() {
 			return libp2pNode, nil
 		}).
 		Component("public network", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
-			builder.PublicNetworkConfig.Metrics = metrics.NewNetworkCollector(builder.Logger, metrics.WithNetworkPrefix("public"))
+			builder.PublicNetworkConfig.Metrics = metrics.NewNetworkCollector(node.Logger, metrics.WithNetworkPrefix("public"))
 
 			msgValidators := publicNetworkMsgValidators(node.Logger.With().Bool("public", true).Logger(), node.IdentityProvider, builder.NodeID)
 

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -114,6 +114,13 @@ type ObserverServiceConfig struct {
 	upstreamNodeAddresses     []string
 	upstreamNodePublicKeys    []string
 	upstreamIdentities        flow.IdentityList // the identity list of upstream peers the node uses to forward API requests to
+	PublicNetworkConfig       PublicNetworkConfig
+}
+
+type PublicNetworkConfig struct {
+	BindAddress string
+	Network     network.Network
+	Metrics     module.NetworkMetrics
 }
 
 // DefaultObserverServiceConfig defines all the default values for the ObserverServiceConfig
@@ -133,9 +140,13 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 			PreferredExecutionNodeIDs: nil,
 			FixedExecutionNodeIDs:     nil,
 		},
-		rpcMetricsEnabled:         false,
-		apiRatelimits:             nil,
-		apiBurstlimits:            nil,
+		rpcMetricsEnabled: false,
+		apiRatelimits:     nil,
+		apiBurstlimits:    nil,
+		PublicNetworkConfig: PublicNetworkConfig{
+			BindAddress: cmd.NotSet,
+			Metrics:     metrics.NewNoopCollector(),
+		},
 		bootstrapNodeAddresses:    []string{},
 		bootstrapNodePublicKeys:   []string{},
 		observerNetworkingKeyPath: cmd.NotSet,
@@ -923,6 +934,7 @@ func (builder *ObserverServiceBuilder) enqueuePublicNetworkInit() {
 			return libp2pNode, nil
 		}).
 		Component("public network", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+			builder.PublicNetworkConfig.Metrics = metrics.NewNetworkCollector(builder.Logger, metrics.WithNetworkPrefix("public"))
 			var heroCacheCollector module.HeroCacheMetrics = metrics.NewNoopCollector()
 			if builder.HeroCacheMetricsEnable {
 				heroCacheCollector = metrics.NetworkReceiveCacheMetricsFactory(builder.MetricsRegisterer)
@@ -936,12 +948,12 @@ func (builder *ObserverServiceBuilder) enqueuePublicNetworkInit() {
 				return nil, fmt.Errorf("could not register networking receive cache metric: %w", err)
 			}
 
-			msgValidators := publicNetworkMsgValidators(node.Logger, node.IdentityProvider, node.NodeID)
+			msgValidators := publicNetworkMsgValidators(node.Logger.With().Bool("public", true).Logger(), node.IdentityProvider, node.NodeID)
 
 			builder.initMiddleware(node.NodeID, node.Metrics.Network, libp2pNode, msgValidators...)
 
 			// topology is nil since it is automatically managed by libp2p
-			net, err := builder.initNetwork(builder.Me, builder.Metrics.Network, builder.Middleware, nil, receiveCache)
+			net, err := builder.initNetwork(builder.Me, builder.PublicNetworkConfig.Metrics, builder.Middleware, nil, receiveCache)
 			if err != nil {
 				return nil, err
 			}

--- a/integration/tests/access/access_test.go
+++ b/integration/tests/access/access_test.go
@@ -3,6 +3,7 @@ package access
 import (
 	"context"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 
@@ -110,5 +111,11 @@ func (suite *AccessSuite) TestAPIsAvailable() {
 
 		_, err = client.Ping(suite.ctx, &accessproto.PingRequest{})
 		assert.NoError(t, err, "failed to ping access node")
+	})
+
+	suite.T().Run("TestAccessMetrics", func(t *testing.T) {
+		metricsAddress := net.JoinHostPort("localhost", suite.net.AccessPorts[testnet.AccessNodeAPIPort])
+		_, err := http.Get("http://" + metricsAddress + "/metrics")
+		require.NoError(suite.T(), err, "metrics port not open on the access node")
 	})
 }


### PR DESCRIPTION
Because the connection metrics have been moved, I have added the initialization for it in the observer, similar to the access node builder's metric init