### PR TITLE
Implement `EVM.getLatestBlock()` function to expose info about the latest block

### DIFF
--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -7,14 +7,14 @@ contract EVM {
     access(all)
     event CadenceOwnedAccountCreated(addressBytes: [UInt8; 20])
 
-    /// FLOWTokensDeposited is emitted when FLOW tokens is bridged 
-    /// into the EVM environment. Note that this event is not emitted 
+    /// FLOWTokensDeposited is emitted when FLOW tokens is bridged
+    /// into the EVM environment. Note that this event is not emitted
     /// for transfer of flow tokens between two EVM addresses.
     access(all)
     event FLOWTokensDeposited(addressBytes: [UInt8; 20], amount: UFix64)
 
-    /// FLOWTokensWithdrawn is emitted when FLOW tokens are bridged 
-    /// out of the EVM environment. Note that this event is not emitted 
+    /// FLOWTokensWithdrawn is emitted when FLOW tokens are bridged
+    /// out of the EVM environment. Note that this event is not emitted
     /// for transfer of flow tokens between two EVM addresses.
     access(all)
     event FLOWTokensWithdrawn(addressBytes: [UInt8; 20], amount: UFix64)
@@ -372,7 +372,7 @@ contract EVM {
     struct ValidationResult {
         access(all)
         let isValid: Bool
-        
+
         access(all)
         let problem: String?
 
@@ -433,13 +433,13 @@ contract EVM {
         if !isValid{
             return ValidationResult(
                 isValid: false,
-                problem: "the given signatures are not valid or provide enough weight" 
+                problem: "the given signatures are not valid or provide enough weight"
             )
         }
 
         let coaRef = acc.getCapability(path)
             .borrow<&EVM.CadenceOwnedAccount{EVM.Addressable}>()
-        
+
         if coaRef == nil {
              return ValidationResult(
                  isValid: false,
@@ -457,10 +457,35 @@ contract EVM {
                 )
             }
         }
-        
+
         return ValidationResult(
-        	isValid: true,
-        	problem: nil
+            isValid: true,
+            problem: nil
         )
+    }
+
+    /// Block returns information about the latest executed block.
+    access(all)
+    struct EVMBlock {
+        access(all)
+        let height: UInt64
+
+        access(all)
+        let hash: String
+
+        access(all)
+        let totalSupply: Int
+
+        init(height: UInt64, hash: String, totalSupply: Int) {
+            self.height = height
+            self.hash = hash
+            self.totalSupply = totalSupply
+        }
+    }
+
+    /// Returns the latest executed block.
+    access(all)
+    fun getLatestBlock(): EVMBlock {
+        return InternalEVM.getLatestBlock() as! EVMBlock
     }
 }

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -49,6 +49,7 @@ const evmAddressTypeQualifiedIdentifier = "EVM.EVMAddress"
 const evmBalanceTypeQualifiedIdentifier = "EVM.Balance"
 const evmResultTypeQualifiedIdentifier = "EVM.Result"
 const evmStatusTypeQualifiedIdentifier = "EVM.Status"
+const evmBlockTypeQualifiedIdentifier = "EVM.EVMBlock"
 
 const abiEncodingByteSize = 32
 
@@ -1710,6 +1711,80 @@ func newInternalEVMTypeCastToFLOWFunction(
 	)
 }
 
+const internalEVMTypeGetLatestBlockFunctionName = "getLatestBlock"
+
+var internalEVMTypeGetLatestBlockFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{},
+	// Actually EVM.Block, but cannot refer to it here
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
+}
+
+func newInternalEVMTypeGetLatestBlockFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewHostFunctionValue(
+		gauge,
+		internalEVMTypeCallFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			latestBlock := handler.LastExecutedBlock()
+			return NewEVMBlockValue(handler, gauge, inter, locationRange, latestBlock)
+		},
+	)
+}
+
+func NewEVMBlockValue(
+	handler types.ContractHandler,
+	gauge common.MemoryGauge,
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	block *types.Block,
+) *interpreter.CompositeValue {
+	loc := common.NewAddressLocation(gauge, handler.EVMContractAddress(), ContractName)
+	hash, err := block.Hash()
+	if err != nil {
+		panic(err)
+	}
+
+	return interpreter.NewCompositeValue(
+		inter,
+		locationRange,
+		loc,
+		evmBlockTypeQualifiedIdentifier,
+		common.CompositeKindStructure,
+		[]interpreter.CompositeField{
+			{
+				Name:  "height",
+				Value: interpreter.UInt64Value(block.Height),
+			},
+			{
+				Name: "hash",
+				Value: interpreter.NewStringValue(
+					inter,
+					common.NewStringMemoryUsage(len(hash)),
+					func() string {
+						return hash.Hex()
+					},
+				),
+			},
+			{
+				Name: "totalSupply",
+				Value: interpreter.NewIntValueFromBigInt(
+					inter,
+					common.NewBigIntMemoryUsage(common.BigIntByteLength(block.TotalSupply)),
+					func() *big.Int {
+						return block.TotalSupply
+					},
+				),
+			},
+		},
+		common.ZeroAddress,
+	)
+}
+
 func NewInternalEVMContractValue(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
@@ -1735,6 +1810,7 @@ func NewInternalEVMContractValue(
 			internalEVMTypeDecodeABIFunctionName:                 newInternalEVMTypeDecodeABIFunction(gauge, location),
 			internalEVMTypeCastToAttoFLOWFunctionName:            newInternalEVMTypeCastToAttoFLOWFunction(gauge, handler),
 			internalEVMTypeCastToFLOWFunctionName:                newInternalEVMTypeCastToFLOWFunction(gauge, handler),
+			internalEVMTypeGetLatestBlockFunctionName:            newInternalEVMTypeGetLatestBlockFunction(gauge, handler),
 		},
 		nil,
 		nil,
@@ -1833,6 +1909,12 @@ var InternalEVMContractType = func() *sema.CompositeType {
 			ty,
 			internalEVMTypeDecodeABIFunctionName,
 			internalEVMTypeDecodeABIFunctionType,
+			"",
+		),
+		sema.NewUnmeteredPublicFunctionMember(
+			ty,
+			internalEVMTypeGetLatestBlockFunctionName,
+			internalEVMTypeGetLatestBlockFunctionType,
 			"",
 		),
 	})
@@ -1950,4 +2032,26 @@ func ResultSummaryFromEVMResultValue(val cadence.Value) (*types.ResultSummary, e
 		ReturnedValue: convertedData,
 	}, nil
 
+}
+
+func NewEVMBlockCadenceType(address common.Address) *cadence.StructType {
+	return cadence.NewStructType(
+		common.NewAddressLocation(nil, address, ContractName),
+		evmBlockTypeQualifiedIdentifier,
+		[]cadence.Field{
+			{
+				Identifier: "height",
+				Type:       cadence.UInt64Type{},
+			},
+			{
+				Identifier: "hash",
+				Type:       cadence.StringType{},
+			},
+			{
+				Identifier: "totalSupply",
+				Type:       cadence.IntType{},
+			},
+		},
+		nil,
+	)
 }


### PR DESCRIPTION
Sample usage:

```cadence
import EVM from 0x1

access(all)
fun main(): EVM.EVMBlock {
    return EVM.getLatestBlock()
}
```

The current fields of the `EVMBlock` struct are:

```cadence
access(all)
struct EVMBlock {
    access(all)
    let height: UInt64

    access(all)
    let hash: String

    access(all)
    let totalSupply: Int

    init(height: UInt64, hash: String, totalSupply: Int) {
        self.height = height
        self.hash = hash
        self.totalSupply = totalSupply
    }
}
```