### PR TITLE
Lower retry interval in EN requester engine

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1048,6 +1048,8 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 			// consistency of collection can be checked by checking hash, and hash comes from trusted source (blocks from consensus follower)
 			// hence we not need to check origin
 			requester.WithValidateStaking(false),
+			// we have observed execution nodes occasionally fail to retrieve collections using this engine, which can cause temporary execution halts
+			// setting a retry maximum of 10s results in a much faster recovery from these faults (default is 2m)
 			requester.WithRetryMaximum(10*time.Second),
 		)
 

--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -1048,6 +1048,7 @@ func (exeNode *ExecutionNode) LoadIngestionEngine(
 			// consistency of collection can be checked by checking hash, and hash comes from trusted source (blocks from consensus follower)
 			// hence we not need to check origin
 			requester.WithValidateStaking(false),
+			requester.WithRetryMaximum(10*time.Second),
 		)
 
 		if err != nil {


### PR DESCRIPTION
We have observed execution nodes (in particular Mainnet EN1) occasionally fail to retrieve collections using this engine, which can cause temporary execution halts. Setting a retry maximum of 10s empirically results in a much faster recovery from these faults (default is 2m).