### PR TITLE
[Ledger] Refactor NewRegisterID to accept address

### DIFF
--- a/cmd/util/ledger/migrations/storage_fees_migration.go
+++ b/cmd/util/ledger/migrations/storage_fees_migration.go
@@ -25,7 +25,7 @@ func StorageFeesMigration(payload []ledger.Payload) ([]ledger.Payload, error) {
 	for s, u := range storageUsed {
 		// this is the storage used by the storage_used register we are about to add
 		id := flow.NewRegisterID(
-			string(flow.BytesToAddress([]byte(s)).Bytes()),
+			flow.BytesToAddress([]byte(s)),
 			"storage_used")
 		storageUsedByStorageUsed := fvm.RegisterSize(id, make([]byte, 8))
 		u = u + uint64(storageUsedByStorageUsed)

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -22,7 +22,7 @@ var _ atree.Ledger = &AccountsAtreeLedger{}
 func (a *AccountsAtreeLedger) GetValue(owner, key []byte) ([]byte, error) {
 	v, err := a.Accounts.GetValue(
 		flow.NewRegisterID(
-			string(flow.BytesToAddress(owner).Bytes()),
+			flow.BytesToAddress(owner),
 			string(key)))
 	if err != nil {
 		return nil, fmt.Errorf("getting value failed: %w", err)
@@ -33,7 +33,7 @@ func (a *AccountsAtreeLedger) GetValue(owner, key []byte) ([]byte, error) {
 func (a *AccountsAtreeLedger) SetValue(owner, key, value []byte) error {
 	err := a.Accounts.SetValue(
 		flow.NewRegisterID(
-			string(flow.BytesToAddress(owner).Bytes()),
+			flow.BytesToAddress(owner),
 			string(key)),
 		value)
 	if err != nil {

--- a/cmd/util/ledger/reporters/atree_reporter.go
+++ b/cmd/util/ledger/reporters/atree_reporter.go
@@ -117,7 +117,7 @@ func getPayloadType(p *ledger.Payload) (payloadType, error) {
 	}
 
 	id := flow.NewRegisterID(
-		string(k.KeyParts[0].Value),
+		flow.BytesToAddress(k.KeyParts[0].Value),
 		string(k.KeyParts[1].Value))
 	if id.IsInternalState() {
 		return fvmPayloadType, nil

--- a/cmd/util/ledger/reporters/storage_snapshot.go
+++ b/cmd/util/ledger/reporters/storage_snapshot.go
@@ -19,7 +19,7 @@ func NewStorageSnapshotFromPayload(
 		}
 
 		id := flow.NewRegisterID(
-			string(key.KeyParts[0].Value),
+			flow.BytesToAddress(key.KeyParts[0].Value),
 			string(key.KeyParts[1].Value))
 
 		snapshot[id] = entry.Value()

--- a/engine/execution/scripts/engine.go
+++ b/engine/execution/scripts/engine.go
@@ -74,7 +74,7 @@ func (e *Engine) GetRegisterAtBlockID(
 		return nil, fmt.Errorf("failed to create storage snapshot: %w", err)
 	}
 
-	id := flow.NewRegisterID(string(owner), string(key))
+	id := flow.NewRegisterID(flow.BytesToAddress(owner), string(key))
 	data, err := blockSnapshot.Get(id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the register (%s): %w", id, err)

--- a/fvm/environment/accounts.go
+++ b/fvm/environment/accounts.go
@@ -75,7 +75,7 @@ func (a *StatefulAccounts) AllocateStorageIndex(
 	key := atree.SlabIndexToLedgerKey(index)
 	a.txnState.RunWithAllLimitsDisabled(func() {
 		err = a.txnState.Set(
-			flow.NewRegisterID(string(address.Bytes()), string(key)),
+			flow.NewRegisterID(address, string(key)),
 			[]byte{})
 	})
 	if err != nil {

--- a/fvm/environment/accounts_test.go
+++ b/fvm/environment/accounts_test.go
@@ -63,7 +63,7 @@ func TestAccounts_GetPublicKey(t *testing.T) {
 
 		address := flow.HexToAddress("01")
 		registerId := flow.NewRegisterID(
-			string(address.Bytes()),
+			address,
 			"public_key_0")
 
 		for _, value := range [][]byte{{}, nil} {
@@ -88,7 +88,7 @@ func TestAccounts_GetPublicKeyCount(t *testing.T) {
 
 		address := flow.HexToAddress("01")
 		registerId := flow.NewRegisterID(
-			string(address.Bytes()),
+			address,
 			"public_key_count")
 
 		for _, value := range [][]byte{{}, nil} {
@@ -114,7 +114,7 @@ func TestAccounts_GetPublicKeys(t *testing.T) {
 
 		address := flow.HexToAddress("01")
 		registerId := flow.NewRegisterID(
-			string(address.Bytes()),
+			address,
 			"public_key_count")
 
 		for _, value := range [][]byte{{}, nil} {
@@ -243,7 +243,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := testutils.NewSimpleTransaction(nil)
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
-		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
+		key := flow.NewRegisterID(address, "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
@@ -260,7 +260,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := testutils.NewSimpleTransaction(nil)
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
-		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
+		key := flow.NewRegisterID(address, "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := testutils.NewSimpleTransaction(nil)
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
-		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
+		key := flow.NewRegisterID(address, "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := testutils.NewSimpleTransaction(nil)
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
-		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
+		key := flow.NewRegisterID(address, "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
@@ -317,7 +317,7 @@ func TestAccount_StorageUsed(t *testing.T) {
 		txnState := testutils.NewSimpleTransaction(nil)
 		accounts := environment.NewAccounts(txnState)
 		address := flow.HexToAddress("01")
-		key := flow.NewRegisterID(string(address.Bytes()), "some_key")
+		key := flow.NewRegisterID(address, "some_key")
 
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
@@ -340,19 +340,19 @@ func TestAccount_StorageUsed(t *testing.T) {
 		err := accounts.Create(nil, address)
 		require.NoError(t, err)
 
-		key1 := flow.NewRegisterID(string(address.Bytes()), "some_key")
+		key1 := flow.NewRegisterID(address, "some_key")
 		err = accounts.SetValue(key1, createByteArray(12))
 		require.NoError(t, err)
 		err = accounts.SetValue(key1, createByteArray(11))
 		require.NoError(t, err)
 
-		key2 := flow.NewRegisterID(string(address.Bytes()), "some_key2")
+		key2 := flow.NewRegisterID(address, "some_key2")
 		err = accounts.SetValue(key2, createByteArray(22))
 		require.NoError(t, err)
 		err = accounts.SetValue(key2, createByteArray(23))
 		require.NoError(t, err)
 
-		key3 := flow.NewRegisterID(string(address.Bytes()), "some_key3")
+		key3 := flow.NewRegisterID(address, "some_key3")
 		err = accounts.SetValue(key3, createByteArray(22))
 		require.NoError(t, err)
 		err = accounts.SetValue(key3, createByteArray(0))

--- a/fvm/environment/derived_data_invalidator_test.go
+++ b/fvm/environment/derived_data_invalidator_test.go
@@ -300,19 +300,21 @@ func TestMeterParamOverridesUpdated(t *testing.T) {
 	executionSnapshot, err = txnState.FinalizeMainTransaction()
 	require.NoError(t, err)
 
+	owner := ctx.Chain.ServiceAddress()
+	otherOwner := unittest.RandomAddressFixtureForChain(ctx.Chain.ChainID())
+
 	for _, registerId := range executionSnapshot.AllRegisterIDs() {
 		checkForUpdates(registerId, true)
 		checkForUpdates(
-			flow.NewRegisterID("other owner", registerId.Key),
+			flow.NewRegisterID(otherOwner, registerId.Key),
 			false)
 	}
 
-	owner := string(ctx.Chain.ServiceAddress().Bytes())
 	stabIndexKey := flow.NewRegisterID(owner, "$12345678")
 	require.True(t, stabIndexKey.IsSlabIndex())
 
 	checkForUpdates(stabIndexKey, true)
 	checkForUpdates(flow.NewRegisterID(owner, "other keys"), false)
-	checkForUpdates(flow.NewRegisterID("other owner", stabIndexKey.Key), false)
-	checkForUpdates(flow.NewRegisterID("other owner", "other key"), false)
+	checkForUpdates(flow.NewRegisterID(otherOwner, stabIndexKey.Key), false)
+	checkForUpdates(flow.NewRegisterID(otherOwner, "other key"), false)
 }

--- a/fvm/meter/meter_test.go
+++ b/fvm/meter/meter_test.go
@@ -408,7 +408,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters(),
 		)
 
-		key1 := flow.NewRegisterID("", "1")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
 
@@ -423,7 +423,7 @@ func TestStorageLimits(t *testing.T) {
 		require.Equal(t, meter1.TotalBytesReadFromStorage(), size1)
 
 		// first read of key2
-		key2 := flow.NewRegisterID("", "2")
+		key2 := flow.NewRegisterID(flow.EmptyAddress, "2")
 		val2 := []byte{0x3, 0x2, 0x1}
 		size2 := meter.GetStorageKeyValueSizeForTesting(key2, val2)
 
@@ -437,7 +437,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters(),
 		)
 
-		key1 := flow.NewRegisterID("", "1")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 
@@ -452,7 +452,7 @@ func TestStorageLimits(t *testing.T) {
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(), meter.GetStorageKeyValueSizeForTesting(key1, val2))
 
 		// first write of key2
-		key2 := flow.NewRegisterID("", "2")
+		key2 := flow.NewRegisterID(flow.EmptyAddress, "2")
 		err = meter1.MeterStorageWrite(key2, val2, false)
 		require.NoError(t, err)
 		require.Equal(t, meter1.TotalBytesWrittenToStorage(),
@@ -464,7 +464,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(1),
 		)
 
-		key1 := flow.NewRegisterID("", "1")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageRead(key1, val1, false /* not enforced */)
@@ -478,7 +478,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
 		)
 
-		key1 := flow.NewRegisterID("", "1")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageRead(key1, val1, true /* enforced */)
@@ -496,7 +496,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
 		)
 
-		key1 := flow.NewRegisterID("", "1")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageWrite(key1, val1, false /* not enforced */)
@@ -509,7 +509,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters().WithStorageInteractionLimit(testLimit),
 		)
 
-		key1 := flow.NewRegisterID("", "1")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
 		val1 := []byte{0x1, 0x2, 0x3}
 
 		err := meter1.MeterStorageWrite(key1, val1, true /* enforced */)
@@ -526,8 +526,8 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters(),
 		)
 
-		key1 := flow.NewRegisterID("", "1")
-		key2 := flow.NewRegisterID("", "2")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
+		key2 := flow.NewRegisterID(flow.EmptyAddress, "2")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
@@ -547,8 +547,8 @@ func TestStorageLimits(t *testing.T) {
 	})
 
 	t.Run("metering storage read and written - exceeding limit - not enforced", func(t *testing.T) {
-		key1 := flow.NewRegisterID("", "1")
-		key2 := flow.NewRegisterID("", "2")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
+		key2 := flow.NewRegisterID(flow.EmptyAddress, "2")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
@@ -572,8 +572,8 @@ func TestStorageLimits(t *testing.T) {
 	})
 
 	t.Run("metering storage read and written - exceeding limit - enforced", func(t *testing.T) {
-		key1 := flow.NewRegisterID("", "1")
-		key2 := flow.NewRegisterID("", "2")
+		key1 := flow.NewRegisterID(flow.EmptyAddress, "1")
+		key2 := flow.NewRegisterID(flow.EmptyAddress, "2")
 		val1 := []byte{0x1, 0x2, 0x3}
 		val2 := []byte{0x1, 0x2, 0x3, 0x4}
 		size1 := meter.GetStorageKeyValueSizeForTesting(key1, val1)
@@ -603,13 +603,13 @@ func TestStorageLimits(t *testing.T) {
 		meter1 := meter.NewMeter(
 			meter.DefaultParameters(),
 		)
-		readKey1 := flow.NewRegisterID("", "r1")
+		readKey1 := flow.NewRegisterID(flow.EmptyAddress, "r1")
 		readVal1 := []byte{0x1, 0x2, 0x3}
 		readSize1 := meter.GetStorageKeyValueSizeForTesting(readKey1, readVal1)
 		err := meter1.MeterStorageRead(readKey1, readVal1, false)
 		require.NoError(t, err)
 
-		writeKey1 := flow.NewRegisterID("", "w1")
+		writeKey1 := flow.NewRegisterID(flow.EmptyAddress, "w1")
 		writeVal1 := []byte{0x1, 0x2, 0x3, 0x4}
 		writeSize1 := meter.GetStorageKeyValueSizeForTesting(writeKey1, writeVal1)
 		err = meter1.MeterStorageWrite(writeKey1, writeVal1, false)
@@ -620,7 +620,7 @@ func TestStorageLimits(t *testing.T) {
 			meter.DefaultParameters(),
 		)
 
-		writeKey2 := flow.NewRegisterID("", "w2")
+		writeKey2 := flow.NewRegisterID(flow.EmptyAddress, "w2")
 		writeVal2 := []byte{0x1, 0x2, 0x3, 0x4, 0x5}
 		writeSize2 := meter.GetStorageKeyValueSizeForTesting(writeKey2, writeVal2)
 

--- a/fvm/storage/derived/table_test.go
+++ b/fvm/storage/derived/table_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onflow/flow-go/fvm/storage/snapshot"
 	"github.com/onflow/flow-go/fvm/storage/state"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func newEmptyTestBlock() *DerivedDataTable[string, *string] {
@@ -962,7 +963,7 @@ func (computer *testValueComputer) Compute(
 func TestDerivedDataTableGetOrCompute(t *testing.T) {
 	blockDerivedData := NewEmptyTable[flow.RegisterID, int](0)
 
-	key := flow.NewRegisterID("addr", "key")
+	key := flow.NewRegisterID(unittest.RandomAddressFixture(), "key")
 	value := 12345
 
 	t.Run("compute value", func(t *testing.T) {

--- a/fvm/storage/snapshot/snapshot_tree_test.go
+++ b/fvm/storage/snapshot/snapshot_tree_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestSnapshotTree(t *testing.T) {
-	id1 := flow.NewRegisterID("1", "")
-	id2 := flow.NewRegisterID("2", "")
-	id3 := flow.NewRegisterID("3", "")
-	missingId := flow.NewRegisterID("missing", "")
+	id1 := flow.NewRegisterID(flow.HexToAddress("0x1"), "")
+	id2 := flow.NewRegisterID(flow.HexToAddress("0x2"), "")
+	id3 := flow.NewRegisterID(flow.HexToAddress("0x3"), "")
+	missingId := flow.NewRegisterID(flow.HexToAddress("0x99"), "")
 
 	value1v0 := flow.RegisterValue("1v0")
 

--- a/fvm/storage/state/execution_state_test.go
+++ b/fvm/storage/state/execution_state_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/storage/state"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func createByteArray(size int) []byte {
@@ -23,12 +24,12 @@ func TestExecutionState_Finalize(t *testing.T) {
 
 	child := parent.NewChild()
 
-	readId := flow.NewRegisterID("0", "x")
+	readId := flow.NewRegisterID(unittest.RandomAddressFixture(), "x")
 
 	_, err := child.Get(readId)
 	require.NoError(t, err)
 
-	writeId := flow.NewRegisterID("1", "y")
+	writeId := flow.NewRegisterID(unittest.RandomAddressFixture(), "y")
 	writeValue := flow.RegisterValue("a")
 
 	err = child.Set(writeId, writeValue)
@@ -65,8 +66,10 @@ func TestExecutionState_Finalize(t *testing.T) {
 func TestExecutionState_ChildMergeFunctionality(t *testing.T) {
 	st := state.NewExecutionState(nil, state.DefaultParameters())
 
+	owner := unittest.RandomAddressFixture()
+
 	t.Run("test read from parent state (backoff)", func(t *testing.T) {
-		key := flow.NewRegisterID("address", "key1")
+		key := flow.NewRegisterID(owner, "key1")
 		value := createByteArray(1)
 		// set key1 on parent
 		err := st.Set(key, value)
@@ -80,7 +83,7 @@ func TestExecutionState_ChildMergeFunctionality(t *testing.T) {
 	})
 
 	t.Run("test write to child (no merge)", func(t *testing.T) {
-		key := flow.NewRegisterID("address", "key2")
+		key := flow.NewRegisterID(owner, "key2")
 		value := createByteArray(2)
 		stChild := st.NewChild()
 
@@ -95,7 +98,7 @@ func TestExecutionState_ChildMergeFunctionality(t *testing.T) {
 	})
 
 	t.Run("test write to child and merge", func(t *testing.T) {
-		key := flow.NewRegisterID("address", "key3")
+		key := flow.NewRegisterID(owner, "key3")
 		value := createByteArray(3)
 		stChild := st.NewChild()
 
@@ -119,7 +122,7 @@ func TestExecutionState_ChildMergeFunctionality(t *testing.T) {
 	})
 
 	t.Run("test write to ledger", func(t *testing.T) {
-		key := flow.NewRegisterID("address", "key4")
+		key := flow.NewRegisterID(owner, "key4")
 		value := createByteArray(4)
 		// set key4 on parent
 		err := st.Set(key, value)
@@ -138,7 +141,7 @@ func TestExecutionState_MaxValueSize(t *testing.T) {
 		nil,
 		state.DefaultParameters().WithMaxValueSizeAllowed(6))
 
-	key := flow.NewRegisterID("address", "key")
+	key := flow.NewRegisterID(unittest.RandomAddressFixture(), "key")
 
 	// update should pass
 	value := createByteArray(5)
@@ -157,8 +160,8 @@ func TestExecutionState_MaxKeySize(t *testing.T) {
 		// Note: owners are always 8 bytes
 		state.DefaultParameters().WithMaxKeySizeAllowed(8+2))
 
-	key1 := flow.NewRegisterID("1", "23")
-	key2 := flow.NewRegisterID("123", "234")
+	key1 := flow.NewRegisterID(unittest.RandomAddressFixture(), "23")
+	key2 := flow.NewRegisterID(unittest.RandomAddressFixture(), "234")
 
 	// read
 	_, err := st.Get(key1)
@@ -179,19 +182,19 @@ func TestExecutionState_MaxKeySize(t *testing.T) {
 }
 
 func TestExecutionState_MaxInteraction(t *testing.T) {
-	key1 := flow.NewRegisterID("1", "2")
+	key1 := flow.NewRegisterID(unittest.RandomAddressFixture(), "2")
 	key1Size := uint64(8 + 1)
 
 	value1 := []byte("A")
 	value1Size := uint64(1)
 
-	key2 := flow.NewRegisterID("123", "23")
+	key2 := flow.NewRegisterID(unittest.RandomAddressFixture(), "23")
 	key2Size := uint64(8 + 2)
 
-	key3 := flow.NewRegisterID("234", "345")
+	key3 := flow.NewRegisterID(unittest.RandomAddressFixture(), "345")
 	key3Size := uint64(8 + 3)
 
-	key4 := flow.NewRegisterID("3", "4567")
+	key4 := flow.NewRegisterID(unittest.RandomAddressFixture(), "4567")
 	key4Size := uint64(8 + 4)
 
 	st := state.NewExecutionState(

--- a/fvm/storage/state/spock_state_test.go
+++ b/fvm/storage/state/spock_state_test.go
@@ -53,6 +53,7 @@ func testSpock(
 }
 
 func TestSpockStateGet(t *testing.T) {
+	otherOwner := unittest.RandomAddressFixture()
 	registerId := flow.NewRegisterID(fooOwner, "bar")
 
 	states := testSpock(
@@ -74,7 +75,7 @@ func TestSpockStateGet(t *testing.T) {
 			},
 			// Reading different register ids will result in different spock
 			func(t *testing.T, state *spockState) {
-				_, err := state.Get(flow.NewRegisterID(unittest.RandomAddressFixture(), "bar"))
+				_, err := state.Get(flow.NewRegisterID(otherOwner, "bar"))
 				require.NoError(t, err)
 			},
 			func(t *testing.T, state *spockState) {
@@ -147,6 +148,7 @@ func TestSpockStateGetVsSetNil(t *testing.T) {
 }
 
 func TestSpockStateSet(t *testing.T) {
+	otherOwner := unittest.RandomAddressFixture()
 	registerId := flow.NewRegisterID(fooOwner, "bar")
 	value := flow.RegisterValue([]byte("value"))
 
@@ -173,7 +175,7 @@ func TestSpockStateSet(t *testing.T) {
 				require.NoError(t, err)
 			},
 			func(t *testing.T, state *spockState) {
-				err := state.Set(flow.NewRegisterID(unittest.RandomAddressFixture(), "bar"), value)
+				err := state.Set(flow.NewRegisterID(otherOwner, "bar"), value)
 				require.NoError(t, err)
 			},
 			// Setting different register value will result in different spock

--- a/fvm/storage/state/storage_state_test.go
+++ b/fvm/storage/state/storage_state_test.go
@@ -7,13 +7,16 @@ import (
 
 	"github.com/onflow/flow-go/fvm/storage/snapshot"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestStorageStateSet(t *testing.T) {
-	registerId1 := flow.NewRegisterID("foo", "1")
+	fooOwner := unittest.RandomAddressFixture()
+
+	registerId1 := flow.NewRegisterID(fooOwner, "1")
 	value1 := flow.RegisterValue([]byte("value1"))
 
-	registerId2 := flow.NewRegisterID("foo", "2")
+	registerId2 := flow.NewRegisterID(fooOwner, "2")
 	value2 := flow.RegisterValue([]byte("value2"))
 
 	state := newStorageState(nil)
@@ -40,13 +43,13 @@ func TestStorageStateSet(t *testing.T) {
 
 func TestStorageStateGetFromNilBase(t *testing.T) {
 	state := newStorageState(nil)
-	value, err := state.Get(flow.NewRegisterID("foo", "bar"))
+	value, err := state.Get(flow.NewRegisterID(unittest.RandomAddressFixture(), "bar"))
 	require.NoError(t, err)
 	require.Nil(t, value)
 }
 
 func TestStorageStateGetFromBase(t *testing.T) {
-	registerId := flow.NewRegisterID("", "base")
+	registerId := flow.NewRegisterID(flow.EmptyAddress, "base")
 	baseValue := flow.RegisterValue([]byte("base"))
 
 	state := newStorageState(
@@ -89,7 +92,7 @@ func TestStorageStateGetFromBase(t *testing.T) {
 }
 
 func TestStorageStateGetFromWriteSet(t *testing.T) {
-	registerId := flow.NewRegisterID("", "base")
+	registerId := flow.NewRegisterID(flow.EmptyAddress, "base")
 	expectedValue := flow.RegisterValue([]byte("base"))
 
 	state := newStorageState(nil)
@@ -112,22 +115,25 @@ func TestStorageStateGetFromWriteSet(t *testing.T) {
 }
 
 func TestStorageStateMerge(t *testing.T) {
-	baseRegisterId := flow.NewRegisterID("", "base")
+	parentOwner := unittest.RandomAddressFixture()
+	childOwner := unittest.RandomAddressFixture()
+
+	baseRegisterId := flow.NewRegisterID(flow.EmptyAddress, "base")
 	baseValue := flow.RegisterValue([]byte("base"))
 
-	parentRegisterId1 := flow.NewRegisterID("parent", "1")
+	parentRegisterId1 := flow.NewRegisterID(parentOwner, "1")
 	parentValue := flow.RegisterValue([]byte("parent"))
 
-	parentRegisterId2 := flow.NewRegisterID("parent", "2")
+	parentRegisterId2 := flow.NewRegisterID(parentOwner, "2")
 
-	parentRegisterId3 := flow.NewRegisterID("parent", "3")
+	parentRegisterId3 := flow.NewRegisterID(parentOwner, "3")
 	originalParentValue3 := flow.RegisterValue([]byte("parent value"))
 	updatedParentValue3 := flow.RegisterValue([]byte("child value"))
 
-	childRegisterId1 := flow.NewRegisterID("child", "1")
+	childRegisterId1 := flow.NewRegisterID(childOwner, "1")
 	childValue1 := flow.RegisterValue([]byte("child"))
 
-	childRegisterId2 := flow.NewRegisterID("child", "2")
+	childRegisterId2 := flow.NewRegisterID(childOwner, "2")
 
 	parent := newStorageState(
 		snapshot.MapStorageSnapshot{

--- a/fvm/storage/state/transaction_state_test.go
+++ b/fvm/storage/state/transaction_state_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/fvm/storage/state"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func newTestTransactionState() state.NestedTransactionPreparer {
@@ -50,7 +51,7 @@ func TestUnrestrictedNestedTransactionBasic(t *testing.T) {
 
 	// Ensure the values are written to the correctly nested state
 
-	key := flow.NewRegisterID("address", "key")
+	key := flow.NewRegisterID(unittest.RandomAddressFixture(), "key")
 	val := createByteArray(2)
 
 	err = txn.Set(key, val)
@@ -173,7 +174,7 @@ func TestParseRestrictedNestedTransactionBasic(t *testing.T) {
 
 	// Sanity check
 
-	key := flow.NewRegisterID("address", "key")
+	key := flow.NewRegisterID(unittest.RandomAddressFixture(), "key")
 
 	v, err := restrictedNestedState2.Get(key)
 	require.NoError(t, err)
@@ -280,7 +281,7 @@ func TestRestartNestedTransaction(t *testing.T) {
 	id, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	key := flow.NewRegisterID("address", "key")
+	key := flow.NewRegisterID(unittest.RandomAddressFixture(), "key")
 	val := createByteArray(2)
 
 	for i := 0; i < 10; i++ {
@@ -332,7 +333,7 @@ func TestRestartNestedTransactionWithInvalidId(t *testing.T) {
 	id, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	key := flow.NewRegisterID("address", "key")
+	key := flow.NewRegisterID(unittest.RandomAddressFixture(), "key")
 	val := createByteArray(2)
 
 	err = txn.Set(key, val)
@@ -498,7 +499,7 @@ func TestFinalizeMainTransaction(t *testing.T) {
 	id1, err := txn.BeginNestedTransaction()
 	require.NoError(t, err)
 
-	registerId := flow.NewRegisterID("foo", "bar")
+	registerId := flow.NewRegisterID(unittest.RandomAddressFixture(), "bar")
 
 	value, err := txn.Get(registerId)
 	require.NoError(t, err)
@@ -531,18 +532,21 @@ func TestInterimReadSet(t *testing.T) {
 
 	// Setup test with a bunch of outstanding nested transaction.
 
-	readRegisterId1 := flow.NewRegisterID("read", "1")
-	readRegisterId2 := flow.NewRegisterID("read", "2")
-	readRegisterId3 := flow.NewRegisterID("read", "3")
-	readRegisterId4 := flow.NewRegisterID("read", "4")
+	readOwner := unittest.RandomAddressFixture()
+	writeOwner := unittest.RandomAddressFixture()
 
-	writeRegisterId1 := flow.NewRegisterID("write", "1")
+	readRegisterId1 := flow.NewRegisterID(readOwner, "1")
+	readRegisterId2 := flow.NewRegisterID(readOwner, "2")
+	readRegisterId3 := flow.NewRegisterID(readOwner, "3")
+	readRegisterId4 := flow.NewRegisterID(readOwner, "4")
+
+	writeRegisterId1 := flow.NewRegisterID(writeOwner, "1")
 	writeValue1 := flow.RegisterValue([]byte("value1"))
 
-	writeRegisterId2 := flow.NewRegisterID("write", "2")
+	writeRegisterId2 := flow.NewRegisterID(writeOwner, "2")
 	writeValue2 := flow.RegisterValue([]byte("value2"))
 
-	writeRegisterId3 := flow.NewRegisterID("write", "3")
+	writeRegisterId3 := flow.NewRegisterID(writeOwner, "3")
 	writeValue3 := flow.RegisterValue([]byte("value3"))
 
 	err := txn.Set(writeRegisterId1, writeValue1)

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -19,8 +19,8 @@ func TestTransactionStorageLimiter(t *testing.T) {
 	owner := flow.HexToAddress("1")
 	executionSnapshot := &snapshot.ExecutionSnapshot{
 		WriteSet: map[flow.RegisterID]flow.RegisterValue{
-			flow.NewRegisterID(string(owner[:]), "a"): flow.RegisterValue("foo"),
-			flow.NewRegisterID(string(owner[:]), "b"): flow.RegisterValue("bar"),
+			flow.NewRegisterID(owner, "a"): flow.RegisterValue("foo"),
+			flow.NewRegisterID(owner, "b"): flow.RegisterValue("bar"),
 		},
 	}
 

--- a/ledger/common/convert/convert.go
+++ b/ledger/common/convert/convert.go
@@ -28,7 +28,7 @@ func LedgerKeyToRegisterID(key ledger.Key) (flow.RegisterID, error) {
 	}
 
 	return flow.NewRegisterID(
-		string(key.KeyParts[0].Value),
+		flow.BytesToAddress(key.KeyParts[0].Value),
 		string(key.KeyParts[1].Value),
 	), nil
 }

--- a/ledger/common/convert/convert_test.go
+++ b/ledger/common/convert/convert_test.go
@@ -12,11 +12,13 @@ import (
 )
 
 func TestLedgerKeyToRegisterID(t *testing.T) {
+	expectedRegisterID := unittest.RegisterIDFixture()
+
 	key := ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
 				Type:  convert.KeyPartOwner,
-				Value: []byte("owner"),
+				Value: []byte(expectedRegisterID.Owner),
 			},
 			{
 				Type:  convert.KeyPartKey,
@@ -25,7 +27,6 @@ func TestLedgerKeyToRegisterID(t *testing.T) {
 		},
 	}
 
-	expectedRegisterID := unittest.RegisterIDFixture()
 	registerID, err := convert.LedgerKeyToRegisterID(key)
 	require.NoError(t, err)
 	require.Equal(t, expectedRegisterID, registerID)
@@ -78,7 +79,7 @@ func TestRegisterIDToLedgerKey(t *testing.T) {
 				Type: convert.KeyPartOwner,
 				// Note: the owner field is extended to address length during NewRegisterID
 				// so we have to do the same here
-				Value: flow.BytesToAddress([]byte("owner")).Bytes(),
+				Value: []byte(registerID.Owner),
 			},
 			{
 				Type:  convert.KeyPartKey,

--- a/ledger/common/convert/convert_test.go
+++ b/ledger/common/convert/convert_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestLedgerKeyToRegisterID(t *testing.T) {
@@ -24,7 +25,7 @@ func TestLedgerKeyToRegisterID(t *testing.T) {
 		},
 	}
 
-	expectedRegisterID := flow.NewRegisterID("owner", "key")
+	expectedRegisterID := unittest.RegisterIDFixture()
 	registerID, err := convert.LedgerKeyToRegisterID(key)
 	require.NoError(t, err)
 	require.Equal(t, expectedRegisterID, registerID)
@@ -70,7 +71,7 @@ func TestLedgerKeyToRegisterID_Error(t *testing.T) {
 }
 
 func TestRegisterIDToLedgerKey(t *testing.T) {
-	registerID := flow.NewRegisterID("owner", "key")
+	registerID := unittest.RegisterIDFixture()
 	expectedKey := ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
@@ -110,20 +111,21 @@ func TestRegisterIDToLedgerKey_Global(t *testing.T) {
 }
 
 func TestPayloadToRegister(t *testing.T) {
+	expected := unittest.RegisterIDFixture()
 	t.Run("can convert", func(t *testing.T) {
 		value := []byte("value")
 		p := ledger.NewPayload(
 			ledger.NewKey(
 				[]ledger.KeyPart{
-					ledger.NewKeyPart(convert.KeyPartOwner, []byte("owner")),
-					ledger.NewKeyPart(convert.KeyPartKey, []byte("key")),
+					ledger.NewKeyPart(convert.KeyPartOwner, []byte(expected.Owner)),
+					ledger.NewKeyPart(convert.KeyPartKey, []byte(expected.Key)),
 				},
 			),
 			value,
 		)
 		regID, regValue, err := convert.PayloadToRegister(p)
 		require.NoError(t, err)
-		require.Equal(t, flow.NewRegisterID("owner", "key"), regID)
+		require.Equal(t, expected, regID)
 		require.Equal(t, value, regValue)
 	})
 
@@ -140,7 +142,7 @@ func TestPayloadToRegister(t *testing.T) {
 		)
 		regID, regValue, err := convert.PayloadToRegister(p)
 		require.NoError(t, err)
-		require.Equal(t, flow.NewRegisterID("", "uuid"), regID)
+		require.Equal(t, flow.NewRegisterID(flow.EmptyAddress, "uuid"), regID)
 		require.Equal(t, "", regID.Owner)
 		require.Equal(t, "uuid", regID.Key)
 		require.True(t, regID.IsInternalState())

--- a/ledger/partial/ledger_test.go
+++ b/ledger/partial/ledger_test.go
@@ -127,7 +127,7 @@ func TestProofsForEmptyRegisters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read one register during execution.
-	registerID := flow.NewRegisterID("b", "nk")
+	registerID := flow.NewRegisterID(unittest.RandomAddressFixture(), "nk")
 	allKeys := []ledger.Key{
 		convert.RegisterIDToLedgerKey(registerID),
 	}

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -81,18 +81,18 @@ func ContractRegisterID(address Address, contractName string) RegisterID {
 
 func CadenceRegisterID(owner []byte, key []byte) RegisterID {
 	return RegisterID{
-		Owner: string(BytesToAddress(owner).Bytes()),
+		Owner: addressToOwner(BytesToAddress(owner)),
 		Key:   string(key),
 	}
 }
 
-func NewRegisterID(owner, key string) RegisterID {
+func NewRegisterID(owner Address, key string) RegisterID {
 	// global registers have an empty owner field
 	ownerString := ""
 
 	// all other registers have the account's address
-	if len(owner) > 0 {
-		ownerString = addressToOwner(BytesToAddress([]byte(owner)))
+	if owner != EmptyAddress {
+		ownerString = addressToOwner(owner)
 	}
 
 	return RegisterID{

--- a/model/flow/ledger_test.go
+++ b/model/flow/ledger_test.go
@@ -1,4 +1,4 @@
-package flow
+package flow_test
 
 import (
 	"encoding/hex"
@@ -22,7 +22,7 @@ var length int
 
 func BenchmarkString(b *testing.B) {
 
-	r := NewRegisterID(unittest.RandomAddressFixture(), "123412341234")
+	r := flow.NewRegisterID(unittest.RandomAddressFixture(), "123412341234")
 
 	ownerLen := len(r.Owner)
 
@@ -42,7 +42,7 @@ func BenchmarkString(b *testing.B) {
 
 func BenchmarkOriginalString(b *testing.B) {
 
-	r := NewRegisterID(unittest.RandomAddressFixture(), "123412341234")
+	r := flow.NewRegisterID(unittest.RandomAddressFixture(), "123412341234")
 
 	ret := fmt.Sprintf("%x/%x", r.Owner, r.Key)
 
@@ -50,36 +50,36 @@ func BenchmarkOriginalString(b *testing.B) {
 }
 
 func TestRegisterID_IsInternalState(t *testing.T) {
-	requireTrue := func(owner Address, key string) {
-		id := NewRegisterID(owner, key)
+	requireTrue := func(owner flow.Address, key string) {
+		id := flow.NewRegisterID(owner, key)
 		require.True(t, id.IsInternalState())
 	}
 
-	requireFalse := func(owner Address, key string) {
-		id := NewRegisterID(owner, key)
+	requireFalse := func(owner flow.Address, key string) {
+		id := flow.NewRegisterID(owner, key)
 		require.False(t, id.IsInternalState())
 	}
 
 	for i := 0; i < 256; i++ {
-		uuid := UUIDRegisterID(byte(i))
+		uuid := flow.UUIDRegisterID(byte(i))
 		if i == 0 {
-			require.Equal(t, uuid.Key, UUIDKeyPrefix)
-			requireTrue(EmptyAddress, UUIDKeyPrefix)
+			require.Equal(t, uuid.Key, flow.UUIDKeyPrefix)
+			requireTrue(flow.EmptyAddress, flow.UUIDKeyPrefix)
 		} else {
-			require.Equal(t, uuid.Key, fmt.Sprintf("%s_%d", UUIDKeyPrefix, i))
-			requireTrue(EmptyAddress, fmt.Sprintf("%s_%d", UUIDKeyPrefix, i))
+			require.Equal(t, uuid.Key, fmt.Sprintf("%s_%d", flow.UUIDKeyPrefix, i))
+			requireTrue(flow.EmptyAddress, fmt.Sprintf("%s_%d", flow.UUIDKeyPrefix, i))
 		}
 		require.True(t, uuid.IsInternalState())
 	}
-	require.True(t, AddressStateRegisterID.IsInternalState())
-	requireTrue(EmptyAddress, AddressStateKey)
-	requireFalse(EmptyAddress, "other")
-	requireFalse(unittest.RandomAddressFixture(), UUIDKeyPrefix)
-	requireFalse(unittest.RandomAddressFixture(), AddressStateKey)
+	require.True(t, flow.AddressStateRegisterID.IsInternalState())
+	requireTrue(flow.EmptyAddress, flow.AddressStateKey)
+	requireFalse(flow.EmptyAddress, "other")
+	requireFalse(unittest.RandomAddressFixture(), flow.UUIDKeyPrefix)
+	requireFalse(unittest.RandomAddressFixture(), flow.AddressStateKey)
 	requireTrue(unittest.RandomAddressFixture(), "public_key_12")
-	requireTrue(unittest.RandomAddressFixture(), ContractNamesKey)
+	requireTrue(unittest.RandomAddressFixture(), flow.ContractNamesKey)
 	requireTrue(unittest.RandomAddressFixture(), "code.MYCODE")
-	requireTrue(unittest.RandomAddressFixture(), AccountStatusKey)
+	requireTrue(unittest.RandomAddressFixture(), flow.AccountStatusKey)
 	requireFalse(unittest.RandomAddressFixture(), "anything else")
 }
 
@@ -88,7 +88,7 @@ func TestRegisterID_String(t *testing.T) {
 		// slab with 189 should result in \\xbd
 		slabIndex := atree.StorageIndex([8]byte{0, 0, 0, 0, 0, 0, 0, 189})
 
-		id := NewRegisterID(
+		id := flow.NewRegisterID(
 			flow.BytesToAddress([]byte{1, 2, 3, 10}),
 			string(atree.SlabIndexToLedgerKey(slabIndex)))
 		require.False(t, utf8.ValidString(id.Key))
@@ -98,7 +98,7 @@ func TestRegisterID_String(t *testing.T) {
 	})
 
 	t.Run("non slab invalid utf-8", func(t *testing.T) {
-		id := NewRegisterID(flow.BytesToAddress([]byte("b\xc5y")), "a\xc5z")
+		id := flow.NewRegisterID(flow.BytesToAddress([]byte("b\xc5y")), "a\xc5z")
 		require.False(t, utf8.ValidString(id.Owner))
 		require.False(t, utf8.ValidString(id.Key))
 		printable := id.String()
@@ -107,8 +107,8 @@ func TestRegisterID_String(t *testing.T) {
 	})
 
 	t.Run("global register", func(t *testing.T) {
-		uuidRegisterID := UUIDRegisterID(0)
-		id := NewRegisterID(EmptyAddress, uuidRegisterID.Key)
+		uuidRegisterID := flow.UUIDRegisterID(0)
+		id := flow.NewRegisterID(flow.EmptyAddress, uuidRegisterID.Key)
 		require.Equal(t, uuidRegisterID.Owner, id.Owner)
 		require.Equal(t, uuidRegisterID.Key, id.Key)
 		printable := id.String()

--- a/model/flow/ledger_test.go
+++ b/model/flow/ledger_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -50,8 +50,8 @@ var eventsList = flow.EventsList{
 
 const computationUsed = uint64(100)
 
-var id0 = flow.NewRegisterID("00", "")
-var id5 = flow.NewRegisterID("05", "")
+var id0 = flow.NewRegisterID(unittest.RandomAddressFixture(), "")
+var id5 = flow.NewRegisterID(unittest.RandomAddressFixture(), "")
 
 // the chain we use for this test suite
 var testChain = flow.Emulator
@@ -403,16 +403,13 @@ func blockFixture(collection *flow.Collection) *flow.Block {
 }
 
 func generateStateUpdates(t *testing.T, f *completeLedger.Ledger) (ledger.State, ledger.Proof, *ledger.Update) {
-	id1 := flow.NewRegisterID("00", "")
-	id2 := flow.NewRegisterID("05", "")
-
 	entries := flow.RegisterEntries{
 		{
-			Key:   id1,
+			Key:   id0,
 			Value: []byte{'a'},
 		},
 		{
-			Key:   id2,
+			Key:   id5,
 			Value: []byte{'b'},
 		},
 	}
@@ -432,7 +429,7 @@ func generateStateUpdates(t *testing.T, f *completeLedger.Ledger) (ledger.State,
 
 	entries = flow.RegisterEntries{
 		{
-			Key:   id2,
+			Key:   id5,
 			Value: []byte{'B'},
 		},
 	}

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -541,9 +541,10 @@ func trieRegistersPayloadComparer(t *testing.T, triePayloads []*ledger.Payload, 
 }
 
 func TestIndexerIntegration_StoreAndGet(t *testing.T) {
-	regOwner := "f8d6e0586b0a20c7"
+	regOwnerAddress := unittest.RandomAddressFixture()
+	regOwner := string(regOwnerAddress.Bytes())
 	regKey := "code"
-	registerID := flow.NewRegisterID(flow.HexToAddress(regOwner), regKey)
+	registerID := flow.NewRegisterID(regOwnerAddress, regKey)
 
 	db, dbDir := unittest.TempBadgerDB(t)
 	t.Cleanup(func() {
@@ -561,13 +562,13 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 
 			values := [][]byte{[]byte("1"), []byte("1"), []byte("2"), []byte("3"), []byte("4")}
 			for i, val := range values {
-				testDesc := fmt.Sprintf("test itteration number %d failed with test value %s", i, val)
+				testDesc := fmt.Sprintf("test iteration number %d failed with test value %s", i, val)
 				height := uint64(i + 1)
 				err := storeRegisterWithValue(index, height, regOwner, regKey, val)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				results, err := index.RegisterValue(registerID, height)
-				require.Nil(t, err, testDesc)
+				require.NoError(t, err, testDesc)
 				assert.Equal(t, val, results)
 			}
 		})

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -543,7 +543,7 @@ func trieRegistersPayloadComparer(t *testing.T, triePayloads []*ledger.Payload, 
 func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	regOwner := "f8d6e0586b0a20c7"
 	regKey := "code"
-	registerID := flow.NewRegisterID(regOwner, regKey)
+	registerID := flow.NewRegisterID(flow.HexToAddress(regOwner), regKey)
 
 	db, dbDir := unittest.TempBadgerDB(t)
 	t.Cleanup(func() {

--- a/storage/badger/operation/interactions_test.go
+++ b/storage/badger/operation/interactions_test.go
@@ -18,15 +18,15 @@ func TestStateInteractionsInsertCheckRetrieve(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 
 		id1 := flow.NewRegisterID(
-			string([]byte("\x89krg\u007fBN\x1d\xf5\xfb\xb8r\xbc4\xbd\x98ռ\xf1\xd0twU\xbf\x16N\xb4?,\xa0&;")),
+			flow.BytesToAddress([]byte("\x89krg\u007fBN\x1d\xf5\xfb\xb8r\xbc4\xbd\x98ռ\xf1\xd0twU\xbf\x16N\xb4?,\xa0&;")),
 			"")
-		id2 := flow.NewRegisterID(string([]byte{2}), "")
-		id3 := flow.NewRegisterID(string([]byte{3}), "")
+		id2 := flow.NewRegisterID(flow.BytesToAddress([]byte{2}), "")
+		id3 := flow.NewRegisterID(flow.BytesToAddress([]byte{3}), "")
 
 		executionSnapshot := &snapshot.ExecutionSnapshot{
 			ReadSet: map[flow.RegisterID]struct{}{
-				id2: struct{}{},
-				id3: struct{}{},
+				id2: {},
+				id3: {},
 			},
 			WriteSet: map[flow.RegisterID]flow.RegisterValue{
 				id1: []byte("zażółć gęślą jaźń"),
@@ -36,7 +36,7 @@ func TestStateInteractionsInsertCheckRetrieve(t *testing.T) {
 
 		interactions := []*snapshot.ExecutionSnapshot{
 			executionSnapshot,
-			&snapshot.ExecutionSnapshot{},
+			{},
 		}
 
 		blockID := unittest.IdentifierFixture()

--- a/storage/pebble/registers_test.go
+++ b/storage/pebble/registers_test.go
@@ -300,12 +300,13 @@ func Benchmark_PayloadStorage(b *testing.B) {
 	require.NoError(b, err)
 	require.NotNil(b, s)
 
-	batchSizeKey := flow.NewRegisterID("batch", "size")
+	owner := unittest.RandomAddressFixture()
+	batchSizeKey := flow.NewRegisterID(owner, "size")
 	const maxBatchSize = 1024
 	var totalBatchSize int
 
 	keyForBatchSize := func(i int) flow.RegisterID {
-		return flow.NewRegisterID("batch", strconv.Itoa(i))
+		return flow.NewRegisterID(owner, strconv.Itoa(i))
 	}
 	valueForHeightAndKey := func(i, j int) []byte {
 		return []byte(fmt.Sprintf("%d-%d", i, j))

--- a/utils/debug/registerCache.go
+++ b/utils/debug/registerCache.go
@@ -97,10 +97,10 @@ func (f *fileRegisterCache) Get(owner, key string) ([]byte, bool) {
 func (f *fileRegisterCache) Set(owner, key string, value []byte) {
 	valueCopy := make([]byte, len(value))
 	copy(valueCopy, value)
-	fmt.Println(hex.EncodeToString([]byte(owner)), hex.EncodeToString([]byte(key)), len(value))
+	ownerAddr := flow.BytesToAddress([]byte(owner))
+	fmt.Println(ownerAddr.Hex(), hex.EncodeToString([]byte(key)), len(value))
 	f.data[owner+"~"+key] = flow.RegisterEntry{
-		Key: flow.NewRegisterID(hex.EncodeToString([]byte(owner)),
-			hex.EncodeToString([]byte(key))),
+		Key:   flow.NewRegisterID(ownerAddr, hex.EncodeToString([]byte(key))),
 		Value: flow.RegisterValue(valueCopy),
 	}
 }

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -73,9 +73,13 @@ func AddressFixture() flow.Address {
 }
 
 func RandomAddressFixture() flow.Address {
+	return RandomAddressFixtureForChain(flow.Testnet)
+}
+
+func RandomAddressFixtureForChain(chainID flow.ChainID) flow.Address {
 	// we use a 32-bit index - since the linear address generator uses 45 bits,
 	// this won't error
-	addr, err := flow.Testnet.Chain().AddressAtIndex(uint64(rand.Uint32()))
+	addr, err := chainID.Chain().AddressAtIndex(uint64(rand.Uint32()))
 	if err != nil {
 		panic(err)
 	}
@@ -1429,10 +1433,7 @@ func TransactionDSLFixture(chain flow.Chain) dsl.Transaction {
 
 // RegisterIDFixture returns a RegisterID with a fixed key and owner
 func RegisterIDFixture() flow.RegisterID {
-	return flow.RegisterID{
-		Owner: "owner",
-		Key:   "key",
-	}
+	return flow.NewRegisterID(RandomAddressFixture(), "key")
 }
 
 // VerifiableChunkDataFixture returns a complete verifiable chunk with an


### PR DESCRIPTION
Currently, `NewRegisterID` accepts a string for the owner field, which needs to be either a valid flow address or an empty string. This creates issues when developers make incorrect assumptions about the inputs, and allows for unrealistic test scenarios that miss important corner cases.

Refactor `NewRegisterID` to accept a `flow.Address` and adjust callers/tests.