### PR TITLE
[Malleability] Update Backend to work with generic BackData.

### DIFF
--- a/module/mempool/common.go
+++ b/module/mempool/common.go
@@ -1,8 +1,6 @@
 package mempool
 
-import "github.com/onflow/flow-go/model/flow"
-
 // OnEjection is a callback which a mempool executes on ejecting
 // one of its elements. The callbacks are executed from within the thread
 // that serves the mempool. Implementations should be non-blocking.
-type OnEjection func(flow.Entity)
+type OnEjection[V any] func(V)

--- a/module/mempool/stdmap/backDataHeapBenchmark_test.go
+++ b/module/mempool/stdmap/backDataHeapBenchmark_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	zlog "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 
@@ -28,9 +28,9 @@ func BenchmarkBaselineLRU(b *testing.B) {
 	defer debug.SetGCPercent(debug.SetGCPercent(-1)) // disable GC
 
 	limit := uint(50)
-	backData := stdmap.NewBackend(
-		stdmap.WithMutableBackData(newBaselineLRU(int(limit))),
-		stdmap.WithLimit(limit))
+	backData := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity](
+		stdmap.WithMutableBackData[flow.Identifier, *unittest.MockEntity](newBaselineLRU[flow.Identifier, *unittest.MockEntity](int(limit))),
+		stdmap.WithLimit[flow.Identifier, *unittest.MockEntity](limit))
 
 	entities := unittest.EntityListFixture(uint(100_000))
 	testAddEntities(b, limit, backData, entities)
@@ -47,15 +47,15 @@ func BenchmarkArrayBackDataLRU(b *testing.B) {
 	defer debug.SetGCPercent(debug.SetGCPercent(-1)) // disable GC
 	limit := uint(50_000)
 
-	backData := stdmap.NewBackend(
-		stdmap.WithMutableBackData(
+	backData := stdmap.NewBackend[flow.Identifier, *unittest.MockEntity](
+		stdmap.WithMutableBackData[flow.Identifier, *unittest.MockEntity](
 			herocache.NewCache(
 				uint32(limit),
 				8,
 				heropool.LRUEjection,
 				unittest.Logger(),
 				metrics.NewNoopCollector())),
-		stdmap.WithLimit(limit))
+		stdmap.WithLimit[flow.Identifier, *unittest.MockEntity](limit))
 
 	entities := unittest.EntityListFixture(uint(100_000_000))
 	testAddEntities(b, limit, backData, entities)
@@ -77,13 +77,13 @@ func gcAndWriteHeapProfile() {
 
 // testAddEntities is a test helper that checks entities are added successfully to the backdata.
 // and each entity is retrievable right after it is written to backdata.
-func testAddEntities(t testing.TB, limit uint, b *stdmap.Backend, entities []*unittest.MockEntity) {
+func testAddEntities(t testing.TB, limit uint, b *stdmap.Backend[flow.Identifier, *unittest.MockEntity], entities []*unittest.MockEntity) {
 	// adding elements
 	t1 := time.Now()
 	for i, e := range entities {
 		require.False(t, b.Has(e.ID()))
 		// adding each element must be successful.
-		require.True(t, b.Add(*e))
+		require.True(t, b.Add(e.ID(), e))
 
 		if uint(i) < limit {
 			// when we are below limit the total of
@@ -96,7 +96,7 @@ func testAddEntities(t testing.TB, limit uint, b *stdmap.Backend, entities []*un
 		}
 
 		// entity should be immediately retrievable
-		actual, ok := b.ByID(e.ID())
+		actual, ok := b.Get(e.ID())
 		require.True(t, ok)
 		require.Equal(t, *e, actual)
 	}
@@ -108,8 +108,8 @@ func testAddEntities(t testing.TB, limit uint, b *stdmap.Backend, entities []*un
 // it compliant to be used as BackData component in mempool.Backend. Note that
 // this is used only as an experimental baseline, and so it's not exported for
 // production.
-type baselineLRU struct {
-	c     *lru.Cache // used to incorporate an LRU cache
+type baselineLRU[K comparable, V any] struct {
+	c     *lru.Cache[K, V] // used to incorporate an LRU cache
 	limit int
 
 	// atomicAdjustMutex is used to synchronize concurrent access to the
@@ -118,59 +118,54 @@ type baselineLRU struct {
 	atomicAdjustMutex sync.Mutex
 }
 
-func newBaselineLRU(limit int) *baselineLRU {
+func newBaselineLRU[K comparable, V any](limit int) *baselineLRU[K, V] {
 	var err error
-	c, err := lru.New(limit)
+	c, err := lru.New[K, V](limit)
 	if err != nil {
 		panic(err)
 	}
 
-	return &baselineLRU{
+	return &baselineLRU[K, V]{
 		c:     c,
 		limit: limit,
 	}
 }
 
-// Has checks if we already contain the item with the given hash.
-func (b *baselineLRU) Has(entityID flow.Identifier) bool {
-	_, ok := b.c.Get(entityID)
+// Has checks if backdata already stores a value under the given key.
+func (b *baselineLRU[K, V]) Has(key K) bool {
+	_, ok := b.c.Get(key)
 	return ok
 }
 
 // Add adds the given item to the pool.
-func (b *baselineLRU) Add(entityID flow.Identifier, entity flow.Entity) bool {
-	b.c.Add(entityID, entity)
+func (b *baselineLRU[K, V]) Add(key K, value V) bool {
+	b.c.Add(key, value)
 	return true
 }
 
 // Remove will remove the item with the given hash.
-func (b *baselineLRU) Remove(entityID flow.Identifier) (flow.Entity, bool) {
-	e, ok := b.c.Get(entityID)
+func (b *baselineLRU[K, V]) Remove(key K) (value V, removed bool) {
+	value, ok := b.c.Get(key)
 	if !ok {
-		return nil, false
-	}
-	entity, ok := e.(flow.Entity)
-	if !ok {
-		return nil, false
+		return value, false
 	}
 
-	return entity, b.c.Remove(entityID)
+	return value, b.c.Remove(key)
 }
 
 // Adjust will adjust the value item using the given function if the given key can be found.
 // Returns a bool which indicates whether the value was updated as well as the updated value
-func (b *baselineLRU) Adjust(entityID flow.Identifier, f func(flow.Entity) flow.Entity) (flow.Entity, bool) {
-	entity, removed := b.Remove(entityID)
+func (b *baselineLRU[K, V]) Adjust(key K, f func(V) V) (value V, ok bool) {
+	value, removed := b.Remove(key)
 	if !removed {
-		return nil, false
+		return value, false
 	}
 
-	newEntity := f(entity)
-	newEntityID := newEntity.ID()
+	newValue := f(value)
 
-	b.Add(newEntityID, newEntity)
+	b.Add(key, newValue)
 
-	return newEntity, true
+	return newValue, true
 }
 
 // AdjustWithInit will adjust the value item using the given function if the given key can be found.
@@ -179,109 +174,78 @@ func (b *baselineLRU) Adjust(entityID flow.Identifier, f func(flow.Entity) flow.
 // a bool indicating whether the value was initialized.
 // Note: this is a benchmark helper, hence, the adjust-with-init provides serializability w.r.t other concurrent adjust-with-init or get-with-init operations,
 // and does not provide serializability w.r.t concurrent add, adjust or get operations.
-func (b *baselineLRU) AdjustWithInit(entityID flow.Identifier, adjust func(flow.Entity) flow.Entity, init func() flow.Entity) (flow.Entity, bool) {
+func (b *baselineLRU[K, V]) AdjustWithInit(key K, adjust func(V) V, init func() V) (value V, ok bool) {
 	b.atomicAdjustMutex.Lock()
 	defer b.atomicAdjustMutex.Unlock()
 
-	if b.Has(entityID) {
-		return b.Adjust(entityID, adjust)
+	if b.Has(key) {
+		return b.Adjust(key, adjust)
 	}
-	added := b.Add(entityID, init())
+	added := b.Add(key, init())
 	if !added {
-		return nil, false
+		return value, false
 	}
-	return b.Adjust(entityID, adjust)
+	return b.Adjust(key, adjust)
 }
 
-// GetWithInit will retrieve the value item if the given key can be found.
-// If the key is not found, the init function will be called to create a new value.
-// Returns a bool which indicates whether the entity was found (or created).
-func (b *baselineLRU) GetWithInit(entityID flow.Identifier, init func() flow.Entity) (flow.Entity, bool) {
-	newE := init()
-	e, ok, _ := b.c.PeekOrAdd(entityID, newE)
+// Get returns the given item from the pool.
+func (b *baselineLRU[K, V]) Get(key K) (value V, ok bool) {
+	value, ok = b.c.Get(key)
 	if !ok {
-		// if the entity was not found, it means that the new entity was added to the cache.
-		return newE, true
-	}
-	// if the entity was found, it means that the new entity was not added to the cache.
-	return e.(flow.Entity), true
-}
-
-// ByID returns the given item from the pool.
-func (b *baselineLRU) ByID(entityID flow.Identifier) (flow.Entity, bool) {
-	e, ok := b.c.Get(entityID)
-	if !ok {
-		return nil, false
+		return value, false
 	}
 
-	entity, ok := e.(flow.Entity)
-	if !ok {
-		return nil, false
-	}
-	return entity, ok
+	return value, ok
 }
 
 // Size will return the total of the backend.
-func (b *baselineLRU) Size() uint {
+func (b *baselineLRU[K, V]) Size() uint {
 	return uint(b.c.Len())
 }
 
 // All returns all entities from the pool.
-func (b *baselineLRU) All() map[flow.Identifier]flow.Entity {
-	all := make(map[flow.Identifier]flow.Entity)
-	for _, entityID := range b.c.Keys() {
-		id, ok := entityID.(flow.Identifier)
-		if !ok {
-			panic("could not assert to entity id")
-		}
+func (b *baselineLRU[K, V]) All() map[K]V {
+	all := make(map[K]V)
+	for _, key := range b.c.Keys() {
 
-		entity, ok := b.ByID(id)
+		entity, ok := b.Get(key)
 		if !ok {
-			panic("could not retrieve entity from mempool")
+			panic("could not retrieve value from mempool")
 		}
-		all[id] = entity
+		all[key] = entity
 	}
 
 	return all
 }
 
-func (b *baselineLRU) Identifiers() flow.IdentifierList {
-	ids := make(flow.IdentifierList, b.c.Len())
-	entityIds := b.c.Keys()
-	total := len(entityIds)
+func (b *baselineLRU[K, V]) Keys() []K {
+	keys := make([]K, b.c.Len())
+	valueKeys := b.c.Keys()
+	total := len(valueKeys)
 	for i := 0; i < total; i++ {
-		id, ok := entityIds[i].(flow.Identifier)
-		if !ok {
-			panic("could not assert to entity id")
-		}
-		ids[i] = id
+		keys[i] = valueKeys[i]
 	}
-	return ids
+	return keys
 }
 
-func (b *baselineLRU) Entities() []flow.Entity {
-	entities := make([]flow.Entity, b.c.Len())
-	entityIds := b.c.Keys()
-	total := len(entityIds)
+func (b *baselineLRU[K, V]) Values() []V {
+	values := make([]V, b.c.Len())
+	valuesIds := b.c.Keys()
+	total := len(valuesIds)
 	for i := 0; i < total; i++ {
-		id, ok := entityIds[i].(flow.Identifier)
-		if !ok {
-			panic("could not assert to entity id")
-		}
-
-		entity, ok := b.ByID(id)
+		entity, ok := b.Get(valuesIds[i])
 		if !ok {
 			panic("could not retrieve entity from mempool")
 		}
-		entities[i] = entity
+		values[i] = entity
 	}
-	return entities
+	return values
 }
 
 // Clear removes all entities from the pool.
-func (b *baselineLRU) Clear() {
+func (b *baselineLRU[K, V]) Clear() {
 	var err error
-	b.c, err = lru.New(b.limit)
+	b.c, err = lru.New[K, V](b.limit)
 	if err != nil {
 		panic(err)
 	}

--- a/module/mempool/stdmap/backend.go
+++ b/module/mempool/stdmap/backend.go
@@ -4,29 +4,27 @@ import (
 	"math"
 	"sync"
 
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module/mempool"
 	"github.com/onflow/flow-go/module/mempool/stdmap/backdata"
-	_ "github.com/onflow/flow-go/utils/binstat"
 )
 
 // Backend is a wrapper around the mutable backdata that provides concurrency-safe operations.
-type Backend struct {
+type Backend[K comparable, V any] struct {
 	sync.RWMutex
-	mutableBackData    mempool.MutableBackData[flow.Identifier, flow.Entity]
+	mutableBackData    mempool.MutableBackData[K, V]
 	guaranteedCapacity uint
-	batchEject         BatchEjectFunc
-	eject              EjectFunc
-	ejectionCallbacks  []mempool.OnEjection
+	batchEject         BatchEjectFunc[K, V]
+	eject              EjectFunc[K, V]
+	ejectionCallbacks  []mempool.OnEjection[V]
 }
 
 // NewBackend creates a new memory pool backend.
 // This is using EjectRandomFast()
-func NewBackend(options ...OptionFunc) *Backend {
-	b := Backend{
-		mutableBackData:    backdata.NewMapBackData[flow.Identifier, flow.Entity](),
+func NewBackend[K comparable, V any](options ...OptionFunc[K, V]) *Backend[K, V] {
+	b := Backend[K, V]{
+		mutableBackData:    backdata.NewMapBackData[K, V](),
 		guaranteedCapacity: uint(math.MaxUint32),
-		batchEject:         EjectRandomFast,
+		batchEject:         EjectRandomFast[K, V],
 		eject:              nil,
 		ejectionCallbacks:  nil,
 	}
@@ -36,8 +34,8 @@ func NewBackend(options ...OptionFunc) *Backend {
 	return &b
 }
 
-// Has checks if we already contain the item with the given hash.
-func (b *Backend) Has(entityID flow.Identifier) bool {
+// Has checks if a value is stored under the given key.
+func (b *Backend[K, V]) Has(key K) bool {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".r_lock.(Backend)Has")
 	b.RLock()
 	// binstat.Leave(bs1)
@@ -45,16 +43,14 @@ func (b *Backend) Has(entityID flow.Identifier) bool {
 	// bs2 := binstat.EnterTime(binstat.BinStdmap + ".inlock.(Backend)Has")
 	// defer binstat.Leave(bs2)
 	defer b.RUnlock()
-	has := b.mutableBackData.Has(entityID)
+	has := b.mutableBackData.Has(key)
 	return has
 }
 
-// Add adds the given item to the pool.
-func (b *Backend) Add(entity flow.Entity) bool {
-	// bs0 := binstat.EnterTime(binstat.BinStdmap + ".<<lock.(Backend)Add")
-	entityID := entity.ID() // this expensive operation done OUTSIDE of lock :-)
-	// binstat.Leave(bs0)
-
+// Add attempts to add the given value, without overwriting existing data.
+// If a value is already stored under the input key, Add is a no-op and returns false.
+// If no value is stored under the input key, Add adds the value and returns true.
+func (b *Backend[K, V]) Add(key K, value V) bool {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".w_lock.(Backend)Add")
 	b.Lock()
 	// binstat.Leave(bs1)
@@ -62,13 +58,15 @@ func (b *Backend) Add(entity flow.Entity) bool {
 	// bs2 := binstat.EnterTime(binstat.BinStdmap + ".inlock.(Backend)Add")
 	// defer binstat.Leave(bs2)
 	defer b.Unlock()
-	added := b.mutableBackData.Add(entityID, entity)
+	added := b.mutableBackData.Add(key, value)
 	b.reduce()
 	return added
 }
 
-// Remove will remove the item with the given hash.
-func (b *Backend) Remove(entityID flow.Identifier) bool {
+// Remove removes the value with the given key.
+// If the key-value pair exists, returns the value and true.
+// Otherwise, returns the zero value for type V and false.
+func (b *Backend[K, V]) Remove(key K) bool {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".w_lock.(Backend)Remove")
 	b.Lock()
 	// binstat.Leave(bs1)
@@ -76,13 +74,15 @@ func (b *Backend) Remove(entityID flow.Identifier) bool {
 	// bs2 := binstat.EnterTime(binstat.BinStdmap + ".inlock.(Backend)Remove")
 	// defer binstat.Leave(bs2)
 	defer b.Unlock()
-	_, removed := b.mutableBackData.Remove(entityID)
+	_, removed := b.mutableBackData.Remove(key)
 	return removed
 }
 
 // Adjust will adjust the value item using the given function if the given key can be found.
-// Returns a bool which indicates whether the value was updated.
-func (b *Backend) Adjust(entityID flow.Identifier, f func(flow.Entity) flow.Entity) (flow.Entity, bool) {
+// Returns:
+//   - value, true if the value with the given key was found. The returned value is the version after the update is applied.
+//   - nil, false if no value with the given key was found
+func (b *Backend[K, V]) Adjust(key K, f func(V) V) (V, bool) {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".w_lock.(Backend)Adjust")
 	b.Lock()
 	// binstat.Leave(bs1)
@@ -90,29 +90,29 @@ func (b *Backend) Adjust(entityID flow.Identifier, f func(flow.Entity) flow.Enti
 	// bs2 := binstat.EnterTime(binstat.BinStdmap + ".inlock.(Backend)Adjust")
 	// defer binstat.Leave(bs2)
 	defer b.Unlock()
-	entity, wasUpdated := b.mutableBackData.Adjust(entityID, f)
-	return entity, wasUpdated
+	value, wasUpdated := b.mutableBackData.Adjust(key, f)
+	return value, wasUpdated
 }
 
-// AdjustWithInit adjusts the entity using the given function if the given identifier can be found. When the
-// entity is not found, it initializes the entity using the given init function and then applies the adjust function.
+// AdjustWithInit adjusts the value using the given function if the given identifier can be found. When the
+// value is not found, it initializes the value using the given init function and then applies the adjust function.
 // Args:
-// - entityID: the identifier of the entity to adjust.
-// - adjust: the function that adjusts the entity.
-// - init: the function that initializes the entity when it is not found.
+// - key: the identifier of the value to adjust.
+// - adjust: the function that adjusts the value.
+// - init: the function that initializes the value when it is not found.
 // Returns:
-//   - the adjusted entity.
-//
-// - a bool which indicates whether the entity was adjusted.
-func (b *Backend) AdjustWithInit(entityID flow.Identifier, adjust func(flow.Entity) flow.Entity, init func() flow.Entity) (flow.Entity, bool) {
+// - the adjusted value.
+// - a bool which indicates whether the value was adjusted.
+func (b *Backend[K, V]) AdjustWithInit(key K, adjust func(V) V, init func() V) (V, bool) {
 	b.Lock()
 	defer b.Unlock()
 
-	return b.mutableBackData.AdjustWithInit(entityID, adjust, init)
+	return b.mutableBackData.AdjustWithInit(key, adjust, init)
 }
 
-// ByID returns the given item from the pool.
-func (b *Backend) ByID(entityID flow.Identifier) (flow.Entity, bool) {
+// Get returns the value for the given key.
+// Returns true if the key-value pair exists, and false otherwise.
+func (b *Backend[K, V]) Get(key K) (V, bool) {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".r_lock.(Backend)ByID")
 	b.RLock()
 	// binstat.Leave(bs1)
@@ -120,12 +120,14 @@ func (b *Backend) ByID(entityID flow.Identifier) (flow.Entity, bool) {
 	// bs2 := binstat.EnterTime(binstat.BinStdmap + ".inlock.(Backend)ByID")
 	// defer binstat.Leave(bs2)
 	defer b.RUnlock()
-	entity, exists := b.mutableBackData.Get(entityID)
-	return entity, exists
+	value, exists := b.mutableBackData.Get(key)
+	return value, exists
 }
 
-// Run executes a function giving it exclusive access to the backdata
-func (b *Backend) Run(f func(backdata mempool.BackData[flow.Identifier, flow.Entity]) error) error {
+// Run executes a function giving it exclusive access to the backdata.
+// All errors returned from the input functor f are considered exceptions.
+// No errors are expected during normal operation.
+func (b *Backend[K, V]) Run(f func(backdata mempool.BackData[K, V]) error) error {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".w_lock.(Backend)Run")
 	b.Lock()
 	// binstat.Leave(bs1)
@@ -139,7 +141,7 @@ func (b *Backend) Run(f func(backdata mempool.BackData[flow.Identifier, flow.Ent
 }
 
 // Size will return the size of the backend.
-func (b *Backend) Size() uint {
+func (b *Backend[K, V]) Size() uint {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".r_lock.(Backend)Size")
 	b.RLock()
 	// binstat.Leave(bs1)
@@ -152,12 +154,12 @@ func (b *Backend) Size() uint {
 }
 
 // Limit returns the maximum number of items allowed in the backend.
-func (b *Backend) Limit() uint {
+func (b *Backend[K, V]) Limit() uint {
 	return b.guaranteedCapacity
 }
 
-// All returns all entities from the pool.
-func (b *Backend) All() []flow.Entity {
+// All returns an unordered list of all values from the pool.
+func (b *Backend[K, V]) All() []V {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".r_lock.(Backend)All")
 	b.RLock()
 	// binstat.Leave(bs1)
@@ -170,7 +172,7 @@ func (b *Backend) All() []flow.Entity {
 }
 
 // Clear removes all entities from the pool.
-func (b *Backend) Clear() {
+func (b *Backend[K, V]) Clear() {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".w_lock.(Backend)Clear")
 	b.Lock()
 	// binstat.Leave(bs1)
@@ -182,7 +184,7 @@ func (b *Backend) Clear() {
 }
 
 // RegisterEjectionCallbacks adds the provided OnEjection callbacks
-func (b *Backend) RegisterEjectionCallbacks(callbacks ...mempool.OnEjection) {
+func (b *Backend[K, V]) RegisterEjectionCallbacks(callbacks ...mempool.OnEjection[V]) {
 	// bs1 := binstat.EnterTime(binstat.BinStdmap + ".r_lock.(Backend)RegisterEjectionCallbacks")
 	b.Lock()
 	// binstat.Leave(bs1)
@@ -195,7 +197,7 @@ func (b *Backend) RegisterEjectionCallbacks(callbacks ...mempool.OnEjection) {
 
 // reduce will reduce the size of the kept entities until we are within the
 // configured memory pool size limit.
-func (b *Backend) reduce() {
+func (b *Backend[K, V]) reduce() {
 	// bs := binstat.EnterTime(binstat.BinStdmap + ".??lock.(Backend)reduce")
 	// defer binstat.Leave(bs)
 

--- a/module/mempool/stdmap/eject.go
+++ b/module/mempool/stdmap/eject.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/rand"
 )
 
@@ -30,13 +29,13 @@ const overCapacityThreshold = 128
 //     concurrency (specifically, it locks the mempool during ejection).
 //   - The implementation should be non-blocking (though, it is allowed to
 //     take a bit of time; the mempool will just be locked during this time).
-type BatchEjectFunc func(b *Backend) (bool, error)
-type EjectFunc func(b *Backend) (flow.Identifier, flow.Entity, bool)
+type BatchEjectFunc[K comparable, V any] func(b *Backend[K, V]) (bool, error)
+type EjectFunc[K comparable, V any] func(b *Backend[K, V]) (K, V, bool)
 
 // EjectRandomFast checks if the map size is beyond the
 // threshold size, and will iterate through them and eject unneeded
 // entries if that is the case.  Return values are unused
-func EjectRandomFast(b *Backend) (bool, error) {
+func EjectRandomFast[K comparable, V any](b *Backend[K, V]) (bool, error) {
 	currentSize := b.mutableBackData.Size()
 
 	if b.guaranteedCapacity >= currentSize {
@@ -66,11 +65,11 @@ func EjectRandomFast(b *Backend) (bool, error) {
 	idx := 0                     // index into mapIndices
 	next2Remove := mapIndices[0] // index of the element to be removed next
 	i := 0                       // index into the entities map
-	for entityID, entity := range b.mutableBackData.All() {
+	for key, value := range b.mutableBackData.All() {
 		if i == next2Remove {
-			b.mutableBackData.Remove(entityID) // remove entity
+			b.mutableBackData.Remove(key) // remove entity
 			for _, callback := range b.ejectionCallbacks {
-				callback(entity) // notify callback
+				callback(value) // notify callback
 			}
 
 			idx++
@@ -93,31 +92,31 @@ func EjectRandomFast(b *Backend) (bool, error) {
 
 // EjectPanic simply panics, crashing the program. Useful when cache is not expected
 // to grow beyond certain limits, but ejecting is not applicable
-func EjectPanic(b *Backend) (flow.Identifier, flow.Entity, bool) {
+func EjectPanic[K comparable, V any](b *Backend[K, V]) (K, V, bool) {
 	panic("unexpected: mempool size over the limit")
 }
 
 // LRUEjector provides a swift FIFO ejection functionality
-type LRUEjector struct {
+type LRUEjector[K comparable] struct {
 	sync.Mutex
-	table  map[flow.Identifier]uint64 // keeps sequence number of entities it tracks
-	seqNum uint64                     // keeps the most recent sequence number
+	table  map[K]uint64 // keeps sequence number of values it tracks
+	seqNum uint64       // keeps the most recent sequence number
 }
 
-func NewLRUEjector() *LRUEjector {
-	return &LRUEjector{
-		table:  make(map[flow.Identifier]uint64),
+func NewLRUEjector[K comparable]() *LRUEjector[K] {
+	return &LRUEjector[K]{
+		table:  make(map[K]uint64),
 		seqNum: 0,
 	}
 }
 
 // Track should be called every time a new entity is added to the mempool.
 // It tracks the entity for later ejection.
-func (q *LRUEjector) Track(entityID flow.Identifier) {
+func (q *LRUEjector[K]) Track(key K) {
 	q.Lock()
 	defer q.Unlock()
 
-	if _, ok := q.table[entityID]; ok {
+	if _, ok := q.table[key]; ok {
 		// skips adding duplicate item
 		return
 	}
@@ -127,28 +126,28 @@ func (q *LRUEjector) Track(entityID flow.Identifier) {
 	// With proper resource cleanups by the mempools, the Eject is supposed
 	// as a very infrequent operation. However, further optimizations on
 	// Eject efficiency is needed.
-	q.table[entityID] = q.seqNum
+	q.table[key] = q.seqNum
 	q.seqNum++
 }
 
 // Untrack simply removes the tracker of the ejector off the entityID
-func (q *LRUEjector) Untrack(entityID flow.Identifier) {
+func (q *LRUEjector[K]) Untrack(key K) {
 	q.Lock()
 	defer q.Unlock()
 
-	delete(q.table, entityID)
+	delete(q.table, key)
 }
 
-// Eject implements EjectFunc for LRUEjector. It finds the entity with the lowest sequence number (i.e.,
-// the oldest entity). It also untracks.  This is using a linear search
-func (q *LRUEjector) Eject(b *Backend) flow.Identifier {
+// Eject implements EjectFunc for LRUEjector. It finds the value with the lowest sequence number (i.e.,
+// the oldest entity). It also untracks. This is using a linear search.
+func Eject[K comparable, V any](q *LRUEjector[K], b *Backend[K, V]) K {
 	q.Lock()
 	defer q.Unlock()
 
 	// finds the oldest entity
 	oldestSQ := uint64(math.MaxUint64)
-	var oldestID flow.Identifier
-	for _, id := range b.mutableBackData.Identifiers() {
+	var oldestID K
+	for _, id := range b.mutableBackData.Keys() {
 		if sq, ok := q.table[id]; ok {
 			if sq < oldestSQ {
 				oldestID = id

--- a/module/mempool/stdmap/eject_test.go
+++ b/module/mempool/stdmap/eject_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestLRUEjector_Track evaluates that tracking a new item adds the item to the ejector table.
 func TestLRUEjector_Track(t *testing.T) {
-	ejector := NewLRUEjector()
+	ejector := NewLRUEjector[flow.Identifier]()
 	// ejector's table should be empty
 	assert.Len(t, ejector.table, 0)
 
@@ -39,7 +39,7 @@ func TestLRUEjector_Track(t *testing.T) {
 // TestLRUEjector_Track_Duplicate evaluates that tracking a duplicate item
 // does not change the internal state of the ejector.
 func TestLRUEjector_Track_Duplicate(t *testing.T) {
-	ejector := NewLRUEjector()
+	ejector := NewLRUEjector[flow.Identifier]()
 
 	// creates adds an item to the ejector
 	item := flow.Identifier{0x00}
@@ -70,7 +70,7 @@ func TestLRUEjector_Track_Duplicate(t *testing.T) {
 // changes the state of ejector properly, i.e., items reside on the
 // memory, and sequence number changed accordingly.
 func TestLRUEjector_Track_Many(t *testing.T) {
-	ejector := NewLRUEjector()
+	ejector := NewLRUEjector[flow.Identifier]()
 
 	// creates and tracks 100 items
 	size := 100
@@ -98,7 +98,7 @@ func TestLRUEjector_Track_Many(t *testing.T) {
 // TestLRUEjector_Untrack_One evaluates that untracking an existing item
 // removes it from the ejector state and changes the state accordingly.
 func TestLRUEjector_Untrack_One(t *testing.T) {
-	ejector := NewLRUEjector()
+	ejector := NewLRUEjector[flow.Identifier]()
 
 	// creates adds an item to the ejector
 	item := flow.Identifier{0x00}
@@ -132,7 +132,7 @@ func TestLRUEjector_Untrack_One(t *testing.T) {
 // TestLRUEjector_Untrack_Duplicate evaluates that untracking an item twice
 // removes it from the ejector state only once and changes the state safely.
 func TestLRUEjector_Untrack_Duplicate(t *testing.T) {
-	ejector := NewLRUEjector()
+	ejector := NewLRUEjector[flow.Identifier]()
 
 	// creates and adds two items to the ejector
 	item1 := flow.Identifier{0x00}
@@ -175,17 +175,17 @@ func TestLRUEjector_Untrack_Duplicate(t *testing.T) {
 // TestLRUEjector_UntrackEject evaluates that untracking the next ejectable item
 // properly changes the next ejectable item in the ejector.
 func TestLRUEjector_UntrackEject(t *testing.T) {
-	ejector := NewLRUEjector()
+	ejector := NewLRUEjector[flow.Identifier]()
 
 	// creates and tracks 100 items
 	size := 100
-	backEnd := NewBackend()
+	backEnd := NewBackend[flow.Identifier, *unittest.MockEntity]()
 
 	items := make([]flow.Identifier, size)
 
 	for i := 0; i < size; i++ {
 		mockEntity := unittest.MockEntityFixture()
-		require.True(t, backEnd.Add(mockEntity))
+		require.True(t, backEnd.Add(mockEntity.ID(), mockEntity))
 
 		id := mockEntity.ID()
 		ejector.Track(id)
@@ -195,25 +195,25 @@ func TestLRUEjector_UntrackEject(t *testing.T) {
 	// untracks the oldest item
 	ejector.Untrack(items[0])
 
-	// next ejectable item should be the second oldest item
-	id := ejector.Eject(backEnd)
+	// next ejectable item should be the second-oldest item
+	id := Eject(ejector, backEnd)
 	assert.Equal(t, id, items[1])
 }
 
 // TestLRUEjector_EjectAll adds many item to the ejector and then ejects them
 // all one by one and evaluates an LRU ejection behavior.
 func TestLRUEjector_EjectAll(t *testing.T) {
-	ejector := NewLRUEjector()
+	ejector := NewLRUEjector[flow.Identifier]()
 
 	// creates and tracks 100 items
 	size := 100
-	backEnd := NewBackend()
+	backEnd := NewBackend[flow.Identifier, *unittest.MockEntity]()
 
 	items := make([]flow.Identifier, size)
 
 	for i := 0; i < size; i++ {
 		mockEntity := unittest.MockEntityFixture()
-		require.True(t, backEnd.Add(mockEntity))
+		require.True(t, backEnd.Add(mockEntity.ID(), mockEntity))
 
 		id := mockEntity.ID()
 		ejector.Track(id)
@@ -224,7 +224,7 @@ func TestLRUEjector_EjectAll(t *testing.T) {
 
 	// ejects one by one
 	for i := 0; i < size; i++ {
-		id := ejector.Eject(backEnd)
+		id := Eject(ejector, backEnd)
 		require.Equal(t, id, items[i])
 	}
 }

--- a/module/mempool/stdmap/options.go
+++ b/module/mempool/stdmap/options.go
@@ -6,13 +6,13 @@ import (
 
 // OptionFunc is a function that can be provided to the backend on creation in
 // order to set a certain custom option.
-type OptionFunc func(*Backend)
+type OptionFunc[K comparable, V any] func(backend *Backend[K, V])
 
 // WithLimit can be provided to the backend on creation in order to set a point
 // where it's time to check for ejection conditions.  The actual size may continue
 // to rise by the threshold for batch ejection (currently 128)
-func WithLimit(limit uint) OptionFunc {
-	return func(be *Backend) {
+func WithLimit[K comparable, V any](limit uint) OptionFunc[K, V] {
+	return func(be *Backend[K, V]) {
 		be.guaranteedCapacity = limit
 	}
 }
@@ -20,8 +20,8 @@ func WithLimit(limit uint) OptionFunc {
 // WithEject can be provided to the backend on creation in order to set a custom
 // eject function to pick the entity to be evicted upon overflow, as well as
 // hooking into it for additional cleanup work.
-func WithEject(eject EjectFunc) OptionFunc {
-	return func(be *Backend) {
+func WithEject[K comparable, V any](eject EjectFunc[K, V]) OptionFunc[K, V] {
+	return func(be *Backend[K, V]) {
 		be.eject = eject
 		be.batchEject = nil
 	}
@@ -31,8 +31,8 @@ func WithEject(eject EjectFunc) OptionFunc {
 //
 // MutableBackData represents the mutable data structure used by mempool.Backend
 // core structure of maintaining data on memory-pools.
-func WithMutableBackData(mutableBackData mempool.MutableBackData) OptionFunc {
-	return func(be *Backend) {
+func WithMutableBackData[K comparable, V any](mutableBackData mempool.MutableBackData[K, V]) OptionFunc[K, V] {
+	return func(be *Backend[K, V]) {
 		be.mutableBackData = mutableBackData
 	}
 }


### PR DESCRIPTION
## Context
Note: This is copy of PR https://github.com/onflow/flow-go/pull/7110 as it was unintentionally merged and reverted than.

In this PR [Backend](https://github.com/onflow/flow-go/blob/feature/malleability/module/mempool/stdmap/backend.go) was refactored to work with the generic `Backdata` interface introduced in this PR https://github.com/onflow/flow-go/pull/7089.  

The [Backend](https://github.com/onflow/flow-go/blob/feature/malleability/module/mempool/stdmap/backend.go) now uses generic type parameters:

- Key (K) is constrained with comparable, ensuring that it supports equality checks.
- Value (V) is defined as any, allowing flexibility.

Also, tests and some parts that are being used by [Backend](https://github.com/onflow/flow-go/blob/feature/malleability/module/mempool/stdmap/backend.go) were updated as well.

All usages of the `Backend` in the `stdmap` package will be fixed in the issue https://github.com/onflow/flow-go/issues/7075.

This PR is part of the broader refactoring effort referenced in EPIC https://github.com/onflow/flow-go/issues/6646.
##
Closes: #7072.