### PR TITLE
[JobQueue] Move the DefaultIndex from Start method to constructor

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -622,7 +622,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				execDataCacheBackend,
 			)
 
-			builder.ExecutionDataRequester = edrequester.New(
+			r, err := edrequester.New(
 				builder.Logger,
 				metrics.NewExecutionDataRequesterCollector(),
 				builder.ExecutionDataDownloader,
@@ -634,6 +634,10 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				builder.executionDataConfig,
 				execDataDistributor,
 			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create execution data requester: %w", err)
+			}
+			builder.ExecutionDataRequester = r
 
 			builder.FollowerDistributor.AddOnBlockFinalizedConsumer(builder.ExecutionDataRequester.OnBlockFinalized)
 
@@ -737,7 +741,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 				builder.ExecutionIndexerCore = indexerCore
 
 				// execution state worker uses a jobqueue to process new execution data and indexes it by using the indexer.
-				builder.ExecutionIndexer = indexer.NewIndexer(
+				builder.ExecutionIndexer, err = indexer.NewIndexer(
 					builder.Logger,
 					registers.FirstHeight(),
 					registers,
@@ -746,6 +750,9 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					builder.ExecutionDataRequester.HighestConsecutiveHeight,
 					indexedBlockHeight,
 				)
+				if err != nil {
+					return nil, err
+				}
 
 				// setup requester to notify indexer when new execution data is received
 				execDataDistributor.AddOnExecutionDataReceivedConsumer(builder.ExecutionIndexer.OnExecutionData)

--- a/cmd/verification_builder.go
+++ b/cmd/verification_builder.go
@@ -245,13 +245,17 @@ func (v *VerificationNodeBuilder) LoadComponentsAndModules() {
 				v.verConf.stopAtHeight)
 
 			// requester and fetcher engines are started by chunk consumer
-			chunkConsumer = chunkconsumer.NewChunkConsumer(
+			chunkConsumer, err = chunkconsumer.NewChunkConsumer(
 				node.Logger,
 				collector,
 				processedChunkIndex,
 				chunkQueue,
 				fetcherEngine,
 				v.verConf.chunkWorkers)
+
+			if err != nil {
+				return nil, fmt.Errorf("could not create chunk consumer: %w", err)
+			}
 
 			err = node.Metrics.Mempool.Register(metrics.ResourceChunkConsumer, chunkConsumer.Size)
 			if err != nil {

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -1055,12 +1055,13 @@ func VerificationNode(t testing.TB,
 	}
 
 	if node.ChunkConsumer == nil {
-		node.ChunkConsumer = chunkconsumer.NewChunkConsumer(node.Log,
+		node.ChunkConsumer, err = chunkconsumer.NewChunkConsumer(node.Log,
 			collector,
 			node.ProcessedChunkIndex,
 			node.ChunksQueue,
 			node.FetcherEngine,
 			chunkconsumer.DefaultChunkWorkers) // defaults number of workers to 3.
+		require.NoError(t, err)
 		err = mempoolCollector.Register(metrics.ResourceChunkConsumer, node.ChunkConsumer.Size)
 		require.NoError(t, err)
 	}

--- a/engine/verification/assigner/blockconsumer/consumer.go
+++ b/engine/verification/assigner/blockconsumer/consumer.go
@@ -21,10 +21,9 @@ const DefaultBlockWorkers = uint64(2)
 // and notifies the consumer to check in the job queue
 // (i.e., its block reader) for new block jobs.
 type BlockConsumer struct {
-	consumer     module.JobConsumer
-	defaultIndex uint64
-	unit         *engine.Unit
-	metrics      module.VerificationMetrics
+	consumer module.JobConsumer
+	unit     *engine.Unit
+	metrics  module.VerificationMetrics
 }
 
 // defaultProcessedIndex returns the last sealed block height from the protocol state.
@@ -59,17 +58,20 @@ func NewBlockConsumer(log zerolog.Logger,
 	// the block reader is where the consumer reads new finalized blocks from (i.e., jobs).
 	jobs := jobqueue.NewFinalizedBlockReader(state, blocks)
 
-	consumer := jobqueue.NewConsumer(lg, jobs, processedHeight, worker, maxProcessing, 0)
 	defaultIndex, err := defaultProcessedIndex(state)
 	if err != nil {
 		return nil, 0, fmt.Errorf("could not read default processed index: %w", err)
 	}
 
+	consumer, err := jobqueue.NewConsumer(lg, jobs, processedHeight, worker, maxProcessing, 0, defaultIndex)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not create block consumer: %w", err)
+	}
+
 	blockConsumer := &BlockConsumer{
-		consumer:     consumer,
-		defaultIndex: defaultIndex,
-		unit:         engine.NewUnit(),
-		metrics:      metrics,
+		consumer: consumer,
+		unit:     engine.NewUnit(),
+		metrics:  metrics,
 	}
 	worker.withBlockConsumer(blockConsumer)
 

--- a/engine/verification/assigner/blockconsumer/consumer.go
+++ b/engine/verification/assigner/blockconsumer/consumer.go
@@ -101,7 +101,7 @@ func (c *BlockConsumer) OnFinalizedBlock(*model.Block) {
 }
 
 func (c *BlockConsumer) Ready() <-chan struct{} {
-	err := c.consumer.Start(c.defaultIndex)
+	err := c.consumer.Start()
 	if err != nil {
 		panic(fmt.Errorf("could not start block consumer for finder engine: %w", err))
 	}

--- a/engine/verification/fetcher/chunkconsumer/consumer_test.go
+++ b/engine/verification/fetcher/chunkconsumer/consumer_test.go
@@ -155,7 +155,7 @@ func WithConsumer(
 		}
 
 		collector := &metrics.NoopCollector{}
-		consumer := chunkconsumer.NewChunkConsumer(
+		consumer, err := chunkconsumer.NewChunkConsumer(
 			unittest.Logger(),
 			collector,
 			processedIndex,
@@ -163,6 +163,7 @@ func WithConsumer(
 			engine,
 			maxProcessing,
 		)
+		require.NoError(t, err)
 
 		withConsumer(consumer, chunksQueue)
 	})

--- a/module/jobqueue.go
+++ b/module/jobqueue.go
@@ -30,7 +30,7 @@ type JobConsumer interface {
 
 	// Start starts processing jobs from a job queue. If this is the first time, a processed index
 	// will be initialized in the storage. If it fails to initialize, an error will be returned
-	Start(defaultIndex uint64) error
+	Start() error
 
 	// Stop gracefully stops the consumer from reading new jobs from the job queue. It does not stop
 	// the existing worker finishing their jobs

--- a/module/jobqueue.go
+++ b/module/jobqueue.go
@@ -28,8 +28,7 @@ type NewJobListener interface {
 type JobConsumer interface {
 	NewJobListener
 
-	// Start starts processing jobs from a job queue. If this is the first time, a processed index
-	// will be initialized in the storage. If it fails to initialize, an error will be returned
+	// Start starts processing jobs from a job queue.
 	Start() error
 
 	// Stop gracefully stops the consumer from reading new jobs from the job queue. It does not stop

--- a/module/jobqueue/component_consumer.go
+++ b/module/jobqueue/component_consumer.go
@@ -33,13 +33,7 @@ func NewComponentConsumer(
 	processor JobProcessor, // method used to process jobs
 	maxProcessing uint64,
 	maxSearchAhead uint64,
-) *ComponentConsumer {
-
-	c := &ComponentConsumer{
-		workSignal: workSignal,
-		jobs:       jobs,
-		log:        log,
-	}
+) (*ComponentConsumer, error) {
 
 	// create a worker pool with maxProcessing workers to process jobs
 	worker := NewWorkerPool(
@@ -47,12 +41,23 @@ func NewComponentConsumer(
 		func(id module.JobID) { c.NotifyJobIsDone(id) },
 		maxProcessing,
 	)
-	c.consumer = NewConsumer(c.log, c.jobs, progress, worker, maxProcessing, maxSearchAhead)
+
+	consumer, err := NewConsumer(log, jobs, progress, worker, maxProcessing, maxSearchAhead, defaultIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &ComponentConsumer{
+		workSignal: workSignal,
+		jobs:       jobs,
+		log:        log,
+		consumer:   consumer,
+	}
 
 	builder := component.NewComponentManagerBuilder().
 		AddWorker(func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 			c.log.Info().Msg("job consumer starting")
-			err := c.consumer.Start(defaultIndex)
+			err := c.consumer.Start()
 			if err != nil {
 				ctx.Throw(fmt.Errorf("could not start consumer: %w", err))
 			}
@@ -95,7 +100,7 @@ func NewComponentConsumer(
 	c.cm = cm
 	c.Component = cm
 
-	return c
+	return c, nil
 }
 
 // SetPreNotifier sets a notification function that is invoked before marking a job as done in the

--- a/module/jobqueue/component_consumer.go
+++ b/module/jobqueue/component_consumer.go
@@ -35,6 +35,12 @@ func NewComponentConsumer(
 	maxSearchAhead uint64,
 ) (*ComponentConsumer, error) {
 
+	c := &ComponentConsumer{
+		workSignal: workSignal,
+		jobs:       jobs,
+		log:        log,
+	}
+
 	// create a worker pool with maxProcessing workers to process jobs
 	worker := NewWorkerPool(
 		processor,
@@ -46,13 +52,7 @@ func NewComponentConsumer(
 	if err != nil {
 		return nil, err
 	}
-
-	c := &ComponentConsumer{
-		workSignal: workSignal,
-		jobs:       jobs,
-		log:        log,
-		consumer:   consumer,
-	}
+	c.consumer = consumer
 
 	builder := component.NewComponentManagerBuilder().
 		AddWorker(func(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {

--- a/module/jobqueue/component_consumer_test.go
+++ b/module/jobqueue/component_consumer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
 
@@ -88,7 +89,7 @@ func (suite *ComponentConsumerSuite) prepareTest(
 	progress.On("ProcessedIndex").Return(suite.defaultIndex, nil)
 	progress.On("SetProcessedIndex", mock.AnythingOfType("uint64")).Return(nil)
 
-	consumer := NewComponentConsumer(
+	consumer, err := NewComponentConsumer(
 		zerolog.New(os.Stdout).With().Timestamp().Logger(),
 		workSignal,
 		progress,
@@ -98,6 +99,7 @@ func (suite *ComponentConsumerSuite) prepareTest(
 		suite.maxProcessing,
 		suite.maxSearchAhead,
 	)
+	require.NoError(suite.T(), err)
 	consumer.SetPreNotifier(preNotifier)
 	consumer.SetPostNotifier(postNotifier)
 

--- a/module/jobqueue/component_consumer_test.go
+++ b/module/jobqueue/component_consumer_test.go
@@ -232,7 +232,7 @@ func (suite *ComponentConsumerSuite) TestSignalsBeforeReadyDoNotCheck() {
 	started := atomic.NewBool(false)
 
 	jobConsumer := modulemock.NewJobConsumer(suite.T())
-	jobConsumer.On("Start", suite.defaultIndex).Return(func(_ uint64) error {
+	jobConsumer.On("Start").Return(func() error {
 		// force Start to take a while so the processingLoop is ready first
 		// the processingLoop should wait to start, otherwise Check would be called
 		time.Sleep(500 * time.Millisecond)

--- a/module/jobqueue/consumer_test.go
+++ b/module/jobqueue/consumer_test.go
@@ -164,7 +164,8 @@ func TestProcessedIndexDeletion(t *testing.T) {
 			progress := badger.NewConsumerProgress(db, "consumer")
 			worker := newMockWorker()
 			maxProcessing := uint64(3)
-			c := NewConsumer(log, jobs, progress, worker, maxProcessing, 0)
+			c, err := NewConsumer(log, jobs, progress, worker, maxProcessing, 0, 0)
+			require.NoError(t, err)
 			worker.WithConsumer(c)
 
 			f(c, jobs)
@@ -173,7 +174,7 @@ func TestProcessedIndexDeletion(t *testing.T) {
 
 	setup(t, func(c *Consumer, jobs *MockJobs) {
 		require.NoError(t, jobs.PushN(10))
-		require.NoError(t, c.Start(0))
+		require.NoError(t, c.Start())
 
 		require.Eventually(t, func() bool {
 			c.mu.Lock()

--- a/module/jobqueue/consumer_test.go
+++ b/module/jobqueue/consumer_test.go
@@ -201,21 +201,23 @@ func TestCheckBeforeStartIsNoop(t *testing.T) {
 		err := progress.InitProcessedIndex(storedProcessedIndex)
 		require.NoError(t, err)
 
-		c := NewConsumer(
+		c, err := NewConsumer(
 			unittest.Logger(),
 			NewMockJobs(),
 			progress,
 			worker,
 			uint64(3),
 			0,
+			10,
 		)
+		require.NoError(t, err)
 		worker.WithConsumer(c)
 
 		// check will store the processedIndex. Before start, it will be uninitialized (0)
 		c.Check()
 
 		// start will load the processedIndex from storage
-		err = c.Start(10)
+		err = c.Start()
 		require.NoError(t, err)
 
 		// make sure that the processedIndex at the end is from storage

--- a/module/mock/job_consumer.go
+++ b/module/mock/job_consumer.go
@@ -59,13 +59,13 @@ func (_m *JobConsumer) Size() uint {
 	return r0
 }
 
-// Start provides a mock function with given fields: defaultIndex
-func (_m *JobConsumer) Start(defaultIndex uint64) error {
-	ret := _m.Called(defaultIndex)
+// Start provides a mock function with given fields:
+func (_m *JobConsumer) Start() error {
+	ret := _m.Called()
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(uint64) error); ok {
-		r0 = rf(defaultIndex)
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/module/state_synchronization/indexer/indexer_test.go
+++ b/module/state_synchronization/indexer/indexer_test.go
@@ -75,7 +75,7 @@ func newIndexerTest(t *testing.T, availableBlocks int, lastIndexedIndex int) *in
 		executionData: executionData,
 	}
 
-	test.worker = NewIndexer(
+	test.worker, err = NewIndexer(
 		unittest.Logger(),
 		test.first().Header.Height,
 		registers,
@@ -84,6 +84,7 @@ func newIndexerTest(t *testing.T, availableBlocks int, lastIndexedIndex int) *in
 		test.latestHeight,
 		progress,
 	)
+	require.NoError(t, err)
 
 	return test
 }

--- a/module/state_synchronization/requester/execution_data_requester.go
+++ b/module/state_synchronization/requester/execution_data_requester.go
@@ -151,7 +151,7 @@ func New(
 	headers storage.Headers,
 	cfg ExecutionDataConfig,
 	distributor *ExecutionDataDistributor,
-) state_synchronization.ExecutionDataRequester {
+) (state_synchronization.ExecutionDataRequester, error) {
 	e := &executionDataRequester{
 		log:                  log.With().Str("component", "execution_data_requester").Logger(),
 		downloader:           downloader,
@@ -179,7 +179,7 @@ func New(
 	// from `processedHeight + 1`. If the database is empty, rootHeight will be used to init the
 	// last processed height. Once the execution data is fetched and stored, it notifies
 	// `executionDataNotifier`.
-	e.blockConsumer = jobqueue.NewComponentConsumer(
+	blockConsumer, err := jobqueue.NewComponentConsumer(
 		e.log.With().Str("module", "block_consumer").Logger(),
 		e.finalizationNotifier.Channel(), // to listen to finalization events to find newly sealed blocks
 		processedHeight,                  // read and persist the downloaded height
@@ -189,6 +189,10 @@ func New(
 		fetchWorkers,                     // the number of concurrent workers
 		e.config.MaxSearchAhead,          // max number of unsent notifications to allow before pausing new fetches
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create block consumer: %w", err)
+	}
+	e.blockConsumer = blockConsumer
 
 	// notifies notificationConsumer when new ExecutionData blobs are available
 	// SetPostNotifier will notify executionDataNotifier AFTER e.blockConsumer.LastProcessedIndex is updated.
@@ -222,7 +226,7 @@ func New(
 	// `e.consumers`.
 	// Note: the `e.consumers` will be guaranteed to receive at least one `OnExecutionDataFetched` event
 	// for each sealed block in consecutive block height order.
-	e.notificationConsumer = jobqueue.NewComponentConsumer(
+	e.notificationConsumer, err = jobqueue.NewComponentConsumer(
 		e.log.With().Str("module", "notification_consumer").Logger(),
 		executionDataNotifier.Channel(), // listen for notifications from the block consumer
 		processedNotifications,          // read and persist the notified height
@@ -232,13 +236,16 @@ func New(
 		1,                               // use a single worker to ensure notification is delivered in consecutive order
 		0,                               // search ahead limit controlled by worker count
 	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create notification consumer: %w", err)
+	}
 
 	e.Component = component.NewComponentManagerBuilder().
 		AddWorker(e.runBlockConsumer).
 		AddWorker(e.runNotificationConsumer).
 		Build()
 
-	return e
+	return e, nil
 }
 
 // OnBlockFinalized accepts block finalization notifications from the FollowerDistributor

--- a/module/state_synchronization/requester/execution_data_requester_test.go
+++ b/module/state_synchronization/requester/execution_data_requester_test.go
@@ -415,7 +415,7 @@ func (suite *ExecutionDataRequesterSuite) prepareRequesterTest(cfg *fetchTestRun
 	processedHeight := bstorage.NewConsumerProgress(suite.db, module.ConsumeProgressExecutionDataRequesterBlockHeight)
 	processedNotification := bstorage.NewConsumerProgress(suite.db, module.ConsumeProgressExecutionDataRequesterNotification)
 
-	edr := requester.New(
+	edr, err := requester.New(
 		logger,
 		metrics,
 		suite.downloader,
@@ -433,6 +433,7 @@ func (suite *ExecutionDataRequesterSuite) prepareRequesterTest(cfg *fetchTestRun
 		},
 		suite.distributor,
 	)
+	require.NoError(suite.T(), err)
 
 	followerDistributor.AddOnBlockFinalizedConsumer(edr.OnBlockFinalized)
 


### PR DESCRIPTION
This PR moves the default index from Start method to constructor in order to prevent from a wrong default index being used before the Start method is called.