### PR TITLE
Migrate payloads by reference

### DIFF
--- a/ledger/common/pathfinder/pathfinder.go
+++ b/ledger/common/pathfinder/pathfinder.go
@@ -97,7 +97,7 @@ func PayloadsToValues(payloads []*ledger.Payload) ([]ledger.Value, error) {
 }
 
 // PathsFromPayloads constructs paths from an slice of payload
-func PathsFromPayloads(payloads []ledger.Payload, version uint8) ([]ledger.Path, error) {
+func PathsFromPayloads(payloads []*ledger.Payload, version uint8) ([]ledger.Path, error) {
 	paths := make([]ledger.Path, len(payloads))
 	for i, pay := range payloads {
 		k, err := pay.Key()

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -362,7 +362,7 @@ func (l *Ledger) MigrateAt(
 			fmt.Errorf("failed to clean up tries to reduce memory usage: %w", err)
 	}
 
-	var payloads []ledger.Payload
+	var payloads []*ledger.Payload
 	var newTrie *trie.MTrie
 
 	noMigration := len(migrations) == 0
@@ -413,9 +413,14 @@ func (l *Ledger) MigrateAt(
 
 		emptyTrie := trie.NewEmptyMTrie()
 
+		derefPayloads := make([]ledger.Payload, len(payloads))
+		for i, p := range payloads {
+			derefPayloads[i] = *p
+		}
+
 		// no need to prune the data since it has already been prunned through migrations
 		applyPruning := false
-		newTrie, _, err = trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, payloads, applyPruning)
+		newTrie, _, err = trie.NewTrieWithUpdatedRegisters(emptyTrie, paths, derefPayloads, applyPruning)
 		if err != nil {
 			return nil, fmt.Errorf("constructing updated trie failed: %w", err)
 		}

--- a/ledger/complete/mtrie/node/node.go
+++ b/ledger/complete/mtrie/node/node.go
@@ -253,18 +253,18 @@ func (n *Node) FmtStr(prefix string, subpath string) string {
 }
 
 // AllPayloads returns the payload of this node and all payloads of the subtrie
-func (n *Node) AllPayloads() []ledger.Payload {
-	return n.appendSubtreePayloads([]ledger.Payload{})
+func (n *Node) AllPayloads() []*ledger.Payload {
+	return n.appendSubtreePayloads([]*ledger.Payload{})
 }
 
 // appendSubtreePayloads appends the payloads of the subtree with this node as root
 // to the provided Payload slice. Follows same pattern as Go's native append method.
-func (n *Node) appendSubtreePayloads(result []ledger.Payload) []ledger.Payload {
+func (n *Node) appendSubtreePayloads(result []*ledger.Payload) []*ledger.Payload {
 	if n == nil {
 		return result
 	}
 	if n.IsLeaf() {
-		return append(result, *n.Payload())
+		return append(result, n.Payload())
 	}
 	result = n.lChild.appendSubtreePayloads(result)
 	result = n.rChild.appendSubtreePayloads(result)

--- a/ledger/complete/mtrie/trie/trie.go
+++ b/ledger/complete/mtrie/trie/trie.go
@@ -748,7 +748,7 @@ func EmptyTrieRootHash() ledger.RootHash {
 }
 
 // AllPayloads returns all payloads
-func (mt *MTrie) AllPayloads() []ledger.Payload {
+func (mt *MTrie) AllPayloads() []*ledger.Payload {
 	return mt.root.AllPayloads()
 }
 

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -343,11 +343,11 @@ func TestWriteAndReadCheckpointV6LeafSimpleTrie(t *testing.T) {
 			err := OpenAndReadLeafNodesFromCheckpointV6(leafNodesCh, dir, fileName, logger)
 			require.NoErrorf(t, err, "fail to read checkpoint %v/%v", dir, fileName)
 		}()
-		resultPayloads := make([]ledger.Payload, 0)
+		resultPayloads := make([]*ledger.Payload, 0)
 		for leafNode := range leafNodesCh {
 			// avoid dummy payload from empty trie
 			if leafNode.Payload != nil {
-				resultPayloads = append(resultPayloads, *leafNode.Payload)
+				resultPayloads = append(resultPayloads, leafNode.Payload)
 			}
 		}
 		require.EqualValues(t, tries[1].AllPayloads(), resultPayloads)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -387,7 +387,7 @@ func (v *Value) UnmarshalJSON(b []byte) error {
 }
 
 // Migration defines how to convert the given slice of input payloads into an slice of output payloads
-type Migration func(payloads []Payload) ([]Payload, error)
+type Migration func(payloads []*Payload) ([]*Payload, error)
 
 // Reporter reports on data from the state
 type Reporter interface {

--- a/ledger/mock/migration.go
+++ b/ledger/mock/migration.go
@@ -13,23 +13,23 @@ type Migration struct {
 }
 
 // Execute provides a mock function with given fields: payloads
-func (_m *Migration) Execute(payloads []ledger.Payload) ([]ledger.Payload, error) {
+func (_m *Migration) Execute(payloads []*ledger.Payload) ([]*ledger.Payload, error) {
 	ret := _m.Called(payloads)
 
-	var r0 []ledger.Payload
+	var r0 []*ledger.Payload
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]ledger.Payload) ([]ledger.Payload, error)); ok {
+	if rf, ok := ret.Get(0).(func([]*ledger.Payload) ([]*ledger.Payload, error)); ok {
 		return rf(payloads)
 	}
-	if rf, ok := ret.Get(0).(func([]ledger.Payload) []ledger.Payload); ok {
+	if rf, ok := ret.Get(0).(func([]*ledger.Payload) []*ledger.Payload); ok {
 		r0 = rf(payloads)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]ledger.Payload)
+			r0 = ret.Get(0).([]*ledger.Payload)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]ledger.Payload) error); ok {
+	if rf, ok := ret.Get(1).(func([]*ledger.Payload) error); ok {
 		r1 = rf(payloads)
 	} else {
 		r1 = ret.Error(1)


### PR DESCRIPTION
Switch migrations to migrate payloads by reference, to reduce memory usage.