### PR TITLE
[backport] minor revision of log, to clarify the root causes of likely benign error log

### DIFF
--- a/engine/common/follower/compliance_core.go
+++ b/engine/common/follower/compliance_core.go
@@ -161,7 +161,11 @@ func (c *ComplianceCore) OnBlockRange(originID flow.Identifier, batch []*flow.Bl
 				//     a critical liveness assumption - see EpochCommitSafetyThreshold in protocol.Params for details.
 				//     -> In this case, it is ok for the protocol to halt. Consequently, we can just disregard
 				//        the block, which will probably lead to this node eventually halting.
-				log.Err(err).Msg("unable to validate proposal with view from unknown epoch")
+				log.Err(err).Msg(
+					"Unable to validate proposal with view from unknown epoch. While there is noting wrong with the node, " +
+						"this could be a symptom of (i) the node being severely behind, (ii) there is a byzantine proposer in " +
+						"the network, or (iii) there was no finalization progress for hundreds of views. This should be " +
+						"investigated to confirm the cause is the benign scenario (i).")
 				return nil
 			}
 			return fmt.Errorf("unexpected error validating proposal: %w", err)


### PR DESCRIPTION

backport of https://github.com/onflow/flow-go/pull/6419

--- 

The following error message was logged by a freshly-bootstrapped AN:
```
{"level":"error","node_role":"access","node_id":"63ee3a914c0274caf8837260a26d06989e744ed242078b2b274d547d362d94a2","engine":"follower_core","origin_id":"faa62915ccfd5f85ac37de31827828b9222bbcfbb6892c3dd61f927b5437c612","chain_id":"flow-testnet","first_block_height":213442756,"first_block_view":2266431,"last_block_height":213442756,"last_block_view":2266431,"last_block_id":"dfa94213567f985fde228f3f5551bfd81741c291496a123812dae857dae7288a","range_length":1,"error":"error verifying leader signature for block dfa94213567f985fde228f3f5551bfd81741c291496a123812dae857dae7288a: error retrieving voter Identity at view 2266431: by-view query for unknown epoch","time":"2024-08-27T23:46:56.492526784Z","message":"unable to validate proposal with view from unknown epoch"}
```

### Challenge

Because this is logged on `error` level, this error log might mislead node operators into thinking that their node is not properly functioning. 

### Context

The current implementation is logging this as error because the software is saying "There could be a byzantine proposer in the network or I am very far behind (can't distinguish), a human should look into it and confirm we don't have malicious consensus participants in the network". In other words, this is not a malfunction in the node; instead it is a potentially safety-critical observation that the node reports about the network it is part of.

See [slack thread](https://flow-foundation.slack.com/archives/C071612SJJE/p1724802738274149) for further details. 

## Goal of this PR


* As we don't have automated attribution and  slashing of byzantine proposals implemented, I am inclined to keep the reporting of this edge case at the most severe error level, because we really want humans to confirm we don't have a byzantine node in the system.
* However, we also don't want to mislead node operators into thinking their node is broken. 
* While the [code emitting the log](https://github.com/onflow/flow-go/blob/eeac47931cd6837ec6e29c4c0480609238959ccd/engine/common/follower/compliance_core.go#L149-L165) already documents possible causes in detail, this requires engineers to trace the log message back to the emitting code, which is an additional hurdle for assessing the severity of this log. 
* This edge case only appears if a node is freshly bootstrapped very close to the epoch switchover. Furthermore, it stops being emitted after a very short time, when the node has caught up. 

Therefore, with this PR, a much more detailed log will be emitted. This should have comparatively little infrastructure cost, but hopefully saves some engineering time that would be otherwise necessary to diagnose this error log. 
