### PR TITLE
[Access] Enable execution sync by default

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -170,7 +170,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 			BindAddress: cmd.NotSet,
 			Metrics:     metrics.NewNoopCollector(),
 		},
-		executionDataSyncEnabled: false,
+		executionDataSyncEnabled: true,
 		executionDataDir:         filepath.Join(homedir, ".flow", "execution_data"),
 		executionDataStartHeight: 0,
 		executionDataConfig: edrequester.ExecutionDataConfig{

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -982,6 +982,9 @@ func (net *FlowNetwork) AddNode(t *testing.T, bootstrapDir string, nodeConf Cont
 				nodeContainer.AddFlag("public-network-address", fmt.Sprintf("%s:%d", nodeContainer.Name(), AccessNodePublicNetworkPort))
 			}
 
+			// execution-sync is enabled by default
+			nodeContainer.AddFlag("execution-data-dir", DefaultExecutionDataServiceDir)
+
 			// nodeContainer.bindPort(hostMetricsPort, containerMetricsPort)
 			// nodeContainer.Ports[AccessNodeMetricsPort] = hostMetricsPort
 			// net.AccessPorts[AccessNodeMetricsPort] = hostMetricsPort


### PR DESCRIPTION
This modifies the default config for Access nodes to enable execution sync by default.

Operators are advised to add a flag to specify the directory where the data should be stored. e.g.
```
--execution-data-dir=/data/execution_data
```