### PR TITLE
Add sub-command to generate addresses for a chain

### DIFF
--- a/cmd/util/cmd/addresses/cmd.go
+++ b/cmd/util/cmd/addresses/cmd.go
@@ -1,0 +1,54 @@
+package addresses
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+var (
+	flagChain          string
+	flagCount          int
+	flagCommaSeparated bool
+)
+
+var Cmd = &cobra.Command{
+	Use:   "addresses",
+	Short: "Prints the version of the utils tool",
+	Run:   run,
+}
+
+func init() {
+	Cmd.Flags().StringVar(&flagChain, "chain", "", "Chain name")
+	_ = Cmd.MarkFlagRequired("chain")
+
+	Cmd.Flags().IntVar(&flagCount, "count", 1, "Count")
+	_ = Cmd.MarkFlagRequired("count")
+
+	Cmd.Flags().BoolVar(&flagCommaSeparated, "commas", false, "Separate using commas instead of newlines")
+}
+
+func run(*cobra.Command, []string) {
+	chain := flow.ChainID(flagChain).Chain()
+
+	generator := chain.NewAddressGenerator()
+
+	for i := 0; i < flagCount; i++ {
+		address, err := generator.NextAddress()
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to generate address")
+		}
+
+		str := address.Hex()
+
+		if flagCommaSeparated {
+			if i > 0 {
+				print(",")
+			}
+			print(str)
+		} else {
+			println(str)
+		}
+	}
+}

--- a/cmd/util/cmd/addresses/cmd.go
+++ b/cmd/util/cmd/addresses/cmd.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	flagChain          string
-	flagCount          int
-	flagCommaSeparated bool
+	flagChain     string
+	flagCount     int
+	flagSeparator string
 )
 
 var Cmd = &cobra.Command{
@@ -26,7 +26,7 @@ func init() {
 	Cmd.Flags().IntVar(&flagCount, "count", 1, "Count")
 	_ = Cmd.MarkFlagRequired("count")
 
-	Cmd.Flags().BoolVar(&flagCommaSeparated, "commas", false, "Separate using commas instead of newlines")
+	Cmd.Flags().StringVar(&flagSeparator, "separator", ",", "Separator to use between addresses")
 }
 
 func run(*cobra.Command, []string) {
@@ -42,13 +42,9 @@ func run(*cobra.Command, []string) {
 
 		str := address.Hex()
 
-		if flagCommaSeparated {
-			if i > 0 {
-				print(",")
-			}
-			print(str)
-		} else {
-			println(str)
+		if i > 0 {
+			print(flagSeparator)
 		}
+		print(str)
 	}
 }

--- a/cmd/util/cmd/addresses/cmd.go
+++ b/cmd/util/cmd/addresses/cmd.go
@@ -15,7 +15,7 @@ var (
 
 var Cmd = &cobra.Command{
 	Use:   "addresses",
-	Short: "Prints the version of the utils tool",
+	Short: "generate addresses for a chain",
 	Run:   run,
 }
 

--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/onflow/flow-go/cmd/util/cmd/addresses"
 	checkpoint_collect_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-collect-stats"
 	checkpoint_list_tries "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-list-tries"
 	checkpoint_trie_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-trie-stats"
@@ -80,6 +81,7 @@ func addCommands() {
 	rootCmd.AddCommand(snapshot.Cmd)
 	rootCmd.AddCommand(export_json_transactions.Cmd)
 	rootCmd.AddCommand(read_hotstuff.RootCmd)
+	rootCmd.AddCommand(addresses.Cmd)
 }
 
 func initConfig() {


### PR DESCRIPTION
This is useful when using `util` with `execution-state-extract` with `--extract-payloads-by-address`