### PR TITLE
[Network] Fix inbound message metrics label

### DIFF
--- a/network/message_scope.go
+++ b/network/message_scope.go
@@ -100,7 +100,7 @@ func (m IncomingMessageScope) EventID() []byte {
 }
 
 func (m IncomingMessageScope) PayloadType() string {
-	return MessageType(m.msg.Payload)
+	return MessageType(m.decodedPayload)
 }
 
 // OutgoingMessageScope captures the context around an outgoing message that is about to be sent.


### PR DESCRIPTION
`PayloadType()` is used when generating incoming metrics labels. `m.msg.Payload` is always a byte slice, whereas `m.decodedPayload` is the actual message struct