### PR TITLE
[Malleability] Fix ID misuse in IncorporatedResultSeal type

### DIFF
--- a/model/flow/incorporated_result_seal.go
+++ b/model/flow/incorporated_result_seal.go
@@ -17,14 +17,8 @@ type IncorporatedResultSeal struct {
 	Header *Header
 }
 
-// ID implements flow.Entity.ID for IncorporatedResultSeal to make it capable of
-// being stored directly in mempools and storage.
-func (s *IncorporatedResultSeal) ID() Identifier {
+// IncorporatedResultID returns the identifier of the IncorporatedResult
+// associated with the IncorporatedResultSeal.
+func (s *IncorporatedResultSeal) IncorporatedResultID() Identifier {
 	return s.IncorporatedResult.ID()
-}
-
-// CheckSum implements flow.Entity.CheckSum for IncorporatedResultSeal to make
-// it capable of being stored directly in mempools and storage.
-func (s *IncorporatedResultSeal) Checksum() Identifier {
-	return MakeID(s)
 }

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -158,7 +158,7 @@ func (bs *BuilderSuite) chainSeal(incorporatedResult *flow.IncorporatedResult) {
 	)
 
 	bs.chain = append(bs.chain, incorporatedResultSeal.Seal)
-	bs.irsMap[incorporatedResultSeal.ID()] = incorporatedResultSeal
+	bs.irsMap[incorporatedResultSeal.IncorporatedResultID()] = incorporatedResultSeal
 	bs.irsList = append(bs.irsList, incorporatedResultSeal)
 }
 
@@ -762,7 +762,7 @@ func (bs *BuilderSuite) TestPayloadSeals_Duplicate() {
 func (bs *BuilderSuite) TestPayloadSeals_MissingNextSeal() {
 	// remove the seal for block [F0]
 	firstSeal := bs.irsList[0]
-	delete(bs.irsMap, firstSeal.ID())
+	delete(bs.irsMap, firstSeal.IncorporatedResultID())
 	bs.pendingSeals = bs.irsMap
 
 	_, err := bs.build.BuildOn(bs.parentID, bs.setter, bs.sign)
@@ -786,7 +786,7 @@ func (bs *BuilderSuite) TestPayloadSeals_MissingNextSeal() {
 func (bs *BuilderSuite) TestPayloadSeals_MissingInterimSeal() {
 	// remove a seal for block [F4]
 	seal := bs.irsList[3]
-	delete(bs.irsMap, seal.ID())
+	delete(bs.irsMap, seal.IncorporatedResultID())
 	bs.pendingSeals = bs.irsMap
 
 	_, err := bs.build.BuildOn(bs.parentID, bs.setter, bs.sign)
@@ -1403,7 +1403,7 @@ func storeSealForIncorporatedResult(result *flow.ExecutionResult, incorporatingB
 		unittest.IncorporatedResultSeal.WithResult(result),
 		unittest.IncorporatedResultSeal.WithIncorporatedBlockID(incorporatingBlockID),
 	)
-	pendingSeals[incorporatedResultSeal.ID()] = incorporatedResultSeal
+	pendingSeals[incorporatedResultSeal.IncorporatedResultID()] = incorporatedResultSeal
 	return incorporatedResultSeal
 }
 

--- a/module/mempool/consensus/exec_fork_suppressor.go
+++ b/module/mempool/consensus/exec_fork_suppressor.go
@@ -53,7 +53,7 @@ type ExecForkSuppressor struct {
 
 var _ mempool.IncorporatedResultSeals = (*ExecForkSuppressor)(nil)
 
-// sealSet is a set of seals; internally represented as a map from sealID -> to seal
+// sealSet is a set of seals; internally represented as a map from incorporated result ID -> to seal
 type sealSet map[flow.Identifier]*flow.IncorporatedResultSeal
 
 // sealsList is a list of seals
@@ -133,7 +133,7 @@ func (s *ExecForkSuppressor) Add(newSeal *flow.IncorporatedResultSeal) (bool, er
 		blockSeals = make(sealSet)
 		s.sealsForBlock[blockID] = blockSeals
 	}
-	blockSeals[newSeal.ID()] = newSeal
+	blockSeals[newSeal.IncorporatedResultID()] = newSeal
 
 	// cache block height to prune additional index by height
 	blocksAtHeight, found := s.byHeight[newSeal.Header.Height]

--- a/module/mempool/stdmap/incorporated_result_seals_test.go
+++ b/module/mempool/stdmap/incorporated_result_seals_test.go
@@ -37,7 +37,7 @@ func (m *icrSealsMachine) Add(t *rapid.T) {
 	// we do not re-add already present seals
 	unmet := true
 	for _, v := range m.state {
-		if v.ID() == seal.ID() {
+		if v.IncorporatedResultID() == seal.IncorporatedResultID() {
 			unmet = false
 		}
 	}
@@ -97,7 +97,7 @@ func (m *icrSealsMachine) GetUnknown(t *rapid.T) {
 	// check seal is unknown
 	unknown := true
 	for _, v := range m.state {
-		if v.ID() == seal.ID() {
+		if v.IncorporatedResultID() == seal.IncorporatedResultID() {
 			unknown = false
 		}
 	}
@@ -145,7 +145,7 @@ func (m *icrSealsMachine) RemoveUnknown(t *rapid.T) {
 	// check seal is unknown
 	unknown := true
 	for _, v := range m.state {
-		if v.ID() == seal.ID() {
+		if v.IncorporatedResultID() == seal.IncorporatedResultID() {
 			unknown = false
 		}
 	}


### PR DESCRIPTION
Close:  #6705

## Context

The `IncorporatedResultSeal` type previously implemented `Entity`, but its `ID()` method was misused in several places. This PR corrects those usages.  

### Changes  

- `ExecForkSuppressor` (`module/mempool/consensus/exec_fork_suppressor.go`)
  Since`mempool.IncorporatedResultSeals` stores seals by the `ID` of the incorporated result. `ExecForkSuppressor` also stores a set of seals indexed by `incorporated result ID`.  

- Updated usages in unit tests