### PR TITLE
Re-enable Epoch Integration Tests

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -757,6 +757,8 @@ func (builder *FlowAccessNodeBuilder) Initialize() error {
 
 	builder.EnqueueTracer()
 	builder.PreInit(cmd.DynamicStartPreInit)
+	builder.ValidateRootSnapshot(badgerState.ValidRootSnapshotContainsEntityExpiryRange)
+
 	return nil
 }
 

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -172,7 +172,7 @@ func main() {
 
 	nodeBuilder.
 		PreInit(cmd.DynamicStartPreInit).
-		ValidateRootSnapshot(badgerState.SanityCheckConsensusNodeRootSnapshotValidity).
+		ValidateRootSnapshot(badgerState.ValidRootSnapshotContainsEntityExpiryRange).
 		Module("consensus node metrics", func(node *cmd.NodeConfig) error {
 			conMetrics = metrics.NewConsensusCollector(node.Tracer, node.MetricsRegisterer)
 			return nil

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -186,40 +186,31 @@ func New(
 }
 
 func (e *Engine) Start(parent irrecoverable.SignalerContext) {
-	rootBlock, err := e.state.Params().Root()
+	err := e.initLastFullBlockHeightIndex()
 	if err != nil {
-		parent.Throw(fmt.Errorf("failed to get root block: %w", err))
-	}
-
-	// if spork root snapshot
-	rootSnapshot := e.state.AtBlockID(rootBlock.ID())
-
-	isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
-	if err != nil {
-		parent.Throw(fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err))
-	}
-
-	// This is useful for dynamically bootstrapped access node, they will request missing collections. In order to ensure all txs
-	// from the missing collections can be verified, we must ensure they are referencing to known blocks.
-	// That's why we set the full block height to be rootHeight + TransactionExpiry, so that we only request missing collections
-	// in blocks above that height.
-	if isSporkRootSnapshot {
-		// for snapshot with a single block in the sealing segment the first full block is the root block.
-		err := e.blocks.InsertLastFullBlockHeightIfNotExists(rootBlock.Height)
-		if err != nil {
-			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
-		}
-	} else {
-		// for midspork snapshots with a sealing segment that has more than 1 block add the transaction expiry to the root block height to avoid
-		// requesting resources for blocks below the expiry.
-		firstFullHeight := rootBlock.Height + flow.DefaultTransactionExpiry
-		err := e.blocks.InsertLastFullBlockHeightIfNotExists(firstFullHeight)
-		if err != nil {
-			parent.Throw(fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err))
-		}
+		parent.Throw(fmt.Errorf("unexpected error initializing full block index: %w", err))
 	}
 
 	e.ComponentManager.Start(parent)
+}
+
+// initializeLastFullBlockHeightIndex initializes the index of full blocks
+// (blocks for which we have ingested all collections) to the root block height.
+// This means that the Access Node will ingest all collections for all blocks
+// ingested after state bootstrapping is complete (all blocks received from the network).
+// If the index has already been initialized, this is a no-op.
+// No errors are expected during normal operation.
+func (e *Engine) initLastFullBlockHeightIndex() error {
+	rootBlock, err := e.state.Params().Root()
+	if err != nil {
+		return fmt.Errorf("failed to get root block: %w", err)
+	}
+	err = e.blocks.InsertLastFullBlockHeightIfNotExists(rootBlock.Height)
+	if err != nil {
+		return fmt.Errorf("failed to update last full block height during ingestion engine startup: %w", err)
+	}
+
+	return nil
 }
 
 func (e *Engine) processBackground(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -39,7 +39,7 @@ consensus-tests:
 .PHONY: epochs-tests
 epochs-tests:
 	# Use a higher timeout of 20m for the suite of tests which span full epochs
-	go test $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic -timeout 20m ./tests/epochs/...
+	go test $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic -timeout 30m ./tests/epochs/...
 
 .PHONY: ghost-tests
 ghost-tests:

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20221214150253-cb74e7764c12
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20221214150253-cb74e7764c12
 	github.com/onflow/flow-emulator v0.38.1
-	github.com/onflow/flow-ft/lib/go/templates v0.2.0
 	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221012204608-ed91c80fee2b
 	github.com/onflow/flow-go-sdk v0.30.0
 	github.com/onflow/flow-go/crypto v0.24.4
@@ -45,6 +44,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
+	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.9.1 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -117,7 +117,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/VictoriaMetrics/fastcache v1.5.3/go.mod h1:+jv9Ckb+za/P1ZRg/sulP5Ni1v49daAVERr0H3CuscE=
 github.com/VictoriaMetrics/fastcache v1.5.7/go.mod h1:ptDBkNMQI4RtmVo8VS/XwRY6RoTu1dAWCbrk+6WsEM8=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
@@ -218,7 +217,6 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
-github.com/c-bata/go-prompt v0.2.3/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
@@ -228,7 +226,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.0.1-0.20190104013014-3767db7a7e18/go.mod h1:HD5P3vAIAh+Y2GAxg0PrPN1P8WkepXGpjbUPDHJqqKM=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -355,7 +352,6 @@ github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c/go.mod h1:YO35OhQPt
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/ef-ds/deque v1.0.4 h1:iFAZNmveMT9WERAkqLJ+oaABF9AcVQ5AjXem/hroniI=
 github.com/ef-ds/deque v1.0.4/go.mod h1:gXDnTC3yqvBcHbq2lcExjtAcVrOnJCbMcZXmuj8Z4tg=
-github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/4=
 github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
@@ -372,7 +368,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethereum/go-ethereum v1.9.9/go.mod h1:a9TqabFudpDu1nucId+k9S8R9whYaHnGBLKFouA5EAo=
 github.com/ethereum/go-ethereum v1.9.25/go.mod h1:vMkFiYLHI4tgPw4k2j4MHKoovchFE8plZ0M9VMk4/oM=
 github.com/ethereum/go-ethereum v1.10.1 h1:bGQezu+kqqRBczcSAruEoqVzTjtkeDnUGI2I4uroyUE=
 github.com/ethereum/go-ethereum v1.10.1/go.mod h1:E5e/zvdfUVr91JZ0AwjyuJM3x+no51zZJRz61orLLSk=
@@ -396,7 +391,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20201006223149-25f67fca9803/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f h1:dxTR4AaxCwuQv9LAVTAC2r1szlS+epeuPT5ClLKT6ZY=
 github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
@@ -455,7 +449,6 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
@@ -501,7 +494,6 @@ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+Licev
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2-0.20190517061210-b285ee9cfc6c/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -651,7 +643,6 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
-github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
@@ -667,7 +658,6 @@ github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iU
 github.com/holiman/uint256 v1.1.1/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3/go.mod h1:MZ2ZmwcBpvOoJ22IJsc7va19ZwoheaBk43rKg12SKag=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goupnp v1.0.1-0.20200620063722-49508fba0031/go.mod h1:nNs7wvRfN1eKaMknBydLNQU6146XQim8t4h+q90biWo=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
@@ -1114,7 +1104,6 @@ github.com/libp2p/go-yamux/v4 v4.0.0 h1:+Y80dV2Yx/kv7Y7JKu0LECyVdMXm1VUoko+VQ9rB
 github.com/libp2p/go-yamux/v4 v4.0.0/go.mod h1:NWjl8ZTLOGlozrXSOZ/HlfG++39iKNnM5wwmtQP1YB4=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lucas-clemente/quic-go v0.19.3/go.mod h1:ADXpNbTQjq1hIzCpB+y/k5iz4n4z4IwqoLb94Kh5Hu8=
@@ -1149,8 +1138,6 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
-github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -1161,8 +1148,6 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5-0.20180830101745-3fb116b82035/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
-github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
@@ -1172,13 +1157,10 @@ github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnU
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
-github.com/mattn/go-tty v0.0.3/go.mod h1:ihxohKRERHTVzN+aSVRwACLCeqIoZAWpoICkkvrWyR0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
@@ -1322,7 +1304,6 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onflow/atree v0.4.0 h1:+TbNisavAkukAKhgQ4plWnvR9o5+SkwPIsi3jaeAqKs=
 github.com/onflow/atree v0.4.0/go.mod h1:7Qe1xaW0YewvouLXrugzMFUYXNoRQ8MT/UsVAWx1Ndo=
-github.com/onflow/cadence v0.11.2/go.mod h1:8NwJGO535nnY/+QWEMDc2rhvOFChToWQ9Bg7fUIIc/I=
 github.com/onflow/cadence v0.30.0 h1:LzxvMLwGeRlUVFvGgprnBTE+En5DZ2NxRIB8wB9/d8U=
 github.com/onflow/cadence v0.30.0/go.mod h1:oRgWkvau1RH15m3NuDlZCPHFQzwvC72jEstCGu8OJ98=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20221214150253-cb74e7764c12 h1:tbWMfGrpVEKslasBLe/dEQ3ufgw0Q/8p+R7gpMW8xyM=
@@ -1333,14 +1314,10 @@ github.com/onflow/flow-emulator v0.38.1 h1:ZfkbhCe2TA4tiZTuhGjuuzUCg+9Z4VWzh40dC
 github.com/onflow/flow-emulator v0.38.1/go.mod h1:EK8PWAwcCV5eEP1V1f0ummHW2QZSbeGmb42+SztmE2U=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0 h1:Cg4gHGVblxcejfNNG5Mfj98Wf4zbY76O0Y28QB0766A=
 github.com/onflow/flow-ft/lib/go/contracts v0.5.0/go.mod h1:1zoTjp1KzNnOPkyqKmWKerUyf0gciw+e6tAEt0Ks3JE=
-github.com/onflow/flow-ft/lib/go/templates v0.2.0 h1:oQQk5UthLS9KfKLkZVJg/XAVq8CXW7HAxSTu4HwBJkU=
-github.com/onflow/flow-ft/lib/go/templates v0.2.0/go.mod h1:qwkTElMcI+PnSBGIWGu1K9OYBLatNimWTC8un9qUji0=
-github.com/onflow/flow-go-sdk v0.13.0/go.mod h1:yqnSajzJVFfrTg68F4WXRR1Yzs1akqAjyscEDyFudPE=
 github.com/onflow/flow-go-sdk v0.30.0 h1:Cb1kYW5DXZe7L6zblFvPItTdzGhmzVvCvFSyJWr8Nao=
 github.com/onflow/flow-go-sdk v0.30.0/go.mod h1:KXw/XIsq8g6EdR0AEa+bq3QYNLAx/NNkzWFFJua5ARc=
 github.com/onflow/flow-go/crypto v0.24.4 h1:SwEtoVS2TidCIHYCZMgQ7U2YsqhI9upnw94fhdHTubM=
 github.com/onflow/flow-go/crypto v0.24.4/go.mod h1:dkVL98P6GHR48iD9zCB6XlnkJX8IQd00FKgt1reV90w=
-github.com/onflow/flow/protobuf/go/flow v0.1.8/go.mod h1:kRugbzZjwQqvevJhrnnCFMJZNmoSJmxlKt6hTGXZojM=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221202093946-932d1c70e288 h1:haWv3D5loiH+zcOoWEvDXtWQvXt5U8PLliQjwhv9sfw=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20221202093946-932d1c70e288/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onflow/go-bitswap v0.0.0-20221017184039-808c5791a8a8 h1:XcSR/n2aSVO7lOEsKScYALcpHlfowLwicZ9yVbL6bnA=
@@ -1417,7 +1394,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
-github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/plus3it/gorecurcopy v0.0.1 h1:H7AgvM0N/uIo7o1PQRlewEGQ92BNr7DqbPy5lnR3uJI=
 github.com/plus3it/gorecurcopy v0.0.1/go.mod h1:NvVTm4RX68A1vQbHmHunDO4OtBLVroT6CrsiqAzNyJA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -1480,15 +1456,12 @@ github.com/psiemens/sconfig v0.1.0 h1:xfWqW+TRpih7mXZIqKYTmpRhlZLQ1kbxV8EjllPv76
 github.com/psiemens/sconfig v0.1.0/go.mod h1:+MLKqdledP/8G3rOBpknbLh0IclCf4WneJUtS26JB2U=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
-github.com/raviqqe/hamt v0.0.0-20190615202029-864fb7caef85/go.mod h1:I9elsTaXMhu41qARmzefHy7v2KmAV2TB1yH4E+nBSf0=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
-github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.1-0.20211004051800-57c86be7915a h1:s7GrsqeorVkFR1vGmQ6WVL9nup0eyQCC+YVUeSQLH/Q=
 github.com/rivo/uniseg v0.2.1-0.20211004051800-57c86be7915a/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
-github.com/robertkrimen/otto v0.0.0-20170205013659-6a77b7cbc37d/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1510,7 +1483,6 @@ github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0
 github.com/schollz/progressbar/v3 v3.8.3 h1:FnLGl3ewlDUP+YdSwveXBaXs053Mem/du+wr7XSYKl8=
 github.com/schollz/progressbar/v3 v3.8.3/go.mod h1:pWnVCjSBZsT2X3nx9HfRdnCDrpbevliMeoEVhStwHko=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/segmentio/fasthash v1.0.2/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -1565,7 +1537,6 @@ github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7A
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.0.1-0.20190317074736-539464a789e9/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -1622,7 +1593,6 @@ github.com/supranational/blst v0.3.4 h1:iZE9lBMoywK2uy2U/5hDOvobQk9FnOQ2wNlu9GmR
 github.com/supranational/blst v0.3.4/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
-github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c h1:HelZ2kAFadG0La9d+4htN4HzQ68Bm2iM9qKMSMES6xg=
@@ -1976,7 +1946,6 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1985,7 +1954,6 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2015,7 +1983,6 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2147,7 +2114,6 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
-golang.org/x/tools v0.0.0-20200323144430-8dcfad9e016e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -2157,7 +2123,6 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
@@ -2211,7 +2176,6 @@ google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
 google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
-google.golang.org/api v0.31.0/go.mod h1:CL+9IBCa2WWU6gRuBWaKqGWLFFwbEUXkfeMkHLQWYWo=
 google.golang.org/api v0.35.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
 google.golang.org/api v0.36.0/go.mod h1:+z5ficQTmoYpPn8LCUNVpK5I7hwkpjbcgqA7I34qYtE=
 google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjRCQ8=
@@ -2285,7 +2249,6 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200831141814-d751682dd103/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -2418,10 +2381,8 @@ gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.66.6 h1:LATuAqN/shcYAOkv3wl2L4rkaKqkcgTBQjOyYDvcPKI=
 gopkg.in/ini.v1 v1.66.6/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
-gopkg.in/olebedev/go-duktape.v3 v3.0.0-20190213234257-ec84240a7772/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=
 gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/integration/templates/create-and-setup-node.cdc
+++ b/integration/templates/create-and-setup-node.cdc
@@ -1,0 +1,67 @@
+import Crypto
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xFLOWTOKENADDRESS
+import FlowIDTableStaking from 0xIDENTITYTABLEADDRESS
+import FlowStakingCollection from 0xSTAKINGCOLLECTIONADDRESS
+
+transaction(
+    stakingAcctKey: Crypto.KeyListEntry,
+    stake: UFix64,
+    id: String,
+    role: UInt8,
+    networkingAddress: String,
+    networkingKey: String,
+    stakingKey: String,
+    machineAcctKey: Crypto.KeyListEntry) {
+
+	prepare(service: AuthAccount) {
+ 	    // 1 - create the staking account for the new node.
+ 	    //
+        let stakingAccount = AuthAccount(payer: signer)
+        stakingAccount.keys.add(publicKey: stakingAcctKey.publicKey, hashAlgorithm: stakingAcctKey.hashAlgorithm, weight: stakingAcctKey.weight)
+
+	    // 2 - fund the new staking account
+	    //
+	    let stakeDst = stakingAccount.getCapability(/public/flowTokenReceiver).borrow<&{FungibleToken.Receiver}>()
+			?? panic("Could not borrow receiver reference to the recipient's Vault")
+        // withdraw stake from service account
+        let stakeSrc = service.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
+   		    ?? panic("Could not borrow reference to the owner's Vault!")
+   		stakeDst.deposit(from: <-vaultRef.withdraw(amount: stake))
+
+	    // Get a reference to the recipient's Receiver
+        let receiverRef =  getAccount(self.stakingAccountAddress)
+            .getCapability(/public/flowTokenReceiver)
+            .borrow<&{FungibleToken.Receiver}>()
+			?? panic("Could not borrow receiver reference to the recipient's Vault")
+        receiverRef.deposit(from: <-self.fundVault)
+
+	    // 3 - set up the staking collection
+	    //
+        let flowToken = stakingAccount.link<&FlowToken.Vault>(/private/flowTokenVault, target: /storage/flowTokenVault)!
+        // Create a new Staking Collection and put it in storage
+        let stakingCollection = <-FlowStakingCollection.createStakingCollection(unlockedVault: flowToken, tokenHolder: nil)
+        let stakingCollectionRef = &stakingCollection as &FlowStakingCollection.StakingCollection
+        stakingAccount.save(<-stakingCollection, to: FlowStakingCollection.StakingCollectionStoragePath)
+
+        // Create a public link to the staking collection
+        stakingAccount.link<&FlowStakingCollection.StakingCollection{FlowStakingCollection.StakingCollectionPublic}>(
+            FlowStakingCollection.StakingCollectionPublicPath,
+            target: FlowStakingCollection.StakingCollectionStoragePath
+        )
+
+        // 4 - register the node
+        //
+        if let machineAccount = stakingCollectionRef.registerNode(
+            id: id,
+            role: role,
+            networkingAddress: networkingAddress,
+            networkingKey: networkingKey,
+            stakingKey: stakingKey,
+            amount: stake,
+            payer: service,
+        ) {
+            machineAccount.keys.add(publicKey: machineAcctKey.publicKey, hashAlgorithm: machineAcctKey.hashAlgorithm, weight: machineAcctKey.weight)
+        }
+	}
+}

--- a/integration/testnet/client.go
+++ b/integration/testnet/client.go
@@ -214,7 +214,7 @@ func (c *Client) WaitForSealed(ctx context.Context, id sdk.Identifier) (*sdk.Tra
 		} else {
 			fmt.Print(".")
 		}
-		time.Sleep(time.Second)
+		time.Sleep(250 * time.Millisecond)
 	}
 
 	fmt.Println()
@@ -289,6 +289,19 @@ func (c *Client) UserAddress(txResp *sdk.TransactionResult) (sdk.Address, bool) 
 	}
 
 	return address, found
+}
+
+// CreatedAccounts returns the addresses of all accounts created in the given transaction,
+// in the order they were created.
+func (c *Client) CreatedAccounts(txResp *sdk.TransactionResult) []sdk.Address {
+	var addresses []sdk.Address
+	for _, event := range txResp.Events {
+		if event.Type == sdk.EventAccountCreated {
+			accountCreatedEvent := sdk.AccountCreatedEvent(event)
+			addresses = append(addresses, accountCreatedEvent.Address())
+		}
+	}
+	return addresses
 }
 
 func (c *Client) TokenAmountByRole(role flow.Role) (string, float64, error) {

--- a/integration/testnet/client.go
+++ b/integration/testnet/client.go
@@ -193,6 +193,7 @@ func (c *Client) Account() *sdk.Account {
 	return c.account
 }
 
+// WaitForSealed waits for the transaction to be sealed, then returns the result.
 func (c *Client) WaitForSealed(ctx context.Context, id sdk.Identifier) (*sdk.TransactionResult, error) {
 
 	fmt.Printf("Waiting for transaction %s to be sealed...\n", id)

--- a/integration/tests/epochs/epoch_join_and_leave_sn_test.go
+++ b/integration/tests/epochs/epoch_join_and_leave_sn_test.go
@@ -6,11 +6,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestEpochJoinAndLeaveSN(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "epochs join/leave tests should be run on an machine with adequate resources")
 	suite.Run(t, new(EpochJoinAndLeaveSNSuite))
 }
 

--- a/integration/tests/epochs/epoch_join_and_leave_vn_test.go
+++ b/integration/tests/epochs/epoch_join_and_leave_vn_test.go
@@ -20,10 +20,10 @@ func (s *EpochJoinAndLeaveVNSuite) SetupTest() {
 	// require approvals for seals to verify that the joining VN is producing valid seals in the second epoch
 	s.RequiredSealApprovals = 1
 	// increase epoch length to account for greater sealing lag due to above
-	s.StakingAuctionLen = 200
+	s.StakingAuctionLen = 100
 	s.DKGPhaseLen = 100
-	s.EpochLen = 650
-	s.EpochCommitSafetyThreshold = 50
+	s.EpochLen = 450
+	s.EpochCommitSafetyThreshold = 20
 	s.DynamicEpochTransitionSuite.SetupTest()
 }
 

--- a/integration/tests/epochs/epoch_join_and_leave_vn_test.go
+++ b/integration/tests/epochs/epoch_join_and_leave_vn_test.go
@@ -20,6 +20,9 @@ func (s *EpochJoinAndLeaveVNSuite) SetupTest() {
 	// require approvals for seals to verify that the joining VN is producing valid seals in the second epoch
 	s.RequiredSealApprovals = 1
 	// increase epoch length to account for greater sealing lag due to above
+	// NOTE: this value is set fairly aggressively to ensure shorter test times.
+	// If flakiness due to failure to complete staking operations in time is observed,
+	// try increasing (by 10-20 views).
 	s.StakingAuctionLen = 100
 	s.DKGPhaseLen = 100
 	s.EpochLen = 450

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -710,8 +710,10 @@ type DynamicEpochTransitionSuite struct {
 }
 
 func (s *DynamicEpochTransitionSuite) SetupTest() {
-	// use a longer staking auction length to accommodate staking operations for
-	// joining/leaving nodes
+	// use a longer staking auction length to accommodate staking operations for joining/leaving nodes
+	// NOTE: this value is set fairly aggressively to ensure shorter test times.
+	// If flakiness due to failure to complete staking operations in time is observed,
+	// try increasing (by 10-20 views).
 	s.StakingAuctionLen = 50
 	s.DKGPhaseLen = 50
 	s.EpochLen = 250

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -488,6 +488,10 @@ func (s *Suite) AssertInEpochPhase(ctx context.Context, expectedEpoch uint64, ex
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), expectedPhase, actualPhase, "not in correct phase")
 	require.Equal(s.T(), expectedEpoch, actualEpoch, "not in correct epoch")
+
+	head, err := snapshot.Head()
+	require.NoError(s.T(), err)
+	s.TimedLogf("asserted in epoch %d, phase %s, finalized height/view: %d/%d", expectedEpoch, expectedPhase, head.Height, head.View)
 }
 
 // AssertInEpoch requires actual epoch counter is equal to counter provided.
@@ -708,10 +712,10 @@ type DynamicEpochTransitionSuite struct {
 func (s *DynamicEpochTransitionSuite) SetupTest() {
 	// use a longer staking auction length to accommodate staking operations for
 	// joining/leaving nodes
-	s.StakingAuctionLen = 200
+	s.StakingAuctionLen = 50
 	s.DKGPhaseLen = 50
-	s.EpochLen = 500
-	s.EpochCommitSafetyThreshold = 50
+	s.EpochLen = 250
+	s.EpochCommitSafetyThreshold = 20
 
 	// run the generic setup, which starts up the network
 	s.Suite.SetupTest()

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -171,7 +171,7 @@ type StakedNodeOperationInfo struct {
 // 7. Add the node to the approved list
 //
 // NOTE: assumes staking occurs in first epoch (counter 0)
-// NOTE 2: This function performs steps 1-7 in one custom transaction, to reduce
+// NOTE 2: This function performs steps 1-6 in one custom transaction, to reduce
 // the time taken by each test case. Individual transactions for each step can be
 // found in Git history, for example: 9867056a8b7246655047bc457f9000398f6687c0.
 func (s *Suite) StakeNode(ctx context.Context, env templates.Environment, role flow.Role) *StakedNodeOperationInfo {

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -168,60 +168,58 @@ type StakedNodeOperationInfo struct {
 // 4. Add additional funds to staking account for storage
 // 5. Create Staking collection for node
 // 6. Register node using staking collection object
+// 7. Add the node to the approved list
+//
 // NOTE: assumes staking occurs in first epoch (counter 0)
+// NOTE 2: This function performs steps 1-7 in one custom transaction, to reduce
+// the time taken by each test case. Individual transactions for each step can be
+// found in Git history, for example: 9867056a8b7246655047bc457f9000398f6687c0.
 func (s *Suite) StakeNode(ctx context.Context, env templates.Environment, role flow.Role) *StakedNodeOperationInfo {
 
 	stakingAccountKey, networkingKey, stakingKey, machineAccountKey, machineAccountPubKey := s.generateAccountKeys(role)
 	nodeID := flow.MakeID(stakingKey.PublicKey().Encode())
-	fullAccountKey := sdk.NewAccountKey().
+	fullStakingAcctKey := sdk.NewAccountKey().
 		SetPublicKey(stakingAccountKey.PublicKey()).
 		SetHashAlgo(sdkcrypto.SHA2_256).
 		SetWeight(sdk.AccountKeyWeightThreshold)
 
-	// create staking account
-	stakingAccountAddress, err := s.createAccount(
-		ctx,
-		fullAccountKey,
-		s.client.Account(),
-		s.client.SDKServiceAddress(),
-	)
-	require.NoError(s.T(), err)
-
 	_, stakeAmount, err := s.client.TokenAmountByRole(role)
 	require.NoError(s.T(), err)
 
-	// fund account with token amount to stake
-	result, err := s.fundAccount(ctx, stakingAccountAddress, fmt.Sprintf("%f", stakeAmount+10.0))
-	require.NoError(s.T(), err)
-	require.NoError(s.T(), result.Error)
-
-	stakingAccount, err := s.client.GetAccount(stakingAccountAddress)
-	require.NoError(s.T(), err)
-
-	// create staking collection
-	result, err = s.createStakingCollection(ctx, env, stakingAccountKey, stakingAccount)
-	require.NoError(s.T(), err)
-	require.NoError(s.T(), result.Error)
-
 	containerName := s.getTestContainerName(role)
 
-	// register node using staking collection
-	result, machineAccountAddr, err := s.SubmitStakingCollectionRegisterNodeTx(
-		ctx,
+	latestBlockID, err := s.client.GetLatestBlockID(ctx)
+	require.NoError(s.T(), err)
+
+	// create and register node
+	tx, err := utils.MakeCreateAndSetupNodeTx(
 		env,
-		stakingAccountKey,
-		stakingAccount,
+		s.client.Account(),
+		sdk.Identifier(latestBlockID),
+		fullStakingAcctKey,
+		fmt.Sprintf("%f", stakeAmount+10.0),
 		nodeID,
 		role,
 		testnet.GetPrivateNodeInfoAddress(containerName),
 		strings.TrimPrefix(networkingKey.PublicKey().String(), "0x"),
 		strings.TrimPrefix(stakingKey.PublicKey().String(), "0x"),
-		fmt.Sprintf("%f", stakeAmount),
 		machineAccountPubKey,
 	)
-
 	require.NoError(s.T(), err)
+
+	err = s.client.SignAndSendTransaction(ctx, tx)
+	require.NoError(s.T(), err)
+	result, err := s.client.WaitForSealed(ctx, tx.ID())
+	require.NoError(s.T(), err)
+	s.client.Account().Keys[0].SequenceNumber++
 	require.NoError(s.T(), result.Error)
+
+	accounts := s.client.CreatedAccounts(result)
+	stakingAccountAddress := accounts[0]
+	var machineAccountAddr sdk.Address
+	if role == flow.RoleCollection || role == flow.RoleConsensus {
+		machineAccountAddr = accounts[1]
+	}
 
 	result = s.SubmitSetApprovedListTx(ctx, env, append(s.net.Identities().NodeIDs(), nodeID)...)
 	require.NoError(s.T(), result.Error)
@@ -233,7 +231,7 @@ func (s *Suite) StakeNode(ctx context.Context, env templates.Environment, role f
 		NodeID:                  nodeID,
 		Role:                    role,
 		StakingAccountAddress:   stakingAccountAddress,
-		FullAccountKey:          fullAccountKey,
+		FullAccountKey:          fullStakingAcctKey,
 		StakingAccountKey:       stakingAccountKey,
 		StakingKey:              stakingKey,
 		NetworkingKey:           networkingKey,
@@ -242,32 +240,6 @@ func (s *Suite) StakeNode(ctx context.Context, env templates.Environment, role f
 		MachineAccountAddress:   machineAccountAddr,
 		ContainerName:           containerName,
 	}
-}
-
-// transfers tokens to receiver from service account
-func (s *Suite) fundAccount(ctx context.Context, receiver sdk.Address, tokenAmount string) (*sdk.TransactionResult, error) {
-	latestBlockID, err := s.client.GetLatestBlockID(ctx)
-	require.NoError(s.T(), err)
-
-	env := utils.LocalnetEnv()
-	transferTx, err := utils.MakeTransferTokenTx(
-		env,
-		receiver,
-		s.client.Account(),
-		0,
-		tokenAmount,
-		sdk.Identifier(latestBlockID),
-	)
-	require.NoError(s.T(), err)
-
-	err = s.client.SignAndSendTransaction(ctx, transferTx)
-	require.NoError(s.T(), err)
-
-	result, err := s.client.WaitForSealed(ctx, transferTx.ID())
-	require.NoError(s.T(), err)
-	s.client.Account().Keys[0].SequenceNumber++
-
-	return result, nil
 }
 
 // generates initial keys needed to bootstrap account
@@ -297,7 +269,7 @@ func (s *Suite) generateAccountKeys(role flow.Role) (
 	return
 }
 
-// creates a new flow account, can be used to test staking
+// createAccount creates a new flow account, can be used to test staking
 func (s *Suite) createAccount(ctx context.Context,
 	accountKey *sdk.AccountKey,
 	payerAccount *sdk.Account,
@@ -311,129 +283,6 @@ func (s *Suite) createAccount(ctx context.Context,
 
 	payerAccount.Keys[0].SequenceNumber++
 	return addr, nil
-}
-
-// creates a staking collection for the given node
-func (s *Suite) createStakingCollection(ctx context.Context, env templates.Environment, accountKey sdkcrypto.PrivateKey, stakingAccount *sdk.Account) (*sdk.TransactionResult, error) {
-	latestBlockID, err := s.client.GetLatestBlockID(ctx)
-	require.NoError(s.T(), err)
-
-	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA2_256)
-	require.NoError(s.T(), err)
-
-	createStakingCollectionTx, err := utils.MakeCreateStakingCollectionTx(
-		env,
-		stakingAccount,
-		0,
-		signer,
-		s.client.SDKServiceAddress(),
-		sdk.Identifier(latestBlockID),
-	)
-	require.NoError(s.T(), err)
-
-	err = s.client.SignAndSendTransaction(ctx, createStakingCollectionTx)
-	require.NoError(s.T(), err)
-
-	result, err := s.client.WaitForSealed(ctx, createStakingCollectionTx.ID())
-	require.NoError(s.T(), err)
-	stakingAccount.Keys[0].SequenceNumber++
-
-	return result, nil
-}
-
-// SubmitStakingCollectionRegisterNodeTx submits tx that calls StakingCollection.registerNode
-func (s *Suite) SubmitStakingCollectionRegisterNodeTx(
-	ctx context.Context,
-	env templates.Environment,
-	accountKey sdkcrypto.PrivateKey,
-	stakingAccount *sdk.Account,
-	nodeID flow.Identifier,
-	role flow.Role,
-	networkingAddress string,
-	networkingKey string,
-	stakingKey string,
-	amount string,
-	machineKey *sdk.AccountKey,
-) (*sdk.TransactionResult, sdk.Address, error) {
-	latestBlockID, err := s.client.GetLatestBlockID(ctx)
-	require.NoError(s.T(), err)
-
-	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA2_256)
-	require.NoError(s.T(), err)
-
-	registerNodeTx, err := utils.MakeStakingCollectionRegisterNodeTx(
-		env,
-		stakingAccount,
-		0,
-		signer,
-		s.client.SDKServiceAddress(),
-		sdk.Identifier(latestBlockID),
-		nodeID,
-		role,
-		networkingAddress,
-		networkingKey,
-		stakingKey,
-		amount,
-		machineKey,
-	)
-	require.NoError(s.T(), err)
-
-	err = s.client.SignAndSendTransaction(ctx, registerNodeTx)
-	require.NoError(s.T(), err)
-
-	result, err := s.client.WaitForSealed(ctx, registerNodeTx.ID())
-	require.NoError(s.T(), err)
-	stakingAccount.Keys[0].SequenceNumber++
-
-	if role == flow.RoleCollection || role == flow.RoleConsensus {
-		var machineAccountAddr sdk.Address
-		for _, event := range result.Events {
-			if event.Type == sdk.EventAccountCreated { // assume only one account created (safe because we control the transaction)
-				accountCreatedEvent := sdk.AccountCreatedEvent(event)
-				machineAccountAddr = accountCreatedEvent.Address()
-				break
-			}
-		}
-
-		require.NotZerof(s.T(), machineAccountAddr, "failed to create the machine account: %s", machineAccountAddr)
-		return result, machineAccountAddr, nil
-	}
-
-	return result, sdk.Address{}, nil
-}
-
-// SubmitStakingCollectionCloseStakeTx submits tx that calls StakingCollection.closeStake
-func (s *Suite) SubmitStakingCollectionCloseStakeTx(
-	ctx context.Context,
-	env templates.Environment,
-	accountKey sdkcrypto.PrivateKey,
-	stakingAccount *sdk.Account,
-	nodeID flow.Identifier,
-) (*sdk.TransactionResult, error) {
-	latestBlockID, err := s.client.GetLatestBlockID(ctx)
-	require.NoError(s.T(), err)
-
-	signer, err := sdkcrypto.NewInMemorySigner(accountKey, sdkcrypto.SHA2_256)
-	require.NoError(s.T(), err)
-
-	closeStakeTx, err := utils.MakeStakingCollectionCloseStakeTx(
-		env,
-		stakingAccount,
-		0,
-		signer,
-		s.client.SDKServiceAddress(),
-		sdk.Identifier(latestBlockID),
-		nodeID,
-	)
-	require.NoError(s.T(), err)
-
-	err = s.client.SignAndSendTransaction(ctx, closeStakeTx)
-	require.NoError(s.T(), err)
-
-	result, err := s.client.WaitForSealed(ctx, closeStakeTx.ID())
-	require.NoError(s.T(), err)
-	stakingAccount.Keys[0].SequenceNumber++
-	return result, nil
 }
 
 // removeNodeFromProtocol removes the given node from the protocol.
@@ -479,7 +328,7 @@ func (s *Suite) ExecuteGetProposedTableScript(ctx context.Context, env templates
 	return v
 }
 
-// SubmitSetApprovedListTx adds a node the the approved node list, this must be done when a node joins the protocol during the epoch staking phase
+// SubmitSetApprovedListTx adds a node to the approved node list, this must be done when a node joins the protocol during the epoch staking phase
 func (s *Suite) SubmitSetApprovedListTx(ctx context.Context, env templates.Environment, identities ...flow.Identifier) *sdk.TransactionResult {
 	ids := make([]cadence.Value, 0)
 	for _, id := range identities {

--- a/integration/tests/lib/util.go
+++ b/integration/tests/lib/util.go
@@ -239,6 +239,7 @@ func LogStatus(t *testing.T, ctx context.Context, log zerolog.Logger, client *te
 	finalized, err := client.GetLatestFinalizedBlockHeader(ctx)
 	if err != nil {
 		log.Err(err).Msg("failed to get finalized header")
+		return
 	}
 
 	sealed, err := snapshot.Head()

--- a/integration/utils/templates/create-and-setup-node.cdc
+++ b/integration/utils/templates/create-and-setup-node.cdc
@@ -12,7 +12,7 @@ transaction(
     networkingAddress: String,
     networkingKey: String,
     stakingKey: String,
-    machineAcctKey: Crypto.KeyListEntry ?) {
+    machineAcctKey: Crypto.KeyListEntry?) {
 
     prepare(service: AuthAccount) {
         // 1 - create the staking account for the new node.
@@ -22,7 +22,7 @@ transaction(
 
         // 2 - fund the new staking account
         //
-        let stakeDst = stakingAccount.getCapability(/public/flowTokenReceiver).borrow <&{FungibleToken.Receiver}> ()
+        let stakeDst = stakingAccount.getCapability(/public/flowTokenReceiver).borrow<&{FungibleToken.Receiver}>()
             ?? panic("Could not borrow receiver reference to the recipient's Vault")
         // withdraw stake from service account
         let stakeSrc = service.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
@@ -33,7 +33,7 @@ transaction(
         //
         let flowToken = stakingAccount.link<&FlowToken.Vault>(/private/flowTokenVault, target: /storage/flowTokenVault)!
         // Create a new Staking Collection and put it in storage
-        let stakingCollection = <-FlowStakingCollection.createStakingCollection(unlockedVault: flowToken, tokenHolder: nil)
+        let stakingCollection <-FlowStakingCollection.createStakingCollection(unlockedVault: flowToken, tokenHolder: nil)
         let stakingCollectionRef = &stakingCollection as &FlowStakingCollection.StakingCollection
         stakingAccount.save(<-stakingCollection, to: FlowStakingCollection.StakingCollectionStoragePath)
 
@@ -54,7 +54,7 @@ transaction(
             amount: stake,
             payer: service,
         ) {
-            machineAccount.keys.add(publicKey: machineAcctKey.publicKey, hashAlgorithm: machineAcctKey.hashAlgorithm, weight: machineAcctKey.weight)
+            machineAccount.keys.add(publicKey: machineAcctKey!.publicKey, hashAlgorithm: machineAcctKey!.hashAlgorithm, weight: machineAcctKey!.weight)
         }
     }
 }

--- a/integration/utils/transactions.go
+++ b/integration/utils/transactions.go
@@ -26,7 +26,8 @@ func LocalnetEnv() templates.Environment {
 	}
 }
 
-// MakeCreateAndSetupNodeTx ...
+// MakeCreateAndSetupNodeTx creates a transaction which creates and configures a new staking account.
+// It creates the account, funds it, and registers the node using the staking collection.
 func MakeCreateAndSetupNodeTx(
 	env templates.Environment,
 	service *sdk.Account,

--- a/integration/utils/transactions.go
+++ b/integration/utils/transactions.go
@@ -1,17 +1,18 @@
 package utils
 
 import (
-	"fmt"
+	_ "embed"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
-	fttemplates "github.com/onflow/flow-ft/lib/go/templates"
 
 	sdk "github.com/onflow/flow-go-sdk"
-	"github.com/onflow/flow-go-sdk/crypto"
 	sdktemplates "github.com/onflow/flow-go-sdk/templates"
 	"github.com/onflow/flow-go/model/flow"
 )
+
+//go:embed templates/create-and-setup-node.cdc
+var createAndSetupNodeTxScript string
 
 func LocalnetEnv() templates.Environment {
 	return templates.Environment{
@@ -25,103 +26,108 @@ func LocalnetEnv() templates.Environment {
 	}
 }
 
-// MakeCreateStakingCollectionTx submits transaction stakingCollection/setup_staking_collection.cdc
-// which will setup the staking collection object for the account
-func MakeCreateStakingCollectionTx(
+// MakeCreateAndSetupNodeTx ...
+func MakeCreateAndSetupNodeTx(
 	env templates.Environment,
-	stakingAccount *sdk.Account,
-	stakingAccountKeyID int,
-	stakingSigner crypto.Signer,
-	payerAddress sdk.Address,
+	service *sdk.Account,
 	latestBlockID sdk.Identifier,
-) (*sdk.Transaction, error) {
-	accountKey := stakingAccount.Keys[stakingAccountKeyID]
-	tx := sdk.NewTransaction().
-		SetScript(templates.GenerateCollectionSetup(env)).
-		SetGasLimit(9999).
-		SetReferenceBlockID(latestBlockID).
-		SetProposalKey(stakingAccount.Address, stakingAccountKeyID, accountKey.SequenceNumber).
-		SetPayer(payerAddress).
-		AddAuthorizer(stakingAccount.Address)
-
-	//signing the payload as used AddAuthorizer
-	err := tx.SignPayload(stakingAccount.Address, stakingAccountKeyID, stakingSigner)
-	if err != nil {
-		return nil, fmt.Errorf("could not sign payload: %w", err)
-	}
-
-	return tx, nil
-}
-
-func MakeStakingCollectionRegisterNodeTx(
-	env templates.Environment,
-	stakingAccount *sdk.Account,
-	stakingAccountKeyID int,
-	stakingSigner crypto.Signer,
-	payerAddress sdk.Address,
-	latestBlockID sdk.Identifier,
+	// transaction arguments
+	stakingAcctKey *sdk.AccountKey,
+	stake string,
 	nodeID flow.Identifier,
 	role flow.Role,
 	networkingAddress string,
 	networkingKey string,
 	stakingKey string,
-	amount string,
 	machineKey *sdk.AccountKey,
-) (*sdk.Transaction, error) {
-	accountKey := stakingAccount.Keys[stakingAccountKeyID]
+) (
+	*sdk.Transaction,
+	error,
+) {
+
+	script := []byte(templates.ReplaceAddresses(createAndSetupNodeTxScript, env))
 	tx := sdk.NewTransaction().
-		SetScript(templates.GenerateCollectionRegisterNode(env)).
+		SetScript(script).
 		SetGasLimit(9999).
 		SetReferenceBlockID(latestBlockID).
-		SetProposalKey(stakingAccount.Address, stakingAccountKeyID, accountKey.SequenceNumber).
-		SetPayer(payerAddress).
-		AddAuthorizer(stakingAccount.Address)
+		SetProposalKey(service.Address, 0, service.Keys[0].SequenceNumber).
+		AddAuthorizer(service.Address).
+		SetPayer(service.Address)
 
-	id, _ := cadence.NewString(nodeID.String())
-	err := tx.AddArgument(id)
+	// 0 - staking account key
+	cdcStakingAcctKey, err := sdktemplates.AccountKeyToCadenceCryptoKey(stakingAcctKey)
+	if err != nil {
+		return nil, err
+	}
+	err = tx.AddArgument(cdcStakingAcctKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// 1 - stake
+	cdcStake, err := cadence.NewUFix64(stake)
+	if err != nil {
+		return nil, err
+	}
+	err = tx.AddArgument(cdcStake)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2 - node ID
+	id, err := cadence.NewString(nodeID.String())
+	if err != nil {
+		return nil, err
+	}
+	err = tx.AddArgument(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3 - role
 	r := cadence.NewUInt8(uint8(role))
 	err = tx.AddArgument(r)
 	if err != nil {
 		return nil, err
 	}
 
-	networkingAddressCDC, _ := cadence.NewString(networkingAddress)
+	// 4 - networking address
+	networkingAddressCDC, err := cadence.NewString(networkingAddress)
+	if err != nil {
+		return nil, err
+	}
 	err = tx.AddArgument(networkingAddressCDC)
 	if err != nil {
 		return nil, err
 	}
 
-	networkingKeyCDC, _ := cadence.NewString(networkingKey)
+	// 5 - networking key
+	networkingKeyCDC, err := cadence.NewString(networkingKey)
+	if err != nil {
+		return nil, err
+	}
 	err = tx.AddArgument(networkingKeyCDC)
 	if err != nil {
 		return nil, err
 	}
 
-	stakingKeyCDC, _ := cadence.NewString(stakingKey)
-	err = tx.AddArgument(stakingKeyCDC)
+	// 6 - staking key
+	stakingKeyCDC, err := cadence.NewString(stakingKey)
 	if err != nil {
 		return nil, err
 	}
-
-	amountCDC, _ := cadence.NewUFix64(amount)
-	err = tx.AddArgument(amountCDC)
+	err = tx.AddArgument(stakingKeyCDC)
 	if err != nil {
 		return nil, err
 	}
 
 	if machineKey != nil {
 		// for collection/consensus nodes, register the machine account key
-		publicKey, err := sdktemplates.AccountKeyToCadenceCryptoKey(machineKey)
+		cdcMachineAcctKey, err := sdktemplates.AccountKeyToCadenceCryptoKey(machineKey)
 		if err != nil {
 			return nil, err
 		}
-		publicKeysCDC := cadence.NewArray([]cadence.Value{publicKey})
-
-		err = tx.AddArgument(cadence.NewOptional(publicKeysCDC))
+		err = tx.AddArgument(cadence.NewOptional(cdcMachineAcctKey))
 		if err != nil {
 			return nil, err
 		}
@@ -131,48 +137,6 @@ func MakeStakingCollectionRegisterNodeTx(
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	err = tx.SignPayload(stakingAccount.Address, stakingAccountKeyID, stakingSigner)
-	if err != nil {
-		return nil, fmt.Errorf("could not sign payload: %w", err)
-	}
-
-	return tx, nil
-}
-
-func MakeStakingCollectionCloseStakeTx(
-	env templates.Environment,
-	stakingAccount *sdk.Account,
-	stakingAccountKeyID int,
-	stakingSigner crypto.Signer,
-	payerAddress sdk.Address,
-	latestBlockID sdk.Identifier,
-	nodeID flow.Identifier,
-) (*sdk.Transaction, error) {
-	accountKey := stakingAccount.Keys[stakingAccountKeyID]
-	tx := sdk.NewTransaction().
-		SetScript(templates.GenerateCollectionCloseStake(env)).
-		SetGasLimit(9999).
-		SetReferenceBlockID(latestBlockID).
-		SetProposalKey(stakingAccount.Address, stakingAccountKeyID, accountKey.SequenceNumber).
-		SetPayer(payerAddress).
-		AddAuthorizer(stakingAccount.Address)
-
-	id, _ := cadence.NewString(nodeID.String())
-	err := tx.AddArgument(id)
-	if err != nil {
-		return nil, err
-	}
-
-	err = tx.AddArgument(cadence.NewOptional(nil))
-	if err != nil {
-		return nil, err
-	}
-
-	err = tx.SignPayload(stakingAccount.Address, stakingAccountKeyID, stakingSigner)
-	if err != nil {
-		return nil, fmt.Errorf("could not sign payload: %w", err)
 	}
 
 	return tx, nil
@@ -201,37 +165,5 @@ func MakeAdminRemoveNodeTx(
 		return nil, err
 	}
 
-	return tx, nil
-}
-
-func MakeTransferTokenTx(env templates.Environment, receiver sdk.Address, sender *sdk.Account, senderKeyID int, tokenAmount string, latestBlockID sdk.Identifier) (
-	*sdk.Transaction, error) {
-
-	senderKey := sender.Keys[senderKeyID]
-	fungible := sdk.HexToAddress(env.FungibleTokenAddress)
-	flowToken := sdk.HexToAddress(env.FlowTokenAddress)
-	script := fttemplates.GenerateTransferVaultScript(fungible, flowToken, "FlowToken")
-
-	tx := sdk.NewTransaction().
-		SetScript([]byte(script)).
-		SetGasLimit(100).
-		SetReferenceBlockID(latestBlockID).
-		SetProposalKey(sender.Address, senderKeyID, senderKey.SequenceNumber).
-		SetPayer(sender.Address).
-		AddAuthorizer(sender.Address)
-
-	amount, err := cadence.NewUFix64(tokenAmount)
-	if err != nil {
-		return nil, fmt.Errorf("could not add arguments to transaction :%w", err)
-	}
-	err = tx.AddArgument(amount)
-	if err != nil {
-		return nil, fmt.Errorf("could not add argument to transaction :%w", err)
-	}
-
-	err = tx.AddArgument(cadence.NewAddress(receiver))
-	if err != nil {
-		return nil, fmt.Errorf("could not add argument to transaction :%w", err)
-	}
 	return tx, nil
 }

--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -384,7 +384,8 @@ func SanityCheckConsensusNodeRootSnapshotValidity(snapshot protocol.Snapshot) er
 
 	sealingSegmentLength := uint64(len(sealingSegment.AllBlocks()))
 	transactionExpiry := uint64(flow.DefaultTransactionExpiry)
-	blocksInSpork := head.Height - sporkRootBlockHeight
+	blocksInSpork := head.Height - sporkRootBlockHeight + 1 // range is inclusive on both ends
+
 	// check if head.Height - sporkRootBlockHeight < flow.DefaultTransactionExpiry
 	// this is the case where we bootstrap early into the spork and there is simply not enough blocks
 	if blocksInSpork < transactionExpiry {

--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -351,22 +351,34 @@ func validateClusterQC(cluster protocol.Cluster) error {
 	return nil
 }
 
-// SanityCheckConsensusNodeRootSnapshotValidity performs a sanity check to make sure root snapshot has enough history
-// to participate in consensus, we require one of next conditions to pass:
-//  1. IsSporkRootSnapshot() == true - this is a snapshot build from a first block of spork.
-//  2. snapshot.SealingSegment().Len() >= transaction_expiry_limit - such snapshot
-//     has enough history to validate collection guarantees and can safely participate in consensus.
-func SanityCheckConsensusNodeRootSnapshotValidity(snapshot protocol.Snapshot) error {
+// ValidRootSnapshotContainsEntityExpiryRange performs a sanity check to make sure the
+// root snapshot has enough history to encompass at least one full entity expiry window.
+// Entities (in particular transactions and collections) may reference a block within
+// the past `flow.DefaultTransactionExpiry` blocks, so a new node must begin with at least
+// this many blocks worth of history leading up to the snapshot's root block.
+//
+// Currently, Access Nodes and Consensus Nodes require root snapshots passing this validator function.
+//
+//   - Consensus Nodes because they process guarantees referencing past blocks
+//   - Access Nodes because they index transactions referencing past blocks
+//
+// One of the following conditions must be satisfied to pass this validation:
+//  1. This is a snapshot build from a first block of spork
+//     -> there is no earlier history which transactions/collections could reference
+//  2. This snapshot sealing segment contains at least one expiry window of blocks
+//     -> all possible reference blocks in future transactions/collections will be within the initial history.
+//  3. This snapshot sealing segment includes the spork root block
+//     -> there is no earlier history which transactions/collections could reference
+func ValidRootSnapshotContainsEntityExpiryRange(snapshot protocol.Snapshot) error {
 	isSporkRootSnapshot, err := protocol.IsSporkRootSnapshot(snapshot)
 	if err != nil {
 		return fmt.Errorf("could not check if root snapshot is a spork root snapshot: %w", err)
 	}
-	// condition 1 satisfied
+	// Condition 1 satisfied
 	if isSporkRootSnapshot {
 		return nil
 	}
 
-	// check condition 2
 	head, err := snapshot.Head()
 	if err != nil {
 		return fmt.Errorf("could not query root snapshot head: %w", err)
@@ -386,6 +398,7 @@ func SanityCheckConsensusNodeRootSnapshotValidity(snapshot protocol.Snapshot) er
 	transactionExpiry := uint64(flow.DefaultTransactionExpiry)
 	blocksInSpork := head.Height - sporkRootBlockHeight + 1 // range is inclusive on both ends
 
+	// Condition 3:
 	// check if head.Height - sporkRootBlockHeight < flow.DefaultTransactionExpiry
 	// this is the case where we bootstrap early into the spork and there is simply not enough blocks
 	if blocksInSpork < transactionExpiry {
@@ -394,6 +407,7 @@ func SanityCheckConsensusNodeRootSnapshotValidity(snapshot protocol.Snapshot) er
 			return fmt.Errorf("invalid root snapshot length, expecting exactly (%d), got (%d)", blocksInSpork, sealingSegmentLength)
 		}
 	} else {
+		// Condition 2:
 		// the distance to spork root is more than transaction expiry, we need at least `transactionExpiry` many blocks
 		if sealingSegmentLength < transactionExpiry {
 			return fmt.Errorf("invalid root snapshot length, expecting at least (%d), got (%d)",

--- a/state/protocol/badger/validity_test.go
+++ b/state/protocol/badger/validity_test.go
@@ -107,13 +107,13 @@ func TestBootstrapInvalidEpochCommit(t *testing.T) {
 func TestBootstrapConsensusRootSnapshot(t *testing.T) {
 	t.Run("spork-root-snapshot", func(t *testing.T) {
 		rootSnapshot := unittest.RootSnapshotFixture(participants)
-		err := SanityCheckConsensusNodeRootSnapshotValidity(rootSnapshot)
+		err := ValidRootSnapshotContainsEntityExpiryRange(rootSnapshot)
 		require.NoError(t, err)
 	})
 	t.Run("not-enough-history", func(t *testing.T) {
 		rootSnapshot := unittest.RootSnapshotFixture(participants)
 		rootSnapshot.Encodable().Head.Height += 10 // advance height to be not spork root snapshot
-		err := SanityCheckConsensusNodeRootSnapshotValidity(rootSnapshot)
+		err := ValidRootSnapshotContainsEntityExpiryRange(rootSnapshot)
 		require.Error(t, err)
 	})
 	t.Run("enough-history-spork-just-started", func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestBootstrapConsensusRootSnapshot(t *testing.T) {
 		rootSnapshot.Encodable().Head.Height += flow.DefaultTransactionExpiry / 2
 		// add blocks to sealing segment
 		rootSnapshot.Encodable().SealingSegment.ExtraBlocks = unittest.BlockFixtures(int(flow.DefaultTransactionExpiry/2) - 1)
-		err := SanityCheckConsensusNodeRootSnapshotValidity(rootSnapshot)
+		err := ValidRootSnapshotContainsEntityExpiryRange(rootSnapshot)
 		require.NoError(t, err)
 	})
 	t.Run("enough-history-long-spork", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestBootstrapConsensusRootSnapshot(t *testing.T) {
 		rootSnapshot.Encodable().Head.Height += flow.DefaultTransactionExpiry * 2
 		// add blocks to sealing segment
 		rootSnapshot.Encodable().SealingSegment.ExtraBlocks = unittest.BlockFixtures(int(flow.DefaultTransactionExpiry) - 1)
-		err := SanityCheckConsensusNodeRootSnapshotValidity(rootSnapshot)
+		err := ValidRootSnapshotContainsEntityExpiryRange(rootSnapshot)
 		require.NoError(t, err)
 	})
 	t.Run("more-history-than-needed", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestBootstrapConsensusRootSnapshot(t *testing.T) {
 		rootSnapshot.Encodable().Head.Height += flow.DefaultTransactionExpiry * 2
 		// add blocks to sealing segment
 		rootSnapshot.Encodable().SealingSegment.ExtraBlocks = unittest.BlockFixtures(flow.DefaultTransactionExpiry * 2)
-		err := SanityCheckConsensusNodeRootSnapshotValidity(rootSnapshot)
+		err := ValidRootSnapshotContainsEntityExpiryRange(rootSnapshot)
 		require.NoError(t, err)
 	})
 }

--- a/state/protocol/badger/validity_test.go
+++ b/state/protocol/badger/validity_test.go
@@ -102,9 +102,10 @@ func TestBootstrapInvalidEpochCommit(t *testing.T) {
 	})
 }
 
-// TestBootstrapInvalidConsensusRootSnapshot tests that we perform correct sanity checks when bootstrapping consensus nodes
-// we expect that we only bootstrap snapshots with sufficient history.
-func TestBootstrapConsensusRootSnapshot(t *testing.T) {
+// TestEntityExpirySnapshotValidation tests that we perform correct sanity checks when
+// bootstrapping consensus nodes and access nodes we expect that we only bootstrap snapshots
+// with sufficient history.
+func TestEntityExpirySnapshotValidation(t *testing.T) {
 	t.Run("spork-root-snapshot", func(t *testing.T) {
 		rootSnapshot := unittest.RootSnapshotFixture(participants)
 		err := ValidRootSnapshotContainsEntityExpiryRange(rootSnapshot)
@@ -121,7 +122,7 @@ func TestBootstrapConsensusRootSnapshot(t *testing.T) {
 		// advance height to be not spork root snapshot, but still lower than transaction expiry
 		rootSnapshot.Encodable().Head.Height += flow.DefaultTransactionExpiry / 2
 		// add blocks to sealing segment
-		rootSnapshot.Encodable().SealingSegment.ExtraBlocks = unittest.BlockFixtures(int(flow.DefaultTransactionExpiry/2) - 1)
+		rootSnapshot.Encodable().SealingSegment.ExtraBlocks = unittest.BlockFixtures(int(flow.DefaultTransactionExpiry / 2))
 		err := ValidRootSnapshotContainsEntityExpiryRange(rootSnapshot)
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
This PR re-enables all epoch integration tests, reduces time taken by epoch integration tests by about 30%, and fixes a bug in the snapshot validator function.

- Fix off-by-one error in snapshot validator function
- Update documentation of validator, and require in Access Node as well
- Remove expiry-escape mitigation in AN ingestion, which is now covered by the snapshot validator
- Replace separate staking step transactions (create account, fund, set up staking collection, register node) with one custom transaction
- This enables reducing the epoch length by 50%, speeding up the test significantly

### Test Speed Notes
#### Local 
Before improvements, was 650-720s.
After improvements, is 400-430s
#### CI
Before improvements, was 30-40m
After improvements, is ~23m