### PR TITLE
Change delta view to read from StorageSnapshot interface instead of readFunc

### DIFF
--- a/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
+++ b/cmd/util/cmd/read-execution-state/list-accounts/cmd.go
@@ -75,28 +75,31 @@ func run(*cobra.Command, []string) {
 		log.Fatal().Err(err).Msgf("invalid chain name")
 	}
 
-	ldg := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
+	ldg := delta.NewDeltaView(delta.NewReadFuncStorageSnapshot(
+		func(id flow.RegisterID) (flow.RegisterValue, error) {
 
-		ledgerKey := executionState.RegisterIDToKey(id)
-		path, err := pathfinder.KeyToPath(ledgerKey, complete.DefaultPathFinderVersion)
-		if err != nil {
-			log.Fatal().Err(err).Msgf("cannot convert key to path")
-		}
+			ledgerKey := executionState.RegisterIDToKey(id)
+			path, err := pathfinder.KeyToPath(
+				ledgerKey,
+				complete.DefaultPathFinderVersion)
+			if err != nil {
+				log.Fatal().Err(err).Msgf("cannot convert key to path")
+			}
 
-		read := &ledger.TrieRead{
-			RootHash: ledger.RootHash(stateCommitment),
-			Paths: []ledger.Path{
-				path,
-			},
-		}
+			read := &ledger.TrieRead{
+				RootHash: ledger.RootHash(stateCommitment),
+				Paths: []ledger.Path{
+					path,
+				},
+			}
 
-		values, err := forest.Read(read)
-		if err != nil {
-			return nil, err
-		}
+			values, err := forest.Read(read)
+			if err != nil {
+				return nil, err
+			}
 
-		return values[0], nil
-	})
+			return values[0], nil
+		}))
 
 	txnState := state.NewTransactionState(ldg, state.DefaultParameters())
 	accounts := environment.NewAccounts(txnState)

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -935,9 +935,7 @@ func Test_AccountStatusRegistersAreIncluded(t *testing.T) {
 	key, err := unittest.AccountKeyDefaultFixture()
 	require.NoError(t, err)
 
-	view := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-		return ledger.Get(id)
-	})
+	view := delta.NewDeltaView(ledger)
 	txnState := state.NewTransactionState(view, state.DefaultParameters())
 	accounts := environment.NewAccounts(txnState)
 
@@ -1074,7 +1072,7 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 	// create empty block, it will have system collection attached while executing
 	block := generateBlock(0, 0, rag)
 
-	view := delta.NewDeltaView(ledger.Get)
+	view := delta.NewDeltaView(ledger)
 
 	result, err := exe.ExecuteBlock(context.Background(), block, view, derived.NewEmptyDerivedBlockData())
 	assert.NoError(t, err)

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -705,7 +705,10 @@ func executeBlockAndVerifyWithParameters(t *testing.T,
 		prov)
 	require.NoError(t, err)
 
-	view := delta.NewDeltaView(state.LedgerGetRegister(ledger, initialCommit))
+	view := delta.NewDeltaView(
+		state.NewLedgerStorageSnapshot(
+			ledger,
+			initialCommit))
 
 	executableBlock := unittest.ExecutableBlockFromTransactions(chain.ChainID(), txs)
 	executableBlock.StartState = &initialCommit

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -166,7 +166,7 @@ func BenchmarkComputeBlock(b *testing.B) {
 		derivedChainData: derivedChainData,
 	}
 
-	view := delta.NewDeltaView(ledger.Get)
+	view := delta.NewDeltaView(ledger)
 	blockView := view.NewChild()
 
 	b.SetParallelism(1)

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -147,7 +147,7 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 		derivedChainData: derivedChainData,
 	}
 
-	view := delta.NewDeltaView(ledger.Get)
+	view := delta.NewDeltaView(ledger)
 	blockView := view.NewChild()
 
 	returnedComputationResult, err := engine.ComputeBlock(context.Background(), executableBlock, blockView)
@@ -258,7 +258,7 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 		derivedChainData: derivedChainData,
 	}
 
-	view := delta.NewDeltaView(ledger.Get)
+	view := delta.NewDeltaView(ledger)
 
 	var (
 		res *execution.ComputationResult

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -36,7 +36,10 @@ func (b *Bootstrapper) BootstrapLedger(
 	chain flow.Chain,
 	opts ...fvm.BootstrapProcedureOption,
 ) (flow.StateCommitment, error) {
-	view := delta.NewDeltaView(state.LedgerGetRegister(ledger, flow.StateCommitment(ledger.InitialState())))
+	view := delta.NewDeltaView(
+		state.NewLedgerStorageSnapshot(
+			ledger,
+			flow.StateCommitment(ledger.InitialState())))
 
 	vm := fvm.NewVirtualMachine()
 

--- a/engine/execution/state/delta/storage_snapshot.go
+++ b/engine/execution/state/delta/storage_snapshot.go
@@ -1,0 +1,51 @@
+package delta
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+)
+
+type StorageSnapshot interface {
+	// Get returns the register id's value, or an empty RegisterValue if the id
+	// is not found.
+	Get(id flow.RegisterID) (flow.RegisterValue, error)
+}
+
+type EmptyStorageSnapshot struct{}
+
+func (EmptyStorageSnapshot) Get(
+	id flow.RegisterID,
+) (
+	flow.RegisterValue,
+	error,
+) {
+	return nil, nil
+}
+
+type ReadFuncStorageSnapshot struct {
+	ReadFunc func(flow.RegisterID) (flow.RegisterValue, error)
+}
+
+func NewReadFuncStorageSnapshot(
+	readFunc func(flow.RegisterID) (flow.RegisterValue, error),
+) StorageSnapshot {
+	return &ReadFuncStorageSnapshot{
+		ReadFunc: readFunc,
+	}
+}
+
+func (storage ReadFuncStorageSnapshot) Get(
+	id flow.RegisterID,
+) (
+	flow.RegisterValue,
+	error,
+) {
+	return storage.ReadFunc(id)
+}
+
+type Peeker interface {
+	Peek(id flow.RegisterID) (flow.RegisterValue, error)
+}
+
+func NewPeekerStorageSnapshot(peeker Peeker) StorageSnapshot {
+	return NewReadFuncStorageSnapshot(peeker.Peek)
+}

--- a/engine/execution/state/delta/view_test.go
+++ b/engine/execution/state/delta/view_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+type testStorage map[flow.RegisterID]string
+
+func (storage testStorage) Get(id flow.RegisterID) (flow.RegisterValue, error) {
+	return flow.RegisterValue(storage[id]), nil
+}
+
 func TestViewGet(t *testing.T) {
 	registerID := flow.NewRegisterID("fruit", "")
 
@@ -23,27 +29,20 @@ func TestViewGet(t *testing.T) {
 	})
 
 	t.Run("ValueNotInCache", func(t *testing.T) {
-		v := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			if id == registerID {
-				return flow.RegisterValue("orange"), nil
-			}
-
-			return nil, nil
-		})
+		v := delta.NewDeltaView(
+			testStorage{
+				registerID: "orange",
+			})
 		b, err := v.Get(registerID)
 		assert.NoError(t, err)
 		assert.Equal(t, flow.RegisterValue("orange"), b)
 	})
 
 	t.Run("ValueInCache", func(t *testing.T) {
-		v := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			if id == registerID {
-				return flow.RegisterValue("orange"), nil
-			}
-
-			return nil, nil
-		})
-
+		v := delta.NewDeltaView(
+			testStorage{
+				registerID: "orange",
+			})
 		err := v.Set(registerID, flow.RegisterValue("apple"))
 		assert.NoError(t, err)
 
@@ -56,7 +55,7 @@ func TestViewGet(t *testing.T) {
 func TestViewSet(t *testing.T) {
 	registerID := flow.NewRegisterID("fruit", "")
 
-	v := delta.NewDeltaView(delta.AlwaysEmptyGetRegisterFunc)
+	v := delta.NewDeltaView(nil)
 
 	err := v.Set(registerID, flow.RegisterValue("apple"))
 	assert.NoError(t, err)
@@ -324,18 +323,11 @@ func TestView_RegisterTouches(t *testing.T) {
 	})
 
 	t.Run("Set and Get", func(t *testing.T) {
-		v := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			if id == registerID1 {
-				return flow.RegisterValue("orange"), nil
-			}
-
-			if id == registerID2 {
-				return flow.RegisterValue("carrot"), nil
-			}
-
-			return nil, nil
-		})
-
+		v := delta.NewDeltaView(
+			testStorage{
+				registerID1: "orange",
+				registerID2: "carrot",
+			})
 		_, err := v.Get(registerID1)
 		assert.NoError(t, err)
 
@@ -363,16 +355,11 @@ func TestView_AllRegisterIDs(t *testing.T) {
 	})
 
 	t.Run("Set and Get", func(t *testing.T) {
-		v := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			if id == idA {
-				return flow.RegisterValue("a_value"), nil
-			}
-
-			if id == idB {
-				return flow.RegisterValue("b_value"), nil
-			}
-			return nil, nil
-		})
+		v := delta.NewDeltaView(
+			testStorage{
+				idA: "a_value",
+				idB: "b_value",
+			})
 
 		_, err := v.Get(idA)
 		assert.NoError(t, err)
@@ -395,16 +382,11 @@ func TestView_AllRegisterIDs(t *testing.T) {
 		assert.Len(t, allRegs, 6)
 	})
 	t.Run("With Merge", func(t *testing.T) {
-		v := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			if id == idA {
-				return flow.RegisterValue("a_value"), nil
-			}
-
-			if id == idB {
-				return flow.RegisterValue("b_value"), nil
-			}
-			return nil, nil
-		})
+		v := delta.NewDeltaView(
+			testStorage{
+				idA: "a_value",
+				idB: "b_value",
+			})
 
 		vv := v.NewChild()
 		_, err := vv.Get(idA)

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -261,7 +261,10 @@ func ExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Chain, refB
 		)
 
 		// create state.View
-		view := delta.NewDeltaView(state.LedgerGetRegister(led, startStateCommitment))
+		view := delta.NewDeltaView(
+			state.NewLedgerStorageSnapshot(
+				led,
+				startStateCommitment))
 		committer := committer.NewLedgerViewCommitter(led, trace.NewNoopTracer())
 		derivedBlockData := derived.NewEmptyDerivedBlockData()
 

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -20,6 +20,20 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+type invalidAccountStatusKeyStorageSnapshot struct{}
+
+func (invalidAccountStatusKeyStorageSnapshot) Get(
+	id flow.RegisterID,
+) (
+	flow.RegisterValue,
+	error,
+) {
+	if id.Key == flow.AccountStatusKey {
+		return nil, fmt.Errorf("error getting register %s", id)
+	}
+	return nil, nil
+}
+
 func createAccount(
 	t *testing.T,
 	vm fvm.VM,
@@ -1310,12 +1324,8 @@ func TestAccountBalanceFields(t *testing.T) {
 					}
 				`, address)))
 
-				view := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-					if id.Key == flow.AccountStatusKey {
-						return nil, fmt.Errorf("error getting register %s", id)
-					}
-					return nil, nil
-				})
+				view := delta.NewDeltaView(
+					invalidAccountStatusKeyStorageSnapshot{})
 
 				err := vm.Run(ctx, script, view)
 				require.ErrorContains(
@@ -1523,12 +1533,8 @@ func TestGetStorageCapacity(t *testing.T) {
 					}
 				`, address)))
 
-				newview := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-					if id.Key == flow.AccountStatusKey {
-						return nil, fmt.Errorf("error getting register %s", id)
-					}
-					return nil, nil
-				})
+				newview := delta.NewDeltaView(
+					invalidAccountStatusKeyStorageSnapshot{})
 
 				err := vm.Run(ctx, script, newview)
 				require.ErrorContains(

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -190,16 +190,17 @@ func Test_Programs(t *testing.T) {
 			derivedBlockData.NextTxIndexForTestingOnly())
 
 		loadedCode := false
-		viewExecA := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			expectedId := flow.ContractRegisterID(
-				flow.BytesToAddress([]byte(id.Owner)),
-				"A")
-			if id == expectedId {
-				loadedCode = true
-			}
+		viewExecA := delta.NewDeltaView(delta.NewReadFuncStorageSnapshot(
+			func(id flow.RegisterID) (flow.RegisterValue, error) {
+				expectedId := flow.ContractRegisterID(
+					flow.BytesToAddress([]byte(id.Owner)),
+					"A")
+				if id == expectedId {
+					loadedCode = true
+				}
 
-			return mainView.Peek(id)
-		})
+				return mainView.Peek(id)
+			}))
 
 		err = vm.Run(context, procCallA, viewExecA)
 		require.NoError(t, err)
@@ -234,15 +235,16 @@ func Test_Programs(t *testing.T) {
 		require.NoError(t, err)
 
 		// execute transaction again, this time make sure it doesn't load code
-		viewExecA2 := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			notId := flow.ContractRegisterID(
-				flow.BytesToAddress([]byte(id.Owner)),
-				"A")
-			// this time we fail if a read of code occurs
-			require.NotEqual(t, id, notId)
+		viewExecA2 := delta.NewDeltaView(delta.NewReadFuncStorageSnapshot(
+			func(id flow.RegisterID) (flow.RegisterValue, error) {
+				notId := flow.ContractRegisterID(
+					flow.BytesToAddress([]byte(id.Owner)),
+					"A")
+				// this time we fail if a read of code occurs
+				require.NotEqual(t, id, notId)
 
-			return mainView.Peek(id)
-		})
+				return mainView.Peek(id)
+			}))
 
 		procCallA = fvm.Transaction(
 			callTx("A", addressA),
@@ -295,7 +297,8 @@ func Test_Programs(t *testing.T) {
 			callTx("B", addressB),
 			derivedBlockData.NextTxIndexForTestingOnly())
 
-		viewExecB = delta.NewDeltaView(mainView.Peek)
+		viewExecB = delta.NewDeltaView(
+			delta.NewPeekerStorageSnapshot(mainView))
 
 		err = vm.Run(context, procCallB, viewExecB)
 		require.NoError(t, err)
@@ -348,19 +351,20 @@ func Test_Programs(t *testing.T) {
 		// rerun transaction
 
 		// execute transaction again, this time make sure it doesn't load code
-		viewExecB2 := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			idA := flow.ContractRegisterID(
-				flow.BytesToAddress([]byte(id.Owner)),
-				"A")
-			idB := flow.ContractRegisterID(
-				flow.BytesToAddress([]byte(id.Owner)),
-				"B")
-			// this time we fail if a read of code occurs
-			require.NotEqual(t, id.Key, idA.Key)
-			require.NotEqual(t, id.Key, idB.Key)
+		viewExecB2 := delta.NewDeltaView(delta.NewReadFuncStorageSnapshot(
+			func(id flow.RegisterID) (flow.RegisterValue, error) {
+				idA := flow.ContractRegisterID(
+					flow.BytesToAddress([]byte(id.Owner)),
+					"A")
+				idB := flow.ContractRegisterID(
+					flow.BytesToAddress([]byte(id.Owner)),
+					"B")
+				// this time we fail if a read of code occurs
+				require.NotEqual(t, id.Key, idA.Key)
+				require.NotEqual(t, id.Key, idB.Key)
 
-			return mainView.Peek(id)
-		})
+				return mainView.Peek(id)
+			}))
 
 		procCallB = fvm.Transaction(
 			callTx("B", addressB),
@@ -383,13 +387,14 @@ func Test_Programs(t *testing.T) {
 		// at this point programs cache should contain data for contract A
 		// only because contract B has been called
 
-		viewExecA := delta.NewDeltaView(func(id flow.RegisterID) (flow.RegisterValue, error) {
-			notId := flow.ContractRegisterID(
-				flow.BytesToAddress([]byte(id.Owner)),
-				"A")
-			require.NotEqual(t, id, notId)
-			return mainView.Peek(id)
-		})
+		viewExecA := delta.NewDeltaView(delta.NewReadFuncStorageSnapshot(
+			func(id flow.RegisterID) (flow.RegisterValue, error) {
+				notId := flow.ContractRegisterID(
+					flow.BytesToAddress([]byte(id.Owner)),
+					"A")
+				require.NotEqual(t, id, notId)
+				return mainView.Peek(id)
+			}))
 
 		// run a TX using contract A
 		procCallA := fvm.Transaction(
@@ -435,7 +440,8 @@ func Test_Programs(t *testing.T) {
 			callTx("C", addressC),
 			derivedBlockData.NextTxIndexForTestingOnly())
 
-		viewExecC := delta.NewDeltaView(mainView.Peek)
+		viewExecC := delta.NewDeltaView(
+			delta.NewPeekerStorageSnapshot(mainView))
 
 		err = vm.Run(context, procCallC, viewExecC)
 		require.NoError(t, err)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -226,7 +226,8 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 		prov)
 	require.NoError(tb, err)
 
-	view := delta.NewDeltaView(exeState.LedgerGetRegister(ledger, initialCommit))
+	view := delta.NewDeltaView(
+		exeState.NewLedgerStorageSnapshot(ledger, initialCommit))
 
 	derivedChainData, err := derived.NewDerivedChainData(
 		derived.DefaultDerivedDataCacheSize)

--- a/ledger/partial/ledger_test.go
+++ b/ledger/partial/ledger_test.go
@@ -119,7 +119,10 @@ func TestProofsForEmptyRegisters(t *testing.T) {
 	// create empty update
 	emptyState := l.InitialState()
 
-	view := delta.NewDeltaView(executionState.LedgerGetRegister(l, flow.StateCommitment(emptyState)))
+	view := delta.NewDeltaView(
+		executionState.NewLedgerStorageSnapshot(
+			l,
+			flow.StateCommitment(emptyState)))
 
 	registerID := flow.NewRegisterID("b", "nk")
 

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -91,6 +91,34 @@ func (fcv *ChunkVerifier) Verify(
 		vc.IsSystemChunk)
 }
 
+type partialLedgerStorageSnapshot struct {
+	snapshot delta.StorageSnapshot
+
+	unknownRegTouch map[flow.RegisterID]struct{}
+}
+
+func (storage *partialLedgerStorageSnapshot) Get(
+	id flow.RegisterID,
+) (
+	flow.RegisterValue,
+	error,
+) {
+	value, err := storage.snapshot.Get(id)
+	if err != nil && errors.Is(err, ledger.ErrMissingKeys{}) {
+		storage.unknownRegTouch[id] = struct{}{}
+
+		// don't send error just return empty byte slice
+		// we always assume empty value for missing registers (which might
+		// cause the transaction to fail)
+		// but after execution we check unknownRegTouch and if any
+		// register is inside it, code won't generate approvals and
+		// it activates a challenge
+		return flow.RegisterValue{}, nil
+	}
+
+	return value, err
+}
+
 func (fcv *ChunkVerifier) verifyTransactionsInContext(
 	context fvm.Context,
 	transactionOffset uint32,
@@ -125,7 +153,11 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 
 	if err != nil {
 		// TODO provide more details based on the error type
-		return nil, chmodels.NewCFInvalidVerifiableChunk("error constructing partial trie: ", err, chIndex, execResID),
+		return nil, chmodels.NewCFInvalidVerifiableChunk(
+				"error constructing partial trie: ",
+				err,
+				chIndex,
+				execResID),
 			nil
 	}
 
@@ -138,41 +170,16 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 	// chunk view construction
 	// unknown register tracks access to parts of the partial trie which
 	// are not expanded and values are unknown.
-	unknownRegTouch := make(map[flow.RegisterID]*ledger.Key)
+	unknownRegTouch := make(map[flow.RegisterID]struct{})
+	chunkView := delta.NewDeltaView(
+		&partialLedgerStorageSnapshot{
+			snapshot: executionState.NewLedgerStorageSnapshot(
+				psmt,
+				chunkDataPack.StartState),
+			unknownRegTouch: unknownRegTouch,
+		})
+
 	var problematicTx flow.Identifier
-	getRegister := func(registerID flow.RegisterID) (flow.RegisterValue, error) {
-		registerKey := executionState.RegisterIDToKey(registerID)
-
-		query, err := ledger.NewQuerySingleValue(ledger.State(chunkDataPack.StartState), registerKey)
-
-		if err != nil {
-			return nil, fmt.Errorf("cannot create query: %w", err)
-		}
-
-		value, err := psmt.GetSingleValue(query)
-		if err != nil {
-			if errors.Is(err, ledger.ErrMissingKeys{}) {
-
-				unknownRegTouch[registerID] = &registerKey
-
-				// don't send error just return empty byte slice
-				// we always assume empty value for missing registers (which might cause the transaction to fail)
-				// but after execution we check unknownRegTouch and if any
-				// register is inside it, code won't generate approvals and
-				// it activates a challenge
-
-				return []byte{}, nil
-			}
-			// append to missing keys if error is ErrMissingKeys
-
-			return nil, fmt.Errorf("cannot query register: %w", err)
-		}
-
-		return value, nil
-	}
-
-	chunkView := delta.NewDeltaView(getRegister)
-
 	// executes all transactions in this chunk
 	for i, tx := range transactions {
 		txView := chunkView.NewChild()
@@ -201,8 +208,8 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 	// check read access to unknown registers
 	if len(unknownRegTouch) > 0 {
 		var missingRegs []string
-		for _, key := range unknownRegTouch {
-			missingRegs = append(missingRegs, key.String())
+		for id := range unknownRegTouch {
+			missingRegs = append(missingRegs, id.String())
 		}
 		return nil, chmodels.NewCFMissingRegisterTouch(missingRegs, chIndex, execResID, problematicTx), nil
 	}


### PR DESCRIPTION
This enables us to compose storage snapshot implementations (e.g., chunk verifer's partial ledger) and allow us to add batch read support in the future.