### PR TITLE
Optimize creation of new payloads

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -428,8 +428,8 @@ func newByAccountRegistersFromPayloadAccountGrouping(
 ) {
 	g, ctx := errgroup.WithContext(context.Background())
 
-	jobs := make(chan *util.PayloadAccountGroup)
-	results := make(chan *registers.AccountRegisters)
+	jobs := make(chan *util.PayloadAccountGroup, nWorker)
+	results := make(chan *registers.AccountRegisters, nWorker)
 
 	g.Go(func() error {
 		defer close(jobs)

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -411,7 +411,7 @@ func newMigration(
 
 		logger.Info().Msg("creating new payloads from registers ...")
 
-		newPayloads := registersByAccount.Payloads()
+		newPayloads := registersByAccount.DestructIntoPayloads()
 
 		logger.Info().Msgf("created new payloads (%d) from registers", len(newPayloads))
 

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -411,7 +411,7 @@ func newMigration(
 
 		logger.Info().Msg("creating new payloads from registers ...")
 
-		newPayloads := registersByAccount.DestructIntoPayloads()
+		newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
 
 		logger.Info().Msgf("created new payloads (%d) from registers", len(newPayloads))
 

--- a/cmd/util/ledger/migrations/deploy_migration_test.go
+++ b/cmd/util/ledger/migrations/deploy_migration_test.go
@@ -144,7 +144,9 @@ func TestDeploy(t *testing.T) {
 
 	storageSnapshot := snapshot.MapStorageSnapshot{}
 
-	for _, newPayload := range registersByAccount.Payloads() {
+	newPayloads := registersByAccount.DestructIntoPayloads()
+
+	for _, newPayload := range newPayloads {
 		registerID, registerValue, err := convert.PayloadToRegister(newPayload)
 		require.NoError(t, err)
 

--- a/cmd/util/ledger/migrations/deploy_migration_test.go
+++ b/cmd/util/ledger/migrations/deploy_migration_test.go
@@ -62,6 +62,8 @@ func TestDeploy(t *testing.T) {
 
 	chain := chainID.Chain()
 
+	const nWorker = 2
+
 	systemContracts := systemcontracts.SystemContractsForChain(chainID)
 	serviceAccountAddress := systemContracts.FlowServiceAccount.Address
 	fungibleTokenAddress := systemContracts.FungibleToken.Address
@@ -144,7 +146,7 @@ func TestDeploy(t *testing.T) {
 
 	storageSnapshot := snapshot.MapStorageSnapshot{}
 
-	newPayloads := registersByAccount.DestructIntoPayloads()
+	newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
 
 	for _, newPayload := range newPayloads {
 		registerID, registerValue, err := convert.PayloadToRegister(newPayload)

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -169,7 +169,7 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 		string([]byte{flow.SlabIndexPrefix, 0, 0, 0, 0, 0, 0, 0, 3}): {},
 	}
 
-	newPayloads := registersByAccount.Payloads()
+	newPayloads := registersByAccount.DestructIntoPayloads()
 	assert.Len(t, newPayloads, totalSlabCount-len(expectedKeys))
 
 	expectedFilteredPayloads := make([]*ledger.Payload, 0, len(expectedKeys))

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -28,6 +28,8 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 	const chainID = flow.Emulator
 	chain := chainID.Chain()
 
+	const nWorker = 2
+
 	testFlowAddress, err := chain.AddressAtIndex(1_000_000)
 	require.NoError(t, err)
 
@@ -169,7 +171,7 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 		string([]byte{flow.SlabIndexPrefix, 0, 0, 0, 0, 0, 0, 0, 3}): {},
 	}
 
-	newPayloads := registersByAccount.DestructIntoPayloads()
+	newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
 	assert.Len(t, newPayloads, totalSlabCount-len(expectedKeys))
 
 	expectedFilteredPayloads := make([]*ledger.Payload, 0, len(expectedKeys))

--- a/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
@@ -19,6 +19,8 @@ import (
 func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	t.Parallel()
 
+	const nWorker = 2
+
 	rawAddress := mustDecodeHex("5e3448b3cffb97f2")
 
 	address := common.MustBytesToAddress(rawAddress)
@@ -149,7 +151,7 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	registersByAccount, err := registers.NewByAccountFromPayloads(oldPayloads)
 	require.NoError(t, err)
 
-	err = migration.InitMigration(log, registersByAccount, 1)
+	err = migration.InitMigration(log, registersByAccount, nWorker)
 	require.NoError(t, err)
 
 	accountRegisters := registersByAccount.AccountRegisters(string(address[:]))
@@ -164,7 +166,7 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	err = migration.Close()
 	require.NoError(t, err)
 
-	newPayloads := registersByAccount.DestructIntoPayloads()
+	newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
 
 	require.Equal(t, len(expectedNewPayloads), len(newPayloads))
 

--- a/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
@@ -164,7 +164,7 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	err = migration.Close()
 	require.NoError(t, err)
 
-	newPayloads := registersByAccount.Payloads()
+	newPayloads := registersByAccount.DestructIntoPayloads()
 
 	require.Equal(t, len(expectedNewPayloads), len(newPayloads))
 

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -236,6 +236,16 @@ func (a *AccountRegisters) Payloads() []*ledger.Payload {
 }
 
 func (a *AccountRegisters) insertPayloads(payloads []*ledger.Payload) {
+	payloadCount := len(payloads)
+	registerCount := len(a.registers)
+	if payloadCount != registerCount {
+		panic(fmt.Errorf(
+			"given payloads slice has wrong size: got %d, expected %d",
+			payloadCount,
+			registerCount,
+		))
+	}
+
 	index := 0
 	for key, value := range a.registers {
 		if len(value) == 0 {

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -94,7 +94,7 @@ func (b *ByAccount) DestructIntoPayloads(nWorker int) []*ledger.Payload {
 
 	var wg sync.WaitGroup
 
-	jobs := make(chan job)
+	jobs := make(chan job, b.AccountCount())
 
 	worker := func() {
 		defer wg.Done()

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -18,7 +18,6 @@ type Registers interface {
 	Get(owner string, key string) ([]byte, error)
 	Set(owner string, key string, value []byte) error
 	ForEach(f ForEachCallback) error
-	Payloads() []*ledger.Payload
 }
 
 // ByAccount represents the registers of all accounts
@@ -70,7 +69,7 @@ func (b *ByAccount) Get(owner string, key string) ([]byte, error) {
 
 func (b *ByAccount) Set(owner string, key string, value []byte) error {
 	accountRegisters := b.AccountRegisters(owner)
-	accountRegisters.registers[key] = value
+	accountRegisters.uncheckedSet(key, value)
 	return nil
 }
 
@@ -84,11 +83,26 @@ func (b *ByAccount) ForEach(f ForEachCallback) error {
 	return nil
 }
 
-func (b *ByAccount) Payloads() []*ledger.Payload {
-	payloads := make([]*ledger.Payload, 0, len(b.registers)*payloadsPerAccountEstimate)
-	for _, accountRegisters := range b.registers {
-		payloads = accountRegisters.appendPayloads(payloads)
+func (b *ByAccount) DestructIntoPayloads() []*ledger.Payload {
+	payloads := make([]*ledger.Payload, b.Count())
+
+	startOffset := 0
+	for owner, accountRegisters := range b.registers {
+
+		endOffset := startOffset + accountRegisters.Count()
+		accountPayloads := payloads[startOffset:endOffset]
+
+		accountRegisters.insertPayloads(accountPayloads)
+
+		// Remove the account from the map to reduce memory usage.
+		// The account registers are now stored in the payloads,
+		// so we don't need to keep them in the by-account registers.
+		// This allows GC to collect converted account registers during the loop.
+		delete(b.registers, owner)
+
+		startOffset = endOffset
 	}
+
 	return payloads
 }
 
@@ -157,12 +171,16 @@ func (a *AccountRegisters) Set(owner string, key string, value []byte) error {
 	if owner != a.owner {
 		return fmt.Errorf("owner mismatch: expected %s, got %s", a.owner, owner)
 	}
+	a.uncheckedSet(key, value)
+	return nil
+}
+
+func (a *AccountRegisters) uncheckedSet(key string, value []byte) {
 	if len(value) == 0 {
 		delete(a.registers, key)
 	} else {
 		a.registers[key] = value
 	}
-	return nil
 }
 
 func (a *AccountRegisters) ForEach(f ForEachCallback) error {
@@ -184,14 +202,16 @@ func (a *AccountRegisters) Owner() string {
 }
 
 func (a *AccountRegisters) Payloads() []*ledger.Payload {
-	payloads := make([]*ledger.Payload, 0, len(a.registers))
-	return a.appendPayloads(payloads)
+	payloads := make([]*ledger.Payload, 0, a.Count())
+	a.insertPayloads(payloads)
+	return payloads
 }
 
-func (a *AccountRegisters) appendPayloads(payloads []*ledger.Payload) []*ledger.Payload {
+func (a *AccountRegisters) insertPayloads(payloads []*ledger.Payload) {
+	index := 0
 	for key, value := range a.registers {
 		if len(value) == 0 {
-			continue
+			panic(fmt.Errorf("unexpected empty register value: %x, %x", a.owner, key))
 		}
 
 		ledgerKey := convert.RegisterIDToLedgerKey(flow.RegisterID{
@@ -199,9 +219,9 @@ func (a *AccountRegisters) appendPayloads(payloads []*ledger.Payload) []*ledger.
 			Key:   key,
 		})
 		payload := ledger.NewPayload(ledgerKey, value)
-		payloads = append(payloads, payload)
+		payloads[index] = payload
+		index++
 	}
-	return payloads
 }
 
 func NewAccountRegistersFromPayloads(owner string, payloads []*ledger.Payload) (*AccountRegisters, error) {


### PR DESCRIPTION
At the end of the migration, registers are converted back to payloads.

This effectively doubles the memory usage, as the key-value pairs are stored both in the registers and in the newly created payloads.

Reduce peak memory usage, by allowing the garbage collection of account registers that have already gotten converted to payloads.

This change brings peak memory usage back to similar, and at times even lower, levels before #5897.

Also optimize speed by creating payloads in parallel.

