### PR TITLE
Don't meter the payer balance check

### DIFF
--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -255,10 +255,15 @@ func (executor *transactionExecutor) normalExecution() (
 	invalidator derived.TransactionInvalidator,
 	err error,
 ) {
-	maxTxFees, err := executor.CheckPayerBalanceAndReturnMaxFees(
-		executor.proc,
-		executor.txnState,
-		executor.env)
+	var maxTxFees uint64
+	// run with limits disabled since this is a static cost check
+	// and should be accounted for in the inclusion cost.
+	executor.txnState.RunWithAllLimitsDisabled(func() {
+		maxTxFees, err = executor.CheckPayerBalanceAndReturnMaxFees(
+			executor.proc,
+			executor.txnState,
+			executor.env)
+	})
 
 	if err != nil {
 		return


### PR DESCRIPTION
ref: https://github.com/onflow/flow-go/issues/2767

I realised that checking the payers account balance should not be metered because of 2 reasons:

1. It should be part of inclusion fees, not execution fees. All transactions need to have this check, and the check is of a constant complexity.
2. Adding additional computation cost to transactions will potentially break any daps that have fine tuned their transaction gas limits. Which we will eventually have to do, but that needs a longer communication change, and we can batch more changes like that together.