### PR TITLE
[Cadence 1.0 migration] Improve EVM contract migration

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -378,10 +378,10 @@ func run(*cobra.Command, []string) {
 	switch chainID {
 	case flow.Emulator:
 		burnerContractChange = migrations.BurnerContractChangeDeploy
-		evmContractChange = migrations.EVMContractChangeDeploy
+		evmContractChange = migrations.EVMContractChangeDeployMinimalAndUpdateFull
 	case flow.Testnet, flow.Mainnet:
 		burnerContractChange = migrations.BurnerContractChangeUpdate
-		evmContractChange = migrations.EVMContractChangeUpdate
+		evmContractChange = migrations.EVMContractChangeUpdateFull
 	}
 
 	stagedContracts, err := migrations.StagedContractsFromCSV(flagStagedContractsFile)

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -374,12 +374,23 @@ func NewCadence1ContractsMigrations(
 		)
 	}
 
-	if opts.EVMContractChange == EVMContractChangeDeploy {
+	switch opts.EVMContractChange {
+	case EVMContractChangeNone:
+		// NO-OP
+
+	case EVMContractChangeUpdateFull:
+		// handled in system contract updates (SystemContractChanges)
+
+	case EVMContractChangeDeployFull,
+		EVMContractChangeDeployMinimalAndUpdateFull:
+
+		full := opts.EVMContractChange == EVMContractChangeDeployFull
+
 		migs = append(
 			migs,
 			NamedMigration{
 				Name:    "evm-deployment-migration",
-				Migrate: NewEVMDeploymentMigration(opts.ChainID, log),
+				Migrate: NewEVMDeploymentMigration(opts.ChainID, log, full),
 			},
 		)
 	}

--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -31,8 +31,13 @@ type EVMContractChange uint8
 
 const (
 	EVMContractChangeNone EVMContractChange = iota
-	EVMContractChangeDeploy
-	EVMContractChangeUpdate
+	// EVMContractChangeDeployFull deploys the full EVM contract
+	EVMContractChangeDeployFull
+	// EVMContractChangeUpdateFull updates the existing EVM contract to the latest, full EVM contract
+	EVMContractChangeUpdateFull
+	// EVMContractChangeDeployMinimalAndUpdateFull deploys the minimal EVM contract
+	// and updates it to the latest, full EVM contract
+	EVMContractChangeDeployMinimalAndUpdateFull
 )
 
 type BurnerContractChange uint8
@@ -216,7 +221,16 @@ func SystemContractChanges(chainID flow.ChainID, options SystemContractsMigratio
 	}
 
 	// EVM contract
-	if options.EVM == EVMContractChangeUpdate {
+	switch options.EVM {
+	case EVMContractChangeNone:
+		// NO-OP
+
+	case EVMContractChangeDeployFull:
+		// handled in migration pipeline (NewCadence1ContractsMigrations)
+
+	case EVMContractChangeUpdateFull,
+		EVMContractChangeDeployMinimalAndUpdateFull:
+
 		contractChanges = append(
 			contractChanges,
 			NewSystemContractChange(

--- a/cmd/util/ledger/migrations/deploy_migration.go
+++ b/cmd/util/ledger/migrations/deploy_migration.go
@@ -63,18 +63,28 @@ func NewBurnerDeploymentMigration(
 func NewEVMDeploymentMigration(
 	chainID flow.ChainID,
 	logger zerolog.Logger,
+	full bool,
 ) RegistersMigration {
+
 	systemContracts := systemcontracts.SystemContractsForChain(chainID)
 	address := systemContracts.EVMContract.Address
+
+	var code []byte
+	if full {
+		code = evm.ContractCode(
+			systemContracts.NonFungibleToken.Address,
+			systemContracts.FungibleToken.Address,
+			systemContracts.FlowToken.Address,
+		)
+	} else {
+		code = []byte(evm.ContractMinimalCode)
+	}
+
 	return NewDeploymentMigration(
 		chainID,
 		Contract{
 			Name: systemContracts.EVMContract.Name,
-			Code: evm.ContractCode(
-				systemContracts.NonFungibleToken.Address,
-				systemContracts.FungibleToken.Address,
-				systemContracts.FlowToken.Address,
-			),
+			Code: code,
 		},
 		address,
 		map[flow.Address]struct{}{

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -27,6 +27,9 @@ import (
 //go:embed contract.cdc
 var contractCode string
 
+//go:embed contract_minimal.cdc
+var ContractMinimalCode string
+
 var nftImportPattern = regexp.MustCompile(`(?m)^import "NonFungibleToken"`)
 var fungibleTokenImportPattern = regexp.MustCompile(`(?m)^import "FungibleToken"`)
 var flowTokenImportPattern = regexp.MustCompile(`(?m)^import "FlowToken"`)

--- a/fvm/evm/stdlib/contract_minimal.cdc
+++ b/fvm/evm/stdlib/contract_minimal.cdc
@@ -1,0 +1,60 @@
+access(all)
+contract EVM {
+
+    /// EVMAddress is an EVM-compatible address
+    access(all)
+    struct EVMAddress {
+
+        /// Bytes of the address
+        access(all)
+        let bytes: [UInt8; 20]
+
+        /// Constructs a new EVM address from the given byte representation
+        init(bytes: [UInt8; 20]) {
+            self.bytes = bytes
+        }
+
+    }
+
+    access(all)
+    fun encodeABI(_ values: [AnyStruct]): [UInt8] {
+        return InternalEVM.encodeABI(values)
+    }
+
+    access(all)
+    fun decodeABI(types: [Type], data: [UInt8]): [AnyStruct] {
+        return InternalEVM.decodeABI(types: types, data: data)
+    }
+
+    access(all)
+    fun encodeABIWithSignature(
+        _ signature: String,
+        _ values: [AnyStruct]
+    ): [UInt8] {
+        let methodID = HashAlgorithm.KECCAK_256.hash(
+            signature.utf8
+        ).slice(from: 0, upTo: 4)
+        let arguments = InternalEVM.encodeABI(values)
+
+        return methodID.concat(arguments)
+    }
+
+    access(all)
+    fun decodeABIWithSignature(
+        _ signature: String,
+        types: [Type],
+        data: [UInt8]
+    ): [AnyStruct] {
+        let methodID = HashAlgorithm.KECCAK_256.hash(
+            signature.utf8
+        ).slice(from: 0, upTo: 4)
+
+        for byte in methodID {
+            if byte != data.removeFirst() {
+                panic("signature mismatch")
+            }
+        }
+
+        return InternalEVM.decodeABI(types: types, data: data)
+    }
+}


### PR DESCRIPTION
Add a new EVM contract change mode that deploys the minimal EVM contract (ABI-only) and updates it to the full contract.

This is the same strategy we currently use for TN and MN: We already manually deployed a minimal, pre-1.0 Cadence contract to those chains, and during the migration, we will update it to the full contract.

However, for the Emulator we want to do this automatically for users.

See https://discord.com/channels/613813861610684416/1263903370574430239 for more information.