### PR TITLE
[State Sync] Update chunk execution data serializer header version

### DIFF
--- a/module/executiondatasync/execution_data/internal/execution_data_versions.go
+++ b/module/executiondatasync/execution_data/internal/execution_data_versions.go
@@ -7,6 +7,10 @@ import (
 
 // This is a collection of data structures from previous versions of ExecutionData.
 // They are maintained here for backwards compatibility testing.
+//
+// Note: the current codebase makes no guarantees about backwards compatibility with previous of
+// execution data. The data structures and tests included are only to help inform of any breaking
+// changes.
 
 // ChunkExecutionDataV1 [deprecated] only use for backwards compatibility testing
 // was used up to block X (TODO: fill in block number after release)

--- a/module/executiondatasync/execution_data/internal/execution_data_versions.go
+++ b/module/executiondatasync/execution_data/internal/execution_data_versions.go
@@ -1,0 +1,17 @@
+package internal
+
+import (
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// This is a collection of data structures from previous versions of ExecutionData.
+// They are maintained here for backwards compatibility testing.
+
+// ChunkExecutionDataV1 [deprecated] only use for backwards compatibility testing
+// was used up to block X (TODO: fill in block number after release)
+type ChunkExecutionDataV1 struct {
+	Collection *flow.Collection
+	Events     flow.EventsList
+	TrieUpdate *ledger.TrieUpdate
+}

--- a/module/executiondatasync/execution_data/serializer_test.go
+++ b/module/executiondatasync/execution_data/serializer_test.go
@@ -1,0 +1,61 @@
+package execution_data_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
+	"github.com/onflow/flow-go/module/executiondatasync/execution_data/internal"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeDeserializeChunkExecutionData(t *testing.T) {
+	serializer := execution_data.DefaultSerializer
+
+	// Test serializing the current ChunkExecutionData version, then deserializing it back to the
+	// same type. Make sure the start and end data structures are the same.
+	t.Run("serialize and deserialize ChunkExecutionData", func(t *testing.T) {
+		ced := unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(unittest.EventsFixture(5)))
+
+		buf := new(bytes.Buffer)
+		err := serializer.Serialize(buf, ced)
+		require.NoError(t, err)
+
+		raw, err := serializer.Deserialize(buf)
+		require.NoError(t, err)
+
+		actual, ok := raw.(*execution_data.ChunkExecutionData)
+		assert.True(t, ok)
+		assert.Equal(t, ced, actual)
+	})
+
+	// Test serializing the past ChunkExecutionDataV1 version, then deserializing it to the current
+	// ChunkExecutionData version. Make sure the fields in the start and end data structures are
+	// the same.
+	//
+	// This test ensures that the current code is backwards compatible with the previous version of
+	// the data structure. It does NOT ensure that the current data structure is backwards compatible
+	// with the previous code.
+	t.Run("serialize ChunkExecutionDataV1 and deserialize to ChunkExecutionData", func(t *testing.T) {
+		cedV2 := unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(unittest.EventsFixture(5)))
+		cedV2.TransactionResults = nil
+		cedV1 := &internal.ChunkExecutionDataV1{
+			Collection: cedV2.Collection,
+			Events:     cedV2.Events,
+			TrieUpdate: cedV2.TrieUpdate,
+		}
+
+		buf := new(bytes.Buffer)
+		err := serializer.Serialize(buf, cedV1)
+		require.NoError(t, err)
+
+		raw, err := serializer.Deserialize(buf)
+		require.NoError(t, err)
+
+		actual, ok := raw.(*execution_data.ChunkExecutionData)
+		assert.True(t, ok)
+		assert.Equal(t, cedV2, actual)
+	})
+}

--- a/module/executiondatasync/execution_data/serializer_test.go
+++ b/module/executiondatasync/execution_data/serializer_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data/internal"
 	"github.com/onflow/flow-go/utils/unittest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSerializeDeserializeChunkExecutionData(t *testing.T) {

--- a/module/executiondatasync/provider/provider_test.go
+++ b/module/executiondatasync/provider/provider_test.go
@@ -151,7 +151,7 @@ func TestCalculateChunkExecutionDataID(t *testing.T) {
 	rootHash, err := ledger.ToRootHash([]byte("0123456789acbdef0123456789acbdef"))
 	require.NoError(t, err)
 
-	expected := cid.MustParse("QmXrbSY6XkrrVGvQzprLKSW6ixp64YHXDhUGKMGHkA862p")
+	expected := cid.MustParse("QmdtRuw9jFgkynBWofz4qFQHDqUwLhi2nReF4fUyXvdERC")
 	ced := execution_data.ChunkExecutionData{
 		Collection: &flow.Collection{
 			Transactions: []*flow.TransactionBody{
@@ -176,40 +176,9 @@ func TestCalculateChunkExecutionDataID(t *testing.T) {
 	cidProvider := provider.NewExecutionDataCIDProvider(execution_data.DefaultSerializer)
 	actual, err := cidProvider.CalculateChunkExecutionDataID(ced)
 	require.NoError(t, err)
+
+	// This can be used for updating the expected ID used by TestCalculateChunkExecutionDataID
+	t.Log(actual)
 
 	assert.Equal(t, expected, actual)
-}
-
-// generateChunkExecutionDataID generates a ChunkExecutionDataID for a static blob. This can be used
-// for updating the expected ID used by TestCalculateChunkExecutionDataID
-func generateChunkExecutionDataID(t *testing.T) {
-	rootHash, err := ledger.ToRootHash([]byte("0123456789acbdef0123456789acbdef"))
-	require.NoError(t, err)
-
-	ced := execution_data.ChunkExecutionData{
-		Collection: &flow.Collection{
-			Transactions: []*flow.TransactionBody{
-				{Script: []byte("pub fun main() {}")},
-			},
-		},
-		Events: []flow.Event{
-			unittest.EventFixture(flow.EventType("A.0123456789abcdef.SomeContract.SomeEvent"), 1, 2, flow.MustHexStringToIdentifier("95e0929839063afbe334a3d175bea0775cdf5d93f64299e369d16ce21aa423d3"), 0),
-		},
-		TrieUpdate: &ledger.TrieUpdate{
-			RootHash: rootHash,
-		},
-		TransactionResults: []flow.LightTransactionResult{
-			{
-				TransactionID:   flow.MustHexStringToIdentifier("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
-				ComputationUsed: 100,
-				Failed:          true,
-			},
-		},
-	}
-
-	cidProvider := provider.NewExecutionDataCIDProvider(execution_data.DefaultSerializer)
-	actual, err := cidProvider.CalculateChunkExecutionDataID(ced)
-	require.NoError(t, err)
-
-	t.Log(actual)
 }

--- a/module/executiondatasync/provider/provider_test.go
+++ b/module/executiondatasync/provider/provider_test.go
@@ -177,7 +177,7 @@ func TestCalculateChunkExecutionDataID(t *testing.T) {
 	actual, err := cidProvider.CalculateChunkExecutionDataID(ced)
 	require.NoError(t, err)
 
-	// This can be used for updating the expected ID used by TestCalculateChunkExecutionDataID
+	// This can be used for updating the expected ID when the format is *intentionally* updated
 	t.Log(actual)
 
 	assert.Equal(t, expected, actual)


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4708

Serialized execution data blobs include a header byte that's used by the serializer to determine how to deserialize its contents. Each unique format should have a different version to simplify version management by consumers.

`ChunkExecutionData` was recently updated (https://github.com/onflow/flow-go/pull/4699) to include transaction results. This changed the format, so we need to also update the header byte.

This PR also adds unittests to the serializer to confirm the previous version can be deserialized into the new format. It is not required that the flow-go codebase maintains backwards compatibility, but it's helpful to understand how it will impact clients.