### PR TITLE
Use consistent method for creating temp dirs

### DIFF
--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -578,9 +578,15 @@ func WithAdditionalFlag(flag string) func(config *NodeConfig) {
 	}
 }
 
-// integrationBootstrapDir creates a temporary directory at /tmp/flow-integration-bootstrap
-func integrationBootstrapDir() (string, error) {
-	return os.MkdirTemp(TmpRoot, integrationBootstrap)
+// tempDir creates a temporary directory at /tmp/flow-integration-bootstrap
+func tempDir(t *testing.T) string {
+	dir, err := os.MkdirTemp(TmpRoot, integrationBootstrap)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.RemoveAll(dir)
+		require.NoError(t, err)
+	})
+	return dir
 }
 
 func PrepareFlowNetwork(t *testing.T, networkConf NetworkConfig, chainID flow.ChainID) *FlowNetwork {
@@ -609,10 +615,13 @@ func PrepareFlowNetwork(t *testing.T, networkConf NetworkConfig, chainID flow.Ch
 	})
 
 	// create a temporary directory to store all bootstrapping files
-	bootstrapDir, err := integrationBootstrapDir()
-	require.Nil(t, err)
+	bootstrapDir := tempDir(t)
 
 	t.Logf("BootstrapDir: %s \n", bootstrapDir)
+	t.Cleanup(func() {
+		err := os.RemoveAll(bootstrapDir)
+		require.NoError(t, err)
+	})
 
 	bootstrapData, err := BootstrapNetwork(networkConf, bootstrapDir, chainID)
 	require.Nil(t, err)
@@ -813,7 +822,7 @@ func (net *FlowNetwork) AddObserver(t *testing.T, ctx context.Context, conf *Obs
 	}()
 
 	// Setup directories
-	tmpdir := t.TempDir()
+	tmpdir := tempDir(t)
 
 	flowDataDir := net.makeDir(t, tmpdir, DefaultFlowDataDir)
 	nodeBootstrapDir := net.makeDir(t, tmpdir, DefaultBootstrapDir)
@@ -921,7 +930,7 @@ func (net *FlowNetwork) AddNode(t *testing.T, bootstrapDir string, nodeConf Cont
 		HostConfig: &container.HostConfig{},
 	}
 
-	tmpdir := t.TempDir()
+	tmpdir := tempDir(t)
 
 	t.Logf("%v adding container %v for %v node", time.Now().UTC(), nodeConf.ContainerName, nodeConf.Role)
 

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -618,10 +618,6 @@ func PrepareFlowNetwork(t *testing.T, networkConf NetworkConfig, chainID flow.Ch
 	bootstrapDir := tempDir(t)
 
 	t.Logf("BootstrapDir: %s \n", bootstrapDir)
-	t.Cleanup(func() {
-		err := os.RemoveAll(bootstrapDir)
-		require.NoError(t, err)
-	})
 
 	bootstrapData, err := BootstrapNetwork(networkConf, bootstrapDir, chainID)
 	require.Nil(t, err)


### PR DESCRIPTION
This PR changes integration test utilities to use a consistent method and root location when creating temporary directories for use in tests. 

This is to mitigate an issue where integration tests would fail on macOS, due to a permissions issue when initializing bootstrap and data directories for Docker containers.
```
lchown /var/folders/bm/wbf3kfs91911lr5w6qyw126c0000gn/T/TestEpochJoinAndLeaveANTestEpochJoinAndLeaveAN4216456854/001/bootstrap/execution-state/00000000: operation not permitted
```

As far as I can tell, `t.TempDir()` created directories which caused `operation not permitted` errors, whereas `os.MkdirTemp("/tmp", ...)` did not. We aren't sure what causes the two methods to behave differently at this point, but using "the good one" consistently works to fix the test failure. 