### PR TITLE
[CI] Revert change to use semver build for without-netgo images - v0.33

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifeq (${IMAGE_TAG},)
 IMAGE_TAG := ${SHORT_COMMIT}
 endif
 
-IMAGE_TAG_NO_NETGO := $(IMAGE_TAG)+without-netgo
+IMAGE_TAG_NO_NETGO := $(IMAGE_TAG)-without-netgo
 
 # Name of the cover profile
 COVER_PROFILE := coverage.txt


### PR DESCRIPTION
Revert https://github.com/onflow/flow-go/pull/5157. The change to `without-netgo` image tags is not compliant with the docker tag format