### PR TITLE
Add manual trigger for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
   merge_group:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   GO_VERSION: "1.23"


### PR DESCRIPTION
Intended to allow running CI tests on PRs that are not directly targeted to master or a feature branch, without requiring CI on all such PRs.