### PR TITLE
V0.33.8 relic

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -38,11 +38,6 @@ on:
         type: boolean
         description: 'Observer'
         required: false
-      # GHA allows only up to 10 inputs - regroup two entries in one
-      include_alternative_builds:
-        type: boolean
-        description: 'Build amd64 `without_adx` and `without_netgo_without_adx` images, and arm64 images'
-        required: false
 
 jobs:
   # matrix_builder generates a matrix that includes the roles selected in the input
@@ -93,7 +88,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.19'
+        go-version: '1.20'
 
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -117,14 +112,5 @@ jobs:
         IMAGE_TAG: ${{ inputs.docker_tag }}
         CADENCE_DEPLOY_KEY: ${{ secrets.CADENCE_DEPLOY_KEY }}
       run: |
-        make docker-build-${{ matrix.role }}-with-adx docker-push-${{ matrix.role }}-with-adx
-
-    - name: Build/Push ${{ matrix.role }} amd64 images without netgo and without adx, arm64 images
-      if: ${{ inputs.include_alternative_builds }}
-      env:
-        IMAGE_TAG: ${{ inputs.docker_tag }}
-        CADENCE_DEPLOY_KEY: ${{ secrets.CADENCE_DEPLOY_KEY }}
-      run: |
-        make docker-build-${{ matrix.role }}-without-adx docker-push-${{ matrix.role }}-without-adx \
-          docker-build-${{ matrix.role }}-without-netgo-without-adx docker-push-${{ matrix.role }}-without-netgo-without-adx \
-          docker-cross-build-${{ matrix.role }}-arm docker-push-${{ matrix.role }}-arm
+        make docker-build-${{ matrix.role }} docker-push-${{ matrix.role }} \
+          docker-build-${{ matrix.role }}-without-netgo docker-push-${{ matrix.role }}-without-netgo

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,13 +33,9 @@ jobs:
       env:
         CADENCE_DEPLOY_KEY: ${{ secrets.CADENCE_DEPLOY_KEY }}
       run: |
-        make docker-build-flow-with-adx
-        make docker-build-flow-without-adx
-        make docker-build-flow-without-netgo-without-adx
-        make docker-cross-build-flow-arm
+        make docker-build-flow
+        make docker-build-flow-without-netgo
     - name: Docker push
       run: |
-        make docker-push-flow-with-adx
-        make docker-push-flow-without-adx
-        make docker-push-flow-without-netgo-without-adx
-        make docker-push-flow-arm
+        make docker-push-flow
+        make docker-push-flow-without-netgo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
         cache: true
     - name: Build relic
-        run: make crypto_setup_gopath
+      run: make crypto_setup_gopath
     - name: Load cached Docker images
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: true
+    - name: Build relic
+      run: make crypto_setup_gopath
     - name: Run go generate
       run: go generate
       working-directory: ${{ matrix.dir }}
@@ -279,6 +281,8 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: true
+    - name: Build relic
+        run: make crypto_setup_gopath
     - name: Load cached Docker images
       uses: actions/cache@v3
       with:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -38,6 +38,8 @@ jobs:
         # to accurately get the version tag
         fetch-depth: 0
         ref: ${{ inputs.tag }}
+    - name: Build relic
+      run: make crypto_setup_gopath
     - name: Build and upload boot-tools
       run: |
         make tool-bootstrap tool-transit

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ go.work.sum
 
 # Local testing result files
 tps-results*.json
+
+# crypto relic folder
+crypto/relic/

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ ifeq (${IMAGE_TAG},)
 IMAGE_TAG := ${SHORT_COMMIT}
 endif
 
-IMAGE_TAG_NO_ADX := $(IMAGE_TAG)-without-adx
-IMAGE_TAG_NO_NETGO_NO_ADX := $(IMAGE_TAG)-without-netgo-without-adx
-IMAGE_TAG_ARM := $(IMAGE_TAG)-arm
+IMAGE_TAG := $(IMAGE_TAG)
+IMAGE_TAG_NO_NETGO := $(IMAGE_TAG)-without-netgo
+
 
 # Name of the cover profile
 COVER_PROFILE := coverage.txt
@@ -299,26 +299,20 @@ docker-native-build-collection:
 		-t "$(CONTAINER_REGISTRY)/collection:latest" \
 		-t "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-collection-with-adx
-docker-build-collection-with-adx:
+.PHONY: docker-build-collection
+docker-build-collection:
 	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/collection --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG) --build-arg GOARCH=amd64 --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
 		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG)" \
 		-t "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG)"  .
 
-.PHONY: docker-build-collection-without-adx
-docker-build-collection-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/collection --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_ADX) --build-arg GOARCH=amd64 --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
-		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG_NO_ADX)"  .
 
-.PHONY: docker-build-collection-without-netgo-without-adx
-docker-build-collection-without-netgo-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/collection --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO_NO_ADX) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
+.PHONY: docker-build-collection-without-netgo
+docker-build-collection-without-netgo:
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/collection --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG_NO_NETGO_NO_ADX)"  .
+		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO)" \
+		-t "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG_NO_NETGO)"  .
 
 .PHONY: docker-cross-build-collection-arm
 docker-cross-build-collection-arm:
@@ -341,26 +335,19 @@ docker-native-build-consensus:
 		-t "$(CONTAINER_REGISTRY)/consensus:latest" \
 		-t "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG)"  .
 
-.PHONY: docker-build-consensus-with-adx
-docker-build-consensus-with-adx:
+.PHONY: docker-build-consensus
+docker-build-consensus:
 	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/consensus --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG) --build-arg GOARCH=amd64 --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
 		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG)" \
 		-t "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-consensus-without-adx
-docker-build-consensus-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/consensus --build-arg COMMIT=$(COMMIT) --build-arg VERSION=$(IMAGE_TAG_NO_ADX) --build-arg GOARCH=amd64 --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
+.PHONY: docker-build-consensus-without-netgo
+docker-build-consensus-without-netgo:
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/consensus --build-arg COMMIT=$(COMMIT) --build-arg VERSION=$(IMAGE_TAG_NO_NETGO) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG_NO_ADX)" .
-
-.PHONY: docker-build-consensus-without-netgo-without-adx
-docker-build-consensus-without-netgo-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/consensus --build-arg COMMIT=$(COMMIT) --build-arg VERSION=$(IMAGE_TAG_NO_NETGO_NO_ADX) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
-		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG_NO_NETGO_NO_ADX)" .
+		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO)" \
+		-t "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG_NO_NETGO)" .
 
 .PHONY: docker-cross-build-consensus-arm
 docker-cross-build-consensus-arm:
@@ -384,26 +371,19 @@ docker-native-build-execution:
 		-t "$(CONTAINER_REGISTRY)/execution:latest" \
 		-t "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-execution-with-adx
-docker-build-execution-with-adx:
+.PHONY: docker-build-execution
+docker-build-execution:
 	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/execution --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG) --build-arg GOARCH=amd64 --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
 		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG)" \
 		-t "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-execution-without-adx
-docker-build-execution-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/execution --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_ADX) --build-arg GOARCH=amd64 --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
+.PHONY: docker-build-execution-without-netgo
+docker-build-execution-without-netgo:
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/execution --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG_NO_ADX)" .
-
-.PHONY: docker-build-execution-without-netgo-without-adx
-docker-build-execution-without-netgo-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/execution --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO_NO_ADX) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
-		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG_NO_NETGO_NO_ADX)" .
+		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO)" \
+		-t "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG_NO_NETGO)" .
 
 .PHONY: docker-cross-build-execution-arm
 docker-cross-build-execution-arm:
@@ -438,26 +418,20 @@ docker-native-build-verification:
 		-t "$(CONTAINER_REGISTRY)/verification:latest" \
 		-t "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-verification-with-adx
-docker-build-verification-with-adx:
+.PHONY: docker-build-verification
+docker-build-verification:
 	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/verification --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG) --build-arg GOARCH=amd64 --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
 		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG)" \
 		-t "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-verification-without-adx
-docker-build-verification-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/verification --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_ADX) --build-arg GOARCH=amd64 --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
-		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG_NO_ADX)" .
 
-.PHONY: docker-build-verification-without-netgo-without-adx
-docker-build-verification-without-netgo-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/verification --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO_NO_ADX) --build-arg GOARCH=amd64 --build-arg TAGS=""  --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
+.PHONY: docker-build-verification-without-netgo
+docker-build-verification-without-netgo:
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/verification --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO) --build-arg GOARCH=amd64 --build-arg TAGS=""  --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG_NO_NETGO_NO_ADX)" .
+		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO)" \
+		-t "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG_NO_NETGO)" .
 
 .PHONY: docker-cross-build-verification-arm
 docker-cross-build-verification-arm:
@@ -492,26 +466,20 @@ docker-native-build-access:
 		-t "$(CONTAINER_REGISTRY)/access:latest" \
 		-t "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-access-with-adx
-docker-build-access-with-adx:
+.PHONY: docker-build-access
+docker-build-access:
 	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/access --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG) --build-arg GOARCH=amd64 --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
 		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG)" \
 		-t "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-access-without-adx
-docker-build-access-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/access --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_ADX) --build-arg GOARCH=amd64 --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
-		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG_NO_ADX)" .
 
-.PHONY: docker-build-access-without-netgo-without-adx
-docker-build-access-without-netgo-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/access --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO_NO_ADX) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
+.PHONY: docker-build-access-without-netgo
+docker-build-access-without-netgo:
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/access --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG_NO_NETGO_NO_ADX)" .
+		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO)" \
+		-t "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG_NO_NETGO)" .
 
 .PHONY: docker-cross-build-access-arm
 docker-cross-build-access-arm:
@@ -548,26 +516,20 @@ docker-native-build-observer:
 		-t "$(CONTAINER_REGISTRY)/observer:latest" \
 		-t "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-observer-with-adx
-docker-build-observer-with-adx:
+.PHONY: docker-build-observer
+docker-build-observer:
 	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/observer --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG) --build-arg GOARCH=amd64 --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
 		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG)" \
 		-t "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG)" .
 
-.PHONY: docker-build-observer-without-adx
-docker-build-observer-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/observer --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_ADX) --build-arg GOARCH=amd64 --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
-		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG_NO_ADX)" .
 
-.PHONY: docker-build-observer-without-netgo-without-adx
-docker-build-observer-without-netgo-without-adx:
-	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/observer --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO_NO_ADX) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
+.PHONY: docker-build-observer-without-netgo
+docker-build-observer-without-netgo:
+	docker build -f cmd/Dockerfile --build-arg TARGET=./cmd/observer --build-arg COMMIT=$(COMMIT)  --build-arg VERSION=$(IMAGE_TAG_NO_NETGO) --build-arg GOARCH=amd64 --build-arg TAGS="" --build-arg CGO_FLAG=$(DISABLE_ADX) --target production \
 		--secret id=cadence_deploy_key,env=CADENCE_DEPLOY_KEY --build-arg GOPRIVATE=$(GOPRIVATE) \
-		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO_NO_ADX)" \
-		-t "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG_NO_NETGO_NO_ADX)" .
+		--label "git_commit=${COMMIT}" --label "git_tag=$(IMAGE_TAG_NO_NETGO)" \
+		-t "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG_NO_NETGO)" .
 
 .PHONY: docker-cross-build-observer-arm
 docker-cross-build-observer-arm:
@@ -623,14 +585,11 @@ docker-native-build-loader:
 .PHONY: docker-native-build-flow
 docker-native-build-flow: docker-native-build-collection docker-native-build-consensus docker-native-build-execution docker-native-build-verification docker-native-build-access docker-native-build-observer docker-native-build-ghost
 
-.PHONY: docker-build-flow-with-adx
-docker-build-flow-with-adx: docker-build-collection-with-adx docker-build-consensus-with-adx docker-build-execution-with-adx docker-build-verification-with-adx docker-build-access-with-adx docker-build-observer-with-adx
+.PHONY: docker-build-flow
+docker-build-flow: docker-build-collection docker-build-consensus docker-build-execution docker-build-verification docker-build-access docker-build-observer
 
-.PHONY: docker-build-flow-without-adx
-docker-build-flow-without-adx: docker-build-collection-without-adx docker-build-consensus-without-adx docker-build-execution-without-adx docker-build-verification-without-adx docker-build-access-without-adx docker-build-observer-without-adx
-
-.PHONY: docker-build-flow-without-netgo-without-adx
-docker-build-flow-without-netgo-without-adx: docker-build-collection-without-netgo-without-adx docker-build-consensus-without-netgo-without-adx docker-build-execution-without-netgo-without-adx docker-build-verification-without-netgo-without-adx docker-build-access-without-netgo-without-adx docker-build-observer-without-netgo-without-adx
+.PHONY: docker-build-flow-without-netgo
+docker-build-flow-without-netgo: docker-build-collection-without-netgo docker-build-consensus-without-netgo docker-build-execution-without-netgo docker-build-verification-without-netgo docker-build-access-without-netgo docker-build-observer-without-netgo
 
 # in this target, images are arm64 (aarch64), are build with `netgo` and with `adx`.
 # other arm64 images can be built without `netgo` or without `adx`
@@ -643,17 +602,13 @@ docker-native-build-flow-corrupt: docker-native-build-execution-corrupt docker-n
 .PHONY: docker-native-build-benchnet
 docker-native-build-benchnet: docker-native-build-flow docker-native-build-loader
 
-.PHONY: docker-push-collection-with-adx
-docker-push-collection-with-adx:
+.PHONY: docker-push-collection
+docker-push-collection:
 	docker push "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG)"
 
-.PHONY: docker-push-collection-without-adx
-docker-push-collection-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG_NO_ADX)"
-
-.PHONY: docker-push-collection-without-netgo-without-adx
-docker-push-collection-without-netgo-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG_NO_NETGO_NO_ADX)"
+.PHONY: docker-push-collection-without-netgo
+docker-push-collection-without-netgo:
+	docker push "$(CONTAINER_REGISTRY)/collection:$(IMAGE_TAG_NO_NETGO)"
 
 .PHONY: docker-push-collection-arm 
 docker-push-collection-arm:
@@ -663,17 +618,13 @@ docker-push-collection-arm:
 docker-push-collection-latest: docker-push-collection
 	docker push "$(CONTAINER_REGISTRY)/collection:latest"
 
-.PHONY: docker-push-consensus-with-adx
-docker-push-consensus-with-adx:
+.PHONY: docker-push-consensus
+docker-push-consensus:
 	docker push "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG)"
 
-.PHONY: docker-push-consensus-without-adx
-docker-push-consensus-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG_NO_ADX)"
-
-.PHONY: docker-push-consensus-without-netgo-without-adx
-docker-push-consensus-without-netgo-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG_NO_NETGO_NO_ADX)"
+.PHONY: docker-push-consensus-without-netgo
+docker-push-consensus-without-netgo:
+	docker push "$(CONTAINER_REGISTRY)/consensus:$(IMAGE_TAG_NO_NETGO)"
 
 .PHONY: docker-push-consensus-arm 
 docker-push-consensus-arm:
@@ -683,21 +634,17 @@ docker-push-consensus-arm:
 docker-push-consensus-latest: docker-push-consensus
 	docker push "$(CONTAINER_REGISTRY)/consensus:latest"
 
-.PHONY: docker-push-execution-with-adx
-docker-push-execution-with-adx:
+.PHONY: docker-push-execution
+docker-push-execution:
 	docker push "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG)"
 
 .PHONY: docker-push-execution-corrupt
 docker-push-execution-corrupt:
 	docker push "$(CONTAINER_REGISTRY)/execution-corrupted:$(IMAGE_TAG)"
 
-.PHONY: docker-push-execution-without-adx
-docker-push-execution-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG_NO_ADX)"
-
-.PHONY: docker-push-execution-without-netgo-without-adx
-docker-push-execution-without-netgo-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG_NO_NETGO_NO_ADX)"
+.PHONY: docker-push-execution-without-netgo
+docker-push-execution-without-netgo:
+	docker push "$(CONTAINER_REGISTRY)/execution:$(IMAGE_TAG_NO_NETGO)"
 
 .PHONY: docker-push-execution-arm 
 docker-push-execution-arm:
@@ -707,21 +654,17 @@ docker-push-execution-arm:
 docker-push-execution-latest: docker-push-execution
 	docker push "$(CONTAINER_REGISTRY)/execution:latest"
 
-.PHONY: docker-push-verification-with-adx
-docker-push-verification-with-adx:
+.PHONY: docker-push-verification
+docker-push-verification:
 	docker push "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG)"
-
-.PHONY: docker-push-verification-without-adx
-docker-push-verification-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG_NO_ADX)"
 
 .PHONY: docker-push-verification-corrupt
 docker-push-verification-corrupt:
 	docker push "$(CONTAINER_REGISTRY)/verification-corrupted:$(IMAGE_TAG)"
 
-.PHONY: docker-push-verification-without-netgo-without-adx
-docker-push-verification-without-netgo-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG_NO_NETGO_NO_ADX)"
+.PHONY: docker-push-verification-without-netgo
+docker-push-verification-without-netgo:
+	docker push "$(CONTAINER_REGISTRY)/verification:$(IMAGE_TAG_NO_NETGO)"
 
 .PHONY: docker-push-verification-arm 
 docker-push-verification-arm:
@@ -731,21 +674,17 @@ docker-push-verification-arm:
 docker-push-verification-latest: docker-push-verification
 	docker push "$(CONTAINER_REGISTRY)/verification:latest"
 
-.PHONY: docker-push-access-with-adx
-docker-push-access-with-adx:
+.PHONY: docker-push-access
+docker-push-access:
 	docker push "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG)"
-
-.PHONY: docker-push-access-without-adx
-docker-push-access-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG_NO_ADX)"
 
 .PHONY: docker-push-access-corrupt
 docker-push-access-corrupt:
 	docker push "$(CONTAINER_REGISTRY)/access-corrupted:$(IMAGE_TAG)"
 
-.PHONY: docker-push-access-without-netgo-without-adx
-docker-push-access-without-netgo-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG_NO_NETGO_NO_ADX)"
+.PHONY: docker-push-access-without-netgo
+docker-push-access-without-netgo:
+	docker push "$(CONTAINER_REGISTRY)/access:$(IMAGE_TAG_NO_NETGO)"
 
 .PHONY: docker-push-access-arm 
 docker-push-access-arm:
@@ -756,17 +695,13 @@ docker-push-access-latest: docker-push-access
 	docker push "$(CONTAINER_REGISTRY)/access:latest"
 
 
-.PHONY: docker-push-observer-with-adx
-docker-push-observer-with-adx:
+.PHONY: docker-push-observer
+docker-push-observer:
 	docker push "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG)"
 
-.PHONY: docker-push-observer-without-adx
-docker-push-observer-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG_NO_ADX)"
-
-.PHONY: docker-push-observer-without-netgo-without-adx
-docker-push-observer-without-netgo-without-adx:
-	docker push "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG_NO_NETGO_NO_ADX)"
+.PHONY: docker-push-observer-without-netgo
+docker-push-observer-without-netgo:
+	docker push "$(CONTAINER_REGISTRY)/observer:$(IMAGE_TAG_NO_NETGO)"
 
 .PHONY: docker-push-observer-arm 
 docker-push-observer-arm:
@@ -792,14 +727,11 @@ docker-push-loader:
 docker-push-loader-latest: docker-push-loader
 	docker push "$(CONTAINER_REGISTRY)/loader:latest"
 
-.PHONY: docker-push-flow-with-adx
-docker-push-flow-with-adx: docker-push-collection-with-adx docker-push-consensus-with-adx docker-push-execution-with-adx docker-push-verification-with-adx docker-push-access-with-adx docker-push-observer-with-adx
+.PHONY: docker-push-flow
+docker-push-flow: docker-push-collection docker-push-consensus docker-push-execution docker-push-verification docker-push-access docker-push-observer
 
-.PHONY: docker-push-flow-without-adx
-docker-push-flow-without-adx: docker-push-collection-without-adx docker-push-consensus-without-adx docker-push-execution-without-adx docker-push-verification-without-adx docker-push-access-without-adx docker-push-observer-without-adx
-
-.PHONY: docker-push-flow-without-netgo-without-adx
-docker-push-flow-without-netgo-without-adx: docker-push-collection-without-netgo-without-adx docker-push-consensus-without-netgo-without-adx docker-push-execution-without-netgo-without-adx docker-push-verification-without-netgo-without-adx docker-push-access-without-netgo-without-adx docker-push-observer-without-netgo-without-adx
+.PHONY: docker-push-flow-without-netgo
+docker-push-flow-without-netgo: docker-push-collection-without-netgo docker-push-consensus-without-netgo docker-push-execution-without-netgo docker-push-verification-without-netgo docker-push-access-without-netgo docker-push-observer-without-netgo
 
 .PHONY: docker-push-flow-arm
 docker-push-flow-arm: docker-push-collection-arm docker-push-consensus-arm docker-push-execution-arm docker-push-verification-arm docker-push-access-arm docker-push-observer-arm

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ install-mock-generators:
     go install github.com/golang/mock/mockgen@v1.6.0;
 
 .PHONY: install-tools
-install-tools: check-go-version install-mock-generators
+install-tools: crypto_setup_gopath check-go-version install-mock-generators
 	cd ${GOPATH}; \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.2; \
 	go install github.com/uber/prototool/cmd/prototool@v1.9.0; \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ include crypto_adx_flag.mk
 noop:
 	@echo "This is a no-op target"
 
+# setup the crypto package under the GOPATH: needed to test packages importing flow-go/crypto
+.PHONY: crypto_setup_gopath
+crypto_setup_gopath:
+	bash crypto_setup.sh
+
 cmd/collection/collection:
 	CGO_CFLAGS=$(CRYPTO_FLAG) go build -o cmd/collection/collection cmd/collection/main.go
 

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -6,7 +6,7 @@
 FROM golang:1.20-bullseye AS build-setup
 
 RUN apt-get update
-RUN apt-get -y install zip apt-utils gcc-aarch64-linux-gnu
+RUN apt-get -y install zip cmake
 
 ## (2) Setup crypto dependencies
 FROM build-setup AS build-env
@@ -34,6 +34,11 @@ RUN ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 ## (3) Build the production app binary
 FROM build-env as build-production
 WORKDIR /app
+
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=secret,id=git_creds,dst=/root/.netrc \
+    make crypto_setup_gopath
 
 ARG GOARCH=amd64
 # TAGS can be overriden to modify the go build tags (e.g. build without netgo)

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -23,6 +23,11 @@ ENV GOPRIVATE=
 
 COPY . .
 
+RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=secret,id=git_creds,dst=/root/.netrc \
+    make crypto_setup_gopath
+
 # Update the git config to use SSH rather than HTTPS for clones
 RUN git config --global url.git@github.com:.insteadOf https://github.com/
 RUN mkdir ~/.ssh
@@ -34,11 +39,6 @@ RUN ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 ## (3) Build the production app binary
 FROM build-env as build-production
 WORKDIR /app
-
-RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=secret,id=git_creds,dst=/root/.netrc \
-    make crypto_setup_gopath
 
 ARG GOARCH=amd64
 # TAGS can be overriden to modify the go build tags (e.g. build without netgo)

--- a/crypto_setup.sh
+++ b/crypto_setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# crypto package 
+PKG_NAME="github.com/onflow/flow-go/crypto"
+
+# go.mod
+MOD_FILE="./go.mod"
+
+# the version of onflow/flow-go/crypto used in the project is read from the go.mod file
+if [ -f "${MOD_FILE}" ]
+then
+    # extract the imported version
+    VERSION="$(go list -f '{{.Version}}' -m ${PKG_NAME})"
+    # go get the package
+    go get "${PKG_NAME}@${VERSION}" || { echo "go get the package failed"; exit 1; }
+    # using the right version, get the package directory path
+    PKG_DIR="$(go env GOPATH)/pkg/mod/${PKG_NAME}@${VERSION}"
+else 
+   { echo "couldn't find go.mod file - make sure the script is in the project root directory"; exit 1; }
+fi
+
+# grant permissions if not existant
+if [[ ! -r ${PKG_DIR}  || ! -w ${PKG_DIR} || ! -x ${PKG_DIR} ]]; then
+   chmod -R 755 "${PKG_DIR}"
+fi
+
+# get into the package directory and set up the external dependencies
+(
+    cd "${PKG_DIR}" || { echo "cd into the GOPATH package folder failed"; exit 1; }
+    go generate
+)

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1-0.20231219201108-fbdb10b0a2da
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1-0.20231219201108-fbdb10b0a2da
 	github.com/onflow/flow-go-sdk v0.41.18
-	github.com/onflow/flow-go/crypto v0.25.0
+	github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2
 	github.com/onflow/go-bitswap v0.0.0-20230703214630-6d3db958c73d
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58

--- a/go.sum
+++ b/go.sum
@@ -1358,8 +1358,8 @@ github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJ
 github.com/onflow/flow-go-sdk v0.41.18 h1:hyT7wEvwCaxIfxF32Mv9M0jXjU1uuVurTidfdsQIJTw=
 github.com/onflow/flow-go-sdk v0.41.18/go.mod h1:Iaw7+wKET7ILH8ih27X31kVplgIItDXLVX+hfTunZh8=
 github.com/onflow/flow-go/crypto v0.21.3/go.mod h1:vI6V4CY3R6c4JKBxdcRiR/AnjBfL8OSD97bJc60cLuQ=
-github.com/onflow/flow-go/crypto v0.25.0 h1:6lmoiAQ3APCF+nV7f4f2AXL3PuDKqQiWqRJXmjrMEq4=
-github.com/onflow/flow-go/crypto v0.25.0/go.mod h1:OOb2vYcS8AOCajBClhHTJ0NKftFl1RQgTQ0+Vh4nbqk=
+github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612 h1:iJL/qhYkacWfGLwh4lWrwX2Z68/hJ7RNKXMD1OWcdSI=
+github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/onflow/flow-go v0.32.4-0.20231130134727-3c01c7f8966c
-	github.com/onflow/flow-go/crypto v0.25.0
+	github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -1333,8 +1333,8 @@ github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJ
 github.com/onflow/flow-go-sdk v0.41.18 h1:hyT7wEvwCaxIfxF32Mv9M0jXjU1uuVurTidfdsQIJTw=
 github.com/onflow/flow-go-sdk v0.41.18/go.mod h1:Iaw7+wKET7ILH8ih27X31kVplgIItDXLVX+hfTunZh8=
 github.com/onflow/flow-go/crypto v0.21.3/go.mod h1:vI6V4CY3R6c4JKBxdcRiR/AnjBfL8OSD97bJc60cLuQ=
-github.com/onflow/flow-go/crypto v0.25.0 h1:6lmoiAQ3APCF+nV7f4f2AXL3PuDKqQiWqRJXmjrMEq4=
-github.com/onflow/flow-go/crypto v0.25.0/go.mod h1:OOb2vYcS8AOCajBClhHTJ0NKftFl1RQgTQ0+Vh4nbqk=
+github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612 h1:iJL/qhYkacWfGLwh4lWrwX2Z68/hJ7RNKXMD1OWcdSI=
+github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -38,7 +38,7 @@ gen-bootstrap: clone-flow
 	cd flow-go/cmd/bootstrap && go run . finalize --root-commit 0000000000000000000000000000000000000000000000000000000000000000 --service-account-public-key-json "{\"PublicKey\":\"R7MTEDdLclRLrj2MI1hcp4ucgRTpR15PCHAWLM5nks6Y3H7+PGkfZTP2di2jbITooWO4DD1yqaBSAVK8iQ6i0A==\",\"SignAlgo\":2,\"HashAlgo\":1,\"SeqNumber\":0,\"Weight\":1000}" --config ../../../bootstrap/conf/node-config.json -o ../../../bootstrap/ --partner-dir ../../../bootstrap/partner-nodes --partner-weights ../../../bootstrap/conf/partner-stakes.json --collection-clusters 1 --epoch-counter 0 --epoch-length 30000 --epoch-staking-phase-length 20000 --epoch-dkg-phase-length 2000 --genesis-token-supply="1000000000.0" --protocol-version=0 --internal-priv-dir ../../../bootstrap/keys/private-root-information --dkg-data ../../../bootstrap/private-root-information/root-dkg-data.priv.json --root-block ../../../bootstrap/public-root-information/root-block.json --root-block-votes-dir ../../../bootstrap/public-root-information/root-block-votes/ --epoch-commit-safety-threshold=1000
 
 gen-helm-l1:
-	go run automate/cmd/level1/bootstrap.go --data bootstrap/public-root-information/root-protocol-state-snapshot.json --dockerTag $(NETWORK_ID) --dockerRegistry $(DOCKER_REGISTRY)
+	go run automate/cmd/level1/bootstrap.go --data bootstrap/public-root-information/root-protocol-state-snapshot.json --dockerTag $(DOCKER_TAG) --dockerRegistry $(DOCKER_REGISTRY)
 
 gen-helm-l2:
 	go run automate/cmd/level2/template.go --data template-data.json --template automate/templates/helm-values-all-nodes.yml --outPath="./values.yml"

--- a/integration/benchnet2/Makefile
+++ b/integration/benchnet2/Makefile
@@ -29,6 +29,7 @@ endif
 # assumes there is a checked out version of flow-go in a "flow-go" sub-folder at this level so that the bootstrap executable
 # for the checked out version will be run in the sub folder but the bootstrap folder will be created here (outside of the checked out flow-go in the sub folder)
 gen-bootstrap: clone-flow
+	cd flow-go && make crypto_setup_gopath
 	cd flow-go/cmd/bootstrap && go run . genconfig --address-format "%s%d-${NETWORK_ID}.${NAMESPACE}:3569" --access $(ACCESS) --collection $(COLLECTION) --consensus $(CONSENSUS) --execution $(EXECUTION) --verification $(VERIFICATION) --weight 100 -o ./ --config ../../../bootstrap/conf/node-config.json
 	cd flow-go/cmd/bootstrap && go run . keygen --machine-account --config ../../../bootstrap/conf/node-config.json -o ../../../bootstrap/keys
 	echo {} > ./bootstrap/conf/partner-stakes.json

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/onflow/flow-emulator v0.59.0
 	github.com/onflow/flow-go v0.32.7
 	github.com/onflow/flow-go-sdk v0.41.18
-	github.com/onflow/flow-go/crypto v0.25.0
+	github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231213135419-ae911cc351a2
 	github.com/plus3it/gorecurcopy v0.0.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1425,8 +1425,8 @@ github.com/onflow/flow-go-sdk v0.24.0/go.mod h1:IoptMLPyFXWvyd9yYA6/4EmSeeozl6nJ
 github.com/onflow/flow-go-sdk v0.41.18 h1:hyT7wEvwCaxIfxF32Mv9M0jXjU1uuVurTidfdsQIJTw=
 github.com/onflow/flow-go-sdk v0.41.18/go.mod h1:Iaw7+wKET7ILH8ih27X31kVplgIItDXLVX+hfTunZh8=
 github.com/onflow/flow-go/crypto v0.21.3/go.mod h1:vI6V4CY3R6c4JKBxdcRiR/AnjBfL8OSD97bJc60cLuQ=
-github.com/onflow/flow-go/crypto v0.25.0 h1:6lmoiAQ3APCF+nV7f4f2AXL3PuDKqQiWqRJXmjrMEq4=
-github.com/onflow/flow-go/crypto v0.25.0/go.mod h1:OOb2vYcS8AOCajBClhHTJ0NKftFl1RQgTQ0+Vh4nbqk=
+github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612 h1:iJL/qhYkacWfGLwh4lWrwX2Z68/hJ7RNKXMD1OWcdSI=
+github.com/onflow/flow-go/crypto v0.24.10-0.20240228014058-3a6273445612/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0 h1:rhUDeD27jhLwOqQKI/23008CYfnqXErrJvc4EFRP2a0=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.0/go.mod h1:YsvzYng4htDgRB9sa9jxdwoTuuhjK8WYWXTyLkIigZY=
 github.com/onflow/flow/protobuf/go/flow v0.2.2/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=


### PR DESCRIPTION
⚠️ Do not merge. 
This is only a draft to see differences against `v0.33`. 

Branch [v0.33.8-relic](https://github.com/onflow/flow-go/tree/v0.33.8-relic) was branched off tag `v0.33.8`. It downgrades the crypto version from `v0.25.0` (blst-based) to `v0.24.10-..` (relic-based) to address CPU compatibility issues with node operators running on `Intel haswell no TSX`

Note that the `v0.24.10-..` crypto version is not a tagged version. It is a commit from branch https://github.com/onflow/flow-go/tree/crypto/v0.24.9-no-build-tag which removes the need to use a Go build tag `-tags=relic`