### PR TITLE
Suggestion to unblock PR 3696

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -54,6 +54,10 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 	rag := &RandomAddressGenerator{}
 
+	me := new(modulemock.Local)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+
 	t.Run("single collection", func(t *testing.T) {
 
 		execCtx := fvm.NewContext()
@@ -106,7 +110,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			trackerStorage,
 		)
 
-		exe, err := computer.NewBlockComputer(vm, execCtx, exemetrics, trace.NewNoopTracer(), zerolog.Nop(), committer, prov)
+		exe, err := computer.NewBlockComputer(
+			vm,
+			execCtx,
+			exemetrics,
+			trace.NewNoopTracer(),
+			zerolog.Nop(),
+			committer,
+			me,
+			prov)
 		require.NoError(t, err)
 
 		// create a block with 1 collection with 2 transactions
@@ -151,7 +163,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			trackerStorage,
 		)
 
-		exe, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer, prov)
+		exe, err := computer.NewBlockComputer(
+			vm,
+			execCtx,
+			metrics.NewNoopCollector(),
+			trace.NewNoopTracer(),
+			zerolog.Nop(),
+			committer,
+			me,
+			prov)
 		require.NoError(t, err)
 
 		// create an empty block
@@ -237,7 +257,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			trackerStorage,
 		)
 
-		exe, err := computer.NewBlockComputer(vm, ctx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), comm, prov)
+		exe, err := computer.NewBlockComputer(
+			vm,
+			ctx,
+			metrics.NewNoopCollector(),
+			trace.NewNoopTracer(),
+			zerolog.Nop(),
+			comm,
+			me,
+			prov)
 		require.NoError(t, err)
 
 		// create an empty block
@@ -276,7 +304,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			trackerStorage,
 		)
 
-		exe, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer, prov)
+		exe, err := computer.NewBlockComputer(
+			vm,
+			execCtx,
+			metrics.NewNoopCollector(),
+			trace.NewNoopTracer(),
+			zerolog.Nop(),
+			committer,
+			me,
+			prov)
 		require.NoError(t, err)
 
 		collectionCount := 2
@@ -447,7 +483,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			trackerStorage,
 		)
 
-		exe, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+		exe, err := computer.NewBlockComputer(
+			vm,
+			execCtx,
+			metrics.NewNoopCollector(),
+			trace.NewNoopTracer(),
+			zerolog.Nop(),
+			committer.NewNoopViewCommitter(),
+			me,
+			prov)
 		require.NoError(t, err)
 
 		view := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
@@ -529,7 +573,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			trackerStorage,
 		)
 
-		exe, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+		exe, err := computer.NewBlockComputer(
+			vm,
+			execCtx,
+			metrics.NewNoopCollector(),
+			trace.NewNoopTracer(),
+			zerolog.Nop(),
+			committer.NewNoopViewCommitter(),
+			me,
+			prov)
 		require.NoError(t, err)
 
 		const collectionCount = 2
@@ -624,7 +676,15 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			trackerStorage,
 		)
 
-		exe, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+		exe, err := computer.NewBlockComputer(
+			vm,
+			execCtx,
+			metrics.NewNoopCollector(),
+			trace.NewNoopTracer(),
+			zerolog.Nop(),
+			committer.NewNoopViewCommitter(),
+			me,
+			prov)
 		require.NoError(t, err)
 
 		block := generateBlock(collectionCount, transactionCount, rag)
@@ -832,7 +892,19 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 		trackerStorage,
 	)
 
-	exe, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+	me := new(modulemock.Local)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+
+	exe, err := computer.NewBlockComputer(
+		vm,
+		execCtx,
+		metrics.NewNoopCollector(),
+		trace.NewNoopTracer(),
+		zerolog.Nop(),
+		committer.NewNoopViewCommitter(),
+		me,
+		prov)
 	require.NoError(t, err)
 
 	block := generateBlockWithVisitor(1, 1, fag, func(txBody *flow.TransactionBody) {
@@ -908,7 +980,19 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 		trackerStorage,
 	)
 
-	exe, err := computer.NewBlockComputer(vm, execCtx, metrics, trace.NewNoopTracer(), zerolog.Nop(), committer, prov)
+	me := new(modulemock.Local)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+
+	exe, err := computer.NewBlockComputer(
+		vm,
+		execCtx,
+		metrics,
+		trace.NewNoopTracer(),
+		zerolog.Nop(),
+		committer,
+		me,
+		prov)
 	require.NoError(t, err)
 
 	// create empty block, it will have system collection attached while executing

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -1,3 +1,6 @@
+//go:build relic
+// +build relic
+
 package computer_test
 
 import (

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 	otelTrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
@@ -46,9 +48,15 @@ type resultCollector struct {
 	committerDoneChan  chan struct{}
 	committerError     error
 
-	hasherInputChan chan flow.EventsList
-	hasherDoneChan  chan struct{}
-	hasherError     error
+	eventHasherInputChan chan flow.EventsList
+	eventHasherDoneChan  chan struct{}
+	eventHasherError     error
+
+	signer               module.Local
+	spockHasher          hash.Hasher
+	spockHasherInputChan chan *delta.SpockSnapshot
+	spockHasherDoneChan  chan struct{}
+	spockHasherError     error
 
 	result *execution.ComputationResult
 }
@@ -58,24 +66,31 @@ func newResultCollector(
 	blockSpan otelTrace.Span,
 	metrics module.ExecutionMetrics,
 	committer ViewCommitter,
+	signer module.Local,
+	spockHasher hash.Hasher,
 	block *entity.ExecutableBlock,
 	numCollections int,
 ) *resultCollector {
 	collector := &resultCollector{
-		tracer:             tracer,
-		blockSpan:          blockSpan,
-		metrics:            metrics,
-		committer:          committer,
-		state:              *block.StartState,
-		committerInputChan: make(chan state.View, numCollections),
-		committerDoneChan:  make(chan struct{}),
-		hasherInputChan:    make(chan flow.EventsList, numCollections),
-		hasherDoneChan:     make(chan struct{}),
-		result:             execution.NewEmptyComputationResult(block),
+		tracer:               tracer,
+		blockSpan:            blockSpan,
+		metrics:              metrics,
+		committer:            committer,
+		state:                *block.StartState,
+		committerInputChan:   make(chan state.View, numCollections),
+		committerDoneChan:    make(chan struct{}),
+		eventHasherInputChan: make(chan flow.EventsList, numCollections),
+		eventHasherDoneChan:  make(chan struct{}),
+		signer:               signer,
+		spockHasher:          spockHasher,
+		spockHasherInputChan: make(chan *delta.SpockSnapshot, numCollections),
+		spockHasherDoneChan:  make(chan struct{}),
+		result:               execution.NewEmptyComputationResult(block),
 	}
 
 	go collector.runCollectionCommitter()
-	go collector.runCollectionHasher()
+	go collector.runEventsHasher()
+	go collector.runSpockHasher()
 
 	return collector
 }
@@ -109,17 +124,19 @@ func (collector *resultCollector) runCollectionCommitter() {
 	}
 }
 
-func (collector *resultCollector) runCollectionHasher() {
-	defer close(collector.hasherDoneChan)
+func (collector *resultCollector) runEventsHasher() {
+	defer close(collector.eventHasherDoneChan)
 
-	for data := range collector.hasherInputChan {
+	for data := range collector.eventHasherInputChan {
 		span := collector.tracer.StartSpanFromParent(
 			collector.blockSpan,
 			trace.EXEHashEvents)
 
 		rootHash, err := flow.EventsMerkleRootHash(data)
 		if err != nil {
-			collector.hasherError = fmt.Errorf("hasher failed: %w", err)
+			collector.eventHasherError = fmt.Errorf(
+				"event hasher failed: %w",
+				err)
 			return
 		}
 
@@ -128,6 +145,27 @@ func (collector *resultCollector) runCollectionHasher() {
 			rootHash)
 
 		span.End()
+	}
+}
+
+func (collector *resultCollector) runSpockHasher() {
+	defer close(collector.spockHasherDoneChan)
+
+	for snapshot := range collector.spockHasherInputChan {
+		spock, err := collector.signer.SignFunc(
+			snapshot.SpockSecret,
+			collector.spockHasher,
+			crypto.SPOCKProve)
+		if err != nil {
+			collector.spockHasherError = fmt.Errorf(
+				"spock hasher failed: %w",
+				err)
+			return
+		}
+
+		collector.result.SpockSignatures = append(
+			collector.result.SpockSignatures,
+			spock)
 	}
 }
 
@@ -152,20 +190,29 @@ func (collector *resultCollector) CommitCollection(
 	}
 
 	select {
-	case collector.hasherInputChan <- collector.result.Events[collectionIndex]:
+	case collector.eventHasherInputChan <- collector.result.Events[collectionIndex]:
 		// Do nothing
-	case <-collector.hasherDoneChan:
-		// Hasher exited (probably due to an error)
+	case <-collector.eventHasherDoneChan:
+		// Events hasher exited (probably due to an error)
 	}
 
-	collector.result.AddCollection(collectionView.(*delta.View).Interactions())
+	snapshot := collectionView.(*delta.View).Interactions()
+	select {
+	case collector.spockHasherInputChan <- snapshot:
+		// do nothing
+	case <-collector.spockHasherDoneChan:
+		// Spock hasher exited (probably due to an error)
+	}
+
+	collector.result.AddCollection(snapshot)
 	return collector.result.CollectionStats(collectionIndex)
 }
 
 func (collector *resultCollector) Stop() {
 	collector.closeOnce.Do(func() {
 		close(collector.committerInputChan)
-		close(collector.hasherInputChan)
+		close(collector.eventHasherInputChan)
+		close(collector.spockHasherInputChan)
 	})
 }
 
@@ -176,15 +223,20 @@ func (collector *resultCollector) Finalize() (
 	collector.Stop()
 
 	<-collector.committerDoneChan
-	<-collector.hasherDoneChan
+	<-collector.eventHasherDoneChan
+	<-collector.spockHasherDoneChan
 
 	var err error
 	if collector.committerError != nil {
 		err = multierror.Append(err, collector.committerError)
 	}
 
-	if collector.hasherError != nil {
-		err = multierror.Append(err, collector.hasherError)
+	if collector.eventHasherError != nil {
+		err = multierror.Append(err, collector.eventHasherError)
+	}
+
+	if collector.spockHasherError != nil {
+		err = multierror.Append(err, collector.spockHasherError)
 	}
 
 	if err != nil {

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	otelTrace "go.opentelemetry.io/otel/trace"
 
-	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
@@ -155,7 +154,7 @@ func (collector *resultCollector) runSpockHasher() {
 		spock, err := collector.signer.SignFunc(
 			snapshot.SpockSecret,
 			collector.spockHasher,
-			crypto.SPOCKProve)
+			spockProveWrapper)
 		if err != nil {
 			collector.spockHasherError = fmt.Errorf(
 				"spock hasher failed: %w",

--- a/engine/execution/computation/computer/spock_norelic.go
+++ b/engine/execution/computation/computer/spock_norelic.go
@@ -1,0 +1,17 @@
+//go:build !relic
+// +build !relic
+
+package computer
+
+import (
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/crypto/hash"
+)
+
+// this is a temporary wrapper that simulates a call to SPoCK prove,
+// required for the emulator build. The function is never called by the emulator
+// although it is required for a successful build.
+// TODO: remove once the crypto module properly implements a non-relic version of SPOCKProve .
+func spockProveWrapper(sk crypto.PrivateKey, data []byte, kmac hash.Hasher) (crypto.Signature, error) {
+	panic("SPoCK prove not supported when flow-go is built without relic")
+}

--- a/engine/execution/computation/computer/spock_relic.go
+++ b/engine/execution/computation/computer/spock_relic.go
@@ -1,0 +1,15 @@
+//go:build relic
+// +build relic
+
+package computer
+
+import (
+	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/crypto/hash"
+)
+
+// this is a temporary wrapper that around the crypto library.
+// TODO: remove once the crypto module properly implements a non-relic version of SPOCKProve .
+func spockProveWrapper(sk crypto.PrivateKey, data []byte, kmac hash.Hasher) (crypto.Signature, error) {
+	return crypto.SPOCKProve(sk, data, kmac)
+}

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -138,6 +138,7 @@ func New(
 		tracer,
 		log.With().Str("component", "block_computer").Logger(),
 		committer,
+		me,
 		executionDataProvider,
 	)
 

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -131,6 +131,8 @@ func BenchmarkComputeBlock(b *testing.B) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 	trackerStorage := new(mocktracker.Storage)
@@ -147,7 +149,15 @@ func BenchmarkComputeBlock(b *testing.B) {
 	)
 
 	// TODO(rbtz): add real ledger
-	blockComputer, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), tracer, zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+	blockComputer, err := computer.NewBlockComputer(
+		vm,
+		execCtx,
+		metrics.NewNoopCollector(),
+		tracer,
+		zerolog.Nop(),
+		committer.NewNoopViewCommitter(),
+		me,
+		prov)
 	require.NoError(b, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -119,6 +119,8 @@ func TestComputeBlockWithStorage(t *testing.T) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 	trackerStorage := new(mocktracker.Storage)
@@ -134,7 +136,15 @@ func TestComputeBlockWithStorage(t *testing.T) {
 		trackerStorage,
 	)
 
-	blockComputer, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+	blockComputer, err := computer.NewBlockComputer(
+		vm,
+		execCtx,
+		metrics.NewNoopCollector(),
+		trace.NewNoopTracer(),
+		zerolog.Nop(),
+		committer.NewNoopViewCommitter(),
+		me,
+		prov)
 	require.NoError(t, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(10)
@@ -177,6 +187,8 @@ func TestComputeBlock_Uploader(t *testing.T) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	computationResult := unittest2.ComputationResultFixture([][]flow.Identifier{
 		{unittest.IdentifierFixture()},
@@ -220,6 +232,8 @@ func TestExecuteScript(t *testing.T) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	vm := fvm.NewVirtualMachine()
 
@@ -284,6 +298,8 @@ func TestExecuteScript_BalanceScriptFailsIfViewIsEmpty(t *testing.T) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	view := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
 		return nil, fmt.Errorf("error getting register")
@@ -695,6 +711,8 @@ func Test_EventEncodingFailsOnlyTxAndCarriesOn(t *testing.T) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 	trackerStorage := new(mocktracker.Storage)
@@ -717,6 +735,7 @@ func Test_EventEncodingFailsOnlyTxAndCarriesOn(t *testing.T) {
 		trace.NewNoopTracer(),
 		zerolog.Nop(),
 		committer.NewNoopViewCommitter(),
+		me,
 		prov,
 	)
 	require.NoError(t, err)

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -114,6 +114,8 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 	trackerStorage := new(mocktracker.Storage)
@@ -129,7 +131,15 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 		trackerStorage,
 	)
 
-	blockComputer, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+	blockComputer, err := computer.NewBlockComputer(
+		vm,
+		execCtx,
+		metrics.NewNoopCollector(),
+		trace.NewNoopTracer(),
+		zerolog.Nop(),
+		committer.NewNoopViewCommitter(),
+		me,
+		prov)
 	require.NoError(t, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(10)
@@ -218,6 +228,8 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
 
 	bservice := requesterunit.MockBlobService(blockstore.NewBlockstore(dssync.MutexWrap(datastore.NewMapDatastore())))
 	trackerStorage := new(mocktracker.Storage)
@@ -233,7 +245,15 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 		trackerStorage,
 	)
 
-	blockComputer, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), zerolog.Nop(), committer.NewNoopViewCommitter(), prov)
+	blockComputer, err := computer.NewBlockComputer(
+		vm,
+		execCtx,
+		metrics.NewNoopCollector(),
+		trace.NewNoopTracer(),
+		zerolog.Nop(),
+		committer.NewNoopViewCommitter(),
+		me,
+		prov)
 	require.NoError(t, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(10)

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -19,7 +19,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/computation/computer/uploader"
 	"github.com/onflow/flow-go/engine/execution/provider"
 	"github.com/onflow/flow-go/engine/execution/state"
-	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/engine/execution/utils"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -61,7 +60,6 @@ type Engine struct {
 	maxCollectionHeight    uint64
 	tracer                 module.Tracer
 	extensiveLogging       bool
-	spockHasher            hash.Hasher
 	syncThreshold          int                 // the threshold for how many sealed unexecuted blocks to trigger state syncing.
 	syncFilter             flow.IdentityFilter // specify the filter to sync state from
 	syncConduit            network.Conduit     // sending state syncing requests
@@ -110,7 +108,6 @@ func New(
 		request:                request,
 		state:                  state,
 		receiptHasher:          utils.NewExecutionReceiptHasher(),
-		spockHasher:            utils.NewSPOCKHasher(),
 		blocks:                 blocks,
 		collections:            collections,
 		events:                 events,
@@ -1200,9 +1197,8 @@ func (e *Engine) saveExecutionResults(
 	executionReceipt, err := GenerateExecutionReceipt(
 		e.me,
 		e.receiptHasher,
-		e.spockHasher,
 		executionResult,
-		result.StateSnapshots)
+		result.SpockSignatures)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not generate execution receipt: %w", err)
@@ -1272,23 +1268,15 @@ func (e *Engine) retryUpload() (err error) {
 func GenerateExecutionReceipt(
 	me module.Local,
 	receiptHasher hash.Hasher,
-	spockHasher hash.Hasher,
 	result *flow.ExecutionResult,
-	stateInteractions []*delta.SpockSnapshot) (*flow.ExecutionReceipt, error) {
-	spocks := make([]crypto.Signature, len(stateInteractions))
-
-	for i, stateInteraction := range stateInteractions {
-		spock, err := me.SignFunc(stateInteraction.SpockSecret, spockHasher, crypto.SPOCKProve)
-
-		if err != nil {
-			return nil, fmt.Errorf("error while generating SPoCK: %w", err)
-		}
-		spocks[i] = spock
-	}
-
+	spockSignatures []crypto.Signature,
+) (
+	*flow.ExecutionReceipt,
+	error,
+) {
 	receipt := &flow.ExecutionReceipt{
 		ExecutionResult:   *result,
-		Spocks:            spocks,
+		Spocks:            spockSignatures,
 		ExecutorSignature: crypto.Signature{},
 		ExecutorID:        me.NodeID(),
 	}

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	state "github.com/onflow/flow-go/engine/execution/state/mock"
 	executionUnittest "github.com/onflow/flow-go/engine/execution/state/unittest"
+
 	"github.com/onflow/flow-go/engine/testutil/mocklocal"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
@@ -306,19 +307,6 @@ func (ctx *testingContext) assertSuccessfulBlockComputation(
 			spocks := receipt.Spocks
 
 			assert.Len(ctx.t, spocks, len(computationResult.StateSnapshots))
-
-			for i, stateSnapshot := range computationResult.StateSnapshots {
-
-				valid, err := crypto.SPOCKVerifyAgainstData(
-					ctx.identity.StakingPubKey,
-					spocks[i],
-					stateSnapshot.SpockSecret,
-					ctx.engine.spockHasher,
-				)
-
-				assert.NoError(ctx.t, err)
-				assert.True(ctx.t, valid)
-			}
 
 			ctx.mu.Lock()
 			ctx.broadcastedReceipts[receipt.ExecutionResult.BlockID] = receipt
@@ -1157,7 +1145,6 @@ func TestExecutionGenerationResultsAreChained(t *testing.T) {
 
 	// mock execution state conversion and signing of
 
-	me.EXPECT().SignFunc(gomock.Any(), gomock.Any(), gomock.Any())
 	me.EXPECT().NodeID()
 	me.EXPECT().Sign(gomock.Any(), gomock.Any())
 
@@ -1254,48 +1241,6 @@ func TestExecuteScriptAtBlockID(t *testing.T) {
 		})
 	})
 
-}
-
-func Test_SPOCKGeneration(t *testing.T) {
-	runWithEngine(t, func(ctx testingContext) {
-
-		snapshots := []*delta.SpockSnapshot{
-			{
-				SpockSecret: []byte{1, 2, 3},
-			},
-			{
-				SpockSecret: []byte{3, 2, 1},
-			},
-			{
-				SpockSecret: []byte{},
-			},
-			{
-				SpockSecret: unittest.RandomBytes(100),
-			},
-		}
-
-		executionReceipt, err := GenerateExecutionReceipt(
-			ctx.engine.me,
-			ctx.engine.receiptHasher,
-			ctx.engine.spockHasher,
-			&flow.ExecutionResult{},
-			snapshots,
-		)
-		require.NoError(t, err)
-
-		for i, snapshot := range snapshots {
-			valid, err := crypto.SPOCKVerifyAgainstData(
-				ctx.identity.StakingPubKey,
-				executionReceipt.Spocks[i],
-				snapshot.SpockSecret,
-				ctx.engine.spockHasher,
-			)
-
-			require.NoError(t, err)
-			require.True(t, valid)
-		}
-
-	})
 }
 
 func TestUnauthorizedNodeDoesNotBroadcastReceipts(t *testing.T) {

--- a/engine/execution/messages.go
+++ b/engine/execution/messages.go
@@ -1,6 +1,7 @@
 package execution
 
 import (
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/meter"
@@ -32,6 +33,7 @@ type ComputationResult struct {
 	ComputationIntensities meter.MeteredComputationIntensities
 	TrieUpdates            []*ledger.TrieUpdate
 	ExecutionDataID        flow.Identifier
+	SpockSignatures        []crypto.Signature
 }
 
 func NewEmptyComputationResult(block *entity.ExecutableBlock) *ComputationResult {

--- a/engine/execution/state/unittest/fixtures.go
+++ b/engine/execution/state/unittest/fixtures.go
@@ -1,6 +1,7 @@
 package unittest
 
 import (
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/model/flow"
@@ -29,6 +30,7 @@ func ComputationResultForBlockFixture(
 	proofs := make([][]byte, numChunks)
 	events := make([]flow.EventsList, numChunks)
 	eventHashes := make([]flow.Identifier, numChunks)
+	spockHashes := make([]crypto.Signature, numChunks)
 	for i := 0; i < numChunks; i++ {
 		stateViews[i] = StateInteractionsFixture()
 		stateCommitments[i] = *completeBlock.StartState
@@ -44,5 +46,6 @@ func ComputationResultForBlockFixture(
 		Proofs:                 proofs,
 		Events:                 events,
 		EventsHashes:           eventHashes,
+		SpockSignatures:        spockHashes,
 	}
 }

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -38,6 +38,7 @@ import (
 	mocktracker "github.com/onflow/flow-go/module/executiondatasync/tracker/mock"
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/metrics"
+	moduleMock "github.com/onflow/flow-go/module/mock"
 	requesterunit "github.com/onflow/flow-go/module/state_synchronization/requester/unittest"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -281,8 +282,20 @@ func ExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Chain, refB
 			trackerStorage,
 		)
 
+		me := new(moduleMock.Local)
+		me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil, nil)
+
 		// create BlockComputer
-		bc, err := computer.NewBlockComputer(vm, execCtx, metrics.NewNoopCollector(), trace.NewNoopTracer(), log, committer, prov)
+		bc, err := computer.NewBlockComputer(
+			vm,
+			execCtx,
+			metrics.NewNoopCollector(),
+			trace.NewNoopTracer(),
+			log,
+			committer,
+			me,
+			prov)
 		require.NoError(t, err)
 
 		completeColls := make(map[flow.Identifier]*entity.CompleteCollection)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/onflow/flow-go/module/executiondatasync/tracker"
 	mocktracker "github.com/onflow/flow-go/module/executiondatasync/tracker/mock"
 	"github.com/onflow/flow-go/module/metrics"
+	moduleMock "github.com/onflow/flow-go/module/mock"
 	requesterunit "github.com/onflow/flow-go/module/state_synchronization/requester/unittest"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -214,8 +215,20 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 		trackerStorage,
 	)
 
+	me := new(moduleMock.Local)
+	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil)
+
 	ledgerCommitter := committer.NewLedgerViewCommitter(ledger, tracer)
-	blockComputer, err := computer.NewBlockComputer(vm, fvmContext, collector, tracer, logger, ledgerCommitter, prov)
+	blockComputer, err := computer.NewBlockComputer(
+		vm,
+		fvmContext,
+		collector,
+		tracer,
+		logger,
+		ledgerCommitter,
+		me,
+		prov)
 	require.NoError(tb, err)
 
 	view := delta.NewView(exeState.LedgerGetRegister(ledger, initialCommit))

--- a/insecure/corruptnet/network.go
+++ b/insecure/corruptnet/network.go
@@ -14,9 +14,9 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 
+	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/engine/execution/ingestion"
-	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/engine/execution/utils"
 	verutils "github.com/onflow/flow-go/engine/verification/utils"
 	"github.com/onflow/flow-go/engine/verification/verifier"
@@ -424,7 +424,7 @@ func (n *Network) eventToIngressMessage(event interface{}, channel channels.Chan
 
 func (n *Network) generateExecutionReceipt(result *flow.ExecutionResult) (*flow.ExecutionReceipt, error) {
 	// TODO: fill spock secret with dictated spock data from attack orchestrator.
-	return ingestion.GenerateExecutionReceipt(n.me, n.receiptHasher, n.spockHasher, result, []*delta.SpockSnapshot{})
+	return ingestion.GenerateExecutionReceipt(n.me, n.receiptHasher, result, []crypto.Signature{})
 }
 
 func (n *Network) generateResultApproval(attestation *flow.Attestation) (*flow.ResultApproval, error) {


### PR DESCRIPTION
Suggestion to unblock https://github.com/onflow/flow-go/pull/3696 :

The PR is blocked because the crypto module function `SPOCKProve` can't be build without the relic tag (necessary for the emulator build). This PR adds a wrapper around the crypto module function to solve the issue temporarily. The proper fix includes:
 - a PR to the crypto module that adds a `SPOCKProve` no relic version
 - once merged, tag a new crypto version
 - a second PR to update the crypto version in flow-go to the new version
This work is blocked by a new version crypto integration going on https://github.com/onflow/flow-go/pull/3441. The temp solution can unblock PR 3696 till the proper fix is done.  
  