### PR TITLE
Remove proposer label from `block_height` metrics

### DIFF
--- a/module/metrics/collection.go
+++ b/module/metrics/collection.go
@@ -49,7 +49,7 @@ func NewCollectionCollector(tracer module.Tracer) *CollectionCollector {
 			Buckets:   []float64{1, 2, 5, 10, 20},
 			Name:      "guarantees_size_transactions",
 			Help:      "size/number of guaranteed/finalized collections",
-		}, []string{LabelChain, LabelProposer}),
+		}, []string{LabelChain}),
 	}
 
 	return cc
@@ -76,15 +76,13 @@ func (cc *CollectionCollector) ClusterBlockProposed(block *cluster.Block) {
 func (cc *CollectionCollector) ClusterBlockFinalized(block *cluster.Block) {
 	collection := block.Payload.Collection.Light()
 	chainID := block.Header.ChainID
-	proposer := block.Header.ProposerID
 
 	cc.finalizedHeight.
 		With(prometheus.Labels{LabelChain: chainID.String()}).
 		Set(float64(block.Header.Height))
 	cc.guarantees.
 		With(prometheus.Labels{
-			LabelChain:    chainID.String(),
-			LabelProposer: proposer.String(),
+			LabelChain: chainID.String(),
 		}).
 		Observe(float64(collection.Len()))
 }


### PR DESCRIPTION
The proposer label makes the metric very high-cardinality, meaning it consumes a lot of Grafana resources to deal with (~2-3% of total series on Grafana). We do not use this label any more, and having it makes for more complex queries over this metric than necessary. For example, we should be able to replace
```
avg by (role) (sum by (num) (rate(consensus_compliance_finalized_blocks_total{role="consensus",network="$network"}[2m])))
```
with 
```
avg(rate(consensus_compliance_finalized_blocks_total{role="consensus",network="$network"}[2m]))
```

We make the same change to the corresponding collection node metric.