### PR TITLE
[Documentation] Replaced `type` with [type]

### DIFF
--- a/admin/commands/execution/stop_at_height.go
+++ b/admin/commands/execution/stop_at_height.go
@@ -63,7 +63,7 @@ func (s *StopAtHeightCommand) Handler(_ context.Context, req *admin.CommandReque
 //
 // Additionally, height must be a positive integer. If a float value is provided, only the integer part is used.
 // The following sentinel errors are expected during normal operations:
-// * `admin.InvalidAdminReqError` if any required field is missing or in a wrong format
+// * [admin.InvalidAdminReqError] if any required field is missing or in a wrong format
 func (s *StopAtHeightCommand) Validator(req *admin.CommandRequest) error {
 
 	input, ok := req.Data.(map[string]interface{})

--- a/cmd/bootstrap/run/epochs.go
+++ b/cmd/bootstrap/run/epochs.go
@@ -204,7 +204,7 @@ func GenerateRecoverEpochTxArgs(log zerolog.Logger,
 		// epoch end view
 		cadence.NewUInt64(currEpochFinalView + numViewsInEpoch),
 		// recovery epoch target duration
-		cadence.NewUInt64(currEpochTargetEndTime),
+		cadence.NewUInt64(recoveryEpochTargetDuration),
 		// target end time
 		cadence.NewUInt64(currEpochTargetEndTime + recoveryEpochTargetDuration),
 		// clusters,

--- a/cmd/util/cmd/epochs/cmd/recover_test.go
+++ b/cmd/util/cmd/epochs/cmd/recover_test.go
@@ -75,7 +75,7 @@ func TestRecoverEpochHappyPath(t *testing.T) {
 		currEpoch := rootSnapshot.Epochs().Current()
 		finalView, err := currEpoch.FinalView()
 		require.NoError(t, err)
-		expectedTargetEndTime, err := currEpoch.TargetEndTime()
+		currEpochTargetEndTime, err := currEpoch.TargetEndTime()
 		require.NoError(t, err)
 
 		// epoch counter
@@ -87,7 +87,7 @@ func TestRecoverEpochHappyPath(t *testing.T) {
 		// epoch end view
 		require.Equal(t, cadence.NewUInt64(finalView+flagNumViewsInEpoch), decodedValues[3])
 		// target duration
-		require.Equal(t, cadence.NewUInt64(expectedTargetEndTime), decodedValues[4])
+		require.Equal(t, cadence.NewUInt64(flagRecoveryEpochTargetDuration), decodedValues[4])
 		// target end time
 		require.Equal(t, cadence.NewUInt64(expectedTargetEndTime+flagRecoveryEpochTargetDuration), decodedValues[5])
 		// clusters: we cannot guarantee order of the cluster when we generate the test fixtures

--- a/cmd/util/ledger/migrations/cadence_values_migration_test.go
+++ b/cmd/util/ledger/migrations/cadence_values_migration_test.go
@@ -2733,7 +2733,7 @@ func TestTypeRequirementRemovalMigration(t *testing.T) {
 
 	contractName := "TiblesProducer"
 
-	// Store a value with the actual `TiblesProducer.Minter` type
+	// Store a value with the actual [TiblesProducer.Minter] type
 	storageMap.WriteValue(
 		migrationRuntime.Interpreter,
 		interpreter.StringStorageMapKey("a"),
@@ -2750,7 +2750,7 @@ func TestTypeRequirementRemovalMigration(t *testing.T) {
 		),
 	)
 
-	// Store a value with a random `TiblesProducer.Minter` type (different address)
+	// Store a value with a random [TiblesProducer.Minter] type (different address)
 	storageMap.WriteValue(
 		migrationRuntime.Interpreter,
 		interpreter.StringStorageMapKey("b"),

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -1697,7 +1697,7 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 		require.Len(t, logWriter.logs, 1)
 		assert.Contains(t,
 			logWriter.logs[0],
-			"incompatible type annotations. expected `FungibleToken.Vault`, found `{FungibleToken.Vault}`",
+			"incompatible type annotations. expected [FungibleToken.Vault], found `{FungibleToken.Vault}`",
 		)
 
 		require.Equal(t, 1, accountRegistersA.Count())
@@ -1976,7 +1976,7 @@ func TestStagedContractConformanceChanges(t *testing.T) {
 
 	t.Run("MetadataViews.Resolver to ArbitraryContract.Resolver unsupported", func(t *testing.T) {
 
-		// `MetadataViews.Resolver` shouldn't be able to replace with any arbitrary `Resolver` interface!
+		// [MetadataViews.Resolver] shouldn't be able to replace with any arbitrary `Resolver` interface!
 
 		t.Parallel()
 

--- a/cmd/util/ledger/migrations/staged_contracts_migration_test.go
+++ b/cmd/util/ledger/migrations/staged_contracts_migration_test.go
@@ -1697,7 +1697,7 @@ func TestStagedContractsWithUpdateValidator(t *testing.T) {
 		require.Len(t, logWriter.logs, 1)
 		assert.Contains(t,
 			logWriter.logs[0],
-			"incompatible type annotations. expected [FungibleToken.Vault], found `{FungibleToken.Vault}`",
+			"incompatible type annotations. expected `FungibleToken.Vault`, found `{FungibleToken.Vault}`",
 		)
 
 		require.Equal(t, 1, accountRegistersA.Count())

--- a/consensus/hotstuff/committees/consensus_committee.go
+++ b/consensus/hotstuff/committees/consensus_committee.go
@@ -339,7 +339,7 @@ func (c *Consensus) handleProtocolEvents(ctx irrecoverable.SignalerContext, read
 	}
 }
 
-// EpochCommittedPhaseStarted informs `committees.Consensus` that the first block in flow.EpochPhaseCommitted has been finalized.
+// EpochCommittedPhaseStarted informs [committees.Consensus] that the first block in flow.EpochPhaseCommitted has been finalized.
 // This event consumer function enqueues an event handler function for the single event handler thread to execute.
 func (c *Consensus) EpochCommittedPhaseStarted(_ uint64, first *flow.Header) {
 	c.epochEvents <- func() error {
@@ -347,7 +347,7 @@ func (c *Consensus) EpochCommittedPhaseStarted(_ uint64, first *flow.Header) {
 	}
 }
 
-// EpochExtended informs `committees.Consensus` that a block including a new epoch extension has been finalized.
+// EpochExtended informs [committees.Consensus] that a block including a new epoch extension has been finalized.
 // This event consumer function enqueues an event handler function for the single event handler thread to execute.
 func (c *Consensus) EpochExtended(epochCounter uint64, _ *flow.Header, extension flow.EpochExtension) {
 	c.epochEvents <- func() error {

--- a/consensus/hotstuff/cruisectl/proposal_timing.go
+++ b/consensus/hotstuff/cruisectl/proposal_timing.go
@@ -82,7 +82,7 @@ var _ ProposalTiming = (*happyPathBlockTime)(nil)
 //     In other words, when primary determines at what future time to broadcast the child, the child
 //     has _not_ been published and the `timedBlock` references the parent on the happy path (or another
 //     earlier block on the unhappy path)
-//   - `unconstrainedBlockTime` is the delay, relative to `timedBlock.TimeObserved` when the controller would
+//   - `unconstrainedBlockTime` is the delay, relative to [timedBlock.TimeObserved] when the controller would
 //     like the child block to be published. Caution, no limits of authority have been applied to this value yet!
 //   - `timingConfig` which defines the limits for authority for the controller.
 //

--- a/consensus/hotstuff/eventloop/event_loop_test.go
+++ b/consensus/hotstuff/eventloop/event_loop_test.go
@@ -84,7 +84,7 @@ func (s *EventLoopTestSuite) Test_SubmitProposal() {
 	require.Eventually(s.T(), processed.Load, time.Millisecond*100, time.Millisecond*10)
 }
 
-// Test_SubmitQC tests that submitted QC is eventually sent to `EventHandler.OnReceiveQc` for processing
+// Test_SubmitQC tests that submitted QC is eventually sent to [EventHandler.OnReceiveQc] for processing
 func (s *EventLoopTestSuite) Test_SubmitQC() {
 	// qcIngestionFunction is the archetype for EventLoop.OnQcConstructedFromVotes and EventLoop.OnNewQcDiscovered
 	type qcIngestionFunction func(*flow.QuorumCertificate)
@@ -108,7 +108,7 @@ func (s *EventLoopTestSuite) Test_SubmitQC() {
 	})
 }
 
-// Test_SubmitTC tests that submitted TC is eventually sent to `EventHandler.OnReceiveTc` for processing
+// Test_SubmitTC tests that submitted TC is eventually sent to [EventHandler.OnReceiveTc] for processing
 func (s *EventLoopTestSuite) Test_SubmitTC() {
 	// tcIngestionFunction is the archetype for EventLoop.OnTcConstructedFromTimeouts and EventLoop.OnNewTcDiscovered
 	type tcIngestionFunction func(*flow.TimeoutCertificate)
@@ -132,7 +132,7 @@ func (s *EventLoopTestSuite) Test_SubmitTC() {
 	})
 }
 
-// Test_SubmitTC_IngestNewestQC tests that included QC in TC is eventually sent to `EventHandler.OnReceiveQc` for processing
+// Test_SubmitTC_IngestNewestQC tests that included QC in TC is eventually sent to [EventHandler.OnReceiveQc] for processing
 func (s *EventLoopTestSuite) Test_SubmitTC_IngestNewestQC() {
 	// tcIngestionFunction is the archetype for EventLoop.OnTcConstructedFromTimeouts and EventLoop.OnNewTcDiscovered
 	type tcIngestionFunction func(*flow.TimeoutCertificate)

--- a/consensus/hotstuff/forks.go
+++ b/consensus/hotstuff/forks.go
@@ -59,7 +59,7 @@ type Forks interface {
 	// Possible error returns:
 	//   - model.MissingBlockError if the parent does not exist in the forest (but is above
 	//     the pruned view). From the perspective of Forks, this error is benign (no-op).
-	//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+	//   - model.InvalidBlockError if the block is invalid (see [Forks.EnsureBlockIsValidExtension]
 	//     for details). From the perspective of Forks, this error is benign (no-op). However, we
 	//     assume all blocks are fully verified, i.e. they should satisfy all consistency
 	//     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.
@@ -81,7 +81,7 @@ type Forks interface {
 	// Possible error returns:
 	//   - model.MissingBlockError if the parent does not exist in the forest (but is above
 	//     the pruned view). From the perspective of Forks, this error is benign (no-op).
-	//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+	//   - model.InvalidBlockError if the block is invalid (see [Forks.EnsureBlockIsValidExtension]
 	//     for details). From the perspective of Forks, this error is benign (no-op). However, we
 	//     assume all blocks are fully verified, i.e. they should satisfy all consistency
 	//     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.

--- a/consensus/hotstuff/forks/blockcontainer.go
+++ b/consensus/hotstuff/forks/blockcontainer.go
@@ -22,7 +22,7 @@ func (b *BlockContainer) Level() uint64             { return b.View }
 func (b *BlockContainer) Parent() (flow.Identifier, uint64) {
 	// Caution: not all blocks have a QC for the parent, such as the spork root blocks.
 	// Per API contract, we are obliged to return a value to prevent panics during logging.
-	// (see vertex `forest.VertexToString` method).
+	// (see vertex [forest.VertexToString] method).
 	if b.QC == nil {
 		return flow.ZeroID, 0
 	}

--- a/consensus/hotstuff/forks/forks.go
+++ b/consensus/hotstuff/forks/forks.go
@@ -185,7 +185,7 @@ func (f *Forks) EnsureBlockIsValidExtension(block *model.Block) error {
 // Possible error returns:
 //   - model.MissingBlockError if the parent does not exist in the forest (but is above
 //     the pruned view). From the perspective of Forks, this error is benign (no-op).
-//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+//   - model.InvalidBlockError if the block is invalid (see [Forks.EnsureBlockIsValidExtension]
 //     for details). From the perspective of Forks, this error is benign (no-op). However, we
 //     assume all blocks are fully verified, i.e. they should satisfy all consistency
 //     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.
@@ -237,7 +237,7 @@ func (f *Forks) AddCertifiedBlock(certifiedBlock *model.CertifiedBlock) error {
 // Possible error returns:
 //   - model.MissingBlockError if the parent does not exist in the forest (but is above
 //     the pruned view). From the perspective of Forks, this error is benign (no-op).
-//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+//   - model.InvalidBlockError if the block is invalid (see [Forks.EnsureBlockIsValidExtension]
 //     for details). From the perspective of Forks, this error is benign (no-op). However, we
 //     assume all blocks are fully verified, i.e. they should satisfy all consistency
 //     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.
@@ -287,7 +287,7 @@ func (f *Forks) AddValidatedBlock(proposal *model.Block) error {
 // Possible error returns:
 //   - model.MissingBlockError if the parent does not exist in the forest (but is above
 //     the pruned view). From the perspective of Forks, this error is benign (no-op).
-//   - model.InvalidBlockError if the block is invalid (see `Forks.EnsureBlockIsValidExtension`
+//   - model.InvalidBlockError if the block is invalid (see [Forks.EnsureBlockIsValidExtension]
 //     for details). From the perspective of Forks, this error is benign (no-op). However, we
 //     assume all blocks are fully verified, i.e. they should satisfy all consistency
 //     requirements. Hence, this error is likely an indicator of a bug in the compliance layer.
@@ -360,7 +360,7 @@ func (f *Forks) checkForDoubleProposal(block *model.Block) {
 
 // checkForAdvancingFinalization checks whether observing certifiedBlock leads to progress of
 // finalization. This function should be called every time a new block is added to Forks. If the new
-// block is the head of a 2-chain satisfying the finalization rule, we update `Forks.finalityProof` to
+// block is the head of a 2-chain satisfying the finalization rule, we update [Forks.finalityProof] to
 // the new latest finalized block. Calling this method with previously-processed blocks leaves the
 // consensus state invariant.
 // UNVALIDATED: assumes that relevant block properties are consistent with previous blocks
@@ -411,7 +411,7 @@ func (f *Forks) checkForAdvancingFinalization(certifiedBlock *model.CertifiedBlo
 	//                   ╰─────────────────────╯
 	//                       certifiedBlock
 	// Hence, we can finalize `parentBlock` as head of a 2-chain,
-	// if and only if `Block.View` is exactly 1 higher than the view of `parentBlock`
+	// if and only if [Block.View] is exactly 1 higher than the view of `parentBlock`
 	if parentBlock.View+1 != certifiedBlock.View() {
 		return nil
 	}

--- a/consensus/hotstuff/forks/forks_test.go
+++ b/consensus/hotstuff/forks/forks_test.go
@@ -493,9 +493,9 @@ func TestConflictingFinalizedForks(t *testing.T) {
 }
 
 // TestAddDisconnectedBlock checks that adding a block which does not connect to the
-// latest finalized block returns a `model.MissingBlockError`
+// latest finalized block returns a [model.MissingBlockError]
 //   - receives [◄(2) 3]
-//   - should return `model.MissingBlockError`, because the parent is above the pruning
+//   - should return [model.MissingBlockError], because the parent is above the pruning
 //     threshold, but Forks does not know its parent
 func TestAddDisconnectedBlock(t *testing.T) {
 	blocks, err := NewBlockBuilder().
@@ -936,7 +936,7 @@ func makeFinalityProof(t *testing.T, block *model.Block, directChild *model.Bloc
 // blockAwaitingFinalization is intended for tracking finalization events and their order for a specific block
 type blockAwaitingFinalization struct {
 	Block                   *model.Block
-	MakeFinalCalled         bool // indicates whether `Finalizer.MakeFinal` was called
+	MakeFinalCalled         bool // indicates whether [Finalizer.MakeFinal] was called
 	OnFinalizedBlockEmitted bool // indicates whether `OnFinalizedBlockCalled` notification was emitted
 }
 

--- a/consensus/hotstuff/model/timeout.go
+++ b/consensus/hotstuff/model/timeout.go
@@ -50,9 +50,9 @@ type TimeoutObject struct {
 	// SigData is a BLS signature created by staking key signing View + NewestQC.View
 	// This signature is further aggregated in TimeoutCertificate.
 	SigData crypto.Signature
-	// TimeoutTick is the number of times the `timeout.Controller` has (re-)emitted the
+	// TimeoutTick is the number of times the [timeout.Controller] has (re-)emitted the
 	// timeout for this view. When the timer for the view's original duration expires, a `TimeoutObject`
-	// with `TimeoutTick = 0` is broadcast. Subsequently, `timeout.Controller` re-broadcasts the
+	// with `TimeoutTick = 0` is broadcast. Subsequently, [timeout.Controller] re-broadcasts the
 	// `TimeoutObject` periodically  based on some internal heuristic. Each time we attempt a re-broadcast,
 	// the `TimeoutTick` is incremented. Incrementing the field prevents de-duplicated within the network layer,
 	// which in turn guarantees quick delivery of the `TimeoutObject` after GST and facilitates recovery.
@@ -89,12 +89,12 @@ func (t *TimeoutObject) String() string {
 	)
 }
 
-// LogContext returns a `zerolog.Contex` including the most important properties of the TC:
+// LogContext returns a [zerolog.Contex] including the most important properties of the TC:
 //   - view number that this TC is for
 //   - view and ID of the block that the included QC points to
 //   - number of times a re-broadcast of this timeout was attempted
 //   - [optional] if the TC also includes a TC for the prior view, i.e. `LastViewTC` ≠ nil:
-//     the new of `LastViewTC` and the view that `LastViewTC.NewestQC` is for
+//     the new of `LastViewTC` and the view that [LastViewTC.NewestQC] is for
 func (t *TimeoutObject) LogContext(logger zerolog.Logger) zerolog.Context {
 	logContext := logger.With().
 		Uint64("timeout_newest_qc_view", t.NewestQC.View).

--- a/consensus/hotstuff/notifications/pubsub/distributor.go
+++ b/consensus/hotstuff/notifications/pubsub/distributor.go
@@ -46,7 +46,7 @@ func NewFollowerDistributor() *FollowerDistributor {
 	}
 }
 
-// AddFollowerConsumer registers the input `consumer` to be notified on `hotstuff.ConsensusFollowerConsumer` events.
+// AddFollowerConsumer registers the input `consumer` to be notified on [hotstuff.ConsensusFollowerConsumer] events.
 func (d *FollowerDistributor) AddFollowerConsumer(consumer hotstuff.FollowerConsumer) {
 	d.FinalizationDistributor.AddFinalizationConsumer(consumer)
 	d.ProposalViolationDistributor.AddProposalViolationConsumer(consumer)

--- a/consensus/hotstuff/pacemaker/pacemaker.go
+++ b/consensus/hotstuff/pacemaker/pacemaker.go
@@ -120,7 +120,7 @@ func (p *ActivePaceMaker) ProcessQC(qc *flow.QuorumCertificate) (*model.NewViewE
 
 // ProcessTC notifies the Pacemaker of a new timeout certificate, which may allow
 // Pacemaker to fast-forward its current view.
-// A nil TC is an expected valid input, so that callers may pass in e.g. `Proposal.LastViewTC`,
+// A nil TC is an expected valid input, so that callers may pass in e.g. [Proposal.LastViewTC],
 // which may or may not have a value.
 // No errors are expected, any error should be treated as exception
 func (p *ActivePaceMaker) ProcessTC(tc *flow.TimeoutCertificate) (*model.NewViewEvent, error) {

--- a/consensus/hotstuff/pacemaker/timeout/config.go
+++ b/consensus/hotstuff/pacemaker/timeout/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Config contains the configuration parameters for a Truncated Exponential Backoff,
-// as implemented by the `timeout.Controller`
+// as implemented by the [timeout.Controller]
 //   - On timeout: increase timeout by multiplicative factor `TimeoutAdjustmentFactor`. This
 //     results in exponentially growing timeout duration on multiple subsequent timeouts.
 //   - On progress: decrease timeout by multiplicative factor `TimeoutAdjustmentFactor.
@@ -66,7 +66,7 @@ func NewDefaultConfig() Config {
 //   - blockRateDelay: a delay to delay the proposal broadcasting [Milliseconds]
 //     Consistency requirement: must be non-negative
 //
-// Returns `model.ConfigurationError` is any of the consistency requirements is violated.
+// Returns [model.ConfigurationError] is any of the consistency requirements is violated.
 func NewConfig(minReplicaTimeout time.Duration, maxReplicaTimeout time.Duration, timeoutAdjustmentFactor float64, happyPathMaxRoundFailures uint64, maxRebroadcastInterval time.Duration) (Config, error) {
 	if minReplicaTimeout <= 0 {
 		return Config{}, model.NewConfigurationErrorf("minReplicaTimeout must be a positive number[milliseconds]")

--- a/consensus/hotstuff/pacemaker/view_tracker.go
+++ b/consensus/hotstuff/pacemaker/view_tracker.go
@@ -76,7 +76,7 @@ func (vt *viewTracker) ProcessQC(qc *flow.QuorumCertificate) (uint64, error) {
 		return view, nil
 	}
 
-	// supermajority of replicas have already voted during round `qc.view`, hence it is safe to proceed to subsequent view
+	// supermajority of replicas have already voted during round [qc.view], hence it is safe to proceed to subsequent view
 	newView := qc.View + 1
 	err := vt.updateLivenessData(newView, qc, nil)
 	if err != nil {
@@ -86,7 +86,7 @@ func (vt *viewTracker) ProcessQC(qc *flow.QuorumCertificate) (uint64, error) {
 }
 
 // ProcessTC ingests a TC, which might advance the current view. A nil TC is accepted as
-// input, so that callers may pass in e.g. `Proposal.LastViewTC`, which may or may not have
+// input, so that callers may pass in e.g. [Proposal.LastViewTC], which may or may not have
 // a value. It returns the resulting view after processing the TC and embedded QC.
 // No errors are expected, any error should be treated as exception
 func (vt *viewTracker) ProcessTC(tc *flow.TimeoutCertificate) (uint64, error) {
@@ -108,7 +108,7 @@ func (vt *viewTracker) ProcessTC(tc *flow.TimeoutCertificate) (uint64, error) {
 		return view, nil
 	}
 
-	// supermajority of replicas have already reached their timeout for view `tc.View`, hence it is safe to proceed to subsequent view
+	// supermajority of replicas have already reached their timeout for view [tc.View], hence it is safe to proceed to subsequent view
 	newView := tc.View + 1
 	err := vt.updateLivenessData(newView, tc.NewestQC, tc)
 	if err != nil {

--- a/consensus/hotstuff/safetyrules/safety_rules_test.go
+++ b/consensus/hotstuff/safetyrules/safety_rules_test.go
@@ -415,7 +415,7 @@ func (s *SafetyRulesTestSuite) TestProduceVote_VotingOnInvalidProposals() {
 //   - replica votes in monotonously increasing views
 //
 // Voting twice per round on equivocating proposals is considered a byzantine behavior.
-// Expect a `model.NoVoteError` sentinel in such scenario.
+// Expect a [model.NoVoteError] sentinel in such scenario.
 func (s *SafetyRulesTestSuite) TestProduceVote_VoteEquivocation() {
 	expectedVote := makeVote(s.proposal.Block)
 	s.signer.On("CreateVote", s.proposal.Block).Return(expectedVote, nil).Once()

--- a/consensus/hotstuff/signature/block_signer_decoder.go
+++ b/consensus/hotstuff/signature/block_signer_decoder.go
@@ -10,7 +10,7 @@ import (
 	"github.com/onflow/flow-go/module/signature"
 )
 
-// BlockSignerDecoder is a wrapper around the `hotstuff.DynamicCommittee`, which implements
+// BlockSignerDecoder is a wrapper around the [hotstuff.DynamicCommittee], which implements
 // the auxiliary logic for de-coding signer indices of a block (header) to full node IDs
 type BlockSignerDecoder struct {
 	hotstuff.DynamicCommittee

--- a/consensus/hotstuff/signature/block_signer_decoder_test.go
+++ b/consensus/hotstuff/signature/block_signer_decoder_test.go
@@ -66,7 +66,7 @@ func (s *blockSignerDecoderSuite) Test_RootBlock() {
 
 // Test_CommitteeException verifies that `BlockSignerDecoder`
 // does _not_ erroneously interpret an unexpected exception from the committee as
-// a sign of an unknown block, i.e. the decoder should _not_ return an `model.ErrViewForUnknownEpoch` or `signature.InvalidSignerIndicesError`
+// a sign of an unknown block, i.e. the decoder should _not_ return an [model.ErrViewForUnknownEpoch] or [signature.InvalidSignerIndicesError]
 func (s *blockSignerDecoderSuite) Test_CommitteeException() {
 	s.Run("ByEpoch exception", func() {
 		exception := errors.New("unexpected exception")

--- a/consensus/hotstuff/signature/packer.go
+++ b/consensus/hotstuff/signature/packer.go
@@ -71,7 +71,7 @@ func (p *ConsensusSigDataPacker) Pack(view uint64, sig *hotstuff.BlockSignatureD
 //   - (nil, model.InvalidFormatError) if failed to unpack the signature data
 func (p *ConsensusSigDataPacker) Unpack(signerIdentities flow.IdentitySkeletonList, sigData []byte) (*hotstuff.BlockSignatureData, error) {
 	// decode into typed data
-	data, err := p.Decode(sigData) // all potential error are of type `model.InvalidFormatError`
+	data, err := p.Decode(sigData) // all potential error are of type [model.InvalidFormatError]
 	if err != nil {
 		return nil, fmt.Errorf("could not decode sig data %w", err)
 	}

--- a/consensus/hotstuff/signature/randombeacon_inspector.go
+++ b/consensus/hotstuff/signature/randombeacon_inspector.go
@@ -16,7 +16,7 @@ type randomBeaconInspector struct {
 }
 
 // NewRandomBeaconInspector instantiates a new randomBeaconInspector.
-// The constructor errors with a `model.ConfigurationError` in any of the following cases
+// The constructor errors with a [model.ConfigurationError] in any of the following cases
 //   - n is not between `ThresholdSignMinSize` and `ThresholdSignMaxSize`,
 //     for n the number of participants `n := len(publicKeyShares)`
 //   - threshold value is not in interval [1, n-1]

--- a/consensus/hotstuff/signature/weighted_signature_aggregator_test.go
+++ b/consensus/hotstuff/signature/weighted_signature_aggregator_test.go
@@ -229,7 +229,7 @@ func TestWeightedSignatureAggregator(t *testing.T) {
 		assert.Nil(t, signers)
 
 		// Also, _after_ attempting to add a signature from unknown `signerID`:
-		// calling `Aggregate()` should error with `model.InsufficientSignaturesError`,
+		// calling `Aggregate()` should error with [model.InsufficientSignaturesError],
 		// as still zero signatures are stored.
 		_, err = aggregator.TrustedAdd(unittest.IdentifierFixture(), unittest.SignatureFixture())
 		assert.True(t, model.IsInvalidSignerError(err))

--- a/consensus/hotstuff/timeoutaggregator/timeout_aggregator.go
+++ b/consensus/hotstuff/timeoutaggregator/timeout_aggregator.go
@@ -210,7 +210,7 @@ func (t *TimeoutAggregator) PruneUpToView(lowestRetainedView uint64) {
 	t.collectors.PruneUpToView(lowestRetainedView)
 }
 
-// OnViewChange implements the `OnViewChange` callback from the `hotstuff.Consumer`.
+// OnViewChange implements the `OnViewChange` callback from the [hotstuff.Consumer].
 // We notify the enteringViewProcessingLoop worker, which then prunes up to the active view.
 // CAUTION: the input to this callback is treated as trusted; precautions should be taken that messages
 // from external nodes cannot be considered as inputs to this function

--- a/consensus/hotstuff/timeoutcollector/aggregation_test.go
+++ b/consensus/hotstuff/timeoutcollector/aggregation_test.go
@@ -228,7 +228,7 @@ func TestTimeoutSignatureAggregator_Aggregate(t *testing.T) {
 		require.Nil(t, aggSig)
 
 		// Also, _after_ attempting to add a signature from unknown `signerID`:
-		// calling `Aggregate()` should error with `model.InsufficientSignaturesError`,
+		// calling `Aggregate()` should error with [model.InsufficientSignaturesError],
 		// as still zero signatures are stored.
 		_, err = aggregator.VerifyAndAdd(unittest.IdentifierFixture(), unittest.SignatureFixture(), 0)
 		require.True(t, model.IsInvalidSignerError(err))

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -221,7 +221,7 @@ func (p *TimeoutProcessor) validateTimeout(timeout *model.TimeoutObject) error {
 		}
 		if errors.Is(err, model.ErrViewForUnknownEpoch) {
 			// We require each replica to be bootstrapped with a QC pointing to a finalized block. Therefore, we should know the
-			// Epoch for any QC.View and TC.View we encounter. Receiving a `model.ErrViewForUnknownEpoch` is conceptually impossible,
+			// Epoch for any QC.View and TC.View we encounter. Receiving a [model.ErrViewForUnknownEpoch] is conceptually impossible,
 			// i.e. a symptom of an internal bug or invalid bootstrapping information.
 			return fmt.Errorf("no Epoch information availalbe for QC that was included in TO; symptom of internal bug or invalid bootstrapping information: %s", err.Error())
 		}
@@ -237,7 +237,7 @@ func (p *TimeoutProcessor) validateTimeout(timeout *model.TimeoutObject) error {
 			}
 			if errors.Is(err, model.ErrViewForUnknownEpoch) {
 				// We require each replica to be bootstrapped with a QC pointing to a finalized block. Therefore, we should know the
-				// Epoch for any QC.View and TC.View we encounter. Receiving a `model.ErrViewForUnknownEpoch` is conceptually impossible,
+				// Epoch for any QC.View and TC.View we encounter. Receiving a [model.ErrViewForUnknownEpoch] is conceptually impossible,
 				// i.e. a symptom of an internal bug or invalid bootstrapping information.
 				return fmt.Errorf("no Epoch information availalbe for TC that was included in TO; symptom of internal bug or invalid bootstrapping information: %s", err.Error())
 			}
@@ -258,7 +258,7 @@ func (p *TimeoutProcessor) buildTC() (*flow.TimeoutCertificate, error) {
 	}
 
 	// IMPORTANT: To properly verify an aggregated signature included in TC we need to provide list of signers with corresponding
-	// messages(`TimeoutCertificate.NewestQCViews`) for each signer. If the one-to-once correspondence of view and signer is not maintained,
+	// messages([TimeoutCertificate.NewestQCViews]) for each signer. If the one-to-once correspondence of view and signer is not maintained,
 	// it won't be possible to verify the aggregated signature.
 	// Aggregate returns an unordered set of signers together with additional data.
 	// Due to implementation specifics of signer indices, the decoding step results in canonically ordered signer ids, which means

--- a/consensus/hotstuff/validator/validator.go
+++ b/consensus/hotstuff/validator/validator.go
@@ -91,11 +91,11 @@ func (v *Validator) ValidateTC(tc *flow.TimeoutCertificate) error {
 
 	// verifying that tc.NewestQC is the QC with the highest view.
 	// Note: A byzantine TC could include `nil` for tc.NewestQCViews, in which case `tc.NewestQCViews[0]`
-	// would panic. Though, per API specification `verifier.VerifyTC(…)` should return a `model.InvalidFormatError`
-	// if `signers` and `tc.NewestQCViews` have different length. Hence, the following code is safe only if it is executed
+	// would panic. Though, per API specification `verifier.VerifyTC(…)` should return a [model.InvalidFormatError]
+	// if `signers` and [tc.NewestQCViews] have different length. Hence, the following code is safe only if it is executed
 	//  1. _after_ checking the quorum threshold (thereby we guarantee that `signers` is not empty); and
-	//  2. _after_ `verifier.VerifyTC(…)`, which enforces that `signers` and `tc.NewestQCViews` have identical length.
-	// Only then we can be sure that `tc.NewestQCViews` cannot be nil.
+	//  2. _after_ `verifier.VerifyTC(…)`, which enforces that `signers` and [tc.NewestQCViews] have identical length.
+	// Only then we can be sure that [tc.NewestQCViews] cannot be nil.
 	newestQCView := tc.NewestQCViews[0]
 	for _, view := range tc.NewestQCViews {
 		if newestQCView < view {
@@ -117,7 +117,7 @@ func (v *Validator) ValidateTC(tc *flow.TimeoutCertificate) error {
 			// a QC at least as new as the root QC must be contained in any TC. This is because the TC must include signatures from a
 			// supermajority of replicas, including at least one honest replica, which attest to their locally highest known QC. Hence,
 			// any QC included in a TC must be the root QC or newer. Therefore, we should know the Epoch for any QC we encounter.
-			// receiving a `model.ErrViewForUnknownEpoch` is conceptually impossible, i.e. a symptom of an internal bug or invalid
+			// receiving a [model.ErrViewForUnknownEpoch] is conceptually impossible, i.e. a symptom of an internal bug or invalid
 			// bootstrapping information.
 			return fmt.Errorf("no Epoch information availalbe for QC that was included in TC; symptom of internal bug or invalid bootstrapping information: %s", err.Error())
 		}
@@ -170,7 +170,7 @@ func (v *Validator) ValidateQC(qc *flow.QuorumCertificate) error {
 		//    is also a member of the random beacon committee. Consequently, `InvalidSignerError` should
 		//    not occur atm.
 		//    TODO: if the random beacon committee is a strict subset of the HotStuff committee,
-		//          we expect `model.InvalidSignerError` here during normal operations.
+		//          we expect [model.InvalidSignerError] here during normal operations.
 		// * model.InsufficientSignaturesError: we previously checked the total weight of all signers
 		//   meets the supermajority threshold, which is a _positive_ number. Hence, there must be at
 		//   least one signer. Hence, receiving this error would be a symptom of a fatal internal bug.
@@ -181,7 +181,7 @@ func (v *Validator) ValidateQC(qc *flow.QuorumCertificate) error {
 			return newInvalidQCError(qc, fmt.Errorf("QC contains invalid signature(s): %w", err))
 		case errors.Is(err, model.ErrViewForUnknownEpoch):
 			// We have earlier queried the Identities for the QC's view, which must have returned proper values,
-			// otherwise, we wouldn't reach this code. Therefore, it should be impossible for `verifier.VerifyQC`
+			// otherwise, we wouldn't reach this code. Therefore, it should be impossible for [verifier.VerifyQC]
 			// to return ErrViewForUnknownEpoch. To avoid confusion with expected sentinel errors, we only preserve
 			// the error messages here, but not the error types.
 			return fmt.Errorf("internal error, as querying identities for view %d succeeded earlier but now the view supposedly belongs to an unknown epoch: %s", qc.View, err.Error())
@@ -260,7 +260,7 @@ func (v *Validator) ValidateProposal(proposal *model.Proposal) error {
 		}
 		if errors.Is(err, model.ErrViewForUnknownEpoch) {
 			// We require each replica to be bootstrapped with a QC pointing to a finalized block. Therefore, we should know the
-			// Epoch for any QC.View and TC.View we encounter. Receiving a `model.ErrViewForUnknownEpoch` is conceptually impossible,
+			// Epoch for any QC.View and TC.View we encounter. Receiving a [model.ErrViewForUnknownEpoch] is conceptually impossible,
 			// i.e. a symptom of an internal bug or invalid bootstrapping information.
 			return fmt.Errorf("no Epoch information availalbe for QC that was included in proposal; symptom of internal bug or invalid bootstrapping information: %s", err.Error())
 		}
@@ -276,7 +276,7 @@ func (v *Validator) ValidateProposal(proposal *model.Proposal) error {
 			}
 			if errors.Is(err, model.ErrViewForUnknownEpoch) {
 				// We require each replica to be bootstrapped with a QC pointing to a finalized block. Therefore, we should know the
-				// Epoch for any QC.View and TC.View we encounter. Receiving a `model.ErrViewForUnknownEpoch` is conceptually impossible,
+				// Epoch for any QC.View and TC.View we encounter. Receiving a [model.ErrViewForUnknownEpoch] is conceptually impossible,
 				// i.e. a symptom of an internal bug or invalid bootstrapping information.
 				return fmt.Errorf("no Epoch information availalbe for QC that was included in TC; symptom of internal bug or invalid bootstrapping information: %s", err.Error())
 			}
@@ -306,11 +306,11 @@ func (v *Validator) ValidateVote(vote *model.Vote) (*flow.IdentitySkeleton, erro
 	// check whether the signature data is valid for the vote in the hotstuff context
 	err = v.verifier.VerifyVote(voter, vote.SigData, vote.View, vote.BlockID)
 	if err != nil {
-		// Theoretically, `VerifyVote` could also return a `model.InvalidSignerError`. However,
+		// Theoretically, `VerifyVote` could also return a [model.InvalidSignerError]. However,
 		// for the time being, we assume that _every_ HotStuff participant is also a member of
 		// the random beacon committee. Consequently, `InvalidSignerError` should not occur atm.
 		// TODO: if the random beacon committee is a strict subset of the HotStuff committee,
-		//       we expect `model.InvalidSignerError` here during normal operations.
+		//       we expect [model.InvalidSignerError] here during normal operations.
 		if model.IsInvalidFormatError(err) || errors.Is(err, model.ErrInvalidSignature) {
 			return nil, newInvalidVoteError(vote, err)
 		}

--- a/consensus/hotstuff/validator/validator_test.go
+++ b/consensus/hotstuff/validator/validator_test.go
@@ -165,9 +165,9 @@ func (ps *ProposalSuite) TestProposalWrongLeader() {
 }
 
 // TestProposalQCInvalid checks that Validator handles the verifier's error returns correctly.
-// In case of `model.InvalidFormatError` and model.ErrInvalidSignature`, we expect the Validator
-// to recognize those as an invalid QC, i.e. returns an `model.InvalidProposalError`.
-// In contrast, unexpected exceptions and `model.InvalidSignerError` should _not_ be
+// In case of [model.InvalidFormatError] and model.ErrInvalidSignature`, we expect the Validator
+// to recognize those as an invalid QC, i.e. returns an [model.InvalidProposalError].
+// In contrast, unexpected exceptions and [model.InvalidSignerError] should _not_ be
 // interpreted as a sign of an invalid QC.
 func (ps *ProposalSuite) TestProposalQCInvalid() {
 	ps.Run("invalid-signature", func() {
@@ -191,11 +191,11 @@ func (ps *ProposalSuite) TestProposalQCInvalid() {
 		assert.True(ps.T(), model.IsInvalidProposalError(err), "if the block's QC has an invalid format, an ErrorInvalidBlock error should be raised")
 	})
 
-	// Theoretically, `VerifyQC` could also return a `model.InvalidSignerError`. However,
+	// Theoretically, `VerifyQC` could also return a [model.InvalidSignerError]. However,
 	// for the time being, we assume that _every_ HotStuff participant is also a member of
 	// the random beacon committee. Consequently, `InvalidSignerError` should not occur atm.
 	// TODO: if the random beacon committee is a strict subset of the HotStuff committee,
-	//       we expect `model.InvalidSignerError` here during normal operations.
+	//       we expect [model.InvalidSignerError] here during normal operations.
 	ps.Run("invalid-signer", func() {
 		*ps.verifier = mocks.Verifier{}
 		ps.verifier.On("VerifyQC", ps.voters, ps.block.QC.SigData, ps.parent.View, ps.parent.BlockID).Return(
@@ -534,14 +534,14 @@ func (vs *VoteSuite) TestVoteVerifyVote_ErrViewForUnknownEpoch() {
 
 // TestVoteInvalidSignerID checks that the Validator correctly handles a vote
 // with a SignerID that does not correspond to a valid consensus participant.
-// In this case, the `hotstuff.DynamicCommittee` returns a `model.InvalidSignerError`,
+// In this case, the [hotstuff.DynamicCommittee] returns a [model.InvalidSignerError],
 // which the Validator should recognize as a symptom for an invalid vote.
-// Hence, we expect the validator to return a `model.InvalidVoteError`.
+// Hence, we expect the validator to return a [model.InvalidVoteError].
 func (vs *VoteSuite) TestVoteInvalidSignerID() {
 	*vs.committee = mocks.Replicas{}
 	vs.committee.On("IdentityByEpoch", vs.block.View, vs.vote.SignerID).Return(nil, model.NewInvalidSignerErrorf(""))
 
-	// A `model.InvalidSignerError` from the committee should be interpreted as
+	// A [model.InvalidSignerError] from the committee should be interpreted as
 	// the Vote being invalid, i.e. we expect an InvalidVoteError to be returned
 	_, err := vs.validator.ValidateVote(vs.vote)
 	assert.Error(vs.T(), err, "a vote with unknown SignerID should be rejected")
@@ -549,15 +549,15 @@ func (vs *VoteSuite) TestVoteInvalidSignerID() {
 }
 
 // TestVoteSignatureInvalid checks that the Validator correctly handles votes
-// with cryptographically invalid signature. In this case, the `hotstuff.Verifier`
-// returns a `model.ErrInvalidSignature`, which the Validator should recognize as
+// with cryptographically invalid signature. In this case, the [hotstuff.Verifier]
+// returns a [model.ErrInvalidSignature], which the Validator should recognize as
 // a symptom for an invalid vote.
-// Hence, we expect the validator to return a `model.InvalidVoteError`.
+// Hence, we expect the validator to return a [model.InvalidVoteError].
 func (vs *VoteSuite) TestVoteSignatureInvalid() {
 	*vs.verifier = mocks.Verifier{}
 	vs.verifier.On("VerifyVote", vs.signer, vs.vote.SigData, vs.block.View, vs.block.BlockID).Return(fmt.Errorf("staking sig is invalid: %w", model.ErrInvalidSignature))
 
-	// A `model.ErrInvalidSignature` from the `hotstuff.Verifier` should be interpreted as
+	// A [model.ErrInvalidSignature] from the [hotstuff.Verifier] should be interpreted as
 	// the Vote being invalid, i.e. we expect an InvalidVoteError to be returned
 	_, err := vs.validator.ValidateVote(vs.vote)
 	assert.Error(vs.T(), err, "a vote with an invalid signature should be rejected")
@@ -668,7 +668,7 @@ func (qs *QCSuite) TestQCSignatureError() {
 }
 
 // TestQCSignatureInvalid verifies that the Validator correctly handles the model.ErrInvalidSignature.
-// This error return from `Verifier.VerifyQC` is an expected failure case in case of a byzantine input, where
+// This error return from [Verifier.VerifyQC] is an expected failure case in case of a byzantine input, where
 // one of the signatures in the QC is broken. Hence, the Validator should wrap it as InvalidProposalError.
 func (qs *QCSuite) TestQCSignatureInvalid() {
 	// change the verifier to fail the QC signature
@@ -692,7 +692,7 @@ func (qs *QCSuite) TestQCVerifyQC_ErrViewForUnknownEpoch() {
 }
 
 // TestQCSignatureInvalidFormat verifies that the Validator correctly handles the model.InvalidFormatError.
-// This error return from `Verifier.VerifyQC` is an expected failure case in case of a byzantine input, where
+// This error return from [Verifier.VerifyQC] is an expected failure case in case of a byzantine input, where
 // some binary vector (e.g. `sigData`) is broken. Hence, the Validator should wrap it as InvalidProposalError.
 func (qs *QCSuite) TestQCSignatureInvalidFormat() {
 	// change the verifier to fail the QC signature
@@ -706,7 +706,7 @@ func (qs *QCSuite) TestQCSignatureInvalidFormat() {
 
 // TestQCEmptySigners verifies that the Validator correctly handles the model.InsufficientSignaturesError:
 // In the validator, we previously checked the total weight of all signers meets the supermajority threshold,
-// which is a _positive_ number. Hence, there must be at least one signer. Hence, `Verifier.VerifyQC`
+// which is a _positive_ number. Hence, there must be at least one signer. Hence, [Verifier.VerifyQC]
 // returning this error would be a symptom of a fatal internal bug. The Validator should _not_ interpret
 // this error as an invalid QC / invalid block, i.e. it should _not_ return an `InvalidProposalError`.
 func (qs *QCSuite) TestQCEmptySigners() {

--- a/consensus/hotstuff/verification/combined_signer_v2_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v2_test.go
@@ -108,8 +108,8 @@ func TestCombinedSignWithBeaconKey(t *testing.T) {
 	require.ErrorIs(t, err, model.ErrInvalidSignature)
 
 	// Vote from a node that is _not_ part of the Random Beacon committee should be rejected.
-	// Specifically, we expect that the verifier recognizes the `protocol.IdentityNotFoundError`
-	// as a sign of an invalid vote and wraps it into a `model.InvalidSignerError`.
+	// Specifically, we expect that the verifier recognizes the [protocol.IdentityNotFoundError]
+	// as a sign of an invalid vote and wraps it into a [model.InvalidSignerError].
 	*dkg = mocks.DKG{} // overwrite DKG mock with a new one
 	dkg.On("KeyShare", signerID).Return(nil, protocol.IdentityNotFoundError{NodeID: signerID})
 	err = verifier.VerifyVote(nodeID, vote.SigData, proposal.Block.View, proposal.Block.BlockID)
@@ -171,9 +171,9 @@ func TestCombinedSignWithNoBeaconKey(t *testing.T) {
 	require.Equal(t, expectedStakingSig, crypto.Signature(proposal.SigData))
 }
 
-// Test_VerifyQC_EmptySigners checks that Verifier returns an `model.InsufficientSignaturesError`
+// Test_VerifyQC_EmptySigners checks that Verifier returns an [model.InsufficientSignaturesError]
 // if `signers` input is empty or nil. This check should happen _before_ the Verifier calls into
-// any sub-components, because some (e.g. `crypto.AggregateBLSPublicKeys`) don't provide sufficient
+// any sub-components, because some (e.g. [crypto.AggregateBLSPublicKeys]) don't provide sufficient
 // sentinel errors to distinguish between internal problems and external byzantine inputs.
 func Test_VerifyQC_EmptySigners(t *testing.T) {
 	committee := &mocks.DynamicCommittee{}

--- a/consensus/hotstuff/verification/combined_signer_v3_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v3_test.go
@@ -75,8 +75,8 @@ func TestCombinedSignWithBeaconKeyV3(t *testing.T) {
 	require.Equal(t, expectedSig, proposal.SigData)
 
 	// Vote from a node that is _not_ part of the Random Beacon committee should be rejected.
-	// Specifically, we expect that the verifier recognizes the `protocol.IdentityNotFoundError`
-	// as a sign of an invalid vote and wraps it into a `model.InvalidSignerError`.
+	// Specifically, we expect that the verifier recognizes the [protocol.IdentityNotFoundError]
+	// as a sign of an invalid vote and wraps it into a [model.InvalidSignerError].
 	*dkg = mocks.DKG{} // overwrite DKG mock with a new one
 	dkg.On("KeyShare", signerID).Return(nil, protocol.IdentityNotFoundError{NodeID: signerID})
 	err = verifier.VerifyVote(nodeID, vote.SigData, proposal.Block.View, proposal.Block.BlockID)
@@ -245,9 +245,9 @@ func Test_VerifyQCV3(t *testing.T) {
 
 }
 
-// Test_VerifyQC_EmptySignersV3 checks that Verifier returns an `model.InsufficientSignaturesError`
+// Test_VerifyQC_EmptySignersV3 checks that Verifier returns an [model.InsufficientSignaturesError]
 // if `signers` input is empty or nil. This check should happen _before_ the Verifier calls into
-// any sub-components, because some (e.g. `crypto.AggregateBLSPublicKeys`) don't provide sufficient
+// any sub-components, because some (e.g. [crypto.AggregateBLSPublicKeys]) don't provide sufficient
 // sentinel errors to distinguish between internal problems and external byzantine inputs.
 func Test_VerifyQC_EmptySignersV3(t *testing.T) {
 	committee := &mocks.DynamicCommittee{}

--- a/consensus/hotstuff/verification/combined_verifier_v3.go
+++ b/consensus/hotstuff/verification/combined_verifier_v3.go
@@ -187,8 +187,8 @@ func (c *CombinedVerifierV3) VerifyQC(signers flow.IdentitySkeletonList, sigData
 
 	// STEP 3: validating the aggregated staking signatures
 	// Note: it is possible that all replicas signed with their random beacon keys, i.e.
-	// `blockSigData.StakingSigners` could be empty. In this case, the
-	// `blockSigData.AggregatedStakingSig` should also be empty.
+	// [blockSigData.StakingSigners] could be empty. In this case, the
+	// [blockSigData.AggregatedStakingSig] should also be empty.
 	numStakingSigners := len(blockSigData.StakingSigners)
 	if numStakingSigners == 0 {
 		if len(blockSigData.AggregatedStakingSig) > 0 {

--- a/consensus/hotstuff/verification/common.go
+++ b/consensus/hotstuff/verification/common.go
@@ -37,7 +37,7 @@ func MakeTimeoutMessage(view uint64, newestQCView uint64) []byte {
 // verifyAggregatedSignatureOneMessage encapsulates the logic of verifying an aggregated signature
 // under the same message.
 // Proofs of possession of all input keys are assumed to be valid (checked by the protocol).
-// This logic is commonly used across the different implementations of `hotstuff.Verifier`.
+// This logic is commonly used across the different implementations of [hotstuff.Verifier].
 // In this context, all signatures apply to blocks.
 // Return values:
 //   - nil if `aggregatedSig` is valid against the public keys and message.
@@ -82,7 +82,7 @@ func verifyAggregatedSignatureOneMessage(
 // verifyTCSignatureManyMessages checks cryptographic validity of the TC's signature w.r.t.
 // multiple messages and public keys.
 // Proofs of possession of all input keys are assumed to be valid (checked by the protocol).
-// This logic is commonly used across the different implementations of `hotstuff.Verifier`.
+// This logic is commonly used across the different implementations of [hotstuff.Verifier].
 // It is the responsibility of the calling code to ensure that all `pks` are authorized,
 // without duplicates. The caller must also make sure the `hasher` passed is non nil and has
 // 128-bytes outputs.

--- a/consensus/hotstuff/verification/staking_verifier.go
+++ b/consensus/hotstuff/verification/staking_verifier.go
@@ -62,7 +62,7 @@ func (v *StakingVerifier) VerifyVote(signer *flow.IdentitySkeleton, sigData []by
 //   - unexpected errors should be treated as symptoms of bugs or uncovered
 //     edge cases in the logic (i.e. as fatal)
 //
-// In the single verification case, `sigData` represents a single signature (`crypto.Signature`).
+// In the single verification case, `sigData` represents a single signature ([crypto.Signature]).
 func (v *StakingVerifier) VerifyQC(signers flow.IdentitySkeletonList, sigData []byte, view uint64, blockID flow.Identifier) error {
 	msg := MakeVoteMessage(view, blockID)
 

--- a/consensus/hotstuff/voteaggregator/vote_aggregator.go
+++ b/consensus/hotstuff/voteaggregator/vote_aggregator.go
@@ -338,7 +338,7 @@ func (va *VoteAggregator) PruneUpToView(lowestRetainedView uint64) {
 	}
 }
 
-// OnFinalizedBlock implements the `OnFinalizedBlock` callback from the `hotstuff.FinalizationConsumer`
+// OnFinalizedBlock implements the `OnFinalizedBlock` callback from the [hotstuff.FinalizationConsumer]
 // It informs sealing.Core about finalization of respective block.
 //
 // CAUTION: the input to this callback is treated as trusted; precautions should be taken that messages

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2.go
@@ -18,14 +18,14 @@ import (
 
 /* **************** Base-Factory for CombinedVoteProcessors ***************** */
 
-// combinedVoteProcessorFactoryBaseV2 is a `votecollector.baseFactory` for creating
+// combinedVoteProcessorFactoryBaseV2 is a [votecollector.baseFactory] for creating
 // CombinedVoteProcessors, holding all needed dependencies.
 // combinedVoteProcessorFactoryBaseV2 is intended to be used for the main consensus.
 // CAUTION:
 // this base factory only creates the VerifyingVoteProcessor for the given block.
 // It does _not_ check the proposer's vote for its own block, i.e. it does _not_
-// implement `hotstuff.VoteProcessorFactory`. This base factory should be wrapped
-// by `votecollector.VoteProcessorFactory` which adds the logic to verify
+// implement [hotstuff.VoteProcessorFactory]. This base factory should be wrapped
+// by [votecollector.VoteProcessorFactory] which adds the logic to verify
 // the proposer's vote (decorator pattern).
 type combinedVoteProcessorFactoryBaseV2 struct {
 	committee   hotstuff.DynamicCommittee

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3.go
@@ -19,14 +19,14 @@ import (
 
 /* **************** Base-Factory for CombinedVoteProcessors ***************** */
 
-// combinedVoteProcessorFactoryBaseV3 is a `votecollector.baseFactory` for creating
+// combinedVoteProcessorFactoryBaseV3 is a [votecollector.baseFactory] for creating
 // CombinedVoteProcessors, holding all needed dependencies.
 // combinedVoteProcessorFactoryBaseV3 is intended to be used for the main consensus.
 // CAUTION:
 // this base factory only creates the VerifyingVoteProcessor for the given block.
 // It does _not_ check the proposer's vote for its own block, i.e. it does _not_
-// implement `hotstuff.VoteProcessorFactory`. This base factory should be wrapped
-// by `votecollector.VoteProcessorFactory` which adds the logic to verify
+// implement [hotstuff.VoteProcessorFactory]. This base factory should be wrapped
+// by [votecollector.VoteProcessorFactory] which adds the logic to verify
 // the proposer's vote (decorator pattern).
 // nolint:unused
 type combinedVoteProcessorFactoryBaseV3 struct {
@@ -275,7 +275,7 @@ func (p *CombinedVoteProcessorV3) buildQC() (*flow.QuorumCertificate, error) {
 	//   `stakingSigners` and `aggregatedStakingSig` both being zero-length
 	//   (here, we use `nil`).
 	// * If it has _not collected any_ signatures, `stakingSigAggtor.Aggregate()`
-	//   errors with a `model.InsufficientSignaturesError`. We shortcut this case,
+	//   errors with a [model.InsufficientSignaturesError]. We shortcut this case,
 	//   and only call `Aggregate`, if the `stakingSigAggtor` has collected signatures
 	//   with non-zero weight (i.e. at least one signature was collected).
 	var stakingSigners []flow.Identifier // nil (zero value) represents empty set of staking signers

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v3_test.go
@@ -519,7 +519,7 @@ func TestCombinedVoteProcessorV3_PropertyCreatingQCCorrectness(testifyT *testing
 			// in the following, we check validity for each field of `blockSigData` individually
 
 			// 1. CHECK: `StakingSigners` and `RandomBeaconSigners`
-			// Verify that input `hotstuff.BlockSignatureData` has the expected structure.
+			// Verify that input [hotstuff.BlockSignatureData] has the expected structure.
 			//  * When the Vote Processor notices that constructing a valid QC is possible, it does
 			//    so with the signatures collected at this time.
 			//  * However, due to concurrency, additional votes might have been added to the aggregators
@@ -687,7 +687,7 @@ func TestCombinedVoteProcessorV3_PropertyCreatingQCCorrectness(testifyT *testing
 // TestCombinedVoteProcessorV3_OnlyRandomBeaconSigners tests the most optimal happy path,
 // where all consensus replicas vote using their random beacon keys. In this case,
 // no staking signatures were collected and the CombinedVoteProcessor should be setting
-// `BlockSignatureData.StakingSigners` and `BlockSignatureData.AggregatedStakingSig` to nil or empty slices.
+// [BlockSignatureData.StakingSigners] and [BlockSignatureData.AggregatedStakingSig] to nil or empty slices.
 func TestCombinedVoteProcessorV3_OnlyRandomBeaconSigners(testifyT *testing.T) {
 	// setup CombinedVoteProcessorV3
 	block := helper.MakeBlock()
@@ -724,8 +724,8 @@ func TestCombinedVoteProcessorV3_OnlyRandomBeaconSigners(testifyT *testing.T) {
 	reconstructor.On("EnoughShares").Return(true).Once()
 	reconstructor.On("Reconstruct").Return(unittest.SignatureFixture(), nil).Once()
 
-	// Adding the vote should trigger QC generation. We expect `BlockSignatureData.StakingSigners`
-	// and `BlockSignatureData.AggregatedStakingSig` to be both empty, as there are no staking signatures.
+	// Adding the vote should trigger QC generation. We expect [BlockSignatureData.StakingSigners]
+	// and [BlockSignatureData.AggregatedStakingSig] to be both empty, as there are no staking signatures.
 	packer.On("Pack", block.View, mock.Anything).
 		Run(func(args mock.Arguments) {
 			blockSigData := args.Get(1).(*hotstuff.BlockSignatureData)

--- a/consensus/hotstuff/votecollector/factory.go
+++ b/consensus/hotstuff/votecollector/factory.go
@@ -15,20 +15,20 @@ import (
 // be used.
 // CAUTION: the baseFactory creates the VerifyingVoteProcessor for the given block. It
 // does _not_ check the proposer's vote for its own block. The API reflects this by
-// expecting a `model.Block` as input (which does _not_ contain the proposer vote) as
-// opposed to `model.Proposal` (combines block with proposer's vote).
-// Therefore, baseFactory does _not_ implement `hotstuff.VoteProcessorFactory` by itself.
+// expecting a [model.Block] as input (which does _not_ contain the proposer vote) as
+// opposed to [model.Proposal] (combines block with proposer's vote).
+// Therefore, baseFactory does _not_ implement [hotstuff.VoteProcessorFactory] by itself.
 // The VoteProcessorFactory adds the missing logic to verify the proposer's vote, by
 // wrapping the baseFactory (decorator pattern).
 type baseFactory func(log zerolog.Logger, block *model.Block) (hotstuff.VerifyingVoteProcessor, error)
 
-// VoteProcessorFactory implements `hotstuff.VoteProcessorFactory`. Its main purpose
+// VoteProcessorFactory implements [hotstuff.VoteProcessorFactory]. Its main purpose
 // is to construct instances of VerifyingVoteProcessors for a given block proposal.
 // VoteProcessorFactory
 // * delegates the creation of the actual instances to baseFactory
 // * adds the logic to verify the proposer's vote for its own block
 // Thereby, VoteProcessorFactory guarantees that only proposals with valid proposer
-// vote are accepted (as per API specification). Otherwise, an `model.InvalidProposalError`
+// vote are accepted (as per API specification). Otherwise, an [model.InvalidProposalError]
 // is returned.
 type VoteProcessorFactory struct {
 	baseFactory baseFactory

--- a/consensus/hotstuff/votecollector/staking_vote_processor.go
+++ b/consensus/hotstuff/votecollector/staking_vote_processor.go
@@ -24,8 +24,8 @@ import (
 // CAUTION:
 // this base factory only creates the VerifyingVoteProcessor for the given block.
 // It does _not_ check the proposer's vote for its own block, i.e. it does _not_
-// implement `hotstuff.VoteProcessorFactory`. This base factory should be wrapped
-// by `votecollector.VoteProcessorFactory` which adds the logic to verify
+// implement [hotstuff.VoteProcessorFactory]. This base factory should be wrapped
+// by [votecollector.VoteProcessorFactory] which adds the logic to verify
 // the proposer's vote (decorator pattern).
 type stakingVoteProcessorFactoryBase struct {
 	committee   hotstuff.DynamicCommittee

--- a/consensus/integration/epoch_test.go
+++ b/consensus/integration/epoch_test.go
@@ -24,7 +24,7 @@ func TestUnweightedNode(t *testing.T) {
 	rootSnapshot := createRootSnapshot(t, participantsData)
 	consensusParticipants := NewConsensusParticipants(participantsData)
 
-	// add a consensus node to next epoch (it will have `flow.EpochParticipationStatusJoining` status in the current epoch)
+	// add a consensus node to next epoch (it will have [flow.EpochParticipationStatusJoining] status in the current epoch)
 	nextEpochParticipantsData := createConsensusIdentities(t, 1)
 	// epoch 2 identities includes:
 	// * same collection node from epoch 1, so cluster QCs are consistent

--- a/engine/access/index/events_index.go
+++ b/engine/access/index/events_index.go
@@ -7,7 +7,7 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
-// EventsIndex implements a wrapper around `storage.Events` ensuring that needed data has been synced and is available to the client.
+// EventsIndex implements a wrapper around [storage.Events] ensuring that needed data has been synced and is available to the client.
 // Note: read detail how `Reporter` is working
 type EventsIndex struct {
 	*Reporter

--- a/engine/access/index/transaction_results_indexer.go
+++ b/engine/access/index/transaction_results_indexer.go
@@ -5,7 +5,7 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
-// TransactionResultsIndex implements a wrapper around `storage.LightTransactionResult` ensuring that needed data has been synced and is available to the client.
+// TransactionResultsIndex implements a wrapper around [storage.LightTransactionResult] ensuring that needed data has been synced and is available to the client.
 // Note: read detail how `Reporter` is working
 type TransactionResultsIndex struct {
 	*Reporter

--- a/engine/access/rpc/backend/backend_events.go
+++ b/engine/access/rpc/backend/backend_events.go
@@ -100,7 +100,7 @@ func (b *backendEvents) GetEventsForHeightRange(
 	blockHeaders := make([]blockMetadata, 0, endHeight-startHeight+1)
 
 	for i := startHeight; i <= endHeight; i++ {
-		// this looks inefficient, but is actually what's done under the covers by `headers.ByHeight`
+		// this looks inefficient, but is actually what's done under the covers by [headers.ByHeight]
 		// and avoids calculating header.ID() for each block.
 		blockID, err := b.headers.BlockIDByHeight(i)
 		if err != nil {

--- a/engine/access/rpc/backend/backend_transactions.go
+++ b/engine/access/rpc/backend/backend_transactions.go
@@ -613,7 +613,7 @@ func (b *backendTransactions) GetSystemTransactionResult(ctx context.Context, bl
 }
 
 // Error returns:
-//   - `storage.ErrNotFound` - collection referenced by transaction or block by a collection has not been found.
+//   - [storage.ErrNotFound] - collection referenced by transaction or block by a collection has not been found.
 //   - all other errors are unexpected and potentially symptoms of internal implementation bugs or state corruption (fatal).
 func (b *backendTransactions) lookupBlock(txID flow.Identifier) (*flow.Block, error) {
 	collection, err := b.collections.LightByTransactionID(txID)

--- a/engine/collection/compliance/core.go
+++ b/engine/collection/compliance/core.go
@@ -373,9 +373,9 @@ func (c *Core) ProcessFinalizedBlock(finalized *flow.Header) {
 	c.mempoolMetrics.MempoolEntries(metrics.ResourceClusterProposal, c.pending.Size())
 }
 
-// checkForAndLogOutdatedInputError checks whether error is an `engine.OutdatedInputError`.
+// checkForAndLogOutdatedInputError checks whether error is an [engine.OutdatedInputError].
 // If this is the case, we emit a log message and return true.
-// For any error other than `engine.OutdatedInputError`, this function is a no-op
+// For any error other than [engine.OutdatedInputError], this function is a no-op
 // and returns false.
 func checkForAndLogOutdatedInputError(err error, log zerolog.Logger) bool {
 	if engine.IsOutdatedInputError(err) {
@@ -387,9 +387,9 @@ func checkForAndLogOutdatedInputError(err error, log zerolog.Logger) bool {
 	return false
 }
 
-// checkForAndLogUnverifiableInputError checks whether error is an `engine.UnverifiableInputError`.
+// checkForAndLogUnverifiableInputError checks whether error is an [engine.UnverifiableInputError].
 // If this is the case, we emit a log message and return true.
-// For any error other than `engine.UnverifiableInputError`, this function is a no-op
+// For any error other than [engine.UnverifiableInputError], this function is a no-op
 // and returns false.
 func checkForAndLogUnverifiableInputError(err error, log zerolog.Logger) bool {
 	if engine.IsUnverifiableInputError(err) {

--- a/engine/collection/compliance/engine.go
+++ b/engine/collection/compliance/engine.go
@@ -21,7 +21,7 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
-// defaultBlockQueueCapacity maximum capacity of inbound queue for `messages.ClusterBlockProposal`s
+// defaultBlockQueueCapacity maximum capacity of inbound queue for [messages.ClusterBlockProposal]s
 const defaultBlockQueueCapacity = 10_000
 
 // Engine is a wrapper struct for `Core` which implements cluster consensus algorithm.

--- a/engine/collection/epochmgr/engine.go
+++ b/engine/collection/epochmgr/engine.go
@@ -35,7 +35,7 @@ var ErrNotAuthorizedForEpoch = fmt.Errorf("we are not an authorized participant 
 // spinning up engines when a new epoch is about to start and spinning down
 // engines for an epoch that has ended.
 //
-// The `epochmgr.Engine` implements the `protocol.Consumer` interface. In particular, it
+// The [epochmgr.Engine] implements the [protocol.Consumer] interface. In particular, it
 // ingests the following notifications from the protocol state:
 //   - EpochSetupPhaseStarted
 //   - EpochTransition

--- a/engine/collection/message_hub/message_hub.go
+++ b/engine/collection/message_hub/message_hub.go
@@ -447,7 +447,7 @@ func (h *MessageHub) Process(channel channels.Channel, originID flow.Identifier,
 	return nil
 }
 
-// forwardToOwnVoteAggregator converts vote to generic `model.Vote`, logs vote and forwards it to own `voteAggregator`.
+// forwardToOwnVoteAggregator converts vote to generic [model.Vote], logs vote and forwards it to own `voteAggregator`.
 // Per API convention, timeoutAggregator` is non-blocking, hence, this call returns quickly.
 func (h *MessageHub) forwardToOwnVoteAggregator(vote *messages.ClusterBlockVote, originID flow.Identifier) {
 	h.engineMetrics.MessageReceived(metrics.EngineCollectionMessageHub, metrics.MessageBlockVote)

--- a/engine/common/follower/cache/cache.go
+++ b/engine/common/follower/cache/cache.go
@@ -87,8 +87,8 @@ func NewCache(log zerolog.Logger, limit uint32, collector module.HeroCacheMetric
 }
 
 // handleEjectedEntity performs cleanup of secondary indexes to prevent memory leaks.
-// WARNING: Concurrency safety of this function is guaranteed by `c.lock`. This method is only called
-// by `herocache.Cache.Add` and we perform this call while `c.lock` is in locked state.
+// WARNING: Concurrency safety of this function is guaranteed by [c.lock]. This method is only called
+// by `herocache.Cache.Add` and we perform this call while [c.lock] is in locked state.
 func (c *Cache) handleEjectedEntity(entity flow.Entity) {
 	block := entity.(*flow.Block)
 	blockID := block.ID()
@@ -150,12 +150,12 @@ func (c *Cache) AddBlocks(batch []*flow.Block) (certifiedBatch []*flow.Block, ce
 
 	// Single atomic operation (main logic), with result returned as `batchContext`
 	//  * add the given batch of blocks to the cache
-	//  * check for equivocating blocks (result stored in `batchContext.equivocatingBlocks`)
+	//  * check for equivocating blocks (result stored in [batchContext.equivocatingBlocks])
 	//  * check whether first block in batch (index 0) has a parent already in the cache
-	//    (result stored in `batchContext.batchParent`)
+	//    (result stored in [batchContext.batchParent])
 	//  * check whether last block in batch has a child already in the cache
-	//    (result stored in `batchContext.batchChild`)
-	//  * check if input is redundant (indicated by `batchContext.redundant`), i.e. ALL blocks
+	//    (result stored in [batchContext.batchChild])
+	//  * check if input is redundant (indicated by [batchContext.redundant]), i.e. ALL blocks
 	//    are already known: then skip further processing
 	bc := c.unsafeAtomicAdd(blockIDs, batch)
 	if bc.redundant {

--- a/engine/common/follower/compliance_core.go
+++ b/engine/common/follower/compliance_core.go
@@ -197,7 +197,7 @@ func (c *ComplianceCore) OnBlockRange(originID flow.Identifier, batch []*flow.Bl
 
 // processCoreSeqEvents processes events that need to be dispatched on dedicated core's goroutine.
 // Here we process events that need to be sequentially ordered(processing certified blocks and new finalized blocks).
-// Implements `component.ComponentWorker` signature.
+// Implements [component.ComponentWorker] signature.
 // Is NOT concurrency safe: should be executed by _single dedicated_ goroutine.
 func (c *ComplianceCore) processCoreSeqEvents(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 	ready()
@@ -224,7 +224,7 @@ func (c *ComplianceCore) processCoreSeqEvents(ctx irrecoverable.SignalerContext,
 // OnFinalizedBlock updates local state of pendingCache tree using received finalized block and queues finalized block
 // to be processed by internal goroutine.
 // This function is safe to use in concurrent environment.
-// CAUTION: this function blocks and hence is not compliant with the `FinalizationConsumer.OnFinalizedBlock` interface.
+// CAUTION: this function blocks and hence is not compliant with the [FinalizationConsumer.OnFinalizedBlock] interface.
 func (c *ComplianceCore) OnFinalizedBlock(final *flow.Header) {
 	c.pendingCache.PruneUpToView(final.View)
 
@@ -243,7 +243,7 @@ func (c *ComplianceCore) OnFinalizedBlock(final *flow.Header) {
 //     finalized block plus all of their connected descendants. The list `connectedBlocks` is in 'parent first'
 //     order, i.e. a block is listed before any of its descendants. The PendingTree guarantees that all
 //     ancestors are listed, _unless_ the ancestor is the finalized block or the ancestor has been returned
-//     by a previous call to `PendingTree.AddBlocks`.
+//     by a previous call to [PendingTree.AddBlocks].
 //  2. We extend the protocol state with the connected certified blocks from step 1.
 //  3. We submit the connected certified blocks from step 1 to the consensus follower.
 //

--- a/engine/common/follower/compliance_core_test.go
+++ b/engine/common/follower/compliance_core_test.go
@@ -29,7 +29,7 @@ func TestFollowerCore(t *testing.T) {
 }
 
 // CoreSuite maintains minimal state for testing ComplianceCore.
-// Performs startup & shutdown using `module.Startable` and `module.ReadyDoneAware` interfaces.
+// Performs startup & shutdown using [module.Startable] and [module.ReadyDoneAware] interfaces.
 type CoreSuite struct {
 	suite.Suite
 

--- a/engine/common/follower/compliance_engine.go
+++ b/engine/common/follower/compliance_engine.go
@@ -183,7 +183,7 @@ func (e *ComplianceEngine) OnBlockProposal(proposal flow.Slashable[*messages.Blo
 // order (less efficient), making it robust against byzantine nodes.
 func (e *ComplianceEngine) OnSyncedBlocks(blocks flow.Slashable[[]*messages.BlockProposal]) {
 	e.engMetrics.MessageReceived(metrics.EngineFollower, metrics.MessageSyncedBlocks)
-	// The synchronization engine feeds the follower with batches of blocks. The field `Slashable.OriginID`
+	// The synchronization engine feeds the follower with batches of blocks. The field [Slashable.OriginID]
 	// states which node forwarded the batch to us. Each block contains its proposer and signature.
 
 	if e.syncedBlocks.Push(blocks) {
@@ -195,7 +195,7 @@ func (e *ComplianceEngine) OnSyncedBlocks(blocks flow.Slashable[[]*messages.Bloc
 // and asynchronously executes the internal pruning logic. We accept inputs out of order, and only act
 // on inputs with strictly monotonously increasing views.
 //
-// Implements the `OnFinalizedBlock` callback from the `hotstuff.FinalizationConsumer`
+// Implements the `OnFinalizedBlock` callback from the [hotstuff.FinalizationConsumer]
 // CAUTION: the input to this callback is treated as trusted; precautions should be taken that messages
 // from external nodes cannot be considered as inputs to this function.
 func (e *ComplianceEngine) OnFinalizedBlock(block *model.Block) {
@@ -222,7 +222,7 @@ func (e *ComplianceEngine) Process(channel channels.Channel, originID flow.Ident
 }
 
 // processBlocksLoop processes available blocks as they are queued.
-// Implements `component.ComponentWorker` signature.
+// Implements [component.ComponentWorker] signature.
 func (e *ComplianceEngine) processBlocksLoop(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 	ready()
 
@@ -252,7 +252,7 @@ func (e *ComplianceEngine) processBlocksLoop(ctx irrecoverable.SignalerContext, 
 //     synchronization produces for a node that is catching up. In other words, prioritizing
 //     the few new proposals first is probably not going to be much of a distraction.
 //     Proposals too far in the future are dropped (see parameter `SkipNewProposalsThreshold`
-//     in `compliance.Config`), to prevent memory overflow.
+//     in [compliance.Config]), to prevent memory overflow.
 //
 // No errors are expected during normal operation. All returned exceptions are potential
 // symptoms of internal state corruption and should be fatal.
@@ -374,7 +374,7 @@ func (e *ComplianceEngine) processConnectedBatch(ctx irrecoverable.SignalerConte
 }
 
 // finalizationProcessingLoop is a separate goroutine that performs processing of finalization events.
-// Implements `component.ComponentWorker` signature.
+// Implements [component.ComponentWorker] signature.
 func (e *ComplianceEngine) finalizationProcessingLoop(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
 	ready()
 

--- a/engine/common/follower/pending_tree/pending_tree.go
+++ b/engine/common/follower/pending_tree/pending_tree.go
@@ -194,10 +194,10 @@ func (t *PendingTree) FinalizeFork(finalized *flow.Header) ([]flow.CertifiedBloc
 	return connectedBlocks, nil
 }
 
-// updateAndCollectFork marks the subtree rooted at `vertex.Block` as connected to the finalized state
-// and returns all blocks in this subtree. No parents of `vertex.Block` are modified or included in the output.
+// updateAndCollectFork marks the subtree rooted at [vertex.Block] as connected to the finalized state
+// and returns all blocks in this subtree. No parents of [vertex.Block] are modified or included in the output.
 // The output list will be ordered so that parents appear before children.
-// The caller must ensure that `vertex.Block` is connected to the finalized state.
+// The caller must ensure that [vertex.Block] is connected to the finalized state.
 //
 //	A ← B ← C ←D
 //	      ↖ E

--- a/engine/common/provider/engine.go
+++ b/engine/common/provider/engine.go
@@ -35,7 +35,7 @@ const (
 // RetrieveFunc is a function provided to the provider engine upon construction.
 // It is used by the engine when receiving requests in order to retrieve the
 // related entities. It is important that the retrieve function return a
-// `storage.ErrNotFound` error if the entity does not exist locally; otherwise,
+// [storage.ErrNotFound] error if the entity does not exist locally; otherwise,
 // the logic will error and not send responses when failing to retrieve entities.
 type RetrieveFunc func(flow.Identifier) (flow.Entity, error)
 

--- a/engine/common/requester/engine.go
+++ b/engine/common/requester/engine.go
@@ -27,7 +27,7 @@ import (
 // and errors should be handled internally within the function.
 type HandleFunc func(originID flow.Identifier, entity flow.Entity)
 
-// CreateFunc is a function that creates a `flow.Entity` with an underlying type
+// CreateFunc is a function that creates a [flow.Entity] with an underlying type
 // so that we can properly decode entities transmitted over the network.
 type CreateFunc func() flow.Entity
 
@@ -199,7 +199,7 @@ func (e *Engine) Process(channel channels.Channel, originID flow.Identifier, mes
 // list. The provided selector will be applied to the set of valid providers on top
 // of the global selector injected upon construction. It allows for finer-grained
 // control over which subset of providers to request a given entity from, such as
-// selection of a collection cluster. Use `filter.Any` if no additional selection
+// selection of a collection cluster. Use [filter.Any] if no additional selection
 // is required. Checks integrity of response to make sure that we got entity that we were requesting.
 func (e *Engine) EntityByID(entityID flow.Identifier, selector flow.IdentityFilter[flow.Identity]) {
 	e.addEntityRequest(entityID, selector, true)

--- a/engine/common/rpc/convert/snapshots.go
+++ b/engine/common/rpc/convert/snapshots.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onflow/flow-go/state/protocol/inmem"
 )
 
-// SnapshotToBytes converts a `protocol.Snapshot` to bytes, encoded as JSON
+// SnapshotToBytes converts a [protocol.Snapshot] to bytes, encoded as JSON
 func SnapshotToBytes(snapshot protocol.Snapshot) ([]byte, error) {
 	serializable, err := inmem.FromSnapshot(snapshot)
 	if err != nil {
@@ -23,7 +23,7 @@ func SnapshotToBytes(snapshot protocol.Snapshot) ([]byte, error) {
 	return data, nil
 }
 
-// BytesToInmemSnapshot converts an array of bytes to `inmem.Snapshot`
+// BytesToInmemSnapshot converts an array of bytes to [inmem.Snapshot]
 func BytesToInmemSnapshot(bytes []byte) (*inmem.Snapshot, error) {
 	var encodable inmem.EncodableSnapshot
 	err := json.Unmarshal(bytes, &encodable)

--- a/engine/consensus/approvals/approvals_lru_cache.go
+++ b/engine/consensus/approvals/approvals_lru_cache.go
@@ -8,8 +8,8 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// LruCache is a wrapper over `simplelru.LRUCache` that provides needed api for processing result approvals
-// Extends functionality of `simplelru.LRUCache` by introducing additional index for quicker access.
+// LruCache is a wrapper over [simplelru.LRUCache] that provides needed api for processing result approvals
+// Extends functionality of [simplelru.LRUCache] by introducing additional index for quicker access.
 type LruCache struct {
 	lru  simplelru.LRUCache[flow.Identifier, *flow.ResultApproval]
 	lock sync.RWMutex

--- a/engine/consensus/compliance/core.go
+++ b/engine/consensus/compliance/core.go
@@ -405,9 +405,9 @@ func (c *Core) ProcessFinalizedBlock(finalized *flow.Header) {
 	c.mempoolMetrics.MempoolEntries(metrics.ResourceProposal, c.pending.Size())
 }
 
-// checkForAndLogOutdatedInputError checks whether error is an `engine.OutdatedInputError`.
+// checkForAndLogOutdatedInputError checks whether error is an [engine.OutdatedInputError].
 // If this is the case, we emit a log message and return true.
-// For any error other than `engine.OutdatedInputError`, this function is a no-op
+// For any error other than [engine.OutdatedInputError], this function is a no-op
 // and returns false.
 func checkForAndLogOutdatedInputError(err error, log zerolog.Logger) bool {
 	if engine.IsOutdatedInputError(err) {
@@ -419,9 +419,9 @@ func checkForAndLogOutdatedInputError(err error, log zerolog.Logger) bool {
 	return false
 }
 
-// checkForAndLogUnverifiableInputError checks whether error is an `engine.UnverifiableInputError`.
+// checkForAndLogUnverifiableInputError checks whether error is an [engine.UnverifiableInputError].
 // If this is the case, we emit a log message and return true.
-// For any error other than `engine.UnverifiableInputError`, this function is a no-op
+// For any error other than [engine.UnverifiableInputError], this function is a no-op
 // and returns false.
 func checkForAndLogUnverifiableInputError(err error, log zerolog.Logger) bool {
 	if engine.IsUnverifiableInputError(err) {

--- a/engine/consensus/compliance/engine.go
+++ b/engine/consensus/compliance/engine.go
@@ -21,13 +21,13 @@ import (
 	"github.com/onflow/flow-go/storage"
 )
 
-// defaultBlockQueueCapacity maximum capacity of inbound queue for `messages.BlockProposal`s
+// defaultBlockQueueCapacity maximum capacity of inbound queue for [messages.BlockProposal]s
 const defaultBlockQueueCapacity = 10_000
 
-// Engine is a wrapper around `compliance.Core`. The Engine queues inbound messages, relevant
+// Engine is a wrapper around [compliance.Core]. The Engine queues inbound messages, relevant
 // node-internal notifications, and manages the worker routines processing the inbound events,
 // and forwards outbound messages to the networking layer.
-// `compliance.Core` implements the actual compliance logic.
+// [compliance.Core] implements the actual compliance logic.
 // Implements consensus.Compliance interface.
 type Engine struct {
 	component.Component
@@ -54,7 +54,7 @@ func NewEngine(
 	core *Core,
 ) (*Engine, error) {
 
-	// Inbound FIFO queue for `messages.BlockProposal`s
+	// Inbound FIFO queue for [messages.BlockProposal]s
 	blocksQueue, err := fifoqueue.NewFifoQueue(
 		defaultBlockQueueCapacity,
 		fifoqueue.WithLengthObserver(func(len int) { core.mempoolMetrics.MempoolEntries(metrics.ResourceBlockProposalQueue, uint(len)) }),

--- a/engine/consensus/dkg/reactor_engine.go
+++ b/engine/consensus/dkg/reactor_engine.go
@@ -423,7 +423,7 @@ func (e *ReactorEngine) end(nextEpochCounter uint64) func() error {
 		if crypto.IsDKGFailureError(err) {
 			// Failing to complete the DKG protocol is a rare but expected scenario, which we must handle.
 			// By convention, if we are leaving the happy path, we want to persist the _first_ failure symptom
-			// in the `dkgState`. If the write yields a `storage.ErrAlreadyExists`, we know the overall protocol
+			// in the `dkgState`. If the write yields a [storage.ErrAlreadyExists], we know the overall protocol
 			// has already abandoned the happy path, because on the happy path the ReactorEngine is the only writer.
 			// Then this function just stops and returns without error.
 			e.log.Warn().Err(err).Msgf("node %s with index %d failed DKG locally", e.me.NodeID(), e.controller.GetIndex())
@@ -440,7 +440,7 @@ func (e *ReactorEngine) end(nextEpochCounter uint64) func() error {
 		}
 
 		// The following only implements the happy path, which is an atomic step-by-step progression
-		// along a single path in the `dkgState` machine. If the write yields a `storage.ErrAlreadyExists`,
+		// along a single path in the `dkgState` machine. If the write yields a [storage.ErrAlreadyExists],
 		// we know the overall protocol has already abandoned the happy path, because on the happy path
 		// ReactorEngine is the only writer. Then this function just stops and returns without error.
 		privateShare, _, _ := e.controller.GetArtifacts()

--- a/engine/consensus/matching/core.go
+++ b/engine/consensus/matching/core.go
@@ -219,7 +219,7 @@ func (c *Core) processReceipt(receipt *flow.ExecutionReceipt) (bool, error) {
 		if module.IsUnknownResultError(err) {
 			// Previous result is missing. Hence, we can't validate this receipt.
 			// We want to efficiently handle receipts arriving out of order. Therefore, we cache the
-			// receipt in `c.pendingReceipts`. On finalization of new blocks, we request receipts
+			// receipt in [c.pendingReceipts]. On finalization of new blocks, we request receipts
 			// for all unsealed but finalized blocks. For instance, given blocks
 			// A <- B <- C <- D <- E, if we receive their receipts in the order of [E,C,D,B,A], then:
 			//  - If we drop the missing previous receipts, then only A will be processed.

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -167,14 +167,14 @@ func (e *Engine) HandleReceipt(originID flow.Identifier, receipt flow.Entity) {
 	}
 }
 
-// OnFinalizedBlock implements the `OnFinalizedBlock` callback from the `hotstuff.FinalizationConsumer`
+// OnFinalizedBlock implements the `OnFinalizedBlock` callback from the [hotstuff.FinalizationConsumer]
 // CAUTION: the input to this callback is treated as trusted; precautions should be taken that messages
 // from external nodes cannot be considered as inputs to this function
 func (e *Engine) OnFinalizedBlock(*model.Block) {
 	e.finalizationEventsNotifier.Notify()
 }
 
-// OnBlockIncorporated implements the `OnBlockIncorporated` callback from the `hotstuff.FinalizationConsumer`
+// OnBlockIncorporated implements the `OnBlockIncorporated` callback from the [hotstuff.FinalizationConsumer]
 // CAUTION: the input to this callback is treated as trusted; precautions should be taken that messages
 // from external nodes cannot be considered as inputs to this function
 func (e *Engine) OnBlockIncorporated(incorporatedBlock *model.Block) {

--- a/engine/consensus/message_hub/message_hub.go
+++ b/engine/consensus/message_hub/message_hub.go
@@ -485,7 +485,7 @@ func (h *MessageHub) Process(channel channels.Channel, originID flow.Identifier,
 	return nil
 }
 
-// forwardToOwnVoteAggregator converts vote to generic `model.Vote`, logs vote and forwards it to own `voteAggregator`.
+// forwardToOwnVoteAggregator converts vote to generic [model.Vote], logs vote and forwards it to own `voteAggregator`.
 // Per API convention, timeoutAggregator` is non-blocking, hence, this call returns quickly.
 func (h *MessageHub) forwardToOwnVoteAggregator(vote *messages.BlockVote, originID flow.Identifier) {
 	h.engineMetrics.MessageReceived(metrics.EngineConsensusMessageHub, metrics.MessageBlockVote)

--- a/engine/consensus/sealing.go
+++ b/engine/consensus/sealing.go
@@ -3,7 +3,7 @@ package consensus
 import "github.com/onflow/flow-go/model/flow"
 
 // SealingCore processes incoming execution results and result approvals.
-// Accepts `flow.IncorporatedResult` to start processing approvals for particular result.
+// Accepts [flow.IncorporatedResult] to start processing approvals for particular result.
 // Whenever enough approvals are collected produces a candidate seal and adds it to the mempool.
 // Implementations of SealingCore are _concurrency safe_.
 type SealingCore interface {

--- a/engine/consensus/sealing/engine.go
+++ b/engine/consensus/sealing/engine.go
@@ -428,7 +428,7 @@ func (e *Engine) Done() <-chan struct{} {
 	})
 }
 
-// OnFinalizedBlock implements the `OnFinalizedBlock` callback from the `hotstuff.FinalizationConsumer`
+// OnFinalizedBlock implements the `OnFinalizedBlock` callback from the [hotstuff.FinalizationConsumer]
 // It informs sealing.Core about finalization of respective block.
 //
 // CAUTION: the input to this callback is treated as trusted; precautions should be taken that messages
@@ -437,7 +437,7 @@ func (e *Engine) OnFinalizedBlock(*model.Block) {
 	e.finalizationEventsNotifier.Notify()
 }
 
-// OnBlockIncorporated implements `OnBlockIncorporated` from the `hotstuff.FinalizationConsumer`
+// OnBlockIncorporated implements `OnBlockIncorporated` from the [hotstuff.FinalizationConsumer]
 // It processes all execution results that were incorporated in parent block payload.
 //
 // CAUTION: the input to this callback is treated as trusted; precautions should be taken that messages

--- a/engine/errors_test.go
+++ b/engine/errors_test.go
@@ -21,7 +21,7 @@ func TestCustomizedError(t *testing.T) {
 
 	require.True(t, IsInvalidInputError(err))
 
-	// if an invalid error is wrapped with `fmt.Errorf`, it
+	// if an invalid error is wrapped with [fmt.Errorf], it
 	// is still an invalid error
 	err = fmt.Errorf("could not process, because: %w", err)
 	require.True(t, IsInvalidInputError(err))

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -220,7 +220,7 @@ func (e *blockComputer) queueTransactionRequests(
 	collectionCtx := fvm.NewContextFromParent(
 		e.vmCtx,
 		fvm.WithBlockHeader(blockHeader),
-		// `protocol.Snapshot` implements `EntropyProvider` interface
+		// [protocol.Snapshot] implements `EntropyProvider` interface
 		// Note that `Snapshot` possible errors for RandomSource() are:
 		// - storage.ErrNotFound if the QC is unknown.
 		// - state.ErrUnknownSnapshotReference if the snapshot reference block is unknown
@@ -261,7 +261,7 @@ func (e *blockComputer) queueTransactionRequests(
 	systemCtx := fvm.NewContextFromParent(
 		e.systemChunkCtx,
 		fvm.WithBlockHeader(blockHeader),
-		// `protocol.Snapshot` implements `EntropyProvider` interface
+		// [protocol.Snapshot] implements `EntropyProvider` interface
 		// Note that `Snapshot` possible errors for RandomSource() are:
 		// - storage.ErrNotFound if the QC is unknown.
 		// - state.ErrUnknownSnapshotReference if the snapshot reference block is unknown

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -38,7 +38,7 @@ type ReadOnlyExecutionState interface {
 	GetHighestExecutedBlockID(context.Context) (uint64, flow.Identifier, error)
 }
 
-// ScriptExecutionState is a subset of the `state.ExecutionState` interface purposed to only access the state
+// ScriptExecutionState is a subset of the [state.ExecutionState] interface purposed to only access the state
 // used for script execution and not mutate the execution state of the blockchain.
 type ScriptExecutionState interface {
 	// NewStorageSnapshot creates a new ready-only view at the given block.

--- a/engine/execution/storehouse/in_memory_register_store.go
+++ b/engine/execution/storehouse/in_memory_register_store.go
@@ -208,7 +208,7 @@ func (s *InMemoryRegisterStore) getUpdatedRegisters(height uint64, blockID flow.
 // Prune prunes the register store to the given height
 // The pruned height must be an executed block, the caller should ensure that by calling SaveRegisters before.
 //
-// Pruning is done by walking up the finalized fork from `s.prunedHeight` to `height`. At each height, prune all
+// Pruning is done by walking up the finalized fork from [s.prunedHeight] to `height`. At each height, prune all
 // other forks that begin at that height. This ensures that data for all conflicting forks are freed
 //
 // TODO: It does not block the caller, the pruning work is done async

--- a/fvm/environment/program_recovery.go
+++ b/fvm/environment/program_recovery.go
@@ -416,7 +416,7 @@ func isNonFungibleTokenContract(program *ast.Program, nonFungibleTokenAddress co
 	return true
 }
 
-// isNonFungibleTokenNFTNominalType checks if the given type is a nominal type representing `NonFungibleToken.NFT`
+// isNonFungibleTokenNFTNominalType checks if the given type is a nominal type representing [NonFungibleToken.NFT]
 func isNonFungibleTokenNFTNominalType(ty ast.Type) bool {
 	nominalType, ok := ty.(*ast.NominalType)
 	return ok &&

--- a/fvm/environment/system_contracts.go
+++ b/fvm/environment/system_contracts.go
@@ -163,7 +163,7 @@ func (sys *SystemContracts) DeductTransactionFees(
 	)
 }
 
-// uses `FlowServiceAccount.setupNewAccount` from https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowServiceAccount.cdc
+// uses [FlowServiceAccount.setupNewAccount] from https://github.com/onflow/flow-core-contracts/blob/master/contracts/FlowServiceAccount.cdc
 var setupNewAccountSpec = ContractFunctionSpec{
 	AddressFromChain: ServiceAddress,
 	LocationName:     systemcontracts.ContractNameServiceAccount,

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -1546,9 +1546,9 @@ func TestDryRun(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
-				// Make sure that gas consumed from `EVM.dryRun` is bigger
+				// Make sure that gas consumed from [EVM.dryRun] is bigger
 				// than the actual gas consumption of the equivalent
-				// `EVM.run`.
+				// [EVM.run].
 				totalGas := emulator.AddOne64th(res.GasConsumed) + gethParams.SstoreSentryGasEIP2200
 				require.Equal(
 					t,
@@ -1680,9 +1680,9 @@ func TestDryRun(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
-				// Make sure that gas consumed from `EVM.dryRun` is bigger
+				// Make sure that gas consumed from [EVM.dryRun] is bigger
 				// than the actual gas consumption of the equivalent
-				// `EVM.run`.
+				// [EVM.run].
 				totalGas := emulator.AddOne64th(res.GasConsumed) + gethParams.SstoreSentryGasEIP2200
 				require.Equal(
 					t,
@@ -1812,9 +1812,9 @@ func TestDryRun(t *testing.T) {
 				require.NoError(t, err)
 				//require.Equal(t, types.StatusSuccessful, res.Status)
 				require.Equal(t, types.ErrCodeNoError, res.ErrorCode)
-				// Make sure that gas consumed from `EVM.dryRun` is bigger
+				// Make sure that gas consumed from [EVM.dryRun] is bigger
 				// than the actual gas consumption of the equivalent
-				// `EVM.run`.
+				// [EVM.run].
 				totalGas := emulator.AddOne64th(res.GasConsumed) + gethParams.SstoreSentryGasEIP2200 + gethParams.SstoreClearsScheduleRefundEIP3529
 				require.Equal(
 					t,

--- a/fvm/evm/types/handler.go
+++ b/fvm/evm/types/handler.go
@@ -10,7 +10,7 @@ import (
 //
 // There are two ways to interact with this environment:
 //
-// First, passing a signed transaction (EOA account) to the `EVM.run` Cadence function
+// First, passing a signed transaction (EOA account) to the [EVM.run] Cadence function
 // creates a new block, updates the internal merkle tree, and emits a new root hash.
 //
 // The Second way is through a new form of account called cadence-owned-accounts (COAs),

--- a/fvm/fvm_blockcontext_test.go
+++ b/fvm/fvm_blockcontext_test.go
@@ -250,7 +250,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 		require.NoError(t, output.Err)
 	})
 
-	t.Run("account with deployed contract has `contracts.names` filled", func(t *testing.T) {
+	t.Run("account with deployed contract has [contracts.names] filled", func(t *testing.T) {
 
 		// Create an account private key.
 		privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
@@ -288,7 +288,7 @@ func TestBlockContext_DeployContract(t *testing.T) {
 
 		snapshotTree = snapshotTree.Append(executionSnapshot)
 
-		// transaction will panic if `contracts.names` is incorrect
+		// transaction will panic if [contracts.names] is incorrect
 		txBody = flow.NewTransactionBody().
 			SetScript([]byte(`
 				transaction {

--- a/fvm/meter/interaction_meter.go
+++ b/fvm/meter/interaction_meter.go
@@ -92,8 +92,8 @@ func (m *InteractionMeter) MeterStorageWrite(
 
 // replaceWrite replaces the write size of a given key with the new size, because
 // only the last write of a given key is counted towards the total interaction limit.
-// These are the only write usages of `m.totalStorageBytesWritten` and `m.writes`,
-// which means that `m.totalStorageBytesWritten` can never become negative.
+// These are the only write usages of [m.totalStorageBytesWritten] and [m.writes],
+// which means that [m.totalStorageBytesWritten] can never become negative.
 // oldSize is always <= m.totalStorageBytesWritten.
 func (m *InteractionMeter) replaceWrite(
 	k flow.RegisterID,

--- a/fvm/runtime/wrapped_cadence_runtime.go
+++ b/fvm/runtime/wrapped_cadence_runtime.go
@@ -11,7 +11,7 @@ import (
 )
 
 // WrappedCadenceRuntime wraps cadence runtime to handle errors.
-// Errors from cadence runtime should be handled with `errors.HandleRuntimeError` before the FVM can understand them.
+// Errors from cadence runtime should be handled with [errors.HandleRuntimeError] before the FVM can understand them.
 // Handling all possible locations, where the error could be coming from, here,
 // makes it impossible to forget to handle the error.
 type WrappedCadenceRuntime struct {

--- a/fvm/script.go
+++ b/fvm/script.go
@@ -123,7 +123,7 @@ func newScriptExecutor(
 	proc *ScriptProcedure,
 	txnState storage.TransactionPreparer,
 ) *scriptExecutor {
-	// update `ctx.EnvironmentParams` with the script info before
+	// update [ctx.EnvironmentParams] with the script info before
 	// creating the executor
 	scriptInfo := environment.NewScriptInfoParams(proc.Script, proc.Arguments)
 	ctx.EnvironmentParams.SetScriptInfoParams(scriptInfo)

--- a/integration/dkg/dkg_emulator_suite.go
+++ b/integration/dkg/dkg_emulator_suite.go
@@ -404,7 +404,7 @@ func (s *EmulatorSuite) isDKGCompleted() bool {
 	return bool(value.(cadence.Bool))
 }
 
-// getParametersAndResult retrieves the DKG setup parameters (`flow.DKGIndexMap`) and the DKG result from the DKG white-board smart contract.
+// getParametersAndResult retrieves the DKG setup parameters ([flow.DKGIndexMap]) and the DKG result from the DKG white-board smart contract.
 func (s *EmulatorSuite) getParametersAndResult() (flow.DKGIndexMap, crypto.PublicKey, []crypto.PublicKey) {
 	res := s.executeScript(templates.GenerateGetDKGCanonicalFinalSubmissionScript(s.env), nil)
 	value := res.(cadence.Optional).Value

--- a/integration/tests/bft/base_orchestrator.go
+++ b/integration/tests/bft/base_orchestrator.go
@@ -13,7 +13,7 @@ import (
 type OnEgressEvent func(event *insecure.EgressEvent) error
 type OnIngressEvent func(event *insecure.IngressEvent) error
 
-// BaseOrchestrator represents a simple `insecure.AttackOrchestrator` that tracks messages. This attack orchestrator
+// BaseOrchestrator represents a simple [insecure.AttackOrchestrator] that tracks messages. This attack orchestrator
 // simply passes through messages without changes to the orchestrator network. This orchestrator reduces boilerplate
 // of BFT tests by implementing common logic. Boilerplate can further be reduced by using the OnEgressEvent and OnIngressEvent
 // fields to define callbacks that will be invoked on each event received, this removes the need to redefine the logger and send

--- a/integration/tests/bft/gossipsub/signature/requirement/orchestrator.go
+++ b/integration/tests/bft/gossipsub/signature/requirement/orchestrator.go
@@ -33,7 +33,7 @@ const (
 	numOfUnauthorizedEvents = 5
 )
 
-// Orchestrator represents a simple `insecure.AttackOrchestrator` that tracks any unsigned messages received by victim nodes as well as the typically expected messages.
+// Orchestrator represents a simple [insecure.AttackOrchestrator] that tracks any unsigned messages received by victim nodes as well as the typically expected messages.
 type Orchestrator struct {
 	*bft.BaseOrchestrator
 	codec                      network.Codec

--- a/integration/tests/bft/protocol/disallowlisting/orchestrator.go
+++ b/integration/tests/bft/protocol/disallowlisting/orchestrator.go
@@ -28,7 +28,7 @@ const (
 	numOfUnauthorizedEvents = 5
 )
 
-// Orchestrator represents a simple `insecure.AttackOrchestrator` that tracks messages received before and after the
+// Orchestrator represents a simple [insecure.AttackOrchestrator] that tracks messages received before and after the
 // senderVN is disallow-listed by the receiverEN via the admin disallow-list command.
 type Orchestrator struct {
 	*bft.BaseOrchestrator

--- a/ledger/complete/mtrie/flattener/iterator.go
+++ b/ledger/complete/mtrie/flattener/iterator.go
@@ -41,7 +41,7 @@ type NodeIterator struct {
 	//     - If `p` has only one child, this child must be `n`.
 	//       Therefore, by recalling `n`, we have recalled all ancestors of `p`.
 	//     - If `n` is the right child, we haven already searched through all of `p`
-	//       descendents (as the `p.LeftChild` must have been searched before)
+	//       descendents (as the [p.LeftChild] must have been searched before)
 	//       Therefore, by recalling `n`, we have recalled all ancestors of `p`
 	// Hence, it follows that the head of the stack always satisfies the
 	// Descendents-First-Relationship. As we search the trie in DFS manner, each

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -61,8 +61,8 @@ func getField[T cadence.Value](fields map[string]cadence.Value, fieldName string
 // convertServiceEventEpochSetup converts a service event encoded as the generic
 // flow.Event type to a ServiceEvent type for an EpochSetup event
 // CONVENTION: in the returned `EpochSetup` event,
-//   - Node identities listed in `EpochSetup.Participants` are in CANONICAL ORDER
-//   - for each cluster assignment (i.e. element in `EpochSetup.Assignments`), the nodeIDs are listed in CANONICAL ORDER
+//   - Node identities listed in [EpochSetup.Participants] are in CANONICAL ORDER
+//   - for each cluster assignment (i.e. element in [EpochSetup.Assignments]), the nodeIDs are listed in CANONICAL ORDER
 //
 // CAUTION: This function must only be used for input events computed locally, by an
 // Execution or Verification Node; it is not resilient to malicious inputs.

--- a/model/flow/assignment/sort.go
+++ b/model/flow/assignment/sort.go
@@ -4,7 +4,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// FromIdentifierLists creates a `flow.AssignmentList` with canonical ordering from
+// FromIdentifierLists creates a [flow.AssignmentList] with canonical ordering from
 // the given `identifierLists`.
 func FromIdentifierLists(identifierLists []flow.IdentifierList) flow.AssignmentList {
 	assignments := make(flow.AssignmentList, 0, len(identifierLists))

--- a/model/flow/dkg.go
+++ b/model/flow/dkg.go
@@ -15,7 +15,7 @@ const (
 	// DKGEndStateDKGFailure - the underlying DKG library reported an error.
 	DKGEndStateDKGFailure
 	// RandomBeaconKeyRecovered - this node has recovered its beacon key from a previous epoch.
-	// This occurs only for epochs which are entered through the EFM Recovery process (`flow.EpochRecover` service event).
+	// This occurs only for epochs which are entered through the EFM Recovery process ([flow.EpochRecover] service event).
 	RandomBeaconKeyRecovered
 )
 

--- a/model/flow/mapfunc/identity.go
+++ b/model/flow/mapfunc/identity.go
@@ -5,7 +5,7 @@ import (
 )
 
 // WithInitialWeight returns an anonymous function that assigns the given weight value
-// to `Identity.InitialWeight`. This function is primarily intended for testing, as
+// to [Identity.InitialWeight]. This function is primarily intended for testing, as
 // Identity structs should be immutable by convention.
 func WithInitialWeight(weight uint64) flow.IdentityMapFunc[flow.Identity] {
 	return func(identity flow.Identity) flow.Identity {
@@ -15,7 +15,7 @@ func WithInitialWeight(weight uint64) flow.IdentityMapFunc[flow.Identity] {
 }
 
 // WithEpochParticipationStatus returns an anonymous function that assigns the given epoch participation status value
-// to `Identity.EpochParticipationStatus`. This function is primarily intended for testing, as
+// to [Identity.EpochParticipationStatus]. This function is primarily intended for testing, as
 // Identity structs should be immutable by convention.
 func WithEpochParticipationStatus(status flow.EpochParticipationStatus) flow.IdentityMapFunc[flow.Identity] {
 	return func(identity flow.Identity) flow.Identity {

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -72,7 +72,7 @@ type EpochExtension struct {
 }
 
 // ID returns an identifier for this EpochStateContainer by hashing internal fields.
-// Per convention, the ID of a `nil` EpochStateContainer is `flow.ZeroID`.
+// Per convention, the ID of a `nil` EpochStateContainer is [flow.ZeroID].
 func (c *EpochStateContainer) ID() Identifier {
 	if c == nil {
 		return ZeroID
@@ -80,8 +80,8 @@ func (c *EpochStateContainer) ID() Identifier {
 	return MakeID(c)
 }
 
-// EventIDs returns the `flow.EventIDs` with the hashes of the EpochSetup and EpochCommit events.
-// Per convention, for a `nil` EpochStateContainer, we return `flow.ZeroID` for both events.
+// EventIDs returns the [flow.EventIDs] with the hashes of the EpochSetup and EpochCommit events.
+// Per convention, for a `nil` EpochStateContainer, we return [flow.ZeroID] for both events.
 func (c *EpochStateContainer) EventIDs() EventIDs {
 	if c == nil {
 		return EventIDs{ZeroID, ZeroID}
@@ -91,7 +91,7 @@ func (c *EpochStateContainer) EventIDs() EventIDs {
 
 // Copy returns a full copy of the entry.
 // Embedded Identities are deep-copied, _except_ for their keys, which are copied by reference.
-// Per convention, the ID of a `nil` EpochStateContainer is `flow.ZeroID`.
+// Per convention, the ID of a `nil` EpochStateContainer is [flow.ZeroID].
 func (c *EpochStateContainer) Copy() *EpochStateContainer {
 	if c == nil {
 		return nil
@@ -152,7 +152,7 @@ func NewEpochStateEntry(
 		NextEpochCommit:     nextEpochCommit,
 	}
 
-	// If previous epoch is specified: ensure respective epoch service events are not nil and consistent with commitments in `MinEpochStateEntry.PreviousEpoch`
+	// If previous epoch is specified: ensure respective epoch service events are not nil and consistent with commitments in [MinEpochStateEntry.PreviousEpoch]
 	if epochState.PreviousEpoch != nil {
 		if epochState.PreviousEpoch.SetupID != previousEpochSetup.ID() { // calling ID() will panic is EpochSetup event is nil
 			return nil, fmt.Errorf("supplied previous epoch's setup event (%x) does not match commitment (%x) in MinEpochStateEntry", previousEpochSetup.ID(), epochState.PreviousEpoch.SetupID)
@@ -169,7 +169,7 @@ func NewEpochStateEntry(
 		}
 	}
 
-	// For current epoch: ensure respective epoch service events are not nil and consistent with commitments in `MinEpochStateEntry.CurrentEpoch`
+	// For current epoch: ensure respective epoch service events are not nil and consistent with commitments in [MinEpochStateEntry.CurrentEpoch]
 	if epochState.CurrentEpoch.SetupID != currentEpochSetup.ID() { // calling ID() will panic is EpochSetup event is nil
 		return nil, fmt.Errorf("supplied current epoch's setup event (%x) does not match commitment (%x) in MinEpochStateEntry", currentEpochSetup.ID(), epochState.CurrentEpoch.SetupID)
 	}
@@ -183,7 +183,7 @@ func NewEpochStateEntry(
 	// Otherwise, we are in epoch setup or epoch commit phase (i.e. epochState.NextEpoch ≠ nil):
 	//  (2a) Full identity table contains active identities from current epoch + nodes joining in next epoch with `EpochParticipationStatusJoining` status.
 	//  (2b) Furthermore, we also build the full identity table for the next epoch's staking phase:
-	//       active identities from next epoch + nodes from current epoch that are leaving at the end of the current epoch with `flow.EpochParticipationStatusLeaving` status.
+	//       active identities from next epoch + nodes from current epoch that are leaving at the end of the current epoch with [flow.EpochParticipationStatusLeaving] status.
 	nextEpoch := epochState.NextEpoch
 	if nextEpoch == nil { // in staking phase: build full identity table for current epoch according to (1)
 		if nextEpochSetup != nil {
@@ -193,7 +193,7 @@ func NewEpochStateEntry(
 			return nil, fmt.Errorf("no next epoch but gotten non-nil EpochCommit event")
 		}
 	} else { // epochState.NextEpoch ≠ nil, i.e. we are in epoch setup or epoch commit phase
-		// ensure respective epoch service events are not nil and consistent with commitments in `MinEpochStateEntry.NextEpoch`
+		// ensure respective epoch service events are not nil and consistent with commitments in [MinEpochStateEntry.NextEpoch]
 		if nextEpoch.SetupID != nextEpochSetup.ID() {
 			return nil, fmt.Errorf("supplied next epoch's setup event (%x) does not match commitment (%x) in MinEpochStateEntry", nextEpoch.SetupID, nextEpochSetup.ID())
 		}
@@ -250,7 +250,7 @@ func NewRichEpochStateEntry(
 	// Otherwise, we are in epoch setup or epoch commit phase (i.e. epochState.NextEpoch ≠ nil):
 	//  (2a) Full identity table contains active identities from current epoch + nodes joining in next epoch with status `EpochParticipationStatusJoining`.
 	//  (2b) Furthermore, we also build the full identity table for the next epoch's staking phase:
-	//       active identities from next epoch + nodes from current epoch that are leaving at the end of the current epoch with `flow.EpochParticipationStatusLeaving` status.
+	//       active identities from next epoch + nodes from current epoch that are leaving at the end of the current epoch with [flow.EpochParticipationStatusLeaving] status.
 	var err error
 	nextEpoch := epochState.NextEpoch
 	if nextEpoch == nil { // in staking phase: build full identity table for current epoch according to (1)
@@ -375,7 +375,7 @@ func (e *EpochStateEntry) CurrentEpochFinalView() uint64 {
 // The receiver MinEpochStateEntry must be properly constructed.
 // See flow.EpochPhase for detailed documentation.
 func (e *MinEpochStateEntry) EpochPhase() EpochPhase {
-	// CAUTION: the logic below that deduces the EpochPhase must be consistent with `epochs.FallbackStateMachine`,
+	// CAUTION: the logic below that deduces the EpochPhase must be consistent with [epochs.FallbackStateMachine],
 	// which sets the fields we are using here. Specifically, we require that the FallbackStateMachine clears out
 	// any tentative values for a subsequent epoch _unless_ that epoch is already committed.
 	if e.EpochFallbackTriggered {
@@ -502,7 +502,7 @@ func BuildIdentityTable(
 		return nil, fmt.Errorf("could not reconstruct participants for adjacent epoch: %w", err)
 	}
 
-	// Combine the participants of the current and adjacent epoch. The method `GenericIdentityList.Union`
+	// Combine the participants of the current and adjacent epoch. The method [GenericIdentityList.Union]
 	// already implements the following required conventions:
 	//  1. Preference for IdentitySkeleton of the target epoch:
 	//     In case an IdentitySkeleton with the same NodeID exists in the target epoch as well as
@@ -527,7 +527,7 @@ func DynamicIdentityEntryListFromIdentities(identities IdentityList) DynamicIden
 // ComposeFullIdentities combines identity skeletons and dynamic identities to produce a flow.IdentityList.
 // It enforces that the input slices `skeletons` and `dynamics` list the same identities (compared by nodeID)
 // in the same order. Otherwise, an exception is returned. For each identity i, we set
-// `i.EpochParticipationStatus` to the `defaultEpochParticipationStatus` _unless_ i is ejected.
+// [i.EpochParticipationStatus] to the `defaultEpochParticipationStatus` _unless_ i is ejected.
 // No errors are expected during normal operations.
 func ComposeFullIdentities(
 	skeletons IdentitySkeletonList,

--- a/model/flow/quorum_certificate.go
+++ b/model/flow/quorum_certificate.go
@@ -31,7 +31,7 @@ func (qc *QuorumCertificate) ID() Identifier {
 }
 
 // QuorumCertificateWithSignerIDs is a QuorumCertificate, where the signing nodes are
-// identified via their `flow.Identifier`s instead of indices. Working with IDs as opposed to
+// identified via their [flow.Identifier]s instead of indices. Working with IDs as opposed to
 // indices is less efficient, but simpler, because we don't require a canonical node order.
 // It is used for bootstrapping new Epochs, because the FlowEpoch smart contract has no
 // notion of node ordering.

--- a/model/flow/version_beacon.go
+++ b/model/flow/version_beacon.go
@@ -169,7 +169,7 @@ func (v *VersionBeacon) String() string {
 // NOTE: A ProtocolStateVersionUpgrade event `E` is accepted while processing block `B`
 // which seals `E` if and only if E.ActiveView > B.View + SafetyThreshold.
 // SafetyThreshold is a protocol parameter set so that it is overwhelmingly likely that
-// block `B` is finalized (ergo the protocol version switch at the specified view `E.ActiveView`)
+// block `B` is finalized (ergo the protocol version switch at the specified view [E.ActiveView])
 // within any stretch of SafetyThreshold-many views.
 // TODO: This concept mirrors `FinalizationSafetyThreshold` and `versionBoundaryFreezePeriod`
 // These parameters should be consolidated.

--- a/module/chunks/chunkVerifier.go
+++ b/module/chunks/chunkVerifier.go
@@ -59,7 +59,7 @@ func (fcv *ChunkVerifier) Verify(
 		ctx = fvm.NewContextFromParent(
 			fcv.systemChunkCtx,
 			fvm.WithBlockHeader(vc.Header),
-			// `protocol.Snapshot` implements `EntropyProvider` interface
+			// [protocol.Snapshot] implements `EntropyProvider` interface
 			// Note that `Snapshot` possible errors for RandomSource() are:
 			// - storage.ErrNotFound if the QC is unknown.
 			// - state.ErrUnknownSnapshotReference if the snapshot reference block is unknown
@@ -80,7 +80,7 @@ func (fcv *ChunkVerifier) Verify(
 		ctx = fvm.NewContextFromParent(
 			fcv.vmCtx,
 			fvm.WithBlockHeader(vc.Header),
-			// `protocol.Snapshot` implements `EntropyProvider` interface
+			// [protocol.Snapshot] implements `EntropyProvider` interface
 			// Note that `Snapshot` possible errors for RandomSource() are:
 			// - storage.ErrNotFound if the QC is unknown.
 			// - state.ErrUnknownSnapshotReference if the snapshot reference block is unknown
@@ -170,7 +170,7 @@ func (fcv *ChunkVerifier) verifyTransactionsInContext(
 
 	// Consensus nodes already enforce some fundamental properties of ExecutionResults:
 	//   1. The result contains the correct number of chunks (compared to the block it pertains to).
-	//   2. The result contains chunks with strictly monotonically increasing `Chunk.Index` starting with index 0
+	//   2. The result contains chunks with strictly monotonically increasing [Chunk.Index] starting with index 0
 	//   3. for each chunk, the consistency requirement `Chunk.Index == Chunk.CollectionIndex` holds
 	// See `module/validation/receiptValidator` for implementation, which is used by the consensus nodes.
 	// And issue https://github.com/dapperlabs/flow-go/issues/6864 for implementing 3.

--- a/module/dkg.go
+++ b/module/dkg.go
@@ -32,7 +32,7 @@ type DKGContractClient interface {
 	// messages for that phase.
 	ReadBroadcast(fromIndex uint, referenceBlock flow.Identifier) ([]messages.BroadcastDKGMessage, error)
 
-	// SubmitParametersAndResult posts the DKG setup parameters (`flow.DKGIndexMap`) and the node's locally-computed DKG result to
+	// SubmitParametersAndResult posts the DKG setup parameters ([flow.DKGIndexMap]) and the node's locally-computed DKG result to
 	// the DKG white-board smart contract. The DKG result are the group public key and the node's local computation of the public
 	// keys for each DKG participant. Serialized public keys are encoded as hex.
 	// Conceptually the flow.DKGIndexMap is not and output of the DKG protocol. Rather, it is part of the configuration/initialization

--- a/module/dkg/client.go
+++ b/module/dkg/client.go
@@ -79,7 +79,7 @@ func (c *Client) ReadBroadcast(fromIndex uint, referenceBlock flow.Identifier) (
 	}
 	values := value.(cadence.Array).Values
 
-	// unpack return from contract to `model.DKGMessage`
+	// unpack return from contract to [model.DKGMessage]
 	messages := make([]model.BroadcastDKGMessage, 0, len(values))
 	for _, val := range values {
 		fields := cadence.FieldsMappedByName(val.(cadence.Struct))
@@ -180,7 +180,7 @@ func (c *Client) Broadcast(msg model.BroadcastDKGMessage) error {
 	return nil
 }
 
-// SubmitParametersAndResult posts the DKG setup parameters (`flow.DKGIndexMap`) and the node's locally-computed DKG result to
+// SubmitParametersAndResult posts the DKG setup parameters ([flow.DKGIndexMap]) and the node's locally-computed DKG result to
 // the DKG white-board smart contract. The DKG result are the group public key and the node's local computation of the public
 // keys for each DKG participant. Serialized public keys are encoded as hex.
 // Conceptually the flow.DKGIndexMap is not and output of the DKG protocol. Rather, it is part of the configuration/initialization

--- a/module/dkg/recovery.go
+++ b/module/dkg/recovery.go
@@ -107,13 +107,13 @@ func (b *BeaconKeyRecovery) recoverMyBeaconPrivateKey(final protocol.Snapshot) e
 		Logger()
 	// Only when the next epoch is committed, Random Beacon keys for that epoch's consensus participants are finally persisted
 	// in `localDKGState`. It is important to wait until this point, so each node can locally check whether their private key
-	// is consistent with its respective entry in the public key vector `EpochCommit.DKGParticipantKeys` (assuming the node
+	// is consistent with its respective entry in the public key vector [EpochCommit.DKGParticipantKeys] (assuming the node
 	// concluded the DKG). This mechanic is identical to the happy path (`EpochCommit` event emitted by Epoch System Smart
 	// Contract) and the recovery epoch (`EpochCommit` event part of `EpochRecover` event, whose content is effectively
 	// provided by the human governance committee).
 	// The next epoch *not yet* being committed is only possible on the happy path, when the node boots up and checks
 	// that it hasn't lost a `FallbackModeExited` notification. However, when observing the `EpochFallbackModeExited`
-	// notification, the Epoch Phase *must* be `flow.EpochPhaseCommitted`, otherwise the state is corrupted.
+	// notification, the Epoch Phase *must* be [flow.EpochPhaseCommitted], otherwise the state is corrupted.
 	// Diligently verifying this case is important to avoid a situation where the node runs into the next epoch and failes
 	// to access its Random Beacon key, just because this recovery here has failed before.
 	if epochProtocolState.EpochPhase() != flow.EpochPhaseCommitted {

--- a/module/epochs/epoch_lookup.go
+++ b/module/epochs/epoch_lookup.go
@@ -68,7 +68,7 @@ func (cache *epochRangeCache) extendLatestEpoch(epochCounter uint64, extension f
 		return nil
 	}
 
-	// sanity check: `extension.FinalView` should be greater than final view of latest epoch
+	// sanity check: [extension.FinalView] should be greater than final view of latest epoch
 	if latestEpoch.finalView > extension.FinalView {
 		return fmt.Errorf(invalidExtensionFinalView, latestEpoch.finalView, extension.FinalView)
 	}

--- a/module/epochs/epoch_lookup_test.go
+++ b/module/epochs/epoch_lookup_test.go
@@ -211,7 +211,7 @@ func (suite *EpochLookupSuite) TestProtocolEvents_EpochExtended_SanityChecks() {
 		return ctx
 	}
 
-	suite.T().Run("sanity check: `extension.FinalView` should be greater than final view of latest epoch", func(t *testing.T) {
+	suite.T().Run("sanity check: [extension.FinalView] should be greater than final view of latest epoch", func(t *testing.T) {
 		// initially, only current epoch is committed
 		suite.CommitEpochs(suite.prevEpoch, suite.currEpoch)
 		ctx := initAndStartLookup()

--- a/module/epochs/qc_voter_test.go
+++ b/module/epochs/qc_voter_test.go
@@ -144,7 +144,7 @@ func (suite *Suite) TestCancelVoting() {
 	go func() {
 		err := suite.voter.Vote(ctxWithCancel, suite.epoch)
 		suite.Assert().Error(err, "when canceling voting process, Vote method should return with an error")
-		suite.Assert().ErrorIs(err, context.Canceled, "`context.Canceled` should be in the error trace")
+		suite.Assert().ErrorIs(err, context.Canceled, "[context.Canceled] should be in the error trace")
 		suite.Assert().True(epochs.IsClusterQCNoVoteError(err), "got error of unexpected type")
 		close(voteReturned)
 	}()

--- a/module/grpcserver/server.go
+++ b/module/grpcserver/server.go
@@ -18,7 +18,7 @@ import (
 	"github.com/onflow/flow-go/module/irrecoverable"
 )
 
-// GrpcServer wraps `grpc.Server` and allows to manage it using `component.Component` interface. It can be injected
+// GrpcServer wraps [grpc.Server] and allows to manage it using [component.Component] interface. It can be injected
 // into different engines making it possible to use single grpc server for multiple services which live in different modules.
 type GrpcServer struct {
 	component.Component

--- a/module/grpcserver/server_builder.go
+++ b/module/grpcserver/server_builder.go
@@ -75,7 +75,7 @@ func NewGrpcServerBuilder(log zerolog.Logger,
 
 	// we use an atomic pointer to setup an interceptor for handling irrecoverable errors, the necessity of this approach
 	// is dictated by complex startup order of grpc server and other services. At the point where we need to register
-	// an interceptor we don't have an `irrecoverable.SignalerContext`, it becomes available only when we start
+	// an interceptor we don't have an [irrecoverable.SignalerContext], it becomes available only when we start
 	// the server but at that point we can't register interceptors anymore, so we inject it using this approach.
 	signalerCtx := atomic.NewPointer[irrecoverable.SignalerContext](nil)
 

--- a/module/id/custom_provider.go
+++ b/module/id/custom_provider.go
@@ -4,7 +4,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// CustomIdentifierProvider implements `module.IdentifierProvider` which provides results from the given function.
+// CustomIdentifierProvider implements [module.IdentifierProvider] which provides results from the given function.
 type CustomIdentifierProvider struct {
 	identifiers func() flow.IdentifierList
 }

--- a/module/id_provider.go
+++ b/module/id_provider.go
@@ -14,7 +14,7 @@ type IdentifierProvider interface {
 
 // IdentityProvider provides an interface to get a list of Identities representing
 // the set of participants in the Flow protocol. CAUTION: return values will include
-// ejected nodes, so callers must check the `Identity.Ejected` flag.
+// ejected nodes, so callers must check the [Identity.Ejected] flag.
 type IdentityProvider interface {
 	// Identities returns the full identities of _all_ nodes currently known to the
 	// protocol that pass the provided filter. Caution, this includes ejected nodes.

--- a/module/irrecoverable/exception.go
+++ b/module/irrecoverable/exception.go
@@ -9,8 +9,8 @@ import (
 // function's interface.
 //
 // It wraps an error, which could be a sentinel error. IT does NOT IMPLEMENT an UNWRAP method,
-// so the enclosed error's type cannot be accessed. Therefore, methods such as `errors.As` and
-// `errors.Is` do not detect the exception as any known sentinel error.
+// so the enclosed error's type cannot be accessed. Therefore, methods such as [errors.As] and
+// [errors.Is] do not detect the exception as any known sentinel error.
 // NOTE: this type is private, because checking for an exception (as opposed to checking for the
 // set of expected error types) is considered an anti-pattern because it may miss unexpected
 // errors which are not implemented as an exception.

--- a/module/irrecoverable/irrecoverable.go
+++ b/module/irrecoverable/irrecoverable.go
@@ -48,7 +48,7 @@ type SignalerContext interface {
 	sealed()         // private, to constrain builder to using WithSignaler
 }
 
-// SignalerContextKey represents the key type for retrieving a SignalerContext from a value `context.Context`.
+// SignalerContextKey represents the key type for retrieving a SignalerContext from a value [context.Context].
 type SignalerContextKey struct{}
 
 // private, to force context derivation / WithSignaler
@@ -65,7 +65,7 @@ func WithSignaler(parent context.Context) (SignalerContext, <-chan error) {
 	return &signalerCtx{parent, sig}, errChan
 }
 
-// WithSignalerContext wraps `SignalerContext` using `context.WithValue` so it can later be used with `Throw`.
+// WithSignalerContext wraps `SignalerContext` using [context.WithValue] so it can later be used with `Throw`.
 func WithSignalerContext(parent context.Context, ctx SignalerContext) context.Context {
 	return context.WithValue(parent, SignalerContextKey{}, ctx)
 }

--- a/module/mempool/consensus/incorporated_result_seals.go
+++ b/module/mempool/consensus/incorporated_result_seals.go
@@ -11,7 +11,7 @@ import (
 
 // IncorporatedResultSeals implements the incorporated result seals memory pool
 // of the consensus nodes.
-// ATTENTION: this is a temporary wrapper for `mempool.IncorporatedResultSeals`
+// ATTENTION: this is a temporary wrapper for [mempool.IncorporatedResultSeals]
 // to enforce that there are at least 2 receipts from _different_ ENs
 // committing to the same incorporated result.
 // This wrapper should only be used with `Core`.

--- a/module/mempool/stdmap/eject.go
+++ b/module/mempool/stdmap/eject.go
@@ -24,7 +24,7 @@ const overCapacityThreshold = 128
 //     keep the mempool size within the desired limit.
 //   - The ejector _might_ (for performance reasons) retain more elements in the
 //     mempool than the targeted capacity.
-//   - The ejector _must_ notify the `Backend.ejectionCallbacks` for _each_
+//   - The ejector _must_ notify the [Backend.ejectionCallbacks] for _each_
 //     element it removes from the mempool.
 //   - Implementations do _not_ need to be concurrency safe. The Backend handles
 //     concurrency (specifically, it locks the mempool during ejection).

--- a/module/receipt_validator.go
+++ b/module/receipt_validator.go
@@ -15,7 +15,7 @@ type ReceiptValidator interface {
 	//   - execution result has a valid parent and satisfies the subgraph check
 	//
 	// In order to validate a receipt, both the executed block and the parent result
-	// referenced in `receipt.ExecutionResult` must be known. We return nil if all checks
+	// referenced in [receipt.ExecutionResult] must be known. We return nil if all checks
 	// pass successfully.
 	//
 	// Expected errors during normal operations:

--- a/module/requester.go
+++ b/module/requester.go
@@ -8,7 +8,7 @@ type Requester interface {
 	// EntityByID will request an entity through the request engine backing
 	// the interface. The additional selector will be applied to the subset
 	// of valid providers for the entity and allows finer-grained control
-	// over which providers to request a given entity from. Use `filter.Any`
+	// over which providers to request a given entity from. Use [filter.Any]
 	// if no additional restrictions are required. Data integrity of response
 	// will be checked upon arrival. This function should be used for requesting
 	// entites by their IDs.

--- a/module/sdk.go
+++ b/module/sdk.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/onflow/flow-go-sdk"
 )
 
-// SDKClientWrapper is a temporary solution to mocking the `sdk.Client` interface from `flow-go-sdk`
+// SDKClientWrapper is a temporary solution to mocking the [sdk.Client] interface from `flow-go-sdk`
 type SDKClientWrapper interface {
 	GetAccount(context.Context, sdk.Address) (*sdk.Account, error)
 	GetAccountAtLatestBlock(context.Context, sdk.Address) (*sdk.Account, error)

--- a/module/signature/aggregation.go
+++ b/module/signature/aggregation.go
@@ -185,7 +185,7 @@ func (s *SignatureAggregatorSameMessage) Aggregate() ([]int, crypto.Signature, e
 		return s.cachedSignerIndices, s.cachedSignature, nil
 	}
 
-	// compute aggregation result and cache it in `s.cachedSignerIndices`, `s.cachedSignature`
+	// compute aggregation result and cache it in [s.cachedSignerIndices], [s.cachedSignature]
 	sharesNum := len(s.indexToSignature)
 	indices := make([]int, 0, sharesNum)
 	signatures := make([]crypto.Signature, 0, sharesNum)
@@ -234,7 +234,7 @@ func (s *SignatureAggregatorSameMessage) Aggregate() ([]int, crypto.Signature, e
 //   - (true, agg_key, nil): signature is valid
 //   - (false, agg_key, nil): signature is cryptographically invalid. This also includes the case where
 //     `agg_key` is equal to the identity public key (because of equivocation). If the caller needs to
-//     differentiate this case, `crypto.IsIdentityPublicKey` can be used to test the returned `agg_key`
+//     differentiate this case, [crypto.IsIdentityPublicKey] can be used to test the returned `agg_key`
 //   - (false, nil, err) with error types:
 //     -- InsufficientSignaturesError if no signer indices are given (`signers` is empty)
 //     -- InvalidSignerIdxError if some signer indices are out of bound

--- a/module/state_synchronization/requester/execution_data_requester.go
+++ b/module/state_synchronization/requester/execution_data_requester.go
@@ -223,8 +223,8 @@ func New(
 	// To know what's the height of the next un-processed consecutive height, it reads the latest
 	// consecutive height in `processedNotifications`. And it's persisted in storage to be crash-resistant.
 	// When a new consecutive height is available, it calls `processNotificationJob` to notify all the
-	// `e.consumers`.
-	// Note: the `e.consumers` will be guaranteed to receive at least one `OnExecutionDataFetched` event
+	// [e.consumers].
+	// Note: the [e.consumers] will be guaranteed to receive at least one `OnExecutionDataFetched` event
 	// for each sealed block in consecutive block height order.
 	e.notificationConsumer, err = jobqueue.NewComponentConsumer(
 		e.log.With().Str("module", "notification_consumer").Logger(),

--- a/module/validation/receipt_validator.go
+++ b/module/validation/receipt_validator.go
@@ -85,7 +85,7 @@ func (v *receiptValidator) verifyChunksFormat(result *flow.ExecutionResult) erro
 	// For a block containing k collections, the Flow protocol prescribes that a valid execution result
 	// must contain k+1 chunks. Specifically, we have one chunk per collection plus the system chunk.
 	// The system chunk must exist, even if block payload itself is empty.
-	index, err := v.index.ByBlockID(result.BlockID) // returns `storage.ErrNotFound` for unknown BlockID
+	index, err := v.index.ByBlockID(result.BlockID) // returns [storage.ErrNotFound] for unknown BlockID
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return module.NewUnknownBlockError("could not find payload index for executed block %v: %w", result.BlockID, err)
@@ -107,7 +107,7 @@ func (v *receiptValidator) verifyChunksFormat(result *flow.ExecutionResult) erro
 //   - engine.InvalidInputError if result does not form a valid sub-graph
 //   - module.UnknownBlockError when the executed block is unknown
 func (v *receiptValidator) subgraphCheck(result *flow.ExecutionResult, prevResult *flow.ExecutionResult) error {
-	block, err := v.state.AtBlockID(result.BlockID).Head() // returns `storage.ErrNotFound` for unknown BlockID
+	block, err := v.state.AtBlockID(result.BlockID).Head() // returns [storage.ErrNotFound] for unknown BlockID
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return module.NewUnknownBlockError("executed block %v unknown: %w", result.BlockID, err)
@@ -154,7 +154,7 @@ func (v *receiptValidator) resultChainCheck(result *flow.ExecutionResult, prevRe
 //   - execution result has a valid parent and satisfies the subgraph check
 //
 // In order to validate a receipt, both the executed block and the parent result
-// referenced in `receipt.ExecutionResult` must be known. We return nil if all checks
+// referenced in [receipt.ExecutionResult] must be known. We return nil if all checks
 // pass successfully.
 //
 // Expected errors during normal operations:
@@ -165,7 +165,7 @@ func (v *receiptValidator) resultChainCheck(result *flow.ExecutionResult, prevRe
 // All other error are potential symptoms critical internal failures, such as bugs or state corruption.
 func (v *receiptValidator) Validate(receipt *flow.ExecutionReceipt) error {
 	parentResult, err := v.results.ByID(receipt.ExecutionResult.PreviousResultID)
-	if err != nil { // we expect `storage.ErrNotFound` in case parent result is unknown; any other error is unexpected, critical failure
+	if err != nil { // we expect [storage.ErrNotFound] in case parent result is unknown; any other error is unexpected, critical failure
 		if errors.Is(err, storage.ErrNotFound) {
 			return module.NewUnknownResultError("parent result %v unknown: %w", receipt.ExecutionResult.PreviousResultID, err)
 		}
@@ -322,7 +322,7 @@ func (v *receiptValidator) ValidatePayload(candidate *flow.Block) error {
 		if _, forBlockOnFork := forkBlocks[result.BlockID]; !forBlockOnFork {
 			return engine.NewInvalidInputErrorf("results %v at index %d is for block not on fork (%x)", resultID, i, result.BlockID)
 		}
-		// Reaching the following code implies that the executed block with ID `result.BlockID` is known to the protocol state, i.e. well formed.
+		// Reaching the following code implies that the executed block with ID [result.BlockID] is known to the protocol state, i.e. well formed.
 
 		// validate result
 		err = v.validateResult(result, prevResult)

--- a/module/validation/receipt_validator_test.go
+++ b/module/validation/receipt_validator_test.go
@@ -60,7 +60,7 @@ func (s *ReceiptValidationSuite) TestReceiptValid() {
 	s.publicKey.AssertExpectations(s.T())
 }
 
-// TestReceiptNoIdentity tests that we reject receipt with invalid `ExecutionResult.ExecutorID`
+// TestReceiptNoIdentity tests that we reject receipt with invalid [ExecutionResult.ExecutorID]
 // Note: for a receipt with a bad `ExecutorID`, we should never get to validating the signature,
 // because there is no valid identity, where we can retrieve a staking signature from.
 func (s *ReceiptValidationSuite) TestReceiptNoIdentity() {
@@ -280,8 +280,8 @@ func (s *ReceiptValidationSuite) TestReceiptInvalidCollectionIndex() {
 }
 
 // TestReceiptNoPreviousResult tests that `Validate` rejects a receipt, whose parent result is unknown:
-// - per API contract it should return a `module.UnknownResultError`
-// - should _not_ be misinterpreted as an invalid receipt, i.e. should not receive an `engine.InvalidInputError`
+// - per API contract it should return a [module.UnknownResultError]
+// - should _not_ be misinterpreted as an invalid receipt, i.e. should not receive an [engine.InvalidInputError]
 func (s *ReceiptValidationSuite) TestReceiptNoPreviousResult() {
 	valSubgrph := s.ValidSubgraphFixture()
 	// invalidate prev execution result, it will result in failing to lookup
@@ -938,8 +938,8 @@ func (s *ReceiptValidationSuite) TestValidateReceiptResultHasEnoughReceipts() {
 }
 
 // TestReceiptNoBlock tests that the validator rejects a receipt, whose executed block is unknown:
-//   - per API contract it should return a `module.UnknownBlockError`
-//   - should _not_ be misinterpreted as an invalid receipt, i.e. should not receive an `engine.InvalidInputError`
+//   - per API contract it should return a [module.UnknownBlockError]
+//   - should _not_ be misinterpreted as an invalid receipt, i.e. should not receive an [engine.InvalidInputError]
 func (s *ReceiptValidationSuite) TestReceiptNoBlock() {
 	s.publicKey.On("Verify", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Maybe()
 
@@ -954,13 +954,13 @@ func (s *ReceiptValidationSuite) TestReceiptNoBlock() {
 			unittest.WithPreviousResult(*s.LatestExecutionResult)), // known parent result
 		)) // but the ID of the executed block is randomly chosen, i.e. unknown
 
-	// attempting to validate receipt `r` should fail with an `module.UnknownBlockError`
+	// attempting to validate receipt `r` should fail with an [module.UnknownBlockError]
 	err := s.receiptValidator.Validate(r)
 	s.Require().Error(err, "should reject invalid receipt")
 	s.Assert().True(module.IsUnknownBlockError(err), err)
 	s.Assert().False(engine.IsInvalidInputError(err), err)
 
-	// attempting to validate a block, whose payload contains receipt `r` should fail with an `module.UnknownBlockError`
+	// attempting to validate a block, whose payload contains receipt `r` should fail with an [module.UnknownBlockError]
 	candidate := unittest.BlockWithParentFixture(unknownExecutedBlock.Header)
 	candidate.SetPayload(unittest.PayloadFixture(unittest.WithReceipts(r)))
 	err = s.receiptValidator.ValidatePayload(candidate)

--- a/network/blob_service.go
+++ b/network/blob_service.go
@@ -28,7 +28,7 @@ type BlobGetter interface {
 
 // BlobService is a hybrid blob datastore. It stores data in a local
 // datastore and may retrieve data from a remote Exchange.
-// It uses an internal `datastore.Datastore` instance to store values.
+// It uses an internal [datastore.Datastore] instance to store values.
 type BlobService interface {
 	component.Component
 	BlobGetter

--- a/network/p2p/cache/node_blocklist_wrapper.go
+++ b/network/p2p/cache/node_blocklist_wrapper.go
@@ -24,13 +24,13 @@ func (s IdentifierSet) Contains(id flow.Identifier) bool {
 	return found
 }
 
-// NodeDisallowListingWrapper is a wrapper for an `module.IdentityProvider` instance, where the
+// NodeDisallowListingWrapper is a wrapper for an [module.IdentityProvider] instance, where the
 // wrapper overrides the `Ejected` flag to true for all NodeIDs in a `disallowList`.
 // To avoid modifying the source of the identities, the wrapper creates shallow copies
 // of the identities (whenever necessary) and modifies the `Ejected` flag only in
 // the copy.
 // The `NodeDisallowListingWrapper` internally represents the `disallowList` as a map, to enable
-// performant lookup. However, the exported API works with `flow.IdentifierList` for
+// performant lookup. However, the exported API works with [flow.IdentifierList] for
 // disallowList, as this is a broadly supported data structure which lends itself better
 // to config or command-line inputs.
 // When a node is disallow-listed, the networking layer connection to that node is closed and no
@@ -134,7 +134,7 @@ func (w *NodeDisallowListingWrapper) Identities(filter flow.IdentityFilter[flow.
 		return identities
 	}
 
-	// Iterate over all returned identities and set the `EpochParticipationStatus` to `flow.EpochParticipationStatusEjected`.
+	// Iterate over all returned identities and set the `EpochParticipationStatus` to [flow.EpochParticipationStatusEjected].
 	// We copy both the return slice and identities of blocked nodes to avoid
 	// any possibility of accidentally modifying the wrapped IdentityProvider
 	idtx := make(flow.IdentityList, 0, len(identities))
@@ -182,7 +182,7 @@ func (w *NodeDisallowListingWrapper) setEjectedIfBlocked(identity *flow.Identity
 	}
 
 	// For blocked nodes, we want to return their `Identity` with the `EpochParticipationStatus`
-	// set to `flow.EpochParticipationStatusEjected`.
+	// set to [flow.EpochParticipationStatusEjected].
 	// Caution: we need to copy the `Identity` before we override `EpochParticipationStatus`, as we
 	// would otherwise potentially change the wrapped IdentityProvider.
 	var i = *identity // shallow copy is sufficient, because `EpochParticipationStatus` is a value type in DynamicIdentity which is also a value type.

--- a/network/p2p/cache/node_blocklist_wrapper_test.go
+++ b/network/p2p/cache/node_blocklist_wrapper_test.go
@@ -46,7 +46,7 @@ func TestNodeDisallowListWrapperTestSuite(t *testing.T) {
 }
 
 // TestHonestNode verifies:
-// For nodes _not_ on the disallowList, the `cache.NodeDisallowListingWrapper` should forward
+// For nodes _not_ on the disallowList, the [cache.NodeDisallowListingWrapper] should forward
 // the identities from the wrapped `IdentityProvider` without modification.
 func (s *NodeDisallowListWrapperTestSuite) TestHonestNode() {
 	s.Run("ByNodeID", func() {
@@ -82,11 +82,11 @@ func (s *NodeDisallowListWrapperTestSuite) TestHonestNode() {
 
 // TestDisallowListNode tests proper handling of identities _on_ the disallowList:
 //   - For any identity `i` with `i.NodeID ∈ disallowList`, the returned identity
-//     should have `i.Ejected` set to `true` (irrespective of the `Ejected`
+//     should have [i.Ejected] set to `true` (irrespective of the `Ejected`
 //     flag's initial returned by the wrapped `IdentityProvider`).
 //   - The wrapper should _copy_ the identity and _not_ write into the wrapped
 //     IdentityProvider's memory.
-//   - For `IdentityProvider.ByNodeID` and `IdentityProvider.ByPeerID`:
+//   - For [IdentityProvider.ByNodeID] and [IdentityProvider.ByPeerID]:
 //     whether or not the wrapper modifies the `Ejected` flag should depend only
 //     in the NodeID of the returned identity, irrespective of the second return
 //     value (boolean).

--- a/network/p2p/cache/protocol_state_provider.go
+++ b/network/p2p/cache/protocol_state_provider.go
@@ -16,8 +16,8 @@ import (
 	"github.com/onflow/flow-go/state/protocol/events"
 )
 
-// ProtocolStateIDCache implements an `id.IdentityProvider` and `p2p.IDTranslator` for the set of
-// authorized Flow network participants as according to the given `protocol.State`.
+// ProtocolStateIDCache implements an [id.IdentityProvider] and `p2p.IDTranslator` for the set of
+// authorized Flow network participants as according to the given [protocol.State].
 // the implementation assumes that the node information changes rarely, while queries are frequent.
 // Hence, we follow an event-driven design, where the ProtocolStateIDCache subscribes to relevant
 // protocol notifications (mainly Epoch notifications) and updates its internally cached list of

--- a/network/p2p/cache/protocol_state_provider_test.go
+++ b/network/p2p/cache/protocol_state_provider_test.go
@@ -146,7 +146,7 @@ func (suite *ProtocolStateProviderTestSuite) TestIDTranslation() {
 
 // TestUnknownIDs verifies that `ProtocolStateIDCache` complies with `p2p.IDTranslator`
 // interface specification: we expect an `p2p.ErrUnknownId` when attempting to
-// translate an unknown `peer.ID` or `flow.Identifier`.
+// translate an unknown [peer.ID] or [flow.Identifier].
 func (suite *ProtocolStateProviderTestSuite) TestUnknownIDs() {
 	unknwonFlowID := unittest.IdentifierFixture()
 	_, err := suite.provider.GetPeerID(unknwonFlowID)

--- a/network/p2p/id_translator.go
+++ b/network/p2p/id_translator.go
@@ -9,17 +9,17 @@ import (
 )
 
 var (
-	// ErrInvalidId indicates that the given ID (either `peer.ID` or `flow.Identifier`) has an invalid format.
+	// ErrInvalidId indicates that the given ID (either [peer.ID] or [flow.Identifier]) has an invalid format.
 	ErrInvalidId = errors.New("empty peer ID")
 
-	// ErrUnknownId indicates that the given ID (either `peer.ID` or `flow.Identifier`) is unknown.
+	// ErrUnknownId indicates that the given ID (either [peer.ID] or [flow.Identifier]) is unknown.
 	ErrUnknownId = errors.New("unknown ID")
 )
 
 // IDTranslator provides an interface for converting from Flow ID's to LibP2P peer ID's
 // and vice versa.
 type IDTranslator interface {
-	// GetPeerID returns the peer ID for the given `flow.Identifier`.
+	// GetPeerID returns the peer ID for the given [flow.Identifier].
 	// During normal operations, the following error returns are expected
 	//  * ErrUnknownId if the given Identifier is unknown
 	//  * ErrInvalidId if the given Identifier has an invalid format.
@@ -31,7 +31,7 @@ type IDTranslator interface {
 	// TODO: implementations do not fully adhere to this convention on error returns
 	GetPeerID(flow.Identifier) (peer.ID, error)
 
-	// GetFlowID returns the `flow.Identifier` for the given `peer.ID`.
+	// GetFlowID returns the [flow.Identifier] for the given [peer.ID].
 	// During normal operations, the following error returns are expected
 	//  * ErrUnknownId if the given Identifier is unknown
 	//  * ErrInvalidId if the given Identifier has an invalid format.

--- a/network/validator/pubsub/topic_validator.go
+++ b/network/validator/pubsub/topic_validator.go
@@ -26,7 +26,7 @@ import (
 func messageSigningID(m *pubsub.Message) (peer.ID, error) {
 	var pubk crypto.PubKey
 
-	// m.From is the original sender of the message (versus `m.ReceivedFrom` which is the last hop which sent us this message)
+	// m.From is the original sender of the message (versus [m.ReceivedFrom] which is the last hop which sent us this message)
 	pid, err := peer.IDFromBytes(m.From)
 	if err != nil {
 		return "", err

--- a/state/protocol/badger/mutator.go
+++ b/state/protocol/badger/mutator.go
@@ -294,8 +294,8 @@ func (m *ParticipantState) Extend(ctx context.Context, candidate *flow.Block) er
 //	5b. store candidate block and index it as a child of its parent (needed for recovery to traverse unfinalized blocks)
 //	5c. if we are given a certifyingQC, store it and queue a `BlockProcessable` notification for the candidate block
 //
-// If `headerExtend` is called by `ParticipantState.Extend` (full consensus participant) then `certifyingQC` will be nil,
-// but the block payload will be validated. If `headerExtend` is called by `FollowerState.Extend` (consensus follower),
+// If `headerExtend` is called by [ParticipantState.Extend] (full consensus participant) then `certifyingQC` will be nil,
+// but the block payload will be validated. If `headerExtend` is called by [FollowerState.Extend] (consensus follower),
 // then `certifyingQC` must be not nil which proves payload validity.
 //
 // Expected errors during normal operations:
@@ -315,7 +315,7 @@ func (m *FollowerState) headerExtend(ctx context.Context, candidate *flow.Block,
 	// (ii) has the same chain ID as its parent and a height incremented by 1.
 	parent, err := m.headers.ByBlockID(header.ParentID) // (i) connects to the known block tree
 	if err != nil {
-		// The only sentinel error that can happen here is `storage.ErrNotFound`. However, by convention the
+		// The only sentinel error that can happen here is [storage.ErrNotFound]. However, by convention the
 		// protocol state must be extended in a parent-first order. This block's parent being unknown breaks
 		// with this API contract and results in an exception.
 		return irrecoverable.NewExceptionf("could not retrieve the candidate's parent block %v: %w", header.ParentID, err)

--- a/state/protocol/badger/snapshot.go
+++ b/state/protocol/badger/snapshot.go
@@ -140,7 +140,7 @@ func (s *Snapshot) SealedResult() (*flow.ExecutionResult, *flow.Seal, error) {
 // SealingSegment will walk through the chain backward until we reach the block referenced
 // by the latest seal and build a SealingSegment. As we visit each block we check each execution
 // receipt in the block's payload to make sure we have a corresponding execution result, any
-// execution results missing from blocks are stored in the `SealingSegment.ExecutionResults` field.
+// execution results missing from blocks are stored in the [SealingSegment.ExecutionResults] field.
 // See `model/flow/sealing_segment.md` for detailed technical specification of the Sealing Segment
 //
 // Expected errors during normal operations:
@@ -155,8 +155,8 @@ func (s *Snapshot) SealingSegment() (*flow.SealingSegment, error) {
 	//  (ii) All blocks that are sealed by `head`. This is relevant if head` contains _multiple_ seals.
 	// (iii) The sealing segment should contain the history back to (including):
 	//       limitHeight := max(blockSealedAtHead.Height - flow.DefaultTransactionExpiry, SporkRootBlockHeight)
-	// Per convention, we include the blocks for (i) in the `SealingSegment.Blocks`, while the
-	// additional blocks for (ii) and optionally (iii) are contained in as `SealingSegment.ExtraBlocks`.
+	// Per convention, we include the blocks for (i) in the [SealingSegment.Blocks], while the
+	// additional blocks for (ii) and optionally (iii) are contained in as [SealingSegment.ExtraBlocks].
 	head, err := s.state.blocks.ByID(s.blockID)
 	if err != nil {
 		return nil, fmt.Errorf("could not get snapshot's reference block: %w", err)

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -898,7 +898,7 @@ func TestSealingSegment_FailureCases(t *testing.T) {
 			block.SetPayload(unittest.PayloadFixture(unittest.WithProtocolStateID(rootProtocolStateID)))
 			buildFinalizedBlock(t, state, block)
 
-			// consistency check: the finalized block at height `orphaned.Height` should be different than `orphaned`
+			// consistency check: the finalized block at height [orphaned.Height] should be different than `orphaned`
 			h, err := state.AtHeight(orphaned.Header.Height).Head()
 			require.NoError(t, err)
 			require.NotEqual(t, h.ID(), orphaned.ID())
@@ -1490,7 +1490,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 					// all current epoch identities should match configuration from EpochSetup event
 					assert.ElementsMatch(t, epoch1Identities, identities.Filter(epoch1Identities.Selector()))
 
-					// should contain single identity for next epoch with status `flow.EpochParticipationStatusJoining`
+					// should contain single identity for next epoch with status [flow.EpochParticipationStatusJoining]
 					nextEpochIdentity := identities.Filter(filter.HasNodeID[flow.Identity](addedAtEpoch2.NodeID))[0]
 					assert.Equal(t, flow.EpochParticipationStatusJoining, nextEpochIdentity.EpochParticipationStatus,
 						"expect joining status since we are in setup & commit phase")
@@ -1512,7 +1512,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 			// all current epoch identities should match configuration from EpochSetup event
 			assert.ElementsMatch(t, epoch2Identities, identities.Filter(epoch2Identities.Selector()))
 
-			// should contain single identity from previous epoch with status `flow.EpochParticipationStatusLeaving`
+			// should contain single identity from previous epoch with status [flow.EpochParticipationStatusLeaving]
 			lastEpochIdentity := identities.Filter(filter.HasNodeID[flow.Identity](removedAtEpoch2.NodeID))[0]
 			assert.Equal(t, flow.EpochParticipationStatusLeaving, lastEpochIdentity.EpochParticipationStatus,
 				"expect leaving status since we are in staking phase")
@@ -1538,7 +1538,7 @@ func TestSnapshot_CrossEpochIdentities(t *testing.T) {
 					// all current epoch identities should match configuration from EpochSetup event
 					assert.ElementsMatch(t, epoch2Identities, identities.Filter(epoch2Identities.Selector()))
 
-					// should contain next epoch's identities with status `flow.EpochParticipationStatusJoining`
+					// should contain next epoch's identities with status [flow.EpochParticipationStatusJoining]
 					for _, expected := range epoch3Identities {
 						actual, exists := identities.ByNodeID(expected.NodeID)
 						require.True(t, exists)

--- a/state/protocol/badger/validity.go
+++ b/state/protocol/badger/validity.go
@@ -204,7 +204,7 @@ func validateVersionBeacon(snap protocol.Snapshot) error {
 // ValidRootSnapshotContainsEntityExpiryRange performs a sanity check to make sure the
 // root snapshot has enough history to encompass at least one full entity expiry window.
 // Entities (in particular transactions and collections) may reference a block within
-// the past `flow.DefaultTransactionExpiry` blocks, so a new node must begin with at least
+// the past [flow.DefaultTransactionExpiry] blocks, so a new node must begin with at least
 // this many blocks worth of history leading up to the snapshot's root block.
 //
 // Currently, Access Nodes and Consensus Nodes require root snapshots passing this validator function.

--- a/state/protocol/blocktimer.go
+++ b/state/protocol/blocktimer.go
@@ -10,7 +10,7 @@ type BlockTimer interface {
 	Build(parentTimestamp time.Time) time.Time
 	// Validate checks validity of a block's time stamp.
 	// Error returns
-	//  * `model.InvalidBlockTimestampError` if time stamp is invalid.
+	//  * [model.InvalidBlockTimestampError] if time stamp is invalid.
 	//  * all other errors are unexpected and potentially symptoms of internal implementation bugs or state corruption (fatal).
 	Validate(parentTimestamp, currentTimestamp time.Time) error
 }

--- a/state/protocol/events/distributor.go
+++ b/state/protocol/events/distributor.go
@@ -7,7 +7,7 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 )
 
-// Distributor implements the `protocol.Consumer` interface for ingesting notifications emitted
+// Distributor implements the [protocol.Consumer] interface for ingesting notifications emitted
 // by the protocol state. It distributes the notifications to all registered consumers.
 type Distributor struct {
 	subscribers []protocol.Consumer

--- a/state/protocol/protocol_state.go
+++ b/state/protocol/protocol_state.go
@@ -62,11 +62,11 @@ type EpochProtocolState interface {
 	// Let `\` denote the relative set complement (also called 'set difference').
 	// The set of authorized identities this function returns is different depending on epoch state:
 	// EpochStaking phase:
-	//   - nodes in C with status `flow.EpochParticipationStatusActive`
-	//   - nodes in P\C with status `flow.EpochParticipationStatusLeaving`
+	//   - nodes in C with status [flow.EpochParticipationStatusActive]
+	//   - nodes in P\C with status [flow.EpochParticipationStatusLeaving]
 	// EpochSetup/EpochCommitted phase:
-	//   - nodes in C with status `flow.EpochParticipationStatusActive`
-	//   - nodes in S\C with status `flow.EpochParticipationStatusJoining`
+	//   - nodes in C with status [flow.EpochParticipationStatusActive]
+	//   - nodes in S\C with status [flow.EpochParticipationStatusJoining]
 	Identities() flow.IdentityList
 
 	// GlobalParams returns global, static network params that are same for all nodes in the network.

--- a/state/protocol/protocol_state/epochs/base_statemachine.go
+++ b/state/protocol/protocol_state/epochs/base_statemachine.go
@@ -50,7 +50,7 @@ func newBaseStateMachine(telemetry protocol_state.StateMachineTelemetryConsumer,
 
 // Build returns updated protocol state entry, state ID and a flag indicating if there were any changes.
 // CAUTION:
-// Do NOT call Build, if the baseStateMachine instance has returned a `protocol.InvalidServiceEventError`
+// Do NOT call Build, if the baseStateMachine instance has returned a [protocol.InvalidServiceEventError]
 // at any time during its lifetime. After this error, the baseStateMachine is left with a potentially
 // dysfunctional state and should be discarded.
 func (u *baseStateMachine) Build() (updatedState *flow.EpochStateEntry, stateID flow.Identifier, hasChanges bool) {

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -210,7 +210,7 @@ func (m *FallbackStateMachine) ProcessEpochRecover(epochRecover *flow.EpochRecov
 
 // ensureValidEpochRecover performs validity checks on the epoch recover event.
 // Expected errors during normal operations:
-// * `protocol.InvalidServiceEventError` - if the service event is invalid or is not a valid state transition for the current protocol state.
+// * [protocol.InvalidServiceEventError] - if the service event is invalid or is not a valid state transition for the current protocol state.
 // This is a side-effect-free function. This function only returns protocol.InvalidServiceEventError as errors.
 func (m *FallbackStateMachine) ensureValidEpochRecover(epochRecover *flow.EpochRecover) error {
 	if m.view+m.parentState.GetFinalizationSafetyThreshold() >= m.state.CurrentEpochFinalView() {

--- a/state/protocol/protocol_state/epochs/happy_path_statemachine.go
+++ b/state/protocol/protocol_state/epochs/happy_path_statemachine.go
@@ -56,7 +56,7 @@ func NewHappyPathStateMachine(telemetry protocol_state.StateMachineTelemetryCons
 // Returned boolean indicates if event triggered a transition in the state machine or not.
 // Implementors must never return (true, error).
 // Expected errors indicating that we are leaving the happy-path of the epoch transitions
-//   - `protocol.InvalidServiceEventError` - if the service event is invalid or is not a valid state transition for the current protocol state.
+//   - [protocol.InvalidServiceEventError] - if the service event is invalid or is not a valid state transition for the current protocol state.
 //     CAUTION: the HappyPathStateMachine is left with a potentially dysfunctional state when this error occurs. Do NOT call the Build method
 //     after such error and discard the HappyPathStateMachine!
 func (u *HappyPathStateMachine) ProcessEpochSetup(epochSetup *flow.EpochSetup) (bool, error) {
@@ -72,18 +72,18 @@ func (u *HappyPathStateMachine) ProcessEpochSetup(epochSetup *flow.EpochSetup) (
 		return false, err
 	}
 
-	// When observing setup event for subsequent epoch, construct the EpochStateContainer for `MinEpochStateEntry.NextEpoch`.
+	// When observing setup event for subsequent epoch, construct the EpochStateContainer for [MinEpochStateEntry.NextEpoch].
 	// Context:
-	// Note that the `EpochStateContainer.ActiveIdentities` only contains the nodes that are *active* in the next epoch. Active means
+	// Note that the [EpochStateContainer.ActiveIdentities] only contains the nodes that are *active* in the next epoch. Active means
 	// that these nodes are authorized to contribute to extending the chain. Nodes are listed in `ActiveIdentities` if and only if
 	// they are part of the EpochSetup event for the respective epoch.
 	//
 	// sanity checking SAFETY-CRITICAL INVARIANT (I):
-	//   - Per convention, the `flow.EpochSetup` event should list the IdentitySkeletons in canonical order. This is useful
+	//   - Per convention, the [flow.EpochSetup] event should list the IdentitySkeletons in canonical order. This is useful
 	//     for most efficient construction of the full active Identities for an epoch. We enforce this here at the gateway
 	//     to the protocol state, when we incorporate new information from the EpochSetup event.
 	//   - Note that the system smart contracts manage the identity table as an unordered set! For the protocol state, we desire a fixed
-	//     ordering to simplify various implementation details, like the DKG. Therefore, we order identities in `flow.EpochSetup` during
+	//     ordering to simplify various implementation details, like the DKG. Therefore, we order identities in [flow.EpochSetup] during
 	//     conversion from cadence to Go in the function `convert.ServiceEvent(flow.ChainID, flow.Event)` in package `model/convert`
 	// sanity checking SAFETY-CRITICAL INVARIANT (II):
 	// While ejection status and dynamic weight are not part of the EpochSetup event, we can supplement this information as follows:
@@ -98,7 +98,7 @@ func (u *HappyPathStateMachine) ProcessEpochSetup(epochSetup *flow.EpochSetup) (
 	//          the system smart contracts later) is illegal.
 	//     (ii) When the EpochSetup event is emitted / processed, the weight of all active nodes equals their InitialWeight and
 
-	// For collector clusters, we rely on invariants (I) and (II) holding. See `committees.Cluster` for details, specifically function
+	// For collector clusters, we rely on invariants (I) and (II) holding. See [committees.Cluster] for details, specifically function
 	// `constructInitialClusterIdentities(..)`. While the system smart contract must satisfy this invariant, we run a sanity check below.
 	activeIdentitiesLookup := u.state.CurrentEpoch.ActiveIdentities.Lookup() // lookup NodeID → DynamicIdentityEntry for nodes _active_ in the current epoch
 	nextEpochActiveIdentities, err := buildNextEpochActiveParticipants(activeIdentitiesLookup, u.state.CurrentEpochSetup, epochSetup)
@@ -135,7 +135,7 @@ func (u *HappyPathStateMachine) ProcessEpochSetup(epochSetup *flow.EpochSetup) (
 // Returned boolean indicates if event triggered a transition in the state machine or not.
 // Implementors must never return (true, error).
 // Expected errors indicating that we are leaving the happy-path of the epoch transitions
-//   - `protocol.InvalidServiceEventError` - if the service event is invalid or is not a valid state transition for the current protocol state.
+//   - [protocol.InvalidServiceEventError] - if the service event is invalid or is not a valid state transition for the current protocol state.
 //     CAUTION: the HappyPathStateMachine is left with a potentially dysfunctional state when this error occurs. Do NOT call the Build method
 //     after such error and discard the HappyPathStateMachine!
 func (u *HappyPathStateMachine) ProcessEpochCommit(epochCommit *flow.EpochCommit) (bool, error) {
@@ -162,7 +162,7 @@ func (u *HappyPathStateMachine) ProcessEpochCommit(epochCommit *flow.EpochCommit
 	return true, nil
 }
 
-// ProcessEpochRecover returns the sentinel error `protocol.InvalidServiceEventError`, which
+// ProcessEpochRecover returns the sentinel error [protocol.InvalidServiceEventError], which
 // indicates that `EpochRecover` are not expected on the happy path of epoch lifecycle.
 func (u *HappyPathStateMachine) ProcessEpochRecover(epochRecover *flow.EpochRecover) (bool, error) {
 	u.telemetry.OnServiceEventReceived(epochRecover.ServiceEvent())
@@ -171,18 +171,18 @@ func (u *HappyPathStateMachine) ProcessEpochRecover(epochRecover *flow.EpochReco
 	return false, err
 }
 
-// When observing setup event for subsequent epoch, construct the EpochStateContainer for `ProtocolStateEntry.NextEpoch`.
+// When observing setup event for subsequent epoch, construct the EpochStateContainer for [ProtocolStateEntry.NextEpoch].
 // Context:
-// Note that the `EpochStateContainer.ActiveIdentities` only contains the nodes that are *active* in the next epoch. Active means
+// Note that the [EpochStateContainer.ActiveIdentities] only contains the nodes that are *active* in the next epoch. Active means
 // that these nodes are authorized to contribute to extending the chain. Nodes are listed in `ActiveIdentities` if and only if
 // they are part of the EpochSetup event for the respective epoch.
 //
 // sanity checking SAFETY-CRITICAL INVARIANT (I):
-//   - Per convention, the `flow.EpochSetup` event should list the IdentitySkeletons in canonical order. This is useful
+//   - Per convention, the [flow.EpochSetup] event should list the IdentitySkeletons in canonical order. This is useful
 //     for most efficient construction of the full active Identities for an epoch. We enforce this here at the gateway
 //     to the protocol state, when we incorporate new information from the EpochSetup event.
 //   - Note that the system smart contracts manage the identity table as an unordered set! For the protocol state, we desire a fixed
-//     ordering to simplify various implementation details, like the DKG. Therefore, we order identities in `flow.EpochSetup` during
+//     ordering to simplify various implementation details, like the DKG. Therefore, we order identities in [flow.EpochSetup] during
 //     conversion from cadence to Go in the function `convert.ServiceEvent(flow.ChainID, flow.Event)` in package `model/convert`
 // sanity checking SAFETY-CRITICAL INVARIANT (II):
 // While ejection status and dynamic weight are not part of the EpochSetup event, we can supplement this information as follows:
@@ -197,7 +197,7 @@ func (u *HappyPathStateMachine) ProcessEpochRecover(epochRecover *flow.EpochReco
 //          the system smart contracts later) is illegal.
 //     (ii) When the EpochSetup event is emitted / processed, the weight of all active nodes equals their InitialWeight and
 
-// For collector clusters, we rely on invariants (I) and (II) holding. See `committees.Cluster` for details, specifically function
+// For collector clusters, we rely on invariants (I) and (II) holding. See [committees.Cluster] for details, specifically function
 // `constructInitialClusterIdentities(..)`. While the system smart contract must satisfy this invariant, we run a sanity check below.
 // This is a side-effect-free function. This function only returns protocol.InvalidServiceEventError as errors.
 func buildNextEpochActiveParticipants(activeIdentitiesLookup map[flow.Identifier]*flow.DynamicIdentityEntry, currentEpochSetup, nextEpochSetup *flow.EpochSetup) (flow.DynamicIdentityEntryList, error) {

--- a/state/protocol/protocol_state/epochs/identity_ejector.go
+++ b/state/protocol/protocol_state/epochs/identity_ejector.go
@@ -65,7 +65,7 @@ func (e *ejector) Eject(nodeID flow.Identifier) bool {
 // It is not allowed to readmit nodes that were ejected. Whenever a new DynamicIdentityList is tracked,
 // we ensure that the ejection status of previously ejected nodes is not reverted.
 // If a node was previously ejected and the new DynamicIdentityList contains the node with an `Ejected`
-// status of `false`, a `protocol.InvalidServiceEventError` is returned and the ejector remains unchanged.
+// status of `false`, a [protocol.InvalidServiceEventError] is returned and the ejector remains unchanged.
 func (e *ejector) TrackDynamicIdentityList(list flow.DynamicIdentityEntryList) error {
 	tracker := trackedDynamicIdentityList{dynamicIdentities: list}
 	if len(e.ejected) > 0 {

--- a/state/protocol/protocol_state/epochs/statemachine.go
+++ b/state/protocol/protocol_state/epochs/statemachine.go
@@ -83,7 +83,7 @@ import (
 type StateMachine interface {
 	// Build returns updated protocol state entry, state ID and a flag indicating if there were any changes.
 	// CAUTION:
-	// Do NOT call Build, if the StateMachine instance has returned a `protocol.InvalidServiceEventError`
+	// Do NOT call Build, if the StateMachine instance has returned a [protocol.InvalidServiceEventError]
 	// at any time during its lifetime. After this error, the StateMachine is left with a potentially
 	// dysfunctional state and should be discarded.
 	Build() (updatedState *flow.EpochStateEntry, stateID flow.Identifier, hasChanges bool)
@@ -96,7 +96,7 @@ type StateMachine interface {
 	// Returned boolean indicates if event triggered a transition in the state machine or not.
 	// Implementors must never return (true, error).
 	// Expected errors indicating that we are leaving the happy-path of the epoch transitions
-	//   - `protocol.InvalidServiceEventError` - if the service event is invalid or is not a valid state transition for the current protocol state.
+	//   - [protocol.InvalidServiceEventError] - if the service event is invalid or is not a valid state transition for the current protocol state.
 	//     CAUTION: the StateMachine is left with a potentially dysfunctional state when this error occurs. Do NOT call the Build method
 	//     after such error and discard the StateMachine!
 	ProcessEpochSetup(epochSetup *flow.EpochSetup) (bool, error)
@@ -107,7 +107,7 @@ type StateMachine interface {
 	// Returned boolean indicates if event triggered a transition in the state machine or not.
 	// Implementors must never return (true, error).
 	// Expected errors indicating that we are leaving the happy-path of the epoch transitions
-	//   - `protocol.InvalidServiceEventError` - if the service event is invalid or is not a valid state transition for the current protocol state.
+	//   - [protocol.InvalidServiceEventError] - if the service event is invalid or is not a valid state transition for the current protocol state.
 	//     CAUTION: the StateMachine is left with a potentially dysfunctional state when this error occurs. Do NOT call the Build method
 	//     after such error and discard the StateMachine!
 	ProcessEpochCommit(epochCommit *flow.EpochCommit) (bool, error)
@@ -123,7 +123,7 @@ type StateMachine interface {
 	// either the `EpochRecover` event is rejected (leading to `InvalidServiceEventError`) or there is an
 	// exception processing the event. Otherwise, an `EpochRecover` event must always lead to a state change.
 	// Expected errors during normal operations:
-	//   - `protocol.InvalidServiceEventError` - if the service event is invalid or is not a valid state transition for the current protocol state.
+	//   - [protocol.InvalidServiceEventError] - if the service event is invalid or is not a valid state transition for the current protocol state.
 	ProcessEpochRecover(epochRecover *flow.EpochRecover) (bool, error)
 
 	// EjectIdentity updates the identity table by changing the node's participation status to 'ejected'
@@ -307,7 +307,7 @@ func (e *EpochStateMachine) EvolveState(sealedServiceEvents []flow.ServiceEvent)
 // This function applies all evolving state operations to the active state machine. In case of successful evolution,
 // it returns the deferred DB updates to be applied to the storage.
 // Expected errors during normal operations:
-// - `protocol.InvalidServiceEventError` if any service event is invalid or is not a valid state transition for the current protocol state
+// - [protocol.InvalidServiceEventError] if any service event is invalid or is not a valid state transition for the current protocol state
 func (e *EpochStateMachine) evolveActiveStateMachine(sealedServiceEvents []flow.ServiceEvent) (*transaction.DeferredBlockPersist, error) {
 	parentProtocolState := e.activeStateMachine.ParentState()
 

--- a/state/protocol/protocol_state/kvstore/kvstore_storage.go
+++ b/state/protocol/protocol_state/kvstore/kvstore_storage.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ProtocolKVStore persists different snapshots of key-value stores [KV-stores]. Here, we augment
-// the low-level primitives provided by `storage.ProtocolKVStore` with logic for encoding and
+// the low-level primitives provided by [storage.ProtocolKVStore] with logic for encoding and
 // decoding the state snapshots into abstract representation `protocol_state.KVStoreAPI`.
 //
 // TODO (optional): include a cache of the _decoded_ Protocol States, so we don't decode+encode on each consensus view (hot-path)
@@ -24,7 +24,7 @@ var _ protocol_state.ProtocolKVStore = (*ProtocolKVStore)(nil)
 // NewProtocolKVStore instantiates a ProtocolKVStore for querying & storing deserialized `protocol_state.KVStoreAPIs`.
 // At this abstraction level, we can only handle protocol state snapshots, whose data models are supported by the current
 // software version. There might be serialized snapshots with legacy versions in the database, that are not supported
-// anymore by this software version and can only be retrieved as versioned binary blobs via `storage.ProtocolKVStore`.
+// anymore by this software version and can only be retrieved as versioned binary blobs via [storage.ProtocolKVStore].
 func NewProtocolKVStore(protocolStateSnapshots storage.ProtocolKVStore) *ProtocolKVStore {
 	return &ProtocolKVStore{
 		ProtocolKVStore: protocolStateSnapshots,
@@ -32,7 +32,7 @@ func NewProtocolKVStore(protocolStateSnapshots storage.ProtocolKVStore) *Protoco
 }
 
 // StoreTx returns an anonymous function (intended to be executed as part of a badger transaction), which persists
-// the given KV-store snapshot as part of a DB tx. Per convention, all implementations of `protocol.KVStoreReader`
+// the given KV-store snapshot as part of a DB tx. Per convention, all implementations of [protocol.KVStoreReader]
 // must support encoding their state into a version and data blob.
 // Expected errors of the returned anonymous function:
 //   - storage.ErrAlreadyExists if a KV-store snapshot with the given id is already stored.

--- a/state/protocol/protocol_state/kvstore/kvstore_storage_test.go
+++ b/state/protocol/protocol_state/kvstore/kvstore_storage_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
-// TestProtocolKVStore_StoreTx verifies correct functioning of `ProtocolKVStore.StoreTx`. In a nutshell,
+// TestProtocolKVStore_StoreTx verifies correct functioning of [ProtocolKVStore.StoreTx]. In a nutshell,
 // `ProtocolKVStore` should encode the provided snapshot and call the lower-level storage abstraction
 // to persist the encoded result.
 func TestProtocolKVStore_StoreTx(t *testing.T) {
@@ -62,7 +62,7 @@ func TestProtocolKVStore_StoreTx(t *testing.T) {
 	})
 }
 
-// TestProtocolKVStore_IndexTx verifies that `ProtocolKVStore.IndexTx` delegate all calls directly to the
+// TestProtocolKVStore_IndexTx verifies that [ProtocolKVStore.IndexTx] delegate all calls directly to the
 // low-level storage abstraction.
 func TestProtocolKVStore_IndexTx(t *testing.T) {
 	blockID := unittest.IdentifierFixture()
@@ -100,7 +100,7 @@ func TestProtocolKVStore_IndexTx(t *testing.T) {
 	})
 }
 
-// TestProtocolKVStore_ByBlockID verifies correct functioning of `ProtocolKVStore.ByBlockID`. In a nutshell,
+// TestProtocolKVStore_ByBlockID verifies correct functioning of [ProtocolKVStore.ByBlockID]. In a nutshell,
 // `ProtocolKVStore` should attempt to retrieve the encoded snapshot from the lower-level storage abstraction
 // and return the decoded result.
 func TestProtocolKVStore_ByBlockID(t *testing.T) {
@@ -131,9 +131,9 @@ func TestProtocolKVStore_ByBlockID(t *testing.T) {
 		require.Equal(t, expectedState, decodedState)
 	})
 
-	// On the unhappy path, either `ProtocolKVStore.ByBlockID` could error, or the decoding could fail. In either case,
+	// On the unhappy path, either [ProtocolKVStore.ByBlockID] could error, or the decoding could fail. In either case,
 	// the error should be escalated to the caller.
-	t.Run("low-level `ProtocolKVStore.ByBlockID` errors", func(t *testing.T) {
+	t.Run("low-level [ProtocolKVStore.ByBlockID] errors", func(t *testing.T) {
 		someError := errors.New("some problem")
 		llStorage.On("ByBlockID", blockID).Return(nil, someError).Once()
 
@@ -152,7 +152,7 @@ func TestProtocolKVStore_ByBlockID(t *testing.T) {
 	})
 	t.Run("decoding yields exception", func(t *testing.T) {
 		versionedSnapshot := &flow.PSKeyValueStoreData{
-			Version: 1, // model version 1 is known, but data is random, which should yield an `irrecoverable.Exception`
+			Version: 1, // model version 1 is known, but data is random, which should yield an [irrecoverable.Exception]
 			Data:    unittest.RandomBytes(117),
 		}
 		llStorage.On("ByBlockID", blockID).Return(versionedSnapshot, nil).Once()
@@ -162,7 +162,7 @@ func TestProtocolKVStore_ByBlockID(t *testing.T) {
 	})
 }
 
-// TestProtocolKVStore_ByID verifies correct functioning of `ProtocolKVStore.ByID`. In a nutshell,
+// TestProtocolKVStore_ByID verifies correct functioning of [ProtocolKVStore.ByID]. In a nutshell,
 // `ProtocolKVStore` should attempt to retrieve the encoded snapshot from the lower-level storage
 // abstraction and return the decoded result.
 func TestProtocolKVStore_ByID(t *testing.T) {
@@ -193,9 +193,9 @@ func TestProtocolKVStore_ByID(t *testing.T) {
 		require.Equal(t, expectedState, decodedState)
 	})
 
-	// On the unhappy path, either `ProtocolKVStore.ByID` could error, or the decoding could fail. In either case,
+	// On the unhappy path, either [ProtocolKVStore.ByID] could error, or the decoding could fail. In either case,
 	// the error should be escalated to the caller.
-	t.Run("low-level `ProtocolKVStore.ByID` errors", func(t *testing.T) {
+	t.Run("low-level [ProtocolKVStore.ByID] errors", func(t *testing.T) {
 		someError := errors.New("some problem")
 		llStorage.On("ByID", protocolStateID).Return(nil, someError).Once()
 
@@ -214,7 +214,7 @@ func TestProtocolKVStore_ByID(t *testing.T) {
 	})
 	t.Run("decoding yields exception", func(t *testing.T) {
 		versionedSnapshot := &flow.PSKeyValueStoreData{
-			Version: 1, // model version 1 is known, but data is random, which should yield an `irrecoverable.Exception`
+			Version: 1, // model version 1 is known, but data is random, which should yield an [irrecoverable.Exception]
 			Data:    unittest.RandomBytes(117),
 		}
 		llStorage.On("ByID", protocolStateID).Return(versionedSnapshot, nil).Once()

--- a/state/protocol/protocol_state/kvstore/upgrade_statemachine.go
+++ b/state/protocol/protocol_state/kvstore/upgrade_statemachine.go
@@ -71,7 +71,7 @@ func (m *PSVersionUpgradeStateMachine) EvolveState(orderedUpdates []flow.Service
 
 // processSingleEvent performs processing of a single protocol version upgrade event.
 // Expected errors indicating that we have observed and invalid service event from protocol's point of view.
-//   - `protocol.InvalidServiceEventError` - if the service event is invalid for the current protocol state.
+//   - [protocol.InvalidServiceEventError] - if the service event is invalid for the current protocol state.
 //
 // All other errors should be treated as exceptions.
 func (m *PSVersionUpgradeStateMachine) processSingleEvent(versionUpgrade *flow.ProtocolStateVersionUpgrade) error {
@@ -118,7 +118,7 @@ func (m *PSVersionUpgradeStateMachine) processSingleEvent(versionUpgrade *flow.P
 	}
 
 	// There can be multiple `versionUpgrade` Service Events sealed in one block. In case we have _not_
-	// encountered any, `m.EvolvingState` contains the latest `versionUpgrade` as of the parent block, because
+	// encountered any, [m.EvolvingState] contains the latest `versionUpgrade` as of the parent block, because
 	// we cloned it from the parent state. If we encountered some version upgrades, we already enforced that
 	// they are all upgrades to the same version. So we only need to check that the next `versionUpgrade`
 	// also has the same version.

--- a/state/protocol/protocol_state/kvstore_storage.go
+++ b/state/protocol/protocol_state/kvstore_storage.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ProtocolKVStore persists different snapshots of the Protocol State's Key-Calue stores [KV-stores].
-// Here, we augment the low-level primitives provided by `storage.ProtocolKVStore` with logic for
+// Here, we augment the low-level primitives provided by [storage.ProtocolKVStore] with logic for
 // encoding and decoding the state snapshots into abstract representation `protocol_state.KVStoreAPI`.
 //
 // At the abstraction level here, we can only handle protocol state snapshots, whose data models are
@@ -16,7 +16,7 @@ import (
 type ProtocolKVStore interface {
 	// StoreTx returns an anonymous function (intended to be executed as part of a database transaction),
 	// which persists the given KV-store snapshot as part of a DB tx. Per convention, all implementations
-	// of `protocol.KVStoreReader` should be able to successfully encode their state into a data blob.
+	// of [protocol.KVStoreReader] should be able to successfully encode their state into a data blob.
 	// If the encoding fails, the anonymous function returns an error upon call.
 	//
 	// Expected errors of the returned anonymous function:

--- a/state/protocol/protocol_state/state/mutable_protocol_state_test.go
+++ b/state/protocol/protocol_state/state/mutable_protocol_state_test.go
@@ -71,7 +71,7 @@ func (s *StateMutatorSuite) SetupTest() {
 	// CAUTION: ID of evolving state must be defined by the tests.
 	s.evolvingState = *protocol_statemock.NewKVStoreMutator(s.T())
 
-	// Factories for the state machines expect `s.parentState` as parent state and `s.replicatedState` as target state.
+	// Factories for the state machines expect [s.parentState] as parent state and [s.replicatedState] as target state.
 	// CAUTION: the behaviour of each state machine has to be defined by the tests.
 	s.kvStateMachines = make([]protocol_statemock.OrthogonalStoreStateMachine[protocol.KVStoreReader], 2)
 	s.kvStateMachineFactories = make([]protocol_statemock.KeyValueStoreStateMachineFactory, len(s.kvStateMachines))
@@ -98,7 +98,7 @@ func (s *StateMutatorSuite) SetupTest() {
 //
 // Note that the `MutableProtocolState` bundles all deferred database updates into a `DeferredBlockPersist`. Conceptually, it is possible that
 // the `MutableProtocolState` wraps the deferred database operations in faulty code, such that they are eventually not executed. Therefore,
-// we explicitly test here whether the storage functors *generated* by `ProtocolKVStore.IndexTx` and “ProtocolKVStore.StoreTx` are
+// we explicitly test here whether the storage functors *generated* by [ProtocolKVStore.IndexTx] and “ProtocolKVStore.StoreTx` are
 // actually called when executing the returned `DeferredBlockPersist`
 func (s *StateMutatorSuite) testEvolveState(seals []*flow.Seal, expectedResultingStateID flow.Identifier, stateChangeExpected bool) {
 	// on the happy path, we _always_ require a deferred db update, which indexes the protocol state by the candidate block's ID
@@ -133,7 +133,7 @@ func (s *StateMutatorSuite) testEvolveState(seals []*flow.Seal, expectedResultin
 	storeTxDeferredUpdate.AssertExpectations(s.T())
 }
 
-// Test_HappyPath_StateInvariant tests that `MutableProtocolState.EvolveState` returns all updates from sub-state state machines and
+// Test_HappyPath_StateInvariant tests that [MutableProtocolState.EvolveState] returns all updates from sub-state state machines and
 // prepares updates to the KV store, when building protocol state. Here, we focus on the path, where the *state remains invariant*.
 func (s *StateMutatorSuite) Test_HappyPath_StateInvariant() {
 	parentProtocolStateID := s.parentState.ID()
@@ -187,7 +187,7 @@ func (s *StateMutatorSuite) Test_HappyPath_StateInvariant() {
 	})
 }
 
-// Test_HappyPath_StateChange tests that `MutableProtocolState.EvolveState` returns all updates from sub-state state machines and
+// Test_HappyPath_StateChange tests that [MutableProtocolState.EvolveState] returns all updates from sub-state state machines and
 // prepares updates to the KV store, when building protocol state. Here, we focus on the path, where the *state is modified*.
 //
 // All mocked state machines return a single deferred db update that will be subsequently returned and executed.
@@ -349,7 +349,7 @@ func (s *StateMutatorSuite) Test_VersionUpgrade() {
 	})
 }
 
-// Test_SealsOrdered verifies that `MutableProtocolState.EvolveState` processes service events from seals ordered by *increasing* block
+// Test_SealsOrdered verifies that [MutableProtocolState.EvolveState] processes service events from seals ordered by *increasing* block
 // height, independently of the order the seals are provided with. Here, we explicitly provide seals in order of *decreasing* block height.
 func (s *StateMutatorSuite) Test_SealsOrdered() {
 	// generate seals in order of *increasing* block height and store the resulting list of _ordered_ service events for reference in `orderedServiceEvents`
@@ -395,7 +395,7 @@ func (s *StateMutatorSuite) Test_SealsOrdered() {
 
 }
 
-// Test_ParentNotFound checks the behaviour of `MutableProtocolState.EvolveState` when the specified parent block is not found.
+// Test_ParentNotFound checks the behaviour of [MutableProtocolState.EvolveState] when the specified parent block is not found.
 func (s *StateMutatorSuite) Test_InvalidParent() {
 	unknownParent := unittest.IdentifierFixture()
 	s.protocolKVStoreDB.On("ByBlockID", unknownParent).Return(nil, storage.ErrNotFound)
@@ -633,7 +633,7 @@ func (m *mockStateTransition) Mock() protocol_statemock.OrthogonalStoreStateMach
 	deferredUpdate.On("Execute", mock.Anything).Return(nil).Once()
 	deferredDBUpdates := transaction.NewDeferredBlockPersist().AddDbOp(deferredUpdate.Execute)
 	stateMachine.On("Build").Run(func(args mock.Arguments) {
-		require.True(m.T, evolveStateCalled, "Method `OrthogonalStoreStateMachine.Build` called before `EvolveState`!")
+		require.True(m.T, evolveStateCalled, "Method [OrthogonalStoreStateMachine.Build] called before `EvolveState`!")
 	}).Return(deferredDBUpdates, nil).Once()
 	return *stateMachine //nolint:govet
 }

--- a/state/protocol/protocol_state/state/protocol_state.go
+++ b/state/protocol/protocol_state/state/protocol_state.go
@@ -35,7 +35,7 @@ func NewProtocolState(epochProtocolStateDB storage.EpochProtocolStateEntries, kv
 }
 
 // newProtocolState creates a new ProtocolState instance. The exported constructor `NewProtocolState` only requires the
-// lower-level `storage.ProtocolKVStore` as input. Though, internally we use the higher-level `protocol_state.ProtocolKVStore`,
+// lower-level [storage.ProtocolKVStore] as input. Though, internally we use the higher-level `protocol_state.ProtocolKVStore`,
 // which wraps the lower-level ProtocolKVStore.
 func newProtocolState(epochProtocolStateDB storage.EpochProtocolStateEntries, kvStoreSnapshots protocol_state.ProtocolKVStore, globalParams protocol.GlobalParams) *ProtocolState {
 	return &ProtocolState{

--- a/state/protocol/protocol_state/state/protocol_state_test.go
+++ b/state/protocol/protocol_state/state/protocol_state_test.go
@@ -24,13 +24,13 @@ func Test_ProtocolState(t *testing.T) {
 	globalParams := psmock.NewGlobalParams(t)
 	protocolState := NewProtocolState(epochProtocolStateDB, protocolKVStoreDB, globalParams)
 
-	t.Run("testing `EpochProtocolStateEntries.AtBlockID`", func(t *testing.T) {
+	t.Run("testing [EpochProtocolStateEntries.AtBlockID]", func(t *testing.T) {
 		test_AtBlockID(t, protocolState, epochProtocolStateDB)
 	})
-	t.Run("testing `EpochProtocolStateEntries.GlobalParams`", func(t *testing.T) {
+	t.Run("testing [EpochProtocolStateEntries.GlobalParams]", func(t *testing.T) {
 		test_GlobalParams(t, protocolState, globalParams)
 	})
-	t.Run("testing `EpochProtocolStateEntries.KVStoreAtBlockID`", func(t *testing.T) {
+	t.Run("testing [EpochProtocolStateEntries.KVStoreAtBlockID]", func(t *testing.T) {
 		test_KVStoreAtBlockID(t, protocolState, protocolKVStoreDB)
 	})
 }
@@ -56,13 +56,13 @@ func Test_MutableProtocolState(t *testing.T) {
 		setupsDB,
 		commitsDB)
 
-	t.Run("testing `MutableProtocolState.AtBlockID`", func(t *testing.T) {
+	t.Run("testing [MutableProtocolState.AtBlockID]", func(t *testing.T) {
 		test_AtBlockID(t, mutableProtocolState, epochProtocolStateDB)
 	})
-	t.Run("testing `MutableProtocolState.GlobalParams`", func(t *testing.T) {
+	t.Run("testing [MutableProtocolState.GlobalParams]", func(t *testing.T) {
 		test_GlobalParams(t, mutableProtocolState, globalParams)
 	})
-	t.Run("testing `MutableProtocolState.KVStoreAtBlockID`", func(t *testing.T) {
+	t.Run("testing [MutableProtocolState.KVStoreAtBlockID]", func(t *testing.T) {
 		test_KVStoreAtBlockID(t, mutableProtocolState, protocolKVStoreDB)
 	})
 }

--- a/state/protocol/util.go
+++ b/state/protocol/util.go
@@ -118,7 +118,7 @@ func FindGuarantors(state State, guarantee *flow.CollectionGuarantee) ([]flow.Id
 // payload validity in this function, the implementation is optimized for valid payloads,
 // where the heights of the sealed blocks form a continuous integer sequence (no gaps).
 // Per convention ['Vacuous Truth'], an empty set of seals is considered to be
-// ordered. Hence, if `payload.Seals` is empty, we return (nil, nil).
+// ordered. Hence, if [payload.Seals] is empty, we return (nil, nil).
 // Expected Error returns during normal operations:
 //   - ErrMultipleSealsForSameHeight in case there are seals repeatedly sealing block at the same height
 //   - ErrDiscontinuousSeals in case there are height-gaps in the sealed blocks

--- a/state/protocol/validity.go
+++ b/state/protocol/validity.go
@@ -60,7 +60,7 @@ func IsValidEpochSetup(setup *flow.EpochSetup, verifyNetworkAddress bool) error 
 	// (b) each has a unique network address (if `verifyNetworkAddress` is true),
 	// (c) participants are sorted in canonical order.
 	//     Note that the system smart contracts manage the identity table as an unordered set! For the protocol state, we desire a fixed
-	//     ordering to simplify various implementation details, like the DKG. Therefore, we order identities in `flow.EpochSetup` during
+	//     ordering to simplify various implementation details, like the DKG. Therefore, we order identities in [flow.EpochSetup] during
 	//     conversion from cadence to Go in the function `convert.ServiceEvent(flow.ChainID, flow.Event)` in package `model/convert`
 	identLookup := make(map[flow.Identifier]struct{})
 	for _, participant := range setup.Participants { // (a) enforce uniqueness of NodeIDs

--- a/storage/badger/cache.go
+++ b/storage/badger/cache.go
@@ -88,7 +88,7 @@ func (c *Cache[K, V]) IsCached(key K) bool {
 
 // Get will try to retrieve the resource from cache first, and then from the
 // injected. During normal operations, the following error returns are expected:
-//   - `storage.ErrNotFound` if key is unknown.
+//   - [storage.ErrNotFound] if key is unknown.
 func (c *Cache[K, V]) Get(key K) func(*badger.Txn) (V, error) {
 	return func(tx *badger.Txn) (V, error) {
 

--- a/storage/badger/dkg_state.go
+++ b/storage/badger/dkg_state.go
@@ -163,7 +163,7 @@ func (keys *SafeBeaconPrivateKeys) RetrieveMyBeaconPrivateKey(epochCounter uint6
 			if err != nil {
 				key = nil
 				safe = false
-				return irrecoverable.NewExceptionf("[unexpected] could not retrieve beacon key for epoch %d with successful DKG: %v", epochCounter, err)
+				return irrecoverable.NewExceptionf("could not retrieve beacon key for epoch %d with successful DKG: %v", epochCounter, err)
 			}
 
 			// return the key only for successful end state

--- a/storage/badger/dkg_state.go
+++ b/storage/badger/dkg_state.go
@@ -157,7 +157,7 @@ func (keys *SafeBeaconPrivateKeys) RetrieveMyBeaconPrivateKey(epochCounter uint6
 
 		// for any end state besides success and recovery, the key is not safe
 		if endState == flow.DKGEndStateSuccess || endState == flow.RandomBeaconKeyRecovered {
-			// retrieve the key - any storage error (including `storage.ErrNotFound`) is an exception
+			// retrieve the key - any storage error (including [storage.ErrNotFound]) is an exception
 			var encodableKey *encodable.RandomBeaconPrivKey
 			encodableKey, err = keys.state.retrieveKeyTx(epochCounter)(txn)
 			if err != nil {
@@ -182,8 +182,8 @@ func (keys *SafeBeaconPrivateKeys) RetrieveMyBeaconPrivateKey(epochCounter uint6
 // EpochRecoveryMyBeaconKey is a specific module that allows to overwrite the beacon private key for a given epoch.
 // This module is used *ONLY* in the epoch recovery process and only by the consensus participants.
 // Each consensus participant takes part in the DKG, and after successfully finishing the DKG protocol it obtains a
-// random beacon private key, which is stored in the database along with DKG end state `flow.DKGEndStateSuccess`.
-// If for any reason the DKG fails, then the private key will be nil and DKG end state will be `flow.DKGEndStateDKGFailure`.
+// random beacon private key, which is stored in the database along with DKG end state [flow.DKGEndStateSuccess].
+// If for any reason the DKG fails, then the private key will be nil and DKG end state will be [flow.DKGEndStateDKGFailure].
 // When the epoch recovery takes place, we need to query the last valid beacon private key for the current replica and
 // also set it for use during the Recovery Epoch, otherwise replicas won't be able to vote for blocks during the Recovery Epoch.
 type EpochRecoveryMyBeaconKey struct {
@@ -198,7 +198,7 @@ func NewEpochRecoveryMyBeaconKey(keys *SafeBeaconPrivateKeys) *EpochRecoveryMyBe
 
 // UpsertMyBeaconPrivateKey overwrites the random beacon private key for the epoch that recovers the protocol from
 // Epoch Fallback Mode. Effectively, this function overwrites whatever might be available in the database with
-// the given private key and sets the DKGEndState to `flow.DKGEndStateRecovered`.
+// the given private key and sets the DKGEndState to [flow.DKGEndStateRecovered].
 // No errors are expected during normal operations.
 func (keys *EpochRecoveryMyBeaconKey) UpsertMyBeaconPrivateKey(epochCounter uint64, key crypto.PrivateKey) error {
 	if key == nil {

--- a/storage/badger/headers.go
+++ b/storage/badger/headers.go
@@ -78,7 +78,7 @@ func (h *Headers) retrieveTx(blockID flow.Identifier) func(*badger.Txn) (*flow.H
 	}
 }
 
-// results in `storage.ErrNotFound` for unknown height
+// results in [storage.ErrNotFound] for unknown height
 func (h *Headers) retrieveIdByHeightTx(height uint64) func(*badger.Txn) (flow.Identifier, error) {
 	return func(tx *badger.Txn) (flow.Identifier, error) {
 		blockID, err := h.heightCache.Get(height)(tx)
@@ -128,7 +128,7 @@ func (h *Headers) Exists(blockID flow.Identifier) (bool, error) {
 
 // BlockIDByHeight returns the block ID that is finalized at the given height. It is an optimized
 // version of `ByHeight` that skips retrieving the block. Expected errors during normal operations:
-//   - `storage.ErrNotFound` if no finalized block is known at given height.
+//   - [storage.ErrNotFound] if no finalized block is known at given height.
 func (h *Headers) BlockIDByHeight(height uint64) (flow.Identifier, error) {
 	tx := h.db.NewTransaction(false)
 	defer tx.Discard()

--- a/storage/badger/operation/bft.go
+++ b/storage/badger/operation/bft.go
@@ -34,7 +34,7 @@ func PersistBlocklist(blocklist map[flow.Identifier]struct{}) func(*badger.Txn) 
 }
 
 // RetrieveBlocklist reads the set of blocked node IDs from the data base.
-// Returns `storage.ErrNotFound` error in case no respective data base entry is present.
+// Returns [storage.ErrNotFound] error in case no respective data base entry is present.
 //
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func RetrieveBlocklist(blocklist *map[flow.Identifier]struct{}) func(*badger.Txn) error {

--- a/storage/badger/transaction/deferred_block_persist.go
+++ b/storage/badger/transaction/deferred_block_persist.go
@@ -5,7 +5,7 @@ import (
 )
 
 // DeferredBlockPersistOp is a shorthand notation for an anonymous function that takes the ID of
-// a fully constructed block and a `transaction.Tx` as inputs and runs some database operations
+// a fully constructed block and a [transaction.Tx] as inputs and runs some database operations
 // as part of that transaction. It is a "Promise Pattern", essentially saying:
 // once we have the completed the block's construction, we persist data structures that are
 // referenced by the block or populate database indices. This pattern is necessary, because
@@ -17,7 +17,7 @@ type DeferredBlockPersistOp func(blockID flow.Identifier, tx *Tx) error
 var noOpPersist DeferredBlockPersistOp = func(blockID flow.Identifier, tx *Tx) error { return nil }
 
 // WithBlock adds the still missing block ID information to a `DeferredBlockPersistOp`, thereby converting
-// it into a `transaction.DeferredDBUpdate`.
+// it into a [transaction.DeferredDBUpdate].
 func (d DeferredBlockPersistOp) WithBlock(blockID flow.Identifier) DeferredDBUpdate {
 	return func(tx *Tx) error {
 		return d(blockID, tx)
@@ -27,14 +27,14 @@ func (d DeferredBlockPersistOp) WithBlock(blockID flow.Identifier) DeferredDBUpd
 // DeferredBlockPersist is a utility for accumulating deferred database interactions that
 // are supposed to be executed in one atomic transaction. It supports:
 //   - Deferred database operations that work directly on Badger transactions.
-//   - Deferred database operations that work on `transaction.Tx`.
+//   - Deferred database operations that work on [transaction.Tx].
 //     Tx is a storage-layer abstraction, with support for callbacks that are executed
 //     after the underlying database transaction completed _successfully_.
 //   - Deferred database operations that depend on the ID of the block under construction
-//     and `transaction.Tx`. Especially useful for populating `ByBlockID` indices.
+//     and [transaction.Tx]. Especially useful for populating `ByBlockID` indices.
 //
 // ORDER OF EXECUTION
-// We extend the process in which `transaction.Tx` executes database operations, schedules
+// We extend the process in which [transaction.Tx] executes database operations, schedules
 // callbacks, and executed the callbacks. Specifically, DeferredDbOps proceeds as follows:
 //
 //  0. Record functors added via `AddBadgerOp`, `AddDbOp`, `OnSucceed` ...

--- a/storage/badger/transaction/deferred_update.go
+++ b/storage/badger/transaction/deferred_update.go
@@ -5,7 +5,7 @@ import (
 )
 
 // DeferredDBUpdate is a shorthand notation for an anonymous function that takes
-// a `transaction.Tx` as input and runs some database operations as part of that transaction.
+// a [transaction.Tx] as input and runs some database operations as part of that transaction.
 type DeferredDBUpdate func(*Tx) error
 
 // DeferredBadgerUpdate is a shorthand notation for an anonymous function that takes
@@ -15,12 +15,12 @@ type DeferredBadgerUpdate = func(*badger.Txn) error
 // DeferredDbOps is a utility for accumulating deferred database interactions that
 // are supposed to be executed in one atomic transaction. It supports:
 //   - Deferred database operations that work directly on Badger transactions.
-//   - Deferred database operations that work on `transaction.Tx`.
+//   - Deferred database operations that work on [transaction.Tx].
 //     Tx is a storage-layer abstraction, with support for callbacks that are executed
 //     after the underlying database transaction completed _successfully_.
 //
 // ORDER OF EXECUTION
-// We extend the process in which `transaction.Tx` executes database operations, schedules
+// We extend the process in which [transaction.Tx] executes database operations, schedules
 // callbacks, and executed the callbacks. Specifically, DeferredDbOps proceeds as follows:
 //
 //  0. Record functors added via `AddBadgerOp`, `AddDbOp`, `OnSucceed` ...

--- a/storage/badger/transaction/tx.go
+++ b/storage/badger/transaction/tx.go
@@ -21,7 +21,7 @@ import (
 //     functions.
 //   - Whether a transaction is considered to have succeeded depends only on the return value
 //     of the outermost function. For example, consider a chain of 3 functions: f3( f2( f1(x)))
-//     Lets assume f1 fails with an `storage.ErrAlreadyExists` sentinel, which f2 expects and
+//     Lets assume f1 fails with an [storage.ErrAlreadyExists] sentinel, which f2 expects and
 //     therefore discards. f3 could then succeed, i.e. return nil.
 //     Consequently, the entire list of callbacks is executed, including f1's callback if it
 //     added one. Callback implementations therefore need to account for this edge case.
@@ -37,7 +37,7 @@ type Tx struct {
 // CAUTION:
 // Whether a transaction is considered to have succeeded depends only on the return value
 // of the outermost function. For example, consider a chain of 3 functions: f3( f2( f1(x)))
-// Lets assume f1 fails with an `storage.ErrAlreadyExists` sentinel, which f2 expects and
+// Lets assume f1 fails with an [storage.ErrAlreadyExists] sentinel, which f2 expects and
 // therefore discards. f3 could then succeed, i.e. return nil.
 // Consequently, the entire list of callbacks is executed, including f1's callback if it
 // added one. Callback implementations therefore need to account for this edge case.

--- a/storage/dkg.go
+++ b/storage/dkg.go
@@ -62,8 +62,8 @@ type SafeBeaconKeys interface {
 // EpochRecoveryMyBeaconKey is a specific interface that allows to overwrite the beacon private key for a given epoch.
 // This interface is used *ONLY* in the epoch recovery process and only by the consensus participants.
 // Each consensus participant takes part in the DKG, and after successfully finishing the DKG protocol it obtains a
-// random beacon private key, which is stored in the database along with DKG end state `flow.DKGEndStateSuccess`.
-// If for any reason the DKG fails, then the private key will be nil and DKG end state will be `flow.DKGEndStateDKGFailure`.
+// random beacon private key, which is stored in the database along with DKG end state [flow.DKGEndStateSuccess].
+// If for any reason the DKG fails, then the private key will be nil and DKG end state will be [flow.DKGEndStateDKGFailure].
 // When the epoch recovery takes place, we need to query the last valid beacon private key for the current replica and
 // also set it for use during the Recovery Epoch, otherwise replicas won't be able to vote for blocks during the Recovery Epoch.
 type EpochRecoveryMyBeaconKey interface {
@@ -71,7 +71,7 @@ type EpochRecoveryMyBeaconKey interface {
 
 	// UpsertMyBeaconPrivateKey overwrites the random beacon private key for the epoch that recovers the protocol from
 	// Epoch Fallback Mode. Effectively, this function overwrites whatever might be available in the database with
-	// the given private key and sets the DKGEndState to `flow.DKGEndStateRecovered`.
+	// the given private key and sets the DKGEndState to [flow.DKGEndStateRecovered].
 	// No errors are expected during normal operations.
 	UpsertMyBeaconPrivateKey(epochCounter uint64, key crypto.PrivateKey) error
 }

--- a/storage/pebble/cache.go
+++ b/storage/pebble/cache.go
@@ -126,7 +126,7 @@ func (c *ReadCache) IsCached(key string) bool {
 
 // Get will try to retrieve the resource from cache first, and then from the
 // injected. During normal operations, the following error returns are expected:
-//   - `storage.ErrNotFound` if key is unknown.
+//   - [storage.ErrNotFound] if key is unknown.
 func (c *ReadCache) Get(key string) (flow.RegisterValue, error) {
 	resource, cached := c.cache.Get(key)
 	if cached {

--- a/storage/pebble/value_cache.go
+++ b/storage/pebble/value_cache.go
@@ -87,7 +87,7 @@ func (c *Cache[K, V]) IsCached(key K) bool {
 
 // Get will try to retrieve the resource from cache first, and then from the
 // injected. During normal operations, the following error returns are expected:
-//   - `storage.ErrNotFound` if key is unknown.
+//   - [storage.ErrNotFound] if key is unknown.
 func (c *Cache[K, V]) Get(key K) func(pebble.Reader) (V, error) {
 	return func(r pebble.Reader) (V, error) {
 

--- a/utils/logging/consts.go
+++ b/utils/logging/consts.go
@@ -6,7 +6,7 @@ const (
 	// regarding misbehaving nodes.
 	// Axiomatically, each node considers its own operator as well as Flow's governance committee as trusted.
 	// Hence, potential problems with inputs (mostly configurations) from these sources are *not* considered
-	// byzantine. To flag inputs from these sources, please use `logging.KeyPotentialConfigurationProblem`.
+	// byzantine. To flag inputs from these sources, please use [logging.KeyPotentialConfigurationProblem].
 	KeySuspicious = "suspicious"
 
 	// KeyPotentialConfigurationProblem is a logging label. It flags that the log event informs about suspected

--- a/utils/unittest/chain_suite.go
+++ b/utils/unittest/chain_suite.go
@@ -183,7 +183,7 @@ func (bc *BaseChainSuite) SetupChain() {
 		return nil, false
 	}
 
-	// define the protocol state snapshot for any block in `bc.Blocks`
+	// define the protocol state snapshot for any block in [bc.Blocks]
 	bc.State.On("AtBlockID", mock.Anything).Return(
 		func(blockID flow.Identifier) realproto.Snapshot {
 			block, found := bc.Blocks[blockID]

--- a/utils/unittest/unittest.go
+++ b/utils/unittest/unittest.go
@@ -293,7 +293,7 @@ func RequireNotClosed(t *testing.T, ch <-chan struct{}, message string) {
 // account for the actual error being wrapped). Fails the test if either error
 // is nil.
 //
-// NOTE: This should only be used in cases where `errors.Is` cannot be, like
+// NOTE: This should only be used in cases where [errors.Is] cannot be, like
 // when errors are transmitted over the network without type information.
 func AssertErrSubstringMatch(t testing.TB, expected, actual error) {
 	require.NotNil(t, expected)


### PR DESCRIPTION
### Context

Based on [comment](https://github.com/onflow/flow-go/pull/6424#discussion_r1847473157) on recent PR this PR replaces usages of \`type\` with [type]. 

I have used following regex to find all type usages: \`([a-zA-Z]+\.[a-zA-Z]+)\` and then next expression to replace: [$1]
