### PR TITLE
Add string function to StateCommitment type, use in place of marshalJSON

### DIFF
--- a/engine/access/rest/common/models/block.go
+++ b/engine/access/rest/common/models/block.go
@@ -197,21 +197,12 @@ func (b *BlockSeals) Build(seals []*flow.Seal) error {
 }
 
 func (b *BlockSeal) Build(seal *flow.Seal) error {
-	finalState := ""
-	if len(seal.FinalState) > 0 { // todo(sideninja) this is always true?
-		finalStateBytes, err := seal.FinalState.MarshalJSON()
-		if err != nil {
-			return err
-		}
-		finalState = string(finalStateBytes)
-	}
-
 	var aggregatedSigs AggregatedSignatures
 	aggregatedSigs.Build(seal.AggregatedApprovalSigs)
 
 	b.BlockId = seal.BlockID.String()
 	b.ResultId = seal.ResultID.String()
-	b.FinalState = finalState
+	b.FinalState = seal.FinalState.String()
 	b.AggregatedApprovalSignatures = aggregatedSigs
 	return nil
 }

--- a/model/flow/ledger.go
+++ b/model/flow/ledger.go
@@ -271,6 +271,11 @@ func ToStateCommitment(stateBytes []byte) (StateCommitment, error) {
 	return state, nil
 }
 
+func (s StateCommitment) String() string {
+	// Just use the string function of the parent type
+	return hash.Hash(s).String()
+}
+
 func (s StateCommitment) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hex.EncodeToString(s[:]))
 }


### PR DESCRIPTION
Closes #7193 

while building the block model for the rest api, we shouldn't manually call marshalJSON, as that will actually double encode this particular value. Instead, just add string function to the type and call that instead