### PR TITLE
[EFM] Added new service event `EpochRecover`

### DIFF
--- a/engine/execution/state/unittest/fixtures.go
+++ b/engine/execution/state/unittest/fixtures.go
@@ -69,11 +69,13 @@ func ComputationResultForBlockFixture(
 
 	_, serviceEventEpochCommitProtocol := unittest.EpochCommitFixtureByChainID(flow.Localnet)
 	_, serviceEventEpochSetupProtocol := unittest.EpochSetupFixtureByChainID(flow.Localnet)
+	_, serviceEventEpochRecoverProtocol := unittest.EpochRecoverFixtureByChainID(flow.Localnet)
 	_, serviceEventVersionBeaconProtocol := unittest.VersionBeaconFixtureByChainID(flow.Localnet)
 
 	convertedServiceEvents := flow.ServiceEventList{
 		serviceEventEpochCommitProtocol.ServiceEvent(),
 		serviceEventEpochSetupProtocol.ServiceEvent(),
+		serviceEventEpochRecoverProtocol.ServiceEvent(),
 		serviceEventVersionBeaconProtocol.ServiceEvent(),
 	}
 

--- a/fvm/systemcontracts/system_contracts.go
+++ b/fvm/systemcontracts/system_contracts.go
@@ -47,6 +47,7 @@ const (
 
 	EventNameEpochSetup                  = "EpochSetup"
 	EventNameEpochCommit                 = "EpochCommit"
+	EventNameEpochRecover                = "EpochRecover"
 	EventNameVersionBeacon               = "VersionBeacon"               // VersionBeacon only controls version of ENs, describing software compatability via semantic versioning
 	EventNameProtocolStateVersionUpgrade = "ProtocolStateVersionUpgrade" // Protocol State version applies to all nodes and uses an _integer version_ of the _protocol state_
 
@@ -213,6 +214,7 @@ func (c SystemContracts) All() []SystemContract {
 type ServiceEvents struct {
 	EpochSetup                  ServiceEvent
 	EpochCommit                 ServiceEvent
+	EpochRecover                ServiceEvent
 	VersionBeacon               ServiceEvent
 	ProtocolStateVersionUpgrade ServiceEvent
 }
@@ -222,6 +224,7 @@ func (se ServiceEvents) All() []ServiceEvent {
 	return []ServiceEvent{
 		se.EpochSetup,
 		se.EpochCommit,
+		se.EpochRecover,
 		se.VersionBeacon,
 		se.ProtocolStateVersionUpgrade,
 	}
@@ -403,6 +406,7 @@ func init() {
 		events := &ServiceEvents{
 			EpochSetup:                  event(ContractNameEpoch, EventNameEpochSetup),
 			EpochCommit:                 event(ContractNameEpoch, EventNameEpochCommit),
+			EpochRecover:                event(ContractNameEpoch, EventNameEpochRecover),
 			VersionBeacon:               event(ContractNameNodeVersionBeacon, EventNameVersionBeacon),
 			ProtocolStateVersionUpgrade: event(ContractNameNodeVersionBeacon, EventNameProtocolStateVersionUpgrade),
 		}

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -28,6 +28,8 @@ func ServiceEvent(chainID flow.ChainID, event flow.Event) (*flow.ServiceEvent, e
 		return convertServiceEventEpochSetup(event)
 	case events.EpochCommit.EventType():
 		return convertServiceEventEpochCommit(event)
+	case events.EpochRecover.EventType():
+		return convertServiceEventEpochRecover(event)
 	case events.VersionBeacon.EventType():
 		return convertServiceEventVersionBeacon(event)
 	case events.ProtocolStateVersionUpgrade.EventType():
@@ -279,14 +281,226 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 	return serviceEvent, nil
 }
 
-func convertServiceEventEpochRecovers(event flow.Event) (*flow.ServiceEvent, error) {
+// convertServiceEventEpochRecover converts a service event encoded as the generic
+// flow.Event type to a ServiceEvent type for an EpochRecover event.
+// CAUTION: This function must only be used for input events computed locally, by an
+// Execution or Verification Node; it is not resilient to malicious inputs.
+// No errors are expected during normal operation.
+func convertServiceEventEpochRecover(event flow.Event) (*flow.ServiceEvent, error) {
+	// decode bytes using ccf
+	payload, err := ccf.Decode(nil, event.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal event payload: %w", err)
+	}
 
+	// NOTE: variable names prefixed with cdc represent cadence types
+	cdcEvent, ok := payload.(cadence.Event)
+	if !ok {
+		return nil, invalidCadenceTypeError("payload", payload, cadence.Event{})
+	}
+
+	if cdcEvent.Type() == nil {
+		return nil, fmt.Errorf("EpochRecover event doesn't have type")
+	}
+
+	fields := cadence.FieldsMappedByName(cdcEvent)
+
+	const expectedFieldCount = 13
+	if len(fields) < expectedFieldCount {
+		return nil, fmt.Errorf(
+			"insufficient fields in EpochRecover event (%d < %d)",
+			len(fields),
+			expectedFieldCount,
+		)
+	}
+
+	// parse EpochSetup event
+
+	counter, err := getField[cadence.UInt64](fields, "counter")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	cdcParticipants, err := getField[cadence.Array](fields, "nodeInfo")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	firstView, err := getField[cadence.UInt64](fields, "firstView")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	finalView, err := getField[cadence.UInt64](fields, "finalView")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	cdcClusters, err := getField[cadence.Array](fields, "collectorClusters")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	randomSrcHex, err := getField[cadence.String](fields, "randomSource")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	targetDuration, err := getField[cadence.UInt64](fields, "targetDuration") // Epoch duration [seconds]
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	targetEndTimeUnix, err := getField[cadence.UInt64](fields, "targetEndTime") // Unix time [seconds]
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	dkgPhase1FinalView, err := getField[cadence.UInt64](fields, "DKGPhase1FinalView")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	dkgPhase2FinalView, err := getField[cadence.UInt64](fields, "DKGPhase2FinalView")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	dkgPhase3FinalView, err := getField[cadence.UInt64](fields, "DKGPhase3FinalView")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	cdcClusterQCVotes, err := getField[cadence.Array](fields, "clusterQCVoteData")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	cdcDKGKeys, err := getField[cadence.Array](fields, "dkgPubKeys")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
+	}
+
+	setup := flow.EpochSetup{
+		Counter:            uint64(counter),
+		FirstView:          uint64(firstView),
+		FinalView:          uint64(finalView),
+		DKGPhase1FinalView: uint64(dkgPhase1FinalView),
+		DKGPhase2FinalView: uint64(dkgPhase2FinalView),
+		DKGPhase3FinalView: uint64(dkgPhase3FinalView),
+		TargetDuration:     uint64(targetDuration),
+		TargetEndTime:      uint64(targetEndTimeUnix),
+	}
+
+	// random source from the event must be a hex string
+	// containing exactly 128 bits (equivalent to 16 bytes or 32 hex characters)
+	setup.RandomSource, err = hex.DecodeString(string(randomSrcHex))
+	if err != nil {
+		return nil, fmt.Errorf(
+			"could not decode random source hex (%v): %w",
+			randomSrcHex,
+			err,
+		)
+	}
+
+	if len(setup.RandomSource) != flow.EpochSetupRandomSourceLength {
+		return nil, fmt.Errorf(
+			"random source in epoch recover event must be of (%d) bytes, got (%d)",
+			flow.EpochSetupRandomSourceLength,
+			len(setup.RandomSource),
+		)
+	}
+
+	// parse cluster assignments; returned assignments are in canonical order
+	setup.Assignments, err = convertEpochRecoverCollectorClusterAssignments(cdcClusters.Values)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert cluster assignments: %w", err)
+	}
+
+	// parse epoch participants; returned node identities are in canonical order
+	setup.Participants, err = convertParticipants(cdcParticipants.Values)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert participants: %w", err)
+	}
+
+	commit := flow.EpochCommit{
+		Counter: uint64(counter),
+	}
+
+	// parse cluster qc votes
+	commit.ClusterQCs, err = convertClusterQCVoteData(cdcClusterQCVotes.Values)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert cluster qc votes: %w", err)
+	}
+
+	// parse DKG group key and participants
+	// Note: this is read in the same order as `DKGClient.SubmitResult` ie. with the group public key first followed by individual keys
+	// https://github.com/onflow/flow-go/blob/feature/dkg/module/dkg/client.go#L182-L183
+	commit.DKGGroupKey, commit.DKGParticipantKeys, err = convertDKGKeys(cdcDKGKeys.Values)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert DKG keys: %w", err)
+	}
+
+	// create the service event
+	serviceEvent := &flow.ServiceEvent{
+		Type: flow.ServiceEventRecover,
+		Event: &flow.EpochRecover{
+			EpochSetup:  setup,
+			EpochCommit: commit,
+		},
+	}
+
+	return serviceEvent, nil
+}
+
+// convertEpochRecoverCollectorClusterAssignments converts collector cluster assignments for EpochRecover event.
+// This is a simplified version compared to the `convertClusterAssignments` function since we are dealing with
+// a list of participants that don't need to be ordered by index or node weights.
+// No errors are expected during normal operation.
+func convertEpochRecoverCollectorClusterAssignments(cdcClusters []cadence.Value) (flow.AssignmentList, error) {
+	// parse cluster assignments to Go types
+	clusterAssignments := make([]flow.IdentifierList, 0, len(cdcClusters))
+	// we are dealing with a nested array where each element is a list of node IDs,
+	// this way we represent the cluster assignments.
+	for _, value := range cdcClusters {
+		cdcCluster, ok := value.(cadence.Array)
+		if !ok {
+			return nil, invalidCadenceTypeError("collectorClusters[i]", cdcCluster, cadence.Array{})
+		}
+
+		clusterMembers := make(flow.IdentifierList, 0, len(cdcCluster.Values))
+		for _, cdcClusterParticipant := range cdcCluster.Values {
+			nodeIDString, ok := cdcClusterParticipant.(cadence.String)
+			if !ok {
+				return nil, invalidCadenceTypeError(
+					"collectorClusters[i][j]",
+					cdcClusterParticipant,
+					cadence.String(""),
+				)
+			}
+
+			nodeID, err := flow.HexStringToIdentifier(string(nodeIDString))
+			if err != nil {
+				return nil, fmt.Errorf(
+					"could not convert hex string to identifer: %w",
+					err,
+				)
+			}
+			clusterMembers = append(clusterMembers, nodeID)
+		}
+
+		// IMPORTANT: for each cluster, node IDs must be in *canonical order*
+		clusterAssignments = append(clusterAssignments, clusterMembers.Sort(flow.IdentifierCanonical))
+	}
+
+	return clusterAssignments, nil
 }
 
 // convertClusterAssignments converts the Cadence representation of cluster
 // assignments included in the EpochSetup into the protocol AssignmentList
 // representation.
 // CONVENTION: for each cluster assignment (i.e. element in `AssignmentList`), the nodeIDs are listed in CANONICAL ORDER
+// No errors are expected during normal operation.
 func convertClusterAssignments(cdcClusters []cadence.Value) (flow.AssignmentList, error) {
 	// ensure we don't have duplicate cluster indices
 	indices := make(map[uint]struct{})
@@ -481,6 +695,126 @@ func convertParticipants(cdcParticipants []cadence.Value) (flow.IdentitySkeleton
 	// IMPORTANT: returned identities must be in *canonical order*
 	participants = participants.Sort(flow.Canonical[flow.IdentitySkeleton])
 	return participants, nil
+}
+
+// convertClusterQCVoteData converts cluster QC vote data from the EpochRecover event
+// to a representation suitable for inclusion in the protocol state. Votes are
+// aggregated as part of this conversion.
+func convertClusterQCVoteData(cdcClusterQCVoteData []cadence.Value) ([]flow.ClusterQCVoteData, error) {
+	qcVoteDatas := make([]flow.ClusterQCVoteData, 0, len(cdcClusterQCVoteData))
+
+	// CAUTION: Votes are not validated prior to aggregation. This means a single
+	// invalid vote submission will result in a fully invalid QC for that cluster.
+	// Votes must be validated by the ClusterQC smart contract.
+
+	for _, cdcClusterQC := range cdcClusterQCVoteData {
+		cdcClusterQCStruct, ok := cdcClusterQC.(cadence.Struct)
+		if !ok {
+			return nil, invalidCadenceTypeError(
+				"clusterQC",
+				cdcClusterQC,
+				cadence.Struct{},
+			)
+		}
+
+		if cdcClusterQCStruct.Type() == nil {
+			return nil, fmt.Errorf("clusterQCVoteData struct doesn't have type")
+		}
+
+		fields := cadence.FieldsMappedByName(cdcClusterQCStruct)
+
+		const expectedFieldCount = 4
+		if len(fields) < expectedFieldCount {
+			return nil, fmt.Errorf(
+				"insufficient fields (%d < %d)",
+				len(fields),
+				expectedFieldCount,
+			)
+		}
+
+		cdcRawVotes, err := getField[cadence.Array](fields, "voteSignatures")
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode clusterQCVoteData struct: %w", err)
+		}
+
+		cdcVoterIDs, err := getField[cadence.Array](fields, "voterIDs")
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode clusterQCVoteData struct: %w", err)
+		}
+
+		voterIDs := make([]flow.Identifier, 0, len(cdcVoterIDs.Values))
+		for _, cdcVoterID := range cdcVoterIDs.Values {
+			voterIDHex, ok := cdcVoterID.(cadence.String)
+			if !ok {
+				return nil, invalidCadenceTypeError(
+					"clusterQC[i].voterID",
+					cdcVoterID,
+					cadence.String(""),
+				)
+			}
+			voterID, err := flow.HexStringToIdentifier(string(voterIDHex))
+			if err != nil {
+				return nil, fmt.Errorf("could not convert voter ID from hex: %w", err)
+			}
+			voterIDs = append(voterIDs, voterID)
+		}
+
+		// gather all the vote signatures
+		signatures := make([]crypto.Signature, 0, len(cdcRawVotes.Values))
+		for _, cdcRawVote := range cdcRawVotes.Values {
+			rawVoteHex, ok := cdcRawVote.(cadence.String)
+			if !ok {
+				return nil, invalidCadenceTypeError(
+					"clusterQC[i].vote",
+					cdcRawVote,
+					cadence.String(""),
+				)
+			}
+			rawVoteBytes, err := hex.DecodeString(string(rawVoteHex))
+			if err != nil {
+				return nil, fmt.Errorf("could not convert raw vote from hex: %w", err)
+			}
+			signatures = append(signatures, rawVoteBytes)
+		}
+		// Aggregate BLS signatures
+		aggregatedSignature, err := crypto.AggregateBLSSignatures(signatures)
+		if err != nil {
+			// expected errors of the function are:
+			//  - empty list of signatures
+			//  - an input signature does not deserialize to a valid point
+			// Both are not expected at this stage because list is guaranteed not to be
+			// empty and individual signatures have been validated.
+			return nil, fmt.Errorf("cluster qc vote aggregation failed: %w", err)
+		}
+
+		// check that aggregated signature is not identity, because an identity signature
+		// is invalid if verified under an identity public key. This can happen in two cases:
+		//  - If the quorum has at least one honest signer, and given all staking key proofs of possession
+		//    are valid, it's extremely unlikely for the aggregated public key (and the corresponding
+		//    aggregated signature) to be identity.
+		//  - If all quorum is malicious and intentionally forge an identity aggregate. As of the previous point,
+		//    this is only possible if there is no honest collector involved in constructing the cluster QC.
+		//    Hence, the cluster would need to contain a supermajority of malicious collectors.
+		//    As we are assuming that the fraction of malicious collectors overall does not exceed 1/3  (measured
+		//    by stake), the probability for randomly assigning 2/3 or more byzantine collectors to a single cluster
+		//    vanishes (provided a sufficiently high collector count in total).
+		//
+		//  Note that at this level, all individual signatures are guaranteed to be valid
+		//  w.r.t their corresponding staking public key. It is therefore enough to check
+		//  the aggregated signature to conclude whether the aggregated public key is identity.
+		//  This check is therefore a sanity check to catch a potential issue early.
+		if crypto.IsBLSSignatureIdentity(aggregatedSignature) {
+			return nil, fmt.Errorf("cluster qc vote aggregation failed because resulting BLS signature is identity")
+		}
+
+		// set the fields on the QC vote data object
+		qcVoteDatas = append(qcVoteDatas, flow.ClusterQCVoteData{
+			SigData:  aggregatedSignature,
+			VoterIDs: voterIDs,
+		})
+	}
+
+	return qcVoteDatas, nil
 }
 
 // convertClusterQCVotes converts raw cluster QC votes from the EpochCommit event

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -279,6 +279,10 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 	return serviceEvent, nil
 }
 
+func convertServiceEventEpochRecovers(event flow.Event) (*flow.ServiceEvent, error) {
+
+}
+
 // convertClusterAssignments converts the Cadence representation of cluster
 // assignments included in the EpochSetup into the protocol AssignmentList
 // representation.

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -371,7 +371,7 @@ func convertServiceEventEpochRecover(event flow.Event) (*flow.ServiceEvent, erro
 		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
 	}
 
-	cdcClusterQCVotes, err := getField[cadence.Array](fields, "clusterQCVoteData")
+	cdcClusterQCVoteData, err := getField[cadence.Array](fields, "clusterQCVoteData")
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode EpochRecover event: %w", err)
 	}
@@ -428,9 +428,9 @@ func convertServiceEventEpochRecover(event flow.Event) (*flow.ServiceEvent, erro
 	}
 
 	// parse cluster qc votes
-	commit.ClusterQCs, err = convertClusterQCVoteData(cdcClusterQCVotes.Values)
+	commit.ClusterQCs, err = convertClusterQCVoteData(cdcClusterQCVoteData.Values)
 	if err != nil {
-		return nil, fmt.Errorf("could not convert cluster qc votes: %w", err)
+		return nil, fmt.Errorf("could not convert cluster qc vote data: %w", err)
 	}
 
 	// parse DKG group key and participants
@@ -723,7 +723,7 @@ func convertClusterQCVoteData(cdcClusterQCVoteData []cadence.Value) ([]flow.Clus
 
 		fields := cadence.FieldsMappedByName(cdcClusterQCStruct)
 
-		const expectedFieldCount = 4
+		const expectedFieldCount = 2
 		if len(fields) < expectedFieldCount {
 			return nil, fmt.Errorf(
 				"insufficient fields (%d < %d)",

--- a/model/convert/service_event_test.go
+++ b/model/convert/service_event_test.go
@@ -120,22 +120,21 @@ func TestEventConversion(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run(
-		"version beacon", func(t *testing.T) {
+	t.Run("version beacon", func(t *testing.T) {
 
-			fixture, expected := unittest.VersionBeaconFixtureByChainID(chainID)
+		fixture, expected := unittest.VersionBeaconFixtureByChainID(chainID)
 
-			// convert Cadence types to Go types
-			event, err := convert.ServiceEvent(chainID, fixture)
-			require.NoError(t, err)
-			require.NotNil(t, event)
+		// convert Cadence types to Go types
+		event, err := convert.ServiceEvent(chainID, fixture)
+		require.NoError(t, err)
+		require.NotNil(t, event)
 
-			// cast event type to version beacon
-			actual, ok := event.Event.(*flow.VersionBeacon)
-			require.True(t, ok)
+		// cast event type to version beacon
+		actual, ok := event.Event.(*flow.VersionBeacon)
+		require.True(t, ok)
 
-			assert.Equal(t, expected, actual)
-		},
+		assert.Equal(t, expected, actual)
+	},
 	)
 
 	t.Run("protocol state version upgrade", func(t *testing.T) {

--- a/model/convert/service_event_test.go
+++ b/model/convert/service_event_test.go
@@ -105,6 +105,21 @@ func TestEventConversion(t *testing.T) {
 		},
 	)
 
+	t.Run("epoch recover", func(t *testing.T) {
+		fixture, expected := unittest.EpochRecoverFixtureByChainID(chainID)
+
+		// convert Cadence types to Go types
+		event, err := convert.ServiceEvent(chainID, fixture)
+		require.NoError(t, err)
+		require.NotNil(t, event)
+
+		// cast event type to epoch recover
+		actual, ok := event.Event.(*flow.EpochRecover)
+		require.True(t, ok)
+
+		assert.Equal(t, expected, actual)
+	})
+
 	t.Run(
 		"version beacon", func(t *testing.T) {
 

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -122,6 +122,90 @@ func (setup *EpochSetup) EqualTo(other *EpochSetup) bool {
 	return bytes.Equal(setup.RandomSource, other.RandomSource)
 }
 
+// EpochRecover service event is emitted when network is in Epoch Fallback Mode(EFM) in an attempt to return to happy path.
+// It contains data from EpochSetup, and EpochCommit events to so replicas can create a committed epoch from which they
+// can continue operating on the happy path.
+type EpochRecover struct {
+	Counter            uint64               // the number of the epoch
+	FirstView          uint64               // the first view of the epoch
+	DKGPhase1FinalView uint64               // the final view of DKG phase 1
+	DKGPhase2FinalView uint64               // the final view of DKG phase 2
+	DKGPhase3FinalView uint64               // the final view of DKG phase 3
+	FinalView          uint64               // the final view of the epoch
+	Participants       IdentitySkeletonList // all participants of the epoch in canonical order
+	Assignments        AssignmentList       // cluster assignment for the epoch
+	RandomSource       []byte               // source of randomness for epoch-specific setup tasks
+	TargetDuration     uint64               // desired real-world duration for the epoch [seconds]
+	TargetEndTime      uint64               // desired real-world end time for the epoch in UNIX time [seconds]
+	ClusterQCs         []ClusterQCVoteData  // quorum certificates for each cluster
+	DKGParticipantKeys []crypto.PublicKey   // public keys for DKG participants
+}
+
+func (recover *EpochRecover) ServiceEvent() ServiceEvent {
+	return ServiceEvent{
+		Type:  ServiceEventRecover,
+		Event: recover,
+	}
+}
+
+// ID returns the hash of the event contents.
+func (recover *EpochRecover) ID() Identifier {
+	return MakeID(recover)
+}
+
+func (recover *EpochRecover) EqualTo(other *EpochRecover) bool {
+	if recover.Counter != other.Counter {
+		return false
+	}
+	if recover.FirstView != other.FirstView {
+		return false
+	}
+	if recover.DKGPhase1FinalView != other.DKGPhase1FinalView {
+		return false
+	}
+	if recover.DKGPhase2FinalView != other.DKGPhase2FinalView {
+		return false
+	}
+	if recover.DKGPhase3FinalView != other.DKGPhase3FinalView {
+		return false
+	}
+	if recover.FinalView != other.FinalView {
+		return false
+	}
+	if recover.TargetDuration != other.TargetDuration {
+		return false
+	}
+	if recover.TargetEndTime != other.TargetEndTime {
+		return false
+	}
+	if !IdentitySkeletonListEqualTo(recover.Participants, other.Participants) {
+		return false
+	}
+	if !recover.Assignments.EqualTo(other.Assignments) {
+		return false
+	}
+	if !bytes.Equal(recover.RandomSource, other.RandomSource) {
+		return false
+	}
+	if len(recover.ClusterQCs) != len(other.ClusterQCs) {
+		return false
+	}
+	for i, qc := range recover.ClusterQCs {
+		if !qc.EqualTo(&other.ClusterQCs[i]) {
+			return false
+		}
+	}
+	if len(recover.DKGParticipantKeys) != len(other.DKGParticipantKeys) {
+		return false
+	}
+	for i, key := range recover.DKGParticipantKeys {
+		if !key.Equals(other.DKGParticipantKeys[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // EpochCommit is a service event emitted when epoch setup has been completed.
 // When an EpochCommit event is emitted, the network is ready to transition to
 // the epoch.

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -126,19 +126,8 @@ func (setup *EpochSetup) EqualTo(other *EpochSetup) bool {
 // It contains data from EpochSetup, and EpochCommit events to so replicas can create a committed epoch from which they
 // can continue operating on the happy path.
 type EpochRecover struct {
-	Counter            uint64               // the number of the epoch
-	FirstView          uint64               // the first view of the epoch
-	DKGPhase1FinalView uint64               // the final view of DKG phase 1
-	DKGPhase2FinalView uint64               // the final view of DKG phase 2
-	DKGPhase3FinalView uint64               // the final view of DKG phase 3
-	FinalView          uint64               // the final view of the epoch
-	Participants       IdentitySkeletonList // all participants of the epoch in canonical order
-	Assignments        AssignmentList       // cluster assignment for the epoch
-	RandomSource       []byte               // source of randomness for epoch-specific setup tasks
-	TargetDuration     uint64               // desired real-world duration for the epoch [seconds]
-	TargetEndTime      uint64               // desired real-world end time for the epoch in UNIX time [seconds]
-	ClusterQCs         []ClusterQCVoteData  // quorum certificates for each cluster
-	DKGParticipantKeys []crypto.PublicKey   // public keys for DKG participants
+	EpochSetup
+	EpochCommit
 }
 
 func (recover *EpochRecover) ServiceEvent() ServiceEvent {
@@ -154,54 +143,11 @@ func (recover *EpochRecover) ID() Identifier {
 }
 
 func (recover *EpochRecover) EqualTo(other *EpochRecover) bool {
-	if recover.Counter != other.Counter {
+	if !recover.EpochSetup.EqualTo(&other.EpochSetup) {
 		return false
 	}
-	if recover.FirstView != other.FirstView {
+	if !recover.EpochCommit.EqualTo(&other.EpochCommit) {
 		return false
-	}
-	if recover.DKGPhase1FinalView != other.DKGPhase1FinalView {
-		return false
-	}
-	if recover.DKGPhase2FinalView != other.DKGPhase2FinalView {
-		return false
-	}
-	if recover.DKGPhase3FinalView != other.DKGPhase3FinalView {
-		return false
-	}
-	if recover.FinalView != other.FinalView {
-		return false
-	}
-	if recover.TargetDuration != other.TargetDuration {
-		return false
-	}
-	if recover.TargetEndTime != other.TargetEndTime {
-		return false
-	}
-	if !IdentitySkeletonListEqualTo(recover.Participants, other.Participants) {
-		return false
-	}
-	if !recover.Assignments.EqualTo(other.Assignments) {
-		return false
-	}
-	if !bytes.Equal(recover.RandomSource, other.RandomSource) {
-		return false
-	}
-	if len(recover.ClusterQCs) != len(other.ClusterQCs) {
-		return false
-	}
-	for i, qc := range recover.ClusterQCs {
-		if !qc.EqualTo(&other.ClusterQCs[i]) {
-			return false
-		}
-	}
-	if len(recover.DKGParticipantKeys) != len(other.DKGParticipantKeys) {
-		return false
-	}
-	for i, key := range recover.DKGParticipantKeys {
-		if !key.Equals(other.DKGParticipantKeys[i]) {
-			return false
-		}
 	}
 	return true
 }

--- a/model/flow/service_event.go
+++ b/model/flow/service_event.go
@@ -21,6 +21,7 @@ func (set ServiceEventType) String() string {
 const (
 	ServiceEventSetup                       ServiceEventType = "setup"
 	ServiceEventCommit                      ServiceEventType = "commit"
+	ServiceEventRecover                     ServiceEventType = "recover"
 	ServiceEventVersionBeacon               ServiceEventType = "version-beacon"                 // VersionBeacon only controls version of ENs, describing software compatability via semantic versioning
 	ServiceEventProtocolStateVersionUpgrade ServiceEventType = "protocol-state-version-upgrade" // Protocol State version applies to all nodes and uses an _integer version_ of the _protocol_
 )

--- a/model/flow/service_event.go
+++ b/model/flow/service_event.go
@@ -118,6 +118,8 @@ func (marshaller marshallerImpl) UnmarshalWrapped(b []byte) (ServiceEvent, error
 		event, err = unmarshalWrapped[EpochSetup](b, marshaller)
 	case ServiceEventCommit:
 		event, err = unmarshalWrapped[EpochCommit](b, marshaller)
+	case ServiceEventRecover:
+		event, err = unmarshalWrapped[EpochRecover](b, marshaller)
 	case ServiceEventVersionBeacon:
 		event, err = unmarshalWrapped[VersionBeacon](b, marshaller)
 	case ServiceEventProtocolStateVersionUpgrade:
@@ -160,6 +162,8 @@ func (marshaller marshallerImpl) UnmarshalWithType(b []byte, eventType ServiceEv
 		event = new(EpochSetup)
 	case ServiceEventCommit:
 		event = new(EpochCommit)
+	case ServiceEventRecover:
+		event = new(EpochRecover)
 	case ServiceEventVersionBeacon:
 		event = new(VersionBeacon)
 	case ServiceEventProtocolStateVersionUpgrade:
@@ -252,6 +256,23 @@ func (se *ServiceEvent) EqualTo(other *ServiceEvent) (bool, error) {
 			)
 		}
 		return commit.EqualTo(otherCommit), nil
+
+	case ServiceEventRecover:
+		ev, ok := se.Event.(*EpochRecover)
+		if !ok {
+			return false, fmt.Errorf(
+				"internal invalid type for ServiceEventRecover: %T",
+				se.Event,
+			)
+		}
+		otherEv, ok := other.Event.(*EpochRecover)
+		if !ok {
+			return false, fmt.Errorf(
+				"internal invalid type for ServiceEventRecover: %T",
+				other.Event,
+			)
+		}
+		return ev.EqualTo(otherEv), nil
 
 	case ServiceEventVersionBeacon:
 		version, ok := se.Event.(*VersionBeacon)

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -160,34 +160,116 @@ func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCom
 
 // EpochRecoverFixtureByChainID returns an EpochRecover service event as a Cadence event
 // representation and as a protocol model representation.
-func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
+func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochRecover) {
 
 	events := systemcontracts.ServiceEventsForChain(chain)
 
+	randomSource := EpochSetupRandomSourceFixture()
 	event := EventFixture(events.EpochRecover.EventType(), 1, 1, IdentifierFixture(), 0)
-	event.Payload = EpochRecoverFixtureCCF
+	event.Payload = EpochRecoverFixtureCCF(randomSource)
 
-	expected := &flow.EpochCommit{
-		Counter: 1,
-		ClusterQCs: []flow.ClusterQCVoteData{
-			{
-				VoterIDs: []flow.Identifier{
+	expected := &flow.EpochRecover{
+		EpochSetup: flow.EpochSetup{
+			Counter:            1,
+			FirstView:          100,
+			FinalView:          200,
+			DKGPhase1FinalView: 150,
+			DKGPhase2FinalView: 160,
+			DKGPhase3FinalView: 170,
+			RandomSource:       randomSource,
+			TargetDuration:     200,
+			TargetEndTime:      2000000000,
+			Assignments: flow.AssignmentList{
+				{
 					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000001"),
 					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000002"),
 				},
-				SigData: MustDecodeSignatureHex("b072ed22ed305acd44818a6c836e09b4e844eebde6a4fdbf5cec983e2872b86c8b0f6c34c0777bf52e385ab7c45dc55d"),
-			},
-			{
-				VoterIDs: []flow.Identifier{
+				{
 					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000003"),
 					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000004"),
 				},
-				SigData: MustDecodeSignatureHex("899e266a543e1b3a564f68b22f7be571f2e944ec30fadc4b39e2d5f526ba044c0f3cb2648f8334fc216fa3360a0418b2"),
+			},
+			Participants: flow.IdentitySkeletonList{
+				{
+					Role:          flow.RoleCollection,
+					NodeID:        flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000001"),
+					Address:       "1.flow.com",
+					NetworkPubKey: MustDecodePublicKeyHex(crypto.ECDSAP256, "378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+					StakingPubKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+					InitialWeight: 100,
+				},
+				{
+					Role:          flow.RoleCollection,
+					NodeID:        flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000002"),
+					Address:       "2.flow.com",
+					NetworkPubKey: MustDecodePublicKeyHex(crypto.ECDSAP256, "378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+					StakingPubKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+					InitialWeight: 100,
+				},
+				{
+					Role:          flow.RoleCollection,
+					NodeID:        flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000003"),
+					Address:       "3.flow.com",
+					NetworkPubKey: MustDecodePublicKeyHex(crypto.ECDSAP256, "378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+					StakingPubKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+					InitialWeight: 100,
+				},
+				{
+					Role:          flow.RoleCollection,
+					NodeID:        flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000004"),
+					Address:       "4.flow.com",
+					NetworkPubKey: MustDecodePublicKeyHex(crypto.ECDSAP256, "378dbf45d85c614feb10d8bd4f78f4b6ef8eec7d987b937e123255444657fb3da031f232a507e323df3a6f6b8f50339c51d188e80c0e7a92420945cc6ca893fc"),
+					StakingPubKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "af4aade26d76bb2ab15dcc89adcef82a51f6f04b3cb5f4555214b40ec89813c7a5f95776ea4fe449de48166d0bbc59b919b7eabebaac9614cf6f9461fac257765415f4d8ef1376a2365ec9960121888ea5383d88a140c24c29962b0a14e4e4e7"),
+					InitialWeight: 100,
+				},
+				{
+					Role:          flow.RoleConsensus,
+					NodeID:        flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000011"),
+					Address:       "11.flow.com",
+					NetworkPubKey: MustDecodePublicKeyHex(crypto.ECDSAP256, "cfdfe8e4362c8f79d11772cb7277ab16e5033a63e8dd5d34caf1b041b77e5b2d63c2072260949ccf8907486e4cfc733c8c42ca0e4e208f30470b0d950856cd47"),
+					StakingPubKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "8207559cd7136af378bba53a8f0196dee3849a3ab02897c1995c3e3f6ca0c4a776c3ae869d1ddbb473090054be2400ad06d7910aa2c5d1780220fdf3765a3c1764bce10c6fe66a5a2be51a422e878518bd750424bb56b8a0ecf0f8ad2057e83f"),
+					InitialWeight: 100,
+				},
+				{
+					Role:          flow.RoleExecution,
+					NodeID:        flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000021"),
+					Address:       "21.flow.com",
+					NetworkPubKey: MustDecodePublicKeyHex(crypto.ECDSAP256, "d64318ba0dbf68f3788fc81c41d507c5822bf53154530673127c66f50fe4469ccf1a054a868a9f88506a8999f2386d86fcd2b901779718cba4fb53c2da258f9e"),
+					StakingPubKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "880b162b7ec138b36af401d07868cb08d25746d905395edbb4625bdf105d4bb2b2f4b0f4ae273a296a6efefa7ce9ccb914e39947ce0e83745125cab05d62516076ff0173ed472d3791ccef937597c9ea12381d76f547a092a4981d77ff3fba83"),
+					InitialWeight: 100,
+				},
+				{
+					Role:          flow.RoleVerification,
+					NodeID:        flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000031"),
+					Address:       "31.flow.com",
+					NetworkPubKey: MustDecodePublicKeyHex(crypto.ECDSAP256, "697241208dcc9142b6f53064adc8ff1c95760c68beb2ba083c1d005d40181fd7a1b113274e0163c053a3addd47cd528ec6a1f190cf465aac87c415feaae011ae"),
+					StakingPubKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "b1f97d0a06020eca97352e1adde72270ee713c7daf58da7e74bf72235321048b4841bdfc28227964bf18e371e266e32107d238358848bcc5d0977a0db4bda0b4c33d3874ff991e595e0f537c7b87b4ddce92038ebc7b295c9ea20a1492302aa7"),
+					InitialWeight: 100,
+				},
 			},
 		},
-		DKGGroupKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
-		DKGParticipantKeys: []crypto.PublicKey{
-			MustDecodePublicKeyHex(crypto.BLSBLS12381, "87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		EpochCommit: flow.EpochCommit{
+			Counter: 1,
+			ClusterQCs: []flow.ClusterQCVoteData{
+				{
+					VoterIDs: []flow.Identifier{
+						flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000001"),
+						flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000002"),
+					},
+					SigData: MustDecodeSignatureHex("b072ed22ed305acd44818a6c836e09b4e844eebde6a4fdbf5cec983e2872b86c8b0f6c34c0777bf52e385ab7c45dc55d"),
+				},
+				{
+					VoterIDs: []flow.Identifier{
+						flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000003"),
+						flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000004"),
+					},
+					SigData: MustDecodeSignatureHex("899e266a543e1b3a564f68b22f7be571f2e944ec30fadc4b39e2d5f526ba044c0f3cb2648f8334fc216fa3360a0418b2"),
+				},
+			},
+			DKGGroupKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+			DKGParticipantKeys: []crypto.PublicKey{
+				MustDecodePublicKeyHex(crypto.BLSBLS12381, "87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+			},
 		},
 	}
 
@@ -1322,8 +1404,8 @@ var EpochCommitFixtureCCF = func() []byte {
 	return b
 }()
 
-var EpochRecoverFixtureCCF = func() []byte {
-	randomSourceHex := hex.EncodeToString(EpochSetupRandomSourceFixture())
+func EpochRecoverFixtureCCF(randomSource []byte) []byte {
+	randomSourceHex := hex.EncodeToString(randomSource)
 	b, err := ccf.Encode(createEpochRecoverEvent(randomSourceHex))
 	if err != nil {
 		panic(err)
@@ -1333,7 +1415,7 @@ var EpochRecoverFixtureCCF = func() []byte {
 		panic(err)
 	}
 	return b
-}()
+}
 
 var VersionBeaconFixtureCCF = func() []byte {
 	b, err := ccf.Encode(createVersionBeaconEvent())

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -158,6 +158,42 @@ func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCom
 	return event, expected
 }
 
+// EpochRecoverFixtureByChainID returns an EpochRecover service event as a Cadence event
+// representation and as a protocol model representation.
+func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
+
+	events := systemcontracts.ServiceEventsForChain(chain)
+
+	event := EventFixture(events.EpochRecover.EventType(), 1, 1, IdentifierFixture(), 0)
+	event.Payload = EpochRecoverFixtureCCF
+
+	expected := &flow.EpochCommit{
+		Counter: 1,
+		ClusterQCs: []flow.ClusterQCVoteData{
+			{
+				VoterIDs: []flow.Identifier{
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000001"),
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000002"),
+				},
+				SigData: MustDecodeSignatureHex("b072ed22ed305acd44818a6c836e09b4e844eebde6a4fdbf5cec983e2872b86c8b0f6c34c0777bf52e385ab7c45dc55d"),
+			},
+			{
+				VoterIDs: []flow.Identifier{
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000003"),
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000004"),
+				},
+				SigData: MustDecodeSignatureHex("899e266a543e1b3a564f68b22f7be571f2e944ec30fadc4b39e2d5f526ba044c0f3cb2648f8334fc216fa3360a0418b2"),
+			},
+		},
+		DKGGroupKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+		DKGParticipantKeys: []crypto.PublicKey{
+			MustDecodePublicKeyHex(crypto.BLSBLS12381, "87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		},
+	}
+
+	return event, expected
+}
+
 // VersionBeaconFixtureByChainID returns a VersionTable service event as a Cadence event
 // representation and as a protocol model representation.
 func VersionBeaconFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.VersionBeacon) {
@@ -681,6 +717,97 @@ func createEpochCommitEvent() cadence.Event {
 	}).WithType(newFlowEpochEpochCommitEventType())
 }
 
+func createEpochRecoverEvent(randomSourceHex string) cadence.Event {
+
+	clusterQCVoteDataType := newFlowClusterQCClusterQCVoteDataStructType()
+
+	cluster1 := cadence.NewStruct([]cadence.Value{
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("a39cd1e1bf7e2fb0609b7388ce5215a6a4c01eef2aee86e1a007faa28a6b2a3dc876e11bb97cdb26c3846231d2d01e4d"),
+			cadence.String("91673ad9c717d396c9a0953617733c128049ac1a639653d4002ab245b121df1939430e313bcbfd06948f6a281f6bf853"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(clusterQCVoteDataType)
+
+	cluster2 := cadence.NewStruct([]cadence.Value{
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("b2bff159971852ed63e72c37991e62c94822e52d4fdcd7bf29aaf9fb178b1c5b4ce20dd9594e029f3574cb29533b857a"),
+			cadence.String("9931562f0248c9195758da3de4fb92f24fa734cbc20c0cb80280163560e0e0348f843ac89ecbd3732e335940c1e8dccb"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(clusterQCVoteDataType)
+
+	return cadence.NewEvent([]cadence.Value{
+		// counter
+		cadence.NewUInt64(1),
+
+		// nodeInfo
+		createEpochNodes(),
+
+		// firstView
+		cadence.NewUInt64(100),
+
+		// finalView
+		cadence.NewUInt64(200),
+
+		// collectorClusters
+		cadence.NewArray([]cadence.Value{
+			// cluster 1
+			cadence.NewArray([]cadence.Value{
+				cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+				cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+			}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+			// cluster 2
+			cadence.NewArray([]cadence.Value{
+				cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+				cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+			}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.NewVariableSizedArrayType(cadence.StringType))),
+
+		// randomSource
+		cadence.String(randomSourceHex),
+
+		// DKGPhase1FinalView
+		cadence.UInt64(150),
+
+		// DKGPhase2FinalView
+		cadence.UInt64(160),
+
+		// DKGPhase3FinalView
+		cadence.UInt64(170),
+
+		// targetDuration
+		cadence.UInt64(200),
+
+		// targetEndTime
+		cadence.UInt64(2000000000),
+
+		// clusterQCs
+		cadence.NewArray([]cadence.Value{
+			cluster1,
+			cluster2,
+		}).WithType(cadence.NewVariableSizedArrayType(clusterQCVoteDataType)),
+
+		// dkgPubKeys
+		cadence.NewArray([]cadence.Value{
+			cadence.String("8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+			cadence.String("87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(newFlowEpochEpochRecoverEventType())
+}
+
 func createVersionBeaconEvent() cadence.Event {
 	versionBoundaryType := NewNodeVersionBeaconVersionBoundaryStructType()
 
@@ -921,6 +1048,73 @@ func newFlowEpochEpochCommitEventType() *cadence.EventType {
 	}
 }
 
+func newFlowEpochEpochRecoverEventType() *cadence.EventType {
+
+	// A.01cf0e2f2f715450.FlowEpoch.EpochRecover
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowEpoch")
+
+	return &cadence.EventType{
+		Location:            location,
+		QualifiedIdentifier: "FlowEpoch.EpochRecover",
+		Fields: []cadence.Field{
+			{
+				Identifier: "counter",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "nodeInfo",
+				Type:       cadence.NewVariableSizedArrayType(newFlowIDTableStakingNodeInfoStructType()),
+			},
+			{
+				Identifier: "firstView",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "finalView",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "collectorClusters",
+				Type:       cadence.NewVariableSizedArrayType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+			},
+			{
+				Identifier: "randomSource",
+				Type:       cadence.StringType,
+			},
+			{
+				Identifier: "DKGPhase1FinalView",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "DKGPhase2FinalView",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "DKGPhase3FinalView",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "targetDuration",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "targetEndTime",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "clusterQCVoteData",
+				Type:       cadence.NewVariableSizedArrayType(newFlowClusterQCClusterQCVoteDataStructType()),
+			},
+			{
+				Identifier: "dkgPubKeys",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType),
+			},
+		},
+	}
+}
+
 func newFlowClusterQCClusterQCStructType() *cadence.StructType {
 
 	// A.01cf0e2f2f715450.FlowClusterQC.ClusterQC"
@@ -943,6 +1137,29 @@ func newFlowClusterQCClusterQCStructType() *cadence.StructType {
 			{
 				Identifier: "voteMessage",
 				Type:       cadence.StringType,
+			},
+			{
+				Identifier: "voterIDs",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType),
+			},
+		},
+	}
+}
+
+func newFlowClusterQCClusterQCVoteDataStructType() *cadence.StructType {
+
+	// A.01cf0e2f2f715450.FlowClusterQC.ClusterQCVoteData"
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "ClusterQCVoteData")
+
+	return &cadence.StructType{
+		Location:            location,
+		QualifiedIdentifier: "FlowClusterQC.ClusterQCVoteData",
+		Fields: []cadence.Field{
+			{
+				Identifier: "voteSignatures",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType),
 			},
 			{
 				Identifier: "voterIDs",
@@ -1095,6 +1312,19 @@ func EpochSetupCCFWithNonHexRandomSource() []byte {
 
 var EpochCommitFixtureCCF = func() []byte {
 	b, err := ccf.Encode(createEpochCommitEvent())
+	if err != nil {
+		panic(err)
+	}
+	_, err = ccf.Decode(nil, b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}()
+
+var EpochRecoverFixtureCCF = func() []byte {
+	randomSourceHex := hex.EncodeToString(EpochSetupRandomSourceFixture())
+	b, err := ccf.Encode(createEpochRecoverEvent(randomSourceHex))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/5727

### Context

This PR implements supports for `EpochRecover` service event for protocol level. As with other events it originates from smart contract level and requires decoding & conversion from Cadence types. 

As part of this PR I have added required logic to decode event, convert it protocol types and added specific tests and fixtures to ensure correct functionality. 