### PR TITLE
[Storehouse Bootstrap] make worker count as option for indexing checkpoint

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -717,7 +717,8 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					}
 
 					// TODO: find a way to hook a context up to this to allow a graceful shutdown
-					err = bootstrap.IndexCheckpointFile(context.Background())
+					workerCount := 10
+					err = bootstrap.IndexCheckpointFile(context.Background(), workerCount)
 					if err != nil {
 						return nil, fmt.Errorf("could not load checkpoint file: %w", err)
 					}

--- a/storage/pebble/bootstrap.go
+++ b/storage/pebble/bootstrap.go
@@ -127,15 +127,15 @@ func (b *RegisterBootstrap) indexCheckpointFileWorker(ctx context.Context) error
 }
 
 // IndexCheckpointFile indexes the checkpoint file in the Dir provided
-func (b *RegisterBootstrap) IndexCheckpointFile(ctx context.Context) error {
+func (b *RegisterBootstrap) IndexCheckpointFile(ctx context.Context, workerCount int) error {
 	cct, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	g, gCtx := errgroup.WithContext(cct)
 
 	start := time.Now()
-	b.log.Info().Msg("indexing registers from checkpoint")
-	for i := 0; i < pebbleBootstrapWorkerCount; i++ {
+	b.log.Info().Msgf("indexing registers from checkpoint with %v worker", workerCount)
+	for i := 0; i < workerCount; i++ {
 		g.Go(func() error {
 			return b.indexCheckpointFileWorker(gCtx)
 		})

--- a/storage/pebble/bootstrap_test.go
+++ b/storage/pebble/bootstrap_test.go
@@ -52,7 +52,7 @@ func TestRegisterBootstrap_IndexCheckpointFile_Happy(t *testing.T) {
 
 		bootstrap, err := NewRegisterBootstrap(pb, checkpointFile, rootHeight, log)
 		require.NoError(t, err)
-		err = bootstrap.IndexCheckpointFile(context.Background())
+		err = bootstrap.IndexCheckpointFile(context.Background(), workerCount)
 		require.NoError(t, err)
 
 		// create registers instance and check values
@@ -86,7 +86,7 @@ func TestRegisterBootstrap_IndexCheckpointFile_Empty(t *testing.T) {
 
 		bootstrap, err := NewRegisterBootstrap(pb, checkpointFile, rootHeight, log)
 		require.NoError(t, err)
-		err = bootstrap.IndexCheckpointFile(context.Background())
+		err = bootstrap.IndexCheckpointFile(context.Background(), workerCount)
 		require.NoError(t, err)
 
 		// create registers instance and check values
@@ -124,7 +124,7 @@ func TestRegisterBootstrap_IndexCheckpointFile_FormatIssue(t *testing.T) {
 
 		bootstrap, err := NewRegisterBootstrap(pb, checkpointFile, rootHeight, log)
 		require.NoError(t, err)
-		err = bootstrap.IndexCheckpointFile(context.Background())
+		err = bootstrap.IndexCheckpointFile(context.Background(), workerCount)
 		require.ErrorContains(t, err, "unexpected ledger key format")
 		require.NoError(t, pb.Close())
 		require.NoError(t, os.RemoveAll(dbDir))
@@ -147,7 +147,7 @@ func TestRegisterBootstrap_IndexCheckpointFile_CorruptedCheckpointFile(t *testin
 		pb, dbDir := createPebbleForTest(t)
 		bootstrap, err := NewRegisterBootstrap(pb, checkpointFileName, rootHeight, log)
 		require.NoError(t, err)
-		err = bootstrap.IndexCheckpointFile(context.Background())
+		err = bootstrap.IndexCheckpointFile(context.Background(), workerCount)
 		require.ErrorIs(t, err, os.ErrNotExist)
 		require.NoError(t, os.RemoveAll(dbDir))
 	})
@@ -165,7 +165,7 @@ func TestRegisterBootstrap_IndexCheckpointFile_MultipleBatch(t *testing.T) {
 		pb, dbDir := createPebbleForTest(t)
 		bootstrap, err := NewRegisterBootstrap(pb, checkpointFile, rootHeight, log)
 		require.NoError(t, err)
-		err = bootstrap.IndexCheckpointFile(context.Background())
+		err = bootstrap.IndexCheckpointFile(context.Background(), workerCount)
 		require.NoError(t, err)
 
 		// create registers instance and check values
@@ -191,9 +191,11 @@ func simpleTrieWithValidRegisterIDs(t *testing.T) ([]*trie.MTrie, []*flow.Regist
 	return trieWithValidRegisterIDs(t, 2)
 }
 
+const workerCount = 10
+
 func largeTrieWithValidRegisterIDs(t *testing.T) ([]*trie.MTrie, []*flow.RegisterID) {
 	// large enough trie so every worker should have something to index
-	largeTrieSize := 2 * pebbleBootstrapRegisterBatchLen * pebbleBootstrapWorkerCount
+	largeTrieSize := 2 * pebbleBootstrapRegisterBatchLen * workerCount
 	return trieWithValidRegisterIDs(t, uint16(largeTrieSize))
 }
 

--- a/storage/pebble/constants.go
+++ b/storage/pebble/constants.go
@@ -11,10 +11,6 @@ const (
 	// register bootstrap process
 	pebbleBootstrapRegisterBatchLen = 1000
 
-	// pebbleBootstrapWorkerCount is the maximum number of concurrent goroutines that read and index
-	// checkpoint leaf nodes
-	pebbleBootstrapWorkerCount = 10
-
 	// placeHolderHeight is an element of the height lookup keys of length HeightSuffixLen
 	// 10 bits per key yields a filter with <1% false positive rate.
 	placeHolderHeight = uint64(0)


### PR DESCRIPTION
EN and AN have different machine resource, EN could use higher worker counter than AN, so I'm making it configurable. 

It allows us to benchmark the checkpoint importing speed with different worker count.