### PR TITLE
[EVM] Remove special EVM type

### DIFF
--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -3,9 +3,10 @@ package evm_test
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/onflow/cadence/runtime/common"
 	"math/big"
 	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/cadence/encoding/ccf"
 	gethTypes "github.com/onflow/go-ethereum/core/types"

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -3,6 +3,7 @@ package evm_test
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/onflow/cadence/runtime/common"
 	"math/big"
 	"testing"
 
@@ -102,11 +103,11 @@ func TestEVMRun(t *testing.T) {
 
 				blockEvent := output.Events[1]
 
-				assert.Equal(t, fmt.Sprintf(
-					"A.%s.%s",
-					sc.EVMContract.Address.String(),
-					types.EventTypeBlockExecuted,
-				), string(blockEvent.Type))
+				assert.Equal(
+					t,
+					common.NewAddressLocation(nil, common.Address(sc.EVMContract.Address), string(types.EventTypeBlockExecuted)).ID(),
+					string(blockEvent.Type),
+				)
 
 				ev, err := ccf.Decode(nil, blockEvent.Payload)
 				require.NoError(t, err)
@@ -119,11 +120,11 @@ func TestEVMRun(t *testing.T) {
 
 				txEvent := output.Events[0]
 
-				assert.Equal(t, fmt.Sprintf(
-					"A.%s.%s",
-					sc.EVMContract.Address.String(),
-					types.EventTypeTransactionExecuted,
-				), string(txEvent.Type))
+				assert.Equal(
+					t,
+					common.NewAddressLocation(nil, common.Address(sc.EVMContract.Address), string(types.EventTypeTransactionExecuted)).ID(),
+					string(txEvent.Type),
+				)
 
 				ev, err = ccf.Decode(nil, txEvent.Payload)
 				require.NoError(t, err)

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -351,7 +351,8 @@ func (h *ContractHandler) meterGasUsage(res *types.Result) error {
 }
 
 func (h *ContractHandler) emitEvent(event *types.Event) error {
-	ev, err := event.Payload.ToCadence()
+	location := common.NewAddressLocation(nil, common.Address(h.evmContractAddress), "EVM")
+	ev, err := event.Payload.ToCadence(location)
 	if err != nil {
 		return err
 	}

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -11,19 +11,19 @@ contract EVM {
     access(all)
     event BlockExecuted(
         // height or number of the block
-        height: UInt64
+        height: UInt64,
         // hash of the block
-        hash: String
+        hash: String,
         // timestamp of the block creation
-        timestamp: UInt64
+        timestamp: UInt64,
         // total Flow supply
-        totalSupply: Int
+        totalSupply: Int,
         // all gas used in the block by transactions included
-        totalGasUsed: UInt64
+        totalGasUsed: UInt64,
         // parent block hash
-        parentHash: String
+        parentHash: String,
         // hash of all the transaction receipts
-        receiptRoot: String
+        receiptRoot: String,
         // all the transactions included in the block
         transactionHashes: [String]
     )

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -6,6 +6,54 @@ import "FlowToken"
 access(all)
 contract EVM {
 
+    /// Block executed event is emitted when a new block is created,
+    /// which always happens when a transaction is executed.
+    access(all)
+    event BlockExecuted(
+        // height or number of the block
+        height: UInt64
+        // hash of the block
+        hash: String
+        // timestamp of the block creation
+        timestamp: UInt64
+        // total Flow supply
+        totalSupply: Int
+        // all gas used in the block by transactions included
+        totalGasUsed: UInt64
+        // parent block hash
+        parentHash: String
+        // hash of all the transaction receipts
+        receiptRoot: String
+        // all the transactions included in the block
+        transactionHashes: [String]
+    )
+
+    /// Transaction executed event is emitted everytime a transaction
+    /// is executed by the EVM (even if failed).
+    access(all)
+    event TransactionExecuted(
+        // hash of the transaction
+        hash: String,
+        // index of the transaction in a block
+        index: UInt16,
+        // type of the transaction
+        type: UInt8,
+        // RLP and hex encoded transaction payload
+        payload: String,
+        // code indicating a specific validation (201-300) or execution (301-400) error
+        errorCode: UInt16,
+        // the amount of gas transaction used
+        gasConsumed: UInt64,
+        // if transaction was a deployment contains a newly deployed contract address
+        contractAddress: String,
+        // RLP and hex encoded logs
+        logs: String,
+        // block height in which transaction was inclued
+        blockHeight: UInt64,
+        // block hash in which transaction was included
+        blockHash: String
+    )
+
     access(all)
     event CadenceOwnedAccountCreated(addressBytes: [UInt8; 20])
 

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	EventTypeBlockExecuted       flow.EventType = "BlockExecuted"
-	EventTypeTransactionExecuted flow.EventType = "TransactionExecuted"
+	EventTypeBlockExecuted       flow.EventType = "EVM.BlockExecuted"
+	EventTypeTransactionExecuted flow.EventType = "EVM.TransactionExecuted"
 )
 
 type EventPayload interface {

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -2,12 +2,9 @@ package types
 
 import (
 	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"strings"
+	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/cadence"
-	"github.com/onflow/cadence/runtime/common"
 	gethCommon "github.com/onflow/go-ethereum/common"
 	"github.com/onflow/go-ethereum/rlp"
 
@@ -17,12 +14,151 @@ import (
 const (
 	EventTypeBlockExecuted       flow.EventType = "BlockExecuted"
 	EventTypeTransactionExecuted flow.EventType = "TransactionExecuted"
-	locationDivider                             = "."
 )
 
 type EventPayload interface {
 	// ToCadence converts the event to Cadence event
-	ToCadence() (cadence.Event, error)
+	ToCadence(location common.Location) (cadence.Event, error)
+}
+
+type Event struct {
+	Etype   flow.EventType
+	Payload EventPayload
+}
+
+// todo we might have to break this event into two (tx included /tx executed) if size becomes an issue
+
+type transactionEvent struct {
+	Payload     []byte  // transaction RLP-encoded payload
+	Result      *Result // transaction execution result
+	BlockHeight uint64
+	BlockHash   gethCommon.Hash
+}
+
+// NewTransactionEvent creates a new transaction event with the given parameters
+// - result: the result of the transaction execution
+// - payload: the RLP-encoded payload of the transaction
+// - blockHeight: the height of the block where the transaction is included
+// - blockHash: the hash of the block where the transaction is included
+func NewTransactionEvent(
+	result *Result,
+	payload []byte,
+	blockHeight uint64,
+	blockHash gethCommon.Hash,
+) *Event {
+	return &Event{
+		Etype: EventTypeTransactionExecuted,
+		Payload: &transactionEvent{
+			BlockHeight: blockHeight,
+			BlockHash:   blockHash,
+			Payload:     payload,
+			Result:      result,
+		},
+	}
+}
+
+func (p *transactionEvent) ToCadence(location common.Location) (cadence.Event, error) {
+	var encodedLogs []byte
+	var err error
+	if len(p.Result.Logs) > 0 {
+		encodedLogs, err = rlp.EncodeToBytes(p.Result.Logs)
+		if err != nil {
+			return cadence.Event{}, err
+		}
+	}
+
+	deployedAddress := cadence.String("")
+	if p.Result.DeployedContractAddress != nil {
+		deployedAddress = cadence.String(p.Result.DeployedContractAddress.String())
+	}
+
+	return cadence.Event{
+		EventType: cadence.NewEventType(
+			location,
+			string(EventTypeTransactionExecuted),
+			[]cadence.Field{
+				cadence.NewField("hash", cadence.StringType{}),
+				cadence.NewField("index", cadence.UInt16Type{}),
+				cadence.NewField("type", cadence.UInt8Type{}),
+				cadence.NewField("payload", cadence.StringType{}),
+				cadence.NewField("errorCode", cadence.UInt16Type{}),
+				cadence.NewField("gasConsumed", cadence.UInt64Type{}),
+				cadence.NewField("contractAddress", cadence.StringType{}),
+				cadence.NewField("logs", cadence.StringType{}),
+				cadence.NewField("blockHeight", cadence.UInt64Type{}),
+				// todo we can remove hash and just reference block by height (evm-gateway dependency)
+				cadence.NewField("blockHash", cadence.StringType{}),
+			},
+			nil,
+		),
+		Fields: []cadence.Value{
+			cadence.String(p.Result.TxHash.String()),
+			cadence.NewUInt16(p.Result.Index),
+			cadence.NewUInt8(p.Result.TxType),
+			cadence.String(hex.EncodeToString(p.Payload)),
+			cadence.NewUInt16(uint16(p.Result.ResultSummary().ErrorCode)),
+			cadence.NewUInt64(p.Result.GasConsumed),
+			deployedAddress,
+			cadence.String(hex.EncodeToString(encodedLogs)),
+			cadence.NewUInt64(p.BlockHeight),
+			cadence.String(p.BlockHash.String()),
+		},
+	}, nil
+}
+
+type blockEvent struct {
+	*Block
+}
+
+// NewBlockEvent creates a new block event with the given block as payload.
+func NewBlockEvent(block *Block) *Event {
+	return &Event{
+		Etype:   EventTypeBlockExecuted,
+		Payload: &blockEvent{block},
+	}
+}
+
+func (p *blockEvent) ToCadence(location common.Location) (cadence.Event, error) {
+	hashes := make([]cadence.Value, len(p.TransactionHashes))
+	for i, hash := range p.TransactionHashes {
+		hashes[i] = cadence.String(hash.String())
+	}
+
+	blockHash, err := p.Hash()
+	if err != nil {
+		return cadence.Event{}, err
+	}
+
+	return cadence.Event{
+		EventType: cadence.NewEventType(
+			location,
+			string(EventTypeBlockExecuted),
+			[]cadence.Field{
+				cadence.NewField("height", cadence.UInt64Type{}),
+				cadence.NewField("hash", cadence.StringType{}),
+				cadence.NewField("timestamp", cadence.UInt64Type{}),
+				cadence.NewField("totalSupply", cadence.IntType{}),
+				cadence.NewField("totalGasUsed", cadence.UInt64Type{}),
+				cadence.NewField("parentHash", cadence.StringType{}),
+				cadence.NewField("receiptRoot", cadence.StringType{}),
+				cadence.NewField(
+					"transactionHashes",
+					cadence.NewVariableSizedArrayType(cadence.StringType{}),
+				),
+			},
+			nil,
+		),
+		Fields: []cadence.Value{
+			cadence.NewUInt64(p.Height),
+			cadence.String(blockHash.String()),
+			cadence.NewUInt64(p.Timestamp),
+			cadence.NewIntFromBig(p.TotalSupply),
+			cadence.NewUInt64(p.TotalGasUsed),
+			cadence.String(p.ParentBlockHash.String()),
+			cadence.String(p.ReceiptRoot.String()),
+			cadence.NewArray(hashes).WithType(cadence.NewVariableSizedArrayType(cadence.StringType{})),
+		},
+	}, nil
 }
 
 type BlockEventPayload struct {
@@ -61,212 +197,4 @@ func DecodeTransactionEventPayload(event cadence.Event) (*TransactionEventPayloa
 	var tx TransactionEventPayload
 	err := cadence.DecodeFields(event, &tx)
 	return &tx, err
-}
-
-type Event struct {
-	Etype   flow.EventType
-	Payload EventPayload
-}
-
-var _ common.Location = EVMLocation{}
-
-type EVMLocation struct{}
-
-func (l EVMLocation) TypeID(memoryGauge common.MemoryGauge, qualifiedIdentifier string) common.TypeID {
-	id := fmt.Sprintf("%s%s%s", flow.EVMLocationPrefix, locationDivider, qualifiedIdentifier)
-	common.UseMemory(memoryGauge, common.NewRawStringMemoryUsage(len(id)))
-
-	return common.TypeID(id)
-}
-
-func (l EVMLocation) QualifiedIdentifier(typeID common.TypeID) string {
-	pieces := strings.SplitN(string(typeID), locationDivider, 2)
-
-	if len(pieces) < 2 {
-		return ""
-	}
-
-	return pieces[1]
-}
-
-func (l EVMLocation) String() string {
-	return flow.EVMLocationPrefix
-}
-
-func (l EVMLocation) Description() string {
-	return flow.EVMLocationPrefix
-}
-
-func (l EVMLocation) ID() string {
-	return flow.EVMLocationPrefix
-}
-
-func (l EVMLocation) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Type string
-	}{
-		Type: "EVMLocation",
-	})
-}
-
-func init() {
-	common.RegisterTypeIDDecoder(
-		flow.EVMLocationPrefix,
-		func(_ common.MemoryGauge, typeID string) (common.Location, string, error) {
-			if typeID == "" {
-				return nil, "", fmt.Errorf("invalid EVM type location ID: missing type prefix")
-			}
-
-			parts := strings.SplitN(typeID, ".", 2)
-			prefix := parts[0]
-			if prefix != flow.EVMLocationPrefix {
-				return EVMLocation{}, "", fmt.Errorf("invalid EVM type location ID: invalid prefix")
-			}
-
-			var qualifiedIdentifier string
-			pieceCount := len(parts)
-			if pieceCount > 1 {
-				qualifiedIdentifier = parts[1]
-			}
-
-			return EVMLocation{}, qualifiedIdentifier, nil
-		},
-	)
-}
-
-// todo we might have to break this event into two (tx included /tx executed) if size becomes an issue
-
-type transactionEvent struct {
-	Payload     []byte  // transaction RLP-encoded payload
-	Result      *Result // transaction execution result
-	BlockHeight uint64
-	BlockHash   gethCommon.Hash
-}
-
-func (p *transactionEvent) ToCadence() (cadence.Event, error) {
-	var encodedLogs []byte
-	var err error
-	if len(p.Result.Logs) > 0 {
-		encodedLogs, err = rlp.EncodeToBytes(p.Result.Logs)
-		if err != nil {
-			return cadence.Event{}, err
-		}
-	}
-
-	deployedAddress := cadence.String("")
-	if p.Result.DeployedContractAddress != nil {
-		deployedAddress = cadence.String(p.Result.DeployedContractAddress.String())
-	}
-
-	return cadence.Event{
-		EventType: cadence.NewEventType(
-			EVMLocation{},
-			string(EventTypeTransactionExecuted),
-			[]cadence.Field{
-				cadence.NewField("hash", cadence.StringType{}),
-				cadence.NewField("index", cadence.UInt16Type{}),
-				cadence.NewField("type", cadence.UInt8Type{}),
-				cadence.NewField("payload", cadence.StringType{}),
-				cadence.NewField("errorCode", cadence.UInt16Type{}),
-				cadence.NewField("gasConsumed", cadence.UInt64Type{}),
-				cadence.NewField("contractAddress", cadence.StringType{}),
-				cadence.NewField("logs", cadence.StringType{}),
-				cadence.NewField("blockHeight", cadence.UInt64Type{}),
-				// todo we can remove hash and just reference block by height (evm-gateway dependency)
-				cadence.NewField("blockHash", cadence.StringType{}),
-			},
-			nil,
-		),
-		Fields: []cadence.Value{
-			cadence.String(p.Result.TxHash.String()),
-			cadence.NewUInt16(p.Result.Index),
-			cadence.NewUInt8(p.Result.TxType),
-			cadence.String(hex.EncodeToString(p.Payload)),
-			cadence.NewUInt16(uint16(p.Result.ResultSummary().ErrorCode)),
-			cadence.NewUInt64(p.Result.GasConsumed),
-			deployedAddress,
-			cadence.String(hex.EncodeToString(encodedLogs)),
-			cadence.NewUInt64(p.BlockHeight),
-			cadence.String(p.BlockHash.String()),
-		},
-	}, nil
-}
-
-// NewTransactionEvent creates a new transaction event with the given parameters
-// - result: the result of the transaction execution
-// - payload: the RLP-encoded payload of the transaction
-// - blockHeight: the height of the block where the transaction is included
-// - blockHash: the hash of the block where the transaction is included
-func NewTransactionEvent(
-	result *Result,
-	payload []byte,
-	blockHeight uint64,
-	blockHash gethCommon.Hash,
-) *Event {
-	return &Event{
-		Etype: EventTypeTransactionExecuted,
-		Payload: &transactionEvent{
-			BlockHeight: blockHeight,
-			BlockHash:   blockHash,
-			Payload:     payload,
-			Result:      result,
-		},
-	}
-}
-
-var blockExecutedEventCadenceType = &cadence.EventType{
-	Location:            EVMLocation{},
-	QualifiedIdentifier: string(EventTypeBlockExecuted),
-	Fields: []cadence.Field{
-		cadence.NewField("height", cadence.UInt64Type{}),
-		cadence.NewField("hash", cadence.StringType{}),
-		cadence.NewField("timestamp", cadence.UInt64Type{}),
-		cadence.NewField("totalSupply", cadence.IntType{}),
-		cadence.NewField("totalGasUsed", cadence.UInt64Type{}),
-		cadence.NewField("parentHash", cadence.StringType{}),
-		cadence.NewField("receiptRoot", cadence.StringType{}),
-		cadence.NewField(
-			"transactionHashes",
-			cadence.NewVariableSizedArrayType(cadence.StringType{}),
-		),
-	},
-}
-
-type blockEvent struct {
-	*Block
-}
-
-func (p *blockEvent) ToCadence() (cadence.Event, error) {
-	hashes := make([]cadence.Value, len(p.TransactionHashes))
-	for i, hash := range p.TransactionHashes {
-		hashes[i] = cadence.String(hash.String())
-	}
-
-	blockHash, err := p.Hash()
-	if err != nil {
-		return cadence.Event{}, err
-	}
-
-	fields := []cadence.Value{
-		cadence.NewUInt64(p.Height),
-		cadence.String(blockHash.String()),
-		cadence.NewUInt64(p.Timestamp),
-		cadence.NewIntFromBig(p.TotalSupply),
-		cadence.NewUInt64(p.TotalGasUsed),
-		cadence.String(p.ParentBlockHash.String()),
-		cadence.String(p.ReceiptRoot.String()),
-		cadence.NewArray(hashes).WithType(cadence.NewVariableSizedArrayType(cadence.StringType{})),
-	}
-
-	return cadence.
-		NewEvent(fields).
-		WithType(blockExecutedEventCadenceType), nil
-}
-
-// NewBlockEvent creates a new block event with the given block as payload.
-func NewBlockEvent(block *Block) *Event {
-	return &Event{
-		Etype:   EventTypeBlockExecuted,
-		Payload: &blockEvent{block},
-	}
 }

--- a/fvm/evm/types/events.go
+++ b/fvm/evm/types/events.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/hex"
+
 	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/cadence"

--- a/fvm/evm/types/events_test.go
+++ b/fvm/evm/types/events_test.go
@@ -2,8 +2,12 @@ package types_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"testing"
+
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/model/flow"
 
 	"github.com/onflow/go-ethereum/core/vm"
 
@@ -17,6 +21,12 @@ import (
 
 	"github.com/onflow/flow-go/fvm/evm/testutils"
 	"github.com/onflow/flow-go/fvm/evm/types"
+)
+
+var evmLocation = cdcCommon.NewAddressLocation(
+	nil,
+	cdcCommon.Address(systemcontracts.SystemContractsForChain(flow.Emulator).EVMContract.Address),
+	"EVM",
 )
 
 func TestEVMBlockExecutedEventCCFEncodingDecoding(t *testing.T) {
@@ -35,7 +45,7 @@ func TestEVMBlockExecutedEventCCFEncodingDecoding(t *testing.T) {
 	}
 
 	event := types.NewBlockEvent(block)
-	ev, err := event.Payload.ToCadence()
+	ev, err := event.Payload.ToCadence(evmLocation)
 	require.NoError(t, err)
 
 	bep, err := types.DecodeBlockEventPayload(ev)
@@ -66,13 +76,10 @@ func TestEVMBlockExecutedEventCCFEncodingDecoding(t *testing.T) {
 	evt, err := ccf.Decode(nil, v)
 	require.NoError(t, err)
 
-	assert.Equal(t, evt.Type().ID(), "evm.BlockExecuted")
-
-	location, qualifiedIdentifier, err := cdcCommon.DecodeTypeID(nil, "evm.BlockExecuted")
-	require.NoError(t, err)
-
-	assert.Equal(t, types.EVMLocation{}, location)
-	assert.Equal(t, "BlockExecuted", qualifiedIdentifier)
+	assert.Equal(t, evt.Type().ID(), fmt.Sprintf(
+		"A.%s.EVM.BlockExecuted",
+		systemcontracts.SystemContractsForChain(flow.Emulator).EVMContract.Address,
+	))
 }
 
 func TestEVMTransactionExecutedEventCCFEncodingDecoding(t *testing.T) {
@@ -113,7 +120,7 @@ func TestEVMTransactionExecutedEventCCFEncodingDecoding(t *testing.T) {
 
 	t.Run("evm.TransactionExecuted with failed status", func(t *testing.T) {
 		event := types.NewTransactionEvent(txResult, txBytes, blockHeight, blockHash)
-		ev, err := event.Payload.ToCadence()
+		ev, err := event.Payload.ToCadence(evmLocation)
 		require.NoError(t, err)
 
 		tep, err := types.DecodeTransactionEventPayload(ev)
@@ -143,20 +150,17 @@ func TestEVMTransactionExecutedEventCCFEncodingDecoding(t *testing.T) {
 		evt, err := ccf.Decode(nil, v)
 		require.NoError(t, err)
 
-		assert.Equal(t, evt.Type().ID(), "evm.TransactionExecuted")
-
-		location, qualifiedIdentifier, err := cdcCommon.DecodeTypeID(nil, "evm.TransactionExecuted")
-		require.NoError(t, err)
-
-		assert.Equal(t, types.EVMLocation{}, location)
-		assert.Equal(t, "TransactionExecuted", qualifiedIdentifier)
+		assert.Equal(t, evt.Type().ID(), fmt.Sprintf(
+			"A.%s.EVM.TransactionExecuted",
+			systemcontracts.SystemContractsForChain(flow.Emulator).EVMContract.Address,
+		))
 	})
 
 	t.Run("evm.TransactionExecuted with non-failed status", func(t *testing.T) {
 		txResult.VMError = nil
 
 		event := types.NewTransactionEvent(txResult, txBytes, blockHeight, blockHash)
-		ev, err := event.Payload.ToCadence()
+		ev, err := event.Payload.ToCadence(evmLocation)
 		require.NoError(t, err)
 
 		tep, err := types.DecodeTransactionEventPayload(ev)
@@ -187,12 +191,9 @@ func TestEVMTransactionExecutedEventCCFEncodingDecoding(t *testing.T) {
 		evt, err := ccf.Decode(nil, v)
 		require.NoError(t, err)
 
-		assert.Equal(t, evt.Type().ID(), "evm.TransactionExecuted")
-
-		location, qualifiedIdentifier, err := cdcCommon.DecodeTypeID(nil, "evm.TransactionExecuted")
-		require.NoError(t, err)
-
-		assert.Equal(t, types.EVMLocation{}, location)
-		assert.Equal(t, "TransactionExecuted", qualifiedIdentifier)
+		assert.Equal(t, evt.Type().ID(), fmt.Sprintf(
+			"A.%s.EVM.TransactionExecuted",
+			systemcontracts.SystemContractsForChain(flow.Emulator).EVMContract.Address,
+		))
 	})
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -3278,10 +3278,9 @@ func TestEVM(t *testing.T) {
 			require.NoError(t, output.Err)
 			require.Len(t, output.Events, 7)
 
-			evmLocation := types.EVMLocation{}
 			txExe, blockExe := output.Events[4], output.Events[5]
-			assert.Equal(t, evmLocation.TypeID(nil, string(types.EventTypeTransactionExecuted)), common.TypeID(txExe.Type))
-			assert.Equal(t, evmLocation.TypeID(nil, string(types.EventTypeBlockExecuted)), common.TypeID(blockExe.Type))
+			assert.Equal(t, fmt.Sprintf("A.%s.%s", sc.EVMContract.Address, types.EventTypeTransactionExecuted), string(txExe.Type))
+			assert.Equal(t, fmt.Sprintf("A.%s.%s", sc.EVMContract.Address, types.EventTypeBlockExecuted), string(blockExe.Type))
 		}),
 	)
 }

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -3279,8 +3279,17 @@ func TestEVM(t *testing.T) {
 			require.Len(t, output.Events, 7)
 
 			txExe, blockExe := output.Events[4], output.Events[5]
-			assert.Equal(t, fmt.Sprintf("A.%s.%s", sc.EVMContract.Address, types.EventTypeTransactionExecuted), string(txExe.Type))
-			assert.Equal(t, fmt.Sprintf("A.%s.%s", sc.EVMContract.Address, types.EventTypeBlockExecuted), string(blockExe.Type))
+
+			assert.Equal(
+				t,
+				common.NewAddressLocation(nil, common.Address(sc.EVMContract.Address), string(types.EventTypeTransactionExecuted)).ID(),
+				string(txExe.Type),
+			)
+			assert.Equal(
+				t,
+				common.NewAddressLocation(nil, common.Address(sc.EVMContract.Address), string(types.EventTypeBlockExecuted)).ID(),
+				string(blockExe.Type),
+			)
 		}),
 	)
 }

--- a/model/events/parse.go
+++ b/model/events/parse.go
@@ -23,16 +23,15 @@ type ParsedEvent struct {
 	Name         string
 }
 
-// ParseEvent parses an event type into its parts. There are 3 valid EventType formats:
+// ParseEvent parses an event type into its parts. There are 2 valid EventType formats:
 // - flow.[EventName]
-// - evm.[EventName]
 // - A.[Address].[Contract].[EventName]
 // Any other format results in an error.
 func ParseEvent(eventType flow.EventType) (*ParsedEvent, error) {
 	parts := strings.Split(string(eventType), ".")
 
 	switch parts[0] {
-	case "flow", flow.EVMLocationPrefix:
+	case "flow":
 		if len(parts) == 2 {
 			return &ParsedEvent{
 				Type:         ProtocolEventType,

--- a/model/events/parse_test.go
+++ b/model/events/parse_test.go
@@ -43,17 +43,6 @@ func TestParseEvent(t *testing.T) {
 				Name:         "EventA",
 			},
 		},
-		{
-			name:      "evm event",
-			eventType: "evm.BlockExecuted",
-			expected: events.ParsedEvent{
-				Type:         events.ProtocolEventType,
-				EventType:    "evm.BlockExecuted",
-				Contract:     "evm",
-				ContractName: "evm",
-				Name:         "BlockExecuted",
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -80,8 +69,6 @@ func TestParseEvent_Invalid(t *testing.T) {
 		"B.0000000000000001.invalid.event", // invalid first part
 		"flow",                             // incorrect number of parts for protocol event
 		"flow.invalid.event",               // incorrect number of parts for protocol event
-		"evm",                              // incorrect number of parts for protocol event
-		"evm.invalid.event",                // incorrect number of parts for protocol event
 		"A.0000000000000001.invalid",       // incorrect number of parts for account event
 		"A.0000000000000001.invalid.a.b",   // incorrect number of parts for account event
 
@@ -124,17 +111,6 @@ func TestValidateEvent(t *testing.T) {
 				Name:         "EventA",
 			},
 		},
-		{
-			name:      "evm event",
-			eventType: "evm.BlockExecuted",
-			expected: events.ParsedEvent{
-				Type:         events.ProtocolEventType,
-				EventType:    "evm.BlockExecuted",
-				Contract:     "evm",
-				ContractName: "evm",
-				Name:         "BlockExecuted",
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -161,8 +137,6 @@ func TestValidateEvent_Invalid(t *testing.T) {
 		"B.0000000000000001.invalid.event", // invalid first part
 		"flow",                             // incorrect number of parts for protocol event
 		"flow.invalid.event",               // incorrect number of parts for protocol event
-		"evm",                              // incorrect number of parts for protocol event
-		"evm.invalid.event",                // incorrect number of parts for protocol event
 		"A.0000000000000001.invalid",       // incorrect number of parts for account event
 		"A.0000000000000001.invalid.a.b",   // incorrect number of parts for account event
 		flow.EventType(fmt.Sprintf("A.%s.Contract1.EventA", unittest.RandomAddressFixture())), // address from wrong chain

--- a/model/flow/event.go
+++ b/model/flow/event.go
@@ -15,8 +15,6 @@ const (
 	EventAccountUpdated EventType = "flow.AccountUpdated"
 )
 
-const EVMLocationPrefix = "evm"
-
 type EventType string
 
 type Event struct {


### PR DESCRIPTION
Closes: #5414 

**💔 API Breaking Change**

Remove the special event type for evm: `evm.BlockExecuted` and `evm.TransactionExecuted` and make them be generic Flow event types: `A.{evm contract address}.EVM.TransactionExecuted` and `A.{evm contract address}.EVM.BlockExecuted`. 
