### PR TITLE
[Localnet] Remove unused hotstuff-proposal-time flag from bootstrap

### DIFF
--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -363,7 +363,6 @@ func prepareCollectionService(container testnet.ContainerConfig, i int, n int) S
 
 	timeout := 1200*time.Millisecond + collectionDelay
 	service.Command = append(service.Command,
-		fmt.Sprintf("--hotstuff-proposal-time=%s", collectionDelay),
 		fmt.Sprintf("--hotstuff-min-timeout=%s", timeout),
 		fmt.Sprintf("--ingress-addr=%s:%s", container.ContainerName, testnet.GRPCPort),
 		"--insecure-access-api=false",


### PR DESCRIPTION
This flag was removed from collection node CLI flag list, so remove it from the list of flags added by the localnet bootstrap