### PR TITLE
Only validate root snapshot when loading file

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1330,6 +1330,13 @@ func (fnb *FlowNodeBuilder) initState() error {
 				return fmt.Errorf("failed to read protocol snapshot from disk: %w", err)
 			}
 		}
+		// apply any extra validation steps to the root snapshot prior to bootstrapping
+		if fnb.extraRootSnapshotCheck != nil {
+			err = fnb.extraRootSnapshotCheck(rootSnapshot)
+			if err != nil {
+				return fmt.Errorf("failed validate root snapshot from disk: %w", err)
+			}
+		}
 		// set root snapshot fields
 		if err := fnb.setRootSnapshot(rootSnapshot); err != nil {
 			return err
@@ -1410,14 +1417,6 @@ func (fnb *FlowNodeBuilder) setRootSnapshot(rootSnapshot protocol.Snapshot) erro
 	err = badgerState.IsValidRootSnapshotQCs(rootSnapshot)
 	if err != nil {
 		return fmt.Errorf("failed to validate root snapshot QCs: %w", err)
-	}
-
-	// perform extra checks requested by specific node types
-	if fnb.extraRootSnapshotCheck != nil {
-		err = fnb.extraRootSnapshotCheck(rootSnapshot)
-		if err != nil {
-			return fmt.Errorf("failed to perform extra checks on root snapshot: %w", err)
-		}
 	}
 
 	fnb.RootSnapshot = rootSnapshot


### PR DESCRIPTION
Currently, we validate the root snapshot every time we startup, meaning that for all startups after the first, we are validating the same thing that we wrote to disk.

This causes a problem on v0.33, because some parts of the software expect a sealing segment of length 590+, and others expect a sealing segment of length 600+. In particular, this can cause a node to accept a root snapshot file when bootstrapping, then reject the root snapshot DB-backed object on subsequent startups, because the DB-backed snapshot is returning an invalid sealing segment.