### PR TITLE
Clean up address usage (part 1 of many)

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -407,7 +407,9 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			Run(func(args mock.Arguments) {
 				tx := args[1].(*fvm.TransactionProcedure)
 
-				tx.Err = fvmErrors.NewInvalidAddressErrorf(flow.Address{}, "no payer address provided")
+				tx.Err = fvmErrors.NewInvalidAddressErrorf(
+					flow.EmptyAddress,
+					"no payer address provided")
 				// create dummy events
 				tx.Events = generateEvents(eventsPerTransaction, tx.TxIndex)
 			}).
@@ -455,7 +457,9 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			for _, t := range c.Transactions {
 				txResult := flow.TransactionResult{
 					TransactionID: t.ID(),
-					ErrorMessage:  fvmErrors.NewInvalidAddressErrorf(flow.Address{}, "no payer address provided").Error(),
+					ErrorMessage: fvmErrors.NewInvalidAddressErrorf(
+						flow.EmptyAddress,
+						"no payer address provided").Error(),
 				}
 				expectedResults = append(expectedResults, txResult)
 			}

--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -271,7 +271,8 @@ func CreateAccountsWithSimpleAddresses(
 				if err != nil {
 					return nil, errors.New("error decoding events")
 				}
-				addr = flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+				addr = flow.ConvertAddress(
+					data.(cadence.Event).Fields[0].(cadence.Address))
 				break
 			}
 		}

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -64,7 +64,8 @@ func createAccount(
 
 	data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 	require.NoError(t, err)
-	address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+	address := flow.ConvertAddress(
+		data.(cadence.Event).Fields[0].(cadence.Address))
 
 	return address
 }
@@ -384,7 +385,8 @@ func TestCreateAccount(t *testing.T) {
 
 				data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 				require.NoError(t, err)
-				address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+				address := flow.ConvertAddress(
+					data.(cadence.Event).Fields[0].(cadence.Address))
 
 				account, err := vm.GetAccount(ctx, address, view)
 				require.NoError(t, err)
@@ -419,7 +421,8 @@ func TestCreateAccount(t *testing.T) {
 
 					data, err := jsoncdc.Decode(nil, tx.Events[i].Payload)
 					require.NoError(t, err)
-					address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+					address := flow.ConvertAddress(
+						data.(cadence.Event).Fields[0].(cadence.Address))
 
 					account, err := vm.GetAccount(ctx, address, view)
 					require.NoError(t, err)

--- a/fvm/derived/derived_block_data.go
+++ b/fvm/derived/derived_block_data.go
@@ -7,13 +7,14 @@ import (
 	"github.com/onflow/cadence/runtime/interpreter"
 
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
 )
 
-// ProgramDependencies are the locations of the programs this program depends on.
-type ProgramDependencies map[common.Address]struct{}
+// ProgramDependencies are the programs' addresses used by this program.
+type ProgramDependencies map[flow.Address]struct{}
 
 // AddDependency adds the address as a dependency.
-func (d ProgramDependencies) AddDependency(address common.Address) {
+func (d ProgramDependencies) AddDependency(address flow.Address) {
 	d[address] = struct{}{}
 }
 

--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -231,12 +231,12 @@ func (creator *accountCreator) createBasicAccount(
 ) {
 	flowAddress, err := creator.NextAddress()
 	if err != nil {
-		return flow.Address{}, err
+		return flow.EmptyAddress, err
 	}
 
 	err = creator.accounts.Create(publicKeys, flowAddress)
 	if err != nil {
-		return flow.Address{}, fmt.Errorf("create account failed: %w", err)
+		return flow.EmptyAddress, fmt.Errorf("create account failed: %w", err)
 	}
 
 	return flowAddress, nil

--- a/fvm/environment/account_freezer.go
+++ b/fvm/environment/account_freezer.go
@@ -19,7 +19,7 @@ type AccountFreezer interface {
 	// Note that the script variant will return OperationNotSupportedError.
 	SetAccountFrozen(address common.Address, frozen bool) error
 
-	FrozenAccounts() []common.Address
+	FrozenAccounts() []flow.Address
 
 	Reset()
 }
@@ -51,7 +51,7 @@ func (freezer ParseRestrictedAccountFreezer) SetAccountFrozen(
 		frozen)
 }
 
-func (freezer ParseRestrictedAccountFreezer) FrozenAccounts() []common.Address {
+func (freezer ParseRestrictedAccountFreezer) FrozenAccounts() []flow.Address {
 	return freezer.impl.FrozenAccounts()
 }
 
@@ -61,7 +61,7 @@ func (freezer ParseRestrictedAccountFreezer) Reset() {
 
 type NoAccountFreezer struct{}
 
-func (NoAccountFreezer) FrozenAccounts() []common.Address {
+func (NoAccountFreezer) FrozenAccounts() []flow.Address {
 	return nil
 }
 
@@ -78,7 +78,7 @@ type accountFreezer struct {
 	accounts        Accounts
 	transactionInfo TransactionInfo
 
-	frozenAccounts []common.Address
+	frozenAccounts []flow.Address
 }
 
 func NewAccountFreezer(
@@ -99,21 +99,21 @@ func (freezer *accountFreezer) Reset() {
 	freezer.frozenAccounts = nil
 }
 
-func (freezer *accountFreezer) FrozenAccounts() []common.Address {
+func (freezer *accountFreezer) FrozenAccounts() []flow.Address {
 	return freezer.frozenAccounts
 }
 
 func (freezer *accountFreezer) SetAccountFrozen(
-	address common.Address,
+	runtimeAddress common.Address,
 	frozen bool,
 ) error {
-	flowAddress := flow.Address(address)
+	address := flow.ConvertAddress(runtimeAddress)
 
-	if flowAddress == freezer.serviceAddress {
+	if address == freezer.serviceAddress {
 		return fmt.Errorf(
 			"setting account frozen failed: %w",
 			errors.NewValueErrorf(
-				flowAddress.String(),
+				address.String(),
 				"cannot freeze service account"))
 	}
 
@@ -126,7 +126,7 @@ func (freezer *accountFreezer) SetAccountFrozen(
 					"the service account"))
 	}
 
-	err := freezer.accounts.SetAccountFrozen(flowAddress, frozen)
+	err := freezer.accounts.SetAccountFrozen(address, frozen)
 	if err != nil {
 		return fmt.Errorf("setting account frozen failed: %w", err)
 	}

--- a/fvm/environment/account_info.go
+++ b/fvm/environment/account_info.go
@@ -128,7 +128,7 @@ func NewAccountInfo(
 }
 
 func (info *accountInfo) GetStorageUsed(
-	address common.Address,
+	runtimeAddress common.Address,
 ) (
 	uint64,
 	error,
@@ -140,7 +140,8 @@ func (info *accountInfo) GetStorageUsed(
 		return 0, fmt.Errorf("get storage used failed: %w", err)
 	}
 
-	value, err := info.accounts.GetStorageUsed(flow.Address(address))
+	value, err := info.accounts.GetStorageUsed(
+		flow.ConvertAddress(runtimeAddress))
 	if err != nil {
 		return 0, fmt.Errorf("get storage used failed: %w", err)
 	}
@@ -157,7 +158,7 @@ func StorageMBUFixToBytesUInt(result cadence.Value) uint64 {
 }
 
 func (info *accountInfo) GetStorageCapacity(
-	address common.Address,
+	runtimeAddress common.Address,
 ) (
 	uint64,
 	error,
@@ -169,7 +170,8 @@ func (info *accountInfo) GetStorageCapacity(
 		return 0, fmt.Errorf("get storage capacity failed: %w", err)
 	}
 
-	result, invokeErr := info.systemContracts.AccountStorageCapacity(address)
+	result, invokeErr := info.systemContracts.AccountStorageCapacity(
+		runtimeAddress)
 	if invokeErr != nil {
 		return 0, invokeErr
 	}
@@ -181,7 +183,7 @@ func (info *accountInfo) GetStorageCapacity(
 }
 
 func (info *accountInfo) GetAccountBalance(
-	address common.Address,
+	runtimeAddress common.Address,
 ) (
 	uint64,
 	error,
@@ -193,7 +195,7 @@ func (info *accountInfo) GetAccountBalance(
 		return 0, fmt.Errorf("get account balance failed: %w", err)
 	}
 
-	result, invokeErr := info.systemContracts.AccountBalance(address)
+	result, invokeErr := info.systemContracts.AccountBalance(runtimeAddress)
 	if invokeErr != nil {
 		return 0, invokeErr
 	}
@@ -201,7 +203,7 @@ func (info *accountInfo) GetAccountBalance(
 }
 
 func (info *accountInfo) GetAccountAvailableBalance(
-	address common.Address,
+	runtimeAddress common.Address,
 ) (
 	uint64,
 	error,
@@ -216,7 +218,8 @@ func (info *accountInfo) GetAccountAvailableBalance(
 		return 0, fmt.Errorf("get account available balance failed: %w", err)
 	}
 
-	result, invokeErr := info.systemContracts.AccountAvailableBalance(address)
+	result, invokeErr := info.systemContracts.AccountAvailableBalance(
+		runtimeAddress)
 	if invokeErr != nil {
 		return 0, invokeErr
 	}

--- a/fvm/environment/account_key_reader.go
+++ b/fvm/environment/account_key_reader.go
@@ -90,7 +90,7 @@ func NewAccountKeyReader(
 }
 
 func (reader *accountKeyReader) GetAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	keyIndex int,
 ) (
 	*runtime.AccountKey,
@@ -112,11 +112,11 @@ func (reader *accountKeyReader) GetAccountKey(
 		return nil, nil
 	}
 
-	accountAddress := flow.Address(address)
+	address := flow.ConvertAddress(runtimeAddress)
 
 	// address verification is also done in this step
 	accountPublicKey, err := reader.accounts.GetPublicKey(
-		accountAddress,
+		address,
 		uint64(keyIndex))
 	if err != nil {
 		// If a key is not found at a given index, then return a nil key with
@@ -139,7 +139,12 @@ func (reader *accountKeyReader) GetAccountKey(
 	return runtimeAccountKey, nil
 }
 
-func (reader *accountKeyReader) AccountKeysCount(address common.Address) (uint64, error) {
+func (reader *accountKeyReader) AccountKeysCount(
+	runtimeAddress common.Address,
+) (
+	uint64,
+	error,
+) {
 	defer reader.tracer.StartChildSpan(trace.FVMEnvAccountKeysCount).End()
 
 	formatErr := func(err error) (uint64, error) {
@@ -151,13 +156,17 @@ func (reader *accountKeyReader) AccountKeysCount(address common.Address) (uint64
 		return formatErr(err)
 	}
 
-	accountAddress := flow.Address(address)
-
 	// address verification is also done in this step
-	return reader.accounts.GetPublicKeyCount(accountAddress)
+	return reader.accounts.GetPublicKeyCount(
+		flow.ConvertAddress(runtimeAddress))
 }
 
-func FlowToRuntimeAccountKey(flowKey flow.AccountPublicKey) (*runtime.AccountKey, error) {
+func FlowToRuntimeAccountKey(
+	flowKey flow.AccountPublicKey,
+) (
+	*runtime.AccountKey,
+	error,
+) {
 	signAlgo := crypto.CryptoToRuntimeSigningAlgorithm(flowKey.SignAlgo)
 	if signAlgo == runtime.SignatureAlgorithmUnknown {
 		return nil, errors.NewValueErrorf(

--- a/fvm/environment/account_key_updater.go
+++ b/fvm/environment/account_key_updater.go
@@ -86,7 +86,7 @@ type AccountKeyUpdater interface {
 	// if the key insertion fails.
 	//
 	// Note that the script variant will return OperationNotSupportedError.
-	AddEncodedAccountKey(address common.Address, publicKey []byte) error
+	AddEncodedAccountKey(runtimeAddress common.Address, publicKey []byte) error
 
 	// RevokeEncodedAccountKey revokes a public key by index from an existing
 	// account.
@@ -96,7 +96,7 @@ type AccountKeyUpdater interface {
 	//
 	// Note that the script variant will return OperationNotSupportedError.
 	RevokeEncodedAccountKey(
-		address common.Address,
+		runtimeAddress common.Address,
 		index int,
 	) (
 		[]byte,
@@ -110,7 +110,7 @@ type AccountKeyUpdater interface {
 	//
 	// Note that the script variant will return OperationNotSupportedError.
 	AddAccountKey(
-		address common.Address,
+		runtimeAddress common.Address,
 		publicKey *runtime.PublicKey,
 		hashAlgo runtime.HashAlgorithm,
 		weight int,
@@ -129,7 +129,7 @@ type AccountKeyUpdater interface {
 	//
 	// Note that the script variant will return OperationNotSupportedError.
 	RevokeAccountKey(
-		address common.Address,
+		runtimeAddress common.Address,
 		keyIndex int,
 	) (
 		*runtime.AccountKey,
@@ -153,19 +153,19 @@ func NewParseRestrictedAccountKeyUpdater(
 }
 
 func (updater ParseRestrictedAccountKeyUpdater) AddEncodedAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	publicKey []byte,
 ) error {
 	return parseRestrict2Arg(
 		updater.txnState,
 		trace.FVMEnvAddEncodedAccountKey,
 		updater.impl.AddEncodedAccountKey,
-		address,
+		runtimeAddress,
 		publicKey)
 }
 
 func (updater ParseRestrictedAccountKeyUpdater) RevokeEncodedAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	index int,
 ) (
 	[]byte,
@@ -175,12 +175,12 @@ func (updater ParseRestrictedAccountKeyUpdater) RevokeEncodedAccountKey(
 		updater.txnState,
 		trace.FVMEnvRevokeEncodedAccountKey,
 		updater.impl.RevokeEncodedAccountKey,
-		address,
+		runtimeAddress,
 		index)
 }
 
 func (updater ParseRestrictedAccountKeyUpdater) AddAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	publicKey *runtime.PublicKey,
 	hashAlgo runtime.HashAlgorithm,
 	weight int,
@@ -192,14 +192,14 @@ func (updater ParseRestrictedAccountKeyUpdater) AddAccountKey(
 		updater.txnState,
 		trace.FVMEnvAddAccountKey,
 		updater.impl.AddAccountKey,
-		address,
+		runtimeAddress,
 		publicKey,
 		hashAlgo,
 		weight)
 }
 
 func (updater ParseRestrictedAccountKeyUpdater) RevokeAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	keyIndex int,
 ) (
 	*runtime.AccountKey,
@@ -209,21 +209,21 @@ func (updater ParseRestrictedAccountKeyUpdater) RevokeAccountKey(
 		updater.txnState,
 		trace.FVMEnvRevokeAccountKey,
 		updater.impl.RevokeAccountKey,
-		address,
+		runtimeAddress,
 		keyIndex)
 }
 
 type NoAccountKeyUpdater struct{}
 
 func (NoAccountKeyUpdater) AddEncodedAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	publicKey []byte,
 ) error {
 	return errors.NewOperationNotSupportedError("AddEncodedAccountKey")
 }
 
 func (NoAccountKeyUpdater) RevokeEncodedAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	index int,
 ) (
 	[]byte,
@@ -233,7 +233,7 @@ func (NoAccountKeyUpdater) RevokeEncodedAccountKey(
 }
 
 func (NoAccountKeyUpdater) AddAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	publicKey *runtime.PublicKey,
 	hashAlgo runtime.HashAlgorithm,
 	weight int,
@@ -245,7 +245,7 @@ func (NoAccountKeyUpdater) AddAccountKey(
 }
 
 func (NoAccountKeyUpdater) RevokeAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	keyIndex int,
 ) (
 	*runtime.AccountKey,
@@ -284,7 +284,7 @@ func NewAccountKeyUpdater(
 // This function returns an error if the specified account does not exist or
 // if the key insertion fails.
 func (updater *accountKeyUpdater) addAccountKey(
-	address common.Address,
+	address flow.Address,
 	publicKey *runtime.PublicKey,
 	hashAlgo runtime.HashAlgorithm,
 	weight int,
@@ -292,19 +292,17 @@ func (updater *accountKeyUpdater) addAccountKey(
 	*runtime.AccountKey,
 	error,
 ) {
-	accountAddress := flow.Address(address)
-
-	ok, err := updater.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(address)
 	if err != nil {
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf(
 			"adding account key failed: %w",
-			errors.NewAccountNotFoundError(accountAddress))
+			errors.NewAccountNotFoundError(address))
 	}
 
-	keyIndex, err := updater.accounts.GetPublicKeyCount(accountAddress)
+	keyIndex, err := updater.accounts.GetPublicKeyCount(address)
 	if err != nil {
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
@@ -318,7 +316,7 @@ func (updater *accountKeyUpdater) addAccountKey(
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
 
-	err = updater.accounts.AppendPublicKey(accountAddress, *accountPublicKey)
+	err = updater.accounts.AppendPublicKey(address, *accountPublicKey)
 	if err != nil {
 		return nil, fmt.Errorf("adding account key failed: %w", err)
 	}
@@ -342,15 +340,13 @@ func (updater *accountKeyUpdater) addAccountKey(
 // TODO (ramtin) do we have to return runtime.AccountKey for this method or
 // can be separated into another method
 func (updater *accountKeyUpdater) revokeAccountKey(
-	address common.Address,
+	address flow.Address,
 	keyIndex int,
 ) (
 	*runtime.AccountKey,
 	error,
 ) {
-	accountAddress := flow.Address(address)
-
-	ok, err := updater.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(address)
 	if err != nil {
 		return nil, fmt.Errorf("revoking account key failed: %w", err)
 	}
@@ -358,7 +354,7 @@ func (updater *accountKeyUpdater) revokeAccountKey(
 	if !ok {
 		return nil, fmt.Errorf(
 			"revoking account key failed: %w",
-			errors.NewAccountNotFoundError(accountAddress))
+			errors.NewAccountNotFoundError(address))
 	}
 
 	// Don't return an error for invalid key indices
@@ -368,7 +364,7 @@ func (updater *accountKeyUpdater) revokeAccountKey(
 
 	var publicKey flow.AccountPublicKey
 	publicKey, err = updater.accounts.GetPublicKey(
-		accountAddress,
+		address,
 		uint64(keyIndex))
 	if err != nil {
 		// If a key is not found at a given index, then return a nil key with
@@ -385,7 +381,7 @@ func (updater *accountKeyUpdater) revokeAccountKey(
 	publicKey.Revoked = true
 
 	_, err = updater.accounts.SetPublicKey(
-		accountAddress,
+		address,
 		uint64(keyIndex),
 		publicKey)
 	if err != nil {
@@ -430,18 +426,16 @@ func (updater *accountKeyUpdater) revokeAccountKey(
 // * NewAccountNotFoundError - if the specified account does not exist
 // * ValueError - if the provided encodedPublicKey is not valid public key
 func (updater *accountKeyUpdater) InternalAddEncodedAccountKey(
-	address common.Address,
+	address flow.Address,
 	encodedPublicKey []byte,
 ) error {
-	accountAddress := flow.Address(address)
-
-	ok, err := updater.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(address)
 	if err != nil {
 		return fmt.Errorf("adding encoded account key failed: %w", err)
 	}
 
 	if !ok {
-		return errors.NewAccountNotFoundError(accountAddress)
+		return errors.NewAccountNotFoundError(address)
 	}
 
 	var publicKey flow.AccountPublicKey
@@ -457,7 +451,7 @@ func (updater *accountKeyUpdater) InternalAddEncodedAccountKey(
 				err))
 	}
 
-	err = updater.accounts.AppendPublicKey(accountAddress, publicKey)
+	err = updater.accounts.AppendPublicKey(address, publicKey)
 	if err != nil {
 		return fmt.Errorf("adding encoded account key failed: %w", err)
 	}
@@ -470,21 +464,19 @@ func (updater *accountKeyUpdater) InternalAddEncodedAccountKey(
 // This function returns an error if the specified account does not exist, the
 // provided key is invalid, or if key revoking fails.
 func (updater *accountKeyUpdater) removeAccountKey(
-	address common.Address,
+	address flow.Address,
 	keyIndex int,
 ) (
 	[]byte,
 	error,
 ) {
-	accountAddress := flow.Address(address)
-
-	ok, err := updater.accounts.Exists(accountAddress)
+	ok, err := updater.accounts.Exists(address)
 	if err != nil {
 		return nil, fmt.Errorf("remove account key failed: %w", err)
 	}
 
 	if !ok {
-		issue := errors.NewAccountNotFoundError(accountAddress)
+		issue := errors.NewAccountNotFoundError(address)
 		return nil, fmt.Errorf("remove account key failed: %w", issue)
 	}
 
@@ -497,7 +489,7 @@ func (updater *accountKeyUpdater) removeAccountKey(
 
 	var publicKey flow.AccountPublicKey
 	publicKey, err = updater.accounts.GetPublicKey(
-		accountAddress,
+		address,
 		uint64(keyIndex))
 	if err != nil {
 		return nil, fmt.Errorf("remove account key failed: %w", err)
@@ -507,7 +499,7 @@ func (updater *accountKeyUpdater) removeAccountKey(
 	publicKey.Revoked = true
 
 	encodedPublicKey, err := updater.accounts.SetPublicKey(
-		accountAddress,
+		address,
 		uint64(keyIndex),
 		publicKey)
 	if err != nil {
@@ -518,7 +510,7 @@ func (updater *accountKeyUpdater) removeAccountKey(
 }
 
 func (updater *accountKeyUpdater) AddEncodedAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	publicKey []byte,
 ) error {
 	defer updater.tracer.StartChildSpan(
@@ -531,7 +523,8 @@ func (updater *accountKeyUpdater) AddEncodedAccountKey(
 		return fmt.Errorf("add encoded account key failed: %w", err)
 	}
 
-	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	address := flow.ConvertAddress(runtimeAddress)
+	err = updater.accounts.CheckAccountNotFrozen(address)
 	if err != nil {
 		return fmt.Errorf("add encoded account key failed: %w", err)
 	}
@@ -550,7 +543,7 @@ func (updater *accountKeyUpdater) AddEncodedAccountKey(
 }
 
 func (updater *accountKeyUpdater) RevokeEncodedAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	index int,
 ) (
 	[]byte,
@@ -565,7 +558,8 @@ func (updater *accountKeyUpdater) RevokeEncodedAccountKey(
 		return nil, fmt.Errorf("revoke encoded account key failed: %w", err)
 	}
 
-	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	address := flow.ConvertAddress(runtimeAddress)
+	err = updater.accounts.CheckAccountNotFrozen(address)
 	if err != nil {
 		return nil, fmt.Errorf("revoke encoded account key failed: %w", err)
 	}
@@ -579,7 +573,7 @@ func (updater *accountKeyUpdater) RevokeEncodedAccountKey(
 }
 
 func (updater *accountKeyUpdater) AddAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	publicKey *runtime.PublicKey,
 	hashAlgo runtime.HashAlgorithm,
 	weight int,
@@ -597,7 +591,7 @@ func (updater *accountKeyUpdater) AddAccountKey(
 	}
 
 	accKey, err := updater.addAccountKey(
-		address,
+		flow.ConvertAddress(runtimeAddress),
 		publicKey,
 		hashAlgo,
 		weight)
@@ -609,7 +603,7 @@ func (updater *accountKeyUpdater) AddAccountKey(
 }
 
 func (updater *accountKeyUpdater) RevokeAccountKey(
-	address common.Address,
+	runtimeAddress common.Address,
 	keyIndex int,
 ) (
 	*runtime.AccountKey,
@@ -624,5 +618,7 @@ func (updater *accountKeyUpdater) RevokeAccountKey(
 		return nil, fmt.Errorf("revoke account key failed: %w", err)
 	}
 
-	return updater.revokeAccountKey(address, keyIndex)
+	return updater.revokeAccountKey(
+		flow.ConvertAddress(runtimeAddress),
+		keyIndex)
 }

--- a/fvm/environment/account_key_updater_test.go
+++ b/fvm/environment/account_key_updater_test.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/atree"
-	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime"
-	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,7 +29,7 @@ func TestAddEncodedAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 		nil,
 		nil)
 
-	address := cadence.BytesToAddress([]byte{1, 2, 3, 4})
+	address := flow.BytesToAddress([]byte{1, 2, 3, 4})
 
 	// emulate encoded public key (which comes as a user input)
 	// containing bytes which are invalid UTF8
@@ -44,9 +42,7 @@ func TestAddEncodedAccountKey_error_handling_produces_valid_utf8(t *testing.T) {
 	encodedPublicKey, err := flow.EncodeRuntimeAccountPublicKey(accountPublicKey)
 	require.NoError(t, err)
 
-	err = akh.InternalAddEncodedAccountKey(
-		common.Address(address),
-		encodedPublicKey)
+	err = akh.InternalAddEncodedAccountKey(address, encodedPublicKey)
 	require.Error(t, err)
 
 	require.True(t, errors.IsValueError(err))

--- a/fvm/environment/contract_updater.go
+++ b/fvm/environment/contract_updater.go
@@ -163,9 +163,9 @@ type ContractUpdaterStubs interface {
 	RestrictedDeploymentEnabled() bool
 	RestrictedRemovalEnabled() bool
 
-	GetAuthorizedAccounts(path cadence.Path) []common.Address
+	GetAuthorizedAccounts(path cadence.Path) []flow.Address
 
-	UseContractAuditVoucher(address common.Address, code []byte) (bool, error)
+	UseContractAuditVoucher(address flow.Address, code []byte) (bool, error)
 }
 
 type contractUpdaterStubsImpl struct {
@@ -239,15 +239,15 @@ func (impl *contractUpdaterStubsImpl) RestrictedRemovalEnabled() bool {
 // service account be authorized).
 func (impl *contractUpdaterStubsImpl) GetAuthorizedAccounts(
 	path cadence.Path,
-) []common.Address {
+) []flow.Address {
 	// set default to service account only
-	service := common.Address(impl.chain.ServiceAddress())
-	defaultAccounts := []common.Address{service}
+	service := impl.chain.ServiceAddress()
+	defaultAccounts := []flow.Address{service}
 
 	runtime := impl.runtime.BorrowCadenceRuntime()
 	defer impl.runtime.ReturnCadenceRuntime(runtime)
 
-	value, err := runtime.ReadStored(service, path)
+	value, err := runtime.ReadStored(common.Address(service), path)
 
 	const warningMsg = "failed to read contract authorized accounts from " +
 		"service account. using default behaviour instead."
@@ -265,7 +265,7 @@ func (impl *contractUpdaterStubsImpl) GetAuthorizedAccounts(
 }
 
 func (impl *contractUpdaterStubsImpl) UseContractAuditVoucher(
-	address common.Address,
+	address flow.Address,
 	code []byte,
 ) (
 	bool,
@@ -280,7 +280,7 @@ type ContractUpdaterImpl struct {
 	tracer          tracing.TracerSpan
 	meter           Meter
 	accounts        Accounts
-	transactionInfo TransactionInfo
+	signingAccounts []flow.Address
 
 	draftUpdates map[ContractUpdateKey]ContractUpdate
 
@@ -311,7 +311,7 @@ func NewContractUpdater(
 	tracer tracing.TracerSpan,
 	meter Meter,
 	accounts Accounts,
-	transactionInfo TransactionInfo,
+	signingAccounts []flow.Address,
 	chain flow.Chain,
 	params ContractUpdaterParams,
 	logger *ProgramLogger,
@@ -322,7 +322,7 @@ func NewContractUpdater(
 		tracer:          tracer,
 		meter:           meter,
 		accounts:        accounts,
-		transactionInfo: transactionInfo,
+		signingAccounts: signingAccounts,
 		ContractUpdaterStubs: &contractUpdaterStubsImpl{
 			logger:                logger,
 			chain:                 chain,
@@ -337,7 +337,7 @@ func NewContractUpdater(
 }
 
 func (updater *ContractUpdaterImpl) UpdateAccountContractCode(
-	address common.Address,
+	runtimeAddress common.Address,
 	name string,
 	code []byte,
 ) error {
@@ -351,7 +351,8 @@ func (updater *ContractUpdaterImpl) UpdateAccountContractCode(
 		return fmt.Errorf("update account contract code failed: %w", err)
 	}
 
-	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	address := flow.ConvertAddress(runtimeAddress)
+	err = updater.accounts.CheckAccountNotFrozen(address)
 	if err != nil {
 		return fmt.Errorf("update account contract code failed: %w", err)
 	}
@@ -360,7 +361,7 @@ func (updater *ContractUpdaterImpl) UpdateAccountContractCode(
 		address,
 		name,
 		code,
-		updater.transactionInfo.SigningAccounts())
+		updater.signingAccounts)
 	if err != nil {
 		return fmt.Errorf("updating account contract code failed: %w", err)
 	}
@@ -369,7 +370,7 @@ func (updater *ContractUpdaterImpl) UpdateAccountContractCode(
 }
 
 func (updater *ContractUpdaterImpl) RemoveAccountContractCode(
-	address common.Address,
+	runtimeAddress common.Address,
 	name string,
 ) error {
 	defer updater.tracer.StartChildSpan(
@@ -382,7 +383,8 @@ func (updater *ContractUpdaterImpl) RemoveAccountContractCode(
 		return fmt.Errorf("remove account contract code failed: %w", err)
 	}
 
-	err = updater.accounts.CheckAccountNotFrozen(flow.Address(address))
+	address := flow.ConvertAddress(runtimeAddress)
+	err = updater.accounts.CheckAccountNotFrozen(address)
 	if err != nil {
 		return fmt.Errorf("remove account contract code failed: %w", err)
 	}
@@ -390,7 +392,7 @@ func (updater *ContractUpdaterImpl) RemoveAccountContractCode(
 	err = updater.RemoveContract(
 		address,
 		name,
-		updater.transactionInfo.SigningAccounts())
+		updater.signingAccounts)
 	if err != nil {
 		return fmt.Errorf("remove account contract code failed: %w", err)
 	}
@@ -399,21 +401,16 @@ func (updater *ContractUpdaterImpl) RemoveAccountContractCode(
 }
 
 func (updater *ContractUpdaterImpl) SetContract(
-	address common.Address,
+	address flow.Address,
 	name string,
 	code []byte,
-	signingAccounts []common.Address,
-) (err error) {
-
-	flowAddress := flow.Address(address)
-
+	signingAccounts []flow.Address,
+) error {
 	// Initial contract deployments must be authorized by signing accounts,
 	// or there must be an audit voucher available.
 	//
 	// Contract updates are always allowed.
-
-	var exists bool
-	exists, err = updater.accounts.ContractExists(name, flowAddress)
+	exists, err := updater.accounts.ContractExists(name, address)
 	if err != nil {
 		return err
 	}
@@ -452,9 +449,9 @@ func (updater *ContractUpdaterImpl) SetContract(
 }
 
 func (updater *ContractUpdaterImpl) RemoveContract(
-	address common.Address,
+	address flow.Address,
 	name string,
-	signingAccounts []common.Address,
+	signingAccounts []flow.Address,
 ) (err error) {
 	// check if authorized
 	if !updater.isAuthorizedForRemoval(signingAccounts) {
@@ -479,12 +476,12 @@ func (updater *ContractUpdaterImpl) Commit() ([]ContractUpdateKey, error) {
 	var err error
 	for _, v := range updateList {
 		if len(v.Code) > 0 {
-			err = updater.accounts.SetContract(v.Name, flow.BytesToAddress(v.Address.Bytes()), v.Code)
+			err = updater.accounts.SetContract(v.Name, v.Address, v.Code)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			err = updater.accounts.DeleteContract(v.Name, flow.BytesToAddress(v.Address.Bytes()))
+			err = updater.accounts.DeleteContract(v.Name, v.Address)
 			if err != nil {
 				return nil, err
 			}
@@ -521,7 +518,7 @@ func (updater *ContractUpdaterImpl) updates() (
 }
 
 func (updater *ContractUpdaterImpl) isAuthorizedForDeployment(
-	signingAccounts []common.Address,
+	signingAccounts []flow.Address,
 ) bool {
 	if updater.RestrictedDeploymentEnabled() {
 		return updater.isAuthorized(
@@ -532,7 +529,7 @@ func (updater *ContractUpdaterImpl) isAuthorizedForDeployment(
 }
 
 func (updater *ContractUpdaterImpl) isAuthorizedForRemoval(
-	signingAccounts []common.Address,
+	signingAccounts []flow.Address,
 ) bool {
 	if updater.RestrictedRemovalEnabled() {
 		return updater.isAuthorized(
@@ -543,7 +540,7 @@ func (updater *ContractUpdaterImpl) isAuthorizedForRemoval(
 }
 
 func (updater *ContractUpdaterImpl) isAuthorized(
-	signingAccounts []common.Address,
+	signingAccounts []flow.Address,
 	path cadence.Path,
 ) bool {
 	accts := updater.GetAuthorizedAccounts(path)

--- a/fvm/environment/contract_updater_test.go
+++ b/fvm/environment/contract_updater_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence"
-	"github.com/onflow/cadence/runtime/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -20,10 +19,10 @@ import (
 type testContractUpdaterStubs struct {
 	deploymentEnabled    bool
 	removalEnabled       bool
-	deploymentAuthorized []common.Address
-	removalAuthorized    []common.Address
+	deploymentAuthorized []flow.Address
+	removalAuthorized    []flow.Address
 
-	auditFunc func(address common.Address, code []byte) (bool, error)
+	auditFunc func(address flow.Address, code []byte) (bool, error)
 }
 
 func (p testContractUpdaterStubs) RestrictedDeploymentEnabled() bool {
@@ -36,7 +35,7 @@ func (p testContractUpdaterStubs) RestrictedRemovalEnabled() bool {
 
 func (p testContractUpdaterStubs) GetAuthorizedAccounts(
 	path cadence.Path,
-) []common.Address {
+) []flow.Address {
 	if path == blueprints.ContractDeploymentAuthorizedAddressesPath {
 		return p.deploymentAuthorized
 	}
@@ -44,7 +43,7 @@ func (p testContractUpdaterStubs) GetAuthorizedAccounts(
 }
 
 func (p testContractUpdaterStubs) UseContractAuditVoucher(
-	address common.Address,
+	address flow.Address,
 	code []byte,
 ) (
 	bool,
@@ -59,7 +58,6 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 		state.DefaultParameters())
 	accounts := environment.NewAccounts(txnState)
 	address := flow.HexToAddress("01")
-	rAdd := common.Address(address)
 	err := accounts.Create(nil, address)
 	require.NoError(t, err)
 
@@ -73,7 +71,11 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	require.Equal(t, len(names), 0)
 
 	// set contract no need for signing accounts
-	err = contractUpdater.SetContract(rAdd, "testContract", []byte("ABC"), nil)
+	err = contractUpdater.SetContract(
+		address,
+		"testContract",
+		[]byte("ABC"),
+		nil)
 	require.NoError(t, err)
 	require.True(t, contractUpdater.HasUpdates())
 
@@ -90,7 +92,11 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	require.Equal(t, cont, []byte("ABC"))
 
 	// rollback
-	err = contractUpdater.SetContract(rAdd, "testContract2", []byte("ABC"), nil)
+	err = contractUpdater.SetContract(
+		address,
+		"testContract2",
+		[]byte("ABC"),
+		nil)
 	require.NoError(t, err)
 	contractUpdater.Reset()
 	require.False(t, contractUpdater.HasUpdates())
@@ -108,7 +114,7 @@ func TestContract_ChildMergeFunctionality(t *testing.T) {
 	require.Equal(t, cont, []byte("ABC"))
 
 	// remove
-	err = contractUpdater.RemoveContract(rAdd, "testContract", nil)
+	err = contractUpdater.RemoveContract(address, "testContract", nil)
 	require.NoError(t, err)
 
 	// contract still there because no commit yet
@@ -133,22 +139,18 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	accounts := environment.NewAccounts(txnState)
 
 	authAdd := flow.HexToAddress("01")
-	rAdd := common.Address(authAdd)
 	err := accounts.Create(nil, authAdd)
 	require.NoError(t, err)
 
 	authRemove := flow.HexToAddress("02")
-	rRemove := common.Address(authRemove)
 	err = accounts.Create(nil, authRemove)
 	require.NoError(t, err)
 
 	authBoth := flow.HexToAddress("03")
-	rBoth := common.Address(authBoth)
 	err = accounts.Create(nil, authBoth)
 	require.NoError(t, err)
 
 	unAuth := flow.HexToAddress("04")
-	unAuthR := common.Address(unAuth)
 	err = accounts.Create(nil, unAuth)
 	require.NoError(t, err)
 
@@ -158,9 +160,9 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 			testContractUpdaterStubs{
 				deploymentEnabled:    true,
 				removalEnabled:       true,
-				deploymentAuthorized: []common.Address{rAdd, rBoth},
-				removalAuthorized:    []common.Address{rRemove, rBoth},
-				auditFunc:            func(address common.Address, code []byte) (bool, error) { return false, nil },
+				deploymentAuthorized: []flow.Address{authAdd, authBoth},
+				removalAuthorized:    []flow.Address{authRemove, authBoth},
+				auditFunc:            func(address flow.Address, code []byte) (bool, error) { return false, nil },
 			})
 
 	}
@@ -168,7 +170,11 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("try to set contract with unauthorized account", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{unAuthR})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract1",
+			[]byte("ABC"),
+			[]flow.Address{unAuth})
 		require.Error(t, err)
 		require.False(t, contractUpdater.HasUpdates())
 	})
@@ -176,7 +182,11 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("try to set contract with account only authorized for removal", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rRemove})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract1",
+			[]byte("ABC"),
+			[]flow.Address{authRemove})
 		require.Error(t, err)
 		require.False(t, contractUpdater.HasUpdates())
 	})
@@ -184,7 +194,11 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("set contract with account authorized for adding", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract2", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract2",
+			[]byte("ABC"),
+			[]flow.Address{authAdd})
 		require.NoError(t, err)
 		require.True(t, contractUpdater.HasUpdates())
 	})
@@ -192,7 +206,11 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("set contract with account authorized for adding and removing", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract2", []byte("ABC"), []common.Address{rBoth})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract2",
+			[]byte("ABC"),
+			[]flow.Address{authBoth})
 		require.NoError(t, err)
 		require.True(t, contractUpdater.HasUpdates())
 	})
@@ -200,12 +218,19 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("try to remove contract with unauthorized account", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract1",
+			[]byte("ABC"),
+			[]flow.Address{authAdd})
 		require.NoError(t, err)
 		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractUpdater.RemoveContract(unAuthR, "testContract2", []common.Address{unAuthR})
+		err = contractUpdater.RemoveContract(
+			unAuth,
+			"testContract2",
+			[]flow.Address{unAuth})
 		require.Error(t, err)
 		require.False(t, contractUpdater.HasUpdates())
 	})
@@ -213,12 +238,19 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("remove contract account authorized for removal", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract1",
+			[]byte("ABC"),
+			[]flow.Address{authAdd})
 		require.NoError(t, err)
 		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractUpdater.RemoveContract(rRemove, "testContract2", []common.Address{rRemove})
+		err = contractUpdater.RemoveContract(
+			authRemove,
+			"testContract2",
+			[]flow.Address{authRemove})
 		require.NoError(t, err)
 		require.True(t, contractUpdater.HasUpdates())
 	})
@@ -226,12 +258,19 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("try to remove contract with account only authorized for adding", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract1",
+			[]byte("ABC"),
+			[]flow.Address{authAdd})
 		require.NoError(t, err)
 		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractUpdater.RemoveContract(rAdd, "testContract2", []common.Address{rAdd})
+		err = contractUpdater.RemoveContract(
+			authAdd,
+			"testContract2",
+			[]flow.Address{authAdd})
 		require.Error(t, err)
 		require.False(t, contractUpdater.HasUpdates())
 	})
@@ -239,12 +278,19 @@ func TestContract_AuthorizationFunctionality(t *testing.T) {
 	t.Run("remove contract with account authorized for adding and removing", func(t *testing.T) {
 		contractUpdater := makeUpdater()
 
-		err = contractUpdater.SetContract(rAdd, "testContract1", []byte("ABC"), []common.Address{rAdd})
+		err = contractUpdater.SetContract(
+			authAdd,
+			"testContract1",
+			[]byte("ABC"),
+			[]flow.Address{authAdd})
 		require.NoError(t, err)
 		_, err = contractUpdater.Commit()
 		require.NoError(t, err)
 
-		err = contractUpdater.RemoveContract(rBoth, "testContract2", []common.Address{rBoth})
+		err = contractUpdater.RemoveContract(
+			authBoth,
+			"testContract2",
+			[]flow.Address{authBoth})
 		require.NoError(t, err)
 		require.True(t, contractUpdater.HasUpdates())
 	})
@@ -258,12 +304,10 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 	accounts := environment.NewAccounts(txnState)
 
 	addressWithVoucher := flow.HexToAddress("01")
-	addressWithVoucherRuntime := common.Address(addressWithVoucher)
 	err := accounts.Create(nil, addressWithVoucher)
 	require.NoError(t, err)
 
 	addressNoVoucher := flow.HexToAddress("02")
-	addressNoVoucherRuntime := common.Address(addressNoVoucher)
 	err = accounts.Create(nil, addressNoVoucher)
 	require.NoError(t, err)
 
@@ -272,7 +316,7 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 		testContractUpdaterStubs{
 			deploymentEnabled: true,
 			removalEnabled:    true,
-			auditFunc: func(address common.Address, code []byte) (bool, error) {
+			auditFunc: func(address flow.Address, code []byte) (bool, error) {
 				if address.String() == addressWithVoucher.String() {
 					return true, nil
 				}
@@ -282,11 +326,11 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 
 	// set contract without voucher
 	err = contractUpdater.SetContract(
-		addressNoVoucherRuntime,
+		addressNoVoucher,
 		"TestContract1",
 		[]byte("pub contract TestContract1 {}"),
-		[]common.Address{
-			addressNoVoucherRuntime,
+		[]flow.Address{
+			addressNoVoucher,
 		},
 	)
 	require.Error(t, err)
@@ -294,11 +338,11 @@ func TestContract_DeploymentVouchers(t *testing.T) {
 
 	// try to set contract with voucher
 	err = contractUpdater.SetContract(
-		addressWithVoucherRuntime,
+		addressWithVoucher,
 		"TestContract2",
 		[]byte("pub contract TestContract2 {}"),
-		[]common.Address{
-			addressWithVoucherRuntime,
+		[]flow.Address{
+			addressWithVoucher,
 		},
 	)
 	require.NoError(t, err)
@@ -313,8 +357,6 @@ func TestContract_ContractUpdate(t *testing.T) {
 	accounts := environment.NewAccounts(txnState)
 
 	flowAddress := flow.HexToAddress("01")
-	flowCommonAddress := common.MustBytesToAddress(flowAddress.Bytes())
-	runtimeAddress := common.Address(flowAddress)
 	err := accounts.Create(nil, flowAddress)
 	require.NoError(t, err)
 
@@ -325,7 +367,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 		testContractUpdaterStubs{
 			deploymentEnabled: true,
 			removalEnabled:    true,
-			auditFunc: func(address common.Address, code []byte) (bool, error) {
+			auditFunc: func(address flow.Address, code []byte) (bool, error) {
 				// Ensure the voucher check is only called once,
 				// for the initial contract deployment,
 				// and not for the subsequent update
@@ -337,11 +379,11 @@ func TestContract_ContractUpdate(t *testing.T) {
 
 	// deploy contract with voucher
 	err = contractUpdater.SetContract(
-		runtimeAddress,
+		flowAddress,
 		"TestContract",
 		[]byte("pub contract TestContract {}"),
-		[]common.Address{
-			runtimeAddress,
+		[]flow.Address{
+			flowAddress,
 		},
 	)
 	require.NoError(t, err)
@@ -353,7 +395,7 @@ func TestContract_ContractUpdate(t *testing.T) {
 		t,
 		[]environment.ContractUpdateKey{
 			{
-				Address: flowCommonAddress,
+				Address: flowAddress,
 				Name:    "TestContract",
 			},
 		},
@@ -362,11 +404,11 @@ func TestContract_ContractUpdate(t *testing.T) {
 
 	// try to update contract without voucher
 	err = contractUpdater.SetContract(
-		runtimeAddress,
+		flowAddress,
 		"TestContract",
 		[]byte("pub contract TestContract {}"),
-		[]common.Address{
-			runtimeAddress,
+		[]flow.Address{
+			flowAddress,
 		},
 	)
 	require.NoError(t, err)
@@ -388,8 +430,8 @@ func TestContract_DeterministicErrorOnCommit(t *testing.T) {
 		mockAccounts,
 		testContractUpdaterStubs{})
 
-	address1 := common.Address(flow.HexToAddress("0000000000000001"))
-	address2 := common.Address(flow.HexToAddress("0000000000000002"))
+	address1 := flow.HexToAddress("0000000000000001")
+	address2 := flow.HexToAddress("0000000000000002")
 
 	err := contractUpdater.SetContract(address2, "A", []byte("ABC"), nil)
 	require.NoError(t, err)
@@ -412,8 +454,6 @@ func TestContract_ContractRemoval(t *testing.T) {
 	accounts := environment.NewAccounts(txnState)
 
 	flowAddress := flow.HexToAddress("01")
-	flowCommonAddress := common.MustBytesToAddress(flowAddress.Bytes())
-	runtimeAddress := common.Address(flowAddress)
 	err := accounts.Create(nil, flowAddress)
 	require.NoError(t, err)
 
@@ -424,7 +464,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 			accounts,
 			testContractUpdaterStubs{
 				removalEnabled: true,
-				auditFunc: func(address common.Address, code []byte) (bool, error) {
+				auditFunc: func(address flow.Address, code []byte) (bool, error) {
 					// Ensure the voucher check is only called once,
 					// for the initial contract deployment,
 					// and not for the subsequent update
@@ -436,11 +476,11 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		// deploy contract with voucher
 		err = contractUpdater.SetContract(
-			runtimeAddress,
+			flowAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
-			[]common.Address{
-				runtimeAddress,
+			[]flow.Address{
+				flowAddress,
 			},
 		)
 		require.NoError(t, err)
@@ -452,7 +492,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 			t,
 			[]environment.ContractUpdateKey{
 				{
-					Address: flowCommonAddress,
+					Address: flowAddress,
 					Name:    "TestContract",
 				},
 			},
@@ -461,11 +501,11 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		// update should work
 		err = contractUpdater.SetContract(
-			runtimeAddress,
+			flowAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
-			[]common.Address{
-				runtimeAddress,
+			[]flow.Address{
+				flowAddress,
 			},
 		)
 		require.NoError(t, err)
@@ -473,10 +513,10 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		// try remove contract should fail
 		err = contractUpdater.RemoveContract(
-			runtimeAddress,
+			flowAddress,
 			"TestContract",
-			[]common.Address{
-				runtimeAddress,
+			[]flow.Address{
+				flowAddress,
 			},
 		)
 		require.Error(t, err)
@@ -488,7 +528,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 		contractUpdater := environment.NewContractUpdaterForTesting(
 			accounts,
 			testContractUpdaterStubs{
-				auditFunc: func(address common.Address, code []byte) (bool, error) {
+				auditFunc: func(address flow.Address, code []byte) (bool, error) {
 					// Ensure the voucher check is only called once,
 					// for the initial contract deployment,
 					// and not for the subsequent update
@@ -500,11 +540,11 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		// deploy contract with voucher
 		err = contractUpdater.SetContract(
-			runtimeAddress,
+			flowAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
-			[]common.Address{
-				runtimeAddress,
+			[]flow.Address{
+				flowAddress,
 			},
 		)
 		require.NoError(t, err)
@@ -516,7 +556,7 @@ func TestContract_ContractRemoval(t *testing.T) {
 			t,
 			[]environment.ContractUpdateKey{
 				{
-					Address: flowCommonAddress,
+					Address: flowAddress,
 					Name:    "TestContract",
 				},
 			},
@@ -525,11 +565,11 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		// update should work
 		err = contractUpdater.SetContract(
-			runtimeAddress,
+			flowAddress,
 			"TestContract",
 			[]byte("pub contract TestContract {}"),
-			[]common.Address{
-				runtimeAddress,
+			[]flow.Address{
+				flowAddress,
 			},
 		)
 		require.NoError(t, err)
@@ -537,10 +577,10 @@ func TestContract_ContractRemoval(t *testing.T) {
 
 		// try remove contract should fail
 		err = contractUpdater.RemoveContract(
-			runtimeAddress,
+			flowAddress,
 			"TestContract",
-			[]common.Address{
-				runtimeAddress,
+			[]flow.Address{
+				flowAddress,
 			},
 		)
 		require.NoError(t, err)

--- a/fvm/environment/derived_data_invalidator.go
+++ b/fvm/environment/derived_data_invalidator.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
 )
 
 type ContractUpdateKey struct {
-	Address common.Address
+	Address flow.Address
 	Name    string
 }
 
@@ -19,7 +20,7 @@ type ContractUpdate struct {
 
 type DerivedDataInvalidator struct {
 	ContractUpdateKeys []ContractUpdateKey
-	FrozenAccounts     []common.Address
+	FrozenAccounts     []flow.Address
 
 	MeterParamOverridesUpdated bool
 }

--- a/fvm/environment/derived_data_invalidator_test.go
+++ b/fvm/environment/derived_data_invalidator_test.go
@@ -32,8 +32,8 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	programALoc := common.AddressLocation{Address: cAddressA, Name: "A"}
 	programA := &derived.Program{
 		Program: nil,
-		Dependencies: map[common.Address]struct{}{
-			cAddressA: {},
+		Dependencies: map[flow.Address]struct{}{
+			addressA: {},
 		},
 	}
 
@@ -42,9 +42,9 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	programBLoc := common.AddressLocation{Address: cAddressB, Name: "B"}
 	programB := &derived.Program{
 		Program: nil,
-		Dependencies: map[common.Address]struct{}{
-			cAddressA: {},
-			cAddressB: {},
+		Dependencies: map[flow.Address]struct{}{
+			addressA: {},
+			addressB: {},
 		},
 	}
 
@@ -53,8 +53,8 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	programDLoc := common.AddressLocation{Address: cAddressD, Name: "D"}
 	programD := &derived.Program{
 		Program: nil,
-		Dependencies: map[common.Address]struct{}{
-			cAddressD: {},
+		Dependencies: map[flow.Address]struct{}{
+			addressD: {},
 		},
 	}
 
@@ -63,12 +63,12 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 	programCLoc := common.AddressLocation{Address: cAddressC, Name: "C"}
 	programC := &derived.Program{
 		Program: nil,
-		Dependencies: map[common.Address]struct{}{
+		Dependencies: map[flow.Address]struct{}{
 			// C indirectly depends on A trough B
-			cAddressA: {},
-			cAddressB: {},
-			cAddressC: {},
-			cAddressD: {},
+			addressA: {},
+			addressB: {},
+			addressC: {},
+			addressD: {},
 		},
 	}
 
@@ -95,8 +95,8 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 
 	t.Run("address invalidator A invalidates all but D", func(t *testing.T) {
 		invalidator := environment.DerivedDataInvalidator{
-			FrozenAccounts: []common.Address{
-				cAddressA,
+			FrozenAccounts: []flow.Address{
+				addressA,
 			},
 		}.ProgramInvalidator()
 
@@ -109,8 +109,8 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 
 	t.Run("address invalidator D invalidates D, C", func(t *testing.T) {
 		invalidator := environment.DerivedDataInvalidator{
-			FrozenAccounts: []common.Address{
-				cAddressD,
+			FrozenAccounts: []flow.Address{
+				addressD,
 			},
 		}.ProgramInvalidator()
 
@@ -123,8 +123,8 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 
 	t.Run("address invalidator B invalidates B, C", func(t *testing.T) {
 		invalidator := environment.DerivedDataInvalidator{
-			FrozenAccounts: []common.Address{
-				cAddressB,
+			FrozenAccounts: []flow.Address{
+				addressB,
 			},
 		}.ProgramInvalidator()
 
@@ -139,7 +139,7 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 		invalidator := environment.DerivedDataInvalidator{
 			ContractUpdateKeys: []environment.ContractUpdateKey{
 				{
-					Address: cAddressA,
+					Address: addressA,
 					Name:    "A",
 				},
 			},
@@ -156,7 +156,7 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 		invalidator := environment.DerivedDataInvalidator{
 			ContractUpdateKeys: []environment.ContractUpdateKey{
 				{
-					Address: cAddressC,
+					Address: addressC,
 					Name:    "C",
 				},
 			},
@@ -173,7 +173,7 @@ func TestDerivedDataProgramInvalidator(t *testing.T) {
 		invalidator := environment.DerivedDataInvalidator{
 			ContractUpdateKeys: []environment.ContractUpdateKey{
 				{
-					Address: cAddressD,
+					Address: addressD,
 					Name:    "D",
 				},
 			},

--- a/fvm/environment/facade_env.go
+++ b/fvm/environment/facade_env.go
@@ -204,7 +204,7 @@ func NewTransactionEnvironment(
 		tracer,
 		env.Meter,
 		env.accounts,
-		env.TransactionInfo,
+		params.TransactionInfoParams.TxBody.Authorizers,
 		params.Chain,
 		params.ContractUpdaterParams,
 		env.ProgramLogger,

--- a/fvm/environment/mock/account_freezer.go
+++ b/fvm/environment/mock/account_freezer.go
@@ -5,6 +5,8 @@ package mock
 import (
 	common "github.com/onflow/cadence/runtime/common"
 
+	flow "github.com/onflow/flow-go/model/flow"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -14,15 +16,15 @@ type AccountFreezer struct {
 }
 
 // FrozenAccounts provides a mock function with given fields:
-func (_m *AccountFreezer) FrozenAccounts() []common.Address {
+func (_m *AccountFreezer) FrozenAccounts() []flow.Address {
 	ret := _m.Called()
 
-	var r0 []common.Address
-	if rf, ok := ret.Get(0).(func() []common.Address); ok {
+	var r0 []flow.Address
+	if rf, ok := ret.Get(0).(func() []flow.Address); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]flow.Address)
 		}
 	}
 

--- a/fvm/environment/mock/account_key_updater.go
+++ b/fvm/environment/mock/account_key_updater.go
@@ -17,13 +17,13 @@ type AccountKeyUpdater struct {
 	mock.Mock
 }
 
-// AddAccountKey provides a mock function with given fields: address, publicKey, hashAlgo, weight
-func (_m *AccountKeyUpdater) AddAccountKey(address common.Address, publicKey *stdlib.PublicKey, hashAlgo sema.HashAlgorithm, weight int) (*stdlib.AccountKey, error) {
-	ret := _m.Called(address, publicKey, hashAlgo, weight)
+// AddAccountKey provides a mock function with given fields: runtimeAddress, publicKey, hashAlgo, weight
+func (_m *AccountKeyUpdater) AddAccountKey(runtimeAddress common.Address, publicKey *stdlib.PublicKey, hashAlgo sema.HashAlgorithm, weight int) (*stdlib.AccountKey, error) {
+	ret := _m.Called(runtimeAddress, publicKey, hashAlgo, weight)
 
 	var r0 *stdlib.AccountKey
 	if rf, ok := ret.Get(0).(func(common.Address, *stdlib.PublicKey, sema.HashAlgorithm, int) *stdlib.AccountKey); ok {
-		r0 = rf(address, publicKey, hashAlgo, weight)
+		r0 = rf(runtimeAddress, publicKey, hashAlgo, weight)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*stdlib.AccountKey)
@@ -32,7 +32,7 @@ func (_m *AccountKeyUpdater) AddAccountKey(address common.Address, publicKey *st
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(common.Address, *stdlib.PublicKey, sema.HashAlgorithm, int) error); ok {
-		r1 = rf(address, publicKey, hashAlgo, weight)
+		r1 = rf(runtimeAddress, publicKey, hashAlgo, weight)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -40,13 +40,13 @@ func (_m *AccountKeyUpdater) AddAccountKey(address common.Address, publicKey *st
 	return r0, r1
 }
 
-// AddEncodedAccountKey provides a mock function with given fields: address, publicKey
-func (_m *AccountKeyUpdater) AddEncodedAccountKey(address common.Address, publicKey []byte) error {
-	ret := _m.Called(address, publicKey)
+// AddEncodedAccountKey provides a mock function with given fields: runtimeAddress, publicKey
+func (_m *AccountKeyUpdater) AddEncodedAccountKey(runtimeAddress common.Address, publicKey []byte) error {
+	ret := _m.Called(runtimeAddress, publicKey)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(common.Address, []byte) error); ok {
-		r0 = rf(address, publicKey)
+		r0 = rf(runtimeAddress, publicKey)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -54,13 +54,13 @@ func (_m *AccountKeyUpdater) AddEncodedAccountKey(address common.Address, public
 	return r0
 }
 
-// RevokeAccountKey provides a mock function with given fields: address, keyIndex
-func (_m *AccountKeyUpdater) RevokeAccountKey(address common.Address, keyIndex int) (*stdlib.AccountKey, error) {
-	ret := _m.Called(address, keyIndex)
+// RevokeAccountKey provides a mock function with given fields: runtimeAddress, keyIndex
+func (_m *AccountKeyUpdater) RevokeAccountKey(runtimeAddress common.Address, keyIndex int) (*stdlib.AccountKey, error) {
+	ret := _m.Called(runtimeAddress, keyIndex)
 
 	var r0 *stdlib.AccountKey
 	if rf, ok := ret.Get(0).(func(common.Address, int) *stdlib.AccountKey); ok {
-		r0 = rf(address, keyIndex)
+		r0 = rf(runtimeAddress, keyIndex)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*stdlib.AccountKey)
@@ -69,7 +69,7 @@ func (_m *AccountKeyUpdater) RevokeAccountKey(address common.Address, keyIndex i
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(common.Address, int) error); ok {
-		r1 = rf(address, keyIndex)
+		r1 = rf(runtimeAddress, keyIndex)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -77,13 +77,13 @@ func (_m *AccountKeyUpdater) RevokeAccountKey(address common.Address, keyIndex i
 	return r0, r1
 }
 
-// RevokeEncodedAccountKey provides a mock function with given fields: address, index
-func (_m *AccountKeyUpdater) RevokeEncodedAccountKey(address common.Address, index int) ([]byte, error) {
-	ret := _m.Called(address, index)
+// RevokeEncodedAccountKey provides a mock function with given fields: runtimeAddress, index
+func (_m *AccountKeyUpdater) RevokeEncodedAccountKey(runtimeAddress common.Address, index int) ([]byte, error) {
+	ret := _m.Called(runtimeAddress, index)
 
 	var r0 []byte
 	if rf, ok := ret.Get(0).(func(common.Address, int) []byte); ok {
-		r0 = rf(address, index)
+		r0 = rf(runtimeAddress, index)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -92,7 +92,7 @@ func (_m *AccountKeyUpdater) RevokeEncodedAccountKey(address common.Address, ind
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(common.Address, int) error); ok {
-		r1 = rf(address, index)
+		r1 = rf(runtimeAddress, index)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/fvm/environment/mock/contract_updater_stubs.go
+++ b/fvm/environment/mock/contract_updater_stubs.go
@@ -4,7 +4,8 @@ package mock
 
 import (
 	cadence "github.com/onflow/cadence"
-	common "github.com/onflow/cadence/runtime/common"
+
+	flow "github.com/onflow/flow-go/model/flow"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -15,15 +16,15 @@ type ContractUpdaterStubs struct {
 }
 
 // GetAuthorizedAccounts provides a mock function with given fields: path
-func (_m *ContractUpdaterStubs) GetAuthorizedAccounts(path cadence.Path) []common.Address {
+func (_m *ContractUpdaterStubs) GetAuthorizedAccounts(path cadence.Path) []flow.Address {
 	ret := _m.Called(path)
 
-	var r0 []common.Address
-	if rf, ok := ret.Get(0).(func(cadence.Path) []common.Address); ok {
+	var r0 []flow.Address
+	if rf, ok := ret.Get(0).(func(cadence.Path) []flow.Address); ok {
 		r0 = rf(path)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]flow.Address)
 		}
 	}
 
@@ -59,18 +60,18 @@ func (_m *ContractUpdaterStubs) RestrictedRemovalEnabled() bool {
 }
 
 // UseContractAuditVoucher provides a mock function with given fields: address, code
-func (_m *ContractUpdaterStubs) UseContractAuditVoucher(address common.Address, code []byte) (bool, error) {
+func (_m *ContractUpdaterStubs) UseContractAuditVoucher(address flow.Address, code []byte) (bool, error) {
 	ret := _m.Called(address, code)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(common.Address, []byte) bool); ok {
+	if rf, ok := ret.Get(0).(func(flow.Address, []byte) bool); ok {
 		r0 = rf(address, code)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(common.Address, []byte) error); ok {
+	if rf, ok := ret.Get(1).(func(flow.Address, []byte) error); ok {
 		r1 = rf(address, code)
 	} else {
 		r1 = ret.Error(1)

--- a/fvm/environment/mock/environment.go
+++ b/fvm/environment/mock/environment.go
@@ -423,15 +423,15 @@ func (_m *Environment) FlushPendingUpdates() (derived.TransactionInvalidator, er
 }
 
 // FrozenAccounts provides a mock function with given fields:
-func (_m *Environment) FrozenAccounts() []common.Address {
+func (_m *Environment) FrozenAccounts() []flow.Address {
 	ret := _m.Called()
 
-	var r0 []common.Address
-	if rf, ok := ret.Get(0).(func() []common.Address); ok {
+	var r0 []flow.Address
+	if rf, ok := ret.Get(0).(func() []flow.Address); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
+			r0 = ret.Get(0).([]flow.Address)
 		}
 	}
 
@@ -1120,22 +1120,6 @@ func (_m *Environment) SetValue(owner []byte, key []byte, value []byte) error {
 		r0 = rf(owner, key, value)
 	} else {
 		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// SigningAccounts provides a mock function with given fields:
-func (_m *Environment) SigningAccounts() []common.Address {
-	ret := _m.Called()
-
-	var r0 []common.Address
-	if rf, ok := ret.Get(0).(func() []common.Address); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
-		}
 	}
 
 	return r0

--- a/fvm/environment/mock/transaction_info.go
+++ b/fvm/environment/mock/transaction_info.go
@@ -66,22 +66,6 @@ func (_m *TransactionInfo) LimitAccountStorage() bool {
 	return r0
 }
 
-// SigningAccounts provides a mock function with given fields:
-func (_m *TransactionInfo) SigningAccounts() []common.Address {
-	ret := _m.Called()
-
-	var r0 []common.Address
-	if rf, ok := ret.Get(0).(func() []common.Address); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Address)
-		}
-	}
-
-	return r0
-}
-
 // TransactionFeesEnabled provides a mock function with given fields:
 func (_m *TransactionInfo) TransactionFeesEnabled() bool {
 	ret := _m.Called()

--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -190,7 +190,7 @@ func (programs *Programs) GetProgram(
 	}
 
 	if addressLocation, ok := location.(common.AddressLocation); ok {
-		address := flow.Address(addressLocation.Address)
+		address := flow.ConvertAddress(addressLocation.Address)
 
 		freezeError := programs.accounts.CheckAccountNotFrozen(address)
 		if freezeError != nil {
@@ -288,7 +288,7 @@ func (s *dependencyStack) push(loc common.AddressLocation) {
 	dependencies := make(derived.ProgramDependencies, 1)
 
 	// A program is listed as its own dependency.
-	dependencies.AddDependency(loc.Address)
+	dependencies.AddDependency(flow.ConvertAddress(loc.Address))
 
 	s.trackers = append(s.trackers, dependencyTracker{
 		location:     loc,

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -218,7 +218,7 @@ func Test_Programs(t *testing.T) {
 
 		// assert dependencies are correct
 		require.Len(t, entry.Value.Dependencies, 1)
-		require.NotNil(t, entry.Value.Dependencies[common.MustBytesToAddress(addressA.Bytes())])
+		require.NotNil(t, entry.Value.Dependencies[addressA])
 
 		// type assertion for further inspections
 		require.IsType(t, entry.State.View(), &delta.View{})
@@ -319,8 +319,8 @@ func Test_Programs(t *testing.T) {
 
 		// assert dependencies are correct
 		require.Len(t, entryB.Value.Dependencies, 2)
-		require.NotNil(t, entryB.Value.Dependencies[common.MustBytesToAddress(addressA.Bytes())])
-		require.NotNil(t, entryB.Value.Dependencies[common.MustBytesToAddress(addressB.Bytes())])
+		require.NotNil(t, entryB.Value.Dependencies[addressA])
+		require.NotNil(t, entryB.Value.Dependencies[addressB])
 
 		// program B should contain all the registers used by program A, as it depends on it
 		require.IsType(t, entryB.State.View(), &delta.View{})
@@ -470,9 +470,9 @@ func Test_Programs(t *testing.T) {
 
 		// assert dependencies are correct
 		require.Len(t, entryC.Value.Dependencies, 3)
-		require.NotNil(t, entryC.Value.Dependencies[common.MustBytesToAddress(addressA.Bytes())])
-		require.NotNil(t, entryC.Value.Dependencies[common.MustBytesToAddress(addressB.Bytes())])
-		require.NotNil(t, entryC.Value.Dependencies[common.MustBytesToAddress(addressC.Bytes())])
+		require.NotNil(t, entryC.Value.Dependencies[addressA])
+		require.NotNil(t, entryC.Value.Dependencies[addressB])
+		require.NotNil(t, entryC.Value.Dependencies[addressC])
 
 		cached := derivedBlockData.CachedPrograms()
 		require.Equal(t, 3, cached)

--- a/fvm/environment/system_contracts.go
+++ b/fvm/environment/system_contracts.go
@@ -292,7 +292,7 @@ var useContractAuditVoucherSpec = ContractFunctionSpec{
 // UseContractAuditVoucher executes the use a contract deployment audit voucher
 // contract.
 func (sys *SystemContracts) UseContractAuditVoucher(
-	address common.Address,
+	address flow.Address,
 	code string,
 ) (bool, error) {
 	resultCdc, err := sys.Invoke(

--- a/fvm/environment/system_contracts_test.go
+++ b/fvm/environment/system_contracts_test.go
@@ -77,7 +77,7 @@ func TestSystemContractsInvoke(t *testing.T) {
 			value, err := invoker.Invoke(
 				environment.ContractFunctionSpec{
 					AddressFromChain: func(_ flow.Chain) flow.Address {
-						return flow.Address{}
+						return flow.EmptyAddress
 					},
 					FunctionName: "functionName",
 				},

--- a/fvm/environment/transaction_info.go
+++ b/fvm/environment/transaction_info.go
@@ -40,8 +40,6 @@ type TransactionInfo interface {
 	TransactionFeesEnabled() bool
 	LimitAccountStorage() bool
 
-	SigningAccounts() []common.Address
-
 	IsServiceAccountAuthorizer() bool
 
 	// Cadence's runtime API.  Note that the script variant will return
@@ -78,10 +76,6 @@ func (info ParseRestrictedTransactionInfo) TransactionFeesEnabled() bool {
 
 func (info ParseRestrictedTransactionInfo) LimitAccountStorage() bool {
 	return info.impl.LimitAccountStorage()
-}
-
-func (info ParseRestrictedTransactionInfo) SigningAccounts() []common.Address {
-	return info.impl.SigningAccounts()
 }
 
 func (info ParseRestrictedTransactionInfo) IsServiceAccountAuthorizer() bool {
@@ -150,10 +144,6 @@ func (info *transactionInfo) LimitAccountStorage() bool {
 	return info.params.LimitAccountStorage
 }
 
-func (info *transactionInfo) SigningAccounts() []common.Address {
-	return info.authorizers
-}
-
 func (info *transactionInfo) IsServiceAccountAuthorizer() bool {
 	return info.isServiceAccountAuthorizer
 }
@@ -185,10 +175,6 @@ func (NoTransactionInfo) TransactionFeesEnabled() bool {
 
 func (NoTransactionInfo) LimitAccountStorage() bool {
 	return false
-}
-
-func (NoTransactionInfo) SigningAccounts() []common.Address {
-	return nil
 }
 
 func (NoTransactionInfo) IsServiceAccountAuthorizer() bool {

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -304,7 +304,8 @@ func (b *BasicBlockExecutor) SetupAccounts(tb testing.TB, privateKeys []flow.Acc
 					if err != nil {
 						tb.Fatal("setup account failed, error decoding events")
 					}
-					addr = flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+					addr = flow.ConvertAddress(
+						data.(cadence.Event).Fields[0].(cadence.Address))
 					break
 				}
 			}

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -1571,7 +1571,8 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		// read the address of the account created (e.g. "0x01" and convert it to flow.address)
 		data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 		require.NoError(t, err)
-		address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+		address := flow.ConvertAddress(
+			data.(cadence.Event).Fields[0].(cadence.Address))
 
 		return address, privateKey.PublicKey(fvm.AccountKeyWeightThreshold).PublicKey
 	}
@@ -1697,7 +1698,8 @@ func TestBlockContext_ExecuteTransaction_CreateAccount_WithMonotonicAddresses(t 
 
 	data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 	require.NoError(t, err)
-	address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+	address := flow.ConvertAddress(
+		data.(cadence.Event).Fields[0].(cadence.Address))
 
 	assert.Equal(t, flow.HexToAddress("05"), address)
 }

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -272,7 +272,8 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 		data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 		require.NoError(tb, err)
 
-		address = flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+		address = flow.ConvertAddress(
+			data.(cadence.Event).Fields[0].(cadence.Address))
 
 		// ==== Transfer tokens to new account ====
 		txBody = transferTokensTx(chain).

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -980,7 +980,8 @@ func TestTransactionFeeDeduction(t *testing.T) {
 			// read the address of the account created (e.g. "0x01" and convert it to flow.address)
 			data, err := jsoncdc.Decode(nil, accountCreatedEvents[0].Payload)
 			require.NoError(t, err)
-			address := flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+			address := flow.ConvertAddress(
+				data.(cadence.Event).Fields[0].(cadence.Address))
 
 			// ==== Transfer tokens to new account ====
 			txBody = transferTokensTx(chain).
@@ -2038,7 +2039,8 @@ func TestInteractionLimit(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			address = flow.Address(data.(cadence.Event).Fields[0].(cadence.Address))
+			address = flow.ConvertAddress(
+				data.(cadence.Event).Fields[0].(cadence.Address))
 
 			// ==== Transfer tokens to new account ====
 			txBody = transferTokensTx(chain).

--- a/fvm/utils/cadenceValues.go
+++ b/fvm/utils/cadenceValues.go
@@ -23,7 +23,10 @@ func AddressSliceToCadenceValue(addresses []common.Address) cadence.Value {
 	return cadence.NewArray(adds)
 }
 
-func CadenceValueToAddressSlice(value cadence.Value) (addresses []common.Address, ok bool) {
+func CadenceValueToAddressSlice(value cadence.Value) (
+	addresses []flow.Address,
+	ok bool,
+) {
 
 	// cast to array
 	v, ok := value.(cadence.Array)
@@ -37,7 +40,7 @@ func CadenceValueToAddressSlice(value cadence.Value) (addresses []common.Address
 		if !ok {
 			return nil, false
 		}
-		addresses = append(addresses, common.Address(a))
+		addresses = append(addresses, flow.ConvertAddress(a))
 	}
 	return addresses, true
 }

--- a/model/flow/address_test.go
+++ b/model/flow/address_test.go
@@ -7,12 +7,43 @@ import (
 	"testing"
 	"time"
 
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type addressWrapper struct {
 	Address Address
+}
+
+func TestConvertAddress(t *testing.T) {
+	expected := BytesToAddress([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	cadenceAddress := cadence.BytesToAddress([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	runtimeAddress := common.MustBytesToAddress([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	assert.NotEqual(t, cadenceAddress, runtimeAddress)
+
+	assert.Equal(t, expected, ConvertAddress(cadenceAddress))
+	assert.Equal(t, expected, ConvertAddress(runtimeAddress))
+}
+
+func TestBytesToAddress(t *testing.T) {
+	type testCase struct {
+		expected string
+		value    string
+	}
+
+	for _, test := range []testCase{
+		{string([]byte{0, 0, 0, 0, 0, 0, 0, 0}), ""},
+		{string([]byte{0, 0, 0, 0}) + "1234", "1234"},
+		{"12345678", "12345678"},
+		{"12345678", "trim12345678"},
+	} {
+		address := BytesToAddress([]byte(test.value))
+		assert.Equal(t, test.expected, string(address[:]))
+	}
 }
 
 func TestHexToAddress(t *testing.T) {


### PR DESCRIPTION
Prep work for changing address internal representation

The number of changes is getting a bit out of hand.  I'll split up the change into smaller PRs, with the goal of consistently operating on flow.Address whenever possible.

Note that (except for tests) I'm trying to consistently name the address variables based on their types:
 - address is always a flow.Address
 - runtimeAddress is a common.Address
 - cadenceAddress is a cadence.Address