### PR TITLE
Make chunk assignment immutable

### DIFF
--- a/engine/consensus/approvals/approval_collector.go
+++ b/engine/consensus/approvals/approval_collector.go
@@ -36,12 +36,11 @@ func NewApprovalCollector(
 ) (*ApprovalCollector, error) {
 	chunkCollectors := make([]*ChunkApprovalCollector, 0, result.Result.Chunks.Len())
 	for _, chunk := range result.Result.Chunks {
-		verifiers, err := assignment.Verifiers(chunk.Index)
+		assignedVerifiers, err := assignment.Verifiers(chunk.Index)
 		if err != nil {
 			return nil, fmt.Errorf("getting verifiers for chunk %d failed: %w", chunk.Index, err)
 		}
-		chunkAssignment := verifiers.Lookup()
-		collector := NewChunkApprovalCollector(chunkAssignment, requiredApprovalsForSealConstruction)
+		collector := NewChunkApprovalCollector(assignedVerifiers, requiredApprovalsForSealConstruction)
 		chunkCollectors = append(chunkCollectors, collector)
 	}
 

--- a/engine/consensus/approvals/approval_collector.go
+++ b/engine/consensus/approvals/approval_collector.go
@@ -36,7 +36,7 @@ func NewApprovalCollector(
 ) (*ApprovalCollector, error) {
 	chunkCollectors := make([]*ChunkApprovalCollector, 0, result.Result.Chunks.Len())
 	for _, chunk := range result.Result.Chunks {
-		chunkAssignment := assignment.Verifiers(chunk).Lookup()
+		chunkAssignment := assignment.Verifiers(chunk.Index).Lookup()
 		collector := NewChunkApprovalCollector(chunkAssignment, requiredApprovalsForSealConstruction)
 		chunkCollectors = append(chunkCollectors, collector)
 	}

--- a/engine/consensus/approvals/approval_collector.go
+++ b/engine/consensus/approvals/approval_collector.go
@@ -36,7 +36,11 @@ func NewApprovalCollector(
 ) (*ApprovalCollector, error) {
 	chunkCollectors := make([]*ChunkApprovalCollector, 0, result.Result.Chunks.Len())
 	for _, chunk := range result.Result.Chunks {
-		chunkAssignment := assignment.Verifiers(chunk.Index).Lookup()
+		verifiers, err := assignment.Verifiers(chunk.Index)
+		if err != nil {
+			return nil, fmt.Errorf("getting verifiers for chunk %d failed: %w", chunk.Index, err)
+		}
+		chunkAssignment := verifiers.Lookup()
 		collector := NewChunkApprovalCollector(chunkAssignment, requiredApprovalsForSealConstruction)
 		chunkCollectors = append(chunkCollectors, collector)
 	}

--- a/engine/consensus/approvals/approval_collector_test.go
+++ b/engine/consensus/approvals/approval_collector_test.go
@@ -94,7 +94,12 @@ func (s *ApprovalCollectorTestSuite) TestCollectMissingVerifiers() {
 	for _, chunk := range s.Chunks {
 		verifiers, err := s.ChunksAssignment.Verifiers(chunk.Index)
 		require.NoError(s.T(), err)
-		assignedVerifiers[chunk.Index] = verifiers
+		// we need a consistent iteration order later, so convert to slice
+		v := make([]flow.Identifier, 0, len(verifiers))
+		for id := range verifiers {
+			v = append(v, id)
+		}
+		assignedVerifiers[chunk.Index] = v
 	}
 
 	// no approvals processed

--- a/engine/consensus/approvals/approval_collector_test.go
+++ b/engine/consensus/approvals/approval_collector_test.go
@@ -92,7 +92,7 @@ func (s *ApprovalCollectorTestSuite) TestCollectMissingVerifiers() {
 
 	assignedVerifiers := make(map[uint64]flow.IdentifierList)
 	for _, chunk := range s.Chunks {
-		assignedVerifiers[chunk.Index] = s.ChunksAssignment.Verifiers(chunk)
+		assignedVerifiers[chunk.Index] = s.ChunksAssignment.Verifiers(chunk.Index)
 	}
 
 	// no approvals processed

--- a/engine/consensus/approvals/approval_collector_test.go
+++ b/engine/consensus/approvals/approval_collector_test.go
@@ -92,7 +92,9 @@ func (s *ApprovalCollectorTestSuite) TestCollectMissingVerifiers() {
 
 	assignedVerifiers := make(map[uint64]flow.IdentifierList)
 	for _, chunk := range s.Chunks {
-		assignedVerifiers[chunk.Index] = s.ChunksAssignment.Verifiers(chunk.Index)
+		verifiers, err := s.ChunksAssignment.Verifiers(chunk.Index)
+		require.NoError(s.T(), err)
+		assignedVerifiers[chunk.Index] = verifiers
 	}
 
 	// no approvals processed

--- a/engine/consensus/approvals/chunk_collector_test.go
+++ b/engine/consensus/approvals/chunk_collector_test.go
@@ -30,7 +30,7 @@ func (s *ChunkApprovalCollectorTestSuite) SetupTest() {
 	s.BaseApprovalsTestSuite.SetupTest()
 	s.chunk = s.Chunks[0]
 	s.chunkAssignment = make(map[flow.Identifier]struct{})
-	for _, verifier := range s.ChunksAssignment.Verifiers(s.chunk) {
+	for _, verifier := range s.ChunksAssignment.Verifiers(s.chunk.Index) {
 		s.chunkAssignment[verifier] = struct{}{}
 	}
 	s.collector = NewChunkApprovalCollector(s.chunkAssignment, uint(len(s.chunkAssignment)))

--- a/engine/consensus/approvals/chunk_collector_test.go
+++ b/engine/consensus/approvals/chunk_collector_test.go
@@ -29,12 +29,9 @@ type ChunkApprovalCollectorTestSuite struct {
 func (s *ChunkApprovalCollectorTestSuite) SetupTest() {
 	s.BaseApprovalsTestSuite.SetupTest()
 	s.chunk = s.Chunks[0]
-	s.chunkAssignment = make(map[flow.Identifier]struct{})
 	verifiers, err := s.ChunksAssignment.Verifiers(s.chunk.Index)
 	require.NoError(s.T(), err)
-	for _, verifier := range verifiers {
-		s.chunkAssignment[verifier] = struct{}{}
-	}
+	s.chunkAssignment = verifiers
 	s.collector = NewChunkApprovalCollector(s.chunkAssignment, uint(len(s.chunkAssignment)))
 }
 

--- a/engine/consensus/approvals/chunk_collector_test.go
+++ b/engine/consensus/approvals/chunk_collector_test.go
@@ -30,7 +30,9 @@ func (s *ChunkApprovalCollectorTestSuite) SetupTest() {
 	s.BaseApprovalsTestSuite.SetupTest()
 	s.chunk = s.Chunks[0]
 	s.chunkAssignment = make(map[flow.Identifier]struct{})
-	for _, verifier := range s.ChunksAssignment.Verifiers(s.chunk.Index) {
+	verifiers, err := s.ChunksAssignment.Verifiers(s.chunk.Index)
+	require.NoError(s.T(), err)
+	for _, verifier := range verifiers {
 		s.chunkAssignment[verifier] = struct{}{}
 	}
 	s.collector = NewChunkApprovalCollector(s.chunkAssignment, uint(len(s.chunkAssignment)))

--- a/engine/consensus/approvals/testutil.go
+++ b/engine/consensus/approvals/testutil.go
@@ -42,7 +42,7 @@ func (s *BaseApprovalsTestSuite) SetupTest() {
 	s.Block = unittest.BlockHeaderWithParentFixture(s.ParentBlock)
 	verifiers := make(flow.IdentifierList, 0)
 	s.AuthorizedVerifiers = make(map[flow.Identifier]*flow.Identity)
-	s.ChunksAssignment = chunks.NewAssignment()
+	assignmentBuilder := chunks.NewAssignmentBuilder()
 	s.Chunks = unittest.ChunkListFixture(50, s.Block.ID())
 	// mock public key to mock signature verifications
 	s.PublicKey = &module.PublicKey{}
@@ -59,8 +59,9 @@ func (s *BaseApprovalsTestSuite) SetupTest() {
 
 	// create assignment
 	for _, chunk := range s.Chunks {
-		s.ChunksAssignment.Add(chunk, verifiers)
+		assignmentBuilder.Add(chunk, verifiers)
 	}
+	s.ChunksAssignment = assignmentBuilder.Build()
 
 	s.VerID = verifiers[0]
 	result := unittest.ExecutionResultFixture()

--- a/engine/consensus/approvals/testutil.go
+++ b/engine/consensus/approvals/testutil.go
@@ -59,7 +59,7 @@ func (s *BaseApprovalsTestSuite) SetupTest() {
 
 	// create assignment
 	for _, chunk := range s.Chunks {
-		assignmentBuilder.Add(chunk, verifiers)
+		assignmentBuilder.Add(chunk.Index, verifiers)
 	}
 	s.ChunksAssignment = assignmentBuilder.Build()
 

--- a/engine/consensus/approvals/testutil.go
+++ b/engine/consensus/approvals/testutil.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/onflow/crypto/hash"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/model/chunks"
@@ -59,7 +60,7 @@ func (s *BaseApprovalsTestSuite) SetupTest() {
 
 	// create assignment
 	for _, chunk := range s.Chunks {
-		assignmentBuilder.Add(chunk.Index, verifiers)
+		require.NoError(s.T(), assignmentBuilder.Add(chunk.Index, verifiers))
 	}
 	s.ChunksAssignment = assignmentBuilder.Build()
 

--- a/engine/consensus/approvals/verifying_assignment_collector_test.go
+++ b/engine/consensus/approvals/verifying_assignment_collector_test.go
@@ -302,13 +302,13 @@ func (s *AssignmentCollectorTestSuite) TestProcessApproval_BeforeIncorporatedRes
 // rate limiting is respected.
 func (s *AssignmentCollectorTestSuite) TestRequestMissingApprovals() {
 	// build new assignment with 2 verifiers
-	assignment := chunks.NewAssignment()
+	assignmentBuilder := chunks.NewAssignmentBuilder()
 	for _, chunk := range s.Chunks {
 		verifiers := s.ChunksAssignment.Verifiers(chunk)
-		assignment.Add(chunk, verifiers[:2])
+		assignmentBuilder.Add(chunk, verifiers[:2])
 	}
 	// replace old one
-	s.ChunksAssignment = assignment
+	s.ChunksAssignment = assignmentBuilder.Build()
 
 	incorporatedBlocks := make([]*flow.Header, 0)
 

--- a/engine/consensus/approvals/verifying_assignment_collector_test.go
+++ b/engine/consensus/approvals/verifying_assignment_collector_test.go
@@ -304,8 +304,9 @@ func (s *AssignmentCollectorTestSuite) TestRequestMissingApprovals() {
 	// build new assignment with 2 verifiers
 	assignmentBuilder := chunks.NewAssignmentBuilder()
 	for _, chunk := range s.Chunks {
-		verifiers := s.ChunksAssignment.Verifiers(chunk.Index)
-		assignmentBuilder.Add(chunk.Index, verifiers[:2])
+		verifiers, err := s.ChunksAssignment.Verifiers(chunk.Index)
+		require.NoError(s.T(), err)
+		require.NoError(s.T(), assignmentBuilder.Add(chunk.Index, verifiers[:2]))
 	}
 	// replace old one
 	s.ChunksAssignment = assignmentBuilder.Build()

--- a/engine/consensus/approvals/verifying_assignment_collector_test.go
+++ b/engine/consensus/approvals/verifying_assignment_collector_test.go
@@ -304,8 +304,8 @@ func (s *AssignmentCollectorTestSuite) TestRequestMissingApprovals() {
 	// build new assignment with 2 verifiers
 	assignmentBuilder := chunks.NewAssignmentBuilder()
 	for _, chunk := range s.Chunks {
-		verifiers := s.ChunksAssignment.Verifiers(chunk)
-		assignmentBuilder.Add(chunk, verifiers[:2])
+		verifiers := s.ChunksAssignment.Verifiers(chunk.Index)
+		assignmentBuilder.Add(chunk.Index, verifiers[:2])
 	}
 	// replace old one
 	s.ChunksAssignment = assignmentBuilder.Build()

--- a/engine/consensus/approvals/verifying_assignment_collector_test.go
+++ b/engine/consensus/approvals/verifying_assignment_collector_test.go
@@ -306,7 +306,11 @@ func (s *AssignmentCollectorTestSuite) TestRequestMissingApprovals() {
 	for _, chunk := range s.Chunks {
 		verifiers, err := s.ChunksAssignment.Verifiers(chunk.Index)
 		require.NoError(s.T(), err)
-		require.NoError(s.T(), assignmentBuilder.Add(chunk.Index, verifiers[:2]))
+		v := make([]flow.Identifier, 0, len(verifiers))
+		for id := range verifiers {
+			v = append(v, id)
+		}
+		require.NoError(s.T(), assignmentBuilder.Add(chunk.Index, v[:2]))
 	}
 	// replace old one
 	s.ChunksAssignment = assignmentBuilder.Build()

--- a/engine/consensus/sealing/core_test.go
+++ b/engine/consensus/sealing/core_test.go
@@ -594,12 +594,13 @@ func (s *ApprovalProcessingCoreTestSuite) TestRequestPendingApprovals() {
 
 		prevResult = ir.Result
 
-		s.ChunksAssignment = chunks.NewAssignment()
+		assignmentBuilder := chunks.NewAssignmentBuilder()
 
 		for _, chunk := range ir.Result.Chunks {
 			// assign the verifier to this chunk
-			s.ChunksAssignment.Add(chunk, verifiers)
+			assignmentBuilder.Add(chunk, verifiers)
 		}
+		s.ChunksAssignment = assignmentBuilder.Build()
 
 		err := s.core.processIncorporatedResult(ir)
 		require.NoError(s.T(), err)

--- a/engine/consensus/sealing/core_test.go
+++ b/engine/consensus/sealing/core_test.go
@@ -598,7 +598,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestRequestPendingApprovals() {
 
 		for _, chunk := range ir.Result.Chunks {
 			// assign the verifier to this chunk
-			assignmentBuilder.Add(chunk, verifiers)
+			assignmentBuilder.Add(chunk.Index, verifiers)
 		}
 		s.ChunksAssignment = assignmentBuilder.Build()
 

--- a/engine/consensus/sealing/core_test.go
+++ b/engine/consensus/sealing/core_test.go
@@ -598,7 +598,7 @@ func (s *ApprovalProcessingCoreTestSuite) TestRequestPendingApprovals() {
 
 		for _, chunk := range ir.Result.Chunks {
 			// assign the verifier to this chunk
-			assignmentBuilder.Add(chunk.Index, verifiers)
+			require.NoError(s.T(), assignmentBuilder.Add(chunk.Index, verifiers))
 		}
 		s.ChunksAssignment = assignmentBuilder.Build()
 

--- a/engine/verification/assigner/engine_test.go
+++ b/engine/verification/assigner/engine_test.go
@@ -87,7 +87,7 @@ func SetupTest(options ...func(suite *AssignerEngineTestSuite)) *AssignerEngineT
 
 // createContainerBlock creates and returns a block that contains an execution receipt, with its corresponding chunks assignment based
 // on the input options.
-func createContainerBlock(options ...func(result *flow.ExecutionResult, assignments *chunks.Assignment)) (*flow.Block, *chunks.Assignment) {
+func createContainerBlock(options ...func(result *flow.ExecutionResult, assignments *chunks.AssignmentBuilder)) (*flow.Block, *chunks.Assignment) {
 	result, assignment := vertestutils.CreateExecutionResult(unittest.IdentifierFixture(), options...)
 	receipt := &flow.ExecutionReceipt{
 		ExecutorID:      unittest.IdentifierFixture(),

--- a/engine/verification/assigner/engine_test.go
+++ b/engine/verification/assigner/engine_test.go
@@ -159,7 +159,7 @@ func newBlockHappyPath(t *testing.T) {
 	// one assigned chunk to verification node.
 	containerBlock, assignment := createContainerBlock(
 		vertestutils.WithChunks(
-			vertestutils.WithAssignee(s.myID())))
+			vertestutils.WithAssignee(t, s.myID())))
 	result := containerBlock.Payload.Results[0]
 	s.mockStateAtBlockID(result.BlockID)
 	chunksNum := s.mockChunkAssigner(flow.NewIncorporatedResult(containerBlock.ID(), result), assignment)
@@ -206,9 +206,9 @@ func newBlockVerifierNotAuthorized(t *testing.T) {
 		// no assigned chunk to verification node.
 		containerBlock, _ := createContainerBlock(
 			vertestutils.WithChunks( // all chunks assigned to some (random) identifiers, but not this verification node
-				vertestutils.WithAssignee(unittest.IdentifierFixture()),
-				vertestutils.WithAssignee(unittest.IdentifierFixture()),
-				vertestutils.WithAssignee(unittest.IdentifierFixture())))
+				vertestutils.WithAssignee(t, unittest.IdentifierFixture()),
+				vertestutils.WithAssignee(t, unittest.IdentifierFixture()),
+				vertestutils.WithAssignee(t, unittest.IdentifierFixture())))
 		result := containerBlock.Payload.Results[0]
 		s.mockStateAtBlockID(result.BlockID)
 
@@ -300,11 +300,11 @@ func newBlockNoAssignedChunk(t *testing.T) {
 	// none of them is assigned to this verification node.
 	containerBlock, assignment := createContainerBlock(
 		vertestutils.WithChunks(
-			vertestutils.WithAssignee(unittest.IdentifierFixture()),  // assigned to others
-			vertestutils.WithAssignee(unittest.IdentifierFixture()),  // assigned to others
-			vertestutils.WithAssignee(unittest.IdentifierFixture()),  // assigned to others
-			vertestutils.WithAssignee(unittest.IdentifierFixture()),  // assigned to others
-			vertestutils.WithAssignee(unittest.IdentifierFixture()))) // assigned to others
+			vertestutils.WithAssignee(t, unittest.IdentifierFixture()),  // assigned to others
+			vertestutils.WithAssignee(t, unittest.IdentifierFixture()),  // assigned to others
+			vertestutils.WithAssignee(t, unittest.IdentifierFixture()),  // assigned to others
+			vertestutils.WithAssignee(t, unittest.IdentifierFixture()),  // assigned to others
+			vertestutils.WithAssignee(t, unittest.IdentifierFixture()))) // assigned to others
 	result := containerBlock.Payload.Results[0]
 	s.mockStateAtBlockID(result.BlockID)
 	chunksNum := s.mockChunkAssigner(flow.NewIncorporatedResult(containerBlock.ID(), result), assignment)
@@ -340,11 +340,11 @@ func newBlockMultipleAssignment(t *testing.T) {
 	// only 3 of them is assigned to this verification node.
 	containerBlock, assignment := createContainerBlock(
 		vertestutils.WithChunks(
-			vertestutils.WithAssignee(unittest.IdentifierFixture()), // assigned to others
-			vertestutils.WithAssignee(s.myID()),                     // assigned to me
-			vertestutils.WithAssignee(s.myID()),                     // assigned to me
-			vertestutils.WithAssignee(unittest.IdentifierFixture()), // assigned to others
-			vertestutils.WithAssignee(s.myID())))                    // assigned to me
+			vertestutils.WithAssignee(t, unittest.IdentifierFixture()), // assigned to others
+			vertestutils.WithAssignee(t, s.myID()),                     // assigned to me
+			vertestutils.WithAssignee(t, s.myID()),                     // assigned to me
+			vertestutils.WithAssignee(t, unittest.IdentifierFixture()), // assigned to others
+			vertestutils.WithAssignee(t, s.myID())))                    // assigned to me
 	result := containerBlock.Payload.Results[0]
 	s.mockStateAtBlockID(result.BlockID)
 	chunksNum := s.mockChunkAssigner(flow.NewIncorporatedResult(containerBlock.ID(), result), assignment)
@@ -383,7 +383,7 @@ func chunkQueueUnhappyPathDuplicate(t *testing.T) {
 	// creates a container block, with a single receipt, that contains a single chunk assigned
 	// to verification node.
 	containerBlock, assignment := createContainerBlock(
-		vertestutils.WithChunks(vertestutils.WithAssignee(s.myID())))
+		vertestutils.WithChunks(vertestutils.WithAssignee(t, s.myID())))
 	result := containerBlock.Payload.Results[0]
 	s.mockStateAtBlockID(result.BlockID)
 	chunksNum := s.mockChunkAssigner(flow.NewIncorporatedResult(containerBlock.ID(), result), assignment)

--- a/engine/verification/utils/mocked.go
+++ b/engine/verification/utils/mocked.go
@@ -26,7 +26,10 @@ func (m *MockAssigner) Assign(result *flow.ExecutionResult, blockID flow.Identif
 	a := chmodel.NewAssignmentBuilder()
 	for _, c := range result.Chunks {
 		if m.isAssigned(c.Index) {
-			a.Add(c.Index, flow.IdentifierList{m.me})
+			err := a.Add(c.Index, flow.IdentifierList{m.me})
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/engine/verification/utils/mocked.go
+++ b/engine/verification/utils/mocked.go
@@ -26,7 +26,7 @@ func (m *MockAssigner) Assign(result *flow.ExecutionResult, blockID flow.Identif
 	a := chmodel.NewAssignmentBuilder()
 	for _, c := range result.Chunks {
 		if m.isAssigned(c.Index) {
-			a.Add(c, flow.IdentifierList{m.me})
+			a.Add(c.Index, flow.IdentifierList{m.me})
 		}
 	}
 

--- a/engine/verification/utils/mocked.go
+++ b/engine/verification/utils/mocked.go
@@ -23,12 +23,12 @@ func (m *MockAssigner) Assign(result *flow.ExecutionResult, blockID flow.Identif
 	if len(result.Chunks) == 0 {
 		return nil, fmt.Errorf("assigner called with empty chunk list")
 	}
-	a := chmodel.NewAssignment()
+	a := chmodel.NewAssignmentBuilder()
 	for _, c := range result.Chunks {
 		if m.isAssigned(c.Index) {
 			a.Add(c, flow.IdentifierList{m.me})
 		}
 	}
 
-	return a, nil
+	return a.Build(), nil
 }

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -353,6 +353,9 @@ func MockChunkAssignmentFixture(chunkAssigner *mock.ChunkAssigner,
 					expectedLocatorIds = append(expectedLocatorIds, locatorID)
 					expectedChunkIds = append(expectedChunkIds, chunk.ID())
 					a.Add(chunk, verIds.NodeIDs())
+				} else {
+					// TODO the chunk has no verifiers assigned (error?)
+					a.Add(chunk, flow.IdentifierList{})
 				}
 
 			}

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -305,7 +305,7 @@ func WithAssignee(assignee flow.Identifier) func(flow.Identifier, uint64, *chunk
 	return func(blockID flow.Identifier, index uint64, assignmentBuilder *chunks.AssignmentBuilder) *flow.Chunk {
 		chunk := ChunkWithIndex(blockID, int(index))
 		fmt.Printf("with assignee: %v, chunk id: %v\n", index, chunk.ID())
-		assignmentBuilder.Add(chunk, flow.IdentifierList{assignee})
+		assignmentBuilder.Add(chunk.Index, flow.IdentifierList{assignee})
 		return chunk
 	}
 }
@@ -352,10 +352,10 @@ func MockChunkAssignmentFixture(chunkAssigner *mock.ChunkAssigner,
 					}.ID()
 					expectedLocatorIds = append(expectedLocatorIds, locatorID)
 					expectedChunkIds = append(expectedChunkIds, chunk.ID())
-					a.Add(chunk, verIds.NodeIDs())
+					a.Add(chunk.Index, verIds.NodeIDs())
 				} else {
 					// the chunk has no verifiers assigned
-					a.Add(chunk, flow.IdentifierList{})
+					a.Add(chunk.Index, flow.IdentifierList{})
 				}
 
 			}

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -354,7 +354,7 @@ func MockChunkAssignmentFixture(chunkAssigner *mock.ChunkAssigner,
 					expectedChunkIds = append(expectedChunkIds, chunk.ID())
 					a.Add(chunk, verIds.NodeIDs())
 				} else {
-					// TODO the chunk has no verifiers assigned (error?)
+					// the chunk has no verifiers assigned
 					a.Add(chunk, flow.IdentifierList{})
 				}
 

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -305,7 +305,10 @@ func WithAssignee(assignee flow.Identifier) func(flow.Identifier, uint64, *chunk
 	return func(blockID flow.Identifier, index uint64, assignmentBuilder *chunks.AssignmentBuilder) *flow.Chunk {
 		chunk := ChunkWithIndex(blockID, int(index))
 		fmt.Printf("with assignee: %v, chunk id: %v\n", index, chunk.ID())
-		assignmentBuilder.Add(chunk.Index, flow.IdentifierList{assignee})
+		err := assignmentBuilder.Add(chunk.Index, flow.IdentifierList{assignee})
+		if err != nil {
+			panic(err)
+		}
 		return chunk
 	}
 }
@@ -352,10 +355,16 @@ func MockChunkAssignmentFixture(chunkAssigner *mock.ChunkAssigner,
 					}.ID()
 					expectedLocatorIds = append(expectedLocatorIds, locatorID)
 					expectedChunkIds = append(expectedChunkIds, chunk.ID())
-					a.Add(chunk.Index, verIds.NodeIDs())
+					err := a.Add(chunk.Index, verIds.NodeIDs())
+					if err != nil {
+						panic(err)
+					}
 				} else {
 					// the chunk has no verifiers assigned
-					a.Add(chunk.Index, flow.IdentifierList{})
+					err := a.Add(chunk.Index, flow.IdentifierList{})
+					if err != nil {
+						panic(err)
+					}
 				}
 
 			}

--- a/model/chunks/chunkassignment.go
+++ b/model/chunks/chunkassignment.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -44,16 +46,13 @@ func (a *AssignmentBuilder) Build() *Assignment {
 // that for each chunk in a block, a verifier assignment exists (though it may be empty) and
 // that each block must at least have one chunk.
 // Errors: ErrUnknownChunkIndex if the chunk index is not present in the assignment
-func (a *Assignment) Verifiers(chunkIdx uint64) (flow.IdentifierList, error) {
+func (a *Assignment) Verifiers(chunkIdx uint64) (map[flow.Identifier]struct{}, error) {
 	if chunkIdx >= uint64(len(a.verifiersForChunk)) {
 		return nil, ErrUnknownChunkIndex
 	}
 	assignedVerifiers := a.verifiersForChunk[chunkIdx]
-	v := make([]flow.Identifier, 0, len(assignedVerifiers))
-	for id := range a.verifiersForChunk[chunkIdx] {
-		v = append(v, id)
-	}
-	return v, nil
+	// return a copy to prevent modification
+	return maps.Clone(assignedVerifiers), nil
 }
 
 // HasVerifier checks if a chunk is assigned to the given verifier

--- a/model/chunks/chunkassignment.go
+++ b/model/chunks/chunkassignment.go
@@ -31,13 +31,13 @@ func (a *AssignmentBuilder) Build() *Assignment {
 }
 
 // Verifiers returns the list of verifier nodes assigned to a chunk
-func (a *Assignment) Verifiers(chunk *flow.Chunk) flow.IdentifierList {
+func (a *Assignment) Verifiers(chunkIdx uint64) flow.IdentifierList {
 	v := make([]flow.Identifier, 0)
-	if chunk.Index >= uint64(len(a.verifiersForChunk)) {
+	if chunkIdx >= uint64(len(a.verifiersForChunk)) {
 		// the chunk does not exist in the assignment, so it has no verifiers
 		return v
 	}
-	for id := range a.verifiersForChunk[chunk.Index] {
+	for id := range a.verifiersForChunk[chunkIdx] {
 		v = append(v, id)
 	}
 	return v
@@ -45,13 +45,13 @@ func (a *Assignment) Verifiers(chunk *flow.Chunk) flow.IdentifierList {
 
 // HasVerifier checks if a chunk is assigned to the given verifier
 // TODO: method should probably error if chunk has unknown index
-func (a *Assignment) HasVerifier(chunk *flow.Chunk, identifier flow.Identifier) bool {
-	if chunk.Index >= uint64(len(a.verifiersForChunk)) {
+func (a *Assignment) HasVerifier(chunkIdx uint64, identifier flow.Identifier) bool {
+	if chunkIdx >= uint64(len(a.verifiersForChunk)) {
 		// is verifier assigned to this chunk?
 		// No, because we only assign verifiers to existing chunks
 		return false
 	}
-	assignedVerifiers := a.verifiersForChunk[chunk.Index]
+	assignedVerifiers := a.verifiersForChunk[chunkIdx]
 	_, isAssigned := assignedVerifiers[identifier]
 	return isAssigned
 }
@@ -59,8 +59,8 @@ func (a *Assignment) HasVerifier(chunk *flow.Chunk, identifier flow.Identifier) 
 // Add records the list of verifier nodes as the assigned verifiers of the chunk.
 // Requires chunks to be added in order of their Index (increasing by 1 each time).
 // Panics if chunks are not added in ascending Index order.
-func (a *AssignmentBuilder) Add(chunk *flow.Chunk, verifiers flow.IdentifierList) {
-	if chunk.Index != uint64(len(a.verifiersForChunk)) {
+func (a *AssignmentBuilder) Add(chunkIdx uint64, verifiers flow.IdentifierList) {
+	if chunkIdx != uint64(len(a.verifiersForChunk)) {
 		panic("chunks added out of order")
 	}
 	// sorts verifiers list based on their identifier

--- a/model/chunks/chunkassignment.go
+++ b/model/chunks/chunkassignment.go
@@ -4,7 +4,7 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// Assignment is an immutable list that, for each chunk (in order),
+// Assignment is an immutable list that, for each chunk (in order of chunk.Index),
 // records the set of verifier nodes that are assigned to verify that chunk.
 type Assignment struct {
 	verifiersForChunk []map[flow.Identifier]struct{}
@@ -21,6 +21,7 @@ func NewAssignmentBuilder() *AssignmentBuilder {
 	}
 }
 
+// Build completes the assignment and makes it immutable.
 func (a *AssignmentBuilder) Build() *Assignment {
 	// TODO is this correct?
 	// the underlying data can still be modified by the Builder,
@@ -34,7 +35,7 @@ func (a *AssignmentBuilder) Build() *Assignment {
 func (a *Assignment) Verifiers(chunk *flow.Chunk) flow.IdentifierList {
 	v := make([]flow.Identifier, 0)
 	if chunk.Index >= uint64(len(a.verifiersForChunk)) {
-		// the chunk does not exist, so it has no verifiers
+		// the chunk does not exist in the assignment, so it has no verifiers
 		return v
 	}
 	for id := range a.verifiersForChunk[chunk.Index] {
@@ -57,6 +58,7 @@ func (a *Assignment) HasVerifier(chunk *flow.Chunk, identifier flow.Identifier) 
 }
 
 // Add records the list of verifier nodes as the assigned verifiers of the chunk.
+// Requires chunks to be added in order of their Index (increasing by 1 each time).
 // It returns an error if the list of verifiers is empty or contains duplicate ids
 func (a *AssignmentBuilder) Add(chunk *flow.Chunk, verifiers flow.IdentifierList) {
 	if chunk.Index != uint64(len(a.verifiersForChunk)) {

--- a/model/chunks/chunkassignment.go
+++ b/model/chunks/chunkassignment.go
@@ -4,15 +4,30 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// Assignment is assignment map of the chunks to the list of the verifier nodes
+// Assignment is an immutable map from chunks to a list of the verifier nodes
+// that are assigned to verify that chunk
 type Assignment struct {
 	// TODO: use a slice here instead of a map, which will be more performant
 	verifiersForChunk map[uint64]map[flow.Identifier]struct{}
 }
 
-func NewAssignment() *Assignment {
-	return &Assignment{
+// AssignmentBuilder is a helper to create a new Assignment map
+type AssignmentBuilder struct {
+	verifiersForChunk map[uint64]map[flow.Identifier]struct{}
+}
+
+func NewAssignmentBuilder() *AssignmentBuilder {
+	return &AssignmentBuilder{
 		verifiersForChunk: make(map[uint64]map[flow.Identifier]struct{}),
+	}
+}
+
+func (a *AssignmentBuilder) Build() *Assignment {
+	// TODO is this correct?
+	// the underlying data can still be modified by the Builder,
+	// but the Builder ideally shouldn't be kept around or reused, so it should be sufficient
+	return &Assignment{
+		verifiersForChunk: a.verifiersForChunk,
 	}
 }
 
@@ -38,9 +53,9 @@ func (a *Assignment) HasVerifier(chunk *flow.Chunk, identifier flow.Identifier) 
 	return isAssigned
 }
 
-// Add records the list of verifier nodes as the assigned verifiers of the chunk
-// it returns an error if the list of verifiers is empty or contains duplicate ids
-func (a *Assignment) Add(chunk *flow.Chunk, verifiers flow.IdentifierList) {
+// Add records the list of verifier nodes as the assigned verifiers of the chunk.
+// It returns an error if the list of verifiers is empty or contains duplicate ids
+func (a *AssignmentBuilder) Add(chunk *flow.Chunk, verifiers flow.IdentifierList) {
 	// sorts verifiers list based on their identifier
 	v := make(map[flow.Identifier]struct{})
 	for _, id := range verifiers {

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -159,7 +159,7 @@ func chunkAssignment(ids flow.IdentifierList, chunks flow.ChunkList, rng random.
 		if !ok {
 			return nil, fmt.Errorf("chunk out of range requested: %v", i)
 		}
-		assignmentBuilder.Add(chunk, assignees)
+		assignmentBuilder.Add(chunk.Index, assignees)
 	}
 	return assignmentBuilder.Build(), nil
 }

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -159,7 +159,10 @@ func chunkAssignment(ids flow.IdentifierList, chunks flow.ChunkList, rng random.
 		if !ok {
 			return nil, fmt.Errorf("chunk out of range requested: %v", i)
 		}
-		assignmentBuilder.Add(chunk.Index, assignees)
+		err := assignmentBuilder.Add(chunk.Index, assignees)
+		if err != nil {
+			return nil, fmt.Errorf("adding chunk %d failed: %w", i, err)
+		}
 	}
 	return assignmentBuilder.Build(), nil
 }

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -118,7 +118,7 @@ func chunkAssignment(ids flow.IdentifierList, chunks flow.ChunkList, rng random.
 	}
 
 	// creates an assignment
-	assignment := chunkmodels.NewAssignment()
+	assignmentBuilder := chunkmodels.NewAssignmentBuilder()
 
 	// permutes the entire slice
 	err := rng.Shuffle(len(ids), ids.Swap)
@@ -159,9 +159,9 @@ func chunkAssignment(ids flow.IdentifierList, chunks flow.ChunkList, rng random.
 		if !ok {
 			return nil, fmt.Errorf("chunk out of range requested: %v", i)
 		}
-		assignment.Add(chunk, assignees)
+		assignmentBuilder.Add(chunk, assignees)
 	}
-	return assignment, nil
+	return assignmentBuilder.Build(), nil
 }
 
 func fingerPrint(blockID flow.Identifier, resultID flow.Identifier, alpha int) (hash.Hash, error) {

--- a/module/chunks/chunk_assigner_test.go
+++ b/module/chunks/chunk_assigner_test.go
@@ -46,7 +46,7 @@ func (a *PublicAssignmentTestSuite) TestByNodeID() {
 	// creates ids and twice chunks of the ids
 	ids := unittest.IdentityListFixture(size)
 	chunks := a.CreateChunks(2*size, a.T())
-	assignment := chmodels.NewAssignment()
+	assignmentBuilder := chmodels.NewAssignmentBuilder()
 
 	// assigns two chunks to each verifier node
 	// j keeps track of chunks
@@ -54,12 +54,13 @@ func (a *PublicAssignmentTestSuite) TestByNodeID() {
 	for i := 0; i < size; i++ {
 		c, ok := chunks.ByIndex(uint64(j))
 		require.True(a.T(), ok, "chunk out of range requested")
-		assignment.Add(c, append(assignment.Verifiers(c), ids[i].NodeID))
+		assignmentBuilder.Add(c, append(assignmentBuilder.Build().Verifiers(c), ids[i].NodeID))
 		j++
 		c, ok = chunks.ByIndex(uint64(j))
 		require.True(a.T(), ok, "chunk out of range requested")
-		assignment.Add(c, append(assignment.Verifiers(c), ids[i].NodeID))
+		assignmentBuilder.Add(c, append(assignmentBuilder.Build().Verifiers(c), ids[i].NodeID))
 	}
+	assignment := assignmentBuilder.Build()
 
 	// evaluating the chunk assignment
 	// each verifier should have two certain chunks based on the assignment
@@ -85,13 +86,13 @@ func (a *PublicAssignmentTestSuite) TestAssignDuplicate() {
 	// creates ids and twice chunks of the ids
 	var ids flow.IdentityList = unittest.IdentityListFixture(size)
 	chunks := a.CreateChunks(2, a.T())
-	assignment := chmodels.NewAssignment()
+	assignmentBuilder := chmodels.NewAssignmentBuilder()
 
 	// assigns first chunk to non-duplicate list of verifiers
 	c, ok := chunks.ByIndex(uint64(0))
 	require.True(a.T(), ok, "chunk out of range requested")
-	assignment.Add(c, ids.NodeIDs())
-	require.Len(a.T(), assignment.Verifiers(c), size)
+	assignmentBuilder.Add(c, ids.NodeIDs())
+	require.Len(a.T(), assignmentBuilder.Build().Verifiers(c), size)
 
 	// duplicates first verifier, hence size increases by 1
 	ids = append(ids, ids[0])
@@ -99,9 +100,9 @@ func (a *PublicAssignmentTestSuite) TestAssignDuplicate() {
 	// assigns second chunk to a duplicate list of verifiers
 	c, ok = chunks.ByIndex(uint64(1))
 	require.True(a.T(), ok, "chunk out of range requested")
-	assignment.Add(c, ids.NodeIDs())
+	assignmentBuilder.Add(c, ids.NodeIDs())
 	// should be size not size + 1
-	require.Len(a.T(), assignment.Verifiers(c), size)
+	require.Len(a.T(), assignmentBuilder.Build().Verifiers(c), size)
 }
 
 // TestPermuteEntirely tests permuting an entire IdentityList against

--- a/module/chunks/chunk_assigner_test.go
+++ b/module/chunks/chunk_assigner_test.go
@@ -83,17 +83,19 @@ func (a *PublicAssignmentTestSuite) TestAssignDuplicate() {
 	c, ok := chunks.ByIndex(uint64(0))
 	require.True(a.T(), ok, "chunk out of range requested")
 	assignmentBuilder.Add(c, ids.NodeIDs())
-	require.Len(a.T(), assignmentBuilder.Build().Verifiers(c), size)
 
 	// duplicates first verifier, hence size increases by 1
 	ids = append(ids, ids[0])
 	require.Len(a.T(), ids, size+1)
 	// assigns second chunk to a duplicate list of verifiers
-	c, ok = chunks.ByIndex(uint64(1))
+	c2, ok := chunks.ByIndex(uint64(1))
 	require.True(a.T(), ok, "chunk out of range requested")
-	assignmentBuilder.Add(c, ids.NodeIDs())
+	assignmentBuilder.Add(c2, ids.NodeIDs())
+
+	assignment := assignmentBuilder.Build()
+	require.Len(a.T(), assignment.Verifiers(c), size)
 	// should be size not size + 1
-	require.Len(a.T(), assignmentBuilder.Build().Verifiers(c), size)
+	require.Len(a.T(), assignment.Verifiers(c2), size)
 }
 
 // TestPermuteEntirely tests permuting an entire IdentityList against

--- a/module/chunks/chunk_assigner_test.go
+++ b/module/chunks/chunk_assigner_test.go
@@ -267,7 +267,7 @@ func (a *PublicAssignmentTestSuite) ChunkAssignmentScenario(chunkNum, verNum, al
 		// each chunk should be assigned to alpha verifiers
 		verifiers, err := p1.Verifiers(chunk.Index)
 		require.NoError(a.T(), err)
-		require.Equal(a.T(), verifiers.Len(), alpha)
+		require.Equal(a.T(), len(verifiers), alpha)
 	}
 }
 

--- a/module/chunks/chunk_assigner_test.go
+++ b/module/chunks/chunk_assigner_test.go
@@ -52,7 +52,7 @@ func (a *PublicAssignmentTestSuite) TestByNodeID() {
 	// Since there are 2x as many chunks as verifiers, each verifier will have 2 chunks
 	for j, chunk := range chunks {
 		v := ids[j%size].NodeID
-		assignmentBuilder.Add(chunk, flow.IdentifierList{v})
+		assignmentBuilder.Add(chunk.Index, flow.IdentifierList{v})
 	}
 	assignment := assignmentBuilder.Build()
 
@@ -74,28 +74,23 @@ func (a *PublicAssignmentTestSuite) TestByNodeID() {
 // TestAssignDuplicate tests assign Add duplicate verifiers
 func (a *PublicAssignmentTestSuite) TestAssignDuplicate() {
 	size := 5
-	// creates ids and twice chunks of the ids
+	// creates verifier ids
 	var ids flow.IdentityList = unittest.IdentityListFixture(size)
-	chunks := a.CreateChunks(2, a.T())
 	assignmentBuilder := chmodels.NewAssignmentBuilder()
 
 	// assigns first chunk to non-duplicate list of verifiers
-	c, ok := chunks.ByIndex(uint64(0))
-	require.True(a.T(), ok, "chunk out of range requested")
-	assignmentBuilder.Add(c, ids.NodeIDs())
+	assignmentBuilder.Add(0, ids.NodeIDs())
 
 	// duplicates first verifier, hence size increases by 1
 	ids = append(ids, ids[0])
 	require.Len(a.T(), ids, size+1)
 	// assigns second chunk to a duplicate list of verifiers
-	c2, ok := chunks.ByIndex(uint64(1))
-	require.True(a.T(), ok, "chunk out of range requested")
-	assignmentBuilder.Add(c2, ids.NodeIDs())
+	assignmentBuilder.Add(1, ids.NodeIDs())
 
 	assignment := assignmentBuilder.Build()
-	require.Len(a.T(), assignment.Verifiers(c), size)
+	require.Len(a.T(), assignment.Verifiers(0), size)
 	// should be size not size + 1
-	require.Len(a.T(), assignment.Verifiers(c2), size)
+	require.Len(a.T(), assignment.Verifiers(1), size)
 }
 
 // TestPermuteEntirely tests permuting an entire IdentityList against
@@ -274,7 +269,7 @@ func (a *PublicAssignmentTestSuite) ChunkAssignmentScenario(chunkNum, verNum, al
 
 	for _, chunk := range result.Chunks {
 		// each chunk should be assigned to alpha verifiers
-		require.Equal(a.T(), p1.Verifiers(chunk).Len(), alpha)
+		require.Equal(a.T(), p1.Verifiers(chunk.Index).Len(), alpha)
 	}
 }
 

--- a/module/validation/seal_validator.go
+++ b/module/validation/seal_validator.go
@@ -291,7 +291,7 @@ func (s *sealValidator) validateSeal(seal *flow.Seal, incorporatedResult *flow.I
 
 		// only Verification Nodes that were assigned to the chunk are allowed to approve it
 		for _, signerId := range chunkSigs.SignerIDs {
-			if !assignments.HasVerifier(chunk, signerId) {
+			if !assignments.HasVerifier(chunk.Index, signerId) {
 				return engine.NewInvalidInputErrorf("invalid signer id at chunk: %d", chunk.Index)
 			}
 		}

--- a/module/validation/seal_validator.go
+++ b/module/validation/seal_validator.go
@@ -291,7 +291,11 @@ func (s *sealValidator) validateSeal(seal *flow.Seal, incorporatedResult *flow.I
 
 		// only Verification Nodes that were assigned to the chunk are allowed to approve it
 		for _, signerId := range chunkSigs.SignerIDs {
-			if !assignments.HasVerifier(chunk.Index, signerId) {
+			b, err := assignments.HasVerifier(chunk.Index, signerId)
+			if err != nil {
+				return fmt.Errorf("getting verifiers for chunk %d failed: %w", chunk.Index, err)
+			}
+			if !b {
 				return engine.NewInvalidInputErrorf("invalid signer id at chunk: %d", chunk.Index)
 			}
 		}

--- a/module/validation/seal_validator_test.go
+++ b/module/validation/seal_validator_test.go
@@ -690,7 +690,7 @@ func (s *SealValidationSuite) validSealForResult(result *flow.ExecutionResult) *
 	assignment := s.Assignments[result.ID()]
 	for _, chunk := range result.Chunks {
 		aggregatedSigs := &seal.AggregatedApprovalSigs[chunk.Index]
-		assignedVerifiers := assignment.Verifiers(chunk)
+		assignedVerifiers := assignment.Verifiers(chunk.Index)
 		aggregatedSigs.SignerIDs = assignedVerifiers[:]
 		aggregatedSigs.VerifierSignatures = unittest.SignaturesFixture(len(assignedVerifiers))
 

--- a/module/validation/seal_validator_test.go
+++ b/module/validation/seal_validator_test.go
@@ -692,8 +692,12 @@ func (s *SealValidationSuite) validSealForResult(result *flow.ExecutionResult) *
 		aggregatedSigs := &seal.AggregatedApprovalSigs[chunk.Index]
 		assignedVerifiers, err := assignment.Verifiers(chunk.Index)
 		require.NoError(s.T(), err)
-		aggregatedSigs.SignerIDs = assignedVerifiers[:]
-		aggregatedSigs.VerifierSignatures = unittest.SignaturesFixture(len(assignedVerifiers))
+		v := make([]flow.Identifier, 0, len(assignedVerifiers))
+		for id := range assignedVerifiers {
+			v = append(v, id)
+		}
+		aggregatedSigs.SignerIDs = v
+		aggregatedSigs.VerifierSignatures = unittest.SignaturesFixture(len(v))
 
 		for i, aggregatedSig := range aggregatedSigs.VerifierSignatures {
 			payload := flow.Attestation{

--- a/module/validation/seal_validator_test.go
+++ b/module/validation/seal_validator_test.go
@@ -690,7 +690,8 @@ func (s *SealValidationSuite) validSealForResult(result *flow.ExecutionResult) *
 	assignment := s.Assignments[result.ID()]
 	for _, chunk := range result.Chunks {
 		aggregatedSigs := &seal.AggregatedApprovalSigs[chunk.Index]
-		assignedVerifiers := assignment.Verifiers(chunk.Index)
+		assignedVerifiers, err := assignment.Verifiers(chunk.Index)
+		require.NoError(s.T(), err)
 		aggregatedSigs.SignerIDs = assignedVerifiers[:]
 		aggregatedSigs.VerifierSignatures = unittest.SignaturesFixture(len(assignedVerifiers))
 

--- a/utils/unittest/chain_suite.go
+++ b/utils/unittest/chain_suite.go
@@ -515,7 +515,7 @@ func (bc *BaseChainSuite) ValidSubgraphFixture() subgraphFixture {
 	for _, chunk := range incorporatedResult.Result.Chunks {
 		assignedVerifiers, err := bc.Approvers.Sample(assignedVerifiersPerChunk)
 		require.NoError(bc.T(), err)
-		assignmentBuilder.Add(chunk.Index, assignedVerifiers.NodeIDs())
+		require.NoError(bc.T(), assignmentBuilder.Add(chunk.Index, assignedVerifiers.NodeIDs()))
 
 		// generate approvals
 		chunkApprovals := make(map[flow.Identifier]*flow.ResultApproval)
@@ -555,7 +555,7 @@ func (bc *BaseChainSuite) Extend(block *flow.Block) {
 		for _, chunk := range incorporatedResult.Result.Chunks {
 			assignedVerifiers, err := bc.Approvers.Sample(assignedVerifiersPerChunk)
 			require.NoError(bc.T(), err)
-			assignmentBuilder.Add(chunk.Index, assignedVerifiers.NodeIDs())
+			require.NoError(bc.T(), assignmentBuilder.Add(chunk.Index, assignedVerifiers.NodeIDs()))
 
 			// generate approvals
 			chunkApprovals := make(map[flow.Identifier]*flow.ResultApproval)

--- a/utils/unittest/chain_suite.go
+++ b/utils/unittest/chain_suite.go
@@ -515,7 +515,7 @@ func (bc *BaseChainSuite) ValidSubgraphFixture() subgraphFixture {
 	for _, chunk := range incorporatedResult.Result.Chunks {
 		assignedVerifiers, err := bc.Approvers.Sample(assignedVerifiersPerChunk)
 		require.NoError(bc.T(), err)
-		assignmentBuilder.Add(chunk, assignedVerifiers.NodeIDs())
+		assignmentBuilder.Add(chunk.Index, assignedVerifiers.NodeIDs())
 
 		// generate approvals
 		chunkApprovals := make(map[flow.Identifier]*flow.ResultApproval)
@@ -555,7 +555,7 @@ func (bc *BaseChainSuite) Extend(block *flow.Block) {
 		for _, chunk := range incorporatedResult.Result.Chunks {
 			assignedVerifiers, err := bc.Approvers.Sample(assignedVerifiersPerChunk)
 			require.NoError(bc.T(), err)
-			assignmentBuilder.Add(chunk, assignedVerifiers.NodeIDs())
+			assignmentBuilder.Add(chunk.Index, assignedVerifiers.NodeIDs())
 
 			// generate approvals
 			chunkApprovals := make(map[flow.Identifier]*flow.ResultApproval)


### PR DESCRIPTION
The assignment of verifiers to chunks of an execution receipt should be immutable after it is created. Currently it is mutable, with the `Assignment.Add()` method being used to add chunks (and the verifiers for them) one-by-one during creation. This PR adds a new `AssignmentBuilder` type and moves the `Add()` method to it.

`Assignment` now has no methods that mutate it. However, the initial implementation doesn't do a deep copy of the data, so any changes to the Builder will continue to be reflected in already-built `Assignment`s. No existing code does this or should do this (reuse the Builder after building the assignment) so I believe this isn't a problem.

In addition, the PR converts the type of the mapping from chunks to verifiers from a `map[chunk.Index]` to a slice, still indexed by the `chunk.Index`.

Issue: https://github.com/onflow/flow-go-internal/issues/5357