### PR TITLE
Collect staged contracts from the storage itself

### DIFF
--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -314,9 +314,8 @@ func NewCadence1ContractsMigrations(
 	)
 
 	stagedContractsMigration := NewStagedContractsMigration(opts.ChainID, log, rwf).
-		WithContractUpdateValidation()
-
-	stagedContractsMigration.RegisterContractUpdates(opts.StagedContracts)
+		WithContractUpdateValidation().
+		WithStagedContractUpdates(opts.StagedContracts)
 
 	toAccountBasedMigration := func(migration AccountBasedMigration) ledger.Migration {
 		return NewAccountBasedMigration(

--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -284,7 +284,7 @@ func NewSystemContractsMigration(
 ) *ChangeContractCodeMigration {
 	migration := NewChangeContractCodeMigration(chainID, log, rwf)
 	for _, change := range SystemContractChanges(chainID, options) {
-		migration.RegisterContractChange(change)
+		migration.registerContractChange(change)
 	}
 	return migration
 }

--- a/cmd/util/ledger/migrations/change_contract_code_migration_test.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 
@@ -54,8 +55,17 @@ type logWriter struct {
 
 var _ io.Writer = &logWriter{}
 
+const warnLogPrefix = "{\"level\":\"warn\""
+
 func (l *logWriter) Write(bytes []byte) (int, error) {
-	l.logs = append(l.logs, string(bytes))
+	logStr := string(bytes)
+
+	// Ignore warnings
+	if strings.HasPrefix(logStr, warnLogPrefix) {
+		return 0, nil
+	}
+
+	l.logs = append(l.logs, logStr)
 	return len(bytes), nil
 }
 

--- a/cmd/util/ledger/migrations/change_contract_code_migration_test.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration_test.go
@@ -55,13 +55,13 @@ type logWriter struct {
 
 var _ io.Writer = &logWriter{}
 
-const warnLogPrefix = "{\"level\":\"warn\""
+const errorLogPrefix = "{\"level\":\"error\""
 
 func (l *logWriter) Write(bytes []byte) (int, error) {
 	logStr := string(bytes)
 
-	// Ignore warnings
-	if strings.HasPrefix(logStr, warnLogPrefix) {
+	// Ignore non-error logs
+	if !strings.HasPrefix(logStr, errorLogPrefix) {
 		return 0, nil
 	}
 
@@ -152,20 +152,19 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf).
+			WithStagedContractUpdates([]migrations.StagedContract{
+				{
+					Address: common.Address(address1),
+					Contract: migrations.Contract{
+						Name: "A",
+						Code: []byte(updatedContractA),
+					},
+				},
+			})
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address1),
-				Contract: migrations.Contract{
-					Name: "A",
-					Code: []byte(updatedContractA),
-				},
-			},
-		)
 
 		payloads, err := migration.MigrateAccount(
 			ctx,
@@ -197,20 +196,19 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf).
+			WithStagedContractUpdates([]migrations.StagedContract{
+				{
+					Address: common.Address(address1),
+					Contract: migrations.Contract{
+						Name: "A",
+						Code: []byte(updatedContractA),
+					},
+				},
+			})
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address1),
-				Contract: migrations.Contract{
-					Name: "A",
-					Code: []byte(updatedContractA),
-				},
-			},
-		)
 
 		payloads, err := migration.MigrateAccount(
 			ctx,
@@ -240,29 +238,26 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf).
+			WithStagedContractUpdates([]migrations.StagedContract{
+				{
+					Address: common.Address(address1),
+					Contract: migrations.Contract{
+						Name: "A",
+						Code: []byte(updatedContractA),
+					},
+				},
+				{
+					Address: common.Address(address1),
+					Contract: migrations.Contract{
+						Name: "B",
+						Code: []byte(updatedContractB),
+					},
+				},
+			})
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address1),
-				Contract: migrations.Contract{
-					Name: "A",
-					Code: []byte(updatedContractA),
-				},
-			},
-		)
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address1),
-				Contract: migrations.Contract{
-					Name: "B",
-					Code: []byte(updatedContractB),
-				},
-			},
-		)
 
 		payloads, err := migration.MigrateAccount(
 			ctx,
@@ -292,20 +287,19 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf).
+			WithStagedContractUpdates([]migrations.StagedContract{
+				{
+					Address: common.Address(address1),
+					Contract: migrations.Contract{
+						Name: "A",
+						Code: []byte(updatedContractA),
+					},
+				},
+			})
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address1),
-				Contract: migrations.Contract{
-					Name: "A",
-					Code: []byte(updatedContractA),
-				},
-			},
-		)
 
 		payloads, err := migration.MigrateAccount(
 			ctx,
@@ -339,29 +333,26 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf).
+			WithStagedContractUpdates([]migrations.StagedContract{
+				{
+					Address: common.Address(address1),
+					Contract: migrations.Contract{
+						Name: "A",
+						Code: []byte(updatedContractA),
+					},
+				},
+				{
+					Address: common.Address(address1),
+					Contract: migrations.Contract{
+						Name: "B",
+						Code: []byte(updatedContractB),
+					},
+				},
+			})
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address1),
-				Contract: migrations.Contract{
-					Name: "A",
-					Code: []byte(updatedContractA),
-				},
-			},
-		)
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address1),
-				Contract: migrations.Contract{
-					Name: "B",
-					Code: []byte(updatedContractB),
-				},
-			},
-		)
 
 		_, err = migration.MigrateAccount(
 			ctx,
@@ -388,20 +379,19 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf).
+			WithStagedContractUpdates([]migrations.StagedContract{
+				{
+					Address: common.Address(address2),
+					Contract: migrations.Contract{
+						Name: "A",
+						Code: []byte(updatedContractA),
+					},
+				},
+			})
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractChange(
-			migrations.StagedContract{
-				Address: common.Address(address2),
-				Contract: migrations.Contract{
-					Name: "A",
-					Code: []byte(updatedContractA),
-				},
-			},
-		)
 
 		_, err = migration.MigrateAccount(
 			ctx,

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -194,6 +194,9 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 		}
 	}
 
+	m.log.Debug().
+		Msgf("found %d payloads in account %s", len(stagingAccountPayloads), stagingAccount)
+
 	mr, err := NewMigratorRuntime(
 		stagingAccountAddress,
 		stagingAccountPayloads,
@@ -215,7 +218,7 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 			Name:    "MigrationContractStaging",
 			Address: stagingAccountAddress,
 		},
-		"Capsule",
+		"MigrationContractStaging.Capsule",
 	)
 
 	stagedContracts := make([]StagedContract, 0)
@@ -238,6 +241,8 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 			// This shouldn't occur, but technically possible.
 			// e.g: accidentally storing other values under the same storage path pattern.
 			// So skip such values. We are not interested in those.
+			m.log.Debug().
+				Msgf("found a value with an unexpected type `%s`", staticType)
 			continue
 		}
 

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -189,7 +189,7 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 
 		address := flow.BytesToAddress(key.KeyParts[0].Value)
 
-		if stagingAccountAddress == common.Address(address) {
+		if common.Address(address) == stagingAccountAddress {
 			stagingAccountPayloads = append(stagingAccountPayloads, payload)
 		}
 	}

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -153,6 +153,9 @@ func (m *StagedContractsMigration) RegisterContractUpdates(stagedContracts []Sta
 	for _, contractChange := range stagedContracts {
 		m.RegisterContractChange(contractChange)
 	}
+
+	m.log.Info().
+		Msgf("total of %d unique contracts are staged for all accounts", len(m.contractsByLocation))
 }
 
 func (m *StagedContractsMigration) RegisterContractChange(change StagedContract) {

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -156,7 +156,6 @@ func (m *StagedContractsMigration) InitMigration(
 // collectAndRegisterStagedContractsFromPayloads scan through the payloads and collects the contracts
 // staged through the `MigrationContractStaging` contract.
 func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads(allPayloads []*ledger.Payload) error {
-	var stagingAccount string
 
 	// If the contracts are already passed as an input to the migration
 	// then no need to scan the storage.
@@ -164,6 +163,8 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 	if len(m.contractsByLocation) > 0 {
 		return nil
 	}
+
+	var stagingAccount string
 
 	switch m.chainID {
 	case flow.Testnet:

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -169,8 +169,7 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 	case flow.Testnet:
 		stagingAccount = "0x2ceae959ed1a7e7a"
 	case flow.Mainnet:
-		// TODO:
-		stagingAccount = "0x2ceae959ed1a7e7a"
+		stagingAccount = "0x56100d46aa9b0212"
 	default:
 		// For other networks such as emulator etc. no need to scan for staged contracts.
 		return nil

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -194,7 +194,7 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 		}
 	}
 
-	m.log.Debug().
+	m.log.Info().
 		Msgf("found %d payloads in account %s", len(stagingAccountPayloads), stagingAccount)
 
 	mr, err := NewMigratorRuntime(
@@ -241,7 +241,7 @@ func (m *StagedContractsMigration) collectAndRegisterStagedContractsFromPayloads
 			// This shouldn't occur, but technically possible.
 			// e.g: accidentally storing other values under the same storage path pattern.
 			// So skip such values. We are not interested in those.
-			m.log.Debug().
+			m.log.Info().
 				Msgf("found a value with an unexpected type `%s`", staticType)
 			continue
 		}

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -508,7 +508,7 @@ func TestStagedContractsMigration(t *testing.T) {
 					Address: stagingAccountAddress,
 					Name:    "MigrationContractStaging",
 				},
-				"ContractUpdate",
+				"MigrationContractStaging.ContractUpdate",
 				common.CompositeKindStructure,
 				[]interpreter.CompositeField{
 					{
@@ -534,7 +534,7 @@ func TestStagedContractsMigration(t *testing.T) {
 					Address: stagingAccountAddress,
 					Name:    "MigrationContractStaging",
 				},
-				"Capsule",
+				"MigrationContractStaging.Capsule",
 				common.CompositeKindResource,
 				[]interpreter.CompositeField{
 					{
@@ -611,9 +611,11 @@ func TestStagedContractsMigration(t *testing.T) {
 		err = migration.Close()
 		require.NoError(t, err)
 
-		require.Len(t, logWriter.logs, 2)
-		require.Contains(t, logWriter.logs[0], "found 1 staged contracts from payloads")
-		require.Contains(t, logWriter.logs[1], "total of 1 unique contracts are staged for all accounts")
+		require.Len(t, logWriter.logs, 4)
+		require.Contains(t, logWriter.logs[0], "found 6 payloads in account 0x2ceae959ed1a7e7a")
+		require.Contains(t, logWriter.logs[1], "found a value with an unexpected type `String`")
+		require.Contains(t, logWriter.logs[2], "found 1 staged contracts from payloads")
+		require.Contains(t, logWriter.logs[3], "total of 1 unique contracts are staged for all accounts")
 
 		require.Len(t, payloads, 1)
 		require.Equal(t, newCode, string(payloads[0].Value()))

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -86,8 +86,8 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
-		migration.RegisterContractUpdates(stagedContracts)
+		migration := NewStagedContractsMigration(chainID, log, rwf).
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
 			WithContractUpdateValidation()
-		migration.RegisterContractUpdates(stagedContracts)
+		migration.WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -180,8 +180,8 @@ func TestStagedContractsMigration(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -241,8 +241,8 @@ func TestStagedContractsMigration(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestStagedContractsMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, logWriter.logs, 2)
-		require.Contains(t, logWriter.logs[0], `{"level":"info","message":"total of 2 unique contracts are staged for all accounts"}`)
+		require.Contains(t, logWriter.logs[0], `{"level":"info","message":"total of 2 staged contracts are provided externally"}`)
 		require.Contains(t, logWriter.logs[1], `error: expected token '{'`)
 
 		require.Len(t, payloads, 2)
@@ -313,8 +313,8 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
-		migration.RegisterContractUpdates(stagedContracts)
+		migration := NewStagedContractsMigration(chainID, log, rwf).
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -397,8 +397,8 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
-		migration.RegisterContractUpdates(stagedContracts)
+		migration := NewStagedContractsMigration(chainID, log, rwf).
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -446,8 +446,8 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
-		migration.RegisterContractUpdates(stagedContracts)
+		migration := NewStagedContractsMigration(chainID, log, rwf).
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -684,8 +684,8 @@ func TestStagedContractsWithImports(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
-		migration.RegisterContractUpdates(stagedContracts)
+		migration := NewStagedContractsMigration(chainID, log, rwf).
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -762,8 +762,8 @@ func TestStagedContractsWithImports(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -855,8 +855,8 @@ func TestStagedContractsWithImports(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -953,8 +953,8 @@ func TestStagedContractsWithImports(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -1173,9 +1173,8 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -1266,9 +1265,8 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err = migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -1356,9 +1354,8 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, allPayloads, 0)
 		require.NoError(t, err)
@@ -1458,9 +1455,8 @@ func TestStagedContractConformanceChanges(t *testing.T) {
 			rwf := &testReportWriterFactory{}
 
 			migration := NewStagedContractsMigration(chainID, log, rwf).
-				WithContractUpdateValidation()
-
-			migration.RegisterContractUpdates(stagedContracts)
+				WithContractUpdateValidation().
+				WithStagedContractUpdates(stagedContracts)
 
 			contractCodePayload := newContractPayload(common.Address(address), "A", []byte(oldCode))
 			viewResolverCodePayload := newContractPayload(
@@ -1573,9 +1569,8 @@ func TestStagedContractConformanceChanges(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		contractCodePayload := newContractPayload(common.Address(address), "A", []byte(oldCode))
 		arbitraryContractCodePayload := newContractPayload(
@@ -1791,9 +1786,8 @@ func TestStagedContractsUpdateValidationErrors(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		payloads := []*ledger.Payload{
 			newContractPayload(common.Address(address), "A", []byte(oldCodeA)),
@@ -1890,9 +1884,8 @@ func TestStagedContractsUpdateValidationErrors(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf).
-			WithContractUpdateValidation()
-
-		migration.RegisterContractUpdates(stagedContracts)
+			WithContractUpdateValidation().
+			WithStagedContractUpdates(stagedContracts)
 
 		contractACode := newContractPayload(common.Address(address), "A", []byte(oldCodeA))
 		nftCode := newContractPayload(nftAddress, "NonFungibleToken", []byte(nftContract))

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -398,11 +398,10 @@ func TestStagedContractsMigration(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf)
+		migration.RegisterContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractUpdates(stagedContracts)
 
 		payloads, err := migration.MigrateAccount(
 			context.Background(),
@@ -448,11 +447,10 @@ func TestStagedContractsMigration(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		migration := NewStagedContractsMigration(chainID, log, rwf)
+		migration.RegisterContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
-
-		migration.RegisterContractUpdates(stagedContracts)
 
 		// NOTE: no payloads
 		_, err = migration.MigrateAccount(


### PR DESCRIPTION
Work for https://github.com/onflow/cadence/issues/3050

Assuming the state/storage that is currently being migrated also contains the staged contracts captured by the [MigrationContractStaging](https://contractbrowser.com/A.2ceae959ed1a7e7a.MigrationContractStaging), this change will read and collect those staged contracts from the storage itself, so they don't needs to be provided externally as a CSV file, etc.

The old way of providing the staged contracts externally/as an argument (as a CSV file) is still supported. The new approach comes into effect only if they are not externally provided.