### PR TITLE
Fix testnet EVM replay

### DIFF
--- a/fvm/evm/offchain/blocks/block_context.go
+++ b/fvm/evm/offchain/blocks/block_context.go
@@ -67,7 +67,7 @@ func UseBlockHashCorrection(chainID flow.ChainID, evmHeightOfCurrentBlock uint64
 	// array of hashes.
 	if chainID == flow.Mainnet && evmHeightOfCurrentBlock < blockHashListFixHCUEVMHeightMainnet {
 		return fixedHashes[flow.Mainnet][queriedEVMHeight%256], true
-	} else if chainID == flow.Testnet && blockHashListBugIntroducedHCUEVMHeightTestnet <= evmHeightOfCurrentBlock && evmHeightOfCurrentBlock < blockHashListFixHCUEVMHeightTestnet {
+	} else if chainID == flow.Testnet && evmHeightOfCurrentBlock < blockHashListFixHCUEVMHeightTestnet {
 		return fixedHashes[flow.Testnet][queriedEVMHeight%256], true
 	}
 	return gethCommon.Hash{}, false
@@ -82,11 +82,6 @@ const blockHashListFixHCUEVMHeightMainnet = 8357079
 // Flow Block: 228025500 7eb808b77f02c3e77c36d57dc893ed63adc5ff6113bb0f4b141bb39e44d634e6
 // PR: https://github.com/onflow/flow-go/pull/6734
 const blockHashListFixHCUEVMHeightTestnet = 16848829
-
-// Testnet52 - Spork
-// Flow Block: 218215350 cc7188f0bdac4c442cc3ee072557d7f7c8ca4462537da945b148d5d0efa7a1ff
-// PR: https://github.com/onflow/flow-go/pull/6377
-const blockHashListBugIntroducedHCUEVMHeightTestnet = 7038679
 
 // Testnet51 - Height Coordinated Upgrade 1
 // Flow Block: 212562161 1a520608c5457f228405c4c30fc39c8a0af7cf915fb2ede7ec5ccffc2a000f57


### PR DESCRIPTION
Extracted from https://github.com/onflow/flow-go/pull/6755.

This was needed to fix the re-execution on testsnet