### PR TITLE
[Cadence 1.0] Update to SDK v1.0.0-M7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240227190927-0e6ce7e3222b
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240227190927-0e6ce7e3222b
-	github.com/onflow/flow-go-sdk v1.0.0-M6
+	github.com/onflow/flow-go-sdk v1.0.0-M7
 	github.com/onflow/flow/protobuf/go/flow v0.3.7
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2502,8 +2502,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 h1:fZj39XxayIL7uvKvonNI3MtQM3wsFJ8oRl/XW/0rn7A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-M6 h1:FNITFgDhdo2H7mZY5bJPWD87k1MyJreBz87N8Xk9+xY=
-github.com/onflow/flow-go-sdk v1.0.0-M6/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
+github.com/onflow/flow-go-sdk v1.0.0-M7 h1:5EhtgpupjdhJZoHpu8AhA7++AroGL6BFpb8D0AYIUQw=
+github.com/onflow/flow-go-sdk v1.0.0-M7/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a h1:xMEtuQp4+ltfEZcw+4smv4wechSBAus4yEAtPghXZeQ=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a h1:Ark2dPAaSxSr45G5WJjB1P5H0tFtXnHcOIp+dM146yo=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240227190927-0e6ce7e3222b // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-M6 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-M7 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a // indirect
 	github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.3.7 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2485,8 +2485,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 h1:fZj39XxayIL7uvKvonNI3MtQM3wsFJ8oRl/XW/0rn7A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-M6 h1:FNITFgDhdo2H7mZY5bJPWD87k1MyJreBz87N8Xk9+xY=
-github.com/onflow/flow-go-sdk v1.0.0-M6/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
+github.com/onflow/flow-go-sdk v1.0.0-M7 h1:5EhtgpupjdhJZoHpu8AhA7++AroGL6BFpb8D0AYIUQw=
+github.com/onflow/flow-go-sdk v1.0.0-M7/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a h1:xMEtuQp4+ltfEZcw+4smv4wechSBAus4yEAtPghXZeQ=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a h1:Ark2dPAaSxSr45G5WJjB1P5H0tFtXnHcOIp+dM146yo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240227190927-0e6ce7e3222b
 	github.com/onflow/flow-emulator v1.0.0-M7.0.20240227020422-2ec59747f9be
 	github.com/onflow/flow-go v0.34.0-crescendo-preview.2.0.20240227001756-cb6311412b78
-	github.com/onflow/flow-go-sdk v1.0.0-M6
+	github.com/onflow/flow-go-sdk v1.0.0-M7
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.3.7
 	github.com/plus3it/gorecurcopy v0.0.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2563,8 +2563,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 h1:fZj39XxayIL7uvKvonNI3MtQM3wsFJ8oRl/XW/0rn7A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-M6 h1:FNITFgDhdo2H7mZY5bJPWD87k1MyJreBz87N8Xk9+xY=
-github.com/onflow/flow-go-sdk v1.0.0-M6/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
+github.com/onflow/flow-go-sdk v1.0.0-M7 h1:5EhtgpupjdhJZoHpu8AhA7++AroGL6BFpb8D0AYIUQw=
+github.com/onflow/flow-go-sdk v1.0.0-M7/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a h1:xMEtuQp4+ltfEZcw+4smv4wechSBAus4yEAtPghXZeQ=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a h1:Ark2dPAaSxSr45G5WJjB1P5H0tFtXnHcOIp+dM146yo=


### PR DESCRIPTION
## Description

Automatically update to:
- [onflow/flow-go-sdk v1.0.0-M7](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-M7)

