### PR TITLE
Improve scheduling in account-based migration

### DIFF
--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -291,7 +291,7 @@ func MigrateGroupConcurrently(
 	topDurations := util.NewTopN[migrationDuration](
 		logTopNDurations,
 		func(duration migrationDuration, duration2 migrationDuration) bool {
-			return duration.Duration > duration2.Duration
+			return duration.Duration < duration2.Duration
 		},
 	)
 

--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -9,9 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog"
-
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
@@ -156,7 +155,7 @@ func MigrateGroupConcurrently(
 
 	wg := sync.WaitGroup{}
 	wg.Add(nWorker)
-	resultCh := make(chan *migrationResult, accountCount)
+	resultCh := make(chan migrationDuration, accountCount)
 	for i := 0; i < nWorker; i++ {
 		go func() {
 			defer wg.Done()
@@ -176,12 +175,10 @@ func MigrateGroupConcurrently(
 
 					// This is not an account, but service level keys.
 					if util.IsServiceLevelAddress(address) {
-						resultCh <- &migrationResult{
-							migrationDuration: migrationDuration{
-								Address:       address,
-								Duration:      time.Since(start),
-								RegisterCount: accountRegisters.Count(),
-							},
+						resultCh <- migrationDuration{
+							Address:       address,
+							Duration:      time.Since(start),
+							RegisterCount: accountRegisters.Count(),
 						}
 						continue
 					}
@@ -207,12 +204,10 @@ func MigrateGroupConcurrently(
 						}
 					}
 
-					resultCh <- &migrationResult{
-						migrationDuration: migrationDuration{
-							Address:       address,
-							Duration:      time.Since(start),
-							RegisterCount: accountRegisters.Count(),
-						},
+					resultCh <- migrationDuration{
+						Address:       address,
+						Duration:      time.Since(start),
+						RegisterCount: accountRegisters.Count(),
 					}
 				}
 			}
@@ -275,14 +270,20 @@ func MigrateGroupConcurrently(
 		),
 	)
 
-	durations := newMigrationDurations(logTopNDurations)
+	topDurations := util.NewTopN[migrationDuration](
+		logTopNDurations,
+		func(duration migrationDuration, duration2 migrationDuration) bool {
+			return duration.Duration > duration2.Duration
+		},
+	)
+
 accountLoop:
 	for accountIndex := 0; accountIndex < accountCount; accountIndex++ {
 		select {
 		case <-ctx.Done():
 			break accountLoop
-		case result := <-resultCh:
-			durations.Add(result)
+		case duration := <-resultCh:
+			topDurations.Add(duration)
 			logAccount(1)
 		}
 	}
@@ -293,7 +294,7 @@ accountLoop:
 	wg.Wait()
 
 	log.Info().
-		Array("top_longest_migrations", durations.Array()).
+		Array("top_longest_migrations", loggableMigrationDurations(topDurations)).
 		Msgf("Top longest migrations")
 
 	err := ctx.Err()
@@ -314,67 +315,24 @@ type jobMigrateAccountGroup struct {
 	AccountRegisters *registers.AccountRegisters
 }
 
-type migrationResult struct {
-	migrationDuration
-}
-
 type migrationDuration struct {
 	Address       common.Address
 	Duration      time.Duration
 	RegisterCount int
 }
 
-// migrationDurations implements heap methods for the timer results
-type migrationDurations struct {
-	v []migrationDuration
-
-	KeepTopN int
-}
-
-// newMigrationDurations creates a new migrationDurations which are used to track the
-// accounts that took the longest time to migrate.
-func newMigrationDurations(keepTopN int) *migrationDurations {
-	return &migrationDurations{
-		v:        make([]migrationDuration, 0, keepTopN),
-		KeepTopN: keepTopN,
-	}
-}
-
-func (h *migrationDurations) Len() int { return len(h.v) }
-func (h *migrationDurations) Less(i, j int) bool {
-	return h.v[i].Duration < h.v[j].Duration
-}
-func (h *migrationDurations) Swap(i, j int) {
-	h.v[i], h.v[j] = h.v[j], h.v[i]
-}
-func (h *migrationDurations) Push(x interface{}) {
-	h.v = append(h.v, x.(migrationDuration))
-}
-func (h *migrationDurations) Pop() interface{} {
-	old := h.v
-	n := len(old)
-	x := old[n-1]
-	h.v = old[0 : n-1]
-	return x
-}
-
-func (h *migrationDurations) Array() zerolog.LogArrayMarshaler {
+func loggableMigrationDurations(durations *util.TopN[migrationDuration]) zerolog.LogArrayMarshaler {
 	array := zerolog.Arr()
-	for _, result := range h.v {
-		array = array.Str(fmt.Sprintf("%s [registers: %d]: %s",
-			result.Address.Hex(),
-			result.RegisterCount,
-			result.Duration.String(),
+
+	for index := durations.Len() - 1; index >= 0; index-- {
+		duration := heap.Pop(durations).(migrationDuration)
+		array = array.Str(fmt.Sprintf(
+			"%s [registers: %d]: %s",
+			duration.Address.Hex(),
+			duration.RegisterCount,
+			duration.Duration.String(),
 		))
 	}
-	return array
-}
 
-func (h *migrationDurations) Add(result *migrationResult) {
-	if h.Len() < h.KeepTopN || result.Duration > h.v[0].Duration {
-		if h.Len() == h.KeepTopN {
-			heap.Pop(h) // remove the element with the smallest duration
-		}
-		heap.Push(h, result.migrationDuration)
-	}
+	return array
 }

--- a/cmd/util/ledger/migrations/account_size_filter_migration.go
+++ b/cmd/util/ledger/migrations/account_size_filter_migration.go
@@ -57,20 +57,24 @@ func NewAccountSizeFilterMigration(
 			}
 		}
 
-		return registersByAccount.ForEachAccount(func(owner string, accountRegisters *registers.AccountRegisters) error {
-			if _, ok := exceptions[owner]; ok {
-				return nil
-			}
+		return registersByAccount.ForEachAccount(
+			func(accountRegisters *registers.AccountRegisters) error {
+				owner := accountRegisters.Owner()
 
-			info := payloadCountByAddress[owner]
-			if info.size <= maxAccountSize {
-				return nil
-			}
+				if _, ok := exceptions[owner]; ok {
+					return nil
+				}
 
-			return accountRegisters.ForEach(func(owner, key string, _ []byte) error {
-				return accountRegisters.Set(owner, key, nil)
-			})
-		})
+				info := payloadCountByAddress[owner]
+				if info.size <= maxAccountSize {
+					return nil
+				}
+
+				return accountRegisters.ForEach(func(owner, key string, _ []byte) error {
+					return accountRegisters.Set(owner, key, nil)
+				})
+			},
+		)
 	}
 }
 

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -92,9 +92,9 @@ func (b *ByAccount) Payloads() []*ledger.Payload {
 	return payloads
 }
 
-func (b *ByAccount) ForEachAccount(f func(owner string, accountRegisters *AccountRegisters) error) error {
-	for owner, accountRegisters := range b.registers {
-		err := f(owner, accountRegisters)
+func (b *ByAccount) ForEachAccount(f func(accountRegisters *AccountRegisters) error) error {
+	for _, accountRegisters := range b.registers {
+		err := f(accountRegisters)
 		if err != nil {
 			return err
 		}

--- a/cmd/util/ledger/util/topn.go
+++ b/cmd/util/ledger/util/topn.go
@@ -7,16 +7,16 @@ import (
 // TopN keeps track of the top N elements.
 // Use Add to add elements to the list.
 type TopN[T any] struct {
-	Tree     []T
-	N        int
-	IsLarger func(T, T) bool
+	Tree   []T
+	N      int
+	IsLess func(T, T) bool
 }
 
-func NewTopN[T any](n int, isLarger func(T, T) bool) *TopN[T] {
+func NewTopN[T any](n int, isLess func(T, T) bool) *TopN[T] {
 	return &TopN[T]{
-		Tree:     make([]T, 0, n),
-		N:        n,
-		IsLarger: isLarger,
+		Tree:   make([]T, 0, n),
+		N:      n,
+		IsLess: isLess,
 	}
 }
 
@@ -27,7 +27,7 @@ func (h *TopN[T]) Len() int {
 func (h *TopN[T]) Less(i, j int) bool {
 	a := h.Tree[i]
 	b := h.Tree[j]
-	return h.IsLarger(a, b)
+	return h.IsLess(a, b)
 }
 
 func (h *TopN[T]) Swap(i, j int) {
@@ -50,9 +50,15 @@ func (h *TopN[T]) Pop() interface{} {
 	return last
 }
 
-func (h *TopN[T]) Add(value T) {
+// Add tries to add a value to the list.
+// If the list is full, it will return the smallest value and true.
+// If the list is not full, it will return the zero value and false.
+func (h *TopN[T]) Add(value T) (popped T, didPop bool) {
 	heap.Push(h, value)
 	if h.Len() > h.N {
-		heap.Pop(h)
+		popped := heap.Pop(h).(T)
+		return popped, true
 	}
+	var empty T
+	return empty, false
 }

--- a/cmd/util/ledger/util/topn.go
+++ b/cmd/util/ledger/util/topn.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"container/heap"
+)
+
+// TopN keeps track of the top N elements.
+// Use Add to add elements to the list.
+type TopN[T any] struct {
+	Tree     []T
+	N        int
+	IsLarger func(T, T) bool
+}
+
+func NewTopN[T any](n int, isLarger func(T, T) bool) *TopN[T] {
+	return &TopN[T]{
+		Tree:     make([]T, 0, n),
+		N:        n,
+		IsLarger: isLarger,
+	}
+}
+
+func (h *TopN[T]) Len() int {
+	return len(h.Tree)
+}
+
+func (h *TopN[T]) Less(i, j int) bool {
+	a := h.Tree[i]
+	b := h.Tree[j]
+	return h.IsLarger(a, b)
+}
+
+func (h *TopN[T]) Swap(i, j int) {
+	h.Tree[i], h.Tree[j] =
+		h.Tree[j], h.Tree[i]
+}
+
+func (h *TopN[T]) Push(x interface{}) {
+	h.Tree = append(h.Tree, x.(T))
+}
+
+func (h *TopN[T]) Pop() interface{} {
+	tree := h.Tree
+	count := len(tree)
+	lastIndex := count - 1
+	last := tree[lastIndex]
+	var empty T
+	tree[lastIndex] = empty
+	h.Tree = tree[0:lastIndex]
+	return last
+}
+
+func (h *TopN[T]) Add(value T) {
+	heap.Push(h, value)
+	if h.Len() > h.N {
+		heap.Pop(h)
+	}
+}

--- a/cmd/util/ledger/util/topn_test.go
+++ b/cmd/util/ledger/util/topn_test.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTopN(t *testing.T) {
+	t.Parallel()
+
+	topN := NewTopN(
+		3,
+		func(a, b int) bool {
+			return a < b
+		},
+	)
+
+	topN.Add(5)
+	assert.ElementsMatch(t,
+		[]int{5},
+		topN.Tree,
+	)
+
+	topN.Add(2)
+	assert.ElementsMatch(t,
+		[]int{5, 2},
+		topN.Tree,
+	)
+
+	topN.Add(3)
+	assert.ElementsMatch(t,
+		[]int{5, 3, 2},
+		topN.Tree,
+	)
+
+	topN.Add(3)
+	assert.ElementsMatch(t,
+		[]int{5, 3, 3},
+		topN.Tree,
+	)
+
+	topN.Add(1)
+	assert.ElementsMatch(t,
+		[]int{5, 3, 3},
+		topN.Tree,
+	)
+
+	topN.Add(4)
+	assert.ElementsMatch(t,
+		[]int{5, 4, 3},
+		topN.Tree,
+	)
+
+	sorted := make([]int, len(topN.Tree))
+	for index := topN.Len() - 1; index >= 0; index-- {
+		sorted[index] = heap.Pop(topN).(int)
+	}
+	assert.Equal(t,
+		[]int{5, 4, 3},
+		sorted,
+	)
+	assert.Empty(t, topN.Tree)
+}

--- a/cmd/util/ledger/util/topn_test.go
+++ b/cmd/util/ledger/util/topn_test.go
@@ -17,37 +17,46 @@ func TestTopN(t *testing.T) {
 		},
 	)
 
-	topN.Add(5)
+	_, didPop := topN.Add(5)
+	assert.False(t, didPop)
 	assert.ElementsMatch(t,
 		[]int{5},
 		topN.Tree,
 	)
 
-	topN.Add(2)
+	_, didPop = topN.Add(2)
+	assert.False(t, didPop)
 	assert.ElementsMatch(t,
 		[]int{5, 2},
 		topN.Tree,
 	)
 
-	topN.Add(3)
+	_, didPop = topN.Add(3)
+	assert.False(t, didPop)
 	assert.ElementsMatch(t,
 		[]int{5, 3, 2},
 		topN.Tree,
 	)
 
-	topN.Add(3)
+	popped, didPop := topN.Add(3)
+	assert.True(t, didPop)
+	assert.Equal(t, 2, popped)
 	assert.ElementsMatch(t,
 		[]int{5, 3, 3},
 		topN.Tree,
 	)
 
-	topN.Add(1)
+	popped, didPop = topN.Add(1)
+	assert.True(t, didPop)
+	assert.Equal(t, 1, popped)
 	assert.ElementsMatch(t,
 		[]int{5, 3, 3},
 		topN.Tree,
 	)
 
-	topN.Add(4)
+	popped, didPop = topN.Add(4)
+	assert.True(t, didPop)
+	assert.Equal(t, 3, popped)
 	assert.ElementsMatch(t,
 		[]int{5, 4, 3},
 		topN.Tree,


### PR DESCRIPTION
Depends on #5897

Currently, the migrations of accounts are scheduled in address order. If there are large accounts at high addresses, the migration might end up waiting for a these accounts, with most available workers idling.

Schedule the migration of large accounts first to increase utilization of available workers.
