### PR TITLE
[Engine] Move weight check out of common provider engine

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -404,7 +404,10 @@ func main() {
 				collectionRequestQueue,
 				collectionProviderWorkers,
 				channels.ProvideCollections,
-				filter.HasRole(flow.RoleAccess, flow.RoleExecution),
+				filter.And(
+					filter.HasWeight(true),
+					filter.HasRole(flow.RoleAccess, flow.RoleExecution),
+				),
 				retrieve,
 			)
 		}).

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -968,7 +968,10 @@ func (exeNode *ExecutionNode) LoadReceiptProviderEngine(
 		receiptRequestQueue,
 		exeNode.exeConf.receiptRequestWorkers,
 		channels.ProvideReceiptsByBlockID,
-		filter.HasRole(flow.RoleConsensus),
+		filter.And(
+			filter.HasWeight(true),
+			filter.HasRole(flow.RoleConsensus),
+		),
 		retrieve,
 	)
 	return eng, err

--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -78,7 +78,6 @@ func New(
 	// make sure we don't respond to request sent by self or unauthorized nodes
 	selector = filter.And(
 		selector,
-		filter.HasWeight(true),
 		filter.Not(filter.HasNodeID(me.NodeID())),
 	)
 


### PR DESCRIPTION
See @jordanschalm's comment here for context: https://github.com/onflow/flow-go/pull/3880#discussion_r1090883044

Move the `HasWeight` identity check out of the common provider engine, and explicitly pass it in when instantiating. The `provider` is a generic engine and some usecases may need to support nodes from past/future epochs.