### PR TITLE
Update or deploy EVM contract, depending on chain

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -355,15 +355,16 @@ func run(*cobra.Command, []string) {
 	log.Info().Msgf("state extraction plan: %s, %s", inputMsg, outputMsg)
 
 	chainID := chain.ChainID()
-	// TODO:
-	evmContractChange := migrations.EVMContractChangeNone
 
-	var burnerContractChange migrations.BurnerContractChange
+	burnerContractChange := migrations.BurnerContractChangeNone
+	evmContractChange := migrations.EVMContractChangeNone
 	switch chainID {
 	case flow.Emulator:
 		burnerContractChange = migrations.BurnerContractChangeDeploy
+		evmContractChange = migrations.EVMContractChangeDeploy
 	case flow.Testnet, flow.Mainnet:
 		burnerContractChange = migrations.BurnerContractChangeUpdate
+		evmContractChange = migrations.EVMContractChangeUpdate
 	}
 
 	stagedContracts, err := migrations.StagedContractsFromCSV(flagStagedContractsFile)

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -353,6 +353,16 @@ func NewCadence1ContractsMigrations(
 		)
 	}
 
+	if opts.EVMContractChange == EVMContractChangeDeploy {
+		migs = append(
+			migs,
+			NamedMigration{
+				Name:    "evm-deployment-migration",
+				Migrate: NewEVMDeploymentMigration(opts.ChainID, log),
+			},
+		)
+	}
+
 	if opts.BurnerContractChange == BurnerContractChangeDeploy {
 		migs = append(
 			migs,

--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -30,7 +30,8 @@ type EVMContractChange uint8
 
 const (
 	EVMContractChangeNone EVMContractChange = iota
-	EVMContractChangeFull
+	EVMContractChangeDeploy
+	EVMContractChangeUpdate
 )
 
 type BurnerContractChange uint8
@@ -213,11 +214,8 @@ func SystemContractChanges(chainID flow.ChainID, options SystemContractsMigratio
 		)
 	}
 
-	// EVM related contracts
-	switch options.EVM {
-	case EVMContractChangeNone:
-		// do nothing
-	case EVMContractChangeFull:
+	// EVM contract
+	if options.EVM == EVMContractChangeUpdate {
 		contractChanges = append(
 			contractChanges,
 			NewSystemContractChange(
@@ -229,8 +227,6 @@ func SystemContractChanges(chainID flow.ChainID, options SystemContractsMigratio
 				),
 			),
 		)
-	default:
-		panic(fmt.Errorf("unsupported EVM contract change option: %d", options.EVM))
 	}
 
 	// Burner contract

--- a/cmd/util/ledger/migrations/deploy_migration.go
+++ b/cmd/util/ledger/migrations/deploy_migration.go
@@ -6,6 +6,8 @@ import (
 	coreContracts "github.com/onflow/flow-core-contracts/lib/go/contracts"
 	"github.com/rs/zerolog"
 
+	evm "github.com/onflow/flow-go/fvm/evm/stdlib"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -49,6 +51,30 @@ func NewBurnerDeploymentMigration(
 		Contract{
 			Name: "Burner",
 			Code: coreContracts.Burner(),
+		},
+		address,
+		map[flow.Address]struct{}{
+			address: {},
+		},
+		logger,
+	)
+}
+
+func NewEVMDeploymentMigration(
+	chainID flow.ChainID,
+	logger zerolog.Logger,
+) RegistersMigration {
+	systemContracts := systemcontracts.SystemContractsForChain(chainID)
+	address := systemContracts.EVMContract.Address
+	return NewDeploymentMigration(
+		chainID,
+		Contract{
+			Name: systemContracts.EVMContract.Name,
+			Code: evm.ContractCode(
+				systemContracts.NonFungibleToken.Address,
+				systemContracts.FungibleToken.Address,
+				systemContracts.FlowToken.Address,
+			),
 		},
 		address,
 		map[flow.Address]struct{}{


### PR DESCRIPTION
See https://discord.com/channels/613813861610684416/1167476806333513800/1239682951923368016

The reduced version of the EVM contract is now deployed to TN and MN. These contracts need to be updated to the full EVM contract in the migration.

In the old Emulator state, the EVM contract does not exist at all, so the full EVM contracts needs to get deployed.