### PR TITLE
Extend Malleability Checker to non-Entity types

### DIFF
--- a/model/flow/epoch_test.go
+++ b/model/flow/epoch_test.go
@@ -27,7 +27,7 @@ func TestMalleability(t *testing.T) {
 		checker := unittest.NewMalleabilityChecker(unittest.WithFieldGenerator("DKGIndexMap", func() flow.DKGIndexMap {
 			return flow.DKGIndexMap{unittest.IdentifierFixture(): 0, unittest.IdentifierFixture(): 1}
 		}))
-		err := checker.Check(unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
+		err := checker.CheckEntity(unittest.EpochCommitFixture(func(commit *flow.EpochCommit) {
 			commit.DKGIndexMap = flow.DKGIndexMap{unittest.IdentifierFixture(): 0, unittest.IdentifierFixture(): 1}
 		}))
 		require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestMalleability(t *testing.T) {
 		checker := unittest.NewMalleabilityChecker(unittest.WithFieldGenerator("EpochCommit.DKGIndexMap", func() flow.DKGIndexMap {
 			return flow.DKGIndexMap{unittest.IdentifierFixture(): 0, unittest.IdentifierFixture(): 1}
 		}))
-		err := checker.Check(unittest.EpochRecoverFixture())
+		err := checker.CheckEntity(unittest.EpochRecoverFixture())
 		require.NoError(t, err)
 	})
 

--- a/utils/unittest/entity.go
+++ b/utils/unittest/entity.go
@@ -183,22 +183,10 @@ func NewMalleabilityChecker(ops ...MalleabilityCheckerOpt) *MalleabilityChecker 
 // It returns an error if the entity is malleable, otherwise it returns nil.
 // No errors are expected during normal operations.
 func (mc *MalleabilityChecker) CheckEntity(entity flow.IDEntity) error {
-	v := reflect.ValueOf(entity)
-	if !v.IsValid() {
-		return fmt.Errorf("input is not a valid entity")
+	if entity == nil {
+		return fmt.Errorf("entity is nil")
 	}
-	if v.Kind() != reflect.Ptr {
-		// If it is not a pointer type, we may not be able to set fields to test malleability, since the entity may not be addressable
-		return fmt.Errorf("entity is not a pointer type (try checking a reference to it), entity: %v %v", v.Kind(), v.Type())
-	}
-	if v.IsNil() {
-		return fmt.Errorf("entity is nil, nothing to check")
-	}
-	v = v.Elem()
-	if err := mc.isEntityMalleable(v, nil, "", entity.ID); err != nil {
-		return err
-	}
-	return mc.checkExpectations()
+	return mc.Check(entity, entity.ID)
 }
 
 // Check is a method that performs the malleability check on the input model.
@@ -212,14 +200,14 @@ func (mc *MalleabilityChecker) CheckEntity(entity flow.IDEntity) error {
 func (mc *MalleabilityChecker) Check(model any, hashModel func() flow.Identifier) error {
 	v := reflect.ValueOf(model)
 	if !v.IsValid() {
-		return fmt.Errorf("input is not a valid model")
+		return fmt.Errorf("input is not a valid entity")
 	}
 	if v.Kind() != reflect.Ptr {
 		// If it is not a pointer type, we may not be able to set fields to test malleability, since the model may not be addressable
-		return fmt.Errorf("model is not a pointer type (try checking a reference to it), model: %v %v", v.Kind(), v.Type())
+		return fmt.Errorf("entity is not a pointer type (try checking a reference to it), entity: %v %v", v.Kind(), v.Type())
 	}
 	if v.IsNil() {
-		return fmt.Errorf("model is nil, nothing to check")
+		return fmt.Errorf("entity is nil, nothing to check")
 	}
 	v = v.Elem()
 	if err := mc.isEntityMalleable(v, nil, "", hashModel); err != nil {

--- a/utils/unittest/entity_test.go
+++ b/utils/unittest/entity_test.go
@@ -161,25 +161,25 @@ func TestRequireEntityNonMalleable(t *testing.T) {
 		})
 	})
 	t.Run("invalid-entity", func(t *testing.T) {
-		err := NewMalleabilityChecker().Check(nil)
+		err := NewMalleabilityChecker().CheckEntity(nil)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "input is not a valid entity")
 	})
 	t.Run("nil-entity", func(t *testing.T) {
 		var e *flow.ExecutionReceipt = nil
-		err := NewMalleabilityChecker().Check(e)
+		err := NewMalleabilityChecker().CheckEntity(e)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "entity is nil")
 	})
 	t.Run("unsupported-field", func(t *testing.T) {
-		err := NewMalleabilityChecker().Check(&StructWithNotSettableFlowField{
+		err := NewMalleabilityChecker().CheckEntity(&StructWithNotSettableFlowField{
 			field: IdentityFixture().IdentitySkeleton,
 		})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "not settable")
 	})
 	t.Run("malleable-entity", func(t *testing.T) {
-		err := NewMalleabilityChecker().Check(&MalleableEntityStruct{
+		err := NewMalleabilityChecker().CheckEntity(&MalleableEntityStruct{
 			Identities: IdentityListFixture(2).ToSkeleton(),
 			QC:         QuorumCertificateFixture(),
 			Signature:  SignatureFixture(),
@@ -189,7 +189,7 @@ func TestRequireEntityNonMalleable(t *testing.T) {
 	})
 	t.Run("struct-with-optional-field", func(t *testing.T) {
 		t.Run("without-optional-field", func(t *testing.T) {
-			err := NewMalleabilityChecker().Check(&StructWithOptionalField{
+			err := NewMalleabilityChecker().CheckEntity(&StructWithOptionalField{
 				Identifier:    IdentifierFixture(),
 				RequiredField: 42,
 				OptionalField: nil,
@@ -203,7 +203,7 @@ func TestRequireEntityNonMalleable(t *testing.T) {
 				OptionalField: new(uint32),
 			}
 			*v.OptionalField = 13
-			err := NewMalleabilityChecker().Check(v)
+			err := NewMalleabilityChecker().CheckEntity(v)
 			require.NoError(t, err)
 		})
 	})
@@ -261,7 +261,7 @@ func (e *StructWithPinning) ID() flow.Identifier {
 func TestMalleabilityChecker_PinField(t *testing.T) {
 	t.Run("v1", func(t *testing.T) {
 		checker := NewMalleabilityChecker(WithPinnedField("Version"), WithPinnedField("Evidence.TC"))
-		err := checker.Check(&StructWithPinning{
+		err := checker.CheckEntity(&StructWithPinning{
 			Version: 1,
 			Evidence: &EnterViewEvidence{
 				QC: QuorumCertificateFixture(),
@@ -272,7 +272,7 @@ func TestMalleabilityChecker_PinField(t *testing.T) {
 	})
 	t.Run("v2", func(t *testing.T) {
 		checker := NewMalleabilityChecker(WithPinnedField("Version"))
-		err := checker.Check(&StructWithPinning{
+		err := checker.CheckEntity(&StructWithPinning{
 			Version: 2,
 			Evidence: &EnterViewEvidence{
 				QC: QuorumCertificateFixture(),

--- a/utils/unittest/entity_test.go
+++ b/utils/unittest/entity_test.go
@@ -160,14 +160,8 @@ func TestRequireEntityNonMalleable(t *testing.T) {
 			})
 		})
 	})
-	t.Run("invalid-entity", func(t *testing.T) {
-		err := NewMalleabilityChecker().CheckEntity(nil)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "input is not a valid entity")
-	})
 	t.Run("nil-entity", func(t *testing.T) {
-		var e *flow.ExecutionReceipt = nil
-		err := NewMalleabilityChecker().CheckEntity(e)
+		err := NewMalleabilityChecker().CheckEntity(nil)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "entity is nil")
 	})


### PR DESCRIPTION
This PR extends the malleability checker to work with types that do not implement `IDEntity` (for example, a hash of all fields excluding a signature field, used as the digest for a signature).