### PR TITLE
backport of Forks2 to v0.30

### DIFF
--- a/consensus/hotstuff/forks/blockQC.go
+++ b/consensus/hotstuff/forks/blockQC.go
@@ -1,1 +1,0 @@
-package forks

--- a/consensus/hotstuff/forks/block_builder_test.go
+++ b/consensus/hotstuff/forks/block_builder_test.go
@@ -42,51 +42,54 @@ func NewBlockBuilder() *BlockBuilder {
 	}
 }
 
-// Add adds a block with the given qcView and blockView.
-func (f *BlockBuilder) Add(qcView uint64, blockView uint64) {
-	f.blockViews = append(f.blockViews, &BlockView{
+// Add adds a block with the given qcView and blockView. Returns self-reference for chaining.
+func (bb *BlockBuilder) Add(qcView uint64, blockView uint64) *BlockBuilder {
+	bb.blockViews = append(bb.blockViews, &BlockView{
 		View:   blockView,
 		QCView: qcView,
 	})
+	return bb
 }
 
 // GenesisBlock returns the genesis block, which is always finalized.
-func (f *BlockBuilder) GenesisBlock() *model.Block {
-	return makeGenesis().Block
+func (bb *BlockBuilder) GenesisBlock() *model.CertifiedBlock {
+	return makeGenesis()
 }
 
 // AddVersioned adds a block with the given qcView and blockView.
-// In addition the version identifier of the QC embedded within the block
+// In addition, the version identifier of the QC embedded within the block
 // is specified by `qcVersion`. The version identifier for the block itself
 // (primarily for emulating different payloads) is specified by `blockVersion`.
-// [3,4] denotes a block of view 4, with a qc of view 3
-// [3,4'] denotes a block of view 4, with a qc of view 3, but has a different BlockID than [3,4]
-// [3,4'] can be created by AddVersioned(3, 4, 0, 1)
-// [3',4] can be created by AddVersioned(3, 4, 1, 0)
-func (f *BlockBuilder) AddVersioned(qcView uint64, blockView uint64, qcVersion int, blockVersion int) {
-	f.blockViews = append(f.blockViews, &BlockView{
+// [(◄3) 4] denotes a block of view 4, with a qc for view 3
+// [(◄3) 4'] denotes a block of view 4 that is different than [(◄3) 4], with a qc for view 3
+// [(◄3) 4'] can be created by AddVersioned(3, 4, 0, 1)
+// [(◄3') 4] can be created by AddVersioned(3, 4, 1, 0)
+// Returns self-reference for chaining.
+func (bb *BlockBuilder) AddVersioned(qcView uint64, blockView uint64, qcVersion int, blockVersion int) *BlockBuilder {
+	bb.blockViews = append(bb.blockViews, &BlockView{
 		View:         blockView,
 		QCView:       qcView,
 		BlockVersion: blockVersion,
 		QCVersion:    qcVersion,
 	})
+	return bb
 }
 
 // Blocks returns a list of all blocks added to the BlockBuilder.
 // Returns an error if the blocks do not form a connected tree rooted at genesis.
-func (f *BlockBuilder) Blocks() ([]*model.Proposal, error) {
-	blocks := make([]*model.Proposal, 0, len(f.blockViews))
+func (bb *BlockBuilder) Blocks() ([]*model.Proposal, error) {
+	blocks := make([]*model.Proposal, 0, len(bb.blockViews))
 
-	genesisBQ := makeGenesis()
+	genesisBlock := makeGenesis()
 	genesisBV := &BlockView{
-		View:   genesisBQ.Block.View,
-		QCView: genesisBQ.QC.View,
+		View:   genesisBlock.Block.View,
+		QCView: genesisBlock.CertifyingQC.View,
 	}
 
 	qcs := make(map[string]*flow.QuorumCertificate)
-	qcs[genesisBV.QCIndex()] = genesisBQ.QC
+	qcs[genesisBV.QCIndex()] = genesisBlock.CertifyingQC
 
-	for _, bv := range f.blockViews {
+	for _, bv := range bb.blockViews {
 		qc, ok := qcs[bv.QCIndex()]
 		if !ok {
 			return nil, fmt.Errorf("test fail: no qc found for qc index: %v", bv.QCIndex())
@@ -145,6 +148,7 @@ func makeBlockID(block *model.Block) flow.Identifier {
 	})
 }
 
+// constructs the genesis block (identical for all calls)
 func makeGenesis() *model.CertifiedBlock {
 	genesis := &model.Block{
 		View: 1,

--- a/consensus/hotstuff/forks/blockcontainer.go
+++ b/consensus/hotstuff/forks/blockcontainer.go
@@ -21,3 +21,17 @@ func (b *BlockContainer) Level() uint64             { return b.Proposal.Block.Vi
 func (b *BlockContainer) Parent() (flow.Identifier, uint64) {
 	return b.Proposal.Block.QC.BlockID, b.Proposal.Block.QC.View
 }
+
+// BlockContainer wraps a block proposal to implement forest.Vertex
+// so the proposal can be stored in forest.LevelledForest
+type BlockContainer2 model.Block
+
+var _ forest.Vertex = (*BlockContainer2)(nil)
+
+func ToBlockContainer2(block *model.Block) *BlockContainer2 { return (*BlockContainer2)(block) }
+func (b *BlockContainer2) Block() *model.Block              { return (*model.Block)(b) }
+
+// Functions implementing forest.Vertex
+func (b *BlockContainer2) VertexID() flow.Identifier         { return b.BlockID }
+func (b *BlockContainer2) Level() uint64                     { return b.View }
+func (b *BlockContainer2) Parent() (flow.Identifier, uint64) { return b.QC.BlockID, b.QC.View }

--- a/consensus/hotstuff/forks/forks.go
+++ b/consensus/hotstuff/forks/forks.go
@@ -47,7 +47,7 @@ type Forks struct {
 var _ hotstuff.Forks = (*Forks)(nil)
 
 func New(trustedRoot *model.CertifiedBlock, finalizationCallback module.Finalizer, notifier hotstuff.FinalizationConsumer) (*Forks, error) {
-	if (trustedRoot.Block.BlockID != trustedRoot.QC.BlockID) || (trustedRoot.Block.View != trustedRoot.QC.View) {
+	if (trustedRoot.Block.BlockID != trustedRoot.CertifyingQC.BlockID) || (trustedRoot.Block.View != trustedRoot.CertifyingQC.View) {
 		return nil, model.NewConfigurationErrorf("invalid root: root QC is not pointing to root block")
 	}
 
@@ -307,7 +307,7 @@ func (f *Forks) updateFinalizedBlockQC(blockContainer *BlockContainer) error {
 	if ancestryChain.oneChain.Block.View != b.Block.View+1 {
 		return nil
 	}
-	return f.finalizeUpToBlock(b.QC)
+	return f.finalizeUpToBlock(b.CertifyingQC)
 }
 
 // getTwoChain returns the 2-chain for the input block container b.

--- a/consensus/hotstuff/forks/forks2.go
+++ b/consensus/hotstuff/forks/forks2.go
@@ -1,0 +1,518 @@
+package forks
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/consensus/hotstuff"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/forest"
+)
+
+// FinalityProof represents a finality proof for a Block. By convention, a FinalityProof
+// is immutable. Finality in Jolteon/HotStuff is determined by the 2-chain rule:
+//
+//	There exists a _certified_ block C, such that Block.View + 1 = C.View
+type FinalityProof struct {
+	Block          *model.Block
+	CertifiedChild model.CertifiedBlock
+}
+
+// Forks enforces structural validity of the consensus state and implements
+// finalization rules as defined in Jolteon consensus https://arxiv.org/abs/2106.10362
+// The same approach has later been adopted by the Diem team resulting in DiemBFT v4:
+// https://developers.diem.com/papers/diem-consensus-state-machine-replication-in-the-diem-blockchain/2021-08-17.pdf
+// Forks is NOT safe for concurrent use by multiple goroutines.
+type Forks2 struct {
+	finalizationCallback module.Finalizer
+	notifier             hotstuff.FinalizationConsumer
+	forest               forest.LevelledForest
+	trustedRoot          *model.CertifiedBlock
+
+	// finalityProof holds the latest finalized block including the certified child as proof of finality.
+	// CAUTION: is nil, when Forks has not yet finalized any blocks beyond the finalized root block it was initialized with
+	finalityProof *FinalityProof
+}
+
+// TODO:
+//  • update `hotstuff.Forks` interface to represent Forks2
+//  • update business logic to of consensus participant and follower to use Forks2
+// As the result, the following should apply again
+// var _ hotstuff.Forks = (*Forks2)(nil)
+
+func NewForks2(trustedRoot *model.CertifiedBlock, finalizationCallback module.Finalizer, notifier hotstuff.FinalizationConsumer) (*Forks2, error) {
+	if (trustedRoot.Block.BlockID != trustedRoot.CertifyingQC.BlockID) || (trustedRoot.Block.View != trustedRoot.CertifyingQC.View) {
+		return nil, model.NewConfigurationErrorf("invalid root: root QC is not pointing to root block")
+	}
+
+	forks := Forks2{
+		finalizationCallback: finalizationCallback,
+		notifier:             notifier,
+		forest:               *forest.NewLevelledForest(trustedRoot.Block.View),
+		trustedRoot:          trustedRoot,
+		finalityProof:        nil,
+	}
+
+	// verify and add root block to levelled forest
+	err := forks.EnsureBlockIsValidExtension(trustedRoot.Block)
+	if err != nil {
+		return nil, fmt.Errorf("invalid root block %v: %w", trustedRoot.ID(), err)
+	}
+	forks.forest.AddVertex(ToBlockContainer2(trustedRoot.Block))
+	return &forks, nil
+}
+
+// FinalizedView returns the largest view number that has been finalized so far
+func (f *Forks2) FinalizedView() uint64 {
+	if f.finalityProof == nil {
+		return f.trustedRoot.Block.View
+	}
+	return f.finalityProof.Block.View
+}
+
+// FinalizedBlock returns the finalized block with the largest view number
+func (f *Forks2) FinalizedBlock() *model.Block {
+	if f.finalityProof == nil {
+		return f.trustedRoot.Block
+	}
+	return f.finalityProof.Block
+}
+
+// FinalityProof returns the latest finalized block and a certified child from
+// the subsequent view, which proves finality.
+// CAUTION: method returns (nil, false), when Forks has not yet finalized any
+// blocks beyond the finalized root block it was initialized with.
+func (f *Forks2) FinalityProof() (*FinalityProof, bool) {
+	return f.finalityProof, f.finalityProof != nil
+}
+
+// GetBlock returns block for given ID
+func (f *Forks2) GetBlock(blockID flow.Identifier) (*model.Block, bool) {
+	blockContainer, hasBlock := f.forest.GetVertex(blockID)
+	if !hasBlock {
+		return nil, false
+	}
+	return blockContainer.(*BlockContainer2).Block(), true
+}
+
+// GetBlocksForView returns all known blocks for the given view
+func (f *Forks2) GetBlocksForView(view uint64) []*model.Block {
+	vertexIterator := f.forest.GetVerticesAtLevel(view)
+	blocks := make([]*model.Block, 0, 1) // in the vast majority of cases, there will only be one proposal for a particular view
+	for vertexIterator.HasNext() {
+		v := vertexIterator.NextVertex()
+		blocks = append(blocks, v.(*BlockContainer2).Block())
+	}
+	return blocks
+}
+
+// IsKnownBlock checks whether block is known.
+func (f *Forks2) IsKnownBlock(blockID flow.Identifier) bool {
+	_, hasBlock := f.forest.GetVertex(blockID)
+	return hasBlock
+}
+
+// IsProcessingNeeded determines whether the given block needs processing,
+// based on the block's view and hash.
+// Returns false if any of the following conditions applies
+//   - block view is _below_ the most recently finalized block
+//   - the block already exists in the consensus state
+//
+// UNVALIDATED: expects block to pass Forks.EnsureBlockIsValidExtension(block)
+func (f *Forks2) IsProcessingNeeded(block *model.Block) bool {
+	if block.View < f.FinalizedView() || f.IsKnownBlock(block.BlockID) {
+		return false
+	}
+	return true
+}
+
+// EnsureBlockIsValidExtension checks that the given block is a valid extension to the tree
+// of blocks already stored (no state modifications). Specifically, the following conditions
+// are enforced, which are critical to the correctness of Forks:
+//
+//  1. If a block with the same ID is already stored, their views must be identical.
+//  2. The block's view must be strictly larger than the view of its parent.
+//  3. The parent must already be stored (or below the pruning height).
+//
+// Exclusions to these rules (by design):
+// Let W denote the view of block's parent (i.e. W := block.QC.View) and F the latest
+// finalized view.
+//
+//	  (i) If block.View < F, adding the block would be a no-op. Such blocks are considered
+//	      compatible (principle of vacuous truth), i.e. we skip checking 1, 2, 3.
+//	 (ii) If block.View == F, we do not inspect the QC / parent at all (skip 2 and 3).
+//	      This exception is important for compatability with genesis or spork-root blocks,
+//	      which do not contain a QC.
+//	(iii) If block.View > F, but block.QC.View < F the parent has already been pruned. In
+//	      this case, we omit rule 3. (principle of vacuous truth applied to the parent)
+//
+// We assume that all blocks are fully verified. A valid block must satisfy all consistency
+// requirements; otherwise we have a bug in the compliance layer.
+//
+// Error returns:
+//   - model.MissingBlockError if the parent of the input proposal does not exist in the
+//     forest (but is above the pruned view). Represents violation of condition 3.
+//   - model.InvalidBlockError if the block violates condition 1. or 2.
+//   - generic error in case of unexpected bug or internal state corruption
+func (f *Forks2) EnsureBlockIsValidExtension(block *model.Block) error {
+	if block.View < f.forest.LowestLevel { // exclusion (i)
+		return nil
+	}
+
+	// LevelledForest enforces conditions 1. and 2. including the respective exclusions (ii) and (iii).
+	blockContainer := ToBlockContainer2(block)
+	err := f.forest.VerifyVertex(blockContainer)
+	if err != nil {
+		if forest.IsInvalidVertexError(err) {
+			return model.NewInvalidBlockError(block.BlockID, block.View, fmt.Errorf("not a valid vertex for block tree: %w", err))
+		}
+		return fmt.Errorf("block tree generated unexpected error validating vertex: %w", err)
+	}
+
+	// Condition 3:
+	// LevelledForest implements a more generalized algorithm that also works for disjoint graphs.
+	// Therefore, LevelledForest _not_ enforce condition 3. Here, we additionally require that the
+	// pending blocks form a tree (connected graph), i.e. we need to enforce condition 3
+	if (block.View == f.forest.LowestLevel) || (block.QC.View < f.forest.LowestLevel) { // exclusion (ii) and (iii)
+		return nil
+	}
+	// For a block whose parent is _not_ below the pruning height, we expect the parent to be known.
+	if _, isParentKnown := f.forest.GetVertex(block.QC.BlockID); !isParentKnown { // missing parent
+		return model.MissingBlockError{
+			View:    block.QC.View,
+			BlockID: block.QC.BlockID,
+		}
+	}
+	return nil
+}
+
+// AddCertifiedBlock appends the given certified block to the tree of pending
+// blocks and updates the latest finalized block (if finalization progressed).
+// Unless the parent is below the pruning threshold (latest finalized view), we
+// require that the parent is already stored in Forks.
+//
+// Possible error returns:
+//   - model.MissingBlockError if the parent does not exist in the forest (but is above
+//     the pruned view). From the perspective of Forks, this error is benign (no-op).
+//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+//     for details). From the perspective of Forks, this error is benign (no-op). However, we
+//     assume all blocks are fully verified, i.e. they should satisfy all consistency
+//     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.
+//   - model.ByzantineThresholdExceededError if conflicting QCs or conflicting finalized
+//     blocks have been detected (violating a foundational consensus guarantees). This
+//     indicates that there are 1/3+ Byzantine nodes (weighted by stake) in the network,
+//     breaking the safety guarantees of HotStuff (or there is a critical bug / data
+//     corruption). Forks cannot recover from this exception.
+//   - All other errors are potential symptoms of bugs or state corruption.
+func (f *Forks2) AddCertifiedBlock(certifiedBlock *model.CertifiedBlock) error {
+	if !f.IsProcessingNeeded(certifiedBlock.Block) {
+		return nil
+	}
+
+	// Check proposal for byzantine evidence, store it and emit `OnBlockIncorporated` notification.
+	// Note: `checkForByzantineEvidence` only inspects the block, but _not_ its certifying QC. Hence,
+	// we have to additionally check here, whether the certifying QC conflicts with any known QCs.
+	err := f.checkForByzantineEvidence(certifiedBlock.Block)
+	if err != nil {
+		return fmt.Errorf("cannot check for Byzantine evidence in certified block %v: %w", certifiedBlock.Block.BlockID, err)
+	}
+	err = f.checkForConflictingQCs(certifiedBlock.CertifyingQC)
+	if err != nil {
+		return fmt.Errorf("certifying QC for block %v failed check for conflicts: %w", certifiedBlock.Block.BlockID, err)
+	}
+	f.forest.AddVertex(ToBlockContainer2(certifiedBlock.Block))
+	f.notifier.OnBlockIncorporated(certifiedBlock.Block)
+
+	// Update finality status:
+	err = f.checkForAdvancingFinalization(certifiedBlock)
+	if err != nil {
+		return fmt.Errorf("updating finalization failed: %w", err)
+	}
+	return nil
+}
+
+// AddProposal appends the given block to the tree of pending
+// blocks and updates the latest finalized block (if applicable). Unless the parent is
+// below the pruning threshold (latest finalized view), we require that the parent is
+// already stored in Forks. Calling this method with previously processed blocks
+// leaves the consensus state invariant (though, it will potentially cause some
+// duplicate processing).
+// Notes:
+//   - Method `AddCertifiedBlock(..)` should be used preferably, if a QC certifying
+//     `block` is already known. This is generally the case for the consensus follower.
+//     Method `AddProposal` is intended for active consensus participants, which fully
+//     validate blocks (incl. payload), i.e. QCs are processed as part of validated proposals.
+//
+// Possible error returns:
+//   - model.MissingBlockError if the parent does not exist in the forest (but is above
+//     the pruned view). From the perspective of Forks, this error is benign (no-op).
+//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+//     for details). From the perspective of Forks, this error is benign (no-op). However, we
+//     assume all blocks are fully verified, i.e. they should satisfy all consistency
+//     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.
+//   - model.ByzantineThresholdExceededError if conflicting QCs or conflicting finalized
+//     blocks have been detected (violating a foundational consensus guarantees). This
+//     indicates that there are 1/3+ Byzantine nodes (weighted by stake) in the network,
+//     breaking the safety guarantees of HotStuff (or there is a critical bug / data
+//     corruption). Forks cannot recover from this exception.
+//   - All other errors are potential symptoms of bugs or state corruption.
+func (f *Forks2) AddProposal(proposal *model.Block) error {
+	if !f.IsProcessingNeeded(proposal) {
+		return nil
+	}
+
+	// Check proposal for byzantine evidence, store it and emit `OnBlockIncorporated` notification:
+	err := f.checkForByzantineEvidence(proposal)
+	if err != nil {
+		return fmt.Errorf("cannot check Byzantine evidence for block %v: %w", proposal.BlockID, err)
+	}
+	f.forest.AddVertex(ToBlockContainer2(proposal))
+	f.notifier.OnBlockIncorporated(proposal)
+
+	// Update finality status: In the implementation, our notion of finality is based on certified blocks.
+	// The certified parent essentially combines the parent, with the QC contained in block, to drive finalization.
+	parent, found := f.GetBlock(proposal.QC.BlockID)
+	if !found {
+		// Not finding the parent means it is already pruned; hence this block does not change the finalization state.
+		return nil
+	}
+	certifiedParent, err := model.NewCertifiedBlock(parent, proposal.QC)
+	if err != nil {
+		return fmt.Errorf("mismatching QC with parent (corrupted Forks state):%w", err)
+	}
+	err = f.checkForAdvancingFinalization(&certifiedParent)
+	if err != nil {
+		return fmt.Errorf("updating finalization failed: %w", err)
+	}
+	return nil
+}
+
+// checkForByzantineEvidence inspects whether the given `block` together with the already
+// known information yields evidence of byzantine behaviour. Furthermore, the method enforces
+// that `block` is a valid extension of the tree of pending blocks. If the block is a double
+// proposal, we emit an `OnBlockIncorporated` notification. Though, provided the block is a
+// valid extension of the block tree by itself, it passes this method without an error.
+//
+// Possible error returns:
+//   - model.MissingBlockError if the parent does not exist in the forest (but is above
+//     the pruned view). From the perspective of Forks, this error is benign (no-op).
+//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+//     for details). From the perspective of Forks, this error is benign (no-op). However, we
+//     assume all blocks are fully verified, i.e. they should satisfy all consistency
+//     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.
+//   - model.ByzantineThresholdExceededError if conflicting QCs have been detected.
+//     Forks cannot recover from this exception.
+//   - All other errors are potential symptoms of bugs or state corruption.
+func (f *Forks2) checkForByzantineEvidence(block *model.Block) error {
+	err := f.EnsureBlockIsValidExtension(block)
+	if err != nil {
+		return fmt.Errorf("consistency check on block failed: %w", err)
+	}
+	err = f.checkForConflictingQCs(block.QC)
+	if err != nil {
+		return fmt.Errorf("checking QC for conflicts failed: %w", err)
+	}
+	f.checkForDoubleProposal(block)
+	return nil
+}
+
+// checkForConflictingQCs checks if QC conflicts with a stored Quorum Certificate.
+// In case a conflicting QC is found, an ByzantineThresholdExceededError is returned.
+// Two Quorum Certificates q1 and q2 are defined as conflicting iff:
+//
+//	q1.View == q2.View AND q1.BlockID ≠ q2.BlockID
+//
+// This means there are two Quorums for conflicting blocks at the same view.
+// Per 'Observation 1' from the Jolteon paper https://arxiv.org/pdf/2106.10362v1.pdf,
+// two conflicting QCs can exist if and only if the Byzantine threshold is exceeded.
+// Error returns:
+//   - model.ByzantineThresholdExceededError if conflicting QCs have been detected.
+//     Forks cannot recover from this exception.
+//   - All other errors are potential symptoms of bugs or state corruption.
+func (f *Forks2) checkForConflictingQCs(qc *flow.QuorumCertificate) error {
+	it := f.forest.GetVerticesAtLevel(qc.View)
+	for it.HasNext() {
+		otherBlock := it.NextVertex() // by construction, must have same view as qc.View
+		if qc.BlockID != otherBlock.VertexID() {
+			// * we have just found another block at the same view number as qc.View but with different hash
+			// * if this block has a child c, this child will have
+			//   c.qc.view = parentView
+			//   c.qc.ID != parentBlockID
+			// => conflicting qc
+			otherChildren := f.forest.GetChildren(otherBlock.VertexID())
+			if otherChildren.HasNext() {
+				otherChild := otherChildren.NextVertex().(*BlockContainer2).Block()
+				conflictingQC := otherChild.QC
+				return model.ByzantineThresholdExceededError{Evidence: fmt.Sprintf(
+					"conflicting QCs at view %d: %v and %v",
+					qc.View, qc.BlockID, conflictingQC.BlockID,
+				)}
+			}
+		}
+	}
+	return nil
+}
+
+// checkForDoubleProposal checks if the input proposal is a double proposal.
+// A double proposal occurs when two proposals with the same view exist in Forks.
+// If there is a double proposal, notifier.OnDoubleProposeDetected is triggered.
+func (f *Forks2) checkForDoubleProposal(block *model.Block) {
+	it := f.forest.GetVerticesAtLevel(block.View)
+	for it.HasNext() {
+		otherVertex := it.NextVertex() // by construction, must have same view as block
+		otherBlock := otherVertex.(*BlockContainer2).Block()
+		if block.BlockID != otherBlock.BlockID {
+			f.notifier.OnDoubleProposeDetected(block, otherBlock)
+		}
+	}
+}
+
+// checkForAdvancingFinalization checks whether observing certifiedBlock leads to progress of
+// finalization. This function should be called every time a new block is added to Forks. If the new
+// block is the head of a 2-chain satisfying the finalization rule, we update `Forks.finalityProof` to
+// the new latest finalized block. Calling this method with previously-processed blocks leaves the
+// consensus state invariant.
+// UNVALIDATED: assumes that relevant block properties are consistent with previous blocks
+// Error returns:
+//   - model.MissingBlockError if the parent does not exist in the forest (but is above
+//     the pruned view). From the perspective of Forks, this error is benign (no-op).
+//   - model.ByzantineThresholdExceededError in case we detect a finalization fork (violating
+//     a foundational consensus guarantee). This indicates that there are 1/3+ Byzantine nodes
+//     (weighted by stake) in the network, breaking the safety guarantees of HotStuff (or there
+//     is a critical bug / data corruption). Forks cannot recover from this exception.
+//   - generic error in case of unexpected bug or internal state corruption
+func (f *Forks2) checkForAdvancingFinalization(certifiedBlock *model.CertifiedBlock) error {
+	// We prune all blocks in forest which are below the most recently finalized block.
+	// Hence, we have a pruned ancestry if and only if either of the following conditions applies:
+	//    (a) If a block's parent view (i.e. block.QC.View) is below the most recently finalized block.
+	//    (b) If a block's view is equal to the most recently finalized block.
+	// Caution:
+	// * Under normal operation, case (b) is covered by the logic for case (a)
+	// * However, the existence of a genesis block requires handling case (b) explicitly:
+	//   The root block is specified and trusted by the node operator. If the root block is the
+	//   genesis block, it might not contain a QC pointing to a parent (as there is no parent).
+	//   In this case, condition (a) cannot be evaluated.
+	lastFinalizedView := f.FinalizedView()
+	if (certifiedBlock.View() <= lastFinalizedView) || (certifiedBlock.Block.QC.View < lastFinalizedView) {
+		// Repeated blocks are expected during normal operations. We enter this code block if and only
+		// if the parent's view is _below_ the last finalized block. It is straight forward to show:
+		// Lemma: Let B be a block whose 2-chain reaches beyond the last finalized block
+		//        => B will not update the locked or finalized block
+		return nil
+	}
+
+	// retrieve parent; always expected to succeed, because we passed the checks above
+	qcForParent := certifiedBlock.Block.QC
+	parentVertex, parentBlockKnown := f.forest.GetVertex(qcForParent.BlockID)
+	if !parentBlockKnown {
+		return model.MissingBlockError{View: qcForParent.View, BlockID: qcForParent.BlockID}
+	}
+	parentBlock := parentVertex.(*BlockContainer2).Block()
+
+	// Note: we assume that all stored blocks pass Forks.EnsureBlockIsValidExtension(block);
+	//       specifically, that Proposal's ViewNumber is strictly monotonically
+	//       increasing which is enforced by LevelledForest.VerifyVertex(...)
+	// We denote:
+	//  * a DIRECT 1-chain as '<-'
+	//  * a general 1-chain as '<~' (direct or indirect)
+	// Jolteon's rule for finalizing `parentBlock` is
+	//     parentBlock <- Block <~ certifyingQC    (i.e. a DIRECT 1-chain PLUS any 1-chain)
+	//                   ╰─────────────────────╯
+	//                       certifiedBlock
+	// Hence, we can finalize `parentBlock` as head of a 2-chain,
+	// if and only if `Block.View` is exactly 1 higher than the view of `parentBlock`
+	if parentBlock.View+1 != certifiedBlock.View() {
+		return nil
+	}
+
+	// `parentBlock` is now finalized:
+	//  * While Forks is single-threaded, there is still the possibility of reentrancy. Specifically, the
+	//    consumers of our finalization events are served by the goroutine executing Forks. It is conceivable
+	//    that a consumer might access Forks and query the latest finalization proof. This would be legal, if
+	//    the component supplying the goroutine to Forks also consumes the notifications.
+	//  * Therefore, for API safety, we want to first update Fork's `finalityProof` before we emit any notifications.
+
+	// Advancing finalization step (i): we collect all blocks for finalization (no notifications are emitted)
+	blocksToBeFinalized, err := f.collectBlocksForFinalization(qcForParent)
+	if err != nil {
+		return fmt.Errorf("advancing finalization to block %v from view %d failed: %w", qcForParent.BlockID, qcForParent.View, err)
+	}
+
+	// Advancing finalization step (ii): update `finalityProof` and prune `LevelledForest`
+	f.finalityProof = &FinalityProof{Block: parentBlock, CertifiedChild: *certifiedBlock}
+	err = f.forest.PruneUpToLevel(f.FinalizedView())
+	if err != nil {
+		return fmt.Errorf("pruning levelled forest failed unexpectedly: %w", err)
+	}
+
+	// Advancing finalization step (iii): iterate over the blocks from (i) and emit finalization events
+	for _, b := range blocksToBeFinalized {
+		// first notify other critical components about finalized block - all errors returned here are fatal exceptions
+		err = f.finalizationCallback.MakeFinal(b.BlockID)
+		if err != nil {
+			return fmt.Errorf("finalization error in other component: %w", err)
+		}
+
+		// notify less important components about finalized block
+		f.notifier.OnFinalizedBlock(b)
+	}
+	return nil
+}
+
+// collectBlocksForFinalization collects and returns all newly finalized blocks up to (and including)
+// the block pointed to by `qc`. The blocks are listed in order of increasing height.
+// Error returns:
+//   - model.ByzantineThresholdExceededError in case we detect a finalization fork (violating
+//     a foundational consensus guarantee). This indicates that there are 1/3+ Byzantine nodes
+//     (weighted by stake) in the network, breaking the safety guarantees of HotStuff (or there
+//     is a critical bug / data corruption). Forks cannot recover from this exception.
+//   - generic error in case of bug or internal state corruption
+func (f *Forks2) collectBlocksForFinalization(qc *flow.QuorumCertificate) ([]*model.Block, error) {
+	lastFinalized := f.FinalizedBlock()
+	if qc.View < lastFinalized.View {
+		return nil, model.ByzantineThresholdExceededError{Evidence: fmt.Sprintf(
+			"finalizing block with view %d which is lower than previously finalized block at view %d",
+			qc.View, lastFinalized.View,
+		)}
+	}
+	if qc.View == lastFinalized.View { // no new blocks to be finalized
+		return nil, nil
+	}
+
+	// Collect all blocks that are pending finalization in slice. While we crawl the blocks starting
+	// from the newest finalized block backwards (decreasing views), we would like to return them in
+	// order of _increasing_ view. Therefore, we fill the slice starting with the highest index.
+	l := qc.View - lastFinalized.View // l is an upper limit to the number of blocks that can be maximally finalized
+	blocksToBeFinalized := make([]*model.Block, l)
+	for qc.View > lastFinalized.View {
+		b, ok := f.GetBlock(qc.BlockID)
+		if !ok {
+			return nil, fmt.Errorf("failed to get block (view=%d, blockID=%x) for finalization", qc.View, qc.BlockID)
+		}
+		l--
+		blocksToBeFinalized[l] = b
+		qc = b.QC // move to parent
+	}
+	// Now, `l` is the index where we stored the oldest block that should be finalized. Note that `l`
+	// might be larger than zero, if some views have no finalized blocks. Hence, `blocksToBeFinalized`
+	// might start with nil entries, which we remove:
+	blocksToBeFinalized = blocksToBeFinalized[l:]
+
+	// qc should now point to the latest finalized block. Otherwise, the
+	// consensus committee is compromised (or we have a critical internal bug).
+	if qc.View < lastFinalized.View {
+		return nil, model.ByzantineThresholdExceededError{Evidence: fmt.Sprintf(
+			"finalizing block with view %d which is lower than previously finalized block at view %d",
+			qc.View, lastFinalized.View,
+		)}
+	}
+	if qc.View == lastFinalized.View && lastFinalized.BlockID != qc.BlockID {
+		return nil, model.ByzantineThresholdExceededError{Evidence: fmt.Sprintf(
+			"finalizing blocks with view %d at conflicting forks: %x and %x",
+			qc.View, qc.BlockID, lastFinalized.BlockID,
+		)}
+	}
+
+	return blocksToBeFinalized, nil
+}

--- a/consensus/hotstuff/forks/forks2_test.go
+++ b/consensus/hotstuff/forks/forks2_test.go
@@ -1,0 +1,960 @@
+package forks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/consensus/hotstuff/mocks"
+	"github.com/onflow/flow-go/consensus/hotstuff/model"
+	"github.com/onflow/flow-go/model/flow"
+	mockmodule "github.com/onflow/flow-go/module/mock"
+)
+
+/*****************************************************************************
+ * NOTATION:                                                                 *
+ * A block is denoted as [(◄<qc_number>) <block_view_number>].               *
+ * For example, [(◄1) 2] means: a block of view 2 that has a QC for view 1.  *
+ *****************************************************************************/
+
+// TestInitialization verifies that at initialization, Forks reports:
+//   - the root / genesis block as finalized
+//   - it has no finalization proof for the root / genesis block (block and its finaization is trusted)
+func TestInitialization(t *testing.T) {
+	forks, _ := newForks(t)
+	requireOnlyGenesisBlockFinalized(t, forks)
+	_, hasProof := forks.FinalityProof()
+	require.False(t, hasProof)
+}
+
+// TestFinalize_Direct1Chain tests adding a direct 1-chain on top of the genesis block:
+//   - receives [(◄1) 2] [(◄2) 5]
+//
+// Expected behaviour:
+//   - On the one hand, Forks should not finalize any _additional_ blocks, because there is
+//     no finalizable 2-chain for [(◄1) 2]. Hence, finalization no events should be emitted.
+//   - On the other hand, after adding the two blocks, Forks has enough knowledge to construct
+//     a FinalityProof for the genesis block.
+func TestFinalize_Direct1Chain(t *testing.T) {
+	builder := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3)
+	blocks, err := builder.Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+
+		// adding block [(◄1) 2] should not finalize anything
+		// as the genesis block is trusted, there should be no FinalityProof available for it
+		require.NoError(t, forks.AddProposal(blocks[0].Block))
+		requireOnlyGenesisBlockFinalized(t, forks)
+		_, hasProof := forks.FinalityProof()
+		require.False(t, hasProof)
+
+		// After adding block [(◄2) 3], Forks has enough knowledge to construct a FinalityProof for the
+		// genesis block. However, finalization remains at the genesis block, so no events should be emitted.
+		expectedFinalityProof := makeFinalityProof(t, builder.GenesisBlock().Block, blocks[0].Block, blocks[1].Block.QC)
+		require.NoError(t, forks.AddProposal(blocks[1].Block))
+		requireLatestFinalizedBlock(t, forks, builder.GenesisBlock().Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+
+		// After adding CertifiedBlock [(◄1) 2] (◄2), Forks has enough knowledge to construct a FinalityProof for
+		// the genesis block. However, finalization remains at the genesis block, so no events should be emitted.
+		expectedFinalityProof := makeFinalityProof(t, builder.GenesisBlock().Block, blocks[0].Block, blocks[1].Block.QC)
+		c, err := model.NewCertifiedBlock(blocks[0].Block, blocks[1].Block.QC)
+		require.NoError(t, err)
+
+		require.NoError(t, forks.AddCertifiedBlock(&c))
+		requireLatestFinalizedBlock(t, forks, builder.GenesisBlock().Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestFinalize_Direct2Chain tests adding a direct 1-chain on a direct 1-chain (direct 2-chain).
+//   - receives [(◄1) 2] [(◄2) 3] [(◄3) 4]
+//   - Forks should finalize [(◄1) 2]
+func TestFinalize_Direct2Chain(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3).
+		Add(3, 4).
+		Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[0].Block, blocks[1].Block, blocks[2].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestFinalize_DirectIndirect2Chain tests adding an indirect 1-chain on a direct 1-chain.
+// receives [(◄1) 2] [(◄2) 3] [(◄3) 5]
+// it should finalize [(◄1) 2]
+func TestFinalize_DirectIndirect2Chain(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3).
+		Add(3, 5).
+		Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[0].Block, blocks[1].Block, blocks[2].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestFinalize_IndirectDirect2Chain tests adding a direct 1-chain on an indirect 1-chain.
+//   - Forks receives [(◄1) 3] [(◄3) 5] [(◄7) 7]
+//   - it should not finalize any blocks because there is no finalizable 2-chain.
+func TestFinalize_IndirectDirect2Chain(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 3).
+		Add(3, 5).
+		Add(5, 7).
+		Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		requireOnlyGenesisBlockFinalized(t, forks)
+		_, hasProof := forks.FinalityProof()
+		require.False(t, hasProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		requireOnlyGenesisBlockFinalized(t, forks)
+		_, hasProof := forks.FinalityProof()
+		require.False(t, hasProof)
+	})
+}
+
+// TestFinalize_Direct2ChainOnIndirect tests adding a direct 2-chain on an indirect 2-chain:
+//   - ingesting [(◄1) 3] [(◄3) 5] [(◄5) 6] [(◄6) 7] [(◄7) 8]
+//   - should result in finalization of [(◄5) 6]
+func TestFinalize_Direct2ChainOnIndirect(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 3).
+		Add(3, 5).
+		Add(5, 6).
+		Add(6, 7).
+		Add(7, 8).
+		Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[2].Block, blocks[3].Block, blocks[4].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[2].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[2].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestFinalize_Direct2ChainOnDirect tests adding a sequence of direct 2-chains:
+//   - ingesting [(◄1) 2] [(◄2) 3] [(◄3) 4] [(◄4) 5] [(◄5) 6]
+//   - should result in finalization of [(◄3) 4]
+func TestFinalize_Direct2ChainOnDirect(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3).
+		Add(3, 4).
+		Add(4, 5).
+		Add(5, 6).
+		Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[2].Block, blocks[3].Block, blocks[4].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[2].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[2].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestFinalize_Multiple2Chains tests the case where a block can be finalized by different 2-chains.
+//   - ingesting [(◄1) 2] [(◄2) 3] [(◄3) 5] [(◄3) 6] [(◄3) 7]
+//   - should result in finalization of [(◄1) 2]
+func TestFinalize_Multiple2Chains(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3).
+		Add(3, 5).
+		Add(3, 6).
+		Add(3, 7).
+		Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[0].Block, blocks[1].Block, blocks[2].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestFinalize_OrphanedFork tests that we can finalize a block which causes a conflicting fork to be orphaned.
+// We ingest the the following block tree:
+//
+//	[(◄1) 2] [(◄2) 3]
+//	         [(◄2) 4] [(◄4) 5] [(◄5) 6]
+//
+// which should result in finalization of [(◄2) 4] and pruning of [(◄2) 3]
+func TestFinalize_OrphanedFork(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2). // [(◄1) 2]
+		Add(2, 3). // [(◄2) 3], should eventually be pruned
+		Add(2, 4). // [(◄2) 4], should eventually be finalized
+		Add(4, 5). // [(◄4) 5]
+		Add(5, 6). // [(◄5) 6]
+		Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[2].Block, blocks[3].Block, blocks[4].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		require.False(t, forks.IsKnownBlock(blocks[1].Block.BlockID))
+		requireLatestFinalizedBlock(t, forks, blocks[2].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		require.False(t, forks.IsKnownBlock(blocks[1].Block.BlockID))
+		requireLatestFinalizedBlock(t, forks, blocks[2].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestDuplication tests that delivering the same block/qc multiple times has
+// the same end state as delivering the block/qc once.
+//   - Forks receives [(◄1) 2] [(◄2) 3] [(◄2) 3] [(◄3) 4] [(◄3) 4] [(◄4) 5] [(◄4) 5]
+//   - it should finalize [(◄2) 3]
+func TestDuplication(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3).
+		Add(2, 3).
+		Add(3, 4).
+		Add(3, 4).
+		Add(4, 5).
+		Add(4, 5).
+		Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[1].Block, blocks[3].Block, blocks[5].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[1].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks))
+
+		requireLatestFinalizedBlock(t, forks, blocks[1].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestIgnoreBlocksBelowFinalizedView tests that blocks below finalized view are ignored.
+//   - Forks receives [(◄1) 2] [(◄2) 3] [(◄3) 4] [(◄1) 5]
+//   - it should finalize [(◄1) 2]
+func TestIgnoreBlocksBelowFinalizedView(t *testing.T) {
+	builder := NewBlockBuilder().
+		Add(1, 2). // [(◄1) 2]
+		Add(2, 3). // [(◄2) 3]
+		Add(3, 4). // [(◄3) 4]
+		Add(1, 5)  // [(◄1) 5]
+	blocks, err := builder.Blocks()
+	require.Nil(t, err)
+	expectedFinalityProof := makeFinalityProof(t, blocks[0].Block, blocks[1].Block, blocks[2].Block.QC)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		// initialize forks and add first 3 blocks:
+		//  * block [(◄1) 2] should then be finalized
+		//  * and block [1] should be pruned
+		forks, _ := newForks(t)
+		require.Nil(t, addProposalsToForks(forks, blocks[:3]))
+
+		// sanity checks to confirm correct test setup
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+		require.False(t, forks.IsKnownBlock(builder.GenesisBlock().ID()))
+
+		// adding block [(◄1) 5]: note that QC is _below_ the pruning threshold, i.e. cannot resolve the parent
+		// * Forks should store block, despite the parent already being pruned
+		// * finalization should not change
+		orphanedBlock := blocks[3].Block
+		require.Nil(t, forks.AddProposal(orphanedBlock))
+		require.True(t, forks.IsKnownBlock(orphanedBlock.BlockID))
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		// initialize forks and add first 3 blocks:
+		//  * block [(◄1) 2] should then be finalized
+		//  * and block [1] should be pruned
+		forks, _ := newForks(t)
+		require.Nil(t, addCertifiedBlocksToForks(forks, blocks[:3]))
+		// sanity checks to confirm correct test setup
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+		require.False(t, forks.IsKnownBlock(builder.GenesisBlock().ID()))
+
+		// adding block [(◄1) 5]: note that QC is _below_ the pruning threshold, i.e. cannot resolve the parent
+		// * Forks should store block, despite the parent already being pruned
+		// * finalization should not change
+		certBlockWithUnknownParent := toCertifiedBlock(t, blocks[3].Block)
+		require.Nil(t, forks.AddCertifiedBlock(certBlockWithUnknownParent))
+		require.True(t, forks.IsKnownBlock(certBlockWithUnknownParent.Block.BlockID))
+		requireLatestFinalizedBlock(t, forks, blocks[0].Block)
+		requireFinalityProof(t, forks, expectedFinalityProof)
+	})
+}
+
+// TestDoubleProposal tests that the DoubleProposal notification is emitted when two different
+// proposals for the same view are added. We ingest the the following block tree:
+//
+//	               / [(◄1) 2]
+//			[1]
+//	               \ [(◄1) 2']
+//
+// which should result in a DoubleProposal event referencing the blocks [(◄1) 2] and [(◄1) 2']
+func TestDoubleProposal(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).                // [(◄1) 2]
+		AddVersioned(1, 2, 0, 1). // [(◄1) 2']
+		Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, notifier := newForks(t)
+		notifier.On("OnDoubleProposeDetected", blocks[1].Block, blocks[0].Block).Once()
+
+		err = addProposalsToForks(forks, blocks)
+		require.Nil(t, err)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, notifier := newForks(t)
+		notifier.On("OnDoubleProposeDetected", blocks[1].Block, blocks[0].Block).Once()
+
+		err = forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[0].Block)) // add [(◄1) 2]  as certified block
+		require.Nil(t, err)
+		err = forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[1].Block)) // add [(◄1) 2']  as certified block
+		require.Nil(t, err)
+	})
+}
+
+// TestConflictingQCs checks that adding 2 conflicting QCs should return model.ByzantineThresholdExceededError
+// We ingest the the following block tree:
+//
+//	[(◄1) 2] [(◄2) 3]   [(◄3) 4]  [(◄4) 6]
+//	         [(◄2) 3']  [(◄3') 5]
+//
+// which should result in a `ByzantineThresholdExceededError`, because conflicting blocks 3 and 3' both have QCs
+func TestConflictingQCs(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).                // [(◄1) 2]
+		Add(2, 3).                // [(◄2) 3]
+		AddVersioned(2, 3, 0, 1). // [(◄2) 3']
+		Add(3, 4).                // [(◄3) 4]
+		Add(4, 6).                // [(◄4) 6]
+		AddVersioned(3, 5, 1, 0). // [(◄3') 5]
+		Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, notifier := newForks(t)
+		notifier.On("OnDoubleProposeDetected", blocks[2].Block, blocks[1].Block).Return(nil)
+
+		err = addProposalsToForks(forks, blocks)
+		assert.True(t, model.IsByzantineThresholdExceededError(err))
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, notifier := newForks(t)
+		notifier.On("OnDoubleProposeDetected", blocks[2].Block, blocks[1].Block).Return(nil)
+
+		// As [(◄3') 5] is not certified, it will not be added to Forks. However, its QC (◄3') is
+		// delivered to Forks as part of the *certified* block [(◄2) 3'].
+		err = addCertifiedBlocksToForks(forks, blocks)
+		assert.True(t, model.IsByzantineThresholdExceededError(err))
+	})
+}
+
+// TestConflictingFinalizedForks checks that finalizing 2 conflicting forks should return model.ByzantineThresholdExceededError
+// We ingest the the following block tree:
+//
+//	[(◄1) 2] [(◄2) 3] [(◄3) 4] [(◄4) 5]
+//	         [(◄2) 6] [(◄6) 7] [(◄7) 8]
+//
+// Here, both blocks [(◄2) 3] and [(◄2) 6] satisfy the finalization condition, i.e. we have a fork
+// in the finalized blocks, which should result in a model.ByzantineThresholdExceededError exception.
+func TestConflictingFinalizedForks(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3).
+		Add(3, 4).
+		Add(4, 5). // finalizes [(◄2) 3]
+		Add(2, 6).
+		Add(6, 7).
+		Add(7, 8). // finalizes [(◄2) 6], conflicting with conflicts with [(◄2) 3]
+		Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		err = addProposalsToForks(forks, blocks)
+		assert.True(t, model.IsByzantineThresholdExceededError(err))
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		err = addCertifiedBlocksToForks(forks, blocks)
+		assert.True(t, model.IsByzantineThresholdExceededError(err))
+	})
+}
+
+// TestAddUnconnectedProposal checks that adding a proposal which does not connect to the
+// latest finalized block returns a `model.MissingBlockError`
+//   - receives [(◄2) 3]
+//   - should return `model.MissingBlockError`, because the parent is above the pruning
+//     threshold, but Forks does not know its parent
+func TestAddUnconnectedProposal(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2). // we will skip this block [(◄1) 2]
+		Add(2, 3). // [(◄2) 3]
+		Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, _ := newForks(t)
+		err := forks.AddProposal(blocks[1].Block)
+		require.Error(t, err)
+		assert.True(t, model.IsMissingBlockError(err))
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, _ := newForks(t)
+		err := forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[1].Block))
+		require.Error(t, err)
+		assert.True(t, model.IsMissingBlockError(err))
+	})
+}
+
+// TestGetProposal tests that we can retrieve stored proposals. Here, we test that
+// attempting to retrieve nonexistent or pruned proposals fails without causing an exception.
+//   - Forks receives [(◄1) 2] [(◄2) 3] [(◄3) 4], then [(◄4) 5]
+//   - should finalize [(◄1) 2], then [(◄2) 3]
+func TestGetProposal(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2). // [(◄1) 2]
+		Add(2, 3). // [(◄2) 3]
+		Add(3, 4). // [(◄3) 4]
+		Add(4, 5). // [(◄4) 5]
+		Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		blocksAddedFirst := blocks[:3]    // [(◄1) 2] [(◄2) 3] [(◄3) 4]
+		remainingBlock := blocks[3].Block // [(◄4) 5]
+		forks, _ := newForks(t)
+
+		// should be unable to retrieve a block before it is added
+		_, ok := forks.GetBlock(blocks[0].Block.BlockID)
+		assert.False(t, ok)
+
+		// add first 3 blocks - should finalize [(◄1) 2]
+		err = addProposalsToForks(forks, blocksAddedFirst)
+		require.Nil(t, err)
+
+		// should be able to retrieve all stored blocks
+		for _, proposal := range blocksAddedFirst {
+			b, ok := forks.GetBlock(proposal.Block.BlockID)
+			assert.True(t, ok)
+			assert.Equal(t, proposal.Block, b)
+		}
+
+		// add remaining block [(◄4) 5] - should finalize [(◄2) 3] and prune [(◄1) 2]
+		require.Nil(t, forks.AddProposal(remainingBlock))
+
+		// should be able to retrieve just added block
+		b, ok := forks.GetBlock(remainingBlock.BlockID)
+		assert.True(t, ok)
+		assert.Equal(t, remainingBlock, b)
+
+		// should be unable to retrieve pruned block
+		_, ok = forks.GetBlock(blocksAddedFirst[0].Block.BlockID)
+		assert.False(t, ok)
+	})
+
+	// Caution: finalization is driven by QCs. Therefore, we include the QC for block 3
+	// in the first batch of blocks that we add. This is analogous to previous test case,
+	// except that we are delivering the QC (◄3) as part of the certified block of view 2
+	//   [(◄2) 3] (◄3)
+	// while in the previous sub-test, the QC (◄3) was delivered as part of block [(◄3) 4]
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		blocksAddedFirst := toCertifiedBlocks(t, toBlocks(blocks[:2])...) // [(◄1) 2] [(◄2) 3] (◄3)
+		remainingBlock := toCertifiedBlock(t, blocks[2].Block)            // [(◄3) 4] (◄4)
+		forks, _ := newForks(t)
+
+		// should be unable to retrieve a block before it is added
+		_, ok := forks.GetBlock(blocks[0].Block.BlockID)
+		assert.False(t, ok)
+
+		// add first blocks - should finalize [(◄1) 2]
+		err := forks.AddCertifiedBlock(blocksAddedFirst[0])
+		require.Nil(t, err)
+		err = forks.AddCertifiedBlock(blocksAddedFirst[1])
+		require.Nil(t, err)
+
+		// should be able to retrieve all stored blocks
+		for _, proposal := range blocksAddedFirst {
+			b, ok := forks.GetBlock(proposal.Block.BlockID)
+			assert.True(t, ok)
+			assert.Equal(t, proposal.Block, b)
+		}
+
+		// add remaining block [(◄4) 5] - should finalize [(◄2) 3] and prune [(◄1) 2]
+		require.Nil(t, forks.AddCertifiedBlock(remainingBlock))
+
+		// should be able to retrieve just added block
+		b, ok := forks.GetBlock(remainingBlock.Block.BlockID)
+		assert.True(t, ok)
+		assert.Equal(t, remainingBlock.Block, b)
+
+		// should be unable to retrieve pruned block
+		_, ok = forks.GetBlock(blocksAddedFirst[0].Block.BlockID)
+		assert.False(t, ok)
+	})
+}
+
+// TestGetProposalsForView tests retrieving proposals for a view (also including double proposals).
+//   - Forks receives [(◄1) 2] [(◄2) 4] [(◄2) 4'],
+//     where [(◄2) 4'] is a double proposal, because it has the same view as [(◄2) 4]
+//
+// Expected behaviour:
+//   - Forks should store all the blocks
+//   - Forks should emit a `OnDoubleProposeDetected` notification
+//   - we can retrieve all blocks, including the double proposal
+func TestGetProposalsForView(t *testing.T) {
+	blocks, err := NewBlockBuilder().
+		Add(1, 2).                // [(◄1) 2]
+		Add(2, 4).                // [(◄2) 4]
+		AddVersioned(2, 4, 0, 1). // [(◄2) 4']
+		Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, notifier := newForks(t)
+		notifier.On("OnDoubleProposeDetected", blocks[2].Block, blocks[1].Block).Once()
+
+		err = addProposalsToForks(forks, blocks)
+		require.Nil(t, err)
+
+		// expect 1 proposal at view 2
+		proposals := forks.GetBlocksForView(2)
+		assert.Len(t, proposals, 1)
+		assert.Equal(t, blocks[0].Block, proposals[0])
+
+		// expect 2 proposals at view 4
+		proposals = forks.GetBlocksForView(4)
+		assert.Len(t, proposals, 2)
+		assert.ElementsMatch(t, toBlocks(blocks[1:]), proposals)
+
+		// expect 0 proposals at view 3
+		proposals = forks.GetBlocksForView(3)
+		assert.Len(t, proposals, 0)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, notifier := newForks(t)
+		notifier.On("OnDoubleProposeDetected", blocks[2].Block, blocks[1].Block).Once()
+
+		err := forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[0].Block))
+		require.Nil(t, err)
+		err = forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[1].Block))
+		require.Nil(t, err)
+		err = forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[2].Block))
+		require.Nil(t, err)
+
+		// expect 1 proposal at view 2
+		proposals := forks.GetBlocksForView(2)
+		assert.Len(t, proposals, 1)
+		assert.Equal(t, blocks[0].Block, proposals[0])
+
+		// expect 2 proposals at view 4
+		proposals = forks.GetBlocksForView(4)
+		assert.Len(t, proposals, 2)
+		assert.ElementsMatch(t, toBlocks(blocks[1:]), proposals)
+
+		// expect 0 proposals at view 3
+		proposals = forks.GetBlocksForView(3)
+		assert.Len(t, proposals, 0)
+	})
+}
+
+// TestNotifications tests that Forks emits the expected events:
+//   - Forks receives [(◄1) 2] [(◄2) 3] [(◄3) 4]
+//
+// Expected Behaviour:
+//   - Each of the ingested blocks should result in an `OnBlockIncorporated` notification
+//   - Forks should finalize [(◄1) 2], resulting in a `MakeFinal` event and an `OnFinalizedBlock` event
+func TestNotifications(t *testing.T) {
+	builder := NewBlockBuilder().
+		Add(1, 2).
+		Add(2, 3).
+		Add(3, 4)
+	blocks, err := builder.Blocks()
+	require.Nil(t, err)
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		notifier := &mocks.Consumer{}
+		// 4 blocks including the genesis are incorporated
+		notifier.On("OnBlockIncorporated", mock.Anything).Return(nil).Times(4)
+		notifier.On("OnFinalizedBlock", blocks[0].Block).Once()
+		finalizationCallback := mockmodule.NewFinalizer(t)
+		finalizationCallback.On("MakeFinal", blocks[0].Block.BlockID).Return(nil).Once()
+
+		forks, err := NewForks2(builder.GenesisBlock(), finalizationCallback, notifier)
+		require.NoError(t, err)
+		require.NoError(t, addProposalsToForks(forks, blocks))
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		notifier := &mocks.Consumer{}
+		// 4 blocks including the genesis are incorporated
+		notifier.On("OnBlockIncorporated", mock.Anything).Return(nil).Times(4)
+		notifier.On("OnFinalizedBlock", blocks[0].Block).Once()
+		finalizationCallback := mockmodule.NewFinalizer(t)
+		finalizationCallback.On("MakeFinal", blocks[0].Block.BlockID).Return(nil).Once()
+
+		forks, err := NewForks2(builder.GenesisBlock(), finalizationCallback, notifier)
+		require.NoError(t, err)
+		require.NoError(t, addCertifiedBlocksToForks(forks, blocks))
+	})
+}
+
+// TestFinalizingMultipleBlocks tests that `OnFinalizedBlock` notifications are emitted in correct order
+// when there are multiple blocks finalized by adding a _single_ block.
+//   - receiving [(◄1) 3] [(◄3) 5] [(◄5) 7] [(◄7) 11] [(◄11) 12] should not finalize any blocks,
+//     because there is no 2-chain with the first chain link being a _direct_ 1-chain
+//   - adding [(◄12) 22] should finalize up to block [(◄6) 11]
+//
+// This test verifies the following expected properties:
+//  1. Safety under reentrancy:
+//     While Forks is single-threaded, there is still the possibility of reentrancy. Specifically, the
+//     consumers of our finalization events are served by the goroutine executing Forks. It is conceivable
+//     that a consumer might access Forks and query the latest finalization proof. This would be legal, if
+//     the component supplying the goroutine to Forks also consumes the notifications. Therefore, for API
+//     safety, we require forks to _first update_ its `FinalityProof()` before it emits _any_ events.
+//  2. For each finalized block, `finalizationCallback` event is executed _before_ `OnFinalizedBlock` notifications.
+//  3. Blocks are finalized in order of increasing height (without skipping any blocks).
+func TestFinalizingMultipleBlocks(t *testing.T) {
+	builder := NewBlockBuilder().
+		Add(1, 3).   // index 0: [(◄1) 2]
+		Add(3, 5).   // index 1: [(◄2) 4]
+		Add(5, 7).   // index 2: [(◄4) 6]
+		Add(7, 11).  // index 3: [(◄6) 11] -- expected to be finalized
+		Add(11, 12). // index 4: [(◄11) 12]
+		Add(12, 22)  // index 5: [(◄12) 22]
+	blocks, err := builder.Blocks()
+	require.Nil(t, err)
+
+	// The Finality Proof should right away point to the _latest_ finalized block. Subsequently emitting
+	// Finalization events for lower blocks is fine, because notifications are guaranteed to be
+	// _eventually_ arriving. I.e. consumers expect notifications / events to be potentially lagging behind.
+	expectedFinalityProof := makeFinalityProof(t, blocks[3].Block, blocks[4].Block, blocks[5].Block.QC)
+
+	setupForksAndAssertions := func() (*Forks2, *mockmodule.Finalizer, *mocks.Consumer) {
+		// initialize Forks with custom event consumers so we can check order of emitted events
+		notifier := &mocks.Consumer{}
+		finalizationCallback := mockmodule.NewFinalizer(t)
+		notifier.On("OnBlockIncorporated", mock.Anything).Return(nil)
+		forks, err := NewForks2(builder.GenesisBlock(), finalizationCallback, notifier)
+		require.NoError(t, err)
+
+		// expecting finalization of [(◄1) 2] [(◄2) 4] [(◄4) 6] [(◄6) 11] in this order
+		blocksAwaitingFinalization := toBlockAwaitingFinalization(toBlocks(blocks[:4]))
+
+		finalizationCallback.On("MakeFinal", mock.Anything).Run(func(args mock.Arguments) {
+			requireFinalityProof(t, forks, expectedFinalityProof) // Requirement 1: forks should _first update_ its `FinalityProof()` before it emits _any_ events
+
+			// Requirement 3: finalized in order of increasing height (without skipping any blocks).
+			expectedNextFinalizationEvents := blocksAwaitingFinalization[0]
+			require.Equal(t, expectedNextFinalizationEvents.Block.BlockID, args[0])
+
+			// Requirement 2: finalized block, `finalizationCallback` event is executed _before_ `OnFinalizedBlock` notifications.
+			// no duplication of events under normal operations expected
+			require.False(t, expectedNextFinalizationEvents.MakeFinalCalled)
+			require.False(t, expectedNextFinalizationEvents.OnFinalizedBlockEmitted)
+			expectedNextFinalizationEvents.MakeFinalCalled = true
+		}).Return(nil).Times(4)
+
+		notifier.On("OnFinalizedBlock", mock.Anything).Run(func(args mock.Arguments) {
+			requireFinalityProof(t, forks, expectedFinalityProof) // Requirement 1: forks should _first update_ its `FinalityProof()` before it emits _any_ events
+
+			// Requirement 3: finalized in order of increasing height (without skipping any blocks).
+			expectedNextFinalizationEvents := blocksAwaitingFinalization[0]
+			require.Equal(t, expectedNextFinalizationEvents.Block, args[0])
+
+			// Requirement 2: finalized block, `finalizationCallback` event is executed _before_ `OnFinalizedBlock` notifications.
+			// no duplication of events under normal operations expected
+			require.True(t, expectedNextFinalizationEvents.MakeFinalCalled)
+			require.False(t, expectedNextFinalizationEvents.OnFinalizedBlockEmitted)
+			expectedNextFinalizationEvents.OnFinalizedBlockEmitted = true
+
+			// At this point, `MakeFinal` and `OnFinalizedBlock` have both been emitted for the block, so we are done with it
+			blocksAwaitingFinalization = blocksAwaitingFinalization[1:]
+		}).Times(4)
+
+		return forks, finalizationCallback, notifier
+	}
+
+	t.Run("ingest proposals", func(t *testing.T) {
+		forks, finalizationCallback, notifier := setupForksAndAssertions()
+		err = addProposalsToForks(forks, blocks[:5]) // adding [(◄1) 2] [(◄2) 4] [(◄4) 6] [(◄6) 11] [(◄11) 12]
+		require.Nil(t, err)
+		requireOnlyGenesisBlockFinalized(t, forks) // finalization should still be at the genesis block
+
+		require.NoError(t, forks.AddProposal(blocks[5].Block)) // adding [(◄12) 22] should trigger finalization events
+		requireFinalityProof(t, forks, expectedFinalityProof)
+		finalizationCallback.AssertExpectations(t)
+		notifier.AssertExpectations(t)
+	})
+
+	t.Run("ingest certified blocks", func(t *testing.T) {
+		forks, finalizationCallback, notifier := setupForksAndAssertions()
+		// adding [(◄1) 2] [(◄2) 4] [(◄4) 6] [(◄6) 11] (◄11)
+		require.NoError(t, forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[0].Block)))
+		require.NoError(t, forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[1].Block)))
+		require.NoError(t, forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[2].Block)))
+		require.NoError(t, forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[3].Block)))
+		require.Nil(t, err)
+		requireOnlyGenesisBlockFinalized(t, forks) // finalization should still be at the genesis block
+
+		// adding certified block [(◄11) 12] (◄12) should trigger finalization events
+		require.NoError(t, forks.AddCertifiedBlock(toCertifiedBlock(t, blocks[4].Block)))
+		requireFinalityProof(t, forks, expectedFinalityProof)
+		finalizationCallback.AssertExpectations(t)
+		notifier.AssertExpectations(t)
+	})
+}
+
+//* ************************************* internal functions ************************************* */
+
+func newForks(t *testing.T) (*Forks2, *mocks.Consumer) {
+	notifier := mocks.NewConsumer(t)
+	notifier.On("OnBlockIncorporated", mock.Anything).Return(nil).Maybe()
+	notifier.On("OnFinalizedBlock", mock.Anything).Maybe()
+	finalizationCallback := mockmodule.NewFinalizer(t)
+	finalizationCallback.On("MakeFinal", mock.Anything).Return(nil).Maybe()
+
+	genesisBQ := makeGenesis()
+
+	forks, err := NewForks2(genesisBQ, finalizationCallback, notifier)
+
+	require.Nil(t, err)
+	return forks, notifier
+}
+
+// addProposalsToForks adds all the given blocks to Forks, in order.
+// If any errors occur, returns the first one.
+func addProposalsToForks(forks *Forks2, proposals []*model.Proposal) error {
+	for _, proposal := range proposals {
+		err := forks.AddProposal(proposal.Block)
+		if err != nil {
+			return fmt.Errorf("test failed to add proposal for view %d: %w", proposal.Block.View, err)
+		}
+	}
+	return nil
+}
+
+// addCertifiedBlocksToForks iterates over all proposals, caches them locally in a map,
+// constructs certified blocks whenever possible and adds the certified blocks to forks,
+// Note: if proposals is a single fork, the _last block_ in the slice will not be added,
+//
+//	because there is no qc for it
+//
+// If any errors occur, returns the first one.
+func addCertifiedBlocksToForks(forks *Forks2, proposals []*model.Proposal) error {
+	uncertifiedBlocks := make(map[flow.Identifier]*model.Block)
+	for _, proposal := range proposals {
+		uncertifiedBlocks[proposal.Block.BlockID] = proposal.Block
+		parentID := proposal.Block.QC.BlockID
+		parent, found := uncertifiedBlocks[parentID]
+		if !found {
+			continue
+		}
+		delete(uncertifiedBlocks, parentID)
+
+		certParent, err := model.NewCertifiedBlock(parent, proposal.Block.QC)
+		if err != nil {
+			return fmt.Errorf("test failed to creat certified block for view %d: %w", certParent.Block.View, err)
+		}
+		err = forks.AddCertifiedBlock(&certParent)
+		if err != nil {
+			return fmt.Errorf("test failed to add certified block for view %d: %w", certParent.Block.View, err)
+		}
+	}
+
+	return nil
+}
+
+// requireLatestFinalizedBlock asserts that the latest finalized block has the given view and qc view.
+func requireLatestFinalizedBlock(t *testing.T, forks *Forks2, expectedFinalized *model.Block) {
+	require.Equal(t, expectedFinalized, forks.FinalizedBlock(), "finalized block is not as expected")
+	require.Equal(t, forks.FinalizedView(), uint64(expectedFinalized.View), "FinalizedView returned wrong value")
+}
+
+// requireOnlyGenesisBlockFinalized asserts that no blocks have been finalized beyond the genesis block.
+// Caution: does not inspect output of `forks.FinalityProof()`
+func requireOnlyGenesisBlockFinalized(t *testing.T, forks *Forks2) {
+	genesis := makeGenesis()
+	require.Equal(t, forks.FinalizedBlock(), genesis.Block, "finalized block is not the genesis block")
+	require.Equal(t, forks.FinalizedBlock().View, genesis.Block.View)
+	require.Equal(t, forks.FinalizedBlock().View, genesis.CertifyingQC.View)
+	require.Equal(t, forks.FinalizedView(), genesis.Block.View, "finalized block has wrong qc")
+
+	finalityProof, isKnown := forks.FinalityProof()
+	require.Nil(t, finalityProof, "expecting finality proof to be nil for genesis block at initialization")
+	require.False(t, isKnown, "no finality proof should be known for genesis block at initialization")
+}
+
+// requireNoBlocksFinalized asserts that no blocks have been finalized (genesis is latest finalized block).
+func requireFinalityProof(t *testing.T, forks *Forks2, expectedFinalityProof *FinalityProof) {
+	finalityProof, isKnown := forks.FinalityProof()
+	require.True(t, isKnown)
+	require.Equal(t, expectedFinalityProof, finalityProof)
+	require.Equal(t, forks.FinalizedBlock(), expectedFinalityProof.Block)
+	require.Equal(t, forks.FinalizedView(), expectedFinalityProof.Block.View)
+}
+
+// toBlocks converts the given proposals to slice of blocks
+// TODO: change `BlockBuilder` to generate model.Blocks instead of model.Proposals and then remove this method
+func toBlocks(proposals []*model.Proposal) []*model.Block {
+	blocks := make([]*model.Block, 0, len(proposals))
+	for _, b := range proposals {
+		blocks = append(blocks, b.Block)
+	}
+	return blocks
+}
+
+// toCertifiedBlock generates a QC for the given block and returns their combination as a certified block
+func toCertifiedBlock(t *testing.T, block *model.Block) *model.CertifiedBlock {
+	qc := &flow.QuorumCertificate{
+		View:    block.View,
+		BlockID: block.BlockID,
+	}
+	cb, err := model.NewCertifiedBlock(block, qc)
+	require.Nil(t, err)
+	return &cb
+}
+
+// toCertifiedBlocks generates a QC for the given block and returns their combination as a certified blocks
+func toCertifiedBlocks(t *testing.T, blocks ...*model.Block) []*model.CertifiedBlock {
+	certBlocks := make([]*model.CertifiedBlock, 0, len(blocks))
+	for _, b := range blocks {
+		certBlocks = append(certBlocks, toCertifiedBlock(t, b))
+	}
+	return certBlocks
+}
+
+func makeFinalityProof(t *testing.T, block *model.Block, directChild *model.Block, qcCertifyingChild *flow.QuorumCertificate) *FinalityProof {
+	c, err := model.NewCertifiedBlock(directChild, qcCertifyingChild) // certified child of FinalizedBlock
+	require.NoError(t, err)
+	return &FinalityProof{block, c}
+}
+
+// blockAwaitingFinalization is intended for tracking finalization events and their order for a specific block
+type blockAwaitingFinalization struct {
+	Block                   *model.Block
+	MakeFinalCalled         bool // indicates whether `Finalizer.MakeFinal` was called
+	OnFinalizedBlockEmitted bool // indicates whether `OnFinalizedBlockCalled` notification was emitted
+}
+
+// toBlockAwaitingFinalization creates a `blockAwaitingFinalization` tracker for each input block
+func toBlockAwaitingFinalization(blocks []*model.Block) []*blockAwaitingFinalization {
+	trackers := make([]*blockAwaitingFinalization, 0, len(blocks))
+	for _, b := range blocks {
+		tracker := &blockAwaitingFinalization{b, false, false}
+		trackers = append(trackers, tracker)
+	}
+	return trackers
+}

--- a/consensus/hotstuff/model/block.go
+++ b/consensus/hotstuff/model/block.go
@@ -51,8 +51,8 @@ func GenesisBlockFromFlow(header *flow.Header) *Block {
 // therefore proves validity of the block. A certified block satisfies:
 // Block.View == QC.View and Block.BlockID == QC.BlockID
 type CertifiedBlock struct {
-	Block *Block
-	QC    *flow.QuorumCertificate
+	Block        *Block
+	CertifyingQC *flow.QuorumCertificate
 }
 
 // NewCertifiedBlock constructs a new certified block. It checks the consistency
@@ -66,19 +66,16 @@ func NewCertifiedBlock(block *Block, qc *flow.QuorumCertificate) (CertifiedBlock
 	if block.BlockID != qc.BlockID {
 		return CertifiedBlock{}, fmt.Errorf("block's ID (%v) should equal the block referenced by the qc (%d)", block.BlockID, qc.BlockID)
 	}
-	return CertifiedBlock{
-		Block: block,
-		QC:    qc,
-	}, nil
+	return CertifiedBlock{Block: block, CertifyingQC: qc}, nil
 }
 
 // ID returns unique identifier for the block.
 // To avoid repeated computation, we use value from the QC.
 func (b *CertifiedBlock) ID() flow.Identifier {
-	return b.QC.BlockID
+	return b.CertifyingQC.BlockID
 }
 
 // View returns view where the block was proposed.
 func (b *CertifiedBlock) View() uint64 {
-	return b.QC.View
+	return b.CertifyingQC.View
 }

--- a/consensus/hotstuff/model/errors.go
+++ b/consensus/hotstuff/model/errors.go
@@ -170,6 +170,11 @@ type InvalidBlockError struct {
 	Err     error
 }
 
+// NewInvalidBlockError instantiates an `InvalidBlockError`. Input `err` cannot be nil.
+func NewInvalidBlockError(blockID flow.Identifier, view uint64, err error) error {
+	return InvalidBlockError{BlockID: blockID, View: view, Err: err}
+}
+
 func (e InvalidBlockError) Error() string {
 	return fmt.Sprintf("invalid block %x at view %d: %s", e.BlockID, e.View, e.Err.Error())
 }
@@ -222,10 +227,13 @@ func (e InvalidVoteError) Unwrap() error {
 	return e.Err
 }
 
-// ByzantineThresholdExceededError is raised if HotStuff detects malicious conditions which
-// prove a Byzantine threshold of consensus replicas has been exceeded.
-// Per definition, the byzantine threshold is exceeded if there are byzantine consensus
-// replicas with _at least_ 1/3 weight.
+// ByzantineThresholdExceededError is raised if HotStuff detects malicious conditions, which
+// prove that the Byzantine threshold of consensus replicas has been exceeded. Per definition,
+// this is the case when there are byzantine consensus replicas with ≥ 1/3 of the committee's
+// total weight. In this scenario, foundational consensus safety guarantees fail.
+// Generally, the protocol cannot continue in such conditions.
+// We represent this exception as with a dedicated type, so its occurrence can be detected by
+// higher-level logic and escalated to the node operator.
 type ByzantineThresholdExceededError struct {
 	Evidence string
 }

--- a/engine/common/follower/compliance_core.go
+++ b/engine/common/follower/compliance_core.go
@@ -260,7 +260,7 @@ func (c *ComplianceCore) processCertifiedBlocks(ctx context.Context, blocks Cert
 	// Step 2 & 3: extend protocol state with connected certified blocks and forward them to consensus follower
 	for _, certifiedBlock := range connectedBlocks {
 		s, _ := c.tracer.StartBlockSpan(ctx, certifiedBlock.ID(), trace.FollowerExtendProtocolState)
-		err = c.state.ExtendCertified(ctx, certifiedBlock.Block, certifiedBlock.QC)
+		err = c.state.ExtendCertified(ctx, certifiedBlock.Block, certifiedBlock.CertifyingQC)
 		s.End()
 		if err != nil {
 			return fmt.Errorf("could not extend protocol state with certified block: %w", err)

--- a/engine/common/follower/compliance_engine.go
+++ b/engine/common/follower/compliance_engine.go
@@ -248,7 +248,7 @@ func (e *ComplianceEngine) processBlocksLoop(ctx irrecoverable.SignalerContext, 
 //     to overwhelm another node through synchronization messages and drown out new blocks
 //     for a node that is up-to-date.
 //   - On the flip side, new proposals are relatively infrequent compared to the load that
-//     synchronization produces for a note that is catching up. In other words, prioritizing
+//     synchronization produces for a node that is catching up. In other words, prioritizing
 //     the few new proposals first is probably not going to be much of a distraction.
 //     Proposals too far in the future are dropped (see parameter `SkipNewProposalsThreshold`
 //     in `compliance.Config`), to prevent memory overflow.

--- a/engine/common/follower/pending_tree/pending_tree.go
+++ b/engine/common/follower/pending_tree/pending_tree.go
@@ -26,8 +26,8 @@ func NewVertex(certifiedBlock flow.CertifiedBlock, connectedToFinalized bool) (*
 	}, nil
 }
 
-func (v *PendingBlockVertex) VertexID() flow.Identifier { return v.QC.BlockID }
-func (v *PendingBlockVertex) Level() uint64             { return v.QC.View }
+func (v *PendingBlockVertex) VertexID() flow.Identifier { return v.CertifyingQC.BlockID }
+func (v *PendingBlockVertex) Level() uint64             { return v.CertifyingQC.View }
 func (v *PendingBlockVertex) Parent() (flow.Identifier, uint64) {
 	return v.Block.Header.ParentID, v.Block.Header.ParentView
 }

--- a/engine/common/follower/pending_tree/pending_tree_test.go
+++ b/engine/common/follower/pending_tree/pending_tree_test.go
@@ -89,8 +89,8 @@ func (s *PendingTreeSuite) TestAllConnectedForksAreCollected() {
 	B2.Header.View = longestFork[len(longestFork)-1].Block.Header.View + 1
 	B3 := unittest.BlockWithParentFixture(B2.Header)
 	shortFork := []flow.CertifiedBlock{{
-		Block: B2,
-		QC:    B3.Header.QuorumCertificate(),
+		Block:        B2,
+		CertifyingQC: B3.Header.QuorumCertificate(),
 	}, certifiedBlockFixture(B3)}
 
 	connectedBlocks, err := s.pendingTree.AddBlocks(shortFork)
@@ -180,8 +180,8 @@ func (s *PendingTreeSuite) TestResolveBlocksAfterFinalization() {
 	B2.Header.View = longestFork[len(longestFork)-1].Block.Header.View + 1
 	B3 := unittest.BlockWithParentFixture(B2.Header)
 	shortFork := []flow.CertifiedBlock{{
-		Block: B2,
-		QC:    B3.Header.QuorumCertificate(),
+		Block:        B2,
+		CertifyingQC: B3.Header.QuorumCertificate(),
 	}, certifiedBlockFixture(B3)}
 
 	connectedBlocks, err := s.pendingTree.AddBlocks(shortFork)

--- a/model/flow/block.go
+++ b/model/flow/block.go
@@ -78,8 +78,8 @@ func (s BlockStatus) String() string {
 // therefore proves validity of the block. A certified block satisfies:
 // Block.View == QC.View and Block.BlockID == QC.BlockID
 type CertifiedBlock struct {
-	Block *Block
-	QC    *QuorumCertificate
+	Block        *Block
+	CertifyingQC *QuorumCertificate
 }
 
 // NewCertifiedBlock constructs a new certified block. It checks the consistency
@@ -93,21 +93,18 @@ func NewCertifiedBlock(block *Block, qc *QuorumCertificate) (CertifiedBlock, err
 	if block.ID() != qc.BlockID {
 		return CertifiedBlock{}, fmt.Errorf("block's ID (%v) should equal the block referenced by the qc (%d)", block.ID(), qc.BlockID)
 	}
-	return CertifiedBlock{
-		Block: block,
-		QC:    qc,
-	}, nil
+	return CertifiedBlock{Block: block, CertifyingQC: qc}, nil
 }
 
 // ID returns unique identifier for the block.
 // To avoid repeated computation, we use value from the QC.
 func (b *CertifiedBlock) ID() Identifier {
-	return b.QC.BlockID
+	return b.CertifyingQC.BlockID
 }
 
 // View returns view where the block was produced.
 func (b *CertifiedBlock) View() uint64 {
-	return b.QC.View
+	return b.CertifyingQC.View
 }
 
 // Height returns height of the block.


### PR DESCRIPTION
backport of https://github.com/onflow/flow-go/pull/4190 to v0.30

**changes are identical to https://github.com/onflow/flow-go/pull/4190**