### PR TITLE
[EVM] Copy the input and output on the call tracker

### DIFF
--- a/fvm/evm/emulator/tracker.go
+++ b/fvm/evm/emulator/tracker.go
@@ -38,8 +38,10 @@ func (ct *CallTracker) CaptureRequiredGas(address types.Address, input []byte, o
 		ct.callsByAddress[address] = calls
 	}
 
+	var in []byte
+	copy(in, input)
 	calls.RequiredGasCalls = append(calls.RequiredGasCalls, types.RequiredGasCall{
-		Input:  input,
+		Input:  in,
 		Output: output,
 	})
 }
@@ -56,13 +58,18 @@ func (ct *CallTracker) CaptureRun(address types.Address, input []byte, output []
 		}
 		ct.callsByAddress[address] = calls
 	}
+
+	var in, out []byte
+	copy(in, input)
+	copy(out, output)
+
 	errMsg := ""
 	if err != nil {
 		errMsg = err.Error()
 	}
 	calls.RunCalls = append(calls.RunCalls, types.RunCall{
-		Input:    input,
-		Output:   output,
+		Input:    in,
+		Output:   out,
 		ErrorMsg: errMsg,
 	})
 }

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -54,6 +54,10 @@ func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) 
 	if p.requiredGasIndex > len(p.expectedCalls.RequiredGasCalls) {
 		panic(errUnexpectedCall)
 	}
+	// strip function selector from input, we assume order
+	if len(input) >= 4 {
+		input = input[4:]
+	}
 	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
 		panic(errUnexpectedCall)
 	}
@@ -65,6 +69,10 @@ func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) 
 func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err error) {
 	if p.runIndex > len(p.expectedCalls.RunCalls) {
 		panic(errUnexpectedCall)
+	}
+	// strip function selector from input, we assume order
+	if len(input) >= 4 {
+		input = input[4:]
 	}
 	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
 		panic(errUnexpectedCall)

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -56,7 +56,7 @@ func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) 
 	}
 	// strip function selector from input, we assume order
 	if len(input) >= 4 {
-		input = input[4:]
+		input = []byte{0, 0, 0, 0}
 	}
 	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
 		panic(errUnexpectedCall)
@@ -71,8 +71,8 @@ func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err erro
 		panic(errUnexpectedCall)
 	}
 	// strip function selector from input, we assume order
-	if len(input) >= 4 {
-		input = input[4:]
+	if len(input) == 4 {
+		input = []byte{0, 0, 0, 0}
 	}
 	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
 		panic(errUnexpectedCall)

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -54,10 +54,9 @@ func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) 
 	if p.requiredGasIndex > len(p.expectedCalls.RequiredGasCalls) {
 		panic(errUnexpectedCall)
 	}
-	// strip function selector from input, we assume order
-	if len(input) >= 4 {
-		input = []byte{0, 0, 0, 0}
-	}
+
+	input = removeFunctionSelector(input)
+
 	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
 		panic(errUnexpectedCall)
 	}
@@ -70,10 +69,8 @@ func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err erro
 	if p.runIndex > len(p.expectedCalls.RunCalls) {
 		panic(errUnexpectedCall)
 	}
-	// strip function selector from input, we assume order
-	if len(input) == 4 {
-		input = []byte{0, 0, 0, 0}
-	}
+	input = removeFunctionSelector(input)
+
 	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
 		panic(errUnexpectedCall)
 	}
@@ -89,4 +86,19 @@ func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err erro
 func (p *ReplayerPrecompiledContract) HasReplayedAll() bool {
 	return len(p.expectedCalls.RequiredGasCalls) == p.requiredGasIndex &&
 		len(p.expectedCalls.RunCalls) == p.runIndex
+}
+
+// removeFunctionSelector sets first 4 bytes to 0, which are set
+// to an ABI encoded function name when called. We ignore this function
+// selectors for now. todo we should compare the function selector.
+func removeFunctionSelector(input []byte) []byte {
+	if len(input) < 4 {
+		return input
+	}
+
+	const funcSelectorLen = 4
+	for i := 0; i < funcSelectorLen; i++ {
+		input[i] = 0
+	}
+	return input
 }

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -1,6 +1,7 @@
 package precompiles
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -50,31 +51,33 @@ func (p *ReplayerPrecompiledContract) Address() types.Address {
 }
 
 func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) {
+	var in []byte
+	copy(in, input)
+
 	if p.requiredGasIndex > len(p.expectedCalls.RequiredGasCalls) {
 		panic(errUnexpectedCall)
 	}
 
-	input = removeFunctionSelector(input)
-
 	// todo temporarily disable input/output check
-	//if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
-	//	panic(errUnexpectedCall)
-	//}
+	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, in) {
+		panic(errUnexpectedCall)
+	}
 	output = p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Output
 	p.requiredGasIndex++
 	return
 }
 
 func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err error) {
+	var in []byte
+	copy(in, input)
+
 	if p.runIndex > len(p.expectedCalls.RunCalls) {
 		panic(errUnexpectedCall)
 	}
-	input = removeFunctionSelector(input)
 
-	// todo temporarily disable input/output check
-	//if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
-	//	panic(errUnexpectedCall)
-	//}
+	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, in) {
+		panic(errUnexpectedCall)
+	}
 	output = p.expectedCalls.RunCalls[p.runIndex].Output
 	errMsg := p.expectedCalls.RunCalls[p.runIndex].ErrorMsg
 	if len(errMsg) > 0 {

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -1,7 +1,6 @@
 package precompiles
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -57,9 +56,10 @@ func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) 
 
 	input = removeFunctionSelector(input)
 
-	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
-		panic(errUnexpectedCall)
-	}
+	// todo temporarily disable input/output check
+	//if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
+	//	panic(errUnexpectedCall)
+	//}
 	output = p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Output
 	p.requiredGasIndex++
 	return
@@ -71,9 +71,10 @@ func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err erro
 	}
 	input = removeFunctionSelector(input)
 
-	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
-		panic(errUnexpectedCall)
-	}
+	// todo temporarily disable input/output check
+	//if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
+	//	panic(errUnexpectedCall)
+	//}
 	output = p.expectedCalls.RunCalls[p.runIndex].Output
 	errMsg := p.expectedCalls.RunCalls[p.runIndex].ErrorMsg
 	if len(errMsg) > 0 {

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -51,15 +51,11 @@ func (p *ReplayerPrecompiledContract) Address() types.Address {
 }
 
 func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) {
-	var in []byte
-	copy(in, input)
-
 	if p.requiredGasIndex > len(p.expectedCalls.RequiredGasCalls) {
 		panic(errUnexpectedCall)
 	}
 
-	// todo temporarily disable input/output check
-	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, in) {
+	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
 		panic(errUnexpectedCall)
 	}
 	output = p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Output
@@ -68,14 +64,11 @@ func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) 
 }
 
 func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err error) {
-	var in []byte
-	copy(in, input)
-
 	if p.runIndex > len(p.expectedCalls.RunCalls) {
 		panic(errUnexpectedCall)
 	}
 
-	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, in) {
+	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
 		panic(errUnexpectedCall)
 	}
 	output = p.expectedCalls.RunCalls[p.runIndex].Output
@@ -90,19 +83,4 @@ func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err erro
 func (p *ReplayerPrecompiledContract) HasReplayedAll() bool {
 	return len(p.expectedCalls.RequiredGasCalls) == p.requiredGasIndex &&
 		len(p.expectedCalls.RunCalls) == p.runIndex
-}
-
-// removeFunctionSelector sets first 4 bytes to 0, which are set
-// to an ABI encoded function name when called. We ignore this function
-// selectors for now. todo we should compare the function selector.
-func removeFunctionSelector(input []byte) []byte {
-	if len(input) < 4 {
-		return input
-	}
-
-	const funcSelectorLen = 4
-	for i := 0; i < funcSelectorLen; i++ {
-		input[i] = 0
-	}
-	return input
 }


### PR DESCRIPTION
The cadence arch tracker was used to track any calls to precompiles and record the input / output, for later mocking of such calls made. The problem is the buffers it referenced changed values after (due to optimizations in geth). We must copy the values in order to preserve them.