### PR TITLE
Update to Cadence v1.0.0-preview.50

### DIFF
--- a/cmd/util/ledger/util/migration_runtime_interface.go
+++ b/cmd/util/ledger/util/migration_runtime_interface.go
@@ -175,8 +175,8 @@ func (m *MigrationRuntimeInterface) GetOrLoadProgram(
 func (m *MigrationRuntimeInterface) RecoverProgram(
 	program *ast.Program,
 	location common.Location,
-) (*ast.Program, error) {
-	return environment.RecoverProgram(nil, m.chainID, program, location)
+) ([]byte, error) {
+	return environment.RecoverProgram(m.chainID, program, location)
 }
 
 type migrationTransactionPreparer struct {

--- a/fvm/environment/facade_env.go
+++ b/fvm/environment/facade_env.go
@@ -336,9 +336,8 @@ func (*facadeEnvironment) GetInterpreterSharedState() *interpreter.SharedState {
 	return nil
 }
 
-func (env *facadeEnvironment) RecoverProgram(program *ast.Program, location common.Location) (*ast.Program, error) {
+func (env *facadeEnvironment) RecoverProgram(program *ast.Program, location common.Location) ([]byte, error) {
 	return RecoverProgram(
-		env,
 		env.chain.ChainID(),
 		program,
 		location,

--- a/fvm/environment/mock/environment.go
+++ b/fvm/environment/mock/environment.go
@@ -1407,23 +1407,23 @@ func (_m *Environment) RecordTrace(operation string, location common.Location, d
 }
 
 // RecoverProgram provides a mock function with given fields: program, location
-func (_m *Environment) RecoverProgram(program *ast.Program, location common.Location) (*ast.Program, error) {
+func (_m *Environment) RecoverProgram(program *ast.Program, location common.Location) ([]byte, error) {
 	ret := _m.Called(program, location)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RecoverProgram")
 	}
 
-	var r0 *ast.Program
+	var r0 []byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ast.Program, common.Location) (*ast.Program, error)); ok {
+	if rf, ok := ret.Get(0).(func(*ast.Program, common.Location) ([]byte, error)); ok {
 		return rf(program, location)
 	}
-	if rf, ok := ret.Get(0).(func(*ast.Program, common.Location) *ast.Program); ok {
+	if rf, ok := ret.Get(0).(func(*ast.Program, common.Location) []byte); ok {
 		r0 = rf(program, location)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*ast.Program)
+			r0 = ret.Get(0).([]byte)
 		}
 	}
 

--- a/fvm/environment/program_recovery.go
+++ b/fvm/environment/program_recovery.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/parser"
 	"github.com/onflow/cadence/runtime/sema"
 
 	"github.com/onflow/flow-go/fvm/systemcontracts"
@@ -13,12 +12,11 @@ import (
 )
 
 func RecoverProgram(
-	memoryGauge common.MemoryGauge,
 	chainID flow.ChainID,
 	program *ast.Program,
 	location common.Location,
 ) (
-	*ast.Program,
+	[]byte,
 	error,
 ) {
 	addressLocation, ok := location.(common.AddressLocation)
@@ -36,9 +34,7 @@ func RecoverProgram(
 
 	contractName := addressLocation.Name
 
-	code := RecoveredFungibleTokenCode(fungibleTokenAddress, contractName)
-
-	return parser.ParseProgram(memoryGauge, []byte(code), parser.Config{})
+	return []byte(RecoveredFungibleTokenCode(fungibleTokenAddress, contractName)), nil
 }
 
 func RecoveredFungibleTokenCode(fungibleTokenAddress common.Address, contractName string) string {

--- a/go.mod
+++ b/go.mod
@@ -48,12 +48,12 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/onflow/atree v0.8.0-rc.6
-	github.com/onflow/cadence v1.0.0-preview.49
+	github.com/onflow/cadence v1.0.0-preview.50
 	github.com/onflow/crypto v0.25.2
 	github.com/onflow/flow v0.3.4
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
-	github.com/onflow/flow-go-sdk v1.0.0-preview.51
+	github.com/onflow/flow-go-sdk v1.0.0-preview.53
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2168,8 +2168,8 @@ github.com/onflow/atree v0.8.0-rc.6/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483 h1:LpiQhTAfM9CAmNVEs0n//cBBgCg+vJSiIxTHYUklZ84=
 github.com/onflow/boxo v0.0.0-20240201202436-f2477b92f483/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.49 h1:MXy6qAtFyRSnqSVKpDkh2J1sb2JEryJoYy/5qsaixlw=
-github.com/onflow/cadence v1.0.0-preview.49/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
+github.com/onflow/cadence v1.0.0-preview.50 h1:sEfUOG7BXzEqPzB68yZZrG/lkBmHf/o0poYDCY18x3A=
+github.com/onflow/cadence v1.0.0-preview.50/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.2 h1:GjHunqVt+vPcdqhxxhAXiMIF3YiLX7gTuTR5O+VG2ns=
 github.com/onflow/crypto v0.25.2/go.mod h1:fY7eLqUdMKV8EGOw301unP8h7PvLVy8/6gVR++/g0BY=
@@ -2184,8 +2184,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51 h1:rsvjyEdiot4oKwx2YsEqV2hsXqDrakuVmSUexsU/lSI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51/go.mod h1:yXinctVJY1VlpQaJhkCUMiC5lvv2kYCCMdMo+FdSV5A=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53 h1:hF6X5b9gVQoc/wUa5JTcYU6tw1B7aW71XDdfsFhU5Gw=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53/go.mod h1:FtsoOHw5RNmMMwC7jI1hc99ZVJWhnm/gE3OMvFaZjyg=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/insecure/go.mod
+++ b/insecure/go.mod
@@ -202,12 +202,12 @@ require (
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onflow/atree v0.8.0-rc.6 // indirect
-	github.com/onflow/cadence v1.0.0-preview.49 // indirect
+	github.com/onflow/cadence v1.0.0-preview.50 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1 // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v1.0.0 // indirect
 	github.com/onflow/flow-ft/lib/go/templates v1.0.0 // indirect
-	github.com/onflow/flow-go-sdk v1.0.0-preview.51 // indirect
+	github.com/onflow/flow-go-sdk v1.0.0-preview.53 // indirect
 	github.com/onflow/flow-nft/lib/go/contracts v1.2.1 // indirect
 	github.com/onflow/flow-nft/lib/go/templates v1.2.0 // indirect
 	github.com/onflow/flow/protobuf/go/flow v0.4.5 // indirect

--- a/insecure/go.sum
+++ b/insecure/go.sum
@@ -2158,8 +2158,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.6 h1:GWgaylK24b5ta2Hq+TvyOF7X5tZLiLzMMn7lEt59fsA=
 github.com/onflow/atree v0.8.0-rc.6/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.49 h1:MXy6qAtFyRSnqSVKpDkh2J1sb2JEryJoYy/5qsaixlw=
-github.com/onflow/cadence v1.0.0-preview.49/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
+github.com/onflow/cadence v1.0.0-preview.50 h1:sEfUOG7BXzEqPzB68yZZrG/lkBmHf/o0poYDCY18x3A=
+github.com/onflow/cadence v1.0.0-preview.50/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.2 h1:GjHunqVt+vPcdqhxxhAXiMIF3YiLX7gTuTR5O+VG2ns=
 github.com/onflow/crypto v0.25.2/go.mod h1:fY7eLqUdMKV8EGOw301unP8h7PvLVy8/6gVR++/g0BY=
@@ -2172,8 +2172,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51 h1:rsvjyEdiot4oKwx2YsEqV2hsXqDrakuVmSUexsU/lSI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51/go.mod h1:yXinctVJY1VlpQaJhkCUMiC5lvv2kYCCMdMo+FdSV5A=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53 h1:hF6X5b9gVQoc/wUa5JTcYU6tw1B7aW71XDdfsFhU5Gw=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53/go.mod h1:FtsoOHw5RNmMMwC7jI1hc99ZVJWhnm/gE3OMvFaZjyg=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -20,13 +20,13 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/ipfs/go-ds-pebble v0.3.1
 	github.com/libp2p/go-libp2p v0.32.2
-	github.com/onflow/cadence v1.0.0-preview.49
+	github.com/onflow/cadence v1.0.0-preview.50
 	github.com/onflow/crypto v0.25.2
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.3.1
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.3.1
 	github.com/onflow/flow-emulator v1.0.0-preview.36.0.20240729195722-d4eb1c30eb9f
 	github.com/onflow/flow-go v0.36.8-0.20240729193633-433a32eeb0cd
-	github.com/onflow/flow-go-sdk v1.0.0-preview.51
+	github.com/onflow/flow-go-sdk v1.0.0-preview.53
 	github.com/onflow/flow-go/insecure v0.0.0-00010101000000-000000000000
 	github.com/onflow/flow/protobuf/go/flow v0.4.5
 	github.com/onflow/go-ethereum v1.14.7

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -2142,8 +2142,8 @@ github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs
 github.com/onflow/atree v0.8.0-rc.6 h1:GWgaylK24b5ta2Hq+TvyOF7X5tZLiLzMMn7lEt59fsA=
 github.com/onflow/atree v0.8.0-rc.6/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
 github.com/onflow/cadence v1.0.0-M3/go.mod h1:odXGZZ/wGNA5mwT8bC9v8u8EXACHllB2ABSZK65TGL8=
-github.com/onflow/cadence v1.0.0-preview.49 h1:MXy6qAtFyRSnqSVKpDkh2J1sb2JEryJoYy/5qsaixlw=
-github.com/onflow/cadence v1.0.0-preview.49/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
+github.com/onflow/cadence v1.0.0-preview.50 h1:sEfUOG7BXzEqPzB68yZZrG/lkBmHf/o0poYDCY18x3A=
+github.com/onflow/cadence v1.0.0-preview.50/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
 github.com/onflow/crypto v0.25.2 h1:GjHunqVt+vPcdqhxxhAXiMIF3YiLX7gTuTR5O+VG2ns=
 github.com/onflow/crypto v0.25.2/go.mod h1:fY7eLqUdMKV8EGOw301unP8h7PvLVy8/6gVR++/g0BY=
@@ -2158,8 +2158,8 @@ github.com/onflow/flow-ft/lib/go/contracts v1.0.0/go.mod h1:PwsL8fC81cjnUnTfmyL/
 github.com/onflow/flow-ft/lib/go/templates v1.0.0 h1:6cMS/lUJJ17HjKBfMO/eh0GGvnpElPgBXx7h5aoWJhs=
 github.com/onflow/flow-ft/lib/go/templates v1.0.0/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51 h1:rsvjyEdiot4oKwx2YsEqV2hsXqDrakuVmSUexsU/lSI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51/go.mod h1:yXinctVJY1VlpQaJhkCUMiC5lvv2kYCCMdMo+FdSV5A=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53 h1:hF6X5b9gVQoc/wUa5JTcYU6tw1B7aW71XDdfsFhU5Gw=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53/go.mod h1:FtsoOHw5RNmMMwC7jI1hc99ZVJWhnm/gE3OMvFaZjyg=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1 h1:woAAS5z651sDpi7ihAHll8NvRS9uFXIXkL6xR+bKFZY=
 github.com/onflow/flow-nft/lib/go/contracts v1.2.1/go.mod h1:2gpbza+uzs1k7x31hkpBPlggIRkI53Suo0n2AyA2HcE=
 github.com/onflow/flow-nft/lib/go/templates v1.2.0 h1:JSQyh9rg0RC+D1930BiRXN8lrtMs+ubVMK6aQPon6Yc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/flow-go-sdk v1.0.0-preview.53](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.53)
- [onflow/cadence v1.0.0-preview.50](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.50)

