### PR TITLE
Refactor meter/interaction limits control

### DIFF
--- a/fvm/derived/table_test.go
+++ b/fvm/derived/table_test.go
@@ -838,7 +838,7 @@ func (computer *testValueComputer) Compute(
 	error,
 ) {
 	computer.called = true
-	_, err := txnState.Get("addr", key, true)
+	_, err := txnState.Get("addr", key)
 	if err != nil {
 		return 0, err
 	}

--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -149,8 +149,7 @@ func NewAccountCreator(
 func (creator *accountCreator) bytes() ([]byte, error) {
 	stateBytes, err := creator.txnState.Get(
 		"",
-		state.AddressStateKey,
-		creator.txnState.EnforceLimits())
+		state.AddressStateKey)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to read address generator state from the state: %w",
@@ -197,8 +196,7 @@ func (creator *accountCreator) NextAddress() (flow.Address, error) {
 	err = creator.txnState.Set(
 		"",
 		state.AddressStateKey,
-		addressGenerator.Bytes(),
-		creator.txnState.EnforceLimits())
+		addressGenerator.Bytes())
 	if err != nil {
 		return address, fmt.Errorf(
 			"failed to update the state with address generator state: %w",

--- a/fvm/environment/derived_data_invalidator_test.go
+++ b/fvm/environment/derived_data_invalidator_test.go
@@ -268,7 +268,7 @@ func TestMeterParamOverridesUpdated(t *testing.T) {
 		view := utils.NewSimpleView()
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 
-		err := txnState.Set(owner, key, flow.RegisterValue("blah"), false)
+		err := txnState.Set(owner, key, flow.RegisterValue("blah"))
 		require.NoError(t, err)
 
 		env := environment.NewTransactionEnvironment(

--- a/fvm/environment/meter.go
+++ b/fvm/environment/meter.go
@@ -73,10 +73,7 @@ func (meter *meterImpl) MeterComputation(
 	kind common.ComputationKind,
 	intensity uint,
 ) error {
-	if meter.txnState.EnforceLimits() {
-		return meter.txnState.MeterComputation(kind, intensity)
-	}
-	return nil
+	return meter.txnState.MeterComputation(kind, intensity)
 }
 
 func (meter *meterImpl) ComputationIntensities() meter.MeteredComputationIntensities {
@@ -88,10 +85,7 @@ func (meter *meterImpl) ComputationUsed() uint64 {
 }
 
 func (meter *meterImpl) MeterMemory(usage common.MemoryUsage) error {
-	if meter.txnState.EnforceLimits() {
-		return meter.txnState.MeterMemory(usage.Kind, uint(usage.Amount))
-	}
-	return nil
+	return meter.txnState.MeterMemory(usage.Kind, uint(usage.Amount))
 }
 
 func (meter *meterImpl) MemoryEstimate() uint64 {
@@ -99,10 +93,7 @@ func (meter *meterImpl) MemoryEstimate() uint64 {
 }
 
 func (meter *meterImpl) MeterEmittedEvent(byteSize uint64) error {
-	if meter.txnState.EnforceLimits() {
-		return meter.txnState.MeterEmittedEvent(byteSize)
-	}
-	return nil
+	return meter.txnState.MeterEmittedEvent(byteSize)
 }
 
 func (meter *meterImpl) TotalEmittedEventBytes() uint64 {

--- a/fvm/environment/uuids.go
+++ b/fvm/environment/uuids.go
@@ -57,10 +57,7 @@ func NewUUIDGenerator(
 
 // GetUUID reads uint64 byte value for uuid from the state
 func (generator *uUIDGenerator) getUUID() (uint64, error) {
-	stateBytes, err := generator.txnState.Get(
-		"",
-		state.UUIDKey,
-		generator.txnState.EnforceLimits())
+	stateBytes, err := generator.txnState.Get("", state.UUIDKey)
 	if err != nil {
 		return 0, fmt.Errorf("cannot get uuid byte from state: %w", err)
 	}
@@ -73,11 +70,7 @@ func (generator *uUIDGenerator) getUUID() (uint64, error) {
 func (generator *uUIDGenerator) setUUID(uuid uint64) error {
 	bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, uuid)
-	err := generator.txnState.Set(
-		"",
-		state.UUIDKey,
-		bytes,
-		generator.txnState.EnforceLimits())
+	err := generator.txnState.Set("", state.UUIDKey, bytes)
 	if err != nil {
 		return fmt.Errorf("cannot set uuid byte to state: %w", err)
 	}

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -29,12 +29,12 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		key := "key1"
 		value := createByteArray(1)
 		// set key1 on parent
-		err := st.Set("address", key, value, true)
+		err := st.Set("address", key, value)
 		require.NoError(t, err)
 
 		// read key1 on child
 		stChild := st.NewChild()
-		v, err := stChild.Get("address", key, true)
+		v, err := stChild.Get("address", key)
 		require.NoError(t, err)
 		require.Equal(t, v, value)
 	})
@@ -45,11 +45,11 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		stChild := st.NewChild()
 
 		// set key2 on child
-		err := stChild.Set("address", key, value, true)
+		err := stChild.Set("address", key, value)
 		require.NoError(t, err)
 
 		// read key2 on parent
-		v, err := st.Get("address", key, true)
+		v, err := st.Get("address", key)
 		require.NoError(t, err)
 		require.Equal(t, len(v), 0)
 	})
@@ -60,11 +60,11 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		stChild := st.NewChild()
 
 		// set key3 on child
-		err := stChild.Set("address", key, value, true)
+		err := stChild.Set("address", key, value)
 		require.NoError(t, err)
 
 		// read before merge
-		v, err := st.Get("address", key, true)
+		v, err := st.Get("address", key)
 		require.NoError(t, err)
 		require.Equal(t, len(v), 0)
 
@@ -73,7 +73,7 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		require.NoError(t, err)
 
 		// read key3 on parent
-		v, err = st.Get("address", key, true)
+		v, err = st.Get("address", key)
 		require.NoError(t, err)
 		require.Equal(t, v, value)
 	})
@@ -82,7 +82,7 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		key := "key4"
 		value := createByteArray(4)
 		// set key4 on parent
-		err := st.Set("address", key, value, true)
+		err := st.Set("address", key, value)
 		require.NoError(t, err)
 
 		// now should be part of the ledger
@@ -99,12 +99,12 @@ func TestState_MaxValueSize(t *testing.T) {
 
 	// update should pass
 	value := createByteArray(5)
-	err := st.Set("address", "key", value, true)
+	err := st.Set("address", "key", value)
 	require.NoError(t, err)
 
 	// update shouldn't pass
 	value = createByteArray(7)
-	err = st.Set("address", "key", value, true)
+	err = st.Set("address", "key", value)
 	require.Error(t, err)
 }
 
@@ -113,19 +113,19 @@ func TestState_MaxKeySize(t *testing.T) {
 	st := state.NewState(view, state.DefaultParameters().WithMaxKeySizeAllowed(4))
 
 	// read
-	_, err := st.Get("1", "2", true)
+	_, err := st.Get("1", "2")
 	require.NoError(t, err)
 
 	// read
-	_, err = st.Get("123", "234", true)
+	_, err = st.Get("123", "234")
 	require.Error(t, err)
 
 	// update
-	err = st.Set("1", "2", []byte{}, true)
+	err = st.Set("1", "2", []byte{})
 	require.NoError(t, err)
 
 	// read
-	err = st.Set("123", "234", []byte{}, true)
+	err = st.Set("123", "234", []byte{})
 	require.Error(t, err)
 
 }
@@ -139,17 +139,17 @@ func TestState_MaxInteraction(t *testing.T) {
 				meter.DefaultParameters().WithStorageInteractionLimit(12)))
 
 	// read - interaction 2
-	_, err := st.Get("1", "2", true)
+	_, err := st.Get("1", "2")
 	require.Equal(t, st.InteractionUsed(), uint64(2))
 	require.NoError(t, err)
 
 	// read - interaction 8
-	_, err = st.Get("123", "234", true)
+	_, err = st.Get("123", "234")
 	require.Equal(t, st.InteractionUsed(), uint64(8))
 	require.NoError(t, err)
 
 	// read - interaction 14
-	_, err = st.Get("234", "345", true)
+	_, err = st.Get("234", "345")
 	require.Equal(t, st.InteractionUsed(), uint64(14))
 	require.Error(t, err)
 
@@ -161,7 +161,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	stChild := st.NewChild()
 
 	// update - 0
-	err = stChild.Set("1", "2", []byte{'A'}, true)
+	err = stChild.Set("1", "2", []byte{'A'})
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), uint64(0))
 
@@ -171,17 +171,17 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Equal(t, st.InteractionUsed(), uint64(3))
 
 	// read - interaction 3 (already in read cache)
-	_, err = st.Get("1", "2", true)
+	_, err = st.Get("1", "2")
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), uint64(3))
 
 	// read - interaction 5
-	_, err = st.Get("2", "3", true)
+	_, err = st.Get("2", "3")
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), uint64(5))
 
 	// read - interaction 7
-	_, err = st.Get("3", "4", true)
+	_, err = st.Get("3", "4")
 	require.Error(t, err)
 
 }

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -23,8 +23,6 @@ type nestedTransactionStackFrame struct {
 // TransactionState provides active transaction states and facilitates common
 // state management operations.
 type TransactionState struct {
-	enforceLimits bool
-
 	// NOTE: The first frame is always the main transaction, and is not
 	// poppable during the course of the transaction.
 	nestedTransactions []nestedTransactionStackFrame
@@ -47,7 +45,6 @@ func NewTransactionState(
 ) *TransactionState {
 	startState := NewState(startView, params)
 	return &TransactionState{
-		enforceLimits: true,
 		nestedTransactions: []nestedTransactionStackFrame{
 			nestedTransactionStackFrame{
 				state:            startState,
@@ -333,21 +330,19 @@ func (s *TransactionState) RestartNestedTransaction(
 func (s *TransactionState) Get(
 	owner string,
 	key string,
-	enforceLimit bool,
 ) (
 	flow.RegisterValue,
 	error,
 ) {
-	return s.currentState().Get(owner, key, enforceLimit)
+	return s.currentState().Get(owner, key)
 }
 
 func (s *TransactionState) Set(
 	owner string,
 	key string,
 	value flow.RegisterValue,
-	enforceLimit bool,
 ) error {
-	return s.currentState().Set(owner, key, value, enforceLimit)
+	return s.currentState().Set(owner, key, value)
 }
 
 func (s *TransactionState) UpdatedAddresses() []flow.Address {
@@ -412,34 +407,7 @@ func (s *TransactionState) UpdatedRegisters() flow.RegisterEntries {
 	return s.currentState().UpdatedRegisters()
 }
 
-// EnableAllLimitEnforcements enables all the limits
-func (s *TransactionState) EnableAllLimitEnforcements() {
-	s.enforceLimits = true
-}
-
-// DisableAllLimitEnforcements disables all the limits
-func (s *TransactionState) DisableAllLimitEnforcements() {
-	s.enforceLimits = false
-}
-
 // RunWithAllLimitsDisabled runs f with limits disabled
 func (s *TransactionState) RunWithAllLimitsDisabled(f func()) {
-	if f == nil {
-		return
-	}
-	current := s.enforceLimits
-	s.enforceLimits = false
-	f()
-	s.enforceLimits = current
-}
-
-// EnforceComputationLimits returns if the computation limits should be enforced
-// or not.
-func (s *TransactionState) EnforceComputationLimits() bool {
-	return s.enforceLimits
-}
-
-// EnforceInteractionLimits returns if the interaction limits should be enforced or not
-func (s *TransactionState) EnforceLimits() bool {
-	return s.enforceLimits
+	s.currentState().RunWithAllLimitsDisabled(f)
 }

--- a/fvm/state/transaction_state_test.go
+++ b/fvm/state/transaction_state_test.go
@@ -54,18 +54,18 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 	key := "key"
 	val := createByteArray(2)
 
-	err = txn.Set(addr, key, val, true)
+	err = txn.Set(addr, key, val)
 	require.NoError(t, err)
 
-	v, err := nestedState2.Get(addr, key, true)
+	v, err := nestedState2.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = nestedState1.Get(addr, key, true)
+	v, err = nestedState1.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -77,11 +77,11 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 1, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(id1))
 
-	v, err = nestedState1.Get(addr, key, true)
+	v, err = nestedState1.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -91,7 +91,7 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 0, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(txn.MainTransactionId()))
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 }
@@ -177,19 +177,19 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	addr := "address"
 	key := "key"
 
-	v, err := restrictedNestedState2.Get(addr, key, true)
+	v, err := restrictedNestedState2.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = restrictedNestedState1.Get(addr, key, true)
+	v, err = restrictedNestedState1.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = nestedState.Get(addr, key, true)
+	v, err = nestedState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -202,7 +202,7 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 		state.DefaultParameters(),
 	)
 
-	err = cachedState.Set(addr, key, val, true)
+	err = cachedState.Set(addr, key, val)
 	require.NoError(t, err)
 
 	err = txn.AttachAndCommit(cachedState)
@@ -211,19 +211,19 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 3, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(restrictedId2))
 
-	v, err = restrictedNestedState2.Get(addr, key, true)
+	v, err = restrictedNestedState2.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = restrictedNestedState1.Get(addr, key, true)
+	v, err = restrictedNestedState1.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = nestedState.Get(addr, key, true)
+	v, err = nestedState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -236,15 +236,15 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 2, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(restrictedId1))
 
-	v, err = restrictedNestedState1.Get(addr, key, true)
+	v, err = restrictedNestedState1.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = nestedState.Get(addr, key, true)
+	v, err = nestedState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -255,11 +255,11 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 1, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(id1))
 
-	v, err = nestedState.Get(addr, key, true)
+	v, err = nestedState.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -269,7 +269,7 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 0, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(mainId))
 
-	v, err = mainState.Get(addr, key, true)
+	v, err = mainState.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 }
@@ -290,7 +290,7 @@ func TestRestartNestedTransaction(t *testing.T) {
 		_, err := txn.BeginNestedTransaction()
 		require.NoError(t, err)
 
-		err = txn.Set(addr, key, val, true)
+		err = txn.Set(addr, key, val)
 		require.NoError(t, err)
 	}
 
@@ -303,7 +303,7 @@ func TestRestartNestedTransaction(t *testing.T) {
 		_, err := txn.BeginParseRestrictedNestedTransaction(loc)
 		require.NoError(t, err)
 
-		err = txn.Set(addr, key, val, true)
+		err = txn.Set(addr, key, val)
 		require.NoError(t, err)
 	}
 
@@ -322,7 +322,7 @@ func TestRestartNestedTransaction(t *testing.T) {
 
 	require.Greater(t, state.InteractionUsed(), uint64(0))
 
-	v, err := state.Get(addr, key, true)
+	v, err := state.Get(addr, key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 }
@@ -339,7 +339,7 @@ func TestRestartNestedTransactionWithInvalidId(t *testing.T) {
 	key := "key"
 	val := createByteArray(2)
 
-	err = txn.Set(addr, key, val, true)
+	err = txn.Set(addr, key, val)
 	require.NoError(t, err)
 
 	var otherId state.NestedTransactionId
@@ -358,7 +358,7 @@ func TestRestartNestedTransactionWithInvalidId(t *testing.T) {
 
 	require.True(t, txn.IsCurrent(id))
 
-	v, err := txn.Get(addr, key, true)
+	v, err := txn.Get(addr, key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 }
@@ -486,40 +486,40 @@ func TestParseRestrictedCannotCommitLocationMismatch(t *testing.T) {
 func TestPauseAndResume(t *testing.T) {
 	txn := newTestTransactionState()
 
-	val, err := txn.Get("addr", "key", true)
+	val, err := txn.Get("addr", "key")
 	require.NoError(t, err)
 	require.Nil(t, val)
 
 	id1, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	err = txn.Set("addr", "key", createByteArray(2), true)
+	err = txn.Set("addr", "key", createByteArray(2))
 	require.NoError(t, err)
 
-	val, err = txn.Get("addr", "key", true)
+	val, err = txn.Get("addr", "key")
 	require.NoError(t, err)
 	require.NotNil(t, val)
 
 	pausedState, err := txn.Pause(id1)
 	require.NoError(t, err)
 
-	val, err = txn.Get("addr", "key", true)
+	val, err = txn.Get("addr", "key")
 	require.NoError(t, err)
 	require.Nil(t, val)
 
 	txn.Resume(pausedState)
 
-	val, err = txn.Get("addr", "key", true)
+	val, err = txn.Get("addr", "key")
 	require.NoError(t, err)
 	require.NotNil(t, val)
 
-	err = txn.Set("addr2", "key2", createByteArray(2), true)
+	err = txn.Set("addr2", "key2", createByteArray(2))
 	require.NoError(t, err)
 
 	_, err = txn.Commit(id1)
 	require.NoError(t, err)
 
-	val, err = txn.Get("addr2", "key2", true)
+	val, err = txn.Get("addr2", "key2")
 	require.NoError(t, err)
 	require.NotNil(t, val)
 }
@@ -530,10 +530,10 @@ func TestInvalidCommittedStateModification(t *testing.T) {
 	id1, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	err = txn.Set("addr", "key", createByteArray(2), true)
+	err = txn.Set("addr", "key", createByteArray(2))
 	require.NoError(t, err)
 
-	_, err = txn.Get("addr", "key", true)
+	_, err = txn.Get("addr", "key")
 	require.NoError(t, err)
 
 	committedState, err := txn.Commit(id1)
@@ -545,10 +545,10 @@ func TestInvalidCommittedStateModification(t *testing.T) {
 
 	txn.Resume(committedState)
 
-	err = txn.Set("addr", "key", createByteArray(2), true)
+	err = txn.Set("addr", "key", createByteArray(2))
 	require.ErrorContains(t, err, "cannot Set on a committed state")
 
-	_, err = txn.Get("addr", "key", true)
+	_, err = txn.Get("addr", "key")
 	require.ErrorContains(t, err, "cannot Get on a committed state")
 
 	_, err = txn.Commit(id1)

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -278,7 +278,7 @@ func (executor *transactionExecutor) ExecuteTransactionBody() error {
 
 	if executor.errs.CollectedError() {
 		invalidator = nil
-		executor.errorExecution()
+		executor.txnState.RunWithAllLimitsDisabled(executor.errorExecution)
 		if executor.errs.CollectedFailure() {
 			return executor.errs.ErrorOrNil()
 		}
@@ -405,9 +405,6 @@ func (executor *transactionExecutor) normalExecution() (
 
 // Clear changes and try to deduct fees again.
 func (executor *transactionExecutor) errorExecution() {
-	executor.txnState.DisableAllLimitEnforcements()
-	defer executor.txnState.EnableAllLimitEnforcements()
-
 	// log transaction as failed
 	executor.env.Logger().Info().
 		Err(executor.errs.ErrorOrNil()).


### PR DESCRIPTION
1. Replace EnableAllLimitEnforcements/DisableAllLimitEnforcements with RunWithAllLimitsDisabled
2. Remove enforceLimit parameter from Get/Set calls.
3. Internalize meter enforceLimits check into State.

This enables us to compose view implementations (meter/interaction limits view, spock view, delta, etc) in the future.