### PR TITLE
[Cadence 1.0 Migration] Merge and commit changes after issuing cap cons

### DIFF
--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -337,6 +337,27 @@ func (m *IssueStorageCapConMigration) MigrateAccount(
 		m.mapping,
 	)
 
+	// finalize the transaction
+	result, err := migrationRuntime.TransactionState.FinalizeMainTransaction()
+	if err != nil {
+		return fmt.Errorf("failed to finalize main transaction: %w", err)
+	}
+
+	// Merge the changes into the registers
+	expectedAddresses := map[flow.Address]struct{}{
+		flow.Address(address): {},
+	}
+
+	err = registers.ApplyChanges(
+		accountRegisters,
+		result.WriteSet,
+		expectedAddresses,
+		m.log,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to apply changes: %w", err)
+	}
+
 	return nil
 }
 

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -328,14 +328,21 @@ func (m *IssueStorageCapConMigration) MigrateAccount(
 		m.verboseErrorOutput,
 	)
 
+	inter := migrationRuntime.Interpreter
+
 	capcons.IssueAccountCapabilities(
-		migrationRuntime.Interpreter,
+		inter,
 		reporter,
 		address,
 		accountCapabilities,
 		handler,
 		m.mapping,
 	)
+
+	err = migrationRuntime.Storage.NondeterministicCommit(inter, false)
+	if err != nil {
+		return fmt.Errorf("failed to commit changes: %w", err)
+	}
 
 	// finalize the transaction
 	result, err := migrationRuntime.TransactionState.FinalizeMainTransaction()


### PR DESCRIPTION
Fix `IssueStorageCapConMigration`: After issuing the capability controllers, commit the changes to storage, and merge the write set into the migrated registers.

Also, add tests to verify the migrated state. Currently the assertions only assert reports.