### PR TITLE
[Storage] Add db Seeker to optimize speed & memory when seeking key inside a range (BadgerDB and Pebble)

### DIFF
--- a/storage/operation/badgerimpl/reader.go
+++ b/storage/operation/badgerimpl/reader.go
@@ -63,6 +63,11 @@ func (b dbReader) NewIter(startPrefix, endPrefix []byte, ops storage.IteratorOpt
 	return newBadgerIterator(b.db, startPrefix, endPrefix, ops), nil
 }
 
+// NewSeeker returns a new Seeker.
+func (b dbReader) NewSeeker() storage.Seeker {
+	return newBadgerSeeker(b.db)
+}
+
 // ToReader is a helper function to convert a *badger.DB to a Reader
 func ToReader(db *badger.DB) storage.Reader {
 	return dbReader{db}

--- a/storage/operation/badgerimpl/seeker.go
+++ b/storage/operation/badgerimpl/seeker.go
@@ -1,0 +1,62 @@
+package badgerimpl
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/dgraph-io/badger/v2"
+
+	"github.com/onflow/flow-go/storage"
+)
+
+type badgerSeeker struct {
+	db *badger.DB
+}
+
+var _ storage.Seeker = (*badgerSeeker)(nil)
+
+func newBadgerSeeker(db *badger.DB) *badgerSeeker {
+	return &badgerSeeker{db: db}
+}
+
+// SeekLE (seek less than or equal) returns given key if present.  Otherwise,
+// it returns the largest key that is less than the given key within startPrefix
+// and endPrefix.  Keys are ordered in lexicographical order.
+// This function returns error if given key is outside range of startPrefix and endPrefix.
+func (i *badgerSeeker) SeekLE(startPrefix, endPrefix []byte, key []byte) ([]byte, bool, error) {
+	options := badger.DefaultIteratorOptions
+	options.PrefetchValues = false
+	options.Reverse = true
+
+	lowerBound, _, hasUpperBound := storage.StartEndPrefixToLowerUpperBound(startPrefix, endPrefix)
+
+	if bytes.Compare(key, startPrefix) < 0 {
+		return nil, false, errors.New("key must be greater than or equal to startPrefix key")
+	}
+
+	if hasUpperBound && bytes.Compare(key, endPrefix) > 0 {
+		return nil, false, errors.New("key must be less than or equal to endPrefix key")
+	}
+
+	tx := i.db.NewTransaction(false)
+	iter := tx.NewIterator(options)
+	defer func() {
+		iter.Close()
+		tx.Discard()
+	}()
+
+	// Seek seeks to given key or largest key less than the given key because we are iterating backwards.
+	iter.Seek(key)
+
+	// Check if we reach the end of the iteration.
+	if !iter.Valid() {
+		return nil, false, nil
+	}
+
+	// Check if returned key is less than lowerBound.
+	if bytes.Compare(iter.Item().Key(), lowerBound) < 0 {
+		return nil, false, nil
+	}
+
+	return iter.Item().KeyCopy(nil), true, nil
+}

--- a/storage/operation/iterate_bench_test.go
+++ b/storage/operation/iterate_bench_test.go
@@ -1,0 +1,109 @@
+package operation_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onflow/flow-go/module/irrecoverable"
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation"
+	"github.com/onflow/flow-go/storage/operation/dbtest"
+	"github.com/onflow/flow-go/utils/merr"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack"
+)
+
+func BenchmarkFindHighestAtOrBelowByPrefixUsingIterator(t *testing.B) {
+	dbtest.BenchWithStorages(t, func(t *testing.B, r storage.Reader, withWriter dbtest.WithWriter) {
+		const count = 500
+		const step = 2
+
+		prefix := byte(67)
+		for i := range count {
+			k := operation.MakePrefix(prefix, uint64(i)*step)
+			e := Entity{ID: uint64(i * 2)}
+			require.NoError(t, withWriter(operation.Upsert(k, e)))
+		}
+
+		t.ResetTimer()
+
+		height := uint64(500)
+		for i := 0; i < t.N; i++ {
+			var entity Entity
+			require.NoError(t, findHighestAtOrBelowByPrefixUsingIterator(r, []byte{prefix}, height, &entity))
+		}
+	})
+}
+
+func BenchmarkFindHighestAtOrBelowByPrefixUsingSeeker(t *testing.B) {
+	dbtest.BenchWithStorages(t, func(t *testing.B, r storage.Reader, withWriter dbtest.WithWriter) {
+		const count = 500
+		const step = 2
+
+		prefix := byte(67)
+		for i := range count {
+			k := operation.MakePrefix(prefix, uint64(i)*step)
+			e := Entity{ID: uint64(i * 2)}
+			require.NoError(t, withWriter(operation.Upsert(k, e)))
+		}
+
+		t.ResetTimer()
+
+		height := uint64(500)
+		for i := 0; i < t.N; i++ {
+			var entity Entity
+			require.NoError(t, findHighestAtOrBelowByPrefixUsingSeeker(r, []byte{prefix}, height, &entity))
+		}
+	})
+}
+
+// findHighestAtOrBelowByPrefixUsingIterator is the original operation.FindHighestAtOrBelowByPrefix().
+func findHighestAtOrBelowByPrefixUsingIterator(r storage.Reader, prefix []byte, height uint64, entity interface{}) (errToReturn error) {
+	if len(prefix) == 0 {
+		return fmt.Errorf("prefix must not be empty")
+	}
+
+	key := append(prefix, operation.EncodeKeyPart(height)...)
+	it, err := r.NewIter(prefix, key, storage.DefaultIteratorOptions())
+	if err != nil {
+		return fmt.Errorf("can not create iterator: %w", err)
+	}
+	defer func() {
+		errToReturn = merr.CloseAndMergeError(it, errToReturn)
+	}()
+
+	var highestKey []byte
+
+	// find highest value below the given height
+	for it.First(); it.Valid(); it.Next() {
+		// copy the key to avoid the underlying slices of the key
+		// being modified by the Next() call
+		highestKey = it.IterItem().KeyCopy(highestKey)
+	}
+
+	if len(highestKey) == 0 {
+		return storage.ErrNotFound
+	}
+
+	// read the value of the highest key
+	val, closer, err := r.Get(highestKey)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		errToReturn = merr.CloseAndMergeError(closer, errToReturn)
+	}()
+
+	err = msgpack.Unmarshal(val, entity)
+	if err != nil {
+		return irrecoverable.NewExceptionf("failed to decode value: %w", err)
+	}
+
+	return nil
+}
+
+func findHighestAtOrBelowByPrefixUsingSeeker(r storage.Reader, prefix []byte, height uint64, entity interface{}) (errToReturn error) {
+	return operation.FindHighestAtOrBelowByPrefix(r, prefix, height, entity)
+}

--- a/storage/operation/pebbleimpl/reader.go
+++ b/storage/operation/pebbleimpl/reader.go
@@ -58,6 +58,11 @@ func (b dbReader) NewIter(startPrefix, endPrefix []byte, ops storage.IteratorOpt
 	return newPebbleIterator(b.db, startPrefix, endPrefix, ops)
 }
 
+// NewSeeker returns a new Seeker.
+func (b dbReader) NewSeeker() storage.Seeker {
+	return newPebbleSeeker(b.db)
+}
+
 // ToReader is a helper function to convert a *pebble.DB to a Reader
 func ToReader(db *pebble.DB) storage.Reader {
 	return dbReader{db}

--- a/storage/operation/pebbleimpl/seeker.go
+++ b/storage/operation/pebbleimpl/seeker.go
@@ -1,0 +1,77 @@
+package pebbleimpl
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/utils/merr"
+
+	"github.com/cockroachdb/pebble"
+)
+
+type pebbleSeeker struct {
+	reader pebble.Reader
+}
+
+var _ storage.Seeker = (*pebbleSeeker)(nil)
+
+func newPebbleSeeker(reader pebble.Reader) *pebbleSeeker {
+	return &pebbleSeeker{
+		reader: reader,
+	}
+}
+
+// SeekLE (seek less than or equal) returns given key if present.  Otherwise,
+// it returns the largest key that is less than the given key within startPrefix
+// and endPrefix.  Keys are ordered in lexicographical order.
+// This function returns error if given key is outside range of startPrefix and endPrefix.
+func (i *pebbleSeeker) SeekLE(startPrefix, endPrefix []byte, key []byte) (_ []byte, _ bool, errToReturn error) {
+	lowerBound, upperBound, hasUpperBound := storage.StartEndPrefixToLowerUpperBound(startPrefix, endPrefix)
+
+	if bytes.Compare(key, startPrefix) < 0 {
+		return nil, false, errors.New("key must be greater than or equal to startPrefix key")
+	}
+
+	if hasUpperBound && bytes.Compare(key, endPrefix) > 0 {
+		return nil, false, errors.New("key must be less than or equal to endPrefix key")
+	}
+
+	options := pebble.IterOptions{
+		LowerBound: lowerBound,
+		UpperBound: upperBound,
+	}
+
+	// Setting UpperBound to nil if there is no upper bound
+	if !hasUpperBound {
+		options.UpperBound = nil
+	}
+
+	iter, err := i.reader.NewIter(&options)
+	if err != nil {
+		return nil, false, fmt.Errorf("can not create iterator: %w", err)
+	}
+	defer func() {
+		errToReturn = merr.CloseAndMergeError(iter, errToReturn)
+	}()
+
+	// Seek given key if present.
+
+	valid := iter.SeekGE(key)
+	if valid {
+		if bytes.Equal(iter.Key(), key) {
+			return slices.Clone(iter.Key()), true, nil
+		}
+	}
+
+	// Seek smallest key less than the given key.
+
+	valid = iter.SeekLT(key)
+	if !valid {
+		return nil, false, nil
+	}
+
+	return slices.Clone(iter.Key()), true, nil
+}

--- a/storage/operation/seeker_test.go
+++ b/storage/operation/seeker_test.go
@@ -1,0 +1,116 @@
+package operation_test
+
+import (
+	"testing"
+
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation"
+	"github.com/onflow/flow-go/storage/operation/dbtest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeekLE(t *testing.T) {
+	dbtest.RunWithStorages(t, func(t *testing.T, r storage.Reader, withWriter dbtest.WithWriter) {
+
+		// Insert the keys into the storage
+		codePrefix := byte(1)
+		keyParts := []uint64{1, 5, 9}
+
+		require.NoError(t, withWriter(func(writer storage.Writer) error {
+			for _, keyPart := range keyParts {
+				key := operation.MakePrefix(codePrefix, keyPart)
+				value := []byte{0x00} // value are skipped, doesn't matter
+
+				err := operation.Upsert(key, value)(writer)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}))
+
+		t.Run("key below start prefix", func(t *testing.T) {
+			seeker := r.NewSeeker()
+
+			key := operation.MakePrefix(codePrefix, uint64(4))
+			startPrefix := operation.MakePrefix(codePrefix, uint64(5))
+			endPrefix := operation.MakePrefix(codePrefix, uint64(10))
+
+			_, _, err := seeker.SeekLE(startPrefix, endPrefix, key)
+			require.Error(t, err)
+		})
+
+		t.Run("key above end prefix", func(t *testing.T) {
+			seeker := r.NewSeeker()
+
+			startPrefix := operation.MakePrefix(codePrefix, uint64(0))
+			endPrefix := operation.MakePrefix(codePrefix, uint64(5))
+			key := operation.MakePrefix(codePrefix, uint64(10))
+
+			_, _, err := seeker.SeekLE(startPrefix, endPrefix, key)
+			require.Error(t, err)
+		})
+
+		t.Run("seek key inside range", func(t *testing.T) {
+			seeker := r.NewSeeker()
+
+			// Seek range is [0, 10]
+			startPrefix := []byte{codePrefix}
+			endPrefix := operation.MakePrefix(codePrefix, uint64(10))
+
+			// Seeking [9, 10] in range of [0, 10] returns 9.
+			for _, keyPart := range []uint64{9, 10} {
+				key := operation.MakePrefix(codePrefix, keyPart)
+				expectedKey := operation.MakePrefix(codePrefix, uint64(9))
+				foundKey, found, err := seeker.SeekLE(startPrefix, endPrefix, key)
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, expectedKey, foundKey)
+			}
+
+			// Seeking [5, 8] in range of [0, 10] returns 5.
+			for _, keyPart := range []uint64{5, 6, 7, 8} {
+				key := operation.MakePrefix(codePrefix, keyPart)
+				expectedKey := operation.MakePrefix(codePrefix, uint64(5))
+				foundKey, found, err := seeker.SeekLE(startPrefix, endPrefix, key)
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, expectedKey, foundKey)
+			}
+
+			// Seeking [1, 4] in range of [0, 10] returns 1.
+			for _, keyPart := range []uint64{1, 2, 3, 4} {
+				key := operation.MakePrefix(codePrefix, keyPart)
+				expectedKey := operation.MakePrefix(codePrefix, uint64(1))
+				foundKey, found, err := seeker.SeekLE(startPrefix, endPrefix, key)
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, expectedKey, foundKey)
+			}
+
+			// Seeking [0] in range of [0, 10] returns nil.
+			for _, keyPart := range []uint64{0} {
+				key := operation.MakePrefix(codePrefix, keyPart)
+				foundKey, found, err := seeker.SeekLE(startPrefix, endPrefix, key)
+				require.NoError(t, err)
+				require.False(t, found)
+				require.Nil(t, foundKey)
+			}
+		})
+
+		t.Run("has key below startPrefix", func(t *testing.T) {
+			seeker := r.NewSeeker()
+
+			startPrefix := operation.MakePrefix(codePrefix, uint64(6))
+			endPrefix := operation.MakePrefix(codePrefix, uint64(10))
+
+			// Key 5 exists, but it is outside of specified range, so nil is returned.
+			key := operation.MakePrefix(codePrefix, uint64(6))
+			foundKey, found, err := seeker.SeekLE(startPrefix, endPrefix, key)
+			require.NoError(t, err)
+			require.False(t, found)
+			require.Nil(t, foundKey)
+		})
+	})
+}

--- a/storage/operations.go
+++ b/storage/operations.go
@@ -68,6 +68,15 @@ func DefaultIteratorOptions() IteratorOption {
 	}
 }
 
+// Seeker is an interface for seeking keys in a given range.
+type Seeker interface {
+	// SeekLE (seek less than or equal) returns given key if present.  Otherwise,
+	// it returns the largest key that is less than the given key within startPrefix
+	// and endPrefix.  Keys are ordered in lexicographical order.
+	// This function returns error if given key is outside range of startPrefix and endPrefix.
+	SeekLE(startPrefix, endPrefix []byte, key []byte) ([]byte, bool, error)
+}
+
 type Reader interface {
 	// Get gets the value for the given key. It returns ErrNotFound if the DB
 	// does not contain the key.
@@ -86,6 +95,9 @@ type Reader interface {
 	//   - have a prefix equal to the endPrefix OR
 	//   - have a prefix that is lexicographically between startPrefix and endPrefix
 	NewIter(startPrefix, endPrefix []byte, ops IteratorOption) (Iterator, error)
+
+	// NewSeeker returns a new Seeker.
+	NewSeeker() Seeker
 }
 
 // Writer is an interface for batch writing to a storage backend.


### PR DESCRIPTION
Currently, `Iterator` is used when we need to get a key within a specified range, where the key is less than or equal to a specified key.  This is very inefficient with both BadgerDB and Pebble.

As one example, `store.VersionBeacons.Highest()` is affected by this inefficiency.

This PR adds a `Seeker` interface which can be used to seek a key that is less than or equal to a specified key within a specified range.  `Seeker` uses db provided seek functions to improve speed and memory use.

This PR also refactors `FindHighestAtOrBelowByPrefix()` to use the new Seeker instead of Iterator.

This optimizes `store.VersionBeacons.Highest()`, which uses `FindHighestAtOrBelowByPrefix()`.

I found this while getting familiar with storage code related to BadgerDB and Pebble (not looking for optimizations).

## Benchmarks using BadgerDB

`FindHighestAtOrBelowByPrefix`

```
                                │ iterator.log  │             seeker.log              │
                                │    sec/op     │   sec/op     vs base                │
FindHighestAtOrBelowByPrefix-12   122.370µ ± 2%   2.458µ ± 3%  -97.99% (p=0.000 n=20)

                                │ iterator.log  │              seeker.log              │
                                │     B/op      │     B/op      vs base                │
FindHighestAtOrBelowByPrefix-12   31.290Ki ± 0%   1.723Ki ± 0%  -94.49% (p=0.000 n=20)

                                │ iterator.log │             seeker.log             │
                                │  allocs/op   │ allocs/op   vs base                │
FindHighestAtOrBelowByPrefix-12    885.00 ± 0%   43.00 ± 0%  -95.14% (p=0.000 n=20)
```

Benchmarks tests used data taken from existing tests.

## Benchmarks using Pebble

`FindHighestAtOrBelowByPrefix`

```
                                │ iterator.log │             seeker.log              │
                                │    sec/op    │   sec/op     vs base                │
FindHighestAtOrBelowByPrefix-12    9.598µ ± 0%   1.591µ ± 2%  -83.42% (p=0.000 n=20)

                                │ iterator.log │            seeker.log             │
                                │     B/op     │    B/op     vs base               │
FindHighestAtOrBelowByPrefix-12     641.0 ± 0%   649.0 ± 0%  +1.25% (p=0.000 n=20)

                                │ iterator.log │           seeker.log           │
                                │  allocs/op   │ allocs/op   vs base            │
FindHighestAtOrBelowByPrefix-12     18.00 ± 0%   18.00 ± 0%  ~ (p=1.000 n=20) ¹
```

Benchmarks tests used data taken from existing tests.
