### PR TITLE
[Execution] Temporary workaround for LN networking issue

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -848,6 +848,7 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 		exeNode.executionDataPruner,
 		exeNode.blockDataUploader,
 		exeNode.stopControl,
+		exeNode.exeConf.onflowOnlyLNs,
 	)
 
 	// TODO: we should solve these mutual dependencies better

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -55,6 +55,12 @@ type ExecutionConfig struct {
 	computationConfig        computation.ComputationConfig
 	receiptRequestWorkers    uint   // common provider engine workers
 	receiptRequestsCacheSize uint32 // common provider engine cache size
+
+	// This is included to temporarily work around an issue observed on a small number of ENs.
+	// It works around an issue where some collection nodes are not configured with enough
+	// this works around an issue where some collection nodes are not configured with enough
+	// file descriptors causing connection failures.
+	onflowOnlyLNs bool
 }
 
 func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
@@ -101,6 +107,8 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&exeConf.blobstoreRateLimit, "blobstore-rate-limit", 0, "per second outgoing rate limit for Execution Data blobstore")
 	flags.IntVar(&exeConf.blobstoreBurstLimit, "blobstore-burst-limit", 0, "outgoing burst limit for Execution Data blobstore")
 	flags.DurationVar(&exeConf.maxGracefulStopDuration, "max-graceful-stop-duration", stop.DefaultMaxGracefulStopDuration, "the maximum amount of time stop control will wait for ingestion engine to gracefully shutdown before crashing")
+
+	flags.BoolVar(&exeConf.onflowOnlyLNs, "temp-onflow-only-lns", false, "do not use unless required. forces node to only request collections from onflow collection nodes")
 }
 
 func (exeConf *ExecutionConfig) ValidateFlags() error {

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -1214,18 +1214,16 @@ func (e *Engine) fetchCollection(
 	}
 
 	// This is included to temporarily work around an issue observed on a small number of ENs.
-	// Using only the dapper run LNs seems to aleviate the issue. This will be removed once a
+	// Using only the onflow LNs seems to aleviate the issue. This will be removed once a
 	// proper fix is in place.
-	if os.Getenv("DAPPER_LN_ONLY_OVERRIDE") != "" {
-		var onlyDapperRegex = regexp.MustCompile(`.*onflow.org:3569$`)
+	if os.Getenv("ONFLOW_LN_ONLY_OVERRIDE") != "" {
+		var onlyOnflowRegex = regexp.MustCompile(`.*onflow.org:3569$`)
 
-		// onlyDapper(Identity("verification-049.mainnet20.nodes.onflow.org:3569")) => true
-		// onlyDapper(Identity("verification-049.hello.org:3569")) => false
-		onlyDapper := func(identity *flow.Identity) bool {
-			return onlyDapperRegex.MatchString(identity.Address)
-		}
-
-		filters = append(filters, onlyDapper)
+		// func(Identity("verification-049.mainnet20.nodes.onflow.org:3569")) => true
+		// func(Identity("verification-049.hello.org:3569")) => false
+		filters = append(filters, func(identity *flow.Identity) bool {
+			return onlyOnflowRegex.MatchString(identity.Address)
+		})
 	}
 
 	// queue the collection to be requested from one of the guarantors

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"sync"
 	"time"
@@ -62,7 +61,15 @@ type Engine struct {
 	executionDataPruner    *pruner.Pruner
 	uploader               *uploader.Manager
 	stopControl            *stop.StopControl
+
+	// This is included to temporarily work around an issue observed on a small number of ENs.
+	// It works around an issue where some collection nodes are not configured with enough
+	// this works around an issue where some collection nodes are not configured with enough
+	// file descriptors causing connection failures.
+	onflowOnlyLNs bool
 }
+
+var onlyOnflowRegex = regexp.MustCompile(`.*\.onflow\.org:3569$`)
 
 func New(
 	unit *engine.Unit,
@@ -87,6 +94,7 @@ func New(
 	pruner *pruner.Pruner,
 	uploader *uploader.Manager,
 	stopControl *stop.StopControl,
+	onflowOnlyLNs bool,
 ) (*Engine, error) {
 	log := logger.With().Str("engine", "ingestion").Logger()
 
@@ -116,6 +124,7 @@ func New(
 		executionDataPruner:    pruner,
 		uploader:               uploader,
 		stopControl:            stopControl,
+		onflowOnlyLNs:          onflowOnlyLNs,
 	}
 
 	return &eng, nil
@@ -1214,11 +1223,10 @@ func (e *Engine) fetchCollection(
 	}
 
 	// This is included to temporarily work around an issue observed on a small number of ENs.
-	// Using only the onflow LNs seems to aleviate the issue. This will be removed once a
+	// It works around an issue where some collection nodes are not configured with enough
+	// file descriptors causing connection failures. This will be removed once a
 	// proper fix is in place.
-	if os.Getenv("ONFLOW_LN_ONLY_OVERRIDE") != "" {
-		var onlyOnflowRegex = regexp.MustCompile(`.*onflow.org:3569$`)
-
+	if e.onflowOnlyLNs {
 		// func(Identity("verification-049.mainnet20.nodes.onflow.org:3569")) => true
 		// func(Identity("verification-049.hello.org:3569")) => false
 		filters = append(filters, func(identity *flow.Identity) bool {

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -242,6 +242,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 		nil,
 		uploadMgr,
 		stopControl,
+		false,
 	)
 	require.NoError(t, err)
 
@@ -1532,6 +1533,7 @@ func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecution
 			false,
 			false,
 		),
+		false,
 	)
 
 	require.NoError(t, err)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -731,6 +731,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		nil,
 		uploader,
 		stopControl,
+		false,
 	)
 	require.NoError(t, err)
 	requestEngine.WithHandle(ingestionEngine.OnCollection)


### PR DESCRIPTION
Add a cli flag to enable a temporary workaround for a networking issue between a small number of ENs and LNs. When enabled, the EN will only request collections from nodes with a `*.onflow.org` hostname.