### PR TITLE
[Storage] Close BadgerDB before db init functions return error

### DIFF
--- a/storage/badger/init.go
+++ b/storage/badger/init.go
@@ -20,6 +20,9 @@ func InitPublic(opts badger.Options) (*badger.DB, error) {
 	}
 	err = db.Update(operation.InsertPublicDBMarker)
 	if err != nil {
+		// Close db before returning error.
+		db.Close()
+
 		return nil, fmt.Errorf("could not assert db type: %w", err)
 	}
 
@@ -38,6 +41,9 @@ func InitSecret(opts badger.Options) (*badger.DB, error) {
 	}
 	err = db.Update(operation.InsertSecretDBMarker)
 	if err != nil {
+		// Close db before returning error.
+		db.Close()
+
 		return nil, fmt.Errorf("could not assert db type: %w", err)
 	}
 


### PR DESCRIPTION
Currently, the `InitPublic()` and `InitSecrets()` functions can successfully open BadgerDB and then return an error without allowing the caller to close the database.

This PR updates `InitPublic()` and `InitSecrets()` to close the opened database before they return an error.