### PR TITLE
Infer the missing borrow type for storage capabilities

### DIFF
--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/cadence/migrations/capcons"
@@ -370,13 +371,13 @@ func (m *IssueStorageCapConMigration) issueAccountCapabilities(
 		}
 
 		borrowStaticType := capability.BorrowType
-		path := capability.Path.Identifier
 
 		if borrowStaticType == nil {
 			reporter.MissingBorrowType(address, addressPath)
 
 			// If the borrow type is missing, treat it as `AnyStruct` or `AnyResource`.
 			// To determine whether it is a resource, read the target path.
+			path := capability.Path.Identifier
 			value := storageMap.ReadValue(nil, interpreter.StringStorageMapKey(path))
 
 			assumedBorrowType := interpreter.PrimitiveStaticTypeAnyStruct


### PR DESCRIPTION
Instead of skipping the capabilities with missing borrow-type, try to infer it as either `&AnyResource` or `&AnyStruct`, and continue migrating such values.