### PR TITLE
[Access] Improve Access API error reporting for results from ENs

### DIFF
--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -138,19 +138,8 @@ func (b *backendAccounts) getAccountFromAnyExeNode(ctx context.Context, execNode
 			Msg("failed to execute GetAccount")
 		errors = multierror.Append(errors, err)
 	}
-	// if we made it till here means there was at least one error
-	errToReturn := errors.ErrorOrNil()
 
-	// if there were an any errors other than codes.NotFound, return those
-	for _, err := range errors.Errors {
-		errStatus, _ := status.FromError(err)
-		if errStatus.Code() != codes.NotFound {
-			return nil, status.Errorf(codes.Internal, "failed to get account from the execution node: %v", errToReturn)
-		}
-	}
-
-	// if all errors were codes.NotFound, then return a codes.NotFound error wrapping all those errors
-	return nil, status.Errorf(codes.NotFound, "failed to get account from the execution node: %v", errToReturn)
+	return nil, rpc.ConvertMultiError(errors, "failed to get account from the execution node", codes.Internal)
 }
 
 func (b *backendAccounts) tryGetAccount(ctx context.Context, execNode *flow.Identity, req *execproto.GetAccountAtBlockIDRequest) (*execproto.GetAccountAtBlockIDResponse, error) {

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -139,7 +139,7 @@ func (b *backendEvents) getBlockEventsFromExecutionNode(
 	resp, successfulNode, err = b.getEventsFromAnyExeNode(ctx, execNodes, req)
 	if err != nil {
 		b.log.Error().Err(err).Msg("failed to retrieve events from execution nodes")
-		return nil, status.Errorf(codes.Internal, "failed to retrieve events from execution nodes %s: %v", execNodes, err)
+		return nil, err
 	}
 	b.log.Trace().
 		Str("execution_id", successfulNode.String()).
@@ -203,7 +203,7 @@ func (b *backendEvents) getEventsFromAnyExeNode(ctx context.Context,
 		}
 		errors = multierror.Append(errors, err)
 	}
-	return nil, nil, errors.ErrorOrNil()
+	return nil, nil, rpc.ConvertMultiError(errors, "failed to retrieve events from execution nodes", codes.Internal)
 }
 
 func (b *backendEvents) tryGetEvents(ctx context.Context,

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -146,11 +146,13 @@ func (b *backendScripts) executeScriptOnExecutionNode(
 		}
 		errors = multierror.Append(errors, err)
 	}
+
 	errToReturn := errors.ErrorOrNil()
 	if errToReturn != nil {
 		b.log.Error().Err(err).Msg("script execution failed for execution node internal reasons")
 	}
-	return nil, errToReturn
+
+	return nil, rpc.ConvertMultiError(errors, "failed to execute script on execution nodes", codes.Internal)
 }
 
 // shouldLogScript checks if the script hash is unique in the time window

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -694,6 +694,9 @@ func (b *backendTransactions) getTransactionResultFromAnyExeNode(
 				Msg("Successfully got transaction results from any node")
 			return resp, nil
 		}
+		if status.Code(err) == codes.NotFound {
+			return nil, err
+		}
 		errs = multierror.Append(errs, err)
 	}
 	return nil, rpc.ConvertMultiError(errs, "failed to retrieve result from execution node", codes.Internal)
@@ -747,6 +750,9 @@ func (b *backendTransactions) getTransactionResultsByBlockIDFromAnyExeNode(
 				Hex("block_id", req.GetBlockId()).
 				Msg("Successfully got transaction results from any node")
 			return resp, nil
+		}
+		if status.Code(err) == codes.NotFound {
+			return nil, err
 		}
 		errs = multierror.Append(errs, err)
 	}
@@ -803,6 +809,9 @@ func (b *backendTransactions) getTransactionResultByIndexFromAnyExeNode(
 				Uint32("index", req.GetIndex()).
 				Msg("Successfully got transaction results from any node")
 			return resp, nil
+		}
+		if status.Code(err) == codes.NotFound {
+			return nil, err
 		}
 		errs = multierror.Append(errs, err)
 	}

--- a/engine/common/rpc/errors.go
+++ b/engine/common/rpc/errors.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/onflow/flow-go/storage"
 )
 
@@ -23,4 +24,50 @@ func ConvertStorageError(err error) error {
 	}
 
 	return status.Errorf(codes.Internal, "failed to find: %v", err)
+}
+
+// ConvertMultiError converts a multierror to a grpc status error.
+// If all of the errors in the multierror have the same code, that code is used, otherwise
+// defaultCode is used.
+func ConvertMultiError(err *multierror.Error, msg string, defaultCode codes.Code) error {
+	allErrors := err.WrappedErrors()
+	if len(allErrors) == 0 {
+		return nil
+	}
+
+	if msg != "" {
+		msg += ": "
+	}
+
+	// get a list of all of status codes
+	allCodes := make(map[codes.Code]struct{})
+	for _, err := range allErrors {
+		allCodes[status.Code(err)] = struct{}{}
+	}
+
+	// if they all match, return that
+	if len(allCodes) == 1 {
+		code := status.Code(allErrors[0])
+		return status.Errorf(code, "%s%v", msg, err)
+	}
+
+	// if they mostly match, ignore Unavailable and DeadlineExceeded since any other code is
+	// more descriptive
+	if len(allCodes) == 2 {
+		if _, ok := allCodes[codes.Unavailable]; ok {
+			delete(allCodes, codes.Unavailable)
+			for code := range allCodes {
+				return status.Errorf(code, "%s%v", msg, err)
+			}
+		}
+		if _, ok := allCodes[codes.DeadlineExceeded]; ok {
+			delete(allCodes, codes.DeadlineExceeded)
+			for code := range allCodes {
+				return status.Errorf(code, "%s%v", msg, err)
+			}
+		}
+	}
+
+	// otherwise, return the default code
+	return status.Errorf(defaultCode, "%s%v", msg, err)
 }

--- a/engine/common/rpc/errors.go
+++ b/engine/common/rpc/errors.go
@@ -3,13 +3,15 @@ package rpc
 import (
 	"errors"
 
+	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/onflow/flow-go/storage"
 )
 
+// ConvertStorageError converts a generic error into a grpc status error, converting storage errors
+// into codes.NotFound
 func ConvertStorageError(err error) error {
 	if err == nil {
 		return nil
@@ -27,8 +29,7 @@ func ConvertStorageError(err error) error {
 }
 
 // ConvertMultiError converts a multierror to a grpc status error.
-// If all of the errors in the multierror have the same code, that code is used, otherwise
-// defaultCode is used.
+// If the errors have related status codes, the common code is returned, otherwise defaultCode is used.
 func ConvertMultiError(err *multierror.Error, msg string, defaultCode codes.Code) error {
 	allErrors := err.WrappedErrors()
 	if len(allErrors) == 0 {

--- a/engine/common/rpc/errors_test.go
+++ b/engine/common/rpc/errors_test.go
@@ -10,22 +10,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestConvertError(t *testing.T) {
-	// tests := map[error]codes.Code{
-	// 	context.Canceled:                          codes.Canceled,
-	// 	context.DeadlineExceeded:                  codes.DeadlineExceeded,
-	// 	storage.ErrNotFound:                       codes.NotFound,
-	// 	status.Error(codes.NotFound, "not found"): codes.NotFound,
-	// 	status.Error(codes.Internal, "internal"):  codes.Internal,
-	// 	status.Error(codes.Unknown, "unknown"):    codes.Unknown,
-	// }
-
-	// for err, expected := range tests {
-	// 	err := status.Err
-
-	// }
-}
-
 func TestConvertMultiError(t *testing.T) {
 	defaultCode := codes.Internal
 	t.Run("same code", func(t *testing.T) {

--- a/engine/common/rpc/errors_test.go
+++ b/engine/common/rpc/errors_test.go
@@ -1,0 +1,81 @@
+package rpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gotest.tools/assert"
+)
+
+func TestConvertError(t *testing.T) {
+	// tests := map[error]codes.Code{
+	// 	context.Canceled:                          codes.Canceled,
+	// 	context.DeadlineExceeded:                  codes.DeadlineExceeded,
+	// 	storage.ErrNotFound:                       codes.NotFound,
+	// 	status.Error(codes.NotFound, "not found"): codes.NotFound,
+	// 	status.Error(codes.Internal, "internal"):  codes.Internal,
+	// 	status.Error(codes.Unknown, "unknown"):    codes.Unknown,
+	// }
+
+	// for err, expected := range tests {
+	// 	err := status.Err
+
+	// }
+}
+
+func TestConvertMultiError(t *testing.T) {
+	defaultCode := codes.Internal
+	t.Run("same code", func(t *testing.T) {
+		var errors *multierror.Error
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+
+		err := ConvertMultiError(errors, "", defaultCode)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("same codes - unavailable ignored", func(t *testing.T) {
+		var errors *multierror.Error
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+		errors = multierror.Append(errors, status.Error(codes.Unavailable, "unavailable"))
+		errors = multierror.Append(errors, status.Error(codes.Unavailable, "unavailable"))
+
+		err := ConvertMultiError(errors, "", defaultCode)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("same codes - deadline exceeded ignored", func(t *testing.T) {
+		var errors *multierror.Error
+		errors = multierror.Append(errors, status.Error(codes.DeadlineExceeded, "deadline exceeded"))
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+
+		err := ConvertMultiError(errors, "", defaultCode)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("all different codes", func(t *testing.T) {
+		var errors *multierror.Error
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+		errors = multierror.Append(errors, status.Error(codes.Internal, "internal"))
+		errors = multierror.Append(errors, status.Error(codes.InvalidArgument, "invalid arg"))
+
+		err := ConvertMultiError(errors, "", defaultCode)
+		assert.Equal(t, defaultCode, status.Code(err))
+	})
+
+	t.Run("non-grpc errors", func(t *testing.T) {
+		var errors *multierror.Error
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+		errors = multierror.Append(errors, fmt.Errorf("not a grpc status code"))
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+
+		err := ConvertMultiError(errors, "some prefix", defaultCode)
+		assert.Equal(t, defaultCode, status.Code(err))
+		assert.ErrorContains(t, err, "some prefix: ")
+	})
+}

--- a/engine/common/rpc/errors_test.go
+++ b/engine/common/rpc/errors_test.go
@@ -12,6 +12,14 @@ import (
 
 func TestConvertMultiError(t *testing.T) {
 	defaultCode := codes.Internal
+	t.Run("single error", func(t *testing.T) {
+		var errors *multierror.Error
+		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))
+
+		err := ConvertMultiError(errors, "", defaultCode)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
 	t.Run("same code", func(t *testing.T) {
 		var errors *multierror.Error
 		errors = multierror.Append(errors, status.Error(codes.NotFound, "not found"))

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -267,13 +267,13 @@ func (h *handler) GetTransactionResult(
 	reqBlockID := req.GetBlockId()
 	blockID, err := convert.BlockID(reqBlockID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid blockID: %v", err)
 	}
 
 	reqTxID := req.GetTransactionId()
 	txID, err := convert.TransactionID(reqTxID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid transactionID: %v", err)
 	}
 
 	var statusCode uint32 = 0
@@ -329,7 +329,7 @@ func (h *handler) GetTransactionResultByIndex(
 	reqBlockID := req.GetBlockId()
 	blockID, err := convert.BlockID(reqBlockID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid blockID: %v", err)
 	}
 
 	index := req.GetIndex()
@@ -387,7 +387,7 @@ func (h *handler) GetTransactionResultsByBlockID(
 	reqBlockID := req.GetBlockId()
 	blockID, err := convert.BlockID(reqBlockID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid blockID: %v", err)
 	}
 
 	// Get all tx results
@@ -483,15 +483,18 @@ func (h *handler) GetAccountAtBlockID(
 	blockID := req.GetBlockId()
 	blockFlowID, err := convert.BlockID(blockID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid blockID: %v", err)
 	}
 
 	flowAddress, err := convert.Address(req.GetAddress(), h.chain.Chain())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid address: %v", err)
 	}
 
 	value, err := h.engine.GetAccount(ctx, flowAddress, blockFlowID)
+	if errors.Is(err, storage.ErrNotFound) {
+		return nil, status.Errorf(codes.NotFound, "account with address %s not found", flowAddress)
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get account: %v", err)
 	}


### PR DESCRIPTION
This PR improves the error reporting for requests that are proxied to Execution nodes. This is accomplished using a new method `rpc.ConvertMultiError` which accepts a `multierror` and returns a `grpc.Status` wrapped error. This uses the following logic:
* If all errors have the same status code, use it
* If there are 2 different codes, and one is either `Unavailable` or `DeadlineExceeded`, use the other code
* In all other cases, return the default code

It also makes a few general improvements:
* Replaces several generic errors with `codes.Internal` (instead of the default `codes.Unknown`)
* Adds specific codes in several places where none were added before (`codes.InvalidArgument` or `codes.NotFound`)