### PR TITLE
[Flow EVM] prepare the StateDB and the Emulator to support batch run operations

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -184,9 +184,9 @@ type procedure struct {
 	state  types.StateDB
 }
 
-// commit commits the changes to the state.
+// commit commits the changes to the state (with finalization)
 func (proc *procedure) commit() error {
-	err := proc.state.Commit()
+	err := proc.state.Commit(true)
 	if err != nil {
 		// if known types (state errors) don't do anything and return
 		if types.IsAFatalError(err) || types.IsAStateError(err) {

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -280,14 +280,15 @@ func (proc *procedure) deployAt(
 	// precheck 1 - check balance of the source
 	if value.Sign() != 0 &&
 		!proc.evm.Context.CanTransfer(proc.state, caller.ToCommon(), value) {
-		return res, gethCore.ErrInsufficientFundsForTransfer
+		res.ValidationError = gethCore.ErrInsufficientFundsForTransfer
+		return res, nil
 	}
 
 	// precheck 2 - ensure there's no existing eoa or contract is deployed at the address
 	contractHash := proc.state.GetCodeHash(addr)
 	if proc.state.GetNonce(addr) != 0 ||
 		(contractHash != (gethCommon.Hash{}) && contractHash != gethTypes.EmptyCodeHash) {
-		res.VMError = gethVM.ErrContractAddressCollision
+		res.ValidationError = gethVM.ErrContractAddressCollision
 		return res, nil
 	}
 

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -160,7 +160,7 @@ func (bl *BlockView) RunTransaction(
 		res = &types.Result{
 			TxType:          tx.Type(),
 			TxHash:          txHash,
-			ValidationError: types.NewEVMValidationError(err),
+			ValidationError: err,
 			GasConsumed:     InvalidTransactionGasCost,
 		}
 		return res, nil
@@ -444,7 +444,7 @@ func (proc *procedure) run(
 		}
 		// otherwise is a validation error (pre-check failure)
 		// no state change, wrap the error and return
-		res.ValidationError = types.NewEVMValidationError(err)
+		res.ValidationError = err
 		res.GasConsumed = InvalidTransactionGasCost
 		return &res, nil
 	}

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -229,8 +229,9 @@ func (proc *procedure) mintTo(
 	// if any error (invalid or vm) on the internal call, revert and don't commit any change
 	// this prevents having cases that we add balance to the bridge but the transfer
 	// fails due to gas, etc.
+	// TODO: in the future we might just return without error and handle everything on higher level
 	if res.Invalid() || res.Failed() {
-		return res, types.ErrInternalDirecCallFailed
+		return res, types.ErrInternalDirectCallFailed
 	}
 
 	// all commmit errors (StateDB errors) has to be returned
@@ -257,8 +258,9 @@ func (proc *procedure) withdrawFrom(
 	}
 
 	// if any error (invalid or vm) on the internal call, revert and don't commit any change
+	// TODO: in the future we might just return without error and handle everything on higher level
 	if res.Invalid() || res.Failed() {
-		return res, types.ErrInternalDirecCallFailed
+		return res, types.ErrInternalDirectCallFailed
 	}
 
 	// now deduct the balance from the bridge

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -370,9 +370,10 @@ func TestContractInteraction(t *testing.T) {
 							nil,                    // data
 						),
 					)
-					_, err = blk.RunTransaction(tx)
-					require.Error(t, err)
-					require.True(t, types.IsEVMValidationError(err))
+					res, err := blk.RunTransaction(tx)
+					require.NoError(t, err)
+					require.Error(t, res.ValidationError)
+					require.True(t, types.IsEVMValidationError(res.ValidationError))
 				})
 			})
 

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -393,9 +393,10 @@ func TestContractInteraction(t *testing.T) {
 						R:        big.NewInt(2),
 						S:        big.NewInt(3),
 					})
-					_, err = blk.RunTransaction(tx)
-					require.Error(t, err)
-					require.True(t, types.IsEVMValidationError(err))
+					res, err := blk.RunTransaction(tx)
+					require.NoError(t, err)
+					require.Error(t, res.ValidationError)
+					require.True(t, types.IsEVMValidationError(res.ValidationError))
 				})
 			})
 		})
@@ -463,7 +464,7 @@ func TestDeployAtFunctionality(t *testing.T) {
 								0),
 						)
 						require.NoError(t, err)
-						require.Equal(t, gethVM.ErrContractAddressCollision, res.ValidationError)
+						require.Equal(t, gethVM.ErrContractAddressCollision, res.VMError)
 					})
 					// test deployment with not enough gas
 					RunWithNewBlockView(t, env, func(blk types.BlockView) {

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -373,7 +373,6 @@ func TestContractInteraction(t *testing.T) {
 					res, err := blk.RunTransaction(tx)
 					require.NoError(t, err)
 					require.Error(t, res.ValidationError)
-					require.True(t, types.IsEVMValidationError(res.ValidationError))
 				})
 			})
 
@@ -396,7 +395,6 @@ func TestContractInteraction(t *testing.T) {
 					res, err := blk.RunTransaction(tx)
 					require.NoError(t, err)
 					require.Error(t, res.ValidationError)
-					require.True(t, types.IsEVMValidationError(res.ValidationError))
 				})
 			})
 		})

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -463,7 +463,7 @@ func TestDeployAtFunctionality(t *testing.T) {
 								0),
 						)
 						require.NoError(t, err)
-						require.Equal(t, gethVM.ErrContractAddressCollision, res.VMError)
+						require.Equal(t, gethVM.ErrContractAddressCollision, res.ValidationError)
 					})
 					// test deployment with not enough gas
 					RunWithNewBlockView(t, env, func(blk types.BlockView) {

--- a/fvm/evm/emulator/state/stateDB.go
+++ b/fvm/evm/emulator/state/stateDB.go
@@ -291,7 +291,7 @@ func (db *StateDB) Preimages() map[gethCommon.Hash][]byte {
 }
 
 // Commit commits state changes back to the underlying
-func (db *StateDB) Commit() error {
+func (db *StateDB) Commit(finalize bool) error {
 	// return error if any has been acumulated
 	if db.cachedError != nil {
 		return wrapError(db.cachedError)
@@ -388,11 +388,17 @@ func (db *StateDB) Commit() error {
 	}
 
 	// don't purge views yet, people might call the logs etc
-	err = db.baseView.Commit()
-	if err != nil {
-		return wrapError(err)
+	if finalize {
+		return db.Finalize()
 	}
 	return nil
+}
+
+// Finalize flushes all the changes
+// to the permanent storage
+func (db *StateDB) Finalize() error {
+	err := db.baseView.Commit()
+	return wrapError(err)
 }
 
 // Prepare is a highlevel logic that sadly is considered to be part of the
@@ -419,6 +425,14 @@ func (db *StateDB) Prepare(rules gethParams.Rules, sender, coinbase gethCommon.A
 			db.AddAddressToAccessList(coinbase)
 		}
 	}
+}
+
+// Reset resets uncommitted changes and transient artifacts such as error, logs,
+// preimages, access lists, ...
+// The method is often called between execution of different transactions
+func (db *StateDB) Reset() {
+	db.views = []*DeltaView{NewDeltaView(db.baseView)}
+	db.cachedError = nil
 }
 
 // Error returns the memorized database failure occurred earlier.

--- a/fvm/evm/emulator/state/stateDB_test.go
+++ b/fvm/evm/emulator/state/stateDB_test.go
@@ -71,7 +71,7 @@ func TestStateDB(t *testing.T) {
 		ret = db.GetCommittedState(addr1, key1)
 		require.Equal(t, gethCommon.Hash{}, ret)
 
-		err = db.Commit()
+		err = db.Commit(true)
 		require.NoError(t, err)
 
 		ret = db.GetCommittedState(addr1, key1)
@@ -256,7 +256,7 @@ func TestStateDB(t *testing.T) {
 
 		db.CreateAccount(testutils.RandomCommonAddress(t))
 
-		err = db.Commit()
+		err = db.Commit(true)
 		// ret := db.Error()
 		require.Error(t, err)
 		// check wrapping
@@ -280,7 +280,7 @@ func TestStateDB(t *testing.T) {
 
 		db.CreateAccount(testutils.RandomCommonAddress(t))
 
-		err = db.Commit()
+		err = db.Commit(true)
 		// ret := db.Error()
 		require.Error(t, err)
 		// check wrapping

--- a/fvm/evm/emulator/state/state_growth_test.go
+++ b/fvm/evm/emulator/state/state_growth_test.go
@@ -64,7 +64,7 @@ func (s *storageTest) run(runner func(state types.StateDB)) error {
 
 	runner(state)
 
-	err = state.Commit()
+	err = state.Commit(true)
 	if err != nil {
 		return err
 	}

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -630,8 +630,9 @@ func panicOnErrorOrInvalidOrFailedState(res *types.Result, err error) {
 		panic(fvmErrors.NewEVMError(res.VMError))
 	}
 
-	if err == nil {
-		return
+	// this should never happen
+	if err == nil && res == nil {
+		panic(fvmErrors.NewEVMError(types.ErrUnexpectedEmptyResult))
 	}
 
 	panicOnError(err)

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -63,7 +63,7 @@ func NewContractHandler(
 // DeployCOA deploys a cadence-owned-account and returns the address
 func (h *ContractHandler) DeployCOA(uuid uint64) types.Address {
 	res, err := h.deployCOA(uuid)
-	panicOnAnyError(res, err)
+	panicOnErrorOrInvalidOrFailedState(res, err)
 	return res.DeployedContractAddress
 }
 
@@ -102,7 +102,7 @@ func (h *ContractHandler) AccountByAddress(addr types.Address, isAuthorized bool
 // LastExecutedBlock returns the last executed block
 func (h *ContractHandler) LastExecutedBlock() *types.Block {
 	block, err := h.blockStore.LatestBlock()
-	panicOnAnyError(nil, err)
+	panicOnError(err)
 	return block
 }
 
@@ -110,14 +110,14 @@ func (h *ContractHandler) LastExecutedBlock() *types.Block {
 // collects the gas fees and pay it to the coinbase address provided.
 func (h *ContractHandler) RunOrPanic(rlpEncodedTx []byte, coinbase types.Address) {
 	res, err := h.run(rlpEncodedTx, coinbase)
-	panicOnAnyError(res, err)
+	panicOnErrorOrInvalidOrFailedState(res, err)
 }
 
 // Run tries to run an rlpencoded evm transaction and
 // collects the gas fees and pay it to the coinbase address provided.
 func (h *ContractHandler) Run(rlpEncodedTx []byte, coinbase types.Address) *types.ResultSummary {
 	res, err := h.run(rlpEncodedTx, coinbase)
-	panicOnFatalOrBackendError(err)
+	panicOnError(err)
 	return res.ResultSummary()
 }
 
@@ -256,7 +256,7 @@ func (h *ContractHandler) getBlockContext() (types.BlockContext, error) {
 		DirectCallBaseGasUsage: types.DefaultDirectCallBaseGasUsage,
 		GetHashFunc: func(n uint64) gethCommon.Hash {
 			hash, err := h.blockStore.BlockHash(n)
-			panicOnAnyError(nil, err) // we have to handle it here given we can't continue with it even in try case
+			panicOnError(err) // we have to handle it here given we can't continue with it even in try case
 			return hash
 		},
 		ExtraPrecompiles: h.precompiles,
@@ -360,7 +360,7 @@ func (h *ContractHandler) executeAndHandleCall(
 
 func (h *ContractHandler) GenerateResourceUUID() uint64 {
 	uuid, err := h.backend.GenerateUUID()
-	panicOnAnyError(nil, err)
+	panicOnError(err)
 	return uuid
 }
 
@@ -390,7 +390,7 @@ func (a *Account) Address() types.Address {
 // from the storage already transalates into computation
 func (a *Account) Nonce() uint64 {
 	nonce, err := a.nonce()
-	panicOnAnyError(nil, err)
+	panicOnError(err)
 	return nonce
 }
 
@@ -414,7 +414,7 @@ func (a *Account) nonce() (uint64, error) {
 // from the storage already transalates into computation
 func (a *Account) Balance() types.Balance {
 	bal, err := a.balance()
-	panicOnAnyError(nil, err)
+	panicOnError(err)
 	return bal
 }
 
@@ -439,7 +439,7 @@ func (a *Account) balance() (types.Balance, error) {
 // from the storage already transalates into computation
 func (a *Account) Code() types.Code {
 	code, err := a.code()
-	panicOnAnyError(nil, err)
+	panicOnError(err)
 	return code
 }
 
@@ -462,7 +462,7 @@ func (a *Account) code() (types.Code, error) {
 // from the storage already transalates into computation
 func (a *Account) CodeHash() []byte {
 	codeHash, err := a.codeHash()
-	panicOnAnyError(nil, err)
+	panicOnError(err)
 	return codeHash
 }
 
@@ -483,7 +483,7 @@ func (a *Account) codeHash() ([]byte, error) {
 // and update the account balance with the new amount
 func (a *Account) Deposit(v *types.FLOWTokenVault) {
 	res, err := a.deposit(v)
-	panicOnAnyError(res, err)
+	panicOnErrorOrInvalidOrFailedState(res, err)
 }
 
 func (a *Account) deposit(v *types.FLOWTokenVault) (*types.Result, error) {
@@ -508,7 +508,7 @@ func (a *Account) deposit(v *types.FLOWTokenVault) (*types.Result, error) {
 // withdraw and return flow token from the Flex main vault.
 func (a *Account) Withdraw(b types.Balance) *types.FLOWTokenVault {
 	res, err := a.withdraw(b)
-	panicOnAnyError(res, err)
+	panicOnErrorOrInvalidOrFailedState(res, err)
 
 	return types.NewFlowTokenVault(b)
 }
@@ -537,7 +537,7 @@ func (a *Account) withdraw(b types.Balance) (*types.Result, error) {
 // Transfer transfers tokens between accounts
 func (a *Account) Transfer(to types.Address, balance types.Balance) {
 	res, err := a.transfer(to, balance)
-	panicOnAnyError(res, err)
+	panicOnErrorOrInvalidOrFailedState(res, err)
 }
 
 func (a *Account) transfer(to types.Address, balance types.Balance) (*types.Result, error) {
@@ -560,7 +560,7 @@ func (a *Account) transfer(to types.Address, balance types.Balance) (*types.Resu
 // the contract data is not controlled by the caller accounts
 func (a *Account) Deploy(code types.Code, gaslimit types.GasLimit, balance types.Balance) types.Address {
 	res, err := a.deploy(code, gaslimit, balance)
-	panicOnAnyError(res, err)
+	panicOnErrorOrInvalidOrFailedState(res, err)
 	return types.Address(res.DeployedContractAddress)
 }
 
@@ -586,7 +586,7 @@ func (a *Account) deploy(code types.Code, gaslimit types.GasLimit, balance types
 // the balance would be deducted from the OFA account and would be transferred to the target address
 func (a *Account) Call(to types.Address, data types.Data, gaslimit types.GasLimit, balance types.Balance) *types.ResultSummary {
 	res, err := a.call(to, data, gaslimit, balance)
-	panicOnFatalOrBackendError(err)
+	panicOnError(err)
 	return res.ResultSummary()
 }
 
@@ -620,7 +620,7 @@ func (a *Account) precheck(authroized bool, gaslimit types.GasLimit) (types.Bloc
 	return a.fch.getBlockContext()
 }
 
-func panicOnAnyError(res *types.Result, err error) {
+func panicOnErrorOrInvalidOrFailedState(res *types.Result, err error) {
 
 	if res != nil && res.Invalid() {
 		panic(fvmErrors.NewEVMError(res.ValidationError))
@@ -634,14 +634,11 @@ func panicOnAnyError(res *types.Result, err error) {
 		return
 	}
 
-	panicOnFatalOrBackendError(err)
-
-	// if not FVM wrap it with EVM error and panic
-	panic(fvmErrors.NewEVMError(err))
+	panicOnError(err)
 }
 
-// panicOnFatalOrBackendError errors panic on fatal or backend-related errors
-func panicOnFatalOrBackendError(err error) {
+// panicOnError errors panic on returned errors
+func panicOnError(err error) {
 	if err == nil {
 		return
 	}

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -798,7 +798,6 @@ func TestHandler_TransactionRun(t *testing.T) {
 					assertPanic(t, isNotFatal, func() {
 						rs := handler.Run([]byte(tx), coinbase)
 						require.Equal(t, types.StatusInvalid, rs.Status)
-						require.Equal(t, types.ValidationErrCodeInsufficientComputation, rs.ErrorCode)
 					})
 
 					tx = eoa.PrepareSignAndEncodeTx(

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -158,7 +158,9 @@ func TestHandler_TransactionRunOrPanic(t *testing.T) {
 					aa := handler.NewAddressAllocator()
 					em := &testutils.TestEmulator{
 						RunTransactionFunc: func(tx *gethTypes.Transaction) (*types.Result, error) {
-							return &types.Result{}, types.NewEVMValidationError(fmt.Errorf("some sort of validation error"))
+							return &types.Result{
+								ValidationError: types.NewEVMValidationError(fmt.Errorf("some sort of validation error")),
+							}, nil
 						},
 					}
 					handler := handler.NewContractHandler(flow.Testnet, rootAddr, flowTokenAddress, bs, aa, backend, em)
@@ -776,7 +778,7 @@ func TestHandler_TransactionRun(t *testing.T) {
 					evmErr := fmt.Errorf("%w: next nonce %v, tx nonce %v", gethCore.ErrNonceTooLow, 1, 0)
 					em := &testutils.TestEmulator{
 						RunTransactionFunc: func(tx *gethTypes.Transaction) (*types.Result, error) {
-							return &types.Result{}, types.NewEVMValidationError(evmErr)
+							return &types.Result{ValidationError: types.NewEVMValidationError(evmErr)}, nil
 						},
 					}
 					handler := handler.NewContractHandler(flow.Testnet, rootAddr, flowTokenAddress, bs, aa, backend, em)
@@ -793,9 +795,11 @@ func TestHandler_TransactionRun(t *testing.T) {
 						big.NewInt(1),
 					)
 
-					rs := handler.Run([]byte(tx), coinbase)
-					require.Equal(t, types.StatusInvalid, rs.Status)
-					require.Equal(t, types.ValidationErrCodeInsufficientComputation, rs.ErrorCode)
+					assertPanic(t, isNotFatal, func() {
+						rs := handler.Run([]byte(tx), coinbase)
+						require.Equal(t, types.StatusInvalid, rs.Status)
+						require.Equal(t, types.ValidationErrCodeInsufficientComputation, rs.ErrorCode)
+					})
 
 					tx = eoa.PrepareSignAndEncodeTx(
 						t,
@@ -806,7 +810,7 @@ func TestHandler_TransactionRun(t *testing.T) {
 						big.NewInt(1),
 					)
 
-					rs = handler.Run([]byte(tx), coinbase)
+					rs := handler.Run([]byte(tx), coinbase)
 					require.Equal(t, types.StatusInvalid, rs.Status)
 					require.Equal(t, types.ValidationErrCodeNonceTooLow, rs.ErrorCode)
 				})

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -159,7 +159,7 @@ func TestHandler_TransactionRunOrPanic(t *testing.T) {
 					em := &testutils.TestEmulator{
 						RunTransactionFunc: func(tx *gethTypes.Transaction) (*types.Result, error) {
 							return &types.Result{
-								ValidationError: types.NewEVMValidationError(fmt.Errorf("some sort of validation error")),
+								ValidationError: fmt.Errorf("some sort of validation error"),
 							}, nil
 						},
 					}
@@ -494,7 +494,7 @@ func TestHandler_COA(t *testing.T) {
 								return 0, nil
 							},
 							DirectCallFunc: func(call *types.DirectCall) (*types.Result, error) {
-								return &types.Result{}, types.NewEVMValidationError(fmt.Errorf("some sort of error"))
+								return &types.Result{}, fmt.Errorf("some sort of error")
 							},
 						}
 
@@ -778,7 +778,7 @@ func TestHandler_TransactionRun(t *testing.T) {
 					evmErr := fmt.Errorf("%w: next nonce %v, tx nonce %v", gethCore.ErrNonceTooLow, 1, 0)
 					em := &testutils.TestEmulator{
 						RunTransactionFunc: func(tx *gethTypes.Transaction) (*types.Result, error) {
-							return &types.Result{ValidationError: types.NewEVMValidationError(evmErr)}, nil
+							return &types.Result{ValidationError: evmErr}, nil
 						},
 					}
 					handler := handler.NewContractHandler(flow.Testnet, rootAddr, flowTokenAddress, bs, aa, backend, em)

--- a/fvm/evm/types/codeFinder.go
+++ b/fvm/evm/types/codeFinder.go
@@ -8,11 +8,6 @@ import (
 )
 
 func ValidationErrorCode(err error) ErrorCode {
-	// if is a EVM validation error first unwrap one level
-	if IsEVMValidationError(err) {
-		err = errors.Unwrap(err)
-	}
-
 	// direct errors that are returned by the evm
 	switch err {
 	case gethVM.ErrGasUintOverflow:

--- a/fvm/evm/types/codeFinder.go
+++ b/fvm/evm/types/codeFinder.go
@@ -10,17 +10,6 @@ import (
 func ValidationErrorCode(err error) ErrorCode {
 	// if is a EVM validation error first unwrap one level
 	if IsEVMValidationError(err) {
-		// check local errors
-		switch err {
-		case ErrInvalidBalance:
-			return ValidationErrCodeInvalidBalance
-		case ErrInsufficientComputation:
-			return ValidationErrCodeInsufficientComputation
-		case ErrUnAuthroizedMethodCall:
-			return ValidationErrCodeUnAuthroizedMethodCall
-		case ErrWithdrawBalanceRounding:
-			return ValidationErrCodeWithdrawBalanceRounding
-		}
 		err = errors.Unwrap(err)
 	}
 

--- a/fvm/evm/types/emulator.go
+++ b/fvm/evm/types/emulator.go
@@ -61,11 +61,11 @@ type ReadOnlyBlockView interface {
 	CodeHashOf(address Address) ([]byte, error)
 }
 
-// BlockView facilitates execution of a transaction or a direct evm  call in the context of a block
-// Errors returned by the methods are one of the followings:
-// - Fatal error
-// - Database error (non-fatal)
+// BlockView facilitates execution of a transaction or a direct evm call in the context of a block
+// Any error returned by any of the methods (e.g. stateDB errors) if non-fatal stops the outer flow transaction
+// if fatal stops the node.
 // EVM validation errors and EVM execution errors are part of the returned result
+// and should be handled separately.
 type BlockView interface {
 	// executes a direct call
 	DirectCall(call *DirectCall) (*Result, error)

--- a/fvm/evm/types/emulator.go
+++ b/fvm/evm/types/emulator.go
@@ -65,8 +65,7 @@ type ReadOnlyBlockView interface {
 // Errors returned by the methods are one of the followings:
 // - Fatal error
 // - Database error (non-fatal)
-// - EVM validation error
-// - EVM execution error
+// EVM validation errors and EVM execution errors are part of the returned result
 type BlockView interface {
 	// executes a direct call
 	DirectCall(call *DirectCall) (*Result, error)

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -125,34 +125,6 @@ var (
 	ErrNotImplemented = NewFatalError(errors.New("a functionality is called that is not implemented"))
 )
 
-// EVMValidationError is a non-fatal error, returned when validation steps of an EVM transaction
-// or direct call has failed.
-type EVMValidationError struct {
-	err error
-}
-
-// NewEVMValidationError returns a new EVMValidationError
-func NewEVMValidationError(rootCause error) EVMValidationError {
-	return EVMValidationError{
-		err: rootCause,
-	}
-}
-
-// Unwrap unwraps the underlying evm error
-func (err EVMValidationError) Unwrap() error {
-	return err.err
-}
-
-func (err EVMValidationError) Error() string {
-	return fmt.Sprintf("EVM validation error: %v", err.err)
-}
-
-// IsEVMValidationError returns true if the error or any underlying errors
-// is of the type EVM validation error
-func IsEVMValidationError(err error) bool {
-	return errors.As(err, &EVMValidationError{})
-}
-
 // StateError is a non-fatal error, returned when a state operation
 // has failed (e.g. reaching storage interaction limit)
 type StateError struct {

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -105,6 +105,10 @@ var (
 	// ErrUnAuthroizedMethodCall method call, usually emited when calls are called on EOA accounts
 	ErrUnAuthroizedMethodCall = errors.New("unauthroized method call")
 
+	// ErrInternalDirecCallFailed is returned when a withdraw or deposit internal call
+	// has failed.
+	ErrInternalDirecCallFailed = errors.New("internal direct call execution failed")
+
 	// ErrWithdrawBalanceRounding is returned when withdraw call has a balance that could
 	// yeild to rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).
 	ErrWithdrawBalanceRounding = NewEVMValidationError(errors.New("withdraw failed! the balance is susceptible to the rounding error"))

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -13,14 +13,6 @@ const ( // code reserved for no error
 
 	// covers all other validation codes that doesn't have an specific code
 	ValidationErrCodeMisc ErrorCode = 100
-	// invalid balance is provided (e.g. negative value)
-	ValidationErrCodeInvalidBalance ErrorCode = 101
-	// insufficient computation is left in the flow transaction
-	ValidationErrCodeInsufficientComputation ErrorCode = 102
-	// unauthroized method call
-	ValidationErrCodeUnAuthroizedMethodCall ErrorCode = 103
-	// withdraw balance is prone to rounding error
-	ValidationErrCodeWithdrawBalanceRounding ErrorCode = 104
 
 	// general execution error returned for cases that don't have an specific code
 	ExecutionErrCodeMisc ErrorCode = 400

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -98,7 +98,7 @@ var (
 	ErrUnAuthroizedMethodCall = errors.New("unauthroized method call")
 
 	// ErrInternalDirecCallFailed is returned when a withdraw or deposit internal call has failed.
-	ErrInternalDirecCallFailed = errors.New("internal direct call execution failed")
+	ErrInternalDirectCallFailed = errors.New("internal direct call execution failed")
 
 	// ErrWithdrawBalanceRounding is returned when withdraw call has a balance that could
 	// yeild to rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -96,7 +96,7 @@ const (
 
 var (
 	// ErrInvalidBalance is returned when an invalid balance is provided for transfer (e.g. negative)
-	ErrInvalidBalance = NewEVMValidationError(errors.New("invalid balance for transfer"))
+	ErrInvalidBalance = errors.New("invalid balance for transfer")
 
 	// ErrInsufficientComputation is returned when not enough computation is
 	// left in the context of flow transaction to execute the evm operation.
@@ -105,16 +105,16 @@ var (
 	// ErrUnAuthroizedMethodCall method call, usually emited when calls are called on EOA accounts
 	ErrUnAuthroizedMethodCall = errors.New("unauthroized method call")
 
-	// ErrInternalDirecCallFailed is returned when a withdraw or deposit internal call
-	// has failed.
+	// ErrInternalDirecCallFailed is returned when a withdraw or deposit internal call has failed.
 	ErrInternalDirecCallFailed = errors.New("internal direct call execution failed")
 
 	// ErrWithdrawBalanceRounding is returned when withdraw call has a balance that could
 	// yeild to rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).
-	ErrWithdrawBalanceRounding = NewEVMValidationError(errors.New("withdraw failed! the balance is susceptible to the rounding error"))
+	ErrWithdrawBalanceRounding = errors.New("withdraw failed! the balance is susceptible to the rounding error")
 
-	// ErrDirectCallExecutionFailed is returned when the direct call execution has failed.
-	ErrDirectCallExecutionFailed = NewEVMValidationError(errors.New("direct call execution failed"))
+	// ErrUnexpectedEmptyResult is returned when a result is expected to be returned by the emulator
+	// but nil has been returned. This should never happen and is a safety error.
+	ErrUnexpectedEmptyResult = errors.New("unexpected empty result has been returned")
 
 	// ErrInsufficientTotalSupply is returned when flow token
 	// is withdraw request is there but not enough balance is on EVM vault

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -100,10 +100,10 @@ var (
 
 	// ErrInsufficientComputation is returned when not enough computation is
 	// left in the context of flow transaction to execute the evm operation.
-	ErrInsufficientComputation = NewEVMValidationError(errors.New("insufficient computation"))
+	ErrInsufficientComputation = errors.New("insufficient computation")
 
 	// ErrUnAuthroizedMethodCall method call, usually emited when calls are called on EOA accounts
-	ErrUnAuthroizedMethodCall = NewEVMValidationError(errors.New("unauthroized method call"))
+	ErrUnAuthroizedMethodCall = errors.New("unauthroized method call")
 
 	// ErrWithdrawBalanceRounding is returned when withdraw call has a balance that could
 	// yeild to rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).

--- a/fvm/evm/types/proof_test.go
+++ b/fvm/evm/types/proof_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestProof(t *testing.T) {
-
 	proof := testutils.COAOwnershipProofFixture(t)
 	encoded, err := proof.Encode()
 	require.NoError(t, err)

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -5,6 +5,43 @@ import (
 	gethTypes "github.com/onflow/go-ethereum/core/types"
 )
 
+// InvalidTransactionGasCost is a gas cost we charge when
+// a transaction or call fails at validation step.
+// in typical evm environment this doesn't exist given
+// if a transaction is invalid it won't be included
+// and no fees can be charged for users even though
+// the validation has used some resources, in our case
+// given we charge the fees on flow transaction and we
+// are doing on chain validation we can/should charge the
+// user for the validation fee.
+const InvalidTransactionGasCost = 1_000
+
+// Status captures the status of an interaction to the emulator
+type Status uint8
+
+var (
+	StatusUnknown Status = 0
+	// StatusInvalid shows that the transaction was not a valid
+	// transaction and rejected to be executed and included in any block.
+	StatusInvalid Status = 1
+	// StatusFailed shows that the transaction has been executed,
+	// but the output of the execution was an error
+	// for this case a block is formed and receipts are available
+	StatusFailed Status = 2
+	// StatusFailed shows that the transaction has been executed and the execution has returned success
+	// for this case a block is formed and receipts are available
+	StatusSuccessful Status = 3
+)
+
+// ResultSummary summerizes the outcome of a EVM call or tx run
+type ResultSummary struct {
+	Status                  Status
+	ErrorCode               ErrorCode
+	GasConsumed             uint64
+	DeployedContractAddress Address
+	ReturnedValue           Data
+}
+
 // Result captures the result of an interaction to the emulator
 // it could be the out put of a direct call or output of running an
 // evm transaction.
@@ -32,14 +69,24 @@ type Result struct {
 	TxHash gethCommon.Hash
 }
 
+// Invalid returns true if transaction has been rejected
 func (res *Result) Invalid() bool {
 	return res.ValidationError != nil
 }
 
+// Failed returns true if transaction has been executed but VM has returned some error
 func (res *Result) Failed() bool {
 	return res.VMError != nil
 }
 
+// SetValidationError sets the validation error
+// and also sets the gas used to the fixed invalid gas usage
+func (res *Result) SetValidationError(err error) {
+	res.ValidationError = err
+	res.GasConsumed = InvalidTransactionGasCost
+}
+
+// returns the VM error as an string, if no error it returns an empty string
 func (res *Result) VMErrorString() string {
 	if res.VMError != nil {
 		return res.VMError.Error()
@@ -75,32 +122,7 @@ func (res *Result) Receipt() *gethTypes.Receipt {
 	return receipt
 }
 
-// Status captures the status of an interaction to the emulator
-type Status uint8
-
-var (
-	StatusUnknown Status = 0
-	// StatusInvalid shows that the transaction was not a valid
-	// transaction and rejected to be executed and included in any block.
-	StatusInvalid Status = 1
-	// StatusFailed shows that the transaction has been executed,
-	// but the output of the execution was an error
-	// for this case a block is formed and receipts are available
-	StatusFailed Status = 2
-	// StatusFailed shows that the transaction has been executed and the execution has returned success
-	// for this case a block is formed and receipts are available
-	StatusSuccessful Status = 3
-)
-
-// ResultSummary summerizes the outcome of a EVM call or tx run
-type ResultSummary struct {
-	Status                  Status
-	ErrorCode               ErrorCode
-	GasConsumed             uint64
-	DeployedContractAddress Address
-	ReturnedValue           Data
-}
-
+// ResultSummary constructs a result summary
 func (res *Result) ResultSummary() *ResultSummary {
 	rs := &ResultSummary{}
 

--- a/fvm/evm/types/state.go
+++ b/fvm/evm/types/state.go
@@ -13,7 +13,15 @@ type StateDB interface {
 	gethVM.StateDB
 
 	// Commit commits the changes
-	Commit() error
+	// setting `finalize` flag
+	// calls a subsequent call to Finalize
+	// defering finalization and calling it once at the end
+	// improves efficiency of batch operations.
+	Commit(finalize bool) error
+
+	// Finalize flushes all the changes
+	// to the permanent storage
+	Finalize() error
 
 	// Logs collects and prepares logs
 	Logs(
@@ -22,8 +30,13 @@ type StateDB interface {
 		txIndex uint,
 	) []*gethTypes.Log
 
-	// returns a map of preimages
+	// Preimages returns a map of preimages
 	Preimages() map[gethCommon.Hash][]byte
+
+	// Reset resets uncommitted changes and transient artifacts such as error, logs,
+	// preimages, access lists, ...
+	// The method is often called between execution of different transactions
+	Reset()
 }
 
 // ReadOnlyView provides a readonly view of the state


### PR DESCRIPTION
This PR 
- is part 1 of the changes needed for #5501 
- changes the stateDB 
  - adds the `Reset` method to clean up the transient part of the storage (logs, transient slots, ... ), this method can be used between transactions. 
  - separate `Finalize` part of the `Commit` method and add it as a separate method. Finalize, commit the changes from the Atree cache into the final ledger state. This has been added so when executing multiple transactions, we can save time on the serialization time of Atree. 
  
- updates the way we return errors from the emulator and handle them on the handler
  - validation errors are also now part of the result and won't be returned by methods like `RunTransaction`. 
  - now any returned error from the emulator requires reverting the flow transaction (is a non-fatal but stopping error)
  - and validation errors are handled by the handler 
  - this allows the returning of multiple results for a batch of transactions and only returns an error when we hit one that requires reverting the flow transaction (e.g. running out of computation). 
  
Given that ValidationErrors are explicitly captured now, we don't need a wrapper.