### PR TITLE
[Access] Reduce logging from version control

### DIFF
--- a/engine/common/version/version_control.go
+++ b/engine/common/version/version_control.go
@@ -155,13 +155,10 @@ func (v *VersionControl) initBoundaries(
 
 		if vb == nil {
 			// no version beacon found
-			// this is unexpected on a live network as there should always be at least the
-			// starting version beacon, but not fatal.
-			// It can happen on new or test networks if the node starts before bootstrap is finished.
-			// TODO: remove when we can guarantee that there will always be a version beacon
+			// this is only expected when a node starts up on a network that has never had a version beacon event.
 			v.log.Info().
 				Uint64("height", processedHeight).
-				Msg("No version beacon found for version control")
+				Msg("No initial version beacon found")
 
 			return nil
 		}
@@ -296,7 +293,7 @@ func (v *VersionControl) blockFinalized(
 		if err != nil {
 			v.log.Err(err).
 				Uint64("height", height).
-				Msg("Failed to get highest version beacon for version control")
+				Msg("Failed to get highest version beacon")
 
 			ctx.Throw(
 				fmt.Errorf(
@@ -305,19 +302,16 @@ func (v *VersionControl) blockFinalized(
 			return
 		}
 
+		v.lastProcessedHeight.Store(height)
+
 		if vb == nil {
 			// no version beacon found
-			// this is unexpected as there should always be at least the
-			// starting version beacon, but not fatal.
-			// It can happen if the node starts before bootstrap is finished.
-			// TODO: remove when we can guarantee that there will always be a version beacon
-			v.log.Info().
+			// this is only expected when a node starts up on a network that has never had a version beacon event.
+			v.log.Debug().
 				Uint64("height", height).
-				Msg("No version beacon found for version control")
+				Msg("No version beacon found at height")
 			continue
 		}
-
-		v.lastProcessedHeight.Store(height)
 
 		previousEndHeight := v.endHeight.Load()
 


### PR DESCRIPTION
Devnet51's root protocol state snapshot does not include information about past version beacon events like it's supposed to, so none of the ANs/ENs have events in their DBs. This was causing ANs to log messages at info level for each height. 

The version control also only updated the processed height counter when an event was found causing cascasing log events. This reduces the log level and fixes the counter update