### PR TITLE
[Malleability] Event

### DIFF
--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -1993,14 +1993,6 @@ func (suite *Suite) setupConnectionFactory() connection.ConnectionFactory {
 	return connFactory
 }
 
-func getEvents(n int) []flow.Event {
-	events := make([]flow.Event, n)
-	for i := range events {
-		events[i] = flow.Event{Type: flow.EventAccountCreated}
-	}
-	return events
-}
-
 func generateEncodedEvents(t *testing.T, n int) ([]flow.Event, []flow.Event) {
 	ccfEvents := generator.GetEventsWithEncoding(n, entities.EventEncodingVersion_CCF_V0)
 	jsonEvents := make([]flow.Event, n)

--- a/model/flow/event_test.go
+++ b/model/flow/event_test.go
@@ -39,24 +39,13 @@ func TestEventFingerprint(t *testing.T) {
 	assert.Equal(t, wrapEvent(evt), decoded)
 }
 
-func TestEventID(t *testing.T) {
-
-	// EventID was historically calculated from just TxID and eventIndex which are enough to uniquely identify it in a system
-	// This test ensures we don't break this promise while introducing proper fingerprinting (which accounts for all the fields)
-
+// TestEventMalleability checks that Event is not malleable: any change in its data
+// should result in a different ID.
+func TestSealMalleability(t *testing.T) {
 	txID := unittest.IdentifierFixture()
-	evtA := unittest.EventFixture(flow.EventAccountUpdated, 21, 37, txID, 2)
-	evtB := unittest.EventFixture(flow.EventAccountCreated, 0, 37, txID, 22)
+	event := unittest.EventFixture(flow.EventAccountUpdated, 21, 37, txID, 2)
 
-	evtC := unittest.EventFixture(evtA.Type, evtA.TransactionIndex, evtA.EventIndex+1, txID, 2)
-	evtC.Payload = evtA.Payload
-
-	a := evtA.ID()
-	b := evtB.ID()
-	c := evtC.ID()
-
-	assert.Equal(t, a, b)
-	assert.NotEqual(t, a, c)
+	unittest.RequireEntityNonMalleable(t, &event)
 }
 
 func TestEventsList(t *testing.T) {

--- a/utils/unittest/entity.go
+++ b/utils/unittest/entity.go
@@ -2,11 +2,11 @@ package unittest
 
 import (
 	"fmt"
-	"github.com/onflow/crypto"
 	"math/rand"
 	"reflect"
 	"testing"
 
+	"github.com/onflow/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"


### PR DESCRIPTION
Close: #6651

## Context
This pull request addresses an issue related to the malleability of the `ID()` method in `Event`. 

- The ID() method has been fixed by using `MakeID`. These changes have no impact on tests.
- Removed  `eventWrapper` because it is not necessary, as it is essentially equivalent to `Event`.
- Removed `eventIDWrapper` because it is unused after these changes.
- Removed the unused `Encode` method.
- Removed the unused `getEvents` test helper function.
- Added an extra unit test to ensure that `Event` is not malleable (replacing the existing test, which only partially verified non-malleability).

