### PR TITLE
[EVM] Fix decoding blocks with no total gas used

### DIFF
--- a/fvm/evm/handler/blockstore_test.go
+++ b/fvm/evm/handler/blockstore_test.go
@@ -73,7 +73,8 @@ func TestBlockStore(t *testing.T) {
 }
 
 // This test reproduces a state before a breaking change on the Block type,
-// which added a timestamp, then it adds new blocks and makes sure the retrival
+// which added a timestamp and total gas used,
+// then it adds new blocks and makes sure the retrival
 // and storage of blocks works as it should, the breaking change was introduced
 // in this PR https://github.com/onflow/flow-go/pull/5660
 func TestBlockStore_AddedTimestamp(t *testing.T) {
@@ -82,21 +83,20 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 
 			bs := handler.NewBlockStore(backend, root)
 
-			// block type before breaking change
-			type blockNoTimestamp struct {
+			// block type before breaking change (no timestamp and total gas used)
+			type oldBlockV1 struct {
 				ParentBlockHash   gethCommon.Hash
 				Height            uint64
 				TotalSupply       *big.Int
 				ReceiptRoot       gethCommon.Hash
 				TransactionHashes []gethCommon.Hash
-				TotalGasUsed      uint64
 			}
 
 			g := types.GenesisBlock
 			h, err := g.Hash()
 			require.NoError(t, err)
 
-			b := blockNoTimestamp{
+			b := oldBlockV1{
 				ParentBlockHash: h,
 				Height:          1,
 				TotalSupply:     g.TotalSupply,
@@ -113,10 +113,45 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Empty(t, block.Timestamp)
+			require.Empty(t, block.TotalGasUsed)
 			require.Equal(t, b.Height, block.Height)
 			require.Equal(t, b.ParentBlockHash, block.ParentBlockHash)
 			require.Equal(t, b.TotalSupply, block.TotalSupply)
 			require.Equal(t, b.ReceiptRoot, block.ReceiptRoot)
+
+			// added timestamp
+			type oldBlockV2 struct {
+				ParentBlockHash   gethCommon.Hash
+				Height            uint64
+				TotalSupply       *big.Int
+				ReceiptRoot       gethCommon.Hash
+				TransactionHashes []gethCommon.Hash
+				Timestamp         uint64
+			}
+
+			b2 := oldBlockV2{
+				ParentBlockHash: h,
+				Height:          2,
+				TotalSupply:     g.TotalSupply,
+				ReceiptRoot:     g.ReceiptRoot,
+				Timestamp:       1,
+			}
+			blockBytes2, err := gethRLP.EncodeToBytes(b2)
+			require.NoError(t, err)
+
+			// store a block without timestamp, simulate existing state before the breaking change
+			err = backend.SetValue(root[:], []byte(handler.BlockStoreLatestBlockKey), blockBytes2)
+			require.NoError(t, err)
+
+			block2, err := bs.LatestBlock()
+			require.NoError(t, err)
+
+			require.Empty(t, block2.TotalGasUsed)
+			require.Equal(t, b2.Height, block2.Height)
+			require.Equal(t, b2.ParentBlockHash, block2.ParentBlockHash)
+			require.Equal(t, b2.TotalSupply, block2.TotalSupply)
+			require.Equal(t, b2.ReceiptRoot, block2.ReceiptRoot)
+			require.Equal(t, b2.Timestamp, block2.Timestamp)
 
 			bp, err := bs.BlockProposal()
 			require.NoError(t, err)
@@ -130,8 +165,9 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			bb, err := bs.LatestBlock()
 			require.NoError(t, err)
 			require.NotNil(t, bb.ParentBlockHash)
+			require.NotNil(t, bb.TotalGasUsed)
 			require.NotNil(t, bb.Timestamp)
-			require.Equal(t, b.Height+1, bb.Height)
+			require.Equal(t, b2.Height+1, bb.Height)
 		})
 	})
 }


### PR DESCRIPTION
This PR fixes decoding of blocks that do have timestamp field but not yet have total gas used field. 

There was a period when these blocks were stored on previewnet and we need to handle decoding of such types.