### PR TITLE
suggested documentation extension for PR #6338

### DIFF
--- a/cmd/bootstrap/run/qc.go
+++ b/cmd/bootstrap/run/qc.go
@@ -50,6 +50,11 @@ type ParticipantData struct {
 // the group public key). The keys are returned in the same order as the nodes appear
 // in the Participants list, which must be the DKG index order.
 func (pd *ParticipantData) PublicBeaconKeys() []crypto.PublicKey {
+	// TODO: I think the PublicBeaconKeys cannot be derived from the `ParticipantData.Participants`
+	//       See for further details: https://github.com/onflow/flow-go/pull/6338#discussion_r1735324548
+	//                                https://github.com/onflow/flow-go/pull/6338#discussion_r1735395983
+	panic("possibly incorrect usage of `ParticipantData.Participants`")
+
 	keys := make([]crypto.PublicKey, len(pd.Participants))
 	for i, participant := range pd.Participants {
 		keys[i] = participant.RandomBeaconPrivKey.PublicKey()

--- a/cmd/bootstrap/run/qc_test.go
+++ b/cmd/bootstrap/run/qc_test.go
@@ -85,8 +85,8 @@ func createSignerData(t *testing.T, n int) *ParticipantData {
 
 	participantData := &ParticipantData{
 		Participants: participants,
-		Lookup:       participantLookup,
-		GroupKey:     groupKey,
+		DKGCommittee: participantLookup,
+		DKGGroupKey:  groupKey,
 	}
 
 	return participantData

--- a/consensus/hotstuff/verification/combined_signer_v2_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v2_test.go
@@ -180,7 +180,7 @@ func Test_VerifyQC_EmptySigners(t *testing.T) {
 	dkg := &mocks.DKG{}
 	pk := &modulemock.PublicKey{}
 	pk.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-	dkg.On("GroupKey").Return(pk)
+	dkg.On("DKGGroupKey").Return(pk)
 	committee.On("DKG", mock.Anything).Return(dkg, nil)
 
 	packer := signature.NewConsensusSigDataPacker(committee)

--- a/consensus/hotstuff/verification/combined_signer_v3_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v3_test.go
@@ -148,7 +148,7 @@ func Test_VerifyQCV3(t *testing.T) {
 	// generate some BLS key as a stub of the random beacon group key and use it to generate a reconstructed beacon sig
 	privGroupKey, beaconSig := generateSignature(t, msg, msig.RandomBeaconTag)
 	dkg := &mocks.DKG{}
-	dkg.On("GroupKey").Return(privGroupKey.PublicKey(), nil)
+	dkg.On("DKGGroupKey").Return(privGroupKey.PublicKey(), nil)
 	dkg.On("Size").Return(uint(20))
 	committee := &mocks.DynamicCommittee{}
 	committee.On("DKG", mock.Anything).Return(dkg, nil)
@@ -254,7 +254,7 @@ func Test_VerifyQC_EmptySignersV3(t *testing.T) {
 	dkg := &mocks.DKG{}
 	pk := &modulemock.PublicKey{}
 	pk.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-	dkg.On("GroupKey").Return(pk)
+	dkg.On("DKGGroupKey").Return(pk)
 	committee.On("DKG", mock.Anything).Return(dkg, nil)
 	packer := signature.NewConsensusSigDataPacker(committee)
 	verifier := NewCombinedVerifier(committee, packer)

--- a/consensus/integration/epoch_test.go
+++ b/consensus/integration/epoch_test.go
@@ -230,7 +230,7 @@ func withNextEpoch(
 		Counter:            nextEpochSetup.Counter,
 		ClusterQCs:         currEpochCommit.ClusterQCs,
 		DKGParticipantKeys: nextEpochParticipantData.PublicBeaconKeys(),
-		DKGGroupKey:        nextEpochParticipantData.GroupKey,
+		DKGGroupKey:        nextEpochParticipantData.DKGGroupKey,
 		DKGIndexMap:        nextEpochParticipantData.DKGIndexMap(),
 	}
 

--- a/model/flow/dkg.go
+++ b/model/flow/dkg.go
@@ -30,3 +30,56 @@ func (state DKGEndState) String() string {
 		return "DKGEndStateUnknown"
 	}
 }
+
+// DKGIndexMap describes the membership of the DKG committee 𝒟. Flow's random beacon utilizes
+// a threshold signature scheme, which requires a Distributed Key Generation [DKG] to generate the
+// key shares for each committee member. In the formal cryptographic protocol for DKG with n parties,
+// the individual participants are solely identified by indices {0, 1, ..., n-1} and the fact that these
+// are non-negative integer values is actively used by the DKG protocol. Accordingly, our implementation
+// of the lower-level cryptographic primitives work with these DKG index values.
+// On the protocol level, only consensus nodes (identified by their nodeIDs) are allowed to contribute
+// random beacon signature shares. Hence, the protocol level needs to map nodeIDs to DKG indices when
+// calling into the lower-level cryptographic primitives.
+//
+// Formal specification:
+//   - DKGIndexMap completely describes the DKG committee. If there were n parties authorized to participate
+//     in the DKG, DKGIndexMap must contain exactly n elements, i.e. n = len(DKGIndexMap)
+//   - The values in DKGIndexMap must form the set {0, 1, …, n-1}.
+//
+// CAUTION: It is important to cleanly differentiate between the consensus committee 𝒞, the random beacon
+// committee ℛ and the DKG committee 𝒟:
+//   - For an epoch, the consensus committee 𝒞 contains all nodes that are authorized to vote for blocks. Authority
+//     to vote (i.e. membership in the consensus committee) is irrevocably granted for an epoch (though, honest nodes
+//     will reject votes and proposals from ejected nodes; nevertheless, ejected nodes formally remain members of
+//     the consensus committee).
+//   - Only consensus nodes are allowed to contribute to the random beacon. We define the random beacon committee ℛ
+//     as the subset of the consensus nodes, which _successfully_ completed the DKG. Hence, ℛ ⊆ 𝒞.
+//   - Lastly, there is the DKG committee 𝒟, which is the set of parties that were authorized to
+//     participate in the DKG. Mathematically, the DKGIndexMap is an injective function
+//     DKGIndexMap: 𝒟 ↦ {0,1,…,n-1}.
+//
+// The protocol explicitly ALLOWS additional parties outside the current epoch's consensus committee to participate.
+// In particular, there can be a key-value pair (d,i) ∈ DKGIndexMap, such that the nodeID d is *not* a consensus
+// committee member, i.e. d ∉ 𝒞. In terms of sets, this implies we must consistently work with the relatively
+// general assumption that 𝒟 \ 𝒞 ≠ ∅ and 𝒞 \ 𝒟 ≠ ∅.
+// Nevertheless, in the vast majority of cases (happy path, roughly 98% of epochs) it will be the case that 𝒟 = 𝒞.
+// Therefore, we can optimize for the case 𝒟 = 𝒞, as long as we still support the more general case 𝒟 ≠ 𝒞.
+// Broadly, this makes the protocol more robust against temporary disruptions and sudden, large fluctuations in node
+// participation.
+// Nevertheless, there is an important liveness constraint: the intersection, 𝒟 ∩ 𝒞 = ℛ should be a larger number of
+// nodes. Specifically, an honest supermajority of consensus nodes must contain enough successful DKG participants
+// (about n/2) to produce a valid group signature for the random beacon [1, 3]. Therefore, we have the approximate
+// lower bound that |ℛ| = |𝒟 ∩ 𝒞| ≤ n/2 = |𝒟|/2 = len(DKGIndexMap)/2. Operating close to this lower bound would
+// require that every random beacon key-holder r ∈ ℛ remaining in the consensus committee is honest
+// (incl. quickly responsive) *all the time*. This is a lower bound, unsuited for decentralized production networks.
+// To reject configurations that are vulnerable to liveness failures, the protocol uses the threshold `t_safety`
+// (heuristic, see [2]), which is implemented on the smart contract level. In a nutshell, the intersection 𝒟 ∩ 𝒞
+// (wrt both sets 𝒟 ∩ 𝒞) should be well above 70%, values in the range 70-62% should be considered for short-term
+// recovery cases. Values of 62% or lower (i.e. |ℛ| ≤ 0.62·|𝒟| or |ℛ| ≤ 0.62·|𝒞|) are not recommend for any
+// production network, as single-node crashes are already enough to halt consensus.
+//
+// For further details, see
+//   - [1] https://www.notion.so/flowfoundation/Threshold-Signatures-7e26c6dd46ae40f7a83689ba75a785e3?pvs=4
+//   - [2] https://www.notion.so/flowfoundation/DKG-contract-success-threshold-86c6bf2b92034855b3c185d7616eb6f1?pvs=4
+//   - [3] https://www.notion.so/flowfoundation/Architecture-for-Concurrent-Vote-Processing-41704666bc414a03869b70ba1043605f?pvs=4
+type DKGIndexMap map[Identifier]int


### PR DESCRIPTION
This contains suggested amendments for PR https://github.com/onflow/flow-go/pull/6338. It mostly proposes changes related to two of my PR review comments 
* confusing, possibly incorrect/inconsistent usage of [ParticipantData](https://github.com/onflow/flow-go/blob/4292b2b951106b519220e6c6a76c4b380744cdd7/cmd/bootstrap/run/qc.go#L27) (see [my PR comment](https://github.com/onflow/flow-go/pull/6338#discussion_r1735395983)): 
   *  I am not entirely sure, what the meaning of `ParticipantData.Participants` is, due to missing documentation. In [my PR comment](https://github.com/onflow/flow-go/pull/6338#discussion_r1735395983) comment, I am describing how I think it is inconsistently used. 
   * However, before fixing the usage problem, we need to agree on the meaning of the `ParticipantData.Participants` field. My PR adds detailed documentation of the `Participants` field. Fixing the usage inconsistency is _not_ part of my PR.
  *  This PR also _partially_ addresses [this comment](https://github.com/onflow/flow-go/pull/6338#discussion_r1735324548): I did the renaming, but did not address the problem about the incorrect generation of the `DKGParticipantKeys`
* As I suggested [in this comment](https://github.com/onflow/flow-go/pull/6338#discussion_r1735304862), I defined a dedicated type for `DKGIndexMap` so we can attach the documentation to this type, rather than every object that uses the type.