### PR TITLE
Separate integration test for version upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
           - make -C integration mvp-tests
           - make -C integration network-tests
           - make -C integration verification-tests
+          - make -C integration upgrades-tests
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -10,10 +10,10 @@ endif
 
 # Run the integration test suite
 .PHONY: integration-test
-integration-test: access-tests ghost-tests mvp-tests execution-tests verification-tests collection-tests epochs-tests network-tests consensus-tests
+integration-test: access-tests ghost-tests mvp-tests execution-tests verification-tests upgrades-tests collection-tests epochs-tests network-tests consensus-tests
 
 .PHONY: ci-integration-test
-ci-integration-test: access-tests ghost-tests mvp-tests epochs-tests consensus-tests execution-tests verification-tests network-tests collection-tests
+ci-integration-test: access-tests ghost-tests mvp-tests epochs-tests consensus-tests execution-tests verification-tests upgrades-tests network-tests collection-tests
 
 ############################################################################################
 # CAUTION: DO NOT MODIFY THE TARGETS BELOW! DOING SO WILL BREAK THE FLAKY TEST MONITOR
@@ -56,6 +56,10 @@ execution-tests:
 .PHONY: verification-tests
 verification-tests:
 	go test $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/verification/...
+
+.PHONY: upgrades-tests
+upgrades-tests:
+	go test $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -tags relic ./tests/upgrades/...
 
 .PHONY: network-tests
 network-tests:

--- a/integration/tests/upgrades/suite.go
+++ b/integration/tests/upgrades/suite.go
@@ -1,0 +1,119 @@
+package upgrades
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/onflow/flow-go/engine/ghost/client"
+	"github.com/onflow/flow-go/integration/testnet"
+	"github.com/onflow/flow-go/integration/tests/lib"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+type Suite struct {
+	suite.Suite
+	log zerolog.Logger
+	lib.TestnetStateTracker
+	cancel  context.CancelFunc
+	net     *testnet.FlowNetwork
+	ghostID flow.Identifier
+	exe1ID  flow.Identifier
+}
+
+func (s *Suite) Ghost() *client.GhostClient {
+	client, err := s.net.ContainerByID(s.ghostID).GhostClient()
+	require.NoError(s.T(), err, "could not get ghost client")
+	return client
+}
+
+func (s *Suite) SetupTest() {
+	s.log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
+	s.log.Info().Msg("================> SetupTest")
+	defer func() {
+		s.log.Info().Msg("================> Finish SetupTest")
+	}()
+
+	collectionConfigs := []func(*testnet.NodeConfig){
+		testnet.WithAdditionalFlag("--block-rate-delay=10ms"),
+		testnet.WithLogLevel(zerolog.WarnLevel),
+	}
+
+	consensusConfigs := []func(config *testnet.NodeConfig){
+		testnet.WithAdditionalFlag("--block-rate-delay=10ms"),
+		testnet.WithAdditionalFlag(
+			fmt.Sprintf(
+				"--required-verification-seal-approvals=%d",
+				1,
+			),
+		),
+		testnet.WithAdditionalFlag(
+			fmt.Sprintf(
+				"--required-construction-seal-approvals=%d",
+				1,
+			),
+		),
+		testnet.WithLogLevel(zerolog.WarnLevel),
+	}
+
+	// a ghost node masquerading as an access node
+	s.ghostID = unittest.IdentifierFixture()
+	ghostNode := testnet.NewNodeConfig(
+		flow.RoleAccess,
+		testnet.WithLogLevel(zerolog.FatalLevel),
+		testnet.WithID(s.ghostID),
+		testnet.AsGhost(),
+	)
+
+	s.exe1ID = unittest.IdentifierFixture()
+	confs := []testnet.NodeConfig{
+		testnet.NewNodeConfig(flow.RoleCollection, collectionConfigs...),
+		testnet.NewNodeConfig(
+			flow.RoleExecution,
+			testnet.WithLogLevel(zerolog.WarnLevel),
+			testnet.WithID(s.exe1ID),
+			testnet.WithAdditionalFlag("--extensive-logging=true"),
+		),
+		testnet.NewNodeConfig(
+			flow.RoleExecution,
+			testnet.WithLogLevel(zerolog.WarnLevel),
+		),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(flow.RoleConsensus, consensusConfigs...),
+		testnet.NewNodeConfig(
+			flow.RoleVerification,
+			testnet.WithLogLevel(zerolog.WarnLevel),
+		),
+		testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.WarnLevel)),
+		ghostNode,
+	}
+
+	netConfig := testnet.NewNetworkConfig(
+		"upgrade_tests",
+		confs,
+		// set long staking phase to avoid QC/DKG transactions during test run
+		testnet.WithViewsInStakingAuction(10_000),
+		testnet.WithViewsInEpoch(100_000),
+	)
+	// initialize the network
+	s.net = testnet.PrepareFlowNetwork(s.T(), netConfig, flow.Localnet)
+
+	// start the network
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.net.Start(ctx)
+
+	// start tracking blocks
+	s.Track(s.T(), ctx, s.Ghost())
+}
+
+func (s *Suite) TearDownTest() {
+	s.log.Info().Msg("================> Start TearDownTest")
+	s.net.Remove()
+	s.cancel()
+	s.log.Info().Msg("================> Finish TearDownTest")
+}


### PR DESCRIPTION
Continuing to dissect this PR https://github.com/onflow/flow-go/pull/3736 into smaller chunks.

This one separates out the integration tests for version upgrades.
The version beacon integration tests will be added to this test suite.