### PR TITLE
[Util] Find block ID by state commitment

### DIFF
--- a/cmd/util/cmd/read-badger/cmd/commits.go
+++ b/cmd/util/cmd/read-badger/cmd/commits.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	findBlockByCommit "github.com/onflow/flow-go/cmd/util/cmd/read-badger/cmd/find-block-by-commit"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -12,6 +13,8 @@ func init() {
 
 	commitsCmd.Flags().StringVarP(&flagBlockID, "block-id", "b", "", "the block id of which to query the state commitment")
 	_ = commitsCmd.MarkFlagRequired("block-id")
+
+	rootCmd.AddCommand(findBlockByCommit.Init(InitStorages))
 }
 
 var commitsCmd = &cobra.Command{

--- a/cmd/util/cmd/read-badger/cmd/commits.go
+++ b/cmd/util/cmd/read-badger/cmd/commits.go
@@ -4,7 +4,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	findBlockByCommit "github.com/onflow/flow-go/cmd/util/cmd/read-badger/cmd/find-block-by-commit"
+	findBlockByCommits "github.com/onflow/flow-go/cmd/util/cmd/read-badger/cmd/find-block-by-commits"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -14,7 +14,7 @@ func init() {
 	commitsCmd.Flags().StringVarP(&flagBlockID, "block-id", "b", "", "the block id of which to query the state commitment")
 	_ = commitsCmd.MarkFlagRequired("block-id")
 
-	rootCmd.AddCommand(findBlockByCommit.Init(InitStorages))
+	rootCmd.AddCommand(findBlockByCommits.Init(InitStorages))
 }
 
 var commitsCmd = &cobra.Command{

--- a/cmd/util/cmd/read-badger/cmd/find-block-by-commit/main.go
+++ b/cmd/util/cmd/read-badger/cmd/find-block-by-commit/main.go
@@ -1,0 +1,101 @@
+package find
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+)
+
+var cmd = &cobra.Command{
+	Use:   "find-block-id-commit",
+	Short: "find block ID by commit",
+	Run:   run,
+}
+
+var flagStartHeight uint64
+var flagEndHeight uint64
+var flagStateCommitment string
+
+var loader func() (*storage.All, *badger.DB) = nil
+
+func Init(f func() (*storage.All, *badger.DB)) *cobra.Command {
+	loader = f
+
+	cmd.Flags().Uint64Var(&flagStartHeight, "start-height", 0, "start height to block for commit")
+	_ = cmd.MarkFlagRequired("start-height")
+
+	cmd.Flags().Uint64Var(&flagEndHeight, "end-height", 0, "end height to block for commit")
+	_ = cmd.MarkFlagRequired("end-height")
+
+	cmd.Flags().StringVar(&flagStateCommitment, "state-commitment", "",
+		"State commitment (64 chars, hex-encoded)")
+	_ = cmd.MarkFlagRequired("state-commitment")
+
+	return cmd
+}
+
+func FindBlockIDByCommit(
+	log zerolog.Logger,
+	headers storage.Headers,
+	commits storage.Commits,
+	commit flow.StateCommitment,
+	startHeight uint64,
+	endHeight uint64,
+) (flow.Identifier, error) {
+	for height := startHeight; height <= endHeight; height++ {
+		log.Info().Msgf("finding for height %v for height range: [%v, %v]", height, startHeight, endHeight)
+		blockID, err := headers.BlockIDByHeight(height)
+		if err != nil {
+			return flow.ZeroID, fmt.Errorf("could not find block by height %v: %w", height, err)
+		}
+
+		executedCommit, err := commits.ByBlockID(blockID)
+		if err != nil {
+			return flow.ZeroID, fmt.Errorf("could not find commitment at height %v: %w", height, err)
+		}
+
+		if commit == executedCommit {
+			log.Info().Msgf("successfully found block %v at height %v for commit %v",
+				blockID, height, commit)
+			return blockID, nil
+		}
+	}
+
+	return flow.ZeroID, fmt.Errorf("could not find commit within height range [%v,%v]", startHeight, endHeight)
+}
+
+func run(*cobra.Command, []string) {
+	stateCommitmentBytes, err := hex.DecodeString(flagStateCommitment)
+	if err != nil {
+		log.Fatal().Err(err).Msg("invalid flag, cannot decode")
+	}
+
+	stateCommitment, err := flow.ToStateCommitment(stateCommitmentBytes)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("invalid number of bytes, got %d expected %d", len(stateCommitmentBytes), len(stateCommitment))
+	}
+
+	storage, db := loader()
+	defer db.Close()
+
+	_, err = FindBlockIDByCommit(
+		log.Logger,
+		storage.Headers,
+		storage.Commits,
+		stateCommitment,
+		flagStartHeight,
+		flagEndHeight,
+	)
+
+	if err != nil {
+		log.Fatal().Err(err).Msgf("fail to find block id by commit")
+	}
+
+}

--- a/cmd/util/cmd/read-badger/cmd/find-block-by-commits/main.go
+++ b/cmd/util/cmd/read-badger/cmd/find-block-by-commits/main.go
@@ -116,7 +116,7 @@ func run(*cobra.Command, []string) {
 	}
 
 	storage, db := loader()
-	defer func () { 
+	defer func() {
 		err := db.Close()
 		if err != nil {
 			log.Warn().Err(err).Msg("error closing db")

--- a/cmd/util/cmd/read-badger/cmd/find-block-by-commits/main.go
+++ b/cmd/util/cmd/read-badger/cmd/find-block-by-commits/main.go
@@ -36,7 +36,7 @@ func Init(f func() (*storage.All, *badger.DB)) *cobra.Command {
 	_ = cmd.MarkFlagRequired("end-height")
 
 	cmd.Flags().StringVar(&flagStateCommitments, "state-commitments", "",
-		"State commitments (each must be 64 chars, hex-encoded)")
+		"Comma separated list of state commitments (each must be 64 chars, hex-encoded)")
 	_ = cmd.MarkFlagRequired("state-commitments")
 
 	return cmd
@@ -116,7 +116,12 @@ func run(*cobra.Command, []string) {
 	}
 
 	storage, db := loader()
-	defer db.Close()
+	defer func () { 
+		err := db.Close()
+		if err != nil {
+			log.Warn().Err(err).Msg("error closing db")
+		}
+	}()
 
 	_, err = FindBlockIDByCommits(
 		log.Logger,

--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 	checkpoint_collect_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-collect-stats"
 	checkpoint_list_tries "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-list-tries"
+	checkpoint_trie_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-trie-stats"
 	epochs "github.com/onflow/flow-go/cmd/util/cmd/epochs/cmd"
 	export "github.com/onflow/flow-go/cmd/util/cmd/exec-data-json-export"
 	edbs "github.com/onflow/flow-go/cmd/util/cmd/execution-data-blobstore/cmd"
@@ -65,6 +66,7 @@ func addCommands() {
 	rootCmd.AddCommand(extract.Cmd)
 	rootCmd.AddCommand(export.Cmd)
 	rootCmd.AddCommand(checkpoint_list_tries.Cmd)
+	rootCmd.AddCommand(checkpoint_trie_stats.Cmd)
 	rootCmd.AddCommand(checkpoint_collect_stats.Cmd)
 	rootCmd.AddCommand(truncate_database.Cmd)
 	rootCmd.AddCommand(read_badger.RootCmd)


### PR DESCRIPTION
This PR adds a command to util to find block ID by state commitment within a height range.

This is useful to know which block is the checkpoint for. 

When recovering an execution node to an old state, we need to know which block is the checkpoint file for. The checkpoint file contains tries with state commitments as trie root hashes. However, the checkpoint file doesn't contain block information, it's difficult to know which blocks are the state commitments for. With this util command, we can specify a height range, and look up the block ID for a list of state commitments we read from the checkpoint file