### PR TITLE
Fix storage health check in Cadence 1.0 migration

### DIFF
--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -133,6 +133,11 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 			}
 		}
 
+		// Load storage map.
+		for _, domain := range domains {
+			_ = storage.GetStorageMap(address, domain, false)
+		}
+
 		storageHealthErrorBefore = storage.CheckHealth()
 		if storageHealthErrorBefore != nil {
 			m.log.Warn().


### PR DESCRIPTION
Currently, storage health check always fails with "slabs not referenced from account storage" in pre-migration because storage maps are not loaded in Cadence runtime storage even though payloads are loaded.

This PR fixes this problem by loading storage map explicitly after loading payloads in storage.

Updates https://github.com/onflow/cadence/issues/3192

cc: @turbolent