### PR TITLE
Use `ErrorMessageWithRevertReason` when validating replay of EVM tx

### DIFF
--- a/fvm/evm/offchain/sync/replay.go
+++ b/fvm/evm/offchain/sync/replay.go
@@ -166,7 +166,7 @@ func ValidateResult(
 	}
 
 	// check error msg
-	if errMsg := res.ErrorMsg(); errMsg != txEvent.ErrorMessage {
+	if errMsg := res.ErrorMessageWithRevertReason(); errMsg != txEvent.ErrorMessage {
 		return fmt.Errorf("error msg mismatch %s != %s", errMsg, txEvent.ErrorMessage)
 	}
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/6951
Follow up on: https://github.com/onflow/flow-go/issues/6770

The `errorMessage` field of `EVM.TransactionExecuted` event, now has a more human-friendly representation.
So we need to use the `ErrorMessageWithRevertReason` when validating the execution replay of an EVM tx.