### PR TITLE
[Testing] Fix flaky test - increased timeout for `TestTopicValidator/TestTopicValidatorE2E`

### DIFF
--- a/integration/tests/bft/topicvalidator/topic_validator_test.go
+++ b/integration/tests/bft/topicvalidator/topic_validator_test.go
@@ -28,7 +28,7 @@ func TestTopicValidator(t *testing.T) {
 func (s *TopicValidatorTestSuite) TestTopicValidatorE2E() {
 	s.Orchestrator.sendUnauthorizedMsgs(s.T())
 	s.Orchestrator.sendAuthorizedMsgs(s.T())
-	unittest.RequireReturnsBefore(s.T(), s.Orchestrator.authorizedEventReceivedWg.Wait, 5*time.Second, "could not send authorized messages on time")
+	unittest.RequireReturnsBefore(s.T(), s.Orchestrator.authorizedEventReceivedWg.Wait, 10*time.Second, "could not send authorized messages on time")
 
 	// Victim nodes are configured with the topic validator enabled, therefore they should not have
 	// received any of the unauthorized messages.


### PR DESCRIPTION
test: `TestTopicValidator/TestTopicValidatorE2E`

This test is flaking in CI with inconsistent passing. Increasing the timeout made it pass very consistently locally.