### PR TITLE
[Networking, 0.32] Refactors inbound connection limit application

### DIFF
--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -54,10 +54,9 @@ network-config:
   # Maximum allowed fraction of memory to be allocated by the libp2p resources in (0,1]
   libp2p-file-descriptors-ratio: 0.2 # libp2p default
   # The default value for libp2p PeerBaseLimitConnsInbound. This limit
-  # restricts the amount of inbound connections from a peer to 1, forcing libp2p to reuse the connection.
-  #	Without this limit peers can end up in a state where there exists n number of connections per peer which
-  #	can lead to resource exhaustion of the libp2p node.
-  libp2p-peer-base-limits-conns-inbound: 1
+  # restricts the amount of inbound connections from each remote peer, forcing libp2p to reuse the connection.
+  # We set this limit to zero by default to allow libp2p resource manager default limit value to be used.
+  libp2p-peer-base-limits-conns-inbound: 0
   # maximum number of inbound system-wide streams, across all peers and protocols
   # Note that streams are ephemeral and are created and destroyed intermittently.
   libp2p-inbound-stream-limit-system: 15_000

--- a/network/p2p/p2pbuilder/libp2pscaler_test.go
+++ b/network/p2p/p2pbuilder/libp2pscaler_test.go
@@ -197,6 +197,8 @@ func TestApplyInboundConnectionLimits(t *testing.T) {
 	applied1 := ApplyInboundConnectionLimits(unittest.Logger(), scaled, cfg.NetworkConfig.ResourceManagerConfig.PeerBaseLimitConnsInbound)
 	// since the peer base limit connections is set to 0, the libp2p default should be used, hence applied1 should be equal to scaled (i.e., the libp2p default).
 	require.Equal(t, int(scaled.ToPartialLimitConfig().PeerDefault.ConnsInbound), int(applied1.ToPartialLimitConfig().PeerDefault.ConnsInbound))
+	// default libp2p peer base limit connections should be greater than 0.
+	require.Greater(t, int(applied1.ToPartialLimitConfig().PeerDefault.ConnsInbound), 0)
 
 	// now set the peer base limit connections to 100, and test that it is applied correctly.
 	applied2 := ApplyInboundConnectionLimits(unittest.Logger(), scaled, 100)

--- a/network/p2p/p2pbuilder/libp2pscaler_test.go
+++ b/network/p2p/p2pbuilder/libp2pscaler_test.go
@@ -110,7 +110,7 @@ func TestAllowedFileDescriptorsScale(t *testing.T) {
 
 // TestApplyInboundStreamLimits tests that the inbound stream limits are applied correctly, i.e., the limits from the config file
 // are applied to the concrete limit config when the concrete limit config is greater than the limits from the config file.
-func TestApplyInboundStreamAndConnectionLimits(t *testing.T) {
+func TestApplyInboundStreamLimits(t *testing.T) {
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
 
@@ -173,7 +173,32 @@ func TestApplyInboundStreamAndConnectionLimits(t *testing.T) {
 	require.Equal(t, int(1), int(applied.ToPartialLimitConfig().Stream.StreamsInbound))
 	// system limit should not be overridden.
 	require.Equal(t, int(1), int(applied.ToPartialLimitConfig().System.StreamsInbound))
+}
 
-	// check that the applied peer base limit connections are overridden.
-	require.Equal(t, int(cfg.NetworkConfig.ResourceManagerConfig.PeerBaseLimitConnsInbound), int(applied.ToPartialLimitConfig().PeerDefault.ConnsInbound))
+// TestApplyInboundConnectionLimits tests that the inbound connection limits are applied correctly, i.e., the limits from the config file
+// are applied to the concrete limit config when the concrete limit config is set.
+func TestApplyInboundConnectionLimits(t *testing.T) {
+	cfg, err := config.DefaultConfig()
+	require.NoError(t, err)
+
+	// by default the peer base limit connections is set to 0 meaning that the libp2p default is used.
+	require.Equal(t, 0, int(cfg.NetworkConfig.ResourceManagerConfig.PeerBaseLimitConnsInbound))
+
+	mem, err := allowedMemory(cfg.NetworkConfig.ResourceManagerConfig.MemoryLimitRatio)
+	require.NoError(t, err)
+
+	fd, err := allowedFileDescriptors(cfg.NetworkConfig.FileDescriptorsRatio)
+	require.NoError(t, err)
+	limits := rcmgr.DefaultLimits
+	libp2p.SetDefaultServiceLimits(&limits)
+	scaled := limits.Scale(mem, fd)
+
+	// then applies the peer base limit connections from the config file.
+	applied1 := ApplyInboundConnectionLimits(unittest.Logger(), scaled, cfg.NetworkConfig.ResourceManagerConfig.PeerBaseLimitConnsInbound)
+	// since the peer base limit connections is set to 0, the libp2p default should be used, hence applied1 should be equal to scaled (i.e., the libp2p default).
+	require.Equal(t, int(scaled.ToPartialLimitConfig().PeerDefault.ConnsInbound), int(applied1.ToPartialLimitConfig().PeerDefault.ConnsInbound))
+
+	// now set the peer base limit connections to 100, and test that it is applied correctly.
+	applied2 := ApplyInboundConnectionLimits(unittest.Logger(), scaled, 100)
+	require.Equal(t, int(100), int(applied2.ToPartialLimitConfig().PeerDefault.ConnsInbound))
 }

--- a/network/p2p/p2pbuilder/utils.go
+++ b/network/p2p/p2pbuilder/utils.go
@@ -186,8 +186,8 @@ func ApplyInboundStreamLimits(logger zerolog.Logger, concrete rcmgr.ConcreteLimi
 }
 
 // ApplyInboundConnectionLimits applies the inbound connection limits to the concrete limit config. The concrete limit config is assumed coming from scaling the
-// base limit config by the scaling factor. The inbound connection limits are applied to the concrete limit config if the concrete limit config is greater than
-// the inbound connection limits.
+// base limit config by the scaling factor. The inbound connection limit is applied if its value is greater than 0. Otherwise, the inbound connection limit is
+// set by the concrete limit config.
 // The inbound limits are assumed coming from the config file.
 // Args:
 //
@@ -204,7 +204,7 @@ func ApplyInboundConnectionLimits(logger zerolog.Logger, concrete rcmgr.Concrete
 	partial := rcmgr.PartialLimitConfig{}
 	lg := logger.With().Logger()
 
-	if int(c.PeerDefault.ConnsInbound) > peerLimit {
+	if peerLimit > 0 {
 		lg = lg.With().Int("concrete_peer_inbound_conns", int(c.PeerDefault.ConnsInbound)).Int("partial_peer_inbound_conns", peerLimit).Logger()
 		partial.PeerDefault.ConnsInbound = rcmgr.LimitVal(peerLimit)
 	}


### PR DESCRIPTION
This PR slightly refactors applying the limit on inbound connections. With changes in this PR, the limit is only applied when the corresponding flag is set. Otherwise, the libp2p default limit is applied.