### PR TITLE
[Util] Add query last executed sealed block

### DIFF
--- a/cmd/util/cmd/read-protocol-state/cmd/blocks.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/blocks.go
@@ -159,6 +159,12 @@ func run(*cobra.Command, []string) {
 
 	reader := NewReader(state, storages)
 
+	// making sure only one flag is being used
+	err = checkOnlyOneFlagIsUsed(flagHeight, flagBlockID, flagFinal, flagSealed, flagExecuted)
+	if err != nil {
+		log.Fatal().Err(err).Msg("could not get block")
+	}
+
 	if flagHeight > 0 {
 		log.Info().Msgf("get block by height: %v", flagHeight)
 		block, err := reader.GetBlockByHeight(flagHeight)
@@ -237,5 +243,30 @@ func run(*cobra.Command, []string) {
 		log.Fatal().Msg("could not find executed block")
 	}
 
-	log.Fatal().Msgf("missing flag, try --final or --sealed or --height or --executed or --block-id")
+	log.Fatal().Msgf("missing flag, try --final or --sealed or --height or --executed or --block-id, note that only one flag can be used at a time")
+}
+
+func checkOnlyOneFlagIsUsed(height uint64, blockID string, final, sealed, executed bool) error {
+	flags := make([]string, 0, 5)
+	if height > 0 {
+		flags = append(flags, "height")
+	}
+	if blockID != "" {
+		flags = append(flags, "blockID")
+	}
+	if final {
+		flags = append(flags, "final")
+	}
+	if sealed {
+		flags = append(flags, "sealed")
+	}
+	if executed {
+		flags = append(flags, "executed")
+	}
+
+	if len(flags) != 1 {
+		return fmt.Errorf("only one flag can be used at a time, used flags: %v", flags)
+	}
+
+	return nil
 }

--- a/cmd/util/cmd/read-protocol-state/cmd/blocks.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/blocks.go
@@ -216,6 +216,7 @@ func run(*cobra.Command, []string) {
 			log.Fatal().Err(err).Msg("could not get root block")
 		}
 
+		// find the last executed and sealed block
 		for h := sealed.Header.Height; h >= root.Header.Height; h-- {
 			block, err := reader.GetBlockByHeight(h)
 			if err != nil {
@@ -233,8 +234,7 @@ func run(*cobra.Command, []string) {
 			}
 		}
 
-		// use binary search to find the last executed and sealed block
-
+		log.Fatal().Msg("could not find executed block")
 	}
 
 	log.Fatal().Msgf("missing flag, try --final or --sealed or --height or --executed or --block-id")

--- a/cmd/util/cmd/read-protocol-state/cmd/blocks.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/blocks.go
@@ -211,7 +211,12 @@ func run(*cobra.Command, []string) {
 			log.Fatal().Err(err).Msg("could not get sealed block")
 		}
 
-		for h := sealed.Header.Height; h >= uint64(0); h-- {
+		root, err := reader.GetRoot()
+		if err != nil {
+			log.Fatal().Err(err).Msg("could not get root block")
+		}
+
+		for h := sealed.Header.Height; h >= root.Header.Height; h-- {
 			block, err := reader.GetBlockByHeight(h)
 			if err != nil {
 				log.Fatal().Err(err).Msgf("could not get block by height: %v", h)

--- a/cmd/util/cmd/read-protocol-state/cmd/blocks.go
+++ b/cmd/util/cmd/read-protocol-state/cmd/blocks.go
@@ -43,7 +43,7 @@ func init() {
 		"get sealed block")
 
 	Cmd.Flags().BoolVar(&flagExecuted, "executed", false,
-		"get last executed and sealed block")
+		"get last executed and sealed block (execution node only)")
 }
 
 type Reader struct {


### PR DESCRIPTION
This PR adds a sub command to the read-protocol-state util to query last executed and sealed block for execution node in order to prevent failure when extracting checkpoint from latest sealed block which might not be executed.