### PR TITLE
[Access] Sort events returned from index in tx index order

### DIFF
--- a/engine/access/rpc/backend/backend_events_test.go
+++ b/engine/access/rpc/backend/backend_events_test.go
@@ -119,10 +119,9 @@ func (s *BackendEventsSuite) SetupTest() {
 
 	// events returned from the db are sorted by txID, txIndex, then eventIndex.
 	// reproduce that here to ensure output order works as expected
-	returnBlockEvents := make([]flow.Event, 0, len(s.blockEvents))
-	for _, event := range s.blockEvents {
-		returnBlockEvents = append(returnBlockEvents, event)
-	}
+	returnBlockEvents := make([]flow.Event, len(s.blockEvents))
+	copy(returnBlockEvents, s.blockEvents)
+
 	sort.Slice(returnBlockEvents, func(i, j int) bool {
 		return bytes.Compare(returnBlockEvents[i].TransactionID[:], returnBlockEvents[j].TransactionID[:]) < 0
 	})

--- a/engine/access/rpc/backend/event_index_test.go
+++ b/engine/access/rpc/backend/event_index_test.go
@@ -17,47 +17,10 @@ import (
 
 // TestGetEvents tests that GetEvents returns the events in the correct order
 func TestGetEvents(t *testing.T) {
-	txID0 := unittest.IdentifierFixture()
-	txID1 := unittest.IdentifierFixture()
-	txID2 := unittest.IdentifierFixture()
-	expectedEvents := flow.EventsList{
-		{
-			Type:             unittest.EventTypeFixture(flow.Localnet),
-			TransactionID:    txID0,
-			TransactionIndex: 0,
-			EventIndex:       0,
-		},
-		{
-			Type:             unittest.EventTypeFixture(flow.Localnet),
-			TransactionID:    txID1,
-			TransactionIndex: 1,
-			EventIndex:       0,
-		},
-		{
-			Type:             unittest.EventTypeFixture(flow.Localnet),
-			TransactionID:    txID1,
-			TransactionIndex: 1,
-			EventIndex:       1,
-		},
-		{
-			Type:             unittest.EventTypeFixture(flow.Localnet),
-			TransactionID:    txID1,
-			TransactionIndex: 1,
-			EventIndex:       2,
-		},
-		{
-			Type:             unittest.EventTypeFixture(flow.Localnet),
-			TransactionID:    txID2,
-			TransactionIndex: 2,
-			EventIndex:       0,
-		},
-		{
-			Type:             unittest.EventTypeFixture(flow.Localnet),
-			TransactionID:    txID2,
-			TransactionIndex: 2,
-			EventIndex:       1,
-		},
-	}
+	expectedEvents := make(flow.EventsList, 0, 6)
+	expectedEvents = append(expectedEvents, generateTxEvents(unittest.IdentifierFixture(), 0, 1)...)
+	expectedEvents = append(expectedEvents, generateTxEvents(unittest.IdentifierFixture(), 1, 3)...)
+	expectedEvents = append(expectedEvents, generateTxEvents(unittest.IdentifierFixture(), 2, 2)...)
 
 	storedEvents := make([]flow.Event, len(expectedEvents))
 	copy(storedEvents, expectedEvents)
@@ -82,7 +45,8 @@ func TestGetEvents(t *testing.T) {
 	})
 
 	eventsIndex := NewEventsIndex(events)
-	eventsIndex.Initialize(&mockIndexReporter{})
+	err := eventsIndex.Initialize(&mockIndexReporter{})
+	require.NoError(t, err)
 
 	actualEvents, err := eventsIndex.GetEvents(header.ID(), header.Height)
 	require.NoError(t, err)
@@ -92,6 +56,19 @@ func TestGetEvents(t *testing.T) {
 	for i, event := range actualEvents {
 		assert.Equal(t, expectedEvents[i], event)
 	}
+}
+
+func generateTxEvents(txID flow.Identifier, txIndex uint32, count int) flow.EventsList {
+	events := make(flow.EventsList, count)
+	for i := 0; i < count; i++ {
+		events[i] = flow.Event{
+			Type:             unittest.EventTypeFixture(flow.Localnet),
+			TransactionID:    txID,
+			TransactionIndex: txIndex,
+			EventIndex:       uint32(i),
+		}
+	}
+	return events
 }
 
 type mockIndexReporter struct{}

--- a/engine/access/rpc/backend/event_index_test.go
+++ b/engine/access/rpc/backend/event_index_test.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"bytes"
-	"log"
 	"math"
 	"sort"
 	"testing"
@@ -74,15 +73,6 @@ func TestGetEvents(t *testing.T) {
 		}
 		return cmp < 0
 	})
-
-	for i := range storedEvents {
-		log.Printf("storedEvents[%d]: %v %v %v",
-			i,
-			storedEvents[i].TransactionID,
-			storedEvents[i].TransactionIndex,
-			storedEvents[i].EventIndex,
-		)
-	}
 
 	events := storagemock.NewEvents(t)
 	header := unittest.BlockHeaderFixture()

--- a/engine/access/rpc/backend/event_index_test.go
+++ b/engine/access/rpc/backend/event_index_test.go
@@ -1,0 +1,115 @@
+package backend
+
+import (
+	"bytes"
+	"log"
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	storagemock "github.com/onflow/flow-go/storage/mock"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestGetEvents tests that GetEvents returns the events in the correct order
+func TestGetEvents(t *testing.T) {
+	txID0 := unittest.IdentifierFixture()
+	txID1 := unittest.IdentifierFixture()
+	txID2 := unittest.IdentifierFixture()
+	expectedEvents := flow.EventsList{
+		{
+			Type:             unittest.EventTypeFixture(flow.Localnet),
+			TransactionID:    txID0,
+			TransactionIndex: 0,
+			EventIndex:       0,
+		},
+		{
+			Type:             unittest.EventTypeFixture(flow.Localnet),
+			TransactionID:    txID1,
+			TransactionIndex: 1,
+			EventIndex:       0,
+		},
+		{
+			Type:             unittest.EventTypeFixture(flow.Localnet),
+			TransactionID:    txID1,
+			TransactionIndex: 1,
+			EventIndex:       1,
+		},
+		{
+			Type:             unittest.EventTypeFixture(flow.Localnet),
+			TransactionID:    txID1,
+			TransactionIndex: 1,
+			EventIndex:       2,
+		},
+		{
+			Type:             unittest.EventTypeFixture(flow.Localnet),
+			TransactionID:    txID2,
+			TransactionIndex: 2,
+			EventIndex:       0,
+		},
+		{
+			Type:             unittest.EventTypeFixture(flow.Localnet),
+			TransactionID:    txID2,
+			TransactionIndex: 2,
+			EventIndex:       1,
+		},
+	}
+
+	storedEvents := make([]flow.Event, len(expectedEvents))
+	copy(storedEvents, expectedEvents)
+
+	// sort events in storage order (by tx ID)
+	sort.Slice(storedEvents, func(i, j int) bool {
+		cmp := bytes.Compare(storedEvents[i].TransactionID[:], storedEvents[j].TransactionID[:])
+		if cmp == 0 {
+			if storedEvents[i].TransactionIndex == storedEvents[j].TransactionIndex {
+				return storedEvents[i].EventIndex < storedEvents[j].EventIndex
+			}
+			return storedEvents[i].TransactionIndex < storedEvents[j].TransactionIndex
+		}
+		return cmp < 0
+	})
+
+	for i := range storedEvents {
+		log.Printf("storedEvents[%d]: %v %v %v",
+			i,
+			storedEvents[i].TransactionID,
+			storedEvents[i].TransactionIndex,
+			storedEvents[i].EventIndex,
+		)
+	}
+
+	events := storagemock.NewEvents(t)
+	header := unittest.BlockHeaderFixture()
+
+	events.On("ByBlockID", mock.Anything).Return(func(blockID flow.Identifier) ([]flow.Event, error) {
+		return storedEvents, nil
+	})
+
+	eventsIndex := NewEventsIndex(events)
+	eventsIndex.Initialize(&mockIndexReporter{})
+
+	actualEvents, err := eventsIndex.GetEvents(header.ID(), header.Height)
+	require.NoError(t, err)
+
+	// output events should be in the same order as the expected events
+	assert.Len(t, actualEvents, len(expectedEvents))
+	for i, event := range actualEvents {
+		assert.Equal(t, expectedEvents[i], event)
+	}
+}
+
+type mockIndexReporter struct{}
+
+func (r *mockIndexReporter) LowestIndexedHeight() (uint64, error) {
+	return 0, nil
+}
+
+func (r *mockIndexReporter) HighestIndexedHeight() (uint64, error) {
+	return math.MaxUint64, nil
+}

--- a/engine/access/rpc/backend/events_index.go
+++ b/engine/access/rpc/backend/events_index.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"fmt"
+	"sort"
 
 	"go.uber.org/atomic"
 
@@ -37,7 +38,21 @@ func (e *EventsIndex) GetEvents(blockID flow.Identifier, height uint64) ([]flow.
 		return nil, err
 	}
 
-	return e.events.ByBlockID(blockID)
+	events, err := e.events.ByBlockID(blockID)
+	if err != nil {
+		return nil, err
+	}
+
+	// events are keyed/sorted by [blockID, txID, txIndex, eventIndex]
+	// we need to resort them by tx index then event index so the output is in execution order
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].TransactionIndex == events[j].TransactionIndex {
+			return events[i].EventIndex < events[j].EventIndex
+		}
+		return events[i].TransactionIndex < events[j].TransactionIndex
+	})
+
+	return events, nil
 }
 
 // LowestIndexedHeight returns the lowest height indexed by the execution state indexer.

--- a/engine/access/state_stream/backend/backend_events_test.go
+++ b/engine/access/state_stream/backend/backend_events_test.go
@@ -54,7 +54,14 @@ func (s *BackendEventsSuite) TestSubscribeEventsFromLocalStorage() {
 			events[i] = event
 		}
 		sort.Slice(events, func(i, j int) bool {
-			return bytes.Compare(events[i].TransactionID[:], events[j].TransactionID[:]) < 0
+			cmp := bytes.Compare(events[i].TransactionID[:], events[j].TransactionID[:])
+			if cmp == 0 {
+				if events[i].TransactionIndex == events[j].TransactionIndex {
+					return events[i].EventIndex < events[j].EventIndex
+				}
+				return events[i].TransactionIndex < events[j].TransactionIndex
+			}
+			return cmp < 0
 		})
 		blockEvents[b.ID()] = events
 	}


### PR DESCRIPTION
Events returned by `ByBlockID` called on the badger storage object are returned in the same order stored. Events are keyed on [ blockID, txID, txIndex, eventIndex ]. This makes querying easier, but results in a list of events that is not in the same order that the tx appeared in the block.

The usually isn't a problem when querying with the polling endpoints, but when streaming it's possible to subscribe to all events. In this case, it's unintuitive for the returned list to not be in tx order.

This PR sorts events returned to the API by txIndex to ensure the returned order is correct.