### PR TITLE
Fix FVM call to checkDependencies

### DIFF
--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -132,6 +132,9 @@ func SystemChunkContext(vmCtx fvm.Context) fvm.Context {
 		fvm.WithMemoryAndInteractionLimitsDisabled(),
 		// only the system transaction is allowed to call the block entropy provider
 		fvm.WithRandomSourceHistoryCallAllowed(true),
+
+		// never enable the dependency check for the system transaction
+		fvm.WithDependencyCheckEnabled(false),
 	)
 }
 

--- a/fvm/environment/system_contracts.go
+++ b/fvm/environment/system_contracts.go
@@ -300,6 +300,8 @@ var checkDependenciesSpec = ContractFunctionSpec{
 	},
 }
 
+// CheckDependencies calls the checkDependencies function on the service account.
+// The inputs should be deterministically sorted.
 func (sys *SystemContracts) CheckDependencies(
 	dependencies []common.AddressLocation,
 	authorizers []flow.Address,


### PR DESCRIPTION
This fixes 2 issues that were found on the dependency check mechanism:

- indeterministically ordered inputs into the cadence function caused the emitted events to be indeterministic causing a execution result fork (the state was still deterministic).
- the check dependencies function was called in the system transaction. It should not be. (this is a really minor thing, and only helps with a little bit of performance improvement)

The FVM tests originally missed the indeterminism, because it was doing an `require.ElementsMatch` instead of `require.Equal`. It is not enough that the elements match they must also always be in the same order. I also added a test that the authorisers are deterministically ordered and re-ran the same test 100 times (`-test.count 100`).
