### PR TITLE
Remove db close in execution state sync tests

### DIFF
--- a/integration/tests/access/cohort3/execution_state_sync_test.go
+++ b/integration/tests/access/cohort3/execution_state_sync_test.go
@@ -205,12 +205,5 @@ func (s *ExecutionStateSyncSuite) nodeExecutionDataStore(node *testnet.Container
 	ds, err := badgerds.NewDatastore(filepath.Join(node.ExecutionDataDBPath(), "blobstore"), &badgerds.DefaultOptions)
 	require.NoError(s.T(), err, "could not get execution datastore")
 
-	go func() {
-		<-s.ctx.Done()
-		if err := ds.Close(); err != nil {
-			s.T().Logf("could not close execution data datastore: %v", err)
-		}
-	}()
-
 	return execution_data.NewExecutionDataStore(blobs.NewBlobstore(ds), execution_data.DefaultSerializer)
 }


### PR DESCRIPTION
The DB is closed and deleted by `Cleanup` [method](https://github.com/onflow/flow-go/blob/leo/fix-execution-state-sync-tests/integration/testnet/network.go#L291) during `TearDownTest` call. 

Calling DB.Close again would try to remove the lock or db folder which has already removed. This sometimes [causing an endless loop](https://github.com/dgraph-io/badger/issues/664) because when badger can't find the files to delete, it will run a loop to try deleting them, and end up causing the tests to run longer and hit timeout eventually. 

