### PR TITLE
Add a Time To Seal metric to access node to track time it takes to seal a transaction

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -148,6 +148,7 @@ type AccessNodeConfig struct {
 	logTxTimeToFinalized                 bool
 	logTxTimeToExecuted                  bool
 	logTxTimeToFinalizedExecuted         bool
+	logTxTimeToSealed                    bool
 	retryEnabled                         bool
 	rpcMetricsEnabled                    bool
 	executionDataSyncEnabled             bool
@@ -237,6 +238,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		logTxTimeToFinalized:         false,
 		logTxTimeToExecuted:          false,
 		logTxTimeToFinalizedExecuted: false,
+		logTxTimeToSealed:            false,
 		pingEnabled:                  false,
 		retryEnabled:                 false,
 		rpcMetricsEnabled:            false,
@@ -296,6 +298,7 @@ type FlowAccessNodeBuilder struct {
 	CollectionsToMarkFinalized *stdmap.Times
 	CollectionsToMarkExecuted  *stdmap.Times
 	BlocksToMarkExecuted       *stdmap.Times
+	BlockTransactions          *stdmap.IdentifierMap
 	TransactionMetrics         *metrics.TransactionCollector
 	RestMetrics                *metrics.RestCollector
 	AccessMetrics              module.AccessMetrics
@@ -1222,6 +1225,10 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"log-tx-time-to-finalized-executed",
 			defaultConfig.logTxTimeToFinalizedExecuted,
 			"log transaction time to finalized and executed")
+		flags.BoolVar(&builder.logTxTimeToSealed,
+			"log-tx-time-to-sealed",
+			defaultConfig.logTxTimeToSealed,
+			"log transaction time to sealed")
 		flags.BoolVar(&builder.pingEnabled,
 			"ping-enabled",
 			defaultConfig.pingEnabled,
@@ -1651,6 +1658,11 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				return err
 			}
 
+			builder.BlockTransactions, err = stdmap.NewIdentifierMap(10000)
+			if err != nil {
+				return err
+			}
+
 			builder.BlocksToMarkExecuted, err = stdmap.NewTimes(1 * 300) // assume 1 block per second * 300 seconds
 
 			return err
@@ -1662,6 +1674,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				builder.logTxTimeToFinalized,
 				builder.logTxTimeToExecuted,
 				builder.logTxTimeToFinalizedExecuted,
+				builder.logTxTimeToSealed,
 			)
 			return nil
 		}).
@@ -1691,6 +1704,7 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 				builder.BlocksToMarkExecuted,
 				builder.Storage.Collections,
 				builder.Storage.Blocks,
+				builder.BlockTransactions,
 			)
 			if err != nil {
 				return err

--- a/cmd/bootstrap/utils/md5.go
+++ b/cmd/bootstrap/utils/md5.go
@@ -3,7 +3,7 @@ package utils
 // The google storage API only provides md5 and crc32 hence overriding the linter flag for md5
 // #nosec
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec
 	"io"
 	"os"
 )

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -156,6 +156,7 @@ type ObserverServiceConfig struct {
 	logTxTimeToFinalized                 bool
 	logTxTimeToExecuted                  bool
 	logTxTimeToFinalizedExecuted         bool
+	logTxTimeToSealed                    bool
 	executionDataSyncEnabled             bool
 	executionDataIndexingEnabled         bool
 	executionDataDBMode                  string
@@ -231,6 +232,7 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 		logTxTimeToFinalized:                 false,
 		logTxTimeToExecuted:                  false,
 		logTxTimeToFinalizedExecuted:         false,
+		logTxTimeToSealed:                    false,
 		executionDataSyncEnabled:             false,
 		executionDataIndexingEnabled:         false,
 		executionDataDBMode:                  execution_data.ExecutionDataDBModeBadger.String(),
@@ -672,6 +674,10 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 			"log-tx-time-to-finalized-executed",
 			defaultConfig.logTxTimeToFinalizedExecuted,
 			"log transaction time to finalized and executed")
+		flags.BoolVar(&builder.logTxTimeToSealed,
+			"log-tx-time-to-sealed",
+			defaultConfig.logTxTimeToSealed,
+			"log transaction time to sealed")
 		flags.BoolVar(&builder.rpcMetricsEnabled, "rpc-metrics-enabled", defaultConfig.rpcMetricsEnabled, "whether to enable the rpc metrics")
 		flags.BoolVar(&builder.executionDataIndexingEnabled,
 			"execution-data-indexing-enabled",
@@ -1739,6 +1745,7 @@ func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 			builder.logTxTimeToFinalized,
 			builder.logTxTimeToExecuted,
 			builder.logTxTimeToFinalizedExecuted,
+			builder.logTxTimeToSealed,
 		)
 		return nil
 	})

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -642,6 +642,8 @@ func (suite *Suite) TestGetSealedTransaction() {
 		require.NoError(suite.T(), err)
 		blocksToMarkExecuted, err := stdmap.NewTimes(100)
 		require.NoError(suite.T(), err)
+		blockTransactions, err := stdmap.NewIdentifierMap(100)
+		require.NoError(suite.T(), err)
 
 		bnd, err := backend.New(backend.Params{State: suite.state,
 			CollectionRPC:             suite.collClient,
@@ -674,6 +676,7 @@ func (suite *Suite) TestGetSealedTransaction() {
 			blocksToMarkExecuted,
 			collections,
 			all.Blocks,
+			blockTransactions,
 		)
 		require.NoError(suite.T(), err)
 
@@ -805,6 +808,8 @@ func (suite *Suite) TestGetTransactionResult() {
 		require.NoError(suite.T(), err)
 		blocksToMarkExecuted, err := stdmap.NewTimes(100)
 		require.NoError(suite.T(), err)
+		blockTransactions, err := stdmap.NewIdentifierMap(100)
+		require.NoError(suite.T(), err)
 
 		bnd, err := backend.New(backend.Params{State: suite.state,
 			CollectionRPC:             suite.collClient,
@@ -837,6 +842,7 @@ func (suite *Suite) TestGetTransactionResult() {
 			blocksToMarkExecuted,
 			collections,
 			all.Blocks,
+			blockTransactions,
 		)
 		require.NoError(suite.T(), err)
 
@@ -1054,6 +1060,8 @@ func (suite *Suite) TestExecuteScript() {
 		require.NoError(suite.T(), err)
 		blocksToMarkExecuted, err := stdmap.NewTimes(100)
 		require.NoError(suite.T(), err)
+		blockTransactions, err := stdmap.NewIdentifierMap(100)
+		require.NoError(suite.T(), err)
 
 		collectionExecutedMetric, err := indexer.NewCollectionExecutedMetricImpl(
 			suite.log,
@@ -1063,6 +1071,7 @@ func (suite *Suite) TestExecuteScript() {
 			blocksToMarkExecuted,
 			collections,
 			all.Blocks,
+			blockTransactions,
 		)
 		require.NoError(suite.T(), err)
 

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -133,6 +133,8 @@ func (s *Suite) SetupTest() {
 	require.NoError(s.T(), err)
 	blocksToMarkExecuted, err := stdmap.NewTimes(100)
 	require.NoError(s.T(), err)
+	blockTransactions, err := stdmap.NewIdentifierMap(100)
+	require.NoError(s.T(), err)
 
 	s.proto.state.On("Identity").Return(s.obsIdentity, nil)
 	s.proto.state.On("Params").Return(s.proto.params)
@@ -174,6 +176,7 @@ func (s *Suite) SetupTest() {
 		blocksToMarkExecuted,
 		s.collections,
 		s.blocks,
+		blockTransactions,
 	)
 	require.NoError(s.T(), err)
 }

--- a/model/flow/transaction_timing.go
+++ b/model/flow/transaction_timing.go
@@ -10,6 +10,7 @@ type TransactionTiming struct {
 	Received      time.Time
 	Finalized     time.Time
 	Executed      time.Time
+	Sealed        time.Time
 }
 
 func (t TransactionTiming) ID() Identifier {

--- a/module/metrics.go
+++ b/module/metrics.go
@@ -1074,6 +1074,10 @@ type TransactionMetrics interface {
 	// works if the transaction was earlier added as received.
 	TransactionFinalized(txID flow.Identifier, when time.Time)
 
+	// TransactionSealed reports the time spent between the transaction being received and sealed. Reporting only
+	// works if the transaction was earlier added as received.
+	TransactionSealed(txID flow.Identifier, when time.Time)
+
 	// TransactionExecuted reports the time spent between the transaction being received and executed. Reporting only
 	// works if the transaction was earlier added as received.
 	TransactionExecuted(txID flow.Identifier, when time.Time)

--- a/module/metrics/noop.go
+++ b/module/metrics/noop.go
@@ -213,6 +213,7 @@ func (nc *NoopCollector) ScriptExecutionNotIndexed()                            
 func (nc *NoopCollector) TransactionResultFetched(dur time.Duration, size int)                  {}
 func (nc *NoopCollector) TransactionReceived(txID flow.Identifier, when time.Time)              {}
 func (nc *NoopCollector) TransactionFinalized(txID flow.Identifier, when time.Time)             {}
+func (nc *NoopCollector) TransactionSealed(txID flow.Identifier, when time.Time)                {}
 func (nc *NoopCollector) TransactionExecuted(txID flow.Identifier, when time.Time)              {}
 func (nc *NoopCollector) TransactionExpired(txID flow.Identifier)                               {}
 func (nc *NoopCollector) TransactionSubmissionFailed()                                          {}

--- a/module/mock/access_metrics.go
+++ b/module/mock/access_metrics.go
@@ -138,6 +138,11 @@ func (_m *AccessMetrics) TransactionResultFetched(dur time.Duration, size int) {
 	_m.Called(dur, size)
 }
 
+// TransactionSealed provides a mock function with given fields: txID, when
+func (_m *AccessMetrics) TransactionSealed(txID flow.Identifier, when time.Time) {
+	_m.Called(txID, when)
+}
+
 // TransactionSubmissionFailed provides a mock function with given fields:
 func (_m *AccessMetrics) TransactionSubmissionFailed() {
 	_m.Called()

--- a/module/mock/transaction_metrics.go
+++ b/module/mock/transaction_metrics.go
@@ -39,6 +39,11 @@ func (_m *TransactionMetrics) TransactionResultFetched(dur time.Duration, size i
 	_m.Called(dur, size)
 }
 
+// TransactionSealed provides a mock function with given fields: txID, when
+func (_m *TransactionMetrics) TransactionSealed(txID flow.Identifier, when time.Time) {
+	_m.Called(txID, when)
+}
+
 // TransactionSubmissionFailed provides a mock function with given fields:
 func (_m *TransactionMetrics) TransactionSubmissionFailed() {
 	_m.Called()

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -197,6 +197,8 @@ func (i *indexCoreTest) initIndexer() *indexCoreTest {
 	require.NoError(i.t, err)
 	blocksToMarkExecuted, err := stdmap.NewTimes(100)
 	require.NoError(i.t, err)
+	blockTransactions, err := stdmap.NewIdentifierMap(100)
+	require.NoError(i.t, err)
 
 	log := zerolog.New(os.Stdout)
 	blocks := storagemock.NewBlocks(i.t)
@@ -209,6 +211,7 @@ func (i *indexCoreTest) initIndexer() *indexCoreTest {
 		blocksToMarkExecuted,
 		i.collections,
 		blocks,
+		blockTransactions,
 	)
 	require.NoError(i.t, err)
 


### PR DESCRIPTION
Backports: https://github.com/onflow/flow-go/pull/6512