### PR TITLE
[Access] Fix AN event decoding in GetTransactionResultsByBlockID

### DIFF
--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -426,7 +426,8 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 				return nil, rpc.ConvertStorageError(err)
 			}
 
-			events, err := convert.MessagesToEventsFromVersion(txResult.GetEvents(), txResult.GetEventEncodingVersion())
+			// note: EventEncodingVersion is set on the GetTransactionResultsResponse, not the individual tx results
+			events, err := convert.MessagesToEventsFromVersion(txResult.GetEvents(), resp.GetEventEncodingVersion())
 			if err != nil {
 				return nil, status.Errorf(codes.Internal,
 					"failed to convert events to message in txID %x: %v", txID, err)

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -447,9 +447,10 @@ func (h *handler) GetTransactionResultsByBlockID(
 		events := convert.EventsToMessages(eventsByTxIndex[txIndex])
 
 		responseTxResults[index] = &execution.GetTransactionResultResponse{
-			StatusCode:   statusCode,
-			ErrorMessage: errMsg,
-			Events:       events,
+			StatusCode:           statusCode,
+			ErrorMessage:         errMsg,
+			Events:               events,
+			EventEncodingVersion: execution.EventEncodingVersion_CCF_V0,
 		}
 	}
 


### PR DESCRIPTION
`GetTransactionResultsByBlockID` was updated to support decoding CCF encoded events from the EN. The encoding version was pulled from the wrong data structure resulting in it being interpreted as cdc-json.