### PR TITLE
fix race condition in PeerManager by starting libp2p node after start…

### DIFF
--- a/network/internal/testutils/testUtil.go
+++ b/network/internal/testutils/testUtil.go
@@ -321,13 +321,17 @@ func StartNodesAndNetworks(ctx irrecoverable.SignalerContext, t *testing.T, node
 // StartNodes starts the provided nodes and their peer managers using the provided irrecoverable context
 func StartNodes(ctx irrecoverable.SignalerContext, t *testing.T, nodes []p2p.LibP2PNode, duration time.Duration) {
 	for _, node := range nodes {
-		node.Start(ctx)
-		unittest.RequireComponentsReadyBefore(t, duration, node)
-
-		pm := node.PeerManagerComponent()
-		pm.Start(ctx)
-		unittest.RequireComponentsReadyBefore(t, duration, pm)
+		StartNode(ctx, t, node, duration)
 	}
+}
+
+// StartNode starts the provided node and their peer managers using the provided irrecoverable context
+func StartNode(ctx irrecoverable.SignalerContext, t *testing.T, node p2p.LibP2PNode, duration time.Duration) {
+	node.Start(ctx)
+	unittest.RequireComponentsReadyBefore(t, duration, node)
+	pm := node.PeerManagerComponent()
+	pm.Start(ctx)
+	unittest.RequireComponentsReadyBefore(t, duration, pm)
 }
 
 type nodeBuilderOption func(p2pbuilder.NodeBuilder)

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -132,12 +132,11 @@ func (m *MiddlewareTestSuite) SetupTest() {
 
 	m.mwCtx = irrecoverable.NewMockSignalerContext(m.T(), ctx)
 
-	testutils.StartNodes(m.mwCtx, m.T(), m.nodes, 100*time.Millisecond)
-
 	for i, mw := range m.mws {
 		mw.SetOverlay(m.ov[i])
 		mw.Start(m.mwCtx)
 		unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, mw)
+		testutils.StartNode(m.mwCtx, m.T(), m.nodes[i], 100*time.Millisecond)
 		require.NoError(m.T(), mw.Subscribe(testChannel))
 	}
 }
@@ -256,9 +255,10 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	ctx, cancel := context.WithCancel(m.mwCtx)
 	irrecoverableCtx, _ := irrecoverable.WithSignaler(ctx)
 
-	testutils.StartNodes(irrecoverableCtx, m.T(), libP2PNodes, 100*time.Millisecond)
 	newMw.Start(irrecoverableCtx)
 	unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, newMw)
+	
+	testutils.StartNodes(irrecoverableCtx, m.T(), libP2PNodes, 100*time.Millisecond)
 
 	require.NoError(m.T(), newMw.Subscribe(testChannel))
 
@@ -349,9 +349,10 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 	ctx, cancel := context.WithCancel(m.mwCtx)
 	irrecoverableCtx, _ := irrecoverable.WithSignaler(ctx)
 
-	testutils.StartNodes(irrecoverableCtx, m.T(), libP2PNodes, 100*time.Millisecond)
 	newMw.Start(irrecoverableCtx)
 	unittest.RequireComponentsReadyBefore(m.T(), 100*time.Millisecond, newMw)
+
+	testutils.StartNodes(irrecoverableCtx, m.T(), libP2PNodes, 100*time.Millisecond)
 
 	require.NoError(m.T(), newMw.Subscribe(testChannel))
 

--- a/network/test/unicast_authorization_test.go
+++ b/network/test/unicast_authorization_test.go
@@ -94,8 +94,6 @@ func (u *UnicastAuthorizationTestSuite) startMiddlewares(overlay *mocknetwork.Ov
 	ctx, cancel := context.WithCancel(context.Background())
 	sigCtx, _ := irrecoverable.WithSignaler(ctx)
 
-	testutils.StartNodes(sigCtx, u.T(), u.libP2PNodes, 100*time.Millisecond)
-
 	u.senderMW.SetOverlay(overlay)
 	u.senderMW.Start(sigCtx)
 
@@ -105,6 +103,8 @@ func (u *UnicastAuthorizationTestSuite) startMiddlewares(overlay *mocknetwork.Ov
 	unittest.RequireComponentsReadyBefore(u.T(), 100*time.Millisecond, u.senderMW, u.receiverMW)
 
 	u.cancel = cancel
+
+	testutils.StartNodes(sigCtx, u.T(), u.libP2PNodes, 100*time.Millisecond)
 }
 
 // stopMiddlewares will stop all middlewares.


### PR DESCRIPTION
This PR fixes a race condition in the `TestUnicastAuthorizationTestSuite` where starting the libp2p nodes before starting the middlewares will cause a race condition with access to the peer manager. 