### PR TITLE
[Networking] Relocate the logic for creating the spork ID within the test code

### DIFF
--- a/network/alsp/manager/manager_test.go
+++ b/network/alsp/manager/manager_test.go
@@ -52,10 +52,16 @@ func TestNetworkPassesReportedMisbehavior(t *testing.T) {
 		return ch
 	}()
 
+	sporkId := unittest.IdentifierFixture()
 	misbehaviorReportManger.On("Ready").Return(readyDoneChan).Once()
 	misbehaviorReportManger.On("Done").Return(readyDoneChan).Once()
-	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, 1)
-	mws, _ := testutils.MiddlewareFixtures(t, ids, nodes, testutils.MiddlewareConfigFixture(t), mocknetwork.NewViolationsConsumer(t))
+	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, sporkId, 1)
+	mws, _ := testutils.MiddlewareFixtures(
+		t,
+		ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(t, sporkId),
+		mocknetwork.NewViolationsConsumer(t))
 
 	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], ids, mws[0])
 	net, err := p2p.NewNetwork(networkCfg, p2p.WithAlspManager(misbehaviorReportManger))
@@ -111,8 +117,15 @@ func TestHandleReportedMisbehavior_Cache_Integration(t *testing.T) {
 			return cache
 		}),
 	}
-	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, 1)
-	mws, _ := testutils.MiddlewareFixtures(t, ids, nodes, testutils.MiddlewareConfigFixture(t), mocknetwork.NewViolationsConsumer(t))
+
+	sporkId := unittest.IdentifierFixture()
+	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, sporkId, 1)
+	mws, _ := testutils.MiddlewareFixtures(
+		t,
+		ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(t, sporkId),
+		mocknetwork.NewViolationsConsumer(t))
 	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], ids, mws[0], p2p.WithAlspConfig(cfg))
 	net, err := p2p.NewNetwork(networkCfg)
 	require.NoError(t, err)
@@ -205,9 +218,18 @@ func TestHandleReportedMisbehavior_And_DisallowListing_Integration(t *testing.T)
 		}),
 	}
 
-	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, 3,
+	sporkId := unittest.IdentifierFixture()
+	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(
+		t,
+		sporkId,
+		3,
 		p2ptest.WithPeerManagerEnabled(p2ptest.PeerManagerConfigFixture(), nil))
-	mws, _ := testutils.MiddlewareFixtures(t, ids, nodes, testutils.MiddlewareConfigFixture(t), mocknetwork.NewViolationsConsumer(t))
+	mws, _ := testutils.MiddlewareFixtures(
+		t,
+		ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(t, sporkId),
+		mocknetwork.NewViolationsConsumer(t))
 	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], ids, mws[0], p2p.WithAlspConfig(cfg))
 	victimNetwork, err := p2p.NewNetwork(networkCfg)
 	require.NoError(t, err)
@@ -278,11 +300,21 @@ func TestHandleReportedMisbehavior_And_DisallowListing_Integration(t *testing.T)
 // The test ensures that despite attempting on connections, no inbound or outbound connections between the victim and
 // the pruned spammer nodes are established.
 func TestHandleReportedMisbehavior_And_SlashingViolationsConsumer_Integration(t *testing.T) {
-
+	sporkId := unittest.IdentifierFixture()
 	// create 1 victim node, 1 honest node and a node for each slashing violation
-	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, 7) // creates 7 nodes (1 victim, 1 honest, 5 spammer nodes one for each slashing violation).
-	mws, _ := testutils.MiddlewareFixtures(t, ids, nodes, testutils.MiddlewareConfigFixture(t), mocknetwork.NewViolationsConsumer(t))
-	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], ids, mws[0], p2p.WithAlspConfig(managerCfgFixture(t)))
+	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, sporkId, 7) // creates 7 nodes (1 victim, 1 honest, 5 spammer nodes one for each slashing violation).
+	mws, _ := testutils.MiddlewareFixtures(
+		t,
+		ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(t, sporkId),
+		mocknetwork.NewViolationsConsumer(t))
+	networkCfg := testutils.NetworkConfigFixture(
+		t,
+		*ids[0],
+		ids,
+		mws[0],
+		p2p.WithAlspConfig(managerCfgFixture(t)))
 	victimNetwork, err := p2p.NewNetwork(networkCfg)
 	require.NoError(t, err)
 
@@ -371,8 +403,9 @@ func TestMisbehaviorReportMetrics(t *testing.T) {
 	alspMetrics := mockmodule.NewAlspMetrics(t)
 	cfg.AlspMetrics = alspMetrics
 
-	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, 1)
-	mws, _ := testutils.MiddlewareFixtures(t, ids, nodes, testutils.MiddlewareConfigFixture(t), mocknetwork.NewViolationsConsumer(t))
+	sporkId := unittest.IdentifierFixture()
+	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(t, sporkId, 1)
+	mws, _ := testutils.MiddlewareFixtures(t, ids, nodes, testutils.MiddlewareConfigFixture(t, sporkId), mocknetwork.NewViolationsConsumer(t))
 	networkCfg := testutils.NetworkConfigFixture(t, *ids[0], ids, mws[0], p2p.WithAlspConfig(cfg))
 	net, err := p2p.NewNetwork(networkCfg)
 	require.NoError(t, err)

--- a/network/internal/testutils/testUtil.go
+++ b/network/internal/testutils/testUtil.go
@@ -116,9 +116,9 @@ func NewTagWatchingConnManager(log zerolog.Logger, metrics module.LibP2PConnecti
 // If you want to create a standalone LibP2PNode without network and middleware components, please use p2ptest.NodeFixture.
 // Args:
 //
-//		t: testing.T- the test object
-//		sporkId: flow.Identifier - the spork id to use for the nodes
-//	 n: int - number of nodes to create
+//	t: testing.T- the test object
+//	sporkId: flow.Identifier - the spork id to use for the nodes
+//	n: int - number of nodes to create
 //
 // opts: []p2ptest.NodeFixtureParameterOption - options to configure the nodes
 // Returns:

--- a/network/internal/testutils/testUtil.go
+++ b/network/internal/testutils/testUtil.go
@@ -39,8 +39,6 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-var sporkID = unittest.IdentifierFixture()
-
 // RateLimitConsumer p2p.RateLimiterConsumer fixture that invokes a callback when rate limit event is consumed.
 type RateLimitConsumer struct {
 	callback func(pid peer.ID, role, msgType, topic, reason string) // callback func that will be invoked on rate limit
@@ -118,9 +116,10 @@ func NewTagWatchingConnManager(log zerolog.Logger, metrics module.LibP2PConnecti
 // If you want to create a standalone LibP2PNode without network and middleware components, please use p2ptest.NodeFixture.
 // Args:
 //
-//	t: testing.T- the test object
+//		t: testing.T- the test object
+//		sporkId: flow.Identifier - the spork id to use for the nodes
+//	 n: int - number of nodes to create
 //
-// n: int - number of nodes to create
 // opts: []p2ptest.NodeFixtureParameterOption - options to configure the nodes
 // Returns:
 //
@@ -128,8 +127,7 @@ func NewTagWatchingConnManager(log zerolog.Logger, metrics module.LibP2PConnecti
 //
 // []p2p.LibP2PNode - list of libp2p nodes created.
 // []observable.Observable - list of observables created for each node.
-func LibP2PNodeForMiddlewareFixture(t *testing.T, n int, opts ...p2ptest.NodeFixtureParameterOption) (flow.IdentityList, []p2p.LibP2PNode, []observable.Observable) {
-
+func LibP2PNodeForMiddlewareFixture(t *testing.T, sporkId flow.Identifier, n int, opts ...p2ptest.NodeFixtureParameterOption) (flow.IdentityList, []p2p.LibP2PNode, []observable.Observable) {
 	libP2PNodes := make([]p2p.LibP2PNode, 0)
 	identities := make(flow.IdentityList, 0)
 	tagObservables := make([]observable.Observable, 0)
@@ -147,7 +145,7 @@ func LibP2PNodeForMiddlewareFixture(t *testing.T, n int, opts ...p2ptest.NodeFix
 
 		opts = append(opts, p2ptest.WithConnectionManager(connManager))
 		node, nodeId := p2ptest.NodeFixture(t,
-			sporkID,
+			sporkId,
 			t.Name(),
 			idProvider,
 			opts...)
@@ -164,11 +162,11 @@ func LibP2PNodeForMiddlewareFixture(t *testing.T, n int, opts ...p2ptest.NodeFix
 // - t: the test instance.
 // Returns:
 // - a middleware config.
-func MiddlewareConfigFixture(t *testing.T) *middleware.Config {
+func MiddlewareConfigFixture(t *testing.T, sporkId flow.Identifier) *middleware.Config {
 	return &middleware.Config{
 		Logger:                unittest.Logger(),
 		BitSwapMetrics:        metrics.NewNoopCollector(),
-		RootBlockID:           sporkID,
+		RootBlockID:           sporkId,
 		UnicastMessageTimeout: middleware.DefaultUnicastTimeout,
 		Codec:                 unittest.NetworkCodec(),
 	}

--- a/network/test/blob_service_test.go
+++ b/network/test/blob_service_test.go
@@ -82,7 +82,9 @@ func (suite *BlobServiceTestSuite) SetupTest() {
 
 	signalerCtx := irrecoverable.NewMockSignalerContext(suite.T(), ctx)
 
+	sporkId := unittest.IdentifierFixture()
 	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(suite.T(),
+		sporkId,
 		suite.numNodes,
 		p2ptest.WithDHTOptions(dht.AsServer()),
 		p2ptest.WithPeerManagerEnabled(&p2pconfig.PeerManagerConfig{
@@ -90,7 +92,12 @@ func (suite *BlobServiceTestSuite) SetupTest() {
 			ConnectionPruning: true,
 			ConnectorFactory:  connection.DefaultLibp2pBackoffConnectorFactory(),
 		}, nil))
-	mws, _ := testutils.MiddlewareFixtures(suite.T(), ids, nodes, testutils.MiddlewareConfigFixture(suite.T()), mocknetwork.NewViolationsConsumer(suite.T()))
+	mws, _ := testutils.MiddlewareFixtures(
+		suite.T(),
+		ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(suite.T(), sporkId),
+		mocknetwork.NewViolationsConsumer(suite.T()))
 	suite.networks = testutils.NetworksFixture(suite.T(), ids, mws)
 	testutils.StartNodesAndNetworks(signalerCtx, suite.T(), nodes, suite.networks, 100*time.Millisecond)
 

--- a/network/test/echoengine_test.go
+++ b/network/test/echoengine_test.go
@@ -54,8 +54,14 @@ func (suite *EchoEngineTestSuite) SetupTest() {
 
 	// both nodes should be of the same role to get connected on epidemic dissemination
 	var nodes []p2p.LibP2PNode
-	suite.ids, nodes, _ = testutils.LibP2PNodeForMiddlewareFixture(suite.T(), count)
-	suite.mws, _ = testutils.MiddlewareFixtures(suite.T(), suite.ids, nodes, testutils.MiddlewareConfigFixture(suite.T()), mocknetwork.NewViolationsConsumer(suite.T()))
+	sporkId := unittest.IdentifierFixture()
+	suite.ids, nodes, _ = testutils.LibP2PNodeForMiddlewareFixture(suite.T(), sporkId, count)
+	suite.mws, _ = testutils.MiddlewareFixtures(
+		suite.T(),
+		suite.ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(suite.T(), sporkId),
+		mocknetwork.NewViolationsConsumer(suite.T()))
 	suite.nets = testutils.NetworksFixture(suite.T(), suite.ids, suite.mws)
 	testutils.StartNodesAndNetworks(signalerCtx, suite.T(), nodes, suite.nets, 100*time.Millisecond)
 }

--- a/network/test/epochtransition_test.go
+++ b/network/test/epochtransition_test.go
@@ -181,8 +181,14 @@ func (suite *MutableIdentityTableSuite) addNodes(count int) {
 	signalerCtx := irrecoverable.NewMockSignalerContext(suite.T(), ctx)
 
 	// create the ids, middlewares and networks
-	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(suite.T(), count)
-	mws, _ := testutils.MiddlewareFixtures(suite.T(), ids, nodes, testutils.MiddlewareConfigFixture(suite.T()), mocknetwork.NewViolationsConsumer(suite.T()))
+	sporkId := unittest.IdentifierFixture()
+	ids, nodes, _ := testutils.LibP2PNodeForMiddlewareFixture(suite.T(), sporkId, count)
+	mws, _ := testutils.MiddlewareFixtures(
+		suite.T(),
+		ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(suite.T(), sporkId),
+		mocknetwork.NewViolationsConsumer(suite.T()))
 	nets := testutils.NetworksFixture(suite.T(), ids, mws)
 	suite.cancels = append(suite.cancels, cancel)
 

--- a/network/test/meshengine_test.go
+++ b/network/test/meshengine_test.go
@@ -72,8 +72,14 @@ func (suite *MeshEngineTestSuite) SetupTest() {
 	signalerCtx := irrecoverable.NewMockSignalerContext(suite.T(), ctx)
 
 	var nodes []p2p.LibP2PNode
-	suite.ids, nodes, obs = testutils.LibP2PNodeForMiddlewareFixture(suite.T(), count)
-	suite.mws, _ = testutils.MiddlewareFixtures(suite.T(), suite.ids, nodes, testutils.MiddlewareConfigFixture(suite.T()), mocknetwork.NewViolationsConsumer(suite.T()))
+	sporkId := unittest.IdentifierFixture()
+	suite.ids, nodes, obs = testutils.LibP2PNodeForMiddlewareFixture(suite.T(), sporkId, count)
+	suite.mws, _ = testutils.MiddlewareFixtures(
+		suite.T(),
+		suite.ids,
+		nodes,
+		testutils.MiddlewareConfigFixture(suite.T(), sporkId),
+		mocknetwork.NewViolationsConsumer(suite.T()))
 	suite.nets = testutils.NetworksFixture(suite.T(), suite.ids, suite.mws)
 	testutils.StartNodesAndNetworks(signalerCtx, suite.T(), nodes, suite.nets, 100*time.Millisecond)
 

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -167,7 +167,12 @@ func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
 	// create a new staked identity
 	sporkId := unittest.IdentifierFixture()
 	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(), sporkId, 1)
-	mws, providers := testutils.MiddlewareFixtures(m.T(), ids, libP2PNodes, testutils.MiddlewareConfigFixture(m.T()), m.slashingViolationsConsumer)
+	mws, providers := testutils.MiddlewareFixtures(
+		m.T(),
+		ids,
+		libP2PNodes,
+		testutils.MiddlewareConfigFixture(m.T(), sporkId),
+		m.slashingViolationsConsumer)
 	require.Len(m.T(), ids, 1)
 	require.Len(m.T(), providers, 1)
 	require.Len(m.T(), mws, 1)
@@ -265,7 +270,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	mws, providers := testutils.MiddlewareFixtures(m.T(),
 		ids,
 		libP2PNodes,
-		testutils.MiddlewareConfigFixture(m.T()),
+		testutils.MiddlewareConfigFixture(m.T(), sporkId),
 		m.slashingViolationsConsumer,
 		middleware.WithUnicastRateLimiters(rateLimiters),
 		middleware.WithPeerManagerFilters([]p2p.PeerFilter{testutils.IsRateLimitedPeerFilter(messageRateLimiter)}))
@@ -421,7 +426,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 	mws, providers := testutils.MiddlewareFixtures(m.T(),
 		ids,
 		libP2PNodes,
-		testutils.MiddlewareConfigFixture(m.T()),
+		testutils.MiddlewareConfigFixture(m.T(), sporkId),
 		m.slashingViolationsConsumer,
 		middleware.WithUnicastRateLimiters(rateLimiters),
 		middleware.WithPeerManagerFilters([]p2p.PeerFilter{testutils.IsRateLimitedPeerFilter(bandwidthRateLimiter)}))

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -71,16 +71,16 @@ func (co *tagsObserver) OnComplete() {
 type MiddlewareTestSuite struct {
 	suite.Suite
 	sync.RWMutex
-	size      int // used to determine number of middlewares under test
-	nodes     []p2p.LibP2PNode
-	mws       []network.Middleware // used to keep track of middlewares under test
-	ov        []*mocknetwork.Overlay
-	obs       chan string // used to keep track of Protect events tagged by pubsub messages
-	ids       []*flow.Identity
-	metrics   *metrics.NoopCollector // no-op performance monitoring simulation
-	logger    zerolog.Logger
-	providers []*unittest.UpdatableIDProvider
-
+	size                       int // used to determine number of middlewares under test
+	nodes                      []p2p.LibP2PNode
+	mws                        []network.Middleware // used to keep track of middlewares under test
+	ov                         []*mocknetwork.Overlay
+	obs                        chan string // used to keep track of Protect events tagged by pubsub messages
+	ids                        []*flow.Identity
+	metrics                    *metrics.NoopCollector // no-op performance monitoring simulation
+	logger                     zerolog.Logger
+	providers                  []*unittest.UpdatableIDProvider
+	sporkId                    flow.Identifier
 	mwCancel                   context.CancelFunc
 	mwCtx                      irrecoverable.SignalerContext
 	slashingViolationsConsumer network.ViolationsConsumer
@@ -108,13 +108,13 @@ func (m *MiddlewareTestSuite) SetupTest() {
 	}
 
 	m.slashingViolationsConsumer = mocknetwork.NewViolationsConsumer(m.T())
-	sporkId := unittest.IdentifierFixture()
-	m.ids, m.nodes, obs = testutils.LibP2PNodeForMiddlewareFixture(m.T(), sporkId, m.size)
+	m.sporkId = unittest.IdentifierFixture()
+	m.ids, m.nodes, obs = testutils.LibP2PNodeForMiddlewareFixture(m.T(), m.sporkId, m.size)
 	m.mws, m.providers = testutils.MiddlewareFixtures(
 		m.T(),
 		m.ids,
 		m.nodes,
-		testutils.MiddlewareConfigFixture(m.T(), sporkId),
+		testutils.MiddlewareConfigFixture(m.T(), m.sporkId),
 		m.slashingViolationsConsumer)
 	for _, observableConnMgr := range obs {
 		observableConnMgr.Subscribe(&ob)
@@ -165,13 +165,12 @@ func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
 	irrecoverableCtx := irrecoverable.NewMockSignalerContext(m.T(), ctx)
 
 	// create a new staked identity
-	sporkId := unittest.IdentifierFixture()
-	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(), sporkId, 1)
+	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(), m.sporkId, 1)
 	mws, providers := testutils.MiddlewareFixtures(
 		m.T(),
 		ids,
 		libP2PNodes,
-		testutils.MiddlewareConfigFixture(m.T(), sporkId),
+		testutils.MiddlewareConfigFixture(m.T(), m.sporkId),
 		m.slashingViolationsConsumer)
 	require.Len(m.T(), ids, 1)
 	require.Len(m.T(), providers, 1)
@@ -253,9 +252,8 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	rateLimiters := ratelimit.NewRateLimiters(opts...)
 
 	idProvider := unittest.NewUpdatableIDProvider(m.ids)
-	sporkId := unittest.IdentifierFixture()
 	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(),
-		sporkId,
+		m.sporkId,
 		1,
 		p2ptest.WithUnicastRateLimitDistributor(distributor),
 		p2ptest.WithConnectionGater(p2ptest.NewConnectionGater(idProvider, func(pid peer.ID) error {
@@ -270,7 +268,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	mws, providers := testutils.MiddlewareFixtures(m.T(),
 		ids,
 		libP2PNodes,
-		testutils.MiddlewareConfigFixture(m.T(), sporkId),
+		testutils.MiddlewareConfigFixture(m.T(), m.sporkId),
 		m.slashingViolationsConsumer,
 		middleware.WithUnicastRateLimiters(rateLimiters),
 		middleware.WithPeerManagerFilters([]p2p.PeerFilter{testutils.IsRateLimitedPeerFilter(messageRateLimiter)}))
@@ -407,9 +405,8 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 
 	idProvider := unittest.NewUpdatableIDProvider(m.ids)
 	// create a new staked identity
-	sporkId := unittest.IdentifierFixture()
 	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(),
-		sporkId,
+		m.sporkId,
 		1,
 		p2ptest.WithUnicastRateLimitDistributor(distributor),
 		p2ptest.WithConnectionGater(p2ptest.NewConnectionGater(idProvider, func(pid peer.ID) error {
@@ -426,7 +423,7 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 	mws, providers := testutils.MiddlewareFixtures(m.T(),
 		ids,
 		libP2PNodes,
-		testutils.MiddlewareConfigFixture(m.T(), sporkId),
+		testutils.MiddlewareConfigFixture(m.T(), m.sporkId),
 		m.slashingViolationsConsumer,
 		middleware.WithUnicastRateLimiters(rateLimiters),
 		middleware.WithPeerManagerFilters([]p2p.PeerFilter{testutils.IsRateLimitedPeerFilter(bandwidthRateLimiter)}))

--- a/network/test/middleware_test.go
+++ b/network/test/middleware_test.go
@@ -108,8 +108,14 @@ func (m *MiddlewareTestSuite) SetupTest() {
 	}
 
 	m.slashingViolationsConsumer = mocknetwork.NewViolationsConsumer(m.T())
-	m.ids, m.nodes, obs = testutils.LibP2PNodeForMiddlewareFixture(m.T(), m.size)
-	m.mws, m.providers = testutils.MiddlewareFixtures(m.T(), m.ids, m.nodes, testutils.MiddlewareConfigFixture(m.T()), m.slashingViolationsConsumer)
+	sporkId := unittest.IdentifierFixture()
+	m.ids, m.nodes, obs = testutils.LibP2PNodeForMiddlewareFixture(m.T(), sporkId, m.size)
+	m.mws, m.providers = testutils.MiddlewareFixtures(
+		m.T(),
+		m.ids,
+		m.nodes,
+		testutils.MiddlewareConfigFixture(m.T(), sporkId),
+		m.slashingViolationsConsumer)
 	for _, observableConnMgr := range obs {
 		observableConnMgr.Subscribe(&ob)
 	}
@@ -159,7 +165,8 @@ func (m *MiddlewareTestSuite) TestUpdateNodeAddresses() {
 	irrecoverableCtx := irrecoverable.NewMockSignalerContext(m.T(), ctx)
 
 	// create a new staked identity
-	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(), 1)
+	sporkId := unittest.IdentifierFixture()
+	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(), sporkId, 1)
 	mws, providers := testutils.MiddlewareFixtures(m.T(), ids, libP2PNodes, testutils.MiddlewareConfigFixture(m.T()), m.slashingViolationsConsumer)
 	require.Len(m.T(), ids, 1)
 	require.Len(m.T(), providers, 1)
@@ -241,8 +248,9 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Messages() {
 	rateLimiters := ratelimit.NewRateLimiters(opts...)
 
 	idProvider := unittest.NewUpdatableIDProvider(m.ids)
-
+	sporkId := unittest.IdentifierFixture()
 	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(),
+		sporkId,
 		1,
 		p2ptest.WithUnicastRateLimitDistributor(distributor),
 		p2ptest.WithConnectionGater(p2ptest.NewConnectionGater(idProvider, func(pid peer.ID) error {
@@ -394,7 +402,9 @@ func (m *MiddlewareTestSuite) TestUnicastRateLimit_Bandwidth() {
 
 	idProvider := unittest.NewUpdatableIDProvider(m.ids)
 	// create a new staked identity
+	sporkId := unittest.IdentifierFixture()
 	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(m.T(),
+		sporkId,
 		1,
 		p2ptest.WithUnicastRateLimitDistributor(distributor),
 		p2ptest.WithConnectionGater(p2ptest.NewConnectionGater(idProvider, func(pid peer.ID) error {

--- a/network/test/unicast_authorization_test.go
+++ b/network/test/unicast_authorization_test.go
@@ -73,8 +73,9 @@ func (u *UnicastAuthorizationTestSuite) TearDownTest() {
 
 // setupMiddlewaresAndProviders will setup 2 middlewares that will be used as a sender and receiver in each suite test.
 func (u *UnicastAuthorizationTestSuite) setupMiddlewaresAndProviders(slashingViolationsConsumer network.ViolationsConsumer) {
-	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(u.T(), 2)
-	cfg := testutils.MiddlewareConfigFixture(u.T())
+	sporkId := unittest.IdentifierFixture()
+	ids, libP2PNodes, _ := testutils.LibP2PNodeForMiddlewareFixture(u.T(), sporkId, 2)
+	cfg := testutils.MiddlewareConfigFixture(u.T(), sporkId)
 	mws, providers := testutils.MiddlewareFixtures(u.T(), ids, libP2PNodes, cfg, slashingViolationsConsumer)
 	require.Len(u.T(), ids, 2)
 	require.Len(u.T(), providers, 2)


### PR DESCRIPTION
This pull request represents an improvement in handling spork ID creation within individual tests, moving away from a shared package-level variable. The change addresses several issues that were identified in our previous approach.

1. **Encapsulation**: By relocating the spork ID creation logic to individual tests, we achieve better encapsulation. Previously, the caller was unaware that a spork ID was being created internally, which could lead to confusion and errors if a new spork ID was mistakenly created elsewhere.

2. **Modifiability**: Since the spork ID was a package-level variable, it was susceptible to unnoticed changes, leading to debugging challenges. By managing spork IDs at the test level, we reduce the potential for unexpected modifications.

3. **Flexibility**: The previous design did not allow for the tuning of new components on the shared spork ID when required. Moving the logic to the test level enhances flexibility and allows individual tests to adapt to specific needs.

4. **Network Communication**: The logic ensures that all networking layer instances are on the same spork ID to facilitate communication. This is particularly relevant to most of our networking components, including libp2p.

5. **Test Stability**: The old approach sometimes resulted in flakey tests and difficulties in debugging. By making this change, we anticipate improved stability and maintainability in our test suite.