### PR TITLE
[Access] Fix CCF decoding in GetTransactionResultsByBlockID

### DIFF
--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -426,7 +426,7 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 				return nil, rpc.ConvertStorageError(err)
 			}
 
-			events, err := convert.MessagesToEventsFromVersion(txResult.GetEvents(), txResult.GetEventEncodingVersion())
+			events, err := convert.MessagesToEventsFromVersion(txResult.GetEvents(), resp.GetEventEncodingVersion())
 			if err != nil {
 				return nil, status.Errorf(codes.Internal,
 					"failed to convert events to message in txID %x: %v", txID, err)
@@ -481,7 +481,7 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 			return nil, rpc.ConvertStorageError(err)
 		}
 
-		events, err := convert.MessagesToEventsFromVersion(systemTxResult.GetEvents(), systemTxResult.GetEventEncodingVersion())
+		events, err := convert.MessagesToEventsFromVersion(systemTxResult.GetEvents(), resp.GetEventEncodingVersion())
 		if err != nil {
 			return nil, rpc.ConvertError(err, "failed to convert events from system tx result", codes.Internal)
 		}


### PR DESCRIPTION
These were fixed in v0.31 here:
https://github.com/onflow/flow-go/pull/4462
https://github.com/onflow/flow-go/pull/4465

# Context
Execution nodes now use CCF encoding for events returned from their grpc API. They include a new version parameter to specify which encoding was used for the returned events. For `GetTransactionResultsByBlockID`, the encoding is returned in the top level `GetTransactionResultsResponse` message, not in each of the included `GetTransactionResultResponse` messages.

There was a bug on the Access node where it attempted to get the encoding from each `GetTransactionResultResponse`. When not specified, the default value is json-cdc, so the payload was not converted.

Note: not including the change to write the encoding version for every results on the EN side. That's unnecessary