### PR TITLE
[EVM] Calculate `EVM.BlockExecuted.TotalGasUsed` for Tx batch runs and COA calls

### DIFF
--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -152,7 +152,7 @@ func TestEVMRun(t *testing.T) {
 				require.Equal(t, blockEventPayload.Hash, txEventPayload.BlockHash)
 				require.Equal(t, blockEventPayload.Height, txEventPayload.BlockHeight)
 				require.Equal(t, blockEventPayload.TotalGasUsed, txEventPayload.GasConsumed)
-				require.Greater(t, blockEventPayload.TotalGasUsed, uint64(0))
+				require.Equal(t, uint64(43807), blockEventPayload.TotalGasUsed)
 				require.Empty(t, txEventPayload.ContractAddress)
 
 				// append the state
@@ -533,7 +533,7 @@ func TestEVMBatchRun(t *testing.T) {
 				blockEventPayload, err := types.DecodeBlockEventPayload(cadenceEvent)
 				require.NoError(t, err)
 				require.NotEmpty(t, blockEventPayload.Hash)
-				require.Greater(t, blockEventPayload.TotalGasUsed, uint64(0))
+				require.Equal(t, uint64(155183), blockEventPayload.TotalGasUsed)
 
 				// append the state
 				snapshot = snapshot.Append(state)
@@ -1012,7 +1012,7 @@ func TestEVMAddressDeposit(t *testing.T) {
 			blockEventPayload, err := types.DecodeBlockEventPayload(cadenceEvent)
 			require.NoError(t, err)
 			require.NotEmpty(t, blockEventPayload.Hash)
-			require.Greater(t, blockEventPayload.TotalGasUsed, uint64(0))
+			require.Equal(t, uint64(21000), blockEventPayload.TotalGasUsed)
 		})
 }
 

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -38,6 +38,7 @@ func TestEVMRun(t *testing.T) {
 	t.Parallel()
 
 	chain := flow.Emulator.Chain()
+
 	t.Run("testing EVM.run (happy case)", func(t *testing.T) {
 
 		t.Parallel()
@@ -151,6 +152,7 @@ func TestEVMRun(t *testing.T) {
 				require.Equal(t, blockEventPayload.Hash, txEventPayload.BlockHash)
 				require.Equal(t, blockEventPayload.Height, txEventPayload.BlockHeight)
 				require.Equal(t, blockEventPayload.TotalGasUsed, txEventPayload.GasConsumed)
+				require.Greater(t, blockEventPayload.TotalGasUsed, uint64(0))
 				require.Empty(t, txEventPayload.ContractAddress)
 
 				// append the state
@@ -509,6 +511,29 @@ func TestEVMBatchRun(t *testing.T) {
 					last := log.Topics[len(log.Topics)-1] // last topic is the value set in the store method
 					assert.Equal(t, storedValues[i], last.Big().Int64())
 				}
+
+				// last one is block executed, make sure TotalGasUsed is non-zero
+				blockEvent := output.Events[batchCount]
+
+				assert.Equal(
+					t,
+					common.NewAddressLocation(
+						nil,
+						common.Address(sc.EVMContract.Address),
+						string(types.EventTypeBlockExecuted),
+					).ID(),
+					string(blockEvent.Type),
+				)
+
+				ev, err := ccf.Decode(nil, blockEvent.Payload)
+				require.NoError(t, err)
+				cadenceEvent, ok := ev.(cadence.Event)
+				require.True(t, ok)
+
+				blockEventPayload, err := types.DecodeBlockEventPayload(cadenceEvent)
+				require.NoError(t, err)
+				require.NotEmpty(t, blockEventPayload.Hash)
+				require.Greater(t, blockEventPayload.TotalGasUsed, uint64(0))
 
 				// append the state
 				snapshot = snapshot.Append(state)
@@ -965,6 +990,29 @@ func TestEVMAddressDeposit(t *testing.T) {
 			expectedBalance := types.OneFlowBalance
 			bal := getEVMAccountBalance(t, ctx, vm, snapshot, addr)
 			require.Equal(t, expectedBalance, bal)
+
+			// block executed event, make sure TotalGasUsed is non-zero
+			blockEvent := output.Events[3]
+
+			assert.Equal(
+				t,
+				common.NewAddressLocation(
+					nil,
+					common.Address(sc.EVMContract.Address),
+					string(types.EventTypeBlockExecuted),
+				).ID(),
+				string(blockEvent.Type),
+			)
+
+			ev, err := ccf.Decode(nil, blockEvent.Payload)
+			require.NoError(t, err)
+			cadenceEvent, ok := ev.(cadence.Event)
+			require.True(t, ok)
+
+			blockEventPayload, err := types.DecodeBlockEventPayload(cadenceEvent)
+			require.NoError(t, err)
+			require.NotEmpty(t, blockEventPayload.Hash)
+			require.Greater(t, blockEventPayload.TotalGasUsed, uint64(0))
 		})
 }
 

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -184,7 +184,11 @@ func (h *ContractHandler) batchRun(rlpEncodedTxs [][]byte, coinbase types.Addres
 		return nil, types.ErrUnexpectedEmptyResult
 	}
 
+	// Populate receipt root
 	bp.PopulateReceiptRoot(res)
+
+	// Populate total gas used
+	bp.CalculateGasUsage(res)
 
 	// meter all the transaction gas usage and append hashes to the block
 	for _, r := range res {
@@ -294,9 +298,11 @@ func (h *ContractHandler) run(
 
 	bp.AppendTxHash(res.TxHash)
 
-	// populate receipt root
+	// Populate receipt root
 	bp.PopulateReceiptRoot([]*types.Result{res})
-	bp.CalculateGasUsage([]types.Result{*res})
+
+	// Populate total gas used
+	bp.CalculateGasUsage([]*types.Result{res})
 
 	blockHash, err := bp.Hash()
 	if err != nil {
@@ -478,6 +484,9 @@ func (h *ContractHandler) executeAndHandleCall(
 
 	// Populate receipt root
 	bp.PopulateReceiptRoot([]*types.Result{res})
+
+	// Populate total gas used
+	bp.CalculateGasUsage([]*types.Result{res})
 
 	if totalSupplyDiff != nil {
 		if deductSupplyDiff {

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -69,7 +69,7 @@ func (b *Block) PopulateReceiptRoot(results []*Result) {
 }
 
 // CalculateGasUsage sums up all the gas transactions in the block used
-func (b *Block) CalculateGasUsage(results []Result) {
+func (b *Block) CalculateGasUsage(results []*Result) {
 	for _, res := range results {
 		b.TotalGasUsed += res.GasConsumed
 	}


### PR DESCRIPTION
Closes https://github.com/onflow/flow-go/issues/5951

For EVM blocks that were produced from `EVM.batchRun`, or COA interactions, the `TotalGasUsed` field was not being calculated.