### PR TITLE
Update cluster config constraints

### DIFF
--- a/cmd/bootstrap/cmd/clusters.go
+++ b/cmd/bootstrap/cmd/clusters.go
@@ -17,6 +17,14 @@ func constructClusterAssignment(partnerNodes, internalNodes []model.NodeInfo, se
 
 	partners := model.ToIdentityList(partnerNodes).Filter(filter.HasRole(flow.RoleCollection))
 	internals := model.ToIdentityList(internalNodes).Filter(filter.HasRole(flow.RoleCollection))
+	nClusters := flagCollectionClusters
+	nCollectors := len(partners) + len(internals)
+
+	// ensure we have at least as many collection nodes as clusters
+	if nCollectors < int(flagCollectionClusters) {
+		log.Fatal().Msgf("network bootstrap is configured with %d collection nodes, but %d clusters - must have at least one collection node per cluster",
+			nCollectors, flagCollectionClusters)
+	}
 
 	// deterministically shuffle both collector lists based on the input seed
 	// by using a different seed each spork, we will have different clusters
@@ -24,7 +32,6 @@ func constructClusterAssignment(partnerNodes, internalNodes []model.NodeInfo, se
 	partners = partners.DeterministicShuffle(seed)
 	internals = internals.DeterministicShuffle(seed)
 
-	nClusters := flagCollectionClusters
 	identifierLists := make([]flow.IdentifierList, nClusters)
 
 	// first, round-robin internal nodes into each cluster

--- a/cmd/bootstrap/cmd/constants.go
+++ b/cmd/bootstrap/cmd/constants.go
@@ -1,5 +1,0 @@
-package cmd
-
-const (
-	minNodesPerCluster = 3
-)

--- a/cmd/bootstrap/cmd/constraints.go
+++ b/cmd/bootstrap/cmd/constraints.go
@@ -60,13 +60,4 @@ func checkConstraints(partnerNodes, internalNodes []model.NodeInfo) {
 		partnerCOLCount += clusterPartnerCount
 		internalCOLCount += clusterInternalCount
 	}
-
-	// ensure we have enough total collectors
-	totalCollectors := partnerCOLCount + internalCOLCount
-	if totalCollectors < flagCollectionClusters*minNodesPerCluster {
-		log.Fatal().Msgf(
-			"will not bootstrap configuration with insufficient # of collectors for cluster count: "+
-				"(total_collectors=%d, clusters=%d, min_total_collectors=%d)",
-			totalCollectors, flagCollectionClusters, flagCollectionClusters*minNodesPerCluster)
-	}
 }


### PR DESCRIPTION
- log a more useful error message if `n_clusters > n_collectors`
- remove unnecessary constraint that clusters must have at least 3 members