### PR TITLE
Port PR 6193 to master (speedup migration by ~21 minutes on m1-ultramem-160)

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	common2 "github.com/onflow/flow-go/cmd/util/common"
 	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
+	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
@@ -407,37 +408,80 @@ func run(*cobra.Command, []string) {
 		CacheEntitlementsMigrationResults: flagCacheEntitlementsMigrationResults,
 	}
 
+	var extractor extractor
 	if len(flagInputPayloadFileName) > 0 {
-		err = extractExecutionStateFromPayloads(
+		extractor = newPayloadFileExtractor(log.Logger, flagInputPayloadFileName)
+	} else {
+		extractor = newExecutionStateExtractor(log.Logger, flagExecutionStateDir, stateCommitment)
+	}
+
+	// Extract payloads.
+
+	payloadsFromPartialState, payloads, err := extractor.extract()
+	if err != nil {
+		log.Fatal().Err(err).Msgf("error extracting payloads: %s", err.Error())
+	}
+
+	log.Info().Msgf("extracted %d payloads", len(payloads))
+
+	// Migrate payloads.
+
+	if !flagNoMigration {
+		migrations := newMigrations(log.Logger, flagOutputDir, opts)
+
+		migration := newMigration(log.Logger, migrations, flagNWorker)
+
+		payloads, err := migration(payloads)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("error migrating payloads: %s", err.Error())
+		}
+
+		log.Info().Msgf("migrated %d payloads", len(payloads))
+	}
+
+	// Export migrated payloads.
+
+	var exporter exporter
+	if len(flagOutputPayloadFileName) > 0 {
+		exporter = newPayloadFileExporter(
 			log.Logger,
-			flagExecutionStateDir,
-			flagOutputDir,
 			flagNWorker,
-			!flagNoMigration,
-			flagInputPayloadFileName,
 			flagOutputPayloadFileName,
 			exportPayloadsForOwners,
 			flagSortPayloads,
-			opts,
 		)
 	} else {
-		err = extractExecutionState(
+		exporter = newCheckpointFileExporter(
 			log.Logger,
-			flagExecutionStateDir,
-			stateCommitment,
 			flagOutputDir,
-			flagNWorker,
-			!flagNoMigration,
-			flagOutputPayloadFileName,
-			exportPayloadsForOwners,
-			flagSortPayloads,
-			opts,
 		)
 	}
 
+	log.Info().Msgf("exporting %d payloads", len(payloads))
+
+	exportedState, err := exporter.export(payloadsFromPartialState, payloads)
 	if err != nil {
-		log.Fatal().Err(err).Msgf("error extracting the execution state: %s", err.Error())
+		log.Fatal().Err(err).Msgf("error exporting migrated payloads: %s", err.Error())
 	}
+
+	log.Info().Msgf("exported %d payloads", len(payloads))
+
+	// Create export reporter.
+	reporter := reporters.NewExportReporter(
+		log.Logger,
+		func() flow.StateCommitment { return stateCommitment },
+	)
+
+	err = reporter.Report(nil, exportedState)
+	if err != nil {
+		log.Error().Err(err).Msgf("can not generate report for migrated state: %v", exportedState)
+	}
+
+	log.Info().Msgf(
+		"New state commitment for the exported state is: %s (base64: %s)",
+		exportedState.String(),
+		exportedState.Base64(),
+	)
 }
 
 // func ensureCheckpointFileExist(dir string) error {

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	syncAtomic "sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
 	migrators "github.com/onflow/flow-go/cmd/util/ledger/migrations"
@@ -26,151 +24,194 @@ import (
 	"github.com/onflow/flow-go/ledger/complete/wal"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/module/metrics"
 )
 
-func extractExecutionState(
-	log zerolog.Logger,
-	dir string,
-	targetHash flow.StateCommitment,
-	outputDir string,
-	nWorker int, // number of concurrent worker to migration payloads
-	runMigrations bool,
-	outputPayloadFile string,
-	exportPayloadsForOwners map[string]struct{},
+type extractor interface {
+	extract() (partialState bool, payloads []*ledger.Payload, err error)
+}
+
+type payloadFileExtractor struct {
+	logger   zerolog.Logger
+	fileName string
+}
+
+func newPayloadFileExtractor(
+	logger zerolog.Logger,
+	fileName string,
+) *payloadFileExtractor {
+	return &payloadFileExtractor{
+		logger:   logger,
+		fileName: fileName,
+	}
+}
+
+func (e *payloadFileExtractor) extract() (bool, []*ledger.Payload, error) {
+	return util.ReadPayloadFile(e.logger, e.fileName)
+}
+
+type executionStateExtractor struct {
+	logger          zerolog.Logger
+	dir             string
+	stateCommitment flow.StateCommitment
+}
+
+func newExecutionStateExtractor(
+	logger zerolog.Logger,
+	executionStateDir string,
+	stateCommitment flow.StateCommitment,
+) *executionStateExtractor {
+	return &executionStateExtractor{
+		logger:          logger,
+		dir:             executionStateDir,
+		stateCommitment: stateCommitment,
+	}
+}
+
+func (e *executionStateExtractor) extract() (bool, []*ledger.Payload, error) {
+	payloads, err := util.ReadTrie(e.dir, e.stateCommitment)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return false, payloads, nil
+}
+
+type exporter interface {
+	export(partialState bool, payloads []*ledger.Payload) (ledger.State, error)
+}
+
+type payloadFileExporter struct {
+	logger         zerolog.Logger
+	nWorker        int
+	fileName       string
+	addressFilters map[string]struct{}
+	sortPayloads   bool
+}
+
+func newPayloadFileExporter(
+	logger zerolog.Logger,
+	nWorker int,
+	fileName string,
+	addressFilters map[string]struct{},
 	sortPayloads bool,
-	opts migrators.Options,
+) *payloadFileExporter {
+	return &payloadFileExporter{
+		logger:         logger,
+		nWorker:        nWorker,
+		fileName:       fileName,
+		addressFilters: addressFilters,
+		sortPayloads:   sortPayloads,
+	}
+}
+
+func (e *payloadFileExporter) export(
+	partialState bool,
+	payloads []*ledger.Payload,
+) (ledger.State, error) {
+
+	var group errgroup.Group
+
+	var migratedState ledger.State
+
+	// Need to use a copy of payloads when creating new trie in goroutine
+	// because payloads are sorted in createPayloadFile().
+	copiedPayloads := make([]*ledger.Payload, len(payloads))
+	copy(copiedPayloads, payloads)
+
+	// Launch goroutine to get root hash of trie from exported payloads
+	group.Go(func() error {
+		newTrie, err := createTrieFromPayloads(log.Logger, copiedPayloads)
+		if err != nil {
+			return err
+		}
+
+		migratedState = ledger.State(newTrie.RootHash())
+		return nil
+	})
+
+	// Export payloads to payload file
+	err := e.createPayloadFile(partialState, payloads)
+	if err != nil {
+		return ledger.DummyState, err
+	}
+
+	err = group.Wait()
+	if err != nil {
+		return ledger.DummyState, err
+	}
+
+	return migratedState, nil
+}
+
+func (e *payloadFileExporter) createPayloadFile(
+	partialState bool,
+	payloads []*ledger.Payload,
 ) error {
+	if e.sortPayloads {
+		e.logger.Info().Msgf("sorting %d payloads", len(payloads))
 
-	log.Info().Msg("init WAL")
+		// Sort payloads to produce deterministic payload file with
+		// same sequence of payloads inside.
+		payloads = util.SortPayloadsByAddress(payloads, e.nWorker)
 
-	diskWal, err := wal.NewDiskWAL(
-		log,
-		nil,
-		metrics.NewNoopCollector(),
-		dir,
-		complete.DefaultCacheSize,
-		pathfinder.PathByteSize,
-		wal.SegmentSize,
+		log.Info().Msgf("sorted %d payloads", len(payloads))
+	}
+
+	log.Info().Msgf("creating payloads file %s", e.fileName)
+
+	exportedPayloadCount, err := util.CreatePayloadFile(
+		e.logger,
+		e.fileName,
+		payloads,
+		e.addressFilters,
+		partialState,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot create disk WAL: %w", err)
+		return fmt.Errorf("cannot generate payloads file: %w", err)
 	}
 
-	log.Info().Msg("init ledger")
-
-	led, err := complete.NewLedger(
-		diskWal,
-		complete.DefaultCacheSize,
-		&metrics.NoopCollector{},
-		log,
-		complete.DefaultPathFinderVersion)
-	if err != nil {
-		return fmt.Errorf("cannot create ledger from write-a-head logs and checkpoints: %w", err)
-	}
-
-	const (
-		checkpointDistance = math.MaxInt // A large number to prevent checkpoint creation.
-		checkpointsToKeep  = 1
-	)
-
-	log.Info().Msg("init compactor")
-
-	compactor, err := complete.NewCompactor(
-		led,
-		diskWal,
-		log,
-		complete.DefaultCacheSize,
-		checkpointDistance,
-		checkpointsToKeep,
-		atomic.NewBool(false),
-		&metrics.NoopCollector{},
-	)
-	if err != nil {
-		return fmt.Errorf("cannot create compactor: %w", err)
-	}
-
-	log.Info().Msgf("waiting for compactor to load checkpoint and WAL")
-
-	<-compactor.Ready()
-
-	defer func() {
-		<-led.Done()
-		<-compactor.Done()
-	}()
-
-	migrations := newMigrations(
-		log,
-		dir,
-		runMigrations,
-		opts,
-	)
-
-	migration := newMigration(log, migrations, nWorker)
-
-	newState := ledger.State(targetHash)
-
-	// migrate the trie if there are migrations
-	newTrie, err := led.MigrateAt(
-		newState,
-		migration,
-		complete.DefaultPathFinderVersion,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	// create reporter
-	reporter := reporters.NewExportReporter(
-		log,
-		func() flow.StateCommitment {
-			return targetHash
-		},
-	)
-
-	newMigratedState := ledger.State(newTrie.RootHash())
-	err = reporter.Report(nil, newMigratedState)
-	if err != nil {
-		log.Err(err).Msgf("can not generate report for migrated state: %v", newMigratedState)
-	}
-
-	if len(outputPayloadFile) > 0 {
-		payloads := newTrie.AllPayloads()
-
-		return exportPayloads(
-			log,
-			payloads,
-			nWorker,
-			outputPayloadFile,
-			exportPayloadsForOwners,
-			false, // payloads represents entire state.
-			sortPayloads,
-		)
-	}
-
-	migratedState, err := createCheckpoint(
-		newTrie,
-		log,
-		outputDir,
-		bootstrap.FilenameWALRootCheckpoint,
-	)
-	if err != nil {
-		return fmt.Errorf("cannot generate the output checkpoint: %w", err)
-	}
-
-	log.Info().Msgf(
-		"New state commitment for the exported state is: %s (base64: %s)",
-		migratedState.String(),
-		migratedState.Base64(),
-	)
+	e.logger.Info().Msgf("exported %d payloads out of %d payloads", exportedPayloadCount, len(payloads))
 
 	return nil
 }
 
+type checkpointFileExporter struct {
+	logger    zerolog.Logger
+	outputDir string
+}
+
+func newCheckpointFileExporter(
+	logger zerolog.Logger,
+	outputDir string,
+) *checkpointFileExporter {
+	return &checkpointFileExporter{
+		logger:    logger,
+		outputDir: outputDir,
+	}
+}
+
+func (e *checkpointFileExporter) export(
+	_ bool,
+	payloads []*ledger.Payload,
+) (ledger.State, error) {
+	// Create trie
+	newTrie, err := createTrieFromPayloads(e.logger, payloads)
+	if err != nil {
+		return ledger.DummyState, err
+	}
+
+	// Create checkpoint files
+	return createCheckpoint(
+		log.Logger,
+		newTrie,
+		e.outputDir,
+		bootstrap.FilenameWALRootCheckpoint,
+	)
+}
+
 func createCheckpoint(
-	newTrie *trie.MTrie,
 	log zerolog.Logger,
+	newTrie *trie.MTrie,
 	outputDir,
 	outputFile string,
 ) (ledger.State, error) {
@@ -205,117 +246,6 @@ func writeStatusFile(fileName string, e error) error {
 	checkpointStatusJson, _ := json.MarshalIndent(checkpointStatus, "", " ")
 	err := os.WriteFile(fileName, checkpointStatusJson, 0644)
 	return err
-}
-
-func extractExecutionStateFromPayloads(
-	log zerolog.Logger,
-	dir string,
-	outputDir string,
-	nWorker int, // number of concurrent worker to migration payloads
-	runMigrations bool,
-	inputPayloadFile string,
-	outputPayloadFile string,
-	exportPayloadsForOwners map[string]struct{},
-	sortPayloads bool,
-	opts migrators.Options,
-) error {
-
-	inputPayloadsFromPartialState, payloads, err := util.ReadPayloadFile(log, inputPayloadFile)
-	if err != nil {
-		return err
-	}
-
-	log.Info().Msgf("read %d payloads", len(payloads))
-
-	migrations := newMigrations(
-		log,
-		dir,
-		runMigrations,
-		opts,
-	)
-
-	migration := newMigration(
-		log,
-		migrations,
-		nWorker,
-	)
-
-	payloads, err = migration(payloads)
-	if err != nil {
-		return err
-	}
-
-	if len(outputPayloadFile) > 0 {
-		return exportPayloads(
-			log,
-			payloads,
-			nWorker,
-			outputPayloadFile,
-			exportPayloadsForOwners,
-			inputPayloadsFromPartialState,
-			sortPayloads,
-		)
-	}
-
-	newTrie, err := createTrieFromPayloads(log, payloads)
-	if err != nil {
-		return err
-	}
-
-	migratedState, err := createCheckpoint(
-		newTrie,
-		log,
-		outputDir,
-		bootstrap.FilenameWALRootCheckpoint,
-	)
-	if err != nil {
-		return fmt.Errorf("cannot generate the output checkpoint: %w", err)
-	}
-
-	log.Info().Msgf(
-		"New state commitment for the exported state is: %s (base64: %s)",
-		migratedState.String(),
-		migratedState.Base64(),
-	)
-
-	return nil
-}
-
-func exportPayloads(
-	log zerolog.Logger,
-	payloads []*ledger.Payload,
-	nWorker int,
-	outputPayloadFile string,
-	exportPayloadsForOwners map[string]struct{},
-	inputPayloadsFromPartialState bool,
-	sortPayloads bool,
-) error {
-	if sortPayloads {
-		log.Info().Msgf("sorting %d payloads", len(payloads))
-
-		// Sort payloads to produce deterministic payload file with
-		// same sequence of payloads inside.
-		payloads = util.SortPayloadsByAddress(payloads, nWorker)
-
-		log.Info().Msgf("sorted %d payloads", len(payloads))
-	}
-
-	log.Info().Msgf("creating payloads file %s", outputPayloadFile)
-
-	exportedPayloadCount, err := util.CreatePayloadFile(
-		log,
-		outputPayloadFile,
-		payloads,
-		exportPayloadsForOwners,
-		inputPayloadsFromPartialState,
-	)
-	if err != nil {
-		return fmt.Errorf("cannot generate payloads file: %w", err)
-	}
-
-	log.Info().Msgf("exported %d payloads out of %d payloads", exportedPayloadCount, len(payloads))
-
-	return nil
 }
 
 func newMigration(
@@ -527,12 +457,8 @@ func createTrieFromPayloads(logger zerolog.Logger, payloads []*ledger.Payload) (
 func newMigrations(
 	log zerolog.Logger,
 	outputDir string,
-	runMigrations bool,
 	opts migrators.Options,
 ) []migrators.NamedMigration {
-	if !runMigrations {
-		return nil
-	}
 
 	log.Info().Msg("initializing migrations")
 

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract_test.go
@@ -15,7 +15,6 @@ import (
 	runtimeCommon "github.com/onflow/cadence/runtime/common"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
-	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
@@ -66,27 +65,12 @@ func TestExtractExecutionState(t *testing.T) {
 
 	t.Run("empty WAL doesn't find anything", func(t *testing.T) {
 		withDirs(t, func(datadir, execdir, outdir string) {
-			opts := migrations.Options{
-				NWorker:              10,
-				ChainID:              flow.Emulator,
-				EVMContractChange:    migrations.EVMContractChangeNone,
-				BurnerContractChange: migrations.BurnerContractChangeDeploy,
-				VerboseErrorOutput:   true,
-			}
+			extractor := newExecutionStateExtractor(zerolog.Nop(), execdir, unittest.StateCommitmentFixture())
 
-			err := extractExecutionState(
-				zerolog.Nop(),
-				execdir,
-				unittest.StateCommitmentFixture(),
-				outdir,
-				10,
-				false,
-				"",
-				nil,
-				false,
-				opts,
-			)
+			partialState, payloads, err := extractor.extract()
 			require.Error(t, err)
+			require.False(t, partialState)
+			require.Equal(t, 0, len(payloads))
 		})
 	})
 


### PR DESCRIPTION
This port to master is for completeness only because atree migration in a feature branch is used for creating the atree inlined payloads file for other migrations to use (e.g. Cadence 1.0 migration).

- From PR: https://github.com/onflow/flow-go/pull/6193
- From Branch: https://github.com/onflow/flow-go/tree/feature/atree-inlining-cadence-v0.42

### Context (PR 6193)

Currently, when migrations specify a payloads file as output (instead of checkpoint), the new trie is created with migrated payloads first and then migrated payloads are written to payload file.

This PR optimizes migrations that generate payloads file as output by creating new trie with migrated payloads in parallel.

While at it, also refactored code related to:
- extracting payloads from different input (payload file and checkpoint file)
- exporting payloads to different output (payload file and checkpoint file)

### Preliminary Results (PR 6193)

Atree migration is faster by 21 minutes on a test vm (m1-ultramem-160 using `nworkers=150` to migrate old testnet state).