### PR TITLE
Update Flaky test monitor to use new table

### DIFF
--- a/.github/workflows/actions/test-monitor-process-results/action.yml
+++ b/.github/workflows/actions/test-monitor-process-results/action.yml
@@ -3,8 +3,11 @@ name: Test Monitor - Process Results
 description: Custom action that's used in multiple Flaky Test Monitor jobs to process test results and upload them to BigQuery
 
 inputs:
-  gcp_sa_key:
-    description: 'The GCP service account key for uploading to BigQuery'
+  service_account:
+    description: 'The GCP Service Account'
+    required: true
+  workload_identity_provider:
+    description: 'The GCP Workload Identity Provider'
     required: true
 
 runs:
@@ -14,20 +17,30 @@ runs:
       id: commit_date
       run: echo "::set-output name=date::$(git show --no-patch --no-notes --pretty='%cI' $COMMIT_SHA)"
       shell: bash
+
     - name: Get job run date
       id: job_run_date
       run: echo "::set-output name=date::$(TZ=":UTC" date -Iseconds)"
       shell: bash
+
     - name: Process test results
       run: cat test-output | go run tools/test_monitor/level1/process_summary1_results.go
       env:
         JOB_STARTED: ${{ steps.job_run_date.outputs.date }}
         COMMIT_DATE: ${{ steps.commit_date.outputs.date }}
       shell: bash
-    - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
+
+    - name: Google auth
+      id: auth
+      uses: google-github-actions/auth@v2
       with:
-        service_account_key: ${{ inputs.gcp_sa_key }}
+        service_account: ${{ inputs.service_account }}
+        token_format: 'access_token'
+        workload_identity_provider: ${{ inputs.workload_identity_provider }}
+
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+
     - name: Upload results to BigQuery (skipped tests)
       uses: nick-fields/retry@v2
       with:

--- a/.github/workflows/flaky-test-monitor.yml
+++ b/.github/workflows/flaky-test-monitor.yml
@@ -8,9 +8,12 @@ on:
   push:
     paths:
       - '.github/workflows/flaky-test-monitor.yml'
+permissions:
+  id-token: write
+  contents: read
 
 env:
-  BIGQUERY_DATASET: production_src_flow_test_metrics
+  BIGQUERY_DATASET: dev_src_flow_test_metrics
   BIGQUERY_TABLE: skipped_tests
   BIGQUERY_TABLE2: test_results
   GO_VERSION: "1.22"
@@ -73,7 +76,8 @@ jobs:
           TEST_CATEGORY: unit
         uses: ./.github/workflows/actions/test-monitor-process-results
         with:
-          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.FLAKY_TEST_SERVICE_ACCOUNT }} 
+          workload_identity_provider: ${{ secrets.FLAKY_TEST_WORKLOAD_IDENTITY_PROVIDER }}
 
   unit-test-modules:
     name: Unit Tests (Modules)
@@ -115,7 +119,8 @@ jobs:
           TEST_CATEGORY: ${{ matrix.test_category }}
         uses: ./.github/workflows/actions/test-monitor-process-results
         with:
-          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.FLAKY_TEST_SERVICE_ACCOUNT }} 
+          workload_identity_provider: ${{ secrets.FLAKY_TEST_WORKLOAD_IDENTITY_PROVIDER }}
 
   integration-test:
     name: Integration Tests
@@ -175,4 +180,6 @@ jobs:
           TEST_CATEGORY: ${{ matrix.test_category }}
         uses: ./.github/workflows/actions/test-monitor-process-results
         with:
-          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.FLAKY_TEST_SERVICE_ACCOUNT }} 
+          workload_identity_provider: ${{ secrets.FLAKY_TEST_WORKLOAD_IDENTITY_PROVIDER }}
+


### PR DESCRIPTION
## Description
This PR updates the Flaky Test Monitor workflow to leverage a new BQ table in a separate project. As part of this change, we are using Workload Identity rather than Service Account keys to ensure that we do not rely on persistent secrets. The changes have been made to the repo to make the appropriate secrets/envs available to the workflow.

For an example run of this, please reference the following [workflow run](https://github.com./onflow/flow-go/actions/runs/9652826902). 