### PR TITLE
Add a migration which detects and filters out unreferenced slabs

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -46,6 +46,7 @@ var (
 	flagOutputPayloadFileName              string
 	flagOutputPayloadByAddresses           string
 	flagMaxAccountSize                     uint64
+	flagFilterUnreferencedSlabs            bool
 )
 
 var Cmd = &cobra.Command{
@@ -151,6 +152,9 @@ func init() {
 
 	Cmd.Flags().Uint64Var(&flagMaxAccountSize, "max-account-size", 0,
 		"max account size")
+
+	Cmd.Flags().BoolVar(&flagFilterUnreferencedSlabs, "filter-unreferenced-slabs", false,
+		"filter unreferenced slabs")
 }
 
 func run(*cobra.Command, []string) {
@@ -371,6 +375,7 @@ func run(*cobra.Command, []string) {
 		Prune:                             flagPrune,
 		MaxAccountSize:                    flagMaxAccountSize,
 		VerboseErrorOutput:                flagVerboseErrorOutput,
+		FilterUnreferencedSlabs:           flagFilterUnreferencedSlabs,
 	}
 
 	if len(flagInputPayloadFileName) > 0 {

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -372,7 +372,7 @@ func createTrieFromPayloads(logger zerolog.Logger, payloads []*ledger.Payload) (
 
 func newMigrations(
 	log zerolog.Logger,
-	dir string,
+	outputDir string,
 	runMigrations bool,
 	opts migrators.Options,
 ) []ledger.Migration {
@@ -382,10 +382,11 @@ func newMigrations(
 
 	log.Info().Msgf("initializing migrations")
 
-	rwf := reporters.NewReportFileWriterFactory(dir, log)
+	rwf := reporters.NewReportFileWriterFactory(outputDir, log)
 
 	namedMigrations := migrators.NewCadence1Migrations(
 		log,
+		outputDir,
 		rwf,
 		opts,
 	)

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -389,6 +389,7 @@ type Options struct {
 
 func NewCadence1Migrations(
 	log zerolog.Logger,
+	outputDir string,
 	rwf reporters.ReportWriterFactory,
 	opts Options,
 ) []NamedMigration {
@@ -420,7 +421,7 @@ func NewCadence1Migrations(
 				log,
 				opts.NWorker,
 				[]AccountBasedMigration{
-					NewFilterUnreferencedSlabsMigration(rwf),
+					NewFilterUnreferencedSlabsMigration(outputDir, rwf),
 				},
 			),
 		})

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -384,6 +384,7 @@ type Options struct {
 	StagedContracts                   []StagedContract
 	Prune                             bool
 	MaxAccountSize                    uint64
+	FilterUnreferencedSlabs           bool
 }
 
 func NewCadence1Migrations(
@@ -410,6 +411,19 @@ func NewCadence1Migrations(
 				Migrate: NewAccountSizeFilterMigration(opts.MaxAccountSize, maxSizeExceptions, log),
 			},
 		)
+	}
+
+	if opts.FilterUnreferencedSlabs {
+		migrations = append(migrations, NamedMigration{
+			Name: "filter-unreferenced-slabs-migration",
+			Migrate: NewAccountBasedMigration(
+				log,
+				opts.NWorker,
+				[]AccountBasedMigration{
+					NewFilterUnreferencedSlabsMigration(rwf),
+				},
+			),
+		})
 	}
 
 	if opts.Prune {

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -79,6 +79,7 @@ func TestCadenceValuesMigration(t *testing.T) {
 
 	migrations := NewCadence1Migrations(
 		logger,
+		t.TempDir(),
 		rwf,
 		Options{
 			NWorker:              nWorker,
@@ -698,6 +699,7 @@ func TestBootstrappedStateMigration(t *testing.T) {
 
 	migrations := NewCadence1Migrations(
 		logger,
+		t.TempDir(),
 		rwf,
 		Options{
 			NWorker:              nWorker,
@@ -823,6 +825,7 @@ func TestProgramParsingError(t *testing.T) {
 
 	migrations := NewCadence1Migrations(
 		logger,
+		t.TempDir(),
 		rwf,
 		Options{
 			NWorker:              nWorker,
@@ -948,6 +951,7 @@ func TestCoreContractUsage(t *testing.T) {
 
 		migrations := NewCadence1Migrations(
 			logger,
+			t.TempDir(),
 			rwf,
 			Options{
 				NWorker:              nWorker,

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -46,8 +46,9 @@ func NewFilterUnreferencedSlabsMigration(
 	rwf reporters.ReportWriterFactory,
 ) *FilterUnreferencedSlabsMigration {
 	return &FilterUnreferencedSlabsMigration{
-		outputDir: outputDir,
-		rw:        rwf.ReportWriter(filterUnreferencedSlabsName),
+		outputDir:        outputDir,
+		rw:               rwf.ReportWriter(filterUnreferencedSlabsName),
+		filteredPayloads: make([]*ledger.Payload, 0, 50_000),
 	}
 }
 

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -1,0 +1,158 @@
+package migrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/onflow/atree"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/convert"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func StorageIDFromRegisterID(registerID flow.RegisterID) atree.StorageID {
+	storageID := atree.StorageID{
+		Address: atree.Address([]byte(registerID.Owner)),
+	}
+	copy(storageID.Index[:], registerID.Key[1:])
+	return storageID
+}
+
+// TODO: use version from atree register inlining (master)
+func CheckAccountStorageHealth(
+	address common.Address,
+	payloads []*ledger.Payload,
+	storage *runtime.Storage,
+) error {
+	// Retrieve all slabs before migration.
+	for _, payload := range payloads {
+		registerID, _, err := convert.PayloadToRegister(payload)
+		if err != nil {
+			return fmt.Errorf("failed to convert payload to register: %w", err)
+		}
+
+		if !registerID.IsSlabIndex() {
+			continue
+		}
+
+		storageID := StorageIDFromRegisterID(registerID)
+
+		// Retrieve the slab.
+		_, _, err = storage.Retrieve(storageID)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve slab %s: %w", storageID, err)
+		}
+	}
+
+	// Load storage map.
+	for _, domain := range domains {
+		_ = storage.GetStorageMap(address, domain, false)
+	}
+
+	return storage.CheckHealth()
+}
+
+type FilterUnreferencedSlabsMigration struct {
+	log zerolog.Logger
+}
+
+var _ AccountBasedMigration = &FilterUnreferencedSlabsMigration{}
+
+func (m *FilterUnreferencedSlabsMigration) InitMigration(
+	log zerolog.Logger,
+	_ []*ledger.Payload,
+	_ int,
+) error {
+	m.log = log.
+		With().
+		Str("migration", "filter-unreferenced-slabs").
+		Logger()
+
+	return nil
+}
+
+func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
+	_ context.Context,
+	address common.Address,
+	oldPayloads []*ledger.Payload,
+) ([]*ledger.Payload, error) {
+
+	checkPayloadsOwnership(oldPayloads, address, m.log)
+
+	migrationRuntime, err := NewMigratorRuntime(
+		address,
+		oldPayloads,
+		util.RuntimeInterfaceConfig{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create migrator runtime: %w", err)
+	}
+
+	storage := migrationRuntime.Storage
+
+	newPayloads := oldPayloads
+
+	err = CheckAccountStorageHealth(address, oldPayloads, storage)
+	if err != nil {
+
+		// The storage health check failed.
+		// This can happen if there are unreferenced root slabs.
+		// In this case, we filter out the unreferenced root slabs from the payloads.
+
+		var unreferencedRootSlabsErr runtime.UnreferencedRootSlabsError
+		if !errors.As(err, &unreferencedRootSlabsErr) {
+			return nil, fmt.Errorf("storage health check failed: %w", err)
+		}
+
+		m.log.Warn().
+			Err(err).
+			Str("account", address.Hex()).
+			Msg("filtering unreferenced root slabs")
+
+		// Create a set of unreferenced root slabs.
+
+		unreferencedRootSlabIDs := map[atree.StorageID]struct{}{}
+		for _, storageID := range unreferencedRootSlabsErr.UnreferencedRootSlabIDs {
+			unreferencedRootSlabIDs[storageID] = struct{}{}
+		}
+
+		// Filter out unreferenced root slabs.
+
+		newCount := len(oldPayloads) - len(unreferencedRootSlabIDs)
+		newPayloads = make([]*ledger.Payload, 0, newCount)
+
+		filteredPayloads := make([]*ledger.Payload, 0, len(unreferencedRootSlabIDs))
+
+		for _, payload := range oldPayloads {
+			registerID, _, err := convert.PayloadToRegister(payload)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert payload to register: %w", err)
+			}
+
+			// Filter unreferenced slabs.
+			if registerID.IsSlabIndex() {
+				storageID := StorageIDFromRegisterID(registerID)
+				if _, ok := unreferencedRootSlabIDs[storageID]; ok {
+					filteredPayloads = append(filteredPayloads, payload)
+					continue
+				}
+			}
+
+			newPayloads = append(newPayloads, payload)
+		}
+
+		// TODO: write filtered payloads to a separate file
+	}
+
+	return newPayloads, nil
+}
+
+func (m *FilterUnreferencedSlabsMigration) Close() error {
+	return nil
+}

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -25,8 +25,8 @@ func StorageIDFromRegisterID(registerID flow.RegisterID) atree.StorageID {
 }
 
 type FilterUnreferencedSlabsMigration struct {
-	log     zerolog.Logger
-	rw      reporters.ReportWriter
+	log zerolog.Logger
+	rw  reporters.ReportWriter
 }
 
 var _ AccountBasedMigration = &FilterUnreferencedSlabsMigration{}
@@ -37,7 +37,7 @@ func NewFilterUnreferencedSlabsMigration(
 	rwf reporters.ReportWriterFactory,
 ) *FilterUnreferencedSlabsMigration {
 	return &FilterUnreferencedSlabsMigration{
-		rw:      rwf.ReportWriter(filterUnreferencedSlabsName),
+		rw: rwf.ReportWriter(filterUnreferencedSlabsName),
 	}
 }
 
@@ -78,7 +78,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 
 	// The storage health check failed.
 	// This can happen if there are unreferenced root slabs.
-	// In this case, we filter out the unreferenced root slabs from the payloads.
+	// In this case, we filter out the unreferenced root slabs and all slabs they reference from the payloads.
 
 	var unreferencedRootSlabsErr runtime.UnreferencedRootSlabsError
 	if !errors.As(err, &unreferencedRootSlabsErr) {
@@ -90,19 +90,32 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 		Str("account", address.Hex()).
 		Msg("filtering unreferenced root slabs")
 
-	// Create a set of unreferenced root slabs.
+	// Create a set of unreferenced slabs: root slabs, and all slabs they reference.
 
-	unreferencedRootSlabIDs := map[atree.StorageID]struct{}{}
-	for _, storageID := range unreferencedRootSlabsErr.UnreferencedRootSlabIDs {
-		unreferencedRootSlabIDs[storageID] = struct{}{}
+	unreferencedSlabIDs := map[atree.StorageID]struct{}{}
+	for _, rootSlabID := range unreferencedRootSlabsErr.UnreferencedRootSlabIDs {
+		unreferencedSlabIDs[rootSlabID] = struct{}{}
+
+		childReferences, _, err := storage.GetAllChildReferences(rootSlabID)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to get all child references for root slab %s: %w",
+				rootSlabID,
+				err,
+			)
+		}
+
+		for _, childSlabID := range childReferences {
+			unreferencedSlabIDs[childSlabID] = struct{}{}
+		}
 	}
 
-	// Filter out unreferenced root slabs.
+	// Filter out unreferenced slabs.
 
-	newCount := len(oldPayloads) - len(unreferencedRootSlabIDs)
+	newCount := len(oldPayloads) - len(unreferencedSlabIDs)
 	newPayloads = make([]*ledger.Payload, 0, newCount)
 
-	filteredPayloads := make([]*ledger.Payload, 0, len(unreferencedRootSlabIDs))
+	filteredPayloads := make([]*ledger.Payload, 0, len(unreferencedSlabIDs))
 
 	for _, payload := range oldPayloads {
 		registerID, _, err := convert.PayloadToRegister(payload)
@@ -113,7 +126,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 		// Filter unreferenced slabs.
 		if registerID.IsSlabIndex() {
 			storageID := StorageIDFromRegisterID(registerID)
-			if _, ok := unreferencedRootSlabIDs[storageID]; ok {
+			if _, ok := unreferencedSlabIDs[storageID]; ok {
 				filteredPayloads = append(filteredPayloads, payload)
 				continue
 			}

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -24,40 +24,6 @@ func StorageIDFromRegisterID(registerID flow.RegisterID) atree.StorageID {
 	return storageID
 }
 
-// TODO: use version from atree register inlining (master)
-func CheckAccountStorageHealth(
-	address common.Address,
-	payloads []*ledger.Payload,
-	storage *runtime.Storage,
-) error {
-	// Retrieve all slabs before migration.
-	for _, payload := range payloads {
-		registerID, _, err := convert.PayloadToRegister(payload)
-		if err != nil {
-			return fmt.Errorf("failed to convert payload to register: %w", err)
-		}
-
-		if !registerID.IsSlabIndex() {
-			continue
-		}
-
-		storageID := StorageIDFromRegisterID(registerID)
-
-		// Retrieve the slab.
-		_, _, err = storage.Retrieve(storageID)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve slab %s: %w", storageID, err)
-		}
-	}
-
-	// Load storage map.
-	for _, domain := range allStorageMapDomains {
-		_ = storage.GetStorageMap(address, domain, false)
-	}
-
-	return storage.CheckHealth()
-}
-
 type FilterUnreferencedSlabsMigration struct {
 	log     zerolog.Logger
 	chainID flow.ChainID
@@ -99,7 +65,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 
 	newPayloads := oldPayloads
 
-	err = CheckAccountStorageHealth(address, oldPayloads, storage)
+	err = checkStorageHealth(address, storage, oldPayloads)
 	if err != nil {
 
 		// The storage health check failed.

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -33,7 +33,6 @@ type FilterUnreferencedSlabsMigration struct {
 	rw               reporters.ReportWriter
 	outputDir        string
 	mutex            sync.Mutex
-	filteredAccounts []common.Address
 	filteredPayloads []*ledger.Payload
 	payloadsFile     string
 }
@@ -151,10 +150,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 		PayloadCount: len(filteredPayloads),
 	})
 
-	m.mergeFilteredPayloads(
-		address,
-		filteredPayloads,
-	)
+	m.mergeFilteredPayloads(filteredPayloads)
 
 	// Do NOT report the health check error here.
 	// The health check error is only reported if it is not due to unreferenced slabs.
@@ -163,14 +159,10 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 	return newPayloads, nil
 }
 
-func (m *FilterUnreferencedSlabsMigration) mergeFilteredPayloads(
-	address common.Address,
-	payloads []*ledger.Payload,
-) {
+func (m *FilterUnreferencedSlabsMigration) mergeFilteredPayloads(payloads []*ledger.Payload) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	m.filteredAccounts = append(m.filteredAccounts, address)
 	m.filteredPayloads = append(m.filteredPayloads, payloads...)
 }
 
@@ -197,7 +189,7 @@ func (m *FilterUnreferencedSlabsMigration) writeFilteredPayloads() error {
 		m.log,
 		m.payloadsFile,
 		m.filteredPayloads,
-		m.filteredAccounts,
+		nil,
 		true,
 	)
 

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -193,10 +193,6 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 		expectedFilteredPayloads,
 		migration.filteredPayloads,
 	)
-	assert.Equal(t,
-		[]common.Address{testAddress},
-		migration.filteredAccounts,
-	)
 
 	readIsPartial, readFilteredPayloads, err := util.ReadPayloadFile(log, migration.payloadsFile)
 	require.NoError(t, err)

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -1,0 +1,130 @@
+package migrations
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/onflow/atree"
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestFilterUnreferencedSlabs(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+
+	const chainID = flow.Emulator
+	chain := chainID.Chain()
+
+	testFlowAddress, err := chain.AddressAtIndex(1_000_000)
+	require.NoError(t, err)
+
+	testAddress := common.Address(testFlowAddress)
+
+	payloads := map[flow.RegisterID]*ledger.Payload{}
+
+	payloadsLedger := util.NewPayloadsLedger(payloads)
+
+	storageIndices := map[string]uint64{}
+	payloadsLedger.AllocateStorageIndexFunc = func(owner []byte) (atree.StorageIndex, error) {
+		var index atree.StorageIndex
+
+		storageIndices[string(owner)]++
+
+		binary.BigEndian.PutUint64(
+			index[:],
+			storageIndices[string(owner)],
+		)
+
+		return index, nil
+	}
+
+	storage := runtime.NewStorage(payloadsLedger, nil)
+
+	// {Int: Int}
+	dictionaryStaticType := interpreter.NewDictionaryStaticType(
+		nil,
+		interpreter.PrimitiveStaticTypeInt,
+		interpreter.PrimitiveStaticTypeInt,
+	)
+
+	inter, err := interpreter.NewInterpreter(
+		nil,
+		nil,
+		&interpreter.Config{
+			Storage: storage,
+		},
+	)
+	require.NoError(t, err)
+
+	dict1 := interpreter.NewDictionaryValueWithAddress(
+		inter,
+		interpreter.EmptyLocationRange,
+		dictionaryStaticType,
+		testAddress,
+	)
+
+	// Storage another dictionary in the account.
+	// It is not referenced through a storage map though.
+
+	interpreter.NewDictionaryValueWithAddress(
+		inter,
+		interpreter.EmptyLocationRange,
+		dictionaryStaticType,
+		testAddress,
+	)
+
+	storageMap := storage.GetStorageMap(
+		testAddress,
+		common.PathDomainStorage.Identifier(),
+		true,
+	)
+
+	// Only insert first dictionary.
+	// Second dictionary is unreferenced.
+
+	storageMap.SetValue(
+		inter,
+		interpreter.StringStorageMapKey("test"),
+		dict1,
+	)
+
+	err = storage.Commit(inter, false)
+	require.NoError(t, err)
+
+	oldPayloads := make([]*ledger.Payload, 0, len(payloads))
+
+	for _, payload := range payloadsLedger.Payloads {
+		oldPayloads = append(oldPayloads, payload)
+	}
+
+	const totalSlabCount = 4
+
+	require.Len(t, oldPayloads, totalSlabCount)
+
+	// Act
+
+	migration := &FilterUnreferencedSlabsMigration{
+		chainID: chainID,
+	}
+
+	log := zerolog.New(zerolog.NewTestWriter(t))
+
+	err = migration.InitMigration(log, nil, 0)
+	require.NoError(t, err)
+
+	newPayloads, err := migration.MigrateAccount(nil, testAddress, oldPayloads)
+	require.NoError(t, err)
+
+	// Assert
+
+	require.Len(t, newPayloads, totalSlabCount-1)
+}

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -115,7 +115,7 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 	// Act
 
 	rwf := &testReportWriterFactory{}
-	migration := NewFilterUnreferencedSlabsMigration(chainID, rwf)
+	migration := NewFilterUnreferencedSlabsMigration(rwf)
 
 	log := zerolog.New(zerolog.NewTestWriter(t))
 

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"context"
 	"encoding/binary"
 	"testing"
 
@@ -122,7 +123,9 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 	err = migration.InitMigration(log, nil, 0)
 	require.NoError(t, err)
 
-	newPayloads, err := migration.MigrateAccount(nil, testAddress, oldPayloads)
+	ctx := context.Background()
+
+	newPayloads, err := migration.MigrateAccount(ctx, testAddress, oldPayloads)
 	require.NoError(t, err)
 
 	// Assert

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -1797,6 +1797,7 @@ func TestConcurrentContractUpdate(t *testing.T) {
 
 	migrations := NewCadence1Migrations(
 		logger,
+		t.TempDir(),
 		rwf,
 		Options{
 			NWorker:              nWorker,

--- a/cmd/util/ledger/util/util.go
+++ b/cmd/util/ledger/util/util.go
@@ -18,6 +18,10 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
+func newRegisterID(owner []byte, key []byte) flow.RegisterID {
+	return flow.NewRegisterID(flow.BytesToAddress(owner), string(key))
+}
+
 type AccountsAtreeLedger struct {
 	Accounts environment.Accounts
 }
@@ -29,10 +33,9 @@ func NewAccountsAtreeLedger(accounts environment.Accounts) *AccountsAtreeLedger 
 var _ atree.Ledger = &AccountsAtreeLedger{}
 
 func (a *AccountsAtreeLedger) GetValue(owner, key []byte) ([]byte, error) {
+	registerID := newRegisterID(owner, key)
 	v, err := a.Accounts.GetValue(
-		flow.NewRegisterID(
-			flow.BytesToAddress(owner),
-			string(key)))
+		registerID)
 	if err != nil {
 		return nil, fmt.Errorf("getting value failed: %w", err)
 	}
@@ -40,11 +43,8 @@ func (a *AccountsAtreeLedger) GetValue(owner, key []byte) ([]byte, error) {
 }
 
 func (a *AccountsAtreeLedger) SetValue(owner, key, value []byte) error {
-	err := a.Accounts.SetValue(
-		flow.NewRegisterID(
-			flow.BytesToAddress(owner),
-			string(key)),
-		value)
+	registerID := newRegisterID(owner, key)
+	err := a.Accounts.SetValue(registerID, value)
 	if err != nil {
 		return fmt.Errorf("setting value failed: %w", err)
 	}
@@ -76,8 +76,11 @@ type PayloadsReadonlyLedger struct {
 	SetValueFunc             func(owner, key, value []byte) (err error)
 }
 
+var _ atree.Ledger = &PayloadsReadonlyLedger{}
+
 func (p *PayloadsReadonlyLedger) GetValue(owner, key []byte) (value []byte, err error) {
-	v, err := p.Snapshot.Get(flow.NewRegisterID(flow.BytesToAddress(owner), string(key)))
+	registerID := newRegisterID(owner, key)
+	v, err := p.Snapshot.Get(registerID)
 	if err != nil {
 		return nil, fmt.Errorf("getting value failed: %w", err)
 	}
@@ -93,7 +96,8 @@ func (p *PayloadsReadonlyLedger) SetValue(owner, key, value []byte) (err error) 
 }
 
 func (p *PayloadsReadonlyLedger) ValueExists(owner, key []byte) (bool, error) {
-	exists := p.Snapshot.Exists(flow.NewRegisterID(flow.BytesToAddress(owner), string(key)))
+	registerID := newRegisterID(owner, key)
+	exists := p.Snapshot.Exists(registerID)
 	return exists, nil
 }
 
@@ -237,4 +241,49 @@ func registerIDKeyFromString(s string) (flow.RegisterID, common.Address) {
 
 type PayloadMetaInfo struct {
 	Height, Version uint64
+}
+
+// PayloadsLedger is a simple read/write in-memory atree.Ledger implementation
+type PayloadsLedger struct {
+	Payloads map[flow.RegisterID]*ledger.Payload
+
+	AllocateStorageIndexFunc func(owner []byte) (atree.StorageIndex, error)
+}
+
+var _ atree.Ledger = &PayloadsLedger{}
+
+func NewPayloadsLedger(payloads map[flow.RegisterID]*ledger.Payload) *PayloadsLedger {
+	return &PayloadsLedger{
+		Payloads: payloads,
+	}
+}
+
+func (p *PayloadsLedger) GetValue(owner, key []byte) (value []byte, err error) {
+	registerID := newRegisterID(owner, key)
+	v, ok := p.Payloads[registerID]
+	if !ok {
+		return nil, nil
+	}
+	return v.Value(), nil
+}
+
+func (p *PayloadsLedger) SetValue(owner, key, value []byte) (err error) {
+	registerID := newRegisterID(owner, key)
+	ledgerKey := convert.RegisterIDToLedgerKey(registerID)
+	p.Payloads[registerID] = ledger.NewPayload(ledgerKey, value)
+	return nil
+}
+
+func (p *PayloadsLedger) ValueExists(owner, key []byte) (exists bool, err error) {
+	registerID := newRegisterID(owner, key)
+	_, ok := p.Payloads[registerID]
+	return ok, nil
+}
+
+func (p *PayloadsLedger) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
+	if p.AllocateStorageIndexFunc != nil {
+		return p.AllocateStorageIndexFunc(owner)
+	}
+
+	panic("AllocateStorageIndex not expected to be called")
 }

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -141,6 +141,8 @@ func (id RegisterID) IsInternalState() bool {
 		id.Key == AccountStatusKey
 }
 
+const SlabIndexPrefix = '$'
+
 // IsSlabIndex returns true if the key is a slab index for an account's ordered fields
 // map.
 //
@@ -148,15 +150,15 @@ func (id RegisterID) IsInternalState() bool {
 // only to cadence.  Cadence encodes this map into bytes and split the bytes
 // into slab chunks before storing the slabs into the ledger.
 func (id RegisterID) IsSlabIndex() bool {
-	return len(id.Key) == 9 && id.Key[0] == '$'
+	return len(id.Key) == 9 && id.Key[0] == SlabIndexPrefix
 }
 
 // String returns formatted string representation of the RegisterID.
 func (id RegisterID) String() string {
 	formattedKey := ""
 	if id.IsSlabIndex() {
-		i := uint64(binary.BigEndian.Uint64([]byte(id.Key[1:])))
-		formattedKey = fmt.Sprintf("$%d", i)
+		i := binary.BigEndian.Uint64([]byte(id.Key[1:]))
+		formattedKey = fmt.Sprintf("%c%d", SlabIndexPrefix, i)
 	} else {
 		formattedKey = fmt.Sprintf("#%x", []byte(id.Key))
 	}


### PR DESCRIPTION
Work towards #5634

