### PR TITLE
Use faster atree funcs to speedup Cadence 1.0 migration

### DIFF
--- a/cmd/util/ledger/migrations/account_storage_migration.go
+++ b/cmd/util/ledger/migrations/account_storage_migration.go
@@ -41,7 +41,7 @@ func NewAccountStorageMigration(
 		}
 
 		// Commit the changes
-		err = storage.Commit(inter, false)
+		err = storage.NondeterministicCommit(inter, false)
 		if err != nil {
 			return fmt.Errorf("failed to commit changes: %w", err)
 		}

--- a/cmd/util/ledger/migrations/cadence_value_diff_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff_test.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createTestPayloads(t, address, domain),
@@ -46,7 +47,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createTestPayloads(t, address, domain),
@@ -67,7 +68,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createTestPayloads(t, address, domain),
@@ -94,7 +95,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
@@ -121,7 +122,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
@@ -148,7 +149,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
@@ -174,7 +175,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		createPayloads := func(arrayValues []interpreter.Value) []*ledger.Payload {
 
@@ -229,7 +230,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -284,7 +285,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		createPayloads := func(dictValues []interpreter.Value) []*ledger.Payload {
 
@@ -340,7 +341,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -401,7 +402,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		createPayloads := func(compositeFields []string, compositeValues []interpreter.Value) []*ledger.Payload {
 
@@ -462,7 +463,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -529,7 +530,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		createPayloads := func(compositeFields []string, compositeValues []interpreter.Value) []*ledger.Payload {
 
@@ -590,7 +591,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -701,7 +702,7 @@ func createStorageMapPayloads(t *testing.T, address common.Address, domain strin
 		)
 	}
 
-	err = mr.Storage.Commit(mr.Interpreter, false)
+	err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 	require.NoError(t, err)
 
 	// finalize the transaction
@@ -850,7 +851,7 @@ func createTestPayloads(t *testing.T, address common.Address, domain string) []*
 		),
 	)
 
-	err = mr.Storage.Commit(mr.Interpreter, false)
+	err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 	require.NoError(t, err)
 
 	// finalize the transaction

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -791,7 +791,7 @@ func TestProgramParsingError(t *testing.T) {
 		capabilityValue,
 	)
 
-	err = storage.Commit(runtime.Interpreter, false)
+	err = storage.NondeterministicCommit(runtime.Interpreter, false)
 	require.NoError(t, err)
 
 	// finalize the transaction
@@ -930,7 +930,7 @@ func TestCoreContractUsage(t *testing.T) {
 			capabilityValue,
 		)
 
-		err = storage.Commit(runtime.Interpreter, false)
+		err = storage.NondeterministicCommit(runtime.Interpreter, false)
 		require.NoError(t, err)
 
 		// finalize the transaction

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -86,7 +86,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 		nil,
 	)
 
-	err := checkStorageHealth(address, storage, accountRegisters)
+	err := checkStorageHealth(address, storage, accountRegisters, m.nWorkers)
 	if err == nil {
 		return nil
 	}

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -121,7 +121,7 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 		dict1,
 	)
 
-	err = storage.Commit(inter, false)
+	err = storage.NondeterministicCommit(inter, false)
 	require.NoError(t, err)
 
 	oldPayloads := make([]*ledger.Payload, 0, len(payloads))

--- a/cmd/util/ledger/migrations/fix_broken_data_migration.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration.go
@@ -78,7 +78,7 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 	storage := migrationRuntime.Storage
 
 	// Load all atree registers in storage
-	err := loadAtreeSlabsInStorage(storage, accountRegisters)
+	err := loadAtreeSlabsInStorage(storage, accountRegisters, m.nWorkers)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 
 	m.mergeBrokenPayloads(brokenPayloads)
 
-	err = storage.FastCommit(m.nWorkers)
+	err = storage.NondeterministicFastCommit(m.nWorkers)
 	if err != nil {
 		return fmt.Errorf("failed to commit storage: %w", err)
 	}

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -707,7 +707,7 @@ func TestStagedContractsMigration(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("Also in the same storage path prefix"),
 		)
 
-		err = mr.Storage.Commit(mr.Interpreter, false)
+		err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 		require.NoError(t, err)
 
 		result, err := mr.TransactionState.FinalizeMainTransaction()

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -1,8 +1,6 @@
 package migrations
 
 import (
-	"fmt"
-
 	"github.com/onflow/atree"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
@@ -31,9 +29,10 @@ func init() {
 	}
 }
 
-func loadAtreeSlabsInStorage(storage *runtime.Storage, registers registers.Registers) error {
+func getSlabIDsFromRegisters(registers registers.Registers) ([]atree.StorageID, error) {
+	storageIDs := make([]atree.StorageID, 0, registers.Count())
 
-	return registers.ForEach(func(owner string, key string, value []byte) error {
+	err := registers.ForEach(func(owner string, key string, value []byte) error {
 
 		if !flow.IsSlabIndexKey(key) {
 			return nil
@@ -44,23 +43,39 @@ func loadAtreeSlabsInStorage(storage *runtime.Storage, registers registers.Regis
 			atree.StorageIndex([]byte(key[1:])),
 		)
 
-		// Retrieve the slab
-		_, _, err := storage.Retrieve(storageID)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve slab %s: %w", storageID, err)
-		}
+		storageIDs = append(storageIDs, storageID)
 
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return storageIDs, nil
+}
+
+func loadAtreeSlabsInStorage(
+	storage *runtime.Storage,
+	registers registers.Registers,
+	nWorkers int,
+) error {
+
+	storageIDs, err := getSlabIDsFromRegisters(registers)
+	if err != nil {
+		return err
+	}
+
+	return storage.PersistentSlabStorage.BatchPreload(storageIDs, nWorkers)
 }
 
 func checkStorageHealth(
 	address common.Address,
 	storage *runtime.Storage,
 	registers registers.Registers,
+	nWorkers int,
 ) error {
 
-	err := loadAtreeSlabsInStorage(storage, registers)
+	err := loadAtreeSlabsInStorage(storage, registers, nWorkers)
 	if err != nil {
 		return err
 	}

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -19,6 +19,7 @@ type Registers interface {
 	Set(owner string, key string, value []byte) error
 	ForEach(f ForEachCallback) error
 	Payloads() []*ledger.Payload
+	Count() int
 }
 
 // ByAccount represents the registers of all accounts

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
-	github.com/onflow/atree v0.7.0-rc.1
-	github.com/onflow/cadence v1.0.0-preview.26
+	github.com/onflow/atree v0.7.0-rc.2
+	github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2152,13 +2152,13 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/atree v0.7.0-rc.1 h1:g2DFhC3JeaA+L7/HZOp4NwE+OfxvfJ8nibymHHw7i3g=
-github.com/onflow/atree v0.7.0-rc.1/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
+github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
+github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.26 h1:FcinbrV7s7SIPzgxEAtA0wWqqf7QrvcSFvMVaKEedv4=
-github.com/onflow/cadence v1.0.0-preview.26/go.mod h1:fGhLBbuEmv5rh48qv0ZS0tUz53gxWsHpB4dPsF09h6E=
+github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a h1:doxA0f5CMnFHlWoVG2mQ/DLsQnIhtazl+P6Snt+7LPc=
+github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -197,8 +197,8 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.7.0-rc.1 // indirect
-	github.com/onflow/cadence v1.0.0-preview.26 // indirect
+	github.com/onflow/atree v0.7.0-rc.2 // indirect
+	github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2140,11 +2140,11 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/atree v0.7.0-rc.1 h1:g2DFhC3JeaA+L7/HZOp4NwE+OfxvfJ8nibymHHw7i3g=
-github.com/onflow/atree v0.7.0-rc.1/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
+github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
+github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.26 h1:FcinbrV7s7SIPzgxEAtA0wWqqf7QrvcSFvMVaKEedv4=
-github.com/onflow/cadence v1.0.0-preview.26/go.mod h1:fGhLBbuEmv5rh48qv0ZS0tUz53gxWsHpB4dPsF09h6E=
+github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a h1:doxA0f5CMnFHlWoVG2mQ/DLsQnIhtazl+P6Snt+7LPc=
+github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview.26
+	github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
@@ -241,7 +241,7 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.7.0-rc.1 // indirect
+	github.com/onflow/atree v0.7.0-rc.2 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2134,11 +2134,11 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/atree v0.7.0-rc.1 h1:g2DFhC3JeaA+L7/HZOp4NwE+OfxvfJ8nibymHHw7i3g=
-github.com/onflow/atree v0.7.0-rc.1/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
+github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
+github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.26 h1:FcinbrV7s7SIPzgxEAtA0wWqqf7QrvcSFvMVaKEedv4=
-github.com/onflow/cadence v1.0.0-preview.26/go.mod h1:fGhLBbuEmv5rh48qv0ZS0tUz53gxWsHpB4dPsF09h6E=
+github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a h1:doxA0f5CMnFHlWoVG2mQ/DLsQnIhtazl+P6Snt+7LPc=
+github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=


### PR DESCRIPTION
This PR updates Cadence 1.0 migration to use newer and faster functions provided by atree:
- `NondeterministicFastCommit()` as faster alterative to `FastCommit()`
- `BatchPreload()` to decode slabs in parallel

More details at https://github.com/onflow/atree/releases

Equivalent change for atree migration (not Cadence 1.0 migration) was 1h20m faster on m1 with nworkers=40 and all storage checks & validation enabled.  However, speedup can vary depending on number of cpus, input data (mainnet vs testnet), etc.

#### Changes in the PR include:

`NondeterministicFastCommit` placed all instances of storage `Commit()` in Cadence migrations.

`BatchPreload()` is only used where all slabs are expected to be loaded:
- storage health check
- Cadence value diff reporter 
- fix broken references migration
- filter unreferenced slab migration

:warning: This PR needs a newer Cadence dependency in flow-go.  Please don't merge until a new Cadence release is tagged.