### PR TITLE
Add default fvm context to the epoch counter script

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -528,6 +528,10 @@ func (exeNode *ExecutionNode) LoadProviderEngine(
 		node.FvmOptions...,
 	)
 
+	opts = append(opts, computation.DefaultFVMOptions(
+		node.RootChainID,
+		exeNode.exeConf.computationConfig.CadenceTracing,
+		exeNode.exeConf.computationConfig.ExtensiveTracing)...)
 	vmCtx := fvm.NewContext(opts...)
 
 	var collector module.ExecutionMetrics


### PR DESCRIPTION
We run a script to get the epoch counter from the state during node startup. 

This script is not run by the block execution manager or the query engine, so it has its own FVM context. This FVM context was not taking the default settings used in Transaction execution and in the query engine.