### PR TITLE
Set transaction procedure's trace span via context

### DIFF
--- a/cmd/util/ledger/reporters/account_reporter.go
+++ b/cmd/util/ledger/reporters/account_reporter.go
@@ -150,6 +150,7 @@ func NewBalanceReporter(chain flow.Chain, view state.View) *balanceProcessor {
 
 	env := environment.NewScriptEnvironment(
 		context.Background(),
+		ctx.TracerSpan,
 		ctx.EnvironmentParams,
 		txnState,
 		derivedTxnData)

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -448,8 +448,11 @@ func (e *blockComputer) executeTransaction(
 	logger.Info().Msg("executing transaction in fvm")
 
 	proc := fvm.Transaction(txn.TransactionBody, txn.txIndex)
+
 	if isSampled {
-		proc.SetTraceSpan(txInternalSpan)
+		txn.ctx = fvm.NewContextFromParent(
+			txn.ctx,
+			fvm.WithSpan(txInternalSpan))
 	}
 
 	txView := collectionView.NewChild()

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -848,6 +848,7 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 
 	env := environment.NewScriptEnvironment(
 		context.Background(),
+		ctx.TracerSpan,
 		ctx.EnvironmentParams,
 		txnState,
 		derivedTxnData)

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/rs/zerolog"
+	otelTrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/environment"
@@ -178,14 +179,6 @@ func WithServiceEventCollectionEnabled() Option {
 	}
 }
 
-// WithExtensiveTracing sets the extensive tracing
-func WithExtensiveTracing() Option {
-	return func(ctx Context) Context {
-		ctx.ExtensiveTracing = true
-		return ctx
-	}
-}
-
 // WithBlocks sets the block storage provider for a virtual machine context.
 //
 // The VM uses the block storage provider to provide historical block information to
@@ -213,6 +206,22 @@ func WithMetricsReporter(mr environment.MetricsReporter) Option {
 func WithTracer(tr module.Tracer) Option {
 	return func(ctx Context) Context {
 		ctx.Tracer = tr
+		return ctx
+	}
+}
+
+// WithSpan sets the trace span for a virtual machine context.
+func WithSpan(span otelTrace.Span) Option {
+	return func(ctx Context) Context {
+		ctx.Span = span
+		return ctx
+	}
+}
+
+// WithExtensiveTracing sets the extensive tracing
+func WithExtensiveTracing() Option {
+	return func(ctx Context) Context {
+		ctx.ExtensiveTracing = true
 		return ctx
 	}
 }

--- a/fvm/environment/facade_env.go
+++ b/fvm/environment/facade_env.go
@@ -143,12 +143,13 @@ func newFacadeEnvironment(
 
 func NewScriptEnvironment(
 	ctx context.Context,
+	tracer tracing.TracerSpan,
 	params EnvironmentParams,
 	txnState *state.TransactionState,
 	derivedTxnData DerivedTransactionData,
 ) *facadeEnvironment {
 	env := newFacadeEnvironment(
-		tracing.NewTracerSpan(),
+		tracer,
 		params,
 		txnState,
 		derivedTxnData,

--- a/fvm/environment/value_store.go
+++ b/fvm/environment/value_store.go
@@ -121,11 +121,9 @@ func (store *valueStore) GetValue(
 	[]byte,
 	error,
 ) {
-	key := string(keyBytes)
+	defer store.tracer.StartChildSpan(trace.FVMEnvGetValue).End()
 
-	var valueByteSize int
-	span := store.tracer.StartChildSpan(trace.FVMEnvGetValue)
-	defer span.End()
+	key := string(keyBytes)
 
 	address := flow.BytesToAddress(owner)
 	if state.IsFVMStateKey(string(owner), key) {
@@ -136,11 +134,8 @@ func (store *valueStore) GetValue(
 	if err != nil {
 		return nil, fmt.Errorf("get value failed: %w", err)
 	}
-	valueByteSize = len(v)
 
-	err = store.meter.MeterComputation(
-		ComputationKindGetValue,
-		uint(valueByteSize))
+	err = store.meter.MeterComputation(ComputationKindGetValue, uint(len(v)))
 	if err != nil {
 		return nil, fmt.Errorf("get value failed: %w", err)
 	}
@@ -153,10 +148,9 @@ func (store *valueStore) SetValue(
 	keyBytes []byte,
 	value []byte,
 ) error {
-	key := string(keyBytes)
+	defer store.tracer.StartChildSpan(trace.FVMEnvSetValue).End()
 
-	span := store.tracer.StartChildSpan(trace.FVMEnvSetValue)
-	defer span.End()
+	key := string(keyBytes)
 
 	address := flow.BytesToAddress(owner)
 	if state.IsFVMStateKey(string(owner), key) {

--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -131,6 +131,7 @@ func (computer MeterParamOverridesComputer) getMeterParamOverrides(
 
 	env := environment.NewScriptEnvironment(
 		context.Background(),
+		computer.ctx.TracerSpan,
 		computer.ctx.EnvironmentParams,
 		txnState,
 		computer.derivedTxnData)

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -168,6 +168,7 @@ func (vm *VirtualMachine) GetAccount(
 
 	env := environment.NewScriptEnvironment(
 		context.Background(),
+		ctx.TracerSpan,
 		ctx.EnvironmentParams,
 		txnState,
 		derviedTxnData)

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -139,6 +139,7 @@ func newScriptExecutor(
 		derivedTxnData: derivedTxnData,
 		env: environment.NewScriptEnvironment(
 			proc.RequestContext,
+			ctx.TracerSpan,
 			ctx.EnvironmentParams,
 			txnState,
 			derivedTxnData),

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -1,15 +1,11 @@
 package fvm
 
 import (
-	otelTrace "go.opentelemetry.io/otel/trace"
-
 	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/module"
-	"github.com/onflow/flow-go/module/trace"
 )
 
 // TODO(patrick): pass in initial snapshot time when we start supporting
@@ -37,24 +33,6 @@ type TransactionProcedure struct {
 	ComputationIntensities meter.MeteredComputationIntensities
 	MemoryEstimate         uint64
 	Err                    errors.CodedError
-	TraceSpan              otelTrace.Span
-}
-
-func (proc *TransactionProcedure) SetTraceSpan(traceSpan otelTrace.Span) {
-	proc.TraceSpan = traceSpan
-}
-
-func (proc *TransactionProcedure) IsSampled() bool {
-	return proc.TraceSpan != nil
-}
-
-func (proc *TransactionProcedure) StartSpanFromProcTraceSpan(
-	tracer module.Tracer,
-	spanName trace.SpanName) otelTrace.Span {
-	if tracer != nil && proc.IsSampled() {
-		return tracer.StartSpanFromParent(proc.TraceSpan, spanName)
-	}
-	return trace.NoopSpan
 }
 
 func (proc *TransactionProcedure) NewExecutor(

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -81,18 +81,15 @@ func newTransactionExecutor(
 	txnState *state.TransactionState,
 	derivedTxnData *derived.DerivedTransactionData,
 ) *transactionExecutor {
-	span := proc.StartSpanFromProcTraceSpan(
-		ctx.Tracer,
-		trace.FVMExecuteTransaction)
+	span := ctx.StartChildSpan(trace.FVMExecuteTransaction)
 	span.SetAttributes(attribute.String("transaction_id", proc.ID.String()))
 
-	ctx.Span = span
 	ctx.TxIndex = proc.TxIndex
 	ctx.TxId = proc.Transaction.ID()
 	ctx.TxBody = proc.Transaction
 
 	env := environment.NewTransactionEnvironment(
-		ctx.TracerSpan,
+		span,
 		ctx.EnvironmentParams,
 		txnState,
 		derivedTxnData)
@@ -214,7 +211,7 @@ func (executor *transactionExecutor) PreprocessTransactionBody() error {
 func (executor *transactionExecutor) execute() error {
 	if executor.AuthorizationChecksEnabled {
 		err := executor.CheckAuthorization(
-			executor.ctx.Tracer,
+			executor.ctx.TracerSpan,
 			executor.proc,
 			executor.txnState,
 			executor.AccountKeyWeightThreshold)
@@ -227,7 +224,7 @@ func (executor *transactionExecutor) execute() error {
 
 	if executor.SequenceNumberCheckAndIncrementEnabled {
 		err := executor.CheckAndIncrementSequenceNumber(
-			executor.ctx.Tracer,
+			executor.ctx.TracerSpan,
 			executor.proc,
 			executor.txnState)
 		if err != nil {

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -6,15 +6,15 @@ import (
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/tracing"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/trace"
 )
 
 type TransactionSequenceNumberChecker struct{}
 
 func (c TransactionSequenceNumberChecker) CheckAndIncrementSequenceNumber(
-	tracer module.Tracer,
+	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
 ) error {
@@ -32,14 +32,12 @@ func (c TransactionSequenceNumberChecker) CheckAndIncrementSequenceNumber(
 }
 
 func (c TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
-	tracer module.Tracer,
+	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
 ) error {
 
-	defer proc.StartSpanFromProcTraceSpan(
-		tracer,
-		trace.FVMSeqNumCheckTransaction).End()
+	defer tracer.StartChildSpan(trace.FVMSeqNumCheckTransaction).End()
 
 	nestedTxnId, err := txnState.BeginNestedTransaction()
 	if err != nil {

--- a/fvm/transactionSequenceNum_test.go
+++ b/fvm/transactionSequenceNum_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/tracing"
 	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -32,7 +33,10 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		seqChecker := fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.CheckAndIncrementSequenceNumber(nil, proc, txnState)
+		err = seqChecker.CheckAndIncrementSequenceNumber(
+			tracing.NewTracerSpan(),
+			proc,
+			txnState)
 		require.NoError(t, err)
 
 		// get fetch the sequence number and it should be updated
@@ -58,7 +62,10 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		seqChecker := fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.CheckAndIncrementSequenceNumber(nil, proc, txnState)
+		err = seqChecker.CheckAndIncrementSequenceNumber(
+			tracing.NewTracerSpan(),
+			proc,
+			txnState)
 		require.Error(t, err)
 		require.True(t, errors.HasErrorCode(err, errors.ErrCodeInvalidProposalSeqNumberError))
 
@@ -85,7 +92,10 @@ func TestTransactionSequenceNumProcess(t *testing.T) {
 		proc := fvm.Transaction(&tx, 0)
 
 		seqChecker := &fvm.TransactionSequenceNumberChecker{}
-		err = seqChecker.CheckAndIncrementSequenceNumber(nil, proc, txnState)
+		err = seqChecker.CheckAndIncrementSequenceNumber(
+			tracing.NewTracerSpan(),
+			proc,
+			txnState)
 		require.Error(t, err)
 
 		// get fetch the sequence number and check it to be unchanged

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -11,8 +11,8 @@ import (
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/tracing"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/trace"
 )
 
@@ -145,7 +145,7 @@ type TransactionVerifier struct {
 }
 
 func (v *TransactionVerifier) CheckAuthorization(
-	tracer module.Tracer,
+	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
 	keyWeightThreshold int,
@@ -163,12 +163,12 @@ func (v *TransactionVerifier) CheckAuthorization(
 }
 
 func (v *TransactionVerifier) verifyTransaction(
-	tracer module.Tracer,
+	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
 	txnState *state.TransactionState,
 	keyWeightThreshold int,
 ) error {
-	span := proc.StartSpanFromProcTraceSpan(tracer, trace.FVMVerifyTransaction)
+	span := tracer.StartChildSpan(trace.FVMVerifyTransaction)
 	span.SetAttributes(
 		attribute.String("transaction.ID", proc.ID.String()),
 	)


### PR DESCRIPTION
Transaction procedure's span was set using a snowflake api.  This change makes span setup consistent with the rest.

This also plumb trace span correctly through script environment.