### PR TITLE
Improve naming for migrator runtime

### DIFF
--- a/cmd/util/ledger/migrations/atree_register_migration.go
+++ b/cmd/util/ledger/migrations/atree_register_migration.go
@@ -94,7 +94,7 @@ func (m *AtreeRegisterMigrator) MigrateAccount(
 	oldPayloads []*ledger.Payload,
 ) ([]*ledger.Payload, error) {
 	// create all the runtime components we need for the migration
-	mr, err := newMigratorRuntime(address, oldPayloads)
+	mr, err := NewAtreeRegisterMigratorRuntime(address, oldPayloads)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create migrator runtime: %w", err)
 	}
@@ -162,7 +162,7 @@ func (m *AtreeRegisterMigrator) MigrateAccount(
 
 	// Check storage health after migration, if enabled.
 	if m.checkStorageHealthAfterMigration {
-		mr, err := newMigratorRuntime(address, newPayloads)
+		mr, err := NewAtreeRegisterMigratorRuntime(address, newPayloads)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create migrator runtime: %w", err)
 		}
@@ -180,7 +180,7 @@ func (m *AtreeRegisterMigrator) MigrateAccount(
 }
 
 func (m *AtreeRegisterMigrator) migrateAccountStorage(
-	mr *migratorRuntime,
+	mr *AtreeRegisterMigratorRuntime,
 	storageMapIds map[string]struct{},
 ) (map[flow.RegisterID]flow.RegisterValue, error) {
 
@@ -207,7 +207,7 @@ func (m *AtreeRegisterMigrator) migrateAccountStorage(
 }
 
 func (m *AtreeRegisterMigrator) convertStorageDomain(
-	mr *migratorRuntime,
+	mr *AtreeRegisterMigratorRuntime,
 	storageMapIds map[string]struct{},
 	domain string,
 ) error {
@@ -285,7 +285,7 @@ func (m *AtreeRegisterMigrator) convertStorageDomain(
 }
 
 func (m *AtreeRegisterMigrator) validateChangesAndCreateNewRegisters(
-	mr *migratorRuntime,
+	mr *AtreeRegisterMigratorRuntime,
 	changes map[flow.RegisterID]flow.RegisterValue,
 	storageMapIds map[string]struct{},
 ) ([]*ledger.Payload, error) {
@@ -420,7 +420,7 @@ func (m *AtreeRegisterMigrator) validateChangesAndCreateNewRegisters(
 }
 
 func (m *AtreeRegisterMigrator) cloneValue(
-	mr *migratorRuntime,
+	mr *AtreeRegisterMigratorRuntime,
 	value interpreter.Value,
 ) (interpreter.Value, error) {
 

--- a/cmd/util/ledger/migrations/atree_register_migration.go
+++ b/cmd/util/ledger/migrations/atree_register_migration.go
@@ -31,7 +31,6 @@ type AtreeRegisterMigrator struct {
 
 	sampler zerolog.Sampler
 	rw      reporters.ReportWriter
-	rwf     reporters.ReportWriterFactory
 
 	nWorkers int
 
@@ -58,7 +57,6 @@ func NewAtreeRegisterMigrator(
 
 	migrator := &AtreeRegisterMigrator{
 		sampler:                            sampler,
-		rwf:                                rwf,
 		rw:                                 rwf.ReportWriter("atree-register-migrator"),
 		validateMigratedValues:             validateMigratedValues,
 		logVerboseValidationError:          logVerboseValidationError,

--- a/cmd/util/ledger/migrations/atree_register_migrator_runtime.go
+++ b/cmd/util/ledger/migrations/atree_register_migrator_runtime.go
@@ -13,12 +13,12 @@ import (
 	"github.com/onflow/flow-go/ledger"
 )
 
-// migratorRuntime is a runtime that can be used to run a migration on a single account
-func newMigratorRuntime(
+// NewAtreeRegisterMigratorRuntime returns a new runtime to be used with the AtreeRegisterMigrator.
+func NewAtreeRegisterMigratorRuntime(
 	address common.Address,
 	payloads []*ledger.Payload,
 ) (
-	*migratorRuntime,
+	*AtreeRegisterMigratorRuntime,
 	error,
 ) {
 	snapshot, err := util.NewPayloadSnapshot(payloads)
@@ -42,23 +42,23 @@ func newMigratorRuntime(
 		return nil, err
 	}
 
-	return &migratorRuntime{
-		Address:          address,
-		Payloads:         payloads,
-		Snapshot:         snapshot,
-		TransactionState: transactionState,
-		Interpreter:      inter,
-		Storage:          storage,
-		Accounts:         accountsAtreeLedger,
+	return &AtreeRegisterMigratorRuntime{
+		Address:             address,
+		Payloads:            payloads,
+		Snapshot:            snapshot,
+		TransactionState:    transactionState,
+		Interpreter:         inter,
+		Storage:             storage,
+		AccountsAtreeLedger: accountsAtreeLedger,
 	}, nil
 }
 
-type migratorRuntime struct {
-	Snapshot         *util.PayloadSnapshot
-	TransactionState state.NestedTransactionPreparer
-	Interpreter      *interpreter.Interpreter
-	Storage          *runtime.Storage
-	Payloads         []*ledger.Payload
-	Address          common.Address
-	Accounts         *util.AccountsAtreeLedger
+type AtreeRegisterMigratorRuntime struct {
+	Snapshot            *util.PayloadSnapshot
+	TransactionState    state.NestedTransactionPreparer
+	Interpreter         *interpreter.Interpreter
+	Storage             *runtime.Storage
+	Payloads            []*ledger.Payload
+	Address             common.Address
+	AccountsAtreeLedger *util.AccountsAtreeLedger
 }

--- a/cmd/util/ledger/migrations/cadence_value_validation_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation_test.go
@@ -52,7 +52,7 @@ func TestValidateCadenceValues(t *testing.T) {
 				accountStatus.ToBytes(),
 			)
 
-			mr, err := newMigratorRuntime(address, []*ledger.Payload{accountStatusPayload})
+			mr, err := NewAtreeRegisterMigratorRuntime(address, []*ledger.Payload{accountStatusPayload})
 			require.NoError(t, err)
 
 			// Create new storage map
@@ -140,7 +140,7 @@ func createTestPayloads(t *testing.T, address common.Address, domain string) []*
 		accountStatus.ToBytes(),
 	)
 
-	mr, err := newMigratorRuntime(address, []*ledger.Payload{accountStatusPayload})
+	mr, err := NewAtreeRegisterMigratorRuntime(address, []*ledger.Payload{accountStatusPayload})
 	require.NoError(t, err)
 
 	// Create new storage map


### PR DESCRIPTION
Rename the migrator runtime used in the atree register inlining migration, and make it clear that it is only supposed to be used for the atree register inlining migration. It only allows storage operations, but does not support e.g. parsing and type checking of contracts.

This is prep work to allow master to be merged more easily into the Cadence 1.0 feature branch and https://github.com/onflow/cadence/issues/3233. The Cadence 1.0 migrations also use this runtime at the moment, but need support for parsing and checking of contract. We plan to move from a per-account runtime/storage, to a whole state one, so we can parse and check all contracts once in a separate migration (https://github.com/onflow/cadence/issues/3233).