### PR TITLE
store chunk data pack in a separate database

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -13,6 +13,7 @@ import (
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	badgerDB "github.com/dgraph-io/badger/v2"
 	"github.com/ipfs/go-cid"
 	badger "github.com/ipfs/go-ds-badger2"
 	"github.com/onflow/flow-core-contracts/lib/go/templates"
@@ -627,6 +628,14 @@ func (exeNode *ExecutionNode) LoadExecutionDataGetter(node *NodeConfig) error {
 	return nil
 }
 
+func openChunkDataPackDB(dbPath string) (*badgerDB.DB, error) {
+	db, err := badgerDB.Open(badgerDB.LSMOnlyOptions(dbPath))
+	if err != nil {
+		return nil, fmt.Errorf("could not open chunk data pack badger db at path %v: %w", dbPath, err)
+	}
+	return db, nil
+}
+
 func (exeNode *ExecutionNode) LoadExecutionState(
 	node *NodeConfig,
 ) (
@@ -634,7 +643,11 @@ func (exeNode *ExecutionNode) LoadExecutionState(
 	error,
 ) {
 
-	chunkDataPacks := storage.NewChunkDataPacks(node.Metrics.Cache, node.DB, node.Storage.Collections, exeNode.exeConf.chunkDataPackCacheSize)
+	chunkDataPackDB, err := openChunkDataPackDB(exeNode.exeConf.chunkDataPackDir)
+	if err != nil {
+		return nil, err
+	}
+	chunkDataPacks := storage.NewChunkDataPacks(node.Metrics.Cache, chunkDataPackDB, node.Storage.Collections, exeNode.exeConf.chunkDataPackCacheSize)
 
 	// Needed for gRPC server, make sure to assign to main scoped vars
 	exeNode.events = storage.NewEvents(node.Metrics.Cache, node.DB)

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -664,6 +664,12 @@ func (exeNode *ExecutionNode) LoadExecutionState(
 	if err != nil {
 		return nil, err
 	}
+	exeNode.builder.ShutdownFunc(func() error {
+		if err := chunkDataPackDB.Close(); err != nil {
+			return fmt.Errorf("error closing chunk data pack database: %w", err)
+		}
+		return nil
+	})
 	chunkDataPacks := storage.NewChunkDataPacks(node.Metrics.Cache, chunkDataPackDB, node.Storage.Collections, exeNode.exeConf.chunkDataPackCacheSize)
 
 	// Needed for gRPC server, make sure to assign to main scoped vars

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -32,6 +32,7 @@ type ExecutionConfig struct {
 	transactionResultsCacheSize          uint
 	checkpointDistance                   uint
 	checkpointsToKeep                    uint
+	chunkDataPackDir                     string
 	chunkDataPackCacheSize               uint
 	chunkDataPackRequestsCacheSize       uint32
 	requestInterval                      time.Duration
@@ -80,6 +81,7 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&exeConf.computationConfig.ExtensiveTracing, "extensive-tracing", false, "adds high-overhead tracing to execution")
 	flags.BoolVar(&exeConf.computationConfig.CadenceTracing, "cadence-tracing", false, "enables cadence runtime level tracing")
 	flags.IntVar(&exeConf.computationConfig.MaxConcurrency, "computer-max-concurrency", 1, "set to greater than 1 to enable concurrent transaction execution")
+	flags.StringVar(&exeConf.chunkDataPackDir, "chunk-data-pack-dir", filepath.Join(homedir, ".flow", "chunk_data_packs"), "directory to use for storing chunk data packs")
 	flags.UintVar(&exeConf.chunkDataPackCacheSize, "chdp-cache", storage.DefaultCacheSize, "cache size for chunk data packs")
 	flags.Uint32Var(&exeConf.chunkDataPackRequestsCacheSize, "chdp-request-queue", mempool.DefaultChunkDataPackRequestQueueSize, "queue size for chunk data pack requests")
 	flags.DurationVar(&exeConf.requestInterval, "request-interval", 60*time.Second, "the interval between requests for the requester engine")

--- a/cmd/util/cmd/truncate-database/cmd.go
+++ b/cmd/util/cmd/truncate-database/cmd.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	flagDatadir string
+	flagDatadir          string
+	flagChunkDataPackDir string
 )
 
 var Cmd = &cobra.Command{
@@ -24,14 +25,22 @@ func init() {
 		"directory that stores the protocol state")
 	_ = Cmd.MarkFlagRequired("datadir")
 
+	Cmd.Flags().StringVar(&flagChunkDataPackDir, "chunk-data-pack-dir", "",
+		"directory that stores the chunk data pack")
+	_ = Cmd.MarkFlagRequired("chunk-data-pack-dir")
 }
 
 func run(*cobra.Command, []string) {
 
-	log.Info().Msg("Opening database with truncate")
+	log.Info().Msg("Opening protocol database with truncate")
 
 	db := common.InitStorageWithTruncate(flagDatadir, true)
 	defer db.Close()
+
+	log.Info().Msg("ProtocolDB Truncated")
+
+	chunkdb := common.InitStorageWithTruncate(flagChunkDataPackDir, true)
+	defer chunkdb.Close()
 
 	log.Info().Msg("Truncated")
 }

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -320,7 +320,7 @@ func (s *state) saveExecutionResults(
 			for _, chunk := range chunks {
 				chunkIDs = append(chunkIDs, chunk.ID())
 			}
-			s.chunkDataPacks.Remove(chunkIDs)
+			_ = s.chunkDataPacks.Remove(chunkIDs)
 		}
 	}()
 

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -288,11 +288,11 @@ func (s *state) SaveExecutionResults(
 
 	err := s.chunkDataPacks.StoreMul(result.AllChunkDataPacks())
 	if err != nil {
-		return fmt.Errorf("can not store multile chunk data pack: %w", err)
+		return fmt.Errorf("can not store multiple chunk data pack: %w", err)
 	}
 
 	// Write Batch is BadgerDB feature designed for handling lots of writes
-	// in efficient and automatic manner, hence pushing all the updates we can
+	// in efficient and atomic manner, hence pushing all the updates we can
 	// as tightly as possible to let Badger manage it.
 	// Note, that it does not guarantee atomicity as transactions has size limit,
 	// but it's the closest thing to atomicity we could have

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -283,10 +283,13 @@ func (s *state) SaveExecutionResults(
 		trace.EXEStateSaveExecutionResults)
 	defer span.End()
 
-	header := result.ExecutableBlock.Block.Header
+	err := s.saveExecutionResults(ctx, result)
+	if err != nil {
+		return fmt.Errorf("could not save execution results: %w", err)
+	}
 
 	//outside batch because it requires read access
-	err := s.UpdateHighestExecutedBlockIfHigher(childCtx, header)
+	err = s.UpdateHighestExecutedBlockIfHigher(childCtx, result.ExecutableBlock.Block.Header)
 	if err != nil {
 		return fmt.Errorf("cannot update highest executed block: %w", err)
 	}

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -299,11 +299,11 @@ func (s *state) SaveExecutionResults(
 func (s *state) saveExecutionResults(
 	ctx context.Context,
 	result *execution.ComputationResult,
-) error {
+) (err error) {
 	header := result.ExecutableBlock.Block.Header
 	blockID := header.ID()
 
-	err := s.chunkDataPacks.Store(result.AllChunkDataPacks())
+	err = s.chunkDataPacks.Store(result.AllChunkDataPacks())
 	if err != nil {
 		return fmt.Errorf("can not store multiple chunk data pack: %w", err)
 	}

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -286,6 +286,11 @@ func (s *state) SaveExecutionResults(
 	header := result.ExecutableBlock.Block.Header
 	blockID := header.ID()
 
+	err := s.chunkDataPacks.StoreMul(result.AllChunkDataPacks())
+	if err != nil {
+		return fmt.Errorf("can not store multile chunk data pack: %w", err)
+	}
+
 	// Write Batch is BadgerDB feature designed for handling lots of writes
 	// in efficient and automatic manner, hence pushing all the updates we can
 	// as tightly as possible to let Badger manage it.
@@ -293,14 +298,7 @@ func (s *state) SaveExecutionResults(
 	// but it's the closest thing to atomicity we could have
 	batch := badgerstorage.NewBatch(s.db)
 
-	for _, chunkDataPack := range result.AllChunkDataPacks() {
-		err := s.chunkDataPacks.BatchStore(chunkDataPack, batch)
-		if err != nil {
-			return fmt.Errorf("cannot store chunk data pack: %w", err)
-		}
-	}
-
-	err := s.events.BatchStore(blockID, []flow.EventsList{result.AllEvents()}, batch)
+	err = s.events.BatchStore(blockID, []flow.EventsList{result.AllEvents()}, batch)
 	if err != nil {
 		return fmt.Errorf("cannot store events: %w", err)
 	}

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -286,7 +286,7 @@ func (s *state) SaveExecutionResults(
 	header := result.ExecutableBlock.Block.Header
 	blockID := header.ID()
 
-	err := s.chunkDataPacks.StoreMul(result.AllChunkDataPacks())
+	err := s.chunkDataPacks.Store(result.AllChunkDataPacks())
 	if err != nil {
 		return fmt.Errorf("can not store multiple chunk data pack: %w", err)
 	}

--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -395,6 +395,7 @@ func prepareExecutionService(container testnet.ContainerConfig, i int, n int) Se
 		fmt.Sprintf("--cadence-tracing=%t", cadenceTracing),
 		fmt.Sprintf("--extensive-tracing=%t", extesiveTracing),
 		"--execution-data-dir=/data/execution-data",
+		"--chunk-data-pack-dir=/data/chunk-data-pack",
 	)
 
 	service.Volumes = append(service.Volumes,

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -75,6 +75,8 @@ const (
 	DefaultExecutionRootDir = "/data/exedb"
 	// DefaultExecutionDataServiceDir for the execution data service blobstore.
 	DefaultExecutionDataServiceDir = "/data/execution_data"
+	// DefaultChunkDataPackDir for the chunk data packs
+	DefaultChunkDataPackDir = "/data/chunk_data_pack"
 	// DefaultProfilerDir is the default directory for the profiler
 	DefaultProfilerDir = "/data/profiler"
 
@@ -861,6 +863,7 @@ func (net *FlowNetwork) AddNode(t *testing.T, bootstrapDir string, nodeConf Cont
 
 			nodeContainer.AddFlag("triedir", DefaultExecutionRootDir)
 			nodeContainer.AddFlag("execution-data-dir", DefaultExecutionDataServiceDir)
+			nodeContainer.AddFlag("chunk-data-pack-dir", DefaultChunkDataPackDir)
 
 		case flow.RoleAccess:
 			nodeContainer.exposePort(GRPCPort, testingdock.RandomPort(t))

--- a/module/mempool/queue/queue_test.go
+++ b/module/mempool/queue/queue_test.go
@@ -292,7 +292,7 @@ func TestQueue(t *testing.T) {
 	//})
 
 	t.Run("String()", func(t *testing.T) {
-		t.Skip("flakey, because String() will iterate through a map, which is not determinsitic")
+		unittest.SkipUnless(t, unittest.TEST_FLAKY, "flakey, because String() will iterate through a map, which is not determinsitic")
 		// a <- c <- d <- f
 		queue := NewQueue(a)
 		stored, _ := queue.TryAdd(c)

--- a/module/mempool/queue/queue_test.go
+++ b/module/mempool/queue/queue_test.go
@@ -292,6 +292,7 @@ func TestQueue(t *testing.T) {
 	//})
 
 	t.Run("String()", func(t *testing.T) {
+		t.Skip("flakey, because String() will iterate through a map, which is not determinsitic")
 		// a <- c <- d <- f
 		queue := NewQueue(a)
 		stored, _ := queue.TryAdd(c)

--- a/module/mempool/queue/queue_test.go
+++ b/module/mempool/queue/queue_test.go
@@ -292,7 +292,7 @@ func TestQueue(t *testing.T) {
 	//})
 
 	t.Run("String()", func(t *testing.T) {
-		unittest.SkipUnless(t, unittest.TEST_FLAKY, "flakey, because String() will iterate through a map, which is not determinsitic")
+		unittest.SkipUnless(t, unittest.TEST_FLAKY, "flakey, because String will iterate through a map, which is not determinsitic")
 		// a <- c <- d <- f
 		queue := NewQueue(a)
 		stored, _ := queue.TryAdd(c)

--- a/storage/badger/chunkDataPacks.go
+++ b/storage/badger/chunkDataPacks.go
@@ -48,15 +48,6 @@ func NewChunkDataPacks(collector module.CacheMetrics, db *badger.DB, collections
 	return &ch
 }
 
-func (ch *ChunkDataPacks) Store(c *flow.ChunkDataPack) error {
-	sc := toStoredChunkDataPack(c)
-	err := operation.RetryOnConflictTx(ch.db, transaction.Update, ch.byChunkIDCache.PutTx(sc.ChunkID, sc))
-	if err != nil {
-		return fmt.Errorf("could not store chunk datapack: %w", err)
-	}
-	return nil
-}
-
 func (ch *ChunkDataPacks) Remove(chunkID flow.Identifier) error {
 	err := operation.RetryOnConflict(ch.db.Update, operation.RemoveChunkDataPack(chunkID))
 	if err != nil {
@@ -79,9 +70,9 @@ func (ch *ChunkDataPacks) BatchStore(c *flow.ChunkDataPack, batch storage.BatchS
 	return operation.BatchInsertChunkDataPack(sc)(writeBatch)
 }
 
-// StoreMul stores multiple ChunkDataPacks cs keyed by their ChunkIDs in provided batch.
+// Store stores multiple ChunkDataPacks cs keyed by their ChunkIDs in a batch.
 // No errors are expected during normal operation, but it may return generic error
-func (ch *ChunkDataPacks) StoreMul(cs []*flow.ChunkDataPack) error {
+func (ch *ChunkDataPacks) Store(cs []*flow.ChunkDataPack) error {
 	batch := NewBatch(ch.db)
 	for _, c := range cs {
 		err := ch.BatchStore(c, batch)

--- a/storage/badger/chunkDataPacks.go
+++ b/storage/badger/chunkDataPacks.go
@@ -79,6 +79,8 @@ func (ch *ChunkDataPacks) BatchStore(c *flow.ChunkDataPack, batch storage.BatchS
 	return operation.BatchInsertChunkDataPack(sc)(writeBatch)
 }
 
+// StoreMul stores multiple ChunkDataPacks cs keyed by their ChunkIDs in provided batch.
+// No errors are expected during normal operation, but it may return generic error
 func (ch *ChunkDataPacks) StoreMul(cs []*flow.ChunkDataPack) error {
 	batch := NewBatch(ch.db)
 	for _, c := range cs {

--- a/storage/badger/chunkDataPacks.go
+++ b/storage/badger/chunkDataPacks.go
@@ -79,6 +79,22 @@ func (ch *ChunkDataPacks) BatchStore(c *flow.ChunkDataPack, batch storage.BatchS
 	return operation.BatchInsertChunkDataPack(sc)(writeBatch)
 }
 
+func (ch *ChunkDataPacks) StoreMul(cs []*flow.ChunkDataPack) error {
+	batch := NewBatch(ch.db)
+	for _, c := range cs {
+		err := ch.BatchStore(c, batch)
+		if err != nil {
+			return fmt.Errorf("cannot store chunk data pack: %w", err)
+		}
+	}
+
+	err := batch.Flush()
+	if err != nil {
+		return fmt.Errorf("cannot flush batch: %w", err)
+	}
+	return nil
+}
+
 // BatchRemove removes ChunkDataPack c keyed by its ChunkID in provided batch
 // No errors are expected during normal operation, even if no entries are matched.
 // If Badger unexpectedly fails to process the request, the error is wrapped in a generic error and returned.

--- a/storage/badger/chunk_data_pack_test.go
+++ b/storage/badger/chunk_data_pack_test.go
@@ -22,24 +22,39 @@ import (
 // It also evaluates that re-inserting is idempotent.
 func TestChunkDataPacks_Store(t *testing.T) {
 	WithChunkDataPacks(t, 100, func(t *testing.T, chunkDataPacks []*flow.ChunkDataPack, chunkDataPackStore *badgerstorage.ChunkDataPacks, _ *badger.DB) {
-		wg := sync.WaitGroup{}
-		wg.Add(len(chunkDataPacks))
+		require.NoError(t, chunkDataPackStore.Store(chunkDataPacks))
+		require.NoError(t, chunkDataPackStore.Store(chunkDataPacks))
+	})
+}
+
+func TestChunkDataPack_Remove(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		transactions := badgerstorage.NewTransactions(&metrics.NoopCollector{}, db)
+		collections := badgerstorage.NewCollections(db, transactions)
+		// keep the cache size at 1 to make sure that entries are written and read from storage itself.
+		chunkDataPackStore := badgerstorage.NewChunkDataPacks(&metrics.NoopCollector{}, db, collections, 1)
+
+		chunkDataPacks := unittest.ChunkDataPacksFixture(10)
 		for _, chunkDataPack := range chunkDataPacks {
-			go func(cdp flow.ChunkDataPack) {
-				err := chunkDataPackStore.Store(&cdp)
-				require.NoError(t, err)
-
-				wg.Done()
-			}(*chunkDataPack)
-		}
-
-		unittest.RequireReturnsBefore(t, wg.Wait, 1*time.Second, "could not store chunk data packs on time")
-
-		// re-insert - should be idempotent
-		for _, chunkDataPack := range chunkDataPacks {
-			err := chunkDataPackStore.Store(chunkDataPack)
+			// stores collection in Collections storage (which ChunkDataPacks store uses internally)
+			err := collections.Store(chunkDataPack.Collection)
 			require.NoError(t, err)
 		}
+
+		chunkIDs := make([]flow.Identifier, 0, len(chunkDataPacks))
+		for _, chunk := range chunkDataPacks {
+			chunkIDs = append(chunkIDs, chunk.ID())
+		}
+
+		require.NoError(t, chunkDataPackStore.Store(chunkDataPacks))
+		require.NoError(t, chunkDataPackStore.Remove(chunkIDs))
+
+		// verify it has been removed
+		_, err := chunkDataPackStore.ByChunkID(chunkIDs[0])
+		assert.True(t, errors.Is(err, storage.ErrNotFound))
+
+		// Removing again should not error
+		require.NoError(t, chunkDataPackStore.Remove(chunkIDs))
 	})
 }
 

--- a/storage/badger/chunk_data_pack_test.go
+++ b/storage/badger/chunk_data_pack_test.go
@@ -86,7 +86,7 @@ func TestChunkDataPacks_StoreTwice(t *testing.T) {
 		transactions := badgerstorage.NewTransactions(&metrics.NoopCollector{}, db)
 		collections := badgerstorage.NewCollections(db, transactions)
 		store := badgerstorage.NewChunkDataPacks(&metrics.NoopCollector{}, db, collections, 1)
-		require.NoError(t, store.StoreMul(chunkDataPacks))
+		require.NoError(t, store.Store(chunkDataPacks))
 
 		for _, c := range chunkDataPacks {
 			c2, err := store.ByChunkID(c.ChunkID)
@@ -94,7 +94,7 @@ func TestChunkDataPacks_StoreTwice(t *testing.T) {
 			require.Equal(t, c, c2)
 		}
 
-		require.NoError(t, store.StoreMul(chunkDataPacks))
+		require.NoError(t, store.Store(chunkDataPacks))
 	})
 }
 

--- a/storage/chunkDataPacks.go
+++ b/storage/chunkDataPacks.go
@@ -10,6 +10,8 @@ type ChunkDataPacks interface {
 	// Store inserts the chunk header, keyed by chunk ID.
 	Store(c *flow.ChunkDataPack) error
 
+	StoreMul(c []*flow.ChunkDataPack) error
+
 	// BatchStore inserts the chunk header, keyed by chunk ID into a given batch
 	BatchStore(c *flow.ChunkDataPack, batch BatchStorage) error
 

--- a/storage/chunkDataPacks.go
+++ b/storage/chunkDataPacks.go
@@ -7,10 +7,9 @@ import (
 // ChunkDataPacks represents persistent storage for chunk data packs.
 type ChunkDataPacks interface {
 
-	// Store inserts the chunk header, keyed by chunk ID.
-	Store(c *flow.ChunkDataPack) error
-
-	StoreMul(c []*flow.ChunkDataPack) error
+	// Store stores multiple ChunkDataPacks cs keyed by their ChunkIDs in a batch.
+	// No errors are expected during normal operation, but it may return generic error
+	Store(cs []*flow.ChunkDataPack) error
 
 	// BatchStore inserts the chunk header, keyed by chunk ID into a given batch
 	BatchStore(c *flow.ChunkDataPack, batch BatchStorage) error

--- a/storage/chunkDataPacks.go
+++ b/storage/chunkDataPacks.go
@@ -11,6 +11,10 @@ type ChunkDataPacks interface {
 	// No errors are expected during normal operation, but it may return generic error
 	Store(cs []*flow.ChunkDataPack) error
 
+	// Remove removes multiple ChunkDataPacks cs keyed by their ChunkIDs in a batch.
+	// No errors are expected during normal operation, but it may return generic error
+	Remove(cs []flow.Identifier) error
+
 	// BatchStore inserts the chunk header, keyed by chunk ID into a given batch
 	BatchStore(c *flow.ChunkDataPack, batch BatchStorage) error
 

--- a/storage/mock/chunk_data_packs.go
+++ b/storage/mock/chunk_data_packs.go
@@ -68,27 +68,13 @@ func (_m *ChunkDataPacks) ByChunkID(chunkID flow.Identifier) (*flow.ChunkDataPac
 	return r0, r1
 }
 
-// Store provides a mock function with given fields: c
-func (_m *ChunkDataPacks) Store(c *flow.ChunkDataPack) error {
-	ret := _m.Called(c)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*flow.ChunkDataPack) error); ok {
-		r0 = rf(c)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// StoreMul provides a mock function with given fields: c
-func (_m *ChunkDataPacks) StoreMul(c []*flow.ChunkDataPack) error {
-	ret := _m.Called(c)
+// Store provides a mock function with given fields: cs
+func (_m *ChunkDataPacks) Store(cs []*flow.ChunkDataPack) error {
+	ret := _m.Called(cs)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func([]*flow.ChunkDataPack) error); ok {
-		r0 = rf(c)
+		r0 = rf(cs)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/storage/mock/chunk_data_packs.go
+++ b/storage/mock/chunk_data_packs.go
@@ -68,6 +68,20 @@ func (_m *ChunkDataPacks) ByChunkID(chunkID flow.Identifier) (*flow.ChunkDataPac
 	return r0, r1
 }
 
+// Remove provides a mock function with given fields: cs
+func (_m *ChunkDataPacks) Remove(cs []flow.Identifier) error {
+	ret := _m.Called(cs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]flow.Identifier) error); ok {
+		r0 = rf(cs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Store provides a mock function with given fields: cs
 func (_m *ChunkDataPacks) Store(cs []*flow.ChunkDataPack) error {
 	ret := _m.Called(cs)

--- a/storage/mock/chunk_data_packs.go
+++ b/storage/mock/chunk_data_packs.go
@@ -82,6 +82,20 @@ func (_m *ChunkDataPacks) Store(c *flow.ChunkDataPack) error {
 	return r0
 }
 
+// StoreMul provides a mock function with given fields: c
+func (_m *ChunkDataPacks) StoreMul(c []*flow.ChunkDataPack) error {
+	ret := _m.Called(c)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]*flow.ChunkDataPack) error); ok {
+		r0 = rf(c)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewChunkDataPacks interface {
 	mock.TestingT
 	Cleanup(func())


### PR DESCRIPTION
- Change chunk data pack to be stored in a separate badger database, so that it can be pruned to reduce disk space usage.

Tested works on canary. 