### PR TITLE
Use RegisterId instead of (owner, key)-tuple as key for accessing register values

### DIFF
--- a/fvm/derived/table_test.go
+++ b/fvm/derived/table_test.go
@@ -832,13 +832,13 @@ type testValueComputer struct {
 
 func (computer *testValueComputer) Compute(
 	txnState *state.TransactionState,
-	key string,
+	key flow.RegisterID,
 ) (
 	int,
 	error,
 ) {
 	computer.called = true
-	_, err := txnState.Get("addr", key)
+	_, err := txnState.Get(key)
 	if err != nil {
 		return 0, err
 	}
@@ -847,9 +847,9 @@ func (computer *testValueComputer) Compute(
 }
 
 func TestTxnDerivedDataGetOrCompute(t *testing.T) {
-	blockDerivedData := NewEmptyTable[string, int]()
+	blockDerivedData := NewEmptyTable[flow.RegisterID, int]()
 
-	key := "key"
+	key := flow.RegisterID{Owner: "addr", Key: "key"}
 	value := 12345
 
 	t.Run("compute value", func(t *testing.T) {
@@ -865,7 +865,7 @@ func TestTxnDerivedDataGetOrCompute(t *testing.T) {
 		assert.Equal(t, value, val)
 		assert.True(t, computer.called)
 
-		_, ok := view.Ledger.RegisterTouches[flow.RegisterID{Owner: "addr", Key: key}]
+		_, ok := view.Ledger.RegisterTouches[key]
 		assert.True(t, ok)
 
 		// Commit to setup the next test.
@@ -886,7 +886,7 @@ func TestTxnDerivedDataGetOrCompute(t *testing.T) {
 		assert.Equal(t, value, val)
 		assert.False(t, computer.called)
 
-		_, ok := view.Ledger.RegisterTouches[flow.RegisterID{Owner: "addr", Key: key}]
+		_, ok := view.Ledger.RegisterTouches[key]
 		assert.True(t, ok)
 	})
 }

--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -19,6 +19,11 @@ const (
 	FlowFeesAccountIndex      = 4
 )
 
+var addressStateKey = flow.RegisterID{
+	Owner: "",
+	Key:   state.AddressStateKey,
+}
+
 type AddressGenerator interface {
 	Bytes() []byte
 	NextAddress() (flow.Address, error)
@@ -147,9 +152,7 @@ func NewAccountCreator(
 }
 
 func (creator *accountCreator) bytes() ([]byte, error) {
-	stateBytes, err := creator.txnState.Get(
-		"",
-		state.AddressStateKey)
+	stateBytes, err := creator.txnState.Get(addressStateKey)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to read address generator state from the state: %w",
@@ -193,9 +196,7 @@ func (creator *accountCreator) NextAddress() (flow.Address, error) {
 	}
 
 	// update the ledger state
-	err = creator.txnState.Set(
-		"",
-		state.AddressStateKey,
+	err = creator.txnState.Set(addressStateKey,
 		addressGenerator.Bytes())
 	if err != nil {
 		return address, fmt.Errorf(

--- a/fvm/environment/accounts.go
+++ b/fvm/environment/accounts.go
@@ -70,8 +70,10 @@ func (a *StatefulAccounts) AllocateStorageIndex(address flow.Address) (atree.Sto
 	key := atree.SlabIndexToLedgerKey(index)
 	a.txnState.RunWithAllLimitsDisabled(func() {
 		err = a.txnState.Set(
-			string(address.Bytes()),
-			string(key),
+			flow.RegisterID{
+				Owner: string(address.Bytes()),
+				Key:   string(key),
+			},
 			[]byte{})
 	})
 	if err != nil {
@@ -417,17 +419,25 @@ func (a *StatefulAccounts) setAccountStatusStorageUsed(address flow.Address, sta
 	return nil
 }
 
+// TODO(patrick): use RegisterID as input key
 func (a *StatefulAccounts) GetValue(address flow.Address, key string) (flow.RegisterValue, error) {
-	return a.txnState.Get(string(address.Bytes()), key)
+	return a.txnState.Get(flow.RegisterID{
+		Owner: string(address.Bytes()),
+		Key:   key,
+	})
 }
 
+// TODO(patrick): use RegisterID as input key
 // SetValue sets a value in address' storage
 func (a *StatefulAccounts) SetValue(address flow.Address, key string, value flow.RegisterValue) error {
 	err := a.updateRegisterSizeChange(address, key, value)
 	if err != nil {
 		return fmt.Errorf("failed to update storage used by key %s on account %s: %w", state.PrintableKey(key), address, err)
 	}
-	return a.txnState.Set(string(address.Bytes()), key, value)
+	return a.txnState.Set(flow.RegisterID{
+		Owner: string(address.Bytes()),
+		Key:   key},
+		value)
 }
 
 func (a *StatefulAccounts) updateRegisterSizeChange(address flow.Address, key string, value flow.RegisterValue) error {

--- a/fvm/environment/derived_data_invalidator_test.go
+++ b/fvm/environment/derived_data_invalidator_test.go
@@ -268,7 +268,9 @@ func TestMeterParamOverridesUpdated(t *testing.T) {
 		view := utils.NewSimpleView()
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 
-		err := txnState.Set(owner, key, flow.RegisterValue("blah"))
+		err := txnState.Set(
+			flow.RegisterID{Owner: owner, Key: key},
+			flow.RegisterValue("blah"))
 		require.NoError(t, err)
 
 		env := environment.NewTransactionEnvironment(

--- a/fvm/environment/uuids.go
+++ b/fvm/environment/uuids.go
@@ -6,9 +6,15 @@ import (
 
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/tracing"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/utils/slices"
 )
+
+var uuidKey = flow.RegisterID{
+	Owner: "",
+	Key:   state.UUIDKey,
+}
 
 type UUIDGenerator interface {
 	GenerateUUID() (uint64, error)
@@ -57,7 +63,7 @@ func NewUUIDGenerator(
 
 // GetUUID reads uint64 byte value for uuid from the state
 func (generator *uUIDGenerator) getUUID() (uint64, error) {
-	stateBytes, err := generator.txnState.Get("", state.UUIDKey)
+	stateBytes, err := generator.txnState.Get(uuidKey)
 	if err != nil {
 		return 0, fmt.Errorf("cannot get uuid byte from state: %w", err)
 	}
@@ -70,7 +76,7 @@ func (generator *uUIDGenerator) getUUID() (uint64, error) {
 func (generator *uUIDGenerator) setUUID(uuid uint64) error {
 	bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, uuid)
-	err := generator.txnState.Set("", state.UUIDKey, bytes)
+	err := generator.txnState.Set(uuidKey, bytes)
 	if err != nil {
 		return fmt.Errorf("cannot set uuid byte to state: %w", err)
 	}

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -1,8 +1,6 @@
 package errors
 
 import (
-	"strings"
-
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime"
 
@@ -150,15 +148,14 @@ func NewEventLimitExceededError(
 // NewStateKeySizeLimitError constructs a CodedError which indicates that the
 // provided key has exceeded the size limit allowed by the storage.
 func NewStateKeySizeLimitError(
-	owner string,
-	key string,
+	id flow.RegisterID,
 	size uint64,
 	limit uint64,
 ) CodedError {
 	return NewCodedError(
 		ErrCodeStateKeySizeLimitError,
 		"key %s has size %d which is higher than storage key size limit %d.",
-		strings.Join([]string{owner, key}, "/"),
+		id,
 		size,
 		limit)
 }

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -182,7 +182,7 @@ func (s *State) UpdatedRegisters() flow.RegisterEntries {
 }
 
 // Get returns a register value given owner and key
-func (s *State) Get(owner, key string) (flow.RegisterValue, error) {
+func (s *State) Get(id flow.RegisterID) (flow.RegisterValue, error) {
 	if s.committed {
 		return nil, fmt.Errorf("cannot Get on a committed state")
 	}
@@ -191,55 +191,50 @@ func (s *State) Get(owner, key string) (flow.RegisterValue, error) {
 	var err error
 
 	if s.enforceLimits {
-		if err = s.checkSize(owner, key, []byte{}); err != nil {
+		if err = s.checkSize(id, []byte{}); err != nil {
 			return nil, err
 		}
 	}
 
-	if value, err = s.view.Get(owner, key); err != nil {
+	if value, err = s.view.Get(id.Owner, id.Key); err != nil {
 		// wrap error into a fatal error
 		getError := errors.NewLedgerFailure(err)
 		// wrap with more info
-		return nil, fmt.Errorf("failed to read key %s on account %s: %w", PrintableKey(key), hex.EncodeToString([]byte(owner)), getError)
+		return nil, fmt.Errorf(
+			"failed to read key %s on account %s: %w",
+			PrintableKey(id.Key),
+			hex.EncodeToString([]byte(id.Owner)),
+			getError)
 	}
 
-	err = s.meter.MeterStorageRead(
-		flow.RegisterID{Owner: owner, Key: key},
-		value,
-		s.enforceLimits)
-
+	err = s.meter.MeterStorageRead(id, value, s.enforceLimits)
 	return value, err
 }
 
 // Set updates state delta with a register update
-func (s *State) Set(owner, key string, value flow.RegisterValue) error {
+func (s *State) Set(id flow.RegisterID, value flow.RegisterValue) error {
 	if s.committed {
 		return fmt.Errorf("cannot Set on a committed state")
 	}
 
 	if s.enforceLimits {
-		if err := s.checkSize(owner, key, value); err != nil {
+		if err := s.checkSize(id, value); err != nil {
 			return err
 		}
 	}
 
-	if err := s.view.Set(owner, key, value); err != nil {
+	if err := s.view.Set(id.Owner, id.Key, value); err != nil {
 		// wrap error into a fatal error
 		setError := errors.NewLedgerFailure(err)
 		// wrap with more info
-		return fmt.Errorf("failed to update key %s on account %s: %w", PrintableKey(key), hex.EncodeToString([]byte(owner)), setError)
+		return fmt.Errorf(
+			"failed to update key %s on account %s: %w",
+			PrintableKey(id.Key),
+			hex.EncodeToString([]byte(id.Owner)),
+			setError)
 	}
 
-	err := s.meter.MeterStorageWrite(
-		flow.RegisterID{Owner: owner, Key: key},
-		value,
-		s.enforceLimits,
-	)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.meter.MeterStorageWrite(id, value, s.enforceLimits)
 }
 
 // MeterComputation meters computation usage
@@ -329,14 +324,23 @@ func (s *State) MergeState(other *State) error {
 	return nil
 }
 
-func (s *State) checkSize(owner, key string, value flow.RegisterValue) error {
-	keySize := uint64(len(owner) + len(key))
+func (s *State) checkSize(
+	id flow.RegisterID,
+	value flow.RegisterValue,
+) error {
+	keySize := uint64(len(id.Owner) + len(id.Key))
 	valueSize := uint64(len(value))
 	if keySize > s.maxKeySizeAllowed {
-		return errors.NewStateKeySizeLimitError(owner, key, keySize, s.maxKeySizeAllowed)
+		return errors.NewStateKeySizeLimitError(
+			id,
+			keySize,
+			s.maxKeySizeAllowed)
 	}
 	if valueSize > s.maxValueSizeAllowed {
-		return errors.NewStateValueSizeLimitError(value, valueSize, s.maxValueSizeAllowed)
+		return errors.NewStateValueSizeLimitError(
+			value,
+			valueSize,
+			s.maxValueSizeAllowed)
 	}
 	return nil
 }
@@ -374,6 +378,7 @@ func IsSlabIndex(key string) bool {
 	return len(key) == 9 && key[0] == '$'
 }
 
+// TODO(patrick): refactor this to RegisterID.String
 // PrintableKey formats slabs properly and avoids invalid utf8s
 func PrintableKey(key string) string {
 	// slab

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func createByteArray(size int) []byte {
@@ -26,45 +27,45 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 	st := state.NewState(view, state.DefaultParameters())
 
 	t.Run("test read from parent state (backoff)", func(t *testing.T) {
-		key := "key1"
+		key := flow.RegisterID{Owner: "address", Key: "key1"}
 		value := createByteArray(1)
 		// set key1 on parent
-		err := st.Set("address", key, value)
+		err := st.Set(key, value)
 		require.NoError(t, err)
 
 		// read key1 on child
 		stChild := st.NewChild()
-		v, err := stChild.Get("address", key)
+		v, err := stChild.Get(key)
 		require.NoError(t, err)
 		require.Equal(t, v, value)
 	})
 
 	t.Run("test write to child (no merge)", func(t *testing.T) {
-		key := "key2"
+		key := flow.RegisterID{Owner: "address", Key: "key2"}
 		value := createByteArray(2)
 		stChild := st.NewChild()
 
 		// set key2 on child
-		err := stChild.Set("address", key, value)
+		err := stChild.Set(key, value)
 		require.NoError(t, err)
 
 		// read key2 on parent
-		v, err := st.Get("address", key)
+		v, err := st.Get(key)
 		require.NoError(t, err)
 		require.Equal(t, len(v), 0)
 	})
 
 	t.Run("test write to child and merge", func(t *testing.T) {
-		key := "key3"
+		key := flow.RegisterID{Owner: "address", Key: "key3"}
 		value := createByteArray(3)
 		stChild := st.NewChild()
 
 		// set key3 on child
-		err := stChild.Set("address", key, value)
+		err := stChild.Set(key, value)
 		require.NoError(t, err)
 
 		// read before merge
-		v, err := st.Get("address", key)
+		v, err := st.Get(key)
 		require.NoError(t, err)
 		require.Equal(t, len(v), 0)
 
@@ -73,20 +74,20 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		require.NoError(t, err)
 
 		// read key3 on parent
-		v, err = st.Get("address", key)
+		v, err = st.Get(key)
 		require.NoError(t, err)
 		require.Equal(t, v, value)
 	})
 
 	t.Run("test write to ledger", func(t *testing.T) {
-		key := "key4"
+		key := flow.RegisterID{Owner: "address", Key: "key4"}
 		value := createByteArray(4)
 		// set key4 on parent
-		err := st.Set("address", key, value)
+		err := st.Set(key, value)
 		require.NoError(t, err)
 
 		// now should be part of the ledger
-		v, err := view.Get("address", key)
+		v, err := view.Get(key.Owner, key.Key)
 		require.NoError(t, err)
 		require.Equal(t, v, value)
 	})
@@ -97,14 +98,16 @@ func TestState_MaxValueSize(t *testing.T) {
 	view := utils.NewSimpleView()
 	st := state.NewState(view, state.DefaultParameters().WithMaxValueSizeAllowed(6))
 
+	key := flow.RegisterID{Owner: "address", Key: "key"}
+
 	// update should pass
 	value := createByteArray(5)
-	err := st.Set("address", "key", value)
+	err := st.Set(key, value)
 	require.NoError(t, err)
 
 	// update shouldn't pass
 	value = createByteArray(7)
-	err = st.Set("address", "key", value)
+	err = st.Set(key, value)
 	require.Error(t, err)
 }
 
@@ -112,20 +115,23 @@ func TestState_MaxKeySize(t *testing.T) {
 	view := utils.NewSimpleView()
 	st := state.NewState(view, state.DefaultParameters().WithMaxKeySizeAllowed(4))
 
+	key1 := flow.RegisterID{Owner: "1", Key: "2"}
+	key2 := flow.RegisterID{Owner: "123", Key: "234"}
+
 	// read
-	_, err := st.Get("1", "2")
+	_, err := st.Get(key1)
 	require.NoError(t, err)
 
 	// read
-	_, err = st.Get("123", "234")
+	_, err = st.Get(key2)
 	require.Error(t, err)
 
 	// update
-	err = st.Set("1", "2", []byte{})
+	err = st.Set(key1, []byte{})
 	require.NoError(t, err)
 
 	// read
-	err = st.Set("123", "234", []byte{})
+	err = st.Set(key2, []byte{})
 	require.Error(t, err)
 
 }
@@ -138,18 +144,20 @@ func TestState_MaxInteraction(t *testing.T) {
 			WithMeterParameters(
 				meter.DefaultParameters().WithStorageInteractionLimit(12)))
 
+	key1 := flow.RegisterID{Owner: "1", Key: "2"}
+
 	// read - interaction 2
-	_, err := st.Get("1", "2")
+	_, err := st.Get(key1)
 	require.Equal(t, st.InteractionUsed(), uint64(2))
 	require.NoError(t, err)
 
 	// read - interaction 8
-	_, err = st.Get("123", "234")
+	_, err = st.Get(flow.RegisterID{Owner: "123", Key: "234"})
 	require.Equal(t, st.InteractionUsed(), uint64(8))
 	require.NoError(t, err)
 
 	// read - interaction 14
-	_, err = st.Get("234", "345")
+	_, err = st.Get(flow.RegisterID{Owner: "234", Key: "345"})
 	require.Equal(t, st.InteractionUsed(), uint64(14))
 	require.Error(t, err)
 
@@ -161,7 +169,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	stChild := st.NewChild()
 
 	// update - 0
-	err = stChild.Set("1", "2", []byte{'A'})
+	err = stChild.Set(key1, []byte{'A'})
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), uint64(0))
 
@@ -171,17 +179,17 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Equal(t, st.InteractionUsed(), uint64(3))
 
 	// read - interaction 3 (already in read cache)
-	_, err = st.Get("1", "2")
+	_, err = st.Get(key1)
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), uint64(3))
 
 	// read - interaction 5
-	_, err = st.Get("2", "3")
+	_, err = st.Get(flow.RegisterID{Owner: "2", Key: "3"})
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), uint64(5))
 
 	// read - interaction 7
-	_, err = st.Get("3", "4")
+	_, err = st.Get(flow.RegisterID{Owner: "3", Key: "4"})
 	require.Error(t, err)
 
 }

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -328,21 +328,19 @@ func (s *TransactionState) RestartNestedTransaction(
 }
 
 func (s *TransactionState) Get(
-	owner string,
-	key string,
+	id flow.RegisterID,
 ) (
 	flow.RegisterValue,
 	error,
 ) {
-	return s.currentState().Get(owner, key)
+	return s.currentState().Get(id)
 }
 
 func (s *TransactionState) Set(
-	owner string,
-	key string,
+	id flow.RegisterID,
 	value flow.RegisterValue,
 ) error {
-	return s.currentState().Set(owner, key, value)
+	return s.currentState().Set(id, value)
 }
 
 func (s *TransactionState) MeterComputation(

--- a/fvm/state/transaction_state_test.go
+++ b/fvm/state/transaction_state_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func newTestTransactionState() *state.TransactionState {
@@ -50,22 +51,21 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 
 	// Ensure the values are written to the correctly nested state
 
-	addr := "address"
-	key := "key"
+	key := flow.RegisterID{Owner: "address", Key: "key"}
 	val := createByteArray(2)
 
-	err = txn.Set(addr, key, val)
+	err = txn.Set(key, val)
 	require.NoError(t, err)
 
-	v, err := nestedState2.Get(addr, key)
+	v, err := nestedState2.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = nestedState1.Get(addr, key)
+	v, err = nestedState1.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -77,11 +77,11 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 1, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(id1))
 
-	v, err = nestedState1.Get(addr, key)
+	v, err = nestedState1.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -91,7 +91,7 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 0, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(txn.MainTransactionId()))
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 }
@@ -174,22 +174,21 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 
 	// Sanity check
 
-	addr := "address"
-	key := "key"
+	key := flow.RegisterID{Owner: "address", Key: "key"}
 
-	v, err := restrictedNestedState2.Get(addr, key)
+	v, err := restrictedNestedState2.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = restrictedNestedState1.Get(addr, key)
+	v, err = restrictedNestedState1.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = nestedState.Get(addr, key)
+	v, err = nestedState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -202,7 +201,7 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 		state.DefaultParameters(),
 	)
 
-	err = cachedState.Set(addr, key, val)
+	err = cachedState.Set(key, val)
 	require.NoError(t, err)
 
 	err = txn.AttachAndCommit(cachedState)
@@ -211,19 +210,19 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 3, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(restrictedId2))
 
-	v, err = restrictedNestedState2.Get(addr, key)
+	v, err = restrictedNestedState2.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = restrictedNestedState1.Get(addr, key)
+	v, err = restrictedNestedState1.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = nestedState.Get(addr, key)
+	v, err = nestedState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -236,15 +235,15 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 2, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(restrictedId1))
 
-	v, err = restrictedNestedState1.Get(addr, key)
+	v, err = restrictedNestedState1.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = nestedState.Get(addr, key)
+	v, err = nestedState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -255,11 +254,11 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 1, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(id1))
 
-	v, err = nestedState.Get(addr, key)
+	v, err = nestedState.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 
@@ -269,7 +268,7 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 	require.Equal(t, 0, txn.NumNestedTransactions())
 	require.True(t, txn.IsCurrent(mainId))
 
-	v, err = mainState.Get(addr, key)
+	v, err = mainState.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 }
@@ -282,15 +281,14 @@ func TestRestartNestedTransaction(t *testing.T) {
 	id, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	addr := "address"
-	key := "key"
+	key := flow.RegisterID{Owner: "address", Key: "key"}
 	val := createByteArray(2)
 
 	for i := 0; i < 10; i++ {
 		_, err := txn.BeginNestedTransaction()
 		require.NoError(t, err)
 
-		err = txn.Set(addr, key, val)
+		err = txn.Set(key, val)
 		require.NoError(t, err)
 	}
 
@@ -303,7 +301,7 @@ func TestRestartNestedTransaction(t *testing.T) {
 		_, err := txn.BeginParseRestrictedNestedTransaction(loc)
 		require.NoError(t, err)
 
-		err = txn.Set(addr, key, val)
+		err = txn.Set(key, val)
 		require.NoError(t, err)
 	}
 
@@ -322,7 +320,7 @@ func TestRestartNestedTransaction(t *testing.T) {
 
 	require.Greater(t, state.InteractionUsed(), uint64(0))
 
-	v, err := state.Get(addr, key)
+	v, err := state.Get(key)
 	require.NoError(t, err)
 	require.Nil(t, v)
 }
@@ -335,11 +333,10 @@ func TestRestartNestedTransactionWithInvalidId(t *testing.T) {
 	id, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	addr := "address"
-	key := "key"
+	key := flow.RegisterID{Owner: "address", Key: "key"}
 	val := createByteArray(2)
 
-	err = txn.Set(addr, key, val)
+	err = txn.Set(key, val)
 	require.NoError(t, err)
 
 	var otherId state.NestedTransactionId
@@ -358,7 +355,7 @@ func TestRestartNestedTransactionWithInvalidId(t *testing.T) {
 
 	require.True(t, txn.IsCurrent(id))
 
-	v, err := txn.Get(addr, key)
+	v, err := txn.Get(key)
 	require.NoError(t, err)
 	require.Equal(t, val, v)
 }
@@ -486,40 +483,43 @@ func TestParseRestrictedCannotCommitLocationMismatch(t *testing.T) {
 func TestPauseAndResume(t *testing.T) {
 	txn := newTestTransactionState()
 
-	val, err := txn.Get("addr", "key")
+	key1 := flow.RegisterID{Owner: "addr", Key: "key"}
+	key2 := flow.RegisterID{Owner: "addr2", Key: "key2"}
+
+	val, err := txn.Get(key1)
 	require.NoError(t, err)
 	require.Nil(t, val)
 
 	id1, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	err = txn.Set("addr", "key", createByteArray(2))
+	err = txn.Set(key1, createByteArray(2))
 	require.NoError(t, err)
 
-	val, err = txn.Get("addr", "key")
+	val, err = txn.Get(key1)
 	require.NoError(t, err)
 	require.NotNil(t, val)
 
 	pausedState, err := txn.Pause(id1)
 	require.NoError(t, err)
 
-	val, err = txn.Get("addr", "key")
+	val, err = txn.Get(key1)
 	require.NoError(t, err)
 	require.Nil(t, val)
 
 	txn.Resume(pausedState)
 
-	val, err = txn.Get("addr", "key")
+	val, err = txn.Get(key1)
 	require.NoError(t, err)
 	require.NotNil(t, val)
 
-	err = txn.Set("addr2", "key2", createByteArray(2))
+	err = txn.Set(key2, createByteArray(2))
 	require.NoError(t, err)
 
 	_, err = txn.Commit(id1)
 	require.NoError(t, err)
 
-	val, err = txn.Get("addr2", "key2")
+	val, err = txn.Get(key2)
 	require.NoError(t, err)
 	require.NotNil(t, val)
 }
@@ -530,10 +530,11 @@ func TestInvalidCommittedStateModification(t *testing.T) {
 	id1, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	err = txn.Set("addr", "key", createByteArray(2))
+	key := flow.RegisterID{Owner: "addr", Key: "key"}
+	err = txn.Set(key, createByteArray(2))
 	require.NoError(t, err)
 
-	_, err = txn.Get("addr", "key")
+	_, err = txn.Get(key)
 	require.NoError(t, err)
 
 	committedState, err := txn.Commit(id1)
@@ -545,10 +546,10 @@ func TestInvalidCommittedStateModification(t *testing.T) {
 
 	txn.Resume(committedState)
 
-	err = txn.Set("addr", "key", createByteArray(2))
+	err = txn.Set(key, createByteArray(2))
 	require.ErrorContains(t, err, "cannot Set on a committed state")
 
-	_, err = txn.Get("addr", "key")
+	_, err = txn.Get(key)
 	require.ErrorContains(t, err, "cannot Get on a committed state")
 
 	_, err = txn.Commit(id1)

--- a/fvm/state/view.go
+++ b/fvm/state/view.go
@@ -27,8 +27,8 @@ type View interface {
 // Ledger is the storage interface used by the virtual machine to read and write register values.
 //
 // TODO Rename this to Storage
-// and remove reference to flow.RegisterValue and use byte[]
 type Ledger interface {
+	// TODO(patrick): replace owner/key tuple with RegisterID
 	Set(owner, key string, value flow.RegisterValue) error
 	Get(owner, key string) (flow.RegisterValue, error)
 }

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -23,9 +23,19 @@ func TestTransactionStorageLimiter(t *testing.T) {
 
 	owner := flow.HexToAddress("1")
 
-	err := txnState.Set(string(owner[:]), "a", flow.RegisterValue("foo"))
+	err := txnState.Set(
+		flow.RegisterID{
+			Owner: string(owner[:]),
+			Key:   "a",
+		},
+		flow.RegisterValue("foo"))
 	require.NoError(t, err)
-	err = txnState.Set(string(owner[:]), "b", flow.RegisterValue("bar"))
+	err = txnState.Set(
+		flow.RegisterID{
+			Owner: string(owner[:]),
+			Key:   "b",
+		},
+		flow.RegisterValue("bar"))
 	require.NoError(t, err)
 
 	t.Run("capacity > storage -> OK", func(t *testing.T) {


### PR DESCRIPTION
The (owner, key) tuple are RegisterID's implementation detail.  The view interface should not be expose to these details.

I'll update the lower level apis in future PRs.