### PR TITLE
Add InterimReadSet method to transaction state.

### DIFF
--- a/fvm/state/execution_state.go
+++ b/fvm/state/execution_state.go
@@ -310,3 +310,13 @@ func (state *ExecutionState) checkSize(
 	}
 	return nil
 }
+
+func (state *ExecutionState) readSetSize() int {
+	return state.spockState.readSetSize()
+}
+
+func (state *ExecutionState) interimReadSet(
+	accumulator map[flow.RegisterID]struct{},
+) {
+	state.spockState.interimReadSet(accumulator)
+}

--- a/fvm/state/spock_state.go
+++ b/fvm/state/spock_state.go
@@ -164,3 +164,13 @@ func (state *spockState) DropChanges() error {
 
 	return state.storageState.DropChanges()
 }
+
+func (state *spockState) readSetSize() int {
+	return state.storageState.readSetSize()
+}
+
+func (state *spockState) interimReadSet(
+	accumulator map[flow.RegisterID]struct{},
+) {
+	state.storageState.interimReadSet(accumulator)
+}

--- a/fvm/state/storage_state.go
+++ b/fvm/state/storage_state.go
@@ -114,3 +114,19 @@ func (state *storageState) DropChanges() error {
 	state.writeSet = map[flow.RegisterID]flow.RegisterValue{}
 	return nil
 }
+
+func (state *storageState) readSetSize() int {
+	return len(state.readSet)
+}
+
+func (state *storageState) interimReadSet(
+	accumulator map[flow.RegisterID]struct{},
+) {
+	for id := range state.writeSet {
+		delete(accumulator, id)
+	}
+
+	for id := range state.readSet {
+		accumulator[id] = struct{}{}
+	}
+}


### PR DESCRIPTION
The interim read set will be used for verification while the transaction is still mid-execution (The finalized execution snapshot's read set will be used for verification prior to commit)