### PR TITLE
[v0.37] Fix cluster assignment >2/3 internal check

### DIFF
--- a/cmd/util/cmd/common/clusters.go
+++ b/cmd/util/cmd/common/clusters.go
@@ -64,10 +64,10 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 	// The following is a heuristic that distributes collectors round-robbin across the specified number of clusters.
 	// This heuristic only works when all collectors have equal weight! The following sanity check enforces this:
 	if len(partnerCollectors) > 0 && len(partnerCollectors) > 2*len(internalCollectors) {
-		return nil, nil, fmt.Errorf("requiring at least x>0 number of partner collection nodes and y > 2x number of internal collection nodes, but got x,y=%d,%d", len(partnerNodes), len(internalNodes))
+		return nil, nil, fmt.Errorf("requiring at least x>0 number of partner collection nodes and y > 2x number of internal collection nodes, but got x,y=%d,%d", len(partnerCollectors), len(internalCollectors))
 	}
 	// sanity check ^ enforces that there is at least one internal node, hence `internalNodes[0].InitialWeight` is always a valid reference weight
-	refWeight := internalNodes[0].InitialWeight
+	refWeight := internalCollectors[0].InitialWeight
 
 	identifierLists := make([]flow.IdentifierList, numCollectionClusters)
 	// array to track the 2/3 internal-nodes constraint (internal_nodes > 2 * partner_nodes)

--- a/cmd/util/cmd/common/clusters.go
+++ b/cmd/util/cmd/common/clusters.go
@@ -64,7 +64,7 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 	// The following is a heuristic that distributes collectors round-robbin across the specified number of clusters.
 	// This heuristic only works when all collectors have equal weight! The following sanity check enforces this:
 	if len(partnerCollectors) > 0 && len(partnerCollectors) > 2*len(internalCollectors) {
-		return nil, nil, fmt.Errorf("requiring at least x>0 number of partner nodes and y > 2x number of internal nodes, but got x,y=%d,%d", len(partnerNodes), len(internalNodes))
+		return nil, nil, fmt.Errorf("requiring at least x>0 number of partner collection nodes and y > 2x number of internal collection nodes, but got x,y=%d,%d", len(partnerNodes), len(internalNodes))
 	}
 	// sanity check ^ enforces that there is at least one internal node, hence `internalNodes[0].InitialWeight` is always a valid reference weight
 	refWeight := internalNodes[0].InitialWeight

--- a/cmd/util/cmd/common/clusters.go
+++ b/cmd/util/cmd/common/clusters.go
@@ -66,7 +66,7 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 	if len(partnerCollectors) > 0 && len(partnerCollectors) > 2*len(internalCollectors) {
 		return nil, nil, fmt.Errorf("requiring at least x>0 number of partner collection nodes and y > 2x number of internal collection nodes, but got x,y=%d,%d", len(partnerCollectors), len(internalCollectors))
 	}
-	// sanity check ^ enforces that there is at least one internal node, hence `internalNodes[0].InitialWeight` is always a valid reference weight
+	// sanity check ^ enforces that there is at least one internal node, hence `internalCollectors[0].InitialWeight` is always a valid reference weight
 	refWeight := internalCollectors[0].InitialWeight
 
 	identifierLists := make([]flow.IdentifierList, numCollectionClusters)

--- a/cmd/util/cmd/common/clusters.go
+++ b/cmd/util/cmd/common/clusters.go
@@ -38,9 +38,9 @@ import (
 // - error: if any error occurs. Any error returned from this function is irrecoverable.
 func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes flow.IdentityList, numCollectionClusters int) (flow.AssignmentList, flow.ClusterList, error) {
 
-	partners := partnerNodes.Filter(filter.HasRole[flow.Identity](flow.RoleCollection))
-	internals := internalNodes.Filter(filter.HasRole[flow.Identity](flow.RoleCollection))
-	nCollectors := len(partners) + len(internals)
+	partnerCollectors := partnerNodes.Filter(filter.HasRole[flow.Identity](flow.RoleCollection))
+	internalCollectors := internalNodes.Filter(filter.HasRole[flow.Identity](flow.RoleCollection))
+	nCollectors := len(partnerCollectors) + len(internalCollectors)
 
 	// ensure we have at least as many collection nodes as clusters
 	if nCollectors < int(numCollectionClusters) {
@@ -49,11 +49,11 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 	}
 
 	// shuffle both collector lists based on a non-deterministic algorithm
-	partners, err := partners.Shuffle()
+	partnerCollectors, err := partnerCollectors.Shuffle()
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not shuffle partners")
 	}
-	internals, err = internals.Shuffle()
+	internalCollectors, err = internalCollectors.Shuffle()
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not shuffle internals")
 	}
@@ -63,7 +63,7 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 	// to control strictly more than 2/3 of the cluster's total weight.
 	// The following is a heuristic that distributes collectors round-robbin across the specified number of clusters.
 	// This heuristic only works when all collectors have equal weight! The following sanity check enforces this:
-	if len(partnerNodes) > 0 && len(partnerNodes) > 2*len(internalNodes) {
+	if len(partnerCollectors) > 0 && len(partnerCollectors) > 2*len(internalCollectors) {
 		return nil, nil, fmt.Errorf("requiring at least x>0 number of partner nodes and y > 2x number of internal nodes, but got x,y=%d,%d", len(partnerNodes), len(internalNodes))
 	}
 	// sanity check ^ enforces that there is at least one internal node, hence `internalNodes[0].InitialWeight` is always a valid reference weight
@@ -74,7 +74,7 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 	constraint := make([]int, numCollectionClusters)
 
 	// first, round-robin internal nodes into each cluster
-	for i, node := range internals {
+	for i, node := range internalCollectors {
 		if node.InitialWeight != refWeight {
 			return nil, nil, fmt.Errorf("current implementation requires all collectors (partner & interal nodes) to have equal weight")
 		}
@@ -84,7 +84,7 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 	}
 
 	// next, round-robin partner nodes into each cluster
-	for i, node := range partners {
+	for i, node := range partnerCollectors {
 		if node.InitialWeight != refWeight {
 			return nil, nil, fmt.Errorf("current implementation requires all collectors (partner & interal nodes) to have equal weight")
 		}
@@ -102,7 +102,7 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 
 	assignments := assignment.FromIdentifierLists(identifierLists)
 
-	collectors := append(partners, internals...)
+	collectors := append(partnerCollectors, internalCollectors...)
 	clusters, err := factory.NewClusterList(assignments, collectors.ToSkeleton())
 	if err != nil {
 		log.Fatal().Err(err).Msg("could not create cluster list")

--- a/cmd/util/cmd/common/clusters.go
+++ b/cmd/util/cmd/common/clusters.go
@@ -58,15 +58,7 @@ func ConstructClusterAssignment(log zerolog.Logger, partnerNodes, internalNodes 
 		log.Fatal().Err(err).Msg("could not shuffle internals")
 	}
 
-	// The following is a heuristic for distributing the internal collector nodes (private staking key available
-	// to generate QC for cluster root block) and partner nodes (private staking unknown). We need internal nodes
-	// to control strictly more than 2/3 of the cluster's total weight.
-	// The following is a heuristic that distributes collectors round-robbin across the specified number of clusters.
-	// This heuristic only works when all collectors have equal weight! The following sanity check enforces this:
-	if len(partnerCollectors) > 0 && len(partnerCollectors) > 2*len(internalCollectors) {
-		return nil, nil, fmt.Errorf("requiring at least x>0 number of partner collection nodes and y > 2x number of internal collection nodes, but got x,y=%d,%d", len(partnerCollectors), len(internalCollectors))
-	}
-	// sanity check ^ enforces that there is at least one internal node, hence `internalCollectors[0].InitialWeight` is always a valid reference weight
+	// capture first reference weight to validate that all collectors have equal weight
 	refWeight := internalCollectors[0].InitialWeight
 
 	identifierLists := make([]flow.IdentifierList, numCollectionClusters)


### PR DESCRIPTION
During refactoring in 2024-04, this check was modified to incorrectly use the wrong variable (operating on all nodes, not only Collection Nodes). This commit uses the correct variable, and renames the filtered lists.