### PR TITLE
[Testing][CI] Unquarantine test - TestCrosstalkPreventionOnNetworkKeyChange

### DIFF
--- a/network/p2p/test/sporking_test.go
+++ b/network/p2p/test/sporking_test.go
@@ -41,7 +41,6 @@ import (
 // TestCrosstalkPreventionOnNetworkKeyChange tests that a node from the old chain cannot talk to a node in the new chain
 // if it's network key is updated while the libp2p protocol ID remains the same
 func TestCrosstalkPreventionOnNetworkKeyChange(t *testing.T) {
-	unittest.SkipUnless(t, unittest.TEST_FLAKY, "flaky test - passing in Flaky Test Monitor but keeps failing in CI and keeps blocking many PRs")
 	idProvider := mockmodule.NewIdentityProvider(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
This test has been consistently passing in [quarantine](https://dapperlabs.grafana.net/d/toErpbynz/single-test-metrics?orgId=1&var-package=github.com%2Fonflow%2Fflow-go%2Fnetwork%2Fp2p%2Ftest&var-dataset_name=dapperlabs-data.production_src_flow_test_metrics&var-skipped_tests_table=skipped_tests&var-test_results_table=test_results&var-query_limit=100000&var-test=TestCrosstalkPreventionOnNetworkKeyChange&from=now-6M&to=now) for the past 6 months and can be unquarantined.

<img width="1490" alt="image" src="https://github.com/onflow/flow-go/assets/15269764/1eecd5df-c53d-4db9-8d06-61fc42b1925e">
