### PR TITLE
Update to Cadence v1.0.0-preview.20

### DIFF
--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -152,6 +152,7 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 		migrationRuntime.Interpreter,
 		storage,
 		m.name,
+		address,
 	)
 
 	reporter := newValueMigrationReporter(m.reporter, m.log, m.errorMessageHandler, m.verboseErrorOutput)
@@ -162,8 +163,7 @@ func (m *CadenceBaseMigrator) MigrateAccount(
 		reporter,
 	)
 
-	migration.MigrateAccount(
-		address,
+	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
 			reporter,
 			valueMigrations...,
@@ -512,6 +512,12 @@ func (t *cadenceValueMigrationReporter) MissingTarget(accountAddressPath interpr
 	})
 }
 
+func (t *cadenceValueMigrationReporter) DictionaryKeyConflict(key interpreter.StringStorageMapKey) {
+	t.reportWriter.Write(dictionaryKeyConflictEntry{
+		Key: string(key),
+	})
+}
+
 type valueMigrationReportEntry interface {
 	accountAddress() common.Address
 }
@@ -577,4 +583,8 @@ var _ valueMigrationReportEntry = capConsMissingTargetEntry{}
 
 func (e capConsMissingCapabilityIDEntry) accountAddress() common.Address {
 	return e.AccountAddress
+}
+
+type dictionaryKeyConflictEntry struct {
+	Key string `json:"key"`
 }

--- a/go.mod
+++ b/go.mod
@@ -51,12 +51,12 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2
-	github.com/onflow/cadence v1.0.0-preview.19
+	github.com/onflow/cadence v1.0.0-preview.20
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240402184019-90048578066e
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240402184019-90048578066e
-	github.com/onflow/flow-go-sdk v1.0.0-preview.17
+	github.com/onflow/flow-go-sdk v1.0.0-preview.19
 	github.com/onflow/flow/protobuf/go/flow v0.4.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2491,8 +2491,8 @@ github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2/go.mod h1:xvP61FoOs
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.19 h1:EowxTD6g1lDAvdh5VK++YVTncj46r4MhYeEpm6L7GnQ=
-github.com/onflow/cadence v1.0.0-preview.19/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
+github.com/onflow/cadence v1.0.0-preview.20 h1:BJmWOPJsMADNLZ3Qbm8mz2C9DeAlWdEfb2dgzyncUPA=
+github.com/onflow/cadence v1.0.0-preview.20/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2507,8 +2507,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240402160548-a9c331660956/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956 h1:Ef9UKtwNcHVG2R8YskYiwRoaTZFhAVmQ0ZN3c0eDUGU=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.17 h1:RDW+FCKWJBCX7U6bK7ZEBVqBrhdNS9CIAV+xvVeLLYY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.17/go.mod h1:2XygOoc/RN2c28o3vebEc3TLhzfAviOEwpn2yQJHojQ=
+github.com/onflow/flow-go-sdk v1.0.0-preview.19 h1:GHO+nbkTc4xopAQucX4bmQM6MtcXXTPfUdcgzAusO0o=
+github.com/onflow/flow-go-sdk v1.0.0-preview.19/go.mod h1:w0UCfB4O0bV4/doU7UZDLEjoGIxGC14cLGKFIWhwjCc=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240402163945-74687e7a5b9d h1:CeM0F/t8f6UYKIP/PzHApt0BfX5FLCbFiSW3tkXHLyA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240402163945-74687e7a5b9d/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240402163945-74687e7a5b9d h1:9BUEgH1oFUMeOab++UNgok9Jk+rejQIrIHYKNe/TD20=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -205,12 +205,12 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2 // indirect
-	github.com/onflow/cadence v1.0.0-preview.19 // indirect
+	github.com/onflow/cadence v1.0.0-preview.20 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240402184019-90048578066e // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240402184019-90048578066e // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240402160548-a9c331660956 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-preview.17 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-preview.19 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240402163945-74687e7a5b9d // indirect
 	github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240402163945-74687e7a5b9d // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.0 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2476,8 +2476,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2 h1:jJLDswfAVB0bHCu1y1FPdKukPcTNmN+jYEX9S9phbv0=
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.19 h1:EowxTD6g1lDAvdh5VK++YVTncj46r4MhYeEpm6L7GnQ=
-github.com/onflow/cadence v1.0.0-preview.19/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
+github.com/onflow/cadence v1.0.0-preview.20 h1:BJmWOPJsMADNLZ3Qbm8mz2C9DeAlWdEfb2dgzyncUPA=
+github.com/onflow/cadence v1.0.0-preview.20/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2490,8 +2490,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240402160548-a9c331660956/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956 h1:Ef9UKtwNcHVG2R8YskYiwRoaTZFhAVmQ0ZN3c0eDUGU=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.17 h1:RDW+FCKWJBCX7U6bK7ZEBVqBrhdNS9CIAV+xvVeLLYY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.17/go.mod h1:2XygOoc/RN2c28o3vebEc3TLhzfAviOEwpn2yQJHojQ=
+github.com/onflow/flow-go-sdk v1.0.0-preview.19 h1:GHO+nbkTc4xopAQucX4bmQM6MtcXXTPfUdcgzAusO0o=
+github.com/onflow/flow-go-sdk v1.0.0-preview.19/go.mod h1:w0UCfB4O0bV4/doU7UZDLEjoGIxGC14cLGKFIWhwjCc=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240402163945-74687e7a5b9d h1:CeM0F/t8f6UYKIP/PzHApt0BfX5FLCbFiSW3tkXHLyA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240402163945-74687e7a5b9d/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240402163945-74687e7a5b9d h1:9BUEgH1oFUMeOab++UNgok9Jk+rejQIrIHYKNe/TD20=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -20,13 +20,13 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview.19
+	github.com/onflow/cadence v1.0.0-preview.20
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240402184019-90048578066e
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240402184019-90048578066e
 	github.com/onflow/flow-emulator v1.0.0-preview.17
 	github.com/onflow/flow-go v0.34.0-crescendo-preview.9.0.20240409075958-ccbe91096438
-	github.com/onflow/flow-go-sdk v1.0.0-preview.17
+	github.com/onflow/flow-go-sdk v1.0.0-preview.19
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.0
 	github.com/onflow/go-ethereum v1.13.4

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2552,8 +2552,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2 h1:jJLDswfAVB0bHCu1y1FPdKukPcTNmN+jYEX9S9phbv0=
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.19 h1:EowxTD6g1lDAvdh5VK++YVTncj46r4MhYeEpm6L7GnQ=
-github.com/onflow/cadence v1.0.0-preview.19/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
+github.com/onflow/cadence v1.0.0-preview.20 h1:BJmWOPJsMADNLZ3Qbm8mz2C9DeAlWdEfb2dgzyncUPA=
+github.com/onflow/cadence v1.0.0-preview.20/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2568,8 +2568,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240402160548-a9c331660956/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956 h1:Ef9UKtwNcHVG2R8YskYiwRoaTZFhAVmQ0ZN3c0eDUGU=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240402160548-a9c331660956/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.17 h1:RDW+FCKWJBCX7U6bK7ZEBVqBrhdNS9CIAV+xvVeLLYY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.17/go.mod h1:2XygOoc/RN2c28o3vebEc3TLhzfAviOEwpn2yQJHojQ=
+github.com/onflow/flow-go-sdk v1.0.0-preview.19 h1:GHO+nbkTc4xopAQucX4bmQM6MtcXXTPfUdcgzAusO0o=
+github.com/onflow/flow-go-sdk v1.0.0-preview.19/go.mod h1:w0UCfB4O0bV4/doU7UZDLEjoGIxGC14cLGKFIWhwjCc=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240402163945-74687e7a5b9d h1:CeM0F/t8f6UYKIP/PzHApt0BfX5FLCbFiSW3tkXHLyA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240402163945-74687e7a5b9d/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240402163945-74687e7a5b9d h1:9BUEgH1oFUMeOab++UNgok9Jk+rejQIrIHYKNe/TD20=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/flow-go-sdk v1.0.0-preview.19](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.19)
- [onflow/cadence v1.0.0-preview.20](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.20)

