### PR TITLE
[Access] Allow small gap between streaming start and indexed height

### DIFF
--- a/engine/access/subscription/tracker/execution_data_tracker.go
+++ b/engine/access/subscription/tracker/execution_data_tracker.go
@@ -24,6 +24,8 @@ import (
 const (
 	// maxIndexBlockDiff is the maximum difference between the highest indexed block height and the
 	// provided start height to allow when starting a new stream.
+	// this is used to account for small delays indexing or requests made to different ANs behind a
+	// load balancer. The diff will result in the stream waiting a few blocks before starting.
 	maxIndexBlockDiff = 30
 )
 

--- a/engine/access/subscription/tracker/execution_data_tracker.go
+++ b/engine/access/subscription/tracker/execution_data_tracker.go
@@ -284,8 +284,8 @@ func (e *ExecutionDataTrackerImpl) checkStartHeight(height uint64) (uint64, erro
 	// allow for a small difference between the highest indexed height and the provided height to
 	// account for small delays indexing or requests made to different ANs behind a load balancer.
 	// this will just result in the stream waiting a few blocks before starting.
-	if height > highestHeight && height-highestHeight > maxIndexBlockDiff {
-		return 0, status.Errorf(codes.InvalidArgument, "start height %d is higher than highest indexed height %d", height, highestHeight)
+	if height > highestHeight + maxIndexBlockDiff {
+		return 0, status.Errorf(codes.InvalidArgument, "start height %d is higher than highest indexed height %d (maxIndexBlockDiff: %d)", height, highestHeight, maxIndexBlockDiff)
 	}
 
 	return height, nil

--- a/engine/access/subscription/tracker/execution_data_tracker.go
+++ b/engine/access/subscription/tracker/execution_data_tracker.go
@@ -284,7 +284,7 @@ func (e *ExecutionDataTrackerImpl) checkStartHeight(height uint64) (uint64, erro
 	// allow for a small difference between the highest indexed height and the provided height to
 	// account for small delays indexing or requests made to different ANs behind a load balancer.
 	// this will just result in the stream waiting a few blocks before starting.
-	if height > highestHeight + maxIndexBlockDiff {
+	if height > highestHeight+maxIndexBlockDiff {
 		return 0, status.Errorf(codes.InvalidArgument, "start height %d is higher than highest indexed height %d (maxIndexBlockDiff: %d)", height, highestHeight, maxIndexBlockDiff)
 	}
 


### PR DESCRIPTION
Closes: #7338 

Currently, the grpc and websockets streams will verify that the requested start height is within the range of indexed blocks on the node. When using endpoints that start from the latest sealed block, this frequently fails with an error because the sealed block has not finished indexing.

```
Error: Failed to subscribe to topic events: internal error: subscription finished with error: rpc error: code = InvalidArgument desc = could not get start height from block height: start height 110896543 is higher than highest indexed height 110896542
```

This PR relaxes this check to allow a small difference between the start height and the indexed height. If a request comes in for a start height that is less than 30 blocks ahead of the latest indexed height, the stream will be allowed. The stream will then sit idle until the start height is reached, then start streaming.