### PR TITLE
[Malleability] ResultApproval 

### DIFF
--- a/model/flow/resultApproval.go
+++ b/model/flow/resultApproval.go
@@ -55,6 +55,8 @@ type ResultApproval struct {
 	VerifierSignature crypto.Signature
 }
 
+var _ Entity = (*ResultApproval)(nil)
+
 // ID generates a unique identifier using result approval full content
 func (ra ResultApproval) ID() Identifier {
 	stub := struct {

--- a/model/flow/resultApproval.go
+++ b/model/flow/resultApproval.go
@@ -55,12 +55,15 @@ type ResultApproval struct {
 	VerifierSignature crypto.Signature
 }
 
-// ID generates a unique identifier using result approval body
+// ID generates a unique identifier using result approval full content
 func (ra ResultApproval) ID() Identifier {
-	return MakeID(ra.Body)
-}
+	stub := struct {
+		Body              Identifier
+		VerifierSignature crypto.Signature
+	}{
+		Body:              ra.Body.ID(),
+		VerifierSignature: ra.VerifierSignature,
+	}
 
-// Checksum generates checksum using the result approval full content
-func (ra ResultApproval) Checksum() Identifier {
-	return MakeID(ra)
+	return MakeID(stub)
 }

--- a/model/flow/resultApproval.go
+++ b/model/flow/resultApproval.go
@@ -67,3 +67,8 @@ func (ra ResultApproval) ID() Identifier {
 
 	return MakeID(stub)
 }
+
+// Checksum generates checksum using the result approval full content
+func (ra ResultApproval) Checksum() Identifier {
+	return MakeID(ra)
+}

--- a/model/flow/resultApproval_test.go
+++ b/model/flow/resultApproval_test.go
@@ -20,6 +20,13 @@ func TestResultApprovalBodyNonMalleable(t *testing.T) {
 	unittest.RequireEntityNonMalleable(t, &ra.Body)
 }
 
+// TestResultApprovalNonMalleable confirms that the ResultApproval struct, which implements
+// the [flow.IDEntity] interface, is resistant to tampering.
+func TestResultApprovalNonMalleable(t *testing.T) {
+	ra := unittest.ResultApprovalFixture()
+	unittest.RequireEntityNonMalleable(t, ra)
+}
+
 // TestAttestationID_Malleability confirms that the Attestation struct, which implements
 // the [flow.IDEntity] interface, is resistant to tampering.
 func TestAttestationID_Malleability(t *testing.T) {


### PR DESCRIPTION
Closes: #6652 

## Context 

In this PR `ID` method of the `ResultApproval` was fixed by hashing all fields of the struct. Malleability checker test was added as well.