### PR TITLE
[EVM] DRAFT - Replace EVM.BridgeRouter interface with implementation

### DIFF
--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -708,6 +708,14 @@ contract EVM {
         }
     }
 
+    /// Initializes the BridgeRouter resource. Can only be executed if there is not already a BridgeRouter resource.
+    access(all) fun initBridgeRouter() {
+        pre {
+            self.account.type(at: /storage/evmBridgeRouter) == nil: "BridgeRouter has already been initialized"
+        }
+        self.account.save(<-create BridgeRouter(), to: /storage/evmBridgeRouter)
+    }
+
     /// Returns a reference to the BridgeAccessor designated for internal bridge requests
     access(self)
     view fun borrowBridgeAccessor(): &{BridgeAccessor} {


### PR DESCRIPTION
Related: https://github.com/onflow/flow-evm-bridge/issues/60

While redeploying bridge contracts to Previewnet, I realized that the Accessor-Router pattern originally introduced is subverted by the Router being defined in a bridge contract. The idea originally was to define a neutral party router which would store a bridge-defined accessor through which the EVM contract would pass bridge calls to from COAs. However, currently, the BridgeRouter implementation is defined in a bridge contract which, in the event of a redeployment, must necessarily be replaced thus defeating the original purpose of the design.

This draft PR seeks to address this issue by replacing the interface with a resource definition within the EVM contract. I'm leaving this as a draft to serve as a point of discussion for a couple of points I could use clarity on:

1. Removing an interface declaration is a breaking change - is this allowable on PreviewNet?
  a. If not, we could leave the EVM contract as-is and simply deploy a simple BridgeRouter defining contract to the EVM host account
2. Normally, we cannot re-initialize a contract but we would need a way to initialize the BridgeRouter resource in the EVM account.
  a. If we proceed with the alternative in 1.a, this wouldn't be a problem as the resource could be initialized on the new contract's deployment
  b. If we move forward with the EVM contract as proposed in this PR, is there a way we could execute an initialization block to remove the need for the public `initBridgeRouter` method and just include setup in the contract's `init` block?
  
You can see changes in context in https://github.com/onflow/flow-evm-bridge/issues/61