### PR TITLE
[Storage] Fix memory caches out of sync with databases (BadgerDB and Pebble)

### DIFF
--- a/storage/store/cache.go
+++ b/storage/store/cache.go
@@ -171,3 +171,12 @@ func (c *Cache[K, V]) RemoveTx(rw storage.ReaderBatchWriter, key K) error {
 
 	return nil
 }
+
+func (c *Cache[K, V]) RemoveByPredicate(pred func(key K) bool) {
+	keys := c.cache.Keys()
+	for _, key := range keys {
+		if pred(key) {
+			c.cache.Remove(key)
+		}
+	}
+}

--- a/storage/store/my_receipts.go
+++ b/storage/store/my_receipts.go
@@ -86,13 +86,23 @@ func NewMyExecutionReceipts(collector module.CacheMetrics, db storage.DB, receip
 		return receipt, nil
 	}
 
+	remove := func(rw storage.ReaderBatchWriter, blockID flow.Identifier) error {
+		indexingMyReceipt.Lock()
+		rw.AddCallback(func(error) {
+			indexingMyReceipt.Unlock()
+		})
+		return operation.RemoveOwnExecutionReceipt(rw.Writer(), blockID)
+	}
+
 	return &MyExecutionReceipts{
 		genericReceipts: receipts,
 		db:              db,
 		cache: newCache(collector, metrics.ResourceMyReceipt,
 			withLimit[flow.Identifier, *flow.ExecutionReceipt](flow.DefaultTransactionExpiry+100),
 			withStore(store),
-			withRetrieve(retrieve)),
+			withRetrieve(retrieve),
+			withRemove[flow.Identifier, *flow.ExecutionReceipt](remove),
+		),
 		indexingMyReceipt: indexingMyReceipt,
 	}
 }
@@ -119,7 +129,7 @@ func (m *MyExecutionReceipts) MyReceipt(blockID flow.Identifier) (*flow.Executio
 
 func (m *MyExecutionReceipts) RemoveIndexByBlockID(blockID flow.Identifier) error {
 	return m.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
-		return operation.RemoveOwnExecutionReceipt(rw.Writer(), blockID)
+		return m.BatchRemoveIndexByBlockID(blockID, rw)
 	})
 }
 
@@ -127,5 +137,5 @@ func (m *MyExecutionReceipts) RemoveIndexByBlockID(blockID flow.Identifier) erro
 // No errors are expected during normal operation, even if no entries are matched.
 // If Badger unexpectedly fails to process the request, the error is wrapped in a generic error and returned.
 func (m *MyExecutionReceipts) BatchRemoveIndexByBlockID(blockID flow.Identifier, rw storage.ReaderBatchWriter) error {
-	return operation.RemoveOwnExecutionReceipt(rw.Writer(), blockID)
+	return m.cache.RemoveTx(rw, blockID)
 }


### PR DESCRIPTION
Updates #7313

Currently, in the new `storage/store` code, the memory cache of some stores can have records that are no longer in the database.

Specifically, the memory cache isn't updated when the database record is deleted. So the memory cache can have records that are not in the database.

This PR updates the following stores to remove the record from the cache when the record is removed from database:
- commits.go
- events.go
- my_receipts.go
- transaction_results.go

This PR also adds tests to ensure cache and database are in sync after records are removed.