### PR TITLE
[Access] Skip root block when streaming from execution data

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -591,6 +591,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 				node.Storage.Seals,
 				node.Storage.Results,
 				node.RootChainID,
+				builder.executionDataConfig.InitialBlockHeight,
 				builder.apiRatelimits,
 				builder.apiBurstlimits,
 				heroCacheCollector,

--- a/engine/access/state_stream/backend.go
+++ b/engine/access/state_stream/backend.go
@@ -44,14 +44,16 @@ type StateStreamBackend struct {
 	ExecutionDataBackend
 	EventsBackend
 
-	log           zerolog.Logger
-	state         protocol.State
-	headers       storage.Headers
-	seals         storage.Seals
-	results       storage.ExecutionResults
-	execDataStore execution_data.ExecutionDataStore
-	execDataCache *herocache.BlockExecutionData
-	broadcaster   *engine.Broadcaster
+	log             zerolog.Logger
+	state           protocol.State
+	headers         storage.Headers
+	seals           storage.Seals
+	results         storage.ExecutionResults
+	execDataStore   execution_data.ExecutionDataStore
+	execDataCache   *herocache.BlockExecutionData
+	broadcaster     *engine.Broadcaster
+	rootBlockHeight uint64
+	rootBlockID     flow.Identifier
 }
 
 func New(
@@ -67,15 +69,28 @@ func New(
 ) (*StateStreamBackend, error) {
 	logger := log.With().Str("module", "state_stream_api").Logger()
 
+	// cache the root block height and ID for
+	rootHeight, err := state.Params().SporkRootBlockHeight()
+	if err != nil {
+		return nil, fmt.Errorf("could not get spork root block height: %w", err)
+	}
+
+	rootBlockID, err := headers.BlockIDByHeight(rootHeight)
+	if err != nil {
+		return nil, fmt.Errorf("could not get spork root block ID: %w", err)
+	}
+
 	b := &StateStreamBackend{
-		log:           logger,
-		state:         state,
-		headers:       headers,
-		seals:         seals,
-		results:       results,
-		execDataStore: execDataStore,
-		execDataCache: execDataCache,
-		broadcaster:   broadcaster,
+		log:             logger,
+		state:           state,
+		headers:         headers,
+		seals:           seals,
+		results:         results,
+		execDataStore:   execDataStore,
+		execDataCache:   execDataCache,
+		broadcaster:     broadcaster,
+		rootBlockHeight: rootHeight,
+		rootBlockID:     rootBlockID,
 	}
 
 	b.ExecutionDataBackend = ExecutionDataBackend{
@@ -144,7 +159,13 @@ func (b *StateStreamBackend) getStartHeight(startBlockID flow.Identifier, startH
 		return 0, status.Errorf(codes.InvalidArgument, "only one of start block ID and start height may be provided")
 	}
 
-	// first, if a start block ID is provided, use that
+	// if the start block is the spork root block, there will not be an execution data. skip it and
+	// begin from the next block.
+	// Note: we can skip the block lookup since it was already done in the constructor
+	if startBlockID == b.rootBlockID || startHeight == b.rootBlockHeight {
+		return b.rootBlockHeight + 1, nil
+	}
+
 	// invalid or missing block IDs will result in an error
 	if startBlockID != flow.ZeroID {
 		header, err := b.headers.ByBlockID(startBlockID)
@@ -154,9 +175,12 @@ func (b *StateStreamBackend) getStartHeight(startBlockID flow.Identifier, startH
 		return header.Height, nil
 	}
 
-	// next, if the start height is provided, use that
-	// heights that are in the future or before the root block will result in an error
+	// heights that have not been indexed yet will result in an error
 	if startHeight > 0 {
+		if startHeight < b.rootBlockHeight {
+			return 0, status.Errorf(codes.InvalidArgument, "start height must be greater than or equal to the spork root height %d", b.rootBlockHeight)
+		}
+
 		header, err := b.headers.ByHeight(startHeight)
 		if err != nil {
 			return 0, rpc.ConvertStorageError(fmt.Errorf("could not get header for height %d: %w", startHeight, err))

--- a/engine/access/state_stream/backend.go
+++ b/engine/access/state_stream/backend.go
@@ -69,7 +69,7 @@ func New(
 ) (*StateStreamBackend, error) {
 	logger := log.With().Str("module", "state_stream_api").Logger()
 
-	// cache the root block height and ID for
+	// cache the root block height and ID for runtime lookups.
 	rootHeight, err := state.Params().SporkRootBlockHeight()
 	if err != nil {
 		return nil, fmt.Errorf("could not get spork root block height: %w", err)

--- a/engine/access/state_stream/backend_executiondata_test.go
+++ b/engine/access/state_stream/backend_executiondata_test.go
@@ -150,9 +150,6 @@ func (s *BackendExecutionDataSuite) SetupTest() {
 	s.state.On("Sealed").Return(s.snapshot, nil).Maybe()
 	s.snapshot.On("Head").Return(s.blocks[0].Header, nil).Maybe()
 
-	s.state.On("Params").Return(s.params, nil).Maybe()
-	s.params.On("SporkRootBlockHeight").Return(rootBlock.Header.Height, nil).Maybe()
-
 	s.seals.On("FinalizedSealForBlock", mock.AnythingOfType("flow.Identifier")).Return(
 		func(blockID flow.Identifier) *flow.Seal {
 			if seal, ok := s.sealMap[blockID]; ok {
@@ -242,6 +239,7 @@ func (s *BackendExecutionDataSuite) SetupTest() {
 		s.eds,
 		s.execDataCache,
 		s.broadcaster,
+		rootBlock.Header.Height,
 	)
 	require.NoError(s.T(), err)
 }

--- a/engine/access/state_stream/engine.go
+++ b/engine/access/state_stream/engine.go
@@ -78,6 +78,7 @@ func NewEng(
 	seals storage.Seals,
 	results storage.ExecutionResults,
 	chainID flow.ChainID,
+	initialBlockHeight uint64,
 	apiRatelimits map[string]int, // the api rate limit (max calls per second) for each of the gRPC API e.g. Ping->100, GetExecutionDataByBlockID->300
 	apiBurstLimits map[string]int, // the api burst limit (max calls at the same time) for each of the gRPC API e.g. Ping->50, GetExecutionDataByBlockID->10
 	heroCacheMetrics module.HeroCacheMetrics,
@@ -116,7 +117,7 @@ func NewEng(
 
 	broadcaster := engine.NewBroadcaster()
 
-	backend, err := New(logger, config, state, headers, seals, results, execDataStore, execDataCache, broadcaster)
+	backend, err := New(logger, config, state, headers, seals, results, execDataStore, execDataCache, broadcaster, initialBlockHeight)
 	if err != nil {
 		return nil, fmt.Errorf("could not create state stream backend: %w", err)
 	}

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -134,8 +134,8 @@ func (h *Headers) Exists(blockID flow.Identifier) (bool, error) {
 	return exists, nil
 }
 
-// BlockIDByHeight the block ID that is finalized at the given height. It is an optimized version
-// of `ByHeight` that skips retrieving the block. Expected errors during normal operations:
+// BlockIDByHeight returns the block ID that is finalized at the given height. It is an optimized
+// version of `ByHeight` that skips retrieving the block. Expected errors during normal operations:
 //   - `storage.ErrNotFound` if no finalized block is known at given height.
 func (h *Headers) BlockIDByHeight(height uint64) (flow.Identifier, error) {
 	tx := h.db.NewTransaction(false)

--- a/storage/headers.go
+++ b/storage/headers.go
@@ -24,8 +24,8 @@ type Headers interface {
 	// No errors are expected during normal operation.
 	Exists(blockID flow.Identifier) (bool, error)
 
-	// BlockIDByHeight the block ID that is finalized at the given height. It is an optimized version
-	// of `ByHeight` that skips retrieving the block. Expected errors during normal operations:
+	// BlockIDByHeight returns the block ID that is finalized at the given height. It is an optimized
+	// version of `ByHeight` that skips retrieving the block. Expected errors during normal operations:
 	//  * `storage.ErrNotFound` if no finalized block is known at given height
 	BlockIDByHeight(height uint64) (flow.Identifier, error)
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4233

When setting up a new stream and the client requested to start from the root block, skip ahead 1 block. This addresses a corner case caused by the fact that the root block has no execution state changes, and thus has no execution data blob.

For the purposes of the streaming API, the root block is one block before whichever block the node operator chose as the execution sync [start height](https://github.com/onflow/flow-go/blob/6aee5ddaabc5ee6bb7edab5e9c0987b270a0bea8/cmd/access/node_builder/access_node_builder.go#L654). By default, this is the `RootBlock`, which is either the `SporkRootBlock` or the `RootBlock` used when starting the node mid-spork.