### PR TITLE
[Execution] clean up - remove unused code

### DIFF
--- a/engine/execution/state/mock/execution_state.go
+++ b/engine/execution/state/mock/execution_state.go
@@ -10,8 +10,6 @@ import (
 
 	fvmstate "github.com/onflow/flow-go/fvm/state"
 
-	messages "github.com/onflow/flow-go/model/messages"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -59,29 +57,6 @@ func (_m *ExecutionState) GetBlockIDByChunkID(chunkID flow.Identifier) (flow.Ide
 	var r1 error
 	if rf, ok := ret.Get(1).(func(flow.Identifier) error); ok {
 		r1 = rf(chunkID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetCollection provides a mock function with given fields: identifier
-func (_m *ExecutionState) GetCollection(identifier flow.Identifier) (*flow.Collection, error) {
-	ret := _m.Called(identifier)
-
-	var r0 *flow.Collection
-	if rf, ok := ret.Get(0).(func(flow.Identifier) *flow.Collection); ok {
-		r0 = rf(identifier)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*flow.Collection)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(flow.Identifier) error); ok {
-		r1 = rf(identifier)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -216,29 +191,6 @@ func (_m *ExecutionState) NewStorageSnapshot(_a0 flow.StateCommitment) fvmstate.
 	}
 
 	return r0
-}
-
-// RetrieveStateDelta provides a mock function with given fields: _a0, _a1
-func (_m *ExecutionState) RetrieveStateDelta(_a0 context.Context, _a1 flow.Identifier) (*messages.ExecutionStateDelta, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *messages.ExecutionStateDelta
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) *messages.ExecutionStateDelta); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*messages.ExecutionStateDelta)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, flow.Identifier) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // SaveExecutionResults provides a mock function with given fields: ctx, result, executionReceipt

--- a/engine/execution/state/mock/read_only_execution_state.go
+++ b/engine/execution/state/mock/read_only_execution_state.go
@@ -8,8 +8,6 @@ import (
 	fvmstate "github.com/onflow/flow-go/fvm/state"
 	flow "github.com/onflow/flow-go/model/flow"
 
-	messages "github.com/onflow/flow-go/model/messages"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -57,29 +55,6 @@ func (_m *ReadOnlyExecutionState) GetBlockIDByChunkID(chunkID flow.Identifier) (
 	var r1 error
 	if rf, ok := ret.Get(1).(func(flow.Identifier) error); ok {
 		r1 = rf(chunkID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetCollection provides a mock function with given fields: identifier
-func (_m *ReadOnlyExecutionState) GetCollection(identifier flow.Identifier) (*flow.Collection, error) {
-	ret := _m.Called(identifier)
-
-	var r0 *flow.Collection
-	if rf, ok := ret.Get(0).(func(flow.Identifier) *flow.Collection); ok {
-		r0 = rf(identifier)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*flow.Collection)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(flow.Identifier) error); ok {
-		r1 = rf(identifier)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -214,29 +189,6 @@ func (_m *ReadOnlyExecutionState) NewStorageSnapshot(_a0 flow.StateCommitment) f
 	}
 
 	return r0
-}
-
-// RetrieveStateDelta provides a mock function with given fields: _a0, _a1
-func (_m *ReadOnlyExecutionState) RetrieveStateDelta(_a0 context.Context, _a1 flow.Identifier) (*messages.ExecutionStateDelta, error) {
-	ret := _m.Called(_a0, _a1)
-
-	var r0 *messages.ExecutionStateDelta
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) *messages.ExecutionStateDelta); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*messages.ExecutionStateDelta)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, flow.Identifier) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // StateCommitmentByBlockID provides a mock function with given fields: _a0, _a1

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -9,13 +9,10 @@ import (
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/engine/execution"
-	"github.com/onflow/flow-go/engine/execution/state/delta"
 	fvmState "github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/module"
-	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/storage"
 	badgerstorage "github.com/onflow/flow-go/storage/badger"
@@ -52,11 +49,7 @@ type ReadOnlyExecutionState interface {
 
 	GetExecutionResultID(context.Context, flow.Identifier) (flow.Identifier, error)
 
-	RetrieveStateDelta(context.Context, flow.Identifier) (*messages.ExecutionStateDelta, error)
-
 	GetHighestExecutedBlockID(context.Context) (uint64, flow.Identifier, error)
-
-	GetCollection(identifier flow.Identifier) (*flow.Collection, error)
 
 	GetBlockIDByChunkID(chunkID flow.Identifier) (flow.Identifier, error)
 }
@@ -429,88 +422,6 @@ func (s *state) SaveExecutionResults(
 		return fmt.Errorf("cannot update highest executed block: %w", err)
 	}
 	return nil
-}
-
-func (s *state) RetrieveStateDelta(ctx context.Context, blockID flow.Identifier) (*messages.ExecutionStateDelta, error) {
-	// TODO: consider using storage.Index.ByBlockID, the index contains collection id and seals ID
-	block, err := s.blocks.ByID(blockID)
-	if err != nil {
-		return nil, fmt.Errorf("cannot retrieve block: %w", err)
-	}
-	completeCollections := make(map[flow.Identifier]*entity.CompleteCollection)
-
-	for _, guarantee := range block.Payload.Guarantees {
-		collection, err := s.collections.ByID(guarantee.CollectionID)
-		if err != nil {
-			return nil, fmt.Errorf("cannot retrieve collection for delta: %w", err)
-		}
-		completeCollections[collection.ID()] = &entity.CompleteCollection{
-			Guarantee:    guarantee,
-			Transactions: collection.Transactions,
-		}
-	}
-
-	var startStateCommitment flow.StateCommitment
-	var endStateCommitment flow.StateCommitment
-	var stateInteractions []*delta.Snapshot
-	var events []flow.Event
-	var serviceEvents []flow.Event
-	var txResults []flow.TransactionResult
-
-	err = s.db.View(func(txn *badger.Txn) error {
-		err = operation.LookupStateCommitment(blockID, &endStateCommitment)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot lookup state commitment: %w", err)
-
-		}
-
-		err = operation.LookupStateCommitment(block.Header.ParentID, &startStateCommitment)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot lookup parent state commitment: %w", err)
-		}
-
-		err = operation.LookupEventsByBlockID(blockID, &events)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot lookup events: %w", err)
-		}
-
-		err = operation.LookupServiceEventsByBlockID(blockID, &serviceEvents)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot lookup events: %w", err)
-		}
-
-		err = operation.LookupTransactionResultsByBlockID(blockID, &txResults)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot lookup transaction errors: %w", err)
-		}
-
-		err = operation.RetrieveExecutionStateInteractions(blockID, &stateInteractions)(txn)
-		if err != nil {
-			return fmt.Errorf("cannot lookup execution state views: %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &messages.ExecutionStateDelta{
-		ExecutableBlock: entity.ExecutableBlock{
-			Block:               block,
-			StartState:          &startStateCommitment,
-			CompleteCollections: completeCollections,
-		},
-		StateInteractions:  stateInteractions,
-		EndState:           endStateCommitment,
-		Events:             events,
-		ServiceEvents:      serviceEvents,
-		TransactionResults: txResults,
-	}, nil
-}
-
-func (s *state) GetCollection(identifier flow.Identifier) (*flow.Collection, error) {
-	return s.collections.ByID(identifier)
 }
 
 func (s *state) GetBlockIDByChunkID(chunkID flow.Identifier) (flow.Identifier, error) {


### PR DESCRIPTION
This PR removes two methods (`RetrieveStateDelta`, and `GetCollection`) from the ReadOnlyState given its legacy code and not used by any components. GetCollection is not used given we construct an `executableBlock` object and pass it to the block computer. 