### PR TITLE
[Backport] Step 1 of Follower optimization

### DIFF
--- a/consensus/hotstuff/forks/blockQC.go
+++ b/consensus/hotstuff/forks/blockQC.go
@@ -1,13 +1,1 @@
 package forks
-
-import (
-	"github.com/onflow/flow-go/consensus/hotstuff/model"
-	"github.com/onflow/flow-go/model/flow"
-)
-
-// BlockQC is a Block with a QC that pointing to it, meaning a Quorum Certified Block.
-// This implies Block.View == QC.View && Block.BlockID == QC.BlockID
-type BlockQC struct {
-	Block *model.Block
-	QC    *flow.QuorumCertificate
-}

--- a/consensus/hotstuff/forks/block_builder_test.go
+++ b/consensus/hotstuff/forks/block_builder_test.go
@@ -145,7 +145,7 @@ func makeBlockID(block *model.Block) flow.Identifier {
 	})
 }
 
-func makeGenesis() *BlockQC {
+func makeGenesis() *model.CertifiedBlock {
 	genesis := &model.Block{
 		View: 1,
 	}
@@ -155,9 +155,9 @@ func makeGenesis() *BlockQC {
 		View:    1,
 		BlockID: genesis.BlockID,
 	}
-	genesisBQ := &BlockQC{
-		Block: genesis,
-		QC:    genesisQC,
+	certifiedGenesisBlock, err := model.NewCertifiedBlock(genesis, genesisQC)
+	if err != nil {
+		panic(fmt.Sprintf("combining genesis block and genensis QC to certified block failed: %s", err.Error()))
 	}
-	return genesisBQ
+	return &certifiedGenesisBlock
 }

--- a/consensus/hotstuff/forks/forks.go
+++ b/consensus/hotstuff/forks/forks.go
@@ -26,8 +26,8 @@ var ErrPrunedAncestry = errors.New("cannot resolve pruned ancestor")
 //	[b<-qc_b]  [b'<-qc_b']  [b*]
 type ancestryChain struct {
 	block    *BlockContainer
-	oneChain *BlockQC
-	twoChain *BlockQC
+	oneChain *model.CertifiedBlock
+	twoChain *model.CertifiedBlock
 }
 
 // Forks enforces structural validity of the consensus state and implements
@@ -40,13 +40,13 @@ type Forks struct {
 	forest   forest.LevelledForest
 
 	finalizationCallback module.Finalizer
-	newestView           uint64   // newestView is the highest view of block proposal stored in Forks
-	lastFinalized        *BlockQC // lastFinalized is the QC that POINTS TO the most recently finalized locked block
+	newestView           uint64                // newestView is the highest view of block proposal stored in Forks
+	lastFinalized        *model.CertifiedBlock // the most recently finalized block and the QC that certifies it
 }
 
 var _ hotstuff.Forks = (*Forks)(nil)
 
-func New(trustedRoot *BlockQC, finalizationCallback module.Finalizer, notifier hotstuff.FinalizationConsumer) (*Forks, error) {
+func New(trustedRoot *model.CertifiedBlock, finalizationCallback module.Finalizer, notifier hotstuff.FinalizationConsumer) (*Forks, error) {
 	if (trustedRoot.Block.BlockID != trustedRoot.QC.BlockID) || (trustedRoot.Block.View != trustedRoot.QC.View) {
 		return nil, model.NewConfigurationErrorf("invalid root: root QC is not pointing to root block")
 	}
@@ -341,7 +341,7 @@ func (f *Forks) getTwoChain(blockContainer *BlockContainer) (*ancestryChain, err
 //   - model.MissingBlockError if the parent block does not exist in the forest
 //     (but is above the pruned view)
 //   - generic error in case of unexpected bug or internal state corruption
-func (f *Forks) getNextAncestryLevel(block *model.Block) (*BlockQC, error) {
+func (f *Forks) getNextAncestryLevel(block *model.Block) (*model.CertifiedBlock, error) {
 	// The finalizer prunes all blocks in forest which are below the most recently finalized block.
 	// Hence, we have a pruned ancestry if and only if either of the following conditions applies:
 	//    (a) if a block's parent view (i.e. block.QC.View) is below the most recently finalized block.
@@ -367,9 +367,11 @@ func (f *Forks) getNextAncestryLevel(block *model.Block) (*BlockQC, error) {
 			block.BlockID, block.View, block.QC.View, block.QC.BlockID, parentBlock.BlockID, parentBlock.View)
 	}
 
-	blockQC := BlockQC{Block: parentBlock, QC: block.QC}
-
-	return &blockQC, nil
+	certifiedBlock, err := model.NewCertifiedBlock(parentBlock, block.QC)
+	if err != nil {
+		return nil, fmt.Errorf("constructing certified block failed: %w", err)
+	}
+	return &certifiedBlock, nil
 }
 
 // finalizeUpToBlock finalizes all blocks up to (and including) the block pointed to by `qc`.
@@ -416,7 +418,10 @@ func (f *Forks) finalizeUpToBlock(qc *flow.QuorumCertificate) error {
 	}
 
 	// finalize block itself:
-	f.lastFinalized = &BlockQC{Block: block, QC: qc}
+	*f.lastFinalized, err = model.NewCertifiedBlock(block, qc)
+	if err != nil {
+		return fmt.Errorf("constructing certified block failed: %w", err)
+	}
 	err = f.forest.PruneUpToLevel(block.View)
 	if err != nil {
 		if mempool.IsBelowPrunedThresholdError(err) {

--- a/consensus/hotstuff/integration/instance_test.go
+++ b/consensus/hotstuff/integration/instance_test.go
@@ -378,7 +378,8 @@ func NewInstance(t *testing.T, options ...Option) *Instance {
 		BlockID:       rootBlock.BlockID,
 		SignerIndices: signerIndices,
 	}
-	rootBlockQC := &forks.BlockQC{Block: rootBlock, QC: rootQC}
+	certifiedRootBlock, err := model.NewCertifiedBlock(rootBlock, rootQC)
+	require.NoError(t, err)
 
 	livenessData := &hotstuff.LivenessData{
 		CurrentView: rootQC.View + 1,
@@ -393,7 +394,7 @@ func NewInstance(t *testing.T, options ...Option) *Instance {
 	require.NoError(t, err)
 
 	// initialize the forks handler
-	in.forks, err = forks.New(rootBlockQC, in.finalizer, notifier)
+	in.forks, err = forks.New(&certifiedRootBlock, in.finalizer, notifier)
 	require.NoError(t, err)
 
 	// initialize the validator

--- a/consensus/hotstuff/model/block.go
+++ b/consensus/hotstuff/model/block.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -43,4 +44,41 @@ func GenesisBlockFromFlow(header *flow.Header) *Block {
 		Timestamp:   header.Timestamp,
 	}
 	return genesis
+}
+
+// CertifiedBlock holds a certified block, which is a block and a QC that is pointing to
+// the block. A QC is the aggregated form of votes from a supermajority of HotStuff and
+// therefore proves validity of the block. A certified block satisfies:
+// Block.View == QC.View and Block.BlockID == QC.BlockID
+type CertifiedBlock struct {
+	Block *Block
+	QC    *flow.QuorumCertificate
+}
+
+// NewCertifiedBlock constructs a new certified block. It checks the consistency
+// requirements and returns an exception otherwise:
+//
+//	Block.View == QC.View and Block.BlockID == QC.BlockID
+func NewCertifiedBlock(block *Block, qc *flow.QuorumCertificate) (CertifiedBlock, error) {
+	if block.View != qc.View {
+		return CertifiedBlock{}, fmt.Errorf("block's view (%d) should equal the qc's view (%d)", block.View, qc.View)
+	}
+	if block.BlockID != qc.BlockID {
+		return CertifiedBlock{}, fmt.Errorf("block's ID (%v) should equal the block referenced by the qc (%d)", block.BlockID, qc.BlockID)
+	}
+	return CertifiedBlock{
+		Block: block,
+		QC:    qc,
+	}, nil
+}
+
+// ID returns unique identifier for the block.
+// To avoid repeated computation, we use value from the QC.
+func (b *CertifiedBlock) ID() flow.Identifier {
+	return b.QC.BlockID
+}
+
+// View returns view where the block was proposed.
+func (b *CertifiedBlock) View() uint64 {
+	return b.QC.View
 }

--- a/consensus/hotstuff/pacemaker/pacemaker.go
+++ b/consensus/hotstuff/pacemaker/pacemaker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/consensus/hotstuff/pacemaker/timeout"
+	"github.com/onflow/flow-go/consensus/hotstuff/tracker"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -29,8 +30,7 @@ type ActivePaceMaker struct {
 	ctx            context.Context
 	timeoutControl *timeout.Controller
 	notifier       hotstuff.Consumer
-	persist        hotstuff.Persister
-	livenessData   *hotstuff.LivenessData
+	viewTracker    viewTracker
 	started        bool
 }
 
@@ -43,111 +43,70 @@ var _ hotstuff.PaceMaker = (*ActivePaceMaker)(nil)
 //
 // Expected error conditions:
 // * model.ConfigurationError if initial LivenessData is invalid
-func New(timeoutController *timeout.Controller,
+func New(
+	timeoutController *timeout.Controller,
 	notifier hotstuff.Consumer,
 	persist hotstuff.Persister,
+	recovery ...recoveryInformation,
 ) (*ActivePaceMaker, error) {
-	livenessData, err := persist.GetLivenessData()
+	vt, err := newViewTracker(persist)
 	if err != nil {
-		return nil, fmt.Errorf("could not recover liveness data: %w", err)
+		return nil, fmt.Errorf("initializing view tracker failed: %w", err)
 	}
 
-	if livenessData.CurrentView < 1 {
-		return nil, model.NewConfigurationErrorf("PaceMaker cannot start in view 0 (view zero is reserved for genesis block, which has no proposer)")
-	}
-	pm := ActivePaceMaker{
-		livenessData:   livenessData,
+	pm := &ActivePaceMaker{
 		timeoutControl: timeoutController,
 		notifier:       notifier,
-		persist:        persist,
+		viewTracker:    vt,
 		started:        false,
 	}
-	return &pm, nil
-}
-
-// updateLivenessData updates the current view, qc, tc. Currently, the calling code
-// ensures that the view number is STRICTLY monotonously increasing. The method
-// updateLivenessData panics as a last resort if ActivePaceMaker is modified to violate this condition.
-// No errors are expected, any error should be treated as exception.
-func (p *ActivePaceMaker) updateLivenessData(newView uint64, qc *flow.QuorumCertificate, tc *flow.TimeoutCertificate) error {
-	if newView <= p.livenessData.CurrentView {
-		// This should never happen: in the current implementation, it is trivially apparent that
-		// newView is _always_ larger than currentView. This check is to protect the code from
-		// future modifications that violate the necessary condition for
-		// STRICTLY monotonously increasing view numbers.
-		return fmt.Errorf("cannot move from view %d to %d: currentView must be strictly monotonously increasing",
-			p.livenessData.CurrentView, newView)
+	for _, recoveryAction := range recovery {
+		err = recoveryAction(pm)
+		if err != nil {
+			return nil, fmt.Errorf("ingesting recovery information failed: %w", err)
+		}
 	}
-
-	p.livenessData.CurrentView = newView
-	if p.livenessData.NewestQC.View < qc.View {
-		p.livenessData.NewestQC = qc
-	}
-	p.livenessData.LastViewTC = tc
-	err := p.persist.PutLivenessData(p.livenessData)
-	if err != nil {
-		return fmt.Errorf("could not persist liveness data: %w", err)
-	}
-
-	return nil
-}
-
-// updateNewestQC updates the highest QC tracked by view, iff `qc` has a larger view than
-// the QC stored in the PaceMaker's `livenessData`. Otherwise, this method is a no-op.
-// No errors are expected, any error should be treated as exception.
-func (p *ActivePaceMaker) updateNewestQC(qc *flow.QuorumCertificate) error {
-	if p.livenessData.NewestQC.View >= qc.View {
-		return nil
-	}
-
-	p.livenessData.NewestQC = qc
-	err := p.persist.PutLivenessData(p.livenessData)
-	if err != nil {
-		return fmt.Errorf("could not persist liveness data: %w", err)
-	}
-
-	return nil
+	return pm, nil
 }
 
 // CurView returns the current view
-func (p *ActivePaceMaker) CurView() uint64 {
-	return p.livenessData.CurrentView
-}
+func (p *ActivePaceMaker) CurView() uint64 { return p.viewTracker.CurView() }
+
+// NewestQC returns QC with the highest view discovered by PaceMaker.
+func (p *ActivePaceMaker) NewestQC() *flow.QuorumCertificate { return p.viewTracker.NewestQC() }
+
+// LastViewTC returns TC for last view, this will be nil only if the current view
+// was entered with a QC.
+func (p *ActivePaceMaker) LastViewTC() *flow.TimeoutCertificate { return p.viewTracker.LastViewTC() }
 
 // TimeoutChannel returns the timeout channel for current active timeout.
 // Note the returned timeout channel returns only one timeout, which is the current
 // timeout.
 // To get the timeout for the next timeout, you need to call TimeoutChannel() again.
-func (p *ActivePaceMaker) TimeoutChannel() <-chan time.Time {
-	return p.timeoutControl.Channel()
-}
+func (p *ActivePaceMaker) TimeoutChannel() <-chan time.Time { return p.timeoutControl.Channel() }
+
+// BlockRateDelay returns the delay for broadcasting its own proposals.
+func (p *ActivePaceMaker) BlockRateDelay() time.Duration { return p.timeoutControl.BlockRateDelay() }
 
 // ProcessQC notifies the pacemaker with a new QC, which might allow pacemaker to
 // fast-forward its view. In contrast to `ProcessTC`, this function does _not_ handle `nil` inputs.
 // No errors are expected, any error should be treated as exception
 func (p *ActivePaceMaker) ProcessQC(qc *flow.QuorumCertificate) (*model.NewViewEvent, error) {
-	oldView := p.CurView()
-	if qc.View < oldView {
-		err := p.updateNewestQC(qc)
-		if err != nil {
-			return nil, fmt.Errorf("could not update tracked newest QC: %w", err)
-		}
+	initialView := p.CurView()
+	resultingView, err := p.viewTracker.ProcessQC(qc)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected exception in viewTracker while processing QC for view %d: %w", qc.View, err)
+	}
+	if resultingView <= initialView {
 		return nil, nil
 	}
 
+	// QC triggered view change:
 	p.timeoutControl.OnProgressBeforeTimeout()
+	p.notifier.OnQcTriggeredViewChange(initialView, resultingView, qc)
 
-	// supermajority of replicas have already voted during round `qc.view`, hence it is safe to proceed to subsequent view
-	newView := qc.View + 1
-	err := p.updateLivenessData(newView, qc, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	p.notifier.OnQcTriggeredViewChange(oldView, newView, qc)
-	p.notifier.OnViewChange(oldView, newView)
-
-	timerInfo := p.timeoutControl.StartTimeout(p.ctx, newView)
+	p.notifier.OnViewChange(initialView, resultingView)
+	timerInfo := p.timeoutControl.StartTimeout(p.ctx, resultingView)
 	p.notifier.OnStartingTimeout(timerInfo)
 
 	return &model.NewViewEvent{
@@ -163,32 +122,21 @@ func (p *ActivePaceMaker) ProcessQC(qc *flow.QuorumCertificate) (*model.NewViewE
 // which may or may not have a value.
 // No errors are expected, any error should be treated as exception
 func (p *ActivePaceMaker) ProcessTC(tc *flow.TimeoutCertificate) (*model.NewViewEvent, error) {
-	if tc == nil {
-		return nil, nil
-	}
-
-	oldView := p.CurView()
-	if tc.View < oldView {
-		err := p.updateNewestQC(tc.NewestQC)
-		if err != nil {
-			return nil, fmt.Errorf("could not update tracked newest QC: %w", err)
-		}
-		return nil, nil
-	}
-
-	p.timeoutControl.OnTimeout()
-
-	// supermajority of replicas have already reached their timeout for view `tc.View`, hence it is safe to proceed to subsequent view
-	newView := tc.View + 1
-	err := p.updateLivenessData(newView, tc.NewestQC, tc)
+	initialView := p.CurView()
+	resultingView, err := p.viewTracker.ProcessTC(tc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unexpected exception in viewTracker while processing TC for view %d: %w", tc.View, err)
+	}
+	if resultingView <= initialView {
+		return nil, nil
 	}
 
-	p.notifier.OnTcTriggeredViewChange(oldView, newView, tc)
-	p.notifier.OnViewChange(oldView, newView)
+	// TC triggered view change:
+	p.timeoutControl.OnTimeout()
+	p.notifier.OnTcTriggeredViewChange(initialView, resultingView, tc)
 
-	timerInfo := p.timeoutControl.StartTimeout(p.ctx, newView)
+	p.notifier.OnViewChange(initialView, resultingView)
+	timerInfo := p.timeoutControl.StartTimeout(p.ctx, resultingView)
 	p.notifier.OnStartingTimeout(timerInfo)
 
 	return &model.NewViewEvent{
@@ -196,17 +144,6 @@ func (p *ActivePaceMaker) ProcessTC(tc *flow.TimeoutCertificate) (*model.NewView
 		StartTime: timerInfo.StartTime,
 		Duration:  timerInfo.Duration,
 	}, nil
-}
-
-// NewestQC returns QC with the highest view discovered by PaceMaker.
-func (p *ActivePaceMaker) NewestQC() *flow.QuorumCertificate {
-	return p.livenessData.NewestQC
-}
-
-// LastViewTC returns TC for last view, this will be nil only if the current view
-// was entered with a QC.
-func (p *ActivePaceMaker) LastViewTC() *flow.TimeoutCertificate {
-	return p.livenessData.LastViewTC
 }
 
 // Start starts the pacemaker by starting the initial timer for the current view.
@@ -224,7 +161,63 @@ func (p *ActivePaceMaker) Start(ctx context.Context) {
 	p.notifier.OnStartingTimeout(timerInfo)
 }
 
-// BlockRateDelay returns the delay for broadcasting its own proposals.
-func (p *ActivePaceMaker) BlockRateDelay() time.Duration {
-	return p.timeoutControl.BlockRateDelay()
+/* ------------------------------------ recovery parameters for PaceMaker ------------------------------------ */
+
+// recoveryInformation provides optional information to the PaceMaker during its construction
+// to ingest additional information that was potentially lost during a crash or reboot.
+// Following the "information-driven" approach, we consider potentially older or redundant
+// information as consistent with our already-present knowledge, i.e. as a no-op.
+type recoveryInformation func(p *ActivePaceMaker) error
+
+// WithQCs informs the PaceMaker about the given QCs. Old and nil QCs are accepted (no-op).
+func WithQCs(qcs ...*flow.QuorumCertificate) recoveryInformation {
+	// To avoid excessive data base writes during initialization, we pre-filter the newest QC
+	// here and only hand that one to the viewTracker. For recovery, we allow the special case
+	// of nil QCs, because the genesis block has no QC.
+	tracker := tracker.NewNewestQCTracker()
+	for _, qc := range qcs {
+		if qc == nil {
+			continue // no-op
+		}
+		tracker.Track(qc)
+	}
+	newestQC := tracker.NewestQC()
+	if newestQC == nil {
+		return func(p *ActivePaceMaker) error { return nil } // no-op
+	}
+
+	return func(p *ActivePaceMaker) error {
+		_, err := p.viewTracker.ProcessQC(newestQC) // panics for nil input
+		return err
+	}
+}
+
+// WithTCs informs the PaceMaker about the given TCs. Old and nil TCs are accepted (no-op).
+func WithTCs(tcs ...*flow.TimeoutCertificate) recoveryInformation {
+	qcTracker := tracker.NewNewestQCTracker()
+	tcTracker := tracker.NewNewestTCTracker()
+	for _, tc := range tcs {
+		if tc == nil {
+			continue // no-op
+		}
+		tcTracker.Track(tc)
+		qcTracker.Track(tc.NewestQC)
+	}
+	newestTC := tcTracker.NewestTC()
+	newestQC := qcTracker.NewestQC()
+	if newestTC == nil { // shortcut if no TCs provided
+		return func(p *ActivePaceMaker) error { return nil } // no-op
+	}
+
+	return func(p *ActivePaceMaker) error {
+		_, err := p.viewTracker.ProcessTC(newestTC) // allows nil inputs
+		if err != nil {
+			return fmt.Errorf("viewTracker failed to process newest TC provided in constructor: %w", err)
+		}
+		_, err = p.viewTracker.ProcessQC(newestQC) // should never be nil, because a valid TC always contain a QC
+		if err != nil {
+			return fmt.Errorf("viewTracker failed to process newest QC extracted from the TCs provided in constructor: %w", err)
+		}
+		return nil
+	}
 }

--- a/consensus/hotstuff/pacemaker/pacemaker_test.go
+++ b/consensus/hotstuff/pacemaker/pacemaker_test.go
@@ -3,6 +3,7 @@ package pacemaker
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -39,18 +40,24 @@ func TestActivePaceMaker(t *testing.T) {
 type ActivePaceMakerTestSuite struct {
 	suite.Suite
 
-	livenessData *hotstuff.LivenessData
-	notifier     *mocks.Consumer
-	persist      *mocks.Persister
-	paceMaker    *ActivePaceMaker
-	stop         context.CancelFunc
+	initialView uint64
+	initialQC   *flow.QuorumCertificate
+	initialTC   *flow.TimeoutCertificate
+
+	notifier    *mocks.Consumer
+	persist     *mocks.Persister
+	paceMaker   *ActivePaceMaker
+	stop        context.CancelFunc
+	timeoutConf timeout.Config
 }
 
 func (s *ActivePaceMakerTestSuite) SetupTest() {
-	s.notifier = mocks.NewConsumer(s.T())
-	s.persist = mocks.NewPersister(s.T())
+	s.initialView = 3
+	s.initialQC = QC(2)
+	s.initialTC = nil
+	var err error
 
-	tc, err := timeout.NewConfig(
+	s.timeoutConf, err = timeout.NewConfig(
 		time.Duration(minRepTimeout*1e6),
 		time.Duration(maxRepTimeout*1e6),
 		multiplicativeIncrease,
@@ -59,18 +66,24 @@ func (s *ActivePaceMakerTestSuite) SetupTest() {
 		time.Duration(maxRepTimeout*1e6))
 	require.NoError(s.T(), err)
 
-	s.livenessData = &hotstuff.LivenessData{
+	// init consumer for notifications emitted by PaceMaker
+	s.notifier = mocks.NewConsumer(s.T())
+	s.notifier.On("OnStartingTimeout", expectedTimerInfo(s.initialView)).Return().Once()
+
+	// init Persister dependency for PaceMaker
+	// CAUTION: The Persister hands a pointer to `livenessData` to the PaceMaker, which means the PaceMaker
+	// could modify our struct in-place. `livenessData` should not be used by tests to determine expected values!
+	s.persist = mocks.NewPersister(s.T())
+	livenessData := &hotstuff.LivenessData{
 		CurrentView: 3,
 		LastViewTC:  nil,
-		NewestQC:    helper.MakeQC(helper.WithQCView(2)),
+		NewestQC:    s.initialQC,
 	}
+	s.persist.On("GetLivenessData").Return(livenessData, nil)
 
-	s.persist.On("GetLivenessData").Return(s.livenessData, nil).Once()
-
-	s.paceMaker, err = New(timeout.NewController(tc), s.notifier, s.persist)
+	// init PaceMaker and start
+	s.paceMaker, err = New(timeout.NewController(s.timeoutConf), s.notifier, s.persist)
 	require.NoError(s.T(), err)
-
-	s.notifier.On("OnStartingTimeout", expectedTimerInfo(s.livenessData.CurrentView)).Return().Once()
 
 	var ctx context.Context
 	ctx, s.stop = context.WithCancel(context.Background())
@@ -82,7 +95,7 @@ func (s *ActivePaceMakerTestSuite) TearDownTest() {
 }
 
 func QC(view uint64) *flow.QuorumCertificate {
-	return &flow.QuorumCertificate{View: view}
+	return helper.MakeQC(helper.WithQCView(view))
 }
 
 func LivenessData(qc *flow.QuorumCertificate) *hotstuff.LivenessData {
@@ -96,11 +109,12 @@ func LivenessData(qc *flow.QuorumCertificate) *hotstuff.LivenessData {
 // TestProcessQC_SkipIncreaseViewThroughQC tests that ActivePaceMaker increases view when receiving QC,
 // if applicable, by skipping views
 func (s *ActivePaceMakerTestSuite) TestProcessQC_SkipIncreaseViewThroughQC() {
-	qc := QC(s.livenessData.CurrentView)
+	// seeing a QC for the current view should advance the view by one
+	qc := QC(s.initialView)
 	s.persist.On("PutLivenessData", LivenessData(qc)).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(4)).Return().Once()
-	s.notifier.On("OnQcTriggeredViewChange", s.livenessData.CurrentView, uint64(4), qc).Return().Once()
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, qc.View+1).Once()
+	s.notifier.On("OnQcTriggeredViewChange", s.initialView, uint64(4), qc).Return().Once()
+	s.notifier.On("OnViewChange", s.initialView, qc.View+1).Once()
 	nve, err := s.paceMaker.ProcessQC(qc)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), qc.View+1, s.paceMaker.CurView())
@@ -108,12 +122,13 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_SkipIncreaseViewThroughQC() {
 	require.Equal(s.T(), qc, s.paceMaker.NewestQC())
 	require.Nil(s.T(), s.paceMaker.LastViewTC())
 
-	// skip 10 views
-	qc = QC(s.livenessData.CurrentView + 10)
+	// seeing a QC for 10 views in the future should advance to view +11
+	curView := s.paceMaker.CurView()
+	qc = QC(curView + 10)
 	s.persist.On("PutLivenessData", LivenessData(qc)).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(qc.View+1)).Return().Once()
-	s.notifier.On("OnQcTriggeredViewChange", s.livenessData.CurrentView, qc.View+1, qc).Return().Once()
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, qc.View+1).Once()
+	s.notifier.On("OnQcTriggeredViewChange", curView, qc.View+1, qc).Return().Once()
+	s.notifier.On("OnViewChange", curView, qc.View+1).Once()
 	nve, err = s.paceMaker.ProcessQC(qc)
 	require.NoError(s.T(), err)
 	require.True(s.T(), nve.View == qc.View+1)
@@ -126,36 +141,35 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_SkipIncreaseViewThroughQC() {
 // TestProcessTC_SkipIncreaseViewThroughTC tests that ActivePaceMaker increases view when receiving TC,
 // if applicable, by skipping views
 func (s *ActivePaceMakerTestSuite) TestProcessTC_SkipIncreaseViewThroughTC() {
-	tc := helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView),
-		helper.WithTCNewestQC(s.livenessData.NewestQC))
+	// seeing a TC for the current view should advance the view by one
+	tc := helper.MakeTC(helper.WithTCView(s.initialView), helper.WithTCNewestQC(s.initialQC))
 	expectedLivenessData := &hotstuff.LivenessData{
 		CurrentView: tc.View + 1,
 		LastViewTC:  tc,
-		NewestQC:    tc.NewestQC,
+		NewestQC:    s.initialQC,
 	}
 	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(tc.View+1)).Return().Once()
-	s.notifier.On("OnTcTriggeredViewChange", s.livenessData.CurrentView, tc.View+1, tc).Return().Once()
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
+	s.notifier.On("OnTcTriggeredViewChange", s.initialView, tc.View+1, tc).Return().Once()
+	s.notifier.On("OnViewChange", s.initialView, tc.View+1).Once()
 	nve, err := s.paceMaker.ProcessTC(tc)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), tc.View+1, s.paceMaker.CurView())
 	require.True(s.T(), nve.View == tc.View+1)
 	require.Equal(s.T(), tc, s.paceMaker.LastViewTC())
 
-	// skip 10 views
-	tc = helper.MakeTC(helper.WithTCView(tc.View+10),
-		helper.WithTCNewestQC(s.livenessData.NewestQC),
-		helper.WithTCNewestQC(QC(s.livenessData.CurrentView)))
+	// seeing a TC for 10 views in the future should advance to view +11
+	curView := s.paceMaker.CurView()
+	tc = helper.MakeTC(helper.WithTCView(curView+10), helper.WithTCNewestQC(s.initialQC))
 	expectedLivenessData = &hotstuff.LivenessData{
 		CurrentView: tc.View + 1,
 		LastViewTC:  tc,
-		NewestQC:    tc.NewestQC,
+		NewestQC:    s.initialQC,
 	}
 	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
 	s.notifier.On("OnStartingTimeout", expectedTimerInfo(tc.View+1)).Return().Once()
-	s.notifier.On("OnTcTriggeredViewChange", s.livenessData.CurrentView, tc.View+1, tc).Return().Once()
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
+	s.notifier.On("OnTcTriggeredViewChange", curView, tc.View+1, tc).Return().Once()
+	s.notifier.On("OnViewChange", curView, tc.View+1).Once()
 	nve, err = s.paceMaker.ProcessTC(tc)
 	require.NoError(s.T(), err)
 	require.True(s.T(), nve.View == tc.View+1)
@@ -167,11 +181,11 @@ func (s *ActivePaceMakerTestSuite) TestProcessTC_SkipIncreaseViewThroughTC() {
 
 // TestProcessTC_IgnoreOldTC tests that ActivePaceMaker ignores old TC and doesn't advance round.
 func (s *ActivePaceMakerTestSuite) TestProcessTC_IgnoreOldTC() {
-	nve, err := s.paceMaker.ProcessTC(helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView-1),
-		helper.WithTCNewestQC(s.livenessData.NewestQC)))
+	nve, err := s.paceMaker.ProcessTC(helper.MakeTC(helper.WithTCView(s.initialView-1),
+		helper.WithTCNewestQC(s.initialQC)))
 	require.NoError(s.T(), err)
 	require.Nil(s.T(), nve)
-	require.Equal(s.T(), s.livenessData.CurrentView, s.paceMaker.CurView())
+	require.Equal(s.T(), s.initialView, s.paceMaker.CurView())
 }
 
 // TestProcessTC_IgnoreNilTC tests that ActivePaceMaker accepts nil TC as allowed input but doesn't trigger a new view event
@@ -179,14 +193,14 @@ func (s *ActivePaceMakerTestSuite) TestProcessTC_IgnoreNilTC() {
 	nve, err := s.paceMaker.ProcessTC(nil)
 	require.NoError(s.T(), err)
 	require.Nil(s.T(), nve)
-	require.Equal(s.T(), s.livenessData.CurrentView, s.paceMaker.CurView())
+	require.Equal(s.T(), s.initialView, s.paceMaker.CurView())
 }
 
 // TestProcessQC_PersistException tests that ActivePaceMaker propagates exception
 // when processing QC
 func (s *ActivePaceMakerTestSuite) TestProcessQC_PersistException() {
 	exception := errors.New("persist-exception")
-	qc := QC(s.livenessData.CurrentView)
+	qc := QC(s.initialView)
 	s.persist.On("PutLivenessData", mock.Anything).Return(exception).Once()
 	nve, err := s.paceMaker.ProcessQC(qc)
 	require.Nil(s.T(), nve)
@@ -197,7 +211,7 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_PersistException() {
 // when processing TC
 func (s *ActivePaceMakerTestSuite) TestProcessTC_PersistException() {
 	exception := errors.New("persist-exception")
-	tc := helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView))
+	tc := helper.MakeTC(helper.WithTCView(s.initialView))
 	s.persist.On("PutLivenessData", mock.Anything).Return(exception).Once()
 	nve, err := s.paceMaker.ProcessTC(tc)
 	require.Nil(s.T(), nve)
@@ -207,20 +221,19 @@ func (s *ActivePaceMakerTestSuite) TestProcessTC_PersistException() {
 // TestProcessQC_InvalidatesLastViewTC verifies that PaceMaker does not retain any old
 // TC if the last view change was triggered by observing a QC from the previous view.
 func (s *ActivePaceMakerTestSuite) TestProcessQC_InvalidatesLastViewTC() {
-	tc := helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView+1),
-		helper.WithTCNewestQC(s.livenessData.NewestQC))
+	tc := helper.MakeTC(helper.WithTCView(s.initialView+1), helper.WithTCNewestQC(s.initialQC))
 	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Times(2)
 	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Times(2)
 	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
 	s.notifier.On("OnQcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
+	s.notifier.On("OnViewChange", s.initialView, tc.View+1).Once()
 	nve, err := s.paceMaker.ProcessTC(tc)
 	require.NotNil(s.T(), nve)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), s.paceMaker.LastViewTC())
 
 	qc := QC(tc.View + 1)
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, qc.View+1).Once()
+	s.notifier.On("OnViewChange", tc.View+1, qc.View+1).Once()
 	nve, err = s.paceMaker.ProcessQC(qc)
 	require.NotNil(s.T(), nve)
 	require.NoError(s.T(), err)
@@ -229,32 +242,31 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_InvalidatesLastViewTC() {
 
 // TestProcessQC_IgnoreOldQC tests that ActivePaceMaker ignores old QC and doesn't advance round
 func (s *ActivePaceMakerTestSuite) TestProcessQC_IgnoreOldQC() {
-	qc := QC(s.livenessData.CurrentView - 1)
+	qc := QC(s.initialView - 1)
 	nve, err := s.paceMaker.ProcessQC(qc)
 	require.NoError(s.T(), err)
 	require.Nil(s.T(), nve)
-	require.Equal(s.T(), s.livenessData.CurrentView, s.paceMaker.CurView())
+	require.Equal(s.T(), s.initialView, s.paceMaker.CurView())
 	require.NotEqual(s.T(), qc, s.paceMaker.NewestQC())
 }
 
 // TestProcessQC_UpdateNewestQC tests that ActivePaceMaker tracks the newest QC even if it has advanced past this view.
 // In this test, we feed a newer QC as part of a TC into the PaceMaker.
 func (s *ActivePaceMakerTestSuite) TestProcessQC_UpdateNewestQC() {
-	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Once()
-	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Once()
+	tc := helper.MakeTC(helper.WithTCView(s.initialView+10), helper.WithTCNewestQC(s.initialQC))
+	expectedView := tc.View + 1
 	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
-	tc := helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView+10),
-		helper.WithTCNewestQC(s.livenessData.NewestQC))
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
+	s.notifier.On("OnViewChange", s.initialView, expectedView).Once()
+	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Once()
+	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Once()
 	nve, err := s.paceMaker.ProcessTC(tc)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), nve)
 
-	qc := QC(s.livenessData.NewestQC.View + 5)
-
+	qc := QC(s.initialView + 5)
 	expectedLivenessData := &hotstuff.LivenessData{
-		CurrentView: s.livenessData.CurrentView,
-		LastViewTC:  s.livenessData.LastViewTC,
+		CurrentView: expectedView,
+		LastViewTC:  tc,
 		NewestQC:    qc,
 	}
 	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
@@ -267,23 +279,21 @@ func (s *ActivePaceMakerTestSuite) TestProcessQC_UpdateNewestQC() {
 
 // TestProcessTC_UpdateNewestQC tests that ActivePaceMaker tracks the newest QC included in TC even if it has advanced past this view.
 func (s *ActivePaceMakerTestSuite) TestProcessTC_UpdateNewestQC() {
-	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Once()
-	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Once()
+	tc := helper.MakeTC(helper.WithTCView(s.initialView+10), helper.WithTCNewestQC(s.initialQC))
+	expectedView := tc.View + 1
 	s.notifier.On("OnTcTriggeredViewChange", mock.Anything, mock.Anything, mock.Anything).Return().Once()
-	tc := helper.MakeTC(helper.WithTCView(s.livenessData.CurrentView+10),
-		helper.WithTCNewestQC(s.livenessData.NewestQC))
-	s.notifier.On("OnViewChange", s.livenessData.CurrentView, tc.View+1).Once()
+	s.notifier.On("OnViewChange", s.initialView, expectedView).Once()
+	s.notifier.On("OnStartingTimeout", mock.Anything).Return().Once()
+	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Once()
 	nve, err := s.paceMaker.ProcessTC(tc)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), nve)
 
-	qc := QC(s.livenessData.NewestQC.View + 5)
-	olderTC := helper.MakeTC(helper.WithTCView(s.paceMaker.CurView()-1),
-		helper.WithTCNewestQC(qc))
-
+	qc := QC(s.initialView + 5)
+	olderTC := helper.MakeTC(helper.WithTCView(s.paceMaker.CurView()-1), helper.WithTCNewestQC(qc))
 	expectedLivenessData := &hotstuff.LivenessData{
-		CurrentView: s.livenessData.CurrentView,
-		LastViewTC:  s.livenessData.LastViewTC,
+		CurrentView: expectedView,
+		LastViewTC:  tc,
 		NewestQC:    qc,
 	}
 	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
@@ -292,4 +302,135 @@ func (s *ActivePaceMakerTestSuite) TestProcessTC_UpdateNewestQC() {
 	require.NoError(s.T(), err)
 	require.Nil(s.T(), nve)
 	require.Equal(s.T(), qc, s.paceMaker.NewestQC())
+}
+
+// Test_Initialization tests QCs and TCs provided as optional constructor arguments.
+// We want to test that nil, old and duplicate TCs & QCs are accepted in arbitrary order.
+// The constructed PaceMaker should be in the state:
+//   - in view V+1, where V is the _largest view of _any_ of the ingested QCs and TCs
+//   - method `NewestQC` should report the QC with the highest View in _any_ of the inputs
+func (s *ActivePaceMakerTestSuite) Test_Initialization() {
+	highestView := uint64(0) // highest View of any QC or TC constructed below
+
+	// Randomly create 80 TCs:
+	//  * their view is randomly sampled from the range [3, 103)
+	//  * as we sample 80 times, probability of creating 2 TCs for the same
+	//    view is practically 1 (-> birthday problem)
+	//  * we place the TCs in a slice of length 110, i.e. some elements are guaranteed to be nil
+	//  * Note: we specifically allow for the TC to have the same view as the highest QC.
+	//    This is useful as a fallback, because it allows replicas other than the designated
+	//     leader to also collect votes and generate a QC.
+	tcs := make([]*flow.TimeoutCertificate, 110)
+	for i := 0; i < 80; i++ {
+		tcView := s.initialView + uint64(rand.Intn(100))
+		qcView := 1 + uint64(rand.Intn(int(tcView)))
+		tcs[i] = helper.MakeTC(helper.WithTCView(tcView), helper.WithTCNewestQC(QC(qcView)))
+		highestView = max(highestView, tcView, qcView)
+	}
+	rand.Shuffle(len(tcs), func(i, j int) {
+		tcs[i], tcs[j] = tcs[j], tcs[i]
+	})
+
+	// randomly create 80 QCs (same logic as above)
+	qcs := make([]*flow.QuorumCertificate, 110)
+	for i := 0; i < 80; i++ {
+		qcs[i] = QC(s.initialView + uint64(rand.Intn(100)))
+		highestView = max(highestView, qcs[i].View)
+	}
+	rand.Shuffle(len(qcs), func(i, j int) {
+		qcs[i], qcs[j] = qcs[j], qcs[i]
+	})
+
+	// set up mocks
+	s.persist.On("PutLivenessData", mock.Anything).Return(nil)
+
+	// test that the constructor finds the newest QC and TC
+	s.Run("Random TCs and QCs combined", func() {
+		pm, err := New(
+			timeout.NewController(s.timeoutConf), s.notifier, s.persist,
+			WithQCs(qcs...), WithTCs(tcs...),
+		)
+		require.NoError(s.T(), err)
+
+		require.Equal(s.T(), highestView+1, pm.CurView())
+		if tc := pm.LastViewTC(); tc != nil {
+			require.Equal(s.T(), highestView, tc.View)
+		} else {
+			require.Equal(s.T(), highestView, pm.NewestQC().View)
+		}
+	})
+
+	// We specifically test an edge case: an outdated TC can still contain a QC that
+	// is newer than the newest QC the pacemaker knows so far.
+	s.Run("Newest QC in older TC", func() {
+		tcs[17] = helper.MakeTC(helper.WithTCView(highestView+20), helper.WithTCNewestQC(QC(highestView+5)))
+		tcs[45] = helper.MakeTC(helper.WithTCView(highestView+15), helper.WithTCNewestQC(QC(highestView+12)))
+
+		pm, err := New(
+			timeout.NewController(s.timeoutConf), s.notifier, s.persist,
+			WithTCs(tcs...), WithQCs(qcs...),
+		)
+		require.NoError(s.T(), err)
+
+		// * when observing tcs[17], which is newer than any other QC or TC, the pacemaker should enter view tcs[17].View + 1
+		// * when observing tcs[45], which is older than tcs[17], the PaceMaker should notice that the QC in tcs[45]
+		//   is newer than its local QC and update it
+		require.Equal(s.T(), tcs[17].View+1, pm.CurView())
+		require.Equal(s.T(), tcs[17], pm.LastViewTC())
+		require.Equal(s.T(), tcs[45].NewestQC, pm.NewestQC())
+	})
+
+	// Another edge case: a TC from a past view contains QC for the same view.
+	// While is TC is outdated, the contained QC is still newer that the QC the pacemaker knows so far.
+	s.Run("Newest QC in older TC", func() {
+		tcs[17] = helper.MakeTC(helper.WithTCView(highestView+20), helper.WithTCNewestQC(QC(highestView+5)))
+		tcs[45] = helper.MakeTC(helper.WithTCView(highestView+15), helper.WithTCNewestQC(QC(highestView+15)))
+
+		pm, err := New(
+			timeout.NewController(s.timeoutConf), s.notifier, s.persist,
+			WithTCs(tcs...), WithQCs(qcs...),
+		)
+		require.NoError(s.T(), err)
+
+		// * when observing tcs[17], which is newer than any other QC or TC, the pacemaker should enter view tcs[17].View + 1
+		// * when observing tcs[45], which is older than tcs[17], the PaceMaker should notice that the QC in tcs[45]
+		//   is newer than its local QC and update it
+		require.Equal(s.T(), tcs[17].View+1, pm.CurView())
+		require.Equal(s.T(), tcs[17], pm.LastViewTC())
+		require.Equal(s.T(), tcs[45].NewestQC, pm.NewestQC())
+	})
+
+	// Verify that WithTCs still works correctly if no TCs are given:
+	// the list of TCs is empty or all contained TCs are nil
+	s.Run("Only nil TCs", func() {
+		pm, err := New(timeout.NewController(s.timeoutConf), s.notifier, s.persist, WithTCs())
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), s.initialView, pm.CurView())
+
+		pm, err = New(timeout.NewController(s.timeoutConf), s.notifier, s.persist, WithTCs(nil, nil, nil))
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), s.initialView, pm.CurView())
+	})
+
+	// Verify that WithQCs still works correctly if no QCs are given:
+	// the list of QCs is empty or all contained QCs are nil
+	s.Run("Only nil QCs", func() {
+		pm, err := New(timeout.NewController(s.timeoutConf), s.notifier, s.persist, WithQCs())
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), s.initialView, pm.CurView())
+
+		pm, err = New(timeout.NewController(s.timeoutConf), s.notifier, s.persist, WithQCs(nil, nil, nil))
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), s.initialView, pm.CurView())
+	})
+
+}
+
+func max(a uint64, values ...uint64) uint64 {
+	for _, v := range values {
+		if v > a {
+			a = v
+		}
+	}
+	return a
 }

--- a/consensus/hotstuff/pacemaker/view_tracker.go
+++ b/consensus/hotstuff/pacemaker/view_tracker.go
@@ -1,0 +1,160 @@
+package pacemaker
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/consensus/hotstuff"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// viewTracker is a sub-component of the PaceMaker, which encapsulates the logic for tracking
+// and updating the current view. For crash resilience, the viewTracker persists its latest
+// internal state.
+//
+// In addition, viewTracker maintains and persists a proof to show that it entered the current
+// view according to protocol rules. To enter a new view `v`, the Pacemaker must observe a
+// valid QC or TC for view `v-1`. Per convention, the proof has the following structure:
+//   - If the current view was entered by observing a QC, this QC is returned by `NewestQC()`.
+//     Furthermore, `LastViewTC()` returns nil.
+//   - If the current view was entered by observing a TC, `NewestQC()` returns the newest QC
+//     known. `LastViewTC()` returns the TC that triggered the view change
+type viewTracker struct {
+	livenessData hotstuff.LivenessData
+	persist      hotstuff.Persister
+}
+
+// newViewTracker instantiates a viewTracker.
+func newViewTracker(persist hotstuff.Persister) (viewTracker, error) {
+	livenessData, err := persist.GetLivenessData()
+	if err != nil {
+		return viewTracker{}, fmt.Errorf("could not load liveness data: %w", err)
+	}
+
+	if livenessData.CurrentView < 1 {
+		return viewTracker{}, model.NewConfigurationErrorf("PaceMaker cannot start in view 0 (view zero is reserved for genesis block, which has no proposer)")
+	}
+
+	return viewTracker{
+		livenessData: *livenessData,
+		persist:      persist,
+	}, nil
+}
+
+// CurView returns the current view.
+func (vt *viewTracker) CurView() uint64 {
+	return vt.livenessData.CurrentView
+}
+
+// NewestQC returns the QC with the highest view known.
+func (vt *viewTracker) NewestQC() *flow.QuorumCertificate {
+	return vt.livenessData.NewestQC
+}
+
+// LastViewTC returns TC for last view, this is nil if ond only of the current view
+// was entered with a QC.
+func (vt *viewTracker) LastViewTC() *flow.TimeoutCertificate {
+	return vt.livenessData.LastViewTC
+}
+
+// ProcessQC ingests a QC, which might advance the current view. Panics for nil input!
+// QCs with views smaller or equal to the newest QC known are a no-op. ProcessQC returns
+// the resulting view after processing the QC.
+// No errors are expected, any error should be treated as exception.
+func (vt *viewTracker) ProcessQC(qc *flow.QuorumCertificate) (uint64, error) {
+	view := vt.livenessData.CurrentView
+	if qc.View < view {
+		// If the QC is for a past view, our view does not change. Nevertheless, the QC might be
+		// newer than the newest QC we know, since view changes can happen through TCs as well.
+		// While not very likely, is is possible that individual replicas know newer QCs than the
+		// ones previously included in TCs. E.g. a primary that crashed before it could construct
+		// its block is has rebooted and is now sharing its newest QC as part of a TimeoutObject.
+		err := vt.updateNewestQC(qc)
+		if err != nil {
+			return view, fmt.Errorf("could not update tracked newest QC: %w", err)
+		}
+		return view, nil
+	}
+
+	// supermajority of replicas have already voted during round `qc.view`, hence it is safe to proceed to subsequent view
+	newView := qc.View + 1
+	err := vt.updateLivenessData(newView, qc, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to update liveness data: %w", err)
+	}
+	return newView, nil
+}
+
+// ProcessTC ingests a TC, which might advance the current view. A nil TC is accepted as
+// input, so that callers may pass in e.g. `Proposal.LastViewTC`, which may or may not have
+// a value. It returns the resulting view after processing the TC and embedded QC.
+// No errors are expected, any error should be treated as exception
+func (vt *viewTracker) ProcessTC(tc *flow.TimeoutCertificate) (uint64, error) {
+	view := vt.livenessData.CurrentView
+	if tc == nil {
+		return view, nil
+	}
+
+	if tc.View < view {
+		// TC and the embedded QC are for a past view, hence our view does not change. Nevertheless,
+		// the QC might be newer than the newest QC we know. While not very likely, is is possible
+		// that individual replicas know newer QCs than the ones previously included in any TCs.
+		// E.g. a primary that crashed before it could construct its block is has rebooted and
+		// now contributed its newest QC to this TC.
+		err := vt.updateNewestQC(tc.NewestQC)
+		if err != nil {
+			return 0, fmt.Errorf("could not update tracked newest QC: %w", err)
+		}
+		return view, nil
+	}
+
+	// supermajority of replicas have already reached their timeout for view `tc.View`, hence it is safe to proceed to subsequent view
+	newView := tc.View + 1
+	err := vt.updateLivenessData(newView, tc.NewestQC, tc)
+	if err != nil {
+		return 0, fmt.Errorf("failed to update liveness data: %w", err)
+	}
+	return newView, nil
+}
+
+// updateLivenessData updates the current view, qc, tc. We want to avoid unnecessary data-base
+// writes, which we enforce by requiring that the view number is STRICTLY monotonously increasing.
+// Otherwise, an exception is returned. No errors are expected, any error should be treated as exception.
+func (vt *viewTracker) updateLivenessData(newView uint64, qc *flow.QuorumCertificate, tc *flow.TimeoutCertificate) error {
+	if newView <= vt.livenessData.CurrentView {
+		// This should never happen: in the current implementation, it is trivially apparent that
+		// newView is _always_ larger than currentView. This check is to protect the code from
+		// future modifications that violate the necessary condition for
+		// STRICTLY monotonously increasing view numbers.
+		return fmt.Errorf("cannot move from view %d to %d: currentView must be strictly monotonously increasing",
+			vt.livenessData.CurrentView, newView)
+	}
+
+	vt.livenessData.CurrentView = newView
+	if vt.livenessData.NewestQC.View < qc.View {
+		vt.livenessData.NewestQC = qc
+	}
+	vt.livenessData.LastViewTC = tc
+	err := vt.persist.PutLivenessData(&vt.livenessData)
+	if err != nil {
+		return fmt.Errorf("could not persist liveness data: %w", err)
+	}
+	return nil
+}
+
+// updateNewestQC updates the highest QC tracked by view, iff `qc` has a larger
+// view than the newest stored QC. Otherwise, this method is a no-op.
+// No errors are expected, any error should be treated as exception.
+func (vt *viewTracker) updateNewestQC(qc *flow.QuorumCertificate) error {
+	if vt.livenessData.NewestQC.View >= qc.View {
+		return nil
+	}
+
+	vt.livenessData.NewestQC = qc
+	err := vt.persist.PutLivenessData(&vt.livenessData)
+	if err != nil {
+		return fmt.Errorf("could not persist liveness data: %w", err)
+	}
+
+	return nil
+}

--- a/consensus/hotstuff/pacemaker/view_tracker_test.go
+++ b/consensus/hotstuff/pacemaker/view_tracker_test.go
@@ -1,0 +1,254 @@
+package pacemaker
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/onflow/flow-go/consensus/hotstuff"
+	"github.com/onflow/flow-go/consensus/hotstuff/helper"
+	"github.com/onflow/flow-go/consensus/hotstuff/mocks"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestViewTracker(t *testing.T) {
+	suite.Run(t, new(ViewTrackerTestSuite))
+}
+
+type ViewTrackerTestSuite struct {
+	suite.Suite
+
+	initialView uint64
+	initialQC   *flow.QuorumCertificate
+	initialTC   *flow.TimeoutCertificate
+
+	livenessData *hotstuff.LivenessData // Caution: we hand the memory address to viewTracker, which could modify this
+	persist      *mocks.Persister
+	tracker      viewTracker
+}
+
+func (s *ViewTrackerTestSuite) SetupTest() {
+	s.initialView = 5
+	s.initialQC = helper.MakeQC(helper.WithQCView(4))
+	s.initialTC = nil
+
+	s.livenessData = &hotstuff.LivenessData{
+		NewestQC:    s.initialQC,
+		LastViewTC:  s.initialTC,
+		CurrentView: s.initialView, // we entered view 5 by observing a QC for view 4
+	}
+	s.persist = mocks.NewPersister(s.T())
+	s.persist.On("GetLivenessData").Return(s.livenessData, nil).Once()
+
+	var err error
+	s.tracker, err = newViewTracker(s.persist)
+	require.NoError(s.T(), err)
+}
+
+// confirmResultingState asserts that the view tracker's stored LivenessData reflects the provided
+// current view, newest QC, and last view TC.
+func (s *ViewTrackerTestSuite) confirmResultingState(curView uint64, qc *flow.QuorumCertificate, tc *flow.TimeoutCertificate) {
+	require.Equal(s.T(), curView, s.tracker.CurView())
+	require.Equal(s.T(), qc, s.tracker.NewestQC())
+	if tc == nil {
+		require.Nil(s.T(), s.tracker.LastViewTC())
+	} else {
+		require.Equal(s.T(), tc, s.tracker.LastViewTC())
+	}
+}
+
+// TestProcessQC_SkipIncreaseViewThroughQC tests that viewTracker increases view when receiving QC,
+// if applicable, by skipping views
+func (s *ViewTrackerTestSuite) TestProcessQC_SkipIncreaseViewThroughQC() {
+	// seeing a QC for the current view should advance the view by one
+	qc := QC(s.initialView)
+	expectedResultingView := s.initialView + 1
+	s.persist.On("PutLivenessData", LivenessData(qc)).Return(nil).Once()
+	resultingCurView, err := s.tracker.ProcessQC(qc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), expectedResultingView, resultingCurView)
+	s.confirmResultingState(expectedResultingView, qc, nil)
+
+	// seeing a QC for 10 views in the future should advance to view +11
+	curView := s.tracker.CurView()
+	qc = QC(curView + 10)
+	expectedResultingView = curView + 11
+	s.persist.On("PutLivenessData", LivenessData(qc)).Return(nil).Once()
+	resultingCurView, err = s.tracker.ProcessQC(qc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), expectedResultingView, resultingCurView)
+	s.confirmResultingState(expectedResultingView, qc, nil)
+}
+
+// TestProcessTC_SkipIncreaseViewThroughTC tests that viewTracker increases view when receiving TC,
+// if applicable, by skipping views
+func (s *ViewTrackerTestSuite) TestProcessTC_SkipIncreaseViewThroughTC() {
+	// seeing a TC for the current view should advance the view by one
+	qc := s.initialQC
+	tc := helper.MakeTC(helper.WithTCView(s.initialView), helper.WithTCNewestQC(qc))
+	expectedResultingView := s.initialView + 1
+	expectedLivenessData := &hotstuff.LivenessData{
+		CurrentView: expectedResultingView,
+		LastViewTC:  tc,
+		NewestQC:    qc,
+	}
+	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
+	resultingCurView, err := s.tracker.ProcessTC(tc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), expectedResultingView, resultingCurView)
+	s.confirmResultingState(expectedResultingView, qc, tc)
+
+	// seeing a TC for 10 views in the future should advance to view +11
+	curView := s.tracker.CurView()
+	tc = helper.MakeTC(helper.WithTCView(curView+10), helper.WithTCNewestQC(qc))
+	expectedResultingView = curView + 11
+	expectedLivenessData = &hotstuff.LivenessData{
+		CurrentView: expectedResultingView,
+		LastViewTC:  tc,
+		NewestQC:    qc,
+	}
+	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
+	resultingCurView, err = s.tracker.ProcessTC(tc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), expectedResultingView, resultingCurView)
+	s.confirmResultingState(expectedResultingView, qc, tc)
+}
+
+// TestProcessTC_IgnoreOldTC tests that viewTracker ignores old TC and doesn't advance round.
+func (s *ViewTrackerTestSuite) TestProcessTC_IgnoreOldTC() {
+	curView := s.tracker.CurView()
+	tc := helper.MakeTC(
+		helper.WithTCView(curView-1),
+		helper.WithTCNewestQC(QC(curView-2)))
+	resultingCurView, err := s.tracker.ProcessTC(tc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), curView, resultingCurView)
+	s.confirmResultingState(curView, s.initialQC, s.initialTC)
+}
+
+// TestProcessTC_IgnoreNilTC tests that viewTracker accepts nil TC as allowed input but doesn't trigger a new view event
+func (s *ViewTrackerTestSuite) TestProcessTC_IgnoreNilTC() {
+	curView := s.tracker.CurView()
+	resultingCurView, err := s.tracker.ProcessTC(nil)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), curView, resultingCurView)
+	s.confirmResultingState(curView, s.initialQC, s.initialTC)
+}
+
+// TestProcessQC_PersistException tests that viewTracker propagates exception
+// when processing QC
+func (s *ViewTrackerTestSuite) TestProcessQC_PersistException() {
+	qc := QC(s.initialView)
+	exception := errors.New("persist-exception")
+	s.persist.On("PutLivenessData", mock.Anything).Return(exception).Once()
+
+	_, err := s.tracker.ProcessQC(qc)
+	require.ErrorIs(s.T(), err, exception)
+}
+
+// TestProcessTC_PersistException tests that viewTracker propagates exception
+// when processing TC
+func (s *ViewTrackerTestSuite) TestProcessTC_PersistException() {
+	tc := helper.MakeTC(helper.WithTCView(s.initialView))
+	exception := errors.New("persist-exception")
+	s.persist.On("PutLivenessData", mock.Anything).Return(exception).Once()
+
+	_, err := s.tracker.ProcessTC(tc)
+	require.ErrorIs(s.T(), err, exception)
+}
+
+// TestProcessQC_InvalidatesLastViewTC verifies that viewTracker does not retain any old
+// TC if the last view change was triggered by observing a QC from the previous view.
+func (s *ViewTrackerTestSuite) TestProcessQC_InvalidatesLastViewTC() {
+	initialView := s.tracker.CurView()
+	tc := helper.MakeTC(helper.WithTCView(initialView),
+		helper.WithTCNewestQC(s.initialQC))
+	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Twice()
+	resultingCurView, err := s.tracker.ProcessTC(tc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), initialView+1, resultingCurView)
+	require.NotNil(s.T(), s.tracker.LastViewTC())
+
+	qc := QC(initialView + 1)
+	resultingCurView, err = s.tracker.ProcessQC(qc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), initialView+2, resultingCurView)
+	require.Nil(s.T(), s.tracker.LastViewTC())
+}
+
+// TestProcessQC_IgnoreOldQC tests that viewTracker ignores old QC and doesn't advance round
+func (s *ViewTrackerTestSuite) TestProcessQC_IgnoreOldQC() {
+	qc := QC(s.initialView - 1)
+	resultingCurView, err := s.tracker.ProcessQC(qc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), s.initialView, resultingCurView)
+	s.confirmResultingState(s.initialView, s.initialQC, s.initialTC)
+}
+
+// TestProcessQC_UpdateNewestQC tests that viewTracker tracks the newest QC even if it has advanced past this view.
+// The only one scenario, where it is possible to receive a QC for a view that we already has passed, yet this QC
+// being newer than any known one is:
+//   - We advance views via TC.
+//   - A QC for a passed view that is newer than any known one can arrive in 3 ways:
+//     1. A QC (e.g. from the vote aggregator)
+//     2. A QC embedded into a TC, where the TC is for a passed view
+//     3. A QC embedded into a TC, where the TC is for the current or newer view
+func (s *ViewTrackerTestSuite) TestProcessQC_UpdateNewestQC() {
+	// Setup
+	// * we start in view 5
+	// * newest known QC is for view 4
+	// * we receive a TC for view 55, which results in entering view 56
+	initialView := s.tracker.CurView() //
+	tc := helper.MakeTC(helper.WithTCView(initialView+50), helper.WithTCNewestQC(s.initialQC))
+	s.persist.On("PutLivenessData", mock.Anything).Return(nil).Once()
+	expectedView := uint64(56) // processing the TC should results in entering view 56
+	resultingCurView, err := s.tracker.ProcessTC(tc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), expectedView, resultingCurView)
+	s.confirmResultingState(expectedView, s.initialQC, tc)
+
+	// Test 1: add QC for view 9, which is newer than our initial QC - it should become our newest QC
+	qc := QC(s.tracker.NewestQC().View + 2)
+	expectedLivenessData := &hotstuff.LivenessData{
+		CurrentView: expectedView,
+		LastViewTC:  tc,
+		NewestQC:    qc,
+	}
+	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
+	resultingCurView, err = s.tracker.ProcessQC(qc)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), expectedView, resultingCurView)
+	s.confirmResultingState(expectedView, qc, tc)
+
+	// Test 2: receiving a TC for a passed view, but the embedded QC is newer than the one we know
+	qc2 := QC(s.tracker.NewestQC().View + 4)
+	olderTC := helper.MakeTC(helper.WithTCView(qc2.View+3), helper.WithTCNewestQC(qc2))
+	expectedLivenessData = &hotstuff.LivenessData{
+		CurrentView: expectedView,
+		LastViewTC:  tc,
+		NewestQC:    qc2,
+	}
+	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
+	resultingCurView, err = s.tracker.ProcessTC(olderTC)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), expectedView, resultingCurView)
+	s.confirmResultingState(expectedView, qc2, tc)
+
+	// Test 3: receiving a TC for a newer view, the embedded QC is newer than the one we know, but still for a passed view
+	qc3 := QC(s.tracker.NewestQC().View + 7)
+	finalView := expectedView + 1
+	newestTC := helper.MakeTC(helper.WithTCView(expectedView), helper.WithTCNewestQC(qc3))
+	expectedLivenessData = &hotstuff.LivenessData{
+		CurrentView: finalView,
+		LastViewTC:  newestTC,
+		NewestQC:    qc3,
+	}
+	s.persist.On("PutLivenessData", expectedLivenessData).Return(nil).Once()
+	resultingCurView, err = s.tracker.ProcessTC(newestTC)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), finalView, resultingCurView)
+	s.confirmResultingState(finalView, qc3, newestTC)
+}

--- a/consensus/participant.go
+++ b/consensus/participant.go
@@ -148,7 +148,7 @@ func NewForks(final *flow.Header, headers storage.Headers, updater module.Finali
 }
 
 // recoverTrustedRoot based on our local state returns root block and QC that can be used to initialize base state
-func recoverTrustedRoot(final *flow.Header, headers storage.Headers, rootHeader *flow.Header, rootQC *flow.QuorumCertificate) (*forks.BlockQC, error) {
+func recoverTrustedRoot(final *flow.Header, headers storage.Headers, rootHeader *flow.Header, rootQC *flow.QuorumCertificate) (*model.CertifiedBlock, error) {
 	if final.View < rootHeader.View {
 		return nil, fmt.Errorf("finalized Block has older view than trusted root")
 	}
@@ -158,7 +158,11 @@ func recoverTrustedRoot(final *flow.Header, headers storage.Headers, rootHeader 
 		if final.ID() != rootHeader.ID() {
 			return nil, fmt.Errorf("finalized Block conflicts with trusted root")
 		}
-		return makeRootBlockQC(rootHeader, rootQC), nil
+		certifiedRoot, err := makeCertifiedRootBlock(rootHeader, rootQC)
+		if err != nil {
+			return nil, fmt.Errorf("constructing certified root block failed: %w", err)
+		}
+		return &certifiedRoot, nil
 	}
 
 	// find a valid child of the finalized block in order to get its QC
@@ -174,15 +178,14 @@ func recoverTrustedRoot(final *flow.Header, headers storage.Headers, rootHeader 
 	child := model.BlockFromFlow(children[0])
 
 	// create the root block to use
-	trustedRoot := &forks.BlockQC{
-		Block: model.BlockFromFlow(final),
-		QC:    child.QC,
+	trustedRoot, err := model.NewCertifiedBlock(model.BlockFromFlow(final), child.QC)
+	if err != nil {
+		return nil, fmt.Errorf("constructing certified root block failed: %w", err)
 	}
-
-	return trustedRoot, nil
+	return &trustedRoot, nil
 }
 
-func makeRootBlockQC(header *flow.Header, qc *flow.QuorumCertificate) *forks.BlockQC {
+func makeCertifiedRootBlock(header *flow.Header, qc *flow.QuorumCertificate) (model.CertifiedBlock, error) {
 	// By convention of Forks, the trusted root block does not need to have a qc
 	// (as is the case for the genesis block). For simplify of the implementation, we always omit
 	// the QC of the root block. Thereby, we have one algorithm which handles all cases,
@@ -196,8 +199,5 @@ func makeRootBlockQC(header *flow.Header, qc *flow.QuorumCertificate) *forks.Blo
 		PayloadHash: header.PayloadHash,
 		Timestamp:   header.Timestamp,
 	}
-	return &forks.BlockQC{
-		QC:    qc,
-		Block: rootBlock,
-	}
+	return model.NewCertifiedBlock(rootBlock, qc)
 }

--- a/engine/common/follower/compliance_core.go
+++ b/engine/common/follower/compliance_core.go
@@ -20,7 +20,7 @@ import (
 )
 
 // CertifiedBlocks is a connected list of certified blocks, in ascending height order.
-type CertifiedBlocks []pending_tree.CertifiedBlock
+type CertifiedBlocks []flow.CertifiedBlock
 
 // defaultCertifiedRangeChannelCapacity maximum capacity of buffered channel that is used to transfer ranges of
 // certified blocks to specific worker.
@@ -177,11 +177,15 @@ func (c *ComplianceCore) OnBlockRange(originID flow.Identifier, batch []*flow.Bl
 	if len(certifiedBatch) < 1 {
 		return nil
 	}
+	certifiedRange, err := rangeToCertifiedBlocks(certifiedBatch, certifyingQC)
+	if err != nil {
+		return fmt.Errorf("converting the certified batch to list of certified blocks failed: %w", err)
+	}
 
 	// in case we have already stopped our worker, we use a select statement to avoid
 	// blocking since there is no active consumer for this channel
 	select {
-	case c.certifiedRangesChan <- rangeToCertifiedBlocks(certifiedBatch, certifyingQC):
+	case c.certifiedRangesChan <- certifiedRange:
 	case <-c.ComponentManager.ShutdownSignal():
 	}
 	return nil
@@ -294,8 +298,8 @@ func (c *ComplianceCore) processFinalizedBlock(ctx context.Context, finalized *f
 
 // rangeToCertifiedBlocks transform batch of connected blocks and a QC that certifies last block to a range of
 // certified and connected blocks.
-// Pure function.
-func rangeToCertifiedBlocks(certifiedRange []*flow.Block, certifyingQC *flow.QuorumCertificate) CertifiedBlocks {
+// Pure function (side-effect free). No errors expected during normal operations.
+func rangeToCertifiedBlocks(certifiedRange []*flow.Block, certifyingQC *flow.QuorumCertificate) (CertifiedBlocks, error) {
 	certifiedBlocks := make(CertifiedBlocks, 0, len(certifiedRange))
 	lastIndex := len(certifiedRange) - 1
 	for i, block := range certifiedRange {
@@ -305,10 +309,13 @@ func rangeToCertifiedBlocks(certifiedRange []*flow.Block, certifyingQC *flow.Quo
 		} else {
 			qc = certifyingQC
 		}
-		certifiedBlocks = append(certifiedBlocks, pending_tree.CertifiedBlock{
-			Block: block,
-			QC:    qc,
-		})
+
+		// bundle block and its certifying QC to `CertifiedBlock`:
+		certBlock, err := flow.NewCertifiedBlock(block, qc)
+		if err != nil {
+			return nil, fmt.Errorf("constructing certified root block failed: %w", err)
+		}
+		certifiedBlocks = append(certifiedBlocks, certBlock)
 	}
-	return certifiedBlocks
+	return certifiedBlocks, nil
 }

--- a/engine/common/follower/pending_tree/pending_tree.go
+++ b/engine/common/follower/pending_tree/pending_tree.go
@@ -9,44 +9,17 @@ import (
 	"github.com/onflow/flow-go/module/mempool"
 )
 
-// CertifiedBlock holds a certified block, it consists of a block and a QC which proves validity of block (QC.BlockID = Block.ID())
-// This is used to compactly store and transport block and certifying QC in one structure.
-type CertifiedBlock struct {
-	Block *flow.Block
-	QC    *flow.QuorumCertificate
-}
-
-// ID returns unique identifier for the certified block
-// To avoid computation we use value from the QC
-func (b *CertifiedBlock) ID() flow.Identifier {
-	return b.QC.BlockID
-}
-
-// View returns view where the block was produced.
-func (b *CertifiedBlock) View() uint64 {
-	return b.QC.View
-}
-
-// Height returns height of the block.
-func (b *CertifiedBlock) Height() uint64 {
-	return b.Block.Header.Height
-}
-
 // PendingBlockVertex wraps a block proposal to implement forest.Vertex
 // so the proposal can be stored in forest.LevelledForest
 type PendingBlockVertex struct {
-	CertifiedBlock
+	flow.CertifiedBlock
 	connectedToFinalized bool
 }
 
 var _ forest.Vertex = (*PendingBlockVertex)(nil)
 
 // NewVertex creates new vertex while performing a sanity check of data correctness.
-func NewVertex(certifiedBlock CertifiedBlock, connectedToFinalized bool) (*PendingBlockVertex, error) {
-	if certifiedBlock.Block.Header.View != certifiedBlock.QC.View {
-		return nil, fmt.Errorf("missmatched block(%d) and QC(%d) view",
-			certifiedBlock.Block.Header.View, certifiedBlock.QC.View)
-	}
+func NewVertex(certifiedBlock flow.CertifiedBlock, connectedToFinalized bool) (*PendingBlockVertex, error) {
 	return &PendingBlockVertex{
 		CertifiedBlock:       certifiedBlock,
 		connectedToFinalized: connectedToFinalized,
@@ -117,8 +90,8 @@ func NewPendingTree(finalized *flow.Header) *PendingTree {
 //   - model.ByzantineThresholdExceededError - detected two certified blocks at the same view
 //
 // All other errors should be treated as exceptions.
-func (t *PendingTree) AddBlocks(certifiedBlocks []CertifiedBlock) ([]CertifiedBlock, error) {
-	var allConnectedBlocks []CertifiedBlock
+func (t *PendingTree) AddBlocks(certifiedBlocks []flow.CertifiedBlock) ([]flow.CertifiedBlock, error) {
+	var allConnectedBlocks []flow.CertifiedBlock
 	for _, block := range certifiedBlocks {
 		// skip blocks lower than finalized view
 		if block.View() <= t.forest.LowestLevel {
@@ -159,7 +132,7 @@ func (t *PendingTree) AddBlocks(certifiedBlocks []CertifiedBlock) ([]CertifiedBl
 }
 
 // connectsToFinalizedBlock checks if candidate block connects to the finalized state.
-func (t *PendingTree) connectsToFinalizedBlock(block CertifiedBlock) bool {
+func (t *PendingTree) connectsToFinalizedBlock(block flow.CertifiedBlock) bool {
 	if block.Block.Header.ParentID == t.lastFinalizedID {
 		return true
 	}
@@ -200,8 +173,8 @@ func (t *PendingTree) connectsToFinalizedBlock(block CertifiedBlock) bool {
 // returns these blocks. Returned blocks are ordered such that parents appear before their children.
 //
 // No errors are expected during normal operation.
-func (t *PendingTree) FinalizeFork(finalized *flow.Header) ([]CertifiedBlock, error) {
-	var connectedBlocks []CertifiedBlock
+func (t *PendingTree) FinalizeFork(finalized *flow.Header) ([]flow.CertifiedBlock, error) {
+	var connectedBlocks []flow.CertifiedBlock
 
 	err := t.forest.PruneUpToLevel(finalized.View)
 	if err != nil {
@@ -236,7 +209,7 @@ func (t *PendingTree) FinalizeFork(finalized *flow.Header) ([]CertifiedBlock, er
 // This method has a similar signature as `append` for performance reasons:
 //   - any connected certified blocks are appended to `queue`
 //   - we return the _resulting slice_ after all appends
-func (t *PendingTree) updateAndCollectFork(queue []CertifiedBlock, vertex *PendingBlockVertex) []CertifiedBlock {
+func (t *PendingTree) updateAndCollectFork(queue []flow.CertifiedBlock, vertex *PendingBlockVertex) []flow.CertifiedBlock {
 	if vertex.connectedToFinalized {
 		return queue // no-op if already connected
 	}

--- a/engine/common/follower/pending_tree/pending_tree_test.go
+++ b/engine/common/follower/pending_tree/pending_tree_test.go
@@ -1,6 +1,7 @@
 package pending_tree
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -87,7 +88,7 @@ func (s *PendingTreeSuite) TestAllConnectedForksAreCollected() {
 	// make sure short fork doesn't have conflicting views, so we don't trigger exception
 	B2.Header.View = longestFork[len(longestFork)-1].Block.Header.View + 1
 	B3 := unittest.BlockWithParentFixture(B2.Header)
-	shortFork := []CertifiedBlock{{
+	shortFork := []flow.CertifiedBlock{{
 		Block: B2,
 		QC:    B3.Header.QuorumCertificate(),
 	}, certifiedBlockFixture(B3)}
@@ -125,12 +126,12 @@ func (s *PendingTreeSuite) TestByzantineThresholdExceeded() {
 	// use same view for conflicted blocks, this is not possible unless there is more than
 	// 1/3 byzantine participants
 	conflictingBlock.Header.View = block.Header.View
-	_, err := s.pendingTree.AddBlocks([]CertifiedBlock{certifiedBlockFixture(block)})
+	_, err := s.pendingTree.AddBlocks([]flow.CertifiedBlock{certifiedBlockFixture(block)})
 	require.NoError(s.T(), err)
 	// adding same block should result in no-op
-	_, err = s.pendingTree.AddBlocks([]CertifiedBlock{certifiedBlockFixture(block)})
+	_, err = s.pendingTree.AddBlocks([]flow.CertifiedBlock{certifiedBlockFixture(block)})
 	require.NoError(s.T(), err)
-	connectedBlocks, err := s.pendingTree.AddBlocks([]CertifiedBlock{certifiedBlockFixture(conflictingBlock)})
+	connectedBlocks, err := s.pendingTree.AddBlocks([]flow.CertifiedBlock{certifiedBlockFixture(conflictingBlock)})
 	require.Empty(s.T(), connectedBlocks)
 	require.True(s.T(), model.IsByzantineThresholdExceededError(err))
 }
@@ -155,7 +156,7 @@ func (s *PendingTreeSuite) TestBatchWithSkipsAndInRandomOrder() {
 	require.NoError(s.T(), err)
 
 	// restore view based order since that's what we will get from PendingTree
-	slices.SortFunc(blocks, func(lhs CertifiedBlock, rhs CertifiedBlock) bool {
+	slices.SortFunc(blocks, func(lhs flow.CertifiedBlock, rhs flow.CertifiedBlock) bool {
 		return lhs.View() < rhs.View()
 	})
 
@@ -178,7 +179,7 @@ func (s *PendingTreeSuite) TestResolveBlocksAfterFinalization() {
 	// make sure short fork doesn't have conflicting views, so we don't trigger exception
 	B2.Header.View = longestFork[len(longestFork)-1].Block.Header.View + 1
 	B3 := unittest.BlockWithParentFixture(B2.Header)
-	shortFork := []CertifiedBlock{{
+	shortFork := []flow.CertifiedBlock{{
 		Block: B2,
 		QC:    B3.Header.QuorumCertificate(),
 	}, certifiedBlockFixture(B3)}
@@ -202,7 +203,7 @@ func (s *PendingTreeSuite) TestBlocksLowerThanFinalizedView() {
 	newFinalized := unittest.BlockWithParentFixture(block.Header)
 	_, err := s.pendingTree.FinalizeFork(newFinalized.Header)
 	require.NoError(s.T(), err)
-	_, err = s.pendingTree.AddBlocks([]CertifiedBlock{certifiedBlockFixture(block)})
+	_, err = s.pendingTree.AddBlocks([]flow.CertifiedBlock{certifiedBlockFixture(block)})
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), uint64(0), s.pendingTree.forest.GetSize())
 }
@@ -245,8 +246,8 @@ func (s *PendingTreeSuite) TestAddingBlocksWithSameHeight() {
 	E := unittest.BlockWithParentFixture(D.Header)
 	E.Header.View = D.Header.View + 1
 
-	firstBatch := []CertifiedBlock{certifiedBlockFixture(A), certifiedBlockFixture(B), certifiedBlockFixture(D)}
-	secondBatch := []CertifiedBlock{certifiedBlockFixture(C), certifiedBlockFixture(E)}
+	firstBatch := []flow.CertifiedBlock{certifiedBlockFixture(A), certifiedBlockFixture(B), certifiedBlockFixture(D)}
+	secondBatch := []flow.CertifiedBlock{certifiedBlockFixture(C), certifiedBlockFixture(E)}
 
 	actual, err := s.pendingTree.AddBlocks(firstBatch)
 	require.NoError(s.T(), err)
@@ -258,23 +259,27 @@ func (s *PendingTreeSuite) TestAddingBlocksWithSameHeight() {
 }
 
 // certifiedBlocksFixture builds a chain of certified blocks starting at some block.
-func certifiedBlocksFixture(count int, parent *flow.Header) []CertifiedBlock {
-	result := make([]CertifiedBlock, 0, count)
+func certifiedBlocksFixture(count int, parent *flow.Header) []flow.CertifiedBlock {
+	result := make([]flow.CertifiedBlock, 0, count)
 	blocks := unittest.ChainFixtureFrom(count, parent)
 	for i := 0; i < count-1; i++ {
-		result = append(result, CertifiedBlock{
-			Block: blocks[i],
-			QC:    blocks[i+1].Header.QuorumCertificate(),
-		})
+		certBlock, err := flow.NewCertifiedBlock(blocks[i], blocks[i+1].Header.QuorumCertificate())
+		if err != nil {
+			// this should never happen, as we are specifically constructing a certifying QC for the input block
+			panic(fmt.Sprintf("unexpected error constructing certified block: %s", err.Error()))
+		}
+		result = append(result, certBlock)
 	}
 	result = append(result, certifiedBlockFixture(blocks[len(blocks)-1]))
 	return result
 }
 
 // certifiedBlockFixture builds a certified block using a QC with fixture signatures.
-func certifiedBlockFixture(block *flow.Block) CertifiedBlock {
-	return CertifiedBlock{
-		Block: block,
-		QC:    unittest.CertifyBlock(block.Header),
+func certifiedBlockFixture(block *flow.Block) flow.CertifiedBlock {
+	certBlock, err := flow.NewCertifiedBlock(block, unittest.CertifyBlock(block.Header))
+	if err != nil {
+		// this should never happen, as we are specifically constructing a certifying QC for the input block
+		panic(fmt.Sprintf("unexpected error constructing certified block: %s", err.Error()))
 	}
+	return certBlock
 }

--- a/model/flow/block.go
+++ b/model/flow/block.go
@@ -2,6 +2,8 @@
 
 package flow
 
+import "fmt"
+
 func Genesis(chainID ChainID) *Block {
 
 	// create the raw content for the genesis block
@@ -69,4 +71,46 @@ const (
 // String returns the string representation of a transaction status.
 func (s BlockStatus) String() string {
 	return [...]string{"BLOCK_UNKNOWN", "BLOCK_FINALIZED", "BLOCK_SEALED"}[s]
+}
+
+// CertifiedBlock holds a certified block, which is a block and a QC that is pointing to
+// the block. A QC is the aggregated form of votes from a supermajority of HotStuff and
+// therefore proves validity of the block. A certified block satisfies:
+// Block.View == QC.View and Block.BlockID == QC.BlockID
+type CertifiedBlock struct {
+	Block *Block
+	QC    *QuorumCertificate
+}
+
+// NewCertifiedBlock constructs a new certified block. It checks the consistency
+// requirements and errors otherwise:
+//
+//	Block.View == QC.View and Block.BlockID == QC.BlockID
+func NewCertifiedBlock(block *Block, qc *QuorumCertificate) (CertifiedBlock, error) {
+	if block.Header.View != qc.View {
+		return CertifiedBlock{}, fmt.Errorf("block's view (%d) should equal the qc's view (%d)", block.Header.View, qc.View)
+	}
+	if block.ID() != qc.BlockID {
+		return CertifiedBlock{}, fmt.Errorf("block's ID (%v) should equal the block referenced by the qc (%d)", block.ID(), qc.BlockID)
+	}
+	return CertifiedBlock{
+		Block: block,
+		QC:    qc,
+	}, nil
+}
+
+// ID returns unique identifier for the block.
+// To avoid repeated computation, we use value from the QC.
+func (b *CertifiedBlock) ID() Identifier {
+	return b.QC.BlockID
+}
+
+// View returns view where the block was produced.
+func (b *CertifiedBlock) View() uint64 {
+	return b.QC.View
+}
+
+// Height returns height of the block.
+func (b *CertifiedBlock) Height() uint64 {
+	return b.Block.Header.Height
 }


### PR DESCRIPTION
Goal: consensus follower detects finalization one view earlier
* see issue https://github.com/onflow/flow-go/issues/4154 for further context
* this is Part 1, which prepares the PaceMaker (no logical changes, only code cleanups and extensions)

**This PR is a backport (squashed) of PR https://github.com/onflow/flow-go/pull/4155**