### PR TITLE
[Logging] Log configuration loaded message at error level - v0.33

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -751,7 +751,7 @@ func (fnb *FlowNodeBuilder) ParseAndPrintFlags() error {
 		fnb.Logger.Fatal().Err(err).Msg("flow configuration validation failed")
 	}
 
-	info := fnb.Logger.Info()
+	info := fnb.Logger.Error()
 
 	noPrint := config.LogConfig(info, fnb.flags)
 	fnb.flags.VisitAll(func(flag *pflag.Flag) {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -759,7 +759,7 @@ func (fnb *FlowNodeBuilder) ParseAndPrintFlags() error {
 			info.Str(flag.Name, fmt.Sprintf("%v", flag.Value))
 		}
 	})
-	info.Msg("configuration loaded")
+	info.Msg("configuration loaded (logged as error for visibility)")
 	return fnb.extraFlagsValidation()
 }
 


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/5785

Log the "configuration loaded" message that includes the node's running config at `error` level. This ensures it's included in the logs for nodes running with "error" level.