### PR TITLE
adding checks when a block has no events

### DIFF
--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -270,10 +270,19 @@ func (h *handler) GetEventsForBlockIDs(
 			return nil, status.Errorf(codes.Internal, "state commitment for block ID %s could not be retrieved", bID)
 		}
 
-		// lookup events
-		blockEvents, err := h.events.ByBlockIDEventType(bID, flow.EventType(eType))
+		// lookup all events for the block
+		blockAllEvents, err := h.events.ByBlockID(bID)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get events for block: %v", err)
+		}
+
+		// filter events by type
+		eventType := flow.EventType(eType)
+		blockEvents := make([]flow.Event, 0, len(blockAllEvents))
+		for _, event := range blockAllEvents {
+			if event.Type == eventType {
+				blockEvents = append(blockEvents, event)
+			}
 		}
 
 		result, err := h.eventResult(bID, blockEvents)
@@ -282,6 +291,22 @@ func (h *handler) GetEventsForBlockIDs(
 		}
 		results[i] = result
 
+		// additional check that when there is no event in the block, double check if the execution
+		// result has no events as well, otherwise return an error.
+		// we check the execution result has no event by checking if each chunk's EventCollection is
+		// the default hash for empty event collection.
+		if len(blockEvents) == 0 {
+			executionResult, err := h.exeResults.ByBlockID(bID)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to get execution result for block: %v", err)
+			}
+
+			for _, chunk := range executionResult.Chunks {
+				if chunk.EventCollection != flow.EmptyEventCollection {
+					return nil, status.Errorf(codes.Internal, "events not found for block %s, but chunk %d has events", bID, chunk.Index)
+				}
+			}
+		}
 	}
 
 	return &execution.GetEventsForBlockIDsResponse{

--- a/engine/execution/rpc/engine.go
+++ b/engine/execution/rpc/engine.go
@@ -819,7 +819,8 @@ func (h *handler) getEventsByBlockID(blockID flow.Identifier) ([]flow.Event, err
 		}
 
 		for _, chunk := range executionResult.Chunks {
-			if chunk.EventCollection != flow.EmptyEventCollectionID {
+			if chunk.EventCollection != flow.EmptyEventCollectionID &&
+				executionResult.PreviousResultID != flow.ZeroID { // skip the root blcok
 				return nil, status.Errorf(codes.Internal, "events not found for block %s, but chunk %d has events", blockID, chunk.Index)
 			}
 		}

--- a/engine/execution/rpc/engine_test.go
+++ b/engine/execution/rpc/engine_test.go
@@ -142,7 +142,7 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 		suite.commits.On("ByBlockID", id).Return(nil, nil).Once()
 
 		// expect one call to lookup events for each block ID
-		suite.events.On("ByBlockIDEventType", id, flow.EventAccountCreated).Return(eventsForBlock, nil).Once()
+		suite.events.On("ByBlockID", id).Return(eventsForBlock, nil).Once()
 
 		// expect one call to lookup each block
 		suite.headers.On("ByBlockID", id).Return(block.Header, nil).Once()

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -6,13 +6,13 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-var EmptyEventCollection Identifier
+var EmptyEventCollectionID Identifier
 
 func init() {
 	// Convert hexadecimal string to a byte slice.
 	var err error
 	emptyEventCollectionHex := "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
-	EmptyEventCollection, err = HexStringToIdentifier(emptyEventCollectionHex)
+	EmptyEventCollectionID, err = HexStringToIdentifier(emptyEventCollectionHex)
 	if err != nil {
 		log.Fatalf("Failed to decode hex: %v", err)
 	}

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -1,8 +1,22 @@
 package flow
 
 import (
+	"log"
+
 	"github.com/ipfs/go-cid"
 )
+
+var EmptyEventCollection Identifier
+
+func init() {
+	// Convert hexadecimal string to a byte slice.
+	var err error
+	emptyEventCollectionHex := "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+	EmptyEventCollection, err = HexStringToIdentifier(emptyEventCollectionHex)
+	if err != nil {
+		log.Fatalf("Failed to decode hex: %v", err)
+	}
+}
 
 type ChunkBody struct {
 	CollectionIndex uint

--- a/model/flow/event_test.go
+++ b/model/flow/event_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/encoding/rlp"
 	"github.com/onflow/flow-go/model/fingerprint"
@@ -117,4 +118,10 @@ func TestEventsMerkleRootHash(t *testing.T) {
 	ABHash, err := flow.EventsMerkleRootHash([]flow.Event{eventA, eventB})
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRootHashHex, ABHash.String())
+}
+
+func TestEmptyEventsMerkleRootHash(t *testing.T) {
+	actualHash, err := flow.EventsMerkleRootHash([]flow.Event{})
+	require.NoError(t, err)
+	require.Equal(t, flow.EmptyEventCollection, actualHash)
 }

--- a/model/flow/event_test.go
+++ b/model/flow/event_test.go
@@ -123,5 +123,5 @@ func TestEventsMerkleRootHash(t *testing.T) {
 func TestEmptyEventsMerkleRootHash(t *testing.T) {
 	actualHash, err := flow.EventsMerkleRootHash([]flow.Event{})
 	require.NoError(t, err)
-	require.Equal(t, flow.EmptyEventCollection, actualHash)
+	require.Equal(t, flow.EmptyEventCollectionID, actualHash)
 }


### PR DESCRIPTION
Close https://github.com/dapperlabs/flow-go/issues/6959#issuecomment-2071211198

This PR adds the check that when there is no event for a block check if it's consistent with the event hash in the execution result, which should be the default hash for an empty event collection.