### PR TITLE
[Storage] Support NodeDisallowList for db migration

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1595,9 +1595,13 @@ func (builder *FlowAccessNodeBuilder) InitIDProviders() {
 
 		// The following wrapper allows to disallow-list byzantine nodes via an admin command:
 		// the wrapper overrides the 'Ejected' flag of disallow-listed nodes to true
-		disallowListWrapper, err := cache.NewNodeDisallowListWrapper(idCache, node.DB, func() network.DisallowListNotificationConsumer {
-			return builder.NetworkUnderlay
-		})
+		disallowListWrapper, err := cache.NewNodeDisallowListWrapper(
+			idCache,
+			node.ProtocolDB,
+			func() network.DisallowListNotificationConsumer {
+				return builder.NetworkUnderlay
+			},
+		)
 		if err != nil {
 			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
 		}

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -953,9 +953,13 @@ func (builder *ObserverServiceBuilder) InitIDProviders() {
 
 		// The following wrapper allows to black-list byzantine nodes via an admin command:
 		// the wrapper overrides the 'Ejected' flag of disallow-listed nodes to true
-		builder.IdentityProvider, err = cache.NewNodeDisallowListWrapper(idCache, node.DB, func() network.DisallowListNotificationConsumer {
-			return builder.NetworkUnderlay
-		})
+		builder.IdentityProvider, err = cache.NewNodeDisallowListWrapper(
+			idCache,
+			node.ProtocolDB,
+			func() network.DisallowListNotificationConsumer {
+				return builder.NetworkUnderlay
+			},
+		)
 		if err != nil {
 			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
 		}

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1287,9 +1287,13 @@ func (fnb *FlowNodeBuilder) InitIDProviders() {
 
 		// The following wrapper allows to disallow-list byzantine nodes via an admin command:
 		// the wrapper overrides the 'Ejected' flag of disallow-listed nodes to true
-		disallowListWrapper, err := cache.NewNodeDisallowListWrapper(idCache, node.DB, func() network.DisallowListNotificationConsumer {
-			return fnb.NetworkUnderlay
-		})
+		disallowListWrapper, err := cache.NewNodeDisallowListWrapper(
+			idCache,
+			node.ProtocolDB,
+			func() network.DisallowListNotificationConsumer {
+				return fnb.NetworkUnderlay
+			},
+		)
 		if err != nil {
 			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
 		}

--- a/follower/follower_builder.go
+++ b/follower/follower_builder.go
@@ -440,9 +440,13 @@ func (builder *FollowerServiceBuilder) InitIDProviders() {
 
 		// The following wrapper allows to disallow-list byzantine nodes via an admin command:
 		// the wrapper overrides the 'Ejected' flag of the disallow-listed nodes to true
-		builder.IdentityProvider, err = cache.NewNodeDisallowListWrapper(idCache, node.DB, func() network.DisallowListNotificationConsumer {
-			return builder.NetworkUnderlay
-		})
+		builder.IdentityProvider, err = cache.NewNodeDisallowListWrapper(
+			idCache,
+			node.ProtocolDB,
+			func() network.DisallowListNotificationConsumer {
+				return builder.NetworkUnderlay
+			},
+		)
 		if err != nil {
 			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
 		}

--- a/network/p2p/cache/node_disallow_list_wrapper_test.go
+++ b/network/p2p/cache/node_disallow_list_wrapper_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -17,20 +16,28 @@ import (
 	"github.com/onflow/flow-go/network"
 	"github.com/onflow/flow-go/network/mocknetwork"
 	"github.com/onflow/flow-go/network/p2p/cache"
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation/badgerimpl"
+	"github.com/onflow/flow-go/storage/operation/pebbleimpl"
 	"github.com/onflow/flow-go/utils/unittest"
 )
 
 type NodeDisallowListWrapperTestSuite struct {
 	suite.Suite
-	DB       *badger.DB
+	DB       storage.DB
 	provider *mocks.IdentityProvider
 
 	wrapper        *cache.NodeDisallowListingWrapper
 	updateConsumer *mocknetwork.DisallowListNotificationConsumer
 }
 
+func newNodeDisallowListWrapperTestSuite(db storage.DB) *NodeDisallowListWrapperTestSuite {
+	return &NodeDisallowListWrapperTestSuite{
+		DB: db,
+	}
+}
+
 func (s *NodeDisallowListWrapperTestSuite) SetupTest() {
-	s.DB, _ = unittest.TempBadgerDB(s.T())
 	s.provider = new(mocks.IdentityProvider)
 
 	var err error
@@ -41,8 +48,14 @@ func (s *NodeDisallowListWrapperTestSuite) SetupTest() {
 	require.NoError(s.T(), err)
 }
 
-func TestNodeDisallowListWrapperTestSuite(t *testing.T) {
-	suite.Run(t, new(NodeDisallowListWrapperTestSuite))
+func TestNodeDisallowListWrapperWithBadgerTestSuite(t *testing.T) {
+	bdb, _ := unittest.TempBadgerDB(t)
+	suite.Run(t, newNodeDisallowListWrapperTestSuite(badgerimpl.ToDB(bdb)))
+}
+
+func TestNodeDisallowListWrapperWithPebbleTestSuite(t *testing.T) {
+	pdb, _ := unittest.TempPebbleDB(t)
+	suite.Run(t, newNodeDisallowListWrapperTestSuite(pebbleimpl.ToDB(pdb)))
 }
 
 // TestHonestNode verifies:

--- a/storage/node_disallow_list.go
+++ b/storage/node_disallow_list.go
@@ -1,0 +1,17 @@
+package storage
+
+import "github.com/onflow/flow-go/model/flow"
+
+// NodeDisallowList represents persistent storage for node disallow list.
+type NodeDisallowList interface {
+	// Store writes the given disallowList to the database.
+	// To avoid legacy entries in the database, we purge
+	// the entire database entry if disallowList is empty.
+	// No errors are expected during normal operations.
+	Store(disallowList map[flow.Identifier]struct{}) error
+
+	// Retrieve reads the set of disallowed nodes from the database.
+	// No error is returned if no database entry exists.
+	// No errors are expected during normal operations.
+	Retrieve(disallowList *map[flow.Identifier]struct{}) error
+}

--- a/storage/operation/node_disallow_list.go
+++ b/storage/operation/node_disallow_list.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -15,7 +14,7 @@ import (
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func PurgeNodeDisallowList(w storage.Writer) error {
 	err := RemoveByKey(w, MakePrefix(blockedNodeIDs))
-	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+	if err != nil {
 		return fmt.Errorf("unexpected error while purging disallow list: %w", err)
 	}
 	return nil

--- a/storage/operation/node_disallow_list.go
+++ b/storage/operation/node_disallow_list.go
@@ -1,0 +1,39 @@
+package operation
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+)
+
+// PurgeNodeDisallowList removes the set of disallowed nodes IDs from the database.
+// If no corresponding entry exists, this function is a no-op.
+// No errors are expected during normal operations.
+//
+// TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
+func PurgeNodeDisallowList(w storage.Writer) error {
+	err := RemoveByKey(w, MakePrefix(blockedNodeIDs))
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return fmt.Errorf("unexpected error while purging disallow list: %w", err)
+	}
+	return nil
+}
+
+// PersistNodeDisallowList writes the set of disallowed nodes IDs into the database.
+// If an entry already exists, it is overwritten; otherwise a new entry is created.
+// No errors are expected during normal operations.
+//
+// TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
+func PersistNodeDisallowList(w storage.Writer, disallowList map[flow.Identifier]struct{}) error {
+	return UpsertByKey(w, MakePrefix(blockedNodeIDs), disallowList)
+}
+
+// RetrieveNodeDisallowList reads the set of disallowed node IDs from the database.
+// Returns `storage.ErrNotFound` error in case no respective database entry is present.
+//
+// TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
+func RetrieveNodeDisallowList(r storage.Reader, disallowList *map[flow.Identifier]struct{}) error {
+	return RetrieveByKey(r, MakePrefix(blockedNodeIDs), disallowList)
+}

--- a/storage/operation/node_disallow_list_test.go
+++ b/storage/operation/node_disallow_list_test.go
@@ -1,0 +1,109 @@
+package operation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation"
+	"github.com/onflow/flow-go/storage/operation/dbtest"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// Test_PersistNodeDisallowlist tests the operations:
+//   - PersistNodeDisallowList(disallowList map[flow.Identifier]struct{})
+//   - RetrieveNodeDisallowLis(disallowList *map[flow.Identifier]struct{})
+//   - PurgeNodeDisallowList()
+func Test_PersistNodeDisallowlist(t *testing.T) {
+	t.Run("Retrieving non-existing disallowlist should return 'storage.ErrNotFound'", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			var disallowList map[flow.Identifier]struct{}
+			err := operation.RetrieveNodeDisallowList(db.Reader(), &disallowList)
+			require.ErrorIs(t, err, storage.ErrNotFound)
+		})
+	})
+
+	t.Run("Persisting and read disalowlist", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			disallowList := unittest.IdentifierListFixture(8).Lookup()
+			err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+				return operation.PersistNodeDisallowList(rw.Writer(), disallowList)
+			})
+			require.NoError(t, err)
+
+			var b map[flow.Identifier]struct{}
+			err = operation.RetrieveNodeDisallowList(db.Reader(), &b)
+			require.NoError(t, err)
+			require.Equal(t, disallowList, b)
+		})
+	})
+
+	t.Run("Overwrite disallowlist", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			disallowList1 := unittest.IdentifierListFixture(8).Lookup()
+			err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+				return operation.PersistNodeDisallowList(rw.Writer(), disallowList1)
+			})
+			require.NoError(t, err)
+
+			disallowList2 := unittest.IdentifierListFixture(8).Lookup()
+			err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+				return operation.PersistNodeDisallowList(rw.Writer(), disallowList2)
+			})
+			require.NoError(t, err)
+
+			var b map[flow.Identifier]struct{}
+			err = operation.RetrieveNodeDisallowList(db.Reader(), &b)
+			require.NoError(t, err)
+			require.Equal(t, disallowList2, b)
+		})
+	})
+
+	t.Run("Write & Purge & Write disallowlist", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			disallowList1 := unittest.IdentifierListFixture(8).Lookup()
+			err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+				return operation.PersistNodeDisallowList(rw.Writer(), disallowList1)
+			})
+			require.NoError(t, err)
+
+			err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+				return operation.PurgeNodeDisallowList(rw.Writer())
+			})
+			require.NoError(t, err)
+
+			var b map[flow.Identifier]struct{}
+			err = operation.RetrieveNodeDisallowList(db.Reader(), &b)
+			require.ErrorIs(t, err, storage.ErrNotFound)
+
+			disallowList2 := unittest.IdentifierListFixture(8).Lookup()
+			err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+				return operation.PersistNodeDisallowList(rw.Writer(), disallowList2)
+			})
+			require.NoError(t, err)
+
+			err = operation.RetrieveNodeDisallowList(db.Reader(), &b)
+			require.NoError(t, err)
+			require.Equal(t, disallowList2, b)
+		})
+	})
+
+	t.Run("Purge non-existing disallowlist", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			var b map[flow.Identifier]struct{}
+
+			err := operation.RetrieveNodeDisallowList(db.Reader(), &b)
+			require.ErrorIs(t, err, storage.ErrNotFound)
+
+			err = db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+				return operation.PurgeNodeDisallowList(rw.Writer())
+			})
+			require.NoError(t, err)
+
+			err = operation.RetrieveNodeDisallowList(db.Reader(), &b)
+			require.ErrorIs(t, err, storage.ErrNotFound)
+		})
+	})
+}

--- a/storage/store/node_disallow_list.go
+++ b/storage/store/node_disallow_list.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"errors"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation"
+)
+
+type NodeDisallowList struct {
+	db storage.DB
+}
+
+var _ storage.NodeDisallowList = (*NodeDisallowList)(nil)
+
+func NewNodeDisallowList(db storage.DB) *NodeDisallowList {
+	return &NodeDisallowList{db: db}
+}
+
+// Store writes the given disallowList to the database.
+// To avoid legacy entries in the database, we purge
+// the entire database entry if disallowList is empty.
+// No errors are expected during normal operations.
+func (dl *NodeDisallowList) Store(disallowList map[flow.Identifier]struct{}) error {
+	return dl.db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
+		if len(disallowList) == 0 {
+			return operation.PurgeNodeDisallowList(rw.Writer())
+		}
+		return operation.PersistNodeDisallowList(rw.Writer(), disallowList)
+	})
+}
+
+// Retrieve reads the set of disallowed nodes from the database.
+// No error is returned if no database entry exists.
+// No errors are expected during normal operations.
+func (dl *NodeDisallowList) Retrieve(disallowList *map[flow.Identifier]struct{}) error {
+	err := operation.RetrieveNodeDisallowList(dl.db.Reader(), disallowList)
+	if err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return err
+	}
+	return nil
+}

--- a/storage/store/node_disallow_list_test.go
+++ b/storage/store/node_disallow_list_test.go
@@ -1,0 +1,104 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/model/flow"
+	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation/dbtest"
+	"github.com/onflow/flow-go/storage/store"
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+func TestNodeDisallowedListStoreAndRetrieve(t *testing.T) {
+	t.Run("Retrieving non-existing disallowlist should return no error", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			nodeDisallowListStore := store.NewNodeDisallowList(db)
+
+			var disallowList map[flow.Identifier]struct{}
+			err := nodeDisallowListStore.Retrieve(&disallowList)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(disallowList))
+		})
+	})
+
+	t.Run("Storing and read disallowlist", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			nodeDisallowListStore := store.NewNodeDisallowList(db)
+
+			disallowList := unittest.IdentifierListFixture(8).Lookup()
+			err := nodeDisallowListStore.Store(disallowList)
+			require.NoError(t, err)
+
+			var b map[flow.Identifier]struct{}
+			err = nodeDisallowListStore.Retrieve(&b)
+			require.NoError(t, err)
+			require.Equal(t, disallowList, b)
+		})
+	})
+
+	t.Run("Overwrite disallowlist", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			nodeDisallowListStore := store.NewNodeDisallowList(db)
+
+			disallowList1 := unittest.IdentifierListFixture(8).Lookup()
+			err := nodeDisallowListStore.Store(disallowList1)
+			require.NoError(t, err)
+
+			disallowList2 := unittest.IdentifierListFixture(8).Lookup()
+			err = nodeDisallowListStore.Store(disallowList2)
+			require.NoError(t, err)
+
+			var b map[flow.Identifier]struct{}
+			err = nodeDisallowListStore.Retrieve(&b)
+			require.NoError(t, err)
+			require.Equal(t, disallowList2, b)
+		})
+	})
+
+	t.Run("Write & Purge & Write disallowlist", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			nodeDisallowListStore := store.NewNodeDisallowList(db)
+
+			disallowList1 := unittest.IdentifierListFixture(8).Lookup()
+			err := nodeDisallowListStore.Store(disallowList1)
+			require.NoError(t, err)
+
+			err = nodeDisallowListStore.Store(nil)
+			require.NoError(t, err)
+
+			var b map[flow.Identifier]struct{}
+			err = nodeDisallowListStore.Retrieve(&b)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(b))
+
+			disallowList2 := unittest.IdentifierListFixture(8).Lookup()
+			err = nodeDisallowListStore.Store(disallowList2)
+			require.NoError(t, err)
+
+			err = nodeDisallowListStore.Retrieve(&b)
+			require.NoError(t, err)
+			require.Equal(t, disallowList2, b)
+		})
+	})
+
+	t.Run("Purge non-existing disallowlis", func(t *testing.T) {
+		dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+			nodeDisallowListStore := store.NewNodeDisallowList(db)
+
+			var b map[flow.Identifier]struct{}
+			err := nodeDisallowListStore.Retrieve(&b)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(b))
+
+			err = nodeDisallowListStore.Store(nil)
+			require.NoError(t, err)
+
+			err = nodeDisallowListStore.Retrieve(&b)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(b))
+		})
+	})
+}


### PR DESCRIPTION
Updates #7242 (completes subtask "Libp2p Blocklist")

Currently, `NodeDisallowListWrapper` receives BadgerDB handle and we need to transition it to use `storage.DB` when we migrate backend database from BadgerDB to Pebble.

This PR supports disallow list.  Changes include:
- Add storage operations in storage/operation/node_disallow_test.go
- Add storage store in storage/store/node_disallow_list.go
- Add storage interface in storage/node_disallow_list.go

This PR also modifies `NodeDisallowListWrapper` to:
- Receive `storage.DB` as input parameter
- Use `storage.NodeDisallowList` to retrieve and store disallow list

### Caveats

The word "blocklist" and "disallowlist" are used interchangeably in the existing code, file name, error messages, etc.  We briefly discussed replacing both with "denylist" but there were too many occurrences using that approach.

I will open separate PR to rename "blocklist" with "disallowlist" since that is more practical.