### PR TITLE
switching off peer-scoring by default

### DIFF
--- a/config/default-config.yml
+++ b/config/default-config.yml
@@ -277,7 +277,7 @@ network-config:
          # instead, the counter will be set to 0. This is to prevent the counter from becoming a large number over time.
          skip-decay-threshold: 0.1
     # Peer scoring is the default value for enabling peer scoring
-    peer-scoring-enabled: true
+    peer-scoring-enabled: false
     scoring-parameters:
       peer-scoring:
         internal:

--- a/insecure/integration/functional/test/gossipsub/rpc_inspector/validation_inspector_test.go
+++ b/insecure/integration/functional/test/gossipsub/rpc_inspector/validation_inspector_test.go
@@ -174,6 +174,7 @@ func TestValidationInspector_DuplicateTopicId_Detection(t *testing.T) {
 	sporkID := unittest.IdentifierFixture()
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 
 	inspectorConfig.InspectionQueue.NumberOfWorkers = 1
@@ -283,6 +284,7 @@ func TestValidationInspector_IHaveDuplicateMessageId_Detection(t *testing.T) {
 	sporkID := unittest.IdentifierFixture()
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 	inspectorConfig.InspectionQueue.NumberOfWorkers = 1
 
@@ -380,6 +382,7 @@ func TestValidationInspector_UnknownClusterId_Detection(t *testing.T) {
 	sporkID := unittest.IdentifierFixture()
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 	// set hard threshold to 0 so that in the case of invalid cluster ID
 	// we force the inspector to return an error
@@ -490,6 +493,7 @@ func TestValidationInspector_ActiveClusterIdsNotSet_Graft_Detection(t *testing.T
 	sporkID := unittest.IdentifierFixture()
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 	inspectorConfig.GraftPrune.InvalidTopicIdThreshold = 0
 	inspectorConfig.ClusterPrefixedMessage.HardThreshold = 5
@@ -571,6 +575,7 @@ func TestValidationInspector_ActiveClusterIdsNotSet_Prune_Detection(t *testing.T
 	sporkID := unittest.IdentifierFixture()
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 	inspectorConfig.GraftPrune.InvalidTopicIdThreshold = 0
 	inspectorConfig.ClusterPrefixedMessage.HardThreshold = 5
@@ -650,6 +655,7 @@ func TestValidationInspector_UnstakedNode_Detection(t *testing.T) {
 	sporkID := unittest.IdentifierFixture()
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 	inspectorConfig.InspectionQueue.NumberOfWorkers = 1
 	controlMessageCount := int64(1)
@@ -742,6 +748,7 @@ func TestValidationInspector_InspectIWants_CacheMissThreshold(t *testing.T) {
 	// create our RPC validation inspector
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 	inspectorConfig.InspectionQueue.NumberOfWorkers = 1
 	inspectorConfig.IWant.CacheMissThreshold = 10
@@ -837,6 +844,7 @@ func TestValidationInspector_InspectRpcPublishMessages(t *testing.T) {
 	// create our RPC validation inspector
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 	inspectorConfig.InspectionQueue.NumberOfWorkers = 1
 
@@ -988,6 +996,7 @@ func testGossipSubSpamMitigationIntegration(t *testing.T, msgType p2pmsg.Control
 
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
+	cfg.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	// set the scoring parameters to be more aggressive to speed up the test
 	cfg.NetworkConfig.GossipSub.RpcTracer.ScoreTracerInterval = 100 * time.Millisecond
 	cfg.NetworkConfig.GossipSub.ScoringParameters.ScoringRegistryParameters.AppSpecificScore.ScoreTTL = 100 * time.Millisecond

--- a/insecure/integration/functional/test/gossipsub/rpc_inspector/validation_inspector_test.go
+++ b/insecure/integration/functional/test/gossipsub/rpc_inspector/validation_inspector_test.go
@@ -44,6 +44,7 @@ func TestValidationInspector_InvalidTopicId_Detection(t *testing.T) {
 	sporkID := unittest.IdentifierFixture()
 	flowConfig, err := config.DefaultConfig()
 	require.NoError(t, err)
+	flowConfig.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	inspectorConfig := flowConfig.NetworkConfig.GossipSub.RpcInspector.Validation
 
 	messageCount := 100

--- a/insecure/integration/functional/test/gossipsub/scoring/scoring_test.go
+++ b/insecure/integration/functional/test/gossipsub/scoring/scoring_test.go
@@ -105,6 +105,7 @@ func testGossipSubInvalidMessageDeliveryScoring(t *testing.T, spamMsgFactory fun
 
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
+	cfg.NetworkConfig.GossipSub.PeerScoringEnabled = true // default is false
 	// we override the decay interval to 1 second so that the score is updated within 1 second intervals.
 	cfg.NetworkConfig.GossipSub.RpcTracer.ScoreTracerInterval = 1 * time.Second
 	cfg.NetworkConfig.GossipSub.ScoringParameters.PeerScoring.Internal.TopicParameters.InvalidMessageDeliveriesDecay = .99

--- a/integration/tests/bft/base_suite.go
+++ b/integration/tests/bft/base_suite.go
@@ -67,7 +67,9 @@ func (b *BaseSuite) SetupSuite() {
 
 	// setup single access node
 	b.NodeConfigs = append(b.NodeConfigs,
-		testnet.NewNodeConfig(flow.RoleAccess, testnet.WithLogLevel(zerolog.FatalLevel)),
+		testnet.NewNodeConfig(flow.RoleAccess,
+			testnet.WithLogLevel(zerolog.FatalLevel),
+			testnet.WithAdditionalFlag("--peer-scoring-enabled=true")), // currently, peer scoring is off by default
 	)
 
 	// setup consensus nodes
@@ -83,25 +85,27 @@ func (b *BaseSuite) SetupSuite() {
 			// TODO: fix the access integration test logic to function without slowing down
 			// the block rate
 			testnet.WithAdditionalFlag("--cruise-ctl-fallback-proposal-duration=250ms"),
+			testnet.WithAdditionalFlag("--peer-scoring-enabled=true"),
 		)
 		b.NodeConfigs = append(b.NodeConfigs, nodeConfig)
 	}
 
 	// setup single verification node
 	b.NodeConfigs = append(b.NodeConfigs,
-		testnet.NewNodeConfig(flow.RoleVerification, testnet.WithLogLevel(zerolog.FatalLevel)),
+		testnet.NewNodeConfig(flow.RoleVerification, testnet.WithLogLevel(zerolog.FatalLevel),
+			testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
 	)
 
 	// setup execution nodes
 	b.NodeConfigs = append(b.NodeConfigs,
-		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel)),
-		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel)),
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
 	)
 
 	// setup collection nodes
 	b.NodeConfigs = append(b.NodeConfigs,
-		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms")),
-		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms")),
+		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms"), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
+		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms"), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
 	)
 
 	// Ghost Node

--- a/integration/tests/bft/base_suite.go
+++ b/integration/tests/bft/base_suite.go
@@ -69,7 +69,7 @@ func (b *BaseSuite) SetupSuite() {
 	b.NodeConfigs = append(b.NodeConfigs,
 		testnet.NewNodeConfig(flow.RoleAccess,
 			testnet.WithLogLevel(zerolog.FatalLevel),
-			testnet.WithAdditionalFlag("--peer-scoring-enabled=true")), // currently, peer scoring is off by default
+			testnet.WithAdditionalFlag("--gossipsub-peer-scoring-enabled=true")), // currently, peer scoring is off by default
 	)
 
 	// setup consensus nodes
@@ -85,7 +85,7 @@ func (b *BaseSuite) SetupSuite() {
 			// TODO: fix the access integration test logic to function without slowing down
 			// the block rate
 			testnet.WithAdditionalFlag("--cruise-ctl-fallback-proposal-duration=250ms"),
-			testnet.WithAdditionalFlag("--peer-scoring-enabled=true"),
+			testnet.WithAdditionalFlag("--gossipsub-peer-scoring-enabled=true"),
 		)
 		b.NodeConfigs = append(b.NodeConfigs, nodeConfig)
 	}
@@ -93,19 +93,19 @@ func (b *BaseSuite) SetupSuite() {
 	// setup single verification node
 	b.NodeConfigs = append(b.NodeConfigs,
 		testnet.NewNodeConfig(flow.RoleVerification, testnet.WithLogLevel(zerolog.FatalLevel),
-			testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
+			testnet.WithAdditionalFlag("--gossipsub-peer-scoring-enabled=true")),
 	)
 
 	// setup execution nodes
 	b.NodeConfigs = append(b.NodeConfigs,
-		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
-		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--gossipsub-peer-scoring-enabled=true")),
+		testnet.NewNodeConfig(flow.RoleExecution, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--gossipsub-peer-scoring-enabled=true")),
 	)
 
 	// setup collection nodes
 	b.NodeConfigs = append(b.NodeConfigs,
-		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms"), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
-		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms"), testnet.WithAdditionalFlag("--peer-scoring-enabled=true")),
+		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms"), testnet.WithAdditionalFlag("--gossipsub-peer-scoring-enabled=true")),
+		testnet.NewNodeConfig(flow.RoleCollection, testnet.WithLogLevel(zerolog.FatalLevel), testnet.WithAdditionalFlag("--hotstuff-proposal-duration=1ms"), testnet.WithAdditionalFlag("--gossipsub-peer-scoring-enabled=true")),
 	)
 
 	// Ghost Node

--- a/network/p2p/scoring/scoring_test.go
+++ b/network/p2p/scoring/scoring_test.go
@@ -43,6 +43,7 @@ func TestInvalidCtrlMsgScoringIntegration(t *testing.T) {
 	cfg, err := config.DefaultConfig()
 	require.NoError(t, err)
 
+	cfg.NetworkConfig.GossipSub.PeerScoringEnabled = true                                                                     // default is false
 	cfg.NetworkConfig.GossipSub.ScoringParameters.ScoringRegistryParameters.AppSpecificScore.ScoreTTL = 10 * time.Millisecond // speed up the test
 
 	var notificationConsumer p2p.GossipSubInvCtrlMsgNotifConsumer


### PR DESCRIPTION
For the upcoming mainnet upgrade, peer-scoring should be turned off by default.