### PR TITLE
Add Payload.Address() to allow migrations, etc. to reduce overhead

### DIFF
--- a/cmd/util/ledger/util/payload_grouping.go
+++ b/cmd/util/ledger/util/payload_grouping.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/ledger"
-	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -56,7 +55,7 @@ func (g *PayloadAccountGrouping) Next() (*PayloadAccountGroup, error) {
 	}
 	g.current++
 
-	address, err := PayloadToAddress(g.payloads[accountStartIndex])
+	address, err := g.payloads[accountStartIndex].Address()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get address from payload: %w", err)
 	}
@@ -123,31 +122,6 @@ func GroupPayloadsByAccount(
 		payloads: p,
 		indexes:  indexes,
 	}
-}
-
-// PayloadToAddress takes a payload and return:
-// - (address, nil) if the payload is for an account, the account address is returned
-// - (common.ZeroAddress, nil) if the payload is not for an account
-// - (common.ZeroAddress, err) if running into any exception
-// The zero address is used for global Payloads and is not an actual account
-func PayloadToAddress(p *ledger.Payload) (flow.Address, error) {
-	k, err := p.Key()
-	if err != nil {
-		return flow.EmptyAddress, fmt.Errorf("could not find key for payload: %w", err)
-	}
-
-	id, err := convert.LedgerKeyToRegisterID(k)
-	if err != nil {
-		return flow.EmptyAddress, fmt.Errorf("error converting key to register ID")
-	}
-
-	if len([]byte(id.Owner)) != flow.AddressLength {
-		return flow.EmptyAddress, nil
-	}
-
-	address := flow.BytesToAddress([]byte(id.Owner))
-
-	return address, nil
 }
 
 type sortablePayloads []*ledger.Payload

--- a/ledger/common/convert/convert.go
+++ b/ledger/common/convert/convert.go
@@ -7,14 +7,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-const (
-	KeyPartOwner = uint16(0)
-	// Deprecated: KeyPartController was only used by the very first
-	// version of Cadence for access control, which was later retired
-	_          = uint16(1) // DO NOT REUSE
-	KeyPartKey = uint16(2)
-)
-
 // UnexpectedLedgerKeyFormat is returned when a ledger key is not in the expected format
 var UnexpectedLedgerKeyFormat = fmt.Errorf("unexpected ledger key format")
 
@@ -23,8 +15,8 @@ var UnexpectedLedgerKeyFormat = fmt.Errorf("unexpected ledger key format")
 func LedgerKeyToRegisterID(key ledger.Key) (flow.RegisterID, error) {
 	parts := key.KeyParts
 	if len(parts) != 2 ||
-		parts[0].Type != KeyPartOwner ||
-		parts[1].Type != KeyPartKey {
+		parts[0].Type != ledger.KeyPartOwner ||
+		parts[1].Type != ledger.KeyPartKey {
 		return flow.RegisterID{}, fmt.Errorf("ledger key %s: %w", key.String(), UnexpectedLedgerKeyFormat)
 	}
 
@@ -39,11 +31,11 @@ func RegisterIDToLedgerKey(registerID flow.RegisterID) ledger.Key {
 	return ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
-				Type:  KeyPartOwner,
+				Type:  ledger.KeyPartOwner,
 				Value: []byte(registerID.Owner),
 			},
 			{
-				Type:  KeyPartKey,
+				Type:  ledger.KeyPartKey,
 				Value: []byte(registerID.Key),
 			},
 		},

--- a/ledger/common/convert/convert_test.go
+++ b/ledger/common/convert/convert_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"
@@ -34,7 +33,7 @@ func TestLedgerKeyToRegisterID(t *testing.T) {
 
 	p := ledger.NewPayload(key, ledger.Value("value"))
 
-	address, err := util.PayloadToAddress(p)
+	address, err := p.Address()
 
 	require.NoError(t, err)
 	require.Equal(t, registerID.Owner, flow.AddressToRegisterOwner(address))
@@ -62,7 +61,7 @@ func TestLedgerKeyToRegisterID_Global(t *testing.T) {
 
 	p := ledger.NewPayload(key, ledger.Value("value"))
 
-	address, err := util.PayloadToAddress(p)
+	address, err := p.Address()
 
 	require.NoError(t, err)
 	require.Equal(t, registerID.Owner, flow.AddressToRegisterOwner(address))

--- a/ledger/common/convert/convert_test.go
+++ b/ledger/common/convert/convert_test.go
@@ -18,11 +18,11 @@ func TestLedgerKeyToRegisterID(t *testing.T) {
 	key := ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
-				Type:  convert.KeyPartOwner,
+				Type:  ledger.KeyPartOwner,
 				Value: []byte(expectedRegisterID.Owner),
 			},
 			{
-				Type:  convert.KeyPartKey,
+				Type:  ledger.KeyPartKey,
 				Value: []byte("key"),
 			},
 		},
@@ -45,11 +45,11 @@ func TestLedgerKeyToRegisterID_Global(t *testing.T) {
 	key := ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
-				Type:  convert.KeyPartOwner,
+				Type:  ledger.KeyPartOwner,
 				Value: []byte(""),
 			},
 			{
-				Type:  convert.KeyPartKey,
+				Type:  ledger.KeyPartKey,
 				Value: []byte("uuid"),
 			},
 		},
@@ -77,7 +77,7 @@ func TestLedgerKeyToRegisterID_Error(t *testing.T) {
 				Value: []byte("owner"),
 			},
 			{
-				Type:  convert.KeyPartKey,
+				Type:  ledger.KeyPartKey,
 				Value: []byte("key"),
 			},
 		},
@@ -93,13 +93,13 @@ func TestRegisterIDToLedgerKey(t *testing.T) {
 	expectedKey := ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
-				Type: convert.KeyPartOwner,
+				Type: ledger.KeyPartOwner,
 				// Note: the owner field is extended to address length during NewRegisterID
 				// so we have to do the same here
 				Value: []byte(registerID.Owner),
 			},
 			{
-				Type:  convert.KeyPartKey,
+				Type:  ledger.KeyPartKey,
 				Value: []byte("key"),
 			},
 		},
@@ -114,11 +114,11 @@ func TestRegisterIDToLedgerKey_Global(t *testing.T) {
 	expectedKey := ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
-				Type:  convert.KeyPartOwner,
+				Type:  ledger.KeyPartOwner,
 				Value: []byte(""),
 			},
 			{
-				Type:  convert.KeyPartKey,
+				Type:  ledger.KeyPartKey,
 				Value: []byte("uuid"),
 			},
 		},
@@ -135,8 +135,8 @@ func TestPayloadToRegister(t *testing.T) {
 		p := ledger.NewPayload(
 			ledger.NewKey(
 				[]ledger.KeyPart{
-					ledger.NewKeyPart(convert.KeyPartOwner, []byte(expected.Owner)),
-					ledger.NewKeyPart(convert.KeyPartKey, []byte(expected.Key)),
+					ledger.NewKeyPart(ledger.KeyPartOwner, []byte(expected.Owner)),
+					ledger.NewKeyPart(ledger.KeyPartKey, []byte(expected.Key)),
 				},
 			),
 			value,
@@ -152,8 +152,8 @@ func TestPayloadToRegister(t *testing.T) {
 		p := ledger.NewPayload(
 			ledger.NewKey(
 				[]ledger.KeyPart{
-					ledger.NewKeyPart(convert.KeyPartOwner, []byte("")),
-					ledger.NewKeyPart(convert.KeyPartKey, []byte("uuid")),
+					ledger.NewKeyPart(ledger.KeyPartOwner, []byte("")),
+					ledger.NewKeyPart(ledger.KeyPartKey, []byte("uuid")),
 				},
 			),
 			value,

--- a/ledger/trie_test.go
+++ b/ledger/trie_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/fxamacker/cbor/v2"
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
 )
 
 // TestPayloadEquals tests equality of payloads.  It tests:

--- a/ledger/trie_test.go
+++ b/ledger/trie_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/fxamacker/cbor/v2"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/stretchr/testify/require"
 )
 
@@ -308,26 +309,52 @@ func TestPayloadKey(t *testing.T) {
 		k, err := p.Key()
 		require.NoError(t, err)
 		require.Equal(t, Key{}, k)
+
+		_, err = p.Address()
+		require.Error(t, err)
 	})
 	t.Run("empty payload", func(t *testing.T) {
 		p := Payload{}
 		k, err := p.Key()
 		require.NoError(t, err)
 		require.Equal(t, Key{}, k)
+
+		_, err = p.Address()
+		require.Error(t, err)
 	})
 	t.Run("empty key", func(t *testing.T) {
 		p := NewPayload(Key{}, Value{})
 		k, err := p.Key()
 		require.NoError(t, err)
 		require.Equal(t, Key{}, k)
+
+		_, err = p.Address()
+		require.Error(t, err)
 	})
-	t.Run("key", func(t *testing.T) {
-		key := Key{KeyParts: []KeyPart{{Type: 0, Value: []byte("abc")}, {Type: 1, Value: []byte("def")}}}
+	t.Run("global key", func(t *testing.T) {
+		key := Key{KeyParts: []KeyPart{{Type: 0, Value: []byte{}}, {Type: 1, Value: []byte("def")}}}
 		value := Value([]byte{0, 1, 2})
 		p := NewPayload(key, value)
 		k, err := p.Key()
 		require.NoError(t, err)
 		require.Equal(t, key, k)
+
+		addr, err := p.Address()
+		require.NoError(t, err)
+		require.Equal(t, flow.EmptyAddress, addr)
+	})
+	t.Run("key", func(t *testing.T) {
+		address := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+		key := Key{KeyParts: []KeyPart{{Type: 0, Value: address}, {Type: 1, Value: []byte("def")}}}
+		value := Value([]byte{0, 1, 2})
+		p := NewPayload(key, value)
+		k, err := p.Key()
+		require.NoError(t, err)
+		require.Equal(t, key, k)
+
+		addr, err := p.Address()
+		require.NoError(t, err)
+		require.Equal(t, flow.Address(address), addr)
 	})
 }
 

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -640,11 +640,11 @@ func ledgerPayloadWithValuesFixture(owner string, key string, value []byte) *led
 	k := ledger.Key{
 		KeyParts: []ledger.KeyPart{
 			{
-				Type:  convert.KeyPartOwner,
+				Type:  ledger.KeyPartOwner,
 				Value: []byte(owner),
 			},
 			{
-				Type:  convert.KeyPartKey,
+				Type:  ledger.KeyPartKey,
 				Value: []byte(key),
 			},
 		},

--- a/storage/pebble/bootstrap_test.go
+++ b/storage/pebble/bootstrap_test.go
@@ -231,8 +231,8 @@ func randomRegisterPayloads(n uint16) []ledger.Payload {
 		o := make([]byte, 0, 8)
 		o = binary.BigEndian.AppendUint16(o, n)
 		k := ledger.Key{KeyParts: []ledger.KeyPart{
-			{Type: convert.KeyPartOwner, Value: o},
-			{Type: convert.KeyPartKey, Value: o},
+			{Type: ledger.KeyPartOwner, Value: o},
+			{Type: ledger.KeyPartKey, Value: o},
 		}}
 		// values are always 'v' for ease of testing/checking
 		v := ledger.Value{defaultRegisterValue}


### PR DESCRIPTION
This PR adds `Payload.Address()` to extract and return payload address.  This can be used (e.g. by migrations) to reduce overhead of extracting address from payload key.

Discussion :thread: https://github.com/onflow/flow-go/pull/5942#issuecomment-2117936857