### PR TITLE
Fix migrations missing PathCapabilityStorageDomain in feature/atree-inlining-cadence-v0.42

### DIFF
--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -74,6 +74,7 @@ var allStorageMapDomains = []string{
 	runtime.StorageDomainContract,
 	stdlib.InboxStorageDomain,
 	stdlib.CapabilityControllerStorageDomain,
+	stdlib.PathCapabilityStorageDomain,
 }
 
 var allStorageMapDomainsSet = map[string]struct{}{}


### PR DESCRIPTION
Closes https://github.com/onflow/flow-go/issues/6069

Currently, migrations don't include PathCapabilityStorageDomain during traversal and storage health check. This causes payloads in the domain to not be migrated.

This affects atree migration and maybe also Cadence 1.0 migration.  Equivalent fix in master branch is:
- #6070 

This PR adds PathCapabilityStorageDomain to migrations.