### PR TITLE
[Flow EVM] Include the block hash in `evm.BlockExecuted` event payload

### DIFF
--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -168,6 +168,7 @@ var blockExecutedEventCadenceType = &cadence.EventType{
 	QualifiedIdentifier: string(EventTypeBlockExecuted),
 	Fields: []cadence.Field{
 		cadence.NewField("height", cadence.UInt64Type{}),
+		cadence.NewField("hash", cadence.StringType{}),
 		cadence.NewField("totalSupply", cadence.UInt64Type{}),
 		cadence.NewField("parentHash", cadence.StringType{}),
 		cadence.NewField("receiptRoot", cadence.StringType{}),
@@ -188,8 +189,14 @@ func (p *BlockExecutedEventPayload) CadenceEvent() (cadence.Event, error) {
 		hashes[i] = cadence.String(hash.String())
 	}
 
+	blockHash, err := p.Block.Hash()
+	if err != nil {
+		return cadence.Event{}, err
+	}
+
 	fields := []cadence.Value{
 		cadence.NewUInt64(p.Block.Height),
+		cadence.String(blockHash.String()),
 		cadence.NewUInt64(p.Block.TotalSupply),
 		cadence.String(p.Block.ParentBlockHash.String()),
 		cadence.String(p.Block.ReceiptRoot.String()),


### PR DESCRIPTION
Currently, the event payload does not include this field:

```shell
- height (UInt64): 1
- totalSupply (UInt64): 5000000000000000000
- parentHash (String): "0x0000000000000000000000000000000000000000000000000000000000000000"
- stateRoot (String): "0xe81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421c0"
- receiptRoot (String): "0x48015828c844bff65608bad9fbd1967ea69a2132aaa3223a0d169b4d11cf743e"
- transactionHashes (?): ["0x7b72b5729cafbd2472a7c5b28e2cb9bf6b4de80cc15dae786a0b13aebc54e97e"]
hex: 5b22307837623732623537323963616662643234373261376335623238653263623962663662346465383063633135646165373836613062313361656263353465393765225d
```