### PR TITLE
[Storage] Update DB.Reader() API to not return error

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -310,11 +310,8 @@ func (exeNode *ExecutionNode) LoadExecutionMetrics(node *NodeConfig) error {
 	// this is guaranteed to exist because LoadBootstrapper has inserted
 	// the root block as executed block
 	var blockID flow.Identifier
-	reader, err := node.ProtocolDB.Reader()
-	if err != nil {
-		return err
-	}
-	err = operation.RetrieveExecutedBlock(reader, &blockID)
+
+	err := operation.RetrieveExecutedBlock(node.ProtocolDB.Reader(), &blockID)
 	if err != nil {
 		// database has not been bootstrapped yet
 		if errors.Is(err, storageerr.ErrNotFound) {

--- a/cmd/util/cmd/exec-data-json-export/delta_snapshot_exporter.go
+++ b/cmd/util/cmd/exec-data-json-export/delta_snapshot_exporter.go
@@ -51,13 +51,8 @@ func ExportDeltaSnapshots(blockID flow.Identifier, dbPath string, outputPath str
 			return nil
 		}
 
-		reader, err := sdb.Reader()
-		if err != nil {
-			return err
-		}
-
 		var snap []*snapshot.ExecutionSnapshot
-		err = operation.RetrieveExecutionStateInteractions(reader, activeBlockID, &snap)
+		err = operation.RetrieveExecutionStateInteractions(sdb.Reader(), activeBlockID, &snap)
 		if err != nil {
 			return fmt.Errorf("could not load delta snapshot: %w", err)
 		}

--- a/cmd/util/cmd/read-badger/cmd/stats.go
+++ b/cmd/util/cmd/read-badger/cmd/stats.go
@@ -48,12 +48,7 @@ var statsCmd = &cobra.Command{
 		}
 		log.Info().Msgf("getting stats for %s db at %s with %v workers0", flagDBType, flagDatadir, numWorkers)
 
-		reader, err := sdb.Reader()
-		if err != nil {
-			return fmt.Errorf("failed to get reader: %w", err)
-		}
-
-		stats, err := operation.SummarizeKeysByFirstByteConcurrent(log.Logger, reader, numWorkers)
+		stats, err := operation.SummarizeKeysByFirstByteConcurrent(log.Logger, sdb.Reader(), numWorkers)
 		if err != nil {
 			return fmt.Errorf("failed to get stats: %w", err)
 		}

--- a/engine/execution/migration/badgerpebble.go
+++ b/engine/execution/migration/badgerpebble.go
@@ -106,13 +106,8 @@ func MigrateLastSealedExecutedResultToPebble(logger zerolog.Logger, badgerDB *ba
 	// create pebble storage modules
 	pebbleResults, pebbleCommits := createStores(pdb)
 
-	reader, err := pdb.Reader()
-	if err != nil {
-		return err
-	}
-
 	var existingExecuted flow.Identifier
-	err = operation.RetrieveExecutedBlock(reader, &existingExecuted)
+	err = operation.RetrieveExecutedBlock(pdb.Reader(), &existingExecuted)
 	if err == nil {
 		// there is an executed block in pebble, compare if it's newer than the badger one,
 		// if newer, it means EN is storing new results in pebble, in this case, we don't

--- a/engine/execution/state/bootstrap/bootstrap.go
+++ b/engine/execution/state/bootstrap/bootstrap.go
@@ -79,12 +79,7 @@ func (b *Bootstrapper) BootstrapLedger(
 func (b *Bootstrapper) IsBootstrapped(db storage.DB) (flow.StateCommitment, bool, error) {
 	var commit flow.StateCommitment
 
-	reader, err := db.Reader()
-	if err != nil {
-		return flow.DummyStateCommitment, false, err
-	}
-
-	err = operation.LookupStateCommitment(reader, flow.ZeroID, &commit)
+	err := operation.LookupStateCommitment(db.Reader(), flow.ZeroID, &commit)
 	if errors.Is(err, storage.ErrNotFound) {
 		return flow.DummyStateCommitment, false, nil
 	}

--- a/engine/execution/state/state.go
+++ b/engine/execution/state/state.go
@@ -484,13 +484,8 @@ func (s *state) GetLastExecutedBlockID(ctx context.Context) (uint64, flow.Identi
 		return height, finalizedID, nil
 	}
 
-	reader, err := s.db.Reader()
-	if err != nil {
-		return 0, flow.ZeroID, err
-	}
-
 	var blockID flow.Identifier
-	err = operation.RetrieveExecutedBlock(reader, &blockID)
+	err := operation.RetrieveExecutedBlock(s.db.Reader(), &blockID)
 	if err != nil {
 		return 0, flow.ZeroID, err
 	}

--- a/module/block_iterator/executor/executor_test.go
+++ b/module/block_iterator/executor/executor_test.go
@@ -61,12 +61,9 @@ func TestExecute(t *testing.T) {
 
 		// expect all blocks are pruned
 		for _, b := range bs {
-			reader, err := pdb.Reader()
-			require.NoError(t, err)
-
 			// verify they are pruned
 			var c storage.StoredChunkDataPack
-			err = operation.RetrieveChunkDataPack(reader, b, &c)
+			err := operation.RetrieveChunkDataPack(pdb.Reader(), b, &c)
 			require.True(t, errors.Is(err, storage.ErrNotFound), "expected ErrNotFound but got %v", err)
 		}
 	})
@@ -126,20 +123,14 @@ func TestExecuteCanBeResumed(t *testing.T) {
 			var c storage.StoredChunkDataPack
 
 			if i < 3 {
-				reader, err := pdb.Reader()
-				require.NoError(t, err)
-
 				// the first 3 blocks in the first batch are pruned
-				err = operation.RetrieveChunkDataPack(reader, b, &c)
+				err = operation.RetrieveChunkDataPack(pdb.Reader(), b, &c)
 				require.True(t, errors.Is(err, storage.ErrNotFound), "expected ErrNotFound for block %v but got %v", i, err)
 				continue
 			}
 
 			// verify the remaining blocks are not pruned yet
-			reader, err := pdb.Reader()
-			require.NoError(t, err)
-
-			require.NoError(t, operation.RetrieveChunkDataPack(reader, b, &c))
+			require.NoError(t, operation.RetrieveChunkDataPack(pdb.Reader(), b, &c))
 		}
 
 		// now resume the pruning
@@ -156,12 +147,9 @@ func TestExecuteCanBeResumed(t *testing.T) {
 
 		// verify all blocks are pruned
 		for _, b := range bs {
-			reader, err := pdb.Reader()
-			require.NoError(t, err)
-
 			var c storage.StoredChunkDataPack
 			// the first 5 blocks are pruned
-			err = operation.RetrieveChunkDataPack(reader, b, &c)
+			err = operation.RetrieveChunkDataPack(pdb.Reader(), b, &c)
 			require.True(t, errors.Is(err, storage.ErrNotFound), "expected ErrNotFound but got %v", err)
 		}
 	})

--- a/module/block_iterator/latest/sealed_and_executed.go
+++ b/module/block_iterator/latest/sealed_and_executed.go
@@ -66,13 +66,8 @@ func LatestSealedAndExecutedHeight(state protocol.State, db storage.DB) (uint64,
 		return 0, err
 	}
 
-	reader, err := db.Reader()
-	if err != nil {
-		return 0, err
-	}
-
 	var blockID flow.Identifier
-	err = operation.RetrieveExecutedBlock(reader, &blockID)
+	err = operation.RetrieveExecutedBlock(db.Reader(), &blockID)
 	if err != nil {
 		return 0, err
 	}

--- a/storage/mock/db.go
+++ b/storage/mock/db.go
@@ -33,7 +33,7 @@ func (_m *DB) NewBatch() storage.Batch {
 }
 
 // Reader provides a mock function with given fields:
-func (_m *DB) Reader() (storage.Reader, error) {
+func (_m *DB) Reader() storage.Reader {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -41,10 +41,6 @@ func (_m *DB) Reader() (storage.Reader, error) {
 	}
 
 	var r0 storage.Reader
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (storage.Reader, error)); ok {
-		return rf()
-	}
 	if rf, ok := ret.Get(0).(func() storage.Reader); ok {
 		r0 = rf()
 	} else {
@@ -53,13 +49,7 @@ func (_m *DB) Reader() (storage.Reader, error) {
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // WithReaderBatchWriter provides a mock function with given fields: _a0

--- a/storage/mock/reader.go
+++ b/storage/mock/reader.go
@@ -84,7 +84,7 @@ func (_m *Reader) NewIter(startPrefix []byte, endPrefix []byte, ops storage.Iter
 }
 
 // NewSeeker provides a mock function with given fields:
-func (_m *Reader) NewSeeker() (storage.Seeker, error) {
+func (_m *Reader) NewSeeker() storage.Seeker {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -92,10 +92,6 @@ func (_m *Reader) NewSeeker() (storage.Seeker, error) {
 	}
 
 	var r0 storage.Seeker
-	var r1 error
-	if rf, ok := ret.Get(0).(func() (storage.Seeker, error)); ok {
-		return rf()
-	}
 	if rf, ok := ret.Get(0).(func() storage.Seeker); ok {
 		r0 = rf()
 	} else {
@@ -104,13 +100,7 @@ func (_m *Reader) NewSeeker() (storage.Seeker, error) {
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // NewReader creates a new instance of Reader. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/storage/operation/badgerimpl/dbstore.go
+++ b/storage/operation/badgerimpl/dbstore.go
@@ -16,8 +16,8 @@ type dbStore struct {
 
 var _ (storage.DB) = (*dbStore)(nil)
 
-func (b *dbStore) Reader() (storage.Reader, error) {
-	return dbReader{db: b.db}, nil
+func (b *dbStore) Reader() storage.Reader {
+	return dbReader{db: b.db}
 }
 
 func (b *dbStore) WithReaderBatchWriter(fn func(storage.ReaderBatchWriter) error) error {

--- a/storage/operation/badgerimpl/reader.go
+++ b/storage/operation/badgerimpl/reader.go
@@ -64,8 +64,8 @@ func (b dbReader) NewIter(startPrefix, endPrefix []byte, ops storage.IteratorOpt
 }
 
 // NewSeeker returns a new Seeker.
-func (b dbReader) NewSeeker() (storage.Seeker, error) {
-	return newBadgerSeeker(b.db), nil
+func (b dbReader) NewSeeker() storage.Seeker {
+	return newBadgerSeeker(b.db)
 }
 
 // ToReader is a helper function to convert a *badger.DB to a Reader

--- a/storage/operation/chunk_data_packs_test.go
+++ b/storage/operation/chunk_data_packs_test.go
@@ -23,11 +23,8 @@ func TestChunkDataPack(t *testing.T) {
 		}
 
 		t.Run("Retrieve non-existent", func(t *testing.T) {
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actual storage.StoredChunkDataPack
-			err = operation.RetrieveChunkDataPack(reader, expected.ChunkID, &actual)
+			err := operation.RetrieveChunkDataPack(db.Reader(), expected.ChunkID, &actual)
 			assert.Error(t, err)
 		})
 
@@ -37,11 +34,8 @@ func TestChunkDataPack(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actual storage.StoredChunkDataPack
-			err = operation.RetrieveChunkDataPack(reader, expected.ChunkID, &actual)
+			err = operation.RetrieveChunkDataPack(db.Reader(), expected.ChunkID, &actual)
 			assert.NoError(t, err)
 
 			assert.Equal(t, *expected, actual)
@@ -53,11 +47,8 @@ func TestChunkDataPack(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actual storage.StoredChunkDataPack
-			err = operation.RetrieveChunkDataPack(reader, expected.ChunkID, &actual)
+			err = operation.RetrieveChunkDataPack(db.Reader(), expected.ChunkID, &actual)
 			assert.Error(t, err)
 		})
 	})

--- a/storage/operation/collections_test.go
+++ b/storage/operation/collections_test.go
@@ -18,11 +18,8 @@ func TestCollections(t *testing.T) {
 		expected := unittest.CollectionFixture(2).Light()
 
 		t.Run("Retrieve nonexistant", func(t *testing.T) {
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actual flow.LightCollection
-			err = operation.RetrieveCollection(reader, expected.ID(), &actual)
+			err := operation.RetrieveCollection(db.Reader(), expected.ID(), &actual)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, storage.ErrNotFound)
 		})
@@ -33,11 +30,8 @@ func TestCollections(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actual flow.LightCollection
-			err = operation.RetrieveCollection(reader, expected.ID(), &actual)
+			err = operation.RetrieveCollection(db.Reader(), expected.ID(), &actual)
 			assert.NoError(t, err)
 
 			assert.Equal(t, expected, actual)
@@ -49,11 +43,8 @@ func TestCollections(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actual flow.LightCollection
-			err = operation.RetrieveCollection(reader, expected.ID(), &actual)
+			err = operation.RetrieveCollection(db.Reader(), expected.ID(), &actual)
 			assert.Error(t, err)
 			assert.ErrorIs(t, err, storage.ErrNotFound)
 
@@ -76,11 +67,8 @@ func TestCollections(t *testing.T) {
 				return nil
 			})
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actual flow.LightCollection
-			err = operation.LookupCollectionPayload(reader, blockID, &actual.Transactions)
+			err := operation.LookupCollectionPayload(db.Reader(), blockID, &actual.Transactions)
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
 		})
@@ -96,10 +84,7 @@ func TestCollections(t *testing.T) {
 				return nil
 			})
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
-			err = operation.LookupCollectionByTransaction(reader, transactionID, &actual)
+			err := operation.LookupCollectionByTransaction(db.Reader(), transactionID, &actual)
 			assert.NoError(t, err)
 
 			assert.Equal(t, expected, actual)

--- a/storage/operation/commits_test.go
+++ b/storage/operation/commits_test.go
@@ -20,11 +20,8 @@ func TestStateCommitments(t *testing.T) {
 			return operation.IndexStateCommitment(rw.Writer(), id, expected)
 		}))
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
 		var actual flow.StateCommitment
-		err = operation.LookupStateCommitment(reader, id, &actual)
+		err := operation.LookupStateCommitment(db.Reader(), id, &actual)
 		require.Nil(t, err)
 		require.Equal(t, expected, actual)
 	})

--- a/storage/operation/computation_result_test.go
+++ b/storage/operation/computation_result_test.go
@@ -29,11 +29,8 @@ func TestUpsertAndRetrieveComputationResultUpdateStatus(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actualUploadStatus bool
-			err = operation.GetComputationResultUploadStatus(reader, expectedId, &actualUploadStatus)
+			err = operation.GetComputationResultUploadStatus(db.Reader(), expectedId, &actualUploadStatus)
 			require.NoError(t, err)
 
 			assert.Equal(t, testUploadStatusVal, actualUploadStatus)
@@ -45,11 +42,8 @@ func TestUpsertAndRetrieveComputationResultUpdateStatus(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err = db.Reader()
-			require.NoError(t, err)
-
 			// check if value is updated
-			err = operation.GetComputationResultUploadStatus(reader, expectedId, &actualUploadStatus)
+			err = operation.GetComputationResultUploadStatus(db.Reader(), expectedId, &actualUploadStatus)
 			require.NoError(t, err)
 
 			assert.Equal(t, testUploadStatusVal, actualUploadStatus)
@@ -70,11 +64,8 @@ func TestRemoveComputationResultUploadStatus(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actualUploadStatus bool
-			err = operation.GetComputationResultUploadStatus(reader, expectedId, &actualUploadStatus)
+			err = operation.GetComputationResultUploadStatus(db.Reader(), expectedId, &actualUploadStatus)
 			require.NoError(t, err)
 
 			assert.Equal(t, testUploadStatusVal, actualUploadStatus)
@@ -84,10 +75,7 @@ func TestRemoveComputationResultUploadStatus(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			reader, err = db.Reader()
-			require.NoError(t, err)
-
-			err = operation.GetComputationResultUploadStatus(reader, expectedId, &actualUploadStatus)
+			err = operation.GetComputationResultUploadStatus(db.Reader(), expectedId, &actualUploadStatus)
 			assert.NotNil(t, err)
 		})
 	})
@@ -111,12 +99,9 @@ func TestListComputationResults(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			// Get the list of IDs of stored ComputationResult
 			crIDs := make([]flow.Identifier, 0)
-			err = operation.GetBlockIDsByStatus(reader, &crIDs, true)
+			err := operation.GetBlockIDsByStatus(db.Reader(), &crIDs, true)
 			require.NoError(t, err)
 			crIDsStrMap := make(map[string]bool, 0)
 			for _, crID := range crIDs {

--- a/storage/operation/events_test.go
+++ b/storage/operation/events_test.go
@@ -81,11 +81,8 @@ func TestRetrieveEventByBlockIDTxID(t *testing.T) {
 			for _, b := range blockIDs {
 				var actualEvents = make([]flow.Event, 0)
 
-				reader, err := db.Reader()
-				require.NoError(t, err)
-
 				// lookup events by block id
-				err = operation.LookupEventsByBlockID(reader, b, &actualEvents)
+				err := operation.LookupEventsByBlockID(db.Reader(), b, &actualEvents)
 
 				expectedEvents := blockMap[b.String()]
 				assertFunc(err, expectedEvents, actualEvents)
@@ -97,11 +94,8 @@ func TestRetrieveEventByBlockIDTxID(t *testing.T) {
 				for _, tid := range txIDs {
 					var actualEvents = make([]flow.Event, 0)
 
-					reader, err := db.Reader()
-					require.NoError(t, err)
-
 					//lookup events by block id and transaction id
-					err = operation.RetrieveEvents(reader, b, tid, &actualEvents)
+					err := operation.RetrieveEvents(db.Reader(), b, tid, &actualEvents)
 
 					expectedEvents := txMap[b.String()+"_"+tid.String()]
 					assertFunc(err, expectedEvents, actualEvents)
@@ -114,11 +108,8 @@ func TestRetrieveEventByBlockIDTxID(t *testing.T) {
 				for _, et := range eTypes {
 					var actualEvents = make([]flow.Event, 0)
 
-					reader, err := db.Reader()
-					require.NoError(t, err)
-
 					//lookup events by block id and transaction id
-					err = operation.LookupEventsByBlockIDEventType(reader, b, et, &actualEvents)
+					err := operation.LookupEventsByBlockIDEventType(db.Reader(), b, et, &actualEvents)
 
 					expectedEvents := typeMap[b.String()+"_"+string(et)]
 					assertFunc(err, expectedEvents, actualEvents)

--- a/storage/operation/interactions_test.go
+++ b/storage/operation/interactions_test.go
@@ -48,10 +48,7 @@ func TestStateInteractionsInsertCheckRetrieve(t *testing.T) {
 
 		var readInteractions []*snapshot.ExecutionSnapshot
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
-		err = operation.RetrieveExecutionStateInteractions(reader, blockID, &readInteractions)
+		err = operation.RetrieveExecutionStateInteractions(db.Reader(), blockID, &readInteractions)
 		require.NoError(t, err)
 
 		assert.Equal(t, interactions, readInteractions)

--- a/storage/operation/multi_dbstore.go
+++ b/storage/operation/multi_dbstore.go
@@ -18,16 +18,11 @@ func NewMultiDBStore(rwStore storage.DB, rStore storage.DB) storage.DB {
 	}
 }
 
-func (b *multiDBStore) Reader() (storage.Reader, error) {
-	r1, err := b.rwStore.Reader()
-	if err != nil {
-		return nil, err
-	}
-	r2, err := b.r.Reader()
-	if err != nil {
-		return nil, err
-	}
-	return NewMultiReader(r1, r2)
+func (b *multiDBStore) Reader() storage.Reader {
+	return NewMultiReader(
+		b.rwStore.Reader(),
+		b.r.Reader(),
+	)
 }
 
 func (b *multiDBStore) WithReaderBatchWriter(fn func(storage.ReaderBatchWriter) error) error {

--- a/storage/operation/multi_iterator.go
+++ b/storage/operation/multi_iterator.go
@@ -25,7 +25,7 @@ var _ storage.Iterator = (*multiIterator)(nil)
 // the second iterator, etc.
 func NewMultiIterator(iterators ...storage.Iterator) (storage.Iterator, error) {
 	if len(iterators) == 0 {
-		return nil, errors.New("failed to create multiIterator: need at least one iterator")
+		panic("failed to create multiIterator: need at least one iterator")
 	}
 	if len(iterators) == 1 {
 		return iterators[0], nil

--- a/storage/operation/multi_iterator.go
+++ b/storage/operation/multi_iterator.go
@@ -23,6 +23,7 @@ var _ storage.Iterator = (*multiIterator)(nil)
 // multiple iterators in the provided sequence.  The returned iterator
 // iterates items in the first iterator, and then iterates items in
 // the second iterator, etc.
+// NewMultiIterator panics if 0 iterators are provided.
 func NewMultiIterator(iterators ...storage.Iterator) (storage.Iterator, error) {
 	if len(iterators) == 0 {
 		panic("failed to create multiIterator: need at least one iterator")

--- a/storage/operation/multi_iterator_test.go
+++ b/storage/operation/multi_iterator_test.go
@@ -53,14 +53,11 @@ func TestMultiIterator(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		preader, err := pebbleimpl.ToDB(pdb).Reader()
-		require.NoError(t, err)
+		preader := pebbleimpl.ToDB(pdb).Reader()
 
-		breader, err := badgerimpl.ToDB(bdb).Reader()
-		require.NoError(t, err)
+		breader := badgerimpl.ToDB(bdb).Reader()
 
-		reader, err := operation.NewMultiReader(preader, breader)
-		require.NoError(t, err)
+		reader := operation.NewMultiReader(preader, breader)
 
 		t.Run("not found, less than lower bound", func(t *testing.T) {
 			startPrefix := []byte{0x00}

--- a/storage/operation/multi_reader.go
+++ b/storage/operation/multi_reader.go
@@ -82,14 +82,10 @@ func (b *multiReader) NewIter(startPrefix, endPrefix []byte, ops storage.Iterato
 //
 // Returned new Seeker consists of multiple seekers in reverse order from underlying readers.
 // For example, the first seeker is created from the last underlying reader.
-func (b *multiReader) NewSeeker() (storage.Seeker, error) {
+func (b *multiReader) NewSeeker() storage.Seeker {
 	seekers := make([]storage.Seeker, len(b.readers))
 	for i, r := range b.readers {
-		seeker, err := r.NewSeeker()
-		if err != nil {
-			return nil, err
-		}
-		seekers[len(b.readers)-1-i] = seeker
+		seekers[len(b.readers)-1-i] = r.NewSeeker()
 	}
 
 	return NewMultiSeeker(seekers...)

--- a/storage/operation/multi_reader.go
+++ b/storage/operation/multi_reader.go
@@ -19,14 +19,14 @@ var _ storage.Reader = (*multiReader)(nil)
 // - a reader succeeds or
 // - a reader returns an error that is not ErrNotFound
 // If all readers return ErrNotFound, Reader.Get will return ErrNotFound.
-func NewMultiReader(readers ...storage.Reader) (storage.Reader, error) {
+func NewMultiReader(readers ...storage.Reader) storage.Reader {
 	if len(readers) == 0 {
-		return nil, errors.New("failed to create multiReader: need at least one reader")
+		panic("failed to create multiReader: need at least one reader")
 	}
 	if len(readers) == 1 {
-		return readers[0], nil
+		return readers[0]
 	}
-	return &multiReader{readers: readers}, nil
+	return &multiReader{readers: readers}
 }
 
 // Get gets the value for the given key from one of the readers.

--- a/storage/operation/multi_reader.go
+++ b/storage/operation/multi_reader.go
@@ -19,6 +19,7 @@ var _ storage.Reader = (*multiReader)(nil)
 // - a reader succeeds or
 // - a reader returns an error that is not ErrNotFound
 // If all readers return ErrNotFound, Reader.Get will return ErrNotFound.
+// NewMultiReader panics if 0 readers are provided.
 func NewMultiReader(readers ...storage.Reader) storage.Reader {
 	if len(readers) == 0 {
 		panic("failed to create multiReader: need at least one reader")

--- a/storage/operation/multi_reader_test.go
+++ b/storage/operation/multi_reader_test.go
@@ -48,14 +48,11 @@ func TestMultiReader(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		preader, err := pebbleimpl.ToDB(pdb).Reader()
-		require.NoError(t, err)
+		preader := pebbleimpl.ToDB(pdb).Reader()
 
-		breader, err := badgerimpl.ToDB(bdb).Reader()
-		require.NoError(t, err)
+		breader := badgerimpl.ToDB(bdb).Reader()
 
-		reader, err := operation.NewMultiReader(preader, breader)
-		require.NoError(t, err)
+		reader := operation.NewMultiReader(preader, breader)
 
 		t.Run("not found", func(t *testing.T) {
 			value, closer, err := reader.Get(notFoundKey)

--- a/storage/operation/multi_seeker.go
+++ b/storage/operation/multi_seeker.go
@@ -15,14 +15,14 @@ var _ storage.Seeker = (*multiSeeker)(nil)
 
 // NewMultiSeeker returns a Seeker that consists of multiple seekers
 // in the provided order.
-func NewMultiSeeker(seekers ...storage.Seeker) (storage.Seeker, error) {
+func NewMultiSeeker(seekers ...storage.Seeker) storage.Seeker {
 	if len(seekers) == 0 {
-		return nil, errors.New("failed to create multiSeeker: need at least one seeker")
+		panic("failed to create multiSeeker: need at least one seeker")
 	}
 	if len(seekers) == 1 {
-		return seekers[0], nil
+		return seekers[0]
 	}
-	return &multiSeeker{seekers: seekers}, nil
+	return &multiSeeker{seekers: seekers}
 }
 
 // SeekLE (seek less than or equal) returns the largest key in lexicographical

--- a/storage/operation/multi_seeker.go
+++ b/storage/operation/multi_seeker.go
@@ -15,6 +15,7 @@ var _ storage.Seeker = (*multiSeeker)(nil)
 
 // NewMultiSeeker returns a Seeker that consists of multiple seekers
 // in the provided order.
+// NewMultiSeeker panics if 0 seekers are provided.
 func NewMultiSeeker(seekers ...storage.Seeker) storage.Seeker {
 	if len(seekers) == 0 {
 		panic("failed to create multiSeeker: need at least one seeker")

--- a/storage/operation/multi_seeker_test.go
+++ b/storage/operation/multi_seeker_test.go
@@ -54,8 +54,7 @@ func TestMultiSeeker(t *testing.T) {
 		r := operation.NewMultiReader(preader, breader)
 
 		t.Run("key below start prefix", func(t *testing.T) {
-			seeker, err := r.NewSeeker()
-			require.NoError(t, err)
+			seeker := r.NewSeeker()
 
 			key := operation.MakePrefix(codePrefix, uint64(4))
 			startPrefix := operation.MakePrefix(codePrefix, uint64(5))
@@ -65,8 +64,7 @@ func TestMultiSeeker(t *testing.T) {
 		})
 
 		t.Run("has key below startPrefix", func(t *testing.T) {
-			seeker, err := r.NewSeeker()
-			require.NoError(t, err)
+			seeker := r.NewSeeker()
 
 			startPrefix := operation.MakePrefix(codePrefix, uint64(6))
 
@@ -78,8 +76,7 @@ func TestMultiSeeker(t *testing.T) {
 		})
 
 		t.Run("seek key in first db (Pebble)", func(t *testing.T) {
-			seeker, err := r.NewSeeker()
-			require.NoError(t, err)
+			seeker := r.NewSeeker()
 
 			startPrefix := operation.MakePrefix(codePrefix)
 
@@ -94,8 +91,7 @@ func TestMultiSeeker(t *testing.T) {
 		})
 
 		t.Run("seek key in second db (BadgerDB)", func(t *testing.T) {
-			seeker, err := r.NewSeeker()
-			require.NoError(t, err)
+			seeker := r.NewSeeker()
 
 			startPrefix := operation.MakePrefix(codePrefix)
 

--- a/storage/operation/multi_seeker_test.go
+++ b/storage/operation/multi_seeker_test.go
@@ -47,14 +47,11 @@ func TestMultiSeeker(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		preader, err := pebbleimpl.ToDB(pdb).Reader()
-		require.NoError(t, err)
+		preader := pebbleimpl.ToDB(pdb).Reader()
 
-		breader, err := badgerimpl.ToDB(bdb).Reader()
-		require.NoError(t, err)
+		breader := badgerimpl.ToDB(bdb).Reader()
 
-		r, err := operation.NewMultiReader(preader, breader)
-		require.NoError(t, err)
+		r := operation.NewMultiReader(preader, breader)
 
 		t.Run("key below start prefix", func(t *testing.T) {
 			seeker, err := r.NewSeeker()

--- a/storage/operation/pebbleimpl/dbstore.go
+++ b/storage/operation/pebbleimpl/dbstore.go
@@ -14,8 +14,8 @@ type dbStore struct {
 	db *pebble.DB
 }
 
-func (b *dbStore) Reader() (storage.Reader, error) {
-	return dbReader{db: b.db}, nil
+func (b *dbStore) Reader() storage.Reader {
+	return dbReader{db: b.db}
 }
 
 func (b *dbStore) WithReaderBatchWriter(fn func(storage.ReaderBatchWriter) error) error {

--- a/storage/operation/pebbleimpl/reader.go
+++ b/storage/operation/pebbleimpl/reader.go
@@ -59,8 +59,8 @@ func (b dbReader) NewIter(startPrefix, endPrefix []byte, ops storage.IteratorOpt
 }
 
 // NewSeeker returns a new Seeker.
-func (b dbReader) NewSeeker() (storage.Seeker, error) {
-	return newPebbleSeeker(b.db), nil
+func (b dbReader) NewSeeker() storage.Seeker {
+	return newPebbleSeeker(b.db)
 }
 
 // ToReader is a helper function to convert a *pebble.DB to a Reader

--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -207,10 +207,7 @@ func FindHighestAtOrBelowByPrefix(r storage.Reader, prefix []byte, height uint64
 
 	key := append(prefix, EncodeKeyPart(height)...)
 
-	seeker, err := r.NewSeeker()
-	if err != nil {
-		return err
-	}
+	seeker := r.NewSeeker()
 
 	// Seek the highest key equal or below to the given key within the [prefix, key] prefix range
 	highestKey, err := seeker.SeekLE(prefix, key)

--- a/storage/operation/receipts_test.go
+++ b/storage/operation/receipts_test.go
@@ -23,11 +23,8 @@ func TestReceipts_InsertRetrieve(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
 		var actual flow.ExecutionReceiptMeta
-		err = operation.RetrieveExecutionReceiptMeta(reader, receipt.ID(), &actual)
+		err = operation.RetrieveExecutionReceiptMeta(db.Reader(), receipt.ID(), &actual)
 		require.Nil(t, err)
 
 		assert.Equal(t, expected, &actual)
@@ -45,11 +42,8 @@ func TestReceipts_Index(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
 		var actual flow.Identifier
-		err = operation.LookupOwnExecutionReceipt(reader, blockID, &actual)
+		err = operation.LookupOwnExecutionReceipt(db.Reader(), blockID, &actual)
 		require.Nil(t, err)
 
 		assert.Equal(t, expected, actual)
@@ -69,11 +63,8 @@ func TestReceipts_MultiIndex(t *testing.T) {
 			return nil
 		}))
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
 		var actual []flow.Identifier
-		err = operation.LookupExecutionReceipts(reader, blockID, &actual)
+		err := operation.LookupExecutionReceipts(db.Reader(), blockID, &actual)
 		require.Nil(t, err)
 
 		assert.ElementsMatch(t, expected, actual)

--- a/storage/operation/results_test.go
+++ b/storage/operation/results_test.go
@@ -22,11 +22,8 @@ func TestResults_InsertRetrieve(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
 		var actual flow.ExecutionResult
-		err = operation.RetrieveExecutionResult(reader, expected.ID(), &actual)
+		err = operation.RetrieveExecutionResult(db.Reader(), expected.ID(), &actual)
 		require.Nil(t, err)
 
 		assert.Equal(t, expected, &actual)

--- a/storage/operation/seeker_test.go
+++ b/storage/operation/seeker_test.go
@@ -31,19 +31,17 @@ func TestSeekLE(t *testing.T) {
 		}))
 
 		t.Run("key below start prefix", func(t *testing.T) {
-			seeker, err := r.NewSeeker()
-			require.NoError(t, err)
+			seeker := r.NewSeeker()
 
 			key := operation.MakePrefix(codePrefix, uint64(4))
 			startPrefix := operation.MakePrefix(codePrefix, uint64(5))
 
-			_, err = seeker.SeekLE(startPrefix, key)
+			_, err := seeker.SeekLE(startPrefix, key)
 			require.Error(t, err)
 		})
 
 		t.Run("seek key inside range", func(t *testing.T) {
-			seeker, err := r.NewSeeker()
-			require.NoError(t, err)
+			seeker := r.NewSeeker()
 
 			startPrefix := operation.MakePrefix(codePrefix)
 
@@ -84,8 +82,7 @@ func TestSeekLE(t *testing.T) {
 		})
 
 		t.Run("has key below startPrefix", func(t *testing.T) {
-			seeker, err := r.NewSeeker()
-			require.NoError(t, err)
+			seeker := r.NewSeeker()
 
 			startPrefix := operation.MakePrefix(codePrefix, uint64(6))
 

--- a/storage/operation/stats_test.go
+++ b/storage/operation/stats_test.go
@@ -53,11 +53,8 @@ func TestSummarizeKeysByFirstByteConcurrent(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
 		// summarize keys by first byte
-		stats, err := operation.SummarizeKeysByFirstByteConcurrent(unittest.Logger(), reader, 10)
+		stats, err := operation.SummarizeKeysByFirstByteConcurrent(unittest.Logger(), db.Reader(), 10)
 		require.NoError(t, err)
 
 		// print

--- a/storage/operation/transactions_test.go
+++ b/storage/operation/transactions_test.go
@@ -23,20 +23,14 @@ func TestTransactions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		reader, err := db.Reader()
-		require.NoError(t, err)
-
 		// verify can be retrieved
 		var actual flow.Transaction
-		err = operation.RetrieveTransaction(reader, expected.ID(), &actual.TransactionBody)
+		err = operation.RetrieveTransaction(db.Reader(), expected.ID(), &actual.TransactionBody)
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 
-		reader, err = db.Reader()
-		require.NoError(t, err)
-
 		// retrieve non exist
-		err = operation.RetrieveTransaction(reader, unittest.IdentifierFixture(), &actual.TransactionBody)
+		err = operation.RetrieveTransaction(db.Reader(), unittest.IdentifierFixture(), &actual.TransactionBody)
 		require.Error(t, err)
 		require.ErrorIs(t, err, storage.ErrNotFound)
 
@@ -46,11 +40,8 @@ func TestTransactions(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		reader, err = db.Reader()
-		require.NoError(t, err)
-
 		// verify has been deleted
-		err = operation.RetrieveTransaction(reader, expected.ID(), &actual.TransactionBody)
+		err = operation.RetrieveTransaction(db.Reader(), expected.ID(), &actual.TransactionBody)
 		require.Error(t, err)
 		require.ErrorIs(t, err, storage.ErrNotFound)
 

--- a/storage/operation/version_beacon_test.go
+++ b/storage/operation/version_beacon_test.go
@@ -71,58 +71,40 @@ func TestResults_IndexByServiceEvents(t *testing.T) {
 		}))
 
 		t.Run("retrieve exact height match", func(t *testing.T) {
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actualVB flow.SealedVersionBeacon
-			err = operation.LookupLastVersionBeaconByHeight(reader, height1, &actualVB)
+			err := operation.LookupLastVersionBeaconByHeight(db.Reader(), height1, &actualVB)
 			require.NoError(t, err)
 			require.Equal(t, vb1, actualVB)
 
-			reader, err = db.Reader()
-			require.NoError(t, err)
-
-			err = operation.LookupLastVersionBeaconByHeight(reader, height2, &actualVB)
+			err = operation.LookupLastVersionBeaconByHeight(db.Reader(), height2, &actualVB)
 			require.NoError(t, err)
 			require.Equal(t, vb2, actualVB)
 
-			reader, err = db.Reader()
-			require.NoError(t, err)
-
-			err = operation.LookupLastVersionBeaconByHeight(reader, height3, &actualVB)
+			err = operation.LookupLastVersionBeaconByHeight(db.Reader(), height3, &actualVB)
 			require.NoError(t, err)
 			require.Equal(t, vb3, actualVB)
 		})
 
 		t.Run("finds highest but not higher than given", func(t *testing.T) {
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actualVB flow.SealedVersionBeacon
 
-			err = operation.LookupLastVersionBeaconByHeight(reader, height3-1, &actualVB)
+			err := operation.LookupLastVersionBeaconByHeight(db.Reader(), height3-1, &actualVB)
 			require.NoError(t, err)
 			require.Equal(t, vb2, actualVB)
 		})
 
 		t.Run("finds highest", func(t *testing.T) {
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actualVB flow.SealedVersionBeacon
 
-			err = operation.LookupLastVersionBeaconByHeight(reader, height3+1, &actualVB)
+			err := operation.LookupLastVersionBeaconByHeight(db.Reader(), height3+1, &actualVB)
 			require.NoError(t, err)
 			require.Equal(t, vb3, actualVB)
 		})
 
 		t.Run("height below lowest entry returns nothing", func(t *testing.T) {
-			reader, err := db.Reader()
-			require.NoError(t, err)
-
 			var actualVB flow.SealedVersionBeacon
 
-			err = operation.LookupLastVersionBeaconByHeight(reader, height1-1, &actualVB)
+			err := operation.LookupLastVersionBeaconByHeight(db.Reader(), height1-1, &actualVB)
 			require.ErrorIs(t, err, storage.ErrNotFound)
 		})
 	})

--- a/storage/operations.go
+++ b/storage/operations.go
@@ -98,7 +98,7 @@ type Reader interface {
 	NewIter(startPrefix, endPrefix []byte, ops IteratorOption) (Iterator, error)
 
 	// NewSeeker returns a new Seeker.
-	NewSeeker() (Seeker, error)
+	NewSeeker() Seeker
 }
 
 // Writer is an interface for batch writing to a storage backend.

--- a/storage/operations.go
+++ b/storage/operations.go
@@ -151,7 +151,7 @@ type ReaderBatchWriter interface {
 type DB interface {
 	// Reader returns a database-backed reader which reads the latest
 	// committed global database state
-	Reader() (Reader, error)
+	Reader() Reader
 
 	// WithReaderBatchWriter creates a batch writer and allows the caller to perform
 	// atomic batch updates to the database.

--- a/storage/store/approvals.go
+++ b/storage/store/approvals.go
@@ -109,12 +109,7 @@ func (r *ResultApprovals) Index(resultID flow.Identifier, chunkIndex uint64, app
 
 // ByID retrieves a ResultApproval by its ID
 func (r *ResultApprovals) ByID(approvalID flow.Identifier) (*flow.ResultApproval, error) {
-	reader, err := r.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
-	val, err := r.cache.Get(reader, approvalID)
+	val, err := r.cache.Get(r.db.Reader(), approvalID)
 	if err != nil {
 		return nil, err
 	}
@@ -125,13 +120,8 @@ func (r *ResultApprovals) ByID(approvalID flow.Identifier) (*flow.ResultApproval
 // ResultApprovals store is only used within a verification node, where it is
 // assumed that there is never more than one approval per chunk.
 func (r *ResultApprovals) ByChunk(resultID flow.Identifier, chunkIndex uint64) (*flow.ResultApproval, error) {
-	reader, err := r.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	var approvalID flow.Identifier
-	err = operation.LookupResultApproval(reader, resultID, chunkIndex, &approvalID)
+	err := operation.LookupResultApproval(r.db.Reader(), resultID, chunkIndex, &approvalID)
 	if err != nil {
 		return nil, fmt.Errorf("could not lookup result approval ID: %w", err)
 	}

--- a/storage/store/chunk_data_packs.go
+++ b/storage/store/chunk_data_packs.go
@@ -130,11 +130,7 @@ func (ch *ChunkDataPacks) byChunkID(chunkID flow.Identifier) (*storage.StoredChu
 }
 
 func (ch *ChunkDataPacks) retrieveCHDP(chunkID flow.Identifier) (*storage.StoredChunkDataPack, error) {
-	reader, err := ch.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-	val, err := ch.byChunkIDCache.Get(reader, chunkID)
+	val, err := ch.byChunkIDCache.Get(ch.db.Reader(), chunkID)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/store/chunks_queue.go
+++ b/storage/store/chunks_queue.go
@@ -126,13 +126,8 @@ func (q *ChunksQueue) StoreChunkLocator(locator *chunks.Locator) (bool, error) {
 		return false, err
 	}
 
-	reader, err := q.db.Reader()
-	if err != nil {
-		return false, err
-	}
-
 	// make sure the chunk locator is unique
-	exists, err := operation.ExistChunkLocator(reader, locator.ID())
+	exists, err := operation.ExistChunkLocator(q.db.Reader(), locator.ID())
 	if err != nil {
 		return false, fmt.Errorf("failed to check chunk locator existence: %w", err)
 	}
@@ -169,13 +164,8 @@ func (q *ChunksQueue) StoreChunkLocator(locator *chunks.Locator) (bool, error) {
 
 // LatestIndex returns the index of the latest chunk locator stored in the queue.
 func (q *ChunksQueue) LatestIndex() (uint64, error) {
-	reader, err := q.db.Reader()
-	if err != nil {
-		return 0, err
-	}
-
 	var latest uint64
-	err = operation.RetrieveJobLatestIndex(reader, JobQueueChunksQueue, &latest)
+	err := operation.RetrieveJobLatestIndex(q.db.Reader(), JobQueueChunksQueue, &latest)
 	if err != nil {
 		return 0, fmt.Errorf("could not retrieve latest index for chunks queue: %w", err)
 	}
@@ -184,9 +174,5 @@ func (q *ChunksQueue) LatestIndex() (uint64, error) {
 
 // AtIndex returns the chunk locator stored at the given index in the queue.
 func (q *ChunksQueue) AtIndex(index uint64) (*chunks.Locator, error) {
-	reader, err := q.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-	return q.chunkLocatorCache.Get(reader, index)
+	return q.chunkLocatorCache.Get(q.db.Reader(), index)
 }

--- a/storage/store/chunks_queue_test.go
+++ b/storage/store/chunks_queue_test.go
@@ -131,11 +131,8 @@ func TestChunksQueue(t *testing.T) {
 			require.Equal(t, uint64(len(locators)), latest)
 
 			for _, locator := range locators {
-				reader, err := db.Reader()
-				require.NoError(t, err)
-
 				var stored chunks.Locator
-				err = operation.RetrieveChunkLocator(reader, locator.ID(), &stored)
+				err = operation.RetrieveChunkLocator(db.Reader(), locator.ID(), &stored)
 				require.NoError(t, err)
 				require.Equal(t, *locator, stored)
 			}

--- a/storage/store/collections.go
+++ b/storage/store/collections.go
@@ -68,12 +68,7 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 		collection flow.Collection
 	)
 
-	reader, err := c.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
-	err = operation.RetrieveCollection(reader, colID, &light)
+	err := operation.RetrieveCollection(c.db.Reader(), colID, &light)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve collection: %w", err)
 	}
@@ -92,14 +87,9 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 
 // LightByID retrieves a light collection by its ID.
 func (c *Collections) LightByID(colID flow.Identifier) (*flow.LightCollection, error) {
-	reader, err := c.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	var collection flow.LightCollection
 
-	err = operation.RetrieveCollection(reader, colID, &collection)
+	err := operation.RetrieveCollection(c.db.Reader(), colID, &collection)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve collection: %w", err)
 	}
@@ -201,19 +191,14 @@ func (c *Collections) StoreLightAndIndexByTransaction(collection *flow.LightColl
 
 // LightByTransactionID retrieves a light collection by a transaction ID.
 func (c *Collections) LightByTransactionID(txID flow.Identifier) (*flow.LightCollection, error) {
-	reader, err := c.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	collID := &flow.Identifier{}
-	err = operation.LookupCollectionByTransaction(reader, txID, collID)
+	err := operation.LookupCollectionByTransaction(c.db.Reader(), txID, collID)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve collection id: %w", err)
 	}
 
 	var collection flow.LightCollection
-	err = operation.RetrieveCollection(reader, *collID, &collection)
+	err = operation.RetrieveCollection(c.db.Reader(), *collID, &collection)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve collection: %w", err)
 	}

--- a/storage/store/commits.go
+++ b/storage/store/commits.go
@@ -65,11 +65,7 @@ func (c *Commits) BatchStore(blockID flow.Identifier, commit flow.StateCommitmen
 }
 
 func (c *Commits) ByBlockID(blockID flow.Identifier) (flow.StateCommitment, error) {
-	reader, err := c.db.Reader()
-	if err != nil {
-		return flow.DummyStateCommitment, nil
-	}
-	return c.retrieveTx(reader, blockID)
+	return c.retrieveTx(c.db.Reader(), blockID)
 }
 
 func (c *Commits) RemoveByBlockID(blockID flow.Identifier) error {

--- a/storage/store/computation_result.go
+++ b/storage/store/computation_result.go
@@ -24,24 +24,14 @@ func (c *ComputationResultUploadStatus) Upsert(blockID flow.Identifier,
 }
 
 func (c *ComputationResultUploadStatus) GetIDsByUploadStatus(targetUploadStatus bool) ([]flow.Identifier, error) {
-	reader, err := c.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	ids := make([]flow.Identifier, 0)
-	err = operation.GetBlockIDsByStatus(reader, &ids, targetUploadStatus)
+	err := operation.GetBlockIDsByStatus(c.db.Reader(), &ids, targetUploadStatus)
 	return ids, err
 }
 
 func (c *ComputationResultUploadStatus) ByID(computationResultID flow.Identifier) (bool, error) {
-	reader, err := c.db.Reader()
-	if err != nil {
-		return false, err
-	}
-
 	var ret bool
-	err = operation.GetComputationResultUploadStatus(reader, computationResultID, &ret)
+	err := operation.GetComputationResultUploadStatus(c.db.Reader(), computationResultID, &ret)
 	if err != nil {
 		return false, err
 	}

--- a/storage/store/consumer_progress.go
+++ b/storage/store/consumer_progress.go
@@ -64,13 +64,8 @@ func newConsumerProgress(db storage.DB, consumer string) *consumerProgress {
 // ProcessedIndex returns the processed index for the consumer
 // any error would be exception
 func (cp *consumerProgress) ProcessedIndex() (uint64, error) {
-	reader, err := cp.db.Reader()
-	if err != nil {
-		return 0, err
-	}
-
 	var processed uint64
-	err = operation.RetrieveProcessedIndex(reader, cp.consumer, &processed)
+	err := operation.RetrieveProcessedIndex(cp.db.Reader(), cp.consumer, &processed)
 	if err != nil {
 		return 0, fmt.Errorf("failed to retrieve processed index: %w", err)
 	}

--- a/storage/store/events.go
+++ b/storage/store/events.go
@@ -76,12 +76,7 @@ func (e *Events) Store(blockID flow.Identifier, blockEvents []flow.EventsList) e
 // ByBlockID returns the events for the given block ID
 // Note: This method will return an empty slice and no error if no entries for the blockID are found
 func (e *Events) ByBlockID(blockID flow.Identifier) ([]flow.Event, error) {
-	reader, err := e.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
-	val, err := e.cache.Get(reader, blockID)
+	val, err := e.cache.Get(e.db.Reader(), blockID)
 	if err != nil {
 		return nil, err
 	}
@@ -194,12 +189,7 @@ func (e *ServiceEvents) BatchStore(blockID flow.Identifier, events []flow.Event,
 
 // ByBlockID returns the events for the given block ID
 func (e *ServiceEvents) ByBlockID(blockID flow.Identifier) ([]flow.Event, error) {
-	reader, err := e.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
-	val, err := e.cache.Get(reader, blockID)
+	val, err := e.cache.Get(e.db.Reader(), blockID)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/store/light_transaction_results.go
+++ b/storage/store/light_transaction_results.go
@@ -119,13 +119,8 @@ func (tr *LightTransactionResults) BatchStoreBadger(blockID flow.Identifier, tra
 
 // ByBlockIDTransactionID returns the transaction result for the given block ID and transaction ID
 func (tr *LightTransactionResults) ByBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) (*flow.LightTransactionResult, error) {
-	reader, err := tr.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockIDTransactionID(blockID, txID)
-	transactionResult, err := tr.cache.Get(reader, key)
+	transactionResult, err := tr.cache.Get(tr.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -134,13 +129,8 @@ func (tr *LightTransactionResults) ByBlockIDTransactionID(blockID flow.Identifie
 
 // ByBlockIDTransactionIndex returns the transaction result for the given blockID and transaction index
 func (tr *LightTransactionResults) ByBlockIDTransactionIndex(blockID flow.Identifier, txIndex uint32) (*flow.LightTransactionResult, error) {
-	reader, err := tr.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockIDIndex(blockID, txIndex)
-	transactionResult, err := tr.indexCache.Get(reader, key)
+	transactionResult, err := tr.indexCache.Get(tr.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -149,13 +139,8 @@ func (tr *LightTransactionResults) ByBlockIDTransactionIndex(blockID flow.Identi
 
 // ByBlockID gets all transaction results for a block, ordered by transaction index
 func (tr *LightTransactionResults) ByBlockID(blockID flow.Identifier) ([]flow.LightTransactionResult, error) {
-	reader, err := tr.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockID(blockID)
-	transactionResults, err := tr.blockCache.Get(reader, key)
+	transactionResults, err := tr.blockCache.Get(tr.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/store/my_receipts.go
+++ b/storage/store/my_receipts.go
@@ -99,11 +99,7 @@ func NewMyExecutionReceipts(collector module.CacheMetrics, db storage.DB, receip
 
 // storeMyReceipt assembles the operations to retrieve my receipt for the given block ID.
 func (m *MyExecutionReceipts) myReceipt(blockID flow.Identifier) (*flow.ExecutionReceipt, error) {
-	reader, err := m.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-	return m.cache.Get(reader, blockID) // assemble DB operations to retrieve receipt (no execution)
+	return m.cache.Get(m.db.Reader(), blockID) // assemble DB operations to retrieve receipt (no execution)
 }
 
 // BatchStoreMyReceipt stores blockID-to-my-receipt index entry keyed by blockID in a provided batch.

--- a/storage/store/receipts.go
+++ b/storage/store/receipts.go
@@ -68,11 +68,7 @@ func (r *ExecutionReceipts) storeTx(rw storage.ReaderBatchWriter, receipt *flow.
 }
 
 func (r *ExecutionReceipts) byID(receiptID flow.Identifier) (*flow.ExecutionReceipt, error) {
-	reader, err := r.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-	val, err := r.cache.Get(reader, receiptID)
+	val, err := r.cache.Get(r.db.Reader(), receiptID)
 	if err != nil {
 		return nil, err
 	}
@@ -80,13 +76,8 @@ func (r *ExecutionReceipts) byID(receiptID flow.Identifier) (*flow.ExecutionRece
 }
 
 func (r *ExecutionReceipts) byBlockID(blockID flow.Identifier) ([]*flow.ExecutionReceipt, error) {
-	reader, err := r.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	var receiptIDs []flow.Identifier
-	err = operation.LookupExecutionReceipts(reader, blockID, &receiptIDs)
+	err := operation.LookupExecutionReceipts(r.db.Reader(), blockID, &receiptIDs)
 	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return nil, fmt.Errorf("could not find receipt index for block: %w", err)
 	}

--- a/storage/store/transaction_result_error_messages.go
+++ b/storage/store/transaction_result_error_messages.go
@@ -99,14 +99,9 @@ func (t *TransactionResultErrorMessages) Exists(blockID flow.Identifier) (bool, 
 		return ok, nil
 	}
 
-	reader, err := t.db.Reader()
-	if err != nil {
-		return false, err
-	}
-
 	// otherwise, check badger store
 	var exists bool
-	err = operation.TransactionResultErrorMessagesExists(reader, blockID, &exists)
+	err := operation.TransactionResultErrorMessagesExists(t.db.Reader(), blockID, &exists)
 	if err != nil {
 		return false, fmt.Errorf("could not check existence: %w", err)
 	}
@@ -155,13 +150,8 @@ func (t *TransactionResultErrorMessages) batchStore(
 // Expected errors during normal operation:
 //   - `storage.ErrNotFound` if no transaction error message is known at given block and transaction id.
 func (t *TransactionResultErrorMessages) ByBlockIDTransactionID(blockID flow.Identifier, transactionID flow.Identifier) (*flow.TransactionResultErrorMessage, error) {
-	reader, err := t.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockIDTransactionID(blockID, transactionID)
-	transactionResultErrorMessage, err := t.cache.Get(reader, key)
+	transactionResultErrorMessage, err := t.cache.Get(t.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -173,13 +163,8 @@ func (t *TransactionResultErrorMessages) ByBlockIDTransactionID(blockID flow.Ide
 // Expected errors during normal operation:
 //   - `storage.ErrNotFound` if no transaction error message is known at given block and transaction index.
 func (t *TransactionResultErrorMessages) ByBlockIDTransactionIndex(blockID flow.Identifier, txIndex uint32) (*flow.TransactionResultErrorMessage, error) {
-	reader, err := t.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockIDIndex(blockID, txIndex)
-	transactionResultErrorMessage, err := t.indexCache.Get(reader, key)
+	transactionResultErrorMessage, err := t.indexCache.Get(t.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -191,13 +176,8 @@ func (t *TransactionResultErrorMessages) ByBlockIDTransactionIndex(blockID flow.
 //
 // No errors are expected during normal operation.
 func (t *TransactionResultErrorMessages) ByBlockID(blockID flow.Identifier) ([]flow.TransactionResultErrorMessage, error) {
-	reader, err := t.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockID(blockID)
-	transactionResultErrorMessages, err := t.blockCache.Get(reader, key)
+	transactionResultErrorMessages, err := t.blockCache.Get(t.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/store/transaction_results.go
+++ b/storage/store/transaction_results.go
@@ -178,13 +178,8 @@ func (tr *TransactionResults) BatchStore(blockID flow.Identifier, transactionRes
 
 // ByBlockIDTransactionID returns the runtime transaction result for the given block ID and transaction ID
 func (tr *TransactionResults) ByBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) (*flow.TransactionResult, error) {
-	reader, err := tr.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockIDTransactionID(blockID, txID)
-	transactionResult, err := tr.cache.Get(reader, key)
+	transactionResult, err := tr.cache.Get(tr.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -193,13 +188,8 @@ func (tr *TransactionResults) ByBlockIDTransactionID(blockID flow.Identifier, tx
 
 // ByBlockIDTransactionIndex returns the runtime transaction result for the given block ID and transaction index
 func (tr *TransactionResults) ByBlockIDTransactionIndex(blockID flow.Identifier, txIndex uint32) (*flow.TransactionResult, error) {
-	reader, err := tr.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockIDIndex(blockID, txIndex)
-	transactionResult, err := tr.indexCache.Get(reader, key)
+	transactionResult, err := tr.indexCache.Get(tr.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}
@@ -208,13 +198,8 @@ func (tr *TransactionResults) ByBlockIDTransactionIndex(blockID flow.Identifier,
 
 // ByBlockID gets all transaction results for a block, ordered by transaction index
 func (tr *TransactionResults) ByBlockID(blockID flow.Identifier) ([]flow.TransactionResult, error) {
-	reader, err := tr.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	key := KeyFromBlockID(blockID)
-	transactionResults, err := tr.blockCache.Get(reader, key)
+	transactionResults, err := tr.blockCache.Get(tr.db.Reader(), key)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/store/transactions.go
+++ b/storage/store/transactions.go
@@ -56,11 +56,7 @@ func (t *Transactions) storeTx(rw storage.ReaderBatchWriter, flowTx *flow.Transa
 }
 
 func (t *Transactions) ByID(txID flow.Identifier) (*flow.TransactionBody, error) {
-	reader, err := t.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-	return t.cache.Get(reader, txID)
+	return t.cache.Get(t.db.Reader(), txID)
 }
 
 // RemoveBatch removes a transaction by fingerprint.

--- a/storage/store/version_beacon.go
+++ b/storage/store/version_beacon.go
@@ -25,14 +25,9 @@ func NewVersionBeacons(db storage.DB) *VersionBeacons {
 func (r *VersionBeacons) Highest(
 	belowOrEqualTo uint64,
 ) (*flow.SealedVersionBeacon, error) {
-	reader, err := r.db.Reader()
-	if err != nil {
-		return nil, err
-	}
-
 	var beacon flow.SealedVersionBeacon
 
-	err = operation.LookupLastVersionBeaconByHeight(reader, belowOrEqualTo, &beacon)
+	err := operation.LookupLastVersionBeaconByHeight(r.db.Reader(), belowOrEqualTo, &beacon)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return nil, nil


### PR DESCRIPTION
This PR modifies `NewMultiReader()` to panic (instead of returning an error) if the provided reader list is empty.  It also updates `DB.Reader()` API to not return an error because the only possible error was replaced by a panic in this PR.

To match this API change to `NewMultiReader`, this PR also updates API of `NewMultiIterator` and `NewMultiSeeker` to be consistent.  E.g., `NewMultiIterator` panics instead of returning error when the caller provides 0 iterators.