### PR TITLE
[EFM] Transition to committed epoch in EFM

### DIFF
--- a/state/protocol/protocol_state/epochs/base_statemachine.go
+++ b/state/protocol/protocol_state/epochs/base_statemachine.go
@@ -1,6 +1,7 @@
 package epochs
 
 import (
+	"fmt"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
 )
@@ -93,5 +94,35 @@ func (u *baseStateMachine) EjectIdentity(nodeID flow.Identifier) error {
 		return protocol.NewInvalidServiceEventErrorf("expected to find identity for "+
 			"prev, current or next epoch, but (%v) was not found", nodeID)
 	}
+	return nil
+}
+
+// TransitionToNextEpoch updates the notion of 'current epoch', 'previous' and 'next epoch' in the protocol
+// state. An epoch transition is only allowed when:
+// - next epoch has been set up,
+// - next epoch has been committed,
+// - invalid state transition has not been attempted (this is ensured by constructor),
+// - candidate block is in the next epoch.
+// No errors are expected during normal operations.
+func (u *baseStateMachine) TransitionToNextEpoch() error {
+	nextEpoch := u.state.NextEpoch
+	// Check if there is next epoch protocol state
+	if nextEpoch == nil {
+		return fmt.Errorf("protocol state has not been setup yet")
+	}
+	// Check if there is a commit event for next epoch
+	if nextEpoch.CommitID == flow.ZeroID {
+		return fmt.Errorf("protocol state has not been committed yet")
+	}
+	// Check if we are at the next epoch, only then a transition is allowed
+	if u.view < u.parentState.NextEpochSetup.FirstView {
+		return fmt.Errorf("protocol state transition is only allowed when enterring next epoch")
+	}
+	u.state = &flow.ProtocolStateEntry{
+		PreviousEpoch:                   &u.state.CurrentEpoch,
+		CurrentEpoch:                    *u.state.NextEpoch,
+		InvalidEpochTransitionAttempted: u.state.InvalidEpochTransitionAttempted,
+	}
+	u.rebuildIdentityLookup()
 	return nil
 }

--- a/state/protocol/protocol_state/epochs/base_statemachine.go
+++ b/state/protocol/protocol_state/epochs/base_statemachine.go
@@ -102,7 +102,6 @@ func (u *baseStateMachine) EjectIdentity(nodeID flow.Identifier) error {
 // state. An epoch transition is only allowed when _all_ of the following conditions are satisfied:
 // - next epoch has been set up,
 // - next epoch has been committed,
-// - invalid state transition has not been attempted (this is ensured by constructor),
 // - candidate block is in the next epoch.
 // No errors are expected during normal operations.
 func (u *baseStateMachine) TransitionToNextEpoch() error {
@@ -112,6 +111,7 @@ func (u *baseStateMachine) TransitionToNextEpoch() error {
 	}
 	if nextEpoch.CommitID == flow.ZeroID { // nextEpoch.CommitID ≠ flow.ZeroID if and only if next epoch was already committed (on the happy path)
 		return fmt.Errorf("protocol state for next epoch has not yet been committed")
+	}
 	// Check if we are at the next epoch, only then a transition is allowed
 	if u.view < u.parentState.NextEpochSetup.FirstView {
 		return fmt.Errorf("epoch transition is only allowed when entering next epoch")

--- a/state/protocol/protocol_state/epochs/base_statemachine.go
+++ b/state/protocol/protocol_state/epochs/base_statemachine.go
@@ -2,6 +2,7 @@ package epochs
 
 import (
 	"fmt"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
 )

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -98,10 +98,3 @@ func (m *FallbackStateMachine) ProcessEpochCommit(_ *flow.EpochCommit) (bool, er
 	// won't process if we are in fallback mode
 	return false, nil
 }
-
-// TransitionToNextEpoch performs transition to next epoch, in epoch fallback no transitions are possible.
-// TODO for 'leaving Epoch Fallback via special service event' this might need to change.
-func (m *FallbackStateMachine) TransitionToNextEpoch() error {
-	// won't process if we are in fallback mode
-	return nil
-}

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -126,6 +126,7 @@ func (s *EpochFallbackStateMachineSuite) TestTransitionToNextEpochNotAllowed() {
 		protocolState := unittest.EpochStateFixture(unittest.WithNextEpochProtocolState(), func(entry *flow.RichProtocolStateEntry) {
 			entry.NextEpoch.CommitID = flow.ZeroID
 			entry.NextEpochCommit = nil
+			entry.NextEpochIdentityTable = nil			
 		})
 		candidate := unittest.BlockHeaderFixture(
 			unittest.HeaderWithView(protocolState.CurrentEpochSetup.FinalView + 1))
@@ -387,7 +388,7 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 // TestEpochFallbackStateMachineInjectsMultipleExtensions_NextEpochCommitted tests that the state machine injects multiple extensions
 // as it reaches the safety threshold of the current epoch and the extensions themselves.
 // In this test we are simulating the scenario where the current epoch enters fallback mode when the next epoch has been committed.
-// It is expected that it will transition into the next epoch (since it was committed)
+// It is expected that it will transition into the next epoch (since it was committed),
 // then reach the safety threshold and add the extension to the next epoch, which at that point will be considered 'current'.
 func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMultipleExtensions_NextEpochCommitted() {
 	originalParentState := s.parentProtocolState.Copy()
@@ -443,7 +444,6 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 			}
 
 			updatedState, _, _ := stateMachine.Build()
-
 			parentProtocolState, err = flow.NewRichProtocolStateEntry(updatedState,
 				previousEpochSetup,
 				previousEpochCommit,
@@ -451,7 +451,6 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 				currentEpochCommit,
 				nextEpochSetup,
 				nextEpochCommit)
-
 			require.NoError(s.T(), err)
 		}
 	}

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -126,7 +126,7 @@ func (s *EpochFallbackStateMachineSuite) TestTransitionToNextEpochNotAllowed() {
 		protocolState := unittest.EpochStateFixture(unittest.WithNextEpochProtocolState(), func(entry *flow.RichProtocolStateEntry) {
 			entry.NextEpoch.CommitID = flow.ZeroID
 			entry.NextEpochCommit = nil
-			entry.NextEpochIdentityTable = nil			
+			entry.NextEpochIdentityTable = nil
 		})
 		candidate := unittest.BlockHeaderFixture(
 			unittest.HeaderWithView(protocolState.CurrentEpochSetup.FinalView + 1))

--- a/state/protocol/protocol_state/epochs/happy_path_statemachine.go
+++ b/state/protocol/protocol_state/epochs/happy_path_statemachine.go
@@ -152,33 +152,3 @@ func (u *HappyPathStateMachine) ProcessEpochCommit(epochCommit *flow.EpochCommit
 	u.state.NextEpoch.CommitID = epochCommit.ID()
 	return true, nil
 }
-
-// TransitionToNextEpoch updates the notion of 'current epoch', 'previous' and 'next epoch' in the protocol
-// state. An epoch transition is only allowed when:
-// - next epoch has been set up,
-// - next epoch has been committed,
-// - invalid state transition has not been attempted (this is ensured by constructor),
-// - candidate block is in the next epoch.
-// No errors are expected during normal operations.
-func (u *HappyPathStateMachine) TransitionToNextEpoch() error {
-	nextEpoch := u.state.NextEpoch
-	// Check if there is next epoch protocol state
-	if nextEpoch == nil {
-		return fmt.Errorf("protocol state has not been setup yet")
-	}
-	// Check if there is a commit event for next epoch
-	if nextEpoch.CommitID == flow.ZeroID {
-		return fmt.Errorf("protocol state has not been committed yet")
-	}
-	// Check if we are at the next epoch, only then a transition is allowed
-	if u.view < u.parentState.NextEpochSetup.FirstView {
-		return fmt.Errorf("protocol state transition is only allowed when enterring next epoch")
-	}
-	u.state = &flow.ProtocolStateEntry{
-		PreviousEpoch:                   &u.state.CurrentEpoch,
-		CurrentEpoch:                    *u.state.NextEpoch,
-		InvalidEpochTransitionAttempted: false,
-	}
-	u.rebuildIdentityLookup()
-	return nil
-}

--- a/state/protocol/protocol_state/epochs/statemachine.go
+++ b/state/protocol/protocol_state/epochs/statemachine.go
@@ -205,6 +205,11 @@ func (e *EpochStateMachine) EvolveState(sealedServiceEvents []flow.ServiceEvent)
 	phase := parentProtocolState.EpochPhase()
 	if phase == flow.EpochPhaseCommitted {
 		activeSetup := parentProtocolState.CurrentEpochSetup
+		// TODO(efm-recovery): This logic needs to be updated when injection of EFM recovery service event is implemented.
+		// 				       For now, we are only checking transition to next epoch when the next epoch is committed.
+		//                     There is no epoch transition logic out of EFM, but once we have it, the following logic
+		//                     will be incorrect as we need to check the epoch final view including the extensions but not
+		//					   only the final view of the setup.
 		if e.activeStateMachine.View() > activeSetup.FinalView {
 			err := e.activeStateMachine.TransitionToNextEpoch()
 			if err != nil {

--- a/state/protocol/protocol_state/epochs/statemachine.go
+++ b/state/protocol/protocol_state/epochs/statemachine.go
@@ -207,7 +207,7 @@ func (e *EpochStateMachine) EvolveState(sealedServiceEvents []flow.ServiceEvent)
 		activeSetup := parentProtocolState.CurrentEpochSetup
 		// TODO(efm-recovery): This logic needs to be updated when injection of EFM recovery service event is implemented.
 		// 				       For now, we are only checking transition to next epoch when the next epoch is committed.
-		//                     There is no epoch transition logic out of EFM, but once we have it, the following logic
+		//                     There is no logic yet to leave EFM, but once we have it, the following logic
 		//                     will be incorrect as we need to check the epoch final view including the extensions but not
 		//					   only the final view of the setup.
 		if e.activeStateMachine.View() > activeSetup.FinalView {


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/5726

### Context

Previously we could maintain EFM only if we have entered it in staking or setup phases, if we have entered EFM when next epoch has been already committed then we wouldn't perform epoch transition because `FallbackStateMachine` ignored request for transition to the next epoch. 

This PR updates `FallbackStateMachine` to use the same logic for epoch transitions as the happy path. Additionally activated previously disabled tests and restructured logic.