### PR TITLE
Add version beacon to snapshot

### DIFF
--- a/engine/execution/state/unittest/fixtures.go
+++ b/engine/execution/state/unittest/fixtures.go
@@ -46,11 +46,21 @@ func ComputationResultForBlockFixture(
 
 	}
 
+	_, serviceEventEpochCommitProtocol := unittest.EpochCommitFixtureByChainID(flow.Localnet)
+	_, serviceEventEpochSetupProtocol := unittest.EpochSetupFixtureByChainID(flow.Localnet)
+	_, serviceEventVersionBeaconProtocol := unittest.VersionBeaconFixtureByChainID(flow.Localnet)
+
+	convertedServiceEvents := flow.ServiceEventList{
+		serviceEventEpochCommitProtocol.ServiceEvent(),
+		serviceEventEpochSetupProtocol.ServiceEvent(),
+		serviceEventVersionBeaconProtocol.ServiceEvent(),
+	}
+
 	executionResult := flow.NewExecutionResult(
 		parentBlockExecutionResultID,
 		completeBlock.ID(),
 		computationResult.AllChunks(),
-		nil,
+		convertedServiceEvents,
 		flow.ZeroID)
 
 	computationResult.ExecutionReceipt = &flow.ExecutionReceipt{

--- a/model/flow/version_beacon.go
+++ b/model/flow/version_beacon.go
@@ -39,7 +39,8 @@ type VersionBeacon struct {
 }
 
 // SealedVersionBeacon is a VersionBeacon with a SealHeight field.
-// Version beacons are effective only after they are sealed.
+// Version beacons are effective only after the results containing the version beacon
+// are sealed.
 type SealedVersionBeacon struct {
 	*VersionBeacon
 	SealHeight uint64

--- a/module/state_synchronization/requester/execution_data_requester_test.go
+++ b/module/state_synchronization/requester/execution_data_requester_test.go
@@ -753,6 +753,8 @@ type mockSnapshot struct {
 	mu     sync.Mutex
 }
 
+var _ protocol.Snapshot = &mockSnapshot{}
+
 func (m *mockSnapshot) set(header *flow.Header, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -777,10 +779,11 @@ func (m *mockSnapshot) Identity(nodeID flow.Identifier) (*flow.Identity, error) 
 func (m *mockSnapshot) SealedResult() (*flow.ExecutionResult, *flow.Seal, error) {
 	return nil, nil, nil
 }
-func (m *mockSnapshot) Commit() (flow.StateCommitment, error)         { return flow.DummyStateCommitment, nil }
-func (m *mockSnapshot) SealingSegment() (*flow.SealingSegment, error) { return nil, nil }
-func (m *mockSnapshot) Descendants() ([]flow.Identifier, error)       { return nil, nil }
-func (m *mockSnapshot) RandomSource() ([]byte, error)                 { return nil, nil }
-func (m *mockSnapshot) Phase() (flow.EpochPhase, error)               { return flow.EpochPhaseUndefined, nil }
-func (m *mockSnapshot) Epochs() protocol.EpochQuery                   { return nil }
-func (m *mockSnapshot) Params() protocol.GlobalParams                 { return nil }
+func (m *mockSnapshot) Commit() (flow.StateCommitment, error)             { return flow.DummyStateCommitment, nil }
+func (m *mockSnapshot) SealingSegment() (*flow.SealingSegment, error)     { return nil, nil }
+func (m *mockSnapshot) Descendants() ([]flow.Identifier, error)           { return nil, nil }
+func (m *mockSnapshot) RandomSource() ([]byte, error)                     { return nil, nil }
+func (m *mockSnapshot) Phase() (flow.EpochPhase, error)                   { return flow.EpochPhaseUndefined, nil }
+func (m *mockSnapshot) Epochs() protocol.EpochQuery                       { return nil }
+func (m *mockSnapshot) Params() protocol.GlobalParams                     { return nil }
+func (m *mockSnapshot) VersionBeacon() (*flow.SealedVersionBeacon, error) { return nil, nil }

--- a/state/errors.go
+++ b/state/errors.go
@@ -87,7 +87,3 @@ func IsUnverifiableExtensionError(err error) bool {
 	var errUnverifiableExtensionError UnverifiableExtensionError
 	return errors.As(err, &errUnverifiableExtensionError)
 }
-
-// ErrNoVersionBeacon is a sentinel error returned to indicate that no Version Beacon table exists.
-// This is generally expected at the beginning of sporks, and for the lifetime of transient networks.
-var ErrNoVersionBeacon = errors.New("no version beacon exists")

--- a/state/errors.go
+++ b/state/errors.go
@@ -87,3 +87,7 @@ func IsUnverifiableExtensionError(err error) bool {
 	var errUnverifiableExtensionError UnverifiableExtensionError
 	return errors.As(err, &errUnverifiableExtensionError)
 }
+
+// ErrNoVersionBeacon is a sentinel error returned to indicate that no Version Beacon table exists.
+// This is generally expected at the beginning of sporks, and for the lifetime of transient networks.
+var ErrNoVersionBeacon = errors.New("no version beacon exists")

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -996,11 +996,11 @@ func (m *FollowerState) epochStatus(block *flow.Header, epochFallbackTriggered b
 
 }
 
-// versionBeaconOnBlockFinalized extracts the VersionBeacons from the parent block's
-// Seals and returns it.
+// versionBeaconOnBlockFinalized extracts and returns the VersionBeacons from the
+// finalized block's seals.
 // This could return multiple VersionBeacons if the parent block contains multiple Seals.
 // The version beacons will be returned in the ascending height order of the seals.
-// Technically only the last seal is relevant.
+// Technically only the last VersionBeacon is relevant.
 func (m *FollowerState) versionBeaconOnBlockFinalized(
 	finalized *flow.Block,
 ) ([]*flow.SealedVersionBeacon, error) {

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -397,8 +397,9 @@ func TestVersionBeaconIndex(t *testing.T) {
 		versionBeacons := bstorage.NewVersionBeacons(db)
 
 		// No VB can be found before finalizing anything
-		_, err = versionBeacons.Highest(b7.Header.Height)
-		require.ErrorIs(t, err, storage.ErrNotFound)
+		vb, err := versionBeacons.Highest(b7.Header.Height)
+		require.NoError(t, err)
+		require.Nil(t, vb)
 
 		// finalizing b1 - b5
 		err = state.Finalize(context.Background(), b1.ID())
@@ -413,8 +414,9 @@ func TestVersionBeaconIndex(t *testing.T) {
 		require.NoError(t, err)
 
 		// No VB can be found after finalizing B5
-		_, err = versionBeacons.Highest(b7.Header.Height)
-		require.ErrorIs(t, err, storage.ErrNotFound)
+		vb, err = versionBeacons.Highest(b7.Header.Height)
+		require.NoError(t, err)
+		require.Nil(t, vb)
 
 		//  once B6 is finalized, events sealed by B5 are considered in effect, hence index should now find it
 		err = state.Finalize(context.Background(), b6.ID())

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -284,7 +284,7 @@ func TestVersionBeaconIndex(t *testing.T) {
 		// G <- B1 <- B2 (resultB1(vb1)) <- B3 <- B4 (resultB2(vb2), resultB3(vb3)) <- B5 (sealB1) <- B6 (sealB2, sealB3)
 		// up until and including finalization of B5 there should be no VBs indexed
 		//    when B5 is finalized, index VB1
-		//    when B6 is finalized, we can index VB2 and VB3, but the last one should be indexed for a height
+		//    when B6 is finalized, we can index VB2 and VB3, but (only) the last one should be indexed by seal height
 
 		// block 1
 		b1 := unittest.BlockWithParentFixture(rootHeader)
@@ -410,7 +410,7 @@ func TestVersionBeaconIndex(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, vb)
 
-		//  once B6 is finalized, events sealed by B5 are considered in effect, hence index should now find it
+		// once B5 is finalized, B1 and VB1 are sealed, hence index should now find it
 		err = state.Finalize(context.Background(), b5.ID())
 		require.NoError(t, err)
 

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -12,7 +12,6 @@ import (
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/flow/mapfunc"
 	"github.com/onflow/flow-go/model/flow/order"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/fork"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/state/protocol/inmem"
@@ -385,16 +384,7 @@ func (s *Snapshot) VersionBeacon() (*flow.SealedVersionBeacon, error) {
 		return nil, err
 	}
 
-	versionBeacon, err := s.state.versionBeacons.Highest(head.Height)
-
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return nil, state.ErrNoVersionBeacon
-		}
-		return nil, fmt.Errorf("could not query highest version beacon: %w", err)
-	}
-
-	return versionBeacon, nil
+	return s.state.versionBeacons.Highest(head.Height)
 }
 
 // EpochQuery encapsulates querying epochs w.r.t. a snapshot.

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -804,11 +804,11 @@ func (state *State) boostrapVersionBeacon(
 	return func(txn *badger.Txn) error {
 		versionBeacon, err := snapshot.VersionBeacon()
 		if err != nil {
-			// if there is no beacon, do nothing
-			if errors.Is(err, statepkg.ErrNoVersionBeacon) {
-				return nil
-			}
 			return err
+		}
+
+		if versionBeacon == nil {
+			return nil
 		}
 
 		return operation.IndexVersionBeaconByHeight(versionBeacon)(txn)

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/mock"
-	pstate "github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 	bprotocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/inmem"
@@ -83,8 +82,9 @@ func TestBootstrapAndOpen(t *testing.T) {
 
 		unittest.AssertSnapshotsEqual(t, rootSnapshot, state.Final())
 
-		_, err = state.Final().VersionBeacon()
-		require.ErrorIs(t, err, pstate.ErrNoVersionBeacon)
+		vb, err := state.Final().VersionBeacon()
+		require.NoError(t, err)
+		require.Nil(t, vb)
 	})
 }
 

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/module/mock"
+	pstate "github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 	bprotocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/inmem"
@@ -81,6 +82,9 @@ func TestBootstrapAndOpen(t *testing.T) {
 		complianceMetrics.AssertExpectations(t)
 
 		unittest.AssertSnapshotsEqual(t, rootSnapshot, state.Final())
+
+		_, err = state.Final().VersionBeacon()
+		require.ErrorIs(t, err, pstate.ErrNoVersionBeacon)
 	})
 }
 

--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -1,7 +1,6 @@
 package badger
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/committees"
@@ -12,7 +11,6 @@ import (
 	"github.com/onflow/flow-go/model/flow/factory"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/model/flow/order"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 )
 
@@ -353,10 +351,11 @@ func validateClusterQC(cluster protocol.Cluster) error {
 func validateVersionBeacon(snap protocol.Snapshot) error {
 	versionBeacon, err := snap.VersionBeacon()
 	if err != nil {
-		if errors.Is(err, state.ErrNoVersionBeacon) {
-			return nil
-		}
 		return fmt.Errorf("could not get version beacon: %w", err)
+	}
+
+	if versionBeacon == nil {
+		return nil
 	}
 
 	head, err := snap.Head()

--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -348,10 +348,16 @@ func validateClusterQC(cluster protocol.Cluster) error {
 	return nil
 }
 
+// validateVersionBeacon returns an InvalidServiceEventError if the snapshot
+// version beacon is invalid
 func validateVersionBeacon(snap protocol.Snapshot) error {
+	errf := func(msg string, args ...any) error {
+		return protocol.NewInvalidServiceEventErrorf(msg, args)
+	}
+
 	versionBeacon, err := snap.VersionBeacon()
 	if err != nil {
-		return fmt.Errorf("could not get version beacon: %w", err)
+		return errf("could not get version beacon: %w", err)
 	}
 
 	if versionBeacon == nil {
@@ -360,17 +366,17 @@ func validateVersionBeacon(snap protocol.Snapshot) error {
 
 	head, err := snap.Head()
 	if err != nil {
-		return fmt.Errorf("could not get snapshot head: %w", err)
+		return errf("could not get snapshot head: %w", err)
 	}
 
 	// version beacon must be included in a past block to be effective
 	if versionBeacon.SealHeight > head.Height {
-		return fmt.Errorf("version table height higher than highest height")
+		return errf("version table height higher than highest height")
 	}
 
 	err = versionBeacon.Validate()
 	if err != nil {
-		return fmt.Errorf("version beacon is invalid: %w", err)
+		return errf("version beacon is invalid: %w", err)
 	}
 
 	return nil

--- a/state/protocol/badger/validity_test.go
+++ b/state/protocol/badger/validity_test.go
@@ -216,7 +216,7 @@ func TestValidateVersionBeacon(t *testing.T) {
 				VersionBoundaries: []flow.VersionBoundary{
 					{
 						BlockHeight: 0,
-						Version:     "asdf",
+						Version:     "asdf", // invalid semver - hence will be considered invalid
 					},
 				},
 				Sequence: 50,

--- a/state/protocol/badger/validity_test.go
+++ b/state/protocol/badger/validity_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol/mock"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -152,7 +151,7 @@ func TestValidateVersionBeacon(t *testing.T) {
 	t.Run("no version beacon is ok", func(t *testing.T) {
 		snap := new(mock.Snapshot)
 
-		snap.On("VersionBeacon").Return(nil, state.ErrNoVersionBeacon)
+		snap.On("VersionBeacon").Return(nil, nil)
 
 		err := validateVersionBeacon(snap)
 		require.NoError(t, err)

--- a/state/protocol/inmem/convert.go
+++ b/state/protocol/inmem/convert.go
@@ -8,7 +8,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/module/signature"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 )
 
@@ -86,11 +85,7 @@ func FromSnapshot(from protocol.Snapshot) (*Snapshot, error) {
 	// convert version beacon
 	versionBeacon, err := from.VersionBeacon()
 	if err != nil {
-		if errors.Is(err, state.ErrNoVersionBeacon) {
-			snap.SealedVersionBeacon = nil
-		} else {
-			return nil, fmt.Errorf("could not get version beacon: %w", err)
-		}
+		return nil, fmt.Errorf("could not get version beacon: %w", err)
 	} else {
 		snap.SealedVersionBeacon = versionBeacon
 	}

--- a/state/protocol/inmem/convert.go
+++ b/state/protocol/inmem/convert.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/module/signature"
+	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 )
 
@@ -81,6 +82,18 @@ func FromSnapshot(from protocol.Snapshot) (*Snapshot, error) {
 		return nil, fmt.Errorf("could not get params: %w", err)
 	}
 	snap.Params = params.enc
+
+	// convert version beacon
+	versionBeacon, err := from.VersionBeacon()
+	if err != nil {
+		if errors.Is(err, state.ErrNoVersionBeacon) {
+			snap.SealedVersionBeacon = nil
+		} else {
+			return nil, fmt.Errorf("could not get version beacon: %w", err)
+		}
+	} else {
+		snap.SealedVersionBeacon = versionBeacon
+	}
 
 	return &Snapshot{snap}, nil
 }
@@ -330,10 +343,11 @@ func SnapshotFromBootstrapStateWithParams(
 			FirstSeal:        seal,
 			ExtraBlocks:      make([]*flow.Block, 0),
 		},
-		QuorumCertificate: qc,
-		Phase:             flow.EpochPhaseStaking,
-		Epochs:            epochs,
-		Params:            params,
+		QuorumCertificate:   qc,
+		Phase:               flow.EpochPhaseStaking,
+		Epochs:              epochs,
+		Params:              params,
+		SealedVersionBeacon: nil,
 	})
 	return snap, nil
 }

--- a/state/protocol/inmem/convert.go
+++ b/state/protocol/inmem/convert.go
@@ -86,9 +86,9 @@ func FromSnapshot(from protocol.Snapshot) (*Snapshot, error) {
 	versionBeacon, err := from.VersionBeacon()
 	if err != nil {
 		return nil, fmt.Errorf("could not get version beacon: %w", err)
-	} else {
-		snap.SealedVersionBeacon = versionBeacon
 	}
+
+	snap.SealedVersionBeacon = versionBeacon
 
 	return &Snapshot{snap}, nil
 }

--- a/state/protocol/inmem/convert_test.go
+++ b/state/protocol/inmem/convert_test.go
@@ -3,13 +3,13 @@ package inmem_test
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/onflow/flow-go/model/flow"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
 	bprotocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/inmem"

--- a/state/protocol/inmem/convert_test.go
+++ b/state/protocol/inmem/convert_test.go
@@ -3,6 +3,7 @@ package inmem_test
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/onflow/flow-go/model/flow"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -40,7 +41,7 @@ func TestFromSnapshot(t *testing.T) {
 		epoch2, ok := epochBuilder.EpochHeights(2)
 		require.True(t, ok)
 
-		// test that we are able retrieve an in-memory version of root snapshot
+		// test that we are able to retrieve an in-memory version of root snapshot
 		t.Run("root snapshot", func(t *testing.T) {
 			root, err := state.Params().Root()
 			require.NoError(t, err)
@@ -99,6 +100,36 @@ func TestFromSnapshot(t *testing.T) {
 				assertSnapshotsEqual(t, expected, actual)
 				testEncodeDecode(t, actual)
 			})
+		})
+
+		// ensure last version beacon is included
+		t.Run("version beacon", func(t *testing.T) {
+
+			expectedVB := &flow.SealedVersionBeacon{
+				VersionBeacon: unittest.VersionBeaconFixture(
+					unittest.WithBoundaries(
+						flow.VersionBoundary{
+							BlockHeight: 1012,
+							Version:     "1.2.3",
+						}),
+				),
+			}
+			unittest.AddVersionBeacon(t, expectedVB.VersionBeacon, state)
+
+			expected := state.Final()
+			head, err := expected.Head()
+			require.NoError(t, err)
+
+			expectedVB.SealHeight = head.Height
+
+			actual, err := inmem.FromSnapshot(expected)
+			require.NoError(t, err)
+			assertSnapshotsEqual(t, expected, actual)
+			testEncodeDecode(t, actual)
+
+			actualVB, err := actual.VersionBeacon()
+			require.NoError(t, err)
+			require.Equal(t, expectedVB, actualVB)
 		})
 	})
 }

--- a/state/protocol/inmem/encodable.go
+++ b/state/protocol/inmem/encodable.go
@@ -8,15 +8,16 @@ import (
 
 // EncodableSnapshot is the encoding format for protocol.Snapshot
 type EncodableSnapshot struct {
-	Head              *flow.Header
-	Identities        flow.IdentityList
-	LatestSeal        *flow.Seal
-	LatestResult      *flow.ExecutionResult
-	SealingSegment    *flow.SealingSegment
-	QuorumCertificate *flow.QuorumCertificate
-	Phase             flow.EpochPhase
-	Epochs            EncodableEpochs
-	Params            EncodableParams
+	Head                *flow.Header
+	Identities          flow.IdentityList
+	LatestSeal          *flow.Seal
+	LatestResult        *flow.ExecutionResult
+	SealingSegment      *flow.SealingSegment
+	QuorumCertificate   *flow.QuorumCertificate
+	Phase               flow.EpochPhase
+	Epochs              EncodableEpochs
+	Params              EncodableParams
+	SealedVersionBeacon *flow.SealedVersionBeacon
 }
 
 // EncodableEpochs is the encoding format for protocol.EpochQuery

--- a/state/protocol/inmem/snapshot.go
+++ b/state/protocol/inmem/snapshot.go
@@ -2,6 +2,7 @@ package inmem
 
 import (
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/state/protocol/seed"
 )
@@ -70,6 +71,13 @@ func (s Snapshot) Params() protocol.GlobalParams {
 
 func (s Snapshot) Encodable() EncodableSnapshot {
 	return s.enc
+}
+
+func (s Snapshot) VersionBeacon() (*flow.SealedVersionBeacon, error) {
+	if s.enc.SealedVersionBeacon == nil {
+		return nil, state.ErrNoVersionBeacon
+	}
+	return s.enc.SealedVersionBeacon, nil
 }
 
 func SnapshotFromEncodable(enc EncodableSnapshot) *Snapshot {

--- a/state/protocol/inmem/snapshot.go
+++ b/state/protocol/inmem/snapshot.go
@@ -2,7 +2,6 @@ package inmem
 
 import (
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/state"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/state/protocol/seed"
 )
@@ -74,9 +73,6 @@ func (s Snapshot) Encodable() EncodableSnapshot {
 }
 
 func (s Snapshot) VersionBeacon() (*flow.SealedVersionBeacon, error) {
-	if s.enc.SealedVersionBeacon == nil {
-		return nil, state.ErrNoVersionBeacon
-	}
 	return s.enc.SealedVersionBeacon, nil
 }
 

--- a/state/protocol/invalid/snapshot.go
+++ b/state/protocol/invalid/snapshot.go
@@ -75,3 +75,7 @@ func (u *Snapshot) RandomSource() ([]byte, error) {
 func (u *Snapshot) Params() protocol.GlobalParams {
 	return Params{u.err}
 }
+
+func (u *Snapshot) VersionBeacon() (*flow.SealedVersionBeacon, error) {
+	return nil, u.err
+}

--- a/state/protocol/mock/snapshot.go
+++ b/state/protocol/mock/snapshot.go
@@ -313,6 +313,32 @@ func (_m *Snapshot) SealingSegment() (*flow.SealingSegment, error) {
 	return r0, r1
 }
 
+// VersionBeacon provides a mock function with given fields:
+func (_m *Snapshot) VersionBeacon() (*flow.SealedVersionBeacon, error) {
+	ret := _m.Called()
+
+	var r0 *flow.SealedVersionBeacon
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*flow.SealedVersionBeacon, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *flow.SealedVersionBeacon); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*flow.SealedVersionBeacon)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewSnapshot interface {
 	mock.TestingT
 	Cleanup(func())

--- a/state/protocol/snapshot.go
+++ b/state/protocol/snapshot.go
@@ -138,6 +138,10 @@ type Snapshot interface {
 	Params() GlobalParams
 
 	// VersionBeacon returns the latest sealed version beacon.
-	// Returns a generic error in case of unexpected critical internal corruption or bugs
+	// If no version beacon has been sealed so far during the current spork, returns nil.
+	// The latest VersionBeacon is only updated for finalized blocks. This means that, when
+	// querying an un-finalized fork, `VersionBeacon` will have the same value as querying
+	// the snapshot for the latest finalized block, even if a newer version beacon is included
+	// in a seal along the un-finalized fork.
 	VersionBeacon() (*flow.SealedVersionBeacon, error)
 }

--- a/state/protocol/snapshot.go
+++ b/state/protocol/snapshot.go
@@ -136,4 +136,10 @@ type Snapshot interface {
 	// Params returns global parameters of the state this snapshot is taken from.
 	// Returns invalid.Params with state.ErrUnknownSnapshotReference if snapshot reference block is unknown.
 	Params() GlobalParams
+
+	// VersionBeacon returns the latest sealed version beacon.
+	// Returns the following errors:
+	// - state.NoVersionBeaconError when no version beacon is available
+	// - generic error in case of unexpected critical internal corruption or bugs
+	VersionBeacon() (*flow.SealedVersionBeacon, error)
 }

--- a/state/protocol/snapshot.go
+++ b/state/protocol/snapshot.go
@@ -138,8 +138,6 @@ type Snapshot interface {
 	Params() GlobalParams
 
 	// VersionBeacon returns the latest sealed version beacon.
-	// Returns the following errors:
-	// - state.NoVersionBeaconError when no version beacon is available
-	// - generic error in case of unexpected critical internal corruption or bugs
+	// Returns a generic error in case of unexpected critical internal corruption or bugs
 	VersionBeacon() (*flow.SealedVersionBeacon, error)
 }

--- a/storage/badger/operation/version_beacon.go
+++ b/storage/badger/operation/version_beacon.go
@@ -11,7 +11,7 @@ import (
 //
 // No errors are expected during normal operation.
 func IndexVersionBeaconByHeight(
-	beacon flow.SealedVersionBeacon,
+	beacon *flow.SealedVersionBeacon,
 ) func(*badger.Txn) error {
 	return upsert(makePrefix(codeVersionBeacon, beacon.SealHeight), beacon)
 }

--- a/storage/badger/operation/version_beacon_test.go
+++ b/storage/badger/operation/version_beacon_test.go
@@ -51,18 +51,18 @@ func TestResults_IndexByServiceEvents(t *testing.T) {
 		}
 
 		// indexing 3 version beacons at different heights
-		err := db.Update(IndexVersionBeaconByHeight(vb1))
+		err := db.Update(IndexVersionBeaconByHeight(&vb1))
 		require.NoError(t, err)
 
-		err = db.Update(IndexVersionBeaconByHeight(vb2))
+		err = db.Update(IndexVersionBeaconByHeight(&vb2))
 		require.NoError(t, err)
 
-		err = db.Update(IndexVersionBeaconByHeight(vb3))
+		err = db.Update(IndexVersionBeaconByHeight(&vb3))
 		require.NoError(t, err)
 
 		// index version beacon 2 again to make sure we tolerate duplicates
 		// it is possible for two or more events of the same type to be from the same height
-		err = db.Update(IndexVersionBeaconByHeight(vb2))
+		err = db.Update(IndexVersionBeaconByHeight(&vb2))
 		require.NoError(t, err)
 
 		t.Run("retrieve exact height match", func(t *testing.T) {

--- a/storage/badger/version_beacon.go
+++ b/storage/badger/version_beacon.go
@@ -28,11 +28,11 @@ func (r *VersionBeacons) Highest(
 	tx := r.db.NewTransaction(false)
 	defer tx.Discard()
 
-	var beacon *flow.SealedVersionBeacon
+	var beacon flow.SealedVersionBeacon
 
-	err := operation.LookupLastVersionBeaconByHeight(belowOrEqualTo, beacon)(tx)
+	err := operation.LookupLastVersionBeaconByHeight(belowOrEqualTo, &beacon)(tx)
 	if err != nil {
 		return nil, err
 	}
-	return beacon, nil
+	return &beacon, nil
 }

--- a/storage/badger/version_beacon.go
+++ b/storage/badger/version_beacon.go
@@ -2,6 +2,7 @@ package badger
 
 import (
 	"errors"
+
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"

--- a/storage/badger/version_beacon.go
+++ b/storage/badger/version_beacon.go
@@ -1,6 +1,7 @@
 package badger
 
 import (
+	"errors"
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -32,6 +33,9 @@ func (r *VersionBeacons) Highest(
 
 	err := operation.LookupLastVersionBeaconByHeight(belowOrEqualTo, &beacon)(tx)
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return &beacon, nil

--- a/storage/version_beacon.go
+++ b/storage/version_beacon.go
@@ -7,6 +7,7 @@ type VersionBeacons interface {
 
 	// Highest finds the highest flow.SealedVersionBeacon but no higher than
 	// belowOrEqualTo
-	// Returns nil.
+	// Returns nil if no version beacon has been sealed below or equal to the
+	// input height.
 	Highest(belowOrEqualTo uint64) (*flow.SealedVersionBeacon, error)
 }

--- a/storage/version_beacon.go
+++ b/storage/version_beacon.go
@@ -7,7 +7,6 @@ type VersionBeacons interface {
 
 	// Highest finds the highest flow.SealedVersionBeacon but no higher than
 	// belowOrEqualTo
-	// Returns storage.ErrNotFound if no version beacon exists at or below the
-	// given height.
+	// Returns nil.
 	Highest(belowOrEqualTo uint64) (*flow.SealedVersionBeacon, error)
 }

--- a/utils/unittest/version_beacon.go
+++ b/utils/unittest/version_beacon.go
@@ -13,10 +13,10 @@ import (
 // AddVersionBeacon adds blocks sequence with given VersionBeacon so this
 // service events takes effect in Flow protocol.
 // This means execution result where event was emitted is sealed, and the seal is
-// finalized by a valid block, meaning having a QC
+// finalized by a valid block.
 // This assumes state is bootstrapped with a root block, as it does NOT produce
 // results for final block of the state
-// Root <- A <- B(result(A(VB))) <- C(seal(B)) <- D <- E(QC(D))
+// Root <- A <- B(result(A(VB))) <- C(seal(B)) <- D
 func AddVersionBeacon(t *testing.T, beacon *flow.VersionBeacon, state protocol.FollowerState) {
 
 	final, err := state.Final().Head()
@@ -48,10 +48,7 @@ func AddVersionBeacon(t *testing.T, beacon *flow.VersionBeacon, state protocol.F
 	addToState(t, state, C, true)
 
 	D := BlockWithParentFixture(C.Header)
-	addToState(t, state, D, true)
-
-	E := BlockWithParentFixture(D.Header)
-	addToState(t, state, E, false)
+	addToState(t, state, D, false)
 }
 
 func addToState(t *testing.T, state protocol.FollowerState, block *flow.Block, finalize bool) {

--- a/utils/unittest/version_beacon.go
+++ b/utils/unittest/version_beacon.go
@@ -16,7 +16,7 @@ import (
 // finalized by a valid block.
 // This assumes state is bootstrapped with a root block, as it does NOT produce
 // results for final block of the state
-// Root <- A <- B(result(A(VB))) <- C(seal(B)) <- D
+// Root <- A <- B(result(A(VB))) <- C(seal(B))
 func AddVersionBeacon(t *testing.T, beacon *flow.VersionBeacon, state protocol.FollowerState) {
 
 	final, err := state.Final().Head()
@@ -46,9 +46,6 @@ func AddVersionBeacon(t *testing.T, beacon *flow.VersionBeacon, state protocol.F
 		Seals: sealsForB,
 	})
 	addToState(t, state, C, true)
-
-	D := BlockWithParentFixture(C.Header)
-	addToState(t, state, D, false)
 }
 
 func addToState(t *testing.T, state protocol.FollowerState, block *flow.Block, finalize bool) {

--- a/utils/unittest/version_beacon.go
+++ b/utils/unittest/version_beacon.go
@@ -1,0 +1,66 @@
+package unittest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state/protocol"
+)
+
+// AddVersionBeacon adds blocks sequence with given VersionBeacon so this
+// service events takes effect in Flow protocol.
+// This means execution result where event was emitted is sealed, and the seal is
+// finalized by a valid block, meaning having a QC
+// This assumes state is bootstrapped with a root block, as it does NOT produce
+// results for final block of the state
+// Root <- A <- B(result(A(VB))) <- C(seal(B)) <- D <- E(QC(D))
+func AddVersionBeacon(t *testing.T, beacon *flow.VersionBeacon, state protocol.FollowerState) {
+
+	final, err := state.Final().Head()
+
+	require.NoError(t, err)
+
+	A := BlockWithParentFixture(final)
+	A.SetPayload(flow.Payload{})
+	addToState(t, state, A, true)
+
+	receiptA := ReceiptForBlockFixture(A)
+	receiptA.ExecutionResult.ServiceEvents = []flow.ServiceEvent{beacon.ServiceEvent()}
+
+	B := BlockWithParentFixture(A.Header)
+	B.SetPayload(flow.Payload{
+		Receipts: []*flow.ExecutionReceiptMeta{receiptA.Meta()},
+		Results:  []*flow.ExecutionResult{&receiptA.ExecutionResult},
+	})
+	addToState(t, state, B, true)
+
+	sealsForB := []*flow.Seal{
+		Seal.Fixture(Seal.WithResult(&receiptA.ExecutionResult)),
+	}
+
+	C := BlockWithParentFixture(B.Header)
+	C.SetPayload(flow.Payload{
+		Seals: sealsForB,
+	})
+	addToState(t, state, C, true)
+
+	D := BlockWithParentFixture(C.Header)
+	addToState(t, state, D, true)
+
+	E := BlockWithParentFixture(D.Header)
+	addToState(t, state, E, false)
+}
+
+func addToState(t *testing.T, state protocol.FollowerState, block *flow.Block, finalize bool) {
+
+	err := state.ExtendCertified(context.Background(), block, CertifyBlock(block.Header))
+	require.NoError(t, err)
+
+	if finalize {
+		err = state.Finalize(context.Background(), block.ID())
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
The last part of https://github.com/onflow/flow-go/pull/3736.

This one is a bit bigger as it is harder to split.

Some things that still need addressing (in future PRs):
- we have a few switch cases between service events where the default branch errors and thus a branch is needed for all service events event if it is empty. This is not a good pattern. there should be a single place for validating if the service event is of valid type, so we don't have to put empty cases everywhere else.
- the validation that the version beacon service event is sequential is still missing.
