### PR TITLE
[Flow EVM] Move tracing reset to `OnTxEnd` hook

### DIFF
--- a/fvm/evm/debug/tracer.go
+++ b/fvm/evm/debug/tracer.go
@@ -165,12 +165,6 @@ func NewSafeTxTracer(ct *CallTracer) *tracers.Tracer {
 		if ct.tracer.OnTxStart != nil {
 			ct.tracer.OnTxStart(vm, tx, from)
 		}
-		// reset tracing to have fresh state
-		if err := ct.ResetTracer(); err != nil {
-			l.Error().Err(err).
-				Msg("failed to reset tracer")
-			return
-		}
 	}
 
 	wrapped.OnTxEnd = func(receipt *types.Receipt, err error) {
@@ -197,6 +191,13 @@ func NewSafeTxTracer(ct *CallTracer) *tracers.Tracer {
 			return
 		}
 		ct.resultsByTxID[receipt.TxHash] = res
+
+		// reset tracing to have fresh state
+		if err := ct.ResetTracer(); err != nil {
+			l.Error().Err(err).
+				Msg("failed to reset tracer")
+			return
+		}
 	}
 
 	wrapped.OnEnter = func(


### PR DESCRIPTION
Currently, the `gas` field was always set to `0x0`, due to the tracing reset being done on `OnTxStart`:
```json
{
      "txHash": "0xf730eacee38a28f93fcf1a9a1f9c360542fe20e3200510126976bb9ee7fd3fca",
      "result": {
        "from": "0x0000000000000000000000030000000000000000",
        "gas": "0x0",
        "gasUsed": "0x5208",
        "to": "0x2c91520ee9e2c55593dc425e1c2b82026391dea7",
        "input": "0x",
        "value": "0x18321634f200",
        "type": "CALL"
      }
    }
```