### PR TITLE
Fix import resolving during staged contract updates

### DIFF
--- a/cmd/util/ledger/migrations/test-data/cadence_values_migration/test_contract_upgraded.cdc
+++ b/cmd/util/ledger/migrations/test-data/cadence_values_migration/test_contract_upgraded.cdc
@@ -1,3 +1,6 @@
+// Unused import. But keep it here for testing the import resolving.
+import NonFungibleToken from 0xf8d6e0586b0a20c7
+
 access(all) contract Test {
 
 	access(all) struct interface Foo {}


### PR DESCRIPTION
Fixes part of https://github.com/onflow/cadence/issues/3098#issuecomment-1998065770

The `elaborations` and the  `ContractAdditionHandler` used for the contract update validator needs to be initialized using **all payloads**, not just with the payloads of the migrating account.