### PR TITLE
Compliance Core - clean up extra arg

### DIFF
--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -202,7 +202,7 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Clus
 	// if the proposal is connected to a block that is neither in the cache, nor
 	// in persistent storage, its direct parent is missing; cache the proposal
 	// and request the parent
-	parent, err := c.headers.ByBlockID(header.ParentID)
+	_, err = c.headers.ByBlockID(header.ParentID)
 	if errors.Is(err, storage.ErrNotFound) {
 		_ = c.pending.Add(originID, block)
 
@@ -222,7 +222,7 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Clus
 	// execution of the entire recursion, which might include processing the
 	// proposal's pending children. There is another span within
 	// processBlockProposal that measures the time spent for a single proposal.
-	err = c.processBlockAndDescendants(block, parent)
+	err = c.processBlockAndDescendants(block)
 	c.mempoolMetrics.MempoolEntries(metrics.ResourceClusterProposal, c.pending.Size())
 	if err != nil {
 		return fmt.Errorf("could not process block proposal: %w", err)
@@ -235,17 +235,17 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Clus
 // its pending descendants. By induction, any child block of a
 // valid proposal is itself connected to the finalized state and can be
 // processed as well.
-func (c *Core) processBlockAndDescendants(proposal *cluster.Block, parent *flow.Header) error {
+func (c *Core) processBlockAndDescendants(proposal *cluster.Block) error {
 	blockID := proposal.ID()
 	log := c.log.With().
 		Str("block_id", blockID.String()).
 		Uint64("block_height", proposal.Header.Height).
 		Uint64("block_view", proposal.Header.View).
-		Uint64("parent_view", parent.View).
+		Uint64("parent_view", proposal.Header.ParentView).
 		Logger()
 
 	// process block itself
-	err := c.processBlockProposal(proposal, parent)
+	err := c.processBlockProposal(proposal)
 	if err != nil {
 		if checkForAndLogOutdatedInputError(err, log) || checkForAndLogUnverifiableInputError(err, log) {
 			return nil
@@ -274,7 +274,7 @@ func (c *Core) processBlockAndDescendants(proposal *cluster.Block, parent *flow.
 		return nil
 	}
 	for _, child := range children {
-		cpr := c.processBlockAndDescendants(child.Message, proposal.Header)
+		cpr := c.processBlockAndDescendants(child.Message)
 		if cpr != nil {
 			// unexpected error: potentially corrupted internal state => abort processing and escalate error
 			return cpr
@@ -293,7 +293,7 @@ func (c *Core) processBlockAndDescendants(proposal *cluster.Block, parent *flow.
 //   - engine.OutdatedInputError if the block proposal is outdated (e.g. orphaned)
 //   - engine.InvalidInputError if the block proposal is invalid
 //   - engine.UnverifiableInputError if the proposal cannot be validated
-func (c *Core) processBlockProposal(proposal *cluster.Block, parent *flow.Header) error {
+func (c *Core) processBlockProposal(proposal *cluster.Block) error {
 	header := proposal.Header
 	blockID := header.ID()
 	log := c.log.With().

--- a/engine/collection/compliance/core_test.go
+++ b/engine/collection/compliance/core_test.go
@@ -96,6 +96,13 @@ func (cs *CommonSuite) SetupTest() {
 			return nil
 		},
 	)
+	cs.headers.On("Exists", mock.Anything).Return(
+		func(blockID flow.Identifier) bool {
+			_, exists := cs.headerDB[blockID]
+			return exists
+		}, func(blockID flow.Identifier) error {
+			return nil
+		})
 
 	// set up protocol state mock
 	cs.state = &clusterstate.MutableState{}
@@ -436,7 +443,7 @@ func (cs *CoreSuite) TestProcessBlockAndDescendants() {
 	}
 
 	// execute the connected children handling
-	err := cs.core.processBlockAndDescendants(&parent, cs.head.Header)
+	err := cs.core.processBlockAndDescendants(&parent)
 	require.NoError(cs.T(), err, "should pass handling children")
 
 	// check that we submitted each child to hotstuff

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -210,17 +210,17 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Bloc
 	// if the proposal is connected to a block that is neither in the cache, nor
 	// in persistent storage, its direct parent is missing; cache the proposal
 	// and request the parent
-	parent, err := c.headers.ByBlockID(header.ParentID)
-	if errors.Is(err, storage.ErrNotFound) {
+	exists, err := c.headers.Exists(header.ParentID)
+	if err != nil {
+		return fmt.Errorf("could not check parent exists: %w", err)
+	}
+	if !exists {
 		_ = c.pending.Add(originID, block)
 		c.mempoolMetrics.MempoolEntries(metrics.ResourceProposal, c.pending.Size())
 
 		c.sync.RequestBlock(header.ParentID, header.Height-1)
 		log.Debug().Msg("requesting missing parent for proposal")
 		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("could not check parent: %w", err)
 	}
 
 	// At this point, we should be able to connect the proposal to the finalized
@@ -229,7 +229,7 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Bloc
 	// execution of the entire recursion, which might include processing the
 	// proposal's pending children. There is another span within
 	// processBlockProposal that measures the time spent for a single proposal.
-	err = c.processBlockAndDescendants(block, parent)
+	err = c.processBlockAndDescendants(block)
 	c.mempoolMetrics.MempoolEntries(metrics.ResourceProposal, c.pending.Size())
 	if err != nil {
 		return fmt.Errorf("could not process block proposal: %w", err)
@@ -244,18 +244,18 @@ func (c *Core) OnBlockProposal(originID flow.Identifier, proposal *messages.Bloc
 // processed as well.
 // No errors are expected during normal operation. All returned exceptions
 // are potential symptoms of internal state corruption and should be fatal.
-func (c *Core) processBlockAndDescendants(proposal *flow.Block, parent *flow.Header) error {
+func (c *Core) processBlockAndDescendants(proposal *flow.Block) error {
 	blockID := proposal.Header.ID()
 
 	log := c.log.With().
 		Str("block_id", blockID.String()).
 		Uint64("block_height", proposal.Header.Height).
 		Uint64("block_view", proposal.Header.View).
-		Uint64("parent_view", parent.View).
+		Uint64("parent_view", proposal.Header.ParentView).
 		Logger()
 
 	// process block itself
-	err := c.processBlockProposal(proposal, parent)
+	err := c.processBlockProposal(proposal)
 	if err != nil {
 		if checkForAndLogOutdatedInputError(err, log) {
 			return nil
@@ -284,7 +284,7 @@ func (c *Core) processBlockAndDescendants(proposal *flow.Block, parent *flow.Hea
 		return nil
 	}
 	for _, child := range children {
-		cpr := c.processBlockAndDescendants(child.Message, proposal.Header)
+		cpr := c.processBlockAndDescendants(child.Message)
 		if cpr != nil {
 			// unexpected error: potentially corrupted internal state => abort processing and escalate error
 			return cpr
@@ -302,7 +302,7 @@ func (c *Core) processBlockAndDescendants(proposal *flow.Block, parent *flow.Hea
 // Expected errors during normal operations:
 //   - engine.OutdatedInputError if the block proposal is outdated (e.g. orphaned)
 //   - engine.InvalidInputError if the block proposal is invalid
-func (c *Core) processBlockProposal(proposal *flow.Block, parent *flow.Header) error {
+func (c *Core) processBlockProposal(proposal *flow.Block) error {
 	startTime := time.Now()
 	defer func() {
 		c.hotstuffMetrics.BlockProcessingDuration(time.Since(startTime))

--- a/engine/consensus/compliance/core_test.go
+++ b/engine/consensus/compliance/core_test.go
@@ -130,6 +130,13 @@ func (cs *CommonSuite) SetupTest() {
 			return nil
 		},
 	)
+	cs.headers.On("Exists", mock.Anything).Return(
+		func(blockID flow.Identifier) bool {
+			_, exists := cs.headerDB[blockID]
+			return exists
+		}, func(blockID flow.Identifier) error {
+			return nil
+		})
 
 	// set up payload storage mock
 	cs.payloads = &storage.Payloads{}
@@ -511,7 +518,7 @@ func (cs *CoreSuite) TestProcessBlockAndDescendants() {
 	}
 
 	// execute the connected children handling
-	err := cs.core.processBlockAndDescendants(parent, cs.head)
+	err := cs.core.processBlockAndDescendants(parent)
 	require.NoError(cs.T(), err, "should pass handling children")
 
 	// make sure we drop the cache after trying to process


### PR DESCRIPTION
- Removes unecessary `parent` argument
- Uses `Exists` method rather than retrieving the whole parent header