### PR TITLE
suggestions for PR #4834

### DIFF
--- a/model/flow/mapfunc/identity.go
+++ b/model/flow/mapfunc/identity.go
@@ -15,8 +15,8 @@ func WithInitialWeight(weight uint64) flow.IdentityMapFunc[flow.Identity] {
 }
 
 // WithWeight returns an anonymous function that assigns the given weight value
-// to `Identity.Weight`. This function is primarily intended for testing, as
-// Identity structs should be immutable by convention.
+// to `Identity.Weight`. We pass the input identity by value, i.e. copy on write,
+// to avoid modifying the original input.
 func WithWeight(weight uint64) flow.IdentityMapFunc[flow.Identity] {
 	return func(identity flow.Identity) flow.Identity {
 		identity.Weight = weight

--- a/model/flow/protocol_state_test.go
+++ b/model/flow/protocol_state_test.go
@@ -34,7 +34,7 @@ func TestNewRichProtocolStateEntry(t *testing.T) {
 				CommitID:         currentEpochCommit.ID(),
 				ActiveIdentities: identities,
 			},
-			PreviousEpoch: flow.EpochStateContainer{
+			PreviousEpoch: &flow.EpochStateContainer{
 				SetupID:          flow.ZeroID,
 				CommitID:         flow.ZeroID,
 				ActiveIdentities: nil,

--- a/model/flow/protocol_state_test.go
+++ b/model/flow/protocol_state_test.go
@@ -29,15 +29,11 @@ func TestNewRichProtocolStateEntry(t *testing.T) {
 			})
 		}
 		stateEntry := &flow.ProtocolStateEntry{
+			PreviousEpoch: nil,
 			CurrentEpoch: flow.EpochStateContainer{
 				SetupID:          setup.ID(),
 				CommitID:         currentEpochCommit.ID(),
 				ActiveIdentities: identities,
-			},
-			PreviousEpoch: &flow.EpochStateContainer{
-				SetupID:          flow.ZeroID,
-				CommitID:         flow.ZeroID,
-				ActiveIdentities: nil,
 			},
 			InvalidStateTransitionAttempted: false,
 		}

--- a/state/protocol/inmem/convert.go
+++ b/state/protocol/inmem/convert.go
@@ -334,11 +334,7 @@ func SnapshotFromBootstrapStateWithParams(
 		})
 	}
 	protocolState := &flow.ProtocolStateEntry{
-		PreviousEpoch: &flow.EpochStateContainer{
-			SetupID:          flow.ZeroID,
-			CommitID:         flow.ZeroID,
-			ActiveIdentities: nil,
-		},
+		PreviousEpoch: nil,
 		CurrentEpoch: flow.EpochStateContainer{
 			SetupID:          setup.ID(),
 			CommitID:         commit.ID(),

--- a/state/protocol/inmem/convert.go
+++ b/state/protocol/inmem/convert.go
@@ -334,7 +334,7 @@ func SnapshotFromBootstrapStateWithParams(
 		})
 	}
 	protocolState := &flow.ProtocolStateEntry{
-		PreviousEpoch: flow.EpochStateContainer{
+		PreviousEpoch: &flow.EpochStateContainer{
 			SetupID:          flow.ZeroID,
 			CommitID:         flow.ZeroID,
 			ActiveIdentities: nil,

--- a/state/protocol/protocol_state/updater.go
+++ b/state/protocol/protocol_state/updater.go
@@ -24,7 +24,8 @@ type Updater struct {
 
 	// The following fields are maps from NodeID → DynamicIdentityEntry for the nodes that are *active* in the respective epoch.
 	// Active means that these nodes are authorized to contribute to extending the chain. Formally, as node is active if and only
-	// if it is listed in the EpochSetup event for the respective epoch.
+	// if it is listed in the EpochSetup event for the respective epoch. Note that map values are pointers, so writes to map values
+	// will modify the respective DynamicIdentityEntry in EpochStateContainer.
 
 	prevEpochIdentitiesLookup    map[flow.Identifier]*flow.DynamicIdentityEntry // lookup for nodes active in the previous epoch, may be nil or empty
 	currentEpochIdentitiesLookup map[flow.Identifier]*flow.DynamicIdentityEntry // lookup for nodes active in the current epoch, never nil or empty

--- a/state/protocol/protocol_state/updater_test.go
+++ b/state/protocol/protocol_state/updater_test.go
@@ -321,9 +321,14 @@ func (s *UpdaterSuite) TestProcessEpochSetupHappyPath() {
 // built updated protocol state. It should build a union of participants from current and next epoch for current and
 // next epoch protocol states respectively.
 func (s *UpdaterSuite) TestProcessEpochSetupWithSameParticipants() {
-	participantsFromCurrentEpochSetup, err := flow.ReconstructIdentities(s.parentProtocolState.CurrentEpochSetup.Participants,
+	participantsFromCurrentEpochSetup, err := flow.ComposeFullIdentities(s.parentProtocolState.CurrentEpochSetup.Participants,
 		s.parentProtocolState.CurrentEpoch.ActiveIdentities)
 	require.NoError(s.T(), err)
+	// Function `ComposeFullIdentities` verified that `Participants` and `ActiveIdentities` have identical ordering w.r.t nodeID.
+	// By construction, `participantsFromCurrentEpochSetup` lists the full Identities in the same ordering as `Participants` and
+	// `ActiveIdentities`. By confirming that `participantsFromCurrentEpochSetup` follows canonical ordering, we can conclude that
+	// also `Participants` and `ActiveIdentities` are canonically ordered.
+	require.True(s.T(), participantsFromCurrentEpochSetup.Sorted(order.Canonical[flow.Identity]), "participants in current epoch's setup event are not in canonical order")
 
 	overlappingNodes, err := participantsFromCurrentEpochSetup.Sample(2)
 	require.NoError(s.T(), err)

--- a/storage/badger/protocol_state.go
+++ b/storage/badger/protocol_state.go
@@ -144,7 +144,7 @@ func newRichProtocolStateEntry(
 		err                 error
 	)
 	// query and fill in epoch setups and commits for previous and current epochs
-	if protocolState.PreviousEpoch.SetupID != flow.ZeroID {
+	if protocolState.PreviousEpoch != nil {
 		previousEpochSetup, err = setups.ByID(protocolState.PreviousEpoch.SetupID)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve previous epoch setup: %w", err)

--- a/storage/badger/protocol_state_test.go
+++ b/storage/badger/protocol_state_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/mapfunc"
+	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage/badger/transaction"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -185,10 +186,10 @@ func TestProtocolStateRootSnapshot(t *testing.T) {
 
 // assertRichProtocolStateValidity checks if RichProtocolState holds its invariant and is correctly populated by storage layer.
 func assertRichProtocolStateValidity(t *testing.T, state *flow.RichProtocolStateEntry) {
-	// invariant: CurrentEpochSetup and CurrentEpochCommit are for the same epoch. Never nil.
+	// invariants:
+	//  - CurrentEpochSetup and CurrentEpochCommit are for the same epoch. Never nil.
+	//  - CurrentEpochSetup and CurrentEpochCommit IDs match respective commitments in the `ProtocolStateEntry`.
 	assert.Equal(t, state.CurrentEpochSetup.Counter, state.CurrentEpochCommit.Counter, "current epoch setup and commit should be for the same epoch")
-
-	// invariant: CurrentEpochSetup and CurrentEpochCommit IDs are the equal to the ID of the protocol state entry. Never nil.
 	assert.Equal(t, state.CurrentEpochSetup.ID(), state.ProtocolStateEntry.CurrentEpoch.SetupID, "epoch setup should be for correct event ID")
 	assert.Equal(t, state.CurrentEpochCommit.ID(), state.ProtocolStateEntry.CurrentEpoch.CommitID, "epoch commit should be for correct event ID")
 
@@ -197,52 +198,66 @@ func assertRichProtocolStateValidity(t *testing.T, state *flow.RichProtocolState
 		err                       error
 	)
 	// invariant: PreviousEpochSetup and PreviousEpochCommit should be present if respective ID is not zero.
-	if state.PreviousEpoch.SetupID != flow.ZeroID {
+	if state.PreviousEpoch != nil {
 		// invariant: PreviousEpochSetup and PreviousEpochCommit are for the same epoch. Never nil.
-		assert.Equal(t, state.CurrentEpochSetup.Counter, state.PreviousEpochSetup.Counter+1, "current epoch setup should be next after previous epoch")
+		assert.Equal(t, state.PreviousEpochSetup.Counter+1, state.CurrentEpochSetup.Counter, "current epoch (%d) should be following right after previous epoch (%d)", state.CurrentEpochSetup.Counter, state.PreviousEpochSetup.Counter)
 		assert.Equal(t, state.PreviousEpochSetup.Counter, state.PreviousEpochCommit.Counter, "previous epoch setup and commit should be for the same epoch")
 
 		// invariant: PreviousEpochSetup and PreviousEpochCommit IDs are the equal to the ID of the protocol state entry. Never nil.
 		assert.Equal(t, state.PreviousEpochSetup.ID(), state.ProtocolStateEntry.PreviousEpoch.SetupID, "epoch setup should be for correct event ID")
 		assert.Equal(t, state.PreviousEpochCommit.ID(), state.ProtocolStateEntry.PreviousEpoch.CommitID, "epoch commit should be for correct event ID")
 
-		// invariant: ReconstructIdentities ensures that we can build full identities of previous epoch active participants.
-		previousEpochParticipants, err = flow.ReconstructIdentities(state.PreviousEpochSetup.Participants, state.PreviousEpoch.ActiveIdentities)
+		// invariant: ComposeFullIdentities ensures that we can build full identities of previous epoch's active participants. This step also confirms that the
+		// previous epoch's `Participants` [IdentitySkeletons] and `ActiveIdentities` [DynamicIdentity properties] list the same nodes in canonical ordering.
+		previousEpochParticipants, err = flow.ComposeFullIdentities(state.PreviousEpochSetup.Participants, state.PreviousEpoch.ActiveIdentities)
 		assert.NoError(t, err, "should be able to reconstruct previous epoch active participants")
+		// Function `ComposeFullIdentities` verified that `Participants` and `ActiveIdentities` have identical ordering w.r.t nodeID.
+		// By construction, `participantsFromCurrentEpochSetup` lists the full Identities in the same ordering as `Participants` and
+		// `ActiveIdentities`. By confirming that `participantsFromCurrentEpochSetup` follows canonical ordering, we can conclude that
+		// also `Participants` and `ActiveIdentities` are canonically ordered.
+		require.True(t, previousEpochParticipants.Sorted(order.Canonical[flow.Identity]), "participants in previous epoch's setup event are not in canonical order")
 	}
 
-	// invariant: ReconstructIdentities ensures that we can build full identities of current epoch active participants.
-	participantsFromCurrentEpochSetup, err := flow.ReconstructIdentities(state.CurrentEpochSetup.Participants, state.CurrentEpoch.ActiveIdentities)
+	// invariant: ComposeFullIdentities ensures that we can build full identities of current epoch's *active* participants. This step also confirms that the
+	// current epoch's `Participants` [IdentitySkeletons] and `ActiveIdentities` [DynamicIdentity properties] list the same nodes in canonical ordering.
+	participantsFromCurrentEpochSetup, err := flow.ComposeFullIdentities(state.CurrentEpochSetup.Participants, state.CurrentEpoch.ActiveIdentities)
 	assert.NoError(t, err, "should be able to reconstruct current epoch active participants")
+	require.True(t, participantsFromCurrentEpochSetup.Sorted(order.Canonical[flow.Identity]), "participants in current epoch's setup event are not in canonical order")
 
-	// invariant: Identities is a full identity table for the current epoch. Identities are sorted in canonical order. Without duplicates. Never nil.
+	// invariants for `CurrentEpochIdentityTable`:
+	//  - full identity table containing *active* nodes for the current epoch + weight-zero identities of adjacent epoch
+	//  - Identities are sorted in canonical order. Without duplicates. Never nil.
 	var allIdentities, participantsFromNextEpochSetup flow.IdentityList
 	if state.NextEpoch != nil {
 		// setup/commit phase
-		// invariant: ReconstructIdentities ensures that we can build full identities of next epoch active participants.
-		participantsFromNextEpochSetup, err = flow.ReconstructIdentities(state.NextEpochSetup.Participants, state.NextEpoch.ActiveIdentities)
+		// invariant: ComposeFullIdentities ensures that we can build full identities of next epoch's *active* participants. This step also confirms that the
+		// next epoch's `Participants` [IdentitySkeletons] and `ActiveIdentities` [DynamicIdentity properties] list the same nodes in canonical ordering.
+		participantsFromNextEpochSetup, err = flow.ComposeFullIdentities(state.NextEpochSetup.Participants, state.NextEpoch.ActiveIdentities)
 		assert.NoError(t, err, "should be able to reconstruct next epoch active participants")
 		allIdentities = participantsFromCurrentEpochSetup.Union(participantsFromNextEpochSetup.Map(mapfunc.WithWeight(0)))
 	} else {
 		// staking phase
 		allIdentities = participantsFromCurrentEpochSetup.Union(previousEpochParticipants.Map(mapfunc.WithWeight(0)))
 	}
-
 	assert.Equal(t, allIdentities, state.CurrentEpochIdentityTable, "identities should be a full identity table for the current epoch, without duplicates")
+	require.True(t, allIdentities.Sorted(order.Canonical[flow.Identity]), "current epoch's identity table is not in canonical order")
 
-	nextEpoch := state.NextEpoch
-	if nextEpoch == nil {
+	// check next epoch; only applicable during setup/commit phase
+	if state.NextEpoch == nil { // during staking phase, next epoch is not yet specified; hence there is nothing else to check
 		return
 	}
-	// invariant: NextEpochSetup and NextEpochCommit are for the same epoch. Never nil.
+
+	// invariants:
+	//  - NextEpochSetup and NextEpochCommit are for the same epoch. Never nil.
+	//  - NextEpochSetup and NextEpochCommit IDs match respective commitments in the `ProtocolStateEntry`.
+	assert.Equal(t, state.CurrentEpochSetup.Counter+1, state.NextEpochSetup.Counter, "next epoch (%d) should be following right after current epoch (%d)", state.NextEpochSetup.Counter, state.CurrentEpochSetup.Counter)
 	assert.Equal(t, state.NextEpochSetup.Counter, state.NextEpochCommit.Counter, "next epoch setup and commit should be for the same epoch")
+	assert.Equal(t, state.NextEpochSetup.ID(), state.NextEpoch.SetupID, "epoch setup should be for correct event ID")
+	assert.Equal(t, state.NextEpochCommit.ID(), state.NextEpoch.CommitID, "epoch commit should be for correct event ID")
 
-	// invariant: NextEpochSetup and NextEpochCommit IDs are the equal to the ID of the protocol state entry. Never nil.
-	assert.Equal(t, state.NextEpochSetup.ID(), nextEpoch.SetupID, "epoch setup should be for correct event ID")
-	assert.Equal(t, state.NextEpochCommit.ID(), nextEpoch.CommitID, "epoch commit should be for correct event ID")
-
-	// invariant: Identities is a full identity table for the current epoch. Identities are sorted in canonical order. Without duplicates. Never nil.
+	// invariants for `NextEpochIdentityTable`:
+	//  - full identity table containing *active* nodes for next epoch + weight-zero identities of current epoch
+	//  - Identities are sorted in canonical order. Without duplicates. Never nil.
 	allIdentities = participantsFromNextEpochSetup.Union(participantsFromCurrentEpochSetup.Map(mapfunc.WithWeight(0)))
-
 	assert.Equal(t, allIdentities, state.NextEpochIdentityTable, "identities should be a full identity table for the next epoch, without duplicates")
 }

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	crand "crypto/rand"
 	"fmt"
-	"github.com/onflow/flow-go/model/flow/mapfunc"
 	"math/rand"
 	"net"
 	"testing"
@@ -34,6 +33,7 @@ import (
 	"github.com/onflow/flow-go/model/encoding"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
+	"github.com/onflow/flow-go/model/flow/mapfunc"
 	"github.com/onflow/flow-go/model/flow/order"
 	"github.com/onflow/flow-go/model/messages"
 	"github.com/onflow/flow-go/model/verification"
@@ -2602,7 +2602,7 @@ func RootProtocolStateFixture() *flow.RichProtocolStateEntry {
 				CommitID:         currentEpochCommit.ID(),
 				ActiveIdentities: flow.DynamicIdentityEntryListFromIdentities(allIdentities),
 			},
-			PreviousEpoch: flow.EpochStateContainer{
+			PreviousEpoch: &flow.EpochStateContainer{
 				SetupID:          flow.ZeroID,
 				CommitID:         flow.ZeroID,
 				ActiveIdentities: nil,
@@ -2673,7 +2673,7 @@ func ProtocolStateFixture(options ...func(*flow.RichProtocolStateEntry)) *flow.R
 				CommitID:         currentEpochCommit.ID(),
 				ActiveIdentities: flow.DynamicIdentityEntryListFromIdentities(currentEpochIdentities),
 			},
-			PreviousEpoch: flow.EpochStateContainer{
+			PreviousEpoch: &flow.EpochStateContainer{
 				SetupID:          prevEpochSetup.ID(),
 				CommitID:         prevEpochCommit.ID(),
 				ActiveIdentities: flow.DynamicIdentityEntryListFromIdentities(prevEpochIdentities),

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2596,16 +2596,11 @@ func RootProtocolStateFixture() *flow.RichProtocolStateEntry {
 	}
 	return &flow.RichProtocolStateEntry{
 		ProtocolStateEntry: &flow.ProtocolStateEntry{
-
+			PreviousEpoch: nil,
 			CurrentEpoch: flow.EpochStateContainer{
 				SetupID:          currentEpochSetup.ID(),
 				CommitID:         currentEpochCommit.ID(),
 				ActiveIdentities: flow.DynamicIdentityEntryListFromIdentities(allIdentities),
-			},
-			PreviousEpoch: &flow.EpochStateContainer{
-				SetupID:          flow.ZeroID,
-				CommitID:         flow.ZeroID,
-				ActiveIdentities: nil,
 			},
 			InvalidStateTransitionAttempted: false,
 			NextEpoch:                       nil,


### PR DESCRIPTION
## Suggested revisions for [PR #4834](https://github.com/onflow/flow-go/pull/4834)

Summary of central changes:
* `model/flow/protocol_state.go`:
  - revised goDoc of protocol state implementation
  - changed `ProtocolStateEntry.PreviousEpoch` to pointer (consistent with `ProtocolStateEntry.NextEpoch`)
  - There should be no significant algorithmic changes. Though, I have switched the order of the if and else branches when processing an Epoch Setup event. For me, this is much more in line with the intuitive order of documentation.

* `state/protocol/protocol_state/updater.go`:
  - notable updates and revisions of goDoc
  - tried to address concerns around inconsistent handling of invariances
  - updated code to work with `ProtocolStateEntry.PreviousEpoch` being potentially a nil pointer

* `storage/badger/protocol_state_test.go`:
  - detailed goDoc revisions for test `assertRichProtocolStateValidity`

This PR is likely incomplete and might require tiding up some minor loose ends. 