### PR TITLE
[CI] fix verify-mocks intermittent CI failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ install-tools: crypto_setup_gopath check-go-version install-mock-generators
 	go install golang.org/x/tools/cmd/stringer@master;
 
 .PHONY: verify-mocks
-verify-mocks: generate-mocks
+verify-mocks: tidy generate-mocks
 	git diff --exit-code
 
 ############################################################################################


### PR DESCRIPTION
This PR fixes a CI issue where there were intermittent failures of `verify-mocks` Makefile target in CI that weren't reproducible locally.

The fix is to add `go mod tidy` to put `go.mod`, `go.sum` into a good state before verifying mocks. Otherwise, `verify-mocks` would often show `git diff` differences in `go.sum`.