### PR TITLE
Back-porting PR4530:  Fixes the bug with chunk data pack max message size

### DIFF
--- a/network/p2p/middleware/middleware.go
+++ b/network/p2p/middleware/middleware.go
@@ -657,7 +657,7 @@ func (m *Middleware) processUnicastStreamMessage(remotePeer peer.ID, msg *messag
 
 	// TODO: once we've implemented per topic message size limits per the TODO above,
 	// we can remove this check
-	maxSize, err := unicastMaxMsgSizeByCode(msg.Payload)
+	maxSize, err := UnicastMaxMsgSizeByCode(msg.Payload)
 	if err != nil {
 		m.slashingViolationsConsumer.OnUnknownMsgTypeError(&slashing.Violation{
 			Identity: nil, PeerID: remotePeer.String(), MsgType: "", Channel: channel, Protocol: message.ProtocolTypeUnicast, Err: err,
@@ -832,15 +832,15 @@ func (m *Middleware) IsConnected(nodeID flow.Identifier) (bool, error) {
 // unicastMaxMsgSize returns the max permissible size for a unicast message
 func unicastMaxMsgSize(messageType string) int {
 	switch messageType {
-	case "messages.ChunkDataResponse":
+	case "*messages.ChunkDataResponse":
 		return LargeMsgMaxUnicastMsgSize
 	default:
 		return DefaultMaxUnicastMsgSize
 	}
 }
 
-// unicastMaxMsgSizeByCode returns the max permissible size for a unicast message code
-func unicastMaxMsgSizeByCode(payload []byte) (int, error) {
+// UnicastMaxMsgSizeByCode returns the max permissible size for a unicast message code
+func UnicastMaxMsgSizeByCode(payload []byte) (int, error) {
 	msgCode, err := codec.MessageCodeFromPayload(payload)
 	if err != nil {
 		return 0, err

--- a/network/p2p/middleware/middleware_test.go
+++ b/network/p2p/middleware/middleware_test.go
@@ -1,0 +1,36 @@
+package middleware_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/messages"
+	"github.com/onflow/flow-go/network"
+	"github.com/onflow/flow-go/network/channels"
+	"github.com/onflow/flow-go/network/message"
+	"github.com/onflow/flow-go/network/p2p/middleware"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestChunkDataPackMaxMessageSize tests that the max message size for a chunk data pack response is set to the large message size.
+func TestChunkDataPackMaxMessageSize(t *testing.T) {
+	// creates an outgoing chunk data pack response message (imitating an EN is sending a chunk data pack response to VN).
+	msg, err := network.NewOutgoingScope(
+		flow.IdentifierList{unittest.IdentifierFixture()},
+		channels.ProvideChunks,
+		&messages.ChunkDataResponse{
+			ChunkDataPack: *unittest.ChunkDataPackFixture(unittest.IdentifierFixture()),
+			Nonce:         rand.Uint64(),
+		},
+		unittest.NetworkCodec().Encode,
+		message.ProtocolTypeUnicast)
+	require.NoError(t, err)
+
+	// get the max message size for the message
+	size, err := middleware.UnicastMaxMsgSizeByCode(msg.Proto().Payload)
+	require.NoError(t, err)
+	require.Equal(t, middleware.LargeMsgMaxUnicastMsgSize, size)
+}


### PR DESCRIPTION
https://github.com/onflow/flow-go/pull/4530