### PR TITLE
Log the checkpoint file when generating protocol snapshot

### DIFF
--- a/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/snapshot.go
@@ -70,13 +70,14 @@ func runSnapshot(*cobra.Command, []string) {
 		var protocolSnapshot protocol.Snapshot
 		var sealedHeight uint64
 		var sealedCommit flow.StateCommitment
+		var checkpointFile string
 		if flagCheckpointScanEndHeight < 0 {
 			// using default end height which is the last sealed height
-			protocolSnapshot, sealedHeight, sealedCommit, err = commonFuncs.GenerateProtocolSnapshotForCheckpoint(
+			protocolSnapshot, sealedHeight, sealedCommit, checkpointFile, err = commonFuncs.GenerateProtocolSnapshotForCheckpoint(
 				log.Logger, state, storages.Headers, storages.Seals, flagCheckpointDir, flagCheckpointScanStep)
 		} else {
 			// using customized end height
-			protocolSnapshot, sealedHeight, sealedCommit, err = commonFuncs.GenerateProtocolSnapshotForCheckpointWithHeights(
+			protocolSnapshot, sealedHeight, sealedCommit, checkpointFile, err = commonFuncs.GenerateProtocolSnapshotForCheckpointWithHeights(
 				log.Logger, state, storages.Headers, storages.Seals, flagCheckpointDir, flagCheckpointScanStep, uint64(flagCheckpointScanEndHeight))
 		}
 
@@ -85,7 +86,7 @@ func runSnapshot(*cobra.Command, []string) {
 		}
 
 		snapshot = protocolSnapshot
-		log.Info().Msgf("snapshot found, sealed height %v, commit %x", sealedHeight, sealedCommit)
+		log.Info().Msgf("snapshot found for checkpoint file %v, sealed height %v, commit %x", checkpointFile, sealedHeight, sealedCommit)
 	}
 
 	head, err := snapshot.Head()

--- a/cmd/util/common/checkpoint.go
+++ b/cmd/util/common/checkpoint.go
@@ -113,12 +113,12 @@ func GenerateProtocolSnapshotForCheckpoint(
 	seals storage.Seals,
 	checkpointDir string,
 	blocksToSkip uint,
-) (protocol.Snapshot, uint64, flow.StateCommitment, error) {
+) (protocol.Snapshot, uint64, flow.StateCommitment, string, error) {
 	// skip X blocks (i.e. 10) each time to find the block that produces the state commitment in the checkpoint file
 	// since a checkpoint file contains 500 tries, this allows us to find the block more efficiently
 	sealed, err := state.Sealed().Head()
 	if err != nil {
-		return nil, 0, flow.DummyStateCommitment, err
+		return nil, 0, flow.DummyStateCommitment, "", err
 	}
 	endHeight := sealed.Height
 
@@ -156,7 +156,7 @@ func GenerateProtocolSnapshotForCheckpointWithHeights(
 	checkpointDir string,
 	blocksToSkip uint,
 	endHeight uint64,
-) (protocol.Snapshot, uint64, flow.StateCommitment, error) {
+) (protocol.Snapshot, uint64, flow.StateCommitment, string, error) {
 	// Stop searching after 10,000 iterations or upon reaching the minimum height, whichever comes first.
 	startHeight := uint64(0)
 	// preventing startHeight from being negative
@@ -167,7 +167,7 @@ func GenerateProtocolSnapshotForCheckpointWithHeights(
 
 	checkpointFilePath, err := findLatestCheckpointFilePath(checkpointDir)
 	if err != nil {
-		return nil, 0, flow.DummyStateCommitment, fmt.Errorf("could not find latest checkpoint file in directory %v: %w", checkpointDir, err)
+		return nil, 0, flow.DummyStateCommitment, "", fmt.Errorf("could not find latest checkpoint file in directory %v: %w", checkpointDir, err)
 	}
 
 	log.Info().
@@ -178,7 +178,7 @@ func GenerateProtocolSnapshotForCheckpointWithHeights(
 	// find the height of the finalized block that produces the state commitment contained in the checkpoint file
 	sealedHeight, commit, finalizedHeight, err := FindHeightsByCheckpoints(logger, headers, seals, checkpointFilePath, blocksToSkip, startHeight, endHeight)
 	if err != nil {
-		return nil, 0, flow.DummyStateCommitment, fmt.Errorf("could not find sealed height in range [%v:%v] (blocksToSkip: %v) by checkpoints: %w",
+		return nil, 0, flow.DummyStateCommitment, "", fmt.Errorf("could not find sealed height in range [%v:%v] (blocksToSkip: %v) by checkpoints: %w",
 			startHeight, endHeight, blocksToSkip,
 			err)
 	}
@@ -186,10 +186,10 @@ func GenerateProtocolSnapshotForCheckpointWithHeights(
 	snapshot := state.AtHeight(finalizedHeight)
 	validSnapshot, err := snapshots.GetDynamicBootstrapSnapshot(state, snapshot)
 	if err != nil {
-		return nil, 0, flow.DummyStateCommitment, fmt.Errorf("could not get dynamic bootstrap snapshot: %w", err)
+		return nil, 0, flow.DummyStateCommitment, "", fmt.Errorf("could not get dynamic bootstrap snapshot: %w", err)
 	}
 
-	return validSnapshot, sealedHeight, commit, nil
+	return validSnapshot, sealedHeight, commit, checkpointFilePath, nil
 }
 
 // hashesToCommits converts a list of ledger.RootHash to a list of flow.StateCommitment


### PR DESCRIPTION
This PR adds logs/return the checkpoint file to the admin tool when generating protocol snapshot from latest checkpoint. This allows us to know which checkpoint file is for the generated protocol snapshot file