### PR TITLE
[Cadence 1.0 migration] Always report checking errors for system contracts

### DIFF
--- a/cmd/util/ledger/migrations/cadence_test.go
+++ b/cmd/util/ledger/migrations/cadence_test.go
@@ -52,7 +52,7 @@ func TestMigrateCadence1EmptyContract(t *testing.T) {
 	// Run contract checking migration
 
 	log := zerolog.Nop()
-	checkingMigration := NewContractCheckingMigration(log, rwf, chainID, false, programs)
+	checkingMigration := NewContractCheckingMigration(log, rwf, chainID, false, nil, programs)
 
 	err = checkingMigration(registersByAccount)
 	require.NoError(t, err)

--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -287,16 +287,24 @@ func NewSystemContractsMigration(
 	log zerolog.Logger,
 	rwf reporters.ReportWriterFactory,
 	options SystemContractsMigrationOptions,
-) *StagedContractsMigration {
-	migration := NewStagedContractsMigration(
+) (
+	migration *StagedContractsMigration,
+	locations map[common.AddressLocation]struct{},
+) {
+	migration = NewStagedContractsMigration(
 		"SystemContractsMigration",
 		"system-contracts-migration",
 		log,
 		rwf,
 		options.StagedContractsMigrationOptions,
 	)
+
+	locations = make(map[common.AddressLocation]struct{})
+
 	for _, change := range SystemContractChanges(options.ChainID, options) {
 		migration.registerContractChange(change)
+		locations[change.AddressLocation()] = struct{}{}
 	}
-	return migration
+
+	return migration, locations
 }

--- a/cmd/util/ledger/migrations/change_contract_code_migration_test.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration_test.go
@@ -560,3 +560,122 @@ func TestChangeContractCodeMigration(t *testing.T) {
 		)
 	})
 }
+
+func TestSystemContractChanges(t *testing.T) {
+	t.Parallel()
+
+	const chainID = flow.Mainnet
+
+	changes := SystemContractChanges(
+		chainID,
+		SystemContractsMigrationOptions{
+			StagedContractsMigrationOptions: StagedContractsMigrationOptions{
+				ChainID: chainID,
+			},
+			EVM:    EVMContractChangeUpdateFull,
+			Burner: BurnerContractChangeDeploy,
+		},
+	)
+
+	var changeLocations []common.AddressLocation
+
+	for _, change := range changes {
+		location := change.AddressLocation()
+		changeLocations = append(changeLocations, location)
+	}
+
+	address1 := common.Address{0x86, 0x24, 0xb5, 0x2f, 0x9d, 0xdc, 0xd0, 0x4a}
+	address2 := common.Address{0xe4, 0x67, 0xb9, 0xdd, 0x11, 0xfa, 0x00, 0xdf}
+	address3 := common.Address{0x8d, 0x0e, 0x87, 0xb6, 0x51, 0x59, 0xae, 0x63}
+	address4 := common.Address{0x62, 0x43, 0x0c, 0xf2, 0x8c, 0x26, 0xd0, 0x95}
+	address5 := common.Address{0xf9, 0x19, 0xee, 0x77, 0x44, 0x7b, 0x74, 0x97}
+	address6 := common.Address{0x16, 0x54, 0x65, 0x33, 0x99, 0x04, 0x0a, 0x61}
+	address7 := common.Address{0xf2, 0x33, 0xdc, 0xee, 0x88, 0xfe, 0x0a, 0xbe}
+	address8 := common.Address{0x1d, 0x7e, 0x57, 0xaa, 0x55, 0x81, 0x74, 0x48}
+
+	assert.Equal(t,
+		[]common.AddressLocation{
+			{
+				Name:    "FlowEpoch",
+				Address: address1,
+			},
+			{
+				Name:    "FlowIDTableStaking",
+				Address: address1,
+			},
+			{
+				Name:    "FlowClusterQC",
+				Address: address1,
+			},
+			{
+				Name:    "FlowDKG",
+				Address: address1,
+			},
+			{
+				Name:    "FlowServiceAccount",
+				Address: address2,
+			},
+			{
+				Name:    "NodeVersionBeacon",
+				Address: address2,
+			},
+			{
+				Name:    "RandomBeaconHistory",
+				Address: address2,
+			},
+			{
+				Name:    "FlowStorageFees",
+				Address: address2,
+			},
+			{
+				Name:    "FlowStakingCollection",
+				Address: address3,
+			},
+			{
+				Name:    "StakingProxy",
+				Address: address4,
+			},
+			{
+				Name:    "LockedTokens",
+				Address: address3,
+			},
+			{
+				Name:    "FlowFees",
+				Address: address5,
+			},
+			{
+				Name:    "FlowToken",
+				Address: address6,
+			},
+			{
+				Name:    "FungibleToken",
+				Address: address7,
+			},
+			{
+				Name:    "FungibleTokenMetadataViews",
+				Address: address7,
+			},
+			{
+				Name:    "NonFungibleToken",
+				Address: address8,
+			},
+			{
+				Name:    "MetadataViews",
+				Address: address8,
+			},
+			{
+				Name:    "ViewResolver",
+				Address: address8,
+			},
+			{
+				Name:    "FungibleTokenSwitchboard",
+				Address: address7,
+			},
+			{
+				Name:    "EVM",
+				Address: address2,
+			},
+		},
+		changeLocations,
+	)
+}

--- a/cmd/util/ledger/migrations/staged_contracts_migration.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration.go
@@ -49,6 +49,13 @@ type StagedContract struct {
 	Address common.Address
 }
 
+func (s StagedContract) AddressLocation() common.AddressLocation {
+	return common.AddressLocation{
+		Name:    s.Name,
+		Address: s.Address,
+	}
+}
+
 type Contract struct {
 	Name string
 	Code []byte


### PR DESCRIPTION
System contracts should always check. Report errors, even when verbose error reporting is turned off