### PR TITLE
[`v0.29`] Remove requirement that `weight > 0` in `EpochSetup` validation

### DIFF
--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -86,14 +86,6 @@ func verifyEpochSetup(setup *flow.EpochSetup, verifyNetworkAddress bool) error {
 		}
 	}
 
-	// there should be no nodes with zero weight
-	// TODO: we might want to remove the following as we generally want to allow nodes with zero weight in the protocol state.
-	for _, participant := range setup.Participants {
-		if participant.Weight == 0 {
-			return fmt.Errorf("node with zero weight (%x)", participant.NodeID)
-		}
-	}
-
 	// the participants must be listed in canonical order
 	if !setup.Participants.Sorted(order.Canonical) {
 		return fmt.Errorf("participants are not canonically ordered")


### PR DESCRIPTION
Backport of https://github.com/onflow/flow-go/pull/3934

> This PR removes the requirement that included nodes have non-zero weight, from `EpochSetup` service event validation. 
> 
> This requirement, in combination with a Staking contract bug, caused EECC to be triggered on Mainnet Feb 15.
> 
> Service event validation is intended to ensure that service events contain valid data. Although it was largely working as designed in this case (a service event which had unexpected data due to a bug in the smart contract was rejected), since the protocol state does correctly handle nodes with zero weight already, removing this requirement will safely prevent any similar smart contract problem from triggering EECC in the future. 