### PR TITLE
Improve migrations

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -371,8 +371,7 @@ func newMigrations(
 
 					&migrators.DeduplicateContractNamesMigration{},
 
-					// This will fix storage used discrepancies caused by the
-					// DeduplicateContractNamesMigration.
+					// This will fix storage used discrepancies caused by the previous migrations
 					&migrators.AccountUsageMigrator{},
 				}),
 		}

--- a/cmd/util/ledger/migrations/atree_register_migration.go
+++ b/cmd/util/ledger/migrations/atree_register_migration.go
@@ -8,9 +8,9 @@ import (
 	runtime2 "runtime"
 	"time"
 
+	"github.com/onflow/atree"
 	"github.com/rs/zerolog"
 
-	"github.com/onflow/atree"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
@@ -185,7 +185,7 @@ func (m *AtreeRegisterMigrator) migrateAccountStorage(
 ) (map[flow.RegisterID]flow.RegisterValue, error) {
 
 	// iterate through all domains and migrate them
-	for _, domain := range domains {
+	for _, domain := range allStorageMapDomains {
 		err := m.convertStorageDomain(mr, storageMapIds, domain)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert storage domain %s : %w", domain, err)
@@ -360,7 +360,7 @@ func (m *AtreeRegisterMigrator) validateChangesAndCreateNewRegisters(
 				continue
 			}
 
-			if _, isADomainKey := domainsLookupMap[id.Key]; isADomainKey {
+			if _, isADomainKey := allStorageMapDomainsSet[id.Key]; isADomainKey {
 				// this is expected. Move it to the new payloads
 				newPayloads = append(newPayloads, value)
 				continue

--- a/cmd/util/ledger/migrations/cadence_value_validation.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation.go
@@ -33,7 +33,7 @@ func validateCadenceValues(
 	}
 
 	// Iterate through all domains and compare cadence values.
-	for _, domain := range domains {
+	for _, domain := range allStorageMapDomains {
 		err := validateStorageDomain(address, oldRuntime, newRuntime, domain, log, verboseLogging)
 		if err != nil {
 			return err

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -40,15 +40,14 @@ func checkStorageHealth(
 		}
 	}
 
-	for _, domain := range domains {
+	for _, domain := range allStorageMapDomains {
 		_ = storage.GetStorageMap(address, domain, false)
 	}
 
 	return storage.CheckHealth()
 }
 
-// convert all domains
-var domains = []string{
+var allStorageMapDomains = []string{
 	common.PathDomainStorage.Identifier(),
 	common.PathDomainPrivate.Identifier(),
 	common.PathDomainPublic.Identifier(),
@@ -57,11 +56,10 @@ var domains = []string{
 	stdlib.CapabilityControllerStorageDomain,
 }
 
-var domainsLookupMap = map[string]struct{}{
-	common.PathDomainStorage.Identifier():    {},
-	common.PathDomainPrivate.Identifier():    {},
-	common.PathDomainPublic.Identifier():     {},
-	runtime.StorageDomainContract:            {},
-	stdlib.InboxStorageDomain:                {},
-	stdlib.CapabilityControllerStorageDomain: {},
+var allStorageMapDomainsSet = map[string]struct{}{}
+
+func init() {
+	for _, domain := range allStorageMapDomains {
+		allStorageMapDomainsSet[domain] = struct{}{}
+	}
 }

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -8,62 +8,9 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/stdlib"
 
-	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
-	"github.com/onflow/flow-go/model/flow"
 )
-
-type AccountsAtreeLedger struct {
-	Accounts environment.Accounts
-}
-
-func NewAccountsAtreeLedger(accounts environment.Accounts) *AccountsAtreeLedger {
-	return &AccountsAtreeLedger{Accounts: accounts}
-}
-
-var _ atree.Ledger = &AccountsAtreeLedger{}
-
-func (a *AccountsAtreeLedger) GetValue(owner, key []byte) ([]byte, error) {
-	v, err := a.Accounts.GetValue(
-		flow.NewRegisterID(
-			flow.BytesToAddress(owner),
-			string(key)))
-	if err != nil {
-		return nil, fmt.Errorf("getting value failed: %w", err)
-	}
-	return v, nil
-}
-
-func (a *AccountsAtreeLedger) SetValue(owner, key, value []byte) error {
-	err := a.Accounts.SetValue(
-		flow.NewRegisterID(
-			flow.BytesToAddress(owner),
-			string(key)),
-		value)
-	if err != nil {
-		return fmt.Errorf("setting value failed: %w", err)
-	}
-	return nil
-}
-
-func (a *AccountsAtreeLedger) ValueExists(owner, key []byte) (exists bool, err error) {
-	v, err := a.GetValue(owner, key)
-	if err != nil {
-		return false, fmt.Errorf("checking value existence failed: %w", err)
-	}
-
-	return len(v) > 0, nil
-}
-
-// AllocateStorageIndex allocates new storage index under the owner accounts to store a new register
-func (a *AccountsAtreeLedger) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
-	v, err := a.Accounts.AllocateStorageIndex(flow.BytesToAddress(owner))
-	if err != nil {
-		return atree.StorageIndex{}, fmt.Errorf("storage address allocation failed: %w", err)
-	}
-	return v, nil
-}
 
 func checkStorageHealth(
 	address common.Address,


### PR DESCRIPTION
- Remove unused `AccountsAtreeLedger`. It's from '21 and not used either by atree register inlining nor Cadence 1.0 migration
- Improve comment
- Generate set of all storage map domains from slice (ensure they are in sync)

@fxamacker @janezpodhostnik seeing `AccountUsageMigrator` made me wonder: I guess we also want to run this after the Cadence 1.0 migration, because it also changes account storage usage (even if just slightly)?