### PR TITLE
Use Dynamic Protocol State API to compute events / metrics

### DIFF
--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -821,6 +821,11 @@ func (m *FollowerState) epochMetricsAndEventsOnBlockFinalized(parentPsSnapshot, 
 	parentEpochPhase := parentPsSnapshot.EpochPhase()
 	childEpochPhase := finalizedPsSnapshot.EpochPhase()
 
+	// Same epoch phase -> nothing to do
+	if parentEpochPhase == childEpochPhase {
+		return
+	}
+
 	// Different counter -> must be an epoch transition
 	if parentEpochCounter != childEpochCounter {
 		childEpochSetup := finalizedPsSnapshot.EpochSetup()
@@ -839,10 +844,6 @@ func (m *FollowerState) epochMetricsAndEventsOnBlockFinalized(parentPsSnapshot, 
 			func() { m.metrics.CurrentDKGPhase2FinalView(childEpochSetup.DKGPhase2FinalView) },
 			func() { m.metrics.CurrentDKGPhase3FinalView(childEpochSetup.DKGPhase3FinalView) },
 		)
-		return
-	}
-	// Same counter and same phase -> nothing to do
-	if parentEpochPhase == childEpochPhase {
 		return
 	}
 	// Transition from Staking phase to Setup phase. `finalized` is first block in Setup phase.

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -971,6 +971,8 @@ func (state *State) populateCache() error {
 }
 
 // isEpochEmergencyFallbackTriggered checks whether epoch fallback has been globally triggered.
+// TODO(efm-recovery): Stop storing a global EFM flag, use parentState.EFMTriggered instead
+//
 // Returns:
 // * (true, nil) if epoch fallback is triggered
 // * (false, nil) if epoch fallback is not triggered (including if the flag is not set)


### PR DESCRIPTION
- Replace direct inspection of service events at the `FollowerState` level with use of the Dynamic Protocol State API. 
- Simplifies `isFirstBlock` function

This addresses the following item from https://github.com/onflow/flow-go/issues/5666: 
> We still directly operate on service events to emit epoch-related metrics events in the FollowerState ([code](https://github.com/onflow/flow-go/pull/5477/files#diff-c79d3fc5d32f153917b7cd923ab4ba64ef22f12268ddd13f353a06391f68a96dR880)). We should instead emit metrics events using the Protocol State field, and only manipulate service events with the StateMutator and protocol state machines (lower level logic).