### PR TITLE
Enable custom `structwrite` linter in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,22 +22,17 @@ linters-settings:
     # Disable SA1019 to allow use of deprecated label
     checks: ["all", "-SA1019"]
 
-# TODO(7271): Un-comment in #7271
-#  custom:
-#    structwrite:
-#      type: module
-#      description: "disallow struct field writes outside constructor"
-#      original-url: "github.com/onflow/flow-go/tools/structwrite"
-#      settings:
-#        structs:
-#          - "github.com/onflow/flow-go/model/flow.Header"
+  custom:
+    structwrite:
+      type: module
+      description: "disallow struct field writes outside constructor"
+      original-url: "github.com/onflow/flow-go/tools/structwrite"
 
 linters:
   enable:
     - goimports
     - gosec
-# TODO(7271): Un-comment in #7271
-#    - structwrite
+    - structwrite
 
 issues:
   exclude-rules:


### PR DESCRIPTION
This PR extends https://github.com/onflow/flow-go/pull/7322. It un-comments out the custom linter config to enable the custom linter. 

This exists as a separate PR only so that each merge to `master` passes CI, because CI uses the version of the workflow definition defined on `master`.