### PR TITLE
Fix bug in cluster block validation. 

### DIFF
--- a/network/errors.go
+++ b/network/errors.go
@@ -35,6 +35,6 @@ func NewTransientErrorf(msg string, args ...interface{}) TransientError {
 }
 
 func IsTransientError(err error) bool {
-	var errClusterVotingFailed TransientError
-	return errors.As(err, &errClusterVotingFailed)
+	var errTransient TransientError
+	return errors.As(err, &errTransient)
 }

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -331,15 +331,25 @@ func (suite *MutatorSuite) TestExtend_WithEmptyCollection() {
 
 // an unknown reference block is unverifiable
 func (suite *MutatorSuite) TestExtend_WithNonExistentReferenceBlock() {
-	block := suite.Block()
-	tx := suite.Tx()
-	payload := suite.Payload(&tx)
-	// set a random reference block ID
-	payload.ReferenceBlockID = unittest.IdentifierFixture()
-	block.SetPayload(payload)
-	err := suite.state.Extend(&block)
-	suite.Assert().Error(err)
-	suite.Assert().True(state.IsUnverifiableExtensionError(err))
+	suite.Run("empty collection", func() {
+		block := suite.Block()
+		block.Payload.ReferenceBlockID = unittest.IdentifierFixture()
+		block.SetPayload(*block.Payload)
+		err := suite.state.Extend(&block)
+		suite.Assert().Error(err)
+		suite.Assert().True(state.IsUnverifiableExtensionError(err))
+	})
+	suite.Run("non-empty collection", func() {
+		block := suite.Block()
+		tx := suite.Tx()
+		payload := suite.Payload(&tx)
+		// set a random reference block ID
+		payload.ReferenceBlockID = unittest.IdentifierFixture()
+		block.SetPayload(payload)
+		err := suite.state.Extend(&block)
+		suite.Assert().Error(err)
+		suite.Assert().True(state.IsUnverifiableExtensionError(err))
+	})
 }
 
 // a collection with an expired reference block is a VALID extension of chain state


### PR DESCRIPTION
This check was duplicated to before we verified existence of the reference block. This caused an empty collection with an unknown reference block to pass validation. This breaks an assumption about the cluster state and would cause an irrecoverable error to be thrown later.