### PR TITLE
[Network] Fix chunk datapack size and timeout limits

### DIFF
--- a/network/p2p/middleware/middleware.go
+++ b/network/p2p/middleware/middleware.go
@@ -818,7 +818,7 @@ func (m *Middleware) IsConnected(nodeID flow.Identifier) (bool, error) {
 // unicastMaxMsgSize returns the max permissible size for a unicast message
 func unicastMaxMsgSize(messageType string) int {
 	switch messageType {
-	case "*messages.ChunkDataResponse":
+	case "*messages.ChunkDataResponse", "messages.ChunkDataResponse":
 		return LargeMsgMaxUnicastMsgSize
 	default:
 		return DefaultMaxUnicastMsgSize
@@ -843,7 +843,7 @@ func UnicastMaxMsgSizeByCode(payload []byte) (int, error) {
 // unicastMaxMsgDuration returns the max duration to allow for a unicast send to complete
 func (m *Middleware) unicastMaxMsgDuration(messageType string) time.Duration {
 	switch messageType {
-	case "messages.ChunkDataResponse":
+	case "*messages.ChunkDataResponse", "messages.ChunkDataResponse":
 		if LargeMsgUnicastTimeout > m.unicastMessageTimeout {
 			return LargeMsgUnicastTimeout
 		}


### PR DESCRIPTION
I ran into an issue on benchnet where chunk data packs exceeded 10MB, resulting in ENs failing to send responses.

There was a previous change that fixed this issue on the receiving side: https://github.com/onflow/flow-go/pull/4530. This uses a different [code path](https://github.com/onflow/flow-go/blob/master/network/p2p/middleware/middleware.go#L647-L647), and the `messageType` field includes a `*`.

On the sending side, the [code path](https://github.com/onflow/flow-go/blob/master/network/p2p/middleware/middleware.go#L369-L369) explicitly removes the `*`:
https://github.com/onflow/flow-go/blob/cc67154583f10942b7990bd91d5516069fec4517/network/message_scope.go#L199-L201

This PR adds a tactical fix to accept either format, but we should also revisit this logic to make it more consistent.