### PR TITLE
Filter ejected peers in the middleware topologypeers provider

### DIFF
--- a/network/p2p/cache/node_blocklist_wrapper.go
+++ b/network/p2p/cache/node_blocklist_wrapper.go
@@ -113,7 +113,9 @@ func (w *NodeBlocklistWrapper) Identities(filter flow.IdentityFilter) flow.Ident
 		if w.blocklist.Contains(identity.NodeID) {
 			var i flow.Identity = *identity // shallow copy is sufficient, because `Ejected` flag is in top-level struct
 			i.Ejected = true
-			idtx = append(idtx, &i)
+			if filter(&i) { // we need to check the filter here again, because the filter might drop ejected nodes and we are modifying the ejected status here
+				idtx = append(idtx, &i)
+			}
 		} else {
 			idtx = append(idtx, identity)
 		}

--- a/network/p2p/cache/node_blocklist_wrapper_test.go
+++ b/network/p2p/cache/node_blocklist_wrapper_test.go
@@ -170,7 +170,8 @@ func (s *NodeBlocklistWrapperTestSuite) TestBlacklistedNode() {
 		require.Equal(s.T(), len(honestIdentities), len(identities)) // expected only honest nodes to be returned
 		for _, i := range identities {
 			_, isBlocked := blocklistLookup[i.NodeID]
-			require.Equal(s.T(), isBlocked, i.Ejected)
+			require.False(s.T(), isBlocked)
+			require.False(s.T(), i.Ejected)
 		}
 
 		// check that original `combinedIdentities` returned by `IdentityProvider` are _not_ modified by wrapper

--- a/network/p2p/cache/node_blocklist_wrapper_test.go
+++ b/network/p2p/cache/node_blocklist_wrapper_test.go
@@ -138,7 +138,7 @@ func (s *NodeBlocklistWrapperTestSuite) TestBlacklistedNode() {
 
 		s.provider.On("Identities", mock.Anything).Return(combinedIdentities)
 
-		noFilter := filter.In(nil)
+		noFilter := filter.Not(filter.In(nil))
 		identities := s.wrapper.Identities(noFilter)
 
 		require.Equal(s.T(), numIdentities, len(identities)) // expected number resulting identities have the

--- a/network/p2p/middleware/middleware.go
+++ b/network/p2p/middleware/middleware.go
@@ -235,9 +235,9 @@ func (m *Middleware) NewPingService(pingProtocol protocol.ID, provider network.P
 }
 
 func (m *Middleware) peerIDs(flowIDs flow.IdentifierList) peer.IDSlice {
-	result := make([]peer.ID, len(flowIDs))
+	result := make([]peer.ID, 0, len(flowIDs))
 
-	for i, fid := range flowIDs {
+	for _, fid := range flowIDs {
 		pid, err := m.idTranslator.GetPeerID(fid)
 		if err != nil {
 			// We probably don't need to fail the entire function here, since the other
@@ -246,7 +246,7 @@ func (m *Middleware) peerIDs(flowIDs flow.IdentifierList) peer.IDSlice {
 			continue
 		}
 
-		result[i] = pid
+		result = append(result, pid)
 	}
 
 	return result

--- a/network/p2p/middleware/middleware.go
+++ b/network/p2p/middleware/middleware.go
@@ -234,23 +234,6 @@ func (m *Middleware) NewPingService(pingProtocol protocol.ID, provider network.P
 	return ping.NewPingService(m.libP2PNode.Host(), pingProtocol, m.log, provider)
 }
 
-// notEjectedPeerFilter returns a p2p.PeerFilter that returns an error if a peer is not found in the topology or is ejected.
-// This peer filter is the default peer filter configured with the libp2p nodes peer manager.
-func (m *Middleware) notEjectedPeerFilter() p2p.PeerFilter {
-	return func(pid peer.ID) error {
-		id, ok := m.ov.Identity(pid)
-		if !ok {
-			return fmt.Errorf("identity for peer %s not found", pid)
-		}
-
-		if id.Ejected {
-			return fmt.Errorf("peer is ejected %s", pid)
-		}
-
-		return nil
-	}
-}
-
 func (m *Middleware) peerIDs(flowIDs flow.IdentifierList) peer.IDSlice {
 	result := make([]peer.ID, len(flowIDs))
 
@@ -330,7 +313,6 @@ func (m *Middleware) start(ctx context.Context) error {
 
 	m.UpdateNodeAddresses()
 
-	m.peerManagerFilters = append(m.peerManagerFilters, m.notEjectedPeerFilter())
 	m.libP2PNode.WithPeersProvider(m.topologyPeers)
 
 	// starting rate limiters kicks off cleanup loop


### PR DESCRIPTION
This PR fixes a bug in the node block list wrapper where ejected identities are returned from the Identities func when provided with the not ejected identity filter. It filters block listed nodes again after modifying the ejected field and adds a unit test for this edgecase.