### PR TITLE
[FVM] Smart/partial programs cache invalidation

### DIFF
--- a/fvm/derived/derived_block_data.go
+++ b/fvm/derived/derived_block_data.go
@@ -9,9 +9,25 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 )
 
+// ProgramDependencies are the locations of the programs this program depends on.
+type ProgramDependencies map[common.Address]struct{}
+
+// AddDependency adds the address as a dependency.
+func (d ProgramDependencies) AddDependency(address common.Address) {
+	d[address] = struct{}{}
+}
+
+// Merge merges current dependencies with other dependencies.
+func (d ProgramDependencies) Merge(other ProgramDependencies) {
+	for address := range other {
+		d[address] = struct{}{}
+	}
+}
+
 type Program struct {
 	*interpreter.Program
-	Dependencies map[common.AddressLocation]struct{}
+
+	Dependencies ProgramDependencies
 }
 
 // DerivedBlockData is a simple fork-aware OCC database for "caching" derived

--- a/fvm/derived/derived_block_data.go
+++ b/fvm/derived/derived_block_data.go
@@ -9,10 +9,15 @@ import (
 	"github.com/onflow/flow-go/fvm/state"
 )
 
+type Program struct {
+	*interpreter.Program
+	dependencies map[common.AddressLocation]struct{}
+}
+
 // DerivedBlockData is a simple fork-aware OCC database for "caching" derived
 // data for a particular block.
 type DerivedBlockData struct {
-	programs *DerivedDataTable[common.AddressLocation, *interpreter.Program]
+	programs *DerivedDataTable[common.AddressLocation, *Program]
 
 	meterParamOverrides *DerivedDataTable[struct{}, MeterParamOverrides]
 }
@@ -22,7 +27,7 @@ type DerivedBlockData struct {
 type DerivedTransactionData struct {
 	programs *TableTransaction[
 		common.AddressLocation,
-		*interpreter.Program,
+		*Program,
 	]
 
 	// There's only a single entry in this table.  For simplicity, we'll use
@@ -34,7 +39,7 @@ func NewEmptyDerivedBlockData() *DerivedBlockData {
 	return &DerivedBlockData{
 		programs: NewEmptyTable[
 			common.AddressLocation,
-			*interpreter.Program,
+			*Program,
 		](),
 		meterParamOverrides: NewEmptyTable[
 			struct{},
@@ -49,7 +54,7 @@ func NewEmptyDerivedBlockDataWithTransactionOffset(offset uint32) *DerivedBlockD
 	return &DerivedBlockData{
 		programs: NewEmptyTableWithOffset[
 			common.AddressLocation,
-			*interpreter.Program,
+			*Program,
 		](offset),
 		meterParamOverrides: NewEmptyTableWithOffset[
 			struct{},
@@ -126,14 +131,14 @@ func (block *DerivedBlockData) NextTxIndexForTestingOnly() uint32 {
 
 func (block *DerivedBlockData) GetProgramForTestingOnly(
 	addressLocation common.AddressLocation,
-) *invalidatableEntry[*interpreter.Program] {
+) *invalidatableEntry[*Program] {
 	return block.programs.GetForTestingOnly(addressLocation)
 }
 
 func (transaction *DerivedTransactionData) GetProgram(
 	addressLocation common.AddressLocation,
 ) (
-	*interpreter.Program,
+	*Program,
 	*state.State,
 	bool,
 ) {
@@ -142,7 +147,7 @@ func (transaction *DerivedTransactionData) GetProgram(
 
 func (transaction *DerivedTransactionData) SetProgram(
 	addressLocation common.AddressLocation,
-	program *interpreter.Program,
+	program *Program,
 	state *state.State,
 ) {
 	transaction.programs.Set(addressLocation, program, state)

--- a/fvm/derived/derived_block_data.go
+++ b/fvm/derived/derived_block_data.go
@@ -11,7 +11,7 @@ import (
 
 type Program struct {
 	*interpreter.Program
-	dependencies map[common.AddressLocation]struct{}
+	Dependencies map[common.AddressLocation]struct{}
 }
 
 // DerivedBlockData is a simple fork-aware OCC database for "caching" derived

--- a/fvm/derived/derived_chain_data_test.go
+++ b/fvm/derived/derived_chain_data_test.go
@@ -37,7 +37,9 @@ func TestDerivedChainData(t *testing.T) {
 	require.NotNil(t, block1)
 
 	loc1 := testLocation("0a")
-	prog1 := &interpreter.Program{}
+	prog1 := &Program{
+		Program: &interpreter.Program{},
+	}
 
 	txn, err := block1.NewDerivedTransactionData(0, 0)
 	require.NoError(t, err)
@@ -61,7 +63,9 @@ func TestDerivedChainData(t *testing.T) {
 	require.NotSame(t, block1, block2)
 
 	loc2 := testLocation("0b")
-	prog2 := &interpreter.Program{}
+	prog2 := &Program{
+		Program: &interpreter.Program{},
+	}
 
 	txn, err = block2.NewDerivedTransactionData(0, 0)
 	require.NoError(t, err)

--- a/fvm/derived/invalidator.go
+++ b/fvm/derived/invalidator.go
@@ -2,7 +2,6 @@ package derived
 
 import (
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/onflow/flow-go/fvm/meter"
 )
@@ -15,7 +14,7 @@ type MeterParamOverrides struct {
 
 type ProgramInvalidator TableInvalidator[
 	common.AddressLocation,
-	*interpreter.Program,
+	*Program,
 ]
 
 type MeterParamOverridesInvalidator TableInvalidator[

--- a/fvm/environment/contract_updater.go
+++ b/fvm/environment/contract_updater.go
@@ -439,7 +439,7 @@ func (updater *ContractUpdaterImpl) SetContract(
 	}
 
 	contractUpdateKey := ContractUpdateKey{
-		Address: flowAddress,
+		Address: address,
 		Name:    name,
 	}
 
@@ -465,8 +465,7 @@ func (updater *ContractUpdaterImpl) RemoveContract(
 					"accounts"))
 	}
 
-	add := flow.Address(address)
-	uk := ContractUpdateKey{Address: add, Name: name}
+	uk := ContractUpdateKey{Address: address, Name: name}
 	u := ContractUpdate{ContractUpdateKey: uk}
 	updater.draftUpdates[uk] = u
 
@@ -480,12 +479,12 @@ func (updater *ContractUpdaterImpl) Commit() ([]ContractUpdateKey, error) {
 	var err error
 	for _, v := range updateList {
 		if len(v.Code) > 0 {
-			err = updater.accounts.SetContract(v.Name, v.Address, v.Code)
+			err = updater.accounts.SetContract(v.Name, flow.BytesToAddress(v.Address.Bytes()), v.Code)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			err = updater.accounts.DeleteContract(v.Name, v.Address)
+			err = updater.accounts.DeleteContract(v.Name, flow.BytesToAddress(v.Address.Bytes()))
 			if err != nil {
 				return nil, err
 			}

--- a/fvm/environment/contract_updater_test.go
+++ b/fvm/environment/contract_updater_test.go
@@ -314,6 +314,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 	accounts := environment.NewAccounts(txnState)
 
 	flowAddress := flow.HexToAddress("01")
+	flowCommonAddress := common.MustBytesToAddress(flowAddress.Bytes())
 	runtimeAddress := runtime.Address(flowAddress)
 	err := accounts.Create(nil, flowAddress)
 	require.NoError(t, err)
@@ -353,7 +354,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 		t,
 		[]environment.ContractUpdateKey{
 			{
-				Address: flowAddress,
+				Address: flowCommonAddress,
 				Name:    "TestContract",
 			},
 		},
@@ -412,6 +413,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 	accounts := environment.NewAccounts(txnState)
 
 	flowAddress := flow.HexToAddress("01")
+	flowCommonAddress := common.MustBytesToAddress(flowAddress.Bytes())
 	runtimeAddress := runtime.Address(flowAddress)
 	err := accounts.Create(nil, flowAddress)
 	require.NoError(t, err)
@@ -451,7 +453,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 			t,
 			[]environment.ContractUpdateKey{
 				{
-					Address: flowAddress,
+					Address: flowCommonAddress,
 					Name:    "TestContract",
 				},
 			},
@@ -515,7 +517,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 			t,
 			[]environment.ContractUpdateKey{
 				{
-					Address: flowAddress,
+					Address: flowCommonAddress,
 					Name:    "TestContract",
 				},
 			},

--- a/fvm/environment/derived_data_invalidator.go
+++ b/fvm/environment/derived_data_invalidator.go
@@ -93,8 +93,25 @@ func (invalidator ProgramInvalidator) ShouldInvalidateEntry(
 	program *derived.Program,
 	state *state.State,
 ) bool {
-	// TODO(rbtz): switch to fine grain invalidation.
-	return invalidator.ShouldInvalidateEntries()
+	if invalidator.MeterParamOverridesUpdated {
+		return true
+	}
+
+	if len(invalidator.FrozenAccounts) > 0 {
+		// TODO: switch to fine grain invalidation.
+		return true
+	}
+
+	for _, key := range invalidator.ContractUpdateKeys {
+		_, ok := program.Dependencies[common.AddressLocation{
+			Address: common.MustBytesToAddress(key.Address.Bytes()),
+			Name:    key.Name,
+		}]
+		if ok {
+			return true
+		}
+	}
+	return false
 }
 
 type MeterParamOverridesInvalidator struct {

--- a/fvm/environment/derived_data_invalidator.go
+++ b/fvm/environment/derived_data_invalidator.go
@@ -2,7 +2,6 @@ package environment
 
 import (
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/state"
@@ -91,7 +90,7 @@ func (invalidator ProgramInvalidator) ShouldInvalidateEntries() bool {
 
 func (invalidator ProgramInvalidator) ShouldInvalidateEntry(
 	location common.AddressLocation,
-	program *interpreter.Program,
+	program *derived.Program,
 	state *state.State,
 ) bool {
 	// TODO(rbtz): switch to fine grain invalidation.

--- a/fvm/environment/mock/derived_transaction_data.go
+++ b/fvm/environment/mock/derived_transaction_data.go
@@ -4,8 +4,7 @@ package mock
 
 import (
 	common "github.com/onflow/cadence/runtime/common"
-
-	interpreter "github.com/onflow/cadence/runtime/interpreter"
+	derived "github.com/onflow/flow-go/fvm/derived"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -18,15 +17,15 @@ type DerivedTransactionData struct {
 }
 
 // GetProgram provides a mock function with given fields: loc
-func (_m *DerivedTransactionData) GetProgram(loc common.AddressLocation) (*interpreter.Program, *state.State, bool) {
+func (_m *DerivedTransactionData) GetProgram(loc common.AddressLocation) (*derived.Program, *state.State, bool) {
 	ret := _m.Called(loc)
 
-	var r0 *interpreter.Program
-	if rf, ok := ret.Get(0).(func(common.AddressLocation) *interpreter.Program); ok {
+	var r0 *derived.Program
+	if rf, ok := ret.Get(0).(func(common.AddressLocation) *derived.Program); ok {
 		r0 = rf(loc)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*interpreter.Program)
+			r0 = ret.Get(0).(*derived.Program)
 		}
 	}
 
@@ -50,7 +49,7 @@ func (_m *DerivedTransactionData) GetProgram(loc common.AddressLocation) (*inter
 }
 
 // SetProgram provides a mock function with given fields: loc, prog, _a2
-func (_m *DerivedTransactionData) SetProgram(loc common.AddressLocation, prog *interpreter.Program, _a2 *state.State) {
+func (_m *DerivedTransactionData) SetProgram(loc common.AddressLocation, prog *derived.Program, _a2 *state.State) {
 	_m.Called(loc, prog, _a2)
 }
 

--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -40,6 +40,7 @@ type Programs struct {
 	// NOTE: non-address programs are not reusable across transactions, hence
 	// they are kept out of the derived data database.
 	nonAddressPrograms map[common.Location]*interpreter.Program
+	dependencies       map[common.AddressLocation]map[common.AddressLocation]struct{}
 }
 
 // NewPrograms construts a new ProgramHandler
@@ -57,6 +58,7 @@ func NewPrograms(
 		accounts:           accounts,
 		derivedTxnData:     derivedTxnData,
 		nonAddressPrograms: make(map[common.Location]*interpreter.Program),
+		dependencies:       make(map[common.AddressLocation]map[common.AddressLocation]struct{}),
 	}
 }
 
@@ -83,8 +85,17 @@ func (programs *Programs) set(
 		return err
 	}
 
+	// stop tracking dependencies
+	dependencies, ok := programs.dependencies[address]
+	if !ok {
+		dependencies = make(map[common.AddressLocation]struct{})
+	} else {
+		delete(programs.dependencies, address)
+	}
+
 	programs.derivedTxnData.SetProgram(address, &derived.Program{
-		Program: program,
+		Program:      program,
+		Dependencies: dependencies,
 	}, state)
 	return nil
 }
@@ -108,6 +119,16 @@ func (programs *Programs) get(
 
 	program, state, has := programs.derivedTxnData.GetProgram(address)
 	if has {
+
+		// add the dependencies to the currents program being loaded
+		// if one is being loaded
+		for _, dependencies := range programs.dependencies {
+			dependencies[address] = struct{}{}
+			for newDep := range program.Dependencies {
+				dependencies[newDep] = struct{}{}
+			}
+		}
+
 		err := programs.txnState.AttachAndCommit(state)
 		if err != nil {
 			panic(fmt.Sprintf(
@@ -126,6 +147,14 @@ func (programs *Programs) get(
 	if err != nil {
 		panic(err)
 	}
+
+	// add the dependencies to the current programs being loaded
+	for _, dependencies := range programs.dependencies {
+		dependencies[address] = struct{}{}
+	}
+
+	// start tracking dependencies for this program
+	programs.dependencies[address] = make(map[common.AddressLocation]struct{})
 
 	return nil, false
 }

--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 
+	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -17,8 +18,8 @@ import (
 // TODO(patrick): remove and switch to *programs.DerivedTransactionData once
 // https://github.com/onflow/flow-emulator/pull/229 is integrated.
 type DerivedTransactionData interface {
-	GetProgram(loc common.AddressLocation) (*interpreter.Program, *state.State, bool)
-	SetProgram(loc common.AddressLocation, prog *interpreter.Program, state *state.State)
+	GetProgram(loc common.AddressLocation) (*derived.Program, *state.State, bool)
+	SetProgram(loc common.AddressLocation, prog *derived.Program, state *state.State)
 }
 
 // Programs manages operations around cadence program parsing.
@@ -82,7 +83,9 @@ func (programs *Programs) set(
 		return err
 	}
 
-	programs.derivedTxnData.SetProgram(address, program, state)
+	programs.derivedTxnData.SetProgram(address, &derived.Program{
+		Program: program,
+	}, state)
 	return nil
 }
 
@@ -112,7 +115,7 @@ func (programs *Programs) get(
 				err))
 		}
 
-		return program, true
+		return program.Program, true
 	}
 
 	// Address location program is reusable across transactions.  Create

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -212,6 +212,10 @@ func Test_Programs(t *testing.T) {
 		entry := derivedBlockData.GetProgramForTestingOnly(contractALocation)
 		require.NotNil(t, entry)
 
+		// assert dependencies are correct
+		require.Len(t, entry.Value.Dependencies, 1)
+		require.NotNil(t, entry.Value.Dependencies[common.MustBytesToAddress(addressA.Bytes())])
+
 		// type assertion for further inspections
 		require.IsType(t, entry.State.View(), &delta.View{})
 
@@ -252,7 +256,7 @@ func Test_Programs(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("deploying another contract cleans programs storage", func(t *testing.T) {
+	t.Run("deploying another contract invalidates dependant programs", func(t *testing.T) {
 
 		// deploy contract B
 		procContractB := fvm.Transaction(
@@ -261,11 +265,15 @@ func Test_Programs(t *testing.T) {
 		err := vm.Run(context, procContractB, mainView)
 		require.NoError(t, err)
 
-		entryA := derivedBlockData.GetProgramForTestingOnly(contractALocation)
+		// b and c are invalid
 		entryB := derivedBlockData.GetProgramForTestingOnly(contractBLocation)
+		entryC := derivedBlockData.GetProgramForTestingOnly(contractCLocation)
+		// a is still valid
+		entryA := derivedBlockData.GetProgramForTestingOnly(contractALocation)
 
-		require.Nil(t, entryA)
 		require.Nil(t, entryB)
+		require.Nil(t, entryC)
+		require.NotNil(t, entryA)
 	})
 
 	var viewExecB *delta.View
@@ -297,6 +305,11 @@ func Test_Programs(t *testing.T) {
 
 		entryB := derivedBlockData.GetProgramForTestingOnly(contractBLocation)
 		require.NotNil(t, entryB)
+
+		// assert dependencies are correct
+		require.Len(t, entryB.Value.Dependencies, 2)
+		require.NotNil(t, entryB.Value.Dependencies[common.MustBytesToAddress(addressA.Bytes())])
+		require.NotNil(t, entryB.Value.Dependencies[common.MustBytesToAddress(addressB.Bytes())])
 
 		// program B should contain all the registers used by program A, as it depends on it
 		require.IsType(t, entryB.State.View(), &delta.View{})
@@ -378,7 +391,7 @@ func Test_Programs(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("deploying contract C cleans programs", func(t *testing.T) {
+	t.Run("deploying contract C invalidates C", func(t *testing.T) {
 		require.NotNil(t, contractBView)
 
 		// deploy contract C
@@ -392,8 +405,8 @@ func Test_Programs(t *testing.T) {
 		entryB := derivedBlockData.GetProgramForTestingOnly(contractBLocation)
 		entryC := derivedBlockData.GetProgramForTestingOnly(contractCLocation)
 
-		require.Nil(t, entryA)
-		require.Nil(t, entryB)
+		require.NotNil(t, entryA)
+		require.NotNil(t, entryB)
 		require.Nil(t, entryC)
 
 	})
@@ -425,6 +438,16 @@ func Test_Programs(t *testing.T) {
 		require.IsType(t, entryB.State.View(), &delta.View{})
 		deltaB := entryB.State.View().(*delta.View)
 		compareViews(t, contractBView, deltaB)
+
+		// program C assertions
+		entryC := derivedBlockData.GetProgramForTestingOnly(contractCLocation)
+		require.NotNil(t, entryC)
+
+		// assert dependencies are correct
+		require.Len(t, entryC.Value.Dependencies, 3)
+		require.NotNil(t, entryC.Value.Dependencies[common.MustBytesToAddress(addressA.Bytes())])
+		require.NotNil(t, entryC.Value.Dependencies[common.MustBytesToAddress(addressB.Bytes())])
+		require.NotNil(t, entryC.Value.Dependencies[common.MustBytesToAddress(addressC.Bytes())])
 	})
 }
 

--- a/fvm/programs/programs.go
+++ b/fvm/programs/programs.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/state"
@@ -56,18 +55,18 @@ func (p *Programs) NextTxIndexForTestingOnly() uint32 {
 	return p.block.NextTxIndexForTestingOnly()
 }
 
-func (p *Programs) GetForTestingOnly(location common.AddressLocation) (*interpreter.Program, *state.State, bool) {
+func (p *Programs) GetForTestingOnly(location common.AddressLocation) (*derived.Program, *state.State, bool) {
 	return p.GetProgram(location)
 }
 
-func (p *Programs) GetProgram(location common.AddressLocation) (*interpreter.Program, *state.State, bool) {
+func (p *Programs) GetProgram(location common.AddressLocation) (*derived.Program, *state.State, bool) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
 	return p.currentTxn.GetProgram(location)
 }
 
-func (p *Programs) SetProgram(location common.AddressLocation, program *interpreter.Program, state *state.State) {
+func (p *Programs) SetProgram(location common.AddressLocation, program *derived.Program, state *state.State) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 


### PR DESCRIPTION
ref:  [Improve FVM Program Cache Invalidation](https://github.com/onflow/flow-go/issues/3015)

Smart contract invalidation.

This relies on Cadence properly calling Get/Set program (which should already be the case, because other parts of the code also depend on this). The proper use of Get/Set will be guaranteed once we replace Get/Set with a single `GetOrCreate(location, create_function)` function. This will be a future PR.

The principle is that we store program dependencies together with the program in the cache. These dependencies are filled when cadence calls Get/Set program.

**Example**
```mermaid
graph TD
  C-->D
  C-->B
  B-->A
```
With this dependency graph, if B is already in cache and we are loading C:

- Get C:
    - Get B. We have B with dependency A, so A is added to C as a dependency
    - Get D. 
        - D  is not loaded so load it here
    - Set D. and add it as a dependency of C
- Set C with dependencies { A, B, D, C[^1]} 

[^1]: C is listed as its own dependency to make some code simpler.