### PR TITLE
Remove buffer gas added in the gas used from `EVM.dryRun`

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -290,26 +290,6 @@ func (bl *BlockView) DryRunTransaction(
 
 	// return without committing the state
 	txResult, err = proc.run(msg, tx.Hash(), tx.Type())
-	if txResult.Successful() {
-		// As mentioned in https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md#specification
-		// Define "all but one 64th" of N as N - floor(N / 64).
-		// If a call asks for more gas than the maximum allowed amount
-		// (i.e. the total amount of gas remaining in the parent after subtracting
-		// the gas cost of the call and memory expansion), do not return an OOG error;
-		// instead, if a call asks for more gas than all but one 64th of the maximum
-		// allowed amount, call with all but one 64th of the maximum allowed amount of
-		// gas (this is equivalent to a version of EIP-901 plus EIP-1142).
-		// CREATE only provides all but one 64th of the parent gas to the child call.
-		txResult.GasConsumed = AddOne64th(txResult.GasConsumed)
-
-		// Adding `gethParams.SstoreSentryGasEIP2200` is needed for this condition:
-		// https://github.com/onflow/go-ethereum/blob/master/core/vm/operations_acl.go#L29-L32
-		txResult.GasConsumed += gethParams.SstoreSentryGasEIP2200
-
-		// Take into account any gas refunds, which are calculated only after
-		// transaction execution.
-		txResult.GasConsumed += txResult.GasRefund
-	}
 
 	// call tracer on tx end
 	if proc.evm.Config.Tracer != nil &&
@@ -705,11 +685,6 @@ func (proc *procedure) run(
 		}
 	}
 	return &res, nil
-}
-
-func AddOne64th(n uint64) uint64 {
-	// NOTE: Go's integer division floors, but that is desirable here
-	return n + (n / 64)
 }
 
 func convertAndCheckValue(input *big.Int) (isValid bool, converted *uint256.Int) {

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -258,8 +258,6 @@ func (bl *BlockView) DryRunTransaction(
 	tx *gethTypes.Transaction,
 	from gethCommon.Address,
 ) (*types.Result, error) {
-	var txResult *types.Result
-
 	// create a new procedure
 	proc, err := bl.newProcedure()
 	if err != nil {
@@ -283,22 +281,8 @@ func (bl *BlockView) DryRunTransaction(
 	// we need to skip nonce check for dry run
 	msg.SkipAccountChecks = true
 
-	// call tracer
-	if proc.evm.Config.Tracer != nil && proc.evm.Config.Tracer.OnTxStart != nil {
-		proc.evm.Config.Tracer.OnTxStart(proc.evm.GetVMContext(), tx, msg.From)
-	}
-
-	// return without committing the state
-	txResult, err = proc.run(msg, tx.Hash(), tx.Type())
-
-	// call tracer on tx end
-	if proc.evm.Config.Tracer != nil &&
-		proc.evm.Config.Tracer.OnTxEnd != nil &&
-		txResult != nil {
-		proc.evm.Config.Tracer.OnTxEnd(txResult.Receipt(), txResult.ValidationError)
-	}
-
-	return txResult, err
+	// run and return without committing the state changes
+	return proc.run(msg, tx.Hash(), tx.Type())
 }
 
 func (bl *BlockView) newProcedure() (*procedure, error) {

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -1538,7 +1538,8 @@ func TestDryRun(t *testing.T) {
 				_, output, err := vm.Run(
 					ctx,
 					script,
-					snapshot)
+					snapshot,
+				)
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
@@ -1765,7 +1766,7 @@ func TestDryRun(t *testing.T) {
 				))
 
 				// use the gas estimation from Evm.dryRun with the necessary buffer gas
-				gasLimit := dryRunResult.GasConsumed + gethParams.SstoreSentryGasEIP2200 + gethParams.SstoreClearsScheduleRefundEIP3529
+				gasLimit := dryRunResult.GasConsumed + gethParams.SstoreClearsScheduleRefundEIP3529
 				innerTxBytes = testAccount.PrepareSignAndEncodeTx(t,
 					testContract.DeployedAt.ToCommon(),
 					data,
@@ -1790,7 +1791,8 @@ func TestDryRun(t *testing.T) {
 				_, output, err = vm.Run(
 					ctx,
 					script,
-					snapshot)
+					snapshot,
+				)
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/6843
Relevant issue: https://github.com/onflow/flow-go/issues/6301

The buffer gas added in `EVM.dryRun`, was a best-effort solution, to find the minimum required gas, that would make a transaction succeed. The calculation was based on top of the actual gas used for a given transaction. However, this did have some issues, and it would fail for certain cases.

With the implementation of the local state index on EVM Gateway, we have completely [reworked](https://github.com/onflow/flow-evm-gateway/pull/671) the `eth_estimateGas` endpoint, and it uses the same logic as `Geth`, to calculate the minimum required gas needed for a transaction to succeed.

With that change deployed, we no longer need to add any buffer gas to the result of `EVM.dryRun`. And this can in fact cause confusion to developers, as it is always a bit higher that the gas usage they would get from tracing the same transaction / contract call.