### PR TITLE
Adjust upper bound of Cruise Control for test networks

### DIFF
--- a/integration/benchnet2/automate/templates/helm-values-all-nodes.yml
+++ b/integration/benchnet2/automate/templates/helm-values-all-nodes.yml
@@ -68,6 +68,7 @@ consensus:
       args:{{template "args" .}}
         - --loglevel=DEBUG
         - --block-rate-delay=800ms
+        - --cruise-ctl-max-view-duration=2s
         - --chunk-alpha=1
         - --emergency-sealing-active=false
         - --insecure-access-api=false

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -12,7 +12,6 @@ EPOCHLEN=10000                  # 0 means use default
 STAKINGLEN=2000                 # 0 means use default
 DKGLEN=2000                     # 0 means use default
 FINALIZATIONSAFETYTHRESHOLD=1000 # 0 means use default
-CONSENSUS_DELAY=800ms
 COLLECTION_DELAY=950ms
 
 PROFILER=false
@@ -71,7 +70,6 @@ else
 		-tracing=$(TRACING) \
 		-cadence-tracing=$(CADENCE_TRACING) \
 		-extensive-tracing=$(EXTENSIVE_TRACING) \
-		-consensus-delay=$(CONSENSUS_DELAY) \
 		-collection-delay=$(COLLECTION_DELAY)
 endif
 

--- a/integration/localnet/Makefile
+++ b/integration/localnet/Makefile
@@ -12,6 +12,7 @@ EPOCHLEN=10000                  # 0 means use default
 STAKINGLEN=2000                 # 0 means use default
 DKGLEN=2000                     # 0 means use default
 FINALIZATIONSAFETYTHRESHOLD=1000 # 0 means use default
+CONSENSUS_DELAY=800ms
 COLLECTION_DELAY=950ms
 
 PROFILER=false
@@ -70,6 +71,7 @@ else
 		-tracing=$(TRACING) \
 		-cadence-tracing=$(CADENCE_TRACING) \
 		-extensive-tracing=$(EXTENSIVE_TRACING) \
+		-consensus-delay=$(CONSENSUS_DELAY) \
 		-collection-delay=$(COLLECTION_DELAY)
 endif
 

--- a/integration/localnet/builder/bootstrap.go
+++ b/integration/localnet/builder/bootstrap.go
@@ -47,7 +47,6 @@ const (
 	DefaultTracing            = true
 	DefaultCadenceTracing     = false
 	DefaultExtensiveTracing   = false
-	DefaultConsensusDelay     = 800 * time.Millisecond
 	DefaultCollectionDelay    = 950 * time.Millisecond
 )
 
@@ -69,8 +68,7 @@ var (
 	profileUploader             bool
 	tracing                     bool
 	cadenceTracing              bool
-	extesiveTracing             bool
-	consensusDelay              time.Duration
+	extensiveTracing            bool
 	collectionDelay             time.Duration
 	logLevel                    string
 
@@ -95,8 +93,7 @@ func init() {
 	flag.BoolVar(&profileUploader, "profile-uploader", DefaultProfileUploader, "whether to upload profiles to the cloud")
 	flag.BoolVar(&tracing, "tracing", DefaultTracing, "whether to enable low-overhead tracing in flow")
 	flag.BoolVar(&cadenceTracing, "cadence-tracing", DefaultCadenceTracing, "whether to enable the tracing in cadance")
-	flag.BoolVar(&extesiveTracing, "extensive-tracing", DefaultExtensiveTracing, "enables high-overhead tracing in fvm")
-	flag.DurationVar(&consensusDelay, "consensus-delay", DefaultConsensusDelay, "delay on consensus node block proposals")
+	flag.BoolVar(&extensiveTracing, "extensive-tracing", DefaultExtensiveTracing, "enables high-overhead tracing in fvm")
 	flag.DurationVar(&collectionDelay, "collection-delay", DefaultCollectionDelay, "delay on collection node block proposals")
 	flag.StringVar(&logLevel, "loglevel", DefaultLogLevel, "log level for all nodes")
 }
@@ -348,10 +345,8 @@ func prepareService(container testnet.ContainerConfig, i int, n int) Service {
 func prepareConsensusService(container testnet.ContainerConfig, i int, n int) Service {
 	service := prepareService(container, i, n)
 
-	timeout := 1200*time.Millisecond + consensusDelay
 	service.Command = append(service.Command,
-		fmt.Sprintf("--cruise-ctl-fallback-proposal-duration=%s", consensusDelay),
-		fmt.Sprintf("--hotstuff-min-timeout=%s", timeout),
+		"--cruise-ctl-max-view-duration=2s",
 		"--chunk-alpha=1",
 		"--emergency-sealing-active=false",
 		"--insecure-access-api=false",
@@ -400,7 +395,7 @@ func prepareExecutionService(container testnet.ContainerConfig, i int, n int) Se
 		"--triedir=/trie",
 		fmt.Sprintf("--rpc-addr=%s:%s", container.ContainerName, testnet.GRPCPort),
 		fmt.Sprintf("--cadence-tracing=%t", cadenceTracing),
-		fmt.Sprintf("--extensive-tracing=%t", extesiveTracing),
+		fmt.Sprintf("--extensive-tracing=%t", extensiveTracing),
 		"--execution-data-dir=/data/execution-data",
 		"--chunk-data-pack-dir=/data/chunk-data-pack",
 		"--pruning-config-threshold=20",

--- a/integration/testnet/network.go
+++ b/integration/testnet/network.go
@@ -650,6 +650,11 @@ func PrepareFlowNetwork(t *testing.T, networkConf NetworkConfig, chainID flow.Ch
 			nodeContainer.AddFlag("insecure-access-api", "false")
 			nodeContainer.AddFlag("access-node-ids", strings.Join(accessNodeIDS, ","))
 		}
+		// Increase the maximum view duration to accommodate the default Localnet block rate of 1bps
+		if nodeConf.Role == flow.RoleConsensus {
+			nodeContainer := flowNetwork.Containers[nodeConf.ContainerName]
+			nodeContainer.AddFlag("cruise-ctl-max-view-duration", "2s")
+		}
 	}
 
 	for i, observerConf := range networkConf.Observers {


### PR DESCRIPTION
The default block rate for transient networks is 1bps, but Cruise Control defaults to a maximum view duration of 910ms (desired default for Mainnet). This causes Cruise Control to prevent the network from operating within the target timing and accumulate error between actual wall-clock time and target timing. 

This PR adjusts the config for Localnet and Benchnet so that Cruise Control can operate within the 1bps timing.