### PR TITLE
Improve JSON encoding of reporter entries

### DIFF
--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
@@ -435,7 +436,7 @@ func (t *cadenceValueMigrationReporter) Migrated(
 	storageMapKey interpreter.StorageMapKey,
 	migration string,
 ) {
-	t.reportWriter.Write(cadenceValueMigrationReportEntry{
+	t.reportWriter.Write(cadenceValueMigrationEntry{
 		StorageKey:    storageKey,
 		StorageMapKey: storageMapKey,
 		Migration:     migration,
@@ -461,7 +462,7 @@ func (t *cadenceValueMigrationReporter) Error(err error) {
 	}
 
 	if t.verboseErrorOutput {
-		t.reportWriter.Write(cadenceValueMigrationErrorEntry{
+		t.reportWriter.Write(cadenceValueMigrationFailureEntry{
 			StorageKey:    storageKey,
 			StorageMapKey: storageMapKey,
 			Migration:     migration,
@@ -475,7 +476,7 @@ func (t *cadenceValueMigrationReporter) MigratedPathCapability(
 	addressPath interpreter.AddressPath,
 	borrowType *interpreter.ReferenceStaticType,
 ) {
-	t.reportWriter.Write(capConsPathCapabilityMigrationEntry{
+	t.reportWriter.Write(capabilityMigrationEntry{
 		AccountAddress: accountAddress,
 		AddressPath:    addressPath,
 		BorrowType:     borrowType,
@@ -486,7 +487,7 @@ func (t *cadenceValueMigrationReporter) MissingCapabilityID(
 	accountAddress common.Address,
 	addressPath interpreter.AddressPath,
 ) {
-	t.reportWriter.Write(capConsMissingCapabilityIDEntry{
+	t.reportWriter.Write(capabilityMissingCapabilityIDEntry{
 		AccountAddress: accountAddress,
 		AddressPath:    addressPath,
 	})
@@ -496,9 +497,9 @@ func (t *cadenceValueMigrationReporter) MigratedLink(
 	accountAddressPath interpreter.AddressPath,
 	capabilityID interpreter.UInt64Value,
 ) {
-	t.reportWriter.Write(capConsLinkMigrationEntry{
+	t.reportWriter.Write(linkMigrationEntry{
 		AccountAddressPath: accountAddressPath,
-		CapabilityID:       capabilityID,
+		CapabilityID:       uint64(capabilityID),
 	})
 }
 
@@ -507,14 +508,14 @@ func (t *cadenceValueMigrationReporter) CyclicLink(err capcons.CyclicLinkError) 
 }
 
 func (t *cadenceValueMigrationReporter) MissingTarget(accountAddressPath interpreter.AddressPath) {
-	t.reportWriter.Write(capConsMissingTargetEntry{
+	t.reportWriter.Write(linkMissingTargetEntry{
 		AddressPath: accountAddressPath,
 	})
 }
 
 func (t *cadenceValueMigrationReporter) DictionaryKeyConflict(key interpreter.StringStorageMapKey) {
 	t.reportWriter.Write(dictionaryKeyConflictEntry{
-		Key: string(key),
+		Key: key,
 	})
 }
 
@@ -522,69 +523,203 @@ type valueMigrationReportEntry interface {
 	accountAddress() common.Address
 }
 
-type cadenceValueMigrationReportEntry struct {
-	StorageKey    interpreter.StorageKey    `json:"storageKey"`
-	StorageMapKey interpreter.StorageMapKey `json:"storageMapKey"`
-	Migration     string                    `json:"migration"`
+// cadenceValueMigrationReportEntry
+
+type cadenceValueMigrationEntry struct {
+	StorageKey    interpreter.StorageKey
+	StorageMapKey interpreter.StorageMapKey
+	Migration     string
 }
 
-type cadenceValueMigrationErrorEntry struct {
-	StorageKey    interpreter.StorageKey    `json:"storageKey"`
-	StorageMapKey interpreter.StorageMapKey `json:"storageMapKey"`
-	Migration     string                    `json:"migration"`
-	Message       string                    `json:"message"`
-}
+var _ valueMigrationReportEntry = cadenceValueMigrationEntry{}
 
-var _ valueMigrationReportEntry = cadenceValueMigrationReportEntry{}
-
-func (e cadenceValueMigrationReportEntry) accountAddress() common.Address {
+func (e cadenceValueMigrationEntry) accountAddress() common.Address {
 	return e.StorageKey.Address
 }
 
-type capConsLinkMigrationEntry struct {
-	AccountAddressPath interpreter.AddressPath `json:"address"`
-	CapabilityID       interpreter.UInt64Value `json:"capabilityID"`
+var _ json.Marshaler = cadenceValueMigrationEntry{}
+
+func (e cadenceValueMigrationEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		StorageDomain  string `json:"domain"`
+		Key            string `json:"key"`
+		Migration      string `json:"migration"`
+	}{
+		Kind:           "cadence-value-migration-success",
+		AccountAddress: e.StorageKey.Address.HexWithPrefix(),
+		StorageDomain:  e.StorageKey.Key,
+		Key:            fmt.Sprintf("%s", e.StorageMapKey),
+		Migration:      e.Migration,
+	})
 }
 
-var _ valueMigrationReportEntry = capConsLinkMigrationEntry{}
+// cadenceValueMigrationFailureEntry
 
-func (e capConsLinkMigrationEntry) accountAddress() common.Address {
+type cadenceValueMigrationFailureEntry struct {
+	StorageKey    interpreter.StorageKey
+	StorageMapKey interpreter.StorageMapKey
+	Migration     string
+	Message       string
+}
+
+var _ valueMigrationReportEntry = cadenceValueMigrationFailureEntry{}
+
+func (e cadenceValueMigrationFailureEntry) accountAddress() common.Address {
+	return e.StorageKey.Address
+}
+
+var _ json.Marshaler = cadenceValueMigrationFailureEntry{}
+
+func (e cadenceValueMigrationFailureEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		StorageDomain  string `json:"domain"`
+		Key            string `json:"key"`
+		Migration      string `json:"migration"`
+		Message        string `json:"message"`
+	}{
+		Kind:           "cadence-value-migration-failure",
+		AccountAddress: e.StorageKey.Address.HexWithPrefix(),
+		StorageDomain:  e.StorageKey.Key,
+		Key:            fmt.Sprintf("%s", e.StorageMapKey),
+		Migration:      e.Migration,
+		Message:        e.Message,
+	})
+}
+
+// linkMigrationEntry
+
+type linkMigrationEntry struct {
+	AccountAddressPath interpreter.AddressPath
+	CapabilityID       uint64
+}
+
+var _ valueMigrationReportEntry = linkMigrationEntry{}
+
+func (e linkMigrationEntry) accountAddress() common.Address {
 	return e.AccountAddressPath.Address
 }
 
-type capConsPathCapabilityMigrationEntry struct {
-	AccountAddress common.Address                   `json:"address"`
-	AddressPath    interpreter.AddressPath          `json:"addressPath"`
-	BorrowType     *interpreter.ReferenceStaticType `json:"borrowType"`
+var _ json.Marshaler = linkMigrationEntry{}
+
+func (e linkMigrationEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		Path           string `json:"path"`
+		CapabilityID   uint64 `json:"capability_id"`
+	}{
+		Kind:           "link-migration-success",
+		AccountAddress: e.AccountAddressPath.Address.HexWithPrefix(),
+		Path:           e.AccountAddressPath.Path.String(),
+		CapabilityID:   e.CapabilityID,
+	})
 }
 
-var _ valueMigrationReportEntry = capConsPathCapabilityMigrationEntry{}
+// capabilityMigrationEntry
 
-func (e capConsPathCapabilityMigrationEntry) accountAddress() common.Address {
+type capabilityMigrationEntry struct {
+	AccountAddress common.Address
+	AddressPath    interpreter.AddressPath
+	BorrowType     *interpreter.ReferenceStaticType
+}
+
+var _ valueMigrationReportEntry = capabilityMigrationEntry{}
+
+func (e capabilityMigrationEntry) accountAddress() common.Address {
 	return e.AccountAddress
 }
 
-type capConsMissingCapabilityIDEntry struct {
-	AccountAddress common.Address          `json:"address"`
-	AddressPath    interpreter.AddressPath `json:"addressPath"`
+var _ json.Marshaler = capabilityMigrationEntry{}
+
+func (e capabilityMigrationEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		Address        string `json:"address"`
+		Path           string `json:"path"`
+		BorrowType     string `json:"borrow_type"`
+	}{
+		Kind:           "capability-migration-success",
+		AccountAddress: e.AccountAddress.HexWithPrefix(),
+		Address:        e.AddressPath.Address.HexWithPrefix(),
+		Path:           e.AddressPath.Path.String(),
+		BorrowType:     string(e.BorrowType.ID()),
+	})
 }
 
-var _ valueMigrationReportEntry = capConsMissingCapabilityIDEntry{}
+// capabilityMissingCapabilityIDEntry
 
-type capConsMissingTargetEntry struct {
-	AddressPath interpreter.AddressPath `json:"addressPath"`
+type capabilityMissingCapabilityIDEntry struct {
+	AccountAddress common.Address
+	AddressPath    interpreter.AddressPath
 }
 
-func (e capConsMissingTargetEntry) accountAddress() common.Address {
+var _ valueMigrationReportEntry = capabilityMissingCapabilityIDEntry{}
+
+func (e capabilityMissingCapabilityIDEntry) accountAddress() common.Address {
+	return e.AccountAddress
+}
+
+var _ json.Marshaler = capabilityMissingCapabilityIDEntry{}
+
+func (e capabilityMissingCapabilityIDEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		Address        string `json:"address"`
+		Path           string `json:"path"`
+	}{
+		Kind:           "capability-missing-capability-id",
+		AccountAddress: e.AccountAddress.HexWithPrefix(),
+		Address:        e.AddressPath.Address.HexWithPrefix(),
+		Path:           e.AddressPath.Path.String(),
+	})
+}
+
+// linkMissingTargetEntry
+
+type linkMissingTargetEntry struct {
+	AddressPath interpreter.AddressPath
+}
+
+var _ valueMigrationReportEntry = linkMissingTargetEntry{}
+
+func (e linkMissingTargetEntry) accountAddress() common.Address {
 	return e.AddressPath.Address
 }
 
-var _ valueMigrationReportEntry = capConsMissingTargetEntry{}
+var _ json.Marshaler = linkMissingTargetEntry{}
 
-func (e capConsMissingCapabilityIDEntry) accountAddress() common.Address {
-	return e.AccountAddress
+func (e linkMissingTargetEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		Path           string `json:"path"`
+	}{
+		Kind:           "link-missing-target",
+		AccountAddress: e.AddressPath.Address.HexWithPrefix(),
+		Path:           e.AddressPath.Path.String(),
+	})
 }
 
+// dictionaryKeyConflictEntry
+
 type dictionaryKeyConflictEntry struct {
-	Key string `json:"key"`
+	Key interpreter.StringStorageMapKey
+}
+
+var _ json.Marshaler = dictionaryKeyConflictEntry{}
+
+func (e dictionaryKeyConflictEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind string `json:"kind"`
+		Key  string `json:"key"`
+	}{
+		Kind: "dictionary-key-conflict",
+		Key:  string(e.Key),
+	})
 }

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -422,11 +422,11 @@ func checkReporters(
 		)
 	}
 
-	newCadenceValueMigrationReportEntry := func(
+	newCadenceValueMigrationEntry := func(
 		migration, key string,
 		domain common.PathDomain,
-	) cadenceValueMigrationReportEntry {
-		return cadenceValueMigrationReportEntry{
+	) cadenceValueMigrationEntry {
+		return cadenceValueMigrationEntry{
 			StorageMapKey: interpreter.StringStorageMapKey(key),
 			StorageKey: interpreter.NewStorageKey(
 				nil,
@@ -451,7 +451,7 @@ func checkReporters(
 		}
 	}
 
-	acctTypedDictKeyMigrationReportEntry := newCadenceValueMigrationReportEntry(
+	acctTypedDictKeyMigrationReportEntry := newCadenceValueMigrationEntry(
 		"StaticTypeMigration",
 		"dictionary_with_account_type_keys",
 		common.PathDomainStorage)
@@ -460,38 +460,38 @@ func checkReporters(
 	assert.ElementsMatch(
 		t,
 		[]valueMigrationReportEntry{
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"StringNormalizingMigration",
 				"string_value_1",
 				common.PathDomainStorage,
 			),
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"StaticTypeMigration",
 				"type_value",
 				common.PathDomainStorage,
 			),
 
 			// String keys in dictionary
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"StringNormalizingMigration",
 				"dictionary_with_string_keys",
 				common.PathDomainStorage,
 			),
 
 			// Restricted typed keys in dictionary
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"StaticTypeMigration",
 				"dictionary_with_restricted_typed_keys",
 				common.PathDomainStorage,
 			),
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"StaticTypeMigration",
 				"dictionary_with_restricted_typed_keys",
 				common.PathDomainStorage,
 			),
 
 			// Capabilities and links
-			cadenceValueMigrationReportEntry{
+			cadenceValueMigrationEntry{
 				StorageMapKey: interpreter.StringStorageMapKey("capability"),
 				StorageKey: interpreter.NewStorageKey(
 					nil,
@@ -500,7 +500,7 @@ func checkReporters(
 				),
 				Migration: "CapabilityValueMigration",
 			},
-			capConsPathCapabilityMigrationEntry{
+			capabilityMigrationEntry{
 				AccountAddress: address,
 				AddressPath: interpreter.AddressPath{
 					Address: address,
@@ -515,19 +515,19 @@ func checkReporters(
 					rResourceType,
 				),
 			},
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"EntitlementsMigration",
 				"capability",
 				common.PathDomainStorage,
 			),
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"EntitlementsMigration",
 				"linkR",
 				common.PathDomainPublic,
 			),
 
 			// untyped capability
-			capConsPathCapabilityMigrationEntry{
+			capabilityMigrationEntry{
 				AccountAddress: address,
 				AddressPath: interpreter.AddressPath{
 					Address: address,
@@ -542,7 +542,7 @@ func checkReporters(
 					rResourceType,
 				),
 			},
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"CapabilityValueMigration",
 				"untyped_capability",
 				common.PathDomainStorage,
@@ -560,24 +560,24 @@ func checkReporters(
 			acctTypedDictKeyMigrationReportEntry,
 
 			// Entitled typed keys in dictionary
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"EntitlementsMigration",
 				"dictionary_with_auth_reference_typed_key",
 				common.PathDomainStorage,
 			),
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"EntitlementsMigration",
 				"dictionary_with_reference_typed_key",
 				common.PathDomainStorage,
 			),
 
 			// Entitlements in links
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"EntitlementsMigration",
 				"flowTokenReceiver",
 				common.PathDomainPublic,
 			),
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"EntitlementsMigration",
 				"flowTokenBalance",
 				common.PathDomainPublic,
@@ -585,7 +585,7 @@ func checkReporters(
 
 			// Cap cons
 
-			capConsLinkMigrationEntry{
+			linkMigrationEntry{
 				AccountAddressPath: interpreter.AddressPath{
 					Address: address,
 					Path: interpreter.PathValue{
@@ -595,13 +595,13 @@ func checkReporters(
 				},
 				CapabilityID: 1,
 			},
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"LinkValueMigration",
 				"flowTokenReceiver",
 				common.PathDomainPublic,
 			),
 
-			capConsLinkMigrationEntry{
+			linkMigrationEntry{
 				AccountAddressPath: interpreter.AddressPath{
 					Address: address,
 					Path: interpreter.PathValue{
@@ -611,13 +611,13 @@ func checkReporters(
 				},
 				CapabilityID: 2,
 			},
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"LinkValueMigration",
 				"linkR",
 				common.PathDomainPublic,
 			),
 
-			capConsLinkMigrationEntry{
+			linkMigrationEntry{
 				AccountAddressPath: interpreter.AddressPath{
 					Address: address,
 					Path: interpreter.PathValue{
@@ -627,7 +627,7 @@ func checkReporters(
 				},
 				CapabilityID: 3,
 			},
-			newCadenceValueMigrationReportEntry(
+			newCadenceValueMigrationEntry(
 				"LinkValueMigration",
 				"flowTokenBalance",
 				common.PathDomainPublic,
@@ -844,7 +844,7 @@ func TestProgramParsingError(t *testing.T) {
 
 	var messages []string
 	for _, entry := range cadenceValueMigratorReporter.entries {
-		if errorEntry, isErrorEntry := entry.(cadenceValueMigrationErrorEntry); isErrorEntry {
+		if errorEntry, isErrorEntry := entry.(cadenceValueMigrationFailureEntry); isErrorEntry {
 			messages = append(messages, errorEntry.Message)
 			break
 		}
@@ -1391,4 +1391,209 @@ func TestCoreContractUsage(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
+}
+
+func TestDictionaryKeyConflictEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := dictionaryKeyConflictEntry{
+		Key: interpreter.StringStorageMapKey("test"),
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "dictionary-key-conflict",
+          "key": "test"
+        }`,
+		string(actual),
+	)
+}
+
+func TestLinkMissingTargetEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := linkMissingTargetEntry{
+		AddressPath: interpreter.AddressPath{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Path: interpreter.PathValue{
+				Domain:     common.PathDomainPublic,
+				Identifier: "test",
+			},
+		},
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "link-missing-target",
+          "account_address": "0x0000000000000001",
+          "path": "/public/test"
+        }`,
+		string(actual),
+	)
+}
+
+func TestCapabilityMissingCapabilityIDEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := capabilityMissingCapabilityIDEntry{
+		AccountAddress: common.MustBytesToAddress([]byte{0x2}),
+		AddressPath: interpreter.AddressPath{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Path: interpreter.PathValue{
+				Domain:     common.PathDomainPublic,
+				Identifier: "test",
+			},
+		},
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "capability-missing-capability-id",
+          "account_address": "0x0000000000000002",
+          "address": "0x0000000000000001",
+          "path": "/public/test"
+        }`,
+		string(actual),
+	)
+}
+
+func TestCapabilityMigrationEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := capabilityMigrationEntry{
+		AccountAddress: common.MustBytesToAddress([]byte{0x2}),
+		AddressPath: interpreter.AddressPath{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Path: interpreter.PathValue{
+				Domain:     common.PathDomainPublic,
+				Identifier: "test",
+			},
+		},
+		BorrowType: interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.UnauthorizedAccess,
+			interpreter.PrimitiveStaticTypeInt,
+		),
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "capability-migration-success",
+          "account_address": "0x0000000000000002",
+          "address": "0x0000000000000001",
+          "path": "/public/test",
+          "borrow_type": "&Int"
+        }`,
+		string(actual),
+	)
+}
+
+func TestLinkMigrationEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := linkMigrationEntry{
+		AccountAddressPath: interpreter.AddressPath{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Path: interpreter.PathValue{
+				Domain:     common.PathDomainPublic,
+				Identifier: "test",
+			},
+		},
+		CapabilityID: 42,
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "link-migration-success",
+          "account_address": "0x0000000000000001",
+          "path": "/public/test",
+          "capability_id": 42
+        }`,
+		string(actual),
+	)
+}
+
+func TestCadenceValueMigrationFailureEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := cadenceValueMigrationFailureEntry{
+		StorageKey: interpreter.StorageKey{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Key:     "storage",
+		},
+		StorageMapKey: interpreter.StringStorageMapKey("test"),
+		Migration:     "test-migration",
+		Message:       "unknown",
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "cadence-value-migration-failure",
+          "account_address": "0x0000000000000001",
+          "domain": "storage",
+          "key": "test",
+          "migration": "test-migration",
+          "message": "unknown"
+        }`,
+		string(actual),
+	)
+}
+
+func TestCadenceValueMigrationEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := cadenceValueMigrationEntry{
+		StorageKey: interpreter.StorageKey{
+			Address: common.MustBytesToAddress([]byte{0x1}),
+			Key:     "storage",
+		},
+		StorageMapKey: interpreter.StringStorageMapKey("test"),
+		Migration:     "test-migration",
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "cadence-value-migration-success",
+          "account_address": "0x0000000000000001",
+          "domain": "storage",
+          "key": "test",
+          "migration": "test-migration"
+        }`,
+		string(actual),
+	)
 }

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -483,10 +484,10 @@ func (m *StagedContractsMigration) MigrateAccount(
 					)
 			}
 
-			m.reporter.Write(contractUpdateFailed{
-				AccountAddressHex: address.HexWithPrefix(),
-				ContractName:      name,
-				Error:             errorDetails,
+			m.reporter.Write(contractUpdateFailureEntry{
+				AccountAddress: address,
+				ContractName:   name,
+				Error:          errorDetails,
 			})
 		} else {
 			// change contract code
@@ -495,9 +496,9 @@ func (m *StagedContractsMigration) MigrateAccount(
 				newCode,
 			)
 
-			m.reporter.Write(contractUpdateSuccessful{
-				AccountAddressHex: address.HexWithPrefix(),
-				ContractName:      name,
+			m.reporter.Write(contractUpdateEntry{
+				AccountAddress: address,
+				ContractName:   name,
 			})
 		}
 
@@ -642,13 +643,47 @@ func NewUserDefinedTypeChangeCheckerFunc(
 	}
 }
 
-type contractUpdateSuccessful struct {
-	AccountAddressHex string `json:"address"`
-	ContractName      string `json:"name"`
+// contractUpdateFailureEntry
+
+type contractUpdateEntry struct {
+	AccountAddress common.Address
+	ContractName   string
 }
 
-type contractUpdateFailed struct {
-	AccountAddressHex string `json:"address"`
-	ContractName      string `json:"name"`
-	Error             string `json:"error"`
+var _ json.Marshaler = contractUpdateEntry{}
+
+func (e contractUpdateEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		ContractName   string `json:"contract_name"`
+	}{
+		Kind:           "contract-update-success",
+		AccountAddress: e.AccountAddress.HexWithPrefix(),
+		ContractName:   e.ContractName,
+	})
+}
+
+// contractUpdateFailureEntry
+
+type contractUpdateFailureEntry struct {
+	AccountAddress common.Address
+	ContractName   string
+	Error          string
+}
+
+var _ json.Marshaler = contractUpdateFailureEntry{}
+
+func (e contractUpdateFailureEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind           string `json:"kind"`
+		AccountAddress string `json:"account_address"`
+		ContractName   string `json:"contract_name"`
+		Error          string `json:"error"`
+	}{
+		Kind:           "contract-update-failure",
+		AccountAddress: e.AccountAddress.HexWithPrefix(),
+		ContractName:   e.ContractName,
+		Error:          e.Error,
+	})
 }

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -295,19 +295,19 @@ func TestStagedContractsMigration(t *testing.T) {
 		require.Len(t, reportWriter.entries, 2)
 		assert.Equal(
 			t,
-			contractUpdateFailed{
-				AccountAddressHex: address1.HexWithPrefix(),
-				ContractName:      "A",
-				Error:             "error: expected token '{'\n --> f8d6e0586b0a20c7.A:1:46\n  |\n1 | access(all) contract A { access(all) struct C () }\n  |                                               ^\n",
+			contractUpdateFailureEntry{
+				AccountAddress: common.Address(address1),
+				ContractName:   "A",
+				Error:          "error: expected token '{'\n --> f8d6e0586b0a20c7.A:1:46\n  |\n1 | access(all) contract A { access(all) struct C () }\n  |                                               ^\n",
 			},
 			reportWriter.entries[0],
 		)
 
 		assert.Equal(
 			t,
-			contractUpdateSuccessful{
-				AccountAddressHex: address1.HexWithPrefix(),
-				ContractName:      "B",
+			contractUpdateEntry{
+				AccountAddress: common.Address(address1),
+				ContractName:   "B",
 			},
 			reportWriter.entries[1],
 		)
@@ -387,9 +387,9 @@ func TestStagedContractsMigration(t *testing.T) {
 		require.Len(t, reportWriter.entries, 1)
 		assert.Equal(
 			t,
-			contractUpdateSuccessful{
-				AccountAddressHex: address2.HexWithPrefix(),
-				ContractName:      "A",
+			contractUpdateEntry{
+				AccountAddress: common.Address(address2),
+				ContractName:   "A",
 			},
 			reportWriter.entries[0],
 		)
@@ -2018,4 +2018,52 @@ func TestStagedContractsUpdateValidationErrors(t *testing.T) {
 			jsonObject["message"],
 		)
 	})
+}
+
+func TestContractUpdateEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := contractUpdateEntry{
+		AccountAddress: common.MustBytesToAddress([]byte{0x1}),
+		ContractName:   "Test",
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "contract-update-success",
+          "account_address": "0x0000000000000001",
+          "contract_name": "Test"
+        }`,
+		string(actual),
+	)
+}
+
+func TestContractUpdateFailureEntry_MarshalJSON(t *testing.T) {
+
+	t.Parallel()
+
+	e := contractUpdateFailureEntry{
+		AccountAddress: common.MustBytesToAddress([]byte{0x1}),
+		ContractName:   "Test",
+		Error:          "unknown",
+	}
+
+	actual, err := e.MarshalJSON()
+	require.NoError(t, err)
+
+	require.JSONEq(t,
+		//language=JSON
+		`{
+          "kind": "contract-update-failure",
+          "account_address": "0x0000000000000001",
+          "contract_name": "Test",
+          "error": "unknown"
+        }`,
+		string(actual),
+	)
 }


### PR DESCRIPTION
Currently, the reporter entries lack detail and they are at times ambiguous.

Implement `json.Marshaler` and consistently format details and add a "kind" property to indicate the kind of reporting entry.