### PR TITLE
Fix sync engine bug, improve observability

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -251,7 +251,7 @@ func (builder *FlowAccessNodeBuilder) buildFollowerState() *FlowAccessNodeBuilde
 
 func (builder *FlowAccessNodeBuilder) buildSyncCore() *FlowAccessNodeBuilder {
 	builder.Module("sync core", func(node *cmd.NodeConfig) error {
-		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
+		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
 		builder.SyncCore = syncCore
 
 		return err

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -251,7 +251,7 @@ func (builder *FlowAccessNodeBuilder) buildFollowerState() *FlowAccessNodeBuilde
 
 func (builder *FlowAccessNodeBuilder) buildSyncCore() *FlowAccessNodeBuilder {
 	builder.Module("sync core", func(node *cmd.NodeConfig) error {
-		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector())
+		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 		builder.SyncCore = syncCore
 
 		return err

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -213,7 +213,7 @@ func main() {
 		}).
 		Module("main chain sync core", func(node *cmd.NodeConfig) error {
 			log := node.Logger.With().Str("sync_chain_id", node.RootChainID.String()).Logger()
-			mainChainSyncCore, err = chainsync.New(log, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
+			mainChainSyncCore, err = chainsync.New(log, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
 			return err
 		}).
 		Module("machine account config", func(node *cmd.NodeConfig) error {

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -212,7 +212,8 @@ func main() {
 			return nil
 		}).
 		Module("main chain sync core", func(node *cmd.NodeConfig) error {
-			mainChainSyncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector())
+			log := node.Logger.With().Str("chain_id", node.RootChainID.String()).Logger()
+			mainChainSyncCore, err = chainsync.New(log, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 			return err
 		}).
 		Module("machine account config", func(node *cmd.NodeConfig) error {

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -212,7 +212,7 @@ func main() {
 			return nil
 		}).
 		Module("main chain sync core", func(node *cmd.NodeConfig) error {
-			log := node.Logger.With().Str("chain_id", node.RootChainID.String()).Logger()
+			log := node.Logger.With().Str("sync_chain_id", node.RootChainID.String()).Logger()
 			mainChainSyncCore, err = chainsync.New(log, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 			return err
 		}).

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -357,7 +357,7 @@ func main() {
 			return nil
 		}).
 		Module("sync core", func(node *cmd.NodeConfig) error {
-			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector())
+			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 			return err
 		}).
 		Module("finalization distributor", func(node *cmd.NodeConfig) error {

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -357,7 +357,7 @@ func main() {
 			return nil
 		}).
 		Module("sync core", func(node *cmd.NodeConfig) error {
-			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
+			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
 			return err
 		}).
 		Module("finalization distributor", func(node *cmd.NodeConfig) error {

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -261,7 +261,7 @@ func (exeNode *ExecutionNode) LoadExecutionMetrics(node *NodeConfig) error {
 
 func (exeNode *ExecutionNode) LoadSyncCore(node *NodeConfig) error {
 	var err error
-	exeNode.syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
+	exeNode.syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
 	return err
 }
 

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -261,7 +261,7 @@ func (exeNode *ExecutionNode) LoadExecutionMetrics(node *NodeConfig) error {
 
 func (exeNode *ExecutionNode) LoadSyncCore(node *NodeConfig) error {
 	var err error
-	exeNode.syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector())
+	exeNode.syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 	return err
 }
 

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -284,7 +284,7 @@ func (builder *ObserverServiceBuilder) buildFollowerState() *ObserverServiceBuil
 
 func (builder *ObserverServiceBuilder) buildSyncCore() *ObserverServiceBuilder {
 	builder.Module("sync core", func(node *cmd.NodeConfig) error {
-		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector())
+		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 		builder.SyncCore = syncCore
 
 		return err

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -284,7 +284,7 @@ func (builder *ObserverServiceBuilder) buildFollowerState() *ObserverServiceBuil
 
 func (builder *ObserverServiceBuilder) buildSyncCore() *ObserverServiceBuilder {
 	builder.Module("sync core", func(node *cmd.NodeConfig) error {
-		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
+		syncCore, err := chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
 		builder.SyncCore = syncCore
 
 		return err

--- a/cmd/verification_builder.go
+++ b/cmd/verification_builder.go
@@ -193,7 +193,7 @@ func (v *VerificationNodeBuilder) LoadComponentsAndModules() {
 		Module("sync core", func(node *NodeConfig) error {
 			var err error
 
-			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
+			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
 			return err
 		}).
 		Component("verifier engine", func(node *NodeConfig) (module.ReadyDoneAware, error) {

--- a/cmd/verification_builder.go
+++ b/cmd/verification_builder.go
@@ -193,7 +193,7 @@ func (v *VerificationNodeBuilder) LoadComponentsAndModules() {
 		Module("sync core", func(node *NodeConfig) error {
 			var err error
 
-			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector())
+			syncCore, err = chainsync.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 			return err
 		}).
 		Component("verifier engine", func(node *NodeConfig) (module.ReadyDoneAware, error) {

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -458,7 +458,7 @@ func createNode(
 	// initialize the block finalizer
 	final := finalizer.NewFinalizer(db, headersDB, fullState, trace.NewNoopTracer())
 
-	syncCore, err := synccore.New(log, synccore.DefaultConfig(), metricsCollector)
+	syncCore, err := synccore.New(log, synccore.DefaultConfig(), metricsCollector, rootHeader.ChainID)
 	require.NoError(t, err)
 
 	qcDistributor := pubsub.NewQCCreatedDistributor()

--- a/engine/collection/epochmgr/factories/epoch.go
+++ b/engine/collection/epochmgr/factories/epoch.go
@@ -152,7 +152,7 @@ func (factory *EpochComponentsFactory) Create(
 		return
 	}
 
-	syncCore, err := factory.syncCore.Create()
+	syncCore, err := factory.syncCore.Create(cluster.ChainID())
 	if err != nil {
 		err = fmt.Errorf("could not create sync core: %w", err)
 		return

--- a/engine/collection/epochmgr/factories/sync_core.go
+++ b/engine/collection/epochmgr/factories/sync_core.go
@@ -28,7 +28,8 @@ func (f *SyncCoreFactory) Create(chainID flow.ChainID) (*chainsync.Core, error) 
 	core, err := chainsync.New(
 		f.log.With().Str("sync_chain_id", chainID.String()).Logger(),
 		f.conf,
-		metrics.NewChainSyncCollector(chainID))
+		metrics.NewChainSyncCollector(chainID),
+		chainID)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/collection/epochmgr/factories/sync_core.go
+++ b/engine/collection/epochmgr/factories/sync_core.go
@@ -3,15 +3,14 @@ package factories
 import (
 	"github.com/rs/zerolog"
 
-	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/chainsync"
 	"github.com/onflow/flow-go/module/metrics"
 )
 
 type SyncCoreFactory struct {
-	log     zerolog.Logger
-	conf    chainsync.Config
-	metrics module.ChainSyncMetrics
+	log  zerolog.Logger
+	conf chainsync.Config
 }
 
 func NewSyncCoreFactory(
@@ -19,15 +18,14 @@ func NewSyncCoreFactory(
 	conf chainsync.Config,
 ) (*SyncCoreFactory, error) {
 	factory := &SyncCoreFactory{
-		log:     log,
-		conf:    conf,
-		metrics: metrics.NewChainSyncCollector(),
+		log:  log,
+		conf: conf,
 	}
 	return factory, nil
 }
 
-func (f *SyncCoreFactory) Create() (*chainsync.Core, error) {
-	core, err := chainsync.New(f.log, f.conf, f.metrics)
+func (f *SyncCoreFactory) Create(chainID flow.ChainID) (*chainsync.Core, error) {
+	core, err := chainsync.New(f.log, f.conf, metrics.NewChainSyncCollector(chainID))
 	if err != nil {
 		return nil, err
 	}

--- a/engine/collection/epochmgr/factories/sync_core.go
+++ b/engine/collection/epochmgr/factories/sync_core.go
@@ -25,7 +25,10 @@ func NewSyncCoreFactory(
 }
 
 func (f *SyncCoreFactory) Create(chainID flow.ChainID) (*chainsync.Core, error) {
-	core, err := chainsync.New(f.log, f.conf, metrics.NewChainSyncCollector(chainID))
+	core, err := chainsync.New(
+		f.log.With().Str("sync_chain_id", chainID.String()).Logger(),
+		f.conf,
+		metrics.NewChainSyncCollector(chainID))
 	if err != nil {
 		return nil, err
 	}

--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -298,7 +298,8 @@ func (e *Engine) onSyncResponse(originID flow.Identifier, res *messages.SyncResp
 func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.ClusterBlockResponse) {
 	// process the blocks one by one
 	for _, block := range res.Blocks {
-		if !e.core.HandleBlock(&block.Header) {
+		header := block.Header
+		if !e.core.HandleBlock(&header) {
 			continue
 		}
 		synced := flow.Slashable[messages.ClusterBlockProposal]{

--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -308,8 +308,6 @@ func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.Cluster
 			},
 		}
 		// forward the block to the compliance engine for validation and processing
-		// we use the network.MessageProcessor interface here because the block is un-validated
-		// NOTE: although we set originID=me, this message is untrusted
 		e.comp.OnSyncedClusterBlock(synced)
 	}
 }

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -338,7 +338,7 @@ func (ss *SyncSuite) TestOnRangeRequest() {
 		var err error
 		config := chainsync.DefaultConfig()
 		config.MaxSize = 2
-		ss.e.requestHandler.core, err = chainsync.New(ss.e.log, config, metrics.NewNoopCollector())
+		ss.e.requestHandler.core, err = chainsync.New(ss.e.log, config, metrics.NewNoopCollector(), flow.Localnet)
 		require.NoError(ss.T(), err)
 
 		err = ss.e.requestHandler.onRangeRequest(originID, req)
@@ -416,7 +416,7 @@ func (ss *SyncSuite) TestOnBatchRequest() {
 		var err error
 		config := chainsync.DefaultConfig()
 		config.MaxSize = 2
-		ss.e.requestHandler.core, err = chainsync.New(ss.e.log, config, metrics.NewNoopCollector())
+		ss.e.requestHandler.core, err = chainsync.New(ss.e.log, config, metrics.NewNoopCollector(), flow.Localnet)
 		require.NoError(ss.T(), err)
 
 		err = ss.e.requestHandler.onBatchRequest(originID, req)

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -301,8 +301,9 @@ func (e *Engine) onBlockResponse(originID flow.Identifier, res *messages.BlockRe
 	e.log.Debug().Uint64("first", first).Uint64("last", last).Msg("received block response")
 
 	for _, block := range res.Blocks {
-		if !e.core.HandleBlock(&block.Header) {
-			e.log.Debug().Uint64("height", block.Header.Height).Msg("block handler rejected")
+		header := block.Header
+		if !e.core.HandleBlock(&header) {
+			e.log.Debug().Uint64("height", header.Height).Msg("block handler rejected")
 			continue
 		}
 		// forward the block to the compliance engine for validation and processing

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -354,7 +354,7 @@ func (ss *SyncSuite) TestOnRangeRequest() {
 		var err error
 		config := synccore.DefaultConfig()
 		config.MaxSize = 2
-		ss.e.requestHandler.core, err = synccore.New(ss.e.log, config, metrics.NewNoopCollector())
+		ss.e.requestHandler.core, err = synccore.New(ss.e.log, config, metrics.NewNoopCollector(), flow.Localnet)
 		require.NoError(ss.T(), err)
 
 		err = ss.e.requestHandler.onRangeRequest(originID, req)
@@ -431,7 +431,7 @@ func (ss *SyncSuite) TestOnBatchRequest() {
 		var err error
 		config := synccore.DefaultConfig()
 		config.MaxSize = 2
-		ss.e.requestHandler.core, err = synccore.New(ss.e.log, config, metrics.NewNoopCollector())
+		ss.e.requestHandler.core, err = synccore.New(ss.e.log, config, metrics.NewNoopCollector(), flow.Localnet)
 		require.NoError(ss.T(), err)
 
 		err = ss.e.requestHandler.onBatchRequest(originID, req)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -643,7 +643,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		Manager: computationEngine,
 	}
 
-	syncCore, err := chainsync.New(node.Log, chainsync.DefaultConfig(), metrics.NewChainSyncCollector())
+	syncCore, err := chainsync.New(node.Log, chainsync.DefaultConfig(), metrics.NewChainSyncCollector(genesisHead.ChainID))
 	require.NoError(t, err)
 
 	deltas, err := ingestion.NewDeltas(1000)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -643,7 +643,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		Manager: computationEngine,
 	}
 
-	syncCore, err := chainsync.New(node.Log, chainsync.DefaultConfig(), metrics.NewChainSyncCollector(genesisHead.ChainID))
+	syncCore, err := chainsync.New(node.Log, chainsync.DefaultConfig(), metrics.NewChainSyncCollector(genesisHead.ChainID), genesisHead.ChainID)
 	require.NoError(t, err)
 
 	deltas, err := ingestion.NewDeltas(1000)

--- a/follower/follower_builder.go
+++ b/follower/follower_builder.go
@@ -173,7 +173,7 @@ func (builder *FollowerServiceBuilder) buildFollowerState() *FollowerServiceBuil
 
 func (builder *FollowerServiceBuilder) buildSyncCore() *FollowerServiceBuilder {
 	builder.Module("sync core", func(node *cmd.NodeConfig) error {
-		syncCore, err := synchronization.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
+		syncCore, err := synchronization.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
 		builder.SyncCore = syncCore
 
 		return err

--- a/follower/follower_builder.go
+++ b/follower/follower_builder.go
@@ -173,7 +173,7 @@ func (builder *FollowerServiceBuilder) buildFollowerState() *FollowerServiceBuil
 
 func (builder *FollowerServiceBuilder) buildSyncCore() *FollowerServiceBuilder {
 	builder.Module("sync core", func(node *cmd.NodeConfig) error {
-		syncCore, err := synchronization.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector())
+		syncCore, err := synchronization.New(node.Logger, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID))
 		builder.SyncCore = syncCore
 
 		return err

--- a/model/chainsync/status.go
+++ b/model/chainsync/status.go
@@ -47,7 +47,6 @@ func (s *Status) StatusString() string {
 }
 
 func NewQueuedStatus(height uint64) *Status {
-	// TODO(jord): why is height not used here ??
 	return &Status{
 		Queued: time.Now(),
 	}

--- a/model/chainsync/status.go
+++ b/model/chainsync/status.go
@@ -47,6 +47,7 @@ func (s *Status) StatusString() string {
 }
 
 func NewQueuedStatus(height uint64) *Status {
+	// TODO(jord): why is height not used here ??
 	return &Status{
 		Queued: time.Now(),
 	}

--- a/model/chainsync/status.go
+++ b/model/chainsync/status.go
@@ -48,6 +48,7 @@ func (s *Status) StatusString() string {
 
 func NewQueuedStatus(height uint64) *Status {
 	return &Status{
-		Queued: time.Now(),
+		BlockHeight: height,
+		Queued:      time.Now(),
 	}
 }

--- a/module/chainsync/core.go
+++ b/module/chainsync/core.go
@@ -201,12 +201,18 @@ func (c *Core) requeueHeight(height uint64) {
 	evt := c.log.With().
 		Uint64("height", height).
 		Str("status", status.StatusString()).
-		Uint("attempts", status.Attempts).
-		Time("queued", status.Queued).
-		Time("requested", status.Requested).
-		Time("received", status.Received).
 		Bool("was_received", status.WasReceived()).
 		Logger()
+	if status != nil {
+		evt = evt.With().
+			Uint("attempts", status.Attempts).
+			Time("queued", status.Queued).
+			Time("requested", status.Requested).
+			Time("received", status.Received).
+			Logger()
+	} else {
+		evt = evt.With().Str("note", "status=nil").Logger()
+	}
 	if height < 20 {
 		evt.Debug().Msgf("requeueHeight()")
 	} else {

--- a/module/chainsync/core.go
+++ b/module/chainsync/core.go
@@ -1,6 +1,7 @@
 package chainsync
 
 import (
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -78,10 +79,16 @@ func New(log zerolog.Logger, config Config, metrics module.ChainSyncMetrics) (*C
 // true if the block should be processed by the compliance layer and false
 // if it should be ignored.
 func (c *Core) HandleBlock(header *flow.Header) bool {
+	log := c.log
+	if c.log.Debug().Enabled() {
+		log = c.log.With().Str("block_id", header.ID().String()).Uint64("block_height", header.Height).Logger()
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	status := c.getRequestStatus(header.Height, header.ID())
+	log.Debug().Uint("attempts", status.Attempts).Str("status", status.StatusString()).Msg("handling block")
+
 	// if we never asked for this block, discard it
 	if !status.WasQueued() {
 		return false
@@ -106,8 +113,11 @@ func (c *Core) HandleBlock(header *flow.Header) bool {
 // If the height difference between local and the reported height, we do nothing.
 // Otherwise, we queue each missing height.
 func (c *Core) HandleHeight(final *flow.Header, height uint64) {
+	log := c.log.With().Uint64("final_height", final.Height).Uint64("recv_height", height).Logger()
+	log.Debug().Msg("received height")
 	// don't bother queueing anything if we're within tolerance
 	if c.WithinTolerance(final, height) {
+		log.Debug().Msg("height within tolerance - discarding")
 		return
 	}
 
@@ -127,10 +137,12 @@ func (c *Core) HandleHeight(final *flow.Header, height uint64) {
 		for h := final.Height + 1; h <= height; h++ {
 			c.requeueHeight(h)
 		}
+		log.Debug().Msgf("requeued heights [%d-%d]", final.Height+1, height)
 	}
 }
 
 func (c *Core) RequestBlock(blockID flow.Identifier, height uint64) {
+	log := c.log.With().Str("block_id", blockID.String()).Uint64("height", height).Logger()
 	// requesting a block by its ID storing the height to prune more efficiently
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -138,11 +150,13 @@ func (c *Core) RequestBlock(blockID flow.Identifier, height uint64) {
 	// if we already received this block, reset the status so we can re-queue
 	status := c.blockIDs[blockID]
 	if status.WasReceived() {
+		log.Debug().Msgf("requested block was already received")
 		delete(c.blockIDs, status.Header.ID())
 		delete(c.heights, status.Header.Height)
 	}
 
 	c.queueByBlockID(blockID, height)
+	log.Debug().Msgf("enqueued requested block")
 }
 
 func (c *Core) RequestHeight(height uint64) {
@@ -150,6 +164,7 @@ func (c *Core) RequestHeight(height uint64) {
 	defer c.mu.Unlock()
 
 	c.requeueHeight(height)
+	c.log.Debug().Uint64("height", height).Msg("enqueued requested height")
 }
 
 // requeueHeight queues the given height, ignoring any previously received
@@ -172,15 +187,19 @@ func (c *Core) ScanPending(final *flow.Header) ([]chainsync.Range, []chainsync.B
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	log := c.log.With().Uint64("final_height", final.Height).Logger()
+
 	// prune if the current height is less than the new height
 	c.prune(final)
 
 	// get all items that are eligible for initial or re-requesting
 	heights, blockIDs := c.getRequestableItems()
+	c.log.Debug().Msgf("scan found %d requestable heights, %d requestable block IDs", len(heights), len(blockIDs))
 
 	// convert to valid range and batch requests
 	ranges := c.getRanges(heights)
 	batches := c.getBatches(blockIDs)
+	log.Debug().Str("ranges", fmt.Sprintf("%v", ranges)).Str("batches", fmt.Sprintf("%v", batches)).Msg("compiled range and batch requests")
 
 	return c.selectRequests(ranges, batches)
 }

--- a/module/chainsync/core.go
+++ b/module/chainsync/core.go
@@ -87,14 +87,15 @@ func (c *Core) HandleBlock(header *flow.Header) bool {
 	defer c.mu.Unlock()
 
 	status := c.getRequestStatus(header.Height, header.ID())
-	log.Debug().Uint("attempts", status.Attempts).Str("status", status.StatusString()).Msg("handling block")
 
 	// if we never asked for this block, discard it
 	if !status.WasQueued() {
+		log.Debug().Msg("discarding not queued block")
 		return false
 	}
 	// if we have already received this block, exit
 	if status.WasReceived() {
+		log.Debug().Msg("discarding not received block")
 		return false
 	}
 
@@ -106,6 +107,7 @@ func (c *Core) HandleBlock(header *flow.Header) bool {
 	c.blockIDs[header.ID()] = status
 	c.heights[header.Height] = status
 
+	log.Debug().Msg("handled block")
 	return true
 }
 

--- a/module/chainsync/core.go
+++ b/module/chainsync/core.go
@@ -138,6 +138,29 @@ func (c *Core) HandleHeight(final *flow.Header, height uint64) {
 			c.requeueHeight(h)
 		}
 		log.Debug().Msgf("requeued heights [%d-%d]", final.Height+1, height)
+
+		// TODO remove
+		{
+			cnt := 0
+			for h := final.Height + 1; h <= height; h++ {
+				status, ok := c.heights[h]
+				if !ok {
+					c.log.Warn().Msgf("could not find just-enqueued height %d", h)
+				}
+				c.log.Trace().
+					Uint64("height", h).
+					Uint("attempts", status.Attempts).
+					Time("queued", status.Queued).
+					Time("requested", status.Requested).
+					Time("received", status.Received).
+					Msgf("re-enqueued height")
+
+				cnt++
+				if cnt > 100 {
+					return
+				}
+			}
+		}
 	}
 }
 
@@ -223,11 +246,19 @@ func (c *Core) queueByHeight(height uint64) {
 	// do not queue the block if the height is lower or the same as the local finalized height
 	// the check != 0 is necessary or we will never queue blocks at height 0
 	if height <= c.localFinalizedHeight && c.localFinalizedHeight != 0 {
+		c.log.Debug().Uint64("height", height).Uint64("loc_final_height", c.localFinalizedHeight).Msg("skipping queueing by height")
 		return
 	}
 
 	// only queue the request if have never queued it before
 	if c.heights[height].WasQueued() {
+		c.log.Debug().
+			Uint64("height", height).
+			Str("status", c.heights[height].StatusString()).
+			Uint("attemtps", c.heights[height].Attempts).
+			Time("queued_at", c.heights[height].Queued).
+			Time("requested_at", c.heights[height].Requested).
+			Msg("skipping queueing by height")
 		return
 	}
 
@@ -330,20 +361,24 @@ func (c *Core) getRequestableItems() ([]uint64, []flow.Identifier) {
 	// create a list of all height requests that should be sent
 	var heights []uint64
 	for height, status := range c.heights {
+		log := c.log.With().Uint64("height", height).Uint("attempts", status.Attempts).Logger()
 
 		// if the last request is young enough, skip
 		retryAfter := status.Requested.Add(c.Config.RetryInterval << status.Attempts)
 		if now.Before(retryAfter) {
+			log.Trace().Msgf("omitting because before %s", retryAfter.String())
 			continue
 		}
 
 		// if we've already received this block, skip
 		if status.WasReceived() {
+			log.Trace().Msg("omitting because was received")
 			continue
 		}
 
 		// if we reached maximum number of attempts, delete
 		if status.Attempts >= c.Config.MaxAttempts {
+			log.Trace().Msgf("omitting+deleting because attempts >= %d", c.Config.MaxAttempts)
 			delete(c.heights, height)
 			continue
 		}
@@ -355,20 +390,29 @@ func (c *Core) getRequestableItems() ([]uint64, []flow.Identifier) {
 	// create list of all the block IDs blocks that are missing
 	var blockIDs []flow.Identifier
 	for blockID, status := range c.blockIDs {
+		log := c.log.With().
+			Uint64("height", status.BlockHeight).
+			Uint("attempts", status.Attempts).
+			Str("status", status.StatusString()).
+			Str("block_id", blockID.String()).
+			Logger()
 
 		// if the last request is young enough, skip
 		retryAfter := status.Requested.Add(c.Config.RetryInterval << status.Attempts)
 		if now.Before(retryAfter) {
+			log.Trace().Msgf("omitting because before %s", retryAfter.String())
 			continue
 		}
 
 		// if we've already received this block, skip
 		if status.WasReceived() {
+			log.Trace().Msg("omitting because was received")
 			continue
 		}
 
 		// if we reached the maximum number of attempts for a queue item, drop
 		if status.Attempts >= c.Config.MaxAttempts {
+			log.Trace().Msgf("omitting+deleting because attempts >= %d", c.Config.MaxAttempts)
 			delete(c.blockIDs, blockID)
 			continue
 		}

--- a/module/chainsync/core.go
+++ b/module/chainsync/core.go
@@ -201,18 +201,12 @@ func (c *Core) requeueHeight(height uint64) {
 	evt := c.log.With().
 		Uint64("height", height).
 		Str("status", status.StatusString()).
+		Uint("attempts", status.Attempts).
+		Time("queued", status.Queued).
+		Time("requested", status.Requested).
+		Time("received", status.Received).
 		Bool("was_received", status.WasReceived()).
 		Logger()
-	if status != nil {
-		evt = evt.With().
-			Uint("attempts", status.Attempts).
-			Time("queued", status.Queued).
-			Time("requested", status.Requested).
-			Time("received", status.Received).
-			Logger()
-	} else {
-		evt = evt.With().Str("note", "status=nil").Logger()
-	}
 	if height < 20 {
 		evt.Debug().Msgf("requeueHeight()")
 	} else {

--- a/module/chainsync/core.go
+++ b/module/chainsync/core.go
@@ -63,9 +63,9 @@ type Core struct {
 	localFinalizedHeight uint64
 }
 
-func New(log zerolog.Logger, config Config, metrics module.ChainSyncMetrics) (*Core, error) {
+func New(log zerolog.Logger, config Config, metrics module.ChainSyncMetrics, chainID flow.ChainID) (*Core, error) {
 	core := &Core{
-		log:                  log.With().Str("module", "synchronization").Logger(),
+		log:                  log.With().Str("sync_core", chainID.String()).Logger(),
 		Config:               config,
 		heights:              make(map[uint64]*chainsync.Status),
 		blockIDs:             make(map[flow.Identifier]*chainsync.Status),

--- a/module/chainsync/core.go
+++ b/module/chainsync/core.go
@@ -91,10 +91,12 @@ func (c *Core) HandleBlock(header *flow.Header) bool {
 
 	// if we never asked for this block, discard it
 	if !status.WasQueued() {
+		log.Debug().Msgf("discarding block we never queued")
 		return false
 	}
 	// if we have already received this block, exit
 	if status.WasReceived() {
+		log.Debug().Msg("discarding block we have already received")
 		return false
 	}
 
@@ -141,23 +143,23 @@ func (c *Core) HandleHeight(final *flow.Header, height uint64) {
 
 		// TODO remove
 		{
-			cnt := 0
 			for h := final.Height + 1; h <= height; h++ {
 				status, ok := c.heights[h]
 				if !ok {
 					c.log.Warn().Msgf("could not find just-enqueued height %d", h)
 				}
-				c.log.Trace().
+				evt := c.log.With().
 					Uint64("height", h).
+					Str("status", status.StatusString()).
 					Uint("attempts", status.Attempts).
 					Time("queued", status.Queued).
 					Time("requested", status.Requested).
 					Time("received", status.Received).
-					Msgf("re-enqueued height")
-
-				cnt++
-				if cnt > 100 {
-					return
+					Logger()
+				if h < 20 {
+					evt.Debug().Msgf("re-enqueued height")
+				} else {
+					evt.Trace().Msgf("re-enqueued height")
 				}
 			}
 		}
@@ -195,7 +197,27 @@ func (c *Core) RequestHeight(height uint64) {
 func (c *Core) requeueHeight(height uint64) {
 	// if we already received this block, reset the status so we can re-queue
 	status := c.heights[height]
+	// TODO remove
+	evt := c.log.With().
+		Uint64("height", height).
+		Str("status", status.StatusString()).
+		Uint("attempts", status.Attempts).
+		Time("queued", status.Queued).
+		Time("requested", status.Requested).
+		Time("received", status.Received).
+		Bool("was_received", status.WasReceived()).
+		Logger()
+	if height < 20 {
+		evt.Debug().Msgf("requeueHeight()")
+	} else {
+		evt.Trace().Msgf("requeueHeight()")
+	}
 	if status.WasReceived() {
+		if height < 20 {
+			evt.Debug().Uint64("status_height", status.Header.Height).Str("status_id", status.Header.ID().String()).Msg("status was received - deleting...")
+		} else {
+			evt.Trace().Uint64("status_height", status.Header.Height).Str("status_id", status.Header.ID().String()).Msg("status was received - deleting...")
+		}
 		delete(c.blockIDs, status.Header.ID())
 		delete(c.heights, status.Header.Height)
 	}
@@ -252,13 +274,19 @@ func (c *Core) queueByHeight(height uint64) {
 
 	// only queue the request if have never queued it before
 	if c.heights[height].WasQueued() {
-		c.log.Debug().
+		evt := c.log.With().
 			Uint64("height", height).
 			Str("status", c.heights[height].StatusString()).
-			Uint("attemtps", c.heights[height].Attempts).
+			Uint("attempts", c.heights[height].Attempts).
 			Time("queued_at", c.heights[height].Queued).
+			Time("received_at", c.heights[height].Received).
 			Time("requested_at", c.heights[height].Requested).
-			Msg("skipping queueing by height")
+			Logger()
+		if height < 20 {
+			evt.Debug().Msg("skipping queueing by height")
+		} else {
+			evt.Trace().Msgf("skipping queueing by height")
+		}
 		return
 	}
 

--- a/module/chainsync/core_rapid_test.go
+++ b/module/chainsync/core_rapid_test.go
@@ -42,7 +42,7 @@ type rapidSync struct {
 func (r *rapidSync) Init(t *rapid.T) {
 	var err error
 
-	r.core, err = New(zerolog.New(io.Discard), DefaultConfig(), metrics.NewNoopCollector())
+	r.core, err = New(zerolog.New(io.Discard), DefaultConfig(), metrics.NewNoopCollector(), flow.Localnet)
 	require.NoError(t, err)
 
 	r.store = populatedBlockStore(t)

--- a/module/chainsync/core_test.go
+++ b/module/chainsync/core_test.go
@@ -30,7 +30,7 @@ type SyncSuite struct {
 func (ss *SyncSuite) SetupTest() {
 	var err error
 
-	ss.core, err = New(zerolog.New(io.Discard), DefaultConfig(), metrics.NewNoopCollector())
+	ss.core, err = New(zerolog.New(io.Discard), DefaultConfig(), metrics.NewNoopCollector(), flow.Localnet)
 	ss.Require().Nil(err)
 }
 

--- a/module/metrics/chainsync.go
+++ b/module/metrics/chainsync.go
@@ -7,9 +7,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/onflow/flow-go/model/chainsync"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 type ChainSyncCollector struct {
+	chainID               flow.ChainID
 	timeToPruned          *prometheus.HistogramVec
 	timeToReceived        *prometheus.HistogramVec
 	totalPruned           *prometheus.CounterVec
@@ -18,8 +20,9 @@ type ChainSyncCollector struct {
 	totalIdsRequested     prometheus.Counter
 }
 
-func NewChainSyncCollector() *ChainSyncCollector {
+func NewChainSyncCollector(chainID flow.ChainID) *ChainSyncCollector {
 	return &ChainSyncCollector{
+		chainID: chainID,
 		timeToPruned: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:      "time_to_pruned_seconds",
 			Namespace: namespaceChainsync,


### PR DESCRIPTION
* Fixes a bug in the sync engine, where many sync `Status` objects would share a reference to the same `Header` due to a re-used loop variable (see https://github.com/onflow/flow-go/commit/a874156937a518704c14edbb8a0a4a4832dee3b1)
* Adds the chain ID to the sync core, making it possibly to easily differentiate between follower and cluster sync core logs, on collection nodes
* Adds the chain ID to the chainsync metrics, for the same reason
