### PR TITLE
[Access] Handle system transaction in local result mode

### DIFF
--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -164,6 +164,7 @@ func New(params Params) (*Backend, error) {
 		backendTransactions: backendTransactions{
 			TransactionsLocalDataProvider: TransactionsLocalDataProvider{
 				state:          params.State,
+				chainID:        params.ChainID,
 				collections:    params.Collections,
 				blocks:         params.Blocks,
 				eventsIndex:    params.EventsIndex,

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/flow-go/engine/access/rpc/connection"
 	connectionmock "github.com/onflow/flow-go/engine/access/rpc/connection/mock"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
@@ -72,7 +73,8 @@ type Suite struct {
 	connectionFactory *connectionmock.ConnectionFactory
 	communicator      *backendmock.Communicator
 
-	chainID flow.ChainID
+	chainID  flow.ChainID
+	systemTx *flow.TransactionBody
 }
 
 func TestHandler(t *testing.T) {
@@ -107,6 +109,10 @@ func (suite *Suite) SetupTest() {
 	suite.connectionFactory = connectionmock.NewConnectionFactory(suite.T())
 
 	suite.communicator = new(backendmock.Communicator)
+
+	var err error
+	suite.systemTx, err = blueprints.SystemChunkTransaction(flow.Testnet.Chain())
+	suite.Require().NoError(err)
 }
 
 func (suite *Suite) TestPing() {

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -18,7 +18,6 @@ import (
 	"github.com/onflow/flow-go/engine/access/rpc/connection"
 	"github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
-	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/irrecoverable"
@@ -43,6 +42,9 @@ type backendTransactions struct {
 	txResultCache        *lru.Cache[flow.Identifier, *access.TransactionResult]
 	txErrorMessagesCache *lru.Cache[flow.Identifier, string] // cache for transactions error messages, indexed by hash(block_id, tx_id).
 	txResultQueryMode    IndexQueryMode
+
+	systemTxID flow.Identifier
+	systemTx   *flow.TransactionBody
 }
 
 var _ TransactionErrorMessage = (*backendTransactions)(nil)
@@ -214,12 +216,7 @@ func (b *backendTransactions) GetTransactionsByBlockID(
 		transactions = append(transactions, collection.Transactions...)
 	}
 
-	systemTx, err := blueprints.SystemChunkTransaction(b.chainID.Chain())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get system chunk transaction: %v", err)
-	}
-
-	transactions = append(transactions, systemTx)
+	transactions = append(transactions, b.systemTx)
 
 	return transactions, nil
 }
@@ -490,10 +487,6 @@ func (b *backendTransactions) getTransactionResultsByBlockIDFromExecutionNode(
 			return nil, status.Errorf(codes.Internal, "number of transaction results returned by execution node is more than the number of transactions  in the block")
 		}
 
-		systemTx, err := blueprints.SystemChunkTransaction(b.chainID.Chain())
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "could not get system chunk transaction: %v", err)
-		}
 		systemTxResult := resp.TransactionResults[len(resp.TransactionResults)-1]
 		systemTxStatus, err := b.deriveTransactionStatus(blockID, block.Header.Height, true)
 		if err != nil {
@@ -514,7 +507,7 @@ func (b *backendTransactions) getTransactionResultsByBlockIDFromExecutionNode(
 			Events:        events,
 			ErrorMessage:  systemTxResult.GetErrorMessage(),
 			BlockID:       blockID,
-			TransactionID: systemTx.ID(),
+			TransactionID: b.systemTxID,
 			BlockHeight:   block.Header.Height,
 		})
 	}
@@ -606,12 +599,7 @@ func (b *backendTransactions) getTransactionResultByIndexFromExecutionNode(
 
 // GetSystemTransaction returns system transaction
 func (b *backendTransactions) GetSystemTransaction(ctx context.Context, _ flow.Identifier) (*flow.TransactionBody, error) {
-	systemTx, err := blueprints.SystemChunkTransaction(b.chainID.Chain())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get system chunk transaction: %v", err)
-	}
-
-	return systemTx, nil
+	return b.systemTx, nil
 }
 
 // GetSystemTransactionResult returns system transaction result
@@ -637,11 +625,6 @@ func (b *backendTransactions) GetSystemTransactionResult(ctx context.Context, bl
 		return nil, rpc.ConvertError(err, "failed to retrieve result from execution node", codes.Internal)
 	}
 
-	systemTx, err := blueprints.SystemChunkTransaction(b.chainID.Chain())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get system chunk transaction: %v", err)
-	}
-
 	systemTxResult := resp.TransactionResults[len(resp.TransactionResults)-1]
 	systemTxStatus, err := b.deriveTransactionStatus(blockID, block.Header.Height, true)
 	if err != nil {
@@ -659,7 +642,7 @@ func (b *backendTransactions) GetSystemTransactionResult(ctx context.Context, bl
 		Events:        events,
 		ErrorMessage:  systemTxResult.GetErrorMessage(),
 		BlockID:       blockID,
-		TransactionID: systemTx.ID(),
+		TransactionID: b.systemTxID,
 		BlockHeight:   block.Header.Height,
 	}, nil
 }

--- a/engine/access/rpc/backend/transactions_local_data_provider.go
+++ b/engine/access/rpc/backend/transactions_local_data_provider.go
@@ -13,7 +13,6 @@ import (
 	"github.com/onflow/flow-go/access"
 	"github.com/onflow/flow-go/engine/common/rpc"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
-	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/state"
@@ -52,7 +51,7 @@ type TransactionsLocalDataProvider struct {
 	eventsIndex     *EventsIndex
 	txResultsIndex  *TransactionResultsIndex
 	txErrorMessages TransactionErrorMessage
-	chainID         flow.ChainID
+	systemTxID      flow.Identifier
 }
 
 // GetTransactionResultFromStorage retrieves a transaction result from storage by block ID and transaction ID.
@@ -158,6 +157,11 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultsByBlockIDFromStorag
 	// cache the tx to collectionID mapping to avoid repeated lookups
 	txToCollectionID, err := t.buildTxIDToCollectionIDMapping(block)
 	if err != nil {
+		// this indicates that one or more of the collections for the block are not indexed. Since
+		// lookups are gated on the indexer signaling it has finished processing all data for the
+		// block, all data must be available in storage, otherwise there is an inconsistency in the
+		// state.
+		irrecoverable.Throw(ctx, fmt.Errorf("inconsistent index state: %w", err))
 		return nil, status.Errorf(codes.Internal, "failed to map tx to collection ID: %v", err)
 	}
 
@@ -398,23 +402,21 @@ func (t *TransactionsLocalDataProvider) lookupCollectionIDInBlock(
 }
 
 // buildTxIDToCollectionIDMapping returns a map of transaction ID to collection ID based on the provided block.
+// No errors expected during normal operations.
 func (t *TransactionsLocalDataProvider) buildTxIDToCollectionIDMapping(block *flow.Block) (map[flow.Identifier]flow.Identifier, error) {
 	txToCollectionID := make(map[flow.Identifier]flow.Identifier)
 	for _, guarantee := range block.Payload.Guarantees {
 		collection, err := t.collections.LightByID(guarantee.ID())
 		if err != nil {
-			return nil, err
+			// if the tx result is in storage, the collection must be too.
+			return nil, fmt.Errorf("failed to get collection %s in indexed block: %w", guarantee.ID(), err)
 		}
 		for _, txID := range collection.Transactions {
 			txToCollectionID[txID] = guarantee.ID()
 		}
 	}
 
-	systemTx, err := blueprints.SystemChunkTransaction(t.chainID.Chain())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get system chunk transaction: %v", err)
-	}
-	txToCollectionID[systemTx.ID()] = flow.ZeroID
+	txToCollectionID[t.systemTxID] = flow.ZeroID
 
 	return txToCollectionID, nil
 }

--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -439,6 +439,7 @@ func prepareAccessService(container testnet.ContainerConfig, i int, n int) Servi
 		"--execution-state-dir=/data/execution-state",
 		"--script-execution-mode=execution-nodes-only",
 		"--event-query-mode=execution-nodes-only",
+		"--tx-result-query-mode=execution-nodes-only",
 	)
 
 	service.AddExposedPorts(


### PR DESCRIPTION
Closes: #5531 

Access nodes support returning tx results from local data. This was not working as expected for the `GetTransactionResultsByBlockID`. The request would fail to lookup the collection for the system tx and return a `NotFound` error.

This PR adds handling for the system tx, and also caches the txID to collectionID lookups since there are typically more than 1 tx per collection.