### PR TITLE
Fix storage map key conversion in atree migration

### DIFF
--- a/cmd/util/ledger/migrations/atree_register_migration.go
+++ b/cmd/util/ledger/migrations/atree_register_migration.go
@@ -179,7 +179,7 @@ func (m *AtreeRegisterMigrator) convertStorageDomain(
 	storageMapIds[string(atree.SlabIndexToLedgerKey(storageMap.StorageID().Index))] = struct{}{}
 
 	iterator := storageMap.Iterator(util.NopMemoryGauge{})
-	keys := make([]interpreter.StringStorageMapKey, 0, storageMap.Count())
+	keys := make([]interpreter.StorageMapKey, 0, storageMap.Count())
 	// to be safe avoid modifying the map while iterating
 	for {
 		key := iterator.NextKey()
@@ -187,12 +187,16 @@ func (m *AtreeRegisterMigrator) convertStorageDomain(
 			break
 		}
 
-		stringKey, ok := key.(interpreter.StringAtreeValue)
-		if !ok {
-			return fmt.Errorf("invalid key type %T, expected interpreter.StringAtreeValue", key)
-		}
+		switch key := key.(type) {
+		case interpreter.StringAtreeValue:
+			keys = append(keys, interpreter.StringStorageMapKey(key))
 
-		keys = append(keys, interpreter.StringStorageMapKey(stringKey))
+		case interpreter.Uint64AtreeValue:
+			keys = append(keys, interpreter.Uint64StorageMapKey(key))
+
+		default:
+			return fmt.Errorf("invalid key type %T, expected interpreter.StringAtreeValue or interpreter.Uint64AtreeValue", key)
+		}
 	}
 
 	for _, key := range keys {
@@ -228,7 +232,7 @@ func (m *AtreeRegisterMigrator) convertStorageDomain(
 			m.rw.Write(migrationProblem{
 				Address: mr.Address.Hex(),
 				Size:    len(mr.Snapshot.Payloads),
-				Key:     string(key),
+				Key:     fmt.Sprintf("%v (%T)", key, key),
 				Kind:    "migration_failure",
 				Msg:     err.Error(),
 			})

--- a/cmd/util/ledger/migrations/cadence_value_validation.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation.go
@@ -86,12 +86,20 @@ func validateStorageDomain(
 			break
 		}
 
-		stringKey, ok := key.(interpreter.StringAtreeValue)
-		if !ok {
-			return fmt.Errorf("invalid key type %T, expected interpreter.StringAtreeValue", key)
+		var mapKey interpreter.StorageMapKey
+
+		switch key := key.(type) {
+		case interpreter.StringAtreeValue:
+			mapKey = interpreter.StringStorageMapKey(key)
+
+		case interpreter.Uint64AtreeValue:
+			mapKey = interpreter.Uint64StorageMapKey(key)
+
+		default:
+			return fmt.Errorf("invalid key type %T, expected interpreter.StringAtreeValue or interpreter.Uint64AtreeValue", key)
 		}
 
-		newValue := newStorageMap.ReadValue(nopMemoryGauge, interpreter.StringStorageMapKey(stringKey))
+		newValue := newStorageMap.ReadValue(nopMemoryGauge, mapKey)
 
 		err := cadenceValueEqual(oldRuntime.Interpreter, oldValue, newRuntime.Interpreter, newValue)
 		if err != nil {
@@ -99,7 +107,7 @@ func validateStorageDomain(
 				log.Info().
 					Str("address", address.Hex()).
 					Str("domain", domain).
-					Str("key", string(stringKey)).
+					Str("key", fmt.Sprintf("%v (%T)", mapKey, mapKey)).
 					Str("trace", err.Error()).
 					Str("old value", oldValue.String()).
 					Str("new value", newValue.String()).

--- a/cmd/util/ledger/migrations/cadence_value_validation_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation_test.go
@@ -103,7 +103,7 @@ func TestValidateCadenceValues(t *testing.T) {
 		oldPayloads := createPayloads(interpreter.NewUnmeteredUInt64Value(1))
 		newPayloads := createPayloads(interpreter.NewUnmeteredUInt64Value(2))
 		wantErrorMsg := "failed to validate value for address 0000000000000001, domain storage, key 0: failed to validate ([AnyStruct][0]).([UInt64][1]): values differ: 1 (interpreter.UInt64Value) != 2 (interpreter.UInt64Value)"
-		wantVerboseMsg := "{\"level\":\"info\",\"address\":\"0000000000000001\",\"domain\":\"storage\",\"key\":\"0\",\"trace\":\"failed to validate ([AnyStruct][0]).([UInt64][1]): values differ: 1 (interpreter.UInt64Value) != 2 (interpreter.UInt64Value)\",\"old value\":\"[[0, 1]]\",\"new value\":\"[[0, 2]]\",\"message\":\"failed to validate value\"}\n"
+		wantVerboseMsg := "{\"level\":\"info\",\"address\":\"0000000000000001\",\"domain\":\"storage\",\"key\":\"0 (interpreter.StringStorageMapKey)\",\"trace\":\"failed to validate ([AnyStruct][0]).([UInt64][1]): values differ: 1 (interpreter.UInt64Value) != 2 (interpreter.UInt64Value)\",\"old value\":\"[[0, 1]]\",\"new value\":\"[[0, 2]]\",\"message\":\"failed to validate value\"}\n"
 
 		// Disable verbose logging
 		err := validateCadenceValues(


### PR DESCRIPTION
Currently storage map key is assumed to be StringAtreeValue type. However, storage domain cap_con uses Uint64AtreeValue as storage map key.

This PR supports both map key types during atree migration and Cadence value validation.

This problem was found by using latest testnet data for atree migration + Cadence v0.42. Prior tests using mainnet data did not encounter this issue.