### PR TITLE
[Util] Add command to run a script

### DIFF
--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	read_protocol_state "github.com/onflow/flow-go/cmd/util/cmd/read-protocol-state/cmd"
 	index_er "github.com/onflow/flow-go/cmd/util/cmd/reindex/cmd"
 	rollback_executed_height "github.com/onflow/flow-go/cmd/util/cmd/rollback-executed-height/cmd"
+	run_script "github.com/onflow/flow-go/cmd/util/cmd/run-script"
 	"github.com/onflow/flow-go/cmd/util/cmd/snapshot"
 	truncate_database "github.com/onflow/flow-go/cmd/util/cmd/truncate-database"
 	"github.com/onflow/flow-go/cmd/util/cmd/version"
@@ -112,6 +113,7 @@ func addCommands() {
 	rootCmd.AddCommand(diff_states.Cmd)
 	rootCmd.AddCommand(atree_inlined_status.Cmd)
 	rootCmd.AddCommand(find_trie_root.Cmd)
+	rootCmd.AddCommand(run_script.Cmd)
 }
 
 func initConfig() {

--- a/cmd/util/cmd/run-script/cmd.go
+++ b/cmd/util/cmd/run-script/cmd.go
@@ -1,0 +1,143 @@
+package run_script
+
+import (
+	"io"
+	"os"
+
+	jsoncdc "github.com/onflow/cadence/encoding/json"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
+	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/engine/execution/computation"
+	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/ledger"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+var (
+	flagPayloads        string
+	flagState           string
+	flagStateCommitment string
+	flagChain           string
+)
+
+var Cmd = &cobra.Command{
+	Use:   "run-script",
+	Short: "run a script against the execution state",
+	Run:   run,
+}
+
+func init() {
+
+	// Input 1
+
+	Cmd.Flags().StringVar(
+		&flagPayloads,
+		"payloads",
+		"",
+		"Input payload file name",
+	)
+
+	Cmd.Flags().StringVar(
+		&flagState,
+		"state",
+		"",
+		"Input state file name",
+	)
+	Cmd.Flags().StringVar(
+		&flagStateCommitment,
+		"state-commitment",
+		"",
+		"Input state commitment",
+	)
+
+	Cmd.Flags().StringVar(
+		&flagChain,
+		"chain",
+		"",
+		"Chain name",
+	)
+	_ = Cmd.MarkFlagRequired("chain")
+}
+
+func run(*cobra.Command, []string) {
+
+	if flagPayloads == "" && flagState == "" {
+		log.Fatal().Msg("Either --payloads or --state must be provided")
+	} else if flagPayloads != "" && flagState != "" {
+		log.Fatal().Msg("Only one of --payloads or --state must be provided")
+	}
+	if flagState != "" && flagStateCommitment == "" {
+		log.Fatal().Msg("--state-commitment must be provided when --state is provided")
+	}
+
+	chainID := flow.ChainID(flagChain)
+	// Validate chain ID
+	_ = chainID.Chain()
+
+	var payloads []*ledger.Payload
+	var err error
+
+	if flagPayloads != "" {
+		_, payloads, err = util.ReadPayloadFile(log.Logger, flagPayloads)
+	} else {
+		log.Info().Msg("Reading trie")
+
+		stateCommitment := util.ParseStateCommitment(flagStateCommitment)
+		payloads, err = util.ReadTrie(flagState, stateCommitment)
+	}
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to read payloads")
+	}
+
+	registersByAccount, err := registers.NewByAccountFromPayloads(payloads)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+
+	log.Info().Msgf("created registers (%d accounts)", registersByAccount.AccountCount())
+
+	options := computation.DefaultFVMOptions(chainID, false, false)
+	options = append(
+		options,
+		fvm.WithContractDeploymentRestricted(false),
+		fvm.WithContractRemovalRestricted(false),
+		fvm.WithAuthorizationChecksEnabled(false),
+		fvm.WithSequenceNumberCheckAndIncrementEnabled(false),
+		fvm.WithTransactionFeesEnabled(false),
+	)
+	ctx := fvm.NewContext(options...)
+
+	storageSnapshot := registers.StorageSnapshot{
+		Registers: registersByAccount,
+	}
+
+	vm := fvm.NewVirtualMachine()
+
+	code, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatal().Msgf("failed to read script: %s", err)
+	}
+
+	_, res, err := vm.Run(
+		ctx,
+		fvm.Script(code),
+		storageSnapshot,
+	)
+	if err != nil {
+		log.Fatal().Msgf("failed to run script: %s", err)
+	}
+
+	if res.Err != nil {
+		log.Fatal().Msgf("script failed: %s", res.Err)
+	}
+
+	encoded, err := jsoncdc.Encode(res.Value)
+	if err != nil {
+		log.Fatal().Msgf("failed to encode result: %s", err)
+	}
+
+	_, _ = os.Stdout.Write(encoded)
+}


### PR DESCRIPTION
Add a new util command `run-script`, which can read in a state from a payloads file, or alternatively from a trie and a state commitment, runs a script, and prints the JSON-encoded result of the script.

This is useful for debugging purposes.