### PR TITLE
[Util] make chunk-data-pack-dir optional for non-execution node

### DIFF
--- a/cmd/util/cmd/truncate-database/cmd.go
+++ b/cmd/util/cmd/truncate-database/cmd.go
@@ -27,7 +27,6 @@ func init() {
 
 	Cmd.Flags().StringVar(&flagChunkDataPackDir, "chunk-data-pack-dir", "",
 		"directory that stores the chunk data pack")
-	_ = Cmd.MarkFlagRequired("chunk-data-pack-dir")
 }
 
 func run(*cobra.Command, []string) {
@@ -39,8 +38,10 @@ func run(*cobra.Command, []string) {
 
 	log.Info().Msg("ProtocolDB Truncated")
 
-	chunkdb := common.InitStorageWithTruncate(flagChunkDataPackDir, true)
-	defer chunkdb.Close()
+	if flagChunkDataPackDir != "" {
+		chunkdb := common.InitStorageWithTruncate(flagChunkDataPackDir, true)
+		defer chunkdb.Close()
 
-	log.Info().Msg("Truncated")
+		log.Info().Msg("Chunk Data Pack database Truncated")
+	}
 }


### PR DESCRIPTION
## Problem: 
The chunk data pack was split into a separate badger DB, it's only needed for execution node, however, when the node operator for non-execution node was using the truncate-database cmd for truncating the protocol badger DB, it was asked for specifying the chunk-data-pack-dir. 

This PR changes so that the chunk data pack dir is optional, and it only truncates the chunk data pack directory if the flag is specified.