### PR TITLE
[v0.29] Update to Cadence v0.31.6-patch.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -295,4 +295,4 @@ require (
 
 replace mellium.im/sasl => github.com/mellium/sasl v0.2.1
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.31.6-patch.1
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.31.6-patch.2

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
-github.com/dapperlabs/cadence-internal v0.31.6-patch.1 h1:Y3qSHMdLk2KOLeuj2QolyOLk/lRc2hDkZmCTDme8izs=
-github.com/dapperlabs/cadence-internal v0.31.6-patch.1/go.mod h1:oRgWkvau1RH15m3NuDlZCPHFQzwvC72jEstCGu8OJ98=
+github.com/dapperlabs/cadence-internal v0.31.6-patch.2 h1:YAY1ZCcu/nBk45TW+a3YHchP1qaJAPyQqmfjPnIvGOY=
+github.com/dapperlabs/cadence-internal v0.31.6-patch.2/go.mod h1:oRgWkvau1RH15m3NuDlZCPHFQzwvC72jEstCGu8OJ98=
 github.com/dapperlabs/testingdock v0.4.4 h1:nDpnEjhs2gNv7rcb70PTfHlL3yr4eQycqp0+oFuhyNg=
 github.com/dapperlabs/testingdock v0.4.4/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -264,4 +264,4 @@ require (
 
 replace github.com/onflow/flow-go => ../
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.31.6-patch.1
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.31.6-patch.2

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -241,8 +241,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
-github.com/dapperlabs/cadence-internal v0.31.6-patch.1 h1:Y3qSHMdLk2KOLeuj2QolyOLk/lRc2hDkZmCTDme8izs=
-github.com/dapperlabs/cadence-internal v0.31.6-patch.1/go.mod h1:oRgWkvau1RH15m3NuDlZCPHFQzwvC72jEstCGu8OJ98=
+github.com/dapperlabs/cadence-internal v0.31.6-patch.2 h1:YAY1ZCcu/nBk45TW+a3YHchP1qaJAPyQqmfjPnIvGOY=
+github.com/dapperlabs/cadence-internal v0.31.6-patch.2/go.mod h1:oRgWkvau1RH15m3NuDlZCPHFQzwvC72jEstCGu8OJ98=
 github.com/dapperlabs/testingdock v0.4.4 h1:nDpnEjhs2gNv7rcb70PTfHlL3yr4eQycqp0+oFuhyNg=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -304,4 +304,4 @@ replace github.com/onflow/flow-go => ../
 
 replace github.com/onflow/flow-go/insecure => ../insecure
 
-replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.31.6-patch.1
+replace github.com/onflow/cadence => github.com/dapperlabs/cadence-internal v0.31.6-patch.2

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -289,8 +289,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
-github.com/dapperlabs/cadence-internal v0.31.6-patch.1 h1:Y3qSHMdLk2KOLeuj2QolyOLk/lRc2hDkZmCTDme8izs=
-github.com/dapperlabs/cadence-internal v0.31.6-patch.1/go.mod h1:oRgWkvau1RH15m3NuDlZCPHFQzwvC72jEstCGu8OJ98=
+github.com/dapperlabs/cadence-internal v0.31.6-patch.2 h1:YAY1ZCcu/nBk45TW+a3YHchP1qaJAPyQqmfjPnIvGOY=
+github.com/dapperlabs/cadence-internal v0.31.6-patch.2/go.mod h1:oRgWkvau1RH15m3NuDlZCPHFQzwvC72jEstCGu8OJ98=
 github.com/dapperlabs/testingdock v0.4.4 h1:nDpnEjhs2gNv7rcb70PTfHlL3yr4eQycqp0+oFuhyNg=
 github.com/dapperlabs/testingdock v0.4.4/go.mod h1:HeTbuHG1J4yt4n7NlZSyuk5c5fmyz6hECbyV+36Ku7Q=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
https://github.com/dapperlabs/cadence-internal/compare/v0.31.6-patch.1...v0.31.6-patch.2