### PR TITLE
[Access] Fix access connection tests for latest version of testing library

### DIFF
--- a/engine/access/rpc/connection/grpc_compression_benchmark_test.go
+++ b/engine/access/rpc/connection/grpc_compression_benchmark_test.go
@@ -38,7 +38,7 @@ func BenchmarkWithDeflateCompression(b *testing.B) {
 // runBenchmark is a helper function that performs the benchmarking for different compressors.
 func runBenchmark(b *testing.B, compressorName string) {
 	// create an execution node
-	en := new(executionNode)
+	en := newExecutionNode(b)
 	en.start(b)
 	defer en.stop(b)
 

--- a/engine/access/rpc/connection/node_mock.go
+++ b/engine/access/rpc/connection/node_mock.go
@@ -64,11 +64,19 @@ type executionNode struct {
 	handler *mock.ExecutionAPIServer
 }
 
+func newExecutionNode(tb testing.TB) *executionNode {
+	return &executionNode{
+		handler: mock.NewExecutionAPIServer(tb),
+	}
+}
+
 func (en *executionNode) start(tb testing.TB) {
+	if en.handler == nil {
+		tb.Fatalf("executionNode must be initialized using newExecutionNode")
+	}
+
 	en.setupNode(tb)
-	handler := new(mock.ExecutionAPIServer)
-	execution.RegisterExecutionAPIServer(en.server, handler)
-	en.handler = handler
+	execution.RegisterExecutionAPIServer(en.server, en.handler)
 	en.node.start(tb)
 }
 
@@ -81,11 +89,19 @@ type collectionNode struct {
 	handler *mock.AccessAPIServer
 }
 
+func newCollectionNode(tb testing.TB) *collectionNode {
+	return &collectionNode{
+		handler: mock.NewAccessAPIServer(tb),
+	}
+}
+
 func (cn *collectionNode) start(t *testing.T) {
+	if cn.handler == nil {
+		t.Fatalf("collectionNode must be initialized using newCollectionNode")
+	}
+
 	cn.setupNode(t)
-	handler := new(mock.AccessAPIServer)
-	access.RegisterAccessAPIServer(cn.server, handler)
-	cn.handler = handler
+	access.RegisterAccessAPIServer(cn.server, cn.handler)
 	cn.node.start(t)
 }
 

--- a/engine/access/rpc/connection/node_mock.go
+++ b/engine/access/rpc/connection/node_mock.go
@@ -95,16 +95,16 @@ func newCollectionNode(tb testing.TB) *collectionNode {
 	}
 }
 
-func (cn *collectionNode) start(t *testing.T) {
+func (cn *collectionNode) start(tb testing.TB) {
 	if cn.handler == nil {
-		t.Fatalf("collectionNode must be initialized using newCollectionNode")
+		tb.Fatalf("collectionNode must be initialized using newCollectionNode")
 	}
 
-	cn.setupNode(t)
+	cn.setupNode(tb)
 	access.RegisterAccessAPIServer(cn.server, cn.handler)
-	cn.node.start(t)
+	cn.node.start(tb)
 }
 
-func (cn *collectionNode) stop(t *testing.T) {
-	cn.node.stop(t)
+func (cn *collectionNode) stop(tb testing.TB) {
+	cn.node.stop(tb)
 }


### PR DESCRIPTION
Fixes failures from https://github.com/onflow/flow-go/actions/runs/12402358137/job/34623739390?pr=6779

Needed to merge https://github.com/onflow/flow-go/pull/6779 which upgrades the testify library