### PR TITLE
fixed missing subscription of telemetry consumer to necessary events

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -602,9 +602,10 @@ func main() {
 				logger,
 				mainMetrics,
 			)
-
-			notifier.AddParticipantConsumer(telemetryConsumer)
 			notifier.AddFollowerConsumer(followerDistributor)
+			notifier.AddFinalizationConsumer(telemetryConsumer)
+			notifier.AddCommunicatorConsumer(telemetryConsumer)
+			notifier.AddParticipantConsumer(telemetryConsumer)
 
 			// initialize the persister
 			persist := persister.New(node.DB, node.RootChainID)

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -38,9 +38,13 @@ type TelemetryConsumer struct {
 	noPathLogger zerolog.Logger
 }
 
-var _ hotstuff.ParticipantConsumer = (*TelemetryConsumer)(nil)
+var _ hotstuff.VoteCollectorConsumer = (*TelemetryConsumer)(nil)
 var _ hotstuff.VoteCollectorConsumer = (*TelemetryConsumer)(nil)
 var _ hotstuff.TimeoutCollectorConsumer = (*TelemetryConsumer)(nil)
+
+var _ hotstuff.FinalizationConsumer = (*TelemetryConsumer)(nil)
+var _ hotstuff.CommunicatorConsumer = (*TelemetryConsumer)(nil)
+var _ hotstuff.ParticipantConsumer = (*TelemetryConsumer)(nil)
 
 // NewTelemetryConsumer creates consumer that reports telemetry events using logger backend.
 // Logger MUST include `chain` parameter as part of log context with corresponding chain ID to correctly map telemetry events to chain.


### PR DESCRIPTION
Metrika reported that they are missing the following events:
* `OnFinalizedBlock`
* ~OnProposingBlock~
* `OnOwnProposal`
* ~OnVoting~
* `OnOwnVote`
* ~block vote received, forwarding block vote to hotstuff vote aggregator~
* ~BlockVoteReceived~

I tracked this problem back to the `TelemetryConsumer` not being subscribed to the respective events. 

Back-ported to `v0.31` branch: https://github.com/onflow/flow-go/pull/4519