### PR TITLE
[EVM] patch evm debug tracer

### DIFF
--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -1103,7 +1103,8 @@ func TestCallingExtraPrecompiles(t *testing.T) {
 					AddressFunc: func() types.Address {
 						return addr
 					},
-					RequiredGasFunc: func(input []byte) uint64 {
+					RequiredGasFunc: func(inp []byte) uint64 {
+						require.Equal(t, input, inp)
 						return uint64(10)
 					},
 					RunFunc: func(inp []byte) ([]byte, error) {
@@ -1194,6 +1195,7 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
+			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x01}
 			uploaded := make(chan struct{})
@@ -1201,7 +1203,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.NotEmpty(t, message)
+				require.Equal(t, trace, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1223,6 +1225,8 @@ func TestTransactionTracing(t *testing.T) {
 			require.NoError(t, res.ValidationError)
 			require.NoError(t, res.VMError)
 			txID = res.TxHash
+			trace = tracer.GetResultByTxHash(txID)
+			require.NotEmpty(t, trace)
 			tracer.Collect(txID)
 
 			testAccount.SetNonce(testAccount.Nonce() + 1)
@@ -1238,6 +1242,7 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
+			var trace json.RawMessage
 
 			uploaded := make(chan struct{})
 			blockID := flow.Identifier{0x01}
@@ -1245,7 +1250,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.NotEmpty(t, message)
+				require.Equal(t, trace, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1263,6 +1268,8 @@ func TestTransactionTracing(t *testing.T) {
 			)
 			requireSuccessfulExecution(t, err, res)
 			txID = res.TxHash
+			trace = tracer.GetResultByTxHash(txID)
+			require.NotEmpty(t, trace)
 			tracer.WithBlockID(blockID)
 			tracer.Collect(txID)
 
@@ -1279,6 +1286,7 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
+			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x02}
 			uploaded := make(chan struct{})
@@ -1286,7 +1294,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.NotEmpty(t, message)
+				require.Equal(t, trace, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1304,6 +1312,8 @@ func TestTransactionTracing(t *testing.T) {
 			res, err := blk.RunTransaction(tx)
 			requireSuccessfulExecution(t, err, res)
 			txID = res.TxHash
+			trace = tracer.GetResultByTxHash(txID)
+			require.NotEmpty(t, trace)
 			tracer.WithBlockID(blockID)
 			tracer.Collect(txID)
 
@@ -1353,6 +1363,7 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
+			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x02}
 			uploaded := make(chan struct{})
@@ -1360,7 +1371,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.NotEmpty(t, message)
+				require.Equal(t, trace, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1380,6 +1391,8 @@ func TestTransactionTracing(t *testing.T) {
 			requireSuccessfulExecution(t, err, res)
 			txID = res.TxHash
 			tracer.WithBlockID(blockID)
+			trace = tracer.GetResultByTxHash(txID)
+			require.NotEmpty(t, trace)
 			tracer.Collect(txID)
 
 			testAccount.SetNonce(testAccount.Nonce() + 1)
@@ -1443,6 +1456,7 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
+			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x02}
 			uploaded := make(chan struct{})
@@ -1450,7 +1464,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.NotEmpty(t, message)
+				require.Equal(t, trace, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1469,6 +1483,7 @@ func TestTransactionTracing(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 			txID = results[0].TxHash
+			trace = tracer.GetResultByTxHash(txID)
 			tracer.WithBlockID(blockID)
 			tracer.Collect(txID)
 

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -1194,7 +1194,6 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
-			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x01}
 			uploaded := make(chan struct{})
@@ -1202,7 +1201,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.Equal(t, trace, message)
+				require.NotEmpty(t, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1225,8 +1224,6 @@ func TestTransactionTracing(t *testing.T) {
 			require.NoError(t, res.VMError)
 			txID = res.TxHash
 			tracer.Collect(txID)
-			trace = tracer.GetResultByTxHash(txID)
-			require.NotEmpty(t, trace)
 
 			testAccount.SetNonce(testAccount.Nonce() + 1)
 			require.Eventuallyf(t, func() bool {
@@ -1241,7 +1238,6 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
-			var trace json.RawMessage
 
 			uploaded := make(chan struct{})
 			blockID := flow.Identifier{0x01}
@@ -1249,7 +1245,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.Equal(t, trace, message)
+				require.NotEmpty(t, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1269,8 +1265,6 @@ func TestTransactionTracing(t *testing.T) {
 			txID = res.TxHash
 			tracer.WithBlockID(blockID)
 			tracer.Collect(txID)
-			trace = tracer.GetResultByTxHash(txID)
-			require.NotEmpty(t, trace)
 
 			testAccount.SetNonce(testAccount.Nonce() + 1)
 			require.Eventuallyf(t, func() bool {
@@ -1285,7 +1279,6 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
-			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x02}
 			uploaded := make(chan struct{})
@@ -1293,7 +1286,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.Equal(t, trace, message)
+				require.NotEmpty(t, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1313,8 +1306,6 @@ func TestTransactionTracing(t *testing.T) {
 			txID = res.TxHash
 			tracer.WithBlockID(blockID)
 			tracer.Collect(txID)
-			trace = tracer.GetResultByTxHash(txID)
-			require.NotEmpty(t, trace)
 
 			testAccount.SetNonce(testAccount.Nonce() + 1)
 			require.Eventuallyf(t, func() bool {
@@ -1362,7 +1353,6 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
-			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x02}
 			uploaded := make(chan struct{})
@@ -1370,7 +1360,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.Equal(t, trace, message)
+				require.NotEmpty(t, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1391,8 +1381,6 @@ func TestTransactionTracing(t *testing.T) {
 			txID = res.TxHash
 			tracer.WithBlockID(blockID)
 			tracer.Collect(txID)
-			trace = tracer.GetResultByTxHash(txID)
-			require.NotEmpty(t, trace)
 
 			testAccount.SetNonce(testAccount.Nonce() + 1)
 			require.Eventuallyf(t, func() bool {
@@ -1455,7 +1443,6 @@ func TestTransactionTracing(t *testing.T) {
 			blk, uploader, tracer := blockWithTracer(t, emu)
 
 			var txID gethCommon.Hash
-			var trace json.RawMessage
 
 			blockID := flow.Identifier{0x02}
 			uploaded := make(chan struct{})
@@ -1463,7 +1450,7 @@ func TestTransactionTracing(t *testing.T) {
 			uploader.UploadFunc = func(id string, message json.RawMessage) error {
 				uploaded <- struct{}{}
 				require.Equal(t, debug.TraceID(txID, blockID), id)
-				require.Equal(t, trace, message)
+				require.NotEmpty(t, message)
 				require.Greater(t, len(message), 0)
 				return nil
 			}
@@ -1484,7 +1471,6 @@ func TestTransactionTracing(t *testing.T) {
 			txID = results[0].TxHash
 			tracer.WithBlockID(blockID)
 			tracer.Collect(txID)
-			trace = tracer.GetResultByTxHash(txID)
 
 			require.Eventuallyf(t, func() bool {
 				<-uploaded


### PR DESCRIPTION
This PR moves the result map updates outside of the concurrent path (uploaded). This prevents concurrent writes to the map in case of uploader failures to upload the results. 