### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/cmd/bootstrap/run/epochs.go
+++ b/cmd/bootstrap/run/epochs.go
@@ -3,11 +3,11 @@ package run
 import (
 	"encoding/hex"
 	"fmt"
+	"slices"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/crypto"
 	"github.com/rs/zerolog"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/cmd/util/cmd/common"
 	"github.com/onflow/flow-go/fvm/systemcontracts"

--- a/cmd/util/cmd/debug-tx/cmd.go
+++ b/cmd/util/cmd/debug-tx/cmd.go
@@ -4,13 +4,13 @@ import (
 	"cmp"
 	"context"
 	"encoding/hex"
+	"slices"
 
 	client "github.com/onflow/flow-go-sdk/access/grpc"
 	"github.com/onflow/flow/protobuf/go/flow/execution"
 	"github.com/onflow/flow/protobuf/go/flow/executiondata"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 

--- a/consensus/hotstuff/timeoutcollector/timeout_processor.go
+++ b/consensus/hotstuff/timeoutcollector/timeout_processor.go
@@ -3,10 +3,10 @@ package timeoutcollector
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/rs/zerolog"
 	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/consensus/hotstuff"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"

--- a/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
+++ b/consensus/hotstuff/votecollector/combined_vote_processor_v2_test.go
@@ -3,6 +3,7 @@ package votecollector
 import (
 	"errors"
 	"math/rand"
+	"slices"
 	"sync"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
 	"pgregory.net/rapid"
 
 	bootstrapDKG "github.com/onflow/flow-go/cmd/bootstrap/dkg"

--- a/engine/access/rest/websockets/legacy/routes/subscribe_events_test.go
+++ b/engine/access/rest/websockets/legacy/routes/subscribe_events_test.go
@@ -8,11 +8,10 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	jsoncdc "github.com/onflow/cadence/encoding/json"
 	"github.com/onflow/flow/protobuf/go/flow/entities"

--- a/engine/common/follower/cache/cache_test.go
+++ b/engine/common/follower/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"math/rand"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/mocks"
 	"github.com/onflow/flow-go/consensus/hotstuff/model"

--- a/engine/common/follower/pending_tree/pending_tree_test.go
+++ b/engine/common/follower/pending_tree/pending_tree_test.go
@@ -3,12 +3,12 @@ package pending_tree
 import (
 	"fmt"
 	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/model/flow"

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -3,6 +3,7 @@ package verificationtest
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/consensus/hotstuff/model"
 	"github.com/onflow/flow-go/engine/testutil"

--- a/fvm/storage/snapshot/execution_snapshot.go
+++ b/fvm/storage/snapshot/execution_snapshot.go
@@ -1,9 +1,8 @@
 package snapshot
 
 import (
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/fvm/meter"
 	"github.com/onflow/flow-go/model/flow"

--- a/fvm/transactionStorageLimiter.go
+++ b/fvm/transactionStorageLimiter.go
@@ -3,10 +3,10 @@ package fvm
 import (
 	"bytes"
 	"fmt"
+	"slices"
 
 	"github.com/onflow/cadence"
 	"github.com/onflow/cadence/common"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/fvm/environment"
 	"github.com/onflow/flow-go/fvm/errors"

--- a/integration/dkg/dkg_emulator_suite.go
+++ b/integration/dkg/dkg_emulator_suite.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"os"
 
 	"github.com/onflow/crypto"
-	"golang.org/x/exp/slices"
-
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/integration/dkg/dkg_whiteboard_test.go
+++ b/integration/dkg/dkg_whiteboard_test.go
@@ -3,10 +3,9 @@ package dkg
 import (
 	"math/rand"
 	"os"
+	"slices"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"

--- a/model/bootstrap/node_info.go
+++ b/model/bootstrap/node_info.go
@@ -4,11 +4,10 @@ package bootstrap
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/onflow/crypto"
-	"golang.org/x/exp/slices"
-
 	sdk "github.com/onflow/flow-go-sdk"
 	sdkcrypto "github.com/onflow/flow-go-sdk/crypto"
 

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/fxamacker/cbor/v2"
 	"github.com/onflow/crypto"
 	"github.com/vmihailenco/msgpack/v4"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/model/encodable"
 )

--- a/model/flow/identifierList.go
+++ b/model/flow/identifierList.go
@@ -2,8 +2,7 @@ package flow
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // IdentifierList defines a sortable list of identifiers

--- a/model/flow/identity_list.go
+++ b/model/flow/identity_list.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/onflow/crypto"
-	"golang.org/x/exp/slices"
-
 	"github.com/onflow/flow-go/utils/rand"
 )
 

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -2,8 +2,7 @@ package flow
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // DynamicIdentityEntry encapsulates nodeID and dynamic portion of identity.

--- a/model/flow/sealing_segment.go
+++ b/model/flow/sealing_segment.go
@@ -3,8 +3,7 @@ package flow
 import (
 	"errors"
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // SealingSegment is a continuous segment of recently finalized blocks that contains enough history

--- a/model/flow/transaction.go
+++ b/model/flow/transaction.go
@@ -2,11 +2,10 @@ package flow
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/onflow/crypto"
 	"github.com/onflow/crypto/hash"
-	"golang.org/x/exp/slices"
-
 	"github.com/onflow/flow-go/model/fingerprint"
 )
 

--- a/state/protocol/protocol_state/state/mutable_protocol_state_test.go
+++ b/state/protocol/protocol_state/state/mutable_protocol_state_test.go
@@ -2,12 +2,8 @@ package state
 
 import (
 	"errors"
+	"slices"
 	"testing"
-
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"golang.org/x/exp/slices"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/state/protocol"
@@ -18,6 +14,9 @@ import (
 	"github.com/onflow/flow-go/storage/badger/transaction"
 	storagemock "github.com/onflow/flow-go/storage/mock"
 	"github.com/onflow/flow-go/utils/unittest"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestProtocolStateMutator(t *testing.T) {

--- a/storage/badger/dkg_state.go
+++ b/storage/badger/dkg_state.go
@@ -3,11 +3,10 @@ package badger
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/onflow/crypto"
-	"golang.org/x/exp/slices"
-
 	"github.com/onflow/flow-go/model/encodable"
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/module"

--- a/storage/operation/events_test.go
+++ b/storage/operation/events_test.go
@@ -2,9 +2,8 @@ package operation_test
 
 import (
 	"bytes"
+	"slices"
 	"testing"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/stretchr/testify/require"
 

--- a/utils/unittest/cluster.go
+++ b/utils/unittest/cluster.go
@@ -2,8 +2,7 @@ package unittest
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/model/flow/factory"


### PR DESCRIPTION
Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.