### PR TITLE
Marking v0.37.18 as backward compatible in terms of script execution

### DIFF
--- a/engine/common/version/version_control.go
+++ b/engine/common/version/version_control.go
@@ -39,6 +39,7 @@ var NoHeight = uint64(0)
 // deployed during the HCU are backwards compatible for scripts.
 var defaultCompatibilityOverrides = map[string]struct{}{
 	"0.37.17": {},
+	"0.37.18": {},
 }
 
 // VersionControl manages the version control system for the node.


### PR DESCRIPTION
Original PR that added this feature: https://github.com/onflow/flow-go/pull/6536