### PR TITLE
Optimize Cadence v0.42 + atree inlining migration

### DIFF
--- a/cmd/util/ledger/migrations/cadence_value_validation_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_validation_test.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -33,6 +34,7 @@ func TestValidateCadenceValues(t *testing.T) {
 			createTestPayloads(t, address, domain),
 			log,
 			false,
+			runtime.NumCPU(),
 		)
 		require.NoError(t, err)
 	})
@@ -112,6 +114,7 @@ func TestValidateCadenceValues(t *testing.T) {
 			newPayloads,
 			log,
 			false,
+			runtime.NumCPU(),
 		)
 		require.ErrorContains(t, err, wantErrorMsg)
 		require.Equal(t, 0, w.Len())
@@ -123,6 +126,7 @@ func TestValidateCadenceValues(t *testing.T) {
 			newPayloads,
 			log,
 			true,
+			runtime.NumCPU(),
 		)
 		require.ErrorContains(t, err, wantErrorMsg)
 		require.Equal(t, wantVerboseMsg, w.String())

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -35,6 +35,7 @@ type FilterUnreferencedSlabsMigration struct {
 	mutex            sync.Mutex
 	filteredPayloads []*ledger.Payload
 	payloadsFile     string
+	nWorkers         int
 }
 
 var _ AccountBasedMigration = &FilterUnreferencedSlabsMigration{}
@@ -55,8 +56,9 @@ func NewFilterUnreferencedSlabsMigration(
 func (m *FilterUnreferencedSlabsMigration) InitMigration(
 	log zerolog.Logger,
 	_ []*ledger.Payload,
-	_ int,
+	nWorkers int,
 ) error {
+	m.nWorkers = nWorkers
 	m.log = log.
 		With().
 		Str("migration", filterUnreferencedSlabsName).
@@ -82,7 +84,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 
 	newPayloads = oldPayloads
 
-	err = checkStorageHealth(address, storage, oldPayloads)
+	err = checkStorageHealth(address, storage, oldPayloads, m.nWorkers, true)
 	if err == nil {
 		return
 	}

--- a/cmd/util/ledger/migrations/fix_broken_data_migration.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration.go
@@ -83,7 +83,7 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 	storage := migrationRuntime.Storage
 
 	// Load all atree registers in storage
-	err = loadAtreeSlabsInStorge(storage, oldPayloads)
+	err = loadAtreeSlabsInStorge(storage, oldPayloads, m.nWorkers)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 
 	m.mergeBrokenPayloads(brokenPayloads)
 
-	err = storage.FastCommit(m.nWorkers)
+	err = storage.NondeterministicFastCommit(m.nWorkers)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
-	github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9
-	github.com/onflow/cadence v0.42.11-atree-register-inlining.2
+	github.com/onflow/atree v0.8.0-rc.2
+	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -1346,13 +1346,13 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x071HgCF/0v5hQcaE5qqjc2UqN5gCU8h5Mk6uqpOg=
-github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9 h1:lS/47Nt8qRIEC+V8QPobTAWnudK982u/wJboucugndg=
-github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2 h1:gdKHbrGmW4ybv19j2kWu7lijHpEWwN9blMepxlmj7IM=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2/go.mod h1:8hS2bM6B5F7a870d+NWLDGUEk3yWvE2d+g0C75KuhUY=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478 h1:yFJu3OInd/Hd/ybWP6WVq6JD2dNkdDgV1FUQfBTK9n4=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478/go.mod h1:FTuO5w5KIxFm9DNqNpma9IysXR3MzFwYdE7/s+O4zmU=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow v0.3.4 h1:FXUWVdYB90f/rjNcY0Owo30gL790tiYff9Pb/sycXYE=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -203,8 +203,8 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9 // indirect
-	github.com/onflow/cadence v0.42.11-atree-register-inlining.2 // indirect
+	github.com/onflow/atree v0.8.0-rc.2 // indirect
+	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -1313,11 +1313,11 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x071HgCF/0v5hQcaE5qqjc2UqN5gCU8h5Mk6uqpOg=
-github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9 h1:lS/47Nt8qRIEC+V8QPobTAWnudK982u/wJboucugndg=
-github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2 h1:gdKHbrGmW4ybv19j2kWu7lijHpEWwN9blMepxlmj7IM=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2/go.mod h1:8hS2bM6B5F7a870d+NWLDGUEk3yWvE2d+g0C75KuhUY=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478 h1:yFJu3OInd/Hd/ybWP6WVq6JD2dNkdDgV1FUQfBTK9n4=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478/go.mod h1:FTuO5w5KIxFm9DNqNpma9IysXR3MzFwYdE7/s+O4zmU=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1 h1:xF5wHug6H8vKfz7p1LYy9jck6eD9K1HLjTdi6o4kg1k=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v0.42.11-atree-register-inlining.2
+	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1
@@ -252,7 +252,7 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9 // indirect
+	github.com/onflow/atree v0.8.0-rc.2 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.1.0 // indirect
 	github.com/onflow/nft-storefront/lib/go/contracts v0.0.0-20221222181731-14b90207cead // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1403,11 +1403,11 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x071HgCF/0v5hQcaE5qqjc2UqN5gCU8h5Mk6uqpOg=
-github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9 h1:lS/47Nt8qRIEC+V8QPobTAWnudK982u/wJboucugndg=
-github.com/onflow/atree v0.6.1-0.20240429171214-e4400b25dfa9/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2 h1:gdKHbrGmW4ybv19j2kWu7lijHpEWwN9blMepxlmj7IM=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2/go.mod h1:8hS2bM6B5F7a870d+NWLDGUEk3yWvE2d+g0C75KuhUY=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478 h1:yFJu3OInd/Hd/ybWP6WVq6JD2dNkdDgV1FUQfBTK9n4=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240514160523-56fb3b4fc478/go.mod h1:FTuO5w5KIxFm9DNqNpma9IysXR3MzFwYdE7/s+O4zmU=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1 h1:xF5wHug6H8vKfz7p1LYy9jck6eD9K1HLjTdi6o4kg1k=


### PR DESCRIPTION
This PR optimizes atree migration by using new atree functions:
- `NondeterministicFastCommit()` for nondeterministic commit to atree storage
- `BatchPreload()` to preload atree slabs in parallel

Informal test showed ~15% speedup (about 1 hour 20 minutes faster) on m1 vm using `nworkers=40` with all storage checks and validations enabled.  Using more cpu cores or different input data (testnet vs mainnet data) may show different speedups.

Changes to migration program in flow-go is not extensive because most of the changes are in onflow/atree repo.  More info at: http://github.com/onflow/atree/releases