### PR TITLE
[Malleability] MissingCollection type ID method malleable.

### DIFF
--- a/engine/execution/ingestion/block_queue/queue.go
+++ b/engine/execution/ingestion/block_queue/queue.go
@@ -55,7 +55,16 @@ type MissingCollection struct {
 }
 
 func (m *MissingCollection) ID() flow.Identifier {
-	return flow.MakeID(m)
+	stub := struct {
+		BlockID               flow.Identifier
+		Height                uint64
+		CollectionGuaranteeID flow.Identifier
+	}{
+		m.BlockID,
+		m.Height,
+		m.Guarantee.ID(),
+	}
+	return flow.MakeID(stub)
 }
 
 // collectionInfo is an internal struct used to keep track of the state of a collection,

--- a/engine/execution/ingestion/block_queue/queue.go
+++ b/engine/execution/ingestion/block_queue/queue.go
@@ -55,7 +55,7 @@ type MissingCollection struct {
 }
 
 func (m *MissingCollection) ID() flow.Identifier {
-	return m.Guarantee.ID()
+	return flow.MakeID(m)
 }
 
 // collectionInfo is an internal struct used to keep track of the state of a collection,

--- a/utils/unittest/chain_suite.go
+++ b/utils/unittest/chain_suite.go
@@ -465,13 +465,6 @@ func ApprovalFor(result *flow.ExecutionResult, chunkIdx uint64, approverID flow.
 	)
 }
 
-func EntityWithID(expectedID flow.Identifier) interface{} {
-	return mock.MatchedBy(
-		func(entity flow.Entity) bool {
-			return expectedID == entity.ID()
-		})
-}
-
 // subgraphFixture represents a subgraph of the blockchain:
 //
 //	Result   -----------------------------------> Block


### PR DESCRIPTION
Closes: #6679 

## Context
This PR fixes the implementation of the `ID()` method for the `MissingCollection` type to cover all fields. In addition, the unused method `EntityWithID` was removed.
Changes have no impact on tests.

## Reference of usage:
https://github.com/onflow/flow-go/blob/914f3531b2b79a695ce8a11a8bc713adf86bd120/engine/execution/ingestion/core.go#L312
