### PR TITLE
Add support for JSONL report format as alternative to JSON array report

### DIFF
--- a/cmd/util/cmd/diff-states/cmd.go
+++ b/cmd/util/cmd/diff-states/cmd.go
@@ -161,7 +161,7 @@ func run(*cobra.Command, []string) {
 		log.Fatal().Msg("--state-commitment-2 must be provided when --state-2 is provided")
 	}
 
-	rw := reporters.NewReportFileWriterFactory(flagOutputDirectory, log.Logger).
+	rw := reporters.NewReportFileWriterFactoryWithFormat(flagOutputDirectory, log.Logger, reporters.ReportFormatJSONL).
 		ReportWriter(ReporterName)
 	defer rw.Close()
 

--- a/cmd/util/cmd/diff-states/diff_states_test.go
+++ b/cmd/util/cmd/diff-states/diff_states_test.go
@@ -2,7 +2,9 @@ package diff_states
 
 import (
 	"encoding/json"
+	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,7 +17,6 @@ import (
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/convert"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/utils/io"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -80,17 +81,26 @@ func TestDiffStates(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, reportPath)
 
-		report, err := io.ReadFile(reportPath)
+		report, err := os.Open(reportPath)
 		require.NoError(t, err)
 
-		var msgs []any
-		err = json.Unmarshal(report, &msgs)
-		require.NoError(t, err)
+		var msgs [][]byte
+		decoder := json.NewDecoder(report)
+		for {
+			var msg json.RawMessage
+			err = decoder.Decode(&msg)
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+
+			msgs = append(msgs, msg)
+		}
 
 		assert.Equal(t, 4, len(msgs))
-		assert.Containsf(t, string(report), `{"kind":"raw-diff","owner":"0100000000000000","key":"62","value1":"03","value2":"05"}`, "diff report contains raw-diff")
-		assert.Containsf(t, string(report), `{"kind":"account-missing","owner":"0200000000000000","state":2}`, "diff report contains account-missing for 0200000000000000")
-		assert.Containsf(t, string(report), `{"kind":"account-missing","owner":"0300000000000000","state":1}`, "diff report contains account-missing for 0300000000000000")
-		assert.Containsf(t, string(report), `{"kind":"account-missing","owner":"0400000000000000","state":1}`, "diff report contains account-missing for 0400000000000000")
+		assert.Containsf(t, msgs, []byte(`{"kind":"account-missing","owner":"0200000000000000","state":2}`), "diff report contains account-missing for 0200000000000000")
+		assert.Containsf(t, msgs, []byte(`{"kind":"account-missing","owner":"0300000000000000","state":1}`), "diff report contains account-missing for 0300000000000000")
+		assert.Containsf(t, msgs, []byte(`{"kind":"account-missing","owner":"0400000000000000","state":1}`), "diff report contains account-missing for 0400000000000000")
+		assert.Containsf(t, msgs, []byte(`{"kind":"raw-diff","owner":"0100000000000000","key":"62","value1":"03","value2":"05"}`), "diff report contains raw-diff")
 	})
 }

--- a/cmd/util/ledger/reporters/reporter_output_test.go
+++ b/cmd/util/ledger/reporters/reporter_output_test.go
@@ -1,6 +1,7 @@
 package reporters_test
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"sync"
@@ -12,7 +13,7 @@ import (
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 )
 
-func TestReportFileWriter(t *testing.T) {
+func TestReportFileWriterJSONArray(t *testing.T) {
 	dir := t.TempDir()
 
 	filename := path.Join(dir, "test.json")
@@ -30,20 +31,20 @@ func TestReportFileWriter(t *testing.T) {
 	}
 
 	t.Run("Open & Close - empty json array", func(t *testing.T) {
-		rw := reporters.NewReportFileWriter(filename, log)
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONArray)
 		rw.Close()
 
 		requireFileContains(t, "[]")
 	})
 	t.Run("Open & Write One & Close - json array with one element", func(t *testing.T) {
-		rw := reporters.NewReportFileWriter(filename, log)
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONArray)
 		rw.Write(testData{TestField: "something"})
 		rw.Close()
 
 		requireFileContains(t, "[{\"TestField\":\"something\"}]")
 	})
 	t.Run("Open & Write Many & Close - json array with many elements", func(t *testing.T) {
-		rw := reporters.NewReportFileWriter(filename, log)
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONArray)
 		rw.Write(testData{TestField: "something0"})
 		rw.Write(testData{TestField: "something1"})
 		rw.Write(testData{TestField: "something2"})
@@ -55,7 +56,7 @@ func TestReportFileWriter(t *testing.T) {
 	})
 
 	t.Run("Open & Write Many in threads & Close", func(t *testing.T) {
-		rw := reporters.NewReportFileWriter(filename, log)
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONArray)
 
 		wg := &sync.WaitGroup{}
 		for i := 0; i < 3; i++ {
@@ -72,5 +73,72 @@ func TestReportFileWriter(t *testing.T) {
 
 		requireFileContains(t,
 			"[{\"TestField\":\"something\"},{\"TestField\":\"something\"},{\"TestField\":\"something\"}]")
+	})
+}
+
+func TestReportFileWriterJSONL(t *testing.T) {
+	dir := t.TempDir()
+
+	filename := path.Join(dir, "test.jsonl")
+	log := zerolog.Logger{}
+
+	requireFileContains := func(t *testing.T, expected string) {
+		dat, err := os.ReadFile(filename)
+		require.NoError(t, err)
+
+		fmt.Printf("filename: %s\n", filename)
+
+		require.Equal(t, []byte(expected), dat)
+	}
+
+	type testData struct {
+		TestField string
+	}
+
+	t.Run("Open & Close", func(t *testing.T) {
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONL)
+		rw.Close()
+
+		requireFileContains(t, "")
+	})
+
+	t.Run("Open & Write One & Close", func(t *testing.T) {
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONL)
+		rw.Write(testData{TestField: "something"})
+		rw.Close()
+
+		requireFileContains(t, "{\"TestField\":\"something\"}")
+	})
+
+	t.Run("Open & Write Many & Close", func(t *testing.T) {
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONL)
+		rw.Write(testData{TestField: "something0"})
+		rw.Write(testData{TestField: "something1"})
+		rw.Write(testData{TestField: "something2"})
+
+		rw.Close()
+
+		requireFileContains(t,
+			"{\"TestField\":\"something0\"}\n{\"TestField\":\"something1\"}\n{\"TestField\":\"something2\"}")
+	})
+
+	t.Run("Open & Write Many in threads & Close", func(t *testing.T) {
+		rw := reporters.NewReportFileWriter(filename, log, reporters.ReportFormatJSONL)
+
+		wg := &sync.WaitGroup{}
+		for i := 0; i < 3; i++ {
+			wg.Add(1)
+			go func() {
+				rw.Write(testData{TestField: "something"})
+				wg.Done()
+			}()
+		}
+
+		wg.Wait()
+
+		rw.Close()
+
+		requireFileContains(t,
+			"{\"TestField\":\"something\"}\n{\"TestField\":\"something\"}\n{\"TestField\":\"something\"}")
 	})
 }


### PR DESCRIPTION
Closes #6175 

Currently, `reports.ReportWriter` outputs all JSON objects to the same JSON array, which can cause JSON parsers like jq to crash on very large reports.

This PR adds support for JSONL format, so each JSON object is output to a separate line in the output file.  This allows each object to be parsed independently (rather than requiring every object in the array to be parsed).

While at it, modify the `diff-states` command to use JSONL format because it can generate 20GB reports.