### PR TITLE
Amortize derived data validation cost

### DIFF
--- a/fvm/derived/table_invalidator.go
+++ b/fvm/derived/table_invalidator.go
@@ -23,12 +23,12 @@ type tableInvalidatorAtTime[TKey comparable, TVal any] struct {
 type chainedTableInvalidators[TKey comparable, TVal any] []tableInvalidatorAtTime[TKey, TVal]
 
 func (chained chainedTableInvalidators[TKey, TVal]) ApplicableInvalidators(
-	snapshotTime LogicalTime,
+	toValidateTime LogicalTime,
 ) chainedTableInvalidators[TKey, TVal] {
 	// NOTE: switch to bisection search (or reverse iteration) if the list
 	// is long.
 	for idx, entry := range chained {
-		if snapshotTime <= entry.executionTime {
+		if toValidateTime <= entry.executionTime {
 			return chained[idx:]
 		}
 	}

--- a/fvm/derived/table_invalidator_test.go
+++ b/fvm/derived/table_invalidator_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 type testInvalidator struct {
+	callCount      int
 	invalidateAll  bool
 	invalidateName string
 }
@@ -18,11 +19,12 @@ func (invalidator testInvalidator) ShouldInvalidateEntries() bool {
 		invalidator.invalidateName != ""
 }
 
-func (invalidator testInvalidator) ShouldInvalidateEntry(
+func (invalidator *testInvalidator) ShouldInvalidateEntry(
 	key string,
 	value *string,
 	state *state.State,
 ) bool {
+	invalidator.callCount += 1
 	return invalidator.invalidateAll ||
 		invalidator.invalidateName == key
 }
@@ -38,15 +40,15 @@ func TestChainedInvalidator(t *testing.T) {
 
 	chain = chainedTableInvalidators[string, *string]{
 		{
-			TableInvalidator: testInvalidator{},
+			TableInvalidator: &testInvalidator{},
 			executionTime:    1,
 		},
 		{
-			TableInvalidator: testInvalidator{},
+			TableInvalidator: &testInvalidator{},
 			executionTime:    2,
 		},
 		{
-			TableInvalidator: testInvalidator{},
+			TableInvalidator: &testInvalidator{},
 			executionTime:    3,
 		},
 	}
@@ -54,19 +56,19 @@ func TestChainedInvalidator(t *testing.T) {
 
 	chain = chainedTableInvalidators[string, *string]{
 		{
-			TableInvalidator: testInvalidator{invalidateName: "1"},
+			TableInvalidator: &testInvalidator{invalidateName: "1"},
 			executionTime:    1,
 		},
 		{
-			TableInvalidator: testInvalidator{invalidateName: "3a"},
+			TableInvalidator: &testInvalidator{invalidateName: "3a"},
 			executionTime:    3,
 		},
 		{
-			TableInvalidator: testInvalidator{invalidateName: "3b"},
+			TableInvalidator: &testInvalidator{invalidateName: "3b"},
 			executionTime:    3,
 		},
 		{
-			TableInvalidator: testInvalidator{invalidateName: "7"},
+			TableInvalidator: &testInvalidator{invalidateName: "7"},
 			executionTime:    7,
 		},
 	}


### PR DESCRIPTION
Skip rechecking previously validated entries.