### PR TITLE
Fix block total supply

### DIFF
--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -168,7 +168,7 @@ var blockExecutedEventCadenceType = &cadence.EventType{
 	Fields: []cadence.Field{
 		cadence.NewField("height", cadence.UInt64Type),
 		cadence.NewField("hash", cadence.StringType),
-		cadence.NewField("totalSupply", cadence.UInt64Type),
+		cadence.NewField("totalSupply", cadence.IntType),
 		cadence.NewField("parentHash", cadence.StringType),
 		cadence.NewField("receiptRoot", cadence.StringType),
 		cadence.NewField(


### PR DESCRIPTION
Fix wrongly resolved merge that re-introduced a wrong block total supply type. 

PR merge for context: https://github.com/onflow/flow-go/commit/2f8dfa0c9285069489a0d9f39f459a9b068f331f