### PR TITLE
Remove obsolete comment

### DIFF
--- a/cmd/bootstrap/run/execution_state.go
+++ b/cmd/bootstrap/run/execution_state.go
@@ -32,7 +32,6 @@ func GenerateServiceAccountPrivateKey(seed []byte) (flow.AccountPrivateKey, erro
 	}, nil
 }
 
-// NOTE: this is now unused and should become part of another tool.
 func GenerateExecutionState(
 	dbDir string,
 	accountKey flow.AccountPublicKey,


### PR DESCRIPTION
Originally a piece from https://github.com/onflow/flow-go/pull/3736.

GenerateExecutionState is now used in the code. It used to not be for a while.