### PR TITLE
Port PR #6407 (Add support for `cap_tag` domain in `diff-states` cmd) to v0.37 branch

### DIFF
--- a/cmd/util/cmd/diff-states/cmd.go
+++ b/cmd/util/cmd/diff-states/cmd.go
@@ -390,7 +390,7 @@ func diffAccount(
 		).DiffStates(
 			accountRegisters1,
 			accountRegisters2,
-			migrations.AllStorageMapDomains,
+			util.StorageMapDomains,
 		)
 	}
 


### PR DESCRIPTION
Currently, the `util` program's `diff-states` command doesn't support the `cap_tag` domain.

`cap_tag` domain was created on testnet and needs to be supported by `diff-states` to compare Cadence values.

This PR adds support for the `cap_tag` domain to util program's `diff-states` command.