### PR TITLE
[Util] Check checkpoint file exists when running state extraction

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -345,7 +345,7 @@ func run(*cobra.Command, []string) {
 
 		err := ensureCheckpointFileExist(flagExecutionStateDir)
 		if err != nil {
-			log.Fatal().Err(err).Msgf("cannot ensure checkpoint file exist in folder %v", flagExecutionStateDir)
+			log.Error().Err(err).Msgf("cannot ensure checkpoint file exist in folder %v", flagExecutionStateDir)
 		}
 
 	}

--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -507,5 +507,5 @@ func ensureCheckpointFileExist(dir string) error {
 		return nil
 	}
 
-	return fmt.Errorf("no checkpoint file was found, no root checkpoint file was found in %v, check the --execution-data-dir flag", dir)
+	return fmt.Errorf("no checkpoint file was found, no root checkpoint file was found in %v, check the --execution-state-dir flag", dir)
 }

--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/onflow/flow-go/cmd/util/ledger/migrations"
 	"github.com/onflow/flow-go/cmd/util/ledger/reporters"
 	"github.com/onflow/flow-go/cmd/util/ledger/util"
+	"github.com/onflow/flow-go/ledger/complete/wal"
 	"github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
@@ -297,11 +298,6 @@ func run(*cobra.Command, []string) {
 		}
 	}
 
-	// err := ensureCheckpointFileExist(flagExecutionStateDir)
-	// if err != nil {
-	// 	log.Fatal().Err(err).Msgf("cannot ensure checkpoint file exist in folder %v", flagExecutionStateDir)
-	// }
-
 	chain := flow.ChainID(flagChain).Chain()
 
 	if flagNoReport {
@@ -346,6 +342,12 @@ func run(*cobra.Command, []string) {
 			hex.EncodeToString(stateCommitment[:]),
 			flagExecutionStateDir,
 		)
+
+		err := ensureCheckpointFileExist(flagExecutionStateDir)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("cannot ensure checkpoint file exist in folder %v", flagExecutionStateDir)
+		}
+
 	}
 
 	var outputMsg string
@@ -484,26 +486,26 @@ func run(*cobra.Command, []string) {
 	)
 }
 
-// func ensureCheckpointFileExist(dir string) error {
-// 	checkpoints, err := wal.Checkpoints(dir)
-// 	if err != nil {
-// 		return fmt.Errorf("could not find checkpoint files: %v", err)
-// 	}
-//
-// 	if len(checkpoints) != 0 {
-// 		log.Info().Msgf("found checkpoint %v files: %v", len(checkpoints), checkpoints)
-// 		return nil
-// 	}
-//
-// 	has, err := wal.HasRootCheckpoint(dir)
-// 	if err != nil {
-// 		return fmt.Errorf("could not check has root checkpoint: %w", err)
-// 	}
-//
-// 	if has {
-// 		log.Info().Msg("found root checkpoint file")
-// 		return nil
-// 	}
-//
-// 	return fmt.Errorf("no checkpoint file was found, no root checkpoint file was found")
-// }
+func ensureCheckpointFileExist(dir string) error {
+	checkpoints, err := wal.Checkpoints(dir)
+	if err != nil {
+		return fmt.Errorf("could not find checkpoint files: %v", err)
+	}
+
+	if len(checkpoints) != 0 {
+		log.Info().Msgf("found checkpoint %v files: %v", len(checkpoints), checkpoints)
+		return nil
+	}
+
+	has, err := wal.HasRootCheckpoint(dir)
+	if err != nil {
+		return fmt.Errorf("could not check has root checkpoint: %w", err)
+	}
+
+	if has {
+		log.Info().Msg("found root checkpoint file")
+		return nil
+	}
+
+	return fmt.Errorf("no checkpoint file was found, no root checkpoint file was found in %v, check the --execution-data-dir flag", dir)
+}

--- a/cmd/util/ledger/util/state.go
+++ b/cmd/util/ledger/util/state.go
@@ -82,9 +82,9 @@ func ReadTrie(dir string, targetHash flow.StateCommitment) ([]*ledger.Payload, e
 		s, err2 := led.MostRecentTouchedState()
 		if err2 != nil {
 			log.Error().Err(err2).
-				Msgf("cannot get most recently touched state in %v, check the --execution-data-dir flag", dir)
+				Msgf("cannot get most recently touched state in %v, check the --execution-state-dir flag", dir)
 		} else if s == ledger.State(mtrie.NewEmptyMTrie().RootHash()) {
-			log.Error().Msgf("cannot find any trie in folder %v. check the --execution-data-dir flag", dir)
+			log.Error().Msgf("cannot find any trie in folder %v. check the --execution-state-dir flag", dir)
 		} else {
 			log.Info().
 				Str("hash", s.String()).

--- a/cmd/util/ledger/util/state.go
+++ b/cmd/util/ledger/util/state.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
 	"github.com/onflow/flow-go/ledger/complete"
+	mtrie "github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 	"github.com/onflow/flow-go/ledger/complete/wal"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
@@ -78,10 +79,17 @@ func ReadTrie(dir string, targetHash flow.StateCommitment) ([]*ledger.Payload, e
 
 	trie, err := led.Trie(ledger.RootHash(state))
 	if err != nil {
-		s, _ := led.MostRecentTouchedState()
-		log.Info().
-			Str("hash", s.String()).
-			Msgf("Most recently touched state")
+		s, err2 := led.MostRecentTouchedState()
+		if err2 != nil {
+			log.Error().Err(err2).
+				Msgf("cannot get most recently touched state in %v, check the --execution-data-dir flag", dir)
+		} else if s == ledger.State(mtrie.NewEmptyMTrie().RootHash()) {
+			log.Error().Msgf("cannot find any trie in folder %v. check the --execution-data-dir flag", dir)
+		} else {
+			log.Info().
+				Str("hash", s.String()).
+				Msgf("Most recently touched state")
+		}
 		return nil, fmt.Errorf("cannot get trie at the given state commitment: %w", err)
 	}
 


### PR DESCRIPTION
When running state extraction with a wrong `--execution-state-dir` flag, the error message is misleading. 

This PR adds check to ensure checkpoint file can be found in the specified `--execution-state-dir` and improved error message when a wrong or empty folder is used.