### PR TITLE
Add function that ensures only valid arguments provided

### DIFF
--- a/engine/access/rest/websockets/data_providers/args_validation.go
+++ b/engine/access/rest/websockets/data_providers/args_validation.go
@@ -1,0 +1,19 @@
+package data_providers
+
+import (
+	"fmt"
+)
+
+func ensureAllowedFields(data map[string]interface{}, allowedFields []string) error {
+	fieldsMap := make(map[string]bool, len(allowedFields))
+	for _, field := range allowedFields {
+		fieldsMap[field] = true
+	}
+
+	for key := range data {
+		if !fieldsMap[key] {
+			return fmt.Errorf("unexpected field: '%s'", key)
+		}
+	}
+	return nil
+}

--- a/engine/access/rest/websockets/data_providers/block_digests_provider.go
+++ b/engine/access/rest/websockets/data_providers/block_digests_provider.go
@@ -39,7 +39,7 @@ func NewBlockDigestsDataProvider(
 	}
 
 	// Parse arguments passed to the provider.
-	blockArgs, err := ParseBlocksArguments(arguments)
+	blockArgs, err := parseBlocksArguments(arguments)
 	if err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}

--- a/engine/access/rest/websockets/data_providers/block_headers_provider.go
+++ b/engine/access/rest/websockets/data_providers/block_headers_provider.go
@@ -40,7 +40,7 @@ func NewBlockHeadersDataProvider(
 	}
 
 	// Parse arguments passed to the provider.
-	blockArgs, err := ParseBlocksArguments(arguments)
+	blockArgs, err := parseBlocksArguments(arguments)
 	if err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}

--- a/engine/access/rest/websockets/data_providers/blocks_provider.go
+++ b/engine/access/rest/websockets/data_providers/blocks_provider.go
@@ -54,7 +54,7 @@ func NewBlocksDataProvider(
 
 	// Parse arguments passed to the provider.
 	var err error
-	p.arguments, err = ParseBlocksArguments(arguments)
+	p.arguments, err = parseBlocksArguments(arguments)
 	if err != nil {
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
@@ -108,29 +108,39 @@ func (p *BlocksDataProvider) createSubscription(ctx context.Context, args blocks
 	return p.api.SubscribeBlocksFromLatest(ctx, args.BlockStatus)
 }
 
-// ParseBlocksArguments validates and initializes the blocks arguments.
-func ParseBlocksArguments(arguments models.Arguments) (blocksArguments, error) {
+// parseBlocksArguments validates and initializes the blocks arguments.
+func parseBlocksArguments(arguments models.Arguments) (blocksArguments, error) {
+	allowedFields := []string{
+		"start_block_id",
+		"start_block_height",
+		"block_status",
+	}
+	err := ensureAllowedFields(arguments, allowedFields)
+	if err != nil {
+		return blocksArguments{}, err
+	}
+
 	var args blocksArguments
 
 	// Parse 'block_status'
 	if blockStatusIn, ok := arguments["block_status"]; ok {
 		result, ok := blockStatusIn.(string)
 		if !ok {
-			return args, fmt.Errorf("'block_status' must be string")
+			return blocksArguments{}, fmt.Errorf("'block_status' must be string")
 		}
 		blockStatus, err := parser.ParseBlockStatus(result)
 		if err != nil {
-			return args, err
+			return blocksArguments{}, err
 		}
 		args.BlockStatus = blockStatus
 	} else {
-		return args, fmt.Errorf("'block_status' must be provided")
+		return blocksArguments{}, fmt.Errorf("'block_status' must be provided")
 	}
 
 	// Parse block arguments
-	startBlockID, startBlockHeight, err := ParseStartBlock(arguments)
+	startBlockID, startBlockHeight, err := parseStartBlock(arguments)
 	if err != nil {
-		return args, err
+		return blocksArguments{}, err
 	}
 	args.StartBlockID = startBlockID
 	args.StartBlockHeight = startBlockHeight
@@ -138,7 +148,7 @@ func ParseBlocksArguments(arguments models.Arguments) (blocksArguments, error) {
 	return args, nil
 }
 
-func ParseStartBlock(arguments models.Arguments) (flow.Identifier, uint64, error) {
+func parseStartBlock(arguments models.Arguments) (flow.Identifier, uint64, error) {
 	startBlockIDIn, hasStartBlockID := arguments["start_block_id"]
 	startBlockHeightIn, hasStartBlockHeight := arguments["start_block_height"]
 

--- a/engine/access/rest/websockets/data_providers/blocks_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/blocks_provider_test.go
@@ -217,6 +217,7 @@ func (s *BlocksProviderSuite) expectedBlockResponses(
 // 1. Missing 'block_status' argument.
 // 2. Invalid 'block_status' argument.
 // 3. Providing both 'start_block_id' and 'start_block_height' simultaneously.
+// 4. Providing unexpected argument.
 func (s *BlocksProviderSuite) TestBlocksDataProvider_InvalidArguments() {
 	ctx := context.Background()
 	send := make(chan interface{})
@@ -239,6 +240,7 @@ func (s *BlocksProviderSuite) TestBlocksDataProvider_InvalidArguments() {
 // 1. Missing the required 'block_status' argument.
 // 2. Providing an unknown or invalid 'block_status' value.
 // 3. Supplying both 'start_block_id' and 'start_block_height' simultaneously, which is not allowed.
+// 4. Providing unexpected argument.
 func (s *BlocksProviderSuite) invalidArgumentsTestCases() []testErrType {
 	return []testErrType{
 		{
@@ -263,6 +265,15 @@ func (s *BlocksProviderSuite) invalidArgumentsTestCases() []testErrType {
 				"start_block_height": fmt.Sprintf("%d", s.rootBlock.Header.Height),
 			},
 			expectedErrorMsg: "can only provide either 'start_block_id' or 'start_block_height'",
+		},
+		{
+			name: "unexpected argument",
+			arguments: map[string]interface{}{
+				"block_status":        parser.Finalized,
+				"start_block_id":      unittest.BlockFixture().ID().String(),
+				"unexpected_argument": "dummy",
+			},
+			expectedErrorMsg: "unexpected field: 'unexpected_argument'",
 		},
 	}
 }

--- a/engine/access/rest/websockets/data_providers/events_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/events_provider_test.go
@@ -330,6 +330,7 @@ func (s *EventsProviderSuite) TestEventsDataProvider_StateStreamNotConfigured() 
 // 1. Supplying both 'start_block_id' and 'start_block_height' simultaneously, which is not allowed.
 // 2. Providing invalid 'start_block_id' value.
 // 3. Providing invalid 'start_block_height' value.
+// 4. Providing unexpected argument.
 func invalidArgumentsTestCases() []testErrType {
 	return []testErrType{
 		{
@@ -353,6 +354,14 @@ func invalidArgumentsTestCases() []testErrType {
 				"start_block_height": "-1",
 			},
 			expectedErrorMsg: "value must be an unsigned 64 bit integer",
+		},
+		{
+			name: "unexpected argument",
+			arguments: map[string]interface{}{
+				"start_block_id":      unittest.BlockFixture().ID().String(),
+				"unexpected_argument": "dummy",
+			},
+			expectedErrorMsg: "unexpected field: 'unexpected_argument'",
 		},
 	}
 }

--- a/engine/access/rest/websockets/data_providers/send_and_get_transaction_statuses_provider.go
+++ b/engine/access/rest/websockets/data_providers/send_and_get_transaction_statuses_provider.go
@@ -117,18 +117,34 @@ func (p *SendAndGetTransactionStatusesDataProvider) handleResponse() func(txResu
 func parseSendAndGetTransactionStatusesArguments(
 	arguments models.Arguments,
 ) (sendAndGetTransactionStatusesArguments, error) {
+	allowedFields := []string{
+		"reference_block_id",
+		"script",
+		"arguments",
+		"gas_limit",
+		"payer",
+		"proposal_key",
+		"authorizers",
+		"payload_signatures",
+		"envelope_signatures",
+	}
+	err := ensureAllowedFields(arguments, allowedFields)
+	if err != nil {
+		return sendAndGetTransactionStatusesArguments{}, err
+	}
+
 	var args sendAndGetTransactionStatusesArguments
 	var tx flow.TransactionBody
 
 	if scriptIn, ok := arguments["script"]; ok && scriptIn != "" {
 		result, ok := scriptIn.(string)
 		if !ok {
-			return args, fmt.Errorf("'script' must be a string")
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("'script' must be a string")
 		}
 
 		script, err := util.FromBase64(result)
 		if err != nil {
-			return args, fmt.Errorf("invalid 'script': %w", err)
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("invalid 'script': %w", err)
 		}
 
 		tx.Script = script
@@ -137,14 +153,14 @@ func parseSendAndGetTransactionStatusesArguments(
 	if argumentsIn, ok := arguments["arguments"]; ok && argumentsIn != "" {
 		result, ok := argumentsIn.([]string)
 		if !ok {
-			return args, fmt.Errorf("'arguments' must be a []string type")
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("'arguments' must be a []string type")
 		}
 
 		var argumentsData [][]byte
 		for _, arg := range result {
 			argument, err := util.FromBase64(arg)
 			if err != nil {
-				return args, fmt.Errorf("invalid 'arguments': %w", err)
+				return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("invalid 'arguments': %w", err)
 			}
 
 			argumentsData = append(argumentsData, argument)
@@ -156,13 +172,13 @@ func parseSendAndGetTransactionStatusesArguments(
 	if referenceBlockIDIn, ok := arguments["reference_block_id"]; ok && referenceBlockIDIn != "" {
 		result, ok := referenceBlockIDIn.(string)
 		if !ok {
-			return args, fmt.Errorf("'reference_block_id' must be a string")
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("'reference_block_id' must be a string")
 		}
 
 		var referenceBlockID parser.ID
 		err := referenceBlockID.Parse(result)
 		if err != nil {
-			return args, fmt.Errorf("invalid 'reference_block_id': %w", err)
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("invalid 'reference_block_id': %w", err)
 		}
 
 		tx.ReferenceBlockID = referenceBlockID.Flow()
@@ -171,12 +187,12 @@ func parseSendAndGetTransactionStatusesArguments(
 	if gasLimitIn, ok := arguments["gas_limit"]; ok && gasLimitIn != "" {
 		result, ok := gasLimitIn.(string)
 		if !ok {
-			return args, fmt.Errorf("'gas_limit' must be a string")
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("'gas_limit' must be a string")
 		}
 
 		gasLimit, err := util.ToUint64(result)
 		if err != nil {
-			return args, fmt.Errorf("invalid 'gas_limit': %w", err)
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("invalid 'gas_limit': %w", err)
 		}
 		tx.GasLimit = gasLimit
 	}
@@ -184,12 +200,12 @@ func parseSendAndGetTransactionStatusesArguments(
 	if payerIn, ok := arguments["payer"]; ok && payerIn != "" {
 		result, ok := payerIn.(string)
 		if !ok {
-			return args, fmt.Errorf("'payerIn' must be a string")
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("'payerIn' must be a string")
 		}
 
 		payerAddr, err := flow.StringToAddress(result)
 		if err != nil {
-			return args, fmt.Errorf("invalid 'payer': %w", err)
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("invalid 'payer': %w", err)
 		}
 		tx.Payer = payerAddr
 	}
@@ -197,7 +213,8 @@ func parseSendAndGetTransactionStatusesArguments(
 	if proposalKeyIn, ok := arguments["proposal_key"]; ok && proposalKeyIn != "" {
 		proposalKey, ok := proposalKeyIn.(flow.ProposalKey)
 		if !ok {
-			return args, fmt.Errorf("'proposal_key' must be a object (ProposalKey)")
+			return sendAndGetTransactionStatusesArguments{},
+				fmt.Errorf("'proposal_key' must be a object (ProposalKey)")
 		}
 
 		tx.ProposalKey = proposalKey
@@ -206,14 +223,14 @@ func parseSendAndGetTransactionStatusesArguments(
 	if authorizersIn, ok := arguments["authorizers"]; ok && authorizersIn != "" {
 		result, ok := authorizersIn.([]string)
 		if !ok {
-			return args, fmt.Errorf("'authorizers' must be a []string type")
+			return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("'authorizers' must be a []string type")
 		}
 
 		var authorizersData []flow.Address
 		for _, auth := range result {
 			authorizer, err := flow.StringToAddress(auth)
 			if err != nil {
-				return args, fmt.Errorf("invalid 'authorizers': %w", err)
+				return sendAndGetTransactionStatusesArguments{}, fmt.Errorf("invalid 'authorizers': %w", err)
 			}
 
 			authorizersData = append(authorizersData, authorizer)
@@ -225,7 +242,8 @@ func parseSendAndGetTransactionStatusesArguments(
 	if payloadSignaturesIn, ok := arguments["payload_signatures"]; ok && payloadSignaturesIn != "" {
 		payloadSignatures, ok := payloadSignaturesIn.([]flow.TransactionSignature)
 		if !ok {
-			return args, fmt.Errorf("'payload_signatures' must be an array of objects (TransactionSignature)")
+			return sendAndGetTransactionStatusesArguments{},
+				fmt.Errorf("'payload_signatures' must be an array of objects (TransactionSignature)")
 		}
 
 		tx.PayloadSignatures = payloadSignatures
@@ -234,7 +252,8 @@ func parseSendAndGetTransactionStatusesArguments(
 	if envelopeSignaturesIn, ok := arguments["envelope_signatures"]; ok && envelopeSignaturesIn != "" {
 		envelopeSignatures, ok := envelopeSignaturesIn.([]flow.TransactionSignature)
 		if !ok {
-			return args, fmt.Errorf("'envelope_signatures' must be an array of objects (TransactionSignature)")
+			return sendAndGetTransactionStatusesArguments{},
+				fmt.Errorf("'envelope_signatures' must be an array of objects (TransactionSignature)")
 		}
 
 		tx.EnvelopeSignatures = envelopeSignatures

--- a/engine/access/rest/websockets/data_providers/send_and_get_transaction_statuses_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/send_and_get_transaction_statuses_provider_test.go
@@ -79,7 +79,7 @@ func (s *TransactionStatusesProviderSuite) TestSendTransactionStatusesDataProvid
 		{
 			name: "SubscribeTransactionStatusesFromStartBlockID happy path",
 			arguments: models.Arguments{
-				"start_block_id": s.rootBlock.ID().String(),
+				"reference_block_id": s.rootBlock.ID().String(),
 			},
 			setupBackend: func(sub *ssmock.Subscription) {
 				s.api.On(
@@ -162,6 +162,7 @@ func (s *SendTransactionStatusesProviderSuite) TestSendTransactionStatusesDataPr
 // 9. Providing invalid 'authorizers' value.
 // 10. Providing invalid 'payload_signatures' value.
 // 11. Providing invalid 'envelope_signatures' value.
+// 12. Providing unexpected argument.
 func invalidSendTransactionStatusesArgumentsTestCases() []testErrType {
 	return []testErrType{
 		{
@@ -240,6 +241,13 @@ func invalidSendTransactionStatusesArgumentsTestCases() []testErrType {
 				"envelope_signatures": "invalid TransactionSignature array",
 			},
 			expectedErrorMsg: "'envelope_signatures' must be an array of objects (TransactionSignature)",
+		},
+		{
+			name: "unexpected argument",
+			arguments: map[string]interface{}{
+				"unexpected_argument": "dummy",
+			},
+			expectedErrorMsg: "unexpected field: 'unexpected_argument'",
 		},
 	}
 }

--- a/engine/access/rest/websockets/data_providers/transaction_statuses_provider.go
+++ b/engine/access/rest/websockets/data_providers/transaction_statuses_provider.go
@@ -128,12 +128,22 @@ func (p *TransactionStatusesDataProvider) handleResponse() func(txResults []*acc
 func parseTransactionStatusesArguments(
 	arguments models.Arguments,
 ) (transactionStatusesArguments, error) {
+	allowedFields := []string{
+		"start_block_id",
+		"start_block_height",
+		"tx_id",
+	}
+	err := ensureAllowedFields(arguments, allowedFields)
+	if err != nil {
+		return transactionStatusesArguments{}, err
+	}
+
 	var args transactionStatusesArguments
 
 	// Parse block arguments
-	startBlockID, startBlockHeight, err := ParseStartBlock(arguments)
+	startBlockID, startBlockHeight, err := parseStartBlock(arguments)
 	if err != nil {
-		return args, err
+		return transactionStatusesArguments{}, err
 	}
 	args.StartBlockID = startBlockID
 	args.StartBlockHeight = startBlockHeight
@@ -141,12 +151,12 @@ func parseTransactionStatusesArguments(
 	if txIDIn, ok := arguments["tx_id"]; ok && txIDIn != "" {
 		result, ok := txIDIn.(string)
 		if !ok {
-			return args, fmt.Errorf("'tx_id' must be a string")
+			return transactionStatusesArguments{}, fmt.Errorf("'tx_id' must be a string")
 		}
 		var txID parser.ID
 		err := txID.Parse(result)
 		if err != nil {
-			return args, fmt.Errorf("invalid 'tx_id': %w", err)
+			return transactionStatusesArguments{}, fmt.Errorf("invalid 'tx_id': %w", err)
 		}
 		args.TxID = txID.Flow()
 	}

--- a/engine/access/rest/websockets/data_providers/transaction_statuses_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/transaction_statuses_provider_test.go
@@ -333,6 +333,7 @@ func (s *TransactionStatusesProviderSuite) TestTransactionStatusesDataProvider_I
 // 2. Providing invalid 'tx_id' value.
 // 3. Providing invalid 'start_block_id'  value.
 // 4. Invalid 'start_block_id' argument.
+// 5. Providing unexpected argument.
 func invalidTransactionStatusesArgumentsTestCases() []testErrType {
 	return []testErrType{
 		{
@@ -363,6 +364,14 @@ func invalidTransactionStatusesArgumentsTestCases() []testErrType {
 				"start_block_height": "-1",
 			},
 			expectedErrorMsg: "value must be an unsigned 64 bit integer",
+		},
+		{
+			name: "unexpected argument",
+			arguments: map[string]interface{}{
+				"start_block_id":      unittest.BlockFixture().ID().String(),
+				"unexpected_argument": "dummy",
+			},
+			expectedErrorMsg: "unexpected field: 'unexpected_argument'",
 		},
 	}
 }


### PR DESCRIPTION
Closes #7066 

Previously, clients could provide arbitrary arguments alongside valid ones. I added a function to prevent them from doing so. Appropriate tests have been updated too to catch this behavior