### PR TITLE
Sync atree inlining branch Cadence 1.0 and update to Cadence v1.0.0-preview-atree-register-inlining.25

### DIFF
--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -1227,6 +1227,62 @@ func TestCoreContractUsage(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
+	t.Run("&NonFungibleToken.Provider => auth(Withdraw) &{NonFungibleToken.Provider}", func(t *testing.T) {
+		t.Parallel()
+
+		systemContracts := systemcontracts.SystemContractsForChain(chainID)
+
+		const nonFungibleTokenContractName = "NonFungibleToken"
+		nonFungibleTokenContractLocation := common.NewAddressLocation(
+			nil,
+			common.Address(systemContracts.NonFungibleToken.Address),
+			nonFungibleTokenContractName,
+		)
+
+		const nonFungibleTokenProviderTypeQualifiedIdentifier = nonFungibleTokenContractName + ".Provider"
+
+		input := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.UnauthorizedAccess,
+			interpreter.NewInterfaceStaticType(
+				nil,
+				nonFungibleTokenContractLocation,
+				nonFungibleTokenProviderTypeQualifiedIdentifier,
+				nonFungibleTokenContractLocation.TypeID(nil, nonFungibleTokenProviderTypeQualifiedIdentifier),
+			),
+		)
+
+		const nonFungibleTokenWithdrawTypeQualifiedIdentifier = nonFungibleTokenContractName + ".Withdraw"
+		expected := interpreter.NewReferenceStaticType(
+			nil,
+			interpreter.NewEntitlementSetAuthorization(
+				nil,
+				func() []common.TypeID {
+					return []common.TypeID{
+						nonFungibleTokenContractLocation.TypeID(nil, nonFungibleTokenWithdrawTypeQualifiedIdentifier),
+					}
+				},
+				1,
+				sema.Conjunction,
+			),
+			interpreter.NewIntersectionStaticType(
+				nil,
+				[]*interpreter.InterfaceStaticType{
+					interpreter.NewInterfaceStaticType(
+						nil,
+						nonFungibleTokenContractLocation,
+						nonFungibleTokenProviderTypeQualifiedIdentifier,
+						nonFungibleTokenContractLocation.TypeID(nil, nonFungibleTokenProviderTypeQualifiedIdentifier),
+					),
+				},
+			),
+		)
+
+		actual := migrate(t, input)
+
+		require.Equal(t, expected, actual)
+	})
+
 	t.Run("&NonFungibleToken.Collection{NonFungibleToken.CollectionPublic} => &{NonFungibleToken.Collection}", func(t *testing.T) {
 		t.Parallel()
 

--- a/go.mod
+++ b/go.mod
@@ -47,12 +47,12 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.8.0-rc.1
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240429192223-e696a8e439b5
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240429192223-e696a8e439b5
-	github.com/onflow/flow-go-sdk v1.0.0-preview.24
+	github.com/onflow/flow-go-sdk v1.0.0-preview.25
 	github.com/onflow/flow/protobuf/go/flow v0.4.1-0.20240412170550-911321113030
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2151,8 +2151,8 @@ github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24 h1:IujMmOL+UcF/zbXTZBVDnL5juY2XwBqD+UWRnKgsELk=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24/go.mod h1:ZjfubL1kS8Q8i7/QcxCh3LR5RTiOTfDkY5AxodB4e0Q=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25 h1:CEIZeSsVwcXaRflpd/og/iTjnFi4Wt4rMkQog1fyJWk=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2167,8 +2167,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e h1:jl7SYAui/gYRmBofrY//Ln8ixRJwvLzvwLstNfRKmWY=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24 h1:Z3Q97UqVLmgjhMwgUkP0I/zWkrxWjzYFCqTMLYNFP8M=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24/go.mod h1:dcBUQSI0rFV7drO9L5yqa2X8MDS+wNQymq421OsZ/5g=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25 h1:wL/+cK7oxSww31qSqTpt1Yfr26c8hJ8YHh9nIdq6PlI=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25/go.mod h1:Px1fQdB7WFC0yhYsEM3rhKzuE+Zi8GpBjR4qVuDAwMA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140 h1:oTj4RGgfuJSSBE1aDVrlh6avxKBMraucpNtRg0K+yhg=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240429184308-40c3de711140 h1:7NwSIG4SEdm+96gr+Aaqx291jZ/Bqkxk/ghVnens9CU=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -196,12 +196,12 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.8.0-rc.1 // indirect
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24 // indirect
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240429192223-e696a8e439b5 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240429192223-e696a8e439b5 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e // indirect
 	github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-preview.24 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-preview.25 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240429184308-40c3de711140 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.1-0.20240412170550-911321113030 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2137,8 +2137,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
 github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24 h1:IujMmOL+UcF/zbXTZBVDnL5juY2XwBqD+UWRnKgsELk=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24/go.mod h1:ZjfubL1kS8Q8i7/QcxCh3LR5RTiOTfDkY5AxodB4e0Q=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25 h1:CEIZeSsVwcXaRflpd/og/iTjnFi4Wt4rMkQog1fyJWk=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2151,8 +2151,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e h1:jl7SYAui/gYRmBofrY//Ln8ixRJwvLzvwLstNfRKmWY=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24 h1:Z3Q97UqVLmgjhMwgUkP0I/zWkrxWjzYFCqTMLYNFP8M=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24/go.mod h1:dcBUQSI0rFV7drO9L5yqa2X8MDS+wNQymq421OsZ/5g=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25 h1:wL/+cK7oxSww31qSqTpt1Yfr26c8hJ8YHh9nIdq6PlI=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25/go.mod h1:Px1fQdB7WFC0yhYsEM3rhKzuE+Zi8GpBjR4qVuDAwMA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140 h1:oTj4RGgfuJSSBE1aDVrlh6avxKBMraucpNtRg0K+yhg=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240429184308-40c3de711140 h1:7NwSIG4SEdm+96gr+Aaqx291jZ/Bqkxk/ghVnens9CU=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.2-0.20240429192223-e696a8e439b5
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.2-0.20240429192223-e696a8e439b5
 	github.com/onflow/flow-emulator v1.0.0-preview.21.0.20240501034320-e644fcba11e2
 	github.com/onflow/flow-go v0.34.0-crescendo-preview.10-staged-contracts-3.0.20240501031941-53ca114d9c37
-	github.com/onflow/flow-go-sdk v1.0.0-preview.24
+	github.com/onflow/flow-go-sdk v1.0.0-preview.25
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.1-0.20240412170550-911321113030
 	github.com/onflow/go-ethereum v1.13.4

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2131,8 +2131,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
 github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24 h1:IujMmOL+UcF/zbXTZBVDnL5juY2XwBqD+UWRnKgsELk=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.24/go.mod h1:ZjfubL1kS8Q8i7/QcxCh3LR5RTiOTfDkY5AxodB4e0Q=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25 h1:CEIZeSsVwcXaRflpd/og/iTjnFi4Wt4rMkQog1fyJWk=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.25/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2147,8 +2147,8 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240424211859-3ff4c0fe2a1e/
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e h1:jl7SYAui/gYRmBofrY//Ln8ixRJwvLzvwLstNfRKmWY=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240424211859-3ff4c0fe2a1e/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24 h1:Z3Q97UqVLmgjhMwgUkP0I/zWkrxWjzYFCqTMLYNFP8M=
-github.com/onflow/flow-go-sdk v1.0.0-preview.24/go.mod h1:dcBUQSI0rFV7drO9L5yqa2X8MDS+wNQymq421OsZ/5g=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25 h1:wL/+cK7oxSww31qSqTpt1Yfr26c8hJ8YHh9nIdq6PlI=
+github.com/onflow/flow-go-sdk v1.0.0-preview.25/go.mod h1:Px1fQdB7WFC0yhYsEM3rhKzuE+Zi8GpBjR4qVuDAwMA=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140 h1:oTj4RGgfuJSSBE1aDVrlh6avxKBMraucpNtRg0K+yhg=
 github.com/onflow/flow-nft/lib/go/contracts v1.1.1-0.20240429184308-40c3de711140/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240429184308-40c3de711140 h1:7NwSIG4SEdm+96gr+Aaqx291jZ/Bqkxk/ghVnens9CU=


### PR DESCRIPTION
Same as #5834 for the atree inlining feature branch

Merge `feature/stable-cadence` into `feature/atree-inlining-cadence-v1.0`, and update to Cadence v1.0.0-preview-atree-register-inlining.25