### PR TITLE
FVM bench test fix

### DIFF
--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -446,7 +446,9 @@ func BenchmarkRuntimeTransaction(b *testing.B) {
 			computationResult := blockExecutor.ExecuteCollections(b, [][]*flow.TransactionBody{transactions})
 			totalInteractionUsed := uint64(0)
 			totalComputationUsed := uint64(0)
-			for _, txRes := range computationResult.AllTransactionResults() {
+			results := computationResult.AllTransactionResults()
+			// not interested in the system transaction
+			for _, txRes := range results[0 : len(results)-1] {
 				require.Empty(b, txRes.ErrorMessage)
 				totalInteractionUsed += logE.InteractionUsed[txRes.ID().String()]
 				totalComputationUsed += txRes.ComputationUsed
@@ -691,7 +693,9 @@ func BenchRunNFTBatchTransfer(b *testing.B,
 		}
 
 		computationResult = blockExecutor.ExecuteCollections(b, [][]*flow.TransactionBody{transactions})
-		for _, txRes := range computationResult.AllTransactionResults() {
+		results := computationResult.AllTransactionResults()
+		// not interested in the system transaction
+		for _, txRes := range results[0 : len(results)-1] {
 			require.Empty(b, txRes.ErrorMessage)
 		}
 	}


### PR DESCRIPTION
We are not interested in the outcome of the system transaction in these tests.

The system transaction does to the total time, but it should be a really small portion compared to the other transactions in the block.

The last time the Bench tests were working the system transaction was also not included. It was recently added in this [PR](https://github.com/onflow/flow-go/pull/4078)