### PR TITLE
Add new TPS loader load type

### DIFF
--- a/integration/benchmark/load/load_type.go
+++ b/integration/benchmark/load/load_type.go
@@ -86,6 +86,8 @@ func CreateLoadType(log zerolog.Logger, t LoadType) Load {
 		return ExecDataHeavyLoad
 	case TokenTransferLoadType:
 		return NewTokenTransferLoad()
+	case TokenTransferMultiLoadType:
+		return NewTokenTransferMultiLoad()
 	case AddKeysLoadType:
 		return NewAddKeysLoad()
 	case EVMTransferLoadType:

--- a/integration/benchmark/load/load_type.go
+++ b/integration/benchmark/load/load_type.go
@@ -22,10 +22,11 @@ const (
 	// TODO: port this load type from old code
 	// ConstExecCostLoadType LoadType = "const-exec" // for an empty transactions with various tx arguments
 
-	TokenTransferLoadType LoadType = "token-transfer"
-	AddKeysLoadType       LoadType = "add-keys"
-	EVMTransferLoadType   LoadType = "evm-transfer"
-	CreateAccount         LoadType = "create-account"
+	TokenTransferLoadType      LoadType = "token-transfer"
+	TokenTransferMultiLoadType LoadType = "token-transfer-multi"
+	AddKeysLoadType            LoadType = "add-keys"
+	EVMTransferLoadType        LoadType = "evm-transfer"
+	CreateAccount              LoadType = "create-account"
 )
 
 type LoadContext struct {

--- a/integration/benchmark/load/load_type_test.go
+++ b/integration/benchmark/load/load_type_test.go
@@ -43,6 +43,7 @@ func TestLoadTypes(t *testing.T) {
 		load.LedgerHeavyLoad,
 		load.ExecDataHeavyLoad,
 		load.NewTokenTransferLoad(),
+		load.NewTokenTransferMultiLoad(),
 		load.NewAddKeysLoad(),
 		evmLoad,
 		load.NewCreateAccountLoad(),

--- a/integration/benchmark/load/token_transfer_multiple_load.go
+++ b/integration/benchmark/load/token_transfer_multiple_load.go
@@ -1,10 +1,12 @@
 package load
 
 import (
-	"github.com/onflow/cadence"
-	"github.com/onflow/flow-go/model/flow"
-	"github.com/rs/zerolog"
 	"sync"
+
+	"github.com/onflow/cadence"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
 
 	flowsdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go/fvm/systemcontracts"

--- a/integration/benchmark/load/token_transfer_multiple_load.go
+++ b/integration/benchmark/load/token_transfer_multiple_load.go
@@ -1,0 +1,91 @@
+package load
+
+import (
+	"github.com/onflow/cadence"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/rs/zerolog"
+	"sync"
+
+	flowsdk "github.com/onflow/flow-go-sdk"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/integration/benchmark/account"
+	"github.com/onflow/flow-go/integration/benchmark/scripts"
+)
+
+type TokenTransferMultiLoad struct {
+	tokensPerTransfer   cadence.UFix64
+	accountsPerTransfer uint
+
+	destinationAddresses      []flow.Address
+	setupDestinationAddresses sync.Once
+}
+
+func NewTokenTransferMultiLoad() *TokenTransferMultiLoad {
+	return &TokenTransferMultiLoad{
+		tokensPerTransfer:   cadence.UFix64(100),
+		accountsPerTransfer: 100,
+	}
+}
+
+var _ Load = (*TokenTransferMultiLoad)(nil)
+
+func (l *TokenTransferMultiLoad) Type() LoadType {
+	return TokenTransferMultiLoadType
+}
+
+func (l *TokenTransferMultiLoad) Setup(_ zerolog.Logger, _ LoadContext) error {
+	return nil
+}
+
+func (l *TokenTransferMultiLoad) Load(log zerolog.Logger, lc LoadContext) error {
+	return sendSimpleTransaction(
+		log,
+		lc,
+		func(
+			log zerolog.Logger,
+			lc LoadContext,
+			acc *account.FlowAccount,
+		) (*flowsdk.Transaction, error) {
+			sc := systemcontracts.SystemContractsForChain(lc.ChainID)
+
+			// we only need to get the destination addresses once
+			l.setupDestinationAddresses.Do(func() {
+				destinationSDKAddresses, err := lc.GetAddresses(l.accountsPerTransfer)
+				if err != nil {
+					log.Warn().Err(err).Msg("failed to get destination addresses")
+					l.destinationAddresses = make([]flow.Address, l.accountsPerTransfer)
+					for i := 0; uint(i) < l.accountsPerTransfer; i++ {
+						l.destinationAddresses[i] = sc.FlowServiceAccount.Address
+					}
+				}
+
+				l.destinationAddresses = apply(
+					destinationSDKAddresses,
+					func(a flowsdk.Address) flow.Address {
+						return flow.ConvertAddress(a)
+					})
+			})
+			// get another account to send tokens to
+
+			transferTx, err := scripts.TokenTransferMultiTransaction(
+				sc.FungibleToken.Address,
+				sc.FlowToken.Address,
+				l.destinationAddresses,
+				l.tokensPerTransfer)
+			if err != nil {
+				return nil, err
+			}
+
+			return transferTx, nil
+		},
+	)
+}
+
+func apply[I any, O any](input []I, transform func(I) O) []O {
+	output := make([]O, 0, len(input))
+	for _, i := range input {
+		output = append(output, transform(i))
+	}
+	return output
+
+}

--- a/integration/benchmark/scripts/tokenTransferMultiTransaction.cdc
+++ b/integration/benchmark/scripts/tokenTransferMultiTransaction.cdc
@@ -1,0 +1,23 @@
+import FungibleToken from 0xFUNGIBLETOKENADDRESS
+import FlowToken from 0xTOKENADDRESS
+
+transaction(amount: UFix64, to: [Address]) {
+    let sentVault: @FungibleToken.Vault
+
+    prepare(signer: AuthAccount) {
+        let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
+			?? panic("Could not borrow reference to the owner's Vault!")
+        self.sentVault <- vaultRef.withdraw(amount: amount * UFix64(to.length))
+    }
+
+    execute {
+        for recipient in to {
+            let receiverRef =  getAccount(recipient)
+                .getCapability(/public/flowTokenReceiver)
+                .borrow<&{FungibleToken.Receiver}>()
+                ?? panic("Could not borrow receiver reference to the recipient's Vault")
+            receiverRef.deposit(from: <-self.sentVault.withdraw(amount: amount))
+        }
+        destroy self.sentVault
+    }
+}

--- a/integration/benchmark/scripts/tokenTransferMultiTransaction.cdc
+++ b/integration/benchmark/scripts/tokenTransferMultiTransaction.cdc
@@ -2,19 +2,18 @@ import FungibleToken from 0xFUNGIBLETOKENADDRESS
 import FlowToken from 0xTOKENADDRESS
 
 transaction(amount: UFix64, to: [Address]) {
-    let sentVault: @FungibleToken.Vault
+    let sentVault: @{FungibleToken.Vault}
 
-    prepare(signer: AuthAccount) {
-        let vaultRef = signer.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
-			?? panic("Could not borrow reference to the owner's Vault!")
-        self.sentVault <- vaultRef.withdraw(amount: amount * UFix64(to.length))
+    prepare(signer: auth(BorrowValue) &Account) {
+        let vaultRef = signer.storage.borrow<auth(FungibleToken.Withdraw) &FlowToken.Vault>(from: /storage/flowTokenVault)
+            ?? panic("Could not borrow reference to the owner's Vault!")
+        self.sentVault <- vaultRef.withdraw(amount: amount*UFix64(to.length))
     }
 
     execute {
         for recipient in to {
             let receiverRef =  getAccount(recipient)
-                .getCapability(/public/flowTokenReceiver)
-                .borrow<&{FungibleToken.Receiver}>()
+                .capabilities.borrow<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
                 ?? panic("Could not borrow receiver reference to the recipient's Vault")
             receiverRef.deposit(from: <-self.sentVault.withdraw(amount: amount))
         }

--- a/integration/benchmark/server/load-config.yml
+++ b/integration/benchmark/server/load-config.yml
@@ -3,6 +3,11 @@ token-transfer:
   tps_initial: 800
   tps_min: 1
   tps_max: 1200
+token-transfer-multi:
+  load_type: token-transfer-multi
+  tps_initial: 20
+  tps_min: 1
+  tps_max: 1200
 create-account:
   load_type: create-account
   tps_initial: 600


### PR DESCRIPTION
closes: https://github.com/onflow/flow-go/issues/5329 

Adding a new load type to the TPS automation:
- **token-transfer-multi**: Multiple flow token transfers in one transaction. By default 100, but can be settable in the future.