### PR TITLE
Refactor to rename blocklist to disallowlist for consistency

### DIFF
--- a/cmd/access/node_builder/access_node_builder.go
+++ b/cmd/access/node_builder/access_node_builder.go
@@ -1603,7 +1603,7 @@ func (builder *FlowAccessNodeBuilder) InitIDProviders() {
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
+			return fmt.Errorf("could not initialize NodeDisallowListWrapper: %w", err)
 		}
 		builder.IdentityProvider = disallowListWrapper
 

--- a/cmd/observer/node_builder/observer_builder.go
+++ b/cmd/observer/node_builder/observer_builder.go
@@ -961,7 +961,7 @@ func (builder *ObserverServiceBuilder) InitIDProviders() {
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
+			return fmt.Errorf("could not initialize NodeDisallowListWrapper: %w", err)
 		}
 
 		// use the default identifier provider

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -1295,7 +1295,7 @@ func (fnb *FlowNodeBuilder) InitIDProviders() {
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
+			return fmt.Errorf("could not initialize NodeDisallowListWrapper: %w", err)
 		}
 		node.IdentityProvider = disallowListWrapper
 

--- a/follower/follower_builder.go
+++ b/follower/follower_builder.go
@@ -448,7 +448,7 @@ func (builder *FollowerServiceBuilder) InitIDProviders() {
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("could not initialize NodeBlockListWrapper: %w", err)
+			return fmt.Errorf("could not initialize NodeDisallowListWrapper: %w", err)
 		}
 
 		// use the default identifier provider

--- a/storage/badger/operation/bft.go
+++ b/storage/badger/operation/bft.go
@@ -16,7 +16,7 @@ import (
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func PurgeBlocklist() func(*badger.Txn) error {
 	return func(tx *badger.Txn) error {
-		err := remove(makePrefix(blockedNodeIDs))(tx)
+		err := remove(makePrefix(disallowedNodeIDs))(tx)
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {
 			return fmt.Errorf("enexpected error while purging blocklist: %w", err)
 		}
@@ -30,7 +30,7 @@ func PurgeBlocklist() func(*badger.Txn) error {
 //
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func PersistBlocklist(blocklist map[flow.Identifier]struct{}) func(*badger.Txn) error {
-	return upsert(makePrefix(blockedNodeIDs), blocklist)
+	return upsert(makePrefix(disallowedNodeIDs), blocklist)
 }
 
 // RetrieveBlocklist reads the set of blocked node IDs from the data base.
@@ -38,5 +38,5 @@ func PersistBlocklist(blocklist map[flow.Identifier]struct{}) func(*badger.Txn) 
 //
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func RetrieveBlocklist(blocklist *map[flow.Identifier]struct{}) func(*badger.Txn) error {
-	return retrieve(makePrefix(blockedNodeIDs), blocklist)
+	return retrieve(makePrefix(disallowedNodeIDs), blocklist)
 }

--- a/storage/badger/operation/prefix.go
+++ b/storage/badger/operation/prefix.go
@@ -105,7 +105,7 @@ const (
 	codeIndexResultApprovalByChunk         = 204
 
 	// TEMPORARY codes
-	blockedNodeIDs = 205 // manual override for adding node IDs to list of ejected nodes, applies to networking layer only
+	disallowedNodeIDs = 205 // manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 
 	// internal failure information that should be preserved across restarts
 	codeExecutionFork                   = 254

--- a/storage/operation/node_disallow_list.go
+++ b/storage/operation/node_disallow_list.go
@@ -14,7 +14,7 @@ import (
 //
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func PurgeNodeDisallowList(w storage.Writer) error {
-	err := RemoveByKey(w, MakePrefix(blockedNodeIDs))
+	err := RemoveByKey(w, MakePrefix(disallowedNodeIDs))
 	if err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return fmt.Errorf("unexpected error while purging disallow list: %w", err)
 	}
@@ -27,7 +27,7 @@ func PurgeNodeDisallowList(w storage.Writer) error {
 //
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func PersistNodeDisallowList(w storage.Writer, disallowList map[flow.Identifier]struct{}) error {
-	return UpsertByKey(w, MakePrefix(blockedNodeIDs), disallowList)
+	return UpsertByKey(w, MakePrefix(disallowedNodeIDs), disallowList)
 }
 
 // RetrieveNodeDisallowList reads the set of disallowed node IDs from the database.
@@ -35,5 +35,5 @@ func PersistNodeDisallowList(w storage.Writer, disallowList map[flow.Identifier]
 //
 // TODO: TEMPORARY manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 func RetrieveNodeDisallowList(r storage.Reader, disallowList *map[flow.Identifier]struct{}) error {
-	return RetrieveByKey(r, MakePrefix(blockedNodeIDs), disallowList)
+	return RetrieveByKey(r, MakePrefix(disallowedNodeIDs), disallowList)
 }

--- a/storage/operation/prefix.go
+++ b/storage/operation/prefix.go
@@ -108,7 +108,7 @@ const (
 	codeIndexResultApprovalByChunk         = 204
 
 	// TEMPORARY codes
-	blockedNodeIDs = 205 // manual override for adding node IDs to list of ejected nodes, applies to networking layer only
+	disallowedNodeIDs = 205 // manual override for adding node IDs to list of ejected nodes, applies to networking layer only
 
 	// internal failure information that should be preserved across restarts
 	codeExecutionFork                   = 254


### PR DESCRIPTION
This addresses old tech debt encountered while working on PR #7361.  For consistency, this PR renames "blocklist" to "disallowlist" and also renames db prefix code `blockedNodeIDs` to `disallowedNodeIDs`.

For more info, see "Caveats" at PR #7361.