### PR TITLE
Change RegisterUpdates's return type

### DIFF
--- a/engine/execution/state/delta/delta_test.go
+++ b/engine/execution/state/delta/delta_test.go
@@ -115,7 +115,7 @@ func TestDelta_MergeWith(t *testing.T) {
 	})
 }
 
-func TestDelta_RegisterUpdatesAreSorted(t *testing.T) {
+func TestDelta_UpdatedRegistersAreSorted(t *testing.T) {
 
 	d := delta.NewDelta()
 
@@ -142,8 +142,7 @@ func TestDelta_RegisterUpdatesAreSorted(t *testing.T) {
 	d.Set(data[0].Key.Owner, data[0].Key.Key, data[0].Value)
 	d.Set(data[4].Key.Owner, data[4].Key.Key, data[4].Value)
 
-	retKeys, retValues := d.RegisterUpdates()
+	ret := d.UpdatedRegisters()
 
-	assert.Equal(t, data.IDs(), retKeys)
-	assert.Equal(t, data.Values(), retValues)
+	assert.Equal(t, data, ret)
 }

--- a/engine/execution/state/delta/view.go
+++ b/engine/execution/state/delta/view.go
@@ -123,8 +123,8 @@ func (v *View) AllRegisters() []flow.RegisterID {
 }
 
 // RegisterUpdates returns a list of register updates
-func (v *View) RegisterUpdates() ([]flow.RegisterID, []flow.RegisterValue) {
-	return v.Delta().RegisterUpdates()
+func (v *View) UpdatedRegisters() flow.RegisterEntries {
+	return v.Delta().UpdatedRegisters()
 }
 
 // Get gets a register value from this view.

--- a/engine/execution/state/mock/register_updates_holder.go
+++ b/engine/execution/state/mock/register_updates_holder.go
@@ -12,29 +12,20 @@ type RegisterUpdatesHolder struct {
 	mock.Mock
 }
 
-// RegisterUpdates provides a mock function with given fields:
-func (_m *RegisterUpdatesHolder) RegisterUpdates() ([]flow.RegisterID, [][]byte) {
+// UpdatedRegisters provides a mock function with given fields:
+func (_m *RegisterUpdatesHolder) UpdatedRegisters() flow.RegisterEntries {
 	ret := _m.Called()
 
-	var r0 []flow.RegisterID
-	if rf, ok := ret.Get(0).(func() []flow.RegisterID); ok {
+	var r0 flow.RegisterEntries
+	if rf, ok := ret.Get(0).(func() flow.RegisterEntries); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]flow.RegisterID)
+			r0 = ret.Get(0).(flow.RegisterEntries)
 		}
 	}
 
-	var r1 [][]byte
-	if rf, ok := ret.Get(1).(func() [][]byte); ok {
-		r1 = rf()
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([][]byte)
-		}
-	}
-
-	return r0, r1
+	return r0
 }
 
 type mockConstructorTestingTNewRegisterUpdatesHolder interface {

--- a/fvm/environment/derived_data_invalidator.go
+++ b/fvm/environment/derived_data_invalidator.go
@@ -38,11 +38,12 @@ func NewDerivedDataInvalidator(
 }
 
 func meterParamOverridesUpdated(env *facadeEnvironment) bool {
-	updatedRegisterIds, _ := env.txnState.RegisterUpdates()
+	// TODO(patrick): expose lighter weight api to list updated ids only
+	updatedRegisters := env.txnState.UpdatedRegisters()
 
 	serviceAccount := string(env.chain.ServiceAddress().Bytes())
 	storageDomain := common.PathDomainStorage.Identifier()
-	for _, registerId := range updatedRegisterIds {
+	for _, registerId := range updatedRegisters.IDs() {
 		// The meter param override values are stored in the service account.
 		if registerId.Owner != serviceAccount {
 			continue

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -315,12 +315,12 @@ func Test_Programs(t *testing.T) {
 		require.IsType(t, entryB.State.View(), &delta.View{})
 		deltaB := entryB.State.View().(*delta.View)
 
-		idsA, valuesA := deltaA.Delta().RegisterUpdates()
-		for i, id := range idsA {
-			v, has := deltaB.Delta().Get(id.Owner, id.Key)
+		entriesA := deltaA.Delta().UpdatedRegisters()
+		for _, entry := range entriesA {
+			v, has := deltaB.Delta().Get(entry.Key.Owner, entry.Key.Key)
 			require.True(t, has)
 
-			require.Equal(t, valuesA[i], v)
+			require.Equal(t, entry.Value, v)
 		}
 
 		for id, registerA := range deltaA.Interactions().Reads {

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -146,9 +146,9 @@ func (s *State) InteractionUsed() uint64 {
 	return s.meter.TotalBytesOfStorageInteractions()
 }
 
-// RegisterUpdates returns the lists of register id / value that were updated.
-func (s *State) RegisterUpdates() ([]flow.RegisterID, []flow.RegisterValue) {
-	return s.view.RegisterUpdates()
+// UpdatedRegisters returns the lists of register id / value that were updated.
+func (s *State) UpdatedRegisters() flow.RegisterEntries {
+	return s.view.UpdatedRegisters()
 }
 
 // Get returns a register value given owner and key

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -404,11 +404,8 @@ func (s *TransactionState) ViewForTestingOnly() View {
 	return s.currentState().View()
 }
 
-func (s *TransactionState) RegisterUpdates() (
-	[]flow.RegisterID,
-	[]flow.RegisterValue,
-) {
-	return s.currentState().RegisterUpdates()
+func (s *TransactionState) UpdatedRegisters() flow.RegisterEntries {
+	return s.currentState().UpdatedRegisters()
 }
 
 // EnableAllLimitEnforcements enables all the limits

--- a/fvm/state/view.go
+++ b/fvm/state/view.go
@@ -8,7 +8,7 @@ type View interface {
 	NewChild() View
 	MergeView(child View) error
 	DropDelta() // drops all the delta changes
-	RegisterUpdates() ([]flow.RegisterID, []flow.RegisterValue)
+	UpdatedRegisters() flow.RegisterEntries
 	AllRegisters() []flow.RegisterID
 	Ledger
 }

--- a/fvm/utils/view.go
+++ b/fvm/utils/view.go
@@ -86,14 +86,17 @@ func (v *SimpleView) AllRegisters() []flow.RegisterID {
 	return res
 }
 
-func (v *SimpleView) RegisterUpdates() ([]flow.RegisterID, []flow.RegisterValue) {
-	ids := make([]flow.RegisterID, 0, len(v.Ledger.RegisterUpdated))
-	values := make([]flow.RegisterValue, 0, len(v.Ledger.RegisterUpdated))
+func (v *SimpleView) UpdatedRegisters() flow.RegisterEntries {
+	entries := make(flow.RegisterEntries, 0, len(v.Ledger.RegisterUpdated))
 	for key := range v.Ledger.RegisterUpdated {
-		ids = append(ids, key)
-		values = append(values, v.Ledger.Registers[key])
+		entries = append(
+			entries,
+			flow.RegisterEntry{
+				Key:   key,
+				Value: v.Ledger.Registers[key],
+			})
 	}
-	return ids, values
+	return entries
 }
 
 func (v *SimpleView) Touch(owner, key string) error {

--- a/ledger/partial/ledger_test.go
+++ b/ledger/partial/ledger_test.go
@@ -127,12 +127,10 @@ func TestProofsForEmptyRegisters(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, v)
 
-	ids, values := view.Delta().RegisterUpdates()
-	updated, err := ledger.NewUpdate(
-		emptyState,
-		executionState.RegisterIDSToKeys(ids),
-		executionState.RegisterValuesToValues(values),
-	)
+	keys, values := executionState.RegisterEntriesToKeysValues(
+		view.Delta().UpdatedRegisters())
+
+	updated, err := ledger.NewUpdate(emptyState, keys, values)
 	require.NoError(t, err)
 
 	allRegisters := view.Interactions().AllRegisters()

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -261,13 +261,13 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 	// applying chunk delta (register updates at chunk level) to the partial trie
 	// this returns the expected end state commitment after updates and the list of
 	// register keys that was not provided by the chunk data package (err).
-	regs, values := chunkView.Delta().RegisterUpdates()
+	keys, values := executionState.RegisterEntriesToKeysValues(
+		chunkView.Delta().UpdatedRegisters())
 
 	update, err := ledger.NewUpdate(
 		ledger.State(chunkDataPack.StartState),
-		executionState.RegisterIDSToKeys(regs),
-		executionState.RegisterValuesToValues(values),
-	)
+		keys,
+		values)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create ledger update: %w", err)
 	}

--- a/utils/debug/remoteView.go
+++ b/utils/debug/remoteView.go
@@ -195,7 +195,7 @@ func (v *RemoteView) AllRegisters() []flow.RegisterID {
 	panic("Not implemented yet")
 }
 
-func (v *RemoteView) RegisterUpdates() ([]flow.RegisterID, []flow.RegisterValue) {
+func (v *RemoteView) UpdatedRegisters() flow.RegisterEntries {
 	panic("Not implemented yet")
 }
 


### PR DESCRIPTION
return RegisterEntries instead of ([]RegisterID, []RegisterValue)

it's safer, and we can potentially skip sorting in the future.  It probably does less work as well.