### PR TITLE
[Observer] Remove unsupported execution sync from observer bootstrap

### DIFF
--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -6,17 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
-	badger "github.com/ipfs/go-ds-badger2"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
-	"github.com/onflow/go-bitswap"
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
 
@@ -42,13 +38,10 @@ import (
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/chainsync"
-	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	finalizer "github.com/onflow/flow-go/module/finalizer/consensus"
 	"github.com/onflow/flow-go/module/id"
 	"github.com/onflow/flow-go/module/local"
 	"github.com/onflow/flow-go/module/metrics"
-	"github.com/onflow/flow-go/module/state_synchronization"
-	edrequester "github.com/onflow/flow-go/module/state_synchronization/requester"
 	consensus_follower "github.com/onflow/flow-go/module/upstream"
 	"github.com/onflow/flow-go/network"
 	alspmgr "github.com/onflow/flow-go/network/alsp/manager"
@@ -57,7 +50,6 @@ import (
 	cborcodec "github.com/onflow/flow-go/network/codec/cbor"
 	"github.com/onflow/flow-go/network/converter"
 	"github.com/onflow/flow-go/network/p2p"
-	"github.com/onflow/flow-go/network/p2p/blob"
 	"github.com/onflow/flow-go/network/p2p/cache"
 	"github.com/onflow/flow-go/network/p2p/conduit"
 	p2pdht "github.com/onflow/flow-go/network/p2p/dht"
@@ -77,8 +69,6 @@ import (
 	badgerState "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/blocktimer"
 	"github.com/onflow/flow-go/state/protocol/events/gadgets"
-	"github.com/onflow/flow-go/storage"
-	bstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/utils/grpcutils"
 	"github.com/onflow/flow-go/utils/io"
 )
@@ -111,10 +101,6 @@ type ObserverServiceConfig struct {
 	apiBurstlimits            map[string]int
 	rpcConf                   rpc.Config
 	rpcMetricsEnabled         bool
-	executionDataSyncEnabled  bool
-	executionDataDir          string
-	executionDataStartHeight  uint64
-	executionDataConfig       edrequester.ExecutionDataConfig
 	apiTimeout                time.Duration
 	upstreamNodeAddresses     []string
 	upstreamNodePublicKeys    []string
@@ -123,7 +109,6 @@ type ObserverServiceConfig struct {
 
 // DefaultObserverServiceConfig defines all the default values for the ObserverServiceConfig
 func DefaultObserverServiceConfig() *ObserverServiceConfig {
-	homedir, _ := os.UserHomeDir()
 	return &ObserverServiceConfig{
 		rpcConf: rpc.Config{
 			UnsecureGRPCListenAddr:    "0.0.0.0:9000",
@@ -146,19 +131,9 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 		bootstrapNodeAddresses:    []string{},
 		bootstrapNodePublicKeys:   []string{},
 		observerNetworkingKeyPath: cmd.NotSet,
-		executionDataSyncEnabled:  false,
-		executionDataDir:          filepath.Join(homedir, ".flow", "execution_data"),
-		executionDataStartHeight:  0,
-		executionDataConfig: edrequester.ExecutionDataConfig{
-			InitialBlockHeight: 0,
-			MaxSearchAhead:     edrequester.DefaultMaxSearchAhead,
-			FetchTimeout:       edrequester.DefaultFetchTimeout,
-			RetryDelay:         edrequester.DefaultRetryDelay,
-			MaxRetryDelay:      edrequester.DefaultMaxRetryDelay,
-		},
-		apiTimeout:             3 * time.Second,
-		upstreamNodeAddresses:  []string{},
-		upstreamNodePublicKeys: []string{},
+		apiTimeout:                3 * time.Second,
+		upstreamNodeAddresses:     []string{},
+		upstreamNodePublicKeys:    []string{},
 	}
 }
 
@@ -169,17 +144,16 @@ type ObserverServiceBuilder struct {
 	*ObserverServiceConfig
 
 	// components
-	LibP2PNode              p2p.LibP2PNode
-	FollowerState           stateprotocol.FollowerState
-	SyncCore                *chainsync.Core
-	RpcEng                  *rpc.Engine
-	FollowerDistributor     *pubsub.FollowerDistributor
-	Committee               hotstuff.DynamicCommittee
-	Finalized               *flow.Header
-	Pending                 []*flow.Header
-	FollowerCore            module.HotStuffFollower
-	ExecutionDataDownloader execution_data.Downloader
-	ExecutionDataRequester  state_synchronization.ExecutionDataRequester // for the observer, the sync engine participants provider is the libp2p peer store which is not
+	LibP2PNode          p2p.LibP2PNode
+	FollowerState       stateprotocol.FollowerState
+	SyncCore            *chainsync.Core
+	RpcEng              *rpc.Engine
+	FollowerDistributor *pubsub.FollowerDistributor
+	Committee           hotstuff.DynamicCommittee
+	Finalized           *flow.Header
+	Pending             []*flow.Header
+	FollowerCore        module.HotStuffFollower
+
 	// available until after the network has started. Hence, a factory function that needs to be called just before
 	// creating the sync engine
 	SyncEngineParticipantsProviderFactory func() module.IdentifierProvider
@@ -435,112 +409,6 @@ func (builder *ObserverServiceBuilder) BuildConsensusFollower() cmd.NodeBuilder 
 	return builder
 }
 
-func (builder *ObserverServiceBuilder) BuildExecutionDataRequester() *ObserverServiceBuilder {
-	var ds *badger.Datastore
-	var bs network.BlobService
-	var processedBlockHeight storage.ConsumerProgress
-	var processedNotifications storage.ConsumerProgress
-
-	builder.
-		Module("execution data datastore and blobstore", func(node *cmd.NodeConfig) error {
-			err := os.MkdirAll(builder.executionDataDir, 0700)
-			if err != nil {
-				return err
-			}
-
-			ds, err = badger.NewDatastore(builder.executionDataDir, &badger.DefaultOptions)
-			if err != nil {
-				return err
-			}
-
-			builder.ShutdownFunc(func() error {
-				if err := ds.Close(); err != nil {
-					return fmt.Errorf("could not close execution data datastore: %w", err)
-				}
-				return nil
-			})
-
-			return nil
-		}).
-		Module("processed block height consumer progress", func(node *cmd.NodeConfig) error {
-			// uses the datastore's DB
-			processedBlockHeight = bstorage.NewConsumerProgress(ds.DB, module.ConsumeProgressExecutionDataRequesterBlockHeight)
-			return nil
-		}).
-		Module("processed notifications consumer progress", func(node *cmd.NodeConfig) error {
-			// uses the datastore's DB
-			processedNotifications = bstorage.NewConsumerProgress(ds.DB, module.ConsumeProgressExecutionDataRequesterNotification)
-			return nil
-		}).
-		Component("execution data service", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
-			var err error
-			bs, err = node.Network.RegisterBlobService(channels.ExecutionDataService, ds,
-				blob.WithBitswapOptions(
-					bitswap.WithTracer(
-						blob.NewTracer(node.Logger.With().Str("blob_service", channels.ExecutionDataService.String()).Logger()),
-					),
-				),
-			)
-			if err != nil {
-				return nil, fmt.Errorf("could not register blob service: %w", err)
-			}
-
-			builder.ExecutionDataDownloader = execution_data.NewDownloader(bs)
-
-			return builder.ExecutionDataDownloader, nil
-		}).
-		Component("execution data requester", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
-			// Validation of the start block height needs to be done after loading state
-			if builder.executionDataStartHeight > 0 {
-				if builder.executionDataStartHeight <= builder.RootBlock.Header.Height {
-					return nil, fmt.Errorf(
-						"execution data start block height (%d) must be greater than the root block height (%d)",
-						builder.executionDataStartHeight, builder.RootBlock.Header.Height)
-				}
-
-				latestSeal, err := builder.State.Sealed().Head()
-				if err != nil {
-					return nil, fmt.Errorf("failed to get latest sealed height")
-				}
-
-				// Note: since the root block of a spork is also sealed in the root protocol state, the
-				// latest sealed height is always equal to the root block height. That means that at the
-				// very beginning of a spork, this check will always fail. Operators should not specify
-				// an InitialBlockHeight when starting from the beginning of a spork.
-				if builder.executionDataStartHeight > latestSeal.Height {
-					return nil, fmt.Errorf(
-						"execution data start block height (%d) must be less than or equal to the latest sealed block height (%d)",
-						builder.executionDataStartHeight, latestSeal.Height)
-				}
-
-				// executionDataStartHeight is provided as the first block to sync, but the
-				// requester expects the initial last processed height, which is the first height - 1
-				builder.executionDataConfig.InitialBlockHeight = builder.executionDataStartHeight - 1
-			} else {
-				builder.executionDataConfig.InitialBlockHeight = builder.RootBlock.Header.Height
-			}
-
-			builder.ExecutionDataRequester = edrequester.New(
-				builder.Logger,
-				metrics.NewExecutionDataRequesterCollector(),
-				builder.ExecutionDataDownloader,
-				processedBlockHeight,
-				processedNotifications,
-				builder.State,
-				builder.Storage.Headers,
-				builder.Storage.Results,
-				builder.Storage.Seals,
-				builder.executionDataConfig,
-			)
-
-			builder.FollowerDistributor.AddOnBlockFinalizedConsumer(builder.ExecutionDataRequester.OnBlockFinalized)
-
-			return builder.ExecutionDataRequester, nil
-		})
-
-	return builder
-}
-
 type Option func(*ObserverServiceConfig)
 
 func NewFlowObserverServiceBuilder(opts ...Option) *ObserverServiceBuilder {
@@ -588,31 +456,6 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 		flags.StringSliceVar(&builder.upstreamNodeAddresses, "upstream-node-addresses", defaultConfig.upstreamNodeAddresses, "the gRPC network addresses of the upstream access node. e.g. access-001.mainnet.flow.org:9000,access-002.mainnet.flow.org:9000")
 		flags.StringSliceVar(&builder.upstreamNodePublicKeys, "upstream-node-public-keys", defaultConfig.upstreamNodePublicKeys, "the networking public key of the upstream access node (in the same order as the upstream node addresses) e.g. \"d57a5e9c5.....\",\"44ded42d....\"")
 		flags.BoolVar(&builder.rpcMetricsEnabled, "rpc-metrics-enabled", defaultConfig.rpcMetricsEnabled, "whether to enable the rpc metrics")
-
-		// ExecutionDataRequester config
-		flags.BoolVar(&builder.executionDataSyncEnabled, "execution-data-sync-enabled", defaultConfig.executionDataSyncEnabled, "whether to enable the execution data sync protocol")
-		flags.StringVar(&builder.executionDataDir, "execution-data-dir", defaultConfig.executionDataDir, "directory to use for Execution Data database")
-		flags.Uint64Var(&builder.executionDataStartHeight, "execution-data-start-height", defaultConfig.executionDataStartHeight, "height of first block to sync execution data from when starting with an empty Execution Data database")
-		flags.Uint64Var(&builder.executionDataConfig.MaxSearchAhead, "execution-data-max-search-ahead", defaultConfig.executionDataConfig.MaxSearchAhead, "max number of heights to search ahead of the lowest outstanding execution data height")
-		flags.DurationVar(&builder.executionDataConfig.FetchTimeout, "execution-data-fetch-timeout", defaultConfig.executionDataConfig.FetchTimeout, "timeout to use when fetching execution data from the network e.g. 300s")
-		flags.DurationVar(&builder.executionDataConfig.RetryDelay, "execution-data-retry-delay", defaultConfig.executionDataConfig.RetryDelay, "initial delay for exponential backoff when fetching execution data fails e.g. 10s")
-		flags.DurationVar(&builder.executionDataConfig.MaxRetryDelay, "execution-data-max-retry-delay", defaultConfig.executionDataConfig.MaxRetryDelay, "maximum delay for exponential backoff when fetching execution data fails e.g. 5m")
-	}).ValidateFlags(func() error {
-		if builder.executionDataSyncEnabled {
-			if builder.executionDataConfig.FetchTimeout <= 0 {
-				return errors.New("execution-data-fetch-timeout must be greater than 0")
-			}
-			if builder.executionDataConfig.RetryDelay <= 0 {
-				return errors.New("execution-data-retry-delay must be greater than 0")
-			}
-			if builder.executionDataConfig.MaxRetryDelay < builder.executionDataConfig.RetryDelay {
-				return errors.New("execution-data-max-retry-delay must be greater than or equal to execution-data-retry-delay")
-			}
-			if builder.executionDataConfig.MaxSearchAhead == 0 {
-				return errors.New("execution-data-max-search-ahead must be greater than 0")
-			}
-		}
-		return nil
 	})
 }
 
@@ -947,9 +790,6 @@ func (builder *ObserverServiceBuilder) initObserverLocal() func(node *cmd.NodeCo
 // Currently, the observer only runs the follower engine.
 func (builder *ObserverServiceBuilder) Build() (cmd.Node, error) {
 	builder.BuildConsensusFollower()
-	if builder.executionDataSyncEnabled {
-		builder.BuildExecutionDataRequester()
-	}
 	return builder.FlowNodeBuilder.Build()
 }
 


### PR DESCRIPTION
Execution sync is currently not support on observers. Remove it for now to avoid churn when making changes to the module. It will be readded in a future PR when support is enabled.