### PR TITLE
Update `checkpoint-collect-stats` command to support payloads file and state commitment

### DIFF
--- a/cmd/util/cmd/checkpoint-collect-stats/cmd.go
+++ b/cmd/util/cmd/checkpoint-collect-stats/cmd.go
@@ -31,6 +31,7 @@ import (
 var (
 	flagCheckpointDir   string
 	flagStateCommitment string
+	flagPayloads        string
 	flagOutputDir       string
 	flagMemProfile      bool
 )
@@ -41,19 +42,25 @@ const (
 
 var Cmd = &cobra.Command{
 	Use:   "checkpoint-collect-stats",
-	Short: "collects stats on tries stored in a checkpoint",
-	Run:   run,
+	Short: "collects stats on tries stored in a checkpoint, or payloads from a payloads file",
+	Long: `checkpoint-collect-stats collects stats on tries stored in a checkpoint, or payloads from a payloads file.
+Two kinds of input data are supported:
+- checkpoint file(s) ("--checkpoint-dir" with optional "--state-commitment"), or
+- payloads file ("--payload-filename")`,
+	Run: run,
 }
 
 func init() {
 	Cmd.Flags().StringVar(&flagCheckpointDir, "checkpoint-dir", "",
 		"Directory to load checkpoint files from")
-	_ = Cmd.MarkFlagRequired("checkpoint-dir")
 
 	// state-commitment is optional.
 	// When provided, this program only gathers stats on trie with matching state commitment.
 	Cmd.Flags().StringVar(&flagStateCommitment, "state-commitment", "",
 		"Trie state commitment")
+
+	Cmd.Flags().StringVar(&flagPayloads, "payload-filename", "",
+		"Payloads file name to load payloads from")
 
 	Cmd.Flags().StringVar(&flagOutputDir, "output-dir", "",
 		"Directory to write checkpoint stats to")
@@ -64,7 +71,7 @@ func init() {
 }
 
 type Stats struct {
-	LedgerStats  *complete.LedgerStats
+	LedgerStats  *complete.LedgerStats `json:",omitempty"`
 	PayloadStats *PayloadStats
 }
 
@@ -90,10 +97,79 @@ type sizesByType map[string][]float64
 
 func run(*cobra.Command, []string) {
 
+	if flagPayloads == "" && flagCheckpointDir == "" {
+		log.Fatal().Msg("Either --payload-filename or --checkpoint-dir must be provided")
+	}
+	if flagPayloads != "" && flagCheckpointDir != "" {
+		log.Fatal().Msg("Only one of --payload-filename or --checkpoint-dir must be provided")
+	}
+	if flagCheckpointDir == "" && flagStateCommitment != "" {
+		log.Fatal().Msg("--checkpont-dir must be provided when --state-commitment is provided")
+	}
+
 	if flagMemProfile {
 		defer profile.Start(profile.MemProfile).Stop()
 	}
 
+	var totalPayloadSize, totalPayloadValueSize uint64
+
+	valueSizesByType := make(sizesByType, 0)
+
+	payloadCallback := func(p *ledger.Payload) {
+		key, err := p.Key()
+		if err != nil {
+			log.Fatal().Err(err).Msg("cannot load a key")
+		}
+
+		size := p.Size()
+		value := p.Value()
+		valueSize := value.Size()
+		totalPayloadSize += uint64(size)
+		totalPayloadValueSize += uint64(valueSize)
+		valueSizesByType[getType(key)] = append(valueSizesByType[getType(key)], float64(valueSize))
+	}
+
+	var ledgerStats *complete.LedgerStats
+
+	useCheckpointFile := flagPayloads == ""
+	if useCheckpointFile {
+		ledgerStats = getPayloadStatsFromCheckpoint(payloadCallback)
+	} else {
+		getPayloadStatsFromPayloadFile(payloadCallback)
+	}
+
+	statsByTypes := getStats(valueSizesByType)
+
+	stats := &Stats{
+		LedgerStats: ledgerStats,
+		PayloadStats: &PayloadStats{
+			TotalPayloadSize:      totalPayloadSize,
+			TotalPayloadValueSize: totalPayloadValueSize,
+			StatsByTypes:          statsByTypes,
+		},
+	}
+
+	writeStats(stats)
+}
+
+func getPayloadStatsFromPayloadFile(payloadCallBack func(payload *ledger.Payload)) {
+	memAllocBefore := debug.GetHeapAllocsBytes()
+	log.Info().Msgf("loading payloads from %v", flagPayloads)
+
+	_, payloads, err := util.ReadPayloadFile(log.Logger, flagPayloads)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to read payloads")
+	}
+
+	memAllocAfter := debug.GetHeapAllocsBytes()
+	log.Info().Msgf("%d payloads are loaded, mem usage: %d", len(payloads), memAllocAfter-memAllocBefore)
+
+	for _, p := range payloads {
+		payloadCallBack(p)
+	}
+}
+
+func getPayloadStatsFromCheckpoint(payloadCallBack func(payload *ledger.Payload)) *complete.LedgerStats {
 	memAllocBefore := debug.GetHeapAllocsBytes()
 	log.Info().Msgf("loading checkpoint(s) from %v", flagCheckpointDir)
 
@@ -117,11 +193,6 @@ func run(*cobra.Command, []string) {
 
 	memAllocAfter := debug.GetHeapAllocsBytes()
 	log.Info().Msgf("the checkpoint is loaded, mem usage: %d", memAllocAfter-memAllocBefore)
-
-	var totalPayloadSize, totalPayloadValueSize uint64
-	var value ledger.Value
-	var key ledger.Key
-	var size, valueSize int
 
 	var tries []*trie.MTrie
 
@@ -148,21 +219,15 @@ func run(*cobra.Command, []string) {
 
 	log.Info().Msgf("collecting stats on %d tries", len(tries))
 
-	valueSizesByType := make(sizesByType, 0)
-	ledgerStats, err := complete.CollectStats(tries, func(p *ledger.Payload) {
-		key, err = p.Key()
-		if err != nil {
-			log.Fatal().Err(err).Msg("cannot load a key")
-		}
+	ledgerStats, err := complete.CollectStats(tries, payloadCallBack)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to collect stats")
+	}
 
-		size = p.Size()
-		value = p.Value()
-		valueSize = value.Size()
-		totalPayloadSize += uint64(size)
-		totalPayloadValueSize += uint64(valueSize)
-		valueSizesByType[getType(key)] = append(valueSizesByType[getType(key)], float64(valueSize))
-	})
+	return ledgerStats
+}
 
+func getStats(valueSizesByType sizesByType) []RegisterStatsByTypes {
 	statsByTypes := make([]RegisterStatsByTypes, 0)
 	for t, values := range valueSizesByType {
 
@@ -215,19 +280,10 @@ func run(*cobra.Command, []string) {
 			})
 	}
 
-	if err != nil {
-		log.Fatal().Err(err).Msg("failed to collect stats")
-	}
+	return statsByTypes
+}
 
-	stats := &Stats{
-		LedgerStats: ledgerStats,
-		PayloadStats: &PayloadStats{
-			TotalPayloadSize:      totalPayloadSize,
-			TotalPayloadValueSize: totalPayloadValueSize,
-			StatsByTypes:          statsByTypes,
-		},
-	}
-
+func writeStats(stats *Stats) {
 	path := filepath.Join(flagOutputDir, ledgerStatsReportName)
 
 	fi, err := os.Create(path)

--- a/ledger/complete/ledger_stats.go
+++ b/ledger/complete/ledger_stats.go
@@ -6,6 +6,7 @@ import (
 	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/flattener"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/node"
+	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 )
 
 type LedgerStats struct {
@@ -16,13 +17,17 @@ type LedgerStats struct {
 }
 
 func (l *Ledger) CollectStats(payloadCallBack func(payload *ledger.Payload)) (*LedgerStats, error) {
-	visitedNodes := make(map[*node.Node]uint64)
-	var interimNodeCounter, leafNodeCounter, totalNodeCounter uint64
-
 	tries, err := l.Tries()
 	if err != nil {
 		return nil, err
 	}
+
+	return CollectStats(tries, payloadCallBack)
+}
+
+func CollectStats(tries []*trie.MTrie, payloadCallBack func(payload *ledger.Payload)) (*LedgerStats, error) {
+	visitedNodes := make(map[*node.Node]uint64)
+	var interimNodeCounter, leafNodeCounter, totalNodeCounter uint64
 
 	bar := progressbar.Default(int64(len(tries)), "collecting ledger stats")
 	for _, trie := range tries {
@@ -38,7 +43,7 @@ func (l *Ledger) CollectStats(payloadCallBack func(payload *ledger.Payload)) (*L
 			visitedNodes[n] = totalNodeCounter
 			totalNodeCounter++
 		}
-		if err = bar.Add(1); err != nil {
+		if err := bar.Add(1); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Updates #6361

Changes to `checkpoint-collect-stats` command include:

- Add optional `state-commitment` flag.  When this new flag is provided, program only collects stats of one trie with specified state commitment, instead of all tries in checkpoint file (currently 500 tries).

  This flag reduces noise when tracking growth of single trie over time.

- Add support for input data from payloads file.  Payloads file is an alternative input and output for migration.

- Prevent overwriting existing file by using `ReportFileWriterFactory` to write stats output.