### PR TITLE
updating the term `DKG key` as it is outdated

### DIFF
--- a/cmd/util/cmd/epochs/cmd/recover.go
+++ b/cmd/util/cmd/epochs/cmd/recover.go
@@ -20,7 +20,7 @@ import (
 // EFM can be exited only by a special service event, EpochRecover, which initially originates from a manual service account transaction.
 // The full epoch data must be generated manually and submitted with this transaction in order for an
 // EpochRecover event to be emitted. This command retrieves the current protocol state identities, computes the cluster assignment using those
-// identities, generates the cluster QCs and retrieves the DKG key vector of the last successful epoch.
+// identities, generates the cluster QCs and retrieves the Random Beacon key vector of the last successful epoch.
 // This recovery process has some constraints:
 //   - The RecoveryEpoch must have exactly the same consensus committee as participated in the most recent successful DKG.
 //   - The RecoveryEpoch must contain enough "internal" collection nodes so that all clusters contain a supermajority of "internal" collection nodes (same constraint as sporks)

--- a/consensus/hotstuff/signature/randombeacon_signer_store.go
+++ b/consensus/hotstuff/signature/randombeacon_signer_store.go
@@ -42,9 +42,9 @@ func (s *EpochAwareRandomBeaconKeyStore) ByView(view uint64) (crypto.PrivateKey,
 	}
 
 	// When DKG has completed,
-	//   - if a node successfully generated the DKG key, the valid private key will be stored in database.
-	//   - if a node failed to generate the DKG key, we will save a record in database to indicate this
-	//      node has no private key for this epoch.
+	//   - if a node successfully generated the Random Beacon key, the valid private key will be stored in database.
+	//   - if a node failed to generate the Random Beacon key, we will save a record in database to indicate this
+	//     node has no private key for this epoch.
 	// Within the epoch, we can look up my random beacon private key for the epoch. There are 3 cases:
 	//   1. DKG has completed, and the private key is stored in database, and we can retrieve it (happy path)
 	//   2. DKG has completed, but we failed to generate a private key (unhappy path)

--- a/consensus/hotstuff/verification/combined_verifier_v3.go
+++ b/consensus/hotstuff/verification/combined_verifier_v3.go
@@ -174,7 +174,7 @@ func (c *CombinedVerifierV3) VerifyQC(signers flow.IdentitySkeletonList, sigData
 			if protocol.IsIdentityNotFound(err) {
 				return model.NewInvalidSignerErrorf("%v is not a random beacon participant: %w", signerID, err)
 			}
-			return fmt.Errorf("unexpected error retrieving dkg key share for signer %v: %w", signerID, err)
+			return fmt.Errorf("unexpected error retrieving Random Beacon key share for signer %v: %w", signerID, err)
 		}
 		beaconPubKeys = append(beaconPubKeys, keyShare)
 	}

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
@@ -812,7 +812,7 @@ func TestCombinedVoteProcessorV2_BuildVerifyQC(t *testing.T) {
 		identity.StakingPubKey = stakingPriv.PublicKey()
 
 		keys := &storagemock.SafeBeaconKeys{}
-		// there is no DKG key for this epoch
+		// there is no Random Beacon key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(nil, false, nil)
 
 		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
@@ -833,7 +833,7 @@ func TestCombinedVoteProcessorV2_BuildVerifyQC(t *testing.T) {
 		}
 
 		keys := &storagemock.SafeBeaconKeys{}
-		// there is DKG key for this epoch
+		// there is Random Beacon key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(dkgKey, true, nil)
 
 		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
@@ -948,7 +948,7 @@ func TestCombinedVoteProcessorV3_BuildVerifyQC(t *testing.T) {
 		identity.StakingPubKey = stakingPriv.PublicKey()
 
 		keys := &storagemock.SafeBeaconKeys{}
-		// there is no DKG key for this epoch
+		// there is no Random Beacon key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(nil, false, nil)
 
 		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)
@@ -970,7 +970,7 @@ func TestCombinedVoteProcessorV3_BuildVerifyQC(t *testing.T) {
 		}
 
 		keys := &storagemock.SafeBeaconKeys{}
-		// there is DKG key for this epoch
+		// there is Random Beacon key for this epoch
 		keys.On("RetrieveMyBeaconPrivateKey", epochCounter).Return(dkgKey, true, nil)
 
 		beaconSignerStore := hsig.NewEpochAwareRandomBeaconKeyStore(epochLookup, keys)

--- a/consensus/integration/epoch_test.go
+++ b/consensus/integration/epoch_test.go
@@ -117,7 +117,7 @@ func TestEpochTransition_IdentitiesOverlap(t *testing.T) {
 		newIdentity,
 	)
 
-	// generate new identities for next epoch, it will generate new DKG keys for random beacon participants
+	// generate new identities for next epoch, it will generate new Random Beacon keys for random beacon participants
 	nextEpochParticipantData := completeConsensusIdentities(t, privateNodeInfos[1:])
 	rootSnapshot = withNextEpoch(t, rootSnapshot, nextEpochIdentities, nextEpochParticipantData, consensusParticipants, 4, func(block *flow.Block) *flow.QuorumCertificate {
 		return createRootQC(t, block, firstEpochConsensusParticipants)

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -530,7 +530,7 @@ func createNode(
 	require.NoError(t, err)
 
 	keys := &storagemock.SafeBeaconKeys{}
-	// there is DKG key for this epoch
+	// there is Random Beacon key for this epoch
 	keys.On("RetrieveMyBeaconPrivateKey", mock.Anything).Return(
 		func(epochCounter uint64) crypto.PrivateKey {
 			dkgInfo, ok := participant.beaconInfoByEpoch[epochCounter]

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -1072,8 +1072,8 @@ func BootstrapNetwork(networkConf NetworkConfig, bootstrapDir string, chainID fl
 
 	allNodeInfos := append(toNodeInfos(stakedConfs), followerInfos...)
 
-	// IMPORTANT: we must use this ordering when writing the DKG keys as
-	//            this ordering defines the DKG participant's indices
+	// IMPORTANT: we must use this ordering when writing the Random Beacon keys as
+	//            this ordering defines the DKG participants' indices
 	stakedNodeInfos := bootstrap.Sort(toNodeInfos(stakedConfs), flow.Canonical[flow.Identity])
 
 	dkg, dkgIndexMap, err := runBeaconKG(stakedConfs)

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -275,13 +275,13 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 	// parse DKG participants
 	commit.DKGParticipantKeys, err = convertDKGKeys(cdcDKGKeys.Values)
 	if err != nil {
-		return nil, fmt.Errorf("could not convert DKG keys: %w", err)
+		return nil, fmt.Errorf("could not convert Random Beacon keys: %w", err)
 	}
 
 	// parse DKG group key
 	commit.DKGGroupKey, err = convertDKGKey(cdcDKGGroupKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not convert DKG group key: %w", err)
+		return nil, fmt.Errorf("could not convert Random Beacon group key: %w", err)
 	}
 
 	// parse DKG Index Map
@@ -469,7 +469,7 @@ func convertServiceEventEpochRecover(event flow.Event) (*flow.ServiceEvent, erro
 	// parse DKG participants
 	commit.DKGParticipantKeys, err = convertDKGKeys(cdcDKGKeys.Values)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode DKG key shares from EpochRecover event: %w", err)
+		return nil, fmt.Errorf("failed to decode Random Beacon key shares from EpochRecover event: %w", err)
 	}
 
 	// parse DKG group key
@@ -986,7 +986,7 @@ func convertClusterQCVotes(cdcClusterQCs []cadence.Value) (
 	return qcVoteDatas, nil
 }
 
-// convertDKGKeys converts hex-encoded DKG public keys as received by the DKG
+// convertDKGKeys converts hex-encoded public beacon keys as received by the DKG
 // smart contract into crypto.PublicKey representations suitable for inclusion
 // in the protocol state.
 func convertDKGKeys(cdcDKGKeys []cadence.Value) ([]crypto.PublicKey, error) {
@@ -1001,7 +1001,7 @@ func convertDKGKeys(cdcDKGKeys []cadence.Value) ([]crypto.PublicKey, error) {
 	return convertedKeys, nil
 }
 
-// convertDKGKey converts a single hex-encoded DKG public key as received by the DKG
+// convertDKGKey converts a single hex-encoded public beacon keys as received by the DKG
 // smart contract into crypto.PublicKey representations suitable for inclusion
 // in the protocol state.
 func convertDKGKey(cdcDKGKeys cadence.Value) (crypto.PublicKey, error) {

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -1653,7 +1653,7 @@ func TestExtendEpochCommitInvalid(t *testing.T) {
 			unittest.InsertAndFinalize(t, state, block3)
 
 			_, receipt, seal := createCommit(block3, func(commit *flow.EpochCommit) {
-				// add an extra dkg key
+				// add an extra Random Beacon key
 				commit.DKGParticipantKeys = append(commit.DKGParticipantKeys, unittest.KeyFixture(crypto.BLSBLS12381).PublicKey())
 			})
 

--- a/state/protocol/validity.go
+++ b/state/protocol/validity.go
@@ -163,7 +163,7 @@ func IsValidEpochCommit(commit *flow.EpochCommit, setup *flow.EpochSetup) error 
 		return NewInvalidServiceEventErrorf("inconsistent epoch counter between commit (%d) and setup (%d) events in same epoch", commit.Counter, setup.Counter)
 	}
 
-	// make sure we have a valid DKG public key
+	// make sure we have a Random Beacon group key:
 	if commit.DKGGroupKey == nil {
 		return NewInvalidServiceEventErrorf("missing DKG public group key")
 	}
@@ -171,7 +171,7 @@ func IsValidEpochCommit(commit *flow.EpochCommit, setup *flow.EpochSetup) error 
 	// enforce invariant: len(DKGParticipantKeys) == len(DKGIndexMap)
 	n := len(commit.DKGIndexMap) // size of the DKG committee
 	if len(commit.DKGParticipantKeys) != n {
-		return NewInvalidServiceEventErrorf("dkg key list (len=%d) does not match index map (len=%d)", len(commit.DKGParticipantKeys), len(commit.DKGIndexMap))
+		return NewInvalidServiceEventErrorf("number of %d Random Beacon key shares is inconsistent with number of DKG participatns (len=%d)", len(commit.DKGParticipantKeys), len(commit.DKGIndexMap))
 	}
 
 	// enforce invariant: DKGIndexMap values form the set {0, 1, ..., n-1} where n=len(DKGParticipantKeys)


### PR DESCRIPTION
Minor follow up to Tarak's great [PR #6590](https://github.com/onflow/flow-go/pull/6590) on the `Random Beacon documentation`  

### summary of my PR

The goDoc still talks in some locations about the "DKG key". This is outdated terminology and we are trying to use "Random Beacon key" instead (reasoning: DKG is only _one_ of the means to produce the threshold key shares. Much more descriptive is the usage for the keys - the random beacon - and not the source of the keys).  

