### PR TITLE
[EVM] Skip nonce check on dry runs

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -229,6 +229,8 @@ func (bl *BlockView) DryRunTransaction(
 	// use the from as the signer
 	proc.evm.TxContext.Origin = from
 	msg.From = from
+	// we need to skip nonce check for dry run
+	msg.SkipAccountChecks = true
 
 	// return without commiting the state
 	return proc.run(msg, tx.Hash(), 0, tx.Type())


### PR DESCRIPTION
We should skip account checks (nonce checks) on Dry Runs as they are used for gas estimation and it's not expected to provide valid nonce when doing gas estimation on EVM.