### PR TITLE
[Access] Use local transaction result data in Access API - v0.33

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -190,6 +190,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 				},
 				ScriptExecutionMode: backend.IndexQueryModeExecutionNodesOnly.String(), // default to ENs only for now
 				EventQueryMode:      backend.IndexQueryModeExecutionNodesOnly.String(), // default to ENs only for now
+				TxResultQueryMode:   backend.IndexQueryModeExecutionNodesOnly.String(), // default to ENs only for now
 			},
 			RestConfig: rest.Config{
 				ListenAddress: "",
@@ -287,6 +288,7 @@ type FlowAccessNodeBuilder struct {
 	ScriptExecutor             *backend.ScriptExecutor
 	RegistersAsyncStore        *execution.RegistersAsyncStore
 	EventsIndex                *backend.EventsIndex
+	TxResultsIndex             *backend.TransactionResultsIndex
 	IndexerDependencies        *cmd.DependencyList
 
 	// The sync engine participants provider is the libp2p peer store for the access node
@@ -855,6 +857,11 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					return nil, err
 				}
 
+				err = builder.TxResultsIndex.Initialize(builder.ExecutionIndexer)
+				if err != nil {
+					return nil, err
+				}
+
 				err = builder.RegistersAsyncStore.Initialize(registers)
 				if err != nil {
 					return nil, err
@@ -950,7 +957,6 @@ func FlowAccessNode(nodeBuilder *cmd.FlowNodeBuilder) *FlowAccessNodeBuilder {
 }
 
 func (builder *FlowAccessNodeBuilder) ParseFlags() error {
-
 	builder.BaseFlags()
 
 	builder.extraFlags()
@@ -1156,6 +1162,11 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"event-query-mode",
 			defaultConfig.rpcConf.BackendConfig.EventQueryMode,
 			"mode to use when querying events. one of [local-only, execution-nodes-only(default), failover]")
+
+		flags.StringVar(&builder.rpcConf.BackendConfig.TxResultQueryMode,
+			"tx-result-query-mode",
+			defaultConfig.rpcConf.BackendConfig.TxResultQueryMode,
+			"mode to use when querying transaction results. one of [local-only, execution-nodes-only(default), failover]")
 
 		// Script Execution
 		flags.StringVar(&builder.rpcConf.BackendConfig.ScriptExecutionMode,
@@ -1524,6 +1535,10 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			builder.EventsIndex = backend.NewEventsIndex(builder.Storage.Events)
 			return nil
 		}).
+		Module("transaction result index", func(node *cmd.NodeConfig) error {
+			builder.TxResultsIndex = backend.NewTransactionResultsIndex(builder.Storage.LightTransactionResults)
+			return nil
+		}).
 		Component("RPC engine", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			config := builder.rpcConf
 			backendConfig := config.BackendConfig
@@ -1563,10 +1578,18 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 
 			eventQueryMode, err := backend.ParseIndexQueryMode(config.BackendConfig.EventQueryMode)
 			if err != nil {
-				return nil, fmt.Errorf("could not parse script execution mode: %w", err)
+				return nil, fmt.Errorf("could not parse event query mode: %w", err)
 			}
 			if eventQueryMode == backend.IndexQueryModeCompare {
 				return nil, fmt.Errorf("event query mode 'compare' is not supported")
+			}
+
+			txResultQueryMode, err := backend.ParseIndexQueryMode(config.BackendConfig.TxResultQueryMode)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse transaction result query mode: %w", err)
+			}
+			if txResultQueryMode == backend.IndexQueryModeCompare {
+				return nil, fmt.Errorf("transaction result query mode 'compare' is not supported")
 			}
 
 			nodeBackend, err := backend.New(backend.Params{
@@ -1595,6 +1618,8 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				ScriptExecutionMode:       scriptExecMode,
 				EventQueryMode:            eventQueryMode,
 				EventsIndex:               builder.EventsIndex,
+				TxResultQueryMode:         txResultQueryMode,
+				TxResultsIndex:            builder.TxResultsIndex,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("could not initialize backend: %w", err)
@@ -1725,7 +1750,6 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			builder.nodeInfoFile,
 			node.PingService,
 		)
-
 		if err != nil {
 			return nil, fmt.Errorf("could not create ping engine: %w", err)
 		}
@@ -1827,7 +1851,8 @@ func (builder *FlowAccessNodeBuilder) enqueuePublicNetworkInit() {
 // - The libp2p node instance for the public network.
 // - Any error encountered during initialization. Any error should be considered fatal.
 func (builder *FlowAccessNodeBuilder) initPublicLibp2pNode(networkKey crypto.PrivateKey, bindAddress string, networkMetrics module.LibP2PMetrics) (p2p.LibP2PNode,
-	error) {
+	error,
+) {
 	connManager, err := connection.NewConnManager(builder.Logger, networkMetrics, &builder.FlowConfig.NetworkConfig.ConnectionManager)
 	if err != nil {
 		return nil, fmt.Errorf("could not create connection manager: %w", err)
@@ -1864,7 +1889,6 @@ func (builder *FlowAccessNodeBuilder) initPublicLibp2pNode(networkKey crypto.Pri
 			return dht.NewDHT(ctx, h, protocols.FlowPublicDHTProtocolID(builder.SporkID), builder.Logger, networkMetrics, dht.AsServer())
 		}).
 		Build()
-
 	if err != nil {
 		return nil, fmt.Errorf("could not build libp2p node for staked access node: %w", err)
 	}

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -655,6 +655,7 @@ func (suite *Suite) TestGetSealedTransaction() {
 			SnapshotHistoryLimit:      backend.DefaultSnapshotHistoryLimit,
 			Communicator:              backend.NewNodeCommunicator(false),
 			TxErrorMessagesCacheSize:  1000,
+			TxResultQueryMode:         backend.IndexQueryModeExecutionNodesOnly,
 		})
 		require.NoError(suite.T(), err)
 
@@ -793,6 +794,7 @@ func (suite *Suite) TestGetTransactionResult() {
 			SnapshotHistoryLimit:      backend.DefaultSnapshotHistoryLimit,
 			Communicator:              backend.NewNodeCommunicator(false),
 			TxErrorMessagesCacheSize:  1000,
+			TxResultQueryMode:         backend.IndexQueryModeExecutionNodesOnly,
 		})
 		require.NoError(suite.T(), err)
 
@@ -986,6 +988,7 @@ func (suite *Suite) TestExecuteScript() {
 			Communicator:             backend.NewNodeCommunicator(false),
 			ScriptExecutionMode:      backend.IndexQueryModeExecutionNodesOnly,
 			TxErrorMessagesCacheSize: 1000,
+			TxResultQueryMode:        backend.IndexQueryModeExecutionNodesOnly,
 		})
 		require.NoError(suite.T(), err)
 

--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/flow-go/cmd/build"
 	"github.com/onflow/flow-go/engine/access/rpc/connection"
 	"github.com/onflow/flow-go/engine/common/rpc"
+	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/module"
@@ -143,6 +144,13 @@ func New(params Params) (*Backend, error) {
 		}
 	}
 
+	// the system tx is hardcoded and never changes during runtime
+	systemTx, err := blueprints.SystemChunkTransaction(params.ChainID.Chain())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create system chunk transaction: %w", err)
+	}
+	systemTxID := systemTx.ID()
+
 	// initialize node version info
 	nodeInfo, err := getNodeVersionInfo(params.State.Params())
 	if err != nil {
@@ -171,6 +179,7 @@ func New(params Params) (*Backend, error) {
 				blocks:         params.Blocks,
 				eventsIndex:    params.EventsIndex,
 				txResultsIndex: params.TxResultsIndex,
+				systemTxID:     systemTxID,
 			},
 			log:                  params.Log,
 			staticCollectionRPC:  params.CollectionRPC,
@@ -186,6 +195,8 @@ func New(params Params) (*Backend, error) {
 			txResultCache:        txResCache,
 			txErrorMessagesCache: txErrorMessagesCache,
 			txResultQueryMode:    params.TxResultQueryMode,
+			systemTx:             systemTx,
+			systemTxID:           systemTxID,
 		},
 		backendEvents: backendEvents{
 			log:               params.Log,

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -353,5 +353,5 @@ func convertAccountError(err error, address flow.Address, height uint64) error {
 		return status.Errorf(codes.NotFound, "account not found")
 	}
 
-	return convertIndexError(err, height, "failed to get account")
+	return rpc.ConvertIndexError(err, height, "failed to get account")
 }

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -233,7 +233,7 @@ func (b *backendEvents) getBlockEventsFromStorage(
 			return nil, nil, rpc.ConvertError(ctx.Err(), "failed to get events from storage", codes.Canceled)
 		}
 
-		events, err := b.eventsIndex.GetEvents(blockInfo.ID, blockInfo.Height)
+		events, err := b.eventsIndex.ByBlockID(blockInfo.ID, blockInfo.Height)
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) ||
 				errors.Is(err, storage.ErrHeightNotIndexed) ||

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"crypto/md5" //nolint:gosec
-	"errors"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -19,7 +18,6 @@ import (
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/execution"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/module/state_synchronization/indexer"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/utils/logging"
@@ -354,26 +352,5 @@ func convertScriptExecutionError(err error, height uint64) error {
 		}
 	}
 
-	return convertIndexError(err, height, "failed to execute script")
-}
-
-// convertIndexError converts errors related to index to a gRPC error
-func convertIndexError(err error, height uint64, defaultMsg string) error {
-	if err == nil {
-		return nil
-	}
-
-	if errors.Is(err, indexer.ErrIndexNotInitialized) {
-		return status.Errorf(codes.FailedPrecondition, "data for block is not available: %v", err)
-	}
-
-	if errors.Is(err, storage.ErrHeightNotIndexed) {
-		return status.Errorf(codes.OutOfRange, "data for block height %d is not available", height)
-	}
-
-	if errors.Is(err, storage.ErrNotFound) {
-		return status.Errorf(codes.NotFound, "data not found: %v", err)
-	}
-
-	return rpc.ConvertError(err, defaultMsg, codes.Internal)
+	return rpc.ConvertIndexError(err, height, "failed to execute script")
 }

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -62,6 +62,7 @@ type Suite struct {
 	receipts           *storagemock.ExecutionReceipts
 	results            *storagemock.ExecutionResults
 	transactionResults *storagemock.LightTransactionResults
+	events             *storagemock.Events
 
 	colClient              *access.AccessAPIClient
 	execClient             *access.ExecutionAPIClient
@@ -99,6 +100,7 @@ func (suite *Suite) SetupTest() {
 	suite.colClient = new(access.AccessAPIClient)
 	suite.execClient = new(access.ExecutionAPIClient)
 	suite.transactionResults = storagemock.NewLightTransactionResults(suite.T())
+	suite.events = storagemock.NewEvents(suite.T())
 	suite.chainID = flow.Testnet
 	suite.historicalAccessClient = new(access.AccessAPIClient)
 	suite.connectionFactory = connectionmock.NewConnectionFactory(suite.T())
@@ -2184,7 +2186,6 @@ func (suite *Suite) defaultBackendParams() Params {
 		Transactions:             suite.transactions,
 		ExecutionReceipts:        suite.receipts,
 		ExecutionResults:         suite.results,
-		LightTransactionResults:  suite.transactionResults,
 		ChainID:                  suite.chainID,
 		CollectionRPC:            suite.colClient,
 		MaxHeightRange:           DefaultMaxHeightRange,
@@ -2193,5 +2194,6 @@ func (suite *Suite) defaultBackendParams() Params {
 		AccessMetrics:            metrics.NewNoopCollector(),
 		Log:                      suite.log,
 		TxErrorMessagesCacheSize: 1000,
+		TxResultQueryMode:        IndexQueryModeExecutionNodesOnly,
 	}
 }

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/flow-go/engine/access/rpc/connection"
 	connectionmock "github.com/onflow/flow-go/engine/access/rpc/connection/mock"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
@@ -71,7 +72,8 @@ type Suite struct {
 	connectionFactory *connectionmock.ConnectionFactory
 	communicator      *backendmock.Communicator
 
-	chainID flow.ChainID
+	chainID  flow.ChainID
+	systemTx *flow.TransactionBody
 }
 
 func TestHandler(t *testing.T) {
@@ -106,6 +108,10 @@ func (suite *Suite) SetupTest() {
 	suite.connectionFactory = connectionmock.NewConnectionFactory(suite.T())
 
 	suite.communicator = new(backendmock.Communicator)
+
+	var err error
+	suite.systemTx, err = blueprints.SystemChunkTransaction(flow.Testnet.Chain())
+	suite.Require().NoError(err)
 }
 
 func (suite *Suite) TestPing() {

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -23,18 +23,14 @@ import (
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/state"
-	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/storage"
 )
 
 type backendTransactions struct {
+	TransactionsLocalDataProvider
 	staticCollectionRPC  accessproto.AccessAPIClient // rpc client tied to a fixed collection node
 	transactions         storage.Transactions
 	executionReceipts    storage.ExecutionReceipts
-	collections          storage.Collections
-	blocks               storage.Blocks
-	results              storage.LightTransactionResults
-	state                protocol.State
 	chainID              flow.ChainID
 	transactionMetrics   module.TransactionMetrics
 	transactionValidator *access.TransactionValidator
@@ -46,7 +42,10 @@ type backendTransactions struct {
 	nodeCommunicator     Communicator
 	txResultCache        *lru.Cache[flow.Identifier, *access.TransactionResult]
 	txErrorMessagesCache *lru.Cache[flow.Identifier, string] // cache for transactions error messages, indexed by hash(block_id, tx_id).
+	txResultQueryMode    IndexQueryMode
 }
+
+var _ TransactionErrorMessage = (*backendTransactions)(nil)
 
 // SendTransaction forwards the transaction to the collection node
 func (b *backendTransactions) SendTransaction(
@@ -84,7 +83,6 @@ func (b *backendTransactions) SendTransaction(
 
 // trySendTransaction tries to transaction to a collection node
 func (b *backendTransactions) trySendTransaction(ctx context.Context, tx *flow.TransactionBody) error {
-
 	// if a collection node rpc client was provided at startup, just use that
 	if b.staticCollectionRPC != nil {
 		return b.grpcTxSend(ctx, b.staticCollectionRPC, tx)
@@ -145,7 +143,6 @@ func (b *backendTransactions) sendTransactionToCollector(
 	tx *flow.TransactionBody,
 	collectionNodeAddr string,
 ) error {
-
 	collectionRPC, closer, err := b.connFactory.GetAccessAPIClient(collectionNodeAddr, nil)
 	if err != nil {
 		return fmt.Errorf("failed to connect to collection node at %s: %w", collectionNodeAddr, err)
@@ -177,7 +174,6 @@ func (b *backendTransactions) SendRawTransaction(
 	ctx context.Context,
 	tx *flow.TransactionBody,
 ) error {
-
 	// send the transaction to the collection node
 	return b.trySendTransaction(ctx, tx)
 }
@@ -276,7 +272,6 @@ func (b *backendTransactions) GetTransactionResult(
 	}
 
 	block, err := b.retrieveBlock(blockID, collectionID, txID)
-
 	// an error occurred looking up the block or the requested block or collection was not found.
 	// If looking up the block based solely on the txID returns not found, then no error is
 	// returned since the block may not be finalized yet.
@@ -284,18 +279,13 @@ func (b *backendTransactions) GetTransactionResult(
 		return nil, rpc.ConvertStorageError(err)
 	}
 
-	var transactionWasExecuted bool
-	var events []flow.Event
-	var txError string
-	var statusCode uint32
 	var blockHeight uint64
-
+	var txResult *access.TransactionResult
 	// access node may not have the block if it hasn't yet been finalized, hence block can be nil at this point
 	if block != nil {
-		foundBlockID := block.ID()
-		transactionWasExecuted, events, statusCode, txError, err = b.lookupTransactionResult(ctx, txID, foundBlockID, requiredEventEncodingVersion)
+		txResult, err = b.lookupTransactionResult(ctx, txID, block, requiredEventEncodingVersion)
 		if err != nil {
-			return nil, rpc.ConvertError(err, "failed to retrieve result from any execution node", codes.Internal)
+			return nil, rpc.ConvertError(err, "failed to retrieve result", codes.Internal)
 		}
 
 		// an additional check to ensure the correctness of the collection ID.
@@ -316,52 +306,41 @@ func (b *backendTransactions) GetTransactionResult(
 			return nil, status.Error(codes.InvalidArgument, "transaction not found in provided collection")
 		}
 
-		blockID = foundBlockID
+		blockID = block.ID()
 		blockHeight = block.Header.Height
 	}
 
-	// derive status of the transaction
-	txStatus, err := b.deriveTransactionStatus(tx, transactionWasExecuted, block)
-	if err != nil {
-		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
-			irrecoverable.Throw(ctx, err)
+	// If there is still no transaction result, provide one based on available information.
+	if txResult == nil {
+		var txStatus flow.TransactionStatus
+		// Derive the status of the transaction.
+		if block == nil {
+			txStatus, err = b.deriveUnknownTransactionStatus(tx.ReferenceBlockID)
+		} else {
+			txStatus, err = b.deriveTransactionStatus(blockID, blockHeight, false)
 		}
-		return nil, rpc.ConvertStorageError(err)
+
+		if err != nil {
+			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
+				irrecoverable.Throw(ctx, err)
+			}
+			return nil, rpc.ConvertStorageError(err)
+		}
+
+		txResult = &access.TransactionResult{
+			BlockID:       blockID,
+			BlockHeight:   blockHeight,
+			TransactionID: txID,
+			Status:        txStatus,
+			CollectionID:  collectionID,
+		}
+	} else {
+		txResult.CollectionID = collectionID
 	}
 
 	b.transactionMetrics.TransactionResultFetched(time.Since(start), len(tx.Script))
 
-	return &access.TransactionResult{
-		Status:        txStatus,
-		StatusCode:    uint(statusCode),
-		Events:        events,
-		ErrorMessage:  txError,
-		BlockID:       blockID,
-		TransactionID: txID,
-		CollectionID:  collectionID,
-		BlockHeight:   blockHeight,
-	}, nil
-}
-
-// lookupCollectionIDInBlock returns the collection ID based on the transaction ID. The lookup is performed in block
-// collections.
-func (b *backendTransactions) lookupCollectionIDInBlock(
-	block *flow.Block,
-	txID flow.Identifier,
-) (flow.Identifier, error) {
-	for _, guarantee := range block.Payload.Guarantees {
-		collection, err := b.collections.LightByID(guarantee.ID())
-		if err != nil {
-			return flow.ZeroID, err
-		}
-
-		for _, collectionTxID := range collection.Transactions {
-			if collectionTxID == txID {
-				return collection.ID(), nil
-			}
-		}
-	}
-	return flow.ZeroID, status.Error(codes.NotFound, "transaction not found in block")
+	return txResult, nil
 }
 
 // retrieveBlock function returns a block based on the input argument. The block ID lookup has the highest priority,
@@ -402,6 +381,30 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 		return nil, rpc.ConvertStorageError(err)
 	}
 
+	switch b.txResultQueryMode {
+	case IndexQueryModeExecutionNodesOnly:
+		return b.getTransactionResultsByBlockIDFromExecutionNode(ctx, block, requiredEventEncodingVersion)
+	case IndexQueryModeLocalOnly:
+		return b.GetTransactionResultsByBlockIDFromStorage(ctx, block, requiredEventEncodingVersion)
+	case IndexQueryModeFailover:
+		results, err := b.GetTransactionResultsByBlockIDFromStorage(ctx, block, requiredEventEncodingVersion)
+		if err == nil {
+			return results, nil
+		}
+
+		// If any error occurs with local storage - request transaction result from EN
+		return b.getTransactionResultsByBlockIDFromExecutionNode(ctx, block, requiredEventEncodingVersion)
+	default:
+		return nil, status.Errorf(codes.Internal, "unknown transaction result query mode: %v", b.txResultQueryMode)
+	}
+}
+
+func (b *backendTransactions) getTransactionResultsByBlockIDFromExecutionNode(
+	ctx context.Context,
+	block *flow.Block,
+	requiredEventEncodingVersion entities.EventEncodingVersion,
+) ([]*access.TransactionResult, error) {
+	blockID := block.ID()
 	req := &execproto.GetTransactionsByBlockIDRequest{
 		BlockId: blockID[:],
 	}
@@ -440,7 +443,7 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 			txResult := resp.TransactionResults[i]
 
 			// tx body is irrelevant to status if it's in an executed block
-			txStatus, err := b.deriveTransactionStatus(nil, true, block)
+			txStatus, err := b.deriveTransactionStatus(blockID, block.Header.Height, true)
 			if err != nil {
 				if !errors.Is(err, state.ErrUnknownSnapshotReference) {
 					irrecoverable.Throw(ctx, err)
@@ -497,7 +500,7 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 			return nil, status.Errorf(codes.Internal, "could not get system chunk transaction: %v", err)
 		}
 		systemTxResult := resp.TransactionResults[len(resp.TransactionResults)-1]
-		systemTxStatus, err := b.deriveTransactionStatus(systemTx, true, block)
+		systemTxStatus, err := b.deriveTransactionStatus(blockID, block.Header.Height, true)
 		if err != nil {
 			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
 				irrecoverable.Throw(ctx, err)
@@ -520,7 +523,6 @@ func (b *backendTransactions) GetTransactionResultsByBlockID(
 			BlockHeight:   block.Header.Height,
 		})
 	}
-
 	return results, nil
 }
 
@@ -538,6 +540,31 @@ func (b *backendTransactions) GetTransactionResultByIndex(
 		return nil, rpc.ConvertStorageError(err)
 	}
 
+	switch b.txResultQueryMode {
+	case IndexQueryModeExecutionNodesOnly:
+		return b.getTransactionResultByIndexFromExecutionNode(ctx, block, index, requiredEventEncodingVersion)
+	case IndexQueryModeLocalOnly:
+		return b.GetTransactionResultByIndexFromStorage(ctx, block, index, requiredEventEncodingVersion)
+	case IndexQueryModeFailover:
+		result, err := b.GetTransactionResultByIndexFromStorage(ctx, block, index, requiredEventEncodingVersion)
+		if err == nil {
+			return result, nil
+		}
+
+		// If any error occurs with local storage - request transaction result from EN
+		return b.getTransactionResultByIndexFromExecutionNode(ctx, block, index, requiredEventEncodingVersion)
+	default:
+		return nil, status.Errorf(codes.Internal, "unknown transaction result query mode: %v", b.txResultQueryMode)
+	}
+}
+
+func (b *backendTransactions) getTransactionResultByIndexFromExecutionNode(
+	ctx context.Context,
+	block *flow.Block,
+	index uint32,
+	requiredEventEncodingVersion entities.EventEncodingVersion,
+) (*access.TransactionResult, error) {
+	blockID := block.ID()
 	// create request and forward to EN
 	req := &execproto.GetTransactionByIndexRequest{
 		BlockId: blockID[:],
@@ -558,7 +585,7 @@ func (b *backendTransactions) GetTransactionResultByIndex(
 	}
 
 	// tx body is irrelevant to status if it's in an executed block
-	txStatus, err := b.deriveTransactionStatus(nil, true, block)
+	txStatus, err := b.deriveTransactionStatus(blockID, block.Header.Height, true)
 	if err != nil {
 		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
 			irrecoverable.Throw(ctx, err)
@@ -621,7 +648,7 @@ func (b *backendTransactions) GetSystemTransactionResult(ctx context.Context, bl
 	}
 
 	systemTxResult := resp.TransactionResults[len(resp.TransactionResults)-1]
-	systemTxStatus, err := b.deriveTransactionStatus(systemTx, true, block)
+	systemTxStatus, err := b.deriveTransactionStatus(blockID, block.Header.Height, true)
 	if err != nil {
 		return nil, rpc.ConvertStorageError(err)
 	}
@@ -642,95 +669,10 @@ func (b *backendTransactions) GetSystemTransactionResult(ctx context.Context, bl
 	}, nil
 }
 
-// deriveTransactionStatus derives the transaction status based on current protocol state
-// Error returns:
-//   - state.ErrUnknownSnapshotReference - block referenced by transaction has not been found.
-//   - all other errors are unexpected and potentially symptoms of internal implementation bugs or state corruption (fatal).
-func (b *backendTransactions) deriveTransactionStatus(
-	tx *flow.TransactionBody,
-	executed bool,
-	block *flow.Block,
-) (flow.TransactionStatus, error) {
-	if block == nil {
-		// Not in a block, let's see if it's expired
-		referenceBlock, err := b.state.AtBlockID(tx.ReferenceBlockID).Head()
-		if err != nil {
-			return flow.TransactionStatusUnknown, err
-		}
-		refHeight := referenceBlock.Height
-		// get the latest finalized block from the state
-		finalized, err := b.state.Final().Head()
-		if err != nil {
-			return flow.TransactionStatusUnknown, irrecoverable.NewExceptionf("failed to lookup final header: %w", err)
-		}
-		finalizedHeight := finalized.Height
-
-		// if we haven't seen the expiry block for this transaction, it's not expired
-		if !b.isExpired(refHeight, finalizedHeight) {
-			return flow.TransactionStatusPending, nil
-		}
-
-		// At this point, we have seen the expiry block for the transaction.
-		// This means that, if no collections  prior to the expiry block contain
-		// the transaction, it can never be included and is expired.
-		//
-		// To ensure this, we need to have received all collections  up to the
-		// expiry block to ensure the transaction did not appear in any.
-
-		// the last full height is the height where we have received all
-		// collections  for all blocks with a lower height
-		fullHeight, err := b.blocks.GetLastFullBlockHeight()
-		if err != nil {
-			return flow.TransactionStatusUnknown, err
-		}
-
-		// if we have received collections  for all blocks up to the expiry block, the transaction is expired
-		if b.isExpired(refHeight, fullHeight) {
-			return flow.TransactionStatusExpired, nil
-		}
-
-		// tx found in transaction storage and collection storage but not in block storage
-		// However, this will not happen as of now since the ingestion engine doesn't subscribe
-		// for collections
-		return flow.TransactionStatusPending, nil
-	}
-
-	if !executed {
-		// If we've gotten here, but the block has not yet been executed, report it as only been finalized
-		return flow.TransactionStatusFinalized, nil
-	}
-
-	// From this point on, we know for sure this transaction has at least been executed
-
-	// get the latest sealed block from the State
-	sealed, err := b.state.Sealed().Head()
-	if err != nil {
-		return flow.TransactionStatusUnknown, irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
-	}
-
-	if block.Header.Height > sealed.Height {
-		// The block is not yet sealed, so we'll report it as only executed
-		return flow.TransactionStatusExecuted, nil
-	}
-
-	// otherwise, this block has been executed, and sealed, so report as sealed
-	return flow.TransactionStatusSealed, nil
-}
-
-// isExpired checks whether a transaction is expired given the height of the
-// transaction's reference block and the height to compare against.
-func (b *backendTransactions) isExpired(refHeight, compareToHeight uint64) bool {
-	if compareToHeight <= refHeight {
-		return false
-	}
-	return compareToHeight-refHeight > flow.DefaultTransactionExpiry
-}
-
 // Error returns:
 //   - `storage.ErrNotFound` - collection referenced by transaction or block by a collection has not been found.
 //   - all other errors are unexpected and potentially symptoms of internal implementation bugs or state corruption (fatal).
 func (b *backendTransactions) lookupBlock(txID flow.Identifier) (*flow.Block, error) {
-
 	collection, err := b.collections.LightByTransactionID(txID)
 	if err != nil {
 		return nil, err
@@ -747,22 +689,38 @@ func (b *backendTransactions) lookupBlock(txID flow.Identifier) (*flow.Block, er
 func (b *backendTransactions) lookupTransactionResult(
 	ctx context.Context,
 	txID flow.Identifier,
-	blockID flow.Identifier,
+	block *flow.Block,
 	requiredEventEncodingVersion entities.EventEncodingVersion,
-) (bool, []flow.Event, uint32, string, error) {
-	events, txStatus, message, err := b.getTransactionResultFromExecutionNode(ctx, blockID, txID[:], requiredEventEncodingVersion)
+) (*access.TransactionResult, error) {
+	var txResult *access.TransactionResult
+	var err error
+	switch b.txResultQueryMode {
+	case IndexQueryModeExecutionNodesOnly:
+		txResult, err = b.getTransactionResultFromExecutionNode(ctx, block, txID, requiredEventEncodingVersion)
+	case IndexQueryModeLocalOnly:
+		txResult, err = b.GetTransactionResultFromStorage(ctx, block, txID, requiredEventEncodingVersion)
+	case IndexQueryModeFailover:
+		txResult, err = b.GetTransactionResultFromStorage(ctx, block, txID, requiredEventEncodingVersion)
+		if err != nil {
+			// If any error occurs with local storage - request transaction result from EN
+			txResult, err = b.getTransactionResultFromExecutionNode(ctx, block, txID, requiredEventEncodingVersion)
+		}
+	default:
+		return nil, status.Errorf(codes.Internal, "unknown transaction result query mode: %v", b.txResultQueryMode)
+	}
+
 	if err != nil {
-		// if either the execution node reported no results or the execution node could not be chosen
+		// if either the storage or execution node reported no results or there were not enough execution results
 		if status.Code(err) == codes.NotFound {
 			// No result yet, indicate that it has not been executed
-			return false, nil, 0, "", nil
+			return nil, nil
 		}
 		// Other Error trying to retrieve the result, return with err
-		return false, nil, 0, "", err
+		return nil, err
 	}
 
 	// considered executed as long as some result is returned, even if it's an error message
-	return true, events, txStatus, message, nil
+	return txResult, nil
 }
 
 func (b *backendTransactions) getHistoricalTransaction(
@@ -831,37 +789,54 @@ func (b *backendTransactions) registerTransactionForRetry(tx *flow.TransactionBo
 
 func (b *backendTransactions) getTransactionResultFromExecutionNode(
 	ctx context.Context,
-	blockID flow.Identifier,
-	transactionID []byte,
+	block *flow.Block,
+	transactionID flow.Identifier,
 	requiredEventEncodingVersion entities.EventEncodingVersion,
-) ([]flow.Event, uint32, string, error) {
-
+) (*access.TransactionResult, error) {
+	blockID := block.ID()
 	// create an execution API request for events at blockID and transactionID
 	req := &execproto.GetTransactionResultRequest{
 		BlockId:       blockID[:],
-		TransactionId: transactionID,
+		TransactionId: transactionID[:],
 	}
 
 	execNodes, err := executionNodesForBlockID(ctx, blockID, b.executionReceipts, b.state, b.log)
 	if err != nil {
 		// if no execution receipt were found, return a NotFound GRPC error
 		if IsInsufficientExecutionReceipts(err) {
-			return nil, 0, "", status.Errorf(codes.NotFound, err.Error())
+			return nil, status.Errorf(codes.NotFound, err.Error())
 		}
-		return nil, 0, "", err
+		return nil, err
 	}
 
 	resp, err := b.getTransactionResultFromAnyExeNode(ctx, execNodes, req)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, err
+	}
+
+	// tx body is irrelevant to status if it's in an executed block
+	txStatus, err := b.deriveTransactionStatus(blockID, block.Header.Height, true)
+	if err != nil {
+		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
+			irrecoverable.Throw(ctx, err)
+		}
+		return nil, rpc.ConvertStorageError(err)
 	}
 
 	events, err := convert.MessagesToEventsWithEncodingConversion(resp.GetEvents(), resp.GetEventEncodingVersion(), requiredEventEncodingVersion)
 	if err != nil {
-		return nil, 0, "", rpc.ConvertError(err, "failed to convert events to message", codes.Internal)
+		return nil, rpc.ConvertError(err, "failed to convert events to message", codes.Internal)
 	}
 
-	return events, resp.GetStatusCode(), resp.GetErrorMessage(), nil
+	return &access.TransactionResult{
+		TransactionID: transactionID,
+		Status:        txStatus,
+		StatusCode:    uint(resp.GetStatusCode()),
+		Events:        events,
+		ErrorMessage:  resp.GetErrorMessage(),
+		BlockID:       blockID,
+		BlockHeight:   block.Header.Height,
+	}, nil
 }
 
 // ATTENTION: might be a source of problems in future. We run this code on finalization gorotuine,
@@ -1043,13 +1018,13 @@ func (b *backendTransactions) tryGetTransactionResultByIndex(
 	return resp, nil
 }
 
-// lookupTransactionErrorMessage returns transaction error message for specified transaction.
+// LookupErrorMessageByTransactionID returns transaction error message for specified transaction.
 // If an error message for transaction can be found in the cache then it will be used to serve the request, otherwise
 // an RPC call will be made to the EN to fetch that error message, fetched value will be cached in the LRU cache.
 // Expected errors during normal operation:
 //   - InsufficientExecutionReceipts - found insufficient receipts for given block ID.
 //   - status.Error - remote GRPC call to EN has failed.
-func (b *backendTransactions) lookupTransactionErrorMessage(
+func (b *backendTransactions) LookupErrorMessageByTransactionID(
 	ctx context.Context,
 	blockID flow.Identifier,
 	transactionID flow.Identifier,
@@ -1090,19 +1065,20 @@ func (b *backendTransactions) lookupTransactionErrorMessage(
 	return value, nil
 }
 
-// lookupTransactionErrorMessageByIndex returns transaction error message for specified transaction using its index.
+// LookupErrorMessageByIndex returns transaction error message for specified transaction using its index.
 // If an error message for transaction can be found in cache then it will be used to serve the request, otherwise
 // an RPC call will be made to the EN to fetch that error message, fetched value will be cached in the LRU cache.
 // Expected errors during normal operation:
 //   - status.Error[codes.NotFound] - transaction result for given block ID and tx index is not available.
 //   - InsufficientExecutionReceipts - found insufficient receipts for given block ID.
 //   - status.Error - remote GRPC call to EN has failed.
-func (b *backendTransactions) lookupTransactionErrorMessageByIndex(
+func (b *backendTransactions) LookupErrorMessageByIndex(
 	ctx context.Context,
 	blockID flow.Identifier,
+	height uint64,
 	index uint32,
 ) (string, error) {
-	txResult, err := b.results.ByBlockIDTransactionIndex(blockID, index)
+	txResult, err := b.txResultsIndex.ByBlockIDTransactionIndex(blockID, height, index)
 	if err != nil {
 		return "", rpc.ConvertStorageError(err)
 	}
@@ -1143,17 +1119,18 @@ func (b *backendTransactions) lookupTransactionErrorMessageByIndex(
 	return value, nil
 }
 
-// lookupTransactionErrorMessagesByBlockID returns all error messages for failed transactions by blockID.
+// LookupErrorMessagesByBlockID returns all error messages for failed transactions by blockID.
 // An RPC call will be made to the EN to fetch missing errors messages, fetched value will be cached in the LRU cache.
 // Expected errors during normal operation:
 //   - status.Error[codes.NotFound] - transaction results for given block ID are not available.
 //   - InsufficientExecutionReceipts - found insufficient receipts for given block ID.
 //   - status.Error - remote GRPC call to EN has failed.
-func (b *backendTransactions) lookupTransactionErrorMessagesByBlockID(
+func (b *backendTransactions) LookupErrorMessagesByBlockID(
 	ctx context.Context,
 	blockID flow.Identifier,
+	height uint64,
 ) (map[flow.Identifier]string, error) {
-	txResults, err := b.results.ByBlockID(blockID)
+	txResults, err := b.txResultsIndex.ByBlockID(blockID, height)
 	if err != nil {
 		return nil, rpc.ConvertStorageError(err)
 	}
@@ -1333,10 +1310,10 @@ func (b *backendTransactions) getTransactionErrorMessagesFromAnyEN(
 
 // Expected errors during normal operation:
 //   - status.Error - GRPC call failed, some of possible codes are:
-//      - codes.NotFound - request cannot be served by EN because of absence of data.
-//      - codes.Unavailable - remote node is not unavailable.
+//   - codes.NotFound - request cannot be served by EN because of absence of data.
+//   - codes.Unavailable - remote node is not unavailable.
+//
 // tryGetTransactionErrorMessageFromEN performs a grpc call to the specified execution node and returns response.
-
 func (b *backendTransactions) tryGetTransactionErrorMessageFromEN(
 	ctx context.Context,
 	execNode *flow.Identity,

--- a/engine/access/rpc/backend/backend_transactions_test.go
+++ b/engine/access/rpc/backend/backend_transactions_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
+	syncmock "github.com/onflow/flow-go/module/state_synchronization/mock"
 	"github.com/onflow/flow-go/state/protocol"
 	bprotocol "github.com/onflow/flow-go/state/protocol/badger"
 	"github.com/onflow/flow-go/state/protocol/util"
@@ -28,6 +29,8 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 	"github.com/onflow/flow-go/utils/unittest/generator"
 )
+
+const expectedErrorMsg = "expected test error"
 
 func (suite *Suite) withPreConfiguredState(f func(snap protocol.Snapshot)) {
 	identities := unittest.CompleteIdentitySet()
@@ -58,7 +61,6 @@ func (suite *Suite) withPreConfiguredState(f func(snap protocol.Snapshot)) {
 
 		f(snap)
 	})
-
 }
 
 // TestGetTransactionResultReturnsUnknown returns unknown result when tx not found
@@ -129,7 +131,6 @@ func (suite *Suite) TestGetTransactionResultReturnsTransactionError() {
 			entities.EventEncodingVersion_JSON_CDC_V0,
 		)
 		suite.Require().Equal(err, status.Errorf(codes.Internal, "failed to find: %v", fmt.Errorf("some other error")))
-
 	})
 }
 
@@ -246,7 +247,6 @@ func (suite *Suite) TestGetTransactionResultFromCache() {
 // TestGetTransactionResultCacheNonExistent tests caches non existing result
 func (suite *Suite) TestGetTransactionResultCacheNonExistent() {
 	suite.withGetTransactionCachingTestSetup(func(block *flow.Block, tx *flow.Transaction) {
-
 		suite.historicalAccessClient.
 			On("GetTransactionResult", mock.AnythingOfType("*context.emptyCtx"), mock.AnythingOfType("*access.GetTransactionRequest")).
 			Return(nil, status.Errorf(codes.NotFound, "no known transaction with ID %s", tx.ID())).Once()
@@ -376,13 +376,13 @@ func (suite *Suite) TestLookupTransactionErrorMessage_HappyPath() {
 
 	suite.execClient.On("GetTransactionErrorMessage", mock.Anything, exeEventReq).Return(exeEventResp, nil).Once()
 
-	errMsg, err := backend.lookupTransactionErrorMessage(context.Background(), blockId, failedTxId)
+	errMsg, err := backend.LookupErrorMessageByTransactionID(context.Background(), blockId, failedTxId)
 	suite.Require().NoError(err)
 	suite.Require().Equal(expectedErrorMsg, errMsg)
 
 	// ensure the transaction error message is cached after retrieval; we do this by mocking the grpc call
 	// only once
-	errMsg, err = backend.lookupTransactionErrorMessage(context.Background(), blockId, failedTxId)
+	errMsg, err = backend.LookupErrorMessageByTransactionID(context.Background(), blockId, failedTxId)
 	suite.Require().NoError(err)
 	suite.Require().Equal(expectedErrorMsg, errMsg)
 	suite.assertAllExpectations()
@@ -416,7 +416,7 @@ func (suite *Suite) TestLookupTransactionErrorMessage_FailedToFetch() {
 	suite.execClient.On("GetTransactionErrorMessage", mock.Anything, mock.Anything).Return(nil,
 		status.Error(codes.Unavailable, "")).Twice()
 
-	errMsg, err := backend.lookupTransactionErrorMessage(context.Background(), blockId, failedTxId)
+	errMsg, err := backend.LookupErrorMessageByTransactionID(context.Background(), blockId, failedTxId)
 	suite.Require().Error(err)
 	suite.Require().Equal(codes.Unavailable, status.Code(err))
 	suite.Require().Empty(errMsg)
@@ -449,10 +449,20 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_HappyPath() {
 	connFactory := connectionmock.NewConnectionFactory(suite.T())
 	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
 
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
 	params := suite.defaultBackendParams()
+
 	// the connection factory should be used to get the execution node client
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err := params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
@@ -471,13 +481,13 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_HappyPath() {
 
 	suite.execClient.On("GetTransactionErrorMessageByIndex", mock.Anything, exeEventReq).Return(exeEventResp, nil).Once()
 
-	errMsg, err := backend.lookupTransactionErrorMessageByIndex(context.Background(), blockId, failedTxIndex)
+	errMsg, err := backend.LookupErrorMessageByIndex(context.Background(), blockId, block.Header.Height, failedTxIndex)
 	suite.Require().NoError(err)
 	suite.Require().Equal(expectedErrorMsg, errMsg)
 
 	// ensure the transaction error message is cached after retrieval; we do this by mocking the grpc call
 	// only once
-	errMsg, err = backend.lookupTransactionErrorMessageByIndex(context.Background(), blockId, failedTxIndex)
+	errMsg, err = backend.LookupErrorMessageByIndex(context.Background(), blockId, block.Header.Height, failedTxIndex)
 	suite.Require().NoError(err)
 	suite.Require().Equal(expectedErrorMsg, errMsg)
 	suite.assertAllExpectations()
@@ -493,11 +503,21 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_UnknownTransaction(
 	suite.transactionResults.On("ByBlockIDTransactionIndex", blockId, failedTxIndex).
 		Return(nil, storage.ErrNotFound).Once()
 
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
 	params := suite.defaultBackendParams()
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err := params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
 	backend, err := New(params)
 	suite.Require().NoError(err)
 
-	errMsg, err := backend.lookupTransactionErrorMessageByIndex(context.Background(), blockId, failedTxIndex)
+	errMsg, err := backend.LookupErrorMessageByIndex(context.Background(), blockId, block.Header.Height, failedTxIndex)
 	suite.Require().Error(err)
 	suite.Require().Equal(codes.NotFound, status.Code(err))
 	suite.Require().Empty(errMsg)
@@ -529,10 +549,19 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_FailedToFetch() {
 	connFactory := connectionmock.NewConnectionFactory(suite.T())
 	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
 
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
 	params := suite.defaultBackendParams()
 	// the connection factory should be used to get the execution node client
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err := params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
@@ -541,7 +570,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_FailedToFetch() {
 	suite.execClient.On("GetTransactionErrorMessageByIndex", mock.Anything, mock.Anything).Return(nil,
 		status.Error(codes.Unavailable, "")).Twice()
 
-	errMsg, err := backend.lookupTransactionErrorMessageByIndex(context.Background(), blockId, failedTxIndex)
+	errMsg, err := backend.LookupErrorMessageByIndex(context.Background(), blockId, block.Header.Height, failedTxIndex)
 	suite.Require().Error(err)
 	suite.Require().Equal(codes.Unavailable, status.Code(err))
 	suite.Require().Empty(errMsg)
@@ -576,10 +605,20 @@ func (suite *Suite) TestLookupTransactionErrorMessages_HappyPath() {
 	connFactory := connectionmock.NewConnectionFactory(suite.T())
 	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
 
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
 	params := suite.defaultBackendParams()
+
 	// the connection factory should be used to get the execution node client
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err := params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
@@ -606,7 +645,7 @@ func (suite *Suite) TestLookupTransactionErrorMessages_HappyPath() {
 		Return(exeEventResp, nil).
 		Once()
 
-	errMessages, err := backend.lookupTransactionErrorMessagesByBlockID(context.Background(), blockId)
+	errMessages, err := backend.LookupErrorMessagesByBlockID(context.Background(), blockId, block.Header.Height)
 	suite.Require().NoError(err)
 	suite.Require().Len(errMessages, len(exeEventResp.Results))
 	for _, expectedResult := range exeEventResp.Results {
@@ -617,7 +656,7 @@ func (suite *Suite) TestLookupTransactionErrorMessages_HappyPath() {
 
 	// ensure the transaction error message is cached after retrieval; we do this by mocking the grpc call
 	// only once
-	errMessages, err = backend.lookupTransactionErrorMessagesByBlockID(context.Background(), blockId)
+	errMessages, err = backend.LookupErrorMessagesByBlockID(context.Background(), blockId, block.Header.Height)
 	suite.Require().NoError(err)
 	suite.Require().Len(errMessages, len(exeEventResp.Results))
 	for _, expectedResult := range exeEventResp.Results {
@@ -650,12 +689,21 @@ func (suite *Suite) TestLookupTransactionErrorMessages_HappyPath_NoFailedTxns() 
 	suite.transactionResults.On("ByBlockID", blockId).
 		Return(resultsByBlockID, nil).Once()
 
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
 	params := suite.defaultBackendParams()
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err := params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
 
-	errMessages, err := backend.lookupTransactionErrorMessagesByBlockID(context.Background(), blockId)
+	errMessages, err := backend.LookupErrorMessagesByBlockID(context.Background(), blockId, block.Header.Height)
 	suite.Require().NoError(err)
 	suite.Require().Empty(errMessages)
 	suite.assertAllExpectations()
@@ -670,11 +718,21 @@ func (suite *Suite) TestLookupTransactionErrorMessages_UnknownTransaction() {
 	suite.transactionResults.On("ByBlockID", blockId).
 		Return(nil, storage.ErrNotFound).Once()
 
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
 	params := suite.defaultBackendParams()
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err := params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
 	backend, err := New(params)
 	suite.Require().NoError(err)
 
-	errMsg, err := backend.lookupTransactionErrorMessagesByBlockID(context.Background(), blockId)
+	errMsg, err := backend.LookupErrorMessagesByBlockID(context.Background(), blockId, block.Header.Height)
 	suite.Require().Error(err)
 	suite.Require().Equal(codes.NotFound, status.Code(err))
 	suite.Require().Empty(errMsg)
@@ -712,10 +770,19 @@ func (suite *Suite) TestLookupTransactionErrorMessages_FailedToFetch() {
 	connFactory := connectionmock.NewConnectionFactory(suite.T())
 	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
 
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
 	params := suite.defaultBackendParams()
 	// the connection factory should be used to get the execution node client
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err := params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
@@ -726,7 +793,7 @@ func (suite *Suite) TestLookupTransactionErrorMessages_FailedToFetch() {
 	suite.execClient.On("GetTransactionErrorMessagesByBlockID", mock.Anything, mock.Anything).Return(nil,
 		status.Error(codes.Unavailable, "")).Twice()
 
-	errMsg, err := backend.lookupTransactionErrorMessagesByBlockID(context.Background(), blockId)
+	errMsg, err := backend.LookupErrorMessagesByBlockID(context.Background(), blockId, block.Header.Height)
 	suite.Require().Error(err)
 	suite.Require().Equal(codes.Unavailable, status.Code(err))
 	suite.Require().Empty(errMsg)
@@ -955,4 +1022,321 @@ func (suite *Suite) TestGetSystemTransactionResult_FailedEncodingConversion() {
 		suite.Require().Equal(err, status.Errorf(codes.Internal, "failed to convert events from system tx result: %v",
 			fmt.Errorf("conversion from format JSON_CDC_V0 to CCF_V0 is not supported")))
 	})
+}
+
+func (suite *Suite) assertTransactionResultResponse(
+	err error,
+	response *acc.TransactionResult,
+	block flow.Block,
+	txId flow.Identifier,
+	txFailed bool,
+	eventsForTx []flow.Event,
+) {
+
+	suite.Require().NoError(err)
+	suite.Assert().Equal(block.ID(), response.BlockID)
+	suite.Assert().Equal(block.Header.Height, response.BlockHeight)
+	suite.Assert().Equal(txId, response.TransactionID)
+	suite.Assert().Equal(block.Payload.Guarantees[0].CollectionID, response.CollectionID)
+	suite.Assert().Equal(len(eventsForTx), len(response.Events))
+	// When there are error messages occurred in the transaction, the status should be 1
+	if txFailed {
+		suite.Assert().Equal(uint(1), response.StatusCode)
+		suite.Assert().Equal(expectedErrorMsg, response.ErrorMessage)
+	} else {
+		suite.Assert().Equal(uint(0), response.StatusCode)
+		suite.Assert().Equal("", response.ErrorMessage)
+	}
+	suite.Assert().Equal(flow.TransactionStatusSealed, response.Status)
+}
+
+// TestTransactionResultFromStorage tests the retrieval of a transaction result (flow.TransactionResult) from storage
+// instead of requesting it from the Execution Node.
+func (suite *Suite) TestTransactionResultFromStorage() {
+	// Create fixtures for block, transaction, and collection
+	block := unittest.BlockFixture()
+	transaction := unittest.TransactionFixture()
+	col := flow.CollectionFromTransactions([]*flow.Transaction{&transaction})
+	guarantee := col.Guarantee()
+	block.SetPayload(unittest.PayloadFixture(unittest.WithGuarantees(&guarantee)))
+	txId := transaction.ID()
+	blockId := block.ID()
+
+	// Mock the behavior of the blocks and transactionResults objects
+	suite.blocks.
+		On("ByID", blockId).
+		Return(&block, nil)
+
+	suite.transactionResults.On("ByBlockIDTransactionID", blockId, txId).
+		Return(&flow.LightTransactionResult{
+			TransactionID:   txId,
+			Failed:          true,
+			ComputationUsed: 0,
+		}, nil)
+
+	suite.transactions.
+		On("ByID", txId).
+		Return(&transaction.TransactionBody, nil)
+
+	// Set up the light collection and mock the behavior of the collections object
+	lightCol := col.Light()
+	suite.collections.On("LightByID", col.ID()).Return(&lightCol, nil)
+
+	// Set up the events storage mock
+	totalEvents := 5
+	eventsForTx := unittest.EventsFixture(totalEvents, flow.EventAccountCreated)
+	eventMessages := make([]*entities.Event, totalEvents)
+	for j, event := range eventsForTx {
+		eventMessages[j] = convert.EventToMessage(event)
+	}
+
+	// expect a call to lookup events by block ID and transaction ID
+	suite.events.On("ByBlockIDTransactionID", blockId, txId).Return(eventsForTx, nil)
+
+	// Set up the state and snapshot mocks
+	_, fixedENIDs := suite.setupReceipts(&block)
+	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
+	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
+	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
+	suite.snapshot.On("Head", mock.Anything).Return(block.Header, nil)
+
+	// create a mock connection factory
+	connFactory := connectionmock.NewConnectionFactory(suite.T())
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
+	// Set up the backend parameters and the backend instance
+	params := suite.defaultBackendParams()
+	// the connection factory should be used to get the execution node client
+	params.ConnFactory = connFactory
+	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
+	params.TxResultQueryMode = IndexQueryModeLocalOnly
+
+	params.EventsIndex = NewEventsIndex(suite.events)
+	err := params.EventsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err = params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
+	backend, err := New(params)
+	suite.Require().NoError(err)
+
+	// Set up the expected error message for the execution node response
+
+	exeEventReq := &execproto.GetTransactionErrorMessageRequest{
+		BlockId:       blockId[:],
+		TransactionId: txId[:],
+	}
+
+	exeEventResp := &execproto.GetTransactionErrorMessageResponse{
+		TransactionId: txId[:],
+		ErrorMessage:  expectedErrorMsg,
+	}
+
+	suite.execClient.On("GetTransactionErrorMessage", mock.Anything, exeEventReq).Return(exeEventResp, nil).Once()
+
+	response, err := backend.GetTransactionResult(context.Background(), txId, blockId, flow.ZeroID, entities.EventEncodingVersion_JSON_CDC_V0)
+	suite.assertTransactionResultResponse(err, response, block, txId, true, eventsForTx)
+}
+
+// TestTransactionByIndexFromStorage tests the retrieval of a transaction result (flow.TransactionResult) by index
+// and returns it from storage instead of requesting from the Execution Node.
+func (suite *Suite) TestTransactionByIndexFromStorage() {
+	// Create fixtures for block, transaction, and collection
+	block := unittest.BlockFixture()
+	transaction := unittest.TransactionFixture()
+	col := flow.CollectionFromTransactions([]*flow.Transaction{&transaction})
+	guarantee := col.Guarantee()
+	block.SetPayload(unittest.PayloadFixture(unittest.WithGuarantees(&guarantee)))
+	blockId := block.ID()
+	txId := transaction.ID()
+	txIndex := rand.Uint32()
+
+	// Set up the light collection and mock the behavior of the collections object
+	lightCol := col.Light()
+	suite.collections.On("LightByID", col.ID()).Return(&lightCol, nil)
+
+	// Mock the behavior of the blocks and transactionResults objects
+	suite.blocks.
+		On("ByID", blockId).
+		Return(&block, nil)
+
+	suite.transactionResults.On("ByBlockIDTransactionIndex", blockId, txIndex).
+		Return(&flow.LightTransactionResult{
+			TransactionID:   txId,
+			Failed:          true,
+			ComputationUsed: 0,
+		}, nil)
+
+	// Set up the events storage mock
+	totalEvents := 5
+	eventsForTx := unittest.EventsFixture(totalEvents, flow.EventAccountCreated)
+	eventMessages := make([]*entities.Event, totalEvents)
+	for j, event := range eventsForTx {
+		eventMessages[j] = convert.EventToMessage(event)
+	}
+
+	// expect a call to lookup events by block ID and transaction ID
+	suite.events.On("ByBlockIDTransactionIndex", blockId, txIndex).Return(eventsForTx, nil)
+
+	// Set up the state and snapshot mocks
+	_, fixedENIDs := suite.setupReceipts(&block)
+	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
+	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
+	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
+	suite.snapshot.On("Head", mock.Anything).Return(block.Header, nil)
+
+	// Create a mock connection factory
+	connFactory := connectionmock.NewConnectionFactory(suite.T())
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
+	// Set up the backend parameters and the backend instance
+	params := suite.defaultBackendParams()
+	// the connection factory should be used to get the execution node client
+	params.ConnFactory = connFactory
+	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
+	params.TxResultQueryMode = IndexQueryModeLocalOnly
+
+	params.EventsIndex = NewEventsIndex(suite.events)
+	err := params.EventsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err = params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
+	backend, err := New(params)
+	suite.Require().NoError(err)
+
+	// Set up the expected error message for the execution node response
+	exeEventReq := &execproto.GetTransactionErrorMessageByIndexRequest{
+		BlockId: blockId[:],
+		Index:   txIndex,
+	}
+
+	exeEventResp := &execproto.GetTransactionErrorMessageResponse{
+		TransactionId: txId[:],
+		ErrorMessage:  expectedErrorMsg,
+	}
+
+	suite.execClient.On("GetTransactionErrorMessageByIndex", mock.Anything, exeEventReq).Return(exeEventResp, nil).Once()
+
+	response, err := backend.GetTransactionResultByIndex(context.Background(), blockId, txIndex, entities.EventEncodingVersion_JSON_CDC_V0)
+	suite.assertTransactionResultResponse(err, response, block, txId, true, eventsForTx)
+}
+
+// TestTransactionResultsByBlockIDFromStorage tests the retrieval of transaction results ([]flow.TransactionResult)
+// by block ID from storage instead of requesting from the Execution Node.
+func (suite *Suite) TestTransactionResultsByBlockIDFromStorage() {
+	// Create fixtures for the block and collection
+	block := unittest.BlockFixture()
+	col := unittest.CollectionFixture(2)
+	guarantee := col.Guarantee()
+	block.SetPayload(unittest.PayloadFixture(unittest.WithGuarantees(&guarantee)))
+	blockId := block.ID()
+
+	// Mock the behavior of the blocks, collections and light transaction results objects
+	suite.blocks.
+		On("ByID", blockId).
+		Return(&block, nil)
+	lightCol := col.Light()
+	suite.collections.On("LightByID", mock.Anything).Return(&lightCol, nil)
+
+	lightTxResults := make([]flow.LightTransactionResult, len(lightCol.Transactions))
+	for i, txId := range lightCol.Transactions {
+		lightTxResults[i] = flow.LightTransactionResult{
+			TransactionID:   txId,
+			Failed:          false,
+			ComputationUsed: 0,
+		}
+	}
+
+	// Mark the first transaction as failed
+	lightTxResults[0].Failed = true
+	suite.transactionResults.On("ByBlockID", blockId).Return(lightTxResults, nil)
+
+	// Set up the events storage mock
+	totalEvents := 5
+	eventsForTx := unittest.EventsFixture(totalEvents, flow.EventAccountCreated)
+	eventMessages := make([]*entities.Event, totalEvents)
+	for j, event := range eventsForTx {
+		eventMessages[j] = convert.EventToMessage(event)
+	}
+
+	// expect a call to lookup events by block ID and transaction ID
+	suite.events.On("ByBlockIDTransactionID", blockId, mock.Anything).Return(eventsForTx, nil)
+
+	// Set up the state and snapshot mocks
+	_, fixedENIDs := suite.setupReceipts(&block)
+	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
+	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
+	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
+	suite.snapshot.On("Head", mock.Anything).Return(block.Header, nil)
+
+	// create a mock connection factory
+	connFactory := connectionmock.NewConnectionFactory(suite.T())
+	connFactory.On("GetExecutionAPIClient", mock.Anything).Return(suite.execClient, &mockCloser{}, nil)
+
+	// create a mock index reporter
+	reporter := syncmock.NewIndexReporter(suite.T())
+	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
+	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
+
+	// Set up the state and snapshot mocks and the backend instance
+	params := suite.defaultBackendParams()
+	// the connection factory should be used to get the execution node client
+	params.ConnFactory = connFactory
+	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
+
+	params.EventsIndex = NewEventsIndex(suite.events)
+	err := params.EventsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
+	params.TxResultsIndex = NewTransactionResultsIndex(suite.transactionResults)
+	err = params.TxResultsIndex.Initialize(reporter)
+	suite.Require().NoError(err)
+
+	params.TxResultQueryMode = IndexQueryModeLocalOnly
+
+	backend, err := New(params)
+	suite.Require().NoError(err)
+
+	// Set up the expected error message for the execution node response
+	exeEventReq := &execproto.GetTransactionErrorMessagesByBlockIDRequest{
+		BlockId: blockId[:],
+	}
+
+	res := &execproto.GetTransactionErrorMessagesResponse_Result{
+		TransactionId: lightTxResults[0].TransactionID[:],
+		ErrorMessage:  expectedErrorMsg,
+		Index:         1,
+	}
+	exeEventResp := &execproto.GetTransactionErrorMessagesResponse{
+		Results: []*execproto.GetTransactionErrorMessagesResponse_Result{
+			res,
+		},
+	}
+
+	suite.execClient.On("GetTransactionErrorMessagesByBlockID", mock.Anything, exeEventReq).Return(exeEventResp, nil).Once()
+
+	response, err := backend.GetTransactionResultsByBlockID(context.Background(), blockId, entities.EventEncodingVersion_JSON_CDC_V0)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(len(lightTxResults), len(response))
+
+	// Assertions for each transaction result in the response
+	for i, responseResult := range response {
+		lightTx := lightTxResults[i]
+		suite.assertTransactionResultResponse(err, responseResult, block, lightTx.TransactionID, lightTx.Failed, eventsForTx)
+	}
 }

--- a/engine/access/rpc/backend/config.go
+++ b/engine/access/rpc/backend/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	CircuitBreakerConfig      connection.CircuitBreakerConfig // the configuration for circuit breaker
 	ScriptExecutionMode       string                          // the mode in which scripts are executed
 	EventQueryMode            string                          // the mode in which events are queried
+	TxResultQueryMode         string                          // the mode in which tx results are queried
 }
 
 type IndexQueryMode int

--- a/engine/access/rpc/backend/event_index_test.go
+++ b/engine/access/rpc/backend/event_index_test.go
@@ -48,7 +48,7 @@ func TestGetEvents(t *testing.T) {
 	err := eventsIndex.Initialize(&mockIndexReporter{})
 	require.NoError(t, err)
 
-	actualEvents, err := eventsIndex.GetEvents(header.ID(), header.Height)
+	actualEvents, err := eventsIndex.ByBlockID(header.ID(), header.Height)
 	require.NoError(t, err)
 
 	// output events should be in the same order as the expected events

--- a/engine/access/rpc/backend/retry.go
+++ b/engine/access/rpc/backend/retry.go
@@ -121,7 +121,13 @@ func (r *Retry) retryTxsAtHeight(heightToRetry uint64) error {
 		}
 
 		// find the transaction status
-		status, err := r.backend.deriveTransactionStatus(tx, false, block)
+		var status flow.TransactionStatus
+		if block == nil {
+			status, err = r.backend.deriveUnknownTransactionStatus(tx.ReferenceBlockID)
+		} else {
+			status, err = r.backend.deriveTransactionStatus(block.ID(), block.Header.Height, false)
+		}
+
 		if err != nil {
 			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
 				return err

--- a/engine/access/rpc/backend/transaction_results_indexer.go
+++ b/engine/access/rpc/backend/transaction_results_indexer.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"fmt"
-	"sort"
 
 	"go.uber.org/atomic"
 
@@ -12,94 +11,80 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
-var _ state_synchronization.IndexReporter = (*EventsIndex)(nil)
-
-// EventsIndex implements a wrapper around `storage.Events` ensuring that needed data has been synced and is available to the client.
-// Note: `EventsIndex` is created with empty report due to the next reasoning:
+// TransactionResultsIndex implements a wrapper around `storage.LightTransactionResult` ensuring that needed data has been synced and is available to the client.
+// Note: `TransactionResultsIndex` is created with empty report due to the next reasoning:
 // When the index is initially bootstrapped, the indexer needs to load an execution state checkpoint from
 // disk and index all the data. This process can take more than 1 hour on some systems. Consequently, the Initialize
 // pattern is implemented to enable the Access API to start up and serve queries before the index is fully ready. During
 // the initialization phase, all calls to retrieve data from this struct should return indexer.ErrIndexNotInitialized.
 // The caller is responsible for handling this error appropriately for the method.
-type EventsIndex struct {
-	events   storage.Events
+type TransactionResultsIndex struct {
+	results  storage.LightTransactionResults
 	reporter *atomic.Pointer[state_synchronization.IndexReporter]
 }
 
-func NewEventsIndex(events storage.Events) *EventsIndex {
-	return &EventsIndex{
-		events:   events,
+var _ state_synchronization.IndexReporter = (*TransactionResultsIndex)(nil)
+
+func NewTransactionResultsIndex(results storage.LightTransactionResults) *TransactionResultsIndex {
+	return &TransactionResultsIndex{
+		results:  results,
 		reporter: atomic.NewPointer[state_synchronization.IndexReporter](nil),
 	}
 }
 
 // Initialize replaces a previously non-initialized reporter. Can be called once.
 // No errors are expected during normal operations.
-func (e *EventsIndex) Initialize(indexReporter state_synchronization.IndexReporter) error {
-	if e.reporter.CompareAndSwap(nil, &indexReporter) {
+func (t *TransactionResultsIndex) Initialize(indexReporter state_synchronization.IndexReporter) error {
+	if t.reporter.CompareAndSwap(nil, &indexReporter) {
 		return nil
 	}
 	return fmt.Errorf("index reporter already initialized")
 }
 
-// ByBlockID checks data availability and returns events for a block
+// ByBlockID checks data availability and returns all transaction results for a block
 // Expected errors:
-//   - indexer.ErrIndexNotInitialized if the `EventsIndex` has not been initialized
+//   - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
 //   - storage.ErrHeightNotIndexed when data is unavailable
 //   - codes.NotFound if result cannot be provided by storage due to the absence of data.
-func (e *EventsIndex) ByBlockID(blockID flow.Identifier, height uint64) ([]flow.Event, error) {
-	if err := e.checkDataAvailability(height); err != nil {
+func (t *TransactionResultsIndex) ByBlockID(blockID flow.Identifier, height uint64) ([]flow.LightTransactionResult, error) {
+	if err := t.checkDataAvailability(height); err != nil {
 		return nil, err
 	}
 
-	events, err := e.events.ByBlockID(blockID)
-	if err != nil {
-		return nil, err
-	}
-
-	// events are keyed/sorted by [blockID, txID, txIndex, eventIndex]
-	// we need to resort them by tx index then event index so the output is in execution order
-	sort.Slice(events, func(i, j int) bool {
-		if events[i].TransactionIndex == events[j].TransactionIndex {
-			return events[i].EventIndex < events[j].EventIndex
-		}
-		return events[i].TransactionIndex < events[j].TransactionIndex
-	})
-
-	return events, nil
+	return t.results.ByBlockID(blockID)
 }
 
-// ByBlockIDTransactionID checks data availability and return events for the given block ID and transaction ID
+// ByBlockIDTransactionID checks data availability and return the transaction result for the given block ID and transaction ID
 // Expected errors:
-//   - indexer.ErrIndexNotInitialized if the `EventsIndex` has not been initialized
+//   - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
 //   - storage.ErrHeightNotIndexed when data is unavailable
 //   - codes.NotFound if result cannot be provided by storage due to the absence of data.
-func (e *EventsIndex) ByBlockIDTransactionID(blockID flow.Identifier, height uint64, transactionID flow.Identifier) ([]flow.Event, error) {
-	if err := e.checkDataAvailability(height); err != nil {
+func (t *TransactionResultsIndex) ByBlockIDTransactionID(blockID flow.Identifier, height uint64, txID flow.Identifier) (*flow.LightTransactionResult, error) {
+	if err := t.checkDataAvailability(height); err != nil {
 		return nil, err
 	}
 
-	return e.events.ByBlockIDTransactionID(blockID, transactionID)
+	return t.results.ByBlockIDTransactionID(blockID, txID)
 }
 
-// ByBlockIDTransactionIndex checks data availability and return events for the transaction at given index in a given block
+// ByBlockIDTransactionIndex checks data availability and return the transaction result for the given blockID and transaction index
 // Expected errors:
-//   - indexer.ErrIndexNotInitialized if the `EventsIndex` has not been initialized
+//   - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
 //   - storage.ErrHeightNotIndexed when data is unavailable
-//   - codes.NotFound if result cannot be provided by storage due to the absence of data.
-func (e *EventsIndex) ByBlockIDTransactionIndex(blockID flow.Identifier, height uint64, txIndex uint32) ([]flow.Event, error) {
-	if err := e.checkDataAvailability(height); err != nil {
+//   - codes.NotFound when result cannot be provided by storage due to the absence of data.
+func (t *TransactionResultsIndex) ByBlockIDTransactionIndex(blockID flow.Identifier, height uint64, index uint32) (*flow.LightTransactionResult, error) {
+	if err := t.checkDataAvailability(height); err != nil {
 		return nil, err
 	}
 
-	return e.events.ByBlockIDTransactionIndex(blockID, txIndex)
+	return t.results.ByBlockIDTransactionIndex(blockID, index)
 }
 
 // LowestIndexedHeight returns the lowest height indexed by the execution state indexer.
 // Expected errors:
-// - indexer.ErrIndexNotInitialized if the EventsIndex has not been initialized
-func (e *EventsIndex) LowestIndexedHeight() (uint64, error) {
-	reporter, err := e.getReporter()
+// - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
+func (t *TransactionResultsIndex) LowestIndexedHeight() (uint64, error) {
+	reporter, err := t.getReporter()
 	if err != nil {
 		return 0, err
 	}
@@ -109,9 +94,9 @@ func (e *EventsIndex) LowestIndexedHeight() (uint64, error) {
 
 // HighestIndexedHeight returns the highest height indexed by the execution state indexer.
 // Expected errors:
-// - indexer.ErrIndexNotInitialized if the EventsIndex has not been initialized
-func (e *EventsIndex) HighestIndexedHeight() (uint64, error) {
-	reporter, err := e.getReporter()
+// - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
+func (t *TransactionResultsIndex) HighestIndexedHeight() (uint64, error) {
+	reporter, err := t.getReporter()
 	if err != nil {
 		return 0, err
 	}
@@ -124,9 +109,9 @@ func (e *EventsIndex) HighestIndexedHeight() (uint64, error) {
 // Expected errors:
 //   - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
 //   - storage.ErrHeightNotIndexed if the block at the provided height is not indexed yet
-//   - fmt.Errorf with custom message if the highest or lowest indexed heights cannot be retrieved from the reporter
-func (e *EventsIndex) checkDataAvailability(height uint64) error {
-	reporter, err := e.getReporter()
+//   - fmt.Errorf if the highest or lowest indexed heights cannot be retrieved from the reporter
+func (t *TransactionResultsIndex) checkDataAvailability(height uint64) error {
+	reporter, err := t.getReporter()
 	if err != nil {
 		return err
 	}
@@ -153,8 +138,8 @@ func (e *EventsIndex) checkDataAvailability(height uint64) error {
 // getReporter retrieves the current index reporter instance from the atomic pointer.
 // Expected errors:
 //   - indexer.ErrIndexNotInitialized if the reporter is not initialized
-func (e *EventsIndex) getReporter() (state_synchronization.IndexReporter, error) {
-	reporter := e.reporter.Load()
+func (t *TransactionResultsIndex) getReporter() (state_synchronization.IndexReporter, error) {
+	reporter := t.reporter.Load()
 	if reporter == nil {
 		return nil, indexer.ErrIndexNotInitialized
 	}

--- a/engine/access/rpc/backend/transactions_local_data_provider.go
+++ b/engine/access/rpc/backend/transactions_local_data_provider.go
@@ -1,0 +1,390 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/status"
+
+	"github.com/onflow/flow/protobuf/go/flow/entities"
+	"google.golang.org/grpc/codes"
+
+	"github.com/onflow/flow-go/access"
+	"github.com/onflow/flow-go/engine/common/rpc"
+	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/state"
+	"github.com/onflow/flow-go/state/protocol"
+	"github.com/onflow/flow-go/storage"
+)
+
+// TransactionErrorMessage declares the lookup transaction error methods by different input parameters.
+type TransactionErrorMessage interface {
+	// LookupErrorMessageByTransactionID is a function type for getting transaction error message by block ID and transaction ID.
+	// Expected errors during normal operation:
+	//   - InsufficientExecutionReceipts - found insufficient receipts for given block ID.
+	//   - status.Error - remote GRPC call to EN has failed.
+	LookupErrorMessageByTransactionID(ctx context.Context, blockID flow.Identifier, transactionID flow.Identifier) (string, error)
+
+	// LookupErrorMessageByIndex is a function type for getting transaction error message by index.
+	// Expected errors during normal operation:
+	//   - status.Error[codes.NotFound] - transaction result for given block ID and tx index is not available.
+	//   - InsufficientExecutionReceipts - found insufficient receipts for given block ID.
+	//   - status.Error - remote GRPC call to EN has failed.
+	LookupErrorMessageByIndex(ctx context.Context, blockID flow.Identifier, height uint64, index uint32) (string, error)
+
+	// LookupErrorMessagesByBlockID is a function type for getting transaction error messages by block ID.
+	// Expected errors during normal operation:
+	//   - status.Error[codes.NotFound] - transaction results for given block ID are not available.
+	//   - InsufficientExecutionReceipts - found insufficient receipts for given block ID.
+	//   - status.Error - remote GRPC call to EN has failed.
+	LookupErrorMessagesByBlockID(ctx context.Context, blockID flow.Identifier, height uint64) (map[flow.Identifier]string, error)
+}
+
+// TransactionsLocalDataProvider provides functionality for retrieving transaction results and error messages from local storages
+type TransactionsLocalDataProvider struct {
+	state           protocol.State
+	collections     storage.Collections
+	blocks          storage.Blocks
+	eventsIndex     *EventsIndex
+	txResultsIndex  *TransactionResultsIndex
+	txErrorMessages TransactionErrorMessage
+}
+
+// GetTransactionResultFromStorage retrieves a transaction result from storage by block ID and transaction ID.
+// Expected errors during normal operation:
+//   - codes.NotFound when result cannot be provided by storage due to the absence of data.
+//   - codes.Internal if event payload conversion failed.
+//   - indexer.ErrIndexNotInitialized when txResultsIndex not initialized
+//   - storage.ErrHeightNotIndexed when data is unavailable
+//
+// All other errors are considered as state corruption (fatal) or internal errors in the transaction error message
+// getter or when deriving transaction status.
+func (t *TransactionsLocalDataProvider) GetTransactionResultFromStorage(
+	ctx context.Context,
+	block *flow.Block,
+	transactionID flow.Identifier,
+	requiredEventEncodingVersion entities.EventEncodingVersion,
+) (*access.TransactionResult, error) {
+	blockID := block.ID()
+	txResult, err := t.txResultsIndex.ByBlockIDTransactionID(blockID, block.Header.Height, transactionID)
+	if err != nil {
+		return nil, rpc.ConvertIndexError(err, block.Header.Height, "failed to get transaction result")
+	}
+
+	var txErrorMessage string
+	var txStatusCode uint = 0
+	if txResult.Failed {
+		txErrorMessage, err = t.txErrorMessages.LookupErrorMessageByTransactionID(ctx, blockID, transactionID)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(txErrorMessage) == 0 {
+			return nil, status.Errorf(codes.Internal, "transaction failed but error message is empty for tx ID: %s block ID: %s", txResult.TransactionID, blockID)
+		}
+
+		txStatusCode = 1 // statusCode of 1 indicates an error and 0 indicates no error, the same as on EN
+	}
+
+	txStatus, err := t.deriveTransactionStatus(blockID, block.Header.Height, true)
+	if err != nil {
+		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
+			irrecoverable.Throw(ctx, err)
+		}
+		return nil, rpc.ConvertStorageError(err)
+	}
+
+	events, err := t.eventsIndex.ByBlockIDTransactionID(blockID, block.Header.Height, transactionID)
+	if err != nil {
+		return nil, rpc.ConvertIndexError(err, block.Header.Height, "failed to get events")
+	}
+
+	// events are encoded in CCF format in storage. convert to JSON-CDC if requested
+	if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
+		for _, e := range events {
+			payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
+			if err != nil {
+				err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
+				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
+			}
+			e.Payload = payload
+		}
+	}
+
+	return &access.TransactionResult{
+		TransactionID: txResult.TransactionID,
+		Status:        txStatus,
+		StatusCode:    txStatusCode,
+		Events:        events,
+		ErrorMessage:  txErrorMessage,
+		BlockID:       blockID,
+		BlockHeight:   block.Header.Height,
+	}, nil
+}
+
+// GetTransactionResultsByBlockIDFromStorage retrieves transaction results by block ID from storage
+// Expected errors during normal operation:
+//   - codes.NotFound if result cannot be provided by storage due to the absence of data.
+//   - codes.Internal when event payload conversion failed.
+//   - indexer.ErrIndexNotInitialized when txResultsIndex not initialized
+//   - storage.ErrHeightNotIndexed when data is unavailable
+//
+// All other errors are considered as state corruption (fatal) or internal errors in the transaction error message
+// getter or when deriving transaction status.
+func (t *TransactionsLocalDataProvider) GetTransactionResultsByBlockIDFromStorage(
+	ctx context.Context,
+	block *flow.Block,
+	requiredEventEncodingVersion entities.EventEncodingVersion,
+) ([]*access.TransactionResult, error) {
+	blockID := block.ID()
+	txResults, err := t.txResultsIndex.ByBlockID(blockID, block.Header.Height)
+	if err != nil {
+		return nil, rpc.ConvertIndexError(err, block.Header.Height, "failed to get transaction result")
+	}
+
+	txErrors, err := t.txErrorMessages.LookupErrorMessagesByBlockID(ctx, blockID, block.Header.Height)
+	if err != nil {
+		return nil, err
+	}
+
+	numberOfTxResults := len(txResults)
+	results := make([]*access.TransactionResult, 0, numberOfTxResults)
+
+	for _, txResult := range txResults {
+		txID := txResult.TransactionID
+
+		var txErrorMessage string
+		var txStatusCode uint = 0
+		if txResult.Failed {
+			txErrorMessage = txErrors[txResult.TransactionID]
+			if len(txErrorMessage) == 0 {
+				return nil, status.Errorf(codes.Internal, "transaction failed but error message is empty for tx ID: %s block ID: %s", txID, blockID)
+			}
+			txStatusCode = 1
+		}
+
+		txStatus, err := t.deriveTransactionStatus(blockID, block.Header.Height, true)
+		if err != nil {
+			if !errors.Is(err, state.ErrUnknownSnapshotReference) {
+				irrecoverable.Throw(ctx, err)
+			}
+			return nil, rpc.ConvertStorageError(err)
+		}
+
+		events, err := t.eventsIndex.ByBlockIDTransactionID(blockID, block.Header.Height, txResult.TransactionID)
+		if err != nil {
+			return nil, rpc.ConvertIndexError(err, block.Header.Height, "failed to get events")
+		}
+
+		// events are encoded in CCF format in storage. convert to JSON-CDC if requested
+		if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
+			for _, e := range events {
+				payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
+				if err != nil {
+					err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
+					return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
+				}
+				e.Payload = payload
+			}
+		}
+
+		collectionID, err := t.lookupCollectionIDInBlock(block, txID)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, &access.TransactionResult{
+			Status:        txStatus,
+			StatusCode:    txStatusCode,
+			Events:        events,
+			ErrorMessage:  txErrorMessage,
+			BlockID:       blockID,
+			TransactionID: txID,
+			CollectionID:  collectionID,
+			BlockHeight:   block.Header.Height,
+		})
+	}
+
+	return results, nil
+}
+
+// GetTransactionResultByIndexFromStorage retrieves a transaction result by index from storage.
+// Expected errors during normal operation:
+//   - codes.NotFound if result cannot be provided by storage due to the absence of data.
+//   - codes.Internal when event payload conversion failed.
+//   - indexer.ErrIndexNotInitialized when txResultsIndex not initialized
+//   - storage.ErrHeightNotIndexed when data is unavailable
+//
+// All other errors are considered as state corruption (fatal) or internal errors in the transaction error message
+// getter or when deriving transaction status.
+func (t *TransactionsLocalDataProvider) GetTransactionResultByIndexFromStorage(
+	ctx context.Context,
+	block *flow.Block,
+	index uint32,
+	requiredEventEncodingVersion entities.EventEncodingVersion,
+) (*access.TransactionResult, error) {
+	blockID := block.ID()
+	txResult, err := t.txResultsIndex.ByBlockIDTransactionIndex(blockID, block.Header.Height, index)
+	if err != nil {
+		return nil, rpc.ConvertIndexError(err, block.Header.Height, "failed to get transaction result")
+	}
+
+	var txErrorMessage string
+	var txStatusCode uint = 0
+	if txResult.Failed {
+		txErrorMessage, err = t.txErrorMessages.LookupErrorMessageByIndex(ctx, blockID, block.Header.Height, index)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(txErrorMessage) == 0 {
+			return nil, status.Errorf(codes.Internal, "transaction failed but error message is empty for tx ID: %s block ID: %s", txResult.TransactionID, blockID)
+		}
+
+		txStatusCode = 1 // statusCode of 1 indicates an error and 0 indicates no error, the same as on EN
+	}
+
+	txStatus, err := t.deriveTransactionStatus(blockID, block.Header.Height, true)
+	if err != nil {
+		if !errors.Is(err, state.ErrUnknownSnapshotReference) {
+			irrecoverable.Throw(ctx, err)
+		}
+		return nil, rpc.ConvertStorageError(err)
+	}
+
+	events, err := t.eventsIndex.ByBlockIDTransactionIndex(blockID, block.Header.Height, index)
+	if err != nil {
+		return nil, rpc.ConvertIndexError(err, block.Header.Height, "failed to get events")
+	}
+
+	// events are encoded in CCF format in storage. convert to JSON-CDC if requested
+	if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
+		for _, e := range events {
+			payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
+			if err != nil {
+				err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
+				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
+			}
+			e.Payload = payload
+		}
+	}
+
+	collectionID, err := t.lookupCollectionIDInBlock(block, txResult.TransactionID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &access.TransactionResult{
+		TransactionID: txResult.TransactionID,
+		Status:        txStatus,
+		StatusCode:    txStatusCode,
+		Events:        events,
+		ErrorMessage:  txErrorMessage,
+		BlockID:       blockID,
+		BlockHeight:   block.Header.Height,
+		CollectionID:  collectionID,
+	}, nil
+}
+
+// deriveUnknownTransactionStatus is used to determine the status of transaction
+// that are not in a block yet based on the provided reference block ID.
+func (t *TransactionsLocalDataProvider) deriveUnknownTransactionStatus(refBlockID flow.Identifier) (flow.TransactionStatus, error) {
+	referenceBlock, err := t.state.AtBlockID(refBlockID).Head()
+	if err != nil {
+		return flow.TransactionStatusUnknown, err
+	}
+	refHeight := referenceBlock.Height
+	// get the latest finalized block from the state
+	finalized, err := t.state.Final().Head()
+	if err != nil {
+		return flow.TransactionStatusUnknown, irrecoverable.NewExceptionf("failed to lookup final header: %w", err)
+	}
+	finalizedHeight := finalized.Height
+
+	// if we haven't seen the expiry block for this transaction, it's not expired
+	if !isExpired(refHeight, finalizedHeight) {
+		return flow.TransactionStatusPending, nil
+	}
+
+	// At this point, we have seen the expiry block for the transaction.
+	// This means that, if no collections  prior to the expiry block contain
+	// the transaction, it can never be included and is expired.
+	//
+	// To ensure this, we need to have received all collections  up to the
+	// expiry block to ensure the transaction did not appear in any.
+
+	// the last full height is the height where we have received all
+	// collections  for all blocks with a lower height
+	fullHeight, err := t.blocks.GetLastFullBlockHeight()
+	if err != nil {
+		return flow.TransactionStatusUnknown, err
+	}
+
+	// if we have received collections  for all blocks up to the expiry block, the transaction is expired
+	if isExpired(refHeight, fullHeight) {
+		return flow.TransactionStatusExpired, nil
+	}
+
+	// tx found in transaction storage and collection storage but not in block storage
+	// However, this will not happen as of now since the ingestion engine doesn't subscribe
+	// for collections
+	return flow.TransactionStatusPending, nil
+}
+
+// deriveTransactionStatus is used to determine the status of a transaction based on the provided block ID, block height, and execution status.
+// No errors expected during normal operations.
+func (t *TransactionsLocalDataProvider) deriveTransactionStatus(blockID flow.Identifier, blockHeight uint64, executed bool) (flow.TransactionStatus, error) {
+	if !executed {
+		// If we've gotten here, but the block has not yet been executed, report it as only been finalized
+		return flow.TransactionStatusFinalized, nil
+	}
+
+	// From this point on, we know for sure this transaction has at least been executed
+
+	// get the latest sealed block from the State
+	sealed, err := t.state.Sealed().Head()
+	if err != nil {
+		return flow.TransactionStatusUnknown, irrecoverable.NewExceptionf("failed to lookup sealed header: %w", err)
+	}
+
+	if blockHeight > sealed.Height {
+		// The block is not yet sealed, so we'll report it as only executed
+		return flow.TransactionStatusExecuted, nil
+	}
+
+	// otherwise, this block has been executed, and sealed, so report as sealed
+	return flow.TransactionStatusSealed, nil
+}
+
+// isExpired checks whether a transaction is expired given the height of the
+// transaction's reference block and the height to compare against.
+func isExpired(refHeight, compareToHeight uint64) bool {
+	if compareToHeight <= refHeight {
+		return false
+	}
+	return compareToHeight-refHeight > flow.DefaultTransactionExpiry
+}
+
+// lookupCollectionIDInBlock returns the collection ID based on the transaction ID. The lookup is performed in block
+// collections.
+func (t *TransactionsLocalDataProvider) lookupCollectionIDInBlock(
+	block *flow.Block,
+	txID flow.Identifier,
+) (flow.Identifier, error) {
+	for _, guarantee := range block.Payload.Guarantees {
+		collection, err := t.collections.LightByID(guarantee.ID())
+		if err != nil {
+			return flow.ZeroID, err
+		}
+
+		for _, collectionTxID := range collection.Transactions {
+			if collectionTxID == txID {
+				return collection.ID(), nil
+			}
+		}
+	}
+	return flow.ZeroID, status.Error(codes.NotFound, "transaction not found in block")
+}

--- a/engine/access/rpc/backend/transactions_local_data_provider.go
+++ b/engine/access/rpc/backend/transactions_local_data_provider.go
@@ -51,6 +51,7 @@ type TransactionsLocalDataProvider struct {
 	eventsIndex     *EventsIndex
 	txResultsIndex  *TransactionResultsIndex
 	txErrorMessages TransactionErrorMessage
+	systemTxID      flow.Identifier
 }
 
 // GetTransactionResultFromStorage retrieves a transaction result from storage by block ID and transaction ID.
@@ -153,6 +154,17 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultsByBlockIDFromStorag
 	numberOfTxResults := len(txResults)
 	results := make([]*access.TransactionResult, 0, numberOfTxResults)
 
+	// cache the tx to collectionID mapping to avoid repeated lookups
+	txToCollectionID, err := t.buildTxIDToCollectionIDMapping(block)
+	if err != nil {
+		// this indicates that one or more of the collections for the block are not indexed. Since
+		// lookups are gated on the indexer signaling it has finished processing all data for the
+		// block, all data must be available in storage, otherwise there is an inconsistency in the
+		// state.
+		irrecoverable.Throw(ctx, fmt.Errorf("inconsistent index state: %w", err))
+		return nil, status.Errorf(codes.Internal, "failed to map tx to collection ID: %v", err)
+	}
+
 	for _, txResult := range txResults {
 		txID := txResult.TransactionID
 
@@ -191,9 +203,9 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultsByBlockIDFromStorag
 			}
 		}
 
-		collectionID, err := t.lookupCollectionIDInBlock(block, txID)
-		if err != nil {
-			return nil, err
+		collectionID, ok := txToCollectionID[txID]
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "transaction %s not found in block %s", txID, blockID)
 		}
 
 		results = append(results, &access.TransactionResult{
@@ -382,9 +394,29 @@ func (t *TransactionsLocalDataProvider) lookupCollectionIDInBlock(
 
 		for _, collectionTxID := range collection.Transactions {
 			if collectionTxID == txID {
-				return collection.ID(), nil
+				return guarantee.ID(), nil
 			}
 		}
 	}
 	return flow.ZeroID, status.Error(codes.NotFound, "transaction not found in block")
+}
+
+// buildTxIDToCollectionIDMapping returns a map of transaction ID to collection ID based on the provided block.
+// No errors expected during normal operations.
+func (t *TransactionsLocalDataProvider) buildTxIDToCollectionIDMapping(block *flow.Block) (map[flow.Identifier]flow.Identifier, error) {
+	txToCollectionID := make(map[flow.Identifier]flow.Identifier)
+	for _, guarantee := range block.Payload.Guarantees {
+		collection, err := t.collections.LightByID(guarantee.ID())
+		if err != nil {
+			// if the tx result is in storage, the collection must be too.
+			return nil, fmt.Errorf("failed to get collection %s in indexed block: %w", guarantee.ID(), err)
+		}
+		for _, txID := range collection.Transactions {
+			txToCollectionID[txID] = guarantee.ID()
+		}
+	}
+
+	txToCollectionID[t.systemTxID] = flow.ZeroID
+
+	return txToCollectionID, nil
 }

--- a/engine/access/rpc/backend/transactions_local_data_provider.go
+++ b/engine/access/rpc/backend/transactions_local_data_provider.go
@@ -105,13 +105,9 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultFromStorage(
 
 	// events are encoded in CCF format in storage. convert to JSON-CDC if requested
 	if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
-		for _, e := range events {
-			payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
-			if err != nil {
-				err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
-				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
-			}
-			e.Payload = payload
+		events, err = convert.CcfEventsToJsonEvents(events)
+		if err != nil {
+			return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
 		}
 	}
 
@@ -193,13 +189,9 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultsByBlockIDFromStorag
 
 		// events are encoded in CCF format in storage. convert to JSON-CDC if requested
 		if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
-			for _, e := range events {
-				payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
-				if err != nil {
-					err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
-					return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
-				}
-				e.Payload = payload
+			events, err = convert.CcfEventsToJsonEvents(events)
+			if err != nil {
+				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
 			}
 		}
 
@@ -274,13 +266,9 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultByIndexFromStorage(
 
 	// events are encoded in CCF format in storage. convert to JSON-CDC if requested
 	if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
-		for _, e := range events {
-			payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
-			if err != nil {
-				err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
-				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
-			}
-			e.Payload = payload
+		events, err = convert.CcfEventsToJsonEvents(events)
+		if err != nil {
+			return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
 		}
 	}
 

--- a/engine/access/state_stream/backend/backend_events.go
+++ b/engine/access/state_stream/backend/backend_events.go
@@ -96,7 +96,7 @@ func (b *EventsBackend) getEventsFromStorage(height uint64, filter state_stream.
 		return nil, fmt.Errorf("could not get header for height %d: %w", height, err)
 	}
 
-	events, err := b.eventsIndex.GetEvents(blockID, height)
+	events, err := b.eventsIndex.ByBlockID(blockID, height)
 	if err != nil {
 		return nil, fmt.Errorf("could not get events for block %d: %w", height, err)
 	}

--- a/engine/common/rpc/convert/events.go
+++ b/engine/common/rpc/convert/events.go
@@ -241,6 +241,20 @@ func CcfEventToJsonEvent(e flow.Event) (*flow.Event, error) {
 	}, nil
 }
 
+// CcfEventsToJsonEvents returns a new event with the payload converted from CCF to JSON
+func CcfEventsToJsonEvents(events []flow.Event) ([]flow.Event, error) {
+	convertedEvents := make([]flow.Event, len(events))
+	for i, e := range events {
+		payload, err := CcfPayloadToJsonPayload(e.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert event payload for event %d: %w", i, err)
+		}
+		e.Payload = payload
+		convertedEvents[i] = e
+	}
+	return convertedEvents, nil
+}
+
 // MessagesToBlockEvents converts a protobuf EventsResponse_Result messages to a slice of flow.BlockEvents.
 func MessagesToBlockEvents(blocksEvents []*accessproto.EventsResponse_Result) []flow.BlockEvents {
 	evs := make([]flow.BlockEvents, len(blocksEvents))

--- a/engine/common/rpc/errors.go
+++ b/engine/common/rpc/errors.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/onflow/flow-go/module/state_synchronization/indexer"
 	"github.com/onflow/flow-go/storage"
 )
 
@@ -64,6 +65,29 @@ func ConvertStorageError(err error) error {
 	}
 
 	return status.Errorf(codes.Internal, "failed to find: %v", err)
+}
+
+// ConvertIndexError converts errors related to index and storage to appropriate gRPC status errors.
+// If the error is nil, it returns nil. If the error is not recognized, it falls back to ConvertError
+// with the provided default message and Internal gRPC code.
+func ConvertIndexError(err error, height uint64, defaultMsg string) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, indexer.ErrIndexNotInitialized) {
+		return status.Errorf(codes.FailedPrecondition, "data for block is not available: %v", err)
+	}
+
+	if errors.Is(err, storage.ErrHeightNotIndexed) {
+		return status.Errorf(codes.OutOfRange, "data for block height %d is not available", height)
+	}
+
+	if errors.Is(err, storage.ErrNotFound) {
+		return status.Errorf(codes.NotFound, "data not found: %v", err)
+	}
+
+	return ConvertError(err, defaultMsg, codes.Internal)
 }
 
 // ConvertMultiError converts a multierror to a grpc status error.

--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -434,6 +434,7 @@ func prepareAccessService(container testnet.ContainerConfig, i int, n int) Servi
 		"--execution-state-dir=/data/execution-state",
 		"--script-execution-mode=execution-nodes-only",
 		"--event-query-mode=execution-nodes-only",
+		"--tx-result-query-mode=execution-nodes-only",
 	)
 
 	service.AddExposedPorts(

--- a/integration/tests/access/cohort1/access_api_test.go
+++ b/integration/tests/access/cohort1/access_api_test.go
@@ -73,6 +73,7 @@ func (s *AccessAPISuite) SetupTest() {
 		testnet.WithLogLevel(zerolog.FatalLevel),
 		// make sure test continues to test as expected if the default config changes
 		testnet.WithAdditionalFlagf("--script-execution-mode=%s", backend.IndexQueryModeExecutionNodesOnly),
+		testnet.WithAdditionalFlagf("--tx-result-query-mode=%s", backend.IndexQueryModeExecutionNodesOnly),
 	)
 
 	indexingAccessConfig := testnet.NewNodeConfig(


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/5306, https://github.com/onflow/flow-go/pull/5532

This PR backports 2 PRs that implemented local data support in the transaction results API endpoints. The new functionality is gated by a new CLI flag `--tx-result-query-mode` which defaults to the existing behavior.