### PR TITLE
[Networking] Partial backport of 4790 (easing peer scoring warning-state log conditions)

### DIFF
--- a/network/p2p/pubsub.go
+++ b/network/p2p/pubsub.go
@@ -208,7 +208,7 @@ func (p PeerScoreSnapshot) IsWarning() bool {
 		// If the IP colocation factor is positive, the peer is in warning state, it means that the peer is running on the
 		// same IP as another peer and is suspected to be a sybil node. For now, we set it to a high value to make sure
 		// that peers from the same operator are not marked as sybil nodes.
-		// TODO: this should be revisited once the collocation penalty is enabled. Setting it to 20 to reduce the noise; 20 is twice the threshold (defaultBehaviourPenaltyThreshold).
+		// TODO: this should be revisited once the collocation penalty is enabled. Setting it to 5 to reduce the noise.
 		return true
 	// Check behaviour penalty.
 	case p.BehaviourPenalty > 20:

--- a/network/p2p/pubsub.go
+++ b/network/p2p/pubsub.go
@@ -194,22 +194,24 @@ func (p PeerScoreSnapshot) IsWarning() bool {
 
 	// Check overall score.
 	switch {
-	case p.Score < 0:
+	case p.Score < -1:
 		// If the overall score is negative, the peer is in warning state, it means that the peer is suspected to be
 		// misbehaving at the GossipSub level.
 		return true
 	// Check app-specific score.
-	case p.AppSpecificScore < 0:
+	case p.AppSpecificScore < -1:
 		// If the app specific score is negative, the peer is in warning state, it means that the peer behaves in a way
 		// that is not allowed by the Flow protocol.
 		return true
 	// Check IP colocation factor.
-	case p.IPColocationFactor > 0:
+	case p.IPColocationFactor > 5:
 		// If the IP colocation factor is positive, the peer is in warning state, it means that the peer is running on the
-		// same IP as another peer and is suspected to be a sybil node.
+		// same IP as another peer and is suspected to be a sybil node. For now, we set it to a high value to make sure
+		// that peers from the same operator are not marked as sybil nodes.
+		// TODO: this should be revisited once the collocation penalty is enabled. Setting it to 20 to reduce the noise; 20 is twice the threshold (defaultBehaviourPenaltyThreshold).
 		return true
 	// Check behaviour penalty.
-	case p.BehaviourPenalty > 0:
+	case p.BehaviourPenalty > 20:
 		// If the behaviour penalty is positive, the peer is in warning state, it means that the peer is suspected to be
 		// misbehaving at the GossipSub level, e.g. sending too many duplicate messages.
 		return true


### PR DESCRIPTION
Partial backport of https://github.com/onflow/flow-go/pull/4790 (easing peer scoring warning-state log conditions).