### PR TITLE
[Access] Reduce logging on some access endpoints

### DIFF
--- a/engine/access/rest/middleware/logging.go
+++ b/engine/access/rest/middleware/logging.go
@@ -23,9 +23,6 @@ func LoggingMiddleware(logger zerolog.Logger) mux.MiddlewareFunc {
 			// continue to the next handler
 			inner.ServeHTTP(respWriter, req)
 			log := logger.Info()
-			if respWriter.statusCode != http.StatusOK {
-				log = logger.Error()
-			}
 			log.Str("method", req.Method).
 				Str("uri", req.RequestURI).
 				Str("client_ip", req.RemoteAddr).

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -198,7 +198,7 @@ func (b *backendScripts) executeScriptLocally(
 			logEvent.Msg("script failed to execute locally")
 
 		default:
-			lg.Error().Err(err).Msg("script execution failed")
+			lg.Debug().Err(err).Msg("script execution failed")
 			b.metrics.ScriptExecutionErrorLocal()
 		}
 


### PR DESCRIPTION
Reduce logs emitted form Access APIs:
* Log local script execution failures at debug level. These are largely errors about unindexed blocks.
* Log REST api errors at info level instead of error