### PR TITLE
[CI][Testing] Add retry mechanism to integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - 'v[0-9]+.[0-9]+'
   pull_request:
     branches:
-      - master
+      - master*
       - 'auto-cadence-upgrade/**'
       - 'feature/**'
       - 'v[0-9]+.[0-9]+'


### PR DESCRIPTION
CI runs often fail due to flaky tests failing that require multiple attempts to make CI run pass.

To make it easier to merge PRs, this PR adds a retry mechanism used by `bors`

- updated to use `master*` branch - to match private repo branch names