### PR TITLE
Improve error code search.

### DIFF
--- a/fvm/errors/base.go
+++ b/fvm/errors/base.go
@@ -33,6 +33,10 @@ func NewInvalidArgumentErrorf(msg string, args ...interface{}) CodedError {
 		args...)
 }
 
+func IsInvalidArgumentError(err error) bool {
+	return HasErrorCode(err, ErrCodeInvalidArgumentError)
+}
+
 // NewInvalidLocationErrorf constructs a new CodedError which indicates an
 // invalid location is passed.
 func NewInvalidLocationErrorf(

--- a/fvm/errors/errors.go
+++ b/fvm/errors/errors.go
@@ -4,15 +4,19 @@ import (
 	stdErrors "errors"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/errors"
 )
 
+type Unwrappable interface {
+	Unwrap() error
+}
+
 type CodedError interface {
 	Code() ErrorCode
 
-	Unwrap() error
-
+	Unwrappable
 	error
 }
 
@@ -134,21 +138,36 @@ func HasErrorCode(err error, code ErrorCode) bool {
 
 // This recursively unwraps the error and returns first CodedError that matches
 // the specified error code.
-func Find(err error, code ErrorCode) CodedError {
-	if err == nil {
+func Find(originalErr error, code ErrorCode) CodedError {
+	if originalErr == nil {
 		return nil
 	}
 
-	var coded CodedError
-	if !As(err, &coded) {
+	var unwrappable Unwrappable
+	if !As(originalErr, &unwrappable) {
 		return nil
 	}
 
-	if coded.Code() == code {
+	coded, ok := unwrappable.(CodedError)
+	if ok && coded.Code() == code {
 		return coded
 	}
 
-	return Find(coded.Unwrap(), code)
+	// NOTE: we need to special case multierror.Error since As() will only
+	// inspect the first error within multierror.Error.
+	errors, ok := unwrappable.(*multierror.Error)
+	if !ok {
+		return Find(unwrappable.Unwrap(), code)
+	}
+
+	for _, innerErr := range errors.Errors {
+		coded = Find(innerErr, code)
+		if coded != nil {
+			return coded
+		}
+	}
+
+	return nil
 }
 
 type codedError struct {

--- a/fvm/errors/failures.go
+++ b/fvm/errors/failures.go
@@ -33,9 +33,9 @@ func NewLedgerFailure(err error) CodedError {
 		"ledger returns unsuccessful")
 }
 
-// IsALedgerFailure returns true if the error or any of the wrapped errors is
+// IsLedgerFailure returns true if the error or any of the wrapped errors is
 // a ledger failure
-func IsALedgerFailure(err error) bool {
+func IsLedgerFailure(err error) bool {
 	return HasErrorCode(err, FailureCodeLedgerFailure)
 }
 

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -174,7 +174,7 @@ func (vm *VirtualMachine) GetAccount(
 		derviedTxnData)
 	account, err := env.GetAccount(address)
 	if err != nil {
-		if errors.IsALedgerFailure(err) {
+		if errors.IsLedgerFailure(err) {
 			return nil, fmt.Errorf(
 				"cannot get account, this error usually happens if the "+
 					"reference block for this query is not set to a recent "+

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -159,7 +159,7 @@ func (executor *scriptExecutor) Execute() error {
 	err := executor.execute()
 	txError, failure := errors.SplitErrorTypes(err)
 	if failure != nil {
-		if errors.IsALedgerFailure(failure) {
+		if errors.IsLedgerFailure(failure) {
 			return fmt.Errorf(
 				"cannot execute the script, this error usually happens if "+
 					"the reference block for this script is not set to a "+


### PR DESCRIPTION
Don't rely on As() to unwrap errors when searching for a non-fatal error code since multierror.Error's As() will only inspects the first error in the list (other error codes in the errors list are ignored).