### PR TITLE
[Access] Fix flakiness in ExecutionStateSync integration test

### DIFF
--- a/engine/access/state_stream/backend/backend_executiondata.go
+++ b/engine/access/state_stream/backend/backend_executiondata.go
@@ -43,7 +43,7 @@ func (b *ExecutionDataBackend) GetExecutionDataByBlockID(ctx context.Context, bl
 
 	if err != nil {
 		// need custom not found handler due to blob not found error
-		if errors.Is(err, storage.ErrNotFound) || execution_data.IsBlobNotFoundError(err) {
+		if errors.Is(err, storage.ErrNotFound) || execution_data.IsBlobNotFoundError(err) || errors.Is(err, subscription.ErrBlockNotReady) {
 			return nil, status.Errorf(codes.NotFound, "could not find execution data: %v", err)
 		}
 

--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -421,7 +421,7 @@ func prepareAccessService(container testnet.ContainerConfig, i int, n int) Servi
 		fmt.Sprintf("--secure-rpc-addr=%s:%s", container.ContainerName, testnet.GRPCSecurePort),
 		fmt.Sprintf("--http-addr=%s:%s", container.ContainerName, testnet.GRPCWebPort),
 		fmt.Sprintf("--rest-addr=%s:%s", container.ContainerName, testnet.RESTPort),
-		fmt.Sprintf("--state-stream-addr=%s:%s", container.ContainerName, testnet.ExecutionStatePort),
+		fmt.Sprintf("--state-stream-addr=%s:%s", container.ContainerName, testnet.GRPCPort),
 		fmt.Sprintf("--collection-ingress-port=%s", testnet.GRPCPort),
 		"--supports-observer=true",
 		fmt.Sprintf("--public-network-address=%s:%s", container.ContainerName, testnet.PublicNetworkPort),
@@ -443,7 +443,6 @@ func prepareAccessService(container testnet.ContainerConfig, i int, n int) Servi
 		testnet.GRPCSecurePort,
 		testnet.GRPCWebPort,
 		testnet.RESTPort,
-		testnet.ExecutionStatePort,
 		testnet.PublicNetworkPort,
 	)
 
@@ -466,7 +465,7 @@ func prepareObserverService(i int, observerName string, agPublicKey string) Serv
 		fmt.Sprintf("--secure-rpc-addr=%s:%s", observerName, testnet.GRPCSecurePort),
 		fmt.Sprintf("--http-addr=%s:%s", observerName, testnet.GRPCWebPort),
 		fmt.Sprintf("--rest-addr=%s:%s", observerName, testnet.RESTPort),
-		fmt.Sprintf("--state-stream-addr=%s:%s", observerName, testnet.ExecutionStatePort),
+		fmt.Sprintf("--state-stream-addr=%s:%s", observerName, testnet.GRPCPort),
 		"--execution-data-dir=/data/execution-data",
 		"--execution-data-sync-enabled=true",
 		"--execution-data-indexing-enabled=true",
@@ -479,7 +478,6 @@ func prepareObserverService(i int, observerName string, agPublicKey string) Serv
 		testnet.GRPCSecurePort,
 		testnet.GRPCWebPort,
 		testnet.RESTPort,
-		testnet.ExecutionStatePort,
 	)
 
 	// observer services rely on the access gateway

--- a/integration/localnet/builder/ports.go
+++ b/integration/localnet/builder/ports.go
@@ -144,7 +144,6 @@ func (a *PortAllocator) Print() {
 			testnet.GRPCSecurePort,
 			testnet.GRPCWebPort,
 			testnet.RESTPort,
-			testnet.ExecutionStatePort,
 			testnet.PublicNetworkPort,
 		} {
 			if hostPort, ok := a.exposedPorts[node][containerPort]; ok {
@@ -165,8 +164,6 @@ func portName(containerPort string) string {
 		return "GRPC-Web"
 	case testnet.RESTPort:
 		return "REST"
-	case testnet.ExecutionStatePort:
-		return "Execution Data"
 	case testnet.AdminPort:
 		return "Admin"
 	case testnet.PublicNetworkPort:

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -89,6 +89,7 @@ const (
 	DefaultProfilerDir = "/data/profiler"
 
 	// GRPCPort is the GRPC API port.
+	// Use this same port for the ExecutionDataAPI
 	GRPCPort = "9000"
 	// GRPCSecurePort is the secure GRPC API port.
 	GRPCSecurePort = "9001"
@@ -100,8 +101,6 @@ const (
 	MetricsPort = "8080"
 	// AdminPort is the admin server port
 	AdminPort = "9002"
-	// ExecutionStatePort is the execution state server port
-	ExecutionStatePort = GRPCPort
 	// PublicNetworkPort is the access node network port accessible from outside any docker container
 	PublicNetworkPort = "9876"
 	// DebuggerPort is the go debugger port
@@ -797,6 +796,7 @@ func (net *FlowNetwork) AddObserver(t *testing.T, conf ObserverConfig) *Containe
 
 	nodeContainer.exposePort(GRPCPort, testingdock.RandomPort(t))
 	nodeContainer.AddFlag("rpc-addr", nodeContainer.ContainerAddr(GRPCPort))
+	nodeContainer.AddFlag("state-stream-addr", nodeContainer.ContainerAddr(GRPCPort))
 
 	nodeContainer.exposePort(GRPCSecurePort, testingdock.RandomPort(t))
 	nodeContainer.AddFlag("secure-rpc-addr", nodeContainer.ContainerAddr(GRPCSecurePort))
@@ -809,9 +809,6 @@ func (net *FlowNetwork) AddObserver(t *testing.T, conf ObserverConfig) *Containe
 
 	nodeContainer.exposePort(RESTPort, testingdock.RandomPort(t))
 	nodeContainer.AddFlag("rest-addr", nodeContainer.ContainerAddr(RESTPort))
-
-	nodeContainer.exposePort(ExecutionStatePort, testingdock.RandomPort(t))
-	nodeContainer.AddFlag("state-stream-addr", nodeContainer.ContainerAddr(ExecutionStatePort))
 
 	nodeContainer.opts.HealthCheck = testingdock.HealthCheckCustom(nodeContainer.HealthcheckCallback())
 
@@ -910,6 +907,7 @@ func (net *FlowNetwork) AddNode(t *testing.T, bootstrapDir string, nodeConf Cont
 		case flow.RoleAccess:
 			nodeContainer.exposePort(GRPCPort, testingdock.RandomPort(t))
 			nodeContainer.AddFlag("rpc-addr", nodeContainer.ContainerAddr(GRPCPort))
+			nodeContainer.AddFlag("state-stream-addr", nodeContainer.ContainerAddr(GRPCPort))
 
 			nodeContainer.exposePort(GRPCSecurePort, testingdock.RandomPort(t))
 			nodeContainer.AddFlag("secure-rpc-addr", nodeContainer.ContainerAddr(GRPCSecurePort))
@@ -919,9 +917,6 @@ func (net *FlowNetwork) AddNode(t *testing.T, bootstrapDir string, nodeConf Cont
 
 			nodeContainer.exposePort(RESTPort, testingdock.RandomPort(t))
 			nodeContainer.AddFlag("rest-addr", nodeContainer.ContainerAddr(RESTPort))
-
-			nodeContainer.exposePort(ExecutionStatePort, testingdock.RandomPort(t))
-			nodeContainer.AddFlag("state-stream-addr", nodeContainer.ContainerAddr(ExecutionStatePort))
 
 			// uncomment line below to point the access node exclusively to a single collection node
 			// nodeContainer.AddFlag("static-collection-ingress-addr", "collection_1:9000")

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -101,7 +101,7 @@ const (
 	// AdminPort is the admin server port
 	AdminPort = "9002"
 	// ExecutionStatePort is the execution state server port
-	ExecutionStatePort = "9003"
+	ExecutionStatePort = GRPCPort
 	// PublicNetworkPort is the access node network port accessible from outside any docker container
 	PublicNetworkPort = "9876"
 	// DebuggerPort is the go debugger port

--- a/integration/tests/access/cohort3/execution_state_sync_test.go
+++ b/integration/tests/access/cohort3/execution_state_sync_test.go
@@ -5,14 +5,22 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-datastore"
 	badgerds "github.com/ipfs/go-ds-badger2"
 	pebbleds "github.com/ipfs/go-ds-pebble"
+	sdk "github.com/onflow/flow-go-sdk"
+	sdkclient "github.com/onflow/flow-go-sdk/access/grpc"
+	"github.com/onflow/flow-go/engine/common/rpc/convert"
+	"github.com/onflow/flow/protobuf/go/flow/entities"
+	"github.com/onflow/flow/protobuf/go/flow/executiondata"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/onflow/flow-go/engine/ghost/client"
 	"github.com/onflow/flow-go/integration/testnet"
@@ -20,8 +28,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/blobs"
 	"github.com/onflow/flow-go/module/executiondatasync/execution_data"
-	"github.com/onflow/flow-go/module/metrics"
-	storage "github.com/onflow/flow-go/storage/badger"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
@@ -158,62 +164,75 @@ func (s *ExecutionStateSyncSuite) executionStateSyncTest() {
 	blockA := s.BlockState.WaitForHighestFinalizedProgress(s.T(), currentFinalized)
 	s.T().Logf("got block height %v ID %v", blockA.Header.Height, blockA.Header.ID())
 
-	// wait for the requested number of sealed blocks, then pause the network so we can inspect the dbs
-	s.BlockState.WaitForSealedHeight(s.T(), blockA.Header.Height+runBlocks)
-	s.net.StopContainers()
-
-	metrics := metrics.NewNoopCollector()
-
-	// start an execution data service using the Access Node's execution data db
-	an := s.net.ContainerByID(s.bridgeID)
-	anEds := s.nodeExecutionDataStore(an)
-
-	// setup storage objects needed to get the execution data id
-	anDB, err := an.DB()
-	require.NoError(s.T(), err, "could not open db")
-
-	anHeaders := storage.NewHeaders(metrics, anDB)
-	anResults := storage.NewExecutionResults(metrics, anDB)
-
-	// start an execution data service using the Observer Node's execution data db
-	on := s.net.ContainerByName(s.observerName)
-	onEds := s.nodeExecutionDataStore(on)
-
-	// setup storage objects needed to get the execution data id
-	onDB, err := on.DB()
-	require.NoError(s.T(), err, "could not open db")
-
-	onHeaders := storage.NewHeaders(metrics, onDB)
-	onResults := storage.NewExecutionResults(metrics, onDB)
-
 	// Loop through checkBlocks and verify the execution data was downloaded correctly
+	an := s.net.ContainerByName(testnet.PrimaryAN)
+	anClient, err := an.SDKClient()
+	require.NoError(s.T(), err, "could not get access node testnet client")
+
+	on := s.net.ContainerByName(s.observerName)
+	onClient, err := on.SDKClient()
+	require.NoError(s.T(), err, "could not get observer testnet client")
+
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Minute)
+	defer cancel()
+
 	for i := blockA.Header.Height; i <= blockA.Header.Height+checkBlocks; i++ {
-		// access node
-		header, err := anHeaders.ByHeight(i)
-		require.NoError(s.T(), err, "%s: could not get header", testnet.PrimaryAN)
+		anBED, err := s.executionDataForHeight(ctx, anClient, i)
+		require.NoError(s.T(), err, "could not get execution data from AN for height %v", i)
 
-		result, err := anResults.ByBlockID(header.ID())
-		require.NoError(s.T(), err, "%s: could not get sealed result", testnet.PrimaryAN)
+		onBED, err := s.executionDataForHeight(ctx, onClient, i)
+		require.NoError(s.T(), err, "could not get execution data from ON for height %v", i)
 
-		ed, err := anEds.Get(s.ctx, result.ExecutionDataID)
-		if assert.NoError(s.T(), err, "%s: could not get execution data for height %v", testnet.PrimaryAN, i) {
-			s.T().Logf("%s: got execution data for height %d", testnet.PrimaryAN, i)
-			assert.Equal(s.T(), header.ID(), ed.BlockID)
-		}
-
-		// observer node
-		header, err = onHeaders.ByHeight(i)
-		require.NoError(s.T(), err, "%s: could not get header", testnet.PrimaryON)
-
-		result, err = onResults.ByID(result.ID())
-		require.NoError(s.T(), err, "%s: could not get sealed result from ON`s storage", testnet.PrimaryON)
-
-		ed, err = onEds.Get(s.ctx, result.ExecutionDataID)
-		if assert.NoError(s.T(), err, "%s: could not get execution data for height %v", testnet.PrimaryON, i) {
-			s.T().Logf("%s: got execution data for height %d", testnet.PrimaryON, i)
-			assert.Equal(s.T(), header.ID(), ed.BlockID)
-		}
+		assert.Equal(s.T(), anBED.BlockID, onBED.BlockID)
 	}
+}
+
+// executionDataForHeight returns the execution data for the given height from the given node
+// It retries the request until the data is available or the context is canceled
+func (s *ExecutionStateSyncSuite) executionDataForHeight(ctx context.Context, nodeClient *sdkclient.Client, height uint64) (*execution_data.BlockExecutionData, error) {
+	execDataClient := nodeClient.ExecutionDataRPCClient()
+
+	var header *sdk.BlockHeader
+	s.Require().NoError(retryNotFound(ctx, 200*time.Millisecond, func() error {
+		var err error
+		header, err = nodeClient.GetBlockHeaderByHeight(s.ctx, height)
+		return err
+	}), "could not get block header for block %d", height)
+
+	var blockED *execution_data.BlockExecutionData
+	s.Require().NoError(retryNotFound(ctx, 200*time.Millisecond, func() error {
+		ed, err := execDataClient.GetExecutionDataByBlockID(s.ctx, &executiondata.GetExecutionDataByBlockIDRequest{
+			BlockId:              header.ID[:],
+			EventEncodingVersion: entities.EventEncodingVersion_CCF_V0,
+		})
+		if err != nil {
+			return err
+		}
+
+		blockED, err = convert.MessageToBlockExecutionData(ed.GetBlockExecutionData(), flow.Localnet.Chain())
+		s.Require().NoError(err, "could not convert execution data")
+
+		return err
+	}), "could not get execution data for block %d", height)
+
+	return blockED, nil
+}
+
+// retryNotFound retries the given function until it returns an error that is not NotFound or the context is canceled
+func retryNotFound(ctx context.Context, delay time.Duration, f func() error) error {
+	for ctx.Err() == nil {
+		err := f()
+		if status.Code(err) == codes.NotFound {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			continue
+		}
+		return err
+	}
+	return ctx.Err()
 }
 
 func (s *ExecutionStateSyncSuite) nodeExecutionDataStore(node *testnet.Container) execution_data.ExecutionDataStore {

--- a/integration/tests/access/cohort3/execution_state_sync_test.go
+++ b/integration/tests/access/cohort3/execution_state_sync_test.go
@@ -12,7 +12,6 @@ import (
 	pebbleds "github.com/ipfs/go-ds-pebble"
 	sdk "github.com/onflow/flow-go-sdk"
 	sdkclient "github.com/onflow/flow-go-sdk/access/grpc"
-	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	"github.com/onflow/flow/protobuf/go/flow/entities"
 	"github.com/onflow/flow/protobuf/go/flow/executiondata"
 	"github.com/rs/zerolog"
@@ -22,6 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/onflow/flow-go/engine/common/rpc/convert"
 	"github.com/onflow/flow-go/engine/ghost/client"
 	"github.com/onflow/flow-go/integration/testnet"
 	"github.com/onflow/flow-go/integration/tests/lib"

--- a/integration/tests/epochs/base_suite.go
+++ b/integration/tests/epochs/base_suite.go
@@ -37,6 +37,12 @@ type BaseSuite struct {
 	Client *testnet.Client
 	Ctx    context.Context
 
+	// these are used for any helper goroutines started for the test
+	// we need to shut them down before stopping the network, however canceling the network's
+	// context before stopping causes the testdock shutdown to fail.
+	HelperCtx   context.Context
+	stopHelpers context.CancelFunc
+
 	// Epoch config (lengths in views)
 	StakingAuctionLen          uint64
 	DKGPhaseLen                uint64
@@ -61,6 +67,7 @@ func (s *BaseSuite) SetupTest() {
 	require.Greater(s.T(), s.EpochLen, minEpochLength+s.EpochCommitSafetyThreshold, "epoch too short")
 
 	s.Ctx, s.cancel = context.WithCancel(context.Background())
+	s.HelperCtx, s.stopHelpers = context.WithCancel(s.Ctx)
 	s.Log = unittest.LoggerForTest(s.Suite.T(), zerolog.InfoLevel)
 	s.Log.Info().Msg("================> SetupTest")
 	defer func() {
@@ -112,7 +119,7 @@ func (s *BaseSuite) SetupTest() {
 	s.Net.Start(s.Ctx)
 
 	// start tracking blocks
-	s.Track(s.T(), s.Ctx, s.Ghost())
+	s.Track(s.T(), s.HelperCtx, s.Ghost())
 
 	// use AN1 for test-related queries - the AN join/leave test will replace AN2
 	client, err := s.Net.ContainerByName(testnet.PrimaryAN).TestnetClient()
@@ -121,11 +128,12 @@ func (s *BaseSuite) SetupTest() {
 	s.Client = client
 
 	// log network info periodically to aid in debugging future flaky tests
-	go lib.LogStatusPeriodically(s.T(), s.Ctx, s.Log, s.Client, 5*time.Second)
+	go lib.LogStatusPeriodically(s.T(), s.HelperCtx, s.Log, s.Client, 5*time.Second)
 }
 
 func (s *BaseSuite) TearDownTest() {
 	s.Log.Info().Msg("================> Start TearDownTest")
+	s.stopHelpers() // cancel before stopping network to ensure helper goroutines are stopped
 	s.Net.Remove()
 	s.cancel()
 	s.Log.Info().Msg("================> Finish TearDownTest")


### PR DESCRIPTION
I rewrote part of the `ExecutionStateSyncSuite` integration tests which were flaky. 

In the original code, we stopped the network and inspected the DBs for the access and observer nodes to make sure they each had all of the expected execution data. This ran into issue because the observer was often much slower than the access node, so some of the data was missing.

I fixed it by switching to use the state stream APIs to fetch data from each node as it becomes available. I also tweaked the shutdown logic for the epoch tests since I noticed they were logging errors connecting to nodes after stopping the network. 