### PR TITLE
Refactor the remote debugger and add support for using the execution data API

### DIFF
--- a/cmd/util/cmd/debug-script/cmd.go
+++ b/cmd/util/cmd/debug-script/cmd.go
@@ -1,11 +1,18 @@
 package debug_tx
 
 import (
+	"context"
 	"os"
 
+	"github.com/onflow/flow/protobuf/go/flow/access"
+	"github.com/onflow/flow/protobuf/go/flow/execution"
+	"github.com/onflow/flow/protobuf/go/flow/executiondata"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/onflow/flow-go/fvm/storage/snapshot"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/debug"
 )
@@ -14,9 +21,12 @@ import (
 // `gcloud compute ssh '--ssh-flag=-A' --no-user-output-enabled --tunnel-through-iap migrationmainnet1-execution-001 --project flow-multi-region -- -NL 9001:localhost:9000`
 
 var (
-	flagExecutionAddress string
-	flagChain            string
-	flagScript           string
+	flagAccessAddress       string
+	flagExecutionAddress    string
+	flagBlockID             string
+	flagChain               string
+	flagScript              string
+	flagUseExecutionDataAPI bool
 )
 
 var Cmd = &cobra.Command{
@@ -33,13 +43,22 @@ func init() {
 		"",
 		"Chain name",
 	)
-	_ = Cmd.MarkFlagRequired("chain")
+
+	Cmd.Flags().StringVar(&flagAccessAddress, "access-address", "", "address of the access node")
+	_ = Cmd.MarkFlagRequired("access-address")
 
 	Cmd.Flags().StringVar(&flagExecutionAddress, "execution-address", "", "address of the execution node")
 	_ = Cmd.MarkFlagRequired("execution-address")
 
+	Cmd.Flags().StringVar(&flagBlockID, "block-id", "", "block ID")
+	_ = Cmd.MarkFlagRequired("block-id")
+
+	_ = Cmd.MarkFlagRequired("chain")
+
 	Cmd.Flags().StringVar(&flagScript, "script", "", "path to script")
 	_ = Cmd.MarkFlagRequired("script")
+
+	Cmd.Flags().BoolVar(&flagUseExecutionDataAPI, "use-execution-data-api", false, "use the execution data API")
 }
 
 func run(*cobra.Command, []string) {
@@ -52,16 +71,68 @@ func run(*cobra.Command, []string) {
 		log.Fatal().Err(err).Msgf("failed to read script from file %s", flagScript)
 	}
 
-	debugger := debug.NewRemoteDebugger(
-		flagExecutionAddress,
-		chain,
-		log.Logger,
+	log.Info().Msg("Fetching block header ...")
+
+	accessConn, err := grpc.NewClient(
+		flagAccessAddress,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to create access connection")
+	}
+	defer accessConn.Close()
+
+	accessClient := access.NewAccessAPIClient(accessConn)
+
+	blockID, err := flow.HexStringToIdentifier(flagBlockID)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to parse block ID")
+	}
+
+	header, err := debug.GetAccessAPIBlockHeader(accessClient, context.Background(), blockID)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to fetch block header")
+	}
+
+	blockHeight := header.Height
+
+	log.Info().Msgf(
+		"Fetched block header: %s (height %d)",
+		header.ID(),
+		blockHeight,
+	)
+
+	var snap snapshot.StorageSnapshot
+
+	if flagUseExecutionDataAPI {
+		executionDataClient := executiondata.NewExecutionDataAPIClient(accessConn)
+		snap, err = debug.NewExecutionDataStorageSnapshot(executionDataClient, nil, blockHeight)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to create storage snapshot")
+		}
+	} else {
+		executionConn, err := grpc.NewClient(
+			flagExecutionAddress,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to create execution connection")
+		}
+		defer executionConn.Close()
+
+		executionClient := execution.NewExecutionAPIClient(executionConn)
+		snap, err = debug.NewExecutionNodeStorageSnapshot(executionClient, nil, blockID)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to create storage snapshot")
+		}
+	}
+
+	debugger := debug.NewRemoteDebugger(chain, log.Logger)
 
 	// TODO: add support for arguments
 	var arguments [][]byte
 
-	result, scriptErr, processErr := debugger.RunScript(code, arguments)
+	result, scriptErr, processErr := debugger.RunScript(code, arguments, snap, header)
 
 	if scriptErr != nil {
 		log.Fatal().Err(scriptErr).Msg("transaction error")

--- a/cmd/util/cmd/debug-tx/cmd.go
+++ b/cmd/util/cmd/debug-tx/cmd.go
@@ -189,7 +189,7 @@ func run(*cobra.Command, []string) {
 
 	txErr, processErr := debugger.RunTransaction(txBody, snap, header)
 	if txErr != nil {
-		log.Fatal().Err(txErr).Msg("transaction error")
+		log.Err(txErr).Msg("transaction error")
 	}
 	if processErr != nil {
 		log.Fatal().Err(processErr).Msg("process error")

--- a/cmd/util/cmd/debug-tx/cmd.go
+++ b/cmd/util/cmd/debug-tx/cmd.go
@@ -1,12 +1,15 @@
 package debug_tx
 
 import (
+	"cmp"
 	"context"
+	"encoding/hex"
 
 	"github.com/onflow/flow/protobuf/go/flow/execution"
 	"github.com/onflow/flow/protobuf/go/flow/executiondata"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -29,6 +32,7 @@ var (
 	flagComputeLimit        uint64
 	flagProposalKeySeq      uint64
 	flagUseExecutionDataAPI bool
+	flagDumpRegisters       bool
 )
 
 var Cmd = &cobra.Command{
@@ -61,6 +65,8 @@ func init() {
 	Cmd.Flags().Uint64Var(&flagProposalKeySeq, "proposal-key-seq", 0, "proposal key sequence number")
 
 	Cmd.Flags().BoolVar(&flagUseExecutionDataAPI, "use-execution-data-api", false, "use the execution data API")
+
+	Cmd.Flags().BoolVar(&flagDumpRegisters, "dump-registers", false, "dump registers")
 }
 
 func run(*cobra.Command, []string) {
@@ -187,11 +193,38 @@ func run(*cobra.Command, []string) {
 		proposalKeySequenceNumber,
 	)
 
-	txErr, processErr := debugger.RunTransaction(txBody, snap, header)
-	if txErr != nil {
-		log.Err(txErr).Msg("transaction error")
-	}
+	resultSnapshot, txErr, processErr := debugger.RunTransaction(txBody, snap, header)
 	if processErr != nil {
 		log.Fatal().Err(processErr).Msg("process error")
 	}
+
+	if flagDumpRegisters {
+		log.Info().Msg("Read registers:")
+		readRegisterIDs := resultSnapshot.ReadRegisterIDs()
+		sortRegisters(readRegisterIDs)
+		for _, registerID := range readRegisterIDs {
+			log.Info().Msgf("\t%s", registerID)
+		}
+
+		log.Info().Msg("Written registers:")
+		for _, updatedRegister := range resultSnapshot.UpdatedRegisters() {
+			log.Info().Msgf(
+				"\t%s, %s",
+				updatedRegister.Key,
+				hex.EncodeToString(updatedRegister.Value),
+			)
+		}
+	}
+	if txErr != nil {
+		log.Err(txErr).Msg("transaction error")
+	}
+}
+
+func sortRegisters(registerIDs []flow.RegisterID) {
+	slices.SortFunc(registerIDs, func(a, b flow.RegisterID) int {
+		return cmp.Or(
+			cmp.Compare(a.Owner, b.Owner),
+			cmp.Compare(a.Key, b.Key),
+		)
+	})
 }

--- a/fvm/environment/block_info.go
+++ b/fvm/environment/block_info.go
@@ -133,17 +133,17 @@ func (info *blockInfo) GetBlockAtHeight(
 			"get block at height failed: %w", err)
 	}
 
-	if info.blocks == nil {
-		return runtime.Block{}, false, errors.NewOperationNotSupportedError(
-			"GetBlockAtHeight")
-	}
-
 	if info.blockHeader != nil && height == info.blockHeader.Height {
 		return runtimeBlockFromHeader(info.blockHeader), true, nil
 	}
 
 	if height+uint64(flow.DefaultTransactionExpiry) < info.blockHeader.Height {
 		return runtime.Block{}, false, nil
+	}
+
+	if info.blocks == nil {
+		return runtime.Block{}, false, errors.NewOperationNotSupportedError(
+			"GetBlockAtHeight")
 	}
 
 	header, err := info.blocks.ByHeightFrom(height, info.blockHeader)

--- a/utils/debug/README.md
+++ b/utils/debug/README.md
@@ -89,7 +89,7 @@ func TestDebugger_RunTransactionAgainstExecutionNodeAtBlockID(t *testing.T) {
 
 	txBody := getTransaction(chain)
 
-	txErr, err := debugger.RunTransaction(txBody, snapshot, header)
+	_, txErr, err := debugger.RunTransaction(txBody, snapshot, header)
 	require.NoError(t, txErr)
 	require.NoError(t, err)
 }
@@ -137,12 +137,12 @@ func TestDebugger_RunTransactionAgainstAccessNodeAtBlockIDWithFileCache(t *testi
 	txBody := getTransaction(chain)
 
 	// the first run will cache the results
-	txErr, err := debugger.RunTransaction(txBody, snapshot, header)
+	_, txErr, err := debugger.RunTransaction(txBody, snapshot, header)
 	require.NoError(t, txErr)
 	require.NoError(t, err)
 
 	// the second run should only use the cache.
-	txErr, err = debugger.RunTransaction(txBody, snapshot, header)
+	_, txErr, err = debugger.RunTransaction(txBody, snapshot, header)
 	require.NoError(t, txErr)
 	require.NoError(t, err)
 }

--- a/utils/debug/README.md
+++ b/utils/debug/README.md
@@ -1,32 +1,44 @@
 
-
 ## Remote Debugger 
 
-Remote debugger provides utils needed to run transactions and scripts against live network data. It uses GRPC endpoints on an execution nodes to fetch registers and block info when running a transaction. This is mostly provided for debugging purpose and should not be used for production level operations. 
-If you use the caching method you can run the transaction once and use the cached values to run transaction in debugging mode. 
+The remote debugger allows running transactions and scripts against existing network data. 
 
-### sample code 
+It uses APIs to fetch registers and block info, for example the register value API of the execution nodes,
+or the execution data API of the access nodes.
+
+This is mostly provided for debugging purpose and should not be used for production level operations. 
+
+Optionally, the debugger allows the fetched registers that are necessary for the execution to be written to
+and read from a cache.
+
+Use the `ExecutionNodeStorageSnapshot` to fetch the registers and block info from the execution node (live/recent data).
+
+Use the `ExecutionDataStorageSnapshot` to fetch the execution data from the access node (recent/historic data).
+
+### Sample Code
 
 ```GO
 package debug_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/onflow/flow/protobuf/go/flow/access"
+	"github.com/onflow/flow/protobuf/go/flow/execution"
+	"github.com/onflow/flow/protobuf/go/flow/executiondata"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/debug"
 )
 
-func TestDebugger_RunTransaction(t *testing.T) {
-
-	grpcAddress := "localhost:3600"
-	chain := flow.Emulator.Chain()
-	debugger := debug.NewRemoteDebugger(grpcAddress, chain, zerolog.New(os.Stdout).With().Logger())
+func getTransaction(chain flow.Chain) *flow.TransactionBody {
 
 	const scriptTemplate = `
 	import FlowServiceAccount from 0x%s
@@ -40,37 +52,99 @@ func TestDebugger_RunTransaction(t *testing.T) {
 	script := []byte(fmt.Sprintf(scriptTemplate, chain.ServiceAddress()))
 	txBody := flow.NewTransactionBody().
 		SetComputeLimit(9999).
-		SetScript([]byte(script)).
+		SetScript(script).
 		SetPayer(chain.ServiceAddress()).
 		SetProposalKey(chain.ServiceAddress(), 0, 0)
 	txBody.Authorizers = []flow.Address{chain.ServiceAddress()}
 
-	// Run at the latest blockID
-	txErr, err := debugger.RunTransaction(txBody)
-	require.NoError(t, txErr)
+	return txBody
+}
+
+func TestDebugger_RunTransactionAgainstExecutionNodeAtBlockID(t *testing.T) {
+
+	host := "execution-001.mainnet26.nodes.onflow.org:9000"
+
+	conn, err := grpc.NewClient(
+		host,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	executionClient := execution.NewExecutionAPIClient(conn)
+
+	blockID, err := flow.HexStringToIdentifier("e68a9a1fe849d1be80e4c5e414f53e3b59a170b88785e0b22be077ae9c3bbd29")
 	require.NoError(t, err)
 
-	// Run with blockID (use the file cache)
-	blockId, err := flow.HexStringToIdentifier("3a8281395e2c1aaa3b8643d148594b19e2acb477611a8e0cab8a55c46c40b563")
-	require.NoError(t, err)
-	txErr, err = debugger.RunTransactionAtBlockID(txBody, blockId, "")
-	require.NoError(t, txErr)
+	header, err := debug.GetExecutionAPIBlockHeader(executionClient, context.Background(), blockID)
+
+	snapshot, err := debug.NewExecutionNodeStorageSnapshot(executionClient, nil, blockID)
 	require.NoError(t, err)
 
-	testCacheFile := "test.cache"
-	defer os.Remove(testCacheFile)
-	// the first run would cache the results
-	txErr, err = debugger.RunTransactionAtBlockID(txBody, blockId, testCacheFile)
-	require.NoError(t, txErr)
-	require.NoError(t, err)
+	defer snapshot.Close()
 
-	// second one should only use the cache
-	// make blockId invalid so if it endsup looking up by id it should fail
-	blockId = flow.Identifier{}
-	txErr, err = debugger.RunTransactionAtBlockID(txBody, blockId, testCacheFile)
+	chain := flow.Mainnet.Chain()
+	logger := zerolog.New(os.Stdout).With().Logger()
+	debugger := debug.NewRemoteDebugger(chain, logger)
+
+	txBody := getTransaction(chain)
+
+	txErr, err := debugger.RunTransaction(txBody, snapshot, header)
 	require.NoError(t, txErr)
 	require.NoError(t, err)
 }
 
+func TestDebugger_RunTransactionAgainstAccessNodeAtBlockIDWithFileCache(t *testing.T) {
+
+	host := "access.mainnet.nodes.onflow.org:9000"
+
+	conn, err := grpc.NewClient(
+		host,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	executionDataClient := executiondata.NewExecutionDataAPIClient(conn)
+
+	var blockHeight uint64 = 100_000_000
+	
+	blockID, err := flow.HexStringToIdentifier("e68a9a1fe849d1be80e4c5e414f53e3b59a170b88785e0b22be077ae9c3bbd29")
+	require.NoError(t, err)
+
+	accessClient := access.NewAccessAPIClient(conn)
+	header, err := debug.GetAccessAPIBlockHeader(
+		accessClient,
+		context.Background(),
+		blockID,
+	)
+	require.NoError(t, err)
+
+	testCacheFile := "test.cache"
+	defer os.Remove(testCacheFile)
+
+	cache := debug.NewFileRegisterCache(testCacheFile)
+
+	snapshot, err := debug.NewExecutionDataStorageSnapshot(executionDataClient, cache, blockHeight)
+	require.NoError(t, err)
+
+	defer snapshot.Close()
+
+	chain := flow.Mainnet.Chain()
+	logger := zerolog.New(os.Stdout).With().Logger()
+	debugger := debug.NewRemoteDebugger(chain, logger)
+
+	txBody := getTransaction(chain)
+
+	// the first run will cache the results
+	txErr, err := debugger.RunTransaction(txBody, snapshot, header)
+	require.NoError(t, txErr)
+	require.NoError(t, err)
+
+	// the second run should only use the cache.
+	txErr, err = debugger.RunTransaction(txBody, snapshot, header)
+	require.NoError(t, txErr)
+	require.NoError(t, err)
+}
 
 ```

--- a/utils/debug/api.go
+++ b/utils/debug/api.go
@@ -1,0 +1,60 @@
+package debug
+
+import (
+	"context"
+
+	"github.com/onflow/flow/protobuf/go/flow/access"
+	"github.com/onflow/flow/protobuf/go/flow/execution"
+
+	"github.com/onflow/flow-go/model/flow"
+)
+
+func GetExecutionAPIBlockHeader(
+	client execution.ExecutionAPIClient,
+	ctx context.Context,
+	blockID flow.Identifier,
+) (
+	*flow.Header,
+	error,
+) {
+	req := &execution.GetBlockHeaderByIDRequest{
+		Id: blockID[:],
+	}
+
+	resp, err := client.GetBlockHeaderByID(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &flow.Header{
+		ChainID:   flow.ChainID(resp.Block.ChainId),
+		ParentID:  flow.Identifier(resp.Block.ParentId),
+		Height:    resp.Block.Height,
+		Timestamp: resp.Block.Timestamp.AsTime(),
+	}, nil
+}
+
+func GetAccessAPIBlockHeader(
+	client access.AccessAPIClient,
+	ctx context.Context,
+	blockID flow.Identifier,
+) (
+	*flow.Header,
+	error,
+) {
+	req := &access.GetBlockHeaderByIDRequest{
+		Id: blockID[:],
+	}
+
+	resp, err := client.GetBlockHeaderByID(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &flow.Header{
+		ChainID:   flow.ChainID(resp.Block.ChainId),
+		ParentID:  flow.Identifier(resp.Block.ParentId),
+		Height:    resp.Block.Height,
+		Timestamp: resp.Block.Timestamp.AsTime(),
+	}, nil
+}

--- a/utils/debug/remoteDebugger.go
+++ b/utils/debug/remoteDebugger.go
@@ -9,19 +9,18 @@ import (
 )
 
 type RemoteDebugger struct {
-	vm          fvm.VM
-	ctx         fvm.Context
-	grpcAddress string
+	vm  fvm.VM
+	ctx fvm.Context
 }
 
-// Warning : make sure you use the proper flow-go version, same version as the network you are collecting registers
-// from, otherwise the execution might differ from the way runs on the network
+// NewRemoteDebugger creates a new remote debugger.
+// NOTE: Make sure to use the same version of flow-go as the network
+// you are collecting registers from, otherwise the execution might differ
+// from the way it runs on the network
 func NewRemoteDebugger(
-	grpcAddress string,
 	chain flow.Chain,
 	logger zerolog.Logger,
 ) *RemoteDebugger {
-
 	vm := fvm.NewVirtualMachine()
 
 	// no signature processor here
@@ -33,26 +32,26 @@ func NewRemoteDebugger(
 	)
 
 	return &RemoteDebugger{
-		ctx:         ctx,
-		vm:          vm,
-		grpcAddress: grpcAddress,
+		ctx: ctx,
+		vm:  vm,
 	}
 }
 
-// RunTransaction runs the transaction given the latest sealed block data
+// RunTransaction runs the transaction using the given storage snapshot.
 func (d *RemoteDebugger) RunTransaction(
 	txBody *flow.TransactionBody,
+	snapshot StorageSnapshot,
+	blockHeader *flow.Header,
 ) (
 	txErr error,
 	processError error,
 ) {
-	snapshot := NewRemoteStorageSnapshot(d.grpcAddress)
-	defer snapshot.Close()
-
 	blockCtx := fvm.NewContextFromParent(
 		d.ctx,
-		fvm.WithBlockHeader(d.ctx.BlockHeader))
+		fvm.WithBlockHeader(blockHeader))
+
 	tx := fvm.Transaction(txBody, 0)
+
 	_, output, err := d.vm.Run(blockCtx, tx, snapshot)
 	if err != nil {
 		return nil, err
@@ -60,80 +59,28 @@ func (d *RemoteDebugger) RunTransaction(
 	return output.Err, nil
 }
 
-// RunTransactionAtBlockID runs the transaction and tries to collect the registers at
-// the given blockID note that it would be very likely that block is far in the
-// past and you can't find the trie to read the registers from.
-// if regCachePath is empty, the register values won't be cached
-func (d *RemoteDebugger) RunTransactionAtBlockID(
-	txBody *flow.TransactionBody,
-	blockID flow.Identifier,
-	regCachePath string,
-) (
-	txErr error,
-	processError error,
-) {
-	snapshot := NewRemoteStorageSnapshot(d.grpcAddress, WithBlockID(blockID))
-	defer snapshot.Close()
-
-	blockCtx := fvm.NewContextFromParent(
-		d.ctx,
-		fvm.WithBlockHeader(d.ctx.BlockHeader))
-	if len(regCachePath) > 0 {
-		snapshot.Cache = newFileRegisterCache(regCachePath)
-	}
-	tx := fvm.Transaction(txBody, 0)
-	_, output, err := d.vm.Run(blockCtx, tx, snapshot)
-	if err != nil {
-		return nil, err
-	}
-	err = snapshot.Cache.Persist()
-	if err != nil {
-		return nil, err
-	}
-	return output.Err, nil
-}
-
+// RunScript runs the script using the given storage snapshot.
 func (d *RemoteDebugger) RunScript(
 	code []byte,
 	arguments [][]byte,
+	snapshot StorageSnapshot,
+	blockHeader *flow.Header,
 ) (
 	value cadence.Value,
 	scriptError error,
 	processError error,
 ) {
-	snapshot := NewRemoteStorageSnapshot(d.grpcAddress)
-	defer snapshot.Close()
-
 	scriptCtx := fvm.NewContextFromParent(
 		d.ctx,
-		fvm.WithBlockHeader(d.ctx.BlockHeader))
+		fvm.WithBlockHeader(blockHeader),
+	)
+
 	script := fvm.Script(code).WithArguments(arguments...)
+
 	_, output, err := d.vm.Run(scriptCtx, script, snapshot)
 	if err != nil {
 		return nil, nil, err
 	}
-	return output.Value, output.Err, nil
-}
 
-func (d *RemoteDebugger) RunScriptAtBlockID(
-	code []byte,
-	arguments [][]byte,
-	blockID flow.Identifier,
-) (
-	value cadence.Value,
-	scriptError error,
-	processError error,
-) {
-	snapshot := NewRemoteStorageSnapshot(d.grpcAddress, WithBlockID(blockID))
-	defer snapshot.Close()
-
-	scriptCtx := fvm.NewContextFromParent(
-		d.ctx,
-		fvm.WithBlockHeader(d.ctx.BlockHeader))
-	script := fvm.Script(code).WithArguments(arguments...)
-	_, output, err := d.vm.Run(scriptCtx, script, snapshot)
-	if err != nil {
-		return nil, nil, err
-	}
 	return output.Value, output.Err, nil
 }

--- a/utils/debug/remoteDebugger.go
+++ b/utils/debug/remoteDebugger.go
@@ -5,6 +5,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/onflow/flow-go/fvm"
+	"github.com/onflow/flow-go/fvm/storage/snapshot"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -43,6 +44,7 @@ func (d *RemoteDebugger) RunTransaction(
 	snapshot StorageSnapshot,
 	blockHeader *flow.Header,
 ) (
+	resultSnapshot *snapshot.ExecutionSnapshot,
 	txErr error,
 	processError error,
 ) {
@@ -52,11 +54,15 @@ func (d *RemoteDebugger) RunTransaction(
 
 	tx := fvm.Transaction(txBody, 0)
 
-	_, output, err := d.vm.Run(blockCtx, tx, snapshot)
+	var (
+		output fvm.ProcedureOutput
+		err    error
+	)
+	resultSnapshot, output, err = d.vm.Run(blockCtx, tx, snapshot)
 	if err != nil {
-		return nil, err
+		return resultSnapshot, nil, err
 	}
-	return output.Err, nil
+	return resultSnapshot, output.Err, nil
 }
 
 // RunScript runs the script using the given storage snapshot.


### PR DESCRIPTION
- Refactor and improve the code of the remote debugger
- Add a new storage snapshot backed by the execution data / state streaming API implemented by access nodes
- Enable EVM
- Add support for `getCurrentBlock()` calls
- Add a flag that dumps all read and written registers
- Add support for running "mid-block" transaction: Also run all transactions preceding the TX in question