### PR TITLE
[Execution] Pause at block 47183000 v0.29.13

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -650,6 +650,9 @@ func (exeNode *ExecutionNode) LoadStopControl(
 		exeNode.exeConf.pauseExecution,
 		lastExecutedHeight)
 
+	// Force all ENs to pause execution at block height 47183000
+	exeNode.stopControl.SetStopHeight(47183000, false)
+
 	return &module.NoopReadyDoneAware{}, nil
 }
 

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -651,7 +651,10 @@ func (exeNode *ExecutionNode) LoadStopControl(
 		lastExecutedHeight)
 
 	// Force all ENs to pause execution at block height 47183000
-	exeNode.stopControl.SetStopHeight(47183000, false)
+	_, _, err = exeNode.stopControl.SetStopHeight(47183000, false)
+	if err != nil {
+		return nil, fmt.Errorf("cannot set stop height: %w", err)
+	}
 
 	return &module.NoopReadyDoneAware{}, nil
 }


### PR DESCRIPTION
This build is based off of `v0.29.13`, and causes ENs to stop executing when they reach block `47183000`. At this block, ENs should be upgrade to `v0.29.15+`