### PR TITLE
Update EVM `ViewProvider` to return block `View` at its end state

### DIFF
--- a/fvm/evm/offchain/query/viewProvider.go
+++ b/fvm/evm/offchain/query/viewProvider.go
@@ -35,7 +35,14 @@ func NewViewProvider(
 
 // GetBlockView returns the block view for the given height
 func (evp *ViewProvider) GetBlockView(height uint64) (*View, error) {
-	readOnly, err := evp.storageProvider.GetSnapshotAt(height)
+	// The `GetSnapshotAt` function of `storageProvider`, will return
+	// the block state at its start, before transaction executions.
+	// This is the indented functionality, for replaying block
+	// transactions.
+	// However, when reading the state from a block, we are interested
+	// in its end state, after transaction executions.
+	// That is why we fetch the block snapshot at the next height.
+	readOnly, err := evp.storageProvider.GetSnapshotAt(height + 1)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes: https://github.com/onflow/flow-go/issues/6962