### PR TITLE
[EFM] `EpochCommit` is backward compatible

### DIFF
--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -203,12 +203,46 @@ func convertServiceEventEpochSetup(event flow.Event) (*flow.ServiceEvent, error)
 	return serviceEvent, nil
 }
 
+// convertServiceEventEpochCommit is a wrapper function to support backward-compatible event parsing for [flow.EpochCommit] events.
+// It delegates to the appropriate version-specific conversion function based on the number of fields in the event.
+// TODO(EFM, #6794): Replace this function with a single version-specific conversion function once the network upgrade is complete.
+func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error) {
+	// decode bytes using ccf
+	payload, err := ccf.Decode(nil, event.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal event payload: %w", err)
+	}
+
+	cdcEvent, ok := payload.(cadence.Event)
+	if !ok {
+		return nil, invalidCadenceTypeError("payload", payload, cadence.Event{})
+	}
+
+	if cdcEvent.Type() == nil {
+		return nil, fmt.Errorf("EpochCommit event doesn't have type")
+	}
+
+	fields := cadence.FieldsMappedByName(cdcEvent)
+
+	switch len(fields) {
+	case 3:
+		return convertServiceEventEpochCommitV0(event)
+	case 5:
+		return convertServiceEventEpochCommitV1(event)
+	default:
+		return nil, fmt.Errorf(
+			"invalid number of fields in EpochCommit event, expect 3 or 5, got: %d",
+			len(fields),
+		)
+	}
+}
+
 // convertServiceEventEpochCommit converts a service event encoded as the generic
 // flow.Event type to a ServiceEvent type for an EpochCommit event.
 // CAUTION: This function must only be used for input events computed locally, by an
 // Execution or Verification Node; it is not resilient to malicious inputs.
 // No errors are expected during normal operation.
-func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error) {
+func convertServiceEventEpochCommitV1(event flow.Event) (*flow.ServiceEvent, error) {
 	// decode bytes using ccf
 	payload, err := ccf.Decode(nil, event.Payload)
 	if err != nil {
@@ -294,6 +328,88 @@ func convertServiceEventEpochCommit(event flow.Event) (*flow.ServiceEvent, error
 		index := pair.Value.(cadence.Int).Int()
 		commit.DKGIndexMap[nodeID] = index
 	}
+
+	// create the service event
+	serviceEvent := &flow.ServiceEvent{
+		Type:  flow.ServiceEventCommit,
+		Event: commit,
+	}
+
+	return serviceEvent, nil
+}
+
+// convertServiceEventEpochCommit converts a service event encoded as the generic
+// flow.Event type to a ServiceEvent type for an EpochCommit event.
+// CAUTION: This function must only be used for input events computed locally, by an
+// Execution or Verification Node; it is not resilient to malicious inputs.
+// No errors are expected during normal operation.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func convertServiceEventEpochCommitV0(event flow.Event) (*flow.ServiceEvent, error) {
+	// decode bytes using ccf
+	payload, err := ccf.Decode(nil, event.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal event payload: %w", err)
+	}
+
+	cdcEvent, ok := payload.(cadence.Event)
+	if !ok {
+		return nil, invalidCadenceTypeError("payload", payload, cadence.Event{})
+	}
+
+	if cdcEvent.Type() == nil {
+		return nil, fmt.Errorf("EpochCommit event doesn't have type")
+	}
+
+	fields := cadence.FieldsMappedByName(cdcEvent)
+
+	const expectedFieldCount = 3
+	if len(fields) < expectedFieldCount {
+		return nil, fmt.Errorf(
+			"insufficient fields in EpochCommit event (%d < %d)",
+			len(fields),
+			expectedFieldCount,
+		)
+	}
+
+	// Extract EpochCommit event fields
+
+	counter, err := getField[cadence.UInt64](fields, "counter")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochCommit event: %w", err)
+	}
+
+	cdcClusterQCVotes, err := getField[cadence.Array](fields, "clusterQCs")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochCommit event: %w", err)
+	}
+
+	cdcDKGKeys, err := getField[cadence.Array](fields, "dkgPubKeys")
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode EpochCommit event: %w", err)
+	}
+
+	commit := &flow.EpochCommit{
+		Counter: uint64(counter),
+	}
+
+	// parse cluster qc votes
+	commit.ClusterQCs, err = convertClusterQCVotes(cdcClusterQCVotes.Values)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert cluster qc votes: %w", err)
+	}
+
+	// parse DKG group key and participants
+	// Note: this is read in the same order as `DKGClient.SubmitResult` ie. with the group public key first followed by individual keys
+	// https://github.com/onflow/flow-go/blob/feature/dkg/module/dkg/client.go#L182-L183
+	commit.DKGGroupKey, err = convertDKGKey(cdcDKGKeys.Values[0])
+	if err != nil {
+		return nil, fmt.Errorf("could not convert DKG group key: %w", err)
+	}
+	commit.DKGParticipantKeys, err = convertDKGKeys(cdcDKGKeys.Values[1:])
+	if err != nil {
+		return nil, fmt.Errorf("could not convert DKG keys: %w", err)
+	}
+	commit.DKGIndexMap = nil
 
 	// create the service event
 	serviceEvent := &flow.ServiceEvent{

--- a/model/convert/service_event_test.go
+++ b/model/convert/service_event_test.go
@@ -100,6 +100,25 @@ func TestEventConversion(t *testing.T) {
 	},
 	)
 
+	// TODO(EFM, #6794): Remove this once we complete the network upgrade, this is only to test
+	//  backward compatibility of EpochCommit service event
+	t.Run("epoch commit, backward compatibility", func(t *testing.T) {
+
+		fixture, expected := unittest.EpochCommitV0FixtureByChainID(chainID)
+
+		// convert Cadence types to Go types
+		event, err := convert.ServiceEvent(chainID, fixture)
+		require.NoError(t, err)
+		require.NotNil(t, event)
+
+		// cast event type to epoch commit
+		actual, ok := event.Event.(*flow.EpochCommit)
+		require.True(t, ok)
+
+		assert.Equal(t, expected, actual)
+	},
+	)
+
 	t.Run("epoch recover", func(t *testing.T) {
 		fixture, expected := unittest.EpochRecoverFixtureByChainID(chainID)
 

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -399,6 +399,9 @@ func (commit *EpochCommit) UnmarshalMsgpack(b []byte) error {
 // differently from JSON/msgpack, because it does not handle custom encoders
 // within map types.
 // NOTE: DecodeRLP is not needed, as this is only used for hashing.
+// TODO(EFM, #6794): Currently we implement RLP encoding based on availability of DKGIndexMap
+// this is needed to support backward compatibility, to guarantee that we will produce same hash
+// for the same event. This should be removed once we complete the network upgrade.
 func (commit *EpochCommit) EncodeRLP(w io.Writer) error {
 	if commit.DKGIndexMap == nil {
 		rlpEncodable := struct {

--- a/state/protocol/inmem/dkg.go
+++ b/state/protocol/inmem/dkg.go
@@ -66,7 +66,7 @@ type DKGv0 struct {
 
 var _ protocol.DKG = (*DKGv0)(nil)
 
-func newDKGv0(setup *flow.EpochSetup, commit *flow.EpochCommit) *DKGv0 {
+func NewDKGv0(setup *flow.EpochSetup, commit *flow.EpochCommit) *DKGv0 {
 	return &DKGv0{
 		Participants: setup.Participants.Filter(filter.IsConsensusCommitteeMember),
 		Commit:       commit,

--- a/state/protocol/inmem/dkg.go
+++ b/state/protocol/inmem/dkg.go
@@ -2,10 +2,11 @@ package inmem
 
 import (
 	"fmt"
+
 	"github.com/onflow/crypto"
-	"github.com/onflow/flow-go/model/flow/filter"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/model/flow/filter"
 	"github.com/onflow/flow-go/state/protocol"
 )
 

--- a/state/protocol/inmem/dkg_test.go
+++ b/state/protocol/inmem/dkg_test.go
@@ -14,7 +14,6 @@ func TestDKGv0(t *testing.T) {
 	otherParticipants := unittest.IdentityListFixture(10, unittest.WithAllRolesExcept(flow.RoleConsensus))
 	setup := unittest.EpochSetupFixture(unittest.WithParticipants(append(consensusParticipants, otherParticipants...).ToSkeleton()))
 	commit := unittest.EpochCommitFixture(unittest.WithDKGFromParticipants(setup.Participants))
-	commit.DKGIndexMap = nil // pretend we don't have the index map and we are forced to use the v0.
 	dkg := inmem.NewDKGv0(setup, commit)
 	t.Run("Index", func(t *testing.T) {
 		for i, participant := range consensusParticipants {

--- a/state/protocol/inmem/dkg_test.go
+++ b/state/protocol/inmem/dkg_test.go
@@ -1,0 +1,54 @@
+package inmem_test
+
+import (
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/state/protocol"
+	"github.com/onflow/flow-go/state/protocol/inmem"
+	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDKGv0(t *testing.T) {
+	consensusParticipants := unittest.IdentityListFixture(5, unittest.WithRole(flow.RoleConsensus)).Sort(flow.Canonical[flow.Identity])
+	otherParticipants := unittest.IdentityListFixture(10, unittest.WithAllRolesExcept(flow.RoleConsensus))
+	setup := unittest.EpochSetupFixture(unittest.WithParticipants(append(consensusParticipants, otherParticipants...).ToSkeleton()))
+	commit := unittest.EpochCommitFixture(unittest.WithDKGFromParticipants(setup.Participants))
+	commit.DKGIndexMap = nil // pretend we don't have the index map and we are forced to use the v0.
+	dkg := inmem.NewDKGv0(setup, commit)
+	t.Run("Index", func(t *testing.T) {
+		for i, participant := range consensusParticipants {
+			index, err := dkg.Index(participant.NodeID)
+			require.NoError(t, err)
+			require.Equal(t, uint(i), index)
+		}
+		_, err := dkg.Index(otherParticipants[0].NodeID)
+		require.Error(t, err)
+		require.True(t, protocol.IsIdentityNotFound(err))
+	})
+	t.Run("NodeID", func(t *testing.T) {
+		for i, participant := range consensusParticipants {
+			nodeID, err := dkg.NodeID(uint(i))
+			require.NoError(t, err)
+			require.Equal(t, participant.NodeID, nodeID)
+		}
+		_, err := dkg.NodeID(uint(len(consensusParticipants)))
+		require.Error(t, err)
+	})
+	t.Run("KeyShare", func(t *testing.T) {
+		for i, participant := range consensusParticipants {
+			keyShare, err := dkg.KeyShare(participant.NodeID)
+			require.NoError(t, err)
+			require.Equal(t, commit.DKGParticipantKeys[i], keyShare)
+		}
+		_, err := dkg.KeyShare(otherParticipants[0].NodeID)
+		require.Error(t, err)
+		require.True(t, protocol.IsIdentityNotFound(err))
+	})
+	t.Run("Size", func(t *testing.T) {
+		require.Equal(t, uint(len(consensusParticipants)), dkg.Size())
+	})
+	t.Run("GroupKey", func(t *testing.T) {
+		require.Equal(t, commit.DKGGroupKey, dkg.GroupKey())
+	})
+}

--- a/state/protocol/inmem/dkg_test.go
+++ b/state/protocol/inmem/dkg_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 )
 
+// TestDKGv0 tests that the [inmem.DKG] is backward compatible with the v0 DKG protocol model.
+// We test this by creating a [inmem.DKG] instance from a v0 [flow.EpochSetup] and [flow.EpochCommit]
+// and verifying that the DKG methods return the expected values.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
 func TestDKGv0(t *testing.T) {
 	consensusParticipants := unittest.IdentityListFixture(5, unittest.WithRole(flow.RoleConsensus)).Sort(flow.Canonical[flow.Identity])
 	otherParticipants := unittest.IdentityListFixture(10, unittest.WithAllRolesExcept(flow.RoleConsensus))

--- a/state/protocol/inmem/dkg_test.go
+++ b/state/protocol/inmem/dkg_test.go
@@ -1,12 +1,14 @@
 package inmem_test
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/state/protocol/inmem"
 	"github.com/onflow/flow-go/utils/unittest"
-	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // TestDKGv0 tests that the [inmem.DKG] is backward compatible with the v0 DKG protocol model.

--- a/state/protocol/inmem/epoch.go
+++ b/state/protocol/inmem/epoch.go
@@ -223,7 +223,7 @@ func (es *committedEpoch) ClusterByChainID(chainID flow.ChainID) (protocol.Clust
 }
 
 func (es *committedEpoch) DKG() (protocol.DKG, error) {
-	return NewDKG(es.commitEvent), nil
+	return NewDKG(es.setupEvent, es.commitEvent), nil
 }
 
 // heightBoundedEpoch represents an epoch (with counter N) for which we know either

--- a/state/protocol/inmem/epoch_protocol_state.go
+++ b/state/protocol/inmem/epoch_protocol_state.go
@@ -52,7 +52,7 @@ func (s *EpochProtocolStateAdapter) EpochCommit() *flow.EpochCommit {
 // DKG returns the DKG information for the current epoch.
 // No errors are expected during normal operations.
 func (s *EpochProtocolStateAdapter) DKG() (protocol.DKG, error) {
-	return NewDKG(s.CurrentEpochCommit), nil
+	return NewDKG(s.CurrentEpochSetup, s.CurrentEpochCommit), nil
 }
 
 // Entry Returns low-level protocol state entry that was used to initialize this object.

--- a/storage/badger/epoch_commits.go
+++ b/storage/badger/epoch_commits.go
@@ -56,11 +56,6 @@ func (ec *EpochCommits) retrieveTx(commitID flow.Identifier) func(tx *badger.Txn
 	}
 }
 
-// TODO: can we remove this method? Its not contained in the interface.
-func (ec *EpochCommits) Store(commit *flow.EpochCommit) error {
-	return operation.RetryOnConflictTx(ec.db, transaction.Update, ec.StoreTx(commit))
-}
-
 // ByID will return the EpochCommit event by its ID.
 // Error returns:
 // * storage.ErrNotFound if no EpochCommit with the ID exists

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -142,8 +142,9 @@ func (commit *epochCommitV0) UnmarshalMsgpack(b []byte) error {
 
 func TestStoreV0AndDecodeV1(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		v1 := unittest.EpochCommitFixture()
-		//v1.DKGIndexMap = nil
+		v1 := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
+			commit.DKGIndexMap = nil
+		})
 		v0 := &epochCommitV0{
 			Counter:            v1.Counter,
 			ClusterQCs:         v1.ClusterQCs,
@@ -164,7 +165,7 @@ func TestStoreV0AndDecodeV1(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, v1, &actual)
 		require.Equal(t, v0.ID(), actual.ID())
-		require.Nil(t, actual.DKGIndexMap)
+		require.Equal(t, v1, &actual)
 	})
 
 }

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -53,6 +53,11 @@ func TestEpochCommitStoreAndRetrieve(t *testing.T) {
 	})
 }
 
+// epochCommitV0 is a version of [flow.EpochCommit] without the [flow.DKGIndexMap] field.
+// This exact structure was used to current mainnet and we would like to ensure that new version of [flow.EpochCommit]
+// is backward compatible with this structure.
+// It is used only in tests.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
 type epochCommitV0 struct {
 	// Counter is the epoch counter of the epoch being committed
 	Counter uint64
@@ -93,6 +98,8 @@ func (commit *epochCommitV0) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, rlpEncodable)
 }
 
+// encodableCommit represents encoding of epochCommitV0, it is used for serialization purposes and is used only in tests.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
 type encodableCommit struct {
 	Counter            uint64
 	ClusterQCs         []flow.ClusterQCVoteData
@@ -140,6 +147,10 @@ func (commit *epochCommitV0) UnmarshalMsgpack(b []byte) error {
 	return nil
 }
 
+// TestStoreV0AndDecodeV1 tests that an [flow.EpochCommit] without [flow.DKGIndexMap](v0) field can be stored and
+// later retrieved as a [flow.EpochCommit](v1) without any errors or data loss.
+// This test verifies that the [flow.EpochCommit] is backward compatible with respect to the [flow.DKGIndexMap] field.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
 func TestStoreV0AndDecodeV1(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		v1 := unittest.EpochCommitFixture()

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -2,6 +2,7 @@ package badger_test
 
 import (
 	"errors"
+	"github.com/onflow/flow-go/storage/badger/transaction"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -27,7 +28,9 @@ func TestEpochCommitStoreAndRetrieve(t *testing.T) {
 
 		// store a commit in db
 		expected := unittest.EpochCommitFixture()
-		err = store.Store(expected)
+		err = transaction.Update(db, func(tx *transaction.Tx) error {
+			return store.StoreTx(expected)(tx)
+		})
 		require.NoError(t, err)
 
 		// retrieve the commit by ID
@@ -36,7 +39,9 @@ func TestEpochCommitStoreAndRetrieve(t *testing.T) {
 		assert.Equal(t, expected, actual)
 
 		// test storing same epoch commit
-		err = store.Store(expected)
+		err = transaction.Update(db, func(tx *transaction.Tx) error {
+			return store.StoreTx(expected)(tx)
+		})
 		require.NoError(t, err)
 	})
 }

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -2,25 +2,24 @@ package badger_test
 
 import (
 	"errors"
-	"github.com/onflow/crypto"
-	"github.com/onflow/flow-go/model/encodable"
-	"github.com/onflow/flow-go/model/flow"
-	"github.com/onflow/flow-go/storage/badger/operation"
-	"github.com/onflow/flow-go/storage/badger/transaction"
-	"github.com/onflow/go-ethereum/rlp"
-	"github.com/vmihailenco/msgpack/v4"
 	"io"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/onflow/crypto"
+	"github.com/onflow/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v4"
 
+	"github.com/onflow/flow-go/model/encodable"
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/metrics"
 	"github.com/onflow/flow-go/storage"
-	"github.com/onflow/flow-go/utils/unittest"
-
 	badgerstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/storage/badger/operation"
+	"github.com/onflow/flow-go/storage/badger/transaction"
+	"github.com/onflow/flow-go/utils/unittest"
 )
 
 // TestEpochCommitStoreAndRetrieve tests that a commit can be stored, retrieved and attempted to be stored again without an error

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -142,9 +142,7 @@ func (commit *epochCommitV0) UnmarshalMsgpack(b []byte) error {
 
 func TestStoreV0AndDecodeV1(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
-		v1 := unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
-			commit.DKGIndexMap = nil
-		})
+		v1 := unittest.EpochCommitFixture()
 		v0 := &epochCommitV0{
 			Counter:            v1.Counter,
 			ClusterQCs:         v1.ClusterQCs,

--- a/storage/badger/epoch_commits_test.go
+++ b/storage/badger/epoch_commits_test.go
@@ -2,7 +2,14 @@ package badger_test
 
 import (
 	"errors"
+	"github.com/onflow/crypto"
+	"github.com/onflow/flow-go/model/encodable"
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage/badger/operation"
 	"github.com/onflow/flow-go/storage/badger/transaction"
+	"github.com/onflow/go-ethereum/rlp"
+	"github.com/vmihailenco/msgpack/v4"
+	"io"
 	"testing"
 
 	"github.com/dgraph-io/badger/v2"
@@ -44,4 +51,120 @@ func TestEpochCommitStoreAndRetrieve(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+}
+
+type epochCommitV0 struct {
+	// Counter is the epoch counter of the epoch being committed
+	Counter uint64
+	// ClusterQCs is an ordered list of root quorum certificates, one per cluster.
+	// EpochCommit.ClustersQCs[i] is the QC for EpochSetup.Assignments[i]
+	ClusterQCs []flow.ClusterQCVoteData
+	// DKGGroupKey is the group public key produced by the DKG associated with this epoch.
+	// It is used to verify Random Beacon signatures for the epoch with counter, Counter.
+	DKGGroupKey crypto.PublicKey
+	// DKGParticipantKeys is a list of public keys, one per DKG participant, ordered by Random Beacon index.
+	// This list is the output of the DKG associated with this epoch.
+	// It is used to verify Random Beacon signatures for the epoch with counter, Counter.
+	// CAUTION: This list may include keys for nodes which do not exist in the consensus committee
+	//          and may NOT include keys for all nodes in the consensus committee.
+	DKGParticipantKeys []crypto.PublicKey
+}
+
+func (commit *epochCommitV0) ID() flow.Identifier {
+	return flow.MakeID(commit)
+}
+
+func (commit *epochCommitV0) EncodeRLP(w io.Writer) error {
+	rlpEncodable := struct {
+		Counter            uint64
+		ClusterQCs         []flow.ClusterQCVoteData
+		DKGGroupKey        []byte
+		DKGParticipantKeys [][]byte
+	}{
+		Counter:            commit.Counter,
+		ClusterQCs:         commit.ClusterQCs,
+		DKGGroupKey:        commit.DKGGroupKey.Encode(),
+		DKGParticipantKeys: make([][]byte, 0, len(commit.DKGParticipantKeys)),
+	}
+	for _, key := range commit.DKGParticipantKeys {
+		rlpEncodable.DKGParticipantKeys = append(rlpEncodable.DKGParticipantKeys, key.Encode())
+	}
+
+	return rlp.Encode(w, rlpEncodable)
+}
+
+type encodableCommit struct {
+	Counter            uint64
+	ClusterQCs         []flow.ClusterQCVoteData
+	DKGGroupKey        encodable.RandomBeaconPubKey
+	DKGParticipantKeys []encodable.RandomBeaconPubKey
+}
+
+func encodableFromCommit(commit *epochCommitV0) encodableCommit {
+	encKeys := make([]encodable.RandomBeaconPubKey, 0, len(commit.DKGParticipantKeys))
+	for _, key := range commit.DKGParticipantKeys {
+		encKeys = append(encKeys, encodable.RandomBeaconPubKey{PublicKey: key})
+	}
+	return encodableCommit{
+		Counter:            commit.Counter,
+		ClusterQCs:         commit.ClusterQCs,
+		DKGGroupKey:        encodable.RandomBeaconPubKey{PublicKey: commit.DKGGroupKey},
+		DKGParticipantKeys: encKeys,
+	}
+}
+
+func commitFromEncodable(enc encodableCommit) epochCommitV0 {
+	dkgKeys := make([]crypto.PublicKey, 0, len(enc.DKGParticipantKeys))
+	for _, key := range enc.DKGParticipantKeys {
+		dkgKeys = append(dkgKeys, key.PublicKey)
+	}
+	return epochCommitV0{
+		Counter:            enc.Counter,
+		ClusterQCs:         enc.ClusterQCs,
+		DKGGroupKey:        enc.DKGGroupKey.PublicKey,
+		DKGParticipantKeys: dkgKeys,
+	}
+}
+
+func (commit *epochCommitV0) MarshalMsgpack() ([]byte, error) {
+	return msgpack.Marshal(encodableFromCommit(commit))
+}
+
+func (commit *epochCommitV0) UnmarshalMsgpack(b []byte) error {
+	var enc encodableCommit
+	err := msgpack.Unmarshal(b, &enc)
+	if err != nil {
+		return err
+	}
+	*commit = commitFromEncodable(enc)
+	return nil
+}
+
+func TestStoreV0AndDecodeV1(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		v1 := unittest.EpochCommitFixture()
+		//v1.DKGIndexMap = nil
+		v0 := &epochCommitV0{
+			Counter:            v1.Counter,
+			ClusterQCs:         v1.ClusterQCs,
+			DKGGroupKey:        v1.DKGGroupKey,
+			DKGParticipantKeys: v1.DKGParticipantKeys,
+		}
+		require.Equal(t, v0.ID(), v1.ID())
+
+		err := transaction.Update(db, func(tx *transaction.Tx) error {
+			return operation.InsertEpochCommitV0(v0.ID(), v0)(tx.DBTxn)
+		})
+		require.NoError(t, err)
+
+		var actual flow.EpochCommit
+		err = transaction.View(db, func(tx *transaction.Tx) error {
+			return operation.RetrieveEpochCommit(v0.ID(), &actual)(tx.DBTxn)
+		})
+		require.NoError(t, err)
+		require.Equal(t, v1, &actual)
+		require.Equal(t, v0.ID(), actual.ID())
+		require.Nil(t, actual.DKGIndexMap)
+	})
+
 }

--- a/storage/badger/operation/epoch.go
+++ b/storage/badger/operation/epoch.go
@@ -18,6 +18,9 @@ func InsertEpochCommit(eventID flow.Identifier, event *flow.EpochCommit) func(*b
 	return insert(makePrefix(codeEpochCommit, eventID), event)
 }
 
+// InsertEpochCommitV0 inserts an epoch commit event. This is used only in testing to verify that we have backward compatibility
+// at storage layer.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
 func InsertEpochCommitV0(eventID flow.Identifier, event any) func(*badger.Txn) error {
 	return insert(makePrefix(codeEpochCommit, eventID), event)
 }

--- a/storage/badger/operation/epoch.go
+++ b/storage/badger/operation/epoch.go
@@ -18,6 +18,10 @@ func InsertEpochCommit(eventID flow.Identifier, event *flow.EpochCommit) func(*b
 	return insert(makePrefix(codeEpochCommit, eventID), event)
 }
 
+func InsertEpochCommitV0(eventID flow.Identifier, event any) func(*badger.Txn) error {
+	return insert(makePrefix(codeEpochCommit, eventID), event)
+}
+
 func RetrieveEpochCommit(eventID flow.Identifier, event *flow.EpochCommit) func(*badger.Txn) error {
 	return retrieve(makePrefix(codeEpochCommit, eventID), event)
 }

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -161,6 +161,43 @@ func EpochCommitFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCom
 	return event, expected
 }
 
+// EpochCommitV0FixtureByChainID returns an EpochCommit service event for old data model as a Cadence event
+// representation and as a protocol model representation. This is used for testing backwards compatibility.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func EpochCommitV0FixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochCommit) {
+	events := systemcontracts.ServiceEventsForChain(chain)
+
+	event := EventFixture(events.EpochCommit.EventType(), 1, 1, IdentifierFixture(), 0)
+	event.Payload = EpochCommitV0FixtureCCF
+
+	expected := &flow.EpochCommit{
+		Counter: 1,
+		ClusterQCs: []flow.ClusterQCVoteData{
+			{
+				VoterIDs: []flow.Identifier{
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000001"),
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000002"),
+				},
+				SigData: MustDecodeSignatureHex("b072ed22ed305acd44818a6c836e09b4e844eebde6a4fdbf5cec983e2872b86c8b0f6c34c0777bf52e385ab7c45dc55d"),
+			},
+			{
+				VoterIDs: []flow.Identifier{
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000003"),
+					flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000004"),
+				},
+				SigData: MustDecodeSignatureHex("899e266a543e1b3a564f68b22f7be571f2e944ec30fadc4b39e2d5f526ba044c0f3cb2648f8334fc216fa3360a0418b2"),
+			},
+		},
+		DKGGroupKey: MustDecodePublicKeyHex(crypto.BLSBLS12381, "8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+		DKGParticipantKeys: []crypto.PublicKey{
+			MustDecodePublicKeyHex(crypto.BLSBLS12381, "87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		},
+		DKGIndexMap: nil,
+	}
+
+	return event, expected
+}
+
 // EpochRecoverFixtureByChainID returns an EpochRecover service event as a Cadence event
 // representation and as a protocol model representation.
 func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochRecover) {
@@ -815,6 +852,71 @@ func createEpochCommitEvent() cadence.Event {
 	}).WithType(newFlowEpochEpochCommitEventType())
 }
 
+// createEpochCommitEventV0 creates an EpochCommit event with the old data model, it is used to ensure that new version
+// is backward compatible with the old version.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func createEpochCommitEventV0() cadence.Event {
+
+	clusterQCType := newFlowClusterQCClusterQCStructType()
+
+	cluster1 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.UInt16(0),
+
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("a39cd1e1bf7e2fb0609b7388ce5215a6a4c01eef2aee86e1a007faa28a6b2a3dc876e11bb97cdb26c3846231d2d01e4d"),
+			cadence.String("91673ad9c717d396c9a0953617733c128049ac1a639653d4002ab245b121df1939430e313bcbfd06948f6a281f6bf853"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+
+		// voteMessage
+		cadence.String("irrelevant_for_these_purposes"),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000001"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000002"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(clusterQCType)
+
+	cluster2 := cadence.NewStruct([]cadence.Value{
+		// index
+		cadence.UInt16(1),
+
+		// voteSignatures
+		cadence.NewArray([]cadence.Value{
+			cadence.String("b2bff159971852ed63e72c37991e62c94822e52d4fdcd7bf29aaf9fb178b1c5b4ce20dd9594e029f3574cb29533b857a"),
+			cadence.String("9931562f0248c9195758da3de4fb92f24fa734cbc20c0cb80280163560e0e0348f843ac89ecbd3732e335940c1e8dccb"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+
+		// voteMessage
+		cadence.String("irrelevant_for_these_purposes"),
+
+		// voterIDs
+		cadence.NewArray([]cadence.Value{
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000003"),
+			cadence.String("0000000000000000000000000000000000000000000000000000000000000004"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(clusterQCType)
+
+	return cadence.NewEvent([]cadence.Value{
+		// counter
+		cadence.NewUInt64(1),
+
+		// clusterQCs
+		cadence.NewArray([]cadence.Value{
+			cluster1,
+			cluster2,
+		}).WithType(cadence.NewVariableSizedArrayType(clusterQCType)),
+
+		// dkgPubKeys
+		cadence.NewArray([]cadence.Value{
+			cadence.String("8c588266db5f5cda629e83f8aa04ae9413593fac19e4865d06d291c9d14fbdd9bdb86a7a12f9ef8590c79cb635e3163315d193087e9336092987150d0cd2b14ac6365f7dc93eec573752108b8c12368abb65f0652d9f644e5aed611c37926950"),
+			cadence.String("87a339e4e5c74f089da20a33f515d8c8f4464ab53ede5a74aa2432cd1ae66d522da0c122249ee176cd747ddc83ca81090498389384201614caf51eac392c1c0a916dfdcfbbdf7363f9552b6468434add3d3f6dc91a92bbe3ee368b59b7828488"),
+		}).WithType(cadence.NewVariableSizedArrayType(cadence.StringType)),
+	}).WithType(newFlowEpochEpochCommitEventTypeV0())
+}
+
 func createEpochRecoverEvent(randomSourceHex string) cadence.Event {
 
 	clusterQCVoteDataType := newFlowClusterQCClusterQCVoteDataStructType()
@@ -1162,6 +1264,37 @@ func newFlowEpochEpochCommitEventType() *cadence.EventType {
 	)
 }
 
+// newFlowEpochEpochCommitEventTypeV0 creates an EpochCommit event with the old data model, it is used to ensure that new version
+// is backward compatible with the old version.
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+func newFlowEpochEpochCommitEventTypeV0() *cadence.EventType {
+
+	// A.01cf0e2f2f715450.FlowEpoch.EpochCommitted
+
+	address, _ := common.HexToAddress("01cf0e2f2f715450")
+	location := common.NewAddressLocation(nil, address, "FlowEpoch")
+
+	return cadence.NewEventType(
+		location,
+		"FlowEpoch.EpochCommitted",
+		[]cadence.Field{
+			{
+				Identifier: "counter",
+				Type:       cadence.UInt64Type,
+			},
+			{
+				Identifier: "clusterQCs",
+				Type:       cadence.NewVariableSizedArrayType(newFlowClusterQCClusterQCStructType()),
+			},
+			{
+				Identifier: "dkgPubKeys",
+				Type:       cadence.NewVariableSizedArrayType(cadence.StringType),
+			},
+		},
+		nil,
+	)
+}
+
 func newFlowEpochEpochRecoverEventType() *cadence.EventType {
 
 	// A.01cf0e2f2f715450.FlowEpoch.EpochRecover
@@ -1441,6 +1574,19 @@ func EpochSetupCCFWithNonHexRandomSource() []byte {
 
 var EpochCommitFixtureCCF = func() []byte {
 	b, err := ccf.Encode(createEpochCommitEvent())
+	if err != nil {
+		panic(err)
+	}
+	_, err = ccf.Decode(nil, b)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}()
+
+// TODO(EFM, #6794): Remove this once we complete the network upgrade
+var EpochCommitV0FixtureCCF = func() []byte {
+	b, err := ccf.Encode(createEpochCommitEventV0())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/6785

### Context

This PR fixes code paths that are relying on changes to the `EpochCommit` which were introduced in EFM workstream. In order to support protocol upgrade without spork we need to ensure that our new software version supports both data models (v0 and v1). 

This PR modifies existing logic to use v0 behavior for v0 data models. Majority of logic still relies on new representation of `flow.EpochCommit` with the `flow.DKGIndexMap` field. However if `flow.DKGIndexMap = nil` we will use pre-upgrade logic to follow the protocol, otherwise we use new rules.

I have created multiple TODOs in next format: `TODO(EFM, #6794)` that needs to be removed after performing the upgrade, when we decide that we don't want to support v0 anymore. 
