### PR TITLE
[Testing][CI] Unquarantine TestExecutionStateSync (integration/tests/access/execution_state_sync_test.go)

### DIFF
--- a/integration/tests/access/execution_state_sync_test.go
+++ b/integration/tests/access/execution_state_sync_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestExecutionStateSync(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "flaky as it constantly runs into badger errors or blob not found errors")
 	suite.Run(t, new(ExecutionStateSyncSuite))
 }
 


### PR DESCRIPTION
`TestExecutionStateSync has been passing about 98% of the time in the [Flaky Test Monitor](https://dapperlabs.grafana.net/d/toErpbynz/single-test-metrics?orgId=1&var-package=github.com%2Fonflow%2Fflow-go%2Fintegration%2Ftests%2Faccess&var-dataset_name=dapperlabs-data.production_src_flow_test_metrics&var-skipped_tests_table=skipped_tests&var-test_results_table=test_results&var-query_limit=100000&var-test=TestExecutionStateSync&from=now-30d&to=now) and can be unquarantined.

<img width="1495" alt="image" src="https://github.com/onflow/flow-go/assets/15269764/23af7488-f229-4881-ae62-7397e7d008f0">
