### PR TITLE
[CI] Add timeout to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,9 @@ jobs:
       #env:
       #  RACE_DETECTOR: 1
     - name: Upload coverage report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      timeout-minutes: 1
+      continue-on-error: true
       with:
         file: ./coverage.txt
         flags: unittests
@@ -193,7 +195,9 @@ jobs:
         #env:
         #  RACE_DETECTOR: 1
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        timeout-minutes: 1
+        continue-on-error: true
         with:
           file: ./coverage.txt
           flags: unittests
@@ -270,7 +274,9 @@ jobs:
         #env:
         #  RACE_DETECTOR: 1
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        timeout-minutes: 1
+        continue-on-error: true
         with:
           file: ./coverage.txt
           flags: unittests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
         file: ./coverage.txt
         flags: unittests
         name: codecov-umbrella
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   unit-test-insecure:
     name: Unit Tests Insecure (${{ matrix.targets.name }})
@@ -202,6 +203,7 @@ jobs:
           file: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   docker-build:
     name: Docker Build
@@ -281,6 +283,7 @@ jobs:
           file: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-test:
     name: Integration Tests


### PR DESCRIPTION
Recently, we've noticed some codecov jobs taking hours to complete. This PR upgrades the action to the latest version and adds a timeout. If the step fails due to a timeout, the job will continue without error