### PR TITLE
Remove inaccurate transaction memory usage metric

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onflow/flow-go/module/executiondatasync/provider"
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/trace"
-	"github.com/onflow/flow-go/utils/debug"
 	"github.com/onflow/flow-go/utils/logging"
 )
 
@@ -359,7 +358,6 @@ func (e *blockComputer) executeTransaction(
 	error,
 ) {
 	startedAt := time.Now()
-	memAllocBefore := debug.GetHeapAllocsBytes()
 
 	txSpan := e.tracer.StartSampledSpanFromParent(
 		parentSpan,
@@ -397,15 +395,9 @@ func (e *blockComputer) executeTransaction(
 			err)
 	}
 
-	postProcessSpan := e.tracer.StartSpanFromParent(txSpan, trace.EXEPostProcessTransaction)
-	defer postProcessSpan.End()
-
-	memAllocAfter := debug.GetHeapAllocsBytes()
-
 	logger = logger.With().
 		Uint64("computation_used", output.ComputationUsed).
 		Uint64("memory_used", output.MemoryEstimate).
-		Uint64("mem_alloc", memAllocAfter-memAllocBefore).
 		Int64("time_spent_in_ms", time.Since(startedAt).Milliseconds()).
 		Logger()
 
@@ -435,7 +427,6 @@ func (e *blockComputer) executeTransaction(
 		time.Since(startedAt),
 		output.ComputationUsed,
 		output.MemoryEstimate,
-		memAllocAfter-memAllocBefore,
 		len(output.Events),
 		flow.EventsList(output.Events).ByteSize(),
 		output.Err != nil,

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -125,7 +125,6 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			mock.Anything, // duration
 			mock.Anything, // computation used
 			mock.Anything, // memory used
-			mock.Anything, // actual memory used
 			mock.Anything, // number of events
 			mock.Anything, // size of events
 			false).        // no failure
@@ -1129,7 +1128,6 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 		mock.Anything, // duration
 		mock.Anything, // computation used
 		mock.Anything, // memory used
-		mock.Anything, // actual memory used
 		expectedNumberOfEvents,
 		expectedEventSize,
 		false).

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -648,7 +648,7 @@ type ExecutionMetrics interface {
 
 	// ExecutionTransactionExecuted reports stats on executing a single transaction
 	ExecutionTransactionExecuted(dur time.Duration,
-		compUsed, memoryUsed, actualMemoryUsed uint64,
+		compUsed, memoryUsed uint64,
 		eventCounts, eventSize int,
 		failed bool)
 

--- a/module/metrics/execution.go
+++ b/module/metrics/execution.go
@@ -60,9 +60,7 @@ type ExecutionCollector struct {
 	transactionCheckTime                   prometheus.Histogram
 	transactionInterpretTime               prometheus.Histogram
 	transactionExecutionTime               prometheus.Histogram
-	transactionMemoryUsage                 prometheus.Histogram
 	transactionMemoryEstimate              prometheus.Histogram
-	transactionMemoryDifference            prometheus.Histogram
 	transactionComputationUsed             prometheus.Histogram
 	transactionEmittedEvents               prometheus.Histogram
 	transactionEventSize                   prometheus.Histogram
@@ -398,28 +396,12 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 		Buckets:   []float64{50, 100, 500, 1000, 5000, 10000},
 	})
 
-	transactionMemoryUsage := promauto.NewHistogram(prometheus.HistogramOpts{
-		Namespace: namespaceExecution,
-		Subsystem: subsystemRuntime,
-		Name:      "transaction_memory_usage",
-		Help:      "the total amount of memory allocated by a transaction",
-		Buckets:   []float64{100_000, 1_000_000, 10_000_000, 50_000_000, 100_000_000, 500_000_000, 1_000_000_000},
-	})
-
 	transactionMemoryEstimate := promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespaceExecution,
 		Subsystem: subsystemRuntime,
 		Name:      "transaction_memory_estimate",
 		Help:      "the estimated memory used by a transaction",
 		Buckets:   []float64{1_000_000, 10_000_000, 100_000_000, 1_000_000_000, 5_000_000_000, 10_000_000_000, 50_000_000_000, 100_000_000_000},
-	})
-
-	transactionMemoryDifference := promauto.NewHistogram(prometheus.HistogramOpts{
-		Namespace: namespaceExecution,
-		Subsystem: subsystemRuntime,
-		Name:      "transaction_memory_difference",
-		Help:      "the difference in actual memory usage and estimate for a transaction",
-		Buckets:   []float64{-1, 0, 10_000_000, 100_000_000, 1_000_000_000},
 	})
 
 	transactionEmittedEvents := promauto.NewHistogram(prometheus.HistogramOpts{
@@ -574,9 +556,7 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 		transactionInterpretTime:               transactionInterpretTime,
 		transactionExecutionTime:               transactionExecutionTime,
 		transactionComputationUsed:             transactionComputationUsed,
-		transactionMemoryUsage:                 transactionMemoryUsage,
 		transactionMemoryEstimate:              transactionMemoryEstimate,
-		transactionMemoryDifference:            transactionMemoryDifference,
 		transactionEmittedEvents:               transactionEmittedEvents,
 		transactionEventSize:                   transactionEventSize,
 		scriptExecutionTime:                    scriptExecutionTime,
@@ -738,16 +718,14 @@ func (ec *ExecutionCollector) ExecutionBlockCachedPrograms(programs int) {
 // TransactionExecuted reports stats for executing a transaction
 func (ec *ExecutionCollector) ExecutionTransactionExecuted(
 	dur time.Duration,
-	compUsed, memoryUsed, actualMemoryUsed uint64,
+	compUsed, memoryUsed uint64,
 	eventCounts, eventSize int,
 	failed bool,
 ) {
 	ec.totalExecutedTransactionsCounter.Inc()
 	ec.transactionExecutionTime.Observe(float64(dur.Milliseconds()))
 	ec.transactionComputationUsed.Observe(float64(compUsed))
-	ec.transactionMemoryUsage.Observe(float64(actualMemoryUsed))
 	ec.transactionMemoryEstimate.Observe(float64(memoryUsed))
-	ec.transactionMemoryDifference.Observe(float64(memoryUsed) - float64(actualMemoryUsed))
 	ec.transactionEmittedEvents.Observe(float64(eventCounts))
 	ec.transactionEventSize.Observe(float64(eventSize))
 	if failed {

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -162,7 +162,7 @@ func (nc *NoopCollector) ExecutionCollectionExecuted(_ time.Duration, _ module.E
 }
 func (nc *NoopCollector) ExecutionBlockExecutionEffortVectorComponent(_ string, _ uint) {}
 func (nc *NoopCollector) ExecutionBlockCachedPrograms(programs int)                     {}
-func (nc *NoopCollector) ExecutionTransactionExecuted(_ time.Duration, _, _, _ uint64, _, _ int, _ bool) {
+func (nc *NoopCollector) ExecutionTransactionExecuted(_ time.Duration, _, _ uint64, _, _ int, _ bool) {
 }
 func (nc *NoopCollector) ExecutionChunkDataPackGenerated(_, _ int)                         {}
 func (nc *NoopCollector) ExecutionScriptExecuted(dur time.Duration, compUsed, _, _ uint64) {}

--- a/module/mock/execution_metrics.go
+++ b/module/mock/execution_metrics.go
@@ -96,9 +96,9 @@ func (_m *ExecutionMetrics) ExecutionSync(syncing bool) {
 	_m.Called(syncing)
 }
 
-// ExecutionTransactionExecuted provides a mock function with given fields: dur, compUsed, memoryUsed, actualMemoryUsed, eventCounts, eventSize, failed
-func (_m *ExecutionMetrics) ExecutionTransactionExecuted(dur time.Duration, compUsed uint64, memoryUsed uint64, actualMemoryUsed uint64, eventCounts int, eventSize int, failed bool) {
-	_m.Called(dur, compUsed, memoryUsed, actualMemoryUsed, eventCounts, eventSize, failed)
+// ExecutionTransactionExecuted provides a mock function with given fields: dur, compUsed, memoryUsed, eventCounts, eventSize, failed
+func (_m *ExecutionMetrics) ExecutionTransactionExecuted(dur time.Duration, compUsed uint64, memoryUsed uint64, eventCounts int, eventSize int, failed bool) {
+	_m.Called(dur, compUsed, memoryUsed, eventCounts, eventSize, failed)
 }
 
 // FinishBlockReceivedToExecuted provides a mock function with given fields: blockID

--- a/module/trace/constants.go
+++ b/module/trace/constants.go
@@ -92,9 +92,8 @@ const (
 
 	EXEBroadcastExecutionReceipt SpanName = "exe.provider.broadcastExecutionReceipt"
 
-	EXEComputeBlock           SpanName = "exe.computer.computeBlock"
-	EXEComputeTransaction     SpanName = "exe.computer.computeTransaction"
-	EXEPostProcessTransaction SpanName = "exe.computer.postProcessTransaction"
+	EXEComputeBlock       SpanName = "exe.computer.computeBlock"
+	EXEComputeTransaction SpanName = "exe.computer.computeTransaction"
 
 	EXEStateSaveExecutionResults          SpanName = "exe.state.saveExecutionResults"
 	EXECommitDelta                        SpanName = "exe.state.commitDelta"


### PR DESCRIPTION
The memory stats is meaningless.  There are too many background goroutines interfering, especially when we execute transactions in parallel.