### PR TITLE
[Malleability] Malleability checker follow up

### DIFF
--- a/model/flow/epoch_test.go
+++ b/model/flow/epoch_test.go
@@ -16,10 +16,10 @@ func TestMalleability(t *testing.T) {
 		unittest.RequireEntityNonMalleable(t, unittest.EpochSetupFixture())
 	})
 	t.Run("EpochCommit with nil DKGIndexMap", func(t *testing.T) {
-		checker := unittest.NewMalleabilityChecker(unittest.WithPinnedField("DKGIndexMap"))
-		// Due to `DKGIndexMap` being nil, `MalleabilityChecker` will skip mutating this field.
-		err := checker.Check(unittest.EpochCommitFixture())
-		require.NoError(t, err)
+		unittest.RequireEntityNonMalleable(t, unittest.EpochCommitFixture(),
+			// Due to `DKGIndexMap` being nil, `MalleabilityChecker` will skip mutating this field.
+			unittest.WithPinnedField("DKGIndexMap"),
+		)
 	})
 
 	t.Run("EpochCommit with proper DKGIndexMap", func(t *testing.T) {

--- a/model/flow/epoch_test.go
+++ b/model/flow/epoch_test.go
@@ -1,7 +1,6 @@
 package flow_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/onflow/crypto"
@@ -41,35 +40,11 @@ func TestMalleability(t *testing.T) {
 	})
 
 	t.Run("EpochStateContainer", func(t *testing.T) {
-		checker := unittest.NewMalleabilityChecker(
-			unittest.WithFieldGenerator("EpochExtensions", func() []flow.EpochExtension {
-				return []flow.EpochExtension{unittest.EpochExtensionFixture()}
-			}),
-			unittest.WithFieldGenerator("ActiveIdentities", func() flow.DynamicIdentityEntryList {
-				return unittest.DynamicIdentityEntryListFixture(5, func(dynamicIdentityEntry *flow.DynamicIdentityEntry) {
-					dynamicIdentityEntry.Ejected = rand.Intn(2) == 1
-				})
-			}),
-		)
-
-		err := checker.Check(unittest.EpochStateContainerFixture())
-		require.NoError(t, err)
+		unittest.RequireEntityNonMalleable(t, unittest.EpochStateContainerFixture())
 	})
 
 	t.Run("MinEpochStateEntry", func(t *testing.T) {
-		checker := unittest.NewMalleabilityChecker(
-			unittest.WithTypeGenerator(func() flow.DynamicIdentityEntry {
-				return *unittest.DynamicIdentityEntryFixture(func(dynamicIdentityEntry *flow.DynamicIdentityEntry) {
-					dynamicIdentityEntry.Ejected = rand.Intn(2) == 1
-				})
-			}),
-			unittest.WithTypeGenerator(func() flow.EpochExtension {
-				return unittest.EpochExtensionFixture()
-			}),
-		)
-
-		err := checker.Check(unittest.EpochStateFixture(unittest.WithNextEpochProtocolState()).MinEpochStateEntry)
-		require.NoError(t, err)
+		unittest.RequireEntityNonMalleable(t, unittest.EpochStateFixture(unittest.WithNextEpochProtocolState()).MinEpochStateEntry)
 	})
 }
 

--- a/state/protocol/protocol_state/kvstore/models_test.go
+++ b/state/protocol/protocol_state/kvstore/models_test.go
@@ -294,14 +294,8 @@ func TestKVStoreMutator_SetEpochExtensionViewCount(t *testing.T) {
 
 // TestMalleability verifies that the entities which implements the ID are not malleable.
 func TestMalleability(t *testing.T) {
-	checker := unittest.NewMalleabilityChecker(
-		unittest.WithFieldGenerator("UpgradableModel.VersionUpgrade", func() protocol.ViewBasedActivator[uint64] {
-			return *unittest.ViewBasedActivatorFixture()
-		}),
-	)
-
 	t.Run("Modelv0", func(t *testing.T) {
-		err := checker.Check(
+		unittest.RequireEntityNonMalleable(t,
 			&kvstore.Modelv0{
 				UpgradableModel: kvstore.UpgradableModel{
 					VersionUpgrade: unittest.ViewBasedActivatorFixture(),
@@ -309,11 +303,10 @@ func TestMalleability(t *testing.T) {
 				EpochStateID: unittest.IdentifierFixture(),
 			},
 		)
-		require.NoError(t, err)
 	})
 
 	t.Run("Modelv1", func(t *testing.T) {
-		err := checker.Check(
+		unittest.RequireEntityNonMalleable(t,
 			&kvstore.Modelv1{
 				Modelv0: kvstore.Modelv0{
 					UpgradableModel: kvstore.UpgradableModel{
@@ -323,6 +316,5 @@ func TestMalleability(t *testing.T) {
 				},
 			},
 		)
-		require.NoError(t, err)
 	})
 }

--- a/utils/unittest/entity.go
+++ b/utils/unittest/entity.go
@@ -2,11 +2,12 @@ package unittest
 
 import (
 	"fmt"
-	"github.com/onflow/crypto"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"reflect"
 	"testing"
+
+	"github.com/onflow/crypto"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
 )

--- a/utils/unittest/entity.go
+++ b/utils/unittest/entity.go
@@ -2,13 +2,11 @@ package unittest
 
 import (
 	"fmt"
+	"github.com/onflow/crypto"
+	"github.com/stretchr/testify/require"
 	"math/rand"
 	"reflect"
 	"testing"
-	"time"
-
-	"github.com/onflow/crypto"
-	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/flow"
 )
@@ -300,40 +298,6 @@ func (mc *MalleabilityChecker) generateRandomReflectValue(field reflect.Value) e
 		field.Set(generatedValue)
 	default:
 		return fmt.Errorf("cannot generate random value, unsupported type: %s", field.Kind().String())
-	}
-	return nil
-}
-
-// generateCustomFlowValue generates a random value for the field of the struct that is not a primitive type.
-// This can be extended for types that are broadly used in the code base.
-func generateCustomFlowValue(field reflect.Value) any {
-	switch field.Type() {
-	case reflect.TypeOf(flow.Identity{}):
-		return *IdentityFixture()
-	case reflect.TypeOf(flow.IdentitySkeleton{}):
-		return IdentityFixture().IdentitySkeleton
-	case reflect.TypeOf(flow.ClusterQCVoteData{}):
-		return flow.ClusterQCVoteDataFromQC(QuorumCertificateWithSignerIDsFixture())
-	case reflect.TypeOf(flow.QuorumCertificate{}):
-		return *QuorumCertificateFixture()
-	case reflect.TypeOf(flow.CollectionGuarantee{}):
-		return *CollectionGuaranteeFixture()
-	case reflect.TypeOf(flow.Chunk{}):
-		return *ChunkFixture(IdentifierFixture(), uint(rand.Uint32()), StateCommitmentFixture())
-	case reflect.TypeOf(flow.ServiceEvent{}):
-		return EpochCommitFixture().ServiceEvent()
-	case reflect.TypeOf(flow.TimeoutCertificate{}):
-		return flow.TimeoutCertificate{
-			View:          rand.Uint64(),
-			NewestQCViews: []uint64{rand.Uint64()},
-			NewestQC:      QuorumCertificateFixture(),
-			SignerIndices: SignerIndicesFixture(2),
-			SigData:       SignatureFixture(),
-		}
-	case reflect.TypeOf(flow.AggregatedSignature{}):
-		return Seal.AggregatedSignatureFixture()
-	case reflect.TypeOf(time.Time{}):
-		return time.Now()
 	}
 	return nil
 }

--- a/utils/unittest/entity_test.go
+++ b/utils/unittest/entity_test.go
@@ -1,6 +1,7 @@
 package unittest
 
 import (
+	clone "github.com/huandu/go-clone/generic"
 	"testing"
 
 	"github.com/onflow/crypto"
@@ -208,16 +209,21 @@ func TestRequireEntityNonMalleable(t *testing.T) {
 	})
 }
 
+// EnterViewEvidence is a utility struct for testing the malleability checker when multiple levels of nested structs are involved.
 type EnterViewEvidence struct {
 	QC *flow.QuorumCertificate
 	TC *flow.TimeoutCertificate
 }
 
+// StructWithPinning is a struct specifically designed to test the pinning feature of the malleability checker.
 type StructWithPinning struct {
 	Version  uint32
 	Evidence *EnterViewEvidence
 }
 
+// ID returns the hash of the entity depending on the value of the Version field.
+// Depending on the value of the Version field, the ID method includes or excludes the TC field in the hash calculation and requires it's nil or not in some cases.
+// This is a contrived example to demonstrate the pinning feature of the malleability checker.
 func (e *StructWithPinning) ID() flow.Identifier {
 	if e.Version == 1 {
 		if e.Evidence.TC != nil {
@@ -248,6 +254,10 @@ func (e *StructWithPinning) ID() flow.Identifier {
 	}
 }
 
+// TestMalleabilityChecker_PinField tests the behavior of MalleabilityChecker when pinning is required.
+// This structure is implemented in a way that the ID method behaves differently depending on the value of the Version field.
+// Depending on the value of the Version field, the ID method includes or excludes the TC field in the hash calculation and requires
+// it's nil or not in some cases, this means we need to use pinning otherwise checker will generate random values for the fields.
 func TestMalleabilityChecker_PinField(t *testing.T) {
 	t.Run("v1", func(t *testing.T) {
 		checker := NewMalleabilityChecker(WithPinnedField("Version"), WithPinnedField("Evidence.TC"))
@@ -279,38 +289,58 @@ func TestMalleabilityChecker_PinField(t *testing.T) {
 	})
 }
 
-type StructWithUnsupportedType struct {
+// StructWithComplexType is a struct that contains a slice with complex type.
+type StructWithComplexType struct {
 	Version   uint32
 	Evidences []*EnterViewEvidence
 }
 
-func (e *StructWithUnsupportedType) ID() flow.Identifier {
+func (e *StructWithComplexType) ID() flow.Identifier {
 	return flow.MakeID(e)
 }
 
+// TestMalleabilityChecker_Generators tests the behavior of MalleabilityChecker when using field and type generators.
+// In this test we actually ensure that checker uses the generator and the generated values are set on the entity that is being checked.
 func TestMalleabilityChecker_Generators(t *testing.T) {
-	t.Run("field-generator", func(t *testing.T) {
-		RequireEntityNonMalleable(t, &StructWithUnsupportedType{
+	t.Run("no-generator", func(t *testing.T) {
+		original := &StructWithComplexType{
 			Version:   0,
 			Evidences: nil,
-		}, WithFieldGenerator("Evidences", func() []*EnterViewEvidence {
-			return []*EnterViewEvidence{
-				{
-					QC: QuorumCertificateFixture(),
-					TC: nil,
-				},
-			}
-		}))
+		}
+		cpy := clone.Clone(original)
+		RequireEntityNonMalleable(t, cpy)
+		require.NotEqual(t, original.Version, cpy.Version)
+		require.NotElementsMatch(t, original.Evidences, cpy.Evidences)
 	})
-	t.Run("type-generator", func(t *testing.T) {
-		RequireEntityNonMalleable(t, &StructWithUnsupportedType{
+	t.Run("field-generator", func(t *testing.T) {
+		original := &StructWithComplexType{
 			Version:   0,
 			Evidences: nil,
-		}, WithTypeGenerator(func() EnterViewEvidence {
-			return EnterViewEvidence{
+		}
+		generated := []*EnterViewEvidence{
+			{
 				QC: QuorumCertificateFixture(),
 				TC: nil,
-			}
+			},
+		}
+		RequireEntityNonMalleable(t, original, WithFieldGenerator("Evidences", func() []*EnterViewEvidence {
+			return generated
 		}))
+		require.Equal(t, generated, original.Evidences)
+	})
+	t.Run("type-generator", func(t *testing.T) {
+		generated := EnterViewEvidence{
+			QC: QuorumCertificateFixture(),
+			TC: nil,
+		}
+		original := &StructWithComplexType{
+			Version:   0,
+			Evidences: nil,
+		}
+		RequireEntityNonMalleable(t, original, WithTypeGenerator(func() EnterViewEvidence {
+			return generated
+		}),
+		)
+		require.Equal(t, generated, *original.Evidences[0])
 	})
 }

--- a/utils/unittest/entity_test.go
+++ b/utils/unittest/entity_test.go
@@ -1,9 +1,9 @@
 package unittest
 
 import (
-	clone "github.com/huandu/go-clone/generic"
 	"testing"
 
+	clone "github.com/huandu/go-clone/generic"
 	"github.com/onflow/crypto"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/7108

### Context

This PR implements a follow up to the previous [PR](https://github.com/onflow/flow-go/pull/7069) which implemented the checker itself. This PR implements:
- new way of generating structures: each structure will be generated recursively, it simplified the implementation a lot and suddenly user doesn't need to use type and field generators as often as they had to
- updates to godoc with respect to the last changes
- cleanup of tests