### PR TITLE
[EVM] Add random to block executed event

### DIFF
--- a/fvm/evm/events/events.go
+++ b/fvm/evm/events/events.go
@@ -127,6 +127,7 @@ func (p *blockEvent) ToCadence(chainID flow.ChainID) (cadence.Event, error) {
 		hashToCadenceArrayValue(p.ParentBlockHash),
 		hashToCadenceArrayValue(p.ReceiptRoot),
 		hashToCadenceArrayValue(p.TransactionHashRoot),
+		hashToCadenceArrayValue(p.Random),
 	}).WithType(eventType), nil
 }
 
@@ -139,6 +140,7 @@ type BlockEventPayload struct {
 	ParentBlockHash     gethCommon.Hash `cadence:"parentHash"`
 	ReceiptRoot         gethCommon.Hash `cadence:"receiptRoot"`
 	TransactionHashRoot gethCommon.Hash `cadence:"transactionHashRoot"`
+	Random              gethCommon.Hash `cadence:"random"`
 }
 
 // DecodeBlockEventPayload decodes Cadence event into block event payload.

--- a/fvm/evm/events/events_test.go
+++ b/fvm/evm/events/events_test.go
@@ -34,6 +34,7 @@ func TestEVMBlockExecutedEventCCFEncodingDecoding(t *testing.T) {
 		ReceiptRoot:         gethCommon.Hash{},
 		TotalGasUsed:        15,
 		TransactionHashRoot: gethCommon.HexToHash("0x70b67ce6710355acf8d69b2ea013d34e212bc4824926c5d26f189c1ca9667246"),
+		Random:              gethCommon.HexToHash("0xf223"),
 	}
 
 	event := events.NewBlockEvent(block)
@@ -55,6 +56,7 @@ func TestEVMBlockExecutedEventCCFEncodingDecoding(t *testing.T) {
 	assert.Equal(t, bep.ParentBlockHash, block.ParentBlockHash)
 	assert.Equal(t, bep.ReceiptRoot, block.ReceiptRoot)
 	assert.Equal(t, bep.TransactionHashRoot, block.TransactionHashRoot)
+	assert.Equal(t, bep.Random, block.Random)
 
 	v, err := ccf.Encode(ev)
 	require.NoError(t, err)

--- a/fvm/evm/handler/blockstore.go
+++ b/fvm/evm/handler/blockstore.go
@@ -77,11 +77,18 @@ func (bs *BlockStore) BlockProposal() (*types.BlockProposal, error) {
 	// expect timestamps in unix seconds so we convert here
 	timestamp := uint64(cadenceBlock.Timestamp / int64(time.Second))
 
+	var random gethCommon.Hash
+	err = bs.backend.ReadRandom(random[:])
+	if err != nil {
+		return nil, err
+	}
+
 	blockProposal := types.NewBlockProposal(
 		parentHash,
 		lastExecutedBlock.Height+1,
 		timestamp,
 		lastExecutedBlock.TotalSupply,
+		random,
 	)
 	return blockProposal, nil
 }

--- a/fvm/evm/handler/blockstore.go
+++ b/fvm/evm/handler/blockstore.go
@@ -77,11 +77,8 @@ func (bs *BlockStore) BlockProposal() (*types.BlockProposal, error) {
 	// expect timestamps in unix seconds so we convert here
 	timestamp := uint64(cadenceBlock.Timestamp / int64(time.Second))
 
-	var random gethCommon.Hash
-	err = bs.backend.ReadRandom(random[:])
-	if err != nil {
-		return nil, err
-	}
+	// we use cadence block hash as random value used in prevrando
+	random := gethCommon.Hash(cadenceBlock.Hash)
 
 	blockProposal := types.NewBlockProposal(
 		parentHash,

--- a/fvm/evm/handler/handler.go
+++ b/fvm/evm/handler/handler.go
@@ -507,11 +507,6 @@ func (h *ContractHandler) getBlockContext() (types.BlockContext, error) {
 	if err != nil {
 		return types.BlockContext{}, err
 	}
-	rand := gethCommon.Hash{}
-	err = h.backend.ReadRandom(rand[:])
-	if err != nil {
-		return types.BlockContext{}, err
-	}
 
 	return types.BlockContext{
 		ChainID:                types.EVMChainIDFromFlowChainID(h.flowChainID),
@@ -524,7 +519,7 @@ func (h *ContractHandler) getBlockContext() (types.BlockContext, error) {
 			return hash
 		},
 		ExtraPrecompiledContracts: h.precompiledContracts,
-		Random:                    rand,
+		Random:                    bp.Random,
 		Tracer:                    h.tracer.TxTracer(),
 		TxCountSoFar:              uint(len(bp.TxHashes)),
 		TotalGasUsedSoFar:         bp.TotalGasUsed,

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -34,6 +34,8 @@ contract EVM {
         receiptRoot: [UInt8; 32],
         // root hash of all the transaction hashes
         transactionHashRoot: [UInt8; 32],
+        // random value used for PREVRANDO
+        random: [UInt8; 32]
     )
 
     /// Transaction executed event is emitted every time a transaction

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -46,6 +46,9 @@ type Block struct {
 
 	// stores gas used by all transactions included in the block.
 	TotalGasUsed uint64
+
+	// Random stores a pseud-random value that is used in PREVRANDO.
+	Random gethCommon.Hash
 }
 
 // ToBytes encodes the block into bytes
@@ -199,6 +202,7 @@ func NewBlockProposal(
 	height uint64,
 	timestamp uint64,
 	totalSupply *big.Int,
+	random gethCommon.Hash,
 ) *BlockProposal {
 	return &BlockProposal{
 		Block: Block{
@@ -207,6 +211,7 @@ func NewBlockProposal(
 			Timestamp:       timestamp,
 			TotalSupply:     totalSupply,
 			ReceiptRoot:     gethTypes.EmptyRootHash,
+			Random:          random,
 		},
 		Receipts: make([]LightReceipt, 0),
 		TxHashes: make([]gethCommon.Hash, 0),

--- a/fvm/evm/types/block.go
+++ b/fvm/evm/types/block.go
@@ -116,6 +116,7 @@ func GenesisBlock(chainID flow.ChainID) *Block {
 		ReceiptRoot:         gethTypes.EmptyRootHash,
 		TransactionHashRoot: gethTypes.EmptyRootHash,
 		TotalGasUsed:        0,
+		Random:              gethTypes.EmptyRootHash,
 	}
 }
 

--- a/fvm/evm/types/block_test.go
+++ b/fvm/evm/types/block_test.go
@@ -39,6 +39,7 @@ func Test_BlockHash(t *testing.T) {
 		ReceiptRoot:         gethCommon.Hash{0x2, 0x3, 0x4},
 		TotalGasUsed:        135,
 		TransactionHashRoot: gethCommon.Hash{0x5, 0x6, 0x7},
+		Random:              gethCommon.Hash{0x2, 0x3, 0x4},
 	}
 
 	h1, err := b.Hash()
@@ -54,7 +55,7 @@ func Test_BlockHash(t *testing.T) {
 }
 
 func Test_BlockProposal(t *testing.T) {
-	bp := NewBlockProposal(gethCommon.Hash{1}, 1, 0, nil)
+	bp := NewBlockProposal(gethCommon.Hash{1}, 1, 0, nil, gethCommon.Hash{0x1})
 
 	bp.AppendTransaction(nil)
 	require.Empty(t, bp.TxHashes)


### PR DESCRIPTION
Access to random values is needed to reproduce the state on the clients. 

Right now we don't have access to which random value was used during execution which makes the state recreation impossible.

This PR shares the random value used in the execution to the block event. It also makes sure the same block persists the random value, because since the change that allows multiple transactions in same block, the current logic would return different values for call to prevrando, which is not expected. This change makes the prevrando equal to the cadence block hash, since using read random that uses a PRGs it would produce a different value every time it's called. The cadence block hash should be safe to use as random since it's not known during execution.