### PR TITLE
Add preview net ID

### DIFF
--- a/cmd/bootstrap/cmd/block.go
+++ b/cmd/bootstrap/cmd/block.go
@@ -86,6 +86,8 @@ func parseChainID(chainID string) flow.ChainID {
 		return flow.Mainnet
 	case "test":
 		return flow.Testnet
+	case "preview":
+		return flow.Previewnet
 	case "sandbox":
 		return flow.Sandboxnet
 	case "bench":

--- a/cmd/bootstrap/cmd/keygen.go
+++ b/cmd/bootstrap/cmd/keygen.go
@@ -104,7 +104,7 @@ func init() {
 
 	// optional parameters, used for generating machine account files
 	keygenCmd.Flags().BoolVar(&flagDefaultMachineAccount, "machine-account", false, "whether or not to generate a default (same as networking key) machine account key file")
-	keygenCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'sandbox', 'bench', or 'local'")
+	keygenCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'sandbox', 'preview', 'bench', or 'local'")
 }
 
 // isEmptyDir returns True if the directory contains children

--- a/cmd/bootstrap/cmd/machine_account.go
+++ b/cmd/bootstrap/cmd/machine_account.go
@@ -125,7 +125,11 @@ func validateMachineAccountAddress(addressStr string) error {
 		return nil
 	}
 	if flow.Sandboxnet.Chain().IsValid(address) {
-		log.Warn().Msgf("Machine account address (%s) is **STAGINGNET** address - ensure this is desired before continuing", address)
+		log.Warn().Msgf("Machine account address (%s) is **SANDBOXNET** address - ensure this is desired before continuing", address)
+		return nil
+	}
+	if flow.Previewnet.Chain().IsValid(address) {
+		log.Warn().Msgf("Machine account address (%s) is **PREVIEWNET** address - ensure this is desired before continuing", address)
 		return nil
 	}
 	if flow.Localnet.Chain().IsValid(address) {

--- a/cmd/bootstrap/cmd/rootblock.go
+++ b/cmd/bootstrap/cmd/rootblock.go
@@ -83,7 +83,7 @@ func addRootBlockCmdFlags() {
 	cmd.MarkFlagRequired(rootBlockCmd, "epoch-dkg-phase-length")
 
 	// required parameters for generation of root block, root execution result and root block seal
-	rootBlockCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'sandbox', 'bench', or 'local'")
+	rootBlockCmd.Flags().StringVar(&flagRootChain, "root-chain", "local", "chain ID for the root block (can be 'main', 'test', 'sandbox', 'preview', 'bench', or 'local'")
 	rootBlockCmd.Flags().StringVar(&flagRootParent, "root-parent", "0000000000000000000000000000000000000000000000000000000000000000", "ID for the parent of the root block")
 	rootBlockCmd.Flags().Uint64Var(&flagRootHeight, "root-height", 0, "height of the root block")
 	rootBlockCmd.Flags().StringVar(&flagRootTimestamp, "root-timestamp", time.Now().UTC().Format(time.RFC3339), "timestamp of the root block (RFC3339)")

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1284,12 +1284,12 @@ func (fnb *FlowNodeBuilder) initFvmOptions() {
 		fvm.WithBlocks(blockFinder),
 		fvm.WithAccountStorageLimit(true),
 	}
-	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Sandboxnet || fnb.RootChainID == flow.Mainnet {
+	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Sandboxnet || fnb.RootChainID == flow.Previewnet || fnb.RootChainID == flow.Mainnet {
 		vmOpts = append(vmOpts,
 			fvm.WithTransactionFeesEnabled(true),
 		)
 	}
-	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Sandboxnet || fnb.RootChainID == flow.Localnet || fnb.RootChainID == flow.Benchnet {
+	if fnb.RootChainID == flow.Testnet || fnb.RootChainID == flow.Sandboxnet || fnb.RootChainID == flow.Previewnet || fnb.RootChainID == flow.Localnet || fnb.RootChainID == flow.Benchnet {
 		vmOpts = append(vmOpts,
 			fvm.WithContractDeploymentRestricted(false),
 		)

--- a/engine/common/rpc/convert/convert.go
+++ b/engine/common/rpc/convert/convert.go
@@ -15,6 +15,7 @@ var ValidChainIds = map[string]bool{
 	flow.Mainnet.String():           true,
 	flow.Testnet.String():           true,
 	flow.Sandboxnet.String():        true,
+	flow.Previewnet.String():        true,
 	flow.Benchnet.String():          true,
 	flow.Localnet.String():          true,
 	flow.Emulator.String():          true,

--- a/model/flow/address.go
+++ b/model/flow/address.go
@@ -273,6 +273,9 @@ const invalidCodeTransientNetwork = uint64(0x1cb159857af02018)
 // invalidCodeSandboxNetwork is the invalid codeword used for Sandbox network.
 const invalidCodeSandboxNetwork = uint64(0x1035ce4eff92ae01)
 
+// TODO: invalidCodePreviewNetwork is the invalid codeword used for Preview network.
+const invalidCodePreviewNetwork = uint64(0)
+
 // encodeWord encodes a word into a code word.
 // In Flow, the word is the account index while the code word
 // is the corresponding address.

--- a/model/flow/address_test.go
+++ b/model/flow/address_test.go
@@ -129,6 +129,7 @@ func testAddressConstants(t *testing.T) {
 		Testnet,
 		Emulator,
 		Sandboxnet,
+		Previewnet,
 	}
 
 	for _, chainID := range chainIDs {
@@ -175,6 +176,7 @@ func testAddressGeneration(t *testing.T) {
 		Testnet,
 		Emulator,
 		Sandboxnet,
+		Previewnet,
 	}
 
 	for _, chainID := range chainIDs {
@@ -265,6 +267,7 @@ func testAddressesIntersection(t *testing.T) {
 		Testnet,
 		Emulator,
 		Sandboxnet,
+		Previewnet,
 	}
 
 	for _, chainID := range chainIDs {
@@ -331,6 +334,7 @@ func testIndexFromAddress(t *testing.T) {
 		testnet,
 		emulator,
 		sandboxnet,
+		previewnet,
 	}
 
 	for _, chain := range chains {

--- a/model/flow/chain.go
+++ b/model/flow/chain.go
@@ -24,6 +24,8 @@ const (
 	Testnet ChainID = "flow-testnet"
 	// Sandboxnet is the chain ID for internal sandboxnet chain.
 	Sandboxnet ChainID = "flow-sandboxnet"
+	// Previewet is the chain ID for an external preview chain.
+	Previewnet ChainID = "flow-previewnet"
 
 	// Transient test networks
 
@@ -46,6 +48,7 @@ func AllChainIDs() ChainIDList {
 		Mainnet,
 		Testnet,
 		Sandboxnet,
+		Previewnet,
 		Benchnet,
 		Localnet,
 		Emulator,
@@ -69,6 +72,8 @@ func (c ChainID) getChainCodeWord() uint64 {
 		return invalidCodeTestNetwork
 	case Sandboxnet:
 		return invalidCodeSandboxNetwork
+	case Previewnet:
+		return invalidCodePreviewNetwork
 	case Emulator, Localnet, Benchnet, BftTestnet:
 		return invalidCodeTransientNetwork
 	default:
@@ -196,6 +201,12 @@ var sandboxnet = &addressedChain{
 	},
 }
 
+var previewnet = &addressedChain{
+	chainImpl: &linearCodeImpl{
+		chainID: Previewnet,
+	},
+}
+
 var benchnet = &addressedChain{
 	chainImpl: &linearCodeImpl{
 		chainID: Benchnet,
@@ -227,6 +238,8 @@ func (c ChainID) Chain() Chain {
 		return testnet
 	case Sandboxnet:
 		return sandboxnet
+	case Previewnet:
+		return previewnet
 	case Benchnet:
 		return benchnet
 	case Localnet:


### PR DESCRIPTION
Still need [invalidCodePreviewNetwork](https://github.com/onflow/flow-go/compare/feature/stable-cadence...kan/preview-net-chain-id?expand=1#diff-ea335e5bacc5828fbe8db5edd37db9f63bb4d363e545f185a52b0f89a6f3a852R277) if we actually do need a brand new chain ID. Typically, this is something i'd get @tarakby's help with.

Otherwise, this is more or a less looking off of this PR: https://github.com/onflow/flow-go/pull/3433/files