### PR TITLE
Add version beacon service event model

### DIFF
--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -362,7 +362,11 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 		err := db.Update(operation.IndexBlockHeight(block2.Header.Height, block2.ID()))
 		require.NoError(suite.T(), err)
 
-		assertHeaderResp := func(resp *accessproto.BlockHeaderResponse, err error, header *flow.Header) {
+		assertHeaderResp := func(
+			resp *accessproto.BlockHeaderResponse,
+			err error,
+			header *flow.Header,
+		) {
 			require.NoError(suite.T(), err)
 			require.NotNil(suite.T(), resp)
 			actual := resp.Block
@@ -374,7 +378,11 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 			require.Equal(suite.T(), expectedBlockHeader, header)
 		}
 
-		assertBlockResp := func(resp *accessproto.BlockResponse, err error, block *flow.Block) {
+		assertBlockResp := func(
+			resp *accessproto.BlockResponse,
+			err error,
+			block *flow.Block,
+		) {
 			require.NoError(suite.T(), err)
 			require.NotNil(suite.T(), resp)
 			actual := resp.Block
@@ -386,7 +394,11 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 			require.Equal(suite.T(), expectedBlock.ID(), block.ID())
 		}
 
-		assertLightBlockResp := func(resp *accessproto.BlockResponse, err error, block *flow.Block) {
+		assertLightBlockResp := func(
+			resp *accessproto.BlockResponse,
+			err error,
+			block *flow.Block,
+		) {
 			require.NoError(suite.T(), err)
 			require.NotNil(suite.T(), resp)
 			actual := resp.Block
@@ -479,12 +491,16 @@ func (suite *Suite) TestGetExecutionResultByBlockID() {
 
 		er := unittest.ExecutionResultFixture(
 			unittest.WithExecutionResultBlockID(blockID),
-			unittest.WithServiceEvents(2))
+			unittest.WithServiceEvents(3))
 
 		require.NoError(suite.T(), all.Results.Store(er))
 		require.NoError(suite.T(), all.Results.Index(blockID, er.ID()))
 
-		assertResp := func(resp *accessproto.ExecutionResultForBlockIDResponse, err error, executionResult *flow.ExecutionResult) {
+		assertResp := func(
+			resp *accessproto.ExecutionResultForBlockIDResponse,
+			err error,
+			executionResult *flow.ExecutionResult,
+		) {
 			require.NoError(suite.T(), err)
 			require.NotNil(suite.T(), resp)
 			er := resp.ExecutionResult

--- a/engine/common/rpc/convert/convert.go
+++ b/engine/common/rpc/convert/convert.go
@@ -31,7 +31,10 @@ var ValidChainIds = map[string]bool{
 	flow.MonotonicEmulator.String(): true,
 }
 
-func MessageToTransaction(m *entities.Transaction, chain flow.Chain) (flow.TransactionBody, error) {
+func MessageToTransaction(
+	m *entities.Transaction,
+	chain flow.Chain,
+) (flow.TransactionBody, error) {
 	if m == nil {
 		return flow.TransactionBody{}, ErrEmptyMessage
 	}
@@ -141,7 +144,10 @@ func TransactionToMessage(tb flow.TransactionBody) *entities.Transaction {
 	}
 }
 
-func BlockHeaderToMessage(h *flow.Header, signerIDs flow.IdentifierList) (*entities.BlockHeader, error) {
+func BlockHeaderToMessage(
+	h *flow.Header,
+	signerIDs flow.IdentifierList,
+) (*entities.BlockHeader, error) {
 	id := h.ID()
 
 	t := timestamppb.New(h.Timestamp)
@@ -267,7 +273,10 @@ func MessagesToBlockSeals(m []*entities.BlockSeal) ([]*flow.Seal, error) {
 	return seals, nil
 }
 
-func ExecutionResultsToMessages(e []*flow.ExecutionResult) ([]*entities.ExecutionResult, error) {
+func ExecutionResultsToMessages(e []*flow.ExecutionResult) (
+	[]*entities.ExecutionResult,
+	error,
+) {
 	execResults := make([]*entities.ExecutionResult, len(e))
 	for i, execRes := range e {
 		parsedExecResult, err := ExecutionResultToMessage(execRes)
@@ -279,7 +288,10 @@ func ExecutionResultsToMessages(e []*flow.ExecutionResult) ([]*entities.Executio
 	return execResults, nil
 }
 
-func MessagesToExecutionResults(m []*entities.ExecutionResult) ([]*flow.ExecutionResult, error) {
+func MessagesToExecutionResults(m []*entities.ExecutionResult) (
+	[]*flow.ExecutionResult,
+	error,
+) {
 	execResults := make([]*flow.ExecutionResult, len(m))
 	for i, e := range m {
 		parsedExecResult, err := MessageToExecutionResult(e)
@@ -291,7 +303,10 @@ func MessagesToExecutionResults(m []*entities.ExecutionResult) ([]*flow.Executio
 	return execResults, nil
 }
 
-func BlockToMessage(h *flow.Block, signerIDs flow.IdentifierList) (*entities.Block, error) {
+func BlockToMessage(h *flow.Block, signerIDs flow.IdentifierList) (
+	*entities.Block,
+	error,
+) {
 
 	id := h.ID()
 
@@ -723,7 +738,10 @@ func MessagesToChunkList(m []*entities.Chunk) (flow.ChunkList, error) {
 	return parsedChunks, nil
 }
 
-func MessagesToServiceEventList(m []*entities.ServiceEvent) (flow.ServiceEventList, error) {
+func MessagesToServiceEventList(m []*entities.ServiceEvent) (
+	flow.ServiceEventList,
+	error,
+) {
 	parsedServiceEvents := make(flow.ServiceEventList, len(m))
 	for i, serviceEvent := range m {
 		parsedServiceEvent, err := MessageToServiceEvent(serviceEvent)
@@ -735,7 +753,10 @@ func MessagesToServiceEventList(m []*entities.ServiceEvent) (flow.ServiceEventLi
 	return parsedServiceEvents, nil
 }
 
-func MessageToExecutionResult(m *entities.ExecutionResult) (*flow.ExecutionResult, error) {
+func MessageToExecutionResult(m *entities.ExecutionResult) (
+	*flow.ExecutionResult,
+	error,
+) {
 	// convert Chunks
 	parsedChunks, err := MessagesToChunkList(m.Chunks)
 	if err != nil {
@@ -755,7 +776,10 @@ func MessageToExecutionResult(m *entities.ExecutionResult) (*flow.ExecutionResul
 	}, nil
 }
 
-func ExecutionResultToMessage(er *flow.ExecutionResult) (*entities.ExecutionResult, error) {
+func ExecutionResultToMessage(er *flow.ExecutionResult) (
+	*entities.ExecutionResult,
+	error,
+) {
 
 	chunks := make([]*entities.Chunk, len(er.Chunks))
 
@@ -813,6 +837,13 @@ func MessageToServiceEvent(m *entities.ServiceEvent) (*flow.ServiceEvent, error)
 			return nil, fmt.Errorf("failed to marshal to EpochCommit event: %w", err)
 		}
 		event = commit
+	case flow.ServiceEventVersionBeacon:
+		versionBeacon := new(flow.VersionBeacon)
+		err := json.Unmarshal(rawEvent, versionBeacon)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal to VersionBeacon event: %w", err)
+		}
+		event = versionBeacon
 	default:
 		return nil, fmt.Errorf("invalid event type: %s", m.Type)
 	}
@@ -859,7 +890,10 @@ func MessageToChunk(m *entities.Chunk) (*flow.Chunk, error) {
 	}, nil
 }
 
-func BlockExecutionDataToMessage(data *execution_data.BlockExecutionData) (*entities.BlockExecutionData, error) {
+func BlockExecutionDataToMessage(data *execution_data.BlockExecutionData) (
+	*entities.BlockExecutionData,
+	error,
+) {
 	chunkExecutionDatas := make([]*entities.ChunkExecutionData, len(data.ChunkExecutionDatas))
 	for i, chunk := range data.ChunkExecutionDatas {
 		chunkMessage, err := ChunkExecutionDataToMessage(chunk)
@@ -874,7 +908,10 @@ func BlockExecutionDataToMessage(data *execution_data.BlockExecutionData) (*enti
 	}, nil
 }
 
-func ChunkExecutionDataToMessage(data *execution_data.ChunkExecutionData) (*entities.ChunkExecutionData, error) {
+func ChunkExecutionDataToMessage(data *execution_data.ChunkExecutionData) (
+	*entities.ChunkExecutionData,
+	error,
+) {
 	collection := &entities.ExecutionDataCollection{}
 	if data.Collection != nil {
 		collection = &entities.ExecutionDataCollection{
@@ -927,7 +964,10 @@ func ChunkExecutionDataToMessage(data *execution_data.ChunkExecutionData) (*enti
 	}, nil
 }
 
-func MessageToBlockExecutionData(m *entities.BlockExecutionData, chain flow.Chain) (*execution_data.BlockExecutionData, error) {
+func MessageToBlockExecutionData(
+	m *entities.BlockExecutionData,
+	chain flow.Chain,
+) (*execution_data.BlockExecutionData, error) {
 	if m == nil {
 		return nil, ErrEmptyMessage
 	}
@@ -946,7 +986,10 @@ func MessageToBlockExecutionData(m *entities.BlockExecutionData, chain flow.Chai
 	}, nil
 }
 
-func MessageToChunkExecutionData(m *entities.ChunkExecutionData, chain flow.Chain) (*execution_data.ChunkExecutionData, error) {
+func MessageToChunkExecutionData(
+	m *entities.ChunkExecutionData,
+	chain flow.Chain,
+) (*execution_data.ChunkExecutionData, error) {
 	collection, err := messageToTrustedCollection(m.GetCollection(), chain)
 	if err != nil {
 		return nil, err
@@ -972,7 +1015,10 @@ func MessageToChunkExecutionData(m *entities.ChunkExecutionData, chain flow.Chai
 	}, nil
 }
 
-func messageToTrustedCollection(m *entities.ExecutionDataCollection, chain flow.Chain) (*flow.Collection, error) {
+func messageToTrustedCollection(
+	m *entities.ExecutionDataCollection,
+	chain flow.Chain,
+) (*flow.Collection, error) {
 	messages := m.GetTransactions()
 	transactions := make([]*flow.TransactionBody, len(messages))
 	for i, message := range messages {
@@ -993,7 +1039,10 @@ func messageToTrustedCollection(m *entities.ExecutionDataCollection, chain flow.
 // messageToTrustedTransaction converts a transaction message to a transaction body.
 // This is useful when converting transactions from trusted state like BlockExecutionData which
 // contain service transactions that do not conform to external transaction format.
-func messageToTrustedTransaction(m *entities.Transaction, chain flow.Chain) (flow.TransactionBody, error) {
+func messageToTrustedTransaction(
+	m *entities.Transaction,
+	chain flow.Chain,
+) (flow.TransactionBody, error) {
 	if m == nil {
 		return flow.TransactionBody{}, ErrEmptyMessage
 	}

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 
 require (
 	github.com/slok/go-http-metrics v0.10.0
+	golang.org/x/mod v0.8.0
 	gonum.org/v1/gonum v0.8.2
 )
 
@@ -265,7 +266,6 @@ require (
 	go.uber.org/dig v1.15.0 // indirect
 	go.uber.org/fx v1.18.2 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/model/flow/service_event.go
+++ b/model/flow/service_event.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	ServiceEventSetup  = "setup"
-	ServiceEventCommit = "commit"
+	ServiceEventSetup         = "setup"
+	ServiceEventCommit        = "commit"
+	ServiceEventVersionBeacon = "version-beacon"
 )
 
 // ServiceEvent represents a service event, which is a special event that when
@@ -87,6 +88,13 @@ func (se *ServiceEvent) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		event = commit
+	case ServiceEventVersionBeacon:
+		version := new(VersionBeacon)
+		err = json.Unmarshal(evb, version)
+		if err != nil {
+			return err
+		}
+		event = version
 	default:
 		return fmt.Errorf("invalid type: %s", tp)
 	}
@@ -137,6 +145,13 @@ func (se *ServiceEvent) UnmarshalMsgpack(b []byte) error {
 			return err
 		}
 		event = commit
+	case ServiceEventVersionBeacon:
+		version := new(VersionBeacon)
+		err = msgpack.Unmarshal(evb, version)
+		if err != nil {
+			return err
+		}
+		event = version
 	default:
 		return fmt.Errorf("invalid type: %s", tp)
 	}
@@ -186,6 +201,13 @@ func (se *ServiceEvent) UnmarshalCBOR(b []byte) error {
 			return err
 		}
 		event = commit
+	case ServiceEventVersionBeacon:
+		version := new(VersionBeacon)
+		err = cbor.Unmarshal(evb, version)
+		if err != nil {
+			return err
+		}
+		event = version
 	default:
 		return fmt.Errorf("invalid type: %s", tp)
 	}
@@ -223,6 +245,23 @@ func (se *ServiceEvent) EqualTo(other *ServiceEvent) (bool, error) {
 			return false, fmt.Errorf("internal invalid type for ServiceEventCommit: %T", other.Event)
 		}
 		return commit.EqualTo(otherCommit), nil
+
+	case ServiceEventVersionBeacon:
+		version, ok := se.Event.(*VersionBeacon)
+		if !ok {
+			return false, fmt.Errorf(
+				"internal invalid type for ServiceEventVersionBeacon: %T",
+				se.Event)
+		}
+		otherVersion, ok := other.Event.(*VersionBeacon)
+		if !ok {
+			return false,
+				fmt.Errorf(
+					"internal invalid type for ServiceEventVersionBeacon: %T",
+					other.Event)
+		}
+		return version.EqualTo(otherVersion), nil
+
 	default:
 		return false, fmt.Errorf("unknown serice event type: %s", se.Type)
 	}

--- a/model/flow/service_event_test.go
+++ b/model/flow/service_event_test.go
@@ -20,6 +20,7 @@ func TestEncodeDecode(t *testing.T) {
 
 	setup := unittest.EpochSetupFixture()
 	commit := unittest.EpochCommitFixture()
+	versionBeacon := unittest.VersionBeaconFixture()
 
 	comparePubKey := cmp.FilterValues(func(a, b crypto.PublicKey) bool {
 		return true
@@ -32,6 +33,7 @@ func TestEncodeDecode(t *testing.T) {
 
 	t.Run("json", func(t *testing.T) {
 		t.Run("specific event types", func(t *testing.T) {
+			// EpochSetup
 			b, err := json.Marshal(setup)
 			require.NoError(t, err)
 
@@ -40,6 +42,7 @@ func TestEncodeDecode(t *testing.T) {
 			require.NoError(t, err)
 			assert.DeepEqual(t, setup, gotSetup, comparePubKey)
 
+			// EpochCommit
 			b, err = json.Marshal(commit)
 			require.NoError(t, err)
 
@@ -47,9 +50,19 @@ func TestEncodeDecode(t *testing.T) {
 			err = json.Unmarshal(b, gotCommit)
 			require.NoError(t, err)
 			assert.DeepEqual(t, commit, gotCommit, comparePubKey)
+
+			// VersionBeacon
+			b, err = json.Marshal(versionBeacon)
+			require.NoError(t, err)
+
+			gotVersionBeacon := new(flow.VersionBeacon)
+			err = json.Unmarshal(b, gotVersionBeacon)
+			require.NoError(t, err)
+			assert.DeepEqual(t, versionBeacon, gotVersionBeacon)
 		})
 
 		t.Run("generic type", func(t *testing.T) {
+			// EpochSetup
 			b, err := json.Marshal(setup.ServiceEvent())
 			require.NoError(t, err)
 
@@ -60,6 +73,7 @@ func TestEncodeDecode(t *testing.T) {
 			require.True(t, ok)
 			assert.DeepEqual(t, setup, gotSetup, comparePubKey)
 
+			// EpochCommit
 			t.Logf("- debug: setup.ServiceEvent()=%+v\n", setup.ServiceEvent())
 			b, err = json.Marshal(commit.ServiceEvent())
 			require.NoError(t, err)
@@ -72,11 +86,26 @@ func TestEncodeDecode(t *testing.T) {
 			gotCommit, ok := outer.Event.(*flow.EpochCommit)
 			require.True(t, ok)
 			assert.DeepEqual(t, commit, gotCommit, comparePubKey)
+
+			// VersionBeacon
+			t.Logf("- debug: versionBeacon.ServiceEvent()=%+v\n", versionBeacon.ServiceEvent())
+			b, err = json.Marshal(versionBeacon.ServiceEvent())
+			require.NoError(t, err)
+
+			outer = new(flow.ServiceEvent)
+			t.Logf("- debug: outer=%+v <-- before .Unmarshal()\n", outer)
+			err = json.Unmarshal(b, outer)
+			t.Logf("- debug: outer=%+v <-- after .Unmarshal()\n", outer)
+			require.NoError(t, err)
+			gotVersionTable, ok := outer.Event.(*flow.VersionBeacon)
+			require.True(t, ok)
+			assert.DeepEqual(t, versionBeacon, gotVersionTable)
 		})
 	})
 
 	t.Run("msgpack", func(t *testing.T) {
 		t.Run("specific event types", func(t *testing.T) {
+			// EpochSetup
 			b, err := msgpack.Marshal(setup)
 			require.NoError(t, err)
 
@@ -85,6 +114,7 @@ func TestEncodeDecode(t *testing.T) {
 			require.NoError(t, err)
 			assert.DeepEqual(t, setup, gotSetup, comparePubKey)
 
+			// EpochCommit
 			b, err = msgpack.Marshal(commit)
 			require.NoError(t, err)
 
@@ -92,6 +122,15 @@ func TestEncodeDecode(t *testing.T) {
 			err = msgpack.Unmarshal(b, gotCommit)
 			require.NoError(t, err)
 			assert.DeepEqual(t, commit, gotCommit, comparePubKey)
+
+			// VersionBeacon
+			b, err = msgpack.Marshal(versionBeacon)
+			require.NoError(t, err)
+
+			gotVersionTable := new(flow.VersionBeacon)
+			err = msgpack.Unmarshal(b, gotVersionTable)
+			require.NoError(t, err)
+			assert.DeepEqual(t, versionBeacon, gotVersionTable)
 		})
 
 		t.Run("generic type", func(t *testing.T) {
@@ -105,6 +144,7 @@ func TestEncodeDecode(t *testing.T) {
 			require.True(t, ok)
 			assert.DeepEqual(t, setup, gotSetup, comparePubKey)
 
+			// EpochCommit
 			t.Logf("- debug: setup.ServiceEvent()=%+v\n", setup.ServiceEvent())
 			b, err = msgpack.Marshal(commit.ServiceEvent())
 			require.NoError(t, err)
@@ -117,11 +157,26 @@ func TestEncodeDecode(t *testing.T) {
 			gotCommit, ok := outer.Event.(*flow.EpochCommit)
 			require.True(t, ok)
 			assert.DeepEqual(t, commit, gotCommit, comparePubKey)
+
+			// VersionBeacon
+			t.Logf("- debug: versionTable.ServiceEvent()=%+v\n", versionBeacon.ServiceEvent())
+			b, err = msgpack.Marshal(versionBeacon.ServiceEvent())
+			require.NoError(t, err)
+
+			outer = new(flow.ServiceEvent)
+			t.Logf("- debug: outer=%+v <-- before .Unmarshal()\n", outer)
+			err = msgpack.Unmarshal(b, outer)
+			t.Logf("- debug: outer=%+v <-- after .Unmarshal()\n", outer)
+			require.NoError(t, err)
+			gotVersionTable, ok := outer.Event.(*flow.VersionBeacon)
+			require.True(t, ok)
+			assert.DeepEqual(t, versionBeacon, gotVersionTable, comparePubKey)
 		})
 	})
 
 	t.Run("cbor", func(t *testing.T) {
 		t.Run("specific event types", func(t *testing.T) {
+			// EpochSetup
 			b, err := cborcodec.EncMode.Marshal(setup)
 			require.NoError(t, err)
 
@@ -130,6 +185,7 @@ func TestEncodeDecode(t *testing.T) {
 			require.NoError(t, err)
 			assert.DeepEqual(t, setup, gotSetup, comparePubKey)
 
+			// EpochCommit
 			b, err = cborcodec.EncMode.Marshal(commit)
 			require.NoError(t, err)
 
@@ -137,9 +193,20 @@ func TestEncodeDecode(t *testing.T) {
 			err = cbor.Unmarshal(b, gotCommit)
 			require.NoError(t, err)
 			assert.DeepEqual(t, commit, gotCommit, comparePubKey)
+
+			// VersionBeacon
+			b, err = cborcodec.EncMode.Marshal(versionBeacon)
+			require.NoError(t, err)
+
+			gotVersionTable := new(flow.VersionBeacon)
+			err = cbor.Unmarshal(b, gotVersionTable)
+			require.NoError(t, err)
+			assert.DeepEqual(t, versionBeacon, gotVersionTable)
+
 		})
 
 		t.Run("generic type", func(t *testing.T) {
+			// EpochSetup
 			t.Logf("- debug: setup.ServiceEvent()=%+v\n", setup.ServiceEvent())
 			b, err := cborcodec.EncMode.Marshal(setup.ServiceEvent())
 			require.NoError(t, err)
@@ -153,6 +220,7 @@ func TestEncodeDecode(t *testing.T) {
 			require.True(t, ok)
 			assert.DeepEqual(t, setup, gotSetup, comparePubKey)
 
+			// EpochCommit
 			b, err = cborcodec.EncMode.Marshal(commit.ServiceEvent())
 			require.NoError(t, err)
 
@@ -162,6 +230,18 @@ func TestEncodeDecode(t *testing.T) {
 			gotCommit, ok := outer.Event.(*flow.EpochCommit)
 			require.True(t, ok)
 			assert.DeepEqual(t, commit, gotCommit, comparePubKey)
+
+			// VersionBeacon
+			t.Logf("- debug: setup.ServiceEvent()=%+v\n", versionBeacon.ServiceEvent())
+			b, err = cborcodec.EncMode.Marshal(versionBeacon.ServiceEvent())
+			require.NoError(t, err)
+
+			outer = new(flow.ServiceEvent)
+			err = cbor.Unmarshal(b, outer)
+			require.NoError(t, err)
+			gotVersionTable, ok := outer.Event.(*flow.VersionBeacon)
+			require.True(t, ok)
+			assert.DeepEqual(t, versionBeacon, gotVersionTable)
 		})
 	})
 }

--- a/model/flow/version_beacon.go
+++ b/model/flow/version_beacon.go
@@ -1,0 +1,62 @@
+package flow
+
+import "golang.org/x/mod/semver"
+
+// VersionBoundary represents a boundary between semver versions.
+// BlockHeight is the first block height which must be run by the given Version (inclusive).
+// Version is semver string.
+type VersionBoundary struct {
+	BlockHeight uint64
+	Version     string
+}
+
+// VersionBeacon represents a service event which specifies required software versions
+// for upcoming blocks.
+//
+// It contains VersionBoundaries field which is an ordered list of VersionBoundary
+// (ordered by VersionBoundary.BlockHeight). While heights are strictly
+// increasing, versions must be equal or greater, compared by semver semantics.
+// It must contain at least one entry. The first entry is for a past block height.
+// The rest of the entries are for all future block heights. Future version boundaries
+// can be removed, in which case the event emitted will not contain the removed version
+// boundaries.
+// VersionBeacon is produced by NodeVersionBeacon smart contract.
+//
+// Sequence is event sequence number, which can be used to verify that no event has been
+// skipped by the follower. Everytime the smart contract emits a new event, it increments
+// the sequence number by one.
+type VersionBeacon struct {
+	VersionBoundaries []VersionBoundary
+	Sequence          uint64
+}
+
+func (v *VersionBeacon) ServiceEvent() ServiceEvent {
+	return ServiceEvent{
+		Type:  ServiceEventVersionBeacon,
+		Event: v,
+	}
+}
+
+func (v *VersionBeacon) EqualTo(other *VersionBeacon) bool {
+
+	if v.Sequence != other.Sequence {
+		return false
+	}
+
+	if len(v.VersionBoundaries) != len(other.VersionBoundaries) {
+		return false
+	}
+
+	for i, v := range v.VersionBoundaries {
+		other := other.VersionBoundaries[i]
+
+		if v.BlockHeight != other.BlockHeight {
+			return false
+		}
+		if semver.Compare(v.Version, other.Version) != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/model/flow/version_beacon_test.go
+++ b/model/flow/version_beacon_test.go
@@ -1,0 +1,96 @@
+package flow_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestEqualTo(t *testing.T) {
+	testCases := []struct {
+		name   string
+		vb1    flow.VersionBeacon
+		vb2    flow.VersionBeacon
+		result bool
+	}{
+		{
+			name: "Equal version beacons",
+			vb1: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 2, Version: "v1.1.0"},
+				},
+				Sequence: 1,
+			},
+			vb2: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 2, Version: "v1.1.0"},
+				},
+				Sequence: 1,
+			},
+			result: true,
+		},
+		{
+			name: "Different sequence",
+			vb1: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 2, Version: "v1.1.0"},
+				},
+				Sequence: 1,
+			},
+			vb2: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 2, Version: "v1.1.0"},
+				},
+				Sequence: 2,
+			},
+			result: false,
+		},
+		{
+			name: "Different version boundaries",
+			vb1: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 2, Version: "v1.1.0"},
+				},
+				Sequence: 1,
+			},
+			vb2: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 2, Version: "v1.2.0"},
+				},
+				Sequence: 1,
+			},
+			result: false,
+		},
+		{
+			name: "Different length of version boundaries",
+			vb1: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 2, Version: "v1.1.0"},
+				},
+				Sequence: 1,
+			},
+			vb2: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v1.0.0"},
+				},
+				Sequence: 1,
+			},
+			result: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.result, tc.vb1.EqualTo(&tc.vb2))
+		})
+	}
+}

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -335,7 +335,11 @@ func StateInteractionsFixture() *state.ExecutionSnapshot {
 	return &state.ExecutionSnapshot{}
 }
 
-func BlockWithParentAndProposerFixture(t *testing.T, parent *flow.Header, proposer flow.Identifier) flow.Block {
+func BlockWithParentAndProposerFixture(
+	t *testing.T,
+	parent *flow.Header,
+	proposer flow.Identifier,
+) flow.Block {
 	block := BlockWithParentFixture(parent)
 
 	indices, err := signature.EncodeSignersToIndices(
@@ -411,7 +415,10 @@ func CidFixture() cid.Cid {
 	return blocks.NewBlock(data).Cid()
 }
 
-func BlockHeaderFixtureOnChain(chainID flow.ChainID, opts ...func(header *flow.Header)) *flow.Header {
+func BlockHeaderFixtureOnChain(
+	chainID flow.ChainID,
+	opts ...func(header *flow.Header),
+) *flow.Header {
 	height := 1 + uint64(rand.Uint32()) // avoiding edge case of height = 0 (genesis block)
 	view := height + uint64(rand.Intn(1000))
 	header := BlockHeaderWithParentFixture(&flow.Header{
@@ -538,7 +545,10 @@ func CollectionGuaranteesWithCollectionIDFixture(collections []*flow.Collection)
 	return guarantees
 }
 
-func CollectionGuaranteesFixture(n int, options ...func(*flow.CollectionGuarantee)) []*flow.CollectionGuarantee {
+func CollectionGuaranteesFixture(
+	n int,
+	options ...func(*flow.CollectionGuarantee),
+) []*flow.CollectionGuarantee {
 	guarantees := make([]*flow.CollectionGuarantee, 0, n)
 	for i := 1; i <= n; i++ {
 		guarantee := CollectionGuaranteeFixture(options...)
@@ -618,7 +628,10 @@ func ExecutableBlockFixture(collectionsSignerIDs [][]flow.Identifier) *entity.Ex
 	return ExecutableBlockFixtureWithParent(collectionsSignerIDs, header)
 }
 
-func ExecutableBlockFixtureWithParent(collectionsSignerIDs [][]flow.Identifier, parent *flow.Header) *entity.ExecutableBlock {
+func ExecutableBlockFixtureWithParent(
+	collectionsSignerIDs [][]flow.Identifier,
+	parent *flow.Header,
+) *entity.ExecutableBlock {
 
 	completeCollections := make(map[flow.Identifier]*entity.CompleteCollection, len(collectionsSignerIDs))
 	block := BlockWithParentFixture(parent)
@@ -639,7 +652,10 @@ func ExecutableBlockFixtureWithParent(collectionsSignerIDs [][]flow.Identifier, 
 	return executableBlock
 }
 
-func ExecutableBlockFromTransactions(chain flow.ChainID, txss [][]*flow.TransactionBody) *entity.ExecutableBlock {
+func ExecutableBlockFromTransactions(
+	chain flow.ChainID,
+	txss [][]*flow.TransactionBody,
+) *entity.ExecutableBlock {
 
 	completeCollections := make(map[flow.Identifier]*entity.CompleteCollection, len(txss))
 	blockHeader := BlockHeaderFixtureOnChain(chain)
@@ -694,13 +710,19 @@ func ReceiptForBlockFixture(block *flow.Block) *flow.ExecutionReceipt {
 	return ReceiptForBlockExecutorFixture(block, IdentifierFixture())
 }
 
-func ReceiptForBlockExecutorFixture(block *flow.Block, executor flow.Identifier) *flow.ExecutionReceipt {
+func ReceiptForBlockExecutorFixture(
+	block *flow.Block,
+	executor flow.Identifier,
+) *flow.ExecutionReceipt {
 	result := ExecutionResultFixture(WithBlock(block))
 	receipt := ExecutionReceiptFixture(WithResult(result), WithExecutorID(executor))
 	return receipt
 }
 
-func ReceiptsForBlockFixture(block *flow.Block, ids []flow.Identifier) []*flow.ExecutionReceipt {
+func ReceiptsForBlockFixture(
+	block *flow.Block,
+	ids []flow.Identifier,
+) []*flow.ExecutionReceipt {
 	result := ExecutionResultFixture(WithBlock(block))
 	var ers []*flow.ExecutionReceipt
 	for _, id := range ids {
@@ -743,7 +765,10 @@ func WithChunks(n uint) func(*flow.ExecutionResult) {
 	}
 }
 
-func ExecutionResultListFixture(n int, opts ...func(*flow.ExecutionResult)) []*flow.ExecutionResult {
+func ExecutionResultListFixture(
+	n int,
+	opts ...func(*flow.ExecutionResult),
+) []*flow.ExecutionResult {
 	results := make([]*flow.ExecutionResult, 0, n)
 	for i := 0; i < n; i++ {
 		results = append(results, ExecutionResultFixture(opts...))
@@ -776,12 +801,14 @@ func WithExecutionDataID(id flow.Identifier) func(result *flow.ExecutionResult) 
 func ServiceEventsFixture(n int) flow.ServiceEventList {
 	sel := make(flow.ServiceEventList, n)
 
-	for ; n > 0; n-- {
-		switch rand.Intn(2) {
+	for i := 0; i < n; i++ {
+		switch i % 3 {
 		case 0:
-			sel[n-1] = EpochCommitFixture().ServiceEvent()
+			sel[i] = EpochCommitFixture().ServiceEvent()
 		case 1:
-			sel[n-1] = EpochSetupFixture().ServiceEvent()
+			sel[i] = EpochSetupFixture().ServiceEvent()
+		case 2:
+			sel[i] = VersionBeaconFixture().ServiceEvent()
 		}
 	}
 
@@ -1013,7 +1040,10 @@ func IdentityFixture(opts ...func(*flow.Identity)) *flow.Identity {
 }
 
 // IdentityWithNetworkingKeyFixture returns a node identity and networking private key
-func IdentityWithNetworkingKeyFixture(opts ...func(*flow.Identity)) (*flow.Identity, crypto.PrivateKey) {
+func IdentityWithNetworkingKeyFixture(opts ...func(*flow.Identity)) (
+	*flow.Identity,
+	crypto.PrivateKey,
+) {
 	networkKey := NetworkingPrivKeyFixture()
 	opts = append(opts, WithNetworkingKey(networkKey.PublicKey()))
 	id := IdentityFixture(opts...)
@@ -1119,7 +1149,11 @@ func WithChunkStartState(startState flow.StateCommitment) func(chunk *flow.Chunk
 	}
 }
 
-func ChunkFixture(blockID flow.Identifier, collectionIndex uint, opts ...func(*flow.Chunk)) *flow.Chunk {
+func ChunkFixture(
+	blockID flow.Identifier,
+	collectionIndex uint,
+	opts ...func(*flow.Chunk),
+) *flow.Chunk {
 	chunk := &flow.Chunk{
 		ChunkBody: flow.ChunkBody{
 			CollectionIndex:      collectionIndex,
@@ -1181,7 +1215,12 @@ func ChunkStatusListToChunkLocatorFixture(statuses []*verification.ChunkStatus) 
 // ChunkStatusListFixture receives an execution result, samples `n` chunks out of it and
 // creates a chunk status for them.
 // It returns the list of sampled chunk statuses for the result.
-func ChunkStatusListFixture(t *testing.T, blockHeight uint64, result *flow.ExecutionResult, n int) verification.ChunkStatusList {
+func ChunkStatusListFixture(
+	t *testing.T,
+	blockHeight uint64,
+	result *flow.ExecutionResult,
+	n int,
+) verification.ChunkStatusList {
 	statuses := verification.ChunkStatusList{}
 
 	// result should have enough chunk to sample
@@ -1360,7 +1399,10 @@ func VerifiableChunkDataFixture(chunkIndex uint64) *verification.VerifiableChunk
 
 // ChunkDataResponseMsgFixture creates a chunk data response message with a single-transaction collection, and random chunk ID.
 // Use options to customize the response.
-func ChunkDataResponseMsgFixture(chunkID flow.Identifier, opts ...func(*messages.ChunkDataResponse)) *messages.ChunkDataResponse {
+func ChunkDataResponseMsgFixture(
+	chunkID flow.Identifier,
+	opts ...func(*messages.ChunkDataResponse),
+) *messages.ChunkDataResponse {
 	cdp := &messages.ChunkDataResponse{
 		ChunkDataPack: *ChunkDataPackFixture(chunkID),
 		Nonce:         rand.Uint64(),
@@ -1394,7 +1436,10 @@ func ChunkDataResponseMessageListFixture(chunkIDs flow.IdentifierList) []*messag
 }
 
 // ChunkDataPackRequestListFixture creates and returns a list of chunk data pack requests fixtures.
-func ChunkDataPackRequestListFixture(n int, opts ...func(*verification.ChunkDataPackRequest)) verification.ChunkDataPackRequestList {
+func ChunkDataPackRequestListFixture(
+	n int,
+	opts ...func(*verification.ChunkDataPackRequest),
+) verification.ChunkDataPackRequestList {
 	lst := make([]*verification.ChunkDataPackRequest, 0, n)
 	for i := 0; i < n; i++ {
 		lst = append(lst, ChunkDataPackRequestFixture(opts...))
@@ -1482,7 +1527,10 @@ func WithStartState(startState flow.StateCommitment) func(*flow.ChunkDataPack) {
 	}
 }
 
-func ChunkDataPackFixture(chunkID flow.Identifier, opts ...func(*flow.ChunkDataPack)) *flow.ChunkDataPack {
+func ChunkDataPackFixture(
+	chunkID flow.Identifier,
+	opts ...func(*flow.ChunkDataPack),
+) *flow.ChunkDataPack {
 	coll := CollectionFixture(1)
 	cdp := &flow.ChunkDataPack{
 		ChunkID:    chunkID,
@@ -1498,7 +1546,10 @@ func ChunkDataPackFixture(chunkID flow.Identifier, opts ...func(*flow.ChunkDataP
 	return cdp
 }
 
-func ChunkDataPacksFixture(count int, opts ...func(*flow.ChunkDataPack)) []*flow.ChunkDataPack {
+func ChunkDataPacksFixture(
+	count int,
+	opts ...func(*flow.ChunkDataPack),
+) []*flow.ChunkDataPack {
 	chunkDataPacks := make([]*flow.ChunkDataPack, count)
 	for i := 0; i < count; i++ {
 		chunkDataPacks[i] = ChunkDataPackFixture(IdentifierFixture())
@@ -1524,7 +1575,11 @@ func SeedFixtures(m int, n int) [][]byte {
 }
 
 // BlockEventsFixture returns a block events model populated with random events of length n.
-func BlockEventsFixture(header *flow.Header, n int, types ...flow.EventType) flow.BlockEvents {
+func BlockEventsFixture(
+	header *flow.Header,
+	n int,
+	types ...flow.EventType,
+) flow.BlockEvents {
 	if len(types) == 0 {
 		types = []flow.EventType{"A.0x1.Foo.Bar", "A.0x2.Zoo.Moo", "A.0x3.Goo.Hoo"}
 	}
@@ -1543,7 +1598,13 @@ func BlockEventsFixture(header *flow.Header, n int, types ...flow.EventType) flo
 }
 
 // EventFixture returns an event
-func EventFixture(eType flow.EventType, transactionIndex uint32, eventIndex uint32, txID flow.Identifier, _ int) flow.Event {
+func EventFixture(
+	eType flow.EventType,
+	transactionIndex uint32,
+	eventIndex uint32,
+	txID flow.Identifier,
+	_ int,
+) flow.Event {
 	return flow.Event{
 		Type:             eType,
 		TransactionIndex: transactionIndex,
@@ -1608,7 +1669,10 @@ func BatchListFixture(n int) []chainsync.Batch {
 	return batches
 }
 
-func BootstrapExecutionResultFixture(block *flow.Block, commit flow.StateCommitment) *flow.ExecutionResult {
+func BootstrapExecutionResultFixture(
+	block *flow.Block,
+	commit flow.StateCommitment,
+) *flow.ExecutionResult {
 	result := &flow.ExecutionResult{
 		BlockID:          block.ID(),
 		PreviousResultID: flow.ZeroID,
@@ -1655,7 +1719,10 @@ func QuorumCertificateWithSignerIDsFixture(opts ...func(*flow.QuorumCertificateW
 	return &qc
 }
 
-func QuorumCertificatesWithSignerIDsFixtures(n uint, opts ...func(*flow.QuorumCertificateWithSignerIDs)) []*flow.QuorumCertificateWithSignerIDs {
+func QuorumCertificatesWithSignerIDsFixtures(
+	n uint,
+	opts ...func(*flow.QuorumCertificateWithSignerIDs),
+) []*flow.QuorumCertificateWithSignerIDs {
 	qcs := make([]*flow.QuorumCertificateWithSignerIDs, 0, n)
 	for i := 0; i < int(n); i++ {
 		qcs = append(qcs, QuorumCertificateWithSignerIDsFixture(opts...))
@@ -1695,7 +1762,10 @@ func CertifyBlock(header *flow.Header) *flow.QuorumCertificate {
 	return qc
 }
 
-func QuorumCertificatesFixtures(n uint, opts ...func(*flow.QuorumCertificate)) []*flow.QuorumCertificate {
+func QuorumCertificatesFixtures(
+	n uint,
+	opts ...func(*flow.QuorumCertificate),
+) []*flow.QuorumCertificate {
 	qcs := make([]*flow.QuorumCertificate, 0, n)
 	for i := 0; i < int(n); i++ {
 		qcs = append(qcs, QuorumCertificateFixture(opts...))
@@ -1755,7 +1825,10 @@ func WithVoteBlockID(blockID flow.Identifier) func(*hotstuff.Vote) {
 	}
 }
 
-func VoteForBlockFixture(block *hotstuff.Block, opts ...func(vote *hotstuff.Vote)) *hotstuff.Vote {
+func VoteForBlockFixture(
+	block *hotstuff.Block,
+	opts ...func(vote *hotstuff.Vote),
+) *hotstuff.Vote {
 	vote := VoteFixture(WithVoteView(block.View),
 		WithVoteBlockID(block.BlockID))
 
@@ -1901,9 +1974,25 @@ func EpochCommitFixture(opts ...func(*flow.EpochCommit)) *flow.EpochCommit {
 	return commit
 }
 
+func VersionBeaconFixture() *flow.VersionBeacon {
+	versionTable := &flow.VersionBeacon{
+		VersionBoundaries: []flow.VersionBoundary{
+			{
+				Version: "0.0.0",
+			},
+		},
+		Sequence: uint64(0),
+	}
+
+	return versionTable
+}
+
 // BootstrapFixture generates all the artifacts necessary to bootstrap the
 // protocol state.
-func BootstrapFixture(participants flow.IdentityList, opts ...func(*flow.Block)) (*flow.Block, *flow.ExecutionResult, *flow.Seal) {
+func BootstrapFixture(
+	participants flow.IdentityList,
+	opts ...func(*flow.Block),
+) (*flow.Block, *flow.ExecutionResult, *flow.Seal) {
 
 	root := GenesisFixture()
 	for _, apply := range opts {
@@ -1924,7 +2013,10 @@ func BootstrapFixture(participants flow.IdentityList, opts ...func(*flow.Block))
 	)
 
 	result := BootstrapExecutionResultFixture(root, GenesisStateCommitment)
-	result.ServiceEvents = []flow.ServiceEvent{setup.ServiceEvent(), commit.ServiceEvent()}
+	result.ServiceEvents = []flow.ServiceEvent{
+		setup.ServiceEvent(),
+		commit.ServiceEvent(),
+	}
 
 	seal := Seal.Fixture(Seal.WithResult(result))
 
@@ -1933,7 +2025,10 @@ func BootstrapFixture(participants flow.IdentityList, opts ...func(*flow.Block))
 
 // RootSnapshotFixture returns a snapshot representing a root chain state, for
 // example one as returned from BootstrapFixture.
-func RootSnapshotFixture(participants flow.IdentityList, opts ...func(*flow.Block)) *inmem.Snapshot {
+func RootSnapshotFixture(
+	participants flow.IdentityList,
+	opts ...func(*flow.Block),
+) *inmem.Snapshot {
 	block, result, seal := BootstrapFixture(participants.Sort(order.Canonical), opts...)
 	qc := QuorumCertificateFixture(QCWithRootBlockID(block.ID()))
 	root, err := inmem.SnapshotFromBootstrapState(block, result, seal, qc)
@@ -1943,7 +2038,10 @@ func RootSnapshotFixture(participants flow.IdentityList, opts ...func(*flow.Bloc
 	return root
 }
 
-func SnapshotClusterByIndex(snapshot *inmem.Snapshot, clusterIndex uint) (protocol.Cluster, error) {
+func SnapshotClusterByIndex(
+	snapshot *inmem.Snapshot,
+	clusterIndex uint,
+) (protocol.Cluster, error) {
 	epochs := snapshot.Epochs()
 	epoch := epochs.Current()
 	cluster, err := epoch.Cluster(clusterIndex)
@@ -1954,7 +2052,11 @@ func SnapshotClusterByIndex(snapshot *inmem.Snapshot, clusterIndex uint) (protoc
 }
 
 // ChainFixture creates a list of blocks that forms a chain
-func ChainFixture(nonGenesisCount int) ([]*flow.Block, *flow.ExecutionResult, *flow.Seal) {
+func ChainFixture(nonGenesisCount int) (
+	[]*flow.Block,
+	*flow.ExecutionResult,
+	*flow.Seal,
+) {
 	chain := make([]*flow.Block, 0, nonGenesisCount+1)
 
 	participants := IdentityListFixture(5, WithAllRoles())
@@ -1980,7 +2082,10 @@ func ChainFixtureFrom(count int, parent *flow.Header) []*flow.Block {
 	return blocks
 }
 
-func ReceiptChainFor(blocks []*flow.Block, result0 *flow.ExecutionResult) []*flow.ExecutionReceipt {
+func ReceiptChainFor(
+	blocks []*flow.Block,
+	result0 *flow.ExecutionResult,
+) []*flow.ExecutionReceipt {
 	receipts := make([]*flow.ExecutionReceipt, len(blocks))
 	receipts[0] = ExecutionReceiptFixture(WithResult(result0))
 	receipts[0].ExecutionResult.BlockID = blocks[0].ID()
@@ -2058,7 +2163,11 @@ func PrivateKeyFixture(algo crypto.SigningAlgorithm, seedLength int) crypto.Priv
 
 // PrivateKeyFixtureByIdentifier returns a private key for a given node.
 // given the same identifier, it will always return the same private key
-func PrivateKeyFixtureByIdentifier(algo crypto.SigningAlgorithm, seedLength int, id flow.Identifier) crypto.PrivateKey {
+func PrivateKeyFixtureByIdentifier(
+	algo crypto.SigningAlgorithm,
+	seedLength int,
+	id flow.Identifier,
+) crypto.PrivateKey {
 	seed := append(id[:], id[:]...)
 	sk, err := crypto.GeneratePrivateKey(algo, seed[:seedLength])
 	if err != nil {
@@ -2091,7 +2200,10 @@ func NodeMachineAccountInfoFixture() bootstrap.NodeMachineAccountInfo {
 	}
 }
 
-func MachineAccountFixture(t *testing.T) (bootstrap.NodeMachineAccountInfo, *sdk.Account) {
+func MachineAccountFixture(t *testing.T) (
+	bootstrap.NodeMachineAccountInfo,
+	*sdk.Account,
+) {
 	info := NodeMachineAccountInfoFixture()
 
 	bal, err := cadence.NewUFix64("0.5")
@@ -2179,7 +2291,11 @@ func EngineMessageFixtures(count int) []*engine.Message {
 }
 
 // GetFlowProtocolEventID returns the event ID for the event provided.
-func GetFlowProtocolEventID(t *testing.T, channel channels.Channel, event interface{}) flow.Identifier {
+func GetFlowProtocolEventID(
+	t *testing.T,
+	channel channels.Channel,
+	event interface{},
+) flow.Identifier {
 	payload, err := NetworkCodec().Encode(event)
 	require.NoError(t, err)
 	eventIDHash, err := network.EventId(channel, payload)


### PR DESCRIPTION
Continuing to dissect this PR https://github.com/onflow/flow-go/pull/3736 into smaller chunks.

This just adds the service event model and tests. 

I changed the equal to tests and some naming and comments from the original in the #3736 PR.