### PR TITLE
[Build] Remove manual install of golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ install-mock-generators:
 
 .PHONY: install-tools
 install-tools: crypto_setup_gopath check-go-version install-mock-generators
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin v1.49.0; \
 	cd ${GOPATH}; \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.2; \
 	go install github.com/uber/prototool/cmd/prototool@v1.9.0; \


### PR DESCRIPTION
non-content addressable `curl | sh` does not look like a best security practice.  Let's see what breaks if we remove it.