### PR TITLE
[Access] Improve logging and validation in local script exec

### DIFF
--- a/access/handler.go
+++ b/access/handler.go
@@ -117,7 +117,7 @@ func (h *Handler) GetBlockHeaderByID(
 ) (*access.BlockHeaderResponse, error) {
 	id, err := convert.BlockID(req.GetId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid block id: %v", err)
 	}
 	header, status, err := h.api.GetBlockHeaderByID(ctx, id)
 	if err != nil {
@@ -157,7 +157,7 @@ func (h *Handler) GetBlockByID(
 ) (*access.BlockResponse, error) {
 	id, err := convert.BlockID(req.GetId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid block id: %v", err)
 	}
 	block, status, err := h.api.GetBlockByID(ctx, id)
 	if err != nil {
@@ -175,7 +175,7 @@ func (h *Handler) GetCollectionByID(
 
 	id, err := convert.CollectionID(req.GetId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid collection id: %v", err)
 	}
 
 	col, err := h.api.GetCollectionByID(ctx, id)
@@ -230,7 +230,7 @@ func (h *Handler) GetTransaction(
 
 	id, err := convert.TransactionID(req.GetId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid transaction id: %v", err)
 	}
 
 	tx, err := h.api.GetTransaction(ctx, id)
@@ -253,7 +253,7 @@ func (h *Handler) GetTransactionResult(
 
 	transactionID, err := convert.TransactionID(req.GetId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid transaction id: %v", err)
 	}
 
 	blockId := flow.ZeroID
@@ -261,7 +261,7 @@ func (h *Handler) GetTransactionResult(
 	if requestBlockId != nil {
 		blockId, err = convert.BlockID(requestBlockId)
 		if err != nil {
-			return nil, err
+			return nil, status.Errorf(codes.InvalidArgument, "invalid block id: %v", err)
 		}
 	}
 
@@ -270,7 +270,7 @@ func (h *Handler) GetTransactionResult(
 	if requestCollectionId != nil {
 		collectionId, err = convert.CollectionID(requestCollectionId)
 		if err != nil {
-			return nil, err
+			return nil, status.Errorf(codes.InvalidArgument, "invalid collection id: %v", err)
 		}
 	}
 
@@ -294,7 +294,7 @@ func (h *Handler) GetTransactionResultsByBlockID(
 
 	id, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid block id: %v", err)
 	}
 
 	eventEncodingVersion := req.GetEventEncodingVersion()
@@ -318,7 +318,7 @@ func (h *Handler) GetTransactionsByBlockID(
 
 	id, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid block id: %v", err)
 	}
 
 	transactions, err := h.api.GetTransactionsByBlockID(ctx, id)
@@ -342,7 +342,7 @@ func (h *Handler) GetTransactionResultByIndex(
 
 	blockID, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid block id: %v", err)
 	}
 
 	eventEncodingVersion := req.GetEventEncodingVersion()

--- a/access/handler.go
+++ b/access/handler.go
@@ -365,7 +365,10 @@ func (h *Handler) GetAccount(
 ) (*access.GetAccountResponse, error) {
 	metadata := h.buildMetadataResponse()
 
-	address := flow.BytesToAddress(req.GetAddress())
+	address, err := convert.Address(req.GetAddress(), h.chain)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid address: %v", err)
+	}
 
 	account, err := h.api.GetAccount(ctx, address)
 	if err != nil {
@@ -392,7 +395,7 @@ func (h *Handler) GetAccountAtLatestBlock(
 
 	address, err := convert.Address(req.GetAddress(), h.chain)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid address: %v", err)
 	}
 
 	account, err := h.api.GetAccountAtLatestBlock(ctx, address)
@@ -419,7 +422,7 @@ func (h *Handler) GetAccountAtBlockHeight(
 
 	address, err := convert.Address(req.GetAddress(), h.chain)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "invalid address: %v", err)
 	}
 
 	account, err := h.api.GetAccountAtBlockHeight(ctx, address, req.GetBlockHeight())

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/md5" //nolint:gosec
 	"errors"
+	"strings"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -302,6 +303,21 @@ func (b *backendScripts) compareScriptExecutionResults(
 		if execErr == localErr {
 			b.metrics.ScriptExecutionErrorMatch()
 			return
+		}
+
+		// error strings generally won't match since the code paths are slightly different
+		// check if the underlying error is the same
+		if status.Code(execErr) == status.Code(localErr) {
+			// both script execution implementations use the same engine, which adds
+			// "failed to execute script at block" to the message before returning. Any characters
+			// before this can be ignored. The string that comes after is the original error and
+			// should match.
+			execParts := strings.Split(execErr.Error(), "failed to execute script at block")
+			localParts := strings.Split(localErr.Error(), "failed to execute script at block")
+			if len(execParts) == 2 && len(localParts) == 2 && execParts[1] == localParts[1] {
+				b.metrics.ScriptExecutionErrorMatch()
+				return
+			}
 		}
 
 		b.metrics.ScriptExecutionErrorMismatch()


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4919
Closes: https://github.com/onflow/flow-go/issues/4918

This PR includes 3 fixes:
1. Add validation for address to `GetAccount`. This was missing from this endpoint, but existed for other `GetAccount*` endpoints.
2. Improve error comparison for semantically identical script execution errors
3. Return `InvalidArgument` errors from AccessAPI handler when request contained invalid `flow.Identifier`