### PR TITLE
Ensure the same runtime config is used

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -463,7 +463,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithReusableCadenceRuntimePool(
 				reusableRuntime.NewCustomReusableCadenceRuntimePool(
 					0,
-					func() runtime.Runtime {
+					func(_ runtime.Config) runtime.Runtime {
 						return emittingRuntime
 					})))
 
@@ -553,7 +553,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithReusableCadenceRuntimePool(
 				reusableRuntime.NewCustomReusableCadenceRuntimePool(
 					0,
-					func() runtime.Runtime {
+					func(_ runtime.Config) runtime.Runtime {
 						return rt
 					})))
 
@@ -656,7 +656,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithReusableCadenceRuntimePool(
 				reusableRuntime.NewCustomReusableCadenceRuntimePool(
 					0,
-					func() runtime.Runtime {
+					func(_ runtime.Config) runtime.Runtime {
 						return rt
 					})))
 

--- a/fvm/environment/system_contracts_test.go
+++ b/fvm/environment/system_contracts_test.go
@@ -57,14 +57,16 @@ func TestSystemContractsInvoke(t *testing.T) {
 			tracer := tracing.NewTracerSpan()
 			runtime := environment.NewRuntime(
 				environment.RuntimeParams{
-					reusableRuntime.NewCustomReusableCadenceRuntimePool(
+					ReusableCadenceRuntimePool: reusableRuntime.NewCustomReusableCadenceRuntimePool(
 						0,
-						func() runtime.Runtime {
+						func(_ runtime.Config) runtime.Runtime {
 							return &testutil.TestInterpreterRuntime{
 								InvokeContractFunc: tc.contractFunction,
 							}
-						}),
-				})
+						},
+					),
+				},
+			)
 			invoker := environment.NewSystemContracts(
 				flow.Mainnet.Chain(),
 				tracer,

--- a/fvm/executionParameters_test.go
+++ b/fvm/executionParameters_test.go
@@ -34,7 +34,10 @@ func TestGetExecutionMemoryWeights(t *testing.T) {
 			reusableRuntime.NewReusableCadenceRuntime(
 				&testutil.TestInterpreterRuntime{
 					ReadStoredFunc: readStored,
-				}))
+				},
+				runtime.Config{},
+			),
+		)
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}
@@ -161,7 +164,10 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 			reusableRuntime.NewReusableCadenceRuntime(
 				&testutil.TestInterpreterRuntime{
 					ReadStoredFunc: readStored,
-				}))
+				},
+				runtime.Config{},
+			),
+		)
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}


### PR DESCRIPTION
Various places create Cadence `runtime.Config`s, e.g. `NewReusableCadenceRuntime` creates an empty one, even when the runtime was potentially created using a different one (e.g. by `ReusableCadenceRuntimePool.newCustomRuntime`).

Propagate the runtime configuration, so it is consistently the same everywhere in `ReusableCadenceRuntimePool` and `ReusableCadenceRuntime`.