### PR TITLE
[Malleability] `flow.TransactionResult` 

### DIFF
--- a/cmd/util/cmd/read-badger/cmd/transaction_results.go
+++ b/cmd/util/cmd/read-badger/cmd/transaction_results.go
@@ -55,7 +55,7 @@ var transactionResultsCmd = &cobra.Command{
 				log.Error().Err(err).Msgf("could not get transaction result for block id and transaction id: %v", txID)
 				return
 			}
-			common.PrettyPrintEntity(transactionResult)
+			common.PrettyPrint(transactionResult)
 		}
 	},
 }

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -521,7 +521,7 @@ func BenchmarkRuntimeTransaction(b *testing.B) {
 			// not interested in the system transaction
 			for _, txRes := range results[0 : len(results)-1] {
 				require.Empty(b, txRes.ErrorMessage)
-				totalInteractionUsed += logE.InteractionUsed[txRes.ID().String()]
+				totalInteractionUsed += logE.InteractionUsed[txRes.TransactionID.String()]
 				totalComputationUsed += txRes.ComputationUsed
 			}
 			b.ReportMetric(float64(totalInteractionUsed/uint64(transactionsPerBlock)), "interactions")

--- a/model/flow/transaction_result.go
+++ b/model/flow/transaction_result.go
@@ -21,15 +21,6 @@ func (t TransactionResult) String() string {
 	return fmt.Sprintf("Transaction ID: %s, Error Message: %s", t.TransactionID.String(), t.ErrorMessage)
 }
 
-// ID returns a canonical identifier that is guaranteed to be unique.
-func (t TransactionResult) ID() Identifier {
-	return t.TransactionID
-}
-
-func (te *TransactionResult) Checksum() Identifier {
-	return te.ID()
-}
-
 // TODO(ramtin): add canonical encoding and ID
 type TransactionResults []TransactionResult
 


### PR DESCRIPTION
https://github.com/onflow/flow-go/issues/6723

### Context

This PR resolves malleability of `flow.TransactionResult` by removing `ID` and fixing usages to depend on data fields instead of `flow.IDEntity` interface.