### PR TITLE
[Execution] Add sealed root for dynamic bootstrapping execution node

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -501,10 +501,10 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 		Component("execution data requester", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			// Validation of the start block height needs to be done after loading state
 			if builder.executionDataStartHeight > 0 {
-				if builder.executionDataStartHeight <= builder.RootBlock.Header.Height {
+				if builder.executionDataStartHeight <= builder.FinalizedRootBlock.Header.Height {
 					return nil, fmt.Errorf(
 						"execution data start block height (%d) must be greater than the root block height (%d)",
-						builder.executionDataStartHeight, builder.RootBlock.Header.Height)
+						builder.executionDataStartHeight, builder.FinalizedRootBlock.Header.Height)
 				}
 
 				latestSeal, err := builder.State.Sealed().Head()
@@ -526,7 +526,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionDataRequester() *FlowAccessN
 				// requester expects the initial last processed height, which is the first height - 1
 				builder.executionDataConfig.InitialBlockHeight = builder.executionDataStartHeight - 1
 			} else {
-				builder.executionDataConfig.InitialBlockHeight = builder.RootBlock.Header.Height
+				builder.executionDataConfig.InitialBlockHeight = builder.FinalizedRootBlock.Header.Height
 			}
 
 			execDataDistributor = edrequester.NewExecutionDataDistributor()

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -319,7 +319,7 @@ func (builder *FlowAccessNodeBuilder) buildFollowerCore() *FlowAccessNodeBuilder
 			node.Storage.Headers,
 			final,
 			builder.FollowerDistributor,
-			node.RootBlock.Header,
+			node.FinalizedRootBlock.Header,
 			node.RootQC,
 			builder.Finalized,
 			builder.Pending,

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -333,7 +333,7 @@ func main() {
 				node.Me,
 				node.Metrics.Engine,
 				node.Storage.Headers,
-				node.FinalizedHeader,
+				node.FinalizedRootBlock.Header,
 				core,
 				node.ComplianceConfig,
 			)

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -290,7 +290,7 @@ func main() {
 				node.Storage.Headers,
 				finalizer,
 				followerDistributor,
-				node.RootBlock.Header,
+				node.FinalizedRootBlock.Header,
 				node.RootQC,
 				finalized,
 				pending,

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -269,7 +269,7 @@ func main() {
 			// their first beacon private key through the DKG in the EpochSetup phase
 			// prior to their first epoch as network participant).
 
-			rootSnapshot := node.State.AtBlockID(node.RootBlock.ID())
+			rootSnapshot := node.State.AtBlockID(node.FinalizedRootBlock.ID())
 			isSporkRoot, err := protocol.IsSporkRootSnapshot(rootSnapshot)
 			if err != nil {
 				return fmt.Errorf("could not check whether root snapshot is spork root: %w", err)
@@ -289,7 +289,7 @@ func main() {
 				return fmt.Errorf("could not load beacon key file: %w", err)
 			}
 
-			rootEpoch := node.State.AtBlockID(node.RootBlock.ID()).Epochs().Current()
+			rootEpoch := node.State.AtBlockID(node.FinalizedRootBlock.ID()).Epochs().Current()
 			epochCounter, err := rootEpoch.Counter()
 			if err != nil {
 				return fmt.Errorf("could not get root epoch counter: %w", err)
@@ -581,7 +581,7 @@ func main() {
 				node.Storage.Headers,
 				finalize,
 				notifier,
-				node.RootBlock.Header,
+				node.FinalizedRootBlock.Header,
 				node.RootQC,
 			)
 			if err != nil {

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1039,7 +1039,7 @@ func (exeNode *ExecutionNode) LoadBootstrapper(node *NodeConfig) error {
 
 		// TODO: check that the checkpoint file contains the root block's statecommit hash
 
-		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootSeal.FinalState, node.RootBlock.Header)
+		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootSeal.FinalState, node.SealedRootBlock.Header)
 		if err != nil {
 			return fmt.Errorf("could not bootstrap execution database: %w", err)
 		}

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -910,7 +910,7 @@ func (exeNode *ExecutionNode) LoadFollowerEngine(
 		node.Me,
 		node.Metrics.Engine,
 		node.Storage.Headers,
-		exeNode.builder.FinalizedHeader,
+		exeNode.builder.FinalizedRootBlock.Header,
 		core,
 		node.ComplianceConfig,
 	)
@@ -1039,7 +1039,7 @@ func (exeNode *ExecutionNode) LoadBootstrapper(node *NodeConfig) error {
 
 		// TODO: check that the checkpoint file contains the root block's statecommit hash
 
-		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootResult, node.RootSeal.FinalState, node.SealedRootBlock.Header)
+		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootSeal, node.SealedRootBlock.Header)
 		if err != nil {
 			return fmt.Errorf("could not bootstrap execution database: %w", err)
 		}

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -791,6 +791,7 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 		node.Me,
 		exeNode.collectionRequester,
 		node.State,
+		node.Storage.Headers,
 		node.Storage.Blocks,
 		node.Storage.Collections,
 		exeNode.events,

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1039,7 +1039,7 @@ func (exeNode *ExecutionNode) LoadBootstrapper(node *NodeConfig) error {
 
 		// TODO: check that the checkpoint file contains the root block's statecommit hash
 
-		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootSeal, node.SealedRootBlock.Header)
+		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootSeal)
 		if err != nil {
 			return fmt.Errorf("could not bootstrap execution database: %w", err)
 		}

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1039,7 +1039,7 @@ func (exeNode *ExecutionNode) LoadBootstrapper(node *NodeConfig) error {
 
 		// TODO: check that the checkpoint file contains the root block's statecommit hash
 
-		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootSeal.FinalState, node.SealedRootBlock.Header)
+		err = bootstrapper.BootstrapExecutionDatabase(node.DB, node.RootResult, node.RootSeal.FinalState, node.SealedRootBlock.Header)
 		if err != nil {
 			return fmt.Errorf("could not bootstrap execution database: %w", err)
 		}

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -861,7 +861,7 @@ func (exeNode *ExecutionNode) LoadFollowerCore(
 		node.Storage.Headers,
 		final,
 		exeNode.followerDistributor,
-		node.RootBlock.Header,
+		node.FinalizedRootBlock.Header,
 		node.RootQC,
 		finalized,
 		pending,

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -295,8 +295,8 @@ type NodeConfig struct {
 type StateExcerptAtBoot struct {
 	// properties of RootSnapshot for convenience
 	// For node bootstrapped with a root snapshot for the first block of a spork,
-	// 		FinalizedRootBlock and SealedRootBlock are the same block
-	// For node bootstrapped with a root snapshot for a block above the first bloc of a spork (dynamically bootstrapped),
+	// 		FinalizedRootBlock and SealedRootBlock are the same block (special case of self-sealing block)
+	// For node bootstrapped with a root snapshot for a block above the first block of a spork (dynamically bootstrapped),
 	// 		FinalizedRootBlock.Height > SealedRootBlock.Height
 	FinalizedRootBlock *flow.Block             // The last finalized block when bootstrapped.
 	SealedRootBlock    *flow.Block             // The last sealed block when bootstrapped.

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -294,13 +294,15 @@ type NodeConfig struct {
 // StateExcerptAtBoot stores information about the root snapshot and latest finalized block for use in bootstrapping.
 type StateExcerptAtBoot struct {
 	// properties of RootSnapshot for convenience
-	RootBlock   *flow.Block
-	RootQC      *flow.QuorumCertificate
-	RootResult  *flow.ExecutionResult
-	RootSeal    *flow.Seal
-	RootChainID flow.ChainID
-	SporkID     flow.Identifier
+	FinalizedRootBlock *flow.Block
+	SealedRootBlock    *flow.Block
+	RootQC             *flow.QuorumCertificate // QC for Finalized Root Block
+	RootResult         *flow.ExecutionResult   // Result for SealedRootBlock
+	RootSeal           *flow.Seal              //Seal for RootResult
+	RootChainID        flow.ChainID
+	SporkID            flow.Identifier
 	// finalized block for use in bootstrapping
+	// TODO:(leo) isn't it FinalizedRootBlock.Header?
 	FinalizedHeader *flow.Header
 }
 

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -294,16 +294,17 @@ type NodeConfig struct {
 // StateExcerptAtBoot stores information about the root snapshot and latest finalized block for use in bootstrapping.
 type StateExcerptAtBoot struct {
 	// properties of RootSnapshot for convenience
-	FinalizedRootBlock *flow.Block
-	SealedRootBlock    *flow.Block
+	// For node bootstrapped with a root snapshot for the first block of a spork,
+	// 		FinalizedRootBlock and SealedRootBlock are the same block
+	// For node bootstrapped with a root snapshot for a block above the first bloc of a spork (dynamically bootstrapped),
+	// 		FinalizedRootBlock.Height > SealedRootBlock.Height
+	FinalizedRootBlock *flow.Block             // The last finalized block when bootstrapped.
+	SealedRootBlock    *flow.Block             // The last sealed block when bootstrapped.
 	RootQC             *flow.QuorumCertificate // QC for Finalized Root Block
 	RootResult         *flow.ExecutionResult   // Result for SealedRootBlock
 	RootSeal           *flow.Seal              //Seal for RootResult
 	RootChainID        flow.ChainID
 	SporkID            flow.Identifier
-	// finalized block for use in bootstrapping
-	// TODO:(leo) isn't it FinalizedRootBlock.Header?
-	FinalizedHeader *flow.Header
 }
 
 func DefaultBaseConfig() *BaseConfig {

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -309,7 +309,7 @@ func (builder *ObserverServiceBuilder) buildFollowerCore() *ObserverServiceBuild
 			node.Storage.Headers,
 			final,
 			builder.FollowerDistributor,
-			node.RootBlock.Header,
+			node.FinalizedRootBlock.Header,
 			node.RootQC,
 			builder.Finalized,
 			builder.Pending,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1175,19 +1175,11 @@ func (fnb *FlowNodeBuilder) initState() error {
 		}
 	}
 
-	lastFinalized, err := fnb.State.Final().Head()
-	if err != nil {
-		return fmt.Errorf("could not get last finalized block header: %w", err)
-	}
-	fnb.NodeConfig.FinalizedHeader = lastFinalized
-
 	fnb.Logger.Info().
 		Hex("root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
 		Uint64("root_block_height", fnb.FinalizedRootBlock.Header.Height).
 		Hex("sealed_root_block_id", logging.Entity(fnb.SealedRootBlock)).
 		Uint64("sealed_root_block_height", fnb.SealedRootBlock.Header.Height).
-		Hex("finalized_block_id", logging.Entity(lastFinalized)).
-		Uint64("finalized_block_height", lastFinalized.Height).
 		Msg("successfully opened protocol state")
 
 	return nil

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1163,6 +1163,8 @@ func (fnb *FlowNodeBuilder) initState() error {
 			Hex("root_state_commitment", fnb.RootSeal.FinalState[:]).
 			Hex("root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
 			Uint64("root_block_height", fnb.FinalizedRootBlock.Header.Height).
+			Hex("sealed_root_block_id", logging.Entity(fnb.SealedRootBlock)).
+			Uint64("sealed_root_block_height", fnb.SealedRootBlock.Header.Height).
 			Msg("protocol state bootstrapped")
 	}
 

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1161,8 +1161,8 @@ func (fnb *FlowNodeBuilder) initState() error {
 		fnb.Logger.Info().
 			Hex("root_result_id", logging.Entity(fnb.RootResult)).
 			Hex("root_state_commitment", fnb.RootSeal.FinalState[:]).
-			Hex("root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
-			Uint64("root_block_height", fnb.FinalizedRootBlock.Header.Height).
+			Hex("finalized_root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
+			Uint64("finalized_root_block_height", fnb.FinalizedRootBlock.Header.Height).
 			Hex("sealed_root_block_id", logging.Entity(fnb.SealedRootBlock)).
 			Uint64("sealed_root_block_height", fnb.SealedRootBlock.Header.Height).
 			Msg("protocol state bootstrapped")
@@ -1176,8 +1176,8 @@ func (fnb *FlowNodeBuilder) initState() error {
 	}
 
 	fnb.Logger.Info().
-		Hex("root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
-		Uint64("root_block_height", fnb.FinalizedRootBlock.Header.Height).
+		Hex("finalized_root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
+		Uint64("finalized_root_block_height", fnb.FinalizedRootBlock.Header.Height).
 		Hex("sealed_root_block_id", logging.Entity(fnb.SealedRootBlock)).
 		Uint64("sealed_root_block_height", fnb.SealedRootBlock.Header.Height).
 		Msg("successfully opened protocol state")

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1106,7 +1106,7 @@ func (fnb *FlowNodeBuilder) initState() error {
 		fnb.State = state
 
 		// set root snapshot field
-		rootBlock, err := state.Params().Root()
+		rootBlock, err := state.Params().FinalizedRoot()
 		if err != nil {
 			return fmt.Errorf("could not get root block from protocol state: %w", err)
 		}
@@ -1258,7 +1258,7 @@ func (fnb *FlowNodeBuilder) initLocal() error {
 	// We enforce this strictly for MainNet. For other networks (e.g. TestNet or BenchNet), we
 	// are lenient, to allow ghost node to run as any role.
 	if self.Role.String() != fnb.BaseConfig.NodeRole {
-		rootBlockHeader, err := fnb.State.Params().Root()
+		rootBlockHeader, err := fnb.State.Params().FinalizedRoot()
 		if err != nil {
 			return fmt.Errorf("could not get root block from protocol state: %w", err)
 		}

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1161,8 +1161,8 @@ func (fnb *FlowNodeBuilder) initState() error {
 		fnb.Logger.Info().
 			Hex("root_result_id", logging.Entity(fnb.RootResult)).
 			Hex("root_state_commitment", fnb.RootSeal.FinalState[:]).
-			Hex("root_block_id", logging.Entity(fnb.RootBlock)).
-			Uint64("root_block_height", fnb.RootBlock.Header.Height).
+			Hex("root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
+			Uint64("root_block_height", fnb.FinalizedRootBlock.Header.Height).
 			Msg("protocol state bootstrapped")
 	}
 
@@ -1180,8 +1180,10 @@ func (fnb *FlowNodeBuilder) initState() error {
 	fnb.NodeConfig.FinalizedHeader = lastFinalized
 
 	fnb.Logger.Info().
-		Hex("root_block_id", logging.Entity(fnb.RootBlock)).
-		Uint64("root_block_height", fnb.RootBlock.Header.Height).
+		Hex("root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
+		Uint64("root_block_height", fnb.FinalizedRootBlock.Header.Height).
+		Hex("sealed_root_block_id", logging.Entity(fnb.SealedRootBlock)).
+		Uint64("sealed_root_block_height", fnb.SealedRootBlock.Header.Height).
 		Hex("finalized_block_id", logging.Entity(lastFinalized)).
 		Uint64("finalized_block_height", lastFinalized.Height).
 		Msg("successfully opened protocol state")
@@ -1219,13 +1221,14 @@ func (fnb *FlowNodeBuilder) setRootSnapshot(rootSnapshot protocol.Snapshot) erro
 		return fmt.Errorf("failed to read root sealing segment: %w", err)
 	}
 
-	fnb.RootBlock = sealingSegment.Highest()
+	fnb.FinalizedRootBlock = sealingSegment.Highest()
+	fnb.SealedRootBlock = sealingSegment.Sealed()
 	fnb.RootQC, err = fnb.RootSnapshot.QuorumCertificate()
 	if err != nil {
 		return fmt.Errorf("failed to read root QC: %w", err)
 	}
 
-	fnb.RootChainID = fnb.RootBlock.Header.ChainID
+	fnb.RootChainID = fnb.FinalizedRootBlock.Header.ChainID
 	fnb.SporkID, err = fnb.RootSnapshot.Params().SporkID()
 	if err != nil {
 		return fmt.Errorf("failed to read spork ID: %w", err)

--- a/cmd/util/cmd/read-hotstuff/cmd/get_liveness.go
+++ b/cmd/util/cmd/read-hotstuff/cmd/get_liveness.go
@@ -27,7 +27,7 @@ func runGetLivenessData(*cobra.Command, []string) {
 		log.Fatal().Err(err).Msg("could not init protocol state")
 	}
 
-	rootBlock, err := state.Params().Root()
+	rootBlock, err := state.Params().FinalizedRoot()
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not get root block")
 	}

--- a/cmd/util/cmd/read-hotstuff/cmd/get_safety.go
+++ b/cmd/util/cmd/read-hotstuff/cmd/get_safety.go
@@ -27,7 +27,7 @@ func runGetSafetyData(*cobra.Command, []string) {
 		log.Fatal().Err(err).Msg("could not init protocol state")
 	}
 
-	rootBlock, err := state.Params().Root()
+	rootBlock, err := state.Params().FinalizedRoot()
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not get root block")
 	}

--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -43,14 +43,10 @@ func runSnapshot(*cobra.Command, []string) {
 	if flagHeight > 0 {
 		log.Info().Msgf("get snapshot by height: %v", flagHeight)
 		snapshot = state.AtHeight(flagHeight)
-	}
-
-	if flagFinal {
+	} else if flagFinal {
 		log.Info().Msgf("get last finalized snapshot")
 		snapshot = state.Final()
-	}
-
-	if flagSealed {
+	} else if flagSealed {
 		log.Info().Msgf("get last sealed snapshot")
 		snapshot = state.Sealed()
 	}

--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/cmd/util/cmd/common"
+	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/state/protocol"
+)
+
+var SnapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Read snapshot from protocol state",
+	Run:   run,
+}
+
+func init() {
+	rootCmd.AddCommand(SnapshotCmd)
+
+	SnapshotCmd.Flags().Uint64Var(&flagHeight, "height", 0,
+		"Block height")
+
+	SnapshotCmd.Flags().BoolVar(&flagFinal, "final", false,
+		"get finalized block")
+
+	SnapshotCmd.Flags().BoolVar(&flagSealed, "sealed", false,
+		"get sealed block")
+}
+
+func runSnapshot(*cobra.Command, []string) {
+	db := common.InitStorage(flagDatadir)
+	defer db.Close()
+
+	storages := common.InitStorages(db)
+	state, err := common.InitProtocolState(db, storages)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not init protocol state")
+	}
+
+	var snapshot protocol.Snapshot
+
+	if flagHeight > 0 {
+		log.Info().Msgf("get block by height: %v", flagHeight)
+		snapshot = state.AtHeight(flagHeight)
+	}
+
+	if flagFinal {
+		log.Info().Msgf("get last finalized block")
+		snapshot = state.Final()
+	}
+
+	if flagSealed {
+		log.Info().Msgf("get last sealed block")
+		snapshot = state.Sealed()
+	}
+
+	data, err := convert.SnapshotToBytes(snapshot)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to convert snapshot to bytes: %v")
+	}
+
+	fmt.Println(data)
+}

--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -67,7 +67,16 @@ func runSnapshot(*cobra.Command, []string) {
 		log.Fatal().Err(err).Msg("fail to serialize snapshot")
 	}
 
-	log.Info().Msgf("snapshot created")
+	sealingSegment, err := serializable.SealingSegment()
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not get sealing segment")
+	}
+
+	log.Info().Msgf("snapshot created, sealed height %v, id %v",
+		sealingSegment.Sealed().Header.Height, sealingSegment.Sealed().Header.ID())
+
+	log.Info().Msgf("highest finalized height %v, id %v",
+		sealingSegment.Highest().Header.Height, sealingSegment.Highest().Header.ID())
 
 	encoded := serializable.Encodable()
 	common.PrettyPrint(encoded)

--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
-	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	"github.com/onflow/flow-go/state/protocol"
+	"github.com/onflow/flow-go/state/protocol/inmem"
 )
 
 var SnapshotCmd = &cobra.Command{
@@ -57,11 +55,20 @@ func runSnapshot(*cobra.Command, []string) {
 		snapshot = state.Sealed()
 	}
 
-	data, err := convert.SnapshotToBytes(snapshot)
+	head, err := snapshot.Head()
 	if err != nil {
-		log.Fatal().Err(err).Msg("failed to convert snapshot to bytes: %v")
+		log.Fatal().Err(err).Msg("fail to get block of snapshot")
+	}
+
+	log.Info().Msgf("creating snapshot for block height %v, id %v", head.Height, head.ID())
+
+	serializable, err := inmem.FromSnapshot(snapshot)
+	if err != nil {
+		log.Fatal().Err(err).Msg("fail to serialize snapshot")
 	}
 
 	log.Info().Msgf("snapshot created")
-	fmt.Println(data)
+
+	encoded := serializable.Encodable()
+	common.PrettyPrint(encoded)
 }

--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -14,7 +14,7 @@ import (
 var SnapshotCmd = &cobra.Command{
 	Use:   "snapshot",
 	Short: "Read snapshot from protocol state",
-	Run:   run,
+	Run:   runSnapshot,
 }
 
 func init() {
@@ -43,17 +43,17 @@ func runSnapshot(*cobra.Command, []string) {
 	var snapshot protocol.Snapshot
 
 	if flagHeight > 0 {
-		log.Info().Msgf("get block by height: %v", flagHeight)
+		log.Info().Msgf("get snapshot by height: %v", flagHeight)
 		snapshot = state.AtHeight(flagHeight)
 	}
 
 	if flagFinal {
-		log.Info().Msgf("get last finalized block")
+		log.Info().Msgf("get last finalized snapshot")
 		snapshot = state.Final()
 	}
 
 	if flagSealed {
-		log.Info().Msgf("get last sealed block")
+		log.Info().Msgf("get last sealed snapshot")
 		snapshot = state.Sealed()
 	}
 
@@ -62,5 +62,6 @@ func runSnapshot(*cobra.Command, []string) {
 		log.Fatal().Err(err).Msg("failed to convert snapshot to bytes: %v")
 	}
 
+	log.Info().Msgf("snapshot created")
 	fmt.Println(data)
 }

--- a/cmd/util/cmd/reindex/cmd/results.go
+++ b/cmd/util/cmd/reindex/cmd/results.go
@@ -26,7 +26,7 @@ var resultsCmd = &cobra.Command{
 		results := storages.Results
 		blocks := storages.Blocks
 
-		root, err := state.Params().Root()
+		root, err := state.Params().FinalizedRoot()
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not get root header from protocol state")
 		}

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height.go
@@ -121,7 +121,7 @@ func removeExecutionResultsFromHeight(
 	fromHeight uint64) error {
 	log.Info().Msgf("removing results for blocks from height: %v", fromHeight)
 
-	root, err := protoState.Params().Root()
+	root, err := protoState.Params().FinalizedRoot()
 	if err != nil {
 		return fmt.Errorf("could not get root: %w", err)
 	}

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -24,7 +24,9 @@ func TestReExecuteBlock(t *testing.T) {
 		// bootstrap to init highest executed height
 		bootstrapper := bootstrap.NewBootstrapper(unittest.Logger())
 		genesis := unittest.BlockHeaderFixture()
-		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(), genesis)
+		rootSeal := unittest.Seal.Fixture()
+		unittest.Seal.WithBlock(genesis)(rootSeal)
+		err := bootstrapper.BootstrapExecutionDatabase(db, rootSeal, genesis)
 		require.NoError(t, err)
 
 		// create all modules
@@ -144,7 +146,9 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		// bootstrap to init highest executed height
 		bootstrapper := bootstrap.NewBootstrapper(unittest.Logger())
 		genesis := unittest.BlockHeaderFixture()
-		err := bootstrapper.BootstrapExecutionDatabase(db, unittest.StateCommitmentFixture(), genesis)
+		rootSeal := unittest.Seal.Fixture()
+		unittest.Seal.WithBlock(genesis)(rootSeal)
+		err := bootstrapper.BootstrapExecutionDatabase(db, rootSeal, genesis)
 		require.NoError(t, err)
 
 		// create all modules

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -24,8 +24,7 @@ func TestReExecuteBlock(t *testing.T) {
 		// bootstrap to init highest executed height
 		bootstrapper := bootstrap.NewBootstrapper(unittest.Logger())
 		genesis := unittest.BlockHeaderFixture()
-		rootSeal := unittest.Seal.Fixture()
-		unittest.Seal.WithBlock(genesis)(rootSeal)
+		rootSeal := unittest.Seal.Fixture(unittest.Seal.WithBlock(genesis))
 		err := bootstrapper.BootstrapExecutionDatabase(db, rootSeal)
 		require.NoError(t, err)
 

--- a/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
+++ b/cmd/util/cmd/rollback-executed-height/cmd/rollback_executed_height_test.go
@@ -26,7 +26,7 @@ func TestReExecuteBlock(t *testing.T) {
 		genesis := unittest.BlockHeaderFixture()
 		rootSeal := unittest.Seal.Fixture()
 		unittest.Seal.WithBlock(genesis)(rootSeal)
-		err := bootstrapper.BootstrapExecutionDatabase(db, rootSeal, genesis)
+		err := bootstrapper.BootstrapExecutionDatabase(db, rootSeal)
 		require.NoError(t, err)
 
 		// create all modules
@@ -148,7 +148,7 @@ func TestReExecuteBlockWithDifferentResult(t *testing.T) {
 		genesis := unittest.BlockHeaderFixture()
 		rootSeal := unittest.Seal.Fixture()
 		unittest.Seal.WithBlock(genesis)(rootSeal)
-		err := bootstrapper.BootstrapExecutionDatabase(db, rootSeal, genesis)
+		err := bootstrapper.BootstrapExecutionDatabase(db, rootSeal)
 		require.NoError(t, err)
 
 		// create all modules

--- a/cmd/verification_builder.go
+++ b/cmd/verification_builder.go
@@ -382,7 +382,7 @@ func (v *VerificationNodeBuilder) LoadComponentsAndModules() {
 				node.Me,
 				node.Metrics.Engine,
 				node.Storage.Headers,
-				node.FinalizedHeader,
+				node.FinalizedRootBlock.Header,
 				core,
 				node.ComplianceConfig,
 			)

--- a/cmd/verification_builder.go
+++ b/cmd/verification_builder.go
@@ -339,7 +339,7 @@ func (v *VerificationNodeBuilder) LoadComponentsAndModules() {
 				node.Storage.Headers,
 				final,
 				followerDistributor,
-				node.RootBlock.Header,
+				node.FinalizedRootBlock.Header,
 				node.RootQC,
 				finalized,
 				pending,

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -107,7 +107,7 @@ func (suite *Suite) SetupTest() {
 	).Maybe()
 
 	suite.params = new(protocol.Params)
-	suite.params.On("Root").Return(suite.rootBlock, nil)
+	suite.params.On("FinalizedRoot").Return(suite.rootBlock, nil)
 	suite.params.On("SporkRootBlockHeight").Return(suite.rootBlock.Height, nil)
 	suite.state.On("Params").Return(suite.params).Maybe()
 	suite.collClient = new(accessmock.AccessAPIClient)

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -196,7 +196,7 @@ func (e *Engine) Start(parent irrecoverable.SignalerContext) {
 // If the index has already been initialized, this is a no-op.
 // No errors are expected during normal operation.
 func (e *Engine) initLastFullBlockHeightIndex() error {
-	rootBlock, err := e.state.Params().Root()
+	rootBlock, err := e.state.Params().FinalizedRoot()
 	if err != nil {
 		return fmt.Errorf("failed to get root block: %w", err)
 	}
@@ -685,7 +685,7 @@ func (e *Engine) updateLastFullBlockReceivedIndex() {
 			return
 		}
 		// use the root height as the last full height
-		header, err := e.state.Params().Root()
+		header, err := e.state.Params().FinalizedRoot()
 		if err != nil {
 			logError(err)
 			return

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -563,7 +563,7 @@ func (suite *Suite) TestUpdateLastFullBlockReceivedIndex() {
 		// simulate the absence of the full block height index
 		lastFullBlockHeight = 0
 		rtnErr = storerr.ErrNotFound
-		suite.proto.params.On("Root").Return(rootBlk.Header, nil)
+		suite.proto.params.On("FinalizedRoot").Return(rootBlk.Header, nil)
 		suite.blocks.On("UpdateLastFullBlockHeight", finalizedHeight).Return(nil).Once()
 
 		suite.eng.updateLastFullBlockReceivedIndex()

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -300,7 +300,7 @@ func executionNodesForBlockID(
 
 	// check if the block ID is of the root block. If it is then don't look for execution receipts since they
 	// will not be present for the root block.
-	rootBlock, err := state.Params().Root()
+	rootBlock, err := state.Params().FinalizedRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retreive execution IDs for block ID %v: %w", blockID, err)
 	}

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -60,7 +60,7 @@ func (suite *Suite) SetupTest() {
 	suite.snapshot = new(protocol.Snapshot)
 	header := unittest.BlockHeaderFixture()
 	params := new(protocol.Params)
-	params.On("Root").Return(header, nil)
+	params.On("FinalizedRoot").Return(header, nil)
 	params.On("SporkRootBlockHeight").Return(header.Height, nil)
 	suite.state.On("Params").Return(params).Maybe()
 	suite.blocks = new(storagemock.Blocks)
@@ -1595,7 +1595,7 @@ func (suite *Suite) TestGetEventsForHeightRange() {
 
 	rootHeader := unittest.BlockHeaderFixture()
 	params := new(protocol.Params)
-	params.On("Root").Return(rootHeader, nil)
+	params.On("FinalizedRoot").Return(rootHeader, nil)
 	state.On("Params").Return(params).Maybe()
 
 	// mock snapshot to return head backend

--- a/engine/consensus/sealing/core.go
+++ b/engine/consensus/sealing/core.go
@@ -137,7 +137,7 @@ func (c *Core) RepopulateAssignmentCollectorTree(payloads storage.Payloads) erro
 
 	// Get the root block of our local state - we allow references to unknown
 	// blocks below the root height
-	rootHeader, err := c.state.Params().Root()
+	rootHeader, err := c.state.Params().FinalizedRoot()
 	if err != nil {
 		return fmt.Errorf("could not retrieve root header: %w", err)
 	}

--- a/engine/consensus/sealing/core_test.go
+++ b/engine/consensus/sealing/core_test.go
@@ -60,7 +60,7 @@ func (s *ApprovalProcessingCoreTestSuite) SetupTest() {
 	params := new(mockstate.Params)
 	s.State.On("Sealed").Return(unittest.StateSnapshotForKnownBlock(s.ParentBlock, nil)).Maybe()
 	s.State.On("Params").Return(params)
-	params.On("Root").Return(
+	params.On("FinalizedRoot").Return(
 		func() *flow.Header { return s.rootHeader },
 		func() error { return nil },
 	)

--- a/engine/consensus/sealing/engine.go
+++ b/engine/consensus/sealing/engine.go
@@ -104,7 +104,7 @@ func NewEngine(log zerolog.Logger,
 	sealsMempool mempool.IncorporatedResultSeals,
 	requiredApprovalsForSealConstructionGetter module.SealingConfigsGetter,
 ) (*Engine, error) {
-	rootHeader, err := state.Params().Root()
+	rootHeader, err := state.Params().FinalizedRoot()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve root block: %w", err)
 	}

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -235,7 +235,7 @@ func (e *Engine) finalizedUnexecutedBlocks(finalized protocol.Snapshot) (
 	// starting from the first unexecuted block, go through each unexecuted and finalized block
 	// reload its block to execution queues
 	for height := firstUnexecuted; height <= final.Height; height++ {
-		header, err := e.getHeaderByHeight(lastExecuted)
+		header, err := e.getHeaderByHeight(height)
 		if err != nil {
 			return nil, fmt.Errorf("could not get header at height: %v, %w", height, err)
 		}

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -207,6 +207,8 @@ func (e *Engine) finalizedUnexecutedBlocks(finalized protocol.Snapshot) (
 	// blocks.
 	lastExecuted := final.Height
 
+	// dynamically bootstrapped execution node will reload blocks from
+	// [sealedRoot.Height + 1, finalizedRoot.Height] and execute them on startup.
 	rootBlock, err := e.state.Params().SealedRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve root block: %w", err)

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -43,7 +43,7 @@ type Engine struct {
 	me                     module.Local
 	request                module.Requester // used to request collections
 	state                  protocol.State
-	headers                storage.Headers
+	headers                storage.Headers // see comments on getHeaderByHeight for why we need it
 	blocks                 storage.Blocks
 	collections            storage.Collections
 	events                 storage.Events
@@ -1312,6 +1312,9 @@ func (e *Engine) fetchCollection(
 	return nil
 }
 
+// if the EN is dynamically bootstrapped, the finalized blocks at height range:
+// [ sealedRoot.Height, finalizedRoot.Height - 1] can not be retrieved from
+// protocol state, but only from headers
 func (e *Engine) getHeaderByHeight(height uint64) (*flow.Header, error) {
 	// we don't use protocol state because for dynamic boostrapped execution node
 	// the last executed and sealed block is below the root block

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -248,7 +248,7 @@ func (e *Engine) finalizedUnexecutedBlocks(finalized protocol.Snapshot) (
 	e.log.Info().
 		Uint64("last_finalized", final.Height).
 		Uint64("last_finalized_executed", lastExecuted).
-		Uint64("sealed_root", rootBlock.Height).
+		Uint64("sealed_root_height", rootBlock.Height).
 		Hex("sealed_root_id", logging.Entity(rootBlock)).
 		Uint64("first_unexecuted", firstUnexecuted).
 		Int("total_finalized_unexecuted", len(unexecuted)).
@@ -1319,6 +1319,6 @@ func (e *Engine) fetchCollection(
 // protocol state, but only from headers
 func (e *Engine) getHeaderByHeight(height uint64) (*flow.Header, error) {
 	// we don't use protocol state because for dynamic boostrapped execution node
-	// the last executed and sealed block is below the root block
+	// the last executed and sealed block is below the finalized root block
 	return e.headers.ByHeight(height)
 }

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -230,8 +230,6 @@ func (e *Engine) finalizedUnexecutedBlocks(finalized protocol.Snapshot) (
 
 	firstUnexecuted := lastExecuted + 1
 
-	e.log.Info().Msgf("last finalized and executed height: %v", lastExecuted)
-
 	unexecuted := make([]flow.Identifier, 0)
 
 	// starting from the first unexecuted block, go through each unexecuted and finalized block
@@ -244,6 +242,15 @@ func (e *Engine) finalizedUnexecutedBlocks(finalized protocol.Snapshot) (
 
 		unexecuted = append(unexecuted, header.ID())
 	}
+
+	e.log.Info().
+		Uint64("last_finalized", final.Height).
+		Uint64("last_finalized_executed", lastExecuted).
+		Uint64("sealed_root", rootBlock.Height).
+		Hex("sealed_root_id", logging.Entity(rootBlock)).
+		Uint64("first_unexecuted", firstUnexecuted).
+		Int("total_finalized_unexecuted", len(unexecuted)).
+		Msgf("finalized unexecuted blocks")
 
 	return unexecuted, nil
 }

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -1512,7 +1512,7 @@ func TestUnauthorizedNodeDoesNotBroadcastReceipts(t *testing.T) {
 // 	require.True(t, shouldTriggerStateSync(20, 29, 10))
 // }
 
-func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecutionState) *Engine {
+func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecutionState) (*Engine, *storage.MockHeaders) {
 	log := unittest.Logger()
 	metrics := metrics.NewNoopCollector()
 	tracer, err := trace.NewTracer(log, "test", "test", trace.SensitivityCaptureAll)
@@ -1571,7 +1571,7 @@ func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecution
 	)
 
 	require.NoError(t, err)
-	return engine
+	return engine, headers
 }
 
 func logChain(chain []*flow.Block) {
@@ -1593,7 +1593,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		require.NoError(t, ps.Bootstrap(genesis, result, seal))
 
 		es := newMockExecutionState(seal)
-		engine := newIngestionEngine(t, ps, es)
+		engine, _ := newIngestionEngine(t, ps, es)
 
 		finalized, pending, err := engine.unexecutedBlocks()
 		require.NoError(t, err)
@@ -1618,7 +1618,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		require.NoError(t, ps.Extend(blockD))
 
 		es := newMockExecutionState(seal)
-		engine := newIngestionEngine(t, ps, es)
+		engine, _ := newIngestionEngine(t, ps, es)
 
 		finalized, pending, err := engine.unexecutedBlocks()
 		require.NoError(t, err)
@@ -1643,7 +1643,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		require.NoError(t, ps.Extend(blockD))
 
 		es := newMockExecutionState(seal)
-		engine := newIngestionEngine(t, ps, es)
+		engine, _ := newIngestionEngine(t, ps, es)
 
 		es.ExecuteBlock(t, blockA)
 		es.ExecuteBlock(t, blockB)
@@ -1673,7 +1673,9 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		require.NoError(t, ps.Finalize(blockC.ID()))
 
 		es := newMockExecutionState(seal)
-		engine := newIngestionEngine(t, ps, es)
+		engine, headers := newIngestionEngine(t, ps, es)
+
+		headers.EXPECT().ByHeight(blockC.Header.Height).Return(blockC.Header, nil)
 
 		es.ExecuteBlock(t, blockA)
 		es.ExecuteBlock(t, blockB)
@@ -1704,7 +1706,9 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		require.NoError(t, ps.Finalize(blockC.ID()))
 
 		es := newMockExecutionState(seal)
-		engine := newIngestionEngine(t, ps, es)
+		engine, headers := newIngestionEngine(t, ps, es)
+
+		headers.EXPECT().ByHeight(blockC.Header.Height).Return(blockC.Header, nil)
 
 		es.ExecuteBlock(t, blockA)
 		es.ExecuteBlock(t, blockB)
@@ -1734,7 +1738,9 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		require.NoError(t, ps.Finalize(blockA.ID()))
 
 		es := newMockExecutionState(seal)
-		engine := newIngestionEngine(t, ps, es)
+		engine, headers := newIngestionEngine(t, ps, es)
+
+		headers.EXPECT().ByHeight(blockA.Header.Height).Return(blockA.Header, nil)
 
 		es.ExecuteBlock(t, blockA)
 		es.ExecuteBlock(t, blockB)
@@ -1790,7 +1796,9 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 
 		es := newMockExecutionState(seal)
 
-		engine := newIngestionEngine(t, ps, es)
+		engine, headers := newIngestionEngine(t, ps, es)
+
+		headers.EXPECT().ByHeight(blockC.Header.Height).Return(blockC.Header, nil)
 
 		es.ExecuteBlock(t, blockA)
 		es.ExecuteBlock(t, blockB)

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -614,7 +614,7 @@ func Test_OnlyHeadOfTheQueueIsExecuted(t *testing.T) {
 		ctx.state.On("AtHeight", blockC.Height()).Return(blockCSnapshot)
 
 		ctx.state.On("Params").Return(params)
-		params.On("Root").Return(&blockA, nil)
+		params.On("FinalizedRoot").Return(&blockA, nil)
 
 		<-ctx.engine.Ready()
 

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -108,6 +108,7 @@ func (es *mockExecutionState) ExecuteBlock(t *testing.T, block *flow.Block) {
 type testingContext struct {
 	t                   *testing.T
 	engine              *Engine
+	headers             *storage.MockHeaders
 	blocks              *storage.MockBlocks
 	collections         *storage.MockCollections
 	state               *protocol.State
@@ -148,6 +149,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 	myIdentity.StakingPubKey = sk.PublicKey()
 	me := mocklocal.NewMockLocal(sk, myIdentity.ID(), t)
 
+	headers := storage.NewMockHeaders(ctrl)
 	blocks := storage.NewMockBlocks(ctrl)
 	payloads := storage.NewMockPayloads(ctrl)
 	collections := storage.NewMockCollections(ctrl)
@@ -210,6 +212,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 		me,
 		request,
 		protocolState,
+		headers,
 		blocks,
 		collections,
 		events,
@@ -231,6 +234,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 	f(testingContext{
 		t:                   t,
 		engine:              engine,
+		headers:             headers,
 		blocks:              blocks,
 		collections:         collections,
 		state:               protocolState,
@@ -1528,6 +1532,7 @@ func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecution
 	myIdentity.StakingPubKey = sk.PublicKey()
 	me := mocklocal.NewMockLocal(sk, myIdentity.ID(), t)
 
+	headers := storage.NewMockHeaders(ctrl)
 	blocks := storage.NewMockBlocks(ctrl)
 	collections := storage.NewMockCollections(ctrl)
 	events := storage.NewMockEvents(ctrl)
@@ -1547,6 +1552,7 @@ func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecution
 		me,
 		request,
 		ps,
+		headers,
 		blocks,
 		collections,
 		events,

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -1675,6 +1675,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		es := newMockExecutionState(seal)
 		engine, headers := newIngestionEngine(t, ps, es)
 
+		// block C is the only finalized block, index its header by its height
 		headers.EXPECT().ByHeight(blockC.Header.Height).Return(blockC.Header, nil)
 
 		es.ExecuteBlock(t, blockA)
@@ -1708,6 +1709,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		es := newMockExecutionState(seal)
 		engine, headers := newIngestionEngine(t, ps, es)
 
+		// block C is finalized, index its header by its height
 		headers.EXPECT().ByHeight(blockC.Header.Height).Return(blockC.Header, nil)
 
 		es.ExecuteBlock(t, blockA)
@@ -1740,6 +1742,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		es := newMockExecutionState(seal)
 		engine, headers := newIngestionEngine(t, ps, es)
 
+		// block A is finalized, index its header by its height
 		headers.EXPECT().ByHeight(blockA.Header.Height).Return(blockA.Header, nil)
 
 		es.ExecuteBlock(t, blockA)
@@ -1798,6 +1801,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 
 		engine, headers := newIngestionEngine(t, ps, es)
 
+		// block C is finalized, index its header by its height
 		headers.EXPECT().ByHeight(blockC.Header.Height).Return(blockC.Header, nil)
 
 		es.ExecuteBlock(t, blockA)

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -107,8 +107,8 @@ func (b *Bootstrapper) BootstrapExecutionDatabase(
 			return fmt.Errorf("could not index initial genesis execution block: %w", err)
 		}
 
-		err = operation.IndexExecutionResult(rootSeal.BlockID, rootSeal.ResultID)(txn)
-		if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
+		err = operation.SkipDuplicates(operation.IndexExecutionResult(rootSeal.BlockID, rootSeal.ResultID))(txn)
+		if err != nil {
 			return fmt.Errorf("could not index result for root result: %w", err)
 		}
 

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -96,19 +96,19 @@ func (b *Bootstrapper) IsBootstrapped(db *badger.DB) (flow.StateCommitment, bool
 
 func (b *Bootstrapper) BootstrapExecutionDatabase(
 	db *badger.DB,
-	rootResult *flow.ExecutionResult,
-	commit flow.StateCommitment,
-	genesis *flow.Header,
+	rootSeal *flow.Seal,
+	sealedRootBlock *flow.Header,
 ) error {
 
+	commit := rootSeal.FinalState
 	err := operation.RetryOnConflict(db.Update, func(txn *badger.Txn) error {
 
-		err := operation.InsertExecutedBlock(genesis.ID())(txn)
+		err := operation.InsertExecutedBlock(sealedRootBlock.ID())(txn)
 		if err != nil {
 			return fmt.Errorf("could not index initial genesis execution block: %w", err)
 		}
 
-		err = operation.IndexExecutionResult(rootResult.BlockID, rootResult.ID())(txn)
+		err = operation.IndexExecutionResult(rootSeal.BlockID, rootSeal.ResultID)(txn)
 		if err != nil {
 			return fmt.Errorf("could not index result for root result: %w", err)
 		}
@@ -118,13 +118,13 @@ func (b *Bootstrapper) BootstrapExecutionDatabase(
 			return fmt.Errorf("could not index void state commitment: %w", err)
 		}
 
-		err = operation.IndexStateCommitment(genesis.ID(), commit)(txn)
+		err = operation.IndexStateCommitment(sealedRootBlock.ID(), commit)(txn)
 		if err != nil {
 			return fmt.Errorf("could not index genesis state commitment: %w", err)
 		}
 
 		snapshots := make([]*snapshot.ExecutionSnapshot, 0)
-		err = operation.InsertExecutionStateInteractions(genesis.ID(), snapshots)(txn)
+		err = operation.InsertExecutionStateInteractions(sealedRootBlock.ID(), snapshots)(txn)
 		if err != nil {
 			return fmt.Errorf("could not bootstrap execution state interactions: %w", err)
 		}

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -108,7 +108,7 @@ func (b *Bootstrapper) BootstrapExecutionDatabase(
 		}
 
 		err = operation.IndexExecutionResult(rootSeal.BlockID, rootSeal.ResultID)(txn)
-		if err != nil {
+		if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
 			return fmt.Errorf("could not index result for root result: %w", err)
 		}
 

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -604,7 +604,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 	rootSeal := unittest.Seal.Fixture()
 	unittest.Seal.WithBlock(genesisHead)(rootSeal)
 
-	err = bootstrapper.BootstrapExecutionDatabase(node.PublicDB, rootSeal, genesisHead)
+	err = bootstrapper.BootstrapExecutionDatabase(node.PublicDB, rootSeal)
 	require.NoError(t, err)
 
 	execState := executionState.NewExecutionState(

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -600,13 +600,12 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply))
 	require.NoError(t, err)
 
-	rootResult := unittest.ExecutionResultFixture(
-		unittest.WithExecutionResultBlockID(genesisHead.ID()),
-		unittest.WithFinalState(commit))
-
 	// TODO: use state commitment from BootstrapLedger?
-	rootSeal := unittest.Seal.Fixture()
-	unittest.Seal.WithResult(rootResult)(rootSeal)
+	rootResult, rootSeal, err := protoState.Sealed().SealedResult()
+	require.NoError(t, err)
+
+	require.Equal(t, rootSeal.FinalState, commit)
+	require.Equal(t, rootSeal.ResultID, rootResult.ID())
 
 	err = bootstrapper.BootstrapExecutionDatabase(node.PublicDB, rootSeal)
 	require.NoError(t, err)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -600,11 +600,10 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply))
 	require.NoError(t, err)
 
-	// TODO: use state commitment from BootstrapLedger?
 	rootResult, rootSeal, err := protoState.Sealed().SealedResult()
 	require.NoError(t, err)
 
-	require.Equal(t, rootSeal.FinalState, commit)
+	require.Equal(t, fmt.Sprintf("%x", rootSeal.FinalState), fmt.Sprintf("%x", commit))
 	require.Equal(t, rootSeal.ResultID, rootResult.ID())
 
 	err = bootstrapper.BootstrapExecutionDatabase(node.PublicDB, rootSeal)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -684,6 +684,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		node.Me,
 		requestEngine,
 		node.State,
+		node.Headers,
 		node.Blocks,
 		collectionsStorage,
 		eventsStorage,

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -788,7 +788,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 }
 
 func getRoot(t *testing.T, node *testmock.GenericNode) (*flow.Header, *flow.QuorumCertificate) {
-	rootHead, err := node.State.Params().Root()
+	rootHead, err := node.State.Params().FinalizedRoot()
 	require.NoError(t, err)
 
 	signers, err := node.State.AtHeight(0).Identities(filter.HasRole(flow.RoleConsensus))

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -593,14 +593,18 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 	require.NoError(t, err)
 
 	bootstrapper := bootstrapexec.NewBootstrapper(node.Log)
-	commit, err := bootstrapper.BootstrapLedger(
+	_, err = bootstrapper.BootstrapLedger(
 		ls,
 		unittest.ServiceAccountPublicKey,
 		node.ChainID.Chain(),
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply))
 	require.NoError(t, err)
 
-	err = bootstrapper.BootstrapExecutionDatabase(node.PublicDB, commit, genesisHead)
+	// TODO: use state commitment from BootstrapLedger?
+	rootSeal := unittest.Seal.Fixture()
+	unittest.Seal.WithBlock(genesisHead)(rootSeal)
+
+	err = bootstrapper.BootstrapExecutionDatabase(node.PublicDB, rootSeal, genesisHead)
 	require.NoError(t, err)
 
 	execState := executionState.NewExecutionState(

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -593,16 +593,20 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 	require.NoError(t, err)
 
 	bootstrapper := bootstrapexec.NewBootstrapper(node.Log)
-	_, err = bootstrapper.BootstrapLedger(
+	commit, err := bootstrapper.BootstrapLedger(
 		ls,
 		unittest.ServiceAccountPublicKey,
 		node.ChainID.Chain(),
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply))
 	require.NoError(t, err)
 
+	rootResult := unittest.ExecutionResultFixture()
+	unittest.WithExecutionResultBlockID(genesisHead.ID())(rootResult)
+	unittest.WithFinalState(commit)(rootResult)
+
 	// TODO: use state commitment from BootstrapLedger?
 	rootSeal := unittest.Seal.Fixture()
-	unittest.Seal.WithBlock(genesisHead)(rootSeal)
+	unittest.Seal.WithResult(rootResult)(rootSeal)
 
 	err = bootstrapper.BootstrapExecutionDatabase(node.PublicDB, rootSeal)
 	require.NoError(t, err)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -121,7 +121,7 @@ func GenericNodeFromParticipants(t testing.TB, hub *stub.Hub, identity *flow.Ide
 	metrics := metrics.NewNoopCollector()
 
 	// creates state fixture and bootstrap it.
-	rootSnapshot := unittest.RootSnapshotFixture(participants)
+	rootSnapshot := unittest.RootSnapshotFixtureWithChainID(participants, chainID)
 	stateFixture := CompleteStateFixture(t, log, metrics, tracer, rootSnapshot)
 
 	require.NoError(t, err)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -600,9 +600,9 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		fvm.WithInitialTokenSupply(unittest.GenesisTokenSupply))
 	require.NoError(t, err)
 
-	rootResult := unittest.ExecutionResultFixture()
-	unittest.WithExecutionResultBlockID(genesisHead.ID())(rootResult)
-	unittest.WithFinalState(commit)(rootResult)
+	rootResult := unittest.ExecutionResultFixture(
+		unittest.WithExecutionResultBlockID(genesisHead.ID()),
+		unittest.WithFinalState(commit))
 
 	// TODO: use state commitment from BootstrapLedger?
 	rootSeal := unittest.Seal.Fixture()

--- a/engine/verification/assigner/blockconsumer/consumer_test.go
+++ b/engine/verification/assigner/blockconsumer/consumer_test.go
@@ -146,7 +146,7 @@ func withConsumer(
 		// blocks (i.e., containing guarantees), and Cs are container blocks for their preceding reference block,
 		// Container blocks only contain receipts of their preceding reference blocks. But they do not
 		// hold any guarantees.
-		root, err := s.State.Params().Root()
+		root, err := s.State.Params().FinalizedRoot()
 		require.NoError(t, err)
 		clusterCommittee := participants.Filter(filter.HasRole(flow.RoleCollection))
 		results := vertestutils.CompleteExecutionReceiptChainFixture(t, root, blockCount/2, vertestutils.WithClusterCommittee(clusterCommittee))

--- a/follower/follower_builder.go
+++ b/follower/follower_builder.go
@@ -216,7 +216,7 @@ func (builder *FollowerServiceBuilder) buildFollowerCore() *FollowerServiceBuild
 		final := finalizer.NewFinalizer(node.DB, node.Storage.Headers, builder.FollowerState, node.Tracer)
 
 		followerCore, err := consensus.NewFollower(node.Logger, node.Storage.Headers, final,
-			builder.FollowerDistributor, node.RootBlock.Header, node.RootQC, builder.Finalized, builder.Pending)
+			builder.FollowerDistributor, node.FinalizedRootBlock.Header, node.RootQC, builder.Finalized, builder.Pending)
 		if err != nil {
 			return nil, fmt.Errorf("could not initialize follower core: %w", err)
 		}

--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -67,6 +67,11 @@ func (segment *SealingSegment) Highest() *Block {
 	return segment.Blocks[len(segment.Blocks)-1]
 }
 
+// Finalized returns the last finalized block, which is an alias of Highest
+func (segment *SealingSegment) Finalized() *Block {
+	return segment.Highest()
+}
+
 // Sealed returns the most recently sealed block based on head of sealing segment(highest block).
 func (segment *SealingSegment) Sealed() *Block {
 	return segment.Blocks[0]

--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -18,6 +18,8 @@ import (
 // Lets denote the highest block in the sealing segment as `head`. Per convention, `head` must be a
 // finalized block. Consider the chain of blocks leading up to `head` (included). The highest block
 // in chain leading up to `head` that is sealed, we denote as B.
+// In other words, head is the last finalized block, and B is the last sealed block,
+// block at height (B.Height + 1) is not sealed.
 type SealingSegment struct {
 	// Blocks contain the chain `B <- ... <- Head` in ascending height order.
 	// Formally, Blocks contains exactly (not more!) the history to satisfy condition

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -183,7 +183,7 @@ func (suite *BuilderSuite) Payload(transactions ...*flow.TransactionBody) model.
 
 // ProtoStateRoot returns the root block of the protocol state.
 func (suite *BuilderSuite) ProtoStateRoot() *flow.Header {
-	root, err := suite.protoState.Params().Root()
+	root, err := suite.protoState.Params().FinalizedRoot()
 	suite.Require().NoError(err)
 	return root
 }

--- a/module/jobqueue/finalized_block_reader_test.go
+++ b/module/jobqueue/finalized_block_reader_test.go
@@ -62,7 +62,7 @@ func withReader(
 		// blocks (i.e., containing guarantees), and Cs are container blocks for their preceding reference block,
 		// Container blocks only contain receipts of their preceding reference blocks. But they do not
 		// hold any guarantees.
-		root, err := s.State.Params().Root()
+		root, err := s.State.Params().FinalizedRoot()
 		require.NoError(t, err)
 		clusterCommittee := participants.Filter(filter.HasRole(flow.RoleCollection))
 		results := vertestutils.CompleteExecutionReceiptChainFixture(t, root, blockCount/2, vertestutils.WithClusterCommittee(clusterCommittee))

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -537,7 +537,7 @@ func (m *FollowerState) insert(ctx context.Context, candidate *flow.Block, certi
 			}
 		} else {
 			// trigger BlockProcessable for parent blocks above root height
-			if parent.Height > m.rootHeight {
+			if parent.Height > m.finalizedRootHeight {
 				events = append(events, func() {
 					m.consumer.BlockProcessable(parent, qc)
 				})

--- a/state/protocol/badger/params.go
+++ b/state/protocol/badger/params.go
@@ -94,6 +94,23 @@ func (p Params) Root() (*flow.Header, error) {
 	return header, nil
 }
 
+func (p Params) SealedRoot() (*flow.Header, error) {
+	// look up root block ID
+	var rootID flow.Identifier
+	err := p.state.db.View(operation.LookupBlockHeight(p.state.sealedRootHeight, &rootID))
+	if err != nil {
+		return nil, fmt.Errorf("could not look up root header: %w", err)
+	}
+
+	// retrieve root header
+	header, err := p.state.headers.ByBlockID(rootID)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve root header: %w", err)
+	}
+
+	return header, nil
+}
+
 func (p Params) Seal() (*flow.Seal, error) {
 
 	// look up root header

--- a/state/protocol/badger/params.go
+++ b/state/protocol/badger/params.go
@@ -100,8 +100,11 @@ func (p Params) SealedRoot() (*flow.Header, error) {
 	// look up root block ID
 	var rootID flow.Identifier
 	err := p.state.db.View(operation.LookupBlockHeight(p.state.sealedRootHeight, &rootID))
-	// TODO(leo): old execution node that starts since beginning of a spork (instead of dynamic bootstrapped)
-	// might not have this key. In that case, fallback to Root()
+	// TODO(leo): this method is called after a node is bootstrapped, which means the key must exist,
+	// however, if this code is running on an old execution node which was bootstrapped without this
+	// key, then this key might not exist. In order to be backward compatible, we fallback to Root().
+	// This check can be removed after a spork, where all nodes should have bootstrapped with this key
+	// saved in database
 	if errors.Is(err, storage.ErrNotFound) {
 		return p.Root()
 	}

--- a/state/protocol/badger/params.go
+++ b/state/protocol/badger/params.go
@@ -19,7 +19,7 @@ var _ protocol.Params = (*Params)(nil)
 func (p Params) ChainID() (flow.ChainID, error) {
 
 	// retrieve root header
-	root, err := p.Root()
+	root, err := p.FinalizedRoot()
 	if err != nil {
 		return "", fmt.Errorf("could not get root: %w", err)
 	}
@@ -78,7 +78,7 @@ func (p Params) EpochFallbackTriggered() (bool, error) {
 	return triggered, nil
 }
 
-func (p Params) Root() (*flow.Header, error) {
+func (p Params) FinalizedRoot() (*flow.Header, error) {
 
 	// look up root block ID
 	var rootID flow.Identifier
@@ -106,7 +106,7 @@ func (p Params) SealedRoot() (*flow.Header, error) {
 	// This check can be removed after a spork, where all nodes should have bootstrapped with this key
 	// saved in database
 	if errors.Is(err, storage.ErrNotFound) {
-		return p.Root()
+		return p.FinalizedRoot()
 	}
 
 	if err != nil {

--- a/state/protocol/badger/params.go
+++ b/state/protocol/badger/params.go
@@ -1,12 +1,10 @@
 package badger
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
-	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
 )
 
@@ -100,14 +98,6 @@ func (p Params) SealedRoot() (*flow.Header, error) {
 	// look up root block ID
 	var rootID flow.Identifier
 	err := p.state.db.View(operation.LookupBlockHeight(p.state.sealedRootHeight, &rootID))
-	// TODO(leo): this method is called after a node is bootstrapped, which means the key must exist,
-	// however, if this code is running on an old execution node which was bootstrapped without this
-	// key, then this key might not exist. In order to be backward compatible, we fallback to Root().
-	// This check can be removed after a spork, where all nodes should have bootstrapped with this key
-	// saved in database
-	if errors.Is(err, storage.ErrNotFound) {
-		return p.FinalizedRoot()
-	}
 
 	if err != nil {
 		return nil, fmt.Errorf("could not look up root header: %w", err)

--- a/state/protocol/badger/params.go
+++ b/state/protocol/badger/params.go
@@ -82,7 +82,7 @@ func (p Params) FinalizedRoot() (*flow.Header, error) {
 
 	// look up root block ID
 	var rootID flow.Identifier
-	err := p.state.db.View(operation.LookupBlockHeight(p.state.rootHeight, &rootID))
+	err := p.state.db.View(operation.LookupBlockHeight(p.state.finalizedRootHeight, &rootID))
 	if err != nil {
 		return nil, fmt.Errorf("could not look up root header: %w", err)
 	}
@@ -126,7 +126,7 @@ func (p Params) Seal() (*flow.Seal, error) {
 
 	// look up root header
 	var rootID flow.Identifier
-	err := p.state.db.View(operation.LookupBlockHeight(p.state.rootHeight, &rootID))
+	err := p.state.db.View(operation.LookupBlockHeight(p.state.finalizedRootHeight, &rootID))
 	if err != nil {
 		return nil, fmt.Errorf("could not look up root header: %w", err)
 	}

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -239,7 +239,7 @@ func (s *Snapshot) SealingSegment() (*flow.SealingSegment, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get snapshot's reference block: %w", err)
 	}
-	if head.Header.Height < s.state.rootHeight {
+	if head.Header.Height < s.state.finalizedRootHeight {
 		return nil, protocol.ErrSealingSegmentBelowRootBlock
 	}
 

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -693,7 +693,7 @@ func TestSealingSegment_FailureCases(t *testing.T) {
 		// Thereby, the state should have b3 as its local root block. In addition, the blocks contained in the sealing
 		// segment, such as b2 should be stored in the state.
 		util.RunWithFollowerProtocolState(t, multipleBlockSnapshot, func(db *badger.DB, state *bprotocol.FollowerState) {
-			localStateRootBlock, err := state.Params().Root()
+			localStateRootBlock, err := state.Params().FinalizedRoot()
 			require.NoError(t, err)
 			assert.Equal(t, b3.ID(), localStateRootBlock.ID())
 
@@ -1276,7 +1276,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 		require.True(t, ok)
 
 		t.Run("should be able to query at root block", func(t *testing.T) {
-			root, err := state.Params().Root()
+			root, err := state.Params().FinalizedRoot()
 			require.NoError(t, err)
 			snapshot := state.AtHeight(root.Height)
 			identities, err := snapshot.Identities(filter.Any)

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -47,7 +47,6 @@ type State struct {
 	// `sporkRootBlockHeight`), for instance if the node joined in an epoch after the last spork.
 	rootHeight uint64
 	// sealedRootHeight returns the root block that is sealed.
-	// sealedRootHeight == rootSnapshot.SealingSegment.Sealed().Header.Height < rootHeight == rootSnapshot.SealingSegment.Highest().Header.Height
 	sealedRootHeight uint64
 	// sporkRootBlockHeight is the height of the root block in the current spork. We cache it in
 	// the state, because it cannot change over the lifecycle of a protocol state instance.

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -240,11 +240,9 @@ func (state *State) bootstrapSealingSegment(segment *flow.SealingSegment, head *
 		// different from the finalized root block, then it means the node dynamically bootstrapped.
 		// In that case, we should index the result of the sealed root block so that the EN is able
 		// to execute the next block.
-		if rootSeal.BlockID != head.ID() {
-			err := transaction.WithTx(operation.IndexExecutionResult(rootSeal.BlockID, rootSeal.ResultID))(tx)
-			if err != nil {
-				return fmt.Errorf("could not index root result: %w", err)
-			}
+		err := transaction.WithTx(operation.SkipDuplicates(operation.IndexExecutionResult(rootSeal.BlockID, rootSeal.ResultID)))(tx)
+		if err != nil {
+			return fmt.Errorf("could not index root result: %w", err)
 		}
 
 		for _, block := range segment.ExtraBlocks {

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -864,7 +864,12 @@ func (state *State) populateCache() error {
 		// sealed root height
 		err = state.db.View(operation.RetrieveSealedRootHeight(&state.sealedRootHeight))
 		if err != nil {
-			return fmt.Errorf("could not read root block to populate cache: %w", err)
+			if errors.Is(err, storage.ErrNotFound) {
+				// to be backward compatible
+				state.sealedRootHeight = state.rootHeight
+			} else {
+				return fmt.Errorf("could not read sealed root block to populate cache: %w", err)
+			}
 		}
 		// spork root block height
 		err = state.db.View(operation.RetrieveSporkRootBlockHeight(&state.sporkRootBlockHeight))

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -236,9 +236,9 @@ func (state *State) bootstrapSealingSegment(segment *flow.SealingSegment, head *
 			}
 
 			// first seal contains the result ID for the sealed root block, indexing it allows dynamically bootstrapped EN to execute
-			// the next block
+			// the next block.
 			err = transaction.WithTx(operation.IndexExecutionResult(rootResult.BlockID, rootResult.ID()))(tx)
-			if err != nil {
+			if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
 				return fmt.Errorf("could not index root result: %w", err)
 			}
 		}

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -45,7 +45,7 @@ type State struct {
 	// because it cannot change over the lifecycle of a protocol state instance. It is frequently
 	// larger than the height of the root block of the spork, (also cached below as
 	// `sporkRootBlockHeight`), for instance if the node joined in an epoch after the last spork.
-	rootHeight uint64
+	finalizedRootHeight uint64
 	// sealedRootHeight returns the root block that is sealed.
 	sealedRootHeight uint64
 	// sporkRootBlockHeight is the height of the root block in the current spork. We cache it in
@@ -374,12 +374,12 @@ func (state *State) bootstrapStatePointers(root protocol.Snapshot) func(*badger.
 		// insert height pointers
 		err = operation.InsertRootHeight(highest.Header.Height)(tx)
 		if err != nil {
-			return fmt.Errorf("could not insert root height: %w", err)
+			return fmt.Errorf("could not insert finalized root height: %w", err)
 		}
 		// the sealed root height is the lowest block in sealing segment
 		err = operation.InsertSealedRootHeight(lowest.Header.Height)(tx)
 		if err != nil {
-			return fmt.Errorf("could not insert root height: %w", err)
+			return fmt.Errorf("could not insert sealed root height: %w", err)
 		}
 		err = operation.InsertFinalizedHeight(highest.Header.Height)(tx)
 		if err != nil {

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -866,12 +866,7 @@ func (state *State) populateCache() error {
 		// sealed root height
 		err = state.db.View(operation.RetrieveSealedRootHeight(&state.sealedRootHeight))
 		if err != nil {
-			if errors.Is(err, storage.ErrNotFound) {
-				// to be backward compatible
-				state.sealedRootHeight = state.finalizedRootHeight
-			} else {
-				return fmt.Errorf("could not read sealed root block to populate cache: %w", err)
-			}
+			return fmt.Errorf("could not read sealed root block to populate cache: %w", err)
 		}
 		// spork root block height
 		err = state.db.View(operation.RetrieveSporkRootBlockHeight(&state.sporkRootBlockHeight))

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -131,7 +131,7 @@ func Bootstrap(
 		return nil, fmt.Errorf("could not get sealing segment: %w", err)
 	}
 
-	rootResult, _, err := root.SealedResult()
+	_, rootSeal, err := root.SealedResult()
 	if err != nil {
 		return nil, fmt.Errorf("could not get sealed result for sealing segment: %w", err)
 	}
@@ -146,7 +146,7 @@ func Bootstrap(
 		// 1) bootstrap the sealing segment
 		// creating sealed root block with the rootResult
 		// creating finalized root block with lastFinalized
-		err = state.bootstrapSealingSegment(segment, lastFinalized, rootResult)(tx)
+		err = state.bootstrapSealingSegment(segment, lastFinalized, rootSeal)(tx)
 		if err != nil {
 			return fmt.Errorf("could not bootstrap sealing chain segment blocks: %w", err)
 		}
@@ -214,7 +214,7 @@ func Bootstrap(
 
 // bootstrapSealingSegment inserts all blocks and associated metadata for the
 // protocol state root snapshot to disk.
-func (state *State) bootstrapSealingSegment(segment *flow.SealingSegment, head *flow.Block, rootResult *flow.ExecutionResult) func(tx *transaction.Tx) error {
+func (state *State) bootstrapSealingSegment(segment *flow.SealingSegment, head *flow.Block, rootSeal *flow.Seal) func(tx *transaction.Tx) error {
 	return func(tx *transaction.Tx) error {
 
 		for _, result := range segment.ExecutionResults {
@@ -234,11 +234,15 @@ func (state *State) bootstrapSealingSegment(segment *flow.SealingSegment, head *
 			if err != nil {
 				return fmt.Errorf("could not insert first seal: %w", err)
 			}
+		}
 
-			// first seal contains the result ID for the sealed root block, indexing it allows dynamically bootstrapped EN to execute
-			// the next block.
-			err = transaction.WithTx(operation.IndexExecutionResult(rootResult.BlockID, rootResult.ID()))(tx)
-			if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
+		// root seal contains the result ID for the sealed root block. If the sealed root block is
+		// different from the finalized root block, then it means the node dynamically bootstrapped.
+		// In that case, we should index the result of the sealed root block so that the EN is able
+		// to execute the next block.
+		if rootSeal.BlockID != head.ID() {
+			err := transaction.WithTx(operation.IndexExecutionResult(rootSeal.BlockID, rootSeal.ResultID))(tx)
+			if err != nil {
 				return fmt.Errorf("could not index root result: %w", err)
 			}
 		}

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -140,8 +140,8 @@ func Bootstrap(
 		// sealing segment is in ascending height order, so the tail is the
 		// oldest ancestor and head is the newest child in the segment
 		// TAIL <- ... <- HEAD
-		lastFinalized := segment.Highest() // the highest block in sealing segment is the last finalized block
-		lastSealed := segment.Sealed()     // the lowest block in sealing segment is the last sealed block
+		lastFinalized := segment.Finalized() // the highest block in sealing segment is the last finalized block
+		lastSealed := segment.Sealed()       // the lowest block in sealing segment is the last sealed block
 
 		// 1) bootstrap the sealing segment
 		// creating sealed root block with the rootResult
@@ -322,7 +322,7 @@ func (state *State) bootstrapStatePointers(root protocol.Snapshot) func(*badger.
 		if err != nil {
 			return fmt.Errorf("could not get sealing segment: %w", err)
 		}
-		highest := segment.Highest()
+		highest := segment.Finalized()
 		lowest := segment.Sealed()
 		// find the finalized seal that seals the lowest block, meaning seal.BlockID == lowest.ID()
 		seal, err := segment.FinalizedSeal()

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -859,7 +859,7 @@ func (state *State) populateCache() error {
 	// cache the initial value for finalized block
 	err := state.db.View(func(tx *badger.Txn) error {
 		// root height
-		err := state.db.View(operation.RetrieveRootHeight(&state.rootHeight))
+		err := state.db.View(operation.RetrieveRootHeight(&state.finalizedRootHeight))
 		if err != nil {
 			return fmt.Errorf("could not read root block to populate cache: %w", err)
 		}
@@ -868,7 +868,7 @@ func (state *State) populateCache() error {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
 				// to be backward compatible
-				state.sealedRootHeight = state.rootHeight
+				state.sealedRootHeight = state.finalizedRootHeight
 			} else {
 				return fmt.Errorf("could not read sealed root block to populate cache: %w", err)
 			}

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -305,7 +305,7 @@ func (state *State) bootstrapSealingSegment(segment *flow.SealingSegment, head *
 		}
 
 		// insert an empty child index for the final block in the segment
-		err := transaction.WithTx(operation.InsertBlockChildren(head.ID(), nil))(tx)
+		err = transaction.WithTx(operation.InsertBlockChildren(head.ID(), nil))(tx)
 		if err != nil {
 			return fmt.Errorf("could not insert child index for head block (id=%x): %w", head.ID(), err)
 		}

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -584,7 +584,7 @@ func assertSealingSegmentBlocksQueryableAfterBootstrap(t *testing.T, snapshot pr
 		segment, err := state.Final().SealingSegment()
 		require.NoError(t, err)
 
-		rootBlock, err := state.Params().Root()
+		rootBlock, err := state.Params().FinalizedRoot()
 		require.NoError(t, err)
 
 		// root block should be the highest block from the sealing segment

--- a/state/protocol/inmem/convert_test.go
+++ b/state/protocol/inmem/convert_test.go
@@ -43,7 +43,7 @@ func TestFromSnapshot(t *testing.T) {
 
 		// test that we are able to retrieve an in-memory version of root snapshot
 		t.Run("root snapshot", func(t *testing.T) {
-			root, err := state.Params().Root()
+			root, err := state.Params().FinalizedRoot()
 			require.NoError(t, err)
 			expected := state.AtHeight(root.Height)
 			actual, err := inmem.FromSnapshot(expected)

--- a/state/protocol/mock/instance_params.go
+++ b/state/protocol/mock/instance_params.go
@@ -88,6 +88,32 @@ func (_m *InstanceParams) Seal() (*flow.Seal, error) {
 	return r0, r1
 }
 
+// SealedRoot provides a mock function with given fields:
+func (_m *InstanceParams) SealedRoot() (*flow.Header, error) {
+	ret := _m.Called()
+
+	var r0 *flow.Header
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*flow.Header, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *flow.Header); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*flow.Header)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewInstanceParams interface {
 	mock.TestingT
 	Cleanup(func())

--- a/state/protocol/mock/instance_params.go
+++ b/state/protocol/mock/instance_params.go
@@ -36,8 +36,8 @@ func (_m *InstanceParams) EpochFallbackTriggered() (bool, error) {
 	return r0, r1
 }
 
-// Root provides a mock function with given fields:
-func (_m *InstanceParams) Root() (*flow.Header, error) {
+// FinalizedRoot provides a mock function with given fields:
+func (_m *InstanceParams) FinalizedRoot() (*flow.Header, error) {
 	ret := _m.Called()
 
 	var r0 *flow.Header

--- a/state/protocol/mock/params.go
+++ b/state/protocol/mock/params.go
@@ -84,32 +84,8 @@ func (_m *Params) EpochFallbackTriggered() (bool, error) {
 	return r0, r1
 }
 
-// ProtocolVersion provides a mock function with given fields:
-func (_m *Params) ProtocolVersion() (uint, error) {
-	ret := _m.Called()
-
-	var r0 uint
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (uint, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() uint); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint)
-	}
-
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Root provides a mock function with given fields:
-func (_m *Params) Root() (*flow.Header, error) {
+// FinalizedRoot provides a mock function with given fields:
+func (_m *Params) FinalizedRoot() (*flow.Header, error) {
 	ret := _m.Called()
 
 	var r0 *flow.Header
@@ -123,6 +99,30 @@ func (_m *Params) Root() (*flow.Header, error) {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*flow.Header)
 		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ProtocolVersion provides a mock function with given fields:
+func (_m *Params) ProtocolVersion() (uint, error) {
+	ret := _m.Called()
+
+	var r0 uint
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (uint, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() uint); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint)
 	}
 
 	if rf, ok := ret.Get(1).(func() error); ok {

--- a/state/protocol/mock/params.go
+++ b/state/protocol/mock/params.go
@@ -160,6 +160,32 @@ func (_m *Params) Seal() (*flow.Seal, error) {
 	return r0, r1
 }
 
+// SealedRoot provides a mock function with given fields:
+func (_m *Params) SealedRoot() (*flow.Header, error) {
+	ret := _m.Called()
+
+	var r0 *flow.Header
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*flow.Header, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *flow.Header); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*flow.Header)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // SporkID provides a mock function with given fields:
 func (_m *Params) SporkID() (flow.Identifier, error) {
 	ret := _m.Called()

--- a/state/protocol/params.go
+++ b/state/protocol/params.go
@@ -21,6 +21,7 @@ type InstanceParams interface {
 	// the head of the protocol state snapshot used to bootstrap this state and
 	// may differ from node to node for the same protocol state.
 	// No errors are expected during normal operation.
+	// TODO(leo): rename to FinalizedRoot
 	Root() (*flow.Header, error)
 
 	// SealedRoot returns the sealed root block. If it's different from Root() block,

--- a/state/protocol/params.go
+++ b/state/protocol/params.go
@@ -17,7 +17,7 @@ type Params interface {
 // different instance params.
 type InstanceParams interface {
 
-	// FinalizedRoot returns the root header of the current protocol state. This will be
+	// FinalizedRoot returns the finalized root header of the current protocol state. This will be
 	// the head of the protocol state snapshot used to bootstrap this state and
 	// may differ from node to node for the same protocol state.
 	// No errors are expected during normal operation.

--- a/state/protocol/params.go
+++ b/state/protocol/params.go
@@ -23,6 +23,11 @@ type InstanceParams interface {
 	// No errors are expected during normal operation.
 	Root() (*flow.Header, error)
 
+	// SealedRoot returns the sealed root block. If it's different from Root() block,
+	// it means the node is bootstrapped from mid-spork.
+	// No errors are expected during normal operation.
+	SealedRoot() (*flow.Header, error)
+
 	// Seal returns the root block seal of the current protocol state. This will be
 	// the seal for the root block used to bootstrap this state and may differ from
 	// node to node for the same protocol state.

--- a/state/protocol/params.go
+++ b/state/protocol/params.go
@@ -17,14 +17,13 @@ type Params interface {
 // different instance params.
 type InstanceParams interface {
 
-	// Root returns the root header of the current protocol state. This will be
+	// FinalizedRoot returns the root header of the current protocol state. This will be
 	// the head of the protocol state snapshot used to bootstrap this state and
 	// may differ from node to node for the same protocol state.
 	// No errors are expected during normal operation.
-	// TODO(leo): rename to FinalizedRoot
-	Root() (*flow.Header, error)
+	FinalizedRoot() (*flow.Header, error)
 
-	// SealedRoot returns the sealed root block. If it's different from Root() block,
+	// SealedRoot returns the sealed root block. If it's different from FinalizedRoot() block,
 	// it means the node is bootstrapped from mid-spork.
 	// No errors are expected during normal operation.
 	SealedRoot() (*flow.Header, error)

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -7,11 +7,11 @@ import (
 )
 
 func InsertRootHeight(height uint64) func(*badger.Txn) error {
-	return insert(makePrefix(codeRootHeight), height)
+	return insert(makePrefix(codeFinalizedRootHeight), height)
 }
 
 func RetrieveRootHeight(height *uint64) func(*badger.Txn) error {
-	return retrieve(makePrefix(codeRootHeight), height)
+	return retrieve(makePrefix(codeFinalizedRootHeight), height)
 }
 
 func InsertSealedRootHeight(height uint64) func(*badger.Txn) error {

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -14,6 +14,14 @@ func RetrieveRootHeight(height *uint64) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeRootHeight), height)
 }
 
+func InsertSealedRootHeight(height uint64) func(*badger.Txn) error {
+	return insert(makePrefix(codeSealedRootHeight), height)
+}
+
+func RetrieveSealedRootHeight(height *uint64) func(*badger.Txn) error {
+	return retrieve(makePrefix(codeSealedRootHeight), height)
+}
+
 func InsertFinalizedHeight(height uint64) func(*badger.Txn) error {
 	return insert(makePrefix(codeFinalizedHeight), height)
 }

--- a/storage/badger/operation/prefix.go
+++ b/storage/badger/operation/prefix.go
@@ -30,7 +30,7 @@ const (
 	codeSealedHeight            = 21 // latest sealed block height
 	codeClusterHeight           = 22 // latest finalized height on cluster
 	codeExecutedBlock           = 23 // latest executed block with max height
-	codeRootHeight              = 24 // the height of the highest finalized block contained in the root snapshot
+	codeFinalizedRootHeight     = 24 // the height of the highest finalized block contained in the root snapshot
 	codeLastCompleteBlockHeight = 25 // the height of the last block for which all collections were received
 	codeEpochFirstHeight        = 26 // the height of the first block in a given epoch
 	codeSealedRootHeight        = 27 // the height of the highest sealed block contained in the root snapshot

--- a/storage/badger/operation/prefix.go
+++ b/storage/badger/operation/prefix.go
@@ -30,10 +30,10 @@ const (
 	codeSealedHeight            = 21 // latest sealed block height
 	codeClusterHeight           = 22 // latest finalized height on cluster
 	codeExecutedBlock           = 23 // latest executed block with max height
-	codeRootHeight              = 24 // the height of the highest block contained in the root snapshot
+	codeRootHeight              = 24 // the height of the highest finalized block contained in the root snapshot
 	codeLastCompleteBlockHeight = 25 // the height of the last block for which all collections were received
 	codeEpochFirstHeight        = 26 // the height of the first block in a given epoch
-	codeSealedRootHeight        = 27 // the height of the lowest block contained in the root snapshot
+	codeSealedRootHeight        = 27 // the height of the highest sealed block contained in the root snapshot
 
 	// codes for single entity storage
 	// 31 was used for identities before epochs

--- a/storage/badger/operation/prefix.go
+++ b/storage/badger/operation/prefix.go
@@ -33,6 +33,7 @@ const (
 	codeRootHeight              = 24 // the height of the highest block contained in the root snapshot
 	codeLastCompleteBlockHeight = 25 // the height of the last block for which all collections were received
 	codeEpochFirstHeight        = 26 // the height of the first block in a given epoch
+	codeSealedRootHeight        = 27 // the height of the lowest block contained in the root snapshot
 
 	// codes for single entity storage
 	// 31 was used for identities before epochs

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -24,8 +24,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-// const GenesisStateCommitmentHex = "1fa4f0ccd3b991627d2c95a7aca3294fbe7407f82711b55f6863dc03c970ce08"
-const GenesisStateCommitmentHex = "a7afac1d7ee4de01d5ef7accd373579ecc59595fb475903fda1cdc98d8350a8a"
+const GenesisStateCommitmentHex = "1fa4f0ccd3b991627d2c95a7aca3294fbe7407f82711b55f6863dc03c970ce08"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -68,4 +67,31 @@ func init() {
 	// Cannot import virtual machine, due to circular dependency. Just use the value of
 	// fvm.AccountKeyWeightThreshold here
 	ServiceAccountPublicKey = ServiceAccountPrivateKey.PublicKey(1000)
+}
+
+// this is done by printing the state commitment in TestBootstrapLedger test with different chain ID
+func GenesisStateCommitmentByChainID(chainID flow.ChainID) flow.StateCommitment {
+	commitString := genesisCommitHexByChainID(chainID)
+	bytes, err := hex.DecodeString(commitString)
+	if err != nil {
+		panic("error while hex decoding hardcoded state commitment")
+	}
+	commit, err := flow.ToStateCommitment(bytes)
+	if err != nil {
+		panic("genesis state commitment size is invalid")
+	}
+	return commit
+}
+
+func genesisCommitHexByChainID(chainID flow.ChainID) string {
+	if chainID == flow.Mainnet {
+		return GenesisStateCommitmentHex
+	}
+	if chainID == flow.Testnet {
+		return "a7afac1d7ee4de01d5ef7accd373579ecc59595fb475903fda1cdc98d8350a8a"
+	}
+	if chainID == flow.Sandboxnet {
+		return "75e1ec7d2af323043aa9751ec2ae3fdf5ed9f445e1cb4349d14008d5edc892e2"
+	}
+	return "1b7736f113f0860f0df1ae5394ea1e926f1677c5944ca6a5a1680cd4f97420ec"
 }

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -24,7 +24,8 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "1fa4f0ccd3b991627d2c95a7aca3294fbe7407f82711b55f6863dc03c970ce08"
+// const GenesisStateCommitmentHex = "1fa4f0ccd3b991627d2c95a7aca3294fbe7407f82711b55f6863dc03c970ce08"
+const GenesisStateCommitmentHex = "a7afac1d7ee4de01d5ef7accd373579ecc59595fb475903fda1cdc98d8350a8a"
 
 var GenesisStateCommitment flow.StateCommitment
 

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2024,8 +2024,16 @@ func BootstrapFixture(
 	participants flow.IdentityList,
 	opts ...func(*flow.Block),
 ) (*flow.Block, *flow.ExecutionResult, *flow.Seal) {
+	return BootstrapFixtureWithChainID(participants, flow.Emulator, opts...)
+}
 
-	root := GenesisFixture()
+func BootstrapFixtureWithChainID(
+	participants flow.IdentityList,
+	chainID flow.ChainID,
+	opts ...func(*flow.Block),
+) (*flow.Block, *flow.ExecutionResult, *flow.Seal) {
+
+	root := flow.Genesis(chainID)
 	for _, apply := range opts {
 		apply(root)
 	}
@@ -2043,7 +2051,8 @@ func BootstrapFixture(
 		WithDKGFromParticipants(participants),
 	)
 
-	result := BootstrapExecutionResultFixture(root, GenesisStateCommitment)
+	stateCommit := GenesisStateCommitmentByChainID(chainID)
+	result := BootstrapExecutionResultFixture(root, stateCommit)
 	result.ServiceEvents = []flow.ServiceEvent{
 		setup.ServiceEvent(),
 		commit.ServiceEvent(),
@@ -2060,7 +2069,15 @@ func RootSnapshotFixture(
 	participants flow.IdentityList,
 	opts ...func(*flow.Block),
 ) *inmem.Snapshot {
-	block, result, seal := BootstrapFixture(participants.Sort(order.Canonical), opts...)
+	return RootSnapshotFixtureWithChainID(participants, flow.Emulator, opts...)
+}
+
+func RootSnapshotFixtureWithChainID(
+	participants flow.IdentityList,
+	chainID flow.ChainID,
+	opts ...func(*flow.Block),
+) *inmem.Snapshot {
+	block, result, seal := BootstrapFixtureWithChainID(participants.Sort(order.Canonical), chainID, opts...)
 	qc := QuorumCertificateFixture(QCWithRootBlockID(block.ID()))
 	root, err := inmem.SnapshotFromBootstrapState(block, result, seal, qc)
 	if err != nil {

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -794,6 +794,12 @@ func WithExecutionResultBlockID(blockID flow.Identifier) func(*flow.ExecutionRes
 	}
 }
 
+func WithFinalState(commit flow.StateCommitment) func(*flow.ExecutionResult) {
+	return func(result *flow.ExecutionResult) {
+		result.Chunks[len(result.Chunks)-1].EndState = commit
+	}
+}
+
 func WithServiceEvents(n int) func(result *flow.ExecutionResult) {
 	return func(result *flow.ExecutionResult) {
 		result.ServiceEvents = ServiceEventsFixture(n)

--- a/utils/unittest/mocks/protocol_state.go
+++ b/utils/unittest/mocks/protocol_state.go
@@ -70,6 +70,10 @@ func (p *Params) Root() (*flow.Header, error) {
 	return p.state.root.Header, nil
 }
 
+func (p *Params) SealedRoot() (*flow.Header, error) {
+	return p.Root()
+}
+
 func (p *Params) Seal() (*flow.Seal, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/utils/unittest/mocks/protocol_state.go
+++ b/utils/unittest/mocks/protocol_state.go
@@ -66,12 +66,12 @@ func (p *Params) EpochFallbackTriggered() (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }
 
-func (p *Params) Root() (*flow.Header, error) {
+func (p *Params) FinalizedRoot() (*flow.Header, error) {
 	return p.state.root.Header, nil
 }
 
 func (p *Params) SealedRoot() (*flow.Header, error) {
-	return p.Root()
+	return p.FinalizedRoot()
 }
 
 func (p *Params) Seal() (*flow.Seal, error) {


### PR DESCRIPTION
- Added a `snapshot` command to util to extract root snapshot for a given block
- Rename `Root` method on protocol state snapshot to `FinalizedRoot` to return the finalized root block
- Added `SealedRoot` method on protocol state snapshot to return the sealed root block. The sealed root block is useful for dynamically bootstrapping an EN, where it needs the result ID of the sealed root block in order to execute the next block, we can't do the same with the `FinalizedRoot`. That's why we added this method.
- For nodes that bootstrapped from the first block of a spork, the `FinalizedRoot` and `SealedRoot` are the same block. But for dynamically bootstrapped node, `SealedRoot` is lower than the `FinalizedRoot`.
- Changed the execution ingestion engine to reload unexecuted blocks from SealedRootBlock.Height + 1 to FinalizedRootBlock.Height, and execute them on startup. 