### PR TITLE
Fix build typo

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
     # We evaluate the SSH agent to safely pass in a key for cloning dependencies
     # We explicitly use ";" rather than && as we want to safely pass if it is unavailable
     eval `ssh-agent -s` && printf "%s\n" "$(cat /run/secrets/cadence_deploy_key)" | ssh-add - ; \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} CC="${CC}" CGO_FLAGS="${CGO_FLAG}" go build --tags "${TAGS}" -ldflags "-extldflags -static \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} CC="${CC}" CGO_CFLAGS="${CGO_FLAG}" go build --tags "${TAGS}" -ldflags "-extldflags -static \
     -X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' -X  'github.com/onflow/flow-go/cmd/build.semver=${VERSION}'" \
     -o ./app ${TARGET}
 
@@ -78,7 +78,7 @@ RUN --mount=type=ssh \
     # We evaluate the SSH agent to safely pass in a key for cloning dependencies
     # We explicitly use ";" rather than && as we want to safely pass if it is unavailable
     eval `ssh-agent -s` && printf "%s\n" "$(cat /run/secrets/cadence_deploy_key)" | ssh-add - ; \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} CC="${CC}" CGO_FLAGS="${CGO_FLAG}" go build --tags "netgo" -ldflags "-extldflags -static \
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} CC="${CC}" CGO_CFLAGS="${CGO_FLAG}" go build --tags "netgo" -ldflags "-extldflags -static \
     -X 'github.com/onflow/flow-go/cmd/build.commit=${COMMIT}' -X  'github.com/onflow/flow-go/cmd/build.semver=${VERSION}'" \
     -gcflags="all=-N -l" -o ./app ${TARGET}
 

--- a/insecure/Makefile
+++ b/insecure/Makefile
@@ -12,14 +12,13 @@ else
 	RACE_FLAG :=
 endif
 
+# set `CRYPTO_FLAG` when building natively (not cross-compiling)
 include ../crypto_adx_flag.mk
-
-CGO_FLAG := CGO_CFLAGS=$(CRYPTO_FLAG)
 
 # runs all unit tests of the insecure module
 .PHONY: test
 test:
-	$(CGO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(GO_TEST_PACKAGES)
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(GO_TEST_PACKAGES)
 
 .PHONY: lint
 lint: tidy

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -10,9 +10,8 @@ else
 	RACE_FLAG :=
 endif
 
+# set `CRYPTO_FLAG` when building natively (not cross-compiling)
 include ../crypto_adx_flag.mk
-
-CGO_FLAG := CGO_CFLAGS=$(CRYPTO_FLAG)
 
 # Run the integration test suite
 .PHONY: integration-test
@@ -21,30 +20,30 @@ integration-test: access-tests ghost-tests mvp-tests execution-tests verificatio
 # Run unit tests for test utilities in this module
 .PHONY: test
 test:
-	$(CGO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(GO_TEST_PACKAGES)
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test $(if $(VERBOSE),-v,) -coverprofile=$(COVER_PROFILE) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) $(GO_TEST_PACKAGES)
 
 .PHONY: access-tests
 access-tests: access-cohort1-tests access-cohort2-tests access-cohort3-tests
 
 .PHONY: access-cohort1-tests
 access-cohort1-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/access/cohort1/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/access/cohort1/...
 
 .PHONY: access-cohort2-tests
 access-cohort2-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/access/cohort2/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/access/cohort2/...
 
 .PHONY: access-cohort3-tests
 access-cohort3-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/access/cohort3/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/access/cohort3/...
 
 .PHONY: collection-tests
 collection-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/collection/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/collection/...
 
 .PHONY: consensus-tests
 consensus-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/consensus/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/consensus/...
 
 .PHONY: epochs-tests
 epochs-tests: epochs-cohort1-tests epochs-cohort2-tests
@@ -52,48 +51,48 @@ epochs-tests: epochs-cohort1-tests epochs-cohort2-tests
 .PHONY: epochs-cohort1-tests
 epochs-cohort1-tests:
 	# Use a higher timeout of 20m for the suite of tests which span full epochs
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -timeout 20m ./tests/epochs/cohort1/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -timeout 20m ./tests/epochs/cohort1/...
 
 .PHONY: epochs-cohort2-tests
 epochs-cohort2-tests:
 	# Use a higher timeout of 20m for the suite of tests which span full epochs
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -timeout 20m ./tests/epochs/cohort2/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) -timeout 20m ./tests/epochs/cohort2/...
 
 .PHONY: ghost-tests
 ghost-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/ghost/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/ghost/...
 
 .PHONY: mvp-tests
 mvp-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/mvp/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/mvp/...
 
 .PHONY: execution-tests
 execution-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/execution/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/execution/...
 
 .PHONY: verification-tests
 verification-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/verification/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/verification/...
 
 # upgrades-tests tests need to be run sequentially (-p 1) due to interference between different Docker networks when tests are run in parallel
 .PHONY: upgrades-tests
 upgrades-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/upgrades/... -p 1
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/upgrades/... -p 1
 
 .PHONY: network-tests
 network-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/network/...
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/network/...
 
 # BFT tests need to be run sequentially (-p 1) due to interference between different Docker networks when tests are run in parallel
 .PHONY: bft-framework-tests
 bft-framework-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/bft/framework/... -p 1
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/bft/framework/... -p 1
 .PHONY: bft-protocol-tests
 bft-protocol-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/bft/protocol/... -p 1
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/bft/protocol/... -p 1
 .PHONY: bft-gossipsub-tests
 bft-gossipsub-tests:
-	$(CGO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/bft/gossipsub/... -p 1
+	CGO_CFLAGS=$(CRYPTO_FLAG) go test -failfast $(if $(VERBOSE),-v,) $(RACE_FLAG) $(if $(JSON_OUTPUT),-json,) $(if $(NUM_RUNS),-count $(NUM_RUNS),) ./tests/bft/gossipsub/... -p 1
 
 .PHONY: bft-tests
 bft-tests: bft-framework-tests bft-protocol-tests bft-gossipsub-tests

--- a/integration/benchmark/cmd/manual/Dockerfile
+++ b/integration/benchmark/cmd/manual/Dockerfile
@@ -39,7 +39,7 @@ RUN --mount=type=cache,sharing=locked,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=ssh \
     cd integration && \
-    CGO_ENABLED=1 CGO_FLAGS="${CGO_FLAG}" go build -ldflags "-extldflags -static" -o ./app ./${TARGET}
+    CGO_ENABLED=1 CGO_CFLAGS="${CGO_FLAG}" go build -ldflags "-extldflags -static" -o ./app ./${TARGET}
 
 RUN mv /app/integration/app /app/app
 


### PR DESCRIPTION
Fix typo for a CGO flag when building for non-adx CPUs. 

Side change:
Update `Makefile` in test modules to match the main repo Makefile. This has no functional impact but keeps the code base consistent