### PR TITLE
Fix wasm build in `module/signature`

### DIFF
--- a/module/signature/type_encoder.go
+++ b/module/signature/type_encoder.go
@@ -61,7 +61,7 @@ func EncodeDoubleSig(stakingSig crypto.Signature, beaconSig crypto.Signature) []
 //     if sigData is the size of a BLS signature, we interpret sigData entirely as staking signature
 //   - nil, nil, ErrInvalidSignatureFormat if the sig type is invalid (covers nil or empty sigData)
 func DecodeDoubleSig(sigData []byte) (crypto.Signature, crypto.Signature, error) {
-	sigLen := crypto.SignatureLenBLSBLS12381
+	sigLen := SigLen
 
 	switch len(sigData) {
 	case sigLen:

--- a/module/signature/type_encoder.go
+++ b/module/signature/type_encoder.go
@@ -61,13 +61,14 @@ func EncodeDoubleSig(stakingSig crypto.Signature, beaconSig crypto.Signature) []
 //     if sigData is the size of a BLS signature, we interpret sigData entirely as staking signature
 //   - nil, nil, ErrInvalidSignatureFormat if the sig type is invalid (covers nil or empty sigData)
 func DecodeDoubleSig(sigData []byte) (crypto.Signature, crypto.Signature, error) {
-	sigLength := len(sigData)
-	switch sigLength {
-	case SigLen:
+	sigLen := crypto.SignatureLenBLSBLS12381
+
+	switch len(sigData) {
+	case sigLen:
 		return sigData, nil, nil
-	case 2 * SigLen:
-		return sigData[:SigLen], sigData[SigLen:], nil
+	case 2 * sigLen:
+		return sigData[:sigLen], sigData[sigLen:], nil
 	}
 
-	return nil, nil, fmt.Errorf("invalid sig data length %d: %w", sigLength, ErrInvalidSignatureFormat)
+	return nil, nil, fmt.Errorf("invalid sig data length %d: %w", len(sigData), ErrInvalidSignatureFormat)
 }


### PR DESCRIPTION
fixes https://github.com/onflow/flow-go/issues/5899

`module/signature` is imported by the flow-emulator and is causing a build error when built without cgo (in the wasm build). This PR makes a minor change with no functional change, to avoid the build error. 