### PR TITLE
[EVM] Add the `GetErrorForCode` helper method

### DIFF
--- a/fvm/evm/types/codeFinder.go
+++ b/fvm/evm/types/codeFinder.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 
 	gethCore "github.com/onflow/go-ethereum/core"
 	gethVM "github.com/onflow/go-ethereum/core/vm"
@@ -86,4 +87,75 @@ func ExecutionErrorCode(err error) ErrorCode {
 	default:
 		return ExecutionErrCodeMisc
 	}
+}
+
+func GetErrorForCode(errorCode ErrorCode) error {
+	switch errorCode {
+	case ValidationErrCodeGasUintOverflow:
+		return gethVM.ErrGasUintOverflow
+	case ValidationErrCodeNonceTooLow:
+		return gethCore.ErrNonceTooLow
+	case ValidationErrCodeNonceTooHigh:
+		return gethCore.ErrNonceTooHigh
+	case ValidationErrCodeNonceMax:
+		return gethCore.ErrNonceMax
+	case ValidationErrCodeGasLimitReached:
+		return gethCore.ErrGasLimitReached
+	case ValidationErrCodeInsufficientFundsForTransfer:
+		return gethCore.ErrInsufficientFundsForTransfer
+	case ValidationErrCodeMaxInitCodeSizeExceeded:
+		return gethCore.ErrMaxInitCodeSizeExceeded
+	case ValidationErrCodeInsufficientFunds:
+		return gethCore.ErrInsufficientFunds
+	case ValidationErrCodeIntrinsicGas:
+		return gethCore.ErrIntrinsicGas
+	case ValidationErrCodeTxTypeNotSupported:
+		return gethCore.ErrTxTypeNotSupported
+	case ValidationErrCodeTipAboveFeeCap:
+		return gethCore.ErrTipAboveFeeCap
+	case ValidationErrCodeTipVeryHigh:
+		return gethCore.ErrTipVeryHigh
+	case ValidationErrCodeFeeCapVeryHigh:
+		return gethCore.ErrFeeCapVeryHigh
+	case ValidationErrCodeFeeCapTooLow:
+		return gethCore.ErrFeeCapTooLow
+	case ValidationErrCodeSenderNoEOA:
+		return gethCore.ErrSenderNoEOA
+	case ValidationErrCodeBlobFeeCapTooLow:
+		return gethCore.ErrBlobFeeCapTooLow
+	case ExecutionErrCodeOutOfGas:
+		return gethVM.ErrOutOfGas
+	case ExecutionErrCodeCodeStoreOutOfGas:
+		return gethVM.ErrCodeStoreOutOfGas
+	case ExecutionErrCodeDepth:
+		return gethVM.ErrDepth
+	case ExecutionErrCodeInsufficientBalance:
+		return gethVM.ErrInsufficientBalance
+	case ExecutionErrCodeContractAddressCollision:
+		return gethVM.ErrContractAddressCollision
+	case ExecutionErrCodeExecutionReverted:
+		return gethVM.ErrExecutionReverted
+	case ExecutionErrCodeMaxInitCodeSizeExceeded:
+		return gethVM.ErrMaxInitCodeSizeExceeded
+	case ExecutionErrCodeMaxCodeSizeExceeded:
+		return gethVM.ErrMaxCodeSizeExceeded
+	case ExecutionErrCodeInvalidJump:
+		return gethVM.ErrInvalidJump
+	case ExecutionErrCodeWriteProtection:
+		return gethVM.ErrWriteProtection
+	case ExecutionErrCodeReturnDataOutOfBounds:
+		return gethVM.ErrReturnDataOutOfBounds
+	case ExecutionErrCodeGasUintOverflow:
+		return gethVM.ErrGasUintOverflow
+	case ExecutionErrCodeInvalidCode:
+		return gethVM.ErrInvalidCode
+	case ExecutionErrCodeNonceUintOverflow:
+		return gethVM.ErrNonceUintOverflow
+	case ValidationErrCodeMisc:
+		return fmt.Errorf("validation error: %d", errorCode)
+	case ExecutionErrCodeMisc:
+		return fmt.Errorf("execution error: %d", errorCode)
+	}
+
+	return fmt.Errorf("unknown error code: %d", errorCode)
 }

--- a/fvm/evm/types/codeFinder.go
+++ b/fvm/evm/types/codeFinder.go
@@ -89,7 +89,7 @@ func ExecutionErrorCode(err error) ErrorCode {
 	}
 }
 
-func GetErrorForCode(errorCode ErrorCode) error {
+func ErrorFromCode(errorCode ErrorCode) error {
 	switch errorCode {
 	case ValidationErrCodeGasUintOverflow:
 		return gethVM.ErrGasUintOverflow


### PR DESCRIPTION
This method performs the inverse mapping of `ExecutionErrorCode` and `ValidationErrorCode`.
It returns the corresponding error object, given an `ErrorCode` value.