### PR TITLE
Update build workflow to push to artifact registry

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -119,7 +119,7 @@ jobs:
         if [[ "${{ github.event.inputs.private_build }}" == "true" ]]; then
           gcloud auth configure-docker us-central1-docker.pkg.dev
         else
-          gcloud auth configure-docker
+          gcloud auth configure-docker us-docker.pkg.dev
         fi
 
     - name: Set CONTAINER_REGISTRY


### PR DESCRIPTION
## Description
GCR is being deprecated by GCP, and we are migrating our images to Artifact Registry. The following PR updates the builds to be pushed to artifact registry. As part of the migration, the registry endpoint will remain the same as it will continue to be the `gcr.io/flow-container-registry` endpoint.