### PR TITLE
Add transaction ms per computation metrics - port

### DIFF
--- a/model/flow/constants.go
+++ b/model/flow/constants.go
@@ -28,6 +28,10 @@ const DefaultTransactionExpiryBuffer = 30
 // DefaultMaxTransactionGasLimit is the default maximum value for the transaction gas limit.
 const DefaultMaxTransactionGasLimit = 9999
 
+// EstimatedComputationPerMillisecond is the approximate number of computation units that can be performed in a millisecond.
+// this was calibrated during the Variable Transaction Fees: Execution Effort FLIP https://github.com/onflow/flow/pull/753
+const EstimatedComputationPerMillisecond = 9999.0 / 200.0
+
 // DefaultMaxTransactionByteSize is the default maximum transaction byte size. (~1.5MB)
 const DefaultMaxTransactionByteSize = 1_500_000
 

--- a/module/metrics/execution.go
+++ b/module/metrics/execution.go
@@ -11,77 +11,78 @@ import (
 )
 
 type ExecutionCollector struct {
-	tracer                                 module.Tracer
-	totalExecutedBlocksCounter             prometheus.Counter
-	totalExecutedCollectionsCounter        prometheus.Counter
-	totalExecutedTransactionsCounter       prometheus.Counter
-	totalExecutedScriptsCounter            prometheus.Counter
-	totalFailedTransactionsCounter         prometheus.Counter
-	lastExecutedBlockHeightGauge           prometheus.Gauge
-	stateStorageDiskTotal                  prometheus.Gauge
-	storageStateCommitment                 prometheus.Gauge
-	forestApproxMemorySize                 prometheus.Gauge
-	forestNumberOfTrees                    prometheus.Gauge
-	latestTrieRegCount                     prometheus.Gauge
-	latestTrieRegCountDiff                 prometheus.Gauge
-	latestTrieRegSize                      prometheus.Gauge
-	latestTrieRegSizeDiff                  prometheus.Gauge
-	latestTrieMaxDepthTouched              prometheus.Gauge
-	updated                                prometheus.Counter
-	proofSize                              prometheus.Gauge
-	updatedValuesNumber                    prometheus.Counter
-	updatedValuesSize                      prometheus.Gauge
-	updatedDuration                        prometheus.Histogram
-	updatedDurationPerValue                prometheus.Histogram
-	readValuesNumber                       prometheus.Counter
-	readValuesSize                         prometheus.Gauge
-	readDuration                           prometheus.Histogram
-	readDurationPerValue                   prometheus.Histogram
-	blockComputationUsed                   prometheus.Histogram
-	blockComputationVector                 *prometheus.GaugeVec
-	blockCachedPrograms                    prometheus.Gauge
-	blockMemoryUsed                        prometheus.Histogram
-	blockEventCounts                       prometheus.Histogram
-	blockEventSize                         prometheus.Histogram
-	blockExecutionTime                     prometheus.Histogram
-	blockTransactionCounts                 prometheus.Histogram
-	blockCollectionCounts                  prometheus.Histogram
-	collectionComputationUsed              prometheus.Histogram
-	collectionMemoryUsed                   prometheus.Histogram
-	collectionEventSize                    prometheus.Histogram
-	collectionEventCounts                  prometheus.Histogram
-	collectionNumberOfRegistersTouched     prometheus.Histogram
-	collectionTotalBytesWrittenToRegisters prometheus.Histogram
-	collectionExecutionTime                prometheus.Histogram
-	collectionTransactionCounts            prometheus.Histogram
-	collectionRequestSent                  prometheus.Counter
-	collectionRequestRetried               prometheus.Counter
-	transactionParseTime                   prometheus.Histogram
-	transactionCheckTime                   prometheus.Histogram
-	transactionInterpretTime               prometheus.Histogram
-	transactionExecutionTime               prometheus.Histogram
-	transactionConflictRetries             prometheus.Histogram
-	transactionMemoryEstimate              prometheus.Histogram
-	transactionComputationUsed             prometheus.Histogram
-	transactionEmittedEvents               prometheus.Histogram
-	transactionEventSize                   prometheus.Histogram
-	scriptExecutionTime                    prometheus.Histogram
-	scriptComputationUsed                  prometheus.Histogram
-	scriptMemoryUsage                      prometheus.Histogram
-	scriptMemoryEstimate                   prometheus.Histogram
-	scriptMemoryDifference                 prometheus.Histogram
-	numberOfAccounts                       prometheus.Gauge
-	programsCacheMiss                      prometheus.Counter
-	programsCacheHit                       prometheus.Counter
-	chunkDataPackRequestProcessedTotal     prometheus.Counter
-	chunkDataPackProofSize                 prometheus.Histogram
-	chunkDataPackCollectionSize            prometheus.Histogram
-	stateSyncActive                        prometheus.Gauge
-	blockDataUploadsInProgress             prometheus.Gauge
-	blockDataUploadsDuration               prometheus.Histogram
-	maxCollectionHeight                    prometheus.Gauge
-	computationResultUploadedCount         prometheus.Counter
-	computationResultUploadRetriedCount    prometheus.Counter
+	tracer                                  module.Tracer
+	totalExecutedBlocksCounter              prometheus.Counter
+	totalExecutedCollectionsCounter         prometheus.Counter
+	totalExecutedTransactionsCounter        prometheus.Counter
+	totalExecutedScriptsCounter             prometheus.Counter
+	totalFailedTransactionsCounter          prometheus.Counter
+	lastExecutedBlockHeightGauge            prometheus.Gauge
+	stateStorageDiskTotal                   prometheus.Gauge
+	storageStateCommitment                  prometheus.Gauge
+	forestApproxMemorySize                  prometheus.Gauge
+	forestNumberOfTrees                     prometheus.Gauge
+	latestTrieRegCount                      prometheus.Gauge
+	latestTrieRegCountDiff                  prometheus.Gauge
+	latestTrieRegSize                       prometheus.Gauge
+	latestTrieRegSizeDiff                   prometheus.Gauge
+	latestTrieMaxDepthTouched               prometheus.Gauge
+	updated                                 prometheus.Counter
+	proofSize                               prometheus.Gauge
+	updatedValuesNumber                     prometheus.Counter
+	updatedValuesSize                       prometheus.Gauge
+	updatedDuration                         prometheus.Histogram
+	updatedDurationPerValue                 prometheus.Histogram
+	readValuesNumber                        prometheus.Counter
+	readValuesSize                          prometheus.Gauge
+	readDuration                            prometheus.Histogram
+	readDurationPerValue                    prometheus.Histogram
+	blockComputationUsed                    prometheus.Histogram
+	blockComputationVector                  *prometheus.GaugeVec
+	blockCachedPrograms                     prometheus.Gauge
+	blockMemoryUsed                         prometheus.Histogram
+	blockEventCounts                        prometheus.Histogram
+	blockEventSize                          prometheus.Histogram
+	blockExecutionTime                      prometheus.Histogram
+	blockTransactionCounts                  prometheus.Histogram
+	blockCollectionCounts                   prometheus.Histogram
+	collectionComputationUsed               prometheus.Histogram
+	collectionMemoryUsed                    prometheus.Histogram
+	collectionEventSize                     prometheus.Histogram
+	collectionEventCounts                   prometheus.Histogram
+	collectionNumberOfRegistersTouched      prometheus.Histogram
+	collectionTotalBytesWrittenToRegisters  prometheus.Histogram
+	collectionExecutionTime                 prometheus.Histogram
+	collectionTransactionCounts             prometheus.Histogram
+	collectionRequestSent                   prometheus.Counter
+	collectionRequestRetried                prometheus.Counter
+	transactionParseTime                    prometheus.Histogram
+	transactionCheckTime                    prometheus.Histogram
+	transactionInterpretTime                prometheus.Histogram
+	transactionExecutionTime                prometheus.Histogram
+	transactionConflictRetries              prometheus.Histogram
+	transactionMemoryEstimate               prometheus.Histogram
+	transactionComputationUsed              prometheus.Histogram
+	transactionNormalizedTimePerComputation prometheus.Histogram
+	transactionEmittedEvents                prometheus.Histogram
+	transactionEventSize                    prometheus.Histogram
+	scriptExecutionTime                     prometheus.Histogram
+	scriptComputationUsed                   prometheus.Histogram
+	scriptMemoryUsage                       prometheus.Histogram
+	scriptMemoryEstimate                    prometheus.Histogram
+	scriptMemoryDifference                  prometheus.Histogram
+	numberOfAccounts                        prometheus.Gauge
+	programsCacheMiss                       prometheus.Counter
+	programsCacheHit                        prometheus.Counter
+	chunkDataPackRequestProcessedTotal      prometheus.Counter
+	chunkDataPackProofSize                  prometheus.Histogram
+	chunkDataPackCollectionSize             prometheus.Histogram
+	stateSyncActive                         prometheus.Gauge
+	blockDataUploadsInProgress              prometheus.Gauge
+	blockDataUploadsDuration                prometheus.Histogram
+	maxCollectionHeight                     prometheus.Gauge
+	computationResultUploadedCount          prometheus.Counter
+	computationResultUploadRetriedCount     prometheus.Counter
 }
 
 func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
@@ -405,6 +406,14 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 		Buckets:   []float64{50, 100, 500, 1000, 5000, 10000},
 	})
 
+	transactionNormalizedTimePerComputation := promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespaceExecution,
+		Subsystem: subsystemRuntime,
+		Name:      "transaction_ms_per_computation",
+		Help:      "The normalized ratio of millisecond of execution time per computation used. Value below 1 means the transaction was executed faster then estimated (is using less resources then estimated)",
+		Buckets:   []float64{0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64},
+	})
+
 	transactionMemoryEstimate := promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespaceExecution,
 		Subsystem: subsystemRuntime,
@@ -524,63 +533,64 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 	ec := &ExecutionCollector{
 		tracer: tracer,
 
-		forestApproxMemorySize:                 forestApproxMemorySize,
-		forestNumberOfTrees:                    forestNumberOfTrees,
-		latestTrieRegCount:                     latestTrieRegCount,
-		latestTrieRegCountDiff:                 latestTrieRegCountDiff,
-		latestTrieRegSize:                      latestTrieRegSize,
-		latestTrieRegSizeDiff:                  latestTrieRegSizeDiff,
-		latestTrieMaxDepthTouched:              latestTrieMaxDepthTouched,
-		updated:                                updatedCount,
-		proofSize:                              proofSize,
-		updatedValuesNumber:                    updatedValuesNumber,
-		updatedValuesSize:                      updatedValuesSize,
-		updatedDuration:                        updatedDuration,
-		updatedDurationPerValue:                updatedDurationPerValue,
-		readValuesNumber:                       readValuesNumber,
-		readValuesSize:                         readValuesSize,
-		readDuration:                           readDuration,
-		readDurationPerValue:                   readDurationPerValue,
-		blockExecutionTime:                     blockExecutionTime,
-		blockComputationUsed:                   blockComputationUsed,
-		blockComputationVector:                 blockComputationVector,
-		blockCachedPrograms:                    blockCachedPrograms,
-		blockMemoryUsed:                        blockMemoryUsed,
-		blockEventCounts:                       blockEventCounts,
-		blockEventSize:                         blockEventSize,
-		blockTransactionCounts:                 blockTransactionCounts,
-		blockCollectionCounts:                  blockCollectionCounts,
-		collectionExecutionTime:                collectionExecutionTime,
-		collectionComputationUsed:              collectionComputationUsed,
-		collectionMemoryUsed:                   collectionMemoryUsed,
-		collectionEventSize:                    collectionEventSize,
-		collectionEventCounts:                  collectionEventCounts,
-		collectionNumberOfRegistersTouched:     collectionNumberOfRegistersTouched,
-		collectionTotalBytesWrittenToRegisters: collectionTotalBytesWrittenToRegisters,
-		collectionTransactionCounts:            collectionTransactionCounts,
-		collectionRequestSent:                  collectionRequestsSent,
-		collectionRequestRetried:               collectionRequestsRetries,
-		transactionParseTime:                   transactionParseTime,
-		transactionCheckTime:                   transactionCheckTime,
-		transactionInterpretTime:               transactionInterpretTime,
-		transactionExecutionTime:               transactionExecutionTime,
-		transactionConflictRetries:             transactionConflictRetries,
-		transactionComputationUsed:             transactionComputationUsed,
-		transactionMemoryEstimate:              transactionMemoryEstimate,
-		transactionEmittedEvents:               transactionEmittedEvents,
-		transactionEventSize:                   transactionEventSize,
-		scriptExecutionTime:                    scriptExecutionTime,
-		scriptComputationUsed:                  scriptComputationUsed,
-		scriptMemoryUsage:                      scriptMemoryUsage,
-		scriptMemoryEstimate:                   scriptMemoryEstimate,
-		scriptMemoryDifference:                 scriptMemoryDifference,
-		chunkDataPackRequestProcessedTotal:     chunkDataPackRequestProcessedTotal,
-		chunkDataPackProofSize:                 chunkDataPackProofSize,
-		chunkDataPackCollectionSize:            chunkDataPackCollectionSize,
-		blockDataUploadsInProgress:             blockDataUploadsInProgress,
-		blockDataUploadsDuration:               blockDataUploadsDuration,
-		computationResultUploadedCount:         computationResultUploadedCount,
-		computationResultUploadRetriedCount:    computationResultUploadRetriedCount,
+		forestApproxMemorySize:                  forestApproxMemorySize,
+		forestNumberOfTrees:                     forestNumberOfTrees,
+		latestTrieRegCount:                      latestTrieRegCount,
+		latestTrieRegCountDiff:                  latestTrieRegCountDiff,
+		latestTrieRegSize:                       latestTrieRegSize,
+		latestTrieRegSizeDiff:                   latestTrieRegSizeDiff,
+		latestTrieMaxDepthTouched:               latestTrieMaxDepthTouched,
+		updated:                                 updatedCount,
+		proofSize:                               proofSize,
+		updatedValuesNumber:                     updatedValuesNumber,
+		updatedValuesSize:                       updatedValuesSize,
+		updatedDuration:                         updatedDuration,
+		updatedDurationPerValue:                 updatedDurationPerValue,
+		readValuesNumber:                        readValuesNumber,
+		readValuesSize:                          readValuesSize,
+		readDuration:                            readDuration,
+		readDurationPerValue:                    readDurationPerValue,
+		blockExecutionTime:                      blockExecutionTime,
+		blockComputationUsed:                    blockComputationUsed,
+		blockComputationVector:                  blockComputationVector,
+		blockCachedPrograms:                     blockCachedPrograms,
+		blockMemoryUsed:                         blockMemoryUsed,
+		blockEventCounts:                        blockEventCounts,
+		blockEventSize:                          blockEventSize,
+		blockTransactionCounts:                  blockTransactionCounts,
+		blockCollectionCounts:                   blockCollectionCounts,
+		collectionExecutionTime:                 collectionExecutionTime,
+		collectionComputationUsed:               collectionComputationUsed,
+		collectionMemoryUsed:                    collectionMemoryUsed,
+		collectionEventSize:                     collectionEventSize,
+		collectionEventCounts:                   collectionEventCounts,
+		collectionNumberOfRegistersTouched:      collectionNumberOfRegistersTouched,
+		collectionTotalBytesWrittenToRegisters:  collectionTotalBytesWrittenToRegisters,
+		collectionTransactionCounts:             collectionTransactionCounts,
+		collectionRequestSent:                   collectionRequestsSent,
+		collectionRequestRetried:                collectionRequestsRetries,
+		transactionParseTime:                    transactionParseTime,
+		transactionCheckTime:                    transactionCheckTime,
+		transactionInterpretTime:                transactionInterpretTime,
+		transactionExecutionTime:                transactionExecutionTime,
+		transactionConflictRetries:              transactionConflictRetries,
+		transactionComputationUsed:              transactionComputationUsed,
+		transactionNormalizedTimePerComputation: transactionNormalizedTimePerComputation,
+		transactionMemoryEstimate:               transactionMemoryEstimate,
+		transactionEmittedEvents:                transactionEmittedEvents,
+		transactionEventSize:                    transactionEventSize,
+		scriptExecutionTime:                     scriptExecutionTime,
+		scriptComputationUsed:                   scriptComputationUsed,
+		scriptMemoryUsage:                       scriptMemoryUsage,
+		scriptMemoryEstimate:                    scriptMemoryEstimate,
+		scriptMemoryDifference:                  scriptMemoryDifference,
+		chunkDataPackRequestProcessedTotal:      chunkDataPackRequestProcessedTotal,
+		chunkDataPackProofSize:                  chunkDataPackProofSize,
+		chunkDataPackCollectionSize:             chunkDataPackCollectionSize,
+		blockDataUploadsInProgress:              blockDataUploadsInProgress,
+		blockDataUploadsDuration:                blockDataUploadsDuration,
+		computationResultUploadedCount:          computationResultUploadedCount,
+		computationResultUploadRetriedCount:     computationResultUploadRetriedCount,
 		totalExecutedBlocksCounter: promauto.NewCounter(prometheus.CounterOpts{
 			Namespace: namespaceExecution,
 			Subsystem: subsystemRuntime,
@@ -739,6 +749,11 @@ func (ec *ExecutionCollector) ExecutionTransactionExecuted(
 	ec.transactionExecutionTime.Observe(float64(dur.Milliseconds()))
 	ec.transactionConflictRetries.Observe(float64(numConflictRetries))
 	ec.transactionComputationUsed.Observe(float64(compUsed))
+	if compUsed > 0 {
+		// normalize so the value should be around 1
+		ec.transactionNormalizedTimePerComputation.Observe(
+			(float64(dur.Milliseconds()) / float64(compUsed)) * flow.EstimatedComputationPerMillisecond)
+	}
 	ec.transactionMemoryEstimate.Observe(float64(memoryUsed))
 	ec.transactionEmittedEvents.Observe(float64(eventCounts))
 	ec.transactionEventSize.Observe(float64(eventSize))

--- a/module/metrics/execution.go
+++ b/module/metrics/execution.go
@@ -410,7 +410,7 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 		Namespace: namespaceExecution,
 		Subsystem: subsystemRuntime,
 		Name:      "transaction_ms_per_computation",
-		Help:      "The normalized ratio of millisecond of execution time per computation used. Value below 1 means the transaction was executed faster then estimated (is using less resources then estimated)",
+		Help:      "The normalized ratio of millisecond of execution time per computation used. Value below 1 means the transaction was executed faster than estimated (is using less resources then estimated)",
 		Buckets:   []float64{0.015625, 0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64},
 	})
 


### PR DESCRIPTION
Port of https://github.com/onflow/flow-go/pull/4615

This just adds additional metrics. It is ok to deploy wit a rolling deploy.