### PR TITLE
[EVM] Trace supplied with invalid error

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -123,12 +123,9 @@ func (bl *BlockView) DirectCall(call *types.DirectCall) (res *types.Result, err 
 		proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), call.Transaction(), call.From.ToCommon())
 		defer func() {
 			if proc.evm.Config.Tracer.OnTxEnd != nil {
-				receipt := &gethTypes.Receipt{}
-				if res != nil {
-					receipt = res.Receipt()
-					err = res.ValidationError
+				if err == nil && res != nil {
+					proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), res.ValidationError)
 				}
-				proc.evm.Config.Tracer.OnTxEnd(receipt, err)
 			}
 		}()
 
@@ -176,12 +173,9 @@ func (bl *BlockView) RunTransaction(
 		proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), tx, msg.From)
 		defer func() {
 			if proc.evm.Config.Tracer.OnTxEnd != nil {
-				receipt := &gethTypes.Receipt{}
-				if result != nil {
-					receipt = result.Receipt()
-					err = result.ValidationError
+				if err == nil && result != nil {
+					proc.evm.Config.Tracer.OnTxEnd(result.Receipt(), result.ValidationError)
 				}
-				proc.evm.Config.Tracer.OnTxEnd(receipt, err)
 			}
 		}()
 	}
@@ -225,17 +219,10 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 			defer func() {
 				if proc.evm.Config.Tracer.OnTxEnd != nil {
 					j := i
-					receipt := &gethTypes.Receipt{}
 					res := batchResults[j]
-					var err error
-					if res != nil {
-						receipt = res.Receipt()
-						err = res.ValidationError
+					if err == nil && res != nil {
+						proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), res.ValidationError)
 					}
-					proc.evm.Config.Tracer.OnTxEnd(
-						receipt,
-						err,
-					)
 				}
 			}()
 

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -179,7 +179,7 @@ func (bl *BlockView) RunTransaction(
 				if result != nil {
 					receipt = result.Receipt()
 				}
-				proc.evm.Config.Tracer.OnTxEnd(receipt, err)
+				proc.evm.Config.Tracer.OnTxEnd(receipt, result.ValidationError)
 			}
 		}()
 

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -126,6 +126,7 @@ func (bl *BlockView) DirectCall(call *types.DirectCall) (res *types.Result, err 
 				receipt := &gethTypes.Receipt{}
 				if res != nil {
 					receipt = res.Receipt()
+					err = res.ValidationError
 				}
 				proc.evm.Config.Tracer.OnTxEnd(receipt, err)
 			}
@@ -178,11 +179,11 @@ func (bl *BlockView) RunTransaction(
 				receipt := &gethTypes.Receipt{}
 				if result != nil {
 					receipt = result.Receipt()
+					err = result.ValidationError
 				}
-				proc.evm.Config.Tracer.OnTxEnd(receipt, result.ValidationError)
+				proc.evm.Config.Tracer.OnTxEnd(receipt, err)
 			}
 		}()
-
 	}
 
 	// run msg
@@ -223,9 +224,13 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 			proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), tx, msg.From)
 			defer func() {
 				if proc.evm.Config.Tracer.OnTxEnd != nil {
+					j := i
 					receipt := &gethTypes.Receipt{}
-					if batchResults[i] != nil {
-						receipt = batchResults[i].Receipt()
+					res := batchResults[j]
+					var err error
+					if res != nil {
+						receipt = res.Receipt()
+						err = res.ValidationError
 					}
 					proc.evm.Config.Tracer.OnTxEnd(
 						receipt,

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -1017,16 +1017,17 @@ func TestTransactionTracing(t *testing.T) {
 			tx := testAccount.PrepareAndSignTx(
 				t,
 				testContract.DeployedAt.ToCommon(),
-				testContract.MakeCallData(t, "store1", big.NewInt(2)),
+				testContract.MakeCallData(t, "store", big.NewInt(2)),
 				big.NewInt(0),
-				1_000_000,
-				big.NewInt(0),
+				21210,
+				big.NewInt(100),
 			)
 
 			// interact and record trace
 			res, err := blk.RunTransaction(tx)
 			require.NoError(t, err)
-			require.EqualError(t, res.VMError, "method 'store1' not found")
+			fmt.Println(res)
+			require.EqualError(t, res.VMError, "out of gas")
 
 			tracer.Collect(txID)
 		})

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -1026,7 +1026,6 @@ func TestTransactionTracing(t *testing.T) {
 			// interact and record trace
 			res, err := blk.RunTransaction(tx)
 			require.NoError(t, err)
-			fmt.Println(res)
 			require.EqualError(t, res.VMError, "out of gas")
 
 			tracer.Collect(txID)


### PR DESCRIPTION
This PR makes sure the tracer gets a possible invalid error passed in, instead of currently getting passed in `err` which anyway is nil, and that is causing a panic in the tracer implementation, because if the error is nil it assumes there are calls made which isn't the case for invalid tx.