### PR TITLE
Suggestions for PR 3965 (part 2)

### DIFF
--- a/engine/common/follower/cache/cache.go
+++ b/engine/common/follower/cache/cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/rs/zerolog"
@@ -41,14 +40,13 @@ type batchContext struct {
 type Cache struct {
 	backend *herocache.Cache // cache with random ejection
 	lock    sync.RWMutex
-	// secondary index by view, can be used to detect equivocation
-	byView map[uint64]flow.Identifier
-	// secondary index by parentID, for finding a block's known children
-	byParent map[flow.Identifier]BlocksByID
-	// when message equivocation has been detected report it using this callback
-	onEquivocation OnEquivocation
-	// lowest view that we use to prune the cache, we don't want to accept blocks lower than it
-	lowestPrunedView counters.StrictMonotonousCounter
+
+	// secondary indices
+	byView   map[uint64]BlocksByID          // lookup of blocks by their respective view; used to detect equivocation
+	byParent map[flow.Identifier]BlocksByID // lookup of blocks by their parentID, for finding a block's known children
+
+	onEquivocation OnEquivocation                   // when message equivocation has been detected report it using this callback
+	lowestView     counters.StrictMonotonousCounter // lowest view that the cache accepts blocks for
 }
 
 // Peek performs lookup of cached block by blockID.
@@ -75,7 +73,7 @@ func NewCache(log zerolog.Logger, limit uint32, collector module.HeroCacheMetric
 			log.With().Str("component", "follower.cache").Logger(),
 			distributor,
 		),
-		byView:         make(map[uint64]flow.Identifier),
+		byView:         make(map[uint64]BlocksByID),
 		byParent:       make(map[flow.Identifier]BlocksByID),
 		onEquivocation: onEquivocation,
 	}
@@ -88,10 +86,19 @@ func NewCache(log zerolog.Logger, limit uint32, collector module.HeroCacheMetric
 // by `herocache.Cache.Add` and we perform this call while `c.lock` is in locked state.
 func (c *Cache) handleEjectedEntity(entity flow.Entity) {
 	block := entity.(*flow.Block)
-	delete(c.byView, block.Header.View)
-	blocksByID := c.byParent[block.Header.ParentID]
-	delete(blocksByID, block.ID())
-	if len(blocksByID) == 0 {
+	blockID := block.ID()
+
+	// remove block from the set of blocks for this view
+	blocksForView := c.byView[block.Header.View]
+	delete(blocksForView, blockID)
+	if len(blocksForView) == 0 {
+		delete(c.byView, block.Header.View)
+	}
+
+	// remove block from the parent's set of its children
+	siblings := c.byParent[block.Header.ParentID]
+	delete(siblings, blockID)
+	if len(siblings) == 0 {
 		delete(c.byParent, block.Header.ParentID)
 	}
 }
@@ -123,7 +130,7 @@ func (c *Cache) handleEjectedEntity(entity flow.Entity) {
 // Expected errors during normal operations:
 //   - ErrDisconnectedBatch
 func (c *Cache) AddBlocks(batch []*flow.Block) (certifiedBatch []*flow.Block, certifyingQC *flow.QuorumCertificate, err error) {
-	batch = filterBlocksByView(c.lowestPrunedView.Value(), batch)
+	batch = c.trimLeadingBlocksBelowPruningThreshold(batch)
 
 	batchSize := len(batch)
 	if batchSize < 1 { // empty batch is no-op
@@ -136,17 +143,14 @@ func (c *Cache) AddBlocks(batch []*flow.Block) (certifiedBatch []*flow.Block, ce
 		return nil, nil, err
 	}
 
-	// Single atomic operation (main logic) with result returned as `batchContext`
+	// Single atomic operation (main logic), with result returned as `batchContext`
 	//  * add the given batch of blocks to the cache
 	//  * check for equivocating blocks (result stored in `batchContext.equivocatingBlocks`)
 	//  * check whether first block in batch (index 0) has a parent already in the cache
 	//    (result stored in `batchContext.batchParent`)
 	//  * check whether last block in batch has a child already in the cache
 	//    (result stored in `batchContext.batchChild`)
-	bc, err := c.unsafeAtomicAdd(blockIDs, batch)
-	if err != nil {
-		return nil, nil, fmt.Errorf("processing batch failed: %w", err)
-	}
+	bc := c.unsafeAtomicAdd(blockIDs, batch)
 
 	// If there exists a child of the last block in the batch, then the entire batch is certified.
 	// Otherwise, all blocks in the batch _except_ for the last one are certified
@@ -159,8 +163,8 @@ func (c *Cache) AddBlocks(batch []*flow.Block) (certifiedBatch []*flow.Block, ce
 	}
 	// caution: in the case `len(batch) == 1`, the `certifiedBatch` might be empty now (else-case)
 
-	// If there exists a parent for the batch's first block, then this is parent is certified by the batch.
-	// Then, we prepend certifiedBatch by the parent
+	// If there exists a parent for the batch's first block, then this is parent is certified
+	//  by the batch. Hence, we prepend certifiedBatch by the parent.
 	if bc.batchParent != nil {
 		s := make([]*flow.Block, 0, 1+len(certifiedBatch))
 		s = append(s, bc.batchParent)
@@ -179,9 +183,54 @@ func (c *Cache) AddBlocks(batch []*flow.Block) (certifiedBatch []*flow.Block, ce
 	return certifiedBatch, certifyingQC, nil
 }
 
-// PruneUpToView sets the lowest view that we are accepting blocks for, we don't need to process anything lower than it.
+// PruneUpToView sets the lowest view that we are accepting blocks for. Any blocks
+// with view _strictly smaller_ that the given threshold are removed from the cache.
+// Concurrency safe.
 func (c *Cache) PruneUpToView(view uint64) {
-	c.lowestPrunedView.Set(view)
+	previousPruningThreshold := c.lowestView.Value()
+	if previousPruningThreshold >= view {
+		return // removing all entries up to view was already done in an earlier call
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if !c.lowestView.Set(view) {
+		return // some other concurrent call to `PruneUpToView` did the work already
+	}
+	if len(c.byView) == 0 {
+		return // empty, noting to prune
+	}
+
+	// Optimization: if there are less elements in the `byView` map
+	// than the view range to prune: inspect each map element.
+	// Otherwise, go through each view to prune.
+	if uint64(len(c.byView)) < view-previousPruningThreshold {
+		for v, blocks := range c.byView {
+			if v < view {
+				c.removeByView(v, blocks)
+			}
+		}
+	} else {
+		for v := previousPruningThreshold; v < view; v++ {
+			if blocks, found := c.byView[v]; found {
+				c.removeByView(v, blocks)
+			}
+		}
+	}
+}
+
+// removeByView removes all blocks for the given view.
+// NOT concurrency safe: execute within Cache's lock.
+func (c *Cache) removeByView(view uint64, blocks BlocksByID) {
+	delete(c.byView, view)
+
+	for blockID, block := range blocks {
+		siblings := c.byParent[block.Header.ParentID]
+		delete(siblings, blockID)
+		if len(siblings) == 0 {
+			delete(c.byParent, block.Header.ParentID)
+		}
+	}
 }
 
 // unsafeAtomicAdd does the following within a single atomic operation:
@@ -198,17 +247,13 @@ func (c *Cache) PruneUpToView(view uint64) {
 //   - requires pre-computed blockIDs in the same order as fullBlocks
 //
 // Any errors are symptoms of internal state corruption.
-func (c *Cache) unsafeAtomicAdd(blockIDs []flow.Identifier, fullBlocks []*flow.Block) (batchContext, error) {
+func (c *Cache) unsafeAtomicAdd(blockIDs []flow.Identifier, fullBlocks []*flow.Block) (bc batchContext) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	bc := batchContext{}
 
 	// add blocks to underlying cache, check for equivocation and report if detected
 	for i, block := range fullBlocks {
-		equivocation, err := c.cache(blockIDs[i], block)
-		if err != nil {
-			return bc, fmt.Errorf("caching block %v failed: %w", blockIDs[i], err)
-		}
+		equivocation := c.cache(blockIDs[i], block)
 		if equivocation != nil {
 			bc.equivocatingBlocks = append(bc.equivocatingBlocks, [2]*flow.Block{equivocation, block})
 		}
@@ -230,39 +275,48 @@ func (c *Cache) unsafeAtomicAdd(blockIDs []flow.Identifier, fullBlocks []*flow.B
 			break
 		}
 	}
-
-	return bc, nil
+	return bc
 }
 
-// cache adds the given block to the underlying block cache. By indexing the
-// first block cached for every view, we can detect equivocation. The first return value contains the
-// already-cached equivocating block or `nil` otherwise. Repeated calls with the same block are no-ops.
-// Any errors are symptoms of internal state corruption
-// NOT concurrency safe: execute within Cache's lock.
-func (c *Cache) cache(blockID flow.Identifier, fullBlock *flow.Block) (equivocation *flow.Block, err error) {
-	// check whether there is a block with the same view already in the cache
-	if otherBlockID, isEquivocation := c.byView[fullBlock.Header.View]; isEquivocation {
+// cache adds the given block to the underlying block cache. By indexing blocks by view, we can detect
+// equivocation. The first return value contains the already-cached equivocating block or `nil` otherwise.
+// Repeated calls with the same block are no-ops.
+// CAUTION: not concurrency safe: execute within Cache's lock.
+func (c *Cache) cache(blockID flow.Identifier, block *flow.Block) (equivocation *flow.Block) {
+	cachedBlocksAtView, haveCachedBlocksAtView := c.byView[block.Header.View]
+	// Check whether there is a block with the same view already in the cache.
+	// During happy-path operations `cachedBlocksAtView` contains usually zero blocks or exactly one block
+	// which is `fullBlock` (duplicate). Larger sets of blocks can only be caused by slashable byzantine actions.
+	for otherBlockID, otherBlock := range cachedBlocksAtView {
 		if otherBlockID == blockID {
-			return nil, nil // already stored
+			return nil // already stored
 		}
 		// have two blocks for the same view but with different IDs => equivocation!
-		otherBlock, found := c.backend.ByID(otherBlockID)
-		if !found {
-			// this should never happen, as Cache should hold all indexed blocks
-			return nil, fmt.Errorf("corrupted cache state: secondary byView index lists unknown block")
-		}
-		equivocation = otherBlock.(*flow.Block)
-	} else {
-		c.byView[fullBlock.Header.View] = blockID
+		equivocation = otherBlock
+		break // we care whether the
 	}
 
-	c.backend.Add(blockID, fullBlock) // store all blocks in the cache for deduplication
-	blocksByID, ok := c.byParent[fullBlock.Header.ParentID]
-	if !ok {
-		blocksByID = make(BlocksByID)
-		c.byParent[fullBlock.Header.ParentID] = blocksByID
+	// block is not a duplicate: store in the underlying HeroCache and add it to secondary indices
+	added := c.backend.Add(blockID, block)
+	if !added { // future proofing code: we allow an overflowing HeroCache to potentially eject the newly added element.
+		return
 	}
-	blocksByID[blockID] = fullBlock
+
+	// populate `byView` index
+	if !haveCachedBlocksAtView {
+		cachedBlocksAtView = make(BlocksByID)
+		c.byView[block.Header.View] = cachedBlocksAtView
+	}
+	cachedBlocksAtView[blockID] = block
+
+	// populate `byParent` index
+	siblings, ok := c.byParent[block.Header.ParentID]
+	if !ok {
+		siblings = make(BlocksByID)
+		c.byParent[block.Header.ParentID] = siblings
+	}
+	siblings[blockID] = block
+
 	return
 }
 
@@ -284,15 +338,22 @@ func enforceSequentialBlocks(batch []*flow.Block) ([]flow.Identifier, error) {
 	return blockIDs, nil
 }
 
-// filterBlocksByView performs a specific filter ensuring blocks are higher than the lowest view.
-// It assumes that batch is ordered sequentially, to avoid extra allocations while filtering.
-// It has to be paired with enforceSequentialBlocks which checks if blocks are properly ordered.
-func filterBlocksByView(lowestView uint64, batch []*flow.Block) []*flow.Block {
-	i := 0
-	for ; i < len(batch); i++ {
-		if batch[i].Header.View > lowestView {
-			break
+// trimLeadingFinalizedBlocks trims the blocks at the _beginning_ of the batch, whose views
+// are smaller or equal to the lowest pruned view. Formally, let i be the _smallest_ index such that
+//
+//	batch[i].View ≥ lowestView
+//
+// Hence, for all k < i: batch[k].View < lowestView (otherwise, a smaller value for i exists).
+// Note:
+//   - For this method, we do _not_ assume any specific ordering of the blocks.
+//   - We drop all blocks at the _beginning_ that we anyway would not want to cache.
+//   - The returned slice of blocks could still contain blocks with views below the cutoff.
+func (c *Cache) trimLeadingBlocksBelowPruningThreshold(batch []*flow.Block) []*flow.Block {
+	lowestView := c.lowestView.Value()
+	for i, block := range batch {
+		if block.Header.View >= lowestView {
+			return batch[i:]
 		}
 	}
-	return batch[i:]
+	return nil
 }

--- a/engine/common/follower/cache/cache.go
+++ b/engine/common/follower/cache/cache.go
@@ -222,15 +222,17 @@ func (c *Cache) PruneUpToView(view uint64) {
 // removeByView removes all blocks for the given view.
 // NOT concurrency safe: execute within Cache's lock.
 func (c *Cache) removeByView(view uint64, blocks BlocksByID) {
-	delete(c.byView, view)
-
 	for blockID, block := range blocks {
+		c.backend.Remove(blockID)
+
 		siblings := c.byParent[block.Header.ParentID]
 		delete(siblings, blockID)
 		if len(siblings) == 0 {
 			delete(c.byParent, block.Header.ParentID)
 		}
 	}
+
+	delete(c.byView, view)
 }
 
 // unsafeAtomicAdd does the following within a single atomic operation:

--- a/engine/common/follower/cache/cache_test.go
+++ b/engine/common/follower/cache/cache_test.go
@@ -169,7 +169,7 @@ func (s *CacheSuite) TestAddBatch() {
 // TestPruneUpToView tests that blocks lower than pruned height will be properly filtered out from incoming batch.
 func (s *CacheSuite) TestPruneUpToView() {
 	blocks := unittest.ChainFixtureFrom(3, unittest.BlockHeaderFixture())
-	s.cache.PruneUpToView(blocks[0].Header.View)
+	s.cache.PruneUpToView(blocks[1].Header.View)
 	certifiedBatch, certifyingQC, err := s.cache.AddBlocks(blocks)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), blocks[1:len(blocks)-1], certifiedBatch)


### PR DESCRIPTION
## Suggested revisions for PR https://github.com/onflow/flow-go/pull/3965/
• extending secondary index to store _all_ blocks by their respective view
• adding pruning logic

### Motivation:
* When we eject a block, we just delete the corresponding element in the `byView` map https://github.com/onflow/flow-go/blob/ec683db33b286b5620d7248499944143291e6a94/engine/common/follower/cache/cache.go#L91
Imagine that we have two blocks for the same view in the cache and one is ejected. Then, we wouldn’t be detecting equations anymore for this block.
I am not sure that this is a problem. I don’t think so. But it makes it very hard to precisely quantify the guarantees the cache makes. Its more a conceptual concern. I have grown very weary of code that has subtle behaviours that are hard to reason about.
* Similarly with the pruning:
   
   We just let the cache run full and then rely on random ejection. While very unlikely, this might eject an element that we still need during normal operations. Its not a conceptual concern, because such block will be _eventually re-requested_. But it can cause a hick-up in the very time sensitive happy path for consensus. 

   In my mind, the random ejection is an emergency protection against being spammed.  But during normal operations, it would be great to not rely on random ejection because it makes the cache’s behaviour somewhat non-deterministic. 

This brings me to the following conclusion
* I like the random ejection as anti-spam protection, because the non-determinism of an overflowing cache makes it hard for spammers to attack a larger set of nodes.
* However, for the happy-path operations, we prefer fully deterministic behaviour (not rely on ejection and instead pre-emptively drop old blocks by view)

## Approach
Addressing both points is unlocked by changing `byView` https://github.com/onflow/flow-go/blob/ec683db33b286b5620d7248499944143291e6a94/engine/common/follower/cache/cache.go#L44-L45

Instead of storing only the first block for each view, we store _all_ blocks for each view: https://github.com/onflow/flow-go/blob/7cf04f9a61722852a96a98c7b4ba965a53d1287d/engine/common/follower/cache/cache.go#L44-L45

Advantages:
* We can actively prune by hight, because we know all the blocks for each height.
* Furthermore, we would reliably detect equivocation as long as the cache doesn’t overflow, which is only expected during a spamming attack.
