### PR TITLE
Fix Cadence 1.0 migration missing PathCapabilityStorageDomain

### DIFF
--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -19,6 +19,7 @@ var AllStorageMapDomains = []string{
 	runtime.StorageDomainContract,
 	stdlib.InboxStorageDomain,
 	stdlib.CapabilityControllerStorageDomain,
+	stdlib.PathCapabilityStorageDomain,
 }
 
 var allStorageMapDomainsSet = map[string]struct{}{}


### PR DESCRIPTION
Closes #6069

Currently, migrations don't include PathCapabilityStorageDomain during traversal and storage health check.  This causes payloads in the domain to not be migrated.

This affects atree migration and maybe also Cadence 1.0 migration.

This PR adds PathCapabilityStorageDomain to migrations.