### PR TITLE
[Access] Disable registers db pruning by default

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -293,7 +293,7 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 		versionControlEnabled:                true,
 		storeTxResultErrorMessages:           false,
 		stopControlEnabled:                   false,
-		registerDBPruneThreshold:             pruner.DefaultThreshold,
+		registerDBPruneThreshold:             0,
 	}
 }
 


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/7015
Disable the registers db pruner by default