### PR TITLE
Fix missing events in block data uploaded to GCP

### DIFF
--- a/engine/execution/ingestion/uploader/model.go
+++ b/engine/execution/ingestion/uploader/model.go
@@ -29,9 +29,10 @@ func ComputationResultToBlockData(computationResult *execution.ComputationResult
 		txResults[i] = &AllResults[i]
 	}
 
-	events := make([]*flow.Event, 0)
-	for _, e := range computationResult.AllEvents() {
-		events = append(events, &e)
+	eventsList := computationResult.AllEvents()
+	events := make([]*flow.Event, len(eventsList))
+	for i := 0; i < len(eventsList); i++ {
+		events[i] = &eventsList[i]
 	}
 
 	trieUpdates := make(


### PR DESCRIPTION
Closes https://github.com/onflow/flow-go/issues/4558

Previously, only last event is included in uploaded block data (repeated n times).

This PR fixes the bug and includes all events.