### PR TITLE
[Access] Fix issues with REST Metrics - v0.31 backport

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -972,7 +972,11 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			return nil
 		}).
 		Module("rest metrics", func(node *cmd.NodeConfig) error {
-			builder.RESTMetrics = metrics.NewRestCollector(rest.URLToRoute, node.MetricsRegisterer)
+			m, err := metrics.NewRestCollector(rest.URLToRoute, node.MetricsRegisterer)
+			if err != nil {
+				return err
+			}
+			builder.RESTMetrics = m
 			return nil
 		}).
 		Module("access metrics", func(node *cmd.NodeConfig) error {

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -37,6 +37,7 @@ import (
 	"github.com/onflow/flow-go/crypto"
 	"github.com/onflow/flow-go/engine/access/ingestion"
 	pingeng "github.com/onflow/flow-go/engine/access/ping"
+	"github.com/onflow/flow-go/engine/access/rest"
 	"github.com/onflow/flow-go/engine/access/rpc"
 	"github.com/onflow/flow-go/engine/access/rpc/backend"
 	"github.com/onflow/flow-go/engine/access/state_stream"
@@ -218,6 +219,7 @@ type FlowAccessNodeBuilder struct {
 	CollectionsToMarkExecuted  *stdmap.Times
 	BlocksToMarkExecuted       *stdmap.Times
 	TransactionMetrics         *metrics.TransactionCollector
+	RESTMetrics                *metrics.RestCollector
 	AccessMetrics              module.AccessMetrics
 	PingMetrics                module.PingMetrics
 	Committee                  hotstuff.DynamicCommittee
@@ -969,10 +971,15 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			)
 			return nil
 		}).
+		Module("rest metrics", func(node *cmd.NodeConfig) error {
+			builder.RESTMetrics = metrics.NewRestCollector(rest.URLToRoute, node.MetricsRegisterer)
+			return nil
+		}).
 		Module("access metrics", func(node *cmd.NodeConfig) error {
 			builder.AccessMetrics = metrics.NewAccessCollector(
 				metrics.WithTransactionMetrics(builder.TransactionMetrics),
 				metrics.WithBackendScriptsMetrics(builder.TransactionMetrics),
+				metrics.WithRestMetrics(builder.RESTMetrics),
 			)
 			return nil
 		}).

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -219,7 +219,7 @@ type FlowAccessNodeBuilder struct {
 	CollectionsToMarkExecuted  *stdmap.Times
 	BlocksToMarkExecuted       *stdmap.Times
 	TransactionMetrics         *metrics.TransactionCollector
-	RESTMetrics                *metrics.RestCollector
+	RestMetrics                *metrics.RestCollector
 	AccessMetrics              module.AccessMetrics
 	PingMetrics                module.PingMetrics
 	Committee                  hotstuff.DynamicCommittee
@@ -976,14 +976,14 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			if err != nil {
 				return err
 			}
-			builder.RESTMetrics = m
+			builder.RestMetrics = m
 			return nil
 		}).
 		Module("access metrics", func(node *cmd.NodeConfig) error {
 			builder.AccessMetrics = metrics.NewAccessCollector(
 				metrics.WithTransactionMetrics(builder.TransactionMetrics),
 				metrics.WithBackendScriptsMetrics(builder.TransactionMetrics),
-				metrics.WithRestMetrics(builder.RESTMetrics),
+				metrics.WithRestMetrics(builder.RestMetrics),
 			)
 			return nil
 		}).

--- a/engine/access/rest/middleware/metrics.go
+++ b/engine/access/rest/middleware/metrics.go
@@ -11,19 +11,12 @@ import (
 	"github.com/onflow/flow-go/module"
 )
 
-func MetricsMiddleware(restCollector module.RestMetrics, urlToRoute func(string) (string, error)) mux.MiddlewareFunc {
+func MetricsMiddleware(restCollector module.RestMetrics) mux.MiddlewareFunc {
 	metricsMiddleware := middleware.New(middleware.Config{Recorder: restCollector})
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			//urlToRoute transforms specific URL to generic url pattern
-			routeName, err := urlToRoute(req.URL.Path)
-			if err != nil {
-				// In case of an error, an empty route name filled with "unknown"
-				routeName = "unknown"
-			}
-
 			// This is a custom metric being called on every http request
-			restCollector.AddTotalRequests(req.Context(), req.Method, routeName)
+			restCollector.AddTotalRequests(req.Context(), req.Method, req.URL.Path)
 
 			// Modify the writer
 			respWriter := &responseWriter{w, http.StatusOK}

--- a/engine/access/rest/middleware/metrics.go
+++ b/engine/access/rest/middleware/metrics.go
@@ -11,12 +11,19 @@ import (
 	"github.com/onflow/flow-go/module"
 )
 
-func MetricsMiddleware(restCollector module.RestMetrics) mux.MiddlewareFunc {
+func MetricsMiddleware(restCollector module.RestMetrics, urlToRoute func(string) (string, error)) mux.MiddlewareFunc {
 	metricsMiddleware := middleware.New(middleware.Config{Recorder: restCollector})
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			//urlToRoute transforms specific URL to generic url pattern
+			routeName, err := urlToRoute(req.URL.Path)
+			if err != nil {
+				// In case of an error, an empty route name filled with "unknown"
+				routeName = "unknown"
+			}
+
 			// This is a custom metric being called on every http request
-			restCollector.AddTotalRequests(req.Context(), req.Method, req.URL.Path)
+			restCollector.AddTotalRequests(req.Context(), req.Method, routeName)
 
 			// Modify the writer
 			respWriter := &responseWriter{w, http.StatusOK}

--- a/engine/access/rest/router.go
+++ b/engine/access/rest/router.go
@@ -1,7 +1,10 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
@@ -21,8 +24,7 @@ func newRouter(backend access.API, logger zerolog.Logger, chain flow.Chain, rest
 	v1SubRouter.Use(middleware.LoggingMiddleware(logger))
 	v1SubRouter.Use(middleware.QueryExpandable())
 	v1SubRouter.Use(middleware.QuerySelect())
-	// collecting too much metrics
-	// v1SubRouter.Use(middleware.MetricsMiddleware(restCollector))
+	v1SubRouter.Use(middleware.MetricsMiddleware(restCollector, URLToRoute))
 
 	linkGenerator := models.NewLinkGeneratorImpl(v1SubRouter)
 
@@ -115,3 +117,59 @@ var Routes = []route{{
 	Name:    "getNodeVersionInfo",
 	Handler: GetNodeVersionInfo,
 }}
+
+var routeUrlMap = map[string]string{}
+var routeRE = regexp.MustCompile(`(?i)/v1/(\w+)(/(\w+)(/(\w+))?)?`)
+
+func init() {
+	for _, r := range Routes {
+		routeUrlMap[r.Pattern] = r.Name
+	}
+}
+
+func URLToRoute(url string) (string, error) {
+	normalized, err := normalizeURL(url)
+	if err != nil {
+		return "", err
+	}
+
+	name, ok := routeUrlMap[normalized]
+	if !ok {
+		return "", fmt.Errorf("invalid url")
+	}
+	return name, nil
+}
+
+func normalizeURL(url string) (string, error) {
+	matches := routeRE.FindAllStringSubmatch(url, -1)
+	if len(matches) != 1 || len(matches[0]) != 6 {
+		return "", fmt.Errorf("invalid url")
+	}
+
+	// given a URL like
+	//      /v1/blocks/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef/payload
+	// groups  [  1  ] [                                3                             ] [  5  ]
+	// normalized form like /v1/blocks/{id}/payload
+
+	parts := []string{matches[0][1]}
+
+	switch len(matches[0][3]) {
+	case 0:
+		// top level resource. e.g. /v1/blocks
+	case 64:
+		// id based resource. e.g. /v1/blocks/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+		parts = append(parts, "{id}")
+	case 16:
+		// address based resource. e.g. /v1/accounts/1234567890abcdef
+		parts = append(parts, "{address}")
+	default:
+		// named resource. e.g. /v1/network/parameters
+		parts = append(parts, matches[0][3])
+	}
+
+	if matches[0][5] != "" {
+		parts = append(parts, matches[0][5])
+	}
+
+	return "/" + strings.Join(parts, "/"), nil
+}

--- a/engine/access/rest/router.go
+++ b/engine/access/rest/router.go
@@ -24,7 +24,7 @@ func newRouter(backend access.API, logger zerolog.Logger, chain flow.Chain, rest
 	v1SubRouter.Use(middleware.LoggingMiddleware(logger))
 	v1SubRouter.Use(middleware.QueryExpandable())
 	v1SubRouter.Use(middleware.QuerySelect())
-	v1SubRouter.Use(middleware.MetricsMiddleware(restCollector, URLToRoute))
+	v1SubRouter.Use(middleware.MetricsMiddleware(restCollector))
 
 	linkGenerator := models.NewLinkGeneratorImpl(v1SubRouter)
 

--- a/engine/access/rest/router_test.go
+++ b/engine/access/rest/router_test.go
@@ -1,0 +1,185 @@
+package rest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "/v1/transactions",
+			url:      "/v1/transactions",
+			expected: "createTransaction",
+		},
+		{
+			name:     "/v1/transactions/{id}",
+			url:      "/v1/transactions/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getTransactionByID",
+		},
+		{
+			name:     "/v1/transaction_results/{id}",
+			url:      "/v1/transaction_results/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getTransactionResultByID",
+		},
+		{
+			name:     "/v1/blocks",
+			url:      "/v1/blocks",
+			expected: "getBlocksByHeight",
+		},
+		{
+			name:     "/v1/blocks/{id}",
+			url:      "/v1/blocks/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getBlocksByIDs",
+		},
+		{
+			name:     "/v1/blocks/{id}/payload",
+			url:      "/v1/blocks/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76/payload",
+			expected: "getBlockPayloadByID",
+		},
+		{
+			name:     "/v1/execution_results/{id}",
+			url:      "/v1/execution_results/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getExecutionResultByID",
+		},
+		{
+			name:     "/v1/execution_results",
+			url:      "/v1/execution_results",
+			expected: "getExecutionResultByBlockID",
+		},
+		{
+			name:     "/v1/collections/{id}",
+			url:      "/v1/collections/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getCollectionByID",
+		},
+		{
+			name:     "/v1/scripts",
+			url:      "/v1/scripts",
+			expected: "executeScript",
+		},
+		{
+			name:     "/v1/accounts/{address}",
+			url:      "/v1/accounts/6a587be304c1224c",
+			expected: "getAccount",
+		},
+		{
+			name:     "/v1/events",
+			url:      "/v1/events",
+			expected: "getEvents",
+		},
+		{
+			name:     "/v1/network/parameters",
+			url:      "/v1/network/parameters",
+			expected: "getNetworkParameters",
+		},
+		{
+			name:     "/v1/node_version_info",
+			url:      "/v1/node_version_info",
+			expected: "getNodeVersionInfo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := URLToRoute(tt.url)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBenchmarkParseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "/v1/transactions",
+			url:      "/v1/transactions",
+			expected: "createTransaction",
+		},
+		{
+			name:     "/v1/transactions/{id}",
+			url:      "/v1/transactions/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getTransactionByID",
+		},
+		{
+			name:     "/v1/transaction_results/{id}",
+			url:      "/v1/transaction_results/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getTransactionResultByID",
+		},
+		{
+			name:     "/v1/blocks",
+			url:      "/v1/blocks",
+			expected: "getBlocksByHeight",
+		},
+		{
+			name:     "/v1/blocks/{id}",
+			url:      "/v1/blocks/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getBlocksByIDs",
+		},
+		{
+			name:     "/v1/blocks/{id}/payload",
+			url:      "/v1/blocks/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76/payload",
+			expected: "getBlockPayloadByID",
+		},
+		{
+			name:     "/v1/execution_results/{id}",
+			url:      "/v1/execution_results/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getExecutionResultByID",
+		},
+		{
+			name:     "/v1/execution_results",
+			url:      "/v1/execution_results",
+			expected: "getExecutionResultByBlockID",
+		},
+		{
+			name:     "/v1/collections/{id}",
+			url:      "/v1/collections/53730d3f3d2d2f46cb910b16db817d3a62adaaa72fdb3a92ee373c37c5b55a76",
+			expected: "getCollectionByID",
+		},
+		{
+			name:     "/v1/scripts",
+			url:      "/v1/scripts",
+			expected: "executeScript",
+		},
+		{
+			name:     "/v1/accounts/{address}",
+			url:      "/v1/accounts/6a587be304c1224c",
+			expected: "getAccount",
+		},
+		{
+			name:     "/v1/events",
+			url:      "/v1/events",
+			expected: "getEvents",
+		},
+		{
+			name:     "/v1/network/parameters",
+			url:      "/v1/network/parameters",
+			expected: "getNetworkParameters",
+		},
+		{
+			name:     "/v1/node_version_info",
+			url:      "/v1/node_version_info",
+			expected: "getNodeVersionInfo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := time.Now()
+			for i := 0; i < 100_000; i++ {
+				_, _ = URLToRoute(tt.url)
+			}
+			t.Logf("%s: %v", tt.name, time.Since(start)/100_000)
+		})
+	}
+}

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -605,7 +605,7 @@ type RestMetrics interface {
 	// Example recorder taken from:
 	// https://github.com/slok/go-http-metrics/blob/master/metrics/prometheus/prometheus.go
 	httpmetrics.Recorder
-	AddTotalRequests(ctx context.Context, service string, id string)
+	AddTotalRequests(ctx context.Context, method string, routeName string)
 }
 
 type GRPCConnectionPoolMetrics interface {

--- a/module/metrics/access.go
+++ b/module/metrics/access.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	metricsProm "github.com/slok/go-http-metrics/metrics/prometheus"
 
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/counters"
@@ -20,6 +19,12 @@ func WithTransactionMetrics(m module.TransactionMetrics) AccessCollectorOpts {
 func WithBackendScriptsMetrics(m module.BackendScriptsMetrics) AccessCollectorOpts {
 	return func(ac *AccessCollector) {
 		ac.BackendScriptsMetrics = m
+	}
+}
+
+func WithRestMetrics(m module.RestMetrics) AccessCollectorOpts {
+	return func(ac *AccessCollector) {
+		ac.RestMetrics = m
 	}
 }
 
@@ -101,8 +106,6 @@ func NewAccessCollector(opts ...AccessCollectorOpts) *AccessCollector {
 			Help:      "gauge to track the maximum block height of execution receipts received",
 		}),
 		maxReceiptHeightValue: counters.NewMonotonousCounter(0),
-
-		RestMetrics: NewRestCollector(metricsProm.Config{Prefix: "access_rest_api"}),
 	}
 
 	for _, opt := range opts {

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -20,6 +20,10 @@ const (
 	LabelSuccess             = "success"
 	LabelCtrlMsgType         = "control_message"
 	LabelMisbehavior         = "misbehavior"
+	LabelHandler             = "handler"
+	LabelStatusCode          = "code"
+	LabelMethod              = "method"
+	LabelService             = "service"
 )
 
 const (

--- a/module/metrics/namespaces.go
+++ b/module/metrics/namespaces.go
@@ -15,6 +15,7 @@ const (
 	namespaceExecutionDataSync = "execution_data_sync"
 	namespaceChainsync         = "chainsync"
 	namespaceFollowerEngine    = "follower"
+	namespaceRestAPI           = "access_rest_api"
 )
 
 // Network subsystems represent the various layers of networking.
@@ -42,6 +43,7 @@ const (
 	subsystemTransactionTiming     = "transaction_timing"
 	subsystemTransactionSubmission = "transaction_submission"
 	subsystemConnectionPool        = "connection_pool"
+	subsystemHTTP                  = "http"
 )
 
 // Observer subsystem

--- a/module/metrics/rest_api.go
+++ b/module/metrics/rest_api.go
@@ -5,11 +5,9 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	httpmetrics "github.com/slok/go-http-metrics/metrics"
 
 	"github.com/onflow/flow-go/module"
-
-	httpmetrics "github.com/slok/go-http-metrics/metrics"
-	metricsProm "github.com/slok/go-http-metrics/metrics/prometheus"
 )
 
 type RestCollector struct {
@@ -17,74 +15,50 @@ type RestCollector struct {
 	httpResponseSizeHistogram *prometheus.HistogramVec
 	httpRequestsInflight      *prometheus.GaugeVec
 	httpRequestsTotal         *prometheus.GaugeVec
+
+	// urlToRouteMapper is a callback that converts a URL to a route name
+	urlToRouteMapper func(string) (string, error)
 }
 
 var _ module.RestMetrics = (*RestCollector)(nil)
 
 // NewRestCollector returns a new metrics RestCollector that implements the RestCollector
 // using Prometheus as the backend.
-func NewRestCollector(cfg metricsProm.Config) module.RestMetrics {
-	if len(cfg.DurationBuckets) == 0 {
-		cfg.DurationBuckets = prometheus.DefBuckets
-	}
-
-	if len(cfg.SizeBuckets) == 0 {
-		cfg.SizeBuckets = prometheus.ExponentialBuckets(100, 10, 8)
-	}
-
-	if cfg.Registry == nil {
-		cfg.Registry = prometheus.DefaultRegisterer
-	}
-
-	if cfg.HandlerIDLabel == "" {
-		cfg.HandlerIDLabel = "handler"
-	}
-
-	if cfg.StatusCodeLabel == "" {
-		cfg.StatusCodeLabel = "code"
-	}
-
-	if cfg.MethodLabel == "" {
-		cfg.MethodLabel = "method"
-	}
-
-	if cfg.ServiceLabel == "" {
-		cfg.ServiceLabel = "service"
-	}
-
+func NewRestCollector(urlToRouteMapper func(string) (string, error), registerer prometheus.Registerer) *RestCollector {
 	r := &RestCollector{
+		urlToRouteMapper: urlToRouteMapper,
 		httpRequestDurHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: cfg.Prefix,
-			Subsystem: "http",
+			Namespace: namespaceRestAPI,
+			Subsystem: subsystemHTTP,
 			Name:      "request_duration_seconds",
 			Help:      "The latency of the HTTP requests.",
-			Buckets:   cfg.DurationBuckets,
-		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel, cfg.StatusCodeLabel}),
+			Buckets:   prometheus.DefBuckets,
+		}, []string{LabelService, LabelHandler, LabelMethod, LabelStatusCode}),
 
 		httpResponseSizeHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: cfg.Prefix,
-			Subsystem: "http",
+			Namespace: namespaceRestAPI,
+			Subsystem: subsystemHTTP,
 			Name:      "response_size_bytes",
 			Help:      "The size of the HTTP responses.",
-			Buckets:   cfg.SizeBuckets,
-		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel, cfg.StatusCodeLabel}),
+			Buckets:   prometheus.ExponentialBuckets(100, 10, 8),
+		}, []string{LabelService, LabelHandler, LabelMethod, LabelStatusCode}),
 
 		httpRequestsInflight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: cfg.Prefix,
-			Subsystem: "http",
+			Namespace: namespaceRestAPI,
+			Subsystem: subsystemHTTP,
 			Name:      "requests_inflight",
 			Help:      "The number of inflight requests being handled at the same time.",
-		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel}),
+		}, []string{LabelService, LabelHandler}),
 
 		httpRequestsTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: cfg.Prefix,
-			Subsystem: "http",
+			Namespace: namespaceRestAPI,
+			Subsystem: subsystemHTTP,
 			Name:      "requests_total",
 			Help:      "The number of requests handled over time.",
-		}, []string{cfg.MethodLabel, cfg.HandlerIDLabel}),
+		}, []string{LabelMethod, LabelHandler}),
 	}
 
-	cfg.Registry.MustRegister(
+	registerer.MustRegister(
 		r.httpRequestDurHistogram,
 		r.httpResponseSizeHistogram,
 		r.httpRequestsInflight,
@@ -94,20 +68,45 @@ func NewRestCollector(cfg metricsProm.Config) module.RestMetrics {
 	return r
 }
 
-// These methods are called automatically by go-http-metrics/middleware
+// ObserveHTTPRequestDuration records the duration of the REST request.
+// This method is called automatically by go-http-metrics/middleware
 func (r *RestCollector) ObserveHTTPRequestDuration(_ context.Context, p httpmetrics.HTTPReqProperties, duration time.Duration) {
-	r.httpRequestDurHistogram.WithLabelValues(p.Service, p.ID, p.Method, p.Code).Observe(duration.Seconds())
+	handler := r.mapURLToRoute(p.ID)
+	r.httpRequestDurHistogram.WithLabelValues(p.Service, handler, p.Method, p.Code).Observe(duration.Seconds())
 }
 
+// ObserveHTTPResponseSize records the response size of the REST request.
+// This method is called automatically by go-http-metrics/middleware
 func (r *RestCollector) ObserveHTTPResponseSize(_ context.Context, p httpmetrics.HTTPReqProperties, sizeBytes int64) {
-	r.httpResponseSizeHistogram.WithLabelValues(p.Service, p.ID, p.Method, p.Code).Observe(float64(sizeBytes))
+	handler := r.mapURLToRoute(p.ID)
+	r.httpResponseSizeHistogram.WithLabelValues(p.Service, handler, p.Method, p.Code).Observe(float64(sizeBytes))
 }
 
+// AddInflightRequests increments and decrements the number of inflight request being processed.
+// This method is called automatically by go-http-metrics/middleware
 func (r *RestCollector) AddInflightRequests(_ context.Context, p httpmetrics.HTTPProperties, quantity int) {
-	r.httpRequestsInflight.WithLabelValues(p.Service, p.ID).Add(float64(quantity))
+	handler := r.mapURLToRoute(p.ID)
+	r.httpRequestsInflight.WithLabelValues(p.Service, handler).Add(float64(quantity))
 }
 
-// New custom method to track all requests made for every REST API request
-func (r *RestCollector) AddTotalRequests(_ context.Context, method string, routeName string) {
-	r.httpRequestsTotal.WithLabelValues(method, routeName).Inc()
+// AddTotalRequests records all REST requests
+// This is a custom method called by the REST handler
+func (r *RestCollector) AddTotalRequests(_ context.Context, method, path string) {
+	handler := r.mapURLToRoute(path)
+	r.httpRequestsTotal.WithLabelValues(method, handler).Inc()
+}
+
+// mapURLToRoute uses the urlToRouteMapper callback to convert a URL to a route name
+// This normalizes the URL, removing dynamic information converting it to a static string
+func (r *RestCollector) mapURLToRoute(url string) string {
+	if r.urlToRouteMapper == nil {
+		return "unknown"
+	}
+
+	route, err := r.urlToRouteMapper(url)
+	if err != nil {
+		return "unknown"
+	}
+
+	return route
 }

--- a/module/metrics/rest_api.go
+++ b/module/metrics/rest_api.go
@@ -70,7 +70,7 @@ func NewRestCollector(urlToRouteMapper func(string) (string, error), registerer 
 		r.httpRequestsTotal,
 	)
 
-	return r
+	return r, nil
 }
 
 // ObserveHTTPRequestDuration records the duration of the REST request.

--- a/module/metrics/rest_api.go
+++ b/module/metrics/rest_api.go
@@ -81,7 +81,7 @@ func NewRestCollector(cfg metricsProm.Config) module.RestMetrics {
 			Subsystem: "http",
 			Name:      "requests_total",
 			Help:      "The number of requests handled over time.",
-		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel}),
+		}, []string{cfg.MethodLabel, cfg.HandlerIDLabel}),
 	}
 
 	cfg.Registry.MustRegister(
@@ -108,6 +108,6 @@ func (r *RestCollector) AddInflightRequests(_ context.Context, p httpmetrics.HTT
 }
 
 // New custom method to track all requests made for every REST API request
-func (r *RestCollector) AddTotalRequests(_ context.Context, method string, id string) {
-	r.httpRequestsTotal.WithLabelValues(method, id).Inc()
+func (r *RestCollector) AddTotalRequests(_ context.Context, method string, routeName string) {
+	r.httpRequestsTotal.WithLabelValues(method, routeName).Inc()
 }

--- a/module/mock/access_metrics.go
+++ b/module/mock/access_metrics.go
@@ -23,9 +23,9 @@ func (_m *AccessMetrics) AddInflightRequests(ctx context.Context, props metrics.
 	_m.Called(ctx, props, quantity)
 }
 
-// AddTotalRequests provides a mock function with given fields: ctx, service, id
-func (_m *AccessMetrics) AddTotalRequests(ctx context.Context, service string, id string) {
-	_m.Called(ctx, service, id)
+// AddTotalRequests provides a mock function with given fields: ctx, method, routeName
+func (_m *AccessMetrics) AddTotalRequests(ctx context.Context, method string, routeName string) {
+	_m.Called(ctx, method, routeName)
 }
 
 // ConnectionAddedToPool provides a mock function with given fields:

--- a/module/mock/rest_metrics.go
+++ b/module/mock/rest_metrics.go
@@ -21,9 +21,9 @@ func (_m *RestMetrics) AddInflightRequests(ctx context.Context, props metrics.HT
 	_m.Called(ctx, props, quantity)
 }
 
-// AddTotalRequests provides a mock function with given fields: ctx, service, id
-func (_m *RestMetrics) AddTotalRequests(ctx context.Context, service string, id string) {
-	_m.Called(ctx, service, id)
+// AddTotalRequests provides a mock function with given fields: ctx, method, routeName
+func (_m *RestMetrics) AddTotalRequests(ctx context.Context, method string, routeName string) {
+	_m.Called(ctx, method, routeName)
 }
 
 // ObserveHTTPRequestDuration provides a mock function with given fields: ctx, props, duration


### PR DESCRIPTION
Backports: 
* https://github.com/onflow/flow-go/pull/4452
* https://github.com/onflow/flow-go/pull/4571

This PR backports 2 fixes for issues with REST metrics that resulted in performance issues on the prometheus node. It normalizes the request URL to route names instead of full URLs which contained request specific information (like blockIDs)