### PR TITLE
[EFM] Add Epoch Fallback Phase

### DIFF
--- a/cmd/dynamic_startup_test.go
+++ b/cmd/dynamic_startup_test.go
@@ -28,7 +28,7 @@ func getMockSnapshot(t *testing.T, epochCounter uint64, phase flow.EpochPhase) *
 
 	snapshot := new(protocolmock.Snapshot)
 	snapshot.On("Epochs").Return(epochQuery)
-	snapshot.On("Phase").Return(phase, nil)
+	snapshot.On("EpochPhase").Return(phase, nil)
 	snapshot.On("Head").Return(unittest.BlockHeaderFixture(), nil)
 
 	return snapshot

--- a/cmd/util/cmd/common/snapshot.go
+++ b/cmd/util/cmd/common/snapshot.go
@@ -83,7 +83,7 @@ func GetSnapshotAtEpochAndPhase(ctx context.Context, log zerolog.Logger, startup
 			return fmt.Errorf("failed to get the current epoch counter: %w", err)
 		}
 
-		currEpochPhase, err := snapshot.Phase()
+		currEpochPhase, err := snapshot.EpochPhase()
 		if err != nil {
 			return fmt.Errorf("failed to get the current epoch phase: %w", err)
 		}

--- a/consensus/hotstuff/committees/consensus_committee.go
+++ b/consensus/hotstuff/committees/consensus_committee.go
@@ -162,6 +162,7 @@ func NewConsensusCommittee(state protocol.State, me flow.Identifier) (*Consensus
 	epochs = append(epochs, final.Epochs().Current())
 
 	// we prepare the next epoch, if it is committed
+	// TODO(EFM, #5730): update phase logic if needed
 	phase, err := final.Phase()
 	if err != nil {
 		return nil, fmt.Errorf("could not check epoch phase: %w", err)
@@ -183,7 +184,7 @@ func NewConsensusCommittee(state protocol.State, me flow.Identifier) (*Consensus
 	}
 
 	// if epoch fallback mode was triggered, inject the fallback epoch
-	// TODO(EFM, #6020): consider replacing with phase check when it's available
+	// TODO(EFM, #5730): consider replacing with phase check when it's available
 	if epochStateSnapshot.EpochFallbackTriggered() {
 		err = com.onEpochFallbackModeTriggered()
 		if err != nil {

--- a/consensus/hotstuff/committees/consensus_committee.go
+++ b/consensus/hotstuff/committees/consensus_committee.go
@@ -163,7 +163,7 @@ func NewConsensusCommittee(state protocol.State, me flow.Identifier) (*Consensus
 
 	// we prepare the next epoch, if it is committed
 	// TODO(EFM, #5730): update phase logic if needed
-	phase, err := final.Phase()
+	phase, err := final.EpochPhase()
 	if err != nil {
 		return nil, fmt.Errorf("could not check epoch phase: %w", err)
 	}

--- a/consensus/hotstuff/committees/consensus_committee_test.go
+++ b/consensus/hotstuff/committees/consensus_committee_test.go
@@ -66,7 +66,7 @@ func (suite *ConsensusSuite) SetupTest() {
 		func() error { return nil },
 	)
 	suite.snapshot.On("EpochProtocolState").Return(suite.epochProtocolState, nil)
-	suite.snapshot.On("Phase").Return(
+	suite.snapshot.On("EpochPhase").Return(
 		func() flow.EpochPhase { return suite.phase },
 		func() error { return nil },
 	)
@@ -624,7 +624,7 @@ func TestRemoveOldEpochs(t *testing.T) {
 	epochQuery := mocks.NewEpochQuery(t, currentEpochCounter, epoch1)
 	snapshot.On("Epochs").Return(epochQuery)
 	currentEpochPhase := flow.EpochPhaseStaking
-	snapshot.On("Phase").Return(
+	snapshot.On("EpochPhase").Return(
 		func() flow.EpochPhase { return currentEpochPhase },
 		func() error { return nil },
 	)

--- a/consensus/hotstuff/cruisectl/block_time_controller.go
+++ b/consensus/hotstuff/cruisectl/block_time_controller.go
@@ -172,7 +172,7 @@ func (ctl *BlockTimeController) initEpochInfo() error {
 	}
 	ctl.curEpochTargetEndTime = curEpochTargetEndTime
 
-	phase, err := finalSnapshot.Phase()
+	phase, err := finalSnapshot.EpochPhase()
 	if err != nil {
 		return fmt.Errorf("could not check snapshot phase: %w", err)
 	}

--- a/consensus/hotstuff/cruisectl/block_time_controller_test.go
+++ b/consensus/hotstuff/cruisectl/block_time_controller_test.go
@@ -93,7 +93,7 @@ func setupMocks(bs *BlockTimeControllerSuite) {
 		func() error { return nil },
 	)
 	bs.snapshot.On("EpochProtocolState").Return(&bs.epochProtocolState, nil)
-	bs.snapshot.On("Phase").Return(
+	bs.snapshot.On("EpochPhase").Return(
 		func() flow.EpochPhase { return bs.epochs.Phase() },
 		func() error { return nil })
 	bs.snapshot.On("Head").Return(unittest.BlockHeaderFixture(unittest.HeaderWithView(bs.initialView+11)), nil).Maybe()

--- a/engine/collection/epochmgr/engine.go
+++ b/engine/collection/epochmgr/engine.go
@@ -240,7 +240,7 @@ func (e *Engine) checkShouldStartPreviousEpochComponentsOnStartup(engineCtx irre
 func (e *Engine) checkShouldVoteOnStartup(finalSnapshot protocol.Snapshot) error {
 	// check the current phase on startup, in case we are in setup phase
 	// and haven't yet voted for the next root QC
-	phase, err := finalSnapshot.Phase()
+	phase, err := finalSnapshot.EpochPhase()
 	if err != nil {
 		return fmt.Errorf("could not get epoch phase for finalized snapshot: %w", err)
 	}

--- a/engine/collection/epochmgr/engine_test.go
+++ b/engine/collection/epochmgr/engine_test.go
@@ -160,7 +160,7 @@ func (suite *Suite) SetupTest() {
 	suite.snap.On("Head").Return(
 		func() *flow.Header { return suite.header },
 		func() error { return nil })
-	suite.snap.On("Phase").Return(
+	suite.snap.On("EpochPhase").Return(
 		func() flow.EpochPhase { return suite.phase },
 		func() error { return nil })
 

--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -84,7 +84,7 @@ func (e *ReactorEngine) Ready() <-chan struct{} {
 		// and fail this epoch's DKG.
 		snap := e.State.Final()
 
-		phase, err := snap.Phase()
+		phase, err := snap.EpochPhase()
 		if err != nil {
 			// unexpected storage-level error
 			// TODO use irrecoverable context

--- a/engine/consensus/dkg/reactor_engine_test.go
+++ b/engine/consensus/dkg/reactor_engine_test.go
@@ -209,7 +209,7 @@ func (suite *ReactorEngineSuite_SetupPhase) TestRunDKG_PhaseTransition() {
 func (suite *ReactorEngineSuite_SetupPhase) TestRunDKG_StartupInSetupPhase() {
 
 	// we are in the EpochSetup phase
-	suite.snapshot.On("Phase").Return(flow.EpochPhaseSetup, nil).Once()
+	suite.snapshot.On("EpochPhase").Return(flow.EpochPhaseSetup, nil).Once()
 	// the dkg for this epoch has not been started
 	suite.dkgState.On("GetDKGStarted", suite.NextEpochCounter()).Return(false, nil).Once()
 
@@ -238,7 +238,7 @@ func (suite *ReactorEngineSuite_SetupPhase) TestRunDKG_StartupInSetupPhase() {
 func (suite *ReactorEngineSuite_SetupPhase) TestRunDKG_StartupInSetupPhase_DKGAlreadyStarted() {
 
 	// we are in the EpochSetup phase
-	suite.snapshot.On("Phase").Return(flow.EpochPhaseSetup, nil).Once()
+	suite.snapshot.On("EpochPhase").Return(flow.EpochPhaseSetup, nil).Once()
 	// the dkg for this epoch has been started
 	suite.dkgState.On("GetDKGStarted", suite.NextEpochCounter()).Return(true, nil).Once()
 
@@ -435,7 +435,7 @@ func (suite *ReactorEngineSuite_CommittedPhase) TestLocalDKGFailure() {
 func (suite *ReactorEngineSuite_CommittedPhase) TestStartupInCommittedPhase_DKGSuccess() {
 
 	// we are in the EpochSetup phase
-	suite.snap.On("Phase").Return(flow.EpochPhaseCommitted, nil).Once()
+	suite.snap.On("EpochPhase").Return(flow.EpochPhaseCommitted, nil).Once()
 	// the dkg for this epoch has been started but not ended
 	suite.dkgState.On("GetDKGStarted", suite.NextEpochCounter()).Return(true, nil).Once()
 	suite.dkgState.On("GetDKGEndState", suite.NextEpochCounter()).Return(flow.DKGEndStateUnknown, storerr.ErrNotFound).Once()
@@ -458,7 +458,7 @@ func (suite *ReactorEngineSuite_CommittedPhase) TestStartupInCommittedPhase_DKGS
 func (suite *ReactorEngineSuite_CommittedPhase) TestStartupInCommittedPhase_DKGEndStateAlreadySet() {
 
 	// we are in the EpochSetup phase
-	suite.snap.On("Phase").Return(flow.EpochPhaseCommitted, nil).Once()
+	suite.snap.On("EpochPhase").Return(flow.EpochPhaseCommitted, nil).Once()
 	// the dkg for this epoch has been started and ended
 	suite.dkgState.On("GetDKGStarted", suite.NextEpochCounter()).Return(true, nil).Once()
 	suite.dkgState.On("GetDKGEndState", suite.NextEpochCounter()).Return(flow.DKGEndStateNoKey, nil).Once()
@@ -479,7 +479,7 @@ func (suite *ReactorEngineSuite_CommittedPhase) TestStartupInCommittedPhase_DKGE
 func (suite *ReactorEngineSuite_CommittedPhase) TestStartupInCommittedPhase_InconsistentKey() {
 
 	// we are in the EpochSetup phase
-	suite.snap.On("Phase").Return(flow.EpochPhaseCommitted, nil).Once()
+	suite.snap.On("EpochPhase").Return(flow.EpochPhaseCommitted, nil).Once()
 	// the dkg for this epoch has been started but not ended
 	suite.dkgState.On("GetDKGStarted", suite.NextEpochCounter()).Return(true, nil).Once()
 	suite.dkgState.On("GetDKGEndState", suite.NextEpochCounter()).Return(flow.DKGEndStateUnknown, storerr.ErrNotFound).Once()
@@ -505,7 +505,7 @@ func (suite *ReactorEngineSuite_CommittedPhase) TestStartupInCommittedPhase_Inco
 func (suite *ReactorEngineSuite_CommittedPhase) TestStartupInCommittedPhase_MissingKey() {
 
 	// we are in the EpochSetup phase
-	suite.snap.On("Phase").Return(flow.EpochPhaseCommitted, nil).Once()
+	suite.snap.On("EpochPhase").Return(flow.EpochPhaseCommitted, nil).Once()
 	// the dkg for this epoch has been started but not ended
 	suite.dkgState.On("GetDKGStarted", suite.NextEpochCounter()).Return(true, nil).Once()
 	suite.dkgState.On("GetDKGEndState", suite.NextEpochCounter()).Return(flow.DKGEndStateUnknown, storerr.ErrNotFound).Once()

--- a/integration/dkg/dkg_whiteboard_test.go
+++ b/integration/dkg/dkg_whiteboard_test.go
@@ -112,7 +112,7 @@ func createNode(
 	epochQuery.Add(nextEpoch)
 	snapshot := new(protocolmock.Snapshot)
 	snapshot.On("Epochs").Return(epochQuery)
-	snapshot.On("Phase").Return(flow.EpochPhaseStaking, nil)
+	snapshot.On("EpochPhase").Return(flow.EpochPhaseStaking, nil)
 	snapshot.On("Head").Return(firstBlock, nil)
 	state := new(protocolmock.ParticipantState)
 	state.On("AtBlockID", firstBlock.ID()).Return(snapshot)

--- a/integration/dkg/node.go
+++ b/integration/dkg/node.go
@@ -86,7 +86,7 @@ func (n *node) setEpochs(t *testing.T, currentSetup flow.EpochSetup, nextSetup f
 	epochQuery.Add(nextEpoch)
 	snapshot := new(protocolmock.Snapshot)
 	snapshot.On("Epochs").Return(epochQuery)
-	snapshot.On("Phase").Return(flow.EpochPhaseStaking, nil)
+	snapshot.On("EpochPhase").Return(flow.EpochPhaseStaking, nil)
 	snapshot.On("Head").Return(firstBlock, nil)
 	state := new(protocolmock.ParticipantState)
 	state.On("AtBlockID", firstBlock.ID()).Return(snapshot)

--- a/integration/epochs/epoch_qc_test.go
+++ b/integration/epochs/epoch_qc_test.go
@@ -98,7 +98,7 @@ func (s *Suite) TestEpochQuorumCertificate() {
 		hotSigner.On("CreateVote", mock.Anything).Return(vote, nil)
 
 		snapshot := &protomock.Snapshot{}
-		snapshot.On("Phase").Return(flow.EpochPhaseSetup, nil)
+		snapshot.On("EpochPhase").Return(flow.EpochPhaseSetup, nil)
 
 		state := &protomock.State{}
 		state.On("CanonicalRootBlock").Return(rootBlock)

--- a/integration/tests/epochs/base_suite.go
+++ b/integration/tests/epochs/base_suite.go
@@ -141,7 +141,7 @@ func (s *BaseSuite) AwaitEpochPhase(ctx context.Context, expectedEpoch uint64, e
 
 		actualEpoch, err = snapshot.Epochs().Current().Counter()
 		require.NoError(s.T(), err)
-		actualPhase, err = snapshot.Phase()
+		actualPhase, err = snapshot.EpochPhase()
 		require.NoError(s.T(), err)
 
 		return actualEpoch == expectedEpoch && actualPhase == expectedPhase

--- a/integration/tests/epochs/dynamic_epoch_transition_suite.go
+++ b/integration/tests/epochs/dynamic_epoch_transition_suite.go
@@ -366,7 +366,7 @@ func (s *DynamicEpochTransitionSuite) AssertInEpochPhase(ctx context.Context, ex
 	require.NoError(s.T(), err)
 	actualEpoch, err := snapshot.Epochs().Current().Counter()
 	require.NoError(s.T(), err)
-	actualPhase, err := snapshot.Phase()
+	actualPhase, err := snapshot.EpochPhase()
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), expectedPhase, actualPhase, "not in correct phase")
 	require.Equal(s.T(), expectedEpoch, actualEpoch, "not in correct epoch")

--- a/integration/tests/lib/util.go
+++ b/integration/tests/lib/util.go
@@ -238,7 +238,7 @@ func LogStatus(t *testing.T, ctx context.Context, log zerolog.Logger, client *te
 	sealed := sealingSegment.Sealed()
 	finalized := sealingSegment.Finalized()
 
-	phase, err := snapshot.Phase()
+	phase, err := snapshot.EpochPhase()
 	require.NoError(t, err)
 	epoch := snapshot.Epochs().Current()
 	counter, err := epoch.Counter()

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -19,6 +19,7 @@ import (
 // An epoch begins in the staking phase, then transitions to the setup phase in
 // the block containing the EpochSetup service event, then to the committed
 // phase in the block containing the EpochCommit service event.
+// TODO(EFM, #6092) update these docs
 // |<--  EpochPhaseStaking -->|<-- EpochPhaseSetup -->|<-- EpochPhaseCommitted -->|<-- EpochPhaseStaking -->...
 // |<------------------------------- Epoch N ------------------------------------>|<-- Epoch N + 1 --...
 type EpochPhase int
@@ -28,6 +29,7 @@ const (
 	EpochPhaseStaking
 	EpochPhaseSetup
 	EpochPhaseCommitted
+	EpochPhaseFallback
 )
 
 func (p EpochPhase) String() string {
@@ -36,6 +38,7 @@ func (p EpochPhase) String() string {
 		"EpochPhaseStaking",
 		"EpochPhaseSetup",
 		"EpochPhaseCommitted",
+		"EpochPhaseFallback",
 	}[p]
 }
 
@@ -45,6 +48,7 @@ func GetEpochPhase(phase string) EpochPhase {
 		EpochPhaseStaking,
 		EpochPhaseSetup,
 		EpochPhaseCommitted,
+		EpochPhaseFallback,
 	}
 	for _, p := range phases {
 		if p.String() == phase {

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -327,21 +327,16 @@ func (e *RichEpochProtocolStateEntry) CurrentEpochFinalView() uint64 {
 // EpochPhase returns the current epoch phase.
 // The receiver EpochProtocolStateEntry must be properly constructed.
 func (e *EpochProtocolStateEntry) EpochPhase() EpochPhase {
-	tentativePhase := e.unsafeEpochPhase()
-	if tentativePhase == EpochPhaseCommitted {
+	if e.EpochFallbackTriggered {
 		// If the next epoch has been committed, we are in EpochPhaseCommitted regardless of EFM status.
 		// We will enter EpochPhaseFallback after completing the transition into the committed next epoch.
-		return EpochPhaseCommitted
-	}
-	if e.EpochFallbackTriggered {
+		if e.NextEpoch != nil && e.NextEpoch.CommitID != ZeroID {
+			return EpochPhaseCommitted
+		}
 		// If the next epoch has not been committed and EFM is triggered, we immediately enter EpochPhaseFallback.
 		return EpochPhaseFallback
 	}
-	return tentativePhase
-}
 
-// unsafeEpochPhase returns the current epoch phase, assuming we are NOT in EFM.
-func (e *EpochProtocolStateEntry) unsafeEpochPhase() EpochPhase {
 	// The epoch phase is determined by how much information we have about the next epoch
 	if e.NextEpoch == nil {
 		return EpochPhaseStaking // if no information about the next epoch is known, we are in the Staking Phase

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -326,6 +326,7 @@ func (e *RichEpochProtocolStateEntry) CurrentEpochFinalView() uint64 {
 
 // EpochPhase returns the current epoch phase.
 // The receiver EpochProtocolStateEntry must be properly constructed.
+// See flow.EpochPhase for detailed documentation.
 func (e *EpochProtocolStateEntry) EpochPhase() EpochPhase {
 	// CAUTION: the logic below that deduces the EpochPhase must be consistent with `epochs.FallbackStateMachine`,
 	// which sets the fields we are using here. Specifically, we require that the FallbackStateMachine clears out

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -327,6 +327,9 @@ func (e *RichEpochProtocolStateEntry) CurrentEpochFinalView() uint64 {
 // EpochPhase returns the current epoch phase.
 // The receiver EpochProtocolStateEntry must be properly constructed.
 func (e *EpochProtocolStateEntry) EpochPhase() EpochPhase {
+	// CAUTION: the logic below that deduces the EpochPhase must be consistent with `epochs.FallbackStateMachine`,
+	// which sets the fields we are using here. Specifically, we require that the FallbackStateMachine clears out
+	// any tentative values for a subsequent epoch _unless_ that epoch is already committed.
 	if e.EpochFallbackTriggered {
 		// If the next epoch has been committed, we are in EpochPhaseCommitted regardless of EFM status.
 		// We will enter EpochPhaseFallback after completing the transition into the committed next epoch.

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -326,6 +326,7 @@ func (e *RichEpochProtocolStateEntry) CurrentEpochFinalView() uint64 {
 
 // EpochPhase returns the current epoch phase.
 // The receiver EpochProtocolStateEntry must be properly constructed.
+// TODO(EFM, #6092) update logic here
 func (e *EpochProtocolStateEntry) EpochPhase() EpochPhase {
 	// The epoch phase is determined by how much information we have about the next epoch
 	if e.NextEpoch == nil {

--- a/model/flow/protocol_state_test.go
+++ b/model/flow/protocol_state_test.go
@@ -10,6 +10,41 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
+// TestEpochProtocolStateEntry_EpochPhase tests that all possible instances of an EpochProtocolStateEntry
+// correctly compute the current epoch phase, taking into account EFM status and incorporated service events.
+func TestEpochProtocolStateEntry_EpochPhase(t *testing.T) {
+
+	t.Run("EFM triggered", func(t *testing.T) {
+		t.Run("tentatively in staking phase", func(t *testing.T) {
+			entry := unittest.EpochProtocolStateEntryFixture(flow.EpochPhaseStaking, true)
+			assert.Equal(t, flow.EpochPhaseFallback, entry.EpochPhase())
+		})
+		t.Run("tentatively in setup phase", func(t *testing.T) {
+			entry := unittest.EpochProtocolStateEntryFixture(flow.EpochPhaseSetup, true)
+			assert.Equal(t, flow.EpochPhaseFallback, entry.EpochPhase())
+		})
+		t.Run("tentatively in committed phase", func(t *testing.T) {
+			entry := unittest.EpochProtocolStateEntryFixture(flow.EpochPhaseCommitted, true)
+			assert.Equal(t, flow.EpochPhaseCommitted, entry.EpochPhase())
+		})
+	})
+
+	t.Run("EFM not triggered", func(t *testing.T) {
+		t.Run("tentatively in staking phase", func(t *testing.T) {
+			entry := unittest.EpochProtocolStateEntryFixture(flow.EpochPhaseStaking, false)
+			assert.Equal(t, flow.EpochPhaseStaking, entry.EpochPhase())
+		})
+		t.Run("tentatively in setup phase", func(t *testing.T) {
+			entry := unittest.EpochProtocolStateEntryFixture(flow.EpochPhaseSetup, false)
+			assert.Equal(t, flow.EpochPhaseSetup, entry.EpochPhase())
+		})
+		t.Run("tentatively in committed phase", func(t *testing.T) {
+			entry := unittest.EpochProtocolStateEntryFixture(flow.EpochPhaseCommitted, false)
+			assert.Equal(t, flow.EpochPhaseCommitted, entry.EpochPhase())
+		})
+	})
+}
+
 // TestNewRichProtocolStateEntry checks that NewRichEpochProtocolStateEntry creates valid identity tables depending on the state
 // of epoch which is derived from the protocol state entry.
 func TestNewRichProtocolStateEntry(t *testing.T) {

--- a/module/epochs/epoch_lookup.go
+++ b/module/epochs/epoch_lookup.go
@@ -148,7 +148,7 @@ func NewEpochLookup(state protocol.State) (*EpochLookup, error) {
 	}
 
 	// we cache the next epoch, if it is committed
-	phase, err := final.Phase()
+	phase, err := final.EpochPhase()
 	if err != nil {
 		return nil, fmt.Errorf("could not check epoch phase: %w", err)
 	}

--- a/module/epochs/epoch_lookup_test.go
+++ b/module/epochs/epoch_lookup_test.go
@@ -61,7 +61,7 @@ func (suite *EpochLookupSuite) SetupTest() {
 	suite.epochQuery = mocks.NewEpochQuery(suite.T(), suite.currentEpochCounter)
 
 	suite.snapshot.On("Epochs").Return(suite.epochQuery)
-	suite.snapshot.On("Phase").Return(
+	suite.snapshot.On("EpochPhase").Return(
 		func() flow.EpochPhase { return suite.Phase() },
 		func() error { return nil })
 

--- a/module/epochs/qc_voter.go
+++ b/module/epochs/qc_voter.go
@@ -124,7 +124,7 @@ func (voter *RootQCVoter) Vote(ctx context.Context, epoch protocol.Epoch) error 
 	castVote := func(ctx context.Context) error {
 		// check that we're still in the setup phase, if we're not we can't
 		// submit a vote anyway and must exit this process
-		phase, err := voter.state.Final().Phase()
+		phase, err := voter.state.Final().EpochPhase()
 		if err != nil {
 			return fmt.Errorf("unexpected error - unable to get current epoch phase: %w", err)
 		} else if phase != flow.EpochPhaseSetup {

--- a/module/epochs/qc_voter_test.go
+++ b/module/epochs/qc_voter_test.go
@@ -62,7 +62,7 @@ func (suite *Suite) SetupTest() {
 	suite.snap = new(protocol.Snapshot)
 	suite.state.On("Final").Return(suite.snap)
 	suite.phase = flow.EpochPhaseSetup
-	suite.snap.On("Phase").Return(
+	suite.snap.On("EpochPhase").Return(
 		func() flow.EpochPhase { return suite.phase },
 		func() error { return nil },
 	)

--- a/module/state_synchronization/requester/execution_data_requester_test.go
+++ b/module/state_synchronization/requester/execution_data_requester_test.go
@@ -800,7 +800,7 @@ func (m *mockSnapshot) Commit() (flow.StateCommitment, error)                   
 func (m *mockSnapshot) SealingSegment() (*flow.SealingSegment, error)            { return nil, nil }
 func (m *mockSnapshot) Descendants() ([]flow.Identifier, error)                  { return nil, nil }
 func (m *mockSnapshot) RandomSource() ([]byte, error)                            { return nil, nil }
-func (m *mockSnapshot) Phase() (flow.EpochPhase, error)                          { return flow.EpochPhaseUndefined, nil }
+func (m *mockSnapshot) EpochPhase() (flow.EpochPhase, error)                     { return flow.EpochPhaseUndefined, nil }
 func (m *mockSnapshot) Epochs() protocol.EpochQuery                              { return nil }
 func (m *mockSnapshot) Params() protocol.GlobalParams                            { return nil }
 func (m *mockSnapshot) EpochProtocolState() (protocol.EpochProtocolState, error) { return nil, nil }

--- a/network/test/cohort2/epochtransition_test.go
+++ b/network/test/cohort2/epochtransition_test.go
@@ -177,7 +177,7 @@ func (suite *MutableIdentityTableSuite) setupStateMock() {
 	suite.state = new(mockprotocol.State)
 	suite.snapshot = new(mockprotocol.Snapshot)
 	suite.snapshot.On("Head").Return(&final, nil)
-	suite.snapshot.On("Phase").Return(flow.EpochPhaseCommitted, nil)
+	suite.snapshot.On("EpochPhase").Return(flow.EpochPhaseCommitted, nil)
 	// return all the current list of ids for the state.Final.Identities call made by the network
 	suite.snapshot.On("Identities", mock.Anything).Return(
 		func(flow.IdentityFilter[flow.Identity]) flow.IdentityList {

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -865,7 +865,7 @@ func (m *FollowerState) epochMetricsAndEventsOnBlockFinalized(parentEpochState, 
 		metrics = append(metrics, func() { m.metrics.CurrentEpochCounter(childEpochSetup.Counter) })
 		// denote the most recent epoch transition height
 		metrics = append(metrics, func() { m.metrics.EpochTransitionHeight(finalized.Height) })
-		// set epoch phase - since we are starting a new epoch we begin in the staking phase
+		// set epoch phase
 		metrics = append(metrics, func() { m.metrics.CurrentEpochPhase(childEpochPhase) })
 		// set current epoch view values
 		metrics = append(

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -814,7 +814,7 @@ func isFirstBlockOfEpoch(parentEpochState, blockEpochState protocol.EpochProtoco
 //   - We notify about an epoch transition when the first block of the new epoch is finalized
 //   - We notify about an epoch phase transition when the first block within the new epoch phase is finalized
 //
-// TODO(EFM, #5732, #6013): needs update for EFM recovery
+// TODO(EFM, #6092): needs update for EFM recovery
 // This method must be called for each finalized block.
 // No errors are expected during normal operation.
 func (m *FollowerState) epochMetricsAndEventsOnBlockFinalized(parentEpochState, finalizedEpochState protocol.EpochProtocolState, finalized *flow.Header) (

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -838,7 +838,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.NoError(t, err)
 		finalView, err := initialCurrentEpoch.FinalView()
 		require.NoError(t, err)
-		initialPhase, err := rootSnapshot.Phase()
+		initialPhase, err := rootSnapshot.EpochPhase()
 		require.NoError(t, err)
 		metrics.On("CurrentEpochCounter", counter).Once()
 		metrics.On("CurrentEpochPhase", initialPhase).Once()
@@ -900,7 +900,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.NoError(t, err)
 
 		// we should begin the epoch in the staking phase
-		phase, err := state.AtBlockID(head.ID()).Phase()
+		phase, err := state.AtBlockID(head.ID()).EpochPhase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseStaking, phase)
 
@@ -951,7 +951,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.NoError(t, err)
 
 		// now that the setup event has been emitted, we should be in the setup phase
-		phase, err = state.AtBlockID(block3.ID()).Phase()
+		phase, err = state.AtBlockID(block3.ID()).EpochPhase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseSetup, phase)
 
@@ -988,7 +988,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		metrics.AssertCalled(t, "CurrentEpochPhase", flow.EpochPhaseSetup)
 
 		// now that the setup event has been emitted, we should be in the setup phase
-		phase, err = state.AtBlockID(block3.ID()).Phase()
+		phase, err = state.AtBlockID(block3.ID()).EpochPhase()
 		require.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseSetup, phase)
 
@@ -1041,7 +1041,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		assert.NoError(t, err)
 
 		// now that the commit event has been emitted, we should be in the committed phase
-		phase, err = state.AtBlockID(block6.ID()).Phase()
+		phase, err = state.AtBlockID(block6.ID()).EpochPhase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseCommitted, phase)
 
@@ -1093,7 +1093,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 
 		// we should begin epoch 2 in staking phase
 		// now that we have entered view range of epoch 2, should be in staking phase
-		phase, err = state.AtBlockID(block8.ID()).Phase()
+		phase, err = state.AtBlockID(block8.ID()).EpochPhase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseStaking, phase)
 
@@ -3092,7 +3092,7 @@ func assertEpochFallbackTriggered(t *testing.T, stateSnapshot realprotocol.Snaps
 
 // assertInPhase tests that the input snapshot is in the expected epoch phase.
 func assertInPhase(t *testing.T, snap realprotocol.Snapshot, expectedPhase flow.EpochPhase) {
-	phase, err := snap.Phase()
+	phase, err := snap.EpochPhase()
 	require.NoError(t, err)
 	assert.Equal(t, expectedPhase, phase)
 }

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -900,6 +900,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.NoError(t, err)
 
 		// we should begin the epoch in the staking phase
+		// TODO(EFM, #6092)
 		phase, err := state.AtBlockID(head.ID()).Phase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseStaking, phase)
@@ -951,6 +952,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.NoError(t, err)
 
 		// now that the setup event has been emitted, we should be in the setup phase
+		// TODO(EFM, #6092)
 		phase, err = state.AtBlockID(block3.ID()).Phase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseSetup, phase)
@@ -988,6 +990,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		metrics.AssertCalled(t, "CurrentEpochPhase", flow.EpochPhaseSetup)
 
 		// now that the setup event has been emitted, we should be in the setup phase
+		// TODO(EFM, #6092)
 		phase, err = state.AtBlockID(block3.ID()).Phase()
 		require.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseSetup, phase)
@@ -1041,6 +1044,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		assert.NoError(t, err)
 
 		// now that the commit event has been emitted, we should be in the committed phase
+		// TODO(EFM, #6092)
 		phase, err = state.AtBlockID(block6.ID()).Phase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseCommitted, phase)
@@ -1093,6 +1097,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 
 		// we should begin epoch 2 in staking phase
 		// how that the commit event has been emitted, we should be in the committed phase
+		// TODO(EFM, #6092)
 		phase, err = state.AtBlockID(block8.ID()).Phase()
 		assert.NoError(t, err)
 		require.Equal(t, flow.EpochPhaseStaking, phase)

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -412,7 +412,7 @@ func (q *EpochQuery) Next() protocol.Epoch {
 	phase := epochState.EpochPhase()
 	entry := epochState.Entry()
 
-	// if we are in the staking phase, the next epoch is not setup yet
+	// if we are in the staking or fallback phase, the next epoch is not setup yet
 	if phase == flow.EpochPhaseStaking || phase == flow.EpochPhaseFallback {
 		return invalid.NewEpoch(protocol.ErrNextEpochNotSetup)
 	}

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -81,7 +81,7 @@ func (s *Snapshot) QuorumCertificate() (*flow.QuorumCertificate, error) {
 	return qc, nil
 }
 
-func (s *Snapshot) Phase() (flow.EpochPhase, error) {
+func (s *Snapshot) EpochPhase() (flow.EpochPhase, error) {
 	epochState, err := s.state.protocolState.EpochStateAtBlockID(s.blockID)
 	if err != nil {
 		return flow.EpochPhaseUndefined, fmt.Errorf("could not retrieve protocol state snapshot: %w", err)

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -413,7 +413,7 @@ func (q *EpochQuery) Next() protocol.Epoch {
 	entry := epochState.Entry()
 
 	// if we are in the staking phase, the next epoch is not setup yet
-	if phase == flow.EpochPhaseStaking {
+	if phase == flow.EpochPhaseStaking || phase == flow.EpochPhaseFallback {
 		return invalid.NewEpoch(protocol.ErrNextEpochNotSetup)
 	}
 	// if we are in setup phase, return a SetupEpoch

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -1473,7 +1473,6 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 			snapshots := []protocol.Snapshot{state.AtHeight(epoch1.Setup), state.AtHeight(epoch1.Committed)}
 
 			for _, snapshot := range snapshots {
-				// TODO(EFM, #6092)
 				phase, err := snapshot.Phase()
 				require.NoError(t, err)
 
@@ -1522,7 +1521,6 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 			snapshots := []protocol.Snapshot{state.AtHeight(epoch2.Setup), state.AtHeight(epoch2.Committed)}
 
 			for _, snapshot := range snapshots {
-				// TODO(EFM, #6092)
 				phase, err := snapshot.Phase()
 				require.NoError(t, err)
 

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -1473,6 +1473,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 			snapshots := []protocol.Snapshot{state.AtHeight(epoch1.Setup), state.AtHeight(epoch1.Committed)}
 
 			for _, snapshot := range snapshots {
+				// TODO(EFM, #6092)
 				phase, err := snapshot.Phase()
 				require.NoError(t, err)
 
@@ -1521,6 +1522,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 			snapshots := []protocol.Snapshot{state.AtHeight(epoch2.Setup), state.AtHeight(epoch2.Committed)}
 
 			for _, snapshot := range snapshots {
+				// TODO(EFM, #6092)
 				phase, err := snapshot.Phase()
 				require.NoError(t, err)
 

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -1473,7 +1473,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 			snapshots := []protocol.Snapshot{state.AtHeight(epoch1.Setup), state.AtHeight(epoch1.Committed)}
 
 			for _, snapshot := range snapshots {
-				phase, err := snapshot.Phase()
+				phase, err := snapshot.EpochPhase()
 				require.NoError(t, err)
 
 				t.Run("phase: "+phase.String(), func(t *testing.T) {
@@ -1521,7 +1521,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 			snapshots := []protocol.Snapshot{state.AtHeight(epoch2.Setup), state.AtHeight(epoch2.Committed)}
 
 			for _, snapshot := range snapshots {
-				phase, err := snapshot.Phase()
+				phase, err := snapshot.EpochPhase()
 				require.NoError(t, err)
 
 				t.Run("phase: "+phase.String(), func(t *testing.T) {

--- a/state/protocol/badger/state.go
+++ b/state/protocol/badger/state.go
@@ -872,7 +872,7 @@ func updateEpochMetrics(metrics module.ComplianceMetrics, snap protocol.Snapshot
 	metrics.CurrentEpochCounter(counter)
 
 	// update epoch phase
-	phase, err := snap.Phase()
+	phase, err := snap.EpochPhase()
 	if err != nil {
 		return fmt.Errorf("could not get current epoch counter: %w", err)
 	}

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -42,7 +42,7 @@ func TestBootstrapAndOpen(t *testing.T) {
 		require.NoError(t, err)
 		counter, err := epoch.Counter()
 		require.NoError(t, err)
-		phase, err := rootSnapshot.Phase()
+		phase, err := rootSnapshot.EpochPhase()
 		require.NoError(t, err)
 
 		complianceMetrics := new(mock.ComplianceMetrics)
@@ -103,7 +103,7 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 
 		// find the point where we transition to the epoch committed phase
 		for height := rootBlock.Height + 1; ; height++ {
-			phase, err := state.AtHeight(height).Phase()
+			phase, err := state.AtHeight(height).EpochPhase()
 			require.NoError(t, err)
 			if phase == flow.EpochPhaseCommitted {
 				return state.AtHeight(height)
@@ -121,7 +121,7 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 		complianceMetrics.On("CurrentEpochCounter", counter).Once()
 
 		// expect epoch phase to be set to current phase
-		phase, err := committedPhaseSnapshot.Phase()
+		phase, err := committedPhaseSnapshot.EpochPhase()
 		require.NoError(t, err)
 		complianceMetrics.On("CurrentEpochPhase", phase).Once()
 
@@ -377,7 +377,7 @@ func TestBootstrapNonRoot(t *testing.T) {
 
 			// find the point where we transition to the epoch setup phase
 			for height := rootBlock.Height + 1; ; height++ {
-				phase, err := state.AtHeight(height).Phase()
+				phase, err := state.AtHeight(height).EpochPhase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseSetup {
 					return state.AtHeight(height)
@@ -408,7 +408,7 @@ func TestBootstrapNonRoot(t *testing.T) {
 
 			// find the point where we transition to the epoch committed phase
 			for height := rootBlock.Height + 1; ; height++ {
-				phase, err := state.AtHeight(height).Phase()
+				phase, err := state.AtHeight(height).EpochPhase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseCommitted {
 					return state.AtHeight(height)
@@ -446,7 +446,7 @@ func TestBootstrapNonRoot(t *testing.T) {
 				snap := state.AtHeight(height)
 				counter, err := snap.Epochs().Current().Counter()
 				require.NoError(t, err)
-				phase, err := snap.Phase()
+				phase, err := snap.EpochPhase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseSetup && counter == epoch1Counter+1 {
 					return snap

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -103,7 +103,6 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 
 		// find the point where we transition to the epoch committed phase
 		for height := rootBlock.Height + 1; ; height++ {
-			// TODO(EFM, #6092)
 			phase, err := state.AtHeight(height).Phase()
 			require.NoError(t, err)
 			if phase == flow.EpochPhaseCommitted {
@@ -122,7 +121,6 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 		complianceMetrics.On("CurrentEpochCounter", counter).Once()
 
 		// expect epoch phase to be set to current phase
-		// TODO(EFM, #6092)
 		phase, err := committedPhaseSnapshot.Phase()
 		require.NoError(t, err)
 		complianceMetrics.On("CurrentEpochPhase", phase).Once()
@@ -379,7 +377,6 @@ func TestBootstrapNonRoot(t *testing.T) {
 
 			// find the point where we transition to the epoch setup phase
 			for height := rootBlock.Height + 1; ; height++ {
-				// TODO(EFM, #6092)
 				phase, err := state.AtHeight(height).Phase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseSetup {
@@ -411,7 +408,6 @@ func TestBootstrapNonRoot(t *testing.T) {
 
 			// find the point where we transition to the epoch committed phase
 			for height := rootBlock.Height + 1; ; height++ {
-				// TODO(EFM, #6092)
 				phase, err := state.AtHeight(height).Phase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseCommitted {
@@ -450,7 +446,6 @@ func TestBootstrapNonRoot(t *testing.T) {
 				snap := state.AtHeight(height)
 				counter, err := snap.Epochs().Current().Counter()
 				require.NoError(t, err)
-				// TODO(EFM, #6092)
 				phase, err := snap.Phase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseSetup && counter == epoch1Counter+1 {

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -103,6 +103,7 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 
 		// find the point where we transition to the epoch committed phase
 		for height := rootBlock.Height + 1; ; height++ {
+			// TODO(EFM, #6092)
 			phase, err := state.AtHeight(height).Phase()
 			require.NoError(t, err)
 			if phase == flow.EpochPhaseCommitted {
@@ -121,6 +122,7 @@ func TestBootstrapAndOpen_EpochCommitted(t *testing.T) {
 		complianceMetrics.On("CurrentEpochCounter", counter).Once()
 
 		// expect epoch phase to be set to current phase
+		// TODO(EFM, #6092)
 		phase, err := committedPhaseSnapshot.Phase()
 		require.NoError(t, err)
 		complianceMetrics.On("CurrentEpochPhase", phase).Once()
@@ -377,6 +379,7 @@ func TestBootstrapNonRoot(t *testing.T) {
 
 			// find the point where we transition to the epoch setup phase
 			for height := rootBlock.Height + 1; ; height++ {
+				// TODO(EFM, #6092)
 				phase, err := state.AtHeight(height).Phase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseSetup {
@@ -408,6 +411,7 @@ func TestBootstrapNonRoot(t *testing.T) {
 
 			// find the point where we transition to the epoch committed phase
 			for height := rootBlock.Height + 1; ; height++ {
+				// TODO(EFM, #6092)
 				phase, err := state.AtHeight(height).Phase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseCommitted {
@@ -446,6 +450,7 @@ func TestBootstrapNonRoot(t *testing.T) {
 				snap := state.AtHeight(height)
 				counter, err := snap.Epochs().Current().Counter()
 				require.NoError(t, err)
+				// TODO(EFM, #6092)
 				phase, err := snap.Phase()
 				require.NoError(t, err)
 				if phase == flow.EpochPhaseSetup && counter == epoch1Counter+1 {

--- a/state/protocol/inmem/epoch.go
+++ b/state/protocol/inmem/epoch.go
@@ -32,7 +32,7 @@ func (eq Epochs) Current() protocol.Epoch {
 
 func (eq Epochs) Next() protocol.Epoch {
 	switch eq.entry.EpochPhase() {
-	case flow.EpochPhaseStaking:
+	case flow.EpochPhaseStaking, flow.EpochPhaseFallback:
 		return invalid.NewEpoch(protocol.ErrNextEpochNotSetup)
 	case flow.EpochPhaseSetup:
 		return NewSetupEpoch(eq.entry.NextEpochSetup)

--- a/state/protocol/inmem/epoch_protocol_state.go
+++ b/state/protocol/inmem/epoch_protocol_state.go
@@ -96,6 +96,7 @@ func (s *EpochProtocolStateAdapter) EpochExtensions() []flow.EpochExtension {
 }
 
 // EpochPhase returns the epoch phase for the current epoch.
+// TODO(EFM, #6092): check callers
 func (s *EpochProtocolStateAdapter) EpochPhase() flow.EpochPhase {
 	return s.Entry().EpochPhase()
 }

--- a/state/protocol/inmem/epoch_protocol_state.go
+++ b/state/protocol/inmem/epoch_protocol_state.go
@@ -97,6 +97,7 @@ func (s *EpochProtocolStateAdapter) EpochExtensions() []flow.EpochExtension {
 }
 
 // EpochPhase returns the epoch phase for the current epoch.
+// The receiver must be properly constructed.
 func (s *EpochProtocolStateAdapter) EpochPhase() flow.EpochPhase {
 	return s.Entry().EpochPhase()
 }

--- a/state/protocol/inmem/epoch_protocol_state.go
+++ b/state/protocol/inmem/epoch_protocol_state.go
@@ -98,6 +98,7 @@ func (s *EpochProtocolStateAdapter) EpochExtensions() []flow.EpochExtension {
 
 // EpochPhase returns the epoch phase for the current epoch.
 // The receiver must be properly constructed.
+// See flow.EpochPhase for detailed documentation.
 func (s *EpochProtocolStateAdapter) EpochPhase() flow.EpochPhase {
 	return s.Entry().EpochPhase()
 }

--- a/state/protocol/inmem/epoch_protocol_state.go
+++ b/state/protocol/inmem/epoch_protocol_state.go
@@ -97,7 +97,6 @@ func (s *EpochProtocolStateAdapter) EpochExtensions() []flow.EpochExtension {
 }
 
 // EpochPhase returns the epoch phase for the current epoch.
-// TODO(EFM, #6092): check callers
 func (s *EpochProtocolStateAdapter) EpochPhase() flow.EpochPhase {
 	return s.Entry().EpochPhase()
 }

--- a/state/protocol/inmem/epoch_protocol_state_test.go
+++ b/state/protocol/inmem/epoch_protocol_state_test.go
@@ -91,12 +91,23 @@ func TestEpochProtocolStateAdapter(t *testing.T) {
 		assert.True(t, adapter.PreviousEpochExists())
 		assert.False(t, adapter.EpochFallbackTriggered())
 	})
-	t.Run("invalid-state-transition-attempted", func(t *testing.T) {
-		entry := unittest.EpochStateFixture(func(entry *flow.RichEpochProtocolStateEntry) {
-			entry.EpochFallbackTriggered = true
+	t.Run("epoch-fallback-triggered", func(t *testing.T) {
+		t.Run("tentatively staking phase", func(t *testing.T) {
+			entry := unittest.EpochStateFixture(func(entry *flow.RichEpochProtocolStateEntry) {
+				entry.EpochFallbackTriggered = true
+			})
+			adapter := inmem.NewEpochProtocolStateAdapter(entry, globalParams)
+			assert.True(t, adapter.EpochFallbackTriggered())
+			assert.Equal(t, flow.EpochPhaseFallback, entry.EpochPhase())
 		})
-		adapter := inmem.NewEpochProtocolStateAdapter(entry, globalParams)
-		assert.True(t, adapter.EpochFallbackTriggered())
+		t.Run("tentatively committed phase", func(t *testing.T) {
+			entry := unittest.EpochStateFixture(unittest.WithNextEpochProtocolState(), func(entry *flow.RichEpochProtocolStateEntry) {
+				entry.EpochFallbackTriggered = true
+			})
+			adapter := inmem.NewEpochProtocolStateAdapter(entry, globalParams)
+			assert.True(t, adapter.EpochFallbackTriggered())
+			assert.Equal(t, flow.EpochPhaseCommitted, entry.EpochPhase())
+		})
 	})
 	t.Run("no-previous-epoch", func(t *testing.T) {
 		entry := unittest.EpochStateFixture(func(entry *flow.RichEpochProtocolStateEntry) {

--- a/state/protocol/inmem/snapshot.go
+++ b/state/protocol/inmem/snapshot.go
@@ -78,7 +78,7 @@ func (s Snapshot) Descendants() ([]flow.Identifier, error) {
 	return nil, nil
 }
 
-func (s Snapshot) Phase() (flow.EpochPhase, error) {
+func (s Snapshot) EpochPhase() (flow.EpochPhase, error) {
 	epochProtocolState, err := s.EpochProtocolState()
 	if err != nil {
 		return flow.EpochPhaseUndefined, fmt.Errorf("could not get epoch protocol state: %w", err)

--- a/state/protocol/invalid/snapshot.go
+++ b/state/protocol/invalid/snapshot.go
@@ -42,7 +42,7 @@ func (u *Snapshot) QuorumCertificate() (*flow.QuorumCertificate, error) {
 	return nil, u.err
 }
 
-func (u *Snapshot) Phase() (flow.EpochPhase, error) {
+func (u *Snapshot) EpochPhase() (flow.EpochPhase, error) {
 	return 0, u.err
 }
 

--- a/state/protocol/mock/snapshot.go
+++ b/state/protocol/mock/snapshot.go
@@ -3,9 +3,8 @@
 package mock
 
 import (
-	mock "github.com/stretchr/testify/mock"
-
 	flow "github.com/onflow/flow-go/model/flow"
+	mock "github.com/stretchr/testify/mock"
 
 	protocol "github.com/onflow/flow-go/state/protocol"
 )
@@ -64,6 +63,34 @@ func (_m *Snapshot) Descendants() ([]flow.Identifier, error) {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]flow.Identifier)
 		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// EpochPhase provides a mock function with given fields:
+func (_m *Snapshot) EpochPhase() (flow.EpochPhase, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for EpochPhase")
+	}
+
+	var r0 flow.EpochPhase
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (flow.EpochPhase, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() flow.EpochPhase); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(flow.EpochPhase)
 	}
 
 	if rf, ok := ret.Get(1).(func() error); ok {
@@ -233,34 +260,6 @@ func (_m *Snapshot) Params() protocol.GlobalParams {
 	}
 
 	return r0
-}
-
-// Phase provides a mock function with given fields:
-func (_m *Snapshot) EpochPhase() (flow.EpochPhase, error) {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for EpochPhase")
-	}
-
-	var r0 flow.EpochPhase
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (flow.EpochPhase, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() flow.EpochPhase); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(flow.EpochPhase)
-	}
-
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // ProtocolState provides a mock function with given fields:

--- a/state/protocol/mock/snapshot.go
+++ b/state/protocol/mock/snapshot.go
@@ -3,8 +3,9 @@
 package mock
 
 import (
-	flow "github.com/onflow/flow-go/model/flow"
 	mock "github.com/stretchr/testify/mock"
+
+	flow "github.com/onflow/flow-go/model/flow"
 
 	protocol "github.com/onflow/flow-go/state/protocol"
 )
@@ -235,11 +236,11 @@ func (_m *Snapshot) Params() protocol.GlobalParams {
 }
 
 // Phase provides a mock function with given fields:
-func (_m *Snapshot) Phase() (flow.EpochPhase, error) {
+func (_m *Snapshot) EpochPhase() (flow.EpochPhase, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for Phase")
+		panic("no return value specified for EpochPhase")
 	}
 
 	var r0 flow.EpochPhase

--- a/state/protocol/protocol_state.go
+++ b/state/protocol/protocol_state.go
@@ -50,6 +50,7 @@ type EpochProtocolState interface {
 	PreviousEpochExists() bool
 
 	// EpochPhase returns the epoch phase for the current epoch.
+	// See flow.EpochPhase for detailed documentation.
 	EpochPhase() flow.EpochPhase
 
 	// EpochExtensions returns the epoch extensions associated with the current epoch, if any.

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -26,6 +26,7 @@ var _ StateMachine = (*FallbackStateMachine)(nil)
 
 // NewFallbackStateMachine constructs a state machine for epoch fallback. It automatically sets
 // EpochFallbackTriggered to true, thereby recording that we have entered epoch fallback mode.
+// See flow.EpochPhase for detailed documentation about EFM and epoch phase transitions.
 // No errors are expected during normal operations.
 func NewFallbackStateMachine(params protocol.GlobalParams, view uint64, parentState *flow.RichEpochProtocolStateEntry) (*FallbackStateMachine, error) {
 	state := parentState.EpochProtocolStateEntry.Copy()

--- a/state/protocol/protocol_state/epochs/happy_path_statemachine.go
+++ b/state/protocol/protocol_state/epochs/happy_path_statemachine.go
@@ -21,6 +21,7 @@ import (
 //
 // All updates are applied to a copy of parent protocol state, so parent protocol state is not modified. The stateMachine internally
 // tracks the current protocol state. A separate instance should be created for each block to process the updates therein.
+// See flow.EpochPhase for detailed documentation about EFM and epoch phase transitions.
 // TODO(EFM, #6019): this structure needs to be updated to stop using parent state.
 type HappyPathStateMachine struct {
 	baseStateMachine

--- a/state/protocol/snapshot.go
+++ b/state/protocol/snapshot.go
@@ -130,7 +130,7 @@ type Snapshot interface {
 
 	// Phase returns the epoch phase for the current epoch, as of the Head block.
 	// TODO document error returns
-	Phase() (flow.EpochPhase, error)
+	EpochPhase() (flow.EpochPhase, error)
 
 	// Epochs returns a query object enabling querying detailed information about
 	// various epochs.

--- a/state/protocol/snapshot.go
+++ b/state/protocol/snapshot.go
@@ -130,7 +130,6 @@ type Snapshot interface {
 
 	// Phase returns the epoch phase for the current epoch, as of the Head block.
 	// TODO document error returns
-	// TODO(EFM, #6092) update these docs
 	Phase() (flow.EpochPhase, error)
 
 	// Epochs returns a query object enabling querying detailed information about

--- a/state/protocol/snapshot.go
+++ b/state/protocol/snapshot.go
@@ -130,6 +130,7 @@ type Snapshot interface {
 
 	// Phase returns the epoch phase for the current epoch, as of the Head block.
 	// TODO document error returns
+	// TODO(EFM, #6092) update these docs
 	Phase() (flow.EpochPhase, error)
 
 	// Epochs returns a query object enabling querying detailed information about

--- a/utils/unittest/epoch_builder.go
+++ b/utils/unittest/epoch_builder.go
@@ -173,7 +173,7 @@ func (builder *EpochBuilder) BuildEpoch() *EpochBuilder {
 	require.NoError(builder.t, err)
 
 	// check that block A satisfies initial condition
-	phase, err := state.Final().Phase()
+	phase, err := state.Final().EpochPhase()
 	require.NoError(builder.t, err)
 	require.Equal(builder.t, flow.EpochPhaseStaking, phase)
 
@@ -317,7 +317,7 @@ func (builder *EpochBuilder) CompleteEpoch() *EpochBuilder {
 
 	state := builder.states[0]
 
-	phase, err := state.Final().Phase()
+	phase, err := state.Final().EpochPhase()
 	require.Nil(builder.t, err)
 	require.Equal(builder.t, flow.EpochPhaseCommitted, phase)
 	finalView, err := state.Final().Epochs().Current().FinalView()

--- a/utils/unittest/matchers.go
+++ b/utils/unittest/matchers.go
@@ -1,8 +1,6 @@
 package unittest
 
 import (
-	"fmt"
-
 	"github.com/stretchr/testify/mock"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -11,8 +9,6 @@ import (
 // MatchEpochExtension matches an epoch extension argument passed to a mocked component.
 func MatchEpochExtension(finalView, extensionLen uint64) any {
 	return mock.MatchedBy(func(extension flow.EpochExtension) bool {
-		fmt.Println("## ", extension.FirstView, extension.FinalView)
-		fmt.Println("$$ ", finalView+1, finalView+extensionLen)
 		return extension.FirstView == finalView+1 && extension.FinalView == finalView+extensionLen
 	})
 }


### PR DESCRIPTION
This PR adds a new epoch phase to the data model, representing a state where epoch fallback mode has been triggered **and** we are within the view range of the latest committed epoch. 

This phase is subtly different than the existing `EpochFallbackTriggered` flag in the protocol state:
- `EpochFallbackTriggered` may be true while in `EpochPhaseCommitted` (in this case the protocol state flag and the epoch phase are "unsynchronized")
- If current phase is not `EpochPhaseCommitted`, then when `EpochFallbackTriggered` is true, we must be in `EpochPhaseFallback`