### PR TITLE
Fix bug in bootstrapping duplicate node ID test

### DIFF
--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -547,7 +547,9 @@ func TestBootstrapNonRoot(t *testing.T) {
 func TestBootstrap_InvalidIdentities(t *testing.T) {
 	t.Run("duplicate node ID", func(t *testing.T) {
 		participants := unittest.CompleteIdentitySet()
-		dupeIDIdentity := unittest.IdentityFixture(unittest.WithNodeID(participants[0].NodeID))
+		// Make sure the duplicate node ID is not a consensus node, otherwise this will form an invalid DKGIDMapping
+		// See [flow.EpochCommit] for details.
+		dupeIDIdentity := unittest.IdentityFixture(unittest.WithNodeID(participants[0].NodeID), unittest.WithRole(flow.RoleVerification))
 		participants = append(participants, dupeIDIdentity)
 
 		root := unittest.RootSnapshotFixture(participants)


### PR DESCRIPTION
This was flakey. If a consensus node was constructed as the duplicate in the test case, it would result in an invalid dkg id mapping representation, which would cause the test to eventually panic.

Closes https://github.com/onflow/flow-go/issues/7332

```
% go test -run=TestBootstrap_InvalidIdentities/duplicate_node_ID -count=100 ./state/protocol/badger
ok  	github.com/onflow/flow-go/state/protocol/badger	5.231s
```