### PR TITLE
Add finalized and executed dispatcher

### DIFF
--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -204,6 +204,16 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 
 	stopControl := NewStopControl(zerolog.Nop(), false, 0)
 
+	finalizedAndExecutedDispatcher := NewFinalizedAndExecutedDispatcher(
+		0,
+		func(ctx context.Context, f *flow.Header) (bool, error) {
+			return false, nil
+		},
+		func(ctx context.Context, f *flow.Header) (bool, error) {
+			return false, nil
+		},
+	)
+
 	uploadMgr := uploader.NewManager(trace.NewNoopTracer())
 
 	engine, err = New(
@@ -228,6 +238,7 @@ func runWithEngine(t *testing.T, f func(testingContext)) {
 		nil,
 		uploadMgr,
 		stopControl,
+		finalizedAndExecutedDispatcher,
 	)
 	require.NoError(t, err)
 
@@ -1546,6 +1557,16 @@ func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecution
 		return stateProtocol.IsNodeAuthorizedAt(ps.AtBlockID(blockID), myIdentity.NodeID)
 	}
 
+	finalizedAndExecutedDispatcher := NewFinalizedAndExecutedDispatcher(
+		0,
+		func(ctx context.Context, f *flow.Header) (bool, error) {
+			return false, nil
+		},
+		func(ctx context.Context, f *flow.Header) (bool, error) {
+			return false, nil
+		},
+	)
+
 	engine, err = New(
 		log,
 		net,
@@ -1568,6 +1589,7 @@ func newIngestionEngine(t *testing.T, ps *mocks.ProtocolState, es *mockExecution
 		nil,
 		nil,
 		NewStopControl(zerolog.Nop(), false, 0),
+		finalizedAndExecutedDispatcher,
 	)
 
 	require.NoError(t, err)

--- a/engine/execution/ingestion/finalized_and_executed_handler.go
+++ b/engine/execution/ingestion/finalized_and_executed_handler.go
@@ -1,0 +1,162 @@
+package ingestion
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+type OnBlockFinalizedAndExecutedConsumer = func(h *flow.Header)
+
+// FinalizedAndExecutedDispatcher dispatches on block finalized and executed events
+type FinalizedAndExecutedDispatcher interface {
+	AddOnFinalizedAndExecutedConsumer(OnBlockFinalizedAndExecutedConsumer)
+	OnBlockExecuted(ctx context.Context, h *flow.Header) error
+	OnBlockFinalized(ctx context.Context, h *flow.Header) error
+}
+
+type finalizedAndExecutedDispatcher struct {
+	sync.RWMutex
+	log zerolog.Logger
+
+	blockFinalizedAndExecutedConsumers []OnBlockFinalizedAndExecutedConsumer
+	latestFinalizedAndExecutedHeight   uint64
+
+	isBlockFinalized func(context.Context, *flow.Header) (bool, error)
+	isBlockExecuted  func(context.Context, *flow.Header) (bool, error)
+}
+
+type FinalizedAndExecutedDispatcherOption func(*finalizedAndExecutedDispatcher)
+
+// FinalizedAndExecutedDispatcherWithLogger sets the logger for the
+// FinalizedAndExecutedDispatcher and adds a component field to the logger
+func FinalizedAndExecutedDispatcherWithLogger(
+	log zerolog.Logger,
+) FinalizedAndExecutedDispatcherOption {
+	return func(f *finalizedAndExecutedDispatcher) {
+		f.log = log.With().
+			Str("component", "finalized-and-executed-dispatcher").
+			Logger()
+	}
+}
+
+// NewFinalizedAndExecutedDispatcher returns a new FinalizedAndExecutedDispatcher
+func NewFinalizedAndExecutedDispatcher(
+	latestFinalizedAndExecutedHeight uint64,
+	isBlockFinalized func(context.Context, *flow.Header) (bool, error),
+	isBlockExecuted func(context.Context, *flow.Header) (bool, error),
+	options ...FinalizedAndExecutedDispatcherOption,
+) FinalizedAndExecutedDispatcher {
+	d := &finalizedAndExecutedDispatcher{
+		log: zerolog.Nop(),
+
+		blockFinalizedAndExecutedConsumers: []OnBlockFinalizedAndExecutedConsumer{},
+		latestFinalizedAndExecutedHeight:   latestFinalizedAndExecutedHeight,
+
+		isBlockFinalized: isBlockFinalized,
+		isBlockExecuted:  isBlockExecuted,
+	}
+
+	for _, option := range options {
+		option(d)
+	}
+
+	return d
+}
+
+func (f *finalizedAndExecutedDispatcher) AddOnFinalizedAndExecutedConsumer(
+	consumer OnBlockFinalizedAndExecutedConsumer,
+) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.blockFinalizedAndExecutedConsumers =
+		append(f.blockFinalizedAndExecutedConsumers, consumer)
+}
+
+func (f *finalizedAndExecutedDispatcher) OnBlockExecuted(
+	ctx context.Context,
+	h *flow.Header,
+) error {
+	isNew, err := f.checkOnBlockExecuted(ctx, h)
+	if !isNew || err != nil {
+		return err
+	}
+
+	f.dispatchFinalizedAndExecuted(h)
+
+	return nil
+}
+
+func (f *finalizedAndExecutedDispatcher) OnBlockFinalized(
+	ctx context.Context,
+	h *flow.Header,
+) error {
+	isNew, err := f.checkOnBlockFinalized(ctx, h)
+	if !isNew || err != nil {
+		return err
+	}
+
+	f.dispatchFinalizedAndExecuted(h)
+
+	return nil
+}
+
+// checkOnBlockExecuted checks if this is a new highest executed and finalized block
+// we know its executed because we are in the OnBlockExecuted callback
+func (f *finalizedAndExecutedDispatcher) checkOnBlockExecuted(
+	ctx context.Context,
+	h *flow.Header,
+) (bool, error) {
+	f.RLock()
+	defer f.RUnlock()
+
+	// we check latestFinalizedAndExecutedHeight+1 to further ensure that we are not
+	// skipping blocks
+	if h.Height != f.latestFinalizedAndExecutedHeight+1 {
+		return false, nil
+	}
+
+	if finalized, err := f.isBlockFinalized(ctx, h); !finalized || err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// checkOnBlockFinalized checks if this is a new highest executed and finalized block
+// we know its finalized because we are in the OnBlockFinalized callback
+func (f *finalizedAndExecutedDispatcher) checkOnBlockFinalized(
+	ctx context.Context,
+	h *flow.Header,
+) (bool, error) {
+	f.RLock()
+	defer f.RUnlock()
+
+	// we check latestFinalizedAndExecutedHeight+1 to further ensure that we are not
+	// skipping blocks
+	if h.Height != f.latestFinalizedAndExecutedHeight+1 {
+		return false, nil
+	}
+
+	if executed, err := f.isBlockExecuted(ctx, h); !executed || err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// dispatchFinalizedAndExecuted dispatches events to all registered consumers
+func (f *finalizedAndExecutedDispatcher) dispatchFinalizedAndExecuted(h *flow.Header) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.latestFinalizedAndExecutedHeight = h.Height
+
+	for _, consumer := range f.blockFinalizedAndExecutedConsumers {
+		consumer(h)
+	}
+}

--- a/engine/execution/ingestion/finalized_and_executed_handler_test.go
+++ b/engine/execution/ingestion/finalized_and_executed_handler_test.go
@@ -1,0 +1,107 @@
+package ingestion
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func Test_finalizedAndExecutedDispatcher_callsForwardedCorrectly(t *testing.T) {
+	ctx := context.Background()
+
+	latestFinalizedAndExecutedHeight := uint64(100)
+	isBlockFinalizedCalled := 0
+	isBlockFinalized := func(context.Context, *flow.Header) (bool, error) {
+		isBlockFinalizedCalled++
+		return true, nil
+	}
+	isBlockExecutedCalled := 0
+	isBlockExecuted := func(context.Context, *flow.Header) (bool, error) {
+		isBlockExecutedCalled++
+		return true, nil
+	}
+
+	dispatcher := NewFinalizedAndExecutedDispatcher(
+		latestFinalizedAndExecutedHeight,
+		isBlockFinalized,
+		isBlockExecuted,
+	)
+
+	consumerCalled := 0
+	consumer := func(h *flow.Header) {
+		consumerCalled++
+	}
+	dispatcher.AddOnFinalizedAndExecutedConsumer(consumer)
+
+	err := dispatcher.OnBlockExecuted(ctx, header(102))
+	require.NoError(t, err)
+	// non sequentially executed block
+	require.Equal(t, 0, isBlockFinalizedCalled)
+	err = dispatcher.OnBlockExecuted(ctx, header(99))
+	require.NoError(t, err)
+	require.Equal(t, 0, isBlockFinalizedCalled)
+	err = dispatcher.OnBlockExecuted(ctx, header(100))
+	require.NoError(t, err)
+	require.Equal(t, 0, isBlockFinalizedCalled)
+	err = dispatcher.OnBlockExecuted(ctx, header(101))
+	require.NoError(t, err)
+	// this is now the new finalized and executed height
+	require.Equal(t, 1, isBlockFinalizedCalled)
+	require.Equal(t, 1, consumerCalled)
+
+	err = dispatcher.OnBlockFinalized(ctx, header(103))
+	require.NoError(t, err)
+	// non sequentially finalized block
+	err = dispatcher.OnBlockFinalized(ctx, header(100))
+	require.NoError(t, err)
+	require.Equal(t, 0, isBlockExecutedCalled)
+	err = dispatcher.OnBlockFinalized(ctx, header(101))
+	require.NoError(t, err)
+	require.Equal(t, 0, isBlockExecutedCalled)
+	err = dispatcher.OnBlockFinalized(ctx, header(102))
+	require.NoError(t, err)
+	// this is now the new finalized and executed height
+	require.Equal(t, 1, isBlockExecutedCalled)
+	require.Equal(t, 2, consumerCalled)
+}
+
+func Test_finalizedAndExecutedDispatcher_ErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+
+	someError := errors.Errorf("some error")
+	someError2 := errors.Errorf("some error 2")
+
+	latestFinalizedAndExecutedHeight := uint64(100)
+	isBlockFinalizedCalled := 0
+	isBlockFinalized := func(context.Context, *flow.Header) (bool, error) {
+		isBlockFinalizedCalled++
+		return true, someError
+	}
+	isBlockExecutedCalled := 0
+	isBlockExecuted := func(context.Context, *flow.Header) (bool, error) {
+		isBlockExecutedCalled++
+		return false, someError2
+	}
+
+	dispatcher := NewFinalizedAndExecutedDispatcher(
+		latestFinalizedAndExecutedHeight,
+		isBlockFinalized,
+		isBlockExecuted,
+	)
+
+	err := dispatcher.OnBlockExecuted(ctx, header(101))
+	require.ErrorIs(t, err, someError)
+
+	err = dispatcher.OnBlockFinalized(ctx, header(101))
+	require.ErrorIs(t, err, someError2)
+}
+
+func header(h uint64) *flow.Header {
+	return &flow.Header{
+		Height: h,
+	}
+}


### PR DESCRIPTION
Add a finalized and executed dispatcher, that other components can hook into so that they can keep track of the latest finalized and executed block.

this will be used for stop control with version beacons.

I am not sure about the naming and the location of the files, please pay special attention to that during the review.