### PR TITLE
[EFM] Updated type conversion of `EpochCommit`

### DIFF
--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -273,8 +273,6 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 	}
 
 	// parse DKG group key and participants
-	// Note: this is read in the same order as `DKGClient.SubmitResult` ie. with the group public key first followed by individual keys
-	// https://github.com/onflow/flow-go/blob/feature/dkg/module/dkg/client.go#L182-L183
 	commit.DKGParticipantKeys, err = convertDKGKeys(cdcDKGKeys.Values...)
 	if err != nil {
 		return nil, fmt.Errorf("could not convert DKG keys: %w", err)

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -968,11 +968,7 @@ func convertClusterQCVotes(cdcClusterQCs []cadence.Value) (
 // convertDKGKeys converts hex-encoded DKG public keys as received by the DKG
 // smart contract into crypto.PublicKey representations suitable for inclusion
 // in the protocol state.
-func convertDKGKeys(cdcDKGKeys ...cadence.Value) (
-	convertedKeys []crypto.PublicKey,
-	err error,
-) {
-
+func convertDKGKeys(cdcDKGKeys ...cadence.Value) ([]crypto.PublicKey, error) {
 	hexDKGKeys := make([]string, 0, len(cdcDKGKeys))
 	for _, value := range cdcDKGKeys {
 		keyHex, ok := value.(cadence.String)
@@ -985,13 +981,9 @@ func convertDKGKeys(cdcDKGKeys ...cadence.Value) (
 	// decode individual public keys
 	convertedKeys = make([]crypto.PublicKey, 0, len(hexDKGKeys))
 	for _, pubKeyString := range hexDKGKeys {
-
 		pubKeyBytes, err := hex.DecodeString(pubKeyString)
 		if err != nil {
-			return nil, fmt.Errorf(
-				"could not decode individual public key into bytes: %w",
-				err,
-			)
+			return nil, fmt.Errorf("could not decode individual public key into bytes: %w", err)
 		}
 		pubKey, err := crypto.DecodePublicKey(crypto.BLSBLS12381, pubKeyBytes)
 		if err != nil {

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -226,7 +226,7 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 
 	fields := cadence.FieldsMappedByName(cdcEvent)
 
-	const expectedFieldCount = 3
+	const expectedFieldCount = 5
 	if len(fields) < expectedFieldCount {
 		return nil, fmt.Errorf(
 			"insufficient fields in EpochCommit event (%d < %d)",
@@ -285,6 +285,7 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 	}
 	commit.DKGGroupKey = groupKey[0]
 
+	commit.DKGIndexMap = make(flow.DKGIndexMap, len(cdcDKGIndexMap.Pairs))
 	for _, pair := range cdcDKGIndexMap.Pairs {
 		nodeID, err := flow.HexStringToIdentifier(string(pair.Key.(cadence.String)))
 		if err != nil {

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -804,6 +804,14 @@ func createEpochCommitEvent() cadence.Event {
 		cadence.NewArray([]cadence.Value{
 			cadence.String("87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
 		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+
+		// dkgIdMapping
+		cadence.NewDictionary([]cadence.KeyValuePair{
+			{
+				Key:   cadence.String("0000000000000000000000000000000000000000000000000000000000000011"),
+				Value: cadence.NewInt(0),
+			},
+		}).WithType(cadence.NewDictionaryType(cadence.StringType, cadence.IntType)),
 	}).WithType(newFlowEpochEpochCommitEventType())
 }
 
@@ -1128,8 +1136,16 @@ func newFlowEpochEpochCommitEventType() *cadence.EventType {
 				Type:       cadence.NewVariableSizedArrayType(newFlowClusterQCClusterQCStructType()),
 			},
 			{
+				Identifier: "dkgGroupKey",
+				Type:       cadence.StringType,
+			},
+			{
 				Identifier: "dkgPubKeys",
 				Type:       cadence.NewVariableSizedArrayType(cadence.StringType),
+			},
+			{
+				Identifier: "dkgIdMapping",
+				Type:       cadence.NewDictionaryType(cadence.StringType, cadence.IntType),
 			},
 		},
 		nil,

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -153,7 +153,9 @@ func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCom
 		DKGParticipantKeys: []crypto.PublicKey{
 			MustDecodePublicKeyHex(crypto.BLSBLS12381, "87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
 		},
-		DKGIndexMap: nil,
+		DKGIndexMap: flow.DKGIndexMap{
+			flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000011"): 0,
+		},
 	}
 
 	return event, expected
@@ -271,6 +273,9 @@ func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochRe
 			DKGParticipantKeys: []crypto.PublicKey{
 				MustDecodePublicKeyHex(crypto.BLSBLS12381, "87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
 			},
+			//DKGIndexMap: flow.DKGIndexMap{
+			//	flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000011"): 0,
+			//},
 		},
 	}
 
@@ -792,9 +797,11 @@ func createEpochCommitEvent() cadence.Event {
 			cluster2,
 		}).WithType(cadence.NewVariableSizedArrayType(clusterQCType)),
 
+		// dkgGroupKey
+		cadence.String("8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+
 		// dkgPubKeys
 		cadence.NewArray([]cadence.Value{
-			cadence.String("8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
 			cadence.String("87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
 		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
 	}).WithType(newFlowEpochEpochCommitEventType())

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -1118,14 +1118,14 @@ func newFlowEpochEpochSetupEventType() *cadence.EventType {
 
 func newFlowEpochEpochCommitEventType() *cadence.EventType {
 
-	// A.01cf0e2f2f715450.FlowEpoch.EpochCommitted
+	// A.01cf0e2f2f715450.FlowEpoch.EpochCommit
 
 	address, _ := common.HexToAddress("01cf0e2f2f715450")
 	location := common.NewAddressLocation(nil, address, "FlowEpoch")
 
 	return cadence.NewEventType(
 		location,
-		"FlowEpoch.EpochCommitted",
+		"FlowEpoch.EpochCommit",
 		[]cadence.Field{
 			{
 				Identifier: "counter",


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/6320

### Context

Several changes have been made to the `EpochCommit` service event:
- It now has 5 fields instead of 3.
- Previously, the group key and participant keys were represented as a single array. Now, the group key has been moved to a separate field.
- The `dkgIdMapping` field has been introduced.

The latest state of the `EpochCommit` event can be viewed [here](https://github.com/onflow/flow-core-contracts/blob/jord/6213-dkg-mapping/contracts/epochs/FlowEpoch.cdc#L133).

This PR updates how the `EpochCommit` event is converted from Cadence to Go. Additionally, the fixtures have been updated to match the new changes so they can be verified using tests.

:exclamation: This PR does **not** change the Go structure of `EpochRecover`. Structurally, `EpochRecover` is composed of `EpochSetup` and `EpochCommit`, but the Cadence representation still uses the old format at the time this PR was created. A separate PR will be needed to update the parsing logic for `EpochRecover`.
