### PR TITLE
[Malleability] Review structs with stub ID implementation

### DIFF
--- a/engine/execution/ingestion/block_queue/queue.go
+++ b/engine/execution/ingestion/block_queue/queue.go
@@ -55,16 +55,7 @@ type MissingCollection struct {
 }
 
 func (m *MissingCollection) ID() flow.Identifier {
-	stub := struct {
-		BlockID               flow.Identifier
-		Height                uint64
-		CollectionGuaranteeID flow.Identifier
-	}{
-		m.BlockID,
-		m.Height,
-		m.Guarantee.ID(),
-	}
-	return flow.MakeID(stub)
+	return flow.MakeID(m)
 }
 
 // collectionInfo is an internal struct used to keep track of the state of a collection,

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -301,18 +301,7 @@ func (e *MinEpochStateEntry) ID() Identifier {
 	if e == nil {
 		return ZeroID
 	}
-	body := struct {
-		PreviousEpochID        Identifier
-		CurrentEpochID         Identifier
-		NextEpochID            Identifier
-		EpochFallbackTriggered bool
-	}{
-		PreviousEpochID:        e.PreviousEpoch.ID(),
-		CurrentEpochID:         e.CurrentEpoch.ID(),
-		NextEpochID:            e.NextEpoch.ID(),
-		EpochFallbackTriggered: e.EpochFallbackTriggered,
-	}
-	return MakeID(body)
+	return MakeID(e)
 }
 
 // Copy returns a full copy of the entry.

--- a/model/flow/resultApproval.go
+++ b/model/flow/resultApproval.go
@@ -59,15 +59,7 @@ var _ Entity = (*ResultApproval)(nil)
 
 // ID generates a unique identifier using result approval full content
 func (ra ResultApproval) ID() Identifier {
-	stub := struct {
-		Body              Identifier
-		VerifierSignature crypto.Signature
-	}{
-		Body:              ra.Body.ID(),
-		VerifierSignature: ra.VerifierSignature,
-	}
-
-	return MakeID(stub)
+	return MakeID(ra)
 }
 
 // Checksum generates checksum using the result approval full content

--- a/model/flow/timeout_certificate.go
+++ b/model/flow/timeout_certificate.go
@@ -26,19 +26,5 @@ func (t *TimeoutCertificate) ID() Identifier {
 	if t == nil {
 		return ZeroID
 	}
-
-	body := struct {
-		View          uint64
-		NewestQCViews []uint64
-		NewestQCID    Identifier
-		SignerIndices []byte
-		SigData       crypto.Signature
-	}{
-		View:          t.View,
-		NewestQCViews: t.NewestQCViews,
-		NewestQCID:    t.NewestQC.ID(),
-		SignerIndices: t.SignerIndices,
-		SigData:       t.SigData,
-	}
-	return MakeID(body)
+	return MakeID(t)
 }


### PR DESCRIPTION
Closes: #7226

## Changes

Reviewed `ID` implementations for all types and refactored the following structs to use the standard `flow.MakeID(struct)` method:
-  `ResultApproval`
-  `EpochStateContainer`
-  `MissingCollection`
-  `TimeoutCertificate`

## Notes
`ExecutionReceiptMeta` type is not included in this PR, as it is currently under review and its `ID` implementation will be handled in PR #7208.