### PR TITLE
Fix migrations missing AccountCapabilityStorageDomain

### DIFF
--- a/cmd/util/ledger/migrations/utils.go
+++ b/cmd/util/ledger/migrations/utils.go
@@ -20,6 +20,7 @@ var AllStorageMapDomains = []string{
 	stdlib.InboxStorageDomain,
 	stdlib.CapabilityControllerStorageDomain,
 	stdlib.PathCapabilityStorageDomain,
+	stdlib.AccountCapabilityStorageDomain,
 }
 
 var allStorageMapDomainsSet = map[string]struct{}{}


### PR DESCRIPTION
Closes #6072 

Currently, migrations don't include AccountCapabilityStorageDomain during traversal and storage health check.  This causes payloads in the domain to not be migrated.

This affects atree migration and maybe also Cadence 1.0 migration.

This commit adds AccountCapabilityStorageDomain to migrations.