### PR TITLE
Adds `getIDs()` to NFT program recovery

### DIFF
--- a/fvm/environment/program_recovery.go
+++ b/fvm/environment/program_recovery.go
@@ -201,6 +201,10 @@ func RecoveredNonFungibleTokenCode(nonFungibleTokenAddress common.Address, contr
                       %[2]s.recoveryPanic("Collection.deposit")
                   }
 
+				  access(all) view fun getIDs(): [UInt64] {
+					  return self.ownedNFTs.keys
+                  }
+
                   access(all)
                   view fun getSupportedNFTTypes(): {Type: Bool} {
                       %[2]s.recoveryPanic("Collection.getSupportedNFTTypes")

--- a/fvm/environment/program_recovery.go
+++ b/fvm/environment/program_recovery.go
@@ -201,8 +201,9 @@ func RecoveredNonFungibleTokenCode(nonFungibleTokenAddress common.Address, contr
                       %[2]s.recoveryPanic("Collection.deposit")
                   }
 
-				  access(all) view fun getIDs(): [UInt64] {
-					  return self.ownedNFTs.keys
+                  access(all)
+                  view fun getIDs(): [UInt64] {
+                      return self.ownedNFTs.keys
                   }
 
                   access(all)


### PR DESCRIPTION
Closes https://github.com/onflow/flow-go/issues/6450

Adds an implementation of `NonFungibleToken.Collection.getIDs()` to the recovered program for unmigrated NFT contracts.

This will allow projects that didn't migrate to be able to query broken collections and recreate ownership with a newly deployed contract.