### PR TITLE
[Access] Fix execution data cache in state stream api

### DIFF
--- a/engine/access/state_stream/backend.go
+++ b/engine/access/state_stream/backend.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
-	herocache "github.com/onflow/flow-go/module/mempool/herocache/backdata"
+	"github.com/onflow/flow-go/module/mempool/herocache"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/utils/logging"
@@ -50,7 +50,7 @@ type StateStreamBackend struct {
 	seals         storage.Seals
 	results       storage.ExecutionResults
 	execDataStore execution_data.ExecutionDataStore
-	execDataCache *herocache.Cache
+	execDataCache *herocache.BlockExecutionData
 	broadcaster   *engine.Broadcaster
 }
 
@@ -62,7 +62,7 @@ func New(
 	seals storage.Seals,
 	results storage.ExecutionResults,
 	execDataStore execution_data.ExecutionDataStore,
-	execDataCache *herocache.Cache,
+	execDataCache *herocache.BlockExecutionData,
 	broadcaster *engine.Broadcaster,
 ) (*StateStreamBackend, error) {
 	logger := log.With().Str("module", "state_stream_api").Logger()
@@ -106,7 +106,7 @@ func (b *StateStreamBackend) getExecutionData(ctx context.Context, blockID flow.
 		b.log.Trace().
 			Hex("block_id", logging.ID(blockID)).
 			Msg("execution data cache hit")
-		return cached.(*execution_data.BlockExecutionDataEntity), nil
+		return cached, nil
 	}
 	b.log.Trace().
 		Hex("block_id", logging.ID(blockID)).
@@ -129,7 +129,7 @@ func (b *StateStreamBackend) getExecutionData(ctx context.Context, blockID flow.
 
 	blockExecData := execution_data.NewBlockExecutionDataEntity(result.ExecutionDataID, execData)
 
-	b.execDataCache.Add(blockID, blockExecData)
+	b.execDataCache.Add(blockExecData)
 
 	return blockExecData, nil
 }

--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -32,7 +32,7 @@ type BenchmarkInfo struct {
 const (
 	loadType                    = "token-transfer"
 	metricport                  = uint(8080)
-	accessNodeAddress           = "127.0.0.1:3569"
+	accessNodeAddress           = "127.0.0.1:4001"
 	pushgateway                 = "127.0.0.1:9091"
 	accountMultiplier           = 50
 	feedbackEnabled             = true

--- a/integration/benchmark/cmd/manual/main.go
+++ b/integration/benchmark/cmd/manual/main.go
@@ -39,7 +39,7 @@ func main() {
 	tpsFlag := flag.String("tps", "1", "transactions per second (TPS) to send, accepts a comma separated list of values if used in conjunction with `tps-durations`")
 	tpsDurationsFlag := flag.String("tps-durations", "0", "duration that each load test will run, accepts a comma separted list that will be applied to multiple values of the `tps` flag (defaults to infinite if not provided, meaning only the first tps case will be tested; additional values will be ignored)")
 	chainIDStr := flag.String("chain", string(flowsdk.Emulator), "chain ID")
-	accessNodes := flag.String("access", net.JoinHostPort("127.0.0.1", "3569"), "access node address")
+	accessNodes := flag.String("access", net.JoinHostPort("127.0.0.1", "4001"), "access node address")
 	serviceAccountPrivateKeyHex := flag.String("servPrivHex", unittest.ServiceAccountPrivateKeyHex, "service account private key hex")
 	logLvl := flag.String("log-level", "info", "set log level")
 	metricport := flag.Uint("metricport", 8080, "port for /metrics endpoint")

--- a/integration/localnet/README.md
+++ b/integration/localnet/README.md
@@ -217,7 +217,7 @@ An example of the Flow CLI configuration modified for connecting to the localnet
 ```
 {
 	"networks": {
-		"localnet": "127.0.0.1:3569"
+		"localnet": "127.0.0.1:4001"
 	}
 }
 ```
@@ -238,7 +238,7 @@ An example of the Flow CLI configuration with the service account added:
 ```
 {
 	"networks": {
-		"localnet": "127.0.0.1:3569"
+		"localnet": "127.0.0.1:4001"
 	},
 	"accounts": {
 		"localnet-service-account": {
@@ -355,15 +355,15 @@ After the transaction is sealed, the account with `<ACCOUNT_ADDRESS>` should hav
 # admin tool
 The admin tool is enabled by default in localnet for all node type except access node.
 
-For instance, in order to use admin tool to change log level, first find the local port that maps to `9002` which is the admin tool address, if the local port is `3702`, then run:
+For instance, in order to use admin tool to change log level, first find the local port that maps to `9002` which is the admin tool address, if the local port is `6100`, then run:
 ```
-curl localhost:3702/admin/run_command -H 'Content-Type: application/json' -d '{"commandName": "set-log-level", "data": "debug"}'
+curl localhost:6100/admin/run_command -H 'Content-Type: application/json' -d '{"commandName": "set-log-level", "data": "debug"}'
 ```
 
 To find the local port after launching the localnet, run `docker ps -a`, and find the port mapping.
-For instance, the following result of `docker ps -a ` shows `localnet-collection` maps 9002 port to localhost's 3702 port, so we could use 3702 port to connect to admin tool.
+For instance, the following result of `docker ps -a ` shows `localnet-collection` maps 9002 port to localhost's 6100 port, so we could use 6100 port to connect to admin tool.
 ```
-2e0621f7e592   localnet-access                   "/bin/app --nodeid=9…"   9 seconds ago    Up 8 seconds              0.0.0.0:3571->9000/tcp, :::3571->9000/tcp, 0.0.0.0:3572->9001/tcp, :::3572->9001/tcp                                                           localnet_access_2_1
-fcd92116f902   localnet-collection               "/bin/app --nodeid=0…"   9 seconds ago    Up 8 seconds              0.0.0.0:3702->9002/tcp, :::3702->9002/tcp                                                                                                      localnet_collection_1_1
-dd841d389e36   localnet-access                   "/bin/app --nodeid=a…"   10 seconds ago   Up 9 seconds              0.0.0.0:3569->9000/tcp, :::3569->9000/tcp, 0.0.0.0:3570->9001/tcp, :::3570->9001/tcp                                                           localnet_access_1_1
+2e0621f7e592   localnet-access                   "/bin/app --nodeid=9…"   9 seconds ago    Up 8 seconds              0.0.0.0:4011->9000/tcp, :::4011->9000/tcp, 0.0.0.0:4012->9001/tcp, :::4012->9001/tcp                                                           localnet_access_2_1
+fcd92116f902   localnet-collection               "/bin/app --nodeid=0…"   9 seconds ago    Up 8 seconds              0.0.0.0:6100->9002/tcp, :::6100->9002/tcp                                                                                                      localnet_collection_1_1
+dd841d389e36   localnet-access                   "/bin/app --nodeid=a…"   10 seconds ago   Up 9 seconds              0.0.0.0:4001->9000/tcp, :::4001->9000/tcp, 0.0.0.0:4002->9001/tcp, :::4002->9001/tcp                                                           localnet_access_1_1
 ```

--- a/module/executiondatasync/execution_data/entity.go
+++ b/module/executiondatasync/execution_data/entity.go
@@ -23,10 +23,10 @@ func NewBlockExecutionDataEntity(id flow.Identifier, executionData *BlockExecuti
 	}
 }
 
-func (c *BlockExecutionDataEntity) ID() flow.Identifier {
+func (c BlockExecutionDataEntity) ID() flow.Identifier {
 	return c.id
 }
 
-func (c *BlockExecutionDataEntity) Checksum() flow.Identifier {
+func (c BlockExecutionDataEntity) Checksum() flow.Identifier {
 	return c.id
 }

--- a/module/mempool/herocache/execution_data.go
+++ b/module/mempool/herocache/execution_data.go
@@ -1,0 +1,97 @@
+package herocache
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
+	herocache "github.com/onflow/flow-go/module/mempool/herocache/backdata"
+	"github.com/onflow/flow-go/module/mempool/herocache/backdata/heropool"
+	"github.com/onflow/flow-go/module/mempool/herocache/internal"
+	"github.com/onflow/flow-go/module/mempool/stdmap"
+)
+
+type BlockExecutionData struct {
+	c *stdmap.Backend
+}
+
+// NewBlockExecutionData implements a block execution data mempool based on hero cache.
+func NewBlockExecutionData(limit uint32, logger zerolog.Logger, collector module.HeroCacheMetrics) *BlockExecutionData {
+	t := &BlockExecutionData{
+		c: stdmap.NewBackend(
+			stdmap.WithBackData(
+				herocache.NewCache(limit,
+					herocache.DefaultOversizeFactor,
+					heropool.LRUEjection,
+					logger.With().Str("mempool", "block_execution_data").Logger(),
+					collector))),
+	}
+
+	return t
+}
+
+// Has checks whether the block execution data with the given hash is currently in
+// the memory pool.
+func (t BlockExecutionData) Has(id flow.Identifier) bool {
+	return t.c.Has(id)
+}
+
+// Add adds a block execution data to the mempool.
+func (t *BlockExecutionData) Add(ed *execution_data.BlockExecutionDataEntity) bool {
+	entity := internal.NewWrappedEntity(ed.BlockID, ed)
+	return t.c.Add(*entity)
+}
+
+// ByID returns the block execution data with the given ID from the mempool.
+func (t BlockExecutionData) ByID(txID flow.Identifier) (*execution_data.BlockExecutionDataEntity, bool) {
+	entity, exists := t.c.ByID(txID)
+	if !exists {
+		return nil, false
+	}
+
+	return unwrap(entity), true
+}
+
+// All returns all block execution data from the mempool. Since it is using the HeroCache, All guarantees returning
+// all block execution data in the same order as they are added.
+func (t BlockExecutionData) All() []*execution_data.BlockExecutionDataEntity {
+	entities := t.c.All()
+	eds := make([]*execution_data.BlockExecutionDataEntity, 0, len(entities))
+	for _, entity := range entities {
+		eds = append(eds, unwrap(entity))
+	}
+	return eds
+}
+
+// Clear removes all block execution data stored in this mempool.
+func (t *BlockExecutionData) Clear() {
+	t.c.Clear()
+}
+
+// Size returns total number of stored block execution data.
+func (t BlockExecutionData) Size() uint {
+	return t.c.Size()
+}
+
+// Remove removes block execution data from mempool.
+func (t *BlockExecutionData) Remove(id flow.Identifier) bool {
+	return t.c.Remove(id)
+}
+
+// unwrap converts an internal.WrappedEntity to a BlockExecutionDataEntity.
+func unwrap(entity flow.Entity) *execution_data.BlockExecutionDataEntity {
+	wrappedEntity, ok := entity.(internal.WrappedEntity)
+	if !ok {
+		panic(fmt.Sprintf("invalid wrapped entity in block execution data pool (%T)", entity))
+	}
+
+	ed, ok := wrappedEntity.Entity.(*execution_data.BlockExecutionDataEntity)
+	if !ok {
+		panic(fmt.Sprintf("invalid entity in block execution data pool (%T)", wrappedEntity.Entity))
+	}
+
+	return ed
+}

--- a/module/mempool/herocache/execution_data_test.go
+++ b/module/mempool/herocache/execution_data_test.go
@@ -1,0 +1,117 @@
+package herocache_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
+	"github.com/onflow/flow-go/module/mempool/herocache"
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestBlockExecutionDataPool(t *testing.T) {
+	ed1 := unittest.BlockExecutionDatEntityFixture(t)
+	ed2 := unittest.BlockExecutionDatEntityFixture(t)
+
+	cache := herocache.NewBlockExecutionData(1000, unittest.Logger(), metrics.NewNoopCollector())
+
+	t.Run("should be able to add first", func(t *testing.T) {
+		added := cache.Add(ed1)
+		assert.True(t, added)
+	})
+
+	t.Run("should be able to add second", func(t *testing.T) {
+		added := cache.Add(ed2)
+		assert.True(t, added)
+	})
+
+	t.Run("should be able to get size", func(t *testing.T) {
+		size := cache.Size()
+		assert.EqualValues(t, 2, size)
+	})
+
+	t.Run("should be able to get first by blockID", func(t *testing.T) {
+		actual, exists := cache.ByID(ed1.BlockID)
+		assert.True(t, exists)
+		assert.Equal(t, ed1, actual)
+	})
+
+	t.Run("should be able to remove second by blockID", func(t *testing.T) {
+		ok := cache.Remove(ed2.BlockID)
+		assert.True(t, ok)
+	})
+
+	t.Run("should be able to retrieve all", func(t *testing.T) {
+		items := cache.All()
+		assert.Len(t, items, 1)
+		assert.Equal(t, ed1, items[0])
+	})
+
+	t.Run("should be able to clear", func(t *testing.T) {
+		assert.True(t, cache.Size() > 0)
+		cache.Clear()
+		assert.Equal(t, uint(0), cache.Size())
+	})
+}
+
+// TestConcurrentWriteAndRead checks correctness of cache mempool under concurrent read and write.
+func TestBlockExecutionDataConcurrentWriteAndRead(t *testing.T) {
+	total := 100
+	execDatas := unittest.BlockExecutionDatEntityListFixture(t, total)
+	cache := herocache.NewBlockExecutionData(uint32(total), unittest.Logger(), metrics.NewNoopCollector())
+
+	wg := sync.WaitGroup{}
+	wg.Add(total)
+
+	// storing all cache
+	for i := 0; i < total; i++ {
+		go func(ed *execution_data.BlockExecutionDataEntity) {
+			require.True(t, cache.Add(ed))
+
+			wg.Done()
+		}(execDatas[i])
+	}
+
+	unittest.RequireReturnsBefore(t, wg.Wait, 100*time.Millisecond, "could not write all cache on time")
+	require.Equal(t, cache.Size(), uint(total))
+
+	wg.Add(total)
+	// reading all cache
+	for i := 0; i < total; i++ {
+		go func(ed *execution_data.BlockExecutionDataEntity) {
+			actual, ok := cache.ByID(ed.BlockID)
+			require.True(t, ok)
+			require.Equal(t, ed, actual)
+
+			wg.Done()
+		}(execDatas[i])
+	}
+	unittest.RequireReturnsBefore(t, wg.Wait, 100*time.Millisecond, "could not read all cache on time")
+}
+
+// TestAllReturnsInOrder checks All method of the HeroCache-based cache mempool returns all
+// cache in the same order as they are returned.
+func TestBlockExecutionDataAllReturnsInOrder(t *testing.T) {
+	total := 100
+	execDatas := unittest.BlockExecutionDatEntityListFixture(t, total)
+	cache := herocache.NewBlockExecutionData(uint32(total), unittest.Logger(), metrics.NewNoopCollector())
+
+	// storing all cache
+	for i := 0; i < total; i++ {
+		require.True(t, cache.Add(execDatas[i]))
+		ed, ok := cache.ByID(execDatas[i].BlockID)
+		require.True(t, ok)
+		require.Equal(t, execDatas[i], ed)
+	}
+
+	// all cache must be retrieved in the same order as they are added
+	all := cache.All()
+	for i := 0; i < total; i++ {
+		require.Equal(t, execDatas[i], all[i])
+	}
+}

--- a/module/mempool/herocache/internal/wrapped_entity.go
+++ b/module/mempool/herocache/internal/wrapped_entity.go
@@ -1,0 +1,33 @@
+package internal
+
+import "github.com/onflow/flow-go/model/flow"
+
+// WrappedEntity is a wrapper around a flow.Entity that allows overriding the ID.
+// The has 2 main use cases:
+//   - when the ID is expensive to compute, we can pre-compute it and use it for the cache
+//   - when caching an entity using a different ID than what's returned by ID(). For example, if there
+//     is a 1:1 mapping between a block and an entity, we can use the block ID as the cache key.
+type WrappedEntity struct {
+	flow.Entity
+	id flow.Identifier
+}
+
+var _ flow.Entity = (*WrappedEntity)(nil)
+
+// NewWrappedEntity creates a new WrappedEntity
+func NewWrappedEntity(id flow.Identifier, entity flow.Entity) *WrappedEntity {
+	return &WrappedEntity{
+		Entity: entity,
+		id:     id,
+	}
+}
+
+// ID returns the cached ID of the wrapped entity
+func (w WrappedEntity) ID() flow.Identifier {
+	return w.id
+}
+
+// Checksum returns th cached ID of the wrapped entity
+func (w WrappedEntity) Checksum() flow.Identifier {
+	return w.id
+}

--- a/module/state_synchronization/requester/execution_data_requester_test.go
+++ b/module/state_synchronization/requester/execution_data_requester_test.go
@@ -656,7 +656,7 @@ func (suite *ExecutionDataRequesterSuite) generateTestData(blockCount int, speci
 		height := uint64(i)
 		block := buildBlock(height, previousBlock, seals)
 
-		ed := synctest.ExecutionDataFixture(block.ID())
+		ed := unittest.BlockExecutionDataFixture(suite.T(), unittest.WithBlockExecutionDataBlockID(block.ID()))
 
 		cid, err := eds.AddExecutionData(context.Background(), ed)
 		require.NoError(suite.T(), err)

--- a/module/state_synchronization/requester/jobs/execution_data_reader_test.go
+++ b/module/state_synchronization/requester/jobs/execution_data_reader_test.go
@@ -56,7 +56,7 @@ func (suite *ExecutionDataReaderSuite) SetupTest() {
 		suite.block.Header.Height: suite.block,
 	}
 
-	suite.executionData = synctest.ExecutionDataFixture(suite.block.ID())
+	suite.executionData = unittest.BlockExecutionDataFixture(suite.T(), unittest.WithBlockExecutionDataBlockID(suite.block.ID()))
 
 	suite.highestAvailableHeight = func() uint64 { return suite.block.Header.Height + 1 }
 
@@ -130,7 +130,7 @@ func (suite *ExecutionDataReaderSuite) TestAtIndex() {
 	suite.Run("returns successfully", func() {
 		suite.reset()
 		suite.runTest(func() {
-			ed := synctest.ExecutionDataFixture(unittest.IdentifierFixture())
+			ed := unittest.BlockExecutionDataFixture(suite.T())
 			setExecutionDataGet(ed, nil)
 
 			edEntity := execution_data.NewBlockExecutionDataEntity(suite.executionDataID, ed)

--- a/module/state_synchronization/requester/unittest/unittest.go
+++ b/module/state_synchronization/requester/unittest/unittest.go
@@ -12,19 +12,11 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/blobs"
-	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/network/mocknetwork"
 	statemock "github.com/onflow/flow-go/state/protocol/mock"
 	"github.com/onflow/flow-go/storage"
 	storagemock "github.com/onflow/flow-go/storage/mock"
 )
-
-func ExecutionDataFixture(blockID flow.Identifier) *execution_data.BlockExecutionData {
-	return &execution_data.BlockExecutionData{
-		BlockID:             blockID,
-		ChunkExecutionDatas: []*execution_data.ChunkExecutionData{},
-	}
-}
 
 func MockBlobService(bs blockstore.Blockstore) *mocknetwork.BlobService {
 	bex := new(mocknetwork.BlobService)

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1,6 +1,7 @@
 package unittest
 
 import (
+	"bytes"
 	crand "crypto/rand"
 	"fmt"
 	"math/rand"
@@ -17,13 +18,14 @@ import (
 
 	sdk "github.com/onflow/flow-go-sdk"
 
+	hotstuff "github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/crypto/hash"
-
-	hotstuff "github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/bitutils"
+	"github.com/onflow/flow-go/ledger/common/testutils"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/chainsync"
 	"github.com/onflow/flow-go/model/chunks"
@@ -35,6 +37,7 @@ import (
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/model/verification"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/signature"
 	"github.com/onflow/flow-go/module/updatable_configs"
@@ -2185,4 +2188,85 @@ func GetFlowProtocolEventID(t *testing.T, channel channels.Channel, event interf
 	eventIDHash, err := network.EventId(channel, payload)
 	require.NoError(t, err)
 	return flow.HashToID(eventIDHash)
+}
+
+func WithBlockExecutionDataBlockID(blockID flow.Identifier) func(*execution_data.BlockExecutionData) {
+	return func(bed *execution_data.BlockExecutionData) {
+		bed.BlockID = blockID
+	}
+}
+
+func WithChunkExecutionDatas(chunks ...*execution_data.ChunkExecutionData) func(*execution_data.BlockExecutionData) {
+	return func(bed *execution_data.BlockExecutionData) {
+		bed.ChunkExecutionDatas = chunks
+	}
+}
+
+func BlockExecutionDataFixture(t *testing.T, opts ...func(*execution_data.BlockExecutionData)) *execution_data.BlockExecutionData {
+	bed := &execution_data.BlockExecutionData{
+		BlockID:             IdentifierFixture(),
+		ChunkExecutionDatas: []*execution_data.ChunkExecutionData{},
+	}
+
+	for _, opt := range opts {
+		opt(bed)
+	}
+
+	return bed
+}
+
+func BlockExecutionDatEntityFixture(t *testing.T, opts ...func(*execution_data.BlockExecutionData)) *execution_data.BlockExecutionDataEntity {
+	execData := BlockExecutionDataFixture(t, opts...)
+	return execution_data.NewBlockExecutionDataEntity(IdentifierFixture(), execData)
+}
+
+func BlockExecutionDatEntityListFixture(t *testing.T, n int) []*execution_data.BlockExecutionDataEntity {
+	l := make([]*execution_data.BlockExecutionDataEntity, n)
+	for i := 0; i < n; i++ {
+		l[i] = BlockExecutionDatEntityFixture(t)
+	}
+
+	return l
+}
+
+func WithChunkEvents(events flow.EventsList) func(*execution_data.ChunkExecutionData) {
+	return func(conf *execution_data.ChunkExecutionData) {
+		conf.Events = events
+	}
+}
+
+func ChunkExecutionDataFixture(t *testing.T, minSize int, opts ...func(*execution_data.ChunkExecutionData)) *execution_data.ChunkExecutionData {
+	collection := CollectionFixture(1)
+	ced := &execution_data.ChunkExecutionData{
+		Collection: &collection,
+		Events:     flow.EventsList{},
+		TrieUpdate: testutils.TrieUpdateFixture(1, 1, 8),
+	}
+
+	for _, opt := range opts {
+		opt(ced)
+	}
+
+	if minSize <= 1 {
+		return ced
+	}
+
+	size := 1
+	for {
+		buf := &bytes.Buffer{}
+		require.NoError(t, execution_data.DefaultSerializer.Serialize(buf, ced))
+		if buf.Len() >= minSize {
+			return ced
+		}
+
+		v := make([]byte, size)
+		_, err := rand.Read(v)
+		require.NoError(t, err)
+
+		k, err := ced.TrieUpdate.Payloads[0].Key()
+		require.NoError(t, err)
+
+		ced.TrieUpdate.Payloads[0] = ledger.NewPayload(k, v)
+		size *= 2
+	}
 }


### PR DESCRIPTION
The original implementation used herocache directly, which is not currency safe. This PR adds a new backdata implementation for `BlockExecutionData`. 

It also fixes some localnet ports that were missed during a recent refactor