### PR TITLE
[Tool] Add the missing checkpoint subfile to be moved

### DIFF
--- a/tools/move-checkpoint.sh
+++ b/tools/move-checkpoint.sh
@@ -44,6 +44,7 @@ mkdir -p "$destination_directory"
 # Define the expected files
 expected_files=(
     "$source_base"
+    "$source_base.000"
     "$source_base.001"
     "$source_base.002"
     "$source_base.003"


### PR DESCRIPTION
This PR fixes an issue in the move-checkpoint.sh tool that a subfile didn't get moved.