### PR TITLE
[FVM] Update fee related constants

### DIFF
--- a/fvm/environment/meter.go
+++ b/fvm/environment/meter.go
@@ -58,14 +58,15 @@ const (
 )
 
 // MainnetExecutionEffortWeights are the execution effort weights as they are
-// on mainnet from 18.8.2022
+// on mainnet from crescendo spork
 var MainnetExecutionEffortWeights = meter.ExecutionEffortWeights{
-	common.ComputationKindStatement:          1569,
-	common.ComputationKindLoop:               1569,
-	common.ComputationKindFunctionInvocation: 1569,
-	ComputationKindGetValue:                  808,
-	ComputationKindCreateAccount:             2837670,
-	ComputationKindSetValue:                  765,
+	common.ComputationKindStatement:          314,
+	common.ComputationKindLoop:               314,
+	common.ComputationKindFunctionInvocation: 314,
+	ComputationKindGetValue:                  162,
+	ComputationKindCreateAccount:             567534,
+	ComputationKindSetValue:                  153,
+	ComputationKindEVMGasUsage:               13,
 }
 
 type Meter interface {

--- a/model/flow/constants.go
+++ b/model/flow/constants.go
@@ -101,8 +101,10 @@ func paddedDomainTag(s string) [DomainTagLength]byte {
 }
 
 // EstimatedComputationPerMillisecond is the approximate number of computation units that can be performed in a millisecond.
-// this was calibrated during the Variable Transaction Fees: Execution Effort FLIP https://github.com/onflow/flow/pull/753
-const EstimatedComputationPerMillisecond = 9999.0 / 200.0
+// this was calibrated during the Variable Transaction Fees: Execution Effort FLIP https://github.com/onflow/flow/pull/753.
+// Updated after the FLIP:
+// https://github.com/onflow/flips/blob/14c5ec4/governance/20240508-computation-limit-hike.md#flip-267-increasing-the-transaction-computation-limit
+const EstimatedComputationPerMillisecond = 9999.0 / 1000.0
 
 // NormalizedExecutionTimePerComputationUnit returns the normalized time per computation unit
 // If the computation estimation is correct (as per the FLIP https://github.com/onflow/flow/pull/753) the value should be 1.


### PR DESCRIPTION
closes: https://github.com/onflow/flow-go/issues/6346

I also fixed the `MainnetExecutionEffortWeights`. They are used for some tests.

This does not require an HCU