### PR TITLE
Remove unnecessary implementations of Entity and IDentity

### DIFF
--- a/model/verification/receiptDataPack.go
+++ b/model/verification/receiptDataPack.go
@@ -13,14 +13,3 @@ type ReceiptDataPack struct {
 	OriginID flow.Identifier
 	Ctx      context.Context // used for span tracing
 }
-
-// ID returns the unique identifier for the ReceiptDataPack which is the
-// id of its execution receipt.
-func (r *ReceiptDataPack) ID() flow.Identifier {
-	return r.Receipt.ID()
-}
-
-// Checksum returns the checksum of the ReceiptDataPack.
-func (r *ReceiptDataPack) Checksum() flow.Identifier {
-	return flow.MakeID(r)
-}

--- a/model/verification/resultDataPack.go
+++ b/model/verification/resultDataPack.go
@@ -10,14 +10,3 @@ type ResultDataPack struct {
 	ExecutorID      flow.Identifier
 	ExecutionResult *flow.ExecutionResult
 }
-
-// ID returns the unique identifier for the ResultDataPack which is the
-// id of its execution result.
-func (r *ResultDataPack) ID() flow.Identifier {
-	return r.ExecutionResult.ID()
-}
-
-// Checksum returns the checksum of the ResultDataPack.
-func (r *ResultDataPack) Checksum() flow.Identifier {
-	return flow.MakeID(r)
-}

--- a/module/mempool/model/approval_map_entity.go
+++ b/module/mempool/model/approval_map_entity.go
@@ -20,9 +20,6 @@ func (a *ApprovalMapEntity) ID() flow.Identifier {
 	return a.ChunkKey
 }
 
-// CheckSum implements flow.Entity.CheckSum for ApprovalMapEntity to make it
-// capable of being stored directly in mempools and storage. It makes the id of
-// the entire ApprovalMapEntity.
-func (a *ApprovalMapEntity) Checksum() flow.Identifier {
+func (a *ApprovalMapEntity) Hash() flow.Identifier {
 	return flow.MakeID(a)
 }

--- a/module/mempool/model/approval_map_entity.go
+++ b/module/mempool/model/approval_map_entity.go
@@ -20,6 +20,6 @@ func (a *ApprovalMapEntity) ID() flow.Identifier {
 	return a.ChunkKey
 }
 
-func (a *ApprovalMapEntity) Hash() flow.Identifier {
+func (a *ApprovalMapEntity) Checksum() flow.Identifier {
 	return flow.MakeID(a)
 }

--- a/module/mempool/model/approval_map_entity.go
+++ b/module/mempool/model/approval_map_entity.go
@@ -20,6 +20,9 @@ func (a *ApprovalMapEntity) ID() flow.Identifier {
 	return a.ChunkKey
 }
 
+// CheckSum implements flow.Entity.CheckSum for ApprovalMapEntity to make it
+// capable of being stored directly in mempools and storage. It makes the id of
+// the entire ApprovalMapEntity.
 func (a *ApprovalMapEntity) Checksum() flow.Identifier {
 	return flow.MakeID(a)
 }

--- a/module/mempool/model/incorporated_result_map.go
+++ b/module/mempool/model/incorporated_result_map.go
@@ -9,16 +9,3 @@ type IncorporatedResultMap struct {
 	ExecutionResult     *flow.ExecutionResult
 	IncorporatedResults map[flow.Identifier]*flow.IncorporatedResult // [incorporated block ID] => IncorporatedResult
 }
-
-// ID implements flow.Entity.ID for IncorporatedResultMap to make it capable of
-// being stored directly in mempools and storage.
-func (a *IncorporatedResultMap) ID() flow.Identifier {
-	return a.ExecutionResult.ID()
-}
-
-// CheckSum implements flow.Entity.CheckSum for IncorporatedResultMap to make it
-// capable of being stored directly in mempools and storage. It makes the id of
-// the entire IncorporatedResultMap.
-func (a *IncorporatedResultMap) Checksum() flow.Identifier {
-	return flow.MakeID(a)
-}


### PR DESCRIPTION
We identified that the types `IncorporatedResultMap`, `ReceiptDataPack`, `ResultDataPack` use neither `Entity` nor `IDEntity` implementations. So, in this PR, I removed these implementations.

Closes https://github.com/onflow/flow-go/issues/6701