### PR TITLE
Revert "[Malleability] Update Backend to work with generic BackData."

### DIFF
--- a/module/mempool/common.go
+++ b/module/mempool/common.go
@@ -1,6 +1,8 @@
 package mempool
 
+import "github.com/onflow/flow-go/model/flow"
+
 // OnEjection is a callback which a mempool executes on ejecting
 // one of its elements. The callbacks are executed from within the thread
 // that serves the mempool. Implementations should be non-blocking.
-type OnEjection[V any] func(V)
+type OnEjection func(flow.Entity)

--- a/module/mempool/stdmap/backend_test.go
+++ b/module/mempool/stdmap/backend_test.go
@@ -24,10 +24,10 @@ func TestAddRemove(t *testing.T) {
 	item2 := unittest.MockEntityFixture()
 
 	t.Run("should be able to add and rem", func(t *testing.T) {
-		pool := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity]()
-		added := pool.Add(item1.ID(), item1)
+		pool := stdmap.NewBackend()
+		added := pool.Add(item1)
 		require.True(t, added)
-		added = pool.Add(item2.ID(), item2)
+		added = pool.Add(item2)
 		require.True(t, added)
 
 		t.Run("should be able to get size", func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestAddRemove(t *testing.T) {
 		})
 
 		t.Run("should be able to get first", func(t *testing.T) {
-			gotItem, exists := pool.Get(item1.ID())
+			gotItem, exists := pool.ByID(item1.ID())
 			assert.True(t, exists)
 			assert.Equal(t, item1, gotItem)
 		})
@@ -61,26 +61,26 @@ func TestAdjust(t *testing.T) {
 	item2 := unittest.MockEntityFixture()
 
 	t.Run("should not adjust if not exist", func(t *testing.T) {
-		pool := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity]()
-		_ = pool.Add(item1.ID(), item1)
+		pool := stdmap.NewBackend()
+		_ = pool.Add(item1)
 
 		// item2 doesn't exist
-		updatedItem, updated := pool.Adjust(item2.ID(), func(old *unittest.MockEntity) *unittest.MockEntity {
+		updatedItem, updated := pool.Adjust(item2.ID(), func(old flow.Entity) flow.Entity {
 			return item2
 		})
 
 		assert.False(t, updated)
 		assert.Nil(t, updatedItem)
 
-		_, found := pool.Get(item2.ID())
+		_, found := pool.ByID(item2.ID())
 		assert.False(t, found)
 	})
 
 	t.Run("should adjust if exists", func(t *testing.T) {
-		pool := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity]()
-		_ = pool.Add(item1.ID(), item1)
+		pool := stdmap.NewBackend()
+		_ = pool.Add(item1)
 
-		updatedItem, ok := pool.Adjust(item1.ID(), func(old *unittest.MockEntity) *unittest.MockEntity {
+		updatedItem, ok := pool.Adjust(item1.ID(), func(old flow.Entity) flow.Entity {
 			// item 1 exist, got replaced with item2, the value was updated
 			return item2
 		})
@@ -88,7 +88,7 @@ func TestAdjust(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, updatedItem, item2)
 
-		value2, found := pool.Get(item2.ID())
+		value2, found := pool.ByID(item2.ID())
 		assert.True(t, found)
 		assert.Equal(t, value2, item2)
 	})
@@ -100,9 +100,9 @@ func Test_DeduplicationByID(t *testing.T) {
 	item2 := unittest.MockEntity{Identifier: item1.Identifier} // duplicate
 	assert.True(t, item1.ID() == item2.ID())
 
-	pool := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity]()
-	pool.Add(item1.ID(), item1)
-	pool.Add(item2.ID(), item1)
+	pool := stdmap.NewBackend()
+	pool.Add(item1)
+	pool.Add(item2)
 	assert.Equal(t, uint(1), pool.Size())
 }
 
@@ -115,7 +115,7 @@ func TestBackend_RunLimitChecking(t *testing.T) {
 		limit = 150
 		swarm = 150
 	)
-	pool := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity](stdmap.WithLimit[flow.Identifier, *unittest.MockEntity](limit))
+	pool := stdmap.NewBackend(stdmap.WithLimit(limit))
 
 	wg := sync.WaitGroup{}
 	wg.Add(swarm)
@@ -124,7 +124,7 @@ func TestBackend_RunLimitChecking(t *testing.T) {
 		go func(x int) {
 			// creates and adds a fake item to the mempool
 			item := unittest.MockEntityFixture()
-			_ = pool.Run(func(backdata mempool.BackData[flow.Identifier, *unittest.MockEntity]) error {
+			_ = pool.Run(func(backdata mempool.BackData) error {
 				added := backdata.Add(item.ID(), item)
 				if !added {
 					return fmt.Errorf("potential race condition on adding to back data")
@@ -150,13 +150,13 @@ func TestBackend_RegisterEjectionCallback(t *testing.T) {
 		limit = 20
 		swarm = 20
 	)
-	pool := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity](stdmap.WithLimit[flow.Identifier, *unittest.MockEntity](limit))
+	pool := stdmap.NewBackend(stdmap.WithLimit(limit))
 
 	// on ejection callback: test whether ejected identity is no longer part of the mempool
-	ensureEntityNotInMempool := func(entity *unittest.MockEntity) {
+	ensureEntityNotInMempool := func(entity flow.Entity) {
 		id := entity.ID()
 		go func() {
-			e, found := pool.Get(id)
+			e, found := pool.ByID(id)
 			require.False(t, found)
 			require.Nil(t, e)
 		}()
@@ -172,7 +172,7 @@ func TestBackend_RegisterEjectionCallback(t *testing.T) {
 		go func(x int) {
 			// creates and adds a fake item to the mempool
 			item := unittest.MockEntityFixture()
-			pool.Add(item.ID(), item)
+			pool.Add(item)
 			wg.Done()
 		}(i)
 	}
@@ -186,7 +186,7 @@ func TestBackend_RegisterEjectionCallback(t *testing.T) {
 func TestBackend_Multiple_OnEjectionCallbacks(t *testing.T) {
 	// ejection callback counts number of calls
 	calls := uint64(0)
-	callback := func(entity *unittest.MockEntity) {
+	callback := func(entity flow.Entity) {
 		atomic.AddUint64(&calls, 1)
 	}
 
@@ -194,7 +194,7 @@ func TestBackend_Multiple_OnEjectionCallbacks(t *testing.T) {
 	const (
 		limit = 30
 	)
-	pool := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity](stdmap.WithLimit[flow.Identifier, *unittest.MockEntity](limit))
+	pool := stdmap.NewBackend(stdmap.WithLimit(limit))
 	pool.RegisterEjectionCallbacks(callback, callback)
 
 	t.Run("fill mempool up to limit", func(t *testing.T) {
@@ -228,7 +228,7 @@ func TestBackend_AdjustWithInit_Concurrent_HeroCache(t *testing.T) {
 		unittest.Logger(),
 		metrics.NewNoopCollector())
 
-	backend := stdmap.NewBackend(stdmap.WithMutableBackData[flow.Identifier, *unittest.MockEntity](backData))
+	backend := stdmap.NewBackend(stdmap.WithMutableBackData(backData))
 	entities := unittest.EntityListFixture(100)
 	adjustDone := sync.WaitGroup{}
 	for _, e := range entities {
@@ -237,11 +237,13 @@ func TestBackend_AdjustWithInit_Concurrent_HeroCache(t *testing.T) {
 		go func() {
 			defer adjustDone.Done()
 
-			backend.AdjustWithInit(e.ID(), func(entity *unittest.MockEntity) *unittest.MockEntity {
+			backend.AdjustWithInit(e.ID(), func(entity flow.Entity) flow.Entity {
 				// increment nonce of the entity
-				entity.Nonce++
+				mockEntity, ok := entity.(*unittest.MockEntity)
+				require.True(t, ok)
+				mockEntity.Nonce++
 				return entity
-			}, func() *unittest.MockEntity {
+			}, func() flow.Entity {
 				return e
 			})
 		}()
@@ -250,10 +252,10 @@ func TestBackend_AdjustWithInit_Concurrent_HeroCache(t *testing.T) {
 	unittest.RequireReturnsBefore(t, adjustDone.Wait, 1*time.Second, "failed to adjust elements in time")
 
 	for _, e := range entities {
-		actual, ok := backend.Get(e.ID())
+		actual, ok := backend.ByID(e.ID())
 		require.True(t, ok)
 		require.Equal(t, e.ID(), actual.ID())
-		require.Equal(t, uint64(1), actual.Nonce)
+		require.Equal(t, uint64(1), actual.(*unittest.MockEntity).Nonce)
 	}
 }
 
@@ -261,7 +263,7 @@ func TestBackend_AdjustWithInit_Concurrent_HeroCache(t *testing.T) {
 // It concurrently attempts on adjusting non-existent entities, and verifies that the entities are initialized and adjusted correctly.
 func TestBackend_AdjustWithInit_Concurrent_MapBased(t *testing.T) {
 	sizeLimit := uint(100)
-	backend := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity](stdmap.WithLimit[flow.Identifier, *unittest.MockEntity](sizeLimit))
+	backend := stdmap.NewBackend(stdmap.WithLimit(sizeLimit))
 	entities := unittest.EntityListFixture(sizeLimit)
 
 	adjustDone := sync.WaitGroup{}
@@ -271,11 +273,13 @@ func TestBackend_AdjustWithInit_Concurrent_MapBased(t *testing.T) {
 		go func() {
 			defer adjustDone.Done()
 
-			backend.AdjustWithInit(e.ID(), func(entity *unittest.MockEntity) *unittest.MockEntity {
+			backend.AdjustWithInit(e.ID(), func(entity flow.Entity) flow.Entity {
 				// increment nonce of the entity
-				entity.Nonce++
+				mockEntity, ok := entity.(*unittest.MockEntity)
+				require.True(t, ok)
+				mockEntity.Nonce++
 				return entity
-			}, func() *unittest.MockEntity {
+			}, func() flow.Entity {
 				return e
 			})
 		}()
@@ -284,42 +288,41 @@ func TestBackend_AdjustWithInit_Concurrent_MapBased(t *testing.T) {
 	unittest.RequireReturnsBefore(t, adjustDone.Wait, 1*time.Second, "failed to adjust elements in time")
 
 	for _, e := range entities {
-		actual, ok := backend.Get(e.ID())
+		actual, ok := backend.ByID(e.ID())
 		require.True(t, ok)
 		require.Equal(t, e.ID(), actual.ID())
-		require.Equal(t, uint64(1), actual.Nonce)
+		require.Equal(t, uint64(1), actual.(*unittest.MockEntity).Nonce)
 	}
 }
 
-func addRandomEntities(t *testing.T, backend *stdmap.Backend[flow.Identifier, *unittest.MockEntity], num int) {
-
+func addRandomEntities(t *testing.T, backend *stdmap.Backend, num int) {
 	// add swarm-number of items to backend
 	wg := sync.WaitGroup{}
 	wg.Add(num)
 	for ; num > 0; num-- {
 		go func() {
 			defer wg.Done()
-			backend.Add(unittest.IdentifierFixture(), unittest.MockEntityFixture()) // creates and adds a fake item to the mempool
+			backend.Add(unittest.MockEntityFixture()) // creates and adds a fake item to the mempool
 		}()
 	}
 	unittest.RequireReturnsBefore(t, wg.Wait, 1*time.Second, "failed to add elements in time")
 }
 
 func TestBackend_All(t *testing.T) {
-	backend := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity]()
+	backend := stdmap.NewBackend()
 	entities := unittest.EntityListFixture(100)
 
 	// Add
 	for _, e := range entities {
 		// all entities must be stored successfully
-		require.True(t, backend.Add(e.ID(), e))
+		require.True(t, backend.Add(e))
 	}
 
 	// All
 	all := backend.All()
 	require.Equal(t, len(entities), len(all))
 	for _, expected := range entities {
-		actual, ok := backend.Get(expected.ID())
+		actual, ok := backend.ByID(expected.ID())
 		require.True(t, ok)
 		require.Equal(t, expected, actual)
 	}

--- a/module/mempool/stdmap/eject.go
+++ b/module/mempool/stdmap/eject.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/rand"
 )
 
@@ -29,13 +30,13 @@ const overCapacityThreshold = 128
 //     concurrency (specifically, it locks the mempool during ejection).
 //   - The implementation should be non-blocking (though, it is allowed to
 //     take a bit of time; the mempool will just be locked during this time).
-type BatchEjectFunc[K comparable, V any] func(b *Backend[K, V]) (bool, error)
-type EjectFunc[K comparable, V any] func(b *Backend[K, V]) (K, V, bool)
+type BatchEjectFunc func(b *Backend) (bool, error)
+type EjectFunc func(b *Backend) (flow.Identifier, flow.Entity, bool)
 
 // EjectRandomFast checks if the map size is beyond the
 // threshold size, and will iterate through them and eject unneeded
 // entries if that is the case.  Return values are unused
-func EjectRandomFast[K comparable, V any](b *Backend[K, V]) (bool, error) {
+func EjectRandomFast(b *Backend) (bool, error) {
 	currentSize := b.mutableBackData.Size()
 
 	if b.guaranteedCapacity >= currentSize {
@@ -65,11 +66,11 @@ func EjectRandomFast[K comparable, V any](b *Backend[K, V]) (bool, error) {
 	idx := 0                     // index into mapIndices
 	next2Remove := mapIndices[0] // index of the element to be removed next
 	i := 0                       // index into the entities map
-	for key, value := range b.mutableBackData.All() {
+	for entityID, entity := range b.mutableBackData.All() {
 		if i == next2Remove {
-			b.mutableBackData.Remove(key) // remove entity
+			b.mutableBackData.Remove(entityID) // remove entity
 			for _, callback := range b.ejectionCallbacks {
-				callback(value) // notify callback
+				callback(entity) // notify callback
 			}
 
 			idx++
@@ -92,31 +93,31 @@ func EjectRandomFast[K comparable, V any](b *Backend[K, V]) (bool, error) {
 
 // EjectPanic simply panics, crashing the program. Useful when cache is not expected
 // to grow beyond certain limits, but ejecting is not applicable
-func EjectPanic[K comparable, V any](b *Backend[K, V]) (K, V, bool) {
+func EjectPanic(b *Backend) (flow.Identifier, flow.Entity, bool) {
 	panic("unexpected: mempool size over the limit")
 }
 
 // LRUEjector provides a swift FIFO ejection functionality
-type LRUEjector[K comparable] struct {
+type LRUEjector struct {
 	sync.Mutex
-	table  map[K]uint64 // keeps sequence number of values it tracks
-	seqNum uint64       // keeps the most recent sequence number
+	table  map[flow.Identifier]uint64 // keeps sequence number of entities it tracks
+	seqNum uint64                     // keeps the most recent sequence number
 }
 
-func NewLRUEjector[K comparable]() *LRUEjector[K] {
-	return &LRUEjector[K]{
-		table:  make(map[K]uint64),
+func NewLRUEjector() *LRUEjector {
+	return &LRUEjector{
+		table:  make(map[flow.Identifier]uint64),
 		seqNum: 0,
 	}
 }
 
 // Track should be called every time a new entity is added to the mempool.
 // It tracks the entity for later ejection.
-func (q *LRUEjector[K]) Track(key K) {
+func (q *LRUEjector) Track(entityID flow.Identifier) {
 	q.Lock()
 	defer q.Unlock()
 
-	if _, ok := q.table[key]; ok {
+	if _, ok := q.table[entityID]; ok {
 		// skips adding duplicate item
 		return
 	}
@@ -126,28 +127,28 @@ func (q *LRUEjector[K]) Track(key K) {
 	// With proper resource cleanups by the mempools, the Eject is supposed
 	// as a very infrequent operation. However, further optimizations on
 	// Eject efficiency is needed.
-	q.table[key] = q.seqNum
+	q.table[entityID] = q.seqNum
 	q.seqNum++
 }
 
 // Untrack simply removes the tracker of the ejector off the entityID
-func (q *LRUEjector[K]) Untrack(key K) {
+func (q *LRUEjector) Untrack(entityID flow.Identifier) {
 	q.Lock()
 	defer q.Unlock()
 
-	delete(q.table, key)
+	delete(q.table, entityID)
 }
 
-// Eject implements EjectFunc for LRUEjector. It finds the value with the lowest sequence number (i.e.,
-// the oldest entity). It also untracks. This is using a linear search.
-func Eject[K comparable, V any](q *LRUEjector[K], b *Backend[K, V]) K {
+// Eject implements EjectFunc for LRUEjector. It finds the entity with the lowest sequence number (i.e.,
+// the oldest entity). It also untracks.  This is using a linear search
+func (q *LRUEjector) Eject(b *Backend) flow.Identifier {
 	q.Lock()
 	defer q.Unlock()
 
 	// finds the oldest entity
 	oldestSQ := uint64(math.MaxUint64)
-	var oldestID K
-	for _, id := range b.mutableBackData.Keys() {
+	var oldestID flow.Identifier
+	for _, id := range b.mutableBackData.Identifiers() {
 		if sq, ok := q.table[id]; ok {
 			if sq < oldestSQ {
 				oldestID = id

--- a/module/mempool/stdmap/eject_test.go
+++ b/module/mempool/stdmap/eject_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestLRUEjector_Track evaluates that tracking a new item adds the item to the ejector table.
 func TestLRUEjector_Track(t *testing.T) {
-	ejector := NewLRUEjector[flow.Identifier]()
+	ejector := NewLRUEjector()
 	// ejector's table should be empty
 	assert.Len(t, ejector.table, 0)
 
@@ -39,7 +39,7 @@ func TestLRUEjector_Track(t *testing.T) {
 // TestLRUEjector_Track_Duplicate evaluates that tracking a duplicate item
 // does not change the internal state of the ejector.
 func TestLRUEjector_Track_Duplicate(t *testing.T) {
-	ejector := NewLRUEjector[flow.Identifier]()
+	ejector := NewLRUEjector()
 
 	// creates adds an item to the ejector
 	item := flow.Identifier{0x00}
@@ -70,7 +70,7 @@ func TestLRUEjector_Track_Duplicate(t *testing.T) {
 // changes the state of ejector properly, i.e., items reside on the
 // memory, and sequence number changed accordingly.
 func TestLRUEjector_Track_Many(t *testing.T) {
-	ejector := NewLRUEjector[flow.Identifier]()
+	ejector := NewLRUEjector()
 
 	// creates and tracks 100 items
 	size := 100
@@ -98,7 +98,7 @@ func TestLRUEjector_Track_Many(t *testing.T) {
 // TestLRUEjector_Untrack_One evaluates that untracking an existing item
 // removes it from the ejector state and changes the state accordingly.
 func TestLRUEjector_Untrack_One(t *testing.T) {
-	ejector := NewLRUEjector[flow.Identifier]()
+	ejector := NewLRUEjector()
 
 	// creates adds an item to the ejector
 	item := flow.Identifier{0x00}
@@ -132,7 +132,7 @@ func TestLRUEjector_Untrack_One(t *testing.T) {
 // TestLRUEjector_Untrack_Duplicate evaluates that untracking an item twice
 // removes it from the ejector state only once and changes the state safely.
 func TestLRUEjector_Untrack_Duplicate(t *testing.T) {
-	ejector := NewLRUEjector[flow.Identifier]()
+	ejector := NewLRUEjector()
 
 	// creates and adds two items to the ejector
 	item1 := flow.Identifier{0x00}
@@ -175,17 +175,17 @@ func TestLRUEjector_Untrack_Duplicate(t *testing.T) {
 // TestLRUEjector_UntrackEject evaluates that untracking the next ejectable item
 // properly changes the next ejectable item in the ejector.
 func TestLRUEjector_UntrackEject(t *testing.T) {
-	ejector := NewLRUEjector[flow.Identifier]()
+	ejector := NewLRUEjector()
 
 	// creates and tracks 100 items
 	size := 100
-	backEnd := NewBackend[flow.Identifier, *unittest.MockEntity]()
+	backEnd := NewBackend()
 
 	items := make([]flow.Identifier, size)
 
 	for i := 0; i < size; i++ {
 		mockEntity := unittest.MockEntityFixture()
-		require.True(t, backEnd.Add(mockEntity.ID(), mockEntity))
+		require.True(t, backEnd.Add(mockEntity))
 
 		id := mockEntity.ID()
 		ejector.Track(id)
@@ -195,25 +195,25 @@ func TestLRUEjector_UntrackEject(t *testing.T) {
 	// untracks the oldest item
 	ejector.Untrack(items[0])
 
-	// next ejectable item should be the second-oldest item
-	id := Eject(ejector, backEnd)
+	// next ejectable item should be the second oldest item
+	id := ejector.Eject(backEnd)
 	assert.Equal(t, id, items[1])
 }
 
 // TestLRUEjector_EjectAll adds many item to the ejector and then ejects them
 // all one by one and evaluates an LRU ejection behavior.
 func TestLRUEjector_EjectAll(t *testing.T) {
-	ejector := NewLRUEjector[flow.Identifier]()
+	ejector := NewLRUEjector()
 
 	// creates and tracks 100 items
 	size := 100
-	backEnd := NewBackend[flow.Identifier, *unittest.MockEntity]()
+	backEnd := NewBackend()
 
 	items := make([]flow.Identifier, size)
 
 	for i := 0; i < size; i++ {
 		mockEntity := unittest.MockEntityFixture()
-		require.True(t, backEnd.Add(mockEntity.ID(), mockEntity))
+		require.True(t, backEnd.Add(mockEntity))
 
 		id := mockEntity.ID()
 		ejector.Track(id)
@@ -224,7 +224,7 @@ func TestLRUEjector_EjectAll(t *testing.T) {
 
 	// ejects one by one
 	for i := 0; i < size; i++ {
-		id := Eject(ejector, backEnd)
+		id := ejector.Eject(backEnd)
 		require.Equal(t, id, items[i])
 	}
 }

--- a/module/mempool/stdmap/options.go
+++ b/module/mempool/stdmap/options.go
@@ -6,13 +6,13 @@ import (
 
 // OptionFunc is a function that can be provided to the backend on creation in
 // order to set a certain custom option.
-type OptionFunc[K comparable, V any] func(backend *Backend[K, V])
+type OptionFunc func(*Backend)
 
 // WithLimit can be provided to the backend on creation in order to set a point
 // where it's time to check for ejection conditions.  The actual size may continue
 // to rise by the threshold for batch ejection (currently 128)
-func WithLimit[K comparable, V any](limit uint) OptionFunc[K, V] {
-	return func(be *Backend[K, V]) {
+func WithLimit(limit uint) OptionFunc {
+	return func(be *Backend) {
 		be.guaranteedCapacity = limit
 	}
 }
@@ -20,8 +20,8 @@ func WithLimit[K comparable, V any](limit uint) OptionFunc[K, V] {
 // WithEject can be provided to the backend on creation in order to set a custom
 // eject function to pick the entity to be evicted upon overflow, as well as
 // hooking into it for additional cleanup work.
-func WithEject[K comparable, V any](eject EjectFunc[K, V]) OptionFunc[K, V] {
-	return func(be *Backend[K, V]) {
+func WithEject(eject EjectFunc) OptionFunc {
+	return func(be *Backend) {
 		be.eject = eject
 		be.batchEject = nil
 	}
@@ -31,8 +31,8 @@ func WithEject[K comparable, V any](eject EjectFunc[K, V]) OptionFunc[K, V] {
 //
 // MutableBackData represents the mutable data structure used by mempool.Backend
 // core structure of maintaining data on memory-pools.
-func WithMutableBackData[K comparable, V any](mutableBackData mempool.MutableBackData[K, V]) OptionFunc[K, V] {
-	return func(be *Backend[K, V]) {
+func WithMutableBackData(mutableBackData mempool.MutableBackData) OptionFunc {
+	return func(be *Backend) {
 		be.mutableBackData = mutableBackData
 	}
 }


### PR DESCRIPTION
This PR reverts the accidental merge introduced in [PR #7110](https://github.com/onflow/flow-go/pull/7110). The changes from the branch `andron/updte-backend-to-work-with-generics-backdata` were unintentionally merged into [UlianaAndrukhiv/7073-mapBackData-generic-refactoring](https://github.com/onflow/flow-go/tree/UlianaAndrukhiv/7073-mapBackData-generic-refactoring), and this revert commit undoes those modifications to restore the intended state of the target branch.

Reverts onflow/flow-go#7110