### PR TITLE
Update atree inlining branch

### DIFF
--- a/access/handler.go
+++ b/access/handler.go
@@ -2,6 +2,7 @@ package access
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,6 +16,8 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/counters"
+	"github.com/onflow/flow-go/module/state_synchronization"
+	"github.com/onflow/flow-go/module/state_synchronization/indexer"
 
 	"github.com/onflow/flow/protobuf/go/flow/access"
 	"github.com/onflow/flow/protobuf/go/flow/entities"
@@ -27,6 +30,7 @@ type Handler struct {
 	signerIndicesDecoder hotstuff.BlockSignerDecoder
 	finalizedHeaderCache module.FinalizedHeaderCache
 	me                   module.Local
+	indexReporter        state_synchronization.IndexReporter
 }
 
 // HandlerOption is used to hand over optional constructor parameters
@@ -196,7 +200,10 @@ func (h *Handler) GetCollectionByID(
 	ctx context.Context,
 	req *access.GetCollectionByIDRequest,
 ) (*access.CollectionResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := convert.CollectionID(req.GetId())
 	if err != nil {
@@ -223,7 +230,10 @@ func (h *Handler) GetFullCollectionByID(
 	ctx context.Context,
 	req *access.GetFullCollectionByIDRequest,
 ) (*access.FullCollectionResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := convert.CollectionID(req.GetId())
 	if err != nil {
@@ -251,7 +261,10 @@ func (h *Handler) SendTransaction(
 	ctx context.Context,
 	req *access.SendTransactionRequest,
 ) (*access.SendTransactionResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	txMsg := req.GetTransaction()
 
@@ -278,7 +291,10 @@ func (h *Handler) GetTransaction(
 	ctx context.Context,
 	req *access.GetTransactionRequest,
 ) (*access.TransactionResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := convert.TransactionID(req.GetId())
 	if err != nil {
@@ -301,7 +317,10 @@ func (h *Handler) GetTransactionResult(
 	ctx context.Context,
 	req *access.GetTransactionRequest,
 ) (*access.TransactionResultResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	transactionID, err := convert.TransactionID(req.GetId())
 	if err != nil {
@@ -342,7 +361,10 @@ func (h *Handler) GetTransactionResultsByBlockID(
 	ctx context.Context,
 	req *access.GetTransactionsByBlockIDRequest,
 ) (*access.TransactionResultsResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
@@ -366,7 +388,10 @@ func (h *Handler) GetSystemTransaction(
 	ctx context.Context,
 	req *access.GetSystemTransactionRequest,
 ) (*access.TransactionResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
@@ -388,7 +413,10 @@ func (h *Handler) GetSystemTransactionResult(
 	ctx context.Context,
 	req *access.GetSystemTransactionResultRequest,
 ) (*access.TransactionResultResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
@@ -410,7 +438,10 @@ func (h *Handler) GetTransactionsByBlockID(
 	ctx context.Context,
 	req *access.GetTransactionsByBlockIDRequest,
 ) (*access.TransactionsResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	id, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
@@ -434,7 +465,10 @@ func (h *Handler) GetTransactionResultByIndex(
 	ctx context.Context,
 	req *access.GetTransactionByIndexRequest,
 ) (*access.TransactionResultResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	blockID, err := convert.BlockID(req.GetBlockId())
 	if err != nil {
@@ -459,7 +493,10 @@ func (h *Handler) GetAccount(
 	ctx context.Context,
 	req *access.GetAccountRequest,
 ) (*access.GetAccountResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	address, err := convert.Address(req.GetAddress(), h.chain)
 	if err != nil {
@@ -487,7 +524,10 @@ func (h *Handler) GetAccountAtLatestBlock(
 	ctx context.Context,
 	req *access.GetAccountAtLatestBlockRequest,
 ) (*access.AccountResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	address, err := convert.Address(req.GetAddress(), h.chain)
 	if err != nil {
@@ -514,7 +554,10 @@ func (h *Handler) GetAccountAtBlockHeight(
 	ctx context.Context,
 	req *access.GetAccountAtBlockHeightRequest,
 ) (*access.AccountResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	address, err := convert.Address(req.GetAddress(), h.chain)
 	if err != nil {
@@ -542,7 +585,10 @@ func (h *Handler) ExecuteScriptAtLatestBlock(
 	ctx context.Context,
 	req *access.ExecuteScriptAtLatestBlockRequest,
 ) (*access.ExecuteScriptResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	script := req.GetScript()
 	arguments := req.GetArguments()
@@ -563,7 +609,10 @@ func (h *Handler) ExecuteScriptAtBlockHeight(
 	ctx context.Context,
 	req *access.ExecuteScriptAtBlockHeightRequest,
 ) (*access.ExecuteScriptResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	script := req.GetScript()
 	arguments := req.GetArguments()
@@ -585,8 +634,10 @@ func (h *Handler) ExecuteScriptAtBlockID(
 	ctx context.Context,
 	req *access.ExecuteScriptAtBlockIDRequest,
 ) (*access.ExecuteScriptResponse, error) {
-	metadata := h.buildMetadataResponse()
-
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 	script := req.GetScript()
 	arguments := req.GetArguments()
 	blockID := convert.MessageToIdentifier(req.GetBlockId())
@@ -607,7 +658,10 @@ func (h *Handler) GetEventsForHeightRange(
 	ctx context.Context,
 	req *access.GetEventsForHeightRangeRequest,
 ) (*access.EventsResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	eventType, err := convert.EventType(req.GetType())
 	if err != nil {
@@ -639,7 +693,10 @@ func (h *Handler) GetEventsForBlockIDs(
 	ctx context.Context,
 	req *access.GetEventsForBlockIDsRequest,
 ) (*access.EventsResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	eventType, err := convert.EventType(req.GetType())
 	if err != nil {
@@ -671,7 +728,10 @@ func (h *Handler) GetEventsForBlockIDs(
 
 // GetLatestProtocolStateSnapshot returns the latest serializable Snapshot
 func (h *Handler) GetLatestProtocolStateSnapshot(ctx context.Context, req *access.GetLatestProtocolStateSnapshotRequest) (*access.ProtocolStateSnapshotResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	snapshot, err := h.api.GetLatestProtocolStateSnapshot(ctx)
 	if err != nil {
@@ -686,7 +746,10 @@ func (h *Handler) GetLatestProtocolStateSnapshot(ctx context.Context, req *acces
 
 // GetProtocolStateSnapshotByBlockID returns serializable Snapshot by blockID
 func (h *Handler) GetProtocolStateSnapshotByBlockID(ctx context.Context, req *access.GetProtocolStateSnapshotByBlockIDRequest) (*access.ProtocolStateSnapshotResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	blockID := convert.MessageToIdentifier(req.GetBlockId())
 
@@ -703,7 +766,10 @@ func (h *Handler) GetProtocolStateSnapshotByBlockID(ctx context.Context, req *ac
 
 // GetProtocolStateSnapshotByHeight returns serializable Snapshot by block height
 func (h *Handler) GetProtocolStateSnapshotByHeight(ctx context.Context, req *access.GetProtocolStateSnapshotByHeightRequest) (*access.ProtocolStateSnapshotResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	snapshot, err := h.api.GetProtocolStateSnapshotByHeight(ctx, req.GetBlockHeight())
 	if err != nil {
@@ -720,7 +786,10 @@ func (h *Handler) GetProtocolStateSnapshotByHeight(ctx context.Context, req *acc
 // AN might receive multiple receipts with conflicting results for unsealed blocks.
 // If this case happens, since AN is not able to determine which result is the correct one until the block is sealed, it has to pick one result to respond to this query. For now, we return the result from the latest received receipt.
 func (h *Handler) GetExecutionResultForBlockID(ctx context.Context, req *access.GetExecutionResultForBlockIDRequest) (*access.ExecutionResultForBlockIDResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	blockID := convert.MessageToIdentifier(req.GetBlockId())
 
@@ -734,7 +803,10 @@ func (h *Handler) GetExecutionResultForBlockID(ctx context.Context, req *access.
 
 // GetExecutionResultByID returns the execution result for the given ID.
 func (h *Handler) GetExecutionResultByID(ctx context.Context, req *access.GetExecutionResultByIDRequest) (*access.ExecutionResultByIDResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	resultID := convert.MessageToIdentifier(req.GetId())
 
@@ -1161,7 +1233,10 @@ func (h *Handler) SendAndSubscribeTransactionStatuses(
 }
 
 func (h *Handler) blockResponse(block *flow.Block, fullResponse bool, status flow.BlockStatus) (*access.BlockResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	signerIDs, err := h.signerIndicesDecoder.DecodeSignerIDs(block.Header)
 	if err != nil {
@@ -1186,7 +1261,10 @@ func (h *Handler) blockResponse(block *flow.Block, fullResponse bool, status flo
 }
 
 func (h *Handler) blockHeaderResponse(header *flow.Header, status flow.BlockStatus) (*access.BlockHeaderResponse, error) {
-	metadata := h.buildMetadataResponse()
+	metadata, err := h.buildMetadataResponse()
+	if err != nil {
+		return nil, err
+	}
 
 	signerIDs, err := h.signerIndicesDecoder.DecodeSignerIDs(header)
 	if err != nil {
@@ -1206,16 +1284,33 @@ func (h *Handler) blockHeaderResponse(header *flow.Header, status flow.BlockStat
 }
 
 // buildMetadataResponse builds and returns the metadata response object.
-func (h *Handler) buildMetadataResponse() *entities.Metadata {
+// Expected errors during normal operation:
+//   - codes.NotFound if result cannot be provided by storage due to the absence of data.
+//   - storage.ErrHeightNotIndexed when data is unavailable
+func (h *Handler) buildMetadataResponse() (*entities.Metadata, error) {
 	lastFinalizedHeader := h.finalizedHeaderCache.Get()
 	blockId := lastFinalizedHeader.ID()
 	nodeId := h.me.NodeID()
 
-	return &entities.Metadata{
+	metadata := &entities.Metadata{
 		LatestFinalizedBlockId: blockId[:],
 		LatestFinalizedHeight:  lastFinalizedHeader.Height,
 		NodeId:                 nodeId[:],
 	}
+
+	if h.indexReporter != nil {
+		highestIndexedHeight, err := h.indexReporter.HighestIndexedHeight()
+		if err != nil {
+			if !errors.Is(err, indexer.ErrIndexNotInitialized) {
+				return nil, rpc.ConvertIndexError(err, lastFinalizedHeader.Height, "could not get highest indexed height")
+			}
+			highestIndexedHeight = 0
+		}
+
+		metadata.HighestIndexedHeight = highestIndexedHeight
+	}
+
+	return metadata, nil
 }
 
 func executionResultToMessages(er *flow.ExecutionResult, metadata *entities.Metadata) (*access.ExecutionResultForBlockIDResponse, error) {
@@ -1234,6 +1329,13 @@ func executionResultToMessages(er *flow.ExecutionResult, metadata *entities.Meta
 func WithBlockSignerDecoder(signerIndicesDecoder hotstuff.BlockSignerDecoder) func(*Handler) {
 	return func(handler *Handler) {
 		handler.signerIndicesDecoder = signerIndicesDecoder
+	}
+}
+
+// WithIndexReporter configures the Handler to work with index reporter
+func WithIndexReporter(indexReporter state_synchronization.IndexReporter) func(*Handler) {
+	return func(handler *Handler) {
+		handler.indexReporter = indexReporter
 	}
 }
 

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -293,6 +293,7 @@ type FlowAccessNodeBuilder struct {
 	ExecutionIndexerCore       *indexer.IndexerCore
 	ScriptExecutor             *backend.ScriptExecutor
 	RegistersAsyncStore        *execution.RegistersAsyncStore
+	Reporter                   *index.Reporter
 	EventsIndex                *index.EventsIndex
 	TxResultsIndex             *index.TransactionResultsIndex
 	IndexerDependencies        *cmd.DependencyList
@@ -872,12 +873,7 @@ func (builder *FlowAccessNodeBuilder) BuildExecutionSyncComponents() *FlowAccess
 					return nil, err
 				}
 
-				err = builder.EventsIndex.Initialize(builder.ExecutionIndexer)
-				if err != nil {
-					return nil, err
-				}
-
-				err = builder.TxResultsIndex.Initialize(builder.ExecutionIndexer)
+				err = builder.Reporter.Initialize(builder.ExecutionIndexer)
 				if err != nil {
 					return nil, err
 				}
@@ -1620,12 +1616,16 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			builder.Storage.Events = bstorage.NewEvents(node.Metrics.Cache, node.DB)
 			return nil
 		}).
+		Module("reporter", func(node *cmd.NodeConfig) error {
+			builder.Reporter = index.NewReporter()
+			return nil
+		}).
 		Module("events index", func(node *cmd.NodeConfig) error {
-			builder.EventsIndex = index.NewEventsIndex(builder.Storage.Events)
+			builder.EventsIndex = index.NewEventsIndex(builder.Reporter, builder.Storage.Events)
 			return nil
 		}).
 		Module("transaction result index", func(node *cmd.NodeConfig) error {
-			builder.TxResultsIndex = index.NewTransactionResultsIndex(builder.Storage.LightTransactionResults)
+			builder.TxResultsIndex = index.NewTransactionResultsIndex(builder.Reporter, builder.Storage.LightTransactionResults)
 			return nil
 		}).
 		Module("processed block height consumer progress", func(node *cmd.NodeConfig) error {
@@ -1753,6 +1753,12 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				return nil, fmt.Errorf("could not initialize backend: %w", err)
 			}
 
+			// If execution data syncing and indexing is disabled, pass nil indexReporter
+			var indexReporter state_synchronization.IndexReporter
+			if builder.executionDataSyncEnabled && builder.executionDataIndexingEnabled {
+				indexReporter = builder.Reporter
+			}
+
 			engineBuilder, err := rpc.NewBuilder(
 				node.Logger,
 				node.State,
@@ -1767,6 +1773,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				builder.unsecureGrpcServer,
 				builder.stateStreamBackend,
 				builder.stateStreamConf,
+				indexReporter,
 			)
 			if err != nil {
 				return nil, err

--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -126,7 +126,7 @@ func main() {
 			"maximum per-transaction byte size")
 		flags.Uint64Var(&ingestConf.MaxCollectionByteSize, "ingest-max-col-byte-size", flow.DefaultMaxCollectionByteSize,
 			"maximum per-collection byte size")
-		flags.BoolVar(&ingestConf.CheckScriptsParse, "ingest-check-scripts-parse", true,
+		flags.BoolVar(&ingestConf.CheckScriptsParse, "ingest-check-scripts-parse", false,
 			"whether we check that inbound transactions are parse-able")
 		flags.UintVar(&ingestConf.ExpiryBuffer, "ingest-expiry-buffer", 30,
 			"expiry buffer for inbound transactions")

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -266,6 +266,7 @@ type ObserverServiceBuilder struct {
 	ExecutionDataStore      execution_data.ExecutionDataStore
 
 	RegistersAsyncStore *execution.RegistersAsyncStore
+	Reporter            *index.Reporter
 	EventsIndex         *index.EventsIndex
 	ScriptExecutor      *backend.ScriptExecutor
 
@@ -1363,7 +1364,7 @@ func (builder *ObserverServiceBuilder) BuildExecutionSyncComponents() *ObserverS
 			// setup requester to notify indexer when new execution data is received
 			execDataDistributor.AddOnExecutionDataReceivedConsumer(builder.ExecutionIndexer.OnExecutionData)
 
-			err = builder.EventsIndex.Initialize(builder.ExecutionIndexer)
+			err = builder.Reporter.Initialize(builder.ExecutionIndexer)
 			if err != nil {
 				return nil, err
 			}
@@ -1383,11 +1384,6 @@ func (builder *ObserverServiceBuilder) BuildExecutionSyncComponents() *ObserverS
 			)
 
 			err = builder.ScriptExecutor.Initialize(builder.ExecutionIndexer, scripts)
-			if err != nil {
-				return nil, err
-			}
-
-			err = builder.TxResultsIndex.Initialize(builder.ExecutionIndexer)
 			if err != nil {
 				return nil, err
 			}
@@ -1682,12 +1678,16 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 		builder.Storage.Events = bstorage.NewEvents(node.Metrics.Cache, node.DB)
 		return nil
 	})
+	builder.Module("reporter", func(node *cmd.NodeConfig) error {
+		builder.Reporter = index.NewReporter()
+		return nil
+	})
 	builder.Module("events index", func(node *cmd.NodeConfig) error {
-		builder.EventsIndex = index.NewEventsIndex(builder.Storage.Events)
+		builder.EventsIndex = index.NewEventsIndex(builder.Reporter, builder.Storage.Events)
 		return nil
 	})
 	builder.Module("transaction result index", func(node *cmd.NodeConfig) error {
-		builder.TxResultsIndex = index.NewTransactionResultsIndex(builder.Storage.LightTransactionResults)
+		builder.TxResultsIndex = index.NewTransactionResultsIndex(builder.Reporter, builder.Storage.LightTransactionResults)
 		return nil
 	})
 	builder.Module("script executor", func(node *cmd.NodeConfig) error {
@@ -1792,6 +1792,12 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 			return nil, err
 		}
 
+		// If execution data syncing and indexing is disabled, pass nil indexReporter
+		var indexReporter state_synchronization.IndexReporter
+		if builder.executionDataSyncEnabled && builder.executionDataIndexingEnabled {
+			indexReporter = builder.Reporter
+		}
+
 		engineBuilder, err := rpc.NewBuilder(
 			node.Logger,
 			node.State,
@@ -1806,6 +1812,7 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 			builder.unsecureGrpcServer,
 			builder.stateStreamBackend,
 			builder.stateStreamConf,
+			indexReporter,
 		)
 		if err != nil {
 			return nil, err

--- a/cmd/util/cmd/bootstrap-execution-state-payloads/cmd.go
+++ b/cmd/util/cmd/bootstrap-execution-state-payloads/cmd.go
@@ -62,7 +62,7 @@ func run(*cobra.Command, []string) {
 		storageSnapshot,
 	)
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("failed to run bootstrap procedure")
 	}
 
 	payloads := make([]*ledger.Payload, 0, len(executionSnapshot.WriteSet))
@@ -83,7 +83,7 @@ func run(*cobra.Command, []string) {
 		false,
 	)
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("failed to create payloads")
 	}
 
 	log.Info().Msgf("wrote %d payloads", numOfPayloadWritten)

--- a/cmd/util/cmd/diff-states/cmd.go
+++ b/cmd/util/cmd/diff-states/cmd.go
@@ -1,0 +1,531 @@
+package diff_states
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/atomic"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
+	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
+	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/pathfinder"
+	"github.com/onflow/flow-go/ledger/complete"
+	"github.com/onflow/flow-go/ledger/complete/wal"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/metrics"
+)
+
+var (
+	flagOutputDirectory  string
+	flagPayloads1        string
+	flagPayloads2        string
+	flagState1           string
+	flagState2           string
+	flagStateCommitment1 string
+	flagStateCommitment2 string
+	flagRaw              bool
+	flagNWorker          int
+	flagChain            string
+)
+
+var Cmd = &cobra.Command{
+	Use:   "diff-states",
+	Short: "Compares the given states",
+	Run:   run,
+}
+
+const ReporterName = "state-diff"
+
+func init() {
+
+	// Input 1
+
+	Cmd.Flags().StringVar(
+		&flagPayloads1,
+		"payloads-1",
+		"",
+		"Input payload file name 1",
+	)
+
+	Cmd.Flags().StringVar(
+		&flagState1,
+		"state-1",
+		"",
+		"Input state file name 1",
+	)
+	Cmd.Flags().StringVar(
+		&flagStateCommitment1,
+		"state-commitment-1",
+		"",
+		"Input state commitment 1",
+	)
+
+	// Input 2
+
+	Cmd.Flags().StringVar(
+		&flagPayloads2,
+		"payloads-2",
+		"",
+		"Input payload file name 2",
+	)
+
+	Cmd.Flags().StringVar(
+		&flagState2,
+		"state-2",
+		"",
+		"Input state file name 2",
+	)
+
+	Cmd.Flags().StringVar(
+		&flagStateCommitment2,
+		"state-commitment-2",
+		"",
+		"Input state commitment 2",
+	)
+
+	// Other
+
+	Cmd.Flags().StringVar(
+		&flagOutputDirectory,
+		"output-directory",
+		"",
+		"Output directory",
+	)
+	_ = Cmd.MarkFlagRequired("output-directory")
+
+	Cmd.Flags().BoolVar(
+		&flagRaw,
+		"raw",
+		true,
+		"Raw or value",
+	)
+
+	Cmd.Flags().IntVar(
+		&flagNWorker,
+		"n-worker",
+		10,
+		"number of workers to use",
+	)
+
+	Cmd.Flags().StringVar(
+		&flagChain,
+		"chain",
+		"",
+		"Chain name",
+	)
+	_ = Cmd.MarkFlagRequired("chain")
+}
+
+func run(*cobra.Command, []string) {
+
+	chainID := flow.ChainID(flagChain)
+	// Validate chain ID
+	_ = chainID.Chain()
+
+	if flagPayloads1 == "" && flagState1 == "" {
+		log.Fatal().Msg("Either --payloads-1 or --state-1 must be provided")
+	} else if flagPayloads1 != "" && flagState1 != "" {
+		log.Fatal().Msg("Only one of --payloads-1 or --state-1 must be provided")
+	}
+	if flagState1 != "" && flagStateCommitment1 == "" {
+		log.Fatal().Msg("--state-commitment-1 must be provided when --state-1 is provided")
+	}
+
+	if flagPayloads2 == "" && flagState2 == "" {
+		log.Fatal().Msg("Either --payloads-2 or --state-2 must be provided")
+	} else if flagPayloads2 != "" && flagState2 != "" {
+		log.Fatal().Msg("Only one of --payloads-2 or --state-2 must be provided")
+	}
+	if flagState2 != "" && flagStateCommitment2 == "" {
+		log.Fatal().Msg("--state-commitment-2 must be provided when --state-2 is provided")
+	}
+
+	rw := reporters.NewReportFileWriterFactory(flagOutputDirectory, log.Logger).
+		ReportWriter(ReporterName)
+	defer rw.Close()
+
+	var registers1, registers2 *registers.ByAccount
+	{
+		// Load payloads and create registers.
+		// Define in a block, so that the memory is released after the registers are created.
+		payloads1, payloads2 := loadPayloads()
+
+		payloadCount1 := len(payloads1)
+		payloadCount2 := len(payloads2)
+		if payloadCount1 != payloadCount2 {
+			log.Warn().Msgf(
+				"Payloads files have different number of payloads: %d vs %d",
+				payloadCount1,
+				payloadCount2,
+			)
+		}
+
+		registers1, registers2 = payloadsToRegisters(payloads1, payloads2)
+
+		accountCount1 := registers1.AccountCount()
+		accountCount2 := registers2.AccountCount()
+		if accountCount1 != accountCount2 {
+			log.Warn().Msgf(
+				"Registers have different number of accounts: %d vs %d",
+				accountCount1,
+				accountCount2,
+			)
+		}
+	}
+
+	diff(registers1, registers2, chainID, rw)
+}
+
+func loadPayloads() (payloads1, payloads2 []*ledger.Payload) {
+
+	log.Info().Msg("Loading payloads")
+
+	var group errgroup.Group
+
+	group.Go(func() (err error) {
+		if flagPayloads1 != "" {
+			_, payloads1, err = util.ReadPayloadFile(log.Logger, flagPayloads1)
+		} else {
+			log.Info().Msg("Reading first trie")
+
+			stateCommitment := parseStateCommitment(flagStateCommitment1)
+			payloads1, err = readTrie(flagState1, stateCommitment)
+		}
+		return
+	})
+
+	group.Go(func() (err error) {
+		if flagPayloads2 != "" {
+			_, payloads2, err = util.ReadPayloadFile(log.Logger, flagPayloads2)
+		} else {
+			log.Info().Msg("Reading second trie")
+
+			stateCommitment := parseStateCommitment(flagStateCommitment2)
+			payloads2, err = readTrie(flagState2, stateCommitment)
+		}
+		return
+	})
+
+	err := group.Wait()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to read payloads")
+	}
+
+	log.Info().Msg("Finished loading payloads")
+
+	return
+}
+
+func payloadsToRegisters(payloads1, payloads2 []*ledger.Payload) (registers1, registers2 *registers.ByAccount) {
+
+	log.Info().Msg("Creating registers from payloads")
+
+	var group errgroup.Group
+
+	group.Go(func() (err error) {
+		log.Info().Msgf("Creating registers from first payloads (%d)", len(payloads1))
+
+		registers1, err = registers.NewByAccountFromPayloads(payloads1)
+
+		log.Info().Msgf(
+			"Created %d registers from payloads (%d accounts)",
+			registers1.Count(),
+			registers1.AccountCount(),
+		)
+
+		return
+	})
+
+	group.Go(func() (err error) {
+		log.Info().Msgf("Creating registers from second payloads (%d)", len(payloads2))
+
+		registers2, err = registers.NewByAccountFromPayloads(payloads2)
+
+		log.Info().Msgf(
+			"Created %d registers from payloads (%d accounts)",
+			registers2.Count(),
+			registers2.AccountCount(),
+		)
+
+		return
+	})
+
+	err := group.Wait()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to create registers from payloads")
+	}
+
+	log.Info().Msg("Finished creating registers from payloads")
+
+	return
+}
+
+var accountsDiffer = errors.New("accounts differ")
+
+func diff(
+	registers1 *registers.ByAccount,
+	registers2 *registers.ByAccount,
+	chainID flow.ChainID,
+	rw reporters.ReportWriter,
+) {
+	log.Info().Msg("Diffing accounts")
+
+	err := registers1.ForEachAccount(func(accountRegisters1 *registers.AccountRegisters) (err error) {
+		owner := accountRegisters1.Owner()
+
+		if !registers2.HasAccountOwner(owner) {
+			rw.Write(accountMissing{
+				Owner: owner,
+				State: 2,
+			})
+
+			return nil
+		}
+
+		accountRegisters2 := registers2.AccountRegisters(owner)
+
+		if accountRegisters1.Count() != accountRegisters2.Count() {
+			rw.Write(countDiff{
+				Owner:  owner,
+				State1: accountRegisters1.Count(),
+				State2: accountRegisters2.Count(),
+			})
+		}
+
+		err = accountRegisters1.ForEach(func(owner, key string, value1 []byte) error {
+			var value2 []byte
+			value2, err = accountRegisters2.Get(owner, key)
+			if err != nil {
+				return err
+			}
+
+			if !bytes.Equal(value1, value2) {
+
+				if flagRaw {
+					rw.Write(rawDiff{
+						Owner:  owner,
+						Key:    key,
+						Value1: value1,
+						Value2: value2,
+					})
+				} else {
+					// stop on first difference in accounts
+					return accountsDiffer
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			if flagRaw || !errors.Is(err, accountsDiffer) {
+				return err
+			}
+
+			address, err := common.BytesToAddress([]byte(owner))
+			if err != nil {
+				return err
+			}
+
+			migrations.NewCadenceValueDiffReporter(
+				address,
+				chainID,
+				rw,
+				true,
+				flagNWorker,
+			).DiffStates(
+				accountRegisters1,
+				accountRegisters2,
+				migrations.AllStorageMapDomains,
+			)
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to diff")
+	}
+
+	err = registers2.ForEachAccount(func(accountRegisters2 *registers.AccountRegisters) (err error) {
+		owner := accountRegisters2.Owner()
+
+		if !registers1.HasAccountOwner(owner) {
+			rw.Write(accountMissing{
+				Owner: owner,
+				State: 1,
+			})
+			return nil
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to diff")
+	}
+
+	log.Info().Msg("Finished diffing accounts")
+
+}
+
+func readTrie(dir string, targetHash flow.StateCommitment) ([]*ledger.Payload, error) {
+	log.Info().Msg("init WAL")
+
+	diskWal, err := wal.NewDiskWAL(
+		log.Logger,
+		nil,
+		metrics.NewNoopCollector(),
+		dir,
+		complete.DefaultCacheSize,
+		pathfinder.PathByteSize,
+		wal.SegmentSize,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create disk WAL: %w", err)
+	}
+
+	log.Info().Msg("init ledger")
+
+	led, err := complete.NewLedger(
+		diskWal,
+		complete.DefaultCacheSize,
+		&metrics.NoopCollector{},
+		log.Logger,
+		complete.DefaultPathFinderVersion)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create ledger from write-a-head logs and checkpoints: %w", err)
+	}
+
+	const (
+		checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
+		checkpointsToKeep  = 1
+	)
+
+	log.Info().Msg("init compactor")
+
+	compactor, err := complete.NewCompactor(
+		led,
+		diskWal,
+		log.Logger,
+		complete.DefaultCacheSize,
+		checkpointDistance,
+		checkpointsToKeep,
+		atomic.NewBool(false),
+		&metrics.NoopCollector{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create compactor: %w", err)
+	}
+
+	log.Info().Msgf("waiting for compactor to load checkpoint and WAL")
+
+	<-compactor.Ready()
+
+	defer func() {
+		<-led.Done()
+		<-compactor.Done()
+	}()
+
+	state := ledger.State(targetHash)
+
+	trie, err := led.Trie(ledger.RootHash(state))
+	if err != nil {
+		s, _ := led.MostRecentTouchedState()
+		log.Info().
+			Str("hash", s.String()).
+			Msgf("Most recently touched state")
+		return nil, fmt.Errorf("cannot get trie at the given state commitment: %w", err)
+	}
+
+	return trie.AllPayloads(), nil
+}
+
+func parseStateCommitment(stateCommitmentHex string) flow.StateCommitment {
+	var err error
+	stateCommitmentBytes, err := hex.DecodeString(stateCommitmentHex)
+	if err != nil {
+		log.Fatal().Err(err).Msg("cannot get decode the state commitment")
+	}
+
+	stateCommitment, err := flow.ToStateCommitment(stateCommitmentBytes)
+	if err != nil {
+		log.Fatal().Err(err).Msg("invalid state commitment length")
+	}
+
+	return stateCommitment
+}
+
+type rawDiff struct {
+	Owner  string
+	Key    string
+	Value1 []byte
+	Value2 []byte
+}
+
+var _ json.Marshaler = rawDiff{}
+
+func (e rawDiff) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind   string `json:"kind"`
+		Owner  string `json:"owner"`
+		Key    string `json:"key"`
+		Value1 string `json:"value1"`
+		Value2 string `json:"value2"`
+	}{
+		Kind:   "raw-diff",
+		Owner:  hex.EncodeToString([]byte(e.Owner)),
+		Key:    hex.EncodeToString([]byte(e.Key)),
+		Value1: hex.EncodeToString(e.Value1),
+		Value2: hex.EncodeToString(e.Value2),
+	})
+}
+
+type accountMissing struct {
+	Owner string
+	State int
+}
+
+var _ json.Marshaler = accountMissing{}
+
+func (e accountMissing) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind  string `json:"kind"`
+		Owner string `json:"owner"`
+		State int    `json:"state"`
+	}{
+		Kind:  "account-missing",
+		Owner: hex.EncodeToString([]byte(e.Owner)),
+		State: e.State,
+	})
+}
+
+type countDiff struct {
+	Owner  string
+	State1 int
+	State2 int
+}
+
+var _ json.Marshaler = countDiff{}
+
+func (e countDiff) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Kind   string `json:"kind"`
+		Owner  string `json:"owner"`
+		State1 int    `json:"state1"`
+		State2 int    `json:"state2"`
+	}{
+		Kind:   "count-diff",
+		Owner:  hex.EncodeToString([]byte(e.Owner)),
+		State1: e.State1,
+		State2: e.State2,
+	})
+}

--- a/cmd/util/cmd/diff-states/diff_states_test.go
+++ b/cmd/util/cmd/diff-states/diff_states_test.go
@@ -1,0 +1,99 @@
+package diff_states
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/convert"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/utils/io"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func newPayload(owner flow.Address, key string, value []byte) *ledger.Payload {
+	registerID := flow.NewRegisterID(owner, key)
+	ledgerKey := convert.RegisterIDToLedgerKey(registerID)
+	return ledger.NewPayload(ledgerKey, value)
+}
+
+func TestDiffStates(t *testing.T) {
+
+	unittest.RunWithTempDir(t, func(datadir string) {
+
+		file1 := filepath.Join(datadir, "first.payloads")
+		file2 := filepath.Join(datadir, "second.payloads")
+
+		payloads1 := []*ledger.Payload{
+			newPayload(flow.Address{1}, "a", []byte{2}),
+			newPayload(flow.Address{1}, "b", []byte{3}),
+			newPayload(flow.Address{2}, "c", []byte{4}),
+		}
+		payloads2 := []*ledger.Payload{
+			newPayload(flow.Address{1}, "a", []byte{2}),
+			newPayload(flow.Address{1}, "b", []byte{5}),
+			newPayload(flow.Address{3}, "d", []byte{6}),
+			newPayload(flow.Address{4}, "e", []byte{7}),
+		}
+
+		numOfPayloadWritten, err := util.CreatePayloadFile(zerolog.Nop(), file1, payloads1, nil, false)
+		require.NoError(t, err)
+		require.Equal(t, len(payloads1), numOfPayloadWritten)
+
+		numOfPayloadWritten, err = util.CreatePayloadFile(zerolog.Nop(), file2, payloads2, nil, false)
+		require.NoError(t, err)
+		require.Equal(t, len(payloads2), numOfPayloadWritten)
+
+		Cmd.SetArgs([]string{
+			"--payloads-1", file1,
+			"--payloads-2", file2,
+			"--chain", string(flow.Emulator),
+			"--output-directory", datadir,
+			"--raw",
+		})
+
+		err = Cmd.Execute()
+		require.NoError(t, err)
+
+		var reportPath string
+		err = filepath.Walk(
+			datadir,
+			func(path string, info fs.FileInfo, err error) error {
+				if path != datadir && info.IsDir() {
+					return filepath.SkipDir
+				}
+				if strings.HasPrefix(filepath.Base(path), ReporterName) {
+					reportPath = path
+					return filepath.SkipAll
+				}
+				return err
+			},
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, reportPath)
+
+		report, err := io.ReadFile(reportPath)
+		require.NoError(t, err)
+
+		assert.JSONEq(
+			t,
+			`
+              [
+                {"kind":"raw-diff", "owner":"0100000000000000", "key":"62", "value1":"03", "value2":"05"},
+                {"kind":"account-missing", "owner":"0200000000000000", "state":2},
+                {"kind":"account-missing", "owner":"0300000000000000", "state":1},
+                {"kind":"account-missing", "owner":"0400000000000000", "state":1}
+              ]
+            `,
+			string(report),
+		)
+
+	})
+}

--- a/cmd/util/cmd/extract-payloads-by-address/cmd.go
+++ b/cmd/util/cmd/extract-payloads-by-address/cmd.go
@@ -18,7 +18,7 @@ var (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "extract-payload-by-address",
+	Use:   "extract-payloads-by-address",
 	Short: "Read payload file and generate payload file containing payloads with specified addresses",
 	Run:   run,
 }
@@ -59,7 +59,7 @@ func run(*cobra.Command, []string) {
 
 	owners, err := common.ParseOwners(strings.Split(flagAddresses, ","))
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("failed to parse addresses")
 	}
 
 	log.Info().Msgf(
@@ -71,7 +71,7 @@ func run(*cobra.Command, []string) {
 
 	inputPayloadsFromPartialState, payloads, err := util.ReadPayloadFile(log.Logger, flagInputPayloadFileName)
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("failed to read payloads")
 	}
 
 	numOfPayloadWritten, err := util.CreatePayloadFile(
@@ -82,7 +82,7 @@ func run(*cobra.Command, []string) {
 		inputPayloadsFromPartialState,
 	)
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("failed to create payloads file")
 	}
 
 	log.Info().Msgf(

--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	checkpoint_collect_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-collect-stats"
 	checkpoint_list_tries "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-list-tries"
 	checkpoint_trie_stats "github.com/onflow/flow-go/cmd/util/cmd/checkpoint-trie-stats"
+	diff_states "github.com/onflow/flow-go/cmd/util/cmd/diff-states"
 	epochs "github.com/onflow/flow-go/cmd/util/cmd/epochs/cmd"
 	export "github.com/onflow/flow-go/cmd/util/cmd/exec-data-json-export"
 	edbs "github.com/onflow/flow-go/cmd/util/cmd/execution-data-blobstore/cmd"
@@ -106,6 +107,7 @@ func addCommands() {
 	rootCmd.AddCommand(bootstrap_execution_state_payloads.Cmd)
 	rootCmd.AddCommand(extractpayloads.Cmd)
 	rootCmd.AddCommand(find_inconsistent_result.Cmd)
+	rootCmd.AddCommand(diff_states.Cmd)
 }
 
 func initConfig() {

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -307,6 +307,7 @@ func NewCadence1ValueMigrations(
 				opts.NWorker,
 				[]AccountBasedMigration{
 					NewMetricsCollectingMigration(
+						log,
 						opts.ChainID,
 						rwf,
 						programs,

--- a/cmd/util/ledger/migrations/cadence_value_diff_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff_test.go
@@ -34,8 +34,8 @@ func TestDiffCadenceValues(t *testing.T) {
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
-			createTestPayloads(t, address, domain),
-			createTestPayloads(t, address, domain),
+			createTestRegisters(t, address, domain),
+			createTestRegisters(t, address, domain),
 			[]string{domain},
 		)
 		require.NoError(t, err)
@@ -50,8 +50,8 @@ func TestDiffCadenceValues(t *testing.T) {
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
-			createTestPayloads(t, address, domain),
-			nil,
+			createTestRegisters(t, address, domain),
+			registers.NewByAccount(),
 			[]string{domain},
 		)
 		require.NoError(t, err)
@@ -71,8 +71,8 @@ func TestDiffCadenceValues(t *testing.T) {
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
-			createTestPayloads(t, address, domain),
-			createStorageMapPayloads(t, address, domain, []string{"unique_key"}, []interpreter.Value{interpreter.UInt64Value(0)}),
+			createTestRegisters(t, address, domain),
+			createStorageMapRegisters(t, address, domain, []string{"unique_key"}, []interpreter.Value{interpreter.UInt64Value(0)}),
 			[]string{domain},
 		)
 		require.NoError(t, err)
@@ -98,8 +98,8 @@ func TestDiffCadenceValues(t *testing.T) {
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
 		diffReporter.DiffStates(
-			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
-			createStorageMapPayloads(t, address, domain, []string{"2", "0"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
+			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
+			createStorageMapRegisters(t, address, domain, []string{"2", "0"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
 			[]string{domain},
 		)
 		require.NoError(t, err)
@@ -125,8 +125,8 @@ func TestDiffCadenceValues(t *testing.T) {
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		diffReporter.DiffStates(
-			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
-			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(111), interpreter.UInt64Value(101)}),
+			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
+			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(111), interpreter.UInt64Value(101)}),
 			[]string{domain},
 		)
 		require.NoError(t, err)
@@ -152,8 +152,8 @@ func TestDiffCadenceValues(t *testing.T) {
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
 		diffReporter.DiffStates(
-			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
-			createStorageMapPayloads(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(111), interpreter.UInt64Value(102)}),
+			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
+			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(111), interpreter.UInt64Value(102)}),
 			[]string{domain},
 		)
 		require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
-		createPayloads := func(arrayValues []interpreter.Value) []*ledger.Payload {
+		createRegisters := func(arrayValues []interpreter.Value) registers.Registers {
 
 			// Create account status payload
 			accountStatus := environment.NewAccountStatus()
@@ -243,12 +243,23 @@ func TestDiffCadenceValues(t *testing.T) {
 				payloads = append(payloads, ledger.NewPayload(key, value))
 			}
 
-			return payloads
+			registers, err := registers.NewByAccountFromPayloads(payloads)
+			require.NoError(t, err)
+
+			return registers
 		}
 
 		diffReporter.DiffStates(
-			createPayloads([]interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(2), interpreter.UInt64Value(4)}),
-			createPayloads([]interpreter.Value{interpreter.UInt64Value(1), interpreter.UInt64Value(3), interpreter.UInt64Value(5)}),
+			createRegisters([]interpreter.Value{
+				interpreter.UInt64Value(0),
+				interpreter.UInt64Value(2),
+				interpreter.UInt64Value(4),
+			}),
+			createRegisters([]interpreter.Value{
+				interpreter.UInt64Value(1),
+				interpreter.UInt64Value(3),
+				interpreter.UInt64Value(5),
+			}),
 			[]string{domain},
 		)
 		require.NoError(t, err)
@@ -287,7 +298,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
-		createPayloads := func(dictValues []interpreter.Value) []*ledger.Payload {
+		createRegisters := func(dictValues []interpreter.Value) registers.Registers {
 
 			// Create account status payload
 			accountStatus := environment.NewAccountStatus()
@@ -354,17 +365,20 @@ func TestDiffCadenceValues(t *testing.T) {
 				payloads = append(payloads, ledger.NewPayload(key, value))
 			}
 
-			return payloads
+			registers, err := registers.NewByAccountFromPayloads(payloads)
+			require.NoError(t, err)
+
+			return registers
 		}
 
 		diffReporter.DiffStates(
-			createPayloads(
+			createRegisters(
 				[]interpreter.Value{interpreter.NewUnmeteredStringValue("dict_key_0"),
 					interpreter.UInt64Value(0),
 					interpreter.NewUnmeteredStringValue("dict_key_1"),
 					interpreter.UInt64Value(2),
 				}),
-			createPayloads(
+			createRegisters(
 				[]interpreter.Value{interpreter.NewUnmeteredStringValue("dict_key_0"),
 					interpreter.UInt64Value(1),
 					interpreter.NewUnmeteredStringValue("dict_key_1"),
@@ -404,7 +418,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, false, runtime.NumCPU())
 
-		createPayloads := func(compositeFields []string, compositeValues []interpreter.Value) []*ledger.Payload {
+		createRegisters := func(compositeFields []string, compositeValues []interpreter.Value) registers.Registers {
 
 			// Create account status payload
 			accountStatus := environment.NewAccountStatus()
@@ -476,11 +490,14 @@ func TestDiffCadenceValues(t *testing.T) {
 				payloads = append(payloads, ledger.NewPayload(key, value))
 			}
 
-			return payloads
+			registers, err := registers.NewByAccountFromPayloads(payloads)
+			require.NoError(t, err)
+
+			return registers
 		}
 
 		diffReporter.DiffStates(
-			createPayloads(
+			createRegisters(
 				[]string{
 					"Field_0",
 					"Field_1",
@@ -489,7 +506,7 @@ func TestDiffCadenceValues(t *testing.T) {
 					interpreter.UInt64Value(0),
 					interpreter.UInt64Value(2),
 				}),
-			createPayloads(
+			createRegisters(
 				[]string{
 					"Field_0",
 					"Field_1",
@@ -532,7 +549,7 @@ func TestDiffCadenceValues(t *testing.T) {
 
 		diffReporter := NewCadenceValueDiffReporter(address, flow.Emulator, writer, true, runtime.NumCPU())
 
-		createPayloads := func(compositeFields []string, compositeValues []interpreter.Value) []*ledger.Payload {
+		createRegisters := func(compositeFields []string, compositeValues []interpreter.Value) registers.Registers {
 
 			// Create account status payload
 			accountStatus := environment.NewAccountStatus()
@@ -604,11 +621,14 @@ func TestDiffCadenceValues(t *testing.T) {
 				payloads = append(payloads, ledger.NewPayload(key, value))
 			}
 
-			return payloads
+			registers, err := registers.NewByAccountFromPayloads(payloads)
+			require.NoError(t, err)
+
+			return registers
 		}
 
 		diffReporter.DiffStates(
-			createPayloads(
+			createRegisters(
 				[]string{
 					"Field_0",
 					"Field_1",
@@ -617,7 +637,7 @@ func TestDiffCadenceValues(t *testing.T) {
 					interpreter.UInt64Value(0),
 					interpreter.UInt64Value(2),
 				}),
-			createPayloads(
+			createRegisters(
 				[]string{
 					"Field_0",
 					"Field_1",
@@ -665,7 +685,13 @@ func TestDiffCadenceValues(t *testing.T) {
 	})
 }
 
-func createStorageMapPayloads(t *testing.T, address common.Address, domain string, keys []string, values []interpreter.Value) []*ledger.Payload {
+func createStorageMapRegisters(
+	t *testing.T,
+	address common.Address,
+	domain string,
+	keys []string,
+	values []interpreter.Value,
+) registers.Registers {
 
 	// Create account status payload
 	accountStatus := environment.NewAccountStatus()
@@ -715,10 +741,13 @@ func createStorageMapPayloads(t *testing.T, address common.Address, domain strin
 		payloads = append(payloads, ledger.NewPayload(key, value))
 	}
 
-	return payloads
+	registers, err := registers.NewByAccountFromPayloads(payloads)
+	require.NoError(t, err)
+
+	return registers
 }
 
-func createTestPayloads(t *testing.T, address common.Address, domain string) []*ledger.Payload {
+func createTestRegisters(t *testing.T, address common.Address, domain string) registers.Registers {
 
 	// Create account status payload
 	accountStatus := environment.NewAccountStatus()
@@ -864,5 +893,8 @@ func createTestPayloads(t *testing.T, address common.Address, domain string) []*
 		payloads = append(payloads, ledger.NewPayload(key, value))
 	}
 
-	return payloads
+	registers, err := registers.NewByAccountFromPayloads(payloads)
+	require.NoError(t, err)
+
+	return registers
 }

--- a/cmd/util/ledger/migrations/cadence_values_migration.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/cadence/migrations/entitlements"
 	"github.com/onflow/cadence/migrations/statictypes"
 	"github.com/onflow/cadence/migrations/string_normalization"
+	"github.com/onflow/cadence/migrations/type_keys"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 	cadenceErrors "github.com/onflow/cadence/runtime/errors"
@@ -209,10 +210,22 @@ func (m *CadenceBaseMigration) MigrateAccount(
 			m.nWorkers,
 		)
 
+		owner := flow.AddressToRegisterOwner(flow.Address(address))
+
+		oldRegistersForDiff, err := registers.NewAccountRegistersFromPayloads(owner, oldPayloadsForDiff)
+		if err != nil {
+			return fmt.Errorf("failed to create registers from old payloads: %w", err)
+		}
+
+		newRegistersForDiff, err := registers.NewAccountRegistersFromPayloads(owner, newPayloadsForDiff)
+		if err != nil {
+			return fmt.Errorf("failed to create registers from new payloads: %w", err)
+		}
+
 		accountDiffReporter.DiffStates(
-			oldPayloadsForDiff,
-			newPayloadsForDiff,
-			allStorageMapDomains,
+			oldRegistersForDiff,
+			newRegistersForDiff,
+			AllStorageMapDomains,
 		)
 	}
 
@@ -254,6 +267,11 @@ func NewCadence1ValueMigration(
 					WithCompositeTypeConverter(compositeTypeConverter).
 					WithInterfaceTypeConverter(interfaceTypeConverter),
 				entitlements.NewEntitlementsMigration(inter),
+				// After the static type and entitlements migration, we run the type key migration,
+				// which ensures that even if the previous migrations failed to migrate `Type` values
+				// used as dictionary keys, they will get re-stored and are accessible by users
+				// and the mutating iterator of the inlined version of atree
+				type_keys.NewTypeKeyMigration(),
 				string_normalization.NewStringNormalizingMigration(),
 			}
 		},

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -139,6 +139,7 @@ func (m *visitMigration) Migrate(
 	storageMapKey interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
+	_ migrations2.ValueMigrationPosition,
 ) (newValue interpreter.Value, err error) {
 
 	m.visits = append(
@@ -872,8 +873,18 @@ func checkReporters(
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_auth_reference_typed_key"),
+				Migration:     "TypeKeyMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
 				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_reference_typed_key"),
 				Migration:     "EntitlementsMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_reference_typed_key"),
+				Migration:     "TypeKeyMigration",
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
@@ -888,7 +899,7 @@ func checkReporters(
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
 				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
-				Migration:     "StaticTypeMigration",
+				Migration:     "TypeKeyMigration",
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
@@ -898,7 +909,7 @@ func checkReporters(
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
 				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
-				Migration:     "StaticTypeMigration",
+				Migration:     "TypeKeyMigration",
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
@@ -908,7 +919,7 @@ func checkReporters(
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
 				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
-				Migration:     "StaticTypeMigration",
+				Migration:     "TypeKeyMigration",
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
@@ -918,12 +929,57 @@ func checkReporters(
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
 				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
-				Migration:     "StaticTypeMigration",
+				Migration:     "TypeKeyMigration",
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
 				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
 				Migration:     "StaticTypeMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "TypeKeyMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "StaticTypeMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "TypeKeyMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "StaticTypeMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "TypeKeyMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "StaticTypeMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "TypeKeyMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "StaticTypeMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_account_type_keys"),
+				Migration:     "TypeKeyMigration",
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
@@ -943,7 +999,17 @@ func checkReporters(
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
 				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_restricted_typed_keys"),
+				Migration:     "TypeKeyMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_restricted_typed_keys"),
 				Migration:     "StaticTypeMigration",
+			},
+			cadenceValueMigrationEntry{
+				StorageKey:    interpreter.StorageKey{Key: "storage", Address: address},
+				StorageMapKey: interpreter.StringStorageMapKey("dictionary_with_restricted_typed_keys"),
+				Migration:     "TypeKeyMigration",
 			},
 			cadenceValueMigrationEntry{
 				StorageKey:    interpreter.StorageKey{Key: "public", Address: address},

--- a/cmd/util/ledger/migrations/migration_matrics_collector_test.go
+++ b/cmd/util/ledger/migrations/migration_matrics_collector_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence/runtime/common"
@@ -32,7 +33,7 @@ func TestMigrationMetricsCollection(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		logWriter := &writer{}
-		logger := zerolog.New(logWriter).Level(zerolog.InfoLevel)
+		logger := zerolog.New(logWriter).Level(zerolog.ErrorLevel)
 
 		const nWorker = 2
 
@@ -70,6 +71,12 @@ func TestMigrationMetricsCollection(t *testing.T) {
 		}
 
 		require.NoError(t, err)
+
+		// Should have 1 error:
+		// - The `Test` contract checking error
+		logs := logWriter.logs
+		require.Len(t, logs, 1)
+		assert.Contains(t, logs[0], "`pub` is no longer a valid access keyword")
 
 		reportWriter := rwf.reportWriters["metrics-collecting-migration"]
 		require.Len(t, reportWriter.entries, 1)
@@ -118,7 +125,7 @@ func TestMigrationMetricsCollection(t *testing.T) {
 		rwf := &testReportWriterFactory{}
 
 		logWriter := &writer{}
-		logger := zerolog.New(logWriter).Level(zerolog.InfoLevel)
+		logger := zerolog.New(logWriter).Level(zerolog.ErrorLevel)
 
 		const nWorker = 2
 
@@ -163,6 +170,14 @@ func TestMigrationMetricsCollection(t *testing.T) {
 		}
 
 		require.NoError(t, err)
+
+		// Should have 2 errors:
+		// - Contract update failure error
+		// - The `Test` contract checking error
+		logs := logWriter.logs
+		require.Len(t, logs, 2)
+		assert.Contains(t, logs[0], `"migration":"StagedContractsMigration","account":"0x01cf0e2f2f715450","contract":"Test"`)
+		assert.Contains(t, logs[1], "`pub` is no longer a valid access keyword")
 
 		reportWriter := rwf.reportWriters["metrics-collecting-migration"]
 		require.Len(t, reportWriter.entries, 1)

--- a/cmd/util/ledger/migrations/migration_matrics_collector_test.go
+++ b/cmd/util/ledger/migrations/migration_matrics_collector_test.go
@@ -87,8 +87,7 @@ func TestMigrationMetricsCollection(t *testing.T) {
 		require.Equal(
 			t,
 			Metrics{
-				// TODO: should be 752, like on master
-				TotalValues: 750,
+				TotalValues: 752,
 				TotalErrors: 6,
 				ErrorsPerContract: map[string]int{
 					"A.01cf0e2f2f715450.Test": 6,
@@ -188,8 +187,7 @@ func TestMigrationMetricsCollection(t *testing.T) {
 		require.Equal(
 			t,
 			Metrics{
-				// TODO: should be 752, like on master
-				TotalValues: 750,
+				TotalValues: 752,
 				TotalErrors: 6,
 				ErrorsPerContract: map[string]int{
 					"A.01cf0e2f2f715450.Test": 6,

--- a/cmd/util/ledger/migrations/migration_metrics_collector.go
+++ b/cmd/util/ledger/migrations/migration_metrics_collector.go
@@ -22,14 +22,15 @@ import (
 const metricsCollectingMigrationName = "metrics_collecting_migration"
 
 type MetricsCollectingMigration struct {
-	name             string
-	chainID          flow.ChainID
-	log              zerolog.Logger
-	mutex            sync.RWMutex
-	reporter         reporters.ReportWriter
-	metricsCollector *MigrationMetricsCollector
-	migratedTypes    map[common.TypeID]struct{}
-	programs         map[common.Location]*interpreter.Program
+	name              string
+	chainID           flow.ChainID
+	log               zerolog.Logger
+	mutex             sync.RWMutex
+	reporter          reporters.ReportWriter
+	metricsCollector  *MigrationMetricsCollector
+	migratedTypes     map[common.TypeID]struct{}
+	migratedContracts map[common.Location]struct{}
+	programs          map[common.Location]*interpreter.Program
 }
 
 var _ migrations.ValueMigration = &MetricsCollectingMigration{}
@@ -62,6 +63,7 @@ func (m *MetricsCollectingMigration) InitMigration(
 	_ int,
 ) error {
 	m.migratedTypes = make(map[common.TypeID]struct{})
+	m.migratedContracts = make(map[common.Location]struct{})
 
 	// If the program is available, that means the associated contracts is compatible with Cadence 1.0.
 	// i.e: the contract is either migrated to be compatible with 1.0 or existing contract already compatible.
@@ -71,12 +73,20 @@ func (m *MetricsCollectingMigration) InitMigration(
 		contract := program.Program.SoleContractDeclaration()
 		if contract != nil {
 			nestedDecls = contract.Members
+
+			contractType := program.Elaboration.CompositeDeclarationType(contract)
+			m.migratedTypes[contractType.ID()] = struct{}{}
+			m.migratedContracts[contractType.Location] = struct{}{}
 		} else {
 			contractInterface := program.Program.SoleContractInterfaceDeclaration()
 			if contractInterface == nil {
 				panic(errors.NewUnreachableError())
 			}
 			nestedDecls = contractInterface.Members
+
+			contractInterfaceType := program.Elaboration.InterfaceDeclarationType(contractInterface)
+			m.migratedTypes[contractInterfaceType.ID()] = struct{}{}
+			m.migratedContracts[contractInterfaceType.Location] = struct{}{}
 		}
 
 		for _, compositeDecl := range nestedDecls.Composites() {
@@ -105,7 +115,8 @@ func (m *MetricsCollectingMigration) InitMigration(
 
 		// Entitlements are not needed, since old values won't have them.
 
-		// TODO: also add the contract type itself?
+		// TODO: Anything else? e.g: Enum cases?
+
 	}
 
 	return nil
@@ -285,6 +296,17 @@ func (m *MetricsCollectingMigration) checkAndRecordIsTypeMigrated(typeID sema.Ty
 		// If this type is not migrated/usable with cadence 1.0,
 		// then record this as an erroneous value.
 		m.metricsCollector.RecordErrorForContract(location)
+
+		// If the type is not migrated, but the contract is migrated, then report an error.
+		// This is more likely to be an implementation error, where the typeID haven't got added to the list.
+		_, ok := m.migratedContracts[location]
+		if ok {
+			m.log.Error().Msgf(
+				"contract `%s` is migrated, but cannot find the migrated type: `%s`",
+				location,
+				typeID,
+			)
+		}
 	}
 
 	return ok

--- a/cmd/util/ledger/migrations/migration_metrics_collector.go
+++ b/cmd/util/ledger/migrations/migration_metrics_collector.go
@@ -24,6 +24,7 @@ const metricsCollectingMigrationName = "metrics_collecting_migration"
 type MetricsCollectingMigration struct {
 	name             string
 	chainID          flow.ChainID
+	log              zerolog.Logger
 	mutex            sync.RWMutex
 	reporter         reporters.ReportWriter
 	metricsCollector *MigrationMetricsCollector
@@ -35,6 +36,7 @@ var _ migrations.ValueMigration = &MetricsCollectingMigration{}
 var _ AccountBasedMigration = &MetricsCollectingMigration{}
 
 func NewMetricsCollectingMigration(
+	log zerolog.Logger,
 	chainID flow.ChainID,
 	rwf reporters.ReportWriterFactory,
 	programs map[common.Location]*interpreter.Program,
@@ -42,6 +44,7 @@ func NewMetricsCollectingMigration(
 
 	return &MetricsCollectingMigration{
 		name:             metricsCollectingMigrationName,
+		log:              log,
 		reporter:         rwf.ReportWriter("metrics-collecting-migration"),
 		metricsCollector: NewMigrationMetricsCollector(),
 		chainID:          chainID,
@@ -137,7 +140,7 @@ func (m *MetricsCollectingMigration) MigrateAccount(
 
 	migration.Migrate(
 		migration.NewValueMigrationsPathMigrator(
-			nil, // No need to report
+			NewStorageVisitingErrorReporter(m.log),
 			m,
 		),
 	)
@@ -155,6 +158,7 @@ func (m *MetricsCollectingMigration) Migrate(
 	_ interpreter.StorageMapKey,
 	value interpreter.Value,
 	_ *interpreter.Interpreter,
+	_ migrations.ValueMigrationPosition,
 ) (
 	newValue interpreter.Value,
 	err error,
@@ -307,10 +311,10 @@ func (m *MetricsCollectingMigration) Domains() map[string]struct{} {
 
 type MigrationMetricsCollector struct {
 	mutex             sync.RWMutex
-	TotalValues       int                     `json:"totalValues"`
-	TotalErrors       int                     `json:"totalErrors"`
-	ValuesPerContract map[common.Location]int `json:"valuesPerContract"`
-	ErrorsPerContract map[common.Location]int `json:"errorsPerContract"`
+	TotalValues       int
+	TotalErrors       int
+	ValuesPerContract map[common.Location]int
+	ErrorsPerContract map[common.Location]int
 }
 
 func NewMigrationMetricsCollector() *MigrationMetricsCollector {
@@ -378,4 +382,32 @@ type Metrics struct {
 
 	// Total values related to each contract
 	ValuesPerContract map[string]int `json:"valuesPerContract"`
+}
+
+type storageVisitingErrorReporter struct {
+	log zerolog.Logger
+}
+
+func NewStorageVisitingErrorReporter(log zerolog.Logger) *storageVisitingErrorReporter {
+	return &storageVisitingErrorReporter{
+		log: log,
+	}
+}
+
+var _ migrations.Reporter = &storageVisitingErrorReporter{}
+
+func (p *storageVisitingErrorReporter) Migrated(
+	_ interpreter.StorageKey,
+	_ interpreter.StorageMapKey,
+	_ string,
+) {
+	// Ignore
+}
+
+func (p *storageVisitingErrorReporter) DictionaryKeyConflict(addressPath interpreter.AddressPath) {
+	p.log.Error().Msgf("dictionary key conflict for %s", addressPath)
+}
+
+func (p *storageVisitingErrorReporter) Error(err error) {
+	p.log.Error().Msgf("%s", err.Error())
 }

--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -12,7 +12,7 @@ import (
 
 type RegistersMigration func(registersByAccount *registers.ByAccount) error
 
-var allStorageMapDomains = []string{
+var AllStorageMapDomains = []string{
 	common.PathDomainStorage.Identifier(),
 	common.PathDomainPrivate.Identifier(),
 	common.PathDomainPublic.Identifier(),
@@ -24,7 +24,7 @@ var allStorageMapDomains = []string{
 var allStorageMapDomainsSet = map[string]struct{}{}
 
 func init() {
-	for _, domain := range allStorageMapDomains {
+	for _, domain := range AllStorageMapDomains {
 		allStorageMapDomainsSet[domain] = struct{}{}
 	}
 }
@@ -80,7 +80,7 @@ func checkStorageHealth(
 		return err
 	}
 
-	for _, domain := range allStorageMapDomains {
+	for _, domain := range AllStorageMapDomains {
 		_ = storage.GetStorageMap(address, domain, false)
 	}
 

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -149,6 +149,11 @@ func (b *ByAccount) AccountCount() int {
 	return len(b.registers)
 }
 
+func (b *ByAccount) HasAccountOwner(owner string) bool {
+	_, ok := b.registers[owner]
+	return ok
+}
+
 func (b *ByAccount) AccountRegisters(owner string) *AccountRegisters {
 	accountRegisters, ok := b.registers[owner]
 	if !ok {

--- a/cmd/util/ledger/util/trace.go
+++ b/cmd/util/ledger/util/trace.go
@@ -1,0 +1,39 @@
+package util
+
+import "strings"
+
+type Trace struct {
+	value  string
+	parent *Trace
+}
+
+func NewTrace(value string) *Trace {
+	return &Trace{
+		value: value,
+	}
+}
+
+func (t *Trace) Append(value string) *Trace {
+	return &Trace{
+		value:  value,
+		parent: t,
+	}
+}
+
+func (t *Trace) String() string {
+	var sb strings.Builder
+
+	var size int
+	var elements []*Trace
+	for current := t; current != nil; current = current.parent {
+		size += len(current.value)
+		elements = append(elements, current)
+	}
+	sb.Grow(size)
+
+	for i := len(elements) - 1; i >= 0; i-- {
+		sb.WriteString(elements[i].value)
+	}
+
+	return sb.String()
+}

--- a/cmd/util/ledger/util/trace_test.go
+++ b/cmd/util/ledger/util/trace_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrace(t *testing.T) {
+	t.Parallel()
+
+	trace := NewTrace("foo")
+	assert.Equal(t, "foo", trace.String())
+
+	traceBar := trace.Append(".bar")
+	assert.Equal(t, "foo.bar", traceBar.String())
+
+	traceBarBaz := traceBar.Append(".baz")
+	assert.Equal(t, "foo.bar.baz", traceBarBaz.String())
+
+	traceQux := trace.Append(".qux")
+	assert.Equal(t, "foo.qux", traceQux.String())
+
+	traceQuux := traceQux.Append(".quux")
+	assert.Equal(t, "foo.qux.quux", traceQuux.String())
+}

--- a/engine/access/handle_irrecoverable_state_test.go
+++ b/engine/access/handle_irrecoverable_state_test.go
@@ -176,6 +176,7 @@ func (suite *IrrecoverableStateTestSuite) SetupTest() {
 		suite.unsecureGrpcServer,
 		nil,
 		stateStreamConfig,
+		nil,
 	)
 	assert.NoError(suite.T(), err)
 	suite.rpcEng, err = rpcEngBuilder.WithLegacy().Build()

--- a/engine/access/index/event_index_test.go
+++ b/engine/access/index/event_index_test.go
@@ -44,7 +44,7 @@ func TestGetEvents(t *testing.T) {
 		return storedEvents, nil
 	})
 
-	eventsIndex := NewEventsIndex(events)
+	eventsIndex := NewEventsIndex(NewReporter(), events)
 	err := eventsIndex.Initialize(&mockIndexReporter{})
 	require.NoError(t, err)
 

--- a/engine/access/index/events_index.go
+++ b/engine/access/index/events_index.go
@@ -1,45 +1,24 @@
 package index
 
 import (
-	"fmt"
 	"sort"
 
-	"go.uber.org/atomic"
-
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/module/state_synchronization"
-	"github.com/onflow/flow-go/module/state_synchronization/indexer"
 	"github.com/onflow/flow-go/storage"
 )
 
-var _ state_synchronization.IndexReporter = (*EventsIndex)(nil)
-
 // EventsIndex implements a wrapper around `storage.Events` ensuring that needed data has been synced and is available to the client.
-// Note: `EventsIndex` is created with empty report due to the next reasoning:
-// When the index is initially bootstrapped, the indexer needs to load an execution state checkpoint from
-// disk and index all the data. This process can take more than 1 hour on some systems. Consequently, the Initialize
-// pattern is implemented to enable the Access API to start up and serve queries before the index is fully ready. During
-// the initialization phase, all calls to retrieve data from this struct should return indexer.ErrIndexNotInitialized.
-// The caller is responsible for handling this error appropriately for the method.
+// Note: read detail how `Reporter` is working
 type EventsIndex struct {
-	events   storage.Events
-	reporter *atomic.Pointer[state_synchronization.IndexReporter]
+	*Reporter
+	events storage.Events
 }
 
-func NewEventsIndex(events storage.Events) *EventsIndex {
+func NewEventsIndex(reporter *Reporter, events storage.Events) *EventsIndex {
 	return &EventsIndex{
+		Reporter: reporter,
 		events:   events,
-		reporter: atomic.NewPointer[state_synchronization.IndexReporter](nil),
 	}
-}
-
-// Initialize replaces a previously non-initialized reporter. Can be called once.
-// No errors are expected during normal operations.
-func (e *EventsIndex) Initialize(indexReporter state_synchronization.IndexReporter) error {
-	if e.reporter.CompareAndSwap(nil, &indexReporter) {
-		return nil
-	}
-	return fmt.Errorf("index reporter already initialized")
 }
 
 // ByBlockID checks data availability and returns events for a block
@@ -93,70 +72,4 @@ func (e *EventsIndex) ByBlockIDTransactionIndex(blockID flow.Identifier, height 
 	}
 
 	return e.events.ByBlockIDTransactionIndex(blockID, txIndex)
-}
-
-// LowestIndexedHeight returns the lowest height indexed by the execution state indexer.
-// Expected errors:
-// - indexer.ErrIndexNotInitialized if the EventsIndex has not been initialized
-func (e *EventsIndex) LowestIndexedHeight() (uint64, error) {
-	reporter, err := e.getReporter()
-	if err != nil {
-		return 0, err
-	}
-
-	return reporter.LowestIndexedHeight()
-}
-
-// HighestIndexedHeight returns the highest height indexed by the execution state indexer.
-// Expected errors:
-// - indexer.ErrIndexNotInitialized if the EventsIndex has not been initialized
-func (e *EventsIndex) HighestIndexedHeight() (uint64, error) {
-	reporter, err := e.getReporter()
-	if err != nil {
-		return 0, err
-	}
-
-	return reporter.HighestIndexedHeight()
-}
-
-// checkDataAvailability checks the availability of data at the given height by comparing it with the highest and lowest
-// indexed heights. If the height is beyond the indexed range, an error is returned.
-// Expected errors:
-//   - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
-//   - storage.ErrHeightNotIndexed if the block at the provided height is not indexed yet
-//   - fmt.Errorf with custom message if the highest or lowest indexed heights cannot be retrieved from the reporter
-func (e *EventsIndex) checkDataAvailability(height uint64) error {
-	reporter, err := e.getReporter()
-	if err != nil {
-		return err
-	}
-
-	highestHeight, err := reporter.HighestIndexedHeight()
-	if err != nil {
-		return fmt.Errorf("could not get highest indexed height: %w", err)
-	}
-	if height > highestHeight {
-		return fmt.Errorf("%w: block not indexed yet", storage.ErrHeightNotIndexed)
-	}
-
-	lowestHeight, err := reporter.LowestIndexedHeight()
-	if err != nil {
-		return fmt.Errorf("could not get lowest indexed height: %w", err)
-	}
-	if height < lowestHeight {
-		return fmt.Errorf("%w: block is before lowest indexed height", storage.ErrHeightNotIndexed)
-	}
-
-	return nil
-}
-
-// getReporter retrieves the current index reporter instance from the atomic pointer.
-// Expected errors:
-//   - indexer.ErrIndexNotInitialized if the reporter is not initialized
-func (e *EventsIndex) getReporter() (state_synchronization.IndexReporter, error) {
-	reporter := e.reporter.Load()
-	if reporter == nil {
-		return nil, indexer.ErrIndexNotInitialized
-	}
-	return *reporter, nil
 }

--- a/engine/access/index/reporter.go
+++ b/engine/access/index/reporter.go
@@ -1,0 +1,106 @@
+package index
+
+import (
+	"fmt"
+
+	"go.uber.org/atomic"
+
+	"github.com/onflow/flow-go/module/state_synchronization/indexer"
+	"github.com/onflow/flow-go/storage"
+
+	"github.com/onflow/flow-go/module/state_synchronization"
+)
+
+var _ state_synchronization.IndexReporter = (*Reporter)(nil)
+
+// Reporter implements a wrapper around `IndexReporter` ensuring that needed data has been synced and is available to the client.
+// Note: `Reporter` is created with empty reporter due to the next reasoning:
+// When the index is initially bootstrapped, the indexer needs to load an execution state checkpoint from
+// disk and index all the data. This process can take more than 1 hour on some systems. Consequently, the Initialize
+// pattern is implemented to enable the Access API to start up and serve queries before the index is fully ready. During
+// the initialization phase, all calls to retrieve data from this struct should return indexer.ErrIndexNotInitialized.
+// The caller is responsible for handling this error appropriately for the method.
+type Reporter struct {
+	reporter *atomic.Pointer[state_synchronization.IndexReporter]
+}
+
+func NewReporter() *Reporter {
+	return &Reporter{
+		reporter: atomic.NewPointer[state_synchronization.IndexReporter](nil),
+	}
+}
+
+// Initialize replaces a previously non-initialized reporter. Can be called once.
+// No errors are expected during normal operations.
+func (s *Reporter) Initialize(indexReporter state_synchronization.IndexReporter) error {
+	if s.reporter.CompareAndSwap(nil, &indexReporter) {
+		return nil
+	}
+	return fmt.Errorf("index reporter already initialized")
+}
+
+// LowestIndexedHeight returns the lowest height indexed by the execution state indexer.
+// Expected errors:
+// - indexer.ErrIndexNotInitialized if the IndexReporter has not been initialized
+func (s *Reporter) LowestIndexedHeight() (uint64, error) {
+	reporter, err := s.getReporter()
+	if err != nil {
+		return 0, err
+	}
+
+	return reporter.LowestIndexedHeight()
+}
+
+// HighestIndexedHeight returns the highest height indexed by the execution state indexer.
+// Expected errors:
+// - indexer.ErrIndexNotInitialized if the IndexReporter has not been initialized
+func (s *Reporter) HighestIndexedHeight() (uint64, error) {
+	reporter, err := s.getReporter()
+	if err != nil {
+		return 0, err
+	}
+
+	return reporter.HighestIndexedHeight()
+}
+
+// checkDataAvailability checks the availability of data at the given height by comparing it with the highest and lowest
+// indexed heights. If the height is beyond the indexed range, an error is returned.
+// Expected errors:
+//   - indexer.ErrIndexNotInitialized if the `IndexReporter` has not been initialized
+//   - storage.ErrHeightNotIndexed if the block at the provided height is not indexed yet
+//   - all other errors are unexpected
+func (s *Reporter) checkDataAvailability(height uint64) error {
+	reporter, err := s.getReporter()
+	if err != nil {
+		return err
+	}
+
+	highestHeight, err := reporter.HighestIndexedHeight()
+	if err != nil {
+		return fmt.Errorf("could not get highest indexed height: %w", err)
+	}
+	if height > highestHeight {
+		return fmt.Errorf("%w: block not indexed yet", storage.ErrHeightNotIndexed)
+	}
+
+	lowestHeight, err := reporter.LowestIndexedHeight()
+	if err != nil {
+		return fmt.Errorf("could not get lowest indexed height: %w", err)
+	}
+	if height < lowestHeight {
+		return fmt.Errorf("%w: block is before lowest indexed height", storage.ErrHeightNotIndexed)
+	}
+
+	return nil
+}
+
+// getReporter retrieves the current index reporter instance from the atomic pointer.
+// Expected errors:
+//   - indexer.ErrIndexNotInitialized if the reporter is not initialized
+func (s *Reporter) getReporter() (state_synchronization.IndexReporter, error) {
+	reporter := s.reporter.Load()
+	if reporter == nil {
+		return nil, indexer.ErrIndexNotInitialized
+	}
+	return *reporter, nil
+}

--- a/engine/access/index/transaction_results_indexer.go
+++ b/engine/access/index/transaction_results_indexer.go
@@ -1,44 +1,22 @@
 package index
 
 import (
-	"fmt"
-
-	"go.uber.org/atomic"
-
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/module/state_synchronization"
-	"github.com/onflow/flow-go/module/state_synchronization/indexer"
 	"github.com/onflow/flow-go/storage"
 )
 
 // TransactionResultsIndex implements a wrapper around `storage.LightTransactionResult` ensuring that needed data has been synced and is available to the client.
-// Note: `TransactionResultsIndex` is created with empty report due to the next reasoning:
-// When the index is initially bootstrapped, the indexer needs to load an execution state checkpoint from
-// disk and index all the data. This process can take more than 1 hour on some systems. Consequently, the Initialize
-// pattern is implemented to enable the Access API to start up and serve queries before the index is fully ready. During
-// the initialization phase, all calls to retrieve data from this struct should return indexer.ErrIndexNotInitialized.
-// The caller is responsible for handling this error appropriately for the method.
+// Note: read detail how `Reporter` is working
 type TransactionResultsIndex struct {
-	results  storage.LightTransactionResults
-	reporter *atomic.Pointer[state_synchronization.IndexReporter]
+	*Reporter
+	results storage.LightTransactionResults
 }
 
-var _ state_synchronization.IndexReporter = (*TransactionResultsIndex)(nil)
-
-func NewTransactionResultsIndex(results storage.LightTransactionResults) *TransactionResultsIndex {
+func NewTransactionResultsIndex(reporter *Reporter, results storage.LightTransactionResults) *TransactionResultsIndex {
 	return &TransactionResultsIndex{
+		Reporter: reporter,
 		results:  results,
-		reporter: atomic.NewPointer[state_synchronization.IndexReporter](nil),
 	}
-}
-
-// Initialize replaces a previously non-initialized reporter. Can be called once.
-// No errors are expected during normal operations.
-func (t *TransactionResultsIndex) Initialize(indexReporter state_synchronization.IndexReporter) error {
-	if t.reporter.CompareAndSwap(nil, &indexReporter) {
-		return nil
-	}
-	return fmt.Errorf("index reporter already initialized")
 }
 
 // ByBlockID checks data availability and returns all transaction results for a block
@@ -78,70 +56,4 @@ func (t *TransactionResultsIndex) ByBlockIDTransactionIndex(blockID flow.Identif
 	}
 
 	return t.results.ByBlockIDTransactionIndex(blockID, index)
-}
-
-// LowestIndexedHeight returns the lowest height indexed by the execution state indexer.
-// Expected errors:
-// - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
-func (t *TransactionResultsIndex) LowestIndexedHeight() (uint64, error) {
-	reporter, err := t.getReporter()
-	if err != nil {
-		return 0, err
-	}
-
-	return reporter.LowestIndexedHeight()
-}
-
-// HighestIndexedHeight returns the highest height indexed by the execution state indexer.
-// Expected errors:
-// - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
-func (t *TransactionResultsIndex) HighestIndexedHeight() (uint64, error) {
-	reporter, err := t.getReporter()
-	if err != nil {
-		return 0, err
-	}
-
-	return reporter.HighestIndexedHeight()
-}
-
-// checkDataAvailability checks the availability of data at the given height by comparing it with the highest and lowest
-// indexed heights. If the height is beyond the indexed range, an error is returned.
-// Expected errors:
-//   - indexer.ErrIndexNotInitialized if the `TransactionResultsIndex` has not been initialized
-//   - storage.ErrHeightNotIndexed if the block at the provided height is not indexed yet
-//   - fmt.Errorf if the highest or lowest indexed heights cannot be retrieved from the reporter
-func (t *TransactionResultsIndex) checkDataAvailability(height uint64) error {
-	reporter, err := t.getReporter()
-	if err != nil {
-		return err
-	}
-
-	highestHeight, err := reporter.HighestIndexedHeight()
-	if err != nil {
-		return fmt.Errorf("could not get highest indexed height: %w", err)
-	}
-	if height > highestHeight {
-		return fmt.Errorf("%w: block not indexed yet", storage.ErrHeightNotIndexed)
-	}
-
-	lowestHeight, err := reporter.LowestIndexedHeight()
-	if err != nil {
-		return fmt.Errorf("could not get lowest indexed height: %w", err)
-	}
-	if height < lowestHeight {
-		return fmt.Errorf("%w: block is before lowest indexed height", storage.ErrHeightNotIndexed)
-	}
-
-	return nil
-}
-
-// getReporter retrieves the current index reporter instance from the atomic pointer.
-// Expected errors:
-//   - indexer.ErrIndexNotInitialized if the reporter is not initialized
-func (t *TransactionResultsIndex) getReporter() (state_synchronization.IndexReporter, error) {
-	reporter := t.reporter.Load()
-	if reporter == nil {
-		return nil, indexer.ErrIndexNotInitialized
-	}
-	return *reporter, nil
 }

--- a/engine/access/integration_unsecure_grpc_server_test.go
+++ b/engine/access/integration_unsecure_grpc_server_test.go
@@ -215,6 +215,7 @@ func (suite *SameGRPCPortTestSuite) SetupTest() {
 		suite.unsecureGrpcServer,
 		nil,
 		stateStreamConfig,
+		nil,
 	)
 	assert.NoError(suite.T(), err)
 	suite.rpcEng, err = rpcEngBuilder.WithLegacy().Build()
@@ -249,7 +250,7 @@ func (suite *SameGRPCPortTestSuite) SetupTest() {
 		subscription.DefaultSendBufferSize,
 	)
 
-	eventIndexer := index.NewEventsIndex(suite.events)
+	eventIndexer := index.NewEventsIndex(index.NewReporter(), suite.events)
 
 	suite.executionDataTracker = subscription.NewExecutionDataTracker(
 		suite.log,

--- a/engine/access/rest_api_test.go
+++ b/engine/access/rest_api_test.go
@@ -193,6 +193,7 @@ func (suite *RestAPITestSuite) SetupTest() {
 		suite.unsecureGrpcServer,
 		nil,
 		stateStreamConfig,
+		nil,
 	)
 	assert.NoError(suite.T(), err)
 	suite.rpcEng, err = rpcEngBuilder.WithLegacy().Build()

--- a/engine/access/rpc/backend/backend_events_test.go
+++ b/engine/access/rpc/backend/backend_events_test.go
@@ -84,7 +84,7 @@ func (s *BackendEventsSuite) SetupTest() {
 
 	s.execClient = access.NewExecutionAPIClient(s.T())
 	s.executionNodes = unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
-	s.eventsIndex = index.NewEventsIndex(s.events)
+	s.eventsIndex = index.NewEventsIndex(index.NewReporter(), s.events)
 
 	blockCount := 5
 	s.blocks = make([]*flow.Block, blockCount)
@@ -310,7 +310,7 @@ func (s *BackendEventsSuite) TestGetEvents_HappyPaths() {
 
 		s.Run(fmt.Sprintf("all from en - %s - %s", tt.encoding.String(), tt.queryMode), func() {
 			events := storagemock.NewEvents(s.T())
-			eventsIndex := index.NewEventsIndex(events)
+			eventsIndex := index.NewEventsIndex(index.NewReporter(), events)
 
 			switch tt.queryMode {
 			case IndexQueryModeLocalOnly:
@@ -340,7 +340,7 @@ func (s *BackendEventsSuite) TestGetEvents_HappyPaths() {
 
 		s.Run(fmt.Sprintf("mixed storage & en - %s - %s", tt.encoding.String(), tt.queryMode), func() {
 			events := storagemock.NewEvents(s.T())
-			eventsIndex := index.NewEventsIndex(events)
+			eventsIndex := index.NewEventsIndex(index.NewReporter(), events)
 
 			switch tt.queryMode {
 			case IndexQueryModeLocalOnly, IndexQueryModeExecutionNodesOnly:

--- a/engine/access/rpc/backend/backend_transactions_test.go
+++ b/engine/access/rpc/backend/backend_transactions_test.go
@@ -461,7 +461,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_HappyPath() {
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
 
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(index.NewReporter(), suite.transactionResults)
 	err := params.TxResultsIndex.Initialize(reporter)
 	suite.Require().NoError(err)
 
@@ -511,7 +511,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_UnknownTransaction(
 
 	params := suite.defaultBackendParams()
 
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(index.NewReporter(), suite.transactionResults)
 	err := params.TxResultsIndex.Initialize(reporter)
 	suite.Require().NoError(err)
 
@@ -560,7 +560,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_FailedToFetch() {
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
 
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(index.NewReporter(), suite.transactionResults)
 	err := params.TxResultsIndex.Initialize(reporter)
 	suite.Require().NoError(err)
 
@@ -617,7 +617,7 @@ func (suite *Suite) TestLookupTransactionErrorMessages_HappyPath() {
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
 
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(index.NewReporter(), suite.transactionResults)
 	err := params.TxResultsIndex.Initialize(reporter)
 	suite.Require().NoError(err)
 
@@ -697,7 +697,7 @@ func (suite *Suite) TestLookupTransactionErrorMessages_HappyPath_NoFailedTxns() 
 
 	params := suite.defaultBackendParams()
 
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(index.NewReporter(), suite.transactionResults)
 	err := params.TxResultsIndex.Initialize(reporter)
 	suite.Require().NoError(err)
 
@@ -726,7 +726,7 @@ func (suite *Suite) TestLookupTransactionErrorMessages_UnknownTransaction() {
 
 	params := suite.defaultBackendParams()
 
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(index.NewReporter(), suite.transactionResults)
 	err := params.TxResultsIndex.Initialize(reporter)
 	suite.Require().NoError(err)
 
@@ -781,7 +781,7 @@ func (suite *Suite) TestLookupTransactionErrorMessages_FailedToFetch() {
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
 
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(index.NewReporter(), suite.transactionResults)
 	err := params.TxResultsIndex.Initialize(reporter)
 	suite.Require().NoError(err)
 
@@ -959,17 +959,16 @@ func (suite *Suite) TestGetSystemTransactionResultFromStorage() {
 	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
 	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
 
+	indexReporter := index.NewReporter()
+	err = indexReporter.Initialize(reporter)
+	suite.Require().NoError(err)
+
 	// Set up the backend parameters and the backend instance
 	params := suite.defaultBackendParams()
 	params.TxResultQueryMode = IndexQueryModeLocalOnly
 
-	params.EventsIndex = index.NewEventsIndex(suite.events)
-	err = params.EventsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
-
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
-	err = params.TxResultsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
+	params.EventsIndex = index.NewEventsIndex(indexReporter, suite.events)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(indexReporter, suite.transactionResults)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
@@ -1185,6 +1184,10 @@ func (suite *Suite) TestTransactionResultFromStorage() {
 	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
 	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
 
+	indexReporter := index.NewReporter()
+	err := indexReporter.Initialize(reporter)
+	suite.Require().NoError(err)
+
 	// Set up the backend parameters and the backend instance
 	params := suite.defaultBackendParams()
 	// the connection factory should be used to get the execution node client
@@ -1192,13 +1195,8 @@ func (suite *Suite) TestTransactionResultFromStorage() {
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
 	params.TxResultQueryMode = IndexQueryModeLocalOnly
 
-	params.EventsIndex = index.NewEventsIndex(suite.events)
-	err := params.EventsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
-
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
-	err = params.TxResultsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
+	params.EventsIndex = index.NewEventsIndex(indexReporter, suite.events)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(indexReporter, suite.transactionResults)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
@@ -1277,6 +1275,10 @@ func (suite *Suite) TestTransactionByIndexFromStorage() {
 	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
 	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
 
+	indexReporter := index.NewReporter()
+	err := indexReporter.Initialize(reporter)
+	suite.Require().NoError(err)
+
 	// Set up the backend parameters and the backend instance
 	params := suite.defaultBackendParams()
 	// the connection factory should be used to get the execution node client
@@ -1284,13 +1286,8 @@ func (suite *Suite) TestTransactionByIndexFromStorage() {
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
 	params.TxResultQueryMode = IndexQueryModeLocalOnly
 
-	params.EventsIndex = index.NewEventsIndex(suite.events)
-	err := params.EventsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
-
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
-	err = params.TxResultsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
+	params.EventsIndex = index.NewEventsIndex(indexReporter, suite.events)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(indexReporter, suite.transactionResults)
 
 	backend, err := New(params)
 	suite.Require().NoError(err)
@@ -1375,19 +1372,18 @@ func (suite *Suite) TestTransactionResultsByBlockIDFromStorage() {
 	reporter.On("LowestIndexedHeight").Return(block.Header.Height, nil)
 	reporter.On("HighestIndexedHeight").Return(block.Header.Height+10, nil)
 
+	indexReporter := index.NewReporter()
+	err := indexReporter.Initialize(reporter)
+	suite.Require().NoError(err)
+
 	// Set up the state and snapshot mocks and the backend instance
 	params := suite.defaultBackendParams()
 	// the connection factory should be used to get the execution node client
 	params.ConnFactory = connFactory
 	params.FixedExecutionNodeIDs = fixedENIDs.NodeIDs().Strings()
 
-	params.EventsIndex = index.NewEventsIndex(suite.events)
-	err := params.EventsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
-
-	params.TxResultsIndex = index.NewTransactionResultsIndex(suite.transactionResults)
-	err = params.TxResultsIndex.Initialize(reporter)
-	suite.Require().NoError(err)
+	params.EventsIndex = index.NewEventsIndex(indexReporter, suite.events)
+	params.TxResultsIndex = index.NewTransactionResultsIndex(indexReporter, suite.transactionResults)
 
 	params.TxResultQueryMode = IndexQueryModeLocalOnly
 

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/onflow/flow-go/module/state_synchronization"
+
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/credentials"
 
@@ -87,6 +89,7 @@ func NewBuilder(log zerolog.Logger,
 	unsecureGrpcServer *grpcserver.GrpcServer,
 	stateStreamBackend state_stream.API,
 	stateStreamConfig statestreambackend.Config,
+	indexReporter state_synchronization.IndexReporter,
 ) (*RPCEngineBuilder, error) {
 	log = log.With().Str("engine", "rpc").Logger()
 
@@ -132,7 +135,7 @@ func NewBuilder(log zerolog.Logger,
 		AddWorker(eng.shutdownWorker).
 		Build()
 
-	builder := NewRPCEngineBuilder(eng, me, finalizedCache)
+	builder := NewRPCEngineBuilder(eng, me, finalizedCache, indexReporter)
 	if rpcMetricsEnabled {
 		builder.WithMetrics()
 	}

--- a/engine/access/rpc/engine_builder.go
+++ b/engine/access/rpc/engine_builder.go
@@ -4,20 +4,21 @@ import (
 	"fmt"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
+	legacyaccessproto "github.com/onflow/flow/protobuf/go/flow/legacy/access"
 
 	"github.com/onflow/flow-go/access"
 	legacyaccess "github.com/onflow/flow-go/access/legacy"
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/module"
-
-	accessproto "github.com/onflow/flow/protobuf/go/flow/access"
-	legacyaccessproto "github.com/onflow/flow/protobuf/go/flow/legacy/access"
+	"github.com/onflow/flow-go/module/state_synchronization"
 )
 
 type RPCEngineBuilder struct {
 	*Engine
 	me                   module.Local
 	finalizedHeaderCache module.FinalizedHeaderCache
+	indexReporter        state_synchronization.IndexReporter
 
 	// optional parameters, only one can be set during build phase
 	signerIndicesDecoder hotstuff.BlockSignerDecoder
@@ -25,12 +26,13 @@ type RPCEngineBuilder struct {
 }
 
 // NewRPCEngineBuilder helps to build a new RPC engine.
-func NewRPCEngineBuilder(engine *Engine, me module.Local, finalizedHeaderCache module.FinalizedHeaderCache) *RPCEngineBuilder {
+func NewRPCEngineBuilder(engine *Engine, me module.Local, finalizedHeaderCache module.FinalizedHeaderCache, indexReporter state_synchronization.IndexReporter) *RPCEngineBuilder {
 	// the default handler will use the engine.backend implementation
 	return &RPCEngineBuilder{
 		Engine:               engine,
 		me:                   me,
 		finalizedHeaderCache: finalizedHeaderCache,
+		indexReporter:        indexReporter,
 	}
 }
 
@@ -80,9 +82,9 @@ func (builder *RPCEngineBuilder) WithLegacy() *RPCEngineBuilder {
 
 func (builder *RPCEngineBuilder) DefaultHandler(signerIndicesDecoder hotstuff.BlockSignerDecoder) *access.Handler {
 	if signerIndicesDecoder == nil {
-		return access.NewHandler(builder.Engine.backend, builder.Engine.chain, builder.finalizedHeaderCache, builder.me, builder.stateStreamConfig.MaxGlobalStreams)
+		return access.NewHandler(builder.Engine.backend, builder.Engine.chain, builder.finalizedHeaderCache, builder.me, builder.stateStreamConfig.MaxGlobalStreams, access.WithIndexReporter(builder.indexReporter))
 	} else {
-		return access.NewHandler(builder.Engine.backend, builder.Engine.chain, builder.finalizedHeaderCache, builder.me, builder.stateStreamConfig.MaxGlobalStreams, access.WithBlockSignerDecoder(signerIndicesDecoder))
+		return access.NewHandler(builder.Engine.backend, builder.Engine.chain, builder.finalizedHeaderCache, builder.me, builder.stateStreamConfig.MaxGlobalStreams, access.WithBlockSignerDecoder(signerIndicesDecoder), access.WithIndexReporter(builder.indexReporter))
 	}
 }
 

--- a/engine/access/rpc/rate_limit_test.go
+++ b/engine/access/rpc/rate_limit_test.go
@@ -186,7 +186,9 @@ func (suite *RateLimitTestSuite) SetupTest() {
 		suite.secureGrpcServer,
 		suite.unsecureGrpcServer,
 		nil,
-		stateStreamConfig)
+		stateStreamConfig,
+		nil,
+	)
 	require.NoError(suite.T(), err)
 	suite.rpcEng, err = rpcEngBuilder.WithLegacy().Build()
 	require.NoError(suite.T(), err)

--- a/engine/access/secure_grpcr_test.go
+++ b/engine/access/secure_grpcr_test.go
@@ -171,6 +171,7 @@ func (suite *SecureGRPCTestSuite) SetupTest() {
 		suite.unsecureGrpcServer,
 		nil,
 		stateStreamConfig,
+		nil,
 	)
 	assert.NoError(suite.T(), err)
 	suite.rpcEng, err = rpcEngBuilder.WithLegacy().Build()

--- a/engine/access/state_stream/backend/backend_executiondata_test.go
+++ b/engine/access/state_stream/backend/backend_executiondata_test.go
@@ -179,7 +179,7 @@ func (s *BackendExecutionDataSuite) SetupTestSuite(blockCount int) {
 func (s *BackendExecutionDataSuite) SetupTestMocks() {
 	s.registerID = unittest.RegisterIDFixture()
 
-	s.eventsIndex = index.NewEventsIndex(s.events)
+	s.eventsIndex = index.NewEventsIndex(index.NewReporter(), s.events)
 	s.registersAsync = execution.NewRegistersAsyncStore()
 	s.registers = storagemock.NewRegisterIndex(s.T())
 	err := s.registersAsync.Initialize(s.registers)

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -38,6 +38,7 @@ func TestEVMRun(t *testing.T) {
 	t.Parallel()
 
 	chain := flow.Emulator.Chain()
+
 	t.Run("testing EVM.run (happy case)", func(t *testing.T) {
 
 		t.Parallel()
@@ -151,6 +152,7 @@ func TestEVMRun(t *testing.T) {
 				require.Equal(t, blockEventPayload.Hash, txEventPayload.BlockHash)
 				require.Equal(t, blockEventPayload.Height, txEventPayload.BlockHeight)
 				require.Equal(t, blockEventPayload.TotalGasUsed, txEventPayload.GasConsumed)
+				require.Equal(t, uint64(43807), blockEventPayload.TotalGasUsed)
 				require.Empty(t, txEventPayload.ContractAddress)
 
 				// append the state
@@ -509,6 +511,29 @@ func TestEVMBatchRun(t *testing.T) {
 					last := log.Topics[len(log.Topics)-1] // last topic is the value set in the store method
 					assert.Equal(t, storedValues[i], last.Big().Int64())
 				}
+
+				// last one is block executed, make sure TotalGasUsed is non-zero
+				blockEvent := output.Events[batchCount]
+
+				assert.Equal(
+					t,
+					common.NewAddressLocation(
+						nil,
+						common.Address(sc.EVMContract.Address),
+						string(types.EventTypeBlockExecuted),
+					).ID(),
+					string(blockEvent.Type),
+				)
+
+				ev, err := ccf.Decode(nil, blockEvent.Payload)
+				require.NoError(t, err)
+				cadenceEvent, ok := ev.(cadence.Event)
+				require.True(t, ok)
+
+				blockEventPayload, err := types.DecodeBlockEventPayload(cadenceEvent)
+				require.NoError(t, err)
+				require.NotEmpty(t, blockEventPayload.Hash)
+				require.Equal(t, uint64(155183), blockEventPayload.TotalGasUsed)
 
 				// append the state
 				snapshot = snapshot.Append(state)
@@ -965,6 +990,29 @@ func TestEVMAddressDeposit(t *testing.T) {
 			expectedBalance := types.OneFlowBalance
 			bal := getEVMAccountBalance(t, ctx, vm, snapshot, addr)
 			require.Equal(t, expectedBalance, bal)
+
+			// block executed event, make sure TotalGasUsed is non-zero
+			blockEvent := output.Events[3]
+
+			assert.Equal(
+				t,
+				common.NewAddressLocation(
+					nil,
+					common.Address(sc.EVMContract.Address),
+					string(types.EventTypeBlockExecuted),
+				).ID(),
+				string(blockEvent.Type),
+			)
+
+			ev, err := ccf.Decode(nil, blockEvent.Payload)
+			require.NoError(t, err)
+			cadenceEvent, ok := ev.(cadence.Event)
+			require.True(t, ok)
+
+			blockEventPayload, err := types.DecodeBlockEventPayload(cadenceEvent)
+			require.NoError(t, err)
+			require.NotEmpty(t, blockEventPayload.Hash)
+			require.Equal(t, uint64(21000), blockEventPayload.TotalGasUsed)
 		})
 }
 

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -184,7 +184,11 @@ func (h *ContractHandler) batchRun(rlpEncodedTxs [][]byte, coinbase types.Addres
 		return nil, types.ErrUnexpectedEmptyResult
 	}
 
+	// Populate receipt root
 	bp.PopulateReceiptRoot(res)
+
+	// Populate total gas used
+	bp.CalculateGasUsage(res)
 
 	// meter all the transaction gas usage and append hashes to the block
 	for _, r := range res {
@@ -294,9 +298,11 @@ func (h *ContractHandler) run(
 
 	bp.AppendTxHash(res.TxHash)
 
-	// populate receipt root
+	// Populate receipt root
 	bp.PopulateReceiptRoot([]*types.Result{res})
-	bp.CalculateGasUsage([]types.Result{*res})
+
+	// Populate total gas used
+	bp.CalculateGasUsage([]*types.Result{res})
 
 	blockHash, err := bp.Hash()
 	if err != nil {
@@ -478,6 +484,9 @@ func (h *ContractHandler) executeAndHandleCall(
 
 	// Populate receipt root
 	bp.PopulateReceiptRoot([]*types.Result{res})
+
+	// Populate total gas used
+	bp.CalculateGasUsage([]*types.Result{res})
 
 	if totalSupplyDiff != nil {
 		if deductSupplyDiff {

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -69,7 +69,7 @@ func (b *Block) PopulateReceiptRoot(results []*Result) {
 }
 
 // CalculateGasUsage sums up all the gas transactions in the block used
-func (b *Block) CalculateGasUsage(results []Result) {
+func (b *Block) CalculateGasUsage(results []*Result) {
 	for _, res := range results {
 		b.TotalGasUsed += res.GasConsumed
 	}

--- a/go.mod
+++ b/go.mod
@@ -47,12 +47,12 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.8.0-rc.3
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
-	github.com/onflow/flow-go-sdk v1.0.0-preview.31
+	github.com/onflow/flow-go-sdk v1.0.0-preview.34
 	github.com/onflow/flow/protobuf/go/flow v0.4.4
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2157,8 +2157,8 @@ github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 h1:ezvc57d1DskazSzsraHlUZsVyOIS6VoZFBheW3eqCeU=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 h1:zsbEystTgIOp2RXt+ChFsY36kWkkT5JBe5GEFVNQs/E=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2173,8 +2173,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31 h1:TWJ7Wi2ZKhU3/xGKOftmxFO2d76xKhQVh3rcr0DW3IY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31/go.mod h1:vinot5qmZxZ+QV1m67/rK+2iK83iAkVg9Vbiy/Q0TO4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34 h1:FXzQfz9rK08EdoZ7gTy7Ve0at6bgcV1iQN6rtrQG/7I=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34/go.mod h1:blgTAtthpHf58QZiyDUaLBabMlebMtbdzvTf2K5+dds=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -198,12 +198,12 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.8.0-rc.3 // indirect
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 // indirect
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-preview.31 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-preview.34 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v1.2.0 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.4 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2143,8 +2143,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 h1:ezvc57d1DskazSzsraHlUZsVyOIS6VoZFBheW3eqCeU=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 h1:zsbEystTgIOp2RXt+ChFsY36kWkkT5JBe5GEFVNQs/E=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2157,8 +2157,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31 h1:TWJ7Wi2ZKhU3/xGKOftmxFO2d76xKhQVh3rcr0DW3IY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31/go.mod h1:vinot5qmZxZ+QV1m67/rK+2iK83iAkVg9Vbiy/Q0TO4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34 h1:FXzQfz9rK08EdoZ7gTy7Ve0at6bgcV1iQN6rtrQG/7I=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34/go.mod h1:blgTAtthpHf58QZiyDUaLBabMlebMtbdzvTf2K5+dds=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
 	github.com/onflow/flow-emulator v1.0.0-preview.24
 	github.com/onflow/flow-go v0.35.5-0.20240517202625-55f862b45dfd
-	github.com/onflow/flow-go-sdk v1.0.0-preview.31
+	github.com/onflow/flow-go-sdk v1.0.0-preview.34
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.4
 	github.com/onflow/go-ethereum v1.13.4

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2130,8 +2130,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 h1:ezvc57d1DskazSzsraHlUZsVyOIS6VoZFBheW3eqCeU=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 h1:zsbEystTgIOp2RXt+ChFsY36kWkkT5JBe5GEFVNQs/E=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2146,8 +2146,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31 h1:TWJ7Wi2ZKhU3/xGKOftmxFO2d76xKhQVh3rcr0DW3IY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.31/go.mod h1:vinot5qmZxZ+QV1m67/rK+2iK83iAkVg9Vbiy/Q0TO4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34 h1:FXzQfz9rK08EdoZ7gTy7Ve0at6bgcV1iQN6rtrQG/7I=
+github.com/onflow/flow-go-sdk v1.0.0-preview.34/go.mod h1:blgTAtthpHf58QZiyDUaLBabMlebMtbdzvTf2K5+dds=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/ledger/complete/ledger.go
+++ b/ledger/complete/ledger.go
@@ -324,6 +324,11 @@ func (l *Ledger) Tries() ([]*trie.MTrie, error) {
 	return l.forest.GetTries()
 }
 
+// Trie returns the trie stored in the forest
+func (l *Ledger) Trie(rootHash ledger.RootHash) (*trie.MTrie, error) {
+	return l.forest.GetTrie(rootHash)
+}
+
 // Checkpointer returns a checkpointer instance
 func (l *Ledger) Checkpointer() (*realWAL.Checkpointer, error) {
 	checkpointer, err := l.wal.NewCheckpointer()


### PR DESCRIPTION
Merge `master` into `feature/atree-inlining-cadence-v1.0`

<details>
<summary>Conflict resolution:</summary>

```diff
commit d3f22643fe3df93e91a1c418320d760ae6c2aa22
Merge: 9506c3ca65 c504b454e5
Author: Bastian Müller <bastian@turbolent.com>
Date:   Tue Jun 4 11:04:02 2024 -0700

    Merge branch 'master' into bastian/update-atree-inlining-cadence-v1.0-8

diff --git a/go.mod b/go.mod
remerge CONFLICT (content): Merge conflict in go.mod
index 5716d5e616..a3369b29fc 100644
--- a/go.mod
+++ b/go.mod
@@ -46,13 +46,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
-<<<<<<< 9506c3ca65 (Merge pull request #5993 from onflow/bastian/update-atree-inlining-cadence-v1.0-7)
 	github.com/onflow/atree v0.8.0-rc.3
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30
-=======
-	github.com/onflow/atree v0.7.0-rc.2
-	github.com/onflow/cadence v1.0.0-preview.32
->>>>>>> c504b454e5 (Merge pull request #6029 from onflow/auto-update-onflow-cadence-v1.0.0-preview.32)
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0
diff --git a/go.sum b/go.sum
remerge CONFLICT (content): Merge conflict in go.sum
index 39a5bedb07..4e0dc5c48a 100644
--- a/go.sum
+++ b/go.sum
@@ -2157,13 +2157,8 @@ github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-<<<<<<< 9506c3ca65 (Merge pull request #5993 from onflow/bastian/update-atree-inlining-cadence-v1.0-7)
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 h1:ezvc57d1DskazSzsraHlUZsVyOIS6VoZFBheW3eqCeU=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
-=======
-github.com/onflow/cadence v1.0.0-preview.32 h1:M4IdYtUt78D33vLegoNtNU4H/PoBy9J8Xk42EiCRkiE=
-github.com/onflow/cadence v1.0.0-preview.32/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
->>>>>>> c504b454e5 (Merge pull request #6029 from onflow/auto-update-onflow-cadence-v1.0.0-preview.32)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 h1:zsbEystTgIOp2RXt+ChFsY36kWkkT5JBe5GEFVNQs/E=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/insecure/go.mod b/insecure/go.mod
remerge CONFLICT (content): Merge conflict in insecure/go.mod
index 305860de4f..359203b299 100644
--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -197,13 +197,8 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-<<<<<<< 9506c3ca65 (Merge pull request #5993 from onflow/bastian/update-atree-inlining-cadence-v1.0-7)
 	github.com/onflow/atree v0.8.0-rc.3 // indirect
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 // indirect
-=======
-	github.com/onflow/atree v0.7.0-rc.2 // indirect
-	github.com/onflow/cadence v1.0.0-preview.32 // indirect
->>>>>>> c504b454e5 (Merge pull request #6029 from onflow/auto-update-onflow-cadence-v1.0.0-preview.32)
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
diff --git a/insecure/go.sum b/insecure/go.sum
remerge CONFLICT (content): Merge conflict in insecure/go.sum
index 58ba69aff4..8150950549 100644
--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2143,13 +2143,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-<<<<<<< 9506c3ca65 (Merge pull request #5993 from onflow/bastian/update-atree-inlining-cadence-v1.0-7)
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 h1:ezvc57d1DskazSzsraHlUZsVyOIS6VoZFBheW3eqCeU=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
-=======
-github.com/onflow/cadence v1.0.0-preview.32 h1:M4IdYtUt78D33vLegoNtNU4H/PoBy9J8Xk42EiCRkiE=
-github.com/onflow/cadence v1.0.0-preview.32/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
->>>>>>> c504b454e5 (Merge pull request #6029 from onflow/auto-update-onflow-cadence-v1.0.0-preview.32)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 h1:zsbEystTgIOp2RXt+ChFsY36kWkkT5JBe5GEFVNQs/E=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/integration/go.mod b/integration/go.mod
remerge CONFLICT (content): Merge conflict in integration/go.mod
index 5bb5c720d2..13f2b41a6a 100644
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,11 +19,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-<<<<<<< 9506c3ca65 (Merge pull request #5993 from onflow/bastian/update-atree-inlining-cadence-v1.0-7)
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30
-=======
-	github.com/onflow/cadence v1.0.0-preview.32
->>>>>>> c504b454e5 (Merge pull request #6029 from onflow/auto-update-onflow-cadence-v1.0.0-preview.32)
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.1.0
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.0.0
diff --git a/integration/go.sum b/integration/go.sum
remerge CONFLICT (content): Merge conflict in integration/go.sum
index 1c3ff9002b..09a136a145 100644
--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2130,13 +2130,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-<<<<<<< 9506c3ca65 (Merge pull request #5993 from onflow/bastian/update-atree-inlining-cadence-v1.0-7)
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30 h1:ezvc57d1DskazSzsraHlUZsVyOIS6VoZFBheW3eqCeU=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.30/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
-=======
-github.com/onflow/cadence v1.0.0-preview.32 h1:M4IdYtUt78D33vLegoNtNU4H/PoBy9J8Xk42EiCRkiE=
-github.com/onflow/cadence v1.0.0-preview.32/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
->>>>>>> c504b454e5 (Merge pull request #6029 from onflow/auto-update-onflow-cadence-v1.0.0-preview.32)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32 h1:zsbEystTgIOp2RXt+ChFsY36kWkkT5JBe5GEFVNQs/E=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.32/go.mod h1:ulmbwFrXnKgqRpY18L1J5irMOerclScfEfAURx2uHFw=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
```

</details>


[c6c0409](https://github.com/onflow/flow-go/pull/6031/commits/c6c04090b96a43b5bfd21925721d096af626def6) shows that https://github.com/onflow/cadence/pull/3386 resolved the issue we saw on the branch