### PR TITLE
[Tools] Add a script to move checkpoint files

### DIFF
--- a/tools/move-checkpoint.sh
+++ b/tools/move-checkpoint.sh
@@ -34,27 +34,65 @@ fi
 source_base=$(basename "$source_file_pattern")
 
 # Extract the directory and base name from the destination file base
+source_directory=$(dirname "$source_file_pattern")
 destination_directory=$(dirname "$destination_file_base")
 destination_base=$(basename "$destination_file_base")
 
 # Create the destination directory if it doesn't exist
 mkdir -p "$destination_directory"
 
-# Loop through the source files and move them to the destination directory
-for file in "$source_file_pattern"*;
-do
-    if [ -f "$file" ]; then
+# Define the expected files
+expected_files=(
+    "$source_base"
+    "$source_base.001"
+    "$source_base.002"
+    "$source_base.003"
+    "$source_base.004"
+    "$source_base.005"
+    "$source_base.006"
+    "$source_base.007"
+    "$source_base.008"
+    "$source_base.009"
+    "$source_base.010"
+    "$source_base.011"
+    "$source_base.012"
+    "$source_base.013"
+    "$source_base.014"
+    "$source_base.015"
+    "$source_base.016"
+)
+
+# Check if all expected files are present
+missing_files=()
+for expected_file in "${expected_files[@]}"; do
+    full_expected_file="$source_directory/$expected_file"
+    if [ ! -f "$full_expected_file" ]; then
+        missing_files+=("$full_expected_file")
+    fi
+done
+
+if [ "${#missing_files[@]}" -ne 0 ]; then
+    echo "Error: The following expected files are missing:"
+    for file in "${missing_files[@]}"; do
+        echo "  $file"
+    done
+    exit 1
+fi
+
+# Loop through the expected files and preview/move them to the destination directory
+for file in "${expected_files[@]}"; do
+    full_source_file="$source_directory/$file"
+    if [ -f "$full_source_file" ]; then
         # Get the file extension (if any)
-        extension="${file#$source_file_pattern}"
+        extension="${file#$source_base}"
         # Construct the destination file name
         destination_file="$destination_directory/$destination_base$extension"
-
         # Preview or move the file
         if [ "$run_mode" = true ]; then
-            echo "Moving: $(realpath "$file") -> $(realpath "$destination_file")"
-            mv "$file" "$destination_file"
+            echo "Moving: $(realpath "$full_source_file") -> $(realpath "$destination_file")"
+            mv "$full_source_file" "$destination_file"
         else
-            echo "Preview: $(realpath "$file") -> $(realpath "$destination_file")"
+            echo "Preview: $(realpath "$full_source_file") -> $(realpath "$destination_file")"
         fi
     fi
 done

--- a/tools/move-checkpoint.sh
+++ b/tools/move-checkpoint.sh
@@ -37,8 +37,7 @@ do
         destination_file="$destination_directory/$destination_base$extension"
         # Move the file
         echo "Moved: $(realpath "$file") -> $(realpath "$destination_file")"
-
-        echo "Moved: $file -> $destination_file"
+        mv "$file" "$destination_file"
     fi
 done
 

--- a/tools/move-checkpoint.sh
+++ b/tools/move-checkpoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Check if exactly two arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Description: move checkpoint files from one directory to another"
+    echo "Usage: $0 source_file destination_file"
+    echo "Example: $0 /var/flow/from-folder/checkpoint.000010 /var/flow/to-folder/root.checkpoint"
+    echo "The above command will move the checkpoint files including its 17 subfiles to the destination folder and rename them"
+
+    exit 1
+fi
+
+# Assign arguments to variables
+source_file_pattern=$1
+destination_file_base=$2
+
+# Extract the basename from the source file pattern
+source_base=$(basename "$source_file_pattern")
+
+# Extract the directory and base name from the destination file base
+destination_directory=$(dirname "$destination_file_base")
+destination_base=$(basename "$destination_file_base")
+
+# Create the destination directory if it doesn't exist
+mkdir -p "$destination_directory"
+
+# Loop through the source files and move them to the destination directory
+for file in "$source_file_pattern"*;
+do
+    if [ -f "$file" ]; then
+        # Get the file extension (if any)
+        extension="${file#$source_file_pattern}"
+        # Construct the destination file name
+        destination_file="$destination_directory/$destination_base$extension"
+        # Move the file
+        echo "Moved: $(realpath "$file") -> $(realpath "$destination_file")"
+
+        echo "Moved: $file -> $destination_file"
+    fi
+done
+
+echo "Checkpoint files are moved successfully."

--- a/tools/move-checkpoint.sh
+++ b/tools/move-checkpoint.sh
@@ -36,7 +36,7 @@ do
         # Construct the destination file name
         destination_file="$destination_directory/$destination_base$extension"
         # Move the file
-        echo "Moved: $(realpath "$file") -> $(realpath "$destination_file")"
+        echo "Moving: $(realpath "$file") -> $(realpath "$destination_file")"
         mv "$file" "$destination_file"
     fi
 done


### PR DESCRIPTION
This PR adds a tool to move checkpoint files. It does both moving and renaming.

See the following example:
```
root@mainnettest-24-execution:/var/flow# bash move-checkpoint.sh test/checkpoint.001 test/root.checkpoint
Moved: /var/flow/test/checkpoint.001 -> /var/flow/test/root.checkpoint
Moved: /var/flow/test/checkpoint.001.000 -> /var/flow/test/root.checkpoint.000
Moved: /var/flow/test/checkpoint.001.001 -> /var/flow/test/root.checkpoint.001
Moved: /var/flow/test/checkpoint.001.002 -> /var/flow/test/root.checkpoint.002
Moved: /var/flow/test/checkpoint.001.003 -> /var/flow/test/root.checkpoint.003
Moved: /var/flow/test/checkpoint.001.004 -> /var/flow/test/root.checkpoint.004
Moved: /var/flow/test/checkpoint.001.005 -> /var/flow/test/root.checkpoint.005
Moved: /var/flow/test/checkpoint.001.006 -> /var/flow/test/root.checkpoint.006
Moved: /var/flow/test/checkpoint.001.007 -> /var/flow/test/root.checkpoint.007
Moved: /var/flow/test/checkpoint.001.008 -> /var/flow/test/root.checkpoint.008
Moved: /var/flow/test/checkpoint.001.009 -> /var/flow/test/root.checkpoint.009
Moved: /var/flow/test/checkpoint.001.010 -> /var/flow/test/root.checkpoint.010
Moved: /var/flow/test/checkpoint.001.011 -> /var/flow/test/root.checkpoint.011
Moved: /var/flow/test/checkpoint.001.012 -> /var/flow/test/root.checkpoint.012
Moved: /var/flow/test/checkpoint.001.013 -> /var/flow/test/root.checkpoint.013
Moved: /var/flow/test/checkpoint.001.014 -> /var/flow/test/root.checkpoint.014
Moved: /var/flow/test/checkpoint.001.015 -> /var/flow/test/root.checkpoint.015
Moved: /var/flow/test/checkpoint.001.016 -> /var/flow/test/root.checkpoint.016
Files moved successfully.
```