### PR TITLE
Optimize migrations by creating output payloads file in parallel to new trie creation

### DIFF
--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -65,18 +65,12 @@ func TestExtractExecutionState(t *testing.T) {
 
 	t.Run("empty WAL doesn't find anything", func(t *testing.T) {
 		withDirs(t, func(datadir, execdir, outdir string) {
-			err := extractExecutionState(
-				zerolog.Nop(),
-				execdir,
-				unittest.StateCommitmentFixture(),
-				outdir,
-				10,
-				false,
-				"",
-				nil,
-				false,
-			)
+			extractor := newExecutionStateExtractor(zerolog.Nop(), execdir, unittest.StateCommitmentFixture())
+
+			partialState, payloads, err := extractor.extract()
 			require.Error(t, err)
+			require.False(t, partialState)
+			require.Equal(t, 0, len(payloads))
 		})
 	})
 

--- a/cmd/util/ledger/util/payload_file.go
+++ b/cmd/util/ledger/util/payload_file.go
@@ -132,9 +132,6 @@ func CreatePayloadFile(
 	defer f.Close()
 
 	writer := bufio.NewWriterSize(f, defaultBufioWriteSize)
-	if err != nil {
-		return 0, fmt.Errorf("can't create bufio writer for %s: %w", payloadFile, err)
-	}
 	defer writer.Flush()
 
 	// TODO: replace CRC-32 checksum.


### PR DESCRIPTION
Currently, when migrations specify a payloads file as output (instead of checkpoint), the new trie is created with migrated payloads first and then migrated payloads are written to payload file.

This PR optimizes migrations that generate payloads file as output by creating new trie with migrated payloads in parallel.

While at it, also refactored code related to:
- extracting payloads from different input (payload file and checkpoint file)
- exporting payloads to different output (payload file and checkpoint file)

### Preliminary Results

This optimization reduces atree migration duration by about 21 minutes on a test vm (m1-ultramem-160 using nworkers=150 to migrate old testnet state).