### PR TITLE
[Benchmark] Prevent PID windup at start

### DIFF
--- a/integration/benchmark/cmd/ci/adjuster.go
+++ b/integration/benchmark/cmd/ci/adjuster.go
@@ -24,6 +24,7 @@ type adjuster struct {
 	log                zerolog.Logger
 }
 type AdjusterParams struct {
+	Delay       time.Duration
 	Interval    time.Duration
 	InitialTPS  uint
 	MinTPS      uint
@@ -75,6 +76,14 @@ func NewTPSAdjuster(
 
 	go func() {
 		defer close(a.done)
+
+		log.Info().Dur("delayInMS", params.Delay).Msg("Waiting before starting TPS adjuster")
+		select {
+		case <-time.After(params.Delay):
+			log.Info().Msg("starting TPS adjuster")
+		case <-ctx.Done():
+			return
+		}
 
 		err := a.adjustTPSForever()
 		if err != nil && err != context.Canceled {

--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -55,6 +55,7 @@ func main() {
 	maxTPSFlag := flag.Int("tps-max", *initialTPSFlag, "maximum transactions per second allowed")
 	minTPSFlag := flag.Int("tps-min", *initialTPSFlag, "minimum transactions per second allowed")
 	adjustIntervalFlag := flag.Duration("tps-adjust-interval", defaultAdjustInterval, "interval for adjusting TPS")
+	adjustDelayFlag := flag.Duration("tps-adjust-delay", 120*time.Second, "delay before adjusting TPS")
 	statIntervalFlag := flag.Duration("stat-interval", defaultMetricCollectionInterval, "")
 	durationFlag := flag.Duration("duration", 10*time.Minute, "test duration")
 	gitRepoPathFlag := flag.String("git-repo-path", "../..", "git repo path of the filesystem")
@@ -186,6 +187,7 @@ func main() {
 		workerStatsTracker,
 
 		AdjusterParams{
+			Delay:       *adjustDelayFlag,
 			Interval:    *adjustIntervalFlag,
 			InitialTPS:  uint(*initialTPSFlag),
 			MinTPS:      uint(*minTPSFlag),


### PR DESCRIPTION
Transactions in-progress are very inertial.  To prevent the initial windup let's delay TPS adjustment by a couple of minutes.