### PR TITLE
Convert service event as part of fvm execution

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -34,6 +35,7 @@ import (
 	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/model/convert/fixtures"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/epochs"
@@ -403,22 +405,27 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		serviceEvents, err := systemcontracts.ServiceEventsForChain(execCtx.Chain.ChainID())
 		require.NoError(t, err)
 
-		serviceEventA := cadence.Event{
-			EventType: &cadence.EventType{
-				Location: common.AddressLocation{
-					Address: common.Address(serviceEvents.EpochSetup.Address),
-				},
-				QualifiedIdentifier: serviceEvents.EpochSetup.QualifiedIdentifier(),
-			},
+		payload, err := json.Decode(nil, []byte(fixtures.EpochSetupFixtureJSON))
+		require.NoError(t, err)
+
+		serviceEventA, ok := payload.(cadence.Event)
+		require.True(t, ok)
+
+		serviceEventA.EventType.Location = common.AddressLocation{
+			Address: common.Address(serviceEvents.EpochSetup.Address),
 		}
-		serviceEventB := cadence.Event{
-			EventType: &cadence.EventType{
-				Location: common.AddressLocation{
-					Address: common.Address(serviceEvents.EpochCommit.Address),
-				},
-				QualifiedIdentifier: serviceEvents.EpochCommit.QualifiedIdentifier(),
-			},
+		serviceEventA.EventType.QualifiedIdentifier = serviceEvents.EpochSetup.QualifiedIdentifier()
+
+		payload, err = json.Decode(nil, []byte(fixtures.EpochCommitFixtureJSON))
+		require.NoError(t, err)
+
+		serviceEventB, ok := payload.(cadence.Event)
+		require.True(t, ok)
+
+		serviceEventB.EventType.Location = common.AddressLocation{
+			Address: common.Address(serviceEvents.EpochCommit.Address),
 		}
+		serviceEventB.EventType.QualifiedIdentifier = serviceEvents.EpochCommit.QualifiedIdentifier()
 
 		// events to emit for each iteration/transaction
 		events := make([][]cadence.Event, totalTransactionCount)

--- a/engine/execution/messages.go
+++ b/engine/execution/messages.go
@@ -22,6 +22,7 @@ type ComputationResult struct {
 	Events                 []flow.EventsList
 	EventsHashes           []flow.Identifier
 	ServiceEvents          flow.EventsList
+	ConvertedServiceEvents flow.ServiceEventList
 	TransactionResults     []flow.TransactionResult
 	TransactionResultIndex []int
 	ComputationIntensities meter.MeteredComputationIntensities
@@ -36,6 +37,7 @@ func NewEmptyComputationResult(block *entity.ExecutableBlock) *ComputationResult
 		ExecutableBlock:        block,
 		Events:                 make([]flow.EventsList, numCollections),
 		ServiceEvents:          make(flow.EventsList, 0),
+		ConvertedServiceEvents: make(flow.ServiceEventList, 0),
 		TransactionResults:     make([]flow.TransactionResult, 0),
 		TransactionResultIndex: make([]int, 0),
 		StateCommitments:       make([]flow.StateCommitment, 0, numCollections),
@@ -54,6 +56,9 @@ func (cr *ComputationResult) AddTransactionResult(
 		cr.Events[collectionIndex],
 		txn.Events...)
 	cr.ServiceEvents = append(cr.ServiceEvents, txn.ServiceEvents...)
+	cr.ConvertedServiceEvents = append(
+		cr.ConvertedServiceEvents,
+		txn.ConvertedServiceEvents...)
 
 	txnResult := flow.TransactionResult{
 		TransactionID:   txn.ID,

--- a/fvm/environment/env.go
+++ b/fvm/environment/env.go
@@ -38,8 +38,9 @@ type Environment interface {
 	Logs() []string
 
 	// EventEmitter
-	Events() []flow.Event
-	ServiceEvents() []flow.Event
+	Events() flow.EventsList
+	ServiceEvents() flow.EventsList
+	ConvertedServiceEvents() flow.ServiceEventList
 
 	// SystemContracts
 	AccountsStorageCapacity(

--- a/fvm/environment/mock/environment.go
+++ b/fvm/environment/mock/environment.go
@@ -284,6 +284,22 @@ func (_m *Environment) ComputationUsed() uint64 {
 	return r0
 }
 
+// ConvertedServiceEvents provides a mock function with given fields:
+func (_m *Environment) ConvertedServiceEvents() flow.ServiceEventList {
+	ret := _m.Called()
+
+	var r0 flow.ServiceEventList
+	if rf, ok := ret.Get(0).(func() flow.ServiceEventList); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(flow.ServiceEventList)
+		}
+	}
+
+	return r0
+}
+
 // CreateAccount provides a mock function with given fields: payer
 func (_m *Environment) CreateAccount(payer common.Address) (common.Address, error) {
 	ret := _m.Called(payer)
@@ -368,15 +384,15 @@ func (_m *Environment) EmitEvent(_a0 cadence.Event) error {
 }
 
 // Events provides a mock function with given fields:
-func (_m *Environment) Events() []flow.Event {
+func (_m *Environment) Events() flow.EventsList {
 	ret := _m.Called()
 
-	var r0 []flow.Event
-	if rf, ok := ret.Get(0).(func() []flow.Event); ok {
+	var r0 flow.EventsList
+	if rf, ok := ret.Get(0).(func() flow.EventsList); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]flow.Event)
+			r0 = ret.Get(0).(flow.EventsList)
 		}
 	}
 
@@ -1047,15 +1063,15 @@ func (_m *Environment) RevokeEncodedAccountKey(address common.Address, index int
 }
 
 // ServiceEvents provides a mock function with given fields:
-func (_m *Environment) ServiceEvents() []flow.Event {
+func (_m *Environment) ServiceEvents() flow.EventsList {
 	ret := _m.Called()
 
-	var r0 []flow.Event
-	if rf, ok := ret.Get(0).(func() []flow.Event); ok {
+	var r0 flow.EventsList
+	if rf, ok := ret.Get(0).(func() flow.EventsList); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]flow.Event)
+			r0 = ret.Get(0).(flow.EventsList)
 		}
 	}
 

--- a/fvm/environment/mock/event_emitter.go
+++ b/fvm/environment/mock/event_emitter.go
@@ -15,6 +15,22 @@ type EventEmitter struct {
 	mock.Mock
 }
 
+// ConvertedServiceEvents provides a mock function with given fields:
+func (_m *EventEmitter) ConvertedServiceEvents() flow.ServiceEventList {
+	ret := _m.Called()
+
+	var r0 flow.ServiceEventList
+	if rf, ok := ret.Get(0).(func() flow.ServiceEventList); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(flow.ServiceEventList)
+		}
+	}
+
+	return r0
+}
+
 // EmitEvent provides a mock function with given fields: event
 func (_m *EventEmitter) EmitEvent(event cadence.Event) error {
 	ret := _m.Called(event)
@@ -30,15 +46,15 @@ func (_m *EventEmitter) EmitEvent(event cadence.Event) error {
 }
 
 // Events provides a mock function with given fields:
-func (_m *EventEmitter) Events() []flow.Event {
+func (_m *EventEmitter) Events() flow.EventsList {
 	ret := _m.Called()
 
-	var r0 []flow.Event
-	if rf, ok := ret.Get(0).(func() []flow.Event); ok {
+	var r0 flow.EventsList
+	if rf, ok := ret.Get(0).(func() flow.EventsList); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]flow.Event)
+			r0 = ret.Get(0).(flow.EventsList)
 		}
 	}
 
@@ -51,15 +67,15 @@ func (_m *EventEmitter) Reset() {
 }
 
 // ServiceEvents provides a mock function with given fields:
-func (_m *EventEmitter) ServiceEvents() []flow.Event {
+func (_m *EventEmitter) ServiceEvents() flow.EventsList {
 	ret := _m.Called()
 
-	var r0 []flow.Event
-	if rf, ok := ret.Get(0).(func() []flow.Event); ok {
+	var r0 flow.EventsList
+	if rf, ok := ret.Get(0).(func() flow.EventsList); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]flow.Event)
+			r0 = ret.Get(0).(flow.EventsList)
 		}
 	}
 

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -38,8 +38,9 @@ type TransactionProcedure struct {
 	TxIndex                uint32
 
 	Logs                   []string
-	Events                 []flow.Event
-	ServiceEvents          []flow.Event
+	Events                 flow.EventsList
+	ServiceEvents          flow.EventsList
+	ConvertedServiceEvents flow.ServiceEventList
 	ComputationUsed        uint64
 	ComputationIntensities meter.MeteredComputationIntensities
 	MemoryEstimate         uint64

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -460,6 +460,7 @@ func (executor *transactionExecutor) commit(
 	// if tx failed this will only contain fee deduction events
 	executor.proc.Events = executor.env.Events()
 	executor.proc.ServiceEvents = executor.env.ServiceEvents()
+	executor.proc.ConvertedServiceEvents = executor.env.ConvertedServiceEvents()
 
 	// Based on various (e.g., contract and frozen account) updates, we decide
 	// how to clean up the derived data.  For failed transactions we also do

--- a/model/convert/fixtures/fixture.go
+++ b/model/convert/fixtures/fixture.go
@@ -19,7 +19,7 @@ func EpochSetupFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochSetu
 	}
 
 	event := unittest.EventFixture(events.EpochSetup.EventType(), 1, 1, unittest.IdentifierFixture(), 0)
-	event.Payload = []byte(epochSetupFixtureJSON)
+	event.Payload = []byte(EpochSetupFixtureJSON)
 
 	// randomSource is [0,0,...,1,2,3,4]
 	randomSource := make([]uint8, flow.EpochSetupRandomSourceLength)
@@ -118,7 +118,7 @@ func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCom
 	}
 
 	event := unittest.EventFixture(events.EpochCommit.EventType(), 1, 1, unittest.IdentifierFixture(), 0)
-	event.Payload = []byte(epochCommitFixtureJSON)
+	event.Payload = []byte(EpochCommitFixtureJSON)
 
 	expected := &flow.EpochCommit{
 		Counter: 1,
@@ -147,7 +147,7 @@ func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCom
 	return event, expected
 }
 
-var epochSetupFixtureJSON = `
+var EpochSetupFixtureJSON = `
 {
   "type": "Event",
   "value": {
@@ -1079,7 +1079,7 @@ var epochSetupFixtureJSON = `
 }
 `
 
-var epochCommitFixtureJSON = `
+var EpochCommitFixtureJSON = `
 {
     "type": "Event",
     "value": {

--- a/model/flow/execution_result.go
+++ b/model/flow/execution_result.go
@@ -17,6 +17,22 @@ type ExecutionResult struct {
 	ExecutionDataID  Identifier
 }
 
+func NewExecutionResult(
+	previousResultID Identifier,
+	blockID Identifier,
+	chunks ChunkList,
+	serviceEvents ServiceEventList,
+	executionDataID Identifier,
+) *ExecutionResult {
+	return &ExecutionResult{
+		PreviousResultID: previousResultID,
+		BlockID:          blockID,
+		Chunks:           chunks,
+		ServiceEvents:    serviceEvents,
+		ExecutionDataID:  executionDataID,
+	}
+}
+
 // ID returns the hash of the execution result body
 func (er ExecutionResult) ID() Identifier {
 	return MakeID(er)

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -52,6 +52,7 @@ var epochSetupEvent, _ = convertfixtures.EpochSetupFixtureByChainID(testChain)
 var epochCommitEvent, _ = convertfixtures.EpochCommitFixtureByChainID(testChain)
 
 var epochSetupServiceEvent, _ = convert.ServiceEvent(testChain, epochSetupEvent)
+var epochCommitServiceEvent, _ = convert.ServiceEvent(testChain, epochCommitEvent)
 
 var serviceEventsList = []flow.ServiceEvent{
 	*epochSetupServiceEvent,
@@ -401,7 +402,7 @@ func (vm *vmSystemOkMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.Vie
 		return fmt.Errorf("invokable is not a transaction")
 	}
 
-	tx.ServiceEvents = []flow.Event{epochSetupEvent}
+	tx.ConvertedServiceEvents = flow.ServiceEventList{*epochSetupServiceEvent}
 
 	// add "default" interaction expected in tests
 	_, _ = led.Get("00", "")
@@ -424,7 +425,7 @@ func (vm *vmSystemBadMock) Run(ctx fvm.Context, proc fvm.Procedure, led state.Vi
 		return fmt.Errorf("invokable is not a transaction")
 	}
 	// EpochSetup event is expected, but we emit EpochCommit here resulting in a chunk fault
-	tx.ServiceEvents = []flow.Event{epochCommitEvent}
+	tx.ConvertedServiceEvents = flow.ServiceEventList{*epochCommitServiceEvent}
 
 	return nil
 }


### PR DESCRIPTION
This reduce the number of places that needs to convert service events, and can be parallelized in the future as part of fvm execution.