### PR TITLE
Remove reporting feature from state extraction

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -2,7 +2,6 @@ package extract
 
 import (
 	"encoding/hex"
-	"fmt"
 	"path"
 
 	"github.com/rs/zerolog/log"
@@ -26,16 +25,6 @@ var (
 	flagNoReport          bool
 	flagNWorker           int
 )
-
-func getChain(chainName string) (chain flow.Chain, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("invalid chain: %s", r)
-		}
-	}()
-	chain = flow.ChainID(chainName).Chain()
-	return
-}
 
 var Cmd = &cobra.Command{
 	Use:   "execution-state-extract",
@@ -135,19 +124,20 @@ func run(*cobra.Command, []string) {
 	// 	log.Fatal().Err(err).Msgf("cannot ensure checkpoint file exist in folder %v", flagExecutionStateDir)
 	// }
 
-	chain, err := getChain(flagChain)
-	if err != nil {
-		log.Fatal().Err(err).Msgf("invalid chain name")
+	if len(flagChain) > 0 {
+		log.Warn().Msgf("--chain flag is deprecated")
 	}
 
-	err = extractExecutionState(
+	if flagNoReport {
+		log.Warn().Msgf("--no-report flag is deprecated")
+	}
+
+	err := extractExecutionState(
 		flagExecutionStateDir,
 		stateCommitment,
 		flagOutputDir,
 		log.Logger,
-		chain,
 		!flagNoMigration,
-		!flagNoReport,
 		flagNWorker,
 	)
 

--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -132,12 +132,15 @@ func run(*cobra.Command, []string) {
 		log.Warn().Msgf("--no-report flag is deprecated")
 	}
 
+	if flagNoMigration {
+		log.Warn().Msgf("--no-migration flag is deprecated")
+	}
+
 	err := extractExecutionState(
 		flagExecutionStateDir,
 		stateCommitment,
 		flagOutputDir,
 		log.Logger,
-		!flagNoMigration,
 		flagNWorker,
 	)
 

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -81,7 +81,6 @@ func extractExecutionState(
 	}()
 
 	var migrations []ledger.Migration
-	var preCheckpointReporters, postCheckpointReporters []ledger.Reporter
 	newState := ledger.State(targetHash)
 
 	if migrate {

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -26,9 +26,7 @@ func extractExecutionState(
 	targetHash flow.StateCommitment,
 	outputDir string,
 	log zerolog.Logger,
-	chain flow.Chain,
 	migrate bool,
-	report bool,
 	nWorker int, // number of concurrent worker to migation payloads
 ) error {
 

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -26,7 +26,6 @@ func extractExecutionState(
 	targetHash flow.StateCommitment,
 	outputDir string,
 	log zerolog.Logger,
-	migrate bool,
 	nWorker int, // number of concurrent worker to migation payloads
 ) error {
 
@@ -80,14 +79,6 @@ func extractExecutionState(
 
 	var migrations []ledger.Migration
 	newState := ledger.State(targetHash)
-
-	if migrate {
-		// add migration here
-		migrations = []ledger.Migration{
-			// the following migration calculate the storage usage and update the storage for each account
-			// mig.MigrateAccountUsage,
-		}
-	}
 
 	migratedState, err := led.ExportCheckpointAt(
 		newState,

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -64,9 +64,6 @@ func TestExtractExecutionState(t *testing.T) {
 				unittest.StateCommitmentFixture(),
 				outdir,
 				zerolog.Nop(),
-				flow.Emulator.Chain(),
-				false,
-				false,
 				10,
 			)
 			require.Error(t, err)

--- a/ledger/complete/ledger_test.go
+++ b/ledger/complete/ledger_test.go
@@ -734,7 +734,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				state, _, err = led.Set(u)
 				require.NoError(t, err)
 
-				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{noOpMigration}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
+				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{noOpMigration}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
 				require.NoError(t, err)
 				assert.Equal(t, newState, state)
 
@@ -792,7 +792,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				state, _, err = led.Set(u)
 				require.NoError(t, err)
 
-				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByValue}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
+				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByValue}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
 				require.NoError(t, err)
 
 				diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)
@@ -848,7 +848,7 @@ func Test_ExportCheckpointAt(t *testing.T) {
 				state, _, err = led.Set(u)
 				require.NoError(t, err)
 
-				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByKey}, []ledger.Reporter{}, []ledger.Reporter{}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
+				newState, err := led.ExportCheckpointAt(state, []ledger.Migration{migrationByKey}, complete.DefaultPathFinderVersion, dir2, "root.checkpoint")
 				require.NoError(t, err)
 
 				diskWal2, err := wal.NewDiskWAL(zerolog.Nop(), nil, metrics.NewNoopCollector(), dir2, capacity, pathfinder.PathByteSize, wal.SegmentSize)


### PR DESCRIPTION
This PR removes the reporting feature for the state extraction util, why?

because:
- The report takes a really long time, and causing it’s hard to tell if the state extraction is completed
- The [post reporting](https://github.com/onflow/flow-go/blob/master/cmd/util/cmd/execution-state-extract/execution_state_extract.go#L109) can be done with a different command line, it just needs to read the checkpoint file again into memory, which is now quite fast.
- The [pre reporting](https://github.com/onflow/flow-go/blob/master/cmd/util/cmd/execution-state-extract/execution_state_extract.go#L101) is currently used printing epoch counter, which we are no longer using during spork, instead we are sending a script querying on an EN to find the latest epoch counter, and using the epoch end view to determine whether the last sealed block exceeds the epoch boundary.
- We can also remove the --chain parameter from the state extraction util, which is only needed by the reporting feature.

This PR also speeds up the state extraction.