### PR TITLE
Refactor get or load program

### DIFF
--- a/fvm/environment/meter.go
+++ b/fvm/environment/meter.go
@@ -45,6 +45,7 @@ const (
 	ComputationKindBLSVerifyPOP               = 2031
 	ComputationKindBLSAggregateSignatures     = 2032
 	ComputationKindBLSAggregatePublicKeys     = 2033
+	ComputationKindGetOrLoadProgram           = 2034
 )
 
 type Meter interface {

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -52,7 +52,7 @@ const (
 	CONSealingProcessIncorporatedResult       SpanName = "con.sealing.processIncorporatedResult"
 	CONSealingProcessApproval                 SpanName = "con.sealing.processApproval"
 
-	//Follower Engine
+	// Follower Engine
 	FollowerOnBlockProposal        SpanName = "follower.onBlockProposal"
 	FollowerProcessBlockProposal   SpanName = "follower.processBlockProposal"
 	FollowerProcessPendingChildren SpanName = "follower.processPendingChildren"
@@ -168,6 +168,7 @@ const (
 	FVMEnvGetAccountContractNames    SpanName = "fvm.env.getAccountContractNames"
 	FVMEnvGetProgram                 SpanName = "fvm.env.getCachedProgram"
 	FVMEnvSetProgram                 SpanName = "fvm.env.cacheProgram"
+	FVMEnvGetOrLoadProgram           SpanName = "fvm.env.getOrLoadCachedProgram"
 	FVMEnvProgramLog                 SpanName = "fvm.env.programLog"
 	FVMEnvEmitEvent                  SpanName = "fvm.env.emitEvent"
 	FVMEnvGenerateUUID               SpanName = "fvm.env.generateUUID"


### PR DESCRIPTION
Refactor GetAndSet (a.k.a. [GetOrLoad](https://github.com/onflow/cadence/pull/2362)) to make it easier to understand what is going on.

The next step is to remove the individual get and set methods, as they shouldn't be used anymore.

Work towards: https://github.com/onflow/cadence/issues/1684