### PR TITLE
Enable attachments on mainnet

### DIFF
--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -231,9 +231,8 @@ func DefaultFVMOptions(chainID flow.ChainID, cadenceTracing bool, extensiveTraci
 			reusableRuntime.NewReusableCadenceRuntimePool(
 				ReusableCadenceRuntimePoolSize,
 				runtime.Config{
-					TracingEnabled: cadenceTracing,
-					// Attachments are enabled everywhere except for Mainnet
-					AttachmentsEnabled: chainID != flow.Mainnet,
+					TracingEnabled:     cadenceTracing,
+					AttachmentsEnabled: true,
 				},
 			)),
 		fvm.WithEVMEnabled(true),

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2404,7 +2404,7 @@ func TestAttachments(t *testing.T) {
 					reusableRuntime.NewReusableCadenceRuntimePool(
 						1,
 						runtime.Config{
-							AttachmentsEnabled: attachmentsEnabled,
+							AttachmentsEnabled: true,
 						},
 					),
 				),

--- a/fvm/fvm_test.go
+++ b/fvm/fvm_test.go
@@ -2396,28 +2396,28 @@ func TestInteractionLimit(t *testing.T) {
 }
 
 func TestAttachments(t *testing.T) {
-	test := func(t *testing.T, attachmentsEnabled bool) {
-		newVMTest().
-			withBootstrapProcedureOptions().
-			withContextOptions(
-				fvm.WithReusableCadenceRuntimePool(
-					reusableRuntime.NewReusableCadenceRuntimePool(
-						1,
-						runtime.Config{
-							AttachmentsEnabled: true,
-						},
-					),
+
+	newVMTest().
+		withBootstrapProcedureOptions().
+		withContextOptions(
+			fvm.WithReusableCadenceRuntimePool(
+				reusableRuntime.NewReusableCadenceRuntimePool(
+					1,
+					runtime.Config{
+						AttachmentsEnabled: true,
+					},
 				),
-			).
-			run(
-				func(
-					t *testing.T,
-					vm fvm.VM,
-					chain flow.Chain,
-					ctx fvm.Context,
-					snapshotTree snapshot.SnapshotTree,
-				) {
-					script := fvm.Script([]byte(`
+			),
+		).
+		run(
+			func(
+				t *testing.T,
+				vm fvm.VM,
+				chain flow.Chain,
+				ctx fvm.Context,
+				snapshotTree snapshot.SnapshotTree,
+			) {
+				script := fvm.Script([]byte(`
 
 						access(all) resource R {}
 
@@ -2430,29 +2430,13 @@ func TestAttachments(t *testing.T) {
 						}
 					`))
 
-					_, output, err := vm.Run(ctx, script, snapshotTree)
-					require.NoError(t, err)
+				_, output, err := vm.Run(ctx, script, snapshotTree)
+				require.NoError(t, err)
+				require.NoError(t, output.Err)
 
-					if attachmentsEnabled {
-						require.NoError(t, output.Err)
-					} else {
-						require.Error(t, output.Err)
-						require.ErrorContains(
-							t,
-							output.Err,
-							"attachments are not enabled")
-					}
-				},
-			)(t)
-	}
+			},
+		)(t)
 
-	t.Run("attachments enabled", func(t *testing.T) {
-		test(t, true)
-	})
-
-	t.Run("attachments disabled", func(t *testing.T) {
-		test(t, false)
-	})
 }
 
 func TestCapabilityControllers(t *testing.T) {


### PR DESCRIPTION
These are unblocked by Cadence 1.0, and can be enabled with its release