### PR TITLE
Collection node: remove unused db dependencies

### DIFF
--- a/cmd/collection/main.go
+++ b/cmd/collection/main.go
@@ -483,8 +483,6 @@ func main() {
 				node.Metrics.Engine,
 				node.Metrics.Mempool,
 				node.Me,
-				node.Storage.Collections,
-				node.Storage.Transactions,
 			)
 			return push, err
 		}).
@@ -531,7 +529,6 @@ func main() {
 				node.Metrics.Engine,
 				node.Metrics.Mempool,
 				node.State,
-				node.Storage.Transactions,
 				clusterComplianceConfig,
 			)
 			if err != nil {

--- a/engine/collection/epochmgr/factories/compliance.go
+++ b/engine/collection/epochmgr/factories/compliance.go
@@ -25,7 +25,6 @@ type ComplianceEngineFactory struct {
 	engMetrics     module.EngineMetrics
 	mempoolMetrics module.MempoolMetrics
 	protoState     protocol.State
-	transactions   storage.Transactions
 	config         modulecompliance.Config
 }
 
@@ -38,7 +37,6 @@ func NewComplianceEngineFactory(
 	engMetrics module.EngineMetrics,
 	mempoolMetrics module.MempoolMetrics,
 	protoState protocol.State,
-	transactions storage.Transactions,
 	config modulecompliance.Config,
 ) (*ComplianceEngineFactory, error) {
 
@@ -50,7 +48,6 @@ func NewComplianceEngineFactory(
 		engMetrics:     engMetrics,
 		mempoolMetrics: mempoolMetrics,
 		protoState:     protoState,
-		transactions:   transactions,
 		config:         config,
 	}
 	return factory, nil

--- a/engine/collection/pusher/engine.go
+++ b/engine/collection/pusher/engine.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/channels"
 	"github.com/onflow/flow-go/state/protocol"
-	"github.com/onflow/flow-go/storage"
 	"github.com/onflow/flow-go/utils/logging"
 )
 
@@ -28,13 +27,11 @@ import (
 // ("collection guarantees") that the cluster generates to Consensus Nodes
 // for inclusion in blocks.
 type Engine struct {
-	log          zerolog.Logger
-	engMetrics   module.EngineMetrics
-	conduit      network.Conduit
-	me           module.Local
-	state        protocol.State
-	collections  storage.Collections
-	transactions storage.Transactions
+	log        zerolog.Logger
+	engMetrics module.EngineMetrics
+	conduit    network.Conduit
+	me         module.Local
+	state      protocol.State
 
 	notifier engine.Notifier
 	queue    *fifoqueue.FifoQueue
@@ -54,8 +51,6 @@ func New(
 	engMetrics module.EngineMetrics,
 	mempoolMetrics module.MempoolMetrics,
 	me module.Local,
-	collections storage.Collections,
-	transactions storage.Transactions,
 ) (*Engine, error) {
 	queue, err := fifoqueue.NewFifoQueue(
 		200, // roughly 1 minute of collections, at 3BPS
@@ -68,12 +63,10 @@ func New(
 	}
 
 	e := &Engine{
-		log:          log.With().Str("engine", "pusher").Logger(),
-		engMetrics:   engMetrics,
-		me:           me,
-		state:        state,
-		collections:  collections,
-		transactions: transactions,
+		log:        log.With().Str("engine", "pusher").Logger(),
+		engMetrics: engMetrics,
+		me:         me,
+		state:      state,
 
 		notifier: engine.NewNotifier(),
 		queue:    queue,

--- a/engine/collection/pusher/engine_test.go
+++ b/engine/collection/pusher/engine_test.go
@@ -72,8 +72,6 @@ func (suite *Suite) SetupTest() {
 		metrics,
 		metrics,
 		suite.me,
-		suite.collections,
-		suite.transactions,
 	)
 	suite.Require().Nil(err)
 }

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -342,7 +342,6 @@ func CollectionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ro
 		node.Me,
 		node.Metrics, node.Metrics, node.Metrics,
 		node.State,
-		transactions,
 		compliance.DefaultConfig(),
 	)
 	require.NoError(t, err)

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -315,7 +315,7 @@ func CollectionNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ro
 		retrieve)
 	require.NoError(t, err)
 
-	pusherEngine, err := pusher.New(node.Log, node.Net, node.State, node.Metrics, node.Metrics, node.Me, collections, transactions)
+	pusherEngine, err := pusher.New(node.Log, node.Net, node.State, node.Metrics, node.Metrics, node.Me)
 	require.NoError(t, err)
 
 	clusterStateFactory, err := factories.NewClusterStateFactory(


### PR DESCRIPTION
Some collection node modules (pusher) depend on some unused database storage modules. This PR removes them.