### PR TITLE
[Benchmark] Simplify transaction follower

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/onflow/flow v0.3.2
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20221214150253-cb74e7764c12
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221214150253-cb74e7764c12
-	github.com/onflow/flow-go-sdk v0.30.0
+	github.com/onflow/flow-go-sdk v0.30.1-0.20221214233640-37e11b82ac05
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221130185733-92eb85ead310
 	github.com/onflow/go-bitswap v0.0.0-20221017184039-808c5791a8a8

--- a/go.sum
+++ b/go.sum
@@ -1233,8 +1233,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221214150253-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221214150253-cb74e7764c12/go.mod h1:WMmeggH/H9Xb/SsT+4QFMtGYf+p1S2LXzbZAIaQQWAk=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go-sdk v0.30.0 h1:Cb1kYW5DXZe7L6zblFvPItTdzGhmzVvCvFSyJWr8Nao=
-github.com/onflow/flow-go-sdk v0.30.0/go.mod h1:KXw/XIsq8g6EdR0AEa+bq3QYNLAx/NNkzWFFJua5ARc=
+github.com/onflow/flow-go-sdk v0.30.1-0.20221214233640-37e11b82ac05 h1:Uo5rPA1CPNFFdXPr/vaR2qB/ukKKk768mUTYyN4n5X4=
+github.com/onflow/flow-go-sdk v0.30.1-0.20221214233640-37e11b82ac05/go.mod h1:KXw/XIsq8g6EdR0AEa+bq3QYNLAx/NNkzWFFJua5ARc=
 github.com/onflow/flow-go/crypto v0.24.4 h1:SwEtoVS2TidCIHYCZMgQ7U2YsqhI9upnw94fhdHTubM=
 github.com/onflow/flow-go/crypto v0.24.4/go.mod h1:dkVL98P6GHR48iD9zCB6XlnkJX8IQd00FKgt1reV90w=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221130185733-92eb85ead310 h1:fOxDpxEi4XbOql9eMc2wBFil21TOdbnjuDjePgnI3Uc=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -180,7 +180,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20221214150253-cb74e7764c12 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221214150253-cb74e7764c12 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.5.0 // indirect
-	github.com/onflow/flow-go-sdk v0.30.0 // indirect
+	github.com/onflow/flow-go-sdk v0.30.1-0.20221214233640-37e11b82ac05 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221130185733-92eb85ead310 // indirect
 	github.com/onflow/go-bitswap v0.0.0-20221017184039-808c5791a8a8 // indirect
 	github.com/onflow/sdks v0.4.4 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -1190,8 +1190,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221214150253-
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221214150253-cb74e7764c12/go.mod h1:WMmeggH/H9Xb/SsT+4QFMtGYf+p1S2LXzbZAIaQQWAk=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-go-sdk v0.30.0 h1:Cb1kYW5DXZe7L6zblFvPItTdzGhmzVvCvFSyJWr8Nao=
-github.com/onflow/flow-go-sdk v0.30.0/go.mod h1:KXw/XIsq8g6EdR0AEa+bq3QYNLAx/NNkzWFFJua5ARc=
+github.com/onflow/flow-go-sdk v0.30.1-0.20221214233640-37e11b82ac05 h1:Uo5rPA1CPNFFdXPr/vaR2qB/ukKKk768mUTYyN4n5X4=
+github.com/onflow/flow-go-sdk v0.30.1-0.20221214233640-37e11b82ac05/go.mod h1:KXw/XIsq8g6EdR0AEa+bq3QYNLAx/NNkzWFFJua5ARc=
 github.com/onflow/flow-go/crypto v0.24.4 h1:SwEtoVS2TidCIHYCZMgQ7U2YsqhI9upnw94fhdHTubM=
 github.com/onflow/flow-go/crypto v0.24.4/go.mod h1:dkVL98P6GHR48iD9zCB6XlnkJX8IQd00FKgt1reV90w=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221130185733-92eb85ead310 h1:fOxDpxEi4XbOql9eMc2wBFil21TOdbnjuDjePgnI3Uc=

--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -103,40 +103,37 @@ func NewTxFollower(ctx context.Context, client access.Client, opts ...followerOp
 	return f, nil
 }
 
-func (f *txFollowerImpl) getAllCollections(ctx context.Context, block *flowsdk.Block) ([]flowsdk.Collection, error) {
-	cols := make([]flowsdk.Collection, 0, len(block.CollectionGuarantees))
-	for i, guaranteed := range block.CollectionGuarantees {
-		col, err := f.client.GetCollection(ctx, guaranteed.CollectionID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get collection: %d: %s: %w",
-				i, guaranteed.CollectionID.Hex(), err)
-		}
-		cols = append(cols, *col)
-	}
-	return cols, nil
+type txStats struct {
+	txs        uint64
+	unknownTxs uint64
+	errorTxs   uint64
 }
 
-func (f *txFollowerImpl) processTransactions(cols []flowsdk.Collection) (blockTxs uint64, blockUnknownTxs uint64) {
-	for _, col := range cols {
-		for _, tx := range col.TransactionIDs {
-			blockTxs++
-
-			if txi, loaded := f.loadAndDelete(tx); loaded {
-				duration := time.Since(txi.submisionTime)
+func (f *txFollowerImpl) processTransactions(results []*flowsdk.TransactionResult) txStats {
+	txStats := txStats{
+		txs: uint64(len(results)),
+	}
+	for _, tx := range results {
+		if tx.Error != nil {
+			txStats.errorTxs++
+		}
+		if txi, loaded := f.loadAndDelete(tx.TransactionID); loaded {
+			duration := time.Since(txi.submisionTime)
+			if f.logger.Trace().Enabled() {
 				f.logger.Trace().
 					Dur("durationInMS", duration).
-					Hex("txID", tx.Bytes()).
+					Hex("txID", tx.TransactionID.Bytes()).
 					Msg("returned account to the pool")
-				close(txi.C)
-				if f.metrics != nil {
-					f.metrics.TransactionExecuted(duration)
-				}
-			} else {
-				blockUnknownTxs++
 			}
+			close(txi.C)
+			if f.metrics != nil {
+				f.metrics.TransactionExecuted(duration)
+			}
+		} else {
+			txStats.unknownTxs++
 		}
 	}
-	return
+	return txStats
 }
 
 func (f *txFollowerImpl) run() {
@@ -146,7 +143,7 @@ func (f *txFollowerImpl) run() {
 
 	lastBlockTime := time.Now()
 
-	var totalTxs, totalUnknownTxs uint64
+	var totalStats txStats
 	for {
 		select {
 		case <-f.ctx.Done():
@@ -155,61 +152,54 @@ func (f *txFollowerImpl) run() {
 		}
 
 		blockResolutionStart := time.Now()
-		block, cols, err := f.pollCollections()
+		hdr, results, err := f.getNextBlocksTransactions()
 		if err != nil {
 			f.logger.Trace().Err(err).Uint64("next_height", f.Height()+1).Msg("collections are not ready yet")
 			continue
 		}
 
-		blockTxs, blockUnknownTxs := f.processTransactions(cols)
-		totalTxs += blockTxs
-		totalUnknownTxs += blockUnknownTxs
+		blockStats := f.processTransactions(results)
+		totalStats.txs += blockStats.txs
+		totalStats.unknownTxs += blockStats.unknownTxs
+		totalStats.errorTxs += blockStats.errorTxs
 
 		f.logger.Debug().
-			Uint64("blockHeight", block.Height).
-			Hex("blockID", block.ID.Bytes()).
+			Uint64("blockHeight", hdr.Height).
+			Hex("blockID", hdr.ID.Bytes()).
 			Dur("timeSinceLastBlockInMS", time.Since(lastBlockTime)).
 			Dur("timeToParseBlockInMS", time.Since(blockResolutionStart)).
-			Int("numCollections", len(block.CollectionGuarantees)).
-			Int("numSeals", len(block.Seals)).
-			Uint64("txsTotal", totalTxs).
-			Uint64("txsTotalUnknown", totalUnknownTxs).
-			Uint64("txsInBlock", blockTxs).
-			Uint64("txsInBlockUnknown", blockUnknownTxs).
+			Dur("timeSinceBlockInMS", time.Since(hdr.Timestamp)).
+			Uint64("txsTotal", totalStats.txs).
+			Uint64("txsTotalUnknown", totalStats.unknownTxs).
+			Uint64("txsTotalErrors", totalStats.errorTxs).
+			Uint64("txsInBlock", blockStats.txs).
+			Uint64("txsInBlockUnknown", blockStats.unknownTxs).
+			Uint64("txsInBlockErrors", blockStats.errorTxs).
 			Int("txsInProgress", f.InProgress()).
 			Msg("new block parsed")
 
-		f.updateFromBlockHeader(block.BlockHeader)
+		f.updateFromBlockHeader(*hdr)
 
 		lastBlockTime = time.Now()
 	}
 }
 
-func (f *txFollowerImpl) pollCollections() (*flowsdk.Block, []flowsdk.Collection, error) {
+func (f *txFollowerImpl) getNextBlocksTransactions() (*flowsdk.BlockHeader, []*flowsdk.TransactionResult, error) {
 	ctx, cancel := context.WithTimeout(f.ctx, 1*time.Second)
 	defer cancel()
 
-	hdr, err := f.client.GetLatestBlockHeader(ctx, true)
+	nextHeight := f.Height() + 1
+	hdr, err := f.client.GetBlockHeaderByHeight(ctx, nextHeight)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get latest block header: %w", err)
 	}
 
-	nextHeight := f.Height() + 1
-	if hdr.Height < nextHeight {
-		return nil, nil, fmt.Errorf("expected block is not yet sealed: want %d, got %d", nextHeight, hdr.Height)
-	}
-
-	block, err := f.client.GetBlockByHeight(ctx, nextHeight)
+	results, err := f.client.GetTransactionResultsByBlockID(ctx, hdr.ID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get block by height: %w", err)
 	}
 
-	cols, err := f.getAllCollections(ctx, block)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get collections: %w", err)
-	}
-
-	return block, cols, nil
+	return hdr, results, nil
 }
 
 // Follow returns a channel that will be closed when the transaction is completed.

--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -187,12 +187,14 @@ func (f *txFollowerImpl) getNextBlocksTransactions() (*flowsdk.BlockHeader, []*f
 	nextHeight := f.Height() + 1
 	hdr, err := f.client.GetBlockHeaderByHeight(ctx, nextHeight)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get latest block header: %w", err)
+		return nil, nil, fmt.Errorf("failed to get block header for height: %d: %w",
+			nextHeight, err)
 	}
 
 	results, err := f.client.GetTransactionResultsByBlockID(ctx, hdr.ID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get block by height: %w", err)
+		return nil, nil, fmt.Errorf("results for block are not available: %d/%s: %w",
+			hdr.Height, hdr.ID, err)
 	}
 
 	return hdr, results, nil

--- a/integration/benchmark/follower.go
+++ b/integration/benchmark/follower.go
@@ -169,12 +169,8 @@ func (f *txFollowerImpl) run() {
 			Dur("timeSinceLastBlockInMS", time.Since(lastBlockTime)).
 			Dur("timeToParseBlockInMS", time.Since(blockResolutionStart)).
 			Dur("timeSinceBlockInMS", time.Since(hdr.Timestamp)).
-			Uint64("txsTotal", totalStats.txs).
-			Uint64("txsTotalUnknown", totalStats.unknownTxs).
-			Uint64("txsTotalErrors", totalStats.errorTxs).
-			Uint64("txsInBlock", blockStats.txs).
-			Uint64("txsInBlockUnknown", blockStats.unknownTxs).
-			Uint64("txsInBlockErrors", blockStats.errorTxs).
+			Interface("blockStats", blockStats).
+			Interface("totalStats", totalStats).
 			Int("txsInProgress", f.InProgress()).
 			Msg("new block parsed")
 

--- a/integration/benchmark/mock/client.go
+++ b/integration/benchmark/mock/client.go
@@ -468,6 +468,52 @@ func (_m *Client) GetTransactionResult(ctx context.Context, txID flow.Identifier
 	return r0, r1
 }
 
+// GetTransactionResultsByBlockID provides a mock function with given fields: ctx, blockID
+func (_m *Client) GetTransactionResultsByBlockID(ctx context.Context, blockID flow.Identifier) ([]*flow.TransactionResult, error) {
+	ret := _m.Called(ctx, blockID)
+
+	var r0 []*flow.TransactionResult
+	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) []*flow.TransactionResult); ok {
+		r0 = rf(ctx, blockID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*flow.TransactionResult)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, flow.Identifier) error); ok {
+		r1 = rf(ctx, blockID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetTransactionsByBlockID provides a mock function with given fields: ctx, blockID
+func (_m *Client) GetTransactionsByBlockID(ctx context.Context, blockID flow.Identifier) ([]*flow.Transaction, error) {
+	ret := _m.Called(ctx, blockID)
+
+	var r0 []*flow.Transaction
+	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) []*flow.Transaction); ok {
+		r0 = rf(ctx, blockID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*flow.Transaction)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, flow.Identifier) error); ok {
+		r1 = rf(ctx, blockID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Ping provides a mock function with given fields: ctx
 func (_m *Client) Ping(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/onflow/flow-emulator v0.38.1
 	github.com/onflow/flow-ft/lib/go/templates v0.2.0
 	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221012204608-ed91c80fee2b
-	github.com/onflow/flow-go-sdk v0.30.0
+	github.com/onflow/flow-go-sdk v0.30.1-0.20221219095751-2f3cf15caf98
 	github.com/onflow/flow-go/crypto v0.24.4
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221130185733-92eb85ead310

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1336,8 +1336,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWK
 github.com/onflow/flow-ft/lib/go/templates v0.2.0 h1:oQQk5UthLS9KfKLkZVJg/XAVq8CXW7HAxSTu4HwBJkU=
 github.com/onflow/flow-ft/lib/go/templates v0.2.0/go.mod h1:qwkTElMcI+PnSBGIWGu1K9OYBLatNimWTC8un9qUji0=
 github.com/onflow/flow-go-sdk v0.13.0/go.mod h1:yqnSajzJVFfrTg68F4WXRR1Yzs1akqAjyscEDyFudPE=
-github.com/onflow/flow-go-sdk v0.30.0 h1:Cb1kYW5DXZe7L6zblFvPItTdzGhmzVvCvFSyJWr8Nao=
-github.com/onflow/flow-go-sdk v0.30.0/go.mod h1:KXw/XIsq8g6EdR0AEa+bq3QYNLAx/NNkzWFFJua5ARc=
+github.com/onflow/flow-go-sdk v0.30.1-0.20221219095751-2f3cf15caf98 h1:8qcE/3Ff8+78BEwoB5ZnHYBPJAxbY8hFTvzGV2/Sl5k=
+github.com/onflow/flow-go-sdk v0.30.1-0.20221219095751-2f3cf15caf98/go.mod h1:KXw/XIsq8g6EdR0AEa+bq3QYNLAx/NNkzWFFJua5ARc=
 github.com/onflow/flow-go/crypto v0.24.4 h1:SwEtoVS2TidCIHYCZMgQ7U2YsqhI9upnw94fhdHTubM=
 github.com/onflow/flow-go/crypto v0.24.4/go.mod h1:dkVL98P6GHR48iD9zCB6XlnkJX8IQd00FKgt1reV90w=
 github.com/onflow/flow/protobuf/go/flow v0.1.8/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=


### PR DESCRIPTION
This switches the follower from using `GetBlockByHeight` and `GetCollection` to a single `GetTransactionResultsByBlockID`.

Initial improvement suggestion: @peterargue 

Depends on: https://github.com/onflow/flow-go-sdk/pull/332