### PR TITLE
Improve migration logging, reports, and new file for very old problematic slabs

### DIFF
--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -423,7 +423,7 @@ func NewCadence1Migrations(
 		if opts.FixSlabsWithBrokenReferences {
 			accountBasedMigrations = append(
 				accountBasedMigrations,
-				NewFixBrokenReferencesInSlabsMigration(rwf, testnetAccountsWithBrokenSlabReferences),
+				NewFixBrokenReferencesInSlabsMigration(outputDir, rwf, testnetAccountsWithBrokenSlabReferences),
 			)
 		}
 

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -99,11 +99,6 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 		return nil, fmt.Errorf("storage health check failed: %w", err)
 	}
 
-	m.log.Warn().
-		Err(err).
-		Str("account", address.Hex()).
-		Msg("filtering unreferenced root slabs")
-
 	// Create a set of unreferenced slabs: root slabs, and all slabs they reference.
 
 	unreferencedSlabIDs := map[atree.StorageID]struct{}{}
@@ -131,6 +126,10 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 
 	filteredPayloads := make([]*ledger.Payload, 0, len(unreferencedSlabIDs))
 
+	m.log.Warn().
+		Str("account", address.Hex()).
+		Msgf("filtering %d unreferenced slabs", len(unreferencedSlabIDs))
+
 	for _, payload := range oldPayloads {
 		registerID, _, err := convert.PayloadToRegister(payload)
 		if err != nil {
@@ -150,7 +149,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 	}
 
 	m.rw.Write(unreferencedSlabs{
-		Account:      address,
+		Account:      address.Hex(),
 		PayloadCount: len(filteredPayloads),
 	})
 
@@ -213,6 +212,6 @@ func (m *FilterUnreferencedSlabsMigration) writeFilteredPayloads() error {
 }
 
 type unreferencedSlabs struct {
-	Account      common.Address `json:"account"`
-	PayloadCount int            `json:"payload_count"`
+	Account      string `json:"account"`
+	PayloadCount int    `json:"payload_count"`
 }

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -183,7 +183,7 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 	assert.Equal(t,
 		[]any{
 			unreferencedSlabs{
-				Account:      testAddress,
+				Account:      testAddress.Hex(),
 				PayloadCount: len(expectedFilteredPayloads),
 			},
 		},

--- a/cmd/util/ledger/migrations/fix_broken_data_migration.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration.go
@@ -3,6 +3,9 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"path"
+	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -11,16 +14,21 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"
 )
 
 type FixSlabsWithBrokenReferencesMigration struct {
-	log           zerolog.Logger
-	rw            reporters.ReportWriter
-	accountsToFix map[common.Address]struct{}
-	nWorkers      int
+	log            zerolog.Logger
+	rw             reporters.ReportWriter
+	outputDir      string
+	accountsToFix  map[common.Address]struct{}
+	nWorkers       int
+	mutex          sync.Mutex
+	brokenPayloads []*ledger.Payload
+	payloadsFile   string
 }
 
 var _ AccountBasedMigration = &FixSlabsWithBrokenReferencesMigration{}
@@ -28,12 +36,15 @@ var _ AccountBasedMigration = &FixSlabsWithBrokenReferencesMigration{}
 const fixSlabsWithBrokenReferencesName = "fix-slabs-with-broken-references"
 
 func NewFixBrokenReferencesInSlabsMigration(
+	outputDir string,
 	rwf reporters.ReportWriterFactory,
 	accountsToFix map[common.Address]struct{},
 ) *FixSlabsWithBrokenReferencesMigration {
 	return &FixSlabsWithBrokenReferencesMigration{
-		rw:            rwf.ReportWriter(fixSlabsWithBrokenReferencesName),
-		accountsToFix: accountsToFix,
+		outputDir:      outputDir,
+		rw:             rwf.ReportWriter(fixSlabsWithBrokenReferencesName),
+		accountsToFix:  accountsToFix,
+		brokenPayloads: make([]*ledger.Payload, 0, 10),
 	}
 }
 
@@ -102,7 +113,15 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 
 	m.log.Log().
 		Str("account", address.Hex()).
-		Msgf("fixed slabs with broken references: %v", fixedStorageIDs)
+		Msgf("fixed %d slabs with broken references", len(fixedStorageIDs))
+
+	// Save broken payloads to save to payload file later
+	brokenPayloads, err := getAtreePayloadsByID(oldPayloads, fixedStorageIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mergeBrokenPayloads(brokenPayloads)
 
 	err = storage.FastCommit(m.nWorkers)
 	if err != nil {
@@ -130,8 +149,73 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 	}
 
 	// Log fixed payloads
-	fixedPayloads := make([]*ledger.Payload, 0, len(fixedStorageIDs))
-	for _, payload := range newPayloads {
+	fixedPayloads, err := getAtreePayloadsByID(newPayloads, fixedStorageIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	m.rw.Write(fixedSlabsWithBrokenReferences{
+		Account:        address.Hex(),
+		BrokenPayloads: brokenPayloads,
+		FixedPayloads:  fixedPayloads,
+	})
+
+	return newPayloads, nil
+}
+
+func (m *FixSlabsWithBrokenReferencesMigration) mergeBrokenPayloads(payloads []*ledger.Payload) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.brokenPayloads = append(m.brokenPayloads, payloads...)
+}
+
+func (m *FixSlabsWithBrokenReferencesMigration) Close() error {
+	// close the report writer so it flushes to file
+	m.rw.Close()
+
+	err := m.writeBrokenPayloads()
+	if err != nil {
+		return fmt.Errorf("failed to write broken payloads to file: %w", err)
+	}
+
+	return nil
+}
+
+func (m *FixSlabsWithBrokenReferencesMigration) writeBrokenPayloads() error {
+
+	m.payloadsFile = path.Join(
+		m.outputDir,
+		fmt.Sprintf("broken_%d.payloads", int32(time.Now().Unix())),
+	)
+
+	writtenPayloadCount, err := util.CreatePayloadFile(
+		m.log,
+		m.payloadsFile,
+		m.brokenPayloads,
+		nil,
+		true,
+	)
+
+	if err != nil {
+		return fmt.Errorf("failed to write all broken payloads to file: %w", err)
+	}
+
+	if writtenPayloadCount != len(m.brokenPayloads) {
+		return fmt.Errorf(
+			"failed to write all broken payloads to file: expected %d, got %d",
+			len(m.brokenPayloads),
+			writtenPayloadCount,
+		)
+	}
+
+	return nil
+}
+
+func getAtreePayloadsByID(payloads []*ledger.Payload, ids map[atree.StorageID][]atree.StorageID) ([]*ledger.Payload, error) {
+	outputPayloads := make([]*ledger.Payload, 0, len(ids))
+
+	for _, payload := range payloads {
 		registerID, _, err := convert.PayloadToRegister(payload)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert payload to register: %w", err)
@@ -146,27 +230,16 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 			atree.StorageIndex([]byte(registerID.Key[1:])),
 		)
 
-		if _, ok := fixedStorageIDs[storageID]; ok {
-			fixedPayloads = append(fixedPayloads, payload)
+		if _, ok := ids[storageID]; ok {
+			outputPayloads = append(outputPayloads, payload)
 		}
 	}
 
-	m.rw.Write(fixedSlabsWithBrokenReferences{
-		Account:  address,
-		Payloads: fixedPayloads,
-	})
-
-	return newPayloads, nil
-}
-
-func (m *FixSlabsWithBrokenReferencesMigration) Close() error {
-	// close the report writer so it flushes to file
-	m.rw.Close()
-
-	return nil
+	return outputPayloads, nil
 }
 
 type fixedSlabsWithBrokenReferences struct {
-	Account  common.Address    `json:"account"`
-	Payloads []*ledger.Payload `json:"payloads"`
+	Account        string            `json:"account"`
+	BrokenPayloads []*ledger.Payload `json:"broken_payloads"`
+	FixedPayloads  []*ledger.Payload `json:"fixed_payloads"`
 }

--- a/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/onflow/cadence/runtime/common"
 
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/ledger"
 )
 
@@ -102,6 +103,12 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	}
 
 	slabIndexWithBrokenReferences := mustDecodeHex("240000000000000003")
+
+	slabWithBrokenReferences := ledger.NewPayload(
+		ledger.NewKey([]ledger.KeyPart{ownerKey, {Type: 2, Value: slabIndexWithBrokenReferences}}),
+		ledger.Value(mustDecodeHex("00c883d8d982d8d582d8c0824848602d8056ff9d937046616e546f705065726d697373696f6e7546616e546f705065726d697373696f6e2e526f6c65d8ddf6011b535c9de83a38cab000c883005b000000000000000856c1dcdf34d761b79b000000000000000182d8ff500000000000000000000000000000002dd8c983d8834848602d8056ff9d93d8c882026b46616e546f7041646d696ed8db82f4d8d582d8c0824848602d8056ff9d937046616e546f705065726d697373696f6e7646616e546f705065726d697373696f6e2e41646d696e")),
+	)
+
 	fixedSlabWithBrokenReferences := ledger.NewPayload(
 		ledger.NewKey([]ledger.KeyPart{ownerKey, {Type: 2, Value: slabIndexWithBrokenReferences}}),
 		ledger.Value(mustDecodeHex("008883d8d982d8d582d8c0824848602d8056ff9d937046616e546f705065726d697373696f6e7546616e546f705065726d697373696f6e2e526f6c65d8ddf6001b535c9de83a38cab0008883005b00000000000000009b0000000000000000")),
@@ -136,12 +143,10 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 		address: struct{}{},
 	}
 
-	migration := NewFixBrokenReferencesInSlabsMigration(rwf, accountsToFix)
+	migration := NewFixBrokenReferencesInSlabsMigration(t.TempDir(), rwf, accountsToFix)
 
 	err := migration.InitMigration(log, nil, runtime.NumCPU())
 	require.NoError(t, err)
-
-	defer migration.Close()
 
 	newPayloads, err := migration.MigrateAccount(
 		context.Background(),
@@ -149,6 +154,10 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 		oldPayloads,
 	)
 	require.NoError(t, err)
+
+	err = migration.Close()
+	require.NoError(t, err)
+
 	require.Equal(t, len(expectedNewPayloads), len(newPayloads))
 
 	for _, expected := range expectedNewPayloads {
@@ -170,12 +179,18 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	assert.Equal(t,
 		[]any{
 			fixedSlabsWithBrokenReferences{
-				Account:  address,
-				Payloads: []*ledger.Payload{fixedSlabWithBrokenReferences},
+				Account:        address.Hex(),
+				BrokenPayloads: []*ledger.Payload{slabWithBrokenReferences},
+				FixedPayloads:  []*ledger.Payload{fixedSlabWithBrokenReferences},
 			},
 		},
 		writer.entries,
 	)
+
+	readIsPartial, readBrokenPayloads, err := util.ReadPayloadFile(log, migration.payloadsFile)
+	require.NoError(t, err)
+	assert.True(t, readIsPartial)
+	assert.Equal(t, []*ledger.Payload{slabWithBrokenReferences}, readBrokenPayloads)
 }
 
 func mustDecodeHex(s string) []byte {


### PR DESCRIPTION
This PR reduces logging, improves reports, and creates a payload file containing all slabs with broken references (currently only 10 testnet slabs and none on mainnet).

Changes include:
- Log filtered slab count instead of slab IDs to reduce overly verbose logging
- Write hex encoded account (instead of raw bytes) in reports
- Write all slabs with broken references to a payload file
  - currently 10 testnet slabs which affects 9 testnet accounts (none on mainnet)
  - more info about this at #5755
- Refactor code