### PR TITLE
Return error if --state-stream-addr no configured.

### DIFF
--- a/engine/access/rest/websockets/controller.go
+++ b/engine/access/rest/websockets/controller.go
@@ -315,20 +315,22 @@ func (c *Controller) readMessages(ctx context.Context) error {
 				return err
 			}
 
+			err = wrapErr("error reading message", err)
 			c.writeErrorResponse(
 				ctx,
 				err,
-				wrapErrorMessage(http.StatusBadRequest, "error reading message", "", ""),
+				wrapErrorMessage(http.StatusBadRequest, err.Error(), "", ""),
 			)
 			continue
 		}
 
 		err := c.handleMessage(ctx, message)
 		if err != nil {
+			err = wrapErr("error parsing message", err)
 			c.writeErrorResponse(
 				ctx,
 				err,
-				wrapErrorMessage(http.StatusBadRequest, "error parsing message", "", ""),
+				wrapErrorMessage(http.StatusBadRequest, err.Error(), "", ""),
 			)
 			continue
 		}
@@ -374,11 +376,11 @@ func (c *Controller) handleMessage(ctx context.Context, message json.RawMessage)
 func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMessageRequest) {
 	subscriptionID, err := c.parseOrCreateSubscriptionID(msg.SubscriptionID)
 	if err != nil {
+		err = wrapErr("error parsing subscription id", err)
 		c.writeErrorResponse(
 			ctx,
 			err,
-			wrapErrorMessage(http.StatusBadRequest, "error parsing subscription id",
-				models.SubscribeAction, msg.SubscriptionID),
+			wrapErrorMessage(http.StatusBadRequest, err.Error(), models.SubscribeAction, msg.SubscriptionID),
 		)
 		return
 	}
@@ -386,11 +388,11 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 	// register new provider
 	provider, err := c.dataProviderFactory.NewDataProvider(ctx, subscriptionID.String(), msg.Topic, msg.Arguments, c.multiplexedStream)
 	if err != nil {
+		err = wrapErr("error creating data provider", err)
 		c.writeErrorResponse(
 			ctx,
 			err,
-			wrapErrorMessage(http.StatusBadRequest, "error creating data provider",
-				models.SubscribeAction, subscriptionID.String()),
+			wrapErrorMessage(http.StatusBadRequest, err.Error(), models.SubscribeAction, subscriptionID.String()),
 		)
 		return
 	}
@@ -409,10 +411,11 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 	go func() {
 		err = provider.Run()
 		if err != nil {
+			err = wrapErr("internal error", err)
 			c.writeErrorResponse(
 				ctx,
 				err,
-				wrapErrorMessage(http.StatusInternalServerError, "internal error",
+				wrapErrorMessage(http.StatusInternalServerError, err.Error(),
 					models.SubscribeAction, subscriptionID.String()),
 			)
 		}
@@ -425,11 +428,11 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 func (c *Controller) handleUnsubscribe(ctx context.Context, msg models.UnsubscribeMessageRequest) {
 	subscriptionID, err := ParseClientSubscriptionID(msg.SubscriptionID)
 	if err != nil {
+		err = wrapErr("error parsing subscription id", err)
 		c.writeErrorResponse(
 			ctx,
 			err,
-			wrapErrorMessage(http.StatusBadRequest, "error parsing subscription id",
-				models.UnsubscribeAction, msg.SubscriptionID),
+			wrapErrorMessage(http.StatusBadRequest, err.Error(), models.UnsubscribeAction, msg.SubscriptionID),
 		)
 		return
 	}
@@ -512,6 +515,10 @@ func wrapErrorMessage(code int, message string, action string, subscriptionID st
 		},
 		Action: action,
 	}
+}
+
+func wrapErr(msg string, err error) error {
+	return errors.Join(fmt.Errorf("%s", msg), err)
 }
 
 func (c *Controller) parseOrCreateSubscriptionID(id string) (SubscriptionID, error) {

--- a/engine/access/rest/websockets/controller.go
+++ b/engine/access/rest/websockets/controller.go
@@ -315,7 +315,7 @@ func (c *Controller) readMessages(ctx context.Context) error {
 				return err
 			}
 
-			err = wrapErr("error reading message", err)
+			err = fmt.Errorf("error reading message: %w", err)
 			c.writeErrorResponse(
 				ctx,
 				err,
@@ -326,7 +326,7 @@ func (c *Controller) readMessages(ctx context.Context) error {
 
 		err := c.handleMessage(ctx, message)
 		if err != nil {
-			err = wrapErr("error parsing message", err)
+			err = fmt.Errorf("error parsing message: %w", err)
 			c.writeErrorResponse(
 				ctx,
 				err,
@@ -376,7 +376,7 @@ func (c *Controller) handleMessage(ctx context.Context, message json.RawMessage)
 func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMessageRequest) {
 	subscriptionID, err := c.parseOrCreateSubscriptionID(msg.SubscriptionID)
 	if err != nil {
-		err = wrapErr("error parsing subscription id", err)
+		err = fmt.Errorf("error parsing subscription id: %w", err)
 		c.writeErrorResponse(
 			ctx,
 			err,
@@ -388,7 +388,7 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 	// register new provider
 	provider, err := c.dataProviderFactory.NewDataProvider(ctx, subscriptionID.String(), msg.Topic, msg.Arguments, c.multiplexedStream)
 	if err != nil {
-		err = wrapErr("error creating data provider", err)
+		err = fmt.Errorf("error creating data provider: %w", err)
 		c.writeErrorResponse(
 			ctx,
 			err,
@@ -411,7 +411,7 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 	go func() {
 		err = provider.Run()
 		if err != nil {
-			err = wrapErr("internal error", err)
+			err = fmt.Errorf("internal error: %w", err)
 			c.writeErrorResponse(
 				ctx,
 				err,
@@ -428,7 +428,7 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 func (c *Controller) handleUnsubscribe(ctx context.Context, msg models.UnsubscribeMessageRequest) {
 	subscriptionID, err := ParseClientSubscriptionID(msg.SubscriptionID)
 	if err != nil {
-		err = wrapErr("error parsing subscription id", err)
+		err = fmt.Errorf("error parsing subscription id: %w", err)
 		c.writeErrorResponse(
 			ctx,
 			err,
@@ -515,10 +515,6 @@ func wrapErrorMessage(code int, message string, action string, subscriptionID st
 		},
 		Action: action,
 	}
-}
-
-func wrapErr(msg string, err error) error {
-	return errors.Join(fmt.Errorf("%s", msg), err)
 }
 
 func (c *Controller) parseOrCreateSubscriptionID(id string) (SubscriptionID, error) {

--- a/engine/access/rest/websockets/data_providers/account_statuses_provider.go
+++ b/engine/access/rest/websockets/data_providers/account_statuses_provider.go
@@ -55,6 +55,12 @@ func NewAccountStatusesDataProvider(
 		heartbeatInterval: heartbeatInterval,
 	}
 
+	if p.stateStreamApi == nil {
+		logger.Debug().Msg("state stream api is nil. cannot stream account statuses")
+		return nil, fmt.Errorf("this acess node is configured with no state stream api. " +
+			"cannot stream account statuses")
+	}
+
 	// Initialize arguments passed to the provider.
 	accountStatusesArgs, err := parseAccountStatusesArguments(arguments, chain, eventFilterConfig)
 	if err != nil {

--- a/engine/access/rest/websockets/data_providers/account_statuses_provider.go
+++ b/engine/access/rest/websockets/data_providers/account_statuses_provider.go
@@ -49,16 +49,14 @@ func NewAccountStatusesDataProvider(
 	eventFilterConfig state_stream.EventFilterConfig,
 	heartbeatInterval uint64,
 ) (*AccountStatusesDataProvider, error) {
+	if stateStreamApi == nil {
+		return nil, fmt.Errorf("this access node does not support streaming account statuses")
+	}
+
 	p := &AccountStatusesDataProvider{
 		logger:            logger.With().Str("component", "account-statuses-data-provider").Logger(),
 		stateStreamApi:    stateStreamApi,
 		heartbeatInterval: heartbeatInterval,
-	}
-
-	if p.stateStreamApi == nil {
-		logger.Debug().Msg("state stream api is nil. cannot stream account statuses")
-		return nil, fmt.Errorf("this acess node is configured with no state stream api. " +
-			"cannot stream account statuses")
 	}
 
 	// Initialize arguments passed to the provider.

--- a/engine/access/rest/websockets/data_providers/account_statuses_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/account_statuses_provider_test.go
@@ -105,7 +105,7 @@ func (s *AccountStatusesProviderSuite) TestAccountStatusesDataProvider_StateStre
 	)
 	s.Require().Nil(provider)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "cannot stream account statuses")
+	s.Require().Contains(err.Error(), "does not support streaming account statuses")
 }
 
 func (s *AccountStatusesProviderSuite) subscribeAccountStatusesDataProviderTestCases(

--- a/engine/access/rest/websockets/data_providers/account_statuses_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/account_statuses_provider_test.go
@@ -85,6 +85,29 @@ func (s *AccountStatusesProviderSuite) TestAccountStatusesDataProvider_HappyPath
 	)
 }
 
+func (s *AccountStatusesProviderSuite) TestAccountStatusesDataProvider_StateStreamNotConfigured() {
+	ctx := context.Background()
+	send := make(chan interface{})
+
+	topic := AccountStatusesTopic
+
+	provider, err := NewAccountStatusesDataProvider(
+		ctx,
+		s.log,
+		nil,
+		"dummy-id",
+		topic,
+		models.Arguments{},
+		send,
+		s.chain,
+		state_stream.DefaultEventFilterConfig,
+		subscription.DefaultHeartbeatInterval,
+	)
+	s.Require().Nil(provider)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "cannot stream account statuses")
+}
+
 func (s *AccountStatusesProviderSuite) subscribeAccountStatusesDataProviderTestCases(
 	backendResponses []*backend.AccountStatusesResponse,
 ) []testType {

--- a/engine/access/rest/websockets/data_providers/events_provider.go
+++ b/engine/access/rest/websockets/data_providers/events_provider.go
@@ -54,6 +54,11 @@ func NewEventsDataProvider(
 		heartbeatInterval: heartbeatInterval,
 	}
 
+	if p.stateStreamApi == nil {
+		logger.Debug().Msg("state stream api is nil. cannot stream events")
+		return nil, fmt.Errorf("this acess node is configured with no state stream api. cannot stream events")
+	}
+
 	// Initialize arguments passed to the provider.
 	eventArgs, err := parseEventsArguments(arguments, chain, eventFilterConfig)
 	if err != nil {

--- a/engine/access/rest/websockets/data_providers/events_provider.go
+++ b/engine/access/rest/websockets/data_providers/events_provider.go
@@ -48,15 +48,14 @@ func NewEventsDataProvider(
 	eventFilterConfig state_stream.EventFilterConfig,
 	heartbeatInterval uint64,
 ) (*EventsDataProvider, error) {
+	if stateStreamApi == nil {
+		return nil, fmt.Errorf("this access node does not support streaming events")
+	}
+
 	p := &EventsDataProvider{
 		logger:            logger.With().Str("component", "events-data-provider").Logger(),
 		stateStreamApi:    stateStreamApi,
 		heartbeatInterval: heartbeatInterval,
-	}
-
-	if p.stateStreamApi == nil {
-		logger.Debug().Msg("state stream api is nil. cannot stream events")
-		return nil, fmt.Errorf("this acess node is configured with no state stream api. cannot stream events")
 	}
 
 	// Initialize arguments passed to the provider.

--- a/engine/access/rest/websockets/data_providers/events_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/events_provider_test.go
@@ -299,6 +299,29 @@ func (s *EventsProviderSuite) TestEventsDataProvider_InvalidArguments() {
 	}
 }
 
+func (s *EventsProviderSuite) TestEventsDataProvider_StateStreamNotConfigured() {
+	ctx := context.Background()
+	send := make(chan interface{})
+
+	topic := EventsTopic
+
+	provider, err := NewEventsDataProvider(
+		ctx,
+		s.log,
+		nil,
+		"dummy-id",
+		topic,
+		models.Arguments{},
+		send,
+		s.chain,
+		state_stream.DefaultEventFilterConfig,
+		subscription.DefaultHeartbeatInterval,
+	)
+	s.Require().Nil(provider)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "cannot stream events")
+}
+
 // invalidArgumentsTestCases returns a list of test cases with invalid argument combinations
 // for testing the behavior of events data providers. Each test case includes a name,
 // a set of input arguments, and the expected error message that should be returned.

--- a/engine/access/rest/websockets/data_providers/events_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/events_provider_test.go
@@ -319,7 +319,7 @@ func (s *EventsProviderSuite) TestEventsDataProvider_StateStreamNotConfigured() 
 	)
 	s.Require().Nil(provider)
 	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "cannot stream events")
+	s.Require().Contains(err.Error(), "does not support streaming events")
 }
 
 // invalidArgumentsTestCases returns a list of test cases with invalid argument combinations


### PR DESCRIPTION
Data providers now check if state stream api is not nil. Improved error messages for clients as well.

Closes #7005 #7008 