### PR TITLE
Initialize register ids with flow.NewRegsiterId instead of flow.RegisterID{...}

### DIFF
--- a/fvm/derived/table_test.go
+++ b/fvm/derived/table_test.go
@@ -849,7 +849,7 @@ func (computer *testValueComputer) Compute(
 func TestTxnDerivedDataGetOrCompute(t *testing.T) {
 	blockDerivedData := NewEmptyTable[flow.RegisterID, int]()
 
-	key := flow.RegisterID{Owner: "addr", Key: "key"}
+	key := flow.NewRegisterID("addr", "key")
 	value := 12345
 
 	t.Run("compute value", func(t *testing.T) {

--- a/fvm/environment/accounts.go
+++ b/fvm/environment/accounts.go
@@ -76,10 +76,7 @@ func (a *StatefulAccounts) AllocateStorageIndex(
 	key := atree.SlabIndexToLedgerKey(index)
 	a.txnState.RunWithAllLimitsDisabled(func() {
 		err = a.txnState.Set(
-			flow.RegisterID{
-				Owner: string(address.Bytes()),
-				Key:   string(key),
-			},
+			flow.NewRegisterID(string(address.Bytes()), string(key)),
 			[]byte{})
 	})
 	if err != nil {

--- a/fvm/meter/meter_test.go
+++ b/fvm/meter/meter_test.go
@@ -384,7 +384,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters(),
 		)
 
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
+		key1 := flow.NewRegisterID("", "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
 
@@ -399,7 +399,7 @@ func TestStorageLimits(t *testing.T) {
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
 
 		// first read of key2
-		key2 := flow.RegisterID{Owner: "", Key: "2"}
+		key2 := flow.NewRegisterID("", "2")
 		val2 := []byte{0x3, 0x2, 0x1}
 		size2 := meter.GetStorageKeyValueSizeForTesting(key2, val2)
 
@@ -413,7 +413,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters(),
 		)
 
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
+		key1 := flow.NewRegisterID("", "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 
@@ -428,7 +428,7 @@ func TestStorageLimits(t *testing.T) {
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val2))
 
 		// first write of key2
-		key2 := flow.RegisterID{Owner: "", Key: "2"}
+		key2 := flow.NewRegisterID("", "2")
 		err = meter1.MeterStorageWrite(key2, val2, false)
 		require.NoError(t, err)
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(),
@@ -440,7 +440,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(1),
 		)
 
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
+		key1 := flow.NewRegisterID("", "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageRead(key1, val1, false /* not enforced */)
@@ -454,7 +454,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
 		)
 
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
+		key1 := flow.NewRegisterID("", "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageRead(key1, val1, true /* enforced */)
@@ -472,7 +472,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
 		)
 
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
+		key1 := flow.NewRegisterID("", "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageWrite(key1, val1, false /* not enforced */)
@@ -485,7 +485,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
 		)
 
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
+		key1 := flow.NewRegisterID("", "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageWrite(key1, val1, true /* enforced */)
@@ -502,8 +502,8 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters(),
 		)
 
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
-		key2 := flow.RegisterID{Owner: "", Key: "2"}
+		key1 := flow.NewRegisterID("", "1")
+		key2 := flow.NewRegisterID("", "2")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
@@ -523,8 +523,8 @@ func TestStorageLimits(t *testing.T) {
 	})
 
 	t.Run("metering storage read and written - exceeding limit - not enforced", func(t *testing.T) {
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
-		key2 := flow.RegisterID{Owner: "", Key: "2"}
+		key1 := flow.NewRegisterID("", "1")
+		key2 := flow.NewRegisterID("", "2")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
@@ -548,8 +548,8 @@ func TestStorageLimits(t *testing.T) {
 	})
 
 	t.Run("metering storage read and written - exceeding limit - enforced", func(t *testing.T) {
-		key1 := flow.RegisterID{Owner: "", Key: "1"}
-		key2 := flow.RegisterID{Owner: "", Key: "2"}
+		key1 := flow.NewRegisterID("", "1")
+		key2 := flow.NewRegisterID("", "2")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
@@ -579,13 +579,13 @@ func TestStorageLimits(t *testing.T) {
 		meter1 := meter.NewMeter(
 			meter.DefaultParameters(),
 		)
-		readKey1 := flow.RegisterID{Owner: "", Key: "r1"}
+		readKey1 := flow.NewRegisterID("", "r1")
 		readVal1 := []byte{0x1, 0x2, 0x3}
 		readSize1 := meter.GetStorageKeyValueSizeForTesting(readKey1, readVal1)
 		err := meter1.MeterStorageRead(readKey1, readVal1, false)
 		require.NoError(t, err)
 
-		writeKey1 := flow.RegisterID{Owner: "", Key: "w1"}
+		writeKey1 := flow.NewRegisterID("", "w1")
 		writeVal1 := []byte{0x1, 0x2, 0x3, 0x4}
 		writeSize1 := meter.GetStorageKeyValueSizeForTesting(writeKey1, writeVal1)
 		err = meter1.MeterStorageWrite(writeKey1, writeVal1, false)
@@ -600,7 +600,7 @@ func TestStorageLimits(t *testing.T) {
 		err = meter2.MeterStorageRead(readKey1, readVal1, false)
 		require.NoError(t, err)
 
-		writeKey2 := flow.RegisterID{Owner: "", Key: "w2"}
+		writeKey2 := flow.NewRegisterID("", "w2")
 		writeVal2 := []byte{0x1, 0x2, 0x3, 0x4, 0x5}
 		writeSize2 := meter.GetStorageKeyValueSizeForTesting(writeKey2, writeVal2)
 		err = meter2.MeterStorageWrite(writeKey2, writeVal2, false)

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -188,5 +188,4 @@ func TestState_MaxInteraction(t *testing.T) {
 	// read - interaction 7
 	_, err = st.Get(flow.NewRegisterID("3", "4"))
 	require.Error(t, err)
-
 }

--- a/fvm/state/transaction_state_test.go
+++ b/fvm/state/transaction_state_test.go
@@ -51,7 +51,7 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 
 	// Ensure the values are written to the correctly nested state
 
-	key := flow.RegisterID{Owner: "address", Key: "key"}
+	key := flow.NewRegisterID("address", "key")
 	val := createByteArray(2)
 
 	err = txn.Set(key, val)
@@ -174,7 +174,7 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 
 	// Sanity check
 
-	key := flow.RegisterID{Owner: "address", Key: "key"}
+	key := flow.NewRegisterID("address", "key")
 
 	v, err := restrictedNestedState2.Get(key)
 	require.NoError(t, err)
@@ -281,7 +281,7 @@ func TestRestartNestedTransaction(t *testing.T) {
 	id, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	key := flow.RegisterID{Owner: "address", Key: "key"}
+	key := flow.NewRegisterID("address", "key")
 	val := createByteArray(2)
 
 	for i := 0; i < 10; i++ {
@@ -333,7 +333,7 @@ func TestRestartNestedTransactionWithInvalidId(t *testing.T) {
 	id, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	key := flow.RegisterID{Owner: "address", Key: "key"}
+	key := flow.NewRegisterID("address", "key")
 	val := createByteArray(2)
 
 	err = txn.Set(key, val)
@@ -483,8 +483,8 @@ func TestParseRestrictedCannotCommitLocationMismatch(t *testing.T) {
 func TestPauseAndResume(t *testing.T) {
 	txn := newTestTransactionState()
 
-	key1 := flow.RegisterID{Owner: "addr", Key: "key"}
-	key2 := flow.RegisterID{Owner: "addr2", Key: "key2"}
+	key1 := flow.NewRegisterID("addr", "key")
+	key2 := flow.NewRegisterID("addr2", "key2")
 
 	val, err := txn.Get(key1)
 	require.NoError(t, err)
@@ -530,7 +530,7 @@ func TestInvalidCommittedStateModification(t *testing.T) {
 	id1, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	key := flow.RegisterID{Owner: "addr", Key: "key"}
+	key := flow.NewRegisterID("addr", "key")
 	err = txn.Set(key, createByteArray(2))
 	require.NoError(t, err)
 

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -24,17 +24,11 @@ func TestTransactionStorageLimiter(t *testing.T) {
 	owner := flow.HexToAddress("1")
 
 	err := txnState.Set(
-		flow.RegisterID{
-			Owner: string(owner[:]),
-			Key:   "a",
-		},
+		flow.NewRegisterID(string(owner[:]), "a"),
 		flow.RegisterValue("foo"))
 	require.NoError(t, err)
 	err = txnState.Set(
-		flow.RegisterID{
-			Owner: string(owner[:]),
-			Key:   "b",
-		},
+		flow.NewRegisterID(string(owner[:]), "b"),
 		flow.RegisterValue("bar"))
 	require.NoError(t, err)
 

--- a/fvm/utils/view.go
+++ b/fvm/utils/view.go
@@ -142,10 +142,9 @@ func NewMapLedgerFromPayloads(payloads []ledger.Payload) *MapLedger {
 			panic(err)
 		}
 
-		id := flow.RegisterID{
-			Owner: string(key.KeyParts[0].Value),
-			Key:   string(key.KeyParts[1].Value),
-		}
+		id := flow.NewRegisterID(
+			string(key.KeyParts[0].Value),
+			string(key.KeyParts[1].Value))
 
 		ledger.Registers[id] = entry.Value()
 	}


### PR DESCRIPTION
Prep work for sanitizing the owner (ensure owners are 8 bytes string) / replacing owner type from string to Address.