### PR TITLE
[Access] add config to limit script execution range - master

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1434,9 +1434,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			return nil
 		}).
 		Module("backend script executor", func(node *cmd.NodeConfig) error {
-			builder.ScriptExecutor = backend.NewScriptExecutor()
-			builder.ScriptExecutor.SetMinCompatibleHeight(builder.scriptExecMinBlock)
-			builder.ScriptExecutor.SetMaxCompatibleHeight(builder.scriptExecMaxBlock)
+			builder.ScriptExecutor = backend.NewScriptExecutor(builder.Logger, builder.scriptExecMinBlock, builder.scriptExecMaxBlock)
 			return nil
 		}).
 		Module("async register store", func(node *cmd.NodeConfig) error {

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -147,6 +148,8 @@ type AccessNodeConfig struct {
 	registersDBPath              string
 	checkpointFile               string
 	scriptExecutorConfig         query.QueryConfig
+	scriptExecMinBlock           uint64
+	scriptExecMaxBlock           uint64
 }
 
 type PublicNetworkConfig struct {
@@ -237,6 +240,8 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		registersDBPath:              filepath.Join(homedir, ".flow", "execution_state"),
 		checkpointFile:               cmd.NotSet,
 		scriptExecutorConfig:         query.NewDefaultConfig(),
+		scriptExecMinBlock:           0,
+		scriptExecMaxBlock:           math.MaxUint64,
 	}
 }
 
@@ -1107,6 +1112,14 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"script-execution-timeout",
 			defaultConfig.scriptExecutorConfig.ExecutionTimeLimit,
 			"timeout value for locally executed scripts. default: 10s")
+		flags.Uint64Var(&builder.scriptExecMinBlock,
+			"script-execution-min-height",
+			defaultConfig.scriptExecMinBlock,
+			"lowest block height to allow for script execution. default: no limit")
+		flags.Uint64Var(&builder.scriptExecMaxBlock,
+			"script-execution-max-height",
+			defaultConfig.scriptExecMaxBlock,
+			"highest block height to allow for script execution. default: no limit")
 
 	}).ValidateFlags(func() error {
 		if builder.supportsObserver && (builder.PublicNetworkConfig.BindAddress == cmd.NotSet || builder.PublicNetworkConfig.BindAddress == "") {
@@ -1422,6 +1435,8 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 		}).
 		Module("backend script executor", func(node *cmd.NodeConfig) error {
 			builder.ScriptExecutor = backend.NewScriptExecutor()
+			builder.ScriptExecutor.SetMinExecutableHeight(builder.scriptExecMinBlock)
+			builder.ScriptExecutor.SetMaxExecutableHeight(builder.scriptExecMaxBlock)
 			return nil
 		}).
 		Module("async register store", func(node *cmd.NodeConfig) error {

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1435,8 +1435,8 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 		}).
 		Module("backend script executor", func(node *cmd.NodeConfig) error {
 			builder.ScriptExecutor = backend.NewScriptExecutor()
-			builder.ScriptExecutor.SetMinExecutableHeight(builder.scriptExecMinBlock)
-			builder.ScriptExecutor.SetMaxExecutableHeight(builder.scriptExecMaxBlock)
+			builder.ScriptExecutor.SetMinCompatibleHeight(builder.scriptExecMinBlock)
+			builder.ScriptExecutor.SetMaxCompatibleHeight(builder.scriptExecMaxBlock)
 			return nil
 		}).
 		Module("async register store", func(node *cmd.NodeConfig) error {

--- a/engine/access/rpc/backend/script_executor.go
+++ b/engine/access/rpc/backend/script_executor.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rs/zerolog"
 	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/execution"
 	"github.com/onflow/flow-go/module/state_synchronization"
-	"github.com/rs/zerolog"
 )
 
 type ScriptExecutor struct {


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/5075

Limit the block range an AN will use for executing scripts and getting accounts when configured to use local data.

This is a stop-gap solution for node upgrades before https://github.com/onflow/flow-go/issues/5040 is completed.

Usage:

When a cadence/fvm upgrade is planned: after the stop height is known and before it is reached, add the `--script-execution-min-height` flag passing the stop height and update the AN to the new version. This will cause the AN to stop locally executing scripts for any height below the stop height.

When running a "historic" node, set
* `--script-execution-min-height` to the first block supported by the current version
* `--script-execution-max-height` to the last block supported by the current version
The node will then locally execute scripts for blocks between the heights (inclusive), and fall back to ENs for the rest.