### PR TITLE
[Tests] Flaky tests for compliance engine

### DIFF
--- a/engine/collection/compliance/engine_test.go
+++ b/engine/collection/compliance/engine_test.go
@@ -165,8 +165,6 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 		for i := 0; i < blockCount; i++ {
 			block := unittest.ClusterBlockWithParent(cs.head)
 			proposal := messages.NewClusterBlockProposal(&block)
-			// store the data for retrieval
-			cs.headerDB[block.Header.ParentID] = cs.head
 			hotstuffProposal := model.ProposalFromFlow(block.Header)
 			cs.hotstuff.On("SubmitProposal", hotstuffProposal).Return().Once()
 			cs.voteAggregator.On("AddBlock", hotstuffProposal).Once()
@@ -185,8 +183,6 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 		block := unittest.ClusterBlockWithParent(cs.head)
 		proposal := messages.NewClusterBlockProposal(&block)
 
-		// store the data for retrieval
-		cs.headerDB[block.Header.ParentID] = cs.head
 		hotstuffProposal := model.ProposalFromFlow(block.Header)
 		cs.hotstuff.On("SubmitProposal", hotstuffProposal).Once()
 		cs.voteAggregator.On("AddBlock", hotstuffProposal).Once()

--- a/engine/consensus/compliance/engine_test.go
+++ b/engine/consensus/compliance/engine_test.go
@@ -70,7 +70,6 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 		for i := 0; i < blockCount; i++ {
 			block := unittest.BlockWithParentFixture(cs.head)
 			proposal := messages.NewBlockProposal(block)
-			cs.headerDB[block.Header.ParentID] = cs.head
 			hotstuffProposal := model.ProposalFromFlow(block.Header)
 			cs.hotstuff.On("SubmitProposal", hotstuffProposal).Return().Once()
 			cs.voteAggregator.On("AddBlock", hotstuffProposal).Once()
@@ -89,8 +88,6 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 		block := unittest.BlockWithParentFixture(cs.head)
 		proposal := unittest.ProposalFromBlock(block)
 
-		// store the data for retrieval
-		cs.headerDB[block.Header.ParentID] = cs.head
 		hotstuffProposal := model.ProposalFromFlow(block.Header)
 		cs.hotstuff.On("SubmitProposal", hotstuffProposal).Return().Once()
 		cs.voteAggregator.On("AddBlock", hotstuffProposal).Once()


### PR DESCRIPTION
### Context

This PR fixes two flaky unit tests for consensus and cluster consensus compliance engines. This behavior was caused by concurrent writes to unprotected map. I have removed that logic since it isn't needed anymore.