### PR TITLE
[CI] Remove --ssh flag from docker build for util

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,7 +551,7 @@ docker-all-tools: tool-util tool-remove-execution-fork
 
 PHONY: docker-build-util
 docker-build-util:
-	docker build -f cmd/Dockerfile --ssh default --build-arg TARGET=./cmd/util --build-arg GOARCH=$(GOARCH) --target production \
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/util --build-arg GOARCH=$(GOARCH) --target production \
 		-t "$(CONTAINER_REGISTRY)/util:latest" -t "$(CONTAINER_REGISTRY)/util:$(SHORT_COMMIT)" -t "$(CONTAINER_REGISTRY)/util:$(IMAGE_TAG)" .
 
 PHONY: tool-util


### PR DESCRIPTION
The `--ssh default` flag is only needed for building when the repo contains a dependency within a private repo. This is generally not needed so removing.

Running with this flag causes CI builds to fail: https://github.com/onflow/flow-go/actions/runs/3896458835/jobs/6653020995