### PR TITLE
[Malleability] Follow up for fixing root interface implementations in the stdmap package

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1712,30 +1712,13 @@ func (builder *FlowAccessNodeBuilder) Build() (cmd.Node, error) {
 			return nil
 		}).
 		Module("transaction timing mempools", func(node *cmd.NodeConfig) error {
-			var err error
-			builder.TransactionTimings, err = stdmap.NewTransactionTimings(1500 * 300) // assume 1500 TPS * 300 seconds
-			if err != nil {
-				return err
-			}
+			builder.TransactionTimings = stdmap.NewTransactionTimings(1500 * 300) // assume 1500 TPS * 300 seconds
+			builder.CollectionsToMarkFinalized = stdmap.NewTimes(50 * 300)        // assume 50 collection nodes * 300 seconds
+			builder.CollectionsToMarkExecuted = stdmap.NewTimes(50 * 300)         // assume 50 collection nodes * 300 seconds
+			builder.BlockTransactions = stdmap.NewIdentifierMap(10000)
+			builder.BlocksToMarkExecuted = stdmap.NewTimes(1 * 300) // assume 1 block per second * 300 seconds
 
-			builder.CollectionsToMarkFinalized, err = stdmap.NewTimes(50 * 300) // assume 50 collection nodes * 300 seconds
-			if err != nil {
-				return err
-			}
-
-			builder.CollectionsToMarkExecuted, err = stdmap.NewTimes(50 * 300) // assume 50 collection nodes * 300 seconds
-			if err != nil {
-				return err
-			}
-
-			builder.BlockTransactions, err = stdmap.NewIdentifierMap(10000)
-			if err != nil {
-				return err
-			}
-
-			builder.BlocksToMarkExecuted, err = stdmap.NewTimes(1 * 300) // assume 1 block per second * 300 seconds
-
-			return err
+			return nil
 		}).
 		Module("transaction metrics", func(node *cmd.NodeConfig) error {
 			builder.TransactionMetrics = metrics.NewTransactionCollector(

--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -383,8 +383,8 @@ func main() {
 			return nil
 		}).
 		Module("collection guarantees mempool", func(node *cmd.NodeConfig) error {
-			guarantees, err = stdmap.NewGuarantees(guaranteeLimit)
-			return err
+			guarantees = stdmap.NewGuarantees(guaranteeLimit)
+			return nil
 		}).
 		Module("execution receipts mempool", func(node *cmd.NodeConfig) error {
 			receipts = consensusMempools.NewExecutionTree()

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -1699,12 +1699,7 @@ func (builder *ObserverServiceBuilder) enqueueConnectWithStakedAN() {
 
 func (builder *ObserverServiceBuilder) enqueueRPCServer() {
 	builder.Module("transaction metrics", func(node *cmd.NodeConfig) error {
-		var err error
-		builder.TransactionTimings, err = stdmap.NewTransactionTimings(1500 * 300) // assume 1500 TPS * 300 seconds
-		if err != nil {
-			return err
-		}
-
+		builder.TransactionTimings = stdmap.NewTransactionTimings(1500 * 300) // assume 1500 TPS * 300 seconds
 		builder.TransactionMetrics = metrics.NewTransactionCollector(
 			node.Logger,
 			builder.TransactionTimings,

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -464,8 +464,7 @@ func createNode(
 	net := hub.AddNetwork(localNodeID, node)
 
 	guaranteeLimit, sealLimit := uint(1000), uint(1000)
-	guarantees, err := stdmap.NewGuarantees(guaranteeLimit)
-	require.NoError(t, err)
+	guarantees := stdmap.NewGuarantees(guaranteeLimit)
 
 	receipts := consensusMempools.NewExecutionTree()
 

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -634,14 +634,10 @@ func (suite *Suite) TestGetSealedTransaction() {
 		metrics := metrics.NewNoopCollector()
 		transactions := bstorage.NewTransactions(metrics, db)
 		collections := bstorage.NewCollections(db, transactions)
-		collectionsToMarkFinalized, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		collectionsToMarkExecuted, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		blocksToMarkExecuted, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		blockTransactions, err := stdmap.NewIdentifierMap(100)
-		require.NoError(suite.T(), err)
+		collectionsToMarkFinalized := stdmap.NewTimes(100)
+		collectionsToMarkExecuted := stdmap.NewTimes(100)
+		blocksToMarkExecuted := stdmap.NewTimes(100)
+		blockTransactions := stdmap.NewIdentifierMap(100)
 
 		execNodeIdentitiesProvider := commonrpc.NewExecutionNodeIdentitiesProvider(
 			suite.log,
@@ -824,14 +820,10 @@ func (suite *Suite) TestGetTransactionResult() {
 		collections := bstorage.NewCollections(db, transactions)
 		err = collections.Store(collectionNegative)
 		require.NoError(suite.T(), err)
-		collectionsToMarkFinalized, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		collectionsToMarkExecuted, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		blocksToMarkExecuted, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		blockTransactions, err := stdmap.NewIdentifierMap(100)
-		require.NoError(suite.T(), err)
+		collectionsToMarkFinalized := stdmap.NewTimes(100)
+		collectionsToMarkExecuted := stdmap.NewTimes(100)
+		blocksToMarkExecuted := stdmap.NewTimes(100)
+		blockTransactions := stdmap.NewIdentifierMap(100)
 
 		execNodeIdentitiesProvider := commonrpc.NewExecutionNodeIdentitiesProvider(
 			suite.log,
@@ -1107,14 +1099,10 @@ func (suite *Suite) TestExecuteScript() {
 
 		// initialize metrics related storage
 		metrics := metrics.NewNoopCollector()
-		collectionsToMarkFinalized, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		collectionsToMarkExecuted, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		blocksToMarkExecuted, err := stdmap.NewTimes(100)
-		require.NoError(suite.T(), err)
-		blockTransactions, err := stdmap.NewIdentifierMap(100)
-		require.NoError(suite.T(), err)
+		collectionsToMarkFinalized := stdmap.NewTimes(100)
+		collectionsToMarkExecuted := stdmap.NewTimes(100)
+		blocksToMarkExecuted := stdmap.NewTimes(100)
+		blockTransactions := stdmap.NewIdentifierMap(100)
 
 		collectionExecutedMetric, err := indexer.NewCollectionExecutedMetricImpl(
 			suite.log,

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -127,14 +127,10 @@ func (s *Suite) SetupTest() {
 	s.receipts = new(storage.ExecutionReceipts)
 	s.transactions = new(storage.Transactions)
 	s.results = new(storage.ExecutionResults)
-	collectionsToMarkFinalized, err := stdmap.NewTimes(100)
-	require.NoError(s.T(), err)
-	collectionsToMarkExecuted, err := stdmap.NewTimes(100)
-	require.NoError(s.T(), err)
-	blocksToMarkExecuted, err := stdmap.NewTimes(100)
-	require.NoError(s.T(), err)
-	blockTransactions, err := stdmap.NewIdentifierMap(100)
-	require.NoError(s.T(), err)
+	collectionsToMarkFinalized := stdmap.NewTimes(100)
+	collectionsToMarkExecuted := stdmap.NewTimes(100)
+	blocksToMarkExecuted := stdmap.NewTimes(100)
+	blockTransactions := stdmap.NewIdentifierMap(100)
 
 	s.proto.state.On("Identity").Return(s.obsIdentity, nil)
 	s.proto.state.On("Params").Return(s.proto.params)
@@ -172,6 +168,7 @@ func (s *Suite) SetupTest() {
 	header := unittest.BlockHeaderFixture(unittest.WithHeaderHeight(0))
 	s.proto.params.On("FinalizedRoot").Return(header, nil)
 
+	var err error
 	s.collectionExecutedMetric, err = indexer.NewCollectionExecutedMetricImpl(
 		s.log,
 		metrics.NewNoopCollector(),

--- a/engine/testutil/nodes.go
+++ b/engine/testutil/nodes.go
@@ -432,8 +432,7 @@ func ConsensusNode(t *testing.T, hub *stub.Hub, identity bootstrap.NodeInfo, ide
 	resultsDB := storage.NewExecutionResults(node.Metrics, node.PublicDB)
 	receiptsDB := storage.NewExecutionReceipts(node.Metrics, node.PublicDB, resultsDB, storage.DefaultCacheSize)
 
-	guarantees, err := stdmap.NewGuarantees(1000)
-	require.NoError(t, err)
+	guarantees := stdmap.NewGuarantees(1000)
 
 	receipts := consensusMempools.NewExecutionTree()
 

--- a/module/chunks/chunk_assigner.go
+++ b/module/chunks/chunk_assigner.go
@@ -31,13 +31,9 @@ type ChunkAssigner struct {
 // be assigned to each chunk.
 func NewChunkAssigner(alpha uint, protocolState protocol.State) (*ChunkAssigner, error) {
 	// TODO to have limit of assignment mempool as a parameter (2703)
-	assignment, err := stdmap.NewAssignments(1000)
-	if err != nil {
-		return nil, fmt.Errorf("could not create an assignment mempool: %w", err)
-	}
 	return &ChunkAssigner{
 		alpha:         int(alpha),
-		assignments:   assignment,
+		assignments:   stdmap.NewAssignments(1000),
 		protocolState: protocolState,
 	}, nil
 }

--- a/module/mempool/stdmap/assignments.go
+++ b/module/mempool/stdmap/assignments.go
@@ -12,6 +12,6 @@ type Assignments struct {
 }
 
 // NewAssignments creates a new memory pool for Assignments.
-func NewAssignments(limit uint) (*Assignments, error) {
-	return &Assignments{NewBackend(WithLimit[flow.Identifier, *chunkmodels.Assignment](limit))}, nil
+func NewAssignments(limit uint) *Assignments {
+	return &Assignments{NewBackend(WithLimit[flow.Identifier, *chunkmodels.Assignment](limit))}
 }

--- a/module/mempool/stdmap/guarantees.go
+++ b/module/mempool/stdmap/guarantees.go
@@ -12,6 +12,6 @@ type Guarantees struct {
 }
 
 // NewGuarantees creates a new memory pool for collection guarantees.
-func NewGuarantees(limit uint) (*Guarantees, error) {
-	return &Guarantees{NewBackend(WithLimit[flow.Identifier, *flow.CollectionGuarantee](limit))}, nil
+func NewGuarantees(limit uint) *Guarantees {
+	return &Guarantees{NewBackend(WithLimit[flow.Identifier, *flow.CollectionGuarantee](limit))}
 }

--- a/module/mempool/stdmap/guarantees_test.go
+++ b/module/mempool/stdmap/guarantees_test.go
@@ -18,8 +18,7 @@ func TestGuaranteePool(t *testing.T) {
 		CollectionID: flow.Identifier{0x02},
 	}
 
-	pool, err := stdmap.NewGuarantees(1000)
-	require.NoError(t, err)
+	pool := stdmap.NewGuarantees(1000)
 
 	t.Run("should be able to add first", func(t *testing.T) {
 		added := pool.Add(item1.CollectionID, item1)

--- a/module/mempool/stdmap/identifier_map.go
+++ b/module/mempool/stdmap/identifier_map.go
@@ -13,8 +13,8 @@ type IdentifierMap struct {
 }
 
 // NewIdentifierMap creates a new memory pool for sets of Identifier (keyed by some Identifier).
-func NewIdentifierMap(limit uint) (*IdentifierMap, error) {
-	return &IdentifierMap{NewBackend(WithLimit[flow.Identifier, map[flow.Identifier]struct{}](limit))}, nil
+func NewIdentifierMap(limit uint) *IdentifierMap {
+	return &IdentifierMap{NewBackend(WithLimit[flow.Identifier, map[flow.Identifier]struct{}](limit))}
 }
 
 // Append will add the id to the set of identifiers associated with key.

--- a/module/mempool/stdmap/identifier_map_test.go
+++ b/module/mempool/stdmap/identifier_map_test.go
@@ -13,11 +13,7 @@ import (
 )
 
 func TestIdentiferMap(t *testing.T) {
-	idMap, err := NewIdentifierMap(10)
-
-	t.Run("creating new mempool", func(t *testing.T) {
-		require.NoError(t, err)
-	})
+	idMap := NewIdentifierMap(10)
 
 	key1 := unittest.IdentifierFixture()
 	id1 := unittest.IdentifierFixture()
@@ -117,7 +113,7 @@ func TestIdentiferMap(t *testing.T) {
 
 		// removes id1 and id2 from key3
 		// removing id1
-		err = idMap.RemoveIdFromKey(key3, id1)
+		err := idMap.RemoveIdFromKey(key3, id1)
 		require.NoError(t, err)
 
 		// key3 should still reside on idMap and id2 should be attached to it
@@ -149,8 +145,7 @@ func TestIdentiferMap(t *testing.T) {
 // Running this test with `-race` flag detects and reports the existence of race condition if
 // it is the case.
 func TestRaceCondition(t *testing.T) {
-	idMap, err := NewIdentifierMap(10)
-	require.NoError(t, err)
+	idMap := NewIdentifierMap(10)
 
 	wg := sync.WaitGroup{}
 
@@ -190,8 +185,7 @@ func TestCapacity(t *testing.T) {
 		limit = 20
 		swarm = 20
 	)
-	idMap, err := NewIdentifierMap(limit)
-	require.NoError(t, err)
+	idMap := NewIdentifierMap(limit)
 
 	wg := sync.WaitGroup{}
 	wg.Add(swarm)

--- a/module/mempool/stdmap/receipts.go
+++ b/module/mempool/stdmap/receipts.go
@@ -12,7 +12,7 @@ type Receipts struct {
 }
 
 // NewReceipts creates a new memory pool for execution receipts.
-func NewReceipts(limit uint) (*Receipts, error) {
+func NewReceipts(limit uint) *Receipts {
 	// create the receipts memory pool with the lookup maps
-	return &Receipts{NewBackend(WithLimit[flow.Identifier, *flow.ExecutionReceipt](limit))}, nil
+	return &Receipts{NewBackend(WithLimit[flow.Identifier, *flow.ExecutionReceipt](limit))}
 }

--- a/module/mempool/stdmap/receipts_test.go
+++ b/module/mempool/stdmap/receipts_test.go
@@ -14,8 +14,7 @@ func TestReceiptPool(t *testing.T) {
 	item1 := unittest.ExecutionReceiptFixture()
 	item2 := unittest.ExecutionReceiptFixture()
 
-	pool, err := stdmap.NewReceipts(1000)
-	require.NoError(t, err)
+	pool := stdmap.NewReceipts(1000)
 
 	t.Run("should be able to add first", func(t *testing.T) {
 		added := pool.Add(item1.ID(), item1)

--- a/module/mempool/stdmap/times.go
+++ b/module/mempool/stdmap/times.go
@@ -13,6 +13,6 @@ type Times struct {
 }
 
 // NewTimes creates a new memory pool for times.
-func NewTimes(limit uint) (*Times, error) {
-	return &Times{NewBackend(WithLimit[flow.Identifier, time.Time](limit))}, nil
+func NewTimes(limit uint) *Times {
+	return &Times{NewBackend(WithLimit[flow.Identifier, time.Time](limit))}
 }

--- a/module/mempool/stdmap/times_test.go
+++ b/module/mempool/stdmap/times_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/module/mempool/stdmap"
 	"github.com/onflow/flow-go/utils/unittest"
@@ -15,8 +14,7 @@ func TestTimesPool(t *testing.T) {
 	id := unittest.IdentifierFixture()
 	ti := time.Now()
 
-	pool, err := stdmap.NewTimes(3)
-	require.NoError(t, err)
+	pool := stdmap.NewTimes(3)
 
 	t.Run("should be able to add", func(t *testing.T) {
 		added := pool.Add(id, ti)

--- a/module/mempool/stdmap/transaction_timings.go
+++ b/module/mempool/stdmap/transaction_timings.go
@@ -12,6 +12,6 @@ type TransactionTimings struct {
 }
 
 // NewTransactionTimings creates a new memory pool for transaction timings.
-func NewTransactionTimings(limit uint) (*TransactionTimings, error) {
-	return &TransactionTimings{NewBackend(WithLimit[flow.Identifier, *flow.TransactionTiming](limit))}, nil
+func NewTransactionTimings(limit uint) *TransactionTimings {
+	return &TransactionTimings{NewBackend(WithLimit[flow.Identifier, *flow.TransactionTiming](limit))}
 }

--- a/module/mempool/stdmap/transaction_timings_test.go
+++ b/module/mempool/stdmap/transaction_timings_test.go
@@ -17,8 +17,7 @@ func TestTransactionTimingsPool(t *testing.T) {
 		Received: time.Now().Add(-10 * time.Second), Executed: time.Now()}
 	item2 := &flow.TransactionTiming{TransactionID: unittest.IdentifierFixture(), Received: time.Now()}
 
-	pool, err := stdmap.NewTransactionTimings(1000)
-	require.NoError(t, err)
+	pool := stdmap.NewTransactionTimings(1000)
 
 	t.Run("should be able to add first", func(t *testing.T) {
 		added := pool.Add(item1.TransactionID, item1)

--- a/module/metrics/example/verification/main.go
+++ b/module/metrics/example/verification/main.go
@@ -85,30 +85,23 @@ func demo() {
 		<-mc.Ready()
 
 		// creates a receipt mempool and registers a metric on its size
-		receipts, err := stdmap.NewReceipts(100)
-		if err != nil {
-			panic(err)
-		}
+		receipts := stdmap.NewReceipts(100)
 		err = mc.Register(metrics.ResourceReceipt, receipts.Size)
 		if err != nil {
 			panic(err)
 		}
 
 		// creates pending receipt ids by block mempool, and registers size method of backend for metrics
-		receiptIDsByBlock, err := stdmap.NewIdentifierMap(100)
-		if err != nil {
-			panic(err)
-		}
+		receiptIDsByBlock := stdmap.NewIdentifierMap(100)
+
 		err = mc.Register(metrics.ResourcePendingReceiptIDsByBlock, receiptIDsByBlock.Size)
 		if err != nil {
 			panic(err)
 		}
 
 		// creates pending receipt ids by result mempool, and registers size method of backend for metrics
-		receiptIDsByResult, err := stdmap.NewIdentifierMap(100)
-		if err != nil {
-			panic(err)
-		}
+		receiptIDsByResult := stdmap.NewIdentifierMap(100)
+
 		err = mc.Register(metrics.ResourceReceiptIDsByResult, receiptIDsByResult.Size)
 		if err != nil {
 			panic(err)

--- a/module/state_synchronization/indexer/indexer_core_test.go
+++ b/module/state_synchronization/indexer/indexer_core_test.go
@@ -191,14 +191,10 @@ func (i *indexCoreTest) initIndexer() *indexCoreTest {
 
 	i.useDefaultHeights()
 
-	collectionsToMarkFinalized, err := stdmap.NewTimes(100)
-	require.NoError(i.t, err)
-	collectionsToMarkExecuted, err := stdmap.NewTimes(100)
-	require.NoError(i.t, err)
-	blocksToMarkExecuted, err := stdmap.NewTimes(100)
-	require.NoError(i.t, err)
-	blockTransactions, err := stdmap.NewIdentifierMap(100)
-	require.NoError(i.t, err)
+	collectionsToMarkFinalized := stdmap.NewTimes(100)
+	collectionsToMarkExecuted := stdmap.NewTimes(100)
+	blocksToMarkExecuted := stdmap.NewTimes(100)
+	blockTransactions := stdmap.NewIdentifierMap(100)
 
 	log := zerolog.New(os.Stdout)
 	blocks := storagemock.NewBlocks(i.t)


### PR DESCRIPTION
Closes: #7166

## Context

This PR updates the constructors for various memory pools (`Assignments`, `Guarantees`, `IdentifierMap`, `Receipts`, `Times`, `TransactionTimings`) by removing the second return value (`error`). These constructors cannot fail, making the error return unnecessary. Removing it simplifies function signatures and improves readability by cleaning up the calling code.