### PR TITLE
[Fix] Fixes flaky `TestGossipSubSpamMitigationIntegration`

### DIFF
--- a/insecure/rpc_inspector/validation_inspector_test.go
+++ b/insecure/rpc_inspector/validation_inspector_test.go
@@ -420,6 +420,9 @@ func TestGossipSubSpamMitigationIntegration(t *testing.T) {
 	spammer.SpamControlMessage(t, victimNode, pruneCtlMsgsInvalidSporkIDTopic)
 	spammer.SpamControlMessage(t, victimNode, pruneCtlMsgsDuplicateTopic)
 
+	// wait for two GossipSub heartbeat intervals to ensure that the victim node has penalized the spammer node.
+	time.Sleep(2 * time.Second)
+
 	// now we expect the detection and mitigation to kick in and the victim node to disconnect from the spammer node.
 	// so the spammer and victim nodes should not be able to exchange messages on the topic.
 	p2ptest.EnsureNoPubsubExchangeBetweenGroups(t, ctx, []p2p.LibP2PNode{victimNode}, []p2p.LibP2PNode{spammer.SpammerNode}, func() (interface{}, channels.Topic) {


### PR DESCRIPTION
This PR fixing flaky `TestGossipSubSpamMitigationIntegration` test. That was failing with the following error: 

```
=== CONT  TestGossipSubSpamMitigationIntegration
    unittest.go:223: 
        	Error Trace:	/home/runner/work/flow-go/flow-go/utils/unittest/unittest.go:223
        	            				/home/runner/work/flow-go/flow-go/network/internal/p2pfixtures/fixtures.go:180
        	            				/home/runner/work/flow-go/flow-go/network/internal/p2pfixtures/fixtures.go:210
        	            				/home/runner/work/flow-go/flow-go/network/p2p/test/fixtures.go:509
        	            				/home/runner/work/flow-go/flow-go/network/p2p/test/fixtures.go:517
        	            				/home/runner/work/flow-go/flow-go/insecure/rpc_inspector/validation_inspector_test.go:425
        	Error:      	could not close done channel on time: timeout did not happen on receiving expected pubsub message
        	Test:       	TestGossipSubSpamMitigationIntegration
    identity_provider.go:95: PASS:	ByPeerID(string)
--- FAIL: TestGossipSubSpamMitigationIntegration (12.64s)
```


The primary cause of the test failure is the error: `timeout did not happen on receiving expected pubsub message`. The test anticipates that the spammer will encounter a timeout when sending pubsub messages to the victim. This expectation is based on the assumption that after a few spam messages have been sent by the spammer, the victim's penalization system will activate and sever all pubsub connections to the spammer.

However, the issue arises because it takes at least one GossipSub heartbeat (1s) for the penalization system to engage after detecting an attack. The test does not account for this delay and proceeds to immediately evaluate the pubsub message exchange cutoff between the spammer and victim, potentially leading to premature evaluation. Sometimes, the evaluation may occur before the next heartbeat, meaning the penalty system has not yet been activated.

To address this flaky behavior, we introduce a forced sleep of 2 seconds to guarantee that at least one GossipSub heartbeat has been processed, ensuring the penalization mechanism is in effect before assessing the pubsub connection health between the spammer and victim.

To validate the effectiveness of this solution in resolving the flaky behavior, we ran the test 100 times using a fast-fail approach and observed that there were no failures.

```
go test -run TestGossipSubSpamMitigationIntegration github.com/onflow/flow-go/insecure/rpc_inspector -count 100 -failfast --tags=relic --vv

ok      github.com/onflow/flow-go/insecure/rpc_inspector        1301.758s
```

