### PR TITLE
[Util] Add flag to backward compatibilities testing tool to continue verify when mismatching is found

### DIFF
--- a/cmd/util/cmd/verify_execution_result/cmd.go
+++ b/cmd/util/cmd/verify_execution_result/cmd.go
@@ -19,6 +19,7 @@ var (
 	flagChain            string
 	flagFromTo           string
 	flagWorkerCount      uint // number of workers to verify the blocks concurrently
+	flagStopOnMismatch   bool
 )
 
 // # verify the last 100 sealed blocks
@@ -52,6 +53,7 @@ func init() {
 	Cmd.Flags().UintVar(&flagWorkerCount, "worker_count", 1,
 		"number of workers to use for verification, default is 1")
 
+	Cmd.Flags().BoolVar(&flagStopOnMismatch, "stop_on_mismatch", false, "stop verification on first mismatch")
 }
 
 func run(*cobra.Command, []string) {
@@ -66,6 +68,10 @@ func run(*cobra.Command, []string) {
 		Str("chain", string(chainID)).
 		Str("datadir", flagDatadir).
 		Str("chunk_data_pack_dir", flagChunkDataPackDir).
+		Uint64("lastk", flagLastK).
+		Str("from_to", flagFromTo).
+		Uint("worker_count", flagWorkerCount).
+		Bool("stop_on_mismatch", flagStopOnMismatch).
 		Logger()
 
 	if flagFromTo != "" {
@@ -75,7 +81,7 @@ func run(*cobra.Command, []string) {
 		}
 
 		lg.Info().Msgf("verifying range from %d to %d", from, to)
-		err = verifier.VerifyRange(from, to, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount)
+		err = verifier.VerifyRange(from, to, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount, flagStopOnMismatch)
 		if err != nil {
 			lg.Fatal().Err(err).Msgf("could not verify range from %d to %d", from, to)
 		}
@@ -83,7 +89,7 @@ func run(*cobra.Command, []string) {
 
 	} else {
 		lg.Info().Msgf("verifying last %d sealed blocks", flagLastK)
-		err := verifier.VerifyLastKHeight(flagLastK, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount)
+		err := verifier.VerifyLastKHeight(flagLastK, chainID, flagDatadir, flagChunkDataPackDir, flagWorkerCount, flagStopOnMismatch)
 		if err != nil {
 			lg.Fatal().Err(err).Msg("could not verify last k height")
 		}

--- a/engine/verification/verifier/verifiers.go
+++ b/engine/verification/verifier/verifiers.go
@@ -30,7 +30,7 @@ import (
 // It assumes the latest sealed block has been executed, and the chunk data packs have not been
 // pruned.
 // Note, it returns nil if certain block is not executed, in this case warning will be logged
-func VerifyLastKHeight(k uint64, chainID flow.ChainID, protocolDataDir string, chunkDataPackDir string, nWorker uint) (err error) {
+func VerifyLastKHeight(k uint64, chainID flow.ChainID, protocolDataDir string, chunkDataPackDir string, nWorker uint, stopOnMismatch bool) (err error) {
 	closer, storages, chunkDataPacks, state, verifier, err := initStorages(chainID, protocolDataDir, chunkDataPackDir)
 	if err != nil {
 		return fmt.Errorf("could not init storages: %w", err)
@@ -67,7 +67,7 @@ func VerifyLastKHeight(k uint64, chainID flow.ChainID, protocolDataDir string, c
 
 	log.Info().Msgf("verifying blocks from %d to %d", from, to)
 
-	err = verifyConcurrently(from, to, nWorker, storages.Headers, chunkDataPacks, storages.Results, state, verifier, verifyHeight)
+	err = verifyConcurrently(from, to, nWorker, stopOnMismatch, storages.Headers, chunkDataPacks, storages.Results, state, verifier, verifyHeight)
 	if err != nil {
 		return err
 	}
@@ -82,6 +82,7 @@ func VerifyRange(
 	chainID flow.ChainID,
 	protocolDataDir string, chunkDataPackDir string,
 	nWorker uint,
+	stopOnMismatch bool,
 ) (err error) {
 	closer, storages, chunkDataPacks, state, verifier, err := initStorages(chainID, protocolDataDir, chunkDataPackDir)
 	if err != nil {
@@ -102,7 +103,7 @@ func VerifyRange(
 		return fmt.Errorf("cannot verify blocks before the root block, from: %d, root: %d", from, root)
 	}
 
-	err = verifyConcurrently(from, to, nWorker, storages.Headers, chunkDataPacks, storages.Results, state, verifier, verifyHeight)
+	err = verifyConcurrently(from, to, nWorker, stopOnMismatch, storages.Headers, chunkDataPacks, storages.Results, state, verifier, verifyHeight)
 	if err != nil {
 		return err
 	}
@@ -113,12 +114,13 @@ func VerifyRange(
 func verifyConcurrently(
 	from, to uint64,
 	nWorker uint,
+	stopOnMismatch bool,
 	headers storage.Headers,
 	chunkDataPacks storage.ChunkDataPacks,
 	results storage.ExecutionResults,
 	state protocol.State,
 	verifier module.ChunkVerifier,
-	verifyHeight func(uint64, storage.Headers, storage.ChunkDataPacks, storage.ExecutionResults, protocol.State, module.ChunkVerifier) error,
+	verifyHeight func(uint64, storage.Headers, storage.ChunkDataPacks, storage.ExecutionResults, protocol.State, module.ChunkVerifier, bool) error,
 ) error {
 	tasks := make(chan uint64, int(nWorker))
 	ctx, cancel := context.WithCancel(context.Background())
@@ -147,7 +149,7 @@ func verifyConcurrently(
 					return // Exit if the tasks channel is closed
 				}
 				log.Info().Uint64("height", height).Msg("verifying height")
-				err := verifyHeight(height, headers, chunkDataPacks, results, state, verifier)
+				err := verifyHeight(height, headers, chunkDataPacks, results, state, verifier, stopOnMismatch)
 				if err != nil {
 					log.Error().Uint64("height", height).Err(err).Msg("error encountered while verifying height")
 
@@ -254,6 +256,7 @@ func verifyHeight(
 	results storage.ExecutionResults,
 	state protocol.State,
 	verifier module.ChunkVerifier,
+	stopOnMismatch bool,
 ) error {
 	header, err := headers.ByHeight(height)
 	if err != nil {
@@ -286,7 +289,11 @@ func verifyHeight(
 
 		_, err = verifier.Verify(vcd)
 		if err != nil {
-			return fmt.Errorf("could not verify %d-th chunk: %w", i, err)
+			if stopOnMismatch {
+				return fmt.Errorf("could not verify chunk (index: %v) at block %v (%v): %w", i, height, blockID, err)
+			}
+
+			log.Error().Err(err).Msgf("could not verify chunk (index: %v) at block %v (%v)", i, height, blockID)
 		}
 	}
 	return nil

--- a/engine/verification/verifier/verifiers_test.go
+++ b/engine/verification/verifier/verifiers_test.go
@@ -59,6 +59,7 @@ func TestVerifyConcurrently(t *testing.T) {
 				results storage.ExecutionResults,
 				state protocol.State,
 				verifier module.ChunkVerifier,
+				stopOnMismatch bool,
 			) error {
 				if err, ok := tt.errors[height]; ok {
 					return err
@@ -72,7 +73,7 @@ func TestVerifyConcurrently(t *testing.T) {
 			mockState := unittestMocks.NewProtocolState()
 			mockVerifier := mockmodule.NewChunkVerifier(t)
 
-			err := verifyConcurrently(tt.from, tt.to, tt.nWorker, mockHeaders, mockChunkDataPacks, mockResults, mockState, mockVerifier, mockVerifyHeight)
+			err := verifyConcurrently(tt.from, tt.to, tt.nWorker, true, mockHeaders, mockChunkDataPacks, mockResults, mockState, mockVerifier, mockVerifyHeight)
 			if tt.expectedErr != nil {
 				if err == nil || errors.Is(err, tt.expectedErr) {
 					t.Fatalf("expected error: %v, got: %v", tt.expectedErr, err)


### PR DESCRIPTION
The current backward compatibilities testing tool (verify execution result) will stop as soon as it found a mismatch. This PR adds a flag to control that and by default it will not stop but continue verifying. 