### PR TITLE
Remove UpdatedAddresses from fvm State

### DIFF
--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -1,14 +1,12 @@
 package state
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"github.com/onflow/cadence/runtime/common"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
@@ -42,9 +40,8 @@ type State struct {
 	// bookkeeping purpose).
 	committed bool
 
-	view             View
-	meter            *meter.Meter
-	updatedAddresses map[flow.Address]struct{}
+	view  View
+	meter *meter.Meter
 
 	// NOTE: parent and child state shares the same limits controller
 	*limitsController
@@ -142,7 +139,6 @@ func NewState(view View, params StateParameters) *State {
 		committed:        false,
 		view:             view,
 		meter:            m,
-		updatedAddresses: make(map[flow.Address]struct{}),
 		limitsController: newLimitsController(params),
 	}
 }
@@ -156,7 +152,6 @@ func (s *State) NewChildWithMeterParams(
 		committed:        false,
 		view:             s.view.NewChild(),
 		meter:            meter.NewMeter(params),
-		updatedAddresses: make(map[flow.Address]struct{}),
 		limitsController: s.limitsController,
 	}
 }
@@ -237,10 +232,6 @@ func (s *State) Set(owner, key string, value flow.RegisterValue) error {
 	)
 	if err != nil {
 		return err
-	}
-
-	if address, isAddress := addressFromOwner(owner); isAddress {
-		s.updatedAddresses[address] = struct{}{}
 	}
 
 	return nil
@@ -330,28 +321,7 @@ func (s *State) MergeState(other *State) error {
 
 	s.meter.MergeMeter(other.meter)
 
-	// apply address updates
-	for k, v := range other.updatedAddresses {
-		s.updatedAddresses[k] = v
-	}
-
 	return nil
-}
-
-// UpdatedAddresses returns a sorted list of addresses that were updated (at least 1 register update)
-func (s *State) UpdatedAddresses() []flow.Address {
-	addresses := make([]flow.Address, 0, len(s.updatedAddresses))
-
-	for k := range s.updatedAddresses {
-		addresses = append(addresses, k)
-	}
-
-	slices.SortFunc(addresses, func(a, b flow.Address) bool {
-		// reverse order to maintain compatibility with previous implementation.
-		return bytes.Compare(a[:], b[:]) >= 0
-	})
-
-	return addresses
 }
 
 func (s *State) checkSize(owner, key string, value flow.RegisterValue) error {
@@ -364,16 +334,6 @@ func (s *State) checkSize(owner, key string, value flow.RegisterValue) error {
 		return errors.NewStateValueSizeLimitError(value, valueSize, s.maxValueSizeAllowed)
 	}
 	return nil
-}
-
-func addressFromOwner(owner string) (flow.Address, bool) {
-	ownerBytes := []byte(owner)
-	if len(ownerBytes) != flow.AddressLength {
-		// not an address
-		return flow.EmptyAddress, false
-	}
-	address := flow.BytesToAddress(ownerBytes)
-	return address, true
 }
 
 // IsFVMStateKey returns true if the key is controlled by the fvm env and

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -345,10 +345,6 @@ func (s *TransactionState) Set(
 	return s.currentState().Set(owner, key, value)
 }
 
-func (s *TransactionState) UpdatedAddresses() []flow.Address {
-	return s.currentState().UpdatedAddresses()
-}
-
 func (s *TransactionState) MeterComputation(
 	kind common.ComputationKind,
 	intensity uint,

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -387,7 +387,7 @@ func (executor *transactionExecutor) normalExecution() (
 	executor.txnState.RunWithAllLimitsDisabled(func() {
 		err = executor.CheckStorageLimits(
 			executor.env,
-			executor.txnState.UpdatedAddresses(),
+			executor.txnState,
 			executor.proc.Transaction.Payer,
 			maxTxFees)
 	})

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -10,12 +10,24 @@ import (
 	"github.com/onflow/flow-go/fvm"
 	fvmmock "github.com/onflow/flow-go/fvm/environment/mock"
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/tracing"
+	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
 )
 
 func TestTransactionStorageLimiter(t *testing.T) {
+	txnState := state.NewTransactionState(
+		utils.NewSimpleView(),
+		state.DefaultParameters())
+
 	owner := flow.HexToAddress("1")
+
+	err := txnState.Set(string(owner[:]), "a", flow.RegisterValue("foo"))
+	require.NoError(t, err)
+	err = txnState.Set(string(owner[:]), "b", flow.RegisterValue("bar"))
+	require.NoError(t, err)
+
 	t.Run("capacity > storage -> OK", func(t *testing.T) {
 		chain := flow.Mainnet.Chain()
 		env := &fvmmock.Environment{}
@@ -32,7 +44,7 @@ func TestTransactionStorageLimiter(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckStorageLimits(env, []flow.Address{owner}, flow.EmptyAddress, 0)
+		err := d.CheckStorageLimits(env, txnState, flow.EmptyAddress, 0)
 		require.NoError(t, err, "Transaction with higher capacity than storage used should work")
 	})
 	t.Run("capacity = storage -> OK", func(t *testing.T) {
@@ -51,7 +63,26 @@ func TestTransactionStorageLimiter(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckStorageLimits(env, []flow.Address{owner}, flow.EmptyAddress, 0)
+		err := d.CheckStorageLimits(env, txnState, flow.EmptyAddress, 0)
+		require.NoError(t, err, "Transaction with equal capacity than storage used should work")
+	})
+	t.Run("capacity = storage -> OK (dedup payer)", func(t *testing.T) {
+		chain := flow.Mainnet.Chain()
+		env := &fvmmock.Environment{}
+		env.On("Chain").Return(chain)
+		env.On("LimitAccountStorage").Return(true)
+		env.On("StartChildSpan", mock.Anything).Return(
+			tracing.NewMockTracerSpan())
+		env.On("GetStorageUsed", mock.Anything).Return(uint64(100), nil)
+		env.On("AccountsStorageCapacity", mock.Anything, mock.Anything, mock.Anything).Return(
+			cadence.NewArray([]cadence.Value{
+				bytesToUFix64(100),
+			}),
+			nil,
+		)
+
+		d := &fvm.TransactionStorageLimiter{}
+		err := d.CheckStorageLimits(env, txnState, owner, 0)
 		require.NoError(t, err, "Transaction with equal capacity than storage used should work")
 	})
 	t.Run("capacity < storage -> Not OK", func(t *testing.T) {
@@ -70,7 +101,57 @@ func TestTransactionStorageLimiter(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckStorageLimits(env, []flow.Address{owner}, flow.EmptyAddress, 0)
+		err := d.CheckStorageLimits(env, txnState, flow.EmptyAddress, 0)
+		require.Error(t, err, "Transaction with lower capacity than storage used should fail")
+	})
+	t.Run("capacity > storage -> OK (payer not updated)", func(t *testing.T) {
+		chain := flow.Mainnet.Chain()
+		env := &fvmmock.Environment{}
+		env.On("Chain").Return(chain)
+		env.On("LimitAccountStorage").Return(true)
+		env.On("StartChildSpan", mock.Anything).Return(
+			tracing.NewMockTracerSpan())
+		env.On("GetStorageUsed", mock.Anything).Return(uint64(99), nil)
+		env.On("AccountsStorageCapacity", mock.Anything, mock.Anything, mock.Anything).Return(
+			cadence.NewArray([]cadence.Value{
+				bytesToUFix64(100),
+			}),
+			nil,
+		)
+
+		txnState := state.NewTransactionState(
+			utils.NewSimpleView(),
+			state.DefaultParameters())
+		// sanity check
+		require.Empty(t, txnState.UpdatedRegisterIDs())
+
+		d := &fvm.TransactionStorageLimiter{}
+		err := d.CheckStorageLimits(env, txnState, owner, 1)
+		require.NoError(t, err, "Transaction with higher capacity than storage used should work")
+	})
+	t.Run("capacity < storage -> Not OK (payer not updated)", func(t *testing.T) {
+		chain := flow.Mainnet.Chain()
+		env := &fvmmock.Environment{}
+		env.On("Chain").Return(chain)
+		env.On("LimitAccountStorage").Return(true)
+		env.On("StartChildSpan", mock.Anything).Return(
+			tracing.NewMockTracerSpan())
+		env.On("GetStorageUsed", mock.Anything).Return(uint64(101), nil)
+		env.On("AccountsStorageCapacity", mock.Anything, mock.Anything, mock.Anything).Return(
+			cadence.NewArray([]cadence.Value{
+				bytesToUFix64(100),
+			}),
+			nil,
+		)
+
+		txnState := state.NewTransactionState(
+			utils.NewSimpleView(),
+			state.DefaultParameters())
+		// sanity check
+		require.Empty(t, txnState.UpdatedRegisterIDs())
+
+		d := &fvm.TransactionStorageLimiter{}
+		err := d.CheckStorageLimits(env, txnState, owner, 1000)
 		require.Error(t, err, "Transaction with lower capacity than storage used should fail")
 	})
 	t.Run("if ctx LimitAccountStorage false-> OK", func(t *testing.T) {
@@ -90,7 +171,7 @@ func TestTransactionStorageLimiter(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckStorageLimits(env, []flow.Address{owner}, flow.EmptyAddress, 0)
+		err := d.CheckStorageLimits(env, txnState, flow.EmptyAddress, 0)
 		require.NoError(t, err, "Transaction with higher capacity than storage used should work")
 	})
 	t.Run("non existing accounts or any other errors on fetching storage used -> Not OK", func(t *testing.T) {
@@ -109,7 +190,7 @@ func TestTransactionStorageLimiter(t *testing.T) {
 		)
 
 		d := &fvm.TransactionStorageLimiter{}
-		err := d.CheckStorageLimits(env, []flow.Address{owner}, flow.EmptyAddress, 0)
+		err := d.CheckStorageLimits(env, txnState, flow.EmptyAddress, 0)
 		require.Error(t, err, "check storage used on non existing account (not general registers) should fail")
 	})
 }


### PR DESCRIPTION
The implementation is buggy; it doesn't handle DropDelta correctly. Luckily, we only use it for storage check and the bug is never triggered.