### PR TITLE
Introduce the `dryCall` method under `EVM` contract & `CadenceOwnedAccount` resource

### DIFF
--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("e5374ec916225cbe3b511b7d741f05ca1e69b77493e258bb7ec981a102535dfc")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("ea660c27b27ecfa7f93ee0462918b60145db8a78bc6a7e428574d4150b83b1b5")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -13,6 +13,8 @@ import (
 	"github.com/onflow/flow-go/fvm/evm/stdlib"
 	"github.com/onflow/flow-go/fvm/evm/types"
 	"github.com/onflow/flow-go/model/flow"
+
+	gethTypes "github.com/onflow/go-ethereum/core/types"
 )
 
 var internalEVMContractStaticType = interpreter.ConvertSemaCompositeTypeToStaticCompositeType(
@@ -50,6 +52,7 @@ func NewInternalEVMContractValue(
 			stdlib.InternalEVMTypeCastToFLOWFunctionName:                newInternalEVMTypeCastToFLOWFunction(gauge),
 			stdlib.InternalEVMTypeGetLatestBlockFunctionName:            newInternalEVMTypeGetLatestBlockFunction(gauge, handler),
 			stdlib.InternalEVMTypeDryRunFunctionName:                    newInternalEVMTypeDryRunFunction(gauge, handler),
+			stdlib.InternalEVMTypeDryCallFunctionName:                   newInternalEVMTypeDryCallFunction(gauge, handler),
 			stdlib.InternalEVMTypeCommitBlockProposalFunctionName:       newInternalEVMTypeCommitBlockProposalFunction(gauge, handler),
 		},
 		nil,
@@ -890,6 +893,95 @@ func newInternalEVMTypeDryRunFunction(
 			// call estimate
 
 			res := handler.DryRun(transaction, types.NewAddressFromBytes(from))
+			return NewResultValue(handler, gauge, inter, locationRange, res)
+		},
+	)
+}
+
+func newInternalEVMTypeDryCallFunction(
+	gauge common.MemoryGauge,
+	handler types.ContractHandler,
+) *interpreter.HostFunctionValue {
+	return interpreter.NewStaticHostFunctionValue(
+		gauge,
+		stdlib.InternalEVMTypeDryCallFunctionType,
+		func(invocation interpreter.Invocation) interpreter.Value {
+			inter := invocation.Interpreter
+			locationRange := invocation.LocationRange
+
+			// Get from address
+
+			fromAddressValue, ok := invocation.Arguments[0].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			fromAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, fromAddressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get to address
+
+			toAddressValue, ok := invocation.Arguments[1].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			toAddress, err := AddressBytesArrayValueToEVMAddress(inter, locationRange, toAddressValue)
+			if err != nil {
+				panic(err)
+			}
+
+			to := toAddress.ToCommon()
+
+			// Get data
+
+			dataValue, ok := invocation.Arguments[2].(*interpreter.ArrayValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			data, err := interpreter.ByteArrayValueToByteSlice(inter, dataValue, locationRange)
+			if err != nil {
+				panic(err)
+			}
+
+			// Get gas limit
+
+			gasLimitValue, ok := invocation.Arguments[3].(interpreter.UInt64Value)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			gasLimit := types.GasLimit(gasLimitValue)
+
+			// Get balance
+
+			balanceValue, ok := invocation.Arguments[4].(interpreter.UIntValue)
+			if !ok {
+				panic(errors.NewUnreachableError())
+			}
+
+			balance := types.NewBalance(balanceValue.BigInt)
+
+			tx := gethTypes.NewTx(&gethTypes.LegacyTx{
+				Nonce:    0,
+				To:       &to,
+				Gas:      uint64(gasLimit),
+				Data:     data,
+				GasPrice: big.NewInt(0),
+				Value:    balance,
+			})
+
+			txPayload, err := tx.MarshalBinary()
+			if err != nil {
+				panic(err)
+			}
+
+			// call contract function
+
+			res := handler.DryRun(txPayload, fromAddress)
 			return NewResultValue(handler, gauge, inter, locationRange, res)
 		},
 	)

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -499,6 +499,25 @@ contract EVM {
             ) as! Result
         }
 
+        /// Calls a contract function with the given data.
+        /// The execution is limited by the given amount of gas.
+        /// The transaction state changes are not persisted.
+        access(all)
+        fun dryCall(
+            to: EVMAddress,
+            data: [UInt8],
+            gasLimit: UInt64,
+            value: Balance,
+        ): Result {
+            return InternalEVM.dryCall(
+                from: self.addressBytes,
+                to: to.bytes,
+                data: data,
+                gasLimit: gasLimit,
+                value: value.attoflow
+            ) as! Result
+        }
+
         /// Bridges the given NFT to the EVM environment, requiring a Provider from which to withdraw a fee to fulfill
         /// the bridge request
         access(all)

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -601,6 +601,26 @@ contract EVM {
         ) as! Result
     }
 
+    /// Calls a contract function with the given data.
+    /// The execution is limited by the given amount of gas.
+    /// The transaction state changes are not persisted.
+    access(all)
+    fun dryCall(
+        from: EVMAddress,
+        to: EVMAddress,
+        data: [UInt8],
+        gasLimit: UInt64,
+        value: Balance,
+    ): Result {
+        return InternalEVM.dryCall(
+            from: from.bytes,
+            to: to.bytes,
+            data: data,
+            gasLimit: gasLimit,
+            value: value.attoflow
+        ) as! Result
+    }
+
     /// Runs a batch of RLP-encoded EVM transactions, deducts the gas fees,
     /// and deposits the gas fees into the provided coinbase address.
     /// An invalid transaction is not executed and not included in the block.

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -178,11 +178,30 @@ var InternalEVMTypeDryRunFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
-// InternalEVM.dryCall
+// InternalEVM.batchRun
 
-const InternalEVMTypeDryCallFunctionName = "dryCall"
+const InternalEVMTypeBatchRunFunctionName = "batchRun"
 
-var InternalEVMTypeDryCallFunctionType = &sema.FunctionType{
+var InternalEVMTypeBatchRunFunctionType *sema.FunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Label:          "txs",
+			TypeAnnotation: sema.NewTypeAnnotation(EVMTransactionsBatchBytesType),
+		},
+		{
+			Label:          "coinbase",
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
+		},
+	},
+	// Actually [EVM.Result], but cannot refer to it here
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.NewVariableSizedType(nil, sema.AnyStructType)),
+}
+
+// InternalEVM.call
+
+const InternalEVMTypeCallFunctionName = "call"
+
+var InternalEVMTypeCallFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "from",
@@ -209,30 +228,11 @@ var InternalEVMTypeDryCallFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
-// InternalEVM.batchRun
+// InternalEVM.dryCall
 
-const InternalEVMTypeBatchRunFunctionName = "batchRun"
+const InternalEVMTypeDryCallFunctionName = "dryCall"
 
-var InternalEVMTypeBatchRunFunctionType *sema.FunctionType = &sema.FunctionType{
-	Parameters: []sema.Parameter{
-		{
-			Label:          "txs",
-			TypeAnnotation: sema.NewTypeAnnotation(EVMTransactionsBatchBytesType),
-		},
-		{
-			Label:          "coinbase",
-			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
-		},
-	},
-	// Actually [EVM.Result], but cannot refer to it here
-	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.NewVariableSizedType(nil, sema.AnyStructType)),
-}
-
-// InternalEVM.call
-
-const InternalEVMTypeCallFunctionName = "call"
-
-var InternalEVMTypeCallFunctionType = &sema.FunctionType{
+var InternalEVMTypeDryCallFunctionType = &sema.FunctionType{
 	Parameters: []sema.Parameter{
 		{
 			Label:          "from",
@@ -467,12 +467,6 @@ var InternalEVMContractType = func() *sema.CompositeType {
 		),
 		sema.NewUnmeteredPublicFunctionMember(
 			ty,
-			InternalEVMTypeDryCallFunctionName,
-			InternalEVMTypeDryCallFunctionType,
-			"",
-		),
-		sema.NewUnmeteredPublicFunctionMember(
-			ty,
 			InternalEVMTypeBatchRunFunctionName,
 			InternalEVMTypeBatchRunFunctionType,
 			"",
@@ -487,6 +481,12 @@ var InternalEVMContractType = func() *sema.CompositeType {
 			ty,
 			InternalEVMTypeCallFunctionName,
 			InternalEVMTypeCallFunctionType,
+			"",
+		),
+		sema.NewUnmeteredPublicFunctionMember(
+			ty,
+			InternalEVMTypeDryCallFunctionName,
+			InternalEVMTypeDryCallFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(

--- a/fvm/evm/stdlib/contract.go
+++ b/fvm/evm/stdlib/contract.go
@@ -178,6 +178,37 @@ var InternalEVMTypeDryRunFunctionType = &sema.FunctionType{
 	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
 }
 
+// InternalEVM.dryCall
+
+const InternalEVMTypeDryCallFunctionName = "dryCall"
+
+var InternalEVMTypeDryCallFunctionType = &sema.FunctionType{
+	Parameters: []sema.Parameter{
+		{
+			Label:          "from",
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
+		},
+		{
+			Label:          "to",
+			TypeAnnotation: sema.NewTypeAnnotation(EVMAddressBytesType),
+		},
+		{
+			Label:          "data",
+			TypeAnnotation: sema.NewTypeAnnotation(sema.ByteArrayType),
+		},
+		{
+			Label:          "gasLimit",
+			TypeAnnotation: sema.NewTypeAnnotation(sema.UInt64Type),
+		},
+		{
+			Label:          "value",
+			TypeAnnotation: sema.NewTypeAnnotation(sema.UIntType),
+		},
+	},
+	// Actually EVM.Result, but cannot refer to it here
+	ReturnTypeAnnotation: sema.NewTypeAnnotation(sema.AnyStructType),
+}
+
 // InternalEVM.batchRun
 
 const InternalEVMTypeBatchRunFunctionName = "batchRun"
@@ -432,6 +463,12 @@ var InternalEVMContractType = func() *sema.CompositeType {
 			ty,
 			InternalEVMTypeDryRunFunctionName,
 			InternalEVMTypeDryRunFunctionType,
+			"",
+		),
+		sema.NewUnmeteredPublicFunctionMember(
+			ty,
+			InternalEVMTypeDryCallFunctionName,
+			InternalEVMTypeDryCallFunctionType,
 			"",
 		),
 		sema.NewUnmeteredPublicFunctionMember(

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "927faa475252088220f00b6677bdebf4c9fd4fb8ad0a5ccaecc7cecffd9df65b"
+const GenesisStateCommitmentHex = "0572718e6a4ed54a7321f51d7800970ece67b5b67e8f2462222653c044be2485"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "fe111c4db2b35f5bc1c14f40ce521317e708f55b0dc7319a65d76348c1891f92"
+		return "7c441d274c07623c52581a07bd4e9e741fd0cc9f678b183192e1f0f5c101e20d"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "8d3552a9ee24700ea03a60932a89c57a7d9e96f68349fec040cba51c687f869e"
+	return "95fac6c0841ffb72de3fff69c8dfdf054ea2e122567eaf57cbaf7bbef56ea9d6"
 }

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,11 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-<<<<<<< HEAD
 const GenesisStateCommitmentHex = "927faa475252088220f00b6677bdebf4c9fd4fb8ad0a5ccaecc7cecffd9df65b"
-=======
-const GenesisStateCommitmentHex = "9f6724d4507e56440d8d5c79271a36b0846a6a431b1644243a512fc9d6d42e86"
->>>>>>> dbdfd0d121 (Update state commitment expected values)
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -96,5 +92,5 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "9dc5fbd17f2baa82481589145a924e02dfc38bd936cfd6e23536035ff8c56a52"
+	return "8d3552a9ee24700ea03a60932a89c57a7d9e96f68349fec040cba51c687f869e"
 }

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,11 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
+<<<<<<< HEAD
 const GenesisStateCommitmentHex = "927faa475252088220f00b6677bdebf4c9fd4fb8ad0a5ccaecc7cecffd9df65b"
+=======
+const GenesisStateCommitmentHex = "9f6724d4507e56440d8d5c79271a36b0846a6a431b1644243a512fc9d6d42e86"
+>>>>>>> dbdfd0d121 (Update state commitment expected values)
 
 var GenesisStateCommitment flow.StateCommitment
 


### PR DESCRIPTION
Closes https://github.com/onflow/flow-go/issues/6800

This new method can be used instead of `COA.call`, in a Cadence transaction, when the user wants to execute a contract call, without committing any state changes. This is useful for reading a contract's state.