### PR TITLE
Dependency tracking on load error

### DIFF
--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -93,7 +93,6 @@ func (programs *Programs) getOrLoadAddressProgram(
 	location common.AddressLocation,
 	load func() (*interpreter.Program, error),
 ) (*interpreter.Program, error) {
-
 	top, err := programs.dependencyStack.top()
 	if err != nil {
 		return nil, err
@@ -270,7 +269,7 @@ func (loader *programLoader) loadWithDependencyTracking(
 	error,
 ) {
 	// this program is not in cache, so we need to load it into the cache.
-	// tho have proper invalidation, we need to track the dependencies of the program.
+	// to have proper invalidation, we need to track the dependencies of the program.
 	// If this program depends on another program,
 	// that program will be loaded before this one finishes loading (calls set).
 	// That is why this is a stack.
@@ -280,7 +279,13 @@ func (loader *programLoader) loadWithDependencyTracking(
 
 	// Get collected dependencies of the loaded program.
 	// Pop the dependencies from the stack even if loading errored.
-	stackLocation, dependencies, depErr := loader.dependencyStack.pop()
+	//
+	// In case of an error, the dependencies of the errored program should not be merged
+	// into the dependencies of the parent program. This is to prevent the parent program
+	// from thinking that this program was already loaded and is in the cache,
+	// if it requests it again.
+	// stackLocation, dependencies, depErr := loader.dependencyStack.pop(err == nil)
+	stackLocation, dependencies, depErr := loader.dependencyStack.pop(true)
 	if depErr != nil {
 		err = multierror.Append(err, depErr).ErrorOrNil()
 	}
@@ -371,7 +376,9 @@ func (s *dependencyStack) add(dependencies derived.ProgramDependencies) error {
 }
 
 // pop the last dependencies on the stack and return them.
-func (s *dependencyStack) pop() (common.Location, derived.ProgramDependencies, error) {
+// if merge is false then the dependencies are not merged into the parent tracker.
+// this is used to pop the dependencies of a program that errored during loading.
+func (s *dependencyStack) pop(merge bool) (common.Location, derived.ProgramDependencies, error) {
 	if len(s.trackers) <= 1 {
 		return nil,
 			derived.NewProgramDependencies(),
@@ -384,11 +391,13 @@ func (s *dependencyStack) pop() (common.Location, derived.ProgramDependencies, e
 	tracker := s.trackers[len(s.trackers)-1]
 	s.trackers = s.trackers[:len(s.trackers)-1]
 
-	// Add the dependencies of the popped tracker to the parent tracker
-	// This is an optimisation to avoid having to iterate through the entire stack
-	// everytime a dependency is pushed or added, instead we add the popped dependencies to the new top of the stack.
-	// (because if C depends on B which depends on A, A's dependencies include C).
-	s.trackers[len(s.trackers)-1].dependencies.Merge(tracker.dependencies)
+	if merge {
+		// Add the dependencies of the popped tracker to the parent tracker
+		// This is an optimisation to avoid having to iterate through the entire stack
+		// everytime a dependency is pushed or added, instead we add the popped dependencies to the new top of the stack.
+		// (because if C depends on B which depends on A, A's dependencies include C).
+		s.trackers[len(s.trackers)-1].dependencies.Merge(tracker.dependencies)
+	}
 
 	return tracker.location, tracker.dependencies, nil
 }

--- a/fvm/environment/programs.go
+++ b/fvm/environment/programs.go
@@ -219,7 +219,7 @@ func newProgramLoader(
 }
 
 func (loader *programLoader) Compute(
-	txState state.NestedTransactionPreparer,
+	_ state.NestedTransactionPreparer,
 	location common.AddressLocation,
 ) (
 	*derived.Program,
@@ -284,8 +284,8 @@ func (loader *programLoader) loadWithDependencyTracking(
 	// into the dependencies of the parent program. This is to prevent the parent program
 	// from thinking that this program was already loaded and is in the cache,
 	// if it requests it again.
-	// stackLocation, dependencies, depErr := loader.dependencyStack.pop(err == nil)
-	stackLocation, dependencies, depErr := loader.dependencyStack.pop(true)
+	merge := err == nil
+	stackLocation, dependencies, depErr := loader.dependencyStack.pop(merge)
 	if depErr != nil {
 		err = multierror.Append(err, depErr).ErrorOrNil()
 	}

--- a/fvm/environment/programs_test.go
+++ b/fvm/environment/programs_test.go
@@ -44,6 +44,8 @@ var (
 
 	contractA0Code = `
 		pub contract A {
+			pub struct interface Foo{}
+			
 			pub fun hello(): String {
         		return "bad version"
     		}
@@ -52,6 +54,8 @@ var (
 
 	contractACode = `
 		pub contract A {
+			pub struct interface Foo{}
+
 			pub fun hello(): String {
         		return "hello from A"
     		}
@@ -60,9 +64,23 @@ var (
 
 	contractA2Code = `
 		pub contract A2 {
+			pub struct interface Foo{}
+
 			pub fun hello(): String {
         		return "hello from A2"
     		}
+		}
+	`
+
+	contractABreakingCode = `
+		pub contract A {
+			pub struct interface Foo{
+				pub fun hello()
+			}
+	
+			pub fun hello(): String {
+	  		return "hello from A with breaking change"
+			}
 		}
 	`
 
@@ -70,6 +88,8 @@ var (
 		import 0xa
 
 		pub contract B {
+			pub struct Bar : A.Foo {}
+
 			pub fun hello(): String {
        			return "hello from B but also ".concat(A.hello())
     		}
@@ -81,6 +101,8 @@ var (
 		import A from 0xa
 
 		pub contract C {
+            pub struct Bar : A.Foo {}
+
 			pub fun hello(): String {
 	   			return "hello from C, ".concat(B.hello())
 			}
@@ -370,7 +392,7 @@ func Test_Programs(t *testing.T) {
 	})
 
 	t.Run("deploying new contract A2 invalidates B because of * imports", func(t *testing.T) {
-		// deploy contract B
+		// deploy contract A2
 		executionSnapshot, output, err := vm.Run(
 			context,
 			fvm.Transaction(
@@ -738,6 +760,79 @@ func Test_ProgramsDoubleCounting(t *testing.T) {
 		// hit A2 because interpreting B because interpreting C because interpreting transaction
 		require.Equal(t, 7, metrics.CacheHits)
 		require.Equal(t, 0, metrics.CacheMisses)
+	})
+
+	t.Run("update A to breaking change and ensure cache state", func(t *testing.T) {
+		// deploy contract A
+		executionSnapshot, output, err := vm.Run(
+			context,
+			fvm.Transaction(
+				updateContractTx("A", contractABreakingCode, addressA),
+				derivedBlockData.NextTxIndexForTestingOnly()),
+			snapshotTree)
+		require.NoError(t, err)
+		require.NoError(t, output.Err)
+
+		snapshotTree = snapshotTree.Append(executionSnapshot)
+
+		entryA := derivedBlockData.GetProgramForTestingOnly(contractALocation)
+		entryB := derivedBlockData.GetProgramForTestingOnly(contractBLocation)
+		entryC := derivedBlockData.GetProgramForTestingOnly(contractCLocation)
+
+		require.Nil(t, entryA)
+		require.Nil(t, entryB)
+		require.Nil(t, entryC)
+
+		cached := derivedBlockData.CachedPrograms()
+		require.Equal(t, 1, cached)
+	})
+
+	callCAfterItsBroken := func(snapshotTree snapshot.SnapshotTree) snapshot.SnapshotTree {
+		procCallC := fvm.Transaction(
+			flow.NewTransactionBody().SetScript(
+				[]byte(
+					`
+					import A from 0xa
+					import B from 0xb
+					import C from 0xc
+					transaction {
+						prepare() {
+							log(C.hello())
+						}
+					}`,
+				)),
+			derivedBlockData.NextTxIndexForTestingOnly())
+
+		executionSnapshot, output, err := vm.Run(
+			context,
+			procCallC,
+			snapshotTree)
+		require.NoError(t, err)
+		require.Error(t, output.Err)
+
+		entryA := derivedBlockData.GetProgramForTestingOnly(contractALocation)
+		entryA2 := derivedBlockData.GetProgramForTestingOnly(contractA2Location)
+		entryB := derivedBlockData.GetProgramForTestingOnly(contractBLocation)
+		entryC := derivedBlockData.GetProgramForTestingOnly(contractCLocation)
+
+		require.NotNil(t, entryA)
+		require.NotNil(t, entryA2) // loaded due to "*" import in B
+		require.Nil(t, entryB)     // failed to load
+		require.Nil(t, entryC)     // failed to load
+
+		cached := derivedBlockData.CachedPrograms()
+		require.Equal(t, 2, cached)
+
+		return snapshotTree.Append(executionSnapshot)
+	}
+
+	t.Run("Call C when broken", func(t *testing.T) {
+		metrics.Reset()
+		snapshotTree = callCAfterItsBroken(snapshotTree)
+
+		// miss A, hit A, hit A2, hit A, hit A2, hit A
+		require.Equal(t, 5, metrics.CacheHits)
+		require.Equal(t, 1, metrics.CacheMisses)
 	})
 
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2681,7 +2681,7 @@ func TestStorageIterationWithBrokenValues(t *testing.T) {
 					[]byte(contractD),
 				))
 
-				// Store values, including `B.Bar()`
+				// Store values
 				runTransaction([]byte(fmt.Sprintf(
 					`
 					import D from %s
@@ -2699,8 +2699,8 @@ func TestStorageIterationWithBrokenValues(t *testing.T) {
 							signer.link<&String>(/private/a, target:/storage/first)
 							signer.link<&[String]>(/private/b, target:/storage/second)
 							signer.link<&D.Bar>(/private/c, target:/storage/third)
-							signer.link<&C.Bar>(/private/c, target:/storage/third)
-							signer.link<&B.Bar>(/private/c, target:/storage/third)
+							signer.link<&C.Bar>(/private/d, target:/storage/fourth)
+							signer.link<&B.Bar>(/private/e, target:/storage/fifth)
 						}
 					}`,
 					accounts[0].HexWithPrefix(),
@@ -2708,7 +2708,7 @@ func TestStorageIterationWithBrokenValues(t *testing.T) {
 					accounts[0].HexWithPrefix(),
 				)))
 
-				// Update `A`, so that `B` and `C` are now broken.
+				// Update `A`. `B`, `C` and `D` are now broken.
 				runTransaction(utils.UpdateTransaction(
 					"A",
 					[]byte(updatedContractA),
@@ -2720,21 +2720,13 @@ func TestStorageIterationWithBrokenValues(t *testing.T) {
 					transaction {
 						prepare(account: AuthAccount) {
 							var total = 0
-
-							account.forEachStored(fun (path: StoragePath, type: Type): Bool {
+							account.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
+								account.getCapability<&AnyStruct>(path).borrow()!
 								total = total + 1
                               return true
 							})
 
-							//account.forEachPrivate(fun (path: PrivatePath, type: Type): Bool {
-							//	account.getCapability<&AnyStruct>(path).borrow()!
-							//	total = total + 1
-                            //    return true
-							//})
-
-							//// 2 from each
-							//// + 1 from flow vault storage
-							//assert(total == 5, message:"found ".concat(total.toString()))
+							assert(total == 2, message:"found ".concat(total.toString()))
 						}
 					}`,
 				))


### PR DESCRIPTION
When loading a program and the loading fails. We need to pop the dependency stack, but not include the offending program as a dependency further up the stack. This is to avoid having dependencies in the stack that were never loaded into the derived cache.

Usually encountering an error when loading a program would terminate the whole tx/script, but storage iteration is an exception to that. If a program is needed to parse a value from storage during storage iteration, and that program is broken, the iteration will move to the next value in storage instead of terminating.

