### PR TITLE
[EVM] Improve EVM addresses in tests

### DIFF
--- a/fvm/evm/stdlib/contract_test.go
+++ b/fvm/evm/stdlib/contract_test.go
@@ -461,10 +461,9 @@ func TestEVMEncodeABIComputation(t *testing.T) {
       access(all)
       fun main(): [UInt8] {
         let address = EVM.EVMAddress(
-          bytes: [
-            122, 88, 192, 190, 114, 190, 33, 139, 65, 198,
-            8, 183, 254, 124, 91, 182, 48, 115, 108, 113
-          ]
+            bytes: "7A58c0Be72BE218B41C608b7Fe7C5bB630736C71"
+                .decodeHex()
+                .toConstantSized<[UInt8; 20]>()!
         )
         let arr: [UInt8] = [1, 2, 3, 4, 5]
 
@@ -884,10 +883,9 @@ func TestEVMDecodeABIComputation(t *testing.T) {
       access(all)
       fun main(): [UInt8] {
         let address = EVM.EVMAddress(
-          bytes: [
-            122, 88, 192, 190, 114, 190, 33, 139, 65, 198,
-            8, 183, 254, 124, 91, 182, 48, 115, 108, 113
-          ]
+            bytes: "7A58c0Be72BE218B41C608b7Fe7C5bB630736C71"
+                .decodeHex()
+                .toConstantSized<[UInt8; 20]>()!
         )
         let arr: [UInt8] = [1, 2, 3, 4, 5]
 
@@ -997,12 +995,10 @@ func TestEVMEncodeDecodeABIRoundtrip(t *testing.T) {
       access(all)
       fun main(): Bool {
         // Check EVM.EVMAddress encode/decode
-        // bytes for address 0x7A58c0Be72BE218B41C608b7Fe7C5bB630736C71
         let address = EVM.EVMAddress(
-          bytes: [
-            122, 88, 192, 190, 114, 190, 33, 139, 65, 198,
-            8, 183, 254, 124, 91, 182, 48, 115, 108, 113
-          ]
+            bytes: "7A58c0Be72BE218B41C608b7Fe7C5bB630736C71"
+                .decodeHex()
+                .toConstantSized<[UInt8; 20]>()!
         )
         var data = EVM.encodeABI([address])
         var values = EVM.decodeABI(types: [Type<EVM.EVMAddress>()], data: data)
@@ -2239,12 +2235,10 @@ func TestEVMEncodeABIWithSignature(t *testing.T) {
 
       access(all)
       fun main(): [UInt8] {
-        // bytes for address 0x7A58c0Be72BE218B41C608b7Fe7C5bB630736C71
         let address = EVM.EVMAddress(
-          bytes: [
-            122, 88, 192, 190, 114, 190, 33, 139, 65, 198,
-            8, 183, 254, 124, 91, 182, 48, 115, 108, 113
-          ]
+            bytes: "7A58c0Be72BE218B41C608b7Fe7C5bB630736C71"
+                .decodeHex()
+                .toConstantSized<[UInt8; 20]>()!
         )
 
         return EVM.encodeABIWithSignature(


### PR DESCRIPTION
Make the tests more readable and maintainable by using the hex address directly