### PR TITLE
[BN2][Testing] Parameterize docker registry url

### DIFF
--- a/integration/benchnet2/automate/cmd/level1/bootstrap.go
+++ b/integration/benchnet2/automate/cmd/level1/bootstrap.go
@@ -12,9 +12,10 @@ import (
 func main() {
 	dataFlag := flag.String("data", "", "Path to bootstrap JSON data.")
 	dockerTagFlag := flag.String("dockerTag", "", "Docker image tag.")
+	dockerRegistry := flag.String("dockerRegistry", "", "Docker image registry base URL.")
 	flag.Parse()
 
-	if *dataFlag == "" || *dockerTagFlag == "" {
+	if *dataFlag == "" || *dockerTagFlag == "" || *dockerRegistry == "" {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}

--- a/integration/benchnet2/automate/cmd/level1/bootstrap.go
+++ b/integration/benchnet2/automate/cmd/level1/bootstrap.go
@@ -21,5 +21,5 @@ func main() {
 	}
 
 	bootstrap := level1.NewBootstrap(*dataFlag)
-	bootstrap.GenTemplateData(true, *dockerTagFlag)
+	bootstrap.GenTemplateData(true, *dockerTagFlag, *dockerRegistry)
 }

--- a/integration/benchnet2/automate/level1/bootstrap.go
+++ b/integration/benchnet2/automate/level1/bootstrap.go
@@ -14,10 +14,11 @@ type Bootstrap struct {
 }
 
 type NodeData struct {
-	Id        string `json:"node_id"`
-	Name      string `json:"name"`
-	Role      string `json:"role"`
-	DockerTag string `json:"docker_tag"`
+	Id             string `json:"node_id"`
+	Name           string `json:"name"`
+	Role           string `json:"role"`
+	DockerTag      string `json:"docker_tag"`
+	DockerRegistry string `json:"docker_registry"`
 }
 
 func NewBootstrap(protocolJsonFilePath string) Bootstrap {
@@ -26,7 +27,7 @@ func NewBootstrap(protocolJsonFilePath string) Bootstrap {
 	}
 }
 
-func (b *Bootstrap) GenTemplateData(outputToFile bool, dockerTag string) []NodeData {
+func (b *Bootstrap) GenTemplateData(outputToFile bool, dockerTag string, dockerRegistry string) []NodeData {
 	// load bootstrap file
 	dataBytes, err := os.ReadFile(b.protocolJsonFilePath)
 	if err != nil {
@@ -55,10 +56,11 @@ func (b *Bootstrap) GenTemplateData(outputToFile bool, dockerTag string) []NodeD
 		name := strings.Split(address, ".")[0]
 
 		nodeDataList = append(nodeDataList, NodeData{
-			Id:        nodeID,
-			Role:      role,
-			Name:      name,
-			DockerTag: dockerTag,
+			Id:             nodeID,
+			Role:           role,
+			Name:           name,
+			DockerTag:      dockerTag,
+			DockerRegistry: dockerRegistry,
 		})
 	}
 

--- a/integration/benchnet2/automate/level1/bootstrap_test.go
+++ b/integration/benchnet2/automate/level1/bootstrap_test.go
@@ -18,6 +18,7 @@ func TestGenerateBootstrap_DataTable(t *testing.T) {
 			bootstrapPath:  filepath.Join(BootstrapPath, "root-protocol-state-snapshot1.json"),
 			expectedOutput: filepath.Join(ExpectedOutputPath, "template-data-input1.json"),
 			dockerTag:      "v0.27.6",
+			dockerRegistry: "gcr.io/flow-container-registry/",
 		},
 	}
 
@@ -25,7 +26,7 @@ func TestGenerateBootstrap_DataTable(t *testing.T) {
 		t.Run(i, func(t *testing.T) {
 			// generate template data file from bootstrap file
 			bootstrap := NewBootstrap(testData.bootstrapPath)
-			actualNodeData := bootstrap.GenTemplateData(false, testData.dockerTag)
+			actualNodeData := bootstrap.GenTemplateData(false, testData.dockerTag, testData.dockerRegistry)
 
 			// load expected template data file
 			var expectedNodeData []NodeData
@@ -45,4 +46,5 @@ type testData struct {
 	bootstrapPath  string
 	expectedOutput string
 	dockerTag      string
+	dockerRegistry string
 }

--- a/integration/benchnet2/automate/testdata/level1/expected/template-data-input1.json
+++ b/integration/benchnet2/automate/testdata/level1/expected/template-data-input1.json
@@ -3,84 +3,98 @@
     "role": "access",
     "name": "access1",
     "node_id": "c8a31df973605a8ec8351810d38e70fc66d9871ef978194f246025a5f9f7bf6e",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "access",
     "name": "access2",
     "node_id": "d3be7a089cc8a29a3ad8fcff5809c1ae27f35159ebcf585e3e4e91a1f3b87d89",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "collection",
     "name": "collection1",
     "node_id": "416c65782048656e74736368656c001844616b8e9b5680103f25545b2e535d72",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "collection",
     "name": "collection2",
     "node_id": "416e647265772042757269616e004bf4e37ab54b9ef5103294895fc58a1fe67b",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "collection",
     "name": "collection3",
     "node_id": "4261737469616e204d756c6c657200f26a128c4ef2b8752f3ad798cfa910d97f",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "collection",
     "name": "collection4",
     "node_id": "42656e6a616d696e2056616e204d6574657200bf596a51dee05642917a9c12c0",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "collection",
     "name": "collection5",
     "node_id": "436173657920417272696e67746f6e004cdbedda99daf9ff9a787c0618cee363",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "collection",
     "name": "collection6",
     "node_id": "44696574657220536869726c657900c100318341c6796198aa37e627949074bc",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "consensus",
     "name": "consensus1",
     "node_id": "4a616d65732048756e74657200e9ffa4e085542cfa80d15f0e61e54606c6cdb3",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "consensus",
     "name": "consensus2",
     "node_id": "4a65666665727920446f796c65005cf2fe1daafe62a66f59fd9afa12f0f78914",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "consensus",
     "name": "consensus3",
     "node_id": "4a6f7264616e20536368616c6d0064527abdf7ba98fac951ab71ac6aba31cfa1",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "execution",
     "name": "execution1",
     "node_id": "4a6f73682048616e6e616e00571da9984a91e31b5592e90d7be91703b2750235",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "execution",
     "name": "execution2",
     "node_id": "4b616e205a68616e670000937a7f84d6df0ca2acf95125c33c4b2637bae4e680",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   },
   {
     "role": "verification",
     "name": "verification1",
     "node_id": "4c61796e65204c616672616e636500ee3643453a3694301f3a232c2f5b9427e2",
-    "docker_tag": "v0.27.6"
+    "docker_tag": "v0.27.6",
+    "docker_registry": "gcr.io/flow-container-registry/"
   }
 ]


### PR DESCRIPTION
## Context

Now that BN2 project has been completed and tested on a dev cluster (https://github.com/dapperlabs/dapper-flow-hosting/issues/957), we need to deploy it to a production k8s cluster.

In order for this to happen, a few things need to be updated.

One of those things is updating the Docker registry URL that we use to upload images to / pull images from.

For the dev cluster, we were using a hard coded value of `gcr.io/flow-container-registry/` as the base URL for images in the Helm template that generates `values.yml`. For the production cluster we need this to be configurable to be a different value.

ref: https://github.com/dapperlabs/flow-go/issues/6553