### PR TITLE
Re-arrange header interface

### DIFF
--- a/fvm/environment/blocks.go
+++ b/fvm/environment/blocks.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Blocks interface {
-	// ByHeight returns the block at the given height in the chain ending in `header` (or finalized
+	// ByHeightFrom returns the block at the given height in the chain ending in `header` (or finalized
 	// if `header` is nil). This enables querying un-finalized blocks by height with respect to the
 	// chain defined by the block we are executing.
 	ByHeightFrom(height uint64, header *flow.Header) (*flow.Header, error)
@@ -21,11 +21,11 @@ type Blocks interface {
 
 // BlocksFinder finds blocks and return block headers
 type BlocksFinder struct {
-	storage storage.Headers
+	storage storage.HeadersGetter
 }
 
 // NewBlockFinder constructs a new block finder
-func NewBlockFinder(storage storage.Headers) Blocks {
+func NewBlockFinder(storage storage.HeadersGetter) Blocks {
 	return &BlocksFinder{storage: storage}
 }
 

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
@@ -163,7 +164,8 @@ func (h *Headers) ByParentID(parentID flow.Identifier) ([]*flow.Header, error) {
 	for _, blockID := range blockIDs {
 		header, err := h.ByBlockID(blockID)
 		if err != nil {
-			return nil, fmt.Errorf("could not retrieve child (%x): %w", blockID, err)
+			// any error (including NotFound) is an exception because it implies the child index is corrupted
+			return nil, irrecoverable.NewExceptionf("could not retrieve child (%x): %w", blockID, err)
 		}
 		headers = append(headers, header)
 	}

--- a/storage/headers.go
+++ b/storage/headers.go
@@ -6,30 +6,35 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// Headers represents persistent storage for blocks.
-type Headers interface {
-
-	// Store will store a header.
-	Store(header *flow.Header) error
-
+// HeadersGetter is read-only storage access for block headers and related indexes.
+type HeadersGetter interface {
 	// ByBlockID returns the header with the given ID. It is available for finalized and ambiguous blocks.
-	// Error returns:
-	//  - ErrNotFound if no block header with the given ID exists
+	// Expected errors during normal operations:
+	//   - storage.ErrNotFound if no block is known with the given ID
 	ByBlockID(blockID flow.Identifier) (*flow.Header, error)
 
 	// ByHeight returns the block with the given number. It is only available for finalized blocks.
+	// Expected errors during normal operations:
+	//   - storage.ErrNotFound if no finalized block is known at given height
 	ByHeight(height uint64) (*flow.Header, error)
 
 	// BlockIDByHeight the block ID that is finalized at the given height. It is an optimized version
-	// of `ByHeight` that skips retrieving the block. Expected errors during normal operations:
-	//  * `storage.ErrNotFound` if no finalized block is known at given height
+	// of `ByHeight` that skips retrieving the block.
+	// Expected errors during normal operations:
+	//   - storage.ErrNotFound if no block is known at given height
 	BlockIDByHeight(height uint64) (flow.Identifier, error)
 
-	// ByParentID finds all children for the given parent block. The returned headers
-	// might be unfinalized; if there is more than one, at least one of them has to
-	// be unfinalized.
+	// ByParentID finds all children for the given parent block. The returned headers might be un-finalized.
+	// If there is more than one, at least one of them has to be un-finalized.
+	// If there are no children, an empty slice is returned (no error).
+	// Expected errors during normal operations:
+	//   - storage.ErrNotFound if no block is known with the given ID `parentID`
 	ByParentID(parentID flow.Identifier) ([]*flow.Header, error)
+}
 
+// HeadersByChunkID is read/write storage for the chunkID->header index.
+// These methods are exclusively used by the Execution Node.
+type HeadersByChunkID interface {
 	// IndexByChunkID indexes block ID by chunk ID.
 	IndexByChunkID(headerID, chunkID flow.Identifier) error
 
@@ -43,4 +48,13 @@ type Headers interface {
 	// No errors are expected during normal operation, even if no entries are matched.
 	// If Badger unexpectedly fails to process the request, the error is wrapped in a generic error and returned.
 	BatchRemoveChunkBlockIndexByChunkID(chunkID flow.Identifier, batch BatchStorage) error
+}
+
+// Headers represents persistent read/write storage for block headers.
+type Headers interface {
+	// Store will store a header.
+	Store(header *flow.Header) error
+
+	HeadersGetter
+	HeadersByChunkID
 }


### PR DESCRIPTION
Simplify interface used by environment.BlocksFinder, and flow-emu, to make dependency less fragile (adding `Headers` methods is no longer a breaking change).