### PR TITLE
[Networking] Enables logging of peer ids together with node id upon connection establishment

### DIFF
--- a/network/internal/testutils/testUtil.go
+++ b/network/internal/testutils/testUtil.go
@@ -128,8 +128,8 @@ func GenerateIDs(t *testing.T, logger zerolog.Logger, n int, opts ...func(*optsC
 	libP2PNodes := make([]p2p.LibP2PNode, n)
 	tagObservables := make([]observable.Observable, n)
 
-	idProvider := mock.NewIdentityProvider(t)
-
+	identities := unittest.IdentityListFixture(n, unittest.WithAllRoles())
+	idProvider := NewUpdatableIDProvider(identities)
 	o := &optsConfig{
 		peerUpdateInterval:            connection.DefaultPeerUpdateInterval,
 		unicastRateLimiterDistributor: ratelimit.NewUnicastRateLimiterDistributor(),
@@ -140,8 +140,6 @@ func GenerateIDs(t *testing.T, logger zerolog.Logger, n int, opts ...func(*optsC
 	for _, opt := range opts {
 		opt(o)
 	}
-
-	identities := unittest.IdentityListFixture(n, unittest.WithAllRoles())
 
 	for _, identity := range identities {
 		for _, idOpt := range o.idOpts {
@@ -167,7 +165,6 @@ func GenerateIDs(t *testing.T, logger zerolog.Logger, n int, opts ...func(*optsC
 		_, port, err := libP2PNodes[i].GetIPPort()
 		require.NoError(t, err)
 
-		idProvider.On("ByPeerID", libP2PNodes[i].Host().ID()).Return(identities[i], true).Maybe()
 		identities[i].Address = unittest.IPPort(port)
 		identities[i].NetworkPubKey = key.PublicKey()
 	}

--- a/network/p2p/connection/connection_gater.go
+++ b/network/p2p/connection/connection_gater.go
@@ -69,8 +69,8 @@ func (c *ConnGater) InterceptPeerDial(p peer.ID) bool {
 	lg := c.log.With().Str("peer_id", p.String()).Logger()
 
 	if len(c.onInterceptPeerDialFilters) == 0 {
-		lg.Debug().
-			Msg("allowing outbound connection intercept peer dial has no peer filters set")
+		lg.Warn().
+			Msg("outbound connection established with no intercept peer dial filters")
 		return true
 	}
 
@@ -120,7 +120,7 @@ func (c *ConnGater) InterceptSecured(dir network.Direction, p peer.ID, addr netw
 			Logger()
 
 		if len(c.onInterceptSecuredFilters) == 0 {
-			lg.Info().Msg("inbound connection established")
+			lg.Warn().Msg("inbound connection established with no intercept secured filters")
 			return true
 		}
 

--- a/network/p2p/p2pbuilder/libp2pNodeBuilder.go
+++ b/network/p2p/p2pbuilder/libp2pNodeBuilder.go
@@ -483,6 +483,7 @@ func DefaultNodeBuilder(log zerolog.Logger,
 	peerFilters := []p2p.PeerFilter{peerFilter}
 
 	connGater := connection.NewConnGater(log,
+		idProvider,
 		connection.WithOnInterceptPeerDialFilters(append(peerFilters, onInterceptPeerDialFilters...)),
 		connection.WithOnInterceptSecuredFilters(append(peerFilters, onInterceptSecuredFilters...)))
 

--- a/network/p2p/p2pnode/libp2pNode_test.go
+++ b/network/p2p/p2pnode/libp2pNode_test.go
@@ -188,7 +188,6 @@ func TestConnGater(t *testing.T) {
 		})))
 	idProvider.On("ByPeerID", node2.Host().ID()).Return(&identity2,
 
-
 		true).Maybe()
 
 	p2ptest.StartNode(t, signalerCtx, node2, 100*time.Millisecond)

--- a/network/p2p/p2pnode/libp2pNode_test.go
+++ b/network/p2p/p2pnode/libp2pNode_test.go
@@ -155,18 +155,20 @@ func TestConnGater(t *testing.T) {
 	signalerCtx := irrecoverable.NewMockSignalerContext(t, ctx)
 
 	sporkID := unittest.IdentifierFixture()
+	idProvider := mock.NewIdentityProvider(t)
 
 	node1Peers := unittest.NewProtectedMap[peer.ID, struct{}]()
 	node1, identity1 := p2ptest.NodeFixture(
 		t,
 		sporkID,
 		t.Name(),
-		p2ptest.WithConnectionGater(testutils.NewConnectionGater(func(pid peer.ID) error {
+		p2ptest.WithConnectionGater(testutils.NewConnectionGater(idProvider, func(pid peer.ID) error {
 			if !node1Peers.Has(pid) {
 				return fmt.Errorf("peer id not found: %s", pid.String())
 			}
 			return nil
 		})))
+	idProvider.On("ByPeerID", node1.Host().ID()).Return(&identity1, true).Maybe()
 
 	p2ptest.StartNode(t, signalerCtx, node1, 100*time.Millisecond)
 	defer p2ptest.StopNode(t, node1, cancel, 100*time.Millisecond)
@@ -178,12 +180,17 @@ func TestConnGater(t *testing.T) {
 	node2, identity2 := p2ptest.NodeFixture(
 		t,
 		sporkID, t.Name(),
-		p2ptest.WithConnectionGater(testutils.NewConnectionGater(func(pid peer.ID) error {
+		p2ptest.WithConnectionGater(testutils.NewConnectionGater(idProvider, func(pid peer.ID) error {
 			if !node2Peers.Has(pid) {
 				return fmt.Errorf("id not found: %s", pid.String())
 			}
 			return nil
 		})))
+	idProvider.On("ByPeerID", node2.Host().ID()).Return(&identity2,
+
+
+		true).Maybe()
+
 	p2ptest.StartNode(t, signalerCtx, node2, 100*time.Millisecond)
 	defer p2ptest.StopNode(t, node2, cancel, 100*time.Millisecond)
 

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -25,7 +25,6 @@ import (
 	libp2pmessage "github.com/onflow/flow-go/model/libp2p/message"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
-	mockmodule "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/module/observable"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/channels"
@@ -247,7 +246,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	opts := []ratelimit.RateLimitersOption{ratelimit.WithMessageRateLimiter(messageRateLimiter), ratelimit.WithNotifier(distributor), ratelimit.WithDisabledRateLimiting(false)}
 	rateLimiters := ratelimit.NewRateLimiters(opts...)
 
-	idProvider := mockmodule.NewIdentityProvider(m.T())
+	idProvider := testutils.NewUpdatableIDProvider(m.ids)
 	// create a new staked identity
 	connGater := testutils.NewConnectionGater(idProvider, func(pid peer.ID) error {
 		if messageRateLimiter.IsRateLimited(pid) {
@@ -261,12 +260,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 		1,
 		testutils.WithUnicastRateLimiterDistributor(distributor),
 		testutils.WithConnectionGater(connGater))
-	for i, node := range libP2PNodes {
-		idProvider.On("ByPeerID", node.Host().ID()).Return(ids[i], nil).Maybe()
-	}
-	for i, node := range m.nodes {
-		idProvider.On("ByPeerID", node.Host().ID()).Return(m.ids[i], nil).Maybe()
-	}
+	idProvider.SetIdentities(append(m.ids, ids...))
 
 	// create middleware
 	mws, providers := testutils.GenerateMiddlewares(m.T(),
@@ -423,7 +417,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 	opts := []ratelimit.RateLimitersOption{ratelimit.WithBandwidthRateLimiter(bandwidthRateLimiter), ratelimit.WithNotifier(distributor), ratelimit.WithDisabledRateLimiting(false)}
 	rateLimiters := ratelimit.NewRateLimiters(opts...)
 
-	idProvider := mockmodule.NewIdentityProvider(m.T())
+	idProvider := testutils.NewUpdatableIDProvider(m.ids)
 	// create connection gater, connection gater will refuse connections from rate limited nodes
 	connGater := testutils.NewConnectionGater(idProvider, func(pid peer.ID) error {
 		if bandwidthRateLimiter.IsRateLimited(pid) {
@@ -438,12 +432,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 		1,
 		testutils.WithUnicastRateLimiterDistributor(distributor),
 		testutils.WithConnectionGater(connGater))
-	for i, node := range libP2PNodes {
-		idProvider.On("ByPeerID", node.Host().ID()).Return(ids[i], nil).Maybe()
-	}
-	for i, node := range m.nodes {
-		idProvider.On("ByPeerID", node.Host().ID()).Return(m.ids[i], nil).Maybe()
-	}
+	idProvider.SetIdentities(append(m.ids, ids...))
 
 	// create middleware
 	mws, providers := testutils.GenerateMiddlewares(m.T(),

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -25,6 +25,7 @@ import (
 	libp2pmessage "github.com/onflow/flow-go/model/libp2p/message"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
+	mockmodule "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/module/observable"
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/channels"
@@ -246,15 +247,26 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	opts := []ratelimit.RateLimitersOption{ratelimit.WithMessageRateLimiter(messageRateLimiter), ratelimit.WithNotifier(distributor), ratelimit.WithDisabledRateLimiting(false)}
 	rateLimiters := ratelimit.NewRateLimiters(opts...)
 
+	idProvider := mockmodule.NewIdentityProvider(m.T())
 	// create a new staked identity
-	connGater := testutils.NewConnectionGater(func(pid peer.ID) error {
+	connGater := testutils.NewConnectionGater(idProvider, func(pid peer.ID) error {
 		if messageRateLimiter.IsRateLimited(pid) {
 			return fmt.Errorf("rate-limited peer")
 		}
 
 		return nil
 	})
-	ids, libP2PNodes, _ := testutils.GenerateIDs(m.T(), m.logger, 1, testutils.WithUnicastRateLimiterDistributor(distributor), testutils.WithConnectionGater(connGater))
+	ids, libP2PNodes, _ := testutils.GenerateIDs(m.T(),
+		m.logger,
+		1,
+		testutils.WithUnicastRateLimiterDistributor(distributor),
+		testutils.WithConnectionGater(connGater))
+	for i, node := range libP2PNodes {
+		idProvider.On("ByPeerID", node.Host().ID()).Return(ids[i], nil).Maybe()
+	}
+	for i, node := range m.nodes {
+		idProvider.On("ByPeerID", node.Host().ID()).Return(m.ids[i], nil).Maybe()
+	}
 
 	// create middleware
 	mws, providers := testutils.GenerateMiddlewares(m.T(),
@@ -411,8 +423,9 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 	opts := []ratelimit.RateLimitersOption{ratelimit.WithBandwidthRateLimiter(bandwidthRateLimiter), ratelimit.WithNotifier(distributor), ratelimit.WithDisabledRateLimiting(false)}
 	rateLimiters := ratelimit.NewRateLimiters(opts...)
 
+	idProvider := mockmodule.NewIdentityProvider(m.T())
 	// create connection gater, connection gater will refuse connections from rate limited nodes
-	connGater := testutils.NewConnectionGater(func(pid peer.ID) error {
+	connGater := testutils.NewConnectionGater(idProvider, func(pid peer.ID) error {
 		if bandwidthRateLimiter.IsRateLimited(pid) {
 			return fmt.Errorf("rate-limited peer")
 		}
@@ -420,7 +433,17 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 		return nil
 	})
 	// create a new staked identity
-	ids, libP2PNodes, _ := testutils.GenerateIDs(m.T(), m.logger, 1, testutils.WithUnicastRateLimiterDistributor(distributor), testutils.WithConnectionGater(connGater))
+	ids, libP2PNodes, _ := testutils.GenerateIDs(m.T(),
+		m.logger,
+		1,
+		testutils.WithUnicastRateLimiterDistributor(distributor),
+		testutils.WithConnectionGater(connGater))
+	for i, node := range libP2PNodes {
+		idProvider.On("ByPeerID", node.Host().ID()).Return(ids[i], nil).Maybe()
+	}
+	for i, node := range m.nodes {
+		idProvider.On("ByPeerID", node.Host().ID()).Return(m.ids[i], nil).Maybe()
+	}
 
 	// create middleware
 	mws, providers := testutils.GenerateMiddlewares(m.T(),


### PR DESCRIPTION
This PR wires in an identity provider to the connection gater to ensure that an `info` level log is always printed displaying the remote `peer_id` together with its `flow.Identifier` upon dialing or rejecting a connection. 