### PR TITLE
[EFM Recovery] Dynamic Protocol State injects `EpochExtension`s

### DIFF
--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -110,20 +110,6 @@ func (c *EpochStateContainer) Copy() *EpochStateContainer {
 	}
 }
 
-// ExtendEpoch appends an epoch extension to the EpochStateContainer.
-// It is expected that the epoch extension is contiguous with the last extension, otherwise an exception is returned.
-// No errors are expected during normal operation.
-func (c *EpochStateContainer) ExtendEpoch(epochExtension EpochExtension) error {
-	if len(c.EpochExtensions) > 0 {
-		lastExtension := c.EpochExtensions[len(c.EpochExtensions)-1]
-		if lastExtension.FinalView+1 != epochExtension.FirstView {
-			return fmt.Errorf("epoch extension is not contiguous with the last extension")
-		}
-	}
-	c.EpochExtensions = append(c.EpochExtensions, epochExtension)
-	return nil
-}
-
 // RichProtocolStateEntry is a ProtocolStateEntry which has additional fields that are cached
 // from storage layer for convenience.
 // Using this structure instead of ProtocolStateEntry allows us to avoid querying

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -109,6 +109,20 @@ func (c *EpochStateContainer) Copy() *EpochStateContainer {
 	}
 }
 
+// ExtendEpoch appends an epoch extension to the EpochStateContainer.
+// It is expected that the epoch extension is contiguous with the last extension, otherwise an exception is returned.
+// No errors are expected during normal operation.
+func (c *EpochStateContainer) ExtendEpoch(epochExtension EpochExtension) error {
+	if len(c.EpochExtensions) > 0 {
+		lastExtension := c.EpochExtensions[len(c.EpochExtensions)-1]
+		if lastExtension.FinalView+1 != epochExtension.FirstView {
+			return fmt.Errorf("epoch extension is not contiguous with the last extension")
+		}
+	}
+	c.EpochExtensions = append(c.EpochExtensions, epochExtension)
+	return nil
+}
+
 // RichProtocolStateEntry is a ProtocolStateEntry which has additional fields that are cached
 // from storage layer for convenience.
 // Using this structure instead of ProtocolStateEntry allows us to avoid querying
@@ -296,6 +310,9 @@ func (e *RichProtocolStateEntry) Copy() *RichProtocolStateEntry {
 	}
 }
 
+// CurrentEpochFinalView returns the final view of the current epoch taking to account possible epoch extensions.
+// If there are no epoch extensions, the final view is the final view of the current epoch setup,
+// otherwise it is the final view of the last epoch extension.
 func (e *RichProtocolStateEntry) CurrentEpochFinalView() uint64 {
 	if len(e.CurrentEpoch.EpochExtensions) > 0 {
 		return e.CurrentEpoch.EpochExtensions[len(e.CurrentEpoch.EpochExtensions)-1].FinalView

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -297,7 +297,7 @@ func (e *RichProtocolStateEntry) Copy() *RichProtocolStateEntry {
 }
 
 func (e *RichProtocolStateEntry) CurrentEpochFinalView() uint64 {
-	if len(e.CurrentEpoch.EpochExtensions) > 1 {
+	if len(e.CurrentEpoch.EpochExtensions) > 0 {
 		return e.CurrentEpoch.EpochExtensions[len(e.CurrentEpoch.EpochExtensions)-1].FinalView
 	}
 	return e.CurrentEpochSetup.FinalView

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -61,15 +61,16 @@ type EpochStateContainer struct {
 	// nodes are _not_ part of `Identities`.
 	ActiveIdentities DynamicIdentityEntryList
 
-	// EpochExtensions represents extensions to the last successful epoch in EFM. In the happy path it is nil.
-	// Epochs in which EFM is triggered will have at least one EpochExtension.
-	// Extensions is an ordered list, such that for each consecutive pair of
-	// EpochExtensions e1, e2, e1.FinalView+1 = e2.FirstView.
+	// EpochExtensions contains potential EFM-extensions of this epoch. In the happy path
+	// it is nil or empty. An Epoch in which Epoch-Fallback-Mode [EFM] is triggered, will
+	// have at least one extension. By convention, the initial extension must satisfy
+	//   EpochSetup.FinalView + 1 = EpochExtensions[0].FirstView
+	// and each consecutive pair of slice elements must obey
+	//   EpochExtensions[i].FinalView+1 = EpochExtensions[i+1].FirstView
 	EpochExtensions []EpochExtension
 }
 
-// EpochExtension represents a range of views, which contiguously extends the
-// current epoch E.
+// EpochExtension represents a range of views, which contiguously extends this epoch.
 type EpochExtension struct {
 	FirstView     uint64
 	FinalView     uint64
@@ -310,7 +311,7 @@ func (e *RichProtocolStateEntry) Copy() *RichProtocolStateEntry {
 	}
 }
 
-// CurrentEpochFinalView returns the final view of the current epoch taking to account possible epoch extensions.
+// CurrentEpochFinalView returns the final view of the current epoch, taking into account possible epoch extensions.
 // If there are no epoch extensions, the final view is the final view of the current epoch setup,
 // otherwise it is the final view of the last epoch extension.
 func (e *RichProtocolStateEntry) CurrentEpochFinalView() uint64 {

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -2,8 +2,8 @@ package flow
 
 import (
 	"fmt"
-	clone "github.com/huandu/go-clone/generic"
 
+	clone "github.com/huandu/go-clone/generic"
 	"golang.org/x/exp/slices"
 )
 

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -1976,8 +1976,11 @@ func TestEmergencyEpochFallback(t *testing.T) {
 			assertEpochEmergencyFallbackTriggered(t, state, true) // triggered after finalization
 
 			// block 5 is the first block past the current epoch boundary
-			block4 := unittest.BlockWithParentProtocolState(block3)
+			block4 := unittest.BlockWithParentFixture(block3.Header)
 			block4.Header.View = epoch1Setup.FinalView + 1
+			block4.SetPayload(flow.Payload{
+				ProtocolStateID: calculateExpectedStateId(t, mutableState)(block4.Header, nil),
+			})
 			err = state.Extend(context.Background(), block4)
 			require.NoError(t, err)
 			err = state.Finalize(context.Background(), block4.ID())

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -1975,7 +1975,7 @@ func TestEmergencyEpochFallback(t *testing.T) {
 			require.NoError(t, err)
 			assertEpochEmergencyFallbackTriggered(t, state, true) // triggered after finalization
 
-			// block 5 is the first block past the current epoch boundary
+			// block 4 is the first block past the current epoch boundary
 			block4 := unittest.BlockWithParentFixture(block3.Header)
 			block4.Header.View = epoch1Setup.FinalView + 1
 			block4.SetPayload(flow.Payload{

--- a/state/protocol/protocol_state/epochs/factory.go
+++ b/state/protocol/protocol_state/epochs/factory.go
@@ -47,7 +47,7 @@ func (f *EpochStateMachineFactory) Create(candidateView uint64, parentID flow.Id
 			return NewHappyPathStateMachine(candidateView, parentState)
 		},
 		func(candidateView uint64, parentState *flow.RichProtocolStateEntry) (StateMachine, error) {
-			return NewFallbackStateMachine(candidateView, parentState), nil
+			return NewFallbackStateMachine(f.params, candidateView, parentState), nil
 		},
 	)
 }

--- a/state/protocol/protocol_state/epochs/factory.go
+++ b/state/protocol/protocol_state/epochs/factory.go
@@ -47,7 +47,7 @@ func (f *EpochStateMachineFactory) Create(candidateView uint64, parentID flow.Id
 			return NewHappyPathStateMachine(candidateView, parentState)
 		},
 		func(candidateView uint64, parentState *flow.RichProtocolStateEntry) (StateMachine, error) {
-			return NewFallbackStateMachine(f.params, candidateView, parentState), nil
+			return NewFallbackStateMachine(f.params, candidateView, parentState)
 		},
 	)
 }

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -8,7 +8,7 @@ import (
 )
 
 // DefaultEpochExtensionLength is a default length of epoch extension.
-// TODO: replace this with value from KV store or protocol.GlobalParams
+// TODO(efm-recovery): replace this with value from KV store or protocol.GlobalParams
 const DefaultEpochExtensionLength = 1_000
 
 // FallbackStateMachine is a special structure that encapsulates logic for processing service events

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -26,8 +26,9 @@ var _ StateMachine = (*FallbackStateMachine)(nil)
 func NewFallbackStateMachine(params protocol.GlobalParams, view uint64, parentState *flow.RichProtocolStateEntry) *FallbackStateMachine {
 	state := parentState.ProtocolStateEntry.Copy()
 	nextEpochCommitted := state.EpochPhase() == flow.EpochPhaseCommitted
+	// we are entering fallback mode, this logic needs to be executed only once
 	if !state.InvalidEpochTransitionAttempted {
-		// we are entering fallback mode, this logic needs to be executed only once
+		// the next epoch has not been committed, but possibly setup, make sure it is cleared
 		if !nextEpochCommitted {
 			state.NextEpoch = nil
 		}

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -9,7 +9,7 @@ import (
 
 // DefaultEpochExtensionLength is a default length of epoch extension.
 // TODO(efm-recovery): replace this with value from KV store or protocol.GlobalParams
-const DefaultEpochExtensionLength = 1_000
+const DefaultEpochExtensionLength = 100_000
 
 // FallbackStateMachine is a special structure that encapsulates logic for processing service events
 // when protocol is in epoch fallback mode. The FallbackStateMachine ignores EpochSetup and EpochCommit

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -2,6 +2,7 @@ package epochs
 
 import (
 	"fmt"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
 )

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -7,9 +7,9 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 )
 
-// DefaultEpochExtensionLength is a default length of epoch extension.
+// DefaultEpochExtensionViewCount is a default length of epoch extension in views, approximately 1 day.
 // TODO(efm-recovery): replace this with value from KV store or protocol.GlobalParams
-const DefaultEpochExtensionLength = 100_000
+const DefaultEpochExtensionViewCount = 100_000
 
 // FallbackStateMachine is a special structure that encapsulates logic for processing service events
 // when protocol is in epoch fallback mode. The FallbackStateMachine ignores EpochSetup and EpochCommit
@@ -43,8 +43,8 @@ func NewFallbackStateMachine(params protocol.GlobalParams, view uint64, parentSt
 		// prepare a new extension for the current epoch.
 		err := state.CurrentEpoch.ExtendEpoch(flow.EpochExtension{
 			FirstView:     parentState.CurrentEpochFinalView() + 1,
-			FinalView:     parentState.CurrentEpochFinalView() + 1 + DefaultEpochExtensionLength, // TODO: replace with EpochExtensionLength
-			TargetEndTime: 0,                                                                     // TODO: calculate and set target end time
+			FinalView:     parentState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount, // TODO: replace with EpochExtensionLength
+			TargetEndTime: 0,                                                                    // TODO: calculate and set target end time
 		})
 		if err != nil {
 			return nil, fmt.Errorf("could not produce a valid epoch extension: %w", err)

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -97,7 +97,7 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 		require.Len(s.T(), updatedState.CurrentEpoch.EpochExtensions, 1)
 		require.Equal(s.T(), flow.EpochExtension{
 			FirstView:     parentProtocolState.CurrentEpochFinalView() + 1,
-			FinalView:     parentProtocolState.CurrentEpochFinalView() + 1 + DefaultEpochExtensionLength,
+			FinalView:     parentProtocolState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount,
 			TargetEndTime: 0,
 		}, updatedState.CurrentEpoch.EpochExtensions[0])
 	})
@@ -126,7 +126,7 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 		require.Len(s.T(), updatedState.CurrentEpoch.EpochExtensions, 1)
 		require.Equal(s.T(), flow.EpochExtension{
 			FirstView:     parentProtocolState.CurrentEpochFinalView() + 1,
-			FinalView:     parentProtocolState.CurrentEpochFinalView() + 1 + DefaultEpochExtensionLength,
+			FinalView:     parentProtocolState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount,
 			TargetEndTime: 0,
 		}, updatedState.CurrentEpoch.EpochExtensions[0])
 		require.Nil(s.T(), updatedState.NextEpoch, "Next epoch has to be nil even if it was previously setup")
@@ -169,11 +169,11 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 	parentProtocolState.NextEpoch.CommitID = flow.ZeroID
 	parentProtocolState.NextEpochCommit = nil
 
-	// finalBlockView is the cumulative number of views that will be produced in the current epoch and its extensions
-	finalBlockView := DefaultEpochExtensionLength +
+	// views2process is the cumulative number of views that will be produced in the current epoch and its extensions
+	views2process := DefaultEpochExtensionViewCount +
 		(parentProtocolState.CurrentEpochSetup.FinalView - parentProtocolState.CurrentEpochSetup.FirstView) + 1
 	candidateView := parentProtocolState.CurrentEpochSetup.FirstView + 1
-	for i := uint64(0); i < finalBlockView; i++ {
+	for i := uint64(0); i < views2process; i++ {
 		stateMachine, err := NewFallbackStateMachine(s.params, candidateView, parentProtocolState.Copy())
 		require.NoError(s.T(), err)
 		updatedState, _, _ := stateMachine.Build()
@@ -196,13 +196,13 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 	require.Len(s.T(), parentProtocolState.CurrentEpoch.EpochExtensions, 2)
 	require.Equal(s.T(), flow.EpochExtension{
 		FirstView:     parentProtocolState.CurrentEpochSetup.FinalView + 1,
-		FinalView:     parentProtocolState.CurrentEpochSetup.FinalView + 1 + DefaultEpochExtensionLength,
+		FinalView:     parentProtocolState.CurrentEpochSetup.FinalView + DefaultEpochExtensionViewCount,
 		TargetEndTime: 0,
 	}, parentProtocolState.CurrentEpoch.EpochExtensions[0])
 
 	require.Equal(s.T(), flow.EpochExtension{
 		FirstView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + 1,
-		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + 1 + DefaultEpochExtensionLength,
+		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + DefaultEpochExtensionViewCount,
 		TargetEndTime: 0,
 	}, parentProtocolState.CurrentEpoch.EpochExtensions[1])
 
@@ -222,13 +222,13 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 	parentProtocolState.InvalidEpochTransitionAttempted = false
 	unittest.WithNextEpochProtocolState()(parentProtocolState)
 
-	// finalBlockView is the cumulative number of views that will be produced in the current epoch and its extensions
-	finalBlockView := DefaultEpochExtensionLength +
+	// views2process is the cumulative number of views that will be produced in the current epoch and its extensions
+	views2process := DefaultEpochExtensionViewCount +
 		(parentProtocolState.CurrentEpochSetup.FinalView - parentProtocolState.CurrentEpochSetup.FirstView) +
 		(parentProtocolState.NextEpochSetup.FinalView - parentProtocolState.NextEpochSetup.FirstView) +
 		1
 	candidateView := parentProtocolState.CurrentEpochSetup.FirstView + 1
-	for i := uint64(0); i < finalBlockView; i++ {
+	for i := uint64(0); i < views2process; i++ {
 		stateMachine, err := NewFallbackStateMachine(s.params, candidateView, parentProtocolState.Copy())
 		require.NoError(s.T(), err)
 
@@ -256,19 +256,19 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 	require.Len(s.T(), parentProtocolState.CurrentEpoch.EpochExtensions, 3)
 	require.Equal(s.T(), flow.EpochExtension{
 		FirstView:     parentProtocolState.CurrentEpochSetup.FinalView + 1,
-		FinalView:     parentProtocolState.CurrentEpochSetup.FinalView + 1 + DefaultEpochExtensionLength,
+		FinalView:     parentProtocolState.CurrentEpochSetup.FinalView + 1 + DefaultEpochExtensionViewCount,
 		TargetEndTime: 0,
 	}, parentProtocolState.CurrentEpoch.EpochExtensions[0])
 
 	require.Equal(s.T(), flow.EpochExtension{
 		FirstView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + 1,
-		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + 1 + DefaultEpochExtensionLength,
+		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + 1 + DefaultEpochExtensionViewCount,
 		TargetEndTime: 0,
 	}, parentProtocolState.CurrentEpoch.EpochExtensions[1])
 
 	require.Equal(s.T(), flow.EpochExtension{
 		FirstView:     parentProtocolState.CurrentEpoch.EpochExtensions[1].FinalView + 1,
-		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[1].FinalView + 1 + DefaultEpochExtensionLength,
+		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[1].FinalView + 1 + DefaultEpochExtensionViewCount,
 		TargetEndTime: 0,
 	}, parentProtocolState.CurrentEpoch.EpochExtensions[2])
 

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -1,6 +1,8 @@
 package epochs
 
 import (
+	"github.com/onflow/flow-go/model/flow"
+	mockstate "github.com/onflow/flow-go/state/protocol/mock"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,13 +18,19 @@ func TestEpochFallbackStateMachine(t *testing.T) {
 // ProtocolStateMachineSuite is a dedicated test suite for testing happy path state machine.
 type EpochFallbackStateMachineSuite struct {
 	BaseStateMachineSuite
+	params *mockstate.GlobalParams
+
 	stateMachine *FallbackStateMachine
 }
 
 func (s *EpochFallbackStateMachineSuite) SetupTest() {
 	s.BaseStateMachineSuite.SetupTest()
+
+	s.params = mockstate.NewGlobalParams(s.T())
+	s.params.On("EpochCommitSafetyThreshold").Return(uint64(200))
 	s.parentProtocolState.InvalidEpochTransitionAttempted = true
-	s.stateMachine = NewFallbackStateMachine(s.candidate.View, s.parentProtocolState.Copy())
+
+	s.stateMachine = NewFallbackStateMachine(s.params, s.candidate.View, s.parentProtocolState.Copy())
 }
 
 // ProcessEpochSetupIsNoop ensures that processing epoch setup event is noop.
@@ -63,15 +71,76 @@ func (s *EpochFallbackStateMachineSuite) TestTransitionToNextEpoch() {
 
 // TestNewEpochFallbackStateMachine tests that creating epoch fallback state machine sets
 // `InvalidEpochTransitionAttempted` to true to record that we have entered epoch fallback mode[EFM].
+// It tests scenarios where the EFM is entered in different phases of the epoch.
+// It is expected that the state machine will inject a new epoch extension for the current epoch.
 func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
-	s.parentProtocolState.InvalidEpochTransitionAttempted = false
-	s.stateMachine = NewFallbackStateMachine(s.candidate.View, s.parentProtocolState.Copy())
-	require.Equal(s.T(), s.parentProtocolState.ID(), s.stateMachine.ParentState().ID())
-	require.Equal(s.T(), s.candidate.View, s.stateMachine.View())
+	parentProtocolState := s.parentProtocolState.Copy()
+	parentProtocolState.InvalidEpochTransitionAttempted = false
 
-	updatedState, stateID, hasChanges := s.stateMachine.Build()
-	require.True(s.T(), hasChanges, "InvalidEpochTransitionAttempted has to be updated")
-	require.True(s.T(), updatedState.InvalidEpochTransitionAttempted, "InvalidEpochTransitionAttempted has to be set")
-	require.Equal(s.T(), updatedState.ID(), stateID)
-	require.NotEqual(s.T(), s.parentProtocolState.ID(), stateID)
+	candidateView := parentProtocolState.CurrentEpochSetup.FinalView - s.params.EpochCommitSafetyThreshold() + 1
+	s.Run("staking-phase", func() {
+
+		stateMachine := NewFallbackStateMachine(s.params, candidateView, parentProtocolState.Copy())
+		require.Equal(s.T(), parentProtocolState.ID(), stateMachine.ParentState().ID())
+		require.Equal(s.T(), candidateView, stateMachine.View())
+
+		updatedState, stateID, hasChanges := stateMachine.Build()
+		require.True(s.T(), hasChanges, "InvalidEpochTransitionAttempted has to be updated")
+		require.True(s.T(), updatedState.InvalidEpochTransitionAttempted, "InvalidEpochTransitionAttempted has to be set")
+		require.Equal(s.T(), updatedState.ID(), stateID)
+		require.NotEqual(s.T(), parentProtocolState.ID(), stateID)
+
+		require.Len(s.T(), updatedState.CurrentEpoch.EpochExtensions, 1)
+		require.Equal(s.T(), flow.EpochExtension{
+			FirstView:     parentProtocolState.CurrentEpochFinalView() + 1,
+			FinalView:     parentProtocolState.CurrentEpochFinalView() + 1 + DefaultEpochExtensionLength,
+			TargetEndTime: 0,
+		}, updatedState.CurrentEpoch.EpochExtensions[0])
+	})
+	s.Run("setup-phase", func() {
+		parentProtocolState := parentProtocolState.Copy()
+		// setup next epoch but without commit event
+		unittest.WithNextEpochProtocolState()(parentProtocolState)
+		parentProtocolState.NextEpoch.CommitID = flow.ZeroID
+		parentProtocolState.NextEpochCommit = nil
+
+		stateMachine := NewFallbackStateMachine(s.params, candidateView, parentProtocolState)
+		require.Equal(s.T(), parentProtocolState.ID(), stateMachine.ParentState().ID())
+		require.Equal(s.T(), candidateView, stateMachine.View())
+
+		updatedState, stateID, hasChanges := stateMachine.Build()
+		require.True(s.T(), hasChanges, "InvalidEpochTransitionAttempted has to be updated")
+		require.True(s.T(), updatedState.InvalidEpochTransitionAttempted, "InvalidEpochTransitionAttempted has to be set")
+		require.Equal(s.T(), updatedState.ID(), stateID)
+		require.NotEqual(s.T(), parentProtocolState.ID(), stateID)
+
+		require.Len(s.T(), updatedState.CurrentEpoch.EpochExtensions, 1)
+		require.Equal(s.T(), flow.EpochExtension{
+			FirstView:     parentProtocolState.CurrentEpochFinalView() + 1,
+			FinalView:     parentProtocolState.CurrentEpochFinalView() + 1 + DefaultEpochExtensionLength,
+			TargetEndTime: 0,
+		}, updatedState.CurrentEpoch.EpochExtensions[0])
+		require.Nil(s.T(), updatedState.NextEpoch, "Next epoch has to be nil even if it was previously setup")
+	})
+	s.Run("commit-phase", func() {
+		parentProtocolState := parentProtocolState.Copy()
+		// setup next committed epoch
+		unittest.WithNextEpochProtocolState()(parentProtocolState)
+
+		// if the next epoch has been committed, the extension shouldn't be added to the current epoch
+		// instead it will be added to the next epoch when **next** epoch reaches its safety threshold.
+
+		stateMachine := NewFallbackStateMachine(s.params, candidateView, parentProtocolState)
+		require.Equal(s.T(), parentProtocolState.ID(), stateMachine.ParentState().ID())
+		require.Equal(s.T(), candidateView, stateMachine.View())
+
+		updatedState, stateID, hasChanges := stateMachine.Build()
+		require.True(s.T(), hasChanges, "InvalidEpochTransitionAttempted has to be updated")
+		require.True(s.T(), updatedState.InvalidEpochTransitionAttempted, "InvalidEpochTransitionAttempted has to be set")
+		require.Equal(s.T(), updatedState.ID(), stateID)
+		require.NotEqual(s.T(), parentProtocolState.ID(), stateID)
+
+		require.Empty(s.T(), updatedState.CurrentEpoch.EpochExtensions,
+			"No extension should be added to the current epoch since next epoch has benn committed")
+	})
 }

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -144,3 +144,54 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 			"No extension should be added to the current epoch since next epoch has benn committed")
 	})
 }
+
+// TestEpochFallbackStateMachineInjectsMultipleExtensions tests that the state machine injects multiple extensions
+// as it reaches the safety threshold of the current epoch and the extensions themselves.
+// In this test we are simulating the scenario where the current epoch enters fallback mode when the next epoch has not been committed yet.
+func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMultipleExtensions() {
+	parentProtocolState := s.parentProtocolState.Copy()
+	parentProtocolState.InvalidEpochTransitionAttempted = false
+
+	// finalBlockView is the cumulative number of views that will be produced in the current epoch and its extensions
+	finalBlockView := DefaultEpochExtensionLength*2 +
+		(parentProtocolState.CurrentEpochSetup.FinalView - parentProtocolState.CurrentEpochSetup.FirstView) + 1
+	candidateView := parentProtocolState.CurrentEpochSetup.FirstView + 1
+	for i := uint64(0); i < finalBlockView; i++ {
+		stateMachine := NewFallbackStateMachine(s.params, candidateView, parentProtocolState.Copy())
+		updatedState, _, _ := stateMachine.Build()
+
+		var err error
+		parentProtocolState, err = flow.NewRichProtocolStateEntry(updatedState,
+			parentProtocolState.PreviousEpochSetup,
+			parentProtocolState.PreviousEpochCommit,
+			parentProtocolState.CurrentEpochSetup,
+			parentProtocolState.CurrentEpochCommit,
+			parentProtocolState.NextEpochSetup,
+			parentProtocolState.NextEpochCommit)
+
+		require.NoError(s.T(), err)
+		candidateView++
+	}
+
+	// assert the validity of extensions after producing multiple extensions
+	// we expect 3 extensions to be added to the current epoch
+	// 1 after we reach the commit threshold of the epoch and two more after reaching the threshold of the extensions themselves
+	require.Len(s.T(), parentProtocolState.CurrentEpoch.EpochExtensions, 3)
+	require.Equal(s.T(), flow.EpochExtension{
+		FirstView:     parentProtocolState.CurrentEpochSetup.FinalView + 1,
+		FinalView:     parentProtocolState.CurrentEpochSetup.FinalView + 1 + DefaultEpochExtensionLength,
+		TargetEndTime: 0,
+	}, parentProtocolState.CurrentEpoch.EpochExtensions[0])
+
+	require.Equal(s.T(), flow.EpochExtension{
+		FirstView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + 1,
+		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[0].FinalView + 1 + DefaultEpochExtensionLength,
+		TargetEndTime: 0,
+	}, parentProtocolState.CurrentEpoch.EpochExtensions[1])
+
+	require.Equal(s.T(), flow.EpochExtension{
+		FirstView:     parentProtocolState.CurrentEpoch.EpochExtensions[1].FinalView + 1,
+		FinalView:     parentProtocolState.CurrentEpoch.EpochExtensions[1].FinalView + 1 + DefaultEpochExtensionLength,
+		TargetEndTime: 0,
+	}, parentProtocolState.CurrentEpoch.EpochExtensions[2])
+}

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -1,13 +1,13 @@
 package epochs
 
 import (
-	"github.com/onflow/flow-go/model/flow"
-	mockstate "github.com/onflow/flow-go/state/protocol/mock"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/onflow/flow-go/model/flow"
+	mockstate "github.com/onflow/flow-go/state/protocol/mock"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -73,8 +73,8 @@ func (s *EpochFallbackStateMachineSuite) TestTransitionToNextEpoch() {
 
 // TestNewEpochFallbackStateMachine tests that creating epoch fallback state machine sets
 // `InvalidEpochTransitionAttempted` to true to record that we have entered epoch fallback mode[EFM].
-// It tests scenarios where the EFM is entered in different phases of the epoch, and verifies
-// protocol-compliant addition of epoch extensions, depending on the candidate view and epoch phase.  
+// It tests scenarios where the EFM is entered in different phases of the epoch,
+// and verifies protocol-compliant addition of epoch extensions, depending on the candidate view and epoch phase.
 func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 	parentProtocolState := s.parentProtocolState.Copy()
 	parentProtocolState.InvalidEpochTransitionAttempted = false

--- a/state/protocol/protocol_state/epochs/happy_path_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/happy_path_statemachine_test.go
@@ -27,7 +27,11 @@ type BaseStateMachineSuite struct {
 }
 
 func (s *BaseStateMachineSuite) SetupTest() {
-	s.parentProtocolState = unittest.ProtocolStateFixture()
+	s.parentProtocolState = unittest.ProtocolStateFixture(func(entry *flow.RichProtocolStateEntry) {
+		// have a fixed boundary for the current epoch
+		entry.CurrentEpochSetup.FinalView = 5_000
+		entry.CurrentEpoch.SetupID = entry.CurrentEpochSetup.ID()
+	})
 	s.parentBlock = unittest.BlockHeaderFixture(unittest.HeaderWithView(s.parentProtocolState.CurrentEpochSetup.FirstView + 1))
 	s.candidate = unittest.BlockHeaderWithParentFixture(s.parentBlock)
 }


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/5717
https://github.com/onflow/flow-go/issues/5724
https://github.com/onflow/flow-go/issues/5726

### Context

This PR adds data types and logic for extending current epoch using approach based around `EpochExtension`s. 

It is implemented by extending `EpochStateContainer` in Dynamic Protocol State to support an extra field `EpochExtensions`. 
The `epochs.FallbackStateMachine` implements logic to add epoch extensions when needed. 

There are several rules when and how epoch is extended:
1. If we are entering EFM we are checking if the next epoch has been committed, if not then we drop whatever intermediate state that was previously setup for the next epoch.
2. If next epoch has been committed then no epoch extensions are added to the current epoch since we want to transition to the next epoch and only then add extensions.
3. If next epoch has not been committed and we have reached view `v` such as: `v + commitSafetyThreshold >= currentEpoch.FinalView` we add an epoch extension to the current epoch.

When following these rules one should never get in a state where there is an epoch extension and a next epoch, epochs extensions are only added to current epoch when there is no next epoch setup(or not anymore). 

:exclamation:  Note that there is no notion of transitioning between epochs when we have entered EFM, extensions are simply added to the state, but no actual transitions are happening. 