### PR TITLE
Increase timeout for committee test

### DIFF
--- a/consensus/hotstuff/committees/consensus_committee_test.go
+++ b/consensus/hotstuff/committees/consensus_committee_test.go
@@ -212,7 +212,7 @@ func (suite *ConsensusSuite) TestProtocolEvents_CommittedEpoch() {
 	assert.Eventually(suite.T(), func() bool {
 		_, err := suite.committee.IdentitiesByEpoch(unittest.Uint64InRange(201, 300))
 		return err == nil
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 
 	suite.Assert().Len(suite.committee.epochs, 2)
 	suite.AssertStoredEpochCounterRange(suite.currentEpochCounter, suite.currentEpochCounter+1)
@@ -238,10 +238,10 @@ func (suite *ConsensusSuite) TestProtocolEvents_EpochFallback() {
 
 	suite.committee.EpochEmergencyFallbackTriggered()
 	// wait for the protocol event to be processed (async)
-	assert.Eventually(suite.T(), func() bool {
+	require.Eventually(suite.T(), func() bool {
 		_, err := suite.committee.IdentitiesByEpoch(unittest.Uint64InRange(201, 300))
 		return err == nil
-	}, 5*time.Second, 50*time.Millisecond)
+	}, 30*time.Second, 50*time.Millisecond)
 
 	suite.Assert().Len(suite.committee.epochs, 2)
 	suite.AssertStoredEpochCounterRange(suite.currentEpochCounter, suite.currentEpochCounter+1)


### PR DESCRIPTION
I'm unable to reproduce test failures for this test locally as configured: https://github.com/dapperlabs/flow-go/issues/6564. By lowering the timeout when waiting for an async event to 1s, I can reproduce the failure locally. 

Increasing the timeout from 5s to 30s in this PR to see if it helps. 