### PR TITLE
[Crypto] C code sanitization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: true
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
     - name: Install C formatter
       run: sudo apt-get install -y clang-format
     - name: Run C formatter and sanitizer for ./crypto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
       uses: mxschmitt/action-tmate@v3
     - name: Install C formatter
       run: sudo apt-get install -y clang-format
-    - name: Run C formatter for ./crypto
-      run: make -C crypto c-format
+    - name: Run C formatter and sanitizer for ./crypto
+      run: make -C crypto c-format && make -C crypto c-sanitize
     - name: Run go generate
       run: go generate
       working-directory: ${{ matrix.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
           cache: true
       - name: Run tidy
         run: make tidy
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
   create-dynamic-test-matrix:
     name: Create Dynamic Test Matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: true
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Install C formatter
       run: sudo apt-get install -y clang-format
     - name: Run C formatter for ./crypto
@@ -69,8 +71,6 @@ jobs:
           cache: true
       - name: Run tidy
         run: make tidy
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
   create-dynamic-test-matrix:
     name: Create Dynamic Test Matrix

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -38,6 +38,19 @@ c-format:
 	rm -f .clang-format
 	git diff --exit-code
 
+# sanitize C code
+# cannot run on macos
+.PHONY: c-sanitize
+c-format:
+# memory sanitization
+	$(CGO_FLAG) CC="clang -O0 -g -fsanitize=memory -fno-omit-frame-pointer" \
+	LD="-fsanitize=memory" go test \
+	if [ $$? -ne 0 ]; then exit 1; fi
+# address sanitization and other checks
+	$(CGO_FLAG) CC="clang -O0 -g -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize=null -fno-sanitize=alignment" \
+	LD="-fsanitize=address" go test \
+	if [ $$? -ne 0 ]; then exit 1; fi
+
 # Go tidy
 .PHONY: go-tidy
 go-tidy:

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -46,7 +46,7 @@ c-format:
 c-asan:
 # - address sanitization and other checks (only on linux)
 	if [ $(UNAME) = "Linux" ]; then \
-		$(CGO_FLAG) CC="-O0 -g -fsanitize=address -fno-omit-frame-pointer -fsanitize=leak -fsanitize=undefined -fno-sanitize-recover=all -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize=null -fno-sanitize=alignment" \
+		$(CGO_FLAG) CC="clang -O0 -g -fsanitize=address -fno-omit-frame-pointer -fsanitize=leak -fsanitize=undefined -fno-sanitize-recover=all -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize=null -fno-sanitize=alignment" \
 		LD="-fsanitize=address -fsanitize=leak" go test; \
 		if [ $$? -ne 0 ]; then exit 1; fi; \
 	else \

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -41,9 +41,9 @@ c-format:
 # sanitize C code
 # cannot run on macos
 .PHONY: c-sanitize
-c-format:
+c-sanitize:
 # memory sanitization
-	$(CGO_FLAG) CC="clang -O0 -g -fsanitize=memory -fno-omit-frame-pointer" \
+	$(CGO_FLAG) CC="clang -O -D__BLST_PORTABLE__ -O0 -g -fsanitize=memory -fno-omit-frame-pointer" \
 	LD="-fsanitize=memory" go test \
 	if [ $$? -ne 0 ]; then exit 1; fi
 # address sanitization and other checks

--- a/crypto/bls12381_utils.c
+++ b/crypto/bls12381_utils.c
@@ -22,7 +22,7 @@ const Fr BLS12_381_rR = {{
 
 // returns true if a == 0 and false otherwise
 bool Fr_is_zero(const Fr *a) {
-  return bytes_are_zero((const byte *)a, sizeof(Fr));
+  return vec_is_zero(a, sizeof(Fr));
 }
 
 // returns true if a == b and false otherwise

--- a/crypto/bls12381_utils.c
+++ b/crypto/bls12381_utils.c
@@ -540,13 +540,7 @@ ERROR E1_read_bytes(E1 *a, const byte *bin, const int len) {
 // uncompressed form. It assumes buffer is of length G1_SER_BYTES The
 // serialization follows:
 // https://www.ietf.org/archive/id/draft-irtf-cfrg-pairing-friendly-curves-08.html#name-zcash-serialization-format-)
-#if defined(__has_feature) && __has_feature(memory_sanitizer)
-// disable memory sanitization in this function because of a use-of-uninitialized-value
-// false positive.
-void __attribute__((no_sanitize("memory"))) E1_write_bytes(byte *bin, const E1 *a) {
-#else
 void E1_write_bytes(byte *bin, const E1 *a) {
-#endif
   if (E1_is_infty(a)) {
     // set the infinity bit
     bin[0] = (G1_SERIALIZATION << 7) | (1 << 6);
@@ -1063,7 +1057,7 @@ void xmd_sha256(byte *hash, int len_hash, byte *msg, int len_msg, byte *dst,
 }
 
 // DEBUG printing functions
-#if (DEBUG == 1)
+#ifdef DEBUG 
 void bytes_print_(char *s, byte *data, int len) {
   if (strlen(s))
     printf("[%s]:\n", s);

--- a/crypto/bls12381_utils.c
+++ b/crypto/bls12381_utils.c
@@ -21,9 +21,7 @@ const Fr BLS12_381_rR = {{
 }};
 
 // returns true if a == 0 and false otherwise
-bool Fr_is_zero(const Fr *a) {
-  return vec_is_zero(a, sizeof(Fr));
-}
+bool Fr_is_zero(const Fr *a) { return vec_is_zero(a, sizeof(Fr)); }
 
 // returns true if a == b and false otherwise
 bool Fr_is_equal(const Fr *a, const Fr *b) {
@@ -1057,7 +1055,7 @@ void xmd_sha256(byte *hash, int len_hash, byte *msg, int len_msg, byte *dst,
 }
 
 // DEBUG printing functions
-#ifdef DEBUG 
+#ifdef DEBUG
 void bytes_print_(char *s, byte *data, int len) {
   if (strlen(s))
     printf("[%s]:\n", s);

--- a/crypto/bls12381_utils.go
+++ b/crypto/bls12381_utils.go
@@ -4,10 +4,9 @@ package crypto
 // these tools are shared by the BLS signature scheme, the BLS based threshold signature
 // and the BLS distributed key generation protocols
 
-// #cgo CFLAGS: -O -D__BLST_PORTABLE__ -O0 -g -fsanitize=address -I${SRCDIR}/ -I${SRCDIR}/blst_src -I${SRCDIR}/blst_src/build -D__BLST_CGO__ -fno-builtin-memcpy -fno-builtin-memset -Wall -Wno-unused-function -Wno-unused-macros
+// #cgo CFLAGS: -I${SRCDIR}/ -I${SRCDIR}/blst_src -I${SRCDIR}/blst_src/build -D__BLST_CGO__ -fno-builtin-memcpy -fno-builtin-memset -Wall -Wno-unused-function -Wno-unused-macros
 // #cgo amd64 CFLAGS: -D__ADX__ -mno-avx
 // #cgo mips64 mips64le ppc64 ppc64le riscv64 s390x CFLAGS: -D__BLST_NO_ASM__
-// #cgo LDFLAGS: -fsanitize=address
 // #include "bls12381_utils.h"
 //
 // #if defined(__x86_64__) && (defined(__unix__) || defined(__APPLE__))

--- a/crypto/bls12381_utils.go
+++ b/crypto/bls12381_utils.go
@@ -4,9 +4,10 @@ package crypto
 // these tools are shared by the BLS signature scheme, the BLS based threshold signature
 // and the BLS distributed key generation protocols
 
-// #cgo CFLAGS: -I${SRCDIR}/ -I${SRCDIR}/blst_src -I${SRCDIR}/blst_src/build -D__BLST_CGO__ -fno-builtin-memcpy -fno-builtin-memset -Wall -Wno-unused-function -Wno-unused-macros
+// #cgo CFLAGS: -O -D__BLST_PORTABLE__ -O0 -g -fsanitize=address -I${SRCDIR}/ -I${SRCDIR}/blst_src -I${SRCDIR}/blst_src/build -D__BLST_CGO__ -fno-builtin-memcpy -fno-builtin-memset -Wall -Wno-unused-function -Wno-unused-macros
 // #cgo amd64 CFLAGS: -D__ADX__ -mno-avx
 // #cgo mips64 mips64le ppc64 ppc64le riscv64 s390x CFLAGS: -D__BLST_NO_ASM__
+// #cgo LDFLAGS: -fsanitize=address
 // #include "bls12381_utils.h"
 //
 // #if defined(__x86_64__) && (defined(__unix__) || defined(__APPLE__))

--- a/crypto/bls12381_utils.go
+++ b/crypto/bls12381_utils.go
@@ -16,8 +16,8 @@ package crypto
 // static void handler(int signum)
 // {	char text[1024] = "Caught SIGILL in blst_cgo_init, BLST library (used by flow-go/crypto) requires ADX support, build with CGO_CFLAGS=\"-O -D__BLST_PORTABLE__\"\n";
 //		ssize_t n = write(2, &text, strlen(text));
-//     _exit(128+SIGILL);
-//     (void)n;
+//      _exit(128+SIGILL);
+//      (void)n;
 // }
 // __attribute__((constructor)) static void flow_crypto_cgo_init()
 // {   Fp temp = { 0 };

--- a/crypto/bls12381_utils.h
+++ b/crypto/bls12381_utils.h
@@ -129,7 +129,7 @@ void Fp12_multi_pairing(Fp12 *, const E1 *, const E2 *, const int);
 void xmd_sha256(byte *, int, byte *, int, byte *, int);
 
 // Debugging related functions
-// DEBUG can be enabled directly from the Go command: CC="clang -DDEBUG" go test 
+// DEBUG can be enabled directly from the Go command: CC="clang -DDEBUG" go test
 #ifdef DEBUG
 #include <stdio.h>
 void bytes_print_(char *, byte *, int);
@@ -145,11 +145,12 @@ void E2_print_(char *, const E2 *, const int);
 // memory sanitization disabler
 #define NO_MSAN
 #ifdef MSAN
-/* add NO_MSAN to a function defintion to disable MSAN in that function ( void NO_MSAN f(..) {} ) */
+/* add NO_MSAN to a function defintion to disable MSAN in that function ( void
+ * NO_MSAN f(..) {} ) */
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
-// disable memory sanitization in this function because of a use-of-uninitialized-value
-// false positive.
+// disable memory sanitization in this function because of a
+// use-of-uninitialized-value false positive.
 #undef NO_MSAN
 #define NO_MSAN __attribute__((no_sanitize("memory")))
 #endif /* __has_feature(memory_sanitizer) */

--- a/crypto/bls12381_utils.h
+++ b/crypto/bls12381_utils.h
@@ -66,10 +66,7 @@ void Fr_mul_montg(Fr *res, const Fr *a, const Fr *b);
 void Fr_squ_montg(Fr *res, const Fr *a);
 void Fr_to_montg(Fr *res, const Fr *a);
 void Fr_from_montg(Fr *res, const Fr *a);
-void Fr_exp_montg(Fr *res, const Fr *base, const limb_t *expo,
-                  const int expo_len);
 void Fr_inv_montg_eucl(Fr *res, const Fr *a);
-void Fr_inv_exp_montg(Fr *res, const Fr *a);
 ERROR Fr_read_bytes(Fr *a, const byte *bin, int len);
 ERROR Fr_star_read_bytes(Fr *a, const byte *bin, int len);
 void Fr_write_bytes(byte *bin, const Fr *a);

--- a/crypto/bls12381_utils.h
+++ b/crypto/bls12381_utils.h
@@ -129,8 +129,8 @@ void Fp12_multi_pairing(Fp12 *, const E1 *, const E2 *, const int);
 void xmd_sha256(byte *, int, byte *, int, byte *, int);
 
 // Debugging related functions
-#define DEBUG 1
-#if (DEBUG == 1)
+// DEBUG can be enabled directly from the Go command: CC="clang -DDEBUG" go test 
+#ifdef DEBUG
 #include <stdio.h>
 void bytes_print_(char *, byte *, int);
 void Fr_print_(char *, Fr *);
@@ -139,6 +139,21 @@ void Fp2_print_(char *, const Fp2 *);
 void Fp12_print_(char *, const Fp12 *);
 void E1_print_(char *, const E1 *, const int);
 void E2_print_(char *, const E2 *, const int);
+
 #endif /* DEBUG */
+
+// memory sanitization disabler
+#define NO_MSAN
+#ifdef MSAN
+/* add NO_MSAN to a function defintion to disable MSAN in that function ( void NO_MSAN f(..) {} ) */
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+// disable memory sanitization in this function because of a use-of-uninitialized-value
+// false positive.
+#undef NO_MSAN
+#define NO_MSAN __attribute__((no_sanitize("memory")))
+#endif /* __has_feature(memory_sanitizer) */
+#endif /* __has_feature*/
+#endif /*MSAN*/
 
 #endif /* BLS12_381_UTILS */

--- a/crypto/blst_src/README.md
+++ b/crypto/blst_src/README.md
@@ -17,11 +17,13 @@ The folder contains:
 - this `README` file.
 
 To upgrade the BLST version:
-- [ ] delete all files in this folder but `blst_src.c` and `README.md`.
+- [ ] delete all files in this folder (`./blst_src`) but `blst_src.c` and `README.md`.
 - [ ] open BLST repository on the new version.
 - [ ] copy all `.c` and `.h` files from `<blst>/src/` into this folder.
 - [ ] delete `server.c` from this folder.
+- [ ] update `blst_src.c` if needed.
 - [ ] copy the folder `<blst>/build/` into this folder.
+- [ ] move `./blst_src/build/assembly.S` to `./blst_src/build/blst_assembly.S`.
 - [ ] copy `<blst>/bindings/blst.h` and `<blst>/bindings/blst_aux.h` into this folder.
 - [ ] solve all breaking changes that may occur.
 - [ ] update the commit version on this `README`.

--- a/crypto/blst_src/README.md
+++ b/crypto/blst_src/README.md
@@ -9,9 +9,21 @@ While BLST exports multiple functions and tools, the implementation in Flow cryp
 
 The folder contains:
 - BLST LICENSE file
-- all <blst>/src/*.c and <blst>/src/*.h files (C source files)
-- all <blst>/build   (assembly generated files)
-- <blst>/bindings/blst.h  (headers of external functions)
-- <blst>/bindings/blst_aux.h (headers of external aux functions)
+- all `<blst>/src/*.c` and `<blst>/src/*.h` files (C source files) but `server.c`.
+- `server.c` is replaced by `blst_src.c` (which lists only the files needed by Flow crypto).
+- all `<blst>/build`   (assembly generated files).
+- `<blst>/bindings/blst.h`  (headers of external functions).
+- `<blst>/bindings/blst_aux.h` (headers of external aux functions).
+- this `README` file.
 
-TODO: add steps for upgrading the BLST version
+To upgrade the BLST version:
+- [ ] delete all files in this folder but `blst_src.c` and `README.md`.
+- [ ] open BLST repository on the new version.
+- [ ] copy all `.c` and `.h` files from `<blst>/src/` into this folder.
+- [ ] delete `server.c` from this folder.
+- [ ] copy the folder `<blst>/build/` into this folder.
+- [ ] copy `<blst>/bindings/blst.h` and `<blst>/bindings/blst_aux.h` into this folder.
+- [ ] solve all breaking changes that may occur.
+- [ ] update the commit version on this `README`.
+
+Remember that Flow crypto is using non exported internal functions from BLST. Checking for interfaces breaking changes in BLST should made along with auditing changes between the old and new versions. This includes checking logical changes and assumptions beyond interfaces, and assessing their security and performance impact on protocols implemented in Flow crypto. 

--- a/crypto/blst_src/blst_src.c
+++ b/crypto/blst_src/blst_src.c
@@ -1,3 +1,8 @@
+// This file contains all BLST lib C files needed for
+// Flow crypto.
+// 
+// The list may need to be updated in a new version of BLST is used. 
+
 #include "keygen.c"
 #include "hash_to_field.c"
 #include "e1.c"


### PR DESCRIPTION
- add C code sanitizers Makefile targets:
  - memory sanitizer `msan` (only works on Linux and with clang)
  - address sanitizer `asan` (only works on Linux)
  - other sanitizers (only work on Linux)
- add sanitizers (but `msan`) to a CI job and they are required to pass for new PRs
- `msan` has many false positive errors from `use-of-unitialized-value`. These errors have been debugged one by one to make sure no uninitialized memory has been read. 
- `NO_MSAN` macro has been added during debugging to disable `msan` in functions. The macro was left in the code for future debugging. It is only defined when compiling with defined `MSAN` (look at the `c-msan` target in Makefile).

Side changes:
- Update `./bls_src/README` with instructions of updating BLST version.
- clean up non used Fermat modular inversion and Montgomery modular expo. 
- minor optimization to `Fr_is_zero`.
- update `DEBUG` macro .  