### PR TITLE
Add support for building private dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,19 @@ jobs:
         # https://github.com/golangci/golangci-lint-action/issues/244
         skip-cache: true
 
-
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+
+      - name: Setup private build environment
+        if: ${{ vars.PRIVATE_BUILDS_SUPPORTED == 'true' }} 
+        uses: ./actions/private-setup
+        with:
+          cadence_deploy_key: ${{ secrets.CADENCE_DEPLOY_KEY }}
+
       - name: Setup Go
         uses: actions/setup-go@v4
         timeout-minutes: 10 # fail fast. sometimes this step takes an extremely long time
@@ -139,6 +145,13 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
+
+    - name: Setup private build environment
+      if: ${{ vars.PRIVATE_BUILDS_SUPPORTED == 'true' }} 
+      uses: ./actions/private-setup
+      with:
+        cadence_deploy_key: ${{ secrets.CADENCE_DEPLOY_KEY }}
+
     - name: Setup Go
       uses: actions/setup-go@v4
       timeout-minutes: 10 # fail fast. sometimes this step takes an extremely long time
@@ -178,6 +191,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+
+      - name: Setup private build environment
+        if: ${{ vars.PRIVATE_BUILDS_SUPPORTED == 'true' }} 
+        uses: ./actions/private-setup
+        with:
+          cadence_deploy_key: ${{ secrets.CADENCE_DEPLOY_KEY }}
+
       - name: Setup Go
         uses: actions/setup-go@v4
         timeout-minutes: 10 # fail fast. sometimes this step takes an extremely long time
@@ -216,6 +236,13 @@ jobs:
         with:
           # all tags are needed for integration tests
           fetch-depth: 0
+
+      - name: Setup private build environment
+        if: ${{ vars.PRIVATE_BUILDS_SUPPORTED == 'true' }} 
+        uses: ./actions/private-setup
+        with:
+          cadence_deploy_key: ${{ secrets.CADENCE_DEPLOY_KEY }}
+
       - name: Setup Go
         uses: actions/setup-go@v4
         timeout-minutes: 10 # fail fast. sometimes this step takes an extremely long time
@@ -255,9 +282,17 @@ jobs:
         targets: ${{ fromJSON(needs.create-integration-dynamic-test-matrix.outputs.dynamic-matrix)}}
     ## need to set image explicitly due to GitHub logging issue as described in https://github.com/onflow/flow-go/pull/3087#issuecomment-1234383202
     runs-on: ${{ matrix.targets.runner }}
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+      
+      - name: Setup private build environment
+        if: ${{ vars.PRIVATE_BUILDS_SUPPORTED == 'true' }} 
+        uses: ./actions/private-setup
+        with:
+          cadence_deploy_key: ${{ secrets.CADENCE_DEPLOY_KEY }}
+
       - name: Setup Go
         uses: actions/setup-go@v4
         timeout-minutes: 10 # fail fast. sometimes this step takes an extremely long time
@@ -348,6 +383,13 @@ jobs:
       with:
           # all tags are needed for integration tests
           fetch-depth: 0
+
+    - name: Setup private build environment
+      if: ${{ vars.PRIVATE_BUILDS_SUPPORTED == 'true' }} 
+      uses: ./actions/private-setup
+      with:
+        cadence_deploy_key: ${{ secrets.CADENCE_DEPLOY_KEY }}
+
     - name: Setup Go
       uses: actions/setup-go@v4
       timeout-minutes: 10 # fail fast. sometimes this step takes an extremely long time

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ IMAGE_TAG_ARM := $(IMAGE_TAG)-arm
 # Name of the cover profile
 COVER_PROFILE := coverage.txt
 # Disable go sum database lookup for private repos
-GOPRIVATE=github.com/dapperlabs/*
+GOPRIVATE=github.com/onflow/*-internal
 # OS
 UNAME := $(shell uname)
 

--- a/actions/private-setup/action.yml
+++ b/actions/private-setup/action.yml
@@ -1,0 +1,29 @@
+name: "Private Build Setup"
+description: "Checks and configures the environment for building private dependencies"
+inputs:
+  cadence_deploy_key:
+    description: "Deploy Key for Private Cadence Repo"
+    required: true
+  go_private_value:
+    description: "The value for GOPRIVATE"
+    required: false
+    default: "github.com/onflow/*-internal"
+runs:
+  using: "composite"
+  steps:
+    - name: Load deploy key
+      uses: webfactory/ssh-agent@v0.5.3
+      with:
+        ssh-private-key: "${{ inputs.cadence_deploy_key }}"
+        known-hosts: "github.com"
+
+    - name: Configure git for SSH
+      shell: bash
+      run: |
+        git config --global url."git@github.com:".insteadOf "https://github.com/"
+
+    - name: Configure GOPRIVATE env  
+      shell: bash
+      run: |
+        echo "GOPRIVATE=${{ inputs.go_private_value }}" >> $GITHUB_ENV
+


### PR DESCRIPTION
### **PR Description: Add Support for Building Private Dependencies in CI**

This PR introduces changes to support building private dependencies in the CI pipeline, specifically for private Cadence repositories.

---

### **Key Changes**

1. **Update CI steps to load Cadence Deploy Key in CI:**
   - Adds CI step to load the `CADENCE_DEPLOY_KEY` into the SSH agent for accessing private repositories.
   - Configures Git to use SSH for dependencies.
   - Dynamically sets `SSH_AUTH_SOCK` in the environment.
   - Warns if `CADENCE_DEPLOY_KEY` is not set, allowing the workflow to continue.

2. **Update `GOPRIVATE` Configuration:**
   - Updates `GOPRIVATE` to `github.com/onflow/*` in both the GitHub Actions workflow and the `Makefile` to bypass the Go module proxy for private repositories.

---

### **Impact**
These changes enable seamless fetching and building of private Cadence dependencies during CI, improving the reliability and security of the build process.
