### PR TITLE
Fix Version Beacon event conversion

### DIFF
--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -1183,22 +1183,14 @@ func convertSemverVersion(structVal cadence.Struct) (
 		return "", err
 	}
 
-	version := fmt.Sprintf(
-		"%d.%d.%d%s",
-		major,
-		minor,
-		patch,
-		preRelease,
-	)
-	_, err = semver.NewVersion(version)
-	if err != nil {
-		return "", fmt.Errorf(
-			"invalid semver %s: %w",
-			version,
-			err,
-		)
+	version := semver.Version{
+		Major:      int64(major),
+		Minor:      int64(minor),
+		Patch:      int64(patch),
+		PreRelease: semver.PreRelease(preRelease),
 	}
-	return version, nil
+
+	return version.String(), nil
 
 }
 

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -165,7 +165,7 @@ func VersionBeaconFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.Versio
 		VersionBoundaries: []flow.VersionBoundary{
 			{
 				BlockHeight: 44,
-				Version:     "2.13.7",
+				Version:     "2.13.7-test",
 			},
 		},
 		Sequence: 5,
@@ -671,7 +671,7 @@ func createVersionBeaconEvent() cadence.Event {
 		cadence.UInt8(7),
 
 		// preRelease
-		cadence.NewOptional(cadence.String("")),
+		cadence.NewOptional(cadence.String("test")),
 	}).WithType(semverType)
 
 	versionBoundary := cadence.NewStruct([]cadence.Value{


### PR DESCRIPTION
"%d.%d.%d%s" should have been "%d.%d.%d-%s". but to make it cleaner I used the semver.VersionObject