### PR TITLE
Sync feature/atree-inlining-cadence-v1.0 with master

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -411,7 +411,7 @@ func newMigration(
 
 		logger.Info().Msg("creating new payloads from registers ...")
 
-		newPayloads := registersByAccount.Payloads()
+		newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
 
 		logger.Info().Msgf("created new payloads (%d) from registers", len(newPayloads))
 
@@ -428,8 +428,8 @@ func newByAccountRegistersFromPayloadAccountGrouping(
 ) {
 	g, ctx := errgroup.WithContext(context.Background())
 
-	jobs := make(chan *util.PayloadAccountGroup)
-	results := make(chan *registers.AccountRegisters)
+	jobs := make(chan *util.PayloadAccountGroup, nWorker)
+	results := make(chan *registers.AccountRegisters, nWorker)
 
 	g.Go(func() error {
 		defer close(jobs)

--- a/cmd/util/ledger/migrations/account_storage_migration.go
+++ b/cmd/util/ledger/migrations/account_storage_migration.go
@@ -41,7 +41,7 @@ func NewAccountStorageMigration(
 		}
 
 		// Commit the changes
-		err = storage.Commit(inter, false)
+		err = storage.NondeterministicCommit(inter, false)
 		if err != nil {
 			return fmt.Errorf("failed to commit changes: %w", err)
 		}

--- a/cmd/util/ledger/migrations/cadence_value_diff_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff_test.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"fmt"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createTestPayloads(t, address, domain),
@@ -46,7 +47,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createTestPayloads(t, address, domain),
@@ -67,7 +68,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createTestPayloads(t, address, domain),
@@ -94,7 +95,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
@@ -121,7 +122,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
@@ -148,7 +149,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		diffReporter.DiffStates(
 			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
@@ -174,7 +175,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		createPayloads := func(arrayValues []interpreter.Value) []*ledger.Payload {
 
@@ -229,7 +230,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -284,7 +285,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		createPayloads := func(dictValues []interpreter.Value) []*ledger.Payload {
 
@@ -340,7 +341,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -401,7 +402,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		createPayloads := func(compositeFields []string, compositeValues []interpreter.Value) []*ledger.Payload {
 
@@ -462,7 +463,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -529,7 +530,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		writer := &testReportWriter{}
 
-		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true)
+		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		createPayloads := func(compositeFields []string, compositeValues []interpreter.Value) []*ledger.Payload {
 
@@ -590,7 +591,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				),
 			)
 
-			err = mr.Storage.Commit(mr.Interpreter, false)
+			err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 			require.NoError(t, err)
 
 			// finalize the transaction
@@ -701,7 +702,7 @@ func createStorageMapPayloads(t *testing.T, address common.Address, domain strin
 		)
 	}
 
-	err = mr.Storage.Commit(mr.Interpreter, false)
+	err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 	require.NoError(t, err)
 
 	// finalize the transaction
@@ -850,7 +851,7 @@ func createTestPayloads(t *testing.T, address common.Address, domain string) []*
 		),
 	)
 
-	err = mr.Storage.Commit(mr.Interpreter, false)
+	err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 	require.NoError(t, err)
 
 	// finalize the transaction

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -791,7 +791,7 @@ func TestProgramParsingError(t *testing.T) {
 		capabilityValue,
 	)
 
-	err = storage.Commit(runtime.Interpreter, false)
+	err = storage.NondeterministicCommit(runtime.Interpreter, false)
 	require.NoError(t, err)
 
 	// finalize the transaction
@@ -930,7 +930,7 @@ func TestCoreContractUsage(t *testing.T) {
 			capabilityValue,
 		)
 
-		err = storage.Commit(runtime.Interpreter, false)
+		err = storage.NondeterministicCommit(runtime.Interpreter, false)
 		require.NoError(t, err)
 
 		// finalize the transaction

--- a/cmd/util/ledger/migrations/deploy_migration_test.go
+++ b/cmd/util/ledger/migrations/deploy_migration_test.go
@@ -62,6 +62,8 @@ func TestDeploy(t *testing.T) {
 
 	chain := chainID.Chain()
 
+	const nWorker = 2
+
 	systemContracts := systemcontracts.SystemContractsForChain(chainID)
 	serviceAccountAddress := systemContracts.FlowServiceAccount.Address
 	fungibleTokenAddress := systemContracts.FungibleToken.Address
@@ -144,7 +146,9 @@ func TestDeploy(t *testing.T) {
 
 	storageSnapshot := snapshot.MapStorageSnapshot{}
 
-	for _, newPayload := range registersByAccount.Payloads() {
+	newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
+
+	for _, newPayload := range newPayloads {
 		registerID, registerValue, err := convert.PayloadToRegister(newPayload)
 		require.NoError(t, err)
 

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration.go
@@ -92,7 +92,7 @@ func (m *FilterUnreferencedSlabsMigration) MigrateAccount(
 		nil,
 	)
 
-	err := checkStorageHealth(address, storage, accountRegisters)
+	err := checkStorageHealth(address, storage, accountRegisters, m.nWorkers)
 	if err == nil {
 		return nil
 	}

--- a/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
+++ b/cmd/util/ledger/migrations/filter_unreferenced_slabs_migration_test.go
@@ -28,6 +28,8 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 	const chainID = flow.Emulator
 	chain := chainID.Chain()
 
+	const nWorker = 2
+
 	testFlowAddress, err := chain.AddressAtIndex(1_000_000)
 	require.NoError(t, err)
 
@@ -130,7 +132,7 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 		dict1,
 	)
 
-	err = storage.Commit(inter, false)
+	err = storage.NondeterministicCommit(inter, false)
 	require.NoError(t, err)
 
 	oldPayloads := make([]*ledger.Payload, 0, len(payloads))
@@ -187,7 +189,7 @@ func TestFilterUnreferencedSlabs(t *testing.T) {
 		string([]byte{flow.SlabIndexPrefix, 0, 0, 0, 0, 0, 0, 0, 3}): {},
 	}
 
-	newPayloads := registersByAccount.Payloads()
+	newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
 	assert.Len(t, newPayloads, totalSlabCount-len(expectedKeys))
 
 	expectedFilteredPayloads := make([]*ledger.Payload, 0, len(expectedKeys))

--- a/cmd/util/ledger/migrations/fix_broken_data_migration.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration.go
@@ -78,7 +78,7 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 	storage := migrationRuntime.Storage
 
 	// Load all atree registers in storage
-	err := loadAtreeSlabsInStorage(storage, accountRegisters)
+	err := loadAtreeSlabsInStorage(storage, accountRegisters, m.nWorkers)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 
 	m.mergeBrokenPayloads(brokenPayloads)
 
-	err = storage.FastCommit(m.nWorkers)
+	err = storage.NondeterministicFastCommit(m.nWorkers)
 	if err != nil {
 		return fmt.Errorf("failed to commit storage: %w", err)
 	}

--- a/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration_test.go
@@ -19,6 +19,8 @@ import (
 func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	t.Parallel()
 
+	const nWorker = 2
+
 	rawAddress := mustDecodeHex("5e3448b3cffb97f2")
 
 	address := common.MustBytesToAddress(rawAddress)
@@ -149,7 +151,7 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	registersByAccount, err := registers.NewByAccountFromPayloads(oldPayloads)
 	require.NoError(t, err)
 
-	err = migration.InitMigration(log, registersByAccount, 1)
+	err = migration.InitMigration(log, registersByAccount, nWorker)
 	require.NoError(t, err)
 
 	accountRegisters := registersByAccount.AccountRegisters(string(address[:]))
@@ -164,7 +166,7 @@ func TestFixSlabsWithBrokenReferences(t *testing.T) {
 	err = migration.Close()
 	require.NoError(t, err)
 
-	newPayloads := registersByAccount.Payloads()
+	newPayloads := registersByAccount.DestructIntoPayloads(nWorker)
 
 	require.Equal(t, len(expectedNewPayloads), len(newPayloads))
 

--- a/cmd/util/ledger/migrations/migrator_runtime.go
+++ b/cmd/util/ledger/migrations/migrator_runtime.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/onflow/crypto/hash"
 
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
@@ -98,11 +99,18 @@ func (c InterpreterMigrationRuntimeConfig) NewRuntimeInterface(
 
 // NewBasicMigrationRuntime returns a basic runtime for migrations.
 func NewBasicMigrationRuntime(regs registers.Registers) *BasicMigrationRuntime {
-	transactionState := state.NewTransactionState(
-		registers.StorageSnapshot{
-			Registers: regs,
-		},
-		state.DefaultParameters(),
+	// Create a new transaction state with a dummy hasher
+	// because we do not need spock proofs for migrations.
+	transactionState := state.NewTransactionStateFromExecutionState(
+		state.NewExecutionStateWithSpockStateHasher(
+			registers.StorageSnapshot{
+				Registers: regs,
+			},
+			state.DefaultParameters(),
+			func() hash.Hasher {
+				return dummyHasher{}
+			},
+		),
 	)
 	accounts := environment.NewAccounts(transactionState)
 
@@ -170,3 +178,12 @@ func NewInterpreterMigrationRuntime(
 		ContractNamesProvider:   env,
 	}, nil
 }
+
+type dummyHasher struct{}
+
+func (d dummyHasher) Algorithm() hash.HashingAlgorithm { return hash.UnknownHashingAlgorithm }
+func (d dummyHasher) Size() int                        { return 0 }
+func (d dummyHasher) ComputeHash([]byte) hash.Hash     { return nil }
+func (d dummyHasher) Write([]byte) (int, error)        { return 0, nil }
+func (d dummyHasher) SumHash() hash.Hash               { return nil }
+func (d dummyHasher) Reset()                           {}

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -707,7 +707,7 @@ func TestStagedContractsMigration(t *testing.T) {
 			interpreter.NewUnmeteredStringValue("Also in the same storage path prefix"),
 		)
 
-		err = mr.Storage.Commit(mr.Interpreter, false)
+		err = mr.Storage.NondeterministicCommit(mr.Interpreter, false)
 		require.NoError(t, err)
 
 		result, err := mr.TransactionState.FinalizeMainTransaction()
@@ -763,7 +763,7 @@ func TestStagedContractsMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, logWriter.logs, 4)
-		require.Contains(t, logWriter.logs[0], "found 6 registers in account 0x2ceae959ed1a7e7a")
+		require.Contains(t, logWriter.logs[0], "found 4 registers in account 0x2ceae959ed1a7e7a")
 		require.Contains(t, logWriter.logs[1], "found a value with an unexpected type `String`")
 		require.Contains(t, logWriter.logs[2], "found 1 staged contracts from payloads")
 		require.Contains(t, logWriter.logs[3], "total of 1 unique contracts are staged for all accounts")

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -2,6 +2,7 @@ package registers
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/onflow/atree"
 	"github.com/rs/zerolog"
@@ -18,7 +19,7 @@ type Registers interface {
 	Get(owner string, key string) ([]byte, error)
 	Set(owner string, key string, value []byte) error
 	ForEach(f ForEachCallback) error
-	Payloads() []*ledger.Payload
+	Count() int
 }
 
 // ByAccount represents the registers of all accounts
@@ -70,7 +71,7 @@ func (b *ByAccount) Get(owner string, key string) ([]byte, error) {
 
 func (b *ByAccount) Set(owner string, key string, value []byte) error {
 	accountRegisters := b.AccountRegisters(owner)
-	accountRegisters.registers[key] = value
+	accountRegisters.uncheckedSet(key, value)
 	return nil
 }
 
@@ -84,11 +85,53 @@ func (b *ByAccount) ForEach(f ForEachCallback) error {
 	return nil
 }
 
-func (b *ByAccount) Payloads() []*ledger.Payload {
-	payloads := make([]*ledger.Payload, 0, len(b.registers)*payloadsPerAccountEstimate)
-	for _, accountRegisters := range b.registers {
-		payloads = accountRegisters.appendPayloads(payloads)
+func (b *ByAccount) DestructIntoPayloads(nWorker int) []*ledger.Payload {
+	payloads := make([]*ledger.Payload, b.Count())
+
+	type job struct {
+		registers *AccountRegisters
+		payloads  []*ledger.Payload
 	}
+
+	var wg sync.WaitGroup
+
+	jobs := make(chan job, b.AccountCount())
+
+	worker := func() {
+		defer wg.Done()
+		for job := range jobs {
+			job.registers.insertPayloads(job.payloads)
+		}
+	}
+
+	for i := 0; i < nWorker; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+	startOffset := 0
+	for owner, accountRegisters := range b.registers {
+
+		endOffset := startOffset + accountRegisters.Count()
+		accountPayloads := payloads[startOffset:endOffset]
+
+		jobs <- job{
+			registers: accountRegisters,
+			payloads:  accountPayloads,
+		}
+
+		// Remove the account from the map to reduce memory usage.
+		// The account registers are now stored in the payloads,
+		// so we don't need to keep them in the by-account registers.
+		// This allows GC to collect converted account registers during the loop.
+		delete(b.registers, owner)
+
+		startOffset = endOffset
+	}
+	close(jobs)
+
+	wg.Wait()
+
 	return payloads
 }
 
@@ -157,12 +200,16 @@ func (a *AccountRegisters) Set(owner string, key string, value []byte) error {
 	if owner != a.owner {
 		return fmt.Errorf("owner mismatch: expected %s, got %s", a.owner, owner)
 	}
+	a.uncheckedSet(key, value)
+	return nil
+}
+
+func (a *AccountRegisters) uncheckedSet(key string, value []byte) {
 	if len(value) == 0 {
 		delete(a.registers, key)
 	} else {
 		a.registers[key] = value
 	}
-	return nil
 }
 
 func (a *AccountRegisters) ForEach(f ForEachCallback) error {
@@ -184,14 +231,26 @@ func (a *AccountRegisters) Owner() string {
 }
 
 func (a *AccountRegisters) Payloads() []*ledger.Payload {
-	payloads := make([]*ledger.Payload, 0, len(a.registers))
-	return a.appendPayloads(payloads)
+	payloads := make([]*ledger.Payload, 0, a.Count())
+	a.insertPayloads(payloads)
+	return payloads
 }
 
-func (a *AccountRegisters) appendPayloads(payloads []*ledger.Payload) []*ledger.Payload {
+func (a *AccountRegisters) insertPayloads(payloads []*ledger.Payload) {
+	payloadCount := len(payloads)
+	registerCount := len(a.registers)
+	if payloadCount != registerCount {
+		panic(fmt.Errorf(
+			"given payloads slice has wrong size: got %d, expected %d",
+			payloadCount,
+			registerCount,
+		))
+	}
+
+	index := 0
 	for key, value := range a.registers {
 		if len(value) == 0 {
-			continue
+			panic(fmt.Errorf("unexpected empty register value: %x, %x", a.owner, key))
 		}
 
 		ledgerKey := convert.RegisterIDToLedgerKey(flow.RegisterID{
@@ -199,9 +258,9 @@ func (a *AccountRegisters) appendPayloads(payloads []*ledger.Payload) []*ledger.
 			Key:   key,
 		})
 		payload := ledger.NewPayload(ledgerKey, value)
-		payloads = append(payloads, payload)
+		payloads[index] = payload
+		index++
 	}
-	return payloads
 }
 
 func NewAccountRegistersFromPayloads(owner string, payloads []*ledger.Payload) (*AccountRegisters, error) {

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("82b80015ac01a065f22b18ebfb739c492bacfddde79a584d19658dcfd7ff4673")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("3f0f1fea08e7e289c2b94f019f5921382bfba87dc1b52cf1fe8f004ed8d70b1b")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -149,6 +149,53 @@ contract EVM {
             )
             emit FLOWTokensDeposited(addressBytes: self.bytes, amount: amount)
         }
+
+        /// Serializes the address to a hex string without the 0x prefix
+        /// Future implementations should pass data to InternalEVM for native serialization
+        access(all)
+        view fun toString(): String {
+            let addressBytes: [UInt8] = [
+                self.bytes[0], self.bytes[1], self.bytes[2], self.bytes[3],
+                self.bytes[4], self.bytes[5], self.bytes[6], self.bytes[7],
+                self.bytes[8], self.bytes[9], self.bytes[10], self.bytes[11],
+                self.bytes[12], self.bytes[13], self.bytes[14], self.bytes[15],
+                self.bytes[16], self.bytes[17], self.bytes[18], self.bytes[19]
+            ]
+            return String.encodeHex(addressBytes)
+        }
+
+        /// Compares the address with another address
+        access(all)
+        view fun equals(_ other: EVMAddress): Bool {
+            return self.bytes == other.bytes
+        }
+    }
+
+    /// Converts a hex string to an EVM address if the string is a valid hex string
+    /// Future implementations should pass data to InternalEVM for native deserialization
+    access(all)
+    fun addressFromString(_ asHex: String): EVMAddress? {
+        pre {
+            asHex.length == 40 || asHex.length == 42: "Invalid hex string length"
+        }
+        // Remove the 0x prefix if it exists
+        let sanitized = (asHex[1] == "x" ? asHex.split(separator: "x")[1] : asHex).toLower()
+        if sanitized.length != 40 {
+            return nil
+        }
+        // Decode the hex string
+        var addressBytes: [UInt8] = asHex.decodeHex()
+        if addressBytes.length != 20 {
+            return nil
+        }
+        // Return the EVM address from the decoded hex string
+        return EVM.EVMAddress(bytes: [
+            addressBytes[0], addressBytes[1], addressBytes[2], addressBytes[3],
+            addressBytes[4], addressBytes[5], addressBytes[6], addressBytes[7],
+            addressBytes[8], addressBytes[9], addressBytes[10], addressBytes[11],
+            addressBytes[12], addressBytes[13], addressBytes[14], addressBytes[15],
+            addressBytes[16], addressBytes[17], addressBytes[18], addressBytes[19]
+        ])
     }
 
     access(all)

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -239,7 +239,7 @@ func newInternalEVMTypeEncodeABIFunction(
 
 	evmAddressTypeID := location.TypeID(gauge, evmAddressTypeQualifiedIdentifier)
 
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeEncodeABIFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -658,7 +658,7 @@ func newInternalEVMTypeDecodeABIFunction(
 ) *interpreter.HostFunctionValue {
 	evmAddressTypeID := location.TypeID(gauge, evmAddressTypeQualifiedIdentifier)
 
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeDecodeABIFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1006,7 +1006,7 @@ func newInternalEVMTypeRunFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeRunFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1070,7 +1070,7 @@ func newInternalEVMTypeDryRunFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeDryRunFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1130,7 +1130,7 @@ func newInternalEVMTypeBatchRunFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeBatchRunFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1392,7 +1392,7 @@ func newInternalEVMTypeCallFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1479,7 +1479,7 @@ func newInternalEVMTypeCreateCadenceOwnedAccountFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCreateCadenceOwnedAccountFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1516,7 +1516,7 @@ func newInternalEVMTypeDepositFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1587,7 +1587,7 @@ func newInternalEVMTypeBalanceFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1629,7 +1629,7 @@ func newInternalEVMTypeNonceFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1671,7 +1671,7 @@ func newInternalEVMTypeCodeFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1713,7 +1713,7 @@ func newInternalEVMTypeCodeHashFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1758,7 +1758,7 @@ func newInternalEVMTypeWithdrawFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1856,7 +1856,7 @@ func newInternalEVMTypeDeployFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1933,7 +1933,7 @@ var internalEVMTypeCastToAttoFLOWFunctionType = &sema.FunctionType{
 func newInternalEVMTypeCastToAttoFLOWFunction(
 	gauge common.MemoryGauge,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1963,7 +1963,7 @@ var internalEVMTypeCastToFLOWFunctionType = &sema.FunctionType{
 func newInternalEVMTypeCastToFLOWFunction(
 	gauge common.MemoryGauge,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1994,7 +1994,7 @@ func newInternalEVMTypeGetLatestBlockFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {

--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -53,7 +53,7 @@ func NewReusableCadenceRuntime(rt runtime.Runtime, config runtime.Config) *Reusa
 		Name: "randomSourceHistory",
 		Type: randomSourceFunctionType,
 		Kind: common.DeclarationKindFunction,
-		Value: interpreter.NewUnmeteredHostFunctionValue(
+		Value: interpreter.NewUnmeteredStaticHostFunctionValue(
 			randomSourceFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
 				if len(invocation.Arguments) != 0 {

--- a/fvm/storage/state/execution_state.go
+++ b/fvm/storage/state/execution_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/crypto/hash"
 
 	"github.com/onflow/flow-go/fvm/errors"
 	"github.com/onflow/flow-go/fvm/meter"
@@ -103,10 +104,23 @@ func NewExecutionState(
 	snapshot snapshot.StorageSnapshot,
 	params StateParameters,
 ) *ExecutionState {
+	return NewExecutionStateWithSpockStateHasher(
+		snapshot,
+		params,
+		DefaultSpockSecretHasher,
+	)
+}
+
+// NewExecutionStateWithSpockStateHasher constructs a new state with a custom hasher
+func NewExecutionStateWithSpockStateHasher(
+	snapshot snapshot.StorageSnapshot,
+	params StateParameters,
+	getHasher func() hash.Hasher,
+) *ExecutionState {
 	m := meter.NewMeter(params.MeterParameters)
 	return &ExecutionState{
 		finalized:        false,
-		spockState:       newSpockState(snapshot),
+		spockState:       newSpockState(snapshot, getHasher),
 		meter:            m,
 		limitsController: newLimitsController(params),
 	}

--- a/fvm/storage/state/spock_state.go
+++ b/fvm/storage/state/spock_state.go
@@ -24,6 +24,8 @@ type spockState struct {
 
 	spockSecretHasher hash.Hasher
 
+	getHasher func() hash.Hasher
+
 	// NOTE: spockState is no longer accessible once Finalize is called.  We
 	// can't support access after Finalize since spockSecretHasher.SumHash is
 	// not idempotent.  Repeated calls to SumHash (without modifying the input)
@@ -31,17 +33,26 @@ type spockState struct {
 	finalizedSpockSecret []byte
 }
 
-func newSpockState(base snapshot.StorageSnapshot) *spockState {
+// DefaultSpockSecretHasher returns a new SHA3_256 hasher
+var DefaultSpockSecretHasher = func() hash.Hasher {
+	return hash.NewSHA3_256()
+}
+
+// NewSpockState creates a new spock state
+// getHasher will be called to create a new hasher for the spock state and each child state
+func newSpockState(base snapshot.StorageSnapshot, getHasher func() hash.Hasher) *spockState {
 	return &spockState{
 		storageState:      newStorageState(base),
-		spockSecretHasher: hash.NewSHA3_256(),
+		spockSecretHasher: getHasher(),
+		getHasher:         getHasher,
 	}
 }
 
 func (state *spockState) NewChild() *spockState {
 	return &spockState{
 		storageState:      state.storageState.NewChild(),
-		spockSecretHasher: hash.NewSHA3_256(),
+		spockSecretHasher: state.getHasher(),
+		getHasher:         state.getHasher,
 	}
 }
 

--- a/fvm/storage/state/spock_state_test.go
+++ b/fvm/storage/state/spock_state_test.go
@@ -31,8 +31,8 @@ func testSpock(
 ) []*spockState {
 	resultStates := []*spockState{}
 	for _, experiment := range counterfactualExperiments {
-		run1 := newSpockState(snapshot.MapStorageSnapshot{})
-		run2 := newSpockState(snapshot.MapStorageSnapshot{})
+		run1 := newSpockState(snapshot.MapStorageSnapshot{}, DefaultSpockSecretHasher)
+		run2 := newSpockState(snapshot.MapStorageSnapshot{}, DefaultSpockSecretHasher)
 
 		if experiment != nil {
 			experiment(t, run1)
@@ -106,12 +106,16 @@ func TestSpockStateGetDifferentUnderlyingStorage(t *testing.T) {
 	state1 := newSpockState(
 		snapshot.MapStorageSnapshot{
 			badRegisterId: value1,
-		})
+		},
+		DefaultSpockSecretHasher,
+	)
 
 	state2 := newSpockState(
 		snapshot.MapStorageSnapshot{
 			badRegisterId: value2,
-		})
+		},
+		DefaultSpockSecretHasher,
+	)
 
 	value, err := state1.Get(badRegisterId)
 	require.NoError(t, err)
@@ -407,7 +411,9 @@ func TestSpockStateNewChild(t *testing.T) {
 	parent := newSpockState(
 		snapshot.MapStorageSnapshot{
 			baseRegisterId: baseValue,
-		})
+		},
+		DefaultSpockSecretHasher,
+	)
 
 	err := parent.Set(parentRegisterId1, parentValue)
 	require.NoError(t, err)

--- a/fvm/storage/state/transaction_state.go
+++ b/fvm/storage/state/transaction_state.go
@@ -177,9 +177,17 @@ func NewTransactionState(
 	params StateParameters,
 ) NestedTransactionPreparer {
 	startState := NewExecutionState(snapshot, params)
+	return NewTransactionStateFromExecutionState(startState)
+}
+
+// NewTransactionStateFromExecutionState constructs a new state transaction directly
+// from an execution state.
+func NewTransactionStateFromExecutionState(
+	startState *ExecutionState,
+) NestedTransactionPreparer {
 	return &transactionState{
 		nestedTransactions: []nestedTransactionStackFrame{
-			nestedTransactionStackFrame{
+			{
 				ExecutionState:   startState,
 				parseRestriction: nil,
 			},

--- a/go.mod
+++ b/go.mod
@@ -46,8 +46,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
-	github.com/onflow/atree v0.8.0-rc.1
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26
+	github.com/onflow/atree v0.8.0-rc.2
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2152,13 +2152,13 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
-github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 h1:0AifXgDMWoSonlIGBRIMHlKesqVnq/JInulr9QUdCDw=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 h1:J2fp33mZcGI9EIQcKw6nImXhGn9LnEmHakslPwTNlnw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27/go.mod h1:KclJlSGWG4USgPK4CsI3V/YtCHYOwPpjyzb6iEfWlbM=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -197,8 +197,8 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.8.0-rc.1 // indirect
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 // indirect
+	github.com/onflow/atree v0.8.0-rc.2 // indirect
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2140,11 +2140,11 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
-github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 h1:0AifXgDMWoSonlIGBRIMHlKesqVnq/JInulr9QUdCDw=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 h1:J2fp33mZcGI9EIQcKw6nImXhGn9LnEmHakslPwTNlnw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27/go.mod h1:KclJlSGWG4USgPK4CsI3V/YtCHYOwPpjyzb6iEfWlbM=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
@@ -241,7 +241,7 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.8.0-rc.1 // indirect
+	github.com/onflow/atree v0.8.0-rc.2 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2134,11 +2134,11 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
-github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 h1:0AifXgDMWoSonlIGBRIMHlKesqVnq/JInulr9QUdCDw=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 h1:J2fp33mZcGI9EIQcKw6nImXhGn9LnEmHakslPwTNlnw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27/go.mod h1:KclJlSGWG4USgPK4CsI3V/YtCHYOwPpjyzb6iEfWlbM=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "89ee0925606973a401f37ca21dddf15c95121d4c2e4fb9ebeb7689ef38377e49"
+const GenesisStateCommitmentHex = "1f001c1c7fc9a9e125fae9175ae040d0aa91741b9c8d5f42f2bec91f93ef63c9"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "b5e7fae0db47a5ab087442e1c18942225bce7eab128b294baf8c5849f2d49276"
+		return "a01e2ae8c955c15bbf4e107b93e7a7edf9d56acc607063dfd338fb7efae29dcc"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "6b962792fa1f2ec6ed6b7ddee45f70bb0811b197f6bedef01be2f5c248c5a87a"
+	return "aa285104f02969b3ad3798e88472f211d36a46e6f66191b827f4bc9560697938"
 }


### PR DESCRIPTION
Merge `master` into `feature/atree-inlining-cadence-v1.0`

<details><summary>Conflict Resolution</summary>

```diff
commit 548c63662958228fc02e52007c88a9b4e64fa282
Merge: 4615b3cbfc 381fe9bc3d
Author: Faye Amacker <33205765+fxamacker@users.noreply.github.com>
Date:   Wed May 15 14:17:30 2024 -0500

    Merge branch 'master' into fxamacker/sync-atree-inlining-cadence-v1.0-with-master

diff --git a/cmd/util/ledger/migrations/staged_contracts_migration_test.go b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
index 2c803adcb8..bb25324889 100644
--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -763,7 +763,7 @@ func TestStagedContractsMigration(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, logWriter.logs, 4)
-		require.Contains(t, logWriter.logs[0], "found 6 registers in account 0x2ceae959ed1a7e7a")
+		require.Contains(t, logWriter.logs[0], "found 4 registers in account 0x2ceae959ed1a7e7a")
 		require.Contains(t, logWriter.logs[1], "found a value with an unexpected type `String`")
 		require.Contains(t, logWriter.logs[2], "found 1 staged contracts from payloads")
 		require.Contains(t, logWriter.logs[3], "total of 1 unique contracts are staged for all accounts")
diff --git a/cmd/util/ledger/migrations/utils.go b/cmd/util/ledger/migrations/utils.go
remerge CONFLICT (content): Merge conflict in cmd/util/ledger/migrations/utils.go
index 65bc1db272..4b9cd133d9 100644
--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -29,8 +29,8 @@ func init() {
 	}
 }
 
-func getSlabIDsFromRegisters(registers registers.Registers) ([]atree.StorageID, error) {
-	storageIDs := make([]atree.StorageID, 0, registers.Count())
+func getSlabIDsFromRegisters(registers registers.Registers) ([]atree.SlabID, error) {
+	storageIDs := make([]atree.SlabID, 0, registers.Count())
 
 	err := registers.ForEach(func(owner string, key string, value []byte) error {
 
@@ -43,15 +43,7 @@ func getSlabIDsFromRegisters(registers registers.Registers) ([]atree.StorageID,
 			atree.SlabIndex([]byte(key[1:])),
 		)
 
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-		// Retrieve the slab
-		_, _, err := storage.Retrieve(slabID)
-		if err != nil {
-			return fmt.Errorf("failed to retrieve slab %s: %w", slabID, err)
-		}
-=======
-		storageIDs = append(storageIDs, storageID)
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+		storageIDs = append(storageIDs, slabID)
 
 		return nil
 	})
diff --git a/engine/execution/state/bootstrap/bootstrap_test.go b/engine/execution/state/bootstrap/bootstrap_test.go
remerge CONFLICT (content): Merge conflict in engine/execution/state/bootstrap/bootstrap_test.go
index d82730e66e..ba25d1e7d8 100644
--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,11 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-	expectedStateCommitmentBytes, _ := hex.DecodeString("82b80015ac01a065f22b18ebfb739c492bacfddde79a584d19658dcfd7ff4673")
-=======
-	expectedStateCommitmentBytes, _ := hex.DecodeString("fe020f31345d3484fdbd24ea02b1a06f474671c421b056ec3b01b78c128c20ca")
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+	expectedStateCommitmentBytes, _ := hex.DecodeString("3f0f1fea08e7e289c2b94f019f5921382bfba87dc1b52cf1fe8f004ed8d70b1b")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 
diff --git a/fvm/evm/stdlib/contract.go b/fvm/evm/stdlib/contract.go
index 53a0d322ec..aa39021423 100644
--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -239,7 +239,7 @@ func newInternalEVMTypeEncodeABIFunction(
 
 	evmAddressTypeID := location.TypeID(gauge, evmAddressTypeQualifiedIdentifier)
 
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeEncodeABIFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -658,7 +658,7 @@ func newInternalEVMTypeDecodeABIFunction(
 ) *interpreter.HostFunctionValue {
 	evmAddressTypeID := location.TypeID(gauge, evmAddressTypeQualifiedIdentifier)
 
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeDecodeABIFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1006,7 +1006,7 @@ func newInternalEVMTypeRunFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeRunFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1070,7 +1070,7 @@ func newInternalEVMTypeDryRunFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeDryRunFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1130,7 +1130,7 @@ func newInternalEVMTypeBatchRunFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeBatchRunFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1392,7 +1392,7 @@ func newInternalEVMTypeCallFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1479,7 +1479,7 @@ func newInternalEVMTypeCreateCadenceOwnedAccountFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCreateCadenceOwnedAccountFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1516,7 +1516,7 @@ func newInternalEVMTypeDepositFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1587,7 +1587,7 @@ func newInternalEVMTypeBalanceFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1629,7 +1629,7 @@ func newInternalEVMTypeNonceFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1671,7 +1671,7 @@ func newInternalEVMTypeCodeFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1713,7 +1713,7 @@ func newInternalEVMTypeCodeHashFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1758,7 +1758,7 @@ func newInternalEVMTypeWithdrawFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1856,7 +1856,7 @@ func newInternalEVMTypeDeployFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1933,7 +1933,7 @@ var internalEVMTypeCastToAttoFLOWFunctionType = &sema.FunctionType{
 func newInternalEVMTypeCastToAttoFLOWFunction(
 	gauge common.MemoryGauge,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1963,7 +1963,7 @@ var internalEVMTypeCastToFLOWFunctionType = &sema.FunctionType{
 func newInternalEVMTypeCastToFLOWFunction(
 	gauge common.MemoryGauge,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
@@ -1994,7 +1994,7 @@ func newInternalEVMTypeGetLatestBlockFunction(
 	gauge common.MemoryGauge,
 	handler types.ContractHandler,
 ) *interpreter.HostFunctionValue {
-	return interpreter.NewHostFunctionValue(
+	return interpreter.NewStaticHostFunctionValue(
 		gauge,
 		internalEVMTypeCallFunctionType,
 		func(invocation interpreter.Invocation) interpreter.Value {
diff --git a/fvm/runtime/reusable_cadence_runtime.go b/fvm/runtime/reusable_cadence_runtime.go
index f2e5c941d7..0248e55a7d 100644
--- a/fvm/runtime/reusable_cadence_runtime.go
+++ b/fvm/runtime/reusable_cadence_runtime.go
@@ -53,7 +53,7 @@ func NewReusableCadenceRuntime(rt runtime.Runtime, config runtime.Config) *Reusa
 		Name: "randomSourceHistory",
 		Type: randomSourceFunctionType,
 		Kind: common.DeclarationKindFunction,
-		Value: interpreter.NewUnmeteredHostFunctionValue(
+		Value: interpreter.NewUnmeteredStaticHostFunctionValue(
 			randomSourceFunctionType,
 			func(invocation interpreter.Invocation) interpreter.Value {
 				if len(invocation.Arguments) != 0 {
diff --git a/go.mod b/go.mod
remerge CONFLICT (content): Merge conflict in go.mod
index 5d748909b7..47e1ddd51f 100644
--- a/go.mod
+++ b/go.mod
@@ -46,13 +46,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-	github.com/onflow/atree v0.8.0-rc.1
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26
-=======
-	github.com/onflow/atree v0.7.0-rc.2
-	github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+	github.com/onflow/atree v0.8.0-rc.2
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0
diff --git a/go.sum b/go.sum
remerge CONFLICT (content): Merge conflict in go.sum
index cf2506f7bd..3c31889aa0 100644
--- a/go.sum
+++ b/go.sum
@@ -2152,23 +2152,13 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
-github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 h1:0AifXgDMWoSonlIGBRIMHlKesqVnq/JInulr9QUdCDw=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
-=======
-github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
-github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
-github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
-github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a h1:doxA0f5CMnFHlWoVG2mQ/DLsQnIhtazl+P6Snt+7LPc=
-github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 h1:J2fp33mZcGI9EIQcKw6nImXhGn9LnEmHakslPwTNlnw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27/go.mod h1:KclJlSGWG4USgPK4CsI3V/YtCHYOwPpjyzb6iEfWlbM=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/insecure/go.mod b/insecure/go.mod
remerge CONFLICT (content): Merge conflict in insecure/go.mod
index b549292462..237e9dfe12 100644
--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -197,13 +197,8 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-	github.com/onflow/atree v0.8.0-rc.1 // indirect
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 // indirect
-=======
-	github.com/onflow/atree v0.7.0-rc.2 // indirect
-	github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a // indirect
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+	github.com/onflow/atree v0.8.0-rc.2 // indirect
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
diff --git a/insecure/go.sum b/insecure/go.sum
remerge CONFLICT (content): Merge conflict in insecure/go.sum
index adc929b761..a06042da8b 100644
--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2140,19 +2140,11 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
-github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 h1:0AifXgDMWoSonlIGBRIMHlKesqVnq/JInulr9QUdCDw=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
-=======
-github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
-github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a h1:doxA0f5CMnFHlWoVG2mQ/DLsQnIhtazl+P6Snt+7LPc=
-github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 h1:J2fp33mZcGI9EIQcKw6nImXhGn9LnEmHakslPwTNlnw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27/go.mod h1:KclJlSGWG4USgPK4CsI3V/YtCHYOwPpjyzb6iEfWlbM=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/integration/go.mod b/integration/go.mod
remerge CONFLICT (content): Merge conflict in integration/go.mod
index 59874316d4..c34639eac5 100644
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,11 +19,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26
-=======
-	github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
@@ -245,11 +241,7 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-	github.com/onflow/atree v0.8.0-rc.1 // indirect
-=======
-	github.com/onflow/atree v0.7.0-rc.2 // indirect
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+	github.com/onflow/atree v0.8.0-rc.2 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.0 // indirect
diff --git a/integration/go.sum b/integration/go.sum
remerge CONFLICT (content): Merge conflict in integration/go.sum
index 252ad56224..dd460e224d 100644
--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2134,19 +2134,11 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-github.com/onflow/atree v0.8.0-rc.1 h1:sTxguTcS0qq8vv0EcJri0OO2be8/GCZDARGm7Nt0XRg=
-github.com/onflow/atree v0.8.0-rc.1/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
+github.com/onflow/atree v0.8.0-rc.2 h1:7XYaOiiYJqLadzmyLyju2ztoqyTw/ikzcI0HI2LA+bI=
+github.com/onflow/atree v0.8.0-rc.2/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26 h1:0AifXgDMWoSonlIGBRIMHlKesqVnq/JInulr9QUdCDw=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.26/go.mod h1:SxUHsIXNA2nLdooN6QzpChw+wNUlrujRgLp7QgI59VQ=
-=======
-github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
-github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a h1:doxA0f5CMnFHlWoVG2mQ/DLsQnIhtazl+P6Snt+7LPc=
-github.com/onflow/cadence v1.0.0-preview.26.0.20240514215601-cb7627bd8f8a/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27 h1:J2fp33mZcGI9EIQcKw6nImXhGn9LnEmHakslPwTNlnw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.27/go.mod h1:KclJlSGWG4USgPK4CsI3V/YtCHYOwPpjyzb6iEfWlbM=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/utils/unittest/execution_state.go b/utils/unittest/execution_state.go
remerge CONFLICT (content): Merge conflict in utils/unittest/execution_state.go
index 027f48cdc5..c7297e0d2e 100644
--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,11 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-const GenesisStateCommitmentHex = "89ee0925606973a401f37ca21dddf15c95121d4c2e4fb9ebeb7689ef38377e49"
-=======
-const GenesisStateCommitmentHex = "dfcc8c01fa316461d6734a93d3291269b559a1a2d57c061cb3d9b5121fa352d7"
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+const GenesisStateCommitmentHex = "1f001c1c7fc9a9e125fae9175ae040d0aa91741b9c8d5f42f2bec91f93ef63c9"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -91,18 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-		return "b5e7fae0db47a5ab087442e1c18942225bce7eab128b294baf8c5849f2d49276"
-=======
-		return "973771c938eec6833222d2b123ff4e3ac65bba1f8368c36d18f47c5c872a3d42"
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+		return "a01e2ae8c955c15bbf4e107b93e7a7edf9d56acc607063dfd338fb7efae29dcc"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-<<<<<<< 4615b3cbfc (Merge pull request #5921 from onflow/fxamacker/sync-atree-inlining-cadence-v1.0-with-master)
-	return "6b962792fa1f2ec6ed6b7ddee45f70bb0811b197f6bedef01be2f5c248c5a87a"
-=======
-	return "bfaf048a4b86b1851ca3e9fe19d8adbe198b5d8eafa846d452e5fac64757fb3d"
->>>>>>> 381fe9bc3d (Merge pull request #5916 from onflow/fxamacker/optimize-commit-and-preload-for-cadence-migration)
+	return "aa285104f02969b3ad3798e88472f211d36a46e6f66191b827f4bc9560697938"
 }

```

</details>