### PR TITLE
[FVM] enable unsafe Random for script execution

### DIFF
--- a/fvm/environment/random_generator.go
+++ b/fvm/environment/random_generator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/onflow/flow-go/crypto/random"
-	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/storage/state"
 	"github.com/onflow/flow-go/fvm/tracing"
 	"github.com/onflow/flow-go/model/flow"
@@ -142,5 +141,5 @@ func NewDummyRandomGenerator() RandomGenerator {
 // UnsafeRandom() returns an error because executing scripts
 // does not support randomness APIs.
 func (gen *dummyRandomGenerator) UnsafeRandom() (uint64, error) {
-	return 0, errors.NewOperationNotSupportedError("Random")
+	return 0, nil
 }


### PR DESCRIPTION
This PR enables cadence's `unsafeRandom` for script execution instead of erroring. This allows scripts not to panic although the returned random value is not equal to the value returned when run as a transaction.

This behaviour is clarified in https://github.com/onflow/flips/pull/120 (https://github.com/onflow/flips/pull/120/commits/051c82b8c3fbf959908ee401eaff00e2d8b7418f)