### PR TITLE
[EFM] Fix `EpochRecover` processing in EFM

### DIFF
--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -165,26 +165,8 @@ func (m *FallbackStateMachine) ProcessEpochRecover(epochRecover *flow.EpochRecov
 		m.telemetry.OnInvalidServiceEvent(epochRecover.ServiceEvent(), err)
 		return false, nil
 	}
-
-	nextEpochParticipants, err := buildNextEpochActiveParticipants(
-		m.state.CurrentEpoch.ActiveIdentities.Lookup(),
-		m.state.CurrentEpochSetup,
-		&epochRecover.EpochSetup)
-	if err != nil {
-		m.telemetry.OnInvalidServiceEvent(epochRecover.ServiceEvent(), fmt.Errorf("rejecting EpochRecover event: %w", err))
-		return false, nil
-	}
-
 	nextEpoch := m.state.NextEpoch
-	if nextEpoch == nil {
-		// setup next epoch if there is none
-		m.state.NextEpoch = &flow.EpochStateContainer{
-			SetupID:          epochRecover.EpochSetup.ID(),
-			CommitID:         epochRecover.EpochCommit.ID(),
-			ActiveIdentities: nextEpochParticipants,
-			EpochExtensions:  nil,
-		}
-	} else {
+	if nextEpoch != nil {
 		// accept iff the EpochRecover is the same as the one we have already recovered.
 		if nextEpoch.SetupID != epochRecover.EpochSetup.ID() ||
 			nextEpoch.CommitID != epochRecover.EpochCommit.ID() {
@@ -193,7 +175,25 @@ func (m *FallbackStateMachine) ProcessEpochRecover(epochRecover *flow.EpochRecov
 			return false, nil
 		}
 	}
-	err = m.ejector.TrackDynamicIdentityList(m.state.NextEpoch.ActiveIdentities)
+	// m.state.NextEpoch is either nil, or its EpochSetup and EpochCommit are identical to the given `epochRecover`
+
+	// assemble EpochStateContainer for next epoch:
+	nextEpochParticipants, err := buildNextEpochActiveParticipants(
+		m.state.CurrentEpoch.ActiveIdentities.Lookup(),
+		m.state.CurrentEpochSetup,
+		&epochRecover.EpochSetup)
+	if err != nil {
+		m.telemetry.OnInvalidServiceEvent(epochRecover.ServiceEvent(), fmt.Errorf("rejecting EpochRecover event: %w", err))
+		return false, nil
+	}
+	nextEpoch = &flow.EpochStateContainer{
+		SetupID:          epochRecover.EpochSetup.ID(),
+		CommitID:         epochRecover.EpochCommit.ID(),
+		ActiveIdentities: nextEpochParticipants,
+		EpochExtensions:  nil,
+	}
+
+	err = m.ejector.TrackDynamicIdentityList(nextEpoch.ActiveIdentities)
 	if err != nil {
 		if protocol.IsInvalidServiceEventError(err) {
 			m.telemetry.OnInvalidServiceEvent(epochRecover.ServiceEvent(), fmt.Errorf("rejecting EpochRecover event: %w", err))
@@ -202,6 +202,7 @@ func (m *FallbackStateMachine) ProcessEpochRecover(epochRecover *flow.EpochRecov
 		return false, fmt.Errorf("unexpected errors tracking identity list: %w", err)
 	}
 	// if we have processed a valid EpochRecover event, we should exit EFM.
+	m.state.NextEpoch = nextEpoch
 	m.state.EpochFallbackTriggered = false
 	m.telemetry.OnServiceEventProcessed(epochRecover.ServiceEvent())
 	return true, nil


### PR DESCRIPTION
This PR updates how `FallbackStateMachine` processes epoch recover event so the state isn't modified if an invalid event has been supplied. 

Added extended test case to ensure correct behavior.