### PR TITLE
v0.31 handle chunk data pack database close

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -657,6 +657,12 @@ func (exeNode *ExecutionNode) LoadExecutionState(
 	if err != nil {
 		return nil, err
 	}
+	exeNode.builder.ShutdownFunc(func() error {
+		if err := chunkDataPackDB.Close(); err != nil {
+			return fmt.Errorf("error closing chunk data pack database: %w", err)
+		}
+		return nil
+	})
 	chunkDataPacks := storage.NewChunkDataPacks(node.Metrics.Cache, chunkDataPackDB, node.Storage.Collections, exeNode.exeConf.chunkDataPackCacheSize)
 
 	// Needed for gRPC server, make sure to assign to main scoped vars

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -300,6 +300,18 @@ func (s *state) SaveExecutionResults(
 	// but it's the closest thing to atomicity we could have
 	batch := badgerstorage.NewBatch(s.db)
 
+	defer func() {
+		// Rollback if an error occurs during batch operations
+		if err != nil {
+			chunks := result.AllChunkDataPacks()
+			chunkIDs := make([]flow.Identifier, 0, len(chunks))
+			for _, chunk := range chunks {
+				chunkIDs = append(chunkIDs, chunk.ID())
+			}
+			s.chunkDataPacks.Remove(chunkIDs)
+		}
+	}()
+
 	err = s.events.BatchStore(blockID, []flow.EventsList{result.AllEvents()}, batch)
 	if err != nil {
 		return fmt.Errorf("cannot store events: %w", err)

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -308,7 +308,7 @@ func (s *state) SaveExecutionResults(
 			for _, chunk := range chunks {
 				chunkIDs = append(chunkIDs, chunk.ID())
 			}
-			s.chunkDataPacks.Remove(chunkIDs)
+			_ = s.chunkDataPacks.Remove(chunkIDs)
 		}
 	}()
 

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -302,11 +302,11 @@ func (s *state) SaveExecutionResults(
 func (s *state) saveExecutionResults(
 	ctx context.Context,
 	result *execution.ComputationResult,
-) error {
+) (err error) {
 	header := result.ExecutableBlock.Block.Header
 	blockID := header.ID()
 
-	err := s.chunkDataPacks.Store(result.AllChunkDataPacks())
+	err = s.chunkDataPacks.Store(result.AllChunkDataPacks())
 	if err != nil {
 		return fmt.Errorf("can not store multiple chunk data pack: %w", err)
 	}

--- a/storage/badger/chunkDataPacks.go
+++ b/storage/badger/chunkDataPacks.go
@@ -51,13 +51,22 @@ func NewChunkDataPacks(collector module.CacheMetrics, db *badger.DB, collections
 	return &ch
 }
 
-func (ch *ChunkDataPacks) Remove(chunkID flow.Identifier) error {
-	err := operation.RetryOnConflict(ch.db.Update, operation.RemoveChunkDataPack(chunkID))
-	if err != nil {
-		return fmt.Errorf("could not remove chunk datapack: %w", err)
+// Remove removes multiple ChunkDataPacks cs keyed by their ChunkIDs in a batch.
+// No errors are expected during normal operation, even if no entries are matched.
+func (ch *ChunkDataPacks) Remove(chunkIDs []flow.Identifier) error {
+	batch := NewBatch(ch.db)
+
+	for _, c := range chunkIDs {
+		err := ch.BatchRemove(c, batch)
+		if err != nil {
+			return fmt.Errorf("cannot remove chunk data pack: %w", err)
+		}
 	}
-	// TODO Integrate cache removal in a similar way as storage/retrieval is
-	ch.byChunkIDCache.Remove(chunkID)
+
+	err := batch.Flush()
+	if err != nil {
+		return fmt.Errorf("cannot flush batch to remove chunk data pack: %w", err)
+	}
 	return nil
 }
 

--- a/storage/chunkDataPacks.go
+++ b/storage/chunkDataPacks.go
@@ -11,6 +11,10 @@ type ChunkDataPacks interface {
 	// No errors are expected during normal operation, but it may return generic error
 	Store(cs []*flow.ChunkDataPack) error
 
+	// Remove removes multiple ChunkDataPacks cs keyed by their ChunkIDs in a batch.
+	// No errors are expected during normal operation, but it may return generic error
+	Remove(cs []flow.Identifier) error
+
 	// BatchStore inserts the chunk header, keyed by chunk ID into a given batch
 	BatchStore(c *flow.ChunkDataPack, batch BatchStorage) error
 

--- a/storage/mock/chunk_data_packs.go
+++ b/storage/mock/chunk_data_packs.go
@@ -68,6 +68,20 @@ func (_m *ChunkDataPacks) ByChunkID(chunkID flow.Identifier) (*flow.ChunkDataPac
 	return r0, r1
 }
 
+// Remove provides a mock function with given fields: cs
+func (_m *ChunkDataPacks) Remove(cs []flow.Identifier) error {
+	ret := _m.Called(cs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]flow.Identifier) error); ok {
+		r0 = rf(cs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Store provides a mock function with given fields: cs
 func (_m *ChunkDataPacks) Store(cs []*flow.ChunkDataPack) error {
 	ret := _m.Called(cs)


### PR DESCRIPTION
Backport [the fix](https://github.com/onflow/flow-go/pull/4618/files) to v0.31

- Close the chunk data pack database during shutdown 
- Rollback stored chunk data packs when fail to store execution result