### PR TITLE
[CI] Update the workflows to use new auth

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -102,11 +102,11 @@ jobs:
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
     - name: Docker login
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: gcr.io
         username: _json_key
-        password: ${{ secrets.GCR_SERVICE_KEY }}
+        password: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
 
     - name: Build/Push ${{ matrix.role }} images
       env:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -101,12 +101,16 @@ jobs:
 
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
-    - name: Docker login
-      uses: docker/login-action@v3
+    - name: Configure gcloud
+      uses: google-github-actions/setup-gcloud@v0.2.1
       with:
-        registry: gcr.io
-        username: _json_key_base64
-        password: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
+        version: "349.0.0"
+        service_account_key: ${{ env.GCR_SERVICE_KEY_SECRET }}
+        export_default_credentials: true
+
+    - name: Authenticate docker with gcloud
+      run: |
+        gcloud auth configure-docker
 
     - name: Build/Push ${{ matrix.role }} images
       env:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -105,7 +105,7 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: gcr.io
-        username: _json_key
+        username: _json_key_base64
         password: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
 
     - name: Build/Push ${{ matrix.role }} images

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -101,13 +101,12 @@ jobs:
 
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
-    - name: Configure gcloud
-      uses: google-github-actions/setup-gcloud@v0.2.1
+    - id: auth
+      uses: google-github-actions/auth@v1
       with:
-        version: "349.0.0"
-        service_account_key: ${{ env.GCR_SERVICE_KEY_SECRET }}
-        export_default_credentials: true
-
+        credentials_json: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
     - name: Authenticate docker with gcloud
       run: |
         gcloud auth configure-docker

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,8 +5,6 @@ on:
     tags: 
       - '*'
       - "!daily-*"
-    branches:
-      - 'petera/update-gcr-cred-format'
 
 jobs:
   docker-push:
@@ -38,5 +36,5 @@ jobs:
         make docker-build-flow-without-netgo
     - name: Docker push
       run: |
-        make -e VERSION=peter-test-deleteme docker-push-access
-        make -e VERSION=peter-test-deleteme docker-push-access-without-netgo
+        make docker-push-flow
+        make docker-push-flow-without-netgo

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,8 @@ on:
     tags: 
       - '*'
       - "!daily-*"
+    branches:
+      - 'petera/update-gcr-cred-format'
 
 jobs:
   docker-push:
@@ -36,5 +38,5 @@ jobs:
         make docker-build-flow-without-netgo
     - name: Docker push
       run: |
-        make docker-push-flow
-        make docker-push-flow-without-netgo
+        make -e VERSION=peter-test-deleteme docker-push-access
+        make -e VERSION=peter-test-deleteme docker-push-access-without-netgo

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,12 +21,15 @@ jobs:
       run: make crypto_setup_gopath
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
-    - name: Docker login
-      uses: docker/login-action@v3
+    - id: auth
+      uses: google-github-actions/auth@v1
       with:
-        registry: gcr.io
-        username: _json_key_base64
-        password: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
+        credentials_json: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v1
+    - name: Authenticate docker with gcloud
+      run: |
+        gcloud auth configure-docker
     - name: Docker build
       run: |
         make docker-build-flow

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,11 +22,11 @@ jobs:
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
     - name: Docker login
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: gcr.io
-        username: _json_key
-        password: ${{ secrets.GCR_SERVICE_KEY }}
+        username: _json_key_base64
+        password: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
     - name: Docker build
       run: |
         make docker-build-flow

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -24,14 +24,14 @@ jobs:
       uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: "1.20"
     - name: Set up Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
       with:
         project_id: flow
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.20"
     - name: Checkout repo
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -23,7 +23,7 @@ jobs:
     - id: auth
       uses: google-github-actions/auth@v1
       with:
-        credentials_json: ${{ secrets.GCR_SERVICE_KEY }} # TODO: we need a new key to allow uploads
+        credentials_json: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
     - name: Setup Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -23,7 +23,7 @@ jobs:
     - id: auth
       uses: google-github-actions/auth@v1
       with:
-        credentials_json: ${{ secrets.GCR_SERVICE_KEY_SECRET }}
+        credentials_json: ${{ secrets.GCR_SERVICE_KEY }}
     - name: Set up Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v1
       with:


### PR DESCRIPTION
This PR updates the docker login approach to better support the new credential format. It switches from the docker-login gha helper to authenticate with gcloud. The docker helper doesn't seem to correctly support the new format.

Test runs
* Builder: https://github.com/onflow/flow-go/actions/runs/6227541426/job/16902395485
* Tools: https://github.com/onflow/flow-go/actions/runs/6253436703
* CD: https://github.com/onflow/flow-go/actions/runs/6253423667/job/16978801212