### PR TITLE
[Access] Fix event conversion in local TxResults endpoint

### DIFF
--- a/engine/access/rpc/backend/transactions_local_data_provider.go
+++ b/engine/access/rpc/backend/transactions_local_data_provider.go
@@ -109,13 +109,9 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultFromStorage(
 
 	// events are encoded in CCF format in storage. convert to JSON-CDC if requested
 	if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
-		for _, e := range events {
-			payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
-			if err != nil {
-				err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
-				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
-			}
-			e.Payload = payload
+		events, err = convert.CcfEventsToJsonEvents(events)
+		if err != nil {
+			return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
 		}
 	}
 
@@ -197,13 +193,9 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultsByBlockIDFromStorag
 
 		// events are encoded in CCF format in storage. convert to JSON-CDC if requested
 		if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
-			for _, e := range events {
-				payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
-				if err != nil {
-					err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
-					return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
-				}
-				e.Payload = payload
+			events, err = convert.CcfEventsToJsonEvents(events)
+			if err != nil {
+				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
 			}
 		}
 
@@ -278,13 +270,9 @@ func (t *TransactionsLocalDataProvider) GetTransactionResultByIndexFromStorage(
 
 	// events are encoded in CCF format in storage. convert to JSON-CDC if requested
 	if requiredEventEncodingVersion == entities.EventEncodingVersion_JSON_CDC_V0 {
-		for _, e := range events {
-			payload, err := convert.CcfPayloadToJsonPayload(e.Payload)
-			if err != nil {
-				err = fmt.Errorf("failed to convert event payload for block %s: %w", blockID, err)
-				return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
-			}
-			e.Payload = payload
+		events, err = convert.CcfEventsToJsonEvents(events)
+		if err != nil {
+			return nil, rpc.ConvertError(err, "failed to convert event payload", codes.Internal)
 		}
 	}
 

--- a/engine/common/rpc/convert/events.go
+++ b/engine/common/rpc/convert/events.go
@@ -241,6 +241,20 @@ func CcfEventToJsonEvent(e flow.Event) (*flow.Event, error) {
 	}, nil
 }
 
+// CcfEventsToJsonEvents returns a new event with the payload converted from CCF to JSON
+func CcfEventsToJsonEvents(events []flow.Event) ([]flow.Event, error) {
+	convertedEvents := make([]flow.Event, len(events))
+	for i, e := range events {
+		payload, err := CcfPayloadToJsonPayload(e.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert event payload for event %d: %w", i, err)
+		}
+		e.Payload = payload
+		convertedEvents[i] = e
+	}
+	return convertedEvents, nil
+}
+
 // MessagesToBlockEvents converts a protobuf EventsResponse_Result messages to a slice of flow.BlockEvents.
 func MessagesToBlockEvents(blocksEvents []*accessproto.EventsResponse_Result) []flow.BlockEvents {
 	evs := make([]flow.BlockEvents, len(blocksEvents))


### PR DESCRIPTION
When running an AN configured to use local events for tx results, the event conversion was thrown away. This was caused by updating a local variable reference within a loop instead of the original data.