### PR TITLE
[Execution] panic when on executed block error

### DIFF
--- a/module/mempool/queue/queue.go
+++ b/module/mempool/queue/queue.go
@@ -1,6 +1,9 @@
 package queue
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -165,4 +168,19 @@ func (q *Queue) Dismount() (Blockify, []*Queue) {
 		}
 	}
 	return q.Head.Item, queues
+}
+
+func (q *Queue) String() string {
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Header: %v\n", q.Head.Item.ID()))
+	builder.WriteString(fmt.Sprintf("Highest: %v\n", q.Highest.Item.ID()))
+	builder.WriteString(fmt.Sprintf("Size: %v, Height: %v\n", q.Size(), q.Height()))
+	for _, node := range q.Nodes {
+		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: %v)\n",
+			node.Item.Height(),
+			node.Item.ID(),
+			len(node.Children),
+		))
+	}
+	return builder.String()
 }

--- a/module/mempool/queue/queue_test.go
+++ b/module/mempool/queue/queue_test.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -289,4 +291,23 @@ func TestQueue(t *testing.T) {
 	//	assert.Error(t, err)
 	//})
 
+	t.Run("String()", func(t *testing.T) {
+		// a <- c <- d <- f
+		queue := NewQueue(a)
+		stored, _ := queue.TryAdd(c)
+		require.True(t, stored)
+		stored, _ = queue.TryAdd(d)
+		require.True(t, stored)
+		stored, _ = queue.TryAdd(f)
+		require.True(t, stored)
+		var builder strings.Builder
+		builder.WriteString(fmt.Sprintf("Header: %v\n", a.ID()))
+		builder.WriteString(fmt.Sprintf("Highest: %v\n", f.ID()))
+		builder.WriteString("Size: 4, Height: 3\n")
+		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 1)\n", a.Height(), a.ID()))
+		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 1)\n", c.Height(), c.ID()))
+		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 1)\n", d.Height(), d.ID()))
+		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 0)\n", f.Height(), f.ID()))
+		require.Equal(t, builder.String(), queue.String())
+	})
 }


### PR DESCRIPTION
This PR handles an unexpected case where the internal state can not find the executed block. In this case, we will crash the EN and log the entire internal state for debugging purpose.