### PR TITLE
Add `EVM` methods for `encodeABI` & `decodeABI`

### DIFF
--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -106,12 +106,12 @@ contract EVM {
     }
 
     access(all)
-    fun encodeABI(arguments: [AnyStruct]): [UInt8] {
-        return InternalEVM.encodeABI(arguments: arguments)
+    fun encodeABI(_ abiSpec: String, arguments: [AnyStruct]): [UInt8] {
+        return InternalEVM.encodeABI(abiSpec, arguments: arguments)
     }
 
     access(all)
-    fun decodeABI(data: [UInt8]): [AnyStruct] {
-        return InternalEVM.decodeABI(data: data)
+    fun decodeABI(_ abiSpec: String, data: [UInt8]): [AnyStruct] {
+        return InternalEVM.decodeABI(abiSpec, data: data)
     }
 }

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -104,4 +104,14 @@ contract EVM {
     fun run(tx: [UInt8], coinbase: EVMAddress) {
         InternalEVM.run(tx: tx, coinbase: coinbase.bytes)
     }
+
+    access(all)
+    fun encodeABI(arguments: [AnyStruct]): [UInt8] {
+        return InternalEVM.encodeABI(arguments: arguments)
+    }
+
+    access(all)
+    fun decodeABI(data: [UInt8]): [AnyStruct] {
+        return InternalEVM.decodeABI(data: data)
+    }
 }

--- a/fvm/evm/stdlib/contract_test.go
+++ b/fvm/evm/stdlib/contract_test.go
@@ -134,7 +134,8 @@ func TestEVMEncodeABI(t *testing.T) {
 
       access(all)
       fun main(): [UInt8] {
-        return EVM.encodeABI(arguments: ["John", "Doe", UInt64(33)])
+        let abiSpec = "[{\"type\": \"function\", \"name\": \"details\", \"inputs\": [{ \"name\": \"name\", \"type\": \"string\" }, { \"name\": \"surname\", \"type\": \"string\" }, { \"name\": \"age\", \"type\": \"uint64\" }], \"outputs\": []}]"
+        return EVM.encodeABI(abiSpec, arguments: ["John", "Doe", UInt64(33)])
       }
 	`)
 
@@ -285,7 +286,8 @@ func TestEVMDecodeABI(t *testing.T) {
 
       access(all)
       fun main(data: [UInt8]): Bool {
-        let unpacked = EVM.decodeABI(data: data)
+        let abiSpec = "[{\"type\": \"function\", \"name\": \"details\", \"inputs\": [{ \"name\": \"name\", \"type\": \"string\" }, { \"name\": \"surname\", \"type\": \"string\" }, { \"name\": \"age\", \"type\": \"uint64\" }], \"outputs\": []}]"
+        let unpacked = EVM.decodeABI(abiSpec, data: data)
         assert(unpacked.length == 3)
         assert((unpacked[0] as! String) == "John")
         assert((unpacked[1] as! String) == "Doe")

--- a/fvm/evm/stdlib/contract_test.go
+++ b/fvm/evm/stdlib/contract_test.go
@@ -136,7 +136,7 @@ func TestEVMEncodeABI(t *testing.T) {
       fun main(): [UInt8] {
         return EVM.encodeABI(arguments: ["John", "Doe", UInt64(33)])
       }
-    `)
+	`)
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -285,11 +285,14 @@ func TestEVMDecodeABI(t *testing.T) {
 
       access(all)
       fun main(data: [UInt8]): Bool {
-		let unpacked = EVM.decodeABI(data: data)
-		assert(unpacked.length == 3, message: "".concat(unpacked.length.toString()))
+        let unpacked = EVM.decodeABI(data: data)
+        assert(unpacked.length == 3)
+        assert((unpacked[0] as! String) == "John")
+        assert((unpacked[1] as! String) == "Doe")
+        assert((unpacked[2] as! UInt64) == UInt64(33))
         return true
       }
-    `)
+	`)
 
 	accountCodes := map[common.Location][]byte{}
 	var events []cadence.Event
@@ -400,7 +403,7 @@ func TestEVMDecodeABI(t *testing.T) {
 			cadence.UInt8(0x0), cadence.UInt8(0x0), cadence.UInt8(0x0), cadence.UInt8(0x0)},
 	).WithType(cadence.NewVariableSizedArrayType(cadence.TheUInt8Type))
 
-	_, err = rt.ExecuteScript(
+	result, err := rt.ExecuteScript(
 		runtime.Script{
 			Source: script,
 			Arguments: EncodeArgs([]cadence.Value{
@@ -414,6 +417,8 @@ func TestEVMDecodeABI(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+
+	assert.Equal(t, cadence.NewBool(true), result)
 }
 
 func TestEVMAddressConstructionAndReturn(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/onflow/flow-go/issues/4937

Introduces two natively-implemented methods on the `EVM` contract, for encoding/decoding ABI:
- `EVM.encodeABI`
- `EVM.decodeABI`

**Note:** Some stuff are still to be decided.