### PR TITLE
[Optimization] Turn on compression for badger db for all nodes

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -870,7 +870,6 @@ func (fnb *FlowNodeBuilder) initDB() error {
 		DefaultOptions(fnb.BaseConfig.datadir).
 		WithKeepL0InMemory(true).
 		WithCompression(options.Snappy). // turn on snappy compression
-		// WithCompression(options.ZSTD). // TODO: to benchmark with Snappy, and pick a better one
 		WithLogger(log).
 
 		// the ValueLogFileSize option specifies how big the value of a

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -12,6 +12,7 @@ import (
 
 	gcemd "cloud.google.com/go/compute/metadata"
 	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger/v2/options"
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
@@ -868,6 +869,8 @@ func (fnb *FlowNodeBuilder) initDB() error {
 	opts := badger.
 		DefaultOptions(fnb.BaseConfig.datadir).
 		WithKeepL0InMemory(true).
+		WithCompression(options.Snappy). // turn on snappy compression
+		// WithCompression(options.ZSTD). // TODO: to benchmark with Snappy, and pick a better one
 		WithLogger(log).
 
 		// the ValueLogFileSize option specifies how big the value of a

--- a/cmd/util/cmd/common/storage.go
+++ b/cmd/util/cmd/common/storage.go
@@ -15,11 +15,7 @@ func InitStorage(datadir string) *badger.DB {
 }
 
 func InitStorageWithTruncate(datadir string, truncate bool) *badger.DB {
-	opts := badger.
-		DefaultOptions(datadir).
-		WithKeepL0InMemory(true).
-		WithLogger(nil).
-		WithTruncate(truncate)
+	opts := storagebadger.BadgerOptions(datadir, nil)
 
 	db, err := badger.Open(opts)
 	if err != nil {

--- a/storage/badger/index_test.go
+++ b/storage/badger/index_test.go
@@ -103,3 +103,42 @@ func TestIndexStoreRetrieveCompaction(t *testing.T) {
 	require.Equal(t, expected2, actual2)
 	require.NoError(t, cdb.Close())
 }
+
+// Benchmark that we can store and retrieve indexes from a database
+func BenchmarkIndexStore(b *testing.B) {
+	unittest.RunWithBadgerDB(b, func(db *badger.DB) {
+		metrics := metrics.NewNoopCollector()
+		store := badgerstorage.NewIndex(metrics, db)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			blockID := unittest.IdentifierFixture()
+			index := unittest.IndexFixture()
+
+			err := store.Store(blockID, index)
+			require.NoError(b, err)
+		}
+	})
+}
+
+// BenchmarkIndexRetrieve benchmarks the retrieval of indexes from the database.
+func BenchmarkIndexRetrieve(b *testing.B) {
+	unittest.RunWithBadgerDB(b, func(db *badger.DB) {
+		metrics := metrics.NewNoopCollector()
+		store := badgerstorage.NewIndex(metrics, db)
+
+		blockID := unittest.IdentifierFixture()
+		index := unittest.IndexFixture()
+
+		err := store.Store(blockID, index)
+		require.NoError(b, err)
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := store.ByBlockID(blockID)
+			require.NoError(b, err)
+		}
+	})
+}

--- a/storage/badger/index_test.go
+++ b/storage/badger/index_test.go
@@ -46,11 +46,11 @@ func TestIndexStoreRetrieveCompaction(t *testing.T) {
 		require.NoError(t, os.RemoveAll(dbDir))
 	}()
 
-	opts := badger.
-		DefaultOptions(dbDir).
-		WithKeepL0InMemory(true).
-		WithLogger(nil)
-	db, err := badger.Open(opts)
+	// create database without compression
+	compressed := badgerstorage.BadgerOptions(dbDir, nil)
+
+	nocompression := compressed.WithCompression(options.None)
+	db, err := badger.Open(nocompression)
 	require.NoError(t, err)
 
 	metrics := metrics.NewNoopCollector()
@@ -74,11 +74,6 @@ func TestIndexStoreRetrieveCompaction(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	// reopen the database with compression
-	compressed := badger.
-		DefaultOptions(dbDir).
-		WithCompression(options.Snappy).
-		WithKeepL0InMemory(true).
-		WithLogger(nil)
 	cdb, err := badger.Open(compressed)
 	require.NoError(t, err)
 

--- a/storage/badger/index_test.go
+++ b/storage/badger/index_test.go
@@ -2,9 +2,11 @@ package badger_test
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger/v2/options"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"
@@ -35,4 +37,69 @@ func TestIndexStoreRetrieve(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, actual)
 	})
+}
+
+// Test that we can store and retrieve indexes from a compressed database
+func TestIndexStoreRetrieveCompaction(t *testing.T) {
+	dbDir := unittest.TempDir(t)
+	defer func() {
+		require.NoError(t, os.RemoveAll(dbDir))
+	}()
+
+	opts := badger.
+		DefaultOptions(dbDir).
+		WithKeepL0InMemory(true).
+		WithLogger(nil)
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+
+	metrics := metrics.NewNoopCollector()
+	store := badgerstorage.NewIndex(metrics, db)
+
+	blockID := unittest.IdentifierFixture()
+	expected := unittest.IndexFixture()
+
+	// retreive without store
+	_, err = store.ByBlockID(blockID)
+	require.True(t, errors.Is(err, storage.ErrNotFound))
+
+	// store index
+	err = store.Store(blockID, expected)
+	require.NoError(t, err)
+
+	// retreive index
+	actual, err := store.ByBlockID(blockID)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+	require.NoError(t, db.Close())
+
+	// reopen the database with compression
+	compressed := badger.
+		DefaultOptions(dbDir).
+		WithCompression(options.Snappy).
+		WithKeepL0InMemory(true).
+		WithLogger(nil)
+	cdb, err := badger.Open(compressed)
+	require.NoError(t, err)
+
+	cstore := badgerstorage.NewIndex(metrics, cdb)
+
+	// retreive index using the compressed database, and
+	// ensure that it is able to read the data saved by un-compressed database
+	actual, err = cstore.ByBlockID(blockID)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+
+	// store a different index using the compressed database,
+	// ensure that the compressed index can be retrieved.
+	blockID2 := unittest.IdentifierFixture()
+	expected2 := unittest.IndexFixture()
+
+	err = cstore.Store(blockID2, expected2)
+	require.NoError(t, err)
+
+	actual2, err := cstore.ByBlockID(blockID2)
+	require.NoError(t, err)
+	require.Equal(t, expected2, actual2)
+	require.NoError(t, cdb.Close())
 }

--- a/storage/badger/options.go
+++ b/storage/badger/options.go
@@ -1,0 +1,24 @@
+package badger
+
+import (
+	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger/v2/options"
+)
+
+func BadgerOptions(dir string, log badger.Logger) badger.Options {
+	opts := badger.
+		DefaultOptions(dir).
+		WithKeepL0InMemory(true).
+		WithLogger(log).
+		WithCompression(options.Snappy).
+		// the ValueLogFileSize option specifies how big the value of a
+		// key-value pair is allowed to be saved into badger.
+		// exceeding this limit, will fail with an error like this:
+		// could not store data: Value with size <xxxx> exceeded 1073741824 limit
+		// Maximum value size is 10G, needed by execution node
+		// TODO: finding a better max value for each node type
+		WithValueLogFileSize(128 << 23).
+		WithValueLogMaxEntries(100_000) // Default is 1_000_000
+
+	return opts
+}

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -318,6 +318,7 @@ func RunWithTempDir(t testing.TB, f func(string)) {
 }
 
 func badgerDB(t testing.TB, dir string, create func(badger.Options) (*badger.DB, error)) *badger.DB {
+	// copied from storage/badger/options#BadgerOptions in order to avoid circular dependency
 	opts := badger.
 		DefaultOptions(dir).
 		WithKeepL0InMemory(true).

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger/v2/options"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -320,7 +321,10 @@ func badgerDB(t testing.TB, dir string, create func(badger.Options) (*badger.DB,
 	opts := badger.
 		DefaultOptions(dir).
 		WithKeepL0InMemory(true).
-		WithLogger(nil)
+		WithLogger(nil).
+		WithCompression(options.Snappy).
+		WithValueLogFileSize(128 << 23).
+		WithValueLogMaxEntries(100_000) // Default is 1_000_000
 	db, err := create(opts)
 	require.NoError(t, err)
 	return db


### PR DESCRIPTION
The default option for compression badgerDB is [Compression.None](https://github.com/dgraph-io/badger/blob/156819ccb106bbeb207e985f561780e2929344bc/options.go#L137), which means there is no compression. 

This PR turn on Snappy compression for data stored in badgerDB. 

Tests were added to verify the previous stored uncompressed data can still be retrieved, when badger is opened with the snappy compression option.
