### PR TITLE
Add support data structures for in memory block database.

### DIFF
--- a/fvm/storage/primary/snapshot_tree.go
+++ b/fvm/storage/primary/snapshot_tree.go
@@ -1,0 +1,88 @@
+package primary
+
+import (
+	"fmt"
+
+	"github.com/onflow/flow-go/fvm/state"
+	"github.com/onflow/flow-go/fvm/storage"
+	"github.com/onflow/flow-go/fvm/storage/logical"
+)
+
+type timestampedSnapshotTree struct {
+	currentSnapshotTime logical.Time
+	baseSnapshotTime    logical.Time
+
+	storage.SnapshotTree
+
+	fullLog storage.UpdateLog
+}
+
+func newTimestampedSnapshotTree(
+	storageSnapshot state.StorageSnapshot,
+	snapshotTime logical.Time,
+) timestampedSnapshotTree {
+	return timestampedSnapshotTree{
+		currentSnapshotTime: snapshotTime,
+		baseSnapshotTime:    snapshotTime,
+		SnapshotTree:        storage.NewSnapshotTree(storageSnapshot),
+		fullLog:             nil,
+	}
+}
+
+func (tree timestampedSnapshotTree) Append(
+	executionSnapshot *state.ExecutionSnapshot,
+) timestampedSnapshotTree {
+	return timestampedSnapshotTree{
+		currentSnapshotTime: tree.currentSnapshotTime + 1,
+		baseSnapshotTime:    tree.baseSnapshotTime,
+		SnapshotTree:        tree.SnapshotTree.Append(executionSnapshot),
+		fullLog:             append(tree.fullLog, executionSnapshot.WriteSet),
+	}
+}
+
+func (tree timestampedSnapshotTree) SnapshotTime() logical.Time {
+	return tree.currentSnapshotTime
+}
+
+func (tree timestampedSnapshotTree) UpdatesSince(
+	snapshotTime logical.Time,
+) (
+	storage.UpdateLog,
+	error,
+) {
+	if snapshotTime < tree.baseSnapshotTime {
+		// This should never happen.
+		return nil, fmt.Errorf(
+			"missing update log range [%v, %v)",
+			snapshotTime,
+			tree.baseSnapshotTime)
+	}
+
+	if snapshotTime > tree.currentSnapshotTime {
+		// This should never happen.
+		return nil, fmt.Errorf(
+			"missing update log range (%v, %v]",
+			tree.currentSnapshotTime,
+			snapshotTime)
+	}
+
+	return tree.fullLog[int(snapshotTime-tree.baseSnapshotTime):], nil
+}
+
+type rebaseableTimestampedSnapshotTree struct {
+	timestampedSnapshotTree
+}
+
+func newRebaseableTimestampedSnapshotTree(
+	snapshotTree timestampedSnapshotTree,
+) *rebaseableTimestampedSnapshotTree {
+	return &rebaseableTimestampedSnapshotTree{
+		timestampedSnapshotTree: snapshotTree,
+	}
+}
+
+func (tree *rebaseableTimestampedSnapshotTree) Rebase(
+	base timestampedSnapshotTree,
+) {
+	tree.timestampedSnapshotTree = base
+}

--- a/fvm/storage/primary/snapshot_tree_test.go
+++ b/fvm/storage/primary/snapshot_tree_test.go
@@ -1,0 +1,196 @@
+package primary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/fvm/storage"
+	"github.com/onflow/flow-go/fvm/storage/logical"
+	"github.com/onflow/flow-go/fvm/storage/state"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestTimestampedSnapshotTree(t *testing.T) {
+	// Test setup ("commit" 4 execution snapshots to the base tree)
+
+	baseSnapshotTime := logical.Time(5)
+
+	registerId0 := flow.RegisterID{
+		Owner: "",
+		Key:   "key0",
+	}
+	value0 := flow.RegisterValue([]byte("value0"))
+
+	tree0 := newTimestampedSnapshotTree(
+		state.MapStorageSnapshot{
+			registerId0: value0,
+		},
+		baseSnapshotTime)
+
+	registerId1 := flow.RegisterID{
+		Owner: "",
+		Key:   "key1",
+	}
+	value1 := flow.RegisterValue([]byte("value1"))
+	writeSet1 := map[flow.RegisterID]flow.RegisterValue{
+		registerId1: value1,
+	}
+
+	tree1 := tree0.Append(
+		&state.ExecutionSnapshot{
+			WriteSet: writeSet1,
+		})
+
+	registerId2 := flow.RegisterID{
+		Owner: "",
+		Key:   "key2",
+	}
+	value2 := flow.RegisterValue([]byte("value2"))
+	writeSet2 := map[flow.RegisterID]flow.RegisterValue{
+		registerId2: value2,
+	}
+
+	tree2 := tree1.Append(
+		&state.ExecutionSnapshot{
+			WriteSet: writeSet2,
+		})
+
+	registerId3 := flow.RegisterID{
+		Owner: "",
+		Key:   "key3",
+	}
+	value3 := flow.RegisterValue([]byte("value3"))
+	writeSet3 := map[flow.RegisterID]flow.RegisterValue{
+		registerId3: value3,
+	}
+
+	tree3 := tree2.Append(
+		&state.ExecutionSnapshot{
+			WriteSet: writeSet3,
+		})
+
+	registerId4 := flow.RegisterID{
+		Owner: "",
+		Key:   "key4",
+	}
+	value4 := flow.RegisterValue([]byte("value4"))
+	writeSet4 := map[flow.RegisterID]flow.RegisterValue{
+		registerId4: value4,
+	}
+
+	tree4 := tree3.Append(
+		&state.ExecutionSnapshot{
+			WriteSet: writeSet4,
+		})
+
+	// Verify the trees internal values
+
+	trees := []timestampedSnapshotTree{tree0, tree1, tree2, tree3, tree4}
+	logs := storage.UpdateLog{writeSet1, writeSet2, writeSet3, writeSet4}
+
+	for i, tree := range trees {
+		require.Equal(t, baseSnapshotTime, tree.baseSnapshotTime)
+		require.Equal(
+			t,
+			baseSnapshotTime+logical.Time(i),
+			tree.SnapshotTime())
+		if i == 0 {
+			require.Nil(t, tree.fullLog)
+		} else {
+			require.Equal(t, logs[:i], tree.fullLog)
+		}
+
+		value, err := tree.Get(registerId0)
+		require.NoError(t, err)
+		require.Equal(t, value0, value)
+
+		value, err = tree.Get(registerId1)
+		require.NoError(t, err)
+		if i >= 1 {
+			require.Equal(t, value1, value)
+		} else {
+			require.Nil(t, value)
+		}
+
+		value, err = tree.Get(registerId2)
+		require.NoError(t, err)
+		if i >= 2 {
+			require.Equal(t, value2, value)
+		} else {
+			require.Nil(t, value)
+		}
+
+		value, err = tree.Get(registerId3)
+		require.NoError(t, err)
+		if i >= 3 {
+			require.Equal(t, value3, value)
+		} else {
+			require.Nil(t, value)
+		}
+
+		value, err = tree.Get(registerId4)
+		require.NoError(t, err)
+		if i == 4 {
+			require.Equal(t, value4, value)
+		} else {
+			require.Nil(t, value)
+		}
+	}
+
+	// Verify UpdatesSince returns
+
+	updates, err := tree0.UpdatesSince(baseSnapshotTime)
+	require.NoError(t, err)
+	require.Nil(t, updates)
+
+	_, err = tree4.UpdatesSince(baseSnapshotTime - 1)
+	require.ErrorContains(t, err, "missing update log range [4, 5)")
+
+	for i := 0; i < 5; i++ {
+		updates, err = tree4.UpdatesSince(baseSnapshotTime + logical.Time(i))
+		require.NoError(t, err)
+		require.Equal(t, logs[i:], updates)
+	}
+
+	snapshotTime := baseSnapshotTime + logical.Time(5)
+	require.Equal(t, tree4.SnapshotTime()+1, snapshotTime)
+
+	_, err = tree4.UpdatesSince(snapshotTime)
+	require.ErrorContains(t, err, "missing update log range (9, 10]")
+}
+
+func TestRebaseableTimestampedSnapshotTree(t *testing.T) {
+	registerId := flow.RegisterID{
+		Owner: "owner",
+		Key:   "key",
+	}
+
+	value1 := flow.RegisterValue([]byte("value1"))
+	value2 := flow.RegisterValue([]byte("value2"))
+
+	tree1 := newTimestampedSnapshotTree(
+		state.MapStorageSnapshot{
+			registerId: value1,
+		},
+		0)
+
+	tree2 := newTimestampedSnapshotTree(
+		state.MapStorageSnapshot{
+			registerId: value2,
+		},
+		0)
+
+	rebaseableTree := newRebaseableTimestampedSnapshotTree(tree1)
+	treeReference := rebaseableTree
+
+	value, err := treeReference.Get(registerId)
+	require.NoError(t, err)
+	require.Equal(t, value, value1)
+
+	rebaseableTree.Rebase(tree2)
+
+	value, err = treeReference.Get(registerId)
+	require.NoError(t, err)
+	require.Equal(t, value, value2)
+}

--- a/fvm/storage/snapshot_tree.go
+++ b/fvm/storage/snapshot_tree.go
@@ -9,15 +9,14 @@ const (
 	compactThreshold = 10
 )
 
-type updateLog []map[flow.RegisterID]flow.RegisterValue
+type UpdateLog []map[flow.RegisterID]flow.RegisterValue
 
 // SnapshotTree is a simple LSM tree representation of the key/value storage
 // at a given point in time.
 type SnapshotTree struct {
 	base state.StorageSnapshot
 
-	fullLog      updateLog
-	compactedLog updateLog
+	compactedLog UpdateLog
 }
 
 // NewSnapshotTree returns a tree with keys/values initialized to the base
@@ -25,7 +24,6 @@ type SnapshotTree struct {
 func NewSnapshotTree(base state.StorageSnapshot) SnapshotTree {
 	return SnapshotTree{
 		base:         base,
-		fullLog:      nil,
 		compactedLog: nil,
 	}
 }
@@ -51,13 +49,12 @@ func (tree SnapshotTree) Append(
 				}
 			}
 
-			compactedLog = updateLog{mergedSet}
+			compactedLog = UpdateLog{mergedSet}
 		}
 	}
 
 	return SnapshotTree{
 		base:         tree.base,
-		fullLog:      append(tree.fullLog, update.WriteSet),
 		compactedLog: compactedLog,
 	}
 }

--- a/fvm/storage/snapshot_tree_test.go
+++ b/fvm/storage/snapshot_tree_test.go
@@ -105,10 +105,8 @@ func TestSnapshotTree(t *testing.T) {
 	check := func(
 		tree SnapshotTree,
 		expected map[flow.RegisterID]flow.RegisterValue,
-		fullLogLen int,
 		compactedLogLen int,
 	) {
-		require.Len(t, tree.fullLog, fullLogLen)
 		require.Len(t, tree.compactedLog, compactedLogLen)
 
 		for key, expectedValue := range expected {
@@ -118,11 +116,11 @@ func TestSnapshotTree(t *testing.T) {
 		}
 	}
 
-	check(tree0, expected0, 0, 0)
-	check(tree1, expected1, 1, 1)
-	check(tree2, expected2, 2, 2)
-	check(tree3, expected3, 3, 3)
-	check(compactedTree, expectedCompacted, 3+numExtraUpdates, 4)
+	check(tree0, expected0, 0)
+	check(tree1, expected1, 1)
+	check(tree2, expected2, 2)
+	check(tree3, expected3, 3)
+	check(compactedTree, expectedCompacted, 4)
 
 	emptyTree := NewSnapshotTree(nil)
 	value, err := emptyTree.Get(id1)


### PR DESCRIPTION
The block database will hold the latest version of the timestamped snapshot tree.  The transactions will hold a rebaseable snapshot tree (and rebase to latest snapshot whenever transaction validate succeed).