### PR TITLE
[Admin] Add support for CPU profiles via admin server

### DIFF
--- a/admin/command_runner.go
+++ b/admin/command_runner.go
@@ -239,6 +239,7 @@ func (r *CommandRunner) runAdminServer(ctx irrecoverable.SignalerContext) error 
 	for _, name := range []string{"allocs", "block", "goroutine", "heap", "mutex", "threadcreate"} {
 		mux.HandleFunc(fmt.Sprintf("/debug/pprof/%s", name), pprof.Handler(name).ServeHTTP)
 	}
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	httpServer := &http.Server{


### PR DESCRIPTION
Add CPU profile support to the admin server. This can be used generate on-demand profiles.