### PR TITLE
Use Cadence func to decide which testnet data to fix during atree migration

### DIFF
--- a/cmd/util/ledger/migrations/fix_broken_data_migration.go
+++ b/cmd/util/ledger/migrations/fix_broken_data_migration.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/onflow/atree"
 
+	"github.com/onflow/cadence/migrations"
 	"github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
@@ -89,10 +90,8 @@ func (m *FixSlabsWithBrokenReferencesMigration) MigrateAccount(
 	}
 
 	// Fix broken references
-	fixedStorageIDs, skippedStorageIDs, err := storage.FixLoadedBrokenReferences(func(old atree.Value) bool {
-		// TODO: Cadence may need to export functions to check type info, etc.
-		return true
-	})
+	fixedStorageIDs, skippedStorageIDs, err :=
+		storage.FixLoadedBrokenReferences(migrations.ShouldFixBrokenCompositeKeyedDictionary)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.8.0-rc.3
-	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719
+	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1

--- a/go.sum
+++ b/go.sum
@@ -1351,8 +1351,8 @@ github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719 h1:A2Z8OK5NtJ4n6NRK2Oz65z8y0gRTcTslKG1vQy+wwck=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719/go.mod h1:/qhvKrT4aNmq/cy5ngna493EljQvonQBYjyrbOELHUk=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6 h1:6TbpdIXayQUFsizmAGZEnDEI5+Yu/8wnQPU7LFCUaNA=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6/go.mod h1:/qhvKrT4aNmq/cy5ngna493EljQvonQBYjyrbOELHUk=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow v0.3.4 h1:FXUWVdYB90f/rjNcY0Owo30gL790tiYff9Pb/sycXYE=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -204,7 +204,7 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.8.0-rc.3 // indirect
-	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719 // indirect
+	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -1316,8 +1316,8 @@ github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719 h1:A2Z8OK5NtJ4n6NRK2Oz65z8y0gRTcTslKG1vQy+wwck=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719/go.mod h1:/qhvKrT4aNmq/cy5ngna493EljQvonQBYjyrbOELHUk=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6 h1:6TbpdIXayQUFsizmAGZEnDEI5+Yu/8wnQPU7LFCUaNA=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6/go.mod h1:/qhvKrT4aNmq/cy5ngna493EljQvonQBYjyrbOELHUk=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1 h1:xF5wHug6H8vKfz7p1LYy9jck6eD9K1HLjTdi6o4kg1k=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-ipfs-blockstore v1.3.0
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719
+	github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v0.15.1

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1406,8 +1406,8 @@ github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719 h1:A2Z8OK5NtJ4n6NRK2Oz65z8y0gRTcTslKG1vQy+wwck=
-github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240521221904-9615ee937719/go.mod h1:/qhvKrT4aNmq/cy5ngna493EljQvonQBYjyrbOELHUk=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6 h1:6TbpdIXayQUFsizmAGZEnDEI5+Yu/8wnQPU7LFCUaNA=
+github.com/onflow/cadence v0.42.11-atree-register-inlining.2.0.20240604235655-945f0e65c1e6/go.mod h1:/qhvKrT4aNmq/cy5ngna493EljQvonQBYjyrbOELHUk=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.15.1 h1:xF5wHug6H8vKfz7p1LYy9jck6eD9K1HLjTdi6o4kg1k=


### PR DESCRIPTION
Currently, all broken testnet data is fixed during atree migration because the default predicate function is passed from flow-go to atree.

Although we want to fix all broken testnet data, we also want to avoid accidentally fixing and not finding out about new broken testnet data.

This PR passes a function provided by Cadence so atree can call it to determine if specific broken data should be fixed during migration.  This allows us to avoid accidentally fixing broken data that we did not know about.