### PR TITLE
[Cadence 1.0 migration] Fix non-determinism in contract code and contract names cleanup migration

### DIFF
--- a/cmd/util/ledger/migrations/contract_cleanup_migration.go
+++ b/cmd/util/ledger/migrations/contract_cleanup_migration.go
@@ -68,11 +68,17 @@ func (d *ContractCleanupMigration) MigrateAccount(
 		contractNameSet[contractName] = struct{}{}
 	}
 
+	contractNamesSorted := make([]string, 0, len(contractNameSet))
+	for contractName := range contractNameSet {
+		contractNamesSorted = append(contractNamesSorted, contractName)
+	}
+	sort.Strings(contractNamesSorted)
+
 	// Cleanup the code for each contract in the account.
 	// If the contract code is empty, the contract code register will be removed,
 	// and the contract name will be removed from the account's contract names.
 
-	for contractName := range contractNameSet {
+	for _, contractName := range contractNamesSorted {
 		removed, err := d.cleanupContractCode(
 			address,
 			accountRegisters,

--- a/cmd/util/ledger/migrations/contract_cleanup_migration_test.go
+++ b/cmd/util/ledger/migrations/contract_cleanup_migration_test.go
@@ -248,15 +248,16 @@ func TestContractCleanupMigration2(t *testing.T) {
 	reporter := rwf.reportWriters[contractCleanupReporterName]
 	require.NotNil(t, reporter)
 
+	// Order is alphabetical
 	assert.Equal(t,
 		[]any{
 			emptyContractRemoved{
 				AccountAddress: address,
-				ContractName:   contractNameEmpty1,
+				ContractName:   contractNameEmpty2,
 			},
 			emptyContractRemoved{
 				AccountAddress: address,
-				ContractName:   contractNameEmpty2,
+				ContractName:   contractNameEmpty1,
 			},
 			contractNamesChanged{
 				AccountAddress: address,


### PR DESCRIPTION
Sort the list of contract names before iterating over it. Go `map`s do not have a deterministic iteration order