### PR TITLE
v0.33 add util update commit

### DIFF
--- a/cmd/util/cmd/find-inconsistent-result/cmd.go
+++ b/cmd/util/cmd/find-inconsistent-result/cmd.go
@@ -50,10 +50,10 @@ func run(*cobra.Command, []string) {
 func findFirstMismatch(datadir string, startHeight, endHeight uint64) error {
 	fmt.Printf("initializing database\n")
 	headers, results, seals, state, db, err := createStorages(datadir)
-	defer db.Close()
 	if err != nil {
 		return fmt.Errorf("could not create storages: %v", err)
 	}
+	defer db.Close()
 
 	c := &checker{
 		headers: headers,

--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	rollback_executed_height "github.com/onflow/flow-go/cmd/util/cmd/rollback-executed-height/cmd"
 	"github.com/onflow/flow-go/cmd/util/cmd/snapshot"
 	truncate_database "github.com/onflow/flow-go/cmd/util/cmd/truncate-database"
+	update_commitment "github.com/onflow/flow-go/cmd/util/cmd/update-commitment"
 	"github.com/onflow/flow-go/cmd/util/cmd/version"
 )
 
@@ -80,6 +81,7 @@ func addCommands() {
 	rootCmd.AddCommand(export_json_transactions.Cmd)
 	rootCmd.AddCommand(read_hotstuff.RootCmd)
 	rootCmd.AddCommand(find_inconsistent_result.Cmd)
+	rootCmd.AddCommand(update_commitment.Cmd)
 }
 
 func initConfig() {

--- a/cmd/util/cmd/update-commitment/cmd.go
+++ b/cmd/util/cmd/update-commitment/cmd.go
@@ -1,0 +1,127 @@
+package update_commitment
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/cmd/util/cmd/common"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+	storagebadger "github.com/onflow/flow-go/storage/badger"
+)
+
+var (
+	flagDatadir    string
+	flagBlockID    string
+	flagCommitment string
+	flagForceAdd   bool
+)
+
+var Cmd = &cobra.Command{
+	Use:   "update-commitment",
+	Short: "update commitment",
+	Run:   run,
+}
+
+func init() {
+	Cmd.Flags().StringVarP(&flagDatadir, "datadir", "d", "/var/flow/data/protocol", "directory to the badger dababase")
+	_ = Cmd.MarkPersistentFlagRequired("datadir")
+
+	Cmd.Flags().StringVar(&flagBlockID, "block-id", "", "block id")
+	_ = Cmd.MarkPersistentFlagRequired("block-id")
+
+	Cmd.Flags().StringVar(&flagCommitment, "commitment", "", "commitment")
+	_ = Cmd.MarkPersistentFlagRequired("commitment")
+
+	Cmd.Flags().BoolVar(&flagForceAdd, "force", false, "force adding even if it doesn't exist")
+}
+
+func run(*cobra.Command, []string) {
+	err := updateCommitment(flagDatadir, flagBlockID, flagCommitment, flagForceAdd)
+	if err != nil {
+		fmt.Printf("fatal: %v\n", err)
+	}
+}
+
+func updateCommitment(datadir, blockIDStr, commitStr string, force bool) error {
+	log.Info().Msgf("updating commitment for block %s, commitment %s, force %t", blockIDStr, commitStr, force)
+	// validate blockID
+	blockID, err := flow.HexStringToIdentifier(blockIDStr)
+	if err != nil {
+		return fmt.Errorf("invalid block id: %v", err)
+	}
+
+	stateCommitmentBytes, err := hex.DecodeString(commitStr)
+	if err != nil {
+		return fmt.Errorf("cannot get decode the state commitment: %v", err)
+	}
+
+	commit, err := flow.ToStateCommitment(stateCommitmentBytes)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("invalid state commitment length: %v", err)
+		}
+
+		log.Warn().Msgf("commitment not found for block %s", blockIDStr)
+
+		if !force {
+			return fmt.Errorf("commitment not found and force flag not set")
+		}
+	}
+
+	commits, db, err := createStorages(datadir)
+	defer db.Close()
+	if err != nil {
+		return fmt.Errorf("could not create storages: %v", err)
+	}
+
+	commitToRemove, err := commits.ByBlockID(blockID)
+	if err != nil {
+		return fmt.Errorf("could not get commit by block id: %v", err)
+	}
+
+	if commitToRemove == commit {
+		return fmt.Errorf("commitment to be updated is identical to the current one")
+	}
+
+	log.Info().Msgf("found commitment to be removed: %x", commitToRemove)
+
+	writeBatch := storagebadger.NewBatch(db)
+	err = commits.BatchRemoveByBlockID(blockID, writeBatch)
+	if err != nil {
+		return fmt.Errorf("could not batch remove commit by block id: %v", err)
+	}
+
+	err = writeBatch.Flush()
+	if err != nil {
+		return fmt.Errorf("could not flush write batch: %v", err)
+	}
+
+	log.Info().Msgf("commitment removed for block %s", blockIDStr)
+
+	log.Info().Msgf("storing new commitment: %x", commit)
+
+	err = commits.Store(blockID, commit)
+	if err != nil {
+		return fmt.Errorf("could not store commit: %v", err)
+	}
+
+	log.Info().Msgf("commitment successfully stored for block %s", blockIDStr)
+
+	return nil
+}
+
+func createStorages(dir string) (storage.Commits, *badger.DB, error) {
+	db := common.InitStorage(dir)
+	if db == nil {
+		return nil, nil, fmt.Errorf("could not initialize db")
+	}
+
+	storages := common.InitStorages(db)
+	return storages.Commits, db, nil
+}

--- a/cmd/util/cmd/update-commitment/cmd.go
+++ b/cmd/util/cmd/update-commitment/cmd.go
@@ -75,10 +75,10 @@ func updateCommitment(datadir, blockIDStr, commitStr string, force bool) error {
 	}
 
 	commits, db, err := createStorages(datadir)
-	defer db.Close()
 	if err != nil {
 		return fmt.Errorf("could not create storages: %v", err)
 	}
+	defer db.Close()	
 
 	commitToRemove, err := commits.ByBlockID(blockID)
 	if err != nil {


### PR DESCRIPTION
Adding a util command to update commitment by block ID.

This is useful for running tests involve state migration. After the state migration, the statecommitment is changed. Using the update commitment tool allows us to continue re-executing transactions.

For instance, testing atree-inlining by rolling back executed height, migrate the state with atree-inlining feature and update commitment to continue re-executing the blocks.