### PR TITLE
[Malleability] Chunk

### DIFF
--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -144,7 +144,7 @@ var _ rlp.Encoder = &Chunk{}
 // not interpreted as the RLP encoding for the entire Chunk.
 // No errors expected during normal operation.
 // TODO(mainnet27, #6773): remove this method https://github.com/onflow/flow-go/issues/6773
-func (ch Chunk) EncodeRLP(w io.Writer) error {
+func (ch *Chunk) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, struct {
 		ChunkBody ChunkBody
 		Index     uint64
@@ -225,9 +225,9 @@ func NewChunk_ProtocolVersion1(
 	}
 }
 
-// ID returns a unique id for this entity
+// ID returns the unique identifier of the Chunk
 func (ch *Chunk) ID() Identifier {
-	return MakeID(ch.ChunkBody)
+	return MakeID(ch)
 }
 
 // Checksum provides a cryptographic commitment for a chunk content
@@ -319,16 +319,6 @@ func (cl ChunkList) Indices() []uint64 {
 	}
 
 	return indices
-}
-
-// ByChecksum returns an entity from the list by entity fingerprint
-func (cl ChunkList) ByChecksum(cs Identifier) (*Chunk, bool) {
-	for _, ch := range cl {
-		if ch.Checksum() == cs {
-			return ch, true
-		}
-	}
-	return nil, false
 }
 
 // ByIndex returns an entity from the list by index

--- a/model/flow/chunk_test.go
+++ b/model/flow/chunk_test.go
@@ -368,7 +368,7 @@ func TestChunk_ModelVersions_EncodeDecode(t *testing.T) {
 //
 // Backward compatibility is implemented by providing a custom EncodeRLP method.
 func TestChunk_FingerprintBackwardCompatibility(t *testing.T) {
-	chunk := unittest.ChunkFixture(unittest.IdentifierFixture(), 0, unittest.StateCommitmentFixture())
+	chunk := unittest.ChunkFixture(unittest.IdentifierFixture(), 1, unittest.StateCommitmentFixture())
 	chunk.ServiceEventCount = nil
 
 	// Define an older type which use flow.ChunkBodyV0

--- a/model/flow/chunk_test.go
+++ b/model/flow/chunk_test.go
@@ -29,58 +29,6 @@ func TestChunkList_ByIndex(t *testing.T) {
 	require.True(t, ok)
 }
 
-// TestDistinctChunkIDs_EmptyChunks evaluates that two empty chunks
-// with the distinct block ids would have distinct chunk ids.
-func TestDistinctChunkIDs_EmptyChunks(t *testing.T) {
-	// generates two random block ids and requires them
-	// being distinct
-	blockIdA := unittest.IdentifierFixture()
-	blockIdB := unittest.IdentifierFixture()
-	require.NotEqual(t, blockIdA, blockIdB)
-
-	// generates a chunk associated with each block id
-	chunkA := &flow.Chunk{
-		ChunkBody: flow.ChunkBody{
-			BlockID: blockIdA,
-		},
-	}
-
-	chunkB := &flow.Chunk{
-		ChunkBody: flow.ChunkBody{
-			BlockID: blockIdB,
-		},
-	}
-
-	require.NotEqual(t, chunkA.ID(), chunkB.ID())
-}
-
-// TestDistinctChunkIDs_FullChunks evaluates that two full chunks
-// with completely identical fields but distinct block ids have
-// distinct chunk ids.
-func TestDistinctChunkIDs_FullChunks(t *testing.T) {
-	// generates two random block ids and requires them
-	// being distinct
-	blockIdA := unittest.IdentifierFixture()
-	blockIdB := unittest.IdentifierFixture()
-	require.NotEqual(t, blockIdA, blockIdB)
-
-	// generates a chunk associated with blockA
-	chunkA := unittest.ChunkFixture(blockIdA, 42, unittest.StateCommitmentFixture())
-
-	// generates a deep copy of chunkA in chunkB
-	chunkB := *chunkA
-
-	// since chunkB is a deep copy of chunkA their
-	// chunk ids should be the same
-	require.Equal(t, chunkA.ID(), chunkB.ID())
-
-	// changes block id in chunkB
-	chunkB.BlockID = blockIdB
-
-	// chunks with distinct block ids should have distinct chunk ids
-	require.NotEqual(t, chunkA.ID(), chunkB.ID())
-}
-
 // TestChunkList_Indices evaluates the Indices method of ChunkList on lists of different sizes.
 func TestChunkList_Indices(t *testing.T) {
 	cl := unittest.ChunkListFixture(5, unittest.IdentifierFixture(), unittest.StateCommitmentFixture())

--- a/model/flow/chunk_test.go
+++ b/model/flow/chunk_test.go
@@ -406,8 +406,13 @@ func TestChunkMalleability(t *testing.T) {
 
 	// TODO(mainnet27, #6773): remove this test according to https://github.com/onflow/flow-go/issues/6773
 	t.Run("Chunk with nil ServiceEventCount", func(t *testing.T) {
-		unittest.RequireEntityNonMalleable(t, unittest.ChunkFixture(unittest.IdentifierFixture(), 0, unittest.StateCommitmentFixture(), func(c *flow.Chunk) {
-			c.ServiceEventCount = nil
-		}))
+		unittest.RequireEntityNonMalleable(
+			t,
+			unittest.ChunkFixture(unittest.IdentifierFixture(), 0, unittest.StateCommitmentFixture(), func(c *flow.Chunk) {
+				c.ServiceEventCount = nil
+			}),
+			// We pin the `ServiceEventCount` to the current value (nil), so `MalleabilityChecker` will not mutate this field:
+			unittest.WithPinnedField("ChunkBody.ServiceEventCount"),
+		)
 	})
 }


### PR DESCRIPTION
Close: #6659

## Context  
This PR resolves the malleability of `flow.Chunk` by updating the `ID()` method based on all the data (`Index` and `EndState` were not included in `ID()` previously). It also ensures the correct `EncodeRLP` implementation for `flow.Chunk` and `flow.ChunkBody`.  

## Changes  
- Added a unit test to verify that `flow.Chunk` is not malleable.  
- Updated unit tests to reflect the changes. 
- Removed `ByChecksum` as it was unused.  
- Removed `TestDistinctChunkIDs_EmptyChunks` and `TestDistinctChunkIDs_FullChunks`, as they are both checking that changing a field in the `ChunkBody` changes the `ID`, which is already be covered by the new `TestChunkMalleability`.
