### PR TITLE
[Access] Update state stream API to return json-cdc encoded events - backport master

### DIFF
--- a/engine/access/state_stream/handler.go
+++ b/engine/access/state_stream/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 
+	"github.com/onflow/flow/protobuf/go/flow/execution"
 	access "github.com/onflow/flow/protobuf/go/flow/executiondata"
 	executiondata "github.com/onflow/flow/protobuf/go/flow/executiondata"
 	"google.golang.org/grpc/codes"
@@ -51,6 +52,13 @@ func (h *Handler) GetExecutionDataByBlockID(ctx context.Context, request *access
 		return nil, status.Errorf(codes.Internal, "could not convert execution data to entity: %v", err)
 	}
 
+	// convert event payloads from CCF to JSON-CDC
+	// This is a temporary solution until the Access API supports specifying the encoding in the request
+	err = convert.BlockExecutionDataEventPayloadsToJson(message)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not convert execution data event payloads to JSON: %v", err)
+	}
+
 	return &access.GetExecutionDataByBlockIDResponse{BlockExecutionData: message}, nil
 }
 
@@ -90,6 +98,13 @@ func (h *Handler) SubscribeExecutionData(request *access.SubscribeExecutionDataR
 		execData, err := convert.BlockExecutionDataToMessage(resp.ExecutionData)
 		if err != nil {
 			return status.Errorf(codes.Internal, "could not convert execution data to entity: %v", err)
+		}
+
+		// convert event payloads from CCF to JSON-CDC
+		// This is a temporary solution until the Access API supports specifying the encoding in the request
+		err = convert.BlockExecutionDataEventPayloadsToJson(execData)
+		if err != nil {
+			return status.Errorf(codes.Internal, "could not convert execution data event payloads to JSON: %v", err)
 		}
 
 		err = stream.Send(&executiondata.SubscribeExecutionDataResponse{
@@ -151,10 +166,18 @@ func (h *Handler) SubscribeEvents(request *access.SubscribeEventsRequest, stream
 			return status.Errorf(codes.Internal, "unexpected response type: %T", v)
 		}
 
-		err := stream.Send(&executiondata.SubscribeEventsResponse{
+		// BlockExecutionData contains CCF encoded events, and the Access API returns JSON-CDC events.
+		// convert event payload formats.
+		// This is a temporary solution until the Access API supports specifying the encoding in the request
+		events, err := convert.EventsToMessagesFromVersion(resp.Events, execution.EventEncodingVersion_CCF_V0)
+		if err != nil {
+			return status.Errorf(codes.Internal, "could not convert events to entity: %v", err)
+		}
+
+		err = stream.Send(&executiondata.SubscribeEventsResponse{
 			BlockHeight: resp.Height,
 			BlockId:     convert.IdentifierToMessage(resp.BlockID),
-			Events:      convert.EventsToMessages(resp.Events),
+			Events:      events,
 		})
 		if err != nil {
 			return rpc.ConvertError(err, "could not send response", codes.Internal)

--- a/engine/access/state_stream/handler_test.go
+++ b/engine/access/state_stream/handler_test.go
@@ -1,0 +1,230 @@
+package state_stream_test
+
+// import (
+// 	"context"
+// 	"io"
+// 	"sync"
+// 	"testing"
+// 	"time"
+
+// 	"github.com/stretchr/testify/assert"
+// 	"github.com/stretchr/testify/mock"
+// 	"github.com/stretchr/testify/require"
+// 	"google.golang.org/grpc"
+
+// 	jsoncdc "github.com/onflow/cadence/encoding/json"
+// 	access "github.com/onflow/flow/protobuf/go/flow/executiondata"
+
+// 	"github.com/onflow/flow-go/engine/access/state_stream"
+// 	ssmock "github.com/onflow/flow-go/engine/access/state_stream/mock"
+// 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+// 	"github.com/onflow/flow-go/model/flow"
+// 	"github.com/onflow/flow-go/utils/unittest"
+// 	"github.com/onflow/flow-go/utils/unittest/generator"
+// )
+
+// func TestExecutionDataStream(t *testing.T) {
+// 	ctx, cancel := context.WithCancel(context.Background())
+// 	defer cancel()
+
+// 	api := ssmock.NewAPI(t)
+// 	stream := makeStreamMock[access.SubscribeExecutionDataRequest, access.SubscribeExecutionDataResponse](ctx)
+// 	sub := state_stream.NewSubscription(1)
+
+// 	// generate some events with a payload to include
+// 	// generators will produce identical event payloads (before encoding)
+// 	ccfEventGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingCCF))
+// 	jsonEventsGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingJSON))
+// 	inputEvents := make([]flow.Event, 0, 3)
+// 	expectedEvents := make([]flow.Event, 0, 3)
+// 	for i := 0; i < 3; i++ {
+// 		inputEvents = append(inputEvents, ccfEventGenerator.New())
+// 		expectedEvents = append(expectedEvents, jsonEventsGenerator.New())
+// 	}
+
+// 	api.On("SubscribeExecutionData", mock.Anything, flow.ZeroID, uint64(0), mock.Anything).Return(sub)
+
+// 	h := state_stream.NewHandler(api, flow.Localnet.Chain(), state_stream.EventFilterConfig{}, 1)
+
+// 	wg := sync.WaitGroup{}
+// 	wg.Add(1)
+// 	go func() {
+// 		wg.Done()
+// 		err := h.SubscribeExecutionData(&access.SubscribeExecutionDataRequest{}, stream)
+// 		require.NoError(t, err)
+// 		t.Log("subscription closed")
+// 	}()
+// 	wg.Wait()
+
+// 	// send a single response
+// 	blockHeight := uint64(1)
+// 	executionData := unittest.BlockExecutionDataFixture(
+// 		unittest.WithChunkExecutionDatas(
+// 			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(inputEvents)),
+// 			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(inputEvents)),
+// 		),
+// 	)
+
+// 	err := sub.Send(ctx, &state_stream.ExecutionDataResponse{
+// 		Height:        blockHeight,
+// 		ExecutionData: executionData,
+// 	}, 100*time.Millisecond)
+// 	require.NoError(t, err)
+
+// 	// notify end of data
+// 	sub.Close()
+
+// 	receivedCount := 0
+// 	for {
+// 		t.Log(receivedCount)
+// 		resp, err := stream.RecvToClient()
+// 		if err == io.EOF {
+// 			break
+// 		}
+// 		require.NoError(t, err)
+
+// 		convertedExecData, err := convert.MessageToBlockExecutionData(resp.GetBlockExecutionData(), flow.Testnet.Chain())
+// 		require.NoError(t, err)
+
+// 		assert.Equal(t, blockHeight, resp.GetBlockHeight())
+
+// 		// make sure the payload is valid JSON-CDC
+// 		for _, chunk := range convertedExecData.ChunkExecutionDatas {
+// 			for i, e := range chunk.Events {
+// 				assert.Equal(t, expectedEvents[i], e)
+
+// 				_, err := jsoncdc.Decode(nil, e.Payload)
+// 				require.NoError(t, err)
+// 			}
+// 		}
+
+// 		receivedCount++
+
+// 		// shutdown the stream after one response
+// 		close(stream.sentFromServer)
+// 	}
+
+// 	// only expect a single response
+// 	assert.Equal(t, 1, receivedCount)
+// }
+
+// func TestEventStream(t *testing.T) {
+// 	ctx, cancel := context.WithCancel(context.Background())
+// 	defer cancel()
+
+// 	api := ssmock.NewAPI(t)
+// 	stream := makeStreamMock[access.SubscribeEventsRequest, access.SubscribeEventsResponse](ctx)
+// 	sub := state_stream.NewSubscription(1)
+
+// 	// generate some events with a payload to include
+// 	// generators will produce identical event payloads (before encoding)
+// 	ccfEventGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingCCF))
+// 	jsonEventsGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingJSON))
+// 	inputEvents := make([]flow.Event, 0, 3)
+// 	expectedEvents := make([]flow.Event, 0, 3)
+// 	for i := 0; i < 3; i++ {
+// 		inputEvents = append(inputEvents, ccfEventGenerator.New())
+// 		expectedEvents = append(expectedEvents, jsonEventsGenerator.New())
+// 	}
+
+// 	api.On("SubscribeEvents", mock.Anything, flow.ZeroID, uint64(0), mock.Anything).Return(sub)
+
+// 	h := state_stream.NewHandler(api, flow.Localnet.Chain(), state_stream.EventFilterConfig{}, 1)
+
+// 	wg := sync.WaitGroup{}
+// 	wg.Add(1)
+// 	go func() {
+// 		wg.Done()
+// 		err := h.SubscribeEvents(&access.SubscribeEventsRequest{}, stream)
+// 		require.NoError(t, err)
+// 		t.Log("subscription closed")
+// 	}()
+// 	wg.Wait()
+
+// 	// send a single response
+// 	blockHeight := uint64(1)
+// 	blockID := unittest.IdentifierFixture()
+// 	err := sub.Send(ctx, &state_stream.EventsResponse{
+// 		BlockID: blockID,
+// 		Height:  blockHeight,
+// 		Events:  inputEvents,
+// 	}, 100*time.Millisecond)
+// 	require.NoError(t, err)
+
+// 	// notify end of data
+// 	sub.Close()
+
+// 	receivedCount := 0
+// 	for {
+// 		t.Log(receivedCount)
+// 		resp, err := stream.RecvToClient()
+// 		if err == io.EOF {
+// 			break
+// 		}
+// 		require.NoError(t, err)
+
+// 		convertedEvents := convert.MessagesToEvents(resp.GetEvents())
+
+// 		assert.Equal(t, blockHeight, resp.GetBlockHeight())
+// 		assert.Equal(t, blockID, convert.MessageToIdentifier(resp.GetBlockId()))
+// 		assert.Equal(t, expectedEvents, convertedEvents)
+
+// 		// make sure the payload is valid JSON-CDC
+// 		for _, e := range convertedEvents {
+// 			_, err := jsoncdc.Decode(nil, e.Payload)
+// 			require.NoError(t, err)
+// 		}
+
+// 		receivedCount++
+
+// 		// shutdown the stream after one response
+// 		close(stream.sentFromServer)
+// 	}
+
+// 	// only expect a single response
+// 	assert.Equal(t, 1, receivedCount)
+// }
+
+// func makeStreamMock[R, T any](ctx context.Context) *StreamMock[R, T] {
+// 	return &StreamMock[R, T]{
+// 		ctx:            ctx,
+// 		recvToServer:   make(chan *R, 10),
+// 		sentFromServer: make(chan *T, 10),
+// 	}
+// }
+
+// type StreamMock[R, T any] struct {
+// 	grpc.ServerStream
+// 	ctx            context.Context
+// 	recvToServer   chan *R
+// 	sentFromServer chan *T
+// }
+
+// func (m *StreamMock[R, T]) Context() context.Context {
+// 	return m.ctx
+// }
+// func (m *StreamMock[R, T]) Send(resp *T) error {
+// 	m.sentFromServer <- resp
+// 	return nil
+// }
+
+// func (m *StreamMock[R, T]) Recv() (*R, error) {
+// 	req, more := <-m.recvToServer
+// 	if !more {
+// 		return nil, io.EOF
+// 	}
+// 	return req, nil
+// }
+
+// func (m *StreamMock[R, T]) SendFromClient(req *R) error {
+// 	m.recvToServer <- req
+// 	return nil
+// }
+
+// func (m *StreamMock[R, T]) RecvToClient() (*T, error) {
+// 	response, more := <-m.sentFromServer
+// 	if !more {
+// 		return nil, io.EOF
+// 	}
+// 	return response, nil
+// }

--- a/engine/access/state_stream/handler_test.go
+++ b/engine/access/state_stream/handler_test.go
@@ -1,230 +1,234 @@
 package state_stream_test
 
-// import (
-// 	"context"
-// 	"io"
-// 	"sync"
-// 	"testing"
-// 	"time"
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
 
-// 	"github.com/stretchr/testify/assert"
-// 	"github.com/stretchr/testify/mock"
-// 	"github.com/stretchr/testify/require"
-// 	"google.golang.org/grpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
-// 	jsoncdc "github.com/onflow/cadence/encoding/json"
-// 	access "github.com/onflow/flow/protobuf/go/flow/executiondata"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+	access "github.com/onflow/flow/protobuf/go/flow/executiondata"
 
-// 	"github.com/onflow/flow-go/engine/access/state_stream"
-// 	ssmock "github.com/onflow/flow-go/engine/access/state_stream/mock"
-// 	"github.com/onflow/flow-go/engine/common/rpc/convert"
-// 	"github.com/onflow/flow-go/model/flow"
-// 	"github.com/onflow/flow-go/utils/unittest"
-// 	"github.com/onflow/flow-go/utils/unittest/generator"
-// )
+	"github.com/onflow/flow-go/engine/access/state_stream"
+	ssmock "github.com/onflow/flow-go/engine/access/state_stream/mock"
+	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/onflow/flow-go/utils/unittest/generator"
+)
 
-// func TestExecutionDataStream(t *testing.T) {
-// 	ctx, cancel := context.WithCancel(context.Background())
-// 	defer cancel()
+func TestExecutionDataStream(t *testing.T) {
+	t.Parallel()
 
-// 	api := ssmock.NewAPI(t)
-// 	stream := makeStreamMock[access.SubscribeExecutionDataRequest, access.SubscribeExecutionDataResponse](ctx)
-// 	sub := state_stream.NewSubscription(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-// 	// generate some events with a payload to include
-// 	// generators will produce identical event payloads (before encoding)
-// 	ccfEventGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingCCF))
-// 	jsonEventsGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingJSON))
-// 	inputEvents := make([]flow.Event, 0, 3)
-// 	expectedEvents := make([]flow.Event, 0, 3)
-// 	for i := 0; i < 3; i++ {
-// 		inputEvents = append(inputEvents, ccfEventGenerator.New())
-// 		expectedEvents = append(expectedEvents, jsonEventsGenerator.New())
-// 	}
+	api := ssmock.NewAPI(t)
+	stream := makeStreamMock[access.SubscribeExecutionDataRequest, access.SubscribeExecutionDataResponse](ctx)
+	sub := state_stream.NewSubscription(1)
 
-// 	api.On("SubscribeExecutionData", mock.Anything, flow.ZeroID, uint64(0), mock.Anything).Return(sub)
+	// generate some events with a payload to include
+	// generators will produce identical event payloads (before encoding)
+	ccfEventGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingCCF))
+	jsonEventsGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingJSON))
+	inputEvents := make([]flow.Event, 0, 3)
+	expectedEvents := make([]flow.Event, 0, 3)
+	for i := 0; i < 3; i++ {
+		inputEvents = append(inputEvents, ccfEventGenerator.New())
+		expectedEvents = append(expectedEvents, jsonEventsGenerator.New())
+	}
 
-// 	h := state_stream.NewHandler(api, flow.Localnet.Chain(), state_stream.EventFilterConfig{}, 1)
+	api.On("SubscribeExecutionData", mock.Anything, flow.ZeroID, uint64(0), mock.Anything).Return(sub)
 
-// 	wg := sync.WaitGroup{}
-// 	wg.Add(1)
-// 	go func() {
-// 		wg.Done()
-// 		err := h.SubscribeExecutionData(&access.SubscribeExecutionDataRequest{}, stream)
-// 		require.NoError(t, err)
-// 		t.Log("subscription closed")
-// 	}()
-// 	wg.Wait()
+	h := state_stream.NewHandler(api, flow.Localnet.Chain(), state_stream.EventFilterConfig{}, 1)
 
-// 	// send a single response
-// 	blockHeight := uint64(1)
-// 	executionData := unittest.BlockExecutionDataFixture(
-// 		unittest.WithChunkExecutionDatas(
-// 			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(inputEvents)),
-// 			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(inputEvents)),
-// 		),
-// 	)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		err := h.SubscribeExecutionData(&access.SubscribeExecutionDataRequest{}, stream)
+		require.NoError(t, err)
+		t.Log("subscription closed")
+	}()
+	wg.Wait()
 
-// 	err := sub.Send(ctx, &state_stream.ExecutionDataResponse{
-// 		Height:        blockHeight,
-// 		ExecutionData: executionData,
-// 	}, 100*time.Millisecond)
-// 	require.NoError(t, err)
+	// send a single response
+	blockHeight := uint64(1)
+	executionData := unittest.BlockExecutionDataFixture(
+		unittest.WithChunkExecutionDatas(
+			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(inputEvents)),
+			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(inputEvents)),
+		),
+	)
 
-// 	// notify end of data
-// 	sub.Close()
+	err := sub.Send(ctx, &state_stream.ExecutionDataResponse{
+		Height:        blockHeight,
+		ExecutionData: executionData,
+	}, 100*time.Millisecond)
+	require.NoError(t, err)
 
-// 	receivedCount := 0
-// 	for {
-// 		t.Log(receivedCount)
-// 		resp, err := stream.RecvToClient()
-// 		if err == io.EOF {
-// 			break
-// 		}
-// 		require.NoError(t, err)
+	// notify end of data
+	sub.Close()
 
-// 		convertedExecData, err := convert.MessageToBlockExecutionData(resp.GetBlockExecutionData(), flow.Testnet.Chain())
-// 		require.NoError(t, err)
+	receivedCount := 0
+	for {
+		t.Log(receivedCount)
+		resp, err := stream.RecvToClient()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
 
-// 		assert.Equal(t, blockHeight, resp.GetBlockHeight())
+		convertedExecData, err := convert.MessageToBlockExecutionData(resp.GetBlockExecutionData(), flow.Testnet.Chain())
+		require.NoError(t, err)
 
-// 		// make sure the payload is valid JSON-CDC
-// 		for _, chunk := range convertedExecData.ChunkExecutionDatas {
-// 			for i, e := range chunk.Events {
-// 				assert.Equal(t, expectedEvents[i], e)
+		assert.Equal(t, blockHeight, resp.GetBlockHeight())
 
-// 				_, err := jsoncdc.Decode(nil, e.Payload)
-// 				require.NoError(t, err)
-// 			}
-// 		}
+		// make sure the payload is valid JSON-CDC
+		for _, chunk := range convertedExecData.ChunkExecutionDatas {
+			for i, e := range chunk.Events {
+				assert.Equal(t, expectedEvents[i], e)
 
-// 		receivedCount++
+				_, err := jsoncdc.Decode(nil, e.Payload)
+				require.NoError(t, err)
+			}
+		}
 
-// 		// shutdown the stream after one response
-// 		close(stream.sentFromServer)
-// 	}
+		receivedCount++
 
-// 	// only expect a single response
-// 	assert.Equal(t, 1, receivedCount)
-// }
+		// shutdown the stream after one response
+		close(stream.sentFromServer)
+	}
 
-// func TestEventStream(t *testing.T) {
-// 	ctx, cancel := context.WithCancel(context.Background())
-// 	defer cancel()
+	// only expect a single response
+	assert.Equal(t, 1, receivedCount)
+}
 
-// 	api := ssmock.NewAPI(t)
-// 	stream := makeStreamMock[access.SubscribeEventsRequest, access.SubscribeEventsResponse](ctx)
-// 	sub := state_stream.NewSubscription(1)
+func TestEventStream(t *testing.T) {
+	t.Parallel()
 
-// 	// generate some events with a payload to include
-// 	// generators will produce identical event payloads (before encoding)
-// 	ccfEventGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingCCF))
-// 	jsonEventsGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingJSON))
-// 	inputEvents := make([]flow.Event, 0, 3)
-// 	expectedEvents := make([]flow.Event, 0, 3)
-// 	for i := 0; i < 3; i++ {
-// 		inputEvents = append(inputEvents, ccfEventGenerator.New())
-// 		expectedEvents = append(expectedEvents, jsonEventsGenerator.New())
-// 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-// 	api.On("SubscribeEvents", mock.Anything, flow.ZeroID, uint64(0), mock.Anything).Return(sub)
+	api := ssmock.NewAPI(t)
+	stream := makeStreamMock[access.SubscribeEventsRequest, access.SubscribeEventsResponse](ctx)
+	sub := state_stream.NewSubscription(1)
 
-// 	h := state_stream.NewHandler(api, flow.Localnet.Chain(), state_stream.EventFilterConfig{}, 1)
+	// generate some events with a payload to include
+	// generators will produce identical event payloads (before encoding)
+	ccfEventGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingCCF))
+	jsonEventsGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingJSON))
+	inputEvents := make([]flow.Event, 0, 3)
+	expectedEvents := make([]flow.Event, 0, 3)
+	for i := 0; i < 3; i++ {
+		inputEvents = append(inputEvents, ccfEventGenerator.New())
+		expectedEvents = append(expectedEvents, jsonEventsGenerator.New())
+	}
 
-// 	wg := sync.WaitGroup{}
-// 	wg.Add(1)
-// 	go func() {
-// 		wg.Done()
-// 		err := h.SubscribeEvents(&access.SubscribeEventsRequest{}, stream)
-// 		require.NoError(t, err)
-// 		t.Log("subscription closed")
-// 	}()
-// 	wg.Wait()
+	api.On("SubscribeEvents", mock.Anything, flow.ZeroID, uint64(0), mock.Anything).Return(sub)
 
-// 	// send a single response
-// 	blockHeight := uint64(1)
-// 	blockID := unittest.IdentifierFixture()
-// 	err := sub.Send(ctx, &state_stream.EventsResponse{
-// 		BlockID: blockID,
-// 		Height:  blockHeight,
-// 		Events:  inputEvents,
-// 	}, 100*time.Millisecond)
-// 	require.NoError(t, err)
+	h := state_stream.NewHandler(api, flow.Localnet.Chain(), state_stream.EventFilterConfig{}, 1)
 
-// 	// notify end of data
-// 	sub.Close()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		err := h.SubscribeEvents(&access.SubscribeEventsRequest{}, stream)
+		require.NoError(t, err)
+		t.Log("subscription closed")
+	}()
+	wg.Wait()
 
-// 	receivedCount := 0
-// 	for {
-// 		t.Log(receivedCount)
-// 		resp, err := stream.RecvToClient()
-// 		if err == io.EOF {
-// 			break
-// 		}
-// 		require.NoError(t, err)
+	// send a single response
+	blockHeight := uint64(1)
+	blockID := unittest.IdentifierFixture()
+	err := sub.Send(ctx, &state_stream.EventsResponse{
+		BlockID: blockID,
+		Height:  blockHeight,
+		Events:  inputEvents,
+	}, 100*time.Millisecond)
+	require.NoError(t, err)
 
-// 		convertedEvents := convert.MessagesToEvents(resp.GetEvents())
+	// notify end of data
+	sub.Close()
 
-// 		assert.Equal(t, blockHeight, resp.GetBlockHeight())
-// 		assert.Equal(t, blockID, convert.MessageToIdentifier(resp.GetBlockId()))
-// 		assert.Equal(t, expectedEvents, convertedEvents)
+	receivedCount := 0
+	for {
+		t.Log(receivedCount)
+		resp, err := stream.RecvToClient()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
 
-// 		// make sure the payload is valid JSON-CDC
-// 		for _, e := range convertedEvents {
-// 			_, err := jsoncdc.Decode(nil, e.Payload)
-// 			require.NoError(t, err)
-// 		}
+		convertedEvents := convert.MessagesToEvents(resp.GetEvents())
 
-// 		receivedCount++
+		assert.Equal(t, blockHeight, resp.GetBlockHeight())
+		assert.Equal(t, blockID, convert.MessageToIdentifier(resp.GetBlockId()))
+		assert.Equal(t, expectedEvents, convertedEvents)
 
-// 		// shutdown the stream after one response
-// 		close(stream.sentFromServer)
-// 	}
+		// make sure the payload is valid JSON-CDC
+		for _, e := range convertedEvents {
+			_, err := jsoncdc.Decode(nil, e.Payload)
+			require.NoError(t, err)
+		}
 
-// 	// only expect a single response
-// 	assert.Equal(t, 1, receivedCount)
-// }
+		receivedCount++
 
-// func makeStreamMock[R, T any](ctx context.Context) *StreamMock[R, T] {
-// 	return &StreamMock[R, T]{
-// 		ctx:            ctx,
-// 		recvToServer:   make(chan *R, 10),
-// 		sentFromServer: make(chan *T, 10),
-// 	}
-// }
+		// shutdown the stream after one response
+		close(stream.sentFromServer)
+	}
 
-// type StreamMock[R, T any] struct {
-// 	grpc.ServerStream
-// 	ctx            context.Context
-// 	recvToServer   chan *R
-// 	sentFromServer chan *T
-// }
+	// only expect a single response
+	assert.Equal(t, 1, receivedCount)
+}
 
-// func (m *StreamMock[R, T]) Context() context.Context {
-// 	return m.ctx
-// }
-// func (m *StreamMock[R, T]) Send(resp *T) error {
-// 	m.sentFromServer <- resp
-// 	return nil
-// }
+func makeStreamMock[R, T any](ctx context.Context) *StreamMock[R, T] {
+	return &StreamMock[R, T]{
+		ctx:            ctx,
+		recvToServer:   make(chan *R, 10),
+		sentFromServer: make(chan *T, 10),
+	}
+}
 
-// func (m *StreamMock[R, T]) Recv() (*R, error) {
-// 	req, more := <-m.recvToServer
-// 	if !more {
-// 		return nil, io.EOF
-// 	}
-// 	return req, nil
-// }
+type StreamMock[R, T any] struct {
+	grpc.ServerStream
+	ctx            context.Context
+	recvToServer   chan *R
+	sentFromServer chan *T
+}
 
-// func (m *StreamMock[R, T]) SendFromClient(req *R) error {
-// 	m.recvToServer <- req
-// 	return nil
-// }
+func (m *StreamMock[R, T]) Context() context.Context {
+	return m.ctx
+}
+func (m *StreamMock[R, T]) Send(resp *T) error {
+	m.sentFromServer <- resp
+	return nil
+}
 
-// func (m *StreamMock[R, T]) RecvToClient() (*T, error) {
-// 	response, more := <-m.sentFromServer
-// 	if !more {
-// 		return nil, io.EOF
-// 	}
-// 	return response, nil
-// }
+func (m *StreamMock[R, T]) Recv() (*R, error) {
+	req, more := <-m.recvToServer
+	if !more {
+		return nil, io.EOF
+	}
+	return req, nil
+}
+
+func (m *StreamMock[R, T]) SendFromClient(req *R) error {
+	m.recvToServer <- req
+	return nil
+}
+
+func (m *StreamMock[R, T]) RecvToClient() (*T, error) {
+	response, more := <-m.sentFromServer
+	if !more {
+		return nil, io.EOF
+	}
+	return response, nil
+}

--- a/engine/common/rpc/convert/events.go
+++ b/engine/common/rpc/convert/events.go
@@ -61,6 +61,25 @@ func MessagesToEvents(l []*entities.Event) []flow.Event {
 	return events
 }
 
+// EventToMessageFromVersion converts a flow.Event to a protobuf message, converting the payload
+// encoding from CCF to JSON if the input version is CCF
+func EventToMessageFromVersion(e flow.Event, version execproto.EventEncodingVersion) (*entities.Event, error) {
+	message := EventToMessage(e)
+	switch version {
+	case execproto.EventEncodingVersion_CCF_V0:
+		convertedPayload, err := CcfPayloadToJsonPayload(e.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert event payload from CCF to Json: %w", err)
+		}
+		message.Payload = convertedPayload
+	case execproto.EventEncodingVersion_JSON_CDC_V0:
+	default:
+		return nil, fmt.Errorf("invalid encoding format %d", version)
+	}
+
+	return message, nil
+}
+
 // MessageToEventFromVersion converts a protobuf message to a flow.Event, and converts the payload
 // encoding from CCF to JSON if the input version is CCF
 func MessageToEventFromVersion(m *entities.Event, inputVersion execproto.EventEncodingVersion) (*flow.Event, error) {
@@ -78,6 +97,21 @@ func MessageToEventFromVersion(m *entities.Event, inputVersion execproto.EventEn
 	default:
 		return nil, fmt.Errorf("invalid encoding format %d", inputVersion)
 	}
+}
+
+// EventsToMessagesFromVersion converts a slice of flow.Events to a slice of protobuf messages, converting
+// the payload encoding from CCF to JSON if the input version is CCF
+func EventsToMessagesFromVersion(flowEvents []flow.Event, version execproto.EventEncodingVersion) ([]*entities.Event, error) {
+	events := make([]*entities.Event, len(flowEvents))
+	for i, e := range flowEvents {
+		event, err := EventToMessageFromVersion(e, version)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert event at index %d from format %d: %w",
+				e.EventIndex, version, err)
+		}
+		events[i] = event
+	}
+	return events, nil
 }
 
 // MessagesToEventsFromVersion converts a slice of protobuf messages to a slice of flow.Events, converting

--- a/engine/common/rpc/convert/execution_data.go
+++ b/engine/common/rpc/convert/execution_data.go
@@ -13,6 +13,21 @@ import (
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 )
 
+// BlockExecutionDataEventPayloadsToJson converts all event payloads from CCF to JSON-CDC in place
+// This is a temporary workaround until a more robust solution is implemented
+func BlockExecutionDataEventPayloadsToJson(m *entities.BlockExecutionData) error {
+	for i, chunk := range m.ChunkExecutionData {
+		for j, e := range chunk.Events {
+			converted, err := CcfPayloadToJsonPayload(e.Payload)
+			if err != nil {
+				return fmt.Errorf("failed to convert payload for event %d to json: %w", j, err)
+			}
+			m.ChunkExecutionData[i].Events[j].Payload = converted
+		}
+	}
+	return nil
+}
+
 // BlockExecutionDataToMessage converts a BlockExecutionData to a protobuf message
 func BlockExecutionDataToMessage(data *execution_data.BlockExecutionData) (
 	*entities.BlockExecutionData,

--- a/engine/common/rpc/convert/execution_data_test.go
+++ b/engine/common/rpc/convert/execution_data_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/encoding/ccf"
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	"github.com/onflow/flow-go/ledger/common/testutils"
 	"github.com/onflow/flow-go/model/flow"

--- a/engine/common/rpc/convert/execution_data_test.go
+++ b/engine/common/rpc/convert/execution_data_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/onflow/flow-go/utils/unittest/generator"
 )
 
 func TestConvertBlockExecutionDataEventPayloads(t *testing.T) {

--- a/engine/common/rpc/convert/execution_data_test.go
+++ b/engine/common/rpc/convert/execution_data_test.go
@@ -6,12 +6,64 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/encoding/ccf"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	"github.com/onflow/flow-go/ledger/common/testutils"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/utils/unittest"
 )
+
+func TestConvertBlockExecutionDataEventPayloads(t *testing.T) {
+	// generators will produce identical event payloads (before encoding)
+	ccfEventGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingCCF))
+	jsonEventsGenerator := generator.EventGenerator(generator.WithEncoding(generator.EncodingJSON))
+
+	ccfEvents := make([]flow.Event, 0, 3)
+	jsonEvents := make([]flow.Event, 0, 3)
+	for i := 0; i < 3; i++ {
+		ccfEvents = append(ccfEvents, ccfEventGenerator.New())
+		jsonEvents = append(jsonEvents, jsonEventsGenerator.New())
+	}
+
+	// generate BlockExecutionData with CCF encoded events
+	executionData := unittest.BlockExecutionDataFixture(
+		unittest.WithChunkExecutionDatas(
+			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(ccfEvents)),
+			unittest.ChunkExecutionDataFixture(t, 1024, unittest.WithChunkEvents(ccfEvents)),
+		),
+	)
+
+	execDataMessage, err := convert.BlockExecutionDataToMessage(executionData)
+	require.NoError(t, err)
+
+	t.Run("regular convert does not modify payload encoding", func(t *testing.T) {
+		for _, chunk := range execDataMessage.GetChunkExecutionData() {
+			events := convert.MessagesToEvents(chunk.Events)
+			for i, e := range events {
+				assert.Equal(t, ccfEvents[i], e)
+
+				_, err := ccf.Decode(nil, e.Payload)
+				require.NoError(t, err)
+			}
+		}
+	})
+
+	t.Run("converted event payloads are encoded in jsoncdc", func(t *testing.T) {
+		err = convert.BlockExecutionDataEventPayloadsToJson(execDataMessage)
+		require.NoError(t, err)
+
+		for _, chunk := range execDataMessage.GetChunkExecutionData() {
+			events := convert.MessagesToEvents(chunk.Events)
+			for i, e := range events {
+				assert.Equal(t, jsonEvents[i], e)
+
+				_, err := jsoncdc.Decode(nil, e.Payload)
+				require.NoError(t, err)
+			}
+		}
+	})
+}
 
 func TestConvertBlockExecutionData(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4504

Backports https://github.com/onflow/flow-go/pull/4533

Updates `ExecutionDataAPI` to use json-cdc event encoding.