### PR TITLE
remove RegisterIDToKey & RegisterValuesToValues from execution state

### DIFF
--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -154,22 +154,6 @@ func makeQuery(commitment flow.StateCommitment, ids []flow.RegisterID) (*ledger.
 	return ledger.NewQuery(ledger.State(commitment), keys)
 }
 
-func RegisterIDSToKeys(ids []flow.RegisterID) []ledger.Key {
-	keys := make([]ledger.Key, len(ids))
-	for i, id := range ids {
-		keys[i] = RegisterIDToKey(id)
-	}
-	return keys
-}
-
-func RegisterValuesToValues(values []flow.RegisterValue) []ledger.Value {
-	vals := make([]ledger.Value, len(values))
-	for i, value := range values {
-		vals[i] = value
-	}
-	return vals
-}
-
 func RegisterEntriesToKeysValues(
 	entries flow.RegisterEntries,
 ) (

--- a/ledger/partial/ledger_test.go
+++ b/ledger/partial/ledger_test.go
@@ -134,7 +134,11 @@ func TestProofsForEmptyRegisters(t *testing.T) {
 	require.NoError(t, err)
 
 	allRegisters := view.Interactions().AllRegisters()
-	allKeys := executionState.RegisterIDSToKeys(allRegisters)
+	allKeys := make([]ledger.Key, len(allRegisters))
+	for i, id := range allRegisters {
+		allKeys[i] = executionState.RegisterIDToKey(id)
+	}
+
 	newState := updated.State()
 
 	proofQuery, err := ledger.NewQuery(newState, allKeys)

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -239,10 +239,16 @@ func GetBaselineVerifiableChunk(t *testing.T, script string, system bool) *verif
 	value2 := []byte{'b'}
 	UpdatedValue2 := []byte{'B'}
 
-	ids := make([]flow.RegisterID, 0)
-	values := make([]flow.RegisterValue, 0)
-	ids = append(ids, id1, id2)
-	values = append(values, value1, value2)
+	entries := flow.RegisterEntries{
+		{
+			Key:   id1,
+			Value: value1,
+		},
+		{
+			Key:   id2,
+			Value: value2,
+		},
+	}
 
 	var verifiableChunkData verification.VerifiableChunkData
 
@@ -258,12 +264,8 @@ func GetBaselineVerifiableChunk(t *testing.T, script string, system bool) *verif
 		<-compactor.Done()
 	}()
 
-	keys := executionState.RegisterIDSToKeys(ids)
-	update, err := ledger.NewUpdate(
-		f.InitialState(),
-		keys,
-		executionState.RegisterValuesToValues(values),
-	)
+	keys, values := executionState.RegisterEntriesToKeysValues(entries)
+	update, err := ledger.NewUpdate(f.InitialState(), keys, values)
 
 	require.NoError(t, err)
 
@@ -276,15 +278,15 @@ func GetBaselineVerifiableChunk(t *testing.T, script string, system bool) *verif
 	proof, err := f.Prove(query)
 	require.NoError(t, err)
 
-	ids = []flow.RegisterID{id2}
-	values = [][]byte{UpdatedValue2}
+	entries = flow.RegisterEntries{
+		{
+			Key:   id2,
+			Value: UpdatedValue2,
+		},
+	}
 
-	keys = executionState.RegisterIDSToKeys(ids)
-	update, err = ledger.NewUpdate(
-		startState,
-		keys,
-		executionState.RegisterValuesToValues(values),
-	)
+	keys, values = executionState.RegisterEntriesToKeysValues(entries)
+	update, err = ledger.NewUpdate(startState, keys, values)
 	require.NoError(t, err)
 
 	endState, _, err := f.Set(update)


### PR DESCRIPTION
they've been replaced by RegisterEntriesToKeysValues