### PR TITLE
[Util] Fix execution state extraction

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -431,7 +431,7 @@ func run(*cobra.Command, []string) {
 
 		migration := newMigration(log.Logger, migrations, flagNWorker)
 
-		payloads, err := migration(payloads)
+		payloads, err = migration(payloads)
 		if err != nil {
 			log.Fatal().Err(err).Msgf("error migrating payloads: %s", err.Error())
 		}


### PR DESCRIPTION
Fix assignment of migrated payloads, remove accidental variable shadowing

It would be great to have (a) test(s) for the migration path of the execution state extraction command.

@fxamacker already checked the pre-1.0 branch, and the bug does not exist there:
https://github.com/onflow/flow-go/blob/feature/atree-inlining-cadence-v0.42/cmd/util/cmd/execution-state-extract/cmd.go#L339