### PR TITLE
Disable account freezing

### DIFF
--- a/fvm/environment/accounts_status.go
+++ b/fvm/environment/accounts_status.go
@@ -71,7 +71,9 @@ func AccountStatusFromBytes(inp []byte) (*AccountStatus, error) {
 
 // IsAccountFrozen returns true if account's frozen flag is set
 func (a *AccountStatus) IsAccountFrozen() bool {
-	return a[flagIndex]&maskFrozen > 0
+	// accounts are never frozen
+	// TODO: remove the freezing feature entirely
+	return false
 }
 
 // SetFrozenFlag sets the frozen flag

--- a/fvm/environment/accounts_status_test.go
+++ b/fvm/environment/accounts_status_test.go
@@ -16,6 +16,9 @@ func TestAccountStatus(t *testing.T) {
 	require.False(t, s.IsAccountFrozen())
 
 	t.Run("test frozen flag set/reset", func(t *testing.T) {
+		// TODO: remove freezing feature
+		t.Skip("Skip as we are removing the freezing feature.")
+
 		s.SetFrozenFlag(true)
 		require.True(t, s.IsAccountFrozen())
 
@@ -24,9 +27,6 @@ func TestAccountStatus(t *testing.T) {
 	})
 
 	t.Run("test setting values", func(t *testing.T) {
-		// set some values for side effect checks
-		s.SetFrozenFlag(true)
-
 		index := atree.StorageIndex{1, 2, 3, 4, 5, 6, 7, 8}
 		s.SetStorageIndex(index)
 		s.SetPublicKeyCount(34)
@@ -37,8 +37,6 @@ func TestAccountStatus(t *testing.T) {
 		require.True(t, bytes.Equal(index[:], returnedIndex[:]))
 		require.Equal(t, uint64(34), s.PublicKeyCount())
 
-		// check no side effect on flags
-		require.True(t, s.IsAccountFrozen())
 	})
 
 	t.Run("test serialization", func(t *testing.T) {

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -207,6 +207,9 @@ func TestTransactionVerification(t *testing.T) {
 	})
 
 	t.Run("frozen account is rejected", func(t *testing.T) {
+		// TODO: remove freezing feature
+		t.Skip("Skip as we are removing the freezing feature.")
+
 		ctx := fvm.NewContext(
 			fvm.WithAuthorizationChecksEnabled(true),
 			fvm.WithAccountKeyWeightThreshold(-1),

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -50,12 +50,13 @@ func makeTwoAccounts(
 }
 
 func TestAccountFreezing(t *testing.T) {
+	// TODO: remove freezing feature
+	t.Skip("Skip as we are removing the freezing feature.")
 
 	chain := flow.Mainnet.Chain()
 	serviceAddress := chain.ServiceAddress()
 
 	t.Run("setFrozenAccount can be enabled", func(t *testing.T) {
-
 		address, _, st := makeTwoAccounts(t, nil, nil)
 		accounts := environment.NewAccounts(st)
 		derivedBlockData := derived.NewEmptyDerivedBlockData()


### PR DESCRIPTION
ref: https://github.com/onflow/flow-go/issues/3983

This just disables account freezing. The (un)freezing functions still exist and still sets the frozen byte, but the byte is never read and accounts are always treated as not frozen.

I will make a different PR(s) to cleanup the code. I left the tests in for now, as its easier to chase down all the places where cleanup is needed.