### PR TITLE
[Testing][CI] Flaky Test Monitor - fix test quarantines

### DIFF
--- a/fvm/environment/accounts_status_test.go
+++ b/fvm/environment/accounts_status_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestAccountStatus(t *testing.T) {
@@ -17,7 +18,7 @@ func TestAccountStatus(t *testing.T) {
 
 	t.Run("test frozen flag set/reset", func(t *testing.T) {
 		// TODO: remove freezing feature
-		t.Skip("Skip as we are removing the freezing feature.")
+		unittest.SkipUnless(t, unittest.TEST_DEPRECATED, "Skip as we are removing the freezing feature.")
 
 		s.SetFrozenFlag(true)
 		require.True(t, s.IsAccountFrozen())

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -209,7 +209,7 @@ func TestTransactionVerification(t *testing.T) {
 
 	t.Run("frozen account is rejected", func(t *testing.T) {
 		// TODO: remove freezing feature
-		t.Skip("Skip as we are removing the freezing feature.")
+		unittest.SkipUnless(t, unittest.TEST_DEPRECATED, "Skip as we are removing the freezing feature.")
 
 		ctx := fvm.NewContext(
 			fvm.WithAuthorizationChecksEnabled(true),

--- a/fvm/transaction_test.go
+++ b/fvm/transaction_test.go
@@ -48,7 +48,7 @@ func makeTwoAccounts(
 
 func TestAccountFreezing(t *testing.T) {
 	// TODO: remove freezing feature
-	t.Skip("Skip as we are removing the freezing feature.")
+	unittest.SkipUnless(t, unittest.TEST_DEPRECATED, "Skip as we are removing the freezing feature.")
 
 	chain := flow.Mainnet.Chain()
 	serviceAddress := chain.ServiceAddress()


### PR DESCRIPTION
## Context
Flaky Test Monitor is currently not able to parse test output because a few tests are being skipped / quarantined using `t.Skip()` instead of the normal way we quarantine tests.

This is preventing from flaky test data from being processed and uploaded even though the test runs themselves run without  errors.