### PR TITLE
[Audit] Revamps connection manager

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1057,7 +1057,10 @@ func (builder *FlowAccessNodeBuilder) enqueuePublicNetworkInit() {
 //   - Default Flow libp2p pubsub options
 func (builder *FlowAccessNodeBuilder) initLibP2PFactory(networkKey crypto.PrivateKey, bindAddress string, networkMetrics module.LibP2PMetrics) p2pbuilder.LibP2PFactoryFunc {
 	return func() (p2p.LibP2PNode, error) {
-		connManager := connection.NewConnManager(builder.Logger, networkMetrics)
+		connManager, err := connection.NewConnManager(builder.Logger, networkMetrics, builder.ConnectionManagerConfig)
+		if err != nil {
+			return nil, fmt.Errorf("could not create connection manager: %w", err)
+		}
 
 		libp2pNode, err := p2pbuilder.NewNodeBuilder(
 			builder.Logger,

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -199,6 +199,7 @@ type NetworkConfig struct {
 	UnicastMessageTimeout       time.Duration
 	DNSCacheTTL                 time.Duration
 	LibP2PResourceManagerConfig *p2pbuilder.ResourceManagerConfig
+	ConnectionManagerConfig     *connection.ManagerConfig
 }
 
 // NodeConfig contains all the derived parameters such the NodeID, private keys etc. and initialized instances of
@@ -279,6 +280,7 @@ func DefaultBaseConfig() *BaseConfig {
 			UnicastRateLimitDryRun:          true,
 			DNSCacheTTL:                     dns.DefaultTimeToLive,
 			LibP2PResourceManagerConfig:     p2pbuilder.DefaultResourceManagerConfig(),
+			ConnectionManagerConfig:         connection.DefaultConnManagerConfig(),
 		},
 		nodeIDHex:        NotSet,
 		AdminAddr:        NotSet,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -171,6 +171,8 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 	fnb.flags.Float64Var(&fnb.BaseConfig.LibP2PResourceManagerConfig.MemoryLimitRatio, "libp2p-memory-limit", defaultConfig.LibP2PResourceManagerConfig.MemoryLimitRatio, "ratio of available memory to be used by libp2p (in (0,1])")
 	fnb.flags.IntVar(&fnb.BaseConfig.ConnectionManagerConfig.LowWatermark, "libp2p-connmgr-low", defaultConfig.ConnectionManagerConfig.LowWatermark, "low watermarking for libp2p connection manager")
 	fnb.flags.IntVar(&fnb.BaseConfig.ConnectionManagerConfig.HighWatermark, "libp2p-connmgr-high", defaultConfig.ConnectionManagerConfig.HighWatermark, "high watermarking for libp2p connection manager")
+	fnb.flags.DurationVar(&fnb.BaseConfig.ConnectionManagerConfig.GracePeriod, "libp2p-connmgr-grace", defaultConfig.ConnectionManagerConfig.GracePeriod, "grace period for libp2p connection manager")
+	fnb.flags.DurationVar(&fnb.BaseConfig.ConnectionManagerConfig.SilencePeriod, "libp2p-connmgr-silence", defaultConfig.ConnectionManagerConfig.SilencePeriod, "silence period for libp2p connection manager")
 
 	fnb.flags.DurationVar(&fnb.BaseConfig.DNSCacheTTL, "dns-cache-ttl", defaultConfig.DNSCacheTTL, "time-to-live for dns cache")
 	fnb.flags.StringSliceVar(&fnb.BaseConfig.PreferredUnicastProtocols, "preferred-unicast-protocols", nil, "preferred unicast protocols in ascending order of preference")

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -169,6 +169,9 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 
 	fnb.flags.Float64Var(&fnb.BaseConfig.LibP2PResourceManagerConfig.FileDescriptorsRatio, "libp2p-fd-ratio", defaultConfig.LibP2PResourceManagerConfig.FileDescriptorsRatio, "ratio of available file descriptors to be used by libp2p (in (0,1])")
 	fnb.flags.Float64Var(&fnb.BaseConfig.LibP2PResourceManagerConfig.MemoryLimitRatio, "libp2p-memory-limit", defaultConfig.LibP2PResourceManagerConfig.MemoryLimitRatio, "ratio of available memory to be used by libp2p (in (0,1])")
+	fnb.flags.IntVar(&fnb.BaseConfig.ConnectionManagerConfig.LowWatermark, "libp2p-connmgr-low", defaultConfig.ConnectionManagerConfig.LowWatermark, "low watermarking for libp2p connection manager")
+	fnb.flags.IntVar(&fnb.BaseConfig.ConnectionManagerConfig.HighWatermark, "libp2p-connmgr-high", defaultConfig.ConnectionManagerConfig.HighWatermark, "high watermarking for libp2p connection manager")
+
 	fnb.flags.DurationVar(&fnb.BaseConfig.DNSCacheTTL, "dns-cache-ttl", defaultConfig.DNSCacheTTL, "time-to-live for dns cache")
 	fnb.flags.StringSliceVar(&fnb.BaseConfig.PreferredUnicastProtocols, "preferred-unicast-protocols", nil, "preferred unicast protocols in ascending order of preference")
 	fnb.flags.Uint32Var(&fnb.BaseConfig.NetworkReceivedMessageCacheSize, "networking-receive-cache-size", p2p.DefaultReceiveCacheSize,

--- a/network/p2p/connection/connManager.go
+++ b/network/p2p/connection/connManager.go
@@ -74,6 +74,10 @@ func NewConnManager(logger zerolog.Logger, metric module.LibP2PConnectionMetrics
 		DisconnectedF: cn.Disconnected,
 	}
 	cn.n = n
+	cn.log.Info().
+		Int("low_watermark", cfg.LowWatermark).
+		Int("high_watermark", cfg.HighWatermark).
+		Msg("connection manager initialized")
 
 	return cn, nil
 }

--- a/network/p2p/connection/connManager.go
+++ b/network/p2p/connection/connManager.go
@@ -3,26 +3,32 @@ package connection
 import (
 	"context"
 	"fmt"
-	"sync"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pconnmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/network/p2p/connection/internal"
 )
 
 const (
-	// DefaultHighWatermark is the default value for the high watermark (i.e., max number of connections).
+	// defaultHighWatermark is the default value for the high watermark (i.e., max number of connections).
 	// We assume a complete topology graph with maximum of 500 nodes.
 	defaultHighWatermark = 500
 
-	// DefaultLowWatermark is the default value for the low watermark (i.e., min number of connections).
+	// defaultLowWatermark is the default value for the low watermark (i.e., min number of connections).
 	// We assume a complete topology graph with minimum of 450 nodes.
 	defaultLowWatermark = 450
+
+	// defaultGracePeriod is the default value for the grace period (i.e., time to wait before pruning a new connection).
+	defaultGracePeriod = 1 * time.Minute
+
+	// defaultSilencePeriod is the default value for the silence period (i.e., time to wait before start pruning connections).
+	defaultSilencePeriod = 10 * time.Second
 )
 
 // DefaultConnManagerConfig returns the default configuration for the connection manager.
@@ -30,6 +36,8 @@ func DefaultConnManagerConfig() *ManagerConfig {
 	return &ManagerConfig{
 		HighWatermark: defaultHighWatermark,
 		LowWatermark:  defaultLowWatermark,
+		GracePeriod:   defaultGracePeriod,
+		SilencePeriod: defaultSilencePeriod,
 	}
 }
 
@@ -38,11 +46,10 @@ func DefaultConnManagerConfig() *ManagerConfig {
 // This implementation updates networking metrics when a peer connection is added or removed
 type ConnManager struct {
 	basicConnMgr *libp2pconnmgr.BasicConnMgr
+	basicNotifee network.Notifiee
 	n            network.Notifiee // the notifiee callback provided by libp2p
 	log          zerolog.Logger   // logger to log connection, stream and other statistics about libp2p
 	metrics      module.LibP2PConnectionMetrics
-	mu           sync.RWMutex
-	protected    map[peer.ID]map[string]struct{}
 }
 
 var _ connmgr.ConnManager = (*ConnManager)(nil)
@@ -53,6 +60,11 @@ type ManagerConfig struct {
 	// their connections terminated) until LowWatermark peers remain.
 	HighWatermark int // naming from libp2p
 	LowWatermark  int // naming from libp2p
+
+	// SilencePeriod is the time to wait before start pruning connections.
+	SilencePeriod time.Duration // naming from libp2p
+	// GracePeriod is the time to wait before pruning a new connection.
+	GracePeriod time.Duration // naming from libp2p
 }
 
 type ConnManagerOpt func(*ConnManager)
@@ -68,7 +80,11 @@ func WithNotifyBundle(n *network.NotifyBundle) ConnManagerOpt {
 // The error is not benign, and we should crash the node if it happens.
 // It is a malpractice to start the node without connection manager.
 func NewConnManager(logger zerolog.Logger, metric module.LibP2PConnectionMetrics, cfg *ManagerConfig, opt ...ConnManagerOpt) (*ConnManager, error) {
-	basic, err := libp2pconnmgr.NewConnManager(cfg.LowWatermark, cfg.HighWatermark)
+	basic, err := libp2pconnmgr.NewConnManager(
+		cfg.LowWatermark,
+		cfg.HighWatermark,
+		libp2pconnmgr.WithGracePeriod(cfg.GracePeriod),
+		libp2pconnmgr.WithSilencePeriod(cfg.SilencePeriod))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create basic connection manager of libp2p: %w", err)
 	}
@@ -76,16 +92,11 @@ func NewConnManager(logger zerolog.Logger, metric module.LibP2PConnectionMetrics
 	cn := &ConnManager{
 		log:          logger.With().Str("component", "connection_manager").Logger(),
 		metrics:      metric,
-		protected:    make(map[peer.ID]map[string]struct{}),
 		basicConnMgr: basic,
 	}
-	n := &network.NotifyBundle{
-		ListenCloseF:  cn.ListenCloseNotifee,
-		ListenF:       cn.ListenNotifee,
-		ConnectedF:    cn.Connected,
-		DisconnectedF: cn.Disconnected,
-	}
-	cn.n = n
+
+	// aggregates the notifiee callbacks from libp2p and our own notifiee into one.
+	cn.n = internal.NewRelayNotifee(internal.NewLoggerNotifiee(cn.log, metric), cn.basicConnMgr.Notifee())
 
 	for _, apply := range opt {
 		apply(cn)
@@ -94,6 +105,8 @@ func NewConnManager(logger zerolog.Logger, metric module.LibP2PConnectionMetrics
 	cn.log.Info().
 		Int("low_watermark", cfg.LowWatermark).
 		Int("high_watermark", cfg.HighWatermark).
+		Dur("grace_period", cfg.GracePeriod).
+		Dur("silence_period", cfg.SilencePeriod).
 		Msg("connection manager initialized")
 
 	return cn, nil
@@ -103,100 +116,16 @@ func (cm *ConnManager) Notifee() network.Notifiee {
 	return cm.n
 }
 
-// ListenNotifee is called by libp2p when network starts listening on an addr
-func (cm *ConnManager) ListenNotifee(_ network.Network, m multiaddr.Multiaddr) {
-	cm.log.Debug().Str("multiaddress", m.String()).Msg("listen started")
-}
-
-// called by libp2p when network stops listening on an addr
-// * This is never called back by libp2p currently and may be a bug on their side
-func (cm *ConnManager) ListenCloseNotifee(_ network.Network, m multiaddr.Multiaddr) {
-	// just log the multiaddress on which we listen
-	cm.log.Debug().Str("multiaddress", m.String()).Msg("listen stopped")
-}
-
-// Connected is called by libp2p when a connection opened
-func (cm *ConnManager) Connected(n network.Network, con network.Conn) {
-	cm.logConnectionUpdate(n, con, "connection established")
-	cm.updateConnectionMetric(n)
-}
-
-// Disconnected is called by libp2p when a connection closed
-func (cm *ConnManager) Disconnected(n network.Network, con network.Conn) {
-	cm.logConnectionUpdate(n, con, "connection removed")
-	cm.updateConnectionMetric(n)
-}
-
-func (cm *ConnManager) updateConnectionMetric(n network.Network) {
-	var totalInbound uint = 0
-	var totalOutbound uint = 0
-
-	for _, conn := range n.Conns() {
-		switch conn.Stat().Direction {
-		case network.DirInbound:
-			totalInbound++
-		case network.DirOutbound:
-			totalOutbound++
-		}
-	}
-
-	cm.metrics.InboundConnections(totalInbound)
-	cm.metrics.OutboundConnections(totalOutbound)
-}
-
-func (cm *ConnManager) logConnectionUpdate(n network.Network, con network.Conn, logMsg string) {
-	cm.log.Debug().
-		Str("remote_peer", con.RemotePeer().String()).
-		Str("remote_address", con.RemoteMultiaddr().String()).
-		Str("local_peer", con.LocalPeer().String()).
-		Str("local_address", con.LocalMultiaddr().String()).
-		Str("direction", con.Stat().Direction.String()).
-		Int("total_connections", len(n.Conns())).
-		Msg(logMsg)
-}
-
 func (cm *ConnManager) Protect(id peer.ID, tag string) {
-	cm.mu.Lock()
-	defer cm.mu.Unlock()
-
-	tags, ok := cm.protected[id]
-	if !ok {
-		tags = make(map[string]struct{}, 2)
-		cm.protected[id] = tags
-	}
-	tags[tag] = struct{}{}
+	cm.basicConnMgr.Protect(id, tag)
 }
 
-func (cm *ConnManager) Unprotect(id peer.ID, tag string) (protected bool) {
-	cm.mu.Lock()
-	defer cm.mu.Unlock()
-
-	tags, ok := cm.protected[id]
-	if !ok {
-		return false
-	}
-	if delete(tags, tag); len(tags) == 0 {
-		delete(cm.protected, id)
-		return false
-	}
-	return true
+func (cm *ConnManager) Unprotect(id peer.ID, tag string) bool {
+	return cm.basicConnMgr.Unprotect(id, tag)
 }
 
-func (cm *ConnManager) IsProtected(id peer.ID, tag string) (protected bool) {
-	cm.mu.RLock()
-	defer cm.mu.RUnlock()
-
-	tags, ok := cm.protected[id]
-	if !ok {
-		return false
-	}
-
-	if tag == "" {
-		return true
-	}
-
-	_, protected = tags[tag]
-	return protected
+func (cm *ConnManager) IsProtected(id peer.ID, tag string) bool {
+	return cm.basicConnMgr.IsProtected(id, tag)
 }
 
 func (cm *ConnManager) TagPeer(id peer.ID, s string, i int) {

--- a/network/p2p/connection/connManager.go
+++ b/network/p2p/connection/connManager.go
@@ -46,10 +46,8 @@ func DefaultConnManagerConfig() *ManagerConfig {
 // This implementation updates networking metrics when a peer connection is added or removed
 type ConnManager struct {
 	basicConnMgr *libp2pconnmgr.BasicConnMgr
-	basicNotifee network.Notifiee
 	n            network.Notifiee // the notifiee callback provided by libp2p
 	log          zerolog.Logger   // logger to log connection, stream and other statistics about libp2p
-	metrics      module.LibP2PConnectionMetrics
 }
 
 var _ connmgr.ConnManager = (*ConnManager)(nil)
@@ -83,7 +81,6 @@ func NewConnManager(logger zerolog.Logger, metric module.LibP2PConnectionMetrics
 
 	cn := &ConnManager{
 		log:          logger.With().Str("component", "connection_manager").Logger(),
-		metrics:      metric,
 		basicConnMgr: basic,
 	}
 

--- a/network/p2p/connection/connManager.go
+++ b/network/p2p/connection/connManager.go
@@ -55,6 +55,10 @@ type ManagerConfig struct {
 	LowWatermark  int // naming from libp2p
 }
 
+// NewConnManager creates a new connection manager.
+// It errors if creating the basic connection manager of libp2p fails.
+// The error is not benign, and we should crash the node if it happens.
+// It is a malpractice to start the node without connection manager.
 func NewConnManager(logger zerolog.Logger, metric module.LibP2PConnectionMetrics, cfg *ManagerConfig) (*ConnManager, error) {
 	basic, err := libp2pconnmgr.NewConnManager(cfg.LowWatermark, cfg.HighWatermark)
 	if err != nil {

--- a/network/p2p/connection/connManager.go
+++ b/network/p2p/connection/connManager.go
@@ -1,11 +1,14 @@
 package connection
 
 import (
+	"context"
+	"fmt"
 	"sync"
 
 	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	libp2pconnmgr "github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/rs/zerolog"
 
@@ -16,31 +19,48 @@ import (
 // It is called back by libp2p when certain events occur such as opening/closing a stream, opening/closing connection etc.
 // This implementation updates networking metrics when a peer connection is added or removed
 type ConnManager struct {
-	connmgr.NullConnMgr                  // a null conn mgr provided by libp2p to allow implementing only the functions needed
-	n                   network.Notifiee // the notifiee callback provided by libp2p
-	log                 zerolog.Logger   // logger to log connection, stream and other statistics about libp2p
-	metrics             module.LibP2PConnectionMetrics
-
-	plk       sync.RWMutex
-	protected map[peer.ID]map[string]struct{}
+	basicConnMgr *libp2pconnmgr.BasicConnMgr
+	n            network.Notifiee // the notifiee callback provided by libp2p
+	log          zerolog.Logger   // logger to log connection, stream and other statistics about libp2p
+	metrics      module.LibP2PConnectionMetrics
+	mu           sync.RWMutex
+	protected    map[peer.ID]map[string]struct{}
 }
 
 var _ connmgr.ConnManager = (*ConnManager)(nil)
 
-func NewConnManager(log zerolog.Logger, metrics module.LibP2PConnectionMetrics) *ConnManager {
-	cn := &ConnManager{
-		log:         log.With().Str("component", "conn_manager").Logger(),
-		NullConnMgr: connmgr.NullConnMgr{},
-		metrics:     metrics,
-		protected:   make(map[peer.ID]map[string]struct{}),
+type ManagerConfig struct {
+	logger zerolog.Logger
+	metric module.LibP2PConnectionMetrics
+
+	// HighWatermark and LowWatermark govern the number of connections are maintained by the ConnManager.
+	// When the peer count exceeds the HighWatermark, as many peers will be pruned (and
+	// their connections terminated) until LowWatermark peers remain.
+	HighWatermark int // naming from libp2p
+	LowWatermark  int // naming from libp2p
+}
+
+func NewConnManager(cfg *ManagerConfig) (*ConnManager, error) {
+	basic, err := libp2pconnmgr.NewConnManager(cfg.LowWatermark, cfg.HighWatermark)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create basic connection manager of libp2p: %w", err)
 	}
-	n := &network.NotifyBundle{ListenCloseF: cn.ListenCloseNotifee,
+
+	cn := &ConnManager{
+		log:          cfg.logger.With().Str("component", "connection_manager").Logger(),
+		metrics:      cfg.metric,
+		protected:    make(map[peer.ID]map[string]struct{}),
+		basicConnMgr: basic,
+	}
+	n := &network.NotifyBundle{
+		ListenCloseF:  cn.ListenCloseNotifee,
 		ListenF:       cn.ListenNotifee,
 		ConnectedF:    cn.Connected,
-		DisconnectedF: cn.Disconnected}
+		DisconnectedF: cn.Disconnected,
+	}
 	cn.n = n
 
-	return cn
+	return cn, nil
 }
 
 func (cm *ConnManager) Notifee() network.Notifiee {
@@ -48,15 +68,15 @@ func (cm *ConnManager) Notifee() network.Notifiee {
 }
 
 // ListenNotifee is called by libp2p when network starts listening on an addr
-func (cm *ConnManager) ListenNotifee(n network.Network, m multiaddr.Multiaddr) {
+func (cm *ConnManager) ListenNotifee(_ network.Network, m multiaddr.Multiaddr) {
 	cm.log.Debug().Str("multiaddress", m.String()).Msg("listen started")
 }
 
 // called by libp2p when network stops listening on an addr
 // * This is never called back by libp2p currently and may be a bug on their side
-func (cm *ConnManager) ListenCloseNotifee(n network.Network, m multiaddr.Multiaddr) {
-	// just log the multiaddress  on which we listen
-	cm.log.Debug().Str("multiaddress", m.String()).Msg("listen stopped ")
+func (cm *ConnManager) ListenCloseNotifee(_ network.Network, m multiaddr.Multiaddr) {
+	// just log the multiaddress on which we listen
+	cm.log.Debug().Str("multiaddress", m.String()).Msg("listen stopped")
 }
 
 // Connected is called by libp2p when a connection opened
@@ -91,17 +111,17 @@ func (cm *ConnManager) updateConnectionMetric(n network.Network) {
 func (cm *ConnManager) logConnectionUpdate(n network.Network, con network.Conn, logMsg string) {
 	cm.log.Debug().
 		Str("remote_peer", con.RemotePeer().String()).
-		Str("remote_addrs", con.RemoteMultiaddr().String()).
+		Str("remote_address", con.RemoteMultiaddr().String()).
 		Str("local_peer", con.LocalPeer().String()).
-		Str("local_addrs", con.LocalMultiaddr().String()).
+		Str("local_address", con.LocalMultiaddr().String()).
 		Str("direction", con.Stat().Direction.String()).
 		Int("total_connections", len(n.Conns())).
 		Msg(logMsg)
 }
 
 func (cm *ConnManager) Protect(id peer.ID, tag string) {
-	cm.plk.Lock()
-	defer cm.plk.Unlock()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
 
 	tags, ok := cm.protected[id]
 	if !ok {
@@ -112,8 +132,8 @@ func (cm *ConnManager) Protect(id peer.ID, tag string) {
 }
 
 func (cm *ConnManager) Unprotect(id peer.ID, tag string) (protected bool) {
-	cm.plk.Lock()
-	defer cm.plk.Unlock()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
 
 	tags, ok := cm.protected[id]
 	if !ok {
@@ -127,8 +147,8 @@ func (cm *ConnManager) Unprotect(id peer.ID, tag string) (protected bool) {
 }
 
 func (cm *ConnManager) IsProtected(id peer.ID, tag string) (protected bool) {
-	cm.plk.RLock()
-	defer cm.plk.RUnlock()
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 
 	tags, ok := cm.protected[id]
 	if !ok {
@@ -141,4 +161,28 @@ func (cm *ConnManager) IsProtected(id peer.ID, tag string) (protected bool) {
 
 	_, protected = tags[tag]
 	return protected
+}
+
+func (cm *ConnManager) TagPeer(id peer.ID, s string, i int) {
+	cm.basicConnMgr.TagPeer(id, s, i)
+}
+
+func (cm *ConnManager) UntagPeer(p peer.ID, tag string) {
+	cm.basicConnMgr.UntagPeer(p, tag)
+}
+
+func (cm *ConnManager) UpsertTag(p peer.ID, tag string, upsert func(int) int) {
+	cm.basicConnMgr.UpsertTag(p, tag, upsert)
+}
+
+func (cm *ConnManager) GetTagInfo(p peer.ID) *connmgr.TagInfo {
+	return cm.basicConnMgr.GetTagInfo(p)
+}
+
+func (cm *ConnManager) TrimOpenConns(ctx context.Context) {
+	cm.basicConnMgr.TrimOpenConns(ctx)
+}
+
+func (cm *ConnManager) Close() error {
+	return cm.basicConnMgr.Close()
 }

--- a/network/p2p/connection/connManager.go
+++ b/network/p2p/connection/connManager.go
@@ -25,6 +25,8 @@ type ConnManager struct {
 	protected map[peer.ID]map[string]struct{}
 }
 
+var _ connmgr.ConnManager = (*ConnManager)(nil)
+
 func NewConnManager(log zerolog.Logger, metrics module.LibP2PConnectionMetrics) *ConnManager {
 	cn := &ConnManager{
 		log:         log.With().Str("component", "conn_manager").Logger(),

--- a/network/p2p/connection/connManager_test.go
+++ b/network/p2p/connection/connManager_test.go
@@ -149,8 +149,8 @@ func TestConnectionManager_Watermarking(t *testing.T) {
 	for _, otherNode := range otherNodes {
 		if len(thisNode.Host().Network().ConnsToPeer(otherNode.Host().ID())) == 0 {
 			require.NoError(t, thisNode.Host().Connect(ctx, otherNode.Host().Peerstore().PeerInfo(otherNode.Host().ID())))
+			break // we only need to connect to one node.
 		}
-		break // we only need to connect to one node.
 	}
 
 	// wait for another grace period to expire and connection manager kick in.

--- a/network/p2p/connection/connManager_test.go
+++ b/network/p2p/connection/connManager_test.go
@@ -51,7 +51,8 @@ func TestConnectionManagerProtection(t *testing.T) {
 
 	log := zerolog.New(os.Stderr).Level(zerolog.ErrorLevel)
 	noopMetrics := metrics.NewNoopCollector()
-	connManager := connection.NewConnManager(log, noopMetrics)
+	connManager, err := connection.NewConnManager(log, noopMetrics, connection.DefaultConnManagerConfig())
+	require.NoError(t, err)
 
 	testCases := [][]fun{
 		// single stream created on a connection

--- a/network/p2p/connection/connManager_test.go
+++ b/network/p2p/connection/connManager_test.go
@@ -94,19 +94,24 @@ func generatePeerInfo(t *testing.T) peer.ID {
 	return pInfo.ID
 }
 
+// TestConnectionManager_Watermarking tests that the connection manager prunes connections when the number of connections
+// exceeds the high watermark and that it does not prune connections when the number of connections is below the low watermark.
 func TestConnectionManager_Watermarking(t *testing.T) {
 	sporkId := unittest.IdentifierFixture()
 	ctx, cancel := context.WithCancel(context.Background())
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
 	defer cancel()
 
+	cfg := &connection.ManagerConfig{
+		HighWatermark: 4,               // whenever the number of connections exceeds 4, connection manager prune connections.
+		LowWatermark:  2,               // connection manager prune connections until the number of connections is 2.
+		GracePeriod:   1 * time.Second, // extra connections will be pruned if they are older than a second (just for testing).
+		SilencePeriod: 5 * time.Second, // connection manager prune checking kicks in every 5 seconds (just for testing).
+	}
 	thisConnMgr, err := connection.NewConnManager(
 		unittest.Logger(),
 		metrics.NewNoopCollector(),
-		&connection.ManagerConfig{
-			HighWatermark: 4,
-			LowWatermark:  2,
-		})
+		cfg)
 	require.NoError(t, err)
 
 	thisNode, _ := p2ptest.NodeFixture(
@@ -122,12 +127,37 @@ func TestConnectionManager_Watermarking(t *testing.T) {
 	p2ptest.StartNodes(t, signalerCtx, nodes, 100*time.Millisecond)
 	defer p2ptest.StopNodes(t, nodes, cancel, 100*time.Millisecond)
 
-	// connect this node to all other nodes
+	// connect this node to all other nodes.
 	for _, otherNode := range otherNodes {
 		require.NoError(t, thisNode.Host().Connect(ctx, otherNode.Host().Peerstore().PeerInfo(otherNode.Host().ID())))
 	}
 
-	time.Sleep(20 * time.Second)
+	// ensures this node is connected to all other nodes (based on the number of connections).
+	require.Eventuallyf(t, func() bool {
+		return len(thisNode.Host().Network().Conns()) == len(otherNodes)
+	}, 1*time.Second, 100*time.Millisecond, "expected %d connections, got %d", len(otherNodes), len(thisNode.Host().Network().Conns()))
 
-	fmt.Println(len(thisNode.Host().Network().Conns()))
+	// wait for grace period to expire and connection manager kick in as the number of connections is beyond high watermark.
+	time.Sleep(5 * time.Second)
+
+	// ensures that eventually connection manager closes connections till the low watermark is reached.
+	require.Eventuallyf(t, func() bool {
+		return len(thisNode.Host().Network().Conns()) == cfg.LowWatermark
+	}, 1*time.Second, 100*time.Millisecond, "expected %d connections, got %d", cfg.LowWatermark, len(thisNode.Host().Network().Conns()))
+
+	// connects this node to one of the other nodes that is pruned by connection manager.
+	for _, otherNode := range otherNodes {
+		if len(thisNode.Host().Network().ConnsToPeer(otherNode.Host().ID())) == 0 {
+			require.NoError(t, thisNode.Host().Connect(ctx, otherNode.Host().Peerstore().PeerInfo(otherNode.Host().ID())))
+		}
+		break // we only need to connect to one node.
+	}
+
+	// wait for another grace period to expire and connection manager kick in.
+	time.Sleep(5 * time.Second)
+
+	// ensures that connection manager does not close any connections as the number of connections is below low watermark.
+	require.Eventuallyf(t, func() bool {
+		return len(thisNode.Host().Network().Conns()) == cfg.LowWatermark+1
+	}, 1*time.Second, 100*time.Millisecond, "expected %d connections, got %d", cfg.LowWatermark+1, len(thisNode.Host().Network().Conns()))
 }

--- a/network/p2p/connection/connManager_test.go
+++ b/network/p2p/connection/connManager_test.go
@@ -45,7 +45,7 @@ var isNotProtected = fun{
 	false,
 }
 
-// TestConnectionManagerProtection tests that multiple protect and unprotect calls result in the correct IsProtected
+// TestConnectionManagerProtection tests that multiple protected and unprotected calls result in the correct IsProtected
 // status for a peer ID
 func TestConnectionManagerProtection(t *testing.T) {
 

--- a/network/p2p/connection/internal/loggerNotifiee.go
+++ b/network/p2p/connection/internal/loggerNotifiee.go
@@ -28,28 +28,29 @@ func (l *LoggerNotifiee) Listen(n network.Network, multiaddr multiaddr.Multiaddr
 }
 
 func (l *LoggerNotifiee) ListenClose(n network.Network, multiaddr multiaddr.Multiaddr) {
-	l.logger.Debug().Str("multiaddress", multiaddr.String()).Msg("listen started")
+	l.logger.Info().Str("multiaddress", multiaddr.String()).Msg("listen started")
 }
 
 func (l *LoggerNotifiee) Connected(n network.Network, conn network.Conn) {
 	l.updateConnectionMetric(n)
-	l.logConnectionUpdate(n, conn, "connection established")
+	lg := l.connectionUpdateLogger(n, conn)
+	lg.Info().Msg("connection established")
 }
 
 func (l *LoggerNotifiee) Disconnected(n network.Network, conn network.Conn) {
 	l.updateConnectionMetric(n)
-	l.logConnectionUpdate(n, conn, "connection removed")
+	lg := l.connectionUpdateLogger(n, conn)
+	lg.Warn().Msg("connection closed")
 }
 
-func (l *LoggerNotifiee) logConnectionUpdate(n network.Network, con network.Conn, logMsg string) {
-	l.logger.Debug().
+func (l *LoggerNotifiee) connectionUpdateLogger(n network.Network, con network.Conn) zerolog.Logger {
+	return l.logger.With().
 		Str("remote_peer", con.RemotePeer().String()).
 		Str("remote_address", con.RemoteMultiaddr().String()).
 		Str("local_peer", con.LocalPeer().String()).
 		Str("local_address", con.LocalMultiaddr().String()).
 		Str("direction", con.Stat().Direction.String()).
-		Int("total_connections", len(n.Conns())).
-		Msg(logMsg)
+		Int("total_connections", len(n.Conns())).Logger()
 }
 
 func (l *LoggerNotifiee) updateConnectionMetric(n network.Network) {

--- a/network/p2p/connection/internal/loggerNotifiee.go
+++ b/network/p2p/connection/internal/loggerNotifiee.go
@@ -1,0 +1,70 @@
+package internal
+
+import (
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/module"
+)
+
+type LoggerNotifiee struct {
+	logger  zerolog.Logger
+	metrics module.LibP2PConnectionMetrics
+}
+
+var _ network.Notifiee = (*LoggerNotifiee)(nil)
+
+func NewLoggerNotifiee(logger zerolog.Logger, metrics module.LibP2PConnectionMetrics) *LoggerNotifiee {
+	return &LoggerNotifiee{
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+func (l *LoggerNotifiee) Listen(n network.Network, multiaddr multiaddr.Multiaddr) {
+	// just log the multiaddress on which we listen
+	l.logger.Info().Str("multiaddress", multiaddr.String()).Msg("listen stopped")
+}
+
+func (l *LoggerNotifiee) ListenClose(n network.Network, multiaddr multiaddr.Multiaddr) {
+	l.logger.Debug().Str("multiaddress", multiaddr.String()).Msg("listen started")
+}
+
+func (l *LoggerNotifiee) Connected(n network.Network, conn network.Conn) {
+	l.updateConnectionMetric(n)
+	l.logConnectionUpdate(n, conn, "connection established")
+}
+
+func (l *LoggerNotifiee) Disconnected(n network.Network, conn network.Conn) {
+	l.updateConnectionMetric(n)
+	l.logConnectionUpdate(n, conn, "connection removed")
+}
+
+func (l *LoggerNotifiee) logConnectionUpdate(n network.Network, con network.Conn, logMsg string) {
+	l.logger.Debug().
+		Str("remote_peer", con.RemotePeer().String()).
+		Str("remote_address", con.RemoteMultiaddr().String()).
+		Str("local_peer", con.LocalPeer().String()).
+		Str("local_address", con.LocalMultiaddr().String()).
+		Str("direction", con.Stat().Direction.String()).
+		Int("total_connections", len(n.Conns())).
+		Msg(logMsg)
+}
+
+func (l *LoggerNotifiee) updateConnectionMetric(n network.Network) {
+	var totalInbound uint = 0
+	var totalOutbound uint = 0
+
+	for _, conn := range n.Conns() {
+		switch conn.Stat().Direction {
+		case network.DirInbound:
+			totalInbound++
+		case network.DirOutbound:
+			totalOutbound++
+		}
+	}
+
+	l.metrics.InboundConnections(totalInbound)
+	l.metrics.OutboundConnections(totalOutbound)
+}

--- a/network/p2p/connection/internal/relayNotifee.go
+++ b/network/p2p/connection/internal/relayNotifee.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type RelayNotifee struct {
+	n []network.Notifiee
+}
+
+func (r RelayNotifee) Listen(n network.Network, multiaddr multiaddr.Multiaddr) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r RelayNotifee) ListenClose(n network.Network, multiaddr multiaddr.Multiaddr) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r RelayNotifee) Connected(n network.Network, conn network.Conn) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (r RelayNotifee) Disconnected(n network.Network, conn network.Conn) {
+	//TODO implement me
+	panic("implement me")
+}
+
+var _ network.Notifiee = (*RelayNotifee)(nil)

--- a/network/p2p/connection/internal/relayNotifee.go
+++ b/network/p2p/connection/internal/relayNotifee.go
@@ -13,6 +13,10 @@ type RelayNotifee struct {
 
 var _ network.Notifiee = (*RelayNotifee)(nil)
 
+func NewRelayNotifee(notifiees ...network.Notifiee) *RelayNotifee {
+	return &RelayNotifee{notifiees}
+}
+
 func (r *RelayNotifee) Listen(n network.Network, multiaddr multiaddr.Multiaddr) {
 	for _, notifiee := range r.n {
 		notifiee.Listen(n, multiaddr)

--- a/network/p2p/connection/internal/relayNotifee.go
+++ b/network/p2p/connection/internal/relayNotifee.go
@@ -9,24 +9,28 @@ type RelayNotifee struct {
 	n []network.Notifiee
 }
 
-func (r RelayNotifee) Listen(n network.Network, multiaddr multiaddr.Multiaddr) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r RelayNotifee) ListenClose(n network.Network, multiaddr multiaddr.Multiaddr) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r RelayNotifee) Connected(n network.Network, conn network.Conn) {
-	//TODO implement me
-	panic("implement me")
-}
-
-func (r RelayNotifee) Disconnected(n network.Network, conn network.Conn) {
-	//TODO implement me
-	panic("implement me")
-}
-
 var _ network.Notifiee = (*RelayNotifee)(nil)
+
+func (r *RelayNotifee) Listen(n network.Network, multiaddr multiaddr.Multiaddr) {
+	for _, notifiee := range r.n {
+		notifiee.Listen(n, multiaddr)
+	}
+}
+
+func (r *RelayNotifee) ListenClose(n network.Network, multiaddr multiaddr.Multiaddr) {
+	for _, notifiee := range r.n {
+		notifiee.ListenClose(n, multiaddr)
+	}
+}
+
+func (r *RelayNotifee) Connected(n network.Network, conn network.Conn) {
+	for _, notifiee := range r.n {
+		notifiee.Connected(n, conn)
+	}
+}
+
+func (r *RelayNotifee) Disconnected(n network.Network, conn network.Conn) {
+	for _, notifiee := range r.n {
+		notifiee.Disconnected(n, conn)
+	}
+}

--- a/network/p2p/connection/internal/relayNotifee.go
+++ b/network/p2p/connection/internal/relayNotifee.go
@@ -5,6 +5,8 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
+// RelayNotifee is a notifiee that relays notifications to a list of notifiees.
+// A network.Notifiee is a function that is called when a network event occurs, such as a new connection.
 type RelayNotifee struct {
 	n []network.Notifiee
 }

--- a/network/p2p/test/fixtures.go
+++ b/network/p2p/test/fixtures.go
@@ -74,8 +74,10 @@ func NodeFixture(
 	logger := parameters.Logger.With().Hex("node_id", logging.ID(identity.NodeID)).Logger()
 
 	noopMetrics := metrics.NewNoopCollector()
-	connManager := connection.NewConnManager(logger, noopMetrics)
 	resourceManager := testutils.NewResourceManager(t)
+
+	connManager, err := connection.NewConnManager(logger, noopMetrics, connection.DefaultConnManagerConfig())
+	require.NoError(t, err)
 
 	builder := p2pbuilder.NewNodeBuilder(
 		logger,

--- a/network/p2p/test/fixtures.go
+++ b/network/p2p/test/fixtures.go
@@ -119,6 +119,10 @@ func NodeFixture(
 		builder.SetGossipSubFactory(parameters.GossipSubFactory, parameters.GossipSubConfig)
 	}
 
+	if parameters.ConnManager != nil {
+		builder.SetConnectionManager(parameters.ConnManager)
+	}
+
 	n, err := builder.Build()
 	require.NoError(t, err)
 
@@ -153,6 +157,7 @@ type NodeFixtureParameters struct {
 	UpdateInterval     time.Duration         // peer manager parameter
 	PeerProvider       p2p.PeersProvider     // peer manager parameter
 	ConnGater          connmgr.ConnectionGater
+	ConnManager        connmgr.ConnManager
 	GossipSubFactory   p2pbuilder.GossipSubFactoryFunc
 	GossipSubConfig    p2pbuilder.GossipSubAdapterConfigFunc
 }
@@ -205,6 +210,12 @@ func WithDHTOptions(opts ...dht.Option) NodeFixtureParameterOption {
 func WithConnectionGater(connGater connmgr.ConnectionGater) NodeFixtureParameterOption {
 	return func(p *NodeFixtureParameters) {
 		p.ConnGater = connGater
+	}
+}
+
+func WithConnectionManager(connManager connmgr.ConnManager) NodeFixtureParameterOption {
+	return func(p *NodeFixtureParameters) {
+		p.ConnManager = connManager
 	}
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/dapperlabs/flow-go/issues/6481. In a nutshell, it introduces the following changes:
- Replaces the `connmgr.NullConnMgr` with `BasicConnMgr` which is a remarkably more powerful manager and provides connection watermarking capability. The connection watermarking capability allows the libp2p node to periodically examine the number of established connections (every `grace_period`), and if the number of connections ever goes beyond `high_watermarking` parameter, it keeps pruning the connections till it reaches the `low_watermarking` parameter. 

- Adds `TestConnectionManager_Watermarking` which tests the integration of the connection manager with the libp2p node. 

- Through the `TestConnectionManager_Watermarking`, we realized a flaw in the way we configure the connection manager. We tracked down the flaw to the `Notifiee` component of the connection manager.  To address this issue, we implemented the `RelayNotifee` that combines the notifee logic of our's and libp2p's connection managers together. 