### PR TITLE
[Network] Add protocol metrics label

### DIFF
--- a/module/metrics.go
+++ b/module/metrics.go
@@ -104,11 +104,11 @@ type NetworkInboundQueueMetrics interface {
 type NetworkCoreMetrics interface {
 	NetworkInboundQueueMetrics
 	// OutboundMessageSent collects metrics related to a message sent by the node.
-	OutboundMessageSent(sizeBytes int, topic string, messageType string)
+	OutboundMessageSent(sizeBytes int, topic string, protocol string, messageType string)
 	// InboundMessageReceived collects metrics related to a message received by the node.
-	InboundMessageReceived(sizeBytes int, topic string, messageType string)
+	InboundMessageReceived(sizeBytes int, topic string, protocol string, messageType string)
 	// DuplicateInboundMessagesDropped increments the metric tracking the number of duplicate messages dropped by the node.
-	DuplicateInboundMessagesDropped(topic string, messageType string)
+	DuplicateInboundMessagesDropped(topic string, protocol string, messageType string)
 	// UnicastMessageSendingStarted increments the metric tracking the number of unicast messages sent by the node.
 	UnicastMessageSendingStarted(topic string)
 	// UnicastMessageSendingCompleted decrements the metric tracking the number of unicast messages sent by the node.

--- a/module/metrics/example/collection/main.go
+++ b/module/metrics/example/collection/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/metrics/example"
 	"github.com/onflow/flow-go/module/trace"
+	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/channels"
 	"github.com/onflow/flow-go/network/queue"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -32,6 +33,8 @@ func main() {
 
 		topic1 := channels.TestNetworkChannel.String()
 		topic2 := channels.TestMetricsChannel.String()
+		protocol1 := network.ProtocolTypeUnicast.String()
+		protocol2 := network.ProtocolTypePubSub.String()
 		message1 := "CollectionRequest"
 		message2 := "ClusterBlockProposal"
 
@@ -43,11 +46,11 @@ func main() {
 			collector.SetCurView(uint64(i))
 			collector.SetQCView(uint64(i))
 
-			collector.OutboundMessageSent(rand.Intn(1000), topic1, message1)
-			collector.OutboundMessageSent(rand.Intn(1000), topic2, message2)
+			collector.OutboundMessageSent(rand.Intn(1000), topic1, protocol1, message1)
+			collector.OutboundMessageSent(rand.Intn(1000), topic2, protocol2, message2)
 
-			collector.InboundMessageReceived(rand.Intn(1000), topic1, message1)
-			collector.InboundMessageReceived(rand.Intn(1000), topic2, message2)
+			collector.InboundMessageReceived(rand.Intn(1000), topic1, protocol1, message1)
+			collector.InboundMessageReceived(rand.Intn(1000), topic2, protocol2, message2)
 
 			priority1 := rand.Intn(int(queue.HighPriority-queue.LowPriority+1)) + int(queue.LowPriority)
 			collector.MessageRemoved(priority1)

--- a/module/metrics/example/consensus/main.go
+++ b/module/metrics/example/consensus/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/metrics/example"
 	"github.com/onflow/flow-go/module/trace"
+	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/channels"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -65,14 +66,16 @@ func main() {
 
 			collProvider := channels.TestNetworkChannel.String()
 			collIngest := channels.TestMetricsChannel.String()
+			protocol1 := network.ProtocolTypeUnicast.String()
+			protocol2 := network.ProtocolTypePubSub.String()
 			message1 := "CollectionRequest"
 			message2 := "ClusterBlockProposal"
 
-			collector.OutboundMessageSent(rand.Intn(1000), collProvider, message1)
-			collector.OutboundMessageSent(rand.Intn(1000), collIngest, message2)
+			collector.OutboundMessageSent(rand.Intn(1000), collProvider, protocol1, message1)
+			collector.OutboundMessageSent(rand.Intn(1000), collIngest, protocol2, message2)
 
-			collector.InboundMessageReceived(rand.Intn(1000), collProvider, message1)
-			collector.InboundMessageReceived(rand.Intn(1000), collIngest, message2)
+			collector.InboundMessageReceived(rand.Intn(1000), collProvider, protocol1, message1)
+			collector.InboundMessageReceived(rand.Intn(1000), collIngest, protocol2, message2)
 
 			time.Sleep(1 * time.Second)
 		}

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -6,6 +6,7 @@ const (
 	LabelProposer            = "proposer"
 	EngineLabel              = "engine"
 	LabelResource            = "resource"
+	LabelProtocol            = "protocol"
 	LabelMessage             = "message"
 	LabelNodeID              = "nodeid"
 	LabelNodeAddress         = "nodeaddress"

--- a/module/metrics/network.go
+++ b/module/metrics/network.go
@@ -74,7 +74,7 @@ func NewNetworkCollector(logger zerolog.Logger, opts ...NetworkCollectorOpt) *Ne
 			Name:      nc.prefix + "outbound_message_size_bytes",
 			Help:      "size of the outbound network message",
 			Buckets:   []float64{KiB, 100 * KiB, 500 * KiB, 1 * MiB, 2 * MiB, 4 * MiB},
-		}, []string{LabelChannel, LabelMessage},
+		}, []string{LabelChannel, LabelProtocol, LabelMessage},
 	)
 
 	nc.inboundMessageSize = promauto.NewHistogramVec(
@@ -84,7 +84,7 @@ func NewNetworkCollector(logger zerolog.Logger, opts ...NetworkCollectorOpt) *Ne
 			Name:      nc.prefix + "inbound_message_size_bytes",
 			Help:      "size of the inbound network message",
 			Buckets:   []float64{KiB, 100 * KiB, 500 * KiB, 1 * MiB, 2 * MiB, 4 * MiB},
-		}, []string{LabelChannel, LabelMessage},
+		}, []string{LabelChannel, LabelProtocol, LabelMessage},
 	)
 
 	nc.duplicateMessagesDropped = promauto.NewCounterVec(
@@ -93,7 +93,7 @@ func NewNetworkCollector(logger zerolog.Logger, opts ...NetworkCollectorOpt) *Ne
 			Subsystem: subsystemGossip,
 			Name:      nc.prefix + "duplicate_messages_dropped",
 			Help:      "number of duplicate messages dropped",
-		}, []string{LabelChannel, LabelMessage},
+		}, []string{LabelChannel, LabelProtocol, LabelMessage},
 	)
 
 	nc.dnsLookupDuration = promauto.NewHistogram(
@@ -237,18 +237,18 @@ func NewNetworkCollector(logger zerolog.Logger, opts ...NetworkCollectorOpt) *Ne
 }
 
 // OutboundMessageSent collects metrics related to a message sent by the node.
-func (nc *NetworkCollector) OutboundMessageSent(sizeBytes int, topic string, messageType string) {
-	nc.outboundMessageSize.WithLabelValues(topic, messageType).Observe(float64(sizeBytes))
+func (nc *NetworkCollector) OutboundMessageSent(sizeBytes int, topic, protocol, messageType string) {
+	nc.outboundMessageSize.WithLabelValues(topic, protocol, messageType).Observe(float64(sizeBytes))
 }
 
 // InboundMessageReceived collects metrics related to a message received by the node.
-func (nc *NetworkCollector) InboundMessageReceived(sizeBytes int, topic string, messageType string) {
-	nc.inboundMessageSize.WithLabelValues(topic, messageType).Observe(float64(sizeBytes))
+func (nc *NetworkCollector) InboundMessageReceived(sizeBytes int, topic, protocol, messageType string) {
+	nc.inboundMessageSize.WithLabelValues(topic, protocol, messageType).Observe(float64(sizeBytes))
 }
 
 // DuplicateInboundMessagesDropped increments the metric tracking the number of duplicate messages dropped by the node.
-func (nc *NetworkCollector) DuplicateInboundMessagesDropped(topic, messageType string) {
-	nc.duplicateMessagesDropped.WithLabelValues(topic, messageType).Add(1)
+func (nc *NetworkCollector) DuplicateInboundMessagesDropped(topic, protocol, messageType string) {
+	nc.duplicateMessagesDropped.WithLabelValues(topic, protocol, messageType).Add(1)
 }
 
 func (nc *NetworkCollector) MessageAdded(priority int) {

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -15,94 +15,94 @@ import (
 
 type NoopCollector struct{}
 
-func (nc *NoopCollector) Peers(prefix string, n int)                                             {}
-func (nc *NoopCollector) Wantlist(prefix string, n int)                                          {}
-func (nc *NoopCollector) BlobsReceived(prefix string, n uint64)                                  {}
-func (nc *NoopCollector) DataReceived(prefix string, n uint64)                                   {}
-func (nc *NoopCollector) BlobsSent(prefix string, n uint64)                                      {}
-func (nc *NoopCollector) DataSent(prefix string, n uint64)                                       {}
-func (nc *NoopCollector) DupBlobsReceived(prefix string, n uint64)                               {}
-func (nc *NoopCollector) DupDataReceived(prefix string, n uint64)                                {}
-func (nc *NoopCollector) MessagesReceived(prefix string, n uint64)                               {}
-func (nc *NoopCollector) OutboundMessageSent(sizeBytes int, topic string, messageType string)    {}
-func (nc *NoopCollector) InboundMessageReceived(sizeBytes int, topic string, messageType string) {}
-func (nc *NoopCollector) DuplicateInboundMessagesDropped(topic string, messageType string)       {}
-func (nc *NoopCollector) MessageAdded(priority int)                                              {}
-func (nc *NoopCollector) MessageRemoved(priority int)                                            {}
-func (nc *NoopCollector) QueueDuration(duration time.Duration, priority int)                     {}
-func (nc *NoopCollector) MessageProcessingStarted(topic string)                                  {}
-func (nc *NoopCollector) MessageProcessingFinished(topic string, duration time.Duration)         {}
-func (nc *NoopCollector) UnicastMessageSendingStarted(topic string)                              {}
-func (nc *NoopCollector) UnicastMessageSendingCompleted(topic string)                            {}
-func (nc *NoopCollector) MessageSent(engine string, message string)                              {}
-func (nc *NoopCollector) MessageReceived(engine string, message string)                          {}
-func (nc *NoopCollector) MessageHandled(engine string, message string)                           {}
-func (nc *NoopCollector) OutboundConnections(_ uint)                                             {}
-func (nc *NoopCollector) InboundConnections(_ uint)                                              {}
-func (nc *NoopCollector) DNSLookupDuration(duration time.Duration)                               {}
-func (nc *NoopCollector) OnDNSCacheMiss()                                                        {}
-func (nc *NoopCollector) OnDNSCacheInvalidated()                                                 {}
-func (nc *NoopCollector) OnDNSCacheHit()                                                         {}
-func (nc *NoopCollector) OnDNSLookupRequestDropped()                                             {}
-func (nc *NoopCollector) UnstakedOutboundConnections(_ uint)                                     {}
-func (nc *NoopCollector) UnstakedInboundConnections(_ uint)                                      {}
-func (nc *NoopCollector) RanGC(duration time.Duration)                                           {}
-func (nc *NoopCollector) BadgerLSMSize(sizeBytes int64)                                          {}
-func (nc *NoopCollector) BadgerVLogSize(sizeBytes int64)                                         {}
-func (nc *NoopCollector) BadgerNumReads(n int64)                                                 {}
-func (nc *NoopCollector) BadgerNumWrites(n int64)                                                {}
-func (nc *NoopCollector) BadgerNumBytesRead(n int64)                                             {}
-func (nc *NoopCollector) BadgerNumBytesWritten(n int64)                                          {}
-func (nc *NoopCollector) BadgerNumGets(n int64)                                                  {}
-func (nc *NoopCollector) BadgerNumPuts(n int64)                                                  {}
-func (nc *NoopCollector) BadgerNumBlockedPuts(n int64)                                           {}
-func (nc *NoopCollector) BadgerNumMemtableGets(n int64)                                          {}
-func (nc *NoopCollector) FinalizedHeight(height uint64)                                          {}
-func (nc *NoopCollector) SealedHeight(height uint64)                                             {}
-func (nc *NoopCollector) BlockProposed(*flow.Block)                                              {}
-func (nc *NoopCollector) BlockFinalized(*flow.Block)                                             {}
-func (nc *NoopCollector) BlockSealed(*flow.Block)                                                {}
-func (nc *NoopCollector) BlockProposalDuration(duration time.Duration)                           {}
-func (nc *NoopCollector) CommittedEpochFinalView(view uint64)                                    {}
-func (nc *NoopCollector) CurrentEpochCounter(counter uint64)                                     {}
-func (nc *NoopCollector) CurrentEpochPhase(phase flow.EpochPhase)                                {}
-func (nc *NoopCollector) CurrentEpochFinalView(view uint64)                                      {}
-func (nc *NoopCollector) CurrentDKGPhase1FinalView(view uint64)                                  {}
-func (nc *NoopCollector) CurrentDKGPhase2FinalView(view uint64)                                  {}
-func (nc *NoopCollector) CurrentDKGPhase3FinalView(view uint64)                                  {}
-func (nc *NoopCollector) EpochEmergencyFallbackTriggered()                                       {}
-func (nc *NoopCollector) CacheEntries(resource string, entries uint)                             {}
-func (nc *NoopCollector) CacheHit(resource string)                                               {}
-func (nc *NoopCollector) CacheNotFound(resource string)                                          {}
-func (nc *NoopCollector) CacheMiss(resource string)                                              {}
-func (nc *NoopCollector) MempoolEntries(resource string, entries uint)                           {}
-func (nc *NoopCollector) Register(resource string, entriesFunc module.EntriesFunc) error         { return nil }
-func (nc *NoopCollector) HotStuffBusyDuration(duration time.Duration, event string)              {}
-func (nc *NoopCollector) HotStuffIdleDuration(duration time.Duration)                            {}
-func (nc *NoopCollector) HotStuffWaitDuration(duration time.Duration, event string)              {}
-func (nc *NoopCollector) SetCurView(view uint64)                                                 {}
-func (nc *NoopCollector) SetQCView(view uint64)                                                  {}
-func (nc *NoopCollector) CountSkipped()                                                          {}
-func (nc *NoopCollector) CountTimeout()                                                          {}
-func (nc *NoopCollector) SetTimeout(duration time.Duration)                                      {}
-func (nc *NoopCollector) CommitteeProcessingDuration(duration time.Duration)                     {}
-func (nc *NoopCollector) SignerProcessingDuration(duration time.Duration)                        {}
-func (nc *NoopCollector) ValidatorProcessingDuration(duration time.Duration)                     {}
-func (nc *NoopCollector) PayloadProductionDuration(duration time.Duration)                       {}
-func (nc *NoopCollector) TransactionIngested(txID flow.Identifier)                               {}
-func (nc *NoopCollector) ClusterBlockProposed(*cluster.Block)                                    {}
-func (nc *NoopCollector) ClusterBlockFinalized(*cluster.Block)                                   {}
-func (nc *NoopCollector) StartCollectionToFinalized(collectionID flow.Identifier)                {}
-func (nc *NoopCollector) FinishCollectionToFinalized(collectionID flow.Identifier)               {}
-func (nc *NoopCollector) StartBlockToSeal(blockID flow.Identifier)                               {}
-func (nc *NoopCollector) FinishBlockToSeal(blockID flow.Identifier)                              {}
-func (nc *NoopCollector) EmergencySeal()                                                         {}
-func (nc *NoopCollector) OnReceiptProcessingDuration(duration time.Duration)                     {}
-func (nc *NoopCollector) OnApprovalProcessingDuration(duration time.Duration)                    {}
-func (nc *NoopCollector) CheckSealingDuration(duration time.Duration)                            {}
-func (nc *NoopCollector) OnExecutionResultReceivedAtAssignerEngine()                             {}
-func (nc *NoopCollector) OnVerifiableChunkReceivedAtVerifierEngine()                             {}
-func (nc *NoopCollector) OnResultApprovalDispatchedInNetworkByVerifier()                         {}
+func (nc *NoopCollector) Peers(prefix string, n int)                                     {}
+func (nc *NoopCollector) Wantlist(prefix string, n int)                                  {}
+func (nc *NoopCollector) BlobsReceived(prefix string, n uint64)                          {}
+func (nc *NoopCollector) DataReceived(prefix string, n uint64)                           {}
+func (nc *NoopCollector) BlobsSent(prefix string, n uint64)                              {}
+func (nc *NoopCollector) DataSent(prefix string, n uint64)                               {}
+func (nc *NoopCollector) DupBlobsReceived(prefix string, n uint64)                       {}
+func (nc *NoopCollector) DupDataReceived(prefix string, n uint64)                        {}
+func (nc *NoopCollector) MessagesReceived(prefix string, n uint64)                       {}
+func (nc *NoopCollector) OutboundMessageSent(int, string, string, string)                {}
+func (nc *NoopCollector) InboundMessageReceived(int, string, string, string)             {}
+func (nc *NoopCollector) DuplicateInboundMessagesDropped(string, string, string)         {}
+func (nc *NoopCollector) MessageAdded(priority int)                                      {}
+func (nc *NoopCollector) MessageRemoved(priority int)                                    {}
+func (nc *NoopCollector) QueueDuration(duration time.Duration, priority int)             {}
+func (nc *NoopCollector) MessageProcessingStarted(topic string)                          {}
+func (nc *NoopCollector) MessageProcessingFinished(topic string, duration time.Duration) {}
+func (nc *NoopCollector) UnicastMessageSendingStarted(topic string)                      {}
+func (nc *NoopCollector) UnicastMessageSendingCompleted(topic string)                    {}
+func (nc *NoopCollector) MessageSent(engine string, message string)                      {}
+func (nc *NoopCollector) MessageReceived(engine string, message string)                  {}
+func (nc *NoopCollector) MessageHandled(engine string, message string)                   {}
+func (nc *NoopCollector) OutboundConnections(_ uint)                                     {}
+func (nc *NoopCollector) InboundConnections(_ uint)                                      {}
+func (nc *NoopCollector) DNSLookupDuration(duration time.Duration)                       {}
+func (nc *NoopCollector) OnDNSCacheMiss()                                                {}
+func (nc *NoopCollector) OnDNSCacheInvalidated()                                         {}
+func (nc *NoopCollector) OnDNSCacheHit()                                                 {}
+func (nc *NoopCollector) OnDNSLookupRequestDropped()                                     {}
+func (nc *NoopCollector) UnstakedOutboundConnections(_ uint)                             {}
+func (nc *NoopCollector) UnstakedInboundConnections(_ uint)                              {}
+func (nc *NoopCollector) RanGC(duration time.Duration)                                   {}
+func (nc *NoopCollector) BadgerLSMSize(sizeBytes int64)                                  {}
+func (nc *NoopCollector) BadgerVLogSize(sizeBytes int64)                                 {}
+func (nc *NoopCollector) BadgerNumReads(n int64)                                         {}
+func (nc *NoopCollector) BadgerNumWrites(n int64)                                        {}
+func (nc *NoopCollector) BadgerNumBytesRead(n int64)                                     {}
+func (nc *NoopCollector) BadgerNumBytesWritten(n int64)                                  {}
+func (nc *NoopCollector) BadgerNumGets(n int64)                                          {}
+func (nc *NoopCollector) BadgerNumPuts(n int64)                                          {}
+func (nc *NoopCollector) BadgerNumBlockedPuts(n int64)                                   {}
+func (nc *NoopCollector) BadgerNumMemtableGets(n int64)                                  {}
+func (nc *NoopCollector) FinalizedHeight(height uint64)                                  {}
+func (nc *NoopCollector) SealedHeight(height uint64)                                     {}
+func (nc *NoopCollector) BlockProposed(*flow.Block)                                      {}
+func (nc *NoopCollector) BlockFinalized(*flow.Block)                                     {}
+func (nc *NoopCollector) BlockSealed(*flow.Block)                                        {}
+func (nc *NoopCollector) BlockProposalDuration(duration time.Duration)                   {}
+func (nc *NoopCollector) CommittedEpochFinalView(view uint64)                            {}
+func (nc *NoopCollector) CurrentEpochCounter(counter uint64)                             {}
+func (nc *NoopCollector) CurrentEpochPhase(phase flow.EpochPhase)                        {}
+func (nc *NoopCollector) CurrentEpochFinalView(view uint64)                              {}
+func (nc *NoopCollector) CurrentDKGPhase1FinalView(view uint64)                          {}
+func (nc *NoopCollector) CurrentDKGPhase2FinalView(view uint64)                          {}
+func (nc *NoopCollector) CurrentDKGPhase3FinalView(view uint64)                          {}
+func (nc *NoopCollector) EpochEmergencyFallbackTriggered()                               {}
+func (nc *NoopCollector) CacheEntries(resource string, entries uint)                     {}
+func (nc *NoopCollector) CacheHit(resource string)                                       {}
+func (nc *NoopCollector) CacheNotFound(resource string)                                  {}
+func (nc *NoopCollector) CacheMiss(resource string)                                      {}
+func (nc *NoopCollector) MempoolEntries(resource string, entries uint)                   {}
+func (nc *NoopCollector) Register(resource string, entriesFunc module.EntriesFunc) error { return nil }
+func (nc *NoopCollector) HotStuffBusyDuration(duration time.Duration, event string)      {}
+func (nc *NoopCollector) HotStuffIdleDuration(duration time.Duration)                    {}
+func (nc *NoopCollector) HotStuffWaitDuration(duration time.Duration, event string)      {}
+func (nc *NoopCollector) SetCurView(view uint64)                                         {}
+func (nc *NoopCollector) SetQCView(view uint64)                                          {}
+func (nc *NoopCollector) CountSkipped()                                                  {}
+func (nc *NoopCollector) CountTimeout()                                                  {}
+func (nc *NoopCollector) SetTimeout(duration time.Duration)                              {}
+func (nc *NoopCollector) CommitteeProcessingDuration(duration time.Duration)             {}
+func (nc *NoopCollector) SignerProcessingDuration(duration time.Duration)                {}
+func (nc *NoopCollector) ValidatorProcessingDuration(duration time.Duration)             {}
+func (nc *NoopCollector) PayloadProductionDuration(duration time.Duration)               {}
+func (nc *NoopCollector) TransactionIngested(txID flow.Identifier)                       {}
+func (nc *NoopCollector) ClusterBlockProposed(*cluster.Block)                            {}
+func (nc *NoopCollector) ClusterBlockFinalized(*cluster.Block)                           {}
+func (nc *NoopCollector) StartCollectionToFinalized(collectionID flow.Identifier)        {}
+func (nc *NoopCollector) FinishCollectionToFinalized(collectionID flow.Identifier)       {}
+func (nc *NoopCollector) StartBlockToSeal(blockID flow.Identifier)                       {}
+func (nc *NoopCollector) FinishBlockToSeal(blockID flow.Identifier)                      {}
+func (nc *NoopCollector) EmergencySeal()                                                 {}
+func (nc *NoopCollector) OnReceiptProcessingDuration(duration time.Duration)             {}
+func (nc *NoopCollector) OnApprovalProcessingDuration(duration time.Duration)            {}
+func (nc *NoopCollector) CheckSealingDuration(duration time.Duration)                    {}
+func (nc *NoopCollector) OnExecutionResultReceivedAtAssignerEngine()                     {}
+func (nc *NoopCollector) OnVerifiableChunkReceivedAtVerifierEngine()                     {}
+func (nc *NoopCollector) OnResultApprovalDispatchedInNetworkByVerifier()                 {}
 func (nc *NoopCollector) SetMaxChunkDataPackAttemptsForNextUnsealedHeightAtRequester(attempts uint64) {
 }
 func (nc *NoopCollector) OnFinalizedBlockArrivedAtAssigner(height uint64)                       {}

--- a/module/mock/network_core_metrics.go
+++ b/module/mock/network_core_metrics.go
@@ -13,14 +13,14 @@ type NetworkCoreMetrics struct {
 	mock.Mock
 }
 
-// DuplicateInboundMessagesDropped provides a mock function with given fields: topic, messageType
-func (_m *NetworkCoreMetrics) DuplicateInboundMessagesDropped(topic string, messageType string) {
-	_m.Called(topic, messageType)
+// DuplicateInboundMessagesDropped provides a mock function with given fields: topic, protocol, messageType
+func (_m *NetworkCoreMetrics) DuplicateInboundMessagesDropped(topic string, protocol string, messageType string) {
+	_m.Called(topic, protocol, messageType)
 }
 
-// InboundMessageReceived provides a mock function with given fields: sizeBytes, topic, messageType
-func (_m *NetworkCoreMetrics) InboundMessageReceived(sizeBytes int, topic string, messageType string) {
-	_m.Called(sizeBytes, topic, messageType)
+// InboundMessageReceived provides a mock function with given fields: sizeBytes, topic, protocol, messageType
+func (_m *NetworkCoreMetrics) InboundMessageReceived(sizeBytes int, topic string, protocol string, messageType string) {
+	_m.Called(sizeBytes, topic, protocol, messageType)
 }
 
 // MessageAdded provides a mock function with given fields: priority
@@ -43,9 +43,9 @@ func (_m *NetworkCoreMetrics) MessageRemoved(priority int) {
 	_m.Called(priority)
 }
 
-// OutboundMessageSent provides a mock function with given fields: sizeBytes, topic, messageType
-func (_m *NetworkCoreMetrics) OutboundMessageSent(sizeBytes int, topic string, messageType string) {
-	_m.Called(sizeBytes, topic, messageType)
+// OutboundMessageSent provides a mock function with given fields: sizeBytes, topic, protocol, messageType
+func (_m *NetworkCoreMetrics) OutboundMessageSent(sizeBytes int, topic string, protocol string, messageType string) {
+	_m.Called(sizeBytes, topic, protocol, messageType)
 }
 
 // QueueDuration provides a mock function with given fields: duration, priority

--- a/module/mock/network_metrics.go
+++ b/module/mock/network_metrics.go
@@ -94,9 +94,9 @@ func (_m *NetworkMetrics) DNSLookupDuration(duration time.Duration) {
 	_m.Called(duration)
 }
 
-// DuplicateInboundMessagesDropped provides a mock function with given fields: topic, messageType
-func (_m *NetworkMetrics) DuplicateInboundMessagesDropped(topic string, messageType string) {
-	_m.Called(topic, messageType)
+// DuplicateInboundMessagesDropped provides a mock function with given fields: topic, _a1, messageType
+func (_m *NetworkMetrics) DuplicateInboundMessagesDropped(topic string, _a1 string, messageType string) {
+	_m.Called(topic, _a1, messageType)
 }
 
 // InboundConnections provides a mock function with given fields: connectionCount
@@ -104,9 +104,9 @@ func (_m *NetworkMetrics) InboundConnections(connectionCount uint) {
 	_m.Called(connectionCount)
 }
 
-// InboundMessageReceived provides a mock function with given fields: sizeBytes, topic, messageType
-func (_m *NetworkMetrics) InboundMessageReceived(sizeBytes int, topic string, messageType string) {
-	_m.Called(sizeBytes, topic, messageType)
+// InboundMessageReceived provides a mock function with given fields: sizeBytes, topic, _a2, messageType
+func (_m *NetworkMetrics) InboundMessageReceived(sizeBytes int, topic string, _a2 string, messageType string) {
+	_m.Called(sizeBytes, topic, _a2, messageType)
 }
 
 // MessageAdded provides a mock function with given fields: priority
@@ -204,9 +204,9 @@ func (_m *NetworkMetrics) OutboundConnections(connectionCount uint) {
 	_m.Called(connectionCount)
 }
 
-// OutboundMessageSent provides a mock function with given fields: sizeBytes, topic, messageType
-func (_m *NetworkMetrics) OutboundMessageSent(sizeBytes int, topic string, messageType string) {
-	_m.Called(sizeBytes, topic, messageType)
+// OutboundMessageSent provides a mock function with given fields: sizeBytes, topic, _a2, messageType
+func (_m *NetworkMetrics) OutboundMessageSent(sizeBytes int, topic string, _a2 string, messageType string) {
+	_m.Called(sizeBytes, topic, _a2, messageType)
 }
 
 // QueueDuration provides a mock function with given fields: duration, priority

--- a/network/p2p/network.go
+++ b/network/p2p/network.go
@@ -323,7 +323,7 @@ func (n *Network) Identity(pid peer.ID) (*flow.Identity, bool) {
 }
 
 func (n *Network) Receive(msg *network.IncomingMessageScope) error {
-	n.metrics.InboundMessageReceived(msg.Size(), msg.Channel().String(), msg.Protocol().String())
+	n.metrics.InboundMessageReceived(msg.Size(), msg.Channel().String(), msg.Protocol().String(), msg.PayloadType())
 
 	err := n.processNetworkMessage(msg)
 	if err != nil {
@@ -342,7 +342,7 @@ func (n *Network) processNetworkMessage(msg *network.IncomingMessageScope) error
 			Str("channel", msg.Channel().String()).
 			Msg("dropping message due to duplication")
 
-		n.metrics.DuplicateInboundMessagesDropped(msg.Channel().String(), msg.Protocol().String())
+		n.metrics.DuplicateInboundMessagesDropped(msg.Channel().String(), msg.Protocol().String(), msg.PayloadType())
 
 		return nil
 	}
@@ -390,7 +390,7 @@ func (n *Network) UnicastOnChannel(channel channels.Channel, payload interface{}
 		return fmt.Errorf("failed to send message to %x: %w", targetID, err)
 	}
 
-	n.metrics.OutboundMessageSent(msg.Size(), network.ProtocolTypeUnicast.String(), msg.PayloadType())
+	n.metrics.OutboundMessageSent(msg.Size(), msg.Channel().String(), network.ProtocolTypeUnicast.String(), msg.PayloadType())
 
 	return nil
 }
@@ -462,7 +462,7 @@ func (n *Network) sendOnChannel(channel channels.Channel, message interface{}, t
 		return fmt.Errorf("failed to send message on channel %s: %w", channel, err)
 	}
 
-	n.metrics.OutboundMessageSent(msg.Size(), msg.Channel().String(), msg.PayloadType())
+	n.metrics.OutboundMessageSent(msg.Size(), msg.Channel().String(), network.ProtocolTypePubSub.String(), msg.PayloadType())
 
 	return nil
 }


### PR DESCRIPTION
A previous change (https://github.com/onflow/flow-go/pull/3757) updated the network message metrics. This PR fixes a modified label and adds a label for protocol (`pubsub` vs `unicast`)