### PR TITLE
Draft: Generic atomic Tracker, cached field

### DIFF
--- a/consensus/hotstuff/tracker/tracker.go
+++ b/consensus/hotstuff/tracker/tracker.go
@@ -16,6 +16,33 @@ type NewestQCTracker struct {
 	newestQC *atomic.UnsafePointer
 }
 
+type EntityCompareFunc[E any] func(a, b E) bool
+
+type NewestEntityTracker[E any] struct {
+	cmp   EntityCompareFunc[*E]
+	store *atomic.UnsafePointer
+}
+
+func NewNewestEntityTracker[E any](cmp func(a, b *E) bool) NewestEntityTracker[E] {
+	return NewestEntityTracker[E]{
+		cmp:   cmp,
+		store: atomic.NewUnsafePointer(unsafe.Pointer(nil)),
+	}
+}
+
+func (t *NewestEntityTracker[E]) Track(e *E) bool {
+	for {
+		cur := t.Get()
+		if t.cmp(e, cur) {
+
+		}
+	}
+}
+
+func (t *NewestEntityTracker[E]) Get() *E {
+	return (*E)(t.store.Load())
+}
+
 func NewNewestQCTracker() *NewestQCTracker {
 	tracker := &NewestQCTracker{
 		newestQC: atomic.NewUnsafePointer(unsafe.Pointer(nil)),

--- a/state/cached/cache.go
+++ b/state/cached/cache.go
@@ -1,0 +1,58 @@
+package cached
+
+import (
+	"unsafe"
+
+	"go.uber.org/atomic"
+)
+
+// WriteOnce is a container for an entity, which can be set exactly once
+// and read any number of times. It is useful for optional cached fields on
+// structures which are used in concurrent environments.
+// It is safe for concurrent use by multiple goroutines.
+type WriteOnce[E any] struct {
+	val *atomic.UnsafePointer
+}
+
+func NewWriteOnce[E any]() WriteOnce[E] {
+	return WriteOnce[E]{
+		val: atomic.NewUnsafePointer(nil),
+	}
+}
+
+func (c WriteOnce[E]) Get() (*E, bool) {
+	cached := (*E)(c.val.Load())
+	if cached != nil {
+		return cached, true
+	}
+	return nil, false
+}
+
+func (c WriteOnce[E]) Set(e *E) bool {
+	if c.val.CompareAndSwap(nil, (unsafe.Pointer)(e)) {
+		return true
+	}
+	return false
+}
+
+type Value[E any] struct {
+	val *atomic.UnsafePointer
+}
+
+func NewValue[E any]() Value[E] {
+	return Value[E]{
+		val: atomic.NewUnsafePointer(nil),
+	}
+}
+
+func (c Value[E]) Get() (*E, bool) {
+	cached := (*E)(c.val.Load())
+	if cached != nil {
+		return cached, true
+	}
+	return nil, false
+}
+
+func (c Value[E]) Set(e *E) {
+	c.val.Store((unsafe.Pointer)(e))
+}

--- a/state/cached/cache_test.go
+++ b/state/cached/cache_test.go
@@ -1,0 +1,127 @@
+package cached
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func randIntPtr() *int {
+	val := rand.Int()
+	return &val
+}
+
+func TestCachedOnce_SetGet(t *testing.T) {
+	cache := NewWriteOnce[int]()
+
+	val, ok := cache.Get()
+	require.Nil(t, val)
+	require.False(t, ok)
+
+	initial := randIntPtr()
+	ok = cache.Set(initial)
+	require.True(t, ok)
+
+	val, ok = cache.Get()
+	require.Equal(t, initial, val)
+	require.True(t, ok)
+
+	ok = cache.Set(randIntPtr())
+	require.False(t, ok)
+
+	val, ok = cache.Get()
+	require.Equal(t, initial, val)
+	require.True(t, ok)
+}
+
+func TestCachedOnce_MultiThreaded(t *testing.T) {
+	nReaders := 20
+	nSetters := 20
+
+	cache := NewWriteOnce[int]()
+
+	// signal to stop read routines
+	stopReaders := make(chan struct{})
+	// contains the set value, for every setter routine which successfully set
+	// a value (should only contain one item)
+	setVals := make(chan int, nSetters)
+	// contains the first read value, for every getter routine (should all match
+	// single item in setVals)
+	readVals := make(chan int, nReaders)
+
+	// start up some reader goroutines
+	// each reader will:
+	//  - attempt to read the cached value in a loop, until stopped
+	//  - store the first cached value it reads
+	//  - validate that the cached value does not change after first read
+	readersStopped := new(sync.WaitGroup)
+	readersStopped.Add(nReaders)
+	for i := 0; i < nReaders; i++ {
+		go func() {
+			defer readersStopped.Done()
+			readOK := false  // read a value successfully at least once
+			var readVal *int // the value of the first read
+			for {
+				select {
+				case <-stopReaders:
+					return
+				default:
+				}
+				val, ok := cache.Get()
+				if !ok {
+					require.Nil(t, val)
+					require.False(t, readOK, "should never get nil after getting a cached value")
+					continue
+				}
+				// once: signal and store read value on the first successful read
+				if !readOK {
+					readOK = true
+					readVal = val
+					readVals <- *readVal
+				}
+				// every time: subsequent read value must match first read
+				require.Equal(t, readVal, val)
+			}
+		}()
+	}
+
+	// starts some setter goroutines
+	// each setter will:
+	//  - attempt to set a random value in the cache
+	//  - if it successfully sets a value, signal that value over setVals
+	settersStopped := new(sync.WaitGroup)
+	settersStopped.Add(nSetters)
+	for i := 0; i < nSetters; i++ {
+		go func() {
+			settingVal := randIntPtr()
+			defer settersStopped.Done()
+			ok := cache.Set(settingVal)
+			if ok {
+				setVals <- *settingVal
+			}
+		}()
+	}
+
+	fmt.Println("waiting for setters to stopReaders")
+	settersStopped.Wait()
+
+	close(setVals)
+	cachedVal := <-setVals
+	unittest.AssertClosedChannelIsEmpty[int](t, setVals)
+
+	fmt.Println("waiting for readers to get val")
+	for i := 0; i < nReaders; i++ {
+		assert.Equal(t, cachedVal, <-readVals)
+	}
+
+	fmt.Println("stopping readers")
+	close(stopReaders)
+	fmt.Println("waiting for reads to stopReaders")
+	readersStopped.Wait()
+}

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -695,6 +695,9 @@ func (m *FollowerState) Finalize(ctx context.Context, blockID flow.Identifier) e
 		return fmt.Errorf("could not persist finalization operations for block (%x): %w", blockID, err)
 	}
 
+	// update the finalized header cache
+	m.State.cachedFinalHeader.Set(&cachedHeader{blockID, header})
+
 	// Emit protocol events after database transaction succeeds. Event delivery is guaranteed,
 	// _except_ in case of a crash. Hence, when recovering from a crash, consumers need to deduce
 	// from the state whether they have missed events and re-execute the respective actions.

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -35,6 +35,11 @@ type Snapshot struct {
 	header  cached.WriteOnce[flow.Header]
 }
 
+type FinalizedSnapshot struct {
+	Snapshot
+	header *flow.Header
+}
+
 var _ protocol.Snapshot = (*Snapshot)(nil)
 
 func NewSnapshot(state *State, blockID flow.Identifier) *Snapshot {
@@ -45,12 +50,18 @@ func NewSnapshot(state *State, blockID flow.Identifier) *Snapshot {
 	}
 }
 
-func NewSnapshotWithHeader(state *State, blockID flow.Identifier, header *flow.Header) *Snapshot {
-	return &Snapshot{
-		state:   state,
-		blockID: blockID,
-		header:  cached.NewWriteOnce[flow.Header](),
+func NewFinalizedSnapshot(state *State, blockID flow.Identifier, header *flow.Header) *FinalizedSnapshot {
+	return &FinalizedSnapshot{
+		Snapshot: Snapshot{
+			state:   state,
+			blockID: blockID,
+		},
+		header: header,
 	}
+}
+
+func (s *FinalizedSnapshot) Head() (*flow.Header, error) {
+	return s.header, nil
 }
 
 func (s *Snapshot) Head() (*flow.Header, error) {

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -637,10 +637,7 @@ func (state *State) Final() protocol.Snapshot {
 	if !ok {
 		return invalid.NewSnapshotf("queried finalized header but cache was empty")
 	}
-	snap := NewSnapshot(state, final.id)
-	snap.header = cached.NewWriteOnce[flow.Header]()
-	snap.header.Set(final.header)
-	return snap
+	return NewFinalizedSnapshot(state, final.id, final.header)
 }
 
 func (state *State) AtHeight(height uint64) protocol.Snapshot {

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -160,6 +160,14 @@ func ClosedChannel() <-chan struct{} {
 	return ch
 }
 
+// AssertClosedChannelIsEmpty asserts that the input channel is empty.
+// This function will block until the input channel is closed.
+func AssertClosedChannelIsEmpty[E any](t *testing.T, ch <-chan E) {
+	for range ch {
+		t.Fail()
+	}
+}
+
 // AssertClosesBefore asserts that the given channel closes before the
 // duration expires.
 func AssertClosesBefore(t assert.TestingT, done <-chan struct{}, duration time.Duration, msgAndArgs ...interface{}) {


### PR DESCRIPTION
Experimenting with replacing FinalizedHeaderCache by guaranteeing finalized header is always cached at protocol state level.