### PR TITLE
Update event validation logic to account for the `evm.*` events

### DIFF
--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -17,7 +17,6 @@ import (
 const (
 	EventTypeBlockExecuted       flow.EventType = "BlockExecuted"
 	EventTypeTransactionExecuted flow.EventType = "TransactionExecuted"
-	EVMLocationPrefix                           = "evm"
 	locationDivider                             = "."
 )
 
@@ -36,7 +35,7 @@ var _ common.Location = EVMLocation{}
 type EVMLocation struct{}
 
 func (l EVMLocation) TypeID(memoryGauge common.MemoryGauge, qualifiedIdentifier string) common.TypeID {
-	id := fmt.Sprintf("%s%s%s", EVMLocationPrefix, locationDivider, qualifiedIdentifier)
+	id := fmt.Sprintf("%s%s%s", flow.EVMLocationPrefix, locationDivider, qualifiedIdentifier)
 	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(id)))
 
 	return common.TypeID(id)
@@ -53,15 +52,15 @@ func (l EVMLocation) QualifiedIdentifier(typeID common.TypeID) string {
 }
 
 func (l EVMLocation) String() string {
-	return EVMLocationPrefix
+	return flow.EVMLocationPrefix
 }
 
 func (l EVMLocation) Description() string {
-	return EVMLocationPrefix
+	return flow.EVMLocationPrefix
 }
 
 func (l EVMLocation) ID() string {
-	return EVMLocationPrefix
+	return flow.EVMLocationPrefix
 }
 
 func (l EVMLocation) MarshalJSON() ([]byte, error) {
@@ -74,7 +73,7 @@ func (l EVMLocation) MarshalJSON() ([]byte, error) {
 
 func init() {
 	common.RegisterTypeIDDecoder(
-		EVMLocationPrefix,
+		flow.EVMLocationPrefix,
 		func(_ common.MemoryGauge, typeID string) (common.Location, string, error) {
 			if typeID == "" {
 				return nil, "", fmt.Errorf("invalid EVM type location ID: missing type prefix")
@@ -82,7 +81,7 @@ func init() {
 
 			parts := strings.SplitN(typeID, ".", 2)
 			prefix := parts[0]
-			if prefix != EVMLocationPrefix {
+			if prefix != flow.EVMLocationPrefix {
 				return EVMLocation{}, "", fmt.Errorf("invalid EVM type location ID: invalid prefix")
 			}
 

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -17,7 +17,7 @@ import (
 const (
 	EventTypeBlockExecuted       flow.EventType = "BlockExecuted"
 	EventTypeTransactionExecuted flow.EventType = "TransactionExecuted"
-	evmLocationPrefix                           = "evm"
+	EVMLocationPrefix                           = "evm"
 	locationDivider                             = "."
 )
 
@@ -36,7 +36,7 @@ var _ common.Location = EVMLocation{}
 type EVMLocation struct{}
 
 func (l EVMLocation) TypeID(memoryGauge common.MemoryGauge, qualifiedIdentifier string) common.TypeID {
-	id := fmt.Sprintf("%s%s%s", evmLocationPrefix, locationDivider, qualifiedIdentifier)
+	id := fmt.Sprintf("%s%s%s", EVMLocationPrefix, locationDivider, qualifiedIdentifier)
 	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(id)))
 
 	return common.TypeID(id)
@@ -53,15 +53,15 @@ func (l EVMLocation) QualifiedIdentifier(typeID common.TypeID) string {
 }
 
 func (l EVMLocation) String() string {
-	return evmLocationPrefix
+	return EVMLocationPrefix
 }
 
 func (l EVMLocation) Description() string {
-	return evmLocationPrefix
+	return EVMLocationPrefix
 }
 
 func (l EVMLocation) ID() string {
-	return evmLocationPrefix
+	return EVMLocationPrefix
 }
 
 func (l EVMLocation) MarshalJSON() ([]byte, error) {
@@ -74,7 +74,7 @@ func (l EVMLocation) MarshalJSON() ([]byte, error) {
 
 func init() {
 	common.RegisterTypeIDDecoder(
-		evmLocationPrefix,
+		EVMLocationPrefix,
 		func(_ common.MemoryGauge, typeID string) (common.Location, string, error) {
 			if typeID == "" {
 				return nil, "", fmt.Errorf("invalid EVM type location ID: missing type prefix")
@@ -82,7 +82,7 @@ func init() {
 
 			parts := strings.SplitN(typeID, ".", 2)
 			prefix := parts[0]
-			if prefix != evmLocationPrefix {
+			if prefix != EVMLocationPrefix {
 				return EVMLocation{}, "", fmt.Errorf("invalid EVM type location ID: invalid prefix")
 			}
 

--- a/model/events/parse.go
+++ b/model/events/parse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -31,7 +32,7 @@ func ParseEvent(eventType flow.EventType) (*ParsedEvent, error) {
 	parts := strings.Split(string(eventType), ".")
 
 	switch parts[0] {
-	case "flow", "evm":
+	case "flow", types.EVMLocationPrefix:
 		if len(parts) == 2 {
 			return &ParsedEvent{
 				Type:         ProtocolEventType,

--- a/model/events/parse.go
+++ b/model/events/parse.go
@@ -31,7 +31,7 @@ func ParseEvent(eventType flow.EventType) (*ParsedEvent, error) {
 	parts := strings.Split(string(eventType), ".")
 
 	switch parts[0] {
-	case "flow":
+	case "flow", "evm":
 		if len(parts) == 2 {
 			return &ParsedEvent{
 				Type:         ProtocolEventType,

--- a/model/events/parse.go
+++ b/model/events/parse.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -24,15 +23,16 @@ type ParsedEvent struct {
 	Name         string
 }
 
-// ParseEvent parses an event type into its parts. There are 2 valid EventType formats:
+// ParseEvent parses an event type into its parts. There are 3 valid EventType formats:
 // - flow.[EventName]
+// - evm.[EventName]
 // - A.[Address].[Contract].[EventName]
 // Any other format results in an error.
 func ParseEvent(eventType flow.EventType) (*ParsedEvent, error) {
 	parts := strings.Split(string(eventType), ".")
 
 	switch parts[0] {
-	case "flow", types.EVMLocationPrefix:
+	case "flow", flow.EVMLocationPrefix:
 		if len(parts) == 2 {
 			return &ParsedEvent{
 				Type:         ProtocolEventType,

--- a/model/events/parse_test.go
+++ b/model/events/parse_test.go
@@ -43,6 +43,17 @@ func TestParseEvent(t *testing.T) {
 				Name:         "EventA",
 			},
 		},
+		{
+			name:      "evm event",
+			eventType: "evm.BlockExecuted",
+			expected: events.ParsedEvent{
+				Type:         events.ProtocolEventType,
+				EventType:    "evm.BlockExecuted",
+				Contract:     "evm",
+				ContractName: "evm",
+				Name:         "BlockExecuted",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -69,6 +80,8 @@ func TestParseEvent_Invalid(t *testing.T) {
 		"B.0000000000000001.invalid.event", // invalid first part
 		"flow",                             // incorrect number of parts for protocol event
 		"flow.invalid.event",               // incorrect number of parts for protocol event
+		"evm",                              // incorrect number of parts for protocol event
+		"evm.invalid.event",                // incorrect number of parts for protocol event
 		"A.0000000000000001.invalid",       // incorrect number of parts for account event
 		"A.0000000000000001.invalid.a.b",   // incorrect number of parts for account event
 
@@ -111,6 +124,17 @@ func TestValidateEvent(t *testing.T) {
 				Name:         "EventA",
 			},
 		},
+		{
+			name:      "evm event",
+			eventType: "evm.BlockExecuted",
+			expected: events.ParsedEvent{
+				Type:         events.ProtocolEventType,
+				EventType:    "evm.BlockExecuted",
+				Contract:     "evm",
+				ContractName: "evm",
+				Name:         "BlockExecuted",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -137,6 +161,8 @@ func TestValidateEvent_Invalid(t *testing.T) {
 		"B.0000000000000001.invalid.event", // invalid first part
 		"flow",                             // incorrect number of parts for protocol event
 		"flow.invalid.event",               // incorrect number of parts for protocol event
+		"evm",                              // incorrect number of parts for protocol event
+		"evm.invalid.event",                // incorrect number of parts for protocol event
 		"A.0000000000000001.invalid",       // incorrect number of parts for account event
 		"A.0000000000000001.invalid.a.b",   // incorrect number of parts for account event
 		flow.EventType(fmt.Sprintf("A.%s.Contract1.EventA", unittest.RandomAddressFixture())), // address from wrong chain

--- a/model/flow/event.go
+++ b/model/flow/event.go
@@ -17,6 +17,8 @@ const (
 	EventAccountUpdated EventType = "flow.AccountUpdated"
 )
 
+const EVMLocationPrefix = "evm"
+
 type EventType string
 
 type Event struct {


### PR DESCRIPTION
It turns out that `flow` service/protocol events, are allowed to have only 2 parts, e.g. `flow.AccountCreated`.

The two newly-introduced EVM related events:
- `flow.evm.BlockExecuted`
- `flow.evm.TransactionExecuted`

do not comply with this format, hence, they are considered as invalid event types:

```shell
rpc error: code = InvalidArgument desc = invalid event filter: invalid event type flow.evm.BlockExecuted: invalid event type: flow.evm.BlockExecuted
```