### PR TITLE
[Access] Improve error messages when querying old blocks

### DIFF
--- a/engine/access/rpc/backend/backend.go
+++ b/engine/access/rpc/backend/backend.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"crypto/md5" //nolint:gosec
+	"errors"
 	"fmt"
 	"time"
 
@@ -640,4 +641,48 @@ func chooseFromPreferredENIDs(allENs flow.IdentityList, executorIDs flow.Identif
 	addIfNotExists(allENs)
 
 	return chosenIDs
+}
+
+// handleErrorMessage processes errors returned during height-based queries.
+// If the error is due to a block not being found, this function determines whether the queried
+// height falls outside the node's accessible range and provides context-sensitive error messages
+// based on spork and node root block heights.
+//
+// Parameters:
+// - stateParams: Protocol parameters that contain spork root and node root block heights.
+// - height: The queried block height.
+// - genericErr: The initial error returned when the block is not found.
+//
+// Expected errors during normal operation:
+// - storage.ErrNotFound - Indicates that the queried block does not exist in the local database.
+func handleErrorMessage(
+	stateParams protocol.Params,
+	height uint64,
+	genericErr error,
+) error {
+	if !errors.Is(genericErr, storage.ErrNotFound) {
+		return genericErr
+	}
+
+	sporkRootBlockHeight := stateParams.SporkRootBlockHeight()
+	nodeRootBlockHeader := stateParams.SealedRoot().Height
+
+	var err error
+	if height < sporkRootBlockHeight {
+		err = fmt.Errorf("block height %d is less than the spork root block height %d. Try to use a historic node: %w",
+			height,
+			sporkRootBlockHeight,
+			genericErr,
+		)
+	} else if height < nodeRootBlockHeader && nodeRootBlockHeader >= sporkRootBlockHeight {
+		err = fmt.Errorf("block height %d is less than the node`s root block height %d. Try to use a different Access node: %w",
+			height,
+			nodeRootBlockHeader,
+			genericErr,
+		)
+	} else {
+		err = genericErr
+	}
+
+	return err
 }

--- a/engine/access/rpc/backend/backend_accounts.go
+++ b/engine/access/rpc/backend/backend_accounts.go
@@ -68,7 +68,7 @@ func (b *backendAccounts) GetAccountAtBlockHeight(
 ) (*flow.Account, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(err)
+		return nil, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), height, err))
 	}
 
 	account, err := b.getAccountAtBlock(ctx, address, blockID, height)
@@ -108,7 +108,7 @@ func (b *backendAccounts) GetAccountBalanceAtBlockHeight(
 ) (uint64, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return 0, rpc.ConvertStorageError(err)
+		return 0, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), height, err))
 	}
 
 	balance, err := b.getAccountBalanceAtBlock(ctx, address, blockID, height)
@@ -176,7 +176,7 @@ func (b *backendAccounts) GetAccountKeyAtBlockHeight(
 ) (*flow.AccountPublicKey, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(err)
+		return nil, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), height, err))
 	}
 
 	accountKey, err := b.getAccountKeyAtBlock(ctx, address, keyIndex, blockID, height)
@@ -196,7 +196,7 @@ func (b *backendAccounts) GetAccountKeysAtBlockHeight(
 ) ([]flow.AccountPublicKey, error) {
 	blockID, err := b.headers.BlockIDByHeight(height)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(err)
+		return nil, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), height, err))
 	}
 
 	accountKeys, err := b.getAccountKeysAtBlock(ctx, address, blockID, height)
@@ -400,7 +400,7 @@ func (b *backendAccounts) getAccountFromLocalStorage(
 	// make sure data is available for the requested block
 	account, err := b.scriptExecutor.GetAccountAtBlockHeight(ctx, address, height)
 	if err != nil {
-		return nil, convertAccountError(err, address, height)
+		return nil, convertAccountError(handleErrorMessage(b.state.Params(), height, err), address, height)
 	}
 	return account, nil
 }

--- a/engine/access/rpc/backend/backend_accounts_test.go
+++ b/engine/access/rpc/backend/backend_accounts_test.go
@@ -238,6 +238,8 @@ func (s *BackendAccountsSuite) TestGetAccountFromStorage_Fails() {
 		scriptExecutor.On("GetAccountAtBlockHeight", mock.Anything, s.failingAddress, s.block.Header.Height).
 			Return(nil, tt.err).Times(3)
 
+		s.state.On("Params").Return(s.params).Times(3)
+
 		s.Run(fmt.Sprintf("GetAccount - fails with %v", tt.err), func() {
 			s.testGetAccount(ctx, backend, tt.statusCode)
 		})
@@ -247,6 +249,9 @@ func (s *BackendAccountsSuite) TestGetAccountFromStorage_Fails() {
 		})
 
 		s.Run(fmt.Sprintf("GetAccountAtBlockHeight - fails with %v", tt.err), func() {
+			s.params.On("SporkRootBlockHeight").Return(s.block.Header.Height-10, nil)
+			s.params.On("SealedRoot").Return(s.block.Header, nil)
+
 			s.testGetAccountAtBlockHeight(ctx, backend, tt.statusCode)
 		})
 	}
@@ -279,6 +284,9 @@ func (s *BackendAccountsSuite) TestGetAccountFromFailover_HappyPath() {
 		})
 
 		s.Run(fmt.Sprintf("GetAccountAtBlockHeight - happy path - recovers %v", errToReturn), func() {
+			s.params.On("SporkRootBlockHeight").Return(s.block.Header.Height-10, nil)
+			s.params.On("SealedRoot").Return(s.block.Header, nil)
+
 			s.testGetAccountAtBlockHeight(ctx, backend, codes.OK)
 		})
 	}

--- a/engine/access/rpc/backend/backend_block_details.go
+++ b/engine/access/rpc/backend/backend_block_details.go
@@ -80,7 +80,7 @@ func (b *backendBlockDetails) GetBlockByID(ctx context.Context, id flow.Identifi
 func (b *backendBlockDetails) GetBlockByHeight(ctx context.Context, height uint64) (*flow.Block, flow.BlockStatus, error) {
 	block, err := b.blocks.ByHeight(height)
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(err)
+		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), height, err))
 	}
 
 	stat, err := b.getBlockStatus(ctx, block)

--- a/engine/access/rpc/backend/backend_block_headers.go
+++ b/engine/access/rpc/backend/backend_block_headers.go
@@ -69,7 +69,7 @@ func (b *backendBlockHeaders) GetBlockHeaderByID(ctx context.Context, id flow.Id
 func (b *backendBlockHeaders) GetBlockHeaderByHeight(ctx context.Context, height uint64) (*flow.Header, flow.BlockStatus, error) {
 	header, err := b.headers.ByHeight(height)
 	if err != nil {
-		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(err)
+		return nil, flow.BlockStatusUnknown, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), height, err))
 	}
 
 	stat, err := b.getBlockStatus(ctx, header)

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -104,7 +104,7 @@ func (b *backendEvents) GetEventsForHeightRange(
 		// and avoids calculating header.ID() for each block.
 		blockID, err := b.headers.BlockIDByHeight(i)
 		if err != nil {
-			return nil, rpc.ConvertStorageError(fmt.Errorf("failed to get blockID for %d: %w", i, err))
+			return nil, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), i, err))
 		}
 		header, err := b.headers.ByBlockID(blockID)
 		if err != nil {

--- a/engine/access/rpc/backend/backend_scripts.go
+++ b/engine/access/rpc/backend/backend_scripts.go
@@ -104,7 +104,7 @@ func (b *backendScripts) ExecuteScriptAtBlockHeight(
 ) ([]byte, error) {
 	header, err := b.headers.ByHeight(blockHeight)
 	if err != nil {
-		return nil, rpc.ConvertStorageError(err)
+		return nil, rpc.ConvertStorageError(handleErrorMessage(b.state.Params(), blockHeight, err))
 	}
 
 	return b.executeScript(ctx, newScriptExecutionRequest(header.ID(), blockHeight, script, arguments))


### PR DESCRIPTION
Closes: #4904

## Context 

This PR improves error messaging on Access nodes for block height-based queries:
- `ExecuteScriptAtBlockHeight`, 
- `GetBlockByHeight`, 
- `GetBlockHeaderByHeight`, 
- `GetEventsForHeightRange`, 
- `GetAccountAtBlockHeight`,
- `GetAccountBalanceAtBlockHeight`,
- `GetAccountKeyAtBlockHeight`,
- `GetAccountKeysAtBlockHeight`.

Errors are now categorized based on the queried height:
- Below `Spork Root Height:` Instructs the caller to use a historic node.
- Below `Node’s Root Height:` Suggests querying a different Access node (if the node was started after a spork).

Updated and added unit tests to validate the new messaging logic.
