### PR TITLE
Update to Cadence v1.0.0-preview.44

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
-	github.com/onflow/flow-go-sdk v1.0.0-preview.46
+	github.com/onflow/flow-go-sdk v1.0.0-preview.47
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2183,8 +2183,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.46 h1:bJRrM1t1xAT/ckvHT3AOmg9W9mljKUIfurSzIiNDNkY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.46/go.mod h1:giVRWZHuXcKbJCB666/cL67l/Z7d3SuH+N/N32lnFDo=
+github.com/onflow/flow-go-sdk v1.0.0-preview.47 h1:vdolgj6nFCR/xPoEOHyYzAg9o9hdXQpPnL7HJPPTXGU=
+github.com/onflow/flow-go-sdk v1.0.0-preview.47/go.mod h1:YAYzmUUytKqri3aMgeKGjvDjvawignNobUI9s2mKdXY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -207,7 +207,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-preview.46 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-preview.47 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v1.2.0 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.5 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2171,8 +2171,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.46 h1:bJRrM1t1xAT/ckvHT3AOmg9W9mljKUIfurSzIiNDNkY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.46/go.mod h1:giVRWZHuXcKbJCB666/cL67l/Z7d3SuH+N/N32lnFDo=
+github.com/onflow/flow-go-sdk v1.0.0-preview.47 h1:vdolgj6nFCR/xPoEOHyYzAg9o9hdXQpPnL7HJPPTXGU=
+github.com/onflow/flow-go-sdk v1.0.0-preview.47/go.mod h1:YAYzmUUytKqri3aMgeKGjvDjvawignNobUI9s2mKdXY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
 	github.com/onflow/flow-emulator v1.0.0-preview.36.0.20240729195722-d4eb1c30eb9f
 	github.com/onflow/flow-go v0.36.8-0.20240729193633-433a32eeb0cd
-	github.com/onflow/flow-go-sdk v1.0.0-preview.46
+	github.com/onflow/flow-go-sdk v1.0.0-preview.47
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/onflow/go-ethereum v1.14.7

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2157,8 +2157,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.46 h1:bJRrM1t1xAT/ckvHT3AOmg9W9mljKUIfurSzIiNDNkY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.46/go.mod h1:giVRWZHuXcKbJCB666/cL67l/Z7d3SuH+N/N32lnFDo=
+github.com/onflow/flow-go-sdk v1.0.0-preview.47 h1:vdolgj6nFCR/xPoEOHyYzAg9o9hdXQpPnL7HJPPTXGU=
+github.com/onflow/flow-go-sdk v1.0.0-preview.47/go.mod h1:YAYzmUUytKqri3aMgeKGjvDjvawignNobUI9s2mKdXY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/flow-go-sdk v1.0.0-preview.47](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.47)
- [onflow/cadence v1.0.0-preview.44](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.44)

