### PR TITLE
[Execution] Remove runtime memory stats

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onflow/flow-go/module/executiondatasync/provider"
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/trace"
-	"github.com/onflow/flow-go/utils/debug"
 	"github.com/onflow/flow-go/utils/logging"
 )
 
@@ -370,7 +369,6 @@ func (e *blockComputer) executeTransaction(
 	isSystemTransaction bool,
 ) error {
 	startedAt := time.Now()
-	memAllocBefore := debug.GetHeapAllocsBytes()
 	txID := txBody.ID()
 
 	// we capture two spans one for tx-based view and one for the current context (block-based) view
@@ -438,15 +436,12 @@ func (e *blockComputer) executeTransaction(
 
 	collector.AddTransactionResult(collectionIndex, tx)
 
-	memAllocAfter := debug.GetHeapAllocsBytes()
-
 	lg := e.log.With().
 		Str("tx_id", txID.String()).
 		Str("block_id", blockIdStr).
 		Str("traceID", traceID).
 		Uint64("computation_used", tx.ComputationUsed).
 		Uint64("memory_used", tx.MemoryEstimate).
-		Uint64("memAlloc", memAllocAfter-memAllocBefore).
 		Int64("timeSpentInMS", time.Since(startedAt).Milliseconds()).
 		Logger()
 
@@ -479,7 +474,6 @@ func (e *blockComputer) executeTransaction(
 		time.Since(startedAt),
 		tx.ComputationUsed,
 		tx.MemoryEstimate,
-		memAllocAfter-memAllocBefore,
 		len(tx.Events),
 		flow.EventsList(tx.Events).ByteSize(),
 		tx.Err != nil,

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -85,7 +85,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			mock.Anything, // duration
 			mock.Anything, // computation used
 			mock.Anything, // memory used
-			mock.Anything, // actual memory used
 			mock.Anything, // number of events
 			mock.Anything, // size of events
 			false).        // no failure
@@ -887,7 +886,6 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 		mock.Anything, // duration
 		mock.Anything, // computation used
 		mock.Anything, // memory used
-		mock.Anything, // actual memory used
 		expectedNumberOfEvents,
 		expectedEventSize,
 		false).

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state/protocol"
-	"github.com/onflow/flow-go/utils/debug"
 	"github.com/onflow/flow-go/utils/logging"
 )
 
@@ -183,7 +182,6 @@ func (e *Manager) ExecuteScript(
 ) ([]byte, error) {
 
 	startedAt := time.Now()
-	memAllocBefore := debug.GetHeapAllocsBytes()
 
 	// allocate a random ID to be able to track this script when its done,
 	// scripts might not be unique so we use this extra tracker to follow their logs
@@ -269,8 +267,7 @@ func (e *Manager) ExecuteScript(
 		return nil, fmt.Errorf("failed to encode runtime value: %w", err)
 	}
 
-	memAllocAfter := debug.GetHeapAllocsBytes()
-	e.metrics.ExecutionScriptExecuted(time.Since(startedAt), script.GasUsed, memAllocAfter-memAllocBefore, script.MemoryEstimate)
+	e.metrics.ExecutionScriptExecuted(time.Since(startedAt), script.GasUsed, script.MemoryEstimate)
 
 	return encodedValue, nil
 }

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -524,7 +524,7 @@ type ExecutionMetrics interface {
 
 	// ExecutionTransactionExecuted reports stats on executing a single transaction
 	ExecutionTransactionExecuted(dur time.Duration,
-		compUsed, memoryUsed, actualMemoryUsed uint64,
+		compUsed, memoryEstimate uint64,
 		eventCounts, eventSize int,
 		failed bool)
 
@@ -532,7 +532,7 @@ type ExecutionMetrics interface {
 	ExecutionChunkDataPackGenerated(proofSize, numberOfTransactions int)
 
 	// ExecutionScriptExecuted reports the time and memory spent on executing an script
-	ExecutionScriptExecuted(dur time.Duration, compUsed, memoryUsed, memoryEstimate uint64)
+	ExecutionScriptExecuted(dur time.Duration, compUsed, memoryEstimate uint64)
 
 	// ExecutionCollectionRequestSent reports when a request for a collection is sent to a collection node
 	ExecutionCollectionRequestSent()

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -134,52 +134,53 @@ func (nc *NoopCollector) ExecutionBlockExecuted(_ time.Duration, _ module.Execut
 func (nc *NoopCollector) ExecutionCollectionExecuted(_ time.Duration, _ module.ExecutionResultStats) {
 }
 func (nc *NoopCollector) ExecutionBlockExecutionEffortVectorComponent(_ string, _ uint) {}
-func (nc *NoopCollector) ExecutionTransactionExecuted(_ time.Duration, _, _, _ uint64, _, _ int, _ bool) {
+func (nc *NoopCollector) ExecutionTransactionExecuted(_ time.Duration, _, _ uint64, _, _ int, _ bool) {
 }
-func (nc *NoopCollector) ExecutionChunkDataPackGenerated(_, _ int)                         {}
-func (nc *NoopCollector) ExecutionScriptExecuted(dur time.Duration, compUsed, _, _ uint64) {}
-func (nc *NoopCollector) ForestApproxMemorySize(bytes uint64)                              {}
-func (nc *NoopCollector) ForestNumberOfTrees(number uint64)                                {}
-func (nc *NoopCollector) LatestTrieRegCount(number uint64)                                 {}
-func (nc *NoopCollector) LatestTrieRegCountDiff(number int64)                              {}
-func (nc *NoopCollector) LatestTrieRegSize(size uint64)                                    {}
-func (nc *NoopCollector) LatestTrieRegSizeDiff(size int64)                                 {}
-func (nc *NoopCollector) LatestTrieMaxDepthTouched(maxDepth uint16)                        {}
-func (nc *NoopCollector) UpdateCount()                                                     {}
-func (nc *NoopCollector) ProofSize(bytes uint32)                                           {}
-func (nc *NoopCollector) UpdateValuesNumber(number uint64)                                 {}
-func (nc *NoopCollector) UpdateValuesSize(byte uint64)                                     {}
-func (nc *NoopCollector) UpdateDuration(duration time.Duration)                            {}
-func (nc *NoopCollector) UpdateDurationPerItem(duration time.Duration)                     {}
-func (nc *NoopCollector) ReadValuesNumber(number uint64)                                   {}
-func (nc *NoopCollector) ReadValuesSize(byte uint64)                                       {}
-func (nc *NoopCollector) ReadDuration(duration time.Duration)                              {}
-func (nc *NoopCollector) ReadDurationPerItem(duration time.Duration)                       {}
-func (nc *NoopCollector) ExecutionCollectionRequestSent()                                  {}
-func (nc *NoopCollector) ExecutionCollectionRequestRetried()                               {}
-func (nc *NoopCollector) RuntimeTransactionParsed(dur time.Duration)                       {}
-func (nc *NoopCollector) RuntimeTransactionChecked(dur time.Duration)                      {}
-func (nc *NoopCollector) RuntimeTransactionInterpreted(dur time.Duration)                  {}
-func (nc *NoopCollector) RuntimeSetNumberOfAccounts(count uint64)                          {}
-func (nc *NoopCollector) ScriptExecuted(dur time.Duration, size int)                       {}
-func (nc *NoopCollector) TransactionResultFetched(dur time.Duration, size int)             {}
-func (nc *NoopCollector) TransactionReceived(txID flow.Identifier, when time.Time)         {}
-func (nc *NoopCollector) TransactionFinalized(txID flow.Identifier, when time.Time)        {}
-func (nc *NoopCollector) TransactionExecuted(txID flow.Identifier, when time.Time)         {}
-func (nc *NoopCollector) TransactionExpired(txID flow.Identifier)                          {}
-func (nc *NoopCollector) TransactionSubmissionFailed()                                     {}
-func (nc *NoopCollector) UpdateExecutionReceiptMaxHeight(height uint64)                    {}
-func (nc *NoopCollector) ChunkDataPackRequestProcessed()                                   {}
-func (nc *NoopCollector) ExecutionSync(syncing bool)                                       {}
-func (nc *NoopCollector) ExecutionBlockDataUploadStarted()                                 {}
-func (nc *NoopCollector) ExecutionBlockDataUploadFinished(dur time.Duration)               {}
-func (nc *NoopCollector) ExecutionComputationResultUploaded()                              {}
-func (nc *NoopCollector) ExecutionComputationResultUploadRetried()                         {}
-func (nc *NoopCollector) RootIDComputed(duration time.Duration, numberOfChunks int)        {}
-func (nc *NoopCollector) AddBlobsSucceeded(duration time.Duration, totalSize uint64)       {}
-func (nc *NoopCollector) AddBlobsFailed()                                                  {}
-func (nc *NoopCollector) FulfilledHeight(blockHeight uint64)                               {}
-func (nc *NoopCollector) ReceiptSkipped()                                                  {}
+func (nc *NoopCollector) ExecutionChunkDataPackGenerated(_, _ int) {}
+func (nc *NoopCollector) ExecutionScriptExecuted(dur time.Duration, compUsed, memoryEstimate uint64) {
+}
+func (nc *NoopCollector) ForestApproxMemorySize(bytes uint64)                        {}
+func (nc *NoopCollector) ForestNumberOfTrees(number uint64)                          {}
+func (nc *NoopCollector) LatestTrieRegCount(number uint64)                           {}
+func (nc *NoopCollector) LatestTrieRegCountDiff(number int64)                        {}
+func (nc *NoopCollector) LatestTrieRegSize(size uint64)                              {}
+func (nc *NoopCollector) LatestTrieRegSizeDiff(size int64)                           {}
+func (nc *NoopCollector) LatestTrieMaxDepthTouched(maxDepth uint16)                  {}
+func (nc *NoopCollector) UpdateCount()                                               {}
+func (nc *NoopCollector) ProofSize(bytes uint32)                                     {}
+func (nc *NoopCollector) UpdateValuesNumber(number uint64)                           {}
+func (nc *NoopCollector) UpdateValuesSize(byte uint64)                               {}
+func (nc *NoopCollector) UpdateDuration(duration time.Duration)                      {}
+func (nc *NoopCollector) UpdateDurationPerItem(duration time.Duration)               {}
+func (nc *NoopCollector) ReadValuesNumber(number uint64)                             {}
+func (nc *NoopCollector) ReadValuesSize(byte uint64)                                 {}
+func (nc *NoopCollector) ReadDuration(duration time.Duration)                        {}
+func (nc *NoopCollector) ReadDurationPerItem(duration time.Duration)                 {}
+func (nc *NoopCollector) ExecutionCollectionRequestSent()                            {}
+func (nc *NoopCollector) ExecutionCollectionRequestRetried()                         {}
+func (nc *NoopCollector) RuntimeTransactionParsed(dur time.Duration)                 {}
+func (nc *NoopCollector) RuntimeTransactionChecked(dur time.Duration)                {}
+func (nc *NoopCollector) RuntimeTransactionInterpreted(dur time.Duration)            {}
+func (nc *NoopCollector) RuntimeSetNumberOfAccounts(count uint64)                    {}
+func (nc *NoopCollector) ScriptExecuted(dur time.Duration, size int)                 {}
+func (nc *NoopCollector) TransactionResultFetched(dur time.Duration, size int)       {}
+func (nc *NoopCollector) TransactionReceived(txID flow.Identifier, when time.Time)   {}
+func (nc *NoopCollector) TransactionFinalized(txID flow.Identifier, when time.Time)  {}
+func (nc *NoopCollector) TransactionExecuted(txID flow.Identifier, when time.Time)   {}
+func (nc *NoopCollector) TransactionExpired(txID flow.Identifier)                    {}
+func (nc *NoopCollector) TransactionSubmissionFailed()                               {}
+func (nc *NoopCollector) UpdateExecutionReceiptMaxHeight(height uint64)              {}
+func (nc *NoopCollector) ChunkDataPackRequestProcessed()                             {}
+func (nc *NoopCollector) ExecutionSync(syncing bool)                                 {}
+func (nc *NoopCollector) ExecutionBlockDataUploadStarted()                           {}
+func (nc *NoopCollector) ExecutionBlockDataUploadFinished(dur time.Duration)         {}
+func (nc *NoopCollector) ExecutionComputationResultUploaded()                        {}
+func (nc *NoopCollector) ExecutionComputationResultUploadRetried()                   {}
+func (nc *NoopCollector) RootIDComputed(duration time.Duration, numberOfChunks int)  {}
+func (nc *NoopCollector) AddBlobsSucceeded(duration time.Duration, totalSize uint64) {}
+func (nc *NoopCollector) AddBlobsFailed()                                            {}
+func (nc *NoopCollector) FulfilledHeight(blockHeight uint64)                         {}
+func (nc *NoopCollector) ReceiptSkipped()                                            {}
 func (nc *NoopCollector) RequestSucceeded(blockHeight uint64, duration time.Duration, totalSize uint64, numberOfAttempts int) {
 }
 func (nc *NoopCollector) RequestFailed(duration time.Duration, retryable bool)                  {}

--- a/module/mock/execution_metrics.go
+++ b/module/mock/execution_metrics.go
@@ -76,9 +76,9 @@ func (_m *ExecutionMetrics) ExecutionLastExecutedBlockHeight(height uint64) {
 	_m.Called(height)
 }
 
-// ExecutionScriptExecuted provides a mock function with given fields: dur, compUsed, memoryUsed, memoryEstimate
-func (_m *ExecutionMetrics) ExecutionScriptExecuted(dur time.Duration, compUsed uint64, memoryUsed uint64, memoryEstimate uint64) {
-	_m.Called(dur, compUsed, memoryUsed, memoryEstimate)
+// ExecutionScriptExecuted provides a mock function with given fields: dur, compUsed, memoryEstimate
+func (_m *ExecutionMetrics) ExecutionScriptExecuted(dur time.Duration, compUsed uint64, memoryEstimate uint64) {
+	_m.Called(dur, compUsed, memoryEstimate)
 }
 
 // ExecutionStorageStateCommitment provides a mock function with given fields: bytes
@@ -91,9 +91,9 @@ func (_m *ExecutionMetrics) ExecutionSync(syncing bool) {
 	_m.Called(syncing)
 }
 
-// ExecutionTransactionExecuted provides a mock function with given fields: dur, compUsed, memoryUsed, actualMemoryUsed, eventCounts, eventSize, failed
-func (_m *ExecutionMetrics) ExecutionTransactionExecuted(dur time.Duration, compUsed uint64, memoryUsed uint64, actualMemoryUsed uint64, eventCounts int, eventSize int, failed bool) {
-	_m.Called(dur, compUsed, memoryUsed, actualMemoryUsed, eventCounts, eventSize, failed)
+// ExecutionTransactionExecuted provides a mock function with given fields: dur, compUsed, memoryEstimate, eventCounts, eventSize, failed
+func (_m *ExecutionMetrics) ExecutionTransactionExecuted(dur time.Duration, compUsed uint64, memoryEstimate uint64, eventCounts int, eventSize int, failed bool) {
+	_m.Called(dur, compUsed, memoryEstimate, eventCounts, eventSize, failed)
 }
 
 // FinishBlockReceivedToExecuted provides a mock function with given fields: blockID


### PR DESCRIPTION
Runtime memory stats have non-zero overhead but quite useless since script execution is happening alongside with transactions and other scripts.  Since script execution is the main user of allocator, the data we get from the `GetHeapAllocsBytes` is useless.