### PR TITLE
[Malleability] Review implementation of Adjust in the heropool cache.

### DIFF
--- a/module/mempool/herocache/backdata/cache.go
+++ b/module/mempool/herocache/backdata/cache.go
@@ -189,39 +189,23 @@ func (c *Cache[V]) Remove(key flow.Identifier) (value V, ok bool) {
 
 // Adjust adjusts the value using the given function if the given identifier can be found.
 // Returns a bool which indicates whether the value was updated as well as the updated value.
-//func (c *Cache[V]) Adjust(key flow.Identifier, f func(V) V) (value V, ok bool) {
-//	defer c.logTelemetry()
-//
-//	value, removed := c.Remove(key)
-//	if !removed {
-//		return value, false
-//	}
-//
-//	newValue := f(value)
-//
-//	// TODO(malleability, #7171): Think of a better solution cause of removing and inserting value with same ID https://github.com/onflow/flow-go/issues/7171
-//	c.put(key, newValue)
-//
-//	return newValue, true
-//}
-
 func (c *Cache[V]) Adjust(key flow.Identifier, f func(V) V) (V, bool) {
 	defer c.logTelemetry()
 
-	// 1) locate the slot
+	// locate the slot
 	value, b, s, ok := c.get(key)
 	if !ok {
 		return value, false
 	}
 
-	// 2) compute the new value
+	// compute the new value
 	newValue := f(value)
 
-	// 3) bump its age (so evictions still see this as “recent”)
+	// bump its age (so evictions still see this as “recent”)
 	c.slotCount++
 	c.buckets[b].slots[s].slotAge = c.slotCount
 
-	// 4) update in the underlying pool, in-place
+	// update in the underlying pool, in-place
 	idx := c.buckets[b].slots[s].valueIndex
 	c.entities.UpdateAtIndex(idx, newValue)
 

--- a/module/mempool/herocache/backdata/cache.go
+++ b/module/mempool/herocache/backdata/cache.go
@@ -209,6 +209,9 @@ func (c *Cache[V]) Adjust(key flow.Identifier, f func(V) V) (V, bool) {
 	idx := c.buckets[b].slots[s].valueIndex
 	c.entities.UpdateAtIndex(idx, newValue)
 
+	// and refresh its LRU position
+	c.entities.Touch(idx)
+
 	return newValue, true
 }
 

--- a/module/mempool/herocache/backdata/heropool/pool.go
+++ b/module/mempool/herocache/backdata/heropool/pool.go
@@ -286,6 +286,15 @@ func (p *Pool[K, V]) UpdateAtIndex(idx EIndex, newValue V) {
 	p.poolEntities[idx].value = newValue
 }
 
+// Touch marks the entry at pool index as “recently used” by moving it
+// from the head of the used list to its tail.
+func (p *Pool[K, V]) Touch(idx EIndex) {
+	// remove from used list
+	p.switchState(stateUsed, stateFree, idx)
+	// immediately append back to used list tail
+	p.switchState(stateFree, stateUsed, idx)
+}
+
 // invalidateValueAtIndex invalidates the given getSliceIndex in the linked list by
 // removing its corresponding linked-list node from the used linked list, and appending
 // it to the tail of the free list. It also removes the value that the invalidated node is presenting.

--- a/module/mempool/herocache/backdata/heropool/pool.go
+++ b/module/mempool/herocache/backdata/heropool/pool.go
@@ -281,6 +281,11 @@ func (p *Pool[K, V]) Remove(sliceIndex EIndex) V {
 	return p.invalidateValueAtIndex(sliceIndex)
 }
 
+// UpdateAtIndex replaces the value at the given pool index.
+func (p *Pool[K, V]) UpdateAtIndex(idx EIndex, newValue V) {
+	p.poolEntities[idx].value = newValue
+}
+
 // invalidateValueAtIndex invalidates the given getSliceIndex in the linked list by
 // removing its corresponding linked-list node from the used linked list, and appending
 // it to the tail of the free list. It also removes the value that the invalidated node is presenting.


### PR DESCRIPTION
Closes: #7171 

## Context

In this PR implementation of the `Adjust`  function is changed in a way where we find the value by the key and adjust it without re-inserting it with the same key.