### PR TITLE
[Flow EVM] Trigger `OnLog` tracer hooks upon successful call & tx results

### DIFF
--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -127,6 +127,14 @@ func (bl *BlockView) DirectCall(call *types.DirectCall) (res *types.Result, err 
 				err == nil && res != nil {
 				proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), res.ValidationError)
 			}
+
+			// call OnLog tracer hook, upon successful call result
+			if proc.evm.Config.Tracer.OnLog != nil &&
+				err == nil && res != nil {
+				for _, log := range res.Logs {
+					proc.evm.Config.Tracer.OnLog(log)
+				}
+			}
 		}()
 	}
 
@@ -191,6 +199,15 @@ func (bl *BlockView) RunTransaction(
 		proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), res.ValidationError)
 	}
 
+	// call OnLog tracer hook, upon successful tx result
+	if proc.evm.Config.Tracer != nil &&
+		proc.evm.Config.Tracer.OnLog != nil &&
+		res != nil {
+		for _, log := range res.Logs {
+			proc.evm.Config.Tracer.OnLog(log)
+		}
+	}
+
 	return res, nil
 }
 
@@ -242,6 +259,15 @@ func (bl *BlockView) BatchRunTransactions(txs []*gethTypes.Transaction) ([]*type
 			proc.evm.Config.Tracer.OnTxEnd != nil &&
 			res != nil {
 			proc.evm.Config.Tracer.OnTxEnd(res.Receipt(), res.ValidationError)
+		}
+
+		// call OnLog tracer hook, upon successful tx result
+		if proc.evm.Config.Tracer != nil &&
+			proc.evm.Config.Tracer.OnLog != nil &&
+			res != nil {
+			for _, log := range res.Logs {
+				proc.evm.Config.Tracer.OnLog(log)
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/6842

This will remove the need for having to trigger this tracer hook on EVM Gateway:
- https://github.com/onflow/flow-evm-gateway/blob/main/services/evm/executor.go#L109-L113
- https://github.com/onflow/flow-evm-gateway/blob/main/api/debug.go#L244-L248

And we will have all the necessary hooks in a single place, instead of being in separate repositories.