### PR TITLE
Enable Account Linking - Fix

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -465,7 +465,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithReusableCadenceRuntimePool(
 				reusableRuntime.NewCustomReusableCadenceRuntimePool(
 					0,
-					chainID,
 					func() runtime.Runtime {
 						return emittingRuntime
 					})))
@@ -556,7 +555,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithReusableCadenceRuntimePool(
 				reusableRuntime.NewCustomReusableCadenceRuntimePool(
 					0,
-					execCtx.Chain.ChainID(),
 					func() runtime.Runtime {
 						return rt
 					})))
@@ -660,7 +658,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			fvm.WithReusableCadenceRuntimePool(
 				reusableRuntime.NewCustomReusableCadenceRuntimePool(
 					0,
-					execCtx.Chain.ChainID(),
 					func() runtime.Runtime {
 						return rt
 					})))

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -125,8 +125,9 @@ func New(
 				ReusableCadenceRuntimePoolSize,
 				runtime.Config{
 					TracingEnabled: params.CadenceTracing,
+					// AccountLinking is enabled everywhere except on mainnet
+					AccountLinkingEnabled: chainID != flow.Mainnet,
 				},
-				chainID,
 			),
 		),
 	}

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -117,7 +117,7 @@ func BenchmarkComputeBlock(b *testing.B) {
 			reusableRuntime.NewReusableCadenceRuntimePool(
 				ReusableCadenceRuntimePoolSize,
 				runtime.Config{},
-				chainID)),
+			)),
 	)
 	ledger := testutil.RootBootstrappedLedger(
 		vm,

--- a/fvm/environment/env.go
+++ b/fvm/environment/env.go
@@ -102,12 +102,11 @@ type EnvironmentParams struct {
 }
 
 func DefaultEnvironmentParams() EnvironmentParams {
-	const chainID = flow.Mainnet
 	return EnvironmentParams{
-		Chain:                 chainID.Chain(),
+		Chain:                 flow.Mainnet.Chain(),
 		ServiceAccountEnabled: true,
 
-		RuntimeParams:         DefaultRuntimeParams(chainID),
+		RuntimeParams:         DefaultRuntimeParams(),
 		TracerParams:          DefaultTracerParams(),
 		ProgramLoggerParams:   DefaultProgramLoggerParams(),
 		EventEmitterParams:    DefaultEventEmitterParams(),

--- a/fvm/environment/runtime.go
+++ b/fvm/environment/runtime.go
@@ -4,19 +4,17 @@ import (
 	cadenceRuntime "github.com/onflow/cadence/runtime"
 
 	"github.com/onflow/flow-go/fvm/runtime"
-	"github.com/onflow/flow-go/model/flow"
 )
 
 type RuntimeParams struct {
 	runtime.ReusableCadenceRuntimePool
 }
 
-func DefaultRuntimeParams(chainID flow.ChainID) RuntimeParams {
+func DefaultRuntimeParams() RuntimeParams {
 	return RuntimeParams{
 		ReusableCadenceRuntimePool: runtime.NewReusableCadenceRuntimePool(
 			0,
 			cadenceRuntime.Config{},
-			chainID,
 		),
 	}
 }

--- a/fvm/environment/system_contracts_test.go
+++ b/fvm/environment/system_contracts_test.go
@@ -56,7 +56,6 @@ func TestSystemContractsInvoke(t *testing.T) {
 			tracer := environment.NewTracer(environment.DefaultTracerParams())
 			runtimePool := reusableRuntime.NewCustomReusableCadenceRuntimePool(
 				0,
-				flow.Emulator,
 				func() runtime.Runtime {
 					return &testutil.TestInterpreterRuntime{
 						InvokeContractFunc: tc.contractFunction,

--- a/fvm/executionParameters_test.go
+++ b/fvm/executionParameters_test.go
@@ -34,7 +34,9 @@ func TestGetExecutionMemoryWeights(t *testing.T) {
 			reusableRuntime.NewReusableCadenceRuntime(
 				&testutil.TestInterpreterRuntime{
 					ReadStoredFunc: readStored,
-				}))
+				},
+				runtime.Config{},
+			))
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}
@@ -161,7 +163,9 @@ func TestGetExecutionEffortWeights(t *testing.T) {
 			reusableRuntime.NewReusableCadenceRuntime(
 				&testutil.TestInterpreterRuntime{
 					ReadStoredFunc: readStored,
-				}))
+				},
+				runtime.Config{},
+			))
 		envMock.On("ReturnCadenceRuntime", mock.Anything).Return()
 		return envMock
 	}

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -160,7 +160,6 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 			reusableRuntime.NewReusableCadenceRuntimePool(
 				computation.ReusableCadenceRuntimePoolSize,
 				runtime.Config{},
-				chain.ChainID(),
 			),
 		),
 	}

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/flow-go/fvm/environment"
 	errors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
+	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/fvm/utils"
 	"github.com/onflow/flow-go/model/flow"
@@ -68,17 +69,18 @@ func (vmt vmTest) run(
 	f func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData),
 ) func(t *testing.T) {
 	return func(t *testing.T) {
-		chain, vm := createChainAndVm(flow.Testnet)
 		derivedBlockData := derived.NewEmptyDerivedBlockData()
 
 		baseOpts := []fvm.Option{
-			fvm.WithChain(chain),
+			// default chain is Testnet
+			fvm.WithChain(flow.Testnet.Chain()),
 			fvm.WithDerivedBlockData(derivedBlockData),
 		}
-
 		opts := append(baseOpts, vmt.contextOptions...)
-
 		ctx := fvm.NewContext(opts...)
+
+		chain := ctx.Chain
+		vm := fvm.NewVirtualMachine()
 
 		view := utils.NewSimpleView()
 
@@ -100,16 +102,17 @@ func (vmt vmTest) run(
 func (vmt vmTest) bootstrapWith(
 	bootstrap func(vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) error,
 ) (bootstrappedVmTest, error) {
-	chain, vm := createChainAndVm(flow.Testnet)
 
 	baseOpts := []fvm.Option{
-		fvm.WithChain(chain),
+		// default chain is Testnet
+		fvm.WithChain(flow.Testnet.Chain()),
 	}
 
 	opts := append(baseOpts, vmt.contextOptions...)
-
 	ctx := fvm.NewContext(opts...)
 
+	chain := ctx.Chain
+	vm := fvm.NewVirtualMachine()
 	view := utils.NewSimpleView()
 
 	baseBootstrapOpts := []fvm.BootstrapProcedureOption{
@@ -117,7 +120,6 @@ func (vmt vmTest) bootstrapWith(
 	}
 
 	derivedBlockData := derived.NewEmptyDerivedBlockData()
-
 	bootstrapOpts := append(baseBootstrapOpts, vmt.bootstrapOptions...)
 
 	err := vm.Run(ctx, fvm.Bootstrap(unittest.ServiceAccountPublicKey, bootstrapOpts...), view)
@@ -2219,40 +2221,69 @@ func TestScriptIterationShouldNotHitsParseRestrictions(t *testing.T) {
 }
 
 func TestAuthAccountCapabilities(t *testing.T) {
+	test := func(t *testing.T, linkingEnabled bool) {
+		newVMTest().
+			withBootstrapProcedureOptions().
+			withContextOptions(
+				fvm.WithReusableCadenceRuntimePool(
+					reusableRuntime.NewReusableCadenceRuntimePool(
+						1,
+						runtime.Config{
+							AccountLinkingEnabled: linkingEnabled,
+						},
+					),
+				),
+			).
+			run(
+				func(
+					t *testing.T,
+					vm *fvm.VirtualMachine,
+					chain flow.Chain,
+					ctx fvm.Context,
+					view state.View,
+					derivedBlockData *derived.DerivedBlockData,
+				) {
+					// Create an account private key.
+					privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
+					privateKey := privateKeys[0]
+					require.NoError(t, err)
 
-	// TODO: Need a way to pass the chainID down.
-	// 	Or a way to override `config.AccountLinkingEnabled` of `ReusableCadenceRuntimePool` from within the test.
+					// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
+					accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+					require.NoError(t, err)
+					account := accounts[0]
 
-	newVMTest().run(
-		func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
-			// Create an account private key.
-			privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
-			privateKey := privateKeys[0]
-			require.NoError(t, err)
+					txBody := flow.NewTransactionBody().SetScript([]byte(`
+					   transaction {
+						   prepare(acct: AuthAccount) {
+							   acct.linkAccount(/public/foo)
+						   }
+					   }
+					`)).
+						AddAuthorizer(account).
+						SetPayer(chain.ServiceAddress()).
+						SetProposalKey(chain.ServiceAddress(), 0, 0)
 
-			// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-			accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
-			require.NoError(t, err)
-			account := accounts[0]
+					_ = testutil.SignPayload(txBody, account, privateKey)
+					_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
+					tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
 
-			txBody := flow.NewTransactionBody().SetScript([]byte(`
-               transaction {
-                   prepare(acct: AuthAccount) {
-                       acct.linkAccount(/public/foo)
-                   }
-               }
-            `)).
-				AddAuthorizer(account).
-				SetPayer(chain.ServiceAddress()).
-				SetProposalKey(chain.ServiceAddress(), 0, 0)
+					err = vm.Run(ctx, tx, view)
+					require.NoError(t, err)
+					if linkingEnabled {
+						require.NoError(t, tx.Err)
+					} else {
+						require.Error(t, tx.Err)
+					}
+				},
+			)(t)
+	}
 
-			_ = testutil.SignPayload(txBody, account, privateKey)
-			_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
-			tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+	t.Run("linking enabled", func(t *testing.T) {
+		test(t, true)
+	})
+	t.Run("linking disabled", func(t *testing.T) {
+		test(t, false)
+	})
 
-			err = vm.Run(ctx, tx, view)
-			require.NoError(t, err)
-			require.NoError(t, tx.Err)
-		},
-	)(t)
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2217,3 +2217,42 @@ func TestScriptIterationShouldNotHitsParseRestrictions(t *testing.T) {
 			require.NoError(t, err)
 		})(t)
 }
+
+func TestAuthAccountCapabilities(t *testing.T) {
+
+	// TODO: Need a way to pass the chainID down.
+	// 	Or a way to override `config.AccountLinkingEnabled` of `ReusableCadenceRuntimePool` from within the test.
+
+	newVMTest().run(
+		func(t *testing.T, vm *fvm.VirtualMachine, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			// Create an account private key.
+			privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
+			privateKey := privateKeys[0]
+			require.NoError(t, err)
+
+			// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
+			accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+			require.NoError(t, err)
+			account := accounts[0]
+
+			txBody := flow.NewTransactionBody().SetScript([]byte(`
+               transaction {
+                   prepare(acct: AuthAccount) {
+                       acct.linkAccount(/public/foo)
+                   }
+               }
+            `)).
+				AddAuthorizer(account).
+				SetPayer(chain.ServiceAddress()).
+				SetProposalKey(chain.ServiceAddress(), 0, 0)
+
+			_ = testutil.SignPayload(txBody, account, privateKey)
+			_ = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
+			tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+
+			err = vm.Run(ctx, tx, view)
+			require.NoError(t, err)
+			require.NoError(t, tx.Err)
+		},
+	)(t)
+}

--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -9,7 +9,6 @@ import (
 	"github.com/onflow/cadence/runtime/stdlib"
 
 	"github.com/onflow/flow-go/fvm/errors"
-	"github.com/onflow/flow-go/model/flow"
 )
 
 // Note: this is a subset of environment.Environment, redeclared to handle
@@ -180,16 +179,12 @@ type ReusableCadenceRuntimePool struct {
 func newReusableCadenceRuntimePool(
 	poolSize int,
 	config runtime.Config,
-	chainID flow.ChainID,
 	newCustomRuntime func() runtime.Runtime,
 ) ReusableCadenceRuntimePool {
 	var pool chan *ReusableCadenceRuntime
 	if poolSize > 0 {
 		pool = make(chan *ReusableCadenceRuntime, poolSize)
 	}
-
-	// Enable account linking on all networks except Mainnet
-	config.AccountLinkingEnabled = chainID != flow.Mainnet
 
 	return ReusableCadenceRuntimePool{
 		pool:             pool,
@@ -201,25 +196,21 @@ func newReusableCadenceRuntimePool(
 func NewReusableCadenceRuntimePool(
 	poolSize int,
 	config runtime.Config,
-	chainID flow.ChainID,
 ) ReusableCadenceRuntimePool {
 	return newReusableCadenceRuntimePool(
 		poolSize,
 		config,
-		chainID,
 		nil,
 	)
 }
 
 func NewCustomReusableCadenceRuntimePool(
 	poolSize int,
-	chainID flow.ChainID,
 	newCustomRuntime func() runtime.Runtime,
 ) ReusableCadenceRuntimePool {
 	return newReusableCadenceRuntimePool(
 		poolSize,
 		runtime.Config{},
-		chainID,
 		newCustomRuntime,
 	)
 }

--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -45,10 +45,10 @@ type ReusableCadenceRuntime struct {
 	fvmEnv Environment
 }
 
-func NewReusableCadenceRuntime(rt runtime.Runtime) *ReusableCadenceRuntime {
+func NewReusableCadenceRuntime(rt runtime.Runtime, config runtime.Config) *ReusableCadenceRuntime {
 	reusable := &ReusableCadenceRuntime{
 		Runtime:     rt,
-		Environment: runtime.NewBaseInterpreterEnvironment(runtime.Config{}),
+		Environment: runtime.NewBaseInterpreterEnvironment(config),
 	}
 
 	setAccountFrozen := stdlib.StandardLibraryValue{
@@ -242,7 +242,9 @@ func (pool ReusableCadenceRuntimePool) Borrow(
 		reusable = NewReusableCadenceRuntime(
 			WrappedCadenceRuntime{
 				pool.newRuntime(),
-			})
+			},
+			pool.config,
+		)
 	}
 
 	reusable.SetFvmEnvironment(fvmEnv)

--- a/fvm/runtime/reusable_cadence_runtime_test.go
+++ b/fvm/runtime/reusable_cadence_runtime_test.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/stretchr/testify/require"
-
-	"github.com/onflow/flow-go/model/flow"
 )
 
-func TestReusableCadanceRuntimePoolUnbuffered(t *testing.T) {
-	pool := NewReusableCadenceRuntimePool(0, runtime.Config{}, flow.Emulator)
+func TestReusableCadenceRuntimePoolUnbuffered(t *testing.T) {
+	pool := NewReusableCadenceRuntimePool(0, runtime.Config{})
 	require.Nil(t, pool.pool)
 
 	entry := pool.Borrow(nil)
@@ -24,8 +22,8 @@ func TestReusableCadanceRuntimePoolUnbuffered(t *testing.T) {
 	require.NotSame(t, entry, entry2)
 }
 
-func TestReusableCadanceRuntimePoolBuffered(t *testing.T) {
-	pool := NewReusableCadenceRuntimePool(100, runtime.Config{}, flow.Emulator)
+func TestReusableCadenceRuntimePoolBuffered(t *testing.T) {
+	pool := NewReusableCadenceRuntimePool(100, runtime.Config{})
 	require.NotNil(t, pool.pool)
 
 	select {
@@ -51,8 +49,8 @@ func TestReusableCadanceRuntimePoolBuffered(t *testing.T) {
 	require.Same(t, entry, entry2)
 }
 
-func TestReusableCadanceRuntimePoolSharing(t *testing.T) {
-	pool := NewReusableCadenceRuntimePool(100, runtime.Config{}, flow.Emulator)
+func TestReusableCadenceRuntimePoolSharing(t *testing.T) {
+	pool := NewReusableCadenceRuntimePool(100, runtime.Config{})
 	require.NotNil(t, pool.pool)
 
 	select {


### PR DESCRIPTION
Based on @SupunS's PR https://github.com/onflow/flow-go/pull/3918


Only the manager, which sets up the VM Context (and thus the cadence runtime Config)  for scripts and transactions, needs to have the account linking check enabled:

```go
// see: engine/execution/computation/manager.go
// AccountLinking is enabled everywhere except on mainnet
AccountLinkingEnabled: chainID != flow.Mainnet,
```