### PR TITLE
[Cadence 1.0] Perform atree storage health check after migrating account

### DIFF
--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -158,7 +158,7 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 
 	err = storage.CheckHealth()
 	if err != nil {
-		return nil, fmt.Errorf("storage health check failed: %w", err)
+		m.log.Err(err).Msg("storage health check failed")
 	}
 
 	// finalize the transaction

--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -156,6 +156,11 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 		return nil, fmt.Errorf("failed to commit changes: %w", err)
 	}
 
+	err = storage.CheckHealth()
+	if err != nil {
+		return nil, fmt.Errorf("storage health check failed: %w", err)
+	}
+
 	// finalize the transaction
 	result, err := migrationRuntime.TransactionState.FinalizeMainTransaction()
 	if err != nil {


### PR DESCRIPTION
Work towards https://github.com/onflow/cadence/issues/3096

