### PR TITLE
Update atree inlining cadence v1.0

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -28,6 +28,7 @@ import (
 	stateSyncCommands "github.com/onflow/flow-go/admin/commands/state_synchronization"
 	storageCommands "github.com/onflow/flow-go/admin/commands/storage"
 	"github.com/onflow/flow-go/cmd"
+	"github.com/onflow/flow-go/cmd/build"
 	"github.com/onflow/flow-go/consensus"
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/committees"
@@ -52,6 +53,7 @@ import (
 	followereng "github.com/onflow/flow-go/engine/common/follower"
 	"github.com/onflow/flow-go/engine/common/requester"
 	synceng "github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/engine/common/version"
 	"github.com/onflow/flow-go/engine/execution/computation/query"
 	"github.com/onflow/flow-go/fvm/storage/derived"
 	"github.com/onflow/flow-go/ledger"
@@ -164,6 +166,7 @@ type AccessNodeConfig struct {
 	registerCacheSize                    uint
 	programCacheSize                     uint
 	checkPayerBalance                    bool
+	versionControlEnabled                bool
 }
 
 type PublicNetworkConfig struct {
@@ -264,6 +267,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		registerCacheSize:                    0,
 		programCacheSize:                     0,
 		checkPayerBalance:                    false,
+		versionControlEnabled:                true,
 	}
 }
 
@@ -311,6 +315,7 @@ type FlowAccessNodeBuilder struct {
 	ExecutionDataPruner        *pruner.Pruner
 	ExecutionDataDatastore     *badger.Datastore
 	ExecutionDataTracker       tracker.Storage
+	versionControl             *version.VersionControl
 
 	// The sync engine participants provider is the libp2p peer store for the access node
 	// which is not available until after the network has started.
@@ -1226,6 +1231,10 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"circuit-breaker-max-requests",
 			defaultConfig.rpcConf.BackendConfig.CircuitBreakerConfig.MaxRequests,
 			"maximum number of requests to check if connection restored after timeout. Default value is 1")
+		flags.BoolVar(&builder.versionControlEnabled,
+			"version-control-enabled",
+			defaultConfig.versionControlEnabled,
+			"whether to enable the version control feature. Default value is true")
 		// ExecutionDataRequester config
 		flags.BoolVar(&builder.executionDataSyncEnabled,
 			"execution-data-sync-enabled",
@@ -1936,6 +1945,34 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			// be handled by the scaffold.
 			return builder.RequestEng, nil
 		})
+
+	if builder.versionControlEnabled {
+		builder.Component("version control", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+			nodeVersion, err := build.Semver()
+			if err != nil {
+				return nil, fmt.Errorf("could not load node version for version control. "+
+					"version (%s) is not semver compliant: %w. Make sure a valid semantic version is provided in the VERSION environment variable", build.Version(), err)
+			}
+
+			versionControl, err := version.NewVersionControl(
+				builder.Logger,
+				node.Storage.VersionBeacons,
+				nodeVersion,
+				builder.SealedRootBlock.Header.Height,
+				builder.LastFinalizedHeader.Height,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("could not create version control: %w", err)
+			}
+
+			// VersionControl needs to consume BlockFinalized events.
+			node.ProtocolEvents.AddConsumer(versionControl)
+
+			builder.versionControl = versionControl
+
+			return versionControl, nil
+		})
+	}
 
 	if builder.supportsObserver {
 		builder.Component("public sync request handler", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onflow/flow-go/admin/commands"
 	stateSyncCommands "github.com/onflow/flow-go/admin/commands/state_synchronization"
 	"github.com/onflow/flow-go/cmd"
+	"github.com/onflow/flow-go/cmd/build"
 	"github.com/onflow/flow-go/consensus"
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/committees"
@@ -51,6 +52,7 @@ import (
 	"github.com/onflow/flow-go/engine/access/subscription"
 	"github.com/onflow/flow-go/engine/common/follower"
 	synceng "github.com/onflow/flow-go/engine/common/synchronization"
+	"github.com/onflow/flow-go/engine/common/version"
 	"github.com/onflow/flow-go/engine/execution/computation/query"
 	"github.com/onflow/flow-go/fvm/storage/derived"
 	"github.com/onflow/flow-go/ledger"
@@ -155,6 +157,7 @@ type ObserverServiceConfig struct {
 	executionDataPrunerHeightRangeTarget uint64
 	executionDataPrunerThreshold         uint64
 	localServiceAPIEnabled               bool
+	versionControlEnabled                bool
 	executionDataDir                     string
 	executionDataStartHeight             uint64
 	executionDataConfig                  edrequester.ExecutionDataConfig
@@ -227,6 +230,7 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 		executionDataPrunerHeightRangeTarget: 0,
 		executionDataPrunerThreshold:         100_000,
 		localServiceAPIEnabled:               false,
+		versionControlEnabled:                true,
 		executionDataDir:                     filepath.Join(homedir, ".flow", "execution_data"),
 		executionDataStartHeight:             0,
 		executionDataConfig: edrequester.ExecutionDataConfig{
@@ -267,6 +271,7 @@ type ObserverServiceBuilder struct {
 	ExecutionIndexerCore *indexer.IndexerCore
 	TxResultsIndex       *index.TransactionResultsIndex
 	IndexerDependencies  *cmd.DependencyList
+	versionControl       *version.VersionControl
 
 	ExecutionDataDownloader execution_data.Downloader
 	ExecutionDataRequester  state_synchronization.ExecutionDataRequester
@@ -664,6 +669,10 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 			"execution-data-indexing-enabled",
 			defaultConfig.executionDataIndexingEnabled,
 			"whether to enable the execution data indexing")
+		flags.BoolVar(&builder.versionControlEnabled,
+			"version-control-enabled",
+			defaultConfig.versionControlEnabled,
+			"whether to enable the version control feature. Default value is true")
 		flags.BoolVar(&builder.localServiceAPIEnabled, "local-service-api-enabled", defaultConfig.localServiceAPIEnabled, "whether to use local indexed data for api queries")
 		flags.StringVar(&builder.registersDBPath, "execution-state-dir", defaultConfig.registersDBPath, "directory to use for execution-state database")
 		flags.StringVar(&builder.checkpointFile, "execution-state-checkpoint", defaultConfig.checkpointFile, "execution-state checkpoint file")
@@ -1685,7 +1694,6 @@ func (builder *ObserverServiceBuilder) enqueueConnectWithStakedAN() {
 }
 
 func (builder *ObserverServiceBuilder) enqueueRPCServer() {
-
 	builder.Module("transaction metrics", func(node *cmd.NodeConfig) error {
 		var err error
 		builder.TransactionTimings, err = stdmap.NewTransactionTimings(1500 * 300) // assume 1500 TPS * 300 seconds
@@ -1783,6 +1791,33 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 		builder.ScriptExecutor = backend.NewScriptExecutor(builder.Logger, builder.scriptExecMinBlock, builder.scriptExecMaxBlock)
 		return nil
 	})
+	if builder.versionControlEnabled {
+		builder.Component("version control", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
+			nodeVersion, err := build.Semver()
+			if err != nil {
+				return nil, fmt.Errorf("could not load node version for version control. "+
+					"version (%s) is not semver compliant: %w. Make sure a valid semantic version is provided in the VERSION environment variable", build.Version(), err)
+			}
+
+			versionControl, err := version.NewVersionControl(
+				builder.Logger,
+				node.Storage.VersionBeacons,
+				nodeVersion,
+				builder.SealedRootBlock.Header.Height,
+				builder.LastFinalizedHeader.Height,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("could not create version control: %w", err)
+			}
+
+			// VersionControl needs to consume BlockFinalized events.
+			node.ProtocolEvents.AddConsumer(versionControl)
+
+			builder.versionControl = versionControl
+
+			return versionControl, nil
+		})
+	}
 	builder.Component("RPC engine", func(node *cmd.NodeConfig) (module.ReadyDoneAware, error) {
 		accessMetrics := builder.AccessMetrics
 		config := builder.rpcConf

--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -378,10 +378,10 @@ func run(*cobra.Command, []string) {
 	switch chainID {
 	case flow.Emulator:
 		burnerContractChange = migrations.BurnerContractChangeDeploy
-		evmContractChange = migrations.EVMContractChangeDeploy
+		evmContractChange = migrations.EVMContractChangeDeployMinimalAndUpdateFull
 	case flow.Testnet, flow.Mainnet:
 		burnerContractChange = migrations.BurnerContractChangeUpdate
-		evmContractChange = migrations.EVMContractChangeUpdate
+		evmContractChange = migrations.EVMContractChangeUpdateFull
 	}
 
 	stagedContracts, err := migrations.StagedContractsFromCSV(flagStagedContractsFile)

--- a/cmd/util/ledger/migrations/burner.go
+++ b/cmd/util/ledger/migrations/burner.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	coreContracts "github.com/onflow/flow-core-contracts/lib/go/contracts"
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func NewBurnerDeploymentMigration(
+	chainID flow.ChainID,
+	logger zerolog.Logger,
+) RegistersMigration {
+	address := BurnerAddressForChain(chainID)
+	return NewDeploymentMigration(
+		chainID,
+		Contract{
+			Name: "Burner",
+			Code: coreContracts.Burner(),
+		},
+		address,
+		map[flow.Address]struct{}{
+			address: {},
+		},
+		logger,
+	)
+}

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -374,12 +374,23 @@ func NewCadence1ContractsMigrations(
 		)
 	}
 
-	if opts.EVMContractChange == EVMContractChangeDeploy {
+	switch opts.EVMContractChange {
+	case EVMContractChangeNone:
+		// NO-OP
+
+	case EVMContractChangeUpdateFull:
+		// handled in system contract updates (SystemContractChanges)
+
+	case EVMContractChangeDeployFull,
+		EVMContractChangeDeployMinimalAndUpdateFull:
+
+		full := opts.EVMContractChange == EVMContractChangeDeployFull
+
 		migs = append(
 			migs,
 			NamedMigration{
 				Name:    "evm-deployment-migration",
-				Migrate: NewEVMDeploymentMigration(opts.ChainID, log),
+				Migrate: NewEVMDeploymentMigration(opts.ChainID, log, full),
 			},
 		)
 	}
@@ -550,6 +561,20 @@ func NewCadence1Migrations(
 			opts,
 		)...,
 	)
+
+	switch opts.EVMContractChange {
+	case EVMContractChangeNone,
+		EVMContractChangeDeployFull:
+		// NO-OP
+	case EVMContractChangeUpdateFull, EVMContractChangeDeployMinimalAndUpdateFull:
+		migs = append(
+			migs,
+			NamedMigration{
+				Name:    "evm-setup-migration",
+				Migrate: NewEVMSetupMigration(opts.ChainID, log),
+			},
+		)
+	}
 
 	return migs
 }

--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -31,8 +31,13 @@ type EVMContractChange uint8
 
 const (
 	EVMContractChangeNone EVMContractChange = iota
-	EVMContractChangeDeploy
-	EVMContractChangeUpdate
+	// EVMContractChangeDeployFull deploys the full EVM contract
+	EVMContractChangeDeployFull
+	// EVMContractChangeUpdateFull updates the existing EVM contract to the latest, full EVM contract
+	EVMContractChangeUpdateFull
+	// EVMContractChangeDeployMinimalAndUpdateFull deploys the minimal EVM contract
+	// and updates it to the latest, full EVM contract
+	EVMContractChangeDeployMinimalAndUpdateFull
 )
 
 type BurnerContractChange uint8
@@ -216,7 +221,16 @@ func SystemContractChanges(chainID flow.ChainID, options SystemContractsMigratio
 	}
 
 	// EVM contract
-	if options.EVM == EVMContractChangeUpdate {
+	switch options.EVM {
+	case EVMContractChangeNone:
+		// NO-OP
+
+	case EVMContractChangeDeployFull:
+		// handled in migration pipeline (NewCadence1ContractsMigrations)
+
+	case EVMContractChangeUpdateFull,
+		EVMContractChangeDeployMinimalAndUpdateFull:
+
 		contractChanges = append(
 			contractChanges,
 			NewSystemContractChange(

--- a/cmd/util/ledger/migrations/deploy_migration.go
+++ b/cmd/util/ledger/migrations/deploy_migration.go
@@ -3,11 +3,8 @@ package migrations
 import (
 	"github.com/onflow/cadence"
 	jsoncdc "github.com/onflow/cadence/encoding/json"
-	coreContracts "github.com/onflow/flow-core-contracts/lib/go/contracts"
 	"github.com/rs/zerolog"
 
-	evm "github.com/onflow/flow-go/fvm/evm/stdlib"
-	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -38,48 +35,5 @@ func NewDeploymentMigration(
 		chainID,
 		logger,
 		expectedWriteAddresses,
-	)
-}
-
-func NewBurnerDeploymentMigration(
-	chainID flow.ChainID,
-	logger zerolog.Logger,
-) RegistersMigration {
-	address := BurnerAddressForChain(chainID)
-	return NewDeploymentMigration(
-		chainID,
-		Contract{
-			Name: "Burner",
-			Code: coreContracts.Burner(),
-		},
-		address,
-		map[flow.Address]struct{}{
-			address: {},
-		},
-		logger,
-	)
-}
-
-func NewEVMDeploymentMigration(
-	chainID flow.ChainID,
-	logger zerolog.Logger,
-) RegistersMigration {
-	systemContracts := systemcontracts.SystemContractsForChain(chainID)
-	address := systemContracts.EVMContract.Address
-	return NewDeploymentMigration(
-		chainID,
-		Contract{
-			Name: systemContracts.EVMContract.Name,
-			Code: evm.ContractCode(
-				systemContracts.NonFungibleToken.Address,
-				systemContracts.FungibleToken.Address,
-				systemContracts.FlowToken.Address,
-			),
-		},
-		address,
-		map[flow.Address]struct{}{
-			address: {},
-		},
-		logger,
 	)
 }

--- a/cmd/util/ledger/migrations/evm.go
+++ b/cmd/util/ledger/migrations/evm.go
@@ -1,0 +1,84 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/fvm/evm/stdlib"
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func NewEVMDeploymentMigration(
+	chainID flow.ChainID,
+	logger zerolog.Logger,
+	full bool,
+) RegistersMigration {
+
+	systemContracts := systemcontracts.SystemContractsForChain(chainID)
+	address := systemContracts.EVMContract.Address
+
+	var code []byte
+	if full {
+		code = stdlib.ContractCode(
+			systemContracts.NonFungibleToken.Address,
+			systemContracts.FungibleToken.Address,
+			systemContracts.FlowToken.Address,
+		)
+	} else {
+		code = []byte(stdlib.ContractMinimalCode)
+	}
+
+	return NewDeploymentMigration(
+		chainID,
+		Contract{
+			Name: systemContracts.EVMContract.Name,
+			Code: code,
+		},
+		address,
+		map[flow.Address]struct{}{
+			address: {},
+		},
+		logger,
+	)
+}
+
+// NewEVMSetupMigration returns a migration that sets up the EVM contract account.
+// It performs the same operations as the EVM contract's initializer, calling the function EVM.setupHeartbeat,
+// which in turn creates an EVM.Heartbeat resource, and writes it to the account's storage.
+func NewEVMSetupMigration(
+	chainID flow.ChainID,
+	logger zerolog.Logger,
+) RegistersMigration {
+
+	systemContracts := systemcontracts.SystemContractsForChain(chainID)
+	evmContract := systemContracts.EVMContract
+
+	tx := flow.NewTransactionBody().
+		SetScript([]byte(fmt.Sprintf(
+			`
+              import EVM from %s
+
+              transaction {
+                  prepare() {
+                      EVM.setupHeartbeat()
+                  }
+              }
+            `,
+			evmContract.Address.HexWithPrefix(),
+		)))
+
+	return NewTransactionBasedMigration(
+		tx,
+		chainID,
+		logger,
+		map[flow.Address]struct{}{
+			// The function call writes to the EVM contract account
+			evmContract.Address: {},
+			// The function call writes to the global account,
+			// as the function creates a resource, which gets initialized with a UUID
+			flow.Address{}: {},
+		},
+	)
+}

--- a/cmd/util/ledger/util/registers/registers.go
+++ b/cmd/util/ledger/util/registers/registers.go
@@ -367,11 +367,18 @@ func ApplyChanges(
 			ownerAddress := flow.BytesToAddress([]byte(registerID.Owner))
 
 			if _, ok := expectedChangeAddresses[ownerAddress]; !ok {
+
+				expectedChangeAddressesArray := zerolog.Arr()
+				for expectedChangeAddress := range expectedChangeAddresses {
+					expectedChangeAddressesArray =
+						expectedChangeAddressesArray.Str(expectedChangeAddress.Hex())
+				}
+
 				// something was changed that does not belong to this account. Log it.
 				logger.Error().
 					Str("key", registerID.String()).
 					Str("actual_address", ownerAddress.Hex()).
-					Interface("expected_addresses", expectedChangeAddresses).
+					Array("expected_addresses", expectedChangeAddressesArray).
 					Hex("value", newValue).
 					Msg("key is part of the change set, but is for a different account")
 			}

--- a/engine/access/rest/apiproxy/rest_proxy_handler.go
+++ b/engine/access/rest/apiproxy/rest_proxy_handler.go
@@ -203,6 +203,30 @@ func (r *RestProxyHandler) GetAccountAtBlockHeight(ctx context.Context, address 
 	return convert.MessageToAccount(accountResponse.Account)
 }
 
+// GetAccountKeyByIndex returns account key by account address, key index and block height.
+func (r *RestProxyHandler) GetAccountKeyByIndex(ctx context.Context, address flow.Address, keyIndex uint32, height uint64) (*flow.AccountPublicKey, error) {
+	upstream, closer, err := r.FaultTolerantClient()
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+
+	getAccountKeyAtBlockHeightRequest := &accessproto.GetAccountKeyAtBlockHeightRequest{
+		Address:     address.Bytes(),
+		Index:       keyIndex,
+		BlockHeight: height,
+	}
+
+	accountKeyResponse, err := upstream.GetAccountKeyAtBlockHeight(ctx, getAccountKeyAtBlockHeightRequest)
+	r.log("upstream", "GetAccountKeyAtBlockHeight", err)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return convert.MessageToAccountKey(accountKeyResponse.AccountKey)
+}
+
 // ExecuteScriptAtLatestBlock executes script at latest block.
 func (r *RestProxyHandler) ExecuteScriptAtLatestBlock(ctx context.Context, script []byte, arguments [][]byte) ([]byte, error) {
 	upstream, closer, err := r.FaultTolerantClient()

--- a/engine/access/rest/routes/account_keys.go
+++ b/engine/access/rest/routes/account_keys.go
@@ -27,20 +27,13 @@ func GetAccountKeyByIndex(r *request.Request, backend access.API, link models.Li
 		req.Height = header.Height
 	}
 
-	account, err := backend.GetAccountAtBlockHeight(r.Context(), req.Address, req.Height)
+	accountKey, err := backend.GetAccountKeyAtBlockHeight(r.Context(), req.Address, req.Index, req.Height)
 	if err != nil {
-		err := fmt.Errorf("account with address: %s does not exist", req.Address)
+		err = fmt.Errorf("failed to get account key with index: %d, reason: %w", req.Index, err)
 		return nil, models.NewNotFoundError(err.Error(), err)
 	}
 
 	var response models.AccountPublicKey
-	for _, key := range account.Keys {
-		if key.Index == req.Index {
-			response.Build(key)
-			return response, nil
-		}
-	}
-
-	err = fmt.Errorf("account key with index: %d does not exist", req.Index)
-	return nil, models.NewNotFoundError(err.Error(), err)
+	response.Build(*accountKey)
+	return response, nil
 }

--- a/engine/common/version/version_control.go
+++ b/engine/common/version/version_control.go
@@ -1,0 +1,367 @@
+package version
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/rs/zerolog"
+	"go.uber.org/atomic"
+
+	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/counters"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/state/protocol"
+	psEvents "github.com/onflow/flow-go/state/protocol/events"
+	"github.com/onflow/flow-go/storage"
+)
+
+// ErrOutOfRange indicates that height is higher than last handled block height
+var ErrOutOfRange = errors.New("height is out of range")
+
+// VersionControlConsumer defines a function type that consumes version control updates.
+// It is called with the block height and the corresponding semantic version.
+// There are two possible notifications options:
+// - A new or updated version will have a height and a semantic version at that height.
+// - A deleted version will have the previous height and nil semantic version, indicating that the update was deleted.
+type VersionControlConsumer func(height uint64, version *semver.Version)
+
+// NoHeight represents the maximum possible height for blocks.
+var NoHeight = uint64(0)
+
+// VersionControl manages the version control system for the node.
+// It consumes BlockFinalized events and updates the node's version control based on the latest version beacon.
+//
+// VersionControl implements the protocol.Consumer and component.Component interfaces.
+type VersionControl struct {
+	// Noop implements the protocol.Consumer interface with no operations.
+	psEvents.Noop
+	sync.Mutex
+	component.Component
+
+	log zerolog.Logger
+	// Storage
+	versionBeacons storage.VersionBeacons
+
+	// nodeVersion stores the node's current version.
+	// It could be nil if the node version is not available.
+	nodeVersion *semver.Version
+
+	// consumers stores the list of consumers for version updates.
+	consumers []VersionControlConsumer
+
+	// Notifier for new finalized block height
+	finalizedHeightNotifier engine.Notifier
+
+	finalizedHeight counters.StrictMonotonousCounter
+
+	// lastProcessedHeight the last handled block height
+	lastProcessedHeight *atomic.Uint64
+
+	// sealedRootBlockHeight the last sealed block height when node bootstrapped
+	sealedRootBlockHeight *atomic.Uint64
+
+	// startHeight and endHeight define the height boundaries for version compatibility.
+	startHeight *atomic.Uint64
+	endHeight   *atomic.Uint64
+}
+
+var _ protocol.Consumer = (*VersionControl)(nil)
+var _ component.Component = (*VersionControl)(nil)
+
+// NewVersionControl creates a new VersionControl instance.
+//
+// We currently have no strong guarantee that the node version is a valid semver.
+// See build.SemverV2 for more details. That is why nil is a valid input for node version.
+func NewVersionControl(
+	log zerolog.Logger,
+	versionBeacons storage.VersionBeacons,
+	nodeVersion *semver.Version,
+	sealedRootBlockHeight uint64,
+	latestFinalizedBlockHeight uint64,
+) (*VersionControl, error) {
+
+	vc := &VersionControl{
+		log: log.With().
+			Str("component", "version_control").
+			Logger(),
+
+		nodeVersion:             nodeVersion,
+		versionBeacons:          versionBeacons,
+		sealedRootBlockHeight:   atomic.NewUint64(sealedRootBlockHeight),
+		lastProcessedHeight:     atomic.NewUint64(latestFinalizedBlockHeight),
+		finalizedHeight:         counters.NewMonotonousCounter(latestFinalizedBlockHeight),
+		finalizedHeightNotifier: engine.NewNotifier(),
+		startHeight:             atomic.NewUint64(NoHeight),
+		endHeight:               atomic.NewUint64(NoHeight),
+	}
+
+	if vc.nodeVersion == nil {
+		return nil, fmt.Errorf("version control node version is empty")
+	}
+
+	vc.log.Info().
+		Stringer("node_version", vc.nodeVersion).
+		Msg("system initialized")
+
+	// Setup component manager for handling worker functions.
+	cm := component.NewComponentManagerBuilder()
+	cm.AddWorker(vc.processEvents)
+	cm.AddWorker(vc.checkInitialVersionBeacon)
+
+	vc.Component = cm.Build()
+
+	return vc, nil
+}
+
+// checkInitialVersionBeacon checks the initial version beacon at the latest finalized block.
+// It ensures the component is not ready until the initial version beacon is checked.
+func (v *VersionControl) checkInitialVersionBeacon(
+	ctx irrecoverable.SignalerContext,
+	ready component.ReadyFunc,
+) {
+	err := v.initBoundaries(ctx)
+	if err == nil {
+		ready()
+	}
+}
+
+// initBoundaries initializes the version boundaries for version control.
+//
+// It searches through version beacons to find the start and end block heights
+// for the current node version. The search continues until the start height
+// is found or until the sealed root block height is reached.
+//
+// Returns an error when could not get the highest version beacon event
+func (v *VersionControl) initBoundaries(
+	ctx irrecoverable.SignalerContext,
+) error {
+	sealedRootBlockHeight := v.sealedRootBlockHeight.Load()
+	latestHeight := v.lastProcessedHeight.Load()
+	processedHeight := latestHeight
+
+	for {
+		vb, err := v.versionBeacons.Highest(processedHeight)
+		if err != nil && !errors.Is(err, storage.ErrNotFound) {
+			ctx.Throw(
+				fmt.Errorf(
+					"failed to get highest version beacon for version control: %w",
+					err))
+			return err
+		}
+
+		if vb == nil {
+			// no version beacon found
+			// this is unexpected on a live network as there should always be at least the
+			// starting version beacon, but not fatal.
+			// It can happen on new or test networks if the node starts before bootstrap is finished.
+			// TODO: remove when we can guarantee that there will always be a version beacon
+			v.log.Info().
+				Uint64("height", processedHeight).
+				Msg("No version beacon found for version control")
+
+			return nil
+		}
+
+		// version boundaries are sorted by blockHeight in ascending order
+		// the first version greater than the node's is the version transition height
+		for i := len(vb.VersionBoundaries) - 1; i >= 0; i-- {
+			boundary := vb.VersionBoundaries[i]
+
+			ver, err := boundary.Semver()
+			// this should never happen as we already validated the version beacon
+			// when indexing it
+			if err != nil || ver == nil {
+				if err == nil {
+					err = fmt.Errorf("boundary semantic version is nil")
+				}
+				ctx.Throw(
+					fmt.Errorf(
+						"failed to parse semver during version control setup: %w",
+						err))
+				return err
+			}
+
+			compResult := ver.Compare(*v.nodeVersion)
+			processedHeight = vb.SealHeight - 1
+
+			if compResult <= 0 {
+				v.startHeight.Store(boundary.BlockHeight)
+				v.log.Info().
+					Uint64("startHeight", boundary.BlockHeight).
+					Msg("Found start block height")
+				// This is the lowest compatible height for this node version, stop search immediately
+				return nil
+			} else {
+				v.endHeight.Store(boundary.BlockHeight - 1)
+				v.log.Info().
+					Uint64("endHeight", boundary.BlockHeight-1).
+					Msg("Found end block height")
+			}
+		}
+
+		// The search should continue until we find the start height or reach the sealed root block height
+		if v.startHeight.Load() == NoHeight && processedHeight <= sealedRootBlockHeight {
+			v.log.Info().
+				Uint64("processedHeight", processedHeight).
+				Uint64("sealedRootBlockHeight", sealedRootBlockHeight).
+				Msg("No start version beacon event found")
+			return nil
+		}
+	}
+}
+
+// BlockFinalized is called when a block is finalized.
+// It implements the protocol.Consumer interface.
+func (v *VersionControl) BlockFinalized(h *flow.Header) {
+	if v.finalizedHeight.Set(h.Height) {
+		v.finalizedHeightNotifier.Notify()
+	}
+}
+
+// CompatibleAtBlock checks if the node's version is compatible at a given block height.
+// It returns true if the node's version is compatible within the specified height range.
+// Returns expected errors:
+// - ErrOutOfRange if incoming block height is higher that last handled block height
+func (v *VersionControl) CompatibleAtBlock(height uint64) (bool, error) {
+	// Check, if the height smaller than sealed root block height. If so, return an error indicating that the height is unhandled.
+	sealedRootHeight := v.sealedRootBlockHeight.Load()
+	if height < sealedRootHeight {
+		return false, fmt.Errorf("could not check compatibility for height %d: the provided height is smaller than sealed root height %d: %w", height, sealedRootHeight, ErrOutOfRange)
+	}
+
+	// Check if the height is greater than the last handled block height. If so, return an error indicating that the height is unhandled.
+	lastProcessedHeight := v.lastProcessedHeight.Load()
+	if height > lastProcessedHeight {
+		return false, fmt.Errorf("could not check compatibility for height %d: last handled height is %d: %w", height, lastProcessedHeight, ErrOutOfRange)
+	}
+
+	startHeight := v.startHeight.Load()
+	// Check if the start height is set and the height is less than the start height. If so, return false indicating that the height is not compatible.
+	if startHeight != NoHeight && height < startHeight {
+		return false, nil
+	}
+
+	endHeight := v.endHeight.Load()
+	// Check if the end height is set and the height is greater than the end height. If so, return false indicating that the height is not compatible.
+	if endHeight != NoHeight && height > endHeight {
+		return false, nil
+	}
+
+	// If none of the above conditions are met, the height is compatible.
+	return true, nil
+}
+
+// AddVersionUpdatesConsumer adds a consumer for version update events.
+func (v *VersionControl) AddVersionUpdatesConsumer(consumer VersionControlConsumer) {
+	v.Lock()
+	defer v.Unlock()
+
+	v.consumers = append(v.consumers, consumer)
+}
+
+// processEvents is a worker that processes block finalized events.
+func (v *VersionControl) processEvents(
+	ctx irrecoverable.SignalerContext,
+	ready component.ReadyFunc,
+) {
+	ready()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-v.finalizedHeightNotifier.Channel():
+			v.blockFinalized(ctx, v.finalizedHeight.Value())
+		}
+	}
+}
+
+// blockFinalized processes a block finalized event and updates the version control state.
+func (v *VersionControl) blockFinalized(
+	ctx irrecoverable.SignalerContext,
+	newFinalizedHeight uint64,
+) {
+	lastProcessedHeight := v.lastProcessedHeight.Load()
+	if lastProcessedHeight >= newFinalizedHeight {
+		// already processed this or a higher version beacon
+		return
+	}
+
+	for height := lastProcessedHeight + 1; height <= newFinalizedHeight; height++ {
+		vb, err := v.versionBeacons.Highest(height)
+		if err != nil {
+			v.log.Err(err).
+				Uint64("height", height).
+				Msg("Failed to get highest version beacon for version control")
+
+			ctx.Throw(
+				fmt.Errorf(
+					"failed to get highest version beacon for version control: %w",
+					err))
+			return
+		}
+
+		if vb == nil {
+			// no version beacon found
+			// this is unexpected as there should always be at least the
+			// starting version beacon, but not fatal.
+			// It can happen if the node starts before bootstrap is finished.
+			// TODO: remove when we can guarantee that there will always be a version beacon
+			v.log.Info().
+				Uint64("height", height).
+				Msg("No version beacon found for version control")
+			continue
+		}
+
+		v.lastProcessedHeight.Store(height)
+
+		previousEndHeight := v.endHeight.Load()
+
+		if previousEndHeight != NoHeight && height > previousEndHeight {
+			// Stop here since it's outside our compatible range
+			return
+		}
+
+		newEndHeight := NoHeight
+		// version boundaries are sorted by blockHeight in ascending order
+		for _, boundary := range vb.VersionBoundaries {
+			ver, err := boundary.Semver()
+			if err != nil || ver == nil {
+				if err == nil {
+					err = fmt.Errorf("boundary semantic version is nil")
+				}
+				// this should never happen as we already validated the version beacon
+				// when indexing it
+				ctx.Throw(
+					fmt.Errorf(
+						"failed to parse semver: %w",
+						err))
+				return
+			}
+
+			if ver.Compare(*v.nodeVersion) > 0 {
+				newEndHeight = boundary.BlockHeight - 1
+
+				for _, consumer := range v.consumers {
+					consumer(boundary.BlockHeight, ver)
+				}
+
+				break
+			}
+		}
+
+		v.endHeight.Store(newEndHeight)
+
+		// Check if previous version was deleted. If yes, notify consumers about deletion
+		if previousEndHeight != NoHeight && newEndHeight == NoHeight {
+			for _, consumer := range v.consumers {
+				// Note: notifying for the boundary height, which is end height + 1
+				consumer(previousEndHeight+1, nil)
+			}
+		}
+	}
+}

--- a/engine/common/version/version_control_test.go
+++ b/engine/common/version/version_control_test.go
@@ -1,0 +1,608 @@
+package version
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/onflow/flow-go/utils/unittest/mocks"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/stretchr/testify/assert"
+	testifyMock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/storage"
+	storageMock "github.com/onflow/flow-go/storage/mock"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// testCaseConfig contains custom tweaks for test cases
+type testCaseConfig struct {
+	name        string
+	nodeVersion string
+
+	versionEvents []*flow.SealedVersionBeacon
+	expectedStart uint64
+	expectedEnd   uint64
+}
+
+// TestVersionControlInitialization tests the initialization process of the VersionControl component
+func TestVersionControlInitialization(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sealedRootBlockHeight := uint64(1000)
+	latestBlockHeight := sealedRootBlockHeight + 100
+
+	testCases := []testCaseConfig{
+		{
+			name:        "no version beacon found",
+			nodeVersion: "0.0.1",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight-100,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight - 50, Version: "0.0.1"}),
+			},
+			expectedStart: sealedRootBlockHeight,
+			expectedEnd:   latestBlockHeight,
+		},
+		{
+			name:        "start version set",
+			nodeVersion: "0.0.1",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight+10,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 12, Version: "0.0.1"}),
+			},
+			expectedStart: sealedRootBlockHeight + 12,
+			expectedEnd:   latestBlockHeight,
+		},
+		{
+			name:        "correct start version found",
+			nodeVersion: "0.0.3",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight+2,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 4, Version: "0.0.1"}),
+				VersionBeaconEvent(sealedRootBlockHeight+5,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 7, Version: "0.0.2"}),
+			},
+			expectedStart: sealedRootBlockHeight + 7,
+			expectedEnd:   latestBlockHeight,
+		},
+		{
+			name:        "end version set",
+			nodeVersion: "0.0.1",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight-100,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight - 50, Version: "0.0.1"}),
+				VersionBeaconEvent(latestBlockHeight-10,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight - 8, Version: "0.0.3"}),
+			},
+			expectedStart: sealedRootBlockHeight,
+			expectedEnd:   latestBlockHeight - 9,
+		},
+		{
+			name:        "correct end version found",
+			nodeVersion: "0.0.1",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight-100,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight - 50, Version: "0.0.1"}),
+				VersionBeaconEvent(latestBlockHeight-10,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight - 8, Version: "0.0.3"}),
+				VersionBeaconEvent(latestBlockHeight-3,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight - 1, Version: "0.0.4"}),
+			},
+			expectedStart: sealedRootBlockHeight,
+			expectedEnd:   latestBlockHeight - 9,
+		},
+		{
+			name:        "start and end version set",
+			nodeVersion: "0.0.2",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight+10,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 12, Version: "0.0.1"}),
+				VersionBeaconEvent(latestBlockHeight-10,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight - 8, Version: "0.0.3"}),
+			},
+			expectedStart: sealedRootBlockHeight + 12,
+			expectedEnd:   latestBlockHeight - 9,
+		},
+		{
+			name:        "correct start and end version found",
+			nodeVersion: "0.0.2",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight+2,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 4, Version: "0.0.1"}),
+				VersionBeaconEvent(sealedRootBlockHeight+10,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 12, Version: "0.0.2"}),
+				VersionBeaconEvent(latestBlockHeight-10,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight - 8, Version: "0.0.3"}),
+				VersionBeaconEvent(latestBlockHeight-3,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight - 1, Version: "0.0.4"}),
+			},
+			expectedStart: sealedRootBlockHeight + 12,
+			expectedEnd:   latestBlockHeight - 9,
+		},
+		{
+			name:        "node's version is too old for current latest",
+			nodeVersion: "0.0.1",
+			versionEvents: []*flow.SealedVersionBeacon{
+				// the node's version is too old for the earliest version boundary for the network
+				VersionBeaconEvent(sealedRootBlockHeight-100,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight - 50, Version: "0.0.2"}),
+			},
+			expectedStart: math.MaxUint64,
+			expectedEnd:   math.MaxUint64,
+		},
+		{
+			name:        "node's version is too new for current latest",
+			nodeVersion: "0.0.3",
+			versionEvents: []*flow.SealedVersionBeacon{
+				VersionBeaconEvent(sealedRootBlockHeight-100,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight - 50, Version: "0.0.2"}),
+
+				// the version boundary that transitions to the node's version applies after the
+				// latest finalized block, so the node's version is not compatible with any block
+				VersionBeaconEvent(latestBlockHeight-3,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight + 1, Version: "0.0.3"}),
+				VersionBeaconEvent(latestBlockHeight-2,
+					flow.VersionBoundary{BlockHeight: latestBlockHeight + 2, Version: "0.0.4"}),
+			},
+			expectedStart: math.MaxUint64,
+			expectedEnd:   math.MaxUint64,
+		},
+		{
+			name:        "pre-release versions handled as expected",
+			nodeVersion: "0.0.1-pre-release.1",
+			versionEvents: []*flow.SealedVersionBeacon{
+				// 0.0.1-pre-release.1 > 0.0.1-pre-release.0
+				VersionBeaconEvent(sealedRootBlockHeight+10,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 12, Version: "0.0.1-pre-release.0"}),
+				// 0.0.1-pre-release.1 < 0.0.1
+				VersionBeaconEvent(sealedRootBlockHeight+12,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 14, Version: "0.0.1"}),
+			},
+			expectedStart: sealedRootBlockHeight + 12,
+			expectedEnd:   sealedRootBlockHeight + 13,
+		},
+		{
+			name:        "0.0.0 handled as expected",
+			nodeVersion: "0.0.0-20230101000000-c0c9f774e40c",
+			versionEvents: []*flow.SealedVersionBeacon{
+				// 0.0.0-20230101000000-c0c9f774e40c > 0.0.0-20220101000000-7b4eea64cf58
+				VersionBeaconEvent(sealedRootBlockHeight+10,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 12, Version: "0.0.0-20220101000000-7b4eea64cf58"}),
+				// 0.0.0-20230101000000-c0c9f774e40c < 0.0.0-20240101000000-6ceb2ff114de
+				VersionBeaconEvent(sealedRootBlockHeight+12,
+					flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 14, Version: "0.0.0-20240101000000-6ceb2ff114de"}),
+			},
+			expectedStart: sealedRootBlockHeight + 12,
+			expectedEnd:   sealedRootBlockHeight + 13,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			eventMap := make(map[uint64]*flow.SealedVersionBeacon, len(testCase.versionEvents))
+			for _, event := range testCase.versionEvents {
+				eventMap[event.SealHeight] = event
+			}
+
+			// make sure events are sorted descending by seal height
+			sort.Slice(testCase.versionEvents, func(i, j int) bool {
+				return testCase.versionEvents[i].SealHeight > testCase.versionEvents[j].SealHeight
+			})
+
+			versionBeacons := storageMock.NewVersionBeacons(t)
+			versionBeacons.
+				On("Highest", testifyMock.AnythingOfType("uint64")).
+				Return(func(height uint64) (*flow.SealedVersionBeacon, error) {
+					// iterating through events sorted descending by seal height
+					// return the first event that was sealed in a height less than or equal to height
+					for _, event := range testCase.versionEvents {
+						if event.SealHeight <= height {
+							return event, nil
+						}
+					}
+					return nil, storage.ErrNotFound
+				})
+
+			vc := createVersionControlComponent(t, versionComponentTestConfigs{
+				nodeVersion:                testCase.nodeVersion,
+				versionBeacons:             versionBeacons,
+				sealedRootBlockHeight:      sealedRootBlockHeight,
+				latestFinalizedBlockHeight: latestBlockHeight,
+				signalerContext:            irrecoverable.NewMockSignalerContext(t, ctx),
+			})
+
+			checks := generateChecks(testCase, sealedRootBlockHeight, latestBlockHeight)
+
+			for height, expected := range checks {
+				compatible, err := vc.CompatibleAtBlock(height)
+
+				require.NoError(t, err)
+				assert.Equal(t, expected, compatible, "unexpected compatibility at height %d. want: %t, got %t", height, expected, compatible)
+			}
+		})
+	}
+}
+
+// TestVersionControlInitializationWithErrors tests the initialization process of the VersionControl component with error cases
+func TestVersionControlInitializationWithErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sealedRootBlockHeight := uint64(1000)
+	latestBlockHeight := sealedRootBlockHeight + 100
+	eventMap := map[uint64]*flow.SealedVersionBeacon{
+		sealedRootBlockHeight + 10: VersionBeaconEvent(sealedRootBlockHeight+10,
+			flow.VersionBoundary{BlockHeight: sealedRootBlockHeight + 12, Version: "0.0.1"}),
+	}
+
+	versionBeacons := storageMock.NewVersionBeacons(t)
+
+	checkForError := func(height uint64) {
+		versionBeacons.
+			On("Highest", testifyMock.AnythingOfType("uint64")).
+			Return(mocks.StorageMapGetter(eventMap)).Once()
+
+		vc := createVersionControlComponent(t, versionComponentTestConfigs{
+			nodeVersion:                "0.0.1",
+			versionBeacons:             versionBeacons,
+			sealedRootBlockHeight:      sealedRootBlockHeight,
+			latestFinalizedBlockHeight: latestBlockHeight,
+			signalerContext:            irrecoverable.NewMockSignalerContext(t, ctx),
+		})
+
+		compatible, err := vc.CompatibleAtBlock(height)
+
+		assert.True(t, errors.Is(err, ErrOutOfRange))
+		assert.False(t, compatible)
+	}
+
+	t.Run("height is bigger than latest block height", func(t *testing.T) {
+		checkForError(latestBlockHeight + 1)
+	})
+
+	t.Run("height is smaller than sealed root block height", func(t *testing.T) {
+		checkForError(sealedRootBlockHeight - 1)
+	})
+
+	t.Run("failed to complete initialization due to \"Highest\" of version beacon returns error", func(t *testing.T) {
+		decodeErr := fmt.Errorf("test decode error")
+
+		versionBeacons.
+			On("Highest", testifyMock.AnythingOfType("uint64")).
+			Return(nil, decodeErr).Once()
+
+		vc, err := NewVersionControl(
+			unittest.Logger(),
+			versionBeacons,
+			semver.New("0.0.1"),
+			sealedRootBlockHeight,
+			latestBlockHeight,
+		)
+		require.NoError(t, err)
+
+		vc.Start(irrecoverable.NewMockSignalerContextExpectError(t, ctx, fmt.Errorf(
+			"failed to get highest version beacon for version control: %w",
+			decodeErr)))
+
+		unittest.AssertNotClosesBefore(t, vc.Ready(), 2*time.Second)
+	})
+}
+
+func generateChecks(testCase testCaseConfig, finalizedRootBlockHeight, latestBlockHeight uint64) map[uint64]bool {
+	checks := map[uint64]bool{}
+	if testCase.expectedStart == math.MaxUint64 && testCase.expectedEnd == math.MaxUint64 {
+		for height := finalizedRootBlockHeight; height <= latestBlockHeight; height++ {
+			checks[height] = false
+		}
+		return checks
+	}
+
+	checks[testCase.expectedStart] = true
+	checks[testCase.expectedEnd] = true
+
+	if testCase.expectedStart > finalizedRootBlockHeight {
+		checks[finalizedRootBlockHeight] = false
+		checks[testCase.expectedStart-1] = false
+	}
+
+	if testCase.expectedEnd < latestBlockHeight {
+		checks[latestBlockHeight] = false
+		checks[testCase.expectedEnd+1] = false
+	}
+
+	return checks
+}
+
+// TestVersionBoundaryUpdated tests the behavior of the VersionControl component when the version is updated.
+func TestVersionBoundaryUpdated(t *testing.T) {
+	signalCtx := irrecoverable.NewMockSignalerContext(t, context.Background())
+
+	contract := &versionBeaconContract{}
+
+	// Create version event for initial height
+	latestHeight := uint64(10)
+	boundaryHeight := uint64(13)
+
+	vc := createVersionControlComponent(t, versionComponentTestConfigs{
+		nodeVersion:                "0.0.1",
+		versionBeacons:             contract,
+		sealedRootBlockHeight:      0,
+		latestFinalizedBlockHeight: latestHeight,
+		signalerContext:            signalCtx,
+	})
+
+	var assertUpdate func(height uint64, version *semver.Version)
+	var assertCallbackCalled func()
+
+	// Add a consumer to verify version updates
+	vc.AddVersionUpdatesConsumer(func(height uint64, version *semver.Version) {
+		assertUpdate(height, version)
+	})
+	assert.Len(t, vc.consumers, 1)
+
+	// At this point, both start and end heights are unset
+
+	// Add a new boundary, and finalize the block
+	latestHeight++ // 11
+	contract.AddBoundary(latestHeight, flow.VersionBoundary{BlockHeight: boundaryHeight, Version: "0.0.2"})
+
+	assertUpdate, assertCallbackCalled = generateConsumerAssertions(t, boundaryHeight, semver.New("0.0.2"))
+	vc.blockFinalized(signalCtx, latestHeight)
+	assertCallbackCalled()
+
+	// Next, update the boundary and finalize the block
+	latestHeight++ // 12
+	contract.UpdateBoundary(latestHeight, boundaryHeight, "0.0.3")
+
+	assertUpdate, assertCallbackCalled = generateConsumerAssertions(t, boundaryHeight, semver.New("0.0.3"))
+	vc.blockFinalized(signalCtx, latestHeight)
+	assertCallbackCalled()
+
+	// Finally, finalize one more block to get past the boundary
+	latestHeight++ // 13
+	vc.blockFinalized(signalCtx, latestHeight)
+
+	// Check compatibility at various heights
+	compatible, err := vc.CompatibleAtBlock(10)
+	require.NoError(t, err)
+	assert.True(t, compatible)
+
+	compatible, err = vc.CompatibleAtBlock(12)
+	require.NoError(t, err)
+	assert.True(t, compatible)
+
+	compatible, err = vc.CompatibleAtBlock(13)
+	require.NoError(t, err)
+	assert.False(t, compatible)
+}
+
+// TestVersionBoundaryDeleted tests the behavior of the VersionControl component when the version is deleted.
+func TestVersionBoundaryDeleted(t *testing.T) {
+	signalCtx := irrecoverable.NewMockSignalerContext(t, context.Background())
+
+	contract := &versionBeaconContract{}
+
+	// Create version event for initial height
+	latestHeight := uint64(10)
+	boundaryHeight := uint64(13)
+
+	vc := createVersionControlComponent(t, versionComponentTestConfigs{
+		nodeVersion:                "0.0.1",
+		versionBeacons:             contract,
+		sealedRootBlockHeight:      0,
+		latestFinalizedBlockHeight: latestHeight,
+		signalerContext:            signalCtx,
+	})
+
+	var assertUpdate func(height uint64, version *semver.Version)
+	var assertCallbackCalled func()
+
+	// Add a consumer to verify version updates
+	vc.AddVersionUpdatesConsumer(func(height uint64, version *semver.Version) {
+		assertUpdate(height, version)
+	})
+	assert.Len(t, vc.consumers, 1)
+
+	// Add a new boundary, and finalize the block
+	latestHeight++ // 11
+	contract.AddBoundary(latestHeight, flow.VersionBoundary{BlockHeight: boundaryHeight, Version: "0.0.2"})
+
+	assertUpdate, assertCallbackCalled = generateConsumerAssertions(t, boundaryHeight, semver.New("0.0.2"))
+	vc.blockFinalized(signalCtx, latestHeight)
+	assertCallbackCalled()
+
+	// Next, delete the boundary and finalize the block
+	latestHeight++ // 12
+	contract.DeleteBoundary(latestHeight, boundaryHeight)
+
+	assertUpdate, assertCallbackCalled = generateConsumerAssertions(t, boundaryHeight, nil) // called with empty string signalling deleted
+	vc.blockFinalized(signalCtx, latestHeight)
+	assertCallbackCalled()
+
+	// Finally, finalize one more block to get past the boundary
+	latestHeight++ // 13
+	vc.blockFinalized(signalCtx, latestHeight)
+
+	// Check compatibility at various heights
+	compatible, err := vc.CompatibleAtBlock(10)
+	require.NoError(t, err)
+	assert.True(t, compatible)
+
+	compatible, err = vc.CompatibleAtBlock(12)
+	require.NoError(t, err)
+	assert.True(t, compatible)
+
+	compatible, err = vc.CompatibleAtBlock(13)
+	require.NoError(t, err)
+	assert.True(t, compatible)
+}
+
+// TestNotificationSkippedForCompatibleVersions tests that the VersionControl component does not
+// send notifications to consumers VersionBeacon events with compatible versions.
+func TestNotificationSkippedForCompatibleVersions(t *testing.T) {
+	signalCtx := irrecoverable.NewMockSignalerContext(t, context.Background())
+
+	contract := &versionBeaconContract{}
+
+	// Create version event for initial height
+	latestHeight := uint64(10)
+	boundaryHeight := uint64(13)
+
+	vc := createVersionControlComponent(t, versionComponentTestConfigs{
+		nodeVersion:                "0.0.1",
+		versionBeacons:             contract,
+		sealedRootBlockHeight:      0,
+		latestFinalizedBlockHeight: latestHeight,
+		signalerContext:            signalCtx,
+	})
+
+	// Add a consumer to verify notification is never sent
+	vc.AddVersionUpdatesConsumer(func(height uint64, version *semver.Version) {
+		t.Errorf("unexpected callback called at height %d with version %s", height, version)
+	})
+	assert.Len(t, vc.consumers, 1)
+
+	// Add a new boundary, and finalize the block
+	latestHeight++ // 11
+	contract.AddBoundary(latestHeight, flow.VersionBoundary{BlockHeight: boundaryHeight, Version: "0.0.1-pre-release"})
+
+	vc.blockFinalized(signalCtx, latestHeight)
+
+	// Check compatibility at various heights
+	compatible, err := vc.CompatibleAtBlock(10)
+	require.NoError(t, err)
+	assert.True(t, compatible)
+
+	compatible, err = vc.CompatibleAtBlock(11)
+	require.NoError(t, err)
+	assert.True(t, compatible)
+}
+
+func generateConsumerAssertions(
+	t *testing.T,
+	boundaryHeight uint64,
+	version *semver.Version,
+) (func(height uint64, semver *semver.Version), func()) {
+	called := false
+
+	assertUpdate := func(height uint64, semver *semver.Version) {
+		assert.Equal(t, boundaryHeight, height)
+		assert.Equal(t, version, semver)
+		called = true
+	}
+
+	assertCalled := func() {
+		assert.True(t, called)
+	}
+
+	return assertUpdate, assertCalled
+}
+
+// versionComponentTestConfigs contains custom tweaks for version control creation
+type versionComponentTestConfigs struct {
+	nodeVersion                string
+	versionBeacons             storage.VersionBeacons
+	sealedRootBlockHeight      uint64
+	latestFinalizedBlockHeight uint64
+	signalerContext            *irrecoverable.MockSignalerContext
+}
+
+func createVersionControlComponent(
+	t *testing.T,
+	config versionComponentTestConfigs,
+) *VersionControl {
+	// Create a new VersionControl instance with initial parameters.
+	vc, err := NewVersionControl(
+		unittest.Logger(),
+		config.versionBeacons,
+		semver.New(config.nodeVersion),
+		config.sealedRootBlockHeight,
+		config.latestFinalizedBlockHeight,
+	)
+	require.NoError(t, err)
+
+	// Start the VersionControl component.
+	vc.Start(config.signalerContext)
+	unittest.RequireComponentsReadyBefore(t, 2*time.Second, vc)
+
+	return vc
+}
+
+// VersionBeaconEvent creates a SealedVersionBeacon for the given heights and versions.
+func VersionBeaconEvent(sealHeight uint64, vb ...flow.VersionBoundary) *flow.SealedVersionBeacon {
+	return &flow.SealedVersionBeacon{
+		VersionBeacon: unittest.VersionBeaconFixture(
+			unittest.WithBoundaries(vb...),
+		),
+		SealHeight: sealHeight,
+	}
+}
+
+type versionBeaconContract struct {
+	boundaries []flow.VersionBoundary
+	events     []*flow.SealedVersionBeacon
+}
+
+func (c *versionBeaconContract) Highest(belowOrEqualTo uint64) (*flow.SealedVersionBeacon, error) {
+	for _, event := range c.events {
+		if event.SealHeight <= belowOrEqualTo {
+			return event, nil
+		}
+	}
+	return nil, storage.ErrNotFound
+}
+
+func (c *versionBeaconContract) AddBoundary(sealedHeight uint64, boundary flow.VersionBoundary) {
+	c.boundaries = append(c.boundaries, boundary)
+	c.emitEvent(sealedHeight)
+}
+
+func (c *versionBeaconContract) DeleteBoundary(sealedHeight, boundaryHeight uint64) {
+	for i, boundary := range c.boundaries {
+		if boundary.BlockHeight == boundaryHeight {
+			c.boundaries = append(c.boundaries[:i], c.boundaries[i+1:]...)
+			break
+		}
+	}
+	c.emitEvent(sealedHeight)
+}
+
+func (c *versionBeaconContract) UpdateBoundary(sealedHeight, boundaryHeight uint64, version string) {
+	for i, boundary := range c.boundaries {
+		if boundary.BlockHeight == boundaryHeight {
+			c.boundaries[i].Version = version
+			break
+		}
+	}
+	c.emitEvent(sealedHeight)
+}
+
+func (c *versionBeaconContract) emitEvent(sealedHeight uint64) {
+	// sort boundaries ascending by height
+	sort.Slice(c.boundaries, func(i, j int) bool {
+		return c.boundaries[i].BlockHeight < c.boundaries[j].BlockHeight
+	})
+
+	// include only future boundaries
+	boundaries := make([]flow.VersionBoundary, 0)
+	for _, boundary := range c.boundaries {
+		if boundary.BlockHeight >= sealedHeight {
+			boundaries = append(boundaries, boundary)
+		}
+	}
+	c.events = append(c.events, VersionBeaconEvent(sealedHeight, boundaries...))
+
+	// sort boundaries descending by height
+	sort.Slice(c.events, func(i, j int) bool {
+		return c.events[i].SealHeight > c.events[j].SealHeight
+	})
+}

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("8394b655612248d6f87c0302762c399613319a9bcec19391755a97b50062b1d4")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("1383e01cdba9bb1df08d413f89c3a252f1081f2ebb0c58850676194a01cfc4c4")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/evm/backends/wrappedEnv.go
+++ b/fvm/evm/backends/wrappedEnv.go
@@ -16,7 +16,8 @@ import (
 	"github.com/onflow/flow-go/module/trace"
 )
 
-// WrappedEnvironment wraps an FVM environment
+// WrappedEnvironment wraps a FVM environment,
+// handles external errors and provides backend to the EVM.
 type WrappedEnvironment struct {
 	env environment.Environment
 }
@@ -28,95 +29,121 @@ func NewWrappedEnvironment(env environment.Environment) types.Backend {
 
 var _ types.Backend = &WrappedEnvironment{}
 
+// GetValue gets a value from the storage for the given owner and key pair,
+// if value not found empty slice and no error is returned.
 func (we *WrappedEnvironment) GetValue(owner, key []byte) ([]byte, error) {
 	val, err := we.env.GetValue(owner, key)
 	return val, handleEnvironmentError(err)
 }
 
+// SetValue sets a value into the storage for the given owner and key pair.
 func (we *WrappedEnvironment) SetValue(owner, key, value []byte) error {
 	err := we.env.SetValue(owner, key, value)
 	return handleEnvironmentError(err)
 }
 
+// ValueExists checks if a value exist for the given owner and key pair.
 func (we *WrappedEnvironment) ValueExists(owner, key []byte) (bool, error) {
 	b, err := we.env.ValueExists(owner, key)
 	return b, handleEnvironmentError(err)
 }
 
+// AllocateSlabIndex allocates a slab index under the given account.
 func (we *WrappedEnvironment) AllocateSlabIndex(owner []byte) (atree.SlabIndex, error) {
 	index, err := we.env.AllocateSlabIndex(owner)
 	return index, handleEnvironmentError(err)
 }
 
+// MeterComputation updates the total computation used based on the kind and intensity of the operation.
 func (we *WrappedEnvironment) MeterComputation(kind common.ComputationKind, intensity uint) error {
 	err := we.env.MeterComputation(kind, intensity)
 	return handleEnvironmentError(err)
 }
 
+// ComputationUsed returns the computation used so far
 func (we *WrappedEnvironment) ComputationUsed() (uint64, error) {
 	val, err := we.env.ComputationUsed()
 	return val, handleEnvironmentError(err)
 }
 
+// ComputationIntensities returns a the list of computation intensities
 func (we *WrappedEnvironment) ComputationIntensities() meter.MeteredComputationIntensities {
 	return we.env.ComputationIntensities()
 }
 
-func (we *WrappedEnvironment) ComputationAvailable(kind common.ComputationKind, intensity uint) bool {
+// ComputationAvailable returns true if there is computation room
+// for the given kind and intensity operation.
+func (we *WrappedEnvironment) ComputationAvailable(
+	kind common.ComputationKind,
+	intensity uint,
+) bool {
 	return we.env.ComputationAvailable(kind, intensity)
 }
 
+// MeterMemory meters the memory usage of a new operation.
 func (we *WrappedEnvironment) MeterMemory(usage common.MemoryUsage) error {
 	err := we.env.MeterMemory(usage)
 	return handleEnvironmentError(err)
 }
 
+// MemoryUsed returns the total memory used so far.
 func (we *WrappedEnvironment) MemoryUsed() (uint64, error) {
 	val, err := we.env.MemoryUsed()
 	return val, handleEnvironmentError(err)
 }
 
+// MeterEmittedEvent meters a newly emitted event.
 func (we *WrappedEnvironment) MeterEmittedEvent(byteSize uint64) error {
 	err := we.env.MeterEmittedEvent(byteSize)
 	return handleEnvironmentError(err)
 }
 
+// TotalEmittedEventBytes returns the total byte size of events emitted so far.
 func (we *WrappedEnvironment) TotalEmittedEventBytes() uint64 {
 	return we.env.TotalEmittedEventBytes()
 }
 
+// InteractionUsed returns the total storage interaction used.
 func (we *WrappedEnvironment) InteractionUsed() (uint64, error) {
 	val, err := we.env.InteractionUsed()
 	return val, handleEnvironmentError(err)
 }
 
+// EmitEvent emits an event.
 func (we *WrappedEnvironment) EmitEvent(event cadence.Event) error {
 	err := we.env.EmitEvent(event)
 	return handleEnvironmentError(err)
 }
 
+// Events returns the list of emitted events.
 func (we *WrappedEnvironment) Events() flow.EventsList {
 	return we.env.Events()
 
 }
 
+// ServiceEvents returns the list of emitted service events
 func (we *WrappedEnvironment) ServiceEvents() flow.EventsList {
 	return we.env.ServiceEvents()
 }
 
+// ConvertedServiceEvents returns the converted list of emitted service events.
 func (we *WrappedEnvironment) ConvertedServiceEvents() flow.ServiceEventList {
 	return we.env.ConvertedServiceEvents()
 }
 
+// Reset resets and discards all the changes to the
+// all stateful environment modules (events, storage, ...)
 func (we *WrappedEnvironment) Reset() {
 	we.env.Reset()
 }
 
+// GetCurrentBlockHeight returns the current Flow block height
 func (we *WrappedEnvironment) GetCurrentBlockHeight() (uint64, error) {
 	val, err := we.env.GetCurrentBlockHeight()
 	return val, handleEnvironmentError(err)
 }
 
+// GetBlockAtHeight returns the block at the given height
 func (we *WrappedEnvironment) GetBlockAtHeight(height uint64) (
 	runtime.Block,
 	bool,
@@ -126,11 +153,13 @@ func (we *WrappedEnvironment) GetBlockAtHeight(height uint64) (
 	return val, found, handleEnvironmentError(err)
 }
 
+// ReadRandom sets a random number into the buffer
 func (we *WrappedEnvironment) ReadRandom(buffer []byte) error {
 	err := we.env.ReadRandom(buffer)
 	return handleEnvironmentError(err)
 }
 
+// Invoke invokes call inside the fvm env.
 func (we *WrappedEnvironment) Invoke(
 	spec environment.ContractFunctionSpec,
 	arguments []cadence.Value,
@@ -142,11 +171,13 @@ func (we *WrappedEnvironment) Invoke(
 	return val, handleEnvironmentError(err)
 }
 
+// GenerateUUID generates a uuid
 func (we *WrappedEnvironment) GenerateUUID() (uint64, error) {
 	uuid, err := we.env.GenerateUUID()
 	return uuid, handleEnvironmentError(err)
 }
 
+// StartChildSpan starts a new child open tracing span.
 func (we *WrappedEnvironment) StartChildSpan(
 	name trace.SpanName,
 	options ...otelTrace.SpanStartOption,

--- a/fvm/evm/emulator/config.go
+++ b/fvm/evm/emulator/config.go
@@ -1,7 +1,6 @@
 package emulator
 
 import (
-	"math"
 	"math/big"
 
 	gethCommon "github.com/onflow/go-ethereum/common"
@@ -14,13 +13,12 @@ import (
 )
 
 var (
-	DefaultBlockLevelGasLimit = uint64(math.MaxUint64)
-	DefaultBaseFee            = big.NewInt(0)
-	zero                      = uint64(0)
-	bigZero                   = big.NewInt(0)
+	zero    = uint64(0)
+	bigZero = big.NewInt(0)
 )
 
-// Config sets the required parameters
+// Config aggregates all the configuration (chain, evm, block, tx, ...)
+// needed during executing a transaction.
 type Config struct {
 	// Chain Config
 	ChainConfig *gethParams.ChainConfig
@@ -34,8 +32,15 @@ type Config struct {
 	DirectCallBaseGasUsage uint64
 	// captures extra precompiled calls
 	PCTracker *CallTracker
+	// BlockTxCount captures the total number of
+	// transactions included in this block so far
+	BlockTxCountSoFar uint
+	// BlockTotalGasSoFar captures the total
+	// amount of gas used so far
+	BlockTotalGasUsedSoFar uint64
 }
 
+// ChainRules returns the chain rules
 func (c *Config) ChainRules() gethParams.Rules {
 	return c.ChainConfig.Rules(
 		c.BlockContext.BlockNumber,
@@ -43,9 +48,9 @@ func (c *Config) ChainRules() gethParams.Rules {
 		c.BlockContext.Time)
 }
 
-// DefaultChainConfig is the default chain config which
-// considers majority of EVM upgrades (e.g. Shanghai update) already been applied
-// this has done through setting the height of these changes
+// DefaultChainConfig is the default chain config used by the emulator
+// considers majority of EVM upgrades (e.g. Cancun update) are already applied
+// This has been done through setting the height of these changes
 // to zero nad setting the time for some other changes to zero
 // For the future changes of EVM, we need to update the EVM go mod version
 // and set a proper height for the specific release based on the Flow EVM heights
@@ -83,7 +88,7 @@ func defaultConfig() *Config {
 	return &Config{
 		ChainConfig: DefaultChainConfig,
 		EVMConfig: gethVM.Config{
-			// setting this flag let us we force the base fee to zero (coinbase will collect)
+			// Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
 			NoBaseFee: true,
 		},
 		TxContext: &gethVM.TxContext{
@@ -93,8 +98,8 @@ func defaultConfig() *Config {
 		BlockContext: &gethVM.BlockContext{
 			CanTransfer: gethCore.CanTransfer,
 			Transfer:    gethCore.Transfer,
-			GasLimit:    DefaultBlockLevelGasLimit,
-			BaseFee:     DefaultBaseFee,
+			GasLimit:    types.DefaultBlockLevelGasLimit,
+			BaseFee:     types.DefaultBaseFee,
 			GetHash: func(n uint64) gethCommon.Hash {
 				return gethCommon.Hash{}
 			},
@@ -221,6 +226,24 @@ func WithTransactionTracer(tracer *tracers.Tracer) Option {
 		if tracer != nil {
 			c.EVMConfig.Tracer = tracer.Hooks
 		}
+		return c
+	}
+}
+
+// WithBlockTxCountSoFar sets the total number of transactions
+// included in the current block so far
+func WithBlockTxCountSoFar(txCount uint) Option {
+	return func(c *Config) *Config {
+		c.BlockTxCountSoFar = txCount
+		return c
+	}
+}
+
+// WithBlockTotalGasSoFar sets the total amount of gas used
+// for this block so far
+func WithBlockTotalGasUsedSoFar(gasUsed uint64) Option {
+	return func(c *Config) *Config {
+		c.BlockTotalGasUsedSoFar = gasUsed
 		return c
 	}
 }

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/holiman/uint256"
 	"github.com/onflow/atree"
-	"github.com/onflow/go-ethereum/common"
 	gethCommon "github.com/onflow/go-ethereum/common"
 	gethCore "github.com/onflow/go-ethereum/core"
-	"github.com/onflow/go-ethereum/core/tracing"
+	gethTracing "github.com/onflow/go-ethereum/core/tracing"
 	gethTypes "github.com/onflow/go-ethereum/core/types"
 	gethVM "github.com/onflow/go-ethereum/core/vm"
 	gethCrypto "github.com/onflow/go-ethereum/crypto"
@@ -20,7 +19,8 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// Emulator handles operations against evm runtime
+// Emulator wraps an EVM runtime where evm transactions
+// and direct calls are accepted.
 type Emulator struct {
 	rootAddr flow.Address
 	ledger   atree.Ledger
@@ -50,10 +50,12 @@ func newConfig(ctx types.BlockContext) *Config {
 		WithGetBlockHashFunction(ctx.GetHashFunc),
 		WithRandom(&ctx.Random),
 		WithTransactionTracer(ctx.Tracer),
+		WithBlockTotalGasUsedSoFar(ctx.TotalGasUsedSoFar),
+		WithBlockTxCountSoFar(ctx.TxCountSoFar),
 	)
 }
 
-// NewReadOnlyBlockView constructs a new readonly block view
+// NewReadOnlyBlockView constructs a new read-only block view
 func (em *Emulator) NewReadOnlyBlockView(ctx types.BlockContext) (types.ReadOnlyBlockView, error) {
 	execState, err := state.NewStateDB(em.ledger, em.rootAddr)
 	return &ReadOnlyBlockView{
@@ -63,16 +65,15 @@ func (em *Emulator) NewReadOnlyBlockView(ctx types.BlockContext) (types.ReadOnly
 
 // NewBlockView constructs a new block view (mutable)
 func (em *Emulator) NewBlockView(ctx types.BlockContext) (types.BlockView, error) {
-	cfg := newConfig(ctx)
 	return &BlockView{
-		config:   cfg,
+		config:   newConfig(ctx),
 		rootAddr: em.rootAddr,
 		ledger:   em.ledger,
 	}, nil
 }
 
 // ReadOnlyBlockView provides a read only view of a block
-// could be used multiple times for queries
+// could be used for multiple queries against a block
 type ReadOnlyBlockView struct {
 	state types.StateDB
 }
@@ -80,25 +81,26 @@ type ReadOnlyBlockView struct {
 // BalanceOf returns the balance of the given address
 func (bv *ReadOnlyBlockView) BalanceOf(address types.Address) (*big.Int, error) {
 	bal := bv.state.GetBalance(address.ToCommon())
-	return bal.ToBig(), nil
+	return bal.ToBig(), bv.state.Error()
 }
 
 // NonceOf returns the nonce of the given address
 func (bv *ReadOnlyBlockView) NonceOf(address types.Address) (uint64, error) {
-	return bv.state.GetNonce(address.ToCommon()), nil
+	return bv.state.GetNonce(address.ToCommon()), bv.state.Error()
 }
 
 // CodeOf returns the code of the given address
 func (bv *ReadOnlyBlockView) CodeOf(address types.Address) (types.Code, error) {
-	return bv.state.GetCode(address.ToCommon()), nil
+	return bv.state.GetCode(address.ToCommon()), bv.state.Error()
 }
 
 // CodeHashOf returns the code hash of the given address
 func (bv *ReadOnlyBlockView) CodeHashOf(address types.Address) ([]byte, error) {
-	return bv.state.GetCodeHash(address.ToCommon()).Bytes(), nil
+	return bv.state.GetCodeHash(address.ToCommon()).Bytes(), bv.state.Error()
 }
 
 // BlockView allows mutation of the evm state as part of a block
+// current version only accepts only a single interaction per block view.
 type BlockView struct {
 	config   *Config
 	rootAddr flow.Address
@@ -106,41 +108,53 @@ type BlockView struct {
 }
 
 // DirectCall executes a direct call
-func (bl *BlockView) DirectCall(call *types.DirectCall) (*types.Result, error) {
-	// negative amounts are not acceptable.
-	if call.Value.Sign() < 0 {
-		return nil, types.ErrInvalidBalance
-	}
-
+func (bl *BlockView) DirectCall(call *types.DirectCall) (res *types.Result, err error) {
+	// construct a new procedure
 	proc, err := bl.newProcedure()
 	if err != nil {
 		return nil, err
 	}
-	txHash := call.Hash()
+
+	// Set the nonce for the call (needed for some operations like deployment)
+	call.Nonce = proc.state.GetNonce(call.From.ToCommon())
+
+	// Call tx tracer
+	if proc.evm.Config.Tracer != nil && proc.evm.Config.Tracer.OnTxStart != nil {
+		proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), call.Transaction(), call.From.ToCommon())
+		if proc.evm.Config.Tracer.OnTxEnd != nil {
+			defer func() {
+				proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), err)
+			}()
+		}
+	}
+
+	// re-route based on the sub type
 	switch call.SubType {
 	case types.DepositCallSubType:
-		return proc.mintTo(call, txHash)
+		return proc.mintTo(call)
 	case types.WithdrawCallSubType:
-		return proc.withdrawFrom(call, txHash)
+		return proc.withdrawFrom(call)
 	case types.DeployCallSubType:
 		if !call.EmptyToField() {
-			return proc.deployAt(call.From, call.To, call.Data, call.GasLimit, call.Value, txHash)
+			return proc.deployAt(call)
 		}
 		fallthrough
 	default:
-		return proc.runDirect(call.Message(), txHash, 0)
+		return proc.runDirect(call)
 	}
 }
 
 // RunTransaction runs an evm transaction
 func (bl *BlockView) RunTransaction(
 	tx *gethTypes.Transaction,
-) (*types.Result, error) {
+) (result *types.Result, err error) {
+	// create a new procedure
 	proc, err := bl.newProcedure()
 	if err != nil {
 		return nil, err
 	}
 
+	// constructs a core.message from the tx
 	msg, err := gethCore.TransactionToMessage(
 		tx,
 		GetSigner(bl.config),
@@ -151,17 +165,22 @@ func (bl *BlockView) RunTransaction(
 		return types.NewInvalidResult(tx, err), nil
 	}
 
-	// negative amounts are not acceptable.
-	if msg.Value.Sign() < 0 {
-		return nil, types.ErrInvalidBalance
+	// call tracer
+	if proc.evm.Config.Tracer != nil && proc.evm.Config.Tracer.OnTxStart != nil {
+		proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), tx, msg.From)
+		if proc.evm.Config.Tracer.OnTxEnd != nil {
+			defer func() {
+				proc.evm.Config.Tracer.OnTxEnd(result.Receipt(), err)
+			}()
+		}
 	}
 
-	// update tx context origin
-	proc.evm.TxContext.Origin = msg.From
-	res, err := proc.run(msg, tx.Hash(), 0, tx.Type())
+	// run msg
+	res, err := proc.run(msg, tx.Hash(), tx.Type())
 	if err != nil {
 		return nil, err
 	}
+
 	// all commit errors (StateDB errors) has to be returned
 	if err := proc.commit(true); err != nil {
 		return nil, err
@@ -170,6 +189,7 @@ func (bl *BlockView) RunTransaction(
 	return res, nil
 }
 
+// BatchRunTransactions runs a batch of EVM transactions
 func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*types.Result, error) {
 	batchResults := make([]*types.Result, len(txs))
 
@@ -188,14 +208,21 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 			continue
 		}
 
-		// negative amounts are not acceptable.
-		if msg.Value.Sign() < 0 {
-			return nil, types.ErrInvalidBalance
+		// call tracer
+		if proc.evm.Config.Tracer != nil && proc.evm.Config.Tracer.OnTxStart != nil {
+			proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), tx, msg.From)
+			if proc.evm.Config.Tracer.OnTxEnd != nil {
+				defer func() {
+					proc.evm.Config.Tracer.OnTxEnd(
+						batchResults[i].Receipt(),
+						err,
+					)
+				}()
+			}
 		}
 
-		// update tx context origin
-		proc.evm.TxContext.Origin = msg.From
-		res, err := proc.run(msg, tx.Hash(), uint(i), tx.Type())
+		// run msg
+		res, err := proc.run(msg, tx.Hash(), tx.Type())
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +233,7 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 
 		// this clears state for any subsequent transaction runs
 		proc.state.Reset()
-
+		// collect result
 		batchResults[i] = res
 	}
 
@@ -218,39 +245,34 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 	return batchResults, nil
 }
 
-// DryRunTransaction run unsigned transaction without persisting the state
+// DryRunTransaction runs an unsigned transaction without persisting the state
 func (bl *BlockView) DryRunTransaction(
 	tx *gethTypes.Transaction,
 	from gethCommon.Address,
 ) (*types.Result, error) {
+	var txResult *types.Result
 	proc, err := bl.newProcedure()
 	if err != nil {
 		return nil, err
 	}
-
 	msg, err := gethCore.TransactionToMessage(
 		tx,
 		GetSigner(bl.config),
 		proc.config.BlockContext.BaseFee,
 	)
-	// negative amounts are not acceptable.
-	if msg.Value.Sign() < 0 {
-		return nil, types.ErrInvalidBalance
-	}
 
-	// we can ignore invalid signature errors since we don't expect signed transctions
+	// we can ignore invalid signature errors since we don't expect signed transactions
 	if !errors.Is(err, gethTypes.ErrInvalidSig) {
 		return nil, err
 	}
 
 	// use the from as the signer
-	proc.evm.TxContext.Origin = from
 	msg.From = from
 	// we need to skip nonce check for dry run
 	msg.SkipAccountChecks = true
 
-	// return without commiting the state
-	txResult, err := proc.run(msg, tx.Hash(), 0, tx.Type())
+	// return without committing the state
+	txResult, err = proc.run(msg, tx.Hash(), tx.Type())
 	if txResult.Successful() {
 		// As mentioned in https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md#specification
 		// Define "all but one 64th" of N as N - floor(N / 64).
@@ -305,7 +327,7 @@ func (proc *procedure) commit(finalize bool) error {
 	err := proc.state.Commit(finalize)
 	if err != nil {
 		// if known types (state errors) don't do anything and return
-		if types.IsAFatalError(err) || types.IsAStateError(err) {
+		if types.IsAFatalError(err) || types.IsAStateError(err) || types.IsABackendError(err) {
 			return err
 		}
 
@@ -317,32 +339,30 @@ func (proc *procedure) commit(finalize bool) error {
 
 func (proc *procedure) mintTo(
 	call *types.DirectCall,
-	txHash gethCommon.Hash,
 ) (*types.Result, error) {
-	// negative amounts are not acceptable.
-	if call.Value.Sign() < 0 {
-		return nil, types.ErrInvalidBalance
+	// convert and check value
+	isValid, value := convertAndCheckValue(call.Value)
+	if !isValid {
+		return types.NewInvalidResult(
+			call.Transaction(),
+			types.ErrInvalidBalance), nil
 	}
-
-	value, overflow := uint256.FromBig(call.Value)
-	if overflow {
-		return nil, types.ErrInvalidBalance
-	}
-
-	bridge := call.From.ToCommon()
 
 	// create bridge account if not exist
+	bridge := call.From.ToCommon()
 	if !proc.state.Exist(bridge) {
 		proc.state.CreateAccount(bridge)
 	}
 
 	// add balance to the bridge account before transfer
-	proc.state.AddBalance(bridge, value, tracing.BalanceIncreaseWithdrawal)
+	proc.state.AddBalance(bridge, value, gethTracing.BalanceIncreaseWithdrawal)
+	// check state errors
+	if err := proc.state.Error(); err != nil {
+		return nil, err
+	}
 
-	msg := call.Message()
-	proc.evm.TxContext.Origin = msg.From
 	// withdraw the amount and move it to the bridge account
-	res, err := proc.run(msg, txHash, 0, types.DirectCallTxType)
+	res, err := proc.run(call.Message(), call.Hash(), types.DirectCallTxType)
 	if err != nil {
 		return res, err
 	}
@@ -350,99 +370,111 @@ func (proc *procedure) mintTo(
 	// if any error (invalid or vm) on the internal call, revert and don't commit any change
 	// this prevents having cases that we add balance to the bridge but the transfer
 	// fails due to gas, etc.
-	// TODO: in the future we might just return without error and handle everything on higher level
 	if res.Invalid() || res.Failed() {
-		return res, types.ErrInternalDirectCallFailed
+		// reset the state to revert the add balances
+		proc.state.Reset()
+		return res, nil
 	}
 
-	// all commmit errors (StateDB errors) has to be returned
+	// commit and finalize the state and return any stateDB error
 	return res, proc.commit(true)
 }
 
 func (proc *procedure) withdrawFrom(
 	call *types.DirectCall,
-	txHash gethCommon.Hash,
 ) (*types.Result, error) {
-	// negative amounts are not acceptable.
-	if call.Value.Sign() < 0 {
-		return nil, types.ErrInvalidBalance
+	// convert and check value
+	isValid, value := convertAndCheckValue(call.Value)
+	if !isValid {
+		return types.NewInvalidResult(
+			call.Transaction(),
+			types.ErrInvalidBalance), nil
 	}
-
-	value, overflow := uint256.FromBig(call.Value)
-	if overflow {
-		return nil, types.ErrInvalidBalance
-	}
-
-	bridge := call.To.ToCommon()
 
 	// create bridge account if not exist
+	bridge := call.To.ToCommon()
 	if !proc.state.Exist(bridge) {
 		proc.state.CreateAccount(bridge)
 	}
 
 	// withdraw the amount and move it to the bridge account
-	msg := call.Message()
-	proc.evm.TxContext.Origin = msg.From
-	res, err := proc.run(msg, txHash, 0, types.DirectCallTxType)
+	res, err := proc.run(call.Message(), call.Hash(), types.DirectCallTxType)
 	if err != nil {
 		return res, err
 	}
 
 	// if any error (invalid or vm) on the internal call, revert and don't commit any change
-	// TODO: in the future we might just return without error and handle everything on higher level
+	// this prevents having cases that we deduct the balance from the account
+	// but doesn't return it as a vault.
 	if res.Invalid() || res.Failed() {
-		return res, types.ErrInternalDirectCallFailed
+		// reset the state to revert the add balances
+		proc.state.Reset()
+		return res, nil
 	}
 
 	// now deduct the balance from the bridge
-	proc.state.SubBalance(bridge, value, tracing.BalanceIncreaseWithdrawal)
-	// all commmit errors (StateDB errors) has to be returned
+	proc.state.SubBalance(bridge, value, gethTracing.BalanceIncreaseWithdrawal)
+
+	// commit and finalize the state and return any stateDB error
 	return res, proc.commit(true)
 }
 
 // deployAt deploys a contract at the given target address
-// behaviour should be similar to what evm.create internal method does with
-// a few differences, don't need to check for previous forks given this
+// behavior should be similar to what evm.create internal method does with
+// a few differences, we don't need to check for previous forks given this
 // functionality was not available to anyone, we don't need to
 // follow snapshoting, given we do commit/revert style in this code base.
 // in the future we might optimize this method accepting deploy-ready byte codes
 // and skip interpreter call, gas calculations and many checks.
 func (proc *procedure) deployAt(
-	caller types.Address,
-	to types.Address,
-	data types.Code,
-	gasLimit uint64,
-	value *big.Int,
-	txHash gethCommon.Hash,
+	call *types.DirectCall,
 ) (*types.Result, error) {
-	if value.Sign() < 0 {
-		return nil, types.ErrInvalidBalance
+	// convert and check value
+	isValid, castedValue := convertAndCheckValue(call.Value)
+	if !isValid {
+		return types.NewInvalidResult(
+			call.Transaction(),
+			types.ErrInvalidBalance), nil
 	}
 
-	castedValue, overflow := uint256.FromBig(value)
-	if overflow {
-		return nil, types.ErrInvalidBalance
-	}
-
+	txHash := call.Hash()
 	res := &types.Result{
 		TxType: types.DirectCallTxType,
 		TxHash: txHash,
 	}
 
 	if proc.evm.Config.Tracer != nil {
-		proc.captureTraceBegin(0, gethVM.CREATE2, caller.ToCommon(), to.ToCommon(), data, gasLimit, value)
-		defer proc.captureTraceEnd(0, gasLimit, res.ReturnedData, res.Receipt(0), res.VMError)
+		tracer := proc.evm.Config.Tracer
+		if tracer.OnEnter != nil {
+			tracer.OnEnter(0, byte(gethVM.CREATE2), call.From.ToCommon(), call.To.ToCommon(), call.Data, call.GasLimit, call.Value)
+		}
+		if tracer.OnGasChange != nil {
+			tracer.OnGasChange(0, call.GasLimit, gethTracing.GasChangeCallInitialBalance)
+		}
+
+		defer func() {
+			if call.GasLimit != 0 && tracer.OnGasChange != nil {
+				tracer.OnGasChange(call.GasLimit, 0, gethTracing.GasChangeCallLeftOverReturned)
+			}
+			if tracer.OnExit != nil {
+				var reverted bool
+				if res.VMError != nil && !errors.Is(res.VMError, gethVM.ErrCodeStoreOutOfGas) {
+					reverted = true
+				}
+				tracer.OnExit(0, res.ReturnedData, call.GasLimit-res.GasConsumed, gethVM.VMErrorFromErr(res.VMError), reverted)
+			}
+		}()
 	}
 
-	addr := to.ToCommon()
-	// precheck 1 - check balance of the source
-	if value.Sign() != 0 &&
-		!proc.evm.Context.CanTransfer(proc.state, caller.ToCommon(), castedValue) {
+	addr := call.To.ToCommon()
+	// pre check 1 - check balance of the source
+	if call.Value.Sign() != 0 &&
+		!proc.evm.Context.CanTransfer(proc.state, call.From.ToCommon(), castedValue) {
 		res.SetValidationError(gethCore.ErrInsufficientFundsForTransfer)
 		return res, nil
 	}
 
-	// precheck 2 - ensure there's no existing eoa or contract is deployed at the address
+	// pre check 2 - ensure there's no existing eoa or contract is deployed at the address
 	contractHash := proc.state.GetCodeHash(addr)
 	if proc.state.GetNonce(addr) != 0 ||
 		(contractHash != (gethCommon.Hash{}) && contractHash != gethTypes.EmptyCodeHash) {
@@ -450,7 +482,7 @@ func (proc *procedure) deployAt(
 		return res, nil
 	}
 
-	callerCommon := caller.ToCommon()
+	callerCommon := call.From.ToCommon()
 	// setup caller if doesn't exist
 	if !proc.state.Exist(callerCommon) {
 		proc.state.CreateAccount(callerCommon)
@@ -461,12 +493,12 @@ func (proc *procedure) deployAt(
 	// setup account
 	proc.state.CreateAccount(addr)
 	proc.state.SetNonce(addr, 1) // (EIP-158)
-	if value.Sign() > 0 {
+	if call.Value.Sign() > 0 {
 		proc.evm.Context.Transfer( // transfer value
 			proc.state,
-			caller.ToCommon(),
+			callerCommon,
 			addr,
-			uint256.MustFromBig(value),
+			uint256.MustFromBig(call.Value),
 		)
 	}
 
@@ -475,12 +507,12 @@ func (proc *procedure) deployAt(
 	var err error
 	inter := gethVM.NewEVMInterpreter(proc.evm)
 	contract := gethVM.NewContract(
-		gethVM.AccountRef(caller.ToCommon()),
+		gethVM.AccountRef(callerCommon),
 		gethVM.AccountRef(addr),
 		castedValue,
-		gasLimit)
+		call.GasLimit)
 
-	contract.SetCallCode(&addr, gethCrypto.Keccak256Hash(data), data)
+	contract.SetCallCode(&addr, gethCrypto.Keccak256Hash(call.Data), call.Data)
 	// update access list (Berlin)
 	proc.state.AddAddressToAccessList(addr)
 
@@ -492,16 +524,16 @@ func (proc *procedure) deployAt(
 	if err != nil {
 		// for all errors except this one consume all the remaining gas (Homestead)
 		if err != gethVM.ErrExecutionReverted {
-			res.GasConsumed = gasLimit
+			res.GasConsumed = call.GasLimit
 		}
 		res.VMError = err
 		return res, nil
 	}
 
 	// update gas usage
-	if gasCost > gasLimit {
+	if gasCost > call.GasLimit {
 		// consume all the remaining gas (Homestead)
-		res.GasConsumed = gasLimit
+		res.GasConsumed = call.GasLimit
 		res.VMError = gethVM.ErrCodeStoreOutOfGas
 		return res, nil
 	}
@@ -509,7 +541,7 @@ func (proc *procedure) deployAt(
 	// check max code size (EIP-158)
 	if len(ret) > gethParams.MaxCodeSize {
 		// consume all the remaining gas (Homestead)
-		res.GasConsumed = gasLimit
+		res.GasConsumed = call.GasLimit
 		res.VMError = gethVM.ErrMaxCodeSizeExceeded
 		return res, nil
 	}
@@ -517,30 +549,31 @@ func (proc *procedure) deployAt(
 	// reject code starting with 0xEF (EIP-3541)
 	if len(ret) >= 1 && ret[0] == 0xEF {
 		// consume all the remaining gas (Homestead)
-		res.GasConsumed = gasLimit
+		res.GasConsumed = call.GasLimit
 		res.VMError = gethVM.ErrInvalidCode
 		return res, nil
 	}
 
-	res.DeployedContractAddress = &to
+	res.DeployedContractAddress = &call.To
+	res.CumulativeGasUsed = proc.config.BlockTotalGasUsedSoFar + res.GasConsumed
 
 	proc.state.SetCode(addr, ret)
 	return res, proc.commit(true)
 }
 
 func (proc *procedure) runDirect(
-	msg *gethCore.Message,
-	txHash gethCommon.Hash,
-	txIndex uint,
+	call *types.DirectCall,
 ) (*types.Result, error) {
-	// set the nonce for the message (needed for some operations like deployment)
-	msg.Nonce = proc.state.GetNonce(msg.From)
-	proc.evm.TxContext.Origin = msg.From
-	res, err := proc.run(msg, txHash, txIndex, types.DirectCallTxType)
+	// run the msg
+	res, err := proc.run(
+		call.Message(),
+		call.Hash(),
+		types.DirectCallTxType,
+	)
 	if err != nil {
 		return nil, err
 	}
-	// all commit errors (StateDB errors) has to be returned
+	// commit and finalize the state and return any stateDB error
 	return res, proc.commit(true)
 }
 
@@ -552,7 +585,6 @@ func (proc *procedure) runDirect(
 func (proc *procedure) run(
 	msg *gethCore.Message,
 	txHash gethCommon.Hash,
-	txIndex uint,
 	txType uint8,
 ) (*types.Result, error) {
 	var err error
@@ -561,9 +593,26 @@ func (proc *procedure) run(
 		TxHash: txHash,
 	}
 
+	// Negative values are not acceptable
+	// although we check this condition on direct calls
+	// its worth an extra check here given some calls are
+	// coming from batch run, etc.
+	if msg.Value.Sign() < 0 {
+		res.SetValidationError(types.ErrInvalidBalance)
+		return &res, nil
+	}
+
+	// set the origin on the TxContext
+	proc.evm.TxContext.Origin = msg.From
+
 	// reset precompile tracking in case
 	proc.config.PCTracker.Reset()
+
+	// Set gas pool based on block gas limit
+	// if the block gas limit is set to anything than max
+	// we need to update this code.
 	gasPool := (*gethCore.GasPool)(&proc.config.BlockContext.GasLimit)
+	// transit the state
 	execResult, err := gethCore.NewStateTransition(
 		proc.evm,
 		msg,
@@ -581,26 +630,34 @@ func (proc *procedure) run(
 		return &res, nil
 	}
 
-	// if prechecks are passed, the exec result won't be nil
+	txIndex := proc.config.BlockTxCountSoFar
+	// if pre-checks are passed, the exec result won't be nil
 	if execResult != nil {
 		res.GasConsumed = execResult.UsedGas
 		res.GasRefund = proc.state.GetRefund()
 		res.Index = uint16(txIndex)
+		res.CumulativeGasUsed = execResult.UsedGas + proc.config.BlockTotalGasUsedSoFar
 		res.PrecompiledCalls, err = proc.config.PCTracker.CapturedCalls()
 		if err != nil {
 			return nil, err
 		}
+
 		// we need to capture the returned value no matter the status
 		// if the tx is reverted the error message is returned as returned value
 		res.ReturnedData = execResult.ReturnData
 
+		// Update proc context
+		proc.config.BlockTotalGasUsedSoFar = res.CumulativeGasUsed
+		proc.config.BlockTxCountSoFar += 1
+
 		if !execResult.Failed() { // collect vm errors
-			// If the transaction created a contract, store the creation address in the receipt,
+			// If the transaction has created a contract,
+			// store the creation address in the receipt
 			if msg.To == nil {
 				deployedAddress := types.NewAddress(gethCrypto.CreateAddress(msg.From, msg.Nonce))
 				res.DeployedContractAddress = &deployedAddress
 			}
-			// replace tx index and tx hash
+			// collect logs
 			res.Logs = proc.state.Logs(
 				proc.config.BlockContext.BlockNumber.Uint64(),
 				txHash,
@@ -614,54 +671,20 @@ func (proc *procedure) run(
 	return &res, nil
 }
 
-func (proc *procedure) captureTraceBegin(
-	depth int,
-	typ gethVM.OpCode,
-	from common.Address,
-	to common.Address,
-	input []byte,
-	startGas uint64,
-	value *big.Int) {
-	tracer := proc.evm.Config.Tracer
-	if tracer.OnTxStart != nil {
-		tracer.OnTxStart(nil, gethTypes.NewTransaction(0, to, value, startGas, nil, input), from)
-	}
-	if tracer.OnEnter != nil {
-		tracer.OnEnter(depth, byte(typ), from, to, input, startGas, value)
-	}
-	if tracer.OnGasChange != nil {
-		tracer.OnGasChange(0, startGas, tracing.GasChangeCallInitialBalance)
-	}
-}
-
-func (proc *procedure) captureTraceEnd(
-	depth int,
-	startGas uint64,
-	ret []byte,
-	receipt *gethTypes.Receipt,
-	err error,
-) {
-	tracer := proc.evm.Config.Tracer
-	leftOverGas := startGas - receipt.GasUsed
-	if leftOverGas != 0 && tracer.OnGasChange != nil {
-		tracer.OnGasChange(leftOverGas, 0, tracing.GasChangeCallLeftOverReturned)
-	}
-	var reverted bool
-	if err != nil {
-		reverted = true
-	}
-	if errors.Is(err, gethVM.ErrCodeStoreOutOfGas) {
-		reverted = false
-	}
-	if tracer.OnExit != nil {
-		tracer.OnExit(depth, ret, startGas-leftOverGas, gethVM.VMErrorFromErr(err), reverted)
-	}
-	if tracer.OnTxEnd != nil {
-		tracer.OnTxEnd(receipt, err)
-	}
-}
-
 func AddOne64th(n uint64) uint64 {
 	// NOTE: Go's integer division floors, but that is desirable here
 	return n + (n / 64)
+}
+
+func convertAndCheckValue(input *big.Int) (isValid bool, converted *uint256.Int) {
+	// check for negative input
+	if input.Sign() < 0 {
+		return false, nil
+	}
+	// convert value into uint256
+	value, overflow := uint256.FromBig(input)
+	if overflow {
+		return true, nil
+	}
+	return true, value
 }

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -51,17 +51,16 @@ func TestNativeTokenBridging(t *testing.T) {
 			originalBalance := big.NewInt(10000)
 			testAccount := types.NewAddressFromString("test")
 			bridgeAccount := types.NewAddressFromString("bridge")
-			nonce := uint64(0)
+			testAccountNonce := uint64(0)
 
 			t.Run("mint tokens to the first account", func(t *testing.T) {
 				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
 					RunWithNewBlockView(t, env, func(blk types.BlockView) {
-						call := types.NewDepositCall(bridgeAccount, testAccount, originalBalance, nonce)
+						call := types.NewDepositCall(bridgeAccount, testAccount, originalBalance, 0)
 						res, err := blk.DirectCall(call)
 						require.NoError(t, err)
 						require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
 						require.Equal(t, call.Hash(), res.TxHash)
-						nonce += 1
 					})
 				})
 				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
@@ -84,16 +83,19 @@ func TestNativeTokenBridging(t *testing.T) {
 						retBalance, err := blk.BalanceOf(testAccount)
 						require.NoError(t, err)
 						require.Equal(t, originalBalance, retBalance)
+						retNonce, err := blk.NonceOf(testAccount)
+						require.NoError(t, err)
+						require.Equal(t, testAccountNonce, retNonce)
 					})
 				})
 				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
 					RunWithNewBlockView(t, env, func(blk types.BlockView) {
-						call := types.NewWithdrawCall(bridgeAccount, testAccount, amount, nonce)
+						call := types.NewWithdrawCall(bridgeAccount, testAccount, amount, testAccountNonce)
 						res, err := blk.DirectCall(call)
 						require.NoError(t, err)
 						require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
 						require.Equal(t, call.Hash(), res.TxHash)
-						nonce += 1
+						testAccountNonce += 1
 					})
 				})
 				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
@@ -106,9 +108,15 @@ func TestNativeTokenBridging(t *testing.T) {
 						retBalance, err = blk.BalanceOf(bridgeAccount)
 						require.NoError(t, err)
 						require.Equal(t, big.NewInt(0).Uint64(), retBalance.Uint64())
+
+						retNonce, err := blk.NonceOf(testAccount)
+						require.NoError(t, err)
+						require.Equal(t, testAccountNonce, retNonce)
 					})
 				})
 			})
+			// TODO: add test for deploying to an empty contract (error on deposit call)
+			// and a test case for when not enough balance on account for withdraw
 		})
 	})
 }
@@ -122,7 +130,7 @@ func TestContractInteraction(t *testing.T) {
 
 			testAccount := types.NewAddressFromString("test")
 			bridgeAccount := types.NewAddressFromString("bridge")
-			nonce := uint64(0)
+			testAccountNonce := uint64(0)
 
 			amount := big.NewInt(0).Mul(big.NewInt(1337), big.NewInt(gethParams.Ether))
 			amountToBeTransfered := big.NewInt(0).Mul(big.NewInt(100), big.NewInt(gethParams.Ether))
@@ -130,9 +138,8 @@ func TestContractInteraction(t *testing.T) {
 			// fund test account
 			RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
 				RunWithNewBlockView(t, env, func(blk types.BlockView) {
-					_, err := blk.DirectCall(types.NewDepositCall(bridgeAccount, testAccount, amount, nonce))
+					_, err := blk.DirectCall(types.NewDepositCall(bridgeAccount, testAccount, amount, 0))
 					require.NoError(t, err)
-					nonce += 1
 				})
 			})
 
@@ -146,13 +153,13 @@ func TestContractInteraction(t *testing.T) {
 							testContract.ByteCode,
 							math.MaxUint64,
 							amountToBeTransfered,
-							nonce)
+							testAccountNonce)
 						res, err := blk.DirectCall(call)
 						require.NoError(t, err)
 						require.NotNil(t, res.DeployedContractAddress)
 						contractAddr = *res.DeployedContractAddress
 						require.Equal(t, call.Hash(), res.TxHash)
-						nonce += 1
+						testAccountNonce += 1
 					})
 					RunWithNewReadOnlyBlockView(t, env, func(blk types.ReadOnlyBlockView) {
 						require.NotNil(t, contractAddr)
@@ -167,6 +174,10 @@ func TestContractInteraction(t *testing.T) {
 						retBalance, err = blk.BalanceOf(testAccount)
 						require.NoError(t, err)
 						require.Equal(t, amount.Sub(amount, amountToBeTransfered), retBalance)
+
+						retNonce, err := blk.NonceOf(testAccount)
+						require.NoError(t, err)
+						require.Equal(t, testAccountNonce, retNonce)
 					})
 				})
 			})
@@ -182,12 +193,12 @@ func TestContractInteraction(t *testing.T) {
 								testContract.MakeCallData(t, "store", num),
 								1_000_000,
 								big.NewInt(0), // this should be zero because the contract doesn't have receiver
-								nonce,
+								testAccountNonce,
 							),
 						)
 						require.NoError(t, err)
 						require.GreaterOrEqual(t, res.GasConsumed, uint64(40_000))
-						nonce += 1
+						testAccountNonce += 1
 						require.Empty(t, res.PrecompiledCalls)
 					})
 				})
@@ -201,11 +212,11 @@ func TestContractInteraction(t *testing.T) {
 								testContract.MakeCallData(t, "retrieve"),
 								1_000_000,
 								big.NewInt(0), // this should be zero because the contract doesn't have receiver
-								nonce,
+								testAccountNonce,
 							),
 						)
 						require.NoError(t, err)
-						nonce += 1
+						testAccountNonce += 1
 
 						ret := new(big.Int).SetBytes(res.ReturnedData)
 						require.Equal(t, num, ret)
@@ -222,14 +233,15 @@ func TestContractInteraction(t *testing.T) {
 								testContract.MakeCallData(t, "blockNumber"),
 								1_000_000,
 								big.NewInt(0), // this should be zero because the contract doesn't have receiver
-								nonce,
+								testAccountNonce,
 							),
 						)
 						require.NoError(t, err)
-						nonce += 1
+						testAccountNonce += 1
 
 						ret := new(big.Int).SetBytes(res.ReturnedData)
 						require.Equal(t, blockNumber, ret)
+
 					})
 				})
 
@@ -242,11 +254,11 @@ func TestContractInteraction(t *testing.T) {
 								testContract.MakeCallData(t, "assertError"),
 								1_000_000,
 								big.NewInt(0), // this should be zero because the contract doesn't have receiver
-								nonce,
+								testAccountNonce,
 							),
 						)
 						require.NoError(t, err)
-						nonce += 1
+						testAccountNonce += 1
 						require.Error(t, res.VMError)
 						strings.Contains(string(res.ReturnedData), "Assert Error Message")
 					})
@@ -261,11 +273,11 @@ func TestContractInteraction(t *testing.T) {
 								testContract.MakeCallData(t, "customError"),
 								1_000_000,
 								big.NewInt(0), // this should be zero because the contract doesn't have receiver
-								nonce,
+								testAccountNonce,
 							),
 						)
 						require.NoError(t, err)
-						nonce += 1
+						testAccountNonce += 1
 						require.Error(t, res.VMError)
 						strings.Contains(string(res.ReturnedData), "Value is too low")
 					})
@@ -282,11 +294,11 @@ func TestContractInteraction(t *testing.T) {
 							testContract.MakeCallData(t, "chainID"),
 							1_000_000,
 							big.NewInt(0), // this should be zero because the contract doesn't have receiver
-							nonce,
+							testAccountNonce,
 						),
 					)
 					require.NoError(t, err)
-					nonce += 1
+					testAccountNonce += 1
 
 					ret := new(big.Int).SetBytes(res.ReturnedData)
 					require.Equal(t, types.FlowEVMPreviewNetChainID, ret)
@@ -592,7 +604,7 @@ func TestDeployAtFunctionality(t *testing.T) {
 // this function is called and we make sure the balance the contract had
 // is returned to the address provided, and the contract data stays according to the
 // EIP 6780 https://eips.ethereum.org/EIPS/eip-6780 in case where the selfdestruct
-// is not caleld in the same transaction as deployment.
+// is not called in the same transaction as deployment.
 func TestSelfdestruct(t *testing.T) {
 	testutils.RunWithTestBackend(t, func(backend *testutils.TestBackend) {
 		testutils.RunWithTestFlowEVMRootAddress(t, backend, func(rootAddr flow.Address) {
@@ -1043,6 +1055,102 @@ func TestTransactionTracing(t *testing.T) {
 
 	})
 
+}
+
+func TestTxIndex(t *testing.T) {
+	testutils.RunWithTestBackend(t, func(backend *testutils.TestBackend) {
+		testutils.RunWithTestFlowEVMRootAddress(t, backend, func(rootAddr flow.Address) {
+			RunWithNewEmulator(t, backend, rootAddr, func(em *emulator.Emulator) {
+				ctx := types.NewDefaultBlockContext(blockNumber.Uint64())
+				expectedTxIndex := uint16(1)
+				ctx.TxCountSoFar = 1
+				testAccount1 := types.NewAddressFromString("test")
+				testAccount2 := types.NewAddressFromString("test")
+
+				blk, err := em.NewBlockView(ctx)
+				require.NoError(t, err)
+
+				res, err := blk.DirectCall(
+					types.NewContractCall(
+						testAccount1,
+						testAccount2,
+						nil,
+						1_000_000,
+						big.NewInt(0),
+						0,
+					),
+				)
+
+				require.NoError(t, err)
+				require.Equal(t, expectedTxIndex, res.Index)
+				expectedTxIndex += 1
+				ctx.TxCountSoFar = 2
+
+				// create a test eoa account
+				account := testutils.GetTestEOAAccount(t, testutils.EOATestAccount1KeyHex)
+				fAddr := account.Address()
+
+				blk, err = em.NewBlockView(ctx)
+				require.NoError(t, err)
+				res, err = blk.DirectCall(
+					types.NewDepositCall(
+						types.EmptyAddress,
+						fAddr,
+						types.OneFlow,
+						account.Nonce(),
+					))
+				require.NoError(t, err)
+				require.NoError(t, res.VMError)
+				require.NoError(t, res.ValidationError)
+				require.Equal(t, expectedTxIndex, res.Index)
+				expectedTxIndex += 1
+				ctx.TxCountSoFar = 3
+
+				blk, err = em.NewBlockView(ctx)
+				require.NoError(t, err)
+
+				tx := account.PrepareAndSignTx(
+					t,
+					testAccount1.ToCommon(), // to
+					nil,                     // data
+					big.NewInt(1000),        // amount
+					gethParams.TxGas,        // gas limit
+					big.NewInt(0),
+				)
+
+				res, err = blk.RunTransaction(tx)
+				require.NoError(t, err)
+				require.NoError(t, res.VMError)
+				require.NoError(t, res.ValidationError)
+				require.Equal(t, expectedTxIndex, res.Index)
+				expectedTxIndex += 1
+				ctx.TxCountSoFar = 4
+
+				blk, err = em.NewBlockView(ctx)
+				require.NoError(t, err)
+
+				const batchSize = 3
+				txs := make([]*gethTypes.Transaction, batchSize)
+				for i := range txs {
+					txs[i] = account.PrepareAndSignTx(
+						t,
+						testAccount1.ToCommon(), // to
+						nil,                     // data
+						big.NewInt(1000),        // amount
+						gethParams.TxGas,        // gas limit
+						big.NewInt(0),
+					)
+				}
+				results, err := blk.BatchRunTransactions(txs)
+				require.NoError(t, err)
+				for i, res := range results {
+					require.NoError(t, res.VMError)
+					require.NoError(t, res.ValidationError)
+					require.Equal(t, expectedTxIndex+uint16(i), res.Index)
+				}
+			})
+		})
+	})
 }
 
 type MockedPrecompiled struct {

--- a/fvm/evm/handler/blockstore.go
+++ b/fvm/evm/handler/blockstore.go
@@ -37,7 +37,7 @@ func (bs *BlockStore) BlockProposal() (*types.BlockProposal, error) {
 	// first fetch it from the storage
 	data, err := bs.backend.GetValue(bs.rootAddress[:], []byte(BlockStoreLatestBlockProposalKey))
 	if err != nil {
-		return nil, types.NewFatalError(err)
+		return nil, err
 	}
 	if len(data) != 0 {
 		return types.NewBlockProposalFromBytes(data)
@@ -141,11 +141,11 @@ func (bs *BlockStore) CommitBlockProposal(bp *types.BlockProposal) error {
 // LatestBlock returns the latest executed block
 func (bs *BlockStore) LatestBlock() (*types.Block, error) {
 	data, err := bs.backend.GetValue(bs.rootAddress[:], []byte(BlockStoreLatestBlockKey))
-	if len(data) == 0 {
-		return types.GenesisBlock, err
-	}
 	if err != nil {
-		return nil, types.NewFatalError(err)
+		return nil, err
+	}
+	if len(data) == 0 {
+		return types.GenesisBlock, nil
 	}
 	return types.NewBlockFromBytes(data)
 }

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -474,6 +474,8 @@ func (h *ContractHandler) getBlockContext() (types.BlockContext, error) {
 		ExtraPrecompiledContracts: h.precompiledContracts,
 		Random:                    rand,
 		Tracer:                    h.tracer.TxTracer(),
+		TxCountSoFar:              uint(len(bp.TxHashes)),
+		TotalGasUsedSoFar:         bp.TotalGasUsed,
 	}, nil
 }
 
@@ -520,7 +522,7 @@ func (h *ContractHandler) executeAndHandleCall(
 	// append transaction to the block proposal
 	bp.AppendTransaction(res)
 
-	if totalSupplyDiff != nil {
+	if res.Successful() && totalSupplyDiff != nil {
 		if deductSupplyDiff {
 			bp.TotalSupply = new(big.Int).Sub(bp.TotalSupply, totalSupplyDiff)
 			if bp.TotalSupply.Sign() < 0 {
@@ -820,10 +822,10 @@ func (a *Account) call(to types.Address, data types.Data, gaslimit types.GasLimi
 	return a.fch.executeAndHandleCall(ctx, call, nil, false)
 }
 
-func (a *Account) precheck(authroized bool, gaslimit types.GasLimit) (types.BlockContext, error) {
+func (a *Account) precheck(authorized bool, gaslimit types.GasLimit) (types.BlockContext, error) {
 	// check if account is authorized (i.e. is a COA)
-	if authroized && !a.isAuthorized {
-		return types.BlockContext{}, types.ErrUnAuthroizedMethodCall
+	if authorized && !a.isAuthorized {
+		return types.BlockContext{}, types.ErrUnauthorizedMethodCall
 	}
 	err := a.fch.checkGasLimit(gaslimit)
 	if err != nil {

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -314,6 +314,7 @@ func TestHandler_OpsWithoutEmulator(t *testing.T) {
 
 func TestHandler_COA(t *testing.T) {
 	t.Parallel()
+
 	t.Run("test deposit/withdraw (with integrated emulator)", func(t *testing.T) {
 		testutils.RunWithTestBackend(t, func(backend *testutils.TestBackend) {
 			testutils.RunWithTestFlowEVMRootAddress(t, backend, func(rootAddr flow.Address) {
@@ -456,7 +457,7 @@ func TestHandler_COA(t *testing.T) {
 					aa := handler.NewAddressAllocator()
 
 					// Withdraw calls are only possible within FOA accounts
-					assertPanic(t, types.IsAUnAuthroizedMethodCallError, func() {
+					assertPanic(t, types.IsAUnauthorizedMethodCallError, func() {
 						em := &testutils.TestEmulator{
 							NonceOfFunc: func(address types.Address) (uint64, error) {
 								return 0, nil
@@ -1115,7 +1116,7 @@ func TestHandler_TransactionRun(t *testing.T) {
 							tr.OnTxStart(nil, tx, from)
 							tr.OnEnter(0, byte(vm.ADD), from, *tx.To(), tx.Data(), 20, big.NewInt(2))
 							tr.OnExit(0, []byte{0x02}, 200, nil, false)
-							tr.OnTxEnd(result.Receipt(0), nil)
+							tr.OnTxEnd(result.Receipt(), nil)
 
 							traceResult, err = tr.GetResult()
 							require.NoError(t, err)
@@ -1350,8 +1351,10 @@ func TestHandler_Metrics(t *testing.T) {
 	testutils.RunWithTestBackend(t, func(backend *testutils.TestBackend) {
 		testutils.RunWithTestFlowEVMRootAddress(t, backend, func(rootAddr flow.Address) {
 			testutils.RunWithEOATestAccount(t, backend, rootAddr, func(eoa *testutils.EOATestAccount) {
+				gasUsed := testutils.RandomGas(1000)
 				result := &types.Result{
-					GasConsumed:             testutils.RandomGas(1000),
+					GasConsumed:             gasUsed,
+					CumulativeGasUsed:       gasUsed * 4,
 					DeployedContractAddress: &types.EmptyAddress,
 				}
 				em := &testutils.TestEmulator{

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -814,7 +814,8 @@ contract EVM {
             ?? panic("Could not borrow reference to the EVM bridge")
     }
 
-    /// The Heartbeat resource controls the block production
+    /// The Heartbeat resource controls the block production.
+    /// It is stored in the storage and used in the Flow protocol to call the heartbeat function once per block.
     access(all)
     resource Heartbeat {
         /// heartbeat calls commit block proposals and forms new blocks including all the
@@ -826,13 +827,23 @@ contract EVM {
         }
     }
 
-    /// createHeartBeat creates a heartbeat resource
-    access(account)
-    fun createHeartBeat(): @Heartbeat{
-        return <-create Heartbeat()
+    /// setupHeartbeat creates a heartbeat resource and saves it to storage.
+    /// The function is called once during the contract initialization.
+    ///
+    /// The heartbeat resource is used to control the block production,
+    /// and used in the Flow protocol to call the heartbeat function once per block.
+    ///
+    /// The function can be called by anyone, but only once:
+    /// the function will fail if the resource already exists.
+    ///
+    /// The resulting resource is stored in the account storage,
+    /// and is only accessible by the account, not the caller of the function.
+    access(all)
+    fun setupHeartbeat() {
+        self.account.storage.save(<-create Heartbeat(), to: /storage/EVMHeartbeat)
     }
 
     init() {
-        self.account.storage.save(<-create Heartbeat(), to: /storage/EVMHeartbeat)
+        self.setupHeartbeat()
     }
 }

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -27,6 +27,9 @@ import (
 //go:embed contract.cdc
 var contractCode string
 
+//go:embed contract_minimal.cdc
+var ContractMinimalCode string
+
 var nftImportPattern = regexp.MustCompile(`(?m)^import "NonFungibleToken"`)
 var fungibleTokenImportPattern = regexp.MustCompile(`(?m)^import "FungibleToken"`)
 var flowTokenImportPattern = regexp.MustCompile(`(?m)^import "FlowToken"`)

--- a/fvm/evm/stdlib/contract_minimal.cdc
+++ b/fvm/evm/stdlib/contract_minimal.cdc
@@ -1,0 +1,60 @@
+access(all)
+contract EVM {
+
+    /// EVMAddress is an EVM-compatible address
+    access(all)
+    struct EVMAddress {
+
+        /// Bytes of the address
+        access(all)
+        let bytes: [UInt8; 20]
+
+        /// Constructs a new EVM address from the given byte representation
+        init(bytes: [UInt8; 20]) {
+            self.bytes = bytes
+        }
+
+    }
+
+    access(all)
+    fun encodeABI(_ values: [AnyStruct]): [UInt8] {
+        return InternalEVM.encodeABI(values)
+    }
+
+    access(all)
+    fun decodeABI(types: [Type], data: [UInt8]): [AnyStruct] {
+        return InternalEVM.decodeABI(types: types, data: data)
+    }
+
+    access(all)
+    fun encodeABIWithSignature(
+        _ signature: String,
+        _ values: [AnyStruct]
+    ): [UInt8] {
+        let methodID = HashAlgorithm.KECCAK_256.hash(
+            signature.utf8
+        ).slice(from: 0, upTo: 4)
+        let arguments = InternalEVM.encodeABI(values)
+
+        return methodID.concat(arguments)
+    }
+
+    access(all)
+    fun decodeABIWithSignature(
+        _ signature: String,
+        types: [Type],
+        data: [UInt8]
+    ): [AnyStruct] {
+        let methodID = HashAlgorithm.KECCAK_256.hash(
+            signature.utf8
+        ).slice(from: 0, upTo: 4)
+
+        for byte in methodID {
+            if byte != data.removeFirst() {
+                panic("signature mismatch")
+            }
+        }
+
+        return InternalEVM.decodeABI(types: types, data: data)
+    }
+}

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -112,11 +112,12 @@ type BlockProposal struct {
 // AppendTransaction appends a transaction hash to the list of transaction hashes of the block
 // and also update the receipts
 func (b *BlockProposal) AppendTransaction(res *Result) {
-	if res == nil {
+	// we don't append invalid transactions to blocks
+	if res == nil || res.Invalid() {
 		return
 	}
 	b.TxHashes = append(b.TxHashes, res.TxHash)
-	r := res.LightReceipt(b.TotalGasUsed)
+	r := res.LightReceipt()
 	if r == nil {
 		return
 	}

--- a/fvm/evm/types/block_test.go
+++ b/fvm/evm/types/block_test.go
@@ -45,13 +45,14 @@ func Test_BlockProposal(t *testing.T) {
 	require.Equal(t, gethTypes.EmptyRootHash, bp.TransactionHashRoot)
 
 	res := &Result{
-		TxHash:      gethCommon.Hash{2},
-		GasConsumed: 10,
+		TxHash:            gethCommon.Hash{2},
+		GasConsumed:       10,
+		CumulativeGasUsed: 20,
 	}
 	bp.AppendTransaction(res)
 	require.Equal(t, res.TxHash, bp.TxHashes[0])
-	require.Equal(t, res.GasConsumed, bp.TotalGasUsed)
-	require.Equal(t, *res.LightReceipt(0), bp.Receipts[0])
+	require.Equal(t, res.CumulativeGasUsed, bp.TotalGasUsed)
+	require.Equal(t, *res.LightReceipt(), bp.Receipts[0])
 
 	bp.PopulateRoots()
 	require.NotEqual(t, gethTypes.EmptyReceiptsHash, bp.ReceiptRoot)

--- a/fvm/evm/types/call.go
+++ b/fvm/evm/types/call.go
@@ -23,7 +23,7 @@ const (
 	ContractCallSubType = byte(5)
 
 	// Note that these gas values might need to change if we
-	// change the transaction (e.g. add accesslist),
+	// change the transaction (e.g. add access list),
 	// then it has to be updated to use Intrinsic function
 	// to calculate the minimum gas needed to run the transaction.
 	IntrinsicFeeForTokenTransfer = gethParams.TxGas
@@ -40,7 +40,7 @@ const (
 // DirectCall captures all the data related to a direct call to evm
 // direct calls are similar to transactions but they don't have
 // signatures and don't need sequence number checks
-// Note that eventhough we don't check the nonce, it impacts
+// Note that while we don't check the nonce, it impacts
 // hash calculation and also impacts the address of resulting contract
 // when deployed through direct calls.
 // Users don't have the worry about the nonce, handler sets
@@ -93,8 +93,12 @@ func (dc *DirectCall) Message() *gethCore.Message {
 		GasPrice:  big.NewInt(0), // price is set to zero fo direct calls
 		GasTipCap: big.NewInt(0), // also known as maxPriorityFeePerGas (in GWei)
 		GasFeeCap: big.NewInt(0), // also known as maxFeePerGas (in GWei)
-		// AccessList:        tx.AccessList(), // TODO revisit this value, the cost matter but performance might
-		SkipAccountChecks: true, // this would let us not set the nonce
+		// TODO: maybe revisit setting the access list
+		// AccessList:        tx.AccessList(),
+		// When SkipAccountChecks is true, the message nonce is not checked against the
+		// account nonce in state. It also disables checking that the sender is an EOA.
+		// Since we use the direct calls for COAs, we set the nonce and the COA is an smart contract.
+		SkipAccountChecks: true,
 	}
 }
 
@@ -131,6 +135,7 @@ func (dc *DirectCall) to() *gethCommon.Address {
 	return nil
 }
 
+// NewDepositCall constructs a new deposit direct call
 func NewDepositCall(
 	bridge Address,
 	address Address,
@@ -149,6 +154,7 @@ func NewDepositCall(
 	}
 }
 
+// NewDepositCall constructs a new withdraw direct call
 func NewWithdrawCall(
 	bridge Address,
 	address Address,
@@ -185,6 +191,7 @@ func NewTransferCall(
 	}
 }
 
+// NewDeployCall constructs a new deploy direct call
 func NewDeployCall(
 	caller Address,
 	code Code,
@@ -204,7 +211,10 @@ func NewDeployCall(
 	}
 }
 
-// this subtype should only be used internally for
+// NewDeployCallWithTargetAddress constructs a new deployment call
+// for the given target address
+//
+// Warning! This subtype should only be used internally for
 // deploying contracts at given addresses (e.g. COA account init setup)
 // should not be used for other means.
 func NewDeployCallWithTargetAddress(
@@ -227,6 +237,7 @@ func NewDeployCallWithTargetAddress(
 	}
 }
 
+// NewContractCall constructs a new contract call
 func NewContractCall(
 	caller Address,
 	to Address,
@@ -247,10 +258,13 @@ func NewContractCall(
 	}
 }
 
+// GasLimit sets the limit for the total gas used by a transaction
 type GasLimit uint64
 
+// Code holds an smart contract code
 type Code []byte
 
+// Data holds the data passed as part of a call
 type Data []byte
 
 // AsBigInt process the data and return it as a big integer

--- a/fvm/evm/types/emulator.go
+++ b/fvm/evm/types/emulator.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"math"
 	"math/big"
 
 	gethCommon "github.com/onflow/go-ethereum/common"
@@ -10,8 +11,27 @@ import (
 )
 
 var (
+	// DefaultBlockLevelGasLimit is the default value for the block gas limit
+	// currently set to maximum and we don't consider any limit
+	// given number of included EVM transactions are naturally
+	// limited by the Flow block production limits.
+	DefaultBlockLevelGasLimit = uint64(math.MaxUint64)
+	// DefaultBaseFee is the default base fee value for the block
+	// is set to zero but can be updated by the config
+	DefaultBaseFee = big.NewInt(0)
+
+	// DefaultDirectCallBaseGasUsage holds the minimum gas
+	// charge for direct calls
 	DefaultDirectCallBaseGasUsage = uint64(21_000)
-	DefaultDirectCallGasPrice     = uint64(0)
+	// DefaultDirectCallGasPrice captures the default
+	// gas price for the direct call.
+	// its set to zero currently given that we charge
+	// computation but we don't need to refund to any
+	// coinbase account.
+	DefaultDirectCallGasPrice = uint64(0)
+
+	// anything block number above 0 works here
+	BlockNumberForEVMRules = big.NewInt(1)
 )
 
 // BlockContext holds the context needed for the emulator operations
@@ -21,6 +41,8 @@ type BlockContext struct {
 	BlockTimestamp         uint64
 	DirectCallBaseGasUsage uint64
 	DirectCallGasPrice     uint64
+	TxCountSoFar           uint
+	TotalGasUsedSoFar      uint64
 	GasFeeCollector        Address
 	GetHashFunc            func(n uint64) gethCommon.Hash
 	Random                 gethCommon.Hash

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -94,14 +94,11 @@ var (
 	// left in the context of flow transaction to execute the evm operation.
 	ErrInsufficientComputation = errors.New("insufficient computation")
 
-	// ErrUnAuthroizedMethodCall method call, usually emited when calls are called on EOA accounts
-	ErrUnAuthroizedMethodCall = errors.New("unauthroized method call")
-
-	// ErrInternalDirecCallFailed is returned when a withdraw or deposit internal call has failed.
-	ErrInternalDirectCallFailed = errors.New("internal direct call execution failed")
+	// ErrUnauthorizedMethodCall method call, usually emitted when calls are called on EOA accounts
+	ErrUnauthorizedMethodCall = errors.New("unauthorized method call")
 
 	// ErrWithdrawBalanceRounding is returned when withdraw call has a balance that could
-	// yeild to rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).
+	// result in rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).
 	ErrWithdrawBalanceRounding = errors.New("withdraw failed! the balance is susceptible to the rounding error")
 
 	// ErrUnexpectedEmptyResult is returned when a result is expected to be returned by the emulator
@@ -109,8 +106,8 @@ var (
 	ErrUnexpectedEmptyResult = errors.New("unexpected empty result has been returned")
 
 	// ErrInsufficientTotalSupply is returned when flow token
-	// is withdraw request is there but not enough balance is on EVM vault
-	// this should never happen but its a saftey measure to protect Flow against EVM issues.
+	// withdraw request is received but not enough balance is on EVM native token vault
+	// this should never happen but its a safety measure to protect Flow against EVM issues.
 	ErrInsufficientTotalSupply = NewFatalError(errors.New("insufficient total supply"))
 
 	// ErrNotImplemented is a fatal error when something is called that is not implemented
@@ -186,10 +183,10 @@ func IsWithdrawBalanceRoundingError(err error) bool {
 	return errors.Is(err, ErrWithdrawBalanceRounding)
 }
 
-// IsAUnAuthroizedMethodCallError returns true if the error type is
-// UnAuthroizedMethodCallError
-func IsAUnAuthroizedMethodCallError(err error) bool {
-	return errors.Is(err, ErrUnAuthroizedMethodCall)
+// IsAUnauthorizedMethodCallError returns true if the error type is
+// UnauthorizedMethodCallError
+func IsAUnauthorizedMethodCallError(err error) bool {
+	return errors.Is(err, ErrUnauthorizedMethodCall)
 }
 
 // BackendError is a non-fatal error wraps errors returned from the backend

--- a/fvm/evm/types/result_test.go
+++ b/fvm/evm/types/result_test.go
@@ -17,8 +17,8 @@ func TestLightReceipts(t *testing.T) {
 	var totalGas uint64
 	for i := 0; i < resCount; i++ {
 		res := testutils.RandomResultFixture(t)
-		receipts[i] = res.Receipt(totalGas)
-		reconstructedReceipts[i] = res.LightReceipt(totalGas).ToReceipt()
+		receipts[i] = res.Receipt()
+		reconstructedReceipts[i] = res.LightReceipt().ToReceipt()
 		totalGas += res.GasConsumed
 	}
 	// the root hash for reconstructed receipts should match the receipts

--- a/fvm/evm/types/state.go
+++ b/fvm/evm/types/state.go
@@ -36,6 +36,9 @@ type StateDB interface {
 	// preimages, access lists, ...
 	// The method is often called between execution of different transactions
 	Reset()
+
+	// Error returns any error that has been cached so far by the state.
+	Error() error
 }
 
 // ReadOnlyView provides a readonly view of the state

--- a/go.mod
+++ b/go.mod
@@ -47,12 +47,12 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.8.0-rc.3
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
-	github.com/onflow/flow-go-sdk v1.0.0-preview.41
+	github.com/onflow/flow-go-sdk v1.0.0-preview.42
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2167,8 +2167,8 @@ github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 h1:5OGjwpd+P7LQPesGkf2RP9iRCJm34eDx5Ll7grTkN+Y=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 h1:c5EWIEtA/gbpospEUEAY1XFN7FEUtDh0wJ73p+wxBYc=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2183,8 +2183,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.41 h1:pOUAIQdlWuc90tQzYixCXkqmnoorDgsFxTu2J1wlhHA=
-github.com/onflow/flow-go-sdk v1.0.0-preview.41/go.mod h1:FyJiLluqK+sNo+ky9VU6HSwVkvhv5/fKH1sIKI1yrrI=
+github.com/onflow/flow-go-sdk v1.0.0-preview.42 h1:XcHWRQfkJ5A24sNqnmo3DocHdf5ulDJLie9/yh5c1Y4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.42/go.mod h1:4/ELH5ooEdZ+9tZfoiTIkkB4B6wVgy4HbMjS/9w/67Q=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -201,12 +201,12 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.8.0-rc.3 // indirect
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 // indirect
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-preview.41 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-preview.42 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v1.2.0 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.5 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2157,8 +2157,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 h1:5OGjwpd+P7LQPesGkf2RP9iRCJm34eDx5Ll7grTkN+Y=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 h1:c5EWIEtA/gbpospEUEAY1XFN7FEUtDh0wJ73p+wxBYc=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2171,8 +2171,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.41 h1:pOUAIQdlWuc90tQzYixCXkqmnoorDgsFxTu2J1wlhHA=
-github.com/onflow/flow-go-sdk v1.0.0-preview.41/go.mod h1:FyJiLluqK+sNo+ky9VU6HSwVkvhv5/fKH1sIKI1yrrI=
+github.com/onflow/flow-go-sdk v1.0.0-preview.42 h1:XcHWRQfkJ5A24sNqnmo3DocHdf5ulDJLie9/yh5c1Y4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.42/go.mod h1:4/ELH5ooEdZ+9tZfoiTIkkB4B6wVgy4HbMjS/9w/67Q=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
 	github.com/onflow/flow-emulator v1.0.0-preview.35.0.20240718190812-a4af59d6987a
 	github.com/onflow/flow-go v0.36.2-0.20240717214129-9ea6faeee3e7
-	github.com/onflow/flow-go-sdk v1.0.0-preview.41
+	github.com/onflow/flow-go-sdk v1.0.0-preview.42
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/onflow/go-ethereum v1.14.7

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2141,8 +2141,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 h1:5OGjwpd+P7LQPesGkf2RP9iRCJm34eDx5Ll7grTkN+Y=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 h1:c5EWIEtA/gbpospEUEAY1XFN7FEUtDh0wJ73p+wxBYc=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
@@ -2157,8 +2157,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.41 h1:pOUAIQdlWuc90tQzYixCXkqmnoorDgsFxTu2J1wlhHA=
-github.com/onflow/flow-go-sdk v1.0.0-preview.41/go.mod h1:FyJiLluqK+sNo+ky9VU6HSwVkvhv5/fKH1sIKI1yrrI=
+github.com/onflow/flow-go-sdk v1.0.0-preview.42 h1:XcHWRQfkJ5A24sNqnmo3DocHdf5ulDJLie9/yh5c1Y4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.42/go.mod h1:4/ELH5ooEdZ+9tZfoiTIkkB4B6wVgy4HbMjS/9w/67Q=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "fcb2545d3252e28eaa8d98ae06eac847ec471ada0d785dfc06c08be3775b38c1"
+const GenesisStateCommitmentHex = "f0eeeadd231fcc1668d4bcc8df8488a35e126600e3c4b88b4120b35e4ea9ee8c"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "d21fc3e90af87b79e3db8a2614f0071c53c1e83feedfe02471e248e5f89707b3"
+		return "b41ab049fc2f2f5f419357f2e4dc9d2181a18f419e3b2e96d7f908511d5e0aa1"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "343cec287c5246bcdb2868d8d9bb5009860e41079dca3cacb9cdc05aa76035a9"
+	return "922fca1ecf717e724328d24a9e3cb147426973405fe0d7ba87f67e0f5347887b"
 }


### PR DESCRIPTION
Merge `master` into `feature/atree-inlining-cadence-v1.0`

<details>
<summary>Conflict resolution</summary>

```diff
commit cf321f5aeec6338a6dbce335c09e61dd4c22f75f
Merge: 9b93276fd4 14f9fddeda
Author: Bastian Müller <bastian@turbolent.com>
Date:   Wed Jul 24 14:33:44 2024 -0700

    Merge branch 'master' into bastian/update-atree-inlining-cadence-v1.0-16

diff --git a/engine/execution/state/bootstrap/bootstrap_test.go b/engine/execution/state/bootstrap/bootstrap_test.go
remerge CONFLICT (content): Merge conflict in engine/execution/state/bootstrap/bootstrap_test.go
index bfbd9718dc..f2ec6d76b6 100644
--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,11 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-	expectedStateCommitmentBytes, _ := hex.DecodeString("8394b655612248d6f87c0302762c399613319a9bcec19391755a97b50062b1d4")
-=======
-	expectedStateCommitmentBytes, _ := hex.DecodeString("483b6a58223d0d93e85bcdf125a224a80d5d7f1260910941e0b3b4bb6121dc56")
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+	expectedStateCommitmentBytes, _ := hex.DecodeString("1383e01cdba9bb1df08d413f89c3a252f1081f2ebb0c58850676194a01cfc4c4")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 
diff --git a/fvm/evm/backends/wrappedEnv.go b/fvm/evm/backends/wrappedEnv.go
remerge CONFLICT (content): Merge conflict in fvm/evm/backends/wrappedEnv.go
index 637e8dcc6b..6f122aecbb 100644
--- a/fvm/evm/backends/wrappedEnv.go
+++ b/fvm/evm/backends/wrappedEnv.go
@@ -48,14 +48,9 @@ func (we *WrappedEnvironment) ValueExists(owner, key []byte) (bool, error) {
 	return b, handleEnvironmentError(err)
 }
 
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
+// AllocateSlabIndex allocates a slab index under the given account.
 func (we *WrappedEnvironment) AllocateSlabIndex(owner []byte) (atree.SlabIndex, error) {
 	index, err := we.env.AllocateSlabIndex(owner)
-=======
-// AllocateStorageIndex allocates an storage index under the given account.
-func (we *WrappedEnvironment) AllocateStorageIndex(owner []byte) (atree.StorageIndex, error) {
-	index, err := we.env.AllocateStorageIndex(owner)
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
 	return index, handleEnvironmentError(err)
 }
 
diff --git a/go.mod b/go.mod
remerge CONFLICT (content): Merge conflict in go.mod
index f4ebc8d61b..42013d9bed 100644
--- a/go.mod
+++ b/go.mod
@@ -46,13 +46,8 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
 	github.com/onflow/atree v0.8.0-rc.3
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38
-=======
-	github.com/onflow/atree v0.7.0-rc.2
-	github.com/onflow/cadence v1.0.0-preview.39
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1
diff --git a/go.sum b/go.sum
remerge CONFLICT (content): Merge conflict in go.sum
index 5f122fbab5..6dcc97097c 100644
--- a/go.sum
+++ b/go.sum
@@ -2167,13 +2167,8 @@ github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 h1:5OGjwpd+P7LQPesGkf2RP9iRCJm34eDx5Ll7grTkN+Y=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
-=======
-github.com/onflow/cadence v1.0.0-preview.39 h1:BDx+hO4THUW6cDN11tqVtBx8hFSUErjQkw/WDAGs0C4=
-github.com/onflow/cadence v1.0.0-preview.39/go.mod h1:jOwvPSSLTr9TvaKMs7KKiBYMmpdpNNAFxBsjMlrqVD0=
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 h1:c5EWIEtA/gbpospEUEAY1XFN7FEUtDh0wJ73p+wxBYc=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/insecure/go.mod b/insecure/go.mod
remerge CONFLICT (content): Merge conflict in insecure/go.mod
index d2dcab55e5..3e0b22c82e 100644
--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -200,13 +200,8 @@ require (
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
 	github.com/onflow/atree v0.8.0-rc.3 // indirect
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 // indirect
-=======
-	github.com/onflow/atree v0.7.0-rc.2 // indirect
-	github.com/onflow/cadence v1.0.0-preview.39 // indirect
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
diff --git a/insecure/go.sum b/insecure/go.sum
remerge CONFLICT (content): Merge conflict in insecure/go.sum
index bd4f93c0bf..28c19a3188 100644
--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2157,13 +2157,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 h1:5OGjwpd+P7LQPesGkf2RP9iRCJm34eDx5Ll7grTkN+Y=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
-=======
-github.com/onflow/cadence v1.0.0-preview.39 h1:BDx+hO4THUW6cDN11tqVtBx8hFSUErjQkw/WDAGs0C4=
-github.com/onflow/cadence v1.0.0-preview.39/go.mod h1:jOwvPSSLTr9TvaKMs7KKiBYMmpdpNNAFxBsjMlrqVD0=
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 h1:c5EWIEtA/gbpospEUEAY1XFN7FEUtDh0wJ73p+wxBYc=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/integration/go.mod b/integration/go.mod
remerge CONFLICT (content): Merge conflict in integration/go.mod
index 40b326c836..bf08dfc36a 100644
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -19,11 +19,7 @@ require (
 	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/libp2p/go-libp2p v0.32.2
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38
-=======
-	github.com/onflow/cadence v1.0.0-preview.39
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+	github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39
 	github.com/onflow/crypto v0.25.1
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
diff --git a/integration/go.sum b/integration/go.sum
remerge CONFLICT (content): Merge conflict in integration/go.sum
index 50df538356..6c3f9614b7 100644
--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2141,13 +2141,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.3 h1:BHVkJLrBHhHo7ET8gkuS1+lyQGNekYYOyoICGK3RFNM=
 github.com/onflow/atree v0.8.0-rc.3/go.mod h1:7YNAyCd5JENq+NzH+fR1ABUZVzbSq9dkt0+5fZH3L2A=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38 h1:5OGjwpd+P7LQPesGkf2RP9iRCJm34eDx5Ll7grTkN+Y=
-github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.38/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
-=======
-github.com/onflow/cadence v1.0.0-preview.39 h1:BDx+hO4THUW6cDN11tqVtBx8hFSUErjQkw/WDAGs0C4=
-github.com/onflow/cadence v1.0.0-preview.39/go.mod h1:jOwvPSSLTr9TvaKMs7KKiBYMmpdpNNAFxBsjMlrqVD0=
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39 h1:c5EWIEtA/gbpospEUEAY1XFN7FEUtDh0wJ73p+wxBYc=
+github.com/onflow/cadence v1.0.0-preview-atree-register-inlining.39/go.mod h1:zyl2lWOLVKiKt8BoGAModCHqFEivJ44Y7Myx6NwND7o=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
diff --git a/utils/unittest/execution_state.go b/utils/unittest/execution_state.go
remerge CONFLICT (content): Merge conflict in utils/unittest/execution_state.go
index 0ae9fd4ac1..ea7278b1e6 100644
--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,11 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-const GenesisStateCommitmentHex = "fcb2545d3252e28eaa8d98ae06eac847ec471ada0d785dfc06c08be3775b38c1"
-=======
-const GenesisStateCommitmentHex = "a642be06b34bd0f120c49d907f38a8241a94360637cdaf51b36ae46d655b86c8"
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+const GenesisStateCommitmentHex = "f0eeeadd231fcc1668d4bcc8df8488a35e126600e3c4b88b4120b35e4ea9ee8c"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -91,18 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-		return "d21fc3e90af87b79e3db8a2614f0071c53c1e83feedfe02471e248e5f89707b3"
-=======
-		return "6d5efa6e328640d727124e2d54febec0ba1fb5b2477f60d0202f555d77470488"
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+		return "b41ab049fc2f2f5f419357f2e4dc9d2181a18f419e3b2e96d7f908511d5e0aa1"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-<<<<<<< 9b93276fd4 (Merge pull request #6250 from onflow/bastian/update-atree-inlining-cadence-v1.0-15)
-	return "343cec287c5246bcdb2868d8d9bb5009860e41079dca3cacb9cdc05aa76035a9"
-=======
-	return "023fc1b2834efce3b86c14544afb7031a2fe253b3d8c3b43fd7fcadc61816186"
->>>>>>> 14f9fddeda (Merge pull request #6257 from onflow/auto-update-onflow-cadence-v1.0.0-preview.39)
+	return "922fca1ecf717e724328d24a9e3cb147426973405fe0d7ba87f67e0f5347887b"
 }

```

</details>