### PR TITLE
[FVM] Add restriction that program loading cannot write to registers

### DIFF
--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -88,6 +88,12 @@ func (programs *Programs) set(
 		return err
 	}
 
+	if state.BytesWritten() > 0 {
+		// This should never happen. Loading a program should not write to the state.
+		// If this happens, it indicates an implementation error.
+		return fmt.Errorf("cannot set program. State was written to during program parsing")
+	}
+
 	// Get collected dependencies of the loaded program.
 	stackLocation, dependencies, err := programs.dependencyStack.pop()
 	if err != nil {

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -166,6 +166,11 @@ func (s *State) InteractionUsed() uint64 {
 	return s.meter.TotalBytesOfStorageInteractions()
 }
 
+// BytesWritten returns the amount of total ledger bytes written
+func (s *State) BytesWritten() uint64 {
+	return s.meter.TotalBytesWrittenToStorage()
+}
+
 // UpdatedRegisterIDs returns the lists of register ids that were updated.
 func (s *State) UpdatedRegisterIDs() []flow.RegisterID {
 	return s.view.UpdatedRegisterIDs()


### PR DESCRIPTION
Just to be more safe, before setting the program in the cache, check the no writes have been performed during program loading.