### PR TITLE
Move `blockHash` calculation after deduction supply diff

### DIFF
--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -300,11 +300,6 @@ func (h *ContractHandler) executeAndHandleCall(
 	bp.AppendTxHash(res.TxHash)
 	// TODO: in the future we might update the receipt hash here
 
-	blockHash, err := bp.Hash()
-	if err != nil {
-		return res, err
-	}
-
 	if totalSupplyDiff != nil {
 		if deductSupplyDiff {
 			bp.TotalSupply = new(big.Int).Sub(bp.TotalSupply, totalSupplyDiff)
@@ -314,6 +309,11 @@ func (h *ContractHandler) executeAndHandleCall(
 		} else {
 			bp.TotalSupply = new(big.Int).Add(bp.TotalSupply, totalSupplyDiff)
 		}
+	}
+
+	blockHash, err := bp.Hash()
+	if err != nil {
+		return res, err
 	}
 
 	// emit events


### PR DESCRIPTION
Port of https://github.com/onflow/flow-go/pull/5462 from `feature/stable-cadence` to `master` branch.