### PR TITLE
Change queue.String() to iterate through children

### DIFF
--- a/module/mempool/queue/queue.go
+++ b/module/mempool/queue/queue.go
@@ -171,16 +171,27 @@ func (q *Queue) Dismount() (Blockify, []*Queue) {
 }
 
 func (q *Queue) String() string {
-	var builder strings.Builder
+	builder := new(strings.Builder)
 	builder.WriteString(fmt.Sprintf("Header: %v\n", q.Head.Item.ID()))
 	builder.WriteString(fmt.Sprintf("Highest: %v\n", q.Highest.Item.ID()))
 	builder.WriteString(fmt.Sprintf("Size: %v, Height: %v\n", q.Size(), q.Height()))
-	for _, node := range q.Nodes {
-		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: %v)\n",
-			node.Item.Height(),
-			node.Item.ID(),
-			len(node.Children),
-		))
-	}
+	builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: %v)\n",
+		q.Head.Item.Height(),
+		q.Head.Item.ID(),
+		len(q.Head.Children),
+	))
+	printChildren(builder, q.Head, "")
 	return builder.String()
+}
+
+func printChildren(builder *strings.Builder, n *Node, prefix string) {
+	for _, child := range n.Children {
+		builder.WriteString(fmt.Sprintf("%s Node(height: %v): %v (children: %v)\n",
+			prefix+"|-",
+			child.Item.Height(),
+			child.Item.ID(),
+			len(child.Children),
+		))
+		printChildren(builder, child, prefix+"   ")
+	}
 }

--- a/module/mempool/queue/queue_test.go
+++ b/module/mempool/queue/queue_test.go
@@ -292,7 +292,6 @@ func TestQueue(t *testing.T) {
 	//})
 
 	t.Run("String()", func(t *testing.T) {
-		unittest.SkipUnless(t, unittest.TEST_FLAKY, "flakey, because String will iterate through a map, which is not determinsitic")
 		// a <- c <- d <- f
 		queue := NewQueue(a)
 		stored, _ := queue.TryAdd(c)
@@ -306,9 +305,9 @@ func TestQueue(t *testing.T) {
 		builder.WriteString(fmt.Sprintf("Highest: %v\n", f.ID()))
 		builder.WriteString("Size: 4, Height: 3\n")
 		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 1)\n", a.Height(), a.ID()))
-		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 1)\n", c.Height(), c.ID()))
-		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 1)\n", d.Height(), d.ID()))
-		builder.WriteString(fmt.Sprintf("Node(height: %v): %v (children: 0)\n", f.Height(), f.ID()))
+		builder.WriteString(fmt.Sprintf("|- Node(height: %v): %v (children: 1)\n", c.Height(), c.ID()))
+		builder.WriteString(fmt.Sprintf("   |- Node(height: %v): %v (children: 1)\n", d.Height(), d.ID()))
+		builder.WriteString(fmt.Sprintf("      |- Node(height: %v): %v (children: 0)\n", f.Height(), f.ID()))
 		require.Equal(t, builder.String(), queue.String())
 	})
 }


### PR DESCRIPTION
A slight change to the string function to remove the previously seen flakey behaviour, + add levels to the children printed