### PR TITLE
cruisectl delay implementation bias (fix for deployment branch `v0.37`)

### DIFF
--- a/consensus/hotstuff/eventhandler/event_handler.go
+++ b/consensus/hotstuff/eventhandler/event_handler.go
@@ -71,6 +71,7 @@ type EventHandler struct {
 	// The node's own proposal will be added to Forks _after_ the broadcast the same way as proposals from other nodes.
 	// On the unhappy path, the node's own proposals will be added to Forks along with unfinalized proposals from other nodes.
 	// TODO: use safety rules also for block signing, which produces the same guarantees of not double-proposing without this extra logic
+	//       For further details, see issue https://github.com/onflow/flow-go/issues/6389
 	myLastProposedView uint64
 }
 

--- a/consensus/hotstuff/eventhandler/event_handler.go
+++ b/consensus/hotstuff/eventhandler/event_handler.go
@@ -342,6 +342,10 @@ func (e *EventHandler) broadcastTimeoutObjectIfAuthorized() error {
 //   - after receiving a proposal (but not changing view), if that proposal is referenced by our highest known QC,
 //     and the proposal was previously unknown, then we can propose a block in the current view
 //
+// Enforced INVARIANTS:
+//   - There will at most be `OnOwnProposal` notification emitted for views where this node is the leader, and none
+//     if another node is the leader. This holds irrespective of restarts. Formally, this prevents proposal equivocation.
+//
 // It reads the current view, and generates a proposal if we are the leader.
 // No errors are expected during normal operation.
 func (e *EventHandler) proposeForNewViewIfPrimary() error {

--- a/consensus/hotstuff/eventhandler/event_handler.go
+++ b/consensus/hotstuff/eventhandler/event_handler.go
@@ -44,6 +44,34 @@ type EventHandler struct {
 	committee     hotstuff.Replicas
 	safetyRules   hotstuff.SafetyRules
 	notifier      hotstuff.Consumer
+
+	// myLastProposedView is the latest view that this node has created a proposal for
+	// CAUTION: in-memory only; information will be lost once the node reboots. This is fine for the following reason:
+	//  1. At the moment, the block construction logic persists its blocks in the database, _before_ returning the
+	//     reference to the EventHandler, which subsequently publishes the block (via the `OnOwnProposal` notification).
+	//     Therefore, for each view that this consensus participant published a block for, this block is also in the database.
+	//  2. Before constructing a proposal for view v, the node confirms that there is no block for view v already stored in
+	//     its local Forks, and skips the block production otherwise. When the node boots up, it populates Forks with all
+	//     unfinalized blocks. Hence, we conclude:
+	//     Let v be a view for which this node constructed a proposal _before_ rebooting. Then, after rebooting it will never
+	//     construct another proposal for view v.
+	//  3. What remains is to show that this node will not propose for views which it has previously proposed for without any
+	//     reboots. Conceptually, this is guaranteed by the SafetyRules, but only if voting and signing proposals is _both_
+	//     done by safety rules. Unfortunately, the current implementation signs its own proposals _independently_ of safety rules.
+	//     Hence, we add the following logic:
+	//      - `myLastProposedView` is zero in case this node has not generated any proposal since its last reboot. Then, argument
+	//         2. guarantees that the node will not double-propose.
+	//      - Whenever this node constructed a proposal for view v, it will set `myLastProposedView` to value `v`, _before_
+	//        publishing the proposal (via the `OnOwnProposal` notification).
+	//      - Only if `v < myLastProposedView`, this node will engage its block production logic for view `v`. Therefore, it is
+	//        guaranteed that this node has not generated any proposal for view v since its last reboot.
+	// In summary, argument 2. and 3. guarantee that this node will not double-propose (independently of whether the node
+	// restarted or not). Note that this holds, _without_ the node needing to store newly generated proposals right away in `Forks`.
+	// On the happy path (no restarts), updating `myLastProposedView` will suffice to prevent creating two proposals for the same view.
+	// The node's own proposal will be added to Forks _after_ the broadcast the same way as proposals from other nodes.
+	// On the unhappy path, the node's own proposals will be added to Forks along with unfinalized proposals from other nodes.
+	// TODO: use safety rules also for block signing, which produces the same guarantees of not double-proposing without this extra logic
+	myLastProposedView uint64
 }
 
 var _ hotstuff.EventHandler = (*EventHandler)(nil)
@@ -330,10 +358,23 @@ func (e *EventHandler) proposeForNewViewIfPrimary() error {
 
 	e.notifier.OnCurrentViewDetails(curView, finalizedView, currentLeader)
 
-	// check that I am the primary for this view and that I haven't already proposed; otherwise there is nothing to do
+	// check that I am the primary for this view
 	if e.committee.Self() != currentLeader {
 		return nil
 	}
+
+	// CASE A: Preventing proposal equivocation on the happy path
+	// We will never produce two proposals for the same view, _since_ the last reboot. This is because without a reboot,
+	// we can only proceed once beyond the following lines.
+	if curView <= e.myLastProposedView {
+		log.Debug().Msg("already proposed for current view")
+		return nil
+	}
+	e.myLastProposedView = curView
+
+	// CASE B: Preventing proposal equivocation on the unhappy path
+	// We will never produce a proposal for view v, if we already constructed a proposal for the same view _before_ the most recent reboot.
+	// This is because all unfinalized proposals are added to Forks during the reboot.
 	for _, b := range e.forks.GetBlocksForView(curView) { // on the happy path, this slice is empty
 		if b.ProposerID == e.committee.Self() {
 			log.Debug().Msg("already proposed for current view")
@@ -395,14 +436,6 @@ func (e *EventHandler) proposeForNewViewIfPrimary() error {
 	//   `TargetPublicationTime`. Technically, `TargetPublicationTime` records the publication delay
 	//    relative to its _latest_ call.
 	targetPublicationTime := e.paceMaker.TargetPublicationTime(flowProposal.View, start, flowProposal.ParentID)
-
-	// we want to store created proposal in forks to make sure that we don't create more proposals for
-	// current view. Due to asynchronous nature of our design it's possible that after creating proposal
-	// we will be asked to propose again for same view.
-	err = e.forks.AddValidatedBlock(proposedBlock)
-	if err != nil {
-		return fmt.Errorf("could not add newly created proposal (%v): %w", proposedBlock.BlockID, err)
-	}
 
 	log.Debug().
 		Uint64("block_view", proposedBlock.View).

--- a/consensus/hotstuff/eventhandler/event_handler_test.go
+++ b/consensus/hotstuff/eventhandler/event_handler_test.go
@@ -766,6 +766,8 @@ func (es *EventHandlerSuite) Test100Timeout() {
 
 // TestLeaderBuild100Blocks tests scenario where leader builds 100 proposals one after another
 func (es *EventHandlerSuite) TestLeaderBuild100Blocks() {
+	require.Equal(es.T(), 1, len(es.forks.proposals), "expect Forks to contain only root block")
+
 	// I'm the leader for the first view
 	es.committee.leaders[es.initView] = struct{}{}
 
@@ -805,7 +807,8 @@ func (es *EventHandlerSuite) TestLeaderBuild100Blocks() {
 	}
 
 	require.Equal(es.T(), es.endView, es.paceMaker.CurView(), "incorrect view change")
-	require.Equal(es.T(), totalView, (len(es.forks.proposals)-1)/2)
+	require.Equal(es.T(), totalView+1, len(es.forks.proposals), "expect Forks to contain root block + 100 proposed blocks")
+	es.notifier.AssertExpectations(es.T())
 }
 
 // TestFollowerFollows100Blocks tests scenario where follower receives 100 proposals one after another

--- a/consensus/hotstuff/model/proposal.go
+++ b/consensus/hotstuff/model/proposal.go
@@ -4,7 +4,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// Proposal represent a new proposed block within HotStuff (and thus a
+// Proposal represent a new proposed block within HotStuff (and thus
 // a header in the bigger picture), signed by the proposer.
 type Proposal struct {
 	Block      *Block

--- a/consensus/hotstuff/safety_rules.go
+++ b/consensus/hotstuff/safety_rules.go
@@ -22,6 +22,13 @@ type SafetyData struct {
 
 // SafetyRules enforces all consensus rules that guarantee safety. It produces votes for
 // the given blocks or TimeoutObject for the given views, only if all safety rules are satisfied.
+// In particular, SafetyRules guarantees a foundational security theorem for HotStuff (incl.
+// the DiemBFT / Jolteon variant), which we utilize also outside of consensus (e.g. queuing pending
+// blocks for execution, verification, sealing etc):
+//
+//	THEOREM: For each view, there can be at most 1 certified block.
+//
+// Implementations are generally *not* concurrency safe.
 type SafetyRules interface {
 	// ProduceVote takes a block proposal and current view, and decides whether to vote for the block.
 	// Voting is deterministic meaning voting for same proposal will always result in the same vote.


### PR DESCRIPTION
this PR contains a temporary solution for the implementation bias observed for Cruise Control on Testnet. 
* The issue was first reported here: https://flow-foundation.slack.com/archives/C071612SJJE/p1723722918506329

This code targets the crescendo deployment branch `v0.37`. This affects only testnet (and not in a critical manner). Fix if fully downwards compatible. Hence, this can be rolled out as part of any future release to testnet and mainnet. 

## Intuition behind the changes: 

- The call to [`forks.AddValidatedBlock` emits the `OnBlockIncorporated` notification](https://github.com/onflow/flow-go/blob/d9f7522d6c502d7e148dab69c926279202677cf8/consensus/hotstuff/forks/forks.go#L261) for `block` with view $v$, which the `BlockTimeController` uses as [its starting point for the view](https://github.com/onflow/flow-go/blob/d9f7522d6c502d7e148dab69c926279202677cf8/consensus/hotstuff/cruisectl/block_time_controller.go#L476-L481).   
- While the [`MessageHub` delays block publication](https://github.com/onflow/flow-go/blob/d9f7522d6c502d7e148dab69c926279202677cf8/engine/consensus/message_hub/message_hub.go#L433-L437), this delay is only observed by nodes other than the primary.
* For the primary itself, the [`EventHandler` adds its own proposal right away](https://github.com/onflow/flow-go/blob/d9f7522d6c502d7e148dab69c926279202677cf8/consensus/hotstuff/eventhandler/event_handler.go#L390-L417) to `Forks`: https://github.com/onflow/flow-go/blob/d9f7522d6c502d7e148dab69c926279202677cf8/consensus/hotstuff/eventhandler/event_handler.go#L390-L417
  Hence, the proposer itself observes the `OnBlockIncorporated` for its own block much earlier. 
* So in the case, where node `A` is the **primary for two _consecutive_ views**:
   - the delay for the later proposal is computed relative to the _construction time_ of the parent
   - however, the delay for the later proposal should be computed relative to the _publication time_ of the parent
   - As the _construction time_ of the parent is about 450ms before the _publication time_, the controller's limits of authority restrict the largest possible delay. Statistically this bias affects 1/n of the views, with `n` the number of consensus nodes. On testnet, the bias is expected to be a lot more severe (n=7) compared to mainnet (n=100).

--- 

For an extended version of this fix for `master`, please see  [PR  #6379](https://github.com/onflow/flow-go/pull/6379)

   