### PR TITLE
Fix `invalidCadenceTypeError` creation

### DIFF
--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -682,11 +682,14 @@ func invalidCadenceTypeError(
 	fieldName string,
 	actualType, expectedType cadence.Value,
 ) error {
+	// NOTE: This error is reported if the Go-types are different (not if Cadence types are different).
+	// Therefore, print the Go-type instead of cadence type.
+	// Cadence type can be `nil`, since the `expectedType` is always the zero-value of the Go type.
 	return fmt.Errorf(
-		"invalid Cadence type for field %s (got=%s, expected=%s)",
+		"invalid Cadence type for field %s (got=%T, expected=%T)",
 		fieldName,
-		actualType.Type().ID(),
-		expectedType.Type().ID(),
+		actualType,
+		expectedType,
 	)
 }
 


### PR DESCRIPTION
Fixes: https://discord.com/channels/613813861610684416/1108479699732152503/1254802566139740293

`invalidCadenceTypeError` can cause NPEs when generating the error message, since `expectedType` passed into the method is always the zero-value of the corresponding Go-type. Then the `expectedType.Type()` can be `nil`, and hence `expectedType.Type().ID()` would cause a NPE.

Instead, print the Go-type. This makes even more sense, since this error is thrown only if the Go-types are mismatching.