### PR TITLE
Remove database dependency from consensus builder

### DIFF
--- a/cmd/consensus/main.go
+++ b/cmd/consensus/main.go
@@ -761,7 +761,6 @@ func main() {
 			var build module.Builder
 			build, err = builder.NewBuilder(
 				node.Metrics.Mempool,
-				node.DB,
 				mutableState,
 				node.Storage.Headers,
 				node.Storage.Seals,

--- a/consensus/integration/nodes_test.go
+++ b/consensus/integration/nodes_test.go
@@ -488,7 +488,6 @@ func createNode(
 	// initialize the block builder
 	build, err := builder.NewBuilder(
 		metricsCollector,
-		db,
 		fullState,
 		headersDB,
 		sealsDB,

--- a/module/builder/consensus/builder.go
+++ b/module/builder/consensus/builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dgraph-io/badger/v2"
 	otelTrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -17,7 +16,6 @@ import (
 	"github.com/onflow/flow-go/state/protocol"
 	"github.com/onflow/flow-go/state/protocol/blocktimer"
 	"github.com/onflow/flow-go/storage"
-	"github.com/onflow/flow-go/storage/badger/operation"
 )
 
 // Builder is the builder for consensus block payloads. Upon providing a payload
@@ -25,7 +23,6 @@ import (
 type Builder struct {
 	metrics              module.MempoolMetrics
 	tracer               module.Tracer
-	db                   *badger.DB
 	state                protocol.ParticipantState
 	seals                storage.Seals
 	headers              storage.Headers
@@ -43,7 +40,6 @@ type Builder struct {
 // NewBuilder creates a new block builder.
 func NewBuilder(
 	metrics module.MempoolMetrics,
-	db *badger.DB,
 	state protocol.ParticipantState,
 	headers storage.Headers,
 	seals storage.Seals,
@@ -80,7 +76,6 @@ func NewBuilder(
 
 	b := &Builder{
 		metrics:              metrics,
-		db:                   db,
 		tracer:               tracer,
 		state:                state,
 		headers:              headers,
@@ -279,13 +274,9 @@ func (b *Builder) getInsertableGuarantees(parentID flow.Identifier) ([]*flow.Col
 		limit = 0
 	}
 
-	// look up the root height so we don't look too far back
-	// initially this is the genesis block height (aka 0).
-	var rootHeight uint64
-	err = b.db.View(operation.RetrieveRootHeight(&rootHeight))
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve root block height: %w", err)
-	}
+	// the finalized root height is the height where we bootstrapped from.
+	// we should not include guarantees that are older than the finalized root
+	rootHeight := b.state.Params().FinalizedRoot().Height
 	if limit < rootHeight {
 		limit = rootHeight
 	}

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -288,6 +288,9 @@ func (bs *BuilderSuite) SetupTest() {
 		}
 		return unittest.StateSnapshotForUnknownBlock()
 	})
+	params := new(protocol.Params)
+	params.On("FinalizedRoot").Return(first.Header)
+	bs.state.On("Params").Return(params)
 
 	// set up storage mocks for tests
 	bs.sealDB = &storage.Seals{}
@@ -424,7 +427,6 @@ func (bs *BuilderSuite) SetupTest() {
 	// initialize the builder
 	bs.build, err = NewBuilder(
 		noopMetrics,
-		bs.db,
 		bs.state,
 		bs.headerDB,
 		bs.sealDB,
@@ -1467,7 +1469,6 @@ func (bs *BuilderSuite) TestIntegration_RepopulateExecutionTreeAtStartup() {
 	var err error
 	bs.build, err = NewBuilder(
 		noopMetrics,
-		bs.db,
 		bs.state,
 		bs.headerDB,
 		bs.sealDB,


### PR DESCRIPTION
The RootHeight can be retrieved from protocol state, this allows us to remove the dependency of database for the builder., and also saves one db query.