### PR TITLE
[Access] Export MessageToTrieUpdate converter method

### DIFF
--- a/engine/common/rpc/convert/convert.go
+++ b/engine/common/rpc/convert/convert.go
@@ -914,7 +914,7 @@ func MessageToChunkExecutionData(m *entities.ChunkExecutionData, chain flow.Chai
 
 	var trieUpdate *ledger.TrieUpdate
 	if m.GetTrieUpdate() != nil {
-		trieUpdate, err = messageToTrieUpdate(m.GetTrieUpdate())
+		trieUpdate, err = MessageToTrieUpdate(m.GetTrieUpdate())
 		if err != nil {
 			return nil, err
 		}
@@ -1010,7 +1010,7 @@ func messageToTrustedTransaction(m *entities.Transaction, chain flow.Chain) (flo
 	return *t, nil
 }
 
-func messageToTrieUpdate(m *entities.TrieUpdate) (*ledger.TrieUpdate, error) {
+func MessageToTrieUpdate(m *entities.TrieUpdate) (*ledger.TrieUpdate, error) {
 	rootHash, err := ledger.ToRootHash(m.GetRootHash())
 	if err != nil {
 		return nil, fmt.Errorf("could not convert root hash: %w", err)


### PR DESCRIPTION
export `convert.MessageToTrieUpdate` so that it can be used by clients without needing to convert the entire `ChunkExecutionData`