### PR TITLE
[Common] Add a component compatible version of unit

### DIFF
--- a/engine/common/unit/unit.go
+++ b/engine/common/unit/unit.go
@@ -1,0 +1,156 @@
+package unit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/irrecoverable"
+)
+
+type Unit interface {
+	component.Component
+	ShutdownSignal() <-chan struct{}
+
+	Do(f func() error) error
+	Launch(f func(context.Context))
+	LaunchAfter(delay time.Duration, f func(context.Context))
+	LaunchPeriodically(f func(context.Context), interval time.Duration, delay time.Duration)
+
+	AddReadyCallbacks(checks ...func())
+	AddDoneCallbacks(actions ...func())
+}
+
+type unitImp struct {
+	*component.ComponentManager
+
+	wg   sync.WaitGroup
+	work chan func(context.Context)
+
+	preReadyFn func()
+	postDoneFn func()
+}
+
+func NewUnit() Unit {
+	u := &unitImp{
+		work: make(chan func(context.Context)),
+	}
+
+	u.ComponentManager = component.NewComponentManagerBuilder().
+		AddWorker(u.workerFactory).
+		AddWorker(u.lifecycle).
+		Build()
+
+	return u
+}
+
+func (u *unitImp) workerFactory(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+	ready()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case f := <-u.work:
+			u.wg.Add(1)
+			go func() {
+				defer u.wg.Done()
+				f(ctx)
+			}()
+		}
+	}
+}
+
+func (u *unitImp) lifecycle(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+	if u.preReadyFn != nil {
+		u.preReadyFn()
+	}
+
+	ready()
+	<-ctx.Done()
+
+	if u.postDoneFn != nil {
+		u.postDoneFn()
+	}
+
+	u.wg.Wait()
+}
+
+func (u *unitImp) Do(f func() error) error {
+	select {
+	case <-u.ShutdownSignal():
+		return fmt.Errorf("unit is shutting down")
+	default:
+	}
+
+	u.wg.Add(1)
+	defer u.wg.Done()
+
+	return f()
+}
+
+func (u *unitImp) Launch(f func(ctx context.Context)) {
+	select {
+	case <-u.ShutdownSignal():
+		return
+	case u.work <- f:
+	}
+}
+
+func (u *unitImp) LaunchAfter(delay time.Duration, f func(context.Context)) {
+	u.Launch(func(ctx context.Context) {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+			f(ctx)
+		}
+	})
+}
+
+func (u *unitImp) LaunchPeriodically(f func(context.Context), interval time.Duration, delay time.Duration) {
+	u.Launch(func(ctx context.Context) {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				f(ctx)
+			}
+		}
+	})
+}
+
+// AddReadyCallbacks adds checks to be executed before the unit is ready.
+func (u *unitImp) AddReadyCallbacks(checks ...func()) {
+	u.preReadyFn = func() {
+		for _, check := range checks {
+			check()
+		}
+	}
+}
+
+// AddDoneCallbacks adds actions to be executed after the unit has shut down.
+func (u *unitImp) AddDoneCallbacks(actions ...func()) {
+	u.postDoneFn = func() {
+		for _, action := range actions {
+			action()
+		}
+	}
+}

--- a/engine/common/unit/unit_test.go
+++ b/engine/common/unit/unit_test.go
@@ -1,0 +1,88 @@
+package unit_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/engine/common/unit"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestReadyDone(t *testing.T) {
+	ctx, cancel := irrecoverable.NewMockSignalerContextWithCancel(t, context.Background())
+
+	u := unit.NewUnit()
+	u.Start(ctx)
+	unittest.RequireCloseBefore(t, u.Ready(), time.Second, "ready did not close")
+
+	cancel()
+	unittest.RequireCloseBefore(t, u.Done(), time.Second, "done did not close")
+}
+
+// Test that if a function is run by LaunchPeriodically and
+// takes longer than the interval, the next call will be blocked
+func TestLaunchPeriod(t *testing.T) {
+	ctx, cancel := irrecoverable.NewMockSignalerContextWithCancel(t, context.Background())
+	lock := sync.Mutex{}
+
+	u := unit.NewUnit()
+	u.Start(ctx)
+	unittest.RequireCloseBefore(t, u.Ready(), time.Second, "ready did not close")
+
+	logs := make([]string, 0)
+	u.LaunchPeriodically(func(_ context.Context) {
+		lock.Lock()
+		logs = append(logs, "running")
+		lock.Unlock()
+
+		time.Sleep(100 * time.Millisecond)
+
+		lock.Lock()
+		logs = append(logs, "finish")
+		lock.Unlock()
+	}, 50*time.Millisecond, 0)
+
+	// 100 * 3 is to ensure enough time for 3 periodic function to finish
+	// adding another 30 as buffer to tolerate, and the buffer has to be
+	// smaller than 50 in order to avoid another trigger of the periodic function
+	<-time.After((100*3 + 30) * time.Millisecond)
+
+	// This can pass
+	lock.Lock()
+	require.Equal(t, []string{
+		"running", "finish",
+		"running", "finish",
+		"running",
+	}, logs)
+	lock.Unlock()
+
+	cancel()
+	unittest.RequireCloseBefore(t, u.Done(), time.Second, "done did not close")
+
+	require.Equal(t, []string{
+		"running", "finish",
+		"running", "finish",
+		"running", "finish",
+	}, logs)
+}
+
+func TestLaunchPeriod_Delay(t *testing.T) {
+	ctx, cancel := irrecoverable.NewMockSignalerContextWithCancel(t, context.Background())
+
+	u := unit.NewUnit()
+	u.Start(ctx)
+	unittest.RequireCloseBefore(t, u.Ready(), time.Second, "ready did not close")
+
+	// launch f with a large initial delay (30s)
+	// the function f should never be invoked, so we use t.Fail
+	u.LaunchPeriodically(func(_ context.Context) { t.Fail() }, time.Millisecond, time.Second*30)
+
+	cancel()
+	// ensure we can stop the unit quickly (we should not need to wait for initial delay)
+	unittest.RequireCloseBefore(t, u.Done(), time.Second, "done did not close")
+}

--- a/engine/unit.go
+++ b/engine/unit.go
@@ -6,8 +6,8 @@ import (
 	"time"
 )
 
-// Deprecated: Use engine/common/unit/unit.go Instead
 // Unit handles synchronization management, startup, and shutdown for engines.
+// Deprecated: Use engine/common/unit/unit.go Instead
 type Unit struct {
 	admitLock sync.Mutex // used for synchronizing context cancellation with work admittance
 

--- a/engine/unit.go
+++ b/engine/unit.go
@@ -18,7 +18,6 @@ type Unit struct {
 
 // NewUnit returns a new unit.
 func NewUnit() *Unit {
-
 	ctx, cancel := context.WithCancel(context.Background())
 	unit := &Unit{
 		ctx:    ctx,


### PR DESCRIPTION
The current version of unit was created before the `component.Component` interface was created and uses some outdated patterns. The general functionality is still useful though. This PR create a new version that also supports the component interface.

There are some API differences:
* `Quit()` was renamed to `ShutdownSignal`. This better aligns with `component.ComponentManager`
* `Ctx()` was removed. Instead, the start context is passed into launched functions. The intention is to avoid the anti-pattern of storing contexts with structs.
* function callbacks for all `Launch*` methods now take a context.
* The callbacks passed into `Ready` and `Done` are now set using `AddReadyCallbacks` and `AddDoneCallbacks`