### PR TITLE
Cadence 1.0 state migrations: Update to new static types migration

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -155,6 +155,8 @@ func run(*cobra.Command, []string) {
 		flagOutputDir,
 		flagNWorker,
 		!flagNoMigration,
+		nil,
+		nil,
 	)
 
 	if err != nil {

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -36,6 +36,8 @@ func extractExecutionState(
 	outputDir string,
 	nWorker int, // number of concurrent worker to migation payloads
 	runMigrations bool,
+	compositeTypeRules migrators.StaticTypeMigrationRules,
+	interfaceTypeRules migrators.StaticTypeMigrationRules,
 ) error {
 
 	log.Info().Msg("init WAL")
@@ -72,7 +74,15 @@ func extractExecutionState(
 
 	log.Info().Msg("init compactor")
 
-	compactor, err := complete.NewCompactor(led, diskWal, log, complete.DefaultCacheSize, checkpointDistance, checkpointsToKeep, atomic.NewBool(false))
+	compactor, err := complete.NewCompactor(
+		led,
+		diskWal,
+		log,
+		complete.DefaultCacheSize,
+		checkpointDistance,
+		checkpointsToKeep,
+		atomic.NewBool(false),
+	)
 	if err != nil {
 		return fmt.Errorf("cannot create compactor: %w", err)
 	}
@@ -99,12 +109,14 @@ func extractExecutionState(
 				nWorker,
 				[]migrators.AccountBasedMigration{
 					migrators.NewCadenceLinkValueMigrator(rwf, capabilityIDs),
-					migrators.NewCadenceValueMigrator(rwf, capabilityIDs),
-
-					// This will fix storage used discrepancies caused by the
-					// DeduplicateContractNamesMigration.
-					&migrators.AccountUsageMigrator{},
-				}),
+					migrators.NewCadenceValueMigrator(
+						rwf,
+						capabilityIDs,
+						migrators.NewStaticTypeMigrator[*interpreter.CompositeStaticType](compositeTypeRules),
+						migrators.NewStaticTypeMigrator[*interpreter.InterfaceStaticType](interfaceTypeRules),
+					),
+				},
+			),
 		}
 	}
 
@@ -158,9 +170,9 @@ func createCheckpoint(
 	outputDir,
 	outputFile string,
 ) (ledger.State, error) {
-	statecommitment := ledger.State(newTrie.RootHash())
+	stateCommitment := ledger.State(newTrie.RootHash())
 
-	log.Info().Msgf("successfully built new trie. NEW ROOT STATECOMMIEMENT: %v", statecommitment.String())
+	log.Info().Msgf("successfully built new trie. NEW ROOT STATECOMMIEMENT: %v", stateCommitment.String())
 
 	err := os.MkdirAll(outputDir, os.ModePerm)
 	if err != nil {
@@ -181,7 +193,7 @@ func createCheckpoint(
 	}
 
 	log.Info().Msgf("checkpoint file successfully stored at: %v %v", outputDir, outputFile)
-	return statecommitment, nil
+	return stateCommitment, nil
 }
 
 func writeStatusFile(fileName string, e error) error {

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -66,6 +66,8 @@ func TestExtractExecutionState(t *testing.T) {
 				outdir,
 				10,
 				false,
+				nil,
+				nil,
 			)
 			require.Error(t, err)
 		})

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/onflow/cadence/migrations"
@@ -12,6 +13,8 @@ import (
 	"github.com/onflow/cadence/migrations/entitlements"
 	"github.com/onflow/cadence/migrations/statictypes"
 	"github.com/onflow/cadence/migrations/string_normalization"
+	"github.com/onflow/cadence/runtime/tests/utils"
+	"github.com/onflow/cadence/tools/analysis"
 
 	"github.com/onflow/flow-go/fvm/environment"
 
@@ -79,10 +82,10 @@ func TestCadenceValuesMigration(t *testing.T) {
 		rwf,
 		capabilityIDs,
 		func(staticType *interpreter.CompositeStaticType) interpreter.StaticType {
-			return staticType
+			return nil
 		},
 		func(staticType *interpreter.InterfaceStaticType) interpreter.StaticType {
-			return staticType
+			return nil
 		},
 	)
 
@@ -631,7 +634,7 @@ func runLinkMigration(
 		t,
 		logWriter.logs[0],
 		fmt.Sprintf(
-			"failed to run LinkValueMigration for path /public/flowTokenReceiver in account %s",
+			"failed to run LinkValueMigration in account %s, domain public, key flowTokenReceiver",
 			testAccountAddress,
 		),
 	)
@@ -640,7 +643,7 @@ func runLinkMigration(
 		t,
 		logWriter.logs[1],
 		fmt.Sprintf(
-			"failed to run LinkValueMigration for path /public/flowTokenBalance in account %s",
+			"failed to run LinkValueMigration in account %s, domain public, key flowTokenBalance:",
 			testAccountAddress,
 		),
 	)

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -7,6 +7,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/onflow/cadence/migrations"
+	"github.com/onflow/cadence/migrations/capcons"
+	"github.com/onflow/cadence/migrations/entitlements"
+	"github.com/onflow/cadence/migrations/statictypes"
+	"github.com/onflow/cadence/migrations/string_normalization"
+
+	"github.com/onflow/flow-go/fvm/environment"
+
 	"github.com/rs/zerolog"
 
 	_ "github.com/glebarez/go-sqlite"
@@ -73,7 +81,16 @@ func TestCadenceValuesMigration(t *testing.T) {
 	payloads = runLinkMigration(t, address, payloads, capabilityIDs, rwf)
 
 	// Run remaining migrations
-	valueMigration := NewCadenceValueMigrator(rwf, capabilityIDs)
+	valueMigration := NewCadenceValueMigrator(
+		rwf,
+		capabilityIDs,
+		func(staticType *interpreter.CompositeStaticType) interpreter.StaticType {
+			return staticType
+		},
+		func(staticType *interpreter.InterfaceStaticType) interpreter.StaticType {
+			return staticType
+		},
+	)
 
 	logWriter := &writer{}
 	logger := zerolog.New(logWriter).Level(zerolog.ErrorLevel)

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -22,11 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/cadence/migrations"
-	"github.com/onflow/cadence/migrations/capcons"
-	"github.com/onflow/cadence/migrations/entitlements"
-	"github.com/onflow/cadence/migrations/statictypes"
-	"github.com/onflow/cadence/migrations/string_normalization"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
@@ -34,7 +29,6 @@ import (
 
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
-	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"

--- a/cmd/util/ledger/migrations/static_type_migration.go
+++ b/cmd/util/ledger/migrations/static_type_migration.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"github.com/onflow/cadence/runtime/interpreter"
+)
+
+type StaticTypeMigrationRules map[interpreter.StaticType]interpreter.StaticType
+
+func NewStaticTypeMigrator[T interpreter.StaticType](
+	rules StaticTypeMigrationRules,
+) func(staticType T) interpreter.StaticType {
+
+	// Returning `nil` form the callback indicates the type wasn't converted.
+
+	if rules == nil {
+		return func(original T) interpreter.StaticType {
+			return nil
+		}
+	}
+
+	return func(original T) interpreter.StaticType {
+		if replacement, ok := rules[original]; ok {
+			return replacement
+		}
+		return nil
+	}
+}

--- a/cmd/util/ledger/migrations/static_type_migration.go
+++ b/cmd/util/ledger/migrations/static_type_migration.go
@@ -1,7 +1,16 @@
 package migrations
 
 import (
+	"encoding/binary"
+	"encoding/csv"
+	"fmt"
+	"io"
+
+	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/tools/analysis"
 )
 
 type StaticTypeMigrationRules map[interpreter.StaticType]interpreter.StaticType
@@ -24,4 +33,121 @@ func NewStaticTypeMigrator[T interpreter.StaticType](
 		}
 		return nil
 	}
+}
+
+func ReadCSVStaticTypeMigrationRules(
+	programs analysis.Programs,
+	reader io.Reader,
+) (
+	rules StaticTypeMigrationRules,
+	err error,
+) {
+	rules = make(StaticTypeMigrationRules)
+
+	csvReader := csv.NewReader(reader)
+
+	type ruleRecord struct {
+		program          string
+		sourceStaticType string
+		targetStaticType string
+	}
+
+	var ruleRecords []ruleRecord
+
+	for index := 0; ; index++ {
+		record, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		const expectedRecordLen = 3
+		actualRecordLen := len(record)
+		if actualRecordLen != expectedRecordLen {
+			return nil, fmt.Errorf(
+				"error in rule %d: invalid CSV rule length. expected %d, got %d",
+				index+1,
+				expectedRecordLen,
+				actualRecordLen,
+			)
+		}
+
+		ruleRecords = append(ruleRecords, ruleRecord{
+			program:          record[0],
+			sourceStaticType: record[1],
+			targetStaticType: record[2],
+		})
+	}
+
+	getLocation := func(index int) common.Location {
+		var location common.ScriptLocation
+		binary.BigEndian.PutUint64(location[:], uint64(index))
+		return location
+	}
+
+	for index, ruleRecord := range ruleRecords {
+		location := getLocation(index)
+
+		err := programs.Load(
+			analysis.NewSimpleConfig(
+				analysis.NeedTypes,
+				map[common.Location][]byte{
+					location: []byte(ruleRecord.program),
+				},
+				nil,
+				nil,
+			),
+			location,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		program := programs[location]
+
+		checker := program.Checker
+
+		sourceStaticType, err := ParseStaticType(
+			ruleRecord.sourceStaticType,
+			checker,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		targetStaticType, err := ParseStaticType(
+			ruleRecord.targetStaticType,
+			checker,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		rules[sourceStaticType] = targetStaticType
+	}
+
+	return
+}
+
+func ParseStaticType(ty string, checker *sema.Checker) (interpreter.StaticType, error) {
+	code := []byte(ty)
+	astType, errs := parser.ParseType(nil, code, parser.Config{})
+	if len(errs) > 0 {
+		return nil, parser.Error{
+			Code:   code,
+			Errors: errs,
+		}
+	}
+
+	semaType := checker.ConvertType(astType)
+
+	checkerErr := checker.CheckerError()
+	if checkerErr != nil {
+		return nil, checkerErr
+	}
+
+	return interpreter.ConvertSemaToStaticType(nil, semaType), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f
-	github.com/onflow/cadence v1.0.0-M3
+	github.com/onflow/cadence v1.0.0-M4
 	github.com/onflow/crypto v0.25.0
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125013952-df76aaf4136f

--- a/go.sum
+++ b/go.sum
@@ -2474,8 +2474,9 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-M3 h1:bSydJise9pU4aALloUKv/EWmDLITRlbBpuG8OPBydZM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
+github.com/onflow/cadence v1.0.0-M4 h1:/nt3j7vpYDxuI0ghIgAJrb2R01ijvJYZLAkKt+zbpTY=
+github.com/onflow/cadence v1.0.0-M4/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow v0.3.4 h1:FXUWVdYB90f/rjNcY0Owo30gL790tiYff9Pb/sycXYE=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -205,7 +205,7 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f // indirect
-	github.com/onflow/cadence v1.0.0-M3 // indirect
+	github.com/onflow/cadence v1.0.0-M4 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125013952-df76aaf4136f // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125013952-df76aaf4136f // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240125000944-01706d1b6a69 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2461,8 +2461,9 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-M3 h1:bSydJise9pU4aALloUKv/EWmDLITRlbBpuG8OPBydZM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
+github.com/onflow/cadence v1.0.0-M4 h1:/nt3j7vpYDxuI0ghIgAJrb2R01ijvJYZLAkKt+zbpTY=
+github.com/onflow/cadence v1.0.0-M4/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125013952-df76aaf4136f h1:QXRSJn3RfmrMfhCiCzDLP5F4aDtoyN+jGuTb6CMBIEA=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
-	github.com/onflow/cadence v1.0.0-M3
+	github.com/onflow/cadence v1.0.0-M4
 	github.com/onflow/crypto v0.25.0
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125013952-df76aaf4136f
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20240125013952-df76aaf4136f

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2536,8 +2536,9 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-M3 h1:bSydJise9pU4aALloUKv/EWmDLITRlbBpuG8OPBydZM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
+github.com/onflow/cadence v1.0.0-M4 h1:/nt3j7vpYDxuI0ghIgAJrb2R01ijvJYZLAkKt+zbpTY=
+github.com/onflow/cadence v1.0.0-M4/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20240125013952-df76aaf4136f h1:QXRSJn3RfmrMfhCiCzDLP5F4aDtoyN+jGuTb6CMBIEA=


### PR DESCRIPTION
Work towards onflow/cadence#3007

Add a utility code to easily define static type migration rules through a CSV file with Cadence syntax 