### PR TITLE
Start pacemaker before processing pending blocks

### DIFF
--- a/consensus/hotstuff/eventhandler/event_handler.go
+++ b/consensus/hotstuff/eventhandler/event_handler.go
@@ -264,12 +264,12 @@ func (e *EventHandler) Start(ctx context.Context) error {
 	// notify about commencing recovery procedure
 	e.notifier.OnStart(e.paceMaker.CurView())
 	defer e.notifier.OnEventProcessed()
+	e.paceMaker.Start(ctx)
 
 	err := e.processPendingBlocks()
 	if err != nil {
 		return fmt.Errorf("could not process pending blocks: %w", err)
 	}
-	e.paceMaker.Start(ctx)
 	err = e.proposeForNewViewIfPrimary()
 	if err != nil {
 		return fmt.Errorf("could not start new view: %w", err)


### PR DESCRIPTION
### Context
We process pending blocks in the EventHandler prior to starting the main event loop. This allows us to validate the pending blocks and process their QC/TCs prior to accepting any new blocks. Part of this may involve changing views, which will cause us to initiate a new timeout in the TimeoutController.

The TimeoutController uses a context to gracefully shut down its ticker goroutine, which is derived from the EventHandler's lifecycle context and is set during the Start function. Currently, we process pending blocks prior to starting the Pacemaker. So the Pacemaker context will be nil at this point. If we process a pending block which causes us to change views, then we will attempt to derive a child of a nil context, which causes a panic!

Since we persist the new view before hitting the panic, a node configured to auto-restart would eventually pass this bug.

### Example stack trace:
```
2023-01-25 14:15:45 | /app/module/component/component.go:252 +0x2de |  
-- | -- | --
  |   | 2023-01-25 14:15:45 | created by github.com/onflow/flow-go/module/component.(*ComponentManager).Start |  
  |   | 2023-01-25 14:15:45 | /app/module/component/component.go:255 +0xf0 |  
  |   | 2023-01-25 14:15:45 | github.com/onflow/flow-go/module/component.(*ComponentManager).Start.func2() |  
  |   | 2023-01-25 14:15:45 | /app/consensus/hotstuff/eventloop/event_loop.go:83 +0x1ee |  
  |   | 2023-01-25 14:15:45 | github.com/onflow/flow-go/consensus/hotstuff/eventloop.NewEventLoop.func1({0x2422c90, 0xc0182bfdb8}, 0x8?) |  
  |   | 2023-01-25 14:15:45 | /app/consensus/hotstuff/eventloop/event_loop.go:96 +0x52 |  
  |   | 2023-01-25 14:15:45 | github.com/onflow/flow-go/consensus/hotstuff/eventloop.(*EventLoop).loop(0xc018290ee0, {0x7fe1e2ad3098, 0xc0182bfdb8}) |  
  |   | 2023-01-25 14:15:45 | /app/consensus/hotstuff/eventhandler/event_handler.go:268 +0xd3 |  
  |   | 2023-01-25 14:15:45 | github.com/onflow/flow-go/consensus/hotstuff/eventhandler.(*EventHandler).Start(0xc00f96f790, {0x7fe1e2ad3098, 0xc0182bfdb8}) |  
  |   | 2023-01-25 14:15:45 | /app/consensus/hotstuff/eventhandler/event_handler.go:340 +0x13c |  
  |   | 2023-01-25 14:15:45 | github.com/onflow/flow-go/consensus/hotstuff/eventhandler.(*EventHandler).processPendingBlocks(0xc00f96f790) |  
  |   | 2023-01-25 14:15:45 | /app/consensus/hotstuff/pacemaker/pacemaker.go:150 +0xf4 |  
  |   | 2023-01-25 14:15:45 | github.com/onflow/flow-go/consensus/hotstuff/pacemaker.(*ActivePaceMaker).ProcessQC(0xc017d1b4f0, 0xc017d43200) |  
  |   | 2023-01-25 14:15:45 | /app/consensus/hotstuff/pacemaker/timeout/controller.go:81 +0xfc |  
  |   | 2023-01-25 14:15:45 | github.com/onflow/flow-go/consensus/hotstuff/pacemaker/timeout.(*Controller).StartTimeout(0xc017d1b4a0, {0x0, 0x0}, 0xf9566) |  
  |   | 2023-01-25 14:15:45 | /usr/local/go/src/context/context.go:234 +0x125 |  
  |   | 2023-01-25 14:15:45 | context.WithCancel({0x0?, 0x0?}) |  
  |   | 2023-01-25 14:15:45 | goroutine 5387 [running]: |  
  |   | 2023-01-25 14:15:45 | panic: cannot create context from nil parent
```