### PR TITLE
[Access] Update default max message size to 1GiB - v0.31 backport

### DIFF
--- a/utils/grpcutils/grpc.go
+++ b/utils/grpcutils/grpc.go
@@ -13,9 +13,10 @@ import (
 	"github.com/onflow/flow-go/network/p2p/keyutils"
 )
 
-// DefaultMaxMsgSize use 20MB as the default message size limit.
-// grpc library default is 4MB
-const DefaultMaxMsgSize = 1024 * 1024 * 20
+// DefaultMaxMsgSize use 1 GiB as the default message size limit.
+// This enforces a sane max message size, while still allowing for reasonably large messages.
+// grpc library default is 4 MiB.
+const DefaultMaxMsgSize = 1 << (10 * 3) // 1 GiB
 
 // CertificateConfig is used to configure an Certificate
 type CertificateConfig struct {


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/4609