### PR TITLE
Update to Cadence v1.0.0-M9

### DIFF
--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("a76ef8608e869025232141334d4559900709b9ef59bfaee3393cc33b69f5483e")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("38414484488a2af39303cd4d53f0bb7f3f15fc66b81f38174511fab9f0b613d6")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/accounts_test.go
+++ b/fvm/accounts_test.go
@@ -297,8 +297,7 @@ transaction {
 const getAccountKeyTransaction = `
 transaction(keyIndex: Int) {
   prepare(signer: &Account) {
-    var key :AccountKey? = signer.keys.get(keyIndex: keyIndex)
-    log(key)
+    log(signer.keys.get(keyIndex: keyIndex))
   }
 }
 `
@@ -307,8 +306,7 @@ const getMultipleAccountKeysTransaction = `
 transaction(keyIndex1: Int, keyIndex2: Int) {
   prepare(signer: &Account) {
     for keyIndex in [keyIndex1, keyIndex2] {
-      var key :AccountKey? = signer.keys.get(keyIndex: keyIndex)
-      log(key)
+      log(signer.keys.get(keyIndex: keyIndex))
     }
   }
 }
@@ -1369,7 +1367,7 @@ func TestGetAccountKey(t *testing.T) {
 					expected := fmt.Sprintf(
 						"AccountKey("+
 							"keyIndex: %d, "+
-							"publicKey: PublicKey(signatureAlgorithm: SignatureAlgorithm(rawValue: 1), publicKey: %s), "+
+							"publicKey: PublicKey(publicKey: %s, signatureAlgorithm: SignatureAlgorithm(rawValue: 1)), "+
 							"hashAlgorithm: HashAlgorithm(rawValue: 3), "+
 							"weight: 1000.00000000, "+
 							"isRevoked: false)",

--- a/go.mod
+++ b/go.mod
@@ -51,12 +51,12 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f
-	github.com/onflow/cadence v1.0.0-M8
+	github.com/onflow/cadence v1.0.0-M9
 	github.com/onflow/crypto v0.25.0
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240227190927-0e6ce7e3222b
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240227190927-0e6ce7e3222b
-	github.com/onflow/flow-go-sdk v1.0.0-M7
+	github.com/onflow/flow-go-sdk v1.0.0-M8
 	github.com/onflow/flow/protobuf/go/flow v0.3.7
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2487,8 +2487,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-M8 h1:ioQ7TyhpsIaImAC7Xn2r8kIgIBdimvyuWeKlGfRxWB8=
-github.com/onflow/cadence v1.0.0-M8/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
+github.com/onflow/cadence v1.0.0-M9 h1:hYqh6iok2X+QEyAlvoEY1k57EV7Yt8+Iz5+lGvjey3o=
+github.com/onflow/cadence v1.0.0-M9/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow v0.3.4 h1:FXUWVdYB90f/rjNcY0Owo30gL790tiYff9Pb/sycXYE=
@@ -2502,8 +2502,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 h1:fZj39XxayIL7uvKvonNI3MtQM3wsFJ8oRl/XW/0rn7A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-M7 h1:5EhtgpupjdhJZoHpu8AhA7++AroGL6BFpb8D0AYIUQw=
-github.com/onflow/flow-go-sdk v1.0.0-M7/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
+github.com/onflow/flow-go-sdk v1.0.0-M8 h1:jnWA6X29sZlMsrIjdxoEkBAJsZBazXTcQJ/wPw1ZbfU=
+github.com/onflow/flow-go-sdk v1.0.0-M8/go.mod h1:qFy2LF0DKfYsEnyEaIxD0frA/zAMc5hURbnqTrSZBjA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a h1:xMEtuQp4+ltfEZcw+4smv4wechSBAus4yEAtPghXZeQ=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a h1:Ark2dPAaSxSr45G5WJjB1P5H0tFtXnHcOIp+dM146yo=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -205,12 +205,12 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f // indirect
-	github.com/onflow/cadence v1.0.0-M8 // indirect
+	github.com/onflow/cadence v1.0.0-M9 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240227190927-0e6ce7e3222b // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240227190927-0e6ce7e3222b // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-M7 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-M8 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a // indirect
 	github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.3.7 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2472,8 +2472,8 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-M8 h1:ioQ7TyhpsIaImAC7Xn2r8kIgIBdimvyuWeKlGfRxWB8=
-github.com/onflow/cadence v1.0.0-M8/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
+github.com/onflow/cadence v1.0.0-M9 h1:hYqh6iok2X+QEyAlvoEY1k57EV7Yt8+Iz5+lGvjey3o=
+github.com/onflow/cadence v1.0.0-M9/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240227190927-0e6ce7e3222b h1:oXHQft30sElpK7G3xWB5tEizI2G+S4p64iVh0LtX4E0=
@@ -2485,8 +2485,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 h1:fZj39XxayIL7uvKvonNI3MtQM3wsFJ8oRl/XW/0rn7A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-M7 h1:5EhtgpupjdhJZoHpu8AhA7++AroGL6BFpb8D0AYIUQw=
-github.com/onflow/flow-go-sdk v1.0.0-M7/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
+github.com/onflow/flow-go-sdk v1.0.0-M8 h1:jnWA6X29sZlMsrIjdxoEkBAJsZBazXTcQJ/wPw1ZbfU=
+github.com/onflow/flow-go-sdk v1.0.0-M8/go.mod h1:qFy2LF0DKfYsEnyEaIxD0frA/zAMc5hURbnqTrSZBjA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a h1:xMEtuQp4+ltfEZcw+4smv4wechSBAus4yEAtPghXZeQ=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a h1:Ark2dPAaSxSr45G5WJjB1P5H0tFtXnHcOIp+dM146yo=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -21,13 +21,13 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-M8
+	github.com/onflow/cadence v1.0.0-M9
 	github.com/onflow/crypto v0.25.0
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240227190927-0e6ce7e3222b
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240227190927-0e6ce7e3222b
 	github.com/onflow/flow-emulator v1.0.0-M7.0.20240227020422-2ec59747f9be
 	github.com/onflow/flow-go v0.34.0-crescendo-preview.2.0.20240227001756-cb6311412b78
-	github.com/onflow/flow-go-sdk v1.0.0-M7
+	github.com/onflow/flow-go-sdk v1.0.0-M8
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.3.7
 	github.com/plus3it/gorecurcopy v0.0.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2548,8 +2548,8 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-M8 h1:ioQ7TyhpsIaImAC7Xn2r8kIgIBdimvyuWeKlGfRxWB8=
-github.com/onflow/cadence v1.0.0-M8/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
+github.com/onflow/cadence v1.0.0-M9 h1:hYqh6iok2X+QEyAlvoEY1k57EV7Yt8+Iz5+lGvjey3o=
+github.com/onflow/cadence v1.0.0-M9/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240227190927-0e6ce7e3222b h1:oXHQft30sElpK7G3xWB5tEizI2G+S4p64iVh0LtX4E0=
@@ -2563,8 +2563,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240213220156-959b70719876/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876 h1:fZj39XxayIL7uvKvonNI3MtQM3wsFJ8oRl/XW/0rn7A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240213220156-959b70719876/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-M7 h1:5EhtgpupjdhJZoHpu8AhA7++AroGL6BFpb8D0AYIUQw=
-github.com/onflow/flow-go-sdk v1.0.0-M7/go.mod h1:aXSavLzoRlz5FiMjcI7p5QhihWScGctxydzf4dv/avo=
+github.com/onflow/flow-go-sdk v1.0.0-M8 h1:jnWA6X29sZlMsrIjdxoEkBAJsZBazXTcQJ/wPw1ZbfU=
+github.com/onflow/flow-go-sdk v1.0.0-M8/go.mod h1:qFy2LF0DKfYsEnyEaIxD0frA/zAMc5hURbnqTrSZBjA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a h1:xMEtuQp4+ltfEZcw+4smv4wechSBAus4yEAtPghXZeQ=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240214230837-cd2c42e54b4a/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240214230837-cd2c42e54b4a h1:Ark2dPAaSxSr45G5WJjB1P5H0tFtXnHcOIp+dM146yo=

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "950eead8a731067405a0b56858e70af4b318d8154a2923e0001b4e239fbd0e56"
+const GenesisStateCommitmentHex = "a54aa85afc0eba964fa0f65247d47b9a87039134ab654661b96dd29a6ce3219b"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "74c54a0d99a9cbdbb835778be1d1aff419664639cf4b3667c7584840a2ea351b"
+		return "f73ec284cf6a6528999095a1c1dfd885eaacc8f1fd465f30408bafd65ac2fa72"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "abd550ebb99650c66d7a27c0a7ca08ab49fbdd5c618666f2bc026223030a12af"
+	return "5547416dac49ea41086be0681a48aae9f98a809e49ebf0d7df6eca2571216b72"
 }


### PR DESCRIPTION
## Description

Automatically update to:
- [onflow/flow-go-sdk v1.0.0-M8](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-M8)
- [onflow/cadence v1.0.0-M9](https://github.com/onflow/cadence/releases/tag/v1.0.0-M9)

Note: Hide whitespace changes to see actual API adjustments