### PR TITLE
Refactor Consensus Matching Engine: `engine.Unit` -> `ComponentManager`

### DIFF
--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -180,7 +180,7 @@ func (e *Engine) finalizationProcessingLoop(ctx irrecoverable.SignalerContext, r
 		case <-finalizationNotifier:
 			err := e.core.OnBlockFinalization()
 			if err != nil {
-				e.log.Fatal().Err(err).Msg("could not process last finalized event")
+				ctx.Throw(fmt.Errorf("could not process last finalized event: %w", err))
 			}
 		}
 	}
@@ -197,7 +197,7 @@ func (e *Engine) blockIncorporatedEventsProcessingLoop(ctx irrecoverable.Signale
 		case <-c:
 			err := e.processBlockIncorporatedEvents(ctx)
 			if err != nil {
-				e.log.Fatal().Err(err).Msg("internal error processing block incorporated queued message")
+				ctx.Throw(fmt.Errorf("internal error processing block incorporated queued message: %w", err))
 			}
 		}
 	}
@@ -215,7 +215,7 @@ func (e *Engine) inboundEventsProcessingLoop(ctx irrecoverable.SignalerContext, 
 		case <-c:
 			err := e.processExecutionReceipts(ctx)
 			if err != nil {
-				e.log.Fatal().Err(err).Msg("internal error processing queued message")
+				ctx.Throw(fmt.Errorf("internal error processing queued execution receipt: %w", err))
 			}
 		}
 	}

--- a/engine/consensus/matching/engine.go
+++ b/engine/consensus/matching/engine.go
@@ -84,17 +84,17 @@ func NewEngine(
 		pendingIncorporatedBlocks:  pendingIncorporatedBlocks,
 	}
 
-	// register engine with the receipt provider
-	_, err = net.Register(channels.ReceiveReceipts, e)
-	if err != nil {
-		return nil, fmt.Errorf("could not register for results: %w", err)
-	}
-
 	e.Component = component.NewComponentManagerBuilder().
 		AddWorker(e.inboundEventsProcessingLoop).
 		AddWorker(e.finalizationProcessingLoop).
 		AddWorker(e.blockIncorporatedEventsProcessingLoop).
 		Build()
+
+	// register engine with the receipt provider
+	_, err = net.Register(channels.ReceiveReceipts, e)
+	if err != nil {
+		return nil, fmt.Errorf("could not register for results: %w", err)
+	}
 
 	return e, nil
 }

--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/onflow/flow-go/engine"
 	mockconsensus "github.com/onflow/flow-go/engine/consensus/mock"
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/module/irrecoverable"
 	"github.com/onflow/flow-go/module/metrics"
 	mockmodule "github.com/onflow/flow-go/module/mock"
 	"github.com/onflow/flow-go/network/channels"
@@ -57,6 +59,8 @@ func (s *MatchingEngineSuite) SetupTest() {
 	s.engine, err = NewEngine(unittest.Logger(), net, me, metrics, metrics, s.state, s.receipts, s.index, s.core)
 	require.NoError(s.T(), err)
 
+	ctx := irrecoverable.NewMockSignalerContext(s.T(), context.Background())
+	s.engine.Start(ctx)
 	<-s.engine.Ready()
 }
 

--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
-	"github.com/onflow/flow-go/engine"
 	mockconsensus "github.com/onflow/flow-go/engine/consensus/mock"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/irrecoverable"
@@ -139,15 +138,12 @@ func (s *MatchingEngineSuite) TestMultipleProcessingItems() {
 	s.core.AssertExpectations(s.T())
 }
 
-// TestProcessUnsupportedMessageType tests that Process and ProcessLocal correctly handle a case where invalid message type
-// was submitted from network layer.
+// TestProcessUnsupportedMessageType tests that Process correctly handles a case where invalid message type
+// (byzantine message) was submitted from network layer.
 func (s *MatchingEngineSuite) TestProcessUnsupportedMessageType() {
 	invalidEvent := uint64(42)
 	err := s.engine.Process("ch", unittest.IdentifierFixture(), invalidEvent)
 	// shouldn't result in error since byzantine inputs are expected
 	require.NoError(s.T(), err)
-	// in case of local processing error cannot be consumed since all inputs are trusted
-	err = s.engine.ProcessLocal(invalidEvent)
-	require.Error(s.T(), err)
-	require.True(s.T(), engine.IsIncompatibleInputTypeError(err))
+	// Local processing happens only via HandleReceipt, which will log.Fatal on invalid input
 }


### PR DESCRIPTION
Refactor the Consensus Matching Engine to move away from deprecated interfaces, as well as improve error handling and documentation. The changes are relatively straightforward drop-in replacements, due to the engine already being structured as an initial set of workers launched when the engine is started.

- Replace deprecated `engine.Unit` with `ComponentManager`
- Replace deprecated `network.Engine` with `network.MessageProcessor`
- Use concrete types where appropriate
- Use `ctx.Throw` to propagate irrecoverable errors instead of `Log.Fatal`, which also allows for tests to verify behaviour by using mock contexts

Closes https://github.com/onflow/flow-go/issues/6854