### PR TITLE
Add support for `cap_tag` domain in `check-storage` command of `util` program

### DIFF
--- a/cmd/util/cmd/check-storage/cmd.go
+++ b/cmd/util/cmd/check-storage/cmd.go
@@ -11,7 +11,6 @@ import (
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
 
-	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
 	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
@@ -282,6 +281,9 @@ func checkStorageHealth(
 
 		err = registersByAccount.ForEachAccount(
 			func(accountRegisters *registers.AccountRegisters) error {
+				if slices.Contains(acctsToSkip, accountRegisters.Owner()) {
+					return nil
+				}
 				jobs <- job{accountRegisters: accountRegisters}
 				return nil
 			})
@@ -323,7 +325,7 @@ func checkAccountStorageHealth(accountRegisters *registers.AccountRegisters, nWo
 	ledger := &registers.ReadOnlyLedger{Registers: accountRegisters}
 	storage := runtime.NewStorage(ledger, nil)
 
-	err = util.CheckStorageHealth(address, storage, accountRegisters, migrations.AllStorageMapDomains, nWorkers)
+	err = util.CheckStorageHealth(address, storage, accountRegisters, util.StorageMapDomains, nWorkers)
 	if err != nil {
 		issues = append(
 			issues,

--- a/cmd/util/ledger/util/util.go
+++ b/cmd/util/ledger/util/util.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 
 	"github.com/onflow/atree"
+	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/stdlib"
 
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/ledger"
@@ -244,4 +246,16 @@ func (p *PayloadsLedger) AllocateSlabIndex(owner []byte) (atree.SlabIndex, error
 	}
 
 	panic("AllocateSlabIndex not expected to be called")
+}
+
+var StorageMapDomains = []string{
+	common.PathDomainStorage.Identifier(),
+	common.PathDomainPrivate.Identifier(),
+	common.PathDomainPublic.Identifier(),
+	runtime.StorageDomainContract,
+	stdlib.InboxStorageDomain,
+	stdlib.CapabilityControllerStorageDomain,
+	stdlib.CapabilityControllerTagStorageDomain,
+	stdlib.PathCapabilityStorageDomain,
+	stdlib.AccountCapabilityStorageDomain,
 }


### PR DESCRIPTION
Closes #6405

Currently, the util program's check-storage command doesn't support the `cap_tag` domain.

`cap_tag` domain was created on testnet and needs to be included in storage health check to avoid false alarms about unreferenced slabs.

This PR adds support for the cap_tag domain to `util` program's `check-storage` command.