### PR TITLE
[Testing][CI] Unquarantine TestMultiCluster (integration/tests/collection/proposal_test.go)

### DIFF
--- a/integration/tests/collection/proposal_test.go
+++ b/integration/tests/collection/proposal_test.go
@@ -13,11 +13,9 @@ import (
 
 	"github.com/onflow/flow-go/integration/convert"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestMultiCluster(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "flaky as it often hits port already allocated, since too many containers are created")
 	suite.Run(t, new(MultiClusterSuite))
 }
 


### PR DESCRIPTION
`TestMultiCluster` test has been passing about 95% of the time in the [Flaky Test Monitor](https://dapperlabs.grafana.net/d/toErpbynz/single-test-metrics?orgId=1&var-package=github.com%2Fonflow%2Fflow-go%2Fintegration%2Ftests%2Fcollection&var-dataset_name=dapperlabs-data.production_src_flow_test_metrics&var-skipped_tests_table=skipped_tests&var-test_results_table=test_results&var-query_limit=100000&var-test=TestMultiCluster&from=now-30d&to=now) and can be unquarantined.

<img width="1482" alt="image" src="https://github.com/onflow/flow-go/assets/15269764/65b6b4ca-ab47-48c1-ba25-d0ebaaab731c">
