### PR TITLE
[State Sync] Update ExecutionData rpc converters with tx results

### DIFF
--- a/engine/common/rpc/convert/execution_data.go
+++ b/engine/common/rpc/convert/execution_data.go
@@ -77,10 +77,23 @@ func ChunkExecutionDataToMessage(data *execution_data.ChunkExecutionData) (
 		return nil, err
 	}
 
+	var results []*entities.ExecutionDataTransactionResult
+	if len(data.TransactionResults) > 0 {
+		results = make([]*entities.ExecutionDataTransactionResult, len(data.TransactionResults))
+		for i, result := range data.TransactionResults {
+			results[i] = &entities.ExecutionDataTransactionResult{
+				TransactionId:   IdentifierToMessage(result.TransactionID),
+				HasError:        result.HasError,
+				ComputationUsed: result.ComputationUsed,
+			}
+		}
+	}
+
 	return &entities.ChunkExecutionData{
-		Collection: collection,
-		Events:     events,
-		TrieUpdate: trieUpdate,
+		Collection:         collection,
+		Events:             events,
+		TrieUpdate:         trieUpdate,
+		TransactionResults: results,
 	}, nil
 }
 
@@ -107,10 +120,23 @@ func MessageToChunkExecutionData(
 		events = nil
 	}
 
+	var results []execution_data.TransactionResult
+	if len(m.GetTransactionResults()) > 0 {
+		results = make([]execution_data.TransactionResult, len(m.GetTransactionResults()))
+		for i, result := range m.GetTransactionResults() {
+			results[i] = execution_data.TransactionResult{
+				TransactionID:   MessageToIdentifier(result.GetTransactionId()),
+				HasError:        result.GetHasError(),
+				ComputationUsed: result.GetComputationUsed(),
+			}
+		}
+	}
+
 	return &execution_data.ChunkExecutionData{
-		Collection: collection,
-		Events:     events,
-		TrieUpdate: trieUpdate,
+		Collection:         collection,
+		Events:             events,
+		TrieUpdate:         trieUpdate,
+		TransactionResults: results,
 	}, nil
 }
 
@@ -190,6 +216,10 @@ func messageToTrustedCollection(
 	chain flow.Chain,
 ) (*flow.Collection, error) {
 	messages := m.GetTransactions()
+	if len(messages) == 0 {
+		return &flow.Collection{}, nil
+	}
+
 	transactions := make([]*flow.TransactionBody, len(messages))
 	for i, message := range messages {
 		transaction, err := messageToTrustedTransaction(message, chain)
@@ -197,10 +227,6 @@ func messageToTrustedCollection(
 			return nil, fmt.Errorf("could not convert transaction %d: %w", i, err)
 		}
 		transactions[i] = &transaction
-	}
-
-	if len(transactions) == 0 {
-		return nil, nil
 	}
 
 	return &flow.Collection{Transactions: transactions}, nil

--- a/engine/common/rpc/convert/execution_data.go
+++ b/engine/common/rpc/convert/execution_data.go
@@ -83,7 +83,7 @@ func ChunkExecutionDataToMessage(data *execution_data.ChunkExecutionData) (
 		for i, result := range data.TransactionResults {
 			results[i] = &entities.ExecutionDataTransactionResult{
 				TransactionId:   IdentifierToMessage(result.TransactionID),
-				HasError:        result.HasError,
+				Failed:          result.Failed,
 				ComputationUsed: result.ComputationUsed,
 			}
 		}
@@ -126,7 +126,7 @@ func MessageToChunkExecutionData(
 		for i, result := range m.GetTransactionResults() {
 			results[i] = execution_data.TransactionResult{
 				TransactionID:   MessageToIdentifier(result.GetTransactionId()),
-				HasError:        result.GetHasError(),
+				Failed:          result.GetFailed(),
 				ComputationUsed: result.GetComputationUsed(),
 			}
 		}

--- a/engine/common/rpc/convert/execution_data_test.go
+++ b/engine/common/rpc/convert/execution_data_test.go
@@ -28,9 +28,6 @@ func TestConvertBlockExecutionData(t *testing.T) {
 			unittest.WithTrieUpdate(testutils.TrieUpdateFixture(5, 32*1024, 64*1024)),
 		)
 
-		// TODO: remove this line after adding TransactionResult to the ChunkExecutionData entity
-		ced.TransactionResults = nil
-
 		chunkData = append(chunkData, ced)
 	}
 	makeServiceTx := func(ced *execution_data.ChunkExecutionData) {
@@ -44,37 +41,84 @@ func TestConvertBlockExecutionData(t *testing.T) {
 		ced.TrieUpdate = nil
 	}
 	chunk := unittest.ChunkExecutionDataFixture(t, execution_data.DefaultMaxBlobSize/5, unittest.WithChunkEvents(events), makeServiceTx)
-	// TODO: remove this line after adding TransactionResult to the ChunkExecutionData entity
-	chunk.TransactionResults = nil
 	chunkData = append(chunkData, chunk)
 
 	blockData := unittest.BlockExecutionDataFixture(unittest.WithChunkExecutionDatas(chunkData...))
 
-	t.Run("chunk execution data conversions", func(t *testing.T) {
-		chunkMsg, err := convert.ChunkExecutionDataToMessage(chunkData[0])
-		require.NoError(t, err)
+	msg, err := convert.BlockExecutionDataToMessage(blockData)
+	require.NoError(t, err)
 
-		chunkReConverted, err := convert.MessageToChunkExecutionData(chunkMsg, flow.Testnet.Chain())
-		require.NoError(t, err)
+	converted, err := convert.MessageToBlockExecutionData(msg, chain)
+	require.NoError(t, err)
 
-		assert.Equal(t, chunkData[0], chunkReConverted)
-		assert.True(t, chunkData[0].TrieUpdate.Equals(chunkReConverted.TrieUpdate))
-	})
-
-	t.Run("block execution data conversions", func(t *testing.T) {
-		msg, err := convert.BlockExecutionDataToMessage(blockData)
-		require.NoError(t, err)
-
-		converted, err := convert.MessageToBlockExecutionData(msg, chain)
-		require.NoError(t, err)
-
-		assert.Equal(t, blockData, converted)
-		for i, chunk := range blockData.ChunkExecutionDatas {
-			if chunk.TrieUpdate == nil {
-				assert.Nil(t, converted.ChunkExecutionDatas[i].TrieUpdate)
-			} else {
-				assert.True(t, chunk.TrieUpdate.Equals(converted.ChunkExecutionDatas[i].TrieUpdate))
-			}
+	assert.Equal(t, blockData, converted)
+	for i, chunk := range blockData.ChunkExecutionDatas {
+		if chunk.TrieUpdate == nil {
+			assert.Nil(t, converted.ChunkExecutionDatas[i].TrieUpdate)
+		} else {
+			assert.True(t, chunk.TrieUpdate.Equals(converted.ChunkExecutionDatas[i].TrieUpdate))
 		}
-	})
+	}
+}
+
+func TestConvertChunkExecutionData(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(*testing.T) *execution_data.ChunkExecutionData
+	}{
+		{
+			name: "chunk execution data conversions",
+			fn: func(t *testing.T) *execution_data.ChunkExecutionData {
+				return unittest.ChunkExecutionDataFixture(t,
+					0, // updates set explicitly to target 160-320KB per chunk
+					unittest.WithChunkEvents(unittest.EventsFixture(5)),
+					unittest.WithTrieUpdate(testutils.TrieUpdateFixture(5, 32*1024, 64*1024)),
+				)
+			},
+		},
+		{
+			name: "chunk execution data conversions - no events",
+			fn: func(t *testing.T) *execution_data.ChunkExecutionData {
+				ced := unittest.ChunkExecutionDataFixture(t, 0)
+				ced.Events = nil
+				return ced
+			},
+		},
+		{
+			name: "chunk execution data conversions - no trie update",
+			fn: func(t *testing.T) *execution_data.ChunkExecutionData {
+				ced := unittest.ChunkExecutionDataFixture(t, 0)
+				ced.TrieUpdate = nil
+				return ced
+			},
+		},
+		{
+			name: "chunk execution data conversions - empty collection",
+			fn: func(t *testing.T) *execution_data.ChunkExecutionData {
+				ced := unittest.ChunkExecutionDataFixture(t, 0)
+				ced.Collection = &flow.Collection{}
+				ced.TransactionResults = nil
+				return ced
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ced := test.fn(t)
+
+			chunkMsg, err := convert.ChunkExecutionDataToMessage(ced)
+			require.NoError(t, err)
+
+			chunkReConverted, err := convert.MessageToChunkExecutionData(chunkMsg, flow.Testnet.Chain())
+			require.NoError(t, err)
+
+			assert.Equal(t, ced, chunkReConverted)
+			if ced.TrieUpdate == nil {
+				assert.Nil(t, chunkReConverted.TrieUpdate)
+			} else {
+				assert.True(t, ced.TrieUpdate.Equals(chunkReConverted.TrieUpdate))
+			}
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3
 	github.com/onflow/flow-go-sdk v0.41.10
 	github.com/onflow/flow-go/crypto v0.24.9
-	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8
 	github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3
 	github.com/onflow/flow-go-sdk v0.41.10
 	github.com/onflow/flow-go/crypto v0.24.9
-	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9
 	github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -828,7 +828,6 @@ github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
-github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
@@ -1207,7 +1206,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
-github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -1329,8 +1327,8 @@ github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128 h1:e6wRlUtaBoydv0hY44HJeUMm0KdeqCI9cYzMvNB/tAk=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 h1:rdthEpTQGPF3IswnHXApC0LKQaulDN85yZ1of0voLcQ=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d h1:QcOAeEyF3iAUHv21LQ12sdcsr0yFrJGoGLyCAzYYtvI=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d/go.mod h1:GCPpiyRoHncdqPj++zPr9ZOYBX4hpJ0pYZRYqSE8VKk=
 github.com/onflow/sdks v0.5.0 h1:2HCRibwqDaQ1c9oUApnkZtEAhWiNY2GTpRD5+ftdkN8=

--- a/go.sum
+++ b/go.sum
@@ -1327,8 +1327,8 @@ github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 h1:rdthEpTQGPF3IswnHXApC0LKQaulDN85yZ1of0voLcQ=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9 h1:IGDANryEVnuVAlDZDzNLMMUui9lbwS04KE70C0HXkFw=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d h1:QcOAeEyF3iAUHv21LQ12sdcsr0yFrJGoGLyCAzYYtvI=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d/go.mod h1:GCPpiyRoHncdqPj++zPr9ZOYBX4hpJ0pYZRYqSE8VKk=
 github.com/onflow/sdks v0.5.0 h1:2HCRibwqDaQ1c9oUApnkZtEAhWiNY2GTpRD5+ftdkN8=

--- a/go.sum
+++ b/go.sum
@@ -828,6 +828,7 @@ github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
@@ -1206,6 +1207,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -186,7 +186,7 @@ require (
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.0 // indirect
 	github.com/onflow/flow-go-sdk v0.41.10 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.0 // indirect
-	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128 // indirect
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 // indirect
 	github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d // indirect
 	github.com/onflow/sdks v0.5.0 // indirect
 	github.com/onflow/wal v0.0.0-20230529184820-bc9f8244608d // indirect

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -186,7 +186,7 @@ require (
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.0 // indirect
 	github.com/onflow/flow-go-sdk v0.41.10 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.0 // indirect
-	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 // indirect
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9 // indirect
 	github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d // indirect
 	github.com/onflow/sdks v0.5.0 // indirect
 	github.com/onflow/wal v0.0.0-20230529184820-bc9f8244608d // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -1233,8 +1233,8 @@ github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128 h1:e6wRlUtaBoydv0hY44HJeUMm0KdeqCI9cYzMvNB/tAk=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 h1:rdthEpTQGPF3IswnHXApC0LKQaulDN85yZ1of0voLcQ=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d h1:QcOAeEyF3iAUHv21LQ12sdcsr0yFrJGoGLyCAzYYtvI=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d/go.mod h1:GCPpiyRoHncdqPj++zPr9ZOYBX4hpJ0pYZRYqSE8VKk=
 github.com/onflow/sdks v0.5.0 h1:2HCRibwqDaQ1c9oUApnkZtEAhWiNY2GTpRD5+ftdkN8=

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -1233,8 +1233,8 @@ github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 h1:rdthEpTQGPF3IswnHXApC0LKQaulDN85yZ1of0voLcQ=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9 h1:IGDANryEVnuVAlDZDzNLMMUui9lbwS04KE70C0HXkFw=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d h1:QcOAeEyF3iAUHv21LQ12sdcsr0yFrJGoGLyCAzYYtvI=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d/go.mod h1:GCPpiyRoHncdqPj++zPr9ZOYBX4hpJ0pYZRYqSE8VKk=
 github.com/onflow/sdks v0.5.0 h1:2HCRibwqDaQ1c9oUApnkZtEAhWiNY2GTpRD5+ftdkN8=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/onflow/flow-go-sdk v0.41.10
 	github.com/onflow/flow-go/crypto v0.24.9
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
-	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9
 	github.com/plus3it/gorecurcopy v0.0.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.4.0

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/onflow/flow-go-sdk v0.41.10
 	github.com/onflow/flow-go/crypto v0.24.9
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
-	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128
+	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8
 	github.com/plus3it/gorecurcopy v0.0.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.4.0

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1373,8 +1373,8 @@ github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 h1:rdthEpTQGPF3IswnHXApC0LKQaulDN85yZ1of0voLcQ=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9 h1:IGDANryEVnuVAlDZDzNLMMUui9lbwS04KE70C0HXkFw=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230915140723-432828f7afb9/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d h1:QcOAeEyF3iAUHv21LQ12sdcsr0yFrJGoGLyCAzYYtvI=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d/go.mod h1:GCPpiyRoHncdqPj++zPr9ZOYBX4hpJ0pYZRYqSE8VKk=
 github.com/onflow/nft-storefront/lib/go/contracts v0.0.0-20221222181731-14b90207cead h1:2j1Unqs76Z1b95Gu4C3Y28hzNUHBix7wL490e61SMSw=

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1373,8 +1373,8 @@ github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128 h1:e6wRlUtaBoydv0hY44HJeUMm0KdeqCI9cYzMvNB/tAk=
-github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230912213857-614a2a0c0128/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8 h1:rdthEpTQGPF3IswnHXApC0LKQaulDN85yZ1of0voLcQ=
+github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230913220758-be0458f1c5a8/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d h1:QcOAeEyF3iAUHv21LQ12sdcsr0yFrJGoGLyCAzYYtvI=
 github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d/go.mod h1:GCPpiyRoHncdqPj++zPr9ZOYBX4hpJ0pYZRYqSE8VKk=
 github.com/onflow/nft-storefront/lib/go/contracts v0.0.0-20221222181731-14b90207cead h1:2j1Unqs76Z1b95Gu4C3Y28hzNUHBix7wL490e61SMSw=

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2498,7 +2498,7 @@ func ChunkExecutionDataFixture(t *testing.T, minSize int, opts ...func(*executio
 
 	ced := &execution_data.ChunkExecutionData{
 		Collection:         &collection,
-		Events:             flow.EventsList{},
+		Events:             nil,
 		TrieUpdate:         testutils.TrieUpdateFixture(2, 1, 8),
 		TransactionResults: results,
 	}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4707

Uses protobuf changes from https://github.com/onflow/flow/pull/1382

Updates rpc message converters to handle `ChunkExecutionData` with `TransactionResults`