### PR TITLE
[Consensus] Service events processing order

### DIFF
--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -167,7 +167,7 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot_NoTransitionSpan() {
 		epochBuilder := unittest.NewEpochBuilder(suite.T(), state)
 		// build epoch 1
 		// blocks in current state
-		// P <- A(S_P-1) <- B(S_P) <- C(S_A) <- D(S_B) |setup| <- E(S_C) <- F(S_D) |commit| <- G(S_E)
+		// P <- A(S_P-1) <- B(S_P) <- C(S_A) <- D(S_B) |setup| <- E(S_C) <- F(S_D) |commit|
 		epochBuilder.
 			BuildEpoch().
 			CompleteEpoch()
@@ -181,9 +181,9 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot_NoTransitionSpan() {
 			suite.state.On("AtHeight", height).Return(state.AtHeight(height)).Once()
 		}
 
-		// Take snapshot at height of block D (epoch1.heights[3]) for valid segment and valid snapshot
-		// where it's sealing segment is B <- C <- D
-		snap := state.AtHeight(epoch1.Range()[3])
+		// Take snapshot at height of block D (epoch1.heights[2]) for valid segment and valid snapshot
+		// where it's sealing segment is B <- C
+		snap := state.AtHeight(epoch1.Range()[2])
 		suite.state.On("Final").Return(snap).Once()
 
 		backend := New(
@@ -283,8 +283,8 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot_TransitionSpans() {
 		suite.Require().NoError(err)
 		fmt.Println()
 
-		// we expect the endpoint to return last valid snapshot which is the snapshot at block D (height 3)
-		expectedSnapshotBytes, err := convert.SnapshotToBytes(state.AtHeight(epoch1.Range()[3]))
+		// we expect the endpoint to return last valid snapshot which is the snapshot at block C (height 2)
+		expectedSnapshotBytes, err := convert.SnapshotToBytes(state.AtHeight(epoch1.Range()[2]))
 		suite.Require().NoError(err)
 		suite.Require().Equal(expectedSnapshotBytes, bytes)
 	})
@@ -300,7 +300,7 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot_PhaseTransitionSpan() {
 		epochBuilder := unittest.NewEpochBuilder(suite.T(), state)
 		// build epoch 1
 		// blocks in current state
-		// P <- A(S_P-1) <- B(S_P) <- C(S_A) <- D(S_B) |setup| <- E(S_C) <- F(S_D) |commit| <- G(S_E)
+		// P <- A(S_P-1) <- B(S_P) <- C(S_A) <- D(S_B) |setup| <- E(S_C) <- F(S_D) |commit|
 		epochBuilder.
 			BuildEpoch().
 			CompleteEpoch()
@@ -314,11 +314,11 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot_PhaseTransitionSpan() {
 			suite.state.On("AtHeight", height).Return(state.AtHeight(height))
 		}
 
-		// Take snapshot at height of block E (epoch1.heights[4]) the sealing segment for this snapshot
-		// is C(S_A) <- D(S_B) |setup| <- E(S_C) which spans the epoch setup phase. This will force
+		// Take snapshot at height of block D (epoch1.heights[3]) the sealing segment for this snapshot
+		// is C(S_A) <- D(S_B) |setup|) which spans the epoch setup phase. This will force
 		// our RPC endpoint to return a snapshot at block D which is the snapshot at the boundary where the phase
 		// transition happens.
-		snap := state.AtHeight(epoch1.Range()[4])
+		snap := state.AtHeight(epoch1.Range()[3])
 		suite.state.On("Final").Return(snap).Once()
 
 		backend := New(
@@ -346,8 +346,8 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot_PhaseTransitionSpan() {
 		bytes, err := backend.GetLatestProtocolStateSnapshot(context.Background())
 		suite.Require().NoError(err)
 
-		// we expect the endpoint to return last valid snapshot which is the snapshot at block D (height 3)
-		expectedSnapshotBytes, err := convert.SnapshotToBytes(state.AtHeight(epoch1.Range()[3]))
+		// we expect the endpoint to return last valid snapshot which is the snapshot at block C (height 2)
+		expectedSnapshotBytes, err := convert.SnapshotToBytes(state.AtHeight(epoch1.Range()[2]))
 		suite.Require().NoError(err)
 		suite.Require().Equal(expectedSnapshotBytes, bytes)
 	})
@@ -363,7 +363,7 @@ func (suite *Suite) TestGetLatestProtocolStateSnapshot_EpochTransitionSpan() {
 		epochBuilder := unittest.NewEpochBuilder(suite.T(), state)
 		// build epoch 1
 		// blocks in current state
-		// P <- A(S_P-1) <- B(S_P) <- C(S_A) <- D(S_B) |setup| <- E(S_C) <- F(S_D) |commit| <- G(S_E)
+		// P <- A(S_P-1) <- B(S_P) <- C(S_A) <- D(S_B) |setup| <- E(S_C) <- F(S_D) |commit|
 		epochBuilder.BuildEpoch()
 
 		// add more blocks to our state in the commit phase, this will allow

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -573,23 +573,21 @@ func TestExtendReceiptsValid(t *testing.T) {
 // event, then a commit event, then finalizing the first block of the next epoch.
 // Also tests that appropriate epoch transition events are fired.
 //
-// Epoch information becomes available in the protocol state in the block AFTER
-// the block sealing the relevant service event. This is because the block after
-// the sealing block contains a QC certifying validity of the payload of the
-// sealing block.
+// Epoch information becomes available in the protocol state in the block when processing
+// the block with relevant service event.
 //
-// ROOT <- B1 <- B2(R1) <- B3(S1) <- B4 <- B5(R2) <- B6(S2) <- B7 <- B8 <-|- B9
+// ROOT <- B1 <- B2(R1) <- B3(S1) <- B4 <- B5(R2) <- B6(S2) <- B7 <-|- B8
 //
-// B4 contains a QC for B3, which seals B1, in which EpochSetup is emitted.
-// * we can query the EpochSetup beginning with B4
-// * EpochSetupPhaseStarted triggered when B4 is finalized
+// B3 seals B1, in which EpochSetup is emitted.
+// * we can query the EpochSetup beginning with B3
+// * EpochSetupPhaseStarted triggered when B3 is finalized
 //
-// B7 contains a QC for B6, which seals B2, in which EpochCommitted is emitted.
-// * we can query the EpochCommit beginning with B7
-// * EpochSetupPhaseStarted triggered when B7 is finalized
+// B6 seals B2, in which EpochCommitted is emitted.
+// * we can query the EpochCommit beginning with B6
+// * EpochSetupPhaseStarted triggered when B6 is finalized
 //
-// B8 is the final block of the epoch.
-// B9 is the first block of the NEXT epoch.
+// B7 is the final block of the epoch.
+// B8 is the first block of the NEXT epoch.
 func TestExtendEpochTransitionValid(t *testing.T) {
 	// create an event consumer to test epoch transition events
 	consumer := mockprotocol.NewConsumer(t)
@@ -692,51 +690,51 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		err = state.Extend(context.Background(), block3)
 		require.NoError(t, err)
 
-		// insert a block with a QC pointing to block 3
-		block4 := unittest.BlockWithParentFixture(block3.Header)
-		err = state.Extend(context.Background(), block4)
-		require.NoError(t, err)
-
 		// now that the setup event has been emitted, we should be in the setup phase
-		phase, err = state.AtBlockID(block4.ID()).Phase()
+		phase, err = state.AtBlockID(block3.ID()).Phase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseSetup, phase)
 
-		// we should NOT be able to query epoch 2 wrt blocks before 4
-		for _, blockID := range []flow.Identifier{block1.ID(), block2.ID(), block3.ID()} {
+		// we should NOT be able to query epoch 2 wrt blocks before 3
+		for _, blockID := range []flow.Identifier{block1.ID(), block2.ID()} {
 			_, err = state.AtBlockID(blockID).Epochs().Next().InitialIdentities()
 			require.Error(t, err)
 			_, err = state.AtBlockID(blockID).Epochs().Next().Clustering()
 			require.Error(t, err)
 		}
 
-		// we should be able to query epoch 2 wrt block 4
-		_, err = state.AtBlockID(block4.ID()).Epochs().Next().InitialIdentities()
+		// we should be able to query epoch 2 wrt block 3
+		_, err = state.AtBlockID(block3.ID()).Epochs().Next().InitialIdentities()
 		assert.NoError(t, err)
-		_, err = state.AtBlockID(block4.ID()).Epochs().Next().Clustering()
+		_, err = state.AtBlockID(block3.ID()).Epochs().Next().Clustering()
 		assert.NoError(t, err)
 
 		// only setup event is finalized, not commit, so shouldn't be able to get certain info
-		_, err = state.AtBlockID(block4.ID()).Epochs().Next().DKG()
+		_, err = state.AtBlockID(block3.ID()).Epochs().Next().DKG()
 		require.Error(t, err)
 
-		// finalize block 3 so we can finalize subsequent blocks
-		err = state.Finalize(context.Background(), block3.ID())
+		// insert B4
+		block4 := unittest.BlockWithParentFixture(block3.Header)
+		err = state.Extend(context.Background(), block4)
 		require.NoError(t, err)
 
-		// finalize block 4 so we can finalize subsequent blocks
-		// ensure an epoch phase transition when we finalize block 4
-		consumer.On("EpochSetupPhaseStarted", epoch2Setup.Counter-1, block4.Header).Once()
+		consumer.On("EpochSetupPhaseStarted", epoch2Setup.Counter-1, block3.Header).Once()
 		metrics.On("CurrentEpochPhase", flow.EpochPhaseSetup).Once()
-		err = state.Finalize(context.Background(), block4.ID())
+		// finalize block 3, so we can finalize subsequent blocks
+		// ensure an epoch phase transition when we finalize block 3
+		err = state.Finalize(context.Background(), block3.ID())
 		require.NoError(t, err)
-		consumer.AssertCalled(t, "EpochSetupPhaseStarted", epoch2Setup.Counter-1, block4.Header)
+		consumer.AssertCalled(t, "EpochSetupPhaseStarted", epoch2Setup.Counter-1, block3.Header)
 		metrics.AssertCalled(t, "CurrentEpochPhase", flow.EpochPhaseSetup)
 
 		// now that the setup event has been emitted, we should be in the setup phase
-		phase, err = state.AtBlockID(block4.ID()).Phase()
-		assert.NoError(t, err)
+		phase, err = state.AtBlockID(block3.ID()).Phase()
+		require.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseSetup, phase)
+
+		// finalize block 4
+		err = state.Finalize(context.Background(), block4.ID())
+		require.NoError(t, err)
 
 		epoch2Commit := unittest.EpochCommitFixture(
 			unittest.CommitWithCounter(epoch2Setup.Counter),
@@ -768,42 +766,42 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		err = state.Extend(context.Background(), block6)
 		require.NoError(t, err)
 
-		// insert a block with a QC pointing to block 6
-		block7 := unittest.BlockWithParentFixture(block6.Header)
-		err = state.Extend(context.Background(), block7)
-		require.NoError(t, err)
-
-		// we should NOT be able to query epoch 2 commit info wrt blocks before 7
-		for _, blockID := range []flow.Identifier{block4.ID(), block5.ID(), block6.ID()} {
+		// we should NOT be able to query epoch 2 commit info wrt blocks before 6
+		for _, blockID := range []flow.Identifier{block4.ID(), block5.ID()} {
 			_, err = state.AtBlockID(blockID).Epochs().Next().DKG()
 			require.Error(t, err)
 		}
 
-		// now epoch 2 is fully ready, we can query anything we want about it wrt block 7 (or later)
-		_, err = state.AtBlockID(block7.ID()).Epochs().Next().InitialIdentities()
+		// now epoch 2 is fully ready, we can query anything we want about it wrt block 6 (or later)
+		_, err = state.AtBlockID(block6.ID()).Epochs().Next().InitialIdentities()
 		require.NoError(t, err)
-		_, err = state.AtBlockID(block7.ID()).Epochs().Next().Clustering()
+		_, err = state.AtBlockID(block6.ID()).Epochs().Next().Clustering()
 		require.NoError(t, err)
-		_, err = state.AtBlockID(block7.ID()).Epochs().Next().DKG()
+		_, err = state.AtBlockID(block6.ID()).Epochs().Next().DKG()
 		assert.NoError(t, err)
 
 		// now that the commit event has been emitted, we should be in the committed phase
-		phase, err = state.AtBlockID(block7.ID()).Phase()
+		phase, err = state.AtBlockID(block6.ID()).Phase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseCommitted, phase)
+
+		// block 7 has the final view of the epoch, insert it, finalized after finalizing block 6
+		block7 := unittest.BlockWithParentFixture(block6.Header)
+		block7.SetPayload(flow.EmptyPayload())
+		block7.Header.View = epoch1FinalView
+		err = state.Extend(context.Background(), block7)
+		require.NoError(t, err)
+
+		// expect epoch phase transition once we finalize block 6
+		consumer.On("EpochCommittedPhaseStarted", epoch2Setup.Counter-1, block6.Header).Once()
+		// expect committed final view to be updated, since we are committing epoch 2
+		metrics.On("CommittedEpochFinalView", epoch2Setup.FinalView).Once()
+		metrics.On("CurrentEpochPhase", flow.EpochPhaseCommitted).Once()
 
 		err = state.Finalize(context.Background(), block6.ID())
 		require.NoError(t, err)
 
-		// expect epoch phase transition once we finalize block 7
-		consumer.On("EpochCommittedPhaseStarted", epoch2Setup.Counter-1, block7.Header).Once()
-		// expect committed final view to be updated, since we are committing epoch 2
-		metrics.On("CommittedEpochFinalView", epoch2Setup.FinalView).Once()
-		metrics.On("CurrentEpochPhase", flow.EpochPhaseCommitted).Once()
-		err = state.Finalize(context.Background(), block7.ID())
-
-		require.NoError(t, err)
-		consumer.AssertCalled(t, "EpochCommittedPhaseStarted", epoch2Setup.Counter-1, block7.Header)
+		consumer.AssertCalled(t, "EpochCommittedPhaseStarted", epoch2Setup.Counter-1, block6.Header)
 		metrics.AssertCalled(t, "CommittedEpochFinalView", epoch2Setup.FinalView)
 		metrics.AssertCalled(t, "CurrentEpochPhase", flow.EpochPhaseCommitted)
 
@@ -812,44 +810,37 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, epoch1Setup.Counter, epochCounter)
 
-		// block 8 has the final view of the epoch
-		block8 := unittest.BlockWithParentFixture(block7.Header)
-		block8.SetPayload(flow.EmptyPayload())
-		block8.Header.View = epoch1FinalView
-
-		err = state.Extend(context.Background(), block8)
-		require.NoError(t, err)
-		err = state.Finalize(context.Background(), block8.ID())
+		err = state.Finalize(context.Background(), block7.ID())
 		require.NoError(t, err)
 
 		// we should still be in epoch 1, since epochs are inclusive of final view
-		epochCounter, err = state.AtBlockID(block8.ID()).Epochs().Current().Counter()
+		epochCounter, err = state.AtBlockID(block7.ID()).Epochs().Current().Counter()
 		require.NoError(t, err)
 		require.Equal(t, epoch1Setup.Counter, epochCounter)
 
-		// block 9 has a view > final view of epoch 1, it will be considered the first block of epoch 2
-		block9 := unittest.BlockWithParentFixture(block8.Header)
-		block9.SetPayload(flow.EmptyPayload())
+		// block 8 has a view > final view of epoch 1, it will be considered the first block of epoch 2
+		block8 := unittest.BlockWithParentFixture(block7.Header)
+		block8.SetPayload(flow.EmptyPayload())
 		// we should handle views that aren't exactly the first valid view of the epoch
-		block9.Header.View = epoch1FinalView + uint64(1+rand.Intn(10))
+		block8.Header.View = epoch1FinalView + uint64(1+rand.Intn(10))
 
-		err = state.Extend(context.Background(), block9)
+		err = state.Extend(context.Background(), block8)
 		require.NoError(t, err)
 
 		// now, at long last, we are in epoch 2
-		epochCounter, err = state.AtBlockID(block9.ID()).Epochs().Current().Counter()
+		epochCounter, err = state.AtBlockID(block8.ID()).Epochs().Current().Counter()
 		require.NoError(t, err)
 		require.Equal(t, epoch2Setup.Counter, epochCounter)
 
 		// we should begin epoch 2 in staking phase
 		// how that the commit event has been emitted, we should be in the committed phase
-		phase, err = state.AtBlockID(block9.ID()).Phase()
+		phase, err = state.AtBlockID(block8.ID()).Phase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseStaking, phase)
 
 		// expect epoch transition once we finalize block 9
-		consumer.On("EpochTransition", epoch2Setup.Counter, block9.Header).Once()
-		metrics.On("EpochTransitionHeight", block9.Header.Height).Once()
+		consumer.On("EpochTransition", epoch2Setup.Counter, block8.Header).Once()
+		metrics.On("EpochTransitionHeight", block8.Header.Height).Once()
 		metrics.On("CurrentEpochCounter", epoch2Setup.Counter).Once()
 		metrics.On("CurrentEpochPhase", flow.EpochPhaseStaking).Once()
 		metrics.On("CurrentEpochFinalView", epoch2Setup.FinalView).Once()
@@ -860,19 +851,19 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		// before block 9 is finalized, the epoch 1-2 boundary is unknown
 		_, err = state.AtBlockID(block8.ID()).Epochs().Current().FinalHeight()
 		assert.ErrorIs(t, err, realprotocol.ErrEpochTransitionNotFinalized)
-		_, err = state.AtBlockID(block9.ID()).Epochs().Current().FirstHeight()
+		_, err = state.AtBlockID(block8.ID()).Epochs().Current().FirstHeight()
 		assert.ErrorIs(t, err, realprotocol.ErrEpochTransitionNotFinalized)
 
-		err = state.Finalize(context.Background(), block9.ID())
+		err = state.Finalize(context.Background(), block8.ID())
 		require.NoError(t, err)
 
-		// once block 9 is finalized, epoch 2 has unambiguously begun - the epoch 1-2 boundary is known
-		epoch1FinalHeight, err := state.AtBlockID(block9.ID()).Epochs().Previous().FinalHeight()
+		// once block 8 is finalized, epoch 2 has unambiguously begun - the epoch 1-2 boundary is known
+		epoch1FinalHeight, err := state.AtBlockID(block8.ID()).Epochs().Previous().FinalHeight()
 		require.NoError(t, err)
-		assert.Equal(t, block8.Header.Height, epoch1FinalHeight)
-		epoch2FirstHeight, err := state.AtBlockID(block9.ID()).Epochs().Current().FirstHeight()
+		assert.Equal(t, block7.Header.Height, epoch1FinalHeight)
+		epoch2FirstHeight, err := state.AtBlockID(block8.ID()).Epochs().Current().FirstHeight()
 		require.NoError(t, err)
-		assert.Equal(t, block9.Header.Height, epoch2FirstHeight)
+		assert.Equal(t, block8.Header.Height, epoch2FirstHeight)
 	})
 }
 
@@ -1151,15 +1142,9 @@ func TestExtendEpochSetupInvalid(t *testing.T) {
 			receiptBlock, sealingBlock := unittest.SealBlock(t, state, block1, receipt, seal)
 			err := state.Finalize(context.Background(), receiptBlock.ID())
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), sealingBlock.ID())
-			require.NoError(t, err)
-
-			qcBlock := unittest.BlockWithParentFixture(sealingBlock)
-			err = state.Extend(context.Background(), qcBlock)
-			require.NoError(t, err)
 			// epoch fallback not triggered before finalization
 			assertEpochEmergencyFallbackTriggered(t, state, false)
-			err = state.Finalize(context.Background(), qcBlock.ID())
+			err = state.Finalize(context.Background(), sealingBlock.ID())
 			require.NoError(t, err)
 			// epoch fallback triggered after finalization
 			assertEpochEmergencyFallbackTriggered(t, state, true)
@@ -1178,15 +1163,9 @@ func TestExtendEpochSetupInvalid(t *testing.T) {
 			receiptBlock, sealingBlock := unittest.SealBlock(t, state, block1, receipt, seal)
 			err := state.Finalize(context.Background(), receiptBlock.ID())
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), sealingBlock.ID())
-			require.NoError(t, err)
-
-			qcBlock := unittest.BlockWithParentFixture(sealingBlock)
-			err = state.Extend(context.Background(), qcBlock)
-			require.NoError(t, err)
 			// epoch fallback not triggered before finalization
 			assertEpochEmergencyFallbackTriggered(t, state, false)
-			err = state.Finalize(context.Background(), qcBlock.ID())
+			err = state.Finalize(context.Background(), sealingBlock.ID())
 			require.NoError(t, err)
 			// epoch fallback triggered after finalization
 			assertEpochEmergencyFallbackTriggered(t, state, true)
@@ -1205,15 +1184,9 @@ func TestExtendEpochSetupInvalid(t *testing.T) {
 			receiptBlock, sealingBlock := unittest.SealBlock(t, state, block1, receipt, seal)
 			err := state.Finalize(context.Background(), receiptBlock.ID())
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), sealingBlock.ID())
-			require.NoError(t, err)
-
-			qcBlock := unittest.BlockWithParentFixture(sealingBlock)
-			err = state.Extend(context.Background(), qcBlock)
-			require.NoError(t, err)
 			// epoch fallback not triggered before finalization
 			assertEpochEmergencyFallbackTriggered(t, state, false)
-			err = state.Finalize(context.Background(), qcBlock.ID())
+			err = state.Finalize(context.Background(), sealingBlock.ID())
 			require.NoError(t, err)
 			// epoch fallback triggered after finalization
 			assertEpochEmergencyFallbackTriggered(t, state, true)
@@ -1296,15 +1269,9 @@ func TestExtendEpochCommitInvalid(t *testing.T) {
 			receiptBlock, sealingBlock := unittest.SealBlock(t, state, block1, receipt, seal)
 			err := state.Finalize(context.Background(), receiptBlock.ID())
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), sealingBlock.ID())
-			require.NoError(t, err)
-
-			qcBlock := unittest.BlockWithParentFixture(sealingBlock)
-			err = state.Extend(context.Background(), qcBlock)
-			require.NoError(t, err)
 			// epoch fallback not triggered before finalization
 			assertEpochEmergencyFallbackTriggered(t, state, false)
-			err = state.Finalize(context.Background(), qcBlock.ID())
+			err = state.Finalize(context.Background(), sealingBlock.ID())
 			require.NoError(t, err)
 			// epoch fallback triggered after finalization
 			assertEpochEmergencyFallbackTriggered(t, state, true)
@@ -1335,15 +1302,9 @@ func TestExtendEpochCommitInvalid(t *testing.T) {
 			receiptBlock, sealingBlock := unittest.SealBlock(t, state, block3, receipt, seal)
 			err = state.Finalize(context.Background(), receiptBlock.ID())
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), sealingBlock.ID())
-			require.NoError(t, err)
-
-			qcBlock := unittest.BlockWithParentFixture(sealingBlock)
-			err = state.Extend(context.Background(), qcBlock)
-			require.NoError(t, err)
 			// epoch fallback not triggered before finalization
 			assertEpochEmergencyFallbackTriggered(t, state, false)
-			err = state.Finalize(context.Background(), qcBlock.ID())
+			err = state.Finalize(context.Background(), sealingBlock.ID())
 			require.NoError(t, err)
 			// epoch fallback triggered after finalization
 			assertEpochEmergencyFallbackTriggered(t, state, true)
@@ -1374,15 +1335,9 @@ func TestExtendEpochCommitInvalid(t *testing.T) {
 			receiptBlock, sealingBlock := unittest.SealBlock(t, state, block3, receipt, seal)
 			err = state.Finalize(context.Background(), receiptBlock.ID())
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), sealingBlock.ID())
-			require.NoError(t, err)
-
-			qcBlock := unittest.BlockWithParentFixture(sealingBlock)
-			err = state.Extend(context.Background(), qcBlock)
-			require.NoError(t, err)
 			// epoch fallback not triggered before finalization
 			assertEpochEmergencyFallbackTriggered(t, state, false)
-			err = state.Finalize(context.Background(), qcBlock.ID())
+			err = state.Finalize(context.Background(), sealingBlock.ID())
 			require.NoError(t, err)
 			// epoch fallback triggered after finalization
 			assertEpochEmergencyFallbackTriggered(t, state, true)
@@ -1414,15 +1369,9 @@ func TestExtendEpochCommitInvalid(t *testing.T) {
 			receiptBlock, sealingBlock := unittest.SealBlock(t, state, block3, receipt, seal)
 			err = state.Finalize(context.Background(), receiptBlock.ID())
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), sealingBlock.ID())
-			require.NoError(t, err)
-
-			qcBlock := unittest.BlockWithParentFixture(sealingBlock)
-			err = state.Extend(context.Background(), qcBlock)
-			require.NoError(t, err)
 			// epoch fallback not triggered before finalization
 			assertEpochEmergencyFallbackTriggered(t, state, false)
-			err = state.Finalize(context.Background(), qcBlock.ID())
+			err = state.Finalize(context.Background(), sealingBlock.ID())
 			require.NoError(t, err)
 			// epoch fallback triggered after finalization
 			assertEpochEmergencyFallbackTriggered(t, state, true)
@@ -1564,11 +1513,11 @@ func TestEmergencyEpochFallback(t *testing.T) {
 	// if we finalize the first block past the epoch commitment deadline while
 	// in the EpochSetup phase, EECC should be triggered
 	//
-	//                                 Epoch Commitment Deadline
-	//                                 |     Epoch Boundary
-	//                                 |     |
-	//                                 v     v
-	// ROOT <- B1 <- B2(R1) <- B3(S1) <- B4 <- B5
+	//                       Epoch Commitment Deadline
+	//                       |         Epoch Boundary
+	//                       |         |
+	//                       v         v
+	// ROOT <- B1 <- B2(R1) <- B3(S1) <- B4
 	t.Run("passed epoch commitment deadline in EpochSetup phase - should trigger EECC", func(t *testing.T) {
 
 		rootSnapshot := unittest.RootSnapshotFixture(participants)
@@ -1622,37 +1571,30 @@ func TestEmergencyEpochFallback(t *testing.T) {
 			err = state.Finalize(context.Background(), block2.ID())
 			require.NoError(t, err)
 
-			// block 3 seals block 1
+			// block 3 seals block 1 and will be the first block on or past the epoch commitment deadline
 			block3 := unittest.BlockWithParentFixture(block2.Header)
+			block3.Header.View = epoch1CommitmentDeadline + rand.Uint64()%2
 			block3.SetPayload(flow.Payload{
 				Seals: []*flow.Seal{seal1},
 			})
 			err = state.Extend(context.Background(), block3)
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), block3.ID())
-			require.NoError(t, err)
 
-			// block 4 will be the first block on or past the epoch commitment deadline
-			block4 := unittest.BlockWithParentFixture(block3.Header)
-			block4.Header.View = epoch1CommitmentDeadline + rand.Uint64()%2
-
-			// finalizing block 4 should trigger EECC
+			// finalizing block 3 should trigger EECC
 			metricsMock.On("EpochEmergencyFallbackTriggered").Once()
 			protoEventsMock.On("EpochEmergencyFallbackTriggered").Once()
 
-			err = state.Extend(context.Background(), block4)
-			require.NoError(t, err)
 			assertEpochEmergencyFallbackTriggered(t, state, false) // not triggered before finalization
-			err = state.Finalize(context.Background(), block4.ID())
+			err = state.Finalize(context.Background(), block3.ID())
 			require.NoError(t, err)
 			assertEpochEmergencyFallbackTriggered(t, state, true) // triggered after finalization
 
-			// block 5 will be the first block past the first epoch boundary
-			block5 := unittest.BlockWithParentFixture(block4.Header)
-			block5.Header.View = epoch1FinalView + 1
-			err = state.Extend(context.Background(), block5)
+			// block 4 will be the first block past the first epoch boundary
+			block4 := unittest.BlockWithParentFixture(block3.Header)
+			block4.Header.View = epoch1FinalView + 1
+			err = state.Extend(context.Background(), block4)
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), block5.ID())
+			err = state.Finalize(context.Background(), block4.ID())
 			require.NoError(t, err)
 
 			// since EECC has been triggered, epoch transition metrics should not be updated
@@ -1665,10 +1607,10 @@ func TestEmergencyEpochFallback(t *testing.T) {
 	//  * not apply the phase transition corresponding to the invalid service event
 	//  * immediately trigger EECC
 	//
-	//                                       Epoch Boundary
-	//                                       |
-	//                                       v
-	// ROOT <- B1 <- B2(R1) <- B3(S1) <- B4 <- B5
+	//                            Epoch Boundary
+	//                                 |
+	//                                 v
+	// ROOT <- B1 <- B2(R1) <- B3(S1) <- B4
 	t.Run("epoch transition with invalid service event - should trigger EECC", func(t *testing.T) {
 
 		rootSnapshot := unittest.RootSnapshotFixture(participants)
@@ -1720,35 +1662,29 @@ func TestEmergencyEpochFallback(t *testing.T) {
 			err = state.Finalize(context.Background(), block2.ID())
 			require.NoError(t, err)
 
-			// block 3 seals block 1
+			// block 3 is where the service event state change comes into effect
 			block3 := unittest.BlockWithParentFixture(block2.Header)
 			block3.SetPayload(flow.Payload{
 				Seals: []*flow.Seal{seal1},
 			})
 			err = state.Extend(context.Background(), block3)
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), block3.ID())
-			require.NoError(t, err)
 
 			// incorporating the service event should trigger EECC
 			metricsMock.On("EpochEmergencyFallbackTriggered").Once()
 			protoEventsMock.On("EpochEmergencyFallbackTriggered").Once()
 
-			// block 4 is where the service event state change comes into effect
-			block4 := unittest.BlockWithParentFixture(block3.Header)
-			err = state.Extend(context.Background(), block4)
-			require.NoError(t, err)
 			assertEpochEmergencyFallbackTriggered(t, state, false) // not triggered before finalization
-			err = state.Finalize(context.Background(), block4.ID())
+			err = state.Finalize(context.Background(), block3.ID())
 			require.NoError(t, err)
 			assertEpochEmergencyFallbackTriggered(t, state, true) // triggered after finalization
 
 			// block 5 is the first block past the current epoch boundary
-			block5 := unittest.BlockWithParentFixture(block4.Header)
-			block5.Header.View = epoch1Setup.FinalView + 1
-			err = state.Extend(context.Background(), block5)
+			block4 := unittest.BlockWithParentFixture(block3.Header)
+			block4.Header.View = epoch1Setup.FinalView + 1
+			err = state.Extend(context.Background(), block4)
 			require.NoError(t, err)
-			err = state.Finalize(context.Background(), block5.ID())
+			err = state.Finalize(context.Background(), block4.ID())
 			require.NoError(t, err)
 
 			// since EECC has been triggered, epoch transition metrics should not be updated
@@ -2016,30 +1952,31 @@ func TestHeaderExtendHighestSeal(t *testing.T) {
 		err := state.ExtendCertified(context.Background(), block2, block3.Header.QuorumCertificate())
 		require.NoError(t, err)
 
-		// create seals for block2 and block3
-		seal2 := unittest.Seal.Fixture(
-			unittest.Seal.WithBlockID(block2.ID()),
-		)
-		seal3 := unittest.Seal.Fixture(
-			unittest.Seal.WithBlockID(block3.ID()),
-		)
+		// create receipts and seals for block2 and block3
+		receipt2, seal2 := unittest.ReceiptAndSealForBlock(block2)
+		receipt3, seal3 := unittest.ReceiptAndSealForBlock(block3)
 
 		// include the seals in block4
 		block4 := unittest.BlockWithParentFixture(block3.Header)
-		block4.SetPayload(flow.Payload{
-			// placing seals in the reversed order to test
-			// Extend will pick the highest sealed block
-			Seals:      []*flow.Seal{seal3, seal2},
-			Guarantees: nil,
-		})
+		// include receipts and results
+		block4.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt3, receipt2)))
+
+		// include the seals in block4
+		block5 := unittest.BlockWithParentFixture(block4.Header)
+		// placing seals in the reversed order to test
+		// Extend will pick the highest sealed block
+		block5.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal3, seal2)))
 
 		err = state.ExtendCertified(context.Background(), block3, block4.Header.QuorumCertificate())
 		require.NoError(t, err)
 
-		err = state.ExtendCertified(context.Background(), block4, unittest.CertifyBlock(block4.Header))
+		err = state.ExtendCertified(context.Background(), block4, block5.Header.QuorumCertificate())
 		require.NoError(t, err)
 
-		finalCommit, err := state.AtBlockID(block4.ID()).Commit()
+		err = state.ExtendCertified(context.Background(), block5, unittest.CertifyBlock(block5.Header))
+		require.NoError(t, err)
+
+		finalCommit, err := state.AtBlockID(block5.ID()).Commit()
 		require.NoError(t, err)
 		require.Equal(t, seal3.FinalState, finalCommit)
 	})

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -262,34 +262,40 @@ func TestSealingSegment(t *testing.T) {
 
 	// test sealing segment for non-root segment with simple sealing structure
 	// (no blocks in between reference block and latest sealed)
-	// ROOT <- B1 <- B2(S1)
-	// Expected sealing segment: [B1, B2], extra blocks: [ROOT]
+	// ROOT <- B1 <- B2(R1) <- B3(S1)
+	// Expected sealing segment: [B1, B2, B3], extra blocks: [ROOT]
 	t.Run("non-root", func(t *testing.T) {
 		util.RunWithFollowerProtocolState(t, rootSnapshot, func(db *badger.DB, state *bprotocol.FollowerState) {
 			// build a block to seal
 			block1 := unittest.BlockWithParentFixture(head)
 			buildFinalizedBlock(t, state, block1)
 
-			// build a block sealing block1
-			block2 := unittest.BlockWithParentFixture(block1.Header)
 			receipt1, seal1 := unittest.ReceiptAndSealForBlock(block1)
-			block2.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt1), unittest.WithSeals(seal1)))
+
+			block2 := unittest.BlockWithParentFixture(block1.Header)
+			block2.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt1)))
 			buildFinalizedBlock(t, state, block2)
 
-			segment, err := state.AtBlockID(block2.ID()).SealingSegment()
+			// build a block sealing block1
+			block3 := unittest.BlockWithParentFixture(block2.Header)
+
+			block3.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal1)))
+			buildFinalizedBlock(t, state, block3)
+
+			segment, err := state.AtBlockID(block3.ID()).SealingSegment()
 			require.NoError(t, err)
 
 			require.Len(t, segment.ExtraBlocks, 1)
 			assert.Equal(t, segment.ExtraBlocks[0].Header.Height, head.Height)
 
 			// build a valid child B3 to ensure we have a QC
-			buildBlock(t, state, unittest.BlockWithParentFixture(block2.Header))
+			buildBlock(t, state, unittest.BlockWithParentFixture(block3.Header))
 
 			// sealing segment should contain B1 and B2
 			// B2 is reference of snapshot, B1 is latest sealed
-			unittest.AssertEqualBlocksLenAndOrder(t, []*flow.Block{block1, block2}, segment.Blocks)
+			unittest.AssertEqualBlocksLenAndOrder(t, []*flow.Block{block1, block2, block3}, segment.Blocks)
 			assert.Len(t, segment.ExecutionResults, 1)
-			assertSealingSegmentBlocksQueryableAfterBootstrap(t, state.AtBlockID(block2.ID()))
+			assertSealingSegmentBlocksQueryableAfterBootstrap(t, state.AtBlockID(block3.ID()))
 		})
 	})
 
@@ -304,22 +310,22 @@ func TestSealingSegment(t *testing.T) {
 			block1 := unittest.BlockWithParentFixture(head)
 			buildFinalizedBlock(t, state, block1)
 
+			receipt1, seal1 := unittest.ReceiptAndSealForBlock(block1)
+
 			parent := block1
 			// build a large chain of intermediary blocks
 			for i := 0; i < 100; i++ {
 				next := unittest.BlockWithParentFixture(parent.Header)
+				next.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt1)))
 				buildFinalizedBlock(t, state, next)
 				parent = next
 			}
 
 			// build the block sealing block 1
 			blockN := unittest.BlockWithParentFixture(parent.Header)
-			receipt1, seal1 := unittest.ReceiptAndSealForBlock(block1)
-			blockN.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt1), unittest.WithSeals(seal1)))
-			buildFinalizedBlock(t, state, blockN)
 
-			// build a valid child B3 to ensure we have a QC
-			buildFinalizedBlock(t, state, unittest.BlockWithParentFixture(blockN.Header))
+			blockN.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal1)))
+			buildFinalizedBlock(t, state, blockN)
 
 			segment, err := state.AtBlockID(blockN.ID()).SealingSegment()
 			require.NoError(t, err)
@@ -613,15 +619,16 @@ func TestSealingSegment_FailureCases(t *testing.T) {
 	t.Run("sealing segment from block below local state root", func(t *testing.T) {
 		// Step I: constructing bootstrapping snapshot with some short history:
 		//
-		//       ╭───── finalized blocks ─────╮
-		//    <-  b1  <-  b2  <-  b3(seal(b1))  <-
-		//                        └── head ──┘
+		//          ╭───── finalized blocks ─────╮
+		//    <-  b1  <-  b2(result(b1))  <-  b3(seal(b1))  <-
+		//                                    └── head ──┘
 		//
 		b1 := unittest.BlockWithParentFixture(sporkRoot) // construct block b1, append to state and finalize
-		b2 := unittest.BlockWithParentFixture(b1.Header) // construct block b2, append to state and finalize
-		b3 := unittest.BlockWithParentFixture(b2.Header) // construct block b3 with seal for b1, append it to state and finalize
 		receipt, seal := unittest.ReceiptAndSealForBlock(b1)
-		b3.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt), unittest.WithSeals(seal)))
+		b2 := unittest.BlockWithParentFixture(b1.Header) // construct block b2, append to state and finalize
+		b2.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt)))
+		b3 := unittest.BlockWithParentFixture(b2.Header) // construct block b3 with seal for b1, append it to state and finalize
+		b3.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal)))
 
 		multipleBlockSnapshot := snapshotAfter(t, sporkRootSnapshot, func(state *bprotocol.FollowerState) protocol.Snapshot {
 			for _, b := range []*flow.Block{b1, b2, b3} {
@@ -788,15 +795,20 @@ func TestLatestSealedResult(t *testing.T) {
 			block1 := unittest.BlockWithParentFixture(head)
 
 			block2 := unittest.BlockWithParentFixture(block1.Header)
+
 			receipt1, seal1 := unittest.ReceiptAndSealForBlock(block1)
-			block2.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal1), unittest.WithReceipts(receipt1)))
+			block2.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt1)))
 			block3 := unittest.BlockWithParentFixture(block2.Header)
+			block3.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal1)))
 
 			receipt2, seal2 := unittest.ReceiptAndSealForBlock(block2)
 			receipt3, seal3 := unittest.ReceiptAndSealForBlock(block3)
 			block4 := unittest.BlockWithParentFixture(block3.Header)
 			block4.SetPayload(unittest.PayloadFixture(
 				unittest.WithReceipts(receipt2, receipt3),
+			))
+			block5 := unittest.BlockWithParentFixture(block4.Header)
+			block5.SetPayload(unittest.PayloadFixture(
 				unittest.WithSeals(seal2, seal3),
 			))
 
@@ -806,34 +818,37 @@ func TestLatestSealedResult(t *testing.T) {
 			err = state.ExtendCertified(context.Background(), block2, block3.Header.QuorumCertificate())
 			require.NoError(t, err)
 
-			// B1 <- B2(R1,S1)
-			// querying B2 should return result R1, seal S1
-			t.Run("reference block contains seal", func(t *testing.T) {
-				gotResult, gotSeal, err := state.AtBlockID(block2.ID()).SealedResult()
-				require.NoError(t, err)
-				assert.Equal(t, block2.Payload.Results[0], gotResult)
-				assert.Equal(t, block2.Payload.Seals[0], gotSeal)
-			})
-
 			err = state.ExtendCertified(context.Background(), block3, block4.Header.QuorumCertificate())
 			require.NoError(t, err)
 
-			// B1 <- B2(R1,S1) <- B3
+			// B1 <- B2(R1) <- B3(S1)
+			// querying B3 should return result R1, seal S1
+			t.Run("reference block contains seal", func(t *testing.T) {
+				gotResult, gotSeal, err := state.AtBlockID(block3.ID()).SealedResult()
+				require.NoError(t, err)
+				assert.Equal(t, block2.Payload.Results[0], gotResult)
+				assert.Equal(t, block3.Payload.Seals[0], gotSeal)
+			})
+
+			err = state.ExtendCertified(context.Background(), block4, block5.Header.QuorumCertificate())
+			require.NoError(t, err)
+
+			// B1 <- B2(S1) <- B3(S1)
 			// querying B3 should still return (R1,S1) even though they are in parent block
 			t.Run("reference block contains no seal", func(t *testing.T) {
-				gotResult, gotSeal, err := state.AtBlockID(block2.ID()).SealedResult()
+				gotResult, gotSeal, err := state.AtBlockID(block3.ID()).SealedResult()
 				require.NoError(t, err)
 				assert.Equal(t, &receipt1.ExecutionResult, gotResult)
 				assert.Equal(t, seal1, gotSeal)
 			})
 
-			// B1 <- B2(R1,S1) <- B3 <- B4(R2,S2,R3,S3)
+			// B1 <- B2(R1) <- B3(S1) <- B4(R2,R3) <- B5(S2,S3)
 			// There are two seals in B4 - should return latest by height (S3,R3)
 			t.Run("reference block contains multiple seals", func(t *testing.T) {
-				err = state.ExtendCertified(context.Background(), block4, unittest.CertifyBlock(block4.Header))
+				err = state.ExtendCertified(context.Background(), block5, unittest.CertifyBlock(block5.Header))
 				require.NoError(t, err)
 
-				gotResult, gotSeal, err := state.AtBlockID(block4.ID()).SealedResult()
+				gotResult, gotSeal, err := state.AtBlockID(block5.ID()).SealedResult()
 				require.NoError(t, err)
 				assert.Equal(t, &receipt3.ExecutionResult, gotResult)
 				assert.Equal(t, seal3, gotSeal)

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -260,7 +260,7 @@ func TestBootstrapNonRoot(t *testing.T) {
 	require.NoError(t, err)
 
 	// should be able to bootstrap from snapshot after sealing a non-root block
-	// ROOT <- B1 <- B2(S1) <- CHILD
+	// ROOT <- B1 <- B2(R1) <- B3(S1) <- CHILD
 	t.Run("with sealed block", func(t *testing.T) {
 		after := snapshotAfter(t, rootSnapshot, func(state *bprotocol.FollowerState) protocol.Snapshot {
 			block1 := unittest.BlockWithParentFixture(rootBlock)
@@ -268,13 +268,17 @@ func TestBootstrapNonRoot(t *testing.T) {
 
 			receipt1, seal1 := unittest.ReceiptAndSealForBlock(block1)
 			block2 := unittest.BlockWithParentFixture(block1.Header)
-			block2.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal1), unittest.WithReceipts(receipt1)))
+			block2.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(receipt1)))
 			buildFinalizedBlock(t, state, block2)
 
-			child := unittest.BlockWithParentFixture(block2.Header)
+			block3 := unittest.BlockWithParentFixture(block2.Header)
+			block3.SetPayload(unittest.PayloadFixture(unittest.WithSeals(seal1)))
+			buildFinalizedBlock(t, state, block3)
+
+			child := unittest.BlockWithParentFixture(block3.Header)
 			buildBlock(t, state, child)
 
-			return state.AtBlockID(block2.ID())
+			return state.AtBlockID(block3.ID())
 		})
 
 		bootstrap(t, after, func(state *bprotocol.State, err error) {

--- a/utils/unittest/epoch_builder.go
+++ b/utils/unittest/epoch_builder.go
@@ -123,14 +123,14 @@ func (builder *EpochBuilder) EpochHeights(counter uint64) (*EpochHeights, bool) 
 //
 //	                |                                  EPOCH N                                                      |
 //	                |                                                                                               |
-//	P                 A               B               C               D             E             F           G
+//	P                 A               B               C               D             E             F
 //
-//	+------------+  +------------+  +-----------+  +-----------+  +----------+  +----------+  +----------+----------+
-//	| ER(P-1)    |->| ER(P)      |->| ER(A)     |->| ER(B)     |->| ER(C)    |->| ER(D)    |->| ER(E)    | ER(F)    |
-//	| S(ER(P-2)) |  | S(ER(P-1)) |  | S(ER(P))  |  | S(ER(A))  |  | S(ER(B)) |  | S(ER(C)) |  | S(ER(D)) | S(ER(E)) |
-//	+------------+  +------------+  +-----------+  +-----------+  +----------+  +----------+  +----------+----------+
-//	                                                                            |                        |
-//	                                                                          Setup                    Commit
+//	+------------+  +------------+  +-----------+  +-----------+  +----------+  +----------+  +----------+
+//	| ER(P-1)    |->| ER(P)      |->| ER(A)     |->| ER(B)     |->| ER(C)    |->| ER(D)    |->| ER(E)    |
+//	| S(ER(P-2)) |  | S(ER(P-1)) |  | S(ER(P))  |  | S(ER(A))  |  | S(ER(B)) |  | S(ER(C)) |  | S(ER(D)) |
+//	+------------+  +------------+  +-----------+  +-----------+  +----------+  +----------+  +----------+
+//	                                                                            |             |
+//	                                                                          Setup         Commit
 //
 // ER(X)    := ExecutionReceipt for block X
 // S(ER(X)) := Seal for the ExecutionResult contained in ER(X) (seals block X)
@@ -142,11 +142,11 @@ func (builder *EpochBuilder) EpochHeights(counter uint64) (*EpochHeights, bool) 
 // block A. This is because the root block is sealed from genesis and we
 // can't insert duplicate seals.
 //
-// D contains a seal for block B containing the EpochSetup service event.
-// E contains a QC for D, which causes the EpochSetup to become activated.
+// D contains a seal for block B containing the EpochSetup service event,
+// processing D causes the EpochSetup to become activated.
 //
 // F contains a seal for block D containing the EpochCommit service event.
-// G contains a QC for F, which causes the EpochCommit to become activated.
+// processing F causes the EpochCommit to become activated.
 //
 // To build a sequence of epochs, we call BuildEpoch, then CompleteEpoch, and so on.
 //
@@ -295,30 +295,14 @@ func (builder *EpochBuilder) BuildEpoch() *EpochBuilder {
 		Seals:    []*flow.Seal{sealForD},
 	})
 	builder.addBlock(F)
-	// create receipt for block F
-	receiptF := ReceiptForBlockFixture(F)
-
-	// build block G
-	// G contains a seal for block E and a receipt for block F
-	G := BlockWithParentFixture(F.Header)
-	sealForE := Seal.Fixture(
-		Seal.WithResult(&receiptE.ExecutionResult),
-	)
-	G.SetPayload(flow.Payload{
-		Receipts: []*flow.ExecutionReceiptMeta{receiptF.Meta()},
-		Results:  []*flow.ExecutionResult{&receiptF.ExecutionResult},
-		Seals:    []*flow.Seal{sealForE},
-	})
-
-	builder.addBlock(G)
 
 	// cache information about the built epoch
 	builder.built[counter] = &EpochHeights{
 		Counter:        counter,
 		Staking:        A.Height,
-		Setup:          E.Header.Height,
-		Committed:      G.Header.Height,
-		CommittedFinal: G.Header.Height,
+		Setup:          D.Header.Height,
+		Committed:      F.Header.Height,
+		CommittedFinal: F.Header.Height,
 	}
 
 	return builder


### PR DESCRIPTION
https://github.com/dapperlabs/flow-go/issues/6502

### Context

This PR changes how service events are processed. Previously service events were processed when observing QC for a block which seals service event. This was needed since follower couldn't determine payload validity even though participant could do it. In our current implementation follower accepts only certified blocks, meaning he has same safety guarantees as participant with respect to payload validity. We are changing service events to be processed directly in a block which seals them, not in next child. 

As part of this PR:
- changed implementation
- updated tests(badger, mutator, epochs)
- updated epoch builder to include less blocks, updated tests

P.S in many tests we had incorrectly built payload, for instance block contains a result and seal for same block, which is not supported. To be 100% honest, we still have many places where we don't enforce gap of 1 block between incorporated result and seal, but that can be refactored in separate PR(if needed). 

Please carefully check if I have correctly modified tests.