### PR TITLE
Use RegisterID instead of (owner, key)-tuple for accessing accounts

### DIFF
--- a/cmd/util/cmd/checkpoint-collect-stats/cmd.go
+++ b/cmd/util/cmd/checkpoint-collect-stats/cmd.go
@@ -2,11 +2,11 @@ package checkpoint_collect_stats
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/montanaflynn/stats"
 	"github.com/pkg/profile"
@@ -17,11 +17,11 @@ import (
 
 	"github.com/onflow/atree"
 
-	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
 	"github.com/onflow/flow-go/ledger/complete"
 	"github.com/onflow/flow-go/ledger/complete/wal"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/utils/debug"
 )
@@ -227,9 +227,9 @@ func getType(key ledger.Key) string {
 		return "account's cadence public domain map"
 	case "contract":
 		return "account's cadence contract domain map"
-	case state.ContractNamesKey:
+	case flow.ContractNamesKey:
 		return "contract names"
-	case state.AccountStatusKey:
+	case flow.AccountStatusKey:
 		return "account status"
 	case "uuid":
 		return "uuid generator state"
@@ -237,10 +237,10 @@ func getType(key ledger.Key) string {
 		return "address generator state"
 	}
 	// other fvm registers
-	if bytes.HasPrefix(k, []byte("public_key_")) {
+	if strings.HasPrefix(kstr, "public_key_") {
 		return "public key"
 	}
-	if bytes.HasPrefix(k, []byte(state.CodeKeyPrefix)) {
+	if strings.HasPrefix(kstr, flow.CodeKeyPrefix) {
 		return "contract content"
 	}
 	return "others"

--- a/cmd/util/ledger/migrations/account_migration.go
+++ b/cmd/util/ledger/migrations/account_migration.go
@@ -6,8 +6,8 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/onflow/flow-go/fvm/environment"
-	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func MigrateAccountUsage(payloads []ledger.Payload, nWorker int) ([]ledger.Payload, error) {
@@ -24,7 +24,7 @@ func payloadSize(key ledger.Key, payload ledger.Payload) (uint64, error) {
 }
 
 func isAccountKey(key ledger.Key) bool {
-	return string(key.KeyParts[1].Value) == state.AccountStatusKey
+	return string(key.KeyParts[1].Value) == flow.AccountStatusKey
 }
 
 type AccountUsageMigrator struct{}

--- a/cmd/util/ledger/migrations/storage_fees_migration.go
+++ b/cmd/util/ledger/migrations/storage_fees_migration.go
@@ -23,17 +23,14 @@ func StorageFeesMigration(payload []ledger.Payload) ([]ledger.Payload, error) {
 
 	for s, u := range storageUsed {
 		// this is the storage used by the storage_used register we are about to add
-		storageUsedByStorageUsed := fvm.RegisterSize(
-			flow.BytesToAddress([]byte(s)),
-			"storage_used",
-			make([]byte, 8))
+		id := flow.NewRegisterID(
+			string(flow.BytesToAddress([]byte(s)).Bytes()),
+			"storage_used")
+		storageUsedByStorageUsed := fvm.RegisterSize(id, make([]byte, 8))
 		u = u + uint64(storageUsedByStorageUsed)
 
 		newPayload = append(newPayload, *ledger.NewPayload(
-			registerIDToKey(flow.RegisterID{
-				Owner: s,
-				Key:   "storage_used",
-			}),
+			registerIDToKey(id),
 			utils.Uint64ToBinary(u),
 		))
 	}
@@ -61,7 +58,5 @@ func incrementStorageUsed(p ledger.Payload, used map[string]uint64) error {
 }
 
 func registerSize(id flow.RegisterID, p ledger.Payload) int {
-	address := flow.BytesToAddress([]byte(id.Owner))
-	key := id.Key
-	return fvm.RegisterSize(address, key, p.Value())
+	return fvm.RegisterSize(id, p.Value())
 }

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -51,9 +51,9 @@ var _ atree.Ledger = &AccountsAtreeLedger{}
 
 func (a *AccountsAtreeLedger) GetValue(owner, key []byte) ([]byte, error) {
 	v, err := a.Accounts.GetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-	)
+		flow.NewRegisterID(
+			string(flow.BytesToAddress(owner).Bytes()),
+			string(key)))
 	if err != nil {
 		return nil, fmt.Errorf("getting value failed: %w", err)
 	}
@@ -62,10 +62,10 @@ func (a *AccountsAtreeLedger) GetValue(owner, key []byte) ([]byte, error) {
 
 func (a *AccountsAtreeLedger) SetValue(owner, key, value []byte) error {
 	err := a.Accounts.SetValue(
-		flow.BytesToAddress(owner),
-		string(key),
-		value,
-	)
+		flow.NewRegisterID(
+			string(flow.BytesToAddress(owner).Bytes()),
+			string(key)),
+		value)
 	if err != nil {
 		return fmt.Errorf("setting value failed: %w", err)
 	}

--- a/cmd/util/ledger/reporters/atree_reporter.go
+++ b/cmd/util/ledger/reporters/atree_reporter.go
@@ -8,12 +8,11 @@ import (
 	"sync"
 
 	"github.com/onflow/atree"
-
-	fvmState "github.com/onflow/flow-go/fvm/state"
-	"github.com/onflow/flow-go/ledger"
-
 	"github.com/rs/zerolog"
 	"github.com/schollz/progressbar/v3"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 // AtreeReporter iterates payloads and generates payload and atree stats.
@@ -116,12 +115,14 @@ func getPayloadType(p *ledger.Payload) (payloadType, error) {
 	if len(k.KeyParts) < 2 {
 		return unknownPayloadType, nil
 	}
-	if fvmState.IsFVMStateKey(
+
+	id := flow.NewRegisterID(
 		string(k.KeyParts[0].Value),
-		string(k.KeyParts[1].Value),
-	) {
+		string(k.KeyParts[1].Value))
+	if id.IsInternalState() {
 		return fvmPayloadType, nil
 	}
+
 	if bytes.HasPrefix(k.KeyParts[1].Value, []byte(atree.LedgerBaseStorageSlabPrefix)) {
 		return slabPayloadType, nil
 	}

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -663,7 +663,10 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			return nil, nil
 		})
 
-		err = view.Set(string(address.Bytes()), state.AccountStatusKey, environment.NewAccountStatus().ToBytes())
+		err = view.Set(
+			string(address.Bytes()),
+			flow.AccountStatusKey,
+			environment.NewAccountStatus().ToBytes())
 		require.NoError(t, err)
 
 		result, err := exe.ExecuteBlock(context.Background(), block, view, derived.NewEmptyDerivedBlockData())
@@ -761,7 +764,10 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			return nil, nil
 		})
 
-		err = view.Set(string(address.Bytes()), state.AccountStatusKey, environment.NewAccountStatus().ToBytes())
+		err = view.Set(
+			string(address.Bytes()),
+			flow.AccountStatusKey,
+			environment.NewAccountStatus().ToBytes())
 		require.NoError(t, err)
 
 		result, err := exe.ExecuteBlock(context.Background(), block, view, derived.NewEmptyDerivedBlockData())
@@ -983,10 +989,7 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 	registerTouches := view.Interactions().RegisterTouches()
 
 	// make sure check for account status has been registered
-	id := flow.RegisterID{
-		Owner: string(address.Bytes()),
-		Key:   state.AccountStatusKey,
-	}
+	id := flow.AccountStatusRegisterID(address)
 
 	require.Contains(t, registerTouches, id)
 }

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -1311,14 +1311,14 @@ func TestAccountBalanceFields(t *testing.T) {
 				`, address)))
 
 				view := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-					if key == state.AccountStatusKey {
+					if key == flow.AccountStatusKey {
 						return nil, fmt.Errorf("error getting register %s, %s", flow.BytesToAddress([]byte(owner)).Hex(), key)
 					}
 					return nil, nil
 				})
 
 				err := vm.Run(ctx, script, view)
-				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.AccountStatusKey))
+				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), flow.AccountStatusKey))
 			}),
 	)
 
@@ -1519,14 +1519,14 @@ func TestGetStorageCapacity(t *testing.T) {
 				`, address)))
 
 				newview := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-					if key == state.AccountStatusKey {
+					if key == flow.AccountStatusKey {
 						return nil, fmt.Errorf("error getting register %s, %s", flow.BytesToAddress([]byte(owner)).Hex(), key)
 					}
 					return nil, nil
 				})
 
 				err := vm.Run(ctx, script, newview)
-				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), state.AccountStatusKey))
+				require.ErrorContains(t, err, fmt.Sprintf("error getting register %s, %s", address.Hex(), flow.AccountStatusKey))
 			}),
 	)
 }

--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -19,11 +19,6 @@ const (
 	FlowFeesAccountIndex      = 4
 )
 
-var addressStateKey = flow.RegisterID{
-	Owner: "",
-	Key:   state.AddressStateKey,
-}
-
 type AddressGenerator interface {
 	Bytes() []byte
 	NextAddress() (flow.Address, error)
@@ -152,7 +147,7 @@ func NewAccountCreator(
 }
 
 func (creator *accountCreator) bytes() ([]byte, error) {
-	stateBytes, err := creator.txnState.Get(addressStateKey)
+	stateBytes, err := creator.txnState.Get(flow.AddressStateRegisterID)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to read address generator state from the state: %w",
@@ -196,7 +191,8 @@ func (creator *accountCreator) NextAddress() (flow.Address, error) {
 	}
 
 	// update the ledger state
-	err = creator.txnState.Set(addressStateKey,
+	err = creator.txnState.Set(
+		flow.AddressStateRegisterID,
 		addressGenerator.Bytes())
 	if err != nil {
 		return address, fmt.Errorf(

--- a/fvm/environment/account_creator_test.go
+++ b/fvm/environment/account_creator_test.go
@@ -27,7 +27,9 @@ func Test_NewAccountCreator_GeneratingUpdatesState(t *testing.T) {
 	_, err := creator.NextAddress()
 	require.NoError(t, err)
 
-	stateBytes, err := view.Get("", state.AddressStateKey)
+	stateBytes, err := view.Get(
+		flow.AddressStateRegisterID.Owner,
+		flow.AddressStateRegisterID.Key)
 	require.NoError(t, err)
 
 	require.Equal(t, flow.BytesToAddress(stateBytes), flow.HexToAddress("01"))
@@ -35,7 +37,10 @@ func Test_NewAccountCreator_GeneratingUpdatesState(t *testing.T) {
 
 func Test_NewAccountCreator_UsesLedgerState(t *testing.T) {
 	view := utils.NewSimpleView()
-	err := view.Set("", state.AddressStateKey, flow.HexToAddress("01").Bytes())
+	err := view.Set(
+		flow.AddressStateRegisterID.Owner,
+		flow.AddressStateRegisterID.Key,
+		flow.HexToAddress("01").Bytes())
 	require.NoError(t, err)
 
 	chain := flow.MonotonicEmulator.Chain()
@@ -45,7 +50,9 @@ func Test_NewAccountCreator_UsesLedgerState(t *testing.T) {
 	_, err = creator.NextAddress()
 	require.NoError(t, err)
 
-	stateBytes, err := view.Get("", state.AddressStateKey)
+	stateBytes, err := view.Get(
+		flow.AddressStateRegisterID.Owner,
+		flow.AddressStateRegisterID.Key)
 	require.NoError(t, err)
 
 	require.Equal(t, flow.BytesToAddress(stateBytes), flow.HexToAddress("02"))

--- a/fvm/environment/account_key_updater_test.go
+++ b/fvm/environment/account_key_updater_test.go
@@ -211,16 +211,16 @@ func (f FakeAccounts) GetPublicKey(address flow.Address, keyIndex uint64) (flow.
 func (f FakeAccounts) SetPublicKey(_ flow.Address, _ uint64, _ flow.AccountPublicKey) ([]byte, error) {
 	return nil, nil
 }
-func (f FakeAccounts) GetContractNames(_ flow.Address) ([]string, error)             { return nil, nil }
-func (f FakeAccounts) GetContract(_ string, _ flow.Address) ([]byte, error)          { return nil, nil }
-func (f FakeAccounts) ContractExists(_ string, _ flow.Address) (bool, error)         { return false, nil }
-func (f FakeAccounts) SetContract(_ string, _ flow.Address, _ []byte) error          { return nil }
-func (f FakeAccounts) DeleteContract(_ string, _ flow.Address) error                 { return nil }
-func (f FakeAccounts) Create(_ []flow.AccountPublicKey, _ flow.Address) error        { return nil }
-func (f FakeAccounts) GetValue(_ flow.Address, _ string) (flow.RegisterValue, error) { return nil, nil }
-func (f FakeAccounts) CheckAccountNotFrozen(_ flow.Address) error                    { return nil }
-func (f FakeAccounts) GetStorageUsed(_ flow.Address) (uint64, error)                 { return 0, nil }
-func (f FakeAccounts) SetValue(_ flow.Address, _ string, _ []byte) error             { return nil }
+func (f FakeAccounts) GetContractNames(_ flow.Address) ([]string, error)      { return nil, nil }
+func (f FakeAccounts) GetContract(_ string, _ flow.Address) ([]byte, error)   { return nil, nil }
+func (f FakeAccounts) ContractExists(_ string, _ flow.Address) (bool, error)  { return false, nil }
+func (f FakeAccounts) SetContract(_ string, _ flow.Address, _ []byte) error   { return nil }
+func (f FakeAccounts) DeleteContract(_ string, _ flow.Address) error          { return nil }
+func (f FakeAccounts) Create(_ []flow.AccountPublicKey, _ flow.Address) error { return nil }
+func (f FakeAccounts) GetValue(_ flow.RegisterID) (flow.RegisterValue, error) { return nil, nil }
+func (f FakeAccounts) CheckAccountNotFrozen(_ flow.Address) error             { return nil }
+func (f FakeAccounts) GetStorageUsed(_ flow.Address) (uint64, error)          { return 0, nil }
+func (f FakeAccounts) SetValue(_ flow.RegisterID, _ []byte) error             { return nil }
 func (f FakeAccounts) AllocateStorageIndex(_ flow.Address) (atree.StorageIndex, error) {
 	return atree.StorageIndex{}, nil
 }

--- a/fvm/environment/accounts.go
+++ b/fvm/environment/accounts.go
@@ -33,10 +33,10 @@ type Accounts interface {
 	SetContract(contractName string, address flow.Address, contract []byte) error
 	DeleteContract(contractName string, address flow.Address) error
 	Create(publicKeys []flow.AccountPublicKey, newAddress flow.Address) error
-	GetValue(address flow.Address, key string) (flow.RegisterValue, error)
+	GetValue(id flow.RegisterID) (flow.RegisterValue, error)
 	CheckAccountNotFrozen(address flow.Address) error
 	GetStorageUsed(address flow.Address) (uint64, error)
-	SetValue(address flow.Address, key string, value flow.RegisterValue) error
+	SetValue(id flow.RegisterID, value flow.RegisterValue) error
 	AllocateStorageIndex(address flow.Address) (atree.StorageIndex, error)
 	SetAccountFrozen(address flow.Address, frozen bool) error
 }
@@ -53,7 +53,12 @@ func NewAccounts(txnState *state.TransactionState) *StatefulAccounts {
 	}
 }
 
-func (a *StatefulAccounts) AllocateStorageIndex(address flow.Address) (atree.StorageIndex, error) {
+func (a *StatefulAccounts) AllocateStorageIndex(
+	address flow.Address,
+) (
+	atree.StorageIndex,
+	error,
+) {
 	// get status
 	status, err := a.getAccountStatus(address)
 	if err != nil {
@@ -65,7 +70,8 @@ func (a *StatefulAccounts) AllocateStorageIndex(address flow.Address) (atree.Sto
 	newIndexBytes := index.Next()
 
 	// store nil so that the setValue for new allocated slabs would be faster
-	// and won't do ledger getValue for every new slabs (currently happening to compute storage size changes)
+	// and won't do ledger getValue for every new slabs (currently happening to
+	// compute storage size changes)
 	// this way the getValue would load this value from deltas
 	key := atree.SlabIndexToLedgerKey(index)
 	a.txnState.RunWithAllLimitsDisabled(func() {
@@ -77,14 +83,18 @@ func (a *StatefulAccounts) AllocateStorageIndex(address flow.Address) (atree.Sto
 			[]byte{})
 	})
 	if err != nil {
-		return atree.StorageIndex{}, fmt.Errorf("failed to allocate an storage index: %w", err)
+		return atree.StorageIndex{}, fmt.Errorf(
+			"failed to allocate an storage index: %w",
+			err)
 	}
 
 	// update the storageIndex bytes
 	status.SetStorageIndex(newIndexBytes)
 	err = a.setAccountStatus(address, status)
 	if err != nil {
-		return atree.StorageIndex{}, fmt.Errorf("failed to allocate an storage index: %w", err)
+		return atree.StorageIndex{}, fmt.Errorf(
+			"failed to allocate an storage index: %w",
+			err)
 	}
 	return index, nil
 }
@@ -130,7 +140,7 @@ func (a *StatefulAccounts) Get(address flow.Address) (*flow.Account, error) {
 }
 
 func (a *StatefulAccounts) Exists(address flow.Address) (bool, error) {
-	accStatusBytes, err := a.GetValue(address, state.AccountStatusKey)
+	accStatusBytes, err := a.GetValue(flow.AccountStatusRegisterID(address))
 	if err != nil {
 		return false, err
 	}
@@ -150,7 +160,10 @@ func (a *StatefulAccounts) Exists(address flow.Address) (bool, error) {
 }
 
 // Create account sets all required registers on an address.
-func (a *StatefulAccounts) Create(publicKeys []flow.AccountPublicKey, newAddress flow.Address) error {
+func (a *StatefulAccounts) Create(
+	publicKeys []flow.AccountPublicKey,
+	newAddress flow.Address,
+) error {
 	exists, err := a.Exists(newAddress)
 	if err != nil {
 		return fmt.Errorf("failed to create a new account: %w", err)
@@ -160,8 +173,13 @@ func (a *StatefulAccounts) Create(publicKeys []flow.AccountPublicKey, newAddress
 	}
 
 	accountStatus := NewAccountStatus()
-	storageUsedByTheStatusItself := uint64(RegisterSize(newAddress, state.AccountStatusKey, accountStatus.ToBytes()))
-	err = a.setAccountStatusStorageUsed(newAddress, accountStatus, storageUsedByTheStatusItself)
+	storageUsedByTheStatusItself := uint64(RegisterSize(
+		flow.AccountStatusRegisterID(newAddress),
+		accountStatus.ToBytes()))
+	err = a.setAccountStatusStorageUsed(
+		newAddress,
+		accountStatus,
+		storageUsedByTheStatusItself)
 	if err != nil {
 		return fmt.Errorf("failed to create a new account: %w", err)
 	}
@@ -169,25 +187,40 @@ func (a *StatefulAccounts) Create(publicKeys []flow.AccountPublicKey, newAddress
 	return a.SetAllPublicKeys(newAddress, publicKeys)
 }
 
-func (a *StatefulAccounts) GetPublicKey(address flow.Address, keyIndex uint64) (flow.AccountPublicKey, error) {
-	publicKey, err := a.GetValue(address, KeyPublicKey(keyIndex))
+func (a *StatefulAccounts) GetPublicKey(
+	address flow.Address,
+	keyIndex uint64,
+) (
+	flow.AccountPublicKey,
+	error,
+) {
+	publicKey, err := a.GetValue(flow.PublicKeyRegisterID(address, keyIndex))
 	if err != nil {
 		return flow.AccountPublicKey{}, err
 	}
 
 	if len(publicKey) == 0 {
-		return flow.AccountPublicKey{}, errors.NewAccountPublicKeyNotFoundError(address, keyIndex)
+		return flow.AccountPublicKey{}, errors.NewAccountPublicKeyNotFoundError(
+			address,
+			keyIndex)
 	}
 
 	decodedPublicKey, err := flow.DecodeAccountPublicKey(publicKey, keyIndex)
 	if err != nil {
-		return flow.AccountPublicKey{}, fmt.Errorf("failed to decode public key: %w", err)
+		return flow.AccountPublicKey{}, fmt.Errorf(
+			"failed to decode public key: %w",
+			err)
 	}
 
 	return decodedPublicKey, nil
 }
 
-func (a *StatefulAccounts) GetPublicKeyCount(address flow.Address) (uint64, error) {
+func (a *StatefulAccounts) GetPublicKeyCount(
+	address flow.Address,
+) (
+	uint64,
+	error,
+) {
 	status, err := a.getAccountStatus(address)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get public key count: %w", err)
@@ -195,25 +228,41 @@ func (a *StatefulAccounts) GetPublicKeyCount(address flow.Address) (uint64, erro
 	return status.PublicKeyCount(), nil
 }
 
-func (a *StatefulAccounts) setPublicKeyCount(address flow.Address, count uint64) error {
+func (a *StatefulAccounts) setPublicKeyCount(
+	address flow.Address,
+	count uint64,
+) error {
 	status, err := a.getAccountStatus(address)
 	if err != nil {
-		return fmt.Errorf("failed to set public key count for account (%s): %w", address.String(), err)
+		return fmt.Errorf(
+			"failed to set public key count for account (%s): %w",
+			address.String(),
+			err)
 	}
 
 	status.SetPublicKeyCount(count)
 
 	err = a.setAccountStatus(address, status)
 	if err != nil {
-		return fmt.Errorf("failed to set public key count for account (%s): %w", address.String(), err)
+		return fmt.Errorf(
+			"failed to set public key count for account (%s): %w",
+			address.String(),
+			err)
 	}
 	return nil
 }
 
-func (a *StatefulAccounts) GetPublicKeys(address flow.Address) (publicKeys []flow.AccountPublicKey, err error) {
+func (a *StatefulAccounts) GetPublicKeys(
+	address flow.Address,
+) (
+	publicKeys []flow.AccountPublicKey,
+	err error,
+) {
 	count, err := a.GetPublicKeyCount(address)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get public key count of account: %w", err)
+		return nil, fmt.Errorf(
+			"failed to get public key count of account: %w",
+			err)
 	}
 	publicKeys = make([]flow.AccountPublicKey, count)
 
@@ -237,26 +286,40 @@ func (a *StatefulAccounts) SetPublicKey(
 	err = publicKey.Validate()
 	if err != nil {
 		encoded, _ := publicKey.MarshalJSON()
-		return nil, errors.NewValueErrorf(string(encoded), "invalid public key value: %w", err)
+		return nil, errors.NewValueErrorf(
+			string(encoded),
+			"invalid public key value: %w",
+			err)
 	}
 
 	encodedPublicKey, err = flow.EncodeAccountPublicKey(publicKey)
 	if err != nil {
 		encoded, _ := publicKey.MarshalJSON()
-		return nil, errors.NewValueErrorf(string(encoded), "invalid public key value: %w", err)
+		return nil, errors.NewValueErrorf(
+			string(encoded),
+			"invalid public key value: %w",
+			err)
 	}
 
-	err = a.SetValue(address, KeyPublicKey(keyIndex), encodedPublicKey)
+	err = a.SetValue(
+		flow.PublicKeyRegisterID(address, keyIndex),
+		encodedPublicKey)
 
 	return encodedPublicKey, err
 }
 
-func (a *StatefulAccounts) SetAllPublicKeys(address flow.Address, publicKeys []flow.AccountPublicKey) error {
+func (a *StatefulAccounts) SetAllPublicKeys(
+	address flow.Address,
+	publicKeys []flow.AccountPublicKey,
+) error {
 
-	count := uint64(len(publicKeys)) // len returns int and this will not exceed uint64
+	count := uint64(len(publicKeys))
 
 	if count >= MaxPublicKeyCount {
-		return errors.NewAccountPublicKeyLimitError(address, count, MaxPublicKeyCount)
+		return errors.NewAccountPublicKeyLimitError(
+			address,
+			count,
+			MaxPublicKeyCount)
 	}
 
 	for i, publicKey := range publicKeys {
@@ -269,14 +332,21 @@ func (a *StatefulAccounts) SetAllPublicKeys(address flow.Address, publicKeys []f
 	return a.setPublicKeyCount(address, count)
 }
 
-func (a *StatefulAccounts) AppendPublicKey(address flow.Address, publicKey flow.AccountPublicKey) error {
+func (a *StatefulAccounts) AppendPublicKey(
+	address flow.Address,
+	publicKey flow.AccountPublicKey,
+) error {
 
 	if !IsValidAccountKeyHashAlgo(publicKey.HashAlgo) {
-		return errors.NewValueErrorf(publicKey.HashAlgo.String(), "hashing algorithm type not found")
+		return errors.NewValueErrorf(
+			publicKey.HashAlgo.String(),
+			"hashing algorithm type not found")
 	}
 
 	if !IsValidAccountKeySignAlgo(publicKey.SignAlgo) {
-		return errors.NewValueErrorf(publicKey.SignAlgo.String(), "signature algorithm type not found")
+		return errors.NewValueErrorf(
+			publicKey.SignAlgo.String(),
+			"signature algorithm type not found")
 	}
 
 	count, err := a.GetPublicKeyCount(address)
@@ -285,7 +355,10 @@ func (a *StatefulAccounts) AppendPublicKey(address flow.Address, publicKey flow.
 	}
 
 	if count >= MaxPublicKeyCount {
-		return errors.NewAccountPublicKeyLimitError(address, count+1, MaxPublicKeyCount)
+		return errors.NewAccountPublicKeyLimitError(
+			address,
+			count+1,
+			MaxPublicKeyCount)
 	}
 
 	_, err = a.SetPublicKey(address, count, publicKey)
@@ -314,13 +387,14 @@ func IsValidAccountKeyHashAlgo(algo hash.HashingAlgorithm) bool {
 	}
 }
 
-func ContractKey(contractName string) string {
-	return state.CodeKeyPrefix + contractName
-}
-
-func (a *StatefulAccounts) getContract(contractName string, address flow.Address) ([]byte, error) {
-
-	contract, err := a.GetValue(address, ContractKey(contractName))
+func (a *StatefulAccounts) getContract(
+	contractName string,
+	address flow.Address,
+) (
+	[]byte,
+	error,
+) {
+	contract, err := a.GetValue(flow.ContractRegisterID(address, contractName))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +402,11 @@ func (a *StatefulAccounts) getContract(contractName string, address flow.Address
 	return contract, nil
 }
 
-func (a *StatefulAccounts) setContract(contractName string, address flow.Address, contract []byte) error {
+func (a *StatefulAccounts) setContract(
+	contractName string,
+	address flow.Address,
+	contract []byte,
+) error {
 	ok, err := a.Exists(address)
 	if err != nil {
 		return err
@@ -338,8 +416,8 @@ func (a *StatefulAccounts) setContract(contractName string, address flow.Address
 		return errors.NewAccountNotFoundError(address)
 	}
 
-	var prevContract []byte
-	prevContract, err = a.GetValue(address, ContractKey(contractName))
+	id := flow.ContractRegisterID(address, contractName)
+	prevContract, err := a.GetValue(id)
 	if err != nil {
 		return errors.NewContractNotFoundError(address, contractName)
 	}
@@ -349,7 +427,7 @@ func (a *StatefulAccounts) setContract(contractName string, address flow.Address
 		return nil
 	}
 
-	err = a.SetValue(address, ContractKey(contractName), contract)
+	err = a.SetValue(id, contract)
 	if err != nil {
 		return err
 	}
@@ -357,7 +435,10 @@ func (a *StatefulAccounts) setContract(contractName string, address flow.Address
 	return nil
 }
 
-func (a *StatefulAccounts) setContractNames(contractNames contractNames, address flow.Address) error {
+func (a *StatefulAccounts) setContractNames(
+	contractNames contractNames,
+	address flow.Address,
+) error {
 	ok, err := a.Exists(address)
 	if err != nil {
 		return err
@@ -377,8 +458,8 @@ func (a *StatefulAccounts) setContractNames(contractNames contractNames, address
 	}
 	newContractNames := buf.Bytes()
 
-	var prevContractNames []byte
-	prevContractNames, err = a.GetValue(address, state.ContractNamesKey)
+	id := flow.ContractNamesRegisterID(address)
+	prevContractNames, err := a.GetValue(id)
 	if err != nil {
 		return fmt.Errorf("cannot retrieve current contract names: %w", err)
 	}
@@ -388,11 +469,16 @@ func (a *StatefulAccounts) setContractNames(contractNames contractNames, address
 		return nil
 	}
 
-	return a.SetValue(address, state.ContractNamesKey, newContractNames)
+	return a.SetValue(id, newContractNames)
 }
 
 // GetStorageUsed returns the amount of storage used in bytes by this account
-func (a *StatefulAccounts) GetStorageUsed(address flow.Address) (uint64, error) {
+func (a *StatefulAccounts) GetStorageUsed(
+	address flow.Address,
+) (
+	uint64,
+	error,
+) {
 	status, err := a.getAccountStatus(address)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get storage used: %w", err)
@@ -400,7 +486,10 @@ func (a *StatefulAccounts) GetStorageUsed(address flow.Address) (uint64, error) 
 	return status.StorageUsed(), nil
 }
 
-func (a *StatefulAccounts) setStorageUsed(address flow.Address, used uint64) error {
+func (a *StatefulAccounts) setStorageUsed(
+	address flow.Address,
+	used uint64,
+) error {
 	status, err := a.getAccountStatus(address)
 	if err != nil {
 		return fmt.Errorf("failed to set storage used: %w", err)
@@ -409,7 +498,11 @@ func (a *StatefulAccounts) setStorageUsed(address flow.Address, used uint64) err
 	return a.setAccountStatusStorageUsed(address, status, used)
 }
 
-func (a *StatefulAccounts) setAccountStatusStorageUsed(address flow.Address, status *AccountStatus, newUsed uint64) error {
+func (a *StatefulAccounts) setAccountStatusStorageUsed(
+	address flow.Address,
+	status *AccountStatus,
+	newUsed uint64,
+) error {
 	status.SetStorageUsed(newUsed)
 
 	err := a.setAccountStatus(address, status)
@@ -419,44 +512,48 @@ func (a *StatefulAccounts) setAccountStatusStorageUsed(address flow.Address, sta
 	return nil
 }
 
-// TODO(patrick): use RegisterID as input key
-func (a *StatefulAccounts) GetValue(address flow.Address, key string) (flow.RegisterValue, error) {
-	return a.txnState.Get(flow.RegisterID{
-		Owner: string(address.Bytes()),
-		Key:   key,
-	})
+func (a *StatefulAccounts) GetValue(
+	id flow.RegisterID,
+) (
+	flow.RegisterValue,
+	error,
+) {
+	return a.txnState.Get(id)
 }
 
-// TODO(patrick): use RegisterID as input key
 // SetValue sets a value in address' storage
-func (a *StatefulAccounts) SetValue(address flow.Address, key string, value flow.RegisterValue) error {
-	err := a.updateRegisterSizeChange(address, key, value)
+func (a *StatefulAccounts) SetValue(
+	id flow.RegisterID,
+	value flow.RegisterValue,
+) error {
+	err := a.updateRegisterSizeChange(id, value)
 	if err != nil {
-		return fmt.Errorf("failed to update storage used by key %s on account %s: %w", state.PrintableKey(key), address, err)
+		return fmt.Errorf("failed to update storage for %s: %w", id, err)
 	}
-	return a.txnState.Set(flow.RegisterID{
-		Owner: string(address.Bytes()),
-		Key:   key},
-		value)
+	return a.txnState.Set(id, value)
 }
 
-func (a *StatefulAccounts) updateRegisterSizeChange(address flow.Address, key string, value flow.RegisterValue) error {
-	if key == state.AccountStatusKey {
+func (a *StatefulAccounts) updateRegisterSizeChange(
+	id flow.RegisterID,
+	value flow.RegisterValue,
+) error {
+	if id.Key == flow.AccountStatusKey {
 		// size of this register is always fixed size
 		// don't double check this to save time and prevent recursion
 		return nil
 	}
-	oldValue, err := a.GetValue(address, key)
+	oldValue, err := a.GetValue(id)
 	if err != nil {
 		return err
 	}
 
-	sizeChange := int64(RegisterSize(address, key, value) - RegisterSize(address, key, oldValue))
+	sizeChange := int64(RegisterSize(id, value) - RegisterSize(id, oldValue))
 	if sizeChange == 0 {
 		// register size has not changed. Nothing to do
 		return nil
 	}
 
+	address := flow.BytesToAddress([]byte(id.Owner))
 	oldSize, err := a.GetStorageUsed(address)
 	if err != nil {
 		return err
@@ -468,7 +565,7 @@ func (a *StatefulAccounts) updateRegisterSizeChange(address flow.Address, key st
 		absChange := uint64(-sizeChange)
 		if absChange > oldSize {
 			// should never happen
-			return fmt.Errorf("storage used by key %s on account %s would be negative", state.PrintableKey(key), address.Hex())
+			return fmt.Errorf("storage would be negative for %s", id)
 		}
 		newSize = oldSize - absChange
 	} else {
@@ -477,11 +574,12 @@ func (a *StatefulAccounts) updateRegisterSizeChange(address flow.Address, key st
 	}
 
 	// this puts us back in the setValue method.
-	// The difference is that storage_used update exits early from this function so there isn't any recursion.
+	// The difference is that storage_used update exits early from this
+	// function so there isn't any recursion.
 	return a.setStorageUsed(address, newSize)
 }
 
-func RegisterSize(address flow.Address, key string, value flow.RegisterValue) int {
+func RegisterSize(id flow.RegisterID, value flow.RegisterValue) int {
 	if len(value) == 0 {
 		// registers with empty value won't (or don't) exist when stored
 		return 0
@@ -489,20 +587,31 @@ func RegisterSize(address flow.Address, key string, value flow.RegisterValue) in
 	size := 0
 	// additional 2 is for len prefixes when encoding is happening
 	// we might get rid of these 2s in the future
-	size += 2 + len(string(address.Bytes()))
-	size += 2 + len(key)
+	size += 2 + len(id.Owner)
+	size += 2 + len(id.Key)
 	size += len(value)
 	return size
 }
 
-// GetContractNames gets a sorted list of names of contracts deployed on an address
-func (a *StatefulAccounts) GetContractNames(address flow.Address) ([]string, error) {
+// GetContractNames gets a sorted list of names of contracts deployed on an
+// address
+func (a *StatefulAccounts) GetContractNames(
+	address flow.Address,
+) (
+	[]string,
+	error,
+) {
 	return a.getContractNames(address)
 }
 
-func (a *StatefulAccounts) getContractNames(address flow.Address) (contractNames, error) {
+func (a *StatefulAccounts) getContractNames(
+	address flow.Address,
+) (
+	contractNames,
+	error,
+) {
 	// TODO return fatal error if can't fetch
-	encContractNames, err := a.GetValue(address, state.ContractNamesKey)
+	encContractNames, err := a.GetValue(flow.ContractNamesRegisterID(address))
 	if err != nil {
 		return nil, fmt.Errorf("cannot get deployed contract names: %w", err)
 	}
@@ -512,13 +621,22 @@ func (a *StatefulAccounts) getContractNames(address flow.Address) (contractNames
 		cborDecoder := cbor.NewDecoder(buf)
 		err = cborDecoder.Decode(&identifiers)
 		if err != nil {
-			return nil, fmt.Errorf("cannot decode deployed contract names %x: %w", encContractNames, err)
+			return nil, fmt.Errorf(
+				"cannot decode deployed contract names %x: %w",
+				encContractNames,
+				err)
 		}
 	}
 	return identifiers, nil
 }
 
-func (a *StatefulAccounts) ContractExists(contractName string, address flow.Address) (bool, error) {
+func (a *StatefulAccounts) ContractExists(
+	contractName string,
+	address flow.Address,
+) (
+	bool,
+	error,
+) {
 	contractNames, err := a.getContractNames(address)
 	if err != nil {
 		return false, err
@@ -526,9 +644,16 @@ func (a *StatefulAccounts) ContractExists(contractName string, address flow.Addr
 	return contractNames.Has(contractName), nil
 }
 
-func (a *StatefulAccounts) GetContract(contractName string, address flow.Address) ([]byte, error) {
-	// we optimized the happy case here, we look up for the content of the contract
-	// and if its not there we check if contract exists or if this is another problem.
+func (a *StatefulAccounts) GetContract(
+	contractName string,
+	address flow.Address,
+) (
+	[]byte,
+	error,
+) {
+	// we optimized the happy case here, we look up for the content of the
+	// contract and if its not there we check if contract exists or if this is
+	// another problem.
 	code, err := a.getContract(contractName, address)
 	if err != nil || len(code) == 0 {
 		exists, err := a.ContractExists(contractName, address)
@@ -542,7 +667,11 @@ func (a *StatefulAccounts) GetContract(contractName string, address flow.Address
 	return code, err
 }
 
-func (a *StatefulAccounts) SetContract(contractName string, address flow.Address, contract []byte) error {
+func (a *StatefulAccounts) SetContract(
+	contractName string,
+	address flow.Address,
+	contract []byte,
+) error {
 	contractNames, err := a.getContractNames(address)
 	if err != nil {
 		return err
@@ -555,7 +684,10 @@ func (a *StatefulAccounts) SetContract(contractName string, address flow.Address
 	return a.setContractNames(contractNames, address)
 }
 
-func (a *StatefulAccounts) DeleteContract(contractName string, address flow.Address) error {
+func (a *StatefulAccounts) DeleteContract(
+	contractName string,
+	address flow.Address,
+) error {
 	contractNames, err := a.getContractNames(address)
 	if err != nil {
 		return err
@@ -571,10 +703,19 @@ func (a *StatefulAccounts) DeleteContract(contractName string, address flow.Addr
 	return a.setContractNames(contractNames, address)
 }
 
-func (a *StatefulAccounts) getAccountStatus(address flow.Address) (*AccountStatus, error) {
-	statusBytes, err := a.GetValue(address, state.AccountStatusKey)
+func (a *StatefulAccounts) getAccountStatus(
+	address flow.Address,
+) (
+	*AccountStatus,
+	error,
+) {
+	id := flow.AccountStatusRegisterID(address)
+	statusBytes, err := a.GetValue(id)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load account status for the account (%s): %w", address.String(), err)
+		return nil, fmt.Errorf(
+			"failed to load account status for the account (%s): %w",
+			address.String(),
+			err)
 	}
 	if len(statusBytes) == 0 {
 		return nil, errors.NewAccountNotFoundError(address)
@@ -582,15 +723,27 @@ func (a *StatefulAccounts) getAccountStatus(address flow.Address) (*AccountStatu
 	return AccountStatusFromBytes(statusBytes)
 }
 
-func (a *StatefulAccounts) setAccountStatus(address flow.Address, status *AccountStatus) error {
-	err := a.SetValue(address, state.AccountStatusKey, status.ToBytes())
+func (a *StatefulAccounts) setAccountStatus(
+	address flow.Address,
+	status *AccountStatus,
+) error {
+	id := flow.AccountStatusRegisterID(address)
+	err := a.SetValue(id, status.ToBytes())
 	if err != nil {
-		return fmt.Errorf("failed to store the account status for account (%s): %w", address.String(), err)
+		return fmt.Errorf(
+			"failed to store the account status for account (%s): %w",
+			address.String(),
+			err)
 	}
 	return nil
 }
 
-func (a *StatefulAccounts) GetAccountFrozen(address flow.Address) (bool, error) {
+func (a *StatefulAccounts) GetAccountFrozen(
+	address flow.Address,
+) (
+	bool,
+	error,
+) {
 	status, err := a.getAccountStatus(address)
 	if err != nil {
 		return false, err
@@ -598,7 +751,10 @@ func (a *StatefulAccounts) GetAccountFrozen(address flow.Address) (bool, error) 
 	return status.IsAccountFrozen(), nil
 }
 
-func (a *StatefulAccounts) SetAccountFrozen(address flow.Address, frozen bool) error {
+func (a *StatefulAccounts) SetAccountFrozen(
+	address flow.Address,
+	frozen bool,
+) error {
 	status, err := a.getAccountStatus(address)
 	if err != nil {
 		return err
@@ -619,8 +775,9 @@ func (a *StatefulAccounts) CheckAccountNotFrozen(address flow.Address) error {
 	return nil
 }
 
-// contractNames container for a list of contract names. Should always be sorted.
-// To ensure this, don't sort while reading it from storage, but sort it while adding/removing elements
+// contractNames container for a list of contract names. Should always be
+// sorted. To ensure this, don't sort while reading it from storage, but sort
+// it while adding/removing elements
 type contractNames []string
 
 func (l contractNames) Has(contractNames string) bool {
@@ -644,8 +801,4 @@ func (l *contractNames) remove(contractName string) {
 		return
 	}
 	*l = append((*l)[:i], (*l)[i+1:]...)
-}
-
-func KeyPublicKey(index uint64) string {
-	return fmt.Sprintf("public_key_%d", index)
 }

--- a/fvm/environment/accounts_test.go
+++ b/fvm/environment/accounts_test.go
@@ -258,11 +258,12 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
+		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
 
-		err = accounts.SetValue(address, "some_key", createByteArray(12))
+		err = accounts.SetValue(key, createByteArray(12))
 		require.NoError(t, err)
 
 		storageUsed, err := accounts.GetStorageUsed(address)
@@ -275,13 +276,14 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
+		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
 
-		err = accounts.SetValue(address, "some_key", createByteArray(12))
+		err = accounts.SetValue(key, createByteArray(12))
 		require.NoError(t, err)
-		err = accounts.SetValue(address, "some_key", createByteArray(12))
+		err = accounts.SetValue(key, createByteArray(12))
 		require.NoError(t, err)
 
 		storageUsed, err := accounts.GetStorageUsed(address)
@@ -294,13 +296,14 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
+		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
 
-		err = accounts.SetValue(address, "some_key", createByteArray(12))
+		err = accounts.SetValue(key, createByteArray(12))
 		require.NoError(t, err)
-		err = accounts.SetValue(address, "some_key", createByteArray(13))
+		err = accounts.SetValue(key, createByteArray(13))
 		require.NoError(t, err)
 
 		storageUsed, err := accounts.GetStorageUsed(address)
@@ -313,13 +316,14 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
+		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
 
-		err = accounts.SetValue(address, "some_key", createByteArray(12))
+		err = accounts.SetValue(key, createByteArray(12))
 		require.NoError(t, err)
-		err = accounts.SetValue(address, "some_key", createByteArray(11))
+		err = accounts.SetValue(key, createByteArray(11))
 		require.NoError(t, err)
 
 		storageUsed, err := accounts.GetStorageUsed(address)
@@ -332,13 +336,14 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
+		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
 
-		err = accounts.SetValue(address, "some_key", createByteArray(12))
+		err = accounts.SetValue(key, createByteArray(12))
 		require.NoError(t, err)
-		err = accounts.SetValue(address, "some_key", nil)
+		err = accounts.SetValue(key, nil)
 		require.NoError(t, err)
 
 		storageUsed, err := accounts.GetStorageUsed(address)
@@ -355,19 +360,22 @@ func TestAccount_StorageUsed(t *testing.T) {
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
 
-		err = accounts.SetValue(address, "some_key", createByteArray(12))
+		key1 := flow.NewRegisterID(string(address.Bytes()), "some_key")
+		err = accounts.SetValue(key1, createByteArray(12))
 		require.NoError(t, err)
-		err = accounts.SetValue(address, "some_key", createByteArray(11))
-		require.NoError(t, err)
-
-		err = accounts.SetValue(address, "some_key2", createByteArray(22))
-		require.NoError(t, err)
-		err = accounts.SetValue(address, "some_key2", createByteArray(23))
+		err = accounts.SetValue(key1, createByteArray(11))
 		require.NoError(t, err)
 
-		err = accounts.SetValue(address, "some_key3", createByteArray(22))
+		key2 := flow.NewRegisterID(string(address.Bytes()), "some_key2")
+		err = accounts.SetValue(key2, createByteArray(22))
 		require.NoError(t, err)
-		err = accounts.SetValue(address, "some_key3", createByteArray(0))
+		err = accounts.SetValue(key2, createByteArray(23))
+		require.NoError(t, err)
+
+		key3 := flow.NewRegisterID(string(address.Bytes()), "some_key3")
+		err = accounts.SetValue(key3, createByteArray(22))
+		require.NoError(t, err)
+		err = accounts.SetValue(key3, createByteArray(0))
 		require.NoError(t, err)
 
 		storageUsed, err := accounts.GetStorageUsed(address)

--- a/fvm/environment/derived_data_invalidator.go
+++ b/fvm/environment/derived_data_invalidator.go
@@ -59,8 +59,7 @@ func meterParamOverridesUpdated(env *facadeEnvironment) bool {
 		//
 		// The meter param overrides use storageDomain as input, so any
 		// changes to it must also invalidate the values.
-		if registerId.Key == storageDomain ||
-			state.IsSlabIndex(registerId.Key) {
+		if registerId.Key == storageDomain || registerId.IsSlabIndex() {
 			return true
 		}
 	}

--- a/fvm/environment/derived_data_invalidator_test.go
+++ b/fvm/environment/derived_data_invalidator_test.go
@@ -264,13 +264,11 @@ func TestMeterParamOverridesUpdated(t *testing.T) {
 
 	ctx.TxBody = &flow.TransactionBody{}
 
-	checkForUpdates := func(owner string, key string, expected bool) {
+	checkForUpdates := func(id flow.RegisterID, expected bool) {
 		view := utils.NewSimpleView()
 		txnState := state.NewTransactionState(view, state.DefaultParameters())
 
-		err := txnState.Set(
-			flow.RegisterID{Owner: owner, Key: key},
-			flow.RegisterValue("blah"))
+		err := txnState.Set(id, flow.RegisterValue("blah"))
 		require.NoError(t, err)
 
 		env := environment.NewTransactionEnvironment(
@@ -284,24 +282,18 @@ func TestMeterParamOverridesUpdated(t *testing.T) {
 	}
 
 	for registerId := range view.Ledger.RegisterTouches {
-		checkForUpdates(registerId.Owner, registerId.Key, true)
-		checkForUpdates("other owner", registerId.Key, false)
+		checkForUpdates(registerId, true)
+		checkForUpdates(
+			flow.NewRegisterID("other owner", registerId.Key),
+			false)
 	}
 
-	stabIndex := "$12345678"
-	require.True(t, state.IsSlabIndex(stabIndex))
+	owner := string(ctx.Chain.ServiceAddress().Bytes())
+	stabIndexKey := flow.NewRegisterID(owner, "$12345678")
+	require.True(t, stabIndexKey.IsSlabIndex())
 
-	checkForUpdates(
-		string(ctx.Chain.ServiceAddress().Bytes()),
-		stabIndex,
-		true)
-
-	checkForUpdates(
-		string(ctx.Chain.ServiceAddress().Bytes()),
-		"other keys",
-		false)
-
-	checkForUpdates("other owner", stabIndex, false)
-
-	checkForUpdates("other owner", "other key", false)
+	checkForUpdates(stabIndexKey, true)
+	checkForUpdates(flow.NewRegisterID(owner, "other keys"), false)
+	checkForUpdates(flow.NewRegisterID("other owner", stabIndexKey.Key), false)
+	checkForUpdates(flow.NewRegisterID("other owner", "other key"), false)
 }

--- a/fvm/environment/mock/accounts.go
+++ b/fvm/environment/mock/accounts.go
@@ -268,13 +268,13 @@ func (_m *Accounts) GetStorageUsed(address flow.Address) (uint64, error) {
 	return r0, r1
 }
 
-// GetValue provides a mock function with given fields: address, key
-func (_m *Accounts) GetValue(address flow.Address, key string) ([]byte, error) {
-	ret := _m.Called(address, key)
+// GetValue provides a mock function with given fields: id
+func (_m *Accounts) GetValue(id flow.RegisterID) ([]byte, error) {
+	ret := _m.Called(id)
 
 	var r0 []byte
-	if rf, ok := ret.Get(0).(func(flow.Address, string) []byte); ok {
-		r0 = rf(address, key)
+	if rf, ok := ret.Get(0).(func(flow.RegisterID) []byte); ok {
+		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -282,8 +282,8 @@ func (_m *Accounts) GetValue(address flow.Address, key string) ([]byte, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(flow.Address, string) error); ok {
-		r1 = rf(address, key)
+	if rf, ok := ret.Get(1).(func(flow.RegisterID) error); ok {
+		r1 = rf(id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -342,13 +342,13 @@ func (_m *Accounts) SetPublicKey(address flow.Address, keyIndex uint64, publicKe
 	return r0, r1
 }
 
-// SetValue provides a mock function with given fields: address, key, value
-func (_m *Accounts) SetValue(address flow.Address, key string, value []byte) error {
-	ret := _m.Called(address, key, value)
+// SetValue provides a mock function with given fields: id, value
+func (_m *Accounts) SetValue(id flow.RegisterID, value []byte) error {
+	ret := _m.Called(id, value)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(flow.Address, string, []byte) error); ok {
-		r0 = rf(address, key, value)
+	if rf, ok := ret.Get(0).(func(flow.RegisterID, []byte) error); ok {
+		r0 = rf(id, value)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -193,7 +193,10 @@ func Test_Programs(t *testing.T) {
 
 		loadedCode := false
 		viewExecA := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-			if key == environment.ContractKey("A") {
+			id := flow.ContractRegisterID(
+				flow.BytesToAddress([]byte(owner)),
+				"A")
+			if key == id.Key {
 				loadedCode = true
 			}
 
@@ -232,8 +235,11 @@ func Test_Programs(t *testing.T) {
 
 		// execute transaction again, this time make sure it doesn't load code
 		viewExecA2 := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
+			id := flow.ContractRegisterID(
+				flow.BytesToAddress([]byte(owner)),
+				"A")
 			// this time we fail if a read of code occurs
-			require.NotEqual(t, key, environment.ContractKey("A"))
+			require.NotEqual(t, key, id.Key)
 
 			return mainView.Peek(owner, key)
 		})
@@ -341,9 +347,15 @@ func Test_Programs(t *testing.T) {
 
 		// execute transaction again, this time make sure it doesn't load code
 		viewExecB2 := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
+			idA := flow.ContractRegisterID(
+				flow.BytesToAddress([]byte(owner)),
+				"A")
+			idB := flow.ContractRegisterID(
+				flow.BytesToAddress([]byte(owner)),
+				"B")
 			// this time we fail if a read of code occurs
-			require.NotEqual(t, key, environment.ContractKey("A"))
-			require.NotEqual(t, key, environment.ContractKey("B"))
+			require.NotEqual(t, key, idA.Key)
+			require.NotEqual(t, key, idB.Key)
 
 			return mainView.Peek(owner, key)
 		})
@@ -370,7 +382,10 @@ func Test_Programs(t *testing.T) {
 		// only because contract B has been called
 
 		viewExecA := delta.NewView(func(owner, key string) (flow.RegisterValue, error) {
-			require.NotEqual(t, key, environment.ContractKey("A"))
+			id := flow.ContractRegisterID(
+				flow.BytesToAddress([]byte(owner)),
+				"A")
+			require.NotEqual(t, key, id.Key)
 			return mainView.Peek(owner, key)
 		})
 

--- a/fvm/environment/uuids.go
+++ b/fvm/environment/uuids.go
@@ -11,11 +11,6 @@ import (
 	"github.com/onflow/flow-go/utils/slices"
 )
 
-var uuidKey = flow.RegisterID{
-	Owner: "",
-	Key:   state.UUIDKey,
-}
-
 type UUIDGenerator interface {
 	GenerateUUID() (uint64, error)
 }
@@ -63,7 +58,7 @@ func NewUUIDGenerator(
 
 // GetUUID reads uint64 byte value for uuid from the state
 func (generator *uUIDGenerator) getUUID() (uint64, error) {
-	stateBytes, err := generator.txnState.Get(uuidKey)
+	stateBytes, err := generator.txnState.Get(flow.UUIDRegisterID)
 	if err != nil {
 		return 0, fmt.Errorf("cannot get uuid byte from state: %w", err)
 	}
@@ -76,7 +71,7 @@ func (generator *uUIDGenerator) getUUID() (uint64, error) {
 func (generator *uUIDGenerator) setUUID(uuid uint64) error {
 	bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(bytes, uuid)
-	err := generator.txnState.Set(uuidKey, bytes)
+	err := generator.txnState.Set(flow.UUIDRegisterID, bytes)
 	if err != nil {
 		return fmt.Errorf("cannot set uuid byte to state: %w", err)
 	}

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -79,7 +79,7 @@ const (
 	ErrCodeScriptExecutionCancelledError             ErrorCode = 1114
 	ErrCodeScriptExecutionTimedOutError              ErrorCode = 1113
 	ErrCodeEventEncodingError                        ErrorCode = 1115
-	ErrCodeInvalidFVMStateAccessError                ErrorCode = 1116
+	ErrCodeInvalidInternalStateAccessError           ErrorCode = 1116
 	// 1117 was never deployed and is free to use
 	ErrCodeInsufficientPayerBalance ErrorCode = 1118
 

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -254,17 +254,16 @@ func NewCouldNotGetExecutionParameterFromStateError(
 		path)
 }
 
-// NewInvalidFVMStateAccessError constructs a new CodedError which indicates
-// that the cadence program attempted to directly access fvm's internal state.
-func NewInvalidFVMStateAccessError(
-	address flow.Address,
-	path string,
+// NewInvalidInternalStateAccessError constructs a new CodedError which
+// indicates that the cadence program attempted to directly access flow's
+// internal state.
+func NewInvalidInternalStateAccessError(
+	id flow.RegisterID,
 	opType string,
 ) CodedError {
 	return NewCodedError(
-		ErrCodeInvalidFVMStateAccessError,
-		"could not directly %s fvm internal state (address: %s: path: %s)",
+		ErrCodeInvalidInternalStateAccessError,
+		"could not directly %s flow internal state (%s)",
 		opType,
-		address,
-		path)
+		id)
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1490,10 +1490,16 @@ func TestStorageUsed(t *testing.T) {
 	address, err := hex.DecodeString("2a3c4c2581cef731")
 	require.NoError(t, err)
 
+	accountStatusId := flow.AccountStatusRegisterID(
+		flow.BytesToAddress(address))
+
 	simpleView := utils.NewSimpleView()
 	status := environment.NewAccountStatus()
 	status.SetStorageUsed(5)
-	err = simpleView.Set(string(address), state.AccountStatusKey, status.ToBytes())
+	err = simpleView.Set(
+		accountStatusId.Owner,
+		accountStatusId.Key,
+		status.ToBytes())
 	require.NoError(t, err)
 
 	script := fvm.Script(code)

--- a/fvm/state/state.go
+++ b/fvm/state/state.go
@@ -1,10 +1,7 @@
 package state
 
 import (
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/onflow/cadence/runtime/common"
 
@@ -16,17 +13,6 @@ import (
 const (
 	DefaultMaxKeySize   = 16_000      // ~16KB
 	DefaultMaxValueSize = 256_000_000 // ~256MB
-
-	// Service level keys (owner is empty):
-	UUIDKey         = "uuid"
-	AddressStateKey = "account_address_state"
-
-	// Account level keys
-	AccountKeyPrefix   = "a."
-	AccountStatusKey   = AccountKeyPrefix + "s"
-	CodeKeyPrefix      = "code."
-	ContractNamesKey   = "contract_names"
-	PublicKeyKeyPrefix = "public_key_"
 )
 
 // TODO(patrick): make State implement the View interface.
@@ -187,11 +173,7 @@ func (s *State) Get(id flow.RegisterID) (flow.RegisterValue, error) {
 		// wrap error into a fatal error
 		getError := errors.NewLedgerFailure(err)
 		// wrap with more info
-		return nil, fmt.Errorf(
-			"failed to read key %s on account %s: %w",
-			PrintableKey(id.Key),
-			hex.EncodeToString([]byte(id.Owner)),
-			getError)
+		return nil, fmt.Errorf("failed to read %s: %w", id, getError)
 	}
 
 	err = s.meter.MeterStorageRead(id, value, s.enforceLimits)
@@ -214,11 +196,7 @@ func (s *State) Set(id flow.RegisterID, value flow.RegisterValue) error {
 		// wrap error into a fatal error
 		setError := errors.NewLedgerFailure(err)
 		// wrap with more info
-		return fmt.Errorf(
-			"failed to update key %s on account %s: %w",
-			PrintableKey(id.Key),
-			hex.EncodeToString([]byte(id.Owner)),
-			setError)
+		return fmt.Errorf("failed to update %s: %w", id, setError)
 	}
 
 	return s.meter.MeterStorageWrite(id, value, s.enforceLimits)
@@ -330,48 +308,4 @@ func (s *State) checkSize(
 			s.maxValueSizeAllowed)
 	}
 	return nil
-}
-
-// IsFVMStateKey returns true if the key is controlled by the fvm env and
-// return false otherwise (key controlled by the cadence env)
-func IsFVMStateKey(owner string, key string) bool {
-	// check if is a service level key (owner is empty)
-	// cases:
-	// 		- "", "uuid"
-	// 		- "", "account_address_state"
-	if len(owner) == 0 && (key == UUIDKey || key == AddressStateKey) {
-		return true
-	}
-
-	// check account level keys
-	// cases:
-	// 		- address, "contract_names"
-	// 		- address, "code.%s" (contract name)
-	// 		- address, "public_key_%d" (index)
-	// 		- address, "a.s" (account status)
-	return strings.HasPrefix(key, PublicKeyKeyPrefix) ||
-		key == ContractNamesKey ||
-		strings.HasPrefix(key, CodeKeyPrefix) ||
-		key == AccountStatusKey
-}
-
-// This returns true if the key is a slab index for an account's ordered fields
-// map.
-//
-// In general, each account's regular fields are stored in ordered map known
-// only to cadence.  Cadence encodes this map into bytes and split the bytes
-// into slab chunks before storing the slabs into the ledger.
-func IsSlabIndex(key string) bool {
-	return len(key) == 9 && key[0] == '$'
-}
-
-// TODO(patrick): refactor this to RegisterID.String
-// PrintableKey formats slabs properly and avoids invalid utf8s
-func PrintableKey(key string) string {
-	// slab
-	if IsSlabIndex(key) {
-		i := uint64(binary.BigEndian.Uint64([]byte(key[1:])))
-		return fmt.Sprintf("$%d", i)
-	}
-	return fmt.Sprintf("#%x", []byte(key))
 }

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -2,11 +2,8 @@ package state_test
 
 import (
 	"testing"
-	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/onflow/atree"
 
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
@@ -192,34 +189,4 @@ func TestState_MaxInteraction(t *testing.T) {
 	_, err = st.Get(flow.RegisterID{Owner: "3", Key: "4"})
 	require.Error(t, err)
 
-}
-
-func TestState_IsFVMStateKey(t *testing.T) {
-	require.True(t, state.IsFVMStateKey("", state.UUIDKey))
-	require.True(t, state.IsFVMStateKey("", state.AddressStateKey))
-	require.False(t, state.IsFVMStateKey("", "other"))
-	require.False(t, state.IsFVMStateKey("Address", state.UUIDKey))
-	require.False(t, state.IsFVMStateKey("Address", state.AddressStateKey))
-	require.True(t, state.IsFVMStateKey("Address", "public_key_12"))
-	require.True(t, state.IsFVMStateKey("Address", state.ContractNamesKey))
-	require.True(t, state.IsFVMStateKey("Address", "code.MYCODE"))
-	require.True(t, state.IsFVMStateKey("Address", state.AccountStatusKey))
-	require.False(t, state.IsFVMStateKey("Address", "anything else"))
-}
-
-func TestAccounts_PrintableKey(t *testing.T) {
-	// slab with 189 should result in \\xbd
-	slabIndex := atree.StorageIndex([8]byte{0, 0, 0, 0, 0, 0, 0, 189})
-	key := string(atree.SlabIndexToLedgerKey(slabIndex))
-	require.False(t, utf8.ValidString(key))
-	printable := state.PrintableKey(key)
-	require.True(t, utf8.ValidString(printable))
-	require.Equal(t, "$189", printable)
-
-	// non slab invalid utf-8
-	key = "a\xc5z"
-	require.False(t, utf8.ValidString(key))
-	printable = state.PrintableKey(key)
-	require.True(t, utf8.ValidString(printable))
-	require.Equal(t, "#61c57a", printable)
 }

--- a/model/flow/ledger_test.go
+++ b/model/flow/ledger_test.go
@@ -3,8 +3,11 @@ package flow
 import (
 	"encoding/hex"
 	"fmt"
-
 	"testing"
+	"unicode/utf8"
+
+	"github.com/onflow/atree"
+	"github.com/stretchr/testify/require"
 )
 
 // this benchmark can run with this command:
@@ -15,10 +18,7 @@ var length int
 
 func BenchmarkString(b *testing.B) {
 
-	var r = RegisterID{
-		Owner: "theowner",
-		Key:   "123412341234",
-	}
+	r := NewRegisterID("theowner", "123412341234")
 
 	ownerLen := len(r.Owner)
 
@@ -38,12 +38,52 @@ func BenchmarkString(b *testing.B) {
 
 func BenchmarkOriginalString(b *testing.B) {
 
-	var r = RegisterID{
-		Owner: "theowner",
-		Key:   "123412341234",
-	}
+	r := NewRegisterID("theowner", "123412341234")
 
 	ret := fmt.Sprintf("%x/%x", r.Owner, r.Key)
 
 	length = len(ret)
+}
+
+func TestRegisterID_IsInternalState(t *testing.T) {
+	requireTrue := func(owner string, key string) {
+		id := NewRegisterID(owner, key)
+		require.True(t, id.IsInternalState())
+	}
+
+	requireFalse := func(owner string, key string) {
+		id := NewRegisterID(owner, key)
+		require.False(t, id.IsInternalState())
+	}
+	requireTrue("", UUIDKey)
+	requireTrue("", AddressStateKey)
+	requireFalse("", "other")
+	requireFalse("Address", UUIDKey)
+	requireFalse("Address", AddressStateKey)
+	requireTrue("Address", "public_key_12")
+	requireTrue("Address", ContractNamesKey)
+	requireTrue("Address", "code.MYCODE")
+	requireTrue("Address", AccountStatusKey)
+	requireFalse("Address", "anything else")
+}
+
+func TestRegisterID_String(t *testing.T) {
+	// slab with 189 should result in \\xbd
+	slabIndex := atree.StorageIndex([8]byte{0, 0, 0, 0, 0, 0, 0, 189})
+
+	id := NewRegisterID(
+		string([]byte{1, 2, 3, 10}),
+		string(atree.SlabIndexToLedgerKey(slabIndex)))
+	require.False(t, utf8.ValidString(id.Key))
+	printable := id.String()
+	require.True(t, utf8.ValidString(printable))
+	require.Equal(t, "0102030a/$189", printable)
+
+	// non slab invalid utf-8
+	id = NewRegisterID("b\xc5y", "a\xc5z")
+	require.False(t, utf8.ValidString(id.Owner))
+	require.False(t, utf8.ValidString(id.Key))
+	printable = id.String()
+	require.True(t, utf8.ValidString(printable))
+	require.Equal(t, "62c579/#61c57a", printable)
 }


### PR DESCRIPTION
1. Refactored flow internal state register id creation from fvm/state to model/flow
2. Convert IsStabIndex, IsInternalState (aka IsFVMStateKey) into register id methods
3. Format RegisterID's key using PrintableKey's logic.
4. Replace accounts (owner, key)-tuple inputs with register id
5. Cleaned up some errors.