### PR TITLE
[Storage Refactor] Using flags to roll out database operation changes for Verification nodes.

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onflow/flow-go/state/protocol/events"
 	"github.com/onflow/flow-go/storage"
 	bstorage "github.com/onflow/flow-go/storage/badger"
+	"github.com/onflow/flow-go/storage/dbops"
 	"github.com/onflow/flow-go/utils/grpcutils"
 )
 
@@ -155,6 +156,7 @@ type BaseConfig struct {
 	datadir                     string
 	pebbleDir                   string
 	protocolDBType              string
+	dbops                       string
 	badgerDB                    *badger.DB
 	pebbleDB                    *pebble.DB
 	secretsdir                  string
@@ -278,7 +280,8 @@ func DefaultBaseConfig() *BaseConfig {
 		BootstrapDir:     "bootstrap",
 		datadir:          datadir,
 		pebbleDir:        pebbleDir,
-		protocolDBType:   "badger",
+		protocolDBType:   "badger",                        // "badger" (default) or "pebble"
+		dbops:            string(dbops.BadgerTransaction), // "badger-transaction" (default) or "batch-update"
 		badgerDB:         nil,
 		pebbleDB:         nil,
 		secretsdir:       NotSet,

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/onflow/flow-go/network/p2p"
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/state/protocol/events"
+	"github.com/onflow/flow-go/storage"
 	bstorage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/utils/grpcutils"
 )
@@ -153,6 +154,7 @@ type BaseConfig struct {
 	DynamicStartupSleepInterval time.Duration
 	datadir                     string
 	pebbleDir                   string
+	protocolDBType              string
 	badgerDB                    *badger.DB
 	pebbleDB                    *pebble.DB
 	secretsdir                  string
@@ -202,6 +204,7 @@ type NodeConfig struct {
 	Metrics           Metrics
 	DB                *badger.DB
 	PebbleDB          *pebble.DB
+	ProtocolDB        storage.DB
 	SecretsDB         *badger.DB
 	Storage           Storage
 	ProtocolEvents    *events.Distributor
@@ -275,6 +278,7 @@ func DefaultBaseConfig() *BaseConfig {
 		BootstrapDir:     "bootstrap",
 		datadir:          datadir,
 		pebbleDir:        pebbleDir,
+		protocolDBType:   "badger",
 		badgerDB:         nil,
 		pebbleDB:         nil,
 		secretsdir:       NotSet,

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -269,17 +269,25 @@ func DefaultBaseConfig() *BaseConfig {
 	codecFactory := func() network.Codec { return cbor.NewCodec() }
 
 	return &BaseConfig{
-		nodeIDHex:        NotSet,
-		AdminAddr:        NotSet,
-		AdminCert:        NotSet,
-		AdminKey:         NotSet,
-		AdminClientCAs:   NotSet,
-		AdminMaxMsgSize:  grpcutils.DefaultMaxMsgSize,
-		BindAddr:         NotSet,
-		ObserverMode:     false,
-		BootstrapDir:     "bootstrap",
-		datadir:          datadir,
-		pebbleDir:        pebbleDir,
+		nodeIDHex:       NotSet,
+		AdminAddr:       NotSet,
+		AdminCert:       NotSet,
+		AdminKey:        NotSet,
+		AdminClientCAs:  NotSet,
+		AdminMaxMsgSize: grpcutils.DefaultMaxMsgSize,
+		BindAddr:        NotSet,
+		ObserverMode:    false,
+		BootstrapDir:    "bootstrap",
+		datadir:         datadir,
+		pebbleDir:       pebbleDir,
+		// the protocolDBType and dbops are the feature flags to transit from badger to pebble
+		// there are three phases:
+		// 1. badger transactions (original implementation)
+		//		in this phase, dbops is "badger-transaction", and protocolDBType is "badger"
+		// 2. badger batch updates (intermediate phase)
+		// 		in this phase, dbops is "batch-update", and protocolDBType is "badger"
+		// 3. pebble batch updates (final phase)
+		//    in this phase, dbops is "batch-update", and protocolDBType is "pebble"
 		protocolDBType:   "badger",                        // "badger" (default) or "pebble"
 		dbops:            string(dbops.BadgerTransaction), // "badger-transaction" (default) or "batch-update"
 		badgerDB:         nil,

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -155,7 +155,6 @@ type BaseConfig struct {
 	DynamicStartupSleepInterval time.Duration
 	datadir                     string
 	pebbleDir                   string
-	protocolDBType              string
 	dbops                       string
 	badgerDB                    *badger.DB
 	pebbleDB                    *pebble.DB
@@ -269,26 +268,17 @@ func DefaultBaseConfig() *BaseConfig {
 	codecFactory := func() network.Codec { return cbor.NewCodec() }
 
 	return &BaseConfig{
-		nodeIDHex:       NotSet,
-		AdminAddr:       NotSet,
-		AdminCert:       NotSet,
-		AdminKey:        NotSet,
-		AdminClientCAs:  NotSet,
-		AdminMaxMsgSize: grpcutils.DefaultMaxMsgSize,
-		BindAddr:        NotSet,
-		ObserverMode:    false,
-		BootstrapDir:    "bootstrap",
-		datadir:         datadir,
-		pebbleDir:       pebbleDir,
-		// the protocolDBType and dbops are the feature flags to transit from badger to pebble
-		// there are three phases:
-		// 1. badger transactions (original implementation)
-		//		in this phase, dbops is "badger-transaction", and protocolDBType is "badger"
-		// 2. badger batch updates (intermediate phase)
-		// 		in this phase, dbops is "batch-update", and protocolDBType is "badger"
-		// 3. pebble batch updates (final phase)
-		//    in this phase, dbops is "batch-update", and protocolDBType is "pebble"
-		protocolDBType:   "badger",                        // "badger" (default) or "pebble"
+		nodeIDHex:        NotSet,
+		AdminAddr:        NotSet,
+		AdminCert:        NotSet,
+		AdminKey:         NotSet,
+		AdminClientCAs:   NotSet,
+		AdminMaxMsgSize:  grpcutils.DefaultMaxMsgSize,
+		BindAddr:         NotSet,
+		ObserverMode:     false,
+		BootstrapDir:     "bootstrap",
+		datadir:          datadir,
+		pebbleDir:        pebbleDir,
 		dbops:            string(dbops.BadgerTransaction), // "badger-transaction" (default) or "batch-update"
 		badgerDB:         nil,
 		pebbleDB:         nil,

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1163,8 +1163,7 @@ func (fnb *FlowNodeBuilder) initProtocolDB(bdb *badger.DB, pdb *pebble.DB) error
 		fnb.ProtocolDB = pebbleimpl.ToDB(pdb)
 		fnb.Logger.Info().Msgf("initProtocolDB: using pebble protocol db")
 	} else {
-		return fmt.Errorf("invalid --protocoldb-type flag, expect badger/pebble, but got: %v",
-			fnb.dbops)
+		return fmt.Errorf(dbops.UsageErrMsg, fnb.dbops)
 	}
 	return nil
 }

--- a/cmd/scaffold/pebble_db.go
+++ b/cmd/scaffold/pebble_db.go
@@ -16,7 +16,7 @@ func InitPebbleDB(dir string) (*pebble.DB, io.Closer, error) {
 	// since we've set an default directory for the pebble DB, this check
 	// is not necessary, but rather a sanity check
 	if dir == "not set" {
-		return nil, nil, fmt.Errorf("missing required flag '--pebble-dir'")
+		return nil, nil, fmt.Errorf("missing required flag '--pebbledir'")
 	}
 
 	// Pre-create DB path

--- a/cmd/verification_builder.go
+++ b/cmd/verification_builder.go
@@ -188,7 +188,7 @@ func (v *VerificationNodeBuilder) LoadComponentsAndModules() {
 				chunkQueue = queue
 				node.Logger.Info().Msgf("chunks queue index has been initialized with protocol db batch updates")
 			} else {
-				return fmt.Errorf("invalid db opts type: %v", v.dbops)
+				return fmt.Errorf(dbops.UsageErrMsg, v.dbops)
 			}
 
 			node.Logger.Info().

--- a/storage/dbops/dbops.go
+++ b/storage/dbops/dbops.go
@@ -18,3 +18,23 @@ const (
 	// PebbleBatch uses pebble batch updates
 	PebbleBatch DBOps = "pebble-batch"
 )
+
+func IsBadgerBased(ops string) bool {
+	return ops == string(BadgerTransaction) || ops == string(BadgerBatch)
+}
+
+func IsBadgerTransaction(ops string) bool {
+	return ops == string(BadgerTransaction)
+}
+
+func IsBadgerBatch(ops string) bool {
+	return ops == string(BadgerBatch)
+}
+
+func IsPebbleBatch(ops string) bool {
+	return ops == string(PebbleBatch)
+}
+
+func IsBatchUpdate(ops string) bool {
+	return ops == string(BadgerBatch) || ops == string(PebbleBatch)
+}

--- a/storage/dbops/dbops.go
+++ b/storage/dbops/dbops.go
@@ -2,7 +2,11 @@ package dbops
 
 // The dbops feature flag is used to toggle between different database update operations.
 // Currently, the existing database update operations use badger-transaction, which is default and deprecated.
-// As part of the refactoring process to eventually transition to batch-update,
+// As part of the refactoring process to eventually transition to pebble-batch updates,
+// an intermediate step is required to switch to badger-batch.
+// This is why the feature flag has three possible values to facilitate the transition.
+const DB_OPS_MSG = "database operations to use (badger-transaction, badger-batch, pebble-batch)"
+const DB_OPS_DEFAULT = string(BadgerTransaction)
 
 type DBOps string
 
@@ -10,13 +14,7 @@ const (
 	// BadgerTransaction uses badger transactions (default and deprecated)
 	BadgerTransaction DBOps = "badger-transaction"
 	// BadgerBatch uses badger batch updates
-	BatchUpdate DBOps = "batch-update"
+	BadgerBatch DBOps = "badger-batch"
+	// PebbleBatch uses pebble batch updates
+	PebbleBatch DBOps = "pebble-batch"
 )
-
-func IsBadgerTransaction(op string) bool {
-	return op == string(BadgerTransaction)
-}
-
-func IsBatchUpdate(op string) bool {
-	return op == string(BatchUpdate)
-}

--- a/storage/dbops/dbops.go
+++ b/storage/dbops/dbops.go
@@ -2,11 +2,7 @@ package dbops
 
 // The dbops feature flag is used to toggle between different database update operations.
 // Currently, the existing database update operations use badger-transaction, which is default and deprecated.
-// As part of the refactoring process to eventually transition to pebble-batch updates,
-// an intermediate step is required to switch to badger-batch.
-// This is why the feature flag has three possible values to facilitate the transition.
-const DB_OPS_MSG = "database operations to use (badger-transaction, badger-batch, pebble-batch)"
-const DB_OPS_DEFAULT = string(BadgerTransaction)
+// As part of the refactoring process to eventually transition to batch-update,
 
 type DBOps string
 
@@ -14,7 +10,13 @@ const (
 	// BadgerTransaction uses badger transactions (default and deprecated)
 	BadgerTransaction DBOps = "badger-transaction"
 	// BadgerBatch uses badger batch updates
-	BadgerBatch DBOps = "badger-batch"
-	// PebbleBatch uses pebble batch updates
-	PebbleBatch DBOps = "pebble-batch"
+	BatchUpdate DBOps = "batch-update"
 )
+
+func IsBadgerTransaction(op string) bool {
+	return op == string(BadgerTransaction)
+}
+
+func IsBatchUpdate(op string) bool {
+	return op == string(BatchUpdate)
+}

--- a/storage/dbops/dbops.go
+++ b/storage/dbops/dbops.go
@@ -17,6 +17,8 @@ const (
 	BadgerBatch DBOps = "badger-batch"
 	// PebbleBatch uses pebble batch updates
 	PebbleBatch DBOps = "pebble-batch"
+
+	UsageErrMsg string = "invalid --dbops flag, expect badger-transaction/badger-batch/pebble-batch, but got: %v"
 )
 
 func IsBadgerBased(ops string) bool {


### PR DESCRIPTION
Depend on:
- https://github.com/onflow/flow-go/pull/6868
- https://github.com/onflow/flow-go/pull/6947
- https://github.com/onflow/flow-go/pull/6872

Working towards: https://github.com/onflow/flow-go/issues/6515

This PR adds flags to all node type for switching database operations, as well as switching from badger to pebble for verification node storing all verification specific data, such as approvals and chunk locators.