### PR TITLE
[Flow EVM] fix the issue with the hash calculation of the direct calls

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -110,10 +110,7 @@ func (bl *BlockView) DirectCall(call *types.DirectCall) (*types.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	txHash, err := call.Hash()
-	if err != nil {
-		return nil, err
-	}
+	txHash := call.Hash()
 	switch call.SubType {
 	case types.DepositCallSubType:
 		return proc.mintTo(call, txHash)

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -60,9 +60,7 @@ func TestNativeTokenBridging(t *testing.T) {
 						res, err := blk.DirectCall(call)
 						require.NoError(t, err)
 						require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
-						expectedHash, err := call.Hash()
-						require.NoError(t, err)
-						require.Equal(t, expectedHash, res.TxHash)
+						require.Equal(t, call.Hash(), res.TxHash)
 						nonce += 1
 					})
 				})
@@ -94,9 +92,7 @@ func TestNativeTokenBridging(t *testing.T) {
 						res, err := blk.DirectCall(call)
 						require.NoError(t, err)
 						require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
-						expectedHash, err := call.Hash()
-						require.NoError(t, err)
-						require.Equal(t, expectedHash, res.TxHash)
+						require.Equal(t, call.Hash(), res.TxHash)
 						nonce += 1
 					})
 				})
@@ -155,9 +151,7 @@ func TestContractInteraction(t *testing.T) {
 						require.NoError(t, err)
 						require.NotNil(t, res.DeployedContractAddress)
 						contractAddr = *res.DeployedContractAddress
-						expectedHash, err := call.Hash()
-						require.NoError(t, err)
-						require.Equal(t, expectedHash, res.TxHash)
+						require.Equal(t, call.Hash(), res.TxHash)
 						nonce += 1
 					})
 					RunWithNewReadOnlyBlockView(t, env, func(blk types.ReadOnlyBlockView) {

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -100,7 +100,7 @@ func (dc *DirectCall) Message() *gethCore.Message {
 
 // Transaction constructs a geth.Transaction from the direct call
 func (dc *DirectCall) Transaction() *gethTypes.Transaction {
-	// Since legacyTX for a direct call doesn't have a valid siganture
+	// Since a direct call doesn't have a valid siganture
 	// and we need to somehow include the From feild for the purpose
 	// of hash calculation. we define the canonical format by
 	// using the FROM bytes to set the bytes for the R part of the tx (big endian),

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -73,12 +73,12 @@ func (dc *DirectCall) Encode() ([]byte, error) {
 }
 
 // Hash computes the hash of a direct call
-func (dc *DirectCall) Hash() (gethCommon.Hash, error) {
+func (dc *DirectCall) Hash() gethCommon.Hash {
 	// we use geth transaction hash calculation since direct call hash is included in the
 	// block transaction hashes, and thus observed as any other transaction
 	// We construct this Legacy tx type so the external 3rd party tools
 	// don't have to support a new type for the purpose of hash computation
-	return dc.Transaction().Hash(), nil
+	return dc.Transaction().Hash()
 }
 
 // Message constructs a core.Message from the direct call

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -77,7 +77,7 @@ func (dc *DirectCall) Hash() (gethCommon.Hash, error) {
 	// we use geth transaction hash calculation since direct call hash is included in the
 	// block transaction hashes, and thus observed as any other transaction
 	// We construct this Legacy tx type so the external 3rd party tools
-	// doesn't have to support a new type for the purpose of hash computation
+	// don't have to support a new type for the purpose of hash computation
 	return dc.Transaction().Hash(), nil
 }
 

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -76,8 +76,8 @@ func (dc *DirectCall) Encode() ([]byte, error) {
 func (dc *DirectCall) Hash() (gethCommon.Hash, error) {
 	// we use geth transaction hash calculation since direct call hash is included in the
 	// block transaction hashes, and thus observed as any other transaction
-	// We construct thislLegacy tx type so the external 3rd party tools
-	// doesn't have to support a new type for hash computation
+	// We construct this Legacy tx type so the external 3rd party tools
+	// doesn't have to support a new type for the purpose of hash computation
 	return dc.Transaction().Hash(), nil
 }
 

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -104,7 +104,7 @@ func (dc *DirectCall) Transaction() *gethTypes.Transaction {
 	// and we need to somehow include the From feild for the purpose
 	// of hash calculation. we define the canonical format by
 	// using the FROM bytes to set the bytes for the R part of the tx (big endian),
-	// all bytes are S is kept to zero and V is set to DirectCallTxType (255).
+	// S captures the subtype of transaction and V is set to DirectCallTxType (255).
 	return gethTypes.NewTx(&gethTypes.LegacyTx{
 		GasPrice: big.NewInt(0),
 		Gas:      dc.GasLimit,
@@ -112,8 +112,9 @@ func (dc *DirectCall) Transaction() *gethTypes.Transaction {
 		Value:    dc.Value,
 		Data:     dc.Data,
 		Nonce:    dc.Nonce,
-		V:        new(big.Int).SetBytes(dc.From.Bytes()),
-		S:        big.NewInt(255),
+		R:        new(big.Int).SetBytes(dc.From.Bytes()),
+		S:        new(big.Int).SetBytes([]byte{dc.SubType}),
+		V:        new(big.Int).SetBytes([]byte{DirectCallTxType}),
 	})
 }
 

--- a/fvm/evm/types/call_test.go
+++ b/fvm/evm/types/call_test.go
@@ -26,7 +26,7 @@ func TestDirectCall(t *testing.T) {
 	t.Run("calculate hash", func(t *testing.T) {
 		h, err := dc.Hash()
 		require.NoError(t, err)
-		assert.Equal(t, "0xe087d6979a543d4b305f522b39a703307cbe97ed951b25d4134ec92e9e3965dd", h.Hex())
+		assert.Equal(t, "0xed76124cc3c59f13e1113f5c380e2a67dab9bf616afc645073d2491fe3aecb62", h.Hex())
 
 		// the hash should stay the same after RLP encoding and decoding
 		var b bytes.Buffer
@@ -39,7 +39,7 @@ func TestDirectCall(t *testing.T) {
 		require.NoError(t, err)
 
 		h = reconstructedTx.Hash()
-		assert.Equal(t, "0xe087d6979a543d4b305f522b39a703307cbe97ed951b25d4134ec92e9e3965dd", h.Hex())
+		assert.Equal(t, "0xed76124cc3c59f13e1113f5c380e2a67dab9bf616afc645073d2491fe3aecb62", h.Hex())
 	})
 
 	t.Run("same content except `from` should result in different hashes", func(t *testing.T) {
@@ -65,8 +65,8 @@ func TestDirectCall(t *testing.T) {
 		assert.Equal(t, uint64(0), tx.Nonce()) // no nonce exists for direct call
 
 		v, r, s := tx.RawSignatureValues()
-		require.Equal(t, dc.From.Bytes(), v.Bytes())
-		require.Empty(t, r.Bytes())
-		require.Equal(t, s.Bytes()[0], DirectCallTxType)
+		require.Equal(t, dc.From.Bytes(), r.Bytes())
+		require.Equal(t, []byte{dc.SubType}, s.Bytes())
+		require.Equal(t, []byte{DirectCallTxType}, v.Bytes())
 	})
 }

--- a/fvm/evm/types/call_test.go
+++ b/fvm/evm/types/call_test.go
@@ -24,14 +24,13 @@ func TestDirectCall(t *testing.T) {
 	}
 
 	t.Run("calculate hash", func(t *testing.T) {
-		h, err := dc.Hash()
-		require.NoError(t, err)
+		h := dc.Hash()
 		assert.Equal(t, "0xed76124cc3c59f13e1113f5c380e2a67dab9bf616afc645073d2491fe3aecb62", h.Hex())
 
 		// the hash should stay the same after RLP encoding and decoding
 		var b bytes.Buffer
 		writer := io.Writer(&b)
-		err = dc.Transaction().EncodeRLP(writer)
+		err := dc.Transaction().EncodeRLP(writer)
 		require.NoError(t, err)
 
 		reconstructedTx := &gethTypes.Transaction{}
@@ -43,20 +42,15 @@ func TestDirectCall(t *testing.T) {
 	})
 
 	t.Run("same content except `from` should result in different hashes", func(t *testing.T) {
-		h, err := dc.Hash()
-		require.NoError(t, err)
-
+		h := dc.Hash()
 		dc.From = Address{0x4, 0x5}
-		h2, err := dc.Hash()
-		require.NoError(t, err)
-
+		h2 := dc.Hash()
 		assert.NotEqual(t, h2.Hex(), h.Hex())
 	})
 
 	t.Run("construct transaction", func(t *testing.T) {
 		tx := dc.Transaction()
-		h, err := dc.Hash()
-		require.NoError(t, err)
+		h := dc.Hash()
 		assert.Equal(t, dc.Value, tx.Value())
 		assert.Equal(t, dc.To.ToCommon(), *tx.To())
 		assert.Equal(t, h, tx.Hash())


### PR DESCRIPTION
Closes: #6115 

To support the 3rd party tools that are not Flow aware, we compute the hash for the direct calls using Legacy Tx format. Yet we don't have signatures, and the uniqueness of hash values is dependent on the source (From field) and nonce. In this PR we define a canonical format for the legacy tx where we include the source information as part of the signatures (V) and we also define what should be set for R, and S.