### PR TITLE
fix: fix slice init length

### DIFF
--- a/cmd/util/cmd/read-badger/cmd/find-block-by-commits/main.go
+++ b/cmd/util/cmd/read-badger/cmd/find-block-by-commits/main.go
@@ -80,7 +80,7 @@ func FindBlockIDByCommits(
 
 func toStateCommitments(commitsStr string) ([]flow.StateCommitment, error) {
 	commitSlice := strings.Split(commitsStr, ",")
-	commits := make([]flow.StateCommitment, len(commitSlice))
+	commits := make([]flow.StateCommitment, 0, len(commitSlice))
 	for _, c := range commitSlice {
 		commit, err := toStateCommitment(c)
 		if err != nil {


### PR DESCRIPTION

The intention here should be to initialize a slice with a capacity of  len(commitSlice)  rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW