### PR TITLE
[Malleability] Fix ID misuse in ExecutableBlock type

### DIFF
--- a/engine/execution/block_result.go
+++ b/engine/execution/block_result.go
@@ -155,7 +155,7 @@ func NewEmptyBlockAttestationResult(
 		BlockExecutionResult:         blockExecutionResult,
 		collectionAttestationResults: make([]CollectionAttestationResult, 0, colSize),
 		BlockExecutionData: &execution_data.BlockExecutionData{
-			BlockID: blockExecutionResult.ID(),
+			BlockID: blockExecutionResult.BlockID(),
 			ChunkExecutionDatas: make(
 				[]*execution_data.ChunkExecutionData,
 				0,

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -25,7 +25,6 @@ import (
 	"github.com/onflow/flow-go/module/mempool/entity"
 	"github.com/onflow/flow-go/module/trace"
 	"github.com/onflow/flow-go/state/protocol"
-	"github.com/onflow/flow-go/utils/logging"
 )
 
 const (
@@ -330,7 +329,7 @@ func (e *blockComputer) executeBlock(
 		return nil, fmt.Errorf("executable block start state is not set")
 	}
 
-	blockId := block.ID()
+	blockId := block.BlockID()
 	blockIdStr := blockId.String()
 
 	rawCollections := block.Collections()
@@ -420,7 +419,7 @@ func (e *blockComputer) executeBlock(
 	}
 
 	e.log.Debug().
-		Hex("block_id", logging.Entity(block)).
+		Str("block_id", blockIdStr).
 		Msg("all views committed")
 
 	e.metrics.ExecutionBlockCachedPrograms(derivedBlockData.CachedPrograms())

--- a/engine/execution/computation/computer/computer.go
+++ b/engine/execution/computation/computer/computer.go
@@ -419,7 +419,7 @@ func (e *blockComputer) executeBlock(
 	}
 
 	e.log.Debug().
-		Str("block_id", blockIdStr).
+		Hex("block_id", blockId[:]).
 		Msg("all views committed")
 
 	e.metrics.ExecutionBlockCachedPrograms(derivedBlockData.CachedPrograms())

--- a/engine/execution/computation/computer/computer_test.go
+++ b/engine/execution/computation/computer/computer_test.go
@@ -226,7 +226,7 @@ func TestBlockExecutor_ExecuteBlock_VersionAwareChunk(t *testing.T) {
 
 		require.Equal(t, 2, committer.callCount)
 
-		assert.Equal(t, block.ID(), result.BlockExecutionData.BlockID)
+		assert.Equal(t, block.BlockID(), result.BlockExecutionData.BlockID)
 
 		expectedChunk1EndState := incStateCommitment(*block.StartState)
 		expectedChunk2EndState := incStateCommitment(expectedChunk1EndState)
@@ -243,7 +243,7 @@ func TestBlockExecutor_ExecuteBlock_VersionAwareChunk(t *testing.T) {
 			t,
 			parentBlockExecutionResultID,
 			receipt.PreviousResultID)
-		assert.Equal(t, block.ID(), receipt.BlockID)
+		assert.Equal(t, block.BlockID(), receipt.BlockID)
 		assert.NotEqual(t, flow.ZeroID, receipt.ExecutionDataID)
 
 		assert.Len(t, receipt.Chunks, 1+1) // +1 system chunk
@@ -251,7 +251,7 @@ func TestBlockExecutor_ExecuteBlock_VersionAwareChunk(t *testing.T) {
 		chunk1 := receipt.Chunks[0]
 
 		eventCommits := result.AllEventCommitments()
-		assert.Equal(t, block.ID(), chunk1.BlockID)
+		assert.Equal(t, block.BlockID(), chunk1.BlockID)
 		assert.Equal(t, uint(0), chunk1.CollectionIndex)
 		assert.Equal(t, uint64(2), chunk1.NumberOfTransactions)
 		assert.Equal(t, eventCommits[0], chunk1.EventCollection)
@@ -263,7 +263,7 @@ func TestBlockExecutor_ExecuteBlock_VersionAwareChunk(t *testing.T) {
 		assert.Equal(t, expectedChunk1EndState, chunk1.EndState)
 
 		chunk2 := receipt.Chunks[1]
-		assert.Equal(t, block.ID(), chunk2.BlockID)
+		assert.Equal(t, block.BlockID(), chunk2.BlockID)
 		assert.Equal(t, uint(1), chunk2.CollectionIndex)
 		assert.Equal(t, uint64(1), chunk2.NumberOfTransactions)
 		assert.Equal(t, eventCommits[1], chunk2.EventCollection)
@@ -450,7 +450,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 
 		require.Equal(t, 2, committer.callCount)
 
-		assert.Equal(t, block.ID(), result.BlockExecutionData.BlockID)
+		assert.Equal(t, block.BlockID(), result.BlockExecutionData.BlockID)
 
 		expectedChunk1EndState := incStateCommitment(*block.StartState)
 		expectedChunk2EndState := incStateCommitment(expectedChunk1EndState)
@@ -467,7 +467,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 			t,
 			parentBlockExecutionResultID,
 			receipt.PreviousResultID)
-		assert.Equal(t, block.ID(), receipt.BlockID)
+		assert.Equal(t, block.BlockID(), receipt.BlockID)
 		assert.NotEqual(t, flow.ZeroID, receipt.ExecutionDataID)
 
 		assert.Len(t, receipt.Chunks, 1+1) // +1 system chunk
@@ -475,7 +475,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		chunk1 := receipt.Chunks[0]
 
 		eventCommits := result.AllEventCommitments()
-		assert.Equal(t, block.ID(), chunk1.BlockID)
+		assert.Equal(t, block.BlockID(), chunk1.BlockID)
 		assert.Equal(t, uint(0), chunk1.CollectionIndex)
 		assert.Equal(t, uint64(2), chunk1.NumberOfTransactions)
 		assert.Equal(t, eventCommits[0], chunk1.EventCollection)
@@ -487,7 +487,7 @@ func TestBlockExecutor_ExecuteBlock(t *testing.T) {
 		assert.Equal(t, expectedChunk1EndState, chunk1.EndState)
 
 		chunk2 := receipt.Chunks[1]
-		assert.Equal(t, block.ID(), chunk2.BlockID)
+		assert.Equal(t, block.BlockID(), chunk2.BlockID)
 		assert.Equal(t, uint(1), chunk2.CollectionIndex)
 		assert.Equal(t, uint64(1), chunk2.NumberOfTransactions)
 		assert.Equal(t, eventCommits[1], chunk2.EventCollection)

--- a/engine/execution/computation/computer/result_collector.go
+++ b/engine/execution/computation/computer/result_collector.go
@@ -405,7 +405,7 @@ func (collector *resultCollector) Finalize(
 
 	executionResult := flow.NewExecutionResult(
 		collector.parentBlockExecutionResultID,
-		collector.result.ExecutableBlock.ID(),
+		collector.result.ExecutableBlock.BlockID(),
 		collector.result.AllChunks(),
 		collector.result.AllConvertedServiceEvents(),
 		executionDataID)

--- a/engine/execution/computation/manager.go
+++ b/engine/execution/computation/manager.go
@@ -170,7 +170,7 @@ func (e *Manager) ComputeBlock(
 		Msg("received complete block")
 
 	derivedBlockData := e.derivedChainData.GetOrCreateDerivedBlockData(
-		block.ID(),
+		block.BlockID(),
 		block.ParentID())
 
 	result, err := e.blockComputer.ExecuteBlock(

--- a/engine/execution/ingestion/block_queue/queue.go
+++ b/engine/execution/ingestion/block_queue/queue.go
@@ -289,7 +289,7 @@ func (q *BlockQueue) handleKnownBlock(executable *entity.ExecutableBlock, parent
 	// there is no need to create the executable block again, since it's already created.
 	if executable.StartState == nil && parentFinalState != nil {
 		q.log.Warn().
-			Str("blockID", executable.ID().String()).
+			Str("blockID", executable.BlockID().String()).
 			Uint64("height", executable.Block.Header.Height).
 			Hex("parentID", executable.Block.Header.ParentID[:]).
 			Msg("edge case: receiving block with no parent commitment, but its parent block actually has been executed")
@@ -297,7 +297,7 @@ func (q *BlockQueue) handleKnownBlock(executable *entity.ExecutableBlock, parent
 		executables, err := q.onBlockExecuted(executable.Block.Header.ParentID, *parentFinalState)
 		if err != nil {
 			return nil, nil, fmt.Errorf("receiving block %v with parent commitment %v, but parent block %v already exists with no commitment, fail to call mark parent as executed: %w",
-				executable.ID(), *parentFinalState, executable.Block.Header.ParentID, err)
+				executable.BlockID(), *parentFinalState, executable.Block.Header.ParentID, err)
 		}
 
 		// we already have this block, its collection must have been fetched, so we only return the
@@ -311,7 +311,7 @@ func (q *BlockQueue) handleKnownBlock(executable *entity.ExecutableBlock, parent
 	// and we can simply ignore this call.
 	if executable.StartState != nil && parentFinalState == nil {
 		q.log.Warn().
-			Str("blockID", executable.ID().String()).
+			Str("blockID", executable.BlockID().String()).
 			Uint64("height", executable.Block.Header.Height).
 			Hex("parentID", executable.Block.Header.ParentID[:]).
 			Msg("edge case: receiving block with no parent commitment, but its parent block actually has been executed")
@@ -322,11 +322,11 @@ func (q *BlockQueue) handleKnownBlock(executable *entity.ExecutableBlock, parent
 	if *executable.StartState != *parentFinalState {
 		return nil, nil,
 			fmt.Errorf("block %s has already been executed with a different parent final state, %v != %v",
-				executable.ID(), *executable.StartState, parentFinalState)
+				executable.BlockID(), *executable.StartState, parentFinalState)
 	}
 
 	q.log.Warn().
-		Str("blockID", executable.ID().String()).
+		Str("blockID", executable.BlockID().String()).
 		Uint64("height", executable.Block.Header.Height).
 		Msg("edge case: OnBlockExecuted is called with the same arguments again")
 	return nil, nil, nil
@@ -397,7 +397,7 @@ func (q *BlockQueue) checkIfChildBlockBecomeExecutable(
 	for _, childBlock := range blocksAtNextHeight {
 		// a child block at the next height must have the same parent ID
 		// as the current block
-		isChild := childBlock.Block.Header.ParentID == block.ID()
+		isChild := childBlock.Block.Header.ParentID == block.BlockID()
 		if !isChild {
 			continue
 		}
@@ -451,7 +451,7 @@ func (q *BlockQueue) GetMissingCollections(blockID flow.Identifier) (
 
 func missingCollectionForBlock(block *entity.ExecutableBlock, guarantee *flow.CollectionGuarantee) *MissingCollection {
 	return &MissingCollection{
-		BlockID:   block.ID(),
+		BlockID:   block.BlockID(),
 		Height:    block.Block.Header.Height,
 		Guarantee: guarantee,
 	}

--- a/engine/execution/ingestion/core.go
+++ b/engine/execution/ingestion/core.go
@@ -476,8 +476,9 @@ func (e *Core) execute(ctx context.Context, executable *entity.ExecutableBlock) 
 		return nil
 	}
 
+	blockID := executable.BlockID()
 	e.log.Info().
-		Str("block_id", executable.BlockID().String()).
+		Hex("block_id", blockID[:]).
 		Uint64("height", executable.Block.Header.Height).
 		Int("collections", len(executable.CompleteCollections)).
 		Msgf("executing block")

--- a/engine/execution/ingestion/core.go
+++ b/engine/execution/ingestion/core.go
@@ -304,13 +304,10 @@ func (e *Core) enqueuBlock(block *flow.Block, blockID flow.Identifier) (
 		}
 
 		// now re-enqueue the block with parent commit
-		missing, execs, err := e.blockQueue.HandleBlock(block, &parentCommitment)
+		missingColls, executables, err = e.blockQueue.HandleBlock(block, &parentCommitment)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unexpected error while reenqueue block to block queue: %w", err)
 		}
-
-		missingColls = append(missingColls, missing...)
-		executables = append(executables, execs...)
 	}
 
 	lg.Info().Bool("parent_is_executed", false).

--- a/engine/execution/ingestion/core.go
+++ b/engine/execution/ingestion/core.go
@@ -309,8 +309,8 @@ func (e *Core) enqueuBlock(block *flow.Block, blockID flow.Identifier) (
 			return nil, nil, fmt.Errorf("unexpected error while reenqueue block to block queue: %w", err)
 		}
 
-		missingColls = flow.Deduplicate(append(missingColls, missing...))
-		executables = flow.Deduplicate(append(executables, execs...))
+		missingColls = append(missingColls, missing...)
+		executables = append(executables, execs...)
 	}
 
 	lg.Info().Bool("parent_is_executed", false).
@@ -345,7 +345,7 @@ func (e *Core) onBlockExecuted(
 		return fmt.Errorf("cannot persist execution state: %w", err)
 	}
 
-	blockID := block.ID()
+	blockID := block.BlockID()
 	lg := e.log.With().
 		Hex("block_id", blockID[:]).
 		Uint64("height", block.Block.Header.Height).
@@ -477,7 +477,7 @@ func (e *Core) execute(ctx context.Context, executable *entity.ExecutableBlock) 
 	}
 
 	e.log.Info().
-		Hex("block_id", logging.Entity(executable)).
+		Str("block_id", executable.BlockID().String()).
 		Uint64("height", executable.Block.Header.Height).
 		Int("collections", len(executable.CompleteCollections)).
 		Msgf("executing block")

--- a/engine/execution/ingestion/core_test.go
+++ b/engine/execution/ingestion/core_test.go
@@ -180,10 +180,10 @@ type mockExecutor struct {
 	consumer *mockConsumer
 }
 
-func (m *mockExecutor) ExecuteBlock(ctx context.Context, block *entity.ExecutableBlock) (*execution.ComputationResult, error) {
+func (m *mockExecutor) ExecuteBlock(_ context.Context, block *entity.ExecutableBlock) (*execution.ComputationResult, error) {
 	result := testutil.ComputationResultFixture(m.t)
 	result.ExecutableBlock = block
-	result.ExecutionResult.BlockID = block.ID()
+	result.ExecutionResult.BlockID = block.BlockID()
 	log.Info().Msgf("mockExecutor: block %v executed", block.Block.Header.Height)
 	return result, nil
 }
@@ -206,10 +206,10 @@ func newMockConsumer(executed flow.Identifier) *mockConsumer {
 func (m *mockConsumer) BeforeComputationResultSaved(ctx context.Context, result *execution.ComputationResult) {
 }
 
-func (m *mockConsumer) OnComputationResultSaved(ctx context.Context, result *execution.ComputationResult) string {
+func (m *mockConsumer) OnComputationResultSaved(_ context.Context, result *execution.ComputationResult) string {
 	m.Lock()
 	defer m.Unlock()
-	blockID := result.BlockExecutionResult.ExecutableBlock.ID()
+	blockID := result.BlockExecutionResult.ExecutableBlock.BlockID()
 	if _, ok := m.executed[blockID]; ok {
 		return fmt.Sprintf("block %v is already executed", blockID)
 	}

--- a/engine/execution/ingestion/mocks/block_store.go
+++ b/engine/execution/ingestion/mocks/block_store.go
@@ -78,7 +78,7 @@ func (bs *MockBlockStore) MarkExecuted(computationResult *execution.ComputationR
 func (bs *MockBlockStore) CreateBlockAndMockResult(t *testing.T, block *entity.ExecutableBlock) *execution.ComputationResult {
 	bs.Lock()
 	defer bs.Unlock()
-	blockID := block.ID()
+	blockID := block.BlockID()
 	_, exist := bs.ResultByBlock[blockID]
 	require.False(t, exist, "block %s already exists", blockID)
 

--- a/engine/execution/ingestion/uploader/file_uploader.go
+++ b/engine/execution/ingestion/uploader/file_uploader.go
@@ -20,7 +20,7 @@ type FileUploader struct {
 }
 
 func (f *FileUploader) Upload(computationResult *execution.ComputationResult) error {
-	file, err := os.Create(path.Join(f.dir, fmt.Sprintf("%s.cbor", computationResult.ExecutableBlock.ID())))
+	file, err := os.Create(path.Join(f.dir, fmt.Sprintf("%s.cbor", computationResult.ExecutableBlock.BlockID())))
 	if err != nil {
 		return fmt.Errorf("cannot create file for writing block data: %w", err)
 	}

--- a/engine/execution/ingestion/uploader/gcp_uploader.go
+++ b/engine/execution/ingestion/uploader/gcp_uploader.go
@@ -70,5 +70,5 @@ func (u *GCPBucketUploader) Upload(computationResult *execution.ComputationResul
 }
 
 func GCPBlockDataObjectName(computationResult *execution.ComputationResult) string {
-	return fmt.Sprintf("%s.cbor", computationResult.ExecutableBlock.ID().String())
+	return fmt.Sprintf("%s.cbor", computationResult.ExecutableBlock.BlockID().String())
 }

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -111,8 +111,9 @@ func (a *AsyncUploader) UploadTask(ctx context.Context, computationResult *execu
 	// We only log upload errors here because the errors originate from an external cloud provider
 	// and the upload success is not critical to correct continued operation of the node
 	if err != nil {
+		blockID := computationResult.ExecutableBlock.BlockID()
 		a.log.Error().Err(err).
-			Str("block_id", computationResult.ExecutableBlock.BlockID().String()).
+			Hex("block_id", blockID[:]).
 			Msg("failed to upload block data")
 	} else {
 		a.log.Debug().Msgf("computation result of block %s was successfully uploaded",

--- a/engine/execution/ingestion/uploader/uploader.go
+++ b/engine/execution/ingestion/uploader/uploader.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/sethvargo/go-retry"
+
 	"github.com/onflow/flow-go/engine/execution"
 	"github.com/onflow/flow-go/module"
 	"github.com/onflow/flow-go/module/component"
 	"github.com/onflow/flow-go/module/irrecoverable"
-	"github.com/onflow/flow-go/utils/logging"
-
-	"github.com/sethvargo/go-retry"
 )
 
 type Uploader interface {
@@ -99,7 +98,7 @@ func (a *AsyncUploader) UploadTask(ctx context.Context, computationResult *execu
 	start := time.Now()
 
 	a.log.Debug().Msgf("computation result of block %s is being uploaded",
-		computationResult.ExecutableBlock.ID().String())
+		computationResult.ExecutableBlock.BlockID().String())
 
 	err := retry.Do(ctx, backoff, func(ctx context.Context) error {
 		err := a.uploader.Upload(computationResult)
@@ -113,11 +112,11 @@ func (a *AsyncUploader) UploadTask(ctx context.Context, computationResult *execu
 	// and the upload success is not critical to correct continued operation of the node
 	if err != nil {
 		a.log.Error().Err(err).
-			Hex("block_id", logging.Entity(computationResult.ExecutableBlock)).
+			Str("block_id", computationResult.ExecutableBlock.BlockID().String()).
 			Msg("failed to upload block data")
 	} else {
 		a.log.Debug().Msgf("computation result of block %s was successfully uploaded",
-			computationResult.ExecutableBlock.ID().String())
+			computationResult.ExecutableBlock.BlockID().String())
 	}
 
 	a.metrics.ExecutionBlockDataUploadFinished(time.Since(start))

--- a/engine/execution/state/state_storehouse_test.go
+++ b/engine/execution/state/state_storehouse_test.go
@@ -231,13 +231,13 @@ func makeComputationResult(
 
 	executionResult := flow.NewExecutionResult(
 		unittest.IdentifierFixture(),
-		completeBlock.ID(),
+		completeBlock.BlockID(),
 		computationResult.AllChunks(),
 		flow.ServiceEventList{},
 		executionDataID)
 
 	computationResult.BlockAttestationResult.BlockExecutionResult.ExecutionDataRoot = &flow.BlockExecutionDataRoot{
-		BlockID:               completeBlock.ID(),
+		BlockID:               completeBlock.BlockID(),
 		ChunkExecutionDataIDs: []cid.Cid{flow.IdToCid(unittest.IdentifierFixture())},
 	}
 

--- a/engine/execution/state/unittest/fixtures.go
+++ b/engine/execution/state/unittest/fixtures.go
@@ -81,7 +81,7 @@ func ComputationResultForBlockFixture(
 
 	executionResult := flow.NewExecutionResult(
 		parentBlockExecutionResultID,
-		completeBlock.ID(),
+		completeBlock.BlockID(),
 		computationResult.AllChunks(),
 		convertedServiceEvents,
 		executionDataID)

--- a/fvm/fvm_bench_test.go
+++ b/fvm/fvm_bench_test.go
@@ -270,7 +270,7 @@ func (b *BasicBlockExecutor) ExecuteCollections(tb testing.TB, collections [][]*
 	executableBlock.StartState = &b.activeStateCommitment
 
 	derivedBlockData := b.derivedChainData.GetOrCreateDerivedBlockData(
-		executableBlock.ID(),
+		executableBlock.BlockID(),
 		executableBlock.ParentID())
 
 	computationResult, err := b.blockComputer.ExecuteBlock(

--- a/module/mempool/entity/executableblock.go
+++ b/module/mempool/entity/executableblock.go
@@ -17,10 +17,10 @@ type CompleteCollection struct {
 
 // ExecutableBlock represents a block that can be executed by the VM
 //
-// It assumes that the Block attached is immutable, so take care in not modifying or changing the inner
+// It assumes that the attached Block is immutable, so take care in not modifying or changing the inner
 // *flow.Block, otherwise the struct will be in an inconsistent state. It requires the Block is immutable
-// because it lazy loads the Block.ID() into the private id field, on the first call to ExecutableBlock.ID()
-// All future calls to BlockID will not call Block.ID(), therefore it Block changes, the blockID will not match the Block.
+// because it lazily loads the Block.ID() into the private blockID field, on the first call to ExecutableBlock.ID()
+// All future calls to BlockID will not call Block.ID(), therefore if the Block changes, the blockID will not match the Block.
 type ExecutableBlock struct {
 	blockID             flow.Identifier
 	Block               *flow.Block

--- a/module/mempool/entity/executableblock.go
+++ b/module/mempool/entity/executableblock.go
@@ -19,7 +19,7 @@ type CompleteCollection struct {
 //
 // It assumes that the attached Block is immutable, so take care in not modifying or changing the inner
 // *flow.Block, otherwise the struct will be in an inconsistent state. It requires the Block is immutable
-// because it lazily loads the Block.ID() into the private blockID field, on the first call to ExecutableBlock.ID()
+// because it lazy loads the Block.ID() into the private blockID field, on the first call to ExecutableBlock.BlockID()
 // All future calls to BlockID will not call Block.ID(), therefore if the Block changes, the blockID will not match the Block.
 type ExecutableBlock struct {
 	blockID             flow.Identifier

--- a/module/mempool/entity/executableblock.go
+++ b/module/mempool/entity/executableblock.go
@@ -19,10 +19,10 @@ type CompleteCollection struct {
 //
 // It assumes that the Block attached is immutable, so take care in not modifying or changing the inner
 // *flow.Block, otherwise the struct will be in an inconsistent state. It requires the Block is immutable
-// because the it lazy lodas the Block.ID() into the private id field, on the first call to ExecutableBlock.ID()
-// All future calls to ID will not call Block.ID(), therefore it Block changes, the id will not match the Block.
+// because it lazy loads the Block.ID() into the private id field, on the first call to ExecutableBlock.ID()
+// All future calls to BlockID will not call Block.ID(), therefore it Block changes, the blockID will not match the Block.
 type ExecutableBlock struct {
-	id                  flow.Identifier
+	blockID             flow.Identifier
 	Block               *flow.Block
 	CompleteCollections map[flow.Identifier]*CompleteCollection // key is the collection ID.
 	StartState          *flow.StateCommitment
@@ -37,17 +37,13 @@ func (c CompleteCollection) IsCompleted() bool {
 	return len(c.Transactions) > 0
 }
 
-// ID lazy loads the Block.ID() into the private id field on the first call, and returns
+// BlockID lazy loads the Block.ID() into the private blockID field on the first call, and returns
 // the id field in all future calls
-func (b *ExecutableBlock) ID() flow.Identifier {
-	if b.id == flow.ZeroID {
-		b.id = b.Block.ID()
+func (b *ExecutableBlock) BlockID() flow.Identifier {
+	if b.blockID == flow.ZeroID {
+		b.blockID = b.Block.ID()
 	}
-	return b.id
-}
-
-func (b *ExecutableBlock) Checksum() flow.Identifier {
-	return b.Block.Checksum()
+	return b.blockID
 }
 
 func (b *ExecutableBlock) Height() uint64 {

--- a/storage/badger/computation_result_test.go
+++ b/storage/badger/computation_result_test.go
@@ -19,7 +19,7 @@ func TestUpsertAndRetrieveComputationResult(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		expected := testutil.ComputationResultFixture(t)
 		crStorage := bstorage.NewComputationResultUploadStatus(db)
-		crId := expected.ExecutableBlock.ID()
+		crId := expected.ExecutableBlock.BlockID()
 
 		// True case - upsert
 		testUploadStatus := true
@@ -47,7 +47,7 @@ func TestRemoveComputationResults(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		t.Run("Remove ComputationResult", func(t *testing.T) {
 			expected := testutil.ComputationResultFixture(t)
-			crId := expected.ExecutableBlock.ID()
+			crId := expected.ExecutableBlock.BlockID()
 			crStorage := bstorage.NewComputationResultUploadStatus(db)
 
 			testUploadStatus := true
@@ -78,7 +78,7 @@ func TestListComputationResults(t *testing.T) {
 			// Store a list of ComputationResult instances first
 			expectedIDs := make(map[string]bool, 0)
 			for _, cr := range expected {
-				crId := cr.ExecutableBlock.ID()
+				crId := cr.ExecutableBlock.BlockID()
 				expectedIDs[crId.String()] = true
 				err := crStorage.Upsert(crId, true)
 				require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestListComputationResults(t *testing.T) {
 				testutil.ComputationResultFixture(t),
 			}
 			for _, cr := range unexpected {
-				crId := cr.ExecutableBlock.ID()
+				crId := cr.ExecutableBlock.BlockID()
 				err := crStorage.Upsert(crId, false)
 				require.NoError(t, err)
 			}

--- a/storage/badger/operation/computation_result_test.go
+++ b/storage/badger/operation/computation_result_test.go
@@ -18,7 +18,7 @@ import (
 func TestInsertAndUpdateAndRetrieveComputationResultUpdateStatus(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		expected := testutil.ComputationResultFixture(t)
-		expectedId := expected.ExecutableBlock.ID()
+		expectedId := expected.ExecutableBlock.BlockID()
 
 		t.Run("Update existing ComputationResult", func(t *testing.T) {
 			// insert as False
@@ -58,7 +58,7 @@ func TestInsertAndUpdateAndRetrieveComputationResultUpdateStatus(t *testing.T) {
 func TestUpsertAndRetrieveComputationResultUpdateStatus(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		expected := testutil.ComputationResultFixture(t)
-		expectedId := expected.ExecutableBlock.ID()
+		expectedId := expected.ExecutableBlock.BlockID()
 
 		t.Run("Upsert ComputationResult", func(t *testing.T) {
 			// first upsert as false
@@ -90,7 +90,7 @@ func TestUpsertAndRetrieveComputationResultUpdateStatus(t *testing.T) {
 func TestRemoveComputationResultUploadStatus(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		expected := testutil.ComputationResultFixture(t)
-		expectedId := expected.ExecutableBlock.ID()
+		expectedId := expected.ExecutableBlock.BlockID()
 
 		t.Run("Remove ComputationResult", func(t *testing.T) {
 			testUploadStatusVal := true
@@ -123,7 +123,7 @@ func TestListComputationResults(t *testing.T) {
 			expectedIDs := make(map[string]bool, 0)
 			// Store a list of ComputationResult instances first
 			for _, cr := range expected {
-				expectedId := cr.ExecutableBlock.ID()
+				expectedId := cr.ExecutableBlock.BlockID()
 				expectedIDs[expectedId.String()] = true
 				err := db.Update(InsertComputationResultUploadStatus(expectedId, true))
 				require.NoError(t, err)

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -809,7 +809,7 @@ func ExecutableBlockFromTransactions(
 		CompleteCollections: completeCollections,
 	}
 	// Preload the id
-	executableBlock.ID()
+	executableBlock.BlockID()
 	return executableBlock
 }
 


### PR DESCRIPTION
Close: #6672

## Context
The `ExecutableBlock` type implemented `Entity`, but its` ID()` method was misused in various places.

## Changes  
- Renamed `ID()` to `BlockID()` to clarify its purpose and refactored its usages.  

**NOTE**: **The only valid use** of `ExecutableBlock` as an `Entity` was in `enqueueBlock`(`engine/execution/ingestion/core.go`) for `flow.Deduplicate`. However, based on the `HandleBlock` implementation, if an error is returned, both `missingColls` and `executables` are always `nil`, making the deduplication step (`flow.Deduplicate(append(...))`) likely redundant.  
