### PR TITLE
[Access] Do not copy protobuf messages

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/google/go-cmp/cmp"
 	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
 	entitiesproto "github.com/onflow/flow/protobuf/go/flow/entities"
 	execproto "github.com/onflow/flow/protobuf/go/flow/execution"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/onflow/flow-go/access"
 	hsmock "github.com/onflow/flow-go/consensus/hotstuff/mocks"
@@ -362,11 +364,11 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 		assertHeaderResp := func(resp *accessproto.BlockHeaderResponse, err error, header *flow.Header) {
 			require.NoError(suite.T(), err)
 			require.NotNil(suite.T(), resp)
-			actual := *resp.Block
+			actual := resp.Block
 			expectedMessage, err := convert.BlockHeaderToMessage(header, suite.signerIds)
 			require.NoError(suite.T(), err)
-			require.Equal(suite.T(), *expectedMessage, actual)
-			expectedBlockHeader, err := convert.MessageToBlockHeader(&actual)
+			require.Empty(suite.T(), cmp.Diff(expectedMessage, actual, protocmp.Transform()))
+			expectedBlockHeader, err := convert.MessageToBlockHeader(actual)
 			require.NoError(suite.T(), err)
 			require.Equal(suite.T(), expectedBlockHeader, header)
 		}
@@ -484,7 +486,7 @@ func (suite *Suite) TestGetExecutionResultByBlockID() {
 		assertResp := func(resp *accessproto.ExecutionResultForBlockIDResponse, err error, executionResult *flow.ExecutionResult) {
 			require.NoError(suite.T(), err)
 			require.NotNil(suite.T(), resp)
-			er := *resp.ExecutionResult
+			er := resp.ExecutionResult
 
 			require.Len(suite.T(), er.Chunks, len(executionResult.Chunks))
 			require.Len(suite.T(), er.ServiceEvents, len(executionResult.ServiceEvents))

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -78,7 +78,7 @@ func (b *backendAccounts) getAccountAtBlockID(
 	blockID flow.Identifier,
 ) (*flow.Account, error) {
 
-	exeReq := execproto.GetAccountAtBlockIDRequest{
+	exeReq := &execproto.GetAccountAtBlockIDRequest{
 		Address: address.Bytes(),
 		BlockId: blockID[:],
 	}
@@ -111,7 +111,7 @@ func getAccountError(err error) error {
 	return status.Errorf(codes.Internal, "failed to get account from the execution node: %v", err)
 }
 
-func (b *backendAccounts) getAccountFromAnyExeNode(ctx context.Context, execNodes flow.IdentityList, req execproto.GetAccountAtBlockIDRequest) (*execproto.GetAccountAtBlockIDResponse, error) {
+func (b *backendAccounts) getAccountFromAnyExeNode(ctx context.Context, execNodes flow.IdentityList, req *execproto.GetAccountAtBlockIDRequest) (*execproto.GetAccountAtBlockIDResponse, error) {
 	var errors *multierror.Error // captures all error except
 	for _, execNode := range execNodes {
 		// TODO: use the GRPC Client interceptor
@@ -153,14 +153,14 @@ func (b *backendAccounts) getAccountFromAnyExeNode(ctx context.Context, execNode
 	return nil, status.Errorf(codes.NotFound, "failed to get account from the execution node: %v", errToReturn)
 }
 
-func (b *backendAccounts) tryGetAccount(ctx context.Context, execNode *flow.Identity, req execproto.GetAccountAtBlockIDRequest) (*execproto.GetAccountAtBlockIDResponse, error) {
+func (b *backendAccounts) tryGetAccount(ctx context.Context, execNode *flow.Identity, req *execproto.GetAccountAtBlockIDRequest) (*execproto.GetAccountAtBlockIDResponse, error) {
 	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, err
 	}
 	defer closer.Close()
 
-	resp, err := execRPCClient.GetAccountAtBlockID(ctx, &req)
+	resp, err := execRPCClient.GetAccountAtBlockID(ctx, req)
 	if err != nil {
 		if status.Code(err) == codes.Unavailable {
 			b.connFactory.InvalidateExecutionAPIClient(execNode.Address)

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -120,7 +120,7 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 		return []flow.BlockEvents{}, nil
 	}
 
-	req := execproto.GetEventsForBlockIDsRequest{
+	req := &execproto.GetEventsForBlockIDsRequest{
 		Type:     eventType,
 		BlockIds: convert.IdentifiersToMessages(blockIDs),
 	}
@@ -193,7 +193,7 @@ func verifyAndConvertToAccessEvents(execEvents []*execproto.GetEventsForBlockIDs
 
 func (b *backendEvents) getEventsFromAnyExeNode(ctx context.Context,
 	execNodes flow.IdentityList,
-	req execproto.GetEventsForBlockIDsRequest) (*execproto.GetEventsForBlockIDsResponse, *flow.Identity, error) {
+	req *execproto.GetEventsForBlockIDsRequest) (*execproto.GetEventsForBlockIDsResponse, *flow.Identity, error) {
 	var errors *multierror.Error
 	// try to get events from one of the execution nodes
 	for _, execNode := range execNodes {
@@ -208,14 +208,14 @@ func (b *backendEvents) getEventsFromAnyExeNode(ctx context.Context,
 
 func (b *backendEvents) tryGetEvents(ctx context.Context,
 	execNode *flow.Identity,
-	req execproto.GetEventsForBlockIDsRequest) (*execproto.GetEventsForBlockIDsResponse, error) {
+	req *execproto.GetEventsForBlockIDsRequest) (*execproto.GetEventsForBlockIDsResponse, error) {
 	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, err
 	}
 	defer closer.Close()
 
-	resp, err := execRPCClient.GetEventsForBlockIDs(ctx, &req)
+	resp, err := execRPCClient.GetEventsForBlockIDs(ctx, req)
 	if err != nil {
 		if status.Code(err) == codes.Unavailable {
 			b.connFactory.InvalidateExecutionAPIClient(execNode.Address)

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -90,7 +90,7 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 	arguments [][]byte,
 ) ([]byte, error) {
 
-	execReq := execproto.ExecuteScriptAtBlockIDRequest{
+	execReq := &execproto.ExecuteScriptAtBlockIDRequest{
 		BlockId:   blockID[:],
 		Script:    script,
 		Arguments: arguments,
@@ -165,14 +165,14 @@ func (b *backendScripts) shouldLogScript(execTime time.Time, scriptHash [16]byte
 	}
 }
 
-func (b *backendScripts) tryExecuteScript(ctx context.Context, execNode *flow.Identity, req execproto.ExecuteScriptAtBlockIDRequest) ([]byte, error) {
+func (b *backendScripts) tryExecuteScript(ctx context.Context, execNode *flow.Identity, req *execproto.ExecuteScriptAtBlockIDRequest) ([]byte, error) {
 	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client for execution node %s: %v", execNode.String(), err)
 	}
 	defer closer.Close()
 
-	execResp, err := execRPCClient.ExecuteScriptAtBlockID(ctx, &req)
+	execResp, err := execRPCClient.ExecuteScriptAtBlockID(ctx, req)
 	if err != nil {
 		if status.Code(err) == codes.Unavailable {
 			b.connFactory.InvalidateExecutionAPIClient(execNode.Address)

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -309,7 +309,7 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 		return nil, rpc.ConvertStorageError(err)
 	}
 
-	req := execproto.GetTransactionsByBlockIDRequest{
+	req := &execproto.GetTransactionsByBlockIDRequest{
 		BlockId: blockID[:],
 	}
 	execNodes, err := executionNodesForBlockID(ctx, blockID, b.executionReceipts, b.state, b.log)
@@ -421,7 +421,7 @@ func (b *backendTransactions) GetTransactionResultByIndex(
 	}
 
 	// create request and forward to EN
-	req := execproto.GetTransactionByIndexRequest{
+	req := &execproto.GetTransactionByIndexRequest{
 		BlockId: blockID[:],
 		Index:   index,
 	}
@@ -641,7 +641,7 @@ func (b *backendTransactions) getTransactionResultFromExecutionNode(
 ) ([]flow.Event, uint32, string, error) {
 
 	// create an execution API request for events at blockID and transactionID
-	req := execproto.GetTransactionResultRequest{
+	req := &execproto.GetTransactionResultRequest{
 		BlockId:       blockID[:],
 		TransactionId: transactionID,
 	}
@@ -675,7 +675,7 @@ func (b *backendTransactions) NotifyFinalizedBlockHeight(height uint64) {
 func (b *backendTransactions) getTransactionResultFromAnyExeNode(
 	ctx context.Context,
 	execNodes flow.IdentityList,
-	req execproto.GetTransactionResultRequest,
+	req *execproto.GetTransactionResultRequest,
 ) (*execproto.GetTransactionResultResponse, error) {
 	var errs *multierror.Error
 	logAnyError := func() {
@@ -707,7 +707,7 @@ func (b *backendTransactions) getTransactionResultFromAnyExeNode(
 func (b *backendTransactions) tryGetTransactionResult(
 	ctx context.Context,
 	execNode *flow.Identity,
-	req execproto.GetTransactionResultRequest,
+	req *execproto.GetTransactionResultRequest,
 ) (*execproto.GetTransactionResultResponse, error) {
 	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
@@ -715,7 +715,7 @@ func (b *backendTransactions) tryGetTransactionResult(
 	}
 	defer closer.Close()
 
-	resp, err := execRPCClient.GetTransactionResult(ctx, &req)
+	resp, err := execRPCClient.GetTransactionResult(ctx, req)
 	if err != nil {
 		if status.Code(err) == codes.Unavailable {
 			b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
@@ -728,7 +728,7 @@ func (b *backendTransactions) tryGetTransactionResult(
 func (b *backendTransactions) getTransactionResultsByBlockIDFromAnyExeNode(
 	ctx context.Context,
 	execNodes flow.IdentityList,
-	req execproto.GetTransactionsByBlockIDRequest,
+	req *execproto.GetTransactionsByBlockIDRequest,
 ) (*execproto.GetTransactionResultsResponse, error) {
 	var errs *multierror.Error
 
@@ -765,7 +765,7 @@ func (b *backendTransactions) getTransactionResultsByBlockIDFromAnyExeNode(
 func (b *backendTransactions) tryGetTransactionResultsByBlockID(
 	ctx context.Context,
 	execNode *flow.Identity,
-	req execproto.GetTransactionsByBlockIDRequest,
+	req *execproto.GetTransactionsByBlockIDRequest,
 ) (*execproto.GetTransactionResultsResponse, error) {
 	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
@@ -773,7 +773,7 @@ func (b *backendTransactions) tryGetTransactionResultsByBlockID(
 	}
 	defer closer.Close()
 
-	resp, err := execRPCClient.GetTransactionResultsByBlockID(ctx, &req)
+	resp, err := execRPCClient.GetTransactionResultsByBlockID(ctx, req)
 	if err != nil {
 		if status.Code(err) == codes.Unavailable {
 			b.connFactory.InvalidateExecutionAPIClient(execNode.Address)
@@ -786,7 +786,7 @@ func (b *backendTransactions) tryGetTransactionResultsByBlockID(
 func (b *backendTransactions) getTransactionResultByIndexFromAnyExeNode(
 	ctx context.Context,
 	execNodes flow.IdentityList,
-	req execproto.GetTransactionByIndexRequest,
+	req *execproto.GetTransactionByIndexRequest,
 ) (*execproto.GetTransactionResultResponse, error) {
 	var errs *multierror.Error
 	logAnyError := func() {
@@ -824,7 +824,7 @@ func (b *backendTransactions) getTransactionResultByIndexFromAnyExeNode(
 func (b *backendTransactions) tryGetTransactionResultByIndex(
 	ctx context.Context,
 	execNode *flow.Identity,
-	req execproto.GetTransactionByIndexRequest,
+	req *execproto.GetTransactionByIndexRequest,
 ) (*execproto.GetTransactionResultResponse, error) {
 	execRPCClient, closer, err := b.connFactory.GetExecutionAPIClient(execNode.Address)
 	if err != nil {
@@ -832,7 +832,7 @@ func (b *backendTransactions) tryGetTransactionResultByIndex(
 	}
 	defer closer.Close()
 
-	resp, err := execRPCClient.GetTransactionResultByIndex(ctx, &req)
+	resp, err := execRPCClient.GetTransactionResultByIndex(ctx, req)
 	if err != nil {
 		if status.Code(err) == codes.Unavailable {
 			b.connFactory.InvalidateExecutionAPIClient(execNode.Address)

--- a/engine/execution/rpc/engine_test.go
+++ b/engine/execution/rpc/engine_test.go
@@ -6,11 +6,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/onflow/flow/protobuf/go/flow/entities"
 	"github.com/onflow/flow/protobuf/go/flow/execution"
@@ -268,7 +270,8 @@ func (suite *Suite) TestGetAccountAtBlockID() {
 		actualAccount := resp.GetAccount()
 		expectedAccount, err := convert.AccountToMessage(&serviceAccount)
 		suite.Require().NoError(err)
-		suite.Require().Equal(*expectedAccount, *actualAccount)
+		suite.Require().Empty(
+			cmp.Diff(expectedAccount, actualAccount, protocmp.Transform()))
 		mockEngine.AssertExpectations(suite.T())
 	})
 


### PR DESCRIPTION
This is a cleanup for the switch to Protobuf v2 API.

* It is now forbidden to copy ptotobuf messages by value since they have [DoNotCopy](https://godoc.org/google.golang.org/protobuf/internal/pragma#DoNotCopy) embedded in them.  So switch to passing pointers.
* It is incorrect to compare protobuf messages by value w/ [DeepEqual](https://developers.google.com/protocol-buffers/docs/reference/go/faq#deepequal), so switched tests to use `go-cmp` and [protocmp.Transform()](https://pkg.go.dev/google.golang.org/protobuf/testing/protocmp#Transform)

ref: https://github.com/onflow/flow/pull/1215