### PR TITLE
Remove derived block/txn data from (most) tests

### DIFF
--- a/cmd/util/ledger/reporters/fungible_token_tracker_test.go
+++ b/cmd/util/ledger/reporters/fungible_token_tracker_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -49,12 +48,10 @@ func TestFungibleTokenTracker(t *testing.T) {
 		reporters.NewStorageSnapshotFromPayload(payloads))
 
 	vm := fvm.NewVirtualMachine()
-	derivedBlockData := derived.NewEmptyDerivedBlockData()
 	opts := []fvm.Option{
 		fvm.WithChain(chain),
 		fvm.WithAuthorizationChecksEnabled(false),
 		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
-		fvm.WithDerivedBlockData(derivedBlockData),
 	}
 	ctx := fvm.NewContext(opts...)
 	bootstrapOptions := []fvm.BootstrapProcedureOption{
@@ -103,7 +100,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		SetScript(deployingTestContractScript).
 		AddAuthorizer(chain.ServiceAddress())
 
-	tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+	tx := fvm.Transaction(txBody, 0)
 	snapshot, output, err := vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, output.Err)
@@ -132,7 +129,7 @@ func TestFungibleTokenTracker(t *testing.T) {
 		AddArgument(jsoncdc.MustEncode(cadence.UFix64(105))).
 		AddAuthorizer(chain.ServiceAddress())
 
-	tx = fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+	tx = fvm.Transaction(txBody, 0)
 	snapshot, output, err = vm.RunV2(ctx, tx, view)
 	require.NoError(t, err)
 	require.NoError(t, output.Err)

--- a/engine/execution/computation/manager_benchmark_test.go
+++ b/engine/execution/computation/manager_benchmark_test.go
@@ -51,7 +51,6 @@ func createAccounts(b *testing.B, vm fvm.VM, ledger state.View, num int) *testAc
 	addresses, err := testutil.CreateAccounts(
 		vm,
 		ledger,
-		derived.NewEmptyDerivedBlockData(),
 		privateKeys,
 		chain)
 	require.NoError(b, err)

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -60,7 +60,7 @@ func TestComputeBlockWithStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	ledger := testutil.RootBootstrappedLedger(vm, execCtx)
-	accounts, err := testutil.CreateAccounts(vm, ledger, derived.NewEmptyDerivedBlockData(), privateKeys, chain)
+	accounts, err := testutil.CreateAccounts(vm, ledger, privateKeys, chain)
 	require.NoError(t, err)
 
 	tx1 := testutil.DeployCounterContractTransaction(accounts[0], chain)
@@ -705,7 +705,7 @@ func Test_EventEncodingFailsOnlyTxAndCarriesOn(t *testing.T) {
 	privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
 	require.NoError(t, err)
 	ledger := testutil.RootBootstrappedLedger(vm, execCtx)
-	accounts, err := testutil.CreateAccounts(vm, ledger, derived.NewEmptyDerivedBlockData(), privateKeys, chain)
+	accounts, err := testutil.CreateAccounts(vm, ledger, privateKeys, chain)
 	require.NoError(t, err)
 
 	// setup transactions
@@ -861,14 +861,12 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 	vm := manager.vm
 	view := testutil.RootBootstrappedLedger(vm, ctx)
 
-	derivedBlockData := derived.NewEmptyDerivedBlockData()
-
 	// Create an account private key.
 	privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
 	require.NoError(t, err)
 
 	// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-	accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+	accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 	require.NoError(t, err)
 	account := accounts[0]
 	address := cadence.NewAddress(account)

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -47,7 +47,6 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 	accounts, err := testutil.CreateAccounts(
 		vm,
 		ledger,
-		derived.NewEmptyDerivedBlockData(),
 		privateKeys,
 		chain)
 	require.NoError(t, err)
@@ -214,7 +213,6 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 	accounts, err := testutil.CreateAccounts(
 		vm,
 		ledger,
-		derived.NewEmptyDerivedBlockData(),
 		privateKeys,
 		chain)
 	require.NoError(t, err)

--- a/engine/execution/testutil/fixtures.go
+++ b/engine/execution/testutil/fixtures.go
@@ -16,7 +16,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state/delta"
 	"github.com/onflow/flow-go/engine/execution/utils"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/epochs"
@@ -190,17 +189,15 @@ func GenerateAccountPrivateKey() (flow.AccountPrivateKey, error) {
 func CreateAccounts(
 	vm fvm.VM,
 	view state.View,
-	derivedBlockData *derived.DerivedBlockData,
 	privateKeys []flow.AccountPrivateKey,
 	chain flow.Chain,
 ) ([]flow.Address, error) {
-	return CreateAccountsWithSimpleAddresses(vm, view, derivedBlockData, privateKeys, chain)
+	return CreateAccountsWithSimpleAddresses(vm, view, privateKeys, chain)
 }
 
 func CreateAccountsWithSimpleAddresses(
 	vm fvm.VM,
 	view state.View,
-	derivedBlockData *derived.DerivedBlockData,
 	privateKeys []flow.AccountPrivateKey,
 	chain flow.Chain,
 ) ([]flow.Address, error) {
@@ -208,7 +205,6 @@ func CreateAccountsWithSimpleAddresses(
 		fvm.WithChain(chain),
 		fvm.WithAuthorizationChecksEnabled(false),
 		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
-		fvm.WithDerivedBlockData(derivedBlockData),
 	)
 
 	var accounts []flow.Address
@@ -251,9 +247,7 @@ func CreateAccountsWithSimpleAddresses(
 			AddArgument(encCadPublicKey).
 			AddAuthorizer(serviceAddress)
 
-		tx := fvm.Transaction(
-			txBody,
-			derivedBlockData.NextTxIndexForTestingOnly())
+		tx := fvm.Transaction(txBody, 0)
 		err := vm.Run(ctx, tx, view)
 		if err != nil {
 			return nil, err

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/derived"
 	errors "github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
@@ -231,7 +230,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -266,7 +264,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -334,7 +331,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -371,7 +367,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -408,7 +403,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -450,7 +444,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -488,7 +481,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -518,7 +510,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -564,7 +555,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -613,7 +603,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -662,7 +651,6 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -896,7 +884,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 
 	t.Run("Storing too much data fails", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		run(
-			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 				ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
 
 				// Create an account private key.
@@ -904,7 +892,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-				accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+				accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 				require.NoError(t, err)
 
 				txBody := testutil.CreateContractDeploymentTransaction(
@@ -922,7 +910,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx := fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
@@ -931,7 +919,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 			}))
 	t.Run("Increasing storage capacity works", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		run(
-			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 				ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
 
 				// Create an account private key.
@@ -939,7 +927,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-				accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+				accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 				require.NoError(t, err)
 
 				// deposit more flow to increase capacity
@@ -975,7 +963,7 @@ func TestBlockContext_ExecuteTransaction_StorageLimit(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx := fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
@@ -1010,7 +998,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 	t.Run("Using to much interaction fails", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		withContextOptions(fvm.WithTransactionFeesEnabled(true)).
 		run(
-			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 				ctx.MaxStateInteractionSize = 500_000
 
 				// Create an account private key.
@@ -1018,7 +1006,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-				accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+				accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 				require.NoError(t, err)
 
 				n := 0
@@ -1037,7 +1025,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 
 				err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				require.NoError(t, err)
-				tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx := fvm.Transaction(txBody, 0)
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
 				assert.NoError(t, tx.Err)
@@ -1059,7 +1047,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx = fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx = fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
@@ -1070,7 +1058,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 	t.Run("Using to much interaction but not failing because of service account", newVMTest().withBootstrapProcedureOptions(bootstrapOptions...).
 		withContextOptions(fvm.WithTransactionFeesEnabled(true)).
 		run(
-			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 				ctx.MaxStateInteractionSize = 500_000
 				// ctx.MaxStateInteractionSize = 100_000 // this is not enough to load the FlowServiceAccount for fee deduction
 
@@ -1079,7 +1067,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-				accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+				accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 				require.NoError(t, err)
 
 				txBody := testutil.CreateContractDeploymentTransaction(
@@ -1097,7 +1085,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, chain.ServiceAddress(), unittest.ServiceAccountPrivateKey)
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx := fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
@@ -1110,7 +1098,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 			fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
 		).
 		run(
-			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 				ctx.MaxStateInteractionSize = 50_000
 
 				// Create an account private key.
@@ -1118,7 +1106,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-				accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+				accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 				require.NoError(t, err)
 
 				_, txBody := testutil.CreateMultiAccountCreationTransaction(t, chain, 40)
@@ -1132,7 +1120,7 @@ func TestBlockContext_ExecuteTransaction_InteractionLimitReached(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx := fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
@@ -1230,7 +1218,6 @@ func TestBlockContext_ExecuteScript(t *testing.T) {
 		accounts, err := testutil.CreateAccounts(
 			vm,
 			ledger,
-			derived.NewEmptyDerivedBlockData(),
 			privateKeys,
 			chain)
 		require.NoError(t, err)
@@ -1473,8 +1460,6 @@ func TestBlockContext_GetAccount(t *testing.T) {
 
 	ledger := testutil.RootBootstrappedLedger(vm, ctx)
 
-	derivedBlockData := derived.NewEmptyDerivedBlockData()
-
 	createAccount := func() (flow.Address, crypto.PublicKey) {
 		privateKey, txBody := testutil.CreateAccountCreationTransaction(t, chain)
 
@@ -1493,7 +1478,7 @@ func TestBlockContext_GetAccount(t *testing.T) {
 		require.NoError(t, err)
 
 		// execute the transaction
-		tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+		tx := fvm.Transaction(txBody, 0)
 
 		err = vm.Run(ctx, tx, ledger)
 		require.NoError(t, err)
@@ -1672,7 +1657,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 		fvm.WithExecutionMemoryLimit(math.MaxUint64),
 	).run(
-		func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+		func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 			ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
 
 			// Create an account private key.
@@ -1680,7 +1665,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			require.NoError(t, err)
 
 			// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-			accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+			accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 			require.NoError(t, err)
 
 			balanceBefore := getBalance(vm, chain, ctx, view, accounts[0])
@@ -1696,7 +1681,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+			tx := fvm.Transaction(txBody, 0)
 
 			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
@@ -1715,7 +1700,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 		fvm.WithExecutionMemoryLimit(math.MaxUint64),
 	).run(
-		func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+		func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 			ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
 
 			// Create an account private key.
@@ -1723,7 +1708,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			require.NoError(t, err)
 
 			// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-			accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+			accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 			require.NoError(t, err)
 
 			// non-existent account
@@ -1744,7 +1729,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 			err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 			require.NoError(t, err)
 
-			tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+			tx := fvm.Transaction(txBody, 0)
 
 			err = vm.Run(ctx, tx, view)
 			require.NoError(t, err)
@@ -1762,7 +1747,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 		fvm.WithAccountCreationFee(fvm.DefaultAccountCreationFee),
 	).
 		run(
-			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 				ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
 
 				// Create an account private key.
@@ -1770,7 +1755,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-				accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+				accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 				require.NoError(t, err)
 
 				txBody := transferTokensTx(chain).
@@ -1785,7 +1770,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx := fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
@@ -1813,7 +1798,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 		fvm.WithStorageMBPerFLOW(fvm.DefaultStorageMBPerFLOW),
 	).
 		run(
-			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+			func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 				ctx.LimitAccountStorage = true // this test requires storage limits to be enforced
 
 				// Create an account private key.
@@ -1821,7 +1806,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				require.NoError(t, err)
 
 				// Bootstrap a ledger, creating accounts with the provided private keys and the root account.
-				accounts, err := testutil.CreateAccounts(vm, view, derivedBlockData, privateKeys, chain)
+				accounts, err := testutil.CreateAccounts(vm, view, privateKeys, chain)
 				require.NoError(t, err)
 
 				txBody := transferTokensTx(chain).
@@ -1835,7 +1820,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				err = testutil.SignEnvelope(txBody, accounts[0], privateKeys[0])
 				require.NoError(t, err)
 
-				tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx := fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)
@@ -1843,7 +1828,7 @@ func TestBlockContext_ExecuteTransaction_FailingTransactions(t *testing.T) {
 				require.True(t, errors.IsCadenceRuntimeError(tx.Err))
 
 				// send it again
-				tx = fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+				tx = fvm.Transaction(txBody, 0)
 
 				err = vm.Run(ctx, tx, view)
 				require.NoError(t, err)

--- a/fvm/fvm_fuzz_test.go
+++ b/fvm/fvm_fuzz_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
-	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
@@ -33,7 +32,7 @@ func FuzzTransactionComputationLimit(f *testing.F) {
 
 		tt := fuzzTransactionTypes[transactionType]
 
-		vmt.run(func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) {
+		vmt.run(func(t *testing.T, vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) {
 			// create the transaction
 			txBody := tt.createTxBody(t, tctx)
 			// set the computation limit
@@ -52,7 +51,7 @@ func FuzzTransactionComputationLimit(f *testing.F) {
 			// set the interaction limit
 			ctx.MaxStateInteractionSize = interactionLimit
 			// run the transaction
-			tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+			tx := fvm.Transaction(txBody, 0)
 
 			require.NotPanics(t, func() {
 				err = vm.Run(ctx, tx, view)
@@ -251,7 +250,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 	).withContextOptions(
 		fvm.WithTransactionFeesEnabled(true),
 		fvm.WithAccountStorageLimit(true),
-	).bootstrapWith(func(vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View, derivedBlockData *derived.DerivedBlockData) error {
+	).bootstrapWith(func(vm fvm.VM, chain flow.Chain, ctx fvm.Context, view state.View) error {
 		// ==== Create an account ====
 		var txBody *flow.TransactionBody
 		privateKey, txBody = testutil.CreateAccountCreationTransaction(tb, chain)
@@ -261,7 +260,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 			return err
 		}
 
-		tx := fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+		tx := fvm.Transaction(txBody, 0)
 
 		err = vm.Run(ctx, tx, view)
 
@@ -291,7 +290,7 @@ func bootstrapFuzzStateAndTxContext(tb testing.TB) (bootstrappedVmTest, transact
 		)
 		require.NoError(tb, err)
 
-		tx = fvm.Transaction(txBody, derivedBlockData.NextTxIndexForTestingOnly())
+		tx = fvm.Transaction(txBody, 0)
 
 		err = vm.Run(ctx, tx, view)
 		if err != nil {

--- a/fvm/fvm_signature_test.go
+++ b/fvm/fvm_signature_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
 	fvmCrypto "github.com/onflow/flow-go/fvm/crypto"
-	"github.com/onflow/flow-go/fvm/derived"
 	"github.com/onflow/flow-go/fvm/state"
 	"github.com/onflow/flow-go/model/flow"
 	msig "github.com/onflow/flow-go/module/signature"
@@ -164,7 +163,6 @@ func TestKeyListSignature(t *testing.T) {
 					chain flow.Chain,
 					ctx fvm.Context,
 					view state.View,
-					derivedBlockData *derived.DerivedBlockData,
 				) {
 					privateKey, publicKey := createKey()
 					signableMessage, message := createMessage("foo")
@@ -261,7 +259,6 @@ func TestKeyListSignature(t *testing.T) {
 					chain flow.Chain,
 					ctx fvm.Context,
 					view state.View,
-					derivedBlockData *derived.DerivedBlockData,
 				) {
 					privateKeyA, publicKeyA := createKey()
 					privateKeyB, publicKeyB := createKey()
@@ -398,7 +395,6 @@ func TestBLSMultiSignature(t *testing.T) {
 				chain flow.Chain,
 				ctx fvm.Context,
 				view state.View,
-				derivedBlockData *derived.DerivedBlockData,
 			) {
 
 				code := func(signatureAlgorithm signatureAlgorithm) []byte {
@@ -510,7 +506,6 @@ func TestBLSMultiSignature(t *testing.T) {
 				chain flow.Chain,
 				ctx fvm.Context,
 				view state.View,
-				derivedBlockData *derived.DerivedBlockData,
 			) {
 
 				code := []byte(
@@ -634,7 +629,6 @@ func TestBLSMultiSignature(t *testing.T) {
 				chain flow.Chain,
 				ctx fvm.Context,
 				view state.View,
-				derivedBlockData *derived.DerivedBlockData,
 			) {
 
 				code := func(signatureAlgorithm signatureAlgorithm) []byte {
@@ -759,7 +753,6 @@ func TestBLSMultiSignature(t *testing.T) {
 				chain flow.Chain,
 				ctx fvm.Context,
 				view state.View,
-				derivedBlockData *derived.DerivedBlockData,
 			) {
 
 				message, cadenceMessage := createMessage("random_message")


### PR DESCRIPTION
Derived txn data is now an optional parameter.  The explicit setup is no longer needed (except for programs test and benchmark)