### PR TITLE
[Cadence 1.0 migration] Add EVM storage account creation migration

### DIFF
--- a/cmd/util/ledger/migrations/account.go
+++ b/cmd/util/ledger/migrations/account.go
@@ -1,0 +1,62 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/onflow/flow-go/cmd/util/ledger/util/registers"
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func NewAccountCreationMigration(
+	address flow.Address,
+	logger zerolog.Logger,
+) RegistersMigration {
+
+	return func(registersByAccount *registers.ByAccount) error {
+
+		migrationRuntime := NewBasicMigrationRuntime(registersByAccount)
+
+		// Check if the account already exists
+		exists, err := migrationRuntime.Accounts.Exists(address)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to check if account %s exists: %w",
+				address,
+				err,
+			)
+		}
+
+		// If the account already exists, do nothing
+		if exists {
+			logger.Info().Msgf("account %s already exists", address)
+			return nil
+		}
+
+		// Create the account
+		err = migrationRuntime.Accounts.Create(nil, address)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to create account %s: %w",
+				address,
+				err,
+			)
+		}
+
+		logger.Info().Msgf("created account %s", address)
+
+		// Commit the changes to the migrated registers
+		err = migrationRuntime.Commit(
+			map[flow.Address]struct{}{
+				address: {},
+			},
+			logger,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to commit account creation: %w", err)
+		}
+
+		return nil
+	}
+}

--- a/cmd/util/ledger/migrations/cadence.go
+++ b/cmd/util/ledger/migrations/cadence.go
@@ -834,6 +834,21 @@ func NewCadence1Migrations(
 				Migrate: NewEVMSetupMigration(opts.ChainID, log),
 			},
 		)
+		if opts.ChainID == flow.Emulator {
+
+			// In the Emulator the EVM storage account needs to be created
+
+			systemContracts := systemcontracts.SystemContractsForChain(opts.ChainID)
+			evmStorageAddress := systemContracts.EVMStorage.Address
+
+			migs = append(
+				migs,
+				NamedMigration{
+					Name:    "evm-storage-account-creation-migration",
+					Migrate: NewAccountCreationMigration(evmStorageAddress, log),
+				},
+			)
+		}
 	}
 
 	return migs


### PR DESCRIPTION
Reported in https://discord.com/channels/613813861610684416/1278736553795129374

After migrating an Emulator state snapshot to Cadence 1.0, sending any transaction against the migrated state fails:

```
Transaction ID: 7c2bf8e9f491fa0b033b984a677304897c7eaecab85586adff163a874bd9345a
❌ Command Error: failed to submit transaction: client: rpc error: code = Internal desc = [Error Code: 1201] error caused by: 1 error occurred:
    * transaction execute failed: [Error Code: 1101] cadence runtime error: Execution failed:
  --> 4b77dc12dc452df7174ff3f73b70dfe4d1e5434d8b40e78deefe3b7b6ae7105d:14:8
   |
14 |         evmHeartbeat.heartbeat()
   |         ^^^^^^^^^^^^^^^^^^^^^^^^

error: unexpected error: backend error: set value failed: failed to update storage for 01cf0e2f2f715450/#4c6174657374426c6f636b50726f706f73616c: failed to get storage used: [Error Code: 1201] account not found for address 01cf0e2f2f715450
...
  --> f8d6e0586b0a20c7.EVM:828:12
    |
828 |             InternalEVM.commitBlockProposal()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This error occurs, because the EVM storage account does not exist yet in the Emulator state. 

Add a new migration to the Cadence 1.0 migration pipeline which creates the EVM storage account, if the migrated state is for the Emulator.
 