### PR TITLE
[Network] Use string concatenation in rpc tracer ID

### DIFF
--- a/network/p2p/tracer/internal/rpc_sent_cache.go
+++ b/network/p2p/tracer/internal/rpc_sent_cache.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"fmt"
-
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -79,5 +77,5 @@ func (r *rpcSentCache) size() uint {
 // Returns:
 // - flow.Identifier: the entity ID.
 func (r *rpcSentCache) rpcSentEntityID(messageId string, controlMsgType p2pmsg.ControlMessageType) flow.Identifier {
-	return flow.MakeIDFromFingerPrint([]byte(fmt.Sprintf("%s%s", messageId, controlMsgType)))
+	return flow.MakeIDFromFingerPrint([]byte(messageId + string(controlMsgType)))
 }


### PR DESCRIPTION
Closes: #5640 

Switch to using string concatenation instead of `fmt.Sprintf` when generating rpc tracer IDs. the latter is 9x slower, so this will make a noticeable difference for this high volume action.