### PR TITLE
[Observer] Fixed issue with incorrect observer logs

### DIFF
--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -566,7 +566,7 @@ func NewFlowObserverServiceBuilder(opts ...Option) *ObserverServiceBuilder {
 	}
 	anb := &ObserverServiceBuilder{
 		ObserverServiceConfig:   config,
-		FlowNodeBuilder:         cmd.FlowNode(flow.RoleAccess.String()),
+		FlowNodeBuilder:         cmd.FlowNode("observer"),
 		FinalizationDistributor: pubsub.NewFinalizationDistributor(),
 	}
 	anb.FinalizationDistributor.AddConsumer(notifications.NewSlashingViolationsConsumer(anb.Logger))


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/3040

### Context

Previously observer logs and metrics were marked as "access". Changed them to display correctly as "observer".