### PR TITLE
Port binstat fix to `feature/stable-cadence`

### DIFF
--- a/utils/binstat/binstat.go
+++ b/utils/binstat/binstat.go
@@ -242,7 +242,7 @@ func init() {
 	}
 
 	t2 := runtimeNanoAsTimeDuration()
-	if t2 <= t1 {
+	if t2 < t1 {
 		panic(fmt.Sprintf("ERROR: BINSTAT: INTERNAL: t1=%d but t2=%d\n", t1, t2))
 	}
 }


### PR DESCRIPTION
Relax requirement for elapsed time during binstat init

I am unsure what the status is on https://github.com/onflow/flow-go/pull/5575, so I just made this PR to cherry-pick the fix from `master` to `feature/stable-cadence`, since this causes issues for Windows users trying to use the Flow CLI & the `flow-c1` CLI does not have this fix yet.