### PR TITLE
Move `blockHash` calculation after deduction of supply diff

### DIFF
--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -300,11 +300,6 @@ func (h *ContractHandler) executeAndHandleCall(
 	bp.AppendTxHash(res.TxHash)
 	// TODO: in the future we might update the receipt hash here
 
-	blockHash, err := bp.Hash()
-	if err != nil {
-		return res, err
-	}
-
 	if totalSupplyDiff != nil {
 		if deductSupplyDiff {
 			bp.TotalSupply = new(big.Int).Sub(bp.TotalSupply, totalSupplyDiff)
@@ -314,6 +309,11 @@ func (h *ContractHandler) executeAndHandleCall(
 		} else {
 			bp.TotalSupply = new(big.Int).Add(bp.TotalSupply, totalSupplyDiff)
 		}
+	}
+
+	blockHash, err := bp.Hash()
+	if err != nil {
+		return res, err
 	}
 
 	// emit events


### PR DESCRIPTION
The `evm.BlockExecuted.hash` & `evm.TransactionExecuted.blockHash` fields did not match up, e.g.
```shell


Index    5
Type    evm.TransactionExecuted
Tx ID    67244b4d6f7e8ed4a5687099386e66424ec8d6adfa1abf739b9b227beb544b24
Values
    - blockHeight (UInt64): 2 
    - blockHash (String): "0x5d85046405a803acf1920cfafb7508f1817f7c905a616e012ea0420704f68c09" 
    - transactionHash (String): "0x95f00658e23f24928fe5a1c4af91df8fdd7b4cf02ea63cc86911d197dfa7912e" 
    - transaction (String): "fff83c81ff0194000000000000000000000000000000000000000094000000000000000000000002fcb52dccbbaa997780891b1ae4d6e2ef50000082520880" 
    - failed (Bool): false 
    - vmError (String): "" 
    - transactionType (UInt8): 255 
    - gasConsumed (UInt64): 21000 
    - deployedContractAddress (String): "0000000000000000000000000000000000000000" 
    - returnedValue (String): "" 
    - logs (String): "" 

Index    6
Type    evm.BlockExecuted
Tx ID    67244b4d6f7e8ed4a5687099386e66424ec8d6adfa1abf739b9b227beb544b24
Values
    - height (UInt64): 2 
    - hash (String): "0x4131fe910a710d9d19128f135f78d33bcf1d4c50d5a6b9b1cd0b3a410539f3bd" 
    - totalSupply (Int): 500000000000000000000 
    - parentHash (String): "0x20fce2ec38f2fe8df9de507d5969487152faae0033a23b2cef1f4ab938af7ef2" 
    - receiptRoot (String): "0x0000000000000000000000000000000000000000000000000000000000000000" 
    - transactionHashes ([String]): ["0x95f00658e23f24928fe5a1c4af91df8fdd7b4cf02ea63cc86911d197dfa7912e"] 
```

This was due to calculating the block hash, before supply diff deduction. The `TotalSupply` field of a block would change, hence resulting in a different hash value.