### PR TITLE
[Networking] Surrounding Trace Level Logs With Level Check in Gossipsub Tracer

### DIFF
--- a/network/p2p/tracer/gossipSubMeshTracer.go
+++ b/network/p2p/tracer/gossipSubMeshTracer.go
@@ -264,7 +264,7 @@ func (t *GossipSubMeshTracer) ValidateMessage(msg *pubsub.Message) {
 	size := len(msg.Data)
 	t.metrics.OnMessageEnteredValidation(size)
 
-	if t.logger.GetLevel() != zerolog.TraceLevel {
+	if t.logger.GetLevel() > zerolog.TraceLevel {
 		return // return fast if we are not logging at trace level.
 	}
 
@@ -289,7 +289,7 @@ func (t *GossipSubMeshTracer) DeliverMessage(msg *pubsub.Message) {
 	size := len(msg.Data)
 	t.metrics.OnMessageDeliveredToAllSubscribers(size)
 
-	if t.logger.GetLevel() != zerolog.TraceLevel {
+	if t.logger.GetLevel() > zerolog.TraceLevel {
 		return // return fast if we are not logging at trace level.
 	}
 
@@ -317,7 +317,7 @@ func (t *GossipSubMeshTracer) RejectMessage(msg *pubsub.Message, reason string) 
 	size := len(msg.Data)
 	t.metrics.OnMessageRejected(size, reason)
 
-	if t.logger.GetLevel() != zerolog.TraceLevel {
+	if t.logger.GetLevel() > zerolog.TraceLevel {
 		return // fail fast if we are not logging at trace level.
 	}
 
@@ -341,7 +341,7 @@ func (t *GossipSubMeshTracer) DuplicateMessage(msg *pubsub.Message) {
 	size := len(msg.Data)
 	t.metrics.OnMessageDuplicate(size)
 
-	if t.logger.GetLevel() != zerolog.TraceLevel {
+	if t.logger.GetLevel() > zerolog.TraceLevel {
 		return // return fast if we are not logging at trace level.
 	}
 

--- a/network/p2p/tracer/gossipSubMeshTracer.go
+++ b/network/p2p/tracer/gossipSubMeshTracer.go
@@ -218,36 +218,44 @@ func (t *GossipSubMeshTracer) SendRPC(rpc *pubsub.RPC, p peer.ID) {
 // AddPeer is called by GossipSub as a callback when a peer is added to the local node on a protocol, i.e., the local node is connected to the peer on a protocol.
 // The peer may or may not be subscribed to any topic.
 func (t *GossipSubMeshTracer) AddPeer(p peer.ID, proto protocol.ID) {
-	t.logger.Trace().
-		Str("local_peer_id", p2plogging.PeerId(p)).
-		Str("protocol", string(proto)).
-		Msg("peer added")
 	t.metrics.OnPeerAddedToProtocol(string(proto))
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		t.logger.Trace().
+			Str("local_peer_id", p2plogging.PeerId(p)).
+			Str("protocol", string(proto)).
+			Msg("peer added")
+	}
 }
 
 // RemovePeer is called by GossipSub as a callback when a peer is removed from the local node,
 // i.e., the local node is no longer connected to the peer.
 func (t *GossipSubMeshTracer) RemovePeer(p peer.ID) {
-	t.logger.Trace().
-		Str("local_peer_id", p2plogging.PeerId(p)).
-		Msg("peer removed")
 	t.metrics.OnPeerRemovedFromProtocol()
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		t.logger.Trace().
+			Str("local_peer_id", p2plogging.PeerId(p)).
+			Msg("peer removed")
+	}
 }
 
 // Join is called by GossipSub as a callback when the local node joins a topic.
 func (t *GossipSubMeshTracer) Join(topic string) {
-	t.logger.Trace().
-		Str("topic", topic).
-		Msg("local peer joined topic")
 	t.metrics.OnLocalPeerJoinedTopic()
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		t.logger.Trace().
+			Str("topic", topic).
+			Msg("local peer joined topic")
+	}
 }
 
 // Leave is called by GossipSub as a callback when the local node leaves a topic.
 func (t *GossipSubMeshTracer) Leave(topic string) {
-	t.logger.Trace().
-		Str("topic", topic).
-		Msg("local peer left topic")
 	t.metrics.OnLocalPeerLeftTopic()
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		t.logger.Trace().
+			Str("topic", topic).
+			Msg("local peer left topic")
+	}
 }
 
 // ValidateMessage is called by GossipSub as a callback when a message is received by the local node and entered the validation phase.
@@ -263,11 +271,13 @@ func (t *GossipSubMeshTracer) ValidateMessage(msg *pubsub.Message) {
 		lg = lg.With().Str("remote_peer_id", p2plogging.PeerId(from)).Logger()
 	}
 	size := len(msg.Data)
-	lg.Trace().
-		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-		Int("message_size", size).
-		Msg("received pubsub message entered validation phase")
 	t.metrics.OnMessageEnteredValidation(size)
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		lg.Trace().
+			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+			Int("message_size", size).
+			Msg("received pubsub message entered validation phase")
+	}
 }
 
 // DeliverMessage is called by GossipSub as a callback when the local node delivers a message to all subscribers of the topic.
@@ -282,11 +292,13 @@ func (t *GossipSubMeshTracer) DeliverMessage(msg *pubsub.Message) {
 		lg = lg.With().Str("remote_peer_id", p2plogging.PeerId(from)).Logger()
 	}
 	size := len(msg.Data)
-	lg.Trace().
-		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-		Int("message_size", len(msg.Data)).
-		Msg("delivered pubsub message to all subscribers")
 	t.metrics.OnMessageDeliveredToAllSubscribers(size)
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		lg.Trace().
+			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+			Int("message_size", len(msg.Data)).
+			Msg("delivered pubsub message to all subscribers")
+	}
 }
 
 // RejectMessage is called by GossipSub as a callback when a message is rejected by the local node.
@@ -305,11 +317,13 @@ func (t *GossipSubMeshTracer) RejectMessage(msg *pubsub.Message, reason string) 
 		lg = lg.With().Str("remote_peer_id", p2plogging.PeerId(from)).Logger()
 	}
 	size := len(msg.Data)
-	lg.Trace().
-		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-		Int("message_size", size).
-		Msg("rejected pubsub message")
 	t.metrics.OnMessageRejected(size, reason)
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		lg.Trace().
+			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+			Int("message_size", size).
+			Msg("rejected pubsub message")
+	}
 }
 
 // DuplicateMessage is called by GossipSub as a callback when a duplicate message is received by the local node.
@@ -326,10 +340,12 @@ func (t *GossipSubMeshTracer) DuplicateMessage(msg *pubsub.Message) {
 
 	size := len(msg.Data)
 	t.metrics.OnMessageDuplicate(size)
-	lg.Trace().
-		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-		Int("message_size", size).
-		Msg("received duplicate pubsub message")
+	if t.logger.GetLevel() == zerolog.TraceLevel {
+		lg.Trace().
+			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+			Int("message_size", size).
+			Msg("received duplicate pubsub message")
+	}
 }
 
 // ThrottlePeer is called by GossipSub when a peer is throttled by the local node, i.e., the local node is not accepting any

--- a/network/p2p/tracer/gossipSubMeshTracer.go
+++ b/network/p2p/tracer/gossipSubMeshTracer.go
@@ -261,8 +261,14 @@ func (t *GossipSubMeshTracer) Leave(topic string) {
 // ValidateMessage is called by GossipSub as a callback when a message is received by the local node and entered the validation phase.
 // As the result of the validation, the message may be rejected or passed to the application (i.e., Flow protocol).
 func (t *GossipSubMeshTracer) ValidateMessage(msg *pubsub.Message) {
-	lg := t.logger.With().Logger()
+	size := len(msg.Data)
+	t.metrics.OnMessageEnteredValidation(size)
 
+	if t.logger.GetLevel() != zerolog.TraceLevel {
+		return // return fast if we are not logging at trace level.
+	}
+
+	lg := t.logger.With().Logger()
 	if msg.Topic != nil {
 		lg = lg.With().Str("topic", *msg.Topic).Logger()
 	}
@@ -270,20 +276,24 @@ func (t *GossipSubMeshTracer) ValidateMessage(msg *pubsub.Message) {
 	if err == nil {
 		lg = lg.With().Str("remote_peer_id", p2plogging.PeerId(from)).Logger()
 	}
-	size := len(msg.Data)
-	t.metrics.OnMessageEnteredValidation(size)
-	if t.logger.GetLevel() == zerolog.TraceLevel {
-		lg.Trace().
-			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-			Int("message_size", size).
-			Msg("received pubsub message entered validation phase")
-	}
+
+	lg.Trace().
+		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+		Int("message_size", size).
+		Msg("received pubsub message entered validation phase")
+
 }
 
 // DeliverMessage is called by GossipSub as a callback when the local node delivers a message to all subscribers of the topic.
 func (t *GossipSubMeshTracer) DeliverMessage(msg *pubsub.Message) {
-	lg := t.logger.With().Logger()
+	size := len(msg.Data)
+	t.metrics.OnMessageDeliveredToAllSubscribers(size)
 
+	if t.logger.GetLevel() != zerolog.TraceLevel {
+		return // return fast if we are not logging at trace level.
+	}
+
+	lg := t.logger.With().Logger()
 	if msg.Topic != nil {
 		lg = lg.With().Str("topic", *msg.Topic).Logger()
 	}
@@ -291,14 +301,11 @@ func (t *GossipSubMeshTracer) DeliverMessage(msg *pubsub.Message) {
 	if err == nil {
 		lg = lg.With().Str("remote_peer_id", p2plogging.PeerId(from)).Logger()
 	}
-	size := len(msg.Data)
-	t.metrics.OnMessageDeliveredToAllSubscribers(size)
-	if t.logger.GetLevel() == zerolog.TraceLevel {
-		lg.Trace().
-			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-			Int("message_size", len(msg.Data)).
-			Msg("delivered pubsub message to all subscribers")
-	}
+
+	lg.Trace().
+		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+		Int("message_size", len(msg.Data)).
+		Msg("delivered pubsub message to all subscribers")
 }
 
 // RejectMessage is called by GossipSub as a callback when a message is rejected by the local node.
@@ -307,8 +314,14 @@ func (t *GossipSubMeshTracer) DeliverMessage(msg *pubsub.Message) {
 // networking public key of the source, and the signature of the message. The local node uses this information to verify the message.
 // If any of the information is missing or invalid, the message is rejected.
 func (t *GossipSubMeshTracer) RejectMessage(msg *pubsub.Message, reason string) {
-	lg := t.logger.With().Logger()
+	size := len(msg.Data)
+	t.metrics.OnMessageRejected(size, reason)
 
+	if t.logger.GetLevel() != zerolog.TraceLevel {
+		return // fail fast if we are not logging at trace level.
+	}
+
+	lg := t.logger.With().Logger()
 	if msg.Topic != nil {
 		lg = lg.With().Str("topic", *msg.Topic).Logger()
 	}
@@ -316,18 +329,22 @@ func (t *GossipSubMeshTracer) RejectMessage(msg *pubsub.Message, reason string) 
 	if err == nil {
 		lg = lg.With().Str("remote_peer_id", p2plogging.PeerId(from)).Logger()
 	}
-	size := len(msg.Data)
-	t.metrics.OnMessageRejected(size, reason)
-	if t.logger.GetLevel() == zerolog.TraceLevel {
-		lg.Trace().
-			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-			Int("message_size", size).
-			Msg("rejected pubsub message")
-	}
+
+	lg.Trace().
+		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+		Int("message_size", size).
+		Msg("rejected pubsub message")
 }
 
 // DuplicateMessage is called by GossipSub as a callback when a duplicate message is received by the local node.
 func (t *GossipSubMeshTracer) DuplicateMessage(msg *pubsub.Message) {
+	size := len(msg.Data)
+	t.metrics.OnMessageDuplicate(size)
+
+	if t.logger.GetLevel() != zerolog.TraceLevel {
+		return // return fast if we are not logging at trace level.
+	}
+
 	lg := t.logger.With().Logger()
 
 	if msg.Topic != nil {
@@ -338,14 +355,10 @@ func (t *GossipSubMeshTracer) DuplicateMessage(msg *pubsub.Message) {
 		lg = lg.With().Str("remote_peer_id", p2plogging.PeerId(from)).Logger()
 	}
 
-	size := len(msg.Data)
-	t.metrics.OnMessageDuplicate(size)
-	if t.logger.GetLevel() == zerolog.TraceLevel {
-		lg.Trace().
-			Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
-			Int("message_size", size).
-			Msg("received duplicate pubsub message")
-	}
+	lg.Trace().
+		Str("received_from", p2plogging.PeerId(msg.ReceivedFrom)).
+		Int("message_size", size).
+		Msg("received duplicate pubsub message")
 }
 
 // ThrottlePeer is called by GossipSub when a peer is throttled by the local node, i.e., the local node is not accepting any


### PR DESCRIPTION
This is a minor expansion on top of https://github.com/onflow/flow-go/pull/5083, which surrounds all trace level logs in GossipSub tracer with level check.