### PR TITLE
[Execution] Move maxCollectionHeight to metrics

### DIFF
--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -45,7 +45,6 @@ type Engine struct {
 	mempool             *Mempool
 	execState           state.ExecutionState
 	metrics             module.ExecutionMetrics
-	maxCollectionHeight uint64
 	tracer              module.Tracer
 	extensiveLogging    bool
 	executionDataPruner *pruner.Pruner
@@ -89,7 +88,6 @@ func New(
 		mempool:             mempool,
 		execState:           execState,
 		metrics:             metrics,
-		maxCollectionHeight: 0,
 		tracer:              tracer,
 		extensiveLogging:    extLog,
 		executionDataPruner: pruner,
@@ -683,11 +681,7 @@ func (e *Engine) addCollectionToMempool(
 		}
 
 		// record collection max height metrics
-		blockHeight := executableBlock.Block.Header.Height
-		if blockHeight > e.maxCollectionHeight {
-			e.metrics.UpdateCollectionMaxHeight(blockHeight)
-			e.maxCollectionHeight = blockHeight
-		}
+		e.metrics.UpdateCollectionMaxHeight(executableBlock.Block.Header.Height)
 
 		if completeCollection.IsCompleted() {
 			// already received transactions for this collection

--- a/engine/execution/ingestion/engine.go
+++ b/engine/execution/ingestion/engine.go
@@ -680,7 +680,6 @@ func (e *Engine) addCollectionToMempool(
 				blockID)
 		}
 
-		// record collection max height metrics
 		e.metrics.UpdateCollectionMaxHeight(executableBlock.Block.Header.Height)
 
 		if completeCollection.IsCompleted() {

--- a/module/metrics/execution.go
+++ b/module/metrics/execution.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/counters"
 )
 
 type ExecutionCollector struct {
@@ -81,7 +82,7 @@ type ExecutionCollector struct {
 	stateSyncActive                         prometheus.Gauge
 	blockDataUploadsInProgress              prometheus.Gauge
 	blockDataUploadsDuration                prometheus.Histogram
-	maxCollectionHeightData                 uint64
+	maxCollectionHeightData                 counters.StrictMonotonousCounter
 	maxCollectionHeight                     prometheus.Gauge
 	computationResultUploadedCount          prometheus.Counter
 	computationResultUploadRetriedCount     prometheus.Counter
@@ -684,7 +685,7 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 			Help:      "the number of times a program was found in the cache",
 		}),
 
-		maxCollectionHeightData: 0,
+		maxCollectionHeightData: counters.NewMonotonousCounter(0),
 		maxCollectionHeight: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "max_collection_height",
 			Namespace: namespaceExecution,
@@ -952,9 +953,9 @@ func (ec *ExecutionCollector) RuntimeTransactionProgramsCacheHit() {
 }
 
 func (ec *ExecutionCollector) UpdateCollectionMaxHeight(height uint64) {
-	if height > ec.maxCollectionHeightData {
+	updated := ec.maxCollectionHeightData.Set(height)
+	if updated {
 		ec.maxCollectionHeight.Set(float64(height))
-		ec.maxCollectionHeightData = height
 	}
 }
 

--- a/module/metrics/execution.go
+++ b/module/metrics/execution.go
@@ -81,6 +81,7 @@ type ExecutionCollector struct {
 	stateSyncActive                         prometheus.Gauge
 	blockDataUploadsInProgress              prometheus.Gauge
 	blockDataUploadsDuration                prometheus.Histogram
+	maxCollectionHeightData                 uint64
 	maxCollectionHeight                     prometheus.Gauge
 	computationResultUploadedCount          prometheus.Counter
 	computationResultUploadRetriedCount     prometheus.Counter
@@ -683,6 +684,7 @@ func NewExecutionCollector(tracer module.Tracer) *ExecutionCollector {
 			Help:      "the number of times a program was found in the cache",
 		}),
 
+		maxCollectionHeightData: 0,
 		maxCollectionHeight: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "max_collection_height",
 			Namespace: namespaceExecution,
@@ -950,7 +952,10 @@ func (ec *ExecutionCollector) RuntimeTransactionProgramsCacheHit() {
 }
 
 func (ec *ExecutionCollector) UpdateCollectionMaxHeight(height uint64) {
-	ec.maxCollectionHeight.Set(float64(height))
+	if height > ec.maxCollectionHeightData {
+		ec.maxCollectionHeight.Set(float64(height))
+		ec.maxCollectionHeightData = height
+	}
 }
 
 func (ec *ExecutionCollector) ExecutionComputationResultUploaded() {


### PR DESCRIPTION
Simplify ingestion engine by moving a metrics-related state var to metrics module.