### PR TITLE
[Storehouse] Add Finalized Reader

### DIFF
--- a/engine/execution/storehouse.go
+++ b/engine/execution/storehouse.go
@@ -30,7 +30,7 @@ type RegisterStore interface {
 	// - exception for any other exception
 	SaveRegisters(header *flow.Header, registers []flow.RegisterEntry) error
 
-	// Depend on FinalizedReader's GetFinalizedBlockIDAtHeight
+	// Depend on FinalizedReader's FinalizedBlockIDAtHeight
 	// Depend on ExecutedFinalizedWAL.Append
 	// Depend on OnDiskRegisterStore.SaveRegisters
 	// OnBlockFinalized trigger the check of whether a block at the next height becomes finalized and executed.
@@ -57,6 +57,9 @@ type RegisterStore interface {
 }
 
 type FinalizedReader interface {
+	// FinalizedBlockIDAtHeight returns the block ID of the finalized block at the given height.
+	// It return storage.NotFound if the given height has not been finalized yet
+	// any other error returned are exceptions
 	FinalizedBlockIDAtHeight(height uint64) (flow.Identifier, error)
 }
 

--- a/engine/execution/storehouse.go
+++ b/engine/execution/storehouse.go
@@ -2,7 +2,9 @@ package execution
 
 import (
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/finalizedreader"
 	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/pebble"
 )
 
 // RegisterStore is the interface for register store
@@ -58,6 +60,9 @@ type FinalizedReader interface {
 	FinalizedBlockIDAtHeight(height uint64) (flow.Identifier, error)
 }
 
+// finalizedreader.FinalizedReader is an implementation of FinalizedReader interface
+var _ FinalizedReader = (*finalizedreader.FinalizedReader)(nil)
+
 // see implementation in engine/execution/storehouse/in_memory_register_store.go
 type InMemoryRegisterStore interface {
 	Prune(finalizedHeight uint64, finalizedBlockID flow.Identifier) error
@@ -79,6 +84,9 @@ type InMemoryRegisterStore interface {
 }
 
 type OnDiskRegisterStore = storage.RegisterIndex
+
+// pebble.Registers is an implementation of OnDiskRegisterStore interface
+var _ OnDiskRegisterStore = (*pebble.Registers)(nil)
 
 type ExecutedFinalizedWAL interface {
 	Append(height uint64, registers []flow.RegisterEntry) error

--- a/module/finalizedreader/finalizedreader.go
+++ b/module/finalizedreader/finalizedreader.go
@@ -1,0 +1,25 @@
+package finalizedreader
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+)
+
+type FinalizedReader struct {
+	headers storage.Headers
+}
+
+func NewFinalizedReader(headers storage.Headers) *FinalizedReader {
+	return &FinalizedReader{
+		headers: headers,
+	}
+}
+
+func (r *FinalizedReader) FinalizedBlockIDAtHeight(height uint64) (flow.Identifier, error) {
+	header, err := r.headers.ByHeight(height)
+	if err != nil {
+		return flow.ZeroID, err
+	}
+
+	return header.ID(), nil
+}

--- a/module/finalizedreader/finalizedreader_test.go
+++ b/module/finalizedreader/finalizedreader_test.go
@@ -1,0 +1,44 @@
+package finalizedreader
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+
+	"github.com/onflow/flow-go/module/metrics"
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/badger/operation"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/stretchr/testify/require"
+
+	badgerstorage "github.com/onflow/flow-go/storage/badger"
+)
+
+func TestFinalizedReader(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		// prepare the storage.Headers instance
+		metrics := metrics.NewNoopCollector()
+		headers := badgerstorage.NewHeaders(metrics, db)
+		block := unittest.BlockFixture()
+
+		// store header
+		err := headers.Store(block.Header)
+		require.NoError(t, err)
+
+		// index the header
+		err = operation.RetryOnConflict(db.Update, operation.IndexBlockHeight(block.Header.Height, block.ID()))
+		require.NoError(t, err)
+
+		// verify is able to reader the finalized block ID
+		reader := NewFinalizedReader(headers)
+		finalized, err := reader.FinalizedBlockIDAtHeight(block.Header.Height)
+		require.NoError(t, err)
+		require.Equal(t, block.ID(), finalized)
+
+		// verify is able to return storage.NotFound when the height is not finalized
+		_, err = reader.FinalizedBlockIDAtHeight(block.Header.Height + 1)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, storage.ErrNotFound), err)
+	})
+}

--- a/module/finalizedreader/finalizedreader_test.go
+++ b/module/finalizedreader/finalizedreader_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/storage/badger/operation"
 	"github.com/onflow/flow-go/utils/unittest"
-	"github.com/stretchr/testify/require"
 
 	badgerstorage "github.com/onflow/flow-go/storage/badger"
 )


### PR DESCRIPTION
Working towards https://github.com/onflow/flow-go/issues/4682

Finalized Reader is needed by storehouse to check whether an executed block is finalized in which case it will index the register updates in storehouse.