### PR TITLE
Missing consensus telemetry events from `FinalizationConsumer` and `CommunicatorConsumer`

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -604,6 +604,8 @@ func main() {
 			)
 
 			notifier.AddParticipantConsumer(telemetryConsumer)
+			notifier.AddCommunicatorConsumer(telemetryConsumer)
+			notifier.AddFinalizationConsumer(telemetryConsumer)
 			notifier.AddFollowerConsumer(followerDistributor)
 
 			// initialize the persister

--- a/consensus/hotstuff/notifications/telemetry.go
+++ b/consensus/hotstuff/notifications/telemetry.go
@@ -38,7 +38,10 @@ type TelemetryConsumer struct {
 	noPathLogger zerolog.Logger
 }
 
+// Telemetry implements consumers for _all happy-path_ interfaces in consensus/hotstuff/notifications/telemetry.go:
 var _ hotstuff.ParticipantConsumer = (*TelemetryConsumer)(nil)
+var _ hotstuff.CommunicatorConsumer = (*TelemetryConsumer)(nil)
+var _ hotstuff.FinalizationConsumer = (*TelemetryConsumer)(nil)
 var _ hotstuff.VoteCollectorConsumer = (*TelemetryConsumer)(nil)
 var _ hotstuff.TimeoutCollectorConsumer = (*TelemetryConsumer)(nil)
 


### PR DESCRIPTION
### Backport of PR https://github.com/onflow/flow-go/pull/5020

Metrika [messaged us via slack](https://dapperlabs.slack.com/archives/C01FNL8769W/p1700002569454369?thread_ts=1699972061.491989&cid=C01FNL8769W
) saying that there is some lack of data in Mainnet 24: 
> none of the consensus nodes have the “proposer” label anymore?

Digging into the current telemetry events, I found that starting in Mainnet 24, the [`TelemetryConsumer`](https://github.com/onflow/flow-go/blob/master/consensus/hotstuff/notifications/telemetry.go) captures
* none of the events emitted via the [`FinalizationConsumer`](https://github.com/onflow/flow-go/blob/ccb723f7cbb3658f0b705cacddfeae28bfb1f9e2/consensus/hotstuff/consumer.go#L99-L113)
* none of the events emitted via the  [`CommunicatorConsumer`](https://github.com/onflow/flow-go/blob/ccb723f7cbb3658f0b705cacddfeae28bfb1f9e2/consensus/hotstuff/consumer.go#L305-L325)

Digging into the code, I found that we are not subscribing the  [`TelemetryConsumer`](https://github.com/onflow/flow-go/blob/master/consensus/hotstuff/notifications/telemetry.go) to the respective events (neither does the `TelemetryConsumer` state that it implements the consumer interface for the respective events).

This PR fixes the missing subscription problem.