### PR TITLE
Update EVM test

### DIFF
--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2955,12 +2955,10 @@ func TestTransientNetworkCoreContractAddresses(t *testing.T) {
 }
 
 func TestEVM(t *testing.T) {
-
 	t.Run("successful transaction", newVMTest().
 		withBootstrapProcedureOptions(fvm.WithSetupEVMEnabled(true)).
-		// we keep this dissabled during bootstrap and later overwrite in the test for test transaction
 		withContextOptions(
-			fvm.WithEVMEnabled(false),
+			fvm.WithEVMEnabled(true),
 			fvm.WithCadenceLogging(true),
 		).
 		run(func(
@@ -2997,7 +2995,6 @@ func TestEVM(t *testing.T) {
 			err = testutil.SignTransactionAsServiceAccount(txBody, 0, chain)
 			require.NoError(t, err)
 
-			ctx = fvm.NewContextFromParent(ctx, fvm.WithEVMEnabled(true))
 			_, output, err := vm.Run(
 				ctx,
 				fvm.Transaction(txBody, 0),


### PR DESCRIPTION
The EVM test had some workarounds that are no longer needed since https://github.com/onflow/flow-go/pull/5106.