### PR TITLE
[CI] Add github action to build boot-tools on demand - v0.29 backport

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,57 @@
+name: Build Tools
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tagged commit to build tools against'
+        required: true
+        type: string
+      promote:
+        description: 'Should this build be promoted to the official boot-tools?'
+        required: false
+        type: boolean
+
+jobs:
+  build-publish:
+    name: Build boot tools
+    runs-on: ubuntu-latest
+    steps:
+    - id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.GCR_SERVICE_KEY }} # TODO: we need a new key to allow uploads
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.19'
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: flow
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag }}
+    - name: Build relic
+      run: make crypto_setup_gopath
+    - name: Build and upload boot-tools
+      run: |
+        make tool-bootstrap tool-transit
+        mkdir boot-tools
+        mv bootstrap transit boot-tools/
+        tar -czf boot-tools.tar ./boot-tools/
+        gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/boot-tools.tar
+    - name: Build and upload util
+      run: |
+        make tool-util
+        tar -czf util.tar util
+        gsutil cp util.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/util.tar
+    - name: Promote boot-tools
+      run: |
+        if [[ "${{ inputs.promote }}" = true ]]; then
+          echo "promoting boot-tools.tar"
+          gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/boot-tools.tar
+        else
+          echo "not promoting boot-tools.tar"
+        fi

--- a/Makefile
+++ b/Makefile
@@ -552,7 +552,7 @@ docker-all-tools: tool-util tool-remove-execution-fork
 
 PHONY: docker-build-util
 docker-build-util:
-	docker build -f cmd/Dockerfile --ssh default --build-arg TARGET=./cmd/util --build-arg GOARCH=$(GOARCH) --target production \
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/util --build-arg GOARCH=$(GOARCH) --target production \
 		-t "$(CONTAINER_REGISTRY)/util:latest" -t "$(CONTAINER_REGISTRY)/util:$(SHORT_COMMIT)" -t "$(CONTAINER_REGISTRY)/util:$(IMAGE_TAG)" .
 
 PHONY: tool-util


### PR DESCRIPTION
backports: https://github.com/onflow/flow-go/pull/3787 and https://github.com/onflow/flow-go/pull/3798