### PR TITLE
Expose computer max concurrency parameter.

### DIFF
--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -71,6 +71,7 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 		"cache size for Cadence execution")
 	flags.BoolVar(&exeConf.computationConfig.ExtensiveTracing, "extensive-tracing", false, "adds high-overhead tracing to execution")
 	flags.BoolVar(&exeConf.computationConfig.CadenceTracing, "cadence-tracing", false, "enables cadence runtime level tracing")
+	flags.IntVar(&exeConf.computationConfig.MaxConcurrency, "computer-max-concurrency", 1, "set to greater than 1 to enable concurrent transaction execution")
 	flags.UintVar(&exeConf.chunkDataPackCacheSize, "chdp-cache", storage.DefaultCacheSize, "cache size for chunk data packs")
 	flags.Uint32Var(&exeConf.chunkDataPackRequestsCacheSize, "chdp-request-queue", mempool.DefaultChunkDataPackRequestQueueSize, "queue size for chunk data pack requests")
 	flags.DurationVar(&exeConf.requestInterval, "request-interval", 60*time.Second, "the interval between requests for the requester engine")

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -141,9 +141,8 @@ func NewBlockComputer(
 	signer module.Local,
 	executionDataProvider *provider.Provider,
 	colResCons []result.ExecutedCollectionConsumer,
+	maxConcurrency int,
 ) (BlockComputer, error) {
-	// TODO(patrick): expose this
-	maxConcurrency := 1
 	if maxConcurrency < 1 {
 		return nil, fmt.Errorf("invalid maxConcurrency: %d", maxConcurrency)
 	}

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -53,6 +53,10 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+const (
+	testMaxConcurrency = 2
+)
+
 func incStateCommitment(startState flow.StateCommitment) flow.StateCommitment {
 	endState := flow.StateCommitment(startState)
 	endState[0] += 1
@@ -166,7 +170,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		// create a block with 1 collection with 2 transactions
@@ -299,7 +304,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		// create an empty block
@@ -395,7 +401,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			comm,
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		// create an empty block
@@ -453,7 +460,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		collectionCount := 2
@@ -669,7 +677,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 				me,
 				prov,
 				nil,
-			)
+				testMaxConcurrency)
 			require.NoError(t, err)
 
 			result, err := exe.ExecuteBlock(
@@ -778,7 +786,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer.NewNoopViewCommitter(),
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		const collectionCount = 2
@@ -889,7 +898,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer.NewNoopViewCommitter(),
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		key := flow.AccountStatusRegisterID(
@@ -932,7 +942,8 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			committer,
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		collectionCount := 5
@@ -1249,7 +1260,8 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 		committer,
 		me,
 		prov,
-		nil)
+		nil,
+		testMaxConcurrency)
 	require.NoError(t, err)
 
 	// create empty block, it will have system collection attached while executing

--- a/engine/execution/computation/execution_verification_test.go
+++ b/engine/execution/computation/execution_verification_test.go
@@ -45,6 +45,12 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+const (
+	// TODO: enable parallel execution once cadence type equivalence check issue
+	// is resolved.
+	testVerifyMaxConcurrency = 1
+)
+
 var chain = flow.Emulator.Chain()
 
 // In the following tests the system transaction is expected to fail, as the epoch related things are not set up properly.
@@ -774,7 +780,8 @@ func executeBlockAndVerifyWithParameters(t *testing.T,
 		ledgerCommiter,
 		me,
 		prov,
-		nil)
+		nil,
+		testVerifyMaxConcurrency)
 	require.NoError(t, err)
 
 	executableBlock := unittest.ExecutableBlockFromTransactions(chain.ChainID(), txs)

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -64,6 +64,7 @@ type ComputationConfig struct {
 	CadenceTracing       bool
 	ExtensiveTracing     bool
 	DerivedDataCacheSize uint
+	MaxConcurrency       int
 
 	// When NewCustomVirtualMachine is nil, the manager will create a standard
 	// fvm virtual machine via fvm.NewVirtualMachine.  Otherwise, the manager
@@ -137,6 +138,7 @@ func New(
 		me,
 		executionDataProvider,
 		nil, // TODO(ramtin): update me with proper consumers
+		params.MaxConcurrency,
 	)
 
 	if err != nil {

--- a/engine/execution/computation/manager_test.go
+++ b/engine/execution/computation/manager_test.go
@@ -142,7 +142,8 @@ func TestComputeBlockWithStorage(t *testing.T) {
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil)
+		nil,
+		testMaxConcurrency)
 	require.NoError(t, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(10)
@@ -268,6 +269,7 @@ func TestExecuteScript(t *testing.T) {
 		ComputationConfig{
 			QueryConfig:          query.NewDefaultConfig(),
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 		},
 	)
 	require.NoError(t, err)
@@ -332,6 +334,7 @@ func TestExecuteScript_BalanceScriptFailsIfViewIsEmpty(t *testing.T) {
 		ComputationConfig{
 			QueryConfig:          query.NewDefaultConfig(),
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 		},
 	)
 	require.NoError(t, err)
@@ -377,6 +380,7 @@ func TestExecuteScripPanicsAreHandled(t *testing.T) {
 		ComputationConfig{
 			QueryConfig:          query.NewDefaultConfig(),
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 			NewCustomVirtualMachine: func() fvm.VM {
 				return &PanickingVM{}
 			},
@@ -430,6 +434,7 @@ func TestExecuteScript_LongScriptsAreLogged(t *testing.T) {
 				ExecutionTimeLimit: query.DefaultExecutionTimeLimit,
 			},
 			DerivedDataCacheSize: 10,
+			MaxConcurrency:       1,
 			NewCustomVirtualMachine: func() fvm.VM {
 				return &LongRunningVM{duration: 2 * time.Millisecond}
 			},
@@ -483,6 +488,7 @@ func TestExecuteScript_ShortScriptsAreNotLogged(t *testing.T) {
 				ExecutionTimeLimit: query.DefaultExecutionTimeLimit,
 			},
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 			NewCustomVirtualMachine: func() fvm.VM {
 				return &LongRunningVM{duration: 0}
 			},
@@ -650,6 +656,7 @@ func TestExecuteScriptTimeout(t *testing.T) {
 				ExecutionTimeLimit: timeout,
 			},
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 		},
 	)
 
@@ -696,6 +703,7 @@ func TestExecuteScriptCancelled(t *testing.T) {
 				ExecutionTimeLimit: timeout,
 			},
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 		},
 	)
 
@@ -827,7 +835,7 @@ func Test_EventEncodingFailsOnlyTxAndCarriesOn(t *testing.T) {
 		me,
 		prov,
 		nil,
-	)
+		testMaxConcurrency)
 	require.NoError(t, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(10)
@@ -905,6 +913,7 @@ func TestScriptStorageMutationsDiscarded(t *testing.T) {
 				ExecutionTimeLimit: timeout,
 			},
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 		},
 	)
 	vm := manager.vm

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -35,6 +35,10 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+const (
+	testMaxConcurrency = 2
+)
+
 func TestPrograms_TestContractUpdates(t *testing.T) {
 	chain := flow.Mainnet.Chain()
 	vm := fvm.NewVirtualMachine()
@@ -133,7 +137,8 @@ func TestPrograms_TestContractUpdates(t *testing.T) {
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil)
+		nil,
+		testMaxConcurrency)
 	require.NoError(t, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(10)
@@ -243,7 +248,8 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 		committer.NewNoopViewCommitter(),
 		me,
 		prov,
-		nil)
+		nil,
+		testMaxConcurrency)
 	require.NoError(t, err)
 
 	derivedChainData, err := derived.NewDerivedChainData(10)

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -141,8 +141,6 @@ func RegisterEntriesToKeysValues(
 	return keys, values
 }
 
-// TODO(patrick): revisit caching.  readCache needs to be mutex guarded for
-// parallel execution.
 type LedgerStorageSnapshot struct {
 	ledger     ledger.Ledger
 	commitment flow.StateCommitment

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -672,6 +672,7 @@ func ExecutionNode(t *testing.T, hub *stub.Hub, identity *flow.Identity, identit
 		computation.ComputationConfig{
 			QueryConfig:          query.NewDefaultConfig(),
 			DerivedDataCacheSize: derived.DefaultDerivedDataCacheSize,
+			MaxConcurrency:       1,
 		},
 	)
 	require.NoError(t, err)

--- a/engine/verification/utils/unittest/fixture.go
+++ b/engine/verification/utils/unittest/fixture.go
@@ -39,6 +39,12 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+const (
+	// TODO: enable parallel execution once cadence type equivalence check issue
+	// is resolved.
+	testMaxConcurrency = 1
+)
+
 // ExecutionReceiptData is a test helper struct that represents all data required
 // to verify the result of an execution receipt.
 type ExecutionReceiptData struct {
@@ -288,7 +294,8 @@ func ExecutionResultFixture(t *testing.T, chunkCount int, chain flow.Chain, refB
 			committer,
 			me,
 			prov,
-			nil)
+			nil,
+			testMaxConcurrency)
 		require.NoError(t, err)
 
 		completeColls := make(map[flow.Identifier]*entity.CompleteCollection)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -224,7 +224,8 @@ func NewBasicBlockExecutor(tb testing.TB, chain flow.Chain, logger zerolog.Logge
 		ledgerCommitter,
 		me,
 		prov,
-		nil)
+		nil,
+		1) // We're interested in fvm's serial execution time
 	require.NoError(tb, err)
 
 	activeSnapshot := snapshot.NewSnapshotTree(

--- a/fvm/storage/transaction.go
+++ b/fvm/storage/transaction.go
@@ -31,9 +31,3 @@ type Transaction interface {
 	// transaction is not committed.
 	Commit() (*snapshot.ExecutionSnapshot, error)
 }
-
-// TODO(patrick): implement proper transaction.
-type SerialTransaction struct {
-	state.NestedTransactionPreparer
-	*derived.DerivedTransactionData
-}


### PR DESCRIPTION
WARNING: it is currently unsafe to enable concurrent execution because it exposes a cadence type equivalence check issue, which in turn causes non-deterministic execution.

Unsurprisingly, enabling concurrent execution today will slightly slow down block execution since transaction conflict rate is currently 100%.  Transactions access pattern will need to be restructure in order to take advantage of concurrent execution, but it is reassuring from a correctness standpoint to see that conflicting transactions are correctly detected / retried.  (For performance expectations, see "Concurrency Control Performance Modeling: Alternatives and Implications", 1987).

Issue: #3547