### PR TITLE
Optimize contracts checking migration

### DIFF
--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -1274,6 +1274,16 @@ func TestProgramParsingError(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	encodedContractNames, err := environment.EncodeContractNames([]string{contractName})
+	require.NoError(t, err)
+
+	err = registersByAccount.Set(
+		string(testAddress[:]),
+		flow.ContractNamesKey,
+		encodedContractNames,
+	)
+	require.NoError(t, err)
+
 	// Migrate
 
 	// TODO: EVM contract is not deployed in snapshot yet, so can't update it

--- a/cmd/util/ledger/migrations/contract_checking_migration.go
+++ b/cmd/util/ledger/migrations/contract_checking_migration.go
@@ -43,6 +43,8 @@ func NewContractCheckingMigration(
 
 		// Gather all contracts
 
+		log.Info().Msg("Gathering contracts ...")
+
 		contractsForPrettyPrinting := make(map[common.Location][]byte, contractCountEstimate)
 
 		type contract struct {
@@ -101,6 +103,8 @@ func NewContractCheckingMigration(
 			b := contracts[j]
 			return a.location.ID() < b.location.ID()
 		})
+
+		log.Info().Msgf("Gathered all contracts (%d)", len(contracts))
 
 		// Check all contracts
 

--- a/cmd/util/ledger/migrations/contract_checking_migration.go
+++ b/cmd/util/ledger/migrations/contract_checking_migration.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -50,35 +51,49 @@ func NewContractCheckingMigration(
 		}
 		contracts := make([]contract, 0, contractCountEstimate)
 
-		err = registersByAccount.ForEach(func(owner string, key string, value []byte) error {
+		err = registersByAccount.ForEachAccount(func(accountRegisters *registers.AccountRegisters) error {
+			owner := accountRegisters.Owner()
 
-			// Skip payloads that are not contract code
-			contractName := flow.KeyContractName(key)
-			if contractName == "" {
-				return nil
+			encodedContractNames, err := accountRegisters.Get(owner, flow.ContractNamesKey)
+			if err != nil {
+				return err
 			}
 
-			address := common.Address([]byte(owner))
-			code := value
-			location := common.AddressLocation{
-				Address: address,
-				Name:    contractName,
+			contractNames, err := environment.DecodeContractNames(encodedContractNames)
+			if err != nil {
+				return err
 			}
 
-			contracts = append(
-				contracts,
-				contract{
-					location: location,
-					code:     code,
-				},
-			)
+			for _, contractName := range contractNames {
 
-			contractsForPrettyPrinting[location] = code
+				contractKey := flow.ContractKey(contractName)
+
+				code, err := accountRegisters.Get(owner, contractKey)
+				if err != nil {
+					return err
+				}
+
+				address := common.Address([]byte(owner))
+				location := common.AddressLocation{
+					Address: address,
+					Name:    contractName,
+				}
+
+				contracts = append(
+					contracts,
+					contract{
+						location: location,
+						code:     code,
+					},
+				)
+
+				contractsForPrettyPrinting[location] = code
+			}
 
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("failed to iterate over registers: %w", err)
+			return fmt.Errorf("failed to get contracts of accounts: %w", err)
 		}
 
 		sort.Slice(contracts, func(i, j int) bool {

--- a/cmd/util/ledger/migrations/contract_checking_migration.go
+++ b/cmd/util/ledger/migrations/contract_checking_migration.go
@@ -31,6 +31,7 @@ func NewContractCheckingMigration(
 	return func(registersByAccount *registers.ByAccount) error {
 
 		reporter := rwf.ReportWriter(contractCheckingReporterName)
+		defer reporter.Close()
 
 		mr, err := NewInterpreterMigrationRuntime(
 			registersByAccount,
@@ -152,8 +153,6 @@ func NewContractCheckingMigration(
 				programs[location] = program
 			}
 		}
-
-		reporter.Close()
 
 		return nil
 	}


### PR DESCRIPTION
Avoid iterating over all registers just to find the contract code registers, by getting all contract names from the contract names register, and directly looking up contract code registers.

This required exposing the contract names register encoding and decoding.