### PR TITLE
Replace View with SnapshotTree as storage representation

### DIFF
--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/engine/execution/computation/result"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
+	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
@@ -40,6 +41,7 @@ type ViewCommitter interface {
 type transactionResult struct {
 	transaction
 	*state.ExecutionSnapshot
+	fvm.ProcedureOutput
 }
 
 // TODO(ramtin): move committer and other folks to consumers layer
@@ -244,32 +246,33 @@ func (collector *resultCollector) commitCollection(
 func (collector *resultCollector) processTransactionResult(
 	txn transaction,
 	txnExecutionSnapshot *state.ExecutionSnapshot,
+	output fvm.ProcedureOutput,
 ) error {
 	collector.convertedServiceEvents = append(
 		collector.convertedServiceEvents,
-		txn.ConvertedServiceEvents...)
+		output.ConvertedServiceEvents...)
 
 	collector.result.Events[txn.collectionIndex] = append(
 		collector.result.Events[txn.collectionIndex],
-		txn.Events...)
+		output.Events...)
 	collector.result.ServiceEvents = append(
 		collector.result.ServiceEvents,
-		txn.ServiceEvents...)
+		output.ServiceEvents...)
 
 	txnResult := flow.TransactionResult{
 		TransactionID:   txn.ID,
-		ComputationUsed: txn.ComputationUsed,
-		MemoryUsed:      txn.MemoryEstimate,
+		ComputationUsed: output.ComputationUsed,
+		MemoryUsed:      output.MemoryEstimate,
 	}
-	if txn.Err != nil {
-		txnResult.ErrorMessage = txn.Err.Error()
+	if output.Err != nil {
+		txnResult.ErrorMessage = output.Err.Error()
 	}
 
 	collector.result.TransactionResults = append(
 		collector.result.TransactionResults,
 		txnResult)
 
-	for computationKind, intensity := range txn.ComputationIntensities {
+	for computationKind, intensity := range output.ComputationIntensities {
 		collector.result.ComputationIntensities[computationKind] += intensity
 	}
 
@@ -278,8 +281,8 @@ func (collector *resultCollector) processTransactionResult(
 		return fmt.Errorf("failed to merge into collection view: %w", err)
 	}
 
-	collector.currentCollectionStats.ComputationUsed += txn.ComputationUsed
-	collector.currentCollectionStats.MemoryUsed += txn.MemoryEstimate
+	collector.currentCollectionStats.ComputationUsed += output.ComputationUsed
+	collector.currentCollectionStats.MemoryUsed += output.MemoryEstimate
 	collector.currentCollectionStats.NumberOfTransactions += 1
 
 	if !txn.lastTransactionInCollection {
@@ -295,10 +298,12 @@ func (collector *resultCollector) processTransactionResult(
 func (collector *resultCollector) AddTransactionResult(
 	txn transaction,
 	snapshot *state.ExecutionSnapshot,
+	output fvm.ProcedureOutput,
 ) {
 	result := transactionResult{
 		transaction:       txn,
 		ExecutionSnapshot: snapshot,
+		ProcedureOutput:   output,
 	}
 
 	select {
@@ -315,7 +320,8 @@ func (collector *resultCollector) runResultProcessor() {
 	for result := range collector.processorInputChan {
 		err := collector.processTransactionResult(
 			result.transaction,
-			result.ExecutionSnapshot)
+			result.ExecutionSnapshot,
+			result.ProcedureOutput)
 		if err != nil {
 			collector.processorError = err
 			return

--- a/fvm/storage/snapshot_tree.go
+++ b/fvm/storage/snapshot_tree.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+const (
+	compactThreshold = 10
+)
+
+type updateLog []map[flow.RegisterID]flow.RegisterValue
+
+// SnapshotTree is a simple LSM tree representation of the key/value storage
+// at a given point in time.
+type SnapshotTree struct {
+	base state.StorageSnapshot
+
+	fullLog      updateLog
+	compactedLog updateLog
+}
+
+// NewSnapshotTree returns a tree with keys/values initialized to the base
+// storage snapshot.
+func NewSnapshotTree(base state.StorageSnapshot) SnapshotTree {
+	return SnapshotTree{
+		base:         base,
+		fullLog:      nil,
+		compactedLog: nil,
+	}
+}
+
+// Append returns a new tree with updates from the execution snapshot "applied"
+// to the original original tree.
+func (tree SnapshotTree) Append(
+	update *state.ExecutionSnapshot,
+) SnapshotTree {
+	compactedLog := tree.compactedLog
+	if len(update.WriteSet) > 0 {
+		compactedLog = append(tree.compactedLog, update.WriteSet)
+		if len(compactedLog) > compactThreshold {
+			size := 0
+			for _, set := range compactedLog {
+				size += len(set)
+			}
+
+			mergedSet := make(map[flow.RegisterID]flow.RegisterValue, size)
+			for _, set := range compactedLog {
+				for id, value := range set {
+					mergedSet[id] = value
+				}
+			}
+
+			compactedLog = updateLog{mergedSet}
+		}
+	}
+
+	return SnapshotTree{
+		base:         tree.base,
+		fullLog:      append(tree.fullLog, update.WriteSet),
+		compactedLog: compactedLog,
+	}
+}
+
+// Get returns the register id's value.
+func (tree SnapshotTree) Get(id flow.RegisterID) (flow.RegisterValue, error) {
+	for idx := len(tree.compactedLog) - 1; idx >= 0; idx-- {
+		value, ok := tree.compactedLog[idx][id]
+		if ok {
+			return value, nil
+		}
+	}
+
+	if tree.base != nil {
+		return tree.base.Get(id)
+	}
+
+	return nil, nil
+}

--- a/fvm/storage/snapshot_tree_test.go
+++ b/fvm/storage/snapshot_tree_test.go
@@ -1,0 +1,131 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestSnapshotTree(t *testing.T) {
+	id1 := flow.NewRegisterID("1", "")
+	id2 := flow.NewRegisterID("2", "")
+	id3 := flow.NewRegisterID("3", "")
+	missingId := flow.NewRegisterID("missing", "")
+
+	value1v0 := flow.RegisterValue("1v0")
+
+	// entries:
+	// 1 -> 1v0
+	tree0 := NewSnapshotTree(
+		state.MapStorageSnapshot{
+			id1: value1v0,
+		})
+
+	expected0 := map[flow.RegisterID]flow.RegisterValue{
+		id1:       value1v0,
+		id2:       nil,
+		id3:       nil,
+		missingId: nil,
+	}
+
+	value2v1 := flow.RegisterValue("2v1")
+
+	tree1 := tree0.Append(
+		&state.ExecutionSnapshot{
+			WriteSet: map[flow.RegisterID]flow.RegisterValue{
+				id2: value2v1,
+			},
+		})
+
+	expected1 := map[flow.RegisterID]flow.RegisterValue{
+		id1:       value1v0,
+		id2:       value2v1,
+		id3:       nil,
+		missingId: nil,
+	}
+
+	value1v1 := flow.RegisterValue("1v1")
+	value3v1 := flow.RegisterValue("3v1")
+
+	tree2 := tree1.Append(
+		&state.ExecutionSnapshot{
+			WriteSet: map[flow.RegisterID]flow.RegisterValue{
+				id1: value1v1,
+				id3: value3v1,
+			},
+		})
+
+	expected2 := map[flow.RegisterID]flow.RegisterValue{
+		id1:       value1v1,
+		id2:       value2v1,
+		id3:       value3v1,
+		missingId: nil,
+	}
+
+	value2v2 := flow.RegisterValue("2v2")
+
+	tree3 := tree2.Append(
+		&state.ExecutionSnapshot{
+			WriteSet: map[flow.RegisterID]flow.RegisterValue{
+				id2: value2v2,
+			},
+		})
+
+	expected3 := map[flow.RegisterID]flow.RegisterValue{
+		id1:       value1v1,
+		id2:       value2v2,
+		id3:       value3v1,
+		missingId: nil,
+	}
+
+	expectedCompacted := map[flow.RegisterID]flow.RegisterValue{
+		id1:       value1v1,
+		id2:       value2v2,
+		id3:       value3v1,
+		missingId: nil,
+	}
+
+	compactedTree := tree3
+	numExtraUpdates := 2*compactThreshold + 1
+	for i := 0; i < numExtraUpdates; i++ {
+		value := []byte(fmt.Sprintf("compacted %d", i))
+		expectedCompacted[id3] = value
+		compactedTree = compactedTree.Append(
+			&state.ExecutionSnapshot{
+				WriteSet: map[flow.RegisterID]flow.RegisterValue{
+					id3: value,
+				},
+			})
+	}
+
+	check := func(
+		tree SnapshotTree,
+		expected map[flow.RegisterID]flow.RegisterValue,
+		fullLogLen int,
+		compactedLogLen int,
+	) {
+		require.Len(t, tree.fullLog, fullLogLen)
+		require.Len(t, tree.compactedLog, compactedLogLen)
+
+		for key, expectedValue := range expected {
+			value, err := tree.Get(key)
+			require.NoError(t, err)
+			require.Equal(t, value, expectedValue, string(expectedValue))
+		}
+	}
+
+	check(tree0, expected0, 0, 0)
+	check(tree1, expected1, 1, 1)
+	check(tree2, expected2, 2, 2)
+	check(tree3, expected3, 3, 3)
+	check(compactedTree, expectedCompacted, 3+numExtraUpdates, 4)
+
+	emptyTree := NewSnapshotTree(nil)
+	value, err := emptyTree.Get(id1)
+	require.NoError(t, err)
+	require.Nil(t, value)
+}


### PR DESCRIPTION
This simplify parallel execution (the tree is immutable and the list of write sets can be used for OCC validation), but at the expense of less efficient value lookups (the cost is amortized by compaction).