### PR TITLE
[Access] Fix race condition in connection cache

### DIFF
--- a/engine/access/rpc/connection/cache.go
+++ b/engine/access/rpc/connection/cache.go
@@ -22,13 +22,15 @@ type CachedClient struct {
 // Close closes the CachedClient connection. It marks the connection for closure and waits asynchronously for ongoing
 // requests to complete before closing the connection.
 func (cc *CachedClient) Close() {
+	cc.mu.Lock()
+
 	// Mark the connection for closure
+	// Note: this must be called within the lock since it is initialized after inserting into the cache
 	if !cc.closeRequested.CompareAndSwap(false, true) {
+		cc.mu.Unlock()
 		return
 	}
 
-	// Obtain the lock to ensure that any connection attempts have completed
-	cc.mu.Lock()
 	conn := cc.ClientConn
 	cc.mu.Unlock()
 


### PR DESCRIPTION
Access nodes crashed with the following stack trace after the HCU on devnet:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1d8aec6]
goroutine 16851798 [running]:
go.uber.org/atomic.(*Bool).CompareAndSwap(...)
	/go/pkg/mod/go.uber.org/atomic@v1.11.0/bool.go:66
github.com/onflow/flow-go/engine/access/rpc/connection.(*CachedClient).Close(0xc09bfd5080?)
	/app/engine/access/rpc/connection/cache.go:26 +0x26
created by github.com/onflow/flow-go/engine/access/rpc/backend.NewCache.func1
	/app/engine/access/rpc/backend/backend.go:229 +0x76
```

This is caused by 2 race conditions in the connection cache.
1. When a connection fails because the backend is unavailable, it is removed from the cache, and the connection is torn down. However, the connection is looked up in the cache by the backend's address, so it's possible that a different goroutine has already removed and recreated the connection for that server.
2. When a new connection is added to the cache, it is added as an empty struct with its lock held. This allows an atomic `GetOrAdd` operation with minimal overhead. After the client is added, fields like the `closeRequested` are set. In the `Close()` method, the `closeRequested` value was checked outside of the lock, resulting in a segfault.

`1` by itself would just result in temporary trashing as the connection is torn down multiple times until it stabilizes. When combined with `2` it causes crashes each time that thrashing occurs.

This PR fixes `2`. `1` is tracked in a separate issue (https://github.com/onflow/flow-go/issues/5074)