### PR TITLE
[Mainnet25] Update Machine Account Status Reporting for FLIP 74

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -87,13 +87,14 @@ func main() {
 		followerDistributor *pubsub.FollowerDistributor
 		addressRateLimiter  *ingest.AddressRateLimiter
 
-		push              *pusher.Engine
-		ing               *ingest.Engine
-		mainChainSyncCore *chainsync.Core
-		followerCore      *hotstuff.FollowerLoop // follower hotstuff logic
-		followerEng       *followereng.ComplianceEngine
-		colMetrics        module.CollectionMetrics
-		err               error
+		push                  *pusher.Engine
+		ing                   *ingest.Engine
+		mainChainSyncCore     *chainsync.Core
+		followerCore          *hotstuff.FollowerLoop // follower hotstuff logic
+		followerEng           *followereng.ComplianceEngine
+		colMetrics            module.CollectionMetrics
+		machineAccountMetrics module.MachineAccountMetrics
+		err                   error
 
 		// epoch qc contract client
 		machineAccountInfo *bootstrap.NodeMachineAccountInfo
@@ -260,8 +261,12 @@ func main() {
 			err := node.Metrics.Mempool.Register(metrics.ResourceTransaction, pools.CombinedSize)
 			return err
 		}).
-		Module("metrics", func(node *cmd.NodeConfig) error {
+		Module("collection node metrics", func(node *cmd.NodeConfig) error {
 			colMetrics = metrics.NewCollectionCollector(node.Tracer)
+			return nil
+		}).
+		Module("machine account metrics", func(node *cmd.NodeConfig) error {
+			machineAccountMetrics = metrics.NewMachineAccountCollector(node.MetricsRegisterer)
 			return nil
 		}).
 		Module("main chain sync core", func(node *cmd.NodeConfig) error {
@@ -303,6 +308,7 @@ func main() {
 				flowClient,
 				flow.RoleCollection,
 				*machineAccountInfo,
+				machineAccountMetrics,
 				opts...,
 			)
 

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -261,21 +261,21 @@ func main() {
 			err := node.Metrics.Mempool.Register(metrics.ResourceTransaction, pools.CombinedSize)
 			return err
 		}).
+		Module("machine account config", func(node *cmd.NodeConfig) error {
+			machineAccountInfo, err = cmd.LoadNodeMachineAccountInfoFile(node.BootstrapDir, node.NodeID)
+			return err
+		}).
 		Module("collection node metrics", func(node *cmd.NodeConfig) error {
 			colMetrics = metrics.NewCollectionCollector(node.Tracer)
 			return nil
 		}).
 		Module("machine account metrics", func(node *cmd.NodeConfig) error {
-			machineAccountMetrics = metrics.NewMachineAccountCollector(node.MetricsRegisterer)
+			machineAccountMetrics = metrics.NewMachineAccountCollector(node.MetricsRegisterer, machineAccountInfo.FlowAddress())
 			return nil
 		}).
 		Module("main chain sync core", func(node *cmd.NodeConfig) error {
 			log := node.Logger.With().Str("sync_chain_id", node.RootChainID.String()).Logger()
 			mainChainSyncCore, err = chainsync.New(log, node.SyncCoreConfig, metrics.NewChainSyncCollector(node.RootChainID), node.RootChainID)
-			return err
-		}).
-		Module("machine account config", func(node *cmd.NodeConfig) error {
-			machineAccountInfo, err = cmd.LoadNodeMachineAccountInfoFile(node.BootstrapDir, node.NodeID)
 			return err
 		}).
 		Module("sdk client connection options", func(node *cmd.NodeConfig) error {

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -430,7 +430,7 @@ func main() {
 			validator, err := epochs.NewMachineAccountConfigValidator(
 				node.Logger,
 				flowClient,
-				flow.RoleCollection,
+				flow.RoleConsensus,
 				*machineAccountInfo,
 				machineAccountMetrics,
 				opts...,

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -103,31 +103,32 @@ func main() {
 		insecureAccessAPI  bool
 		accessNodeIDS      []string
 
-		err                 error
-		mutableState        protocol.ParticipantState
-		beaconPrivateKey    *encodable.RandomBeaconPrivKey
-		guarantees          mempool.Guarantees
-		receipts            mempool.ExecutionTree
-		seals               mempool.IncorporatedResultSeals
-		pendingReceipts     mempool.PendingReceipts
-		receiptRequester    *requester.Engine
-		syncCore            *chainsync.Core
-		comp                *compliance.Engine
-		hot                 module.HotStuff
-		conMetrics          module.ConsensusMetrics
-		mainMetrics         module.HotstuffMetrics
-		receiptValidator    module.ReceiptValidator
-		chunkAssigner       *chmodule.ChunkAssigner
-		followerDistributor *pubsub.FollowerDistributor
-		dkgBrokerTunnel     *dkgmodule.BrokerTunnel
-		blockTimer          protocol.BlockTimer
-		proposalDurProvider hotstuff.ProposalDurationProvider
-		committee           *committees.Consensus
-		epochLookup         *epochs.EpochLookup
-		hotstuffModules     *consensus.HotstuffModules
-		dkgState            *bstorage.DKGState
-		safeBeaconKeys      *bstorage.SafeBeaconPrivateKeys
-		getSealingConfigs   module.SealingConfigsGetter
+		err                   error
+		mutableState          protocol.ParticipantState
+		beaconPrivateKey      *encodable.RandomBeaconPrivKey
+		guarantees            mempool.Guarantees
+		receipts              mempool.ExecutionTree
+		seals                 mempool.IncorporatedResultSeals
+		pendingReceipts       mempool.PendingReceipts
+		receiptRequester      *requester.Engine
+		syncCore              *chainsync.Core
+		comp                  *compliance.Engine
+		hot                   module.HotStuff
+		conMetrics            module.ConsensusMetrics
+		machineAccountMetrics module.MachineAccountMetrics
+		mainMetrics           module.HotstuffMetrics
+		receiptValidator      module.ReceiptValidator
+		chunkAssigner         *chmodule.ChunkAssigner
+		followerDistributor   *pubsub.FollowerDistributor
+		dkgBrokerTunnel       *dkgmodule.BrokerTunnel
+		blockTimer            protocol.BlockTimer
+		proposalDurProvider   hotstuff.ProposalDurationProvider
+		committee             *committees.Consensus
+		epochLookup           *epochs.EpochLookup
+		hotstuffModules       *consensus.HotstuffModules
+		dkgState              *bstorage.DKGState
+		safeBeaconKeys        *bstorage.SafeBeaconPrivateKeys
+		getSealingConfigs     module.SealingConfigsGetter
 	)
 	var deprecatedFlagBlockRateDelay time.Duration
 
@@ -201,6 +202,10 @@ func main() {
 		ValidateRootSnapshot(badgerState.ValidRootSnapshotContainsEntityExpiryRange).
 		Module("consensus node metrics", func(node *cmd.NodeConfig) error {
 			conMetrics = metrics.NewConsensusCollector(node.Tracer, node.MetricsRegisterer)
+			return nil
+		}).
+		Module("machine account metrics", func(node *cmd.NodeConfig) error {
+			machineAccountMetrics = metrics.NewMachineAccountCollector(node.MetricsRegisterer)
 			return nil
 		}).
 		Module("dkg state", func(node *cmd.NodeConfig) error {
@@ -427,6 +432,7 @@ func main() {
 				flowClient,
 				flow.RoleCollection,
 				*machineAccountInfo,
+				machineAccountMetrics,
 				opts...,
 			)
 			return validator, err

--- a/engine/unit.go
+++ b/engine/unit.go
@@ -1,5 +1,3 @@
-// (c) 2019 Dapper Labs - ALL RIGHTS RESERVED
-
 package engine
 
 import (
@@ -9,6 +7,7 @@ import (
 )
 
 // Unit handles synchronization management, startup, and shutdown for engines.
+// New components should use component.ComponentManager rather than Unit.
 type Unit struct {
 	admitLock sync.Mutex // used for synchronizing context cancellation with work admittance
 

--- a/module/epochs/machine_account.go
+++ b/module/epochs/machine_account.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/onflow/flow-go/module"
-	"github.com/onflow/flow-go/module/component"
-	"github.com/onflow/flow-go/module/irrecoverable"
 	"strconv"
 	"time"
 
@@ -17,8 +14,12 @@ import (
 	sdk "github.com/onflow/flow-go-sdk"
 	client "github.com/onflow/flow-go-sdk/access/grpc"
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
+
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/irrecoverable"
 )
 
 var (

--- a/module/epochs/machine_account.go
+++ b/module/epochs/machine_account.go
@@ -118,7 +118,7 @@ func NewMachineAccountConfigValidator(
 	flowClient *client.Client,
 	role flow.Role,
 	info bootstrap.NodeMachineAccountInfo,
-	// TODO metrics
+	metrics module.MachineAccountMetrics,
 	opts ...MachineAccountValidatorConfigOption,
 ) (*MachineAccountConfigValidator, error) {
 
@@ -128,11 +128,12 @@ func NewMachineAccountConfigValidator(
 	}
 
 	validator := &MachineAccountConfigValidator{
-		config: conf,
-		log:    log.With().Str("component", "machine_account_config_validator").Logger(),
-		client: flowClient,
-		role:   role,
-		info:   info,
+		config:  conf,
+		log:     log.With().Str("component", "machine_account_config_validator").Logger(),
+		client:  flowClient,
+		role:    role,
+		info:    info,
+		metrics: metrics,
 	}
 
 	validator.Component = component.NewComponentManagerBuilder().

--- a/module/epochs/machine_account_test.go
+++ b/module/epochs/machine_account_test.go
@@ -205,3 +205,32 @@ func TestMachineAccountValidatorBackoff_Overflow(t *testing.T) {
 		lastWait = wait
 	}
 }
+
+// TestUfix64Tofloat64 sanity checks the conversion between cadence.UFix64 and float64.
+func TestUfix64Tofloat64(t *testing.T) {
+	for _, testcase := range []struct {
+		str      string
+		expected float64
+	}{{
+		str:      "1.01",
+		expected: 1.01,
+	}, {
+		str:      "0.0001",
+		expected: 0.0001,
+	}, {
+		str:      "100000.001",
+		expected: 100000.001,
+	}, {
+		str:      "0.0",
+		expected: 0,
+	}, {
+		str:      "123456.0",
+		expected: 123456,
+	}} {
+		cdc, err := cadence.NewUFix64(testcase.str)
+		require.NoError(t, err)
+		f, err := ufix64Tofloat64(cdc)
+		require.NoError(t, err)
+		assert.InDelta(t, testcase.expected, f, 0.0000001)
+	}
+}

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -1110,3 +1110,15 @@ type CollectionExecutedMetric interface {
 	ExecutionReceiptReceived(r *flow.ExecutionReceipt)
 	UpdateLastFullBlockHeight(height uint64)
 }
+
+type MachineAccountMetrics interface {
+	// AccountBalance reports the current balance of the machine account.
+	AccountBalance(bal float64)
+	// RecommendedMinBalance reports the recommended minimum balance. If the actual balance
+	// falls below this level, it must be refilled.
+	// NOTE: Operators should alert on `AccountBalance < RecommendedMinBalance`
+	RecommendedMinBalance(bal float64)
+	// IsMisconfigured reports whether a critical misconfiguration has been detected.
+	// NOTE Operators should alert on non-zero values reported here.
+	IsMisconfigured(misconfigured bool)
+}

--- a/module/metrics/labels.go
+++ b/module/metrics/labels.go
@@ -24,6 +24,7 @@ const (
 	LabelMethod              = "method"
 	LabelService             = "service"
 	LabelRejectionReason     = "rejection_reason"
+	LabelAccountAddress      = "acct_address" // Account address for a machine account
 )
 
 const (

--- a/module/metrics/machine_account.go
+++ b/module/metrics/machine_account.go
@@ -1,0 +1,52 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// MachineAccountCollector implements metric collection for machine accounts.
+type MachineAccountCollector struct {
+	accountBalance        prometheus.Gauge
+	recommendedMinBalance prometheus.Gauge
+	misconfigured         prometheus.Gauge
+}
+
+func NewMachineAccountCollector(registerer prometheus.Registerer) *MachineAccountCollector {
+	accountBalance := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespaceMachineAcct,
+		Name:      "balance",
+		Help:      "the last observed balance of this node's machine account, in units of FLOW",
+	})
+	recommendedMinBalance := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespaceMachineAcct,
+		Name:      "recommended_min_balance",
+		Help:      "the recommended minimum balance for this node role; refill the account when the balance reaches this threshold",
+	})
+	misconfigured := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespaceMachineAcct,
+		Name:      "is_misconfigured",
+		Help:      "reported as a non-zero value when a misconfiguration is detected; check logs for further details",
+	})
+	registerer.MustRegister(accountBalance, recommendedMinBalance, misconfigured)
+
+	collector := &MachineAccountCollector{
+		accountBalance:        accountBalance,
+		recommendedMinBalance: recommendedMinBalance,
+		misconfigured:         misconfigured,
+	}
+	return collector
+}
+
+func (m MachineAccountCollector) AccountBalance(bal float64) {
+	m.accountBalance.Set(bal)
+}
+
+func (m MachineAccountCollector) RecommendedMinBalance(bal float64) {
+	m.recommendedMinBalance.Set(bal)
+}
+
+func (m MachineAccountCollector) IsMisconfigured(misconfigured bool) {
+	if misconfigured {
+		m.misconfigured.Set(1)
+	} else {
+		m.misconfigured.Set(0)
+	}
+}

--- a/module/metrics/machine_account.go
+++ b/module/metrics/machine_account.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // MachineAccountCollector implements metric collection for machine accounts.
 type MachineAccountCollector struct {
@@ -9,21 +12,24 @@ type MachineAccountCollector struct {
 	misconfigured         prometheus.Gauge
 }
 
-func NewMachineAccountCollector(registerer prometheus.Registerer) *MachineAccountCollector {
+func NewMachineAccountCollector(registerer prometheus.Registerer, machineAccountAddress flow.Address) *MachineAccountCollector {
 	accountBalance := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespaceMachineAcct,
-		Name:      "balance",
-		Help:      "the last observed balance of this node's machine account, in units of FLOW",
+		Namespace:   namespaceMachineAcct,
+		Name:        "balance",
+		Help:        "the last observed balance of this node's machine account, in units of FLOW",
+		ConstLabels: map[string]string{LabelAccountAddress: machineAccountAddress.String()},
 	})
 	recommendedMinBalance := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespaceMachineAcct,
-		Name:      "recommended_min_balance",
-		Help:      "the recommended minimum balance for this node role; refill the account when the balance reaches this threshold",
+		Namespace:   namespaceMachineAcct,
+		Name:        "recommended_min_balance",
+		Help:        "the recommended minimum balance for this node role; refill the account when the balance reaches this threshold",
+		ConstLabels: map[string]string{LabelAccountAddress: machineAccountAddress.String()},
 	})
 	misconfigured := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: namespaceMachineAcct,
-		Name:      "is_misconfigured",
-		Help:      "reported as a non-zero value when a misconfiguration is detected; check logs for further details",
+		Namespace:   namespaceMachineAcct,
+		Name:        "is_misconfigured",
+		Help:        "reported as a non-zero value when a misconfiguration is detected; check logs for further details",
+		ConstLabels: map[string]string{LabelAccountAddress: machineAccountAddress.String()},
 	})
 	registerer.MustRegister(accountBalance, recommendedMinBalance, misconfigured)
 

--- a/module/metrics/machine_account.go
+++ b/module/metrics/machine_account.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/onflow/flow-go/model/flow"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/module/metrics/namespaces.go
+++ b/module/metrics/namespaces.go
@@ -16,6 +16,7 @@ const (
 	namespaceChainsync         = "chainsync"
 	namespaceFollowerEngine    = "follower"
 	namespaceRestAPI           = "access_rest_api"
+	namespaceMachineAcct       = "machine_account"
 )
 
 // Network subsystems represent the various layers of networking.

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -374,3 +374,9 @@ func (nc *NoopCollector) CollectionFinalized(light flow.LightCollection) {}
 func (nc *NoopCollector) CollectionExecuted(light flow.LightCollection)  {}
 func (nc *NoopCollector) ExecutionReceiptReceived(r *flow.ExecutionReceipt) {
 }
+
+func (nc *NoopCollector) AccountBalance(bal float64)         {}
+func (nc *NoopCollector) RecommendedMinBalance(bal float64)  {}
+func (nc *NoopCollector) IsMisconfigured(misconfigured bool) {}
+
+var _ module.MachineAccountMetrics = (*NoopCollector)(nil)


### PR DESCRIPTION
## Context
This PR updates machine account status reporting, in preparation for [FLIP 74](https://github.com/onflow/flips/blob/main/governance/20230323-transaction-fee.md) which we anticipate being applied around the Crescendo spork. 
- Adds metrics for machine account misconfiguration and account balance notification (previously only logged)
- Adds metric for recommended minimum, so operators can uniformly alert on `balance - min < 0`
- Adds the machine account address in the metric's constant labels
- Runs reporter routine persistently in the background, with a longer polling period
- Replaces `engine.Unit` with `ComponentManager`

## Remaining TODOs
- [ ] TODO: Update minimum balance recommendation constants

## Localnet Testing

Node reporting a misconfiguration:
<img width="1395" alt="image" src="https://github.com/onflow/flow-go/assets/10557821/f374c069-2aff-4033-9a0e-b4676e5ddc72">

Node reporting balance changes:
<img width="1399" alt="image" src="https://github.com/onflow/flow-go/assets/10557821/db21b1c6-09e1-4677-ae9d-c9824b9edb69">

Suggested query for balance alerts:
<img width="1402" alt="image" src="https://github.com/onflow/flow-go/assets/10557821/9ce1f4f1-d668-45d2-b39f-93e13c914de9">


