### PR TITLE
[Flaky Test] Modifies block rate in VN test to address sealing lagging finalization

### DIFF
--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -34,7 +34,7 @@ const DefaultMaxHeightRange = 250
 
 // DefaultSnapshotHistoryLimit the amount of blocks to look back in state
 // when recursively searching for a valid snapshot
-const DefaultSnapshotHistoryLimit = 50
+const DefaultSnapshotHistoryLimit = 500
 
 // DefaultLoggedScriptsCacheSize is the default size of the lookup cache used to dedupe logs of scripts sent to ENs
 // limiting cache size to 16MB and does not affect script execution, only for keeping logs tidy

--- a/integration/tests/epochs/cohort2/epoch_join_and_leave_vn_test.go
+++ b/integration/tests/epochs/cohort2/epoch_join_and_leave_vn_test.go
@@ -2,6 +2,7 @@ package cohort2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -20,6 +21,8 @@ type EpochJoinAndLeaveVNSuite struct {
 func (s *EpochJoinAndLeaveVNSuite) SetupTest() {
 	// require approvals for seals to verify that the joining VN is producing valid seals in the second epoch
 	s.RequiredSealApprovals = 1
+	// slow down consensus, as sealing tends to lag behind
+	s.ConsensusProposalDuration = time.Millisecond * 250
 	// increase epoch length to account for greater sealing lag due to above
 	// NOTE: this value is set fairly aggressively to ensure shorter test times.
 	// If flakiness due to failure to complete staking operations in time is observed,

--- a/integration/tests/epochs/cohort2/epoch_join_and_leave_vn_test.go
+++ b/integration/tests/epochs/cohort2/epoch_join_and_leave_vn_test.go
@@ -28,7 +28,7 @@ func (s *EpochJoinAndLeaveVNSuite) SetupTest() {
 	s.DKGPhaseLen = 100
 	s.EpochLen = 450
 	s.EpochCommitSafetyThreshold = 20
-	s.DynamicEpochTransitionSuite.SetupTest()
+	s.DynamicEpochTransitionSuite.Suite.SetupTest()
 }
 
 // TestEpochJoinAndLeaveVN should update verification nodes and assert healthy network conditions

--- a/integration/tests/epochs/suite.go
+++ b/integration/tests/epochs/suite.go
@@ -64,10 +64,16 @@ type Suite struct {
 	// Whether approvals are required for sealing (we only enable for VN tests because
 	// requiring approvals requires a longer DKG period to avoid flakiness)
 	RequiredSealApprovals uint // defaults to 0 (no approvals required)
+	// Consensus Node proposal duration
+	ConsensusProposalDuration time.Duration
 }
 
 // SetupTest is run automatically by the testing framework before each test case.
 func (s *Suite) SetupTest() {
+	// If unset, use default value 100ms
+	if s.ConsensusProposalDuration == 0 {
+		s.ConsensusProposalDuration = time.Millisecond * 100
+	}
 
 	minEpochLength := s.StakingAuctionLen + s.DKGPhaseLen*3 + 20
 	// ensure epoch lengths are set correctly
@@ -85,7 +91,7 @@ func (s *Suite) SetupTest() {
 		testnet.WithLogLevel(zerolog.WarnLevel)}
 
 	consensusConfigs := []func(config *testnet.NodeConfig){
-		testnet.WithAdditionalFlag("--cruise-ctl-fallback-proposal-duration=100ms"),
+		testnet.WithAdditionalFlag(fmt.Sprintf("--cruise-ctl-fallback-proposal-duration=%s", s.ConsensusProposalDuration)),
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", s.RequiredSealApprovals)),
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", s.RequiredSealApprovals)),
 		testnet.WithLogLevel(zerolog.WarnLevel)}

--- a/integration/tests/lib/util.go
+++ b/integration/tests/lib/util.go
@@ -220,28 +220,28 @@ func WithChainID(chainID flow.ChainID) func(tx *sdk.Transaction) {
 
 // LogStatus logs current information about the test network state.
 func LogStatus(t *testing.T, ctx context.Context, log zerolog.Logger, client *testnet.Client) {
+	// retrieves latest FINALIZED snapshot
 	snapshot, err := client.GetLatestProtocolSnapshot(ctx)
 	if err != nil {
-		log.Err(err).Msg("failed to get sealed snapshot")
-		return
-	}
-	finalized, err := client.GetLatestFinalizedBlockHeader(ctx)
-	if err != nil {
-		log.Err(err).Msg("failed to get finalized header")
+		log.Err(err).Msg("failed to get finalized snapshot")
 		return
 	}
 
-	sealed, err := snapshot.Head()
+	sealingSegment, err := snapshot.SealingSegment()
 	require.NoError(t, err)
+	sealed := sealingSegment.Sealed()
+	finalized := sealingSegment.Finalized()
+
 	phase, err := snapshot.Phase()
 	require.NoError(t, err)
 	epoch := snapshot.Epochs().Current()
 	counter, err := epoch.Counter()
 	require.NoError(t, err)
 
-	log.Info().Uint64("final_height", finalized.Height).
-		Uint64("sealed_height", sealed.Height).
-		Uint64("sealed_view", sealed.View).
+	log.Info().Uint64("final_height", finalized.Header.Height).
+		Uint64("final_view", finalized.Header.View).
+		Uint64("sealed_height", sealed.Header.Height).
+		Uint64("sealed_view", sealed.Header.View).
 		Str("cur_epoch_phase", phase.String()).
 		Uint64("cur_epoch_counter", counter).
 		Msg("test run status")


### PR DESCRIPTION
This PR modifies the block rate in the Verification Node test to address sealing lagging finalization. In the VN epoch integration test only, we enable `require-seals-for-approvals`, which requires VN participation in sealing. In practice, this results in sealing lagging finalization (see [here](https://www.notion.so/dapperlabs/VN-Epoch-Test-Flakey-Nov-8-2023-175c8ed3d2dd421b9d03ef49c8be9902?pvs=4) for some tests) by up to 100 blocks.
- This over-ran the default snapshot history limit, preventing the test from validating state
- This also causes epoch transition failures, because DKG requires somewhat up-to-date sealing w.r.t. the DKG phase length, which is small in these tests.

To fix the problem, I increased the block rate delay for consensus nodes, from 100ms to 250 ms. This PR also updates several test utilities for observing what is going on while the test runs.