### PR TITLE
Remove unneeded code copyright notices

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Flow-go
-Copyright 2019-2020 Dapper Labs, Inc.
+Copyright 2019-2024 Flow Foundation.
 
-This product includes software developed at Dapper Labs, Inc. (https://www.dapperlabs.com/). 
+This product includes software developed at Flow Foundation (https://flow.com/flow-foundation).
 

--- a/consensus/hotstuff/committees/metrics_wrapper.go
+++ b/consensus/hotstuff/committees/metrics_wrapper.go
@@ -1,4 +1,3 @@
-// (c) 2020 Dapper Labs - ALL RIGHTS RESERVED
 package committees
 
 import (

--- a/engine/access/ingestion/engine.go
+++ b/engine/access/ingestion/engine.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package ingestion
 
 import (

--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package compliance
 
 import (

--- a/engine/collection/synchronization/engine.go
+++ b/engine/collection/synchronization/engine.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package synchronization
 
 import (

--- a/engine/common/synchronization/engine.go
+++ b/engine/common/synchronization/engine.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package synchronization
 
 import (

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package compliance
 
 import (

--- a/engine/consensus/ingestion/core.go
+++ b/engine/consensus/ingestion/core.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package ingestion
 
 import (

--- a/engine/consensus/ingestion/core_test.go
+++ b/engine/consensus/ingestion/core_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package ingestion
 
 import (

--- a/engine/consensus/ingestion/engine.go
+++ b/engine/consensus/ingestion/engine.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package ingestion
 
 import (

--- a/engine/consensus/ingestion/engine_test.go
+++ b/engine/consensus/ingestion/engine_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package ingestion
 
 import (

--- a/engine/unit.go
+++ b/engine/unit.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package engine
 
 import (

--- a/model/chainsync/range.go
+++ b/model/chainsync/range.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package chainsync
 
 import "github.com/onflow/flow-go/model/flow"

--- a/model/flow/account.go
+++ b/model/flow/account.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import (

--- a/model/flow/address.go
+++ b/model/flow/address.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import (

--- a/model/flow/block.go
+++ b/model/flow/block.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import (

--- a/model/flow/collectionGuarantee.go
+++ b/model/flow/collectionGuarantee.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import (

--- a/model/flow/event.go
+++ b/model/flow/event.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import (

--- a/model/flow/identifier.go
+++ b/model/flow/identifier.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import (

--- a/model/flow/identity_order.go
+++ b/model/flow/identity_order.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 // Canonical is a function that defines a weak strict ordering "<" for identities.

--- a/model/flow/role.go
+++ b/model/flow/role.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import (

--- a/model/flow/seal.go
+++ b/model/flow/seal.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package flow
 
 import "encoding/json"

--- a/model/flow/transaction_result.go
+++ b/model/flow/transaction_result.go
@@ -1,4 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
 package flow
 
 import (

--- a/model/libp2p/peer/filters.go
+++ b/model/libp2p/peer/filters.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package peer
 
 import (

--- a/module/builder/consensus/config.go
+++ b/module/builder/consensus/config.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package consensus
 
 import (

--- a/module/finalizer.go
+++ b/module/finalizer.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package module
 
 import (

--- a/module/finalizer/consensus/finalizer.go
+++ b/module/finalizer/consensus/finalizer.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package consensus
 
 import (

--- a/module/local.go
+++ b/module/local.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package module
 
 import (

--- a/module/local/me.go
+++ b/module/local/me.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package local
 
 import (

--- a/module/mempool/assignments.go
+++ b/module/mempool/assignments.go
@@ -1,4 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
 package mempool
 
 import (

--- a/module/mempool/blocks.go
+++ b/module/mempool/blocks.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/mempool/chunk_data_packs.go
+++ b/module/mempool/chunk_data_packs.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/mempool/collections.go
+++ b/module/mempool/collections.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/mempool/execution_tree.go
+++ b/module/mempool/execution_tree.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/mempool/guarantees.go
+++ b/module/mempool/guarantees.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/mempool/incorporated_result_seals.go
+++ b/module/mempool/incorporated_result_seals.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/mempool/stdmap/backend.go
+++ b/module/mempool/stdmap/backend.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/backend_test.go
+++ b/module/mempool/stdmap/backend_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap_test
 
 import (

--- a/module/mempool/stdmap/blockbycollections.go
+++ b/module/mempool/stdmap/blockbycollections.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/blocks.go
+++ b/module/mempool/stdmap/blocks.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/chunk_data_packs.go
+++ b/module/mempool/stdmap/chunk_data_packs.go
@@ -1,4 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
 package stdmap
 
 import (

--- a/module/mempool/stdmap/collections.go
+++ b/module/mempool/stdmap/collections.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/eject.go
+++ b/module/mempool/stdmap/eject.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/guarantees.go
+++ b/module/mempool/stdmap/guarantees.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/guarantees_test.go
+++ b/module/mempool/stdmap/guarantees_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap_test
 
 import (

--- a/module/mempool/stdmap/options.go
+++ b/module/mempool/stdmap/options.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/receipts.go
+++ b/module/mempool/stdmap/receipts.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/receipts_test.go
+++ b/module/mempool/stdmap/receipts_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap_test
 
 import (

--- a/module/mempool/stdmap/times.go
+++ b/module/mempool/stdmap/times.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/times_test.go
+++ b/module/mempool/stdmap/times_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap_test
 
 import (

--- a/module/mempool/stdmap/transaction_timings.go
+++ b/module/mempool/stdmap/transaction_timings.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/transaction_timings_test.go
+++ b/module/mempool/stdmap/transaction_timings_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap_test
 
 import (

--- a/module/mempool/stdmap/transactions.go
+++ b/module/mempool/stdmap/transactions.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap
 
 import (

--- a/module/mempool/stdmap/transactions_test.go
+++ b/module/mempool/stdmap/transactions_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package stdmap_test
 
 import (

--- a/module/mempool/transaction_timings.go
+++ b/module/mempool/transaction_timings.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/mempool/transactions.go
+++ b/module/mempool/transactions.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package mempool
 
 import (

--- a/module/synchronization.go
+++ b/module/synchronization.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package module
 
 import (

--- a/network/channels/channels.go
+++ b/network/channels/channels.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package channels
 
 import (

--- a/network/codec.go
+++ b/network/codec.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package network
 
 import (

--- a/network/codec/cbor/codec.go
+++ b/network/codec/cbor/codec.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package cbor
 
 import (

--- a/network/codec/cbor/decoder.go
+++ b/network/codec/cbor/decoder.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package cbor
 
 import (

--- a/network/codec/cbor/encoder.go
+++ b/network/codec/cbor/encoder.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package cbor
 
 import (

--- a/network/codec/codes.go
+++ b/network/codec/codes.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package codec
 
 import (

--- a/network/conduit.go
+++ b/network/conduit.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package network
 
 import (

--- a/network/engine.go
+++ b/network/engine.go
@@ -1,4 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
 package network
 
 import (

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package badger_test
 
 import (

--- a/storage/badger/blocks.go
+++ b/storage/badger/blocks.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package badger
 
 import (

--- a/storage/badger/cleaner.go
+++ b/storage/badger/cleaner.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package badger
 
 import (

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package badger
 
 import (

--- a/storage/badger/index.go
+++ b/storage/badger/index.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package badger
 
 import (

--- a/storage/badger/operation/collections.go
+++ b/storage/badger/operation/collections.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/collections_test.go
+++ b/storage/badger/operation/collections_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/commits.go
+++ b/storage/badger/operation/commits.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/common.go
+++ b/storage/badger/operation/common.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/common_test.go
+++ b/storage/badger/operation/common_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/events.go
+++ b/storage/badger/operation/events.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/headers.go
+++ b/storage/badger/operation/headers.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/headers_test.go
+++ b/storage/badger/operation/headers_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/heights.go
+++ b/storage/badger/operation/heights.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/heights_test.go
+++ b/storage/badger/operation/heights_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/interactions_test.go
+++ b/storage/badger/operation/interactions_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/modifiers_test.go
+++ b/storage/badger/operation/modifiers_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/payload_test.go
+++ b/storage/badger/operation/payload_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/prefix.go
+++ b/storage/badger/operation/prefix.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/prefix_test.go
+++ b/storage/badger/operation/prefix_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/receipts_test.go
+++ b/storage/badger/operation/receipts_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/results_test.go
+++ b/storage/badger/operation/results_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/operation/transaction_results.go
+++ b/storage/badger/operation/transaction_results.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package operation
 
 import (

--- a/storage/badger/seals.go
+++ b/storage/badger/seals.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package badger
 
 import (

--- a/storage/blocks.go
+++ b/storage/blocks.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/storage/epoch_commits.go
+++ b/storage/epoch_commits.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/storage/epoch_setups.go
+++ b/storage/epoch_setups.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/storage/headers.go
+++ b/storage/headers.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/storage/merkle/node.go
+++ b/storage/merkle/node.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package merkle
 
 import (

--- a/storage/merkle/tree.go
+++ b/storage/merkle/tree.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package merkle
 
 import (
@@ -21,6 +19,7 @@ import (
 // Therefore, the range of valid key length in bytes is [1, 8191] (the corresponding
 // range in bits is [8, 65528]) .
 const maxKeyLength = 8191
+
 const maxKeyLenBits = maxKeyLength * 8
 
 var EmptyTreeRootHash []byte

--- a/storage/merkle/tree_test.go
+++ b/storage/merkle/tree_test.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package merkle
 
 import (

--- a/storage/payloads.go
+++ b/storage/payloads.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/storage/receipts.go
+++ b/storage/receipts.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/storage/results.go
+++ b/storage/results.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/storage/seals.go
+++ b/storage/seals.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package storage
 
 import (

--- a/utils/logging/identifier.go
+++ b/utils/logging/identifier.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package logging
 
 import (

--- a/utils/logging/json.go
+++ b/utils/logging/json.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package logging
 
 import (


### PR DESCRIPTION
This PR removes unneeded and duplicated notices in the source files. It also changes the notice from mentioning Dapper Labs to Flow Foundation.