### PR TITLE
Add  support for account format v2 in util `check-storage`

### DIFF
--- a/cmd/util/cmd/check-storage/evm_account_storage_health.go
+++ b/cmd/util/cmd/check-storage/evm_account_storage_health.go
@@ -70,7 +70,7 @@ func checkCadenceAtreeRegistersInEVMAccount(
 ) []accountStorageIssue {
 	var issues []accountStorageIssue
 
-	storage := runtime.NewStorage(ledger, nil, runtime.StorageConfig{})
+	storage := runtime.NewStorage(ledger, nil, runtime.StorageConfig{StorageFormatV2Enabled: true})
 
 	inter, err := interpreter.NewInterpreter(
 		nil,

--- a/cmd/util/cmd/checkpoint-collect-stats/account_stats.go
+++ b/cmd/util/cmd/checkpoint-collect-stats/account_stats.go
@@ -33,12 +33,11 @@ func (format accountFormat) MarshalJSON() ([]byte, error) {
 
 type AccountStats struct {
 	stats
-	FormatV1Count      int            `json:"account_format_v1_count"`
-	FormatV2Count      int            `json:"account_format_v2_count"`
-	AccountsInFormatV2 []string       `json:"accounts_in_format_v2,omitempty"`
-	ServiceAccount     *AccountInfo   `json:"service_account,omitempty"`
-	EVMAccount         *AccountInfo   `json:"evm_account,omitempty"`
-	TopN               []*AccountInfo `json:"largest_accounts"`
+	FormatV1Count  int            `json:"account_format_v1_count"`
+	FormatV2Count  int            `json:"account_format_v2_count"`
+	ServiceAccount *AccountInfo   `json:"service_account,omitempty"`
+	EVMAccount     *AccountInfo   `json:"evm_account,omitempty"`
+	TopN           []*AccountInfo `json:"largest_accounts"`
 }
 
 type AccountInfo struct {
@@ -55,7 +54,6 @@ func getAccountStatus(
 	accountsSlice := make([]*AccountInfo, 0, len(accounts))
 	accountSizesSlice := make([]float64, 0, len(accounts))
 
-	var accountsInFormatV2 []string
 	var accountFormatV1Count, accountFormatV2Count int
 
 	for _, acct := range accounts {
@@ -68,7 +66,6 @@ func getAccountStatus(
 
 		case accountFormatV2:
 			accountFormatV2Count++
-			accountsInFormatV2 = append(accountsInFormatV2, acct.Address)
 
 		default:
 			if acct.Address != "" {
@@ -82,9 +79,6 @@ func getAccountStatus(
 		return cmp.Compare(b.PayloadSize, a.PayloadSize)
 	})
 
-	// Sort accounts in format v2
-	slices.SortFunc(accountsInFormatV2, cmp.Compare)
-
 	stats := getValueStats(accountSizesSlice, percentiles)
 
 	evmAccountAddress := systemcontracts.SystemContractsForChain(chainID).EVMStorage.Address
@@ -92,13 +86,12 @@ func getAccountStatus(
 	serviceAccountAddress := serviceAccountAddressForChain(chainID)
 
 	return AccountStats{
-		stats:              stats,
-		FormatV1Count:      accountFormatV1Count,
-		FormatV2Count:      accountFormatV2Count,
-		AccountsInFormatV2: accountsInFormatV2,
-		ServiceAccount:     accounts[string(serviceAccountAddress[:])],
-		EVMAccount:         accounts[string(evmAccountAddress[:])],
-		TopN:               accountsSlice[:flagTopN],
+		stats:          stats,
+		FormatV1Count:  accountFormatV1Count,
+		FormatV2Count:  accountFormatV2Count,
+		ServiceAccount: accounts[string(serviceAccountAddress[:])],
+		EVMAccount:     accounts[string(evmAccountAddress[:])],
+		TopN:           accountsSlice[:flagTopN],
 	}
 }
 

--- a/cmd/util/cmd/diff-states/cmd.go
+++ b/cmd/util/cmd/diff-states/cmd.go
@@ -338,14 +338,6 @@ func diffAccount(
 	acctsToSkip []string,
 ) (err error) {
 
-	if accountRegisters1.Count() != accountRegisters2.Count() {
-		rw.Write(countDiff{
-			Owner:  owner,
-			State1: accountRegisters1.Count(),
-			State2: accountRegisters2.Count(),
-		})
-	}
-
 	diffValues := flagAlwaysDiffValues
 
 	err = accountRegisters1.ForEach(func(owner, key string, value1 []byte) error {

--- a/cmd/util/ledger/migrations/cadence_value_diff.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff.go
@@ -1145,7 +1145,10 @@ func min(a, b int) int {
 
 func newReadonlyStorage(regs registers.Registers) *runtime.Storage {
 	ledger := &registers.ReadOnlyLedger{Registers: regs}
-	return runtime.NewStorage(ledger, nil, runtime.StorageConfig{})
+	config := runtime.StorageConfig{
+		StorageFormatV2Enabled: true,
+	}
+	return runtime.NewStorage(ledger, nil, config)
 }
 
 type readonlyStorageRuntime struct {

--- a/cmd/util/ledger/migrations/cadence_value_diff.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff.go
@@ -136,101 +136,6 @@ func (dr *CadenceValueDiffReporter) DiffStates(oldRegs, newRegs registers.Regist
 		return
 	}
 
-	oldInter, err := interpreter.NewInterpreter(
-		nil,
-		nil,
-		&interpreter.Config{
-			Storage: oldStorage,
-		},
-	)
-	if err != nil {
-		dr.reportWriter.Write(
-			diffError{
-				Address: dr.address.Hex(),
-				Kind:    diffErrorKindString[abortErrorKind],
-				Msg:     fmt.Sprintf("failed to create interpreter for old registers: %s", err),
-			},
-		)
-		return
-	}
-
-	newInter, err := interpreter.NewInterpreter(
-		nil,
-		nil,
-		&interpreter.Config{
-			Storage: newStorage,
-		},
-	)
-	if err != nil {
-		dr.reportWriter.Write(
-			diffError{
-				Address: dr.address.Hex(),
-				Kind:    diffErrorKindString[abortErrorKind],
-				Msg:     fmt.Sprintf("failed to create interpreter for new registers: %s", err),
-			},
-		)
-		return
-	}
-
-	if oldRegs.Count() > minLargeAccountRegisterCount {
-		// Add concurrency to diff domains
-		var g errgroup.Group
-
-		// NOTE: preload storage map in the same goroutine
-		for _, domain := range domains {
-			_ = oldStorage.GetDomainStorageMap(oldInter, dr.address, domain, false)
-			_ = newStorage.GetDomainStorageMap(newInter, dr.address, domain, false)
-		}
-
-		// Create goroutine to diff storage domain
-		g.Go(func() (err error) {
-			oldRuntime, err := newReadonlyStorageRuntimeWithStorage(oldStorage, oldRegs.Count())
-			if err != nil {
-				return fmt.Errorf("failed to create runtime for old registers: %s", err)
-			}
-
-			newRuntime, err := newReadonlyStorageRuntimeWithStorage(newStorage, newRegs.Count())
-			if err != nil {
-				return fmt.Errorf("failed to create runtime for new registers: %s", err)
-			}
-
-			dr.diffDomain(oldRuntime, newRuntime, common.StorageDomainPathStorage)
-			return nil
-		})
-
-		// Create goroutine to diff other domains
-		g.Go(func() (err error) {
-			oldRuntime, err := newReadonlyStorageRuntimeWithStorage(oldStorage, oldRegs.Count())
-			if err != nil {
-				return fmt.Errorf("failed to create runtime for old registers: %s", err)
-			}
-
-			newRuntime, err := newReadonlyStorageRuntimeWithStorage(newStorage, oldRegs.Count())
-			if err != nil {
-				return fmt.Errorf("failed to create runtime for new registers: %s", err)
-			}
-
-			for _, domain := range domains {
-				if domain != common.StorageDomainPathStorage {
-					dr.diffDomain(oldRuntime, newRuntime, domain)
-				}
-			}
-			return nil
-		})
-
-		err = g.Wait()
-		if err != nil {
-			dr.reportWriter.Write(
-				diffError{
-					Address: dr.address.Hex(),
-					Kind:    diffErrorKindString[abortErrorKind],
-					Msg:     err.Error(),
-				})
-		}
-
-		return
-	}
-
 	// Skip goroutine overhead for smaller accounts
 	oldRuntime, err := newReadonlyStorageRuntimeWithStorage(oldStorage, oldRegs.Count())
 	if err != nil {
@@ -464,65 +369,19 @@ func (dr *CadenceValueDiffReporter) diffDomain(
 		oldRuntime.PayloadCount,
 	)
 
-	// Diffing storage domain in large account
+	// Diffing storage domain
 
-	type job struct {
-		oldValue interpreter.Value
-		newValue interpreter.Value
-		trace    *util.Trace
-	}
-
-	nWorkers := dr.nWorkers
-	if len(sharedKeys) < nWorkers {
-		nWorkers = len(sharedKeys)
-	}
-
-	jobs := make(chan job, nWorkers)
-
-	var g errgroup.Group
-
-	for i := 0; i < nWorkers; i++ {
-
-		g.Go(func() error {
-			for job := range jobs {
-				diffValues(
-					oldRuntime.Interpreter,
-					job.oldValue,
-					newRuntime.Interpreter,
-					job.newValue,
-					job.trace,
-				)
-			}
-
-			return nil
-		})
-	}
-
-	// Launch goroutine to send account registers to jobs channel
-	go func() {
-		defer close(jobs)
-
-		for _, key := range sharedKeys {
-			oldValue, newValue, trace, canDiff := getValues(key)
-			if canDiff {
-				jobs <- job{
-					oldValue: oldValue,
-					newValue: newValue,
-					trace:    trace,
-				}
-			}
+	for _, key := range sharedKeys {
+		oldValue, newValue, trace, canDiff := getValues(key)
+		if canDiff {
+			diffValues(
+				oldRuntime.Interpreter,
+				oldValue,
+				newRuntime.Interpreter,
+				newValue,
+				trace,
+			)
 		}
-	}()
-
-	// Wait for workers
-	err := g.Wait()
-	if err != nil {
-		dr.reportWriter.Write(
-			diffError{
-				Address: dr.address.Hex(),
-				Kind:    diffErrorKindString[abortErrorKind],
-				Msg:     fmt.Sprintf("failed to diff domain %s: %s", domain.Identifier(), err),
-			})
 	}
 
 	log.Info().


### PR DESCRIPTION
Currently, `util` program's `check-storage` command (to check storage health) only supports account storage format v1.  However, we need to also support the recently added v2.

This commit adds two flags to check storage health of account format (v1 or v2).
- `account-format-v1` flag should be on if state contains any accounts in v1 format
- `account-format-v2` flag should be on if state contains any accounts in v2 format

**IMPORTANT**: Both flags should be specified if both v1 and v2 are present in the state.