### PR TITLE
[Malleability] cluster.Block type ID method malleable.

### DIFF
--- a/model/cluster/block.go
+++ b/model/cluster/block.go
@@ -31,9 +31,9 @@ type Block struct {
 	Payload *Payload
 }
 
-// ID returns the ID of the underlying block header.
+// ID returns unique identifier for the block.
 func (b Block) ID() flow.Identifier {
-	return b.Header.ID()
+	return flow.MakeID(b)
 }
 
 // SetPayload sets the payload and payload hash.


### PR DESCRIPTION
closes: #6660 

## Context
This PR fixes the implementation of the `ID()` method for the `cluster.Block` type to cover all fields as it's used through the codebase. 
Changes have no impact on tests.

Not for review yet.