### PR TITLE
[Storage] Fix InitBadgerAndPebble() not closing badger.DB on error

### DIFF
--- a/cmd/util/cmd/read-badger/cmd/storages.go
+++ b/cmd/util/cmd/read-badger/cmd/storages.go
@@ -52,15 +52,18 @@ func InitBadgerAndPebble() (bdb *badger.DB, pdb *pebble.DB, err error) {
 	if flagDatadir == "" {
 		return nil, nil, fmt.Errorf("must specify --datadir")
 	}
-	bdb = common.InitStorage(flagDatadir)
+
 	if flagPebbleDir == "" {
 		return nil, nil, fmt.Errorf("must specify --pebbledir")
 	}
+
 	pdb, err = pebblestorage.MustOpenDefaultPebbleDB(
 		log.Logger.With().Str("pebbledb", "protocol").Logger(), flagPebbleDir)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	bdb = common.InitStorage(flagDatadir)
 
 	return bdb, pdb, nil
 }


### PR DESCRIPTION
Currently, `InitBadgerAndPebble()` can return error without closing `badger.DB`.  In this case, the opened badger.DB is not accessible to the caller so it cannot be closed.

This PR fixes this by not opening `badger.DB` before `InitBadgerAndPebble()` returns error along with `nil *badger.DB`.