### PR TITLE
Fix read leaf nodes

### DIFF
--- a/ledger/complete/wal/checkpoint_v6_leaf_reader.go
+++ b/ledger/complete/wal/checkpoint_v6_leaf_reader.go
@@ -18,11 +18,6 @@ type LeafNode struct {
 	Payload *ledger.Payload
 }
 
-type LeafNodeResult struct {
-	LeafNode *LeafNode
-	Err      error
-}
-
 func nodeToLeaf(leaf *node.Node) *LeafNode {
 	return &LeafNode{
 		Hash:    leaf.Hash(),
@@ -34,7 +29,7 @@ func nodeToLeaf(leaf *node.Node) *LeafNode {
 // OpenAndReadLeafNodesFromCheckpointV6 takes a channel for pushing the leaf nodes that are read from
 // the given checkpoint file specified by dir and fileName.
 // It returns when finish reading the checkpoint file and the input channel can be closed.
-func OpenAndReadLeafNodesFromCheckpointV6(allLeafNodesCh chan<- LeafNodeResult, dir string, fileName string, logger *zerolog.Logger) (errToReturn error) {
+func OpenAndReadLeafNodesFromCheckpointV6(allLeafNodesCh chan<- *LeafNode, dir string, fileName string, logger *zerolog.Logger) (errToReturn error) {
 	// we are the only sender of the channel, closing it after done
 	defer func() {
 		close(allLeafNodesCh)
@@ -73,8 +68,8 @@ func OpenAndReadLeafNodesFromCheckpointV6(allLeafNodesCh chan<- LeafNodeResult, 
 	return nil
 }
 
-func readCheckpointSubTrieLeafNodes(leafNodesCh chan<- LeafNodeResult, dir string, fileName string, index int, checksum uint32, logger *zerolog.Logger) error {
-	err := processCheckpointSubTrie(dir, fileName, index, checksum, logger,
+func readCheckpointSubTrieLeafNodes(leafNodesCh chan<- *LeafNode, dir string, fileName string, index int, checksum uint32, logger *zerolog.Logger) error {
+	return processCheckpointSubTrie(dir, fileName, index, checksum, logger,
 		func(reader *Crc32Reader, nodesCount uint64) error {
 			scratch := make([]byte, 1024*4) // must not be less than 1024
 
@@ -91,23 +86,11 @@ func readCheckpointSubTrieLeafNodes(leafNodesCh chan<- LeafNodeResult, dir strin
 					return fmt.Errorf("cannot read node %d: %w", i, err)
 				}
 				if node.IsLeaf() {
-					leafNodesCh <- LeafNodeResult{
-						LeafNode: nodeToLeaf(node),
-						Err:      nil,
-					}
+					leafNodesCh <- nodeToLeaf(node)
 				}
 
 				logging(i)
 			}
 			return nil
 		})
-
-	if err != nil {
-		leafNodesCh <- LeafNodeResult{
-			LeafNode: nil,
-			Err:      err,
-		}
-	}
-
-	return err
 }

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -313,7 +313,6 @@ func TestWriteAndReadCheckpointV6LeafEmptyTrie(t *testing.T) {
 		bufSize := 10
 		leafNodesCh := make(chan LeafNodeResult, bufSize)
 		go func() {
-			defer close(leafNodesCh)
 			err := OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, &logger)
 			require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
 		}()
@@ -329,10 +328,9 @@ func TestWriteAndReadCheckpointV6LeafSimpleTrie(t *testing.T) {
 		fileName := "checkpoint"
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, &logger), "fail to store checkpoint")
-		bufSize := 10
+		bufSize := 1
 		leafNodesCh := make(chan LeafNodeResult, bufSize)
 		go func() {
-			defer close(leafNodesCh)
 			err := OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, &logger)
 			require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
 		}()
@@ -357,7 +355,6 @@ func TestWriteAndReadCheckpointV6LeafMultipleTries(t *testing.T) {
 		bufSize := 5
 		leafNodesCh := make(chan LeafNodeResult, bufSize)
 		go func() {
-			defer close(leafNodesCh)
 			err := OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, &logger)
 			require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
 		}()

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -137,7 +137,7 @@ func createMultipleRandomTriesMini(t *testing.T) []*trie.MTrie {
 	var err error
 	// add tries with no shared paths
 	for i := 0; i < 5; i++ {
-		paths, payloads := randNPathPayloads(10)
+		paths, payloads := randNPathPayloads(20)
 		activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, paths, payloads, false)
 		require.NoError(t, err, "update registers")
 		tries = append(tries, activeTrie)
@@ -309,9 +309,15 @@ func TestWriteAndReadCheckpointV6LeafEmptyTrie(t *testing.T) {
 		fileName := "checkpoint-empty-trie"
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, &logger), "fail to store checkpoint")
-		resultChan, err := OpenAndReadLeafNodesFromCheckpointV6(dir, fileName, &logger)
-		require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
-		for range resultChan {
+
+		bufSize := 10
+		leafNodesCh := make(chan LeafNodeResult, bufSize)
+		go func() {
+			defer close(leafNodesCh)
+			err := OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, &logger)
+			require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
+		}()
+		for range leafNodesCh {
 			require.Fail(t, "should not return any nodes")
 		}
 	})
@@ -323,10 +329,15 @@ func TestWriteAndReadCheckpointV6LeafSimpleTrie(t *testing.T) {
 		fileName := "checkpoint"
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, &logger), "fail to store checkpoint")
-		resultChan, err := OpenAndReadLeafNodesFromCheckpointV6(dir, fileName, &logger)
-		require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
+		bufSize := 10
+		leafNodesCh := make(chan LeafNodeResult, bufSize)
+		go func() {
+			defer close(leafNodesCh)
+			err := OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, &logger)
+			require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
+		}()
 		resultPayloads := make([]ledger.Payload, 0)
-		for readResult := range resultChan {
+		for readResult := range leafNodesCh {
 			require.NoError(t, readResult.Err, "no errors in read results")
 			// avoid dummy payload from empty trie
 			if readResult.LeafNode.Payload != nil {
@@ -343,10 +354,15 @@ func TestWriteAndReadCheckpointV6LeafMultipleTries(t *testing.T) {
 		tries := createMultipleRandomTriesMini(t)
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, &logger), "fail to store checkpoint")
-		resultChan, err := OpenAndReadLeafNodesFromCheckpointV6(dir, fileName, &logger)
-		require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
+		bufSize := 5
+		leafNodesCh := make(chan LeafNodeResult, bufSize)
+		go func() {
+			defer close(leafNodesCh)
+			err := OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, &logger)
+			require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
+		}()
 		resultPayloads := make([]ledger.Payload, 0)
-		for readResult := range resultChan {
+		for readResult := range leafNodesCh {
 			require.NoError(t, readResult.Err, "no errors in read results")
 			resultPayloads = append(resultPayloads, *readResult.LeafNode.Payload)
 		}
@@ -519,7 +535,9 @@ func TestAllPartFileExistLeafReader(t *testing.T) {
 			err = os.Remove(fileToDelete)
 			require.NoError(t, err, "fail to remove part file")
 
-			_, err = OpenAndReadLeafNodesFromCheckpointV6(dir, fileName, &logger)
+			bufSize := 10
+			leafNodesCh := make(chan LeafNodeResult, bufSize)
+			err = OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, &logger)
 			require.ErrorIs(t, err, os.ErrNotExist, "wrong error type returned")
 		}
 	})


### PR DESCRIPTION
This PR fixes the `OpenAndReadLeafNodesFromCheckpointV6` by letting it take the leaf nodes channel.

This also allow the caller to specify the buffer of the channel 