### PR TITLE
Add `--exclude-randombeaconhistory` to `diff-states` cmd in `util` program

### DIFF
--- a/cmd/util/cmd/diff-states/cmd.go
+++ b/cmd/util/cmd/diff-states/cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dustin/go-humanize/english"
 	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/interpreter"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -26,17 +27,18 @@ import (
 )
 
 var (
-	flagOutputDirectory  string
-	flagPayloads1        string
-	flagPayloads2        string
-	flagState1           string
-	flagState2           string
-	flagStateCommitment1 string
-	flagStateCommitment2 string
-	flagMode             string
-	flagAlwaysDiffValues bool
-	flagNWorker          int
-	flagChain            string
+	flagOutputDirectory            string
+	flagPayloads1                  string
+	flagPayloads2                  string
+	flagState1                     string
+	flagState2                     string
+	flagStateCommitment1           string
+	flagStateCommitment2           string
+	flagMode                       string
+	flagAlwaysDiffValues           bool
+	flagExcludeRandomBeaconHistory bool
+	flagNWorker                    int
+	flagChain                      string
 )
 
 var Cmd = &cobra.Command{
@@ -139,7 +141,19 @@ func init() {
 		"Chain name",
 	)
 	_ = Cmd.MarkFlagRequired("chain")
+
+	Cmd.Flags().BoolVar(
+		&flagExcludeRandomBeaconHistory,
+		"exclude-randombeaconhistory",
+		false,
+		"exclude random beacon history",
+	)
 }
+
+const (
+	randomBeaconHistoryDomain    = common.StorageDomainContract
+	randomBeaconHistoryDomainKey = interpreter.StringStorageMapKey("RandomBeaconHistory")
+)
 
 type mode uint8
 
@@ -189,6 +203,10 @@ func run(*cobra.Command, []string) {
 			"--mode must be one of %s",
 			english.OxfordWordSeries(modeNames, "or"),
 		)
+	}
+
+	if flagExcludeRandomBeaconHistory {
+		log.Info().Msg("--exclude-randombeaconhistory is set to exclude random beacon history")
 	}
 
 	var acctsToSkipForCadenceValueDiff []string
@@ -336,6 +354,7 @@ func diffAccount(
 	rw reporters.ReportWriter,
 	mode mode,
 	acctsToSkip []string,
+	serviceAccountAddress common.Address,
 ) (err error) {
 
 	diffValues := flagAlwaysDiffValues
@@ -398,6 +417,15 @@ func diffAccount(
 			accountRegisters1,
 			accountRegisters2,
 			common.AllStorageDomains,
+			func(address common.Address, domain common.StorageDomain, key any) bool {
+				if flagExcludeRandomBeaconHistory {
+					if isRandomBeaconHistory(serviceAccountAddress, address, domain, key) {
+						log.Info().Msgf("excluding random beacon history in account %s, domain %s, key %v", address, domain.Identifier(), key)
+						return false
+					}
+				}
+				return true
+			},
 		)
 	}
 
@@ -414,6 +442,8 @@ func diff(
 	acctsToSkip []string,
 ) error {
 	log.Info().Msgf("Diffing %d accounts", registers1.AccountCount())
+
+	serviceAccountAddress := serviceAccountAddressForChain(chainID)
 
 	if registers1.AccountCount() < nWorkers {
 		nWorkers = registers1.AccountCount()
@@ -454,6 +484,7 @@ func diff(
 				rw,
 				mode,
 				acctsToSkip,
+				common.Address(serviceAccountAddress),
 			)
 			if err != nil {
 				log.Warn().Err(err).Msgf("failed to diff account %x", []byte(owner))
@@ -509,6 +540,7 @@ func diff(
 					rw,
 					mode,
 					acctsToSkip,
+					common.Address(serviceAccountAddress),
 				)
 
 				select {
@@ -668,4 +700,30 @@ func (e countDiff) MarshalJSON() ([]byte, error) {
 		State1: e.State1,
 		State2: e.State2,
 	})
+}
+
+func isRandomBeaconHistory(serviceAccountAddress, address common.Address, domain common.StorageDomain, key any) bool {
+	if serviceAccountAddress.Compare(address) != 0 {
+		return false
+	}
+
+	if domain != randomBeaconHistoryDomain {
+		return false
+	}
+
+	switch key := key.(type) {
+	case interpreter.StringAtreeValue:
+		return interpreter.StringStorageMapKey(key) == randomBeaconHistoryDomainKey
+
+	case interpreter.StringStorageMapKey:
+		return key == randomBeaconHistoryDomainKey
+
+	default:
+		return false
+	}
+}
+
+func serviceAccountAddressForChain(chainID flow.ChainID) flow.Address {
+	sc := systemcontracts.SystemContractsForChain(chainID)
+	return sc.FlowServiceAccount.Address
 }

--- a/cmd/util/ledger/migrations/cadence_value_diff_test.go
+++ b/cmd/util/ledger/migrations/cadence_value_diff_test.go
@@ -26,6 +26,10 @@ func TestDiffCadenceValues(t *testing.T) {
 
 	const domain = common.StorageDomainPathStorage
 
+	alwaysDiff := func(address common.Address, domain common.StorageDomain, key any) bool {
+		return true
+	}
+
 	t.Run("no diff", func(t *testing.T) {
 		t.Parallel()
 
@@ -37,6 +41,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			createTestRegisters(t, address, domain),
 			createTestRegisters(t, address, domain),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(writer.entries))
@@ -53,6 +58,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			createTestRegisters(t, address, domain),
 			registers.NewByAccount(),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(writer.entries))
@@ -74,6 +80,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			createTestRegisters(t, address, domain),
 			createStorageMapRegisters(t, address, domain, []string{"unique_key"}, []interpreter.Value{interpreter.UInt64Value(0)}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 
@@ -101,6 +108,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
 			createStorageMapRegisters(t, address, domain, []string{"2", "0"}, []interpreter.Value{interpreter.UInt64Value(0), interpreter.UInt64Value(0)}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 
@@ -128,6 +136,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
 			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(111), interpreter.UInt64Value(101)}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 
@@ -155,6 +164,7 @@ func TestDiffCadenceValues(t *testing.T) {
 			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(100), interpreter.UInt64Value(101)}),
 			createStorageMapRegisters(t, address, domain, []string{"0", "1"}, []interpreter.Value{interpreter.UInt64Value(111), interpreter.UInt64Value(102)}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 
@@ -261,6 +271,7 @@ func TestDiffCadenceValues(t *testing.T) {
 				interpreter.UInt64Value(5),
 			}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 
@@ -385,6 +396,7 @@ func TestDiffCadenceValues(t *testing.T) {
 					interpreter.UInt64Value(3),
 				}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 
@@ -516,6 +528,7 @@ func TestDiffCadenceValues(t *testing.T) {
 					interpreter.UInt64Value(3),
 				}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 
@@ -647,6 +660,7 @@ func TestDiffCadenceValues(t *testing.T) {
 					interpreter.UInt64Value(3),
 				}),
 			[]common.StorageDomain{domain},
+			alwaysDiff,
 		)
 		require.NoError(t, err)
 


### PR DESCRIPTION
Closes #6989 

This PR adds `--exclude-randombeaconhistory` flag to util's `diff-states` command.

This flag can be used to reduce noise when comparing states.

Without this flag, the diff-states report (JSONL) can sometimes contain lines that are 30+ GB each, depending on the states being compared (e.g. before/after test of partial zero-downtime migration).

While at it, also removed some obsolete concurrency code.