### PR TITLE
[EFM] minor polishing

### DIFF
--- a/module/epochs.go
+++ b/module/epochs.go
@@ -46,6 +46,7 @@ type QCContractClient interface {
 }
 
 // EpochLookup enables looking up epochs by view.
+// Only Epochs that are fully committed can be retrieved.
 // CAUTION: EpochLookup should only be used for querying the previous, current, or next epoch.
 type EpochLookup interface {
 

--- a/module/epochs/epoch_lookup.go
+++ b/module/epochs/epoch_lookup.go
@@ -70,12 +70,12 @@ func (cache *epochRangeCache) extendLatestEpoch(epochCounter uint64, extension f
 
 	// sanity check: `extension.FinalView` should be greater than final view of latest epoch
 	if latestEpoch.finalView > extension.FinalView {
-		return fmt.Errorf(invalidExtensionFinalView, cache[2].finalView, extension.FinalView)
+		return fmt.Errorf(invalidExtensionFinalView, latestEpoch.finalView, extension.FinalView)
 	}
 
 	// sanity check: epoch extension should have the same epoch counter as the latest epoch
 	if latestEpoch.epochCounter != epochCounter {
-		return fmt.Errorf(mismatchEpochCounter, cache[2].epochCounter, epochCounter)
+		return fmt.Errorf(mismatchEpochCounter, latestEpoch.epochCounter, epochCounter)
 	}
 
 	// sanity check: first view of the epoch extension should immediately start after the final view of the latest epoch.

--- a/module/epochs/epoch_lookup.go
+++ b/module/epochs/epoch_lookup.go
@@ -21,7 +21,7 @@ const (
 
 // viewRange captures the counter and view range of an epoch (inclusive on both ends)
 // The zero value (epochCounter = firstView = finalView = 0) can conceptually not occur:
-// even the genesis epoch '0' is required to have some view to prepare the subsequent epoch.
+// even the genesis epoch '0' is required to have some views to prepare the subsequent epoch.
 // Therefore, we use the zero value to represent 'undefined'.
 type viewRange struct {
 	epochCounter uint64

--- a/module/epochs/epoch_lookup.go
+++ b/module/epochs/epoch_lookup.go
@@ -278,7 +278,12 @@ func (lookup *EpochLookup) EpochForView(view uint64) (uint64, error) {
 	}
 	// view is before any known epochs
 	// ---*---[----|----|----]-------
-	return 0, model.ErrViewForUnknownEpoch
+	if view < cachedEpochs[0].firstView {
+		return 0, model.ErrViewForUnknownEpoch
+	}
+
+	// reaching this point indicates a corrupted state or internal bug
+	return 0, fmt.Errorf("sanity check failed: input view %d falls within the view range [%d, %d] of the cached epochs epochs, but none contains it", view, cachedEpochs[0].firstView, cachedEpochs[l-1].finalView)
 }
 
 // handleProtocolEvents processes queued Epoch events `EpochCommittedPhaseStarted`

--- a/module/epochs/epoch_lookup.go
+++ b/module/epochs/epoch_lookup.go
@@ -58,12 +58,12 @@ func (cache *epochRangeCache) extendLatestEpoch(epochCounter uint64, extension f
 	}
 
 	// sanity check: `extension.FinalView` should be greater than final view of latest epoch
-	if cache[2].finalView > extension.FinalView {
+	if latestEpoch.finalView > extension.FinalView {
 		return fmt.Errorf(invalidExtensionFinalView, cache[2].finalView, extension.FinalView)
 	}
 
 	// sanity check: epoch extension should have the same epoch counter as the latest epoch
-	if cache[2].counter != epochCounter {
+	if latestEpoch.counter != epochCounter {
 		return fmt.Errorf(mismatchEpochCounter, cache[2].counter, epochCounter)
 	}
 

--- a/module/epochs/epoch_lookup_test.go
+++ b/module/epochs/epoch_lookup_test.go
@@ -34,9 +34,9 @@ type EpochLookupSuite struct {
 
 	// config for each epoch
 	currentEpochCounter uint64
-	prevEpoch           epochRange
-	currEpoch           epochRange
-	nextEpoch           epochRange
+	prevEpoch           viewRange
+	currEpoch           viewRange
+	nextEpoch           viewRange
 
 	lookup *EpochLookup
 	cancel context.CancelFunc
@@ -50,9 +50,9 @@ func (suite *EpochLookupSuite) SetupTest() {
 	suite.currentEpochCounter = uint64(1)
 	suite.phase = flow.EpochPhaseStaking
 
-	suite.prevEpoch = epochRange{counter: suite.currentEpochCounter - 1, firstView: 100, finalView: 199}
-	suite.currEpoch = epochRange{counter: suite.currentEpochCounter, firstView: 200, finalView: 299}
-	suite.nextEpoch = epochRange{counter: suite.currentEpochCounter + 1, firstView: 300, finalView: 399}
+	suite.prevEpoch = viewRange{epochCounter: suite.currentEpochCounter - 1, firstView: 100, finalView: 199}
+	suite.currEpoch = viewRange{epochCounter: suite.currentEpochCounter, firstView: 200, finalView: 299}
+	suite.nextEpoch = viewRange{epochCounter: suite.currentEpochCounter + 1, firstView: 300, finalView: 399}
 
 	suite.state = new(mockprotocol.State)
 	suite.snapshot = new(mockprotocol.Snapshot)
@@ -93,12 +93,12 @@ func (suite *EpochLookupSuite) Phase() flow.EpochPhase {
 }
 
 // CommitEpochs adds the new epochs to the state.
-func (suite *EpochLookupSuite) CommitEpochs(epochs ...epochRange) {
+func (suite *EpochLookupSuite) CommitEpochs(epochs ...viewRange) {
 	for _, epoch := range epochs {
-		mockEpoch := newMockEpoch(epoch.counter, epoch.firstView, epoch.finalView)
+		mockEpoch := newMockEpoch(epoch.epochCounter, epoch.firstView, epoch.finalView)
 		suite.epochQuery.Add(mockEpoch)
 		// if we add a next epoch (counter 1 greater than current), then set phase to committed
-		if epoch.counter == suite.currentEpochCounter+1 {
+		if epoch.epochCounter == suite.currentEpochCounter+1 {
 			suite.WithLock(func() {
 				suite.phase = flow.EpochPhaseCommitted
 			})
@@ -123,7 +123,7 @@ func (suite *EpochLookupSuite) CreateAndStartEpochLookup() {
 // TestEpochForView_Curr tests constructing and subsequently querying
 // EpochLookup with an initial state of a current epoch.
 func (suite *EpochLookupSuite) TestEpochForView_Curr() {
-	epochs := []epochRange{suite.currEpoch}
+	epochs := []viewRange{suite.currEpoch}
 	suite.CommitEpochs(epochs...)
 	suite.CreateAndStartEpochLookup()
 	testEpochForView(suite.T(), suite.lookup, epochs...)
@@ -132,7 +132,7 @@ func (suite *EpochLookupSuite) TestEpochForView_Curr() {
 // TestEpochForView_PrevCurr tests constructing and subsequently querying
 // EpochLookup with an initial state of a previous and current epoch.
 func (suite *EpochLookupSuite) TestEpochForView_PrevCurr() {
-	epochs := []epochRange{suite.prevEpoch, suite.currEpoch}
+	epochs := []viewRange{suite.prevEpoch, suite.currEpoch}
 	suite.CommitEpochs(epochs...)
 	suite.CreateAndStartEpochLookup()
 	testEpochForView(suite.T(), suite.lookup, epochs...)
@@ -141,7 +141,7 @@ func (suite *EpochLookupSuite) TestEpochForView_PrevCurr() {
 // TestEpochForView_CurrNext tests constructing and subsequently querying
 // EpochLookup with an initial state of a current and next epoch.
 func (suite *EpochLookupSuite) TestEpochForView_CurrNext() {
-	epochs := []epochRange{suite.currEpoch, suite.nextEpoch}
+	epochs := []viewRange{suite.currEpoch, suite.nextEpoch}
 	suite.CommitEpochs(epochs...)
 	suite.CreateAndStartEpochLookup()
 	testEpochForView(suite.T(), suite.lookup, epochs...)
@@ -150,7 +150,7 @@ func (suite *EpochLookupSuite) TestEpochForView_CurrNext() {
 // TestEpochForView_CurrNextPrev tests constructing and subsequently querying
 // EpochLookup with an initial state of a previous, current, and next epoch.
 func (suite *EpochLookupSuite) TestEpochForView_CurrNextPrev() {
-	epochs := []epochRange{suite.prevEpoch, suite.currEpoch, suite.nextEpoch}
+	epochs := []viewRange{suite.prevEpoch, suite.currEpoch, suite.nextEpoch}
 	suite.CommitEpochs(epochs...)
 	suite.CreateAndStartEpochLookup()
 	testEpochForView(suite.T(), suite.lookup, epochs...)
@@ -162,7 +162,7 @@ func (suite *EpochLookupSuite) TestEpochForView_CurrNextPrev() {
 // in the protocol state.
 func (suite *EpochLookupSuite) TestProtocolEvents_EpochExtended() {
 	// previous and current epochs will be committed
-	epochs := []epochRange{suite.prevEpoch, suite.currEpoch}
+	epochs := []viewRange{suite.prevEpoch, suite.currEpoch}
 	suite.CommitEpochs(suite.prevEpoch, suite.currEpoch)
 
 	suite.CreateAndStartEpochLookup()
@@ -171,7 +171,7 @@ func (suite *EpochLookupSuite) TestProtocolEvents_EpochExtended() {
 		FirstView: suite.currEpoch.finalView + 1,
 		FinalView: suite.currEpoch.finalView + 100,
 	}
-	suite.lookup.EpochExtended(suite.currEpoch.counter, nil, extension)
+	suite.lookup.EpochExtended(suite.currEpoch.epochCounter, nil, extension)
 
 	// wait for the protocol event to be processed (async)
 	assert.Eventually(suite.T(), func() bool {
@@ -184,9 +184,9 @@ func (suite *EpochLookupSuite) TestProtocolEvents_EpochExtended() {
 	testEpochForView(suite.T(), suite.lookup, epochs...)
 
 	// should handle multiple deliveries of the protocol event
-	suite.lookup.EpochExtended(suite.currEpoch.counter, nil, extension)
-	suite.lookup.EpochExtended(suite.currEpoch.counter, nil, extension)
-	suite.lookup.EpochExtended(suite.currEpoch.counter, nil, extension)
+	suite.lookup.EpochExtended(suite.currEpoch.epochCounter, nil, extension)
+	suite.lookup.EpochExtended(suite.currEpoch.epochCounter, nil, extension)
+	suite.lookup.EpochExtended(suite.currEpoch.epochCounter, nil, extension)
 
 	assert.Eventually(suite.T(), func() bool {
 		return len(suite.lookup.epochEvents) == 0
@@ -228,7 +228,7 @@ func (suite *EpochLookupSuite) TestProtocolEvents_EpochExtended_SanityChecks() {
 			assert.Contains(suite.T(), err.Error(), fmt.Sprintf(invalidExtensionFinalView, suite.currEpoch.finalView, extension.FinalView))
 		})
 
-		suite.lookup.EpochExtended(suite.currEpoch.counter, nil, extension)
+		suite.lookup.EpochExtended(suite.currEpoch.epochCounter, nil, extension)
 
 		// wait for the protocol event to be processed (async)
 		assert.Eventually(suite.T(), func() bool {
@@ -244,7 +244,7 @@ func (suite *EpochLookupSuite) TestProtocolEvents_EpochExtended_SanityChecks() {
 		ctx.On("Throw", mock.AnythingOfType("*errors.errorString")).Run(func(args mock.Arguments) {
 			err, ok := args.Get(0).(error)
 			assert.True(suite.T(), ok)
-			assert.Contains(suite.T(), err.Error(), fmt.Sprintf(mismatchEpochCounter, suite.currEpoch.counter, unknownCounter))
+			assert.Contains(suite.T(), err.Error(), fmt.Sprintf(mismatchEpochCounter, suite.currEpoch.epochCounter, unknownCounter))
 		})
 
 		suite.lookup.EpochExtended(unknownCounter, nil, flow.EpochExtension{
@@ -274,7 +274,7 @@ func (suite *EpochLookupSuite) TestProtocolEvents_EpochExtended_SanityChecks() {
 			assert.Contains(suite.T(), err.Error(), fmt.Sprintf(invalidEpochViewSequence, extension.FirstView, suite.currEpoch.finalView))
 		})
 
-		suite.lookup.EpochExtended(suite.currEpoch.counter, nil, extension)
+		suite.lookup.EpochExtended(suite.currEpoch.epochCounter, nil, extension)
 
 		// wait for the protocol event to be processed (async)
 		assert.Eventually(suite.T(), func() bool {
@@ -316,23 +316,23 @@ func (suite *EpochLookupSuite) TestProtocolEvents_CommittedEpoch() {
 // testEpochForView accepts a constructed EpochLookup and state, and
 // validates correctness by issuing various queries, using the input state and
 // epochs as source of truth.
-func testEpochForView(t *testing.T, lookup *EpochLookup, epochs ...epochRange) {
+func testEpochForView(t *testing.T, lookup *EpochLookup, epochs ...viewRange) {
 	t.Run("should be able to query within any committed epoch", func(t *testing.T) {
 		for _, epoch := range epochs {
 			t.Run("first view", func(t *testing.T) {
 				counter, err := lookup.EpochForView(epoch.firstView)
 				assert.NoError(t, err)
-				assert.Equal(t, epoch.counter, counter)
+				assert.Equal(t, epoch.epochCounter, counter)
 			})
 			t.Run("final view", func(t *testing.T) {
 				counter, err := lookup.EpochForView(epoch.finalView)
 				assert.NoError(t, err)
-				assert.Equal(t, epoch.counter, counter)
+				assert.Equal(t, epoch.epochCounter, counter)
 			})
 			t.Run("random view in range", func(t *testing.T) {
 				counter, err := lookup.EpochForView(unittest.Uint64InRange(epoch.firstView, epoch.finalView))
 				assert.NoError(t, err)
-				assert.Equal(t, epoch.counter, counter)
+				assert.Equal(t, epoch.epochCounter, counter)
 			})
 		}
 	})

--- a/module/epochs/epoch_lookup_test.go
+++ b/module/epochs/epoch_lookup_test.go
@@ -353,7 +353,9 @@ func testEpochForView(t *testing.T, lookup *EpochLookup, epochs ...viewRange) {
 	})
 
 	t.Run("should return ErrViewForUnknownEpoch for queries above latest epoch final view", func(t *testing.T) {
-		_, err := lookup.EpochForView(lookup.epochs.latest().finalView + 1)
+		latest, exists := lookup.epochs.latest()
+		assert.True(t, exists)
+		_, err := lookup.EpochForView(latest.finalView + 1)
 		assert.ErrorIs(t, err, model.ErrViewForUnknownEpoch)
 	})
 }

--- a/state/protocol/protocol_state/epochs/identity_ejector.go
+++ b/state/protocol/protocol_state/epochs/identity_ejector.go
@@ -33,12 +33,14 @@ func newEjector() ejector {
 	}
 }
 
-// Eject marks the node as ejected in all tracked identity lists. If it's the first ejection during lifetime of the state machine,
-// EjectIdentity updates the identity table by changing the node's participation status to 'ejected'. If
-// and only if the node is active in the previous or current or next epoch, the node's ejection status is set
-// to true for all occurrences, and we return true.  If `nodeID` is not found, we return false. This method
-// is idempotent and behaves identically for repeated calls with the same `nodeID` (and same internal state).
-// Repeated calls with the same input create minor performance overhead.
+// Eject marks the node as ejected in all tracked identity lists. If and only if the node is active in the previous
+// or current or next epoch, the node's ejection status is set to true for all occurrences, and we return true. If
+// `nodeID` is not found, we return false. This method is idempotent and behaves identically for repeated calls with
+// the same `nodeID`. Repeated calls with the same input create minor performance overhead.
+//
+// If it's the first ejection during the `ejector`s lifetime (i.e. this `ejector` has no previous ejection events
+// memorized), it populates an internal lookup for each `DynamicIdentityList` is tracks. This lazy initialization
+// benefits the vastly common happy path (no ejection events during the ejector's lifetime).
 func (e *ejector) Eject(nodeID flow.Identifier) bool {
 	l := len(e.identityLists)
 	if len(e.ejected) == 0 { // if this is the first ejection sealed in this block, we have to populate the lookup first


### PR DESCRIPTION
for our `EpochLookup` we have introduced the auxiliary component `epochRangeCache`. While the implementation is highly optimized (using an array of value types as opposed to pointers for improved data locality), it leaked implementation details (specifically the concept of zero values representing the "undefined" value). The documentation was hardly clarifying this special meaning of the zero value, and in [some areas was still (incorrectly) talking about nil values](https://github.com/onflow/flow-go/blob/2aeebea1359c9089633de5608fad1405c1adb1c3/module/epochs/epoch_lookup.go#L37-L38). 

This PR:
* cleans up the documentation
* increases encapsulation so that the `EpochLookup` does not need to concern itself with the implementation detail how  `epochRangeCache` represents the undefined entry. For this purpose:
  - I replaced the method [`epochRangeCache.combinedRange`](https://github.com/onflow/flow-go/blob/2aeebea1359c9089633de5608fad1405c1adb1c3/module/epochs/epoch_lookup.go#L79-L94) with `epochRangeCache.cachedEpochs`
  - consolidated and optimized the logic [`EpochLookup.EpochForView`](https://github.com/onflow/flow-go/blob/2aeebea1359c9089633de5608fad1405c1adb1c3/module/epochs/epoch_lookup.go#L238-L269)