### PR TITLE
Rename State to ExecutionState

### DIFF
--- a/fvm/state/execution_state.go
+++ b/fvm/state/execution_state.go
@@ -20,7 +20,7 @@ const (
 // State represents the execution state
 // it holds draft of updates and captures
 // all register touches
-type State struct {
+type ExecutionState struct {
 	// NOTE: A finalized view is no longer accessible.  It can however be
 	// re-attached to another transaction and be committed (for cached result
 	// bookkeeping purpose).
@@ -99,14 +99,14 @@ func (controller *limitsController) RunWithAllLimitsDisabled(f func()) {
 	controller.enforceLimits = current
 }
 
-func (s *State) View() View {
-	return s.view
+func (state *ExecutionState) View() View {
+	return state.view
 }
 
-// NewState constructs a new state
-func NewState(view View, params StateParameters) *State {
+// NewExecutionState constructs a new state
+func NewExecutionState(view View, params StateParameters) *ExecutionState {
 	m := meter.NewMeter(params.MeterParameters)
-	return &State{
+	return &ExecutionState{
 		finalized:        false,
 		view:             view,
 		meter:            m,
@@ -116,198 +116,198 @@ func NewState(view View, params StateParameters) *State {
 
 // NewChildWithMeterParams generates a new child state using the provide meter
 // parameters.
-func (s *State) NewChildWithMeterParams(
+func (state *ExecutionState) NewChildWithMeterParams(
 	params meter.MeterParameters,
-) *State {
-	return &State{
+) *ExecutionState {
+	return &ExecutionState{
 		finalized:        false,
-		view:             s.view.NewChild(),
+		view:             state.view.NewChild(),
 		meter:            meter.NewMeter(params),
-		limitsController: s.limitsController,
+		limitsController: state.limitsController,
 	}
 }
 
 // NewChild generates a new child state using the parent's meter parameters.
-func (s *State) NewChild() *State {
-	return s.NewChildWithMeterParams(s.meter.MeterParameters)
+func (state *ExecutionState) NewChild() *ExecutionState {
+	return state.NewChildWithMeterParams(state.meter.MeterParameters)
 }
 
 // InteractionUsed returns the amount of ledger interaction (total ledger byte read + total ledger byte written)
-func (s *State) InteractionUsed() uint64 {
-	return s.meter.TotalBytesOfStorageInteractions()
+func (state *ExecutionState) InteractionUsed() uint64 {
+	return state.meter.TotalBytesOfStorageInteractions()
 }
 
 // BytesWritten returns the amount of total ledger bytes written
-func (s *State) BytesWritten() uint64 {
-	return s.meter.TotalBytesWrittenToStorage()
+func (state *ExecutionState) BytesWritten() uint64 {
+	return state.meter.TotalBytesWrittenToStorage()
 }
 
-func (s *State) DropChanges() error {
-	if s.finalized {
+func (state *ExecutionState) DropChanges() error {
+	if state.finalized {
 		return fmt.Errorf("cannot DropChanges on a finalized view")
 	}
 
-	return s.view.DropChanges()
+	return state.view.DropChanges()
 }
 
 // Get returns a register value given owner and key
-func (s *State) Get(id flow.RegisterID) (flow.RegisterValue, error) {
-	if s.finalized {
+func (state *ExecutionState) Get(id flow.RegisterID) (flow.RegisterValue, error) {
+	if state.finalized {
 		return nil, fmt.Errorf("cannot Get on a finalized view")
 	}
 
 	var value []byte
 	var err error
 
-	if s.enforceLimits {
-		if err = s.checkSize(id, []byte{}); err != nil {
+	if state.enforceLimits {
+		if err = state.checkSize(id, []byte{}); err != nil {
 			return nil, err
 		}
 	}
 
-	if value, err = s.view.Get(id); err != nil {
+	if value, err = state.view.Get(id); err != nil {
 		// wrap error into a fatal error
 		getError := errors.NewLedgerFailure(err)
 		// wrap with more info
 		return nil, fmt.Errorf("failed to read %s: %w", id, getError)
 	}
 
-	err = s.meter.MeterStorageRead(id, value, s.enforceLimits)
+	err = state.meter.MeterStorageRead(id, value, state.enforceLimits)
 	return value, err
 }
 
 // Set updates state delta with a register update
-func (s *State) Set(id flow.RegisterID, value flow.RegisterValue) error {
-	if s.finalized {
+func (state *ExecutionState) Set(id flow.RegisterID, value flow.RegisterValue) error {
+	if state.finalized {
 		return fmt.Errorf("cannot Set on a finalized view")
 	}
 
-	if s.enforceLimits {
-		if err := s.checkSize(id, value); err != nil {
+	if state.enforceLimits {
+		if err := state.checkSize(id, value); err != nil {
 			return err
 		}
 	}
 
-	if err := s.view.Set(id, value); err != nil {
+	if err := state.view.Set(id, value); err != nil {
 		// wrap error into a fatal error
 		setError := errors.NewLedgerFailure(err)
 		// wrap with more info
 		return fmt.Errorf("failed to update %s: %w", id, setError)
 	}
 
-	return s.meter.MeterStorageWrite(id, value, s.enforceLimits)
+	return state.meter.MeterStorageWrite(id, value, state.enforceLimits)
 }
 
 // MeterComputation meters computation usage
-func (s *State) MeterComputation(kind common.ComputationKind, intensity uint) error {
-	if s.finalized {
+func (state *ExecutionState) MeterComputation(kind common.ComputationKind, intensity uint) error {
+	if state.finalized {
 		return fmt.Errorf("cannot MeterComputation on a finalized view")
 	}
 
-	if s.enforceLimits {
-		return s.meter.MeterComputation(kind, intensity)
+	if state.enforceLimits {
+		return state.meter.MeterComputation(kind, intensity)
 	}
 	return nil
 }
 
 // TotalComputationUsed returns total computation used
-func (s *State) TotalComputationUsed() uint64 {
-	return s.meter.TotalComputationUsed()
+func (state *ExecutionState) TotalComputationUsed() uint64 {
+	return state.meter.TotalComputationUsed()
 }
 
 // ComputationIntensities returns computation intensities
-func (s *State) ComputationIntensities() meter.MeteredComputationIntensities {
-	return s.meter.ComputationIntensities()
+func (state *ExecutionState) ComputationIntensities() meter.MeteredComputationIntensities {
+	return state.meter.ComputationIntensities()
 }
 
 // TotalComputationLimit returns total computation limit
-func (s *State) TotalComputationLimit() uint {
-	return s.meter.TotalComputationLimit()
+func (state *ExecutionState) TotalComputationLimit() uint {
+	return state.meter.TotalComputationLimit()
 }
 
 // MeterMemory meters memory usage
-func (s *State) MeterMemory(kind common.MemoryKind, intensity uint) error {
-	if s.finalized {
+func (state *ExecutionState) MeterMemory(kind common.MemoryKind, intensity uint) error {
+	if state.finalized {
 		return fmt.Errorf("cannot MeterMemory on a finalized view")
 	}
 
-	if s.enforceLimits {
-		return s.meter.MeterMemory(kind, intensity)
+	if state.enforceLimits {
+		return state.meter.MeterMemory(kind, intensity)
 	}
 
 	return nil
 }
 
 // MemoryIntensities returns computation intensities
-func (s *State) MemoryIntensities() meter.MeteredMemoryIntensities {
-	return s.meter.MemoryIntensities()
+func (state *ExecutionState) MemoryIntensities() meter.MeteredMemoryIntensities {
+	return state.meter.MemoryIntensities()
 }
 
 // TotalMemoryEstimate returns total memory used
-func (s *State) TotalMemoryEstimate() uint64 {
-	return s.meter.TotalMemoryEstimate()
+func (state *ExecutionState) TotalMemoryEstimate() uint64 {
+	return state.meter.TotalMemoryEstimate()
 }
 
 // TotalMemoryLimit returns total memory limit
-func (s *State) TotalMemoryLimit() uint {
-	return uint(s.meter.TotalMemoryLimit())
+func (state *ExecutionState) TotalMemoryLimit() uint {
+	return uint(state.meter.TotalMemoryLimit())
 }
 
-func (s *State) MeterEmittedEvent(byteSize uint64) error {
-	if s.finalized {
+func (state *ExecutionState) MeterEmittedEvent(byteSize uint64) error {
+	if state.finalized {
 		return fmt.Errorf("cannot MeterEmittedEvent on a finalized view")
 	}
 
-	if s.enforceLimits {
-		return s.meter.MeterEmittedEvent(byteSize)
+	if state.enforceLimits {
+		return state.meter.MeterEmittedEvent(byteSize)
 	}
 
 	return nil
 }
 
-func (s *State) TotalEmittedEventBytes() uint64 {
-	return s.meter.TotalEmittedEventBytes()
+func (state *ExecutionState) TotalEmittedEventBytes() uint64 {
+	return state.meter.TotalEmittedEventBytes()
 }
 
-func (s *State) Finalize() *ExecutionSnapshot {
-	s.finalized = true
-	snapshot := s.view.Finalize()
-	snapshot.Meter = s.meter
+func (state *ExecutionState) Finalize() *ExecutionSnapshot {
+	state.finalized = true
+	snapshot := state.view.Finalize()
+	snapshot.Meter = state.meter
 	return snapshot
 }
 
 // MergeState the changes from a the given view to this view.
-func (s *State) Merge(other *ExecutionSnapshot) error {
-	if s.finalized {
+func (state *ExecutionState) Merge(other *ExecutionSnapshot) error {
+	if state.finalized {
 		return fmt.Errorf("cannot Merge on a finalized view")
 	}
 
-	err := s.view.Merge(other)
+	err := state.view.Merge(other)
 	if err != nil {
 		return errors.NewStateMergeFailure(err)
 	}
 
-	s.meter.MergeMeter(other.Meter)
+	state.meter.MergeMeter(other.Meter)
 	return nil
 }
 
-func (s *State) checkSize(
+func (state *ExecutionState) checkSize(
 	id flow.RegisterID,
 	value flow.RegisterValue,
 ) error {
 	keySize := uint64(len(id.Owner) + len(id.Key))
 	valueSize := uint64(len(value))
-	if keySize > s.maxKeySizeAllowed {
+	if keySize > state.maxKeySizeAllowed {
 		return errors.NewStateKeySizeLimitError(
 			id,
 			keySize,
-			s.maxKeySizeAllowed)
+			state.maxKeySizeAllowed)
 	}
-	if valueSize > s.maxValueSizeAllowed {
+	if valueSize > state.maxValueSizeAllowed {
 		return errors.NewStateValueSizeLimitError(
 			value,
 			valueSize,
-			s.maxValueSizeAllowed)
+			state.maxValueSizeAllowed)
 	}
 	return nil
 }

--- a/fvm/state/execution_state_test.go
+++ b/fvm/state/execution_state_test.go
@@ -19,9 +19,9 @@ func createByteArray(size int) []byte {
 	return bytes
 }
 
-func TestState_Finalize(t *testing.T) {
+func TestExecutionState_Finalize(t *testing.T) {
 	view := delta.NewDeltaView(nil)
-	parent := state.NewState(view, state.DefaultParameters())
+	parent := state.NewExecutionState(view, state.DefaultParameters())
 
 	child := parent.NewChild()
 
@@ -65,9 +65,9 @@ func TestState_Finalize(t *testing.T) {
 
 }
 
-func TestState_ChildMergeFunctionality(t *testing.T) {
+func TestExecutionState_ChildMergeFunctionality(t *testing.T) {
 	view := delta.NewDeltaView(nil)
-	st := state.NewState(view, state.DefaultParameters())
+	st := state.NewExecutionState(view, state.DefaultParameters())
 
 	t.Run("test read from parent state (backoff)", func(t *testing.T) {
 		key := flow.NewRegisterID("address", "key1")
@@ -137,9 +137,11 @@ func TestState_ChildMergeFunctionality(t *testing.T) {
 
 }
 
-func TestState_MaxValueSize(t *testing.T) {
+func TestExecutionState_MaxValueSize(t *testing.T) {
 	view := delta.NewDeltaView(nil)
-	st := state.NewState(view, state.DefaultParameters().WithMaxValueSizeAllowed(6))
+	st := state.NewExecutionState(
+		view,
+		state.DefaultParameters().WithMaxValueSizeAllowed(6))
 
 	key := flow.NewRegisterID("address", "key")
 
@@ -154,9 +156,9 @@ func TestState_MaxValueSize(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestState_MaxKeySize(t *testing.T) {
+func TestExecutionState_MaxKeySize(t *testing.T) {
 	view := delta.NewDeltaView(nil)
-	st := state.NewState(
+	st := state.NewExecutionState(
 		view,
 		// Note: owners are always 8 bytes
 		state.DefaultParameters().WithMaxKeySizeAllowed(8+2))
@@ -182,7 +184,7 @@ func TestState_MaxKeySize(t *testing.T) {
 
 }
 
-func TestState_MaxInteraction(t *testing.T) {
+func TestExecutionState_MaxInteraction(t *testing.T) {
 	view := delta.NewDeltaView(nil)
 
 	key1 := flow.NewRegisterID("1", "2")
@@ -200,7 +202,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	key4 := flow.NewRegisterID("3", "4567")
 	key4Size := uint64(8 + 4)
 
-	st := state.NewState(
+	st := state.NewExecutionState(
 		view,
 		state.DefaultParameters().
 			WithMeterParameters(
@@ -222,7 +224,7 @@ func TestState_MaxInteraction(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, st.InteractionUsed(), key1Size+key2Size+key3Size)
 
-	st = state.NewState(
+	st = state.NewExecutionState(
 		view,
 		state.DefaultParameters().
 			WithMeterParameters(

--- a/fvm/state/transaction_state_test.go
+++ b/fvm/state/transaction_state_test.go
@@ -196,7 +196,7 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 
 	val := createByteArray(2)
 
-	cachedState := state.NewState(
+	cachedState := state.NewExecutionState(
 		delta.NewDeltaView(nil),
 		state.DefaultParameters(),
 	)

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -69,7 +69,7 @@ type transactionExecutor struct {
 	errs *errors.ErrorsCollector
 
 	nestedTxnId state.NestedTransactionId
-	pausedState *state.State
+	pausedState *state.ExecutionState
 
 	cadenceRuntime  *reusableRuntime.ReusableCadenceRuntime
 	txnBodyExecutor runtime.Executor


### PR DESCRIPTION
I'm going to refactor delta view into SpockState and StorageState.  Renaming State to ExecutionState to distinguish the different states.