### PR TITLE
[EVM] Benchmark state transitions

### DIFF
--- a/fvm/evm/emulator/database/database.go
+++ b/fvm/evm/emulator/database/database.go
@@ -34,6 +34,7 @@ type Database struct {
 	flowEVMRootAddress    flow.Address
 	led                   atree.Ledger
 	storage               *atree.PersistentSlabStorage
+	baseStorage           *atree.LedgerBaseStorage
 	atreemap              *atree.OrderedMap
 	rootIDBytesToBeStored []byte // if is empty means we don't need to store anything
 	// Ramtin: other database implementations for EVM uses a lock
@@ -59,6 +60,7 @@ func NewDatabase(led atree.Ledger, flowEVMRootAddress flow.Address) (*Database, 
 		led:                led,
 		flowEVMRootAddress: flowEVMRootAddress,
 		storage:            storage,
+		baseStorage:        baseStorage,
 	}
 
 	err = db.retrieveOrCreateMapRoot()
@@ -323,6 +325,10 @@ func (db *Database) Len() int {
 	defer db.lock.RUnlock()
 
 	return int(db.atreemap.Count())
+}
+
+func (db *Database) BytesStored() int {
+	return db.baseStorage.BytesStored()
 }
 
 // keyvalue is a key-value tuple tagged with a deletion field to allow creating

--- a/fvm/evm/emulator/database/metered_database.go
+++ b/fvm/evm/emulator/database/metered_database.go
@@ -1,0 +1,40 @@
+package database
+
+import (
+	"github.com/onflow/atree"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// MeteredDatabase wrapper around the database purposely built for testing and benchmarking.
+type MeteredDatabase struct {
+	*Database
+}
+
+// NewMeteredDatabase create a database wrapper purposely built for testing and benchmarking.
+func NewMeteredDatabase(led atree.Ledger, flowEVMRootAddress flow.Address) (*MeteredDatabase, error) {
+	database, err := NewDatabase(led, flowEVMRootAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MeteredDatabase{
+		Database: database,
+	}, nil
+}
+
+func (m *MeteredDatabase) DropCache() {
+	m.storage.DropCache()
+}
+
+func (m *MeteredDatabase) BytesRetrieved() int {
+	return m.baseStorage.BytesRetrieved()
+}
+
+func (m *MeteredDatabase) BytesStored() int {
+	return m.baseStorage.BytesStored()
+}
+func (m *MeteredDatabase) ResetReporter() {
+	m.baseStorage.ResetReporter()
+	m.baseStorage.Size()
+	m.storage.Count()
+}

--- a/fvm/evm/emulator/state_test.go
+++ b/fvm/evm/emulator/state_test.go
@@ -1,0 +1,46 @@
+package emulator_test
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/fvm/evm/testutils"
+	"github.com/onflow/flow-go/fvm/evm/types"
+
+	"github.com/onflow/flow-go/model/flow"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethRawDB "github.com/ethereum/go-ethereum/core/rawdb"
+	gethState "github.com/ethereum/go-ethereum/core/state"
+	"github.com/onflow/flow-go/fvm/evm/emulator/database"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateWrites(t *testing.T) {
+
+	testutils.RunWithTestBackend(t, func(backend types.Backend) {
+		rootAddr := types.Address{0x01}
+		testAddr := types.Address{0x02}
+
+		db, err := database.NewDatabase(backend, (flow.Address)(rootAddr.Bytes()))
+		require.NoError(t, err)
+
+		root, err := db.GetRootHash()
+		require.NoError(t, err)
+
+		stateDB := gethState.NewDatabase(gethRawDB.NewDatabase(db))
+
+		state, err := gethState.New(root, stateDB, nil)
+		require.NoError(t, err)
+
+		stateObj := state.GetOrNewStateObject(testAddr.ToCommon())
+		stateObj.SetState(stateDB, common.Hash{0x01}, common.Hash{0x02})
+
+		hash, err := state.Commit(true)
+		require.NoError(t, err)
+
+		err = state.Database().TrieDB().Commit(hash, false)
+		require.NoError(t, err)
+
+	})
+
+}

--- a/fvm/evm/emulator/state_test.go
+++ b/fvm/evm/emulator/state_test.go
@@ -1,45 +1,65 @@
 package emulator_test
 
 import (
+	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/onflow/flow-go/fvm/evm/testutils"
 	"github.com/onflow/flow-go/fvm/evm/types"
 
 	"github.com/onflow/flow-go/model/flow"
 
-	"github.com/ethereum/go-ethereum/common"
 	gethRawDB "github.com/ethereum/go-ethereum/core/rawdb"
 	gethState "github.com/ethereum/go-ethereum/core/state"
 	"github.com/onflow/flow-go/fvm/evm/emulator/database"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStateWrites(t *testing.T) {
+func fullKey(owner, key []byte) string {
+	return string(owner) + "~" + string(key)
+}
 
-	testutils.RunWithTestBackend(t, func(backend types.Backend) {
+func BenchmarkStateBalance(b *testing.B) {
+
+	testutils.RunWithTestBackend(b, func(backend types.Backend) {
+
 		rootAddr := types.Address{0x01}
-		testAddr := types.Address{0x02}
+		testAddr := types.Address{0x02}.ToCommon()
 
-		db, err := database.NewDatabase(backend, (flow.Address)(rootAddr.Bytes()))
-		require.NoError(t, err)
+		//log.Root().SetHandler(log.StreamHandler(os.Stdout, log.LogfmtFormat()))
+
+		db, err := database.NewMeteredDatabase(backend, (flow.Address)(rootAddr.Bytes()))
+		require.NoError(b, err)
 
 		root, err := db.GetRootHash()
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		stateDB := gethState.NewDatabase(gethRawDB.NewDatabase(db))
 
-		state, err := gethState.New(root, stateDB, nil)
-		require.NoError(t, err)
+		updateAccount := func(root common.Hash, balance *big.Int) common.Hash {
+			state, err := gethState.New(root, stateDB, nil)
+			require.NoError(b, err)
 
-		stateObj := state.GetOrNewStateObject(testAddr.ToCommon())
-		stateObj.SetState(stateDB, common.Hash{0x01}, common.Hash{0x02})
+			state.SetBalance(testAddr, balance)
+			hash, err := state.Commit(true)
+			require.NoError(b, err)
 
-		hash, err := state.Commit(true)
-		require.NoError(t, err)
+			err = state.Database().TrieDB().Commit(hash, true)
+			require.NoError(b, err)
 
-		err = state.Database().TrieDB().Commit(hash, false)
-		require.NoError(t, err)
+			err = db.Commit(hash)
+			require.NoError(b, err)
+
+			return hash
+		}
+
+		hash := root
+		for i := 0; i < 1000; i++ {
+			hash = updateAccount(hash, big.NewInt(int64(i)))
+			b.ReportMetric((float64)(db.BytesStored()), "bytes_used")
+		}
 
 	})
 


### PR DESCRIPTION
Implementation of benchmarking state transition for a single account. The test measures the impact on the underlying storage from the changes done on the state object.

As currently visible from the tests the storage grows too rapidly, likely due to lack of pruning mechanism. This will be a base for work towards solving the issue: #4963  
