### PR TITLE
[Benchmark] Limit GOMAXPROCS on localnet

### DIFF
--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -36,6 +36,7 @@ const (
 	PrometheusTargetsFile    = "./targets.nodes.json"
 	DefaultAccessGatewayName = "access_1"
 	DefaultObserverName      = "observer"
+	DefaultGOMAXPROCS        = 8
 	DefaultMaxObservers      = 1000
 	DefaultCollectionCount   = 3
 	DefaultConsensusCount    = 3
@@ -519,10 +520,7 @@ func defaultService(role, dataDir, profilerDir string, i int) Service {
 			"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo:4317",
 			"OTEL_EXPORTER_OTLP_TRACES_INSECURE=true",
 			fmt.Sprintf("OTEL_RESOURCE_ATTRIBUTES=network=localnet,role=%s,num=%s", role, num),
-			"BINSTAT_ENABLE",
-			"BINSTAT_LEN_WHAT",
-			"BINSTAT_DMP_NAME",
-			"BINSTAT_DMP_PATH",
+			fmt.Sprintf("GOMAXPROCS=%d", DefaultGOMAXPROCS),
 		},
 		Labels: map[string]string{
 			"com.dapperlabs.role": role,


### PR DESCRIPTION
In a large benchmark environments it does not make sense to give every binary all `NumCPU` threads.  Otherwise we are looking at the order of thousands of GC threads threshing caches across the cores.

Also while here, remove `BINSTAT` since we do not use it.