### PR TITLE
adding an option to boostrapcmd to pull candidate access nodes in addition to proposed nodes

### DIFF
--- a/cmd/util/cmd/common/transactions.go
+++ b/cmd/util/cmd/common/transactions.go
@@ -23,6 +23,21 @@ const (
 		
 			return infos
 	}`
+
+	getInfoForCandidateAccessNodesScript = `
+		import FlowIDTableStaking from "FlowIDTableStaking"
+		access(all) fun main(): [FlowIDTableStaking.NodeInfo] {
+		let candidateNodes = FlowIDTableStaking.getCandidateNodeList()
+		let candidateAccessNodes = candidateNodes[UInt8(5)]!
+
+        let nodeInfos: [FlowIDTableStaking.NodeInfo] = []
+        for nodeID in candidateAccessNodes.keys {
+            let nodeInfo = FlowIDTableStaking.NodeInfo(nodeID: nodeID)
+            nodeInfos.append(nodeInfo)
+        }
+
+        return nodeInfos
+	}`
 )
 
 // GetNodeInfoForProposedNodesScript returns a script that will return an array of FlowIDTableStaking.NodeInfo for each
@@ -33,6 +48,19 @@ func GetNodeInfoForProposedNodesScript(network string) ([]byte, error) {
 	return []byte(
 		templates.ReplaceAddresses(
 			getInfoForProposedNodesScript,
+			contracts.AsTemplateEnv(),
+		),
+	), nil
+}
+
+// GetNodeInfoForCandidateNodesScript returns a script that will return an array of FlowIDTableStaking.NodeInfo for each
+// node in the candidate table (nodes which have staked but not yet chosen by the network).
+func GetNodeInfoForCandidateNodesScript(network string) ([]byte, error) {
+	contracts := systemcontracts.SystemContractsForChain(flow.ChainID(fmt.Sprintf("flow-%s", network)))
+
+	return []byte(
+		templates.ReplaceAddresses(
+			getInfoForCandidateAccessNodesScript,
 			contracts.AsTemplateEnv(),
 		),
 	), nil


### PR DESCRIPTION
The bootstrapcmd is used to download all the partner node info during a network upgrade. It downloads all the nodes in the proposed table.
For the upcoming mainnet upgrade, the access nodes that have staked but have not yet been chosen and included in the proposed table must also be included. They are in the candidate table.
This PR adds an option to the bootstrap command to include those candidate access nodes.

Before we would run:
```
./bootstrapcmd populate-partner-infos \
--access-address=access.mainnet.nodes.onflow.org:9000 \
--network=mainnet \
--outdir=./bootstrap/mainnet25-partners
```

With this change we would run the same command with the additional flag **`include-candidate-access-nodes`**,

```
./bootstrapcmd populate-partner-infos \
--access-address=access.mainnet.nodes.onflow.org:9000 \
--network=mainnet \
--outdir=./bootstrap/mainnet25-partners \
--include-candidate-access-nodes
```

## Example Output by running the command without the flag: Total partner nodes = 359
```
<nil> INF total nodes in proposed table total_proposed_nodes=459
<nil> INF wrote file /tmp/bootstraptest/mainnet25-partners/public-root-information/node-info.pub.61ab46c9e1421eedbfeebf2f9abafc183ed664d6a094b74b923986fbec9e76fd.json
...
...
<nil> INF wrote file /tmp/bootstraptest/mainnet25-partners/partner-weights.json
Total number of flow nodes (skipped): 100
Total number of partner nodes: 359
Number of partner nodes by role:        verification : 48       access : 179    collection : 57 consensus : 70  execution : 5
```

## Example Output by running the command with the flag: Total partner nodes = 359 proposed + 5 candidate = 364

```
<nil> INF total nodes in proposed table total_proposed_nodes=459
<nil> INF total access nodes in candidate table total_candidate_access_nodes=5
<nil> INF wrote file /tmp/bootstraptest2/mainnet25-partners/public-root-information/node-info.pub.61ab46c9e1421eedbfeebf2f9abafc183ed664d6a094b74b923986fbec9e76fd.json
...
...
<nil> INF wrote file /tmp/bootstraptest2/mainnet25-partners/partner-weights.json
Total number of flow nodes (skipped): 100
Total number of partner nodes: 364
Number of partner nodes by role:        verification : 48       access : 184    collection : 57 consensus : 70  execution : 5
```

