### PR TITLE
[Access] Fix race condition in jobqueue

### DIFF
--- a/module/jobqueue/component_consumer_test.go
+++ b/module/jobqueue/component_consumer_test.go
@@ -245,7 +245,7 @@ func (suite *ComponentConsumerSuite) TestSignalsBeforeReadyDoNotCheck() {
 	jobConsumer.On("Check").Run(func(_ mock.Arguments) {
 		assert.True(suite.T(), started.Load(), "check was called before started")
 		wg.Done()
-	}).Maybe()
+	})
 
 	consumer, workSignal := suite.prepareTest(nil, nil, nil, nil)
 	consumer.consumer = jobConsumer

--- a/module/jobqueue/component_consumer_test.go
+++ b/module/jobqueue/component_consumer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/irrecoverable"
@@ -27,8 +28,6 @@ type ComponentConsumerSuite struct {
 	defaultIndex   uint64
 	maxProcessing  uint64
 	maxSearchAhead uint64
-
-	progress *storagemock.ConsumerProgress
 }
 
 func TestComponentConsumerSuite(t *testing.T) {
@@ -40,8 +39,6 @@ func (suite *ComponentConsumerSuite) SetupTest() {
 	suite.defaultIndex = uint64(0)
 	suite.maxProcessing = uint64(2)
 	suite.maxSearchAhead = uint64(5)
-
-	suite.progress = new(storagemock.ConsumerProgress)
 }
 
 func mockJobs(data map[uint64]TestJob) *modulemock.Jobs {
@@ -67,14 +64,6 @@ func mockJobs(data map[uint64]TestJob) *modulemock.Jobs {
 	return jobs
 }
 
-func mockProgress() *storagemock.ConsumerProgress {
-	progress := new(storagemock.ConsumerProgress)
-	progress.On("ProcessedIndex").Return(uint64(0), nil)
-	progress.On("SetProcessedIndex", mock.AnythingOfType("uint64")).Return(nil)
-
-	return progress
-}
-
 func generateTestData(jobCount uint64) map[uint64]TestJob {
 	jobData := make(map[uint64]TestJob, jobCount)
 
@@ -93,8 +82,11 @@ func (suite *ComponentConsumerSuite) prepareTest(
 ) (*ComponentConsumer, chan struct{}) {
 
 	jobs := mockJobs(jobData)
-	workSignal := make(chan struct{})
-	progress := mockProgress()
+	workSignal := make(chan struct{}, 1)
+
+	progress := new(storagemock.ConsumerProgress)
+	progress.On("ProcessedIndex").Return(suite.defaultIndex, nil)
+	progress.On("SetProcessedIndex", mock.AnythingOfType("uint64")).Return(nil)
 
 	consumer := NewComponentConsumer(
 		zerolog.New(os.Stdout).With().Timestamp().Logger(),
@@ -144,7 +136,7 @@ func (suite *ComponentConsumerSuite) TestHappyPath() {
 		wg.Add(int(testJobsCount))
 		consumer, workSignal := suite.prepareTest(processor, nil, notifier, jobData)
 
-		suite.runTest(testCtx, consumer, workSignal, func() {
+		suite.runTest(testCtx, consumer, func() {
 			workSignal <- struct{}{}
 			wg.Wait()
 		})
@@ -162,7 +154,7 @@ func (suite *ComponentConsumerSuite) TestHappyPath() {
 		wg.Add(int(testJobsCount))
 		consumer, workSignal := suite.prepareTest(processor, notifier, nil, jobData)
 
-		suite.runTest(testCtx, consumer, workSignal, func() {
+		suite.runTest(testCtx, consumer, func() {
 			workSignal <- struct{}{}
 			wg.Wait()
 		})
@@ -216,7 +208,7 @@ func (suite *ComponentConsumerSuite) TestProgressesOnComplete() {
 	suite.maxProcessing = 1
 	consumer, workSignal := suite.prepareTest(processor, nil, notifier, jobData)
 
-	suite.runTest(testCtx, consumer, workSignal, func() {
+	suite.runTest(testCtx, consumer, func() {
 		workSignal <- struct{}{}
 		unittest.RequireNeverClosedWithin(suite.T(), done, 100*time.Millisecond, fmt.Sprintf("job %d wasn't supposed to finish", stopIndex+1))
 	})
@@ -228,6 +220,48 @@ func (suite *ComponentConsumerSuite) TestProgressesOnComplete() {
 	for index := range finishedJobs {
 		assert.LessOrEqual(suite.T(), index, stopIndex)
 	}
+}
+
+func (suite *ComponentConsumerSuite) TestSignalsBeforeReadyDoNotCheck() {
+	testCtx, testCancel := context.WithCancel(context.Background())
+	defer testCancel()
+
+	suite.defaultIndex = uint64(100)
+	started := atomic.NewBool(false)
+
+	jobConsumer := modulemock.NewJobConsumer(suite.T())
+	jobConsumer.On("Start", suite.defaultIndex).Return(func(_ uint64) error {
+		// force Start to take a while so the processingLoop is ready first
+		// the processingLoop should wait to start, otherwise Check would be called
+		time.Sleep(500 * time.Millisecond)
+		started.Store(true)
+		return nil
+	})
+	jobConsumer.On("Stop")
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	jobConsumer.On("Check").Run(func(_ mock.Arguments) {
+		assert.True(suite.T(), started.Load(), "check was called before started")
+		wg.Done()
+	}).Maybe()
+
+	consumer, workSignal := suite.prepareTest(nil, nil, nil, nil)
+	consumer.consumer = jobConsumer
+
+	// send a signal before the component starts to ensure Check would be called if the
+	// processingLoop was started
+	workSignal <- struct{}{}
+
+	ctx, cancel := context.WithCancel(testCtx)
+	signalCtx := irrecoverable.NewMockSignalerContext(suite.T(), ctx)
+	consumer.Start(signalCtx)
+
+	unittest.RequireCloseBefore(suite.T(), consumer.Ready(), 1*time.Second, "timeout waiting for consumer to be ready")
+	unittest.RequireReturnsBefore(suite.T(), wg.Wait, 100*time.Millisecond, "check was not called")
+	cancel()
+	unittest.RequireCloseBefore(suite.T(), consumer.Done(), 1*time.Second, "timeout waiting for consumer to be done")
 }
 
 // TestPassesIrrecoverableErrors:
@@ -282,7 +316,6 @@ func (suite *ComponentConsumerSuite) TestPassesIrrecoverableErrors() {
 func (suite *ComponentConsumerSuite) runTest(
 	testCtx context.Context,
 	consumer *ComponentConsumer,
-	workSignal chan<- struct{},
 	sendJobs func(),
 ) {
 	ctx, cancel := context.WithCancel(testCtx)

--- a/module/jobqueue/consumer.go
+++ b/module/jobqueue/consumer.go
@@ -171,6 +171,7 @@ func (c *Consumer) NotifyJobIsDone(jobID module.JobID) uint64 {
 func (c *Consumer) Check() {
 	if !c.started.Load() {
 		// Check is not allowed before the consumer is started
+		c.log.Warn().Msg("ignoring Check before Start")
 		return
 	}
 

--- a/module/jobqueue/consumer.go
+++ b/module/jobqueue/consumer.go
@@ -43,6 +43,8 @@ type Consumer struct {
 	processings      map[uint64]*jobStatus   // keep track of the status of each on going job
 	processingsIndex map[module.JobID]uint64 // lookup the index of the job, useful when fast forwarding the
 	// `processed` variable
+
+	started *atomic.Bool // only allow the consumer to be started once, and forbid calls to Check before Start
 }
 
 func NewConsumer(
@@ -68,6 +70,7 @@ func NewConsumer(
 		// init state variables
 		running:          false,
 		isChecking:       atomic.NewBool(false),
+		started:          atomic.NewBool(false),
 		processedIndex:   0,
 		processings:      make(map[uint64]*jobStatus),
 		processingsIndex: make(map[module.JobID]uint64),
@@ -79,10 +82,9 @@ func (c *Consumer) Start(defaultIndex uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.running {
-		return nil
+	if !c.started.CompareAndSwap(false, true) {
+		return fmt.Errorf("consumer has already been started")
 	}
-
 	c.running = true
 
 	// on startup, sync with storage for the processed index
@@ -109,11 +111,12 @@ func (c *Consumer) Start(defaultIndex uint64) error {
 
 	c.processedIndex = processedIndex
 
-	c.checkProcessable()
-
 	c.log.Info().
 		Uint64("processed", processedIndex).
 		Msg("consumer started")
+
+	c.checkProcessable()
+
 	return nil
 }
 
@@ -166,6 +169,11 @@ func (c *Consumer) NotifyJobIsDone(jobID module.JobID) uint64 {
 // since multiple checks at the same time are unnecessary, we could only keep one check by checking.
 // an atomic isChecking value.
 func (c *Consumer) Check() {
+	if !c.started.Load() {
+		// Check is not allowed before the consumer is started
+		return
+	}
+
 	if !c.isChecking.CompareAndSwap(false, true) {
 		// other process is checking, we could exit and rely on that process to check
 		// processable jobs

--- a/module/jobqueue/consumer_test.go
+++ b/module/jobqueue/consumer_test.go
@@ -214,7 +214,7 @@ func TestCheckBeforeStartIsNoop(t *testing.T) {
 		c.Check()
 
 		// start will load the processedIndex from storage
-		err := c.Start(10)
+		err = c.Start(10)
 		require.NoError(t, err)
 
 		// make sure that the processedIndex at the end is from storage

--- a/module/jobqueue/consumer_test.go
+++ b/module/jobqueue/consumer_test.go
@@ -9,6 +9,7 @@ import (
 
 	badgerdb "github.com/dgraph-io/badger/v2"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module"
@@ -185,6 +186,38 @@ func TestProcessedIndexDeletion(t *testing.T) {
 		defer c.mu.Unlock()
 		require.Len(t, c.processings, 0)
 		require.Len(t, c.processingsIndex, 0)
+	})
+}
+
+func TestCheckBeforeStartIsNoop(t *testing.T) {
+	t.Parallel()
+
+	unittest.RunWithBadgerDB(t, func(db *badgerdb.DB) {
+		storedProcessedIndex := uint64(100)
+
+		worker := newMockWorker()
+		progress := badger.NewConsumerProgress(db, "consumer")
+		progress.InitProcessedIndex(storedProcessedIndex)
+
+		c := NewConsumer(
+			unittest.Logger(),
+			NewMockJobs(),
+			progress,
+			worker,
+			uint64(3),
+			0,
+		)
+		worker.WithConsumer(c)
+
+		// check will store the processedIndex. Before start, it will be uninitialized (0)
+		c.Check()
+
+		// start will load the processedIndex from storage
+		err := c.Start(10)
+		require.NoError(t, err)
+
+		// make sure that the processedIndex at the end is from storage
+		assert.Equal(t, storedProcessedIndex, c.LastProcessedIndex())
 	})
 }
 

--- a/module/jobqueue/consumer_test.go
+++ b/module/jobqueue/consumer_test.go
@@ -197,7 +197,8 @@ func TestCheckBeforeStartIsNoop(t *testing.T) {
 
 		worker := newMockWorker()
 		progress := badger.NewConsumerProgress(db, "consumer")
-		progress.InitProcessedIndex(storedProcessedIndex)
+		err := progress.InitProcessedIndex(storedProcessedIndex)
+		require.NoError(t, err)
 
 		c := NewConsumer(
 			unittest.Logger(),


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4839

Fixes a race condition that can occur while starting up a jobqueue consumer with the following changes:
* Ignore calls to `JobConsumer.Check()` before `Start` is called. This prevents the dangerous situation that can cause the `processedIndex` value to be reset.
* Refactor `ComponentConsumer`'s startup to ensure that the processing loop is run after the component starts up.
* Add tests covering the race condition for both cases.