### PR TITLE
[Malleability] flow.Block malleability test

### DIFF
--- a/model/flow/block_test.go
+++ b/model/flow/block_test.go
@@ -3,6 +3,7 @@ package flow_test
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,18 @@ import (
 	"github.com/onflow/flow-go/model/flow"
 	"github.com/onflow/flow-go/utils/unittest"
 )
+
+func TestBlockID_Malleability(t *testing.T) {
+	block := unittest.FullBlockFixture()
+	block.SetPayload(unittest.PayloadFixture(unittest.WithAllTheFixins))
+	unittest.RequireEntityNonMalleable(t, &block,
+		unittest.WithFieldGenerator("Header.Timestamp", func() time.Time { return time.Now().UTC() }),
+		unittest.WithFieldGenerator("Payload", func() flow.Payload {
+			payload := unittest.PayloadFixture(unittest.WithAllTheFixins)
+			block.SetPayload(payload)
+			return payload
+		}))
+}
 
 func TestGenesisEncodingJSON(t *testing.T) {
 	genesis := flow.Genesis(flow.Mainnet)


### PR DESCRIPTION
Proposed malleability test for `flow.Block`, using field generators to update the Header.PayloadHash according to the payload when the payload is changed.
See #6716 and #7164.

Block payloads, as part of the block, should be write-once; and therefore if we verify that the payload is only written once when creating a new Block structure (whether by proposing, receiving from the network, or reading from storage), we should have sufficient guarantee that the block is not malleable.