### PR TITLE
[Access] Make script exec configurable

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -146,6 +146,7 @@ type AccessNodeConfig struct {
 	executionDataIndexingEnabled bool
 	registersDBPath              string
 	checkpointFile               string
+	scriptExecutorConfig         query.QueryConfig
 }
 
 type PublicNetworkConfig struct {
@@ -232,6 +233,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		executionDataIndexingEnabled: false,
 		registersDBPath:              filepath.Join(homedir, ".flow", "execution_state"),
 		checkpointFile:               cmd.NotSet,
+		scriptExecutorConfig:         query.NewDefaultConfig(),
 	}
 }
 
@@ -771,6 +773,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					query.NewProtocolStateWrapper(builder.State),
 					builder.Storage.Headers,
 					builder.ExecutionIndexerCore.RegisterValue,
+					builder.scriptExecutorConfig,
 				)
 				if err != nil {
 					return nil, err
@@ -929,6 +932,11 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 
 		// Script Execution
 		flags.StringVar(&builder.rpcConf.BackendConfig.ScriptExecutionMode, "script-execution-mode", defaultConfig.rpcConf.BackendConfig.ScriptExecutionMode, "mode to use when executing scripts. one of (local-only, execution-nodes-only, failover, compare)")
+		flags.Uint64Var(&builder.scriptExecutorConfig.ComputationLimit, "script-execution-computation-limit", defaultConfig.scriptExecutorConfig.ComputationLimit, "maximum number of computation units a locally executed script can use. default: 100000")
+		flags.IntVar(&builder.scriptExecutorConfig.MaxErrorMessageSize, "script-execution-max-error-length", defaultConfig.scriptExecutorConfig.MaxErrorMessageSize, "maximum number characters to include in error message strings. additional characters are truncated. default: 1000")
+		flags.DurationVar(&builder.scriptExecutorConfig.LogTimeThreshold, "script-execution-log-time-threshold", defaultConfig.scriptExecutorConfig.LogTimeThreshold, "emit a log for any scripts that take over this threshold. default: 1s")
+		flags.DurationVar(&builder.scriptExecutorConfig.ExecutionTimeLimit, "script-execution-timeout", defaultConfig.scriptExecutorConfig.ExecutionTimeLimit, "timeout value for locally executed scripts. default: 10s")
+
 	}).ValidateFlags(func() error {
 		if builder.supportsObserver && (builder.PublicNetworkConfig.BindAddress == cmd.NotSet || builder.PublicNetworkConfig.BindAddress == "") {
 			return errors.New("public-network-address must be set if supports-observer is true")

--- a/cmd/execution_config.go
+++ b/cmd/execution_config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/engine/common/provider"
 	"github.com/onflow/flow-go/engine/execution/computation/query"
 	exeprovider "github.com/onflow/flow-go/engine/execution/provider"
+	"github.com/onflow/flow-go/fvm"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/mempool"
 	"github.com/onflow/flow-go/utils/grpcutils"
@@ -89,6 +90,8 @@ func (exeConf *ExecutionConfig) SetupFlags(flags *pflag.FlagSet) {
 		"threshold for logging script execution")
 	flags.DurationVar(&exeConf.computationConfig.QueryConfig.ExecutionTimeLimit, "script-execution-time-limit", query.DefaultExecutionTimeLimit,
 		"script execution time limit")
+	flags.Uint64Var(&exeConf.computationConfig.QueryConfig.ComputationLimit, "script-execution-computation-limit", fvm.DefaultComputationLimit,
+		"script execution computation limit")
 	flags.UintVar(&exeConf.transactionResultsCacheSize, "transaction-results-cache-size", 10000, "number of transaction results to be cached")
 	flags.BoolVar(&exeConf.extensiveLog, "extensive-logging", false, "extensive logging logs tx contents and block headers")
 	flags.DurationVar(&exeConf.chunkDataPackQueryTimeout, "chunk-data-pack-query-timeout", exeprovider.DefaultChunkDataPackQueryTimeout, "timeout duration to determine a chunk data pack query being slow")

--- a/engine/execution/computation/query/executor.go
+++ b/engine/execution/computation/query/executor.go
@@ -174,11 +174,9 @@ func (e *QueryExecutor) ExecuteScript(
 			fvm.WithBlockHeader(blockHeader),
 			fvm.WithEntropyProvider(e.entropyPerBlock.AtBlockID(blockHeader.ID())),
 			fvm.WithDerivedBlockData(
-				e.derivedChainData.NewDerivedBlockDataForScript(blockHeader.ID())),
-		),
+				e.derivedChainData.NewDerivedBlockDataForScript(blockHeader.ID()))),
 		fvm.NewScriptWithContextAndArgs(script, requestCtx, arguments...),
-		snapshot,
-	)
+		snapshot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute script (internal error): %w", err)
 	}

--- a/engine/execution/computation/query/executor.go
+++ b/engine/execution/computation/query/executor.go
@@ -89,6 +89,9 @@ func NewQueryExecutor(
 	derivedChainData *derived.DerivedChainData,
 	entropyPerBlock EntropyProviderPerBlock,
 ) *QueryExecutor {
+	if config.ComputationLimit > 0 {
+		vmCtx = fvm.NewContextFromParent(vmCtx, fvm.WithComputationLimit(config.ComputationLimit))
+	}
 	return &QueryExecutor{
 		config:           config,
 		logger:           logger,
@@ -172,7 +175,6 @@ func (e *QueryExecutor) ExecuteScript(
 			fvm.WithEntropyProvider(e.entropyPerBlock.AtBlockID(blockHeader.ID())),
 			fvm.WithDerivedBlockData(
 				e.derivedChainData.NewDerivedBlockDataForScript(blockHeader.ID())),
-			fvm.WithComputationLimit(e.config.ComputationLimit),
 		),
 		fvm.NewScriptWithContextAndArgs(script, requestCtx, arguments...),
 		snapshot,

--- a/engine/execution/computation/query/executor.go
+++ b/engine/execution/computation/query/executor.go
@@ -89,10 +89,6 @@ func NewQueryExecutor(
 	derivedChainData *derived.DerivedChainData,
 	entropyPerBlock EntropyProviderPerBlock,
 ) *QueryExecutor {
-	if config.ComputationLimit == 0 {
-		config.ComputationLimit = fvm.DefaultComputationLimit
-	}
-
 	return &QueryExecutor{
 		config:           config,
 		logger:           logger,

--- a/module/execution/scripts.go
+++ b/module/execution/scripts.go
@@ -66,6 +66,7 @@ func NewScripts(
 	entropy query.EntropyProviderPerBlock,
 	header storage.Headers,
 	registerAtHeight RegisterAtHeight,
+	queryConf query.QueryConfig,
 ) (*Scripts, error) {
 	vm := fvm.NewVirtualMachine()
 
@@ -80,7 +81,7 @@ func NewScripts(
 	}
 
 	queryExecutor := query.NewQueryExecutor(
-		query.NewDefaultConfig(),
+		queryConf,
 		log,
 		metrics,
 		vm,

--- a/module/execution/scripts_test.go
+++ b/module/execution/scripts_test.go
@@ -15,6 +15,7 @@ import (
 	mocks "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/onflow/flow-go/engine/execution/computation/query"
 	"github.com/onflow/flow-go/engine/execution/computation/query/mock"
 	"github.com/onflow/flow-go/engine/execution/testutil"
 	"github.com/onflow/flow-go/fvm"
@@ -165,6 +166,7 @@ func (s *scriptTestSuite) SetupTest() {
 		entropyBlock,
 		headers,
 		index.RegisterValue,
+		query.NewDefaultConfig(),
 	)
 	s.Require().NoError(err)
 	s.scripts = scripts


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/4776

This PR makes script execution options configurable by a node operator, including:
* Execution timeout
* Computation limit
* Error message size limit
* Log time threshold