### PR TITLE
Flex: Refactor and extend generated type definition

### DIFF
--- a/fvm/flex/flex_test.go
+++ b/fvm/flex/flex_test.go
@@ -1,4 +1,4 @@
-package flex
+package flex_test
 
 import (
 	"bytes"
@@ -21,7 +21,9 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/flex"
 	flexStdlib "github.com/onflow/flow-go/fvm/flex/stdlib"
+	"github.com/onflow/flow-go/fvm/flex/stdlib/emulator"
 	"github.com/onflow/flow-go/fvm/flex/storage"
 	"github.com/onflow/flow-go/fvm/storage/testutils"
 )
@@ -49,10 +51,10 @@ var flexAddressBytesCadenceType = cadence.NewConstantSizedArrayType(20, cadence.
 
 var flexAddressCadenceType = cadence.NewStructType(
 	nil,
-	flexStdlib.Flex_FlexAddressType.QualifiedIdentifier(),
+	emulator.Flex_FlexAddressType.QualifiedIdentifier(),
 	[]cadence.Field{
 		{
-			Identifier: flexStdlib.Flex_FlexAddressTypeBytesFieldName,
+			Identifier: emulator.Flex_FlexAddressTypeBytesFieldName,
 			Type:       flexAddressBytesCadenceType,
 		},
 	},
@@ -64,12 +66,13 @@ func TestFlexAddressConstructionAndReturn(t *testing.T) {
 	t.Parallel()
 
 	RunWithTempLedger(t, func(led atree.Ledger) {
-		handler := NewFlexContractHandler(led)
+		handler := flex.NewFlexContractHandler(led)
 
 		env := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
 
-		env.DeclareValue(flexStdlib.NewFlexStandardLibraryValue(nil, handler))
-		env.DeclareType(flexStdlib.FlexStandardLibraryType)
+		flexTypeDefinition := emulator.FlexTypeDefinition
+		env.DeclareValue(flexStdlib.NewFlexStandardLibraryValue(nil, flexTypeDefinition, handler))
+		env.DeclareType(flexStdlib.NewFlexStandardLibraryType(flexTypeDefinition))
 
 		inter := runtime.NewInterpreterRuntime(runtime.Config{})
 
@@ -131,12 +134,13 @@ func TestFlexRun(t *testing.T) {
 	t.Parallel()
 
 	RunWithTempLedger(t, func(led atree.Ledger) {
-		handler := NewFlexContractHandler(led)
+		handler := flex.NewFlexContractHandler(led)
 
 		env := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
 
-		env.DeclareValue(flexStdlib.NewFlexStandardLibraryValue(nil, handler))
-		env.DeclareType(flexStdlib.FlexStandardLibraryType)
+		flexTypeDefinition := emulator.FlexTypeDefinition
+		env.DeclareValue(flexStdlib.NewFlexStandardLibraryValue(nil, flexTypeDefinition, handler))
+		env.DeclareType(flexStdlib.NewFlexStandardLibraryType(flexTypeDefinition))
 
 		inter := runtime.NewInterpreterRuntime(runtime.Config{})
 

--- a/fvm/flex/handler_test.go
+++ b/fvm/flex/handler_test.go
@@ -12,17 +12,18 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/onflow/atree"
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/flow-go/fvm/flex"
 	env "github.com/onflow/flow-go/fvm/flex/environment"
 	"github.com/onflow/flow-go/fvm/flex/models"
 	"github.com/onflow/flow-go/fvm/flex/utils"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFlexContractHandler(t *testing.T) {
 	t.Parallel()
 	t.Run("test last executed block call", func(t *testing.T) {
-		flex.RunWithTempLedger(t, func(led atree.Ledger) {
+		RunWithTempLedger(t, func(led atree.Ledger) {
 			handler := flex.NewFlexContractHandler(led)
 			// test call last executed block without initialization
 			b := handler.LastExecutedBlock()
@@ -41,7 +42,7 @@ func TestFlexContractHandler(t *testing.T) {
 	})
 
 	t.Run("test foa creation", func(t *testing.T) {
-		flex.RunWithTempLedger(t, func(led atree.Ledger) {
+		RunWithTempLedger(t, func(led atree.Ledger) {
 			handler := flex.NewFlexContractHandler(led)
 			foa := handler.NewFlowOwnedAccount()
 			require.NotNil(t, foa)
@@ -52,7 +53,7 @@ func TestFlexContractHandler(t *testing.T) {
 	})
 
 	t.Run("test running transaction", func(t *testing.T) {
-		flex.RunWithTempLedger(t, func(led atree.Ledger) {
+		RunWithTempLedger(t, func(led atree.Ledger) {
 			handler := flex.NewFlexContractHandler(led)
 			keyHex := "9c647b8b7c4e7c3490668fb6c11473619db80c93704c70893d3813af4090c39c"
 			key, _ := crypto.HexToECDSA(keyHex)
@@ -107,7 +108,7 @@ func TestFlexContractHandler(t *testing.T) {
 
 func TestFOA(t *testing.T) {
 	t.Run("test deposit/withdraw", func(t *testing.T) {
-		flex.RunWithTempLedger(t, func(led atree.Ledger) {
+		RunWithTempLedger(t, func(led atree.Ledger) {
 			handler := flex.NewFlexContractHandler(led)
 			foa := handler.NewFlowOwnedAccount()
 			require.NotNil(t, foa)
@@ -135,7 +136,7 @@ func TestFOA(t *testing.T) {
 	})
 
 	t.Run("test deploy/call", func(t *testing.T) {
-		flex.RunWithTempLedger(t, func(led atree.Ledger) {
+		RunWithTempLedger(t, func(led atree.Ledger) {
 			handler := flex.NewFlexContractHandler(led)
 			foa := handler.NewFlowOwnedAccount()
 			require.NotNil(t, foa)

--- a/fvm/flex/stdlib/emulator/flex.gen.go
+++ b/fvm/flex/stdlib/emulator/flex.gen.go
@@ -84,6 +84,248 @@ func init() {
 	Flex_FlexAddressType.ConstructorParameters = Flex_FlexAddressTypeConstructorType.Parameters
 }
 
+var Flex_BalanceTypeConstructorType = &sema.FunctionType{
+	IsConstructor: true,
+	Parameters: []sema.Parameter{
+		{
+			Identifier:     "flowAmount",
+			TypeAnnotation: sema.NewTypeAnnotation(sema.UFix64Type),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		Flex_BalanceType,
+	),
+}
+
+const Flex_BalanceTypeConstructorDocString = `
+Constructs a new
+`
+
+const Flex_BalanceTypeToFLOWFunctionName = "toFLOW"
+
+var Flex_BalanceTypeToFLOWFunctionType = &sema.FunctionType{
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		sema.UFix64Type,
+	),
+}
+
+const Flex_BalanceTypeToFLOWFunctionDocString = `
+Returns the balance in FLOW
+`
+
+const Flex_BalanceTypeToAttoFlowFunctionName = "toAttoFlow"
+
+var Flex_BalanceTypeToAttoFlowFunctionType = &sema.FunctionType{
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		sema.UInt64Type,
+	),
+}
+
+const Flex_BalanceTypeToAttoFlowFunctionDocString = `
+Returns the balance in terms of atto-FLOW.
+Atto-FLOW is the smallest denomination of FLOW inside Flex.
+`
+
+const Flex_BalanceTypeName = "Balance"
+
+var Flex_BalanceType = func() *sema.CompositeType {
+	var t = &sema.CompositeType{
+		Identifier:         Flex_BalanceTypeName,
+		Kind:               common.CompositeKindStructure,
+	}
+
+	return t
+}()
+
+func init() {
+	var members = []*sema.Member{
+		sema.NewUnmeteredFunctionMember(
+			Flex_BalanceType,
+			ast.AccessPublic,
+			Flex_BalanceTypeToFLOWFunctionName,
+			Flex_BalanceTypeToFLOWFunctionType,
+			Flex_BalanceTypeToFLOWFunctionDocString,
+		),
+		sema.NewUnmeteredFunctionMember(
+			Flex_BalanceType,
+						ast.AccessPublic,
+			Flex_BalanceTypeToAttoFlowFunctionName,
+			Flex_BalanceTypeToAttoFlowFunctionType,
+			Flex_BalanceTypeToAttoFlowFunctionDocString,
+		),
+	}
+
+	Flex_BalanceType.Members = sema.MembersAsMap(members)
+	Flex_BalanceType.Fields = sema.MembersFieldNames(members)
+	Flex_BalanceType.ConstructorParameters = Flex_BalanceTypeConstructorType.Parameters
+}
+
+const Flex_FlowOwnedAccountTypeAddressFunctionName = "address"
+
+var Flex_FlowOwnedAccountTypeAddressFunctionType = &sema.FunctionType{
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		Flex_FlexAddressType,
+	),
+}
+
+const Flex_FlowOwnedAccountTypeAddressFunctionDocString = `
+The address of the owned Flex account
+`
+
+const Flex_FlowOwnedAccountTypeDepositFunctionName = "deposit"
+
+var Flex_FlowOwnedAccountTypeDepositFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Identifier:     "from",
+			TypeAnnotation: sema.NewTypeAnnotation(FlowToken_VaultType),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		sema.VoidType,
+	),
+}
+
+const Flex_FlowOwnedAccountTypeDepositFunctionDocString = `
+Deposits the given vault into the Flex account's balance
+`
+
+const Flex_FlowOwnedAccountTypeWithdrawFunctionName = "withdraw"
+
+var Flex_FlowOwnedAccountTypeWithdrawFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Identifier:     "balance",
+			TypeAnnotation: sema.NewTypeAnnotation(Flex_BalanceType),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		FlowToken_VaultType,
+	),
+}
+
+const Flex_FlowOwnedAccountTypeWithdrawFunctionDocString = `
+Withdraws the balance from the Flex account's balance
+`
+
+const Flex_FlowOwnedAccountTypeDeployFunctionName = "deploy"
+
+var Flex_FlowOwnedAccountTypeDeployFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Identifier: "code",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{
+				Type: sema.UInt8Type,
+			}),
+		},
+		{
+			Identifier:     "gaslimit",
+			TypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
+		},
+		{
+			Identifier:     "value",
+			TypeAnnotation: sema.NewTypeAnnotation(Flex_BalanceType),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		Flex_FlexAddressType,
+	),
+}
+
+const Flex_FlowOwnedAccountTypeDeployFunctionDocString = `
+Deploys a contract to the Flex environment.
+Returns the address of the newly deployed.
+`
+
+const Flex_FlowOwnedAccountTypeCallFunctionName = "call"
+
+var Flex_FlowOwnedAccountTypeCallFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Identifier:     "to",
+			TypeAnnotation: sema.NewTypeAnnotation(Flex_FlexAddressType),
+		},
+		{
+			Identifier: "data",
+			TypeAnnotation: sema.NewTypeAnnotation(&sema.VariableSizedType{
+				Type: sema.UInt8Type,
+			}),
+		},
+		{
+			Identifier:     "gaslimit",
+			TypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
+		},
+		{
+			Identifier:     "value",
+			TypeAnnotation: sema.NewTypeAnnotation(Flex_BalanceType),
+		},
+	},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(
+		&sema.VariableSizedType{
+			Type: sema.UInt8Type,
+		},
+	),
+}
+
+const Flex_FlowOwnedAccountTypeCallFunctionDocString = `
+Calls a function with the given data.
+The execution is limited by the given amount of gas.
+`
+
+const Flex_FlowOwnedAccountTypeName = "FlowOwnedAccount"
+
+var Flex_FlowOwnedAccountType = func() *sema.CompositeType {
+	var t = &sema.CompositeType{
+		Identifier:         Flex_FlowOwnedAccountTypeName,
+		Kind:               common.CompositeKindResource,
+	}
+
+	return t
+}()
+
+func init() {
+	var members = []*sema.Member{
+		sema.NewUnmeteredFunctionMember(
+			Flex_FlowOwnedAccountType,
+						ast.AccessPublic,
+			Flex_FlowOwnedAccountTypeAddressFunctionName,
+			Flex_FlowOwnedAccountTypeAddressFunctionType,
+			Flex_FlowOwnedAccountTypeAddressFunctionDocString,
+		),
+		sema.NewUnmeteredFunctionMember(
+			Flex_FlowOwnedAccountType,
+						ast.AccessPublic,
+			Flex_FlowOwnedAccountTypeDepositFunctionName,
+			Flex_FlowOwnedAccountTypeDepositFunctionType,
+			Flex_FlowOwnedAccountTypeDepositFunctionDocString,
+		),
+		sema.NewUnmeteredFunctionMember(
+			Flex_FlowOwnedAccountType,
+						ast.AccessPublic,
+			Flex_FlowOwnedAccountTypeWithdrawFunctionName,
+			Flex_FlowOwnedAccountTypeWithdrawFunctionType,
+			Flex_FlowOwnedAccountTypeWithdrawFunctionDocString,
+		),
+		sema.NewUnmeteredFunctionMember(
+			Flex_FlowOwnedAccountType,
+						ast.AccessPublic,
+			Flex_FlowOwnedAccountTypeDeployFunctionName,
+			Flex_FlowOwnedAccountTypeDeployFunctionType,
+			Flex_FlowOwnedAccountTypeDeployFunctionDocString,
+		),
+		sema.NewUnmeteredFunctionMember(
+			Flex_FlowOwnedAccountType,
+						ast.AccessPublic,
+			Flex_FlowOwnedAccountTypeCallFunctionName,
+			Flex_FlowOwnedAccountTypeCallFunctionType,
+			Flex_FlowOwnedAccountTypeCallFunctionDocString,
+		),
+	}
+
+	Flex_FlowOwnedAccountType.Members = sema.MembersAsMap(members)
+	Flex_FlowOwnedAccountType.Fields = sema.MembersFieldNames(members)
+}
+
 const FlexTypeRunFunctionName = "run"
 
 var FlexTypeRunFunctionType = &sema.FunctionType{
@@ -105,8 +347,12 @@ var FlexTypeRunFunctionType = &sema.FunctionType{
 }
 
 const FlexTypeRunFunctionDocString = `
-Run runs a flex transaction, deducts the gas fees and deposits them into the
-provided coinbase address
+Runs an a RLP-encoded Flex transaction,
+deducts the gas fees and deposits them into the
+provided coinbase address.
+
+Returns true if the transaction was successful,
+and returns false otherwise.
 `
 
 const FlexTypeName = "Flex"
@@ -118,6 +364,8 @@ var FlexType = func() *sema.CompositeType {
 	}
 
 	t.SetNestedType(Flex_FlexAddressTypeName, Flex_FlexAddressType)
+	t.SetNestedType(Flex_BalanceTypeName, Flex_BalanceType)
+	t.SetNestedType(Flex_FlowOwnedAccountTypeName, Flex_FlowOwnedAccountType)
 	return t
 }()
 
@@ -130,6 +378,14 @@ func init() {
 			Flex_FlexAddressTypeName,
 			Flex_FlexAddressTypeConstructorType,
 			Flex_FlexAddressTypeConstructorDocString,
+		),
+		// TODO: use NewUnmeteredConstructorMember
+		sema.NewUnmeteredFunctionMember(
+			FlexType,
+			ast.AccessPublic,
+			Flex_BalanceTypeName,
+			Flex_BalanceTypeConstructorType,
+			Flex_BalanceTypeConstructorDocString,
 		),
 		sema.NewUnmeteredFunctionMember(
 			FlexType,

--- a/fvm/flex/stdlib/emulator/flex.gen.go
+++ b/fvm/flex/stdlib/emulator/flex.gen.go
@@ -1,4 +1,4 @@
-// Code generated from flex.cdc. DO NOT EDIT.
+// Code generated from ../flex.cdc. DO NOT EDIT.
 /*
  * Cadence - The resource-oriented smart contract programming language
  *
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package stdlib
+package emulator
 
 import (
 	"github.com/onflow/cadence/runtime/ast"

--- a/fvm/flex/stdlib/emulator/flex.go
+++ b/fvm/flex/stdlib/emulator/flex.go
@@ -1,0 +1,14 @@
+package emulator
+
+import "github.com/onflow/flow-go/fvm/flex/stdlib"
+
+// TODO: switch to released version once available
+//go:generate env GOPROXY=direct go run github.com/onflow/cadence/runtime/sema/gen@1e04b7af1c098a3deff37931ef33191644606a89 -p emulator ../flex.cdc flex.gen.go
+
+var FlexTypeDefinition = stdlib.FlexTypeDefinition{
+	FlexType:                           FlexType,
+	FlexTypeRunFunctionType:            FlexTypeRunFunctionType,
+	FlexTypeRunFunctionName:            FlexTypeRunFunctionName,
+	Flex_FlexAddressType:               Flex_FlexAddressType,
+	Flex_FlexAddressTypeBytesFieldName: Flex_FlexAddressTypeBytesFieldName,
+}

--- a/fvm/flex/stdlib/emulator/flex.go
+++ b/fvm/flex/stdlib/emulator/flex.go
@@ -1,6 +1,9 @@
 package emulator
 
-import "github.com/onflow/flow-go/fvm/flex/stdlib"
+import (
+	"github.com/onflow/flow-go/fvm/flex/stdlib"
+	"github.com/onflow/flow-go/model/flow"
+)
 
 // TODO: switch to released version once available
 //go:generate env GOPROXY=direct go run github.com/onflow/cadence/runtime/sema/gen@1e04b7af1c098a3deff37931ef33191644606a89 -p emulator ../flex.cdc flex.gen.go
@@ -12,3 +15,5 @@ var FlexTypeDefinition = stdlib.FlexTypeDefinition{
 	Flex_FlexAddressType:               Flex_FlexAddressType,
 	Flex_FlexAddressTypeBytesFieldName: Flex_FlexAddressTypeBytesFieldName,
 }
+
+var FlowToken_VaultType = stdlib.NewFlowTokenVaultType(flow.Emulator.Chain())

--- a/fvm/flex/stdlib/flex.cdc
+++ b/fvm/flex/stdlib/flex.cdc
@@ -13,8 +13,59 @@ contract Flex {
         let bytes: [UInt8; 20]
     }
 
-    /// Run runs a flex transaction, deducts the gas fees and deposits them into the
-    /// provided coinbase address
+    access(all)
+    struct Balance {
+
+        /// Constructs a new
+        init(flowAmount: UFix64)
+
+        /// Returns the balance in FLOW
+        access(all)
+        fun toFLOW(): UFix64
+
+        /// Returns the balance in terms of atto-FLOW.
+        /// Atto-FLOW is the smallest denomination of FLOW inside Flex.
+        access(all)
+        fun toAttoFlow(): UInt64
+    }
+
+    access(all)
+    resource FlowOwnedAccount{
+
+        /// The address of the owned Flex account
+        access(all)
+        fun address(): Flex.FlexAddress
+
+        /// Deposits the given vault into the Flex account's balance
+        access(all)
+        fun deposit(from: @FlowToken.Vault)
+
+        /// Withdraws the balance from the Flex account's balance
+        access(all)
+        fun withdraw(balance: Flex.Balance): @FlowToken.Vault
+
+        /// Deploys a contract to the Flex environment.
+        /// Returns the address of the newly deployed.
+        access(all)
+        fun deploy(code: [UInt8], gaslimit: UInt64, value: Flex.Balance): Flex.FlexAddress
+
+        /// Calls a function with the given data.
+        /// The execution is limited by the given amount of gas.
+        access(all)
+        fun call(
+            to: Flex.FlexAddress,
+            data: [UInt8],
+            gaslimit: UInt64,
+            value: Flex.Balance
+        ): [UInt8]
+    }
+
+    /// Runs an a RLP-encoded Flex transaction,
+    /// deducts the gas fees and deposits them into the
+    /// provided coinbase address.
+    ///
+    /// Returns true if the transaction was successful,
+    /// and returns false otherwise.
     access(all)
     fun run(tx: [UInt8], coinbase: Flex.FlexAddress): Bool
 }

--- a/fvm/flex/stdlib/flex.go
+++ b/fvm/flex/stdlib/flex.go
@@ -7,8 +7,44 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
 
+	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/flex/models"
+	"github.com/onflow/flow-go/model/flow"
 )
+
+func NewFlowTokenVaultType(chain flow.Chain) *sema.CompositeType {
+	const flowTokenContractName = "FlowToken"
+	const vaultTypeName = "Vault"
+
+	var flowTokenAddress, err = chain.AddressAtIndex(environment.FlowTokenAccountIndex)
+	if err != nil {
+		panic(err)
+	}
+
+	location := common.NewAddressLocation(
+		nil,
+		common.Address(flowTokenAddress),
+		flowTokenContractName,
+	)
+
+	// TODO: replace with proper type, e.g. extracted from checker
+
+	flowTokenType := &sema.CompositeType{
+		Location:   location,
+		Identifier: flowTokenContractName,
+		Kind:       common.CompositeKindContract,
+	}
+
+	vaultType := &sema.CompositeType{
+		Location:   location,
+		Identifier: vaultTypeName,
+		Kind:       common.CompositeKindResource,
+	}
+
+	flowTokenType.SetNestedType(vaultTypeName, vaultType)
+
+	return vaultType
+}
 
 type FlexTypeDefinition struct {
 	FlexType *sema.CompositeType

--- a/fvm/flex/stdlib/flex.go
+++ b/fvm/flex/stdlib/flex.go
@@ -10,23 +10,45 @@ import (
 	"github.com/onflow/flow-go/fvm/flex/models"
 )
 
-// TODO: switch to released version once available
-//go:generate env GOPROXY=direct go run github.com/onflow/cadence/runtime/sema/gen@1e04b7af1c098a3deff37931ef33191644606a89 -p stdlib flex.cdc flex.gen.go
+type FlexTypeDefinition struct {
+	FlexType *sema.CompositeType
+	// Use FlexStaticType()
+	_flexStaticType                    interpreter.StaticType
+	FlexTypeRunFunctionType            *sema.FunctionType
+	FlexTypeRunFunctionName            string
+	Flex_FlexAddressType               *sema.CompositeType
+	Flex_FlexAddressTypeBytesFieldName string
+	_flex_FlexAddressConstructorType   *sema.FunctionType
+}
 
-var flexContractStaticType interpreter.StaticType = interpreter.NewCompositeStaticType(
-	nil,
-	FlexType.Location,
-	FlexType.QualifiedIdentifier(),
-	FlexType.ID(),
-)
+func (t *FlexTypeDefinition) FlexStaticType() interpreter.StaticType {
+	if t._flexStaticType == nil {
+		flexType := t.FlexType
+		t._flexStaticType = interpreter.NewCompositeStaticType(
+			nil,
+			flexType.Location,
+			flexType.QualifiedIdentifier(),
+			flexType.ID(),
+		)
+	}
+	return t._flexStaticType
+}
 
-func newFlexTypeRunFunction(
+func (t *FlexTypeDefinition) Flex_FlexAddressConstructorType() *sema.FunctionType {
+	if t._flex_FlexAddressConstructorType == nil {
+		t._flex_FlexAddressConstructorType = constructorType(t.Flex_FlexAddressType)
+	}
+	return t._flex_FlexAddressConstructorType
+}
+
+func NewFlexTypeRunFunction(
 	gauge common.MemoryGauge,
+	def FlexTypeDefinition,
 	handler models.FlexContractHandler,
 ) *interpreter.HostFunctionValue {
 	return interpreter.NewHostFunctionValue(
 		gauge,
-		FlexTypeRunFunctionType,
+		def.FlexTypeRunFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
 			inter := invocation.Interpreter
 			locationRange := invocation.LocationRange
@@ -50,7 +72,7 @@ func newFlexTypeRunFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			coinbaseBytesValue := coinbaseValue.GetMember(inter, locationRange, Flex_FlexAddressTypeBytesFieldName)
+			coinbaseBytesValue := coinbaseValue.GetMember(inter, locationRange, def.Flex_FlexAddressTypeBytesFieldName)
 			if coinbaseBytesValue == nil {
 				panic(errors.NewUnreachableError())
 			}
@@ -80,51 +102,52 @@ func constructorType(compositeType *sema.CompositeType) *sema.FunctionType {
 	}
 }
 
-var Flex_FlexAddressConstructorType = constructorType(Flex_FlexAddressType)
+func NewFlexAddressConstructor(def FlexTypeDefinition) *interpreter.HostFunctionValue {
+	return interpreter.NewHostFunctionValue(
+		nil,
+		def.Flex_FlexAddressConstructorType(),
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
 
-var flexAddressConstructor = interpreter.NewHostFunctionValue(
-	nil,
-	Flex_FlexAddressConstructorType,
-	func(invocation interpreter.Invocation) interpreter.Value {
-		inter := invocation.Interpreter
-		locationRange := invocation.LocationRange
+			// Get address
 
-		// Get address
+			bytesValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
 
-		bytesValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-		if !ok {
-			panic(errors.NewUnreachableError())
-		}
-
-		return interpreter.NewCompositeValue(
-			inter,
-			locationRange,
-			FlexType.Location,
-			Flex_FlexAddressType.QualifiedIdentifier(),
-			Flex_FlexAddressType.Kind,
-			[]interpreter.CompositeField{
-				{
-					Name:  Flex_FlexAddressTypeBytesFieldName,
-					Value: bytesValue,
+			return interpreter.NewCompositeValue(
+				inter,
+				locationRange,
+				def.FlexType.Location,
+				def.Flex_FlexAddressType.QualifiedIdentifier(),
+				def.Flex_FlexAddressType.Kind,
+				[]interpreter.CompositeField{
+					{
+						Name:  def.Flex_FlexAddressTypeBytesFieldName,
+						Value: bytesValue,
+					},
 				},
-			},
-			common.ZeroAddress,
-		)
-	},
-)
+				common.ZeroAddress,
+			)
+		},
+	)
+}
 
 func NewFlexContractValue(
 	gauge common.MemoryGauge,
+	def FlexTypeDefinition,
 	handler models.FlexContractHandler,
 ) *interpreter.SimpleCompositeValue {
 	return interpreter.NewSimpleCompositeValue(
 		gauge,
-		FlexType.ID(),
-		flexContractStaticType,
-		FlexType.Fields,
+		def.FlexType.ID(),
+		def.FlexStaticType(),
+		def.FlexType.Fields,
 		map[string]interpreter.Value{
-			Flex_FlexAddressTypeName: flexAddressConstructor,
-			FlexTypeRunFunctionName:  newFlexTypeRunFunction(gauge, handler),
+			def.Flex_FlexAddressType.Identifier: NewFlexAddressConstructor(def),
+			def.FlexTypeRunFunctionName:         NewFlexTypeRunFunction(gauge, def, handler),
 		},
 		nil,
 		nil,
@@ -134,18 +157,21 @@ func NewFlexContractValue(
 
 func NewFlexStandardLibraryValue(
 	gauge common.MemoryGauge,
+	def FlexTypeDefinition,
 	handler models.FlexContractHandler,
 ) stdlib.StandardLibraryValue {
 	return stdlib.StandardLibraryValue{
-		Name:  FlexTypeName,
-		Type:  FlexType,
-		Value: NewFlexContractValue(gauge, handler),
+		Name:  def.FlexType.Identifier,
+		Type:  def.FlexType,
+		Value: NewFlexContractValue(gauge, def, handler),
 		Kind:  common.DeclarationKindContract,
 	}
 }
 
-var FlexStandardLibraryType = stdlib.StandardLibraryType{
-	Name: FlexTypeName,
-	Type: FlexType,
-	Kind: common.DeclarationKindContract,
+func NewFlexStandardLibraryType(def FlexTypeDefinition) stdlib.StandardLibraryType {
+	return stdlib.StandardLibraryType{
+		Name: def.FlexType.Identifier,
+		Type: def.FlexType,
+		Kind: common.DeclarationKindContract,
+	}
 }

--- a/fvm/flex/stdlib/flex_test.go
+++ b/fvm/flex/stdlib/flex_test.go
@@ -1,4 +1,4 @@
-package stdlib
+package stdlib_test
 
 import (
 	"bytes"
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/onflow/flow-go/fvm/flex/models"
+	"github.com/onflow/flow-go/fvm/flex/stdlib"
+	"github.com/onflow/flow-go/fvm/flex/stdlib/emulator"
 )
 
 type testFlexContractHandler struct {
@@ -59,10 +61,10 @@ var flexAddressBytesCadenceType = cadence.NewConstantSizedArrayType(20, cadence.
 
 var flexAddressCadenceType = cadence.NewStructType(
 	nil,
-	Flex_FlexAddressType.QualifiedIdentifier(),
+	emulator.Flex_FlexAddressType.QualifiedIdentifier(),
 	[]cadence.Field{
 		{
-			Identifier: Flex_FlexAddressTypeBytesFieldName,
+			Identifier: emulator.Flex_FlexAddressTypeBytesFieldName,
 			Type:       flexAddressBytesCadenceType,
 		},
 	},
@@ -77,8 +79,9 @@ func TestFlexAddressConstructionAndReturn(t *testing.T) {
 
 	env := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
 
-	env.DeclareValue(NewFlexStandardLibraryValue(nil, handler))
-	env.DeclareType(FlexStandardLibraryType)
+	flexTypeDefinition := emulator.FlexTypeDefinition
+	env.DeclareValue(stdlib.NewFlexStandardLibraryValue(nil, flexTypeDefinition, handler))
+	env.DeclareType(stdlib.NewFlexStandardLibraryType(flexTypeDefinition))
 
 	inter := runtime.NewInterpreterRuntime(runtime.Config{})
 
@@ -178,8 +181,9 @@ func TestFlexRun(t *testing.T) {
 
 	env := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
 
-	env.DeclareValue(NewFlexStandardLibraryValue(nil, handler))
-	env.DeclareType(FlexStandardLibraryType)
+	flexTypeDefinition := emulator.FlexTypeDefinition
+	env.DeclareValue(stdlib.NewFlexStandardLibraryValue(nil, flexTypeDefinition, handler))
+	env.DeclareType(stdlib.NewFlexStandardLibraryType(flexTypeDefinition))
 
 	inter := runtime.NewInterpreterRuntime(runtime.Config{})
 

--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/flex"
 	flexStdlib "github.com/onflow/flow-go/fvm/flex/stdlib"
+	"github.com/onflow/flow-go/fvm/flex/stdlib/emulator"
 	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
 	"github.com/onflow/flow-go/fvm/storage"
 	"github.com/onflow/flow-go/fvm/storage/derived"
@@ -94,8 +95,10 @@ func newTransactionExecutor(
 	// TODO: how to clean up?
 	if ctx.FlexEnabled {
 		handler := flex.NewFlexContractHandler(env)
-		cadenceRuntime.DeclareValue(flexStdlib.NewFlexStandardLibraryValue(nil, handler))
-		cadenceRuntime.DeclareType(flexStdlib.FlexStandardLibraryType)
+		// TODO: pass proper Flex type definition based on environment
+		flexTypeDefinition := emulator.FlexTypeDefinition
+		cadenceRuntime.DeclareValue(flexStdlib.NewFlexStandardLibraryValue(nil, flexTypeDefinition, handler))
+		cadenceRuntime.DeclareType(flexStdlib.NewFlexStandardLibraryType(flexTypeDefinition))
 	}
 
 	return &transactionExecutor{


### PR DESCRIPTION
Extend the type definition with e.g. `FlowOwnedAccount`.

The type definition relies on `FlowToken.Vault`. As the type definition depends on environment, generate the type definitions into an environment-specific package. Start with the emulator environment.