### PR TITLE
[Ledger] Add special handling for global register keys

### DIFF
--- a/ledger/common/convert/convert_test.go
+++ b/ledger/common/convert/convert_test.go
@@ -30,6 +30,26 @@ func TestLedgerKeyToRegisterID(t *testing.T) {
 	require.Equal(t, expectedRegisterID, registerID)
 }
 
+func TestLedgerKeyToRegisterID_Global(t *testing.T) {
+	key := ledger.Key{
+		KeyParts: []ledger.KeyPart{
+			{
+				Type:  convert.KeyPartOwner,
+				Value: []byte(""),
+			},
+			{
+				Type:  convert.KeyPartKey,
+				Value: []byte("uuid"),
+			},
+		},
+	}
+
+	expectedRegisterID := flow.UUIDRegisterID(0)
+	registerID, err := convert.LedgerKeyToRegisterID(key)
+	require.NoError(t, err)
+	require.Equal(t, expectedRegisterID, registerID)
+}
+
 func TestLedgerKeyToRegisterID_Error(t *testing.T) {
 	key := ledger.Key{
 		KeyParts: []ledger.KeyPart{
@@ -62,6 +82,25 @@ func TestRegisterIDToLedgerKey(t *testing.T) {
 			{
 				Type:  convert.KeyPartKey,
 				Value: []byte("key"),
+			},
+		},
+	}
+
+	key := convert.RegisterIDToLedgerKey(registerID)
+	require.Equal(t, expectedKey, key)
+}
+
+func TestRegisterIDToLedgerKey_Global(t *testing.T) {
+	registerID := flow.UUIDRegisterID(0)
+	expectedKey := ledger.Key{
+		KeyParts: []ledger.KeyPart{
+			{
+				Type:  convert.KeyPartOwner,
+				Value: []byte(""),
+			},
+			{
+				Type:  convert.KeyPartKey,
+				Value: []byte("uuid"),
 			},
 		},
 	}

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -88,8 +88,8 @@ func CadenceRegisterID(owner []byte, key []byte) RegisterID {
 
 func NewRegisterID(owner, key string) RegisterID {
 	ownerString := ""
-	
-	if len(owner) >0 {
+
+	if len(owner) > 0 {
 		ownerString = addressToOwner(BytesToAddress([]byte(owner)))
 	}
 

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -87,8 +87,10 @@ func CadenceRegisterID(owner []byte, key []byte) RegisterID {
 }
 
 func NewRegisterID(owner, key string) RegisterID {
+	// global registers have an empty owner field
 	ownerString := ""
 
+	// all other registers have the account's address
 	if len(owner) > 0 {
 		ownerString = addressToOwner(BytesToAddress([]byte(owner)))
 	}

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -87,15 +87,14 @@ func CadenceRegisterID(owner []byte, key []byte) RegisterID {
 }
 
 func NewRegisterID(owner, key string) RegisterID {
-	if owner == "" {
-		return RegisterID{
-			Owner: "",
-			Key:   key,
-		}
+	ownerString := ""
+	
+	if len(owner) >0 {
+		ownerString = addressToOwner(BytesToAddress([]byte(owner)))
 	}
 
 	return RegisterID{
-		Owner: addressToOwner(BytesToAddress([]byte(owner))),
+		Owner: ownerString,
 		Key:   key,
 	}
 }

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -87,6 +87,13 @@ func CadenceRegisterID(owner []byte, key []byte) RegisterID {
 }
 
 func NewRegisterID(owner, key string) RegisterID {
+	if owner == "" {
+		return RegisterID{
+			Owner: "",
+			Key:   key,
+		}
+	}
+
 	return RegisterID{
 		Owner: addressToOwner(BytesToAddress([]byte(owner))),
 		Key:   key,

--- a/model/flow/ledger_test.go
+++ b/model/flow/ledger_test.go
@@ -62,17 +62,15 @@ func TestRegisterID_IsInternalState(t *testing.T) {
 		uuid := UUIDRegisterID(byte(i))
 		if i == 0 {
 			require.Equal(t, uuid.Key, UUIDKeyPrefix)
+			requireTrue("", UUIDKeyPrefix)
 		} else {
 			require.Equal(t, uuid.Key, fmt.Sprintf("%s_%d", UUIDKeyPrefix, i))
+			requireTrue("", fmt.Sprintf("%s_%d", UUIDKeyPrefix, i))
 		}
 		require.True(t, uuid.IsInternalState())
 	}
-	requireFalse("", UUIDKeyPrefix)
-	for i := 0; i < 256; i++ {
-		requireFalse("", fmt.Sprintf("%s_%d", UUIDKeyPrefix, i))
-	}
 	require.True(t, AddressStateRegisterID.IsInternalState())
-	requireFalse("", AddressStateKey)
+	requireTrue("", AddressStateKey)
 	requireFalse("", "other")
 	requireFalse("Address", UUIDKeyPrefix)
 	requireFalse("Address", AddressStateKey)

--- a/model/flow/ledger_test.go
+++ b/model/flow/ledger_test.go
@@ -82,7 +82,7 @@ func TestRegisterID_IsInternalState(t *testing.T) {
 }
 
 func TestRegisterID_String(t *testing.T) {
-	t.Run("atree slap", func(t *testing.T) {
+	t.Run("atree slab", func(t *testing.T) {
 		// slab with 189 should result in \\xbd
 		slabIndex := atree.StorageIndex([8]byte{0, 0, 0, 0, 0, 0, 0, 189})
 

--- a/model/flow/ledger_test.go
+++ b/model/flow/ledger_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/onflow/atree"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/atree"
 )
 
 // this benchmark can run with this command:
@@ -82,22 +84,35 @@ func TestRegisterID_IsInternalState(t *testing.T) {
 }
 
 func TestRegisterID_String(t *testing.T) {
-	// slab with 189 should result in \\xbd
-	slabIndex := atree.StorageIndex([8]byte{0, 0, 0, 0, 0, 0, 0, 189})
+	t.Run("atree slap", func(t *testing.T) {
+		// slab with 189 should result in \\xbd
+		slabIndex := atree.StorageIndex([8]byte{0, 0, 0, 0, 0, 0, 0, 189})
 
-	id := NewRegisterID(
-		string([]byte{1, 2, 3, 10}),
-		string(atree.SlabIndexToLedgerKey(slabIndex)))
-	require.False(t, utf8.ValidString(id.Key))
-	printable := id.String()
-	require.True(t, utf8.ValidString(printable))
-	require.Equal(t, "000000000102030a/$189", printable)
+		id := NewRegisterID(
+			string([]byte{1, 2, 3, 10}),
+			string(atree.SlabIndexToLedgerKey(slabIndex)))
+		require.False(t, utf8.ValidString(id.Key))
+		printable := id.String()
+		require.True(t, utf8.ValidString(printable))
+		require.Equal(t, "000000000102030a/$189", printable)
+	})
 
-	// non slab invalid utf-8
-	id = NewRegisterID("b\xc5y", "a\xc5z")
-	require.False(t, utf8.ValidString(id.Owner))
-	require.False(t, utf8.ValidString(id.Key))
-	printable = id.String()
-	require.True(t, utf8.ValidString(printable))
-	require.Equal(t, "000000000062c579/#61c57a", printable)
+	t.Run("non slab invalid utf-8", func(t *testing.T) {
+		id := NewRegisterID("b\xc5y", "a\xc5z")
+		require.False(t, utf8.ValidString(id.Owner))
+		require.False(t, utf8.ValidString(id.Key))
+		printable := id.String()
+		require.True(t, utf8.ValidString(printable))
+		require.Equal(t, "000000000062c579/#61c57a", printable)
+	})
+
+	t.Run("global register", func(t *testing.T) {
+		uuidRegisterID := UUIDRegisterID(0)
+		id := NewRegisterID(uuidRegisterID.Owner, uuidRegisterID.Key)
+		require.Equal(t, uuidRegisterID.Owner, id.Owner)
+		require.Equal(t, uuidRegisterID.Key, id.Key)
+		printable := id.String()
+		assert.True(t, utf8.ValidString(printable))
+		assert.Equal(t, "/#75756964", printable)
+	})
 }

--- a/storage/pebble/registers_test.go
+++ b/storage/pebble/registers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -206,6 +207,79 @@ func TestRegisters_Store_Versioning(t *testing.T) {
 		// make sure the key is unavailable at height 1
 		_, err = r.Get(key1, uint64(1))
 		require.ErrorIs(t, err, storage.ErrNotFound)
+	})
+}
+
+func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
+	t.Parallel()
+	height := uint64(2)
+	emptyOwnerKey := flow.RegisterID{Owner: "", Key: "uuid"}
+	zeroOwnerKey := flow.RegisterID{Owner: flow.EmptyAddress.Hex(), Key: "uuid"}
+	expectedValue := []byte("expectedValue")
+	unexpectedValue := []byte("unexpectedValue")
+
+	t.Run("empty owner", func(t *testing.T) {
+		RunWithRegistersStorageAtInitialHeights(t, 1, 1, func(r *Registers) {
+			// First, only set the empty Owner key, and make sure the empty value is available,
+			// and the zero value returns an errors
+			entries := flow.RegisterEntries{
+				{Key: emptyOwnerKey, Value: expectedValue},
+			}
+
+			err := r.Store(entries, height)
+			require.NoError(t, err)
+
+			actual, err := r.Get(emptyOwnerKey, height)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedValue, actual)
+
+			actual, err = r.Get(zeroOwnerKey, height)
+			assert.Error(t, err)
+
+			// Next, add the zero value, and make sure it is returned
+			entries = flow.RegisterEntries{
+				{Key: zeroOwnerKey, Value: unexpectedValue},
+			}
+
+			err = r.Store(entries, height+1)
+			require.NoError(t, err)
+
+			actual, err = r.Get(zeroOwnerKey, height+1)
+			assert.NoError(t, err)
+			assert.Equal(t, unexpectedValue, actual)
+		})
+	})
+
+	t.Run("zero owner", func(t *testing.T) {
+		RunWithRegistersStorageAtInitialHeights(t, 1, 1, func(r *Registers) {
+			// First, only set the zero Owner key, and make sure the zero value is available,
+			// and the empty value returns an errors
+			entries := flow.RegisterEntries{
+				{Key: zeroOwnerKey, Value: expectedValue},
+			}
+
+			err := r.Store(entries, height)
+			require.NoError(t, err)
+
+			actual, err := r.Get(zeroOwnerKey, height)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedValue, actual)
+
+			actual, err = r.Get(emptyOwnerKey, height)
+			assert.Error(t, err)
+
+			// Next, add the empty value, and make sure it is returned
+			entries = flow.RegisterEntries{
+				{Key: emptyOwnerKey, Value: unexpectedValue},
+			}
+
+			err = r.Store(entries, height+1)
+			require.NoError(t, err)
+
+			actual, err = r.Get(emptyOwnerKey, height+1)
+			assert.NoError(t, err)
+			assert.Equal(t, unexpectedValue, actual)
+		})
 	})
 }
 

--- a/storage/pebble/registers_test.go
+++ b/storage/pebble/registers_test.go
@@ -235,6 +235,7 @@ func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
 
 			actual, err = r.Get(zeroOwnerKey, height)
 			assert.Error(t, err)
+			assert.Nil(t, actual)
 
 			// Next, add the zero value, and make sure it is returned
 			entries = flow.RegisterEntries{
@@ -267,6 +268,7 @@ func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
 
 			actual, err = r.Get(emptyOwnerKey, height)
 			assert.Error(t, err)
+			assert.Nil(t, actual)
 
 			// Next, add the empty value, and make sure it is returned
 			entries = flow.RegisterEntries{

--- a/storage/pebble/registers_test.go
+++ b/storage/pebble/registers_test.go
@@ -210,13 +210,15 @@ func TestRegisters_Store_Versioning(t *testing.T) {
 	})
 }
 
+// TestRegisters_GetAndStoreEmptyOwner tests behavior of storing and retrieving registers with
+// an empty owner value, which is used for global state variables.
 func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
 	t.Parallel()
 	height := uint64(2)
 	emptyOwnerKey := flow.RegisterID{Owner: "", Key: "uuid"}
 	zeroOwnerKey := flow.RegisterID{Owner: flow.EmptyAddress.Hex(), Key: "uuid"}
-	expectedValue := []byte("expectedValue")
-	unexpectedValue := []byte("unexpectedValue")
+	expectedValue := []byte("first value")
+	otherValue := []byte("other value")
 
 	t.Run("empty owner", func(t *testing.T) {
 		RunWithRegistersStorageAtInitialHeights(t, 1, 1, func(r *Registers) {
@@ -239,7 +241,7 @@ func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
 
 			// Next, add the zero value, and make sure it is returned
 			entries = flow.RegisterEntries{
-				{Key: zeroOwnerKey, Value: unexpectedValue},
+				{Key: zeroOwnerKey, Value: otherValue},
 			}
 
 			err = r.Store(entries, height+1)
@@ -247,7 +249,7 @@ func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
 
 			actual, err = r.Get(zeroOwnerKey, height+1)
 			assert.NoError(t, err)
-			assert.Equal(t, unexpectedValue, actual)
+			assert.Equal(t, otherValue, actual)
 		})
 	})
 
@@ -272,7 +274,7 @@ func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
 
 			// Next, add the empty value, and make sure it is returned
 			entries = flow.RegisterEntries{
-				{Key: emptyOwnerKey, Value: unexpectedValue},
+				{Key: emptyOwnerKey, Value: otherValue},
 			}
 
 			err = r.Store(entries, height+1)
@@ -280,7 +282,7 @@ func TestRegisters_GetAndStoreEmptyOwner(t *testing.T) {
 
 			actual, err = r.Get(emptyOwnerKey, height+1)
 			assert.NoError(t, err)
-			assert.Equal(t, unexpectedValue, actual)
+			assert.Equal(t, otherValue, actual)
 		})
 	})
 }


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4938

This PR adds special handling for global register keys, which have empty owner strings. Previously, the empty string was converted to an address, resulting in `NewRegisterID` converting it to `0000000000000000`. With this change, these global registerIDs remain an empty string.

This caused problems on Access nodes when indexing `TrieUpdates` data from checkpoints or execution data. Instead of preserving the empty string, registers were written to the db using an empty address. This caused `uuid` lookups to fail.