### PR TITLE
Update workflow to add summary for GCS location for tools

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -53,6 +53,9 @@ jobs:
         if [[ "${{ inputs.promote }}" = true ]]; then
           echo "promoting boot-tools.tar"
           gsutil cp boot-tools.tar gs://flow-genesis-bootstrap/boot-tools.tar
+          SUMMARY=$'# Tool Build and Upload Summary \n Your tools were uploaded to the following GCS objects \n * Boot Tools gs://flow-genesis-bootstrap/boot-tools.tar \n * Util util.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/util.tar'
         else
           echo "not promoting boot-tools.tar"
+          SUMMARY=$'# Tool Build and Upload Summary \n Your tools were uploaded to the following GCS objects \n * Boot Tools gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/boot-tools.tar \n * Util util.tar gs://flow-genesis-bootstrap/tools/${{ inputs.tag }}/util.tar'
         fi
+        echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description
Add a summary to the the tools build workflow so that the user explicitly knows where the objects were uploaded.

Please reference the following workflow execution as an example of how the summary is generated at the end. https://github.com/onflow/flow-go/actions/runs/4622665760