### PR TITLE
Remove double counting of imports

### DIFF
--- a/fvm/derived/derived_block_data.go
+++ b/fvm/derived/derived_block_data.go
@@ -18,6 +18,7 @@ type DerivedTransaction interface {
 		*Program,
 		error,
 	)
+	GetProgram(location common.AddressLocation) (*Program, bool)
 
 	GetMeterParamOverrides(
 		txnState state.NestedTransaction,
@@ -183,6 +184,19 @@ func (transaction *DerivedTransactionData) GetOrComputeProgram(
 		txState,
 		addressLocation,
 		programComputer)
+}
+
+// GetProgram returns the program for the given address location.
+// This does NOT apply reads/metering to any nested transaction.
+// Use with caution!
+func (transaction *DerivedTransactionData) GetProgram(
+	location common.AddressLocation,
+) (
+	*Program,
+	bool,
+) {
+	program, _, ok := transaction.programs.get(location)
+	return program, ok
 }
 
 func (transaction *DerivedTransactionData) AddInvalidator(

--- a/fvm/errors/codes.go
+++ b/fvm/errors/codes.go
@@ -25,6 +25,7 @@ const (
 	FailureCodeHasherFailure                           ErrorCode = 2005
 	FailureCodeParseRestrictedModeInvalidAccessFailure ErrorCode = 2006
 	FailureCodePayerBalanceCheckFailure                ErrorCode = 2007
+	FailureCodeDerivedDataCacheImplementationFailure   ErrorCode = 2008
 	// Deprecated: No longer used.
 	FailureCodeMetaTransactionFailure ErrorCode = 2100
 )

--- a/fvm/errors/execution.go
+++ b/fvm/errors/execution.go
@@ -84,6 +84,17 @@ func NewPayerBalanceCheckFailure(
 		payer)
 }
 
+// NewDerivedDataCacheImplementationFailure indicate an implementation error in
+// the derived data cache.
+func NewDerivedDataCacheImplementationFailure(
+	err error,
+) CodedError {
+	return WrapCodedError(
+		FailureCodeDerivedDataCacheImplementationFailure,
+		err,
+		"implementation error in derived data cache")
+}
+
 // NewComputationLimitExceededError constructs a new CodedError which indicates
 // that computation has exceeded its limit.
 func NewComputationLimitExceededError(limit uint64) CodedError {

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -1993,7 +1993,7 @@ func TestInteractionLimit(t *testing.T) {
 		},
 		{
 			name:             "even lower low limit fails, and has only 3 events",
-			interactionLimit: 10000,
+			interactionLimit: 5000,
 			require: func(t *testing.T, tx *fvm.TransactionProcedure) {
 				require.Error(t, tx.Err)
 				require.Len(t, tx.Events, 3)


### PR DESCRIPTION
closes: https://github.com/onflow/cadence/issues/1684

This removes metering imports multiple times within the same "scope".

with this scenario:
```
A
B imports A
C imports A,B
D imports C,A, B  <- order is important
```

this is the loading process:

- scope D: count importing D
    - scope C: count importing C
        - count importing A
        - scope B: 
            - count importing  A (even though it has been seen in scope C it has not been seen in scope B so we need to count it)
    - don't count importing A it has already been seen in scope D
    - don't count importing B (and dependencies) it has already been seen in scope D

The reason for this is that any of those individual "scopes"/contracts/programs need to be loaded independently because they are cached independently.
