### PR TITLE
[Access] Failover when script exceeds computation or memory limit - backport

### DIFF
--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -346,6 +346,12 @@ func convertScriptExecutionError(err error, height uint64) error {
 		case fvmerrors.ErrCodeScriptExecutionTimedOutError:
 			return status.Errorf(codes.DeadlineExceeded, "script execution timed out: %v", err)
 
+		case fvmerrors.ErrCodeComputationLimitExceededError:
+			return status.Errorf(codes.ResourceExhausted, "script execution computation limit exceeded: %v", err)
+
+		case fvmerrors.ErrCodeMemoryLimitExceededError:
+			return status.Errorf(codes.ResourceExhausted, "script execution memory limit exceeded: %v", err)
+
 		default:
 			// runtime errors
 			return status.Errorf(codes.InvalidArgument, "failed to execute script: %v", err)

--- a/engine/access/rpc/backend/backend_scripts_test.go
+++ b/engine/access/rpc/backend/backend_scripts_test.go
@@ -36,6 +36,8 @@ var (
 	fvmFailureErr = fvmerrors.NewCodedFailure(fvmerrors.FailureCodeBlockFinderFailure, "fvm error")
 	ctxCancelErr  = fvmerrors.NewCodedError(fvmerrors.ErrCodeScriptExecutionCancelledError, "context canceled error")
 	timeoutErr    = fvmerrors.NewCodedError(fvmerrors.ErrCodeScriptExecutionTimedOutError, "timeout error")
+	compLimitErr  = fvmerrors.NewCodedError(fvmerrors.ErrCodeComputationLimitExceededError, "computation limit exceeded error")
+	memLimitErr   = fvmerrors.NewCodedError(fvmerrors.ErrCodeMemoryLimitExceededError, "memory limit exceeded error")
 )
 
 // Create a suite similar to GetAccount that covers each of the modes
@@ -291,6 +293,8 @@ func (s *BackendScriptsSuite) TestExecuteScriptWithFailover_HappyPath() {
 		storage.ErrNotFound,
 		fmt.Errorf("system error"),
 		fvmFailureErr,
+		compLimitErr,
+		memLimitErr,
 	}
 
 	s.setupExecutionNodes(s.block)


### PR DESCRIPTION
Closes: #5876
Backports: https://github.com/onflow/flow-go/pull/5877