### PR TITLE
Improve validation for Cadence values in atree migration

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -21,21 +21,22 @@ import (
 )
 
 var (
-	flagExecutionStateDir             string
-	flagOutputDir                     string
-	flagBlockHash                     string
-	flagStateCommitment               string
-	flagDatadir                       string
-	flagChain                         string
-	flagNWorker                       int
-	flagNoMigration                   bool
-	flagNoReport                      bool
-	flagValidateMigration             bool
-	flagLogVerboseValidationError     bool
-	flagAllowPartialStateFromPayloads bool
-	flagInputPayloadFileName          string
-	flagOutputPayloadFileName         string
-	flagOutputPayloadByAddresses      string
+	flagExecutionStateDir                  string
+	flagOutputDir                          string
+	flagBlockHash                          string
+	flagStateCommitment                    string
+	flagDatadir                            string
+	flagChain                              string
+	flagNWorker                            int
+	flagNoMigration                        bool
+	flagNoReport                           bool
+	flagValidateMigration                  bool
+	flagLogVerboseValidationError          bool
+	flagAllowPartialStateFromPayloads      bool
+	flagContinueMigrationOnValidationError bool
+	flagInputPayloadFileName               string
+	flagOutputPayloadFileName              string
+	flagOutputPayloadByAddresses           string
 )
 
 var Cmd = &cobra.Command{
@@ -80,6 +81,9 @@ func init() {
 
 	Cmd.Flags().BoolVar(&flagAllowPartialStateFromPayloads, "allow-partial-state-from-payload-file", false,
 		"allow input payload file containing partial state (e.g. not all accounts)")
+
+	Cmd.Flags().BoolVar(&flagContinueMigrationOnValidationError, "continue-migration-on-validation-errors", false,
+		"continue migration even if validation fails")
 
 	// If specified, the state will consist of payloads from the given input payload file.
 	// If not specified, then the state will be extracted from the latest checkpoint file.

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -364,6 +364,7 @@ func newMigrations(
 						rwf,
 						flagValidateMigration,
 						flagLogVerboseValidationError,
+						flagContinueMigrationOnValidationError,
 					),
 
 					&migrators.DeduplicateContractNamesMigration{},

--- a/cmd/util/ledger/migrations/atree_register_migration_test.go
+++ b/cmd/util/ledger/migrations/atree_register_migration_test.go
@@ -30,7 +30,12 @@ func TestAtreeRegisterMigration(t *testing.T) {
 			"test-data/bootstrapped_v0.31",
 			migrations.CreateAccountBasedMigration(log, 2,
 				[]migrations.AccountBasedMigration{
-					migrations.NewAtreeRegisterMigrator(reporters.NewReportFileWriterFactory(dir, log), true, false),
+					migrations.NewAtreeRegisterMigrator(
+						reporters.NewReportFileWriterFactory(dir, log),
+						true,
+						false,
+						false,
+					),
 				},
 			),
 			func(t *testing.T, oldPayloads []*ledger.Payload, newPayloads []*ledger.Payload) {

--- a/cmd/util/ledger/migrations/cadence_value_validation.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation.go
@@ -290,14 +290,13 @@ func cadenceCompositeValueEqual(
 		return err
 	}
 
-	// TODO: Use CompositeValue.FieldCount() from Cadence after it is merged and available.
-	otherFieldNames := make([]string, 0, len(vFieldNames)) // otherComposite's field names
-	otherComposite.ForEachField(nopMemoryGauge, func(fieldName string, _ interpreter.Value) bool {
-		otherFieldNames = append(otherFieldNames, fieldName)
-		return true
-	})
+	if len(vFieldNames) != otherComposite.FieldCount() {
+		otherFieldNames := make([]string, 0, len(vFieldNames)) // otherComposite's field names
+		otherComposite.ForEachField(nopMemoryGauge, func(fieldName string, _ interpreter.Value) bool {
+			otherFieldNames = append(otherFieldNames, fieldName)
+			return true
+		})
 
-	if len(vFieldNames) != len(otherFieldNames) {
 		return newValidationErrorf(
 			"composite %s fields differ: %v != %v",
 			v.TypeID(),

--- a/cmd/util/ledger/migrations/cadence_value_validation.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation.go
@@ -286,6 +286,9 @@ func cadenceCompositeValueEqual(
 		vFieldNames = append(vFieldNames, fieldName)
 		return true
 	})
+	if err != nil {
+		return err
+	}
 
 	// TODO: Use CompositeValue.FieldCount() from Cadence after it is merged and available.
 	otherFieldNames := make([]string, 0, len(vFieldNames)) // otherComposite's field names


### PR DESCRIPTION
Closes #5335 

Changes:
- Added flag `continue-migration-on-validation-errors` to continue migration even if validation fails.
- Optimized Cadence field count in migration value validation
- Made validation errors of Cadence composite elements return early