### PR TITLE
[EVM] Support decoding of all previous block types

### DIFF
--- a/fvm/evm/handler/blockstore_test.go
+++ b/fvm/evm/handler/blockstore_test.go
@@ -87,7 +87,9 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			type oldBlockV1 struct {
 				ParentBlockHash   gethCommon.Hash
 				Height            uint64
-				TotalSupply       *big.Int
+				UUIDIndex         uint64
+				TotalSupply       uint64
+				StateRoot         gethCommon.Hash
 				ReceiptRoot       gethCommon.Hash
 				TransactionHashes []gethCommon.Hash
 			}
@@ -97,10 +99,13 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			require.NoError(t, err)
 
 			b := oldBlockV1{
-				ParentBlockHash: h,
-				Height:          1,
-				TotalSupply:     g.TotalSupply,
-				ReceiptRoot:     g.ReceiptRoot,
+				ParentBlockHash:   h,
+				Height:            1,
+				ReceiptRoot:       g.ReceiptRoot,
+				UUIDIndex:         123,
+				TotalSupply:       1,
+				StateRoot:         h,
+				TransactionHashes: []gethCommon.Hash{h},
 			}
 			blockBytes, err := gethRLP.EncodeToBytes(b)
 			require.NoError(t, err)
@@ -116,17 +121,16 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			require.Empty(t, block.TotalGasUsed)
 			require.Equal(t, b.Height, block.Height)
 			require.Equal(t, b.ParentBlockHash, block.ParentBlockHash)
-			require.Equal(t, b.TotalSupply, block.TotalSupply)
 			require.Equal(t, b.ReceiptRoot, block.ReceiptRoot)
 
 			// added timestamp
 			type oldBlockV2 struct {
 				ParentBlockHash   gethCommon.Hash
 				Height            uint64
+				Timestamp         uint64
 				TotalSupply       *big.Int
 				ReceiptRoot       gethCommon.Hash
 				TransactionHashes []gethCommon.Hash
-				Timestamp         uint64
 			}
 
 			b2 := oldBlockV2{

--- a/fvm/evm/handler/blockstore_test.go
+++ b/fvm/evm/handler/blockstore_test.go
@@ -73,7 +73,8 @@ func TestBlockStore(t *testing.T) {
 }
 
 // This test reproduces a state before a breaking change on the Block type,
-// which added a timestamp, then it adds new blocks and makes sure the retrival
+// which added a timestamp and total gas used,
+// then it adds new blocks and makes sure the retrival
 // and storage of blocks works as it should, the breaking change was introduced
 // in this PR https://github.com/onflow/flow-go/pull/5660
 func TestBlockStore_AddedTimestamp(t *testing.T) {
@@ -82,21 +83,20 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 
 			bs := handler.NewBlockStore(backend, root)
 
-			// block type before breaking change
-			type blockNoTimestamp struct {
+			// block type before breaking change (no timestamp and total gas used)
+			type oldBlockV1 struct {
 				ParentBlockHash   gethCommon.Hash
 				Height            uint64
 				TotalSupply       *big.Int
 				ReceiptRoot       gethCommon.Hash
 				TransactionHashes []gethCommon.Hash
-				TotalGasUsed      uint64
 			}
 
 			g := types.GenesisBlock
 			h, err := g.Hash()
 			require.NoError(t, err)
 
-			b := blockNoTimestamp{
+			b := oldBlockV1{
 				ParentBlockHash: h,
 				Height:          1,
 				TotalSupply:     g.TotalSupply,
@@ -113,10 +113,45 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Empty(t, block.Timestamp)
+			require.Empty(t, block.TotalGasUsed)
 			require.Equal(t, b.Height, block.Height)
 			require.Equal(t, b.ParentBlockHash, block.ParentBlockHash)
 			require.Equal(t, b.TotalSupply, block.TotalSupply)
 			require.Equal(t, b.ReceiptRoot, block.ReceiptRoot)
+
+			// added timestamp
+			type oldBlockV2 struct {
+				ParentBlockHash   gethCommon.Hash
+				Height            uint64
+				TotalSupply       *big.Int
+				ReceiptRoot       gethCommon.Hash
+				TransactionHashes []gethCommon.Hash
+				Timestamp         uint64
+			}
+
+			b2 := oldBlockV2{
+				ParentBlockHash: h,
+				Height:          2,
+				TotalSupply:     g.TotalSupply,
+				ReceiptRoot:     g.ReceiptRoot,
+				Timestamp:       1,
+			}
+			blockBytes2, err := gethRLP.EncodeToBytes(b2)
+			require.NoError(t, err)
+
+			// store a block without timestamp, simulate existing state before the breaking change
+			err = backend.SetValue(root[:], []byte(handler.BlockStoreLatestBlockKey), blockBytes2)
+			require.NoError(t, err)
+
+			block2, err := bs.LatestBlock()
+			require.NoError(t, err)
+
+			require.Empty(t, block2.TotalGasUsed)
+			require.Equal(t, b2.Height, block2.Height)
+			require.Equal(t, b2.ParentBlockHash, block2.ParentBlockHash)
+			require.Equal(t, b2.TotalSupply, block2.TotalSupply)
+			require.Equal(t, b2.ReceiptRoot, block2.ReceiptRoot)
+			require.Equal(t, b2.Timestamp, block2.Timestamp)
 
 			bp, err := bs.BlockProposal()
 			require.NoError(t, err)
@@ -130,8 +165,9 @@ func TestBlockStore_AddedTimestamp(t *testing.T) {
 			bb, err := bs.LatestBlock()
 			require.NoError(t, err)
 			require.NotNil(t, bb.ParentBlockHash)
+			require.NotNil(t, bb.TotalGasUsed)
 			require.NotNil(t, bb.Timestamp)
-			require.Equal(t, b.Height+1, bb.Height)
+			require.Equal(t, b2.Height+1, bb.Height)
 		})
 	})
 }

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -131,10 +131,10 @@ func NewBlockFromBytes(encoded []byte) (*Block, error) {
 		v1 := struct {
 			ParentBlockHash   gethCommon.Hash
 			Height            uint64
+			Timestamp         uint64
 			TotalSupply       *big.Int
 			ReceiptRoot       gethCommon.Hash
 			TransactionHashes []gethCommon.Hash
-			Timestamp         uint64
 		}{}
 		if e := gethRLP.DecodeBytes(encoded, &v1); e == nil {
 			return &Block{
@@ -163,3 +163,74 @@ var GenesisBlock = &Block{
 }
 
 var GenesisBlockHash, _ = GenesisBlock.Hash()
+
+// Below block type section, defines earlier block types,
+// this is being used to decode blocks that were stored
+// before block type changes. It allows us to still decode
+// a block that would otherwise be invalid if decoded into
+// latest version of the above Block type.
+
+type blockV0 struct {
+	ParentBlockHash gethCommon.Hash
+	Height          uint64
+	UUIDIndex       uint64
+	TotalSupply     uint64
+	StateRoot       gethCommon.Hash
+	ReceiptRoot     gethCommon.Hash
+}
+
+// adds TransactionHashes
+
+type blockV1 struct {
+	blockV0
+	TransactionHashes []gethCommon.Hash
+}
+
+// removes UUIDIndex
+
+type blockV2 struct {
+	ParentBlockHash   gethCommon.Hash
+	Height            uint64
+	TotalSupply       uint64
+	StateRoot         gethCommon.Hash
+	ReceiptRoot       gethCommon.Hash
+	TransactionHashes []gethCommon.Hash
+}
+
+// removes state root
+
+type blockV3 struct {
+	ParentBlockHash   gethCommon.Hash
+	Height            uint64
+	TotalSupply       uint64
+	ReceiptRoot       gethCommon.Hash
+	TransactionHashes []gethCommon.Hash
+}
+
+// change total supply type
+
+type blockV4 struct {
+	ParentBlockHash   gethCommon.Hash
+	Height            uint64
+	TotalSupply       *big.Int
+	ReceiptRoot       gethCommon.Hash
+	TransactionHashes []gethCommon.Hash
+}
+
+// adds timestamp
+
+type blockV5 struct {
+	ParentBlockHash   gethCommon.Hash
+	Height            uint64
+	Timestamp         uint64
+	TotalSupply       *big.Int
+	ReceiptRoot       gethCommon.Hash
+	TransactionHashes []gethCommon.Hash
+}
+
+// adds total gas used
+
+type blockV6 struct {
+	blockV5
+	TotalGasUsed uint64
+}

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -198,7 +198,7 @@ type blockV5 struct {
 // migrated block, otherwise it will return nil.
 func decodeBlockBreakingChanges(encoded []byte) *Block {
 	b0 := &blockV0{}
-	if e := gethRLP.DecodeBytes(encoded, b0); e == nil {
+	if err := gethRLP.DecodeBytes(encoded, b0); err == nil {
 		return &Block{
 			ParentBlockHash: b0.ParentBlockHash,
 			Height:          b0.Height,
@@ -208,7 +208,7 @@ func decodeBlockBreakingChanges(encoded []byte) *Block {
 	}
 
 	b1 := &blockV1{}
-	if e := gethRLP.DecodeBytes(encoded, b1); e == nil {
+	if err := gethRLP.DecodeBytes(encoded, b1); err == nil {
 		return &Block{
 			ParentBlockHash:   b1.ParentBlockHash,
 			Height:            b1.Height,
@@ -219,7 +219,7 @@ func decodeBlockBreakingChanges(encoded []byte) *Block {
 	}
 
 	b2 := &blockV2{}
-	if e := gethRLP.DecodeBytes(encoded, b2); e == nil {
+	if err := gethRLP.DecodeBytes(encoded, b2); err == nil {
 		return &Block{
 			ParentBlockHash:   b2.ParentBlockHash,
 			Height:            b2.Height,
@@ -230,7 +230,7 @@ func decodeBlockBreakingChanges(encoded []byte) *Block {
 	}
 
 	b3 := &blockV3{}
-	if e := gethRLP.DecodeBytes(encoded, b3); e == nil {
+	if err := gethRLP.DecodeBytes(encoded, b3); err == nil {
 		return &Block{
 			ParentBlockHash:   b3.ParentBlockHash,
 			Height:            b3.Height,
@@ -241,7 +241,7 @@ func decodeBlockBreakingChanges(encoded []byte) *Block {
 	}
 
 	b4 := &blockV4{}
-	if e := gethRLP.DecodeBytes(encoded, b4); e == nil {
+	if err := gethRLP.DecodeBytes(encoded, b4); err == nil {
 		return &Block{
 			ParentBlockHash:   b4.ParentBlockHash,
 			Height:            b4.Height,
@@ -252,7 +252,7 @@ func decodeBlockBreakingChanges(encoded []byte) *Block {
 	}
 
 	b5 := &blockV5{}
-	if e := gethRLP.DecodeBytes(encoded, b5); e == nil {
+	if err := gethRLP.DecodeBytes(encoded, b5); err == nil {
 		return &Block{
 			ParentBlockHash:   b5.ParentBlockHash,
 			Height:            b5.Height,

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -142,7 +142,12 @@ type blockV0 struct {
 // adds TransactionHashes
 
 type blockV1 struct {
-	blockV0
+	ParentBlockHash   gethCommon.Hash
+	Height            uint64
+	UUIDIndex         uint64
+	TotalSupply       uint64
+	StateRoot         gethCommon.Hash
+	ReceiptRoot       gethCommon.Hash
 	TransactionHashes []gethCommon.Hash
 }
 

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -124,6 +124,8 @@ var GenesisBlock = &Block{
 
 var GenesisBlockHash, _ = GenesisBlock.Hash()
 
+// todo remove this if confirmed we no longer need it on testnet, mainnet and previewnet.
+
 // Below block type section, defines earlier block types,
 // this is being used to decode blocks that were stored
 // before block type changes. It allows us to still decode

--- a/fvm/evm/types/block_test.go
+++ b/fvm/evm/types/block_test.go
@@ -1,12 +1,12 @@
 package types
 
 import (
-	gethRLP "github.com/onflow/go-ethereum/rlp"
 	"math/big"
 	"testing"
 
 	gethCommon "github.com/onflow/go-ethereum/common"
 	gethTypes "github.com/onflow/go-ethereum/core/types"
+	gethRLP "github.com/onflow/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/fvm/evm/types/block_test.go
+++ b/fvm/evm/types/block_test.go
@@ -86,4 +86,86 @@ func Test_DecodeBlocks(t *testing.T) {
 	require.Empty(t, b.Timestamp)
 	require.Empty(t, b.TotalGasUsed)
 
+	bv2 := blockV2{
+		ParentBlockHash:   GenesisBlockHash,
+		Height:            1,
+		TotalSupply:       2,
+		StateRoot:         gethCommon.Hash{0x01},
+		ReceiptRoot:       gethCommon.Hash{0x02},
+		TransactionHashes: []gethCommon.Hash{{0x04}},
+	}
+
+	b2, err := gethRLP.EncodeToBytes(bv2)
+	require.NoError(t, err)
+
+	b = decodeBlockBreakingChanges(b2)
+
+	require.Equal(t, b.TotalSupply.Uint64(), bv2.TotalSupply)
+	require.Equal(t, b.Height, bv2.Height)
+	require.Equal(t, b.ParentBlockHash, bv2.ParentBlockHash)
+	require.Equal(t, b.TransactionHashes, bv2.TransactionHashes)
+	require.Empty(t, b.Timestamp)
+	require.Empty(t, b.TotalGasUsed)
+
+	bv3 := blockV3{
+		ParentBlockHash:   GenesisBlockHash,
+		Height:            1,
+		TotalSupply:       2,
+		ReceiptRoot:       gethCommon.Hash{0x02},
+		TransactionHashes: []gethCommon.Hash{{0x04}},
+	}
+
+	b3, err := gethRLP.EncodeToBytes(bv3)
+	require.NoError(t, err)
+
+	b = decodeBlockBreakingChanges(b3)
+
+	require.Equal(t, b.TotalSupply.Uint64(), bv3.TotalSupply)
+	require.Equal(t, b.Height, bv3.Height)
+	require.Equal(t, b.ParentBlockHash, bv3.ParentBlockHash)
+	require.Equal(t, b.TransactionHashes, bv3.TransactionHashes)
+	require.Empty(t, b.Timestamp)
+	require.Empty(t, b.TotalGasUsed)
+
+	bv4 := blockV4{
+		ParentBlockHash:   GenesisBlockHash,
+		Height:            1,
+		TotalSupply:       big.NewInt(4),
+		ReceiptRoot:       gethCommon.Hash{0x02},
+		TransactionHashes: []gethCommon.Hash{{0x04}},
+	}
+
+	b4, err := gethRLP.EncodeToBytes(bv4)
+	require.NoError(t, err)
+
+	b = decodeBlockBreakingChanges(b4)
+
+	require.Equal(t, b.TotalSupply, bv4.TotalSupply)
+	require.Equal(t, b.Height, bv4.Height)
+	require.Equal(t, b.ParentBlockHash, bv4.ParentBlockHash)
+	require.Equal(t, b.TransactionHashes, bv4.TransactionHashes)
+	require.Empty(t, b.Timestamp)
+	require.Empty(t, b.TotalGasUsed)
+
+	bv5 := blockV5{
+		ParentBlockHash:   GenesisBlockHash,
+		Height:            1,
+		TotalSupply:       big.NewInt(2),
+		ReceiptRoot:       gethCommon.Hash{0x02},
+		TransactionHashes: []gethCommon.Hash{{0x04}},
+		Timestamp:         100,
+	}
+
+	b5, err := gethRLP.EncodeToBytes(bv5)
+	require.NoError(t, err)
+
+	b = decodeBlockBreakingChanges(b5)
+
+	require.Equal(t, b.Timestamp, bv5.Timestamp)
+	require.Equal(t, b.TotalSupply.Uint64(), bv5.TotalSupply)
+	require.Equal(t, b.Height, bv5.Height)
+	require.Equal(t, b.ParentBlockHash, bv5.ParentBlockHash)
+	require.Equal(t, b.TransactionHashes, bv5.TransactionHashes)
+	require.Empty(t, b.Timestamp)
+	require.Empty(t, b.TotalGasUsed)
 }

--- a/fvm/evm/types/block_test.go
+++ b/fvm/evm/types/block_test.go
@@ -166,6 +166,5 @@ func Test_DecodeBlocks(t *testing.T) {
 	require.Equal(t, b.Height, bv5.Height)
 	require.Equal(t, b.ParentBlockHash, bv5.ParentBlockHash)
 	require.Equal(t, b.TransactionHashes, bv5.TransactionHashes)
-	require.Empty(t, b.Timestamp)
 	require.Empty(t, b.TotalGasUsed)
 }

--- a/fvm/evm/types/block_test.go
+++ b/fvm/evm/types/block_test.go
@@ -162,7 +162,7 @@ func Test_DecodeBlocks(t *testing.T) {
 	b = decodeBlockBreakingChanges(b5)
 
 	require.Equal(t, b.Timestamp, bv5.Timestamp)
-	require.Equal(t, b.TotalSupply.Uint64(), bv5.TotalSupply)
+	require.Equal(t, b.TotalSupply, bv5.TotalSupply)
 	require.Equal(t, b.Height, bv5.Height)
 	require.Equal(t, b.ParentBlockHash, bv5.ParentBlockHash)
 	require.Equal(t, b.TransactionHashes, bv5.TransactionHashes)


### PR DESCRIPTION
Support decoding of all previous block types. Block types were changing during development and since it was deployed on previewnet we must make sure we can decode those previously stored blocks. 
