### PR TITLE
[Access] Add wait in integration tests for index to be synced

### DIFF
--- a/integration/tests/access/access_api_test.go
+++ b/integration/tests/access/access_api_test.go
@@ -243,20 +243,25 @@ func (s *AccessAPISuite) testExecuteScriptWithSimpleContract(client *client.Clie
 	script := lib.ReadCounterScript(serviceAccount.Address, serviceAccount.Address).ToCadence()
 
 	s.Run("execute at latest block", func() {
-		result, err := client.ExecuteScriptAtLatestBlock(s.ctx, []byte(script), nil)
+		result, err := s.waitScriptExecutionUntilIndexed(func() (cadence.Value, error) {
+			return client.ExecuteScriptAtLatestBlock(s.ctx, []byte(script), nil)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(lib.CounterInitializedValue, result.(cadence.Int).Int())
 	})
 
 	s.Run("execute at block height", func() {
-		result, err := client.ExecuteScriptAtBlockHeight(s.ctx, header.Height, []byte(script), nil)
+		result, err := s.waitScriptExecutionUntilIndexed(func() (cadence.Value, error) {
+			return client.ExecuteScriptAtBlockHeight(s.ctx, header.Height, []byte(script), nil)
+		})
 		s.Require().NoError(err)
-
 		s.Assert().Equal(lib.CounterInitializedValue, result.(cadence.Int).Int())
 	})
 
 	s.Run("execute at block ID", func() {
-		result, err := client.ExecuteScriptAtBlockID(s.ctx, header.ID, []byte(script), nil)
+		result, err := s.waitScriptExecutionUntilIndexed(func() (cadence.Value, error) {
+			return client.ExecuteScriptAtBlockID(s.ctx, header.ID, []byte(script), nil)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(lib.CounterInitializedValue, result.(cadence.Int).Int())
 	})

--- a/integration/tests/access/access_api_test.go
+++ b/integration/tests/access/access_api_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/codes"
+
+	"google.golang.org/grpc/status"
+
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
 
@@ -174,21 +178,27 @@ func (s *AccessAPISuite) testGetAccount(client *client.Client) {
 	serviceAddress := s.serviceClient.SDKServiceAddress()
 
 	s.Run("get account at latest block", func() {
-		account, err := client.GetAccount(s.ctx, serviceAddress)
+		account, err := s.waitAccountsUntilIndexed(func() (*sdk.Account, error) {
+			return client.GetAccount(s.ctx, serviceAddress)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(serviceAddress, account.Address)
 		s.Assert().NotZero(serviceAddress, account.Balance)
 	})
 
 	s.Run("get account block ID", func() {
-		account, err := client.GetAccountAtLatestBlock(s.ctx, serviceAddress)
+		account, err := s.waitAccountsUntilIndexed(func() (*sdk.Account, error) {
+			return client.GetAccountAtLatestBlock(s.ctx, serviceAddress)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(serviceAddress, account.Address)
 		s.Assert().NotZero(serviceAddress, account.Balance)
 	})
 
 	s.Run("get account block height", func() {
-		account, err := client.GetAccountAtBlockHeight(s.ctx, serviceAddress, header.Height)
+		account, err := s.waitAccountsUntilIndexed(func() (*sdk.Account, error) {
+			return client.GetAccountAtBlockHeight(s.ctx, serviceAddress, header.Height)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(serviceAddress, account.Address)
 		s.Assert().NotZero(serviceAddress, account.Balance)
@@ -200,19 +210,25 @@ func (s *AccessAPISuite) testExecuteScriptWithSimpleScript(client *client.Client
 	s.Require().NoError(err)
 
 	s.Run("execute at latest block", func() {
-		result, err := client.ExecuteScriptAtLatestBlock(s.ctx, []byte(simpleScript), nil)
+		result, err := s.waitScriptExecutionUntilIndexed(func() (cadence.Value, error) {
+			return client.ExecuteScriptAtLatestBlock(s.ctx, []byte(simpleScript), nil)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(simpleScriptResult, result)
 	})
 
 	s.Run("execute at block height", func() {
-		result, err := client.ExecuteScriptAtBlockHeight(s.ctx, header.Height, []byte(simpleScript), nil)
+		result, err := s.waitScriptExecutionUntilIndexed(func() (cadence.Value, error) {
+			return client.ExecuteScriptAtBlockHeight(s.ctx, header.Height, []byte(simpleScript), nil)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(simpleScriptResult, result)
 	})
 
 	s.Run("execute at block ID", func() {
-		result, err := client.ExecuteScriptAtBlockID(s.ctx, header.ID, []byte(simpleScript), nil)
+		result, err := s.waitScriptExecutionUntilIndexed(func() (cadence.Value, error) {
+			return client.ExecuteScriptAtBlockID(s.ctx, header.ID, []byte(simpleScript), nil)
+		})
 		s.Require().NoError(err)
 		s.Assert().Equal(simpleScriptResult, result)
 	})
@@ -286,6 +302,37 @@ func (s *AccessAPISuite) deployContract() *sdk.TransactionResult {
 	s.Require().Empty(result.Error, "create counter tx should be accepted but got: %s", result.Error)
 
 	return result
+}
+
+type getAccount func() (*sdk.Account, error)
+type executeScript func() (cadence.Value, error)
+
+var indexDelay = 10 * time.Second
+var indexRetry = 100 * time.Millisecond
+
+// wait for sealed block to get indexed, as there is a delay in syncing blocks between nodes
+func (s *AccessAPISuite) waitAccountsUntilIndexed(get getAccount) (*sdk.Account, error) {
+	var account *sdk.Account
+	var err error
+	s.Require().Eventually(func() bool {
+		account, err = get()
+		statusErr, ok := status.FromError(err)
+		return ok && statusErr.Code() != codes.OutOfRange
+	}, indexDelay, indexRetry)
+
+	return account, err
+}
+
+func (s *AccessAPISuite) waitScriptExecutionUntilIndexed(execute executeScript) (cadence.Value, error) {
+	var val cadence.Value
+	var err error
+	s.Require().Eventually(func() bool {
+		val, err = execute()
+		statusErr, ok := status.FromError(err)
+		return ok && statusErr.Code() != codes.OutOfRange
+	}, indexDelay, indexRetry)
+
+	return val, err
 }
 
 func (s *AccessAPISuite) waitUntilIndexed(height uint64) {

--- a/integration/tests/access/access_api_test.go
+++ b/integration/tests/access/access_api_test.go
@@ -317,7 +317,8 @@ func (s *AccessAPISuite) waitAccountsUntilIndexed(get getAccount) (*sdk.Account,
 	s.Require().Eventually(func() bool {
 		account, err = get()
 		statusErr, ok := status.FromError(err)
-		return ok && statusErr.Code() != codes.OutOfRange
+		// make sure we either don't have an error or the error is not out of range error, since in that case we have to wait a bit longer for index to get synced
+		return err == nil || ok && statusErr.Code() != codes.OutOfRange
 	}, indexDelay, indexRetry)
 
 	return account, err
@@ -329,7 +330,7 @@ func (s *AccessAPISuite) waitScriptExecutionUntilIndexed(execute executeScript) 
 	s.Require().Eventually(func() bool {
 		val, err = execute()
 		statusErr, ok := status.FromError(err)
-		return ok && statusErr.Code() != codes.OutOfRange
+		return err == nil || ok && statusErr.Code() != codes.OutOfRange
 	}, indexDelay, indexRetry)
 
 	return val, err


### PR DESCRIPTION
Add wait wrappers for integration tests so the index gets synced, this is because the index will fall behind a bit compared to latest sealed height found in protocol state storage.