### PR TITLE
[EVM] Fix the setup process

### DIFF
--- a/fvm/transactionInvoker.go
+++ b/fvm/transactionInvoker.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/onflow/flow-go/fvm/evm"
-
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/rs/zerolog"
@@ -14,6 +12,7 @@ import (
 
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/evm"
 	reusableRuntime "github.com/onflow/flow-go/fvm/runtime"
 	"github.com/onflow/flow-go/fvm/storage"
 	"github.com/onflow/flow-go/fvm/storage/derived"


### PR DESCRIPTION
Closes: #5068 

This PR fixes an issue with EVM setup. It moves the setup in the preprocess of the transaction invoker, since the Cadence env needs to have `EVMInternal` values set during the preprocess as it loads the transaction program and the checker fails otherwise. 