### PR TITLE
Decouple transaction execution from result collection

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -30,51 +30,41 @@ const (
 	SystemChunkEventCollectionMaxSize = 256_000_000 // ~256MB
 )
 
-type collectionItem struct {
+type collectionInfo struct {
 	blockId    flow.Identifier
 	blockIdStr string
 
 	collectionIndex int
-
 	*entity.CompleteCollection
 
-	isSystemCollection bool
-
-	transactions []transaction
+	isSystemTransaction bool
 }
 
 func newTransactions(
-	blockId flow.Identifier,
-	blockIdStr string,
-	collectionIndex int,
+	collection collectionInfo,
 	collectionCtx fvm.Context,
-	isSystemCollection bool,
 	startTxnIndex int,
-	txnBodies []*flow.TransactionBody,
 ) []transaction {
-	txns := make([]transaction, 0, len(txnBodies))
+	txns := make([]transaction, 0, len(collection.Transactions))
 
 	logger := collectionCtx.Logger.With().
-		Str("block_id", blockIdStr).
+		Str("block_id", collection.blockIdStr).
 		Uint64("height", collectionCtx.BlockHeader.Height).
-		Bool("system_chunk", isSystemCollection).
-		Bool("system_transaction", isSystemCollection).
+		Bool("system_chunk", collection.isSystemTransaction).
+		Bool("system_transaction", collection.isSystemTransaction).
 		Logger()
 
-	for idx, txnBody := range txnBodies {
+	for idx, txnBody := range collection.Transactions {
 		txnId := txnBody.ID()
 		txnIdStr := txnId.String()
 		txnIndex := uint32(startTxnIndex + idx)
 		txns = append(
 			txns,
 			transaction{
-				blockId:             blockId,
-				blockIdStr:          blockIdStr,
-				txnId:               txnId,
-				txnIdStr:            txnIdStr,
-				collectionIndex:     collectionIndex,
-				txnIndex:            txnIndex,
-				isSystemTransaction: isSystemCollection,
+				collectionInfo: collection,
+				txnId:          txnId,
+				txnIdStr:       txnIdStr,
+				txnIndex:       txnIndex,
 				ctx: fvm.NewContextFromParent(
 					collectionCtx,
 					fvm.WithLogger(
@@ -82,27 +72,32 @@ func newTransactions(
 							Str("tx_id", txnIdStr).
 							Uint32("tx_index", txnIndex).
 							Logger())),
-				TransactionBody: txnBody,
+				TransactionProcedure: fvm.NewTransaction(
+					txnId,
+					txnIndex,
+					txnBody),
 			})
+	}
+
+	if len(txns) > 0 {
+		txns[len(txns)-1].lastTransactionInCollection = true
 	}
 
 	return txns
 }
 
 type transaction struct {
-	blockId    flow.Identifier
-	blockIdStr string
+	collectionInfo
 
 	txnId    flow.Identifier
 	txnIdStr string
 
-	collectionIndex int
-	txnIndex        uint32
+	txnIndex uint32
 
-	isSystemTransaction bool
+	lastTransactionInCollection bool
 
 	ctx fvm.Context
-	*flow.TransactionBody
+	*fvm.TransactionProcedure
 }
 
 // A BlockComputer executes the transactions in a block.
@@ -202,16 +197,16 @@ func (e *blockComputer) ExecuteBlock(
 	return results, nil
 }
 
-func (e *blockComputer) getRootSpanAndCollections(
+func (e *blockComputer) getRootSpanAndTransactions(
 	block *entity.ExecutableBlock,
 	derivedBlockData *derived.DerivedBlockData,
 ) (
 	otelTrace.Span,
-	[]collectionItem,
+	[]transaction,
 	error,
 ) {
 	rawCollections := block.Collections()
-	collections := make([]collectionItem, 0, len(rawCollections)+1)
+	var transactions []transaction
 
 	blockId := block.ID()
 	blockIdStr := blockId.String()
@@ -223,24 +218,18 @@ func (e *blockComputer) getRootSpanAndCollections(
 
 	startTxnIndex := 0
 	for idx, collection := range rawCollections {
-		collections = append(
-			collections,
-			collectionItem{
-				blockId:            blockId,
-				blockIdStr:         blockIdStr,
-				collectionIndex:    idx,
-				CompleteCollection: collection,
-				isSystemCollection: false,
-
-				transactions: newTransactions(
-					blockId,
-					blockIdStr,
-					idx,
-					blockCtx,
-					false,
-					startTxnIndex,
-					collection.Transactions),
-			})
+		transactions = append(
+			transactions,
+			newTransactions(
+				collectionInfo{
+					blockId:             blockId,
+					blockIdStr:          blockIdStr,
+					collectionIndex:     idx,
+					CompleteCollection:  collection,
+					isSystemTransaction: false,
+				},
+				blockCtx,
+				startTxnIndex)...)
 		startTxnIndex += len(collection.Transactions)
 	}
 
@@ -255,30 +244,24 @@ func (e *blockComputer) getRootSpanAndCollections(
 		e.systemChunkCtx,
 		fvm.WithBlockHeader(block.Block.Header),
 		fvm.WithDerivedBlockData(derivedBlockData))
-	systemTransactions := []*flow.TransactionBody{systemTxn}
+	systemCollection := &entity.CompleteCollection{
+		Transactions: []*flow.TransactionBody{systemTxn},
+	}
 
-	collections = append(
-		collections,
-		collectionItem{
-			blockId:         blockId,
-			blockIdStr:      blockIdStr,
-			collectionIndex: len(collections),
-			CompleteCollection: &entity.CompleteCollection{
-				Transactions: systemTransactions,
+	transactions = append(
+		transactions,
+		newTransactions(
+			collectionInfo{
+				blockId:             blockId,
+				blockIdStr:          blockIdStr,
+				collectionIndex:     len(rawCollections),
+				CompleteCollection:  systemCollection,
+				isSystemTransaction: true,
 			},
-			isSystemCollection: true,
+			systemCtx,
+			startTxnIndex)...)
 
-			transactions: newTransactions(
-				blockId,
-				blockIdStr,
-				len(rawCollections),
-				systemCtx,
-				true,
-				startTxnIndex,
-				systemTransactions),
-		})
-
-	return e.tracer.BlockRootSpan(blockId), collections, nil
+	return e.tracer.BlockRootSpan(blockId), transactions, nil
 }
 
 func (e *blockComputer) executeBlock(
@@ -296,7 +279,7 @@ func (e *blockComputer) executeBlock(
 		return nil, fmt.Errorf("executable block start state is not set")
 	}
 
-	rootSpan, collections, err := e.getRootSpanAndCollections(
+	rootSpan, transactions, err := e.getRootSpanAndTransactions(
 		block,
 		derivedBlockData)
 	if err != nil {
@@ -320,39 +303,23 @@ func (e *blockComputer) executeBlock(
 		e.receiptHasher,
 		parentBlockExecutionResultID,
 		block,
-		len(collections))
+		len(transactions))
 	defer collector.Stop()
 
 	stateView := delta.NewDeltaView(snapshot)
-
-	var txnIndex uint32
-	for _, collection := range collections {
-		colView := stateView.NewChild()
-		txnIndex, err = e.executeCollection(
-			blockSpan,
-			txnIndex,
-			colView,
-			collection,
-			collector)
+	for _, txn := range transactions {
+		err := e.executeTransaction(blockSpan, txn, stateView, collector)
 		if err != nil {
-			collectionPrefix := ""
-			if collection.isSystemCollection {
-				collectionPrefix = "system "
+			prefix := ""
+			if txn.isSystemTransaction {
+				prefix = "system "
 			}
 
 			return nil, fmt.Errorf(
-				"failed to execute %scollection at txnIndex %v: %w",
-				collectionPrefix,
-				txnIndex,
+				"failed to execute %stransaction at txnIndex %v: %w",
+				prefix,
+				txn.txnIndex,
 				err)
-		}
-		err = e.mergeView(
-			stateView,
-			colView,
-			blockSpan,
-			trace.EXEMergeCollectionView)
-		if err != nil {
-			return nil, fmt.Errorf("cannot merge view: %w", err)
 		}
 	}
 
@@ -370,58 +337,10 @@ func (e *blockComputer) executeBlock(
 	return res, nil
 }
 
-func (e *blockComputer) executeCollection(
-	blockSpan otelTrace.Span,
-	startTxIndex uint32,
-	collectionView state.View,
-	collection collectionItem,
-	collector *resultCollector,
-) (uint32, error) {
-
-	// call tracing
-	startedAt := time.Now()
-
-	txns := collection.transactions
-
-	collectionId := ""
-	referenceBlockId := ""
-	if !collection.isSystemCollection {
-		collectionId = collection.Guarantee.CollectionID.String()
-		referenceBlockId = collection.Guarantee.ReferenceBlockID.String()
-	}
-
-	logger := e.log.With().
-		Str("block_id", collection.blockIdStr).
-		Str("collection_id", collectionId).
-		Str("reference_block_id", referenceBlockId).
-		Int("number_of_transactions", len(txns)).
-		Bool("system_collection", collection.isSystemCollection).
-		Logger()
-	logger.Debug().Msg("executing collection")
-
-	for _, txn := range txns {
-		err := e.executeTransaction(blockSpan, txn, collectionView, collector)
-		if err != nil {
-			return txn.txnIndex, err
-		}
-	}
-
-	logger.Info().
-		Int64("time_spent_in_ms", time.Since(startedAt).Milliseconds()).
-		Msg("collection executed")
-
-	collector.CommitCollection(
-		collection,
-		startedAt,
-		collectionView)
-
-	return startTxIndex + uint32(len(txns)), nil
-}
-
 func (e *blockComputer) executeTransaction(
 	parentSpan otelTrace.Span,
 	txn transaction,
-	collectionView state.View,
+	stateView state.View,
 	collector *resultCollector,
 ) error {
 	startedAt := time.Now()
@@ -448,12 +367,10 @@ func (e *blockComputer) executeTransaction(
 		Logger()
 	logger.Info().Msg("executing transaction in fvm")
 
-	proc := fvm.NewTransaction(txn.txnId, txn.txnIndex, txn.TransactionBody)
-
 	txn.ctx = fvm.NewContextFromParent(txn.ctx, fvm.WithSpan(txSpan))
 
-	txView := collectionView.NewChild()
-	err := e.vm.Run(txn.ctx, proc, txView)
+	txView := stateView.NewChild()
+	err := e.vm.Run(txn.ctx, txn.TransactionProcedure, txView)
 	if err != nil {
 		return fmt.Errorf("failed to execute transaction %v for block %s at height %v: %w",
 			txn.txnIdStr,
@@ -468,7 +385,7 @@ func (e *blockComputer) executeTransaction(
 	// always merge the view, fvm take cares of reverting changes
 	// of failed transaction invocation
 
-	err = e.mergeView(collectionView, txView, postProcessSpan, trace.EXEMergeTransactionView)
+	err = e.mergeView(stateView, txView, postProcessSpan, trace.EXEMergeTransactionView)
 	if err != nil {
 		return fmt.Errorf(
 			"merging tx view to collection view failed for tx %v: %w",
@@ -476,21 +393,21 @@ func (e *blockComputer) executeTransaction(
 			err)
 	}
 
-	collector.AddTransactionResult(txn.collectionIndex, proc)
+	collector.AddTransactionResult(txn, txView)
 
 	memAllocAfter := debug.GetHeapAllocsBytes()
 
 	logger = logger.With().
-		Uint64("computation_used", proc.ComputationUsed).
-		Uint64("memory_used", proc.MemoryEstimate).
+		Uint64("computation_used", txn.ComputationUsed).
+		Uint64("memory_used", txn.MemoryEstimate).
 		Uint64("mem_alloc", memAllocAfter-memAllocBefore).
 		Int64("time_spent_in_ms", time.Since(startedAt).Milliseconds()).
 		Logger()
 
-	if proc.Err != nil {
+	if txn.Err != nil {
 		logger = logger.With().
-			Str("error_message", proc.Err.Error()).
-			Uint16("error_code", uint16(proc.Err.Code())).
+			Str("error_message", txn.Err.Error()).
+			Uint16("error_code", uint16(txn.Err.Code())).
 			Logger()
 		logger.Info().Msg("transaction execution failed")
 
@@ -511,12 +428,12 @@ func (e *blockComputer) executeTransaction(
 
 	e.metrics.ExecutionTransactionExecuted(
 		time.Since(startedAt),
-		proc.ComputationUsed,
-		proc.MemoryEstimate,
+		txn.ComputationUsed,
+		txn.MemoryEstimate,
 		memAllocAfter-memAllocBefore,
-		len(proc.Events),
-		flow.EventsList(proc.Events).ByteSize(),
-		proc.Err != nil,
+		len(txn.Events),
+		flow.EventsList(txn.Events).ByteSize(),
+		txn.Err != nil,
 	)
 	return nil
 }

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -6,14 +6,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
 	otelTrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
-	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
@@ -38,10 +36,9 @@ type ViewCommitter interface {
 	)
 }
 
-type collectionResult struct {
-	collectionItem
-	startTime time.Time
-	state.View
+type transactionResult struct {
+	transaction
+	state.ExecutionSnapshot
 }
 
 type resultCollector struct {
@@ -50,20 +47,16 @@ type resultCollector struct {
 
 	metrics module.ExecutionMetrics
 
-	closeOnce sync.Once
+	closeOnce          sync.Once
+	processorInputChan chan transactionResult
+	processorDoneChan  chan struct{}
+	processorError     error
 
-	committer          ViewCommitter
-	committerInputChan chan collectionResult
-	committerDoneChan  chan struct{}
-	committerError     error
+	committer ViewCommitter
 
 	signer        module.Local
 	spockHasher   hash.Hasher
 	receiptHasher hash.Hasher
-
-	snapshotHasherInputChan chan collectionResult
-	snapshotHasherDoneChan  chan struct{}
-	snapshotHasherError     error
 
 	executionDataProvider *provider.Provider
 
@@ -74,6 +67,9 @@ type resultCollector struct {
 	chunks                 []*flow.Chunk
 	spockSignatures        []crypto.Signature
 	convertedServiceEvents flow.ServiceEventList
+
+	currentCollectionStartTime time.Time
+	currentCollectionView      *delta.View
 }
 
 func newResultCollector(
@@ -87,158 +83,152 @@ func newResultCollector(
 	receiptHasher hash.Hasher,
 	parentBlockExecutionResultID flow.Identifier,
 	block *entity.ExecutableBlock,
-	numCollections int,
+	numTransactions int,
 ) *resultCollector {
+	numCollections := len(block.Collections()) + 1
 	collector := &resultCollector{
 		tracer:                       tracer,
 		blockSpan:                    blockSpan,
 		metrics:                      metrics,
+		processorInputChan:           make(chan transactionResult, numTransactions),
+		processorDoneChan:            make(chan struct{}),
 		committer:                    committer,
-		committerInputChan:           make(chan collectionResult, numCollections),
-		committerDoneChan:            make(chan struct{}),
 		signer:                       signer,
 		spockHasher:                  spockHasher,
 		receiptHasher:                receiptHasher,
-		snapshotHasherInputChan:      make(chan collectionResult, numCollections),
-		snapshotHasherDoneChan:       make(chan struct{}),
 		executionDataProvider:        executionDataProvider,
 		parentBlockExecutionResultID: parentBlockExecutionResultID,
 		result:                       execution.NewEmptyComputationResult(block),
 		chunks:                       make([]*flow.Chunk, 0, numCollections),
 		spockSignatures:              make([]crypto.Signature, 0, numCollections),
+		currentCollectionStartTime:   time.Now(),
+		currentCollectionView:        delta.NewDeltaView(nil),
 	}
 
-	go collector.runCollectionCommitter()
-	go collector.runSnapshotHasher()
+	go collector.runResultProcessor()
 
 	return collector
 }
 
-func (collector *resultCollector) runCollectionCommitter() {
-	defer close(collector.committerDoneChan)
+func (collector *resultCollector) commitCollection(
+	collection collectionInfo,
+	startTime time.Time,
+	// TODO(patrick): switch to ExecutionSnapshot
+	collectionExecutionSnapshot state.View,
+) error {
+	defer collector.tracer.StartSpanFromParent(
+		collector.blockSpan,
+		trace.EXECommitDelta).End()
 
-	for collection := range collector.committerInputChan {
-		span := collector.tracer.StartSpanFromParent(
-			collector.blockSpan,
-			trace.EXECommitDelta)
+	startState := collector.result.EndState
+	endState, proof, trieUpdate, err := collector.committer.CommitView(
+		collectionExecutionSnapshot,
+		startState)
+	if err != nil {
+		return fmt.Errorf("commit view failed: %w", err)
+	}
 
-		startState := collector.result.EndState
-		endState, proof, trieUpdate, err := collector.committer.CommitView(
-			collection.View,
-			startState)
-		if err != nil {
-			collector.committerError = fmt.Errorf(
-				"commit view failed: %w",
-				err)
-			return
-		}
+	collector.result.StateCommitments = append(
+		collector.result.StateCommitments,
+		endState)
 
-		collector.result.StateCommitments = append(
-			collector.result.StateCommitments,
-			endState)
+	eventsHash, err := flow.EventsMerkleRootHash(
+		collector.result.Events[collection.collectionIndex])
+	if err != nil {
+		return fmt.Errorf("hash events failed: %w", err)
+	}
 
-		eventsHash, err := flow.EventsMerkleRootHash(
-			collector.result.Events[collection.collectionIndex])
-		if err != nil {
-			collector.committerError = fmt.Errorf(
-				"hash events failed: %w",
-				err)
-			return
-		}
+	collector.result.EventsHashes = append(
+		collector.result.EventsHashes,
+		eventsHash)
 
-		collector.result.EventsHashes = append(
-			collector.result.EventsHashes,
-			eventsHash)
+	chunk := flow.NewChunk(
+		collection.blockId,
+		collection.collectionIndex,
+		startState,
+		len(collection.Transactions),
+		eventsHash,
+		endState)
+	collector.chunks = append(collector.chunks, chunk)
 
-		chunk := flow.NewChunk(
-			collection.blockId,
-			collection.collectionIndex,
+	collectionStruct := collection.Collection()
+
+	// Note: There's some inconsistency in how chunk execution data and
+	// chunk data pack populate their collection fields when the collection
+	// is the system collection.
+	executionCollection := &collectionStruct
+	dataPackCollection := executionCollection
+	if collection.isSystemTransaction {
+		dataPackCollection = nil
+	}
+
+	collector.result.ChunkDataPacks = append(
+		collector.result.ChunkDataPacks,
+		flow.NewChunkDataPack(
+			chunk.ID(),
 			startState,
-			len(collection.transactions),
-			eventsHash,
-			endState)
-		collector.chunks = append(collector.chunks, chunk)
+			proof,
+			dataPackCollection))
 
-		collectionStruct := collection.Collection()
+	collector.result.ChunkExecutionDatas = append(
+		collector.result.ChunkExecutionDatas,
+		&execution_data.ChunkExecutionData{
+			Collection: executionCollection,
+			Events:     collector.result.Events[collection.collectionIndex],
+			TrieUpdate: trieUpdate,
+		})
 
-		// Note: There's some inconsistency in how chunk execution data and
-		// chunk data pack populate their collection fields when the collection
-		// is the system collection.
-		executionCollection := &collectionStruct
-		dataPackCollection := executionCollection
-		if collection.isSystemCollection {
-			dataPackCollection = nil
-		}
+	collector.metrics.ExecutionChunkDataPackGenerated(
+		len(proof),
+		len(collection.Transactions))
 
-		collector.result.ChunkDataPacks = append(
-			collector.result.ChunkDataPacks,
-			flow.NewChunkDataPack(
-				chunk.ID(),
-				startState,
-				proof,
-				dataPackCollection))
+	collector.result.EndState = endState
 
-		collector.result.ChunkExecutionDatas = append(
-			collector.result.ChunkExecutionDatas,
-			&execution_data.ChunkExecutionData{
-				Collection: executionCollection,
-				Events:     collector.result.Events[collection.collectionIndex],
-				TrieUpdate: trieUpdate,
-			})
-
-		collector.metrics.ExecutionChunkDataPackGenerated(
-			len(proof),
-			len(collection.transactions))
-
-		collector.result.EndState = endState
-
-		span.End()
-	}
+	return nil
 }
 
-func (collector *resultCollector) runSnapshotHasher() {
-	defer close(collector.snapshotHasherDoneChan)
+func (collector *resultCollector) hashCollection(
+	collection collectionInfo,
+	startTime time.Time,
+	collectionExecutionSnapshot state.ExecutionSnapshot,
+) error {
+	// TODO(patrick): fix this ...
+	snapshot := collectionExecutionSnapshot.(*delta.View).Interactions()
 
-	for collection := range collector.snapshotHasherInputChan {
+	collector.result.TransactionResultIndex = append(
+		collector.result.TransactionResultIndex,
+		len(collector.result.TransactionResults))
+	collector.result.StateSnapshots = append(
+		collector.result.StateSnapshots,
+		snapshot)
 
-		snapshot := collection.View.(*delta.View).Interactions()
+	collector.metrics.ExecutionCollectionExecuted(
+		time.Since(startTime),
+		collector.result.CollectionStats(collection.collectionIndex))
 
-		collector.result.TransactionResultIndex = append(
-			collector.result.TransactionResultIndex,
-			len(collector.result.TransactionResults))
-		collector.result.StateSnapshots = append(
-			collector.result.StateSnapshots,
-			snapshot)
-
-		collector.metrics.ExecutionCollectionExecuted(
-			time.Since(collection.startTime),
-			collector.result.CollectionStats(collection.collectionIndex))
-
-		spock, err := collector.signer.SignFunc(
-			snapshot.SpockSecret,
-			collector.spockHasher,
-			SPOCKProve)
-		if err != nil {
-			collector.snapshotHasherError = fmt.Errorf(
-				"signing spock hash failed: %w",
-				err)
-			return
-		}
-
-		collector.spockSignatures = append(collector.spockSignatures, spock)
+	spock, err := collector.signer.SignFunc(
+		snapshot.SpockSecret,
+		collector.spockHasher,
+		SPOCKProve)
+	if err != nil {
+		return fmt.Errorf("signing spock hash failed: %w", err)
 	}
+
+	collector.spockSignatures = append(collector.spockSignatures, spock)
+
+	return nil
 }
 
-func (collector *resultCollector) AddTransactionResult(
-	collectionIndex int,
-	txn *fvm.TransactionProcedure,
-) {
+func (collector *resultCollector) processTransactionResult(
+	txn transaction,
+	txnExecutionSnapshot state.ExecutionSnapshot,
+) error {
 	collector.convertedServiceEvents = append(
 		collector.convertedServiceEvents,
 		txn.ConvertedServiceEvents...)
 
-	collector.result.Events[collectionIndex] = append(
-		collector.result.Events[collectionIndex],
+	collector.result.Events[txn.collectionIndex] = append(
+		collector.result.Events[txn.collectionIndex],
 		txn.Events...)
 	collector.result.ServiceEvents = append(
 		collector.result.ServiceEvents,
@@ -260,39 +250,72 @@ func (collector *resultCollector) AddTransactionResult(
 	for computationKind, intensity := range txn.ComputationIntensities {
 		collector.result.ComputationIntensities[computationKind] += intensity
 	}
+
+	err := collector.currentCollectionView.Merge(txnExecutionSnapshot)
+	if err != nil {
+		return fmt.Errorf("failed to merge into collection view: %w", err)
+	}
+
+	if !txn.lastTransactionInCollection {
+		return nil
+	}
+
+	err = collector.commitCollection(
+		txn.collectionInfo,
+		collector.currentCollectionStartTime,
+		collector.currentCollectionView)
+	if err != nil {
+		return err
+	}
+
+	err = collector.hashCollection(
+		txn.collectionInfo,
+		collector.currentCollectionStartTime,
+		collector.currentCollectionView)
+	if err != nil {
+		return err
+	}
+
+	collector.currentCollectionStartTime = time.Now()
+	collector.currentCollectionView = delta.NewDeltaView(nil)
+
+	return nil
 }
 
-func (collector *resultCollector) CommitCollection(
-	collection collectionItem,
-	startTime time.Time,
-	collectionView state.View,
+func (collector *resultCollector) AddTransactionResult(
+	txn transaction,
+	snapshot state.ExecutionSnapshot,
 ) {
-
-	result := collectionResult{
-		collectionItem: collection,
-		startTime:      startTime,
-		View:           collectionView,
+	result := transactionResult{
+		transaction:       txn,
+		ExecutionSnapshot: snapshot,
 	}
 
 	select {
-	case collector.committerInputChan <- result:
+	case collector.processorInputChan <- result:
 		// Do nothing
-	case <-collector.committerDoneChan:
-		// Committer exited (probably due to an error)
+	case <-collector.processorDoneChan:
+		// Processor exited (probably due to an error)
 	}
+}
 
-	select {
-	case collector.snapshotHasherInputChan <- result:
-		// do nothing
-	case <-collector.snapshotHasherDoneChan:
-		// Snapshot hasher exited (probably due to an error)
+func (collector *resultCollector) runResultProcessor() {
+	defer close(collector.processorDoneChan)
+
+	for result := range collector.processorInputChan {
+		err := collector.processTransactionResult(
+			result.transaction,
+			result.ExecutionSnapshot)
+		if err != nil {
+			collector.processorError = err
+			return
+		}
 	}
 }
 
 func (collector *resultCollector) Stop() {
 	collector.closeOnce.Do(func() {
-		close(collector.committerInputChan)
-		close(collector.snapshotHasherInputChan)
+		close(collector.processorInputChan)
 	})
 }
 
@@ -304,20 +327,10 @@ func (collector *resultCollector) Finalize(
 ) {
 	collector.Stop()
 
-	<-collector.committerDoneChan
-	<-collector.snapshotHasherDoneChan
+	<-collector.processorDoneChan
 
-	var err error
-	if collector.committerError != nil {
-		err = multierror.Append(err, collector.committerError)
-	}
-
-	if collector.snapshotHasherError != nil {
-		err = multierror.Append(err, collector.snapshotHasherError)
-	}
-
-	if err != nil {
-		return nil, err
+	if collector.processorError != nil {
+		return nil, collector.processorError
 	}
 
 	executionDataID, err := collector.executionDataProvider.Provide(

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -129,6 +129,7 @@ func BenchmarkComputeBlock(b *testing.B) {
 
 	me := new(module.Local)
 	me.On("NodeID").Return(flow.ZeroID)
+	me.On("Sign", mock.Anything, mock.Anything).Return(nil, nil)
 	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 


### PR DESCRIPTION
1. flatten execution loop to operation directly on transactions, bypassing collections
2. change result collector to only operate on transaction result (and generate collection views internally)
3. change result collector to pipleine transaction processing

Note that I've purposely left result collector in a messy state to minimize the number of changes (most of the changes in result collector are just indent changes).  I'll go back to clean it up in a follow up PR.