### PR TITLE
[Malleability] test for Vote, ResultApprovalBody

### DIFF
--- a/consensus/hotstuff/model/vote_test.go
+++ b/consensus/hotstuff/model/vote_test.go
@@ -1,0 +1,11 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestVoteNonMalleable(t *testing.T) {
+	unittest.RequireEntityNonMalleable(t, unittest.VoteFixture())
+}

--- a/model/flow/resultApproval_test.go
+++ b/model/flow/resultApproval_test.go
@@ -14,3 +14,8 @@ func TestResultApprovalEncode(t *testing.T) {
 	id := ra.ID()
 	assert.NotEqual(t, flow.ZeroID, id)
 }
+
+func TestResultApprovalBodyNonMalleable(t *testing.T) {
+	ra := unittest.ResultApprovalFixture()
+	unittest.RequireEntityNonMalleable(t, &ra.Body)
+}


### PR DESCRIPTION
Add simple unittests to verify `Vote` and `ResultApprovalBody` are not malleable.

Closes: #6692 
Closes: #6658 