### PR TITLE
[Access] Add initial register cache implementation

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -752,7 +752,8 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					if err != nil {
 						return nil, fmt.Errorf("could not parse register cache type: %w", err)
 					}
-					registersCache, err := pStorage.NewRegistersCache(registers, cacheType, builder.registerCacheSize, builder.Metrics.Cache)
+					cacheMetrics := metrics.NewCacheCollector(builder.RootChainID)
+					registersCache, err := pStorage.NewRegistersCache(registers, cacheType, builder.registerCacheSize, cacheMetrics)
 					if err != nil {
 						return nil, fmt.Errorf("could not create registers cache: %w", err)
 					}

--- a/storage/pebble/cache.go
+++ b/storage/pebble/cache.go
@@ -66,7 +66,7 @@ func (c *wrapped) Get(key string) (value flow.RegisterValue, ok bool) {
 	return c.cache.Get(key)
 }
 func (c *wrapped) Add(key string, value flow.RegisterValue) {
-	c.cache.Add(key, value)
+	_ = c.cache.Add(key, value)
 }
 func (c *wrapped) Contains(key string) bool {
 	return c.cache.Contains(key)
@@ -75,7 +75,7 @@ func (c *wrapped) Len() int {
 	return c.cache.Len()
 }
 func (c *wrapped) Remove(key string) {
-	c.cache.Remove(key)
+	_ = c.cache.Remove(key)
 }
 
 type ReadCache struct {

--- a/storage/pebble/cache.go
+++ b/storage/pebble/cache.go
@@ -1,0 +1,166 @@
+package pebble
+
+import (
+	"errors"
+	"fmt"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/storage"
+)
+
+const DefaultCacheSize = uint(1000)
+
+type CacheType int
+
+const (
+	CacheTypeLRU CacheType = iota + 1
+	CacheTypeARC
+	CacheTypeTwoQueue
+)
+
+func ParseCacheType(s string) (CacheType, error) {
+	switch s {
+	case CacheTypeLRU.String():
+		return CacheTypeLRU, nil
+	case CacheTypeARC.String():
+		return CacheTypeARC, nil
+	case CacheTypeTwoQueue.String():
+		return CacheTypeTwoQueue, nil
+	default:
+		return 0, errors.New("invalid cache type")
+	}
+}
+
+func (m CacheType) String() string {
+	switch m {
+	case CacheTypeLRU:
+		return "lru"
+	case CacheTypeARC:
+		return "arc"
+	case CacheTypeTwoQueue:
+		return "2q"
+	default:
+		return ""
+	}
+}
+
+type CacheBackend interface {
+	Get(key string) (value flow.RegisterValue, ok bool)
+	Add(key string, value flow.RegisterValue)
+	Contains(key string) bool
+	Len() int
+	Remove(key string)
+}
+
+type wrapped struct {
+	cache *lru.Cache[string, flow.RegisterValue]
+}
+
+func (c *wrapped) Get(key string) (value flow.RegisterValue, ok bool) {
+	return c.cache.Get(key)
+}
+func (c *wrapped) Add(key string, value flow.RegisterValue) {
+	c.cache.Add(key, value)
+}
+func (c *wrapped) Contains(key string) bool {
+	return c.cache.Contains(key)
+}
+func (c *wrapped) Len() int {
+	return c.cache.Len()
+}
+func (c *wrapped) Remove(key string) {
+	c.cache.Remove(key)
+}
+
+type ReadCache struct {
+	metrics  module.CacheMetrics
+	resource string
+	cache    CacheBackend
+	retrieve func(key string) (flow.RegisterValue, error)
+}
+
+func newReadCache(
+	collector module.CacheMetrics,
+	resourceName string,
+	cacheType CacheType,
+	cacheSize uint,
+	retrieve func(key string) (flow.RegisterValue, error),
+) (*ReadCache, error) {
+	cache, err := getCache(cacheType, int(cacheSize))
+	if err != nil {
+		return nil, fmt.Errorf("could not create cache: %w", err)
+	}
+
+	c := ReadCache{
+		metrics:  collector,
+		resource: resourceName,
+		cache:    cache,
+		retrieve: retrieve,
+	}
+	c.metrics.CacheEntries(c.resource, uint(c.cache.Len()))
+
+	return &c, nil
+}
+
+func getCache(cacheType CacheType, size int) (CacheBackend, error) {
+	switch cacheType {
+	case CacheTypeLRU:
+		cache, err := lru.New[string, flow.RegisterValue](size)
+		if err != nil {
+			return nil, err
+		}
+		return &wrapped{cache: cache}, nil
+	case CacheTypeARC:
+		return lru.NewARC[string, flow.RegisterValue](size)
+	case CacheTypeTwoQueue:
+		return lru.New2Q[string, flow.RegisterValue](size)
+	default:
+		return nil, fmt.Errorf("unknown cache type: %d", cacheType)
+	}
+}
+
+// IsCached returns true if the key exists in the cache.
+// It DOES NOT check whether the key exists in the underlying data store.
+func (c *ReadCache) IsCached(key string) bool {
+	return c.cache.Contains(key)
+}
+
+// Get will try to retrieve the resource from cache first, and then from the
+// injected. During normal operations, the following error returns are expected:
+//   - `storage.ErrNotFound` if key is unknown.
+func (c *ReadCache) Get(key string) (flow.RegisterValue, error) {
+	resource, cached := c.cache.Get(key)
+	if cached {
+		c.metrics.CacheHit(c.resource)
+		return resource, nil
+	}
+
+	// get it from the database
+	resource, err := c.retrieve(key)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			c.metrics.CacheNotFound(c.resource)
+		}
+		return nil, fmt.Errorf("could not retrieve resource: %w", err)
+	}
+
+	c.metrics.CacheMiss(c.resource)
+
+	c.cache.Add(key, resource)
+	c.metrics.CacheEntries(c.resource, uint(c.cache.Len()))
+
+	return resource, nil
+}
+
+func (c *ReadCache) Remove(key string) {
+	c.cache.Remove(key)
+}
+
+// Insert will add a resource directly to the cache with the given ID
+func (c *ReadCache) Insert(key string, resource flow.RegisterValue) {
+	c.cache.Add(key, resource)
+	c.metrics.CacheEntries(c.resource, uint(c.cache.Len()))
+}

--- a/storage/pebble/cache.go
+++ b/storage/pebble/cache.go
@@ -11,7 +11,7 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
-const DefaultCacheSize = uint(1000)
+const DefaultCacheSize = uint(10_000)
 
 type CacheType int
 
@@ -55,6 +55,9 @@ type CacheBackend interface {
 	Remove(key string)
 }
 
+// wrapped is a wrapper around lru.Cache to implement CacheBackend
+// this is needed because the standard lru cache implementation provides additional features that
+// the ARC and 2Q caches do not. This standardizes the interface to allow swapping between types.
 type wrapped struct {
 	cache *lru.Cache[string, flow.RegisterValue]
 }

--- a/storage/pebble/lookup.go
+++ b/storage/pebble/lookup.go
@@ -116,6 +116,11 @@ func (h lookupKey) Bytes() []byte {
 	return h.encoded
 }
 
+// String returns the encoded lookup key as a string.
+func (h lookupKey) String() string {
+	return string(h.encoded)
+}
+
 // encodedUint64 encodes uint64 for storing as a pebble payload
 func encodedUint64(height uint64) []byte {
 	payload := make([]byte, 0, 8)

--- a/storage/pebble/registers.go
+++ b/storage/pebble/registers.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/storage"
 )
 
@@ -19,42 +18,14 @@ type Registers struct {
 	db           *pebble.DB
 	firstHeight  uint64
 	latestHeight *atomic.Uint64
-
-	cache *ReadCache
 }
 
 var _ storage.RegisterIndex = (*Registers)(nil)
 
-type RegistersOption func(*Registers) error
-
-func WithReadCache(cacheType CacheType, size uint, metrics module.CacheMetrics) RegistersOption {
-	return func(r *Registers) error {
-		if size == 0 {
-			return errors.New("cache size cannot be 0")
-		}
-
-		cache, err := newReadCache(
-			metrics,
-			"registers",
-			cacheType,
-			size,
-			func(key string) (flow.RegisterValue, error) {
-				return r.lookupRegister([]byte(key))
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("could not create cache: %w", err)
-		}
-
-		r.cache = cache
-		return nil
-	}
-}
-
 // NewRegisters takes a populated pebble instance with LatestHeight and FirstHeight set.
 // return storage.ErrNotBootstrapped if they those two keys are unavailable as it implies a uninitialized state
 // return other error if database is in a corrupted state
-func NewRegisters(db *pebble.DB, opts ...RegistersOption) (*Registers, error) {
+func NewRegisters(db *pebble.DB) (*Registers, error) {
 	// check height keys and populate cache. These two variables will have been set
 	firstHeight, latestHeight, err := ReadHeightsFromBootstrappedDB(db)
 	if err != nil {
@@ -62,20 +33,12 @@ func NewRegisters(db *pebble.DB, opts ...RegistersOption) (*Registers, error) {
 		return nil, fmt.Errorf("unable to initialize register storage, latest height unavailable in db: %w", err)
 	}
 
-	/// All registers between firstHeight and lastHeight have been indexed
-	r := &Registers{
+	// All registers between firstHeight and lastHeight have been indexed
+	return &Registers{
 		db:           db,
 		firstHeight:  firstHeight,
 		latestHeight: atomic.NewUint64(latestHeight),
-	}
-
-	for _, opt := range opts {
-		if err := opt(r); err != nil {
-			return nil, fmt.Errorf("failed to apply option: %w", err)
-		}
-	}
-
-	return r, nil
+	}, nil
 }
 
 // Get returns the most recent updated payload for the given RegisterID.
@@ -98,10 +61,6 @@ func (s *Registers) Get(
 		)
 	}
 	key := newLookupKey(height, reg)
-
-	if s.cache != nil {
-		return s.cache.Get(key.String())
-	}
 	return s.lookupRegister(key.Bytes())
 }
 

--- a/storage/pebble/registers_cache.go
+++ b/storage/pebble/registers_cache.go
@@ -15,8 +15,8 @@ const (
 )
 
 type RegistersCache struct {
-	registers *Registers
-	cache     *ReadCache
+	*Registers
+	cache *ReadCache
 }
 
 var _ storage.RegisterIndex = (*RegistersCache)(nil)
@@ -41,7 +41,7 @@ func NewRegistersCache(registers *Registers, cacheType CacheType, size uint, met
 	}
 
 	return &RegistersCache{
-		registers: registers,
+		Registers: registers,
 		cache:     cache,
 	}, nil
 }
@@ -59,25 +59,4 @@ func (c *RegistersCache) Get(
 	height uint64,
 ) (flow.RegisterValue, error) {
 	return c.cache.Get(newLookupKey(height, reg).String())
-}
-
-// Store sets the given entries in a batch.
-// This function is expected to be called at one batch per height, sequentially. Under normal conditions,
-// it should be called wth the value of height set to LatestHeight + 1
-// CAUTION: This function is not safe for concurrent use.
-func (c *RegistersCache) Store(
-	entries flow.RegisterEntries,
-	height uint64,
-) error {
-	return c.registers.Store(entries, height)
-}
-
-// LatestHeight Gets the latest height of complete registers available
-func (c *RegistersCache) LatestHeight() uint64 {
-	return c.registers.LatestHeight()
-}
-
-// FirstHeight first indexed height found in the store, typically root block for the spork
-func (c *RegistersCache) FirstHeight() uint64 {
-	return c.registers.FirstHeight()
 }

--- a/storage/pebble/registers_cache.go
+++ b/storage/pebble/registers_cache.go
@@ -1,0 +1,83 @@
+package pebble
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/storage"
+)
+
+const (
+	registerResourceName = "registers"
+)
+
+type RegistersCache struct {
+	registers *Registers
+	cache     *ReadCache
+}
+
+var _ storage.RegisterIndex = (*RegistersCache)(nil)
+
+// NewRegistersCache wraps a read cache around Get requests to a underlying Registers object.
+func NewRegistersCache(registers *Registers, cacheType CacheType, size uint, metrics module.CacheMetrics) (*RegistersCache, error) {
+	if size == 0 {
+		return nil, errors.New("cache size cannot be 0")
+	}
+
+	cache, err := newReadCache(
+		metrics,
+		registerResourceName,
+		cacheType,
+		size,
+		func(key string) (flow.RegisterValue, error) {
+			return registers.lookupRegister([]byte(key))
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not create cache: %w", err)
+	}
+
+	return &RegistersCache{
+		registers: registers,
+		cache:     cache,
+	}, nil
+}
+
+// Get returns the most recent updated payload for the given RegisterID.
+// "most recent" means the updates happens most recent up the given height.
+//
+// For example, if there are 2 values stored for register A at height 6 and 11, then
+// GetPayload(13, A) would return the value at height 11.
+//
+// - storage.ErrNotFound if no register values are found
+// - storage.ErrHeightNotIndexed if the requested height is out of the range of stored heights
+func (c *RegistersCache) Get(
+	reg flow.RegisterID,
+	height uint64,
+) (flow.RegisterValue, error) {
+	return c.cache.Get(newLookupKey(height, reg).String())
+}
+
+// Store sets the given entries in a batch.
+// This function is expected to be called at one batch per height, sequentially. Under normal conditions,
+// it should be called wth the value of height set to LatestHeight + 1
+// CAUTION: This function is not safe for concurrent use.
+func (c *RegistersCache) Store(
+	entries flow.RegisterEntries,
+	height uint64,
+) error {
+	return c.registers.Store(entries, height)
+}
+
+// LatestHeight Gets the latest height of complete registers available
+func (c *RegistersCache) LatestHeight() uint64 {
+	return c.registers.LatestHeight()
+}
+
+// FirstHeight first indexed height found in the store, typically root block for the spork
+func (c *RegistersCache) FirstHeight() uint64 {
+	return c.registers.FirstHeight()
+}


### PR DESCRIPTION
Closes: #5277

This PR adds a simple cache for register lookups on Access nodes. This improves the performance of scripts that lookup frequently queried registers, like common contract code.