### PR TITLE
[EFM] Extended documentation where generalized protocol logic meets bootstrapping implementation

### DIFF
--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -269,7 +269,7 @@ type EpochCommit struct {
 	// CAUTION: This mapping may include identifiers for nodes which do not exist in the consensus committee
 	//          and may NOT include identifiers for all nodes in the consensus committee.
 	//
-	DKGIndexMap map[Identifier]int
+	DKGIndexMap DKGIndexMap
 }
 
 // ClusterQCVoteData represents the votes for a cluster quorum certificate, as
@@ -325,7 +325,7 @@ type encodableCommit struct {
 	ClusterQCs         []ClusterQCVoteData
 	DKGGroupKey        encodable.RandomBeaconPubKey
 	DKGParticipantKeys []encodable.RandomBeaconPubKey
-	DKGIndexMap        map[Identifier]int
+	DKGIndexMap        DKGIndexMap
 }
 
 func encodableFromCommit(commit *EpochCommit) encodableCommit {


### PR DESCRIPTION
This PR contains some suggested amendments for PR https://github.com/onflow/flow-go/pull/6338:

* Extended documentation where generalized protocol logic meets bootstrapping implementation, the latter still being limited to handling DKG data from a trusted dealer only. This is an important part in the code, that might need to be generalized in the future. 
* [flow.DKGIndexMap](https://github.com/onflow/flow-go/blob/0e6cd5d392a381fdb6db2adb018c619c5dacbbc6/model/flow/dkg.go#L34-L85) has the important documentation attached. I think we should use it in all places, instead of the ambiguous field definition `map[Identifier]int`. 