### PR TITLE
[Malleability] Fix ID implementation of IncorporatedResult type

### DIFF
--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -21,7 +21,7 @@ func NewIncorporatedResult(incorporatedBlockID Identifier, result *ExecutionResu
 	}
 }
 
-// ID returns unique identifier for the IncorporatedResult struct.
+// ID returns a collision-resistant hash for the [IncorporatedResult] structure.
 func (ir *IncorporatedResult) ID() Identifier {
 	return MakeID(ir)
 }

--- a/model/flow/incorporated_result.go
+++ b/model/flow/incorporated_result.go
@@ -21,15 +21,8 @@ func NewIncorporatedResult(incorporatedBlockID Identifier, result *ExecutionResu
 	}
 }
 
-// ID implements flow.Entity.ID for IncorporatedResult to make it capable of
-// being stored directly in mempools and storage.
+// ID returns unique identifier for the IncorporatedResult struct.
 func (ir *IncorporatedResult) ID() Identifier {
-	return MakeID([2]Identifier{ir.IncorporatedBlockID, ir.Result.ID()})
-}
-
-// CheckSum implements flow.Entity.CheckSum for IncorporatedResult to make it
-// capable of being stored directly in mempools and storage.
-func (ir *IncorporatedResult) Checksum() Identifier {
 	return MakeID(ir)
 }
 

--- a/model/flow/incorporated_result_test.go
+++ b/model/flow/incorporated_result_test.go
@@ -41,3 +41,13 @@ func TestIncorporatedResultGroupBy(t *testing.T) {
 	unknown := groups.GetGroup(unittest.IdentifierFixture())
 	assert.Equal(t, 0, unknown.Size())
 }
+
+// TestIncorporatedResultID_Malleability confirms that the IncorporatedResult struct, which implements
+// the [flow.IDEntity] interface, is resistant to tampering.
+func TestIncorporatedResultID_Malleability(t *testing.T) {
+	unittest.RequireEntityNonMalleable(t,
+		flow.NewIncorporatedResult(unittest.IdentifierFixture(), unittest.ExecutionResultFixture()),
+		unittest.WithFieldGenerator("Result.ServiceEvents", func() []flow.ServiceEvent {
+			return unittest.ServiceEventsFixture(3)
+		}))
+}


### PR DESCRIPTION
Closes: #6675.

## Context
The `IncorporatedResult` previously implemented the `Entity` interface without any need. This PR corrects that issue and fixed implementation of the `ID` method.

## Changes

- The `Checksum` method was removed from `IncorporatedResult`, and its `ID()` method is now used solely to identify the struct.
- Added unit test with the Malleability checker to reflect these changes.