### PR TITLE
[Util] Add a command to print all system addresses

### DIFF
--- a/cmd/util/cmd/root.go
+++ b/cmd/util/cmd/root.go
@@ -34,6 +34,7 @@ import (
 	rollback_executed_height "github.com/onflow/flow-go/cmd/util/cmd/rollback-executed-height/cmd"
 	run_script "github.com/onflow/flow-go/cmd/util/cmd/run-script"
 	"github.com/onflow/flow-go/cmd/util/cmd/snapshot"
+	system_addresses "github.com/onflow/flow-go/cmd/util/cmd/system-addresses"
 	truncate_database "github.com/onflow/flow-go/cmd/util/cmd/truncate-database"
 	"github.com/onflow/flow-go/cmd/util/cmd/version"
 	"github.com/onflow/flow-go/module/profiler"
@@ -114,6 +115,7 @@ func addCommands() {
 	rootCmd.AddCommand(atree_inlined_status.Cmd)
 	rootCmd.AddCommand(find_trie_root.Cmd)
 	rootCmd.AddCommand(run_script.Cmd)
+	rootCmd.AddCommand(system_addresses.Cmd)
 }
 
 func initConfig() {

--- a/cmd/util/cmd/system-addresses/cmd.go
+++ b/cmd/util/cmd/system-addresses/cmd.go
@@ -1,0 +1,62 @@
+package addresses
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/onflow/flow-go/fvm/systemcontracts"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+var (
+	flagChain     string
+	flagSeparator string
+)
+
+var Cmd = &cobra.Command{
+	Use:   "system-addresses",
+	Short: "print addresses of system contracts",
+	Run:   run,
+}
+
+func init() {
+	Cmd.Flags().StringVar(&flagChain, "chain", "", "Chain name")
+	_ = Cmd.MarkFlagRequired("chain")
+
+	Cmd.Flags().StringVar(&flagSeparator, "separator", ",", "Separator to use between addresses")
+}
+
+func run(*cobra.Command, []string) {
+	chainID := flow.ChainID(flagChain)
+	// validate
+	_ = chainID.Chain()
+
+	systemContracts := systemcontracts.SystemContractsForChain(chainID)
+
+	addressSet := map[flow.Address]struct{}{}
+	for _, contract := range systemContracts.All() {
+		addressSet[contract.Address] = struct{}{}
+	}
+
+	addresses := make([]flow.Address, 0, len(addressSet))
+	for address := range addressSet {
+		addresses = append(addresses, address)
+	}
+
+	sort.Slice(addresses, func(i, j int) bool {
+		a := addresses[i]
+		b := addresses[j]
+		return bytes.Compare(a[:], b[:]) < 0
+	})
+
+	for i, address := range addresses {
+		str := address.Hex()
+
+		if i > 0 {
+			print(flagSeparator)
+		}
+		print(str)
+	}
+}


### PR DESCRIPTION
Add a command similar to `addresses`, which prints the addresses of all system accounts, based on the information in the system contracts struct