### PR TITLE
Export user defined type change checker

### DIFF
--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -63,7 +63,7 @@ func NewStagedContractsMigration(chainID flow.ChainID, log zerolog.Logger) *Stag
 
 func (m *StagedContractsMigration) WithContractUpdateValidation() *StagedContractsMigration {
 	m.enableUpdateValidation = true
-	m.userDefinedTypeChangeCheckFunc = newUserDefinedTypeChangeCheckerFunc(m.chainID)
+	m.userDefinedTypeChangeCheckFunc = NewUserDefinedTypeChangeCheckerFunc(m.chainID)
 	return m
 }
 
@@ -403,7 +403,7 @@ func StagedContractsFromCSV(path string) ([]StagedContract, error) {
 	return contracts, nil
 }
 
-func newUserDefinedTypeChangeCheckerFunc(
+func NewUserDefinedTypeChangeCheckerFunc(
 	chainID flow.ChainID,
 ) func(oldTypeID common.TypeID, newTypeID common.TypeID) (checked, valid bool) {
 


### PR DESCRIPTION
This needs to be used in the Flow CLI for preliminary staging validation, would be useful to have this exported if there are any changes in the future/elimates code duplication.

re. https://github.com/onflow/flow-cli/pull/1495