### PR TITLE
[Cadence 1.0 migration] Add migration to setup EVM heartbeat resource

### DIFF
--- a/cmd/util/ledger/migrations/burner.go
+++ b/cmd/util/ledger/migrations/burner.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	coreContracts "github.com/onflow/flow-core-contracts/lib/go/contracts"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func NewBurnerDeploymentMigration(
+	chainID flow.ChainID,
+	logger zerolog.Logger,
+) RegistersMigration {
+	address := BurnerAddressForChain(chainID)
+	return NewDeploymentMigration(
+		chainID,
+		Contract{
+			Name: "Burner",
+			Code: coreContracts.Burner(),
+		},
+		address,
+		map[flow.Address]struct{}{
+			address: {},
+		},
+		logger,
+	)
+}

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -562,5 +562,19 @@ func NewCadence1Migrations(
 		)...,
 	)
 
+	switch opts.EVMContractChange {
+	case EVMContractChangeNone,
+		EVMContractChangeDeployFull:
+		// NO-OP
+	case EVMContractChangeUpdateFull, EVMContractChangeDeployMinimalAndUpdateFull:
+		migs = append(
+			migs,
+			NamedMigration{
+				Name:    "evm-setup-migration",
+				Migrate: NewEVMSetupMigration(opts.ChainID, log),
+			},
+		)
+	}
+
 	return migs
 }

--- a/cmd/util/ledger/migrations/deploy_migration.go
+++ b/cmd/util/ledger/migrations/deploy_migration.go
@@ -3,11 +3,8 @@ package migrations
 import (
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
-	coreContracts "github.com/onflow/flow-core-contracts/lib/go/contracts"
 	"github.com/rs/zerolog"
 
-	evm "github.com/onflow/flow-go/fvm/evm/stdlib"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -38,58 +35,5 @@ func NewDeploymentMigration(
 		chainID,
 		logger,
 		expectedWriteAddresses,
-	)
-}
-
-func NewBurnerDeploymentMigration(
-	chainID flow.ChainID,
-	logger zerolog.Logger,
-) RegistersMigration {
-	address := BurnerAddressForChain(chainID)
-	return NewDeploymentMigration(
-		chainID,
-		Contract{
-			Name: "Burner",
-			Code: coreContracts.Burner(),
-		},
-		address,
-		map[flow.Address]struct{}{
-			address: {},
-		},
-		logger,
-	)
-}
-
-func NewEVMDeploymentMigration(
-	chainID flow.ChainID,
-	logger zerolog.Logger,
-	full bool,
-) RegistersMigration {
-
-	systemContracts := systemcontracts.SystemContractsForChain(chainID)
-	address := systemContracts.EVMContract.Address
-
-	var code []byte
-	if full {
-		code = evm.ContractCode(
-			systemContracts.NonFungibleToken.Address,
-			systemContracts.FungibleToken.Address,
-			systemContracts.FlowToken.Address,
-		)
-	} else {
-		code = []byte(evm.ContractMinimalCode)
-	}
-
-	return NewDeploymentMigration(
-		chainID,
-		Contract{
-			Name: systemContracts.EVMContract.Name,
-			Code: code,
-		},
-		address,
-		map[flow.Address]struct{}{
-			address: {},
-		},
-		logger,
 	)
 }

--- a/cmd/util/ledger/migrations/evm.go
+++ b/cmd/util/ledger/migrations/evm.go
@@ -1,0 +1,113 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util"
+	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/evm/stdlib"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/fvm/tracing"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func NewEVMDeploymentMigration(
+	chainID flow.ChainID,
+	logger zerolog.Logger,
+	full bool,
+) RegistersMigration {
+
+	systemContracts := systemcontracts.SystemContractsForChain(chainID)
+	address := systemContracts.EVMContract.Address
+
+	var code []byte
+	if full {
+		code = stdlib.ContractCode(
+			systemContracts.NonFungibleToken.Address,
+			systemContracts.FungibleToken.Address,
+			systemContracts.FlowToken.Address,
+		)
+	} else {
+		code = []byte(stdlib.ContractMinimalCode)
+	}
+
+	return NewDeploymentMigration(
+		chainID,
+		Contract{
+			Name: systemContracts.EVMContract.Name,
+			Code: code,
+		},
+		address,
+		map[flow.Address]struct{}{
+			address: {},
+		},
+		logger,
+	)
+}
+
+func NewEVMSetupMigration(
+	chainID flow.ChainID,
+	logger zerolog.Logger,
+) RegistersMigration {
+
+	chain := chainID.Chain()
+
+	return func(registersByAccount *registers.ByAccount) error {
+
+		tracerSpan := tracing.NewTracerSpan()
+
+		transactionInfoParams := environment.DefaultTransactionInfoParams()
+		transactionInfoParams.TxBody = &flow.TransactionBody{}
+
+		environmentParams := environment.EnvironmentParams{
+			Chain:                 chain,
+			RuntimeParams:         environment.DefaultRuntimeParams(),
+			ProgramLoggerParams:   environment.DefaultProgramLoggerParams(),
+			TransactionInfoParams: transactionInfoParams,
+		}
+
+		basicMigrationRuntime := NewBasicMigrationRuntime(registersByAccount)
+
+		transactionPreparer, err := util.NewTransactionPreparer(basicMigrationRuntime.TransactionState)
+		if err != nil {
+			return fmt.Errorf("failed to create transaction preparer: %w", err)
+		}
+
+		transactionEnvironment := environment.NewTransactionEnvironment(
+			tracerSpan,
+			environmentParams,
+			transactionPreparer,
+		)
+
+		runtime := environment.NewRuntime(environmentParams.RuntimeParams)
+		runtime.SetEnvironment(transactionEnvironment)
+
+		programLogger := environment.NewProgramLogger(
+			tracerSpan,
+			environmentParams.ProgramLoggerParams,
+		)
+		systemContracts := environment.NewSystemContracts(
+			chain,
+			tracerSpan,
+			programLogger,
+			runtime,
+		)
+
+		_, err = systemContracts.Invoke(
+			environment.ContractFunctionSpec{
+				AddressFromChain: environment.ServiceAddress,
+				LocationName:     systemcontracts.ContractNameEVM,
+				FunctionName:     "setupHeartbeat",
+			},
+			nil,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to setup EVM heartbeat: %w", err)
+		}
+
+		return nil
+	}
+}

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -367,11 +367,18 @@ func ApplyChanges(
 			ownerAddress := flow.BytesToAddress([]byte(registerID.Owner))
 
 			if _, ok := expectedChangeAddresses[ownerAddress]; !ok {
+
+				expectedChangeAddressesArray := zerolog.Arr()
+				for expectedChangeAddress := range expectedChangeAddresses {
+					expectedChangeAddressesArray =
+						expectedChangeAddressesArray.Str(expectedChangeAddress.Hex())
+				}
+
 				// something was changed that does not belong to this account. Log it.
 				logger.Error().
 					Str("key", registerID.String()).
 					Str("actual_address", ownerAddress.Hex()).
-					Interface("expected_addresses", expectedChangeAddresses).
+					Array("expected_addresses", expectedChangeAddressesArray).
 					Hex("value", newValue).
 					Msg("key is part of the change set, but is for a different account")
 			}

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("1c8f9d71ffa0e261b5f278477ce39cf905640f9fad660f3791c71fa524693952")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("483b6a58223d0d93e85bcdf125a224a80d5d7f1260910941e0b3b4bb6121dc56")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("8d634458df94d3a284d7363686269c31c45b5ddd017215ec0505ea03a5f547d1")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("1c8f9d71ffa0e261b5f278477ce39cf905640f9fad660f3791c71fa524693952")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -832,7 +832,13 @@ contract EVM {
     ///
     /// The heartbeat resource is used to control the block production,
     /// and used in the Flow protocol to call the heartbeat function once per block.
-    access(account)
+    ///
+    /// The function can be called by anyone, but only once:
+    /// the function will fail if the resource already exists.
+    ///
+    /// The resulting resource is stored in the account storage,
+    /// and is only accessible by the account, not the caller of the function.
+    access(all)
     fun setupHeartbeat() {
         self.account.storage.save(<-create Heartbeat(), to: /storage/EVMHeartbeat)
     }

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -814,7 +814,8 @@ contract EVM {
             ?? panic("Could not borrow reference to the EVM bridge")
     }
 
-    /// The Heartbeat resource controls the block production
+    /// The Heartbeat resource controls the block production.
+    /// It is stored in the storage and used in the Flow protocol to call the heartbeat function once per block.
     access(all)
     resource Heartbeat {
         /// heartbeat calls commit block proposals and forms new blocks including all the
@@ -826,13 +827,17 @@ contract EVM {
         }
     }
 
-    /// createHeartBeat creates a heartbeat resource
+    /// setupHeartbeat creates a heartbeat resource and saves it to storage.
+    /// The function is called once during the contract initialization.
+    ///
+    /// The heartbeat resource is used to control the block production,
+    /// and used in the Flow protocol to call the heartbeat function once per block.
     access(account)
-    fun createHeartBeat(): @Heartbeat{
-        return <-create Heartbeat()
+    fun setupHeartbeat() {
+        self.account.storage.save(<-create Heartbeat(), to: /storage/EVMHeartbeat)
     }
 
     init() {
-        self.account.storage.save(<-create Heartbeat(), to: /storage/EVMHeartbeat)
+        self.setupHeartbeat()
     }
 }

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "a9e1cdb1870f90ed3b9b7844e0f4f6b48c1a7439041f454785e42eaf6e2a6621"
+const GenesisStateCommitmentHex = "36d6212f3fab6fcff7c2f9f4156c5ca3313ba197defd23b3ad22cb8646d09802"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "69f5c914c2220dcfcc7a267c740e296cf34e50d59878d8ca99c682e65b092857"
+		return "5b539b8abe3e67d5a74ce11219e81212e67eb05bb1afaa3f85e6838a973331c8"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "b65ae8f791ef1775ad27c3705622a3e788bce3b053edc20365d7d90e48bebe60"
+	return "e013ae397d544ed28fee8cc056f771112246f13c4f0f687ce94870bf932b80be"
 }

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "36d6212f3fab6fcff7c2f9f4156c5ca3313ba197defd23b3ad22cb8646d09802"
+const GenesisStateCommitmentHex = "a642be06b34bd0f120c49d907f38a8241a94360637cdaf51b36ae46d655b86c8"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "5b539b8abe3e67d5a74ce11219e81212e67eb05bb1afaa3f85e6838a973331c8"
+		return "6d5efa6e328640d727124e2d54febec0ba1fb5b2477f60d0202f555d77470488"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "e013ae397d544ed28fee8cc056f771112246f13c4f0f687ce94870bf932b80be"
+	return "023fc1b2834efce3b86c14544afb7031a2fe253b3d8c3b43fd7fcadc61816186"
 }


### PR DESCRIPTION
Depends on #6249 

When the EVM contract is updated from minimal to full contract, the `EVM.Heartbeat` resource must be set up.
