### PR TITLE
[EFM] Calculate valid `TargetEndTime` for extended epoch

### DIFF
--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -70,9 +70,8 @@ type EpochStateContainer struct {
 
 // EpochExtension represents a range of views, which contiguously extends this epoch.
 type EpochExtension struct {
-	FirstView     uint64
-	FinalView     uint64
-	TargetEndTime uint64
+	FirstView uint64
+	FinalView uint64
 }
 
 // ID returns an identifier for this EpochStateContainer by hashing internal fields.

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -2479,6 +2479,7 @@ func TestEpochTargetEndTime(t *testing.T) {
 		secondExtension := epochState.EpochExtensions()[1]
 		expectedTargetEndTime = rootTargetEndTime + uint64(float64(secondExtension.FinalView-epoch1Setup.FinalView)*targetViewDuration)
 		afterSecondExtensionTargetEndTime, err := state.Final().Epochs().Current().TargetEndTime()
+		require.NoError(t, err)
 		require.Equal(t, expectedTargetEndTime, afterSecondExtensionTargetEndTime)
 	})
 }

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -2351,6 +2351,14 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, epochExtensions[0].FinalView, finalView)
 
+			targetEndTime, err := state.Final().Epochs().Current().TargetEndTime()
+			require.NoError(t, err)
+			targetViewTime := float64(epoch2Setup.TargetDuration) / float64(epoch2Setup.FinalView-epoch2Setup.FirstView+1)
+			expectedTargetEndTime := epoch2Setup.TargetEndTime + uint64(float64(epochExtensions[0].FinalView-epoch2Setup.FinalView)*targetViewTime)
+			assert.Equal(t, expectedTargetEndTime, targetEndTime)
+
+			// After epoch extension, TargetEndTime must be updated accordingly
+
 			// Constructing blocks
 			//   ... <- B10 <- B11(ER(B4, EpochRecover)) <- B12(S(ER(B4))) <- ...
 			// B10 will be the first block past the epoch extension. Block B11 incorporates the Execution Result [ER]

--- a/state/protocol/inmem/epoch.go
+++ b/state/protocol/inmem/epoch.go
@@ -92,6 +92,8 @@ func (es *setupEpoch) TargetDuration() (uint64, error) {
 // Unix Time (in units of seconds). This target is specified by the FlowEpoch smart contract in
 // the EpochSetup event and used by the Cruise Control system to moderate the block rate.
 func (es *setupEpoch) TargetEndTime() (uint64, error) {
+	//desiredViewDuration := es.setupEvent.TargetDuration / (es.setupEvent.FinalView - es.setupEvent.FirstView + 1)
+	//targetEndTime := es.setupEvent.TargetEndTime + (extension.FinalView-es.setupEvent.FinalView)*desiredViewDuration
 	return es.setupEvent.TargetEndTime, nil
 }
 

--- a/state/protocol/inmem/epoch.go
+++ b/state/protocol/inmem/epoch.go
@@ -91,13 +91,15 @@ func (es *setupEpoch) TargetDuration() (uint64, error) {
 // TargetEndTime returns the desired real-world end time for this epoch, represented as
 // Unix Time (in units of seconds). This target is specified by the FlowEpoch smart contract in
 // the EpochSetup event and used by the Cruise Control system to moderate the block rate.
+// In case the epoch has extensions, the target end time is calculated based on the last extension, by calculating how many
+// views were added by the extension and adding the proportional time to the target end time.
 func (es *setupEpoch) TargetEndTime() (uint64, error) {
 	if len(es.extensions) == 0 {
 		return es.setupEvent.TargetEndTime, nil
 	} else {
-		desiredViewDuration := float64(es.setupEvent.TargetDuration) / float64(es.setupEvent.FinalView-es.setupEvent.FirstView+1)
+		viewDuration := float64(es.setupEvent.TargetDuration) / float64(es.setupEvent.FinalView-es.setupEvent.FirstView+1)
 		lastExtension := es.extensions[len(es.extensions)-1]
-		return es.setupEvent.TargetEndTime + uint64(float64(lastExtension.FinalView-es.setupEvent.FinalView)*desiredViewDuration), nil
+		return es.setupEvent.TargetEndTime + uint64(float64(lastExtension.FinalView-es.setupEvent.FinalView)*viewDuration), nil
 	}
 }
 

--- a/state/protocol/inmem/epoch.go
+++ b/state/protocol/inmem/epoch.go
@@ -92,9 +92,13 @@ func (es *setupEpoch) TargetDuration() (uint64, error) {
 // Unix Time (in units of seconds). This target is specified by the FlowEpoch smart contract in
 // the EpochSetup event and used by the Cruise Control system to moderate the block rate.
 func (es *setupEpoch) TargetEndTime() (uint64, error) {
-	//desiredViewDuration := es.setupEvent.TargetDuration / (es.setupEvent.FinalView - es.setupEvent.FirstView + 1)
-	//targetEndTime := es.setupEvent.TargetEndTime + (extension.FinalView-es.setupEvent.FinalView)*desiredViewDuration
-	return es.setupEvent.TargetEndTime, nil
+	if len(es.extensions) == 0 {
+		return es.setupEvent.TargetEndTime, nil
+	} else {
+		desiredViewDuration := float64(es.setupEvent.TargetDuration) / float64(es.setupEvent.FinalView-es.setupEvent.FirstView+1)
+		lastExtension := es.extensions[len(es.extensions)-1]
+		return es.setupEvent.TargetEndTime + uint64(float64(lastExtension.FinalView-es.setupEvent.FinalView)*desiredViewDuration), nil
+	}
 }
 
 func (es *setupEpoch) RandomSource() ([]byte, error) {

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -60,9 +60,8 @@ func NewFallbackStateMachine(params protocol.GlobalParams, telemetry protocol_st
 		// we have reached safety threshold and we are still in the fallback mode
 		// prepare a new extension for the current epoch.
 		err := sm.extendCurrentEpoch(flow.EpochExtension{
-			FirstView:     parentState.CurrentEpochFinalView() + 1,
-			FinalView:     parentState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount, // TODO(EFM, #6020): replace with EpochExtensionLength
-			TargetEndTime: 0,                                                                    // TODO(EFM, #6020): calculate and set target end time
+			FirstView: parentState.CurrentEpochFinalView() + 1,
+			FinalView: parentState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount, // TODO(EFM, #6020): replace with EpochExtensionLength
 		})
 		if err != nil {
 			return nil, err

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -138,9 +138,8 @@ func (s *EpochFallbackStateMachineSuite) TestProcessInvalidEpochRecover() {
 		parentProtocolState := s.parentProtocolState.Copy()
 		parentProtocolState.CurrentEpoch.EpochExtensions = []flow.EpochExtension{
 			{
-				FirstView:     s.parentProtocolState.CurrentEpochSetup.FinalView + 2, // invalid view for extension
-				FinalView:     s.parentProtocolState.CurrentEpochSetup.FinalView + 1 + 10_000,
-				TargetEndTime: 0,
+				FirstView: s.parentProtocolState.CurrentEpochSetup.FinalView + 2, // invalid view for extension
+				FinalView: s.parentProtocolState.CurrentEpochSetup.FinalView + 1 + 10_000,
 			},
 		}
 
@@ -392,9 +391,8 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 				ActiveIdentities: parentProtocolState.CurrentEpoch.ActiveIdentities,
 				EpochExtensions: []flow.EpochExtension{
 					{
-						FirstView:     parentProtocolState.CurrentEpochFinalView() + 1,
-						FinalView:     parentProtocolState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount,
-						TargetEndTime: 0,
+						FirstView: parentProtocolState.CurrentEpochFinalView() + 1,
+						FinalView: parentProtocolState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount,
 					},
 				},
 			},
@@ -432,9 +430,8 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 				ActiveIdentities: parentProtocolState.CurrentEpoch.ActiveIdentities,
 				EpochExtensions: []flow.EpochExtension{
 					{
-						FirstView:     parentProtocolState.CurrentEpochFinalView() + 1,
-						FinalView:     parentProtocolState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount,
-						TargetEndTime: 0,
+						FirstView: parentProtocolState.CurrentEpochFinalView() + 1,
+						FinalView: parentProtocolState.CurrentEpochFinalView() + DefaultEpochExtensionViewCount,
 					},
 				},
 			},
@@ -504,14 +501,12 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 		// we expect 2 extensions to be added to the current epoch
 		// 1 after we reach the commit threshold of the epoch and another one after reaching the threshold of the extension themselves
 		firstExtension := flow.EpochExtension{
-			FirstView:     originalParentState.CurrentEpochSetup.FinalView + 1,
-			FinalView:     originalParentState.CurrentEpochSetup.FinalView + DefaultEpochExtensionViewCount,
-			TargetEndTime: 0,
+			FirstView: originalParentState.CurrentEpochSetup.FinalView + 1,
+			FinalView: originalParentState.CurrentEpochSetup.FinalView + DefaultEpochExtensionViewCount,
 		}
 		secondExtension := flow.EpochExtension{
-			FirstView:     firstExtension.FinalView + 1,
-			FinalView:     firstExtension.FinalView + DefaultEpochExtensionViewCount,
-			TargetEndTime: 0,
+			FirstView: firstExtension.FinalView + 1,
+			FinalView: firstExtension.FinalView + DefaultEpochExtensionViewCount,
 		}
 
 		parentProtocolState := originalParentState.Copy()
@@ -585,19 +580,16 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 	// we expect 3 extensions to be added to the current epoch
 	// 1 after we reach the commit threshold of the epoch and two more after reaching the threshold of the extensions themselves
 	firstExtension := flow.EpochExtension{
-		FirstView:     originalParentState.NextEpochSetup.FinalView + 1,
-		FinalView:     originalParentState.NextEpochSetup.FinalView + DefaultEpochExtensionViewCount,
-		TargetEndTime: 0,
+		FirstView: originalParentState.NextEpochSetup.FinalView + 1,
+		FinalView: originalParentState.NextEpochSetup.FinalView + DefaultEpochExtensionViewCount,
 	}
 	secondExtension := flow.EpochExtension{
-		FirstView:     firstExtension.FinalView + 1,
-		FinalView:     firstExtension.FinalView + DefaultEpochExtensionViewCount,
-		TargetEndTime: 0,
+		FirstView: firstExtension.FinalView + 1,
+		FinalView: firstExtension.FinalView + DefaultEpochExtensionViewCount,
 	}
 	thirdExtension := flow.EpochExtension{
-		FirstView:     secondExtension.FinalView + 1,
-		FinalView:     secondExtension.FinalView + DefaultEpochExtensionViewCount,
-		TargetEndTime: 0,
+		FirstView: secondExtension.FinalView + 1,
+		FinalView: secondExtension.FinalView + DefaultEpochExtensionViewCount,
 	}
 
 	// In the previous test `TestNewEpochFallbackStateMachine`, we verified that the first extension is added correctly. Below we


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/6194

### Context

This PR introduces proper logic for calculating `TargetEndTime` for an epoch that has been extended. 
I have removed `TargetEndTime` from `flow.EpochExtension` and instead move the value calculation in `inmem/epoch.go` to avoid redundancy. 