### PR TITLE
Add a buffer gas of "all but one 64th" for gas used on `EVM.dryRun`

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -245,7 +245,7 @@ func (bl *BlockView) DryRunTransaction(
 		// allowed amount, call with all but one 64th of the maximum allowed amount of
 		// gas (this is equivalent to a version of EIP-901 plus EIP-1142).
 		// CREATE only provides all but one 64th of the parent gas to the child call.
-		txResult.GasConsumed = txResult.GasConsumed + (txResult.GasConsumed / 64)
+		txResult.GasConsumed = AddOne64th(txResult.GasConsumed)
 
 		// Adding `gethParams.SstoreSentryGasEIP2200` is needed for this condition:
 		// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
@@ -568,4 +568,9 @@ func (proc *procedure) run(
 		}
 	}
 	return &res, nil
+}
+
+func AddOne64th(n uint64) uint64 {
+	// NOTE: Go's integer division floors, but that is desirable here
+	return n + (n / 64)
 }

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -236,9 +236,21 @@ func (bl *BlockView) DryRunTransaction(
 	// return without commiting the state
 	txResult, err := proc.run(msg, tx.Hash(), 0, tx.Type())
 	if txResult.Successful() {
+		// As mentioned in https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md#specification
+		// Define "all but one 64th" of N as N - floor(N / 64).
+		// If a call asks for more gas than the maximum allowed amount
+		// (i.e. the total amount of gas remaining in the parent after subtracting
+		// the gas cost of the call and memory expansion), do not return an OOG error;
+		// instead, if a call asks for more gas than all but one 64th of the maximum
+		// allowed amount, call with all but one 64th of the maximum allowed amount of
+		// gas (this is equivalent to a version of EIP-901 plus EIP-1142).
+		// CREATE only provides all but one 64th of the parent gas to the child call.
+		txResult.GasConsumed = txResult.GasConsumed + (txResult.GasConsumed / 64)
+
 		// Adding `gethParams.SstoreSentryGasEIP2200` is needed for this condition:
 		// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
 		txResult.GasConsumed += gethParams.SstoreSentryGasEIP2200
+
 		// Take into account any gas refunds, which are calculated only after
 		// transaction execution.
 		txResult.GasConsumed += txResult.GasRefund

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -1534,9 +1534,10 @@ func TestDryRun(t *testing.T) {
 				// Make sure that gas consumed from `EVM.dryRun` is bigger
 				// than the actual gas consumption of the equivalent
 				// `EVM.run`.
+				expected := res.GasConsumed + (res.GasConsumed / 64) + gethParams.SstoreSentryGasEIP2200
 				require.Equal(
 					t,
-					res.GasConsumed+gethParams.SstoreSentryGasEIP2200,
+					expected,
 					dryRunResult.GasConsumed,
 				)
 			})
@@ -1667,9 +1668,10 @@ func TestDryRun(t *testing.T) {
 				// Make sure that gas consumed from `EVM.dryRun` is bigger
 				// than the actual gas consumption of the equivalent
 				// `EVM.run`.
+				expected := res.GasConsumed + (res.GasConsumed / 64) + gethParams.SstoreSentryGasEIP2200
 				require.Equal(
 					t,
-					res.GasConsumed+gethParams.SstoreSentryGasEIP2200,
+					expected,
 					dryRunResult.GasConsumed,
 				)
 			})
@@ -1798,9 +1800,10 @@ func TestDryRun(t *testing.T) {
 				// Make sure that gas consumed from `EVM.dryRun` is bigger
 				// than the actual gas consumption of the equivalent
 				// `EVM.run`.
+				expected := res.GasConsumed + (res.GasConsumed / 64) + gethParams.SstoreSentryGasEIP2200 + gethParams.SstoreClearsScheduleRefundEIP3529
 				require.Equal(
 					t,
-					res.GasConsumed+gethParams.SstoreSentryGasEIP2200+gethParams.SstoreClearsScheduleRefundEIP3529,
+					expected,
 					dryRunResult.GasConsumed,
 				)
 			})

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/flow-go/fvm/crypto"
 	envMock "github.com/onflow/flow-go/fvm/environment/mock"
 	"github.com/onflow/flow-go/fvm/evm"
+	"github.com/onflow/flow-go/fvm/evm/emulator"
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	"github.com/onflow/flow-go/fvm/evm/testutils"
 	. "github.com/onflow/flow-go/fvm/evm/testutils"
@@ -1534,10 +1535,10 @@ func TestDryRun(t *testing.T) {
 				// Make sure that gas consumed from `EVM.dryRun` is bigger
 				// than the actual gas consumption of the equivalent
 				// `EVM.run`.
-				expected := res.GasConsumed + (res.GasConsumed / 64) + gethParams.SstoreSentryGasEIP2200
+				totalGas := emulator.AddOne64th(res.GasConsumed) + gethParams.SstoreSentryGasEIP2200
 				require.Equal(
 					t,
-					expected,
+					totalGas,
 					dryRunResult.GasConsumed,
 				)
 			})
@@ -1668,10 +1669,10 @@ func TestDryRun(t *testing.T) {
 				// Make sure that gas consumed from `EVM.dryRun` is bigger
 				// than the actual gas consumption of the equivalent
 				// `EVM.run`.
-				expected := res.GasConsumed + (res.GasConsumed / 64) + gethParams.SstoreSentryGasEIP2200
+				totalGas := emulator.AddOne64th(res.GasConsumed) + gethParams.SstoreSentryGasEIP2200
 				require.Equal(
 					t,
-					expected,
+					totalGas,
 					dryRunResult.GasConsumed,
 				)
 			})
@@ -1800,10 +1801,10 @@ func TestDryRun(t *testing.T) {
 				// Make sure that gas consumed from `EVM.dryRun` is bigger
 				// than the actual gas consumption of the equivalent
 				// `EVM.run`.
-				expected := res.GasConsumed + (res.GasConsumed / 64) + gethParams.SstoreSentryGasEIP2200 + gethParams.SstoreClearsScheduleRefundEIP3529
+				totalGas := emulator.AddOne64th(res.GasConsumed) + gethParams.SstoreSentryGasEIP2200 + gethParams.SstoreClearsScheduleRefundEIP3529
 				require.Equal(
 					t,
-					expected,
+					totalGas,
 					dryRunResult.GasConsumed,
 				)
 			})


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/6135

Addresses the case from [EIP-150](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md#specification)

> - Define "all but one 64th" of N as N - floor(N / 64).
> - If a call asks for more gas than the maximum allowed amount (i.e. the total amount of gas remaining in the parent after subtracting the gas cost of the call and memory expansion), do not return an OOG error; instead, if a call asks for more gas than all but one 64th of the maximum allowed amount, call with all but one 64th of the maximum allowed amount of gas (this is equivalent to a version of EIP-90https://github.com/ethereum/EIPs/issues/90 plus EIP-114https://github.com/ethereum/EIPs/issues/114). CREATE only provides all but one 64th of the parent gas to the child call.