### PR TITLE
[CI] Only run jobs for selected roles

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -45,43 +45,51 @@ on:
 
 jobs:
   docker-push:
-    name: Push ${{ matrix.role }} to container registry
+    name: ${{ matrix.role }} images
     runs-on: ubuntu-latest
 
     # setup jobs for each role
     strategy:
       fail-fast: false
       matrix:
-        role: [access, collection, consensus, execution, verification, observer]
+        role: ${{ steps.set-matrix.outputs.roles }}
 
     steps:
-    - name: Check build selected
-      # gate the run based on whether or not the role was selected.
-      # this avoids running all the setup steps for roles that aren't enabled
-      if: ${{ (matrix.role == 'access'       && inputs.build_access) ||
-              (matrix.role == 'collection'   && inputs.build_collection) ||
-              (matrix.role == 'consensus'    && inputs.build_consensus) ||
-              (matrix.role == 'execution'    && inputs.build_execution) ||
-              (matrix.role == 'verification' && inputs.build_verification) ||
-              (matrix.role == 'observer'     && inputs.build_observer) }}
-      run: echo "role_enabled=true" >> $GITHUB_ENV
+    # select the roles to add to the matrix based on the input selections
+    - id: set-matrix
+      run: |
+        roles=()
+        if [[ "${{ inputs.build_access }}" = "true" ]]; then
+          roles+=( "access" )
+        fi
+        if [[ "${{ inputs.build_collection }}" = "true" ]]; then
+          roles+=( "collection" )
+        fi
+        if [[ "${{ inputs.build_consensus }}" = "true" ]]; then
+          roles+=( "consensus" )
+        fi
+        if [[ "${{ inputs.build_execution }}" = "true" ]]; then
+          roles+=( "execution" )
+        fi
+        if [[ "${{ inputs.build_verification }}" = "true" ]]; then
+          roles+=( "verification" )
+        fi
+        if [[ "${{ inputs.build_observer }}" = "true" ]]; then
+          roles+=( "observer" )
+        fi
+        rolesJSON=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${X[@]}")
+        echo "roles=${rolesJSON}" >> $GITHUB_OUTPUT
     - name: Setup Go
-      if: env.role_enabled
       uses: actions/setup-go@v2
       with:
         go-version: '1.19'
     - name: Checkout repo
-      if: env.role_enabled
       uses: actions/checkout@v2
       with:
         ref: ${{ inputs.tag }}
-    - name: Build relic
-      if: env.role_enabled
-      run: make crypto_setup_gopath
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
     - name: Docker login
-      if: env.role_enabled
       uses: docker/login-action@v1
       with:
         registry: gcr.io
@@ -89,11 +97,14 @@ jobs:
         password: ${{ secrets.GCR_SERVICE_KEY }}
 
     - name: Build/Push ${{ matrix.role }} images
-      if: env.role_enabled
       env:
         IMAGE_TAG: ${{ inputs.docker_tag }}
       run: |
         make docker-build-${{ matrix.role }} docker-push-${{ matrix.role }}
-        if [[ "${{ inputs.include_without_netgo }}" = "true" ]]; then
-          make docker-build-${{ matrix.role }}-without-netgo docker-push-${{ matrix.role }}-without-netgo
-        fi
+
+    - name: Build/Push ${{ matrix.role }} without_netgo images
+      if: ${{ inputs.include_without_netgo }}
+      env:
+        IMAGE_TAG: ${{ inputs.docker_tag }}
+      run: |
+        make docker-build-${{ matrix.role }}-without-netgo docker-push-${{ matrix.role }}-without-netgo

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -54,16 +54,17 @@ jobs:
       matrix:
         role: [access, collection, consensus, execution, verification, observer]
 
-    # gate the run based on whether or not the role was selected.
-    # this avoids running all the setup steps for roles that aren't enabled
-    if: ${{ (inputs.build_access && matrix.role == 'access') ||
-            (inputs.build_collection && matrix.role == 'collection') ||
-            (inputs.build_consensus && matrix.role == 'consensus') ||
-            (inputs.build_execution && matrix.role == 'execution') ||
-            (inputs.build_verification && matrix.role == 'verification') ||
-            (inputs.build_observer && matrix.role == 'observer') }}
-
     steps:
+    - name: Check build selected
+      # gate the run based on whether or not the role was selected.
+      # this avoids running all the setup steps for roles that aren't enabled
+      if: ${{ (matrix.role == 'access'       && !inputs.build_access) ||
+              (matrix.role == 'collection'   && !inputs.build_collection) ||
+              (matrix.role == 'consensus'    && !inputs.build_consensus) ||
+              (matrix.role == 'execution'    && !inputs.build_execution) ||
+              (matrix.role == 'verification' && !inputs.build_verification) ||
+              (matrix.role == 'observer'     && !inputs.build_observer) }}
+      run: exit 1
     - name: Setup Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -64,20 +64,24 @@ jobs:
               (matrix.role == 'execution'    && !inputs.build_execution) ||
               (matrix.role == 'verification' && !inputs.build_verification) ||
               (matrix.role == 'observer'     && !inputs.build_observer) }}
-      run: exit 1
+      run: echo "role_enabled=true" >> $GITHUB_ENV
     - name: Setup Go
+      if: env.role_enabled
       uses: actions/setup-go@v2
       with:
         go-version: '1.19'
     - name: Checkout repo
+      if: env.role_enabled
       uses: actions/checkout@v2
       with:
         ref: ${{ inputs.tag }}
     - name: Build relic
+      if: env.role_enabled
       run: make crypto_setup_gopath
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
     - name: Docker login
+      if: env.role_enabled
       uses: docker/login-action@v1
       with:
         registry: gcr.io
@@ -85,6 +89,7 @@ jobs:
         password: ${{ secrets.GCR_SERVICE_KEY }}
 
     - name: Build/Push ${{ matrix.role }} images
+      if: env.role_enabled
       env:
         IMAGE_TAG: ${{ inputs.docker_tag }}
       run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -71,7 +71,7 @@ jobs:
         if [[ "${{ inputs.build_observer }}" = "true" ]]; then
           roles+=( "observer" )
         fi
-        rolesJSON=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${X[@]}")
+        rolesJSON=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${roles[@]}")
         echo "matrix={\"roles\":$(echo $rolesJSON)}" >> $GITHUB_OUTPUT
   docker-push:
     name: ${{ matrix.role }} images

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -44,19 +44,13 @@ on:
         required: false
 
 jobs:
-  docker-push:
-    name: ${{ matrix.role }} images
+  # matrix_builder generates a matrix that includes the roles selected in the input
+  matrix_builder:
     runs-on: ubuntu-latest
-
-    # setup jobs for each role
-    strategy:
-      fail-fast: false
-      matrix:
-        role: ${{ steps.set-matrix.outputs.roles }}
-
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
     steps:
-    # select the roles to add to the matrix based on the input selections
-    - id: set-matrix
+    - id: generate
       run: |
         roles=()
         if [[ "${{ inputs.build_access }}" = "true" ]]; then
@@ -78,7 +72,18 @@ jobs:
           roles+=( "observer" )
         fi
         rolesJSON=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${X[@]}")
-        echo "roles=${rolesJSON}" >> $GITHUB_OUTPUT
+        echo "matrix={\"roles\":$(echo $rolesJSON)}" >> $GITHUB_OUTPUT
+  docker-push:
+    name: ${{ matrix.role }} images
+    runs-on: ubuntu-latest
+    needs: matrix_builder
+
+    # setup jobs for each role
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix_builder.outputs.matrix) }}
+
+    steps:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -45,12 +45,24 @@ on:
 
 jobs:
   docker-push:
-    name: Push to container registry
+    name: Push ${{ matrix.role }} to container registry
     runs-on: ubuntu-latest
+
+    # setup jobs for each role
     strategy:
       fail-fast: false
       matrix:
         role: [access, collection, consensus, execution, verification, observer]
+
+    # gate the run based on whether or not the role was selected.
+    # this avoids running all the setup steps for roles that aren't enabled
+    if: ${{ (inputs.build_access && matrix.role == 'access') ||
+            (inputs.build_collection && matrix.role == 'collection') ||
+            (inputs.build_consensus && matrix.role == 'consensus') ||
+            (inputs.build_execution && matrix.role == 'execution') ||
+            (inputs.build_verification && matrix.role == 'verification') ||
+            (inputs.build_observer && matrix.role == 'observer') }}
+
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
@@ -72,12 +84,6 @@ jobs:
         password: ${{ secrets.GCR_SERVICE_KEY }}
 
     - name: Build/Push ${{ matrix.role }} images
-      if: ${{ (inputs.build_access && matrix.role == 'access') ||
-              (inputs.build_collection && matrix.role == 'collection') ||
-              (inputs.build_consensus && matrix.role == 'consensus') ||
-              (inputs.build_execution && matrix.role == 'execution') ||
-              (inputs.build_verification && matrix.role == 'verification') ||
-              (inputs.build_observer && matrix.role == 'observer') }}
       env:
         IMAGE_TAG: ${{ inputs.docker_tag }}
       run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -72,7 +72,7 @@ jobs:
           roles+=( "observer" )
         fi
         rolesJSON=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${roles[@]}")
-        echo "matrix={\"roles\":$(echo $rolesJSON)}" >> $GITHUB_OUTPUT
+        echo "matrix={\"role\":$(echo $rolesJSON)}" >> $GITHUB_OUTPUT
   docker-push:
     name: ${{ matrix.role }} images
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -58,12 +58,12 @@ jobs:
     - name: Check build selected
       # gate the run based on whether or not the role was selected.
       # this avoids running all the setup steps for roles that aren't enabled
-      if: ${{ (matrix.role == 'access'       && !inputs.build_access) ||
-              (matrix.role == 'collection'   && !inputs.build_collection) ||
-              (matrix.role == 'consensus'    && !inputs.build_consensus) ||
-              (matrix.role == 'execution'    && !inputs.build_execution) ||
-              (matrix.role == 'verification' && !inputs.build_verification) ||
-              (matrix.role == 'observer'     && !inputs.build_observer) }}
+      if: ${{ (matrix.role == 'access'       && inputs.build_access) ||
+              (matrix.role == 'collection'   && inputs.build_collection) ||
+              (matrix.role == 'consensus'    && inputs.build_consensus) ||
+              (matrix.role == 'execution'    && inputs.build_execution) ||
+              (matrix.role == 'verification' && inputs.build_verification) ||
+              (matrix.role == 'observer'     && inputs.build_observer) }}
       run: echo "role_enabled=true" >> $GITHUB_ENV
     - name: Setup Go
       if: env.role_enabled

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -46,6 +46,7 @@ on:
 jobs:
   # matrix_builder generates a matrix that includes the roles selected in the input
   matrix_builder:
+    name: Setup build jobs
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}


### PR DESCRIPTION
The original version would spawn jobs and do all of the pre-build steps for all roles, wasting runner resources. This change:
* Only creates jobs for roles that were selected
* Skips building relic on the node runner since it is already run during the docker builds