### PR TITLE
Track script/transaction procedure program depedencies

### DIFF
--- a/fvm/environment/facade_env.go
+++ b/fvm/environment/facade_env.go
@@ -286,6 +286,7 @@ func (env *facadeEnvironment) FlushPendingUpdates() (
 func (env *facadeEnvironment) Reset() {
 	env.ContractUpdater.Reset()
 	env.EventEmitter.Reset()
+	env.Programs.Reset()
 }
 
 // Miscellaneous cadence runtime.Interface API.


### PR DESCRIPTION
ref: https://github.com/onflow/cadence/issues/1684

Change the dependency stack for transaction/script programs to always have root dependencies. The root dependencies in this case are dependencies of the script/transaction procedure itself. 

The reason we want this is to have a map of "seen" imports, so we know when we need to reapply metering and when not... which is the next/last step in this PR chain.

I added a reset (which is called when switching from the transactions happy path/normal execution to the transaction failure path/fee deduction) that clears all non address programs and dependencies tracked, to avoid any potential cache poisoning.