### PR TITLE
move FlowClient to grpcclient package

### DIFF
--- a/cmd/bootstrap/cmd/partner_infos.go
+++ b/cmd/bootstrap/cmd/partner_infos.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/grpcclient"
 )
 
 const (
@@ -117,12 +118,12 @@ func getFlowClient() *client.Client {
 		insecureClient = false
 	}
 
-	config, err := common.NewFlowClientConfig(flagANAddress, strings.TrimPrefix(flagANNetworkKey, "0x"), flow.ZeroID, insecureClient)
+	config, err := grpcclient.NewFlowClientConfig(flagANAddress, strings.TrimPrefix(flagANNetworkKey, "0x"), flow.ZeroID, insecureClient)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not get flow client config with address (%s) and network key (%s)", flagANAddress, flagANNetworkKey)
 	}
 
-	flowClient, err := common.FlowClient(config)
+	flowClient, err := grpcclient.FlowClient(config)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("could not get flow client with address (%s) and network key (%s)", flagANAddress, flagANNetworkKey)
 	}

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -43,6 +43,7 @@ import (
 	modulecompliance "github.com/onflow/flow-go/module/compliance"
 	"github.com/onflow/flow-go/module/epochs"
 	confinalizer "github.com/onflow/flow-go/module/finalizer/consensus"
+	"github.com/onflow/flow-go/module/grpcclient"
 	"github.com/onflow/flow-go/module/mempool"
 	epochpool "github.com/onflow/flow-go/module/mempool/epochs"
 	"github.com/onflow/flow-go/module/mempool/herocache"
@@ -98,7 +99,7 @@ func main() {
 
 		// epoch qc contract client
 		machineAccountInfo *bootstrap.NodeMachineAccountInfo
-		flowClientConfigs  []*common.FlowClientConfig
+		flowClientConfigs  []*grpcclient.FlowClientConfig
 		insecureAccessAPI  bool
 		accessNodeIDS      []string
 		apiRatelimits      map[string]int
@@ -284,7 +285,7 @@ func main() {
 				return fmt.Errorf("failed to validate flag --access-node-ids %w", err)
 			}
 
-			flowClientConfigs, err = common.FlowClientConfigs(anIDS, insecureAccessAPI, node.State.Sealed())
+			flowClientConfigs, err = grpcclient.FlowClientConfigs(anIDS, insecureAccessAPI, node.State.Sealed())
 			if err != nil {
 				return fmt.Errorf("failed to prepare flow client connection configs for each access node id %w", err)
 			}
@@ -293,7 +294,7 @@ func main() {
 		}).
 		Component("machine account config validator", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			// @TODO use fallback logic for flowClient similar to DKG/QC contract clients
-			flowClient, err := common.FlowClient(flowClientConfigs[0])
+			flowClient, err := grpcclient.FlowClient(flowClientConfigs[0])
 			if err != nil {
 				return nil, fmt.Errorf("failed to get flow client connection option for access node (0): %s %w", flowClientConfigs[0].AccessAddress, err)
 			}
@@ -682,11 +683,11 @@ func createQCContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap.
 }
 
 // createQCContractClients creates priority ordered array of QCContractClient
-func createQCContractClients(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClientOpts []*common.FlowClientConfig) ([]module.QCContractClient, error) {
+func createQCContractClients(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClientOpts []*grpcclient.FlowClientConfig) ([]module.QCContractClient, error) {
 	qcClients := make([]module.QCContractClient, 0)
 
 	for _, opt := range flowClientOpts {
-		flowClient, err := common.FlowClient(opt)
+		flowClient, err := grpcclient.FlowClient(opt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create flow client for qc contract client with options: %s %w", flowClientOpts, err)
 		}

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -50,6 +50,7 @@ import (
 	dkgmodule "github.com/onflow/flow-go/module/dkg"
 	"github.com/onflow/flow-go/module/epochs"
 	finalizer "github.com/onflow/flow-go/module/finalizer/consensus"
+	"github.com/onflow/flow-go/module/grpcclient"
 	"github.com/onflow/flow-go/module/mempool"
 	consensusMempools "github.com/onflow/flow-go/module/mempool/consensus"
 	"github.com/onflow/flow-go/module/mempool/stdmap"
@@ -99,7 +100,7 @@ func main() {
 
 		// DKG contract client
 		machineAccountInfo *bootstrap.NodeMachineAccountInfo
-		flowClientConfigs  []*common.FlowClientConfig
+		flowClientConfigs  []*grpcclient.FlowClientConfig
 		insecureAccessAPI  bool
 		accessNodeIDS      []string
 
@@ -408,7 +409,7 @@ func main() {
 				return fmt.Errorf("failed to validate flag --access-node-ids %w", err)
 			}
 
-			flowClientConfigs, err = common.FlowClientConfigs(anIDS, insecureAccessAPI, node.State.Sealed())
+			flowClientConfigs, err = grpcclient.FlowClientConfigs(anIDS, insecureAccessAPI, node.State.Sealed())
 			if err != nil {
 				return fmt.Errorf("failed to prepare flow client connection configs for each access node id %w", err)
 			}
@@ -417,7 +418,7 @@ func main() {
 		}).
 		Component("machine account config validator", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 			// @TODO use fallback logic for flowClient similar to DKG/QC contract clients
-			flowClient, err := common.FlowClient(flowClientConfigs[0])
+			flowClient, err := grpcclient.FlowClient(flowClientConfigs[0])
 			if err != nil {
 				return nil, fmt.Errorf("failed to get flow client connection option for access node (0): %s %w", flowClientConfigs[0].AccessAddress, err)
 			}
@@ -981,11 +982,11 @@ func createDKGContractClient(node *cmd.NodeConfig, machineAccountInfo *bootstrap
 }
 
 // createDKGContractClients creates an array dkgContractClient that is sorted by retry fallback priority
-func createDKGContractClients(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClientOpts []*common.FlowClientConfig) ([]module.DKGContractClient, error) {
+func createDKGContractClients(node *cmd.NodeConfig, machineAccountInfo *bootstrap.NodeMachineAccountInfo, flowClientOpts []*grpcclient.FlowClientConfig) ([]module.DKGContractClient, error) {
 	dkgClients := make([]module.DKGContractClient, 0)
 
 	for _, opt := range flowClientOpts {
-		flowClient, err := common.FlowClient(opt)
+		flowClient, err := grpcclient.FlowClient(opt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create flow client for dkg contract client with options: %s %w", flowClientOpts, err)
 		}

--- a/cmd/dynamic_startup.go
+++ b/cmd/dynamic_startup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/grpcclient"
 	"github.com/onflow/flow-go/state/protocol"
 	badgerstate "github.com/onflow/flow-go/state/protocol/badger"
 	utilsio "github.com/onflow/flow-go/utils/io"
@@ -92,11 +93,11 @@ func DynamicStartPreInit(nodeConfig *NodeConfig) error {
 	// CASE 2.2: Use Dynamic Startup to bootstrap.
 
 	// get flow client with secure client connection to download protocol snapshot from access node
-	config, err := common.NewFlowClientConfig(nodeConfig.DynamicStartupANAddress, nodeConfig.DynamicStartupANPubkey, flow.ZeroID, false)
+	config, err := grpcclient.NewFlowClientConfig(nodeConfig.DynamicStartupANAddress, nodeConfig.DynamicStartupANPubkey, flow.ZeroID, false)
 	if err != nil {
 		return fmt.Errorf("failed to create flow client config for node dynamic startup pre-init: %w", err)
 	}
-	flowClient, err := common.FlowClient(config)
+	flowClient, err := grpcclient.FlowClient(config)
 	if err != nil {
 		return fmt.Errorf("failed to create flow client for node dynamic startup pre-init: %w", err)
 	}

--- a/cmd/util/cmd/common/validation.go
+++ b/cmd/util/cmd/common/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/grpcclient"
 	"github.com/onflow/flow-go/state/protocol"
 )
 
@@ -31,7 +32,7 @@ func validateFlags(accessNodeIDS []string, snapshot protocol.Snapshot) ([]flow.I
 	}
 
 	if accessNodeIDS[0] == "*" {
-		anIDS, err := DefaultAccessNodeIDS(snapshot)
+		anIDS, err := grpcclient.DefaultAccessNodeIDS(snapshot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get default access node ids %w", err)
 		}
@@ -59,7 +60,7 @@ func validateFlagsMainNet(accessNodeIDS []string) ([]flow.Identifier, error) {
 
 // convertIDS converts a list of access node id hex strings to flow.Identifier
 func convertIDS(accessNodeIDS []string) ([]flow.Identifier, error) {
-	anIDS, err := FlowIDFromHexString(accessNodeIDS...)
+	anIDS, err := grpcclient.FlowIDFromHexString(accessNodeIDS...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert access node ID(s) into flow identifier(s) %w", err)
 	}

--- a/cmd/util/cmd/epochs/cmd/recover.go
+++ b/cmd/util/cmd/epochs/cmd/recover.go
@@ -13,6 +13,7 @@ import (
 	epochcmdutil "github.com/onflow/flow-go/cmd/util/cmd/epochs/utils"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/filter"
+	"github.com/onflow/flow-go/module/grpcclient"
 	"github.com/onflow/flow-go/state/protocol/inmem"
 )
 
@@ -90,12 +91,12 @@ func addGenerateRecoverEpochTxArgsCmdFlags() error {
 
 func getSnapshot() *inmem.Snapshot {
 	// get flow client with secure client connection to download protocol snapshot from access node
-	config, err := common.NewFlowClientConfig(flagAnAddress, flagAnPubkey, flow.ZeroID, false)
+	config, err := grpcclient.NewFlowClientConfig(flagAnAddress, flagAnPubkey, flow.ZeroID, false)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create flow client config")
 	}
 
-	flowClient, err := common.FlowClient(config)
+	flowClient, err := grpcclient.FlowClient(config)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create flow client")
 	}

--- a/module/grpcclient/flow_client.go
+++ b/module/grpcclient/flow_client.go
@@ -1,4 +1,4 @@
-package common
+package grpcclient
 
 import (
 	"fmt"


### PR DESCRIPTION
Move FlowClient to other package, so that engines can reuse it as well without depending on the top `cmd` package namespace.