### PR TITLE
[EVM] Add decoder for blocks without timestamp

### DIFF
--- a/fvm/evm/handler/blockstore_test.go
+++ b/fvm/evm/handler/blockstore_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	gethRLP "github.com/onflow/go-ethereum/rlp"
 	"math/big"
 	"testing"
 
@@ -69,4 +70,53 @@ func TestBlockStore(t *testing.T) {
 
 	})
 
+}
+
+// This test reproduces a state before a breaking change on the Block type,
+// which added a timestamp, then it adds new blocks and makes sure the retrival
+// and storage of blocks works as it should, the breaking change was introduced
+// in this PR https://github.com/onflow/flow-go/pull/5660
+func TestBlockStore_AddedTimestamp(t *testing.T) {
+	testutils.RunWithTestBackend(t, func(backend *testutils.TestBackend) {
+		testutils.RunWithTestFlowEVMRootAddress(t, backend, func(root flow.Address) {
+
+			bs := handler.NewBlockStore(backend, root)
+
+			// block type before breaking change
+			type blockNoTimestamp struct {
+				ParentBlockHash   gethCommon.Hash
+				Height            uint64
+				TotalSupply       *big.Int
+				ReceiptRoot       gethCommon.Hash
+				TransactionHashes []gethCommon.Hash
+				TotalGasUsed      uint64
+			}
+
+			g := types.GenesisBlock
+			h, err := g.Hash()
+			require.NoError(t, err)
+
+			b := blockNoTimestamp{
+				ParentBlockHash: h,
+				Height:          1,
+				TotalSupply:     g.TotalSupply,
+				ReceiptRoot:     g.ReceiptRoot,
+			}
+			blockBytes, err := gethRLP.EncodeToBytes(b)
+			require.NoError(t, err)
+
+			// store a block without timestamp, simulate existing state before the breaking change
+			err = backend.SetValue(root[:], []byte(handler.BlockStoreLatestBlockKey), blockBytes)
+			require.NoError(t, err)
+
+			block, err := bs.LatestBlock()
+			require.NoError(t, err)
+
+			require.Empty(t, block.Timestamp)
+			require.Equal(t, b.Height, block.Height)
+			require.Equal(t, b.ParentBlockHash, block.ParentBlockHash)
+			require.Equal(t, b.TotalSupply, block.TotalSupply)
+			require.Equal(t, b.ReceiptRoot, block.ReceiptRoot)
+		})
+	})
 }

--- a/fvm/evm/handler/blockstore_test.go
+++ b/fvm/evm/handler/blockstore_test.go
@@ -117,6 +117,21 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			require.Equal(t, b.ParentBlockHash, block.ParentBlockHash)
 			require.Equal(t, b.TotalSupply, block.TotalSupply)
 			require.Equal(t, b.ReceiptRoot, block.ReceiptRoot)
+
+			bp, err := bs.BlockProposal()
+			require.NoError(t, err)
+
+			blockBytes, err = bp.ToBytes()
+			require.NoError(t, err)
+
+			err = backend.SetValue(root[:], []byte(handler.BlockStoreLatestBlockKey), blockBytes)
+			require.NoError(t, err)
+
+			bb, err := bs.LatestBlock()
+			require.NoError(t, err)
+			require.NotNil(t, bb.ParentBlockHash)
+			require.NotNil(t, bb.Timestamp)
+			require.Equal(t, b.Height+1, bb.Height)
 		})
 	})
 }

--- a/fvm/evm/handler/blockstore_test.go
+++ b/fvm/evm/handler/blockstore_test.go
@@ -1,11 +1,11 @@
 package handler_test
 
 import (
-	gethRLP "github.com/onflow/go-ethereum/rlp"
 	"math/big"
 	"testing"
 
 	gethCommon "github.com/onflow/go-ethereum/common"
+	gethRLP "github.com/onflow/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/fvm/evm/handler"

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -114,7 +114,7 @@ func NewBlockFromBytes(encoded []byte) (*Block, error) {
 			TransactionHashes []gethCommon.Hash
 			TotalGasUsed      uint64
 		}{}
-		if e := gethRLP.DecodeBytes(encoded, r); e != nil {
+		if e := gethRLP.DecodeBytes(encoded, &r); e != nil {
 			// if both error out, return first error since it's more relevant
 			return nil, err
 		}


### PR DESCRIPTION
Closes: #5846 

Add RLP decoding of blocks before the breaking change of introducing new `timestamp` field. This was introduced in the PR: https://github.com/onflow/flow-go/pull/5660 and it created an issue for the blockstore to decode blocks that are lacking the timestamp field.