### PR TITLE
[Access] Script execution coded errors

### DIFF
--- a/engine/execution/computation/query/executor.go
+++ b/engine/execution/computation/query/executor.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/onflow/flow-go/fvm/errors"
+
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/rs/zerolog"
 
@@ -175,10 +177,11 @@ func (e *QueryExecutor) ExecuteScript(
 	}
 
 	if output.Err != nil {
-		return nil, fmt.Errorf("failed to execute script at block (%s): %s",
-			blockHeader.ID(),
-			summarizeLog(output.Err.Error(),
-				e.config.MaxErrorMessageSize))
+		return nil, errors.NewCodedError(
+			output.Err.Code(),
+			"failed to execute script at block (%s): %s", blockHeader.ID(),
+			summarizeLog(output.Err.Error(), e.config.MaxErrorMessageSize),
+		)
 	}
 
 	encodedValue, err = jsoncdc.Encode(output.Value)

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -198,6 +198,7 @@ func (h *handler) ExecuteScriptAtBlockID(
 
 	value, err := h.engine.ExecuteScriptAtBlockID(ctx, req.GetScript(), req.GetArguments(), blockID)
 	if err != nil {
+		// todo check the error code instead
 		// return code 3 as this passes the litmus test in our context
 		return nil, status.Errorf(codes.InvalidArgument, "failed to execute script: %v", err)
 	}

--- a/module/execution/scripts.go
+++ b/module/execution/scripts.go
@@ -98,7 +98,7 @@ func NewScripts(
 // A result value is returned encoded as byte array. An error will be returned if script
 // doesn't successfully execute.
 // Expected errors:
-// - storage.ErrNotFound if block or register value at height was not found.
+// - Script execution related errors
 // - ErrDataNotAvailable if the data for the block height is not available
 func (s *Scripts) ExecuteAtBlockHeight(
 	ctx context.Context,
@@ -117,7 +117,7 @@ func (s *Scripts) ExecuteAtBlockHeight(
 
 // GetAccountAtBlockHeight returns a Flow account by the provided address and block height.
 // Expected errors:
-// - storage.ErrNotFound if block or register value at height was not found.
+// - Script execution related errors
 // - ErrDataNotAvailable if the data for the block height is not available
 func (s *Scripts) GetAccountAtBlockHeight(ctx context.Context, address flow.Address, height uint64) (*flow.Account, error) {
 	snap, header, err := s.snapshotWithBlock(height)

--- a/module/execution/scripts_test.go
+++ b/module/execution/scripts_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/onflow/flow-go/fvm/errors"
+
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/rs/zerolog"
@@ -70,6 +72,54 @@ func Test_ExecuteScript(t *testing.T) {
 		result, err := scripts.ExecuteAtBlockHeight(context.Background(), code, nil, first.Header.Height)
 		require.True(t, strings.Contains(err.Error(), "invalid number of returned values for a single register"))
 		require.Nil(t, result)
+	})
+
+	t.Run("Valid Argument", func(t *testing.T) {
+		blockchain := unittest.BlockchainFixture(10)
+		first := blockchain[0]
+		tree := bootstrapFVM()
+
+		scripts := newScripts(
+			t,
+			newBlockHeadersStorage(blockchain),
+			treeToRegisterAdapter(tree),
+		)
+
+		code := []byte("pub fun main(foo: Int): Int { return foo }")
+		arg := cadence.NewInt(2)
+		encoded, err := jsoncdc.Encode(arg)
+		require.NoError(t, err)
+
+		result, err := scripts.ExecuteAtBlockHeight(
+			context.Background(),
+			code,
+			[][]byte{encoded},
+			first.Header.Height,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, encoded, result)
+	})
+
+	t.Run("Invalid Argument", func(t *testing.T) {
+		blockchain := unittest.BlockchainFixture(10)
+		first := blockchain[0]
+		tree := bootstrapFVM()
+
+		scripts := newScripts(
+			t,
+			newBlockHeadersStorage(blockchain),
+			treeToRegisterAdapter(tree),
+		)
+
+		code := []byte("pub fun main(foo: Int): Int { return foo }")
+		invalid := [][]byte{[]byte("i")}
+
+		result, err := scripts.ExecuteAtBlockHeight(context.Background(), code, invalid, first.Header.Height)
+		assert.Nil(t, result)
+		var coded errors.CodedError
+		require.True(t, errors.As(err, &coded))
+		fmt.Println(coded.Code(), coded.Error())
+		assert.Equal(t, errors.ErrCodeInvalidArgumentError, coded.Code())
 	})
 }
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4881

Changing how errors are being handled to preserve the code that is needed.