### PR TITLE
[EVM] Add 1.0 bridging interface to COA

### DIFF
--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -223,6 +223,8 @@ func SystemContractChanges(chainID flow.ChainID, options SystemContractsMigratio
 			NewSystemContractChange(
 				systemContracts.EVMContract,
 				evm.ContractCode(
+					flow.HexToAddress(env.NonFungibleTokenAddress),
+					flow.HexToAddress(env.FungibleTokenAddress),
 					flow.HexToAddress(env.FlowTokenAddress),
 				),
 			),

--- a/fvm/bootstrap.go
+++ b/fvm/bootstrap.go
@@ -434,7 +434,7 @@ func (b *bootstrapExecutor) Execute() error {
 	b.deployStakingCollection(service, &env)
 
 	// sets up the EVM environment
-	b.setupEVM(service, fungibleToken, flowToken)
+	b.setupEVM(service, nonFungibleToken, fungibleToken, flowToken)
 
 	err = expectAccounts(systemcontracts.EVMStorageAccountIndex)
 	if err != nil {
@@ -895,7 +895,7 @@ func (b *bootstrapExecutor) setStakingAllowlist(
 	panicOnMetaInvokeErrf("failed to set staking allow-list: %s", txError, err)
 }
 
-func (b *bootstrapExecutor) setupEVM(serviceAddress, fungibleTokenAddress, flowTokenAddress flow.Address) {
+func (b *bootstrapExecutor) setupEVM(serviceAddress, nonFungibleTokenAddress, fungibleTokenAddress, flowTokenAddress flow.Address) {
 	if b.setupEVMEnabled {
 		// account for storage
 		// we dont need to deploy anything to this account, but it needs to exist
@@ -906,7 +906,7 @@ func (b *bootstrapExecutor) setupEVM(serviceAddress, fungibleTokenAddress, flowT
 		// deploy the EVM contract to the service account
 		tx := blueprints.DeployContractTransaction(
 			serviceAddress,
-			stdlib.ContractCode(flowTokenAddress),
+			stdlib.ContractCode(nonFungibleTokenAddress, fungibleTokenAddress, flowTokenAddress),
 			stdlib.ContractName,
 		)
 		// WithEVMEnabled should only be used after we create an account for storage

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -252,12 +252,6 @@ contract EVM {
             return self.address()
         }
 
-        /// The EVM address of the cadence owned account behind an entitlement, acting as proof of access
-        access(Owner | Validate)
-        view fun protectedAddress(): EVMAddress {
-            return self.address()
-        }
-
         /// Withdraws the balance from the cadence owned account's balance
         /// Note that amounts smaller than 10nF (10e-8) can't be withdrawn
         /// given that Flow Token Vaults use UFix64s to store balances.

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -27,13 +27,24 @@ import (
 //go:embed contract.cdc
 var contractCode string
 
-var flowTokenImportPattern = regexp.MustCompile(`(?m)^import "FlowToken"\n`)
+var nftImportPattern = regexp.MustCompile(`(?m)^import "NonFungibleToken"`)
+var fungibleTokenImportPattern = regexp.MustCompile(`(?m)^import "FungibleToken"`)
+var flowTokenImportPattern = regexp.MustCompile(`(?m)^import "FlowToken"`)
 
-func ContractCode(flowTokenAddress flow.Address) []byte {
-	return []byte(flowTokenImportPattern.ReplaceAllString(
+func ContractCode(nonFungibleTokenAddress, fungibleTokenAddress, flowTokenAddress flow.Address) []byte {
+	contractCode = nftImportPattern.ReplaceAllString(
+		contractCode,
+		fmt.Sprintf("import NonFungibleToken from %s", nonFungibleTokenAddress.HexWithPrefix()),
+	)
+	contractCode = fungibleTokenImportPattern.ReplaceAllString(
+		contractCode,
+		fmt.Sprintf("import FungibleToken from %s", fungibleTokenAddress.HexWithPrefix()),
+	)
+	contractCode = flowTokenImportPattern.ReplaceAllString(
 		contractCode,
 		fmt.Sprintf("import FlowToken from %s", flowTokenAddress.HexWithPrefix()),
-	))
+	)
+	return []byte(contractCode)
 }
 
 const ContractName = "EVM"

--- a/fvm/evm/stdlib/contract_test.go
+++ b/fvm/evm/stdlib/contract_test.go
@@ -238,7 +238,7 @@ func deployContracts(
 		},
 		{
 			name: stdlib.ContractName,
-			code: stdlib.ContractCode(contractsAddress),
+			code: stdlib.ContractCode(contractsAddress, contractsAddress, contractsAddress),
 		},
 	}
 


### PR DESCRIPTION
Closes: #5663 

This PR introduces bridge functionality to the COA resource, enabling a caller to bridge owned NFTs & FTs between VMs. These requests are routed from the calling COA to a `BridgeRouter` implementation which is stored in the EVM contract account. This resource encapsulates and safeguards a Capability on a `BridgeAccessor` implementation - defined in a bridge contract and stored in the bridge account - to which the `BridgeRouter` routes bridge requests.

The `BridgeAccessor` (not in scope for this PR but can be seen in https://github.com/onflow/flow-evm-bridge/pull/28) then passes routed calls through to the VM bridge. Via these new interfaces and their stored implementations, the EVM contract can be integrated with the bridge.

Note that simply updating the EVM contract with these changes isn't sufficient to integrate with the bridge as calls to `borrowBridgeAccessor` will revert if a `BridgeRouter` is not saved with a valid `BridgeAccessor` Capability. To fully integrate, the bridge contracts will need to be deployed, a `BridgeAccessor` Capability published for the EVM contract account, and the published Capability will need to be saved in a `BridgeRouter` stored at the hardcoded storage path of `/storage/evmBridgeRouter`. Between the EVM update and the storage of the `BridgeRouter`, any bridge-related COA calls will simply fail.