### PR TITLE
Change derived snapshot read transaction commit behavior

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -413,7 +413,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			unittest.IdentifierFixture(),
 			block,
 			snapshotTree,
-			derivedBlockData)
+			derivedBlockData.NewChildDerivedBlockData())
 		assert.NoError(t, err)
 		assert.Len(t, result.AllExecutionSnapshots(), 1)
 		assert.Len(t, result.AllTransactionResults(), 1)

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -199,16 +199,11 @@ func (vm *VirtualMachine) Run(
 		return nil, ProcedureOutput{}, err
 	}
 
-	// Note: it is safe to skip committing derived data for non-normal
-	// transactions (i.e., bootstrap and script) since these do not invalidate
-	// derived data entries.
-	if proc.Type() == TransactionProcedureType {
-		// NOTE: It is not safe to ignore derivedTxnData' commit error for
-		// transactions that trigger derived data invalidation.
-		err = derivedTxnData.Commit()
-		if err != nil {
-			return nil, ProcedureOutput{}, err
-		}
+	// NOTE: It is not safe to ignore derivedTxnData' commit error for
+	// transactions that trigger derived data invalidation.
+	err = derivedTxnData.Commit()
+	if err != nil {
+		return nil, ProcedureOutput{}, err
 	}
 
 	executionSnapshot, err := txnState.FinalizeMainTransaction()

--- a/fvm/storage/derived/table.go
+++ b/fvm/storage/derived/table.go
@@ -251,6 +251,12 @@ func (table *DerivedDataTable[TKey, TVal]) commit(
 		return err
 	}
 
+	// Don't perform actual commit for snapshot read transaction.  This is
+	// safe since all values are derived from the primary source.
+	if txn.isSnapshotReadTransaction {
+		return nil
+	}
+
 	for key, entry := range txn.writeSet {
 		_, ok := table.items[key]
 		if ok {
@@ -280,13 +286,7 @@ func (table *DerivedDataTable[TKey, TVal]) commit(
 			txn.invalidators...)
 	}
 
-	// NOTE: We cannot advance commit time when we encounter a snapshot read
-	// (aka script) transaction since these transactions don't generate new
-	// snapshots.  It is safe to commit the entries since snapshot read
-	// transactions never invalidate entries.
-	if !txn.isSnapshotReadTransaction {
-		table.latestCommitExecutionTime = txn.executionTime
-	}
+	table.latestCommitExecutionTime = txn.executionTime
 	return nil
 }
 


### PR DESCRIPTION
Don't commit derived snapshot read transaction's data back to the block.  This is safe since all values are derived from the primary source.

This simplify 2PC between the primary index and the derived indices.

This also fixes a bad test setup which prevented us from committing bootstrap programs previously.