### PR TITLE
rename transaction interfaces to transaction preparer.

### DIFF
--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -1334,7 +1334,7 @@ func generateEvents(eventCount int, txIndex uint32) []flow.Event {
 func getSetAProgram(
 	t *testing.T,
 	storageSnapshot state.StorageSnapshot,
-	derivedTxnData derived.DerivedTransactionCommitter,
+	derivedTxnData *derived.DerivedTransactionData,
 ) {
 
 	txnState := state.NewTransactionState(
@@ -1365,7 +1365,7 @@ type programLoader struct {
 }
 
 func (p *programLoader) Compute(
-	_ state.NestedTransaction,
+	_ state.NestedTransactionPreparer,
 	_ common.AddressLocation,
 ) (
 	*derived.Program,

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -246,7 +246,7 @@ func Bootstrap(
 
 func (b *BootstrapProcedure) NewExecutor(
 	ctx Context,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) ProcedureExecutor {
 	return newBootstrapExecutor(b.BootstrapParams, ctx, txnState)
 }
@@ -279,7 +279,7 @@ type bootstrapExecutor struct {
 	BootstrapParams
 
 	ctx      Context
-	txnState storage.Transaction
+	txnState storage.TransactionPreparer
 
 	accountCreator environment.BootstrapAccountCreator
 }
@@ -287,7 +287,7 @@ type bootstrapExecutor struct {
 func newBootstrapExecutor(
 	params BootstrapParams,
 	ctx Context,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) *bootstrapExecutor {
 	return &bootstrapExecutor{
 		BootstrapParams: params,
@@ -936,8 +936,8 @@ func (b *bootstrapExecutor) invokeMetaTransaction(
 	}
 
 	txn := &storage.SerialTransaction{
-		NestedTransaction:           b.txnState,
-		DerivedTransactionCommitter: prog,
+		NestedTransactionPreparer: b.txnState,
+		DerivedTransactionData:    prog,
 	}
 
 	err = Run(tx.NewExecutor(ctx, txn))

--- a/fvm/environment/account_creator.go
+++ b/fvm/environment/account_creator.go
@@ -37,12 +37,12 @@ type BootstrapAccountCreator interface {
 // This ensures cadence can't access unexpected operations while parsing
 // programs.
 type ParseRestrictedAccountCreator struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     AccountCreator
 }
 
 func NewParseRestrictedAccountCreator(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	creator AccountCreator,
 ) AccountCreator {
 	return ParseRestrictedAccountCreator{
@@ -88,7 +88,7 @@ func (NoAccountCreator) CreateAccount(
 // updates the state when next address is called (This secondary functionality
 // is only used in utility command line).
 type accountCreator struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	chain    flow.Chain
 	accounts Accounts
 
@@ -102,7 +102,7 @@ type accountCreator struct {
 }
 
 func NewAddressGenerator(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	chain flow.Chain,
 ) AddressGenerator {
 	return &accountCreator{
@@ -112,7 +112,7 @@ func NewAddressGenerator(
 }
 
 func NewBootstrapAccountCreator(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	chain flow.Chain,
 	accounts Accounts,
 ) BootstrapAccountCreator {
@@ -124,7 +124,7 @@ func NewBootstrapAccountCreator(
 }
 
 func NewAccountCreator(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	chain flow.Chain,
 	accounts Accounts,
 	isServiceAccountEnabled bool,

--- a/fvm/environment/account_info.go
+++ b/fvm/environment/account_info.go
@@ -24,12 +24,12 @@ type AccountInfo interface {
 }
 
 type ParseRestrictedAccountInfo struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     AccountInfo
 }
 
 func NewParseRestrictedAccountInfo(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl AccountInfo,
 ) AccountInfo {
 	return ParseRestrictedAccountInfo{

--- a/fvm/environment/account_key_reader.go
+++ b/fvm/environment/account_key_reader.go
@@ -32,12 +32,12 @@ type AccountKeyReader interface {
 }
 
 type ParseRestrictedAccountKeyReader struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     AccountKeyReader
 }
 
 func NewParseRestrictedAccountKeyReader(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl AccountKeyReader,
 ) AccountKeyReader {
 	return ParseRestrictedAccountKeyReader{

--- a/fvm/environment/account_key_updater.go
+++ b/fvm/environment/account_key_updater.go
@@ -138,12 +138,12 @@ type AccountKeyUpdater interface {
 }
 
 type ParseRestrictedAccountKeyUpdater struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     AccountKeyUpdater
 }
 
 func NewParseRestrictedAccountKeyUpdater(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl AccountKeyUpdater,
 ) ParseRestrictedAccountKeyUpdater {
 	return ParseRestrictedAccountKeyUpdater{
@@ -259,7 +259,7 @@ type accountKeyUpdater struct {
 	meter  Meter
 
 	accounts Accounts
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	env      Environment
 }
 
@@ -267,7 +267,7 @@ func NewAccountKeyUpdater(
 	tracer tracing.TracerSpan,
 	meter Meter,
 	accounts Accounts,
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	env Environment,
 ) *accountKeyUpdater {
 	return &accountKeyUpdater{

--- a/fvm/environment/accounts.go
+++ b/fvm/environment/accounts.go
@@ -42,10 +42,10 @@ type Accounts interface {
 var _ Accounts = &StatefulAccounts{}
 
 type StatefulAccounts struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 }
 
-func NewAccounts(txnState state.NestedTransaction) *StatefulAccounts {
+func NewAccounts(txnState state.NestedTransactionPreparer) *StatefulAccounts {
 	return &StatefulAccounts{
 		txnState: txnState,
 	}

--- a/fvm/environment/block_info.go
+++ b/fvm/environment/block_info.go
@@ -6,11 +6,11 @@ import (
 	"github.com/onflow/cadence/runtime"
 
 	"github.com/onflow/flow-go/fvm/errors"
-	storageTxn "github.com/onflow/flow-go/fvm/storage"
+	"github.com/onflow/flow-go/fvm/storage"
 	"github.com/onflow/flow-go/fvm/tracing"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/trace"
-	"github.com/onflow/flow-go/storage"
+	storageErr "github.com/onflow/flow-go/storage"
 )
 
 type BlockInfo interface {
@@ -28,12 +28,12 @@ type BlockInfo interface {
 }
 
 type ParseRestrictedBlockInfo struct {
-	txnState storageTxn.Transaction
+	txnState storage.TransactionPreparer
 	impl     BlockInfo
 }
 
 func NewParseRestrictedBlockInfo(
-	txnState storageTxn.Transaction,
+	txnState storage.TransactionPreparer,
 	impl BlockInfo,
 ) BlockInfo {
 	return ParseRestrictedBlockInfo{
@@ -145,7 +145,7 @@ func (info *blockInfo) GetBlockAtHeight(
 	header, err := info.blocks.ByHeightFrom(height, info.blockHeader)
 	// TODO (ramtin): remove dependency on storage and move this if condition
 	// to blockfinder
-	if errors.Is(err, storage.ErrNotFound) {
+	if errors.Is(err, storageErr.ErrNotFound) {
 		return runtime.Block{}, false, nil
 	} else if err != nil {
 		return runtime.Block{}, false, fmt.Errorf(

--- a/fvm/environment/contract_updater.go
+++ b/fvm/environment/contract_updater.go
@@ -80,12 +80,12 @@ type ContractUpdater interface {
 }
 
 type ParseRestrictedContractUpdater struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     ContractUpdater
 }
 
 func NewParseRestrictedContractUpdater(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl ContractUpdater,
 ) ParseRestrictedContractUpdater {
 	return ParseRestrictedContractUpdater{

--- a/fvm/environment/crypto_library.go
+++ b/fvm/environment/crypto_library.go
@@ -54,12 +54,12 @@ type CryptoLibrary interface {
 }
 
 type ParseRestrictedCryptoLibrary struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     CryptoLibrary
 }
 
 func NewParseRestrictedCryptoLibrary(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl CryptoLibrary,
 ) CryptoLibrary {
 	return ParseRestrictedCryptoLibrary{

--- a/fvm/environment/derived_data_invalidator_test.go
+++ b/fvm/environment/derived_data_invalidator_test.go
@@ -265,8 +265,8 @@ func TestMeterParamOverridesUpdated(t *testing.T) {
 	require.NoError(t, err)
 
 	txnState := storage.SerialTransaction{
-		NestedTransaction:           nestedTxn,
-		DerivedTransactionCommitter: derivedTxnData,
+		NestedTransactionPreparer: nestedTxn,
+		DerivedTransactionData:    derivedTxnData,
 	}
 	computer := fvm.NewMeterParamOverridesComputer(ctx, txnState)
 

--- a/fvm/environment/event_emitter.go
+++ b/fvm/environment/event_emitter.go
@@ -50,12 +50,12 @@ type EventEmitter interface {
 }
 
 type ParseRestrictedEventEmitter struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     EventEmitter
 }
 
 func NewParseRestrictedEventEmitter(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl EventEmitter,
 ) EventEmitter {
 	return ParseRestrictedEventEmitter{

--- a/fvm/environment/facade_env.go
+++ b/fvm/environment/facade_env.go
@@ -47,13 +47,13 @@ type facadeEnvironment struct {
 	*Programs
 
 	accounts Accounts
-	txnState storage.Transaction
+	txnState storage.TransactionPreparer
 }
 
 func newFacadeEnvironment(
 	tracer tracing.TracerSpan,
 	params EnvironmentParams,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 	meter Meter,
 ) *facadeEnvironment {
 	accounts := NewAccounts(txnState)
@@ -149,10 +149,10 @@ func NewScriptEnvironmentFromStorageSnapshot(
 	derivedTxn := derivedBlockData.NewSnapshotReadDerivedTransactionData()
 
 	txn := storage.SerialTransaction{
-		NestedTransaction: state.NewTransactionState(
+		NestedTransactionPreparer: state.NewTransactionState(
 			storageSnapshot,
 			state.DefaultParameters()),
-		DerivedTransactionCommitter: derivedTxn,
+		DerivedTransactionData: derivedTxn,
 	}
 
 	return NewScriptEnv(
@@ -166,7 +166,7 @@ func NewScriptEnv(
 	ctx context.Context,
 	tracer tracing.TracerSpan,
 	params EnvironmentParams,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) *facadeEnvironment {
 	env := newFacadeEnvironment(
 		tracer,
@@ -182,7 +182,7 @@ func NewScriptEnv(
 func NewTransactionEnvironment(
 	tracer tracing.TracerSpan,
 	params EnvironmentParams,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) *facadeEnvironment {
 	env := newFacadeEnvironment(
 		tracer,

--- a/fvm/environment/generate-wrappers/main.go
+++ b/fvm/environment/generate-wrappers/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func parseRestricted(
-    txnState state.NestedTransaction,
+    txnState state.NestedTransactionPreparer,
     spanName trace.SpanName,
 ) error {
     if txnState.IsParseRestricted() {
@@ -84,7 +84,7 @@ func generateWrapper(numArgs int, numRets int, content *FileContent) {
 	l("](")
 	push()
 
-	l("txnState state.NestedTransaction,")
+	l("txnState state.NestedTransactionPreparer,")
 	l("spanName trace.SpanName,")
 
 	callbackRet := "error"

--- a/fvm/environment/meter.go
+++ b/fvm/environment/meter.go
@@ -63,10 +63,10 @@ type Meter interface {
 }
 
 type meterImpl struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 }
 
-func NewMeter(txnState state.NestedTransaction) Meter {
+func NewMeter(txnState state.NestedTransactionPreparer) Meter {
 	return &meterImpl{
 		txnState: txnState,
 	}
@@ -115,7 +115,7 @@ type cancellableMeter struct {
 
 func NewCancellableMeter(
 	ctx context.Context,
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 ) Meter {
 	return &cancellableMeter{
 		meterImpl: meterImpl{

--- a/fvm/environment/parse_restricted_checker.go
+++ b/fvm/environment/parse_restricted_checker.go
@@ -9,7 +9,7 @@ import (
 )
 
 func parseRestricted(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 ) error {
 	if txnState.IsParseRestricted() {
@@ -31,7 +31,7 @@ func parseRestricted(
 func parseRestrict1Arg[
 	Arg0T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T) error,
 	arg0 Arg0T,
@@ -48,7 +48,7 @@ func parseRestrict2Arg[
 	Arg0T any,
 	Arg1T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T, Arg1T) error,
 	arg0 Arg0T,
@@ -67,7 +67,7 @@ func parseRestrict3Arg[
 	Arg1T any,
 	Arg2T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T, Arg1T, Arg2T) error,
 	arg0 Arg0T,
@@ -85,7 +85,7 @@ func parseRestrict3Arg[
 func parseRestrict1Ret[
 	Ret0T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func() (Ret0T, error),
 ) (
@@ -105,7 +105,7 @@ func parseRestrict1Arg1Ret[
 	Arg0T any,
 	Ret0T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T) (Ret0T, error),
 	arg0 Arg0T,
@@ -127,7 +127,7 @@ func parseRestrict2Arg1Ret[
 	Arg1T any,
 	Ret0T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T, Arg1T) (Ret0T, error),
 	arg0 Arg0T,
@@ -151,7 +151,7 @@ func parseRestrict3Arg1Ret[
 	Arg2T any,
 	Ret0T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T, Arg1T, Arg2T) (Ret0T, error),
 	arg0 Arg0T,
@@ -177,7 +177,7 @@ func parseRestrict4Arg1Ret[
 	Arg3T any,
 	Ret0T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T, Arg1T, Arg2T, Arg3T) (Ret0T, error),
 	arg0 Arg0T,
@@ -206,7 +206,7 @@ func parseRestrict6Arg1Ret[
 	Arg5T any,
 	Ret0T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T, Arg1T, Arg2T, Arg3T, Arg4T, Arg5T) (Ret0T, error),
 	arg0 Arg0T,
@@ -233,7 +233,7 @@ func parseRestrict1Arg2Ret[
 	Ret0T any,
 	Ret1T any,
 ](
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	spanName trace.SpanName,
 	callback func(Arg0T) (Ret0T, Ret1T, error),
 	arg0 Arg0T,

--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -29,7 +29,7 @@ type Programs struct {
 	meter   Meter
 	metrics MetricsReporter
 
-	txnState storage.Transaction
+	txnState storage.TransactionPreparer
 	accounts Accounts
 
 	// NOTE: non-address programs are not reusable across transactions, hence
@@ -45,7 +45,7 @@ func NewPrograms(
 	tracer tracing.TracerSpan,
 	meter Meter,
 	metrics MetricsReporter,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 	accounts Accounts,
 ) *Programs {
 	return &Programs{
@@ -220,7 +220,7 @@ func newProgramLoader(
 }
 
 func (loader *programLoader) Compute(
-	txState state.NestedTransaction,
+	txState state.NestedTransactionPreparer,
 	location common.AddressLocation,
 ) (
 	*derived.Program,

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -89,7 +89,7 @@ var (
 
 func setupProgramsTest(t *testing.T) storage.SnapshotTree {
 	txnState := storage.SerialTransaction{
-		NestedTransaction: state.NewTransactionState(
+		NestedTransactionPreparer: state.NewTransactionState(
 			nil,
 			state.DefaultParameters()),
 	}

--- a/fvm/environment/transaction_info.go
+++ b/fvm/environment/transaction_info.go
@@ -48,12 +48,12 @@ type TransactionInfo interface {
 }
 
 type ParseRestrictedTransactionInfo struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     TransactionInfo
 }
 
 func NewParseRestrictedTransactionInfo(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl TransactionInfo,
 ) TransactionInfo {
 	return ParseRestrictedTransactionInfo{

--- a/fvm/environment/unsafe_random_generator.go
+++ b/fvm/environment/unsafe_random_generator.go
@@ -32,12 +32,12 @@ type unsafeRandomGenerator struct {
 }
 
 type ParseRestrictedUnsafeRandomGenerator struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     UnsafeRandomGenerator
 }
 
 func NewParseRestrictedUnsafeRandomGenerator(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl UnsafeRandomGenerator,
 ) UnsafeRandomGenerator {
 	return ParseRestrictedUnsafeRandomGenerator{

--- a/fvm/environment/uuids.go
+++ b/fvm/environment/uuids.go
@@ -16,12 +16,12 @@ type UUIDGenerator interface {
 }
 
 type ParseRestrictedUUIDGenerator struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     UUIDGenerator
 }
 
 func NewParseRestrictedUUIDGenerator(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl UUIDGenerator,
 ) UUIDGenerator {
 	return ParseRestrictedUUIDGenerator{
@@ -41,13 +41,13 @@ type uUIDGenerator struct {
 	tracer tracing.TracerSpan
 	meter  Meter
 
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 }
 
 func NewUUIDGenerator(
 	tracer tracing.TracerSpan,
 	meter Meter,
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 ) *uUIDGenerator {
 	return &uUIDGenerator{
 		tracer:   tracer,

--- a/fvm/environment/value_store.go
+++ b/fvm/environment/value_store.go
@@ -24,12 +24,12 @@ type ValueStore interface {
 }
 
 type ParseRestrictedValueStore struct {
-	txnState state.NestedTransaction
+	txnState state.NestedTransactionPreparer
 	impl     ValueStore
 }
 
 func NewParseRestrictedValueStore(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	impl ValueStore,
 ) ValueStore {
 	return ParseRestrictedValueStore{

--- a/fvm/executionParameters.go
+++ b/fvm/executionParameters.go
@@ -45,7 +45,7 @@ func getBasicMeterParameters(
 func getBodyMeterParameters(
 	ctx Context,
 	proc Procedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) (
 	meter.MeterParameters,
 	error,
@@ -84,12 +84,12 @@ func getBodyMeterParameters(
 
 type MeterParamOverridesComputer struct {
 	ctx      Context
-	txnState storage.Transaction
+	txnState storage.TransactionPreparer
 }
 
 func NewMeterParamOverridesComputer(
 	ctx Context,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) MeterParamOverridesComputer {
 	return MeterParamOverridesComputer{
 		ctx:      ctx,
@@ -98,7 +98,7 @@ func NewMeterParamOverridesComputer(
 }
 
 func (computer MeterParamOverridesComputer) Compute(
-	_ state.NestedTransaction,
+	_ state.NestedTransactionPreparer,
 	_ struct{},
 ) (
 	derived.MeterParamOverrides,

--- a/fvm/fvm.go
+++ b/fvm/fvm.go
@@ -87,7 +87,7 @@ func Run(executor ProcedureExecutor) error {
 type Procedure interface {
 	NewExecutor(
 		ctx Context,
-		txnState storage.Transaction,
+		txnState storage.TransactionPreparer,
 	) ProcedureExecutor
 
 	ComputationLimit(ctx Context) uint64
@@ -158,7 +158,7 @@ func (vm *VirtualMachine) Run(
 			uint32(proc.ExecutionTime()))
 	}
 
-	var derivedTxnData derived.DerivedTransactionCommitter
+	var derivedTxnData *derived.DerivedTransactionData
 	var err error
 	switch proc.Type() {
 	case ScriptProcedureType:
@@ -187,8 +187,8 @@ func (vm *VirtualMachine) Run(
 			WithMaxValueSizeAllowed(ctx.MaxStateValueSize))
 
 	txnState := &storage.SerialTransaction{
-		NestedTransaction:           nestedTxn,
-		DerivedTransactionCommitter: derivedTxnData,
+		NestedTransactionPreparer: nestedTxn,
+		DerivedTransactionData:    derivedTxnData,
 	}
 
 	executor := proc.NewExecutor(ctx, txnState)
@@ -238,8 +238,8 @@ func (vm *VirtualMachine) GetAccount(
 	derivedTxnData := derivedBlockData.NewSnapshotReadDerivedTransactionData()
 
 	txnState := &storage.SerialTransaction{
-		NestedTransaction:           nestedTxn,
-		DerivedTransactionCommitter: derivedTxnData,
+		NestedTransactionPreparer: nestedTxn,
+		DerivedTransactionData:    derivedTxnData,
 	}
 
 	env := environment.NewScriptEnv(

--- a/fvm/mock/procedure.go
+++ b/fvm/mock/procedure.go
@@ -58,11 +58,11 @@ func (_m *Procedure) MemoryLimit(ctx fvm.Context) uint64 {
 }
 
 // NewExecutor provides a mock function with given fields: ctx, txnState
-func (_m *Procedure) NewExecutor(ctx fvm.Context, txnState storage.Transaction) fvm.ProcedureExecutor {
+func (_m *Procedure) NewExecutor(ctx fvm.Context, txnState storage.TransactionPreparer) fvm.ProcedureExecutor {
 	ret := _m.Called(ctx, txnState)
 
 	var r0 fvm.ProcedureExecutor
-	if rf, ok := ret.Get(0).(func(fvm.Context, storage.Transaction) fvm.ProcedureExecutor); ok {
+	if rf, ok := ret.Get(0).(func(fvm.Context, storage.TransactionPreparer) fvm.ProcedureExecutor); ok {
 		r0 = rf(ctx, txnState)
 	} else {
 		if ret.Get(0) != nil {

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -71,7 +71,7 @@ func NewScriptWithContextAndArgs(
 
 func (proc *ScriptProcedure) NewExecutor(
 	ctx Context,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) ProcedureExecutor {
 	return newScriptExecutor(ctx, proc, txnState)
 }
@@ -115,7 +115,7 @@ func (proc *ScriptProcedure) ExecutionTime() logical.Time {
 type scriptExecutor struct {
 	ctx      Context
 	proc     *ScriptProcedure
-	txnState storage.Transaction
+	txnState storage.TransactionPreparer
 
 	env environment.Environment
 
@@ -125,7 +125,7 @@ type scriptExecutor struct {
 func newScriptExecutor(
 	ctx Context,
 	proc *ScriptProcedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) *scriptExecutor {
 	return &scriptExecutor{
 		ctx:      ctx,

--- a/fvm/storage/derived/derived_chain_data_test.go
+++ b/fvm/storage/derived/derived_chain_data_test.go
@@ -50,7 +50,7 @@ func TestDerivedChainData(t *testing.T) {
 
 	_, err = txn.GetOrComputeProgram(txState, loc1, newProgramLoader(
 		func(
-			txnState state.NestedTransaction,
+			txnState state.NestedTransactionPreparer,
 			key common.AddressLocation,
 		) (*Program, error) {
 			return prog1, nil
@@ -85,7 +85,7 @@ func TestDerivedChainData(t *testing.T) {
 
 	_, err = txn.GetOrComputeProgram(txState, loc2, newProgramLoader(
 		func(
-			txnState state.NestedTransaction,
+			txnState state.NestedTransactionPreparer,
 			key common.AddressLocation,
 		) (*Program, error) {
 			return prog2, nil
@@ -182,7 +182,7 @@ func TestDerivedChainData(t *testing.T) {
 
 type programLoader struct {
 	f func(
-		txnState state.NestedTransaction,
+		txnState state.NestedTransactionPreparer,
 		key common.AddressLocation,
 	) (*Program, error)
 }
@@ -191,7 +191,7 @@ var _ ValueComputer[common.AddressLocation, *Program] = &programLoader{}
 
 func newProgramLoader(
 	f func(
-		txnState state.NestedTransaction,
+		txnState state.NestedTransactionPreparer,
 		key common.AddressLocation,
 	) (*Program, error),
 ) *programLoader {
@@ -201,7 +201,7 @@ func newProgramLoader(
 }
 
 func (p *programLoader) Compute(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	key common.AddressLocation,
 ) (*Program, error) {
 	return p.f(txnState, key)

--- a/fvm/storage/derived/table.go
+++ b/fvm/storage/derived/table.go
@@ -14,7 +14,7 @@ import (
 // ValueComputer is used by DerivedDataTable's GetOrCompute to compute the
 // derived value when the value is not in DerivedDataTable (i.e., "cache miss").
 type ValueComputer[TKey any, TVal any] interface {
-	Compute(txnState state.NestedTransaction, key TKey) (TVal, error)
+	Compute(txnState state.NestedTransactionPreparer, key TKey) (TVal, error)
 }
 
 type invalidatableEntry[TVal any] struct {
@@ -423,7 +423,7 @@ func (txn *TableTransaction[TKey, TVal]) SetForTestingOnly(
 // Note: valFunc must be an idempotent function and it must not modify
 // txnState's values.
 func (txn *TableTransaction[TKey, TVal]) GetOrCompute(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	key TKey,
 	computer ValueComputer[TKey, TVal],
 ) (

--- a/fvm/storage/derived/table_test.go
+++ b/fvm/storage/derived/table_test.go
@@ -946,7 +946,7 @@ type testValueComputer struct {
 }
 
 func (computer *testValueComputer) Compute(
-	txnState state.NestedTransaction,
+	txnState state.NestedTransactionPreparer,
 	key flow.RegisterID,
 ) (
 	int,

--- a/fvm/storage/state/transaction_state.go
+++ b/fvm/storage/state/transaction_state.go
@@ -37,9 +37,9 @@ type Meter interface {
 	RunWithAllLimitsDisabled(f func())
 }
 
-// NestedTransaction provides active transaction states and facilitates common
-// state management operations.
-type NestedTransaction interface {
+// NestedTransactionPreparer provides active transaction states and facilitates
+// common state management operations.
+type NestedTransactionPreparer interface {
 	Meter
 
 	// NumNestedTransactions returns the number of uncommitted nested
@@ -171,7 +171,7 @@ type transactionState struct {
 func NewTransactionState(
 	snapshot StorageSnapshot,
 	params StateParameters,
-) NestedTransaction {
+) NestedTransactionPreparer {
 	startState := NewExecutionState(snapshot, params)
 	return &transactionState{
 		nestedTransactions: []nestedTransactionStackFrame{

--- a/fvm/storage/state/transaction_state_test.go
+++ b/fvm/storage/state/transaction_state_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func newTestTransactionState() state.NestedTransaction {
+func newTestTransactionState() state.NestedTransactionPreparer {
 	return state.NewTransactionState(
 		nil,
 		state.DefaultParameters(),

--- a/fvm/storage/testutils/utils.go
+++ b/fvm/storage/testutils/utils.go
@@ -18,9 +18,9 @@ func NewSimpleTransaction(
 	}
 
 	return &storage.SerialTransaction{
-		NestedTransaction: state.NewTransactionState(
+		NestedTransactionPreparer: state.NewTransactionState(
 			snapshot,
 			state.DefaultParameters()),
-		DerivedTransactionCommitter: derivedTxnData,
+		DerivedTransactionData: derivedTxnData,
 	}
 }

--- a/fvm/storage/transaction.go
+++ b/fvm/storage/transaction.go
@@ -5,13 +5,13 @@ import (
 	"github.com/onflow/flow-go/fvm/storage/state"
 )
 
-type Transaction interface {
-	state.NestedTransaction
-	derived.DerivedTransaction
+type TransactionPreparer interface {
+	state.NestedTransactionPreparer
+	derived.DerivedTransactionPreparer
 }
 
 type TransactionComitter interface {
-	Transaction
+	TransactionPreparer
 
 	// Validate returns nil if the transaction does not conflict with
 	// previously committed transactions.  It returns an error otherwise.
@@ -25,6 +25,6 @@ type TransactionComitter interface {
 
 // TODO(patrick): implement proper transaction.
 type SerialTransaction struct {
-	state.NestedTransaction
-	derived.DerivedTransactionCommitter
+	state.NestedTransactionPreparer
+	*derived.DerivedTransactionData
 }

--- a/fvm/transaction.go
+++ b/fvm/transaction.go
@@ -38,7 +38,7 @@ type TransactionProcedure struct {
 
 func (proc *TransactionProcedure) NewExecutor(
 	ctx Context,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) ProcedureExecutor {
 	return newTransactionExecutor(ctx, proc, txnState)
 }

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -53,7 +53,7 @@ type transactionExecutor struct {
 
 	ctx      Context
 	proc     *TransactionProcedure
-	txnState storage.Transaction
+	txnState storage.TransactionPreparer
 
 	span otelTrace.Span
 	env  environment.Environment
@@ -72,7 +72,7 @@ type transactionExecutor struct {
 func newTransactionExecutor(
 	ctx Context,
 	proc *TransactionProcedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) *transactionExecutor {
 	span := ctx.StartChildSpan(trace.FVMExecuteTransaction)
 	span.SetAttributes(attribute.String("transaction_id", proc.ID.String()))

--- a/fvm/transactionPayerBalanceChecker.go
+++ b/fvm/transactionPayerBalanceChecker.go
@@ -14,7 +14,7 @@ type TransactionPayerBalanceChecker struct{}
 
 func (_ TransactionPayerBalanceChecker) CheckPayerBalanceAndReturnMaxFees(
 	proc *TransactionProcedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 	env environment.Environment,
 ) (uint64, error) {
 	if !env.TransactionFeesEnabled() {

--- a/fvm/transactionSequenceNum.go
+++ b/fvm/transactionSequenceNum.go
@@ -16,7 +16,7 @@ type TransactionSequenceNumberChecker struct{}
 func (c TransactionSequenceNumberChecker) CheckAndIncrementSequenceNumber(
 	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) error {
 	// TODO(Janez): verification is part of inclusion fees, not execution fees.
 	var err error
@@ -34,7 +34,7 @@ func (c TransactionSequenceNumberChecker) CheckAndIncrementSequenceNumber(
 func (c TransactionSequenceNumberChecker) checkAndIncrementSequenceNumber(
 	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 ) error {
 
 	defer tracer.StartChildSpan(trace.FVMSeqNumCheckTransaction).End()

--- a/fvm/transactionVerifier.go
+++ b/fvm/transactionVerifier.go
@@ -168,7 +168,7 @@ type TransactionVerifier struct {
 func (v *TransactionVerifier) CheckAuthorization(
 	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 	keyWeightThreshold int,
 ) error {
 	// TODO(Janez): verification is part of inclusion fees, not execution fees.
@@ -188,7 +188,7 @@ func (v *TransactionVerifier) CheckAuthorization(
 func (v *TransactionVerifier) verifyTransaction(
 	tracer tracing.TracerSpan,
 	proc *TransactionProcedure,
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 	keyWeightThreshold int,
 ) error {
 	span := tracer.StartChildSpan(trace.FVMVerifyTransaction)
@@ -259,7 +259,7 @@ func (v *TransactionVerifier) verifyTransaction(
 // getAccountKeys gets the signatures' account keys and populate the account
 // keys into the signature continuation structs.
 func (v *TransactionVerifier) getAccountKeys(
-	txnState storage.Transaction,
+	txnState storage.TransactionPreparer,
 	accounts environment.Accounts,
 	signatures []*signatureContinuation,
 	proposalKey flow.ProposalKey,

--- a/fvm/transactionVerifier_test.go
+++ b/fvm/transactionVerifier_test.go
@@ -39,7 +39,7 @@ func TestTransactionVerification(t *testing.T) {
 	run := func(
 		body *flow.TransactionBody,
 		ctx fvm.Context,
-		txn storage.Transaction,
+		txn storage.TransactionPreparer,
 	) error {
 		executor := fvm.Transaction(body, 0).NewExecutor(ctx, txn)
 		err := fvm.Run(executor)


### PR DESCRIPTION
This is more consistent with db literature since these apis are only accessible during the prepare phase of 2PC.