### PR TITLE
[Access Client] Set message received limits

### DIFF
--- a/cmd/util/cmd/common/flow_client.go
+++ b/cmd/util/cmd/common/flow_client.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"google.golang.org/grpc"
-
 	client "github.com/onflow/flow-go-sdk/access/grpc"
+	"google.golang.org/grpc"
+	grpcinsecure "google.golang.org/grpc/credentials/insecure"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/flow/order"
@@ -62,7 +63,10 @@ func secureFlowClient(accessAddress, accessApiNodePubKey string) (*client.Client
 	}
 
 	// create flow client
-	flowClient, err := client.NewClient(accessAddress, dialOpts)
+	flowClient, err := client.NewClient(accessAddress,
+		dialOpts,
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcutils.DefaultMaxMsgSize)),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +77,10 @@ func secureFlowClient(accessAddress, accessApiNodePubKey string) (*client.Client
 // insecureFlowClient creates flow client with insecure GRPC connection
 func insecureFlowClient(accessAddress string) (*client.Client, error) {
 	// create flow client
-	flowClient, err := client.NewClient(accessAddress, grpc.WithInsecure()) //nolint:staticcheck
+	flowClient, err := client.NewClient(accessAddress,
+		grpc.WithTransportCredentials(grpcinsecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(grpcutils.DefaultMaxMsgSize)),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create flow client %w", err)
 	}


### PR DESCRIPTION
The default limit is 4MB, which is too small on mainnet