### PR TITLE
Simplify chunk verifier api

### DIFF
--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/onflow/flow-go/fvm/errors"
 	completeLedger "github.com/onflow/flow-go/ledger/complete"
 	"github.com/onflow/flow-go/ledger/complete/wal/fixtures"
-	chmodels "github.com/onflow/flow-go/model/chunks"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/verification"
 	"github.com/onflow/flow-go/module/chunks"
@@ -764,12 +763,7 @@ func executeBlockAndVerifyWithParameters(t *testing.T,
 	require.Len(t, vcds, len(txs)+1) // +1 for system chunk
 
 	for _, vcd := range vcds {
-		var fault chmodels.ChunkFault
-		if vcd.IsSystemChunk {
-			_, fault, err = verifier.SystemChunkVerify(vcd)
-		} else {
-			_, fault, err = verifier.Verify(vcd)
-		}
+		_, fault, err := verifier.Verify(vcd)
 		assert.NoError(t, err)
 		assert.Nil(t, fault)
 	}

--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -188,13 +188,7 @@ func (e *Engine) verify(ctx context.Context, originID flow.Identifier,
 	// execute the assigned chunk
 	span, _ := e.tracer.StartSpanFromContext(ctx, trace.VERVerChunkVerify)
 
-	var spockSecret []byte
-	var chFault chmodels.ChunkFault
-	if vc.IsSystemChunk {
-		spockSecret, chFault, err = e.chVerif.SystemChunkVerify(vc)
-	} else {
-		spockSecret, chFault, err = e.chVerif.Verify(vc)
-	}
+	spockSecret, chFault, err := e.chVerif.Verify(vc)
 	span.End()
 	// Any err means that something went wrong when verify the chunk
 	// the outcome of the verification is captured inside the chFault and not the err

--- a/engine/verification/verifier/engine_test.go
+++ b/engine/verification/verifier/engine_test.go
@@ -3,7 +3,6 @@ package verifier_test
 import (
 	"crypto/rand"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -213,7 +212,7 @@ type ChunkVerifierMock struct {
 
 func (v ChunkVerifierMock) Verify(vc *verification.VerifiableChunkData) ([]byte, chmodel.ChunkFault, error) {
 	if vc.IsSystemChunk {
-		return nil, nil, fmt.Errorf("wrong method invoked for verifying system chunk")
+		return nil, nil, nil
 	}
 
 	switch vc.Chunk.Index {
@@ -247,11 +246,4 @@ func (v ChunkVerifierMock) Verify(vc *verification.VerifiableChunkData) ([]byte,
 		return nil, nil, nil
 	}
 
-}
-
-func (v ChunkVerifierMock) SystemChunkVerify(vc *verification.VerifiableChunkData) ([]byte, chmodel.ChunkFault, error) {
-	if !vc.IsSystemChunk {
-		return nil, nil, fmt.Errorf("wrong method invoked for verifying non-system chunk")
-	}
-	return nil, nil, nil
 }

--- a/module/chunks.go
+++ b/module/chunks.go
@@ -18,17 +18,15 @@ type ChunkAssigner interface {
 
 // ChunkVerifier provides functionality to verify chunks
 type ChunkVerifier interface {
-	// Verify verifies the given VerifiableChunk by executing it and checking the final state commitment
-	// It returns a Spock Secret as a byte array, verification fault of the chunk, and an error.
-	// Note: Verify should only be executed on non-system chunks. It returns an error if it is invoked on
-	// system chunk.
-	// TODO return challenges plus errors
-	Verify(ch *verification.VerifiableChunkData) ([]byte, chmodels.ChunkFault, error)
-
-	// SystemChunkVerify verifies a given VerifiableChunk corresponding to a system chunk.
-	// by executing it and checking the final state commitment
-	// It returns a Spock Secret as a byte array, verification fault of the chunk, and an error.
-	// Note: Verify should only be executed on system chunks. It returns an error if it is invoked on
-	// non-system chunks.
-	SystemChunkVerify(ch *verification.VerifiableChunkData) ([]byte, chmodels.ChunkFault, error)
+	// Verify verifies the given VerifiableChunk by executing it and checking
+	// the final state commitment.
+	// It returns a Spock Secret as a byte array, verification fault of the
+	// chunk, and an error.
+	Verify(
+		ch *verification.VerifiableChunkData,
+	) (
+		[]byte,
+		chmodels.ChunkFault,
+		error,
+	)
 }

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -39,64 +39,57 @@ func NewChunkVerifier(vm computer.VirtualMachine, vmCtx fvm.Context, logger zero
 	}
 }
 
-// Verify verifies a given VerifiableChunk corresponding to a non-system chunk.
-// by executing it and checking the final state commitment
-// It returns a Spock Secret as a byte array, verification fault of the chunk, and an error.
-// Note: Verify should only be executed on non-system chunks. It returns an error if it is invoked on
-// system chunks.
-func (fcv *ChunkVerifier) Verify(vc *verification.VerifiableChunkData) ([]byte, chmodels.ChunkFault, error) {
+// Verify verifies a given VerifiableChunk by executing it and checking the
+// final state commitment.
+// It returns a Spock Secret as a byte array, verification fault of the chunk,
+// and an error.
+func (fcv *ChunkVerifier) Verify(
+	vc *verification.VerifiableChunkData,
+) (
+	[]byte,
+	chmodels.ChunkFault,
+	error,
+) {
+
+	var ctx fvm.Context
+	var transactions []*fvm.TransactionProcedure
 	if vc.IsSystemChunk {
-		return nil, nil, fmt.Errorf("wrong method invoked for verifying system chunk")
+		ctx = fvm.NewContextFromParent(
+			fcv.systemChunkCtx,
+			fvm.WithBlockHeader(vc.Header))
+
+		txBody, err := blueprints.SystemChunkTransaction(fcv.vmCtx.Chain)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not get system chunk transaction: %w", err)
+		}
+
+		transactions = []*fvm.TransactionProcedure{
+			fvm.Transaction(txBody, vc.TransactionOffset+uint32(0)),
+		}
+	} else {
+		ctx = fvm.NewContextFromParent(
+			fcv.vmCtx,
+			fvm.WithBlockHeader(vc.Header))
+
+		transactions = make(
+			[]*fvm.TransactionProcedure,
+			0,
+			len(vc.ChunkDataPack.Collection.Transactions))
+		for i, txBody := range vc.ChunkDataPack.Collection.Transactions {
+			tx := fvm.Transaction(txBody, vc.TransactionOffset+uint32(i))
+			transactions = append(transactions, tx)
+		}
 	}
-
-	transactions := make([]*fvm.TransactionProcedure, 0)
-	for i, txBody := range vc.ChunkDataPack.Collection.Transactions {
-		tx := fvm.Transaction(txBody, vc.TransactionOffset+uint32(i))
-		transactions = append(transactions, tx)
-	}
-
-	return fcv.verifyTransactions(
-		vc.TransactionOffset,
-		vc.Chunk,
-		vc.ChunkDataPack,
-		vc.Result,
-		vc.Header,
-		transactions,
-		vc.EndState)
-}
-
-// SystemChunkVerify verifies a given VerifiableChunk corresponding to a system chunk.
-// by executing it and checking the final state commitment
-// It returns a Spock Secret as a byte array, verification fault of the chunk, and an error.
-// Note: SystemChunkVerify should only be executed on system chunks. It returns an error if it is invoked on
-// non-system chunks.
-func (fcv *ChunkVerifier) SystemChunkVerify(vc *verification.VerifiableChunkData) ([]byte, chmodels.ChunkFault, error) {
-	if !vc.IsSystemChunk {
-		return nil, nil, fmt.Errorf("wrong method invoked for verifying non-system chunk")
-	}
-
-	// transaction body of system chunk
-	txBody, err := blueprints.SystemChunkTransaction(fcv.vmCtx.Chain)
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not get system chunk transaction: %w", err)
-	}
-
-	tx := fvm.Transaction(txBody, vc.TransactionOffset+uint32(0))
-	transactions := []*fvm.TransactionProcedure{tx}
-
-	systemChunkContext := fvm.NewContextFromParent(fcv.systemChunkCtx,
-		fvm.WithBlockHeader(vc.Header),
-	)
 
 	return fcv.verifyTransactionsInContext(
-		systemChunkContext,
+		ctx,
 		vc.TransactionOffset,
 		vc.Chunk,
 		vc.ChunkDataPack,
 		vc.Result,
 		transactions,
 		vc.EndState,
-		true)
+		vc.IsSystemChunk)
 }
 
 func (fcv *ChunkVerifier) verifyTransactionsInContext(
@@ -300,32 +293,4 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 		return nil, chmodels.NewCFNonMatchingFinalState(flow.StateCommitment(expEndStateComm), endState, chIndex, execResID), nil
 	}
 	return chunkView.SpockSecret(), nil, nil
-}
-
-func (fcv *ChunkVerifier) verifyTransactions(
-	transactionOffset uint32,
-	chunk *flow.Chunk,
-	chunkDataPack *flow.ChunkDataPack,
-	result *flow.ExecutionResult,
-	header *flow.Header,
-	transactions []*fvm.TransactionProcedure,
-	endState flow.StateCommitment,
-) (
-	[]byte,
-	chmodels.ChunkFault,
-	error,
-) {
-
-	// build a block context
-	blockCtx := fvm.NewContextFromParent(fcv.vmCtx, fvm.WithBlockHeader(header))
-
-	return fcv.verifyTransactionsInContext(
-		blockCtx,
-		transactionOffset,
-		chunk,
-		chunkDataPack,
-		result,
-		transactions,
-		endState,
-		false)
 }

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -171,7 +171,7 @@ func (s *ChunkVerifierTestSuite) TestEventsMismatch() {
 func (s *ChunkVerifierTestSuite) TestServiceEventsMismatch() {
 	vch := GetBaselineVerifiableChunk(s.T(), "doesn't matter", true)
 	assert.NotNil(s.T(), vch)
-	_, chFault, err := s.systemBadVerifier.SystemChunkVerify(vch)
+	_, chFault, err := s.systemBadVerifier.Verify(vch)
 	assert.Nil(s.T(), err)
 	assert.NotNil(s.T(), chFault)
 	assert.IsType(s.T(), &chunksmodels.CFInvalidServiceEventsEmitted{}, chFault)
@@ -181,30 +181,9 @@ func (s *ChunkVerifierTestSuite) TestServiceEventsMismatch() {
 func (s *ChunkVerifierTestSuite) TestServiceEventsAreChecked() {
 	vch := GetBaselineVerifiableChunk(s.T(), "doesn't matter", true)
 	assert.NotNil(s.T(), vch)
-	_, chFault, err := s.systemOkVerifier.SystemChunkVerify(vch)
+	_, chFault, err := s.systemOkVerifier.Verify(vch)
 	assert.Nil(s.T(), err)
 	assert.Nil(s.T(), chFault)
-}
-
-// TestVerifyWrongChunkType evaluates that following invocations return an error:
-// - verifying a system chunk with Verify method.
-// - verifying a non-system chunk with SystemChunkVerify method.
-func (s *ChunkVerifierTestSuite) TestVerifyWrongChunkType() {
-	// defines verifiable chunk for a system chunk
-	svc := &verification.VerifiableChunkData{
-		IsSystemChunk: true,
-	}
-	// invoking Verify method with system chunk should return an error
-	_, _, err := s.verifier.Verify(svc)
-	require.Error(s.T(), err)
-
-	// defines verifiable chunk for a non-system chunk
-	vc := &verification.VerifiableChunkData{
-		IsSystemChunk: false,
-	}
-	// invoking SystemChunkVerify method with a non-system chunk should return an error
-	_, _, err = s.verifier.SystemChunkVerify(vc)
-	require.Error(s.T(), err)
 }
 
 // TestEmptyCollection tests verification behaviour if a

--- a/module/mock/chunk_verifier.go
+++ b/module/mock/chunk_verifier.go
@@ -14,38 +14,6 @@ type ChunkVerifier struct {
 	mock.Mock
 }
 
-// SystemChunkVerify provides a mock function with given fields: ch
-func (_m *ChunkVerifier) SystemChunkVerify(ch *verification.VerifiableChunkData) ([]byte, chunks.ChunkFault, error) {
-	ret := _m.Called(ch)
-
-	var r0 []byte
-	if rf, ok := ret.Get(0).(func(*verification.VerifiableChunkData) []byte); ok {
-		r0 = rf(ch)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
-		}
-	}
-
-	var r1 chunks.ChunkFault
-	if rf, ok := ret.Get(1).(func(*verification.VerifiableChunkData) chunks.ChunkFault); ok {
-		r1 = rf(ch)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(chunks.ChunkFault)
-		}
-	}
-
-	var r2 error
-	if rf, ok := ret.Get(2).(func(*verification.VerifiableChunkData) error); ok {
-		r2 = rf(ch)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
 // Verify provides a mock function with given fields: ch
 func (_m *ChunkVerifier) Verify(ch *verification.VerifiableChunkData) ([]byte, chunks.ChunkFault, error) {
 	ret := _m.Called(ch)


### PR DESCRIPTION
From the caller's perspective, there's not need to treat non-system vs system chunk differently.