### PR TITLE
[Flow EVM] patch evm debug tracer to collect results and reset internal state after each tx execution

### DIFF
--- a/fvm/evm/debug/tracer.go
+++ b/fvm/evm/debug/tracer.go
@@ -111,7 +111,8 @@ func (t *CallTracer) Collect(txID gethCommon.Hash) {
 				Msg("failed to upload trace results, no more retries")
 			return
 		}
-
+		// remove the result
+		delete(t.resultsByTxID, txID)
 		l.Debug().Msg("evm traces uploaded successfully")
 	}()
 

--- a/fvm/evm/debug/tracer.go
+++ b/fvm/evm/debug/tracer.go
@@ -101,8 +101,7 @@ func (t *CallTracer) Collect(txID gethCommon.Hash) {
 
 		res, found := t.resultsByTxID[txID]
 		if !found {
-			l.Error().Str("txID", txID.Hex()).
-				Msg("trace result not found")
+			l.Error().Msg("trace result not found")
 			return
 		}
 		if err := t.uploader.Upload(TraceID(txID, t.blockID), res); err != nil {

--- a/fvm/evm/debug/tracer_test.go
+++ b/fvm/evm/debug/tracer_test.go
@@ -17,7 +17,7 @@ import (
 
 func Test_CallTracer(t *testing.T) {
 	t.Run("collect traces and upload them", func(t *testing.T) {
-		txID := gethCommon.Hash{0x05}
+		var txID gethCommon.Hash
 		blockID := flow.Identifier{0x01}
 		var res json.RawMessage
 
@@ -42,7 +42,9 @@ func Test_CallTracer(t *testing.T) {
 		// first transaction
 		tr := tracer.TxTracer()
 		require.NotNil(t, tr)
+
 		tx := gethTypes.NewTransaction(nonce, to, amount, 100, big.NewInt(10), data)
+		txID = tx.Hash()
 		tr.OnTxStart(nil, tx, from)
 		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
 		tr.OnEnter(1, byte(vm.ADD), from, to, data, 20, big.NewInt(2))
@@ -53,8 +55,8 @@ func Test_CallTracer(t *testing.T) {
 	})
 
 	t.Run("collect traces and upload them (after a failed transaction)", func(t *testing.T) {
-		txID := gethCommon.Hash{0x05}
 		blockID := flow.Identifier{0x01}
+		var txID gethCommon.Hash
 		var res json.RawMessage
 
 		mockUpload := &testutils.MockUploader{
@@ -75,7 +77,6 @@ func Test_CallTracer(t *testing.T) {
 		data := []byte{0x02, 0x04}
 		amount := big.NewInt(1)
 
-		// first transaction
 		tr := tracer.TxTracer()
 		require.NotNil(t, tr)
 
@@ -85,8 +86,9 @@ func Test_CallTracer(t *testing.T) {
 		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
 		tr.OnEnter(1, byte(vm.ADD), from, to, data, 20, big.NewInt(2))
 
-		// 4th transaction
+		// success
 		tx = gethTypes.NewTransaction(nonce, to, amount, 400, big.NewInt(40), data)
+		txID = tx.Hash()
 		tr.OnTxStart(nil, tx, from)
 		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
 		tr.OnExit(0, []byte{0x02}, 200, nil, false)

--- a/fvm/evm/debug/tracer_test.go
+++ b/fvm/evm/debug/tracer_test.go
@@ -50,17 +50,37 @@ func Test_CallTracer(t *testing.T) {
 		tr.OnExit(0, []byte{0x02}, 200, nil, false)
 		tr.OnTxEnd(&gethTypes.Receipt{TxHash: tx.Hash()}, nil)
 		tracer.Collect(tx.Hash())
+	})
 
-		// second transaction
-		tx = gethTypes.NewTransaction(nonce, to, amount, 200, big.NewInt(20), data)
-		tr.OnTxStart(nil, tx, from)
-		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
-		tr.OnExit(0, []byte{0x02}, 200, nil, false)
-		tr.OnTxEnd(&gethTypes.Receipt{TxHash: tx.Hash()}, nil)
-		tracer.Collect(tx.Hash())
+	t.Run("collect traces and upload them (after a failed transaction)", func(t *testing.T) {
+		txID := gethCommon.Hash{0x05}
+		blockID := flow.Identifier{0x01}
+		var res json.RawMessage
+
+		mockUpload := &testutils.MockUploader{
+			UploadFunc: func(id string, message json.RawMessage) error {
+				require.Equal(t, TraceID(txID, blockID), id)
+				require.Equal(t, res, message)
+				return nil
+			},
+		}
+
+		tracer, err := NewEVMCallTracer(mockUpload, zerolog.Nop())
+		require.NoError(t, err)
+		tracer.WithBlockID(blockID)
+
+		from := gethCommon.HexToAddress("0x01")
+		to := gethCommon.HexToAddress("0x02")
+		nonce := uint64(10)
+		data := []byte{0x02, 0x04}
+		amount := big.NewInt(1)
+
+		// first transaction
+		tr := tracer.TxTracer()
+		require.NotNil(t, tr)
 
 		// failed transaction (no exit and collect call)
-		tx = gethTypes.NewTransaction(nonce, to, amount, 300, big.NewInt(30), data)
+		tx := gethTypes.NewTransaction(nonce, to, amount, 300, big.NewInt(30), data)
 		tr.OnTxStart(nil, tx, from)
 		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
 		tr.OnEnter(1, byte(vm.ADD), from, to, data, 20, big.NewInt(2))

--- a/fvm/evm/debug/tracer_test.go
+++ b/fvm/evm/debug/tracer_test.go
@@ -39,9 +39,9 @@ func Test_CallTracer(t *testing.T) {
 		data := []byte{0x02, 0x04}
 		amount := big.NewInt(1)
 
+		// first transaction
 		tr := tracer.TxTracer()
 		require.NotNil(t, tr)
-
 		tx := gethTypes.NewTransaction(nonce, to, amount, 100, big.NewInt(10), data)
 		tr.OnTxStart(nil, tx, from)
 		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
@@ -49,7 +49,28 @@ func Test_CallTracer(t *testing.T) {
 		tr.OnExit(1, nil, 10, nil, false)
 		tr.OnExit(0, []byte{0x02}, 200, nil, false)
 		tr.OnTxEnd(&gethTypes.Receipt{TxHash: tx.Hash()}, nil)
+		tracer.Collect(tx.Hash())
 
+		// second transaction
+		tx = gethTypes.NewTransaction(nonce, to, amount, 200, big.NewInt(20), data)
+		tr.OnTxStart(nil, tx, from)
+		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
+		tr.OnExit(0, []byte{0x02}, 200, nil, false)
+		tr.OnTxEnd(&gethTypes.Receipt{TxHash: tx.Hash()}, nil)
+		tracer.Collect(tx.Hash())
+
+		// failed transaction (no exit and collect call)
+		tx = gethTypes.NewTransaction(nonce, to, amount, 300, big.NewInt(30), data)
+		tr.OnTxStart(nil, tx, from)
+		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
+		tr.OnEnter(1, byte(vm.ADD), from, to, data, 20, big.NewInt(2))
+
+		// 4th transaction
+		tx = gethTypes.NewTransaction(nonce, to, amount, 400, big.NewInt(40), data)
+		tr.OnTxStart(nil, tx, from)
+		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
+		tr.OnExit(0, []byte{0x02}, 200, nil, false)
+		tr.OnTxEnd(&gethTypes.Receipt{TxHash: tx.Hash()}, nil)
 		tracer.Collect(tx.Hash())
 	})
 

--- a/fvm/evm/debug/tracer_test.go
+++ b/fvm/evm/debug/tracer_test.go
@@ -42,19 +42,15 @@ func Test_CallTracer(t *testing.T) {
 		tr := tracer.TxTracer()
 		require.NotNil(t, tr)
 
-		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
 		tx := gethTypes.NewTransaction(nonce, to, amount, 100, big.NewInt(10), data)
 		tr.OnTxStart(nil, tx, from)
+		tr.OnEnter(0, 0, from, to, []byte{0x01, 0x02}, 10, big.NewInt(1))
 		tr.OnEnter(1, byte(vm.ADD), from, to, data, 20, big.NewInt(2))
 		tr.OnExit(1, nil, 10, nil, false)
-		tr.OnTxEnd(&gethTypes.Receipt{}, nil)
 		tr.OnExit(0, []byte{0x02}, 200, nil, false)
+		tr.OnTxEnd(&gethTypes.Receipt{TxHash: tx.Hash()}, nil)
 
-		res, err = tr.GetResult()
-		require.NoError(t, err)
-		require.NotNil(t, res)
-
-		tracer.Collect(txID)
+		tracer.Collect(tx.Hash())
 	})
 
 	t.Run("collector panic recovery", func(t *testing.T) {

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -182,8 +182,10 @@ func (bl *BlockView) RunTransaction(
 		return nil, err
 	}
 
-	// call tracer
-	if proc.evm.Config.Tracer != nil && proc.evm.Config.Tracer.OnTxEnd != nil {
+	// call tracer on tx end
+	if proc.evm.Config.Tracer != nil &&
+		proc.evm.Config.Tracer.OnTxEnd != nil &&
+		res != nil {
 		proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), res.ValidationError)
 	}
 
@@ -210,7 +212,7 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 			continue
 		}
 
-		// call tracer
+		// call tracer on tx start
 		if proc.evm.Config.Tracer != nil && proc.evm.Config.Tracer.OnTxStart != nil {
 			proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), tx, msg.From)
 		}
@@ -232,7 +234,10 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 		// collect result
 		batchResults[i] = res
 
-		if proc.evm.Config.Tracer != nil && proc.evm.Config.Tracer.OnTxEnd != nil {
+		// call tracer on tx end
+		if proc.evm.Config.Tracer != nil &&
+			proc.evm.Config.Tracer.OnTxEnd != nil &&
+			res != nil {
 			proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), res.ValidationError)
 		}
 	}

--- a/fvm/evm/types/result.go
+++ b/fvm/evm/types/result.go
@@ -139,6 +139,7 @@ func (res *Result) Receipt() *gethTypes.Receipt {
 	}
 
 	receipt := &gethTypes.Receipt{
+		TxHash:            res.TxHash,
 		GasUsed:           res.GasConsumed,
 		CumulativeGasUsed: res.CumulativeGasUsed,
 		Logs:              res.Logs,


### PR DESCRIPTION
The tracer can be used for multiple transactions and later collect results being called. We need to support storing interim results until the collection time. 
Unfortunately, the call tracer is stateful and if not cleaned up could result in bugs. for example, a failed transaction might change the internal state of the call tracer and the next transaction would start from an invalid state. This usually result in an "incorrect number of top-level calls" error. 
This PR updates the tracer to collect and hold on to the tracing results after each transaction execution (onTxEnd) and reset the internal state of the tracer before each transaction execution (onTxStart).
It also makes the trace collection during batchRun function more clear. 