### PR TITLE
[Access] Fix slice iteration bug in TrieUpdate protobuf conversion

### DIFF
--- a/engine/common/rpc/convert/execution_data.go
+++ b/engine/common/rpc/convert/execution_data.go
@@ -153,8 +153,8 @@ func TrieUpdateToMessage(t *ledger.TrieUpdate) (*entities.TrieUpdate, error) {
 	}
 
 	paths := make([][]byte, len(t.Paths))
-	for i, path := range t.Paths {
-		paths[i] = path[:]
+	for i := range t.Paths {
+		paths[i] = t.Paths[i][:]
 	}
 
 	payloads := make([]*entities.Payload, len(t.Payloads))

--- a/engine/common/rpc/convert/execution_data_test.go
+++ b/engine/common/rpc/convert/execution_data_test.go
@@ -23,9 +23,9 @@ func TestConvertBlockExecutionData(t *testing.T) {
 	chunkData := make([]*execution_data.ChunkExecutionData, 0, chunks)
 	for i := 0; i < chunks-1; i++ {
 		ced := unittest.ChunkExecutionDataFixture(t,
-			0, // updates set explicitly to target 5*32K per chunk
+			0, // updates set explicitly to target 160-320KB per chunk
 			unittest.WithChunkEvents(events),
-			unittest.WithTrieUpdate(testutils.TrieUpdateFixture(5, 32*1024, 128*1024)),
+			unittest.WithTrieUpdate(testutils.TrieUpdateFixture(5, 32*1024, 64*1024)),
 		)
 		chunkData = append(chunkData, ced)
 	}

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2472,6 +2472,12 @@ func WithChunkEvents(events flow.EventsList) func(*execution_data.ChunkExecution
 	}
 }
 
+func WithTrieUpdate(trieUpdate *ledger.TrieUpdate) func(*execution_data.ChunkExecutionData) {
+	return func(conf *execution_data.ChunkExecutionData) {
+		conf.TrieUpdate = trieUpdate
+	}
+}
+
 func ChunkExecutionDataFixture(t *testing.T, minSize int, opts ...func(*execution_data.ChunkExecutionData)) *execution_data.ChunkExecutionData {
 	collection := CollectionFixture(5)
 	ced := &execution_data.ChunkExecutionData{

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2483,7 +2483,7 @@ func ChunkExecutionDataFixture(t *testing.T, minSize int, opts ...func(*executio
 	ced := &execution_data.ChunkExecutionData{
 		Collection: &collection,
 		Events:     flow.EventsList{},
-		TrieUpdate: testutils.TrieUpdateFixture(1, 1, 8),
+		TrieUpdate: testutils.TrieUpdateFixture(2, 1, 8),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
There was a bug in the logic that converts `ledger.TrieUpdate` objects to their protobuf form. The iteration did not properly handle memory reuse by the for loop, resulting the the output containing copies of the last element only.

This PR updates this logic to use the correct element, and improves tests to cover this case.

The previous tests only use a single path in the `TrieUpdate`, so this case was never exercised.