### PR TITLE
Fix atree migration not migrating payloads from AccountCapabilityStorageDomain (feature/atree-inlining-cadence-v0.42)

### DIFF
--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -75,6 +75,7 @@ var allStorageMapDomains = []string{
 	stdlib.InboxStorageDomain,
 	stdlib.CapabilityControllerStorageDomain,
 	stdlib.PathCapabilityStorageDomain,
+	stdlib.AccountCapabilityStorageDomain,
 }
 
 var allStorageMapDomainsSet = map[string]struct{}{}


### PR DESCRIPTION
Closes #6072 

Currently, migrations are not migrating payloads in account capability domain.

This affects atree migration and maybe also Cadence 1.0 migration. Equivalent  PR for Cadence 1.0 is:
- #6074

This PR adds `AccountCapabilityStorageDomain` to migrations so their payloads can get migrated.