### PR TITLE
[Access] Index tx results and events

### DIFF
--- a/module/state_synchronization/indexer/indexer_core.go
+++ b/module/state_synchronization/indexer/indexer_core.go
@@ -189,12 +189,6 @@ func (c *IndexerCore) IndexBlockData(data *execution_data.BlockExecutionDataEnti
 	return nil
 }
 
-func (c *IndexerCore) indexEvents(blockID flow.Identifier, events flow.EventsList) error {
-	// Note: the last chunk in an execution data is the system chunk. All events in that ChunkExecutionData are service events.
-	err := c.events.Store(blockID, []flow.EventsList{events})
-	return err
-}
-
 func (c *IndexerCore) indexRegisters(registers map[ledger.Path]*ledger.Payload, height uint64) error {
 	regEntries := make(flow.RegisterEntries, 0, len(registers))
 

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -34,6 +34,7 @@ type indexCoreTest struct {
 	indexer          *IndexerCore
 	registers        *storagemock.RegisterIndex
 	events           *storagemock.Events
+	results          *storagemock.LightTransactionResults
 	headers          *storagemock.Headers
 	ctx              context.Context
 	blocks           []*flow.Block
@@ -54,6 +55,7 @@ func newIndexCoreTest(
 		t:         t,
 		registers: storagemock.NewRegisterIndex(t),
 		events:    storagemock.NewEvents(t),
+		results:   storagemock.NewLightTransactionResults(t),
 		blocks:    blocks,
 		ctx:       context.Background(),
 		data:      exeData,
@@ -103,11 +105,22 @@ func (i *indexCoreTest) setStoreRegisters(f func(t *testing.T, entries flow.Regi
 	return i
 }
 
-func (i *indexCoreTest) setStoreEvents(f func(t *testing.T, ID flow.Identifier, events []flow.EventsList) error) *indexCoreTest {
+func (i *indexCoreTest) setStoreEvents(f func(*testing.T, flow.Identifier, []flow.EventsList) error) *indexCoreTest {
 	i.events.
-		On("Store", mock.AnythingOfType("flow.Identifier"), mock.AnythingOfType("[]flow.EventsList")).
-		Return(func(ID flow.Identifier, events []flow.EventsList) error {
-			return f(i.t, ID, events)
+		On("BatchStore", mock.AnythingOfType("flow.Identifier"), mock.AnythingOfType("[]flow.EventsList"), mock.Anything).
+		Return(func(blockID flow.Identifier, events []flow.EventsList, batch storage.BatchStorage) error {
+			require.NotNil(i.t, batch)
+			return f(i.t, blockID, events)
+		})
+	return i
+}
+
+func (i *indexCoreTest) setStoreTransactionResults(f func(*testing.T, flow.Identifier, []flow.LightTransactionResult) error) *indexCoreTest {
+	i.results.
+		On("BatchStore", mock.AnythingOfType("flow.Identifier"), mock.AnythingOfType("[]flow.LightTransactionResult"), mock.Anything).
+		Return(func(blockID flow.Identifier, results []flow.LightTransactionResult, batch storage.BatchStorage) error {
+			require.NotNil(i.t, batch)
+			return f(i.t, blockID, results)
 		})
 	return i
 }
@@ -123,13 +136,25 @@ func (i *indexCoreTest) setGetRegisters(f func(t *testing.T, ID flow.RegisterID,
 
 func (i *indexCoreTest) useDefaultEvents() *indexCoreTest {
 	i.events.
-		On("Store", mock.AnythingOfType("flow.Identifier"), mock.AnythingOfType("[]flow.EventsList")).
+		On("BatchStore", mock.AnythingOfType("flow.Identifier"), mock.AnythingOfType("[]flow.EventsList"), mock.Anything).
+		Return(nil)
+	return i
+}
+
+func (i *indexCoreTest) useDefaultTransactionResults() *indexCoreTest {
+	i.results.
+		On("BatchStore", mock.AnythingOfType("flow.Identifier"), mock.AnythingOfType("[]flow.LightTransactionResult"), mock.Anything).
 		Return(nil)
 	return i
 }
 
 func (i *indexCoreTest) initIndexer() *indexCoreTest {
-	indexer, err := New(zerolog.New(os.Stdout), i.registers, i.headers, i.events)
+	db, dbDir := unittest.TempBadgerDB(i.t)
+	i.t.Cleanup(func() {
+		require.NoError(i.t, os.RemoveAll(dbDir))
+	})
+
+	indexer, err := New(zerolog.New(os.Stdout), db, i.registers, i.headers, i.events, i.results)
 	require.NoError(i.t, err)
 	i.indexer = indexer
 	return i
@@ -165,6 +190,7 @@ func TestExecutionState_IndexBlockData(t *testing.T) {
 			initIndexer().
 			useDefaultLastHeight().
 			useDefaultEvents().
+			useDefaultTransactionResults().
 			// make sure update registers match in length and are same as block data ledger payloads
 			setStoreRegisters(func(t *testing.T, entries flow.RegisterEntries, height uint64) error {
 				assert.Equal(t, height, block.Header.Height)
@@ -208,6 +234,7 @@ func TestExecutionState_IndexBlockData(t *testing.T) {
 			initIndexer().
 			useDefaultEvents().
 			useDefaultLastHeight().
+			useDefaultTransactionResults().
 			// make sure update registers match in length and are same as block data ledger payloads
 			setStoreRegisters(func(t *testing.T, entries flow.RegisterEntries, height uint64) error {
 				for _, entry := range entries {
@@ -225,6 +252,152 @@ func TestExecutionState_IndexBlockData(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.True(t, testRegisterFound)
+	})
+
+	t.Run("Index Events", func(t *testing.T) {
+		expectedEvents := unittest.EventsFixture(20)
+		ed := &execution_data.BlockExecutionData{
+			BlockID: block.ID(),
+			ChunkExecutionDatas: []*execution_data.ChunkExecutionData{
+				// split events into 2 chunks
+				{Events: expectedEvents[:10]},
+				{Events: expectedEvents[10:]},
+			},
+		}
+		execData := execution_data.NewBlockExecutionDataEntity(block.ID(), ed)
+
+		err := newIndexCoreTest(t, blocks, execData).
+			initIndexer().
+			useDefaultLastHeight().
+			// make sure all events are stored at once in order
+			setStoreEvents(func(t *testing.T, actualBlockID flow.Identifier, actualEvents []flow.EventsList) error {
+				assert.Equal(t, block.ID(), actualBlockID)
+				require.Len(t, actualEvents, 1)
+				require.Len(t, actualEvents[0], len(expectedEvents))
+				for i, expected := range expectedEvents {
+					assert.Equal(t, expected, actualEvents[0][i])
+				}
+				return nil
+			}).
+			// make sure an empty set of transaction results were stored
+			setStoreTransactionResults(func(t *testing.T, actualBlockID flow.Identifier, actualResults []flow.LightTransactionResult) error {
+				assert.Equal(t, block.ID(), actualBlockID)
+				require.Len(t, actualResults, 0)
+				return nil
+			}).
+			// make sure an empty set of register entries was stored
+			setStoreRegisters(func(t *testing.T, entries flow.RegisterEntries, height uint64) error {
+				assert.Equal(t, height, block.Header.Height)
+				assert.Equal(t, 0, entries.Len())
+				return nil
+			}).
+			runIndexBlockData()
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("Index Tx Results", func(t *testing.T) {
+		expectedResults := unittest.LightTransactionResultsFixture(20)
+		ed := &execution_data.BlockExecutionData{
+			BlockID: block.ID(),
+			ChunkExecutionDatas: []*execution_data.ChunkExecutionData{
+				// split events into 2 chunks
+				{TransactionResults: expectedResults[:10]},
+				{TransactionResults: expectedResults[10:]},
+			},
+		}
+		execData := execution_data.NewBlockExecutionDataEntity(block.ID(), ed)
+
+		err := newIndexCoreTest(t, blocks, execData).
+			initIndexer().
+			useDefaultLastHeight().
+			// make sure an empty set of events were stored
+			setStoreEvents(func(t *testing.T, actualBlockID flow.Identifier, actualEvents []flow.EventsList) error {
+				assert.Equal(t, block.ID(), actualBlockID)
+				require.Len(t, actualEvents, 1)
+				require.Len(t, actualEvents[0], 0)
+				return nil
+			}).
+			// make sure all results are stored at once in order
+			setStoreTransactionResults(func(t *testing.T, actualBlockID flow.Identifier, actualResults []flow.LightTransactionResult) error {
+				assert.Equal(t, block.ID(), actualBlockID)
+				require.Len(t, actualResults, len(expectedResults))
+				for i, expected := range expectedResults {
+					assert.Equal(t, expected, actualResults[i])
+				}
+				return nil
+			}).
+			// make sure an empty set of register entries was stored
+			setStoreRegisters(func(t *testing.T, entries flow.RegisterEntries, height uint64) error {
+				assert.Equal(t, height, block.Header.Height)
+				assert.Equal(t, 0, entries.Len())
+				return nil
+			}).
+			runIndexBlockData()
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("Index AllTheThings", func(t *testing.T) {
+		expectedEvents := unittest.EventsFixture(20)
+		expectedResults := unittest.LightTransactionResultsFixture(20)
+		expectedTries := []*ledger.TrieUpdate{trieUpdateFixture(t), trieUpdateFixture(t)}
+		expectedPayloads := make([]*ledger.Payload, 0)
+		for _, trie := range expectedTries {
+			expectedPayloads = append(expectedPayloads, trie.Payloads...)
+		}
+
+		ed := &execution_data.BlockExecutionData{
+			BlockID: block.ID(),
+			ChunkExecutionDatas: []*execution_data.ChunkExecutionData{
+				{
+					Events:             expectedEvents[:10],
+					TransactionResults: expectedResults[:10],
+					TrieUpdate:         expectedTries[0],
+				},
+				{
+					TransactionResults: expectedResults[10:],
+					Events:             expectedEvents[10:],
+					TrieUpdate:         expectedTries[1],
+				},
+			},
+		}
+		execData := execution_data.NewBlockExecutionDataEntity(block.ID(), ed)
+
+		err := newIndexCoreTest(t, blocks, execData).
+			initIndexer().
+			useDefaultLastHeight().
+			// make sure all events are stored at once in order
+			setStoreEvents(func(t *testing.T, actualBlockID flow.Identifier, actualEvents []flow.EventsList) error {
+				assert.Equal(t, block.ID(), actualBlockID)
+				require.Len(t, actualEvents, 1)
+				require.Len(t, actualEvents[0], len(expectedEvents))
+				for i, expected := range expectedEvents {
+					assert.Equal(t, expected, actualEvents[0][i])
+				}
+				return nil
+			}).
+			// make sure all results are stored at once in order
+			setStoreTransactionResults(func(t *testing.T, actualBlockID flow.Identifier, actualResults []flow.LightTransactionResult) error {
+				assert.Equal(t, block.ID(), actualBlockID)
+				require.Len(t, actualResults, len(expectedResults))
+				for i, expected := range expectedResults {
+					assert.Equal(t, expected, actualResults[i])
+				}
+				return nil
+			}).
+			// make sure update registers match in length and are same as block data ledger payloads
+			setStoreRegisters(func(t *testing.T, entries flow.RegisterEntries, actualHeight uint64) error {
+				assert.Equal(t, actualHeight, block.Header.Height)
+				assert.Equal(t, entries.Len(), len(expectedPayloads))
+
+				// make sure all the registers from the execution data have been stored as well the value matches
+				trieRegistersPayloadComparer(t, expectedPayloads, entries)
+				return nil
+			}).
+			runIndexBlockData()
+
+		assert.NoError(t, err)
 	})
 
 	// this test makes sure we get correct error when we try to index block that is not
@@ -422,10 +595,15 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	regKey := "code"
 	registerID := flow.NewRegisterID(regOwner, regKey)
 
+	db, dbDir := unittest.TempBadgerDB(t)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(dbDir))
+	})
+
 	// this test makes sure index values for a single register are correctly updated and always last value is returned
 	t.Run("Single Index Value Changes", func(t *testing.T) {
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
-			index, err := New(zerolog.Nop(), registers, nil, nil)
+			index, err := New(zerolog.Nop(), db, registers, nil, nil, nil)
 			require.NoError(t, err)
 
 			values := [][]byte{[]byte("1"), []byte("1"), []byte("2"), []byte("3") /*nil,*/, []byte("4")}
@@ -452,7 +630,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// e.g. we index A{h(1) -> X}, A{h(2) -> Y}, when we request h(4) we get value Y
 	t.Run("Single Index Value At Later Heights", func(t *testing.T) {
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
-			index, err := New(zerolog.Nop(), registers, nil, nil)
+			index, err := New(zerolog.Nop(), db, registers, nil, nil, nil)
 			require.NoError(t, err)
 
 			storeValues := [][]byte{[]byte("1"), []byte("2")}
@@ -483,7 +661,7 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// this test makes sure we correctly handle weird payloads
 	t.Run("Empty and Nil Payloads", func(t *testing.T) {
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
-			index, err := New(zerolog.Nop(), registers, nil, nil)
+			index, err := New(zerolog.Nop(), db, registers, nil, nil, nil)
 			require.NoError(t, err)
 
 			require.NoError(t, index.indexRegisters(map[ledger.Path]*ledger.Payload{}, 1))

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -151,6 +151,7 @@ func (i *indexCoreTest) useDefaultTransactionResults() *indexCoreTest {
 func (i *indexCoreTest) initIndexer() *indexCoreTest {
 	db, dbDir := unittest.TempBadgerDB(i.t)
 	i.t.Cleanup(func() {
+		require.NoError(i.t, db.Close())
 		require.NoError(i.t, os.RemoveAll(dbDir))
 	})
 

--- a/module/state_synchronization/indexer/indexer_test.go
+++ b/module/state_synchronization/indexer/indexer_test.go
@@ -44,6 +44,7 @@ func newIndexerTest(t *testing.T, availableBlocks int, lastIndexedIndex int) *in
 		}).
 		useDefaultBlockByHeight().
 		useDefaultEvents().
+		useDefaultTransactionResults().
 		initIndexer()
 
 	executionData := mempool.NewExecutionData(t)

--- a/storage/badger/batch.go
+++ b/storage/badger/batch.go
@@ -6,6 +6,10 @@ import (
 	"github.com/dgraph-io/badger/v2"
 )
 
+type BatchBuilder interface {
+	NewWriteBatch() *badger.WriteBatch
+}
+
 type Batch struct {
 	writer *badger.WriteBatch
 
@@ -13,7 +17,7 @@ type Batch struct {
 	callbacks []func()
 }
 
-func NewBatch(db *badger.DB) *Batch {
+func NewBatch(db BatchBuilder) *Batch {
 	batch := db.NewWriteBatch()
 	return &Batch{
 		writer:    batch,

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2368,6 +2368,18 @@ func TransactionResultsFixture(n int) []flow.TransactionResult {
 	return results
 }
 
+func LightTransactionResultsFixture(n int) []flow.LightTransactionResult {
+	results := make([]flow.LightTransactionResult, 0, n)
+	for i := 0; i < n; i++ {
+		results = append(results, flow.LightTransactionResult{
+			TransactionID:   IdentifierFixture(),
+			Failed:          i%2 == 0,
+			ComputationUsed: Uint64InRange(1, 10_000),
+		})
+	}
+	return results
+}
+
 func AllowAllPeerFilter() func(peer.ID) error {
 	return func(_ peer.ID) error {
 		return nil


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4739, https://github.com/onflow/flow-go/issues/4674

This PR adds support for indexing `flow.LightTransactionResults` and `flow.Events` from ExecutionData as part of the data indexing.