### PR TITLE
Use correct EVM address in tests and transient networks

### DIFF
--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -325,7 +325,7 @@ func SystemContractChanges(chainID flow.ChainID) []SystemContractChange {
 
 		// EVM related contracts
 		NewSystemContractChange(
-			systemContracts.EVM,
+			systemContracts.EVMContract,
 			evm.ContractCode(
 				systemContracts.FlowToken.Address,
 				true,

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -821,7 +821,7 @@ func (b *bootstrapExecutor) setupEVM(serviceAddress, fungibleTokenAddress, flowT
 	if b.setupEVMEnabled {
 		evmAcc := b.createAccount(nil) // account for storage
 		tx := blueprints.DeployContractTransaction(
-			serviceAddress,
+			evmAcc,
 			stdlib.ContractCode(flowTokenAddress, bool(b.evmAbiOnly)),
 			stdlib.ContractName,
 		)

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -819,9 +819,15 @@ func (b *bootstrapExecutor) setStakingAllowlist(
 
 func (b *bootstrapExecutor) setupEVM(serviceAddress, fungibleTokenAddress, flowTokenAddress flow.Address) {
 	if b.setupEVMEnabled {
-		evmAcc := b.createAccount(nil) // account for storage
+		// account for storage
+		// we dont need to deploy anything to this account, but it needs to exist
+		// so that we can store the EVM state on it
+		evmAcc := b.createAccount(nil)
+		b.setupStorageForAccount(evmAcc, serviceAddress, fungibleTokenAddress, flowTokenAddress)
+
+		// deploy the EVM contract to the service account
 		tx := blueprints.DeployContractTransaction(
-			evmAcc,
+			serviceAddress,
 			stdlib.ContractCode(flowTokenAddress, bool(b.evmAbiOnly)),
 			stdlib.ContractName,
 		)
@@ -831,8 +837,6 @@ func (b *bootstrapExecutor) setupEVM(serviceAddress, fungibleTokenAddress, flowT
 			Transaction(tx, 0),
 		)
 		panicOnMetaInvokeErrf("failed to deploy EVM contract: %s", txError, err)
-
-		b.setupStorageForAccount(evmAcc, serviceAddress, fungibleTokenAddress, flowTokenAddress)
 	}
 }
 

--- a/fvm/evm/evm.go
+++ b/fvm/evm/evm.go
@@ -12,9 +12,14 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func RootAccountAddress(chainID flow.ChainID) (flow.Address, error) {
+func ContractAccountAddress(chainID flow.ChainID) (flow.Address, error) {
 	sc := systemcontracts.SystemContractsForChain(chainID)
 	return sc.EVM.Address, nil
+}
+
+func StorageAccountAddress(chainID flow.ChainID) (flow.Address, error) {
+	sc := systemcontracts.SystemContractsForChain(chainID)
+	return sc.EVMStorage.Address, nil
 }
 
 func SetupEnvironment(
@@ -24,26 +29,31 @@ func SetupEnvironment(
 	service flow.Address,
 	flowToken flow.Address,
 ) error {
-	evmRootAddress, err := RootAccountAddress(chainID)
+	evmStorageAccountAddress, err := StorageAccountAddress(chainID)
 	if err != nil {
 		return err
 	}
 
-	em := evm.NewEmulator(backend, evmRootAddress)
-
-	bs, err := handler.NewBlockStore(backend, evmRootAddress)
+	evmContractAccountAddress, err := ContractAccountAddress(chainID)
 	if err != nil {
 		return err
 	}
 
-	aa, err := handler.NewAddressAllocator(backend, evmRootAddress)
+	em := evm.NewEmulator(backend, evmStorageAccountAddress)
+
+	bs, err := handler.NewBlockStore(backend, evmStorageAccountAddress)
+	if err != nil {
+		return err
+	}
+
+	aa, err := handler.NewAddressAllocator(backend, evmStorageAccountAddress)
 	if err != nil {
 		return err
 	}
 
 	contractHandler := handler.NewContractHandler(common.Address(flowToken), bs, aa, backend, em)
 
-	stdlib.SetupEnvironment(env, contractHandler, evmRootAddress)
+	stdlib.SetupEnvironment(env, contractHandler, evmContractAccountAddress)
 
 	return nil
 }

--- a/fvm/evm/evm.go
+++ b/fvm/evm/evm.go
@@ -14,7 +14,7 @@ import (
 
 func ContractAccountAddress(chainID flow.ChainID) (flow.Address, error) {
 	sc := systemcontracts.SystemContractsForChain(chainID)
-	return sc.EVM.Address, nil
+	return sc.EVMContract.Address, nil
 }
 
 func StorageAccountAddress(chainID flow.ChainID) (flow.Address, error) {

--- a/fvm/evm/evm.go
+++ b/fvm/evm/evm.go
@@ -24,7 +24,6 @@ func SetupEnvironment(
 	service flow.Address,
 	flowToken flow.Address,
 ) error {
-	// TODO: setup proper root address based on chainID
 	evmRootAddress, err := RootAccountAddress(chainID)
 	if err != nil {
 		return err
@@ -44,7 +43,7 @@ func SetupEnvironment(
 
 	contractHandler := handler.NewContractHandler(common.Address(flowToken), bs, aa, backend, em)
 
-	stdlib.SetupEnvironment(env, contractHandler, service)
+	stdlib.SetupEnvironment(env, contractHandler, evmRootAddress)
 
 	return nil
 }

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -44,7 +44,7 @@ func TestEVMRun(t *testing.T) {
                               EVM.run(tx: tx, coinbase: coinbase)
                           }
                         `,
-								sc.EVM.Address.HexWithPrefix(),
+								sc.EVMContract.Address.HexWithPrefix(),
 							))
 
 							gasLimit := uint64(100_000)
@@ -144,7 +144,7 @@ func TestEVMAddressDeposit(t *testing.T) {
                                    address.deposit(from: <-vault)
                                }
                             `,
-							sc.EVM.Address.HexWithPrefix(),
+							sc.EVMContract.Address.HexWithPrefix(),
 							sc.FlowToken.Address.HexWithPrefix(),
 							sc.FlowServiceAccount.Address.HexWithPrefix(),
 						))
@@ -205,7 +205,7 @@ func TestBridgedAccountWithdraw(t *testing.T) {
                                    return balance
                                }
                             `,
-							sc.EVM.Address.HexWithPrefix(),
+							sc.EVMContract.Address.HexWithPrefix(),
 							sc.FlowToken.Address.HexWithPrefix(),
 							sc.FlowServiceAccount.Address.HexWithPrefix(),
 						))
@@ -268,7 +268,7 @@ func TestBridgedAccountDeploy(t *testing.T) {
                                    return address.bytes
                                 }
                             `,
-							sc.EVM.Address.HexWithPrefix(),
+							sc.EVMContract.Address.HexWithPrefix(),
 							sc.FlowToken.Address.HexWithPrefix(),
 							sc.FlowServiceAccount.Address.HexWithPrefix(),
 						))

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -33,6 +33,7 @@ func TestEVMRun(t *testing.T) {
 						chain := flow.Emulator.Chain()
 
 						RunWithNewTestVM(t, chain, func(ctx fvm.Context, vm fvm.VM, snapshot snapshot.SnapshotTree) {
+							sc := systemcontracts.SystemContractsForChain(chain.ChainID())
 							code := []byte(fmt.Sprintf(
 								`
                           import EVM from %s
@@ -43,7 +44,7 @@ func TestEVMRun(t *testing.T) {
                               EVM.run(tx: tx, coinbase: coinbase)
                           }
                         `,
-								chain.ServiceAddress().HexWithPrefix(),
+								sc.EVM.Address.HexWithPrefix(),
 							))
 
 							gasLimit := uint64(100_000)
@@ -126,12 +127,12 @@ func TestEVMAddressDeposit(t *testing.T) {
 
 						code := []byte(fmt.Sprintf(
 							`
-                               import EVM from %[1]s
-                               import FlowToken from %[2]s
+                               import EVM from %s
+                               import FlowToken from %s
 
                                access(all)
                                fun main() {
-                                   let admin = getAuthAccount(%[1]s)
+                                   let admin = getAuthAccount(%s)
                                        .borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)!
                                    let minter <- admin.createNewMinter(allowedAmount: 1.23)
                                    let vault <- minter.mintTokens(amount: 1.23)
@@ -143,8 +144,9 @@ func TestEVMAddressDeposit(t *testing.T) {
                                    address.deposit(from: <-vault)
                                }
                             `,
-							sc.FlowServiceAccount.Address.HexWithPrefix(),
+							sc.EVM.Address.HexWithPrefix(),
 							sc.FlowToken.Address.HexWithPrefix(),
+							sc.FlowServiceAccount.Address.HexWithPrefix(),
 						))
 
 						script := fvm.Script(code)
@@ -181,12 +183,12 @@ func TestBridgedAccountWithdraw(t *testing.T) {
 
 						code := []byte(fmt.Sprintf(
 							`
-                               import EVM from %[1]s
-                               import FlowToken from %[2]s
+                               import EVM from %s
+                               import FlowToken from %s
 
                                access(all)
                                fun main(): UFix64 {
-                                   let admin = getAuthAccount(%[1]s)
+                                   let admin = getAuthAccount(%s)
                                        .borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)!
                                    let minter <- admin.createNewMinter(allowedAmount: 2.34)
                                    let vault <- minter.mintTokens(amount: 2.34)
@@ -203,8 +205,9 @@ func TestBridgedAccountWithdraw(t *testing.T) {
                                    return balance
                                }
                             `,
-							sc.FlowServiceAccount.Address.HexWithPrefix(),
+							sc.EVM.Address.HexWithPrefix(),
 							sc.FlowToken.Address.HexWithPrefix(),
+							sc.FlowServiceAccount.Address.HexWithPrefix(),
 						))
 
 						script := fvm.Script(code)
@@ -242,12 +245,12 @@ func TestBridgedAccountDeploy(t *testing.T) {
 
 						code := []byte(fmt.Sprintf(
 							`
-                               import EVM from %[1]s
-                               import FlowToken from %[2]s
+                               import EVM from %s
+                               import FlowToken from %s
 
                                 access(all)
                                 fun main(): [UInt8; 20] {
-                                   let admin = getAuthAccount(%[1]s)
+                                   let admin = getAuthAccount(%s)
                                        .borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)!
                                    let minter <- admin.createNewMinter(allowedAmount: 2.34)
                                    let vault <- minter.mintTokens(amount: 2.34)
@@ -265,8 +268,9 @@ func TestBridgedAccountDeploy(t *testing.T) {
                                    return address.bytes
                                 }
                             `,
-							sc.FlowServiceAccount.Address.HexWithPrefix(),
+							sc.EVM.Address.HexWithPrefix(),
 							sc.FlowToken.Address.HexWithPrefix(),
+							sc.FlowServiceAccount.Address.HexWithPrefix(),
 						))
 
 						script := fvm.Script(code)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -542,7 +542,7 @@ func BenchmarkRuntimeTransaction(b *testing.B) {
 			sc.FungibleToken.Address.Hex(),
 			sc.FlowToken.Address.Hex(),
 			testContractAddress,
-			sc.FlowServiceAccount.Address.Hex(),
+			sc.EVM.Address.Hex(),
 			rep,
 			prepare,
 		)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -542,7 +542,7 @@ func BenchmarkRuntimeTransaction(b *testing.B) {
 			sc.FungibleToken.Address.Hex(),
 			sc.FlowToken.Address.Hex(),
 			testContractAddress,
-			sc.EVM.Address.Hex(),
+			sc.EVMContract.Address.Hex(),
 			rep,
 			prepare,
 		)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -423,7 +423,7 @@ func BenchmarkRuntimeTransaction(b *testing.B) {
 	}
 	sc := systemcontracts.SystemContractsForChain(chain.ChainID())
 
-	testContractAddress, err := chain.AddressAtIndex(systemcontracts.EVMAccountIndex + 1)
+	testContractAddress, err := chain.AddressAtIndex(systemcontracts.EVMStorageAccountIndex + 1)
 	require.NoError(b, err)
 
 	benchTransaction := func(
@@ -448,7 +448,7 @@ func BenchmarkRuntimeTransaction(b *testing.B) {
 		for _, account := range accounts {
 			addrs = append(addrs, account.Address)
 		}
-		evmAddress, err := chain.AddressAtIndex(systemcontracts.EVMAccountIndex)
+		evmAddress, err := chain.AddressAtIndex(systemcontracts.EVMStorageAccountIndex)
 		require.NoError(b, err)
 		addrs = append(addrs, evmAddress)
 

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2992,7 +2992,7 @@ func TestEVM(t *testing.T) {
 								log(addr)
 							}
 						}
-					`, sc.EVM.Address.HexWithPrefix()))).
+					`, sc.EVMContract.Address.HexWithPrefix()))).
 				SetProposalKey(chain.ServiceAddress(), 0, 0).
 				SetPayer(chain.ServiceAddress()).
 				AddArgument(encodedArg)
@@ -3010,7 +3010,7 @@ func TestEVM(t *testing.T) {
 			require.Len(t, output.Logs, 1)
 			require.Equal(t, output.Logs[0], fmt.Sprintf(
 				"A.%s.EVM.EVMAddress(bytes: %s)",
-				sc.EVM.Address,
+				sc.EVMContract.Address,
 				addrBytes.String(),
 			))
 		}),
@@ -3091,7 +3091,7 @@ func TestEVM(t *testing.T) {
 					destroy acc.withdraw(balance: bal);
 					destroy acc;
 				}
-			`, sc.EVM.Address.HexWithPrefix())))
+			`, sc.EVMContract.Address.HexWithPrefix())))
 
 			_, output, err := vm.Run(ctx, script, snapshotTree)
 
@@ -3149,7 +3149,7 @@ func TestEVM(t *testing.T) {
 					pub fun main() {
 						destroy <- EVM.createBridgedAccount();
 					}
-				`, sc.EVM.Address.HexWithPrefix())))
+				`, sc.EVMContract.Address.HexWithPrefix())))
 
 				_, output, err := vm.Run(ctx, script, errStorage)
 

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2980,6 +2980,8 @@ func TestEVM(t *testing.T) {
 			encodedArg, err := jsoncdc.Encode(addrBytes)
 			require.NoError(t, err)
 
+			sc := systemcontracts.SystemContractsForChain(chain.ChainID())
+
 			txBody := flow.NewTransactionBody().
 				SetScript([]byte(fmt.Sprintf(`
 						import EVM from %s
@@ -2990,7 +2992,7 @@ func TestEVM(t *testing.T) {
 								log(addr)
 							}
 						}
-					`, chain.ServiceAddress().HexWithPrefix()))).
+					`, sc.EVM.Address.HexWithPrefix()))).
 				SetProposalKey(chain.ServiceAddress(), 0, 0).
 				SetPayer(chain.ServiceAddress()).
 				AddArgument(encodedArg)
@@ -3008,7 +3010,7 @@ func TestEVM(t *testing.T) {
 			require.Len(t, output.Logs, 1)
 			require.Equal(t, output.Logs[0], fmt.Sprintf(
 				"A.%s.EVM.EVMAddress(bytes: %s)",
-				chain.ServiceAddress(),
+				sc.EVM.Address,
 				addrBytes.String(),
 			))
 		}),
@@ -3078,6 +3080,7 @@ func TestEVM(t *testing.T) {
 			ctx fvm.Context,
 			snapshotTree snapshot.SnapshotTree,
 		) {
+			sc := systemcontracts.SystemContractsForChain(chain.ChainID())
 			script := fvm.Script([]byte(fmt.Sprintf(`
 				import EVM from %s
 				
@@ -3088,7 +3091,7 @@ func TestEVM(t *testing.T) {
 					destroy acc.withdraw(balance: bal);
 					destroy acc;
 				}
-			`, chain.ServiceAddress().HexWithPrefix())))
+			`, sc.EVM.Address.HexWithPrefix())))
 
 			_, output, err := vm.Run(ctx, script, snapshotTree)
 
@@ -3114,6 +3117,7 @@ func TestEVM(t *testing.T) {
 			ctx fvm.Context,
 			snapshotTree snapshot.SnapshotTree,
 		) {
+			sc := systemcontracts.SystemContractsForChain(chain.ChainID())
 
 			tests := []struct {
 				err        error
@@ -3145,7 +3149,7 @@ func TestEVM(t *testing.T) {
 					pub fun main() {
 						destroy <- EVM.createBridgedAccount();
 					}
-				`, chain.ServiceAddress().HexWithPrefix())))
+				`, sc.EVM.Address.HexWithPrefix())))
 
 				_, output, err := vm.Run(ctx, script, errStorage)
 

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -140,8 +140,8 @@ type SystemContracts struct {
 	ViewResolver     SystemContract
 
 	// EVM related contracts
-	EVM        SystemContract
-	EVMStorage SystemAccount
+	EVMContract SystemContract
+	EVMStorage  SystemAccount
 }
 
 // AsTemplateEnv returns a template environment with all system contracts filled in.
@@ -194,7 +194,7 @@ func (c SystemContracts) All() []SystemContract {
 		c.MetadataViews,
 		c.ViewResolver,
 
-		c.EVM,
+		c.EVMContract,
 		// EVMStorage is not included here, since it is not a contract
 	}
 }
@@ -354,8 +354,8 @@ func init() {
 			MetadataViews:    addressOfContract(ContractNameMetadataViews),
 			ViewResolver:     addressOfContract(ContractNameViewResolver),
 
-			EVM:        addressOfContract(ContractNameEVM),
-			EVMStorage: addressOfAccount(AccountNameEVMStorage),
+			EVMContract: addressOfContract(ContractNameEVM),
+			EVMStorage:  addressOfAccount(AccountNameEVMStorage),
 		}
 
 		return contracts

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -40,6 +40,9 @@ const (
 	ContractNameViewResolver        = "ViewResolver"
 	ContractNameEVM                 = "EVM"
 
+	// AccountNameEVMStorage is not a contract, but a special account that is used to store EVM state
+	AccountNameEVMStorage = "EVMStorageAccount"
+
 	// Unqualified names of service events (not including address prefix or contract name)
 
 	EventNameEpochSetup    = "EpochSetup"
@@ -61,7 +64,7 @@ const (
 	FungibleTokenAccountIndex = 2
 	FlowTokenAccountIndex     = 3
 	FlowFeesAccountIndex      = 4
-	EVMAccountIndex           = 5
+	EVMStorageAccountIndex    = 5
 )
 
 // Well-known addresses for system contracts on long-running networks.
@@ -83,6 +86,12 @@ var (
 
 // SystemContract represents a system contract on a particular chain.
 type SystemContract struct {
+	Address flow.Address
+	Name    string
+}
+
+// SystemAccount represents an address used by the system.
+type SystemAccount struct {
 	Address flow.Address
 	Name    string
 }
@@ -131,7 +140,8 @@ type SystemContracts struct {
 	ViewResolver     SystemContract
 
 	// EVM related contracts
-	EVM SystemContract
+	EVM        SystemContract
+	EVMStorage SystemAccount
 }
 
 // AsTemplateEnv returns a template environment with all system contracts filled in.
@@ -185,6 +195,7 @@ func (c SystemContracts) All() []SystemContract {
 		c.ViewResolver,
 
 		c.EVM,
+		// EVMStorage is not included here, since it is not a contract
 	}
 }
 
@@ -292,12 +303,13 @@ func init() {
 		ContractNameMetadataViews:    nftTokenAddressFunc,
 		ContractNameViewResolver:     nftTokenAddressFunc,
 
-		ContractNameEVM: nthAddressFunc(EVMAccountIndex),
+		ContractNameEVM:       serviceAddressFunc,
+		AccountNameEVMStorage: nthAddressFunc(EVMStorageAccountIndex),
 	}
 
 	getSystemContractsForChain := func(chainID flow.ChainID) *SystemContracts {
 
-		contract := func(name string) SystemContract {
+		addressOfContract := func(name string) SystemContract {
 			addressFunc, ok := contractAddressFunc[name]
 			if !ok {
 				// this is a panic, since it can only happen if the code is wrong
@@ -310,26 +322,40 @@ func init() {
 			}
 		}
 
+		addressOfAccount := func(name string) SystemAccount {
+			addressFunc, ok := contractAddressFunc[name]
+			if !ok {
+				// this is a panic, since it can only happen if the code is wrong
+				panic(fmt.Sprintf("unknown system account name: %s", name))
+			}
+
+			return SystemAccount{
+				Address: addressFunc(chainID),
+				Name:    name,
+			}
+		}
+
 		contracts := &SystemContracts{
-			Epoch:          contract(ContractNameEpoch),
-			IDTableStaking: contract(ContractNameIDTableStaking),
-			ClusterQC:      contract(ContractNameClusterQC),
-			DKG:            contract(ContractNameDKG),
+			Epoch:          addressOfContract(ContractNameEpoch),
+			IDTableStaking: addressOfContract(ContractNameIDTableStaking),
+			ClusterQC:      addressOfContract(ContractNameClusterQC),
+			DKG:            addressOfContract(ContractNameDKG),
 
-			FlowServiceAccount:  contract(ContractNameServiceAccount),
-			NodeVersionBeacon:   contract(ContractNameNodeVersionBeacon),
-			RandomBeaconHistory: contract(ContractNameRandomBeaconHistory),
-			FlowStorageFees:     contract(ContractNameStorageFees),
+			FlowServiceAccount:  addressOfContract(ContractNameServiceAccount),
+			NodeVersionBeacon:   addressOfContract(ContractNameNodeVersionBeacon),
+			RandomBeaconHistory: addressOfContract(ContractNameRandomBeaconHistory),
+			FlowStorageFees:     addressOfContract(ContractNameStorageFees),
 
-			FlowFees:      contract(ContractNameFlowFees),
-			FlowToken:     contract(ContractNameFlowToken),
-			FungibleToken: contract(ContractNameFungibleToken),
+			FlowFees:      addressOfContract(ContractNameFlowFees),
+			FlowToken:     addressOfContract(ContractNameFlowToken),
+			FungibleToken: addressOfContract(ContractNameFungibleToken),
 
-			NonFungibleToken: contract(ContractNameNonFungibleToken),
-			MetadataViews:    contract(ContractNameMetadataViews),
-			ViewResolver:     contract(ContractNameViewResolver),
+			NonFungibleToken: addressOfContract(ContractNameNonFungibleToken),
+			MetadataViews:    addressOfContract(ContractNameMetadataViews),
+			ViewResolver:     addressOfContract(ContractNameViewResolver),
 
-			EVM: contract(ContractNameEVM),
+			EVM:        addressOfContract(ContractNameEVM),
+			EVMStorage: addressOfAccount(AccountNameEVMStorage),
 		}
 
 		return contracts

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -173,5 +173,5 @@ func (limiter TransactionStorageLimiter) shouldSkipSpecialAddress(
 	address flow.Address,
 	sc *systemcontracts.SystemContracts,
 ) bool {
-	return sc.EVM.Address == address
+	return sc.EVMStorage.Address == address
 }

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -173,5 +173,9 @@ func (limiter TransactionStorageLimiter) shouldSkipSpecialAddress(
 	address flow.Address,
 	sc *systemcontracts.SystemContracts,
 ) bool {
+	if !ctx.EVMEnabled {
+		return false
+	}
+
 	return sc.EVMStorage.Address == address
 }

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -183,7 +183,7 @@ func TestTransactionStorageLimiter(t *testing.T) {
 	)
 	t.Run("special account is skipped", func(t *testing.T) {
 		sc := systemcontracts.SystemContractsForChain(ctx.Chain.ChainID())
-		evm := sc.EVM.Address
+		evm := sc.EVMStorage.Address
 
 		executionSnapshot := &snapshot.ExecutionSnapshot{
 			WriteSet: map[flow.RegisterID]flow.RegisterValue{

--- a/fvm/transactionStorageLimiter_test.go
+++ b/fvm/transactionStorageLimiter_test.go
@@ -208,7 +208,14 @@ func TestTransactionStorageLimiter(t *testing.T) {
 			)
 
 		d := &fvm.TransactionStorageLimiter{}
+
+		// if EVM is disabled don't skip the storage check
 		err := d.CheckStorageLimits(ctx, env, executionSnapshot, flow.EmptyAddress, 0)
+		require.Error(t, err)
+
+		// if EVM is enabled skip the storage check
+		ctx := fvm.NewContextFromParent(ctx, fvm.WithEVMEnabled(true))
+		err = d.CheckStorageLimits(ctx, env, executionSnapshot, flow.EmptyAddress, 0)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
What was done in this PR

- A new system account (not a contract in this case) was introduced for EVM state storage. 
- The tests that use the EVM contract use the EVM account address from systemcontracts
- only skip the storage check on the EVM storage account if EVM is actually enabled. 


The EVM contract account will be the service account on all networks.
The EVM state storage account will be the fifth account on all transient networks. On non-transient networks an Account still has to be picked to serve that purpose.
