### PR TITLE
[Consensus] TC aggregation multi-message verification fix

### DIFF
--- a/cmd/consensus/notifier.go
+++ b/cmd/consensus/notifier.go
@@ -14,8 +14,10 @@ func createNotifier(log zerolog.Logger, metrics module.HotstuffMetrics, tracer m
 ) *pubsub.Distributor {
 	telemetryConsumer := notifications.NewTelemetryConsumer(log, chain)
 	metricsConsumer := metricsconsumer.NewMetricsConsumer(metrics)
+	logsConsumer := notifications.NewLogConsumer(log)
 	dis := pubsub.NewDistributor()
 	dis.AddConsumer(telemetryConsumer)
 	dis.AddConsumer(metricsConsumer)
+	dis.AddConsumer(logsConsumer)
 	return dis
 }

--- a/consensus/hotstuff/integration/instance_test.go
+++ b/consensus/hotstuff/integration/instance_test.go
@@ -469,14 +469,16 @@ func NewInstance(t *testing.T, options ...Option) *Instance {
 				}, nil,
 			).Maybe()
 			aggregator.On("Aggregate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
-				[]flow.Identifier(in.participants.NodeIDs()),
-				func() []uint64 {
-					newestQCViews := make([]uint64, 0, len(in.participants))
+				func() []hotstuff.TimeoutSignerInfo {
+					signersData := make([]hotstuff.TimeoutSignerInfo, 0, len(in.participants))
 					newestQCView := newestView.Value()
-					for range in.participants {
-						newestQCViews = append(newestQCViews, newestQCView)
+					for _, signer := range in.participants.NodeIDs() {
+						signersData = append(signersData, hotstuff.TimeoutSignerInfo{
+							NewestQCView: newestQCView,
+							Signer:       signer,
+						})
 					}
-					return newestQCViews
+					return signersData
 				},
 				unittest.SignatureFixture(),
 				nil,

--- a/consensus/hotstuff/mocks/timeout_signature_aggregator.go
+++ b/consensus/hotstuff/mocks/timeout_signature_aggregator.go
@@ -6,6 +6,8 @@ import (
 	crypto "github.com/onflow/flow-go/crypto"
 	flow "github.com/onflow/flow-go/model/flow"
 
+	hotstuff "github.com/onflow/flow-go/consensus/hotstuff"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,44 +17,35 @@ type TimeoutSignatureAggregator struct {
 }
 
 // Aggregate provides a mock function with given fields:
-func (_m *TimeoutSignatureAggregator) Aggregate() ([]flow.Identifier, []uint64, crypto.Signature, error) {
+func (_m *TimeoutSignatureAggregator) Aggregate() ([]hotstuff.TimeoutSignerInfo, crypto.Signature, error) {
 	ret := _m.Called()
 
-	var r0 []flow.Identifier
-	if rf, ok := ret.Get(0).(func() []flow.Identifier); ok {
+	var r0 []hotstuff.TimeoutSignerInfo
+	if rf, ok := ret.Get(0).(func() []hotstuff.TimeoutSignerInfo); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]flow.Identifier)
+			r0 = ret.Get(0).([]hotstuff.TimeoutSignerInfo)
 		}
 	}
 
-	var r1 []uint64
-	if rf, ok := ret.Get(1).(func() []uint64); ok {
+	var r1 crypto.Signature
+	if rf, ok := ret.Get(1).(func() crypto.Signature); ok {
 		r1 = rf()
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]uint64)
+			r1 = ret.Get(1).(crypto.Signature)
 		}
 	}
 
-	var r2 crypto.Signature
-	if rf, ok := ret.Get(2).(func() crypto.Signature); ok {
+	var r2 error
+	if rf, ok := ret.Get(2).(func() error); ok {
 		r2 = rf()
 	} else {
-		if ret.Get(2) != nil {
-			r2 = ret.Get(2).(crypto.Signature)
-		}
+		r2 = ret.Error(2)
 	}
 
-	var r3 error
-	if rf, ok := ret.Get(3).(func() error); ok {
-		r3 = rf()
-	} else {
-		r3 = ret.Error(3)
-	}
-
-	return r0, r1, r2, r3
+	return r0, r1, r2
 }
 
 // TotalWeight provides a mock function with given fields:

--- a/consensus/hotstuff/notifications/log_consumer.go
+++ b/consensus/hotstuff/notifications/log_consumer.go
@@ -176,10 +176,8 @@ func (lc *LogConsumer) OnDoubleTimeoutDetected(timeout *model.TimeoutObject, alt
 }
 
 func (lc *LogConsumer) OnInvalidTimeoutDetected(timeout *model.TimeoutObject) {
-	lc.log.Warn().
-		Uint64("timeout_view", timeout.View).
-		Hex("signer_id", timeout.SignerID[:]).
-		Msg("invalid timeout detected")
+	log := timeout.LogContext(lc.log).Logger()
+	log.Warn().Msg("invalid timeout detected")
 }
 
 func (lc *LogConsumer) logBasicBlockData(loggerEvent *zerolog.Event, block *model.Block) *zerolog.Event {
@@ -227,7 +225,7 @@ func (lc *LogConsumer) OnNewTcDiscovered(tc *flow.TimeoutCertificate) {
 }
 
 func (lc *LogConsumer) OnOwnVote(blockID flow.Identifier, view uint64, sigData []byte, recipientID flow.Identifier) {
-	lc.log.Info().
+	lc.log.Debug().
 		Hex("block_id", blockID[:]).
 		Uint64("block_view", view).
 		Hex("recipient_id", recipientID[:]).
@@ -236,11 +234,11 @@ func (lc *LogConsumer) OnOwnVote(blockID flow.Identifier, view uint64, sigData [
 
 func (lc *LogConsumer) OnOwnTimeout(timeout *model.TimeoutObject) {
 	log := timeout.LogContext(lc.log).Logger()
-	log.Info().Msg("publishing HotStuff timeout object")
+	log.Debug().Msg("publishing HotStuff timeout object")
 }
 
 func (lc *LogConsumer) OnOwnProposal(header *flow.Header, targetPublicationTime time.Time) {
-	lc.log.Info().
+	lc.log.Debug().
 		Str("chain_id", header.ChainID.String()).
 		Uint64("block_height", header.Height).
 		Uint64("block_view", header.View).

--- a/consensus/hotstuff/signature.go
+++ b/consensus/hotstuff/signature.go
@@ -131,8 +131,8 @@ type TimeoutSignatureAggregator interface {
 	Aggregate() (signersInfo []TimeoutSignerInfo, aggregatedSig crypto.Signature, exception error)
 }
 
-// TimeoutSignerInfo is a helper structure that stores what QC views each signer has contributed into TC's aggregated signature.
-// Used as result of TimeoutSignatureAggregator.Aggregate()
+// TimeoutSignerInfo is a helper structure that stores the QC views that each signer
+// contributed to a TC. Used as result of TimeoutSignatureAggregator.Aggregate()
 type TimeoutSignerInfo struct {
 	NewestQCView uint64
 	Signer       flow.Identifier

--- a/consensus/hotstuff/signature.go
+++ b/consensus/hotstuff/signature.go
@@ -128,7 +128,14 @@ type TimeoutSignatureAggregator interface {
 	// Caller can be sure that resulting signature is valid.
 	// Expected errors during normal operations:
 	//  - model.InsufficientSignaturesError if no signatures have been added yet
-	Aggregate() (signers []flow.Identifier, newestQCViews []uint64, aggregatedSig crypto.Signature, exception error)
+	Aggregate() (signersInfo []TimeoutSignerInfo, aggregatedSig crypto.Signature, exception error)
+}
+
+// TimeoutSignerInfo is a helper structure that stores what QC views each signer has contributed into TC's aggregated signature.
+// Used as result of TimeoutSignatureAggregator.Aggregate()
+type TimeoutSignerInfo struct {
+	NewestQCView uint64
+	Signer       flow.Identifier
 }
 
 // BlockSignatureData is an intermediate struct for Packer to pack the

--- a/consensus/hotstuff/timeoutcollector/aggregation_test.go
+++ b/consensus/hotstuff/timeoutcollector/aggregation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/consensus/hotstuff/verification"
 	"github.com/onflow/flow-go/crypto"
@@ -22,7 +23,7 @@ func createAggregationData(t *testing.T, signersNumber int) (
 	flow.IdentityList,
 	[]crypto.PublicKey,
 	[]crypto.Signature,
-	[]uint64,
+	[]hotstuff.TimeoutSignerInfo,
 	[][]byte,
 	[]hash.Hasher) {
 
@@ -30,7 +31,7 @@ func createAggregationData(t *testing.T, signersNumber int) (
 	tag := "random_tag"
 	hasher := msig.NewBLSHasher(tag)
 	sigs := make([]crypto.Signature, 0, signersNumber)
-	newestQCViews := make([]uint64, 0, signersNumber)
+	signersInfo := make([]hotstuff.TimeoutSignerInfo, 0, signersNumber)
 	msgs := make([][]byte, 0, signersNumber)
 	hashers := make([]hash.Hasher, 0, signersNumber)
 
@@ -52,13 +53,16 @@ func createAggregationData(t *testing.T, signersNumber int) (
 		sigs = append(sigs, sig)
 
 		pks = append(pks, identity.StakingPubKey)
-		newestQCViews = append(newestQCViews, newestQCView)
+		signersInfo = append(signersInfo, hotstuff.TimeoutSignerInfo{
+			NewestQCView: newestQCView,
+			Signer:       identity.NodeID,
+		})
 		hashers = append(hashers, hasher)
 		msgs = append(msgs, msg)
 	}
 	aggregator, err := NewTimeoutSignatureAggregator(view, ids, tag)
 	require.NoError(t, err)
-	return aggregator, ids, pks, sigs, newestQCViews, msgs, hashers
+	return aggregator, ids, pks, sigs, signersInfo, msgs, hashers
 }
 
 // TestNewTimeoutSignatureAggregator tests different happy and unhappy path scenarios when constructing
@@ -80,7 +84,7 @@ func TestNewTimeoutSignatureAggregator(t *testing.T) {
 // Tests verification, adding and aggregation. Test is performed in concurrent environment
 func TestTimeoutSignatureAggregator_HappyPath(t *testing.T) {
 	signersNum := 20
-	aggregator, ids, pks, sigs, newestQCViews, msgs, hashers := createAggregationData(t, signersNum)
+	aggregator, ids, pks, sigs, actualSignersInfo, msgs, hashers := createAggregationData(t, signersNum)
 
 	// only add a subset of the signatures
 	subSet := signersNum / 2
@@ -93,7 +97,7 @@ func TestTimeoutSignatureAggregator_HappyPath(t *testing.T) {
 			defer wg.Done()
 			index := i + subSet
 			// test VerifyAndAdd
-			_, err := aggregator.VerifyAndAdd(ids[index].NodeID, sig, newestQCViews[index])
+			_, err := aggregator.VerifyAndAdd(ids[index].NodeID, sig, actualSignersInfo[index].NewestQCView)
 			// ignore weight as comparing against expected weight is not thread safe
 			require.NoError(t, err)
 		}(i, sig)
@@ -101,9 +105,9 @@ func TestTimeoutSignatureAggregator_HappyPath(t *testing.T) {
 	}
 
 	wg.Wait()
-	signers, actualHighQCViews, aggSig, err := aggregator.Aggregate()
+	signersData, aggSig, err := aggregator.Aggregate()
 	require.NoError(t, err)
-	require.ElementsMatch(t, newestQCViews[subSet:], actualHighQCViews)
+	require.ElementsMatch(t, signersData[subSet:], actualSignersInfo)
 
 	ok, err := crypto.VerifyBLSSignatureManyMessages(pks[subSet:], aggSig, msgs[subSet:], hashers[subSet:])
 	require.NoError(t, err)
@@ -113,20 +117,20 @@ func TestTimeoutSignatureAggregator_HappyPath(t *testing.T) {
 	for i := subSet; i < signersNum; i++ {
 		identifiers = append(identifiers, ids[i].NodeID)
 	}
-	require.ElementsMatch(t, signers, identifiers)
+	require.ElementsMatch(t, signersData, identifiers)
 
 	// add remaining signatures in one thread in order to test the returned weight
 	for i, sig := range sigs[:subSet] {
-		weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sig, newestQCViews[i])
+		weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sig, actualSignersInfo[i].NewestQCView)
 		require.NoError(t, err)
 		expectedWeight += ids[i].Weight
 		require.Equal(t, expectedWeight, weight)
 		// test TotalWeight
 		require.Equal(t, expectedWeight, aggregator.TotalWeight())
 	}
-	signers, actualHighQCViews, aggSig, err = aggregator.Aggregate()
+	signersData, aggSig, err = aggregator.Aggregate()
 	require.NoError(t, err)
-	require.ElementsMatch(t, newestQCViews, actualHighQCViews)
+	require.ElementsMatch(t, signersData, actualSignersInfo)
 
 	ok, err = crypto.VerifyBLSSignatureManyMessages(pks, aggSig, msgs, hashers)
 	require.NoError(t, err)
@@ -136,7 +140,7 @@ func TestTimeoutSignatureAggregator_HappyPath(t *testing.T) {
 	for i := 0; i < signersNum; i++ {
 		identifiers = append(identifiers, ids[i].NodeID)
 	}
-	require.ElementsMatch(t, signers, identifiers)
+	require.ElementsMatch(t, signersData, identifiers)
 }
 
 // TestTimeoutSignatureAggregator_VerifyAndAdd tests behavior of VerifyAndAdd under invalid input data.
@@ -145,22 +149,22 @@ func TestTimeoutSignatureAggregator_VerifyAndAdd(t *testing.T) {
 
 	// Unhappy paths
 	t.Run("invalid signer ID", func(t *testing.T) {
-		aggregator, _, _, sigs, newestQCViews, _, _ := createAggregationData(t, signersNum)
+		aggregator, _, _, sigs, signersInfo, _, _ := createAggregationData(t, signersNum)
 		// generate an ID that is not in the node ID list
 		invalidId := unittest.IdentifierFixture()
 
-		weight, err := aggregator.VerifyAndAdd(invalidId, sigs[0], newestQCViews[0])
+		weight, err := aggregator.VerifyAndAdd(invalidId, sigs[0], signersInfo[0].NewestQCView)
 		require.Equal(t, uint64(0), weight)
 		require.Equal(t, uint64(0), aggregator.TotalWeight())
 		require.True(t, model.IsInvalidSignerError(err))
 	})
 
 	t.Run("duplicate signature", func(t *testing.T) {
-		aggregator, ids, _, sigs, newestQCViews, _, _ := createAggregationData(t, signersNum)
+		aggregator, ids, _, sigs, signersInfo, _, _ := createAggregationData(t, signersNum)
 		expectedWeight := uint64(0)
 		// add signatures
 		for i, sig := range sigs {
-			weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sig, newestQCViews[i])
+			weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sig, signersInfo[i].NewestQCView)
 			expectedWeight += ids[i].Weight
 			require.Equal(t, expectedWeight, weight)
 			require.NoError(t, err)
@@ -172,15 +176,15 @@ func TestTimeoutSignatureAggregator_VerifyAndAdd(t *testing.T) {
 			// test thread safety
 			go func(i int, sig crypto.Signature) {
 				defer wg.Done()
-				weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sigs[i], newestQCViews[i]) // same signature for same index
+				weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sigs[i], signersInfo[i].NewestQCView) // same signature for same index
 				// weight should not change
 				require.Equal(t, expectedWeight, weight)
 				require.True(t, model.IsDuplicatedSignerError(err))
-				weight, err = aggregator.VerifyAndAdd(ids[i].NodeID, sigs[(i+1)%signersNum], newestQCViews[(i+1)%signersNum]) // different signature for same index
+				weight, err = aggregator.VerifyAndAdd(ids[i].NodeID, sigs[(i+1)%signersNum], signersInfo[(i+1)%signersNum].NewestQCView) // different signature for same index
 				// weight should not change
 				require.Equal(t, expectedWeight, weight)
 				require.True(t, model.IsDuplicatedSignerError(err))
-				weight, err = aggregator.VerifyAndAdd(ids[(i+1)%signersNum].NodeID, sigs[(i+1)%signersNum], newestQCViews[(i+1)%signersNum]) // different signature for same index
+				weight, err = aggregator.VerifyAndAdd(ids[(i+1)%signersNum].NodeID, sigs[(i+1)%signersNum], signersInfo[(i+1)%signersNum].NewestQCView) // different signature for same index
 				// weight should not change
 				require.Equal(t, expectedWeight, weight)
 				require.True(t, model.IsDuplicatedSignerError(err))
@@ -197,26 +201,26 @@ func TestTimeoutSignatureAggregator_Aggregate(t *testing.T) {
 
 	t.Run("invalid signature", func(t *testing.T) {
 		var err error
-		aggregator, ids, pks, sigs, newestQCViews, msgs, hashers := createAggregationData(t, signersNum)
+		aggregator, ids, pks, sigs, signersInfo, msgs, hashers := createAggregationData(t, signersNum)
 		// replace sig with random one
 		sk := unittest.PrivateKeyFixture(crypto.BLSBLS12381, crypto.KeyGenSeedMinLenECDSAP256)
 		sigs[0], err = sk.Sign([]byte("dummy"), hashers[0])
 		require.NoError(t, err)
 
 		// test VerifyAndAdd
-		_, err = aggregator.VerifyAndAdd(ids[0].NodeID, sigs[0], newestQCViews[0])
+		_, err = aggregator.VerifyAndAdd(ids[0].NodeID, sigs[0], signersInfo[0].NewestQCView)
 		require.ErrorIs(t, err, model.ErrInvalidSignature)
 
 		// add signatures for aggregation including corrupt sigs[0]
 		expectedWeight := uint64(0)
 		for i, sig := range sigs {
-			weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sig, newestQCViews[i])
+			weight, err := aggregator.VerifyAndAdd(ids[i].NodeID, sig, signersInfo[i].NewestQCView)
 			if err == nil {
 				expectedWeight += ids[i].Weight
 			}
 			require.Equal(t, expectedWeight, weight)
 		}
-		signers, _, aggSig, err := aggregator.Aggregate()
+		signers, aggSig, err := aggregator.Aggregate()
 		require.NoError(t, err)
 		// we should have signers for all signatures except first one since it's invalid
 		require.Equal(t, len(signers), len(ids)-1)
@@ -230,10 +234,9 @@ func TestTimeoutSignatureAggregator_Aggregate(t *testing.T) {
 		aggregator, _, _, _, _, _, _ := createAggregationData(t, signersNum)
 
 		// no signatures were added => aggregate should error with
-		signers, actualHighQCViews, aggSig, err := aggregator.Aggregate()
+		signersData, aggSig, err := aggregator.Aggregate()
 		require.True(t, model.IsInsufficientSignaturesError(err))
-		require.Nil(t, signers)
-		require.Nil(t, actualHighQCViews)
+		require.Nil(t, signersData)
 		require.Nil(t, aggSig)
 
 		// Also, _after_ attempting to add a signature from unknown `signerID`:
@@ -242,10 +245,9 @@ func TestTimeoutSignatureAggregator_Aggregate(t *testing.T) {
 		_, err = aggregator.VerifyAndAdd(unittest.IdentifierFixture(), unittest.SignatureFixture(), 0)
 		require.True(t, model.IsInvalidSignerError(err))
 
-		signers, actualHighQCViews, aggSig, err = aggregator.Aggregate()
+		signersData, aggSig, err = aggregator.Aggregate()
 		require.True(t, model.IsInsufficientSignaturesError(err))
-		require.Nil(t, signers)
-		require.Nil(t, actualHighQCViews)
+		require.Nil(t, signersData)
 		require.Nil(t, aggSig)
 	})
 }

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -251,10 +251,11 @@ func (p *TimeoutProcessor) buildTC() (*flow.TimeoutCertificate, error) {
 	}
 
 	// IMPORTANT: To properly verify an aggregated signature included in TC we need to provide list of signers with corresponding
-	// messages(`TimeoutCertificate.NewestQCViews`) for each signer, this relation should be very strict.
+	// messages(`TimeoutCertificate.NewestQCViews`) for each signer. If the one-to-once correspondence of view and signer is not
+	// maintained, the TC's aggregated signature will be invalid. 
 	// Aggregate returns an unordered set of signers together with additional data.
-	// Due to implementation specifics of signer indices decoding step results in canonically ordered
-	// signer ids which means we need to canonically order messages, so we can properly map signer to message after decoding.
+	// Due to implementation specifics of signer indices, the decoding step results in canonically ordered signer ids, which means
+	// we need to canonically order the respective `newestQCView`, so we can properly map signer to `newestQCView` after decoding.
 
 	// sort data in canonical order
 	slices.SortFunc(signersData, func(lhs, rhs hotstuff.TimeoutSignerInfo) bool {

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -3,7 +3,7 @@ package timeoutcollector
 import (
 	"errors"
 	"fmt"
-	"github.com/onflow/flow-go/model/flow/order"
+
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/consensus/hotstuff/tracker"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/signature"
 )
 

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -251,8 +251,8 @@ func (p *TimeoutProcessor) buildTC() (*flow.TimeoutCertificate, error) {
 	}
 
 	// IMPORTANT: To properly verify an aggregated signature included in TC we need to provide list of signers with corresponding
-	// messages(`TimeoutCertificate.NewestQCViews`) for each signer. If the one-to-once correspondence of view and signer is not
-	// maintained, the TC's aggregated signature will be invalid. 
+	// messages(`TimeoutCertificate.NewestQCViews`) for each signer. If the one-to-once correspondence of view and signer is not maintained,
+	// it won't be possible to verify the aggregated signature.
 	// Aggregate returns an unordered set of signers together with additional data.
 	// Due to implementation specifics of signer indices, the decoding step results in canonically ordered signer ids, which means
 	// we need to canonically order the respective `newestQCView`, so we can properly map signer to `newestQCView` after decoding.

--- a/consensus/hotstuff/timeoutcollector/timeout_processor_test.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor_test.go
@@ -3,7 +3,6 @@ package timeoutcollector
 import (
 	"errors"
 	"fmt"
-	"github.com/onflow/flow-go/consensus/hotstuff"
 	"math/rand"
 	"sync"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
+	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/committees"
 	"github.com/onflow/flow-go/consensus/hotstuff/helper"
 	"github.com/onflow/flow-go/consensus/hotstuff/mocks"
@@ -22,6 +22,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff/votecollector"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/local"
 	msig "github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -445,6 +446,8 @@ func TestTimeoutProcessor_BuildVerifyTC(t *testing.T) {
 
 		signers[identity.NodeID] = verification.NewStakingSigner(me)
 	})
+	// identities must be in canonical order
+	stakingSigners = stakingSigners.Sort(order.Canonical)
 
 	// utility function which generates a valid timeout for every signer
 	createTimeouts := func(participants flow.IdentityList, view uint64, newestQC *flow.QuorumCertificate, lastViewTC *flow.TimeoutCertificate) []*model.TimeoutObject {

--- a/module/signature/signer_indices.go
+++ b/module/signature/signer_indices.go
@@ -3,7 +3,6 @@ package signature
 import (
 	"errors"
 	"fmt"
-
 	"github.com/onflow/flow-go/ledger/common/bitutils"
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/module/signature/signer_indices.go
+++ b/module/signature/signer_indices.go
@@ -3,6 +3,7 @@ package signature
 import (
 	"errors"
 	"fmt"
+
 	"github.com/onflow/flow-go/ledger/common/bitutils"
 	"github.com/onflow/flow-go/model/flow"
 )


### PR DESCRIPTION
### Context

This PR fixes a bug which can occur under specific conditions and results in consensus halt effectively undermining liveness. 
Replicas perform a multi-message BLS aggregation to build a TC. To verify such signature we need to provide list of signers and messages used to construct the signature. We provide this data as part of `flow.TimeoutCertificate` structure as two separate lists `SignerIndices` and `NewestQCViews`. Strictly speaking TC verification depends on correct relation between signers and messages, should the order of signers or messages be altered and we cannot verify the signature anymore. 
And that's exactly what has happened when replicas contributed with different messages, signers got sorted in canonical order because of signer indices implementation but messages weren't which resulted in inability to verify the signature.

Proposed solution is to properly order both signers and messages when constructing a TC. As part of this PR I have modified our test to represent this scenario to make sure that problem is indeed solved.

### Motivation for implementation

There were two ways how to approach it:
1. Sort data in `TimeoutSignatureAggregator.Aggregate()`
2. Sort data in `TimeoutProcessor.buildTC()`.

While the 1. would be simpler to implement I have picked 2. because this resulted in more clear separation of concepts. Sig aggregator doesn't know anything what we are going to do aggregated data, it doesn't require ordered data, doesn't know anything about TC structure and signer indices. On other side `TimeoutProcessor` knows about all of those things and can make a decision to properly order data knowing that signer indices will introduce canonical ordering.
