### PR TITLE
Use Production Docker Registry environment for pushing to docker

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -82,6 +82,7 @@ jobs:
   docker-push:
     name: ${{ matrix.role }} images
     runs-on: ubuntu-latest
+    environment: Production Docker Registry
     needs: matrix_builder
 
     # setup jobs for each role

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,7 @@ jobs:
   docker-push:
     name: Push to container registry
     runs-on: ubuntu-latest
+    environment: Production Docker Registry
     steps:
     - name: Setup Go
       uses: actions/setup-go@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,18 @@
 name: CD
 
 on:
-  push:
-    tags:
-      - '*'
-      - "!daily-*"
+# Workflow dispatch for now, while we're testing environments
+  # push:
+  #   tags:
+  #     - '*'
+  #     - "!daily-*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag/commit'
+        required: true
+        type: string
+
 
 env:
   GO_VERSION: "1.22"
@@ -22,6 +30,8 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     - name: Checkout repo
       uses: actions/checkout@v2
+      with:
+        ref: ${{ inputs.tag }}
     # Provide Google Service Account credentials to Github Action, allowing interaction with the Google Container Registry
     # Logging in as github-actions@dl-flow.iam.gserviceaccount.com
     - id: auth


### PR DESCRIPTION
This change will allow better control of the build process for containers.

Environments allow control over
a) Additional approval for usage of the environment/secrets, and
b) Allows admins to limit which branches can access the secrets

As of writing, the `Production Docker Registry` environment requires @Kay-Zee or @sjonpaulbrown approval to push to the docker registry, but this will be expanded once testing is complete.

Also, branches are limited to `master` and `v0.37`, which means we will have to update `v0.37` to the new "active" branch whenever that happens. This should be exceedingly rare with our current release schedule.