### PR TITLE
[Access] Backport register and program cache to master

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -52,6 +52,7 @@ import (
 	"github.com/onflow/flow-go/engine/common/requester"
 	synceng "github.com/onflow/flow-go/engine/common/synchronization"
 	"github.com/onflow/flow-go/engine/execution/computation/query"
+	"github.com/onflow/flow-go/fvm/storage/derived"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/complete/wal"
 	"github.com/onflow/flow-go/model/bootstrap"
@@ -155,6 +156,7 @@ type AccessNodeConfig struct {
 	scriptExecMaxBlock                uint64
 	registerCacheType                 string
 	registerCacheSize                 uint
+	programCacheSize                  uint
 }
 
 type PublicNetworkConfig struct {
@@ -251,6 +253,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		scriptExecMaxBlock:           math.MaxUint64,
 		registerCacheType:            pStorage.CacheTypeTwoQueue.String(),
 		registerCacheSize:            0,
+		programCacheSize:             0,
 	}
 }
 
@@ -803,6 +806,11 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					builder.Storage.RegisterIndex = registers
 				}
 
+				indexerDerivedChainData, queryDerivedChainData, err := builder.buildDerivedChainData()
+				if err != nil {
+					return nil, fmt.Errorf("could not create derived chain data: %w", err)
+				}
+
 				indexerCore, err := indexer.New(
 					builder.Logger,
 					metrics.NewExecutionStateIndexerCollector(),
@@ -813,6 +821,8 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					builder.Storage.Collections,
 					builder.Storage.Transactions,
 					builder.Storage.LightTransactionResults,
+					builder.RootChainID.Chain(),
+					indexerDerivedChainData,
 					builder.collectionExecutedMetric,
 				)
 				if err != nil {
@@ -839,7 +849,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 
 				// create script execution module, this depends on the indexer being initialized and the
 				// having the register storage bootstrapped
-				scripts, err := execution.NewScripts(
+				scripts := execution.NewScripts(
 					builder.Logger,
 					metrics.NewExecutionCollector(builder.Tracer),
 					builder.RootChainID,
@@ -847,10 +857,9 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					builder.Storage.Headers,
 					builder.ExecutionIndexerCore.RegisterValue,
 					builder.scriptExecutorConfig,
+					queryDerivedChainData,
+					builder.programCacheSize > 0,
 				)
-				if err != nil {
-					return nil, err
-				}
 
 				err = builder.ScriptExecutor.Initialize(builder.ExecutionIndexer, scripts)
 				if err != nil {
@@ -966,6 +975,34 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 	}
 
 	return builder
+}
+
+// buildDerivedChainData creates the derived chain data for the indexer and the query engine
+// If program caching is disabled, the function will return nil for the indexer cache, and a
+// derived chain data object for the query engine cache.
+func (builder *FlowAccessNodeBuilder) buildDerivedChainData() (
+	indexerCache *derived.DerivedChainData,
+	queryCache *derived.DerivedChainData,
+	err error,
+) {
+	cacheSize := builder.programCacheSize
+
+	// the underlying cache requires size > 0. no data will be written so 1 is fine.
+	if cacheSize == 0 {
+		cacheSize = 1
+	}
+
+	derivedChainData, err := derived.NewDerivedChainData(cacheSize)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// writes are done by the indexer. using a nil value effectively disables writes to the cache.
+	if builder.programCacheSize == 0 {
+		return nil, derivedChainData, nil
+	}
+
+	return derivedChainData, derivedChainData, nil
 }
 
 func FlowAccessNode(nodeBuilder *cmd.FlowNodeBuilder) *FlowAccessNodeBuilder {
@@ -1229,6 +1266,10 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"register-cache-size",
 			defaultConfig.registerCacheSize,
 			"number of registers to cache for script execution. default: 0 (no cache)")
+		flags.UintVar(&builder.programCacheSize,
+			"program-cache-size",
+			defaultConfig.programCacheSize,
+			"[experimental] number of blocks to cache for cadence programs. use 0 to disable cache. default: 0. Note: this is an experimental feature and may cause nodes to become unstable under certain workloads. Use with caution.")
 	}).ValidateFlags(func() error {
 		if builder.supportsObserver && (builder.PublicNetworkConfig.BindAddress == cmd.NotSet || builder.PublicNetworkConfig.BindAddress == "") {
 			return errors.New("public-network-address must be set if supports-observer is true")

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -153,6 +153,8 @@ type AccessNodeConfig struct {
 	scriptExecutorConfig              query.QueryConfig
 	scriptExecMinBlock                uint64
 	scriptExecMaxBlock                uint64
+	registerCacheType                 string
+	registerCacheSize                 uint
 }
 
 type PublicNetworkConfig struct {
@@ -247,6 +249,8 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		scriptExecutorConfig:         query.NewDefaultConfig(),
 		scriptExecMinBlock:           0,
 		scriptExecMaxBlock:           math.MaxUint64,
+		registerCacheType:            pStorage.CacheTypeTwoQueue.String(),
+		registerCacheSize:            0,
 	}
 }
 
@@ -784,7 +788,20 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					return nil, fmt.Errorf("could not create registers storage: %w", err)
 				}
 
-				builder.Storage.RegisterIndex = registers
+				if builder.registerCacheSize > 0 {
+					cacheType, err := pStorage.ParseCacheType(builder.registerCacheType)
+					if err != nil {
+						return nil, fmt.Errorf("could not parse register cache type: %w", err)
+					}
+					cacheMetrics := metrics.NewCacheCollector(builder.RootChainID)
+					registersCache, err := pStorage.NewRegistersCache(registers, cacheType, builder.registerCacheSize, cacheMetrics)
+					if err != nil {
+						return nil, fmt.Errorf("could not create registers cache: %w", err)
+					}
+					builder.Storage.RegisterIndex = registersCache
+				} else {
+					builder.Storage.RegisterIndex = registers
+				}
 
 				indexerCore, err := indexer.New(
 					builder.Logger,
@@ -1203,6 +1220,15 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"script-execution-max-height",
 			defaultConfig.scriptExecMaxBlock,
 			"highest block height to allow for script execution. default: no limit")
+
+		flags.StringVar(&builder.registerCacheType,
+			"register-cache-type",
+			defaultConfig.registerCacheType,
+			"type of backend cache to use for registers (lru, arc, 2q)")
+		flags.UintVar(&builder.registerCacheSize,
+			"register-cache-size",
+			defaultConfig.registerCacheSize,
+			"number of registers to cache for script execution. default: 0 (no cache)")
 	}).ValidateFlags(func() error {
 		if builder.supportsObserver && (builder.PublicNetworkConfig.BindAddress == cmd.NotSet || builder.PublicNetworkConfig.BindAddress == "") {
 			return errors.New("public-network-address must be set if supports-observer is true")

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -151,6 +151,13 @@ func NewBlockComputer(
 	if maxConcurrency < 1 {
 		return nil, fmt.Errorf("invalid maxConcurrency: %d", maxConcurrency)
 	}
+
+	// this is a safeguard to prevent scripts from writing to the program cache on Execution nodes.
+	// writes are only allowed by transactions.
+	if vmCtx.AllowProgramCacheWritesInScripts {
+		return nil, fmt.Errorf("program cache writes are not allowed in scripts on Execution nodes")
+	}
+
 	systemChunkCtx := SystemChunkContext(vmCtx)
 	vmCtx = fvm.NewContextFromParent(
 		vmCtx,

--- a/fvm/context.go
+++ b/fvm/context.go
@@ -42,6 +42,10 @@ type Context struct {
 	tracing.TracerSpan
 
 	environment.EnvironmentParams
+
+	// AllowProgramCacheWritesInScripts determines if the program cache can be written to in scripts
+	// By default, the program cache is only updated by transactions.
+	AllowProgramCacheWritesInScripts bool
 }
 
 // NewContext initializes a new execution context with the provided options.
@@ -372,6 +376,14 @@ func WithEventEncoder(encoder environment.EventEncoder) Option {
 func WithEVMEnabled(enabled bool) Option {
 	return func(ctx Context) Context {
 		ctx.EVMEnabled = enabled
+		return ctx
+	}
+}
+
+// WithAllowProgramCacheWritesInScriptsEnabled enables caching of programs accessed by scripts
+func WithAllowProgramCacheWritesInScriptsEnabled(enabled bool) Option {
+	return func(ctx Context) Context {
+		ctx.AllowProgramCacheWritesInScripts = enabled
 		return ctx
 	}
 }

--- a/fvm/storage/block_database.go
+++ b/fvm/storage/block_database.go
@@ -66,6 +66,7 @@ func (database *BlockDatabase) NewTransaction(
 	}, nil
 }
 
+// NewSnapshotReadTransaction creates a new readonly transaction.
 func (database *BlockDatabase) NewSnapshotReadTransaction(
 	parameters state.StateParameters,
 ) Transaction {
@@ -76,6 +77,17 @@ func (database *BlockDatabase) NewSnapshotReadTransaction(
 		DerivedTransactionData: database.DerivedBlockData.
 			NewSnapshotReadDerivedTransactionData(),
 	}
+}
+
+// NewCachingSnapshotReadTransaction creates a new readonly transaction that allows writing to the
+// derived transaction data table.
+func (database *BlockDatabase) NewCachingSnapshotReadTransaction(
+	parameters state.StateParameters,
+) (Transaction, error) {
+	return &transaction{
+		TransactionData:        database.BlockData.NewCachingSnapshotReadTransactionData(parameters),
+		DerivedTransactionData: database.DerivedBlockData.NewCachingSnapshotReadDerivedTransactionData(),
+	}, nil
 }
 
 func (txn *transaction) Validate() error {

--- a/fvm/storage/derived/derived_block_data.go
+++ b/fvm/storage/derived/derived_block_data.go
@@ -82,13 +82,16 @@ func (block *DerivedBlockData) NewChildDerivedBlockData() *DerivedBlockData {
 }
 
 func (block *DerivedBlockData) NewSnapshotReadDerivedTransactionData() *DerivedTransactionData {
-	txnPrograms := block.programs.NewSnapshotReadTableTransaction()
-
-	txnMeterParamOverrides := block.meterParamOverrides.NewSnapshotReadTableTransaction()
-
 	return &DerivedTransactionData{
-		programs:            txnPrograms,
-		meterParamOverrides: txnMeterParamOverrides,
+		programs:            block.programs.NewSnapshotReadTableTransaction(),
+		meterParamOverrides: block.meterParamOverrides.NewSnapshotReadTableTransaction(),
+	}
+}
+
+func (block *DerivedBlockData) NewCachingSnapshotReadDerivedTransactionData() *DerivedTransactionData {
+	return &DerivedTransactionData{
+		programs:            block.programs.NewCachingSnapshotReadTableTransaction(),
+		meterParamOverrides: block.meterParamOverrides.NewCachingSnapshotReadTableTransaction(),
 	}
 }
 

--- a/fvm/storage/derived/table.go
+++ b/fvm/storage/derived/table.go
@@ -77,6 +77,11 @@ type TableTransaction[TKey comparable, TVal any] struct {
 	// When isSnapshotReadTransaction is true, invalidators must be empty.
 	isSnapshotReadTransaction bool
 	invalidators              chainedTableInvalidators[TKey, TVal]
+
+	// ignoreLatestCommitExecutionTime is used to bypass latestCommitExecutionTime checks during
+	// commit. This is used when operating in caching mode with scripts since "commits" are all done
+	// at the end of the block and are not expected to progress the execution time.
+	ignoreLatestCommitExecutionTime bool
 }
 
 func NewEmptyTable[
@@ -270,6 +275,7 @@ func (table *DerivedDataTable[TKey, TVal]) commit(
 	defer table.lock.Unlock()
 
 	if !txn.isSnapshotReadTransaction &&
+		!txn.ignoreLatestCommitExecutionTime &&
 		table.latestCommitExecutionTime+1 < txn.snapshotTime {
 
 		return fmt.Errorf(
@@ -328,15 +334,17 @@ func (table *DerivedDataTable[TKey, TVal]) newTableTransaction(
 	snapshotTime logical.Time,
 	executionTime logical.Time,
 	isSnapshotReadTransaction bool,
+	ignoreLatestCommitExecutionTime bool,
 ) *TableTransaction[TKey, TVal] {
 	return &TableTransaction[TKey, TVal]{
-		table:                     table,
-		snapshotTime:              snapshotTime,
-		executionTime:             executionTime,
-		toValidateTime:            snapshotTime,
-		readSet:                   map[TKey]*invalidatableEntry[TVal]{},
-		writeSet:                  map[TKey]*invalidatableEntry[TVal]{},
-		isSnapshotReadTransaction: isSnapshotReadTransaction,
+		table:                           table,
+		snapshotTime:                    snapshotTime,
+		executionTime:                   executionTime,
+		toValidateTime:                  snapshotTime,
+		readSet:                         map[TKey]*invalidatableEntry[TVal]{},
+		writeSet:                        map[TKey]*invalidatableEntry[TVal]{},
+		isSnapshotReadTransaction:       isSnapshotReadTransaction,
+		ignoreLatestCommitExecutionTime: ignoreLatestCommitExecutionTime,
 	}
 }
 
@@ -344,6 +352,15 @@ func (table *DerivedDataTable[TKey, TVal]) NewSnapshotReadTableTransaction() *Ta
 	return table.newTableTransaction(
 		logical.EndOfBlockExecutionTime,
 		logical.EndOfBlockExecutionTime,
+		true,
+		false)
+}
+
+func (table *DerivedDataTable[TKey, TVal]) NewCachingSnapshotReadTableTransaction() *TableTransaction[TKey, TVal] {
+	return table.newTableTransaction(
+		logical.EndOfBlockExecutionTime,
+		logical.EndOfBlockExecutionTime,
+		false,
 		true)
 }
 
@@ -372,6 +389,7 @@ func (table *DerivedDataTable[TKey, TVal]) NewTableTransaction(
 	return table.newTableTransaction(
 		snapshotTime,
 		executionTime,
+		false,
 		false), nil
 }
 

--- a/fvm/storage/primary/block_data.go
+++ b/fvm/storage/primary/block_data.go
@@ -86,7 +86,7 @@ func (block *BlockData) NewTransactionData(
 		executionTime > logical.LargestNormalTransactionExecutionTime {
 
 		return nil, fmt.Errorf(
-			"invalid tranaction: execution time out of bound")
+			"invalid transaction: execution time out of bound")
 	}
 
 	txn := block.newTransactionData(
@@ -102,6 +102,15 @@ func (block *BlockData) NewTransactionData(
 	}
 
 	return txn, nil
+}
+
+func (block *BlockData) NewCachingSnapshotReadTransactionData(
+	parameters state.StateParameters,
+) *TransactionData {
+	return block.newTransactionData(
+		false,
+		logical.EndOfBlockExecutionTime,
+		parameters)
 }
 
 func (block *BlockData) NewSnapshotReadTransactionData(

--- a/integration/testnet/client.go
+++ b/integration/testnet/client.go
@@ -77,18 +77,18 @@ func NewClient(addr string, chain flow.Chain) (*Client, error) {
 	}
 	// Uncomment for debugging keys
 
-	//json, err := key.MarshalJSON()
-	//if err != nil {
+	// json, err := key.MarshalJSON()
+	// if err != nil {
 	//	return nil, fmt.Errorf("cannot marshal key json: %w", err)
-	//}
-	//public := key.PublicKey(1000)
-	//publicJson, err := public.MarshalJSON()
-	//if err != nil {
+	// }
+	// public := key.PublicKey(1000)
+	// publicJson, err := public.MarshalJSON()
+	// if err != nil {
 	//	return nil, fmt.Errorf("cannot marshal key json: %w", err)
-	//}
+	// }
 	//
-	//fmt.Printf("New client with private key: \n%s\n", json)
-	//fmt.Printf("and public key: \n%s\n", publicJson)
+	// fmt.Printf("New client with private key: \n%s\n", json)
+	// fmt.Printf("and public key: \n%s\n", publicJson)
 
 	return NewClientWithKey(addr, sdk.Address(chain.ServiceAddress()), privateKey, chain)
 }
@@ -111,14 +111,33 @@ func (c *Client) Events(ctx context.Context, typ string) ([]sdk.BlockEvents, err
 // DeployContract submits a transaction to deploy a contract with the given
 // code to the root account.
 func (c *Client) DeployContract(ctx context.Context, refID sdk.Identifier, contract dsl.Contract) (*sdk.Transaction, error) {
-
-	code := dsl.Transaction{
+	return c.deployContract(ctx, refID, dsl.Transaction{
 		Import: dsl.Import{},
 		Content: dsl.Prepare{
-			Content: dsl.UpdateAccountCode{Code: contract.ToCadence(), Name: contract.Name},
+			Content: dsl.SetAccountCode{
+				Code: contract.ToCadence(),
+				Name: contract.Name,
+			},
 		},
-	}
+	})
+}
 
+// UpdateContract submits a transaction to deploy a contract update with the given
+// code to the root account.
+func (c *Client) UpdateContract(ctx context.Context, refID sdk.Identifier, contract dsl.Contract) (*sdk.Transaction, error) {
+	return c.deployContract(ctx, refID, dsl.Transaction{
+		Import: dsl.Import{},
+		Content: dsl.Prepare{
+			Content: dsl.SetAccountCode{
+				Code:   contract.ToCadence(),
+				Name:   contract.Name,
+				Update: true,
+			},
+		},
+	})
+}
+
+func (c *Client) deployContract(ctx context.Context, refID sdk.Identifier, code dsl.Transaction) (*sdk.Transaction, error) {
 	tx := sdk.NewTransaction().
 		SetScript([]byte(code.ToCadence())).
 		SetReferenceBlockID(refID).

--- a/module/execution/scripts.go
+++ b/module/execution/scripts.go
@@ -60,18 +60,17 @@ func NewScripts(
 	header storage.Headers,
 	registerAtHeight RegisterAtHeight,
 	queryConf query.QueryConfig,
-) (*Scripts, error) {
+	derivedChainData *derived.DerivedChainData,
+	enableProgramCacheWrites bool,
+) *Scripts {
 	vm := fvm.NewVirtualMachine()
 
 	options := computation.DefaultFVMOptions(chainID, false, false)
 	blocks := environment.NewBlockFinder(header)
 	options = append(options, fvm.WithBlocks(blocks)) // add blocks for getBlocks calls in scripts
+	options = append(options, fvm.WithMetricsReporter(metrics))
+	options = append(options, fvm.WithAllowProgramCacheWritesInScriptsEnabled(enableProgramCacheWrites))
 	vmCtx := fvm.NewContext(options...)
-
-	derivedChainData, err := derived.NewDerivedChainData(derived.DefaultDerivedDataCacheSize)
-	if err != nil {
-		return nil, err
-	}
 
 	queryExecutor := query.NewQueryExecutor(
 		queryConf,
@@ -87,7 +86,7 @@ func NewScripts(
 		executor:         queryExecutor,
 		headers:          header,
 		registerAtHeight: registerAtHeight,
-	}, nil
+	}
 }
 
 // ExecuteAtBlockHeight executes provided script against the block height.

--- a/module/execution/scripts_test.go
+++ b/module/execution/scripts_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/onflow/flow-go/fvm/errors"
+	"github.com/onflow/flow-go/fvm/storage/derived"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/encoding/ccf"
@@ -156,6 +157,9 @@ func (s *scriptTestSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.registerIndex = pebbleRegisters
 
+	derivedChainData, err := derived.NewDerivedChainData(derived.DefaultDerivedDataCacheSize)
+	s.Require().NoError(err)
+
 	index, err := indexer.New(
 		logger,
 		metrics.NewNoopCollector(),
@@ -166,11 +170,13 @@ func (s *scriptTestSuite) SetupTest() {
 		nil,
 		nil,
 		nil,
+		flow.Testnet.Chain(),
+		derivedChainData,
 		nil,
 	)
 	s.Require().NoError(err)
 
-	scripts, err := NewScripts(
+	s.scripts = NewScripts(
 		logger,
 		metrics.NewNoopCollector(),
 		s.chain.ChainID(),
@@ -178,9 +184,9 @@ func (s *scriptTestSuite) SetupTest() {
 		headers,
 		index.RegisterValue,
 		query.NewDefaultConfig(),
+		derivedChainData,
+		true,
 	)
-	s.Require().NoError(err)
-	s.scripts = scripts
 
 	s.bootstrap()
 }

--- a/module/state_synchronization/indexer/indexer_core.go
+++ b/module/state_synchronization/indexer/indexer_core.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/onflow/flow-go/fvm/storage/derived"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"
@@ -32,6 +33,9 @@ type IndexerCore struct {
 	batcher      bstorage.BatchBuilder
 
 	collectionExecutedMetric module.CollectionExecutedMetric
+
+	derivedChainData *derived.DerivedChainData
+	serviceAddress   flow.Address
 }
 
 // New execution state indexer used to ingest block execution data and index it by height.
@@ -47,6 +51,8 @@ func New(
 	collections storage.Collections,
 	transactions storage.Transactions,
 	results storage.LightTransactionResults,
+	chain flow.Chain,
+	derivedChainData *derived.DerivedChainData,
 	collectionExecutedMetric module.CollectionExecutedMetric,
 ) (*IndexerCore, error) {
 	log = log.With().Str("component", "execution_indexer").Logger()
@@ -58,15 +64,18 @@ func New(
 		Msg("indexer initialized")
 
 	return &IndexerCore{
-		log:                      log,
-		metrics:                  metrics,
-		batcher:                  batcher,
-		registers:                registers,
-		headers:                  headers,
-		events:                   events,
-		collections:              collections,
-		transactions:             transactions,
-		results:                  results,
+		log:              log,
+		metrics:          metrics,
+		batcher:          batcher,
+		registers:        registers,
+		headers:          headers,
+		collections:      collections,
+		transactions:     transactions,
+		events:           events,
+		results:          results,
+		serviceAddress:   chain.ServiceAddress(),
+		derivedChainData: derivedChainData,
+
 		collectionExecutedMetric: collectionExecutedMetric,
 	}, nil
 }
@@ -97,27 +106,27 @@ func (c *IndexerCore) RegisterValue(ID flow.RegisterID, height uint64) (flow.Reg
 // Expected errors:
 // - storage.ErrNotFound if the block for execution data was not found
 func (c *IndexerCore) IndexBlockData(data *execution_data.BlockExecutionDataEntity) error {
-	block, err := c.headers.ByBlockID(data.BlockID)
+	header, err := c.headers.ByBlockID(data.BlockID)
 	if err != nil {
 		return fmt.Errorf("could not get the block by ID %s: %w", data.BlockID, err)
 	}
 
 	lg := c.log.With().
 		Hex("block_id", logging.ID(data.BlockID)).
-		Uint64("height", block.Height).
+		Uint64("height", header.Height).
 		Logger()
 
 	lg.Debug().Msgf("indexing new block")
 
 	// the height we are indexing must be exactly one bigger or same as the latest height indexed from the storage
 	latest := c.registers.LatestHeight()
-	if block.Height != latest+1 && block.Height != latest {
-		return fmt.Errorf("must index block data with the next height %d, but got %d", latest+1, block.Height)
+	if header.Height != latest+1 && header.Height != latest {
+		return fmt.Errorf("must index block data with the next height %d, but got %d", latest+1, header.Height)
 	}
 
 	// allow rerunning the indexer for same height since we are fetching height from register storage, but there are other storages
 	// for indexing resources which might fail to update the values, so this enables rerunning and reindexing those resources
-	if block.Height == latest {
+	if header.Height == latest {
 		lg.Warn().Msg("reindexing block data")
 		c.metrics.BlockReindexed()
 	}
@@ -140,12 +149,12 @@ func (c *IndexerCore) IndexBlockData(data *execution_data.BlockExecutionDataEnti
 
 		err := c.events.BatchStore(data.BlockID, []flow.EventsList{events}, batch)
 		if err != nil {
-			return fmt.Errorf("could not index events at height %d: %w", block.Height, err)
+			return fmt.Errorf("could not index events at height %d: %w", header.Height, err)
 		}
 
 		err = c.results.BatchStore(data.BlockID, results, batch)
 		if err != nil {
-			return fmt.Errorf("could not index transaction results at height %d: %w", block.Height, err)
+			return fmt.Errorf("could not index transaction results at height %d: %w", header.Height, err)
 		}
 
 		batch.Flush()
@@ -203,7 +212,11 @@ func (c *IndexerCore) IndexBlockData(data *execution_data.BlockExecutionDataEnti
 		// second chunk updates: { X: 2 }
 		// then we should persist only {X: 2: Y: 2}
 		payloads := make(map[ledger.Path]*ledger.Payload)
+		events := make([]flow.Event, 0)
+		collections := make([]*flow.Collection, 0)
 		for _, chunk := range data.ChunkExecutionDatas {
+			events = append(events, chunk.Events...)
+			collections = append(collections, chunk.Collection)
 			update := chunk.TrieUpdate
 			if update != nil {
 				// this should never happen but we check anyway
@@ -217,9 +230,14 @@ func (c *IndexerCore) IndexBlockData(data *execution_data.BlockExecutionDataEnti
 			}
 		}
 
-		err = c.indexRegisters(payloads, block.Height)
+		err = c.indexRegisters(payloads, header.Height)
 		if err != nil {
-			return fmt.Errorf("could not index register payloads at height %d: %w", block.Height, err)
+			return fmt.Errorf("could not index register payloads at height %d: %w", header.Height, err)
+		}
+
+		err = c.updateProgramCache(header, events, collections)
+		if err != nil {
+			return fmt.Errorf("could not update program cache at height %d: %w", header.Height, err)
 		}
 
 		registerCount = len(payloads)
@@ -234,13 +252,52 @@ func (c *IndexerCore) IndexBlockData(data *execution_data.BlockExecutionDataEnti
 
 	err = g.Wait()
 	if err != nil {
-		return fmt.Errorf("failed to index block data at height %d: %w", block.Height, err)
+		return fmt.Errorf("failed to index block data at height %d: %w", header.Height, err)
 	}
 
-	c.metrics.BlockIndexed(block.Height, time.Since(start), eventCount, registerCount, resultCount)
+	c.metrics.BlockIndexed(header.Height, time.Since(start), eventCount, registerCount, resultCount)
 	lg.Debug().
 		Dur("duration_ms", time.Since(start)).
 		Msg("indexed block data")
+
+	return nil
+}
+
+func (c *IndexerCore) updateProgramCache(header *flow.Header, events []flow.Event, collections []*flow.Collection) error {
+	if c.derivedChainData == nil {
+		return nil
+	}
+
+	derivedBlockData := c.derivedChainData.GetOrCreateDerivedBlockData(
+		header.ID(),
+		header.ParentID,
+	)
+
+	// get a list of all contracts that were updated in this block
+	updatedContracts, err := findContractUpdates(events)
+	if err != nil {
+		return fmt.Errorf("could not find contract updates for block %d: %w", header.Height, err)
+	}
+
+	// invalidate cache entries for all modified programs
+	tx, err := derivedBlockData.NewDerivedTransactionData(0, 0)
+	if err != nil {
+		return fmt.Errorf("could not create derived transaction data for block %d: %w", header.Height, err)
+	}
+
+	tx.AddInvalidator(&accessInvalidator{
+		programs: &programInvalidator{
+			invalidated: updatedContracts,
+		},
+		meterParamOverrides: &meterParamOverridesInvalidator{
+			invalidateAll: hasAuthorizedTransaction(collections, c.serviceAddress),
+		},
+	})
+
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("could not commit derived transaction data for block %d: %w", header.Height, err)
+	}
 
 	return nil
 }

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -14,6 +14,7 @@ import (
 	mocks "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/fvm/storage/derived"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -82,6 +83,17 @@ func (i *indexCoreTest) useDefaultBlockByHeight() *indexCoreTest {
 				}
 			}
 			return flow.ZeroID, fmt.Errorf("not found")
+		})
+
+	i.headers.
+		On("ByHeight", mocks.AnythingOfType("uint64")).
+		Return(func(height uint64) (*flow.Header, error) {
+			for _, b := range i.blocks {
+				if b.Header.Height == height {
+					return b.Header, nil
+				}
+			}
+			return nil, fmt.Errorf("not found")
 		})
 
 	return i
@@ -200,8 +212,23 @@ func (i *indexCoreTest) initIndexer() *indexCoreTest {
 	)
 	require.NoError(i.t, err)
 
-	indexer, err := New(log, metrics.NewNoopCollector(), db, i.registers, i.headers, i.events,
-		i.collections, i.transactions, i.results, collectionExecutedMetric)
+	derivedChainData, err := derived.NewDerivedChainData(derived.DefaultDerivedDataCacheSize)
+	require.NoError(i.t, err)
+
+	indexer, err := New(
+		log,
+		metrics.NewNoopCollector(),
+		db,
+		i.registers,
+		i.headers,
+		i.events,
+		i.collections,
+		i.transactions,
+		i.results,
+		flow.Testnet.Chain(),
+		derivedChainData,
+		collectionExecutedMetric,
+	)
 	require.NoError(i.t, err)
 	i.indexer = indexer
 	return i
@@ -660,11 +687,26 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	logger := zerolog.Nop()
 	metrics := metrics.NewNoopCollector()
 
+	derivedChainData, err := derived.NewDerivedChainData(derived.DefaultDerivedDataCacheSize)
+	require.NoError(t, err)
+
 	// this test makes sure index values for a single register are correctly updated and always last value is returned
 	t.Run("Single Index Value Changes", func(t *testing.T) {
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
-			index, err := New(logger, metrics, db, registers,
-				nil, nil, nil, nil, nil, nil)
+			index, err := New(
+				logger,
+				metrics,
+				db,
+				registers,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				flow.Testnet.Chain(),
+				derivedChainData,
+				nil,
+			)
 			require.NoError(t, err)
 
 			values := [][]byte{[]byte("1"), []byte("1"), []byte("2"), []byte("3"), []byte("4")}
@@ -685,8 +727,20 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// up to the specification script executor requires
 	t.Run("Missing Register", func(t *testing.T) {
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
-			index, err := New(logger, metrics, db, registers,
-				nil, nil, nil, nil, nil, nil)
+			index, err := New(
+				logger,
+				metrics,
+				db,
+				registers,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				flow.Testnet.Chain(),
+				derivedChainData,
+				nil,
+			)
 			require.NoError(t, err)
 
 			value, err := index.RegisterValue(registerID, 0)
@@ -700,8 +754,20 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// e.g. we index A{h(1) -> X}, A{h(2) -> Y}, when we request h(4) we get value Y
 	t.Run("Single Index Value At Later Heights", func(t *testing.T) {
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
-			index, err := New(logger, metrics, db, registers,
-				nil, nil, nil, nil, nil, nil)
+			index, err := New(
+				logger,
+				metrics,
+				db,
+				registers,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				flow.Testnet.Chain(),
+				derivedChainData,
+				nil,
+			)
 			require.NoError(t, err)
 
 			storeValues := [][]byte{[]byte("1"), []byte("2")}
@@ -732,8 +798,20 @@ func TestIndexerIntegration_StoreAndGet(t *testing.T) {
 	// this test makes sure we correctly handle weird payloads
 	t.Run("Empty and Nil Payloads", func(t *testing.T) {
 		pebbleStorage.RunWithRegistersStorageAtInitialHeights(t, 0, 0, func(registers *pebbleStorage.Registers) {
-			index, err := New(logger, metrics, db, registers,
-				nil, nil, nil, nil, nil, nil)
+			index, err := New(
+				logger,
+				metrics,
+				db,
+				registers,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				flow.Testnet.Chain(),
+				derivedChainData,
+				nil,
+			)
 			require.NoError(t, err)
 
 			require.NoError(t, index.indexRegisters(map[ledger.Path]*ledger.Payload{}, 1))

--- a/module/state_synchronization/indexer/indexer_test.go
+++ b/module/state_synchronization/indexer/indexer_test.go
@@ -169,11 +169,13 @@ func TestIndexer_Success(t *testing.T) {
 
 	test.setBlockDataByID(func(ID flow.Identifier) (*execution_data.BlockExecutionDataEntity, bool) {
 		trie := trieUpdateFixture(t)
+		collection := unittest.CollectionFixture(0)
 		ed := &execution_data.BlockExecutionData{
 			BlockID: ID,
-			ChunkExecutionDatas: []*execution_data.ChunkExecutionData{
-				{TrieUpdate: trie},
-			},
+			ChunkExecutionDatas: []*execution_data.ChunkExecutionData{{
+				Collection: &collection,
+				TrieUpdate: trie,
+			}},
 		}
 
 		// create this to capture the closure of the creation of block execution data, so we can for each returned
@@ -211,11 +213,13 @@ func TestIndexer_Failure(t *testing.T) {
 
 	test.setBlockDataByID(func(ID flow.Identifier) (*execution_data.BlockExecutionDataEntity, bool) {
 		trie := trieUpdateFixture(t)
+		collection := unittest.CollectionFixture(0)
 		ed := &execution_data.BlockExecutionData{
 			BlockID: ID,
-			ChunkExecutionDatas: []*execution_data.ChunkExecutionData{
-				{TrieUpdate: trie},
-			},
+			ChunkExecutionDatas: []*execution_data.ChunkExecutionData{{
+				Collection: &collection,
+				TrieUpdate: trie,
+			}},
 		}
 
 		// fail when trying to persist registers

--- a/module/state_synchronization/indexer/util.go
+++ b/module/state_synchronization/indexer/util.go
@@ -1,0 +1,126 @@
+package indexer
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/ccf"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/stdlib"
+
+	"github.com/onflow/flow-go/fvm/storage/derived"
+	"github.com/onflow/flow-go/fvm/storage/snapshot"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+var (
+	accountContractUpdated = flow.EventType(stdlib.AccountContractUpdatedEventType.ID())
+)
+
+// hasAuthorizedTransaction checks if the provided account was an authorizer in any of the transactions
+// within the provided collections.
+func hasAuthorizedTransaction(collections []*flow.Collection, address flow.Address) bool {
+	for _, collection := range collections {
+		for _, tx := range collection.Transactions {
+			for _, authorizer := range tx.Authorizers {
+				if authorizer == address {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// findContractUpdates returns a map of common.AddressLocation for all contracts updated within the
+// provided events.
+// No errors are expected during normal operation and indicate an invalid protocol event was encountered
+func findContractUpdates(events []flow.Event) (map[common.Location]struct{}, error) {
+	invalidatedPrograms := make(map[common.Location]struct{})
+	for _, event := range events {
+		if event.Type == accountContractUpdated {
+			location, err := parseAccountContractUpdated(&event)
+			if err != nil {
+				return nil, fmt.Errorf("could not parse account contract updated event: %w", err)
+			}
+			invalidatedPrograms[location] = struct{}{}
+		}
+	}
+	return invalidatedPrograms, nil
+}
+
+// parseAccountContractUpdated parses an account contract updated event and returns the address location.
+// No errors are expected during normal operation and indicate an invalid protocol event was encountered
+func parseAccountContractUpdated(event *flow.Event) (common.AddressLocation, error) {
+	payload, err := ccf.Decode(nil, event.Payload)
+	if err != nil {
+		return common.AddressLocation{}, fmt.Errorf("could not unmarshal event payload: %w", err)
+	}
+
+	cdcEvent, ok := payload.(cadence.Event)
+	if !ok {
+		return common.AddressLocation{}, fmt.Errorf("invalid event payload type: %T", payload)
+	}
+
+	address, ok := cdcEvent.Fields[0].(cadence.Address)
+	if !ok {
+		return common.AddressLocation{}, fmt.Errorf("invalid cadence type for address: %T", cdcEvent.Fields[0])
+	}
+
+	contractName, ok := cdcEvent.Fields[2].ToGoValue().(string)
+	if !ok {
+		return common.AddressLocation{}, fmt.Errorf("invalid cadence type for contract name: %T", cdcEvent.Fields[2])
+	}
+
+	return common.NewAddressLocation(nil, common.Address(address), contractName), nil
+}
+
+var _ derived.TransactionInvalidator = (*accessInvalidator)(nil)
+
+// accessInvalidator is a derived.TransactionInvalidator that invalidates programs and meter param overrides.
+type accessInvalidator struct {
+	programs            *programInvalidator
+	meterParamOverrides *meterParamOverridesInvalidator
+}
+
+func (inv *accessInvalidator) ProgramInvalidator() derived.ProgramInvalidator {
+	return inv.programs
+}
+
+func (inv *accessInvalidator) MeterParamOverridesInvalidator() derived.MeterParamOverridesInvalidator {
+	return inv.meterParamOverrides
+}
+
+var _ derived.ProgramInvalidator = (*programInvalidator)(nil)
+
+// programInvalidator is a derived.ProgramInvalidator that invalidates all programs or a specific set of programs.
+// this is used to invalidate all programs who's code was updated in a specific block.
+type programInvalidator struct {
+	invalidateAll bool
+	invalidated   map[common.Location]struct{}
+}
+
+func (inv *programInvalidator) ShouldInvalidateEntries() bool {
+	return inv.invalidateAll
+}
+
+func (inv *programInvalidator) ShouldInvalidateEntry(location common.AddressLocation, _ *derived.Program, _ *snapshot.ExecutionSnapshot) bool {
+	_, ok := inv.invalidated[location]
+	return inv.invalidateAll || ok
+}
+
+var _ derived.MeterParamOverridesInvalidator = (*meterParamOverridesInvalidator)(nil)
+
+// meterParamOverridesInvalidator is a derived.MeterParamOverridesInvalidator that invalidates meter param overrides.
+type meterParamOverridesInvalidator struct {
+	invalidateAll bool
+}
+
+func (inv *meterParamOverridesInvalidator) ShouldInvalidateEntries() bool {
+	return inv.invalidateAll
+}
+
+func (inv *meterParamOverridesInvalidator) ShouldInvalidateEntry(_ struct{}, _ derived.MeterParamOverrides, _ *snapshot.ExecutionSnapshot) bool {
+	return inv.invalidateAll
+}

--- a/module/state_synchronization/indexer/util_test.go
+++ b/module/state_synchronization/indexer/util_test.go
@@ -1,0 +1,100 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/encoding/ccf"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow/protobuf/go/flow/entities"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/onflow/flow-go/utils/unittest/generator"
+)
+
+// TestFindContractUpdates tests the findContractUpdates function returns all contract updates
+func TestFindContractUpdates(t *testing.T) {
+	t.Parallel()
+
+	g := generator.EventGenerator(generator.WithEncoding(entities.EventEncodingVersion_CCF_V0))
+
+	expectedAddress1 := unittest.RandomAddressFixture()
+	expected1 := common.NewAddressLocation(nil, common.Address(expectedAddress1), "TestContract1")
+
+	expectedAddress2 := unittest.RandomAddressFixture()
+	expected2 := common.NewAddressLocation(nil, common.Address(expectedAddress2), "TestContract2")
+
+	events := []flow.Event{
+		g.New(), // random event
+		contractUpdatedFixture(
+			t,
+			expected1.Address,
+			expected1.Name,
+		),
+		g.New(), // random event
+		g.New(), // random event
+		contractUpdatedFixture(
+			t,
+			expected2.Address,
+			expected2.Name,
+		),
+	}
+
+	updates, err := findContractUpdates(events)
+	require.NoError(t, err)
+
+	assert.Len(t, updates, 2)
+
+	_, ok := updates[expected1]
+	assert.Truef(t, ok, "could not find %s", expected1.ID())
+
+	_, ok = updates[expected2]
+	assert.Truef(t, ok, "could not find %s", expected2.ID())
+}
+
+func contractUpdatedFixture(t *testing.T, address common.Address, contractName string) flow.Event {
+	contractUpdateEventType := &cadence.EventType{
+		Location:            stdlib.AccountContractAddedEventType.Location,
+		QualifiedIdentifier: stdlib.AccountContractAddedEventType.QualifiedIdentifier(),
+		Fields: []cadence.Field{
+			{
+				Identifier: "address",
+				Type:       cadence.AddressType{},
+			},
+			{
+				Identifier: "codeHash",
+				Type:       cadence.AddressType{}, // actually a byte slice, but we're ignoring it anyway
+			},
+			{
+				Identifier: "contract",
+				Type:       cadence.StringType{},
+			},
+		},
+	}
+
+	contractString, err := cadence.NewString(contractName)
+	require.NoError(t, err)
+
+	testEvent := cadence.NewEvent(
+		[]cadence.Value{
+			cadence.NewAddress(address),
+			cadence.NewAddress(flow.EmptyAddress),
+			contractString,
+		}).WithType(contractUpdateEventType)
+
+	payload, err := ccf.Encode(testEvent)
+	require.NoError(t, err)
+
+	return flow.Event{
+		Type:             accountContractUpdated,
+		TransactionID:    unittest.IdentifierFixture(),
+		TransactionIndex: 0,
+		EventIndex:       0,
+		Payload:          payload,
+	}
+}

--- a/storage/pebble/cache.go
+++ b/storage/pebble/cache.go
@@ -1,0 +1,167 @@
+package pebble
+
+import (
+	"errors"
+	"fmt"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/storage"
+)
+
+const DefaultCacheSize = uint(10_000)
+
+type CacheType int
+
+const (
+	CacheTypeLRU CacheType = iota + 1
+	CacheTypeTwoQueue
+)
+
+func ParseCacheType(s string) (CacheType, error) {
+	switch s {
+	case CacheTypeLRU.String():
+		return CacheTypeLRU, nil
+	case CacheTypeTwoQueue.String():
+		return CacheTypeTwoQueue, nil
+	default:
+		return 0, errors.New("invalid cache type")
+	}
+}
+
+func (m CacheType) String() string {
+	switch m {
+	case CacheTypeLRU:
+		return "lru"
+	case CacheTypeTwoQueue:
+		return "2q"
+	default:
+		return ""
+	}
+}
+
+type CacheBackend interface {
+	Get(key string) (value flow.RegisterValue, ok bool)
+	Add(key string, value flow.RegisterValue)
+	Contains(key string) bool
+	Len() int
+	Remove(key string)
+}
+
+// wrapped is a wrapper around lru.Cache to implement CacheBackend
+// this is needed because the standard lru cache implementation provides additional features that
+// the 2Q cache do not. This standardizes the interface to allow swapping between types.
+type wrapped struct {
+	cache *lru.Cache[string, flow.RegisterValue]
+}
+
+func (c *wrapped) Get(key string) (value flow.RegisterValue, ok bool) {
+	return c.cache.Get(key)
+}
+func (c *wrapped) Add(key string, value flow.RegisterValue) {
+	_ = c.cache.Add(key, value)
+}
+func (c *wrapped) Contains(key string) bool {
+	return c.cache.Contains(key)
+}
+func (c *wrapped) Len() int {
+	return c.cache.Len()
+}
+func (c *wrapped) Remove(key string) {
+	_ = c.cache.Remove(key)
+}
+
+type ReadCache struct {
+	metrics  module.CacheMetrics
+	resource string
+	cache    CacheBackend
+	retrieve func(key string) (flow.RegisterValue, error)
+}
+
+func newReadCache(
+	collector module.CacheMetrics,
+	resourceName string,
+	cacheType CacheType,
+	cacheSize uint,
+	retrieve func(key string) (flow.RegisterValue, error),
+) (*ReadCache, error) {
+	cache, err := getCache(cacheType, int(cacheSize))
+	if err != nil {
+		return nil, fmt.Errorf("could not create cache: %w", err)
+	}
+
+	c := ReadCache{
+		metrics:  collector,
+		resource: resourceName,
+		cache:    cache,
+		retrieve: retrieve,
+	}
+	c.metrics.CacheEntries(c.resource, uint(c.cache.Len()))
+
+	return &c, nil
+}
+
+func getCache(cacheType CacheType, size int) (CacheBackend, error) {
+	switch cacheType {
+	case CacheTypeLRU:
+		cache, err := lru.New[string, flow.RegisterValue](size)
+		if err != nil {
+			return nil, err
+		}
+		return &wrapped{cache: cache}, nil
+	case CacheTypeTwoQueue:
+		return lru.New2Q[string, flow.RegisterValue](size)
+	default:
+		return nil, fmt.Errorf("unknown cache type: %d", cacheType)
+	}
+}
+
+// IsCached returns true if the key exists in the cache.
+// It DOES NOT check whether the key exists in the underlying data store.
+func (c *ReadCache) IsCached(key string) bool {
+	return c.cache.Contains(key)
+}
+
+// Get will try to retrieve the resource from cache first, and then from the
+// injected. During normal operations, the following error returns are expected:
+//   - `storage.ErrNotFound` if key is unknown.
+func (c *ReadCache) Get(key string) (flow.RegisterValue, error) {
+	resource, cached := c.cache.Get(key)
+	if cached {
+		c.metrics.CacheHit(c.resource)
+		if resource == nil {
+			return nil, storage.ErrNotFound
+		}
+		return resource, nil
+	}
+
+	// get it from the database
+	resource, err := c.retrieve(key)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			c.cache.Add(key, nil)
+			c.metrics.CacheEntries(c.resource, uint(c.cache.Len()))
+			c.metrics.CacheNotFound(c.resource)
+		}
+		return nil, fmt.Errorf("could not retrieve resource: %w", err)
+	}
+
+	c.metrics.CacheMiss(c.resource)
+
+	c.cache.Add(key, resource)
+	c.metrics.CacheEntries(c.resource, uint(c.cache.Len()))
+
+	return resource, nil
+}
+
+func (c *ReadCache) Remove(key string) {
+	c.cache.Remove(key)
+}
+
+// Insert will add a resource directly to the cache with the given ID
+func (c *ReadCache) Insert(key string, resource flow.RegisterValue) {
+	c.cache.Add(key, resource)
+	c.metrics.CacheEntries(c.resource, uint(c.cache.Len()))
+}

--- a/storage/pebble/lookup.go
+++ b/storage/pebble/lookup.go
@@ -116,6 +116,11 @@ func (h lookupKey) Bytes() []byte {
 	return h.encoded
 }
 
+// String returns the encoded lookup key as a string.
+func (h lookupKey) String() string {
+	return string(h.encoded)
+}
+
 // encodedUint64 encodes uint64 for storing as a pebble payload
 func encodedUint64(height uint64) []byte {
 	payload := make([]byte, 0, 8)

--- a/storage/pebble/registers_cache.go
+++ b/storage/pebble/registers_cache.go
@@ -1,0 +1,62 @@
+package pebble
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/storage"
+)
+
+const (
+	registerResourceName = "registers"
+)
+
+type RegistersCache struct {
+	*Registers
+	cache *ReadCache
+}
+
+var _ storage.RegisterIndex = (*RegistersCache)(nil)
+
+// NewRegistersCache wraps a read cache around Get requests to a underlying Registers object.
+func NewRegistersCache(registers *Registers, cacheType CacheType, size uint, metrics module.CacheMetrics) (*RegistersCache, error) {
+	if size == 0 {
+		return nil, errors.New("cache size cannot be 0")
+	}
+
+	cache, err := newReadCache(
+		metrics,
+		registerResourceName,
+		cacheType,
+		size,
+		func(key string) (flow.RegisterValue, error) {
+			return registers.lookupRegister([]byte(key))
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not create cache: %w", err)
+	}
+
+	return &RegistersCache{
+		Registers: registers,
+		cache:     cache,
+	}, nil
+}
+
+// Get returns the most recent updated payload for the given RegisterID.
+// "most recent" means the updates happens most recent up the given height.
+//
+// For example, if there are 2 values stored for register A at height 6 and 11, then
+// GetPayload(13, A) would return the value at height 11.
+//
+// - storage.ErrNotFound if no register values are found
+// - storage.ErrHeightNotIndexed if the requested height is out of the range of stored heights
+func (c *RegistersCache) Get(
+	reg flow.RegisterID,
+	height uint64,
+) (flow.RegisterValue, error) {
+	return c.cache.Get(newLookupKey(height, reg).String())
+}

--- a/utils/dsl/dsl.go
+++ b/utils/dsl/dsl.go
@@ -68,16 +68,24 @@ func (i Import) ToCadence() string {
 	return ""
 }
 
-type UpdateAccountCode struct {
-	Code string
-	Name string
+type SetAccountCode struct {
+	Code   string
+	Name   string
+	Update bool
 }
 
-func (u UpdateAccountCode) ToCadence() string {
+func (u SetAccountCode) ToCadence() string {
 
 	bytes := []byte(u.Code)
 
 	hexCode := hex.EncodeToString(bytes)
+
+	if u.Update {
+		return fmt.Sprintf(`
+		let code = "%s"
+        signer.contracts.update__experimental(name: "%s", code: code.decodeHex())
+    `, hexCode, u.Name)
+	}
 
 	return fmt.Sprintf(`
 		let code = "%s"


### PR DESCRIPTION
Backports the following changes from v0.33:
* https://github.com/onflow/flow-go/pull/5347
* https://github.com/onflow/flow-go/pull/5585

Add a simple cache for register lookups on Access nodes. This improves the performance of scripts that lookup frequently queried registers, like common contract code.

Add support for running the programs cache on Access nodes with script execution enabled. This improves overall script execution performance since the most common cadence contracts will be cached.