### PR TITLE
[Malleability] Refactor BlockDigest and ChannelList types

### DIFF
--- a/access/handler.go
+++ b/access/handler.go
@@ -1366,7 +1366,7 @@ func (h *Handler) SubscribeBlockDigestsFromLatest(request *access.SubscribeBlock
 func (h *Handler) handleBlockDigestsResponse(send sendSubscribeBlockDigestsResponseFunc) func(*flow.BlockDigest) error {
 	return func(blockDigest *flow.BlockDigest) error {
 		err := send(&access.SubscribeBlockDigestsResponse{
-			BlockId:        convert.IdentifierToMessage(blockDigest.ID()),
+			BlockId:        convert.IdentifierToMessage(blockDigest.BlockID),
 			BlockHeight:    blockDigest.Height,
 			BlockTimestamp: timestamppb.New(blockDigest.Timestamp),
 		})

--- a/engine/access/rest/websockets/models/block_digest.go
+++ b/engine/access/rest/websockets/models/block_digest.go
@@ -7,7 +7,7 @@ import (
 
 // Build creates a BlockDigest instance with data from the provided flow.BlockDigest.
 func (b *BlockDigest) Build(block *flow.BlockDigest) {
-	b.BlockId = block.ID().String()
+	b.BlockId = block.BlockID.String()
 	b.Height = util.FromUint(block.Height)
 	b.Timestamp = block.Timestamp
 }

--- a/engine/access/rpc/backend/backend_stream_block_digests_test.go
+++ b/engine/access/rpc/backend/backend_stream_block_digests_test.go
@@ -82,7 +82,7 @@ func (s *BackendBlockDigestSuite) requireBlockDigests(v interface{}, expectedBlo
 	actualBlock, ok := v.(*flow.BlockDigest)
 	require.True(s.T(), ok, "unexpected response type: %T", v)
 
-	s.Require().Equal(expectedBlock.Header.ID(), actualBlock.ID())
+	s.Require().Equal(expectedBlock.Header.ID(), actualBlock.BlockID)
 	s.Require().Equal(expectedBlock.Header.Height, actualBlock.Height)
 	s.Require().Equal(expectedBlock.Header.Timestamp, actualBlock.Timestamp)
 }

--- a/model/flow/block.go
+++ b/model/flow/block.go
@@ -113,7 +113,7 @@ func (b *CertifiedBlock) Height() uint64 {
 	return b.Block.Header.Height
 }
 
-// BlockDigest holds lightweight block information which includes only block id, block height and block timestamp
+// BlockDigest holds lightweight block information which includes only the block's id, height and timestamp
 type BlockDigest struct {
 	BlockID   Identifier
 	Height    uint64

--- a/model/flow/block.go
+++ b/model/flow/block.go
@@ -115,25 +115,20 @@ func (b *CertifiedBlock) Height() uint64 {
 
 // BlockDigest holds lightweight block information which includes only block id, block height and block timestamp
 type BlockDigest struct {
-	id        Identifier
+	BlockID   Identifier
 	Height    uint64
 	Timestamp time.Time
 }
 
 // NewBlockDigest constructs a new block digest.
 func NewBlockDigest(
-	id Identifier,
+	blockID Identifier,
 	height uint64,
 	timestamp time.Time,
 ) *BlockDigest {
 	return &BlockDigest{
-		id:        id,
+		BlockID:   blockID,
 		Height:    height,
 		Timestamp: timestamp,
 	}
-}
-
-// ID returns the id of the BlockDigest.
-func (b *BlockDigest) ID() Identifier {
-	return b.id
 }

--- a/network/channels/channel.go
+++ b/network/channels/channel.go
@@ -2,9 +2,6 @@ package channels
 
 import (
 	"regexp"
-	"sort"
-
-	"github.com/onflow/flow-go/model/flow"
 )
 
 // Channel specifies a virtual and isolated communication medium.
@@ -34,13 +31,6 @@ func (cl ChannelList) Less(i, j int) bool {
 // It satisfies the sort.Interface making the ChannelList sortable.
 func (cl ChannelList) Swap(i, j int) {
 	cl[i], cl[j] = cl[j], cl[i]
-}
-
-// ID returns hash of the content of ChannelList. It first sorts the ChannelList and then takes its
-// hash value.
-func (cl ChannelList) ID() flow.Identifier {
-	sort.Sort(cl)
-	return flow.MakeID(cl)
 }
 
 // Contains returns true if the ChannelList contains the given channel.


### PR DESCRIPTION
Closes:  #6665, #6667

## Context
This pull request addresses two issues related to the misuse and redundancy of the `ID()` method in `BlockDigest` and `ChannelList`.

- `BlockDigest`: the id field has been renamed to `BlockID`, and the `ID()` method has been removed. All affected unit tests and usages have been updated to reflect this change.

- `ChannelList`: the `ID()` method has been removed, and all relevant tests have been verified to ensure correctness.