### PR TITLE
[Util] Add command to validate Cadence 1.0 migration

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -373,16 +373,7 @@ func run(*cobra.Command, []string) {
 
 	chainID := chain.ChainID()
 
-	burnerContractChange := migrations.BurnerContractChangeNone
-	evmContractChange := migrations.EVMContractChangeNone
-	switch chainID {
-	case flow.Emulator:
-		burnerContractChange = migrations.BurnerContractChangeDeploy
-		evmContractChange = migrations.EVMContractChangeDeployMinimalAndUpdateFull
-	case flow.Testnet, flow.Mainnet:
-		burnerContractChange = migrations.BurnerContractChangeUpdate
-		evmContractChange = migrations.EVMContractChangeUpdateFull
-	}
+	burnerContractChange, evmContractChange := migrations.SystemContractChangesForChainID(chainID)
 
 	stagedContracts, err := migrations.StagedContractsFromCSV(flagStagedContractsFile)
 	if err != nil {

--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -35,6 +35,7 @@ import (
 	run_script "github.com/onflow/flow-go/cmd/util/cmd/run-script"
 	"github.com/onflow/flow-go/cmd/util/cmd/snapshot"
 	truncate_database "github.com/onflow/flow-go/cmd/util/cmd/truncate-database"
+	validate_c1_migration "github.com/onflow/flow-go/cmd/util/cmd/validate-c1-migration"
 	"github.com/onflow/flow-go/cmd/util/cmd/version"
 	"github.com/onflow/flow-go/module/profiler"
 )
@@ -114,6 +115,7 @@ func addCommands() {
 	rootCmd.AddCommand(atree_inlined_status.Cmd)
 	rootCmd.AddCommand(find_trie_root.Cmd)
 	rootCmd.AddCommand(run_script.Cmd)
+	rootCmd.AddCommand(validate_c1_migration.Cmd)
 }
 
 func initConfig() {

--- a/cmd/util/cmd/validate-c1-migration/cmd.go
+++ b/cmd/util/cmd/validate-c1-migration/cmd.go
@@ -66,14 +66,13 @@ func runSystemContractsChecking(_ *cobra.Command, args []string) {
 		systemContractLocations[change.AddressLocation()] = struct{}{}
 	}
 
-	var reader io.Reader
-	var err error
-
-	reader, err = os.Open(report)
+	f, err := os.Open(report)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to open report")
 	}
+	defer f.Close()
 
+	var reader io.Reader = f
 	if flagGzip {
 		reader, err = gzip.NewReader(reader)
 		if err != nil {

--- a/cmd/util/cmd/validate-c1-migration/cmd.go
+++ b/cmd/util/cmd/validate-c1-migration/cmd.go
@@ -1,0 +1,118 @@
+package validate_c1_migration
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+var (
+	flagChain string
+	flagGzip  bool
+)
+
+var Cmd = &cobra.Command{
+	Use:   "validate-c1-migration",
+	Short: "validate the Cadence 1.0 migration",
+}
+
+var systemContractsCheckingCmd = &cobra.Command{
+	Use:   "system-contracts-checking [report]",
+	Short: "validate checking of all system contracts",
+	Args:  cobra.ExactArgs(1),
+	Run:   runSystemContractsChecking,
+}
+
+func init() {
+	Cmd.PersistentFlags().StringVar(&flagChain, "chain", "", "Chain name")
+	_ = Cmd.MarkFlagRequired("chain")
+
+	Cmd.AddCommand(systemContractsCheckingCmd)
+
+	systemContractsCheckingCmd.Flags().BoolVar(&flagGzip, "gzip", false, "report is gzipped")
+}
+
+func runSystemContractsChecking(_ *cobra.Command, args []string) {
+	chainID := flow.ChainID(flagChain)
+	_ = chainID.Chain()
+
+	report := args[0]
+
+	log.Info().Msgf("Validating checking of system contracts for chain %s, report %s ...", chainID, report)
+
+	burnerContractChange, evmContractChange := migrations.SystemContractChangesForChainID(chainID)
+
+	systemContractChanges := migrations.SystemContractChanges(
+		chainID,
+		migrations.SystemContractsMigrationOptions{
+			StagedContractsMigrationOptions: migrations.StagedContractsMigrationOptions{
+				ChainID: chainID,
+			},
+			EVM:    evmContractChange,
+			Burner: burnerContractChange,
+		},
+	)
+
+	systemContractLocations := make(map[common.AddressLocation]struct{}, len(systemContractChanges))
+	for _, change := range systemContractChanges {
+		systemContractLocations[change.AddressLocation()] = struct{}{}
+	}
+
+	var reader io.Reader
+	var err error
+
+	reader, err = os.Open(report)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to open report")
+	}
+
+	if flagGzip {
+		reader, err = gzip.NewReader(reader)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to open gzip reader")
+		}
+	}
+
+	var results []migrations.ContractCheckingResultJSON
+	err = json.NewDecoder(reader).Decode(&results)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to decode report")
+	}
+
+	log.Info().Msgf("Read %d checking results", len(results))
+
+	var failures bool
+
+	for _, result := range results {
+		if result.ContractCheckingSuccess != nil {
+			continue
+		}
+
+		failure := result.ContractCheckingFailure
+
+		location := common.AddressLocation{
+			Address: failure.AccountAddress,
+			Name:    failure.ContractName,
+		}
+
+		_, ok := systemContractLocations[location]
+		if !ok {
+			continue
+		}
+
+		log.Error().Msgf("Failed to check system contract %s:\n%s", location, failure.Error)
+		failures = true
+	}
+
+	if !failures {
+		log.Info().Msg("All system contracts checked successfully")
+	}
+}

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -1297,7 +1297,7 @@ func TestProgramParsingError(t *testing.T) {
 	var messages []string
 
 	for _, entry := range reporter.entries {
-		if errorEntry, isErrorEntry := entry.(contractCheckingFailure); isErrorEntry {
+		if errorEntry, isErrorEntry := entry.(ContractCheckingFailure); isErrorEntry {
 			messages = append(messages, errorEntry.Error)
 			break
 		}

--- a/cmd/util/ledger/migrations/change_contract_code_migration.go
+++ b/cmd/util/ledger/migrations/change_contract_code_migration.go
@@ -308,3 +308,23 @@ func NewSystemContractsMigration(
 
 	return migration, locations
 }
+
+func SystemContractChangesForChainID(chainID flow.ChainID) (
+	burnerContractChange BurnerContractChange,
+	evmContractChange EVMContractChange,
+) {
+	burnerContractChange = BurnerContractChangeNone
+	evmContractChange = EVMContractChangeNone
+
+	switch chainID {
+	case flow.Emulator:
+		burnerContractChange = BurnerContractChangeDeploy
+		evmContractChange = EVMContractChangeDeployMinimalAndUpdateFull
+
+	case flow.Testnet, flow.Mainnet:
+		burnerContractChange = BurnerContractChangeUpdate
+		evmContractChange = EVMContractChangeUpdateFull
+	}
+
+	return
+}


### PR DESCRIPTION
Add a new command which can validate reports from the Cadence 1.0 migration.

To begin, add a sub-command which can validate the checking report, and warn if any system contracts failed to check.

We can extend this command in the future.