### PR TITLE
Update Stable Cadence feature branch

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -107,6 +107,10 @@ func (bl *BlockView) DirectCall(call *types.DirectCall) (*types.Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	txHash, err := call.Hash()
+	if err != nil {
+		return nil, err
+	}
 	switch call.SubType {
 	case types.DepositCallSubType:
 		return proc.mintTo(call.To, call.Value)
@@ -118,7 +122,9 @@ func (bl *BlockView) DirectCall(call *types.DirectCall) (*types.Result, error) {
 		}
 		fallthrough
 	default:
-		return proc.runDirect(call.Message(), types.DirectCallTxType)
+		// TODO: when we support mutiple calls per block, we need
+		// to update the value zero here for tx index
+		return proc.runDirect(call.Message(), txHash, 0, types.DirectCallTxType)
 	}
 }
 
@@ -139,9 +145,17 @@ func (bl *BlockView) RunTransaction(
 		return res, types.NewEVMValidationError(err)
 	}
 
+	txHash := tx.Hash()
+
 	// update tx context origin
 	proc.evm.TxContext.Origin = msg.From
-	res, err = proc.run(msg, tx.Type())
+	// TODO: when we support multiple tx per block we need to update
+	// the tx index here to proper value
+	res, err = proc.run(msg, txHash, 0, tx.Type())
+	if err != nil {
+		return nil, err
+	}
+	res.TxHash = txHash
 	return res, err
 }
 
@@ -351,16 +365,27 @@ func (proc *procedure) deployAt(
 	return res, proc.commit()
 }
 
-func (proc *procedure) runDirect(msg *gethCore.Message, txType uint8) (*types.Result, error) {
+func (proc *procedure) runDirect(
+	msg *gethCore.Message,
+	txHash gethCommon.Hash,
+	txIndex uint,
+	txType uint8,
+) (*types.Result, error) {
 	// set the nonce for the message (needed for some opeartions like deployment)
 	msg.Nonce = proc.state.GetNonce(msg.From)
 	proc.evm.TxContext.Origin = msg.From
-	return proc.run(msg, types.DirectCallTxType)
+	return proc.run(msg, txHash, txIndex, types.DirectCallTxType)
 }
 
-func (proc *procedure) run(msg *gethCore.Message, txType uint8) (*types.Result, error) {
+func (proc *procedure) run(
+	msg *gethCore.Message,
+	txHash gethCommon.Hash,
+	txIndex uint,
+	txType uint8,
+) (*types.Result, error) {
 	res := types.Result{
 		TxType: txType,
+		TxHash: txHash,
 	}
 
 	gasPool := (*gethCore.GasPool)(&proc.config.BlockContext.GasLimit)
@@ -390,12 +415,11 @@ func (proc *procedure) run(msg *gethCore.Message, txType uint8) (*types.Result, 
 			if msg.To == nil {
 				res.DeployedContractAddress = types.NewAddress(gethCrypto.CreateAddress(msg.From, msg.Nonce))
 			}
+			// replace tx index and tx hash
 			res.Logs = proc.state.Logs(
-				// TODO pass proper hash values
-				gethCommon.Hash{},
 				proc.config.BlockContext.BlockNumber.Uint64(),
-				gethCommon.Hash{},
-				0,
+				txHash,
+				txIndex,
 			)
 		} else {
 			// execResult.Err is VM errors (we don't return it as error)

--- a/fvm/evm/emulator/state/stateDB.go
+++ b/fvm/evm/emulator/state/stateDB.go
@@ -263,7 +263,6 @@ func (db *StateDB) Snapshot() int {
 // Logs returns the list of logs
 // it also update each log with the block and tx info
 func (db *StateDB) Logs(
-	blockHash gethCommon.Hash,
 	blockNumber uint64,
 	txHash gethCommon.Hash,
 	txIndex uint,
@@ -272,7 +271,6 @@ func (db *StateDB) Logs(
 	for _, view := range db.views {
 		for _, log := range view.Logs() {
 			log.BlockNumber = blockNumber
-			log.BlockHash = blockHash
 			log.TxHash = txHash
 			log.TxIndex = txIndex
 			allLogs = append(allLogs, log)

--- a/fvm/evm/emulator/state/stateDB_test.go
+++ b/fvm/evm/emulator/state/stateDB_test.go
@@ -170,7 +170,7 @@ func TestStateDB(t *testing.T) {
 		db.AddLog(testutils.GetRandomLogFixture(t))
 		db.RevertToSnapshot(snapshot)
 
-		ret := db.Logs(gethCommon.Hash{}, 1, gethCommon.Hash{}, 1)
+		ret := db.Logs(1, gethCommon.Hash{}, 1)
 		require.Equal(t, ret, logs)
 	})
 

--- a/fvm/evm/handler/blockstore.go
+++ b/fvm/evm/handler/blockstore.go
@@ -45,12 +45,12 @@ func (bs *BlockStore) BlockProposal() (*types.Block, error) {
 		return nil, err
 	}
 
-	bs.blockProposal = &types.Block{
-		Height:            lastExecutedBlock.Height + 1,
-		ParentBlockHash:   parentHash,
-		TotalSupply:       lastExecutedBlock.TotalSupply,
-		TransactionHashes: make([]gethCommon.Hash, 0),
-	}
+	bs.blockProposal = types.NewBlock(parentHash,
+		lastExecutedBlock.Height+1,
+		lastExecutedBlock.TotalSupply,
+		gethCommon.Hash{},
+		make([]gethCommon.Hash, 0),
+	)
 	return bs.blockProposal, nil
 }
 

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -206,14 +206,21 @@ func (h *ContractHandler) run(
 		return res, err
 	}
 
-	txHash := tx.Hash()
-	bp.AppendTxHash(txHash)
+	bp.AppendTxHash(res.TxHash)
+
+	// TODO: in the future we might update the receipt hash here
+
+	blockHash, err := bp.Hash()
+	if err != nil {
+		return res, err
+	}
 
 	// step 4 - emit events
 	err = h.emitEvent(types.NewTransactionExecutedEvent(
 		bp.Height,
 		rlpEncodedTx,
-		txHash,
+		blockHash,
+		res.TxHash,
 		res,
 	))
 	if err != nil {
@@ -309,17 +316,18 @@ func (h *ContractHandler) executeAndHandleCall(
 	}
 
 	// update block proposal
-	callHash, err := call.Hash()
-	if err != nil {
-		return res, types.NewFatalError(err)
-	}
-
 	bp, err := h.blockStore.BlockProposal()
 	if err != nil {
 		return res, err
 	}
 
-	bp.AppendTxHash(callHash)
+	bp.AppendTxHash(res.TxHash)
+	// TODO: in the future we might update the receipt hash here
+
+	blockHash, err := bp.Hash()
+	if err != nil {
+		return res, err
+	}
 
 	if totalSupplyDiff != nil {
 		if deductSupplyDiff {
@@ -342,7 +350,8 @@ func (h *ContractHandler) executeAndHandleCall(
 		types.NewTransactionExecutedEvent(
 			bp.Height,
 			encoded,
-			callHash,
+			blockHash,
+			res.TxHash,
 			res,
 		),
 	)

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -77,6 +77,12 @@ func TestHandler_TransactionRun(t *testing.T) {
 						big.NewInt(1),
 					)
 
+					// calculate tx id to match it
+					var evmTx gethTypes.Transaction
+					err := evmTx.UnmarshalBinary(tx)
+					require.NoError(t, err)
+					result.TxHash = evmTx.Hash()
+
 					// successfully run (no-panic)
 					handler.Run(tx, coinbase)
 
@@ -123,11 +129,6 @@ func TestHandler_TransactionRun(t *testing.T) {
 					// make sure block transaction list references the above transaction id
 					cadenceEvent, ok = ev.(cadence.Event)
 					require.True(t, ok)
-
-					// calculate tx id to match it
-					var evmTx gethTypes.Transaction
-					err = evmTx.UnmarshalBinary(tx)
-					require.NoError(t, err)
 
 					for j, f := range cadenceEvent.GetFields() {
 						if f.Identifier == "transactionHashes" {

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -45,11 +45,15 @@ func (b *Block) AppendTxHash(txHash gethCommon.Hash) {
 }
 
 // NewBlock constructs a new block
-func NewBlock(height, uuidIndex uint64, totalSupply *big.Int,
-	stateRoot, receiptRoot gethCommon.Hash,
+func NewBlock(
+	parentBlockHash gethCommon.Hash,
+	height uint64,
+	totalSupply *big.Int,
+	receiptRoot gethCommon.Hash,
 	txHashes []gethCommon.Hash,
 ) *Block {
 	return &Block{
+		ParentBlockHash:   parentBlockHash,
 		Height:            height,
 		TotalSupply:       totalSupply,
 		ReceiptRoot:       receiptRoot,

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -100,6 +100,7 @@ func init() {
 type TransactionExecutedPayload struct {
 	BlockHeight uint64
 	TxEncoded   []byte
+	BlockHash   gethCommon.Hash
 	TxHash      gethCommon.Hash
 	Result      *Result
 }
@@ -120,6 +121,7 @@ func (p *TransactionExecutedPayload) CadenceEvent() (cadence.Event, error) {
 			string(EventTypeTransactionExecuted),
 			[]cadence.Field{
 				cadence.NewField("blockHeight", cadence.UInt64Type),
+				cadence.NewField("blockHash", cadence.StringType),
 				cadence.NewField("transactionHash", cadence.StringType),
 				cadence.NewField("transaction", cadence.StringType),
 				cadence.NewField("failed", cadence.BoolType),
@@ -134,6 +136,7 @@ func (p *TransactionExecutedPayload) CadenceEvent() (cadence.Event, error) {
 		),
 		Fields: []cadence.Value{
 			cadence.NewUInt64(p.BlockHeight),
+			cadence.String(p.BlockHash.String()),
 			cadence.String(p.TxHash.String()),
 			cadence.String(hex.EncodeToString(p.TxEncoded)),
 			cadence.Bool(p.Result.Failed()),
@@ -150,6 +153,7 @@ func (p *TransactionExecutedPayload) CadenceEvent() (cadence.Event, error) {
 func NewTransactionExecutedEvent(
 	height uint64,
 	txEncoded []byte,
+	blockHash gethCommon.Hash,
 	txHash gethCommon.Hash,
 	result *Result,
 ) *Event {
@@ -157,6 +161,7 @@ func NewTransactionExecutedEvent(
 		Etype: EventTypeTransactionExecuted,
 		Payload: &TransactionExecutedPayload{
 			BlockHeight: height,
+			BlockHash:   blockHash,
 			TxEncoded:   txEncoded,
 			TxHash:      txHash,
 			Result:      result,

--- a/fvm/evm/types/events_test.go
+++ b/fvm/evm/types/events_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/fvm/evm/testutils"
 	"github.com/onflow/flow-go/fvm/evm/types"
 )
 
@@ -56,13 +57,14 @@ func TestEVMEventsCCFEncodingDecoding(t *testing.T) {
 
 		txEncoded, err := hex.DecodeString("fff83b81ff0194000000000000000000000000000000000000000094000000000000000000000000000000000000000180895150ae84a8cdf00000825208")
 		require.NoError(t, err)
-		txHash := gethCommon.HexToHash("0xf3593c3eb9ac1125f31acfa5520877f223279f6238a670936e65a710ccd44641")
+		txHash := testutils.RandomCommonHash(t)
+		blockHash := testutils.RandomCommonHash(t)
 		data, err := hex.DecodeString("000000000000000000000000000000000000000000000000000000000000002a")
 		require.NoError(t, err)
 		log := &gethTypes.Log{
 			Index:       0,
 			BlockNumber: 2,
-			BlockHash:   gethCommon.HexToHash("0xf3593c3eb9ac1125f31acfa5520877f223279f6238a670936e65a710ccd44641"),
+			BlockHash:   blockHash,
 			TxHash:      txHash,
 			TxIndex:     0,
 			Address:     gethCommon.HexToAddress("0x99466ed2e37b892a2ee3e9cd55a98b68f5735db2"),
@@ -83,6 +85,7 @@ func TestEVMEventsCCFEncodingDecoding(t *testing.T) {
 		event := types.NewTransactionExecutedEvent(
 			2,
 			txEncoded,
+			blockHash,
 			txHash,
 			txResult,
 		)

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	gethCommon "github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -24,6 +25,8 @@ type Result struct {
 	ReturnedValue []byte
 	// EVM logs (events that are emited by evm)
 	Logs []*gethTypes.Log
+	// TX hash holdes the cached value of tx hash
+	TxHash gethCommon.Hash
 }
 
 func (res *Result) Failed() bool {

--- a/fvm/evm/types/state.go
+++ b/fvm/evm/types/state.go
@@ -17,7 +17,6 @@ type StateDB interface {
 
 	// Logs collects and prepares logs
 	Logs(
-		blockHash gethCommon.Hash,
 		blockNumber uint64,
 		txHash gethCommon.Hash,
 		txIndex uint,


### PR DESCRIPTION
<details>
<summary>Conflict resolution</summary>

```diff
commit 6944e9d91cacce71aa450e3d9bf65fe821d03c08
Merge: 6b0ce48e3d 8b2113a309
Author: Bastian Müller <bastian@turbolent.com>
Date:   Tue Feb 20 12:46:04 2024 -0800

    Merge branch 'master' into bastian/update-stable-cadence-11

diff --git a/fvm/evm/types/events.go b/fvm/evm/types/events.go
remerge CONFLICT (content): Merge conflict in fvm/evm/types/events.go
index adf763feb9..140467ad7e 100644
--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -120,8 +120,8 @@ func (p *TransactionExecutedPayload) CadenceEvent() (cadence.Event, error) {
 			EVMLocation{},
 			string(EventTypeTransactionExecuted),
 			[]cadence.Field{
-<<<<<<< 6b0ce48e3d (Merge pull request #5396 from onflow/kan/preview-net-chain-id)
 				cadence.NewField("blockHeight", cadence.UInt64Type),
+				cadence.NewField("blockHash", cadence.StringType),
 				cadence.NewField("transactionHash", cadence.StringType),
 				cadence.NewField("transaction", cadence.StringType),
 				cadence.NewField("failed", cadence.BoolType),
@@ -131,19 +131,6 @@ func (p *TransactionExecutedPayload) CadenceEvent() (cadence.Event, error) {
 				cadence.NewField("deployedContractAddress", cadence.StringType),
 				cadence.NewField("returnedValue", cadence.StringType),
 				cadence.NewField("logs", cadence.StringType),
-=======
-				cadence.NewField("blockHeight", cadence.UInt64Type{}),
-				cadence.NewField("blockHash", cadence.StringType{}),
-				cadence.NewField("transactionHash", cadence.StringType{}),
-				cadence.NewField("transaction", cadence.StringType{}),
-				cadence.NewField("failed", cadence.BoolType{}),
-				cadence.NewField("vmError", cadence.StringType{}),
-				cadence.NewField("transactionType", cadence.UInt8Type{}),
-				cadence.NewField("gasConsumed", cadence.UInt64Type{}),
-				cadence.NewField("deployedContractAddress", cadence.StringType{}),
-				cadence.NewField("returnedValue", cadence.StringType{}),
-				cadence.NewField("logs", cadence.StringType{}),
->>>>>>> 8b2113a309 (Merge pull request #5387 from onflow/ramtin/5372-update-log-with-txhash)
 			},
 			nil,
 		),
```

</details>