### PR TITLE
[Malleability] UntrustedClusterProposal, BlockProposal refactoring

### DIFF
--- a/cmd/bootstrap/run/cluster_qc_test.go
+++ b/cmd/bootstrap/run/cluster_qc_test.go
@@ -31,7 +31,7 @@ func TestGenerateClusterRootQC(t *testing.T) {
 	)
 
 	orderedParticipants := model.ToIdentityList(participants).Sort(flow.Canonical[flow.Identity]).ToSkeleton()
-	_, err := GenerateClusterRootQC(participants, orderedParticipants, clusterBlock)
+	_, err := GenerateClusterRootQC(participants, orderedParticipants, &clusterBlock)
 	require.NoError(t, err)
 }
 

--- a/cmd/util/cmd/read-light-block/read_light_block.go
+++ b/cmd/util/cmd/read-light-block/read_light_block.go
@@ -35,7 +35,7 @@ func ReadClusterLightBlockByHeightRange(clusterBlocks storage.ClusterBlocks, sta
 			}
 			return nil, fmt.Errorf("could not get cluster block by height %v: %w", height, err)
 		}
-		light := ClusterBlockToLight(block.Block)
+		light := ClusterBlockToLight(&block.Block)
 		blocks = append(blocks, light)
 	}
 	return blocks, nil

--- a/cmd/util/cmd/read-light-block/read_light_block_test.go
+++ b/cmd/util/cmd/read-light-block/read_light_block_test.go
@@ -28,7 +28,7 @@ func TestReadClusterRange(t *testing.T) {
 
 		// add blocks
 		for _, block := range blocks {
-			err := db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(&block)))
+			err := db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(block)))
 			require.NoError(t, err)
 
 			err = db.Update(procedure.FinalizeClusterBlock(block.ID()))

--- a/engine/collection/compliance/core_test.go
+++ b/engine/collection/compliance/core_test.go
@@ -65,7 +65,7 @@ type CommonSuite struct {
 
 func (cs *CommonSuite) SetupTest() {
 	block := unittest.ClusterBlockFixture()
-	cs.head = unittest.ClusterProposalFromBlock(&block)
+	cs.head = unittest.ClusterProposalFromBlock(block)
 
 	// initialize the storage data
 	cs.headerDB = make(map[flow.Identifier]*flow.Header)
@@ -196,11 +196,10 @@ func (cs *CommonSuite) SetupTest() {
 }
 
 func (cs *CoreSuite) TestOnBlockProposalValidParent() {
-
 	// create a proposal that directly descends from the latest finalized header
 	originID := unittest.IdentifierFixture()
 	block := unittest.ClusterBlockWithParent(cs.head.Block)
-	proposal := unittest.ClusterProposalFromBlock(&block)
+	proposal := unittest.ClusterProposalFromBlock(block)
 
 	hotstuffProposal := model.SignedProposalFromClusterBlock(proposal)
 	cs.validator.On("ValidateProposal", hotstuffProposal).Return(nil)
@@ -220,9 +219,9 @@ func (cs *CoreSuite) TestOnBlockProposalValidAncestor() {
 	// create a proposal that has two ancestors in the cache
 	originID := unittest.IdentifierFixture()
 	ancestor := unittest.ClusterBlockWithParent(cs.head.Block)
-	parent := unittest.ClusterBlockWithParent(&ancestor)
-	block := unittest.ClusterBlockWithParent(&parent)
-	proposal := unittest.ClusterProposalFromBlock(&block)
+	parent := unittest.ClusterBlockWithParent(ancestor)
+	block := unittest.ClusterBlockWithParent(parent)
+	proposal := unittest.ClusterProposalFromBlock(block)
 
 	// store the data for retrieval
 	cs.headerDB[parent.ID()] = parent.ToHeader()
@@ -250,7 +249,7 @@ func (cs *CoreSuite) TestOnBlockProposalSkipProposalThreshold() {
 	originID := unittest.IdentifierFixture()
 	block := unittest.ClusterBlockFixture()
 	block.Header.Height = cs.head.Block.Header.Height + compliance.DefaultConfig().SkipNewProposalsThreshold + 1
-	proposal := unittest.ClusterProposalFromBlock(&block)
+	proposal := unittest.ClusterProposalFromBlock(block)
 
 	err := cs.core.OnBlockProposal(flow.Slashable[*messages.UntrustedClusterProposal]{
 		OriginID: originID,
@@ -273,9 +272,9 @@ func (cs *CoreSuite) TestOnBlockProposal_FailsHotStuffValidation() {
 	// create a proposal that has two ancestors in the cache
 	originID := unittest.IdentifierFixture()
 	ancestor := unittest.ClusterBlockWithParent(cs.head.Block)
-	parent := unittest.ClusterBlockWithParent(&ancestor)
-	block := unittest.ClusterBlockWithParent(&parent)
-	proposal := unittest.ClusterProposalFromBlock(&block)
+	parent := unittest.ClusterBlockWithParent(ancestor)
+	block := unittest.ClusterBlockWithParent(parent)
+	proposal := unittest.ClusterProposalFromBlock(block)
 	proposalMsg := messages.UntrustedClusterProposalFromInternal(proposal)
 	hotstuffProposal := model.SignedProposalFromClusterBlock(proposal)
 
@@ -357,9 +356,9 @@ func (cs *CoreSuite) TestOnBlockProposal_FailsProtocolStateValidation() {
 	// create a proposal that has two ancestors in the cache
 	originID := unittest.IdentifierFixture()
 	ancestor := unittest.ClusterBlockWithParent(cs.head.Block)
-	parent := unittest.ClusterBlockWithParent(&ancestor)
-	block := unittest.ClusterBlockWithParent(&parent)
-	proposal := unittest.ClusterProposalFromBlock(&block)
+	parent := unittest.ClusterBlockWithParent(ancestor)
+	block := unittest.ClusterBlockWithParent(parent)
+	proposal := unittest.ClusterProposalFromBlock(block)
 	proposalMsg := messages.UntrustedClusterProposalFromInternal(proposal)
 	hotstuffProposal := model.SignedProposalFromClusterBlock(proposal)
 
@@ -448,14 +447,14 @@ func (cs *CoreSuite) TestProcessBlockAndDescendants() {
 
 	// create three children blocks
 	parent := unittest.ClusterBlockWithParent(cs.head.Block)
-	block1 := unittest.ClusterBlockWithParent(&parent)
-	block2 := unittest.ClusterBlockWithParent(&parent)
-	block3 := unittest.ClusterBlockWithParent(&parent)
+	block1 := unittest.ClusterBlockWithParent(parent)
+	block2 := unittest.ClusterBlockWithParent(parent)
+	block3 := unittest.ClusterBlockWithParent(parent)
 
-	proposal0 := unittest.ClusterProposalFromBlock(&parent)
-	proposal1 := unittest.ClusterProposalFromBlock(&block1)
-	proposal2 := unittest.ClusterProposalFromBlock(&block2)
-	proposal3 := unittest.ClusterProposalFromBlock(&block3)
+	proposal0 := unittest.ClusterProposalFromBlock(parent)
+	proposal1 := unittest.ClusterProposalFromBlock(block1)
+	proposal2 := unittest.ClusterProposalFromBlock(block2)
+	proposal3 := unittest.ClusterProposalFromBlock(block3)
 
 	pendingFromProposal := func(block *cluster.BlockProposal) flow.Slashable[*cluster.BlockProposal] {
 		return flow.Slashable[*cluster.BlockProposal]{
@@ -500,11 +499,10 @@ func (cs *CoreSuite) TestProcessBlockAndDescendants() {
 }
 
 func (cs *CoreSuite) TestProposalBufferingOrder() {
-
 	// create a proposal that we will not submit until the end
 	originID := unittest.IdentifierFixture()
 	block := unittest.ClusterBlockWithParent(cs.head.Block)
-	missing := &block
+	missing := block
 
 	// create a chain of descendants
 	var proposals []*cluster.BlockProposal
@@ -512,10 +510,10 @@ func (cs *CoreSuite) TestProposalBufferingOrder() {
 	parent := missing
 	for i := 0; i < 3; i++ {
 		block := unittest.ClusterBlockWithParent(parent)
-		proposal := unittest.ClusterProposalFromBlock(&block)
+		proposal := unittest.ClusterProposalFromBlock(block)
 		proposals = append(proposals, proposal)
 		proposalsLookup[block.ID()] = proposal
-		parent = &block
+		parent = block
 	}
 
 	// replace the engine buffer with the real one

--- a/engine/collection/compliance/engine_test.go
+++ b/engine/collection/compliance/engine_test.go
@@ -164,7 +164,7 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 	go func() {
 		for i := 0; i < blockCount; i++ {
 			block := unittest.ClusterBlockWithParent(cs.head.Block)
-			proposal := unittest.ClusterProposalFromBlock(&block)
+			proposal := unittest.ClusterProposalFromBlock(block)
 			hotstuffProposal := model.SignedProposalFromClusterBlock(proposal)
 			cs.hotstuff.On("SubmitProposal", hotstuffProposal).Return().Once()
 			cs.voteAggregator.On("AddBlock", hotstuffProposal).Once()
@@ -181,7 +181,7 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 	go func() {
 		// create a proposal that directly descends from the latest finalized header
 		block := unittest.ClusterBlockWithParent(cs.head.Block)
-		proposal := unittest.ClusterProposalFromBlock(&block)
+		proposal := unittest.ClusterProposalFromBlock(block)
 
 		hotstuffProposal := model.SignedProposalFromClusterBlock(proposal)
 		cs.hotstuff.On("SubmitProposal", hotstuffProposal).Once()
@@ -206,7 +206,7 @@ func (cs *EngineSuite) TestSubmittingMultipleEntries() {
 // Tests the whole processing pipeline.
 func (cs *EngineSuite) TestOnFinalizedBlock() {
 	finalizedBlock := unittest.ClusterBlockFixture()
-	proposal := unittest.ClusterProposalFromBlock(&finalizedBlock)
+	proposal := unittest.ClusterProposalFromBlock(finalizedBlock)
 	cs.head = proposal
 	cs.headerDB[finalizedBlock.ID()] = proposal.Block.ToHeader()
 

--- a/engine/collection/synchronization/engine_test.go
+++ b/engine/collection/synchronization/engine_test.go
@@ -230,7 +230,7 @@ func (ss *SyncSuite) TestOnRangeRequest() {
 	for height := ref; height >= ref-4; height-- {
 		block := unittest.ClusterBlockFixture()
 		block.Header.Height = height
-		ss.heights[height] = unittest.ClusterProposalFromBlock(&block)
+		ss.heights[height] = unittest.ClusterProposalFromBlock(block)
 		ss.blockIDs[block.ID()] = ss.heights[height]
 	}
 
@@ -366,7 +366,7 @@ func (ss *SyncSuite) TestOnBatchRequest() {
 		block := unittest.ClusterBlockFixture()
 		block.Header.Height = ss.head.Height - 1
 		req.BlockIDs = []flow.Identifier{block.ID()}
-		proposal := unittest.ClusterProposalFromBlock(&block)
+		proposal := unittest.ClusterProposalFromBlock(block)
 		ss.blockIDs[block.ID()] = proposal
 		ss.con.On("Unicast", mock.Anything, mock.Anything).Return(nil).Once().Run(
 			func(args mock.Arguments) {
@@ -390,7 +390,7 @@ func (ss *SyncSuite) TestOnBatchRequest() {
 			b := unittest.ClusterBlockFixture()
 			b.Header.Height = ss.head.Height - uint64(i)
 			req.BlockIDs[i] = b.ID()
-			ss.blockIDs[b.ID()] = unittest.ClusterProposalFromBlock(&b)
+			ss.blockIDs[b.ID()] = unittest.ClusterProposalFromBlock(b)
 		}
 
 		ss.con.On("Unicast", mock.Anything, mock.Anything).Return(nil).Once().Run(
@@ -427,12 +427,12 @@ func (ss *SyncSuite) TestOnBlockResponse() {
 	// add one block that should be processed
 	processable := unittest.ClusterBlockFixture()
 	ss.core.On("HandleBlock", processable.ToHeader()).Return(true)
-	res.Blocks = append(res.Blocks, *messages.NewUntrustedClusterProposal(&processable, unittest.SignatureFixture()))
+	res.Blocks = append(res.Blocks, *messages.NewUntrustedClusterProposal(processable, unittest.SignatureFixture()))
 
 	// add one block that should not be processed
 	unprocessable := unittest.ClusterBlockFixture()
 	ss.core.On("HandleBlock", unprocessable.ToHeader()).Return(false)
-	res.Blocks = append(res.Blocks, *messages.NewUntrustedClusterProposal(&unprocessable, unittest.SignatureFixture()))
+	res.Blocks = append(res.Blocks, *messages.NewUntrustedClusterProposal(unprocessable, unittest.SignatureFixture()))
 
 	ss.comp.On("OnSyncedClusterBlock", mock.Anything).Run(func(args mock.Arguments) {
 		res := args.Get(0).(flow.Slashable[*messages.UntrustedClusterProposal])

--- a/integration/tests/collection/suite.go
+++ b/integration/tests/collection/suite.go
@@ -212,8 +212,8 @@ func (suite *CollectorSuite) AwaitProposals(n uint) []cluster.Block {
 
 		switch val := msg.(type) {
 		case *messages.UntrustedClusterProposal:
-			block := val.Block.ToInternal()
-			blocks = append(blocks, *block)
+			internalClusterProposal := val.ToInternal()
+			blocks = append(blocks, internalClusterProposal.Block)
 			if len(blocks) == int(n) {
 				return blocks
 			}
@@ -261,7 +261,8 @@ func (suite *CollectorSuite) AwaitTransactionsIncluded(txIDs ...flow.Identifier)
 
 		switch val := msg.(type) {
 		case *messages.UntrustedClusterProposal:
-			block := val.Block.ToInternal()
+			internalClusterProposal := val.ToInternal()
+			block := internalClusterProposal.Block
 			header := block.Header
 			collection := block.Payload.Collection
 			suite.T().Logf("got collection from %v height=%d col_id=%x size=%d", originID, header.Height, collection.ID(), collection.Len())

--- a/model/cluster/block.go
+++ b/model/cluster/block.go
@@ -16,7 +16,8 @@ func Genesis() *Block {
 		},
 	}
 
-	return NewBlock(header.HeaderBody, EmptyPayload(flow.ZeroID))
+	block := NewBlock(header.HeaderBody, EmptyPayload(flow.ZeroID))
+	return &block
 }
 
 // Block represents a block in collection node cluster consensus. It contains
@@ -34,8 +35,8 @@ type Block struct {
 func NewBlock(
 	headerBody flow.HeaderBody,
 	payload Payload,
-) *Block {
-	return &Block{
+) Block {
+	return Block{
 		Header:  headerBody,
 		Payload: payload,
 	}
@@ -57,6 +58,6 @@ func (b *Block) ToHeader() *flow.Header {
 
 // BlockProposal represents a signed proposed block in collection node cluster consensus.
 type BlockProposal struct {
-	Block           *Block
+	Block           Block
 	ProposerSigData []byte
 }

--- a/model/messages/collection.go
+++ b/model/messages/collection.go
@@ -47,16 +47,14 @@ func NewUntrustedClusterProposal(internal cluster.Block, proposerSig []byte) *Un
 // TODO: Validate the untrusted input before converting to trusted internal representation.
 func (cbp *UntrustedClusterProposal) ToInternal() *cluster.BlockProposal {
 	return &cluster.BlockProposal{
-		Block:           cbp.Block,
+		Block:           cluster.NewBlock(cbp.Block.Header, cbp.Block.Payload),
 		ProposerSigData: cbp.ProposerSigData,
 	}
 }
 
 func UntrustedClusterProposalFromInternal(proposal *cluster.BlockProposal) *UntrustedClusterProposal {
-	return &UntrustedClusterProposal{
-		Block:           proposal.Block,
-		ProposerSigData: proposal.ProposerSigData,
-	}
+	p := UntrustedClusterProposal(*proposal)
+	return &p
 }
 
 // ClusterBlockVote is a vote for a proposed block in collection node cluster

--- a/model/messages/collection.go
+++ b/model/messages/collection.go
@@ -30,44 +30,31 @@ func (ub *UntrustedClusterBlock) ToHeader() *flow.Header {
 	return (*cluster.Block)(ub).ToHeader()
 }
 
-// ToInternal returns the internal representation of the type.
-// TODO: Validate the untrusted input before converting to trusted internal representation.
-func (ub *UntrustedClusterBlock) ToInternal() *cluster.Block {
-	return cluster.NewBlock(ub.Header, ub.Payload)
-}
+// UntrustedClusterProposal represents untrusted signed proposed block in collection node cluster consensus.
+// This type exists only to explicitly differentiate between trusted and untrusted instances of a cluster block proposal.
+// This differentiation is currently largely unused, but eventually untrusted models should use
+// a different type (like this one), until such time as they are fully validated.
+type UntrustedClusterProposal cluster.BlockProposal
 
-// UntrustedClusterBlockFromInternal converts the internal cluster.Block representation
-// to the representation used in untrusted messages.
-func UntrustedClusterBlockFromInternal(clusterBlock *cluster.Block) UntrustedClusterBlock {
-	return UntrustedClusterBlock(*clusterBlock)
-}
-
-// UntrustedClusterProposal is a proposal for a block in collection node cluster
-// consensus. The header contains information about consensus state and the
-// payload contains the proposed collection (may be empty).
-type UntrustedClusterProposal struct {
-	Block           UntrustedClusterBlock
-	ProposerSigData []byte
-}
-
-func NewUntrustedClusterProposal(internal *cluster.Block, proposerSig []byte) *UntrustedClusterProposal {
+func NewUntrustedClusterProposal(internal cluster.Block, proposerSig []byte) *UntrustedClusterProposal {
 	return &UntrustedClusterProposal{
-		Block:           UntrustedClusterBlockFromInternal(internal),
+		Block:           internal,
 		ProposerSigData: proposerSig,
 	}
 }
 
 // ToInternal converts the UntrustedClusterProposal to a trusted internal cluster.BlockProposal.
+// TODO: Validate the untrusted input before converting to trusted internal representation.
 func (cbp *UntrustedClusterProposal) ToInternal() *cluster.BlockProposal {
 	return &cluster.BlockProposal{
-		Block:           cbp.Block.ToInternal(),
+		Block:           cbp.Block,
 		ProposerSigData: cbp.ProposerSigData,
 	}
 }
 
 func UntrustedClusterProposalFromInternal(proposal *cluster.BlockProposal) *UntrustedClusterProposal {
 	return &UntrustedClusterProposal{
-		Block:           UntrustedClusterBlockFromInternal(proposal.Block),
+		Block:           proposal.Block,
 		ProposerSigData: proposal.ProposerSigData,
 	}
 }

--- a/model/messages/convert_test.go
+++ b/model/messages/convert_test.go
@@ -21,7 +21,7 @@ func TestBlockProposal(t *testing.T) {
 
 func TestClusterBlockProposal(t *testing.T) {
 	block := unittest.ClusterBlockFixture()
-	proposal := unittest.ClusterProposalFromBlock(&block)
+	proposal := unittest.ClusterProposalFromBlock(block)
 	proposalMsg := messages.UntrustedClusterProposalFromInternal(proposal)
 	converted := proposalMsg.ToInternal()
 	assert.Equal(t, proposal, converted)
@@ -42,7 +42,7 @@ func TestBlockResponse(t *testing.T) {
 func TestClusterBlockResponse(t *testing.T) {
 	b1 := unittest.ClusterBlockFixture()
 	b2 := unittest.ClusterBlockFixture()
-	expected := []*cluster.BlockProposal{unittest.ClusterProposalFromBlock(&b1), unittest.ClusterProposalFromBlock(&b2)}
+	expected := []*cluster.BlockProposal{unittest.ClusterProposalFromBlock(b1), unittest.ClusterProposalFromBlock(b2)}
 	res := messages.ClusterBlockResponse{
 		Blocks: []messages.UntrustedClusterProposal{
 			*messages.UntrustedClusterProposalFromInternal(expected[0]),

--- a/module/builder/collection/builder_test.go
+++ b/module/builder/collection/builder_test.go
@@ -173,7 +173,7 @@ func (suite *BuilderSuite) TearDownTest() {
 }
 
 func (suite *BuilderSuite) InsertBlock(block model.Block) {
-	err := suite.db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(&block)))
+	err := suite.db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(block)))
 	suite.Assert().NoError(err)
 }
 
@@ -419,13 +419,13 @@ func (suite *BuilderSuite) TestBuildOn_WithForks() {
 	tx3 := mempoolTransactions[2] // in no block
 
 	// build first fork on top of genesis
-	block1 := unittest.ClusterBlockWithParentAndPayload(suite.genesis, suite.Payload(tx1))
+	block1 := unittest.ClusterBlockWithParentAndPayload(*suite.genesis, suite.Payload(tx1))
 
 	// insert block on fork 1
 	suite.InsertBlock(block1)
 
 	// build second fork on top of genesis
-	block2 := unittest.ClusterBlockWithParentAndPayload(suite.genesis, suite.Payload(tx2))
+	block2 := unittest.ClusterBlockWithParentAndPayload(*suite.genesis, suite.Payload(tx2))
 
 	// insert block on fork 2
 	suite.InsertBlock(block2)
@@ -458,13 +458,13 @@ func (suite *BuilderSuite) TestBuildOn_ConflictingFinalizedBlock() {
 
 	// build a block containing tx1 on genesis
 	finalizedPayload := suite.Payload(tx1)
-	finalizedBlock := unittest.ClusterBlockWithParentAndPayload(suite.genesis, finalizedPayload)
+	finalizedBlock := unittest.ClusterBlockWithParentAndPayload(*suite.genesis, finalizedPayload)
 	suite.InsertBlock(finalizedBlock)
 	t.Logf("finalized: height=%d id=%s txs=%s parent_id=%s\t\n", finalizedBlock.Header.Height, finalizedBlock.ID(), finalizedPayload.Collection.Light(), finalizedBlock.Header.ParentID)
 
 	// build a block containing tx2 on the first block
 	unFinalizedPayload := suite.Payload(tx2)
-	unFinalizedBlock := unittest.ClusterBlockWithParentAndPayload(&finalizedBlock, unFinalizedPayload)
+	unFinalizedBlock := unittest.ClusterBlockWithParentAndPayload(finalizedBlock, unFinalizedPayload)
 	suite.InsertBlock(unFinalizedBlock)
 	t.Logf("finalized: height=%d id=%s txs=%s parent_id=%s\t\n", unFinalizedBlock.Header.Height, unFinalizedBlock.ID(), unFinalizedPayload.Collection.Light(), unFinalizedBlock.Header.ParentID)
 
@@ -503,13 +503,13 @@ func (suite *BuilderSuite) TestBuildOn_ConflictingInvalidatedForks() {
 	t.Logf("tx1: %s\ntx2: %s\ntx3: %s", tx1.ID(), tx2.ID(), tx3.ID())
 
 	// build a block containing tx1 on genesis - will be finalized
-	finalizedBlock := unittest.ClusterBlockWithParentAndPayload(suite.genesis, suite.Payload(tx1))
+	finalizedBlock := unittest.ClusterBlockWithParentAndPayload(*suite.genesis, suite.Payload(tx1))
 
 	suite.InsertBlock(finalizedBlock)
 	t.Logf("finalized: id=%s\tparent_id=%s\theight=%d\n", finalizedBlock.ID(), finalizedBlock.Header.ParentID, finalizedBlock.Header.Height)
 
 	// build a block containing tx2 ALSO on genesis - will be invalidated
-	invalidatedBlock := unittest.ClusterBlockWithParentAndPayload(suite.genesis, suite.Payload(tx2))
+	invalidatedBlock := unittest.ClusterBlockWithParentAndPayload(*suite.genesis, suite.Payload(tx2))
 	suite.InsertBlock(invalidatedBlock)
 	t.Logf("invalidated: id=%s\tparent_id=%s\theight=%d\n", invalidatedBlock.ID(), invalidatedBlock.Header.ParentID, invalidatedBlock.Header.Height)
 
@@ -578,7 +578,7 @@ func (suite *BuilderSuite) TestBuildOn_LargeHistory() {
 		}
 
 		// create a block containing the transaction
-		block := unittest.ClusterBlockWithParentAndPayload(&head, suite.Payload(&tx))
+		block := unittest.ClusterBlockWithParentAndPayload(head, suite.Payload(&tx))
 		suite.InsertBlock(block)
 
 		// reset the valid head if we aren't building a conflicting fork
@@ -1075,8 +1075,8 @@ func benchmarkBuildOn(b *testing.B, size int) {
 	// create a block history to test performance against
 	final := suite.genesis
 	for i := 0; i < size; i++ {
-		block := unittest.ClusterBlockWithParent(final)
-		err := suite.db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(&block)))
+		block := unittest.ClusterBlockWithParent(*final)
+		err := suite.db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(block)))
 		require.NoError(b, err)
 
 		// finalize the block 80% of the time, resulting in a fork-rate of 20%

--- a/module/finalizer/collection/finalizer.go
+++ b/module/finalizer/collection/finalizer.go
@@ -126,7 +126,7 @@ func (f *Finalizer) MakeFinal(blockID flow.Identifier) error {
 			}
 
 			block := cluster.NewBlock(step.HeaderBody, payload)
-			f.metrics.ClusterBlockFinalized(block)
+			f.metrics.ClusterBlockFinalized(&block)
 
 			// if the finalized collection is empty, we don't need to include it
 			// in the reference height index or submit it to consensus nodes

--- a/module/finalizer/collection/finalizer_test.go
+++ b/module/finalizer/collection/finalizer_test.go
@@ -25,7 +25,7 @@ func TestFinalizer(t *testing.T) {
 		// reference block on the main consensus chain
 		refBlock := unittest.ClusterBlockFixture()
 		// genesis block for the cluster chain
-		genesis := model.Genesis()
+		genesis := *model.Genesis()
 
 		metrics := metrics.NewNoopCollector()
 
@@ -46,7 +46,7 @@ func TestFinalizer(t *testing.T) {
 
 		// a helper function to bootstrap with the genesis block
 		bootstrap := func() {
-			stateRoot, err := cluster.NewStateRoot(genesis, unittest.QuorumCertificateFixture(), 0)
+			stateRoot, err := cluster.NewStateRoot(&genesis, unittest.QuorumCertificateFixture(), 0)
 			require.NoError(t, err)
 			state, err = cluster.Bootstrap(db, stateRoot)
 			require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestFinalizer(t *testing.T) {
 
 		// a helper function to insert a block
 		insert := func(block model.Block) {
-			err := db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(&block)))
+			err := db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(block)))
 			assert.NoError(t, err)
 		}
 
@@ -201,7 +201,7 @@ func TestFinalizer(t *testing.T) {
 			insert(block1)
 
 			// create a block containing tx2 on top of block1
-			block2 := unittest.ClusterBlockWithParentAndPayload(&block1, model.PayloadFromTransactions(refBlock.ID(), &tx2))
+			block2 := unittest.ClusterBlockWithParentAndPayload(block1, model.PayloadFromTransactions(refBlock.ID(), &tx2))
 			insert(block2)
 
 			// both blocks should be passed to pusher
@@ -254,7 +254,7 @@ func TestFinalizer(t *testing.T) {
 			insert(block1)
 
 			// create a block containing tx2 on top of block1
-			block2 := unittest.ClusterBlockWithParentAndPayload(&block1, model.PayloadFromTransactions(refBlock.ID(), &tx2))
+			block2 := unittest.ClusterBlockWithParentAndPayload(block1, model.PayloadFromTransactions(refBlock.ID(), &tx2))
 			insert(block2)
 
 			// block should be passed to pusher

--- a/state/cluster/badger/mutator.go
+++ b/state/cluster/badger/mutator.go
@@ -104,14 +104,14 @@ func (m *MutableState) Extend(proposal *cluster.BlockProposal) error {
 	defer parentSpan.End()
 
 	span, _ := m.tracer.StartSpanFromContext(ctx, trace.COLClusterStateMutatorExtendCheckHeader)
-	err := m.checkHeaderValidity(candidate)
+	err := m.checkHeaderValidity(&candidate)
 	span.End()
 	if err != nil {
 		return fmt.Errorf("error checking header validity: %w", err)
 	}
 
 	span, _ = m.tracer.StartSpanFromContext(ctx, trace.COLClusterStateMutatorExtendGetExtendCtx)
-	extendCtx, err := m.getExtendCtx(candidate)
+	extendCtx, err := m.getExtendCtx(&candidate)
 	span.End()
 	if err != nil {
 		return fmt.Errorf("error gettting extend context data: %w", err)

--- a/state/cluster/badger/mutator_test.go
+++ b/state/cluster/badger/mutator_test.go
@@ -38,7 +38,7 @@ type MutatorSuite struct {
 	db    *badger.DB
 	dbdir string
 
-	genesis      *model.Block
+	genesis      model.Block
 	chainID      flow.ChainID
 	epochCounter uint64
 
@@ -54,7 +54,7 @@ type MutatorSuite struct {
 func (suite *MutatorSuite) SetupTest() {
 	var err error
 
-	suite.genesis = model.Genesis()
+	suite.genesis = *model.Genesis()
 	suite.chainID = suite.genesis.Header.ChainID
 
 	suite.dbdir = unittest.TempDir(suite.T())
@@ -120,7 +120,7 @@ func (suite *MutatorSuite) SetupTest() {
 		all.EpochCommits,
 	)
 
-	clusterStateRoot, err := NewStateRoot(suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
+	clusterStateRoot, err := NewStateRoot(&suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
 	suite.NoError(err)
 	clusterState, err := Bootstrap(suite.db, clusterStateRoot)
 	suite.Assert().Nil(err)
@@ -158,9 +158,9 @@ func (suite *MutatorSuite) Payload(transactions ...*flow.TransactionBody) model.
 }
 
 // ProposalWithParent returns a valid block proposal with the given parent and the given payload.
-func (suite *MutatorSuite) ProposalWithParentAndPayload(parent *model.Block, payload model.Payload) model.BlockProposal {
+func (suite *MutatorSuite) ProposalWithParentAndPayload(parent model.Block, payload model.Payload) model.BlockProposal {
 	block := unittest.ClusterBlockWithParentAndPayload(parent, payload)
-	return *unittest.ClusterProposalFromBlock(&block)
+	return *unittest.ClusterProposalFromBlock(block)
 }
 
 // Proposal returns a valid cluster block proposal with genesis as parent.
@@ -201,14 +201,14 @@ func TestMutator(t *testing.T) {
 func (suite *MutatorSuite) TestBootstrap_InvalidHeight() {
 	suite.genesis.Header.Height = 1
 
-	_, err := NewStateRoot(suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
+	_, err := NewStateRoot(&suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
 	suite.Assert().Error(err)
 }
 
 func (suite *MutatorSuite) TestBootstrap_InvalidParentHash() {
 	suite.genesis.Header.ParentID = unittest.IdentifierFixture()
 
-	_, err := NewStateRoot(suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
+	_, err := NewStateRoot(&suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
 	suite.Assert().Error(err)
 }
 
@@ -216,7 +216,7 @@ func (suite *MutatorSuite) TestBootstrap_InvalidPayload() {
 	// this is invalid because genesis collection should be empty
 	suite.genesis.Payload = *unittest.ClusterPayloadFixture(2)
 
-	_, err := NewStateRoot(suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
+	_, err := NewStateRoot(&suite.genesis, unittest.QuorumCertificateFixture(), suite.epochCounter)
 	suite.Assert().Error(err)
 }
 
@@ -260,7 +260,7 @@ func (suite *MutatorSuite) TestBootstrap_Successful() {
 
 func (suite *MutatorSuite) TestExtend_WithoutBootstrap() {
 	block := unittest.ClusterBlockWithParent(suite.genesis)
-	err := suite.state.Extend(unittest.ClusterProposalFromBlock(&block))
+	err := suite.state.Extend(unittest.ClusterProposalFromBlock(block))
 	suite.Assert().Error(err)
 }
 
@@ -314,7 +314,7 @@ func (suite *MutatorSuite) TestExtend_OnParentOfFinalized() {
 	suite.Assert().Nil(err)
 
 	// finalize the block
-	suite.FinalizeBlock(*proposal1.Block)
+	suite.FinalizeBlock(proposal1.Block)
 
 	// insert another block on top of genesis
 	// since we have already finalized block 1, this is invalid
@@ -491,14 +491,14 @@ func (suite *MutatorSuite) TestExtend_FinalizedBlockWithDupeTx() {
 	suite.Assert().Nil(err)
 
 	// should be able to finalize block 1
-	suite.FinalizeBlock(*proposal1.Block)
+	suite.FinalizeBlock(proposal1.Block)
 	suite.Assert().Nil(err)
 
 	// create a block building on block1 ALSO containing tx1
 	block2 := unittest.ClusterBlockWithParentAndPayload(proposal1.Block, suite.Payload(&tx1))
 
 	// should be unable to extend block 2, as it contains a dupe transaction
-	err = suite.state.Extend(unittest.ClusterProposalFromBlock(&block2))
+	err = suite.state.Extend(unittest.ClusterProposalFromBlock(block2))
 	suite.Assert().Error(err)
 	suite.Assert().True(state.IsInvalidExtensionError(err))
 }
@@ -531,7 +531,7 @@ func (suite *MutatorSuite) TestExtend_LargeHistory() {
 	refID := final.ID()
 
 	// keep track of the head of the chain
-	head := *suite.genesis
+	head := suite.genesis
 
 	// keep track of transactions in orphaned forks (eligible for inclusion in future block)
 	var invalidatedTransactions []*flow.TransactionBody
@@ -566,8 +566,8 @@ func (suite *MutatorSuite) TestExtend_LargeHistory() {
 		}
 
 		// create a block containing the transaction
-		block := unittest.ClusterBlockWithParentAndPayload(&head, suite.Payload(&tx))
-		err = suite.state.Extend(unittest.ClusterProposalFromBlock(&block))
+		block := unittest.ClusterBlockWithParentAndPayload(head, suite.Payload(&tx))
+		err = suite.state.Extend(unittest.ClusterProposalFromBlock(block))
 		assert.NoError(t, err)
 
 		// reset the valid head if we aren't building a conflicting fork
@@ -588,14 +588,14 @@ func (suite *MutatorSuite) TestExtend_LargeHistory() {
 	t.Log("conflicting: ", len(invalidatedTransactions))
 
 	t.Run("should be able to extend with transactions in orphaned forks", func(t *testing.T) {
-		block := unittest.ClusterBlockWithParentAndPayload(&head, suite.Payload(invalidatedTransactions...))
-		err = suite.state.Extend(unittest.ClusterProposalFromBlock(&block))
+		block := unittest.ClusterBlockWithParentAndPayload(head, suite.Payload(invalidatedTransactions...))
+		err = suite.state.Extend(unittest.ClusterProposalFromBlock(block))
 		assert.NoError(t, err)
 	})
 
 	t.Run("should be unable to extend with conflicting transactions within reference height range of extending block", func(t *testing.T) {
-		block := unittest.ClusterBlockWithParentAndPayload(&head, suite.Payload(oldTransactions...))
-		err = suite.state.Extend(unittest.ClusterProposalFromBlock(&block))
+		block := unittest.ClusterBlockWithParentAndPayload(head, suite.Payload(oldTransactions...))
+		err = suite.state.Extend(unittest.ClusterProposalFromBlock(block))
 		assert.Error(t, err)
 		suite.Assert().True(state.IsInvalidExtensionError(err))
 	})

--- a/state/cluster/badger/state.go
+++ b/state/cluster/badger/state.go
@@ -41,7 +41,7 @@ func Bootstrap(db *badger.DB, stateRoot *StateRoot) (*State, error) {
 	err = operation.RetryOnConflict(state.db.Update, func(tx *badger.Txn) error {
 		chainID := genesis.Header.ChainID
 		// insert the block - by protocol convention, the genesis block does not have a proposer signature, which must be handled by the implementation
-		err := procedure.InsertClusterBlock(&clustermodel.BlockProposal{Block: genesis, ProposerSigData: nil})(tx)
+		err := procedure.InsertClusterBlock(&clustermodel.BlockProposal{Block: *genesis, ProposerSigData: nil})(tx)
 		if err != nil {
 			return fmt.Errorf("could not insert genesis block: %w", err)
 		}

--- a/state/cluster/root_block.go
+++ b/state/cluster/root_block.go
@@ -31,6 +31,7 @@ func CanonicalRootBlock(epoch uint64, participants flow.IdentitySkeletonList) *c
 		ParentVoterSigData: nil,
 		ProposerID:         flow.ZeroID,
 	}
+	block := cluster.NewBlock(headerBody, rootBlockPayload)
 
-	return cluster.NewBlock(headerBody, rootBlockPayload)
+	return &block
 }

--- a/storage/badger/cluster_blocks_test.go
+++ b/storage/badger/cluster_blocks_test.go
@@ -26,7 +26,7 @@ func TestClusterBlocksByHeight(t *testing.T) {
 
 		// store a chain of blocks
 		for _, block := range blocks {
-			err := db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(&block)))
+			err := db.Update(procedure.InsertClusterBlock(unittest.ClusterProposalFromBlock(block)))
 			require.NoError(t, err)
 
 			err = db.Update(procedure.FinalizeClusterBlock(block.ID()))

--- a/storage/badger/procedure/cluster.go
+++ b/storage/badger/procedure/cluster.go
@@ -62,7 +62,7 @@ func RetrieveClusterBlock(blockID flow.Identifier, block *cluster.Block) func(*b
 		}
 
 		// overwrite block
-		*block = *cluster.NewBlock(header.HeaderBody, payload)
+		*block = cluster.NewBlock(header.HeaderBody, payload)
 
 		return nil
 	}

--- a/storage/badger/procedure/cluster_test.go
+++ b/storage/badger/procedure/cluster_test.go
@@ -16,7 +16,7 @@ func TestInsertRetrieveClusterBlock(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		block := unittest.ClusterBlockFixture()
 
-		err := db.Update(InsertClusterBlock(unittest.ClusterProposalFromBlock(&block)))
+		err := db.Update(InsertClusterBlock(unittest.ClusterProposalFromBlock(block)))
 		require.NoError(t, err)
 
 		var retrieved cluster.Block
@@ -31,9 +31,9 @@ func TestFinalizeClusterBlock(t *testing.T) {
 	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
 		parent := unittest.ClusterBlockFixture()
 
-		block := unittest.ClusterBlockWithParent(&parent)
+		block := unittest.ClusterBlockWithParent(parent)
 
-		err := db.Update(InsertClusterBlock(unittest.ClusterProposalFromBlock(&block)))
+		err := db.Update(InsertClusterBlock(unittest.ClusterProposalFromBlock(block)))
 		require.NoError(t, err)
 
 		err = db.Update(operation.IndexClusterBlockHeight(block.Header.ChainID, parent.Header.Height, parent.ID()))

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -285,7 +285,7 @@ func ProposalFromBlock(block *flow.Block) *flow.BlockProposal {
 	}
 }
 
-func ClusterProposalFromBlock(block *cluster.Block) *cluster.BlockProposal {
+func ClusterProposalFromBlock(block cluster.Block) *cluster.BlockProposal {
 	return &cluster.BlockProposal{
 		Block:           block,
 		ProposerSigData: SignatureFixture(),
@@ -636,7 +636,7 @@ func ClusterBlockFixture() cluster.Block {
 	payload := ClusterPayloadFixture(3)
 	headerBody := HeaderBodyFixture()
 
-	return *cluster.NewBlock(*headerBody, *payload)
+	return cluster.NewBlock(*headerBody, *payload)
 }
 
 func ClusterBlockChainFixture(n int) []cluster.Block {
@@ -645,7 +645,7 @@ func ClusterBlockChainFixture(n int) []cluster.Block {
 	parent := ClusterBlockFixture()
 
 	for i := 0; i < n; i++ {
-		block := ClusterBlockWithParent(&parent)
+		block := ClusterBlockWithParent(parent)
 		clusterBlocks = append(clusterBlocks, block)
 		parent = block
 	}
@@ -655,14 +655,14 @@ func ClusterBlockChainFixture(n int) []cluster.Block {
 
 // ClusterBlockWithParent creates a new cluster consensus block that is valid
 // with respect to the given parent block.
-func ClusterBlockWithParent(parent *cluster.Block) cluster.Block {
+func ClusterBlockWithParent(parent cluster.Block) cluster.Block {
 	payload := ClusterPayloadFixture(3)
 	return ClusterBlockWithParentAndPayload(parent, *payload)
 }
 
 // ClusterBlockWithParentAndPayload creates a new cluster consensus block that is valid
 // with respect to the given parent block and with given payload.
-func ClusterBlockWithParentAndPayload(parent *cluster.Block, payload cluster.Payload) cluster.Block {
+func ClusterBlockWithParentAndPayload(parent cluster.Block, payload cluster.Payload) cluster.Block {
 	headerBody := HeaderBodyFixture()
 	headerBody.Height = parent.Header.Height + 1
 	headerBody.View = parent.Header.View + 1
@@ -671,7 +671,7 @@ func ClusterBlockWithParentAndPayload(parent *cluster.Block, payload cluster.Pay
 	headerBody.ParentID = parent.ID()
 	headerBody.ParentView = parent.Header.View
 
-	return *cluster.NewBlock(*headerBody, payload)
+	return cluster.NewBlock(*headerBody, payload)
 }
 
 func WithCollRef(refID flow.Identifier) func(*flow.CollectionGuarantee) {


### PR DESCRIPTION
Related PR: #7334

This PR builds on the work in [#7334](https://github.com/onflow/flow-go/pull/7334) and applies a similar approach as for `UntrustedClusterBlock` to `UntrustedClusterProposal` ([comment](https://github.com/onflow/flow-go/pull/7334#discussion_r2064197494)).

Given the widespread usage of `cluster.BlockProposal` and `UntrustedClusterProposal` these changes are isolated into a separate PR for clarity and ease of review.

## Changes
- Replaced fields for `cluster.BlockProposal` with non-pointers.
- Replaced the `UntrustedClusterProposal` type with:
`type UntrustedClusterProposal cluster.BlockProposal`
- Updated constructor for `cluster.Block` to return non-pointer as it mostly uses in creating `cluster.BlockProposal`.

Additionally:
- Simplified some helper fixture functions.
- Updated relevant code and tests accordingly.

The most significant changes are in the following files:
-  `model/messages/collection.go`
-  `model/cluster/block.go`
