### PR TITLE
[EVM] Split contract implementation into separate package

### DIFF
--- a/fvm/evm/evm.go
+++ b/fvm/evm/evm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/debug"
 	evm "github.com/onflow/flow-go/fvm/evm/emulator"
 	"github.com/onflow/flow-go/fvm/evm/handler"
+	"github.com/onflow/flow-go/fvm/evm/impl"
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	"github.com/onflow/flow-go/fvm/systemcontracts"
 	"github.com/onflow/flow-go/model/flow"
@@ -56,9 +57,11 @@ func SetupEnvironment(
 		tracer.WithBlockID(flow.Identifier(block.Hash))
 	}
 
+	evmContractAddress := ContractAccountAddress(chainID)
+
 	contractHandler := handler.NewContractHandler(
 		chainID,
-		ContractAccountAddress(chainID),
+		evmContractAddress,
 		common.Address(flowTokenAddress),
 		randomBeaconAddress,
 		blockStore,
@@ -68,10 +71,16 @@ func SetupEnvironment(
 		tracer,
 	)
 
+	internalEVMContractValue := impl.NewInternalEVMContractValue(
+		nil,
+		contractHandler,
+		common.Address(evmContractAddress),
+	)
+
 	stdlib.SetupEnvironment(
 		runtimeEnv,
-		contractHandler,
-		ContractAccountAddress(chainID),
+		internalEVMContractValue,
+		evmContractAddress,
 	)
 
 	return nil

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onflow/flow-go/fvm/evm"
 	"github.com/onflow/flow-go/fvm/evm/emulator"
 	"github.com/onflow/flow-go/fvm/evm/events"
+	"github.com/onflow/flow-go/fvm/evm/impl"
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	"github.com/onflow/flow-go/fvm/evm/testutils"
 	. "github.com/onflow/flow-go/fvm/evm/testutils"
@@ -195,7 +196,7 @@ func TestEVMRun(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -307,7 +308,7 @@ func TestEVMRun(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -574,7 +575,7 @@ func TestEVMBatchRun(t *testing.T) {
 
 				// make sure the retrieved value is the same as the last value
 				// that was stored by transaction batch
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -714,7 +715,7 @@ func TestEVMBatchRun(t *testing.T) {
 
 				// make sure the retrieved value is the same as the last value
 				// that was stored by transaction batch
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -858,7 +859,7 @@ func TestEVMBatchRun(t *testing.T) {
 
 				// make sure the retrieved value is the same as the last value
 				// that was stored by transaction batch
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
 				require.Equal(t, types.StatusSuccessful, res.Status)
@@ -922,7 +923,7 @@ func TestEVMBlockData(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, output.Err)
 
-			res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+			res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 			require.NoError(t, err)
 			require.Equal(t, types.StatusSuccessful, res.Status)
 			require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -1372,7 +1373,7 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -1428,7 +1429,7 @@ func TestDryRun(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, output.Err)
 
-		result, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+		result, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 		require.NoError(t, err)
 		return result
 	}
@@ -1541,7 +1542,7 @@ func TestDryRun(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -1675,7 +1676,7 @@ func TestDryRun(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -1807,7 +1808,7 @@ func TestDryRun(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				//require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
@@ -1891,7 +1892,7 @@ func TestDryRun(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
-				res, err := stdlib.ResultSummaryFromEVMResultValue(output.Value)
+				res, err := impl.ResultSummaryFromEVMResultValue(output.Value)
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)

--- a/fvm/evm/impl/abi.go
+++ b/fvm/evm/impl/abi.go
@@ -1,0 +1,862 @@
+package impl
+
+import (
+	"math"
+	"math/big"
+	"reflect"
+	"strings"
+
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/interpreter"
+	gethABI "github.com/onflow/go-ethereum/accounts/abi"
+	gethCommon "github.com/onflow/go-ethereum/common"
+
+	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/evm/stdlib"
+	"github.com/onflow/flow-go/fvm/evm/types"
+)
+
+const abiEncodingByteSize = 32
+
+// abiEncodingError
+type abiEncodingError struct {
+	Type interpreter.StaticType
+}
+
+var _ errors.UserError = abiEncodingError{}
+
+func (abiEncodingError) IsUserError() {}
+
+func (e abiEncodingError) Error() string {
+	var b strings.Builder
+	b.WriteString("failed to ABI encode value")
+
+	ty := e.Type
+	if ty != nil {
+		b.WriteString(" of type ")
+		b.WriteString(ty.String())
+	}
+
+	return b.String()
+}
+
+// abiDecodingError
+type abiDecodingError struct {
+	Type    interpreter.StaticType
+	Message string
+}
+
+var _ errors.UserError = abiDecodingError{}
+
+func (abiDecodingError) IsUserError() {}
+
+func (e abiDecodingError) Error() string {
+	var b strings.Builder
+	b.WriteString("failed to ABI decode data")
+
+	ty := e.Type
+	if ty != nil {
+		b.WriteString(" with type ")
+		b.WriteString(ty.String())
+	}
+
+	message := e.Message
+	if message != "" {
+		b.WriteString(": ")
+		b.WriteString(message)
+	}
+
+	return b.String()
+}
+
+func reportABIEncodingComputation(
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	values *interpreter.ArrayValue,
+	evmAddressTypeID common.TypeID,
+	reportComputation func(intensity uint),
+) {
+	values.Iterate(
+		inter,
+		func(element interpreter.Value) (resume bool) {
+			switch value := element.(type) {
+			case *interpreter.StringValue:
+				// Dynamic variables, such as strings, are encoded
+				// in 2+ chunks of 32 bytes. The first chunk contains
+				// the index where information for the string begin,
+				// the second chunk contains the number of bytes the
+				// string occupies, and the third chunk contains the
+				// value of the string itself.
+				computation := uint(2 * abiEncodingByteSize)
+				stringLength := len(value.Str)
+				chunks := math.Ceil(float64(stringLength) / float64(abiEncodingByteSize))
+				computation += uint(chunks * abiEncodingByteSize)
+				reportComputation(computation)
+
+			case interpreter.BoolValue,
+				interpreter.UInt8Value,
+				interpreter.UInt16Value,
+				interpreter.UInt32Value,
+				interpreter.UInt64Value,
+				interpreter.UInt128Value,
+				interpreter.UInt256Value,
+				interpreter.Int8Value,
+				interpreter.Int16Value,
+				interpreter.Int32Value,
+				interpreter.Int64Value,
+				interpreter.Int128Value,
+				interpreter.Int256Value:
+
+				// Numeric and bool variables are also static variables
+				// with a fixed size of 32 bytes.
+				reportComputation(abiEncodingByteSize)
+
+			case *interpreter.CompositeValue:
+				if value.TypeID() == evmAddressTypeID {
+					// EVM addresses are static variables with a fixed
+					// size of 32 bytes.
+					reportComputation(abiEncodingByteSize)
+				} else {
+					panic(abiEncodingError{
+						Type: value.StaticType(inter),
+					})
+				}
+			case *interpreter.ArrayValue:
+				// Dynamic variables, such as arrays & slices, are encoded
+				// in 2+ chunks of 32 bytes. The first chunk contains
+				// the index where information for the array begin,
+				// the second chunk contains the number of bytes the
+				// array occupies, and the third chunk contains the
+				// values of the array itself.
+				computation := uint(2 * abiEncodingByteSize)
+				reportComputation(computation)
+				reportABIEncodingComputation(
+					inter,
+					locationRange,
+					value,
+					evmAddressTypeID,
+					reportComputation,
+				)
+
+			default:
+				panic(abiEncodingError{
+					Type: element.StaticType(inter),
+				})
+			}
+
+			// continue iteration
+			return true
+		},
+		false,
+		locationRange,
+	)
+}
+
+func newInternalEVMTypeEncodeABIFunction(
+	gauge common.MemoryGauge,
+	location common.AddressLocation,
+) *interpreter.HostFunctionValue {
+
+	evmAddressTypeID := location.TypeID(gauge, stdlib.EVMAddressTypeQualifiedIdentifier)
+
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeEncodeABIFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get `values` argument
+
+			valuesArray, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			reportABIEncodingComputation(
+				inter,
+				locationRange,
+				valuesArray,
+				evmAddressTypeID,
+				func(intensity uint) {
+					inter.ReportComputation(environment.ComputationKindEVMEncodeABI, intensity)
+				},
+			)
+
+			size := valuesArray.Count()
+
+			values := make([]any, 0, size)
+			arguments := make(gethABI.Arguments, 0, size)
+
+			valuesArray.Iterate(
+				inter,
+				func(element interpreter.Value) (resume bool) {
+					value, ty, err := encodeABI(
+						inter,
+						locationRange,
+						element,
+						element.StaticType(inter),
+						evmAddressTypeID,
+					)
+					if err != nil {
+						panic(err)
+					}
+
+					values = append(values, value)
+					arguments = append(arguments, gethABI.Argument{Type: ty})
+
+					// continue iteration
+					return true
+				},
+				false,
+				locationRange,
+			)
+
+			encodedValues, err := arguments.Pack(values...)
+			if err != nil {
+				panic(abiEncodingError{})
+			}
+
+			return interpreter.ByteSliceToByteArrayValue(inter, encodedValues)
+		},
+	)
+}
+
+var gethTypeString = gethABI.Type{T: gethABI.StringTy}
+
+var gethTypeBool = gethABI.Type{T: gethABI.BoolTy}
+
+var gethTypeUint8 = gethABI.Type{T: gethABI.UintTy, Size: 8}
+
+var gethTypeUint16 = gethABI.Type{T: gethABI.UintTy, Size: 16}
+
+var gethTypeUint32 = gethABI.Type{T: gethABI.UintTy, Size: 32}
+
+var gethTypeUint64 = gethABI.Type{T: gethABI.UintTy, Size: 64}
+
+var gethTypeUint128 = gethABI.Type{T: gethABI.UintTy, Size: 128}
+
+var gethTypeUint256 = gethABI.Type{T: gethABI.UintTy, Size: 256}
+
+var gethTypeInt8 = gethABI.Type{T: gethABI.IntTy, Size: 8}
+
+var gethTypeInt16 = gethABI.Type{T: gethABI.IntTy, Size: 16}
+
+var gethTypeInt32 = gethABI.Type{T: gethABI.IntTy, Size: 32}
+
+var gethTypeInt64 = gethABI.Type{T: gethABI.IntTy, Size: 64}
+
+var gethTypeInt128 = gethABI.Type{T: gethABI.IntTy, Size: 128}
+
+var gethTypeInt256 = gethABI.Type{T: gethABI.IntTy, Size: 256}
+
+var gethTypeAddress = gethABI.Type{Size: 20, T: gethABI.AddressTy}
+
+func gethABIType(staticType interpreter.StaticType, evmAddressTypeID common.TypeID) (gethABI.Type, bool) {
+	switch staticType {
+	case interpreter.PrimitiveStaticTypeString:
+		return gethTypeString, true
+	case interpreter.PrimitiveStaticTypeBool:
+		return gethTypeBool, true
+	case interpreter.PrimitiveStaticTypeUInt8:
+		return gethTypeUint8, true
+	case interpreter.PrimitiveStaticTypeUInt16:
+		return gethTypeUint16, true
+	case interpreter.PrimitiveStaticTypeUInt32:
+		return gethTypeUint32, true
+	case interpreter.PrimitiveStaticTypeUInt64:
+		return gethTypeUint64, true
+	case interpreter.PrimitiveStaticTypeUInt128:
+		return gethTypeUint128, true
+	case interpreter.PrimitiveStaticTypeUInt256:
+		return gethTypeUint256, true
+	case interpreter.PrimitiveStaticTypeInt8:
+		return gethTypeInt8, true
+	case interpreter.PrimitiveStaticTypeInt16:
+		return gethTypeInt16, true
+	case interpreter.PrimitiveStaticTypeInt32:
+		return gethTypeInt32, true
+	case interpreter.PrimitiveStaticTypeInt64:
+		return gethTypeInt64, true
+	case interpreter.PrimitiveStaticTypeInt128:
+		return gethTypeInt128, true
+	case interpreter.PrimitiveStaticTypeInt256:
+		return gethTypeInt256, true
+	case interpreter.PrimitiveStaticTypeAddress:
+		return gethTypeAddress, true
+	}
+
+	switch staticType := staticType.(type) {
+	case *interpreter.CompositeStaticType:
+		if staticType.TypeID != evmAddressTypeID {
+			break
+		}
+
+		return gethTypeAddress, true
+
+	case *interpreter.ConstantSizedStaticType:
+		elementGethABIType, ok := gethABIType(
+			staticType.ElementType(),
+			evmAddressTypeID,
+		)
+		if !ok {
+			break
+		}
+
+		return gethABI.Type{
+			T:    gethABI.ArrayTy,
+			Elem: &elementGethABIType,
+			Size: int(staticType.Size),
+		}, true
+
+	case *interpreter.VariableSizedStaticType:
+		elementGethABIType, ok := gethABIType(
+			staticType.ElementType(),
+			evmAddressTypeID,
+		)
+		if !ok {
+			break
+		}
+
+		return gethABI.Type{
+			T:    gethABI.SliceTy,
+			Elem: &elementGethABIType,
+		}, true
+
+	}
+
+	return gethABI.Type{}, false
+}
+
+func goType(
+	staticType interpreter.StaticType,
+	evmAddressTypeID common.TypeID,
+) (reflect.Type, bool) {
+	switch staticType {
+	case interpreter.PrimitiveStaticTypeString:
+		return reflect.TypeOf(""), true
+	case interpreter.PrimitiveStaticTypeBool:
+		return reflect.TypeOf(true), true
+	case interpreter.PrimitiveStaticTypeUInt8:
+		return reflect.TypeOf(uint8(0)), true
+	case interpreter.PrimitiveStaticTypeUInt16:
+		return reflect.TypeOf(uint16(0)), true
+	case interpreter.PrimitiveStaticTypeUInt32:
+		return reflect.TypeOf(uint32(0)), true
+	case interpreter.PrimitiveStaticTypeUInt64:
+		return reflect.TypeOf(uint64(0)), true
+	case interpreter.PrimitiveStaticTypeUInt128:
+		return reflect.TypeOf((*big.Int)(nil)), true
+	case interpreter.PrimitiveStaticTypeUInt256:
+		return reflect.TypeOf((*big.Int)(nil)), true
+	case interpreter.PrimitiveStaticTypeInt8:
+		return reflect.TypeOf(int8(0)), true
+	case interpreter.PrimitiveStaticTypeInt16:
+		return reflect.TypeOf(int16(0)), true
+	case interpreter.PrimitiveStaticTypeInt32:
+		return reflect.TypeOf(int32(0)), true
+	case interpreter.PrimitiveStaticTypeInt64:
+		return reflect.TypeOf(int64(0)), true
+	case interpreter.PrimitiveStaticTypeInt128:
+		return reflect.TypeOf((*big.Int)(nil)), true
+	case interpreter.PrimitiveStaticTypeInt256:
+		return reflect.TypeOf((*big.Int)(nil)), true
+	case interpreter.PrimitiveStaticTypeAddress:
+		return reflect.TypeOf((*big.Int)(nil)), true
+	}
+
+	switch staticType := staticType.(type) {
+	case *interpreter.ConstantSizedStaticType:
+		elementType, ok := goType(staticType.ElementType(), evmAddressTypeID)
+		if !ok {
+			break
+		}
+
+		return reflect.ArrayOf(int(staticType.Size), elementType), true
+
+	case *interpreter.VariableSizedStaticType:
+		elementType, ok := goType(staticType.ElementType(), evmAddressTypeID)
+		if !ok {
+			break
+		}
+
+		return reflect.SliceOf(elementType), true
+	}
+
+	if staticType.ID() == evmAddressTypeID {
+		return reflect.TypeOf(gethCommon.Address{}), true
+	}
+
+	return nil, false
+}
+
+func encodeABI(
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	value interpreter.Value,
+	staticType interpreter.StaticType,
+	evmAddressTypeID common.TypeID,
+) (
+	any,
+	gethABI.Type,
+	error,
+) {
+
+	switch value := value.(type) {
+	case *interpreter.StringValue:
+		if staticType == interpreter.PrimitiveStaticTypeString {
+			return value.Str, gethTypeString, nil
+		}
+
+	case interpreter.BoolValue:
+		if staticType == interpreter.PrimitiveStaticTypeBool {
+			return bool(value), gethTypeBool, nil
+		}
+
+	case interpreter.UInt8Value:
+		if staticType == interpreter.PrimitiveStaticTypeUInt8 {
+			return uint8(value), gethTypeUint8, nil
+		}
+
+	case interpreter.UInt16Value:
+		if staticType == interpreter.PrimitiveStaticTypeUInt16 {
+			return uint16(value), gethTypeUint16, nil
+		}
+
+	case interpreter.UInt32Value:
+		if staticType == interpreter.PrimitiveStaticTypeUInt32 {
+			return uint32(value), gethTypeUint32, nil
+		}
+
+	case interpreter.UInt64Value:
+		if staticType == interpreter.PrimitiveStaticTypeUInt64 {
+			return uint64(value), gethTypeUint64, nil
+		}
+
+	case interpreter.UInt128Value:
+		if staticType == interpreter.PrimitiveStaticTypeUInt128 {
+			return value.BigInt, gethTypeUint128, nil
+		}
+
+	case interpreter.UInt256Value:
+		if staticType == interpreter.PrimitiveStaticTypeUInt256 {
+			return value.BigInt, gethTypeUint256, nil
+		}
+
+	case interpreter.Int8Value:
+		if staticType == interpreter.PrimitiveStaticTypeInt8 {
+			return int8(value), gethTypeInt8, nil
+		}
+
+	case interpreter.Int16Value:
+		if staticType == interpreter.PrimitiveStaticTypeInt16 {
+			return int16(value), gethTypeInt16, nil
+		}
+
+	case interpreter.Int32Value:
+		if staticType == interpreter.PrimitiveStaticTypeInt32 {
+			return int32(value), gethTypeInt32, nil
+		}
+
+	case interpreter.Int64Value:
+		if staticType == interpreter.PrimitiveStaticTypeInt64 {
+			return int64(value), gethTypeInt64, nil
+		}
+
+	case interpreter.Int128Value:
+		if staticType == interpreter.PrimitiveStaticTypeInt128 {
+			return value.BigInt, gethTypeInt128, nil
+		}
+
+	case interpreter.Int256Value:
+		if staticType == interpreter.PrimitiveStaticTypeInt256 {
+			return value.BigInt, gethTypeInt256, nil
+		}
+
+	case *interpreter.CompositeValue:
+		if value.TypeID() == evmAddressTypeID {
+			addressBytesArrayValue := value.GetMember(inter, locationRange, stdlib.EVMAddressTypeBytesFieldName)
+			bytes, err := interpreter.ByteArrayValueToByteSlice(
+				inter,
+				addressBytesArrayValue,
+				locationRange,
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			return gethCommon.Address(bytes), gethTypeAddress, nil
+		}
+
+	case *interpreter.ArrayValue:
+		arrayStaticType := value.Type
+
+		arrayGethABIType, ok := gethABIType(arrayStaticType, evmAddressTypeID)
+		if !ok {
+			break
+		}
+
+		elementStaticType := arrayStaticType.ElementType()
+
+		elementGoType, ok := goType(elementStaticType, evmAddressTypeID)
+		if !ok {
+			break
+		}
+
+		var result reflect.Value
+
+		switch arrayStaticType := arrayStaticType.(type) {
+		case *interpreter.ConstantSizedStaticType:
+			size := int(arrayStaticType.Size)
+			result = reflect.Indirect(reflect.New(reflect.ArrayOf(size, elementGoType)))
+
+		case *interpreter.VariableSizedStaticType:
+			size := value.Count()
+			result = reflect.MakeSlice(reflect.SliceOf(elementGoType), size, size)
+		}
+
+		var index int
+		value.Iterate(
+			inter,
+			func(element interpreter.Value) (resume bool) {
+
+				arrayElement, _, err := encodeABI(
+					inter,
+					locationRange,
+					element,
+					element.StaticType(inter),
+					evmAddressTypeID,
+				)
+				if err != nil {
+					panic(err)
+				}
+
+				result.Index(index).Set(reflect.ValueOf(arrayElement))
+
+				index++
+
+				// continue iteration
+				return true
+			},
+			false,
+			locationRange,
+		)
+
+		return result.Interface(), arrayGethABIType, nil
+	}
+
+	return nil, gethABI.Type{}, abiEncodingError{
+		Type: value.StaticType(inter),
+	}
+}
+func newInternalEVMTypeDecodeABIFunction(
+	gauge common.MemoryGauge,
+	location common.AddressLocation,
+) *interpreter.HostFunctionValue {
+	evmAddressTypeID := location.TypeID(gauge, stdlib.EVMAddressTypeQualifiedIdentifier)
+
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeDecodeABIFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get `types` argument
+
+			typesArray, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			// Get `data` argument
+
+			dataValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			invocation.Interpreter.ReportComputation(
+				environment.ComputationKindEVMDecodeABI,
+				uint(dataValue.Count()),
+			)
+
+			data, err := interpreter.ByteArrayValueToByteSlice(inter, dataValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			var arguments gethABI.Arguments
+			typesArray.Iterate(
+				inter,
+				func(element interpreter.Value) (resume bool) {
+					typeValue, ok := element.(interpreter.TypeValue)
+					if !ok {
+						panic(errors.NewUnreachableError())
+					}
+
+					staticType := typeValue.Type
+
+					gethABITy, ok := gethABIType(staticType, evmAddressTypeID)
+					if !ok {
+						panic(abiDecodingError{
+							Type: staticType,
+						})
+					}
+
+					arguments = append(
+						arguments,
+						gethABI.Argument{
+							Type: gethABITy,
+						},
+					)
+
+					// continue iteration
+					return true
+				},
+				false,
+				locationRange,
+			)
+
+			decodedValues, err := arguments.Unpack(data)
+			if err != nil {
+				panic(abiDecodingError{})
+			}
+
+			var index int
+			values := make([]interpreter.Value, 0, len(decodedValues))
+
+			typesArray.Iterate(
+				inter,
+				func(element interpreter.Value) (resume bool) {
+					typeValue, ok := element.(interpreter.TypeValue)
+					if !ok {
+						panic(errors.NewUnreachableError())
+					}
+
+					staticType := typeValue.Type
+
+					value, err := decodeABI(
+						inter,
+						locationRange,
+						decodedValues[index],
+						staticType,
+						location,
+						evmAddressTypeID,
+					)
+					if err != nil {
+						panic(err)
+					}
+
+					index++
+
+					values = append(values, value)
+
+					// continue iteration
+					return true
+				},
+				false,
+				locationRange,
+			)
+
+			arrayType := interpreter.NewVariableSizedStaticType(
+				inter,
+				interpreter.NewPrimitiveStaticType(
+					inter,
+					interpreter.PrimitiveStaticTypeAnyStruct,
+				),
+			)
+
+			return interpreter.NewArrayValue(
+				inter,
+				locationRange,
+				arrayType,
+				common.ZeroAddress,
+				values...,
+			)
+		},
+	)
+}
+
+func decodeABI(
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	value any,
+	staticType interpreter.StaticType,
+	location common.AddressLocation,
+	evmAddressTypeID common.TypeID,
+) (
+	interpreter.Value,
+	error,
+) {
+
+	switch staticType {
+	case interpreter.PrimitiveStaticTypeString:
+		value, ok := value.(string)
+		if !ok {
+			break
+		}
+		return interpreter.NewStringValue(
+			inter,
+			common.NewStringMemoryUsage(len(value)),
+			func() string {
+				return value
+			},
+		), nil
+
+	case interpreter.PrimitiveStaticTypeBool:
+		value, ok := value.(bool)
+		if !ok {
+			break
+		}
+		return interpreter.BoolValue(value), nil
+
+	case interpreter.PrimitiveStaticTypeUInt8:
+		value, ok := value.(uint8)
+		if !ok {
+			break
+		}
+		return interpreter.NewUInt8Value(inter, func() uint8 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeUInt16:
+		value, ok := value.(uint16)
+		if !ok {
+			break
+		}
+		return interpreter.NewUInt16Value(inter, func() uint16 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeUInt32:
+		value, ok := value.(uint32)
+		if !ok {
+			break
+		}
+		return interpreter.NewUInt32Value(inter, func() uint32 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeUInt64:
+		value, ok := value.(uint64)
+		if !ok {
+			break
+		}
+		return interpreter.NewUInt64Value(inter, func() uint64 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeUInt128:
+		value, ok := value.(*big.Int)
+		if !ok {
+			break
+		}
+		return interpreter.NewUInt128ValueFromBigInt(inter, func() *big.Int { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeUInt256:
+		value, ok := value.(*big.Int)
+		if !ok {
+			break
+		}
+		return interpreter.NewUInt256ValueFromBigInt(inter, func() *big.Int { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeInt8:
+		value, ok := value.(int8)
+		if !ok {
+			break
+		}
+		return interpreter.NewInt8Value(inter, func() int8 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeInt16:
+		value, ok := value.(int16)
+		if !ok {
+			break
+		}
+		return interpreter.NewInt16Value(inter, func() int16 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeInt32:
+		value, ok := value.(int32)
+		if !ok {
+			break
+		}
+		return interpreter.NewInt32Value(inter, func() int32 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeInt64:
+		value, ok := value.(int64)
+		if !ok {
+			break
+		}
+		return interpreter.NewInt64Value(inter, func() int64 { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeInt128:
+		value, ok := value.(*big.Int)
+		if !ok {
+			break
+		}
+		return interpreter.NewInt128ValueFromBigInt(inter, func() *big.Int { return value }), nil
+
+	case interpreter.PrimitiveStaticTypeInt256:
+		value, ok := value.(*big.Int)
+		if !ok {
+			break
+		}
+		return interpreter.NewInt256ValueFromBigInt(inter, func() *big.Int { return value }), nil
+	}
+
+	switch staticType := staticType.(type) {
+	case interpreter.ArrayStaticType:
+		array := reflect.ValueOf(value)
+
+		elementStaticType := staticType.ElementType()
+
+		size := array.Len()
+
+		var index int
+		return interpreter.NewArrayValueWithIterator(
+			inter,
+			staticType,
+			common.ZeroAddress,
+			uint64(size),
+			func() interpreter.Value {
+				if index >= size {
+					return nil
+				}
+
+				element := array.Index(index).Interface()
+
+				result, err := decodeABI(
+					inter,
+					locationRange,
+					element,
+					elementStaticType,
+					location,
+					evmAddressTypeID,
+				)
+				if err != nil {
+					panic(err)
+				}
+
+				index++
+
+				return result
+			},
+		), nil
+
+	case *interpreter.CompositeStaticType:
+		if staticType.TypeID != evmAddressTypeID {
+			break
+		}
+
+		addr, ok := value.(gethCommon.Address)
+		if !ok {
+			break
+		}
+
+		var address types.Address
+		copy(address[:], addr.Bytes())
+		return NewEVMAddress(
+			inter,
+			locationRange,
+			location,
+			address,
+		), nil
+	}
+
+	return nil, abiDecodingError{
+		Type: staticType,
+	}
+}

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -1,0 +1,1027 @@
+package impl
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/onflow/cadence"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/errors"
+	"github.com/onflow/cadence/runtime/interpreter"
+	"github.com/onflow/cadence/runtime/sema"
+
+	"github.com/onflow/flow-go/fvm/evm/stdlib"
+	"github.com/onflow/flow-go/fvm/evm/types"
+)
+
+var internalEVMContractStaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
+	nil,
+	stdlib.InternalEVMContractType,
+)
+
+func NewInternalEVMContractValue(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+	contractAddress common.Address,
+) *interpreter.SimpleCompositeValue {
+	location := common.NewAddressLocation(nil, common.Address(contractAddress), stdlib.ContractName)
+
+	return interpreter.NewSimpleCompositeValue(
+		gauge,
+		stdlib.InternalEVMContractType.ID(),
+		internalEVMContractStaticType,
+		stdlib.InternalEVMContractType.Fields,
+		map[string]interpreter.Value{
+			stdlib.InternalEVMTypeRunFunctionName:                       newInternalEVMTypeRunFunction(gauge, handler),
+			stdlib.InternalEVMTypeBatchRunFunctionName:                  newInternalEVMTypeBatchRunFunction(gauge, handler),
+			stdlib.InternalEVMTypeCreateCadenceOwnedAccountFunctionName: newInternalEVMTypeCreateCadenceOwnedAccountFunction(gauge, handler),
+			stdlib.InternalEVMTypeCallFunctionName:                      newInternalEVMTypeCallFunction(gauge, handler),
+			stdlib.InternalEVMTypeDepositFunctionName:                   newInternalEVMTypeDepositFunction(gauge, handler),
+			stdlib.InternalEVMTypeWithdrawFunctionName:                  newInternalEVMTypeWithdrawFunction(gauge, handler),
+			stdlib.InternalEVMTypeDeployFunctionName:                    newInternalEVMTypeDeployFunction(gauge, handler),
+			stdlib.InternalEVMTypeBalanceFunctionName:                   newInternalEVMTypeBalanceFunction(gauge, handler),
+			stdlib.InternalEVMTypeNonceFunctionName:                     newInternalEVMTypeNonceFunction(gauge, handler),
+			stdlib.InternalEVMTypeCodeFunctionName:                      newInternalEVMTypeCodeFunction(gauge, handler),
+			stdlib.InternalEVMTypeCodeHashFunctionName:                  newInternalEVMTypeCodeHashFunction(gauge, handler),
+			stdlib.InternalEVMTypeEncodeABIFunctionName:                 newInternalEVMTypeEncodeABIFunction(gauge, location),
+			stdlib.InternalEVMTypeDecodeABIFunctionName:                 newInternalEVMTypeDecodeABIFunction(gauge, location),
+			stdlib.InternalEVMTypeCastToAttoFLOWFunctionName:            newInternalEVMTypeCastToAttoFLOWFunction(gauge),
+			stdlib.InternalEVMTypeCastToFLOWFunctionName:                newInternalEVMTypeCastToFLOWFunction(gauge),
+			stdlib.InternalEVMTypeGetLatestBlockFunctionName:            newInternalEVMTypeGetLatestBlockFunction(gauge, handler),
+			stdlib.InternalEVMTypeDryRunFunctionName:                    newInternalEVMTypeDryRunFunction(gauge, handler),
+			stdlib.InternalEVMTypeCommitBlockProposalFunctionName:       newInternalEVMTypeCommitBlockProposalFunction(gauge, handler),
+		},
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func newInternalEVMTypeGetLatestBlockFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeGetLatestBlockFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			latestBlock := handler.LastExecutedBlock()
+			return NewEVMBlockValue(handler, gauge, inter, locationRange, latestBlock)
+		},
+	)
+}
+
+func NewEVMBlockValue(
+	handler types.ContractHandler,
+	gauge common.MemoryGauge,
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	block *types.Block,
+) *interpreter.CompositeValue {
+	loc := common.NewAddressLocation(gauge, handler.EVMContractAddress(), stdlib.ContractName)
+	hash, err := block.Hash()
+	if err != nil {
+		panic(err)
+	}
+
+	return interpreter.NewCompositeValue(
+		inter,
+		locationRange,
+		loc,
+		stdlib.EVMBlockTypeQualifiedIdentifier,
+		common.CompositeKindStructure,
+		[]interpreter.CompositeField{
+			{
+				Name:  "height",
+				Value: interpreter.UInt64Value(block.Height),
+			},
+			{
+				Name: "hash",
+				Value: interpreter.NewStringValue(
+					inter,
+					common.NewStringMemoryUsage(len(hash)),
+					func() string {
+						return hash.Hex()
+					},
+				),
+			},
+			{
+				Name: "totalSupply",
+				Value: interpreter.NewIntValueFromBigInt(
+					inter,
+					common.NewBigIntMemoryUsage(common.BigIntByteLength(block.TotalSupply)),
+					func() *big.Int {
+						return block.TotalSupply
+					},
+				),
+			},
+			{
+				Name:  "timestamp",
+				Value: interpreter.UInt64Value(block.Timestamp),
+			},
+		},
+		common.ZeroAddress,
+	)
+}
+
+func NewEVMAddress(
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	location common.AddressLocation,
+	address types.Address,
+) *interpreter.CompositeValue {
+	return interpreter.NewCompositeValue(
+		inter,
+		locationRange,
+		location,
+		stdlib.EVMAddressTypeQualifiedIdentifier,
+		common.CompositeKindStructure,
+		[]interpreter.CompositeField{
+			{
+				Name:  stdlib.EVMAddressTypeBytesFieldName,
+				Value: EVMAddressToAddressBytesArrayValue(inter, address),
+			},
+		},
+		common.ZeroAddress,
+	)
+}
+
+func AddressBytesArrayValueToEVMAddress(
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	addressBytesValue *interpreter.ArrayValue,
+) (
+	result types.Address,
+	err error,
+) {
+	// Convert
+
+	var bytes []byte
+	bytes, err = interpreter.ByteArrayValueToByteSlice(
+		inter,
+		addressBytesValue,
+		locationRange,
+	)
+	if err != nil {
+		return result, err
+	}
+
+	// Check length
+
+	length := len(bytes)
+	const expectedLength = types.AddressLength
+	if length != expectedLength {
+		return result, errors.NewDefaultUserError(
+			"invalid address length: got %d, expected %d",
+			length,
+			expectedLength,
+		)
+	}
+
+	copy(result[:], bytes)
+
+	return result, nil
+}
+
+func EVMAddressToAddressBytesArrayValue(
+	inter *interpreter.Interpreter,
+	address types.Address,
+) *interpreter.ArrayValue {
+	var index int
+	return interpreter.NewArrayValueWithIterator(
+		inter,
+		stdlib.EVMAddressBytesStaticType,
+		common.ZeroAddress,
+		types.AddressLength,
+		func() interpreter.Value {
+			if index >= types.AddressLength {
+				return nil
+			}
+			result := interpreter.NewUInt8Value(inter, func() uint8 {
+				return address[index]
+			})
+			index++
+			return result
+		},
+	)
+}
+
+func newInternalEVMTypeCreateCadenceOwnedAccountFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeCreateCadenceOwnedAccountFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			uuid, ok := invocation.Arguments[0].(interpreter.UInt64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+			address := handler.DeployCOA(uint64(uuid))
+			return EVMAddressToAddressBytesArrayValue(inter, address)
+		},
+	)
+}
+
+// newInternalEVMTypeCodeFunction returns the code of the account
+func newInternalEVMTypeCodeFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeCodeFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			const isAuthorized = false
+			account := handler.AccountByAddress(address, isAuthorized)
+
+			return interpreter.ByteSliceToByteArrayValue(inter, account.Code())
+		},
+	)
+}
+
+// newInternalEVMTypeNonceFunction returns the nonce of the account
+func newInternalEVMTypeNonceFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeNonceFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			const isAuthorized = false
+			account := handler.AccountByAddress(address, isAuthorized)
+
+			return interpreter.UInt64Value(account.Nonce())
+		},
+	)
+}
+
+func newInternalEVMTypeCallFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeCallFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get from address
+
+			fromAddressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			fromAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, fromAddressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get to address
+
+			toAddressValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			toAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, toAddressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get data
+
+			dataValue, ok := invocation.Arguments[2].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			data, err := interpreter.ByteArrayValueToByteSlice(inter, dataValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get gas limit
+
+			gasLimitValue, ok := invocation.Arguments[3].(interpreter.UInt64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			gasLimit := types.GasLimit(gasLimitValue)
+
+			// Get balance
+
+			balanceValue, ok := invocation.Arguments[4].(interpreter.UIntValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			balance := types.NewBalance(balanceValue.BigInt)
+			// Call
+
+			const isAuthorized = true
+			account := handler.AccountByAddress(fromAddress, isAuthorized)
+			result := account.Call(toAddress, data, gasLimit, balance)
+
+			return NewResultValue(handler, gauge, inter, locationRange, result)
+		},
+	)
+}
+
+const fungibleTokenVaultTypeBalanceFieldName = "balance"
+
+func newInternalEVMTypeDepositFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeDepositFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get from vault
+
+			fromValue, ok := invocation.Arguments[0].(*interpreter.CompositeValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			amountValue, ok := fromValue.GetField(
+				inter,
+				locationRange,
+				fungibleTokenVaultTypeBalanceFieldName,
+			).(interpreter.UFix64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			amount := types.NewBalanceFromUFix64(cadence.UFix64(amountValue))
+
+			// Get to address
+
+			toAddressValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			toAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, toAddressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			// NOTE: We're intentionally not destroying the vault here,
+			// because the value of it is supposed to be "kept alive".
+			// Destroying would incorrectly be equivalent to a burn and decrease the total supply,
+			// and a withdrawal would then have to perform an actual mint of new tokens.
+
+			// Deposit
+
+			const isAuthorized = false
+			account := handler.AccountByAddress(toAddress, isAuthorized)
+			account.Deposit(types.NewFlowTokenVault(amount))
+
+			return interpreter.Void
+		},
+	)
+}
+
+// newInternalEVMTypeBalanceFunction returns the Flow balance of the account
+func newInternalEVMTypeBalanceFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeBalanceFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			const isAuthorized = false
+			account := handler.AccountByAddress(address, isAuthorized)
+
+			return interpreter.UIntValue{BigInt: account.Balance()}
+		},
+	)
+}
+
+// newInternalEVMTypeCodeHashFunction returns the code hash of the account
+func newInternalEVMTypeCodeHashFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeCodeHashFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			const isAuthorized = false
+			account := handler.AccountByAddress(address, isAuthorized)
+
+			return interpreter.ByteSliceToByteArrayValue(inter, account.CodeHash())
+		},
+	)
+}
+
+func newInternalEVMTypeWithdrawFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeWithdrawFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get from address
+
+			fromAddressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			fromAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, fromAddressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get amount
+
+			amountValue, ok := invocation.Arguments[1].(interpreter.UIntValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			amount := types.NewBalance(amountValue.BigInt)
+
+			// Withdraw
+
+			const isAuthorized = true
+			account := handler.AccountByAddress(fromAddress, isAuthorized)
+			vault := account.Withdraw(amount)
+
+			ufix, roundedOff, err := types.ConvertBalanceToUFix64(vault.Balance())
+			if err != nil {
+				panic(err)
+			}
+			if roundedOff {
+				panic(types.ErrWithdrawBalanceRounding)
+			}
+
+			// TODO: improve: maybe call actual constructor
+			return interpreter.NewCompositeValue(
+				inter,
+				locationRange,
+				common.NewAddressLocation(gauge, handler.FlowTokenAddress(), "FlowToken"),
+				"FlowToken.Vault",
+				common.CompositeKindResource,
+				[]interpreter.CompositeField{
+					{
+						Name: "balance",
+						Value: interpreter.NewUFix64Value(gauge, func() uint64 {
+							return uint64(ufix)
+						}),
+					},
+					{
+						Name: sema.ResourceUUIDFieldName,
+						Value: interpreter.NewUInt64Value(gauge, func() uint64 {
+							return handler.GenerateResourceUUID()
+						}),
+					},
+				},
+				common.ZeroAddress,
+			)
+		},
+	)
+}
+
+func newInternalEVMTypeDeployFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeDeployFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get from address
+
+			fromAddressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			fromAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, fromAddressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get code
+
+			codeValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			code, err := interpreter.ByteArrayValueToByteSlice(inter, codeValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get gas limit
+
+			gasLimitValue, ok := invocation.Arguments[2].(interpreter.UInt64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			gasLimit := types.GasLimit(gasLimitValue)
+
+			// Get value
+
+			amountValue, ok := invocation.Arguments[3].(interpreter.UIntValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			amount := types.NewBalance(amountValue.BigInt)
+
+			// Deploy
+
+			const isAuthorized = true
+			account := handler.AccountByAddress(fromAddress, isAuthorized)
+			result := account.Deploy(code, gasLimit, amount)
+
+			res := NewResultValue(handler, gauge, inter, locationRange, result)
+			return res
+		},
+	)
+}
+
+func newInternalEVMTypeCastToAttoFLOWFunction(
+	gauge common.MemoryGauge,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeCastToAttoFLOWFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			balanceValue, ok := invocation.Arguments[0].(interpreter.UFix64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+			balance := types.NewBalanceFromUFix64(cadence.UFix64(balanceValue))
+			return interpreter.UIntValue{BigInt: balance}
+		},
+	)
+}
+
+func newInternalEVMTypeCastToFLOWFunction(
+	gauge common.MemoryGauge,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeCastToFLOWFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			balanceValue, ok := invocation.Arguments[0].(interpreter.UIntValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+			balance := types.NewBalance(balanceValue.BigInt)
+			// ignoring the rounding error and let user handle it
+			v, _, err := types.ConvertBalanceToUFix64(balance)
+			if err != nil {
+				panic(err)
+			}
+			return interpreter.UFix64Value(v)
+		},
+	)
+}
+
+func newInternalEVMTypeCommitBlockProposalFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeCommitBlockProposalFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			handler.CommitBlockProposal()
+			return interpreter.Void
+		},
+	)
+}
+
+func newInternalEVMTypeRunFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeRunFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get transaction argument
+
+			transactionValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			transaction, err := interpreter.ByteArrayValueToByteSlice(inter, transactionValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get gas fee collector argument
+
+			gasFeeCollectorValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			gasFeeCollector, err := interpreter.ByteArrayValueToByteSlice(inter, gasFeeCollectorValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// run transaction
+			result := handler.Run(transaction, types.NewAddressFromBytes(gasFeeCollector))
+
+			return NewResultValue(handler, gauge, inter, locationRange, result)
+		},
+	)
+}
+
+func newInternalEVMTypeDryRunFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeDryRunFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get transaction argument
+
+			transactionValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			transaction, err := interpreter.ByteArrayValueToByteSlice(inter, transactionValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get from argument
+
+			fromValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			from, err := interpreter.ByteArrayValueToByteSlice(inter, fromValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// call estimate
+
+			res := handler.DryRun(transaction, types.NewAddressFromBytes(from))
+			return NewResultValue(handler, gauge, inter, locationRange, res)
+		},
+	)
+}
+
+func newInternalEVMTypeBatchRunFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeBatchRunFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get transactions batch argument
+			transactionsBatchValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			batchCount := transactionsBatchValue.Count()
+			var transactionBatch [][]byte
+			if batchCount > 0 {
+				transactionBatch = make([][]byte, batchCount)
+				i := 0
+				transactionsBatchValue.Iterate(inter, func(transactionValue interpreter.Value) (resume bool) {
+					t, err := interpreter.ByteArrayValueToByteSlice(inter, transactionValue, locationRange)
+					if err != nil {
+						panic(err)
+					}
+					transactionBatch[i] = t
+					i++
+					return true
+				}, false, locationRange)
+			}
+
+			// Get gas fee collector argument
+			gasFeeCollectorValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			gasFeeCollector, err := interpreter.ByteArrayValueToByteSlice(inter, gasFeeCollectorValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// Batch run
+			batchResults := handler.BatchRun(transactionBatch, types.NewAddressFromBytes(gasFeeCollector))
+
+			values := newResultValues(handler, gauge, inter, locationRange, batchResults)
+
+			loc := common.NewAddressLocation(gauge, handler.EVMContractAddress(), stdlib.ContractName)
+			evmResultType := interpreter.NewVariableSizedStaticType(
+				inter,
+				interpreter.NewCompositeStaticType(
+					nil,
+					loc,
+					stdlib.EVMResultTypeQualifiedIdentifier,
+					common.NewTypeIDFromQualifiedName(
+						nil,
+						loc,
+						stdlib.EVMResultTypeQualifiedIdentifier,
+					),
+				),
+			)
+
+			return interpreter.NewArrayValue(
+				inter,
+				locationRange,
+				evmResultType,
+				common.ZeroAddress,
+				values...,
+			)
+		},
+	)
+}
+
+// newResultValues converts batch run result summary type to cadence array of structs
+func newResultValues(
+	handler types.ContractHandler,
+	gauge common.MemoryGauge,
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	results []*types.ResultSummary,
+) []interpreter.Value {
+	values := make([]interpreter.Value, 0)
+	for _, result := range results {
+		res := NewResultValue(handler, gauge, inter, locationRange, result)
+		values = append(values, res)
+	}
+	return values
+}
+
+func NewResultValue(
+	handler types.ContractHandler,
+	gauge common.MemoryGauge,
+	inter *interpreter.Interpreter,
+	locationRange interpreter.LocationRange,
+	result *types.ResultSummary,
+) *interpreter.CompositeValue {
+
+	evmContractLocation := common.NewAddressLocation(
+		gauge,
+		handler.EVMContractAddress(),
+		stdlib.ContractName,
+	)
+
+	deployedContractAddress := result.DeployedContractAddress
+	deployedContractValue := interpreter.NilOptionalValue
+	if deployedContractAddress != nil {
+		deployedContractValue = interpreter.NewSomeValueNonCopying(
+			inter,
+			NewEVMAddress(
+				inter,
+				locationRange,
+				evmContractLocation,
+				*deployedContractAddress,
+			),
+		)
+	}
+
+	fields := []interpreter.CompositeField{
+		{
+			Name: "status",
+			Value: interpreter.NewEnumCaseValue(
+				inter,
+				locationRange,
+				&sema.CompositeType{
+					Location:   evmContractLocation,
+					Identifier: stdlib.EVMStatusTypeQualifiedIdentifier,
+					Kind:       common.CompositeKindEnum,
+				},
+				interpreter.NewUInt8Value(gauge, func() uint8 {
+					return uint8(result.Status)
+				}),
+				nil,
+			),
+		},
+		{
+			Name: "errorCode",
+			Value: interpreter.NewUInt64Value(gauge, func() uint64 {
+				return uint64(result.ErrorCode)
+			}),
+		},
+		{
+			Name: "errorMessage",
+			Value: interpreter.NewStringValue(inter,
+				common.NewStringMemoryUsage(len(result.ErrorMessage)),
+				func() string {
+					return result.ErrorMessage
+				},
+			),
+		},
+		{
+			Name: "gasUsed",
+			Value: interpreter.NewUInt64Value(gauge, func() uint64 {
+				return result.GasConsumed
+			}),
+		},
+		{
+			Name:  "data",
+			Value: interpreter.ByteSliceToByteArrayValue(inter, result.ReturnedData),
+		},
+		{
+			Name:  "deployedContract",
+			Value: deployedContractValue,
+		},
+	}
+
+	return interpreter.NewCompositeValue(
+		inter,
+		locationRange,
+		evmContractLocation,
+		stdlib.EVMResultTypeQualifiedIdentifier,
+		common.CompositeKindStructure,
+		fields,
+		common.ZeroAddress,
+	)
+}
+
+func ResultSummaryFromEVMResultValue(val cadence.Value) (*types.ResultSummary, error) {
+	str, ok := val.(cadence.Struct)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected value type")
+	}
+
+	fields := cadence.FieldsMappedByName(str)
+
+	const expectedFieldCount = 6
+	if len(fields) != expectedFieldCount {
+		return nil, fmt.Errorf(
+			"invalid input: field count mismatch: expected %d, got %d",
+			expectedFieldCount,
+			len(fields),
+		)
+	}
+
+	statusEnum, ok := fields[stdlib.EVMResultTypeStatusFieldName].(cadence.Enum)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected type for status field")
+	}
+
+	status, ok := cadence.FieldsMappedByName(statusEnum)[sema.EnumRawValueFieldName].(cadence.UInt8)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected type for status field")
+	}
+
+	errorCode, ok := fields[stdlib.EVMResultTypeErrorCodeFieldName].(cadence.UInt64)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected type for error code field")
+	}
+
+	errorMsg, ok := fields[stdlib.EVMResultTypeErrorMessageFieldName].(cadence.String)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected type for error msg field")
+	}
+
+	gasUsed, ok := fields[stdlib.EVMResultTypeGasUsedFieldName].(cadence.UInt64)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected type for gas field")
+	}
+
+	data, ok := fields[stdlib.EVMResultTypeDataFieldName].(cadence.Array)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected type for data field")
+	}
+
+	convertedData := make([]byte, len(data.Values))
+	for i, value := range data.Values {
+		convertedData[i] = byte(value.(cadence.UInt8))
+	}
+
+	var convertedDeployedAddress *types.Address
+
+	deployedAddressField, ok := fields[stdlib.EVMResultTypeDeployedContractFieldName].(cadence.Optional)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: unexpected type for deployed contract field")
+	}
+
+	if deployedAddressField.Value != nil {
+		evmAddress, ok := deployedAddressField.Value.(cadence.Struct)
+		if !ok {
+			return nil, fmt.Errorf("invalid input: unexpected type for deployed contract field")
+		}
+
+		bytes, ok := cadence.SearchFieldByName(evmAddress, stdlib.EVMAddressTypeBytesFieldName).(cadence.Array)
+		if !ok {
+			return nil, fmt.Errorf("invalid input: unexpected type for deployed contract field")
+		}
+
+		convertedAddress := make([]byte, len(bytes.Values))
+		for i, value := range bytes.Values {
+			convertedAddress[i] = byte(value.(cadence.UInt8))
+		}
+		addr := types.Address(convertedAddress)
+		convertedDeployedAddress = &addr
+	}
+
+	return &types.ResultSummary{
+		Status:                  types.Status(status),
+		ErrorCode:               types.ErrorCode(errorCode),
+		ErrorMessage:            string(errorMsg),
+		GasConsumed:             uint64(gasUsed),
+		ReturnedData:            convertedData,
+		DeployedContractAddress: convertedDeployedAddress,
+	}, nil
+
+}

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -3,24 +3,15 @@ package stdlib
 import (
 	_ "embed"
 	"fmt"
-	"math"
-	"math/big"
-	"reflect"
 	"regexp"
-	"strings"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
-	"github.com/onflow/cadence/runtime/errors"
 	"github.com/onflow/cadence/runtime/interpreter"
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/onflow/cadence/runtime/stdlib"
-	gethABI "github.com/onflow/go-ethereum/accounts/abi"
-	gethCommon "github.com/onflow/go-ethereum/common"
 
-	"github.com/onflow/flow-go/fvm/environment"
-	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -53,177 +44,44 @@ func ContractCode(nonFungibleTokenAddress, fungibleTokenAddress, flowTokenAddres
 const (
 	ContractName = "EVM"
 
-	evmAddressTypeBytesFieldName = "bytes"
+	EVMAddressTypeBytesFieldName = "bytes"
 
-	evmAddressTypeQualifiedIdentifier = "EVM.EVMAddress"
+	EVMAddressTypeQualifiedIdentifier = "EVM.EVMAddress"
 
-	evmBalanceTypeQualifiedIdentifier = "EVM.Balance"
+	EVMBalanceTypeQualifiedIdentifier = "EVM.Balance"
 
-	evmResultTypeQualifiedIdentifier       = "EVM.Result"
-	evmResultTypeStatusFieldName           = "status"
-	evmResultTypeErrorCodeFieldName        = "errorCode"
-	evmResultTypeErrorMessageFieldName     = "errorMessage"
-	evmResultTypeGasUsedFieldName          = "gasUsed"
-	evmResultTypeDataFieldName             = "data"
-	evmResultTypeDeployedContractFieldName = "deployedContract"
+	EVMResultTypeQualifiedIdentifier       = "EVM.Result"
+	EVMResultTypeStatusFieldName           = "status"
+	EVMResultTypeErrorCodeFieldName        = "errorCode"
+	EVMResultTypeErrorMessageFieldName     = "errorMessage"
+	EVMResultTypeGasUsedFieldName          = "gasUsed"
+	EVMResultTypeDataFieldName             = "data"
+	EVMResultTypeDeployedContractFieldName = "deployedContract"
 
-	evmStatusTypeQualifiedIdentifier = "EVM.Status"
+	EVMStatusTypeQualifiedIdentifier = "EVM.Status"
 
-	evmBlockTypeQualifiedIdentifier = "EVM.EVMBlock"
-	abiEncodingByteSize             = 32
+	EVMBlockTypeQualifiedIdentifier = "EVM.EVMBlock"
 )
+
+const EVMAddressLength = 20
 
 var (
 	EVMTransactionBytesCadenceType = cadence.NewVariableSizedArrayType(cadence.UInt8Type)
 
-	evmTransactionBytesType       = sema.NewVariableSizedType(nil, sema.UInt8Type)
-	evmTransactionsBatchBytesType = sema.NewVariableSizedType(nil, evmTransactionBytesType)
-	evmAddressBytesType           = sema.NewConstantSizedType(nil, sema.UInt8Type, types.AddressLength)
+	EVMTransactionBytesType       = sema.NewVariableSizedType(nil, sema.UInt8Type)
+	EVMTransactionsBatchBytesType = sema.NewVariableSizedType(nil, EVMTransactionBytesType)
+	EVMAddressBytesType           = sema.NewConstantSizedType(nil, sema.UInt8Type, EVMAddressLength)
 
-	evmAddressBytesStaticType = interpreter.ConvertSemaArrayTypeToStaticArrayType(nil, evmAddressBytesType)
+	EVMAddressBytesStaticType = interpreter.ConvertSemaArrayTypeToStaticArrayType(nil, EVMAddressBytesType)
 
-	EVMAddressBytesCadenceType = cadence.NewConstantSizedArrayType(types.AddressLength, cadence.UInt8Type)
+	EVMAddressBytesCadenceType = cadence.NewConstantSizedArrayType(EVMAddressLength, cadence.UInt8Type)
 )
 
-// abiEncodingError
-type abiEncodingError struct {
-	Type interpreter.StaticType
-}
+// InternalEVM.encodeABI
 
-var _ errors.UserError = abiEncodingError{}
+const InternalEVMTypeEncodeABIFunctionName = "encodeABI"
 
-func (abiEncodingError) IsUserError() {}
-
-func (e abiEncodingError) Error() string {
-	var b strings.Builder
-	b.WriteString("failed to ABI encode value")
-
-	ty := e.Type
-	if ty != nil {
-		b.WriteString(" of type ")
-		b.WriteString(ty.String())
-	}
-
-	return b.String()
-}
-
-// abiDecodingError
-type abiDecodingError struct {
-	Type    interpreter.StaticType
-	Message string
-}
-
-var _ errors.UserError = abiDecodingError{}
-
-func (abiDecodingError) IsUserError() {}
-
-func (e abiDecodingError) Error() string {
-	var b strings.Builder
-	b.WriteString("failed to ABI decode data")
-
-	ty := e.Type
-	if ty != nil {
-		b.WriteString(" with type ")
-		b.WriteString(ty.String())
-	}
-
-	message := e.Message
-	if message != "" {
-		b.WriteString(": ")
-		b.WriteString(message)
-	}
-
-	return b.String()
-}
-
-func reportABIEncodingComputation(
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	values *interpreter.ArrayValue,
-	evmAddressTypeID common.TypeID,
-	reportComputation func(intensity uint),
-) {
-	values.Iterate(
-		inter,
-		func(element interpreter.Value) (resume bool) {
-			switch value := element.(type) {
-			case *interpreter.StringValue:
-				// Dynamic variables, such as strings, are encoded
-				// in 2+ chunks of 32 bytes. The first chunk contains
-				// the index where information for the string begin,
-				// the second chunk contains the number of bytes the
-				// string occupies, and the third chunk contains the
-				// value of the string itself.
-				computation := uint(2 * abiEncodingByteSize)
-				stringLength := len(value.Str)
-				chunks := math.Ceil(float64(stringLength) / float64(abiEncodingByteSize))
-				computation += uint(chunks * abiEncodingByteSize)
-				reportComputation(computation)
-
-			case interpreter.BoolValue,
-				interpreter.UInt8Value,
-				interpreter.UInt16Value,
-				interpreter.UInt32Value,
-				interpreter.UInt64Value,
-				interpreter.UInt128Value,
-				interpreter.UInt256Value,
-				interpreter.Int8Value,
-				interpreter.Int16Value,
-				interpreter.Int32Value,
-				interpreter.Int64Value,
-				interpreter.Int128Value,
-				interpreter.Int256Value:
-
-				// Numeric and bool variables are also static variables
-				// with a fixed size of 32 bytes.
-				reportComputation(abiEncodingByteSize)
-
-			case *interpreter.CompositeValue:
-				if value.TypeID() == evmAddressTypeID {
-					// EVM addresses are static variables with a fixed
-					// size of 32 bytes.
-					reportComputation(abiEncodingByteSize)
-				} else {
-					panic(abiEncodingError{
-						Type: value.StaticType(inter),
-					})
-				}
-			case *interpreter.ArrayValue:
-				// Dynamic variables, such as arrays & slices, are encoded
-				// in 2+ chunks of 32 bytes. The first chunk contains
-				// the index where information for the array begin,
-				// the second chunk contains the number of bytes the
-				// array occupies, and the third chunk contains the
-				// values of the array itself.
-				computation := uint(2 * abiEncodingByteSize)
-				reportComputation(computation)
-				reportABIEncodingComputation(
-					inter,
-					locationRange,
-					value,
-					evmAddressTypeID,
-					reportComputation,
-				)
-
-			default:
-				panic(abiEncodingError{
-					Type: element.StaticType(inter),
-				})
-			}
-
-			// continue iteration
-			return true
-		},
-		false,
-		locationRange,
-	)
-}
-
-// EVM.encodeABI
-
-const internalEVMTypeEncodeABIFunctionName = "encodeABI"
-
-var internalEVMTypeEncodeABIFunctionType = &sema.FunctionType{
+var InternalEVMTypeEncodeABIFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:      sema.ArgumentLabelNotRequired,
@@ -236,409 +94,11 @@ var internalEVMTypeEncodeABIFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
 }
 
-func newInternalEVMTypeEncodeABIFunction(
-	gauge common.MemoryGauge,
-	location common.AddressLocation,
-) *interpreter.HostFunctionValue {
+// InternalEVM.decodeABI
 
-	evmAddressTypeID := location.TypeID(gauge, evmAddressTypeQualifiedIdentifier)
+const InternalEVMTypeDecodeABIFunctionName = "decodeABI"
 
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeEncodeABIFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
-
-			// Get `values` argument
-
-			valuesArray, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			reportABIEncodingComputation(
-				inter,
-				locationRange,
-				valuesArray,
-				evmAddressTypeID,
-				func(intensity uint) {
-					inter.ReportComputation(environment.ComputationKindEVMEncodeABI, intensity)
-				},
-			)
-
-			size := valuesArray.Count()
-
-			values := make([]any, 0, size)
-			arguments := make(gethABI.Arguments, 0, size)
-
-			valuesArray.Iterate(
-				inter,
-				func(element interpreter.Value) (resume bool) {
-					value, ty, err := encodeABI(
-						inter,
-						locationRange,
-						element,
-						element.StaticType(inter),
-						evmAddressTypeID,
-					)
-					if err != nil {
-						panic(err)
-					}
-
-					values = append(values, value)
-					arguments = append(arguments, gethABI.Argument{Type: ty})
-
-					// continue iteration
-					return true
-				},
-				false,
-				locationRange,
-			)
-
-			encodedValues, err := arguments.Pack(values...)
-			if err != nil {
-				panic(abiEncodingError{})
-			}
-
-			return interpreter.ByteSliceToByteArrayValue(inter, encodedValues)
-		},
-	)
-}
-
-var gethTypeString = gethABI.Type{T: gethABI.StringTy}
-
-var gethTypeBool = gethABI.Type{T: gethABI.BoolTy}
-
-var gethTypeUint8 = gethABI.Type{T: gethABI.UintTy, Size: 8}
-
-var gethTypeUint16 = gethABI.Type{T: gethABI.UintTy, Size: 16}
-
-var gethTypeUint32 = gethABI.Type{T: gethABI.UintTy, Size: 32}
-
-var gethTypeUint64 = gethABI.Type{T: gethABI.UintTy, Size: 64}
-
-var gethTypeUint128 = gethABI.Type{T: gethABI.UintTy, Size: 128}
-
-var gethTypeUint256 = gethABI.Type{T: gethABI.UintTy, Size: 256}
-
-var gethTypeInt8 = gethABI.Type{T: gethABI.IntTy, Size: 8}
-
-var gethTypeInt16 = gethABI.Type{T: gethABI.IntTy, Size: 16}
-
-var gethTypeInt32 = gethABI.Type{T: gethABI.IntTy, Size: 32}
-
-var gethTypeInt64 = gethABI.Type{T: gethABI.IntTy, Size: 64}
-
-var gethTypeInt128 = gethABI.Type{T: gethABI.IntTy, Size: 128}
-
-var gethTypeInt256 = gethABI.Type{T: gethABI.IntTy, Size: 256}
-
-var gethTypeAddress = gethABI.Type{Size: 20, T: gethABI.AddressTy}
-
-func gethABIType(staticType interpreter.StaticType, evmAddressTypeID common.TypeID) (gethABI.Type, bool) {
-	switch staticType {
-	case interpreter.PrimitiveStaticTypeString:
-		return gethTypeString, true
-	case interpreter.PrimitiveStaticTypeBool:
-		return gethTypeBool, true
-	case interpreter.PrimitiveStaticTypeUInt8:
-		return gethTypeUint8, true
-	case interpreter.PrimitiveStaticTypeUInt16:
-		return gethTypeUint16, true
-	case interpreter.PrimitiveStaticTypeUInt32:
-		return gethTypeUint32, true
-	case interpreter.PrimitiveStaticTypeUInt64:
-		return gethTypeUint64, true
-	case interpreter.PrimitiveStaticTypeUInt128:
-		return gethTypeUint128, true
-	case interpreter.PrimitiveStaticTypeUInt256:
-		return gethTypeUint256, true
-	case interpreter.PrimitiveStaticTypeInt8:
-		return gethTypeInt8, true
-	case interpreter.PrimitiveStaticTypeInt16:
-		return gethTypeInt16, true
-	case interpreter.PrimitiveStaticTypeInt32:
-		return gethTypeInt32, true
-	case interpreter.PrimitiveStaticTypeInt64:
-		return gethTypeInt64, true
-	case interpreter.PrimitiveStaticTypeInt128:
-		return gethTypeInt128, true
-	case interpreter.PrimitiveStaticTypeInt256:
-		return gethTypeInt256, true
-	case interpreter.PrimitiveStaticTypeAddress:
-		return gethTypeAddress, true
-	}
-
-	switch staticType := staticType.(type) {
-	case *interpreter.CompositeStaticType:
-		if staticType.TypeID != evmAddressTypeID {
-			break
-		}
-
-		return gethTypeAddress, true
-
-	case *interpreter.ConstantSizedStaticType:
-		elementGethABIType, ok := gethABIType(
-			staticType.ElementType(),
-			evmAddressTypeID,
-		)
-		if !ok {
-			break
-		}
-
-		return gethABI.Type{
-			T:    gethABI.ArrayTy,
-			Elem: &elementGethABIType,
-			Size: int(staticType.Size),
-		}, true
-
-	case *interpreter.VariableSizedStaticType:
-		elementGethABIType, ok := gethABIType(
-			staticType.ElementType(),
-			evmAddressTypeID,
-		)
-		if !ok {
-			break
-		}
-
-		return gethABI.Type{
-			T:    gethABI.SliceTy,
-			Elem: &elementGethABIType,
-		}, true
-
-	}
-
-	return gethABI.Type{}, false
-}
-
-func goType(
-	staticType interpreter.StaticType,
-	evmAddressTypeID common.TypeID,
-) (reflect.Type, bool) {
-	switch staticType {
-	case interpreter.PrimitiveStaticTypeString:
-		return reflect.TypeOf(""), true
-	case interpreter.PrimitiveStaticTypeBool:
-		return reflect.TypeOf(true), true
-	case interpreter.PrimitiveStaticTypeUInt8:
-		return reflect.TypeOf(uint8(0)), true
-	case interpreter.PrimitiveStaticTypeUInt16:
-		return reflect.TypeOf(uint16(0)), true
-	case interpreter.PrimitiveStaticTypeUInt32:
-		return reflect.TypeOf(uint32(0)), true
-	case interpreter.PrimitiveStaticTypeUInt64:
-		return reflect.TypeOf(uint64(0)), true
-	case interpreter.PrimitiveStaticTypeUInt128:
-		return reflect.TypeOf((*big.Int)(nil)), true
-	case interpreter.PrimitiveStaticTypeUInt256:
-		return reflect.TypeOf((*big.Int)(nil)), true
-	case interpreter.PrimitiveStaticTypeInt8:
-		return reflect.TypeOf(int8(0)), true
-	case interpreter.PrimitiveStaticTypeInt16:
-		return reflect.TypeOf(int16(0)), true
-	case interpreter.PrimitiveStaticTypeInt32:
-		return reflect.TypeOf(int32(0)), true
-	case interpreter.PrimitiveStaticTypeInt64:
-		return reflect.TypeOf(int64(0)), true
-	case interpreter.PrimitiveStaticTypeInt128:
-		return reflect.TypeOf((*big.Int)(nil)), true
-	case interpreter.PrimitiveStaticTypeInt256:
-		return reflect.TypeOf((*big.Int)(nil)), true
-	case interpreter.PrimitiveStaticTypeAddress:
-		return reflect.TypeOf((*big.Int)(nil)), true
-	}
-
-	switch staticType := staticType.(type) {
-	case *interpreter.ConstantSizedStaticType:
-		elementType, ok := goType(staticType.ElementType(), evmAddressTypeID)
-		if !ok {
-			break
-		}
-
-		return reflect.ArrayOf(int(staticType.Size), elementType), true
-
-	case *interpreter.VariableSizedStaticType:
-		elementType, ok := goType(staticType.ElementType(), evmAddressTypeID)
-		if !ok {
-			break
-		}
-
-		return reflect.SliceOf(elementType), true
-	}
-
-	if staticType.ID() == evmAddressTypeID {
-		return reflect.TypeOf(gethCommon.Address{}), true
-	}
-
-	return nil, false
-}
-
-func encodeABI(
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	value interpreter.Value,
-	staticType interpreter.StaticType,
-	evmAddressTypeID common.TypeID,
-) (
-	any,
-	gethABI.Type,
-	error,
-) {
-
-	switch value := value.(type) {
-	case *interpreter.StringValue:
-		if staticType == interpreter.PrimitiveStaticTypeString {
-			return value.Str, gethTypeString, nil
-		}
-
-	case interpreter.BoolValue:
-		if staticType == interpreter.PrimitiveStaticTypeBool {
-			return bool(value), gethTypeBool, nil
-		}
-
-	case interpreter.UInt8Value:
-		if staticType == interpreter.PrimitiveStaticTypeUInt8 {
-			return uint8(value), gethTypeUint8, nil
-		}
-
-	case interpreter.UInt16Value:
-		if staticType == interpreter.PrimitiveStaticTypeUInt16 {
-			return uint16(value), gethTypeUint16, nil
-		}
-
-	case interpreter.UInt32Value:
-		if staticType == interpreter.PrimitiveStaticTypeUInt32 {
-			return uint32(value), gethTypeUint32, nil
-		}
-
-	case interpreter.UInt64Value:
-		if staticType == interpreter.PrimitiveStaticTypeUInt64 {
-			return uint64(value), gethTypeUint64, nil
-		}
-
-	case interpreter.UInt128Value:
-		if staticType == interpreter.PrimitiveStaticTypeUInt128 {
-			return value.BigInt, gethTypeUint128, nil
-		}
-
-	case interpreter.UInt256Value:
-		if staticType == interpreter.PrimitiveStaticTypeUInt256 {
-			return value.BigInt, gethTypeUint256, nil
-		}
-
-	case interpreter.Int8Value:
-		if staticType == interpreter.PrimitiveStaticTypeInt8 {
-			return int8(value), gethTypeInt8, nil
-		}
-
-	case interpreter.Int16Value:
-		if staticType == interpreter.PrimitiveStaticTypeInt16 {
-			return int16(value), gethTypeInt16, nil
-		}
-
-	case interpreter.Int32Value:
-		if staticType == interpreter.PrimitiveStaticTypeInt32 {
-			return int32(value), gethTypeInt32, nil
-		}
-
-	case interpreter.Int64Value:
-		if staticType == interpreter.PrimitiveStaticTypeInt64 {
-			return int64(value), gethTypeInt64, nil
-		}
-
-	case interpreter.Int128Value:
-		if staticType == interpreter.PrimitiveStaticTypeInt128 {
-			return value.BigInt, gethTypeInt128, nil
-		}
-
-	case interpreter.Int256Value:
-		if staticType == interpreter.PrimitiveStaticTypeInt256 {
-			return value.BigInt, gethTypeInt256, nil
-		}
-
-	case *interpreter.CompositeValue:
-		if value.TypeID() == evmAddressTypeID {
-			addressBytesArrayValue := value.GetMember(inter, locationRange, evmAddressTypeBytesFieldName)
-			bytes, err := interpreter.ByteArrayValueToByteSlice(
-				inter,
-				addressBytesArrayValue,
-				locationRange,
-			)
-			if err != nil {
-				panic(err)
-			}
-
-			return gethCommon.Address(bytes), gethTypeAddress, nil
-		}
-
-	case *interpreter.ArrayValue:
-		arrayStaticType := value.Type
-
-		arrayGethABIType, ok := gethABIType(arrayStaticType, evmAddressTypeID)
-		if !ok {
-			break
-		}
-
-		elementStaticType := arrayStaticType.ElementType()
-
-		elementGoType, ok := goType(elementStaticType, evmAddressTypeID)
-		if !ok {
-			break
-		}
-
-		var result reflect.Value
-
-		switch arrayStaticType := arrayStaticType.(type) {
-		case *interpreter.ConstantSizedStaticType:
-			size := int(arrayStaticType.Size)
-			result = reflect.Indirect(reflect.New(reflect.ArrayOf(size, elementGoType)))
-
-		case *interpreter.VariableSizedStaticType:
-			size := value.Count()
-			result = reflect.MakeSlice(reflect.SliceOf(elementGoType), size, size)
-		}
-
-		var index int
-		value.Iterate(
-			inter,
-			func(element interpreter.Value) (resume bool) {
-
-				arrayElement, _, err := encodeABI(
-					inter,
-					locationRange,
-					element,
-					element.StaticType(inter),
-					evmAddressTypeID,
-				)
-				if err != nil {
-					panic(err)
-				}
-
-				result.Index(index).Set(reflect.ValueOf(arrayElement))
-
-				index++
-
-				// continue iteration
-				return true
-			},
-			false,
-			locationRange,
-		)
-
-		return result.Interface(), arrayGethABIType, nil
-	}
-
-	return nil, gethABI.Type{}, abiEncodingError{
-		Type: value.StaticType(inter),
-	}
-}
-
-// EVM.decodeABI
-
-const internalEVMTypeDecodeABIFunctionName = "decodeABI"
-
-var internalEVMTypeDecodeABIFunctionType = &sema.FunctionType{
+var InternalEVMTypeDecodeABIFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Identifier: "types",
@@ -656,690 +116,76 @@ var internalEVMTypeDecodeABIFunctionType = &sema.FunctionType{
 	),
 }
 
-func newInternalEVMTypeDecodeABIFunction(
-	gauge common.MemoryGauge,
-	location common.AddressLocation,
-) *interpreter.HostFunctionValue {
-	evmAddressTypeID := location.TypeID(gauge, evmAddressTypeQualifiedIdentifier)
+// InternalEVM.run
 
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeDecodeABIFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+const InternalEVMTypeRunFunctionName = "run"
 
-			// Get `types` argument
-
-			typesArray, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			// Get `data` argument
-
-			dataValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			invocation.Interpreter.ReportComputation(
-				environment.ComputationKindEVMDecodeABI,
-				uint(dataValue.Count()),
-			)
-
-			data, err := interpreter.ByteArrayValueToByteSlice(inter, dataValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			var arguments gethABI.Arguments
-			typesArray.Iterate(
-				inter,
-				func(element interpreter.Value) (resume bool) {
-					typeValue, ok := element.(interpreter.TypeValue)
-					if !ok {
-						panic(errors.NewUnreachableError())
-					}
-
-					staticType := typeValue.Type
-
-					gethABITy, ok := gethABIType(staticType, evmAddressTypeID)
-					if !ok {
-						panic(abiDecodingError{
-							Type: staticType,
-						})
-					}
-
-					arguments = append(
-						arguments,
-						gethABI.Argument{
-							Type: gethABITy,
-						},
-					)
-
-					// continue iteration
-					return true
-				},
-				false,
-				locationRange,
-			)
-
-			decodedValues, err := arguments.Unpack(data)
-			if err != nil {
-				panic(abiDecodingError{})
-			}
-
-			var index int
-			values := make([]interpreter.Value, 0, len(decodedValues))
-
-			typesArray.Iterate(
-				inter,
-				func(element interpreter.Value) (resume bool) {
-					typeValue, ok := element.(interpreter.TypeValue)
-					if !ok {
-						panic(errors.NewUnreachableError())
-					}
-
-					staticType := typeValue.Type
-
-					value, err := decodeABI(
-						inter,
-						locationRange,
-						decodedValues[index],
-						staticType,
-						location,
-						evmAddressTypeID,
-					)
-					if err != nil {
-						panic(err)
-					}
-
-					index++
-
-					values = append(values, value)
-
-					// continue iteration
-					return true
-				},
-				false,
-				locationRange,
-			)
-
-			arrayType := interpreter.NewVariableSizedStaticType(
-				inter,
-				interpreter.NewPrimitiveStaticType(
-					inter,
-					interpreter.PrimitiveStaticTypeAnyStruct,
-				),
-			)
-
-			return interpreter.NewArrayValue(
-				inter,
-				locationRange,
-				arrayType,
-				common.ZeroAddress,
-				values...,
-			)
-		},
-	)
-}
-
-func decodeABI(
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	value any,
-	staticType interpreter.StaticType,
-	location common.AddressLocation,
-	evmAddressTypeID common.TypeID,
-) (
-	interpreter.Value,
-	error,
-) {
-
-	switch staticType {
-	case interpreter.PrimitiveStaticTypeString:
-		value, ok := value.(string)
-		if !ok {
-			break
-		}
-		return interpreter.NewStringValue(
-			inter,
-			common.NewStringMemoryUsage(len(value)),
-			func() string {
-				return value
-			},
-		), nil
-
-	case interpreter.PrimitiveStaticTypeBool:
-		value, ok := value.(bool)
-		if !ok {
-			break
-		}
-		return interpreter.BoolValue(value), nil
-
-	case interpreter.PrimitiveStaticTypeUInt8:
-		value, ok := value.(uint8)
-		if !ok {
-			break
-		}
-		return interpreter.NewUInt8Value(inter, func() uint8 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeUInt16:
-		value, ok := value.(uint16)
-		if !ok {
-			break
-		}
-		return interpreter.NewUInt16Value(inter, func() uint16 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeUInt32:
-		value, ok := value.(uint32)
-		if !ok {
-			break
-		}
-		return interpreter.NewUInt32Value(inter, func() uint32 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeUInt64:
-		value, ok := value.(uint64)
-		if !ok {
-			break
-		}
-		return interpreter.NewUInt64Value(inter, func() uint64 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeUInt128:
-		value, ok := value.(*big.Int)
-		if !ok {
-			break
-		}
-		return interpreter.NewUInt128ValueFromBigInt(inter, func() *big.Int { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeUInt256:
-		value, ok := value.(*big.Int)
-		if !ok {
-			break
-		}
-		return interpreter.NewUInt256ValueFromBigInt(inter, func() *big.Int { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeInt8:
-		value, ok := value.(int8)
-		if !ok {
-			break
-		}
-		return interpreter.NewInt8Value(inter, func() int8 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeInt16:
-		value, ok := value.(int16)
-		if !ok {
-			break
-		}
-		return interpreter.NewInt16Value(inter, func() int16 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeInt32:
-		value, ok := value.(int32)
-		if !ok {
-			break
-		}
-		return interpreter.NewInt32Value(inter, func() int32 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeInt64:
-		value, ok := value.(int64)
-		if !ok {
-			break
-		}
-		return interpreter.NewInt64Value(inter, func() int64 { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeInt128:
-		value, ok := value.(*big.Int)
-		if !ok {
-			break
-		}
-		return interpreter.NewInt128ValueFromBigInt(inter, func() *big.Int { return value }), nil
-
-	case interpreter.PrimitiveStaticTypeInt256:
-		value, ok := value.(*big.Int)
-		if !ok {
-			break
-		}
-		return interpreter.NewInt256ValueFromBigInt(inter, func() *big.Int { return value }), nil
-	}
-
-	switch staticType := staticType.(type) {
-	case interpreter.ArrayStaticType:
-		array := reflect.ValueOf(value)
-
-		elementStaticType := staticType.ElementType()
-
-		size := array.Len()
-
-		var index int
-		return interpreter.NewArrayValueWithIterator(
-			inter,
-			staticType,
-			common.ZeroAddress,
-			uint64(size),
-			func() interpreter.Value {
-				if index >= size {
-					return nil
-				}
-
-				element := array.Index(index).Interface()
-
-				result, err := decodeABI(
-					inter,
-					locationRange,
-					element,
-					elementStaticType,
-					location,
-					evmAddressTypeID,
-				)
-				if err != nil {
-					panic(err)
-				}
-
-				index++
-
-				return result
-			},
-		), nil
-
-	case *interpreter.CompositeStaticType:
-		if staticType.TypeID != evmAddressTypeID {
-			break
-		}
-
-		addr, ok := value.(gethCommon.Address)
-		if !ok {
-			break
-		}
-
-		var address types.Address
-		copy(address[:], addr.Bytes())
-		return NewEVMAddress(
-			inter,
-			locationRange,
-			location,
-			address,
-		), nil
-	}
-
-	return nil, abiDecodingError{
-		Type: staticType,
-	}
-}
-
-func NewEVMAddress(
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	location common.AddressLocation,
-	address types.Address,
-) *interpreter.CompositeValue {
-	return interpreter.NewCompositeValue(
-		inter,
-		locationRange,
-		location,
-		evmAddressTypeQualifiedIdentifier,
-		common.CompositeKindStructure,
-		[]interpreter.CompositeField{
-			{
-				Name:  evmAddressTypeBytesFieldName,
-				Value: EVMAddressToAddressBytesArrayValue(inter, address),
-			},
-		},
-		common.ZeroAddress,
-	)
-}
-
-const internalEVMTypeRunFunctionName = "run"
-
-var internalEVMTypeRunFunctionType = &sema.FunctionType{
+var InternalEVMTypeRunFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "tx",
-			TypeAnnotation: sema.NewTypeAnnotation(evmTransactionBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMTransactionBytesType),
 		},
 		{
 			Label:          "coinbase",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	// Actually EVM.Result, but cannot refer to it here
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
-func newInternalEVMTypeRunFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeRunFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.dryRun
 
-			// Get transaction argument
+const InternalEVMTypeDryRunFunctionName = "dryRun"
 
-			transactionValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			transaction, err := interpreter.ByteArrayValueToByteSlice(inter, transactionValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get gas fee collector argument
-
-			gasFeeCollectorValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			gasFeeCollector, err := interpreter.ByteArrayValueToByteSlice(inter, gasFeeCollectorValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			// run transaction
-			result := handler.Run(transaction, types.NewAddressFromBytes(gasFeeCollector))
-
-			return NewResultValue(handler, gauge, inter, locationRange, result)
-		},
-	)
-}
-
-// dry run
-
-const internalEVMTypeDryRunFunctionName = "dryRun"
-
-var internalEVMTypeDryRunFunctionType = &sema.FunctionType{
+var InternalEVMTypeDryRunFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "tx",
-			TypeAnnotation: sema.NewTypeAnnotation(evmTransactionBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMTransactionBytesType),
 		},
 		{
 			Label:          "from",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	// Actually EVM.Result, but cannot refer to it here
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
-func newInternalEVMTypeDryRunFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeDryRunFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.batchRun
 
-			// Get transaction argument
+const InternalEVMTypeBatchRunFunctionName = "batchRun"
 
-			transactionValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			transaction, err := interpreter.ByteArrayValueToByteSlice(inter, transactionValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get from argument
-
-			fromValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			from, err := interpreter.ByteArrayValueToByteSlice(inter, fromValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			// call estimate
-
-			res := handler.DryRun(transaction, types.NewAddressFromBytes(from))
-			return NewResultValue(handler, gauge, inter, locationRange, res)
-		},
-	)
-}
-
-const internalEVMTypeBatchRunFunctionName = "batchRun"
-
-var internalEVMTypeBatchRunFunctionType = &sema.FunctionType{
+var InternalEVMTypeBatchRunFunctionType *sema.FunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "txs",
-			TypeAnnotation: sema.NewTypeAnnotation(evmTransactionsBatchBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMTransactionsBatchBytesType),
 		},
 		{
 			Label:          "coinbase",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	// Actually [EVM.Result], but cannot refer to it here
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.NewVariableSizedType(nil, sema.AnyStructType)),
 }
 
-func newInternalEVMTypeBatchRunFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeBatchRunFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.call
 
-			// Get transactions batch argument
-			transactionsBatchValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
+const InternalEVMTypeCallFunctionName = "call"
 
-			batchCount := transactionsBatchValue.Count()
-			var transactionBatch [][]byte
-			if batchCount > 0 {
-				transactionBatch = make([][]byte, batchCount)
-				i := 0
-				transactionsBatchValue.Iterate(inter, func(transactionValue interpreter.Value) (resume bool) {
-					t, err := interpreter.ByteArrayValueToByteSlice(inter, transactionValue, locationRange)
-					if err != nil {
-						panic(err)
-					}
-					transactionBatch[i] = t
-					i++
-					return true
-				}, false, locationRange)
-			}
-
-			// Get gas fee collector argument
-			gasFeeCollectorValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			gasFeeCollector, err := interpreter.ByteArrayValueToByteSlice(inter, gasFeeCollectorValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			// Batch run
-			batchResults := handler.BatchRun(transactionBatch, types.NewAddressFromBytes(gasFeeCollector))
-
-			values := newResultValues(handler, gauge, inter, locationRange, batchResults)
-
-			loc := common.NewAddressLocation(gauge, handler.EVMContractAddress(), ContractName)
-			evmResultType := interpreter.NewVariableSizedStaticType(
-				inter,
-				interpreter.NewCompositeStaticType(
-					nil,
-					loc,
-					evmResultTypeQualifiedIdentifier,
-					common.NewTypeIDFromQualifiedName(
-						nil,
-						loc,
-						evmResultTypeQualifiedIdentifier,
-					),
-				),
-			)
-
-			return interpreter.NewArrayValue(
-				inter,
-				locationRange,
-				evmResultType,
-				common.ZeroAddress,
-				values...,
-			)
-		},
-	)
-}
-
-// newResultValues converts batch run result summary type to cadence array of structs
-func newResultValues(
-	handler types.ContractHandler,
-	gauge common.MemoryGauge,
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	results []*types.ResultSummary,
-) []interpreter.Value {
-	values := make([]interpreter.Value, 0)
-	for _, result := range results {
-		res := NewResultValue(handler, gauge, inter, locationRange, result)
-		values = append(values, res)
-	}
-	return values
-}
-
-func NewResultValue(
-	handler types.ContractHandler,
-	gauge common.MemoryGauge,
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	result *types.ResultSummary,
-) *interpreter.CompositeValue {
-
-	evmContractLocation := common.NewAddressLocation(
-		gauge,
-		handler.EVMContractAddress(),
-		ContractName,
-	)
-
-	deployedContractAddress := result.DeployedContractAddress
-	deployedContractValue := interpreter.NilOptionalValue
-	if deployedContractAddress != nil {
-		deployedContractValue = interpreter.NewSomeValueNonCopying(
-			inter,
-			NewEVMAddress(
-				inter,
-				locationRange,
-				evmContractLocation,
-				*deployedContractAddress,
-			),
-		)
-	}
-
-	fields := []interpreter.CompositeField{
-		{
-			Name: "status",
-			Value: interpreter.NewEnumCaseValue(
-				inter,
-				locationRange,
-				&sema.CompositeType{
-					Location:   evmContractLocation,
-					Identifier: evmStatusTypeQualifiedIdentifier,
-					Kind:       common.CompositeKindEnum,
-				},
-				interpreter.NewUInt8Value(gauge, func() uint8 {
-					return uint8(result.Status)
-				}),
-				nil,
-			),
-		},
-		{
-			Name: "errorCode",
-			Value: interpreter.NewUInt64Value(gauge, func() uint64 {
-				return uint64(result.ErrorCode)
-			}),
-		},
-		{
-			Name: "errorMessage",
-			Value: interpreter.NewStringValue(inter,
-				common.NewStringMemoryUsage(len(result.ErrorMessage)),
-				func() string {
-					return result.ErrorMessage
-				},
-			),
-		},
-		{
-			Name: "gasUsed",
-			Value: interpreter.NewUInt64Value(gauge, func() uint64 {
-				return result.GasConsumed
-			}),
-		},
-		{
-			Name:  "data",
-			Value: interpreter.ByteSliceToByteArrayValue(inter, result.ReturnedData),
-		},
-		{
-			Name:  "deployedContract",
-			Value: deployedContractValue,
-		},
-	}
-
-	return interpreter.NewCompositeValue(
-		inter,
-		locationRange,
-		evmContractLocation,
-		evmResultTypeQualifiedIdentifier,
-		common.CompositeKindStructure,
-		fields,
-		common.ZeroAddress,
-	)
-}
-
-func EVMAddressToAddressBytesArrayValue(
-	inter *interpreter.Interpreter,
-	address types.Address,
-) *interpreter.ArrayValue {
-	var index int
-	return interpreter.NewArrayValueWithIterator(
-		inter,
-		evmAddressBytesStaticType,
-		common.ZeroAddress,
-		types.AddressLength,
-		func() interpreter.Value {
-			if index >= types.AddressLength {
-				return nil
-			}
-			result := interpreter.NewUInt8Value(inter, func() uint8 {
-				return address[index]
-			})
-			index++
-			return result
-		},
-	)
-}
-
-const internalEVMTypeCallFunctionName = "call"
-
-var internalEVMTypeCallFunctionType = &sema.FunctionType{
+var InternalEVMTypeCallFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "from",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 		{
 			Label:          "to",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 		{
 			Label:          "data",
@@ -1358,152 +204,25 @@ var internalEVMTypeCallFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
-func AddressBytesArrayValueToEVMAddress(
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	addressBytesValue *interpreter.ArrayValue,
-) (
-	result types.Address,
-	err error,
-) {
-	// Convert
+// InternalEVM.createCadenceOwnedAccount
 
-	var bytes []byte
-	bytes, err = interpreter.ByteArrayValueToByteSlice(
-		inter,
-		addressBytesValue,
-		locationRange,
-	)
-	if err != nil {
-		return result, err
-	}
+const InternalEVMTypeCreateCadenceOwnedAccountFunctionName = "createCadenceOwnedAccount"
 
-	// Check length
-
-	length := len(bytes)
-	const expectedLength = types.AddressLength
-	if length != expectedLength {
-		return result, errors.NewDefaultUserError(
-			"invalid address length: got %d, expected %d",
-			length,
-			expectedLength,
-		)
-	}
-
-	copy(result[:], bytes)
-
-	return result, nil
-}
-
-func newInternalEVMTypeCallFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeCallFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
-
-			// Get from address
-
-			fromAddressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			fromAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, fromAddressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get to address
-
-			toAddressValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			toAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, toAddressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get data
-
-			dataValue, ok := invocation.Arguments[2].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			data, err := interpreter.ByteArrayValueToByteSlice(inter, dataValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get gas limit
-
-			gasLimitValue, ok := invocation.Arguments[3].(interpreter.UInt64Value)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			gasLimit := types.GasLimit(gasLimitValue)
-
-			// Get balance
-
-			balanceValue, ok := invocation.Arguments[4].(interpreter.UIntValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			balance := types.NewBalance(balanceValue.BigInt)
-			// Call
-
-			const isAuthorized = true
-			account := handler.AccountByAddress(fromAddress, isAuthorized)
-			result := account.Call(toAddress, data, gasLimit, balance)
-
-			return NewResultValue(handler, gauge, inter, locationRange, result)
-		},
-	)
-}
-
-const internalEVMTypeCreateCadenceOwnedAccountFunctionName = "createCadenceOwnedAccount"
-
-var internalEVMTypeCreateCadenceOwnedAccountFunctionType = &sema.FunctionType{
+var InternalEVMTypeCreateCadenceOwnedAccountFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "uuid",
 			TypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
 		},
 	},
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 }
 
-func newInternalEVMTypeCreateCadenceOwnedAccountFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeCreateCadenceOwnedAccountFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			uuid, ok := invocation.Arguments[0].(interpreter.UInt64Value)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-			address := handler.DeployCOA(uint64(uuid))
-			return EVMAddressToAddressBytesArrayValue(inter, address)
-		},
-	)
-}
+// InternalEVM.deposit
 
-const internalEVMTypeDepositFunctionName = "deposit"
+const InternalEVMTypeDepositFunctionName = "deposit"
 
-var internalEVMTypeDepositFunctionType = &sema.FunctionType{
+var InternalEVMTypeDepositFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "from",
@@ -1511,247 +230,78 @@ var internalEVMTypeDepositFunctionType = &sema.FunctionType{
 		},
 		{
 			Label:          "to",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 }
 
-const fungibleTokenVaultTypeBalanceFieldName = "balance"
+// InternalEVM.balance
 
-func newInternalEVMTypeDepositFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeDepositFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+const InternalEVMTypeBalanceFunctionName = "balance"
 
-			// Get from vault
-
-			fromValue, ok := invocation.Arguments[0].(*interpreter.CompositeValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			amountValue, ok := fromValue.GetField(
-				inter,
-				locationRange,
-				fungibleTokenVaultTypeBalanceFieldName,
-			).(interpreter.UFix64Value)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			amount := types.NewBalanceFromUFix64(cadence.UFix64(amountValue))
-
-			// Get to address
-
-			toAddressValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			toAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, toAddressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			// NOTE: We're intentionally not destroying the vault here,
-			// because the value of it is supposed to be "kept alive".
-			// Destroying would incorrectly be equivalent to a burn and decrease the total supply,
-			// and a withdrawal would then have to perform an actual mint of new tokens.
-
-			// Deposit
-
-			const isAuthorized = false
-			account := handler.AccountByAddress(toAddress, isAuthorized)
-			account.Deposit(types.NewFlowTokenVault(amount))
-
-			return interpreter.Void
-		},
-	)
-}
-
-const internalEVMTypeBalanceFunctionName = "balance"
-
-var internalEVMTypeBalanceFunctionType = &sema.FunctionType{
+var InternalEVMTypeBalanceFunctionType = &sema.FunctionType{
 	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
 			Label:          "address",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UIntType),
 }
 
-// newInternalEVMTypeBalanceFunction returns the Flow balance of the account
-func newInternalEVMTypeBalanceFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeBalanceFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.nonce
 
-			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
+const InternalEVMTypeNonceFunctionName = "nonce"
 
-			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			const isAuthorized = false
-			account := handler.AccountByAddress(address, isAuthorized)
-
-			return interpreter.UIntValue{BigInt: account.Balance()}
-		},
-	)
-}
-
-const internalEVMTypeNonceFunctionName = "nonce"
-
-var internalEVMTypeNonceFunctionType = &sema.FunctionType{
+var InternalEVMTypeNonceFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "address",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
 }
 
-// newInternalEVMTypeNonceFunction returns the nonce of the account
-func newInternalEVMTypeNonceFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeNonceFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.code
 
-			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
+const InternalEVMTypeCodeFunctionName = "code"
 
-			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			const isAuthorized = false
-			account := handler.AccountByAddress(address, isAuthorized)
-
-			return interpreter.UInt64Value(account.Nonce())
-		},
-	)
-}
-
-const internalEVMTypeCodeFunctionName = "code"
-
-var internalEVMTypeCodeFunctionType = &sema.FunctionType{
+var InternalEVMTypeCodeFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "address",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
 }
 
-// newInternalEVMTypeCodeFunction returns the code of the account
-func newInternalEVMTypeCodeFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeCodeFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.codeHash
 
-			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
+const InternalEVMTypeCodeHashFunctionName = "codeHash"
 
-			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			const isAuthorized = false
-			account := handler.AccountByAddress(address, isAuthorized)
-
-			return interpreter.ByteSliceToByteArrayValue(inter, account.Code())
-		},
-	)
-}
-
-const internalEVMTypeCodeHashFunctionName = "codeHash"
-
-var internalEVMTypeCodeHashFunctionType = &sema.FunctionType{
+var InternalEVMTypeCodeHashFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "address",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 	},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
 }
 
-// newInternalEVMTypeCodeHashFunction returns the code hash of the account
-func newInternalEVMTypeCodeHashFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeCodeHashFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.withdraw
 
-			addressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
+const InternalEVMTypeWithdrawFunctionName = "withdraw"
 
-			address, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, addressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			const isAuthorized = false
-			account := handler.AccountByAddress(address, isAuthorized)
-
-			return interpreter.ByteSliceToByteArrayValue(inter, account.CodeHash())
-		},
-	)
-}
-
-const internalEVMTypeWithdrawFunctionName = "withdraw"
-
-var internalEVMTypeWithdrawFunctionType = &sema.FunctionType{
+var InternalEVMTypeWithdrawFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "from",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 		{
 			Label:          "amount",
@@ -1761,86 +311,15 @@ var internalEVMTypeWithdrawFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyResourceType),
 }
 
-func newInternalEVMTypeWithdrawFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeWithdrawFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.deploy
 
-			// Get from address
+const InternalEVMTypeDeployFunctionName = "deploy"
 
-			fromAddressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			fromAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, fromAddressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get amount
-
-			amountValue, ok := invocation.Arguments[1].(interpreter.UIntValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			amount := types.NewBalance(amountValue.BigInt)
-
-			// Withdraw
-
-			const isAuthorized = true
-			account := handler.AccountByAddress(fromAddress, isAuthorized)
-			vault := account.Withdraw(amount)
-
-			ufix, roundedOff, err := types.ConvertBalanceToUFix64(vault.Balance())
-			if err != nil {
-				panic(err)
-			}
-			if roundedOff {
-				panic(types.ErrWithdrawBalanceRounding)
-			}
-
-			// TODO: improve: maybe call actual constructor
-			return interpreter.NewCompositeValue(
-				inter,
-				locationRange,
-				common.NewAddressLocation(gauge, handler.FlowTokenAddress(), "FlowToken"),
-				"FlowToken.Vault",
-				common.CompositeKindResource,
-				[]interpreter.CompositeField{
-					{
-						Name: "balance",
-						Value: interpreter.NewUFix64Value(gauge, func() uint64 {
-							return uint64(ufix)
-						}),
-					},
-					{
-						Name: sema.ResourceUUIDFieldName,
-						Value: interpreter.NewUInt64Value(gauge, func() uint64 {
-							return handler.GenerateResourceUUID()
-						}),
-					},
-				},
-				common.ZeroAddress,
-			)
-		},
-	)
-}
-
-const internalEVMTypeDeployFunctionName = "deploy"
-
-var internalEVMTypeDeployFunctionType = &sema.FunctionType{
+var InternalEVMTypeDeployFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "from",
-			TypeAnnotation: sema.NewTypeAnnotation(evmAddressBytesType),
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
 		},
 		{
 			Label:          "code",
@@ -1859,74 +338,11 @@ var internalEVMTypeDeployFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
-func newInternalEVMTypeDeployFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeDeployFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
+// InternalEVM.castToAttoFLOW
 
-			// Get from address
+const InternalEVMTypeCastToAttoFLOWFunctionName = "castToAttoFLOW"
 
-			fromAddressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			fromAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, fromAddressValue)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get code
-
-			codeValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			code, err := interpreter.ByteArrayValueToByteSlice(inter, codeValue, locationRange)
-			if err != nil {
-				panic(err)
-			}
-
-			// Get gas limit
-
-			gasLimitValue, ok := invocation.Arguments[2].(interpreter.UInt64Value)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			gasLimit := types.GasLimit(gasLimitValue)
-
-			// Get value
-
-			amountValue, ok := invocation.Arguments[3].(interpreter.UIntValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-
-			amount := types.NewBalance(amountValue.BigInt)
-
-			// Deploy
-
-			const isAuthorized = true
-			account := handler.AccountByAddress(fromAddress, isAuthorized)
-			result := account.Deploy(code, gasLimit, amount)
-
-			res := NewResultValue(handler, gauge, inter, locationRange, result)
-			return res
-		},
-	)
-}
-
-const internalEVMTypeCastToAttoFLOWFunctionName = "castToAttoFLOW"
-
-var internalEVMTypeCastToAttoFLOWFunctionType = &sema.FunctionType{
+var InternalEVMTypeCastToAttoFLOWFunctionType = &sema.FunctionType{
 	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
@@ -1937,26 +353,11 @@ var internalEVMTypeCastToAttoFLOWFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UIntType),
 }
 
-func newInternalEVMTypeCastToAttoFLOWFunction(
-	gauge common.MemoryGauge,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeCastToAttoFLOWFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			balanceValue, ok := invocation.Arguments[0].(interpreter.UFix64Value)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-			balance := types.NewBalanceFromUFix64(cadence.UFix64(balanceValue))
-			return interpreter.UIntValue{BigInt: balance}
-		},
-	)
-}
+// InternalEVM.castToFLOW
 
-const internalEVMTypeCastToFLOWFunctionName = "castToFLOW"
+const InternalEVMTypeCastToFLOWFunctionName = "castToFLOW"
 
-var internalEVMTypeCastToFLOWFunctionType = &sema.FunctionType{
+var InternalEVMTypeCastToFLOWFunctionType = &sema.FunctionType{
 	Purity: sema.FunctionPurityView,
 	Parameters: []sema.Parameter{
 		{
@@ -1967,162 +368,26 @@ var internalEVMTypeCastToFLOWFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.UFix64Type),
 }
 
-func newInternalEVMTypeCastToFLOWFunction(
-	gauge common.MemoryGauge,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeCastToFLOWFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			balanceValue, ok := invocation.Arguments[0].(interpreter.UIntValue)
-			if !ok {
-				panic(errors.NewUnreachableError())
-			}
-			balance := types.NewBalance(balanceValue.BigInt)
-			// ignoring the rounding error and let user handle it
-			v, _, err := types.ConvertBalanceToUFix64(balance)
-			if err != nil {
-				panic(err)
-			}
-			return interpreter.UFix64Value(v)
-		},
-	)
-}
+// InternalEVM.commitBlockProposal
 
-const internalEVMTypeCommitBlockProposalFunctionName = "commitBlockProposal"
+const InternalEVMTypeCommitBlockProposalFunctionName = "commitBlockProposal"
 
-var internalEVMTypeCommitBlockProposalFunctionType = &sema.FunctionType{
+var InternalEVMTypeCommitBlockProposalFunctionType = &sema.FunctionType{
 	Parameters:           []sema.Parameter{},
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.VoidType),
 }
 
-func newInternalEVMTypeCommitBlockProposalFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeCommitBlockProposalFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			handler.CommitBlockProposal()
-			return interpreter.Void
-		},
-	)
-}
+// InternalEVM.getLatestBlock
 
-const internalEVMTypeGetLatestBlockFunctionName = "getLatestBlock"
+const InternalEVMTypeGetLatestBlockFunctionName = "getLatestBlock"
 
-var internalEVMTypeGetLatestBlockFunctionType = &sema.FunctionType{
+var InternalEVMTypeGetLatestBlockFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{},
 	// Actually EVM.Block, but cannot refer to it here
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
-func newInternalEVMTypeGetLatestBlockFunction(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-) *interpreter.HostFunctionValue {
-	return interpreter.NewStaticHostFunctionValue(
-		gauge,
-		internalEVMTypeGetLatestBlockFunctionType,
-		func(invocation interpreter.Invocation) interpreter.Value {
-			inter := invocation.Interpreter
-			locationRange := invocation.LocationRange
-
-			latestBlock := handler.LastExecutedBlock()
-			return NewEVMBlockValue(handler, gauge, inter, locationRange, latestBlock)
-		},
-	)
-}
-
-func NewEVMBlockValue(
-	handler types.ContractHandler,
-	gauge common.MemoryGauge,
-	inter *interpreter.Interpreter,
-	locationRange interpreter.LocationRange,
-	block *types.Block,
-) *interpreter.CompositeValue {
-	loc := common.NewAddressLocation(gauge, handler.EVMContractAddress(), ContractName)
-	hash, err := block.Hash()
-	if err != nil {
-		panic(err)
-	}
-
-	return interpreter.NewCompositeValue(
-		inter,
-		locationRange,
-		loc,
-		evmBlockTypeQualifiedIdentifier,
-		common.CompositeKindStructure,
-		[]interpreter.CompositeField{
-			{
-				Name:  "height",
-				Value: interpreter.UInt64Value(block.Height),
-			},
-			{
-				Name: "hash",
-				Value: interpreter.NewStringValue(
-					inter,
-					common.NewStringMemoryUsage(len(hash)),
-					func() string {
-						return hash.Hex()
-					},
-				),
-			},
-			{
-				Name: "totalSupply",
-				Value: interpreter.NewIntValueFromBigInt(
-					inter,
-					common.NewBigIntMemoryUsage(common.BigIntByteLength(block.TotalSupply)),
-					func() *big.Int {
-						return block.TotalSupply
-					},
-				),
-			},
-			{
-				Name:  "timestamp",
-				Value: interpreter.UInt64Value(block.Timestamp),
-			},
-		},
-		common.ZeroAddress,
-	)
-}
-
-func NewInternalEVMContractValue(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-	location common.AddressLocation,
-) *interpreter.SimpleCompositeValue {
-	return interpreter.NewSimpleCompositeValue(
-		gauge,
-		InternalEVMContractType.ID(),
-		internalEVMContractStaticType,
-		InternalEVMContractType.Fields,
-		map[string]interpreter.Value{
-			internalEVMTypeRunFunctionName:                       newInternalEVMTypeRunFunction(gauge, handler),
-			internalEVMTypeBatchRunFunctionName:                  newInternalEVMTypeBatchRunFunction(gauge, handler),
-			internalEVMTypeCreateCadenceOwnedAccountFunctionName: newInternalEVMTypeCreateCadenceOwnedAccountFunction(gauge, handler),
-			internalEVMTypeCallFunctionName:                      newInternalEVMTypeCallFunction(gauge, handler),
-			internalEVMTypeDepositFunctionName:                   newInternalEVMTypeDepositFunction(gauge, handler),
-			internalEVMTypeWithdrawFunctionName:                  newInternalEVMTypeWithdrawFunction(gauge, handler),
-			internalEVMTypeDeployFunctionName:                    newInternalEVMTypeDeployFunction(gauge, handler),
-			internalEVMTypeBalanceFunctionName:                   newInternalEVMTypeBalanceFunction(gauge, handler),
-			internalEVMTypeNonceFunctionName:                     newInternalEVMTypeNonceFunction(gauge, handler),
-			internalEVMTypeCodeFunctionName:                      newInternalEVMTypeCodeFunction(gauge, handler),
-			internalEVMTypeCodeHashFunctionName:                  newInternalEVMTypeCodeHashFunction(gauge, handler),
-			internalEVMTypeEncodeABIFunctionName:                 newInternalEVMTypeEncodeABIFunction(gauge, location),
-			internalEVMTypeDecodeABIFunctionName:                 newInternalEVMTypeDecodeABIFunction(gauge, location),
-			internalEVMTypeCastToAttoFLOWFunctionName:            newInternalEVMTypeCastToAttoFLOWFunction(gauge),
-			internalEVMTypeCastToFLOWFunctionName:                newInternalEVMTypeCastToFLOWFunction(gauge),
-			internalEVMTypeGetLatestBlockFunctionName:            newInternalEVMTypeGetLatestBlockFunction(gauge, handler),
-			internalEVMTypeDryRunFunctionName:                    newInternalEVMTypeDryRunFunction(gauge, handler),
-			internalEVMTypeCommitBlockProposalFunctionName:       newInternalEVMTypeCommitBlockProposalFunction(gauge, handler),
-		},
-		nil,
-		nil,
-		nil,
-	)
-}
+// InternalEVM
 
 const InternalEVMContractName = "InternalEVM"
 
@@ -2135,130 +400,123 @@ var InternalEVMContractType = func() *sema.CompositeType {
 	ty.Members = sema.MembersAsMap([]*sema.Member{
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeRunFunctionName,
-			internalEVMTypeRunFunctionType,
+			InternalEVMTypeRunFunctionName,
+			InternalEVMTypeRunFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeDryRunFunctionName,
-			internalEVMTypeDryRunFunctionType,
+			InternalEVMTypeDryRunFunctionName,
+			InternalEVMTypeDryRunFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeBatchRunFunctionName,
-			internalEVMTypeBatchRunFunctionType,
+			InternalEVMTypeBatchRunFunctionName,
+			InternalEVMTypeBatchRunFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeCreateCadenceOwnedAccountFunctionName,
-			internalEVMTypeCreateCadenceOwnedAccountFunctionType,
+			InternalEVMTypeCreateCadenceOwnedAccountFunctionName,
+			InternalEVMTypeCreateCadenceOwnedAccountFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeCallFunctionName,
-			internalEVMTypeCallFunctionType,
+			InternalEVMTypeCallFunctionName,
+			InternalEVMTypeCallFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeDepositFunctionName,
-			internalEVMTypeDepositFunctionType,
+			InternalEVMTypeDepositFunctionName,
+			InternalEVMTypeDepositFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeWithdrawFunctionName,
-			internalEVMTypeWithdrawFunctionType,
+			InternalEVMTypeWithdrawFunctionName,
+			InternalEVMTypeWithdrawFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeDeployFunctionName,
-			internalEVMTypeDeployFunctionType,
+			InternalEVMTypeDeployFunctionName,
+			InternalEVMTypeDeployFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeCastToAttoFLOWFunctionName,
-			internalEVMTypeCastToAttoFLOWFunctionType,
+			InternalEVMTypeCastToAttoFLOWFunctionName,
+			InternalEVMTypeCastToAttoFLOWFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeCastToFLOWFunctionName,
-			internalEVMTypeCastToFLOWFunctionType,
+			InternalEVMTypeCastToFLOWFunctionName,
+			InternalEVMTypeCastToFLOWFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeBalanceFunctionName,
-			internalEVMTypeBalanceFunctionType,
+			InternalEVMTypeBalanceFunctionName,
+			InternalEVMTypeBalanceFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeNonceFunctionName,
-			internalEVMTypeNonceFunctionType,
+			InternalEVMTypeNonceFunctionName,
+			InternalEVMTypeNonceFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeCodeFunctionName,
-			internalEVMTypeCodeFunctionType,
+			InternalEVMTypeCodeFunctionName,
+			InternalEVMTypeCodeFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeCodeHashFunctionName,
-			internalEVMTypeCodeHashFunctionType,
+			InternalEVMTypeCodeHashFunctionName,
+			InternalEVMTypeCodeHashFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeEncodeABIFunctionName,
-			internalEVMTypeEncodeABIFunctionType,
+			InternalEVMTypeEncodeABIFunctionName,
+			InternalEVMTypeEncodeABIFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeDecodeABIFunctionName,
-			internalEVMTypeDecodeABIFunctionType,
+			InternalEVMTypeDecodeABIFunctionName,
+			InternalEVMTypeDecodeABIFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeGetLatestBlockFunctionName,
-			internalEVMTypeGetLatestBlockFunctionType,
+			InternalEVMTypeGetLatestBlockFunctionName,
+			InternalEVMTypeGetLatestBlockFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			internalEVMTypeCommitBlockProposalFunctionName,
-			internalEVMTypeCommitBlockProposalFunctionType,
+			InternalEVMTypeCommitBlockProposalFunctionName,
+			InternalEVMTypeCommitBlockProposalFunctionType,
 			"",
 		),
 	})
 	return ty
 }()
 
-var internalEVMContractStaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
-	nil,
-	InternalEVMContractType,
-)
-
 func newInternalEVMStandardLibraryValue(
-	gauge common.MemoryGauge,
-	handler types.ContractHandler,
-	location common.AddressLocation,
+	value interpreter.Value,
 ) stdlib.StandardLibraryValue {
 	return stdlib.StandardLibraryValue{
 		Name:  InternalEVMContractName,
 		Type:  InternalEVMContractType,
-		Value: NewInternalEVMContractValue(gauge, handler, location),
+		Value: value,
 		Kind:  common.DeclarationKindContract,
 	}
 }
@@ -2271,7 +529,7 @@ var internalEVMStandardLibraryType = stdlib.StandardLibraryType{
 
 func SetupEnvironment(
 	env runtime.Environment,
-	handler types.ContractHandler,
+	internalEVMValue interpreter.Value,
 	contractAddress flow.Address,
 ) {
 	location := common.NewAddressLocation(nil, common.Address(contractAddress), ContractName)
@@ -2281,7 +539,7 @@ func SetupEnvironment(
 		location,
 	)
 	env.DeclareValue(
-		newInternalEVMStandardLibraryValue(nil, handler, location),
+		newInternalEVMStandardLibraryValue(internalEVMValue),
 		location,
 	)
 }
@@ -2289,7 +547,7 @@ func SetupEnvironment(
 func NewEVMAddressCadenceType(address common.Address) *cadence.StructType {
 	return cadence.NewStructType(
 		common.NewAddressLocation(nil, address, ContractName),
-		evmAddressTypeQualifiedIdentifier,
+		EVMAddressTypeQualifiedIdentifier,
 		[]cadence.Field{
 			{
 				Identifier: "bytes",
@@ -2303,7 +561,7 @@ func NewEVMAddressCadenceType(address common.Address) *cadence.StructType {
 func NewBalanceCadenceType(address common.Address) *cadence.StructType {
 	return cadence.NewStructType(
 		common.NewAddressLocation(nil, address, ContractName),
-		evmBalanceTypeQualifiedIdentifier,
+		EVMBalanceTypeQualifiedIdentifier,
 		[]cadence.Field{
 			{
 				Identifier: "attoflow",
@@ -2314,99 +572,10 @@ func NewBalanceCadenceType(address common.Address) *cadence.StructType {
 	)
 }
 
-func ResultSummaryFromEVMResultValue(val cadence.Value) (*types.ResultSummary, error) {
-	str, ok := val.(cadence.Struct)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected value type")
-	}
-
-	fields := cadence.FieldsMappedByName(str)
-
-	const expectedFieldCount = 6
-	if len(fields) != expectedFieldCount {
-		return nil, fmt.Errorf(
-			"invalid input: field count mismatch: expected %d, got %d",
-			expectedFieldCount,
-			len(fields),
-		)
-	}
-
-	statusEnum, ok := fields[evmResultTypeStatusFieldName].(cadence.Enum)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected type for status field")
-	}
-
-	status, ok := cadence.FieldsMappedByName(statusEnum)[sema.EnumRawValueFieldName].(cadence.UInt8)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected type for status field")
-	}
-
-	errorCode, ok := fields[evmResultTypeErrorCodeFieldName].(cadence.UInt64)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected type for error code field")
-	}
-
-	errorMsg, ok := fields[evmResultTypeErrorMessageFieldName].(cadence.String)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected type for error msg field")
-	}
-
-	gasUsed, ok := fields[evmResultTypeGasUsedFieldName].(cadence.UInt64)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected type for gas field")
-	}
-
-	data, ok := fields[evmResultTypeDataFieldName].(cadence.Array)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected type for data field")
-	}
-
-	convertedData := make([]byte, len(data.Values))
-	for i, value := range data.Values {
-		convertedData[i] = byte(value.(cadence.UInt8))
-	}
-
-	var convertedDeployedAddress *types.Address
-
-	deployedAddressField, ok := fields[evmResultTypeDeployedContractFieldName].(cadence.Optional)
-	if !ok {
-		return nil, fmt.Errorf("invalid input: unexpected type for deployed contract field")
-	}
-
-	if deployedAddressField.Value != nil {
-		evmAddress, ok := deployedAddressField.Value.(cadence.Struct)
-		if !ok {
-			return nil, fmt.Errorf("invalid input: unexpected type for deployed contract field")
-		}
-
-		bytes, ok := cadence.SearchFieldByName(evmAddress, evmAddressTypeBytesFieldName).(cadence.Array)
-		if !ok {
-			return nil, fmt.Errorf("invalid input: unexpected type for deployed contract field")
-		}
-
-		convertedAddress := make([]byte, len(bytes.Values))
-		for i, value := range bytes.Values {
-			convertedAddress[i] = byte(value.(cadence.UInt8))
-		}
-		addr := types.Address(convertedAddress)
-		convertedDeployedAddress = &addr
-	}
-
-	return &types.ResultSummary{
-		Status:                  types.Status(status),
-		ErrorCode:               types.ErrorCode(errorCode),
-		ErrorMessage:            string(errorMsg),
-		GasConsumed:             uint64(gasUsed),
-		ReturnedData:            convertedData,
-		DeployedContractAddress: convertedDeployedAddress,
-	}, nil
-
-}
-
 func NewEVMBlockCadenceType(address common.Address) *cadence.StructType {
 	return cadence.NewStructType(
 		common.NewAddressLocation(nil, address, ContractName),
-		evmBlockTypeQualifiedIdentifier,
+		EVMBlockTypeQualifiedIdentifier,
 		[]cadence.Field{
 			{
 				Identifier: "height",

--- a/fvm/evm/stdlib/contract_test.go
+++ b/fvm/evm/stdlib/contract_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/flow-go/fvm/blueprints"
 	"github.com/onflow/flow-go/fvm/environment"
+	"github.com/onflow/flow-go/fvm/evm/impl"
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	. "github.com/onflow/flow-go/fvm/evm/testutils"
 	"github.com/onflow/flow-go/fvm/evm/types"
@@ -308,9 +309,15 @@ func deployContracts(
 func newEVMTransactionEnvironment(handler types.ContractHandler, contractAddress flow.Address) runtime.Environment {
 	transactionEnvironment := runtime.NewBaseInterpreterEnvironment(runtime.Config{})
 
+	internalEVMValue := impl.NewInternalEVMContractValue(
+		nil,
+		handler,
+		common.Address(contractAddress),
+	)
+
 	stdlib.SetupEnvironment(
 		transactionEnvironment,
-		handler,
+		internalEVMValue,
 		contractAddress,
 	)
 
@@ -320,9 +327,15 @@ func newEVMTransactionEnvironment(handler types.ContractHandler, contractAddress
 func newEVMScriptEnvironment(handler types.ContractHandler, contractAddress flow.Address) runtime.Environment {
 	scriptEnvironment := runtime.NewScriptInterpreterEnvironment(runtime.Config{})
 
+	internalEVMValue := impl.NewInternalEVMContractValue(
+		nil,
+		handler,
+		common.Address(contractAddress),
+	)
+
 	stdlib.SetupEnvironment(
 		scriptEnvironment,
-		handler,
+		internalEVMValue,
 		contractAddress,
 	)
 
@@ -3203,7 +3216,7 @@ func TestEVMDryRun(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	res, err := stdlib.ResultSummaryFromEVMResultValue(val)
+	res, err := impl.ResultSummaryFromEVMResultValue(val)
 	require.NoError(t, err)
 	assert.Equal(t, types.StatusSuccessful, res.Status)
 	assert.True(t, dryRunCalled)
@@ -3335,7 +3348,7 @@ func TestEVMBatchRun(t *testing.T) {
 	require.True(t, ok)
 
 	for _, v := range resultsCadence.Values {
-		res, err := stdlib.ResultSummaryFromEVMResultValue(v)
+		res, err := impl.ResultSummaryFromEVMResultValue(v)
 		require.NoError(t, err)
 		assert.Equal(t, types.StatusSuccessful, res.Status)
 	}

--- a/fvm/evm/stdlib/type_test.go
+++ b/fvm/evm/stdlib/type_test.go
@@ -1,4 +1,4 @@
-package stdlib
+package stdlib_test
 
 import (
 	"testing"
@@ -6,13 +6,14 @@ import (
 	"github.com/onflow/cadence/runtime/sema"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	"github.com/onflow/flow-go/model/flow"
 )
 
 func TestContractTypeForChain(t *testing.T) {
 	t.Parallel()
 
-	comp := ContractTypeForChain(flow.Emulator)
+	comp := stdlib.ContractTypeForChain(flow.Emulator)
 	require.NotNil(t, comp)
 
 	nestedTypes := comp.GetNestedTypes()


### PR DESCRIPTION
Move the implementation of the `EVM` and `InternalEVM` contract values into a separate package.

No actual logic changed, all code changes are purely for moving code as-is and renaming variables, constants, and functions, to export them.

This leaves all type definitions in `stdlib`, and removes all direct imports (or indirect imports, e.g. through `types`) of `go-ethereum`. This is useful, because the type definitions are needed e.g. for checking in the language server. The language server is compiled to WebAssembly and `go-ethereum` cannot be compiled to it.
See https://discord.com/channels/613813861610684416/1123314820763111465/1276610295485300758

For now the new package with the implementation is simply named `impl`, but only because I could not come up with a better name. Suggestions are very welcome!

cc @bluesign 
