### PR TITLE
[Malleability] Fixed misuse of ID for IncorporatedResult and MockEntity

### DIFF
--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -21,8 +21,15 @@ func NewIncorporatedResult(incorporatedBlockID Identifier, result *ExecutionResu
 	}
 }
 
-// ID returns unique identifier for the IncorporatedResult struct.
+// ID implements flow.Entity.ID for IncorporatedResult to make it capable of
+// being stored directly in mempools and storage.
 func (ir *IncorporatedResult) ID() Identifier {
+	return MakeID([2]Identifier{ir.IncorporatedBlockID, ir.Result.ID()})
+}
+
+// CheckSum implements flow.Entity.CheckSum for IncorporatedResult to make it
+// capable of being stored directly in mempools and storage.
+func (ir *IncorporatedResult) Checksum() Identifier {
 	return MakeID(ir)
 }
 

--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -21,15 +21,8 @@ func NewIncorporatedResult(incorporatedBlockID Identifier, result *ExecutionResu
 	}
 }
 
-// ID implements flow.Entity.ID for IncorporatedResult to make it capable of
-// being stored directly in mempools and storage.
+// ID returns unique identifier for the IncorporatedResult struct.
 func (ir *IncorporatedResult) ID() Identifier {
-	return MakeID([2]Identifier{ir.IncorporatedBlockID, ir.Result.ID()})
-}
-
-// CheckSum implements flow.Entity.CheckSum for IncorporatedResult to make it
-// capable of being stored directly in mempools and storage.
-func (ir *IncorporatedResult) Checksum() Identifier {
 	return MakeID(ir)
 }
 

--- a/module/mempool/queue/heroQueue_test.go
+++ b/module/mempool/queue/heroQueue_test.go
@@ -28,10 +28,10 @@ func TestHeroQueue_Sequential(t *testing.T) {
 	entities := unittest.EntityListFixture(uint(sizeLimit))
 	// pushing entities sequentially.
 	for i, e := range entities {
-		require.True(t, q.Push(e.ID(), e))
+		require.True(t, q.Push(e.Identifier, e))
 
 		// duplicate push should fail
-		require.False(t, q.Push(e.ID(), e))
+		require.False(t, q.Push(e.Identifier, e))
 
 		require.Equal(t, q.Size(), uint(i+1))
 	}
@@ -39,7 +39,7 @@ func TestHeroQueue_Sequential(t *testing.T) {
 	// once queue meets the size limit, any extra push should fail.
 	for i := 0; i < 100; i++ {
 		entity := unittest.MockEntityFixture()
-		require.False(t, q.Push(entity.ID(), entity))
+		require.False(t, q.Push(entity.Identifier, entity))
 
 		// size should not change
 		require.Equal(t, q.Size(), uint(sizeLimit))
@@ -50,7 +50,7 @@ func TestHeroQueue_Sequential(t *testing.T) {
 		popedE, ok := q.Pop()
 		require.True(t, ok)
 		require.Equal(t, e, popedE)
-		require.Equal(t, e.ID(), popedE.ID())
+		require.Equal(t, e.Identifier, popedE.Identifier)
 
 		require.Equal(t, q.Size(), uint(len(entities)-i-1))
 	}
@@ -75,7 +75,7 @@ func TestHeroQueue_Concurrent(t *testing.T) {
 	for _, e := range entities {
 		e := e // suppress loop variable
 		go func() {
-			require.True(t, q.Push(e.ID(), e))
+			require.True(t, q.Push(e.Identifier, e))
 			pushWG.Done()
 		}()
 	}
@@ -86,7 +86,7 @@ func TestHeroQueue_Concurrent(t *testing.T) {
 	for i := 0; i < sizeLimit; i++ {
 		go func() {
 			entity := unittest.MockEntityFixture()
-			require.False(t, q.Push(entity.ID(), entity))
+			require.False(t, q.Push(entity.Identifier, entity))
 			pushWG.Done()
 		}()
 	}

--- a/module/mempool/stdmap/backDataHeapBenchmark_test.go
+++ b/module/mempool/stdmap/backDataHeapBenchmark_test.go
@@ -81,9 +81,9 @@ func testAddEntities(t testing.TB, limit uint, b *stdmap.Backend[flow.Identifier
 	// adding elements
 	t1 := time.Now()
 	for i, e := range entities {
-		require.False(t, b.Has(e.ID()))
+		require.False(t, b.Has(e.Identifier))
 		// adding each element must be successful.
-		require.True(t, b.Add(e.ID(), e))
+		require.True(t, b.Add(e.Identifier, e))
 
 		if uint(i) < limit {
 			// when we are below limit the total of
@@ -96,7 +96,7 @@ func testAddEntities(t testing.TB, limit uint, b *stdmap.Backend[flow.Identifier
 		}
 
 		// entity should be immediately retrievable
-		actual, ok := b.Get(e.ID())
+		actual, ok := b.Get(e.Identifier)
 		require.True(t, ok)
 		require.Equal(t, e, actual)
 	}

--- a/module/mempool/stdmap/backdata/mapBackData_test.go
+++ b/module/mempool/stdmap/backdata/mapBackData_test.go
@@ -16,13 +16,13 @@ func TestMapBackData_StoreAnd(t *testing.T) {
 	// Add
 	for _, e := range entities {
 		// all entities must be stored successfully
-		require.True(t, backData.Add(e.ID(), e))
+		require.True(t, backData.Add(e.Identifier, e))
 	}
 
 	// Get
 	for _, expected := range entities {
 		// all entities must be retrievable successfully
-		actual, ok := backData.Get(expected.ID())
+		actual, ok := backData.Get(expected.Identifier)
 		require.True(t, ok)
 		require.Equal(t, expected, actual)
 	}
@@ -31,7 +31,7 @@ func TestMapBackData_StoreAnd(t *testing.T) {
 	all := backData.All()
 	require.Equal(t, len(entities), len(all))
 	for _, expected := range entities {
-		actual, ok := backData.Get(expected.ID())
+		actual, ok := backData.Get(expected.Identifier)
 		require.True(t, ok)
 		require.Equal(t, expected, actual)
 	}
@@ -54,12 +54,16 @@ func TestMapBackData_StoreAnd(t *testing.T) {
 func TestMapBackData_AdjustWithInit(t *testing.T) {
 	backData := NewMapBackData[flow.Identifier, *unittest.MockEntity]()
 	entities := unittest.EntityListFixture(100)
-	ids := flow.GetIDs(entities)
+
+	ids := make([]flow.Identifier, 0, len(entities))
+	for _, entity := range entities {
+		ids = append(ids, entity.Identifier)
+	}
 
 	// AdjustWithInit
 	for _, e := range entities {
 		// all entities must be adjusted successfully
-		actual, ok := backData.AdjustWithInit(e.ID(), func(entity *unittest.MockEntity) *unittest.MockEntity {
+		actual, ok := backData.AdjustWithInit(e.Identifier, func(entity *unittest.MockEntity) *unittest.MockEntity {
 			// increment nonce of the entity
 			entity.Nonce++
 			return entity
@@ -74,9 +78,9 @@ func TestMapBackData_AdjustWithInit(t *testing.T) {
 	all := backData.All()
 	require.Equal(t, len(entities), len(all))
 	for _, expected := range entities {
-		actual, ok := backData.Get(expected.ID())
+		actual, ok := backData.Get(expected.Identifier)
 		require.True(t, ok)
-		require.Equal(t, expected.ID(), actual.ID())
+		require.Equal(t, expected.Identifier, actual.Identifier)
 		require.Equal(t, uint64(1), actual.Nonce)
 	}
 
@@ -96,9 +100,9 @@ func TestMapBackData_AdjustWithInit(t *testing.T) {
 	// Get
 	for _, e := range entities {
 		// all entities must be retrieved successfully
-		actual, ok := backData.Get(e.ID())
+		actual, ok := backData.Get(e.Identifier)
 		require.True(t, ok)
-		require.Equal(t, e.ID(), actual.ID())
+		require.Equal(t, e.Identifier, actual.Identifier)
 		require.Equal(t, uint64(1), actual.Nonce)
 	}
 }

--- a/module/mempool/stdmap/eject_test.go
+++ b/module/mempool/stdmap/eject_test.go
@@ -185,9 +185,9 @@ func TestLRUEjector_UntrackEject(t *testing.T) {
 
 	for i := 0; i < size; i++ {
 		mockEntity := unittest.MockEntityFixture()
-		require.True(t, backEnd.Add(mockEntity.ID(), mockEntity))
+		require.True(t, backEnd.Add(mockEntity.Identifier, mockEntity))
 
-		id := mockEntity.ID()
+		id := mockEntity.Identifier
 		ejector.Track(id)
 		items[i] = id
 	}
@@ -213,9 +213,9 @@ func TestLRUEjector_EjectAll(t *testing.T) {
 
 	for i := 0; i < size; i++ {
 		mockEntity := unittest.MockEntityFixture()
-		require.True(t, backEnd.Add(mockEntity.ID(), mockEntity))
+		require.True(t, backEnd.Add(mockEntity.Identifier, mockEntity))
 
-		id := mockEntity.ID()
+		id := mockEntity.Identifier
 		ejector.Track(id)
 		items[i] = id
 	}

--- a/utils/unittest/entity.go
+++ b/utils/unittest/entity.go
@@ -13,32 +13,6 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// MockEntity implements a bare minimum entity for sake of test.
-type MockEntity struct {
-	Identifier flow.Identifier
-	Nonce      uint64
-}
-
-func (m MockEntity) ID() flow.Identifier {
-	return m.Identifier
-}
-
-func (m MockEntity) Checksum() flow.Identifier {
-	return m.Identifier
-}
-
-func EntityListFixture(n uint) []*MockEntity {
-	list := make([]*MockEntity, 0, n)
-	for range n {
-		list = append(list, MockEntityFixture())
-	}
-	return list
-}
-
-func MockEntityFixture() *MockEntity {
-	return &MockEntity{Identifier: IdentifierFixture()}
-}
-
 // RequireEntityNonMalleable is a sanity check that the entity is not malleable with regards to the ID() function.
 // Non-malleability in this sense means that it is computationally hard to build a different entity with the same ID.
 // Hence, changing *any* field of a non-malleable entity should change the ID, which we check here.

--- a/utils/unittest/util.go
+++ b/utils/unittest/util.go
@@ -1,0 +1,30 @@
+package unittest
+
+import "github.com/onflow/flow-go/model/flow"
+
+// MockEntity implements a bare minimum entity for sake of test.
+type MockEntity struct {
+	Identifier flow.Identifier
+	Nonce      uint64
+}
+
+//
+//func (m MockEntity) ID() flow.Identifier {
+//	return m.Identifier
+//}
+//
+//func (m MockEntity) Checksum() flow.Identifier {
+//	return m.Identifier
+//}
+
+func EntityListFixture(n uint) []*MockEntity {
+	list := make([]*MockEntity, 0, n)
+	for range n {
+		list = append(list, MockEntityFixture())
+	}
+	return list
+}
+
+func MockEntityFixture() *MockEntity {
+	return &MockEntity{Identifier: IdentifierFixture()}
+}

--- a/utils/unittest/util.go
+++ b/utils/unittest/util.go
@@ -8,15 +8,6 @@ type MockEntity struct {
 	Nonce      uint64
 }
 
-//
-//func (m MockEntity) ID() flow.Identifier {
-//	return m.Identifier
-//}
-//
-//func (m MockEntity) Checksum() flow.Identifier {
-//	return m.Identifier
-//}
-
 func EntityListFixture(n uint) []*MockEntity {
 	list := make([]*MockEntity, 0, n)
 	for range n {

--- a/utils/unittest/util.go
+++ b/utils/unittest/util.go
@@ -1,8 +1,12 @@
 package unittest
 
-import "github.com/onflow/flow-go/model/flow"
+import (
+	"github.com/onflow/flow-go/model/flow"
+)
 
-// MockEntity implements a bare minimum entity for sake of test.
+// MockEntity is a simple struct used for testing mempools that work with entities.
+// It provides an Identifier and a Nonce field to simulate basic entity behavior.
+// This allows for controlled testing of how mempools handle entity storage and updates.
 type MockEntity struct {
 	Identifier flow.Identifier
 	Nonce      uint64

--- a/utils/unittest/util.go
+++ b/utils/unittest/util.go
@@ -4,8 +4,10 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 )
 
-// MockEntity is a simple struct used for testing mempools that work with entities.
-// It provides an Identifier and a Nonce field to simulate basic entity behavior.
+// MockEntity is a simple struct used for testing mempools constrained to Identifier-typed keys.
+// The Identifier field is the key used to store the entity in the mempool. 
+// The Nonce field can be used to simulate modifying the entity value stored in the mempool,
+// for example via `Adjust`/`AdjustWithInit` methods.
 // This allows for controlled testing of how mempools handle entity storage and updates.
 type MockEntity struct {
 	Identifier flow.Identifier


### PR DESCRIPTION
Closes: #6675, #6680.

## Context
The `IncorporatedResult` and `MockEntity` structs previously implemented the `Entity` interface, but their `ID()` method was misused. This PR corrects that issue.

## Changes

- The `Checksum` method was removed from `IncorporatedResult`, and its `ID()` method is now used solely to identify the struct, rather than to implement the `Entity` interface.
- `MockEntity` has been refactored to serve as a standalone struct for testing mempool functionality.
- Updated unit tests to reflect these changes.