### PR TITLE
[Benchmark] Match log-level w/ production

### DIFF
--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -18,6 +18,7 @@ PROFILE_UPLOADER=false
 TRACING=true
 EXTENSIVE_TRACING=false
 CADENCE_TRACING=false
+LOGLEVEL=DEBUG
 
 # The Git commit hash
 COMMIT=$(shell git rev-parse HEAD)
@@ -46,6 +47,7 @@ else
 		-ldflags="-X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' \
 		-X  'github.com/onflow/flow-go/cmd/build.semver=${VERSION}'" \
 		bootstrap.go \
+		-loglevel=$(LOGLEVEL) \
 		-collection=$(COLLECTION) \
 		-consensus=$(CONSENSUS) \
 		-execution=$(EXECUTION) \
@@ -74,7 +76,7 @@ bootstrap-light:
 # CI tests have a larger number of nodes
 .PHONY: bootstrap-ci
 bootstrap-ci:
-	$(MAKE) -e COLLECTION=10 VERIFICATION=10 NCLUSTERS=10 bootstrap
+	$(MAKE) -e COLLECTION=10 VERIFICATION=10 NCLUSTERS=10 LOGLEVEL=INFO bootstrap
 
 # Creates a version of localnet configured with short epochs
 .PHONY: bootstrap-short-epochs

--- a/integration/localnet/bootstrap.go
+++ b/integration/localnet/bootstrap.go
@@ -36,6 +36,7 @@ const (
 	PrometheusTargetsFile    = "./targets.nodes.json"
 	DefaultAccessGatewayName = "access_1"
 	DefaultObserverName      = "observer"
+	DefaultLogLevel          = "DEBUG"
 	DefaultGOMAXPROCS        = 8
 	DefaultMaxObservers      = 1000
 	DefaultCollectionCount   = 3
@@ -81,6 +82,7 @@ var (
 	extesiveTracing        bool
 	consensusDelay         time.Duration
 	collectionDelay        time.Duration
+	logLevel               string
 )
 
 func init() {
@@ -101,6 +103,7 @@ func init() {
 	flag.BoolVar(&extesiveTracing, "extensive-tracing", DefaultExtensiveTracing, "enables high-overhead tracing in fvm")
 	flag.DurationVar(&consensusDelay, "consensus-delay", DefaultConsensusDelay, "delay on consensus node block proposals")
 	flag.DurationVar(&collectionDelay, "collection-delay", DefaultCollectionDelay, "delay on collection node block proposals")
+	flag.StringVar(&logLevel, "loglevel", DefaultLogLevel, "log level for all nodes")
 }
 
 func generateBootstrapData(flowNetworkConf testnet.NetworkConfig) []testnet.ContainerConfig {
@@ -502,7 +505,7 @@ func defaultService(role, dataDir, profilerDir string, i int) Service {
 			"--bootstrapdir=/bootstrap",
 			"--datadir=/data/protocol",
 			"--secretsdir=/data/secret",
-			"--loglevel=DEBUG",
+			fmt.Sprintf("--loglevel=%s", logLevel),
 			fmt.Sprintf("--profiler-enabled=%t", profiler),
 			fmt.Sprintf("--profile-uploader-enabled=%t", profileUploader),
 			fmt.Sprintf("--tracer-enabled=%t", tracing),


### PR DESCRIPTION
Right now we are logging too much data from ~30 daemons on the same box most of which debug data.  Since production runs with an info level by default, let's switch to it in benchmarks too.

PS. Keep default at DEBUG to preserve backwards compatibility with previous localnet setups (it is quite useful for local troubleshooting.)