### PR TITLE
[Flaky Tests] Testing adjusting safety threshold and block time variables

### DIFF
--- a/integration/tests/epochs/base_suite.go
+++ b/integration/tests/epochs/base_suite.go
@@ -50,9 +50,8 @@ type BaseSuite struct {
 
 // SetupTest is run automatically by the testing framework before each test case.
 func (s *BaseSuite) SetupTest() {
-	// If unset, use default value 100ms
 	if s.ConsensusProposalDuration == 0 {
-		s.ConsensusProposalDuration = time.Millisecond * 100
+		s.ConsensusProposalDuration = time.Millisecond * 250
 	}
 
 	minEpochLength := s.StakingAuctionLen + s.DKGPhaseLen*3 + 20

--- a/integration/tests/epochs/cohort2/epoch_join_and_leave_sn_test.go
+++ b/integration/tests/epochs/cohort2/epoch_join_and_leave_sn_test.go
@@ -2,7 +2,6 @@ package cohort2
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -19,11 +18,6 @@ type EpochJoinAndLeaveSNSuite struct {
 }
 
 func (s *EpochJoinAndLeaveSNSuite) SetupTest() {
-	// slow down the block rate. This is needed since the crypto module
-	// update provides faster BLS operations.
-	// TODO: fix the access integration test logic to function without slowing down
-	// the block rate
-	s.ConsensusProposalDuration = time.Millisecond * 250
 	s.DynamicEpochTransitionSuite.SetupTest()
 }
 

--- a/integration/tests/epochs/cohort2/epoch_join_and_leave_vn_test.go
+++ b/integration/tests/epochs/cohort2/epoch_join_and_leave_vn_test.go
@@ -2,7 +2,6 @@ package cohort2
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -21,8 +20,6 @@ type EpochJoinAndLeaveVNSuite struct {
 func (s *EpochJoinAndLeaveVNSuite) SetupTest() {
 	// require approvals for seals to verify that the joining VN is producing valid seals in the second epoch
 	s.RequiredSealApprovals = 1
-	// slow down consensus, as sealing tends to lag behind
-	s.ConsensusProposalDuration = time.Millisecond * 250
 	// increase epoch length to account for greater sealing lag due to above
 	// NOTE: this value is set fairly aggressively to ensure shorter test times.
 	// If flakiness due to failure to complete staking operations in time is observed,


### PR DESCRIPTION
Use a uniform 250ms block time target for other epoch tests. 

Ran 10 CI runs against https://github.com/onflow/flow-go/pull/6061/commits/058e3c4e76f292c060957b7a6111fa2a25f3dc57 with 0 epoch test failures. 