### PR TITLE
Add step to print results of test monitor

### DIFF
--- a/.github/workflows/test-monitor-flaky.yml
+++ b/.github/workflows/test-monitor-flaky.yml
@@ -72,6 +72,8 @@ jobs:
         TEST_FLAKY: true
         JSON_OUTPUT: true
         RACE_DETECTOR: 1
+    - name: Print test results
+      run: cat test-output
     - name: Process test results
       run: cat test-output | go run tools/test_monitor/level1/process_summary1_results.go
       env:

--- a/.github/workflows/test-monitor-regular-skipped.yml
+++ b/.github/workflows/test-monitor-regular-skipped.yml
@@ -76,6 +76,8 @@ jobs:
         command: ./tools/test_monitor/run-tests.sh
       env:
         JSON_OUTPUT: true
+    - name: Print test results
+      run: cat test-output
     - name: Process test results
       run: cat test-output | go run tools/test_monitor/level1/process_summary1_results.go
       env:


### PR DESCRIPTION
The Flaky test monitor processes results and makes them available on a test-by-test basis in Bigquery, however there is not a way to see the full test output.

Here's an example of where this can be useful: https://dapperlabs.grafana.net/d/toErpbynz/single-test-metrics?orgId=1&var-package=github.com%2Fonflow%2Fflow-go%2Fintegration%2Fdkg&var-dataset_name=dapperlabs-data.production_src_flow_test_metrics&var-skipped_tests_table=skipped_tests&var-test_results_table=test_results&var-query_limit=100000&var-test=TestWithEmulator%2FTestNodesDown&from=1679042550234&to=1679065565932

The test failed, but the output shows an immediate timeout. Did the test itself time out without printing any logs? Did a previous test time out? It's difficult to tell without more context.