### PR TITLE
Refactor AsyncUploader to replace Engine.Unit with ComponentManager

### DIFF
--- a/engine/execution/ingestion/uploader/retryable_uploader_wrapper.go
+++ b/engine/execution/ingestion/uploader/retryable_uploader_wrapper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/storage"
@@ -34,6 +35,7 @@ type BadgerRetryableUploaderWrapper struct {
 	results            storage.ExecutionResults
 	transactionResults storage.TransactionResults
 	uploadStatusStore  storage.ComputationResultUploadStatus
+	component.Component
 }
 
 func NewBadgerRetryableUploaderWrapper(
@@ -99,15 +101,8 @@ func NewBadgerRetryableUploaderWrapper(
 		results:            results,
 		transactionResults: transactionResults,
 		uploadStatusStore:  uploadStatusStore,
+		Component:          uploader, // delegate to the AsyncUploader
 	}
-}
-
-func (b *BadgerRetryableUploaderWrapper) Ready() <-chan struct{} {
-	return b.uploader.Ready()
-}
-
-func (b *BadgerRetryableUploaderWrapper) Done() <-chan struct{} {
-	return b.uploader.Done()
 }
 
 func (b *BadgerRetryableUploaderWrapper) Upload(computationResult *execution.ComputationResult) error {

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -2,13 +2,17 @@ package uploader
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/engine"
+	"github.com/onflow/flow-go/engine/common/fifoqueue"
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/module"
+	"github.com/onflow/flow-go/module/component"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/utils/logging"
 
 	"github.com/sethvargo/go-retry"
@@ -26,74 +30,135 @@ func NewAsyncUploader(uploader Uploader,
 	maxRetryNumber uint64,
 	log zerolog.Logger,
 	metrics module.ExecutionMetrics) *AsyncUploader {
-	return &AsyncUploader{
-		unit:                engine.NewUnit(),
+	// TODO queue size, add length metrics and check error
+	queue, _ := fifoqueue.NewFifoQueue(1000)
+	a := &AsyncUploader{
 		uploader:            uploader,
 		log:                 log.With().Str("component", "block_data_uploader").Logger(),
 		metrics:             metrics,
 		retryInitialTimeout: retryInitialTimeout,
 		maxRetryNumber:      maxRetryNumber,
+		queue:               queue,
+		notifier:            engine.NewNotifier(),
 	}
+	builder := component.NewComponentManagerBuilder()
+	for range 3 {
+		builder.AddWorker(a.UploadWorker)
+	}
+	a.cm = builder.Build()
+	a.Component = a.cm
+	return a
 }
 
 // AsyncUploader wraps up another Uploader instance and make its upload asynchronous
 type AsyncUploader struct {
-	module.ReadyDoneAware
-	unit                *engine.Unit
 	uploader            Uploader
 	log                 zerolog.Logger
 	metrics             module.ExecutionMetrics
 	retryInitialTimeout time.Duration
 	maxRetryNumber      uint64
 	onComplete          OnCompleteFunc // callback function called after Upload is completed
+	queue               *fifoqueue.FifoQueue
+	notifier            engine.Notifier
+	cm                  *component.ComponentManager
+	component.Component
+	// TODO Replace fifoqueue with channel, and make Upload() blocking
 }
 
-func (a *AsyncUploader) Ready() <-chan struct{} {
-	return a.unit.Ready()
+// UploadWorker implements a component worker which asynchronously uploads computation results
+// from the execution node (after a block is executed) to storage such as a GCP bucket or S3 bucket.
+func (a *AsyncUploader) UploadWorker(ctx irrecoverable.SignalerContext, ready component.ReadyFunc) {
+	ready()
+
+	done := ctx.Done()
+	wake := a.notifier.Channel()
+	for {
+		select {
+		case <-done:
+			return
+		case <-wake:
+			err := a.processUploadTasks(ctx)
+			if err != nil {
+				ctx.Throw(err)
+			}
+		}
+	}
 }
 
-func (a *AsyncUploader) Done() <-chan struct{} {
-	return a.unit.Done()
+// processUploadTasks processes any available tasks from the queue.
+// Only returns when the queue is empty (or the component is terminated).
+// No errors expected during normal operation.
+func (a *AsyncUploader) processUploadTasks(ctx context.Context) error {
+	for {
+		item, ok := a.queue.Pop()
+		if !ok {
+			return nil
+		}
+
+		computationResult, ok := item.(*execution.ComputationResult)
+		if !ok {
+			return fmt.Errorf("invalid type in AsyncUploader queue")
+		}
+
+		a.UploadTask(ctx, computationResult)
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
 }
 
 func (a *AsyncUploader) SetOnCompleteCallback(onComplete OnCompleteFunc) {
 	a.onComplete = onComplete
 }
 
+// Upload adds the computation result to a queue to be processed asynchronously by workers,
+// ensuring that multiple uploads can be run in parallel.
+// No errors expected during normal operation.
 func (a *AsyncUploader) Upload(computationResult *execution.ComputationResult) error {
+	if a.queue.Push(computationResult) {
+		a.notifier.Notify()
+	} else {
+		// TODO record in metrics
+	}
+	return nil
+}
 
+// UploadTask implements retrying for uploading computation results.
+// When the upload is complete, the callback will be called with the result (for example,
+// to record that the upload was successful) and any error.
+// No errors expected during normal operation.
+func (a *AsyncUploader) UploadTask(ctx context.Context, computationResult *execution.ComputationResult) {
 	backoff := retry.NewFibonacci(a.retryInitialTimeout)
 	backoff = retry.WithMaxRetries(a.maxRetryNumber, backoff)
 
-	a.unit.Launch(func() {
-		a.metrics.ExecutionBlockDataUploadStarted()
-		start := time.Now()
+	a.metrics.ExecutionBlockDataUploadStarted()
+	start := time.Now()
 
-		a.log.Debug().Msgf("computation result of block %s is being uploaded",
-			computationResult.ExecutableBlock.ID().String())
+	a.log.Debug().Msgf("computation result of block %s is being uploaded",
+		computationResult.ExecutableBlock.ID().String())
 
-		err := retry.Do(a.unit.Ctx(), backoff, func(ctx context.Context) error {
-			err := a.uploader.Upload(computationResult)
-			if err != nil {
-				a.log.Warn().Err(err).Msg("error while uploading block data, retrying")
-			}
-			return retry.RetryableError(err)
-		})
-
+	err := retry.Do(ctx, backoff, func(ctx context.Context) error {
+		err := a.uploader.Upload(computationResult)
 		if err != nil {
-			a.log.Error().Err(err).
-				Hex("block_id", logging.Entity(computationResult.ExecutableBlock)).
-				Msg("failed to upload block data")
-		} else {
-			a.log.Debug().Msgf("computation result of block %s was successfully uploaded",
-				computationResult.ExecutableBlock.ID().String())
+			a.log.Warn().Err(err).Msg("error while uploading block data, retrying")
 		}
-
-		a.metrics.ExecutionBlockDataUploadFinished(time.Since(start))
-
-		if a.onComplete != nil {
-			a.onComplete(computationResult, err)
-		}
+		return retry.RetryableError(err)
 	})
-	return nil
+
+	if err != nil {
+		a.log.Error().Err(err).
+			Hex("block_id", logging.Entity(computationResult.ExecutableBlock)).
+			Msg("failed to upload block data")
+	} else {
+		a.log.Debug().Msgf("computation result of block %s was successfully uploaded",
+			computationResult.ExecutableBlock.ID().String())
+	}
+
+	a.metrics.ExecutionBlockDataUploadFinished(time.Since(start))
+
+	if a.onComplete != nil {
+		a.onComplete(computationResult, err)
+	}
 }

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -36,7 +36,7 @@ func NewAsyncUploader(uploader Uploader,
 		queue:               make(chan *execution.ComputationResult, 100),
 	}
 	builder := component.NewComponentManagerBuilder()
-	for range 3 {
+	for i := 0; i < 3; i++ {
 		builder.AddWorker(a.UploadWorker)
 	}
 	a.cm = builder.Build()

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -35,7 +35,7 @@ func NewAsyncUploader(uploader Uploader,
 		maxRetryNumber:      maxRetryNumber,
 		// we use a channel rather than a Fifoqueue here because a Fifoqueue might drop items when full,
 		// but it is not acceptable to skip uploading an execution result
-		queue:               make(chan *execution.ComputationResult, 20000),
+		queue: make(chan *execution.ComputationResult, 20000),
 	}
 	builder := component.NewComponentManagerBuilder()
 	for i := 0; i < 10; i++ {

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -33,6 +33,8 @@ func NewAsyncUploader(uploader Uploader,
 		metrics:             metrics,
 		retryInitialTimeout: retryInitialTimeout,
 		maxRetryNumber:      maxRetryNumber,
+		// we use a channel rather than a Fifoqueue here because a Fifoqueue might drop items when full,
+		// but it is not acceptable to skip uploading an execution result
 		queue:               make(chan *execution.ComputationResult, 100),
 	}
 	builder := component.NewComponentManagerBuilder()

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -35,10 +35,10 @@ func NewAsyncUploader(uploader Uploader,
 		maxRetryNumber:      maxRetryNumber,
 		// we use a channel rather than a Fifoqueue here because a Fifoqueue might drop items when full,
 		// but it is not acceptable to skip uploading an execution result
-		queue:               make(chan *execution.ComputationResult, 100),
+		queue:               make(chan *execution.ComputationResult, 20000),
 	}
 	builder := component.NewComponentManagerBuilder()
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		builder.AddWorker(a.UploadWorker)
 	}
 	a.cm = builder.Build()

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -2,13 +2,10 @@ package uploader
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/rs/zerolog"
 
-	"github.com/onflow/flow-go/engine"
-	"github.com/onflow/flow-go/engine/common/fifoqueue"
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/component"
@@ -30,16 +27,13 @@ func NewAsyncUploader(uploader Uploader,
 	maxRetryNumber uint64,
 	log zerolog.Logger,
 	metrics module.ExecutionMetrics) *AsyncUploader {
-	// TODO queue size, add length metrics and check error
-	queue, _ := fifoqueue.NewFifoQueue(1000)
 	a := &AsyncUploader{
 		uploader:            uploader,
 		log:                 log.With().Str("component", "block_data_uploader").Logger(),
 		metrics:             metrics,
 		retryInitialTimeout: retryInitialTimeout,
 		maxRetryNumber:      maxRetryNumber,
-		queue:               queue,
-		notifier:            engine.NewNotifier(),
+		queue:               make(chan *execution.ComputationResult, 100),
 	}
 	builder := component.NewComponentManagerBuilder()
 	for range 3 {
@@ -58,8 +52,7 @@ type AsyncUploader struct {
 	retryInitialTimeout time.Duration
 	maxRetryNumber      uint64
 	onComplete          OnCompleteFunc // callback function called after Upload is completed
-	queue               *fifoqueue.FifoQueue
-	notifier            engine.Notifier
+	queue               chan *execution.ComputationResult
 	cm                  *component.ComponentManager
 	component.Component
 	// TODO Replace fifoqueue with channel, and make Upload() blocking
@@ -71,40 +64,12 @@ func (a *AsyncUploader) UploadWorker(ctx irrecoverable.SignalerContext, ready co
 	ready()
 
 	done := ctx.Done()
-	wake := a.notifier.Channel()
 	for {
 		select {
 		case <-done:
 			return
-		case <-wake:
-			err := a.processUploadTasks(ctx)
-			if err != nil {
-				ctx.Throw(err)
-			}
-		}
-	}
-}
-
-// processUploadTasks processes any available tasks from the queue.
-// Only returns when the queue is empty (or the component is terminated).
-// No errors expected during normal operation.
-func (a *AsyncUploader) processUploadTasks(ctx context.Context) error {
-	for {
-		item, ok := a.queue.Pop()
-		if !ok {
-			return nil
-		}
-
-		computationResult, ok := item.(*execution.ComputationResult)
-		if !ok {
-			return fmt.Errorf("invalid type in AsyncUploader queue")
-		}
-
-		a.UploadTask(ctx, computationResult)
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
+		case computationResult := <-a.queue:
+			a.UploadTask(ctx, computationResult)
 		}
 	}
 }
@@ -117,11 +82,7 @@ func (a *AsyncUploader) SetOnCompleteCallback(onComplete OnCompleteFunc) {
 // ensuring that multiple uploads can be run in parallel.
 // No errors expected during normal operation.
 func (a *AsyncUploader) Upload(computationResult *execution.ComputationResult) error {
-	if a.queue.Push(computationResult) {
-		a.notifier.Notify()
-	} else {
-		// TODO record in metrics
-	}
+	a.queue <- computationResult
 	return nil
 }
 

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -55,7 +55,6 @@ type AsyncUploader struct {
 	queue               chan *execution.ComputationResult
 	cm                  *component.ComponentManager
 	component.Component
-	// TODO Replace fifoqueue with channel, and make Upload() blocking
 }
 
 // UploadWorker implements a component worker which asynchronously uploads computation results
@@ -108,6 +107,8 @@ func (a *AsyncUploader) UploadTask(ctx context.Context, computationResult *execu
 		return retry.RetryableError(err)
 	})
 
+	// We only log upload errors here because the errors originate from an external cloud provider
+	// and the upload success is not critical to correct continued operation of the node
 	if err != nil {
 		a.log.Error().Err(err).
 			Hex("block_id", logging.Entity(computationResult.ExecutableBlock)).

--- a/engine/execution/ingestion/uploader/uploader_test.go
+++ b/engine/execution/ingestion/uploader/uploader_test.go
@@ -206,7 +206,7 @@ func Test_AsyncUploader(t *testing.T) {
 		err := async.Upload(computationResult)
 		require.NoError(t, err)
 
-		wgUploadCalleded.Wait()
+		unittest.AssertReturnsBefore(t, wgUploadCalleded.Wait, time.Second)
 		cancel()
 		unittest.AssertClosesBefore(t, async.Done(), 1*time.Second, "async uploader not done in time")
 

--- a/module/component/component.go
+++ b/module/component/component.go
@@ -19,9 +19,25 @@ var ErrComponentShutdown = fmt.Errorf("component has already shut down")
 // channels that close when startup and shutdown have completed.
 // Once Start has been called, the channel returned by Done must close eventually,
 // whether that be because of a graceful shutdown or an irrecoverable error.
+// See also ComponentManager below.
 type Component interface {
 	module.Startable
-	module.ReadyDoneAware
+	// Ready returns a ready channel that is closed once startup has completed.
+	// Unlike the previous ReadyDoneAware interface, it has no effect on the state of the component,
+	// and only exposes information about the component's state.
+	// To start the component, instead use the Start() method.
+	// Note that the ready channel may never close if errors are encountered during startup,
+	// or if shutdown has already commenced before startup is complete.
+	// This should be an idempotent method.
+	Ready() <-chan struct{}
+
+	// Done returns a done channel that is closed once shutdown has completed.
+	// Unlike the previous ReadyDoneAware interface, it has no effect on the state of the component,
+	// and only exposes information about the component's state.
+	// To shutdown the component, instead cancel the context that was passed to Start().
+	// Note that the done channel should be closed even if errors are encountered during shutdown.
+	// This should be an idempotent method.
+	Done() <-chan struct{}
 }
 
 type ComponentFactory func() (Component, error)

--- a/module/component/component.go
+++ b/module/component/component.go
@@ -23,7 +23,7 @@ var ErrComponentShutdown = fmt.Errorf("component has already shut down")
 type Component interface {
 	module.Startable
 	// Ready returns a ready channel that is closed once startup has completed.
-	// Unlike the previous ReadyDoneAware interface, it has no effect on the state of the component,
+	// Unlike the previous [module.ReadyDoneAware] interface, it has no effect on the state of the component,
 	// and only exposes information about the component's state.
 	// To start the component, instead use the Start() method.
 	// Note that the ready channel may never close if errors are encountered during startup,
@@ -32,10 +32,10 @@ type Component interface {
 	Ready() <-chan struct{}
 
 	// Done returns a done channel that is closed once shutdown has completed.
-	// Unlike the previous ReadyDoneAware interface, it has no effect on the state of the component,
+	// Unlike the previous [module.ReadyDoneAware] interface, it has no effect on the state of the component,
 	// and only exposes information about the component's state.
 	// To shutdown the component, instead cancel the context that was passed to Start().
-	// Note that the done channel should be closed even if errors are encountered during shutdown.
+	// Implementations must close the done channel even if errors are encountered during shutdown.
 	// This should be an idempotent method.
 	Done() <-chan struct{}
 }

--- a/module/component/component.go
+++ b/module/component/component.go
@@ -23,8 +23,8 @@ var ErrComponentShutdown = fmt.Errorf("component has already shut down")
 type Component interface {
 	module.Startable
 	// Ready returns a ready channel that is closed once startup has completed.
-	// Unlike the previous [module.ReadyDoneAware] interface, it has no effect on the state of the component,
-	// and only exposes information about the component's state.
+	// Unlike the previous [module.ReadyDoneAware] interface, Ready does not start the component,
+	// but only exposes information about whether the component has completed startup.
 	// To start the component, instead use the Start() method.
 	// Note that the ready channel may never close if errors are encountered during startup,
 	// or if shutdown has already commenced before startup is complete.
@@ -32,8 +32,8 @@ type Component interface {
 	Ready() <-chan struct{}
 
 	// Done returns a done channel that is closed once shutdown has completed.
-	// Unlike the previous [module.ReadyDoneAware] interface, it has no effect on the state of the component,
-	// and only exposes information about the component's state.
+	// Unlike the previous [module.ReadyDoneAware] interface, Done does not shut down the component,
+	// but only exposes information about whether the component has shut down yet.
 	// To shutdown the component, instead cancel the context that was passed to Start().
 	// Implementations must close the done channel even if errors are encountered during shutdown.
 	// This should be an idempotent method.


### PR DESCRIPTION
AsyncUploader now uses the Component interface, and a channel is used to buffer upload tasks until a worker goroutine is available to begin the upload.
- An [arbitrary value of 3](https://github.com/onflow/flow-go/pull/6809/files#diff-2ba04bc060b7bbc8d31bb4a84c91a0bbfc31e2c781ff0f5ef15c0153427d2ddbR39-R41) was chosen as the worker count; need feedback on an appropriate number for this (and the [channel buffer size](https://github.com/onflow/flow-go/pull/6809/files#diff-2ba04bc060b7bbc8d31bb4a84c91a0bbfc31e2c781ff0f5ef15c0153427d2ddbR36) as well). This could also potentially be configurable.
- Also affects the [BadgerRetryableUploadWrapper](https://github.com/onflow/flow-go/commit/9c57c77c1772cb258e0be1dda91cb133e2b5e473) which wraps an AsyncUploader.

In addition, updated documentation comments for the Component interface to clarify differences from ReadyDoneAware.

Part of https://github.com/onflow/flow-go/issues/6807.