### PR TITLE
Add version beacon storage initialization

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -991,6 +991,7 @@ func (fnb *FlowNodeBuilder) initStorage() error {
 	epochCommits := bstorage.NewEpochCommits(fnb.Metrics.Cache, fnb.DB)
 	statuses := bstorage.NewEpochStatuses(fnb.Metrics.Cache, fnb.DB)
 	commits := bstorage.NewCommits(fnb.Metrics.Cache, fnb.DB)
+	versionBeacons := bstorage.NewVersionBeacons(fnb.DB)
 
 	fnb.Storage = Storage{
 		Headers:            headers,
@@ -1006,6 +1007,7 @@ func (fnb *FlowNodeBuilder) initStorage() error {
 		Collections:        collections,
 		Setups:             setups,
 		EpochCommits:       epochCommits,
+		VersionBeacons:     versionBeacons,
 		Statuses:           statuses,
 		Commits:            commits,
 	}
@@ -1078,6 +1080,7 @@ func (fnb *FlowNodeBuilder) initState() error {
 			fnb.Storage.Setups,
 			fnb.Storage.EpochCommits,
 			fnb.Storage.Statuses,
+			fnb.Storage.VersionBeacons,
 		)
 		if err != nil {
 			return fmt.Errorf("could not open protocol state: %w", err)
@@ -1129,6 +1132,7 @@ func (fnb *FlowNodeBuilder) initState() error {
 			fnb.Storage.Setups,
 			fnb.Storage.EpochCommits,
 			fnb.Storage.Statuses,
+			fnb.Storage.VersionBeacons,
 			fnb.RootSnapshot,
 			options...,
 		)

--- a/cmd/util/cmd/common/state.go
+++ b/cmd/util/cmd/common/state.go
@@ -25,6 +25,7 @@ func InitProtocolState(db *badger.DB, storages *storage.All) (protocol.State, er
 		storages.Setups,
 		storages.EpochCommits,
 		storages.Statuses,
+		storages.VersionBeacons,
 	)
 
 	if err != nil {

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -375,6 +375,7 @@ func createNode(
 	setupsDB := storage.NewEpochSetups(metricsCollector, db)
 	commitsDB := storage.NewEpochCommits(metricsCollector, db)
 	statusesDB := storage.NewEpochStatuses(metricsCollector, db)
+	versionBeaconDB := storage.NewVersionBeacons(db)
 	consumer := events.NewDistributor()
 
 	localID := identity.ID()
@@ -395,6 +396,7 @@ func createNode(
 		setupsDB,
 		commitsDB,
 		statusesDB,
+		versionBeaconDB,
 		rootSnapshot,
 	)
 	require.NoError(t, err)

--- a/engine/common/follower/integration_test.go
+++ b/engine/common/follower/integration_test.go
@@ -52,7 +52,20 @@ func TestFollowerHappyPath(t *testing.T) {
 		all := storageutil.StorageLayer(t, db)
 
 		// bootstrap root snapshot
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		mockTimer := util.MockBlockTimer()
 

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -245,6 +245,7 @@ func CompleteStateFixture(
 		s.Setups,
 		s.EpochCommits,
 		s.Statuses,
+		s.VersionBeacons,
 		rootSnapshot,
 	)
 	require.NoError(t, err)

--- a/integration/testnet/container.go
+++ b/integration/testnet/container.go
@@ -391,6 +391,7 @@ func (c *Container) OpenState() (*state.State, error) {
 	setups := storage.NewEpochSetups(metrics, db)
 	commits := storage.NewEpochCommits(metrics, db)
 	statuses := storage.NewEpochStatuses(metrics, db)
+	versionBeacons := storage.NewVersionBeacons(db)
 
 	return state.OpenState(
 		metrics,
@@ -403,6 +404,7 @@ func (c *Container) OpenState() (*state.State, error) {
 		setups,
 		commits,
 		statuses,
+		versionBeacons,
 	)
 }
 

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -101,7 +101,20 @@ func (suite *BuilderSuite) SetupTest() {
 	rootSnapshot, err := inmem.SnapshotFromBootstrapState(root, result, seal, unittest.QuorumCertificateFixture(unittest.QCWithRootBlockID(root.ID())))
 	require.NoError(suite.T(), err)
 
-	state, err := pbadger.Bootstrap(metrics, suite.db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+	state, err := pbadger.Bootstrap(
+		metrics,
+		suite.db,
+		all.Headers,
+		all.Seals,
+		all.Results,
+		all.Blocks,
+		all.QuorumCertificates,
+		all.Setups,
+		all.EpochCommits,
+		all.Statuses,
+		all.VersionBeacons,
+		rootSnapshot,
+	)
 	require.NoError(suite.T(), err)
 
 	suite.protoState, err = pbadger.NewFollowerState(

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -88,7 +88,20 @@ func (suite *MutatorSuite) SetupTest() {
 
 	suite.protoGenesis = genesis.Header
 
-	state, err := pbadger.Bootstrap(metrics, suite.db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+	state, err := pbadger.Bootstrap(
+		metrics,
+		suite.db,
+		all.Headers,
+		all.Seals,
+		all.Results,
+		all.Blocks,
+		all.QuorumCertificates,
+		all.Setups,
+		all.EpochCommits,
+		all.Statuses,
+		all.VersionBeacons,
+		rootSnapshot,
+	)
 	require.NoError(suite.T(), err)
 
 	suite.protoState, err = pbadger.NewFollowerState(

--- a/state/cluster/badger/snapshot_test.go
+++ b/state/cluster/badger/snapshot_test.go
@@ -68,7 +68,20 @@ func (suite *SnapshotSuite) SetupTest() {
 	participants := unittest.IdentityListFixture(5, unittest.WithAllRoles())
 	root := unittest.RootSnapshotFixture(participants)
 
-	suite.protoState, err = pbadger.Bootstrap(metrics, suite.db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, root)
+	suite.protoState, err = pbadger.Bootstrap(
+		metrics,
+		suite.db,
+		all.Headers,
+		all.Seals,
+		all.Results,
+		all.Blocks,
+		all.QuorumCertificates,
+		all.Setups,
+		all.EpochCommits,
+		all.Statuses,
+		all.VersionBeacons,
+		root,
+	)
 	require.NoError(suite.T(), err)
 
 	suite.Require().Nil(err)

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -103,7 +103,20 @@ func TestExtendValid(t *testing.T) {
 		rootSnapshot, err := inmem.SnapshotFromBootstrapState(block, result, seal, qc)
 		require.NoError(t, err)
 
-		state, err := protocol.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := protocol.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 
 		fullState, err := protocol.NewFullConsensusState(
@@ -639,7 +652,20 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		all := storeutil.StorageLayer(t, db)
-		protoState, err := protocol.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		protoState, err := protocol.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		receiptValidator := util.MockReceiptValidator()
 		sealValidator := util.MockSealValidator(all.Seals)
@@ -1732,7 +1758,20 @@ func TestExtendInvalidSealsInBlock(t *testing.T) {
 
 		rootSnapshot := unittest.RootSnapshotFixture(participants)
 
-		state, err := protocol.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := protocol.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 
 		head, err := rootSnapshot.Head()
@@ -2249,7 +2288,20 @@ func TestHeaderInvalidTimestamp(t *testing.T) {
 		rootSnapshot, err := inmem.SnapshotFromBootstrapState(block, result, seal, qc)
 		require.NoError(t, err)
 
-		state, err := protocol.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := protocol.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 
 		blockTimer := &mockprotocol.BlockTimer{}

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -32,6 +32,7 @@ type State struct {
 		commits  storage.EpochCommits
 		statuses storage.EpochStatuses
 	}
+	versionBeacons storage.VersionBeacons
 	// cache the root height because it cannot change over the lifecycle of a protocol state instance
 	rootHeight uint64
 	// cache the spork root block height because it cannot change over the lifecycle of a protocol state instance
@@ -69,6 +70,7 @@ func Bootstrap(
 	setups storage.EpochSetups,
 	commits storage.EpochCommits,
 	statuses storage.EpochStatuses,
+	versionBeacons storage.VersionBeacons,
 	root protocol.Snapshot,
 	options ...BootstrapConfigOptions,
 ) (*State, error) {
@@ -86,7 +88,19 @@ func Bootstrap(
 		return nil, fmt.Errorf("expected empty database")
 	}
 
-	state := newState(metrics, db, headers, seals, results, blocks, qcs, setups, commits, statuses)
+	state := newState(
+		metrics,
+		db,
+		headers,
+		seals,
+		results,
+		blocks,
+		qcs,
+		setups,
+		commits,
+		statuses,
+		versionBeacons,
+	)
 
 	if err := IsValidRootSnapshot(root, !config.SkipNetworkAddressValidation); err != nil {
 		return nil, fmt.Errorf("cannot bootstrap invalid root snapshot: %w", err)
@@ -555,6 +569,7 @@ func OpenState(
 	setups storage.EpochSetups,
 	commits storage.EpochCommits,
 	statuses storage.EpochStatuses,
+	versionBeacons storage.VersionBeacons,
 ) (*State, error) {
 	isBootstrapped, err := IsBootstrapped(db)
 	if err != nil {
@@ -563,7 +578,19 @@ func OpenState(
 	if !isBootstrapped {
 		return nil, fmt.Errorf("expected database to contain bootstrapped state")
 	}
-	state := newState(metrics, db, headers, seals, results, blocks, qcs, setups, commits, statuses)
+	state := newState(
+		metrics,
+		db,
+		headers,
+		seals,
+		results,
+		blocks,
+		qcs,
+		setups,
+		commits,
+		statuses,
+		versionBeacons,
+	)
 
 	// report last finalized and sealed block height
 	finalSnapshot := state.Final()
@@ -675,6 +702,7 @@ func newState(
 	setups storage.EpochSetups,
 	commits storage.EpochCommits,
 	statuses storage.EpochStatuses,
+	versionBeacons storage.VersionBeacons,
 ) *State {
 	return &State{
 		metrics: metrics,
@@ -693,6 +721,7 @@ func newState(
 			commits:  commits,
 			statuses: statuses,
 		},
+		versionBeacons: versionBeacons,
 	}
 }
 

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -74,6 +74,7 @@ func TestBootstrapAndOpen(t *testing.T) {
 			all.Setups,
 			all.EpochCommits,
 			all.Statuses,
+			all.VersionBeacons,
 		)
 		require.NoError(t, err)
 
@@ -154,6 +155,7 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 			all.Setups,
 			all.EpochCommits,
 			all.Statuses,
+			all.VersionBeacons,
 		)
 		require.NoError(t, err)
 
@@ -524,7 +526,20 @@ func bootstrap(t *testing.T, rootSnapshot protocol.Snapshot, f func(*bprotocol.S
 	db := unittest.BadgerDB(t, dir)
 	defer db.Close()
 	all := storutil.StorageLayer(t, db)
-	state, err := bprotocol.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+	state, err := bprotocol.Bootstrap(
+		metrics,
+		db,
+		all.Headers,
+		all.Seals,
+		all.Results,
+		all.Blocks,
+		all.QuorumCertificates,
+		all.Setups,
+		all.EpochCommits,
+		all.Statuses,
+		all.VersionBeacons,
+		rootSnapshot,
+	)
 	f(state, err)
 }
 

--- a/state/protocol/util/testing.go
+++ b/state/protocol/util/testing.go
@@ -67,7 +67,20 @@ func RunWithBootstrapState(t testing.TB, rootSnapshot protocol.Snapshot, f func(
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		metrics := metrics.NewNoopCollector()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		f(db, state)
 	})
@@ -80,7 +93,20 @@ func RunWithFullProtocolState(t testing.TB, rootSnapshot protocol.Snapshot, f fu
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		receiptValidator := MockReceiptValidator()
 		sealValidator := MockSealValidator(all.Seals)
@@ -97,7 +123,20 @@ func RunWithFullProtocolStateAndMetrics(t testing.TB, rootSnapshot protocol.Snap
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		receiptValidator := MockReceiptValidator()
 		sealValidator := MockSealValidator(all.Seals)
@@ -115,7 +154,20 @@ func RunWithFullProtocolStateAndValidator(t testing.TB, rootSnapshot protocol.Sn
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		sealValidator := MockSealValidator(all.Seals)
 		mockTimer := MockBlockTimer()
@@ -132,7 +184,20 @@ func RunWithFollowerProtocolState(t testing.TB, rootSnapshot protocol.Snapshot, 
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		mockTimer := MockBlockTimer()
 		followerState, err := pbadger.NewFollowerState(log, tracer, consumer, state, all.Index, all.Payloads, mockTimer)
@@ -147,7 +212,20 @@ func RunWithFullProtocolStateAndConsumer(t testing.TB, rootSnapshot protocol.Sna
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		receiptValidator := MockReceiptValidator()
 		sealValidator := MockSealValidator(all.Seals)
@@ -163,7 +241,20 @@ func RunWithFullProtocolStateAndMetricsAndConsumer(t testing.TB, rootSnapshot pr
 		tracer := trace.NewNoopTracer()
 		log := zerolog.Nop()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		receiptValidator := MockReceiptValidator()
 		sealValidator := MockSealValidator(all.Seals)
@@ -181,7 +272,20 @@ func RunWithFollowerProtocolStateAndHeaders(t testing.TB, rootSnapshot protocol.
 		log := zerolog.Nop()
 		consumer := events.NewNoop()
 		all := util.StorageLayer(t, db)
-		state, err := pbadger.Bootstrap(metrics, db, all.Headers, all.Seals, all.Results, all.Blocks, all.QuorumCertificates, all.Setups, all.EpochCommits, all.Statuses, rootSnapshot)
+		state, err := pbadger.Bootstrap(
+			metrics,
+			db,
+			all.Headers,
+			all.Seals,
+			all.Results,
+			all.Blocks,
+			all.QuorumCertificates,
+			all.Setups,
+			all.EpochCommits,
+			all.Statuses,
+			all.VersionBeacons,
+			rootSnapshot,
+		)
 		require.NoError(t, err)
 		mockTimer := MockBlockTimer()
 		followerState, err := pbadger.NewFollowerState(log, tracer, consumer, state, all.Index, all.Payloads, mockTimer)

--- a/storage/all.go
+++ b/storage/all.go
@@ -20,4 +20,5 @@ type All struct {
 	TransactionResults TransactionResults
 	Collections        Collections
 	Events             Events
+	VersionBeacons     VersionBeacons
 }

--- a/storage/badger/all.go
+++ b/storage/badger/all.go
@@ -20,6 +20,7 @@ func InitAll(metrics module.CacheMetrics, db *badger.DB) *storage.All {
 	setups := NewEpochSetups(metrics, db)
 	epochCommits := NewEpochCommits(metrics, db)
 	statuses := NewEpochStatuses(metrics, db)
+	versionBeacons := NewVersionBeacons(db)
 
 	commits := NewCommits(metrics, db)
 	transactions := NewTransactions(metrics, db)
@@ -39,6 +40,7 @@ func InitAll(metrics module.CacheMetrics, db *badger.DB) *storage.All {
 		Setups:             setups,
 		EpochCommits:       epochCommits,
 		Statuses:           statuses,
+		VersionBeacons:     versionBeacons,
 		Results:            results,
 		Receipts:           receipts,
 		ChunkDataPacks:     chunkDataPacks,


### PR DESCRIPTION
Extracted from https://github.com/onflow/flow-go/pull/3736.

This just adds a version beacons parameter to initialization of storage and bootstrapping. 
It does nothing for now, but I wanted  to split this out as it touches a lot of files.