### PR TITLE
When reading leaf nodes from a checkpoint, also read from the top trie

### DIFF
--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -151,7 +151,9 @@ func isTrieDeepEnough(trie *trie.MTrie) bool {
 	return true
 }
 
-func createMultipleRandomTriesMini(t *testing.T) []*trie.MTrie {
+// createMultipleRandomTriesMini creates a set of tries with some shared paths,
+// the second returned trie is the last trie in the set, and it is guaranteed to be deep enough
+func createMultipleRandomTriesMini(t *testing.T) ([]*trie.MTrie, *trie.MTrie) {
 	tries := make([]*trie.MTrie, 0)
 	activeTrie := trie.NewEmptyMTrie()
 
@@ -181,7 +183,7 @@ func createMultipleRandomTriesMini(t *testing.T) []*trie.MTrie {
 		return createMultipleRandomTriesMini(t)
 	}
 
-	return tries
+	return tries, activeTrie
 }
 
 func TestEncodeSubTrie(t *testing.T) {
@@ -382,7 +384,7 @@ func TestWriteAndReadCheckpointV6LeafSimpleTrie(t *testing.T) {
 func TestWriteAndReadCheckpointV6LeafMultipleTriesFail(t *testing.T) {
 	unittest.RunWithTempDir(t, func(dir string) {
 		fileName := "checkpoint-multi-leaf-file"
-		tries := createMultipleRandomTriesMini(t)
+		tries, _ := createMultipleRandomTriesMini(t)
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, logger), "fail to store checkpoint")
 		bufSize := 5
@@ -396,9 +398,9 @@ func TestWriteAndReadCheckpointV6LeafMultipleTriesFail(t *testing.T) {
 func TestWriteAndReadCheckpointV6LeafMultipleTriesOK(t *testing.T) {
 	unittest.RunWithTempDir(t, func(dir string) {
 		fileName := "checkpoint-multi-leaf-file"
-		multi := createMultipleRandomTriesMini(t)
+		_, last := createMultipleRandomTriesMini(t)
 
-		tries := multi[len(multi)-1:]
+		tries := []*trie.MTrie{last}
 
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, logger), "fail to store checkpoint")

--- a/ledger/complete/wal/checkpoint_v6_test.go
+++ b/ledger/complete/wal/checkpoint_v6_test.go
@@ -131,7 +131,24 @@ func createMultipleRandomTries(t *testing.T) []*trie.MTrie {
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
 
+	// trie must be deep enough to test the subtrie
+	if !isTrieDeepEnough(activeTrie) {
+		// if not deep enough, keep re-trying
+		return createMultipleRandomTries(t)
+	}
+
 	return tries
+}
+
+func isTrieDeepEnough(trie *trie.MTrie) bool {
+	nodes := getNodesAtLevel(trie.RootNode(), subtrieLevel)
+	for _, n := range nodes {
+		if n == nil || n.IsLeaf() {
+			return false
+		}
+	}
+
+	return true
 }
 
 func createMultipleRandomTriesMini(t *testing.T) []*trie.MTrie {
@@ -157,6 +174,12 @@ func createMultipleRandomTriesMini(t *testing.T) []*trie.MTrie {
 	activeTrie, _, err = trie.NewTrieWithUpdatedRegisters(activeTrie, sharedPaths, payloads2, false)
 	require.NoError(t, err, "update registers")
 	tries = append(tries, activeTrie)
+
+	// trie must be deep enough to test the subtrie
+	if !isTrieDeepEnough(activeTrie) {
+		// if not deep enough, keep re-trying
+		return createMultipleRandomTriesMini(t)
+	}
 
 	return tries
 }
@@ -375,7 +398,7 @@ func TestWriteAndReadCheckpointV6LeafMultipleTriesOK(t *testing.T) {
 		fileName := "checkpoint-multi-leaf-file"
 		multi := createMultipleRandomTriesMini(t)
 
-		tries := multi[1:2]
+		tries := multi[len(multi)-1:]
 
 		logger := unittest.Logger()
 		require.NoErrorf(t, StoreCheckpointV6Concurrently(tries, dir, fileName, logger), "fail to store checkpoint")


### PR DESCRIPTION
Fix https://github.com/onflow/flow-go/issues/6166

This PR fixes an issue that the `OpenAndReadLeafNodesFromCheckpointV6` function assumes all the leaf nodes are stored in subtrie files and read from them. However, when the trie only has very few nodes, it's possible some subtrie branch isn't deep enough, the subtrie is empty, and some payload has to be stored in the top trie leaf nodes. This would cause an issue that those payload stored in top trie will not be read. That's why it caused the `TestWriteAndReadCheckpointV6LeafMultipleTriesOK` test case to be flakey, since it create a trie with 40 payloads, if running many times, it will hit the case where a payload gets stored to a toptrie, and fail the test case.

It's not an issue for Testnet or Mainnet, where they have way more payloads that no payload will be stored in the top level trie.