### PR TITLE
[Storage Refactor] Init pebble DB in scaffold.

### DIFF
--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/pebble"
 	"github.com/dgraph-io/badger/v2"
 	madns "github.com/multiformats/go-multiaddr-dns"
 	"github.com/onflow/crypto"
@@ -198,6 +199,7 @@ type NodeConfig struct {
 	MetricsRegisterer prometheus.Registerer
 	Metrics           Metrics
 	DB                *badger.DB
+	PebbleDB          *pebble.DB
 	SecretsDB         *badger.DB
 	Storage           Storage
 	ProtocolEvents    *events.Distributor

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -153,6 +153,8 @@ type BaseConfig struct {
 	DynamicStartupSleepInterval time.Duration
 	datadir                     string
 	pebbleDir                   string
+	badgerDB                    *badger.DB
+	pebbleDB                    *pebble.DB
 	secretsdir                  string
 	secretsDBEnabled            bool
 	InsecureSecretsDB           bool

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -151,6 +151,7 @@ type BaseConfig struct {
 	DynamicStartupEpoch         string
 	DynamicStartupSleepInterval time.Duration
 	datadir                     string
+	pebbleDir                   string
 	secretsdir                  string
 	secretsDBEnabled            bool
 	InsecureSecretsDB           bool
@@ -164,7 +165,6 @@ type BaseConfig struct {
 	MetricsEnabled              bool
 	guaranteesCacheSize         uint
 	receiptsCacheSize           uint
-	db                          *badger.DB
 	HeroCacheMetricsEnable      bool
 	SyncCoreConfig              chainsync.Config
 	CodecFactory                func() network.Codec
@@ -253,6 +253,7 @@ type StateExcerptAtBoot struct {
 
 func DefaultBaseConfig() *BaseConfig {
 	datadir := "/data/protocol"
+	pebbleDir := "/data/protocol-pebble"
 
 	// NOTE: if the codec used in the network component is ever changed any code relying on
 	// the message format specific to the codec must be updated. i.e: the AuthorizedSenderValidator.
@@ -269,6 +270,7 @@ func DefaultBaseConfig() *BaseConfig {
 		ObserverMode:     false,
 		BootstrapDir:     "bootstrap",
 		datadir:          datadir,
+		pebbleDir:        pebbleDir,
 		secretsdir:       NotSet,
 		secretsDBEnabled: true,
 		level:            "info",

--- a/cmd/node_builder.go
+++ b/cmd/node_builder.go
@@ -275,6 +275,8 @@ func DefaultBaseConfig() *BaseConfig {
 		BootstrapDir:     "bootstrap",
 		datadir:          datadir,
 		pebbleDir:        pebbleDir,
+		badgerDB:         nil,
+		pebbleDB:         nil,
 		secretsdir:       NotSet,
 		secretsDBEnabled: true,
 		level:            "info",

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1885,9 +1885,7 @@ func WithBindAddress(bindAddress string) Option {
 
 func WithDataDir(dataDir string) Option {
 	return func(config *BaseConfig) {
-		if config.db == nil {
-			config.datadir = dataDir
-		}
+		config.datadir = dataDir
 	}
 }
 
@@ -1918,14 +1916,6 @@ func WithComplianceConfig(complianceConfig compliance.Config) Option {
 func WithLogLevel(level string) Option {
 	return func(config *BaseConfig) {
 		config.level = level
-	}
-}
-
-// WithDB takes precedence over WithDataDir and datadir will be set to empty if DB is set using this option
-func WithDB(db *badger.DB) Option {
-	return func(config *BaseConfig) {
-		config.db = db
-		config.datadir = ""
 	}
 }
 

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1925,18 +1925,32 @@ func WithBindAddress(bindAddress string) Option {
 	}
 }
 
+// WithDataDir set the data directory for the badger database
+// It will be ignored if WithBadgerDB is used
 func WithDataDir(dataDir string) Option {
 	return func(config *BaseConfig) {
 		config.datadir = dataDir
 	}
 }
 
+// WithBadgerDB sets the badger database instance
+// If used, then WithDataDir method will be ignored
 func WithBadgerDB(db *badger.DB) Option {
 	return func(config *BaseConfig) {
 		config.badgerDB = db
 	}
 }
 
+// WithPebbleDir set the data directory for the pebble database
+// It will be ignored if WithPebbleDB is used
+func WithPebbleDir(dataDir string) Option {
+	return func(config *BaseConfig) {
+		config.pebbleDir = dataDir
+	}
+}
+
+// WithPebbleDB sets the pebble database instance
+// If used, then WithPebbleDir method will be ignored
 func WithPebbleDB(db *pebble.DB) Option {
 	return func(config *BaseConfig) {
 		config.pebbleDB = db

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -21,6 +21,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/pflag"
 	"golang.org/x/time/rate"
 	"google.golang.org/api/option"
@@ -1921,6 +1922,11 @@ func WithBindAddress(bindAddress string) Option {
 // It will be ignored if WithBadgerDB is used
 func WithDataDir(dataDir string) Option {
 	return func(config *BaseConfig) {
+		if config.badgerDB != nil {
+			log.Warn().Msgf("ignoring data directory %s as badger database is already set", dataDir)
+			return
+		}
+
 		config.datadir = dataDir
 	}
 }
@@ -1929,6 +1935,11 @@ func WithDataDir(dataDir string) Option {
 // If used, then WithDataDir method will be ignored
 func WithBadgerDB(db *badger.DB) Option {
 	return func(config *BaseConfig) {
+		if config.datadir != "" && config.datadir != NotSet {
+			log.Warn().Msgf("ignoring data directory is already set for badger %v", config.datadir)
+			config.datadir = ""
+		}
+
 		config.badgerDB = db
 	}
 }
@@ -1937,6 +1948,11 @@ func WithBadgerDB(db *badger.DB) Option {
 // It will be ignored if WithPebbleDB is used
 func WithPebbleDir(dataDir string) Option {
 	return func(config *BaseConfig) {
+		if config.pebbleDB != nil {
+			log.Warn().Msgf("ignoring data directory %s as pebble database is already set", dataDir)
+			return
+		}
+
 		config.pebbleDir = dataDir
 	}
 }
@@ -1945,6 +1961,11 @@ func WithPebbleDir(dataDir string) Option {
 // If used, then WithPebbleDir method will be ignored
 func WithPebbleDB(db *pebble.DB) Option {
 	return func(config *BaseConfig) {
+		if config.pebbleDir != "" && config.pebbleDir != NotSet {
+			log.Warn().Msgf("ignoring data directory is already set for pebble %v", config.pebbleDir)
+			config.pebbleDir = ""
+		}
+
 		config.pebbleDB = db
 	}
 }

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1130,14 +1130,6 @@ func (fnb *FlowNodeBuilder) initPebbleDB() error {
 		return nil
 	}
 
-	// if the pebble DB is not set, we skip initialization
-	// the pebble DB must be provided to initialize
-	// since we've set an default directory for the pebble DB, this check
-	// is not necessary, but rather a sanity check
-	if fnb.BaseConfig.pebbleDir == NotSet {
-		return fmt.Errorf("missing required flag '--pebble-dir'")
-	}
-
 	db, closer, err := scaffold.InitPebbleDB(fnb.BaseConfig.pebbleDir)
 	if err != nil {
 		return err

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -164,6 +164,7 @@ func (fnb *FlowNodeBuilder) BaseFlags() {
 	fnb.flags.StringVar(&fnb.BaseConfig.BindAddr, "bind", defaultConfig.BindAddr, "address to bind on")
 	fnb.flags.StringVarP(&fnb.BaseConfig.BootstrapDir, "bootstrapdir", "b", defaultConfig.BootstrapDir, "path to the bootstrap directory")
 	fnb.flags.StringVarP(&fnb.BaseConfig.datadir, "datadir", "d", defaultConfig.datadir, "directory to store the public database (protocol state)")
+	fnb.flags.StringVar(&fnb.BaseConfig.pebbleDir, "pebble-dir", defaultConfig.pebbleDir, "directory to store the public pebble database (protocol state)")
 	fnb.flags.StringVar(&fnb.BaseConfig.secretsdir, "secretsdir", defaultConfig.secretsdir, "directory to store private database (secrets)")
 	fnb.flags.StringVarP(&fnb.BaseConfig.level, "loglevel", "l", defaultConfig.level, "level for logging output")
 	fnb.flags.Uint32Var(&fnb.BaseConfig.debugLogLimit, "debug-log-limit", defaultConfig.debugLogLimit, "max number of debug/trace log events per second")
@@ -1058,12 +1059,6 @@ func (fnb *FlowNodeBuilder) initProfiler() error {
 }
 
 func (fnb *FlowNodeBuilder) initDB() error {
-
-	// if a db has been passed in, use that instead of creating one
-	if fnb.BaseConfig.db != nil {
-		fnb.DB = fnb.BaseConfig.db
-		return nil
-	}
 
 	// Pre-create DB path (Badger creates only one-level dirs)
 	err := os.MkdirAll(fnb.BaseConfig.datadir, 0700)

--- a/cmd/scaffold/pebble_db.go
+++ b/cmd/scaffold/pebble_db.go
@@ -11,6 +11,14 @@ import (
 )
 
 func InitPebbleDB(dir string) (*pebble.DB, io.Closer, error) {
+	// if the pebble DB is not set, we skip initialization
+	// the pebble DB must be provided to initialize
+	// since we've set an default directory for the pebble DB, this check
+	// is not necessary, but rather a sanity check
+	if dir == "not set" {
+		return nil, nil, fmt.Errorf("missing required flag '--pebble-dir'")
+	}
+
 	// Pre-create DB path
 	err := os.MkdirAll(dir, 0700)
 	if err != nil {

--- a/cmd/scaffold/pebble_db.go
+++ b/cmd/scaffold/pebble_db.go
@@ -1,0 +1,26 @@
+package scaffold
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/cockroachdb/pebble"
+
+	pebblestorage "github.com/onflow/flow-go/storage/pebble"
+)
+
+func InitPebbleDB(dir string) (*pebble.DB, io.Closer, error) {
+	// Pre-create DB path
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not create pebble db (path: %s): %w", dir, err)
+	}
+
+	db, err := pebblestorage.OpenDefaultPebbleDB(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return db, db, nil
+}

--- a/cmd/scaffold/pebble_db.go
+++ b/cmd/scaffold/pebble_db.go
@@ -27,7 +27,7 @@ func InitPebbleDB(dir string) (*pebble.DB, io.Closer, error) {
 
 	db, err := pebblestorage.OpenDefaultPebbleDB(dir)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("could not open newly created pebble db (path: %s): %w", dir, err)
 	}
 
 	return db, db, nil

--- a/cmd/scaffold/pebble_db_test.go
+++ b/cmd/scaffold/pebble_db_test.go
@@ -1,0 +1,17 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestInitPebbleDB(t *testing.T) {
+	unittest.RunWithTempDir(t, func(dir string) {
+		_, closer, err := InitPebbleDB(dir)
+		require.NoError(t, err)
+		require.NoError(t, closer.Close())
+	})
+}

--- a/cmd/scaffold/pebble_db_test.go
+++ b/cmd/scaffold/pebble_db_test.go
@@ -1,17 +1,25 @@
-package scaffold
+package scaffold_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/flow-go/cmd"
+	"github.com/onflow/flow-go/cmd/scaffold"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
 func TestInitPebbleDB(t *testing.T) {
 	unittest.RunWithTempDir(t, func(dir string) {
-		_, closer, err := InitPebbleDB(dir)
+		_, closer, err := scaffold.InitPebbleDB(dir)
 		require.NoError(t, err)
 		require.NoError(t, closer.Close())
 	})
+}
+
+func TestInitPebbleDBDirNotSet(t *testing.T) {
+	_, _, err := scaffold.InitPebbleDB(cmd.NotSet)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing required flag")
 }

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dgraph-io/badger/v2"
 	"github.com/onflow/crypto"
 	"github.com/rs/zerolog"
 
@@ -36,7 +35,6 @@ type Config struct {
 	networkPrivKey   crypto.PrivateKey   // the network private key of this node
 	bootstrapNodes   []BootstrapNodeInfo // the bootstrap nodes to use
 	bindAddr         string              // address to bind on
-	db               *badger.DB          // the badger DB storage to use for the protocol state
 	dataDir          string              // directory to store the protocol state (if the badger storage is not provided)
 	bootstrapDir     string              // path to the bootstrap directory
 	logLevel         string              // log level
@@ -51,9 +49,7 @@ type Option func(c *Config)
 // If a database is supplied, then data directory will be set to empty string
 func WithDataDir(dataDir string) Option {
 	return func(cf *Config) {
-		if cf.db == nil {
-			cf.dataDir = dataDir
-		}
+		cf.dataDir = dataDir
 	}
 }
 

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -37,8 +37,8 @@ type Config struct {
 	networkPrivKey   crypto.PrivateKey   // the network private key of this node
 	bootstrapNodes   []BootstrapNodeInfo // the bootstrap nodes to use
 	bindAddr         string              // address to bind on
-	badgerDB         *badger.DB          // directory to store the badger instance
-	pebbleDB         *pebble.DB          // directory to store the pebble instance
+	badgerDB         *badger.DB          // badger instance
+	pebbleDB         *pebble.DB          // pebble instance
 	bootstrapDir     string              // path to the bootstrap directory
 	logLevel         string              // log level
 	exposeMetrics    bool                // whether to expose metrics

--- a/follower/consensus_follower.go
+++ b/follower/consensus_follower.go
@@ -69,15 +69,6 @@ func WithLogLevel(level string) Option {
 	}
 }
 
-// WithDB sets the underlying database that will be used to store the chain state
-// WithDB takes precedence over WithDataDir and datadir will be set to empty if DB is set using this option
-func WithDB(db *badger.DB) Option {
-	return func(cf *Config) {
-		cf.db = db
-		cf.dataDir = ""
-	}
-}
-
 func WithExposeMetrics(expose bool) Option {
 	return func(c *Config) {
 		c.exposeMetrics = expose
@@ -141,9 +132,6 @@ func getBaseOptions(config *Config) []cmd.Option {
 	}
 	if config.logLevel != "" {
 		options = append(options, cmd.WithLogLevel(config.logLevel))
-	}
-	if config.db != nil {
-		options = append(options, cmd.WithDB(config.db))
 	}
 	if config.exposeMetrics {
 		options = append(options, cmd.WithMetricsEnabled(config.exposeMetrics))

--- a/follower/database/init.go
+++ b/follower/database/init.go
@@ -1,0 +1,14 @@
+package database
+
+import (
+	"io"
+
+	"github.com/cockroachdb/pebble"
+
+	"github.com/onflow/flow-go/cmd/scaffold"
+)
+
+// InitPebbleDB is an alias for scaffold.InitPebbleDB.
+func InitPebbleDB(dir string) (*pebble.DB, io.Closer, error) {
+	return scaffold.InitPebbleDB(dir)
+}

--- a/storage/pebble/open.go
+++ b/storage/pebble/open.go
@@ -82,6 +82,8 @@ func MustOpenDefaultPebbleDB(dir string) (*pebble.DB, error) {
 }
 
 // IsPebbleInitialized checks if the given folder contains a valid Pebble DB.
+// return error if the folder does not exist, is not a directory, or is missing required files
+// return nil if the folder contains a valid Pebble DB
 func IsPebbleInitialized(folderPath string) error {
 	// Check if the folder exists
 	info, err := os.Stat(folderPath)


### PR DESCRIPTION
This PR adds a flag `pebble-dir` with default value `/data/pebble-dir` for storing pebble database data. It will be used for the transition from badger to pebbleDB.