### PR TITLE
Add sandboxnet missing keys and upgrade contract

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.uber.org/atomic"
 
+	mig "github.com/onflow/flow-go/cmd/util/ledger/migrations"
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -90,6 +91,7 @@ func extractExecutionState(
 		migrations = []ledger.Migration{
 			// the following migration calculate the storage usage and update the storage for each account
 			// mig.MigrateAccountUsage,
+			mig.AddMissingKeysAndUpgradeContractsMigration(chain, log),
 		}
 	}
 	// generating reports at the end, so that the checkpoint file can be used

--- a/cmd/util/ledger/migrations/FlowFees.cdc
+++ b/cmd/util/ledger/migrations/FlowFees.cdc
@@ -1,0 +1,192 @@
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xFLOWTOKENADDRESS
+import FlowStorageFees from 0xFLOWSTORAGEFEESADDRESS
+
+pub contract FlowFees {
+
+    // Event that is emitted when tokens are deposited to the fee vault
+    pub event TokensDeposited(amount: UFix64)
+
+    // Event that is emitted when tokens are withdrawn from the fee vault
+    pub event TokensWithdrawn(amount: UFix64)
+
+    // Event that is emitted when fees are deducted
+    pub event FeesDeducted(amount: UFix64, inclusionEffort: UFix64, executionEffort: UFix64)
+
+    // Event that is emitted when fee parameters change
+    pub event FeeParametersChanged(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCost: UFix64)
+
+    // Private vault with public deposit function
+    access(self) var vault: @FlowToken.Vault
+
+    pub fun deposit(from: @FungibleToken.Vault) {
+        let from <- from as! @FlowToken.Vault
+        let balance = from.balance
+        self.vault.deposit(from: <-from)
+        emit TokensDeposited(amount: balance)
+    }
+
+    /// Get the balance of the Fees Vault
+    pub fun getFeeBalance(): UFix64 {
+        return self.vault.balance
+    }
+
+    pub resource Administrator {
+        // withdraw
+        //
+        // Allows the administrator to withdraw tokens from the fee vault
+        pub fun withdrawTokensFromFeeVault(amount: UFix64): @FungibleToken.Vault {
+            let vault <- FlowFees.vault.withdraw(amount: amount)
+            emit TokensWithdrawn(amount: amount)
+            return <-vault
+        }
+
+        /// Allows the administrator to change all the fee parameters at once
+        pub fun setFeeParameters(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCost: UFix64) {
+            let newParameters = FeeParameters(surgeFactor: surgeFactor, inclusionEffortCost: inclusionEffortCost, executionEffortCost: executionEffortCost)
+            FlowFees.setFeeParameters(newParameters)
+        }
+
+        /// Allows the administrator to change the fee surge factor
+        pub fun setFeeSurgeFactor(_ surgeFactor: UFix64) {
+            let oldParameters = FlowFees.getFeeParameters()
+            let newParameters = FeeParameters(surgeFactor: surgeFactor, inclusionEffortCost: oldParameters.inclusionEffortCost, executionEffortCost: oldParameters.executionEffortCost)
+            FlowFees.setFeeParameters(newParameters)
+        }
+    }
+
+    /// A struct holding the fee parameters needed to calculate the fees
+    pub struct FeeParameters {
+        /// The surge factor is used to make transaction fees respond to high loads on the network
+        pub var surgeFactor: UFix64
+        /// The FLOW cost of one unit of inclusion effort. The FVM is responsible for metering inclusion effort.
+        pub var inclusionEffortCost: UFix64
+        /// The FLOW cost of one unit of execution effort. The FVM is responsible for metering execution effort.
+        pub var executionEffortCost: UFix64
+
+        init(surgeFactor: UFix64, inclusionEffortCost: UFix64, executionEffortCost: UFix64){
+            self.surgeFactor = surgeFactor
+            self.inclusionEffortCost = inclusionEffortCost
+            self.executionEffortCost = executionEffortCost
+        }
+    }
+
+    // VerifyPayerBalanceResult is returned by the verifyPayersBalanceForTransactionExecution function
+    pub struct VerifyPayerBalanceResult {
+        // True if the payer has sufficient balance for the transaction execution to continue
+        pub let canExecuteTransaction: Bool
+        // The minimum payer balance required for the transaction execution to continue. 
+        // This value is defined by verifyPayersBalanceForTransactionExecution.
+        pub let requiredBalance: UFix64
+        // The maximum transaction fees (inclusion fees + execution fees) the transaction can incur 
+        // (if all available execution effort is used)
+        pub let maximumTransactionFees: UFix64
+
+        init(canExecuteTransaction: Bool, requiredBalance: UFix64,  maximumTransactionFees: UFix64){
+            self.canExecuteTransaction = canExecuteTransaction
+            self.requiredBalance = requiredBalance
+            self.maximumTransactionFees = maximumTransactionFees
+        }
+
+    }
+
+    // verifyPayersBalanceForTransactionExecution is called by the FVM before executing a transaction.
+    // It verifies that the transaction payer's balance is high enough to continue transaction execution,
+    // and returns the maximum possible transaction fees.
+    // (according to the inclusion effort and maximum execution effort of the transaction).
+    //
+    // The requiredBalance balance is defined as the minimum account balance + 
+    //  maximum transaction fees (inclusion fees + execution fees at max execution effort).
+    pub fun verifyPayersBalanceForTransactionExecution(
+        _ payerAcct: AuthAccount, 
+        inclusionEffort: UFix64, 
+        maxExecutionEffort: UFix64,
+    ): VerifyPayerBalanceResult {
+        // Get the maximum fees required for the transaction.
+        var maxTransactionFee = self.computeFees(inclusionEffort: inclusionEffort, executionEffort: maxExecutionEffort)
+
+        // Get the minimum required payer's balance for the transaction.
+        let minimumRequiredBalance = FlowStorageFees.defaultTokenReservedBalance(payerAcct.address)
+
+        if minimumRequiredBalance == UFix64(0) {
+            // If the required balance is zero exit early.
+            return VerifyPayerBalanceResult(
+                canExecuteTransaction: true, 
+                requiredBalance: minimumRequiredBalance,
+                maximumTransactionFees: maxTransactionFee,
+            )
+        }
+        
+        // Get the balance of the payers default vault.
+        // In the edge case where the payer doesnt have a vault, treat the balance as 0.
+        var balance = 0.0
+        if let tokenVault = payerAcct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault) {
+            balance = tokenVault.balance
+        }
+
+        return VerifyPayerBalanceResult(
+            // The transaction can be executed it the payers balance is greater than the minimum required balance. 
+            canExecuteTransaction: balance >= minimumRequiredBalance,
+            requiredBalance: minimumRequiredBalance,
+            maximumTransactionFees: maxTransactionFee)
+    }
+
+    /// Called when a transaction is submitted to deduct the fee
+    /// from the AuthAccount that submitted it
+    pub fun deductTransactionFee(_ acct: AuthAccount, inclusionEffort: UFix64, executionEffort: UFix64) {
+        var feeAmount = self.computeFees(inclusionEffort: inclusionEffort, executionEffort: executionEffort)
+
+        if feeAmount == UFix64(0) {
+            // If there are no fees to deduct, do not continue, 
+            // so that there are no unnecessarily emitted events
+            return
+        }
+
+        let tokenVault = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
+            ?? panic("Unable to borrow reference to the default token vault")
+
+        
+        if feeAmount > tokenVault.balance {
+            // In the future this code path will never be reached, 
+            // as payers that are under account minimum balance will not have their transactions included in a collection
+            //
+            // Currently this is not used to fail the transaction (as that is the responsibility of the minimum account balance logic),
+            // But is used to reduce the balance of the vault to 0.0, if the vault has less available balance than the transaction fees. 
+            feeAmount = tokenVault.balance
+        }
+        
+        let feeVault <- tokenVault.withdraw(amount: feeAmount)
+        self.vault.deposit(from: <-feeVault)
+
+        // The fee calculation can be reconstructed using the data from this event and the FeeParameters at the block when the event happened
+        emit FeesDeducted(amount: feeAmount, inclusionEffort: inclusionEffort, executionEffort: executionEffort)
+    }
+
+    pub fun getFeeParameters(): FeeParameters {
+        return self.account.copy<FeeParameters>(from: /storage/FlowTxFeeParameters) ?? panic("Error getting tx fee parameters. They need to be initialized first!")
+    }
+
+    access(self) fun setFeeParameters(_ feeParameters: FeeParameters) {
+        // empty storage before writing new FeeParameters to it
+        self.account.load<FeeParameters>(from: /storage/FlowTxFeeParameters)
+        self.account.save(feeParameters,to: /storage/FlowTxFeeParameters)
+        emit FeeParametersChanged(surgeFactor: feeParameters.surgeFactor, inclusionEffortCost: feeParameters.inclusionEffortCost, executionEffortCost: feeParameters.executionEffortCost)
+    }
+
+    
+    // compute the transaction fees with the current fee parameters and the given inclusionEffort and executionEffort
+    pub fun computeFees(inclusionEffort: UFix64, executionEffort: UFix64): UFix64 {
+        let params = self.getFeeParameters()
+        
+        let totalFees = params.surgeFactor * ( inclusionEffort * params.inclusionEffortCost + executionEffort * params.executionEffortCost )
+        return totalFees
+    }
+
+    init(adminAccount: AuthAccount) {
+        // Create a new FlowToken Vault and save it in storage
+        self.vault <- FlowToken.createEmptyVault() as! @FlowToken.Vault
+
+        let admin <- create Administrator()
+        adminAccount.save(<-admin, to: /storage/flowFeesAdmin)
+    }
+}

--- a/cmd/util/ledger/migrations/add_missing_keys_migration.go
+++ b/cmd/util/ledger/migrations/add_missing_keys_migration.go
@@ -1,0 +1,142 @@
+package migrations
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-core-contracts/lib/go/templates"
+
+	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/utils"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+//go:embed FlowFees.cdc
+var flowFeesContract string
+
+// AddMissingKeysAndUpgradeContractsMigration is a temporary migration that adds the missing keys to the core contract accounts
+// and upgrades the contracts to the latest version.
+// This migration is only needed for the sandboxnet but is written to also work on benchnet, so it can be tested.
+// context: https://dapperlabs.slack.com/archives/C015G65HR2P/p1671218228441159
+func AddMissingKeysAndUpgradeContractsMigration(chain flow.Chain, logger zerolog.Logger) func(payloads []ledger.Payload) ([]ledger.Payload, error) {
+	return func(payloads []ledger.Payload) ([]ledger.Payload, error) {
+		return addMissingKeysAndUpgradeContractsMigration(
+			chain,
+			payloads,
+			logger.With().Str("migration", "add-missing-keys-and-upgrade-contracts").Logger())
+	}
+}
+
+func addMissingKeysAndUpgradeContractsMigration(
+	chain flow.Chain,
+	payloads []ledger.Payload,
+	logger zerolog.Logger,
+) ([]ledger.Payload, error) {
+
+	// only run this migration on sandboxnet and benchnet
+	switch chain {
+	case flow.Sandboxnet.Chain():
+		logger.Info().Msg("running migration for sandboxnet")
+	case flow.Benchnet.Chain():
+		logger.Info().Msg("running migration for benchnet")
+	default:
+		logger.Error().
+			Msg("migration not supported for this chain")
+		return nil, fmt.Errorf("migration not supported for chain %s", chain)
+	}
+
+	view := utils.NewSimpleViewFromPayloads(payloads)
+	txState := state.NewTransactionState(view, state.DefaultParameters())
+	accounts := environment.NewAccounts(txState)
+
+	// get the key that we want to copy from the service account
+	serviceAddress := chain.ServiceAddress()
+	ok, err := accounts.Exists(serviceAddress)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("service account does not exist: %s", serviceAddress)
+	}
+
+	keys, err := accounts.GetPublicKeys(serviceAddress)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) != 1 {
+		return nil, fmt.Errorf("expected 1 key for service account, got: %d", len(keys))
+	}
+	// this is the key we want to copy to other addresses
+	key := keys[0]
+
+	// core contract accounts with missing keys
+	accountsWithMissingKeys := []flow.Address{
+		fvm.FlowTokenAddress(chain),
+		fvm.FlowFeesAddress(chain),
+		fvm.FungibleTokenAddress(chain),
+	}
+	for _, address := range accountsWithMissingKeys {
+		err = appendKeyForAccount(accounts, address, key, logger)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// upgrade the FlowFees contract
+	logger.Info().
+		Msg("upgrade the FlowFees contract")
+
+	// replace the imports with actual addresses:
+	// import FungibleToken from 0xFUNGIBLETOKENADDRESS
+	// import FlowToken from 0xFLOWTOKENADDRESS
+	// import FlowStorageFees from 0xFLOWSTORAGEFEESADDRESS
+	flowFeesContractWithReplacedAddresses := templates.ReplaceAddresses(
+		flowFeesContract,
+		templates.Environment{
+			FungibleTokenAddress: fvm.FungibleTokenAddress(chain).Hex(),
+			FlowTokenAddress:     fvm.FlowTokenAddress(chain).Hex(),
+			StorageFeesAddress:   chain.ServiceAddress().Hex(),
+		},
+	)
+
+	err = accounts.SetContract(
+		"FlowFees",
+		fvm.FlowFeesAddress(chain),
+		[]byte(flowFeesContractWithReplacedAddresses),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return view.Payloads(), nil
+}
+
+func appendKeyForAccount(
+	accounts *environment.StatefulAccounts,
+	address flow.Address,
+	accountKey flow.AccountPublicKey,
+	logger zerolog.Logger,
+) error {
+	ok, err := accounts.Exists(address)
+	if err != nil {
+		return err
+	}
+	if ok {
+		err = accounts.AppendPublicKey(address, accountKey)
+		logger.Info().
+			Str("address", address.String()).
+			Msg("added missing key to account")
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("account does not exist: %s", address)
+	}
+	return nil
+}

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -872,6 +872,11 @@ func FlowTokenAddress(chain flow.Chain) flow.Address {
 	return address
 }
 
+func FlowFeesAddress(chain flow.Chain) flow.Address {
+	address, _ := chain.AddressAtIndex(environment.FlowFeesAccountIndex)
+	return address
+}
+
 // invokeMetaTransaction invokes a meta transaction inside the context of an
 // outer transaction.
 //


### PR DESCRIPTION
The FlowFees contract is from core contracts version c1b31d5a4722aba3bc4ccaae9a7ec6e660887591

This adds missing keys to 3 core accounts and upgrades the FlowFees core contract.

This should not be merged, and should fail anywhere but Sandboxnet (or benchnet, since that is where its being tested)