### PR TITLE
suggestions for COA address 

### DIFF
--- a/fvm/evm/handler/addressAllocator.go
+++ b/fvm/evm/handler/addressAllocator.go
@@ -13,7 +13,11 @@ const (
 	ledgerAddressAllocatorKey = "AddressAllocator"
 	// `addressIndexMultiplierConstant` is used for mapping address indices
 	// into deterministic random-looking address postfixes. 
-	// The constant must be an ODD number. It is a "nothing-up-my-sleeves" constant.
+	// The constant must be an ODD number.
+	// It is a "nothing-up-my-sleeves" constant, chosen to be big enough so that
+	// the index and its corresponding address look less "related". 
+	// Note that the least significant byte was set to "77" instead of "88" to force
+	// the odd parity.
 	// Look at `mapAddressIndex` for more details.
 	addressIndexMultiplierConstant = uint64(0xFFEEDDCCBBAA9977)
 )

--- a/fvm/evm/handler/addressAllocator.go
+++ b/fvm/evm/handler/addressAllocator.go
@@ -11,9 +11,10 @@ import (
 
 const (
 	ledgerAddressAllocatorKey = "AddressAllocator"
-	// addressIndexShuffleSeed is used for shuffling address index
-	// shuffling index is used to make address postfixes look random
-	addressIndexShuffleSeed = uint64(0xFFEEDDCCBBAA9987)
+	// addressIndexMultiplierConstant is used for mapping address indices
+	// into a deterministic random-looking address postfixes. 
+	// look at `mapAddressIndex` for more details.
+	addressIndexMultiplierConstant = uint64(0xFFEEDDCCBBAA9977)
 )
 
 type AddressAllocator struct {
@@ -41,7 +42,7 @@ func (aa *AddressAllocator) AllocateCOAAddress(uuid uint64) types.Address {
 }
 
 func MakeCOAAddress(index uint64) types.Address {
-	return makePrefixedAddress(shuffleAddressIndex(index), types.FlowEVMCOAAddressPrefix)
+	return makePrefixedAddress(mapAddressIndex(index), types.FlowEVMCOAAddressPrefix)
 }
 
 func (aa *AddressAllocator) AllocatePrecompileAddress(index uint64) types.Address {
@@ -64,6 +65,18 @@ func makePrefixedAddress(
 	return addr
 }
 
-func shuffleAddressIndex(preShuffleIndex uint64) uint64 {
-	return uint64(preShuffleIndex * addressIndexShuffleSeed)
+// `mapAddressIndex` maps an index of 64 bits to a deterministic random-looking 64 bits.
+//
+// The mapping function must be an injective mapping (in this case bijective) 
+// where every two indices always map to two different results. Multiple injective 
+// mappings are possible.
+// 
+// The current implementation uses a simple modular multiplication by a constant modulo 2^64.
+// The multiplier constant can be any odd number. Since odd numbers are co-prime with 2^64, they
+// have an multiplicative inverse modulo 2^64. 
+// This makes multiplying by an odd number an injective function (and therefore bijective).
+//
+// Multiplying modulo 2^64 is implicitly implemented as a uint64 multiplication with a uin64 result.
+func mapAddressIndex(index uint64) uint64 {
+	return uint64(index * addressIndexMultiplierConstant)
 }

--- a/fvm/evm/handler/addressAllocator.go
+++ b/fvm/evm/handler/addressAllocator.go
@@ -74,7 +74,7 @@ func makePrefixedAddress(
 // 
 // The current implementation uses a simple modular multiplication by a constant modulo 2^64.
 // The multiplier constant can be any odd number. Since odd numbers are co-prime with 2^64, they
-// have an multiplicative inverse modulo 2^64. 
+// have a multiplicative inverse modulo 2^64. 
 // This makes multiplying by an odd number an injective function (and therefore bijective).
 //
 // Multiplying modulo 2^64 is implicitly implemented as a uint64 multiplication with a uin64 result.

--- a/fvm/evm/handler/addressAllocator.go
+++ b/fvm/evm/handler/addressAllocator.go
@@ -11,9 +11,10 @@ import (
 
 const (
 	ledgerAddressAllocatorKey = "AddressAllocator"
-	// addressIndexMultiplierConstant is used for mapping address indices
-	// into a deterministic random-looking address postfixes. 
-	// look at `mapAddressIndex` for more details.
+	// `addressIndexMultiplierConstant` is used for mapping address indices
+	// into deterministic random-looking address postfixes. 
+	// The constant must be an ODD number. It is a "nothing-up-my-sleeves" constant.
+	// Look at `mapAddressIndex` for more details.
 	addressIndexMultiplierConstant = uint64(0xFFEEDDCCBBAA9977)
 )
 

--- a/fvm/evm/handler/addressAllocator.go
+++ b/fvm/evm/handler/addressAllocator.go
@@ -11,7 +11,6 @@ import (
 
 const (
 	ledgerAddressAllocatorKey = "AddressAllocator"
-	uint64ByteSize            = 8
 	// addressIndexShuffleSeed is used for shuffling address index
 	// shuffling index is used to make address postfixes look random
 	addressIndexShuffleSeed = uint64(0xFFEEDDCCBBAA9987)
@@ -59,9 +58,9 @@ func makePrefixedAddress(
 	prefix [types.FlowEVMSpecialAddressPrefixLen]byte,
 ) types.Address {
 	var addr types.Address
-	prefixIndex := types.AddressLength - uint64ByteSize
-	copy(addr[:prefixIndex], prefix[:])
-	binary.BigEndian.PutUint64(addr[prefixIndex:], index)
+	copy(addr[:], prefix[:])
+	// only works if `len(addr) - len(prefix)` is exactly 8 bytes
+	binary.BigEndian.PutUint64(addr[len(prefix):], index)
 	return addr
 }
 

--- a/fvm/evm/types/address.go
+++ b/fvm/evm/types/address.go
@@ -7,22 +7,24 @@ import (
 )
 
 const (
-	// number of prefix bytes with constant values for special accounts (extended precompiles and COAs)
-	// using leading zeros for prefix helps with the storage compactness.
+	// number of prefix bytes with constant values for special accounts (extended precompiles and COAs).
 	//
 	// The prefix length should insure a high-enough level of security against finding a preimage using the hash
 	// function used for EVM addresses generation (Keccak256). This is required to avoid finding an EVM address
-	// that can also be a valid FlowEVM address. 
+	// that is also a valid FlowEVM address. 
 	// The target (minimal) security in this case is the security level provided by EVM addresses.
-	// Since EVM addresses are 160-bits long, EVM addresses offer only 80 bits of security (collision resistance 
+	// Since EVM addresses are 160-bits long, they offer only 80 bits of security (collision resistance 
 	// offers the lowest level).
-	// A preimage resistance of 80 bits requires the prefix to be at least 80-bits long (i.e 10 bytes)
+	// A preimage resistance of 80 bits requires the prefix to be at least 80-bits long (i.e 10 bytes).
 	//
-	// When used as a prefix in EVM addresses (20-bytes long), it leaves a variable part of 8 bytes (64 bits).
+	// When used as a prefix in EVM addresses (20-bytes long), a prefix length of 12 bytes
+	// leaves a variable part of 8 bytes (64 bits).
 	FlowEVMSpecialAddressPrefixLen = 12
 )
 
 var (
+	// Using leading zeros for prefix helps with the storage compactness.
+	//
 	// Prefix for the built-in EVM precompiles
 	FlowEVMNativePrecompileAddressPrefix = [FlowEVMSpecialAddressPrefixLen]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	// Prefix for the extended precompiles

--- a/fvm/evm/types/address.go
+++ b/fvm/evm/types/address.go
@@ -17,6 +17,8 @@ const (
 	// Since EVM addresses are 160-bits long, EVM addresses offer only 80 bits of security (collision resistance 
 	// offers the lowest level).
 	// A preimage resistance of 80 bits requires the prefix to be at least 80-bits long (i.e 10 bytes)
+	//
+	// When used as a prefix in EVM addresses (20-bytes long), it leaves a variable part of 8 bytes (64 bits).
 	FlowEVMSpecialAddressPrefixLen = 12
 )
 
@@ -65,7 +67,7 @@ func NewAddressFromString(str string) Address {
 
 // IsACOAAddress returns true if the address is a COA address
 //
-// This test insure `addr` has been generated as a COA address with high probability.
+// This test insures `addr` has been generated as a COA address with high probability.
 // Brute forcing an EVM address `addr` to pass the `IsACOAAddress` test is as hard as the bit-length
 // of `FlowEVMCOAAddressPrefix` (here 96 bits).
 // Although this is lower than the protocol-wide security level in Flow (128 bits), it remains

--- a/fvm/evm/types/address.go
+++ b/fvm/evm/types/address.go
@@ -7,8 +7,16 @@ import (
 )
 
 const (
-	// number of prefix bytes with specific values for special accounts (extended precompiles and COAs)
-	// using leading zeros for prefix helps with the storage compactness
+	// number of prefix bytes with constant values for special accounts (extended precompiles and COAs)
+	// using leading zeros for prefix helps with the storage compactness.
+	//
+	// The prefix length should insure a high-enough level of security against finding a preimage using the hash
+	// function used for EVM addresses generation (Keccak256). This is required to avoid finding an EVM address
+	// that can also be a valid FlowEVM address. 
+	// The target (minimal) security in this case is the security level provided by EVM addresses.
+	// Since EVM addresses are 160-bits long, EVM addresses offer only 80 bits of security (collision resistance 
+	// offers the lowest level).
+	// A preimage resistance of 80 bits requires the prefix to be at least 80-bits long (i.e 10 bytes)
 	FlowEVMSpecialAddressPrefixLen = 12
 )
 
@@ -56,6 +64,12 @@ func NewAddressFromString(str string) Address {
 }
 
 // IsACOAAddress returns true if the address is a COA address
+//
+// This test insure `addr` has been generated as a COA address with high probability.
+// Brute forcing an EVM address `addr` to pass the `IsACOAAddress` test is as hard as the bit-length
+// of `FlowEVMCOAAddressPrefix` (here 96 bits).
+// Although this is lower than the protocol-wide security level in Flow (128 bits), it remains
+// higher than the EVM addresses security (80 bits when considering collision attacks)
 func IsACOAAddress(addr Address) bool {
 	return bytes.HasPrefix(addr[:], FlowEVMCOAAddressPrefix[:])
 }


### PR DESCRIPTION
- add comments to clarify:
  - security reasoning behind choosing an address prefix of 12 bytes
  - reasoning behind the index to postfix mapping 
- rename some function and constants to match the underlying logic
- minor code simplification 