### PR TITLE
Add a log message during an epoch transition

### DIFF
--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -884,6 +884,12 @@ func (m *FollowerState) epochMetricsAndEventsOnBlockFinalized(parentEpochState, 
 				m.metrics.CurrentDKGPhaseViews(childEpochSetup.DKGPhase1FinalView, childEpochSetup.DKGPhase2FinalView, childEpochSetup.DKGPhase3FinalView)
 			},
 		)
+		m.logger.Info().
+			Uint64("new_epoch_counter", childEpochSetup.Counter).
+			Uint64("new_epoch_height", finalized.Height).
+			Str("new_epoch_phase", childEpochPhase.String()).
+			Timestamp().
+			Msg("Epoch Transition")
 		return
 	}
 


### PR DESCRIPTION
Example log if we want one line per epoch transition.