### PR TITLE
Pass config from runtime-pool to the reusable-runtime

### DIFF
--- a/fvm/executionParameters_test.go
+++ b/fvm/executionParameters_test.go
@@ -34,7 +34,9 @@ func TestGetExecutionMemoryWeights(t *testing.T) {
 			reusableRuntime.NewReusableCadenceRuntime(
 				&testutil.TestInterpreterRuntime{
 					ReadStoredFunc: readStored,
-				}))
+				},
+				runtime.Config{},
+			))
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}
@@ -161,7 +163,9 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 			reusableRuntime.NewReusableCadenceRuntime(
 				&testutil.TestInterpreterRuntime{
 					ReadStoredFunc: readStored,
-				}))
+				},
+				runtime.Config{},
+			))
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}

--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -45,10 +45,10 @@ type ReusableCadenceRuntime struct {
 	fvmEnv Environment
 }
 
-func NewReusableCadenceRuntime(rt runtime.Runtime) *ReusableCadenceRuntime {
+func NewReusableCadenceRuntime(rt runtime.Runtime, config runtime.Config) *ReusableCadenceRuntime {
 	reusable := &ReusableCadenceRuntime{
 		Runtime:     rt,
-		Environment: runtime.NewBaseInterpreterEnvironment(runtime.Config{}),
+		Environment: runtime.NewBaseInterpreterEnvironment(config),
 	}
 
 	setAccountFrozen := stdlib.StandardLibraryValue{
@@ -242,7 +242,9 @@ func (pool ReusableCadenceRuntimePool) Borrow(
 		reusable = NewReusableCadenceRuntime(
 			WrappedCadenceRuntime{
 				pool.newRuntime(),
-			})
+			},
+			pool.config,
+		)
 	}
 
 	reusable.SetFvmEnvironment(fvmEnv)


### PR DESCRIPTION
Fixes the issue where the `AccountLinkingEnabled` set at FVM is not getting passed to the Cadence interpreter and checker.