### PR TITLE
[FVM] Add normalised time per computation logs to transaction execution

### DIFF
--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -246,6 +246,17 @@ func (collector *resultCollector) processTransactionResult(
 		Int64("time_spent_in_ms", timeSpent.Milliseconds()).
 		Logger()
 
+	if output.ComputationUsed > 0 {
+		// log the normalized time per computation
+		// if the computation estimation is correct the value should be 1.
+		// if the value is greater than 1, the computation estimation is too low; we are underestimating transaction complexity (and thus undercharging).
+		// if the value is less than 1, the computation estimation is too high; we are overestimating transaction complexity (and thus overcharging).
+		logger = logger.With().
+			Float64("normalized_time_per_computation",
+				float64(timeSpent.Microseconds())/float64(output.ComputationUsed)*flow.EstimatedComputationPerMillisecond).
+			Logger()
+	}
+
 	if output.Err != nil {
 		logger = logger.With().
 			Str("error_message", output.Err.Error()).


### PR DESCRIPTION
The normalised time per computation metrics that were added are proving to be useful, but it would be great to have these logs, so it would be easier to chase down outliers.