### PR TITLE
Switch to always using the 0th partition for UUID generation

### DIFF
--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("33ff069b59f8eab1e58a15875bf859ebfc2068432c5cd7680ca084dbfc6c60ed")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("9a33f619b1a7bd84eabf19d7e7a2884ee9e62976b091efe21c1b92f8a7d7602d")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/environment/uuids.go
+++ b/fvm/environment/uuids.go
@@ -162,9 +162,12 @@ func (generator *uUIDGenerator) maybeInitializePartition() {
 	if generator.blockHeader == nil {
 		generator.partition = 0
 	} else {
-		generator.partition = uuidPartition(
-			generator.blockHeader.ID(),
-			generator.txnIndex)
+		// temporarily use the 0 partition so that uuid fits into 56 bits.
+		generator.partition = 0
+		// TODO: switch to code below once the community is ready
+		// generator.partition = uuidPartition(
+		//	 generator.blockHeader.ID(),
+		//	 generator.txnIndex)
 	}
 
 	generator.registerId = flow.UUIDRegisterID(generator.partition)

--- a/fvm/environment/uuids_test.go
+++ b/fvm/environment/uuids_test.go
@@ -66,6 +66,9 @@ func TestUUIDGeneratorInitializePartitionNoHeader(t *testing.T) {
 }
 
 func TestUUIDGeneratorInitializePartition(t *testing.T) {
+	t.Skip("Temporarily disabled because we want to always use the 0 partition" +
+		" for now")
+
 	blockHeader := &flow.Header{}
 
 	for numBlocks := 0; numBlocks < 10; numBlocks++ {

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -24,7 +24,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "8476e9a47da2f993fd0d04efc10238113f217b0c037ccf903613088d51027d6a"
+const GenesisStateCommitmentHex = "dbfa60082e7c8992a39cd4543f2c06c569a3c96e1378431b4796efc3c02c9bf5"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -88,10 +88,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "7df9e8ac804d283b27052abda8278866edcb6cae298862a21634ca62892049e7"
+		return "542d7b4c17f940bb97136be8b1544f2c85a9e2f79d88336148fb7a355edcef78"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "8476b2a11c9bf11e70b82adfa2daee598ba08e6e7d40e78958768b7aed4e6a4d"
+	return "f9f80b1ddadf0a7bc81fcd9c0706731d40fa39385c5cdde9f268266cab6aa26a"
 }


### PR DESCRIPTION
This is so that the uuid fits into a smaller type. 
This is a temporary fix intended to give the community more time to migrate.

more discussion here: https://discord.com/channels/613813861610684416/1162086721471647874/1166809690936709181

**do not merge to master** this is only a v0.32 change