### PR TITLE
Only log failed staged updates if verbose logging is enabled

### DIFF
--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -303,18 +303,30 @@ func NewCadence1ContractsMigrations(
 	opts Options,
 ) []NamedMigration {
 
+	stagedContractsMigrationOptions := StagedContractsMigrationOptions{
+		ChainID:            opts.ChainID,
+		VerboseErrorOutput: opts.VerboseErrorOutput,
+	}
+
+	systemContractsMigrationOptions := SystemContractsMigrationOptions{
+		StagedContractsMigrationOptions: stagedContractsMigrationOptions,
+		EVM:                             opts.EVMContractChange,
+		Burner:                          opts.BurnerContractChange,
+	}
+
 	systemContractsMigration := NewSystemContractsMigration(
-		opts.ChainID,
 		log,
 		rwf,
-		SystemContractChangesOptions{
-			EVM:    opts.EVMContractChange,
-			Burner: opts.BurnerContractChange,
-		},
+		systemContractsMigrationOptions,
 	)
 
-	stagedContractsMigration := NewStagedContractsMigration(opts.ChainID, log, rwf).
-		WithContractUpdateValidation()
+	stagedContractsMigration := NewStagedContractsMigration(
+		"StagedContractsMigration",
+		"staged-contracts-migrator",
+		log,
+		rwf,
+		stagedContractsMigrationOptions,
+	).WithContractUpdateValidation()
 
 	stagedContractsMigration.RegisterContractUpdates(opts.StagedContracts)
 

--- a/cmd/util/ledger/migrations/change_contract_code_migration_test.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration_test.go
@@ -81,7 +81,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -107,7 +111,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -142,7 +150,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -187,7 +199,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -230,7 +246,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -282,7 +302,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -329,7 +353,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -378,7 +406,11 @@ func TestChangeContractCodeMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := migrations.NewChangeContractCodeMigration(flow.Emulator, log, rwf)
+		options := migrations.StagedContractsMigrationOptions{
+			ChainID:            flow.Emulator,
+			VerboseErrorOutput: true,
+		}
+		migration := migrations.NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -73,7 +73,12 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options)
 		migration.RegisterContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
@@ -118,7 +123,12 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 		migration.RegisterContractUpdates(stagedContracts)
 
@@ -166,7 +176,12 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 		migration.RegisterContractUpdates(stagedContracts)
 
@@ -224,7 +239,13 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		const reporterName = "test"
+		migration := NewStagedContractsMigration("test", reporterName, log, rwf, options).
 			WithContractUpdateValidation()
 		migration.RegisterContractUpdates(stagedContracts)
 
@@ -253,7 +274,7 @@ func TestStagedContractsMigration(t *testing.T) {
 		// Second payload should have the updated code
 		require.Equal(t, newCode2, string(payloads[1].Value()))
 
-		reportWriter := rwf.reportWriters["staged-contracts-migrator"]
+		reportWriter := rwf.reportWriters[reporterName]
 		require.Len(t, reportWriter.entries, 2)
 		assert.Equal(
 			t,
@@ -296,7 +317,13 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		const reporterName = "test"
+		migration := NewStagedContractsMigration("test", reporterName, log, rwf, options)
 		migration.RegisterContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
@@ -339,7 +366,7 @@ func TestStagedContractsMigration(t *testing.T) {
 		// No errors.
 		require.Empty(t, logWriter.logs)
 
-		reportWriter := rwf.reportWriters["staged-contracts-migrator"]
+		reportWriter := rwf.reportWriters[reporterName]
 		require.Len(t, reportWriter.entries, 1)
 		assert.Equal(
 			t,
@@ -380,7 +407,12 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -430,7 +462,12 @@ func TestStagedContractsMigration(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options)
 
 		err := migration.InitMigration(log, nil, 0)
 		require.NoError(t, err)
@@ -515,7 +552,12 @@ func TestStagedContractsWithImports(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf)
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options)
 		migration.RegisterContractUpdates(stagedContracts)
 
 		err := migration.InitMigration(log, nil, 0)
@@ -592,7 +634,12 @@ func TestStagedContractsWithImports(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 		migration.RegisterContractUpdates(stagedContracts)
 
@@ -685,7 +732,12 @@ func TestStagedContractsWithImports(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 		migration.RegisterContractUpdates(stagedContracts)
 
@@ -783,7 +835,12 @@ func TestStagedContractsWithImports(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 		migration.RegisterContractUpdates(stagedContracts)
 
@@ -1003,7 +1060,12 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 
 		migration.RegisterContractUpdates(stagedContracts)
@@ -1096,7 +1158,12 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 
 		migration.RegisterContractUpdates(stagedContracts)
@@ -1186,7 +1253,12 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 
 		migration.RegisterContractUpdates(stagedContracts)
@@ -1288,7 +1360,12 @@ func TestStagedContractConformanceChanges(t *testing.T) {
 
 			rwf := &testReportWriterFactory{}
 
-			migration := NewStagedContractsMigration(chainID, log, rwf).
+			options := StagedContractsMigrationOptions{
+				ChainID:            chainID,
+				VerboseErrorOutput: true,
+			}
+
+			migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 				WithContractUpdateValidation()
 
 			migration.RegisterContractUpdates(stagedContracts)
@@ -1403,7 +1480,12 @@ func TestStagedContractConformanceChanges(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 
 		migration.RegisterContractUpdates(stagedContracts)
@@ -1621,7 +1703,12 @@ func TestStagedContractsUpdateValidationErrors(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 
 		migration.RegisterContractUpdates(stagedContracts)
@@ -1720,7 +1807,12 @@ func TestStagedContractsUpdateValidationErrors(t *testing.T) {
 
 		rwf := &testReportWriterFactory{}
 
-		migration := NewStagedContractsMigration(chainID, log, rwf).
+		options := StagedContractsMigrationOptions{
+			ChainID:            chainID,
+			VerboseErrorOutput: true,
+		}
+
+		migration := NewStagedContractsMigration("test", "test", log, rwf, options).
 			WithContractUpdateValidation()
 
 		migration.RegisterContractUpdates(stagedContracts)


### PR DESCRIPTION
Failures are already and always reported.

Also, clean up and remove the unnecessary `ChangeContractCodeMigration` wrapper around `StagedContractsMigration`