### PR TITLE
[Executino] Chunk data pack pruning config fix

### DIFF
--- a/engine/execution/pruner/core.go
+++ b/engine/execution/pruner/core.go
@@ -61,6 +61,10 @@ func LoopPruneExecutionDataFromRootToLatestSealed(
 			return fmt.Errorf("failed to get next and latest to prune: %w", err)
 		}
 
+		// report the target pruned height and pruned height
+		metrics.ExecutionTargetChunkDataPackPrunedHeight(latestToPrune)
+		metrics.ExecutionLastChunkDataPackPrunedHeight(nextToPrune - 1)
+
 		commitDuration := 2 * time.Millisecond // with default batch size 1200, the avg commit duration is 2ms
 		batchCount, totalDuration := EstimateBatchProcessing(
 			nextToPrune, latestToPrune,
@@ -76,9 +80,6 @@ func LoopPruneExecutionDataFromRootToLatestSealed(
 				time.Now().Add(config.SleepAfterEachIteration).UTC(),
 				time.Now().Add(config.SleepAfterEachIteration).Add(totalDuration).UTC(),
 			)
-
-		// report the target pruned height
-		metrics.ExecutionTargetChunkDataPackPrunedHeight(latestToPrune)
 
 		select {
 		case <-ctx.Done():

--- a/module/block_iterator/state.go
+++ b/module/block_iterator/state.go
@@ -55,9 +55,12 @@ func (n *PersistentIteratorState) NextRange() (rg module.IteratorRange, hasNext 
 		return module.IteratorRange{}, false, nil
 	}
 
-	// latest could be less than next, if the pruning-threshold was increased, which means
-	// we would like to keep more data than before.
-	// in this case, we should not iterate any block.
+	// latest might go backwards if user updated some parameters that controls that.
+	// for instance, if the user uses block iterator to prune data by height, and then updated
+	// the threshold to retain more data, which makes the latest block to go backwards.
+	//
+	// in that case, we need to respect the latest block and return an empty iteration range, so
+	// that we ensure that the block iteration is always forward.
 	if latest < next {
 		return module.IteratorRange{}, false, nil
 	}

--- a/module/block_iterator/state.go
+++ b/module/block_iterator/state.go
@@ -55,8 +55,11 @@ func (n *PersistentIteratorState) NextRange() (rg module.IteratorRange, hasNext 
 		return module.IteratorRange{}, false, nil
 	}
 
+	// latest could be less than next, if the pruning-threshold was increased, which means
+	// we would like to keep more data than before.
+	// in this case, we should not iterate any block.
 	if latest < next {
-		return module.IteratorRange{}, false, fmt.Errorf("latest block is less than next block: %d < %d", latest, next)
+		return module.IteratorRange{}, false, nil
 	}
 
 	// iterate from next to latest (inclusive)

--- a/module/block_iterator/state_test.go
+++ b/module/block_iterator/state_test.go
@@ -67,5 +67,14 @@ func TestProgress(t *testing.T) {
 		rg, hasNext, err = progress.NextRange()
 		require.NoError(t, err)
 		require.False(t, hasNext)
+
+		// now initialize again with a different latest that which cause latest < next
+		// verify there will be no block to iterate
+		initializer = store.NewConsumerProgress(pebbleimpl.ToDB(db), "test")
+		progress, err = NewPersistentIteratorState(initializer, root, getLatest)
+		require.NoError(t, err)
+		_, hasNext, err = progress.NextRange()
+		require.NoError(t, err)
+		require.False(t, hasNext) // has no block to iterate
 	})
 }


### PR DESCRIPTION
This PR fixes two issues:
1. When I increase the threshold to retain more chunk data packs, it run into a fatal error, saying the latest is less than next block. 
```
{"level":"fatal",..."error":"failed to create block iterator: failed to create range for block iteration: latest block is less than next block: 242742568 < 245752965","time":"2025-03-03T20:40:39.583143782Z","message":"unhandled irrecoverable error"}
```
This is resolved by allowing the latest to go backward and even blow the next block to iterate.

2. Report the pruning related metrics on startup, so that the metrics won't report as 0, which causes the dashboard showing some confusing spikes.