### PR TITLE
Change View merging to operate on execution snapshot

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -529,5 +529,5 @@ func (e *blockComputer) mergeView(
 	mergeSpan := e.tracer.StartSpanFromParent(parentSpan, mergeSpanName)
 	defer mergeSpan.End()
 
-	return parent.MergeView(child)
+	return parent.Merge(child)
 }

--- a/engine/execution/state/delta/view.go
+++ b/engine/execution/state/delta/view.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/onflow/flow-go/crypto/hash"
+	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -16,7 +17,6 @@ import (
 type View struct {
 	delta       Delta
 	regTouchSet map[flow.RegisterID]struct{} // contains all the registers that have been touched (either read or written to)
-	readsCount  uint64                       // contains the total number of reads
 	// spockSecret keeps the secret used for SPoCKs
 	// TODO we can add a flag to disable capturing spockSecret
 	// for views other than collection views to improve performance
@@ -124,8 +124,13 @@ func (v *View) NewChild() state.View {
 	return NewDeltaView(state.NewPeekerStorageSnapshot(v))
 }
 
-func (v *View) DropDelta() {
+func (v *View) Meter() *meter.Meter {
+	return nil
+}
+
+func (v *View) DropChanges() error {
 	v.delta = NewDelta()
+	return nil
 }
 
 func (v *View) AllRegisterIDs() []flow.RegisterID {
@@ -158,7 +163,6 @@ func (v *View) Get(registerID flow.RegisterID) (flow.RegisterValue, error) {
 		// capture register touch
 		v.regTouchSet[registerID] = struct{}{}
 		// increase reads
-		v.readsCount++
 	}
 	// every time we read a value (order preserving) we update the secret
 	// with the registerID only (value is not required)
@@ -206,33 +210,24 @@ func (v *View) Delta() Delta {
 	return v.delta
 }
 
-// MergeView applies the changes from a the given view to this view.
-// TODO rename this, this is not actually a merge as we can't merge
-// readFunc s.
+// TODO(patrick): remove after updating emulator
+func (view *View) MergeView(child state.ExecutionSnapshot) error {
+	return view.Merge(child)
+}
 
-func (v *View) MergeView(ch state.View) error {
-
-	child, ok := ch.(*View)
-	if !ok {
-		return fmt.Errorf("can not merge view: view type mismatch (given: %T, expected:delta.View)", ch)
+func (view *View) Merge(child state.ExecutionSnapshot) error {
+	for _, id := range child.AllRegisterIDs() {
+		view.regTouchSet[id] = struct{}{}
 	}
 
-	for id := range child.Interactions().RegisterTouches() {
-		v.regTouchSet[id] = struct{}{}
-	}
-
-	// SpockSecret is order aware
-	// TODO return the error and handle it properly on other places
-
-	spockSecret := child.SpockSecret()
-
-	_, err := v.spockSecretHasher.Write(spockSecret)
+	_, err := view.spockSecretHasher.Write(child.SpockSecret())
 	if err != nil {
 		return fmt.Errorf("merging SPoCK secrets failed: %w", err)
 	}
-	v.delta.MergeWith(child.delta)
 
-	v.readsCount += child.readsCount
+	for _, entry := range child.UpdatedRegisters() {
+		view.delta.Data[entry.Key] = entry.Value
+	}
 
 	return nil
 }
@@ -244,11 +239,6 @@ func (r *Snapshot) RegisterTouches() map[flow.RegisterID]struct{} {
 		ret[k] = struct{}{}
 	}
 	return ret
-}
-
-// ReadsCount returns the total number of reads performed on this view including all child views
-func (v *View) ReadsCount() uint64 {
-	return v.readsCount
 }
 
 // SpockSecret returns the secret value for SPoCK

--- a/engine/execution/state/delta/view_test.go
+++ b/engine/execution/state/delta/view_test.go
@@ -150,7 +150,7 @@ func TestViewSet(t *testing.T) {
 	})
 }
 
-func TestViewMergeView(t *testing.T) {
+func TestViewMerge(t *testing.T) {
 	registerID1 := flow.NewRegisterID("fruit", "")
 	registerID2 := flow.NewRegisterID("vegetable", "")
 	registerID3 := flow.NewRegisterID("diary", "")
@@ -164,7 +164,7 @@ func TestViewMergeView(t *testing.T) {
 		err = chView.Set(registerID2, flow.RegisterValue("carrot"))
 		assert.NoError(t, err)
 
-		err = v.MergeView(chView)
+		err = v.Merge(chView)
 		assert.NoError(t, err)
 
 		b1, err := v.Get(registerID1)
@@ -185,7 +185,7 @@ func TestViewMergeView(t *testing.T) {
 		assert.NoError(t, err)
 
 		chView := v.NewChild()
-		err = v.MergeView(chView)
+		err = v.Merge(chView)
 		assert.NoError(t, err)
 
 		b1, err := v.Get(registerID1)
@@ -207,7 +207,7 @@ func TestViewMergeView(t *testing.T) {
 		err = chView.Set(registerID2, flow.RegisterValue("carrot"))
 		assert.NoError(t, err)
 
-		err = v.MergeView(chView)
+		err = v.Merge(chView)
 		assert.NoError(t, err)
 
 		b1, err := v.Get(registerID1)
@@ -228,7 +228,7 @@ func TestViewMergeView(t *testing.T) {
 		chView := v.NewChild()
 		err = chView.Set(registerID1, flow.RegisterValue("orange"))
 		assert.NoError(t, err)
-		err = v.MergeView(chView)
+		err = v.Merge(chView)
 		assert.NoError(t, err)
 
 		b, err := v.Get(registerID1)
@@ -245,7 +245,7 @@ func TestViewMergeView(t *testing.T) {
 		chView := v.NewChild()
 		err = chView.Set(registerID1, flow.RegisterValue("orange"))
 		assert.NoError(t, err)
-		err = v.MergeView(chView)
+		err = v.Merge(chView)
 		assert.NoError(t, err)
 
 		b, err := v.Get(registerID1)
@@ -276,7 +276,7 @@ func TestViewMergeView(t *testing.T) {
 		hash2 := expSpock2.SumHash()
 		assert.Equal(t, chView.(*delta.View).SpockSecret(), []uint8(hash2))
 
-		err = v.MergeView(chView)
+		err = v.Merge(chView)
 		assert.NoError(t, err)
 
 		hashIt(t, expSpock1, hash2)
@@ -295,7 +295,7 @@ func TestViewMergeView(t *testing.T) {
 		err = chView.Set(registerID3, flow.RegisterValue("milk"))
 		assert.NoError(t, err)
 
-		err = v.MergeView(chView)
+		err = v.Merge(chView)
 		assert.NoError(t, err)
 
 		reads := v.Interactions().Reads
@@ -405,7 +405,7 @@ func TestView_AllRegisterIDs(t *testing.T) {
 		err = vv.Set(idF, flow.RegisterValue("f_value"))
 		assert.NoError(t, err)
 
-		err = v.MergeView(vv)
+		err = v.Merge(vv)
 		assert.NoError(t, err)
 		allRegs := v.Interactions().AllRegisterIDs()
 		assert.Len(t, allRegs, 6)

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -235,7 +235,7 @@ func Test_Programs(t *testing.T) {
 		txAView = viewExecA
 
 		// merge it back
-		err = mainView.MergeView(viewExecA)
+		err = mainView.Merge(viewExecA)
 		require.NoError(t, err)
 
 		// execute transaction again, this time make sure it doesn't load code
@@ -264,7 +264,7 @@ func Test_Programs(t *testing.T) {
 		compareViews(t, viewExecA, viewExecA2)
 
 		// merge it back
-		err = mainView.MergeView(viewExecA2)
+		err = mainView.Merge(viewExecA2)
 		require.NoError(t, err)
 	})
 
@@ -349,7 +349,7 @@ func Test_Programs(t *testing.T) {
 		contractBView = deltaB
 
 		// merge it back
-		err = mainView.MergeView(viewExecB)
+		err = mainView.Merge(viewExecB)
 		require.NoError(t, err)
 
 		// rerun transaction
@@ -382,7 +382,7 @@ func Test_Programs(t *testing.T) {
 		compareViews(t, viewExecB, viewExecB2)
 
 		// merge it back
-		err = mainView.MergeView(viewExecB2)
+		err = mainView.Merge(viewExecB2)
 		require.NoError(t, err)
 	})
 
@@ -413,7 +413,7 @@ func Test_Programs(t *testing.T) {
 		compareViews(t, txAView, viewExecA)
 
 		// merge it back
-		err = mainView.MergeView(viewExecA)
+		err = mainView.Merge(viewExecA)
 		require.NoError(t, err)
 	})
 
@@ -488,6 +488,5 @@ func Test_Programs(t *testing.T) {
 func compareViews(t *testing.T, a, b *delta.View) {
 	require.Equal(t, a.Delta(), b.Delta())
 	require.Equal(t, a.Interactions(), b.Interactions())
-	require.Equal(t, a.ReadsCount(), b.ReadsCount())
 	require.Equal(t, a.SpockSecret(), b.SpockSecret())
 }

--- a/fvm/state/state_test.go
+++ b/fvm/state/state_test.go
@@ -67,7 +67,7 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 		require.Equal(t, len(v), 0)
 
 		// merge to parent
-		err = st.MergeState(stChild)
+		err = st.Merge(stChild)
 		require.NoError(t, err)
 
 		// read key3 on parent
@@ -190,7 +190,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Equal(t, st.InteractionUsed(), uint64(0))
 
 	// commit
-	err = st.MergeState(stChild)
+	err = st.Merge(stChild)
 	require.NoError(t, err)
 	require.Equal(t, st.InteractionUsed(), key1Size+value1Size)
 

--- a/fvm/state/transaction_state.go
+++ b/fvm/state/transaction_state.go
@@ -306,9 +306,9 @@ func (s *transactionState) mergeIntoParent() (*State, error) {
 		return nil, err
 	}
 
-	childState.committed = true
+	childState.Finalize()
 
-	err = s.current().state.MergeState(childState)
+	err = s.current().state.Merge(childState)
 	if err != nil {
 		return nil, err
 	}
@@ -417,8 +417,7 @@ func (s *transactionState) RestartNestedTransaction(
 		}
 	}
 
-	s.currentState().View().DropDelta()
-	return nil
+	return s.currentState().DropChanges()
 }
 
 func (s *transactionState) Get(

--- a/fvm/state/transaction_state_test.go
+++ b/fvm/state/transaction_state_test.go
@@ -540,19 +540,22 @@ func TestInvalidCommittedStateModification(t *testing.T) {
 	committedState, err := txn.CommitNestedTransaction(id1)
 	require.NoError(t, err)
 
-	err = committedState.MergeState(
+	err = committedState.Merge(
 		state.NewState(
 			delta.NewDeltaView(nil),
 			state.DefaultParameters()))
-	require.ErrorContains(t, err, "cannot MergeState on a committed state")
+	require.ErrorContains(t, err, "cannot Merge on a finalized view")
 
 	txn.ResumeNestedTransaction(committedState)
 
 	err = txn.Set(key, createByteArray(2))
-	require.ErrorContains(t, err, "cannot Set on a committed state")
+	require.ErrorContains(t, err, "cannot Set on a finalized view")
 
 	_, err = txn.Get(key)
-	require.ErrorContains(t, err, "cannot Get on a committed state")
+	require.ErrorContains(t, err, "cannot Get on a finalized view")
+
+	err = txn.RestartNestedTransaction(id1)
+	require.ErrorContains(t, err, "cannot DropChanges on a finalized view")
 
 	_, err = txn.CommitNestedTransaction(id1)
 	require.NoError(t, err)

--- a/fvm/state/view.go
+++ b/fvm/state/view.go
@@ -1,24 +1,16 @@
 package state
 
 import (
+	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/model/flow"
 )
 
 type View interface {
 	NewChild() View
-	MergeView(child View) error
 
-	// UpdatedRegisters returns all registers that were updated by this view.
-	// The returned entries are sorted by ids.
-	UpdatedRegisters() flow.RegisterEntries
+	Merge(child ExecutionSnapshot) error
 
-	// UpdatedRegisterIDs returns all register ids that were updated by this
-	// view.  The returned ids are unsorted.
-	UpdatedRegisterIDs() []flow.RegisterID
-
-	// AllRegisterIDs returns all register ids that were touched by this view.
-	// The returned ids are unsorted.
-	AllRegisterIDs() []flow.RegisterID
+	ExecutionSnapshot
 
 	Storage
 }
@@ -29,5 +21,34 @@ type Storage interface {
 	Set(id flow.RegisterID, value flow.RegisterValue) error
 	Get(id flow.RegisterID) (flow.RegisterValue, error)
 
-	DropDelta() // drops all the delta changes
+	DropChanges() error
+}
+
+type ExecutionSnapshot interface {
+	// UpdatedRegisters returns all registers that were updated by this view.
+	// The returned entries are sorted by ids.
+	UpdatedRegisters() flow.RegisterEntries
+
+	// UpdatedRegisterIDs returns all register ids that were updated by this
+	// view.  The returned ids are unsorted.
+	UpdatedRegisterIDs() []flow.RegisterID
+
+	// AllRegisterIDs returns all register ids that were read / write by this
+	// view. The returned ids are unsorted.
+	AllRegisterIDs() []flow.RegisterID
+
+	// TODO(patrick): implement this.
+	//
+	// StorageSnapshotRegisterIDs returns all register ids that were read
+	// from the underlying storage snapshot / view. The returned ids are
+	// unsorted.
+	// StorageSnapshotRegisterIDs() []flow.RegisterID
+
+	// Note that the returned spock secret may be nil if the view does not
+	// support spock.
+	SpockSecret() []byte
+
+	// Note that the returned meter may be nil if the view does not
+	// support metering.
+	Meter() *meter.Meter
 }

--- a/fvm/utils/view.go
+++ b/fvm/utils/view.go
@@ -1,10 +1,10 @@
 package utils
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/onflow/flow-go/engine/execution/state/delta"
+	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
@@ -56,20 +56,22 @@ func (view *SimpleView) NewChild() state.View {
 	}
 }
 
-func (view *SimpleView) MergeView(o state.View) error {
-	other, ok := o.(*SimpleView)
-	if !ok {
-		return fmt.Errorf("can not merge: view type mismatch (given: %T, expected:SimpleView)", o)
-	}
-
-	return view.base.MergeView(other.base)
+func (view *SimpleView) Merge(other state.ExecutionSnapshot) error {
+	return view.base.Merge(other)
 }
 
-func (view *SimpleView) DropDelta() {
+func (view *SimpleView) SpockSecret() []byte {
+	return nil
+}
+
+func (view *SimpleView) Meter() *meter.Meter {
+	return nil
+}
+
+func (view *SimpleView) DropChanges() error {
 	view.Lock()
 	defer view.Unlock()
-
-	view.base.DropDelta()
+	return view.base.DropChanges()
 }
 
 func (view *SimpleView) Get(id flow.RegisterID) (flow.RegisterValue, error) {

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -200,7 +200,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 		serviceEvents = append(serviceEvents, tx.ConvertedServiceEvents...)
 
 		// always merge back the tx view (fvm is responsible for changes on tx errors)
-		err = chunkView.MergeView(txView)
+		err = chunkView.Merge(txView)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to execute transaction: %d (%w)", i, err)
 		}


### PR DESCRIPTION
Note that this change is slightly less efficient than the original implementation since UpdatedRegisters does extra/unnecessary sorting. The sorting is only needed for ledger updates, we should move aways from sorting the updates in general.