### PR TITLE
[Networking] Fixing flakey TestGossipSubSpamMitigationIntegration

### DIFF
--- a/insecure/integration/functional/test/gossipsub/rpc_inspector/validation_inspector_test.go
+++ b/insecure/integration/functional/test/gossipsub/rpc_inspector/validation_inspector_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/flow-go/network/p2p/inspector/validation"
 	p2pmsg "github.com/onflow/flow-go/network/p2p/message"
 	mockp2p "github.com/onflow/flow-go/network/p2p/mock"
+	"github.com/onflow/flow-go/network/p2p/scoring"
 	p2ptest "github.com/onflow/flow-go/network/p2p/test"
 	"github.com/onflow/flow-go/utils/unittest"
 )
@@ -1041,6 +1042,7 @@ func TestGossipSubSpamMitigationIntegration(t *testing.T) {
 		sporkID,
 		t.Name(),
 		idProvider,
+		p2ptest.WithPeerScoreTracerInterval(100*time.Millisecond),
 		p2ptest.WithRole(flow.RoleConsensus),
 		p2ptest.EnablePeerScoringWithOverride(p2p.PeerScoringConfigNoOverride))
 
@@ -1066,8 +1068,8 @@ func TestGossipSubSpamMitigationIntegration(t *testing.T) {
 		}
 	})
 
-	spamRpcCount := 10            // total number of individual rpc messages to send
-	spamCtrlMsgCount := int64(10) // total number of control messages to send on each RPC
+	spamRpcCount := 100            // total number of individual rpc messages to send
+	spamCtrlMsgCount := int64(100) // total number of control messages to send on each RPC
 
 	// unknownTopic is an unknown topic to the victim node but shaped like a valid topic (i.e., it has the correct prefix and spork ID).
 	unknownTopic := channels.Topic(fmt.Sprintf("%s/%s", p2ptest.GossipSubTopicIdFixture(), sporkID))
@@ -1119,7 +1121,10 @@ func TestGossipSubSpamMitigationIntegration(t *testing.T) {
 	spammer.SpamControlMessage(t, victimNode, pruneCtlMsgsDuplicateTopic)
 
 	// wait for three GossipSub heartbeat intervals to ensure that the victim node has penalized the spammer node.
-	time.Sleep(3 * time.Second)
+	require.Eventually(t, func() bool {
+		score, ok := victimNode.PeerScoreExposer().GetScore(spammer.SpammerNode.ID())
+		return ok && score < 2*scoring.DefaultGraylistThreshold
+	}, 5*time.Second, 100*time.Millisecond, "expected victim node to penalize spammer node")
 
 	// now we expect the detection and mitigation to kick in and the victim node to disconnect from the spammer node.
 	// so the spammer and victim nodes should not be able to exchange messages on the topic.

--- a/network/p2p/distributor/gossipsub_inspector.go
+++ b/network/p2p/distributor/gossipsub_inspector.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/module/mempool/queue"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/network/p2p"
+	"github.com/onflow/flow-go/network/p2p/p2plogging"
 )
 
 const (
@@ -80,10 +81,12 @@ func NewGossipSubInspectorNotificationDistributor(log zerolog.Logger, store engi
 // The distribution is done asynchronously and non-blocking. The notification is added to a queue and processed by a worker pool.
 // DistributeEvent in this implementation does not return an error, but it logs a warning if the queue is full.
 func (g *GossipSubInspectorNotifDistributor) Distribute(notification *p2p.InvCtrlMsgNotif) error {
+	lg := g.logger.With().Str("peer_id", p2plogging.PeerId(notification.PeerID)).Logger()
 	if ok := g.workerPool.Submit(notification); !ok {
 		// we use a queue with a fixed size, so this can happen when queue is full or when the notification is duplicate.
-		g.logger.Warn().Msg("gossipsub rpc inspector notification queue is full or notification is duplicate, discarding notification")
+		lg.Warn().Msg("gossipsub rpc inspector notification queue is full or notification is duplicate, discarding notification")
 	}
+	lg.Trace().Msg("gossipsub rpc inspector notification submitted to the queue")
 	return nil
 }
 

--- a/network/p2p/scoring/registry.go
+++ b/network/p2p/scoring/registry.go
@@ -182,7 +182,7 @@ func (r *GossipSubAppSpecificScoreRegistry) AppSpecificScoreFunc() func(peer.ID)
 	return func(pid peer.ID) float64 {
 		appSpecificScore := float64(0)
 
-		lg := r.logger.With().Str("peer_id", p2plogging.PeerId(pid)).Logger()
+		lg := r.logger.With().Str("remote_peer_id", p2plogging.PeerId(pid)).Logger()
 		// (1) spam penalty: the penalty is applied to the application specific penalty when a peer conducts a spamming misbehaviour.
 		spamRecord, err, spamRecordExists := r.spamScoreCache.Get(pid)
 		if err != nil {
@@ -224,7 +224,7 @@ func (r *GossipSubAppSpecificScoreRegistry) AppSpecificScoreFunc() func(peer.ID)
 			appSpecificScore += stakingScore
 		}
 
-		lg.Trace().
+		lg.Debug().
 			Float64("total_app_specific_score", appSpecificScore).
 			Msg("application specific penalty computed")
 

--- a/network/p2p/test/fixtures.go
+++ b/network/p2p/test/fixtures.go
@@ -84,7 +84,7 @@ func NodeFixture(t *testing.T,
 	defaultFlowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
 
-	logger := unittest.Logger().Level(zerolog.WarnLevel)
+	logger := unittest.Logger()
 	require.NotNil(t, idProvider)
 	connectionGater := NewConnectionGater(idProvider, func(p peer.ID) error {
 		return nil
@@ -116,7 +116,7 @@ func NodeFixture(t *testing.T,
 			Metrics:          metrics.NewNoopCollector(),
 		},
 		ResourceManager:                  &network.NullResourceManager{},
-		GossipSubPeerScoreTracerInterval: 0, // disabled by default
+		GossipSubPeerScoreTracerInterval: defaultFlowConfig.NetworkConfig.GossipSubConfig.ScoreTracerInterval,
 		ConnGater:                        connectionGater,
 		PeerManagerConfig:                PeerManagerConfigFixture(), // disabled by default
 		FlowConfig:                       defaultFlowConfig,
@@ -140,7 +140,8 @@ func NodeFixture(t *testing.T,
 	require.NoError(t, err)
 
 	builder := p2pbuilder.NewNodeBuilder(
-		logger, parameters.MetricsCfg,
+		logger,
+		parameters.MetricsCfg,
 		parameters.NetworkingType,
 		parameters.Address,
 		parameters.Key,


### PR DESCRIPTION
This PR fixes the flakey behavior with `TestGossipSubSpamMitigationIntegration`. 

**Test scenario**:
The test assesses the comprehensive effectiveness of our GossipSub control message spam mitigation system. It initiates with a spammer, representing an attacker, bombarding a victim node through various control message spam attacks. The expectation is for the victim's RPC inspector module to detect these attacks and report them to the GossipSub score registry. The registry, in turn, penalizes the spammer based on the GossipSub's application-specific score. The severity of the attack is calibrated to be high, ensuring that the spammer's penalty eventually crosses the graylisting threshold. This results in the suppression of all GossipSub RPC exchanges between the spammer and the victim.

**Flakiness root cause**:
At the test's conclusion, we scrutinize the GossipSub RPC interactions between spammer and victim, focusing on the absence of pubsub message exchange. This absence suggests the victim has penalized the spammer. However, previously, the test hurriedly assessed the pubsub exchange capability without confirming if the penalty was substantial enough for graylisting. Given the 5-second timeout to verify pubsub exchange disruption, the spammer's penalty could diminish to a level where it regains pubsub exchange capabilities with the victim. This could lead to inconsistent test outcomes.

**Fix implemented in this PR**:
To address the issue, this PR implements two key changes:
1. Enhanced test logic to verify the spammer's penalty value before evaluating pubsub message exchange. Specifically, the threshold is set at double the graylisting threshold. This ensures that when assessing the pubsub message exchange between the spammer and victim, the spammer's penalty is sufficiently high. This approach counters the natural decay of the GossipSub score registry, especially considering the 5-second timeout for assessing pubsub message exchange health.
2. The attack load in the test has been increased tenfold. This amplification ensures the spammer's penalty value significantly falls below the graylisting threshold.

To confirm the test's resolution, we execute it in four sets, each consisting of 20 consecutive runs, implementing a fail-fast approach. This means if any single execution in a set fails, the whole set is terminated. Success is determined by the test completing all 80 runs without failure.

```
go test -v -run TestGossipSubSpamMitigationIntegration github.com/onflow/flow-go/insecure/integration/functional/test/gossipsub/rpc_inspector -count 20 -failfast --tags=relic

PASS
ok      github.com/onflow/flow-go/insecure/integration/functional/test/gossipsub/rpc_inspector  266.765s

PASS
ok      github.com/onflow/flow-go/insecure/integration/functional/test/gossipsub/rpc_inspector  266.704s

PASS
ok      github.com/onflow/flow-go/insecure/integration/functional/test/gossipsub/rpc_inspector  266.763s

PASS
ok      github.com/onflow/flow-go/insecure/integration/functional/test/gossipsub/rpc_inspector  267.313s
```