### PR TITLE
Fixes Connection Gater Test

### DIFF
--- a/network/p2p/connection/connection_gater_test.go
+++ b/network/p2p/connection/connection_gater_test.go
@@ -81,12 +81,12 @@ func TestConnectionGating(t *testing.T) {
 		// add node2 to node1's allow list, but not the other way around.
 		node1Peers.Add(node2.Host().ID(), struct{}{})
 
+		// from node2 -> node1 should also NOT work, since node 1 is not in node2's allow list for dialing!
+		p2pfixtures.EnsureNoStreamCreation(t, ctx, []p2p.LibP2PNode{node2}, []p2p.LibP2PNode{node1})
+
 		// now node2 should be able to connect to node1.
 		// from node1 -> node2 shouldn't work
 		p2pfixtures.EnsureNoStreamCreation(t, ctx, []p2p.LibP2PNode{node1}, []p2p.LibP2PNode{node2})
-
-		// however, from node2 -> node1 should also NOT work, since node 1 is not in node2's allow list for dialing!
-		p2pfixtures.EnsureNoStreamCreation(t, ctx, []p2p.LibP2PNode{node2}, []p2p.LibP2PNode{node1})
 	})
 
 	t.Run("outbound connection to an approved node is allowed", func(t *testing.T) {

--- a/network/p2p/connection/connection_gater_test.go
+++ b/network/p2p/connection/connection_gater_test.go
@@ -82,7 +82,10 @@ func TestConnectionGating(t *testing.T) {
 		node1Peers.Add(node2.Host().ID(), struct{}{})
 
 		// from node2 -> node1 should also NOT work, since node 1 is not in node2's allow list for dialing!
-		p2pfixtures.EnsureNoStreamCreation(t, ctx, []p2p.LibP2PNode{node2}, []p2p.LibP2PNode{node1})
+		p2pfixtures.EnsureNoStreamCreation(t, ctx, []p2p.LibP2PNode{node2}, []p2p.LibP2PNode{node1}, func(t *testing.T, err error) {
+			// dialing node-1 by node-2 should fail locally at the connection gater of node-2.
+			require.True(t, errors.Is(err, swarm.ErrGaterDisallowedConnection))
+		})
 
 		// now node2 should be able to connect to node1.
 		// from node1 -> node2 shouldn't work


### PR DESCRIPTION
Fixing: `TestConnectionGating/inbound_connection_from_an_allowed_node_is_rejected`
It was failing with the following error:
```
    --- FAIL: TestConnectionGating/inbound_connection_from_an_allowed_node_is_rejected (0.02s)
        fixtures.go:354: 
                Error Trace:    /Users/yahya/go/src/github/onflow/flow-go/network/p2p/connection/fixtures.go:354
                                                        /Users/yahya/go/src/github/onflow/flow-go/network/p2p/connection/connection_gater_test.go:89
                Error:          Should be empty, but was [<swarm.Conn[*tcp.TcpTransport] /ip4/127.0.0.1/tcp/63352 (16Uiu2HAm25DESm7brWshLYESjNKrye1b2gps6NQpJRmWj7Xjy34Q) <-> /ip4/127.0.0.1/tcp/63343 (16Uiu2HAmG8RAYybc2tR1evq23rn1UAMeNfsPSxZGHxsNFaK81md7)>]
                Test:           TestConnectionGating/inbound_connection_from_an_allowed_node_is_rejected

```

The reason for the failure is:
1. `node-1` allowlists `node-2` **but not vice versa**. 
2. Then `node-1` creates a stream to `node-2`. Although `node-2` does not allowlist `node-1`, with libp2p `v0.24`, `node-1` keeps resources for a secured but not upgraded connection. Let's call this connection, `conn1`. 
3. The test is however checking that since `node-1` is connection gated by `node-2` it cannot allocate any resources on `node-2`, which is correct ✅. 
4. In the next step, the test checks that `node-2` cannot make a connection to `node-1`. Since `node-1` is not in the allow list of `node-2`, the dial from `node-2` to `node-1` fails locally at the connection gater of `node-2`. However, the test checks whether `node-2` can allocate any resources on `node-1`, i.e., any connection between `node-1` and `node-2`. At this stage, the test false-positively fails ❌  by taking `conn1` from step 2 as a connection that has been established as the result of `node-2` dialing `node-1`, which is not the case, i.e., it is not a connection created on the receiving side as the result of dialing. 

How this PR fixes that: 
1. This PR swaps steps 3 <-> 4 above, i.e., `node-2` dials `node-1` first and then `node-1` attempts dialing `node-2`. In this way, no connection is created on the receiving side as a result of dialing.
2. This PR also adds an extra check to examine that `node-2` indeed locally hits an error when dialing `node-1` by its connection gater. 

