### PR TITLE
Remove last remnants of Cadence 1.0 and authorization fixes migrations

### DIFF
--- a/cmd/util/cmd/execution-state-extract/cmd.go
+++ b/cmd/util/cmd/execution-state-extract/cmd.go
@@ -33,7 +33,6 @@ var (
 	flagNWorker                            int
 	flagNoMigration                        bool
 	flagMigration                          string
-	flagAuthorizationFixes                 string
 	flagNoReport                           bool
 	flagValidateMigration                  bool
 	flagAllowPartialStateFromPayloads      bool
@@ -89,11 +88,7 @@ func init() {
 	Cmd.Flags().BoolVar(&flagNoMigration, "no-migration", false,
 		"don't migrate the state")
 
-	Cmd.Flags().StringVar(&flagMigration, "migration", "cadence-1.0",
-		"migration name. 'cadence-1.0' (default) or 'fix-authorizations'")
-
-	Cmd.Flags().StringVar(&flagAuthorizationFixes, "authorization-fixes", "",
-		"authorization fixes to apply. requires '--migration=fix-authorizations'")
+	Cmd.Flags().StringVar(&flagMigration, "migration", "", "migration name")
 
 	Cmd.Flags().BoolVar(&flagNoReport, "no-report", false,
 		"don't report the state")
@@ -228,19 +223,6 @@ func run(*cobra.Command, []string) {
 
 	if flagValidateMigration && flagDiffMigration {
 		log.Fatal().Msg("Both --validate and --diff are enabled, please specify only one (or none) of these")
-	}
-
-	switch flagMigration {
-	case "cadence-1.0":
-		// valid, no-op
-
-	case "fix-authorizations":
-		if flagAuthorizationFixes == "" {
-			log.Fatal().Msg("--migration=fix-authorizations requires --authorization-fixes")
-		}
-
-	default:
-		log.Fatal().Msg("Invalid --migration: got %s, expected 'cadence-1.0' or 'fix-authorizations'")
 	}
 
 	var stateCommitment flow.StateCommitment


### PR DESCRIPTION
#6572 left some code related to the Cadence 1.0 and authorization fixes migrations in the code base, e.g. the flags.

Remove them