### PR TITLE
[CI] Add github action to build boot-tools on demand

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,44 @@
+name: Build Tools
+
+on:
+  workflow_dispatch:
+    inputs: 
+      tag:
+        description: 'Tagged commit to build tools against'
+        required: true
+        type: string
+
+jobs:
+  docker-push:
+    name: Push to container registry
+    runs-on: ubuntu-latest
+    steps:
+    - id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GCR_SERVICE_KEY }} # TODO: we need a new key to allow uploads
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.19'
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: flow # TODO: is this correct?
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag }}
+    - name: Build relic
+      run: make crypto_setup_gopath
+    - name: Build Tools
+      run: |
+        make tool-bootstrap
+        make tool-util
+        make tool-transit
+    - name: Upload boot-tools
+      run: |
+        mkdir boot-tools
+        mv bootstrap util transit boot-tools/
+        tar -czf boot-tools.tar ./boot-tools/
+        gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/boot-tools.tar

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -35,21 +35,18 @@ jobs:
         ref: ${{ inputs.tag }}
     - name: Build relic
       run: make crypto_setup_gopath
-    - name: Build Tools
+    - name: Build and upload boot-tools
       run: |
-        make tool-bootstrap
-        make tool-util
-        make tool-transit
-    - name: Upload boot-tools
-      run: |
+        make tool-bootstrap tool-transit
         mkdir boot-tools
         mv bootstrap transit boot-tools/
         tar -czf boot-tools.tar ./boot-tools/
         gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/boot-tools.tar
-    - name: Upload util
+    - name: Build and upload util
       run: |
-        tar -czf util.tar ./util
-        gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/util.tar
+        make tool-util
+        tar -czf util.tar util
+        gsutil cp util.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/util.tar
     - name: Promote boot-tools
       run: |
         if [[ "${{ inputs.promote }}" = true ]]; then

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -2,15 +2,19 @@ name: Build Tools
 
 on:
   workflow_dispatch:
-    inputs: 
+    inputs:
       tag:
         description: 'Tagged commit to build tools against'
         required: true
         type: string
+      promote:
+        description: 'Should this build be promoted to the official boot-tools?'
+        required: false
+        type: boolean
 
 jobs:
-  docker-push:
-    name: Push to container registry
+  build-publish:
+    name: Build boot tools
     runs-on: ubuntu-latest
     steps:
     - id: auth
@@ -24,7 +28,7 @@ jobs:
     - name: Set up Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
       with:
-        project_id: flow # TODO: is this correct?
+        project_id: flow
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
@@ -39,6 +43,18 @@ jobs:
     - name: Upload boot-tools
       run: |
         mkdir boot-tools
-        mv bootstrap util transit boot-tools/
+        mv bootstrap transit boot-tools/
         tar -czf boot-tools.tar ./boot-tools/
-        gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/boot-tools.tar
+        gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/boot-tools.tar
+    - name: Upload util
+      run: |
+        tar -czf util.tar ./util
+        gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/util.tar
+    - name: Promote boot-tools
+      run: |
+        if [[ "${{ inputs.promote }}" = true ]]; then
+          echo "promoting boot-tools.tar"
+          gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/boot-tools.tar
+        else
+          echo "not promoting boot-tools.tar"
+        fi


### PR DESCRIPTION
The PR adds a github action workflow that can be run on demand to build the `bootstrap`, `transit` and `util` tools, then upload them to GCS