### PR TITLE
read trie root hash from checkpoint

### DIFF
--- a/ledger/complete/mtrie/flattener/encoding.go
+++ b/ledger/complete/mtrie/flattener/encoding.go
@@ -313,9 +313,7 @@ func EncodeTrie(trie *trie.MTrie, rootIndex uint64, scratch []byte) []byte {
 	return buf[:pos]
 }
 
-// ReadTrie reconstructs a trie from data read from reader.
-func ReadTrie(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (*node.Node, error)) (*trie.MTrie, error) {
-
+func ReadEncodedTrie(reader io.Reader, scratch []byte) (EncodedTrie, error) {
 	if len(scratch) < encodedTrieSize {
 		scratch = make([]byte, encodedTrieSize)
 	}
@@ -323,7 +321,7 @@ func ReadTrie(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 	// Read encoded trie
 	_, err := io.ReadFull(reader, scratch[:encodedTrieSize])
 	if err != nil {
-		return nil, fmt.Errorf("failed to read serialized trie: %w", err)
+		return EncodedTrie{}, fmt.Errorf("failed to read serialized trie: %w", err)
 	}
 
 	pos := 0
@@ -343,21 +341,36 @@ func ReadTrie(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (
 	// Decode root node hash
 	readRootHash, err := hash.ToHash(scratch[pos : pos+encHashSize])
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode hash of serialized trie: %w", err)
+		return EncodedTrie{}, fmt.Errorf("failed to decode hash of serialized trie: %w", err)
 	}
 
-	rootNode, err := getNode(rootIndex)
+	return EncodedTrie{
+		RootIndex: rootIndex,
+		RegCount:  regCount,
+		RegSize:   regSize,
+		RootHash:  readRootHash,
+	}, nil
+}
+
+// ReadTrie reconstructs a trie from data read from reader.
+func ReadTrie(reader io.Reader, scratch []byte, getNode func(nodeIndex uint64) (*node.Node, error)) (*trie.MTrie, error) {
+	encodedTrie, err := ReadEncodedTrie(reader, scratch)
+	if err != nil {
+		return nil, err
+	}
+
+	rootNode, err := getNode(encodedTrie.RootIndex)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find root node of serialized trie: %w", err)
 	}
 
-	mtrie, err := trie.NewMTrie(rootNode, regCount, regSize)
+	mtrie, err := trie.NewMTrie(rootNode, encodedTrie.RegCount, encodedTrie.RegSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to restore serialized trie: %w", err)
 	}
 
 	rootHash := mtrie.RootHash()
-	if !rootHash.Equals(ledger.RootHash(readRootHash)) {
+	if !rootHash.Equals(ledger.RootHash(encodedTrie.RootHash)) {
 		return nil, fmt.Errorf("failed to restore serialized trie: roothash doesn't match")
 	}
 
@@ -399,43 +412,4 @@ func readPayloadFromReader(reader io.Reader, scratch []byte) (*ledger.Payload, e
 	}
 
 	return payload, nil
-}
-
-func ReadEncodedTrie(reader io.Reader, scratch []byte) (EncodedTrie, error) {
-	if len(scratch) < encodedTrieSize {
-		scratch = make([]byte, encodedTrieSize)
-	}
-
-	// Read encoded trie
-	_, err := io.ReadFull(reader, scratch[:encodedTrieSize])
-	if err != nil {
-		return EncodedTrie{}, fmt.Errorf("failed to read serialized trie: %w", err)
-	}
-
-	pos := 0
-
-	// Decode root node index
-	rootIndex := binary.BigEndian.Uint64(scratch)
-	pos += encNodeIndexSize
-
-	// Decode trie reg count (8 bytes)
-	regCount := binary.BigEndian.Uint64(scratch[pos:])
-	pos += encRegCountSize
-
-	// Decode trie reg size (8 bytes)
-	regSize := binary.BigEndian.Uint64(scratch[pos:])
-	pos += encRegSizeSize
-
-	// Decode root node hash
-	readRootHash, err := hash.ToHash(scratch[pos : pos+encHashSize])
-	if err != nil {
-		return EncodedTrie{}, fmt.Errorf("failed to decode hash of serialized trie: %w", err)
-	}
-
-	return EncodedTrie{
-		RootIndex: rootIndex,
-		RegCount:  regCount,
-		RegSize:   regSize,
-		RootHash:  readRootHash,
-	}, nil
 }

--- a/ledger/complete/wal/checkpoint_v6_reader.go
+++ b/ledger/complete/wal/checkpoint_v6_reader.go
@@ -20,6 +20,8 @@ import (
 // ErrEOFNotReached for indicating end of file not reached error
 var ErrEOFNotReached = errors.New("expect to reach EOF, but actually didn't")
 
+var ReadTriesRootHash = readTriesRootHash
+
 // readCheckpointV6 reads checkpoint file from a main file and 17 file parts.
 // the main file stores:
 //   - version
@@ -632,7 +634,7 @@ func readTopLevelTries(dir string, fileName string, subtrieNodes [][]*node.Node,
 	return tries, nil
 }
 
-func readTriesRootHash(dir string, fileName string, logger zerolog.Logger) (
+func readTriesRootHash(logger zerolog.Logger, dir string, fileName string) (
 	trieRoots []ledger.RootHash,
 	errToReturn error,
 ) {

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -590,3 +590,37 @@ func TestCopyCheckpointFileV6(t *testing.T) {
 		requireTriesEqual(t, tries, decoded)
 	})
 }
+
+func TestReadCheckpointRootHash(t *testing.T) {
+	unittest.RunWithTempDir(t, func(dir string) {
+		tries := createSimpleTrie(t)
+		fileName := "checkpoint"
+		logger := unittest.Logger()
+		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, logger), "fail to store checkpoint")
+
+		trieRoots, err := readTriesRootHash(dir, fileName, logger)
+		require.NoError(t, err)
+		for i, root := range trieRoots {
+			expectedHash := tries[i].RootHash()
+			require.Equal(t, expectedHash, root)
+		}
+		require.Equal(t, len(tries), len(trieRoots))
+	})
+}
+
+func TestReadCheckpointRootHashMulti(t *testing.T) {
+	unittest.RunWithTempDir(t, func(dir string) {
+		tries := createMultipleRandomTries(t)
+		fileName := "checkpoint"
+		logger := unittest.Logger()
+		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, logger), "fail to store checkpoint")
+
+		trieRoots, err := readTriesRootHash(dir, fileName, logger)
+		require.NoError(t, err)
+		for i, root := range trieRoots {
+			expectedHash := tries[i].RootHash()
+			require.Equal(t, expectedHash, root)
+		}
+		require.Equal(t, len(tries), len(trieRoots))
+	})
+}

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -598,7 +598,7 @@ func TestReadCheckpointRootHash(t *testing.T) {
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, logger), "fail to store checkpoint")
 
-		trieRoots, err := readTriesRootHash(dir, fileName, logger)
+		trieRoots, err := readTriesRootHash(logger, dir, fileName)
 		require.NoError(t, err)
 		for i, root := range trieRoots {
 			expectedHash := tries[i].RootHash()
@@ -615,7 +615,7 @@ func TestReadCheckpointRootHashMulti(t *testing.T) {
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, logger), "fail to store checkpoint")
 
-		trieRoots, err := readTriesRootHash(dir, fileName, logger)
+		trieRoots, err := readTriesRootHash(logger, dir, fileName)
 		require.NoError(t, err)
 		for i, root := range trieRoots {
 			expectedHash := tries[i].RootHash()


### PR DESCRIPTION
This PR adds a `ReadTriesRootHash` function under `github.com/onflow/flow-go/ledger/complete/wal/` to read root hash of the tries from a V6 checkpoint file