### PR TITLE
[Access] Update REST get events to return empty BlockEvents for blocks with no events

### DIFF
--- a/engine/access/rest/events.go
+++ b/engine/access/rest/events.go
@@ -27,7 +27,7 @@ func GetEvents(r *request.Request, backend access.API, _ models.LinkGenerator) (
 			return nil, err
 		}
 
-		blocksEvents.Build(events, false)
+		blocksEvents.Build(events)
 		return blocksEvents, nil
 	}
 
@@ -51,6 +51,6 @@ func GetEvents(r *request.Request, backend access.API, _ models.LinkGenerator) (
 		return nil, err
 	}
 
-	blocksEvents.Build(events, true)
+	blocksEvents.Build(events)
 	return blocksEvents, nil
 }

--- a/engine/access/rest/events.go
+++ b/engine/access/rest/events.go
@@ -27,7 +27,7 @@ func GetEvents(r *request.Request, backend access.API, _ models.LinkGenerator) (
 			return nil, err
 		}
 
-		blocksEvents.Build(events)
+		blocksEvents.Build(events, false)
 		return blocksEvents, nil
 	}
 
@@ -51,6 +51,6 @@ func GetEvents(r *request.Request, backend access.API, _ models.LinkGenerator) (
 		return nil, err
 	}
 
-	blocksEvents.Build(events)
+	blocksEvents.Build(events, true)
 	return blocksEvents, nil
 }

--- a/engine/access/rest/events_test.go
+++ b/engine/access/rest/events_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,8 +29,16 @@ func TestGetEvents(t *testing.T) {
 	for i, e := range events {
 		allBlockIDs[i] = e.BlockID.String()
 	}
-	startHeight := fmt.Sprintf("%d", events[0].BlockHeight)
-	endHeight := fmt.Sprintf("%d", events[len(events)-1].BlockHeight)
+	startHeight := fmt.Sprint(events[0].BlockHeight)
+	endHeight := fmt.Sprint(events[len(events)-1].BlockHeight)
+
+	// remove events from the last block to test that an empty BlockEvents is returned when the last
+	// block contains no events
+	trucatedEvents := append(events[:len(events)-1], flow.BlockEvents{
+		BlockHeight:    events[len(events)-1].BlockHeight,
+		BlockID:        events[len(events)-1].BlockID,
+		BlockTimestamp: events[len(events)-1].BlockTimestamp,
+	})
 
 	testVectors := []testVector{
 		// valid
@@ -37,25 +46,31 @@ func TestGetEvents(t *testing.T) {
 			description:      "Get events for a single block by ID",
 			request:          getEventReq(t, "A.179b6b1cb6755e31.Foo.Bar", "", "", []string{events[0].BlockID.String()}),
 			expectedStatus:   http.StatusOK,
-			expectedResponse: testBlockEventResponse([]flow.BlockEvents{events[0]}),
+			expectedResponse: testBlockEventResponse(t, []flow.BlockEvents{events[0]}),
 		},
 		{
 			description:      "Get events by all block IDs",
 			request:          getEventReq(t, "A.179b6b1cb6755e31.Foo.Bar", "", "", allBlockIDs),
 			expectedStatus:   http.StatusOK,
-			expectedResponse: testBlockEventResponse(events),
+			expectedResponse: testBlockEventResponse(t, events),
 		},
 		{
 			description:      "Get events for height range",
 			request:          getEventReq(t, "A.179b6b1cb6755e31.Foo.Bar", startHeight, endHeight, nil),
 			expectedStatus:   http.StatusOK,
-			expectedResponse: testBlockEventResponse(events),
+			expectedResponse: testBlockEventResponse(t, events),
 		},
 		{
-			description:      "Get invalid - invalid height format",
+			description:      "Get events range ending at sealed block",
 			request:          getEventReq(t, "A.179b6b1cb6755e31.Foo.Bar", "0", "sealed", nil),
 			expectedStatus:   http.StatusOK,
-			expectedResponse: testBlockEventResponse(events),
+			expectedResponse: testBlockEventResponse(t, events),
+		},
+		{
+			description:      "Get events range ending after last block",
+			request:          getEventReq(t, "A.179b6b1cb6755e31.Foo.Bar", "0", fmt.Sprint(events[len(events)-1].BlockHeight+1), nil),
+			expectedStatus:   http.StatusOK,
+			expectedResponse: testBlockEventResponse(t, trucatedEvents),
 		},
 		// invalid
 		{
@@ -143,6 +158,7 @@ func generateEventsMocks(backend *mock.API, n int) []flow.BlockEvents {
 	events := make([]flow.BlockEvents, n)
 	ids := make([]flow.Identifier, n)
 
+	var lastHeader *flow.Header
 	for i := 0; i < n; i++ {
 		header := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(uint64(i)))
 		ids[i] = header.ID()
@@ -152,12 +168,15 @@ func generateEventsMocks(backend *mock.API, n int) []flow.BlockEvents {
 		backend.Mock.
 			On("GetEventsForBlockIDs", mocks.Anything, mocks.Anything, []flow.Identifier{header.ID()}).
 			Return([]flow.BlockEvents{events[i]}, nil)
+
+		lastHeader = header
 	}
 
 	backend.Mock.
 		On("GetEventsForBlockIDs", mocks.Anything, mocks.Anything, ids).
 		Return(events, nil)
 
+	// range from first to last block
 	backend.Mock.On(
 		"GetEventsForHeightRange",
 		mocks.Anything,
@@ -165,6 +184,15 @@ func generateEventsMocks(backend *mock.API, n int) []flow.BlockEvents {
 		events[0].BlockHeight,
 		events[len(events)-1].BlockHeight,
 	).Return(events, nil)
+
+	// range from first to last block + 1
+	backend.Mock.On(
+		"GetEventsForHeightRange",
+		mocks.Anything,
+		mocks.Anything,
+		events[0].BlockHeight,
+		events[len(events)-1].BlockHeight+1,
+	).Return(append(events[:len(events)-1], unittest.BlockEventsFixture(lastHeader, 0)), nil)
 
 	latestBlock := unittest.BlockHeaderFixture()
 	latestBlock.Height = uint64(n - 1)
@@ -185,34 +213,48 @@ func generateEventsMocks(backend *mock.API, n int) []flow.BlockEvents {
 	return events
 }
 
-func testBlockEventResponse(events []flow.BlockEvents) string {
-	res := make([]string, len(events))
+func testBlockEventResponse(t *testing.T, events []flow.BlockEvents) string {
 
-	for i, e := range events {
-		events := make([]string, len(e.Events))
-
-		for i, ev := range e.Events {
-			events[i] = fmt.Sprintf(`{
-				"type": "%s",
-				"transaction_id": "%s",
-				"transaction_index": "%d",
-				"event_index": "%d",
-				"payload": "%s"
-			}`, ev.Type, ev.TransactionID, ev.TransactionIndex, ev.EventIndex, util.ToBase64(ev.Payload))
-		}
-
-		res[i] = fmt.Sprintf(`{
-			"block_id": "%s",
-			"block_height": "%d",
-			"block_timestamp": "%s",
-			"events": [%s]
-		}`,
-			e.BlockID.String(),
-			e.BlockHeight,
-			e.BlockTimestamp.Format(time.RFC3339Nano),
-			strings.Join(events, ","),
-		)
+	type eventResponse struct {
+		Type             flow.EventType  `json:"type"`
+		TransactionID    flow.Identifier `json:"transaction_id"`
+		TransactionIndex string          `json:"transaction_index"`
+		EventIndex       string          `json:"event_index"`
+		Payload          string          `json:"payload"`
 	}
 
-	return fmt.Sprintf(`[%s]`, strings.Join(res, ","))
+	type blockEventsResponse struct {
+		BlockID        flow.Identifier `json:"block_id"`
+		BlockHeight    string          `json:"block_height"`
+		BlockTimestamp string          `json:"block_timestamp"`
+		Events         []eventResponse `json:"events,omitempty"`
+	}
+
+	res := make([]blockEventsResponse, len(events))
+
+	for i, e := range events {
+		events := make([]eventResponse, len(e.Events))
+
+		for i, ev := range e.Events {
+			events[i] = eventResponse{
+				Type:             ev.Type,
+				TransactionID:    ev.TransactionID,
+				TransactionIndex: fmt.Sprint(ev.TransactionIndex),
+				EventIndex:       fmt.Sprint(ev.EventIndex),
+				Payload:          util.ToBase64(ev.Payload),
+			}
+		}
+
+		res[i] = blockEventsResponse{
+			BlockID:        e.BlockID,
+			BlockHeight:    fmt.Sprint(e.BlockHeight),
+			BlockTimestamp: e.BlockTimestamp.Format(time.RFC3339Nano),
+			Events:         events,
+		}
+	}
+
+	data, err := json.Marshal(res)
+	require.NoError(t, err)
+
+	return string(data)
 }

--- a/engine/access/rest/events_test.go
+++ b/engine/access/rest/events_test.go
@@ -34,7 +34,7 @@ func TestGetEvents(t *testing.T) {
 
 	// remove events from the last block to test that an empty BlockEvents is returned when the last
 	// block contains no events
-	trucatedEvents := append(events[:len(events)-1], flow.BlockEvents{
+	truncatedEvents := append(events[:len(events)-1], flow.BlockEvents{
 		BlockHeight:    events[len(events)-1].BlockHeight,
 		BlockID:        events[len(events)-1].BlockID,
 		BlockTimestamp: events[len(events)-1].BlockTimestamp,
@@ -68,9 +68,9 @@ func TestGetEvents(t *testing.T) {
 		},
 		{
 			description:      "Get events range ending after last block",
-			request:          getEventReq(t, "A.179b6b1cb6755e31.Foo.Bar", "0", fmt.Sprint(events[len(events)-1].BlockHeight+1), nil),
+			request:          getEventReq(t, "A.179b6b1cb6755e31.Foo.Bar", "0", fmt.Sprint(events[len(events)-1].BlockHeight+5), nil),
 			expectedStatus:   http.StatusOK,
-			expectedResponse: testBlockEventResponse(t, trucatedEvents),
+			expectedResponse: testBlockEventResponse(t, truncatedEvents),
 		},
 		// invalid
 		{
@@ -185,13 +185,13 @@ func generateEventsMocks(backend *mock.API, n int) []flow.BlockEvents {
 		events[len(events)-1].BlockHeight,
 	).Return(events, nil)
 
-	// range from first to last block + 1
+	// range from first to last block + 5
 	backend.Mock.On(
 		"GetEventsForHeightRange",
 		mocks.Anything,
 		mocks.Anything,
 		events[0].BlockHeight,
-		events[len(events)-1].BlockHeight+1,
+		events[len(events)-1].BlockHeight+5,
 	).Return(append(events[:len(events)-1], unittest.BlockEventsFixture(lastHeader, 0)), nil)
 
 	latestBlock := unittest.BlockHeaderFixture()

--- a/engine/access/rest/models/event.go
+++ b/engine/access/rest/models/event.go
@@ -40,9 +40,11 @@ type BlocksEvents []BlockEvents
 
 func (b *BlocksEvents) Build(blocksEvents []flow.BlockEvents) {
 	evs := make([]BlockEvents, 0)
-	for _, ev := range blocksEvents {
-		// don't include blocks without events
-		if len(ev.Events) == 0 {
+	for i, ev := range blocksEvents {
+		// don't include blocks without events, except for the last block
+		// always include the last block so clients know which was the last block processed event
+		// when it doesn't contain any events
+		if len(ev.Events) == 0 && i < len(blocksEvents)-1 {
 			continue
 		}
 

--- a/engine/access/rest/models/event.go
+++ b/engine/access/rest/models/event.go
@@ -40,14 +40,7 @@ type BlocksEvents []BlockEvents
 
 func (b *BlocksEvents) Build(blocksEvents []flow.BlockEvents, isRangeRequest bool) {
 	evs := make([]BlockEvents, 0)
-	for i, ev := range blocksEvents {
-		// don't include blocks without events, except for the last block of a range request.
-		// always include the last block for range requests so clients can identify the last block
-		// processed even when it doesn't contain any events
-		if len(ev.Events) == 0 && (!isRangeRequest || i < len(blocksEvents)-1) {
-			continue
-		}
-
+	for _, ev := range blocksEvents {
 		var blockEvent BlockEvents
 		blockEvent.Build(ev)
 		evs = append(evs, blockEvent)

--- a/engine/access/rest/models/event.go
+++ b/engine/access/rest/models/event.go
@@ -38,13 +38,13 @@ func (b *BlockEvents) Build(blockEvents flow.BlockEvents) {
 
 type BlocksEvents []BlockEvents
 
-func (b *BlocksEvents) Build(blocksEvents []flow.BlockEvents) {
+func (b *BlocksEvents) Build(blocksEvents []flow.BlockEvents, isRangeRequest bool) {
 	evs := make([]BlockEvents, 0)
 	for i, ev := range blocksEvents {
-		// don't include blocks without events, except for the last block
-		// always include the last block so clients know which was the last block processed event
-		// when it doesn't contain any events
-		if len(ev.Events) == 0 && i < len(blocksEvents)-1 {
+		// don't include blocks without events, except for the last block of a range request.
+		// always include the last block for range requests so clients can identify the last block
+		// processed even when it doesn't contain any events
+		if len(ev.Events) == 0 && (!isRangeRequest || i < len(blocksEvents)-1) {
 			continue
 		}
 

--- a/engine/access/rest/models/event.go
+++ b/engine/access/rest/models/event.go
@@ -38,7 +38,7 @@ func (b *BlockEvents) Build(blockEvents flow.BlockEvents) {
 
 type BlocksEvents []BlockEvents
 
-func (b *BlocksEvents) Build(blocksEvents []flow.BlockEvents, isRangeRequest bool) {
+func (b *BlocksEvents) Build(blocksEvents []flow.BlockEvents) {
 	evs := make([]BlockEvents, 0)
 	for _, ev := range blocksEvents {
 		var blockEvent BlockEvents


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4216

When querying for events by block range, if the end height is higher than the latest sealed height on the node, it is reset to the sealed height. This is OK for the grpc endpoints because they return empty `BlockEvents` entries for each block searched, so clients can see which was the last block. The REST API currently returns no results for blocks with no events, so clients have no way to tell what the actual searched range was.

This PR updates the REST api to always return a `BlockEvents` result for blocks searched, even if it has no events. This is makes the behavior consistent with the gRPC version of the API.