### PR TITLE
Create payload snapshot using multiple workers

### DIFF
--- a/cmd/util/ledger/migrations/account_storage_migration.go
+++ b/cmd/util/ledger/migrations/account_storage_migration.go
@@ -16,12 +16,14 @@ import (
 func NewAccountStorageMigration(
 	address common.Address,
 	log zerolog.Logger,
+	nWorker int,
 	migrate func(*runtime.Storage, *interpreter.Interpreter) error,
 ) ledger.Migration {
 	return func(payloads []*ledger.Payload) ([]*ledger.Payload, error) {
 
 		migrationRuntime, err := NewMigratorRuntime(
 			log,
+			nWorker,
 			address,
 			payloads,
 			util.RuntimeInterfaceConfig{},

--- a/cmd/util/ledger/migrations/account_storage_migration.go
+++ b/cmd/util/ledger/migrations/account_storage_migration.go
@@ -21,6 +21,7 @@ func NewAccountStorageMigration(
 	return func(payloads []*ledger.Payload) ([]*ledger.Payload, error) {
 
 		migrationRuntime, err := NewMigratorRuntime(
+			log,
 			address,
 			payloads,
 			util.RuntimeInterfaceConfig{},
@@ -61,7 +62,6 @@ func NewAccountStorageMigration(
 		newPayloads, err := migrationRuntime.Snapshot.ApplyChangesAndGetNewPayloads(
 			result.WriteSet,
 			expectedAddresses,
-			log,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to merge register changes: %w", err)

--- a/cmd/util/ledger/migrations/atree_register_migration.go
+++ b/cmd/util/ledger/migrations/atree_register_migration.go
@@ -87,7 +87,7 @@ func (m *AtreeRegisterMigrator) MigrateAccount(
 	oldPayloads []*ledger.Payload,
 ) ([]*ledger.Payload, error) {
 	// create all the runtime components we need for the migration
-	mr, err := NewMigratorRuntime(address, oldPayloads, util.RuntimeInterfaceConfig{})
+	mr, err := NewMigratorRuntime(m.log, address, oldPayloads, util.RuntimeInterfaceConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migrator runtime: %w", err)
 	}

--- a/cmd/util/ledger/migrations/atree_register_migration.go
+++ b/cmd/util/ledger/migrations/atree_register_migration.go
@@ -87,7 +87,7 @@ func (m *AtreeRegisterMigrator) MigrateAccount(
 	oldPayloads []*ledger.Payload,
 ) ([]*ledger.Payload, error) {
 	// create all the runtime components we need for the migration
-	mr, err := NewMigratorRuntime(m.log, address, oldPayloads, util.RuntimeInterfaceConfig{})
+	mr, err := NewMigratorRuntime(m.log, 1, address, oldPayloads, util.RuntimeInterfaceConfig{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migrator runtime: %w", err)
 	}

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -330,7 +330,7 @@ func NewCadence1ContractsMigrations(
 			migrations,
 			NamedMigration{
 				Name:    "burner-deployment-migration",
-				Migrate: NewBurnerDeploymentMigration(chainID, log),
+				Migrate: NewBurnerDeploymentMigration(chainID, log, nWorker),
 			},
 		)
 	}
@@ -385,7 +385,7 @@ func NewCadence1Migrations(
 	}
 
 	if prune {
-		migration := NewCadence1PruneMigration(chainID, log)
+		migration := NewCadence1PruneMigration(chainID, nWorker, log)
 		if migration != nil {
 			migrations = append(
 				migrations,

--- a/cmd/util/ledger/migrations/cadence_value_diff_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff_test.go
@@ -174,6 +174,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 			mr, err := NewMigratorRuntime(
 				zerolog.Nop(),
+				2,
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -275,6 +276,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 			mr, err := NewMigratorRuntime(
 				zerolog.Nop(),
+				2,
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -383,6 +385,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 			mr, err := NewMigratorRuntime(
 				zerolog.Nop(),
+				2,
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -502,6 +505,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 			mr, err := NewMigratorRuntime(
 				zerolog.Nop(),
+				2,
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -628,6 +632,7 @@ func createStorageMapPayloads(t *testing.T, address common.Address, domain strin
 
 	mr, err := NewMigratorRuntime(
 		zerolog.Nop(),
+		2,
 		address,
 		[]*ledger.Payload{accountStatusPayload},
 		util.RuntimeInterfaceConfig{},

--- a/cmd/util/ledger/migrations/cadence_value_diff_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rs/zerolog"
+
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 
@@ -171,6 +173,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			)
 
 			mr, err := NewMigratorRuntime(
+				zerolog.Nop(),
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -271,6 +274,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			)
 
 			mr, err := NewMigratorRuntime(
+				zerolog.Nop(),
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -378,6 +382,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			)
 
 			mr, err := NewMigratorRuntime(
+				zerolog.Nop(),
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -496,6 +501,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			)
 
 			mr, err := NewMigratorRuntime(
+				zerolog.Nop(),
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -621,6 +627,7 @@ func createStorageMapPayloads(t *testing.T, address common.Address, domain strin
 	)
 
 	mr, err := NewMigratorRuntime(
+		zerolog.Nop(),
 		address,
 		[]*ledger.Payload{accountStatusPayload},
 		util.RuntimeInterfaceConfig{},

--- a/cmd/util/ledger/migrations/cadence_value_validation.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation.go
@@ -363,7 +363,7 @@ func newReadonlyStorageRuntime(payloads []*ledger.Payload) (
 	*readonlyStorageRuntime,
 	error,
 ) {
-	snapshot, err := util.NewMapBasedPayloadSnapshot(payloads)
+	snapshot, err := util.NewMapBasedPayloadSnapshot(zerolog.Nop(), payloads)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payload snapshot: %w", err)
 	}

--- a/cmd/util/ledger/migrations/cadence_value_validation.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation.go
@@ -363,7 +363,7 @@ func newReadonlyStorageRuntime(payloads []*ledger.Payload) (
 	*readonlyStorageRuntime,
 	error,
 ) {
-	snapshot, err := util.NewMapBasedPayloadSnapshot(zerolog.Nop(), payloads)
+	snapshot, err := util.NewMapBasedPayloadSnapshotWithWorkers(zerolog.Nop(), payloads, 1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payload snapshot: %w", err)
 	}

--- a/cmd/util/ledger/migrations/cadence_value_validation_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation_test.go
@@ -54,6 +54,7 @@ func TestValidateCadenceValues(t *testing.T) {
 			)
 
 			mr, err := NewMigratorRuntime(
+				zerolog.Nop(),
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -146,6 +147,7 @@ func createTestPayloads(t *testing.T, address common.Address, domain string) []*
 	)
 
 	mr, err := NewMigratorRuntime(
+		zerolog.Nop(),
 		address,
 		[]*ledger.Payload{accountStatusPayload},
 		util.RuntimeInterfaceConfig{},

--- a/cmd/util/ledger/migrations/cadence_value_validation_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation_test.go
@@ -55,6 +55,7 @@ func TestValidateCadenceValues(t *testing.T) {
 
 			mr, err := NewMigratorRuntime(
 				zerolog.Nop(),
+				2,
 				address,
 				[]*ledger.Payload{accountStatusPayload},
 				util.RuntimeInterfaceConfig{},
@@ -148,6 +149,7 @@ func createTestPayloads(t *testing.T, address common.Address, domain string) []*
 
 	mr, err := NewMigratorRuntime(
 		zerolog.Nop(),
+		2,
 		address,
 		[]*ledger.Payload{accountStatusPayload},
 		util.RuntimeInterfaceConfig{},

--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -94,6 +94,7 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 
 	migrationRuntime, err := NewMigratorRuntime(
 		m.log,
+		1,
 		address,
 		oldPayloads,
 		m.runtimeInterfaceConfig,

--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -93,6 +93,7 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 	// Create all the runtime components we need for the migration
 
 	migrationRuntime, err := NewMigratorRuntime(
+		m.log,
 		address,
 		oldPayloads,
 		m.runtimeInterfaceConfig,
@@ -148,7 +149,6 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 	newPayloads, err := migrationRuntime.Snapshot.ApplyChangesAndGetNewPayloads(
 		result.WriteSet,
 		expectedAddresses,
-		m.log,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to merge register changes: %w", err)

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -124,6 +124,7 @@ func checkMigratedPayloads(
 ) {
 	mr, err := NewMigratorRuntime(
 		zerolog.Nop(),
+		2,
 		address,
 		newPayloads,
 		util.RuntimeInterfaceConfig{},
@@ -745,6 +746,7 @@ func TestProgramParsingError(t *testing.T) {
 
 	runtime, err := NewMigratorRuntime(
 		zerolog.Nop(),
+		2,
 		testAddress,
 		payloads,
 		util.RuntimeInterfaceConfig{},
@@ -889,6 +891,7 @@ func TestCoreContractUsage(t *testing.T) {
 
 		runtime, err := NewMigratorRuntime(
 			zerolog.Nop(),
+			2,
 			testAddress,
 			payloads,
 			util.RuntimeInterfaceConfig{},
@@ -979,6 +982,7 @@ func TestCoreContractUsage(t *testing.T) {
 
 		mr, err := NewMigratorRuntime(
 			zerolog.Nop(),
+			2,
 			testAddress,
 			payloads,
 			util.RuntimeInterfaceConfig{},

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -123,6 +123,7 @@ func checkMigratedPayloads(
 	newPayloads []*ledger.Payload,
 ) {
 	mr, err := NewMigratorRuntime(
+		zerolog.Nop(),
 		address,
 		newPayloads,
 		util.RuntimeInterfaceConfig{},
@@ -743,6 +744,7 @@ func TestProgramParsingError(t *testing.T) {
 	require.NoError(t, err)
 
 	runtime, err := NewMigratorRuntime(
+		zerolog.Nop(),
 		testAddress,
 		payloads,
 		util.RuntimeInterfaceConfig{},
@@ -799,7 +801,6 @@ func TestProgramParsingError(t *testing.T) {
 	payloads, err = runtime.Snapshot.ApplyChangesAndGetNewPayloads(
 		result.WriteSet,
 		expectedAddresses,
-		logger,
 	)
 	require.NoError(t, err)
 
@@ -887,6 +888,7 @@ func TestCoreContractUsage(t *testing.T) {
 		require.NoError(t, err)
 
 		runtime, err := NewMigratorRuntime(
+			zerolog.Nop(),
 			testAddress,
 			payloads,
 			util.RuntimeInterfaceConfig{},
@@ -935,7 +937,6 @@ func TestCoreContractUsage(t *testing.T) {
 		payloads, err = runtime.Snapshot.ApplyChangesAndGetNewPayloads(
 			result.WriteSet,
 			expectedAddresses,
-			logger,
 		)
 		require.NoError(t, err)
 
@@ -977,6 +978,7 @@ func TestCoreContractUsage(t *testing.T) {
 		// Get result
 
 		mr, err := NewMigratorRuntime(
+			zerolog.Nop(),
 			testAddress,
 			payloads,
 			util.RuntimeInterfaceConfig{},

--- a/cmd/util/ledger/migrations/deploy_migration.go
+++ b/cmd/util/ledger/migrations/deploy_migration.go
@@ -15,6 +15,7 @@ func NewDeploymentMigration(
 	contract Contract,
 	authorizer flow.Address,
 	expectedWriteAddresses map[flow.Address]struct{},
+	nWorker int,
 	logger zerolog.Logger,
 ) ledger.Migration {
 
@@ -36,6 +37,7 @@ func NewDeploymentMigration(
 		tx,
 		chainID,
 		logger,
+		nWorker,
 		expectedWriteAddresses,
 	)
 }
@@ -43,6 +45,7 @@ func NewDeploymentMigration(
 func NewBurnerDeploymentMigration(
 	chainID flow.ChainID,
 	logger zerolog.Logger,
+	nWorker int,
 ) ledger.Migration {
 	address := BurnerAddressForChain(chainID)
 	return NewDeploymentMigration(
@@ -55,6 +58,7 @@ func NewBurnerDeploymentMigration(
 		map[flow.Address]struct{}{
 			address: {},
 		},
+		nWorker,
 		logger,
 	)
 }

--- a/cmd/util/ledger/migrations/deploy_migration_test.go
+++ b/cmd/util/ledger/migrations/deploy_migration_test.go
@@ -67,6 +67,7 @@ func TestDeploy(t *testing.T) {
 
 	targetAddress := serviceAccountAddress
 
+	nWorker := 2
 	migration := NewDeploymentMigration(
 		chainID,
 		Contract{
@@ -91,6 +92,7 @@ func TestDeploy(t *testing.T) {
 		map[flow.Address]struct{}{
 			targetAddress: {},
 		},
+		nWorker,
 		zerolog.New(zerolog.NewTestWriter(t)),
 	)
 

--- a/cmd/util/ledger/migrations/migrator_runtime.go
+++ b/cmd/util/ledger/migrations/migrator_runtime.go
@@ -30,6 +30,7 @@ var _ storage.TransactionPreparer = migrationTransactionPreparer{}
 // migratorRuntime is a runtime that can be used to run a migration on a single account
 func NewMigratorRuntime(
 	log zerolog.Logger,
+	nWorker int,
 	address common.Address,
 	payloads []*ledger.Payload,
 	config util.RuntimeInterfaceConfig,
@@ -37,7 +38,7 @@ func NewMigratorRuntime(
 	*migratorRuntime,
 	error,
 ) {
-	snapshot, err := util.NewMapBasedPayloadSnapshot(log, payloads)
+	snapshot, err := util.NewMapBasedPayloadSnapshotWithWorkers(log, payloads, nWorker)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payload snapshot: %w", err)
 	}

--- a/cmd/util/ledger/migrations/migrator_runtime.go
+++ b/cmd/util/ledger/migrations/migrator_runtime.go
@@ -3,6 +3,8 @@ package migrations
 import (
 	"fmt"
 
+	"github.com/rs/zerolog"
+
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -27,6 +29,7 @@ var _ storage.TransactionPreparer = migrationTransactionPreparer{}
 
 // migratorRuntime is a runtime that can be used to run a migration on a single account
 func NewMigratorRuntime(
+	log zerolog.Logger,
 	address common.Address,
 	payloads []*ledger.Payload,
 	config util.RuntimeInterfaceConfig,
@@ -34,7 +37,7 @@ func NewMigratorRuntime(
 	*migratorRuntime,
 	error,
 ) {
-	snapshot, err := util.NewMapBasedPayloadSnapshot(payloads)
+	snapshot, err := util.NewMapBasedPayloadSnapshot(log, payloads)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payload snapshot: %w", err)
 	}

--- a/cmd/util/ledger/migrations/prune_migration.go
+++ b/cmd/util/ledger/migrations/prune_migration.go
@@ -25,7 +25,7 @@ func PruneEmptyMigration(payload []ledger.Payload) ([]ledger.Payload, error) {
 }
 
 // NewCadence1PruneMigration prunes some values from the service account in the Testnet state
-func NewCadence1PruneMigration(chainID flow.ChainID, log zerolog.Logger) ledger.Migration {
+func NewCadence1PruneMigration(chainID flow.ChainID, nWorker int, log zerolog.Logger) ledger.Migration {
 	if chainID != flow.Testnet {
 		return nil
 	}
@@ -45,6 +45,7 @@ func NewCadence1PruneMigration(chainID flow.ChainID, log zerolog.Logger) ledger.
 	return NewAccountStorageMigration(
 		serviceAccountAddress,
 		log,
+		nWorker,
 		migrate,
 	)
 }

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -97,7 +97,7 @@ func (m *StagedContractsMigration) Close() error {
 func (m *StagedContractsMigration) InitMigration(
 	log zerolog.Logger,
 	allPayloads []*ledger.Payload,
-	_ int,
+	nWorker int,
 ) error {
 	m.log = log.
 		With().
@@ -129,7 +129,7 @@ func (m *StagedContractsMigration) InitMigration(
 	}
 
 	// Pass empty address. We are only interested in the created `env` object.
-	mr, err := NewMigratorRuntime(m.log, common.Address{}, allPayloads, config)
+	mr, err := NewMigratorRuntime(m.log, nWorker, common.Address{}, allPayloads, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -129,7 +129,7 @@ func (m *StagedContractsMigration) InitMigration(
 	}
 
 	// Pass empty address. We are only interested in the created `env` object.
-	mr, err := NewMigratorRuntime(common.Address{}, allPayloads, config)
+	mr, err := NewMigratorRuntime(m.log, common.Address{}, allPayloads, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/util/ledger/migrations/transaction_migration.go
+++ b/cmd/util/ledger/migrations/transaction_migration.go
@@ -10,12 +10,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-func NewTransactionBasedMigration(
-	tx *flow.TransactionBody,
-	chainID flow.ChainID,
-	logger zerolog.Logger,
-	expectedWriteAddresses map[flow.Address]struct{},
-) ledger.Migration {
+func NewTransactionBasedMigration(tx *flow.TransactionBody, chainID flow.ChainID, logger zerolog.Logger, workers int, expectedWriteAddresses map[flow.Address]struct{}) ledger.Migration {
 	return func(payloads []*ledger.Payload) ([]*ledger.Payload, error) {
 
 		options := computation.DefaultFVMOptions(chainID, false, false)
@@ -27,7 +22,7 @@ func NewTransactionBasedMigration(
 			fvm.WithTransactionFeesEnabled(false))
 		ctx := fvm.NewContext(options...)
 
-		snapshot, err := util.NewMapBasedPayloadSnapshot(logger, payloads)
+		snapshot, err := util.NewMapBasedPayloadSnapshotWithWorkers(logger, payloads, workers)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/util/ledger/migrations/transaction_migration.go
+++ b/cmd/util/ledger/migrations/transaction_migration.go
@@ -27,7 +27,7 @@ func NewTransactionBasedMigration(
 			fvm.WithTransactionFeesEnabled(false))
 		ctx := fvm.NewContext(options...)
 
-		snapshot, err := util.NewMapBasedPayloadSnapshot(payloads)
+		snapshot, err := util.NewMapBasedPayloadSnapshot(logger, payloads)
 		if err != nil {
 			return nil, err
 		}
@@ -51,7 +51,6 @@ func NewTransactionBasedMigration(
 		return snapshot.ApplyChangesAndGetNewPayloads(
 			executionSnapshot.WriteSet,
 			expectedWriteAddresses,
-			logger,
 		)
 	}
 }

--- a/cmd/util/ledger/util/payload_snapshot_test.go
+++ b/cmd/util/ledger/util/payload_snapshot_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 func Benchmark_PayloadSnapshot(b *testing.B) {
-	//benchMerge := func(
-	//	b *testing.B,
-	//	payloadsNum int, changesNum []int,
-	//) {
-	//	b.Run("merge_"+strconv.Itoa(payloadsNum), func(b *testing.B) {
-	//		benchmarkMerge(b, payloadsNum, changesNum)
-	//	})
-	//}
+	benchMerge := func(
+		b *testing.B,
+		payloadsNum int, changesNum []int,
+	) {
+		b.Run("merge_"+strconv.Itoa(payloadsNum), func(b *testing.B) {
+			benchmarkMerge(b, payloadsNum, changesNum)
+		})
+	}
 
 	benchCreate := func(
 		b *testing.B,
@@ -34,13 +34,13 @@ func Benchmark_PayloadSnapshot(b *testing.B) {
 		})
 	}
 
-	//benchCreate(b, 1000)
-	//benchCreate(b, 100000)
+	benchCreate(b, 1000)
+	benchCreate(b, 100000)
 	benchCreate(b, 100000000)
 
-	//benchMerge(b, 1000, []int{10, 100, 1000})
-	//benchMerge(b, 100000, []int{10, 1000, 100000})
-	//benchMerge(b, 10000000, []int{10, 10000, 10000000})
+	benchMerge(b, 1000, []int{10, 100, 1000})
+	benchMerge(b, 100000, []int{10, 1000, 100000})
+	benchMerge(b, 10000000, []int{10, 10000, 10000000})
 }
 
 func randomPayload(size int) []byte {


### PR DESCRIPTION
I tried using go `maps.Copy` to speed up payload creation, since, from the logs, it seems it takes a few minutes on testnet.

The results for `1 00 000 000` payloads look promising:

```
BenchmarkGroupPayloadsByAccount/1_worker
BenchmarkGroupPayloadsByAccount/1_worker-12         	       1	1550036375 ns/op
BenchmarkGroupPayloadsByAccount/2_worker
BenchmarkGroupPayloadsByAccount/2_worker-12         	       2	 893871916 ns/op
BenchmarkGroupPayloadsByAccount/4_worker
BenchmarkGroupPayloadsByAccount/4_worker-12         	       2	 886168479 ns/op
BenchmarkGroupPayloadsByAccount/8_worker
BenchmarkGroupPayloadsByAccount/8_worker-12         	       2	 528607542 ns/op
BenchmarkGroupPayloadsByAccount/max_worker
BenchmarkGroupPayloadsByAccount/max_worker-12       	       2	 561127042 ns/op
```
about a 2.7X improvement with 12 cores.

What do you think?