### PR TITLE
[CI] Reduce log level in integration tests

### DIFF
--- a/integration/tests/access/cohort1/access_api_test.go
+++ b/integration/tests/access/cohort1/access_api_test.go
@@ -87,7 +87,7 @@ func (s *AccessAPISuite) SetupTest() {
 
 	indexingAccessConfig := testnet.NewNodeConfig(
 		flow.RoleAccess,
-		testnet.WithLogLevel(zerolog.DebugLevel),
+		testnet.WithLogLevel(zerolog.InfoLevel),
 		testnet.WithAdditionalFlag("--execution-data-sync-enabled=true"),
 		testnet.WithAdditionalFlagf("--execution-data-dir=%s", testnet.DefaultExecutionDataServiceDir),
 		testnet.WithAdditionalFlag("--execution-data-retry-delay=1s"),

--- a/integration/tests/access/cohort3/collection_indexing_test.go
+++ b/integration/tests/access/cohort3/collection_indexing_test.go
@@ -39,7 +39,7 @@ func (s *CollectionIndexingSuite) SetupTest() {
 	}
 	// access_2 is running the indexer, so all collections are indexed using the indexer
 	testANOpts := append(defaultAccessOpts,
-		testnet.WithLogLevel(zerolog.DebugLevel),
+		testnet.WithLogLevel(zerolog.InfoLevel),
 		testnet.WithAdditionalFlag("--execution-data-indexing-enabled=true"),
 	)
 

--- a/integration/tests/access/cohort3/execution_state_sync_test.go
+++ b/integration/tests/access/cohort3/execution_state_sync_test.go
@@ -116,7 +116,7 @@ func (s *ExecutionStateSyncSuite) buildNetworkConfig() {
 	s.observerName = testnet.PrimaryON
 	observers := []testnet.ObserverConfig{{
 		ContainerName: s.observerName,
-		LogLevel:      zerolog.DebugLevel,
+		LogLevel:      zerolog.InfoLevel,
 		AdditionalFlags: []string{
 			fmt.Sprintf("--execution-data-dir=%s", testnet.DefaultExecutionDataServiceDir),
 			"--execution-data-sync-enabled=true",

--- a/integration/tests/access/cohort3/grpc_state_stream_test.go
+++ b/integration/tests/access/cohort3/grpc_state_stream_test.go
@@ -19,6 +19,7 @@ import (
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 
 	"github.com/onflow/flow-go-sdk/test"
+
 	"github.com/onflow/flow-go/engine/access/state_stream/backend"
 	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	"github.com/onflow/flow-go/engine/ghost/client"
@@ -136,7 +137,7 @@ func (s *GrpcStateStreamSuite) SetupTest() {
 	// add the observer node config
 	observers := []testnet.ObserverConfig{{
 		ContainerName: testnet.PrimaryON,
-		LogLevel:      zerolog.DebugLevel,
+		LogLevel:      zerolog.InfoLevel,
 		AdditionalFlags: []string{
 			fmt.Sprintf("--execution-data-dir=%s", testnet.DefaultExecutionDataServiceDir),
 			fmt.Sprintf("--execution-state-dir=%s", testnet.DefaultExecutionStateDir),
@@ -319,7 +320,8 @@ func (s *GrpcStateStreamSuite) getRPCs() []subscribeEventsRPCTest {
 		{
 			name: "SubscribeEvents",
 			call: func(ctx context.Context, client executiondata.ExecutionDataAPIClient, _ interface{}, filter *executiondata.EventFilter) func() (*executiondata.SubscribeEventsResponse, error) {
-				//nolint: staticcheck
+				// Ignore deprecation warning. keeping these tests until endpoint is removed
+				//nolint:staticcheck
 				stream, err := client.SubscribeEvents(ctx, &executiondata.SubscribeEventsRequest{
 					StartBlockId:         convert.IdentifierToMessage(flow.ZeroID),
 					StartBlockHeight:     0,

--- a/integration/tests/access/cohort3/grpc_streaming_blocks_test.go
+++ b/integration/tests/access/cohort3/grpc_streaming_blocks_test.go
@@ -104,7 +104,7 @@ func (s *GrpcBlocksStreamSuite) SetupTest() {
 	// add the observer node config
 	observers := []testnet.ObserverConfig{{
 		ContainerName: testnet.PrimaryON,
-		LogLevel:      zerolog.DebugLevel,
+		LogLevel:      zerolog.InfoLevel,
 		AdditionalFlags: []string{
 			fmt.Sprintf("--execution-data-dir=%s", testnet.DefaultExecutionDataServiceDir),
 			fmt.Sprintf("--execution-state-dir=%s", testnet.DefaultExecutionStateDir),

--- a/integration/tests/epochs/base_suite.go
+++ b/integration/tests/epochs/base_suite.go
@@ -75,7 +75,7 @@ func (s *BaseSuite) SetupTest() {
 		testnet.WithAdditionalFlag("--cruise-ctl-enabled=false"), // disable cruise control for integration tests
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", s.RequiredSealApprovals)),
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", s.RequiredSealApprovals)),
-		testnet.WithLogLevel(zerolog.DebugLevel)}
+		testnet.WithLogLevel(zerolog.InfoLevel)}
 
 	// a ghost node masquerading as an access node
 	s.ghostID = unittest.IdentifierFixture()

--- a/integration/tests/ghost/ghost_node_example_test.go
+++ b/integration/tests/ghost/ghost_node_example_test.go
@@ -25,10 +25,10 @@ func TestGhostNodeExample_Send(t *testing.T) {
 
 	var (
 		// one real collection node
-		realCollNode = testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.DebugLevel), testnet.WithIDInt(1))
+		realCollNode = testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.InfoLevel), testnet.WithIDInt(1))
 
 		// a ghost node masquerading as a collection node
-		ghostCollNode = testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.DebugLevel), testnet.WithIDInt(2),
+		ghostCollNode = testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.InfoLevel), testnet.WithIDInt(2),
 			testnet.AsGhost())
 
 		// three consensus nodes
@@ -86,7 +86,7 @@ func TestGhostNodeExample_Subscribe(t *testing.T) {
 		realExeNode = testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithIDInt(2))
 
 		// a ghost node masquerading as an execution node
-		ghostExeNode = testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.DebugLevel), testnet.WithIDInt(3),
+		ghostExeNode = testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.InfoLevel), testnet.WithIDInt(3),
 			testnet.AsGhost())
 
 		// a verification node


### PR DESCRIPTION
Experimenting to see if this helps speed up the tests. at the very least it will make it so we can download the Access Cohort 3 test logs