### PR TITLE
EFM Recovery: Fixes from Benchnet Testing

### DIFF
--- a/cmd/bootstrap/cmd/block.go
+++ b/cmd/bootstrap/cmd/block.go
@@ -42,7 +42,10 @@ func constructRootEpochEvents(
 	participants flow.IdentityList,
 	assignments flow.AssignmentList,
 	clusterQCs []*flow.QuorumCertificate,
-	dkgData dkg.DKGData) (*flow.EpochSetup, *flow.EpochCommit) {
+	dkgData dkg.DKGData,
+	dkgIndexMap flow.DKGIndexMap,
+) (*flow.EpochSetup, *flow.EpochCommit) {
+
 	epochSetup := &flow.EpochSetup{
 		Counter:            flagEpochCounter,
 		FirstView:          firstView,
@@ -77,6 +80,7 @@ func constructRootEpochEvents(
 		ClusterQCs:         flow.ClusterQCVoteDatasFromQCs(qcsWithSignerIDs),
 		DKGGroupKey:        dkgData.PubGroupKey,
 		DKGParticipantKeys: dkgData.PubKeyShares,
+		DKGIndexMap:        dkgIndexMap,
 	}
 	return epochSetup, epochCommit
 }

--- a/cmd/bootstrap/cmd/dkg.go
+++ b/cmd/bootstrap/cmd/dkg.go
@@ -10,10 +10,11 @@ import (
 	model "github.com/onflow/flow-go/model/bootstrap"
 	"github.com/onflow/flow-go/model/dkg"
 	"github.com/onflow/flow-go/model/encodable"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol/inmem"
 )
 
-func runBeaconKG(nodes []model.NodeInfo) dkg.DKGData {
+func runBeaconKG(nodes []model.NodeInfo) (dkg.DKGData, flow.DKGIndexMap) {
 	n := len(nodes)
 
 	log.Info().Msgf("read %v node infos for DKG", n)
@@ -46,6 +47,11 @@ func runBeaconKG(nodes []model.NodeInfo) dkg.DKGData {
 		log.Info().Msgf("wrote file %s/%s", flagOutdir, fmt.Sprintf(model.PathRandomBeaconPriv, nodeID))
 	}
 
+	indexMap := make(flow.DKGIndexMap, len(pubKeyShares))
+	for i, node := range nodes {
+		indexMap[node.NodeID] = i
+	}
+
 	// write full DKG info that will be used to construct QC
 	err = common.WriteJSON(model.PathRootDKGData, flagOutdir, inmem.EncodableFullDKG{
 		GroupKey: encodable.RandomBeaconPubKey{
@@ -59,5 +65,5 @@ func runBeaconKG(nodes []model.NodeInfo) dkg.DKGData {
 	}
 	log.Info().Msgf("wrote file %s/%s", flagOutdir, model.PathRootDKGData)
 
-	return dkgData
+	return dkgData, indexMap
 }

--- a/cmd/bootstrap/cmd/rootblock.go
+++ b/cmd/bootstrap/cmd/rootblock.go
@@ -174,7 +174,7 @@ func rootBlock(cmd *cobra.Command, args []string) {
 	log.Info().Msg("")
 
 	log.Info().Msg("running DKG for consensus nodes")
-	dkgData := runBeaconKG(model.FilterByRole(stakingNodes, flow.RoleConsensus))
+	dkgData, dkgIndexMap := runBeaconKG(model.FilterByRole(stakingNodes, flow.RoleConsensus))
 	log.Info().Msg("")
 
 	// create flow.IdentityList representation of the participant set
@@ -200,7 +200,7 @@ func rootBlock(cmd *cobra.Command, args []string) {
 	log.Info().Msg("")
 
 	log.Info().Msg("constructing intermediary bootstrapping data")
-	epochSetup, epochCommit := constructRootEpochEvents(header.View, participants, assignments, clusterQCs, dkgData)
+	epochSetup, epochCommit := constructRootEpochEvents(header.View, participants, assignments, clusterQCs, dkgData, dkgIndexMap)
 	epochConfig := generateExecutionStateEpochConfig(epochSetup, clusterQCs, dkgData)
 	intermediaryEpochData := IntermediaryEpochData{
 		RootEpochSetup:       epochSetup,

--- a/cmd/util/cmd/epochs/cmd/recover.go
+++ b/cmd/util/cmd/epochs/cmd/recover.go
@@ -76,14 +76,13 @@ func addGenerateRecoverEpochTxArgsCmdFlags() error {
 		"containing the output from the `keygen` command for internal nodes")
 	generateRecoverEpochTxArgsCmd.Flags().Uint64Var(&flagNumViewsInEpoch, "epoch-length", 0, "length of each epoch measured in views")
 	generateRecoverEpochTxArgsCmd.Flags().Uint64Var(&flagNumViewsInStakingAuction, "epoch-staking-phase-length", 0, "length of the epoch staking phase measured in views")
-	generateRecoverEpochTxArgsCmd.Flags().Uint64Var(&flagEpochCounter, "epoch-counter", 0, "the epoch counter used to generate the root cluster block")
 	generateRecoverEpochTxArgsCmd.Flags().Uint64Var(&flagTargetDuration, "epoch-timing-duration", 0, "the target duration of the epoch, in seconds")
 	// The following option allows the RecoveryEpoch specified by this command to overwrite an epoch which already exists in the smart contract.
 	// This is needed only if a previous recoverEpoch transaction was submitted and a race condition occurred such that:
 	//   - the RecoveryEpoch in the admin transaction was accepted by the smart contract
 	//   - the RecoveryEpoch service event (after sealing latency) was rejected by the Protocol State
 	generateRecoverEpochTxArgsCmd.Flags().BoolVar(&flagUnsafeAllowOverWrite, "unsafe-overwrite-epoch-data", false, "set to true if the resulting transaction is allowed to overwrite an already specified epoch in the smart contract.")
-	generateRecoverEpochTxArgsCmd.Flags().Uint64Var(&flagEpochCounter, "recovery-epoch-counter", 0, "the recovery epoch counter")
+	generateRecoverEpochTxArgsCmd.Flags().Uint64Var(&flagEpochCounter, "recovery-epoch-counter", 0, "the epoch counter for the recovery epoch")
 
 	err := generateRecoverEpochTxArgsCmd.MarkFlagRequired("access-address")
 	if err != nil {
@@ -96,10 +95,6 @@ func addGenerateRecoverEpochTxArgsCmdFlags() error {
 	err = generateRecoverEpochTxArgsCmd.MarkFlagRequired("epoch-staking-phase-length")
 	if err != nil {
 		return fmt.Errorf("failed to mark epoch-staking-phase-length flag as required")
-	}
-	err = generateRecoverEpochTxArgsCmd.MarkFlagRequired("epoch-counter")
-	if err != nil {
-		return fmt.Errorf("failed to mark epoch-counter flag as required")
 	}
 	err = generateRecoverEpochTxArgsCmd.MarkFlagRequired("collection-clusters")
 	if err != nil {


### PR DESCRIPTION
- Previously the DKG index mapping was omitted from the bootstrapping command. This uses a similar approach to that used in integration tests. 
- Removes a duplicate flag (epoch counter was specified twice)