### PR TITLE
Improve Cadence 1.0 migration: Clean up contract names and code

### DIFF
--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -242,7 +242,7 @@ func NewCadence1ValueMigrations(
 				log,
 				opts.NWorker,
 				[]AccountBasedMigration{
-					NewContractCleanupMigration(),
+					NewContractCleanupMigration(rwf),
 				},
 			),
 		},

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -237,6 +237,16 @@ func NewCadence1ValueMigrations(
 
 	migs = []NamedMigration{
 		{
+			Name: "cleanup-contracts",
+			Migrate: NewAccountBasedMigration(
+				log,
+				opts.NWorker,
+				[]AccountBasedMigration{
+					NewContractCleanupMigration(),
+				},
+			),
+		},
+		{
 			Name: "check-contracts",
 			Migrate: NewContractCheckingMigration(
 				log,

--- a/cmd/util/ledger/migrations/contract_cleanup_migration.go
+++ b/cmd/util/ledger/migrations/contract_cleanup_migration.go
@@ -1,0 +1,180 @@
+package migrations
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/cadence/runtime/common"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+// ContractCleanupMigration normalized account's contract names and removes empty contracts.
+type ContractCleanupMigration struct {
+	log zerolog.Logger
+}
+
+var _ AccountBasedMigration = &ContractCleanupMigration{}
+
+func NewContractCleanupMigration() *ContractCleanupMigration {
+	return &ContractCleanupMigration{}
+}
+
+func (d *ContractCleanupMigration) InitMigration(
+	log zerolog.Logger,
+	_ *registers.ByAccount,
+	_ int,
+) error {
+	d.log = log.
+		With().
+		Str("migration", "ContractCleanupMigration").
+		Logger()
+
+	return nil
+}
+
+func (d *ContractCleanupMigration) MigrateAccount(
+	_ context.Context,
+	address common.Address,
+	accountRegisters *registers.AccountRegisters,
+) error {
+
+	// Normalize the account's contract names.
+	// This will deduplicate and sort the contract names.
+
+	contractNames, err := d.normalizeContractNames(accountRegisters)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to normalize contract names for %s: %w",
+			address.HexWithPrefix(),
+			err,
+		)
+	}
+
+	// Cleanup the code for each contract.
+	// If the contract code is empty, it will be removed.
+
+	for _, contractName := range contractNames {
+		err = d.cleanupContractCode(accountRegisters, contractName)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to cleanup contract code for %s: %w",
+				address.HexWithPrefix(),
+				err,
+			)
+		}
+	}
+
+	return nil
+}
+
+// normalizeContractNames deduplicates and sorts the account's contract names.
+func (d *ContractCleanupMigration) normalizeContractNames(
+	accountRegisters *registers.AccountRegisters,
+) (
+	[]string,
+	error,
+) {
+	owner := accountRegisters.Owner()
+
+	encodedContractNames, err := accountRegisters.Get(owner, flow.ContractNamesKey)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get contract names: %w",
+			err,
+		)
+	}
+
+	if len(encodedContractNames) == 0 {
+		return nil, nil
+	}
+
+	contractNames, err := environment.DecodeContractNames(encodedContractNames)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to decode contract names: %w",
+			err,
+		)
+	}
+
+	contractNames = normalizeContractNames(contractNames)
+
+	newEncodedContractNames, err := environment.EncodeContractNames(contractNames)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to encode contract names: %w",
+			err,
+		)
+	}
+
+	err = accountRegisters.Set(owner, flow.ContractNamesKey, newEncodedContractNames)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to set new contract names: %w",
+			err,
+		)
+	}
+
+	return contractNames, nil
+}
+
+// normalizeContractNames deduplicates and sorts the contract names.
+func normalizeContractNames(names []string) []string {
+	seen := make(map[string]struct{}, len(names))
+	deduplicated := make([]string, 0, len(names))
+
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+
+		seen[name] = struct{}{}
+		deduplicated = append(deduplicated, name)
+	}
+
+	sort.Strings(deduplicated)
+
+	return deduplicated
+}
+
+// cleanupContractCode removes the code for the contract if it is empty.
+func (d *ContractCleanupMigration) cleanupContractCode(
+	accountRegisters *registers.AccountRegisters,
+	contractName string,
+) error {
+	owner := accountRegisters.Owner()
+
+	contractKey := flow.ContractKey(contractName)
+
+	code, err := accountRegisters.Get(owner, contractKey)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to get contract code for %s: %w",
+			contractName,
+			err,
+		)
+	}
+
+	if len(bytes.TrimSpace(code)) == 0 {
+		err = accountRegisters.Set(owner, contractKey, nil)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to clear contract code for %s: %w",
+				contractName,
+				err,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (d *ContractCleanupMigration) Close() error {
+	return nil
+}

--- a/cmd/util/ledger/migrations/contract_cleanup_migration_test.go
+++ b/cmd/util/ledger/migrations/contract_cleanup_migration_test.go
@@ -1,0 +1,117 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func TestContractCleanupMigration(t *testing.T) {
+
+	t.Parallel()
+
+	// Arrange
+
+	address, err := common.HexToAddress("0x4184b8bdf78db9eb")
+	require.NoError(t, err)
+
+	flowAddress := flow.ConvertAddress(address)
+	owner := flow.AddressToRegisterOwner(flowAddress)
+
+	const contractNameEmpty = "Foo"
+	const contractNameNonEmpty = "Bar"
+
+	registersByAccount := registers.NewByAccount()
+
+	err = registersByAccount.Set(
+		owner,
+		flow.ContractKey(contractNameEmpty),
+		// Some whitespace for testing purposes
+		[]byte(" \t  \n  "),
+	)
+	require.NoError(t, err)
+
+	err = registersByAccount.Set(
+		owner,
+		flow.ContractKey(contractNameNonEmpty),
+		[]byte(" \n  \t access(all) contract Bar {} \n \n"),
+	)
+	require.NoError(t, err)
+
+	encodedContractNames, err := environment.EncodeContractNames([]string{
+		// Unsorted and duplicates for testing purposes
+		contractNameEmpty,
+		contractNameNonEmpty,
+		contractNameEmpty,
+		contractNameNonEmpty,
+		contractNameEmpty,
+		contractNameEmpty,
+		contractNameNonEmpty,
+	})
+	require.NoError(t, err)
+
+	err = registersByAccount.Set(
+		owner,
+		flow.ContractNamesKey,
+		encodedContractNames,
+	)
+	require.NoError(t, err)
+
+	// Act
+
+	checkingMigration := NewContractCleanupMigration()
+
+	log := zerolog.Nop()
+
+	err = checkingMigration.InitMigration(log, registersByAccount, 1)
+	require.NoError(t, err)
+
+	accountRegisters := registersByAccount.AccountRegisters(owner)
+
+	err = checkingMigration.MigrateAccount(
+		context.Background(),
+		address,
+		accountRegisters,
+	)
+	require.NoError(t, err)
+
+	// Assert
+
+	encodedContractNames, err = registersByAccount.Get(
+		owner,
+		flow.ContractNamesKey,
+	)
+	require.NoError(t, err)
+
+	contractNames, err := environment.DecodeContractNames(encodedContractNames)
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]string{
+			contractNameNonEmpty,
+			contractNameEmpty,
+		},
+		contractNames,
+	)
+
+	contractEmpty, err := registersByAccount.Get(
+		owner,
+		flow.ContractKey(contractNameEmpty),
+	)
+	require.NoError(t, err)
+	assert.Nil(t, contractEmpty)
+
+	contractNonEmpty, err := registersByAccount.Get(
+		owner,
+		flow.ContractKey(contractNameNonEmpty),
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, contractNonEmpty)
+}


### PR DESCRIPTION

Follow-up to onflow/cadence#3436

Inspired by the old contract deduplication migration, https://github.com/onflow/flow-go/blob/feature/atree-inlining-cadence-v0.42/cmd/util/ledger/migrations/deduplicate_contract_names_migration.go
