### PR TITLE
Reuse static type cache across migrations in different accounts

### DIFF
--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 
+	"github.com/onflow/cadence/migrations"
 	"github.com/onflow/cadence/migrations/capcons"
 	"github.com/onflow/cadence/migrations/statictypes"
 	"github.com/onflow/cadence/runtime/common"
@@ -219,13 +220,18 @@ func NewCadence1ValueMigrations(
 	log zerolog.Logger,
 	rwf reporters.ReportWriterFactory,
 	opts Options,
-) (migrations []NamedMigration) {
+) (migs []NamedMigration) {
 
 	// Populated by CadenceLinkValueMigrator,
 	// used by CadenceCapabilityValueMigrator
 	capabilityMapping := &capcons.CapabilityMapping{}
 
 	errorMessageHandler := &errorMessageHandler{}
+
+	// As the proper migrated static type is computed for each old type,
+	// the entitlements migration will store that info in this cache to be
+	// reused across accounts for instances of the same types
+	staticTypeCache := &migrations.StaticTypeCache{}
 
 	// The value migrations are run as account-based migrations,
 	// i.e. the migrations are only given the payloads for the account to be migrated.
@@ -236,7 +242,7 @@ func NewCadence1ValueMigrations(
 
 	programs := make(map[common.Location]*interpreter.Program, 1000)
 
-	migrations = []NamedMigration{
+	migs = []NamedMigration{
 		{
 			Name: "check-contracts",
 			Migrate: NewContractCheckingMigration(
@@ -258,6 +264,7 @@ func NewCadence1ValueMigrations(
 				programs,
 				NewCadence1CompositeStaticTypeConverter(opts.ChainID),
 				NewCadence1InterfaceStaticTypeConverter(opts.ChainID),
+				staticTypeCache,
 				opts,
 			)
 		},
@@ -286,8 +293,8 @@ func NewCadence1ValueMigrations(
 
 		accountBasedMigration := migrationConstructor(opts)
 
-		migrations = append(
-			migrations,
+		migs = append(
+			migs,
 			NamedMigration{
 				Name: accountBasedMigration.name,
 				Migrate: NewAccountBasedMigration(

--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -255,6 +255,7 @@ func NewCadence1ValueMigrator(
 	programs map[runtime.Location]*interpreter.Program,
 	compositeTypeConverter statictypes.CompositeTypeConverterFunc,
 	interfaceTypeConverter statictypes.InterfaceTypeConverterFunc,
+	staticTypeCache *migrations.StaticTypeCache,
 	opts Options,
 ) *CadenceBaseMigrator {
 
@@ -279,7 +280,7 @@ func NewCadence1ValueMigrator(
 				statictypes.NewStaticTypeMigration().
 					WithCompositeTypeConverter(compositeTypeConverter).
 					WithInterfaceTypeConverter(interfaceTypeConverter),
-				entitlements.NewEntitlementsMigration(inter),
+				entitlements.NewEntitlementsMigrationWithCache(inter, staticTypeCache),
 				string_normalization.NewStringNormalizingMigration(),
 			}
 		},


### PR DESCRIPTION
Reuse the cache added in https://github.com/onflow/cadence/pull/3232 across different accounts in the entitlements migration