### PR TITLE
Disable spock proof generation for migrations

### DIFF
--- a/cmd/util/ledger/migrations/migrator_runtime.go
+++ b/cmd/util/ledger/migrations/migrator_runtime.go
@@ -108,7 +108,7 @@ func NewBasicMigrationRuntime(regs registers.Registers) *BasicMigrationRuntime {
 			},
 			state.DefaultParameters(),
 			func() hash.Hasher {
-				return newDummyHasher(0)
+				return dummyHasher{}
 			},
 		),
 	)
@@ -179,12 +179,11 @@ func NewInterpreterMigrationRuntime(
 	}, nil
 }
 
-type dummyHasher struct{ size int }
+type dummyHasher struct{}
 
-func newDummyHasher(size int) hash.Hasher               { return &dummyHasher{size} }
-func (d *dummyHasher) Algorithm() hash.HashingAlgorithm { return hash.UnknownHashingAlgorithm }
-func (d *dummyHasher) Size() int                        { return d.size }
-func (d *dummyHasher) ComputeHash([]byte) hash.Hash     { return make([]byte, d.size) }
-func (d *dummyHasher) Write([]byte) (int, error)        { return 0, nil }
-func (d *dummyHasher) SumHash() hash.Hash               { return make([]byte, d.size) }
-func (d *dummyHasher) Reset()                           {}
+func (d dummyHasher) Algorithm() hash.HashingAlgorithm { return hash.UnknownHashingAlgorithm }
+func (d dummyHasher) Size() int                        { return 0 }
+func (d dummyHasher) ComputeHash([]byte) hash.Hash     { return nil }
+func (d dummyHasher) Write([]byte) (int, error)        { return 0, nil }
+func (d dummyHasher) SumHash() hash.Hash               { return nil }
+func (d dummyHasher) Reset()                           {}

--- a/cmd/util/ledger/migrations/migrator_runtime.go
+++ b/cmd/util/ledger/migrations/migrator_runtime.go
@@ -2,12 +2,12 @@ package migrations
 
 import (
 	"fmt"
-	"github.com/onflow/crypto/hash"
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/crypto/hash"
 
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
@@ -99,6 +99,8 @@ func (c InterpreterMigrationRuntimeConfig) NewRuntimeInterface(
 
 // NewBasicMigrationRuntime returns a basic runtime for migrations.
 func NewBasicMigrationRuntime(regs registers.Registers) *BasicMigrationRuntime {
+	// Create a new transaction state with a dummy hasher
+	// because we do not need spock proofs for migrations.
 	transactionState := state.NewTransactionStateFromExecutionState(
 		state.NewExecutionStateWithSpockStateHasher(
 			registers.StorageSnapshot{
@@ -106,7 +108,7 @@ func NewBasicMigrationRuntime(regs registers.Registers) *BasicMigrationRuntime {
 			},
 			state.DefaultParameters(),
 			func() hash.Hasher {
-				return newDummyHasher(32)
+				return newDummyHasher(0)
 			},
 		),
 	)

--- a/fvm/storage/state/execution_state.go
+++ b/fvm/storage/state/execution_state.go
@@ -2,9 +2,9 @@ package state
 
 import (
 	"fmt"
-	"github.com/onflow/crypto/hash"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/crypto/hash"
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"

--- a/fvm/storage/state/execution_state.go
+++ b/fvm/storage/state/execution_state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"github.com/onflow/crypto/hash"
 
 	"github.com/onflow/cadence/runtime/common"
 
@@ -103,10 +104,23 @@ func NewExecutionState(
 	snapshot snapshot.StorageSnapshot,
 	params StateParameters,
 ) *ExecutionState {
+	return NewExecutionStateWithSpockStateHasher(
+		snapshot,
+		params,
+		DefaultSpockSecretHasher,
+	)
+}
+
+// NewExecutionStateWithSpockStateHasher constructs a new state with a custom hasher
+func NewExecutionStateWithSpockStateHasher(
+	snapshot snapshot.StorageSnapshot,
+	params StateParameters,
+	getHasher func() hash.Hasher,
+) *ExecutionState {
 	m := meter.NewMeter(params.MeterParameters)
 	return &ExecutionState{
 		finalized:        false,
-		spockState:       newSpockState(snapshot),
+		spockState:       newSpockState(snapshot, getHasher),
 		meter:            m,
 		limitsController: newLimitsController(params),
 	}

--- a/fvm/storage/state/spock_state.go
+++ b/fvm/storage/state/spock_state.go
@@ -33,10 +33,13 @@ type spockState struct {
 	finalizedSpockSecret []byte
 }
 
+// DefaultSpockSecretHasher returns a new SHA3_256 hasher
 var DefaultSpockSecretHasher = func() hash.Hasher {
 	return hash.NewSHA3_256()
 }
 
+// NewSpockState creates a new spock state
+// getHasher will be called to create a new hasher for the spock state and each child state
 func newSpockState(base snapshot.StorageSnapshot, getHasher func() hash.Hasher) *spockState {
 	return &spockState{
 		storageState:      newStorageState(base),

--- a/fvm/storage/state/spock_state_test.go
+++ b/fvm/storage/state/spock_state_test.go
@@ -31,8 +31,8 @@ func testSpock(
 ) []*spockState {
 	resultStates := []*spockState{}
 	for _, experiment := range counterfactualExperiments {
-		run1 := newSpockState(snapshot.MapStorageSnapshot{})
-		run2 := newSpockState(snapshot.MapStorageSnapshot{})
+		run1 := newSpockState(snapshot.MapStorageSnapshot{}, DefaultSpockSecretHasher)
+		run2 := newSpockState(snapshot.MapStorageSnapshot{}, DefaultSpockSecretHasher)
 
 		if experiment != nil {
 			experiment(t, run1)
@@ -106,12 +106,16 @@ func TestSpockStateGetDifferentUnderlyingStorage(t *testing.T) {
 	state1 := newSpockState(
 		snapshot.MapStorageSnapshot{
 			badRegisterId: value1,
-		})
+		},
+		DefaultSpockSecretHasher,
+	)
 
 	state2 := newSpockState(
 		snapshot.MapStorageSnapshot{
 			badRegisterId: value2,
-		})
+		},
+		DefaultSpockSecretHasher,
+	)
 
 	value, err := state1.Get(badRegisterId)
 	require.NoError(t, err)
@@ -407,7 +411,9 @@ func TestSpockStateNewChild(t *testing.T) {
 	parent := newSpockState(
 		snapshot.MapStorageSnapshot{
 			baseRegisterId: baseValue,
-		})
+		},
+		DefaultSpockSecretHasher,
+	)
 
 	err := parent.Set(parentRegisterId1, parentValue)
 	require.NoError(t, err)

--- a/fvm/storage/state/transaction_state.go
+++ b/fvm/storage/state/transaction_state.go
@@ -177,14 +177,7 @@ func NewTransactionState(
 	params StateParameters,
 ) NestedTransactionPreparer {
 	startState := NewExecutionState(snapshot, params)
-	return &transactionState{
-		nestedTransactions: []nestedTransactionStackFrame{
-			nestedTransactionStackFrame{
-				ExecutionState:   startState,
-				parseRestriction: nil,
-			},
-		},
-	}
+	return NewTransactionStateFromExecutionState(startState)
 }
 
 // NewTransactionStateFromExecutionState constructs a new state transaction directly
@@ -194,7 +187,7 @@ func NewTransactionStateFromExecutionState(
 ) NestedTransactionPreparer {
 	return &transactionState{
 		nestedTransactions: []nestedTransactionStackFrame{
-			nestedTransactionStackFrame{
+			{
 				ExecutionState:   startState,
 				parseRestriction: nil,
 			},

--- a/fvm/storage/state/transaction_state.go
+++ b/fvm/storage/state/transaction_state.go
@@ -187,6 +187,21 @@ func NewTransactionState(
 	}
 }
 
+// NewTransactionStateFromExecutionState constructs a new state transaction directly
+// from an execution state.
+func NewTransactionStateFromExecutionState(
+	startState *ExecutionState,
+) NestedTransactionPreparer {
+	return &transactionState{
+		nestedTransactions: []nestedTransactionStackFrame{
+			nestedTransactionStackFrame{
+				ExecutionState:   startState,
+				parseRestriction: nil,
+			},
+		},
+	}
+}
+
 func (txnState *transactionState) current() nestedTransactionStackFrame {
 	return txnState.nestedTransactions[txnState.NumNestedTransactions()]
 }


### PR DESCRIPTION
closes: https://github.com/onflow/flow-go/issues/5919