### PR TITLE
Transaction Validator recovers from script parse panic

### DIFF
--- a/access/validator.go
+++ b/access/validator.go
@@ -320,11 +320,20 @@ func (v *TransactionValidator) checkExpiry(tx *flow.TransactionBody) error {
 	return nil
 }
 
-func (v *TransactionValidator) checkCanBeParsed(tx *flow.TransactionBody) error {
+func (v *TransactionValidator) checkCanBeParsed(tx *flow.TransactionBody) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if panicErr, ok := r.(error); ok {
+				err = InvalidScriptError{ParserErr: panicErr}
+			} else {
+				err = InvalidScriptError{ParserErr: fmt.Errorf("non-error-typed panic: %v", r)}
+			}
+		}
+	}()
 	if v.options.CheckScriptsParse {
-		_, err := parser.ParseProgram(nil, tx.Script, parser.Config{})
-		if err != nil {
-			return InvalidScriptError{ParserErr: err}
+		_, parseErr := parser.ParseProgram(nil, tx.Script, parser.Config{})
+		if parseErr != nil {
+			return InvalidScriptError{ParserErr: parseErr}
 		}
 	}
 

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -172,9 +172,10 @@ func (suite *Suite) TestInvalidTransaction() {
 		suite.Assert().True(errors.As(err, &access.InvalidScriptError{}))
 	})
 
-	suite.Run("transaction script exceeds parse token limit", func() {
-		unittest.SkipUnless(suite.T(), unittest.TEST_TODO, "https://github.com/dapperlabs/flow-go/issues/6964")
-		// https://github.com/onflow/cadence/blob/master/runtime/parser/lexer/lexer.go#L32
+	// In some cases the Cadence parser will panic rather than return an error.
+	// If this happens, we should recover from the panic and return an InvalidScriptError.
+	// See: https://github.com/onflow/cadence/issues/3428, https://github.com/dapperlabs/flow-go/issues/6964
+	suite.Run("transaction script exceeds parse token limit (Cadence parser panic should be caught)", func() {
 		const tokenLimit = 1 << 19
 		script := "{};"
 		for len(script) < tokenLimit {


### PR DESCRIPTION
In some cases, the Cadence parser can panic rather than return an error. This PR changes the `TransactionValidator` -- which attempts to parse scripts as part of transaction validation -- to recover from such panics and return the recovered error.

See: https://github.com/dapperlabs/flow-go/issues/6964 and https://github.com/onflow/cadence/issues/3428