### PR TITLE
Ignore Inclusion field when verifying trie proof

### DIFF
--- a/ledger/common/proof/proof.go
+++ b/ledger/common/proof/proof.go
@@ -46,7 +46,7 @@ func VerifyTrieProof(p *ledger.TrieProof, expectedState ledger.State) bool {
 			computed = hash.HashInterNode(computed, siblingHash)
 		}
 	}
-	return (computed == hash.Hash(expectedState)) == p.Inclusion
+	return computed == hash.Hash(expectedState)
 }
 
 // VerifyTrieBatchProof verifies all the proof inside the batchproof

--- a/ledger/complete/mtrie/forest_test.go
+++ b/ledger/complete/mtrie/forest_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
 	prf "github.com/onflow/flow-go/ledger/common/proof"
 	"github.com/onflow/flow-go/ledger/common/testutils"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
@@ -739,6 +740,38 @@ func TestIdenticalUpdateAppliedTwice(t *testing.T) {
 	for i := range paths {
 		require.Equal(t, retValuesB[i], payloads[i].Value())
 	}
+}
+
+func TestNonExistingInvalidProof(t *testing.T) {
+	forest, err := NewForest(5, &metrics.NoopCollector{}, nil)
+	require.NoError(t, err)
+	paths := testutils.RandomPaths(2)
+	payloads := testutils.RandomPayloads(len(paths), 10, 20)
+
+	existingPaths := paths[1:]
+	existingPayloads := payloads[1:]
+
+	nonExistingPaths := paths[:1]
+
+	activeRoot := forest.GetEmptyRootHash()
+
+	// adding a payload to a path
+	update := &ledger.TrieUpdate{RootHash: activeRoot, Paths: existingPaths, Payloads: existingPayloads}
+	activeRoot, err = forest.Update(update)
+	require.NoError(t, err, "error updating")
+
+	// reading proof for nonExistingPaths
+	read := &ledger.TrieRead{RootHash: activeRoot, Paths: nonExistingPaths}
+	batchProof, err := forest.Proofs(read)
+	require.NoError(t, err, "error generating proofs")
+
+	// now a malicious node modifies the proof to be Inclusion false
+	// and change the proof such that one interim node has invalid hash
+	batchProof.Proofs[0].Inclusion = false
+	batchProof.Proofs[0].Interims[0] = hash.DummyHash
+
+	// expect the VerifyTrieBatchProof should return false
+	require.False(t, prf.VerifyTrieBatchProof(batchProof, ledger.State(activeRoot)))
 }
 
 // TestRandomUpdateReadProofValueSizes repeats a sequence of actions update, read, get value sizes, and proof random paths


### PR DESCRIPTION
The exclusion proof for a path is created by adding an empty payload to the trie without pruning, and then creating an inclusion proof for the empty payload on the given non-existing path. Therefore, the "Inclusion" field is not needed for verifying the trie proof, removing it. 