### PR TITLE
Update CI runners

### DIFF
--- a/tools/test_matrix_generator/default-test-matrix-config.json
+++ b/tools/test_matrix_generator/default-test-matrix-config.json
@@ -24,7 +24,7 @@
       {"name": "network/alsp"},
       {"name": "network/p2p/connection"},
       {"name": "network/p2p/scoring"},
-      {"name": "network/p2p", "runner":  "buildjet-16vcpu-ubuntu-2204"},
+      {"name": "network/p2p", "runner":  "ubuntu-22.04-16core"},
       {"name": "network/test/cohort1", "runner":  "buildjet-16vcpu-ubuntu-2204"},
       {"name": "network/test/cohort2", "runner":  "buildjet-4vcpu-ubuntu-2204"},
       {"name": "network/p2p/node", "runner":  "buildjet-4vcpu-ubuntu-2204"}

--- a/tools/test_matrix_generator/default-test-matrix-config.json
+++ b/tools/test_matrix_generator/default-test-matrix-config.json
@@ -9,7 +9,7 @@
     {"name":  "state"},
     {"name":  "storage"},
     {"name":  "utils"},
-    {"name":  "engine", "runner":  "buildjet-4vcpu-ubuntu-2004" ,"subpackages": [
+    {"name":  "engine", "runner":  "buildjet-4vcpu-ubuntu-2204" ,"subpackages": [
       {"name": "engine/access"},
       {"name": "engine/collection"},
       {"name": "engine/common"},
@@ -17,17 +17,17 @@
       {"name": "engine/execution/computation"},
       {"name": "engine/execution"},
       {"name": "engine/verification"},
-      {"name": "engine/execution/ingestion", "runner":  "buildjet-8vcpu-ubuntu-2004"}
+      {"name": "engine/execution/ingestion", "runner":  "buildjet-8vcpu-ubuntu-2204"}
     ]},
-    {"name":  "module", "runner":  "buildjet-4vcpu-ubuntu-2004" ,"subpackages": [{"name": "module/dkg"}]},
+    {"name":  "module", "runner":  "buildjet-4vcpu-ubuntu-2204" ,"subpackages": [{"name": "module/dkg"}]},
     {"name":  "network", "subpackages": [
       {"name": "network/alsp"},
       {"name": "network/p2p/connection"},
       {"name": "network/p2p/scoring"},
-      {"name": "network/p2p", "runner":  "buildjet-16vcpu-ubuntu-2004"},
-      {"name": "network/test/cohort1", "runner":  "buildjet-16vcpu-ubuntu-2004"},
-      {"name": "network/test/cohort2", "runner":  "buildjet-4vcpu-ubuntu-2004"},
-      {"name": "network/p2p/node", "runner":  "buildjet-4vcpu-ubuntu-2004"}
+      {"name": "network/p2p", "runner":  "buildjet-16vcpu-ubuntu-2204"},
+      {"name": "network/test/cohort1", "runner":  "buildjet-16vcpu-ubuntu-2204"},
+      {"name": "network/test/cohort2", "runner":  "buildjet-4vcpu-ubuntu-2204"},
+      {"name": "network/p2p/node", "runner":  "buildjet-4vcpu-ubuntu-2204"}
     ]}
   ]
 }

--- a/tools/test_matrix_generator/default-test-matrix-config.json
+++ b/tools/test_matrix_generator/default-test-matrix-config.json
@@ -24,7 +24,7 @@
       {"name": "network/alsp"},
       {"name": "network/p2p/connection"},
       {"name": "network/p2p/scoring"},
-      {"name": "network/p2p", "runner":  "ubuntu-22.04-16core"},
+      {"name": "network/p2p", "runner":  "buildjet-8vcpu-ubuntu-2004"},
       {"name": "network/test/cohort1", "runner":  "buildjet-16vcpu-ubuntu-2204"},
       {"name": "network/test/cohort2", "runner":  "buildjet-4vcpu-ubuntu-2204"},
       {"name": "network/p2p/node", "runner":  "buildjet-4vcpu-ubuntu-2204"}

--- a/tools/test_matrix_generator/insecure-module-test-matrix-config.json
+++ b/tools/test_matrix_generator/insecure-module-test-matrix-config.json
@@ -2,9 +2,9 @@
   "packagesPath": "./insecure",
   "includeOthers": false,
   "packages": [
-      {"name":  "insecure", "runner":  "buildjet-4vcpu-ubuntu-2004" ,"subpackages": [
-      {"name": "insecure/integration/functional/test/gossipsub/rpc_inspector", "runner":  "buildjet-8vcpu-ubuntu-2004"},
-      {"name": "insecure/integration/functional/test/gossipsub/scoring", "runner":  "buildjet-8vcpu-ubuntu-2004"}
+      {"name":  "insecure", "runner":  "buildjet-4vcpu-ubuntu-2204" ,"subpackages": [
+      {"name": "insecure/integration/functional/test/gossipsub/rpc_inspector", "runner":  "buildjet-8vcpu-ubuntu-2204"},
+      {"name": "insecure/integration/functional/test/gossipsub/scoring", "runner":  "buildjet-8vcpu-ubuntu-2204"}
     ]}
   ]
 }

--- a/tools/test_matrix_generator/integration-module-test-matrix-config.json
+++ b/tools/test_matrix_generator/integration-module-test-matrix-config.json
@@ -3,7 +3,7 @@
   "includeOthers": false,
   "packages": [{
       "name": "integration",
-      "runner": "buildjet-4vcpu-ubuntu-2004",
+      "runner": "buildjet-4vcpu-ubuntu-2204",
       "exclude": ["integration/tests"]
     }]
 }


### PR DESCRIPTION
Buildjet runners are currently taking very long to pick up github actions jobs for ubuntu-2004 runners, this PR updates the runners to use ubuntu-2204 except for network/p2p which becomes flakey on the 2204 runner.  