### PR TITLE
Fix sealed header cache in state bootstrap - backport

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1184,7 +1184,16 @@ func (fnb *FlowNodeBuilder) initState() error {
 	}
 	fnb.NodeConfig.LastFinalizedHeader = lastFinalized
 
+	lastSealed, err := fnb.State.Sealed().Head()
+	if err != nil {
+		return fmt.Errorf("could not get last sealed block header: %w", err)
+	}
+
 	fnb.Logger.Info().
+		Hex("last_finalized_block_id", logging.Entity(lastFinalized)).
+		Uint64("last_finalized_block_height", lastFinalized.Height).
+		Hex("last_sealed_block_id", logging.Entity(lastSealed)).
+		Uint64("last_sealed_block_height", lastSealed.Height).
 		Hex("finalized_root_block_id", logging.Entity(fnb.FinalizedRootBlock)).
 		Uint64("finalized_root_block_height", fnb.FinalizedRootBlock.Header.Height).
 		Hex("sealed_root_block_id", logging.Entity(fnb.SealedRootBlock)).

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -896,13 +896,13 @@ func (state *State) populateCache() error {
 			return fmt.Errorf("could not lookup sealed height: %w", err)
 		}
 		var cachedSealedHeader cachedHeader
-		err = operation.LookupBlockHeight(finalizedHeight, &cachedSealedHeader.id)(tx)
+		err = operation.LookupBlockHeight(sealedHeight, &cachedSealedHeader.id)(tx)
 		if err != nil {
-			return fmt.Errorf("could not lookup sealed id (height=%d): %w", finalizedHeight, err)
+			return fmt.Errorf("could not lookup sealed id (height=%d): %w", sealedHeight, err)
 		}
 		cachedSealedHeader.header, err = state.headers.ByBlockID(cachedSealedHeader.id)
 		if err != nil {
-			return fmt.Errorf("could not get sealed block (id=%x): %w", cachedFinalHeader.id, err)
+			return fmt.Errorf("could not get sealed block (id=%x): %w", cachedSealedHeader.id, err)
 		}
 		state.cachedSealed.Store(&cachedSealedHeader)
 		return nil


### PR DESCRIPTION
There is a bug in the state bootstrapping from an existing protocol db where the latest finalized header is mistakenly cached as the latest sealed header. This broke execution state sync since this header is used to determine the next block to processes on startup.