### PR TITLE
Tiny QoL makefile update for updating dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,17 @@ cmd/util/util:
 
 .PHONY: update-core-contracts-version
 update-core-contracts-version:
+	# updates the core-contracts version in all of the go.mod files
+	# usage example: CC_VERSION=0.16.0 make update-core-contracts-version
 	./scripts/update-core-contracts.sh $(CC_VERSION)
+	make tidy
+
+.PHONY: update-cadence-version
+update-cadence-version:
+	# updates the cadence version in all of the go.mod files
+	# usage example: CC_VERSION=0.16.0 make update-cadence-version
+	./scripts/update-cadence.sh $(CC_VERSION)
+	make tidy
 
 ############################################################################################
 # CAUTION: DO NOT MODIFY THESE TARGETS! DOING SO WILL BREAK THE FLAKY TEST MONITOR

--- a/scripts/update-cadence.sh
+++ b/scripts/update-cadence.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script updates all cadence dependencies to a new version.
+# Specify the desired version as the only argument when running the script:
+#   ./scripts/update-cadence.sh v1.2.3
+
+go get github.com/onflow/cadence@$1
+cd integration
+go get github.com/onflow/cadence@$1
+cd ../insecure/
+go get github.com/onflow/cadence@$1
+cd ..

--- a/scripts/update-core-contracts.sh
+++ b/scripts/update-core-contracts.sh
@@ -9,4 +9,7 @@ go get github.com/onflow/flow-core-contracts/lib/go/templates@$1
 cd integration
 go get github.com/onflow/flow-core-contracts/lib/go/contracts@$1
 go get github.com/onflow/flow-core-contracts/lib/go/templates@$1
+cd ../insecure/
+go get github.com/onflow/flow-core-contracts/lib/go/contracts@$1
+go get github.com/onflow/flow-core-contracts/lib/go/templates@$1
 cd ..


### PR DESCRIPTION
Wanted to add/change some makefile commands to make it more convenient to upgrade dependencies.

1. Added `make tidy` to update-core-contracts, since that is the required next step anyway
2. Added another script to update cadence version in all `flow-go` `go.mod` files