### PR TITLE
Update TPS monitor automation to write to new BigQuery table

### DIFF
--- a/integration/benchmark/cmd/ci/main.go
+++ b/integration/benchmark/cmd/ci/main.go
@@ -64,7 +64,7 @@ func main() {
 	gitRepoURLFlag := flag.String("git-repo-url", "https://github.com/onflow/flow-go.git", "git repo URL")
 	bigQueryUpload := flag.Bool("bigquery-upload", true, "whether to upload results to BigQuery (true / false)")
 	pushgateway := flag.String("pushgateway", "disabled", "host:port for pushgateway")
-	bigQueryProjectFlag := flag.String("bigquery-project", "dapperlabs-data", "project name for the bigquery uploader")
+	bigQueryProjectFlag := flag.String("bigquery-project", "ff-data-platform", "project name for the bigquery uploader")
 	bigQueryDatasetFlag := flag.String("bigquery-dataset", "dev_src_flow_tps_metrics", "dataset name for the bigquery uploader")
 	bigQueryRawTableFlag := flag.String("bigquery-raw-table", "rawResults", "table name for the bigquery raw results")
 	flag.Parse()


### PR DESCRIPTION
## Description
We are moving our BigQuery tables to a new project, and this change will ensure the new project is used. A new table has been created, and the existing service account has been granted write access to the table.