### PR TITLE
Add logs to merge

### DIFF
--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -163,6 +163,7 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 	return MergeRegisterChanges(
 		migrationRuntime.Snapshot.Payloads,
 		result.WriteSet,
+		flow.ConvertAddress(address),
 		m.log,
 	)
 }

--- a/cmd/util/ledger/migrations/deploy_migration.go
+++ b/cmd/util/ledger/migrations/deploy_migration.go
@@ -53,6 +53,8 @@ func NewTransactionBasedMigration(
 		return MergeRegisterChanges(
 			snapshot.Payloads,
 			executionSnapshot.WriteSet,
+			// we expect more  than one address to change here
+			flow.EmptyAddress,
 			logger,
 		)
 	}


### PR DESCRIPTION
Add extra logs to the merge function.

When doing account based migration only that one account should have changes.