### PR TITLE
Alex/4070 missing random beacon private key hot fix

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -537,7 +537,7 @@ func main() {
 			// wrap Main consensus committee with metrics
 			wrappedCommittee := committees.NewMetricsWrapper(committee, mainMetrics) // wrapper for measuring time spent determining consensus committee relations
 
-			beaconKeyStore := hotsignature.NewEpochAwareRandomBeaconKeyStore(epochLookup, safeBeaconKeys)
+			beaconKeyStore := hotsignature.NewEpochAwareRandomBeaconKeyStore(node.Logger, epochLookup, safeBeaconKeys)
 
 			// initialize the combined signer for hotstuff
 			var signer hotstuff.Signer

--- a/consensus/hotstuff/signature/block_signer_decoder_test.go
+++ b/consensus/hotstuff/signature/block_signer_decoder_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/signature"
+	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 

--- a/consensus/hotstuff/verification/combined_signer_v2_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v2_test.go
@@ -3,6 +3,7 @@ package verification
 import (
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +44,7 @@ func TestCombinedSignWithDKGKey(t *testing.T) {
 	// there is DKG key for this epoch
 	keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(dkgKey, true, nil)
 
-	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 	stakingPriv := unittest.StakingPrivKeyFixture()
 	nodeID := unittest.IdentityFixture()
@@ -143,7 +144,7 @@ func TestCombinedSignWithNoDKGKey(t *testing.T) {
 	// there is no DKG key for this epoch
 	keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(nil, false, nil)
 
-	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 	stakingPriv := unittest.StakingPrivKeyFixture()
 	nodeID := unittest.IdentityFixture()

--- a/consensus/hotstuff/verification/combined_signer_v3_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v3_test.go
@@ -3,6 +3,7 @@ package verification
 import (
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -43,7 +44,7 @@ func TestCombinedSignWithDKGKeyV3(t *testing.T) {
 	// there is DKG key for this epoch
 	keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(dkgKey, true, nil)
 
-	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 	stakingPriv := unittest.StakingPrivKeyFixture()
 	nodeID := unittest.IdentityFixture()
@@ -110,7 +111,7 @@ func TestCombinedSignWithNoDKGKeyV3(t *testing.T) {
 	// there is no DKG key for this epoch
 	keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(nil, false, nil)
 
-	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+	beaconKeyStore := signature.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 	stakingPriv := unittest.StakingPrivKeyFixture()
 	nodeID := unittest.IdentityFixture()

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -818,7 +819,7 @@ func TestCombinedVoteProcessorV2_BuildVerifyQC(t *testing.T) {
 		// there is no DKG key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(nil, false, nil)
 
-		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 		me, err := local.New(identity, stakingPriv)
 		require.NoError(t, err)
@@ -840,7 +841,7 @@ func TestCombinedVoteProcessorV2_BuildVerifyQC(t *testing.T) {
 		// there is DKG key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(dkgKey, true, nil)
 
-		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 		me, err := local.New(identity, stakingPriv)
 		require.NoError(t, err)

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -953,7 +954,7 @@ func TestCombinedVoteProcessorV3_BuildVerifyQC(t *testing.T) {
 		// there is no DKG key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(nil, false, nil)
 
-		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 		me, err := local.New(identity, stakingPriv)
 		require.NoError(t, err)
@@ -975,7 +976,7 @@ func TestCombinedVoteProcessorV3_BuildVerifyQC(t *testing.T) {
 		// there is DKG key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(dkgKey, true, nil)
 
-		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(zerolog.Nop(), epochLookup, keys)
 
 		me, err := local.New(identity, stakingPriv)
 		require.NoError(t, err)

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -487,7 +487,7 @@ func createNode(
 		nil)
 
 	// use epoch aware store for testing scenarios where epoch changes
-	beaconKeyStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
+	beaconKeyStore := hsig.NewEpochAwareRandomBeaconKeyStore(log, epochLookup, keys)
 
 	signer := verification.NewCombinedSigner(me, beaconKeyStore)
 

--- a/module/signer.go
+++ b/module/signer.go
@@ -14,7 +14,8 @@ var (
 
 // RandomBeaconKeyStore returns the random beacon private key for the given view,
 type RandomBeaconKeyStore interface {
-	// It returns:
+	// ByView returns the consensus node's _private_ random beacon key share for
+	// signing blocks at the given view. Possible returns:
 	//  - (signer, nil) if the node has beacon keys in the epoch of the view
 	//  - (nil, DKGFailError) if the node doesn't have beacon keys in the epoch of the view
 	//  - (nil, error) if there is any exception

--- a/storage/badger/dkg_state.go
+++ b/storage/badger/dkg_state.go
@@ -149,7 +149,7 @@ func (keys *SafeBeaconPrivateKeys) RetrieveMyBeaconPrivateKey(epochCounter uint6
 		if err != nil {
 			key = nil
 			safe = false
-			return err
+			return fmt.Errorf("failed to read DKGEndState from database for epoch %d: %w", epochCounter, err)
 		}
 
 		// for any end state besides success, the key is not safe
@@ -165,7 +165,7 @@ func (keys *SafeBeaconPrivateKeys) RetrieveMyBeaconPrivateKey(epochCounter uint6
 		if err != nil {
 			key = nil
 			safe = false
-			return err
+			return fmt.Errorf("failed to read random beacon private key from database for epoch %d: %w", epochCounter, err)
 		}
 
 		// return the key only for successful end state


### PR DESCRIPTION
## _HOT-FIX_ for consensus node in a crash loop after missing Epoch Setup Phase and hence missing a private random beacon key share. 

see issue https://github.com/onflow/flow-go/issues/4070 for more details

### Caution
**Run ONLY on AFFECTED NODES.** If this hot-fix is deployed on many consensus nodes, it could undermine
protocol liveness by potentially hiding other liveness-critical bugs!


