### PR TITLE
[FVM] beyond EVM part 7 - update evm-related events to capture the content and hash of transactions

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -96,7 +96,6 @@ func (bl *Block) DirectCall(call *types.DirectCall) (*types.Result, error) {
 		return nil, err
 	}
 	res.TxType = types.DirectCallTxType
-	res.TxHash, err = call.Hash()
 	if err != nil {
 		return nil, err
 	}

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -57,13 +57,13 @@ func TestNativeTokenBridging(t *testing.T) {
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
 					amount := big.NewInt(10000)
-					res, err := blk.MintTo(testAccount, amount)
+					res, err := blk.DirectCall(types.NewDepositCall(testAccount, amount))
 					require.NoError(t, err)
 					require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
 				})
 			})
 		})
-		t.Run("mint tokens withdraw", func(t *testing.T) {
+		t.Run("tokens withdraw", func(t *testing.T) {
 			amount := big.NewInt(1000)
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewReadOnlyBlockView(t, env, func(blk types.ReadOnlyBlockView) {
@@ -74,7 +74,7 @@ func TestNativeTokenBridging(t *testing.T) {
 			})
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					res, err := blk.WithdrawFrom(testAccount, amount)
+					res, err := blk.DirectCall(types.NewWithdrawCall(testAccount, amount))
 					require.NoError(t, err)
 					require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
 				})
@@ -103,7 +103,7 @@ func TestContractInteraction(t *testing.T) {
 		// fund test account
 		RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 			RunWithNewBlockView(t, env, func(blk types.BlockView) {
-				_, err := blk.MintTo(testAccount, amount)
+				_, err := blk.DirectCall(types.NewDepositCall(testAccount, amount))
 				require.NoError(t, err)
 			})
 		})
@@ -113,7 +113,13 @@ func TestContractInteraction(t *testing.T) {
 		t.Run("deploy contract", func(t *testing.T) {
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					res, err := blk.Deploy(testAccount, testContract.ByteCode, math.MaxUint64, amountToBeTransfered)
+					res, err := blk.DirectCall(
+						types.NewDeployCall(
+							testAccount,
+							testContract.ByteCode,
+							math.MaxUint64,
+							amountToBeTransfered),
+					)
 					require.NoError(t, err)
 					contractAddr = res.DeployedContractAddress
 				})
@@ -139,13 +145,14 @@ func TestContractInteraction(t *testing.T) {
 
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					res, err := blk.Call(
-						testAccount,
-						contractAddr,
-						testContract.MakeStoreCallData(t, num),
-						1_000_000,
-						// this should be zero because the contract doesn't have receiver
-						big.NewInt(0),
+					res, err := blk.DirectCall(
+						types.NewContractCall(
+							testAccount,
+							contractAddr,
+							testContract.MakeStoreCallData(t, num),
+							1_000_000,
+							big.NewInt(0), // this should be zero because the contract doesn't have receiver
+						),
 					)
 					require.NoError(t, err)
 					require.GreaterOrEqual(t, res.GasConsumed, uint64(40_000))
@@ -154,13 +161,14 @@ func TestContractInteraction(t *testing.T) {
 
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					res, err := blk.Call(
-						testAccount,
-						contractAddr,
-						testContract.MakeRetrieveCallData(t),
-						1_000_000,
-						// this should be zero because the contract doesn't have receiver
-						big.NewInt(0),
+					res, err := blk.DirectCall(
+						types.NewContractCall(
+							testAccount,
+							contractAddr,
+							testContract.MakeRetrieveCallData(t),
+							1_000_000,
+							big.NewInt(0), // this should be zero because the contract doesn't have receiver
+						),
 					)
 					require.NoError(t, err)
 
@@ -172,13 +180,14 @@ func TestContractInteraction(t *testing.T) {
 
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					res, err := blk.Call(
-						testAccount,
-						contractAddr,
-						testContract.MakeBlockNumberCallData(t),
-						1_000_000,
-						// this should be zero because the contract doesn't have receiver
-						big.NewInt(0),
+					res, err := blk.DirectCall(
+						types.NewContractCall(
+							testAccount,
+							contractAddr,
+							testContract.MakeBlockNumberCallData(t),
+							1_000_000,
+							big.NewInt(0), // this should be zero because the contract doesn't have receiver
+						),
 					)
 					require.NoError(t, err)
 
@@ -197,7 +206,7 @@ func TestContractInteraction(t *testing.T) {
 
 			RunWithNewEmulator(t, db, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					_, err := blk.MintTo(fAddr, amount)
+					_, err := blk.DirectCall(types.NewDepositCall(fAddr, amount))
 					require.NoError(t, err)
 				})
 			})
@@ -208,7 +217,7 @@ func TestContractInteraction(t *testing.T) {
 				coinbaseOrgBalance := gethCommon.Big1
 				// small amount of money to create account
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					_, err := blk.MintTo(ctx.GasFeeCollector, coinbaseOrgBalance)
+					_, err := blk.DirectCall(types.NewDepositCall(ctx.GasFeeCollector, coinbaseOrgBalance))
 					require.NoError(t, err)
 				})
 

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -304,14 +304,6 @@ func (a *Account) Withdraw(b types.Balance) *types.FLOWTokenVault {
 	handleError(err)
 
 	// emit event
-	a.fch.EmitEvent(
-		types.NewTransactionExecutedEvent(
-			a.fch.lastExecutedBlock.Height+1,
-			encoded,
-			callHash,
-			res,
-		),
-	)
 	a.fch.EmitLastExecutedBlockEvent()
 	a.fch.totalSupply -= b.ToAttoFlow().Uint64()
 	a.fch.updateLastExecutedBlock(res.StateRootHash, gethTypes.EmptyRootHash)

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -222,7 +222,12 @@ func (a *Account) Deposit(v *types.FLOWTokenVault) {
 	blk, err := a.fch.emulator.NewBlockView(cfg)
 	handleError(err)
 
-	res, err := blk.MintTo(a.address, v.Balance().ToAttoFlow())
+	res, err := blk.DirectCall(
+		types.NewDepositCall(
+			a.address,
+			v.Balance().ToAttoFlow(),
+		),
+	)
 	a.fch.meterGasUsage(res)
 	handleError(err)
 	// emit event
@@ -248,7 +253,12 @@ func (a *Account) Withdraw(b types.Balance) *types.FLOWTokenVault {
 	blk, err := a.fch.emulator.NewBlockView(cfg)
 	handleError(err)
 
-	res, err := blk.WithdrawFrom(a.address, b.ToAttoFlow())
+	res, err := blk.DirectCall(
+		types.NewWithdrawCall(
+			a.address,
+			b.ToAttoFlow(),
+		),
+	)
 	a.fch.meterGasUsage(res)
 	handleError(err)
 
@@ -270,7 +280,13 @@ func (a *Account) Transfer(to types.Address, balance types.Balance) {
 	blk, err := a.fch.emulator.NewBlockView(cfg)
 	handleError(err)
 
-	res, err := blk.Transfer(a.address, to, balance.ToAttoFlow())
+	res, err := blk.DirectCall(
+		types.NewTransferCall(
+			a.address,
+			to,
+			balance.ToAttoFlow(),
+		),
+	)
 	a.fch.meterGasUsage(res)
 	handleError(err)
 
@@ -288,7 +304,14 @@ func (a *Account) Deploy(code types.Code, gaslimit types.GasLimit, balance types
 	blk, err := a.fch.emulator.NewBlockView(a.fch.getBlockContext())
 	handleError(err)
 
-	res, err := blk.Deploy(a.address, code, uint64(gaslimit), balance.ToAttoFlow())
+	res, err := blk.DirectCall(
+		types.NewDeployCall(
+			a.address,
+			code,
+			uint64(gaslimit),
+			balance.ToAttoFlow(),
+		),
+	)
 	a.fch.meterGasUsage(res)
 	handleError(err)
 	a.fch.EmitLastExecutedBlockEvent()
@@ -308,7 +331,15 @@ func (a *Account) Call(to types.Address, data types.Data, gaslimit types.GasLimi
 	blk, err := a.fch.emulator.NewBlockView(a.fch.getBlockContext())
 	handleError(err)
 
-	res, err := blk.Call(a.address, to, data, uint64(gaslimit), balance.ToAttoFlow())
+	res, err := blk.DirectCall(
+		types.NewContractCall(
+			a.address,
+			to,
+			data,
+			uint64(gaslimit),
+			balance.ToAttoFlow(),
+		),
+	)
 	a.fch.meterGasUsage(res)
 	handleError(err)
 	a.fch.EmitLastExecutedBlockEvent()

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -298,12 +298,13 @@ func TestHandler_BridgedAccount(t *testing.T) {
 
 				// deposit event
 				event := events[0]
-				assert.Equal(t, event.Type, types.EventTypeFlowTokenDeposit)
-				ret := types.FlowTokenEventPayload{}
+				assert.Equal(t, event.Type, types.EventTypeTransactionExecuted)
+				ret := types.TransactionExecutedPayload{}
 				err = rlp.Decode(bytes.NewReader(event.Payload), &ret)
 				require.NoError(t, err)
-				assert.Equal(t, foa.Address(), ret.Address)
-				assert.Equal(t, balance, ret.Amount)
+				// TODO: decode encoded tx and check for the amount and value
+				// assert.Equal(t, foa.Address(), ret.Address)
+				// assert.Equal(t, balance, ret.Amount)
 
 				// block event
 				event = events[1]
@@ -311,12 +312,13 @@ func TestHandler_BridgedAccount(t *testing.T) {
 
 				// withdraw event
 				event = events[2]
-				assert.Equal(t, event.Type, types.EventTypeFlowTokenWithdrawal)
-				ret = types.FlowTokenEventPayload{}
+				assert.Equal(t, event.Type, types.EventTypeTransactionExecuted)
+				ret = types.TransactionExecutedPayload{}
 				err = rlp.Decode(bytes.NewReader(event.Payload), &ret)
 				require.NoError(t, err)
-				assert.Equal(t, foa.Address(), ret.Address)
-				assert.Equal(t, balance, ret.Amount)
+				// TODO: decode encoded tx and check for the amount and value
+				// assert.Equal(t, foa.Address(), ret.Address)
+				// assert.Equal(t, balance, ret.Amount)
 
 				// block event
 				event = events[3]

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -257,7 +257,7 @@ func TestHandler_OpsWithoutEmulator(t *testing.T) {
 	})
 }
 
-func TestHandler_FOA(t *testing.T) {
+func TestHandler_BridgedAccount(t *testing.T) {
 
 	t.Run("test deposit/withdraw (with integrated emulator)", func(t *testing.T) {
 		testutils.RunWithTestBackend(t, func(backend types.Backend) {
@@ -349,7 +349,7 @@ func TestHandler_FOA(t *testing.T) {
 					// test insufficient total supply
 					assertPanic(t, types.IsAInsufficientTotalSupplyError, func() {
 						em := &testutils.TestEmulator{
-							WithdrawFromFunc: func(address types.Address, amount *big.Int) (*types.Result, error) {
+							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
 								return &types.Result{}, types.NewEVMExecutionError(fmt.Errorf("some sort of error"))
 							},
 						}
@@ -361,8 +361,8 @@ func TestHandler_FOA(t *testing.T) {
 					// test non fatal error of emulator
 					assertPanic(t, types.IsEVMExecutionError, func() {
 						em := &testutils.TestEmulator{
-							WithdrawFromFunc: func(address types.Address, amount *big.Int) (*types.Result, error) {
-								return &types.Result{}, types.NewEVMExecutionError(fmt.Errorf("some sort of error"))
+							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
+								return &types.Result{}, fmt.Errorf("some sort of error")
 							},
 						}
 						handler := handler.NewContractHandler(bs, backend, em)
@@ -373,8 +373,8 @@ func TestHandler_FOA(t *testing.T) {
 					// test fatal error of emulator
 					assertPanic(t, types.IsAFatalError, func() {
 						em := &testutils.TestEmulator{
-							WithdrawFromFunc: func(address types.Address, amount *big.Int) (*types.Result, error) {
-								return &types.Result{}, types.NewFatalError(fmt.Errorf("some sort of fatal error"))
+							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
+								return &types.Result{}, types.NewEVMExecutionError(fmt.Errorf("some sort of error"))
 							},
 						}
 						handler := handler.NewContractHandler(bs, backend, em)
@@ -396,8 +396,8 @@ func TestHandler_FOA(t *testing.T) {
 					// test non fatal error of emulator
 					assertPanic(t, types.IsEVMExecutionError, func() {
 						em := &testutils.TestEmulator{
-							MintToFunc: func(address types.Address, amount *big.Int) (*types.Result, error) {
-								return nil, types.NewEVMExecutionError(fmt.Errorf("some sort of error"))
+							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
+								return &types.Result{}, types.NewEVMExecutionError(fmt.Errorf("some sort of error"))
 							},
 						}
 						handler := handler.NewContractHandler(bs, backend, em)
@@ -408,8 +408,8 @@ func TestHandler_FOA(t *testing.T) {
 					// test fatal error of emulator
 					assertPanic(t, types.IsAFatalError, func() {
 						em := &testutils.TestEmulator{
-							MintToFunc: func(address types.Address, amount *big.Int) (*types.Result, error) {
-								return nil, types.NewFatalError(fmt.Errorf("some sort of fatal error"))
+							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
+								return &types.Result{}, fmt.Errorf("some sort of fatal error")
 							},
 						}
 						handler := handler.NewContractHandler(bs, backend, em)

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -362,7 +362,7 @@ func TestHandler_BridgedAccount(t *testing.T) {
 					assertPanic(t, types.IsEVMExecutionError, func() {
 						em := &testutils.TestEmulator{
 							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
-								return &types.Result{}, fmt.Errorf("some sort of error")
+								return &types.Result{}, types.NewEVMExecutionError(fmt.Errorf("some sort of error"))
 							},
 						}
 						handler := handler.NewContractHandler(bs, backend, em)
@@ -374,7 +374,7 @@ func TestHandler_BridgedAccount(t *testing.T) {
 					assertPanic(t, types.IsAFatalError, func() {
 						em := &testutils.TestEmulator{
 							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
-								return &types.Result{}, types.NewEVMExecutionError(fmt.Errorf("some sort of error"))
+								return &types.Result{}, types.NewFatalError(fmt.Errorf("some sort of fatal error"))
 							},
 						}
 						handler := handler.NewContractHandler(bs, backend, em)
@@ -409,7 +409,7 @@ func TestHandler_BridgedAccount(t *testing.T) {
 					assertPanic(t, types.IsAFatalError, func() {
 						em := &testutils.TestEmulator{
 							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
-								return &types.Result{}, fmt.Errorf("some sort of fatal error")
+								return &types.Result{}, types.NewFatalError(fmt.Errorf("some sort of fatal error"))
 							},
 						}
 						handler := handler.NewContractHandler(bs, backend, em)

--- a/fvm/evm/testutils/accounts.go
+++ b/fvm/evm/testutils/accounts.go
@@ -103,7 +103,12 @@ func RunWithEOATestAccount(t *testing.T, led atree.Ledger, flowEVMRootAddress fl
 	blk, err := e.NewBlockView(types.NewDefaultBlockContext(2))
 	require.NoError(t, err)
 
-	_, err = blk.MintTo(account.Address(), new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1000)))
+	_, err = blk.DirectCall(
+		types.NewDepositCall(
+			account.Address(),
+			new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1000)),
+		),
+	)
 	require.NoError(t, err)
 
 	f(account)

--- a/fvm/evm/testutils/contract.go
+++ b/fvm/evm/testutils/contract.go
@@ -177,10 +177,23 @@ func RunWithDeployedContract(t *testing.T, led atree.Ledger, flowEVMRootAddress 
 	require.NoError(t, err)
 
 	caller := types.NewAddress(gethCommon.Address{})
-	_, err = blk.MintTo(caller, new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1000)))
+
+	_, err = blk.DirectCall(
+		types.NewDepositCall(
+			caller,
+			new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1000)),
+		),
+	)
 	require.NoError(t, err)
 
-	res, err := blk.Deploy(caller, tc.ByteCode, math.MaxUint64, big.NewInt(0))
+	res, err := blk.DirectCall(
+		types.NewDeployCall(
+			caller,
+			tc.ByteCode,
+			math.MaxUint64,
+			big.NewInt(0),
+		),
+	)
 	require.NoError(t, err)
 
 	tc.SetDeployedAt(res.DeployedContractAddress)

--- a/fvm/evm/testutils/emulator.go
+++ b/fvm/evm/testutils/emulator.go
@@ -12,13 +12,10 @@ import (
 )
 
 type TestEmulator struct {
-	BalanceOfFunc      func(address types.Address) (*big.Int, error)
-	CodeOfFunc         func(address types.Address) (types.Code, error)
-	MintToFunc         func(address types.Address, amount *big.Int) (*types.Result, error)
-	WithdrawFromFunc   func(address types.Address, amount *big.Int) (*types.Result, error)
-	TransferFunc       func(from types.Address, to types.Address, value *big.Int) (*types.Result, error)
-	DeployFunc         func(caller types.Address, code types.Code, gasLimit uint64, value *big.Int) (*types.Result, error)
-	CallFunc           func(caller types.Address, to types.Address, data types.Data, gasLimit uint64, value *big.Int) (*types.Result, error)
+	BalanceOfFunc func(address types.Address) (*big.Int, error)
+	CodeOfFunc    func(address types.Address) (types.Code, error)
+
+	DirectCallFunc     func(call *types.DirectCall) (*types.Result, error)
 	RunTransactionFunc func(tx *gethTypes.Transaction) (*types.Result, error)
 }
 
@@ -50,44 +47,12 @@ func (em *TestEmulator) CodeOf(address types.Address) (types.Code, error) {
 	return em.CodeOfFunc(address)
 }
 
-// MintTo mints new tokens to this address
-func (em *TestEmulator) MintTo(address types.Address, amount *big.Int) (*types.Result, error) {
-	if em.MintToFunc == nil {
+// DirectCall executes a direct call
+func (em *TestEmulator) DirectCall(call *types.DirectCall) (*types.Result, error) {
+	if em.DirectCallFunc == nil {
 		panic("method not set")
 	}
-	return em.MintToFunc(address, amount)
-}
-
-// WithdrawFrom withdraws tokens from this address
-func (em *TestEmulator) WithdrawFrom(address types.Address, amount *big.Int) (*types.Result, error) {
-	if em.WithdrawFromFunc == nil {
-		panic("method not set")
-	}
-	return em.WithdrawFromFunc(address, amount)
-}
-
-// Transfer transfers token between addresses
-func (em *TestEmulator) Transfer(from types.Address, to types.Address, value *big.Int) (*types.Result, error) {
-	if em.TransferFunc == nil {
-		panic("method not set")
-	}
-	return em.TransferFunc(from, to, value)
-}
-
-// Deploy deploys an smart contract
-func (em *TestEmulator) Deploy(caller types.Address, code types.Code, gasLimit uint64, value *big.Int) (*types.Result, error) {
-	if em.DeployFunc == nil {
-		panic("method not set")
-	}
-	return em.DeployFunc(caller, code, gasLimit, value)
-}
-
-// Call makes a call to a smart contract
-func (em *TestEmulator) Call(caller types.Address, to types.Address, data types.Data, gasLimit uint64, value *big.Int) (*types.Result, error) {
-	if em.CallFunc == nil {
-		panic("method not set")
-	}
-	return em.CallFunc(caller, to, data, gasLimit, value)
+	return em.DirectCallFunc(call)
 }
 
 // RunTransaction runs a transaction and collect gas fees to the coinbase account

--- a/fvm/evm/types/address.go
+++ b/fvm/evm/types/address.go
@@ -12,6 +12,9 @@ type Address gethCommon.Address
 // AddressLength holds the number of bytes used for each EVM address
 const AddressLength = gethCommon.AddressLength
 
+// EmptyAddress is an empty evm address
+var EmptyAddress = Address(gethCommon.Address{})
+
 // NewAddress constructs a new Address
 func NewAddress(addr gethCommon.Address) Address {
 	fa := Address(addr)

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -26,6 +26,9 @@ type Block struct {
 
 	// ReceiptRoot returns the root hash of the receipts emitted in this block
 	ReceiptRoot gethCommon.Hash
+
+	// transaction hashes
+	TransactionHashes []gethCommon.Hash
 }
 
 func (b *Block) ToBytes() ([]byte, error) {
@@ -38,7 +41,14 @@ func (b *Block) Hash() (gethCommon.Hash, error) {
 }
 
 // NewBlock constructs a new block
-func NewBlock(height, uuidIndex, totalSupply uint64, stateRoot, receiptRoot gethCommon.Hash) *Block {
+func NewBlock(
+	height,
+	uuidIndex,
+	totalSupply uint64,
+	stateRoot,
+	receiptRoot gethCommon.Hash,
+	TransactionHashes []gethCommon.Hash,
+) *Block {
 	return &Block{
 		Height:      height,
 		UUIDIndex:   uuidIndex,

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -1,0 +1,117 @@
+package types
+
+import (
+	"math/big"
+
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	gethCore "github.com/ethereum/go-ethereum/core"
+	gethCrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const (
+	// tx type 255 is used for direct calls from bridged accounts
+	DirectCallTxType = byte(255)
+
+	UnknownCallSubType  = byte(0)
+	DepositCallSubType  = byte(1)
+	WithdrawCallSubType = byte(2)
+	TransferCallSubType = byte(3)
+	DeployCallSubType   = byte(4)
+	ContractCallSubType = byte(5)
+
+	TransferGasUsage = 21_000
+)
+
+type DirectCall struct {
+	SubType  byte
+	From     Address
+	To       Address
+	Data     []byte
+	Value    *big.Int
+	GasLimit uint64
+}
+
+func (dc *DirectCall) Encode() ([]byte, error) {
+	return rlp.EncodeToBytes(dc)
+}
+
+func (dc *DirectCall) Hash() (gethCommon.Hash, error) {
+	encoded, err := dc.Encode()
+	return gethCrypto.Keccak256Hash(encoded), err
+}
+
+func (dc *DirectCall) Message() *gethCore.Message {
+	var to *gethCommon.Address
+	if dc.To != EmptyAddress {
+		ct := dc.To.ToCommon()
+		to = &ct
+	}
+	return &gethCore.Message{
+		From:      dc.From.ToCommon(),
+		To:        to,
+		Value:     dc.Value,
+		Data:      dc.Data,
+		GasLimit:  dc.GasLimit,
+		GasPrice:  big.NewInt(0), // price is set to zero fo direct calls
+		GasTipCap: big.NewInt(1), // also known as maxPriorityFeePerGas
+		GasFeeCap: big.NewInt(2), // also known as maxFeePerGas
+		// AccessList:        tx.AccessList(), // TODO revisit this value, the cost matter but performance might
+		SkipAccountChecks: true, // this would let us not set the nonce
+	}
+}
+
+func NewDepositCall(address Address, amount *big.Int) *DirectCall {
+	return &DirectCall{
+		SubType:  DepositCallSubType,
+		From:     EmptyAddress,
+		To:       address,
+		Data:     nil,
+		Value:    amount,
+		GasLimit: TransferGasUsage,
+	}
+}
+
+func NewWithdrawCall(address Address, amount *big.Int) *DirectCall {
+	return &DirectCall{
+		SubType:  WithdrawCallSubType,
+		From:     address,
+		To:       EmptyAddress,
+		Data:     nil,
+		Value:    amount,
+		GasLimit: TransferGasUsage,
+	}
+}
+
+func NewTransferCall(from Address, to Address, amount *big.Int) *DirectCall {
+	return &DirectCall{
+		SubType:  TransferCallSubType,
+		From:     from,
+		To:       to,
+		Data:     nil,
+		Value:    amount,
+		GasLimit: TransferGasUsage,
+	}
+}
+
+func NewDeployCall(caller Address, code Code, gasLimit uint64, value *big.Int) *DirectCall {
+	return &DirectCall{
+		SubType:  DeployCallSubType,
+		From:     caller,
+		To:       EmptyAddress,
+		Data:     code,
+		Value:    value,
+		GasLimit: gasLimit,
+	}
+}
+
+func NewContractCall(caller Address, to Address, data Data, gasLimit uint64, value *big.Int) *DirectCall {
+	return &DirectCall{
+		SubType:  DepositCallSubType,
+		From:     caller,
+		To:       to,
+		Data:     data,
+		Value:    value,
+		GasLimit: gasLimit,
+	}
+}

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -107,7 +107,7 @@ func NewDeployCall(caller Address, code Code, gasLimit uint64, value *big.Int) *
 
 func NewContractCall(caller Address, to Address, data Data, gasLimit uint64, value *big.Int) *DirectCall {
 	return &DirectCall{
-		SubType:  DepositCallSubType,
+		SubType:  ContractCallSubType,
 		From:     caller,
 		To:       to,
 		Data:     data,

--- a/fvm/evm/types/emulator.go
+++ b/fvm/evm/types/emulator.go
@@ -41,17 +41,10 @@ type ReadOnlyBlockView interface {
 
 // BlockView allows evm calls in the context of a block
 type BlockView interface {
-	// MintTo mints new tokens to this address
-	MintTo(address Address, amount *big.Int) (*Result, error)
-	// WithdrawFrom withdraws tokens from this address
-	WithdrawFrom(address Address, amount *big.Int) (*Result, error)
-	// Transfer transfers token between addresses
-	Transfer(from Address, to Address, value *big.Int) (*Result, error)
-	// Deploy deploys an smart contract
-	Deploy(caller Address, code Code, gasLimit uint64, value *big.Int) (*Result, error)
-	// Call makes a call to a smart contract
-	Call(caller Address, to Address, data Data, gasLimit uint64, value *big.Int) (*Result, error)
-	// RunTransaction runs a transaction
+	// executes a direct call
+	DirectCall(call *DirectCall) (*Result, error)
+
+	// RunTransaction executes an evm transaction
 	RunTransaction(tx *gethTypes.Transaction) (*Result, error)
 }
 

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -21,6 +21,7 @@ type Event struct {
 	Payload EventPayload
 }
 
+// we might break this event into two (tx included /tx executed) if size becomes an issue
 type TransactionExecutedPayload struct {
 	BlockHeight uint64
 	TxEncoded   []byte

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -8,10 +9,7 @@ import (
 
 const (
 	EventTypeBlockExecuted       flow.EventType = "evm.BlockExecuted"
-	EventTypeTransactionIncluded flow.EventType = "evm.TransactionIncluded"
 	EventTypeTransactionExecuted flow.EventType = "evm.TransactionExecuted"
-	EventTypeFlowTokenDeposit    flow.EventType = "evm.FlowTokenDeposit"
-	EventTypeFlowTokenWithdrawal flow.EventType = "evm.FlowTokenWithdrawal"
 )
 
 type EventPayload interface {
@@ -23,37 +21,10 @@ type Event struct {
 	Payload EventPayload
 }
 
-type FlowTokenEventPayload struct {
-	Address Address
-	Amount  Balance
-}
-
-func (p *FlowTokenEventPayload) Encode() ([]byte, error) {
-	return rlp.EncodeToBytes(p)
-}
-
-func NewFlowTokenDepositEvent(address Address, amount Balance) *Event {
-	return &Event{
-		Etype: EventTypeFlowTokenDeposit,
-		Payload: &FlowTokenEventPayload{
-			Address: address,
-			Amount:  amount,
-		},
-	}
-}
-
-func NewFlowTokenWithdrawalEvent(address Address, amount Balance) *Event {
-	return &Event{
-		Etype: EventTypeFlowTokenWithdrawal,
-		Payload: &FlowTokenEventPayload{
-			Address: address,
-			Amount:  amount,
-		},
-	}
-}
-
 type TransactionExecutedPayload struct {
 	BlockHeight uint64
+	TxEncoded   []byte
+	TxHash      gethCommon.Hash
 	Result      *Result
 }
 
@@ -63,12 +34,16 @@ func (p *TransactionExecutedPayload) Encode() ([]byte, error) {
 
 func NewTransactionExecutedEvent(
 	height uint64,
+	txEncoded []byte,
+	txHash gethCommon.Hash,
 	result *Result,
 ) *Event {
 	return &Event{
 		Etype: EventTypeTransactionExecuted,
 		Payload: &TransactionExecutedPayload{
 			BlockHeight: height,
+			TxEncoded:   txEncoded,
+			TxHash:      txHash,
 			Result:      result,
 		},
 	}

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	EventTypeBlockExecuted       flow.EventType = "evm.BlockExecuted"
+	EventTypeTransactionIncluded flow.EventType = "evm.TransactionIncluded"
 	EventTypeTransactionExecuted flow.EventType = "evm.TransactionExecuted"
 	EventTypeFlowTokenDeposit    flow.EventType = "evm.FlowTokenDeposit"
 	EventTypeFlowTokenWithdrawal flow.EventType = "evm.FlowTokenWithdrawal"

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -5,9 +5,6 @@ import (
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 )
 
-// tx type 255 is used for direct calls from bridged accounts
-var DirectCallTxType = uint8(255)
-
 // Result captures the result of an interaction to the emulator
 // it could be the out put of a direct call or output of running an
 // evm transaction.
@@ -21,6 +18,8 @@ type Result struct {
 	// type of transaction defined by the evm package
 	// see DirectCallTxType as extra type we added type for direct calls.
 	TxType uint8
+	// transaction hash
+	TxHash gethCommon.Hash
 	// total gas consumed during an opeartion
 	GasConsumed uint64
 	// the root hash of the state after execution
@@ -42,6 +41,7 @@ func (res *Result) Receipt() *gethTypes.ReceiptForStorage {
 		CumulativeGasUsed: res.GasConsumed, // TODO: update to capture cumulative
 		Logs:              res.Logs,
 		ContractAddress:   res.DeployedContractAddress.ToCommon(),
+		TxHash:            res.TxHash,
 	}
 	if res.Failed {
 		receipt.Status = gethTypes.ReceiptStatusFailed

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -18,8 +18,6 @@ type Result struct {
 	// type of transaction defined by the evm package
 	// see DirectCallTxType as extra type we added type for direct calls.
 	TxType uint8
-	// transaction hash
-	TxHash gethCommon.Hash
 	// total gas consumed during an opeartion
 	GasConsumed uint64
 	// the root hash of the state after execution
@@ -41,7 +39,6 @@ func (res *Result) Receipt() *gethTypes.ReceiptForStorage {
 		CumulativeGasUsed: res.GasConsumed, // TODO: update to capture cumulative
 		Logs:              res.Logs,
 		ContractAddress:   res.DeployedContractAddress.ToCommon(),
-		TxHash:            res.TxHash,
 	}
 	if res.Failed {
 		receipt.Status = gethTypes.ReceiptStatusFailed


### PR DESCRIPTION
This PR unifies direct calls to be trackable in the outside world. 