### PR TITLE
Simplify snapshot read transactions

### DIFF
--- a/fvm/environment/facade_env.go
+++ b/fvm/environment/facade_env.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/onflow/flow-go/fvm/storage"
 	"github.com/onflow/flow-go/fvm/storage/derived"
-	"github.com/onflow/flow-go/fvm/storage/logical"
 	"github.com/onflow/flow-go/fvm/storage/state"
 	"github.com/onflow/flow-go/fvm/tracing"
 )
@@ -147,12 +146,7 @@ func NewScriptEnvironmentFromStorageSnapshot(
 	storageSnapshot state.StorageSnapshot,
 ) *facadeEnvironment {
 	derivedBlockData := derived.NewEmptyDerivedBlockData()
-	derivedTxn, err := derivedBlockData.NewSnapshotReadDerivedTransactionData(
-		logical.EndOfBlockExecutionTime,
-		logical.EndOfBlockExecutionTime)
-	if err != nil {
-		panic(err)
-	}
+	derivedTxn := derivedBlockData.NewSnapshotReadDerivedTransactionData()
 
 	txn := storage.SerialTransaction{
 		NestedTransaction: state.NewTransactionState(

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -162,9 +162,7 @@ func (vm *VirtualMachine) Run(
 	var err error
 	switch proc.Type() {
 	case ScriptProcedureType:
-		derivedTxnData, err = derivedBlockData.NewSnapshotReadDerivedTransactionData(
-			proc.ExecutionTime(),
-			proc.ExecutionTime())
+		derivedTxnData = derivedBlockData.NewSnapshotReadDerivedTransactionData()
 	case TransactionProcedureType, BootstrapProcedureType:
 		derivedTxnData, err = derivedBlockData.NewDerivedTransactionData(
 			proc.ExecutionTime(),
@@ -237,14 +235,7 @@ func (vm *VirtualMachine) GetAccount(
 		derivedBlockData = derived.NewEmptyDerivedBlockData()
 	}
 
-	derivedTxnData, err := derivedBlockData.NewSnapshotReadDerivedTransactionData(
-		logical.EndOfBlockExecutionTime,
-		logical.EndOfBlockExecutionTime)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error creating derived transaction data for GetAccount: %w",
-			err)
-	}
+	derivedTxnData := derivedBlockData.NewSnapshotReadDerivedTransactionData()
 
 	txnState := &storage.SerialTransaction{
 		NestedTransaction:           nestedTxn,

--- a/fvm/storage/derived/derived_block_data.go
+++ b/fvm/storage/derived/derived_block_data.go
@@ -101,31 +101,15 @@ func (block *DerivedBlockData) NewChildDerivedBlockData() *DerivedBlockData {
 	}
 }
 
-func (block *DerivedBlockData) NewSnapshotReadDerivedTransactionData(
-	snapshotTime logical.Time,
-	executionTime logical.Time,
-) (
-	DerivedTransactionCommitter,
-	error,
-) {
-	txnPrograms, err := block.programs.NewSnapshotReadTableTransaction(
-		snapshotTime,
-		executionTime)
-	if err != nil {
-		return nil, err
-	}
+func (block *DerivedBlockData) NewSnapshotReadDerivedTransactionData() DerivedTransactionCommitter {
+	txnPrograms := block.programs.NewSnapshotReadTableTransaction()
 
-	txnMeterParamOverrides, err := block.meterParamOverrides.NewSnapshotReadTableTransaction(
-		snapshotTime,
-		executionTime)
-	if err != nil {
-		return nil, err
-	}
+	txnMeterParamOverrides := block.meterParamOverrides.NewSnapshotReadTableTransaction()
 
 	return &DerivedTransactionData{
 		programs:            txnPrograms,
 		meterParamOverrides: txnMeterParamOverrides,
-	}, nil
+	}
 }
 
 func (block *DerivedBlockData) NewDerivedTransactionData(

--- a/fvm/storage/derived/table_test.go
+++ b/fvm/storage/derived/table_test.go
@@ -60,28 +60,6 @@ func TestDerivedDataTableNormalTransactionInvalidSnapshotTime(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDerivedDataTableSnapshotReadTransactionInvalidExecutionTimeBound(
-	t *testing.T,
-) {
-	block := newEmptyTestBlock()
-
-	_, err := block.NewSnapshotReadTableTransaction(
-		logical.ParentBlockTime,
-		logical.ParentBlockTime)
-	require.ErrorContains(t, err, "execution time out of bound")
-
-	_, err = block.NewSnapshotReadTableTransaction(logical.ParentBlockTime, 0)
-	require.NoError(t, err)
-
-	_, err = block.NewSnapshotReadTableTransaction(0, logical.ChildBlockTime)
-	require.ErrorContains(t, err, "execution time out of bound")
-
-	_, err = block.NewSnapshotReadTableTransaction(
-		0,
-		logical.EndOfBlockExecutionTime)
-	require.NoError(t, err)
-}
-
 func TestDerivedDataTableToValidateTime(t *testing.T) {
 	block := NewEmptyTableWithOffset[string, *string](8)
 	require.Equal(
@@ -401,54 +379,6 @@ func TestDerivedDataTableValidateIgnoreInvalidatorsOlderThanSnapshot(t *testing.
 
 	err = testTxn.Validate()
 	require.NoError(t, err)
-}
-
-func TestDerivedDataTableCommitEndOfBlockSnapshotRead(t *testing.T) {
-	block := newEmptyTestBlock()
-
-	commitTime := logical.Time(5)
-	testSetupTxn, err := block.NewTableTransaction(0, commitTime)
-	require.NoError(t, err)
-
-	err = testSetupTxn.Commit()
-	require.NoError(t, err)
-
-	require.Equal(t, commitTime, block.LatestCommitExecutionTimeForTestingOnly())
-
-	testTxn, err := block.NewSnapshotReadTableTransaction(
-		logical.EndOfBlockExecutionTime,
-		logical.EndOfBlockExecutionTime)
-	require.NoError(t, err)
-
-	err = testTxn.Commit()
-	require.NoError(t, err)
-
-	require.Equal(t, commitTime, block.LatestCommitExecutionTimeForTestingOnly())
-}
-
-func TestDerivedDataTableCommitSnapshotReadDontAdvanceTime(t *testing.T) {
-	block := newEmptyTestBlock()
-
-	commitTime := logical.Time(71)
-	testSetupTxn, err := block.NewTableTransaction(0, commitTime)
-	require.NoError(t, err)
-
-	err = testSetupTxn.Commit()
-	require.NoError(t, err)
-
-	repeatedTime := commitTime + 1
-	for i := 0; i < 10; i++ {
-		txn, err := block.NewSnapshotReadTableTransaction(0, repeatedTime)
-		require.NoError(t, err)
-
-		err = txn.Commit()
-		require.NoError(t, err)
-	}
-
-	require.Equal(
-		t,
-		commitTime,
-		block.LatestCommitExecutionTimeForTestingOnly())
 }
 
 func TestDerivedDataTableCommitWriteOnlyTransactionNoInvalidation(t *testing.T) {
@@ -797,59 +727,33 @@ func TestDerivedDataTableCommitRejectCommitGapForNormalTxn(t *testing.T) {
 	require.False(t, errors.IsRetryableConflictError(commitErr))
 }
 
-func TestDerivedDataTableCommitRejectCommitGapForSnapshotRead(t *testing.T) {
+func TestDerivedDataTableCommitSnapshotReadDontAdvanceTime(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	commitTime := logical.Time(5)
+	commitTime := logical.Time(71)
 	testSetupTxn, err := block.NewTableTransaction(0, commitTime)
 	require.NoError(t, err)
 
 	err = testSetupTxn.Commit()
 	require.NoError(t, err)
 
+	for i := 0; i < 10; i++ {
+		txn := block.NewSnapshotReadTableTransaction()
+
+		err = txn.Commit()
+		require.NoError(t, err)
+	}
+
 	require.Equal(
 		t,
 		commitTime,
-		block.LatestCommitExecutionTimeForTestingOnly())
-
-	testTxn, err := block.NewSnapshotReadTableTransaction(10, 10)
-	require.NoError(t, err)
-
-	err = testTxn.Validate()
-	require.NoError(t, err)
-
-	commitErr := testTxn.Commit()
-	require.ErrorContains(t, commitErr, "missing commit range [6, 10)")
-	require.False(t, errors.IsRetryableConflictError(commitErr))
-}
-
-func TestDerivedDataTableCommitSnapshotReadDoesNotAdvanceCommitTime(t *testing.T) {
-	block := newEmptyTestBlock()
-
-	expectedTime := logical.Time(10)
-	testSetupTxn, err := block.NewTableTransaction(0, expectedTime)
-	require.NoError(t, err)
-
-	err = testSetupTxn.Commit()
-	require.NoError(t, err)
-
-	testTxn, err := block.NewSnapshotReadTableTransaction(0, 11)
-	require.NoError(t, err)
-
-	err = testTxn.Commit()
-	require.NoError(t, err)
-
-	require.Equal(
-		t,
-		expectedTime,
 		block.LatestCommitExecutionTimeForTestingOnly())
 }
 
 func TestDerivedDataTableCommitBadSnapshotReadInvalidator(t *testing.T) {
 	block := newEmptyTestBlock()
 
-	testTxn, err := block.NewSnapshotReadTableTransaction(0, 42)
-	require.NoError(t, err)
+	testTxn := block.NewSnapshotReadTableTransaction()
 
 	testTxn.AddInvalidator(&testInvalidator{invalidateAll: true})
 

--- a/fvm/storage/logical/time.go
+++ b/fvm/storage/logical/time.go
@@ -41,10 +41,6 @@ const (
 	// such as during script execution.
 	EndOfBlockExecutionTime = ChildBlockTime - 1
 
-	// A snapshot read transaction may occur at any time within the range
-	// [0, EndOfBlockExecutionTime]
-	LargestSnapshotReadTransactionExecutionTime = EndOfBlockExecutionTime
-
 	// A normal transaction cannot commit to EndOfBlockExecutionTime.
 	//
 	// Note that we can assign the time to any value in the range


### PR DESCRIPTION
script are always executed at the end of block