### PR TITLE
[Cadence 1.0] Improve migrations

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -42,6 +42,7 @@ var (
 	flagInputPayloadFileName          string
 	flagOutputPayloadFileName         string
 	flagOutputPayloadByAddresses      string
+	flagMaxAccountSize                uint64
 )
 
 var Cmd = &cobra.Command{
@@ -132,6 +133,9 @@ func init() {
 		"",
 		"extract payloads of addresses (comma separated hex-encoded addresses) to file specified by output-payload-filename",
 	)
+
+	Cmd.Flags().Uint64Var(&flagMaxAccountSize, "max-account-size", 0,
+		"max account size")
 }
 
 func run(*cobra.Command, []string) {
@@ -346,6 +350,7 @@ func run(*cobra.Command, []string) {
 			exportedAddresses,
 			flagSortPayloads,
 			flagPrune,
+			flagMaxAccountSize,
 		)
 	} else {
 		err = extractExecutionState(
@@ -365,6 +370,7 @@ func run(*cobra.Command, []string) {
 			exportedAddresses,
 			flagSortPayloads,
 			flagPrune,
+			flagMaxAccountSize,
 		)
 	}
 

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -15,7 +15,6 @@ import (
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/ledger"
-	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/ledger/common/hash"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
 	"github.com/onflow/flow-go/ledger/complete"
@@ -48,6 +47,7 @@ func extractExecutionState(
 	exportPayloadsByAddresses []common.Address,
 	sortPayloads bool,
 	prune bool,
+	maxAccountSize uint64,
 ) error {
 
 	log.Info().Msg("init WAL")
@@ -119,6 +119,7 @@ func extractExecutionState(
 		burnerContractChange,
 		stagedContracts,
 		prune,
+		maxAccountSize,
 	)
 
 	newState := ledger.State(targetHash)
@@ -220,20 +221,6 @@ func writeStatusFile(fileName string, e error) error {
 	return err
 }
 
-func ByteCountIEC(b int64) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB",
-		float64(b)/float64(div), "KMGTPE"[exp])
-}
-
 func extractExecutionStateFromPayloads(
 	log zerolog.Logger,
 	dir string,
@@ -251,6 +238,7 @@ func extractExecutionStateFromPayloads(
 	exportPayloadsByAddresses []common.Address,
 	sortPayloads bool,
 	prune bool,
+	maxAccountSize uint64,
 ) error {
 
 	inputPayloadsFromPartialState, payloads, err := util.ReadPayloadFile(log, inputPayloadFile)
@@ -259,36 +247,6 @@ func extractExecutionStateFromPayloads(
 	}
 
 	log.Info().Msgf("read %d payloads", len(payloads))
-
-	if log.Debug().Enabled() {
-
-		type accountInfo struct {
-			count int
-			size  uint64
-		}
-		payloadCountByAddress := make(map[string]accountInfo)
-
-		for _, payload := range payloads {
-			registerID, payloadValue, err := convert.PayloadToRegister(payload)
-			if err != nil {
-				return fmt.Errorf("cannot convert payload to register: %w", err)
-			}
-			owner := registerID.Owner
-			accountInfo := payloadCountByAddress[owner]
-			accountInfo.count++
-			accountInfo.size += uint64(len(payloadValue))
-			payloadCountByAddress[owner] = accountInfo
-		}
-
-		for address, info := range payloadCountByAddress {
-			log.Debug().Msgf(
-				"address %x has %d payloads and a total size of %s",
-				address,
-				info.count,
-				ByteCountIEC(int64(info.size)),
-			)
-		}
-	}
 
 	migrations := newMigrations(
 		log,
@@ -302,6 +260,7 @@ func extractExecutionStateFromPayloads(
 		burnerContractChange,
 		stagedContracts,
 		prune,
+		maxAccountSize,
 	)
 
 	payloads, err = migratePayloads(log, payloads, migrations)
@@ -458,6 +417,7 @@ func newMigrations(
 	burnerContractChange migrators.BurnerContractChange,
 	stagedContracts []migrators.StagedContract,
 	prune bool,
+	maxAccountSize uint64,
 ) []ledger.Migration {
 	if !runMigrations {
 		return nil
@@ -478,6 +438,7 @@ func newMigrations(
 		burnerContractChange,
 		stagedContracts,
 		prune,
+		maxAccountSize,
 	)
 
 	migrations := make([]ledger.Migration, 0, len(namedMigrations))

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -393,7 +393,7 @@ func migratePayloads(logger zerolog.Logger, payloads []*ledger.Payload, migratio
 
 	// migrate payloads
 	for i, migrate := range migrations {
-		logger.Info().Msgf("migration %d/%d is underway", i, len(migrations))
+		logger.Info().Msgf("migration %d/%d is underway", i+1, len(migrations))
 
 		start := time.Now()
 		payloads, err = migrate(payloads)

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -83,6 +83,7 @@ func TestExtractExecutionState(t *testing.T) {
 				nil,
 				false,
 				false,
+				0,
 			)
 			require.Error(t, err)
 		})

--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -317,14 +317,6 @@ func MigrateGroupConcurrently(
 
 var knownProblematicAccounts = map[common.Address]string{}
 
-func mustHexToAddress(hex string) common.Address {
-	address, err := common.HexToAddress(hex)
-	if err != nil {
-		panic(err)
-	}
-	return address
-}
-
 type jobMigrateAccountGroup struct {
 	Address  common.Address
 	Payloads []*ledger.Payload

--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -315,19 +315,7 @@ func MigrateGroupConcurrently(
 	return migrated, nil
 }
 
-var knownProblematicAccounts = map[common.Address]string{
-	// Testnet accounts with broken contracts
-	mustHexToAddress("434a1f199a7ae3ba"): "Broken contract FanTopPermission",
-	mustHexToAddress("454c9991c2b8d947"): "Broken contract Test",
-	mustHexToAddress("48602d8056ff9d93"): "Broken contract FanTopPermission",
-	mustHexToAddress("5d63c34d7f05e5a4"): "Broken contract FanTopPermission",
-	mustHexToAddress("5e3448b3cffb97f2"): "Broken contract FanTopPermission",
-	mustHexToAddress("7d8c7e050c694eaa"): "Broken contract Test",
-	mustHexToAddress("ba53f16ede01972d"): "Broken contract FanTopPermission",
-	mustHexToAddress("c843c1f5a4805c3a"): "Broken contract FanTopPermission",
-	mustHexToAddress("48d3be92e6e4a973"): "Broken contract FanTopPermission",
-	// Mainnet account
-}
+var knownProblematicAccounts = map[common.Address]string{}
 
 func mustHexToAddress(hex string) common.Address {
 	address, err := common.HexToAddress(hex)

--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -127,7 +127,7 @@ func withMigrations(
 				Type("migration", migrator).
 				Msg("closing migration")
 			if cerr := migrator.Close(); cerr != nil {
-				log.Error().Err(cerr).Msg("error closing migration")
+				log.Err(cerr).Msg("error closing migration")
 				if err == nil {
 					// only set the error if it's not already set
 					// so that we don't overwrite the original error

--- a/cmd/util/ledger/migrations/account_size_filter_migration.go
+++ b/cmd/util/ledger/migrations/account_size_filter_migration.go
@@ -1,0 +1,99 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/convert"
+)
+
+func NewAccountSizeFilterMigration(
+	maxAccountSize uint64,
+	exceptions map[string]struct{},
+	log zerolog.Logger,
+) ledger.Migration {
+
+	if maxAccountSize == 0 {
+		return nil
+	}
+
+	return func(payloads []*ledger.Payload) ([]*ledger.Payload, error) {
+
+		type accountInfo struct {
+			count int
+			size  uint64
+		}
+		payloadCountByAddress := make(map[string]accountInfo)
+
+		for _, payload := range payloads {
+			registerID, payloadValue, err := convert.PayloadToRegister(payload)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert payload to register: %w", err)
+			}
+
+			owner := registerID.Owner
+			accountInfo := payloadCountByAddress[owner]
+			accountInfo.count++
+			accountInfo.size += uint64(len(payloadValue))
+			payloadCountByAddress[owner] = accountInfo
+		}
+
+		if log.Debug().Enabled() {
+			for address, info := range payloadCountByAddress {
+				log.Debug().Msgf(
+					"address %x has %d payloads and a total size of %s",
+					address,
+					info.count,
+					ByteCountIEC(int64(info.size)),
+				)
+
+				if _, ok := exceptions[address]; !ok && info.size > maxAccountSize {
+					log.Warn().Msgf(
+						"dropping payloads of account %x. size of payloads %s exceeds max size %s",
+						address,
+						ByteCountIEC(int64(info.size)),
+						ByteCountIEC(int64(maxAccountSize)),
+					)
+				}
+			}
+		}
+
+		filteredPayloads := make([]*ledger.Payload, 0, int(0.8*float32(len(payloads))))
+
+		for _, payload := range payloads {
+			registerID, _, err := convert.PayloadToRegister(payload)
+			if err != nil {
+				return nil, fmt.Errorf("cannot convert payload to register: %w", err)
+			}
+
+			owner := registerID.Owner
+
+			if _, ok := exceptions[owner]; !ok {
+				info := payloadCountByAddress[owner]
+				if info.size > maxAccountSize {
+					continue
+				}
+			}
+
+			filteredPayloads = append(filteredPayloads, payload)
+		}
+
+		return filteredPayloads, nil
+	}
+}
+
+func ByteCountIEC(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB",
+		float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	_ "embed"
+	"fmt"
 
 	"github.com/onflow/cadence/migrations/capcons"
 	"github.com/onflow/cadence/migrations/statictypes"
@@ -18,10 +19,15 @@ import (
 func NewInterfaceTypeConversionRules(chainID flow.ChainID) StaticTypeMigrationRules {
 	systemContracts := systemcontracts.SystemContractsForChain(chainID)
 
-	oldFungibleTokenResolverType, newFungibleTokenResolverType := fungibleTokenResolverRule(systemContracts)
+	oldFungibleTokenResolverType, newFungibleTokenResolverType :=
+		newFungibleTokenMetadataViewsToViewResolverRule(systemContracts, "Resolver")
+
+	oldFungibleTokenResolverCollectionType, newFungibleTokenResolverCollectionType :=
+		newFungibleTokenMetadataViewsToViewResolverRule(systemContracts, "ResolverCollection")
 
 	return StaticTypeMigrationRules{
-		oldFungibleTokenResolverType.ID(): newFungibleTokenResolverType,
+		oldFungibleTokenResolverType.ID():           newFungibleTokenResolverType,
+		oldFungibleTokenResolverCollectionType.ID(): newFungibleTokenResolverCollectionType,
 	}
 }
 
@@ -119,8 +125,9 @@ func fungibleTokenVaultRule(
 	return oldType, newType
 }
 
-func fungibleTokenResolverRule(
+func newFungibleTokenMetadataViewsToViewResolverRule(
 	systemContracts *systemcontracts.SystemContracts,
+	typeName string,
 ) (
 	*interpreter.InterfaceStaticType,
 	*interpreter.InterfaceStaticType,
@@ -138,8 +145,8 @@ func fungibleTokenResolverRule(
 		Name:    newContract.Name,
 	}
 
-	oldQualifiedIdentifier := oldContract.Name + ".Resolver"
-	newQualifiedIdentifier := newContract.Name + ".Resolver"
+	oldQualifiedIdentifier := fmt.Sprintf("%s.%s", oldContract.Name, typeName)
+	newQualifiedIdentifier := fmt.Sprintf("%s.%s", newContract.Name, typeName)
 
 	oldType := &interpreter.InterfaceStaticType{
 		Location:            oldLocation,

--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -216,7 +216,7 @@ func checkPayloadsOwnership(payloads []*ledger.Payload, address common.Address, 
 func checkPayloadOwnership(payload *ledger.Payload, address common.Address, log zerolog.Logger) {
 	registerID, _, err := convert.PayloadToRegister(payload)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to convert payload to register")
+		log.Err(err).Msg("failed to convert payload to register")
 		return
 	}
 
@@ -225,7 +225,7 @@ func checkPayloadOwnership(payload *ledger.Payload, address common.Address, log 
 	if len(owner) > 0 {
 		payloadAddress, err := common.BytesToAddress([]byte(owner))
 		if err != nil {
-			log.Error().Err(err).Msgf("failed to convert register owner to address: %x", owner)
+			log.Err(err).Msgf("failed to convert register owner to address: %x", owner)
 			return
 		}
 

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -88,6 +88,7 @@ func TestCadenceValuesMigration(t *testing.T) {
 		burnerContractChange,
 		stagedContracts,
 		false,
+		0,
 	)
 
 	for _, migration := range migrations {
@@ -725,6 +726,7 @@ func TestBootstrappedStateMigration(t *testing.T) {
 		burnerContractChange,
 		nil,
 		false,
+		0,
 	)
 
 	for _, migration := range migrations {
@@ -852,6 +854,7 @@ func TestProgramParsingError(t *testing.T) {
 		burnerContractChange,
 		nil,
 		false,
+		0,
 	)
 
 	for _, migration := range migrations {
@@ -997,6 +1000,7 @@ func TestCoreContractUsage(t *testing.T) {
 		burnerContractChange,
 		nil,
 		false,
+		0,
 	)
 
 	for _, migration := range migrations {

--- a/cmd/util/ledger/migrations/contracts.go
+++ b/cmd/util/ledger/migrations/contracts.go
@@ -1,0 +1,53 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/convert"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// NewContractsExtractionMigration returns a migration that extracts the code for contracts from the payloads.
+// The given contracts map must be allocated, and gets populated with the code for the contracts found in the payloads.
+func NewContractsExtractionMigration(
+	contracts map[common.AddressLocation][]byte,
+	log zerolog.Logger,
+) ledger.Migration {
+	return func(payloads []*ledger.Payload) ([]*ledger.Payload, error) {
+
+		log.Info().Msg("extracting contracts from payloads ...")
+
+		for _, payload := range payloads {
+			registerID, registerValue, err := convert.PayloadToRegister(payload)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert payload to register: %w", err)
+			}
+
+			contractName := flow.RegisterIDContractName(registerID)
+			if contractName == "" {
+				continue
+			}
+
+			address, err := common.BytesToAddress([]byte(registerID.Owner))
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert register owner to address: %w", err)
+			}
+
+			addressLocation := common.AddressLocation{
+				Address: address,
+				Name:    contractName,
+			}
+
+			contracts[addressLocation] = registerValue
+		}
+
+		log.Info().Msgf("extracted %d contracts from payloads", len(contracts))
+
+		// Return the payloads as-is
+		return payloads, nil
+	}
+}

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -244,7 +244,7 @@ func (m *StagedContractsMigration) MigrateAccount(
 		}
 
 		if err != nil {
-			m.log.Error().Err(err).
+			m.log.Err(err).
 				Msgf(
 					"failed to update contract %s in account %s",
 					name,

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -377,7 +377,7 @@ func (l *Ledger) MigrateAt(
 
 		// migrate payloads
 		for i, migrate := range migrations {
-			l.logger.Info().Msgf("migration %d/%d is underway", i, len(migrations))
+			l.logger.Info().Msgf("migration %d/%d is underway", i+1, len(migrations))
 
 			start := time.Now()
 			payloads, err = migrate(payloads)
@@ -426,9 +426,9 @@ func (l *Ledger) MigrateAt(
 		}
 	}
 
-	statecommitment := ledger.State(newTrie.RootHash())
+	stateCommitment := ledger.State(newTrie.RootHash())
 
-	l.logger.Info().Msgf("successfully built new trie. NEW ROOT STATECOMMIEMENT: %v", statecommitment.String())
+	l.logger.Info().Msgf("successfully built new trie. NEW ROOT STATECOMMIEMENT: %v", stateCommitment.String())
 
 	return newTrie, nil
 }


### PR DESCRIPTION
Depends on #5539  
Work towards #3162

- Remove "known problematic accounts"
- Improve logging
- Test that migrated values may refer to types of core contracts
- Optimize contract lookup: Instead of gathering all contracts when migrating each account, gather all contracts once, after updating/deploying contracts and before running the value migrations
- Add migration to filter accounts by max size