### PR TITLE
v0.33 adjust extra blocks in sealing segment

### DIFF
--- a/fvm/environment/block_info.go
+++ b/fvm/environment/block_info.go
@@ -142,7 +142,9 @@ func (info *blockInfo) GetBlockAtHeight(
 		return runtimeBlockFromHeader(info.blockHeader), true, nil
 	}
 
-	if height+uint64(flow.DefaultTransactionExpiry) < info.blockHeader.Height {
+	// Check if the requested block height is within the range of the current
+	// block height and the extra blocks in the root sealing segment.
+	if height+uint64(flow.ExtraBlocksInRootSealingSegment) < info.blockHeader.Height {
 		return runtime.Block{}, false, errors.NewBlockHeightOutOfRangeError(height)
 	}
 

--- a/model/flow/constants.go
+++ b/model/flow/constants.go
@@ -21,6 +21,13 @@ const DefaultProtocolVersion uint = 0
 // * R.height < B.height <= R.height+E
 const DefaultTransactionExpiry = 10 * 60
 
+// ExtraBlocksInRootSealingSegment is the default number of extra blocks to be included
+// in the the root sealing segment.
+// "- 10" is to be backward compatible, since some dynamically bootstrapped execution nodes
+// are using previously generated root snapshot which has about 6-7 blocks less than DefaultTransactionExpiry
+// number of extra blocks in the sealing segment.
+const ExtraBlocksInRootSealingSegment = DefaultTransactionExpiry - 10
+
 // DefaultTransactionExpiryBuffer is the default buffer time between a transaction being ingested by a
 // collection node and being included in a collection and block.
 const DefaultTransactionExpiryBuffer = 30

--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -33,7 +33,7 @@ type SealingSegment struct {
 	// (see sealing_segment.md for details):
 	//  (ii) All blocks that are sealed by `head`. This is relevant if `head` contains _multiple_ seals.
 	// (iii) The sealing segment holds the history of all non-expired collection guarantees, i.e.
-	//       limitHeight := max(blockSealedAtHead.Height - flow.DefaultTransactionExpiry, SporkRootBlockHeight)
+	//       limitHeight := max(blockSealedAtHead.Height - flow.ExtraBlocksInRootSealingSegment, SporkRootBlockHeight)
 	//       where blockSealedAtHead is the block sealed by `head` block.
 	// (Potentially longer history is permitted)
 	ExtraBlocks []*Block

--- a/model/flow/sealing_segment.md
+++ b/model/flow/sealing_segment.md
@@ -85,9 +85,9 @@ ExtraBlocks []*Block
   of the sealed block. The seals don't contain the block's height information, hence we need to resolve the block.
 
 **Extended history to check for duplicated collection guarantees in blocks** is required by nodes that _validate_ block
-payloads (e.g. consensus nodes). Also Access Nodes require these blocks. Collections expire after `flow.DefaultTransactionExpiry` blocks.
-Hence, we desire a history of `flow.DefaultTransactionExpiry` blocks. However, there is the edge case of a recent spork (or genesis),
-where the history is simply less that `flow.DefaultTransactionExpiry`.
+payloads (e.g. consensus nodes). Also Access Nodes require these blocks. Collections expire after `flow.ExtraBlocksInRootSealingSegment` blocks.
+Hence, we desire a history of `flow.ExtraBlocksInRootSealingSegment` blocks. However, there is the edge case of a recent spork (or genesis),
+where the history is simply less that `flow.ExtraBlocksInRootSealingSegment`.
 
 ### Formal definition
 
@@ -98,7 +98,7 @@ The descriptions from the previous section can be formalized as follows
 * (ii) All blocks that are sealed by `head`. This is relevant if `head` contains _multiple_ seals.
 * (iii) The sealing segment should contain the history back to (including):
   ```
-  limitHeight := max(blockSealedAtHead.Height - flow.DefaultTransactionExpiry, SporkRootBlockHeight)
+  limitHeight := max(blockSealedAtHead.Height - flow.ExtraBlocksInRootSealingSegment, SporkRootBlockHeight)
   ```
    where blockSealedAtHead is the block sealed by `head` block.
 Note that all three conditions have to be satisfied by a sealing segment. Therefore, it must contain the longest history
@@ -110,7 +110,7 @@ additional blocks for (ii) and optionally (iii) are contained in as `SealingSegm
 
 Condition (i) and (ii) are necessary for the sealing segment for _any node_. In contrast, (iii) is
 necessary to bootstrap nodes that _validate_ block payloads (e.g. consensus nodes), to verify that
-collection guarantees are not duplicated (collections expire after `flow.DefaultTransactionExpiry` blocks).
+collection guarantees are not duplicated (collections expire after `flow.ExtraBlocksInRootSealingSegment` blocks).
 
 ## Special case: Root Sealing Segment
 

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -231,7 +231,7 @@ func (s *Snapshot) SealingSegment() (*flow.SealingSegment, error) {
 	//       This is relevant if `head` does not contain any seals.
 	//  (ii) All blocks that are sealed by `head`. This is relevant if head` contains _multiple_ seals.
 	// (iii) The sealing segment should contain the history back to (including):
-	//       limitHeight := max(blockSealedAtHead.Height - flow.DefaultTransactionExpiry, SporkRootBlockHeight)
+	//       limitHeight := max(blockSealedAtHead.Height - flow.ExtraBlocksInRootSealingSegment, SporkRootBlockHeight)
 	// Per convention, we include the blocks for (i) in the `SealingSegment.Blocks`, while the
 	// additional blocks for (ii) and optionally (iii) are contained in as `SealingSegment.ExtraBlocks`.
 	head, err := s.state.blocks.ByID(s.blockID)
@@ -299,10 +299,10 @@ func (s *Snapshot) SealingSegment() (*flow.SealingSegment, error) {
 	}
 
 	// STEP (iii): extended history to allow checking for duplicated collections, i.e.
-	// limitHeight = max(blockSealedAtHead.Height - flow.DefaultTransactionExpiry, SporkRootBlockHeight)
+	// limitHeight = max(blockSealedAtHead.Height - flow.ExtraBlocksInRootSealingSegment, SporkRootBlockHeight)
 	limitHeight := s.state.sporkRootBlockHeight
-	if blockSealedAtHead.Height > s.state.sporkRootBlockHeight+flow.DefaultTransactionExpiry {
-		limitHeight = blockSealedAtHead.Height - flow.DefaultTransactionExpiry
+	if blockSealedAtHead.Height > s.state.sporkRootBlockHeight+flow.ExtraBlocksInRootSealingSegment {
+		limitHeight = blockSealedAtHead.Height - flow.ExtraBlocksInRootSealingSegment
 	}
 
 	// As we have to satisfy (ii) _and_ (iii), we have to take the longest history, i.e. the lowest height.

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -589,17 +589,17 @@ func TestSealingSegment(t *testing.T) {
 		})
 	})
 
-	// Root <- B1 <- B2 <- ... <- B700(Seal_B699)
-	// Expected sealing segment: [B699, B700], Extra blocks: [B98, B99, ..., B698]
-	// where DefaultTransactionExpiry = 600
-	t.Run("test extra blocks contain exactly DefaultTransactionExpiry number of blocks below the sealed block", func(t *testing.T) {
+	// Root <- B1 <- B2 <- ... <- B700(Seal_B689)
+	// Expected sealing segment: [B689, B690], Extra blocks: [B98, B99, ..., B688]
+	// where ExtraBlocksInRootSealingSegment = 590
+	t.Run("test extra blocks contain exactly ExtraBlocksInRootSealingSegment number of blocks below the sealed block", func(t *testing.T) {
 		util.RunWithFollowerProtocolState(t, rootSnapshot, func(db *badger.DB, state *bprotocol.FollowerState) {
 			root := unittest.BlockWithParentFixture(head)
 			buildFinalizedBlock(t, state, root)
 
-			blocks := make([]*flow.Block, 0, flow.DefaultTransactionExpiry+3)
+			blocks := make([]*flow.Block, 0, flow.ExtraBlocksInRootSealingSegment+3)
 			parent := root
-			for i := 0; i < flow.DefaultTransactionExpiry+1; i++ {
+			for i := 0; i < flow.ExtraBlocksInRootSealingSegment+1; i++ {
 				next := unittest.BlockWithParentFixture(parent.Header)
 				next.Header.View = next.Header.Height + 1 // set view so we are still in the same epoch
 				buildFinalizedBlock(t, state, next)
@@ -634,9 +634,9 @@ func TestSealingSegment(t *testing.T) {
 			assert.Equal(t, lastBlock.Header, segment.Finalized().Header)
 			assert.Equal(t, lastSealedBlock.Header, segment.Sealed().Header)
 
-			// there are DefaultTransactionExpiry number of blocks in total
-			unittest.AssertEqualBlocksLenAndOrder(t, blocks[:flow.DefaultTransactionExpiry], segment.ExtraBlocks)
-			assert.Len(t, segment.ExtraBlocks, flow.DefaultTransactionExpiry)
+			// there are ExtraBlocksInRootSealingSegment number of blocks in total
+			unittest.AssertEqualBlocksLenAndOrder(t, blocks[:flow.ExtraBlocksInRootSealingSegment], segment.ExtraBlocks)
+			assert.Len(t, segment.ExtraBlocks, flow.ExtraBlocksInRootSealingSegment)
 			assertSealingSegmentBlocksQueryableAfterBootstrap(t, snapshot)
 
 		})


### PR DESCRIPTION
This PR is to adjust the number of extra blocks included in the sealing segment, so that it's backward compatible with the old root snapshot generated before which doesn't have `DefaultTransactionExpiry` (600) number of extra blocks. 