### PR TITLE
[Storage] Remove old code in `initBadgerDB()`

### DIFF
--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1121,9 +1121,6 @@ func (fnb *FlowNodeBuilder) initBadgerDB() error {
 		return fmt.Errorf("could not open public db: %w", err)
 	}
 	fnb.DB = publicDB
-	// set badger db as protocol db
-	// TODO: making it dynamic to switch between badger and pebble
-	fnb.ProtocolDB = badgerimpl.ToDB(publicDB)
 
 	fnb.ShutdownFunc(func() error {
 		if err := publicDB.Close(); err != nil {


### PR DESCRIPTION
Currently, `initProtocolDB()` sets `ProtocolDB` to either BadgerDB or PebbleDB depending on `dbops`. But there is still some old code that sets `ProtocolDB` to BadgerDB in `initBadgerDB()`.

This PR removes the old code in `initBadgerDB()`.