### PR TITLE
Commit nested transaction on derived value compute error

### DIFF
--- a/fvm/derived/table.go
+++ b/fvm/derived/table.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/hashicorp/go-multierror"
+
 	"github.com/onflow/flow-go/fvm/state"
 )
 
@@ -423,13 +425,17 @@ func (txn *TableTransaction[TKey, TVal]) GetOrCompute(
 	}
 
 	val, err = computer.Compute(txnState, key)
-	if err != nil {
-		return defaultVal, fmt.Errorf("failed to derive value: %w", err)
+
+	// Commit the nested transaction, even if the computation fails.
+	committedState, commitErr := txnState.CommitNestedTransaction(nestedTxId)
+	if commitErr != nil {
+		err = multierror.Append(err,
+			fmt.Errorf("failed to commit nested txn: %w", commitErr),
+		).ErrorOrNil()
 	}
 
-	committedState, err := txnState.CommitNestedTransaction(nestedTxId)
 	if err != nil {
-		return defaultVal, fmt.Errorf("failed to commit nested txn: %w", err)
+		return defaultVal, fmt.Errorf("failed to derive value: %w", err)
 	}
 
 	txn.Set(key, val, committedState)


### PR DESCRIPTION
Computing (a.k.a.: loading) a derived value ( programs for the programs cache, metering settings for the metering settings cache)  is done in a state transaction (to record state interaction, and metered quantities). 

If computing errors the state transaction is left in a state where you could not just handle the error and continue.

By committing the current nested state transaction in case of a error during the compute function the caller can choose to handle the error and continue execution.

This will allow for further simplification of GetOrLoadProgram. Ref: https://github.com/onflow/flow-go/pull/3976
Work towards: https://github.com/onflow/cadence/issues/1684