### PR TITLE
[CI] Add static port for observer bind address in integration tests

### DIFF
--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -465,7 +465,7 @@ func prepareObserverService(i int, observerName string, agPublicKey string) Serv
 		fmt.Sprintf("--upstream-node-addresses=%s:%s", testnet.PrimaryAN, testnet.GRPCSecurePort),
 		fmt.Sprintf("--upstream-node-public-keys=%s", agPublicKey),
 		fmt.Sprintf("--observer-networking-key-path=/bootstrap/private-root-information/%s_key", observerName),
-		"--bind=0.0.0.0:0",
+		"--bind=0.0.0.0:3569",
 		fmt.Sprintf("--rpc-addr=%s:%s", observerName, testnet.GRPCPort),
 		fmt.Sprintf("--secure-rpc-addr=%s:%s", observerName, testnet.GRPCSecurePort),
 		fmt.Sprintf("--http-addr=%s:%s", observerName, testnet.GRPCWebPort),

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -740,7 +740,7 @@ func (net *FlowNetwork) addObserver(t *testing.T, conf ObserverConfig) {
 			Image: "gcr.io/flow-container-registry/observer:latest",
 			User:  currentUser(),
 			Cmd: append([]string{
-				"--bind=0.0.0.0:0",
+				"--bind=0.0.0.0:3569",
 				fmt.Sprintf("--bootstrapdir=%s", DefaultBootstrapDir),
 				fmt.Sprintf("--datadir=%s", DefaultFlowDBDir),
 				fmt.Sprintf("--secretsdir=%s", DefaultFlowSecretsDBDir),


### PR DESCRIPTION
Occationally, observers fail to start because of a port conflict while starting the network ([Run](https://github.com/onflow/flow-go/actions/runs/8878528638/job/24374566969#step:6:6217)):
```
container.go:219: testingdock: container start failure: Error response from daemon: driver failed programming external connectivity on endpoint observer_1 (eea0760122c76ba24b88f943b71079c312b5354c5d79fe3a309d5000a56de93f): Bind for 0.0.0.0:43343 failed: port is already allocated
```

This fixes the container bind port to avoid situations where the testingdock uses it twice.