### PR TITLE
[Access] Disable rest metrics v0.29

### DIFF
--- a/engine/access/rest/router.go
+++ b/engine/access/rest/router.go
@@ -20,7 +20,6 @@ func newRouter(backend access.API, logger zerolog.Logger, chain flow.Chain) (*mu
 	v1SubRouter.Use(middleware.LoggingMiddleware(logger))
 	v1SubRouter.Use(middleware.QueryExpandable())
 	v1SubRouter.Use(middleware.QuerySelect())
-	v1SubRouter.Use(middleware.MetricsMiddleware())
 
 	linkGenerator := models.NewLinkGeneratorImpl(v1SubRouter)
 


### PR DESCRIPTION
The rest metrics handler causes high memory on ANs. Disable it on mainnet until it's fixed.

heap profile:
<img width="2125" alt="image" src="https://user-images.githubusercontent.com/89119817/221977364-41f946f0-af13-4ea8-9229-811a7b55dfbf.png">
