### PR TITLE
Change info level log for provider engine

### DIFF
--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -189,7 +189,7 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 		Strs("entity_ids", flow.IdentifierList(request.EntityIds).Strings()).
 		Logger()
 
-	lg.Debug().
+	lg.Info().
 		Msg("entity request received")
 
 	// TODO: add reputation system to punish nodes for malicious behaviour (spam / repeated requests)
@@ -263,7 +263,7 @@ func (e *Engine) onEntityRequest(request *internal.EntityRequest) error {
 	}
 
 	e.metrics.MessageSent(e.channel.String(), metrics.MessageEntityResponse)
-	lg.Debug().Msg("entity response sent")
+	lg.Info().Msg("entity response sent")
 
 	return nil
 }

--- a/engine/common/requester/engine.go
+++ b/engine/common/requester/engine.go
@@ -415,7 +415,7 @@ func (e *Engine) dispatchRequest() (bool, error) {
 
 	err = e.con.Unicast(req, providerID)
 	if err != nil {
-		return true, fmt.Errorf("could not send request: %w", err)
+		return true, fmt.Errorf("could not send request for entities %v: %w", logging.IDs(entityIDs), err)
 	}
 	e.requests[req.Nonce] = req
 


### PR DESCRIPTION
Changing the provider engine's log level into INFO for making debugging execution halt issue easier