### PR TITLE
[Provider] Temporarily disable weight check

### DIFF
--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -78,7 +78,8 @@ func New(
 	// make sure we don't respond to request sent by self or unauthorized nodes
 	selector = filter.And(
 		selector,
-		filter.HasWeight(true),
+		// TODO: disabling this on TESTNET only to work around an issue in the staking contract where all ANs were reset to 0 weight
+		// filter.HasWeight(true),
 		filter.Not(filter.HasNodeID(me.NodeID())),
 	)
 


### PR DESCRIPTION
The staking contract was upgraded on devnet recently and resulted in all ANs having their weight reset to 0. This caused collection nodes to reject requests for collections, breaking the access api.

This PR updates the Provider engine to disable the requirement that the requester has weight.

This is a temporary workaround until the staking contract is fixed and the nodes' protocol state is refreshed