### PR TITLE
Relax requirement for elapsed time during binstat init

### DIFF
--- a/utils/binstat/binstat.go
+++ b/utils/binstat/binstat.go
@@ -242,7 +242,7 @@ func init() {
 	}
 
 	t2 := runtimeNanoAsTimeDuration()
-	if t2 <= t1 {
+	if t2 < t1 {
 		panic(fmt.Sprintf("ERROR: BINSTAT: INTERNAL: t1=%d but t2=%d\n", t1, t2))
 	}
 }


### PR DESCRIPTION
closes #5584 

Relaxes the requirement for elapsed time because some systems do not have time resolution precise enough in comparison to the execution time.