### PR TITLE
Add util for finding trie root hash

### DIFF
--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -25,9 +25,18 @@ var (
 	flagOutputDir         string
 )
 
+// find trie root hash from the wal files.
+// useful for state extraction and rolling back executed height.
+// for instance, when extracting state for a target height, it requires the wal files
+// has the trie root hash of the target block as the latest few records. If not the case,
+// then it is necessary to trim the wal files to the last record with the target trie root hash.
+// in order to do that, this command can be used to find the trie root hash in the wal files,
+// and copy the wal that contains the trie root hash to a new directory and trim it to
+// have the target trie root hash as the last record.
+// after that, the new wal file can be used to extract the state for the target height.
 var Cmd = &cobra.Command{
 	Use:   "find-trie-root",
-	Short: "find trie root",
+	Short: "find trie root hash from the wal files",
 	Run:   run,
 }
 

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -148,7 +148,7 @@ func searchRootHashInSegments(
 
 		switch operation {
 		case wal.WALUpdate:
-			if rootHash == expectedHash {
+			if rootHash.Equals(expectedHash) {
 				log.Info().Msgf("found expected trie root hash %x", rootHash)
 				return reader.Segment(), reader.Offset(), nil
 			}
@@ -205,7 +205,7 @@ func copyWAL(dir, outputDir string, segment int, expectedRoot ledger.RootHash) e
 
 		switch operation {
 		case wal.WALUpdate:
-			if rootHash == expectedRoot {
+			if rootHash.Equals(expectedRoot) {
 				log.Info().Msgf("found expected trie root hash %x, finish writing", rootHash)
 				return nil
 			}

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -150,7 +150,7 @@ func searchRootHashInSegments(
 		switch operation {
 		case wal.WALUpdate:
 			if rootHash.Equals(expectedHash) {
-				log.Info().Msgf("found expected trie root hash %x", rootHash)
+				log.Info().Msgf("found expected trie root hash %v", rootHash)
 				return reader.Segment(), reader.Offset(), nil
 			}
 		default:
@@ -207,7 +207,7 @@ func copyWAL(dir, outputDir string, segment int, expectedRoot ledger.RootHash) e
 		switch operation {
 		case wal.WALUpdate:
 			if rootHash.Equals(expectedRoot) {
-				log.Info().Msgf("found expected trie root hash %x, finish writing", rootHash)
+				log.Info().Msgf("found expected trie root hash %v, finish writing", rootHash)
 				return nil
 			}
 		default:

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -1,0 +1,151 @@
+package find_trie_root
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+
+	prometheusWAL "github.com/onflow/wal/wal"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
+	"github.com/onflow/flow-go/ledger/complete/wal"
+)
+
+var (
+	flagExecutionStateDir string
+	flagRootHash          string
+	flagFrom              int
+	flagTo                int
+)
+
+var Cmd = &cobra.Command{
+	Use:   "find-trie-root",
+	Short: "find trie root",
+	Run:   run,
+}
+
+func init() {
+	Cmd.Flags().StringVarP(&flagExecutionStateDir, "execution-state-dir", "e", "/var/flow/data/execution", "directory to the execution state")
+	_ = Cmd.MarkFlagRequired("execution-state-dir")
+
+	Cmd.Flags().StringVar(&flagRootHash, "root-hash", "",
+		"ledger root hash (hex-encoded, 64 characters)")
+	_ = Cmd.MarkFlagRequired("root-hash")
+
+	Cmd.Flags().IntVar(&flagFrom, "from", 0, "from segment")
+	Cmd.Flags().IntVar(&flagTo, "to", math.MaxInt32, "to segment")
+}
+
+func run(*cobra.Command, []string) {
+	rootHash, err := parseInput(flagRootHash)
+	if err != nil {
+		log.Fatal().Err(err).Msg("cannot parse input")
+	}
+
+	segment, offset, err := searchRootHashInSegments(rootHash, flagExecutionStateDir, flagFrom, flagTo)
+	if err != nil {
+		log.Fatal().Err(err).Msg("cannot find root hash in segments")
+	}
+	log.Info().Msgf("found root hash in segment %d at offset %d", segment, offset)
+}
+
+func parseInput(rootHashStr string) (ledger.RootHash, error) {
+	rootHashBytes, err := hex.DecodeString(rootHashStr)
+	if err != nil {
+		return ledger.RootHash(hash.DummyHash), fmt.Errorf("cannot decode root hash: %w", err)
+	}
+	rootHash, err := ledger.ToRootHash(rootHashBytes)
+	if err != nil {
+		return ledger.RootHash(hash.DummyHash), fmt.Errorf("invalid root hash: %w", err)
+	}
+	return rootHash, nil
+}
+
+func searchRootHashInSegments(
+	expectedHash ledger.RootHash,
+	dir string,
+	wantFrom, wantTo int,
+) (int, int64, error) {
+	log := zerolog.Logger{}
+	w, err := prometheusWAL.NewSize(log, prometheus.DefaultRegisterer, dir, wal.SegmentSize, false)
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot create WAL: %w", err)
+	}
+
+	from, to, err := prometheusWAL.Segments(dir)
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot get segments: %w", err)
+	}
+
+	if wantFrom > to {
+		return 0, 0, fmt.Errorf("from segment %d is greater than the last segment %d", wantFrom, to)
+	}
+
+	if wantTo < from {
+		return 0, 0, fmt.Errorf("to segment %d is less than the first segment %d", wantTo, from)
+	}
+
+	if wantFrom > from {
+		from = wantFrom
+	}
+
+	if wantTo < to {
+		to = wantTo
+	}
+
+	log.Info().
+		Str("dir", dir).
+		Int("from", from).
+		Int("to", to).
+		Int("want-from", wantFrom).
+		Int("want-to", wantTo).
+		Msgf("searching for trie root hash %x in segments [%d,%d]", expectedHash, wantFrom, wantTo)
+
+	sr, err := prometheusWAL.NewSegmentsRangeReader(log, prometheusWAL.SegmentRange{
+		Dir:   w.Dir(),
+		First: from,
+		Last:  to,
+	})
+
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot create WAL segments reader: %w", err)
+	}
+
+	defer sr.Close()
+
+	reader := prometheusWAL.NewReader(sr)
+
+	for reader.Next() {
+		record := reader.Record()
+		operation, rootHash, _, err := wal.Decode(record)
+		if err != nil {
+			return 0, 0, fmt.Errorf("cannot decode LedgerWAL record: %w", err)
+		}
+
+		log.Debug().
+			Uint8("operation", uint8(operation)).
+			Str("root-hash", rootHash.String()).
+			Msgf("read LedgerWAL record")
+
+		switch operation {
+		case wal.WALUpdate:
+			if rootHash == expectedHash {
+				log.Info().Msgf("found expected trie root hash %x", rootHash)
+				return reader.Segment(), reader.Offset(), nil
+			}
+		default:
+		}
+
+		err = reader.Err()
+		if err != nil {
+			return 0, 0, fmt.Errorf("cannot read LedgerWAL: %w", err)
+		}
+	}
+
+	return 0, 0, fmt.Errorf("finish reading all segment files from %d to %d, but not found", from, to)
+}

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -166,14 +166,14 @@ func searchRootHashInSegments(
 }
 
 func copyWAL(dir, outputDir string, segment int, expectedRoot ledger.RootHash) error {
-	writer, err := prometheusWAL.NewSize(log.Logger, prometheus.DefaultRegisterer, outputDir, wal.SegmentSize, false)
+	writer, err := prometheusWAL.NewSize(log.Logger, nil, outputDir, wal.SegmentSize, false)
 	if err != nil {
 		return fmt.Errorf("cannot create writer WAL: %w", err)
 	}
 
 	defer writer.Close()
 
-	w, err := prometheusWAL.NewSize(log.Logger, prometheus.DefaultRegisterer, dir, wal.SegmentSize, false)
+	w, err := prometheusWAL.NewSize(log.Logger, nil, dir, wal.SegmentSize, false)
 	if err != nil {
 		return fmt.Errorf("cannot create WAL: %w", err)
 	}

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -119,7 +119,7 @@ func searchRootHashInSegments(
 		Int("to", to).
 		Int("want-from", wantFrom).
 		Int("want-to", wantTo).
-		Msgf("searching for trie root hash %x in segments [%d,%d]", expectedHash, wantFrom, wantTo)
+		Msgf("searching for trie root hash %v in segments [%d,%d]", expectedHash, wantFrom, wantTo)
 
 	sr, err := prometheusWAL.NewSegmentsRangeReader(lg, prometheusWAL.SegmentRange{
 		Dir:   w.Dir(),

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"os"
 
 	prometheusWAL "github.com/onflow/wal/wal"
 	"github.com/prometheus/client_golang/prometheus"
@@ -85,8 +86,8 @@ func searchRootHashInSegments(
 	dir string,
 	wantFrom, wantTo int,
 ) (int, int64, error) {
-	log := zerolog.Logger{}
-	w, err := prometheusWAL.NewSize(log, prometheus.DefaultRegisterer, dir, wal.SegmentSize, false)
+	lg := zerolog.New(os.Stderr).With().Timestamp().Logger()
+	w, err := prometheusWAL.NewSize(lg, prometheus.DefaultRegisterer, dir, wal.SegmentSize, false)
 	if err != nil {
 		return 0, 0, fmt.Errorf("cannot create WAL: %w", err)
 	}
@@ -120,7 +121,7 @@ func searchRootHashInSegments(
 		Int("want-to", wantTo).
 		Msgf("searching for trie root hash %x in segments [%d,%d]", expectedHash, wantFrom, wantTo)
 
-	sr, err := prometheusWAL.NewSegmentsRangeReader(log, prometheusWAL.SegmentRange{
+	sr, err := prometheusWAL.NewSegmentsRangeReader(lg, prometheusWAL.SegmentRange{
 		Dir:   w.Dir(),
 		First: from,
 		Last:  to,

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -214,7 +214,9 @@ func findRootHashAndCreateTrimmed(dir string, segment int, expectedRoot ledger.R
 		return "", fmt.Errorf("cannot create temporary folder: %w", err)
 	}
 
-	newSegmentFile := prometheusWAL.SegmentName(tmpFolder, segment)
+	// the new segment file will be created in the temporary folder
+	// and it's always 00000000
+	newSegmentFile := prometheusWAL.SegmentName(tmpFolder, 0)
 
 	log.Info().Msgf("writing new segment file to %v", newSegmentFile)
 

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -21,6 +21,7 @@ var (
 	flagRootHash          string
 	flagFrom              int
 	flagTo                int
+	flagOutputDir         string
 )
 
 var Cmd = &cobra.Command{
@@ -30,7 +31,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.Flags().StringVarP(&flagExecutionStateDir, "execution-state-dir", "e", "/var/flow/data/execution", "directory to the execution state")
+	Cmd.Flags().StringVar(&flagExecutionStateDir, "execution-state-dir", "/var/flow/data/execution", "directory to the execution state")
 	_ = Cmd.MarkFlagRequired("execution-state-dir")
 
 	Cmd.Flags().StringVar(&flagRootHash, "root-hash", "",
@@ -39,6 +40,8 @@ func init() {
 
 	Cmd.Flags().IntVar(&flagFrom, "from", 0, "from segment")
 	Cmd.Flags().IntVar(&flagTo, "to", math.MaxInt32, "to segment")
+
+	Cmd.Flags().StringVar(&flagOutputDir, "output-dir", "", "output directory")
 }
 
 func run(*cobra.Command, []string) {
@@ -52,6 +55,17 @@ func run(*cobra.Command, []string) {
 		log.Fatal().Err(err).Msg("cannot find root hash in segments")
 	}
 	log.Info().Msgf("found root hash in segment %d at offset %d", segment, offset)
+
+	if len(flagOutputDir) == 0 {
+		return
+	}
+
+	err = copyWAL(flagExecutionStateDir, flagOutputDir, segment, rootHash)
+	if err != nil {
+		log.Fatal().Err(err).Msg("cannot copy WAL")
+	}
+
+	log.Info().Msgf("copied WAL to %s", flagOutputDir)
 }
 
 func parseInput(rootHashStr string) (ledger.RootHash, error) {
@@ -148,4 +162,61 @@ func searchRootHashInSegments(
 	}
 
 	return 0, 0, fmt.Errorf("finish reading all segment files from %d to %d, but not found", from, to)
+}
+
+func copyWAL(dir, outputDir string, segment int, expectedRoot ledger.RootHash) error {
+	writer, err := prometheusWAL.NewSize(log.Logger, prometheus.DefaultRegisterer, outputDir, wal.SegmentSize, false)
+	if err != nil {
+		return fmt.Errorf("cannot create writer WAL: %w", err)
+	}
+
+	defer writer.Close()
+
+	w, err := prometheusWAL.NewSize(log.Logger, prometheus.DefaultRegisterer, dir, wal.SegmentSize, false)
+	if err != nil {
+		return fmt.Errorf("cannot create WAL: %w", err)
+	}
+
+	sr, err := prometheusWAL.NewSegmentsRangeReader(log.Logger, prometheusWAL.SegmentRange{
+		Dir:   w.Dir(),
+		First: segment,
+		Last:  segment,
+	})
+	if err != nil {
+		return fmt.Errorf("cannot create WAL segments reader: %w", err)
+	}
+
+	defer sr.Close()
+
+	reader := prometheusWAL.NewReader(sr)
+
+	for reader.Next() {
+		record := reader.Record()
+		operation, rootHash, update, err := wal.Decode(record)
+		if err != nil {
+			return fmt.Errorf("cannot decode LedgerWAL record: %w", err)
+		}
+
+		bytes := wal.EncodeUpdate(update)
+		_, err = writer.Log(bytes)
+		if err != nil {
+			return fmt.Errorf("cannot write LedgerWAL record: %w", err)
+		}
+
+		switch operation {
+		case wal.WALUpdate:
+			if rootHash == expectedRoot {
+				log.Info().Msgf("found expected trie root hash %x, finish writing", rootHash)
+				return nil
+			}
+		default:
+		}
+
+		err = reader.Err()
+		if err != nil {
+			return fmt.Errorf("cannot read LedgerWAL: %w", err)
+		}
+	}
+
+	return fmt.Errorf("finish reading all segment files from %d to %d, but not found", segment, segment)
 }

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -304,6 +304,8 @@ func checkFolderIsEmpty(folderPath string) (bool, error) {
 	info, err := os.Stat(folderPath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			log.Info().Msgf("folder %v does not exist, creating the folder", folderPath)
+
 			// create the folder if not exist
 			err = os.MkdirAll(folderPath, os.ModePerm)
 			if err != nil {

--- a/cmd/util/cmd/find-trie-root/cmd.go
+++ b/cmd/util/cmd/find-trie-root/cmd.go
@@ -195,15 +195,12 @@ func searchRootHashInSegments(
 			return 0, 0, fmt.Errorf("cannot decode LedgerWAL record: %w", err)
 		}
 
-		lg = lg.With().
-			Uint8("operation", uint8(operation)).
-			Logger()
-
 		switch operation {
 		case wal.WALUpdate:
 			rootHash := update.RootHash
 
-			lg.Debug().
+			log.Debug().
+				Uint8("operation", uint8(operation)).
 				Str("root-hash", rootHash.String()).
 				Msg("found WALUpdate")
 

--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	ledger_json_exporter "github.com/onflow/flow-go/cmd/util/cmd/export-json-execution-state"
 	export_json_transactions "github.com/onflow/flow-go/cmd/util/cmd/export-json-transactions"
 	find_inconsistent_result "github.com/onflow/flow-go/cmd/util/cmd/find-inconsistent-result"
+	find_trie_root "github.com/onflow/flow-go/cmd/util/cmd/find-trie-root"
 	read_badger "github.com/onflow/flow-go/cmd/util/cmd/read-badger/cmd"
 	read_execution_state "github.com/onflow/flow-go/cmd/util/cmd/read-execution-state"
 	read_hotstuff "github.com/onflow/flow-go/cmd/util/cmd/read-hotstuff/cmd"
@@ -81,6 +82,7 @@ func addCommands() {
 	rootCmd.AddCommand(export_json_transactions.Cmd)
 	rootCmd.AddCommand(read_hotstuff.RootCmd)
 	rootCmd.AddCommand(find_inconsistent_result.Cmd)
+	rootCmd.AddCommand(find_trie_root.Cmd)
 	rootCmd.AddCommand(update_commitment.Cmd)
 }
 

--- a/ledger/complete/wal/encoding.go
+++ b/ledger/complete/wal/encoding.go
@@ -51,6 +51,10 @@ func EncodeDelete(rootHash ledger.RootHash) []byte {
 	return buf
 }
 
+// Decode decodes the given data into a WAL operation, root hash and trie update.
+// It returns (WALDelete, rootHash, nil, nil) if the operation is WALDelete.
+// It returns (WALUpdate, hash.DummyHash, update, nil) if the operation is WALUpdate.
+// To read the root hash of the trie update, use update.RootHash.
 func Decode(data []byte) (operation WALOperation, rootHash ledger.RootHash, update *ledger.TrieUpdate, err error) {
 	if len(data) < 4 { // 1 byte op + 2 size + actual data = 4 minimum
 		err = fmt.Errorf("data corrupted, too short to represent operation - hexencoded data: %x", data)
@@ -61,7 +65,6 @@ func Decode(data []byte) (operation WALOperation, rootHash ledger.RootHash, upda
 	switch operation {
 	case WALUpdate:
 		update, err = ledger.DecodeTrieUpdate(data[1:])
-		rootHash = update.RootHash
 		return
 	case WALDelete:
 		var rootHashBytes []byte

--- a/ledger/complete/wal/encoding.go
+++ b/ledger/complete/wal/encoding.go
@@ -61,6 +61,7 @@ func Decode(data []byte) (operation WALOperation, rootHash ledger.RootHash, upda
 	switch operation {
 	case WALUpdate:
 		update, err = ledger.DecodeTrieUpdate(data[1:])
+		rootHash = update.RootHash
 		return
 	case WALDelete:
 		var rootHashBytes []byte

--- a/ledger/complete/wal/encoding_test.go
+++ b/ledger/complete/wal/encoding_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/ledger/common/hash"
 	"github.com/onflow/flow-go/ledger/common/testutils"
 	realWAL "github.com/onflow/flow-go/ledger/complete/wal"
 )
@@ -43,7 +44,7 @@ func TestUpdate(t *testing.T) {
 		operation, stateCommitment, up, err := realWAL.Decode(data)
 		require.NoError(t, err)
 		assert.Equal(t, realWAL.WALUpdate, operation)
-		assert.Equal(t, stateCommitment, ledger.RootHash(rootHash))
+		assert.Equal(t, stateCommitment, ledger.RootHash(hash.DummyHash))
 		assert.Equal(t, update, up)
 	})
 }

--- a/ledger/complete/wal/encoding_test.go
+++ b/ledger/complete/wal/encoding_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/ledger"
-	"github.com/onflow/flow-go/ledger/common/hash"
 	"github.com/onflow/flow-go/ledger/common/testutils"
 	realWAL "github.com/onflow/flow-go/ledger/complete/wal"
 )
@@ -44,7 +43,7 @@ func TestUpdate(t *testing.T) {
 		operation, stateCommitment, up, err := realWAL.Decode(data)
 		require.NoError(t, err)
 		assert.Equal(t, realWAL.WALUpdate, operation)
-		assert.Equal(t, stateCommitment, ledger.RootHash(hash.DummyHash))
+		assert.Equal(t, stateCommitment, ledger.RootHash(rootHash))
 		assert.Equal(t, update, up)
 	})
 }


### PR DESCRIPTION
This PR adds a util command to find trie root hash in the wal file. It allows us to roll back executed height to any height.

Context: the current util allows us to roll back executed height to any height, which remove the execution results in the database. However, the EN is not able to start up, because the checkpoint and wal file has not been rollback to the corresponding height. 

Rolling back the checkpoint and wal has been quite difficult, we've made tool to find the block for the block, however, it only allow us to roll back executed height to the block of the checkpoint. In order to be able to roll back to any height, we need to find the trie root hash in the wal files, and this is what this find trie root hash util is made for.