### PR TITLE
[Flow EVM] adding a new encoding type for captured precompiled calls

### DIFF
--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -1088,13 +1088,9 @@ func TestCallingExtraPrecompiles(t *testing.T) {
 				output := []byte{3, 4}
 				addr := testutils.RandomAddress(t)
 				capturedCall := &types.PrecompiledCalls{
-					Address: addr,
-					RequiredGasCalls: []types.RequiredGasCall{{
-						Input:  input,
-						Output: uint64(10),
-					}},
+					Address:          addr,
+					RequiredGasCalls: []uint64{10},
 					RunCalls: []types.RunCall{{
-						Input:    input,
 						Output:   output,
 						ErrorMsg: "",
 					}},

--- a/fvm/evm/emulator/tracker.go
+++ b/fvm/evm/emulator/tracker.go
@@ -38,10 +38,7 @@ func (ct *CallTracker) CaptureRequiredGas(address types.Address, input []byte, o
 		ct.callsByAddress[address] = calls
 	}
 
-	calls.RequiredGasCalls = append(calls.RequiredGasCalls, types.RequiredGasCall{
-		Input:  input,
-		Output: output,
-	})
+	calls.RequiredGasCalls = append(calls.RequiredGasCalls, output)
 }
 
 // CaptureRun captures a run calls
@@ -61,7 +58,6 @@ func (ct *CallTracker) CaptureRun(address types.Address, input []byte, output []
 		errMsg = err.Error()
 	}
 	calls.RunCalls = append(calls.RunCalls, types.RunCall{
-		Input:    input,
 		Output:   output,
 		ErrorMsg: errMsg,
 	})

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -668,16 +668,12 @@ func TestHandler_COA(t *testing.T) {
 				require.Len(t, pc.RequiredGasCalls, 1)
 				require.Equal(t,
 					pc.RequiredGasCalls[0],
-					types.RequiredGasCall{
-						Input:  precompiles.FlowBlockHeightFuncSig[:],
-						Output: precompiles.FlowBlockHeightFixedGas,
-					},
+					precompiles.FlowBlockHeightFixedGas,
 				)
 				require.Len(t, pc.RunCalls, 1)
 				require.Equal(t,
 					pc.RunCalls[0],
 					types.RunCall{
-						Input:    precompiles.FlowBlockHeightFuncSig[:],
 						Output:   ret.ReturnedData,
 						ErrorMsg: "",
 					},

--- a/fvm/evm/precompiles/replayer.go
+++ b/fvm/evm/precompiles/replayer.go
@@ -1,7 +1,6 @@
 package precompiles
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 
@@ -54,19 +53,13 @@ func (p *ReplayerPrecompiledContract) RequiredGas(input []byte) (output uint64) 
 	if p.requiredGasIndex > len(p.expectedCalls.RequiredGasCalls) {
 		panic(errUnexpectedCall)
 	}
-	if !bytes.Equal(p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Input, input) {
-		panic(errUnexpectedCall)
-	}
-	output = p.expectedCalls.RequiredGasCalls[p.requiredGasIndex].Output
+	output = p.expectedCalls.RequiredGasCalls[p.requiredGasIndex]
 	p.requiredGasIndex++
 	return
 }
 
 func (p *ReplayerPrecompiledContract) Run(input []byte) (output []byte, err error) {
 	if p.runIndex > len(p.expectedCalls.RunCalls) {
-		panic(errUnexpectedCall)
-	}
-	if !bytes.Equal(p.expectedCalls.RunCalls[p.runIndex].Input, input) {
 		panic(errUnexpectedCall)
 	}
 	output = p.expectedCalls.RunCalls[p.runIndex].Output

--- a/fvm/evm/precompiles/replayer_test.go
+++ b/fvm/evm/precompiles/replayer_test.go
@@ -24,23 +24,15 @@ func TestReplayer(t *testing.T) {
 
 	pc := &types.PrecompiledCalls{
 		Address: address,
-		RequiredGasCalls: []types.RequiredGasCall{
-			{
-				Input:  input1,
-				Output: gas1,
-			},
-			{
-				Input:  input2,
-				Output: gas2,
-			},
+		RequiredGasCalls: []uint64{
+			gas1,
+			gas2,
 		},
 		RunCalls: []types.RunCall{
 			{
-				Input:  input1,
 				Output: output1,
 			},
 			{
-				Input:    input2,
 				Output:   output2,
 				ErrorMsg: errMsg2,
 			},

--- a/fvm/evm/testutils/misc.go
+++ b/fvm/evm/testutils/misc.go
@@ -104,18 +104,13 @@ func RandomResultFixture(t testing.TB) *types.Result {
 func AggregatedPrecompiledCallsFixture(t testing.TB) types.AggregatedPrecompiledCalls {
 	return types.AggregatedPrecompiledCalls{
 		types.PrecompiledCalls{
-			Address: RandomAddress(t),
-			RequiredGasCalls: []types.RequiredGasCall{{
-				Input:  RandomData(t),
-				Output: 2,
-			}},
+			Address:          RandomAddress(t),
+			RequiredGasCalls: []uint64{2},
 			RunCalls: []types.RunCall{
 				{
-					Input:  RandomData(t),
 					Output: RandomData(t),
 				},
 				{
-					Input:    RandomData(t),
 					Output:   []byte{},
 					ErrorMsg: "Some error msg",
 				},

--- a/fvm/evm/types/precompiled.go
+++ b/fvm/evm/types/precompiled.go
@@ -79,13 +79,13 @@ func AggregatedPrecompileCallsFromEncoded(encoded []byte) (AggregatedPrecompiled
 	if len(encoded) == 0 {
 		return apc, nil
 	}
-	switch encoded[0] {
+	switch int(encoded[0]) {
 	case 1:
 		return decodePrecompiledCallsV1(encoded)
 	case 2:
 		return apc, rlp.DecodeBytes(encoded[AggregatedPrecompiledCallsEncodingByteSize:], &apc)
 	default:
-		return nil, fmt.Errorf("unknown type for encoded AggregatedPrecompiledCalls received")
+		return nil, fmt.Errorf("unknown type for encoded AggregatedPrecompiledCalls received %d", int(encoded[0]))
 	}
 }
 

--- a/fvm/evm/types/precompiled.go
+++ b/fvm/evm/types/precompiled.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 
 	gethVM "github.com/onflow/go-ethereum/core/vm"
 	"github.com/onflow/go-ethereum/rlp"
@@ -17,15 +18,8 @@ type PrecompiledContract interface {
 	Address() Address
 }
 
-// RunCall captures a call to the RequiredGas method of a precompiled contract
-type RequiredGasCall struct {
-	Input  []byte
-	Output uint64
-}
-
 // RunCall captures a call to the Run method of a precompiled contract
 type RunCall struct {
-	Input    []byte
 	Output   []byte
 	ErrorMsg string
 }
@@ -33,7 +27,7 @@ type RunCall struct {
 // PrecompiledCalls captures all the calls to a precompiled contract
 type PrecompiledCalls struct {
 	Address          Address
-	RequiredGasCalls []RequiredGasCall
+	RequiredGasCalls []uint64
 	RunCalls         []RunCall
 }
 
@@ -43,8 +37,8 @@ func (pc *PrecompiledCalls) IsEmpty() bool {
 }
 
 const (
-	AggregatedPrecompiledCallsEncodingVersion  uint8 = 1
 	AggregatedPrecompiledCallsEncodingByteSize int   = 1
+	AggregatedPrecompiledCallsEncodingVersion  uint8 = 2 // current version
 )
 
 // AggregatedPrecompiledCalls aggregates a list of precompiled calls
@@ -85,5 +79,54 @@ func AggregatedPrecompileCallsFromEncoded(encoded []byte) (AggregatedPrecompiled
 	if len(encoded) == 0 {
 		return apc, nil
 	}
-	return apc, rlp.DecodeBytes(encoded[AggregatedPrecompiledCallsEncodingByteSize:], &apc)
+	switch encoded[0] {
+	case 1:
+		return decodePrecompiledCallsV1(encoded)
+	case 2:
+		return apc, rlp.DecodeBytes(encoded[AggregatedPrecompiledCallsEncodingByteSize:], &apc)
+	default:
+		return nil, fmt.Errorf("unknown type for encoded AggregatedPrecompiledCalls received")
+	}
+}
+
+func decodePrecompiledCallsV1(encoded []byte) (AggregatedPrecompiledCalls, error) {
+	legacy := make([]precompiledCallsV1, 0)
+	err := rlp.DecodeBytes(encoded[AggregatedPrecompiledCallsEncodingByteSize:], &legacy)
+	if err != nil {
+		return nil, err
+	}
+	apc := make([]PrecompiledCalls, len(legacy))
+	for i, ap := range legacy {
+		reqCalls := make([]uint64, len(ap.RequiredGasCalls))
+		for j, rc := range ap.RequiredGasCalls {
+			reqCalls[j] = rc.Output
+		}
+		runCalls := make([]RunCall, len(ap.RunCalls))
+		for j, rc := range ap.RunCalls {
+			runCalls[j] = RunCall{
+				Output:   rc.Output,
+				ErrorMsg: rc.ErrorMsg,
+			}
+		}
+		apc[i] = PrecompiledCalls{
+			Address:          ap.Address,
+			RequiredGasCalls: reqCalls,
+			RunCalls:         runCalls,
+		}
+	}
+	return apc, nil
+}
+
+// legacy encoding types
+type precompiledCallsV1 struct {
+	Address          Address
+	RequiredGasCalls []struct {
+		Input  []byte
+		Output uint64
+	}
+	RunCalls []struct {
+		Input    []byte
+		Output   []byte
+		ErrorMsg string
+	}
 }

--- a/fvm/evm/types/precompiled_test.go
+++ b/fvm/evm/types/precompiled_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,65 +11,97 @@ import (
 )
 
 func TestPrecompiledCallsEncoding(t *testing.T) {
-	// empty precompiled calls
-	empty := types.AggregatedPrecompiledCalls{
-		types.PrecompiledCalls{
-			Address: testutils.RandomAddress(t),
-		},
-		types.PrecompiledCalls{
-			Address: testutils.RandomAddress(t),
-		},
-	}
+	t.Run("test latest version of encoding", func(t *testing.T) {
+		// empty precompiled calls
+		empty := types.AggregatedPrecompiledCalls{
+			types.PrecompiledCalls{
+				Address: testutils.RandomAddress(t),
+			},
+			types.PrecompiledCalls{
+				Address: testutils.RandomAddress(t),
+			},
+		}
 
-	encoded, err := empty.Encode()
-	require.NoError(t, err)
-	require.Empty(t, encoded)
+		encoded, err := empty.Encode()
+		require.NoError(t, err)
+		require.Empty(t, encoded)
 
-	apc := types.AggregatedPrecompiledCalls{
-		types.PrecompiledCalls{
-			Address: testutils.RandomAddress(t),
-			RequiredGasCalls: []types.RequiredGasCall{{
-				Input:  []byte{1},
-				Output: 2,
-			}},
-			RunCalls: []types.RunCall{},
-		},
-	}
+		apc := types.AggregatedPrecompiledCalls{
+			types.PrecompiledCalls{
+				Address:          testutils.RandomAddress(t),
+				RequiredGasCalls: []uint64{2},
+				RunCalls:         []types.RunCall{},
+			},
+		}
 
-	encoded, err = apc.Encode()
-	require.NoError(t, err)
-	require.NotEmpty(t, encoded)
+		encoded, err = apc.Encode()
+		require.NoError(t, err)
+		require.NotEmpty(t, encoded)
 
-	ret, err := types.AggregatedPrecompileCallsFromEncoded(encoded)
-	require.NoError(t, err)
-	require.Equal(t, apc, ret)
+		ret, err := types.AggregatedPrecompileCallsFromEncoded(encoded)
+		require.NoError(t, err)
+		require.Equal(t, apc, ret)
 
-	apc = types.AggregatedPrecompiledCalls{
-		types.PrecompiledCalls{
-			Address: testutils.RandomAddress(t),
-			RequiredGasCalls: []types.RequiredGasCall{{
-				Input:  []byte{1},
-				Output: 2,
-			}},
-			RunCalls: []types.RunCall{
-				{
-					Input:  []byte{3, 4},
-					Output: []byte{5, 6},
-				},
-				{
-					Input:    []byte{3, 4},
-					Output:   []byte{},
-					ErrorMsg: "Some error msg",
+		apc = types.AggregatedPrecompiledCalls{
+			types.PrecompiledCalls{
+				Address:          testutils.RandomAddress(t),
+				RequiredGasCalls: []uint64{2},
+				RunCalls: []types.RunCall{
+					{
+						Output: []byte{5, 6},
+					},
+					{
+						Output:   []byte{},
+						ErrorMsg: "Some error msg",
+					},
 				},
 			},
-		},
-	}
+		}
 
-	encoded, err = apc.Encode()
-	require.NoError(t, err)
-	require.NotEmpty(t, encoded)
+		encoded, err = apc.Encode()
+		require.NoError(t, err)
+		require.NotEmpty(t, encoded)
 
-	ret, err = types.AggregatedPrecompileCallsFromEncoded(encoded)
-	require.NoError(t, err)
-	require.Equal(t, apc, ret)
+		ret, err = types.AggregatedPrecompileCallsFromEncoded(encoded)
+		require.NoError(t, err)
+		require.Equal(t, apc, ret)
+
+	})
+
+	t.Run("test latest version of encoding v1", func(t *testing.T) {
+		encodedV1, err := hex.DecodeString("01f7f69408190002143239aaaed0d52d4a5bf218d62453ffc3c20102dcc782030482050680d3820304808e536f6d65206572726f72206d7367")
+		require.NoError(t, err)
+		expected := types.AggregatedPrecompiledCalls{
+			types.PrecompiledCalls{
+				Address:          types.Address{0x8, 0x19, 0x0, 0x2, 0x14, 0x32, 0x39, 0xaa, 0xae, 0xd0, 0xd5, 0x2d, 0x4a, 0x5b, 0xf2, 0x18, 0xd6, 0x24, 0x53, 0xff},
+				RequiredGasCalls: []uint64{2},
+				RunCalls: []types.RunCall{
+					{
+						Output: []byte{5, 6},
+					},
+					{
+						Output:   []byte{},
+						ErrorMsg: "Some error msg",
+					},
+				},
+			},
+		}
+
+		apc, err := types.AggregatedPrecompileCallsFromEncoded(encodedV1)
+		require.NoError(t, err)
+		require.Equal(t, len(expected), len(apc))
+		for i := range expected {
+			require.Equal(t, expected[i].Address, apc[i].Address)
+			require.Equal(t, len(expected[i].RequiredGasCalls), len(apc[i].RequiredGasCalls))
+			for j := range expected[i].RequiredGasCalls {
+				require.Equal(t, expected[i].RequiredGasCalls[j], apc[i].RequiredGasCalls[j])
+			}
+			require.Equal(t, len(expected[i].RunCalls), len(apc[i].RunCalls))
+			for j := range expected[i].RunCalls {
+				require.Equal(t, expected[i].RunCalls[j].ErrorMsg, apc[i].RunCalls[j].ErrorMsg)
+				require.Equal(t, expected[i].RunCalls[j].Output, apc[i].RunCalls[j].Output)
+			}
+		}
+	})
+
 }


### PR DESCRIPTION
Since we have state change checksum going forward, there is no need to check the input of the captured precompiled calls. Currently emitting inputs as part of captured precompiled calls is costly and removing this unnecessary data part can reduce an EVM transaction cost (especially for COA proofs). 