### PR TITLE
[Access] add config to limit script execution range

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -147,6 +148,8 @@ type AccessNodeConfig struct {
 	registersDBPath              string
 	checkpointFile               string
 	scriptExecutorConfig         query.QueryConfig
+	scriptExecMinBlock           uint64
+	scriptExecMaxBlock           uint64
 }
 
 type PublicNetworkConfig struct {
@@ -234,6 +237,8 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		registersDBPath:              filepath.Join(homedir, ".flow", "execution_state"),
 		checkpointFile:               cmd.NotSet,
 		scriptExecutorConfig:         query.NewDefaultConfig(),
+		scriptExecMinBlock:           0,
+		scriptExecMaxBlock:           math.MaxUint64,
 	}
 }
 
@@ -935,6 +940,8 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 		flags.IntVar(&builder.scriptExecutorConfig.MaxErrorMessageSize, "script-execution-max-error-length", defaultConfig.scriptExecutorConfig.MaxErrorMessageSize, "maximum number characters to include in error message strings. additional characters are truncated. default: 1000")
 		flags.DurationVar(&builder.scriptExecutorConfig.LogTimeThreshold, "script-execution-log-time-threshold", defaultConfig.scriptExecutorConfig.LogTimeThreshold, "emit a log for any scripts that take over this threshold. default: 1s")
 		flags.DurationVar(&builder.scriptExecutorConfig.ExecutionTimeLimit, "script-execution-timeout", defaultConfig.scriptExecutorConfig.ExecutionTimeLimit, "timeout value for locally executed scripts. default: 10s")
+		flags.Uint64Var(&builder.scriptExecMinBlock, "script-execution-min-height", defaultConfig.scriptExecMinBlock, "lowest block height to allow for script execution. default: no limit")
+		flags.Uint64Var(&builder.scriptExecMaxBlock, "script-execution-max-height", defaultConfig.scriptExecMaxBlock, "highest block height to allow for script execution. default: no limit")
 
 	}).ValidateFlags(func() error {
 		if builder.supportsObserver && (builder.PublicNetworkConfig.BindAddress == cmd.NotSet || builder.PublicNetworkConfig.BindAddress == "") {
@@ -1241,6 +1248,8 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 		}).
 		Module("backend script executor", func(node *cmd.NodeConfig) error {
 			builder.ScriptExecutor = backend.NewScriptExecutor()
+			builder.ScriptExecutor.SetMinExecutableHeight(builder.scriptExecMinBlock)
+			builder.ScriptExecutor.SetMaxExecutableHeight(builder.scriptExecMaxBlock)
 			return nil
 		}).
 		Component("RPC engine", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {


### PR DESCRIPTION
Limit the block range an AN will use for executing scripts and getting accounts when configured to use local data.

This is a stop-gap solution for node upgrades before https://github.com/onflow/flow-go/issues/5040 is completed.

Usage:

When a cadence/fvm upgrade is planned: after the stop height is known and before it is reached, add the `--script-execution-min-height` flag passing the stop height and update the AN to the new version. This will cause the AN to stop locally executing scripts for any height below the stop height.

When running a "historic" node, set
* `--script-execution-min-height` to the first block supported by the current version
* `--script-execution-max-height` to the last block supported by the current version
The node will then locally execute scripts for blocks between the heights (inclusive), and fall back to ENs for the rest.