### PR TITLE
Update to Cadence v1.0.0-preview.29

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,12 +47,12 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.7.0-rc.2
-	github.com/onflow/cadence v1.0.0-preview.28
+	github.com/onflow/cadence v1.0.0-preview.29
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
-	github.com/onflow/flow-go-sdk v1.0.0-preview.29
+	github.com/onflow/flow-go-sdk v1.0.0-preview.30
 	github.com/onflow/flow/protobuf/go/flow v0.4.3
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2157,8 +2157,8 @@ github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.28 h1:HUGwDFS3GRp1OB5AHXzz+UeZmDgWfvuJeJsmztwswjI=
-github.com/onflow/cadence v1.0.0-preview.28/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
+github.com/onflow/cadence v1.0.0-preview.29 h1:kuglA1LXKsti1JWhZ25riVkIZsLnyiudF8fgzeblZ40=
+github.com/onflow/cadence v1.0.0-preview.29/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2173,8 +2173,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.29 h1:cyJIYeT4H5JWkotxvz3UjcsxVR/NSWfaEfyoE92Eqyc=
-github.com/onflow/flow-go-sdk v1.0.0-preview.29/go.mod h1:AikkHjKDpQ/Rzjt0zQNQE4w5ixlD8UOxEqR7BVq3410=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30 h1:62IwC7l8Uw1mxoZe7ewJII0HFHLUMsg04z1BW3JSEfM=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30/go.mod h1:PBIk3vLqU1aLdbWPw7ljRDmwSGLcsuk/ipL9eLMgWwc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.0 h1:TFH7GCJKcGi0+x14SCvF7Gbnxp68gJOGNV8PSIAM2J0=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.0/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -198,12 +198,12 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.7.0-rc.2 // indirect
-	github.com/onflow/cadence v1.0.0-preview.28 // indirect
+	github.com/onflow/cadence v1.0.0-preview.29 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-preview.29 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-preview.30 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.0 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v1.2.0 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.3 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2143,8 +2143,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
 github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.28 h1:HUGwDFS3GRp1OB5AHXzz+UeZmDgWfvuJeJsmztwswjI=
-github.com/onflow/cadence v1.0.0-preview.28/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
+github.com/onflow/cadence v1.0.0-preview.29 h1:kuglA1LXKsti1JWhZ25riVkIZsLnyiudF8fgzeblZ40=
+github.com/onflow/cadence v1.0.0-preview.29/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2157,8 +2157,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.29 h1:cyJIYeT4H5JWkotxvz3UjcsxVR/NSWfaEfyoE92Eqyc=
-github.com/onflow/flow-go-sdk v1.0.0-preview.29/go.mod h1:AikkHjKDpQ/Rzjt0zQNQE4w5ixlD8UOxEqR7BVq3410=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30 h1:62IwC7l8Uw1mxoZe7ewJII0HFHLUMsg04z1BW3JSEfM=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30/go.mod h1:PBIk3vLqU1aLdbWPw7ljRDmwSGLcsuk/ipL9eLMgWwc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.0 h1:TFH7GCJKcGi0+x14SCvF7Gbnxp68gJOGNV8PSIAM2J0=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.0/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview.28
+	github.com/onflow/cadence v1.0.0-preview.29
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.0.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
 	github.com/onflow/flow-emulator v1.0.0-preview.21.0.20240501034320-e644fcba11e2
 	github.com/onflow/flow-go v0.34.0-crescendo-preview.10-staged-contracts-3.0.20240501031941-53ca114d9c37
-	github.com/onflow/flow-go-sdk v1.0.0-preview.29
+	github.com/onflow/flow-go-sdk v1.0.0-preview.30
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.3
 	github.com/onflow/go-ethereum v1.13.4

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2137,8 +2137,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
 github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.28 h1:HUGwDFS3GRp1OB5AHXzz+UeZmDgWfvuJeJsmztwswjI=
-github.com/onflow/cadence v1.0.0-preview.28/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
+github.com/onflow/cadence v1.0.0-preview.29 h1:kuglA1LXKsti1JWhZ25riVkIZsLnyiudF8fgzeblZ40=
+github.com/onflow/cadence v1.0.0-preview.29/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2153,8 +2153,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.29 h1:cyJIYeT4H5JWkotxvz3UjcsxVR/NSWfaEfyoE92Eqyc=
-github.com/onflow/flow-go-sdk v1.0.0-preview.29/go.mod h1:AikkHjKDpQ/Rzjt0zQNQE4w5ixlD8UOxEqR7BVq3410=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30 h1:62IwC7l8Uw1mxoZe7ewJII0HFHLUMsg04z1BW3JSEfM=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30/go.mod h1:PBIk3vLqU1aLdbWPw7ljRDmwSGLcsuk/ipL9eLMgWwc=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.0 h1:TFH7GCJKcGi0+x14SCvF7Gbnxp68gJOGNV8PSIAM2J0=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.0/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/flow-go-sdk v1.0.0-preview.30](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.30)
- [onflow/cadence v1.0.0-preview.29](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.29)

