### PR TITLE
Fix fvm bench test setup.

### DIFF
--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -132,7 +132,7 @@ func (account *TestBenchAccount) AddArrayToStorage(b *testing.B, blockExec TestB
 type BasicBlockExecutor struct {
 	blockComputer         computer.BlockComputer
 	derivedChainData      *derived.DerivedChainData
-	activeSnapshot        snapshot.StorageSnapshot
+	activeSnapshot        snapshot.SnapshotTree
 	activeStateCommitment flow.StateCommitment
 	chain                 flow.Chain
 	serviceAccount        *TestBenchAccount
@@ -208,6 +208,8 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 	)
 
 	me := new(moduleMock.Local)
+	me.On("NodeID").Return(unittest.IdentifierFixture())
+	me.On("Sign", mock.Anything, mock.Anything).Return(nil, nil)
 	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
@@ -224,7 +226,8 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 		nil)
 	require.NoError(tb, err)
 
-	snapshot := exeState.NewLedgerStorageSnapshot(ledger, initialCommit)
+	activeSnapshot := snapshot.NewSnapshotTree(
+		exeState.NewLedgerStorageSnapshot(ledger, initialCommit))
 
 	derivedChainData, err := derived.NewDerivedChainData(
 		derived.DefaultDerivedDataCacheSize)
@@ -234,7 +237,7 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 		blockComputer:         blockComputer,
 		derivedChainData:      derivedChainData,
 		activeStateCommitment: initialCommit,
-		activeSnapshot:        snapshot,
+		activeSnapshot:        activeSnapshot,
 		chain:                 chain,
 		serviceAccount:        serviceAccount,
 		onStopFunc:            onStopFunc,
@@ -266,6 +269,10 @@ func (b *BasicBlockExecutor) ExecuteCollections(tb testing.TB, collections [][]*
 	require.NoError(tb, err)
 
 	b.activeStateCommitment = computationResult.CurrentEndState()
+
+	for _, snapshot := range computationResult.AllExecutionSnapshots() {
+		b.activeSnapshot = b.activeSnapshot.Append(snapshot)
+	}
 
 	return computationResult
 }


### PR DESCRIPTION
There are a bunch of version beacon failures after the plumbing fixes.  janez will look into those.
```
--- FAIL: BenchmarkRuntimeNFTBatchTransfer
    fvm_bench_test.go:695:
        	Error Trace:	/Users/patricklee/workspace/github.com/onflow/flow-go/fvm/fvm_bench_test.go:695
        	            				/Users/patricklee/workspace/github.com/onflow/flow-go/fvm/fvm_bench_test.go:623
        	Error:      	Should be empty, but was [Error Code: 1101] error caused by: 1 error occurred:
        	            		* transaction preprocess failed: [Error Code: 1101] cadence runtime error: Execution failed:
        	            	error: cannot find declaration `FlowEpoch` in `9eca2b38b18b5dfe.FlowEpoch`
        	            	 --> 17bdab0c7ac0959d1a455941c153da68507cd1fd4fce03161eb27c220088adf8:1:7
        	            	  |
        	            	1 | import FlowEpoch from 0x9eca2b38b18b5dfe
        	            	  |        ^^^^^^^^^ available exported declarations are:

        	            	error: cannot find declaration `NodeVersionBeacon` in `f8d6e0586b0a20c7.NodeVersionBeacon`
        	            	 --> 17bdab0c7ac0959d1a455941c153da68507cd1fd4fce03161eb27c220088adf8:2:7
        	            	  |
        	            	2 | import NodeVersionBeacon from 0xf8d6e0586b0a20c7
        	            	  |        ^^^^^^^^^^^^^^^^^ available exported declarations are:

        	            	error: cannot infer type parameter: `T`
        	            	 --> 17bdab0c7ac0959d1a455941c153da68507cd1fd4fce03161eb27c220088adf8:7:12
        	            	  |
        	            	7 |             serviceAccount.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath) ??
        	            	  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

        	            	error: cannot infer type parameter: `T`
        	            	 --> 17bdab0c7ac0959d1a455941c153da68507cd1fd4fce03161eb27c220088adf8:8:12
        	            	  |
        	            	8 |             epochAccount.borrow<&FlowEpoch.Heartbeat>(from: FlowEpoch.heartbeatStoragePath) ??
        	            	  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

        	            	error: cannot infer type parameter: `T`
        	            	  --> 17bdab0c7ac0959d1a455941c153da68507cd1fd4fce03161eb27c220088adf8:13:12
        	            	   |
        	            	13 |             serviceAccount.borrow<&NodeVersionBeacon.Heartbeat>(from: NodeVersionBeacon.HeartbeatStoragePath) ??
        	            	   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

        	            	error: cannot infer type parameter: `T`
        	            	  --> 17bdab0c7ac0959d1a455941c153da68507cd1fd4fce03161eb27c220088adf8:14:12
        	            	   |
        	            	14 |             epochAccount.borrow<&NodeVersionBeacon.Heartbeat>(from: NodeVersionBeacon.HeartbeatStoragePath) ??
        	            	   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

        	Test:       	BenchmarkRuntimeNFTBatchTransfer
```