### PR TITLE
[CI] Remove cruise control overrides in Access integration tests

### DIFF
--- a/integration/tests/access/cohort3/grpc_state_stream_test.go
+++ b/integration/tests/access/cohort3/grpc_state_stream_test.go
@@ -114,7 +114,6 @@ func (s *GrpcStateStreamSuite) SetupTest() {
 		testnet.AsGhost())
 
 	consensusConfigs := []func(config *testnet.NodeConfig){
-		testnet.WithAdditionalFlag("--cruise-ctl-fallback-proposal-duration=400ms"),
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", 1)),
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", 1)),
 		testnet.WithLogLevel(zerolog.FatalLevel),

--- a/integration/tests/access/cohort3/grpc_streaming_blocks_test.go
+++ b/integration/tests/access/cohort3/grpc_streaming_blocks_test.go
@@ -74,7 +74,6 @@ func (s *GrpcBlocksStreamSuite) SetupTest() {
 	)
 
 	consensusConfigs := []func(config *testnet.NodeConfig){
-		testnet.WithAdditionalFlag("--cruise-ctl-fallback-proposal-duration=400ms"),
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-verification-seal-approvals=%d", 1)),
 		testnet.WithAdditionalFlag(fmt.Sprintf("--required-construction-seal-approvals=%d", 1)),
 		testnet.WithLogLevel(zerolog.FatalLevel),


### PR DESCRIPTION
Remove custom cruise control overrides in Access integration tests. These were copied from old tests that now have different values for this setting. Using default to see if that helps with flakiness, or at least don't add more.