### PR TITLE
Change system transaction to have dual authorizers

### DIFF
--- a/fvm/blueprints/scripts/systemChunkTransactionTemplateDualAuthorizer.cdc
+++ b/fvm/blueprints/scripts/systemChunkTransactionTemplateDualAuthorizer.cdc
@@ -1,0 +1,18 @@
+import FlowEpoch from 0xEPOCHADDRESS
+import NodeVersionBeacon from 0xNODEVERSIONBEACONADDRESS
+
+transaction {
+    prepare(serviceAccount: AuthAccount, epochAccount: AuthAccount) {
+        let epochHeartbeat =
+            serviceAccount.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath) ??
+            epochAccount.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath) ??
+            panic("Could not borrow heartbeat from storage path")
+        epochHeartbeat.advanceBlock()
+
+        let versionBeaconHeartbeat =
+            serviceAccount.borrow<&NodeVersionBeacon.Heartbeat>(from: NodeVersionBeacon.HeartbeatStoragePath) ??
+            epochAccount.borrow<&NodeVersionBeacon.Heartbeat>(from: NodeVersionBeacon.HeartbeatStoragePath) ??
+            panic("Couldn't borrow NodeVersionBeacon.Heartbeat Resource")
+        versionBeaconHeartbeat.heartbeat()
+    }
+}

--- a/fvm/blueprints/system.go
+++ b/fvm/blueprints/system.go
@@ -14,15 +14,31 @@ const SystemChunkTransactionGasLimit = 100_000_000
 
 // TODO (Ramtin) after changes to this method are merged into master move them here.
 
+// systemChunkTransactionTemplate looks for the epoch and version beacon heartbeat resources
+// and calls them.
+//
 //go:embed scripts/systemChunkTransactionTemplate.cdc
 var systemChunkTransactionTemplate string
 
-// SystemChunkTransaction creates and returns the transaction corresponding to the system chunk
-// for the given chain.
+// SystemChunkTransaction creates and returns the transaction corresponding to the
+// system chunk for the given chain.
 func SystemChunkTransaction(chain flow.Chain) (*flow.TransactionBody, error) {
 	contracts, err := systemcontracts.SystemContractsForChain(chain.ChainID())
 	if err != nil {
 		return nil, fmt.Errorf("could not get system contracts for chain: %w", err)
+	}
+
+	// this is only true for testnet, sandboxnet and mainnet.
+	if contracts.Epoch.Address != chain.ServiceAddress() {
+		// Temporary workaround because the heartbeat resources need to be moved
+		// to the service account:
+		//  - the system chunk will attempt to load both Epoch and VersionBeacon
+		//      resources from either the service account or the staking account
+		//  - the service account committee can then safely move the resources
+		//      at any time
+		//  - once the resources are moved, this workaround should be removed
+		//      after version v0.31.0
+		return systemChunkTransactionDualAuthorizers(chain, contracts)
 	}
 
 	tx := flow.NewTransactionBody().
@@ -35,6 +51,34 @@ func SystemChunkTransaction(chain flow.Chain) (*flow.TransactionBody, error) {
 				},
 			)),
 		).
+		AddAuthorizer(contracts.Epoch.Address).
+		SetGasLimit(SystemChunkTransactionGasLimit)
+
+	return tx, nil
+}
+
+// systemChunkTransactionTemplateDualAuthorizer is the same as systemChunkTransactionTemplate
+// but it looks for the heartbeat resources on two different accounts.
+//
+//go:embed scripts/systemChunkTransactionTemplateDualAuthorizer.cdc
+var systemChunkTransactionTemplateDualAuthorizer string
+
+func systemChunkTransactionDualAuthorizers(
+	chain flow.Chain,
+	contracts *systemcontracts.SystemContracts,
+) (*flow.TransactionBody, error) {
+
+	tx := flow.NewTransactionBody().
+		SetScript(
+			[]byte(templates.ReplaceAddresses(
+				systemChunkTransactionTemplateDualAuthorizer,
+				templates.Environment{
+					EpochAddress:             contracts.Epoch.Address.Hex(),
+					NodeVersionBeaconAddress: contracts.NodeVersionBeacon.Address.Hex(),
+				},
+			)),
+		).
+		AddAuthorizer(chain.ServiceAddress()).
 		AddAuthorizer(contracts.Epoch.Address).
 		SetGasLimit(SystemChunkTransactionGasLimit)
 


### PR DESCRIPTION
See https://github.com/onflow/flow-go/issues/4291 for details.

I tested that the system transaction work on testnet/mainnet by running the following script:

```cadence
import FlowEpoch from 0x9eca2b38b18b5dfe
import NodeVersionBeacon from 0x8c5303eaa26202d6

pub fun main(): UInt64 {
    let serviceAccount = getAuthAccount(0x8c5303eaa26202d6)
    let epochAccount = getAuthAccount(0x9eca2b38b18b5dfe)


    let epochHeartbeat =
        serviceAccount.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath) ??
        epochAccount.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath) ??
        panic("Could not borrow heartbeat from storage path")
    epochHeartbeat.advanceBlock()

    let versionBeaconHeartbeat =
        serviceAccount.borrow<&NodeVersionBeacon.Heartbeat>(from: NodeVersionBeacon.HeartbeatStoragePath) ??
        epochAccount.borrow<&NodeVersionBeacon.Heartbeat>(from: NodeVersionBeacon.HeartbeatStoragePath) ??
        panic("Couldn't borrow NodeVersionBeacon.Heartbeat Resource")
    versionBeaconHeartbeat.heartbeat()

    return 1
}
```
