### PR TITLE
Fix  Cadence 1.0 migration: Ignore empty contracts when checking all contracts

### DIFF
--- a/cmd/util/ledger/migrations/cadence_test.go
+++ b/cmd/util/ledger/migrations/cadence_test.go
@@ -1,0 +1,69 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestMigrateCadence1EmptyContract(t *testing.T) {
+
+	t.Parallel()
+
+	const chainID = flow.Testnet
+
+	address, err := common.HexToAddress("0x4184b8bdf78db9eb")
+	require.NoError(t, err)
+
+	const contractName = "FungibleToken"
+
+	registersByAccount := registers.NewByAccount()
+
+	err = registersByAccount.Set(
+		string(address[:]),
+		flow.ContractKey(contractName),
+		// some whitespace for testing purposes
+		[]byte(" \t  \n  "),
+	)
+	require.NoError(t, err)
+
+	encodedContractNames, err := environment.EncodeContractNames([]string{contractName})
+	require.NoError(t, err)
+
+	err = registersByAccount.Set(
+		string(address[:]),
+		flow.ContractNamesKey,
+		encodedContractNames,
+	)
+	require.NoError(t, err)
+
+	programs := map[common.Location]*interpreter.Program{}
+
+	rwf := &testReportWriterFactory{}
+
+	// Run contract checking migration
+
+	log := zerolog.Nop()
+	checkingMigration := NewContractCheckingMigration(log, rwf, chainID, false, programs)
+
+	err = checkingMigration(registersByAccount)
+	require.NoError(t, err)
+
+	reporter := rwf.reportWriters[contractCheckingReporterName]
+	assert.Empty(t, reporter.entries)
+
+	// Initialize metrics collecting migration (used to run into unexpected error)
+
+	metricsCollectingMigration := NewMetricsCollectingMigration(log, chainID, rwf, programs)
+
+	err = metricsCollectingMigration.InitMigration(log, registersByAccount, 1)
+	require.NoError(t, err)
+}

--- a/cmd/util/ledger/migrations/contract_checking_migration.go
+++ b/cmd/util/ledger/migrations/contract_checking_migration.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -76,6 +77,10 @@ func NewContractCheckingMigration(
 				code, err := accountRegisters.Get(owner, contractKey)
 				if err != nil {
 					return err
+				}
+
+				if len(bytes.TrimSpace(code)) == 0 {
+					continue
 				}
 
 				address := common.Address([]byte(owner))

--- a/cmd/util/ledger/migrations/migration_metrics_collector.go
+++ b/cmd/util/ledger/migrations/migration_metrics_collector.go
@@ -67,7 +67,7 @@ func (m *MetricsCollectingMigration) InitMigration(
 
 	// If the program is available, that means the associated contracts is compatible with Cadence 1.0.
 	// i.e: the contract is either migrated to be compatible with 1.0 or existing contract already compatible.
-	for _, program := range m.programs {
+	for location, program := range m.programs {
 		var nestedDecls *ast.Members
 
 		contract := program.Program.SoleContractDeclaration()
@@ -80,7 +80,16 @@ func (m *MetricsCollectingMigration) InitMigration(
 		} else {
 			contractInterface := program.Program.SoleContractInterfaceDeclaration()
 			if contractInterface == nil {
-				panic(errors.NewUnreachableError())
+				declarations := program.Program.Declarations()
+				declarationKinds := make([]common.DeclarationKind, 0, len(declarations))
+				for _, declaration := range declarations {
+					declarationKinds = append(declarationKinds, declaration.DeclarationKind())
+				}
+				panic(errors.NewUnexpectedError(
+					"invalid program %s: expected a sole contract or contract interface, got %s",
+					location,
+					declarationKinds,
+				))
 			}
 			nestedDecls = contractInterface.Members
 


### PR DESCRIPTION
Closes onflow/cadence#3436