### PR TITLE
Remove Touch/Delete from view interface.

### DIFF
--- a/engine/execution/state/delta/view.go
+++ b/engine/execution/state/delta/view.go
@@ -194,24 +194,6 @@ func (v *View) Set(owner, key string, value flow.RegisterValue) error {
 	return nil
 }
 
-// Touch explicitly adds a register to the touched registers set.
-func (v *View) Touch(owner, key string) error {
-
-	k := flow.NewRegisterID(owner, key)
-
-	// capture register touch
-	v.regTouchSet[k] = struct{}{}
-	// increase reads
-	v.readsCount++
-
-	return nil
-}
-
-// Delete removes a register in this view.
-func (v *View) Delete(owner, key string) error {
-	return v.Set(owner, key, nil)
-}
-
 // Delta returns a record of the registers that were mutated in this view.
 func (v *View) Delta() Delta {
 	return v.delta

--- a/engine/execution/state/delta/view_test.go
+++ b/engine/execution/state/delta/view_test.go
@@ -76,14 +76,12 @@ func TestViewSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, flow.RegisterValue("orange"), b2)
 
-	t.Run("AfterDelete", func(t *testing.T) {
+	t.Run("Overwrite register", func(t *testing.T) {
 		v := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
 			return nil, nil
 		})
 
 		err := v.Set(registerID, "", flow.RegisterValue("apple"))
-		assert.NoError(t, err)
-		err = v.Delete(registerID, "")
 		assert.NoError(t, err)
 		err = v.Set(registerID, "", flow.RegisterValue("orange"))
 		assert.NoError(t, err)
@@ -141,12 +139,6 @@ func TestViewSet(t *testing.T) {
 		require.NoError(t, err)
 		hashIt(t, expSpock, registerID1Bytes)
 
-		// this part uses the delete functionality
-		// to check that only the register ID is written to the spock secret
-		err = v.Delete(registerID1, "")
-		require.NoError(t, err)
-		hashIt(t, expSpock, registerID1Bytes)
-
 		// this part checks that it always update the
 		// intermediate values and not just the final values
 		err = v.Set(registerID1, "", flow.RegisterValue("4"))
@@ -170,51 +162,6 @@ func TestViewSet(t *testing.T) {
 		t.Run("reflects in the snapshot", func(t *testing.T) {
 			assert.Equal(t, v.SpockSecret(), v.Interactions().SpockSecret)
 		})
-	})
-}
-
-func TestView_Delete(t *testing.T) {
-	registerID := "fruit"
-
-	t.Run("ValueNotSet", func(t *testing.T) {
-		v := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-			return nil, nil
-		})
-
-		b1, err := v.Get(registerID, "")
-		assert.NoError(t, err)
-		assert.Nil(t, b1)
-
-		err = v.Delete(registerID, "")
-		assert.NoError(t, err)
-
-		b2, err := v.Get(registerID, "")
-		assert.NoError(t, err)
-		assert.Nil(t, b2)
-	})
-
-	t.Run("ValueInCache", func(t *testing.T) {
-		v := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-			if owner == registerID {
-				return flow.RegisterValue("orange"), nil
-			}
-
-			return nil, nil
-		})
-
-		err := v.Set(registerID, "", flow.RegisterValue("apple"))
-		assert.NoError(t, err)
-
-		b1, err := v.Get(registerID, "")
-		assert.NoError(t, err)
-		assert.Equal(t, flow.RegisterValue("apple"), b1)
-
-		err = v.Delete(registerID, "")
-		assert.NoError(t, err)
-
-		b2, err := v.Get(registerID, "")
-		assert.NoError(t, err)
-		assert.Nil(t, b2)
 	})
 }
 
@@ -314,14 +261,12 @@ func TestViewMergeView(t *testing.T) {
 		assert.Equal(t, flow.RegisterValue("orange"), b)
 	})
 
-	t.Run("OverwriteDeletedValue", func(t *testing.T) {
+	t.Run("OverwriteValue", func(t *testing.T) {
 		v := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
 			return nil, nil
 		})
 
 		err := v.Set(registerID1, "", flow.RegisterValue("apple"))
-		assert.NoError(t, err)
-		err = v.Delete(registerID1, "")
 		assert.NoError(t, err)
 
 		chView := v.NewChild()
@@ -335,24 +280,6 @@ func TestViewMergeView(t *testing.T) {
 		assert.Equal(t, flow.RegisterValue("orange"), b)
 	})
 
-	t.Run("DeleteSetValue", func(t *testing.T) {
-		v := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-			return nil, nil
-		})
-
-		err := v.Set(registerID1, "", flow.RegisterValue("apple"))
-		assert.NoError(t, err)
-
-		chView := v.NewChild()
-		err = chView.Delete(registerID1, "")
-		assert.NoError(t, err)
-		err = v.MergeView(chView)
-		assert.NoError(t, err)
-
-		b, err := v.Get(registerID1, "")
-		assert.NoError(t, err)
-		assert.Nil(t, b)
-	})
 	t.Run("SpockDataMerge", func(t *testing.T) {
 		v := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
 			return nil, nil
@@ -493,9 +420,9 @@ func TestView_AllRegisterIDs(t *testing.T) {
 		err = v.Set("d", "", flow.RegisterValue("d_value"))
 		assert.NoError(t, err)
 
-		err = v.Touch("e", "")
+		err = v.Set("e", "", flow.RegisterValue("e_value"))
 		assert.NoError(t, err)
-		err = v.Touch("f", "")
+		err = v.Set("f", "", flow.RegisterValue("f_value"))
 		assert.NoError(t, err)
 
 		allRegs := v.Interactions().AllRegisterIDs()
@@ -525,9 +452,9 @@ func TestView_AllRegisterIDs(t *testing.T) {
 		err = vv.Set("d", "", flow.RegisterValue("d_value"))
 		assert.NoError(t, err)
 
-		err = vv.Touch("e", "")
+		err = vv.Set("e", "", flow.RegisterValue("e_value"))
 		assert.NoError(t, err)
-		err = vv.Touch("f", "")
+		err = vv.Set("f", "", flow.RegisterValue("f_value"))
 		assert.NoError(t, err)
 
 		err = v.MergeView(vv)

--- a/engine/execution/state/state_test.go
+++ b/engine/execution/state/state_test.go
@@ -178,7 +178,7 @@ func TestExecutionStateWithTrieStorage(t *testing.T) {
 
 		// update value and get resulting state commitment
 		view2 := es.NewView(sc2)
-		err = view2.Delete(registerID1, "")
+		err = view2.Set(registerID1, "", nil)
 		assert.NoError(t, err)
 
 		sc3, _, err := state.CommitDelta(l, view2.Delta(), sc2)

--- a/fvm/environment/accounts_test.go
+++ b/fvm/environment/accounts_test.go
@@ -144,29 +144,6 @@ func TestAccounts_GetPublicKeys(t *testing.T) {
 	})
 }
 
-// Some old account could be created without key count register
-// we recreate it in a test
-func TestAccounts_GetWithNoKeysCounter(t *testing.T) {
-	view := utils.NewSimpleView()
-
-	txnState := state.NewTransactionState(view, state.DefaultParameters())
-	accounts := environment.NewAccounts(txnState)
-	address := flow.HexToAddress("01")
-
-	err := accounts.Create(nil, address)
-	require.NoError(t, err)
-
-	err = view.Delete(
-		string(address.Bytes()),
-		"public_key_count")
-
-	require.NoError(t, err)
-
-	require.NotPanics(t, func() {
-		_, _ = accounts.Get(address)
-	})
-}
-
 func TestAccounts_SetContracts(t *testing.T) {
 
 	address := flow.HexToAddress("0x01")

--- a/fvm/state/view.go
+++ b/fvm/state/view.go
@@ -31,6 +31,4 @@ type View interface {
 type Ledger interface {
 	Set(owner, key string, value flow.RegisterValue) error
 	Get(owner, key string) (flow.RegisterValue, error)
-	Touch(owner, key string) error
-	Delete(owner, key string) error
 }

--- a/fvm/utils/view.go
+++ b/fvm/utils/view.go
@@ -108,14 +108,6 @@ func (v *SimpleView) UpdatedRegisters() flow.RegisterEntries {
 	return entries
 }
 
-func (v *SimpleView) Touch(owner, key string) error {
-	return v.Ledger.Touch(owner, key)
-}
-
-func (v *SimpleView) Delete(owner, key string) error {
-	return v.Ledger.Delete(owner, key)
-}
-
 func (v *SimpleView) Payloads() []ledger.Payload {
 	return v.Ledger.Payloads()
 }
@@ -179,22 +171,6 @@ func (m *MapLedger) Get(owner, key string) (flow.RegisterValue, error) {
 	k := flow.RegisterID{Owner: owner, Key: key}
 	m.RegisterTouches[k] = struct{}{}
 	return m.Registers[k], nil
-}
-
-func (m *MapLedger) Touch(owner, key string) error {
-	m.Lock()
-	defer m.Unlock()
-
-	m.RegisterTouches[flow.RegisterID{Owner: owner, Key: key}] = struct{}{}
-	return nil
-}
-
-func (m *MapLedger) Delete(owner, key string) error {
-	m.Lock()
-	defer m.Unlock()
-
-	delete(m.RegisterTouches, flow.RegisterID{Owner: owner, Key: key})
-	return nil
 }
 
 func registerIdToLedgerKey(id flow.RegisterID) ledger.Key {

--- a/utils/debug/remoteView.go
+++ b/utils/debug/remoteView.go
@@ -203,13 +203,3 @@ func (v *RemoteView) AllRegisterIDs() []flow.RegisterID {
 func (v *RemoteView) UpdatedRegisters() flow.RegisterEntries {
 	panic("Not implemented yet")
 }
-
-func (v *RemoteView) Touch(owner, key string) error {
-	// no-op for now
-	return nil
-}
-
-func (v *RemoteView) Delete(owner, key string) error {
-	v.Delta[owner+"~"+key] = nil
-	return nil
-}


### PR DESCRIPTION
This simplifies changing view implementations.  We can add them back in the future if the support is needed.