### PR TITLE
[BN2] Update BN2 creation, deletion CI workflows

### DIFF
--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -115,7 +115,7 @@ func addFinalizeCmdFlags() {
 	cmd.MarkFlagRequired(finalizeCmd, "protocol-version")
 
 	// optional parameters to influence various aspects of identity generation
-	finalizeCmd.Flags().UintVar(&flagCollectionClusters, "collection-clusters", 2, "number of collection clusters")
+	finalizeCmd.Flags().UintVar(&flagCollectionClusters, "collection-clusters", 1, "number of collection clusters")
 
 	// these two flags are only used when setup a network from genesis
 	finalizeCmd.Flags().StringVar(&flagServiceAccountPublicKeyJSON, "service-account-public-key-json",

--- a/cmd/bootstrap/cmd/finalize.go
+++ b/cmd/bootstrap/cmd/finalize.go
@@ -115,7 +115,7 @@ func addFinalizeCmdFlags() {
 	cmd.MarkFlagRequired(finalizeCmd, "protocol-version")
 
 	// optional parameters to influence various aspects of identity generation
-	finalizeCmd.Flags().UintVar(&flagCollectionClusters, "collection-clusters", 1, "number of collection clusters")
+	finalizeCmd.Flags().UintVar(&flagCollectionClusters, "collection-clusters", 2, "number of collection clusters")
 
 	// these two flags are only used when setup a network from genesis
 	finalizeCmd.Flags().StringVar(&flagServiceAccountPublicKeyJSON, "service-account-public-key-json",

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -3,8 +3,9 @@ DOCKER_REGISTRY := us-west1-docker.pkg.dev/dl-flow-benchnet-automation/benchnet
 
 # default values that callers can override when calling target
 ACCESS = 1
-COLLECTION = 1
+COLLECTION = 6
 VALID_COLLECTION := $(shell test $(COLLECTION) -ge 6; echo $$?)
+CONSENSUS = 2
 VALID_CONSENSUS := $(shell test $(CONSENSUS) -ge 2; echo $$?)
 EXECUTION = 2
 VALID_EXECUTION := $(shell test $(EXECUTION) -ge 2; echo $$?)

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -67,7 +67,7 @@ k8s-secrets-create:
 	bash ./create-secrets.sh ${NETWORK_ID} ${NAMESPACE}
 
 helm-deploy:
-	helm upgrade --install -f ./values.yml ${NETWORK_ID} ./flow --set networkId="${NETWORK_ID}" --set owner="${OWNER}" --debug --namespace ${NAMESPACE} --wait
+	helm upgrade --install -f ./values.yml ${NETWORK_ID} ./flow --set ingress.enabled=true --set networkId="${NETWORK_ID}" --set owner="${OWNER}" --debug --namespace ${NAMESPACE} --wait
 
 k8s-delete:
 	helm delete ${NETWORK_ID} --namespace ${NAMESPACE}

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -3,10 +3,9 @@ DOCKER_REGISTRY := us-west1-docker.pkg.dev/dl-flow-benchnet-automation/benchnet
 
 # default values that callers can override when calling target
 ACCESS = 1
-COLLECTION = 6
-VALID_COLLECTION := $(shell test $(COLLECTION) -ge 6; echo $$?)
-CONSENSUS = 2
-VALID_CONSENSUS := $(shell test $(CONSENSUS) -ge 2; echo $$?)
+COLLECTION = 1
+VALID_COLLECTION := $(shell test $(COLLECTION) -ge 1; echo $$?)
+CONSENSUS = 1
 EXECUTION = 2
 VALID_EXECUTION := $(shell test $(EXECUTION) -ge 2; echo $$?)
 VERIFICATION = 1
@@ -17,10 +16,6 @@ ifeq ($(strip $(VALID_EXECUTION)), 1)
 	$(error Number of Execution nodes should be no less than 2)
 else ifeq ($(strip $(NETWORK_ID)),)
 	$(error NETWORK_ID cannot be empty)
-else ifeq ($(strip $(VALID_CONSENSUS)), 1)
-	$(error Number of Consensus nodes should be no less than 2)
-else ifeq ($(strip $(VALID_COLLECTION)), 1)
-	$(error Number of Collection nodes should be no less than 6)
 else ifeq ($(strip $(NAMESPACE)),)
 	$(error NAMESPACE cannot be empty)
 endif
@@ -55,7 +50,7 @@ deploy-all: validate gen-helm-values k8s-secrets-create helm-deploy
 clean-all: validate k8s-delete k8s-delete-secrets clean-bootstrap clean-gen-helm clean-flow
 
 # target to be used in workflow as local clean up will not be needed
-remote-clean-all: validate k8s-delete-secrets k8s-delete 
+remote-clean-all: validate k8s-delete-secrets k8s-delete
 
 clean-bootstrap:
 	rm -rf ./bootstrap
@@ -68,7 +63,7 @@ k8s-secrets-create:
 	bash ./create-secrets.sh ${NETWORK_ID} ${NAMESPACE}
 
 helm-deploy:
-	helm upgrade --install -f ./values.yml ${NETWORK_ID} ./flow --set ingress.enabled=true --set networkId="${NETWORK_ID}" --set owner="${OWNER}" --debug --namespace ${NAMESPACE} --wait
+	helm upgrade --install -f ./values.yml ${NETWORK_ID} ./flow --set networkId="${NETWORK_ID}" --set owner="${OWNER}" --debug --namespace ${NAMESPACE} --wait
 
 k8s-delete:
 	helm delete ${NETWORK_ID} --namespace ${NAMESPACE}
@@ -77,15 +72,8 @@ k8s-delete:
 k8s-delete-secrets:
 	kubectl delete secrets -l networkId=${NETWORK_ID} --namespace ${NAMESPACE}
 
-k8s-expose-locally: validate
-	kubectl port-forward service/access1-${NETWORK_ID} 9000:9000 --namespace ${NAMESPACE}
-
 k8s-pod-health: validate
 	kubectl get pods --namespace ${NAMESPACE}
-
-k8s-test-network-accessibility:
-	flow blocks get latest --host localhost:9000
-	flow accounts create --network benchnet --key  e0ef5e52955e6542287db4528b3e8acc84a2c204eee9609f7c3120d1dac5a11b1bcb39677511db14354aa8c1a0ef62151220d97f015d49a8f0b78b653b570bfd --signer benchnet-account -f ~/flow.json
 
 clone-flow: clean-flow 
 	# this cloned repo will be used for generating bootstrap info specific to that tag / version

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -4,8 +4,8 @@ DOCKER_REGISTRY := us-west1-docker.pkg.dev/dl-flow-benchnet-automation/benchnet
 # default values that callers can override when calling target
 ACCESS = 1
 COLLECTION = 1
-VALID_COLLECTION := $(shell test $(COLLECTION) -ge 2; echo $$?)
-CONSENSUS = 1
+VALID_COLLECTION := $(shell test $(COLLECTION) -ge 6; echo $$?)
+VALID_CONSENSUS := $(shell test $(CONSENSUS) -ge 2; echo $$?)
 EXECUTION = 2
 VALID_EXECUTION := $(shell test $(EXECUTION) -ge 2; echo $$?)
 VERIFICATION = 1
@@ -14,8 +14,10 @@ validate:
 ifeq ($(strip $(VALID_EXECUTION)), 1)
 	# multiple execution nodes are required to prevent seals being generated in case of execution forking.
 	$(error Number of Execution nodes should be no less than 2)
+else ifeq ($(strip $(VALID_CONSENSUS)), 1)
+	$(error Number of Consensus nodes should be no less than 2)
 else ifeq ($(strip $(VALID_COLLECTION)), 1)
-	$(error Number of Collection nodes should be no less than 2)
+	$(error Number of Collection nodes should be no less than 6)
 else ifeq ($(strip $(NETWORK_ID)),)
 	$(error NETWORK_ID cannot be empty)
 else ifeq ($(strip $(NAMESPACE)),)

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -14,7 +14,7 @@ validate:
 ifeq ($(strip $(VALID_EXECUTION)), 1)
 	# multiple execution nodes are required to prevent seals being generated in case of execution forking.
 	$(error Number of Execution nodes should be no less than 2)
-ifeq ($(strip $(VALID_COLLECTION)), 1)
+else ifeq ($(strip $(VALID_COLLECTION)), 1)
 	$(error Number of Collection nodes should be no less than 2)
 else ifeq ($(strip $(NETWORK_ID)),)
 	$(error NETWORK_ID cannot be empty)

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -4,7 +4,7 @@ DOCKER_REGISTRY := us-west1-docker.pkg.dev/dl-flow-benchnet-automation/benchnet
 # default values that callers can override when calling target
 ACCESS = 1
 COLLECTION = 1
-VALID_COLLECTION := $(shell test $(COLLECTION) -ge 1; echo $$?)
+VALID_COLLECTION := $(shell test $(COLLECTION) -ge 2; echo $$?)
 CONSENSUS = 1
 EXECUTION = 2
 VALID_EXECUTION := $(shell test $(EXECUTION) -ge 2; echo $$?)
@@ -14,6 +14,8 @@ validate:
 ifeq ($(strip $(VALID_EXECUTION)), 1)
 	# multiple execution nodes are required to prevent seals being generated in case of execution forking.
 	$(error Number of Execution nodes should be no less than 2)
+ifeq ($(strip $(VALID_COLLECTION)), 1)
+	$(error Number of Collection nodes should be no less than 2)
 else ifeq ($(strip $(NETWORK_ID)),)
 	$(error NETWORK_ID cannot be empty)
 else ifeq ($(strip $(NAMESPACE)),)


### PR DESCRIPTION
## Context

This PR tweaks and finalizes the changes to BN2 CI workflows for creating and deleting Benchnet 2 networks.

This PR is made in conjunction with https://github.com/dapperlabs/flow-go/pull/6632

- removed old way of testing new network is accessible 
  - removed `make k8s-expose-locally`
  - removed `make k8s-test-network-accessibility`
  - using new way now (`flow blocks get latest --host access1-<network_id>.benchnet.onflow.org:80`)




ref: https://github.com/dapperlabs/flow-go/pull/6632