### PR TITLE
[Consensus] Vote/Timeout aggregation telemetry events

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -546,9 +546,12 @@ func main() {
 			)
 			signer = verification.NewMetricsWrapper(signer, mainMetrics) // wrapper for measuring time spent with crypto-related operations
 
+			// create consensus logger
+			logger := createLogger(node.Logger, node.RootChainID)
+
 			// initialize a logging notifier for hotstuff
 			notifier := createNotifier(
-				node.Logger,
+				logger,
 				mainMetrics,
 			)
 
@@ -579,7 +582,7 @@ func main() {
 			voteProcessorFactory := votecollector.NewCombinedVoteProcessorFactory(wrappedCommittee, qcDistributor.OnQcConstructedFromVotes)
 			lowestViewForVoteProcessing := finalizedBlock.View + 1
 			voteAggregator, err := consensus.NewVoteAggregator(
-				node.Logger,
+				logger,
 				mainMetrics,
 				node.Metrics.Engine,
 				node.Metrics.Mempool,
@@ -593,14 +596,14 @@ func main() {
 
 			timeoutCollectorDistributor := pubsub.NewTimeoutCollectorDistributor()
 			timeoutProcessorFactory := timeoutcollector.NewTimeoutProcessorFactory(
-				node.Logger,
+				logger,
 				timeoutCollectorDistributor,
 				committee,
 				validator,
 				msig.ConsensusTimeoutTag,
 			)
 			timeoutAggregator, err := consensus.NewTimeoutAggregator(
-				node.Logger,
+				logger,
 				mainMetrics,
 				node.Metrics.Engine,
 				node.Metrics.Mempool,
@@ -673,7 +676,7 @@ func main() {
 
 			// initialize hotstuff consensus algorithm
 			hot, err = consensus.NewParticipant(
-				node.Logger,
+				createLogger(node.Logger, node.RootChainID),
 				mainMetrics,
 				build,
 				finalizedBlock,
@@ -693,7 +696,8 @@ func main() {
 			// initialize the pending blocks cache
 			proposals := buffer.NewPendingBlocks()
 
-			complianceCore, err := compliance.NewCore(node.Logger,
+			logger := createLogger(node.Logger, node.RootChainID)
+			complianceCore, err := compliance.NewCore(logger,
 				node.Metrics.Engine,
 				node.Metrics.Mempool,
 				mainMetrics,
@@ -717,7 +721,7 @@ func main() {
 
 			// initialize the compliance engine
 			comp, err = compliance.NewEngine(
-				node.Logger,
+				logger,
 				node.Me,
 				complianceCore,
 			)
@@ -731,7 +735,7 @@ func main() {
 		}).
 		Component("consensus message hub", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			messageHub, err := message_hub.NewMessageHub(
-				node.Logger,
+				createLogger(node.Logger, node.RootChainID),
 				node.Metrics.Engine,
 				node.Network,
 				node.Me,

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -550,8 +550,6 @@ func main() {
 			notifier := createNotifier(
 				node.Logger,
 				mainMetrics,
-				node.Tracer,
-				node.RootChainID,
 			)
 
 			notifier.AddConsumer(finalizationDistributor)
@@ -594,7 +592,13 @@ func main() {
 			}
 
 			timeoutCollectorDistributor := pubsub.NewTimeoutCollectorDistributor()
-			timeoutProcessorFactory := timeoutcollector.NewTimeoutProcessorFactory(timeoutCollectorDistributor, committee, validator, msig.ConsensusTimeoutTag)
+			timeoutProcessorFactory := timeoutcollector.NewTimeoutProcessorFactory(
+				node.Logger,
+				timeoutCollectorDistributor,
+				committee,
+				validator,
+				msig.ConsensusTimeoutTag,
+			)
 			timeoutAggregator, err := consensus.NewTimeoutAggregator(
 				node.Logger,
 				mainMetrics,

--- a/cmd/consensus/notifier.go
+++ b/cmd/consensus/notifier.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications"
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications/pubsub"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	metricsconsumer "github.com/onflow/flow-go/module/metrics/hotstuff"
 )

--- a/cmd/consensus/notifier.go
+++ b/cmd/consensus/notifier.go
@@ -5,14 +5,12 @@ import (
 
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications"
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications/pubsub"
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	metricsconsumer "github.com/onflow/flow-go/module/metrics/hotstuff"
 )
 
-func createNotifier(log zerolog.Logger, metrics module.HotstuffMetrics, tracer module.Tracer, chain flow.ChainID,
-) *pubsub.Distributor {
-	telemetryConsumer := notifications.NewTelemetryConsumer(log, chain)
+func createNotifier(log zerolog.Logger, metrics module.HotstuffMetrics) *pubsub.Distributor {
+	telemetryConsumer := notifications.NewTelemetryConsumer(log)
 	metricsConsumer := metricsconsumer.NewMetricsConsumer(metrics)
 	logsConsumer := notifications.NewLogConsumer(log)
 	dis := pubsub.NewDistributor()

--- a/cmd/consensus/notifier.go
+++ b/cmd/consensus/notifier.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/notifications"
@@ -9,6 +10,12 @@ import (
 	metricsconsumer "github.com/onflow/flow-go/module/metrics/hotstuff"
 )
 
+// createLogger creates logger which reports chain ID on every log message.
+func createLogger(log zerolog.Logger, chainID flow.ChainID) zerolog.Logger {
+	return log.With().Str("chain", chainID.String()).Logger()
+}
+
+// createNotifier creates a pubsub distributor and connects it to consensus consumers.
 func createNotifier(log zerolog.Logger, metrics module.HotstuffMetrics) *pubsub.Distributor {
 	telemetryConsumer := notifications.NewTelemetryConsumer(log)
 	metricsConsumer := metricsconsumer.NewMetricsConsumer(metrics)

--- a/consensus/aggregators.go
+++ b/consensus/aggregators.go
@@ -61,7 +61,7 @@ func NewTimeoutAggregator(log zerolog.Logger,
 	lowestRetainedView uint64,
 ) (hotstuff.TimeoutAggregator, error) {
 
-	timeoutCollectorFactory := timeoutcollector.NewTimeoutCollectorFactory(notifier, distributor, timeoutProcessorFactory)
+	timeoutCollectorFactory := timeoutcollector.NewTimeoutCollectorFactory(log, notifier, distributor, timeoutProcessorFactory)
 	collectors := timeoutaggregator.NewTimeoutCollectors(log, lowestRetainedView, timeoutCollectorFactory)
 
 	// initialize the timeout aggregator

--- a/consensus/hotstuff/consumer.go
+++ b/consensus/hotstuff/consumer.go
@@ -133,6 +133,26 @@ type Consumer interface {
 	// and must handle repetition of the same events (with some processing overhead).
 	OnStartingTimeout(model.TimerInfo)
 
+	// OnVoteProcessed notifications are produced by Vote Aggregation logic.
+	// Such a notification indicates that we have successfully processed vote.
+	// Prerequisites:
+	// Implementation must be concurrency safe; Non-blocking;
+	// and must handle repetition of the same events (with some processing overhead).
+	OnVoteProcessed(vote *model.Vote)
+
+	// OnTimeoutProcessed notifications are produced by Timeout Aggregation logic.
+	// Such a notification indicates that we have successfully processed timeout.
+	// Prerequisites:
+	// Implementation must be concurrency safe; Non-blocking;
+	// and must handle repetition of the same events (with some processing overhead).
+	OnTimeoutProcessed(timeout *model.TimeoutObject)
+
+	// OnCurrentViewDetails notifications are produced by EventHandler when proposing logic is triggered.
+	// Prerequisites:
+	// Implementation must be concurrency safe; Non-blocking;
+	// and must handle repetition of the same events (with some processing overhead).
+	OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier)
+
 	// OnDoubleVotingDetected notifications are produced by the Vote Aggregation logic
 	// whenever a double voting (same voter voting for different blocks at the same view) was detected.
 	// Prerequisites:

--- a/consensus/hotstuff/consumer.go
+++ b/consensus/hotstuff/consumer.go
@@ -115,7 +115,7 @@ type Consumer interface {
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).
-	OnQcTriggeredViewChange(qc *flow.QuorumCertificate, newView uint64)
+	OnQcTriggeredViewChange(oldView uint64, newView uint64, qc *flow.QuorumCertificate)
 
 	// OnTcTriggeredViewChange notifications are produced by PaceMaker when it moves to a new view
 	// based on processing a TC. The arguments specify the tc (first argument), which triggered
@@ -123,7 +123,7 @@ type Consumer interface {
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).
-	OnTcTriggeredViewChange(tc *flow.TimeoutCertificate, newView uint64)
+	OnTcTriggeredViewChange(oldView uint64, newView uint64, tc *flow.TimeoutCertificate)
 
 	// OnStartingTimeout notifications are produced by PaceMaker. Such a notification indicates that the
 	// PaceMaker is now waiting for the system to (receive and) process blocks or votes.
@@ -161,7 +161,7 @@ type Consumer interface {
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).
-	OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier)
+	OnCurrentViewDetails(currentView, finalizedView uint64, currentLeader flow.Identifier)
 
 	// OnDoubleVotingDetected notifications are produced by the Vote Aggregation logic
 	// whenever a double voting (same voter voting for different blocks at the same view) was detected.

--- a/consensus/hotstuff/consumer.go
+++ b/consensus/hotstuff/consumer.go
@@ -175,7 +175,7 @@ type Consumer interface {
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).
-	OnInvalidVoteDetected(*model.Vote)
+	OnInvalidVoteDetected(err model.InvalidVoteError)
 
 	// OnVoteForInvalidBlockDetected notifications are produced by the Vote Aggregation logic
 	// whenever vote for invalid proposal was detected.
@@ -196,7 +196,7 @@ type Consumer interface {
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).
-	OnInvalidTimeoutDetected(*model.TimeoutObject)
+	OnInvalidTimeoutDetected(err model.InvalidTimeoutError)
 }
 
 // QCCreatedConsumer consumes outbound notifications produced by HotStuff and its components.

--- a/consensus/hotstuff/consumer.go
+++ b/consensus/hotstuff/consumer.go
@@ -134,14 +134,14 @@ type Consumer interface {
 	OnStartingTimeout(model.TimerInfo)
 
 	// OnVoteProcessed notifications are produced by Vote Aggregation logic.
-	// Such a notification indicates that we have successfully processed vote.
+	// Such a notification indicates that we have processed a vote.
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).
 	OnVoteProcessed(vote *model.Vote)
 
 	// OnTimeoutProcessed notifications are produced by Timeout Aggregation logic.
-	// Such a notification indicates that we have successfully processed timeout.
+	// Such a notification indicates that we have processed a timeout.
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).

--- a/consensus/hotstuff/consumer.go
+++ b/consensus/hotstuff/consumer.go
@@ -133,15 +133,15 @@ type Consumer interface {
 	// and must handle repetition of the same events (with some processing overhead).
 	OnStartingTimeout(model.TimerInfo)
 
-	// OnVoteProcessed notifications are produced by Vote Aggregation logic.
-	// Such a notification indicates that we have processed a vote.
+	// OnVoteProcessed notifications are produced by the Vote Aggregation logic, each time
+	// we successfully ingest a valid vote.
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).
 	OnVoteProcessed(vote *model.Vote)
 
-	// OnTimeoutProcessed notifications are produced by Timeout Aggregation logic.
-	// Such a notification indicates that we have processed a timeout.
+	// OnTimeoutProcessed notifications are produced by the Timeout Aggregation logic,
+	// each time we successfully ingest a valid timeout.
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).

--- a/consensus/hotstuff/consumer.go
+++ b/consensus/hotstuff/consumer.go
@@ -150,12 +150,12 @@ type Consumer interface {
 	// OnCurrentViewDetails notifications are produced by the EventHandler during the course of a view with auxiliary information.
 	// These notifications are generally not produced for all views (for example skipped views).
 	// These notifications are guaranteed to be produced for all views we enter after fully processing a message.
-	// Example 1: 
+	// Example 1:
 	//   - We are in view 8. We process a QC with view 10, causing us to enter view 11.
 	//   - Then this notification will be produced for view 11.
-	// Example 2: 
+	// Example 2:
 	//   - We are in view 8. We process a proposal with view 10, which contains a TC for view 9 and TC.NewestQC for view 8.
-	//   - The QC would allow us to enter view 9 and the TC would allow us to enter view 10, 
+	//   - The QC would allow us to enter view 9 and the TC would allow us to enter view 10,
 	//     so after fully processing the message we are in view 10.
 	//   - Then this notification will be produced for view 10, but not view 9
 	// Prerequisites:

--- a/consensus/hotstuff/consumer.go
+++ b/consensus/hotstuff/consumer.go
@@ -147,7 +147,17 @@ type Consumer interface {
 	// and must handle repetition of the same events (with some processing overhead).
 	OnTimeoutProcessed(timeout *model.TimeoutObject)
 
-	// OnCurrentViewDetails notifications are produced by EventHandler when proposing logic is triggered.
+	// OnCurrentViewDetails notifications are produced by the EventHandler during the course of a view with auxiliary information.
+	// These notifications are generally not produced for all views (for example skipped views).
+	// These notifications are guaranteed to be produced for all views we enter after fully processing a message.
+	// Example 1: 
+	//   - We are in view 8. We process a QC with view 10, causing us to enter view 11.
+	//   - Then this notification will be produced for view 11.
+	// Example 2: 
+	//   - We are in view 8. We process a proposal with view 10, which contains a TC for view 9 and TC.NewestQC for view 8.
+	//   - The QC would allow us to enter view 9 and the TC would allow us to enter view 10, 
+	//     so after fully processing the message we are in view 10.
+	//   - Then this notification will be produced for view 10, but not view 9
 	// Prerequisites:
 	// Implementation must be concurrency safe; Non-blocking;
 	// and must handle repetition of the same events (with some processing overhead).

--- a/consensus/hotstuff/eventhandler/event_handler.go
+++ b/consensus/hotstuff/eventhandler/event_handler.go
@@ -375,7 +375,7 @@ func (e *EventHandler) proposeForNewViewIfPrimary() error {
 		Uint64("finalized_view", finalizedView).
 		Hex("leader_id", currentLeader[:]).Logger()
 
-	e.notifier.OnCurrentViewDetails(finalizedView, currentLeader)
+	e.notifier.OnCurrentViewDetails(curView, finalizedView, currentLeader)
 
 	// check that I am the primary for this view and that I haven't already proposed; otherwise there is nothing to do
 	if e.committee.Self() != currentLeader {

--- a/consensus/hotstuff/eventhandler/event_handler.go
+++ b/consensus/hotstuff/eventhandler/event_handler.go
@@ -369,10 +369,13 @@ func (e *EventHandler) proposeForNewViewIfPrimary() error {
 	if err != nil {
 		return fmt.Errorf("failed to determine primary for new view %d: %w", curView, err)
 	}
+	finalizedView := e.forks.FinalizedView()
 	log := e.log.With().
 		Uint64("cur_view", curView).
-		Uint64("finalized_view", e.forks.FinalizedView()).
+		Uint64("finalized_view", finalizedView).
 		Hex("leader_id", currentLeader[:]).Logger()
+
+	e.notifier.OnCurrentViewDetails(finalizedView, currentLeader)
 
 	// check that I am the primary for this view and that I haven't already proposed; otherwise there is nothing to do
 	if e.committee.Self() != currentLeader {

--- a/consensus/hotstuff/eventhandler/event_handler_test.go
+++ b/consensus/hotstuff/eventhandler/event_handler_test.go
@@ -301,6 +301,7 @@ func (es *EventHandlerSuite) SetupTest() {
 	es.notifier.On("OnReceiveTc", mock.Anything, mock.Anything).Maybe()
 	es.notifier.On("OnPartialTc", mock.Anything, mock.Anything).Maybe()
 	es.notifier.On("OnLocalTimeout", mock.Anything).Maybe()
+	es.notifier.On("OnCurrentViewDetails", mock.Anything, mock.Anything).Maybe()
 
 	eventhandler, err := NewEventHandler(
 		zerolog.New(os.Stderr),

--- a/consensus/hotstuff/eventhandler/event_handler_test.go
+++ b/consensus/hotstuff/eventhandler/event_handler_test.go
@@ -87,8 +87,8 @@ func initPaceMaker(t require.TestingT, ctx context.Context, livenessData *hotstu
 	persist.On("GetLivenessData").Return(livenessData, nil).Once()
 	pm := NewTestPaceMaker(timeout.NewController(tc), notifier, persist)
 	notifier.On("OnStartingTimeout", mock.Anything).Return()
-	notifier.On("OnQcTriggeredViewChange", mock.Anything, mock.Anything).Return()
-	notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything).Return()
+	notifier.On("OnQcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return()
+	notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return()
 	notifier.On("OnViewChange", mock.Anything, mock.Anything).Maybe()
 	pm.Start(ctx)
 	return pm
@@ -301,7 +301,7 @@ func (es *EventHandlerSuite) SetupTest() {
 	es.notifier.On("OnReceiveTc", mock.Anything, mock.Anything).Maybe()
 	es.notifier.On("OnPartialTc", mock.Anything, mock.Anything).Maybe()
 	es.notifier.On("OnLocalTimeout", mock.Anything).Maybe()
-	es.notifier.On("OnCurrentViewDetails", mock.Anything, mock.Anything).Maybe()
+	es.notifier.On("OnCurrentViewDetails", mock.Anything, mock.Anything, mock.Anything).Maybe()
 
 	eventhandler, err := NewEventHandler(
 		zerolog.New(os.Stderr),

--- a/consensus/hotstuff/integration/instance_test.go
+++ b/consensus/hotstuff/integration/instance_test.go
@@ -484,11 +484,22 @@ func NewInstance(t *testing.T, options ...Option) *Instance {
 				nil,
 			).Maybe()
 
-			p, err := timeoutcollector.NewTimeoutProcessor(in.committee, in.validator, aggregator, collectorDistributor)
+			p, err := timeoutcollector.NewTimeoutProcessor(
+				unittest.Logger(),
+				in.committee,
+				in.validator,
+				aggregator,
+				collectorDistributor,
+			)
 			require.NoError(t, err)
 			return p
 		}, nil).Maybe()
-	timeoutCollectorFactory := timeoutcollector.NewTimeoutCollectorFactory(notifier, collectorDistributor, timeoutProcessorFactory)
+	timeoutCollectorFactory := timeoutcollector.NewTimeoutCollectorFactory(
+		unittest.Logger(),
+		notifier,
+		collectorDistributor,
+		timeoutProcessorFactory,
+	)
 	timeoutCollectors := timeoutaggregator.NewTimeoutCollectors(log, livenessData.CurrentView, timeoutCollectorFactory)
 
 	// initialize the timeout aggregator

--- a/consensus/hotstuff/mocks/consumer.go
+++ b/consensus/hotstuff/mocks/consumer.go
@@ -23,6 +23,11 @@ func (_m *Consumer) OnBlockIncorporated(_a0 *model.Block) {
 	_m.Called(_a0)
 }
 
+// OnCurrentViewDetails provides a mock function with given fields: finalizedView, currentLeader
+func (_m *Consumer) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
+	_m.Called(finalizedView, currentLeader)
+}
+
 // OnDoubleProposeDetected provides a mock function with given fields: _a0, _a1
 func (_m *Consumer) OnDoubleProposeDetected(_a0 *model.Block, _a1 *model.Block) {
 	_m.Called(_a0, _a1)
@@ -118,6 +123,11 @@ func (_m *Consumer) OnTcTriggeredViewChange(tc *flow.TimeoutCertificate, newView
 	_m.Called(tc, newView)
 }
 
+// OnTimeoutProcessed provides a mock function with given fields: timeout
+func (_m *Consumer) OnTimeoutProcessed(timeout *model.TimeoutObject) {
+	_m.Called(timeout)
+}
+
 // OnViewChange provides a mock function with given fields: oldView, newView
 func (_m *Consumer) OnViewChange(oldView uint64, newView uint64) {
 	_m.Called(oldView, newView)
@@ -126,6 +136,11 @@ func (_m *Consumer) OnViewChange(oldView uint64, newView uint64) {
 // OnVoteForInvalidBlockDetected provides a mock function with given fields: vote, invalidProposal
 func (_m *Consumer) OnVoteForInvalidBlockDetected(vote *model.Vote, invalidProposal *model.Proposal) {
 	_m.Called(vote, invalidProposal)
+}
+
+// OnVoteProcessed provides a mock function with given fields: vote
+func (_m *Consumer) OnVoteProcessed(vote *model.Vote) {
+	_m.Called(vote)
 }
 
 type mockConstructorTestingTNewConsumer interface {

--- a/consensus/hotstuff/mocks/consumer.go
+++ b/consensus/hotstuff/mocks/consumer.go
@@ -23,9 +23,9 @@ func (_m *Consumer) OnBlockIncorporated(_a0 *model.Block) {
 	_m.Called(_a0)
 }
 
-// OnCurrentViewDetails provides a mock function with given fields: finalizedView, currentLeader
-func (_m *Consumer) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
-	_m.Called(finalizedView, currentLeader)
+// OnCurrentViewDetails provides a mock function with given fields: currentView, finalizedView, currentLeader
+func (_m *Consumer) OnCurrentViewDetails(currentView uint64, finalizedView uint64, currentLeader flow.Identifier) {
+	_m.Called(currentView, finalizedView, currentLeader)
 }
 
 // OnDoubleProposeDetected provides a mock function with given fields: _a0, _a1
@@ -53,14 +53,14 @@ func (_m *Consumer) OnFinalizedBlock(_a0 *model.Block) {
 	_m.Called(_a0)
 }
 
-// OnInvalidTimeoutDetected provides a mock function with given fields: _a0
-func (_m *Consumer) OnInvalidTimeoutDetected(_a0 *model.TimeoutObject) {
-	_m.Called(_a0)
+// OnInvalidTimeoutDetected provides a mock function with given fields: err
+func (_m *Consumer) OnInvalidTimeoutDetected(err model.InvalidTimeoutError) {
+	_m.Called(err)
 }
 
-// OnInvalidVoteDetected provides a mock function with given fields: _a0
-func (_m *Consumer) OnInvalidVoteDetected(_a0 *model.Vote) {
-	_m.Called(_a0)
+// OnInvalidVoteDetected provides a mock function with given fields: err
+func (_m *Consumer) OnInvalidVoteDetected(err model.InvalidVoteError) {
+	_m.Called(err)
 }
 
 // OnLocalTimeout provides a mock function with given fields: currentView
@@ -88,9 +88,9 @@ func (_m *Consumer) OnPartialTc(currentView uint64, partialTc *hotstuff.PartialT
 	_m.Called(currentView, partialTc)
 }
 
-// OnQcTriggeredViewChange provides a mock function with given fields: qc, newView
-func (_m *Consumer) OnQcTriggeredViewChange(qc *flow.QuorumCertificate, newView uint64) {
-	_m.Called(qc, newView)
+// OnQcTriggeredViewChange provides a mock function with given fields: oldView, newView, qc
+func (_m *Consumer) OnQcTriggeredViewChange(oldView uint64, newView uint64, qc *flow.QuorumCertificate) {
+	_m.Called(oldView, newView, qc)
 }
 
 // OnReceiveProposal provides a mock function with given fields: currentView, proposal
@@ -118,9 +118,9 @@ func (_m *Consumer) OnStartingTimeout(_a0 model.TimerInfo) {
 	_m.Called(_a0)
 }
 
-// OnTcTriggeredViewChange provides a mock function with given fields: tc, newView
-func (_m *Consumer) OnTcTriggeredViewChange(tc *flow.TimeoutCertificate, newView uint64) {
-	_m.Called(tc, newView)
+// OnTcTriggeredViewChange provides a mock function with given fields: oldView, newView, tc
+func (_m *Consumer) OnTcTriggeredViewChange(oldView uint64, newView uint64, tc *flow.TimeoutCertificate) {
+	_m.Called(oldView, newView, tc)
 }
 
 // OnTimeoutProcessed provides a mock function with given fields: timeout

--- a/consensus/hotstuff/model/errors.go
+++ b/consensus/hotstuff/model/errors.go
@@ -186,21 +186,19 @@ func (e InvalidBlockError) Unwrap() error {
 
 // InvalidVoteError indicates that the vote with identifier `VoteID` is invalid
 type InvalidVoteError struct {
-	VoteID flow.Identifier
-	View   uint64
-	Err    error
+	Vote *Vote
+	Err  error
 }
 
 func NewInvalidVoteErrorf(vote *Vote, msg string, args ...interface{}) error {
 	return InvalidVoteError{
-		VoteID: vote.ID(),
-		View:   vote.View,
-		Err:    fmt.Errorf(msg, args...),
+		Vote: vote,
+		Err:  fmt.Errorf(msg, args...),
 	}
 }
 
 func (e InvalidVoteError) Error() string {
-	return fmt.Sprintf("invalid vote %x for view %d: %s", e.VoteID, e.View, e.Err.Error())
+	return fmt.Sprintf("invalid vote at view %d for block %x: %s", e.Vote.View, e.Vote.BlockID, e.Err.Error())
 }
 
 // IsInvalidVoteError returns whether an error is InvalidVoteError
@@ -421,6 +419,17 @@ func (e InvalidTimeoutError) Error() string {
 func IsInvalidTimeoutError(err error) bool {
 	var e InvalidTimeoutError
 	return errors.As(err, &e)
+}
+
+// AsInvalidTimeoutError determines whether the given error is a InvalidTimeoutError
+// (potentially wrapped). It follows the same semantics as a checked type cast.
+func AsInvalidTimeoutError(err error) (*InvalidTimeoutError, bool) {
+	var e InvalidTimeoutError
+	ok := errors.As(err, &e)
+	if ok {
+		return &e, true
+	}
+	return nil, false
 }
 
 func (e InvalidTimeoutError) Unwrap() error {

--- a/consensus/hotstuff/model/errors.go
+++ b/consensus/hotstuff/model/errors.go
@@ -207,6 +207,17 @@ func IsInvalidVoteError(err error) bool {
 	return errors.As(err, &e)
 }
 
+// AsInvalidVoteError determines whether the given error is a InvalidVoteError
+// (potentially wrapped). It follows the same semantics as a checked type cast.
+func AsInvalidVoteError(err error) (*InvalidVoteError, bool) {
+	var e InvalidVoteError
+	ok := errors.As(err, &e)
+	if ok {
+		return &e, true
+	}
+	return nil, false
+}
+
 func (e InvalidVoteError) Unwrap() error {
 	return e.Err
 }

--- a/consensus/hotstuff/notifications/log_consumer.go
+++ b/consensus/hotstuff/notifications/log_consumer.go
@@ -140,6 +140,26 @@ func (lc *LogConsumer) OnStartingTimeout(info model.TimerInfo) {
 		Msg("timeout started")
 }
 
+func (lc *LogConsumer) OnVoteProcessed(vote *model.Vote) {
+	lc.log.Debug().
+		Hex("block_id", vote.BlockID[:]).
+		Uint64("block_view", vote.View).
+		Hex("recipient_id", vote.SignerID[:]).
+		Msg("processed HotStuff vote")
+}
+
+func (lc *LogConsumer) OnTimeoutProcessed(timeout *model.TimeoutObject) {
+	log := timeout.LogContext(lc.log).Logger()
+	log.Debug().Msg("processed timeout object")
+}
+
+func (lc *LogConsumer) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
+	lc.log.Info().
+		Uint64("finalized_view", finalizedView).
+		Hex("current_leader", currentLeader[:]).
+		Msg("current view details")
+}
+
 func (lc *LogConsumer) OnDoubleVotingDetected(vote *model.Vote, alt *model.Vote) {
 	lc.log.Warn().
 		Uint64("vote_view", vote.View).

--- a/consensus/hotstuff/notifications/log_consumer.go
+++ b/consensus/hotstuff/notifications/log_consumer.go
@@ -145,12 +145,12 @@ func (lc *LogConsumer) OnVoteProcessed(vote *model.Vote) {
 		Hex("block_id", vote.BlockID[:]).
 		Uint64("block_view", vote.View).
 		Hex("recipient_id", vote.SignerID[:]).
-		Msg("processed HotStuff vote")
+		Msg("processed valid HotStuff vote")
 }
 
 func (lc *LogConsumer) OnTimeoutProcessed(timeout *model.TimeoutObject) {
 	log := timeout.LogContext(lc.log).Logger()
-	log.Debug().Msg("processed timeout object")
+	log.Debug().Msg("processed valid timeout object")
 }
 
 func (lc *LogConsumer) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {

--- a/consensus/hotstuff/notifications/log_consumer.go
+++ b/consensus/hotstuff/notifications/log_consumer.go
@@ -169,12 +169,12 @@ func (lc *LogConsumer) OnDoubleVotingDetected(vote *model.Vote, alt *model.Vote)
 		Msg("double vote detected")
 }
 
-func (lc *LogConsumer) OnInvalidVoteDetected(vote *model.Vote) {
+func (lc *LogConsumer) OnInvalidVoteDetected(err model.InvalidVoteError) {
 	lc.log.Warn().
-		Uint64("vote_view", vote.View).
-		Hex("voted_block_id", vote.BlockID[:]).
-		Hex("voter_id", vote.SignerID[:]).
-		Msg("invalid vote detected")
+		Uint64("vote_view", err.Vote.View).
+		Hex("voted_block_id", err.Vote.BlockID[:]).
+		Hex("voter_id", err.Vote.SignerID[:]).
+		Msgf("invalid vote detected: %s", err.Error())
 }
 
 func (lc *LogConsumer) OnVoteForInvalidBlockDetected(vote *model.Vote, proposal *model.Proposal) {
@@ -195,9 +195,9 @@ func (lc *LogConsumer) OnDoubleTimeoutDetected(timeout *model.TimeoutObject, alt
 		Msg("double timeout detected")
 }
 
-func (lc *LogConsumer) OnInvalidTimeoutDetected(timeout *model.TimeoutObject) {
-	log := timeout.LogContext(lc.log).Logger()
-	log.Warn().Msg("invalid timeout detected")
+func (lc *LogConsumer) OnInvalidTimeoutDetected(err model.InvalidTimeoutError) {
+	log := err.Timeout.LogContext(lc.log).Logger()
+	log.Warn().Msgf("invalid timeout detected: %s", err.Error())
 }
 
 func (lc *LogConsumer) logBasicBlockData(loggerEvent *zerolog.Event, block *model.Block) *zerolog.Event {

--- a/consensus/hotstuff/notifications/log_consumer.go
+++ b/consensus/hotstuff/notifications/log_consumer.go
@@ -117,19 +117,21 @@ func (lc *LogConsumer) OnViewChange(oldView, newView uint64) {
 		Msg("entered new view")
 }
 
-func (lc *LogConsumer) OnQcTriggeredViewChange(qc *flow.QuorumCertificate, newView uint64) {
+func (lc *LogConsumer) OnQcTriggeredViewChange(oldView uint64, newView uint64, qc *flow.QuorumCertificate) {
 	lc.log.Debug().
 		Uint64("qc_view", qc.View).
 		Hex("qc_block_id", qc.BlockID[:]).
+		Uint64("old_view", oldView).
 		Uint64("new_view", newView).
 		Msg("QC triggered view change")
 }
 
-func (lc *LogConsumer) OnTcTriggeredViewChange(tc *flow.TimeoutCertificate, newView uint64) {
+func (lc *LogConsumer) OnTcTriggeredViewChange(oldView uint64, newView uint64, tc *flow.TimeoutCertificate) {
 	lc.log.Debug().
 		Uint64("tc_view", tc.View).
 		Uint64("tc_newest_qc_view", tc.NewestQC.View).
 		Uint64("new_view", newView).
+		Uint64("old_view", oldView).
 		Msg("TC triggered view change")
 }
 
@@ -153,8 +155,9 @@ func (lc *LogConsumer) OnTimeoutProcessed(timeout *model.TimeoutObject) {
 	log.Debug().Msg("processed valid timeout object")
 }
 
-func (lc *LogConsumer) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
+func (lc *LogConsumer) OnCurrentViewDetails(currentView, finalizedView uint64, currentLeader flow.Identifier) {
 	lc.log.Info().
+		Uint64("view", currentView).
 		Uint64("finalized_view", finalizedView).
 		Hex("current_leader", currentLeader[:]).
 		Msg("current view details")

--- a/consensus/hotstuff/notifications/noop_consumer.go
+++ b/consensus/hotstuff/notifications/noop_consumer.go
@@ -43,9 +43,9 @@ func (*NoopPartialConsumer) OnLocalTimeout(uint64) {}
 
 func (*NoopPartialConsumer) OnViewChange(uint64, uint64) {}
 
-func (*NoopPartialConsumer) OnQcTriggeredViewChange(*flow.QuorumCertificate, uint64) {}
+func (*NoopPartialConsumer) OnQcTriggeredViewChange(uint64, uint64, *flow.QuorumCertificate) {}
 
-func (*NoopPartialConsumer) OnTcTriggeredViewChange(*flow.TimeoutCertificate, uint64) {}
+func (*NoopPartialConsumer) OnTcTriggeredViewChange(uint64, uint64, *flow.TimeoutCertificate) {}
 
 func (*NoopPartialConsumer) OnStartingTimeout(model.TimerInfo) {}
 
@@ -53,7 +53,7 @@ func (*NoopPartialConsumer) OnVoteProcessed(*model.Vote) {}
 
 func (*NoopPartialConsumer) OnTimeoutProcessed(*model.TimeoutObject) {}
 
-func (*NoopPartialConsumer) OnCurrentViewDetails(uint64, flow.Identifier) {}
+func (*NoopPartialConsumer) OnCurrentViewDetails(uint64, uint64, flow.Identifier) {}
 
 func (*NoopPartialConsumer) OnDoubleVotingDetected(*model.Vote, *model.Vote) {}
 

--- a/consensus/hotstuff/notifications/noop_consumer.go
+++ b/consensus/hotstuff/notifications/noop_consumer.go
@@ -49,6 +49,12 @@ func (*NoopPartialConsumer) OnTcTriggeredViewChange(*flow.TimeoutCertificate, ui
 
 func (*NoopPartialConsumer) OnStartingTimeout(model.TimerInfo) {}
 
+func (*NoopPartialConsumer) OnVoteProcessed(*model.Vote) {}
+
+func (*NoopPartialConsumer) OnTimeoutProcessed(*model.TimeoutObject) {}
+
+func (*NoopPartialConsumer) OnCurrentViewDetails(uint64, flow.Identifier) {}
+
 func (*NoopPartialConsumer) OnDoubleVotingDetected(*model.Vote, *model.Vote) {}
 
 func (*NoopPartialConsumer) OnInvalidVoteDetected(*model.Vote) {}

--- a/consensus/hotstuff/notifications/noop_consumer.go
+++ b/consensus/hotstuff/notifications/noop_consumer.go
@@ -57,13 +57,13 @@ func (*NoopPartialConsumer) OnCurrentViewDetails(uint64, flow.Identifier) {}
 
 func (*NoopPartialConsumer) OnDoubleVotingDetected(*model.Vote, *model.Vote) {}
 
-func (*NoopPartialConsumer) OnInvalidVoteDetected(*model.Vote) {}
+func (*NoopPartialConsumer) OnInvalidVoteDetected(model.InvalidVoteError) {}
 
 func (*NoopPartialConsumer) OnVoteForInvalidBlockDetected(*model.Vote, *model.Proposal) {}
 
 func (*NoopPartialConsumer) OnDoubleTimeoutDetected(*model.TimeoutObject, *model.TimeoutObject) {}
 
-func (*NoopPartialConsumer) OnInvalidTimeoutDetected(*model.TimeoutObject) {}
+func (*NoopPartialConsumer) OnInvalidTimeoutDetected(model.InvalidTimeoutError) {}
 
 // no-op implementation of hotstuff.FinalizationConsumer
 

--- a/consensus/hotstuff/notifications/pubsub/distributor.go
+++ b/consensus/hotstuff/notifications/pubsub/distributor.go
@@ -31,7 +31,7 @@ func NewDistributor() *Distributor {
 	return &Distributor{}
 }
 
-// AddConsumer adds an a event consumer to the Distributor
+// AddConsumer adds an event consumer to the Distributor
 func (p *Distributor) AddConsumer(consumer hotstuff.Consumer) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -94,19 +94,19 @@ func (p *Distributor) OnViewChange(oldView, newView uint64) {
 	}
 }
 
-func (p *Distributor) OnQcTriggeredViewChange(qc *flow.QuorumCertificate, newView uint64) {
+func (p *Distributor) OnQcTriggeredViewChange(oldView uint64, newView uint64, qc *flow.QuorumCertificate) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	for _, subscriber := range p.subscribers {
-		subscriber.OnQcTriggeredViewChange(qc, newView)
+		subscriber.OnQcTriggeredViewChange(oldView, newView, qc)
 	}
 }
 
-func (p *Distributor) OnTcTriggeredViewChange(tc *flow.TimeoutCertificate, newView uint64) {
+func (p *Distributor) OnTcTriggeredViewChange(oldView uint64, newView uint64, tc *flow.TimeoutCertificate) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	for _, subscriber := range p.subscribers {
-		subscriber.OnTcTriggeredViewChange(tc, newView)
+		subscriber.OnTcTriggeredViewChange(oldView, newView, tc)
 	}
 }
 
@@ -134,11 +134,11 @@ func (p *Distributor) OnTimeoutProcessed(timeout *model.TimeoutObject) {
 	}
 }
 
-func (p *Distributor) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
+func (p *Distributor) OnCurrentViewDetails(currentView, finalizedView uint64, currentLeader flow.Identifier) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	for _, subscriber := range p.subscribers {
-		subscriber.OnCurrentViewDetails(finalizedView, currentLeader)
+		subscriber.OnCurrentViewDetails(currentView, finalizedView, currentLeader)
 	}
 }
 
@@ -174,11 +174,11 @@ func (p *Distributor) OnDoubleVotingDetected(vote1, vote2 *model.Vote) {
 	}
 }
 
-func (p *Distributor) OnInvalidVoteDetected(vote *model.Vote) {
+func (p *Distributor) OnInvalidVoteDetected(err model.InvalidVoteError) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	for _, subscriber := range p.subscribers {
-		subscriber.OnInvalidVoteDetected(vote)
+		subscriber.OnInvalidVoteDetected(err)
 	}
 }
 
@@ -198,11 +198,11 @@ func (p *Distributor) OnDoubleTimeoutDetected(timeout *model.TimeoutObject, altT
 	}
 }
 
-func (p *Distributor) OnInvalidTimeoutDetected(timeout *model.TimeoutObject) {
+func (p *Distributor) OnInvalidTimeoutDetected(err model.InvalidTimeoutError) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 	for _, subscriber := range p.subscribers {
-		subscriber.OnInvalidTimeoutDetected(timeout)
+		subscriber.OnInvalidTimeoutDetected(err)
 	}
 }
 

--- a/consensus/hotstuff/notifications/pubsub/distributor.go
+++ b/consensus/hotstuff/notifications/pubsub/distributor.go
@@ -118,6 +118,30 @@ func (p *Distributor) OnStartingTimeout(timerInfo model.TimerInfo) {
 	}
 }
 
+func (p *Distributor) OnVoteProcessed(vote *model.Vote) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	for _, subscriber := range p.subscribers {
+		subscriber.OnVoteProcessed(vote)
+	}
+}
+
+func (p *Distributor) OnTimeoutProcessed(timeout *model.TimeoutObject) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	for _, subscriber := range p.subscribers {
+		subscriber.OnTimeoutProcessed(timeout)
+	}
+}
+
+func (p *Distributor) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	for _, subscriber := range p.subscribers {
+		subscriber.OnCurrentViewDetails(finalizedView, currentLeader)
+	}
+}
+
 func (p *Distributor) OnBlockIncorporated(block *model.Block) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -39,6 +39,8 @@ type TelemetryConsumer struct {
 
 var _ hotstuff.Consumer = (*TelemetryConsumer)(nil)
 
+// NewTelemetryConsumer creates consumer that reports telemetry events using logger backend.
+// Logger MUST include `chain` parameter as part of log context with corresponding chain ID to correctly map telemetry events to chain.
 func NewTelemetryConsumer(log zerolog.Logger) *TelemetryConsumer {
 	pathHandler := NewPathHandler(log)
 	return &TelemetryConsumer{
@@ -254,6 +256,7 @@ type PathHandler struct {
 
 // NewPathHandler instantiate a new PathHandler.
 // The PathHandler has no currently open path
+// Logger MUST include `chain` parameter as part of log context with corresponding chain ID to correctly map telemetry events to chain.
 func NewPathHandler(log zerolog.Logger) *PathHandler {
 	return &PathHandler{
 		log:         log.With().Str("component", "hotstuff.telemetry").Logger(),

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -198,6 +198,13 @@ func (t *TelemetryConsumer) OnOwnTimeout(timeout *model.TimeoutObject) {
 	step.Msg("OnOwnTimeout")
 }
 
+func (t *TelemetryConsumer) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
+	t.pathHandler.NextStep().
+		Uint64("finalized_view", finalizedView).
+		Hex("current_leader", currentLeader[:]).
+		Msg("OnCurrentViewDetails")
+}
+
 // PathHandler maintains a notion of the current path through the state machine.
 // It allows to close a path and open new path. Each path is identified by a unique
 // (randomly generated) uuid. Along each path, we can capture information about relevant

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -253,7 +253,7 @@ type PathHandler struct {
 // The PathHandler has no currently open path
 func NewPathHandler(log zerolog.Logger) *PathHandler {
 	return &PathHandler{
-		log:         log.With().Str("hotstuff", "telemetry").Logger(),
+		log:         log.With().Str("component", "hotstuff.telemetry").Logger(),
 		currentPath: nil,
 	}
 }

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -33,8 +33,8 @@ import (
 // Telemetry does NOT capture slashing notifications
 type TelemetryConsumer struct {
 	NoopConsumer
-	pathHandler *PathHandler
-	noPathEvent *zerolog.Event
+	pathHandler  *PathHandler
+	noPathLogger zerolog.Logger
 }
 
 var _ hotstuff.Consumer = (*TelemetryConsumer)(nil)
@@ -42,8 +42,8 @@ var _ hotstuff.Consumer = (*TelemetryConsumer)(nil)
 func NewTelemetryConsumer(log zerolog.Logger) *TelemetryConsumer {
 	pathHandler := NewPathHandler(log)
 	return &TelemetryConsumer{
-		pathHandler: pathHandler,
-		noPathEvent: pathHandler.log.Info(),
+		pathHandler:  pathHandler,
+		noPathLogger: pathHandler.log,
 	}
 }
 
@@ -204,7 +204,7 @@ func (t *TelemetryConsumer) OnOwnTimeout(timeout *model.TimeoutObject) {
 }
 
 func (t *TelemetryConsumer) OnVoteProcessed(vote *model.Vote) {
-	t.noPathEvent.
+	t.noPathLogger.Info().
 		Uint64("voted_block_view", vote.View).
 		Hex("voted_block_id", logging.ID(vote.BlockID)).
 		Hex("signer_id", logging.ID(vote.SignerID)).
@@ -212,7 +212,7 @@ func (t *TelemetryConsumer) OnVoteProcessed(vote *model.Vote) {
 }
 
 func (t *TelemetryConsumer) OnTimeoutProcessed(timeout *model.TimeoutObject) {
-	step := t.noPathEvent.
+	step := t.noPathLogger.Info().
 		Uint64("view", timeout.View).
 		Uint64("timeout_tick", timeout.TimeoutTick).
 		Uint64("newest_qc_view", timeout.NewestQC.View).

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -142,17 +142,19 @@ func (t *TelemetryConsumer) OnFinalizedBlock(block *model.Block) {
 		Msg("OnFinalizedBlock")
 }
 
-func (t *TelemetryConsumer) OnQcTriggeredViewChange(qc *flow.QuorumCertificate, newView uint64) {
+func (t *TelemetryConsumer) OnQcTriggeredViewChange(oldView uint64, newView uint64, qc *flow.QuorumCertificate) {
 	t.pathHandler.NextStep().
 		Uint64("qc_view", qc.View).
+		Uint64("old_view", oldView).
 		Uint64("next_view", newView).
 		Hex("qc_block_id", qc.BlockID[:]).
 		Msg("OnQcTriggeredViewChange")
 }
 
-func (t *TelemetryConsumer) OnTcTriggeredViewChange(tc *flow.TimeoutCertificate, newView uint64) {
+func (t *TelemetryConsumer) OnTcTriggeredViewChange(oldView uint64, newView uint64, tc *flow.TimeoutCertificate) {
 	t.pathHandler.NextStep().
 		Uint64("tc_view", tc.View).
+		Uint64("old_view", oldView).
 		Uint64("next_view", newView).
 		Uint64("tc_newest_qc_view", tc.NewestQC.View).
 		Hex("tc_newest_qc_block_id", tc.NewestQC.BlockID[:]).
@@ -228,8 +230,9 @@ func (t *TelemetryConsumer) OnTimeoutProcessed(timeout *model.TimeoutObject) {
 	step.Msg("OnTimeoutProcessed")
 }
 
-func (t *TelemetryConsumer) OnCurrentViewDetails(finalizedView uint64, currentLeader flow.Identifier) {
+func (t *TelemetryConsumer) OnCurrentViewDetails(currentView, finalizedView uint64, currentLeader flow.Identifier) {
 	t.pathHandler.NextStep().
+		Uint64("view", currentView).
 		Uint64("finalized_view", finalizedView).
 		Hex("current_leader", currentLeader[:]).
 		Msg("OnCurrentViewDetails")

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -36,9 +36,9 @@ type TelemetryConsumer struct {
 
 var _ hotstuff.Consumer = (*TelemetryConsumer)(nil)
 
-func NewTelemetryConsumer(log zerolog.Logger, chain flow.ChainID) *TelemetryConsumer {
+func NewTelemetryConsumer(log zerolog.Logger) *TelemetryConsumer {
 	return &TelemetryConsumer{
-		pathHandler: NewPathHandler(log, chain),
+		pathHandler: NewPathHandler(log),
 	}
 }
 
@@ -205,8 +205,7 @@ func (t *TelemetryConsumer) OnOwnTimeout(timeout *model.TimeoutObject) {
 // In case there is no currently open path, the PathHandler still returns a Step,
 // but such steps are logged as telemetry errors.
 type PathHandler struct {
-	chain flow.ChainID
-	log   zerolog.Logger
+	log zerolog.Logger
 
 	// currentPath holds a Zerolog Context with the information about the current path.
 	// We represent the case where the current path has been closed by nil value.
@@ -215,10 +214,9 @@ type PathHandler struct {
 
 // NewPathHandler instantiate a new PathHandler.
 // The PathHandler has no currently open path
-func NewPathHandler(log zerolog.Logger, chain flow.ChainID) *PathHandler {
+func NewPathHandler(log zerolog.Logger) *PathHandler {
 	return &PathHandler{
-		chain:       chain,
-		log:         log.With().Str("hotstuff", "telemetry").Str("chain", chain.String()).Logger(),
+		log:         log.With().Str("hotstuff", "telemetry").Logger(),
 		currentPath: nil,
 	}
 }

--- a/consensus/hotstuff/pacemaker/pacemaker.go
+++ b/consensus/hotstuff/pacemaker/pacemaker.go
@@ -144,7 +144,7 @@ func (p *ActivePaceMaker) ProcessQC(qc *flow.QuorumCertificate) (*model.NewViewE
 		return nil, err
 	}
 
-	p.notifier.OnQcTriggeredViewChange(qc, newView)
+	p.notifier.OnQcTriggeredViewChange(oldView, newView, qc)
 	p.notifier.OnViewChange(oldView, newView)
 
 	timerInfo := p.timeoutControl.StartTimeout(p.ctx, newView)
@@ -185,7 +185,7 @@ func (p *ActivePaceMaker) ProcessTC(tc *flow.TimeoutCertificate) (*model.NewView
 		return nil, err
 	}
 
-	p.notifier.OnTcTriggeredViewChange(tc, newView)
+	p.notifier.OnTcTriggeredViewChange(oldView, newView, tc)
 	p.notifier.OnViewChange(oldView, newView)
 
 	timerInfo := p.timeoutControl.StartTimeout(p.ctx, newView)

--- a/consensus/hotstuff/pacemaker/pacemaker_test.go
+++ b/consensus/hotstuff/pacemaker/pacemaker_test.go
@@ -99,7 +99,7 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_SkipIncreaseViewThroughQC() {
 	qc := QC(s.livenessData.CurrentView)
 	s.persist.On("PutLivenessData", LivenessData(qc)).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(4)).Return().Once()
-	s.notifier.On("OnQcTriggeredViewChange", qc, uint64(4)).Return().Once()
+	s.notifier.On("OnQcTriggeredViewChange", s.livenessData.CurrentView, uint64(4), qc).Return().Once()
 	s.notifier.On("OnViewChange", s.livenessData.CurrentView, qc.View+1).Once()
 	nve, err := s.paceMaker.ProcessQC(qc)
 	require.NoError(s.T(), err)
@@ -112,7 +112,7 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_SkipIncreaseViewThroughQC() {
 	qc = QC(s.livenessData.CurrentView + 10)
 	s.persist.On("PutLivenessData", LivenessData(qc)).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(qc.View+1)).Return().Once()
-	s.notifier.On("OnQcTriggeredViewChange", qc, qc.View+1).Return().Once()
+	s.notifier.On("OnQcTriggeredViewChange", s.livenessData.CurrentView, qc.View+1, qc).Return().Once()
 	s.notifier.On("OnViewChange", s.livenessData.CurrentView, qc.View+1).Once()
 	nve, err = s.paceMaker.ProcessQC(qc)
 	require.NoError(s.T(), err)
@@ -135,7 +135,7 @@ func (s *ActivePaceMakerTestSuite) TestProcessTC_SkipIncreaseViewThroughTC() {
 	}
 	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(tc.View+1)).Return().Once()
-	s.notifier.On("OnTcTriggeredViewChange", tc, tc.View+1).Return().Once()
+	s.notifier.On("OnTcTriggeredViewChange", s.livenessData.CurrentView, tc.View+1, tc).Return().Once()
 	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
 	nve, err := s.paceMaker.ProcessTC(tc)
 	require.NoError(s.T(), err)
@@ -154,7 +154,7 @@ func (s *ActivePaceMakerTestSuite) TestProcessTC_SkipIncreaseViewThroughTC() {
 	}
 	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(tc.View+1)).Return().Once()
-	s.notifier.On("OnTcTriggeredViewChange", tc, tc.View+1).Return().Once()
+	s.notifier.On("OnTcTriggeredViewChange", s.livenessData.CurrentView, tc.View+1, tc).Return().Once()
 	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
 	nve, err = s.paceMaker.ProcessTC(tc)
 	require.NoError(s.T(), err)
@@ -211,8 +211,8 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_InvalidatesLastViewTC() {
 		helper.WithTCNewestQC(s.livenessData.NewestQC))
 	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Times(2)
 	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Times(2)
-	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything).Return().Once()
-	s.notifier.On("OnQcTriggeredViewChange", mock.Anything, mock.Anything).Return().Once()
+	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
+	s.notifier.On("OnQcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
 	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
 	nve, err := s.paceMaker.ProcessTC(tc)
 	require.NotNil(s.T(), nve)
@@ -242,7 +242,7 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_IgnoreOldQC() {
 func (s *ActivePaceMakerTestSuite) TestProcessQC_UpdateNewestQC() {
 	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Once()
-	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything).Return().Once()
+	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
 	tc := helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView+10),
 		helper.WithTCNewestQC(s.livenessData.NewestQC))
 	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
@@ -269,7 +269,7 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_UpdateNewestQC() {
 func (s *ActivePaceMakerTestSuite) TestProcessTC_UpdateNewestQC() {
 	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Once()
-	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything).Return().Once()
+	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
 	tc := helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView+10),
 		helper.WithTCNewestQC(s.livenessData.NewestQC))
 	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()

--- a/consensus/hotstuff/timeoutaggregator/timeout_aggregator.go
+++ b/consensus/hotstuff/timeoutaggregator/timeout_aggregator.go
@@ -63,7 +63,7 @@ func NewTimeoutAggregator(log zerolog.Logger,
 	}
 
 	aggregator := &TimeoutAggregator{
-		log:                    log.With().Str("component", "timeout_aggregator").Logger(),
+		log:                    log.With().Str("hotstuff", "timeout_aggregator").Logger(),
 		hotstuffMetrics:        hotstuffMetrics,
 		engineMetrics:          engineMetrics,
 		notifier:               notifier,

--- a/consensus/hotstuff/timeoutaggregator/timeout_aggregator.go
+++ b/consensus/hotstuff/timeoutaggregator/timeout_aggregator.go
@@ -63,7 +63,7 @@ func NewTimeoutAggregator(log zerolog.Logger,
 	}
 
 	aggregator := &TimeoutAggregator{
-		log:                    log.With().Str("hotstuff", "timeout_aggregator").Logger(),
+		log:                    log.With().Str("component", "hotstuff.timeout_aggregator").Logger(),
 		hotstuffMetrics:        hotstuffMetrics,
 		engineMetrics:          engineMetrics,
 		notifier:               notifier,

--- a/consensus/hotstuff/timeoutcollector/factory.go
+++ b/consensus/hotstuff/timeoutcollector/factory.go
@@ -2,6 +2,7 @@ package timeoutcollector
 
 import (
 	"fmt"
+
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/consensus/hotstuff"

--- a/consensus/hotstuff/timeoutcollector/timeout_collector.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector.go
@@ -74,7 +74,6 @@ func (c *TimeoutCollector) AddTimeout(timeout *model.TimeoutObject) error {
 	if err != nil {
 		return fmt.Errorf("internal error processing TO %v for view: %d: %w", timeout.ID(), timeout.View, err)
 	}
-	c.notifier.OnTimeoutProcessed(timeout)
 	return nil
 }
 
@@ -92,6 +91,8 @@ func (c *TimeoutCollector) processTimeout(timeout *model.TimeoutObject) error {
 		}
 		return fmt.Errorf("internal error while processing timeout: %w", err)
 	}
+
+	c.notifier.OnTimeoutProcessed(timeout)
 
 	// In the following, we emit notifications about new QCs, if their view is newer than any QC previously
 	// known to the TimeoutCollector. Note that our implementation only provides weak ordering:

--- a/consensus/hotstuff/timeoutcollector/timeout_collector.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector.go
@@ -74,6 +74,7 @@ func (c *TimeoutCollector) AddTimeout(timeout *model.TimeoutObject) error {
 	if err != nil {
 		return fmt.Errorf("internal error processing TO %v for view: %d: %w", timeout.ID(), timeout.View, err)
 	}
+	c.notifier.OnTimeoutProcessed(timeout)
 	return nil
 }
 

--- a/consensus/hotstuff/timeoutcollector/timeout_collector.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector.go
@@ -84,9 +84,8 @@ func (c *TimeoutCollector) AddTimeout(timeout *model.TimeoutObject) error {
 func (c *TimeoutCollector) processTimeout(timeout *model.TimeoutObject) error {
 	err := c.processor.Process(timeout)
 	if err != nil {
-		if model.IsInvalidTimeoutError(err) {
-			c.log.Err(err).Msgf("invalid timeout detected")
-			c.notifier.OnInvalidTimeoutDetected(timeout)
+		if invalidTimeoutErr, ok := model.AsInvalidTimeoutError(err); ok {
+			c.notifier.OnInvalidTimeoutDetected(*invalidTimeoutErr)
 			return nil
 		}
 		return fmt.Errorf("internal error while processing timeout: %w", err)

--- a/consensus/hotstuff/timeoutcollector/timeout_collector.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector.go
@@ -3,6 +3,7 @@ package timeoutcollector
 import (
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
@@ -14,6 +15,7 @@ import (
 // their view is newer than any QC or TC previously known to the TimeoutCollector.
 // This module is safe to use in concurrent environment.
 type TimeoutCollector struct {
+	log               zerolog.Logger
 	notifier          hotstuff.Consumer
 	timeoutsCache     *TimeoutObjectsCache // cache for tracking double timeout and timeout equivocation
 	collectorNotifier hotstuff.TimeoutCollectorConsumer
@@ -25,12 +27,17 @@ type TimeoutCollector struct {
 var _ hotstuff.TimeoutCollector = (*TimeoutCollector)(nil)
 
 // NewTimeoutCollector creates new instance of TimeoutCollector
-func NewTimeoutCollector(view uint64,
+func NewTimeoutCollector(log zerolog.Logger,
+	view uint64,
 	notifier hotstuff.Consumer,
 	collectorNotifier hotstuff.TimeoutCollectorConsumer,
 	processor hotstuff.TimeoutProcessor,
 ) *TimeoutCollector {
 	return &TimeoutCollector{
+		log: log.With().
+			Str("hotstuff", "timeout_collector").
+			Uint64("view", view).
+			Logger(),
 		notifier:          notifier,
 		timeoutsCache:     NewTimeoutObjectsCache(view),
 		processor:         processor,
@@ -77,6 +84,7 @@ func (c *TimeoutCollector) processTimeout(timeout *model.TimeoutObject) error {
 	err := c.processor.Process(timeout)
 	if err != nil {
 		if model.IsInvalidTimeoutError(err) {
+			c.log.Err(err).Msgf("invalid timeout detected")
 			c.notifier.OnInvalidTimeoutDetected(timeout)
 			return nil
 		}

--- a/consensus/hotstuff/timeoutcollector/timeout_collector.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector.go
@@ -36,7 +36,7 @@ func NewTimeoutCollector(log zerolog.Logger,
 ) *TimeoutCollector {
 	return &TimeoutCollector{
 		log: log.With().
-			Str("hotstuff", "timeout_collector").
+			Str("component", "hotstuff.timeout_collector").
 			Uint64("view", view).
 			Logger(),
 		notifier:          notifier,

--- a/consensus/hotstuff/timeoutcollector/timeout_collector.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector.go
@@ -3,6 +3,7 @@ package timeoutcollector
 import (
 	"errors"
 	"fmt"
+
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/consensus/hotstuff"

--- a/consensus/hotstuff/timeoutcollector/timeout_collector_test.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector_test.go
@@ -43,7 +43,7 @@ func (s *TimeoutCollectorTestSuite) SetupTest() {
 	s.collectorNotifier.On("OnNewQcDiscovered", mock.Anything).Maybe()
 	s.collectorNotifier.On("OnNewTcDiscovered", mock.Anything).Maybe()
 
-	s.collector = NewTimeoutCollector(s.view, s.notifier, s.collectorNotifier, s.processor)
+	s.collector = NewTimeoutCollector(unittest.Logger(), s.view, s.notifier, s.collectorNotifier, s.processor)
 }
 
 // TestView tests that `View` returns the same value that was passed in constructor

--- a/consensus/hotstuff/timeoutcollector/timeout_collector_test.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector_test.go
@@ -119,7 +119,6 @@ func (s *TimeoutCollectorTestSuite) TestAddTimeout_InvalidTimeout() {
 	s.Run("invalid-timeout", func() {
 		timeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectView(s.view))
 		s.processor.On("Process", timeout).Return(model.NewInvalidTimeoutErrorf(timeout, "")).Once()
-		s.notifier.On("OnTimeoutProcessed", timeout).Once()
 		s.notifier.On("OnInvalidTimeoutDetected", timeout).Once()
 		err := s.collector.AddTimeout(timeout)
 		require.NoError(s.T(), err)

--- a/consensus/hotstuff/timeoutcollector/timeout_collector_test.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_collector_test.go
@@ -60,6 +60,7 @@ func (s *TimeoutCollectorTestSuite) TestAddTimeout_HappyPath() {
 		go func() {
 			defer wg.Done()
 			timeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectView(s.view))
+			s.notifier.On("OnTimeoutProcessed", timeout).Once()
 			s.processor.On("Process", timeout).Return(nil).Once()
 			err := s.collector.AddTimeout(timeout)
 			require.NoError(s.T(), err)
@@ -74,6 +75,7 @@ func (s *TimeoutCollectorTestSuite) TestAddTimeout_HappyPath() {
 // double timeout to notifier which can be slashed later.
 func (s *TimeoutCollectorTestSuite) TestAddTimeout_DoubleTimeout() {
 	timeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectView(s.view))
+	s.notifier.On("OnTimeoutProcessed", timeout).Once()
 	s.processor.On("Process", timeout).Return(nil).Once()
 	err := s.collector.AddTimeout(timeout)
 	require.NoError(s.T(), err)
@@ -92,6 +94,7 @@ func (s *TimeoutCollectorTestSuite) TestAddTimeout_DoubleTimeout() {
 // TestAddTimeout_RepeatedTimeout checks that repeated timeouts are silently dropped without any errors.
 func (s *TimeoutCollectorTestSuite) TestAddTimeout_RepeatedTimeout() {
 	timeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectView(s.view))
+	s.notifier.On("OnTimeoutProcessed", timeout).Once()
 	s.processor.On("Process", timeout).Return(nil).Once()
 	err := s.collector.AddTimeout(timeout)
 	require.NoError(s.T(), err)
@@ -116,6 +119,7 @@ func (s *TimeoutCollectorTestSuite) TestAddTimeout_InvalidTimeout() {
 	s.Run("invalid-timeout", func() {
 		timeout := helper.TimeoutObjectFixture(helper.WithTimeoutObjectView(s.view))
 		s.processor.On("Process", timeout).Return(model.NewInvalidTimeoutErrorf(timeout, "")).Once()
+		s.notifier.On("OnTimeoutProcessed", timeout).Once()
 		s.notifier.On("OnInvalidTimeoutDetected", timeout).Once()
 		err := s.collector.AddTimeout(timeout)
 		require.NoError(s.T(), err)
@@ -161,6 +165,7 @@ func (s *TimeoutCollectorTestSuite) TestAddTimeout_TONotifications() {
 			timeout.LastViewTC = lastViewTC
 		})
 		timeouts = append(timeouts, timeout)
+		s.notifier.On("OnTimeoutProcessed", timeout).Once()
 		s.processor.On("Process", timeout).Return(nil).Once()
 	}
 

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -3,8 +3,8 @@ package timeoutcollector
 import (
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog"
 
+	"github.com/rs/zerolog"
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
 

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -77,7 +77,7 @@ func NewTimeoutProcessor(log zerolog.Logger,
 	}
 	return &TimeoutProcessor{
 		log: log.With().
-			Str("hotstuff", "timeout_processor").
+			Str("component", "hotstuff.timeout_processor").
 			Uint64("view", view).
 			Logger(),
 		view:      view,
@@ -146,7 +146,6 @@ func (p *TimeoutProcessor) Process(timeout *model.TimeoutObject) error {
 		// It does _not necessarily_ imply that the timeout is invalid or the sender is equivocating.
 		return fmt.Errorf("adding signature to aggregator failed: %w", err)
 	}
-
 	p.log.Debug().Msgf("processed timeout, total weight=(%d), required=(%d)", totalWeight, p.tcTracker.minRequiredWeight)
 
 	if p.partialTCTracker.Track(totalWeight) {

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -3,6 +3,7 @@ package timeoutcollector
 import (
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog"
 
 	"go.uber.org/atomic"
 	"golang.org/x/exp/slices"
@@ -41,6 +42,7 @@ func (t *accumulatedWeightTracker) Track(weight uint64) bool {
 // TimeoutProcessor will create a timeout certificate which can be used to advance round.
 // Concurrency safe.
 type TimeoutProcessor struct {
+	log              zerolog.Logger
 	view             uint64
 	validator        hotstuff.Validator
 	committee        hotstuff.Replicas
@@ -58,7 +60,8 @@ var _ hotstuff.TimeoutProcessor = (*TimeoutProcessor)(nil)
 //   - model.ErrViewForUnknownEpoch if no epoch containing the given view is known
 //
 // All other errors should be treated as exceptions.
-func NewTimeoutProcessor(committee hotstuff.Replicas,
+func NewTimeoutProcessor(log zerolog.Logger,
+	committee hotstuff.Replicas,
 	validator hotstuff.Validator,
 	sigAggregator hotstuff.TimeoutSignatureAggregator,
 	notifier hotstuff.TimeoutCollectorConsumer,
@@ -73,6 +76,10 @@ func NewTimeoutProcessor(committee hotstuff.Replicas,
 		return nil, fmt.Errorf("could not retrieve timeout weight threshold for view %d: %w", view, err)
 	}
 	return &TimeoutProcessor{
+		log: log.With().
+			Str("hotstuff", "timeout_processor").
+			Uint64("view", view).
+			Logger(),
 		view:      view,
 		committee: committee,
 		validator: validator,
@@ -139,6 +146,8 @@ func (p *TimeoutProcessor) Process(timeout *model.TimeoutObject) error {
 		// It does _not necessarily_ imply that the timeout is invalid or the sender is equivocating.
 		return fmt.Errorf("adding signature to aggregator failed: %w", err)
 	}
+
+	p.log.Debug().Msgf("processed timeout, total weight=(%d), required=(%d)", totalWeight, p.tcTracker.minRequiredWeight)
 
 	if p.partialTCTracker.Track(totalWeight) {
 		p.notifier.OnPartialTcCreated(p.view, p.newestQCTracker.NewestQC(), timeout.LastViewTC)

--- a/consensus/hotstuff/timeoutcollector/timeout_processor_test.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor_test.go
@@ -75,7 +75,9 @@ func (s *TimeoutProcessorTestSuite) SetupTest() {
 		return s.totalWeight.Load()
 	}).Maybe()
 
-	s.processor, err = NewTimeoutProcessor(s.committee,
+	s.processor, err = NewTimeoutProcessor(
+		unittest.Logger(),
+		s.committee,
 		s.validator,
 		s.sigAggregator,
 		s.notifier,
@@ -527,7 +529,7 @@ func TestTimeoutProcessor_BuildVerifyTC(t *testing.T) {
 	notifier := mocks.NewTimeoutCollectorConsumer(t)
 	notifier.On("OnPartialTcCreated", view, olderQC, (*flow.TimeoutCertificate)(nil)).Return().Once()
 	notifier.On("OnTcConstructedFromTimeouts", mock.Anything).Run(onTCCreated).Return().Once()
-	processor, err := NewTimeoutProcessor(committee, validator, aggregator, notifier)
+	processor, err := NewTimeoutProcessor(unittest.Logger(), committee, validator, aggregator, notifier)
 	require.NoError(t, err)
 
 	// last view was successful, no lastViewTC in this case
@@ -548,7 +550,7 @@ func TestTimeoutProcessor_BuildVerifyTC(t *testing.T) {
 	notifier = mocks.NewTimeoutCollectorConsumer(t)
 	notifier.On("OnPartialTcCreated", view+1, newestQC, (*flow.TimeoutCertificate)(nil)).Return().Once()
 	notifier.On("OnTcConstructedFromTimeouts", mock.Anything).Run(onTCCreated).Return().Once()
-	processor, err = NewTimeoutProcessor(committee, validator, aggregator, notifier)
+	processor, err = NewTimeoutProcessor(unittest.Logger(), committee, validator, aggregator, notifier)
 	require.NoError(t, err)
 
 	// part of committee will use QC, another part TC, this will result in aggregated signature consisting

--- a/consensus/hotstuff/validator/validator.go
+++ b/consensus/hotstuff/validator/validator.go
@@ -348,8 +348,7 @@ func newInvalidTCError(tc *flow.TimeoutCertificate, err error) error {
 
 func newInvalidVoteError(vote *model.Vote, err error) error {
 	return model.InvalidVoteError{
-		VoteID: vote.ID(),
-		View:   vote.View,
-		Err:    err,
+		Vote: vote,
+		Err:  err,
 	}
 }

--- a/consensus/hotstuff/voteaggregator/vote_aggregator.go
+++ b/consensus/hotstuff/voteaggregator/vote_aggregator.go
@@ -75,7 +75,7 @@ func NewVoteAggregator(
 	}
 
 	aggregator := &VoteAggregator{
-		log:                        log,
+		log:                        log.With().Str("hotstuff", "vote_aggregator").Logger(),
 		hotstuffMetrics:            hotstuffMetrics,
 		engineMetrics:              engineMetrics,
 		notifier:                   notifier,

--- a/consensus/hotstuff/voteaggregator/vote_aggregator.go
+++ b/consensus/hotstuff/voteaggregator/vote_aggregator.go
@@ -75,7 +75,7 @@ func NewVoteAggregator(
 	}
 
 	aggregator := &VoteAggregator{
-		log:                        log.With().Str("hotstuff", "vote_aggregator").Logger(),
+		log:                        log.With().Str("component", "hotstuff.vote_aggregator").Logger(),
 		hotstuffMetrics:            hotstuffMetrics,
 		engineMetrics:              engineMetrics,
 		notifier:                   notifier,

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
@@ -233,11 +233,10 @@ func (p *CombinedVoteProcessorV2) Process(vote *model.Vote) error {
 		}
 	}
 
+	// checking of conditions for building QC are satisfied
 	totalWeight := p.stakingSigAggtor.TotalWeight()
 	p.log.Debug().Msgf("processed vote, total weight=(%d), required=(%d)", totalWeight, p.minRequiredWeight)
-
-	// checking of conditions for building QC are satisfied
-	if p.stakingSigAggtor.TotalWeight() < p.minRequiredWeight {
+	if totalWeight < p.minRequiredWeight {
 		return nil
 	}
 	if !p.rbRector.EnoughShares() {

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
@@ -233,6 +233,9 @@ func (p *CombinedVoteProcessorV2) Process(vote *model.Vote) error {
 		}
 	}
 
+	totalWeight := p.stakingSigAggtor.TotalWeight()
+	p.log.Debug().Msgf("processed vote, total weight=(%d), required=(%d)", totalWeight, p.minRequiredWeight)
+
 	// checking of conditions for building QC are satisfied
 	if p.stakingSigAggtor.TotalWeight() < p.minRequiredWeight {
 		return nil
@@ -258,7 +261,7 @@ func (p *CombinedVoteProcessorV2) Process(vote *model.Vote) error {
 	p.log.Info().
 		Uint64("view", qc.View).
 		Hex("signers", qc.SignerIndices).
-		Msg("new qc has been created")
+		Msg("new QC has been created")
 
 	p.onQCCreated(qc)
 

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
@@ -258,7 +258,7 @@ func (p *CombinedVoteProcessorV3) Process(vote *model.Vote) error {
 	p.log.Info().
 		Uint64("view", qc.View).
 		Hex("signers", qc.SignerIndices).
-		Msg("new qc has been created")
+		Msg("new QC has been created")
 
 	p.onQCCreated(qc)
 

--- a/consensus/hotstuff/votecollector/staking_vote_processor.go
+++ b/consensus/hotstuff/votecollector/staking_vote_processor.go
@@ -160,7 +160,6 @@ func (p *StakingVoteProcessor) Process(vote *model.Vote) error {
 		Uint64("view", qc.View).
 		Hex("signers", qc.SignerIndices).
 		Msg("new QC has been created")
-
 	p.onQCCreated(qc)
 
 	return nil

--- a/consensus/hotstuff/votecollector/staking_vote_processor.go
+++ b/consensus/hotstuff/votecollector/staking_vote_processor.go
@@ -60,7 +60,7 @@ func (f *stakingVoteProcessorFactoryBase) Create(log zerolog.Logger, block *mode
 	}
 
 	return &StakingVoteProcessor{
-		log:               log,
+		log:               log.With().Hex("block_id", block.BlockID[:]).Logger(),
 		block:             block,
 		stakingSigAggtor:  stakingSigAggtor,
 		onQCCreated:       f.onQCCreated,
@@ -139,6 +139,8 @@ func (p *StakingVoteProcessor) Process(vote *model.Vote) error {
 		return fmt.Errorf("unexpected exception adding signature from vote %x to staking aggregator: %w", vote.ID(), err)
 	}
 
+	p.log.Debug().Msgf("processed vote, total weight=(%d), required=(%d)", totalWeight, p.minRequiredWeight)
+
 	// checking of conditions for building QC are satisfied
 	if totalWeight < p.minRequiredWeight {
 		return nil
@@ -153,6 +155,12 @@ func (p *StakingVoteProcessor) Process(vote *model.Vote) error {
 	if err != nil {
 		return fmt.Errorf("internal error constructing QC from votes: %w", err)
 	}
+
+	p.log.Info().
+		Uint64("view", qc.View).
+		Hex("signers", qc.SignerIndices).
+		Msg("new QC has been created")
+
 	p.onQCCreated(qc)
 
 	return nil

--- a/consensus/hotstuff/votecollector/statemachine.go
+++ b/consensus/hotstuff/votecollector/statemachine.go
@@ -120,6 +120,7 @@ func (m *VoteCollector) AddVote(vote *model.Vote) error {
 		return fmt.Errorf("internal error processing vote %v for block %v: %w",
 			vote.ID(), vote.BlockID, err)
 	}
+	m.notifier.OnVoteProcessed(vote)
 	return nil
 }
 

--- a/consensus/hotstuff/votecollector/statemachine.go
+++ b/consensus/hotstuff/votecollector/statemachine.go
@@ -120,7 +120,6 @@ func (m *VoteCollector) AddVote(vote *model.Vote) error {
 		return fmt.Errorf("internal error processing vote %v for block %v: %w",
 			vote.ID(), vote.BlockID, err)
 	}
-	m.notifier.OnVoteProcessed(vote)
 	return nil
 }
 
@@ -149,6 +148,7 @@ func (m *VoteCollector) processVote(vote *model.Vote) error {
 			continue
 		}
 
+		m.notifier.OnVoteProcessed(vote)
 		return nil
 	}
 }

--- a/consensus/hotstuff/votecollector/statemachine.go
+++ b/consensus/hotstuff/votecollector/statemachine.go
@@ -130,8 +130,8 @@ func (m *VoteCollector) processVote(vote *model.Vote) error {
 		currentState := processor.Status()
 		err := processor.Process(vote)
 		if err != nil {
-			if model.IsInvalidVoteError(err) {
-				m.notifier.OnInvalidVoteDetected(vote)
+			if invalidVoteErr, ok := model.AsInvalidVoteError(err); ok {
+				m.notifier.OnInvalidVoteDetected(*invalidVoteErr)
 				return nil
 			}
 			// ATTENTION: due to how our logic is designed this situation is only possible

--- a/consensus/hotstuff/votecollector/statemachine.go
+++ b/consensus/hotstuff/votecollector/statemachine.go
@@ -63,7 +63,7 @@ func NewStateMachine(
 	verifyingVoteProcessorFactory VerifyingVoteProcessorFactory,
 ) *VoteCollector {
 	log = log.With().
-		Str("hotstuff", "vote_collector").
+		Str("component", "hotstuff.vote_collector").
 		Uint64("view", view).
 		Logger()
 	sm := &VoteCollector{

--- a/consensus/hotstuff/votecollector/statemachine_test.go
+++ b/consensus/hotstuff/votecollector/statemachine_test.go
@@ -209,8 +209,9 @@ func (s *StateMachineTestSuite) TestProcessBlock_ProcessingOfCachedVotes() {
 	processor := s.prepareMockedProcessor(proposal)
 	for i := 0; i < votes; i++ {
 		vote := unittest.VoteForBlockFixture(block)
-		// eventually it has to be process by processor
-		s.notifier.On("OnVoteProcessed", vote).Once()
+		// once when caching vote, and once when processing cached vote
+		s.notifier.On("OnVoteProcessed", vote).Twice()
+		// eventually it has to be processed by processor
 		processor.On("Process", vote).Return(nil).Once()
 		require.NoError(s.T(), s.collector.AddVote(vote))
 	}

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -514,8 +514,19 @@ func createNode(
 	timeoutCollectorDistributor := pubsub.NewTimeoutCollectorDistributor()
 	timeoutCollectorDistributor.AddConsumer(logConsumer)
 
-	timeoutProcessorFactory := timeoutcollector.NewTimeoutProcessorFactory(timeoutCollectorDistributor, committee, validator, msig.ConsensusTimeoutTag)
-	timeoutCollectorsFactory := timeoutcollector.NewTimeoutCollectorFactory(notifier, timeoutCollectorDistributor, timeoutProcessorFactory)
+	timeoutProcessorFactory := timeoutcollector.NewTimeoutProcessorFactory(
+		log,
+		timeoutCollectorDistributor,
+		committee,
+		validator,
+		msig.ConsensusTimeoutTag,
+	)
+	timeoutCollectorsFactory := timeoutcollector.NewTimeoutCollectorFactory(
+		log,
+		notifier,
+		timeoutCollectorDistributor,
+		timeoutProcessorFactory,
+	)
 	timeoutCollectors := timeoutaggregator.NewTimeoutCollectors(log, livenessData.CurrentView, timeoutCollectorsFactory)
 
 	timeoutAggregator, err := timeoutaggregator.NewTimeoutAggregator(

--- a/engine/collection/epochmgr/factories/epoch.go
+++ b/engine/collection/epochmgr/factories/epoch.go
@@ -141,6 +141,7 @@ func (factory *EpochComponentsFactory) Create(
 	validator := hotstuffModules.Validator
 
 	hotstuff, err = factory.hotstuff.Create(
+		cluster,
 		state,
 		metrics,
 		builder,

--- a/engine/collection/epochmgr/factories/hotstuff.go
+++ b/engine/collection/epochmgr/factories/hotstuff.go
@@ -72,10 +72,8 @@ func (f *HotStuffFactory) CreateModules(
 	payloads storage.ClusterPayloads,
 	updater module.Finalizer,
 ) (*consensus.HotstuffModules, module.HotstuffMetrics, error) {
-
-	log := f.createLogger(cluster)
-
 	// setup metrics/logging with the new chain ID
+	log := f.createLogger(cluster)
 	metrics := f.createMetrics(cluster.ChainID())
 	notifier := pubsub.NewDistributor()
 	finalizationDistributor := pubsub.NewFinalizationDistributor()

--- a/module/metrics/hotstuff/consumer.go
+++ b/module/metrics/hotstuff/consumer.go
@@ -25,13 +25,13 @@ func NewMetricsConsumer(metrics module.HotstuffMetrics) *MetricsConsumer {
 	}
 }
 
-func (c *MetricsConsumer) OnQcTriggeredViewChange(qc *flow.QuorumCertificate, newView uint64) {
+func (c *MetricsConsumer) OnQcTriggeredViewChange(_ uint64, newView uint64, qc *flow.QuorumCertificate) {
 	c.metrics.SetCurView(newView)
 	c.metrics.SetQCView(qc.View)
 	c.metrics.CountSkipped()
 }
 
-func (c *MetricsConsumer) OnTcTriggeredViewChange(tc *flow.TimeoutCertificate, newView uint64) {
+func (c *MetricsConsumer) OnTcTriggeredViewChange(_ uint64, newView uint64, tc *flow.TimeoutCertificate) {
 	c.metrics.SetCurView(newView)
 	c.metrics.SetTCView(tc.View)
 	c.metrics.CountTimeout()


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/3728

### Context

This PR enriches telemetry events for timeout and vote aggregation to report each processed vote and timeout. Additionally it adds new logs for vote and timeout aggregation for easier debugging of possible issues.

### What was done
- Extended `hotstuff.Consumer` to report new events
- Updated all objects implementing `hotstuff.Consumer`
- Implemented telemetry events without notion of current path when compared to `EventHandler` telemetry
- Added extra logs for vote/timeout aggregation