### PR TITLE
Revert deleted `crypto/hash` and `crypto/random` packages

### DIFF
--- a/crypto/hash/empty.go
+++ b/crypto/hash/empty.go
@@ -1,0 +1,1 @@
+package hash

--- a/crypto/random/empty.go
+++ b/crypto/random/empty.go
@@ -1,0 +1,1 @@
+package random


### PR DESCRIPTION
Updating dependencies in other repos is failing because the packages `onflow/flow-go/crypto/hash` and `onflow/flow-go/crypto/random` do not exist anymore. 
This PR reverts the packages as empty (similar to `onflow/flow-go/crypto`)  to unblock the other repos updates.