### PR TITLE
Add storage health check flags for atree migration

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -34,6 +34,8 @@ var (
 	flagLogVerboseValidationError          bool
 	flagAllowPartialStateFromPayloads      bool
 	flagContinueMigrationOnValidationError bool
+	flagCheckStorageHealthBeforeMigration  bool
+	flagCheckStorageHealthAfterMigration   bool
 	flagInputPayloadFileName               string
 	flagOutputPayloadFileName              string
 	flagOutputPayloadByAddresses           string
@@ -81,6 +83,12 @@ func init() {
 
 	Cmd.Flags().BoolVar(&flagAllowPartialStateFromPayloads, "allow-partial-state-from-payload-file", false,
 		"allow input payload file containing partial state (e.g. not all accounts)")
+
+	Cmd.Flags().BoolVar(&flagCheckStorageHealthBeforeMigration, "check-storage-health-before", false,
+		"check (atree) storage health before migration")
+
+	Cmd.Flags().BoolVar(&flagCheckStorageHealthAfterMigration, "check-storage-health-after", false,
+		"check (atree) storage health after migration")
 
 	Cmd.Flags().BoolVar(&flagContinueMigrationOnValidationError, "continue-migration-on-validation-errors", false,
 		"continue migration even if validation fails")
@@ -246,6 +254,14 @@ func run(*cobra.Command, []string) {
 
 	if flagLogVerboseValidationError {
 		log.Warn().Msgf("atree migration has verbose validation error logging enabled which may increase size of log")
+	}
+
+	if flagCheckStorageHealthBeforeMigration {
+		log.Warn().Msgf("--check-storage-health-before flag is enabled and will increase duration of migration")
+	}
+
+	if flagCheckStorageHealthAfterMigration {
+		log.Warn().Msgf("--check-storage-health-after flag is enabled and will increase duration of migration")
 	}
 
 	var inputMsg string

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -365,6 +365,8 @@ func newMigrations(
 						flagValidateMigration,
 						flagLogVerboseValidationError,
 						flagContinueMigrationOnValidationError,
+						flagCheckStorageHealthBeforeMigration,
+						flagCheckStorageHealthAfterMigration,
 					),
 
 					&migrators.DeduplicateContractNamesMigration{},

--- a/cmd/util/ledger/migrations/atree_register_migration.go
+++ b/cmd/util/ledger/migrations/atree_register_migration.go
@@ -14,7 +14,6 @@ import (
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
-	"github.com/onflow/cadence/runtime/stdlib"
 
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/fvm/environment"
@@ -178,41 +177,6 @@ func (m *AtreeRegisterMigrator) MigrateAccount(
 	}
 
 	return newPayloads, nil
-}
-
-func checkStorageHealth(
-	address common.Address,
-	storage *runtime.Storage,
-	payloads []*ledger.Payload,
-) error {
-
-	for _, payload := range payloads {
-		registerID, _, err := convert.PayloadToRegister(payload)
-		if err != nil {
-			return fmt.Errorf("failed to convert payload to register: %w", err)
-		}
-
-		if !registerID.IsSlabIndex() {
-			continue
-		}
-
-		// Convert the register ID to a storage ID.
-		slabID := atree.NewStorageID(
-			atree.Address([]byte(registerID.Owner)),
-			atree.StorageIndex([]byte(registerID.Key[1:])))
-
-		// Retrieve the slab.
-		_, _, err = storage.Retrieve(slabID)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve slab %s: %w", slabID, err)
-		}
-	}
-
-	for _, domain := range domains {
-		_ = storage.GetStorageMap(address, domain, false)
-	}
-
-	return storage.CheckHealth()
 }
 
 func (m *AtreeRegisterMigrator) migrateAccountStorage(
@@ -492,25 +456,6 @@ func capturePanic(f func()) (err error) {
 	f()
 
 	return
-}
-
-// convert all domains
-var domains = []string{
-	common.PathDomainStorage.Identifier(),
-	common.PathDomainPrivate.Identifier(),
-	common.PathDomainPublic.Identifier(),
-	runtime.StorageDomainContract,
-	stdlib.InboxStorageDomain,
-	stdlib.CapabilityControllerStorageDomain,
-}
-
-var domainsLookupMap = map[string]struct{}{
-	common.PathDomainStorage.Identifier():    {},
-	common.PathDomainPrivate.Identifier():    {},
-	common.PathDomainPublic.Identifier():     {},
-	runtime.StorageDomainContract:            {},
-	stdlib.InboxStorageDomain:                {},
-	stdlib.CapabilityControllerStorageDomain: {},
 }
 
 // migrationProblem is a struct for reporting errors

--- a/cmd/util/ledger/migrations/atree_register_migration_test.go
+++ b/cmd/util/ledger/migrations/atree_register_migration_test.go
@@ -35,6 +35,8 @@ func TestAtreeRegisterMigration(t *testing.T) {
 						true,
 						false,
 						false,
+						false,
+						false,
 					),
 				},
 			),

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -4,8 +4,13 @@ import (
 	"fmt"
 
 	"github.com/onflow/atree"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/stdlib"
 
 	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -58,4 +63,58 @@ func (a *AccountsAtreeLedger) AllocateStorageIndex(owner []byte) (atree.StorageI
 		return atree.StorageIndex{}, fmt.Errorf("storage address allocation failed: %w", err)
 	}
 	return v, nil
+}
+
+func checkStorageHealth(
+	address common.Address,
+	storage *runtime.Storage,
+	payloads []*ledger.Payload,
+) error {
+
+	for _, payload := range payloads {
+		registerID, _, err := convert.PayloadToRegister(payload)
+		if err != nil {
+			return fmt.Errorf("failed to convert payload to register: %w", err)
+		}
+
+		if !registerID.IsSlabIndex() {
+			continue
+		}
+
+		// Convert the register ID to a storage ID.
+		slabID := atree.NewStorageID(
+			atree.Address([]byte(registerID.Owner)),
+			atree.StorageIndex([]byte(registerID.Key[1:])))
+
+		// Retrieve the slab.
+		_, _, err = storage.Retrieve(slabID)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve slab %s: %w", slabID, err)
+		}
+	}
+
+	for _, domain := range domains {
+		_ = storage.GetStorageMap(address, domain, false)
+	}
+
+	return storage.CheckHealth()
+}
+
+// convert all domains
+var domains = []string{
+	common.PathDomainStorage.Identifier(),
+	common.PathDomainPrivate.Identifier(),
+	common.PathDomainPublic.Identifier(),
+	runtime.StorageDomainContract,
+	stdlib.InboxStorageDomain,
+	stdlib.CapabilityControllerStorageDomain,
+}
+
+var domainsLookupMap = map[string]struct{}{
+	common.PathDomainStorage.Identifier():    {},
+	common.PathDomainPrivate.Identifier():    {},
+	common.PathDomainPublic.Identifier():     {},
+	runtime.StorageDomainContract:            {},
+	stdlib.InboxStorageDomain:                {},
+	stdlib.CapabilityControllerStorageDomain: {},
 }


### PR DESCRIPTION
This PR adds debug flags to check storage health before and after atree migration.
- `check-storage-health-before`
- `check-storage-health-after`