### PR TITLE
[EVM] Take into account gas refunds in `EVM.dryRun`

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -234,7 +234,17 @@ func (bl *BlockView) DryRunTransaction(
 	msg.SkipAccountChecks = true
 
 	// return without commiting the state
-	return proc.run(msg, tx.Hash(), 0, tx.Type())
+	txResult, err := proc.run(msg, tx.Hash(), 0, tx.Type())
+	if txResult.VMError == nil && txResult.ValidationError == nil {
+		// Adding `gethParams.SstoreSentryGasEIP2200` is needed for this condition:
+		// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
+		txResult.GasConsumed += gethParams.SstoreSentryGasEIP2200
+		// Take into account any gas refunds, which are calculated only after
+		// transaction execution.
+		txResult.GasConsumed += txResult.GasRefund
+	}
+
+	return txResult, err
 }
 
 func (bl *BlockView) newProcedure() (*procedure, error) {
@@ -522,6 +532,7 @@ func (proc *procedure) run(
 	// if prechecks are passed, the exec result won't be nil
 	if execResult != nil {
 		res.GasConsumed = execResult.UsedGas
+		res.GasRefund = proc.state.GetRefund()
 		res.Index = uint16(txIndex)
 		// we need to capture the returned value no matter the status
 		// if the tx is reverted the error message is returned as returned value

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -235,7 +235,7 @@ func (bl *BlockView) DryRunTransaction(
 
 	// return without commiting the state
 	txResult, err := proc.run(msg, tx.Hash(), 0, tx.Type())
-	if txResult.VMError == nil && txResult.ValidationError == nil {
+	if txResult.Successful() {
 		// Adding `gethParams.SstoreSentryGasEIP2200` is needed for this condition:
 		// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
 		txResult.GasConsumed += gethParams.SstoreSentryGasEIP2200

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -96,6 +96,11 @@ func (res *Result) Failed() bool {
 	return res.VMError != nil
 }
 
+// Successful returns true if transaction has been executed without any errors
+func (res *Result) Successful() bool {
+	return !res.Failed() && !res.Invalid()
+}
+
 // SetValidationError sets the validation error
 // and also sets the gas used to the fixed invalid gas usage
 func (res *Result) SetValidationError(err error) {

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -39,6 +39,7 @@ type ResultSummary struct {
 	ErrorCode               ErrorCode
 	ErrorMessage            string
 	GasConsumed             uint64
+	GasRefund               uint64
 	DeployedContractAddress *Address
 	ReturnedData            Data
 }
@@ -71,6 +72,8 @@ type Result struct {
 	TxType uint8
 	// total gas consumed during an opeartion
 	GasConsumed uint64
+	// total gas refunds after transaction execution
+	GasRefund uint64
 	// the address where the contract is deployed (if any)
 	DeployedContractAddress *Address
 	// returned data from a function call
@@ -142,6 +145,7 @@ func (res *Result) Receipt() *gethTypes.Receipt {
 func (res *Result) ResultSummary() *ResultSummary {
 	rs := &ResultSummary{
 		GasConsumed:             res.GasConsumed,
+		GasRefund:               res.GasRefund,
 		DeployedContractAddress: res.DeployedContractAddress,
 		ReturnedData:            res.ReturnedData,
 		Status:                  StatusSuccessful,


### PR DESCRIPTION
To correctly compute the gas estimation with `EVM.dryRun`, we need to add any gas refunds to the used gas.
Any potential gas refunds are required during transaction execution, and only after they are refunded to the transaction author.