### PR TITLE
[FVM] Change interaction metering

### DIFF
--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1178,8 +1178,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 		).
 		run(
 			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
-				ctx.MaxStateInteractionSize = 500_000
-				// ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
+				ctx.MaxStateInteractionSize = 50_000
 
 				// Create an account private key.
 				privateKeys, err := testutil.GenerateAccountPrivateKeys(1)

--- a/fvm/meter/interaction_meter.go
+++ b/fvm/meter/interaction_meter.go
@@ -3,6 +3,8 @@ package meter
 import (
 	"math"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -27,18 +29,24 @@ func (params MeterParameters) WithStorageInteractionLimit(
 	return newParams
 }
 
+// InteractionMeter is a meter that tracks storage interaction
+// Only the first read of a given key is counted
+// Only the last write of a given key is counted
 type InteractionMeter struct {
 	params InteractionMeterParameters
 
-	storageUpdateSizeMap     map[flow.RegisterID]uint64
+	reads  map[flow.RegisterID]uint64
+	writes map[flow.RegisterID]uint64
+
 	totalStorageBytesRead    uint64
 	totalStorageBytesWritten uint64
 }
 
 func NewInteractionMeter(params InteractionMeterParameters) InteractionMeter {
 	return InteractionMeter{
-		params:               params,
-		storageUpdateSizeMap: make(map[flow.RegisterID]uint64),
+		params: params,
+		reads:  make(map[flow.RegisterID]uint64),
+		writes: make(map[flow.RegisterID]uint64),
 	}
 }
 
@@ -51,32 +59,65 @@ func (m *InteractionMeter) MeterStorageRead(
 ) error {
 
 	// all reads are on a View which only read from storage at the first read of a given key
-	if _, ok := m.storageUpdateSizeMap[storageKey]; !ok {
+	if _, ok := m.reads[storageKey]; !ok {
 		readByteSize := getStorageKeyValueSize(storageKey, value)
 		m.totalStorageBytesRead += readByteSize
-		m.storageUpdateSizeMap[storageKey] = readByteSize
+		m.reads[storageKey] = readByteSize
 	}
 
 	return m.checkStorageInteractionLimit(enforceLimit)
 }
 
 // MeterStorageWrite captures storage written bytes count and returns an error
-// if it goes beyond the total interaction limit and limit is enforced
+// if it goes beyond the total interaction limit and limit is enforced.
+// If a key is written multiple times, only the last write is counted.
+// If a key is written before it has been read, next time it will be read it will be from the view,
+// not from storage, so count it as read 0.
 func (m *InteractionMeter) MeterStorageWrite(
 	storageKey flow.RegisterID,
 	value flow.RegisterValue,
 	enforceLimit bool,
 ) error {
-	// all writes are on a View which only writes the latest updated value to storage at commit
-	if old, ok := m.storageUpdateSizeMap[storageKey]; ok {
-		m.totalStorageBytesWritten -= old
+	updateSize := getStorageKeyValueSize(storageKey, value)
+	m.replaceWrite(storageKey, updateSize)
+
+	if _, ok := m.reads[storageKey]; !ok {
+		// write without read, count as read 0 because next time you read it the written value
+		// will be returned from cache, so no interaction with storage will happen.
+		m.reads[storageKey] = 0
 	}
 
-	updateSize := getStorageKeyValueSize(storageKey, value)
-	m.totalStorageBytesWritten += updateSize
-	m.storageUpdateSizeMap[storageKey] = updateSize
-
 	return m.checkStorageInteractionLimit(enforceLimit)
+}
+
+// replaceWrite replaces the write size of a given key with the new size, because
+// only the last write of a given key is counted towards the total interaction limit.
+// These are the only write usages of `m.totalStorageBytesWritten` and `m.writes`,
+// which means that `m.totalStorageBytesWritten` can never become negative.
+// oldSize is always <= m.totalStorageBytesWritten.
+func (m *InteractionMeter) replaceWrite(
+	k flow.RegisterID,
+	newSize uint64,
+) {
+	totalBefore := m.totalStorageBytesWritten
+
+	// remove old write
+	oldSize := m.writes[k]
+	m.totalStorageBytesWritten -= oldSize
+
+	// sanity check
+	// this should never happen, but if it does, it should be fatal
+	if m.totalStorageBytesWritten > totalBefore {
+		log.Fatal().
+			Str("component", "interaction_meter").
+			Uint64("total", totalBefore).
+			Uint64("subtract", oldSize).
+			Msg("totalStorageBytesWritten would have become negative")
+	}
+
+	// add new write
+	m.writes[k] = newSize
+	m.totalStorageBytesWritten += newSize
 }
 
 func (m *InteractionMeter) checkStorageInteractionLimit(enforceLimit bool) error {
@@ -117,14 +158,30 @@ func GetStorageKeyValueSizeForTesting(
 	return getStorageKeyValueSize(storageKey, value)
 }
 
-func (m *InteractionMeter) GetStorageUpdateSizeMapForTesting() MeteredStorageInteractionMap {
-	return m.storageUpdateSizeMap
+func (m *InteractionMeter) GetStorageRWSizeMapForTesting() (
+	reads MeteredStorageInteractionMap,
+	writes MeteredStorageInteractionMap,
+) {
+	return m.reads, m.writes
 }
 
+// Merge merges the child interaction meter into the parent interaction meter
+// Prioritise parent reads because they happened first
+// Prioritise child writes because they happened last
 func (m *InteractionMeter) Merge(child InteractionMeter) {
-	for key, value := range child.storageUpdateSizeMap {
-		m.storageUpdateSizeMap[key] = value
+	for key, value := range child.reads {
+		_, parentRead := m.reads[key]
+		if parentRead {
+			// avoid metering the same read more than once, because a second read
+			// is from the cache
+			continue
+		}
+
+		m.reads[key] = value
+		m.totalStorageBytesRead += value
 	}
-	m.totalStorageBytesRead += child.TotalBytesReadFromStorage()
-	m.totalStorageBytesWritten += child.TotalBytesWrittenToStorage()
+
+	for key, value := range child.writes {
+		m.replaceWrite(key, value)
+	}
 }

--- a/fvm/meter/interaction_meter_test.go
+++ b/fvm/meter/interaction_meter_test.go
@@ -1,0 +1,248 @@
+package meter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+/*
+*  When merging meter interaction limits for a register from meter B to meter A
+*  - `RA[k]`  is the **R**ead of register with **k**ey in meter **A**
+*  - `WB[k]`  is the **W**rite of register with **k**ey in meter **B**
+*  The following rules apply:
+*
+*  1. `RB[k] != nil && WB[k] == nil`:
+*    1. `RA[k] ==nil && WA[k] == nil` -> do: `RA[k] = RB[k]`
+*    2. `RA[k] != nil && WA[k] == nil` -> `RA[k]` must be equal to `RB[k]` as B is reading the same register as A did. Nothing to do.
+*    3. `RA[k] == nil && WA[k] != nil`-> when register k is read in B the value is taken from the changed value that A metered as a write so no storage read happened in B, `RB[k]` must be equal to `WA[k]`. Nothing to do.
+*    4. `RA[k] != nil && WA[k] != nil` -> similar to 1.3. no storage read happened in B as the changed register was read from A.  `WA[k]` must be equal to `RB[k]`. Nothing to do
+*
+*  2.  `RB[k] == nil && WB[k] != nil`:
+*    1. `RA[k] ==nil && WA[k] == nil` -> do: `WA[k] = WB[k]`
+*    2. `RA[k] != nil && WA[k] == nil` -> do: `WA[k] = WB[k]`
+*    3. `RA[k] == nil && WA[k] != nil` -> the write in B is latest so that one should be used. do: `WA[k] = WB[k]`
+*    4. `RA[k] != nil && WA[k] != nil` -> the write in B is latest so that one should be used. do: `WA[k] = WB[k]`
+*
+*  3. `RB[k] != nil && WB[k] != nil`:
+*    1. `RA[k] ==nil && WA[k] == nil` -> do: `WA[k] = WB[k]` and `RA[k] = RB[k]`
+*    2. `RA[k] != nil && WA[k] == nil` -> `RA[k]` must be equal to `RB[k]` as B is reading the same register as A did. do: `WA[k] = WB[k]`
+*    3. `RA[k] == nil && WA[k] != nil` -> B read should be equal to A write, because the value of the register was taken from the changed value in A, `RB[k]` must be equal to `WA[k]`. do:  `WA[k] = WB[k]`
+*    4. `RA[k] != nil && WA[k] != nil` -> similar to 3.3. do:  `WA[k] = WB[k]`
+*
+*  We shouldn't do error checking in merging, so just assume that cases that shouldn't happen don't happen. The checks for those should be, and are, elsewhere.
+*
+*  in short this means that when merging we should do the following:
+*  - take reads from the parent unless the parents write and read is nil
+*  - take writes from the child unless nil
+ */
+func TestInteractionMeter_Merge(t *testing.T) {
+	key := flow.RegisterID{
+		Owner: "owner",
+		Key:   "key",
+	}
+
+	value1 := []byte{1, 2, 3}
+	value1Size := getStorageKeyValueSize(key, value1)
+	value2 := []byte{4, 5, 6, 7}
+	value2Size := getStorageKeyValueSize(key, value2)
+	value3 := []byte{8, 9, 10, 11, 12}
+	value3Size := getStorageKeyValueSize(key, value3)
+	value4 := []byte{8, 9, 10, 11, 12, 13}
+	value4Size := getStorageKeyValueSize(key, value4)
+
+	type testCase struct {
+		Descripiton string
+
+		ParentReads flow.RegisterValue
+		ChildReads  flow.RegisterValue
+
+		ParentWrites flow.RegisterValue
+		ChildWrites  flow.RegisterValue
+
+		TotalReadShouldBe    uint64
+		TotalWrittenShouldBe uint64
+	}
+
+	cases := []testCase{
+		{
+			Descripiton: "no interaction",
+
+			ParentReads:          nil,
+			ParentWrites:         nil,
+			ChildReads:           nil,
+			ChildWrites:          nil,
+			TotalReadShouldBe:    0,
+			TotalWrittenShouldBe: 0,
+		},
+	}
+
+	desc := "child Reads, "
+	cases = append(cases,
+		testCase{
+			Descripiton: desc + "parent Nothing",
+
+			ParentReads:          nil,
+			ParentWrites:         nil,
+			ChildReads:           value1,
+			ChildWrites:          nil,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: 0,
+		},
+		testCase{
+			Descripiton: desc + "parent Reads",
+
+			ParentReads:          value1,
+			ParentWrites:         nil,
+			ChildReads:           value2,
+			ChildWrites:          nil,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: 0,
+		},
+		testCase{
+			Descripiton: desc + "parent Writes",
+
+			ParentReads:          nil,
+			ParentWrites:         value1,
+			ChildReads:           value2,
+			ChildWrites:          nil,
+			TotalReadShouldBe:    0,
+			TotalWrittenShouldBe: value1Size,
+		},
+		testCase{
+			Descripiton: desc + "parent Reads and Writes",
+
+			ParentReads:          value1,
+			ParentWrites:         value2,
+			ChildReads:           value3,
+			ChildWrites:          nil,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: value2Size,
+		},
+	)
+
+	desc = "child Writes, "
+	cases = append(cases,
+		testCase{
+			Descripiton: desc + "parent Nothing",
+
+			ParentReads:          nil,
+			ParentWrites:         nil,
+			ChildReads:           nil,
+			ChildWrites:          value1,
+			TotalReadShouldBe:    0,
+			TotalWrittenShouldBe: value1Size,
+		},
+		testCase{
+			Descripiton: desc + "parent Reads",
+
+			ParentReads:          value1,
+			ParentWrites:         nil,
+			ChildReads:           nil,
+			ChildWrites:          value2,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: value2Size,
+		},
+		testCase{
+			Descripiton: desc + "parent Writes",
+
+			ParentReads:          nil,
+			ParentWrites:         value1,
+			ChildReads:           nil,
+			ChildWrites:          value2,
+			TotalReadShouldBe:    0,
+			TotalWrittenShouldBe: value2Size,
+		},
+		testCase{
+			Descripiton: desc + "parent Reads and Writes",
+
+			ParentReads:          value1,
+			ParentWrites:         value2,
+			ChildReads:           nil,
+			ChildWrites:          value3,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: value3Size,
+		},
+	)
+
+	desc = "child Reads and Writes, "
+	cases = append(cases,
+		testCase{
+			Descripiton: desc + "parent Nothing",
+
+			ParentReads:          nil,
+			ParentWrites:         nil,
+			ChildReads:           value1,
+			ChildWrites:          value2,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: value2Size,
+		},
+		testCase{
+			Descripiton: desc + "parent Reads",
+
+			ParentReads:          value1,
+			ParentWrites:         nil,
+			ChildReads:           value2,
+			ChildWrites:          value3,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: value3Size,
+		},
+		testCase{
+			Descripiton: desc + "parent Writes",
+
+			ParentReads:          nil,
+			ParentWrites:         value1,
+			ChildReads:           value2, // this is a read from the parent
+			ChildWrites:          value3,
+			TotalReadShouldBe:    0,
+			TotalWrittenShouldBe: value3Size,
+		},
+		testCase{
+			Descripiton: desc + "parent Reads and Writes",
+
+			ParentReads:          value1,
+			ParentWrites:         value2,
+			ChildReads:           value3, // this is a read from the parent
+			ChildWrites:          value4,
+			TotalReadShouldBe:    value1Size,
+			TotalWrittenShouldBe: value4Size,
+		},
+	)
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d: %s", i, c.Descripiton), func(t *testing.T) {
+			parentMeter := NewInteractionMeter(DefaultInteractionMeterParameters())
+			childMeter := NewInteractionMeter(DefaultInteractionMeterParameters())
+
+			var err error
+			if c.ParentReads != nil {
+				err = parentMeter.MeterStorageRead(key, c.ParentReads, false)
+				require.NoError(t, err)
+			}
+
+			if c.ChildReads != nil {
+				err = childMeter.MeterStorageRead(key, c.ChildReads, false)
+				require.NoError(t, err)
+			}
+
+			if c.ParentWrites != nil {
+				err = parentMeter.MeterStorageWrite(key, c.ParentWrites, false)
+				require.NoError(t, err)
+			}
+
+			if c.ChildWrites != nil {
+				err = childMeter.MeterStorageWrite(key, c.ChildWrites, false)
+				require.NoError(t, err)
+			}
+
+			parentMeter.Merge(childMeter)
+
+			require.Equal(t, c.TotalReadShouldBe, parentMeter.TotalBytesReadFromStorage())
+			require.Equal(t, c.TotalWrittenShouldBe, parentMeter.TotalBytesWrittenToStorage())
+		})
+	}
+
+}


### PR DESCRIPTION
closes: https://github.com/onflow/flow-go/issues/3782

Interaction metering was very aggressive.

When merging sub-meters (as from the importing cadence contracts) the storage reads were simply added together. Which meant that if the parent meter already counted a read for a register that the child meter also counted, the same register will be counted as read twice.

In reality interaction metering is supposed to only meter first read from a register, and last write to a register.

