### PR TITLE
Add the `EVM.latestBlockNumber()` method to expose the latest executed block number

### DIFF
--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -449,4 +449,10 @@ contract EVM {
         	problem: nil
         )
     }
+
+    /// Returns the number of the latest executed block.
+    access(all)
+    view fun latestBlockNumber(): UInt64 {
+        return InternalEVM.latestBlockNumber()
+    }
 }

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -1744,6 +1744,28 @@ func newInternalEVMTypeCastToFLOWFunction(
 	)
 }
 
+const internalEVMTypeLatestBlockNumberFunctionName = "latestBlockNumber"
+
+var internalEVMTypeLatestBlockNumberFunctionType = &sema.FunctionType{
+	Purity:               sema.FunctionPurityView,
+	Parameters:           []sema.Parameter{},
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
+}
+
+func newInternalEVMTypeLatestBlockNumberFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewHostFunctionValue(
+		gauge,
+		internalEVMTypeCallFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			height := handler.LastExecutedBlock().Height
+			return interpreter.UInt64Value(height)
+		},
+	)
+}
+
 func NewInternalEVMContractValue(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
@@ -1769,6 +1791,7 @@ func NewInternalEVMContractValue(
 			internalEVMTypeDecodeABIFunctionName:                 newInternalEVMTypeDecodeABIFunction(gauge, location),
 			internalEVMTypeCastToAttoFLOWFunctionName:            newInternalEVMTypeCastToAttoFLOWFunction(gauge),
 			internalEVMTypeCastToFLOWFunctionName:                newInternalEVMTypeCastToFLOWFunction(gauge),
+			internalEVMTypeLatestBlockNumberFunctionName:         newInternalEVMTypeLatestBlockNumberFunction(gauge, handler),
 		},
 		nil,
 		nil,
@@ -1867,6 +1890,12 @@ var InternalEVMContractType = func() *sema.CompositeType {
 			ty,
 			internalEVMTypeDecodeABIFunctionName,
 			internalEVMTypeDecodeABIFunctionType,
+			"",
+		),
+		sema.NewUnmeteredPublicFunctionMember(
+			ty,
+			internalEVMTypeLatestBlockNumberFunctionName,
+			internalEVMTypeLatestBlockNumberFunctionType,
 			"",
 		),
 	})


### PR DESCRIPTION
The usage is as follows:
```cadence
import EVM from 0x1

access(all)
fun main(): UInt64 {
    return EVM.latestBlockNumber()
}
```

The function name is debatable, I am open to suggestions.