### PR TITLE
Simplify Start Entity Span.

### DIFF
--- a/engine/common/follower/engine.go
+++ b/engine/common/follower/engine.go
@@ -222,7 +222,7 @@ func (e *Engine) onBlockProposal(originID flow.Identifier, proposal *messages.Bl
 	block := proposal.Block.ToInternal()
 	header := block.Header
 
-	span, ctx, _ := e.tracer.StartBlockSpan(context.Background(), header.ID(), trace.FollowerOnBlockProposal)
+	span, ctx := e.tracer.StartBlockSpan(context.Background(), header.ID(), trace.FollowerOnBlockProposal)
 	defer span.End()
 
 	log := e.log.With().

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -96,17 +96,13 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Bloc
 	block := proposal.Block.ToInternal()
 	header := block.Header
 
-	var traceID string
-
-	span, _, isSampled := c.tracer.StartBlockSpan(context.Background(), header.ID(), trace.CONCompOnBlockProposal)
-	if isSampled {
-		span.SetAttributes(
-			attribute.Int64("view", int64(header.View)),
-			attribute.String("origin_id", originID.String()),
-			attribute.String("proposer", header.ProposerID.String()),
-		)
-		traceID = span.SpanContext().TraceID().String()
-	}
+	span, _ := c.tracer.StartBlockSpan(context.Background(), header.ID(), trace.CONCompOnBlockProposal)
+	span.SetAttributes(
+		attribute.Int64("view", int64(header.View)),
+		attribute.String("origin_id", originID.String()),
+		attribute.String("proposer", header.ProposerID.String()),
+	)
+	traceID := span.SpanContext().TraceID().String()
 	defer span.End()
 
 	log := c.log.With().
@@ -279,12 +275,10 @@ func (c *Core) processBlockProposal(block *flow.Block, inRangeBlockResponse bool
 	startTime := time.Now()
 	defer c.complianceMetrics.BlockProposalDuration(time.Since(startTime))
 
-	span, ctx, isSampled := c.tracer.StartBlockSpan(context.Background(), header.ID(), trace.ConCompProcessBlockProposal)
-	if isSampled {
-		span.SetAttributes(
-			attribute.String("proposer", header.ProposerID.String()),
-		)
-	}
+	span, ctx := c.tracer.StartBlockSpan(context.Background(), header.ID(), trace.ConCompProcessBlockProposal)
+	span.SetAttributes(
+		attribute.String("proposer", header.ProposerID.String()),
+	)
 	defer span.End()
 
 	log := c.log.With().
@@ -344,12 +338,10 @@ func (c *Core) processBlockProposal(block *flow.Block, inRangeBlockResponse bool
 // OnBlockVote handles incoming block votes.
 func (c *Core) OnBlockVote(originID flow.Identifier, vote *messages.BlockVote) error {
 
-	span, _, isSampled := c.tracer.StartBlockSpan(context.Background(), vote.BlockID, trace.CONCompOnBlockVote)
-	if isSampled {
-		span.SetAttributes(
-			attribute.String("origin_id", originID.String()),
-		)
-	}
+	span, _ := c.tracer.StartBlockSpan(context.Background(), vote.BlockID, trace.CONCompOnBlockVote)
+	span.SetAttributes(
+		attribute.String("origin_id", originID.String()),
+	)
 	defer span.End()
 
 	v := &model.Vote{

--- a/engine/consensus/ingestion/core.go
+++ b/engine/consensus/ingestion/core.go
@@ -61,12 +61,10 @@ func NewCore(
 // All other errors are unexpected and potential symptoms of internal state corruption.
 func (e *Core) OnGuarantee(originID flow.Identifier, guarantee *flow.CollectionGuarantee) error {
 
-	span, _, isSampled := e.tracer.StartCollectionSpan(context.Background(), guarantee.CollectionID, trace.CONIngOnCollectionGuarantee)
-	if isSampled {
-		span.SetAttributes(
-			attribute.String("originID", originID.String()),
-		)
-	}
+	span, _ := e.tracer.StartCollectionSpan(context.Background(), guarantee.CollectionID, trace.CONIngOnCollectionGuarantee)
+	span.SetAttributes(
+		attribute.String("originID", originID.String()),
+	)
 	defer span.End()
 
 	guaranteeID := guarantee.ID()

--- a/engine/consensus/matching/core.go
+++ b/engine/consensus/matching/core.go
@@ -161,13 +161,11 @@ func (c *Core) processReceipt(receipt *flow.ExecutionReceipt) (bool, error) {
 		c.metrics.OnReceiptProcessingDuration(time.Since(startTime))
 	}()
 
-	receiptSpan, _, isSampled := c.tracer.StartBlockSpan(context.Background(), receipt.ExecutionResult.BlockID, trace.CONMatchProcessReceipt)
-	if isSampled {
-		receiptSpan.SetAttributes(
-			attribute.String("result_id", receipt.ExecutionResult.ID().String()),
-			attribute.String("executor", receipt.ExecutorID.String()),
-		)
-	}
+	receiptSpan, _ := c.tracer.StartBlockSpan(context.Background(), receipt.ExecutionResult.BlockID, trace.CONMatchProcessReceipt)
+	receiptSpan.SetAttributes(
+		attribute.String("result_id", receipt.ExecutionResult.ID().String()),
+		attribute.String("executor", receipt.ExecutorID.String()),
+	)
 	defer receiptSpan.End()
 
 	initialState, finalState, err := getStartAndEndStates(receipt)

--- a/engine/consensus/sealing/core.go
+++ b/engine/consensus/sealing/core.go
@@ -303,7 +303,7 @@ func (c *Core) processIncorporatedResult(incRes *flow.IncorporatedResult) error 
 // * nil - successfully processed incorporated result
 func (c *Core) ProcessIncorporatedResult(result *flow.IncorporatedResult) error {
 
-	span, _, _ := c.tracer.StartBlockSpan(context.Background(), result.Result.BlockID, trace.CONSealingProcessIncorporatedResult)
+	span, _ := c.tracer.StartBlockSpan(context.Background(), result.Result.BlockID, trace.CONSealingProcessIncorporatedResult)
 	defer span.End()
 
 	err := c.processIncorporatedResult(result)
@@ -352,13 +352,11 @@ func (c *Core) ProcessApproval(approval *flow.ResultApproval) error {
 		Str("verifier_id", approval.Body.ApproverID.String()).
 		Msg("processing result approval")
 
-	span, _, isSampled := c.tracer.StartBlockSpan(context.Background(), approval.Body.BlockID, trace.CONSealingProcessApproval)
-	if isSampled {
-		span.SetAttributes(
-			attribute.String("approverId", approval.Body.ApproverID.String()),
-			attribute.Int64("chunkIndex", int64(approval.Body.ChunkIndex)),
-		)
-	}
+	span, _ := c.tracer.StartBlockSpan(context.Background(), approval.Body.BlockID, trace.CONSealingProcessApproval)
+	span.SetAttributes(
+		attribute.String("approverId", approval.Body.ApproverID.String()),
+		attribute.Int64("chunkIndex", int64(approval.Body.ChunkIndex)),
+	)
 	defer span.End()
 
 	startTime := time.Now()
@@ -505,7 +503,7 @@ func (c *Core) processPendingApprovals(collector approvals.AssignmentCollectorSt
 // * nil - successfully processed finalized block
 func (c *Core) ProcessFinalizedBlock(finalizedBlockID flow.Identifier) error {
 
-	processFinalizedBlockSpan, _, _ := c.tracer.StartBlockSpan(context.Background(), finalizedBlockID, trace.CONSealingProcessFinalizedBlock)
+	processFinalizedBlockSpan, _ := c.tracer.StartBlockSpan(context.Background(), finalizedBlockID, trace.CONSealingProcessFinalizedBlock)
 	defer processFinalizedBlockSpan.End()
 
 	// STEP 0: Collect auxiliary information

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -176,10 +176,8 @@ func (e *blockComputer) ExecuteBlock(
 	derivedBlockData *derived.DerivedBlockData,
 ) (*execution.ComputationResult, error) {
 
-	span, _, isSampled := e.tracer.StartBlockSpan(ctx, block.ID(), trace.EXEComputeBlock)
-	if isSampled {
-		span.SetAttributes(attribute.Int("collection_counts", len(block.CompleteCollections)))
-	}
+	span, _ := e.tracer.StartBlockSpan(ctx, block.ID(), trace.EXEComputeBlock)
+	span.SetAttributes(attribute.Int("collection_counts", len(block.CompleteCollections)))
 	defer span.End()
 
 	results, err := e.executeBlock(ctx, span, block, stateView, derivedBlockData)
@@ -428,19 +426,15 @@ func (e *blockComputer) executeTransaction(
 	)
 	defer txSpan.End()
 
-	var traceID string
-	txInternalSpan, _, isSampled := e.tracer.StartTransactionSpan(context.Background(), txID, trace.EXERunTransaction)
-	if isSampled {
-		txInternalSpan.SetAttributes(attribute.String("tx_id", txID.String()))
-		traceID = txInternalSpan.SpanContext().TraceID().String()
-	}
+	txInternalSpan, _ := e.tracer.StartTransactionSpan(context.Background(), txID, trace.EXERunTransaction)
+	txInternalSpan.SetAttributes(attribute.String("tx_id", txID.String()))
 	defer txInternalSpan.End()
 
 	logger := e.log.With().
 		Str("tx_id", txID.String()).
 		Uint32("tx_index", txn.txIndex).
 		Str("block_id", txn.blockIdStr).
-		Str("trace_id", traceID).
+		Str("trace_id", txInternalSpan.SpanContext().TraceID().String()).
 		Uint64("height", txn.ctx.BlockHeader.Height).
 		Bool("system_chunk", txn.isSystemTransaction).
 		Bool("system_transaction", txn.isSystemTransaction).
@@ -449,11 +443,9 @@ func (e *blockComputer) executeTransaction(
 
 	proc := fvm.Transaction(txn.TransactionBody, txn.txIndex)
 
-	if isSampled {
-		txn.ctx = fvm.NewContextFromParent(
-			txn.ctx,
-			fvm.WithSpan(txInternalSpan))
-	}
+	txn.ctx = fvm.NewContextFromParent(
+		txn.ctx,
+		fvm.WithSpan(txInternalSpan))
 
 	txView := collectionView.NewChild()
 	err := e.vm.Run(txn.ctx, proc, txView)

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -467,7 +467,7 @@ func (e *Engine) handleBlock(ctx context.Context, block *flow.Block) error {
 	blockID := block.ID()
 	log := e.log.With().Hex("block_id", blockID[:]).Logger()
 
-	span, _, _ := e.tracer.StartBlockSpan(ctx, blockID, trace.EXEHandleBlock)
+	span, _ := e.tracer.StartBlockSpan(ctx, blockID, trace.EXEHandleBlock)
 	defer span.End()
 
 	executed, err := state.IsBlockExecuted(e.unit.Ctx(), e.execState, blockID)
@@ -872,7 +872,7 @@ func (e *Engine) OnCollection(originID flow.Identifier, entity flow.Entity) {
 func (e *Engine) handleCollection(originID flow.Identifier, collection *flow.Collection) error {
 	collID := collection.ID()
 
-	span, _, _ := e.tracer.StartCollectionSpan(context.Background(), collID, trace.EXEHandleCollection)
+	span, _ := e.tracer.StartCollectionSpan(context.Background(), collID, trace.EXEHandleCollection)
 	defer span.End()
 
 	lg := e.log.With().Hex("collection_id", collID[:]).Logger()

--- a/engine/verification/assigner/engine.go
+++ b/engine/verification/assigner/engine.go
@@ -163,7 +163,7 @@ func (e *Engine) processChunk(chunk *flow.Chunk, resultID flow.Identifier, block
 func (e *Engine) ProcessFinalizedBlock(block *flow.Block) {
 	blockID := block.ID()
 
-	span, ctx, _ := e.tracer.StartBlockSpan(e.unit.Ctx(), blockID, trace.VERProcessFinalizedBlock)
+	span, ctx := e.tracer.StartBlockSpan(e.unit.Ctx(), blockID, trace.VERProcessFinalizedBlock)
 	defer span.End()
 
 	e.processFinalizedBlock(ctx, block)

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -169,10 +169,8 @@ func (e *Engine) ProcessAssignedChunk(locator *chunks.Locator) {
 // processAssignedChunkWithTracing encapsulates the logic of processing assigned chunk with tracing enabled.
 func (e *Engine) processAssignedChunkWithTracing(chunk *flow.Chunk, result *flow.ExecutionResult, chunkLocatorID flow.Identifier) (bool, uint64, error) {
 
-	span, _, isSampled := e.tracer.StartBlockSpan(e.unit.Ctx(), result.BlockID, trace.VERProcessAssignedChunk)
-	if isSampled {
-		span.SetAttributes(attribute.Int("collection_index", int(chunk.CollectionIndex)))
-	}
+	span, _ := e.tracer.StartBlockSpan(e.unit.Ctx(), result.BlockID, trace.VERProcessAssignedChunk)
+	span.SetAttributes(attribute.Int("collection_index", int(chunk.CollectionIndex)))
 	defer span.End()
 
 	requested, blockHeight, err := e.processAssignedChunk(chunk, result, chunkLocatorID)
@@ -264,7 +262,7 @@ func (e *Engine) HandleChunkDataPack(originID flow.Identifier, response *verific
 		Bool("system_chunk", IsSystemChunk(status.ChunkIndex, status.ExecutionResult)).
 		Logger()
 
-	span, ctx, _ := e.tracer.StartBlockSpan(context.Background(), status.ExecutionResult.BlockID, trace.VERFetcherHandleChunkDataPack)
+	span, ctx := e.tracer.StartBlockSpan(context.Background(), status.ExecutionResult.BlockID, trace.VERFetcherHandleChunkDataPack)
 	defer span.End()
 
 	processed, err := e.handleChunkDataPackWithTracing(ctx, originID, status, response.Cdp)

--- a/engine/verification/requester/requester.go
+++ b/engine/verification/requester/requester.go
@@ -168,10 +168,8 @@ func (e *Engine) process(originID flow.Identifier, event interface{}) error {
 func (e *Engine) handleChunkDataPackWithTracing(originID flow.Identifier, chunkDataPack *flow.ChunkDataPack) {
 	// TODO: change this to block level as well
 	if chunkDataPack.Collection != nil {
-		span, _, isSampled := e.tracer.StartCollectionSpan(e.unit.Ctx(), chunkDataPack.Collection.ID(), trace.VERRequesterHandleChunkDataResponse)
-		if isSampled {
-			span.SetAttributes(attribute.String("chunk_id", chunkDataPack.ChunkID.String()))
-		}
+		span, _ := e.tracer.StartCollectionSpan(e.unit.Ctx(), chunkDataPack.Collection.ID(), trace.VERRequesterHandleChunkDataResponse)
+		span.SetAttributes(attribute.String("chunk_id", chunkDataPack.ChunkID.String()))
 		defer span.End()
 	}
 	e.handleChunkDataPack(originID, chunkDataPack)

--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -317,14 +317,12 @@ func GenerateResultApproval(
 // verifiableChunkHandler acts as a wrapper around the verify method that captures its performance-related metrics
 func (e *Engine) verifiableChunkHandler(originID flow.Identifier, ch *verification.VerifiableChunkData) error {
 
-	span, ctx, isSampled := e.tracer.StartBlockSpan(context.Background(), ch.Chunk.BlockID, trace.VERVerVerifyWithMetrics)
-	if isSampled {
-		span.SetAttributes(
-			attribute.Int64("chunk_index", int64(ch.Chunk.Index)),
-			attribute.String("result_id", ch.Result.ID().String()),
-			attribute.String("origin_id", originID.String()),
-		)
-	}
+	span, ctx := e.tracer.StartBlockSpan(context.Background(), ch.Chunk.BlockID, trace.VERVerVerifyWithMetrics)
+	span.SetAttributes(
+		attribute.Int64("chunk_index", int64(ch.Chunk.Index)),
+		attribute.String("result_id", ch.Result.ID().String()),
+		attribute.String("origin_id", originID.String()),
+	)
 	defer span.End()
 
 	// increments number of received verifiable chunks

--- a/module/builder/collection/builder.go
+++ b/module/builder/collection/builder.go
@@ -349,7 +349,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 	// TODO (ramtin): enable this again
 	// b.tracer.FinishSpan(parentID, trace.COLBuildOnCreateHeader)
 
-	span, ctx, _ := b.tracer.StartCollectionSpan(context.Background(), proposal.ID(), trace.COLBuildOn, otelTrace.WithTimestamp(startTime))
+	span, ctx := b.tracer.StartCollectionSpan(context.Background(), proposal.ID(), trace.COLBuildOn, otelTrace.WithTimestamp(startTime))
 	defer span.End()
 
 	dbInsertSpan, _ := b.tracer.StartSpanFromContext(ctx, trace.COLBuildOnDBInsert)

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -141,7 +141,7 @@ func (b *Builder) BuildOn(parentID flow.Identifier, setter func(*flow.Header) er
 		return nil, fmt.Errorf("could not assemble proposal: %w", err)
 	}
 
-	span, ctx, _ := b.tracer.StartBlockSpan(context.Background(), proposal.ID(), trace.CONBuilderBuildOn, otelTrace.WithTimestamp(startTime))
+	span, ctx := b.tracer.StartBlockSpan(context.Background(), proposal.ID(), trace.CONBuilderBuildOn, otelTrace.WithTimestamp(startTime))
 	defer span.End()
 
 	err = b.state.Extend(ctx, proposal)

--- a/module/finalizer/consensus/finalizer.go
+++ b/module/finalizer/consensus/finalizer.go
@@ -54,7 +54,7 @@ func NewFinalizer(db *badger.DB,
 // pools and persistent storage.
 func (f *Finalizer) MakeFinal(blockID flow.Identifier) error {
 
-	span, ctx, _ := f.tracer.StartBlockSpan(context.Background(), blockID, trace.CONFinalizerFinalizeBlock)
+	span, ctx := f.tracer.StartBlockSpan(context.Background(), blockID, trace.CONFinalizerFinalizeBlock)
 	defer span.End()
 
 	// STEP ONE: This is an idempotent operation. In case we are trying to

--- a/module/mock/tracer.go
+++ b/module/mock/tracer.go
@@ -68,7 +68,7 @@ func (_m *Tracer) RecordSpanFromParent(parentSpan trace.Span, operationName modu
 }
 
 // StartBlockSpan provides a mock function with given fields: ctx, blockID, spanName, opts
-func (_m *Tracer) StartBlockSpan(ctx context.Context, blockID flow.Identifier, spanName moduletrace.SpanName, opts ...trace.SpanStartOption) (trace.Span, context.Context, bool) {
+func (_m *Tracer) StartBlockSpan(ctx context.Context, blockID flow.Identifier, spanName moduletrace.SpanName, opts ...trace.SpanStartOption) (trace.Span, context.Context) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
@@ -96,18 +96,11 @@ func (_m *Tracer) StartBlockSpan(ctx context.Context, blockID flow.Identifier, s
 		}
 	}
 
-	var r2 bool
-	if rf, ok := ret.Get(2).(func(context.Context, flow.Identifier, moduletrace.SpanName, ...trace.SpanStartOption) bool); ok {
-		r2 = rf(ctx, blockID, spanName, opts...)
-	} else {
-		r2 = ret.Get(2).(bool)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // StartCollectionSpan provides a mock function with given fields: ctx, collectionID, spanName, opts
-func (_m *Tracer) StartCollectionSpan(ctx context.Context, collectionID flow.Identifier, spanName moduletrace.SpanName, opts ...trace.SpanStartOption) (trace.Span, context.Context, bool) {
+func (_m *Tracer) StartCollectionSpan(ctx context.Context, collectionID flow.Identifier, spanName moduletrace.SpanName, opts ...trace.SpanStartOption) (trace.Span, context.Context) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
@@ -135,14 +128,7 @@ func (_m *Tracer) StartCollectionSpan(ctx context.Context, collectionID flow.Ide
 		}
 	}
 
-	var r2 bool
-	if rf, ok := ret.Get(2).(func(context.Context, flow.Identifier, moduletrace.SpanName, ...trace.SpanStartOption) bool); ok {
-		r2 = rf(ctx, collectionID, spanName, opts...)
-	} else {
-		r2 = ret.Get(2).(bool)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // StartSpanFromContext provides a mock function with given fields: ctx, operationName, opts
@@ -201,7 +187,7 @@ func (_m *Tracer) StartSpanFromParent(parentSpan trace.Span, operationName modul
 }
 
 // StartTransactionSpan provides a mock function with given fields: ctx, transactionID, spanName, opts
-func (_m *Tracer) StartTransactionSpan(ctx context.Context, transactionID flow.Identifier, spanName moduletrace.SpanName, opts ...trace.SpanStartOption) (trace.Span, context.Context, bool) {
+func (_m *Tracer) StartTransactionSpan(ctx context.Context, transactionID flow.Identifier, spanName moduletrace.SpanName, opts ...trace.SpanStartOption) (trace.Span, context.Context) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
@@ -229,14 +215,7 @@ func (_m *Tracer) StartTransactionSpan(ctx context.Context, transactionID flow.I
 		}
 	}
 
-	var r2 bool
-	if rf, ok := ret.Get(2).(func(context.Context, flow.Identifier, moduletrace.SpanName, ...trace.SpanStartOption) bool); ok {
-		r2 = rf(ctx, transactionID, spanName, opts...)
-	} else {
-		r2 = ret.Get(2).(bool)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // WithSpanFromContext provides a mock function with given fields: ctx, operationName, f, opts

--- a/module/trace/noop.go
+++ b/module/trace/noop.go
@@ -42,8 +42,11 @@ func (t *NoopTracer) StartBlockSpan(
 	entityID flow.Identifier,
 	spanName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context, bool) {
-	return NoopSpan, ctx, false
+) (
+	trace.Span,
+	context.Context,
+) {
+	return NoopSpan, ctx
 }
 
 func (t *NoopTracer) StartCollectionSpan(
@@ -51,8 +54,11 @@ func (t *NoopTracer) StartCollectionSpan(
 	entityID flow.Identifier,
 	spanName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context, bool) {
-	return NoopSpan, ctx, false
+) (
+	trace.Span,
+	context.Context,
+) {
+	return NoopSpan, ctx
 }
 
 func (t *NoopTracer) StartTransactionSpan(
@@ -60,15 +66,21 @@ func (t *NoopTracer) StartTransactionSpan(
 	entityID flow.Identifier,
 	spanName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context, bool) {
-	return NoopSpan, ctx, false
+) (
+	trace.Span,
+	context.Context,
+) {
+	return NoopSpan, ctx
 }
 
 func (t *NoopTracer) StartSpanFromContext(
 	ctx context.Context,
 	operationName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context) {
+) (
+	trace.Span,
+	context.Context,
+) {
 	return NoopSpan, ctx
 }
 

--- a/module/trace/trace.go
+++ b/module/trace/trace.go
@@ -52,7 +52,10 @@ func NewTracer(
 	serviceName string,
 	chainID string,
 	sensitivity uint,
-) (*Tracer, error) {
+) (
+	*Tracer,
+	error,
+) {
 	ctx := context.TODO()
 	res, err := resource.New(
 		ctx,
@@ -130,13 +133,16 @@ func (t *Tracer) startEntitySpan(
 	entityType string,
 	spanName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context, bool) {
+) (
+	trace.Span,
+	context.Context,
+) {
 	if !entityID.IsSampled(t.sensitivity) {
-		return NoopSpan, ctx, false
+		return NoopSpan, ctx
 	}
 
 	ctx, rootSpan := t.entityRootSpan(ctx, entityID, entityType)
-	return t.StartSpanFromParent(rootSpan, spanName, opts...), ctx, true
+	return t.StartSpanFromParent(rootSpan, spanName, opts...), ctx
 }
 
 // entityRootSpan returns the root span for the given entity from the cache
@@ -147,7 +153,10 @@ func (t *Tracer) entityRootSpan(
 	entityID flow.Identifier,
 	entityType string,
 	opts ...trace.SpanStartOption,
-) (context.Context, trace.Span) {
+) (
+	context.Context,
+	trace.Span,
+) {
 	if c, ok := t.spanCache.Get(entityID); ok {
 		span := c.(trace.Span)
 		return trace.ContextWithSpan(ctx, span), span
@@ -176,7 +185,10 @@ func (t *Tracer) StartBlockSpan(
 	blockID flow.Identifier,
 	spanName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context, bool) {
+) (
+	trace.Span,
+	context.Context,
+) {
 	return t.startEntitySpan(ctx, blockID, EntityTypeBlock, spanName, opts...)
 }
 
@@ -185,18 +197,25 @@ func (t *Tracer) StartCollectionSpan(
 	collectionID flow.Identifier,
 	spanName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context, bool) {
+) (
+	trace.Span,
+	context.Context,
+) {
 	return t.startEntitySpan(ctx, collectionID, EntityTypeCollection, spanName, opts...)
 }
 
-// StartTransactionSpan starts a span that will be aggregated under the given transaction.
+// StartTransactionSpan starts a span that will be aggregated under the given
+// transaction.
 // All spans for the same transaction will be aggregated under a root span
 func (t *Tracer) StartTransactionSpan(
 	ctx context.Context,
 	transactionID flow.Identifier,
 	spanName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context, bool) {
+) (
+	trace.Span,
+	context.Context,
+) {
 	return t.startEntitySpan(ctx, transactionID, EntityTypeTransaction, spanName, opts...)
 }
 
@@ -204,7 +223,10 @@ func (t *Tracer) StartSpanFromContext(
 	ctx context.Context,
 	operationName SpanName,
 	opts ...trace.SpanStartOption,
-) (trace.Span, context.Context) {
+) (
+	trace.Span,
+	context.Context,
+) {
 	ctx, span := t.tracer.Start(ctx, string(operationName), opts...)
 	return span, ctx
 }

--- a/module/trace/trace_test.go
+++ b/module/trace/trace_test.go
@@ -18,8 +18,7 @@ func BenchmarkStartSpanFromParent(b *testing.B) {
 	tracer.Ready()
 	defer tracer.Done()
 
-	span, _, sampled := tracer.StartTransactionSpan(context.Background(), flow.Identifier{}, "test")
-	require.True(b, sampled)
+	span, _ := tracer.StartTransactionSpan(context.Background(), flow.Identifier{}, "test")
 	defer span.End()
 
 	b.ResetTimer()
@@ -56,8 +55,7 @@ func BenchmarkStartTransactionSpan(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				span, _, sampled := tracer.StartTransactionSpan(context.Background(), randomIDs[i%t.n], "test")
-				require.True(b, sampled)
+				span, _ := tracer.StartTransactionSpan(context.Background(), randomIDs[i%t.n], "test")
 				span.End()
 			}
 			b.StopTimer()

--- a/module/tracer.go
+++ b/module/tracer.go
@@ -21,41 +21,53 @@ var (
 type Tracer interface {
 	ReadyDoneAware
 
-	// StartBlockSpan starts an span for a block, built as a child of rootSpan
-	// it also returns the context including this span which can be used for nested calls.
-	// and also a boolean reporting if this span is sampled (is used for avoiding unncessary computation for tags)
+	// StartBlockSpan starts an span for a block, built as a child of rootSpan.
+	// It also returns the context including this span which can be used for
+	// nested calls.
 	StartBlockSpan(
 		ctx context.Context,
 		blockID flow.Identifier,
 		spanName trace.SpanName,
 		opts ...otelTrace.SpanStartOption,
-	) (otelTrace.Span, context.Context, bool)
+	) (
+		otelTrace.Span,
+		context.Context,
+	)
 
-	// StartCollectionSpan starts an span for a collection, built as a child of rootSpan
-	// it also returns the context including this span which can be used for nested calls.
-	// and also a boolean reporting if this span is sampled (is used for avoiding unncessary computation for tags)
+	// StartCollectionSpan starts an span for a collection, built as a child of
+	// rootSpan.  It also returns the context including this span which can be
+	// used for nested calls.
 	StartCollectionSpan(
 		ctx context.Context,
 		collectionID flow.Identifier,
 		spanName trace.SpanName,
 		opts ...otelTrace.SpanStartOption,
-	) (otelTrace.Span, context.Context, bool)
+	) (
+		otelTrace.Span,
+		context.Context,
+	)
 
-	// StartTransactionSpan starts an span for a transaction, built as a child of rootSpan
-	// it also returns the context including this span which can be used for nested calls.
-	// and also a boolean reporting if this span is sampled (is used for avoiding unncessary computation for tags)
+	// StartTransactionSpan starts an span for a transaction, built as a child
+	// of rootSpan.  It also returns the context including this span which can
+	// be used for nested calls.
 	StartTransactionSpan(
 		ctx context.Context,
 		transactionID flow.Identifier,
 		spanName trace.SpanName,
 		opts ...otelTrace.SpanStartOption,
-	) (otelTrace.Span, context.Context, bool)
+	) (
+		otelTrace.Span,
+		context.Context,
+	)
 
 	StartSpanFromContext(
 		ctx context.Context,
 		operationName trace.SpanName,
 		opts ...otelTrace.SpanStartOption,
-	) (otelTrace.Span, context.Context)
+	) (
+		otelTrace.Span,
+		context.Context,
+	)
 
 	StartSpanFromParent(
 		parentSpan otelTrace.Span,

--- a/state/cluster/badger/mutator.go
+++ b/state/cluster/badger/mutator.go
@@ -41,7 +41,7 @@ func (m *MutableState) Extend(block *cluster.Block) error {
 
 	blockID := block.ID()
 
-	span, ctx, _ := m.tracer.StartCollectionSpan(context.Background(), blockID, trace.COLClusterStateMutatorExtend)
+	span, ctx := m.tracer.StartCollectionSpan(context.Background(), blockID, trace.COLClusterStateMutatorExtend)
 	defer span.End()
 
 	err := m.State.db.View(func(tx *badger.Txn) error {


### PR DESCRIPTION
Remove isSample from Start`<Block|Collection|Transaction>`Span's return value. The span attribute value overhead is minimal.

Note that we usually set the same attribute values into the logger at the same time.  If the attribute value formatting is expensive, we can just precompute the formatted value and reuse it for both the span and the logger.