### PR TITLE
[EVM] Decode legacy block event

### DIFF
--- a/fvm/evm/events/events.go
+++ b/fvm/evm/events/events.go
@@ -143,11 +143,48 @@ type BlockEventPayload struct {
 	PrevRandao          gethCommon.Hash `cadence:"prevrandao"`
 }
 
+// blockEventPayloadV0 legacy format of the block without prevrando field
+type blockEventPayloadV0 struct {
+	Height              uint64          `cadence:"height"`
+	Hash                gethCommon.Hash `cadence:"hash"`
+	Timestamp           uint64          `cadence:"timestamp"`
+	TotalSupply         cadence.Int     `cadence:"totalSupply"`
+	TotalGasUsed        uint64          `cadence:"totalGasUsed"`
+	ParentBlockHash     gethCommon.Hash `cadence:"parentHash"`
+	ReceiptRoot         gethCommon.Hash `cadence:"receiptRoot"`
+	TransactionHashRoot gethCommon.Hash `cadence:"transactionHashRoot"`
+}
+
+// decodeLegacyBlockEventPayload decodes any legacy block formats into
+// current version of the block event payload.
+func decodeLegacyBlockEventPayload(event cadence.Event) (*BlockEventPayload, error) {
+	var lb blockEventPayloadV0
+	if err := cadence.DecodeFields(event, &lb); err != nil {
+		return nil, err
+	}
+
+	return &BlockEventPayload{
+		Height:              lb.Height,
+		Hash:                lb.Hash,
+		Timestamp:           lb.Timestamp,
+		TotalSupply:         lb.TotalSupply,
+		TotalGasUsed:        lb.TotalGasUsed,
+		ParentBlockHash:     lb.ParentBlockHash,
+		ReceiptRoot:         lb.ReceiptRoot,
+		TransactionHashRoot: lb.TransactionHashRoot,
+	}, nil
+}
+
 // DecodeBlockEventPayload decodes Cadence event into block event payload.
 func DecodeBlockEventPayload(event cadence.Event) (*BlockEventPayload, error) {
 	var block BlockEventPayload
-	err := cadence.DecodeFields(event, &block)
-	return &block, err
+	if err := cadence.DecodeFields(event, &block); err != nil {
+		if block, err := decodeLegacyBlockEventPayload(event); err == nil {
+			return block, nil
+		}
+		return nil, err
+	}
+	return &block, nil
 }
 
 type TransactionEventPayload struct {


### PR DESCRIPTION
Decode legacy block event that doesn't contain `prevrandao` field. These events were emitted on testnet so we must make sure we can decode them using the events package.