### PR TITLE
Link checkpoint on bootstrapping

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1347,6 +1347,7 @@ func (exeNode *ExecutionNode) LoadBootstrapper(node *NodeConfig) error {
 
 	// if the execution database does not exist, then we need to bootstrap the execution database.
 	if !bootstrapped {
+
 		err := wal.CheckpointHasRootHash(
 			node.Logger,
 			path.Join(node.BootstrapDir, bootstrapFilenames.DirnameExecutionState),
@@ -1454,16 +1455,16 @@ func copyBootstrapState(dir, trie string) error {
 	from, to := path.Join(dir, bootstrapFilenames.DirnameExecutionState), trie
 
 	log.Info().Str("dir", dir).Str("trie", trie).
-		Msgf("copying checkpoint file %v from directory: %v, to: %v", filename, from, to)
+		Msgf("linking checkpoint file %v from directory: %v, to: %v", filename, from, to)
 
-	copiedFiles, err := wal.CopyCheckpointFile(filename, from, to)
+	copiedFiles, err := wal.SoftlinkCheckpointFile(filename, from, to)
 	if err != nil {
-		return fmt.Errorf("can not copy checkpoint file %s, from %s to %s",
-			filename, from, to)
+		return fmt.Errorf("can not link checkpoint file %s, from %s to %s, %w",
+			filename, from, to, err)
 	}
 
 	for _, newPath := range copiedFiles {
-		fmt.Printf("copied root checkpoint file from directory: %v, to: %v\n", from, newPath)
+		fmt.Printf("linked root checkpoint file from directory: %v, to: %v\n", from, newPath)
 	}
 
 	return nil

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.4
 	github.com/onflow/go-ethereum v1.13.4
-	github.com/plus3it/gorecurcopy v0.0.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.46.0

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2243,8 +2243,6 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pkg/term v1.2.0-beta.2/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
-github.com/plus3it/gorecurcopy v0.0.1 h1:H7AgvM0N/uIo7o1PQRlewEGQ92BNr7DqbPy5lnR3uJI=
-github.com/plus3it/gorecurcopy v0.0.1/go.mod h1:NvVTm4RX68A1vQbHmHunDO4OtBLVroT6CrsiqAzNyJA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4=

--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -14,11 +14,9 @@ import (
 	"time"
 
 	"github.com/go-yaml/yaml"
-	"github.com/plus3it/gorecurcopy"
 
 	"github.com/onflow/flow-go/cmd/build"
 	"github.com/onflow/flow-go/integration/testnet"
-	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -389,13 +387,6 @@ func prepareExecutionService(container testnet.ContainerConfig, i int, n int) Se
 	trieDir := "./" + filepath.Join(TrieDir, container.Role.String(), container.NodeID.String())
 	err := os.MkdirAll(trieDir, 0755)
 	if err != nil && !errors.Is(err, fs.ErrExist) {
-		panic(err)
-	}
-
-	// we need to actually copy the execution state into the directory for bootstrapping
-	sourceDir := "./" + filepath.Join(BootstrapDir, bootstrap.DirnameExecutionState)
-	err = gorecurcopy.CopyDirectory(sourceDir, trieDir)
-	if err != nil {
 		panic(err)
 	}
 

--- a/ledger/complete/wal/checkpointer.go
+++ b/ledger/complete/wal/checkpointer.go
@@ -1086,3 +1086,35 @@ func CopyCheckpointFile(filename string, from string, to string) (
 
 	return newPaths, nil
 }
+
+// SoftlinkCheckpointFile creates soft links of the checkpoint file including the part files from the given `from` to
+// the `to` directory
+func SoftlinkCheckpointFile(filename string, from string, to string) ([]string, error) {
+
+	// It's possible that the trie dir does not yet exist. If not this will create the the required path
+	err := os.MkdirAll(to, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	// checkpoint V6 produces multiple checkpoint part files that need to be copied over
+	pattern := filePathPattern(from, filename)
+	matched, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("could not glob checkpoint file with pattern %v: %w", pattern, err)
+	}
+
+	newPaths := make([]string, len(matched))
+	for i, match := range matched {
+		_, partfile := filepath.Split(match)
+		newPath := filepath.Join(to, partfile)
+		newPaths[i] = newPath
+
+		err := os.Symlink(match, newPath)
+		if err != nil {
+			return nil, fmt.Errorf("cannot link file from %v to %v: %w", match, newPath, err)
+		}
+	}
+
+	return newPaths, nil
+}


### PR DESCRIPTION
Close https://github.com/onflow/flow-go/issues/6167. 

This PR reduce bootstrapping time by creating soft links of checkpoint files instead of copying them. Could save ~10 mins for bootstrapping.

Tested on mainnet test EN, and worked.

<img width="861" alt="image" src="https://github.com/onflow/flow-go/assets/811374/7b64c9c8-d497-4e34-bb36-85f1e5a4dbe6">
