### PR TITLE
Automatically update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "github.com/onflow/cadence"


### PR DESCRIPTION
This adds Github action to keep dependencies of Go and Github actions updated, which is good to do at regular intervals, this is currently set to 2 weeks we can increase it. This has proved to be valuable for us on tools repos. It might be very noise the first time it runs since it opens a PR for each update but then after first run it's great, but even that can be addressed by creating a Github workflow that merges those PRs if yall think is worth it.

p.s. I was asked by @turbolent to create this here as well https://github.com/onflow/flow-emulator/pull/278#pullrequestreview-1262402446