### PR TITLE
Remove outdated command from readme

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -21,11 +21,6 @@ libp2p, badger, and other golog-based libraries:
 curl localhost:9002/admin/run_command -H 'Content-Type: application/json' -d '{"commandName": "set-golog-level", "data": "debug"}'
 ```
 
-### To turn on profiler
-```
-curl localhost:9002/admin/run_command -H 'Content-Type: application/json' -d '{"commandName": "set-profiler-enabled", "data": true}'
-```
-
 ### To get the latest finalized block
 ```
 curl localhost:9002/admin/run_command -H 'Content-Type: application/json' -d '{"commandName": "read-blocks", "data": { "block": "final" }}'


### PR DESCRIPTION
Command no longer exists - replaced by `set-config`