### PR TITLE
[Collection] Make QC Voter more resiliant to access node instability - v0.32 backport

### DIFF
--- a/module/epochs/qc_voter.go
+++ b/module/epochs/qc_voter.go
@@ -118,7 +118,7 @@ func (voter *RootQCVoter) Vote(ctx context.Context, epoch protocol.Epoch) error 
 
 	clientIndex, qcContractClient := voter.getInitialContractClient()
 	onMaxConsecutiveRetries := func(totalAttempts int) {
-		voter.updateContractClient(clientIndex)
+		clientIndex, qcContractClient = voter.updateContractClient(clientIndex)
 		log.Warn().Msgf("retrying on attempt (%d) with fallback access node at index (%d)", totalAttempts, clientIndex)
 	}
 	backoff = retrymiddleware.AfterConsecutiveFailures(retryMaxConsecutiveFailures, backoff, onMaxConsecutiveRetries)


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/4924