### PR TITLE
Make tests less flaky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ go.work.sum
 
 # Ledger checkpoint status files
 **/checkpoint_status.json
+**/export_report.json
 
 # Local testing result files
 tps-results*.json

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -1261,6 +1261,8 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 	me.On("SignFunc", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil)
 
+	constRandomSource := make([]byte, 32)
+
 	exe, err := computer.NewBlockComputer(
 		vm,
 		execCtx,
@@ -1271,7 +1273,7 @@ func Test_ExecutingSystemCollection(t *testing.T) {
 		me,
 		prov,
 		nil,
-		testutil.ProtocolStateWithSourceFixture(nil),
+		testutil.ProtocolStateWithSourceFixture(constRandomSource),
 		testMaxConcurrency)
 	require.NoError(t, err)
 


### PR DESCRIPTION
The problem is that EpochCommit event is of nondeterministic byte size. This is because of the changes to the random.