### PR TITLE
update to transit script pull command to download file if md5 of remote file is not known

### DIFF
--- a/cmd/bootstrap/transit/cmd/pull.go
+++ b/cmd/bootstrap/transit/cmd/pull.go
@@ -97,7 +97,7 @@ func pull(cmd *cobra.Command, args []string) {
 			fullOutpath := filepath.Join(flagBootDir, "public-root-information", filepath.Base(file.Name))
 			fmd5 := utils.CalcMd5(fullOutpath)
 			// only skip files that have an MD5 hash
-			if file.MD5 != nil && bytes.Equal(fmd5, file.MD5) {
+			if len(file.MD5) > 0 && bytes.Equal(fmd5, file.MD5) {
 				log.Info().Str("source", file.Name).Str("dest", fullOutpath).Msgf("skipping existing file from transit servers")
 				return
 			}


### PR DESCRIPTION
After the Crescendo network upgrade, the execution state file (`root.checkpoint*`) could not be downloaded via the transit script. The transit script kept reporting `skipping existing file from transit servers` even though the file didn't exist locally.

e.g. Execution node operator reported this:
![image (25)](https://github.com/user-attachments/assets/286bc41b-787a-467b-acf5-1739880d3a61)

The root cause of this issue is that the md5 for a remote object is often reported as an empty []byte array by GCS library. The `if` condition [here](https://github.com/onflow/flow-go/blob/5916debb73cc13717f1c090179e32ba038e65166/cmd/bootstrap/transit/cmd/pull.go#L100) succeeds due to this and skips the file without downloading it.