### PR TITLE
Allow `COA.withdraw` call to run when there is a possible rounding error

### DIFF
--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("413e2f84be8b8a8a135b34df85cc97d167048fe8d3d17cafc8ce8c4a4056bf57")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("e42d232ea16fc1122f4c98823451dba079672181106166eaddd2993a3a2fcef0")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/engine/execution/state/bootstrap/bootstrap_test.go
+++ b/engine/execution/state/bootstrap/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapLedger(t *testing.T) {
 }
 
 func TestBootstrapLedger_ZeroTokenSupply(t *testing.T) {
-	expectedStateCommitmentBytes, _ := hex.DecodeString("ea660c27b27ecfa7f93ee0462918b60145db8a78bc6a7e428574d4150b83b1b5")
+	expectedStateCommitmentBytes, _ := hex.DecodeString("413e2f84be8b8a8a135b34df85cc97d167048fe8d3d17cafc8ce8c4a4056bf57")
 	expectedStateCommitment, err := flow.ToStateCommitment(expectedStateCommitmentBytes)
 	require.NoError(t, err)
 

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -407,7 +407,7 @@ func (proc *procedure) withdrawFrom(
 		), nil
 	}
 
-	if types.BalanceInAttFlowValidForFlowVault(call.Value) {
+	if !types.AttoFlowBalanceValidForFlowVault(call.Value) {
 		return types.NewInvalidResult(
 			call.Transaction(),
 			types.ErrWithdrawBalanceRounding,

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -706,7 +706,7 @@ func convertAndCheckValue(input *big.Int) (isValid bool, converted *uint256.Int)
 	// convert value into uint256
 	value, overflow := uint256.FromBig(input)
 	if overflow {
-		return true, nil
+		return false, nil
 	}
 	return true, value
 }

--- a/fvm/evm/emulator/emulator.go
+++ b/fvm/evm/emulator/emulator.go
@@ -403,14 +403,15 @@ func (proc *procedure) withdrawFrom(
 	if !isValid {
 		return types.NewInvalidResult(
 			call.Transaction(),
-			types.ErrInvalidBalance), nil
+			types.ErrInvalidBalance,
+		), nil
 	}
 
-	// check balance is not prone to rounding error
-	if types.BalanceConversionToUFix64ProneToRoundingError(call.Value) {
+	if types.BalanceInAttFlowValidForFlowVault(call.Value) {
 		return types.NewInvalidResult(
 			call.Transaction(),
-			types.ErrWithdrawBalanceRounding), nil
+			types.ErrWithdrawBalanceRounding,
+		), nil
 	}
 
 	// create bridge account if not exist

--- a/fvm/evm/emulator/emulator_test.go
+++ b/fvm/evm/emulator/emulator_test.go
@@ -152,10 +152,68 @@ func TestNativeTokenBridging(t *testing.T) {
 			t.Run("tokens withdraw that results in rounding error", func(t *testing.T) {
 				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
 					RunWithNewBlockView(t, env, func(blk types.BlockView) {
-						call := types.NewWithdrawCall(bridgeAccount, testAccount, big.NewInt(1000), testAccountNonce)
+						call := types.NewWithdrawCall(bridgeAccount, testAccount, types.OneFlow(), testAccountNonce)
+						res, err := blk.DirectCall(call)
+						requireSuccessfulExecution(t, err, res)
+						require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
+						require.Equal(t, call.Hash(), res.TxHash)
+						testAccountNonce += 1
+					})
+				})
+				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
+					RunWithNewBlockView(t, env, func(blk types.BlockView) {
+						call := types.NewWithdrawCall(bridgeAccount, testAccount, big.NewInt(1000000000), testAccountNonce)
 						res, err := blk.DirectCall(call)
 						require.NoError(t, err)
-						require.Equal(t, res.ValidationError, types.ErrWithdrawBalanceRounding)
+						require.ErrorContains(
+							t,
+							res.ValidationError,
+							types.ErrWithdrawBalanceRounding.Error(),
+						)
+						testAccountNonce += 1
+					})
+				})
+				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
+					RunWithNewBlockView(t, env, func(blk types.BlockView) {
+						call := types.NewWithdrawCall(bridgeAccount, testAccount, big.NewInt(10000000000), testAccountNonce)
+						res, err := blk.DirectCall(call)
+						requireSuccessfulExecution(t, err, res)
+						require.Equal(t, defaultCtx.DirectCallBaseGasUsage, res.GasConsumed)
+						require.Equal(t, call.Hash(), res.TxHash)
+						testAccountNonce += 1
+					})
+				})
+				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
+					RunWithNewBlockView(t, env, func(blk types.BlockView) {
+						// Test withdraw amounts that overflow the UInt256 range
+						amount := big.NewInt(1)
+						amount.Lsh(amount, 256)
+
+						call := types.NewWithdrawCall(bridgeAccount, testAccount, amount, testAccountNonce)
+						res, err := blk.DirectCall(call)
+						require.NoError(t, err)
+						require.ErrorContains(
+							t,
+							res.ValidationError,
+							"invalid amount for transfer or balance change",
+						)
+						testAccountNonce += 1
+					})
+				})
+				RunWithNewEmulator(t, backend, rootAddr, func(env *emulator.Emulator) {
+					RunWithNewBlockView(t, env, func(blk types.BlockView) {
+						// Test withdraw amounts within the max range of UInt256
+						amount := big.NewInt(1)
+						amount.Lsh(amount, 255)
+
+						call := types.NewWithdrawCall(bridgeAccount, testAccount, amount, testAccountNonce)
+						res, err := blk.DirectCall(call)
+						require.NoError(t, err)
+						require.ErrorContains(
+							t,
+							res.ValidationError,
+							"insufficient funds for gas * price + value",
+						)
 						testAccountNonce += 1
 					})
 				})

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -1296,7 +1296,7 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 			})
 	})
 
-	t.Run("test coa withdraw", func(t *testing.T) {
+	t.Run("test coa withdraw with rounding error", func(t *testing.T) {
 		t.Parallel()
 
 		RunWithNewEnvironment(t,
@@ -1314,8 +1314,9 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 
 				transaction() {
 					prepare(account: auth(BorrowValue) &Account) {
-						let admin = account.storage
-							.borrow<&FlowToken.Administrator>(from: /storage/flowTokenAdmin)!
+						let admin = account.storage.borrow<&FlowToken.Administrator>(
+							from: /storage/flowTokenAdmin
+						)!
 
 						let minter <- admin.createNewMinter(allowedAmount: 2.34)
 						let vault <- minter.mintTokens(amount: 2.34)
@@ -1324,10 +1325,282 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 						let cadenceOwnedAccount <- EVM.createCadenceOwnedAccount()
 						cadenceOwnedAccount.deposit(from: <-vault)
 
-						let bal = EVM.Balance(attoflow: 0)
-						bal.setFLOW(flow: 1.23)
+						let bal = EVM.Balance(attoflow: 9999999999)
 						let vault2 <- cadenceOwnedAccount.withdraw(balance: bal)
 						let balance = vault2.balance
+						destroy cadenceOwnedAccount
+						destroy vault2
+					}
+				}
+				`,
+					sc.EVMContract.Address.HexWithPrefix(),
+					sc.FlowToken.Address.HexWithPrefix(),
+				))
+
+				tx := fvm.Transaction(
+					flow.NewTransactionBody().
+						SetScript(code).
+						AddAuthorizer(sc.FlowServiceAccount.Address),
+					0,
+				)
+
+				_, output, err := vm.Run(
+					ctx,
+					tx,
+					snapshot,
+				)
+				require.NoError(t, err)
+				require.Error(t, output.Err)
+				require.ErrorContains(
+					t,
+					output.Err,
+					types.ErrWithdrawBalanceRounding.Error(),
+				)
+			},
+		)
+	})
+
+	t.Run("test coa withdraw with minimum allowed transfer", func(t *testing.T) {
+		t.Parallel()
+
+		RunWithNewEnvironment(t,
+			chain, func(
+				ctx fvm.Context,
+				vm fvm.VM,
+				snapshot snapshot.SnapshotTree,
+				testContract *TestContract,
+				testAccount *EOATestAccount,
+			) {
+				code := []byte(fmt.Sprintf(
+					`
+				import EVM from %s
+				import FlowToken from %s
+
+				transaction() {
+					prepare(account: auth(BorrowValue) &Account) {
+						let admin = account.storage.borrow<&FlowToken.Administrator>(
+							from: /storage/flowTokenAdmin
+						)!
+
+						let minter <- admin.createNewMinter(allowedAmount: 2.34)
+						let vault <- minter.mintTokens(amount: 2.34)
+						destroy minter
+
+						let cadenceOwnedAccount <- EVM.createCadenceOwnedAccount()
+						cadenceOwnedAccount.deposit(from: <-vault)
+
+						let bal = EVM.Balance(attoflow: 10000000000)
+						let vault2 <- cadenceOwnedAccount.withdraw(balance: bal)
+						let balance = vault2.balance
+						assert(balance == 0.00000001, message: "mismatching vault balance")
+						destroy cadenceOwnedAccount
+						destroy vault2
+					}
+				}
+				`,
+					sc.EVMContract.Address.HexWithPrefix(),
+					sc.FlowToken.Address.HexWithPrefix(),
+				))
+
+				tx := fvm.Transaction(
+					flow.NewTransactionBody().
+						SetScript(code).
+						AddAuthorizer(sc.FlowServiceAccount.Address),
+					0,
+				)
+
+				_, output, err := vm.Run(
+					ctx,
+					tx,
+					snapshot,
+				)
+				require.NoError(t, err)
+				require.NoError(t, output.Err)
+
+				withdrawEvent := output.Events[7]
+
+				ev, err := events.FlowEventToCadenceEvent(withdrawEvent)
+				require.NoError(t, err)
+
+				evPayload, err := events.DecodeFLOWTokensWithdrawnEventPayload(ev)
+				require.NoError(t, err)
+
+				// 2.34000000 - 0.00000001 = 2.33999999
+				expectedBalanceAfterWithdraw := big.NewInt(2_339_999_990_000_000_000)
+				require.Equal(t, expectedBalanceAfterWithdraw, evPayload.BalanceAfterInAttoFlow.Value)
+			},
+		)
+	})
+
+	t.Run("test coa withdraw with success", func(t *testing.T) {
+		t.Parallel()
+
+		RunWithNewEnvironment(t,
+			chain, func(
+				ctx fvm.Context,
+				vm fvm.VM,
+				snapshot snapshot.SnapshotTree,
+				testContract *TestContract,
+				testAccount *EOATestAccount,
+			) {
+				code := []byte(fmt.Sprintf(
+					`
+				import EVM from %s
+				import FlowToken from %s
+
+				transaction() {
+					prepare(account: auth(BorrowValue) &Account) {
+						let admin = account.storage.borrow<&FlowToken.Administrator>(
+							from: /storage/flowTokenAdmin
+						)!
+
+						let minter <- admin.createNewMinter(allowedAmount: 2.34)
+						let vault <- minter.mintTokens(amount: 2.34)
+						destroy minter
+
+						let cadenceOwnedAccount <- EVM.createCadenceOwnedAccount()
+						cadenceOwnedAccount.deposit(from: <-vault)
+
+						let bal = EVM.Balance(attoflow: 1230000780000000000)
+						let vault2 <- cadenceOwnedAccount.withdraw(balance: bal)
+						let balance = vault2.balance
+						assert(balance == 1.23000078, message: "mismatching vault balance")
+						destroy cadenceOwnedAccount
+						destroy vault2
+					}
+				}
+				`,
+					sc.EVMContract.Address.HexWithPrefix(),
+					sc.FlowToken.Address.HexWithPrefix(),
+				))
+
+				tx := fvm.Transaction(
+					flow.NewTransactionBody().
+						SetScript(code).
+						AddAuthorizer(sc.FlowServiceAccount.Address),
+					0,
+				)
+
+				_, output, err := vm.Run(
+					ctx,
+					tx,
+					snapshot,
+				)
+				require.NoError(t, err)
+				require.NoError(t, output.Err)
+
+				withdrawEvent := output.Events[7]
+
+				ev, err := events.FlowEventToCadenceEvent(withdrawEvent)
+				require.NoError(t, err)
+
+				evPayload, err := events.DecodeFLOWTokensWithdrawnEventPayload(ev)
+				require.NoError(t, err)
+
+				// 2.34000000 - 1.23000078 = 1.10999922
+				expectedBalanceAfterWithdraw := big.NewInt(1_109_999_220_000_000_000)
+				require.Equal(t, expectedBalanceAfterWithdraw, evPayload.BalanceAfterInAttoFlow.Value)
+			},
+		)
+	})
+
+	t.Run("test coa withdraw with value bigger than uint256", func(t *testing.T) {
+		t.Parallel()
+
+		RunWithNewEnvironment(t,
+			chain, func(
+				ctx fvm.Context,
+				vm fvm.VM,
+				snapshot snapshot.SnapshotTree,
+				testContract *TestContract,
+				testAccount *EOATestAccount,
+			) {
+				code := []byte(fmt.Sprintf(
+					`
+				import EVM from %s
+				import FlowToken from %s
+
+				transaction() {
+					prepare(account: auth(BorrowValue) &Account) {
+						let admin = account.storage.borrow<&FlowToken.Administrator>(
+							from: /storage/flowTokenAdmin
+						)!
+
+						let minter <- admin.createNewMinter(allowedAmount: 2.34)
+						let vault <- minter.mintTokens(amount: 2.34)
+						destroy minter
+
+						let cadenceOwnedAccount <- EVM.createCadenceOwnedAccount()
+						cadenceOwnedAccount.deposit(from: <-vault)
+
+						let bal = EVM.Balance(attoflow: 115792089237316195423570985008687907853269984665640564039457584007913129639936)
+						let vault2 <- cadenceOwnedAccount.withdraw(balance: bal)
+						let balance = vault2.balance
+						destroy cadenceOwnedAccount
+						destroy vault2
+					}
+				}
+				`,
+					sc.EVMContract.Address.HexWithPrefix(),
+					sc.FlowToken.Address.HexWithPrefix(),
+				))
+
+				tx := fvm.Transaction(
+					flow.NewTransactionBody().
+						SetScript(code).
+						AddAuthorizer(sc.FlowServiceAccount.Address),
+					0,
+				)
+
+				_, output, err := vm.Run(
+					ctx,
+					tx,
+					snapshot,
+				)
+				require.NoError(t, err)
+				require.Error(t, output.Err)
+				require.ErrorContains(
+					t,
+					output.Err,
+					types.ErrInvalidBalance.Error(),
+				)
+			},
+		)
+	})
+
+	t.Run("test coa withdraw with remainder truncation", func(t *testing.T) {
+		t.Parallel()
+
+		RunWithNewEnvironment(t,
+			chain, func(
+				ctx fvm.Context,
+				vm fvm.VM,
+				snapshot snapshot.SnapshotTree,
+				testContract *TestContract,
+				testAccount *EOATestAccount,
+			) {
+				code := []byte(fmt.Sprintf(
+					`
+				import EVM from %s
+				import FlowToken from %s
+
+				transaction() {
+					prepare(account: auth(BorrowValue) &Account) {
+						let admin = account.storage.borrow<&FlowToken.Administrator>(
+							from: /storage/flowTokenAdmin
+						)!
+
+						let minter <- admin.createNewMinter(allowedAmount: 2.34)
+						let vault <- minter.mintTokens(amount: 2.34)
+						destroy minter
+
+						let cadenceOwnedAccount <- EVM.createCadenceOwnedAccount()
+						cadenceOwnedAccount.deposit(from: <-vault)
+
+						let bal = EVM.Balance(attoflow: 1230000789912345678)
+						let vault2 <- cadenceOwnedAccount.withdraw(balance: bal)
+						let balance = vault2.balance
+						assert(balance == 1.23000078, message: "mismatching vault balance")
 						destroy cadenceOwnedAccount
 						destroy vault2
 					}
@@ -1346,7 +1619,8 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 				_, output, err := vm.Run(
 					ctx,
 					tx,
-					snapshot)
+					snapshot,
+				)
 				require.NoError(t, err)
 				require.NoError(t, output.Err)
 
@@ -1358,10 +1632,11 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 				evPayload, err := events.DecodeFLOWTokensWithdrawnEventPayload(ev)
 				require.NoError(t, err)
 
-				// 2.34 - 1.23 = 1.11
-				expectedBalanceAfterWithdraw := big.NewInt(1_110_000_000_000_000_000)
+				// 2.34000000 - 1.2300000078 = 1.10999922
+				expectedBalanceAfterWithdraw := big.NewInt(1_109_999_220_000_000_000)
 				require.Equal(t, expectedBalanceAfterWithdraw, evPayload.BalanceAfterInAttoFlow.Value)
-			})
+			},
+		)
 	})
 
 	t.Run("test coa transfer", func(t *testing.T) {

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -1325,6 +1325,8 @@ func TestCadenceOwnedAccountFunctionalities(t *testing.T) {
 						let cadenceOwnedAccount <- EVM.createCadenceOwnedAccount()
 						cadenceOwnedAccount.deposit(from: <-vault)
 
+						// since 1e10 attoFlow is the minimum withdrawable amount,
+						// verify any amount below 1e10 can not be withdrawn.
 						let bal = EVM.Balance(attoflow: 9999999999)
 						let vault2 <- cadenceOwnedAccount.withdraw(balance: bal)
 						let balance = vault2.balance

--- a/fvm/evm/handler/handler_test.go
+++ b/fvm/evm/handler/handler_test.go
@@ -1178,10 +1178,10 @@ func TestHandler_TransactionRun(t *testing.T) {
 					acc.Call(types.EmptyAddress, nil, 1000, types.EmptyBalance)
 
 					backend.ExpectedSpan(t, trace.FVMEVMDeposit)
-					acc.Deposit(types.NewFlowTokenVault(types.EmptyBalance))
+					acc.Deposit(types.NewFlowTokenVault(types.OneFlow()))
 
 					backend.ExpectedSpan(t, trace.FVMEVMWithdraw)
-					acc.Withdraw(types.EmptyBalance)
+					acc.Withdraw(types.OneFlow())
 
 					backend.ExpectedSpan(t, trace.FVMEVMDeploy)
 					acc.Deploy(nil, 1, types.EmptyBalance)

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -647,7 +647,7 @@ func newInternalEVMTypeWithdrawFunction(
 				panic(types.ErrInvalidBalance)
 			}
 
-			if types.BalanceInAttFlowValidForFlowVault(amountValue.BigInt) {
+			if !types.AttoFlowBalanceValidForFlowVault(amountValue.BigInt) {
 				panic(types.ErrWithdrawBalanceRounding)
 			}
 

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -651,6 +651,7 @@ func newInternalEVMTypeWithdrawFunction(
 				panic(types.ErrWithdrawBalanceRounding)
 			}
 
+// this is where rounding from Atto scale to UFix scale happens.
 			value := new(big.Int).Div(amountValue.BigInt, types.UFixToAttoConversionMultiplier)
 			amount := types.NewBalanceFromUFix64(cadence.UFix64(value.Uint64()))
 

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/holiman/uint256"
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/errors"
@@ -641,7 +642,17 @@ func newInternalEVMTypeWithdrawFunction(
 				panic(errors.NewUnreachableError())
 			}
 
-			amount := types.NewBalance(amountValue.BigInt)
+			_, overflow := uint256.FromBig(amountValue.BigInt)
+			if overflow {
+				panic(types.ErrInvalidBalance)
+			}
+
+			if types.BalanceInAttFlowValidForFlowVault(amountValue.BigInt) {
+				panic(types.ErrWithdrawBalanceRounding)
+			}
+
+			value := new(big.Int).Div(amountValue.BigInt, types.UFixToAttoConversionMultiplier)
+			amount := types.NewBalanceFromUFix64(cadence.UFix64(value.Uint64()))
 
 			// Withdraw
 
@@ -649,12 +660,11 @@ func newInternalEVMTypeWithdrawFunction(
 			account := handler.AccountByAddress(fromAddress, isAuthorized)
 			vault := account.Withdraw(amount)
 
-			ufix, roundedOff, err := types.ConvertBalanceToUFix64(vault.Balance())
+			// We have already truncated the remainder above, so we do not
+			// care about rounding loss here.
+			ufix, _, err := types.ConvertBalanceToUFix64(vault.Balance())
 			if err != nil {
 				panic(err)
-			}
-			if roundedOff {
-				panic(types.ErrWithdrawBalanceRounding)
 			}
 
 			// TODO: improve: maybe call actual constructor

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -661,11 +661,14 @@ func newInternalEVMTypeWithdrawFunction(
 			account := handler.AccountByAddress(fromAddress, isAuthorized)
 			vault := account.Withdraw(amount)
 
-			// We have already truncated the remainder above, so we do not
-			// care about rounding loss here.
-			ufix, _, err := types.ConvertBalanceToUFix64(vault.Balance())
+			ufix, roundedOff, err := types.ConvertBalanceToUFix64(vault.Balance())
 			if err != nil {
 				panic(err)
+			}
+			// We have already truncated the remainder above, but we still leave
+			// the rounding check in as a redundancy.
+			if roundedOff {
+				panic(types.ErrWithdrawBalanceRounding)
 			}
 
 			// TODO: improve: maybe call actual constructor

--- a/fvm/evm/impl/impl.go
+++ b/fvm/evm/impl/impl.go
@@ -651,7 +651,7 @@ func newInternalEVMTypeWithdrawFunction(
 				panic(types.ErrWithdrawBalanceRounding)
 			}
 
-// this is where rounding from Atto scale to UFix scale happens.
+			// this is where rounding from Atto scale to UFix scale happens.
 			value := new(big.Int).Div(amountValue.BigInt, types.UFixToAttoConversionMultiplier)
 			amount := types.NewBalanceFromUFix64(cadence.UFix64(value.Uint64()))
 

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -441,9 +441,12 @@ contract EVM {
             return self.address()
         }
 
-        /// Withdraws the balance from the cadence owned account's balance
-        /// Note that amounts smaller than 1e10 attoFlow can't be withdrawn
-        /// given that Flow Token Vaults use UFix64s to store balances.
+        /// Withdraws the balance from the cadence owned account's balance.
+        /// Note that amounts smaller than 1e10 attoFlow can't be withdrawn,
+        /// given that Flow Token Vaults use UFix64 to store balances.
+        /// In other words, the smallest withdrawable amount is 1e10 attoFlow.
+        /// Amounts smaller than 1e10 attoFlow, will cause the function to panic
+        /// with: "withdraw failed! smallest unit allowed to transfer is 1e10 attoFlow".
         /// If the given balance conversion to UFix64 results in
         /// rounding loss, the withdrawal amount will be truncated to the
         /// maximum precision for UFix64.

--- a/fvm/evm/stdlib/contract.cdc
+++ b/fvm/evm/stdlib/contract.cdc
@@ -284,7 +284,7 @@ contract EVM {
         /// Casts the balance to a UFix64 (rounding down)
         /// Warning! casting a balance to a UFix64 which supports a lower level of precision
         /// (8 decimal points in compare to 18) might result in rounding down error.
-        /// Use the toAttoFlow function if you care need more accuracy.
+        /// Use the inAttoFLOW function if you care need more accuracy.
         access(all)
         view fun inFLOW(): UFix64 {
             return InternalEVM.castToFLOW(balance: self.attoflow)
@@ -442,10 +442,11 @@ contract EVM {
         }
 
         /// Withdraws the balance from the cadence owned account's balance
-        /// Note that amounts smaller than 10nF (10e-8) can't be withdrawn
+        /// Note that amounts smaller than 1e10 attoFlow can't be withdrawn
         /// given that Flow Token Vaults use UFix64s to store balances.
         /// If the given balance conversion to UFix64 results in
-        /// rounding error, this function would fail.
+        /// rounding loss, the withdrawal amount will be truncated to the
+        /// maximum precision for UFix64.
         access(Owner | Withdraw)
         fun withdraw(balance: Balance): @FlowToken.Vault {
             if balance.isZero() {

--- a/fvm/evm/stdlib/contract_test.go
+++ b/fvm/evm/stdlib/contract_test.go
@@ -5252,6 +5252,7 @@ func TestCadenceOwnedAccountWithdraw(t *testing.T) {
 
           let vault2 <- cadenceOwnedAccount.withdraw(balance: EVM.Balance(attoflow: 1230000000000000000))
           let balance = vault2.balance
+          assert(balance == 1.23000000, message: "mismatching vault balance")
           log(vault2.uuid)
 
           destroy cadenceOwnedAccount

--- a/fvm/evm/types/balance.go
+++ b/fvm/evm/types/balance.go
@@ -95,11 +95,11 @@ func BalanceConversionToUFix64ProneToRoundingError(bal Balance) bool {
 }
 
 // AttoFlowBalanceValidForFlowVault returns true if the given balance,
-// represented as atto Flow, can be stored in a Flow Vault.
+// represented as atto-flow, can be stored in a Flow Vault.
 //
 // Warning! The smallest unit of Flow token that a Flow Vault (Cadence)
 // can store, is 1e-8 .
-// That means the minimum balance, in atto Flow, that can be stored in a Flow Vault,
+// That means the minimum balance, in atto-flow, that can be stored in a Flow Vault,
 // is 1e10 .
 func AttoFlowBalanceValidForFlowVault(bal *big.Int) bool {
 	return bal.Cmp(UFixToAttoConversionMultiplier) >= 0

--- a/fvm/evm/types/balance.go
+++ b/fvm/evm/types/balance.go
@@ -94,6 +94,17 @@ func BalanceConversionToUFix64ProneToRoundingError(bal Balance) bool {
 	return new(big.Int).Mod(bal, UFixToAttoConversionMultiplier).BitLen() != 0
 }
 
+// BalanceInAttFlowValidForFlowVault returns true if the given balance,
+// represented as atto Flow, can be stored in a Flow Vault.
+//
+// Warning! The smallest unit of Flow token that a Flow Vault (Cadence)
+// can store, is 1e10^-8 .
+// That means the minimum balance, in atto Flow, that can be stored in a Flow Vault,
+// is 1e10^10 .
+func BalanceInAttFlowValidForFlowVault(bal *big.Int) bool {
+	return bal.Cmp(UFixToAttoConversionMultiplier) < 0
+}
+
 // Subtract balance 2 from balance 1 and returns the result as a new balance
 func SubBalance(bal1 Balance, bal2 Balance) (Balance, error) {
 	if (*big.Int)(bal1).Cmp(bal2) == -1 {

--- a/fvm/evm/types/balance.go
+++ b/fvm/evm/types/balance.go
@@ -94,15 +94,15 @@ func BalanceConversionToUFix64ProneToRoundingError(bal Balance) bool {
 	return new(big.Int).Mod(bal, UFixToAttoConversionMultiplier).BitLen() != 0
 }
 
-// BalanceInAttFlowValidForFlowVault returns true if the given balance,
+// AttoFlowBalanceValidForFlowVault returns true if the given balance,
 // represented as atto Flow, can be stored in a Flow Vault.
 //
 // Warning! The smallest unit of Flow token that a Flow Vault (Cadence)
 // can store, is 1e10^-8 .
 // That means the minimum balance, in atto Flow, that can be stored in a Flow Vault,
 // is 1e10^10 .
-func BalanceInAttFlowValidForFlowVault(bal *big.Int) bool {
-	return bal.Cmp(UFixToAttoConversionMultiplier) < 0
+func AttoFlowBalanceValidForFlowVault(bal *big.Int) bool {
+	return bal.Cmp(UFixToAttoConversionMultiplier) >= 0
 }
 
 // Subtract balance 2 from balance 1 and returns the result as a new balance

--- a/fvm/evm/types/balance.go
+++ b/fvm/evm/types/balance.go
@@ -100,7 +100,7 @@ func BalanceConversionToUFix64ProneToRoundingError(bal Balance) bool {
 // Warning! The smallest unit of Flow token that a Flow Vault (Cadence)
 // can store, is 1e-8 .
 // That means the minimum balance, in atto Flow, that can be stored in a Flow Vault,
-// is 1e10^10 .
+// is 1e10 .
 func AttoFlowBalanceValidForFlowVault(bal *big.Int) bool {
 	return bal.Cmp(UFixToAttoConversionMultiplier) >= 0
 }

--- a/fvm/evm/types/balance.go
+++ b/fvm/evm/types/balance.go
@@ -98,7 +98,7 @@ func BalanceConversionToUFix64ProneToRoundingError(bal Balance) bool {
 // represented as atto Flow, can be stored in a Flow Vault.
 //
 // Warning! The smallest unit of Flow token that a Flow Vault (Cadence)
-// can store, is 1e10^-8 .
+// can store, is 1e-8 .
 // That means the minimum balance, in atto Flow, that can be stored in a Flow Vault,
 // is 1e10^10 .
 func AttoFlowBalanceValidForFlowVault(bal *big.Int) bool {

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -99,7 +99,7 @@ var (
 
 	// ErrWithdrawBalanceRounding is returned when withdraw call has a balance that could
 	// result in rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).
-	ErrWithdrawBalanceRounding = errors.New("withdraw failed! the balance is susceptible to the rounding error")
+	ErrWithdrawBalanceRounding = errors.New("withdraw failed! smallest unit allowed to transfer is 1e10^10 attoFlow")
 
 	// ErrUnexpectedEmptyResult is returned when a result is expected to be returned by the emulator
 	// but nil has been returned. This should never happen and is a safety error.

--- a/fvm/evm/types/errors.go
+++ b/fvm/evm/types/errors.go
@@ -99,7 +99,7 @@ var (
 
 	// ErrWithdrawBalanceRounding is returned when withdraw call has a balance that could
 	// result in rounding error, i.e. the balance contains fractions smaller than 10^8 Flow (smallest unit allowed to transfer).
-	ErrWithdrawBalanceRounding = errors.New("withdraw failed! smallest unit allowed to transfer is 1e10^10 attoFlow")
+	ErrWithdrawBalanceRounding = errors.New("withdraw failed! smallest unit allowed to transfer is 1e10 attoFlow")
 
 	// ErrUnexpectedEmptyResult is returned when a result is expected to be returned by the emulator
 	// but nil has been returned. This should never happen and is a safety error.

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "0572718e6a4ed54a7321f51d7800970ece67b5b67e8f2462222653c044be2485"
+const GenesisStateCommitmentHex = "c6fc5b46c7e302667ba66a29fef733fdf0330c4dd7d71f31f35275c10df28c22"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "7c441d274c07623c52581a07bd4e9e741fd0cc9f678b183192e1f0f5c101e20d"
+		return "26cca7f2d4ffbfe083714104f602c80fa05b3e7f334b29e7c36cd588fb01cd7a"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "95fac6c0841ffb72de3fff69c8dfdf054ea2e122567eaf57cbaf7bbef56ea9d6"
+	return "42030f01b34cfea613f3366e4f7b2e4ea5d831245c2f25aee7950f9e4f408b93"
 }

--- a/utils/unittest/execution_state.go
+++ b/utils/unittest/execution_state.go
@@ -23,7 +23,7 @@ const ServiceAccountPrivateKeySignAlgo = crypto.ECDSAP256
 const ServiceAccountPrivateKeyHashAlgo = hash.SHA2_256
 
 // Pre-calculated state commitment with root account with the above private key
-const GenesisStateCommitmentHex = "c6fc5b46c7e302667ba66a29fef733fdf0330c4dd7d71f31f35275c10df28c22"
+const GenesisStateCommitmentHex = "82b54327c722b74390f72646ada6a64ae056da86038a9beaa2e4194cac506af6"
 
 var GenesisStateCommitment flow.StateCommitment
 
@@ -87,10 +87,10 @@ func genesisCommitHexByChainID(chainID flow.ChainID) string {
 		return GenesisStateCommitmentHex
 	}
 	if chainID == flow.Testnet {
-		return "26cca7f2d4ffbfe083714104f602c80fa05b3e7f334b29e7c36cd588fb01cd7a"
+		return "9d7937004f626b4dd3ed3f201c39a007dcced1305e5e9d5f512b4395a560cb14"
 	}
 	if chainID == flow.Sandboxnet {
 		return "e1c08b17f9e5896f03fe28dd37ca396c19b26628161506924fbf785834646ea1"
 	}
-	return "42030f01b34cfea613f3366e4f7b2e4ea5d831245c2f25aee7950f9e4f408b93"
+	return "a998420349545ba478ae3b305830bcf221ef10ddb86d8be99a3eb1bcbd9b96f1"
 }


### PR DESCRIPTION
Closes https://github.com/onflow/flow-go/issues/6856

In this case, we perform the withdrawal, by simply truncating the remainder that cannot fit in a Flow token vault.
When the attoFlow balance is too small to fit in a Flow vault, we panic with a dedicated error message.