### PR TITLE
[Access] Backport version control overrides from v0.37

### DIFF
--- a/engine/common/version/version_control.go
+++ b/engine/common/version/version_control.go
@@ -37,7 +37,12 @@ var NoHeight = uint64(0)
 //
 // IMPORTANT: only add versions to this list if you are certain that the cadence and fvm changes
 // deployed during the HCU are backwards compatible for scripts.
-var defaultCompatibilityOverrides = map[string]struct{}{}
+var defaultCompatibilityOverrides = map[string]struct{}{
+	"0.37.17": {},
+	"0.37.18": {},
+	"0.37.22": {},
+	"0.37.26": {},
+}
 
 // VersionControl manages the version control system for the node.
 // It consumes BlockFinalized events and updates the node's version control based on the latest version beacon.


### PR DESCRIPTION
Backports the version control overrides from v0.37 to master, which is needed before rolling out master as an HCU.