### PR TITLE
Port PR 5901 from Cadence 1.0 migration to atree migration

### DIFF
--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sort"
 	"sync"
 	"time"
 
@@ -218,14 +217,33 @@ func MigrateGroupConcurrently(
 	go func() {
 		defer close(jobs)
 
-		allAccountRegisters := make([]*registers.AccountRegisters, 0, accountCount)
+		// TODO: maybe adjust, make configurable, or dependent on chain
+		const keepTopNAccountRegisters = 20
+		largestAccountRegisters := util.NewTopN[*registers.AccountRegisters](
+			keepTopNAccountRegisters,
+			func(a, b *registers.AccountRegisters) bool {
+				return a.Count() < b.Count()
+			},
+		)
 
+		allAccountRegisters := make([]*registers.AccountRegisters, accountCount)
+
+		smallerAccountRegisterIndex := keepTopNAccountRegisters
 		err := registersByAccount.ForEachAccount(
 			func(accountRegisters *registers.AccountRegisters) error {
-				allAccountRegisters = append(
-					allAccountRegisters,
-					accountRegisters,
-				)
+
+				// Try to add the account registers to the top N largest account registers.
+				// If there is an "overflow" element (either the added element, or an existing element),
+				// add it to the account registers.
+				// This way we can process the largest account registers first,
+				// and do not need to sort all account registers.
+
+				popped, didPop := largestAccountRegisters.Add(accountRegisters)
+				if didPop {
+					allAccountRegisters[smallerAccountRegisterIndex] = popped
+					smallerAccountRegisterIndex++
+				}
+
 				return nil
 			},
 		)
@@ -233,12 +251,12 @@ func MigrateGroupConcurrently(
 			cancel(fmt.Errorf("failed to get all account registers: %w", err))
 		}
 
-		// Schedule jobs in descending order of the number of registers
-		sort.Slice(allAccountRegisters, func(i, j int) bool {
-			a := allAccountRegisters[i]
-			b := allAccountRegisters[j]
-			return a.Count() > b.Count()
-		})
+		// Add the largest account registers to the account registers.
+		// The elements in the top N largest account registers are returned in reverse order.
+		for index := largestAccountRegisters.Len() - 1; index >= 0; index-- {
+			accountRegisters := heap.Pop(largestAccountRegisters).(*registers.AccountRegisters)
+			allAccountRegisters[index] = accountRegisters
+		}
 
 		for _, accountRegisters := range allAccountRegisters {
 			owner := accountRegisters.Owner()

--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"time"
 
@@ -221,28 +222,48 @@ func MigrateGroupConcurrently(
 
 	go func() {
 		defer close(jobs)
+
+		allAccountRegisters := make([]*registers.AccountRegisters, 0, accountCount)
+
 		err := registersByAccount.ForEachAccount(
-			func(owner string, accountRegisters *registers.AccountRegisters) error {
-				address, err := common.BytesToAddress([]byte(owner))
-				if err != nil {
-					return err
-				}
-				job := jobMigrateAccountGroup{
-					Address:          address,
-					AccountRegisters: accountRegisters,
-				}
-
-				select {
-				case <-ctx.Done():
-					return nil
-				case jobs <- job:
-				}
-
+			func(accountRegisters *registers.AccountRegisters) error {
+				allAccountRegisters = append(
+					allAccountRegisters,
+					accountRegisters,
+				)
 				return nil
 			},
 		)
 		if err != nil {
-			cancel(fmt.Errorf("failed to schedule jobs for all accounts: %w", err))
+			cancel(fmt.Errorf("failed to get all account registers: %w", err))
+		}
+
+		// Schedule jobs in descending order of the number of registers
+		sort.Slice(allAccountRegisters, func(i, j int) bool {
+			a := allAccountRegisters[i]
+			b := allAccountRegisters[j]
+			return a.Count() > b.Count()
+		})
+
+		for _, accountRegisters := range allAccountRegisters {
+			owner := accountRegisters.Owner()
+
+			address, err := common.BytesToAddress([]byte(owner))
+			if err != nil {
+				cancel(fmt.Errorf("failed to convert owner to address: %w", err))
+				return
+			}
+
+			job := jobMigrateAccountGroup{
+				Address:          address,
+				AccountRegisters: accountRegisters,
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- job:
+			}
 		}
 	}()
 

--- a/cmd/util/ledger/migrations/account_based_migration.go
+++ b/cmd/util/ledger/migrations/account_based_migration.go
@@ -292,7 +292,7 @@ func MigrateGroupConcurrently(
 	topDurations := util.NewTopN[migrationDuration](
 		logTopNDurations,
 		func(duration migrationDuration, duration2 migrationDuration) bool {
-			return duration.Duration > duration2.Duration
+			return duration.Duration < duration2.Duration
 		},
 	)
 

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -135,9 +135,9 @@ func (b *ByAccount) DestructIntoPayloads(nWorker int) []*ledger.Payload {
 	return payloads
 }
 
-func (b *ByAccount) ForEachAccount(f func(owner string, accountRegisters *AccountRegisters) error) error {
-	for owner, accountRegisters := range b.registers {
-		err := f(owner, accountRegisters)
+func (b *ByAccount) ForEachAccount(f func(accountRegisters *AccountRegisters) error) error {
+	for _, accountRegisters := range b.registers {
+		err := f(accountRegisters)
 		if err != nil {
 			return err
 		}

--- a/cmd/util/ledger/util/topn.go
+++ b/cmd/util/ledger/util/topn.go
@@ -7,16 +7,16 @@ import (
 // TopN keeps track of the top N elements.
 // Use Add to add elements to the list.
 type TopN[T any] struct {
-	Tree     []T
-	N        int
-	IsLarger func(T, T) bool
+	Tree   []T
+	N      int
+	IsLess func(T, T) bool
 }
 
-func NewTopN[T any](n int, isLarger func(T, T) bool) *TopN[T] {
+func NewTopN[T any](n int, isLess func(T, T) bool) *TopN[T] {
 	return &TopN[T]{
-		Tree:     make([]T, 0, n),
-		N:        n,
-		IsLarger: isLarger,
+		Tree:   make([]T, 0, n),
+		N:      n,
+		IsLess: isLess,
 	}
 }
 
@@ -27,7 +27,7 @@ func (h *TopN[T]) Len() int {
 func (h *TopN[T]) Less(i, j int) bool {
 	a := h.Tree[i]
 	b := h.Tree[j]
-	return h.IsLarger(a, b)
+	return h.IsLess(a, b)
 }
 
 func (h *TopN[T]) Swap(i, j int) {
@@ -50,9 +50,15 @@ func (h *TopN[T]) Pop() interface{} {
 	return last
 }
 
-func (h *TopN[T]) Add(value T) {
+// Add tries to add a value to the list.
+// If the list is full, it will return the smallest value and true.
+// If the list is not full, it will return the zero value and false.
+func (h *TopN[T]) Add(value T) (popped T, didPop bool) {
 	heap.Push(h, value)
 	if h.Len() > h.N {
-		heap.Pop(h)
+		popped := heap.Pop(h).(T)
+		return popped, true
 	}
+	var empty T
+	return empty, false
 }

--- a/cmd/util/ledger/util/topn.go
+++ b/cmd/util/ledger/util/topn.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"container/heap"
+)
+
+// TopN keeps track of the top N elements.
+// Use Add to add elements to the list.
+type TopN[T any] struct {
+	Tree     []T
+	N        int
+	IsLarger func(T, T) bool
+}
+
+func NewTopN[T any](n int, isLarger func(T, T) bool) *TopN[T] {
+	return &TopN[T]{
+		Tree:     make([]T, 0, n),
+		N:        n,
+		IsLarger: isLarger,
+	}
+}
+
+func (h *TopN[T]) Len() int {
+	return len(h.Tree)
+}
+
+func (h *TopN[T]) Less(i, j int) bool {
+	a := h.Tree[i]
+	b := h.Tree[j]
+	return h.IsLarger(a, b)
+}
+
+func (h *TopN[T]) Swap(i, j int) {
+	h.Tree[i], h.Tree[j] =
+		h.Tree[j], h.Tree[i]
+}
+
+func (h *TopN[T]) Push(x interface{}) {
+	h.Tree = append(h.Tree, x.(T))
+}
+
+func (h *TopN[T]) Pop() interface{} {
+	tree := h.Tree
+	count := len(tree)
+	lastIndex := count - 1
+	last := tree[lastIndex]
+	var empty T
+	tree[lastIndex] = empty
+	h.Tree = tree[0:lastIndex]
+	return last
+}
+
+func (h *TopN[T]) Add(value T) {
+	heap.Push(h, value)
+	if h.Len() > h.N {
+		heap.Pop(h)
+	}
+}

--- a/cmd/util/ledger/util/topn_test.go
+++ b/cmd/util/ledger/util/topn_test.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTopN(t *testing.T) {
+	t.Parallel()
+
+	topN := NewTopN(
+		3,
+		func(a, b int) bool {
+			return a < b
+		},
+	)
+
+	topN.Add(5)
+	assert.ElementsMatch(t,
+		[]int{5},
+		topN.Tree,
+	)
+
+	topN.Add(2)
+	assert.ElementsMatch(t,
+		[]int{5, 2},
+		topN.Tree,
+	)
+
+	topN.Add(3)
+	assert.ElementsMatch(t,
+		[]int{5, 3, 2},
+		topN.Tree,
+	)
+
+	topN.Add(3)
+	assert.ElementsMatch(t,
+		[]int{5, 3, 3},
+		topN.Tree,
+	)
+
+	topN.Add(1)
+	assert.ElementsMatch(t,
+		[]int{5, 3, 3},
+		topN.Tree,
+	)
+
+	topN.Add(4)
+	assert.ElementsMatch(t,
+		[]int{5, 4, 3},
+		topN.Tree,
+	)
+
+	sorted := make([]int, len(topN.Tree))
+	for index := topN.Len() - 1; index >= 0; index-- {
+		sorted[index] = heap.Pop(topN).(int)
+	}
+	assert.Equal(t,
+		[]int{5, 4, 3},
+		sorted,
+	)
+	assert.Empty(t, topN.Tree)
+}

--- a/cmd/util/ledger/util/topn_test.go
+++ b/cmd/util/ledger/util/topn_test.go
@@ -17,37 +17,46 @@ func TestTopN(t *testing.T) {
 		},
 	)
 
-	topN.Add(5)
+	_, didPop := topN.Add(5)
+	assert.False(t, didPop)
 	assert.ElementsMatch(t,
 		[]int{5},
 		topN.Tree,
 	)
 
-	topN.Add(2)
+	_, didPop = topN.Add(2)
+	assert.False(t, didPop)
 	assert.ElementsMatch(t,
 		[]int{5, 2},
 		topN.Tree,
 	)
 
-	topN.Add(3)
+	_, didPop = topN.Add(3)
+	assert.False(t, didPop)
 	assert.ElementsMatch(t,
 		[]int{5, 3, 2},
 		topN.Tree,
 	)
 
-	topN.Add(3)
+	popped, didPop := topN.Add(3)
+	assert.True(t, didPop)
+	assert.Equal(t, 2, popped)
 	assert.ElementsMatch(t,
 		[]int{5, 3, 3},
 		topN.Tree,
 	)
 
-	topN.Add(1)
+	popped, didPop = topN.Add(1)
+	assert.True(t, didPop)
+	assert.Equal(t, 1, popped)
 	assert.ElementsMatch(t,
 		[]int{5, 3, 3},
 		topN.Tree,
 	)
 
-	topN.Add(4)
+	popped, didPop = topN.Add(4)
+	assert.True(t, didPop)
+	assert.Equal(t, 3, popped)
 	assert.ElementsMatch(t,
 		[]int{5, 4, 3},
 		topN.Tree,


### PR DESCRIPTION
Closes #6130

This ports @turbolent's optimization to process largest accounts first since they take longer.

