### PR TITLE
[Access] Always failover to EN on script exec err - v0.32

### DIFF
--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -128,7 +128,10 @@ func (b *backendScripts) executeScript(
 
 	case IndexQueryModeFailover:
 		localResult, localDuration, localErr := b.executeScriptLocally(ctx, scriptRequest)
-		if localErr == nil || isInvalidArgumentError(localErr) || status.Code(localErr) == codes.Canceled {
+		// Note: temporarily ignoring error types and falling back to ENs for ALL errors
+		// This should only fallback for non-cadence errors, but on v0.32, some errors are hidden
+		// within a cadence runtime error, resulting in the incorrect error type being returned.
+		if localErr == nil || status.Code(localErr) == codes.Canceled {
 			return localResult, localErr
 		}
 		// Note: scripts that timeout are retried on the execution nodes since ANs may have performance


### PR DESCRIPTION
On the `v0.32` branch, there are some cases where the error message returned by the AN does not accurately reflect the root cause of the error. See https://github.com/onflow/flow-go/pull/5272

To work around this on this branch, update the AN to always failover to the EN when an error is encountered.