### PR TITLE
Update cadence version to v0.41.0-stable-cadence.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,11 +51,11 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.6.0
-	github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1
+	github.com/onflow/cadence v0.41.0-stable-cadence.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20230808220007-f00e74ca675b
-	github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee
+	github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1
 	github.com/onflow/flow-go/crypto v0.24.9
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce
 	github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d

--- a/go.sum
+++ b/go.sum
@@ -1780,8 +1780,8 @@ github.com/onflow/atree v0.5.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
 github.com/onflow/cadence v0.39.13-stable-cadence/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1 h1:ELu6aFiphx4QAQE64EbYidJjc5DQSF087QfJZfamnXY=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
+github.com/onflow/cadence v0.41.0-stable-cadence.1 h1:ATWDm7WaxogV3f99wCEnVcQWZ36FAHya/4dI7ffw2u8=
+github.com/onflow/cadence v0.41.0-stable-cadence.1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
 github.com/onflow/flow v0.3.4 h1:FXUWVdYB90f/rjNcY0Owo30gL790tiYff9Pb/sycXYE=
 github.com/onflow/flow v0.3.4/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4 h1:MyiN3RknOanPPiDpBIdJ43ZrQNppgQUZgy5njPDdF7w=
@@ -1791,8 +1791,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20230808220007-f
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230818200853-ab1b03e98a95 h1:mtQIjtnUQ2axR74YRMSG4rYo5PzWIbToGCdbu0oZjGs=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230818200853-ab1b03e98a95/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
 github.com/onflow/flow-go-sdk v0.41.7-stable-cadence/go.mod h1:ejVN+bqcsTHVvRpDDJDoBNdmcxUfFMW4IvdTbMeQ/hQ=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee h1:zU78xj/94YNYtf4CLGWogCTPyrR+1h3QTalsU/ZEKDg=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee/go.mod h1:JdN8uOpLMFaMTCFSoeck78fYPupTsV7ccvyrDM88nQU=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1 h1:6WjkZS1S0nYdphBsdZcU48mrLpccgfuCNX06ry4/c8c=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1/go.mod h1:aWDwdlvZeX0LTR2buq9D+uPytaZ3hvzxEAMPfLhZCm0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-go/crypto v0.24.9 h1:0EQp+kSZYJepMIiSypfJVe7tzsPcb6UXOdOtsTCDhBs=
 github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -182,11 +182,11 @@ require (
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/onflow/atree v0.6.0 // indirect
-	github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1 // indirect
+	github.com/onflow/cadence v0.41.0-stable-cadence.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20230808220007-f00e74ca675b // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230818200853-ab1b03e98a95 // indirect
-	github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee // indirect
+	github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20230818200521-3acffe2472a3 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce // indirect
 	github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -1770,8 +1770,8 @@ github.com/onflow/atree v0.5.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
 github.com/onflow/cadence v0.39.13-stable-cadence/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1 h1:ELu6aFiphx4QAQE64EbYidJjc5DQSF087QfJZfamnXY=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
+github.com/onflow/cadence v0.41.0-stable-cadence.1 h1:ATWDm7WaxogV3f99wCEnVcQWZ36FAHya/4dI7ffw2u8=
+github.com/onflow/cadence v0.41.0-stable-cadence.1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4 h1:MyiN3RknOanPPiDpBIdJ43ZrQNppgQUZgy5njPDdF7w=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4/go.mod h1:IRraF/nm1xiefjSIkQ6w6ZNzZbUGfB14bzMUNXjrMmo=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20230808220007-f00e74ca675b h1:f+5TwXPwlvtaDwn0ZlMIxibuPwbvmtlnSkeZgAm38Yw=
@@ -1779,8 +1779,8 @@ github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20230808220007-f
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230818200853-ab1b03e98a95 h1:mtQIjtnUQ2axR74YRMSG4rYo5PzWIbToGCdbu0oZjGs=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230818200853-ab1b03e98a95/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
 github.com/onflow/flow-go-sdk v0.41.7-stable-cadence/go.mod h1:ejVN+bqcsTHVvRpDDJDoBNdmcxUfFMW4IvdTbMeQ/hQ=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee h1:zU78xj/94YNYtf4CLGWogCTPyrR+1h3QTalsU/ZEKDg=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee/go.mod h1:JdN8uOpLMFaMTCFSoeck78fYPupTsV7ccvyrDM88nQU=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1 h1:6WjkZS1S0nYdphBsdZcU48mrLpccgfuCNX06ry4/c8c=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1/go.mod h1:aWDwdlvZeX0LTR2buq9D+uPytaZ3hvzxEAMPfLhZCm0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-go/crypto v0.24.9 h1:0EQp+kSZYJepMIiSypfJVe7tzsPcb6UXOdOtsTCDhBs=
 github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -17,12 +17,12 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
-	github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1
+	github.com/onflow/cadence v0.41.0-stable-cadence.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20230808220007-f00e74ca675b
 	github.com/onflow/flow-emulator v0.53.1-0.20230801165926-9fd4af1cce5b
 	github.com/onflow/flow-go v0.31.1-0.20230801162100-85890d2bf9bb
-	github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee
+	github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1
 	github.com/onflow/flow-go/crypto v0.24.9
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1900,8 +1900,8 @@ github.com/onflow/atree v0.5.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
 github.com/onflow/cadence v0.39.13-stable-cadence/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1 h1:ELu6aFiphx4QAQE64EbYidJjc5DQSF087QfJZfamnXY=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
+github.com/onflow/cadence v0.41.0-stable-cadence.1 h1:ATWDm7WaxogV3f99wCEnVcQWZ36FAHya/4dI7ffw2u8=
+github.com/onflow/cadence v0.41.0-stable-cadence.1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4 h1:MyiN3RknOanPPiDpBIdJ43ZrQNppgQUZgy5njPDdF7w=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230822191436-8a95802475f4/go.mod h1:IRraF/nm1xiefjSIkQ6w6ZNzZbUGfB14bzMUNXjrMmo=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20230808220007-f00e74ca675b h1:f+5TwXPwlvtaDwn0ZlMIxibuPwbvmtlnSkeZgAm38Yw=
@@ -1911,8 +1911,8 @@ github.com/onflow/flow-emulator v0.53.1-0.20230801165926-9fd4af1cce5b/go.mod h1:
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230818200853-ab1b03e98a95 h1:mtQIjtnUQ2axR74YRMSG4rYo5PzWIbToGCdbu0oZjGs=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230818200853-ab1b03e98a95/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
 github.com/onflow/flow-go-sdk v0.41.7-stable-cadence/go.mod h1:ejVN+bqcsTHVvRpDDJDoBNdmcxUfFMW4IvdTbMeQ/hQ=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee h1:zU78xj/94YNYtf4CLGWogCTPyrR+1h3QTalsU/ZEKDg=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee/go.mod h1:JdN8uOpLMFaMTCFSoeck78fYPupTsV7ccvyrDM88nQU=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1 h1:6WjkZS1S0nYdphBsdZcU48mrLpccgfuCNX06ry4/c8c=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1/go.mod h1:aWDwdlvZeX0LTR2buq9D+uPytaZ3hvzxEAMPfLhZCm0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-go/crypto v0.24.9 h1:0EQp+kSZYJepMIiSypfJVe7tzsPcb6UXOdOtsTCDhBs=
 github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=


### PR DESCRIPTION
## Description

Update to
- cadence [v0.41.0-stable-cadence.1](https://github.com/onflow/cadence/releases/tag/v0.41.0-stable-cadence.1)
- flow-go-sdk [v0.44.0-stable-cadence.1](https://github.com/onflow/flow-go-sdk/releases/tag/v0.44.0-stable-cadence.1)
