### PR TITLE
[Storehouse] Execution State - Update IsBlockExecuted

### DIFF
--- a/engine/execution/checker/engine.go
+++ b/engine/execution/checker/engine.go
@@ -82,7 +82,7 @@ func (e *Engine) checkLastSealed(finalizedID flow.Identifier) error {
 	blockID := seal.BlockID
 	sealedCommit := seal.FinalState
 
-	mycommit, err := e.execState.StateCommitmentByBlockID(e.unit.Ctx(), blockID)
+	mycommit, err := e.execState.StateCommitmentByBlockID(blockID)
 	if errors.Is(err, storage.ErrNotFound) {
 		// have not executed the sealed block yet
 		// in other words, this can't detect execution fork, if the execution is behind

--- a/engine/execution/execution_test.go
+++ b/engine/execution/execution_test.go
@@ -437,10 +437,10 @@ func TestFailedTxWillNotChangeStateCommitment(t *testing.T) {
 	})
 	exe1Node.AssertHighestExecutedBlock(t, block1.Header)
 
-	scExe1Genesis, err := exe1Node.ExecutionState.StateCommitmentByBlockID(context.Background(), genesis.ID())
+	scExe1Genesis, err := exe1Node.ExecutionState.StateCommitmentByBlockID(genesis.ID())
 	assert.NoError(t, err)
 
-	scExe1Block1, err := exe1Node.ExecutionState.StateCommitmentByBlockID(context.Background(), block1.ID())
+	scExe1Block1, err := exe1Node.ExecutionState.StateCommitmentByBlockID(block1.ID())
 	assert.NoError(t, err)
 	assert.NotEqual(t, scExe1Genesis, scExe1Block1)
 
@@ -461,7 +461,7 @@ func TestFailedTxWillNotChangeStateCommitment(t *testing.T) {
 	// exe2Node.AssertHighestExecutedBlock(t, block3.Header)
 
 	// verify state commitment of block 2 is the same as block 1, since tx failed on seq number verification
-	scExe1Block2, err := exe1Node.ExecutionState.StateCommitmentByBlockID(context.Background(), block2.ID())
+	scExe1Block2, err := exe1Node.ExecutionState.StateCommitmentByBlockID(block2.ID())
 	assert.NoError(t, err)
 	// TODO this is no longer valid because the system chunk can change the state
 	//assert.Equal(t, scExe1Block1, scExe1Block2)

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -284,7 +284,7 @@ func (e *Engine) handleBlock(ctx context.Context, block *flow.Block) error {
 	span, _ := e.tracer.StartBlockSpan(ctx, blockID, trace.EXEHandleBlock)
 	defer span.End()
 
-	executed, err := state.IsBlockExecuted(e.unit.Ctx(), e.execState, blockID)
+	executed, err := e.execState.IsBlockExecuted(block.Header.Height, blockID)
 	if err != nil {
 		return fmt.Errorf("could not check whether block is executed: %w", err)
 	}
@@ -357,7 +357,7 @@ func (e *Engine) enqueueBlockAndCheckExecutable(
 	// check if the block's parent has been executed. (we can't execute the block if the parent has
 	// not been executed yet)
 	// check if there is a statecommitment for the parent block
-	parentCommitment, err := e.execState.StateCommitmentByBlockID(e.unit.Ctx(), block.Header.ParentID)
+	parentCommitment, err := e.execState.StateCommitmentByBlockID(block.Header.ParentID)
 
 	// if we found the statecommitment for the parent block, then add it to the executable block.
 	if err == nil {

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -742,7 +742,7 @@ func makeBlockWithCollection(parent *flow.Header, cols ...*flow.Collection) *ent
 }
 
 func (ctx *testingContext) mockStateCommitmentByBlockID(store *mocks.MockBlockStore) {
-	mocked := ctx.executionState.On("StateCommitmentByBlockID", mock.Anything, mock.Anything)
+	mocked := ctx.executionState.On("StateCommitmentByBlockID", mock.Anything)
 	// https://github.com/stretchr/testify/issues/350#issuecomment-570478958
 	mocked.RunFn = func(args mock.Arguments) {
 		blockID := args[1].(flow.Identifier)

--- a/engine/execution/ingestion/engine_test.go
+++ b/engine/execution/ingestion/engine_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/crypto"
+	"github.com/onflow/flow-go/fvm/storage/snapshot"
 
 	enginePkg "github.com/onflow/flow-go/engine"
 	"github.com/onflow/flow-go/engine/execution"
@@ -171,6 +172,7 @@ func TestExecuteOneBlock(t *testing.T) {
 		blockA := makeBlockWithCollection(store.RootBlock, &col)
 		result := store.CreateBlockAndMockResult(t, blockA)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -226,6 +228,7 @@ func TestExecuteBlocks(t *testing.T) {
 		store.CreateBlockAndMockResult(t, blockA)
 		store.CreateBlockAndMockResult(t, blockB)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -275,6 +278,7 @@ func TestExecuteNextBlockIfCollectionIsReady(t *testing.T) {
 		// C2 is available in storage
 		require.NoError(t, ctx.collections.Store(&col2))
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -319,6 +323,7 @@ func TestExecuteBlockOnlyOnce(t *testing.T) {
 		blockA := makeBlockWithCollection(store.RootBlock, &col)
 		store.CreateBlockAndMockResult(t, blockA)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -375,6 +380,7 @@ func TestExecuteForkConcurrently(t *testing.T) {
 		store.CreateBlockAndMockResult(t, blockA)
 		store.CreateBlockAndMockResult(t, blockB)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -425,6 +431,7 @@ func TestExecuteBlockInOrder(t *testing.T) {
 		store.CreateBlockAndMockResult(t, blockB)
 		store.CreateBlockAndMockResult(t, blockC)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -495,6 +502,7 @@ func TestStopAtHeightWhenFinalizedBeforeExecuted(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -562,6 +570,7 @@ func TestStopAtHeightWhenExecutedBeforeFinalized(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -623,6 +632,7 @@ func TestStopAtHeightWhenExecutionFinalization(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -678,6 +688,7 @@ func TestExecutedBlockUploadedFailureDoesntBlock(t *testing.T) {
 		blockA := makeBlockWithCollection(store.RootBlock, &col)
 		result := store.CreateBlockAndMockResult(t, blockA)
 
+		ctx.mockIsBlockExecuted(store)
 		ctx.mockStateCommitmentByBlockID(store)
 		ctx.mockGetExecutionResultID(store)
 		ctx.executionState.On("NewStorageSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -741,63 +752,63 @@ func makeBlockWithCollection(parent *flow.Header, cols ...*flow.Collection) *ent
 	return executableBlock
 }
 
+func (ctx *testingContext) mockIsBlockExecuted(store *mocks.MockBlockStore) {
+	ctx.executionState.On("IsBlockExecuted", mock.Anything, mock.Anything).
+		Return(func(height uint64, blockID flow.Identifier) (bool, error) {
+			_, err := store.GetExecuted(blockID)
+			if err != nil {
+				return false, nil
+			}
+			return true, nil
+		})
+}
+
 func (ctx *testingContext) mockStateCommitmentByBlockID(store *mocks.MockBlockStore) {
-	mocked := ctx.executionState.On("StateCommitmentByBlockID", mock.Anything)
-	// https://github.com/stretchr/testify/issues/350#issuecomment-570478958
-	mocked.RunFn = func(args mock.Arguments) {
-		blockID := args[1].(flow.Identifier)
-		result, err := store.GetExecuted(blockID)
-		if err != nil {
-			mocked.ReturnArguments = mock.Arguments{flow.StateCommitment{}, storageerr.ErrNotFound}
-			return
-		}
-		mocked.ReturnArguments = mock.Arguments{result.Result.CurrentEndState(), nil}
-	}
+	ctx.executionState.On("StateCommitmentByBlockID", mock.Anything).
+		Return(func(blockID flow.Identifier) (flow.StateCommitment, error) {
+			result, err := store.GetExecuted(blockID)
+			if err != nil {
+				return flow.StateCommitment{}, storageerr.ErrNotFound
+			}
+			return result.Result.CurrentEndState(), nil
+		})
 }
 
 func (ctx *testingContext) mockGetExecutionResultID(store *mocks.MockBlockStore) {
+	ctx.executionState.On("GetExecutionResultID", mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, blockID flow.Identifier) (flow.Identifier, error) {
+			blockResult, err := store.GetExecuted(blockID)
+			if err != nil {
+				return flow.ZeroID, storageerr.ErrNotFound
+			}
 
-	mocked := ctx.executionState.On("GetExecutionResultID", mock.Anything, mock.Anything)
-	mocked.RunFn = func(args mock.Arguments) {
-		blockID := args[1].(flow.Identifier)
-		blockResult, err := store.GetExecuted(blockID)
-		if err != nil {
-			mocked.ReturnArguments = mock.Arguments{nil, storageerr.ErrNotFound}
-			return
-		}
-
-		mocked.ReturnArguments = mock.Arguments{
-			blockResult.Result.ExecutionReceipt.ExecutionResult.ID(), nil}
-	}
+			return blockResult.Result.ExecutionReceipt.ExecutionResult.ID(), nil
+		})
 }
 
 func (ctx *testingContext) mockComputeBlock(store *mocks.MockBlockStore) {
-	mocked := ctx.computationManager.On("ComputeBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-	mocked.RunFn = func(args mock.Arguments) {
-		block := args[2].(*entity.ExecutableBlock)
-		blockResult, ok := store.ResultByBlock[block.ID()]
-		if !ok {
-			mocked.ReturnArguments = mock.Arguments{nil, fmt.Errorf("block %s not found", block.ID())}
-			return
-		}
-		mocked.ReturnArguments = mock.Arguments{blockResult.Result, nil}
-	}
+	ctx.computationManager.On("ComputeBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context,
+			parentBlockExecutionResultID flow.Identifier,
+			block *entity.ExecutableBlock,
+			snapshot snapshot.StorageSnapshot) (
+			*execution.ComputationResult, error) {
+			blockResult, ok := store.ResultByBlock[block.ID()]
+			if !ok {
+				return nil, fmt.Errorf("block %s not found", block.ID())
+			}
+			return blockResult.Result, nil
+		})
 }
 
 func (ctx *testingContext) mockSaveExecutionResults(store *mocks.MockBlockStore, wg *sync.WaitGroup) {
-	mocked := ctx.executionState.
-		On("SaveExecutionResults", mock.Anything, mock.Anything)
-
-	mocked.RunFn = func(args mock.Arguments) {
-		result := args[1].(*execution.ComputationResult)
-
-		err := store.MarkExecuted(result)
-		if err != nil {
-			mocked.ReturnArguments = mock.Arguments{err}
-			wg.Done()
-			return
-		}
-		mocked.ReturnArguments = mock.Arguments{nil}
-		wg.Done()
-	}
+	ctx.executionState.On("SaveExecutionResults", mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, result *execution.ComputationResult) error {
+			defer wg.Done()
+			err := store.MarkExecuted(result)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
 }

--- a/engine/execution/ingestion/loader/unexecuted_loader.go
+++ b/engine/execution/ingestion/loader/unexecuted_loader.go
@@ -66,7 +66,7 @@ func (e *UnexecutedLoader) LoadUnexecuted(ctx context.Context) ([]flow.Identifie
 	blockIDs := make([]flow.Identifier, 0)
 	isRoot := rootBlock.ID() == last.ID()
 	if !isRoot {
-		executed, err := state.IsBlockExecuted(ctx, e.execState, lastExecutedID)
+		executed, err := e.execState.IsBlockExecuted(lastExecutedHeight, lastExecutedID)
 		if err != nil {
 			return nil, fmt.Errorf("cannot check is last exeucted final block has been executed %v: %w", lastExecutedID, err)
 		}
@@ -162,7 +162,7 @@ func (e *UnexecutedLoader) finalizedUnexecutedBlocks(ctx context.Context, finali
 			return nil, fmt.Errorf("could not get header at height: %v, %w", lastExecuted, err)
 		}
 
-		executed, err := state.IsBlockExecuted(ctx, e.execState, header.ID())
+		executed, err := e.execState.IsBlockExecuted(header.Height, header.ID())
 		if err != nil {
 			return nil, fmt.Errorf("could not check whether block is executed: %w", err)
 		}
@@ -211,7 +211,11 @@ func (e *UnexecutedLoader) pendingUnexecutedBlocks(ctx context.Context, finalize
 	unexecuted := make([]flow.Identifier, 0)
 
 	for _, pending := range pendings {
-		executed, err := state.IsBlockExecuted(ctx, e.execState, pending)
+		p, err := e.headers.ByBlockID(pending)
+		if err != nil {
+			return nil, fmt.Errorf("could not get header by block id: %w", err)
+		}
+		executed, err := e.execState.IsBlockExecuted(p.Height, pending)
 		if err != nil {
 			return nil, fmt.Errorf("could not check block executed or not: %w", err)
 		}

--- a/engine/execution/ingestion/loader/unexecuted_loader_test.go
+++ b/engine/execution/ingestion/loader/unexecuted_loader_test.go
@@ -55,6 +55,13 @@ func (es *mockExecutionState) StateCommitmentByBlockID(
 	return commit, nil
 }
 
+func (es *mockExecutionState) IsBlockExecuted(height uint64, blockID flow.Identifier) (bool, error) {
+	es.Lock()
+	defer es.Unlock()
+	_, ok := es.commits[blockID]
+	return ok, nil
+}
+
 func (es *mockExecutionState) ExecuteBlock(t *testing.T, block *flow.Block) {
 	parentExecuted, err := es.IsBlockExecuted(
 		block.Header.Height,
@@ -117,6 +124,10 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		headers := storage.NewMockHeaders(ctrl)
 		headers.EXPECT().ByBlockID(genesis.ID()).Return(genesis.Header, nil)
+		headers.EXPECT().ByBlockID(blockA.ID()).Return(blockA.Header, nil)
+		headers.EXPECT().ByBlockID(blockB.ID()).Return(blockB.Header, nil)
+		headers.EXPECT().ByBlockID(blockC.ID()).Return(blockC.Header, nil)
+		headers.EXPECT().ByBlockID(blockD.ID()).Return(blockD.Header, nil)
 		log := unittest.Logger()
 		loader := loader.NewUnexecutedLoader(log, ps, headers, es)
 
@@ -145,6 +156,11 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		headers := storage.NewMockHeaders(ctrl)
 		headers.EXPECT().ByBlockID(genesis.ID()).Return(genesis.Header, nil)
+		headers.EXPECT().ByBlockID(blockA.ID()).Return(blockA.Header, nil)
+		headers.EXPECT().ByBlockID(blockB.ID()).Return(blockB.Header, nil)
+		headers.EXPECT().ByBlockID(blockC.ID()).Return(blockC.Header, nil)
+		headers.EXPECT().ByBlockID(blockD.ID()).Return(blockD.Header, nil)
+
 		log := unittest.Logger()
 		loader := loader.NewUnexecutedLoader(log, ps, headers, es)
 
@@ -178,6 +194,8 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		headers := storage.NewMockHeaders(ctrl)
 		headers.EXPECT().ByBlockID(genesis.ID()).Return(genesis.Header, nil)
+		headers.EXPECT().ByBlockID(blockD.ID()).Return(blockD.Header, nil)
+
 		log := unittest.Logger()
 		loader := loader.NewUnexecutedLoader(log, ps, headers, es)
 
@@ -215,6 +233,7 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		headers := storage.NewMockHeaders(ctrl)
 		headers.EXPECT().ByBlockID(genesis.ID()).Return(genesis.Header, nil)
+		headers.EXPECT().ByBlockID(blockD.ID()).Return(blockD.Header, nil)
 		log := unittest.Logger()
 		loader := loader.NewUnexecutedLoader(log, ps, headers, es)
 
@@ -251,6 +270,10 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		headers := storage.NewMockHeaders(ctrl)
 		headers.EXPECT().ByBlockID(genesis.ID()).Return(genesis.Header, nil)
+		headers.EXPECT().ByBlockID(blockB.ID()).Return(blockB.Header, nil)
+		headers.EXPECT().ByBlockID(blockC.ID()).Return(blockC.Header, nil)
+		headers.EXPECT().ByBlockID(blockD.ID()).Return(blockD.Header, nil)
+
 		log := unittest.Logger()
 		loader := loader.NewUnexecutedLoader(log, ps, headers, es)
 
@@ -312,6 +335,13 @@ func TestLoadingUnexecutedBlocks(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		headers := storage.NewMockHeaders(ctrl)
 		headers.EXPECT().ByBlockID(genesis.ID()).Return(genesis.Header, nil)
+		headers.EXPECT().ByBlockID(blockD.ID()).Return(blockD.Header, nil)
+		headers.EXPECT().ByBlockID(blockE.ID()).Return(blockE.Header, nil)
+		headers.EXPECT().ByBlockID(blockF.ID()).Return(blockF.Header, nil)
+		headers.EXPECT().ByBlockID(blockG.ID()).Return(blockG.Header, nil)
+		headers.EXPECT().ByBlockID(blockH.ID()).Return(blockH.Header, nil)
+		headers.EXPECT().ByBlockID(blockI.ID()).Return(blockI.Header, nil)
+
 		log := unittest.Logger()
 		loader := loader.NewUnexecutedLoader(log, ps, headers, es)
 

--- a/engine/execution/ingestion/loader/unexecuted_loader_test.go
+++ b/engine/execution/ingestion/loader/unexecuted_loader_test.go
@@ -41,7 +41,6 @@ func newMockExecutionState(seal *flow.Seal, genesis *flow.Header) *mockExecution
 }
 
 func (es *mockExecutionState) StateCommitmentByBlockID(
-	ctx context.Context,
 	blockID flow.Identifier,
 ) (
 	flow.StateCommitment,

--- a/engine/execution/ingestion/loader/unexecuted_loader_test.go
+++ b/engine/execution/ingestion/loader/unexecuted_loader_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/onflow/flow-go/engine/execution/ingestion"
 	"github.com/onflow/flow-go/engine/execution/ingestion/loader"
-	"github.com/onflow/flow-go/engine/execution/state"
 	stateMock "github.com/onflow/flow-go/engine/execution/state/mock"
 	"github.com/onflow/flow-go/model/flow"
 	storageerr "github.com/onflow/flow-go/storage"
@@ -57,9 +56,8 @@ func (es *mockExecutionState) StateCommitmentByBlockID(
 }
 
 func (es *mockExecutionState) ExecuteBlock(t *testing.T, block *flow.Block) {
-	parentExecuted, err := state.IsBlockExecuted(
-		context.Background(),
-		es,
+	parentExecuted, err := es.IsBlockExecuted(
+		block.Header.Height,
 		block.Header.ParentID)
 	require.NoError(t, err)
 	require.True(t, parentExecuted, "parent block not executed")

--- a/engine/execution/ingestion/stop/stop_control.go
+++ b/engine/execution/ingestion/stop/stop_control.go
@@ -493,7 +493,7 @@ func (s *StopControl) blockFinalized(
 		Msgf("Found ID of the block that should be executed last")
 
 	// check if the parent block has been executed then stop right away
-	executed, err := state.IsBlockExecuted(ctx, s.exeState, h.ParentID)
+	executed, err := s.exeState.IsBlockExecuted(h.Height, h.ParentID)
 	if err != nil {
 		handleErr(fmt.Errorf(
 			"failed to check if the block has been executed: %w",

--- a/engine/execution/ingestion/stop/stop_control.go
+++ b/engine/execution/ingestion/stop/stop_control.go
@@ -493,7 +493,7 @@ func (s *StopControl) blockFinalized(
 		Msgf("Found ID of the block that should be executed last")
 
 	// check if the parent block has been executed then stop right away
-	executed, err := s.exeState.IsBlockExecuted(h.Height-1, h.ParentID)
+	executed, err := state.IsParentExecuted(s.exeState, h)
 	if err != nil {
 		handleErr(fmt.Errorf(
 			"failed to check if the block has been executed: %w",

--- a/engine/execution/ingestion/stop/stop_control.go
+++ b/engine/execution/ingestion/stop/stop_control.go
@@ -493,7 +493,7 @@ func (s *StopControl) blockFinalized(
 		Msgf("Found ID of the block that should be executed last")
 
 	// check if the parent block has been executed then stop right away
-	executed, err := s.exeState.IsBlockExecuted(h.Height, h.ParentID)
+	executed, err := s.exeState.IsBlockExecuted(h.Height-1, h.ParentID)
 	if err != nil {
 		handleErr(fmt.Errorf(
 			"failed to check if the block has been executed: %w",

--- a/engine/execution/ingestion/stop/stop_control_test.go
+++ b/engine/execution/ingestion/stop/stop_control_test.go
@@ -92,7 +92,7 @@ func TestCannotSetNewValuesAfterStoppingCommenced(t *testing.T) {
 		require.Equal(t, stop, sc.GetStopParameters())
 
 		// make execution check pretends block has been executed
-		execState.On("StateCommitmentByBlockID", testifyMock.Anything, testifyMock.Anything).Return(nil, nil)
+		execState.On("StateCommitmentByBlockID", testifyMock.Anything).Return(nil, nil)
 
 		// no stopping has started yet, block below stop height
 		header := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(20))
@@ -146,7 +146,7 @@ func TestExecutionFallingBehind(t *testing.T) {
 	require.Equal(t, stop, sc.GetStopParameters())
 
 	execState.
-		On("StateCommitmentByBlockID", testifyMock.Anything, headerC.ParentID).
+		On("StateCommitmentByBlockID", headerC.ParentID).
 		Return(nil, storage.ErrNotFound)
 
 	// finalize blocks first
@@ -215,7 +215,7 @@ func TestAddStopForPastBlocks(t *testing.T) {
 
 	// block is executed
 	execState.
-		On("StateCommitmentByBlockID", testifyMock.Anything, headerD.ParentID).
+		On("StateCommitmentByBlockID", headerD.ParentID).
 		Return(nil, nil)
 
 	// set stop at 22, but finalization and execution is at 23
@@ -262,7 +262,7 @@ func TestAddStopForPastBlocksExecutionFallingBehind(t *testing.T) {
 	)
 
 	execState.
-		On("StateCommitmentByBlockID", testifyMock.Anything, headerD.ParentID).
+		On("StateCommitmentByBlockID", headerD.ParentID).
 		Return(nil, storage.ErrNotFound)
 
 	// finalize blocks first
@@ -318,7 +318,7 @@ func TestStopControlWithVersionControl(t *testing.T) {
 
 		// setting this means all finalized blocks are considered already executed
 		execState.
-			On("StateCommitmentByBlockID", testifyMock.Anything, headerC.ParentID).
+			On("StateCommitmentByBlockID", headerC.ParentID).
 			Return(nil, nil)
 
 		versionBeacons.
@@ -743,7 +743,6 @@ func Test_StopControlWorkers(t *testing.T) {
 		execState := mock.NewExecutionState(t)
 		execState.On(
 			"StateCommitmentByBlockID",
-			testifyMock.Anything,
 			headerA.ID(),
 		).Return(flow.StateCommitment{}, nil).
 			Once()
@@ -819,7 +818,6 @@ func Test_StopControlWorkers(t *testing.T) {
 		execState := mock.NewExecutionState(t)
 		execState.On(
 			"StateCommitmentByBlockID",
-			testifyMock.Anything,
 			headerB.ID(),
 		).Return(flow.StateCommitment{}, nil).
 			Once()

--- a/engine/execution/ingestion/stop/stop_control_test.go
+++ b/engine/execution/ingestion/stop/stop_control_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/state/mock"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/storage"
 	storageMock "github.com/onflow/flow-go/storage/mock"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -92,7 +91,7 @@ func TestCannotSetNewValuesAfterStoppingCommenced(t *testing.T) {
 		require.Equal(t, stop, sc.GetStopParameters())
 
 		// make execution check pretends block has been executed
-		execState.On("StateCommitmentByBlockID", testifyMock.Anything).Return(nil, nil)
+		execState.On("IsBlockExecuted", testifyMock.Anything, testifyMock.Anything).Return(true, nil)
 
 		// no stopping has started yet, block below stop height
 		header := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(20))
@@ -145,9 +144,7 @@ func TestExecutionFallingBehind(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, stop, sc.GetStopParameters())
 
-	execState.
-		On("StateCommitmentByBlockID", headerC.ParentID).
-		Return(nil, storage.ErrNotFound)
+	execState.On("IsBlockExecuted", headerC.Height-1, headerC.ParentID).Return(false, nil)
 
 	// finalize blocks first
 	sc.BlockFinalizedForTesting(headerA)
@@ -214,9 +211,7 @@ func TestAddStopForPastBlocks(t *testing.T) {
 	sc.OnBlockExecuted(headerC)
 
 	// block is executed
-	execState.
-		On("StateCommitmentByBlockID", headerD.ParentID).
-		Return(nil, nil)
+	execState.On("IsBlockExecuted", headerD.Height-1, headerD.ParentID).Return(true, nil)
 
 	// set stop at 22, but finalization and execution is at 23
 	// so stop right away
@@ -261,9 +256,7 @@ func TestAddStopForPastBlocksExecutionFallingBehind(t *testing.T) {
 		false,
 	)
 
-	execState.
-		On("StateCommitmentByBlockID", headerD.ParentID).
-		Return(nil, storage.ErrNotFound)
+	execState.On("IsBlockExecuted", headerD.Height-1, headerD.ParentID).Return(false, nil)
 
 	// finalize blocks first
 	sc.BlockFinalizedForTesting(headerA)
@@ -317,9 +310,7 @@ func TestStopControlWithVersionControl(t *testing.T) {
 		)
 
 		// setting this means all finalized blocks are considered already executed
-		execState.
-			On("StateCommitmentByBlockID", headerC.ParentID).
-			Return(nil, nil)
+		execState.On("IsBlockExecuted", headerC.Height-1, headerC.ParentID).Return(true, nil)
 
 		versionBeacons.
 			On("Highest", testifyMock.Anything).
@@ -741,11 +732,8 @@ func Test_StopControlWorkers(t *testing.T) {
 			Once()
 
 		execState := mock.NewExecutionState(t)
-		execState.On(
-			"StateCommitmentByBlockID",
-			headerA.ID(),
-		).Return(flow.StateCommitment{}, nil).
-			Once()
+
+		execState.On("IsBlockExecuted", headerA.Height, headerA.ID()).Return(true, nil).Once()
 
 		headers := &stopControlMockHeaders{
 			headers: map[uint64]*flow.Header{
@@ -816,11 +804,7 @@ func Test_StopControlWorkers(t *testing.T) {
 			Once()
 
 		execState := mock.NewExecutionState(t)
-		execState.On(
-			"StateCommitmentByBlockID",
-			headerB.ID(),
-		).Return(flow.StateCommitment{}, nil).
-			Once()
+		execState.On("IsBlockExecuted", headerB.Height, headerB.ID()).Return(true, nil).Once()
 
 		headers := &stopControlMockHeaders{
 			headers: map[uint64]*flow.Header{

--- a/engine/execution/state/mock/execution_state.go
+++ b/engine/execution/state/mock/execution_state.go
@@ -152,6 +152,30 @@ func (_m *ExecutionState) HasState(_a0 flow.StateCommitment) bool {
 	return r0
 }
 
+// IsBlockExecuted provides a mock function with given fields: height, blockID
+func (_m *ExecutionState) IsBlockExecuted(height uint64, blockID flow.Identifier) (bool, error) {
+	ret := _m.Called(height, blockID)
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint64, flow.Identifier) (bool, error)); ok {
+		return rf(height, blockID)
+	}
+	if rf, ok := ret.Get(0).(func(uint64, flow.Identifier) bool); ok {
+		r0 = rf(height, blockID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(uint64, flow.Identifier) error); ok {
+		r1 = rf(height, blockID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewStorageSnapshot provides a mock function with given fields: commit, blockID, height
 func (_m *ExecutionState) NewStorageSnapshot(commit flow.StateCommitment, blockID flow.Identifier, height uint64) snapshot.StorageSnapshot {
 	ret := _m.Called(commit, blockID, height)
@@ -182,25 +206,25 @@ func (_m *ExecutionState) SaveExecutionResults(ctx context.Context, result *exec
 	return r0
 }
 
-// StateCommitmentByBlockID provides a mock function with given fields: _a0, _a1
-func (_m *ExecutionState) StateCommitmentByBlockID(_a0 context.Context, _a1 flow.Identifier) (flow.StateCommitment, error) {
-	ret := _m.Called(_a0, _a1)
+// StateCommitmentByBlockID provides a mock function with given fields: _a0
+func (_m *ExecutionState) StateCommitmentByBlockID(_a0 flow.Identifier) (flow.StateCommitment, error) {
+	ret := _m.Called(_a0)
 
 	var r0 flow.StateCommitment
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) (flow.StateCommitment, error)); ok {
-		return rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(flow.Identifier) (flow.StateCommitment, error)); ok {
+		return rf(_a0)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) flow.StateCommitment); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(flow.Identifier) flow.StateCommitment); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(flow.StateCommitment)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, flow.Identifier) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(flow.Identifier) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/engine/execution/state/mock/read_only_execution_state.go
+++ b/engine/execution/state/mock/read_only_execution_state.go
@@ -150,6 +150,30 @@ func (_m *ReadOnlyExecutionState) HasState(_a0 flow.StateCommitment) bool {
 	return r0
 }
 
+// IsBlockExecuted provides a mock function with given fields: height, blockID
+func (_m *ReadOnlyExecutionState) IsBlockExecuted(height uint64, blockID flow.Identifier) (bool, error) {
+	ret := _m.Called(height, blockID)
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint64, flow.Identifier) (bool, error)); ok {
+		return rf(height, blockID)
+	}
+	if rf, ok := ret.Get(0).(func(uint64, flow.Identifier) bool); ok {
+		r0 = rf(height, blockID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(uint64, flow.Identifier) error); ok {
+		r1 = rf(height, blockID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewStorageSnapshot provides a mock function with given fields: commit, blockID, height
 func (_m *ReadOnlyExecutionState) NewStorageSnapshot(commit flow.StateCommitment, blockID flow.Identifier, height uint64) snapshot.StorageSnapshot {
 	ret := _m.Called(commit, blockID, height)
@@ -166,25 +190,25 @@ func (_m *ReadOnlyExecutionState) NewStorageSnapshot(commit flow.StateCommitment
 	return r0
 }
 
-// StateCommitmentByBlockID provides a mock function with given fields: _a0, _a1
-func (_m *ReadOnlyExecutionState) StateCommitmentByBlockID(_a0 context.Context, _a1 flow.Identifier) (flow.StateCommitment, error) {
-	ret := _m.Called(_a0, _a1)
+// StateCommitmentByBlockID provides a mock function with given fields: _a0
+func (_m *ReadOnlyExecutionState) StateCommitmentByBlockID(_a0 flow.Identifier) (flow.StateCommitment, error) {
+	ret := _m.Called(_a0)
 
 	var r0 flow.StateCommitment
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) (flow.StateCommitment, error)); ok {
-		return rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(flow.Identifier) (flow.StateCommitment, error)); ok {
+		return rf(_a0)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) flow.StateCommitment); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(flow.Identifier) flow.StateCommitment); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(flow.StateCommitment)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, flow.Identifier) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(flow.Identifier) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/engine/execution/state/mock/script_execution_state.go
+++ b/engine/execution/state/mock/script_execution_state.go
@@ -3,8 +3,6 @@
 package mock
 
 import (
-	context "context"
-
 	flow "github.com/onflow/flow-go/model/flow"
 	mock "github.com/stretchr/testify/mock"
 
@@ -65,6 +63,30 @@ func (_m *ScriptExecutionState) HasState(_a0 flow.StateCommitment) bool {
 	return r0
 }
 
+// IsBlockExecuted provides a mock function with given fields: height, blockID
+func (_m *ScriptExecutionState) IsBlockExecuted(height uint64, blockID flow.Identifier) (bool, error) {
+	ret := _m.Called(height, blockID)
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint64, flow.Identifier) (bool, error)); ok {
+		return rf(height, blockID)
+	}
+	if rf, ok := ret.Get(0).(func(uint64, flow.Identifier) bool); ok {
+		r0 = rf(height, blockID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(uint64, flow.Identifier) error); ok {
+		r1 = rf(height, blockID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewStorageSnapshot provides a mock function with given fields: commit, blockID, height
 func (_m *ScriptExecutionState) NewStorageSnapshot(commit flow.StateCommitment, blockID flow.Identifier, height uint64) snapshot.StorageSnapshot {
 	ret := _m.Called(commit, blockID, height)
@@ -81,25 +103,25 @@ func (_m *ScriptExecutionState) NewStorageSnapshot(commit flow.StateCommitment, 
 	return r0
 }
 
-// StateCommitmentByBlockID provides a mock function with given fields: _a0, _a1
-func (_m *ScriptExecutionState) StateCommitmentByBlockID(_a0 context.Context, _a1 flow.Identifier) (flow.StateCommitment, error) {
-	ret := _m.Called(_a0, _a1)
+// StateCommitmentByBlockID provides a mock function with given fields: _a0
+func (_m *ScriptExecutionState) StateCommitmentByBlockID(_a0 flow.Identifier) (flow.StateCommitment, error) {
+	ret := _m.Called(_a0)
 
 	var r0 flow.StateCommitment
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) (flow.StateCommitment, error)); ok {
-		return rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(flow.Identifier) (flow.StateCommitment, error)); ok {
+		return rf(_a0)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, flow.Identifier) flow.StateCommitment); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(flow.Identifier) flow.StateCommitment); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(flow.StateCommitment)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, flow.Identifier) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(flow.Identifier) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -463,6 +463,8 @@ func (s *state) GetHighestExecutedBlockID(ctx context.Context) (uint64, flow.Ide
 // results, etc are all stored.
 // otherwise returns false
 func (s *state) IsBlockExecuted(height uint64, blockID flow.Identifier) (bool, error) {
+	// ledger-based execution state uses commitment to determine if a block has been executed
+	// TODO: storehouse-based execution state will check its storage to determine if a block has been executed
 	_, err := s.StateCommitmentByBlockID(blockID)
 
 	// statecommitment exists means the block has been executed


### PR DESCRIPTION
Working towards #4998 

This PR moves the IsBlockExecuted to execution state struct, so that we can provide different implementation for ledger-based storage or storehouse-based storage.