### PR TITLE
[General] Reporting node info metrics

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -671,6 +671,14 @@ func (fnb *FlowNodeBuilder) initMetrics() error {
 		fnb.Component("mempools metrics", func(node *NodeConfig) (module.ReadyDoneAware, error) {
 			return mempools, nil
 		})
+
+		nodeInfoMetrics := metrics.NewNodeInfoCollector(fnb.MetricsRegisterer)
+
+		// metrics enabled, report node info metrics as post init event
+		fnb.PostInit(func(nodeConfig *NodeConfig) error {
+			nodeInfoMetrics.NodeInfo(build.Semver(), build.Commit(), nodeConfig.SporkID.String())
+			return nil
+		})
 	}
 	return nil
 }

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -672,10 +672,9 @@ func (fnb *FlowNodeBuilder) initMetrics() error {
 			return mempools, nil
 		})
 
-		nodeInfoMetrics := metrics.NewNodeInfoCollector(fnb.MetricsRegisterer)
-
 		// metrics enabled, report node info metrics as post init event
 		fnb.PostInit(func(nodeConfig *NodeConfig) error {
+			nodeInfoMetrics := metrics.NewNodeInfoCollector()
 			nodeInfoMetrics.NodeInfo(build.Semver(), build.Commit(), nodeConfig.SporkID.String())
 			return nil
 		})

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -675,7 +675,11 @@ func (fnb *FlowNodeBuilder) initMetrics() error {
 		// metrics enabled, report node info metrics as post init event
 		fnb.PostInit(func(nodeConfig *NodeConfig) error {
 			nodeInfoMetrics := metrics.NewNodeInfoCollector()
-			nodeInfoMetrics.NodeInfo(build.Semver(), build.Commit(), nodeConfig.SporkID.String())
+			protocolVersion, err := fnb.RootSnapshot.Params().ProtocolVersion()
+			if err != nil {
+				return fmt.Errorf("could not query root snapshoot protocol version: %w", err)
+			}
+			nodeInfoMetrics.NodeInfo(build.Semver(), build.Commit(), nodeConfig.SporkID.String(), protocolVersion)
 			return nil
 		})
 	}

--- a/module/metrics/node_info.go
+++ b/module/metrics/node_info.go
@@ -1,9 +1,10 @@
 package metrics
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"strconv"
 )
 
 // NodeInfoCollector implements metrics to report static information about node.

--- a/module/metrics/node_info.go
+++ b/module/metrics/node_info.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// NodeInfoCollector implements metrics to report static information about node.
+// Such information can include: version, commit, sporkID.
+type NodeInfoCollector struct {
+	nodeInfo *prometheus.GaugeVec
+}
+
+const (
+	sporkIDLabel = "spork_id"
+	versionLabel = "version"
+	commitLabel  = "commit"
+)
+
+func NewNodeInfoCollector(register prometheus.Registerer) *NodeInfoCollector {
+	collector := &NodeInfoCollector{
+		nodeInfo: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name:      "node_info",
+			Namespace: "general",
+			Help:      "report general information about node, such information can include version, sporkID, commit hash, etc",
+		}, []string{"key", "value"}),
+	}
+	register.MustRegister(collector.nodeInfo)
+
+	return collector
+}
+
+func (sc *NodeInfoCollector) NodeInfo(version, commit, sporkID string) {
+	sc.nodeInfo.WithLabelValues(versionLabel, version)
+	sc.nodeInfo.WithLabelValues(commitLabel, commit)
+	sc.nodeInfo.WithLabelValues(sporkIDLabel, sporkID)
+}

--- a/module/metrics/node_info.go
+++ b/module/metrics/node_info.go
@@ -17,7 +17,7 @@ const (
 	commitLabel  = "commit"
 )
 
-func NewNodeInfoCollector(register prometheus.Registerer) *NodeInfoCollector {
+func NewNodeInfoCollector() *NodeInfoCollector {
 	collector := &NodeInfoCollector{
 		nodeInfo: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name:      "node_info",
@@ -25,7 +25,6 @@ func NewNodeInfoCollector(register prometheus.Registerer) *NodeInfoCollector {
 			Help:      "report general information about node, such information can include version, sporkID, commit hash, etc",
 		}, []string{"key", "value"}),
 	}
-	register.MustRegister(collector.nodeInfo)
 
 	return collector
 }

--- a/module/metrics/node_info.go
+++ b/module/metrics/node_info.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"strconv"
 )
 
 // NodeInfoCollector implements metrics to report static information about node.
@@ -12,9 +13,10 @@ type NodeInfoCollector struct {
 }
 
 const (
-	sporkIDLabel = "spork_id"
-	versionLabel = "version"
-	commitLabel  = "commit"
+	sporkIDLabel         = "spork_id"
+	versionLabel         = "version"
+	commitLabel          = "commit"
+	protocolVersionLabel = "protocol_version"
 )
 
 func NewNodeInfoCollector() *NodeInfoCollector {
@@ -29,8 +31,9 @@ func NewNodeInfoCollector() *NodeInfoCollector {
 	return collector
 }
 
-func (sc *NodeInfoCollector) NodeInfo(version, commit, sporkID string) {
+func (sc *NodeInfoCollector) NodeInfo(version, commit, sporkID string, protocolVersion uint) {
 	sc.nodeInfo.WithLabelValues(versionLabel, version)
 	sc.nodeInfo.WithLabelValues(commitLabel, commit)
 	sc.nodeInfo.WithLabelValues(sporkIDLabel, sporkID)
+	sc.nodeInfo.WithLabelValues(protocolVersionLabel, strconv.FormatUint(uint64(protocolVersion), 10))
 }

--- a/module/metrics/node_info_test.go
+++ b/module/metrics/node_info_test.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestNodeInfoCollector_NodeInfo tests if node info collector reports desired metrics
+func TestNodeInfoCollector_NodeInfo(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	collector := NewNodeInfoCollector(reg)
+	version := "0.29"
+	commit := "63cec231136914941e2358de2054a6ef71ea3c99"
+	sporkID := unittest.IdentifierFixture().String()
+	collector.NodeInfo(version, commit, sporkID)
+	metricsFamilies, err := reg.Gather()
+	require.NoError(t, err)
+
+	assertReported := func(value string) {
+		for _, metric := range metricsFamilies[0].Metric {
+			for _, label := range metric.GetLabel() {
+				if label.GetValue() == value {
+					return
+				}
+			}
+		}
+		assert.Failf(t, "metric not found", "except to find value %s", value)
+	}
+
+	for _, value := range []string{version, commit, sporkID} {
+		assertReported(value)
+	}
+	//t.Logf(proto.MarshalTextString(metricsFamilies[0]))
+}

--- a/module/metrics/node_info_test.go
+++ b/module/metrics/node_info_test.go
@@ -1,11 +1,13 @@
 package metrics
 
 import (
-	"github.com/onflow/flow-go/utils/unittest"
+	"testing"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 // TestNodeInfoCollector_NodeInfo tests if node info collector reports desired metrics

--- a/module/metrics/node_info_test.go
+++ b/module/metrics/node_info_test.go
@@ -13,7 +13,8 @@ import (
 // TestNodeInfoCollector_NodeInfo tests if node info collector reports desired metrics
 func TestNodeInfoCollector_NodeInfo(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	collector := NewNodeInfoCollector(reg)
+	prometheus.DefaultRegisterer = reg
+	collector := NewNodeInfoCollector()
 	version := "0.29"
 	commit := "63cec231136914941e2358de2054a6ef71ea3c99"
 	sporkID := unittest.IdentifierFixture().String()

--- a/module/metrics/node_info_test.go
+++ b/module/metrics/node_info_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,7 +19,8 @@ func TestNodeInfoCollector_NodeInfo(t *testing.T) {
 	version := "0.29"
 	commit := "63cec231136914941e2358de2054a6ef71ea3c99"
 	sporkID := unittest.IdentifierFixture().String()
-	collector.NodeInfo(version, commit, sporkID)
+	protocolVersion := uint(10076)
+	collector.NodeInfo(version, commit, sporkID, protocolVersion)
 	metricsFamilies, err := reg.Gather()
 	require.NoError(t, err)
 
@@ -33,8 +35,8 @@ func TestNodeInfoCollector_NodeInfo(t *testing.T) {
 		assert.Failf(t, "metric not found", "except to find value %s", value)
 	}
 
-	for _, value := range []string{version, commit, sporkID} {
+	protocolVersionAsString := strconv.FormatUint(uint64(protocolVersion), 10)
+	for _, value := range []string{version, commit, sporkID, protocolVersionAsString} {
 		assertReported(value)
 	}
-	//t.Logf(proto.MarshalTextString(metricsFamilies[0]))
 }


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/3597

### Context 

This PR implements reporting of static metrics that are common for each node type. 
Currently we report _sporkID_, _version_ and _commit_. 
Prometheus doesn't support reporting static metrics, the recommended way is to use `GaugeVec` with dummy data, the metrics itself are reported as gauge labels. 
Metrics are reported as part of startup process in scaffold code, this allows to utilize same logic for all nodes.