### PR TITLE
[v0.29] Backport: `Fix OBO and inconsistency in signer indices decoding used in Access API #3906`

### DIFF
--- a/access/handler.go
+++ b/access/handler.go
@@ -492,7 +492,7 @@ func (h *Handler) GetExecutionResultForBlockID(ctx context.Context, req *access.
 func (h *Handler) blockResponse(block *flow.Block, fullResponse bool, status flow.BlockStatus) (*access.BlockResponse, error) {
 	signerIDs, err := h.signerIndicesDecoder.DecodeSignerIDs(block.Header)
 	if err != nil {
-		return nil, err
+		return nil, err // the block was retrieved from local storage - so no errors are expected
 	}
 
 	var msg *entities.Block
@@ -513,7 +513,7 @@ func (h *Handler) blockResponse(block *flow.Block, fullResponse bool, status flo
 func (h *Handler) blockHeaderResponse(header *flow.Header, status flow.BlockStatus) (*access.BlockHeaderResponse, error) {
 	signerIDs, err := h.signerIndicesDecoder.DecodeSignerIDs(header)
 	if err != nil {
-		return nil, err
+		return nil, err // the block was retrieved from local storage - so no errors are expected
 	}
 
 	msg, err := convert.BlockHeaderToMessage(header, signerIDs)

--- a/consensus/hotstuff/committee.go
+++ b/consensus/hotstuff/committee.go
@@ -126,9 +126,9 @@ type DynamicCommittee interface {
 // particular block header to the identifiers of the nodes which signed the block.
 type BlockSignerDecoder interface {
 	// DecodeSignerIDs decodes the signer indices from the given block header into full node IDs.
-	// Note: A block header contains a quorum certificate for its parent, which proves that consensus committee 
-	// has reached agreement on validity of parent block. Consequently, the returned IdentifierList contains the
-	// consensus participants that signed the parent block.
+	// Note: A block header contains a quorum certificate for its parent, which proves that the
+	// consensus committee has reached agreement on validity of parent block. Consequently, the
+	// returned IdentifierList contains the consensus participants that signed the parent block.
 	// Expected Error returns during normal operations:
 	//   - model.ErrViewForUnknownEpoch if the given block's parent is within an unknown epoch
 	//   - signature.InvalidSignerIndicesError if signer indices included in the header do

--- a/consensus/hotstuff/committee.go
+++ b/consensus/hotstuff/committee.go
@@ -126,8 +126,8 @@ type DynamicCommittee interface {
 // particular block header to the identifiers of the nodes which signed the block.
 type BlockSignerDecoder interface {
 	// DecodeSignerIDs decodes the signer indices from the given block header into full node IDs.
-	// Note: A block header contains a quorum certificate for its parent, which proves that
-	// the block extends a valid fork. Consequently, the returned IdentifierList contains the
+	// Note: A block header contains a quorum certificate for its parent, which proves that consensus committee 
+	// has reached agreement on validity of parent block. Consequently, the returned IdentifierList contains the
 	// consensus participants that signed the parent block.
 	// Expected Error returns during normal operations:
 	//   - model.ErrViewForUnknownEpoch if the given block's parent is within an unknown epoch

--- a/consensus/hotstuff/committee.go
+++ b/consensus/hotstuff/committee.go
@@ -122,15 +122,17 @@ type DynamicCommittee interface {
 	IdentityByBlock(blockID flow.Identifier, participantID flow.Identifier) (*flow.Identity, error)
 }
 
-// BlockSignerDecoder defines how to convert the SignerIndices field within a particular
-// block header to the identifiers of the nodes which signed the block.
+// BlockSignerDecoder defines how to convert the ParentSignerIndices field within a
+// particular block header to the identifiers of the nodes which signed the block.
 type BlockSignerDecoder interface {
 	// DecodeSignerIDs decodes the signer indices from the given block header into full node IDs.
+	// Note: A block header contains a quorum certificate for its parent, which proves that
+	// the block extends a valid fork. Consequently, the returned IdentifierList contains the
+	// consensus participants that signed the parent block.
 	// Expected Error returns during normal operations:
-	//  * state.UnknownBlockError if block has not been ingested yet
-	//    TODO: this sentinel could be changed to `ErrViewForUnknownEpoch` once we merge the active pacemaker
-	//  * signature.InvalidSignerIndicesError if signer indices included in the header do
-	//    not encode a valid subset of the consensus committee
+	//   - model.ErrViewForUnknownEpoch if the given block's parent is within an unknown epoch
+	//   - signature.InvalidSignerIndicesError if signer indices included in the header do
+	//     not encode a valid subset of the consensus committee
 	DecodeSignerIDs(header *flow.Header) (flow.IdentifierList, error)
 }
 

--- a/consensus/hotstuff/signature/block_signer_decoder.go
+++ b/consensus/hotstuff/signature/block_signer_decoder.go
@@ -23,8 +23,8 @@ func NewBlockSignerDecoder(committee hotstuff.DynamicCommittee) *BlockSignerDeco
 var _ hotstuff.BlockSignerDecoder = (*BlockSignerDecoder)(nil)
 
 // DecodeSignerIDs decodes the signer indices from the given block header into full node IDs.
-// Note: A block header contains a quorum certificate for its parent, which proves that
-// the block extends a valid fork. Consequently, the returned IdentifierList contains the
+// Note: A block header contains a quorum certificate for its parent, which proves that consensus committee 
+// has reached agreement on validity of parent block. Consequently, the returned IdentifierList contains the
 // consensus participants that signed the parent block.
 // Expected Error returns during normal operations:
 //   - model.ErrViewForUnknownEpoch if the given block is within an unknown epoch

--- a/consensus/hotstuff/signature/block_signer_decoder.go
+++ b/consensus/hotstuff/signature/block_signer_decoder.go
@@ -23,9 +23,9 @@ func NewBlockSignerDecoder(committee hotstuff.DynamicCommittee) *BlockSignerDeco
 var _ hotstuff.BlockSignerDecoder = (*BlockSignerDecoder)(nil)
 
 // DecodeSignerIDs decodes the signer indices from the given block header into full node IDs.
-// Note: A block header contains a quorum certificate for its parent, which proves that consensus committee 
-// has reached agreement on validity of parent block. Consequently, the returned IdentifierList contains the
-// consensus participants that signed the parent block.
+// Note: A block header contains a quorum certificate for its parent, which proves that the
+// consensus committee has reached agreement on validity of parent block. Consequently, the
+// returned IdentifierList contains the consensus participants that signed the parent block.
 // Expected Error returns during normal operations:
 //   - model.ErrViewForUnknownEpoch if the given block is within an unknown epoch
 //   - signature.InvalidSignerIndicesError if signer indices included in the header do

--- a/consensus/hotstuff/signature/block_signer_decoder.go
+++ b/consensus/hotstuff/signature/block_signer_decoder.go
@@ -23,6 +23,9 @@ func NewBlockSignerDecoder(committee hotstuff.DynamicCommittee) *BlockSignerDeco
 var _ hotstuff.BlockSignerDecoder = (*BlockSignerDecoder)(nil)
 
 // DecodeSignerIDs decodes the signer indices from the given block header into full node IDs.
+// Note: A block header contains a quorum certificate for its parent, which proves that
+// the block extends a valid fork. Consequently, the returned IdentifierList contains the
+// consensus participants that signed the parent block.
 // Expected Error returns during normal operations:
 //   - model.ErrViewForUnknownEpoch if the given block is within an unknown epoch
 //   - signature.InvalidSignerIndicesError if signer indices included in the header do

--- a/consensus/hotstuff/signature/block_signer_decoder.go
+++ b/consensus/hotstuff/signature/block_signer_decoder.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/signature"
-	"github.com/onflow/flow-go/state"
-	"github.com/onflow/flow-go/storage"
 )
 
 // BlockSignerDecoder is a wrapper around the `hotstuff.DynamicCommittee`, which implements
@@ -25,7 +24,7 @@ var _ hotstuff.BlockSignerDecoder = (*BlockSignerDecoder)(nil)
 
 // DecodeSignerIDs decodes the signer indices from the given block header into full node IDs.
 // Expected Error returns during normal operations:
-//   - state.UnknownBlockError if block has not been ingested yet
+//   - model.ErrViewForUnknownEpoch if the given block is within an unknown epoch
 //   - signature.InvalidSignerIndicesError if signer indices included in the header do
 //     not encode a valid subset of the consensus committee
 func (b *BlockSignerDecoder) DecodeSignerIDs(header *flow.Header) (flow.IdentifierList, error) {
@@ -34,15 +33,12 @@ func (b *BlockSignerDecoder) DecodeSignerIDs(header *flow.Header) (flow.Identifi
 		return []flow.Identifier{}, nil
 	}
 
-	id := header.ID()
-	members, err := b.IdentitiesByBlock(id)
+	members, err := b.IdentitiesByEpoch(header.ParentView)
 	if err != nil {
-		// TODO: this potentially needs to be updated when we implement and document proper error handling for
-		//       `hotstuff.Committee` and underlying code (such as `protocol.Snapshot`)
-		if errors.Is(err, storage.ErrNotFound) {
-			return nil, state.WrapAsUnknownBlockError(id, err)
+		if errors.Is(err, model.ErrViewForUnknownEpoch) {
+			return nil, fmt.Errorf("could not retrieve identities for block %x with QC view %d: %w", header.ID(), header.ParentView, err)
 		}
-		return nil, fmt.Errorf("fail to retrieve identities for block %v: %w", id, err)
+		return nil, fmt.Errorf("unexpected error retrieving identities for block %v: %w", header.ID(), err)
 	}
 	signerIDs, err := signature.DecodeSignerIndicesToIdentifiers(members.NodeIDs(), header.ParentVoterIndices)
 	if err != nil {

--- a/consensus/hotstuff/signature/block_signer_decoder_test.go
+++ b/consensus/hotstuff/signature/block_signer_decoder_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/signature"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 

--- a/consensus/hotstuff/signature/block_signer_decoder_test.go
+++ b/consensus/hotstuff/signature/block_signer_decoder_test.go
@@ -91,7 +91,7 @@ func (s *blockSignerDecoderSuite) Test_UnknownEpoch() {
 }
 
 // Test_InvalidIndices verifies that `BlockSignerDecoder` returns
-// signature.InvalidSignerIndicesError is the signer indices in the provided header
+// signature.InvalidSignerIndicesError if the signer indices in the provided header
 // are not a valid encoding.
 func (s *blockSignerDecoderSuite) Test_InvalidIndices() {
 	s.block.Header.ParentVoterIndices = unittest.RandomBytes(1)

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -557,6 +557,7 @@ func (h *handler) GetBlockHeaderByID(
 func (h *handler) blockHeaderResponse(header *flow.Header) (*execution.BlockHeaderResponse, error) {
 	signerIDs, err := h.signerIndicesDecoder.DecodeSignerIDs(header)
 	if err != nil {
+		// the block was retrieved from local storage - so no errors are expected
 		return nil, fmt.Errorf("failed to decode signer indices to Identifiers for block %v: %w", header.ID(), err)
 	}
 

--- a/engine/protocol/handler.go
+++ b/engine/protocol/handler.go
@@ -143,7 +143,7 @@ func (h *Handler) GetBlockByID(
 func (h *Handler) blockResponse(block *flow.Block, fullResponse bool) (*access.BlockResponse, error) {
 	signerIDs, err := h.signerIndicesDecoder.DecodeSignerIDs(block.Header)
 	if err != nil {
-		return nil, err
+		return nil, err // the block was retrieved from local storage - so no errors are expected
 	}
 
 	var msg *entities.Block
@@ -163,7 +163,7 @@ func (h *Handler) blockResponse(block *flow.Block, fullResponse bool) (*access.B
 func (h *Handler) blockHeaderResponse(header *flow.Header) (*access.BlockHeaderResponse, error) {
 	signerIDs, err := h.signerIndicesDecoder.DecodeSignerIDs(header)
 	if err != nil {
-		return nil, err
+		return nil, err // the block was retrieved from local storage - so no errors are expected
 	}
 
 	msg, err := convert.BlockHeaderToMessage(header, signerIDs)


### PR DESCRIPTION
Backport https://github.com/onflow/flow-go/pull/3906