### PR TITLE
Add feature flag for new websockets stream API

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -186,7 +186,6 @@ type AccessNodeConfig struct {
 	storeTxResultErrorMessages           bool
 	stopControlEnabled                   bool
 	registerDBPruneThreshold             uint64
-	enableWebSocketsStreamAPI            bool
 }
 
 type PublicNetworkConfig struct {

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1474,9 +1474,9 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 
 		flags.BoolVar(
 			&builder.rpcConf.EnableWebSocketsStreamAPI,
-			"enable-websockets-stream-api",
+			"experimental-enable-websockets-stream-api",
 			defaultConfig.rpcConf.EnableWebSocketsStreamAPI,
-			"enables WebSockets Stream API that operates under /ws endpoint. (it is experimental feature for now)",
+			"[experimental] enables WebSockets Stream API that operates under /ws endpoint. this flag may change in a future release.",
 		)
 	}).ValidateFlags(func() error {
 		if builder.supportsObserver && (builder.PublicNetworkConfig.BindAddress == cmd.NotSet || builder.PublicNetworkConfig.BindAddress == "") {

--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -186,6 +186,7 @@ type AccessNodeConfig struct {
 	storeTxResultErrorMessages           bool
 	stopControlEnabled                   bool
 	registerDBPruneThreshold             uint64
+	enableWebSocketsStreamAPI            bool
 }
 
 type PublicNetworkConfig struct {
@@ -232,9 +233,10 @@ func DefaultAccessNodeConfig() *AccessNodeConfig {
 				IdleTimeout:    rest.DefaultIdleTimeout,
 				MaxRequestSize: commonrest.DefaultMaxRequestSize,
 			},
-			MaxMsgSize:      grpcutils.DefaultMaxMsgSize,
-			CompressorName:  grpcutils.NoCompressor,
-			WebSocketConfig: websockets.NewDefaultWebsocketConfig(),
+			MaxMsgSize:                grpcutils.DefaultMaxMsgSize,
+			CompressorName:            grpcutils.NoCompressor,
+			WebSocketConfig:           websockets.NewDefaultWebsocketConfig(),
+			EnableWebSocketsStreamAPI: false,
 		},
 		stateStreamConf: statestreambackend.Config{
 			MaxExecutionDataMsgSize: grpcutils.DefaultMaxMsgSize,
@@ -1470,6 +1472,13 @@ func (builder *FlowAccessNodeBuilder) extraFlags() {
 			"websocket-inactivity-timeout",
 			defaultConfig.rpcConf.WebSocketConfig.InactivityTimeout,
 			"specifies the duration a WebSocket connection can remain open without any active subscriptions before being automatically closed")
+
+		flags.BoolVar(
+			&builder.rpcConf.EnableWebSocketsStreamAPI,
+			"enable-websockets-stream-api",
+			defaultConfig.rpcConf.EnableWebSocketsStreamAPI,
+			"enables WebSockets Stream API that operates under /ws endpoint. (it is experimental feature for now)",
+		)
 	}).ValidateFlags(func() error {
 		if builder.supportsObserver && (builder.PublicNetworkConfig.BindAddress == cmd.NotSet || builder.PublicNetworkConfig.BindAddress == "") {
 			return errors.New("public-network-address must be set if supports-observer is true")

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -203,9 +203,10 @@ func DefaultObserverServiceConfig() *ObserverServiceConfig {
 				IdleTimeout:    rest.DefaultIdleTimeout,
 				MaxRequestSize: commonrest.DefaultMaxRequestSize,
 			},
-			MaxMsgSize:      grpcutils.DefaultMaxMsgSize,
-			CompressorName:  grpcutils.NoCompressor,
-			WebSocketConfig: websockets.NewDefaultWebsocketConfig(),
+			MaxMsgSize:                grpcutils.DefaultMaxMsgSize,
+			CompressorName:            grpcutils.NoCompressor,
+			WebSocketConfig:           websockets.NewDefaultWebsocketConfig(),
+			EnableWebSocketsStreamAPI: false,
 		},
 		stateStreamConf: statestreambackend.Config{
 			MaxExecutionDataMsgSize: grpcutils.DefaultMaxMsgSize,
@@ -822,6 +823,13 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 			"websocket-inactivity-timeout",
 			defaultConfig.rpcConf.WebSocketConfig.InactivityTimeout,
 			"specifies the duration a WebSocket connection can remain open without any active subscriptions before being automatically closed")
+
+		flags.BoolVar(
+			&builder.rpcConf.EnableWebSocketsStreamAPI,
+			"enable-websockets-stream-api",
+			defaultConfig.rpcConf.EnableWebSocketsStreamAPI,
+			"enables WebSockets Stream API that operates under /ws endpoint. (it is experimental feature for now)",
+		)
 	}).ValidateFlags(func() error {
 		if builder.executionDataSyncEnabled {
 			if builder.executionDataConfig.FetchTimeout <= 0 {

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -826,9 +826,9 @@ func (builder *ObserverServiceBuilder) extraFlags() {
 
 		flags.BoolVar(
 			&builder.rpcConf.EnableWebSocketsStreamAPI,
-			"enable-websockets-stream-api",
+			"experimental-enable-websockets-stream-api",
 			defaultConfig.rpcConf.EnableWebSocketsStreamAPI,
-			"enables WebSockets Stream API that operates under /ws endpoint. (it is experimental feature for now)",
+			"[experimental] enables WebSockets Stream API that operates under /ws endpoint. this flag may change in a future release.",
 		)
 	}).ValidateFlags(func() error {
 		if builder.executionDataSyncEnabled {

--- a/cmd/util/cmd/run-script/cmd.go
+++ b/cmd/util/cmd/run-script/cmd.go
@@ -170,6 +170,7 @@ func run(*cobra.Command, []string) {
 			metrics.NewNoopCollector(),
 			nil,
 			backend.Config{},
+			false,
 			websockets.NewDefaultWebsocketConfig(),
 		)
 		if err != nil {

--- a/engine/access/rest/server.go
+++ b/engine/access/rest/server.go
@@ -44,6 +44,7 @@ func NewServer(serverAPI access.API,
 	restCollector module.RestMetrics,
 	stateStreamApi state_stream.API,
 	stateStreamConfig backend.Config,
+	enableNewWebsocketsStreamAPI bool,
 	wsConfig websockets.Config,
 ) (*http.Server, error) {
 	builder := router.NewRouterBuilder(logger, restCollector).AddRestRoutes(serverAPI, chain, config.MaxRequestSize)
@@ -60,7 +61,10 @@ func NewServer(serverAPI access.API,
 		stateStreamConfig.HeartbeatInterval,
 		builder.LinkGenerator,
 	)
-	builder.AddWebsocketsRoute(chain, wsConfig, config.MaxRequestSize, dataProviderFactory)
+
+	if enableNewWebsocketsStreamAPI {
+		builder.AddWebsocketsRoute(chain, wsConfig, config.MaxRequestSize, dataProviderFactory)
+	}
 
 	c := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},

--- a/engine/access/rest/websockets/controller.go
+++ b/engine/access/rest/websockets/controller.go
@@ -400,6 +400,7 @@ func (c *Controller) handleSubscribe(ctx context.Context, msg models.SubscribeMe
 	responseOk := models.SubscribeMessageResponse{
 		BaseMessageResponse: models.BaseMessageResponse{
 			SubscriptionID: subscriptionID.String(),
+			Action:         models.SubscribeAction,
 		},
 	}
 	c.writeResponse(ctx, responseOk)
@@ -451,6 +452,7 @@ func (c *Controller) handleUnsubscribe(ctx context.Context, msg models.Unsubscri
 	responseOk := models.UnsubscribeMessageResponse{
 		BaseMessageResponse: models.BaseMessageResponse{
 			SubscriptionID: subscriptionID.String(),
+			Action:         models.UnsubscribeAction,
 		},
 	}
 	c.writeResponse(ctx, responseOk)

--- a/engine/access/rpc/engine.go
+++ b/engine/access/rpc/engine.go
@@ -39,11 +39,12 @@ type Config struct {
 	CollectionAddr         string                           // the address of the upstream collection node
 	HistoricalAccessAddrs  string                           // the list of all access nodes from previous spork
 
-	BackendConfig   backend.Config // configurable options for creating Backend
-	RestConfig      rest.Config    // the REST server configuration
-	MaxMsgSize      uint           // GRPC max message size
-	CompressorName  string         // GRPC compressor name
-	WebSocketConfig websockets.Config
+	BackendConfig             backend.Config // configurable options for creating Backend
+	RestConfig                rest.Config    // the REST server configuration
+	MaxMsgSize                uint           // GRPC max message size
+	CompressorName            string         // GRPC compressor name
+	WebSocketConfig           websockets.Config
+	EnableWebSocketsStreamAPI bool
 }
 
 // Engine exposes the server with a simplified version of the Access API.
@@ -251,6 +252,7 @@ func (e *Engine) serveREST(ctx irrecoverable.SignalerContext, ready component.Re
 		e.restCollector,
 		e.stateStreamBackend,
 		e.stateStreamConfig,
+		e.config.EnableWebSocketsStreamAPI,
 		e.config.WebSocketConfig,
 	)
 	if err != nil {


### PR DESCRIPTION
Closes #7012 

Add feature flag for access and observer nodes to enable new WebSockets Stream API