### PR TITLE
Queue transaction requests instead of returning a slice of transaction requests

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -40,53 +40,7 @@ type collectionInfo struct {
 	isSystemTransaction bool
 }
 
-func newTransactions(
-	collection collectionInfo,
-	collectionCtx fvm.Context,
-	startTxnIndex int,
-) []transaction {
-	txns := make([]transaction, 0, len(collection.Transactions))
-
-	logger := collectionCtx.Logger.With().
-		Str("block_id", collection.blockIdStr).
-		Uint64("height", collectionCtx.BlockHeader.Height).
-		Bool("system_chunk", collection.isSystemTransaction).
-		Bool("system_transaction", collection.isSystemTransaction).
-		Logger()
-
-	for idx, txnBody := range collection.Transactions {
-		txnId := txnBody.ID()
-		txnIdStr := txnId.String()
-		txnIndex := uint32(startTxnIndex + idx)
-		txns = append(
-			txns,
-			transaction{
-				collectionInfo: collection,
-				txnId:          txnId,
-				txnIdStr:       txnIdStr,
-				txnIndex:       txnIndex,
-				ctx: fvm.NewContextFromParent(
-					collectionCtx,
-					fvm.WithLogger(
-						logger.With().
-							Str("tx_id", txnIdStr).
-							Uint32("tx_index", txnIndex).
-							Logger())),
-				TransactionProcedure: fvm.NewTransaction(
-					txnId,
-					txnIndex,
-					txnBody),
-			})
-	}
-
-	if len(txns) > 0 {
-		txns[len(txns)-1].lastTransactionInCollection = true
-	}
-
-	return txns
-}
-
-type transaction struct {
+type transactionRequest struct {
 	collectionInfo
 
 	txnId    flow.Identifier
@@ -98,6 +52,37 @@ type transaction struct {
 
 	ctx fvm.Context
 	*fvm.TransactionProcedure
+}
+
+func newTransactionRequest(
+	collection collectionInfo,
+	collectionCtx fvm.Context,
+	collectionLogger zerolog.Logger,
+	txnIndex uint32,
+	txnBody *flow.TransactionBody,
+	lastTransactionInCollection bool,
+) transactionRequest {
+	txnId := txnBody.ID()
+	txnIdStr := txnId.String()
+
+	return transactionRequest{
+		collectionInfo: collection,
+		txnId:          txnId,
+		txnIdStr:       txnIdStr,
+		txnIndex:       txnIndex,
+		ctx: fvm.NewContextFromParent(
+			collectionCtx,
+			fvm.WithLogger(
+				collectionLogger.With().
+					Str("tx_id", txnIdStr).
+					Uint32("tx_index", txnIndex).
+					Logger())),
+		TransactionProcedure: fvm.NewTransaction(
+			txnId,
+			txnIndex,
+			txnBody),
+		lastTransactionInCollection: lastTransactionInCollection,
+	}
 }
 
 // A BlockComputer executes the transactions in a block.
@@ -200,71 +185,89 @@ func (e *blockComputer) ExecuteBlock(
 	return results, nil
 }
 
-func (e *blockComputer) getRootSpanAndTransactions(
-	block *entity.ExecutableBlock,
+func (e *blockComputer) queueTransactionRequests(
+	blockId flow.Identifier,
+	blockIdStr string,
+	blockHeader *flow.Header,
 	derivedBlockData *derived.DerivedBlockData,
-) (
-	otelTrace.Span,
-	[]transaction,
-	error,
+	rawCollections []*entity.CompleteCollection,
+	systemTxnBody *flow.TransactionBody,
+	requestQueue chan transactionRequest,
 ) {
-	rawCollections := block.Collections()
-	var transactions []transaction
+	txnIndex := uint32(0)
 
-	blockId := block.ID()
-	blockIdStr := blockId.String()
-
-	blockCtx := fvm.NewContextFromParent(
+	// TODO(patrick): remove derivedBlockData from context
+	collectionCtx := fvm.NewContextFromParent(
 		e.vmCtx,
-		fvm.WithBlockHeader(block.Block.Header),
+		fvm.WithBlockHeader(blockHeader),
 		fvm.WithDerivedBlockData(derivedBlockData))
 
-	startTxnIndex := 0
 	for idx, collection := range rawCollections {
-		transactions = append(
-			transactions,
-			newTransactions(
-				collectionInfo{
-					blockId:             blockId,
-					blockIdStr:          blockIdStr,
-					collectionIndex:     idx,
-					CompleteCollection:  collection,
-					isSystemTransaction: false,
-				},
-				blockCtx,
-				startTxnIndex)...)
-		startTxnIndex += len(collection.Transactions)
+		collectionLogger := collectionCtx.Logger.With().
+			Str("block_id", blockIdStr).
+			Uint64("height", blockHeader.Height).
+			Bool("system_chunk", false).
+			Bool("system_transaction", false).
+			Logger()
+
+		collectionInfo := collectionInfo{
+			blockId:             blockId,
+			blockIdStr:          blockIdStr,
+			collectionIndex:     idx,
+			CompleteCollection:  collection,
+			isSystemTransaction: false,
+		}
+
+		for i, txnBody := range collection.Transactions {
+			requestQueue <- newTransactionRequest(
+				collectionInfo,
+				collectionCtx,
+				collectionLogger,
+				txnIndex,
+				txnBody,
+				i == len(collection.Transactions)-1)
+			txnIndex += 1
+		}
+
 	}
 
-	systemTxn, err := blueprints.SystemChunkTransaction(e.vmCtx.Chain)
-	if err != nil {
-		return trace.NoopSpan, nil, fmt.Errorf(
-			"could not get system chunk transaction: %w",
-			err)
-	}
-
+	// TODO(patrick): remove derivedBlockData from context
 	systemCtx := fvm.NewContextFromParent(
 		e.systemChunkCtx,
-		fvm.WithBlockHeader(block.Block.Header),
+		fvm.WithBlockHeader(blockHeader),
 		fvm.WithDerivedBlockData(derivedBlockData))
-	systemCollection := &entity.CompleteCollection{
-		Transactions: []*flow.TransactionBody{systemTxn},
+	systemCollectionLogger := systemCtx.Logger.With().
+		Str("block_id", blockIdStr).
+		Uint64("height", blockHeader.Height).
+		Bool("system_chunk", true).
+		Bool("system_transaction", true).
+		Logger()
+	systemCollectionInfo := collectionInfo{
+		blockId:         blockId,
+		blockIdStr:      blockIdStr,
+		collectionIndex: len(rawCollections),
+		CompleteCollection: &entity.CompleteCollection{
+			Transactions: []*flow.TransactionBody{systemTxnBody},
+		},
+		isSystemTransaction: true,
 	}
 
-	transactions = append(
-		transactions,
-		newTransactions(
-			collectionInfo{
-				blockId:             blockId,
-				blockIdStr:          blockIdStr,
-				collectionIndex:     len(rawCollections),
-				CompleteCollection:  systemCollection,
-				isSystemTransaction: true,
-			},
-			systemCtx,
-			startTxnIndex)...)
+	requestQueue <- newTransactionRequest(
+		systemCollectionInfo,
+		systemCtx,
+		systemCollectionLogger,
+		txnIndex,
+		systemTxnBody,
+		true)
+}
 
-	return e.tracer.BlockRootSpan(blockId), transactions, nil
+func numberOfTransactionsInBlock(collections []*entity.CompleteCollection) int {
+	numTxns := 1 // there's one system transaction per block
+	for _, collection := range collections {
+		numTxns += len(collection.Transactions)
+	}
+
+	return numTxns
 }
 
 func (e *blockComputer) executeBlock(
@@ -282,18 +285,27 @@ func (e *blockComputer) executeBlock(
 		return nil, fmt.Errorf("executable block start state is not set")
 	}
 
-	rootSpan, transactions, err := e.getRootSpanAndTransactions(
-		block,
-		derivedBlockData)
+	blockId := block.ID()
+	blockIdStr := blockId.String()
+
+	rawCollections := block.Collections()
+
+	blockSpan := e.tracer.StartSpanFromParent(
+		e.tracer.BlockRootSpan(blockId),
+		trace.EXEComputeBlock)
+	blockSpan.SetAttributes(
+		attribute.String("block_id", blockIdStr),
+		attribute.Int("collection_counts", len(rawCollections)))
+	defer blockSpan.End()
+
+	systemTxn, err := blueprints.SystemChunkTransaction(e.vmCtx.Chain)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"could not get system chunk transaction: %w",
+			err)
 	}
 
-	blockSpan := e.tracer.StartSpanFromParent(rootSpan, trace.EXEComputeBlock)
-	blockSpan.SetAttributes(
-		attribute.String("block_id", block.ID().String()),
-		attribute.Int("collection_counts", len(block.CompleteCollections)))
-	defer blockSpan.End()
+	numTxns := numberOfTransactionsInBlock(rawCollections)
 
 	collector := newResultCollector(
 		e.tracer,
@@ -306,31 +318,41 @@ func (e *blockComputer) executeBlock(
 		e.receiptHasher,
 		parentBlockExecutionResultID,
 		block,
-		len(transactions),
+		numTxns,
 		e.colResCons)
 	defer collector.Stop()
 
+	requestQueue := make(chan transactionRequest, numTxns)
+	e.queueTransactionRequests(
+		blockId,
+		blockIdStr,
+		block.Block.Header,
+		derivedBlockData,
+		rawCollections,
+		systemTxn,
+		requestQueue)
+	close(requestQueue)
+
 	snapshotTree := snapshot.NewSnapshotTree(baseSnapshot)
-	for _, txn := range transactions {
+	for request := range requestQueue {
 		txnExecutionSnapshot, output, err := e.executeTransaction(
 			blockSpan,
-			txn,
-			snapshotTree,
-			collector)
+			request,
+			snapshotTree)
 		if err != nil {
 			prefix := ""
-			if txn.isSystemTransaction {
+			if request.isSystemTransaction {
 				prefix = "system "
 			}
 
 			return nil, fmt.Errorf(
 				"failed to execute %stransaction at txnIndex %v: %w",
 				prefix,
-				txn.txnIndex,
+				request.txnIndex,
 				err)
 		}
 
-		collector.AddTransactionResult(txn, txnExecutionSnapshot, output)
+		collector.AddTransactionResult(request, txnExecutionSnapshot, output)
 		snapshotTree = snapshotTree.Append(txnExecutionSnapshot)
 	}
 
@@ -350,9 +372,8 @@ func (e *blockComputer) executeBlock(
 
 func (e *blockComputer) executeTransaction(
 	parentSpan otelTrace.Span,
-	txn transaction,
+	request transactionRequest,
 	storageSnapshot snapshot.StorageSnapshot,
-	collector *resultCollector,
 ) (
 	*snapshot.ExecutionSnapshot,
 	fvm.ProcedureOutput,
@@ -363,37 +384,37 @@ func (e *blockComputer) executeTransaction(
 
 	txSpan := e.tracer.StartSampledSpanFromParent(
 		parentSpan,
-		txn.txnId,
+		request.txnId,
 		trace.EXEComputeTransaction)
 	txSpan.SetAttributes(
-		attribute.String("tx_id", txn.txnIdStr),
-		attribute.Int64("tx_index", int64(txn.txnIndex)),
-		attribute.Int("col_index", txn.collectionIndex),
+		attribute.String("tx_id", request.txnIdStr),
+		attribute.Int64("tx_index", int64(request.txnIndex)),
+		attribute.Int("col_index", request.collectionIndex),
 	)
 	defer txSpan.End()
 
 	logger := e.log.With().
-		Str("tx_id", txn.txnIdStr).
-		Uint32("tx_index", txn.txnIndex).
-		Str("block_id", txn.blockIdStr).
-		Uint64("height", txn.ctx.BlockHeader.Height).
-		Bool("system_chunk", txn.isSystemTransaction).
-		Bool("system_transaction", txn.isSystemTransaction).
+		Str("tx_id", request.txnIdStr).
+		Uint32("tx_index", request.txnIndex).
+		Str("block_id", request.blockIdStr).
+		Uint64("height", request.ctx.BlockHeader.Height).
+		Bool("system_chunk", request.isSystemTransaction).
+		Bool("system_transaction", request.isSystemTransaction).
 		Logger()
 	logger.Info().Msg("executing transaction in fvm")
 
-	txn.ctx = fvm.NewContextFromParent(txn.ctx, fvm.WithSpan(txSpan))
+	request.ctx = fvm.NewContextFromParent(request.ctx, fvm.WithSpan(txSpan))
 
 	executionSnapshot, output, err := e.vm.Run(
-		txn.ctx,
-		txn.TransactionProcedure,
+		request.ctx,
+		request.TransactionProcedure,
 		storageSnapshot)
 	if err != nil {
 		return nil, fvm.ProcedureOutput{}, fmt.Errorf(
 			"failed to execute transaction %v for block %s at height %v: %w",
-			txn.txnIdStr,
-			txn.blockIdStr,
-			txn.ctx.BlockHeader.Height,
+			request.txnIdStr,
+			request.blockIdStr,
+			request.ctx.BlockHeader.Height,
 			err)
 	}
 
@@ -416,7 +437,7 @@ func (e *blockComputer) executeTransaction(
 			Logger()
 		logger.Info().Msg("transaction execution failed")
 
-		if txn.isSystemTransaction {
+		if request.isSystemTransaction {
 			// This log is used as the data source for an alert on grafana.
 			// The system_chunk_error field must not be changed without adding
 			// the corresponding changes in grafana.

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -41,7 +41,7 @@ type ViewCommitter interface {
 }
 
 type transactionResult struct {
-	transaction
+	transactionRequest
 	*snapshot.ExecutionSnapshot
 	fvm.ProcedureOutput
 }
@@ -215,7 +215,7 @@ func (collector *resultCollector) commitCollection(
 }
 
 func (collector *resultCollector) processTransactionResult(
-	txn transaction,
+	txn transactionRequest,
 	txnExecutionSnapshot *snapshot.ExecutionSnapshot,
 	output fvm.ProcedureOutput,
 ) error {
@@ -258,14 +258,14 @@ func (collector *resultCollector) processTransactionResult(
 }
 
 func (collector *resultCollector) AddTransactionResult(
-	txn transaction,
+	txn transactionRequest,
 	snapshot *snapshot.ExecutionSnapshot,
 	output fvm.ProcedureOutput,
 ) {
 	result := transactionResult{
-		transaction:       txn,
-		ExecutionSnapshot: snapshot,
-		ProcedureOutput:   output,
+		transactionRequest: txn,
+		ExecutionSnapshot:  snapshot,
+		ProcedureOutput:    output,
 	}
 
 	select {
@@ -281,7 +281,7 @@ func (collector *resultCollector) runResultProcessor() {
 
 	for result := range collector.processorInputChan {
 		err := collector.processTransactionResult(
-			result.transaction,
+			result.transactionRequest,
 			result.ExecutionSnapshot,
 			result.ProcedureOutput)
 		if err != nil {


### PR DESCRIPTION
Prep work for parallel workers pulling requests off the queue.

This also rename transaction to transactionRequest since the term is overloaded.