### PR TITLE
Fix flakey network/p2p tests

### DIFF
--- a/integration/tests/access/cohort3/grpc_state_stream_test.go
+++ b/integration/tests/access/cohort3/grpc_state_stream_test.go
@@ -167,6 +167,7 @@ func (s *GrpcStateStreamSuite) Ghost() *client.GhostClient {
 
 // TestRestEventStreaming tests gRPC event streaming
 func (s *GrpcStateStreamSuite) TestHappyPath() {
+	unittest.SkipUnless(s.T(), unittest.TEST_FLAKY, "flaky tests: https://github.com/onflow/flow-go/issues/5825")
 	testANURL := fmt.Sprintf("localhost:%s", s.net.ContainerByName(testnet.PrimaryAN).Port(testnet.ExecutionStatePort))
 	sdkClientTestAN, err := getClient(testANURL)
 	s.Require().NoError(err)

--- a/network/p2p/inspector/validation/control_message_validation_inspector_test.go
+++ b/network/p2p/inspector/validation/control_message_validation_inspector_test.go
@@ -3,8 +3,8 @@ package validation_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -1813,7 +1813,7 @@ func hookedLogger(counter *atomic.Int64, expectedLogLevel zerolog.Level, expecte
 			}
 		}
 	})
-	return zerolog.New(os.Stdout).Level(expectedLogLevel).Hook(hook)
+	return zerolog.New(io.Discard).Level(expectedLogLevel).Hook(hook)
 }
 
 // ensureMessageIdsLen ensures RPC IHave and IWant message ids are the expected len.

--- a/network/p2p/scoring/registry_test.go
+++ b/network/p2p/scoring/registry_test.go
@@ -3,8 +3,8 @@ package scoring_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -1167,7 +1167,7 @@ func TestScoringRegistrySilencePeriod(t *testing.T) {
 			}
 		}
 	})
-	logger := zerolog.New(os.Stdout).Level(zerolog.TraceLevel).Hook(hook)
+	logger := zerolog.New(io.Discard).Level(zerolog.TraceLevel).Hook(hook)
 
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)

--- a/network/p2p/tracer/gossipSubMeshTracer_test.go
+++ b/network/p2p/tracer/gossipSubMeshTracer_test.go
@@ -2,7 +2,7 @@ package tracer_test
 
 import (
 	"context"
-	"os"
+	"io"
 	"testing"
 	"time"
 
@@ -61,7 +61,7 @@ func TestGossipSubMeshTracer(t *testing.T) {
 			}
 		}
 	})
-	logger := zerolog.New(os.Stdout).Level(zerolog.DebugLevel).Hook(hook)
+	logger := zerolog.New(io.Discard).Level(zerolog.DebugLevel).Hook(hook)
 
 	// creates one node with a gossipsub mesh meshTracer, and the other nodes without a gossipsub mesh meshTracer.
 	// we only need one node with a meshTracer to test the meshTracer.

--- a/network/p2p/tracer/gossipSubScoreTracer_test.go
+++ b/network/p2p/tracer/gossipSubScoreTracer_test.go
@@ -2,7 +2,7 @@ package tracer_test
 
 import (
 	"context"
-	"os"
+	"io"
 	"testing"
 	"time"
 
@@ -62,7 +62,7 @@ func TestGossipSubScoreTracer(t *testing.T) {
 			}
 		}
 	})
-	logger := zerolog.New(os.Stdout).Level(zerolog.DebugLevel).Hook(hook)
+	logger := zerolog.New(io.Discard).Level(zerolog.DebugLevel).Hook(hook)
 
 	// sets some fixed scores for the nodes for sake of testing based on their roles.
 	consensusScore := float64(87)


### PR DESCRIPTION
This PR updates the hooked loggers used in the network/p2p tests. Currently these hooks are writing all logs to std.Out causing long test runs, and making it causing github actions raw log downloads and inspection to fail. 