### PR TITLE
Add version beacon verify function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,6 @@ require (
 require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/slok/go-http-metrics v0.10.0
-	golang.org/x/mod v0.8.0
 	gonum.org/v1/gonum v0.8.2
 )
 
@@ -267,6 +266,7 @@ require (
 	go.uber.org/dig v1.15.0 // indirect
 	go.uber.org/fx v1.18.2 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/model/flow/version_beacon.go
+++ b/model/flow/version_beacon.go
@@ -1,29 +1,37 @@
 package flow
 
-import "golang.org/x/mod/semver"
+import (
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
+)
 
 // VersionBoundary represents a boundary between semver versions.
-// BlockHeight is the first block height which must be run by the given Version (inclusive).
-// Version is semver string.
+// BlockHeight is the first block height that must be run by the given Version (inclusive).
+// Version is a semver string.
 type VersionBoundary struct {
 	BlockHeight uint64
 	Version     string
 }
 
-// VersionBeacon represents a service event which specifies required software versions
+func (v VersionBoundary) Semver() (*semver.Version, error) {
+	return semver.NewVersion(v.Version)
+}
+
+// VersionBeacon represents a service event specifying the required software versions
 // for upcoming blocks.
 //
-// It contains VersionBoundaries field which is an ordered list of VersionBoundary
-// (ordered by VersionBoundary.BlockHeight). While heights are strictly
-// increasing, versions must be equal or greater, compared by semver semantics.
+// It contains a VersionBoundaries field, which is an ordered list of VersionBoundary
+// (sorted by VersionBoundary.BlockHeight). While heights are strictly
+// increasing, versions must be equal or greater when compared using semver semantics.
 // It must contain at least one entry. The first entry is for a past block height.
-// The rest of the entries are for all future block heights. Future version boundaries
-// can be removed, in which case the event emitted will not contain the removed version
+// The remaining entries are for all future block heights. Future version boundaries
+// can be removed, in which case the emitted event will not contain the removed version
 // boundaries.
-// VersionBeacon is produced by NodeVersionBeacon smart contract.
+// VersionBeacon is produced by the NodeVersionBeacon smart contract.
 //
-// Sequence is event sequence number, which can be used to verify that no event has been
-// skipped by the follower. Everytime the smart contract emits a new event, it increments
+// Sequence is the event sequence number, which can be used to verify that no event has been
+// skipped by the follower. Every time the smart contract emits a new event, it increments
 // the sequence number by one.
 type VersionBeacon struct {
 	VersionBoundaries []VersionBoundary
@@ -44,6 +52,8 @@ func (v *VersionBeacon) ServiceEvent() ServiceEvent {
 	}
 }
 
+// EqualTo returns true if two VersionBeacons are equal.
+// If any of the VersionBeacons has a malformed version, it will return false.
 func (v *VersionBeacon) EqualTo(other *VersionBeacon) bool {
 
 	if v.Sequence != other.Sequence {
@@ -60,10 +70,78 @@ func (v *VersionBeacon) EqualTo(other *VersionBeacon) bool {
 		if v.BlockHeight != other.BlockHeight {
 			return false
 		}
-		if semver.Compare(v.Version, other.Version) != 0 {
+
+		v1, err := v.Semver()
+		if err != nil {
+			return false
+		}
+		v2, err := other.Semver()
+		if err != nil {
+			return false
+		}
+		if !v1.Equal(*v2) {
 			return false
 		}
 	}
 
 	return true
+}
+
+// Validate validates the internal structure of a flow.VersionBeacon.
+// An error with an appropriate message is returned
+// if any validation fails.
+func (v *VersionBeacon) Validate() error {
+	eventError := func(format string, args ...interface{}) error {
+		args = append([]interface{}{v.Sequence}, args...)
+		return fmt.Errorf(
+			"version beacon (sequence=%d) error: "+format,
+			args...,
+		)
+	}
+
+	if len(v.VersionBoundaries) == 0 {
+		return eventError("required version boundaries empty")
+	}
+
+	var previousHeight uint64
+	var previousVersion *semver.Version
+	for i, boundary := range v.VersionBoundaries {
+		version, err := boundary.Semver()
+		if err != nil {
+			return eventError(
+				"invalid semver %s for version boundary (height=%d) (index=%d): %w",
+				boundary.Version,
+				boundary.BlockHeight,
+				i,
+				err,
+			)
+		}
+
+		if i != 0 && previousHeight >= boundary.BlockHeight {
+			return eventError(
+				"higher requirement (index=%d) height %d "+
+					"at or below previous height (index=%d) %d",
+				i,
+				boundary.BlockHeight,
+				i-1,
+				previousHeight,
+			)
+		}
+
+		if i != 0 && version.LessThan(*previousVersion) {
+			return eventError(
+				"higher requirement (index=%d) semver %s "+
+					"lower than previous (index=%d) %s",
+				i,
+				version,
+				i-1,
+				previousVersion,
+			)
+		}
+
+		previousVersion = version
+		previousHeight = boundary.BlockHeight
+	}
+
+	return nil
 }

--- a/model/flow/version_beacon_test.go
+++ b/model/flow/version_beacon_test.go
@@ -19,15 +19,15 @@ func TestEqualTo(t *testing.T) {
 			name: "Equal version beacons",
 			vb1: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
-					{BlockHeight: 1, Version: "v1.0.0"},
-					{BlockHeight: 2, Version: "v1.1.0"},
+					{BlockHeight: 1, Version: "1.0.0"},
+					{BlockHeight: 2, Version: "1.1.0"},
 				},
 				Sequence: 1,
 			},
 			vb2: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
-					{BlockHeight: 1, Version: "v1.0.0"},
-					{BlockHeight: 2, Version: "v1.1.0"},
+					{BlockHeight: 1, Version: "1.0.0"},
+					{BlockHeight: 2, Version: "1.1.0"},
 				},
 				Sequence: 1,
 			},
@@ -37,17 +37,33 @@ func TestEqualTo(t *testing.T) {
 			name: "Different sequence",
 			vb1: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "1.0.0"},
+					{BlockHeight: 2, Version: "1.1.0"},
+				},
+				Sequence: 1,
+			},
+			vb2: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "1.0.0"},
+					{BlockHeight: 2, Version: "1.1.0"},
+				},
+				Sequence: 2,
+			},
+			result: false,
+		},
+		{
+			name: "Equal sequence, but invalid version",
+			vb1: flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
 					{BlockHeight: 1, Version: "v1.0.0"},
-					{BlockHeight: 2, Version: "v1.1.0"},
 				},
 				Sequence: 1,
 			},
 			vb2: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
 					{BlockHeight: 1, Version: "v1.0.0"},
-					{BlockHeight: 2, Version: "v1.1.0"},
 				},
-				Sequence: 2,
+				Sequence: 1,
 			},
 			result: false,
 		},
@@ -55,15 +71,15 @@ func TestEqualTo(t *testing.T) {
 			name: "Different version boundaries",
 			vb1: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
-					{BlockHeight: 1, Version: "v1.0.0"},
-					{BlockHeight: 2, Version: "v1.1.0"},
+					{BlockHeight: 1, Version: "1.0.0"},
+					{BlockHeight: 2, Version: "1.1.0"},
 				},
 				Sequence: 1,
 			},
 			vb2: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
-					{BlockHeight: 1, Version: "v1.0.0"},
-					{BlockHeight: 2, Version: "v1.2.0"},
+					{BlockHeight: 1, Version: "1.0.0"},
+					{BlockHeight: 2, Version: "1.2.0"},
 				},
 				Sequence: 1,
 			},
@@ -73,14 +89,14 @@ func TestEqualTo(t *testing.T) {
 			name: "Different length of version boundaries",
 			vb1: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
-					{BlockHeight: 1, Version: "v1.0.0"},
-					{BlockHeight: 2, Version: "v1.1.0"},
+					{BlockHeight: 1, Version: "1.0.0"},
+					{BlockHeight: 2, Version: "1.1.0"},
 				},
 				Sequence: 1,
 			},
 			vb2: flow.VersionBeacon{
 				VersionBoundaries: []flow.VersionBoundary{
-					{BlockHeight: 1, Version: "v1.0.0"},
+					{BlockHeight: 1, Version: "1.0.0"},
 				},
 				Sequence: 1,
 			},
@@ -91,6 +107,109 @@ func TestEqualTo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.result, tc.vb1.EqualTo(&tc.vb2))
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		vb       *flow.VersionBeacon
+		expected bool
+	}{
+		{
+			name: "empty requirements table is invalid",
+			vb: &flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{},
+				Sequence:          1,
+			},
+			expected: false,
+		},
+		{
+			name: "single version required requirement must be valid semver",
+			vb: &flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "v0.21.37"},
+				},
+				Sequence: 1,
+			},
+			expected: false,
+		},
+		{
+			name: "ordered by height ascending is valid",
+			vb: &flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "0.21.37"},
+					{BlockHeight: 100, Version: "0.21.37"},
+					{BlockHeight: 200, Version: "0.21.37"},
+					{BlockHeight: 300, Version: "0.21.37"},
+				},
+				Sequence: 1,
+			},
+			expected: true,
+		},
+		{
+			name: "decreasing height is invalid",
+			vb: &flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "0.21.37"},
+					{BlockHeight: 200, Version: "0.21.37"},
+					{BlockHeight: 180, Version: "0.21.37"},
+					{BlockHeight: 300, Version: "0.21.37"},
+				},
+				Sequence: 1,
+			},
+			expected: false,
+		},
+		{
+			name: "version higher or equal to the previous one is valid",
+			vb: &flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "0.21.37"},
+					{BlockHeight: 200, Version: "0.21.37"},
+					{BlockHeight: 300, Version: "0.21.38"},
+					{BlockHeight: 400, Version: "1.0.0"},
+				},
+				Sequence: 1,
+			},
+			expected: true,
+		},
+		{
+			name: "any version lower than previous one is invalid",
+			vb: &flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "0.21.37"},
+					{BlockHeight: 200, Version: "1.2.3"},
+					{BlockHeight: 300, Version: "1.2.4"},
+					{BlockHeight: 400, Version: "1.2.3"},
+				},
+				Sequence: 1,
+			},
+			expected: false,
+		},
+		{
+			name: "all version must be valid semver string to be valid",
+			vb: &flow.VersionBeacon{
+				VersionBoundaries: []flow.VersionBoundary{
+					{BlockHeight: 1, Version: "0.21.37"},
+					{BlockHeight: 200, Version: "0.21.37"},
+					{BlockHeight: 300, Version: "0.21.38"},
+					{BlockHeight: 400, Version: "v0.21.39"},
+				},
+				Sequence: 1,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.vb.Validate()
+			if tc.expected {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add version beacon verify function

this was originally added in https://github.com/onflow/flow-go/pull/3736 state/protocol/badger/validity.go but it doesn't really belong there IMO.

I didn't want to use two different libraries for semver so I changed EqualTo to github.com/coreos/go-semver/semver as well