### PR TITLE
Cache ID on hash strategy

### DIFF
--- a/model/flow/collection.go
+++ b/model/flow/collection.go
@@ -61,14 +61,22 @@ func (c Collection) Fingerprint() []byte {
 //structwrite:immutable - mutations allowed only within the constructor
 type LightCollection struct {
 	Transactions []Identifier
+	idCache
 }
 
 func NewLightCollection(txIDs []Identifier) LightCollection {
-	return LightCollection{Transactions: txIDs}
+	return LightCollection{
+		Transactions: txIDs,
+		idCache:      newIDCache(),
+	}
+}
+
+func (lc LightCollection) uncachedID() Identifier {
+	return MakeID(lc)
 }
 
 func (lc LightCollection) ID() Identifier {
-	return MakeID(lc)
+	return lc.idCache.getID(lc.uncachedID)
 }
 
 func (lc LightCollection) Checksum() Identifier {

--- a/model/flow/collection.go
+++ b/model/flow/collection.go
@@ -1,6 +1,10 @@
 package flow
 
-import "github.com/onflow/flow-go/model/fingerprint"
+import (
+	"github.com/fxamacker/cbor/v2"
+
+	"github.com/onflow/flow-go/model/fingerprint"
+)
 
 // Collection is set of transactions.
 type Collection struct {
@@ -81,6 +85,18 @@ func (lc LightCollection) UncachedID() Identifier {
 // or returns a cached version if the ID has ever been computed before.
 func (lc LightCollection) ID() Identifier {
 	return lc.cachedID.getID()
+}
+
+// UnmarshalCBOR populates the ID cache field (otherwise uses default CBOR unmarshaling behaviour).
+func (lc *LightCollection) UnmarshalCBOR(bytes []byte) error {
+	type alias LightCollection
+	lca := (*alias)(lc)
+	err := cbor.Unmarshal(bytes, &lca)
+	if err != nil {
+		return err
+	}
+	lc.cachedID = newIDCache(lc.UncachedID)
+	return nil
 }
 
 func (lc LightCollection) Checksum() Identifier {

--- a/model/flow/collection.go
+++ b/model/flow/collection.go
@@ -61,22 +61,26 @@ func (c Collection) Fingerprint() []byte {
 //structwrite:immutable - mutations allowed only within the constructor
 type LightCollection struct {
 	Transactions []Identifier
-	idCache
+	cachedID     idCache
 }
 
 func NewLightCollection(txIDs []Identifier) LightCollection {
-	return LightCollection{
+	lc := LightCollection{
 		Transactions: txIDs,
-		idCache:      newIDCache(),
 	}
+	lc.cachedID = newIDCache(lc.UncachedID)
+	return lc
 }
 
-func (lc LightCollection) uncachedID() Identifier {
+// UncachedID computes and returns the canonical ID of the LightCollection, bypassing the ID cache.
+func (lc LightCollection) UncachedID() Identifier {
 	return MakeID(lc)
 }
 
+// ID computes and returns the canonical ID of the LightCollection,
+// or returns a cached version if the ID has ever been computed before.
 func (lc LightCollection) ID() Identifier {
-	return lc.idCache.getID(lc.uncachedID)
+	return lc.cachedID.getID()
 }
 
 func (lc LightCollection) Checksum() Identifier {

--- a/model/flow/collection_test.go
+++ b/model/flow/collection_test.go
@@ -21,3 +21,29 @@ func TestLightCollectionFingerprint(t *testing.T) {
 	assert.Equal(t, colID, decodedID)
 	assert.Equal(t, col.Light(), decoded)
 }
+
+// TestLightCollectionID is a basic check that the ID function is deterministic.
+func TestLightCollectionID(t *testing.T) {
+	col := unittest.CollectionFixture(2).Light()
+	uncached := col.UncachedID()
+	id := col.ID()
+	id2 := col.ID()
+	assert.Equal(t, uncached, id)
+	assert.Equal(t, id, id2)
+}
+
+// BenchmarkLightCollectionID compares the cached and uncached ID functions.
+func BenchmarkLightCollectionID(b *testing.B) {
+	col := unittest.CollectionFixture(20).Light()
+
+	b.Run("cached", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = col.ID()
+		}
+	})
+	b.Run("uncached", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = col.UncachedID()
+		}
+	})
+}

--- a/model/flow/collection_test.go
+++ b/model/flow/collection_test.go
@@ -3,7 +3,9 @@ package flow_test
 import (
 	"testing"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/flow-go/model/encoding/rlp"
 	"github.com/onflow/flow-go/model/fingerprint"
@@ -46,4 +48,19 @@ func BenchmarkLightCollectionID(b *testing.B) {
 			_ = col.UncachedID()
 		}
 	})
+}
+
+// TestLightCollectionCBOR tests that unmarshalled instances have a instantiated cache field.
+func TestLightCollectionCBOR(t *testing.T) {
+	col := unittest.CollectionFixture(2).Light()
+	colID := col.ID()
+	encoded, err := cbor.Marshal(col)
+	require.NoError(t, err)
+
+	var decoded flow.LightCollection
+	err = cbor.Unmarshal(encoded, &decoded)
+	require.NoError(t, err)
+
+	decodedID := decoded.ID()
+	assert.Equal(t, colID, decodedID)
 }

--- a/model/flow/entity.go
+++ b/model/flow/entity.go
@@ -57,23 +57,47 @@ func Deduplicate[T IDEntity](entities []T) []T {
 	return result
 }
 
-// TODO docs
+// idCache is a utility for caching the ID (canonical hash) of a Flow entity.
+// The entity should define an UncachedID method, which computes the ID without caching.
+// Upon construction, the entity should construct a cache using newIDCache,
+// passing in the UncachedID method as the single parameter.
+// Entities should use a literal (not pointer) field for the cache, as the
+// cache already includes only reference-typed fields and can be safely copied.
+//
+// idCache is safe for concurrent use by multiple goroutines.
+//
+// CAUTION: idCache is a write-once, never-invalidated cache for a derived field.
+// This means that instances of entities that use idCache must be immutable after construction.
+// These entities should opt-in to the structwrite linter to enforce most classes of immutability.
 type idCache struct {
-	id *atomic.Pointer[Identifier]
+	id        *atomic.Pointer[Identifier]
+	computeID func() Identifier
 }
 
-func newIDCache() idCache {
+// newIDCache returns a new idCache.
+// Caller is responsible for ensure that computeID always returns the same ID
+// (should be a deterministic hashing function over an immutable data structure).
+func newIDCache(computeID func() Identifier) idCache {
 	return idCache{
-		id: new(atomic.Pointer[Identifier]),
+		id:        new(atomic.Pointer[Identifier]),
+		computeID: computeID,
 	}
 }
 
-func (cache *idCache) EncodeRLP(w io.Writer) error {
+// EncodeRLP overrides RLP encoding when this type is encoded.
+// This implementation results in an empty encoding of 0 bytes.
+// This is useful when the cache is included as a field of a struct,
+// so that any cached value does not impact the encoding of the struct.
+func (cache idCache) EncodeRLP(w io.Writer) error {
 	return nil
 }
 
-// getID ...
-func (cache *idCache) getID(computeID func() Identifier) Identifier {
+// getID computes the ID or returns a cached version if the ID has ever been computed before.
+// In the typical path where the ID is cached, we simply read and return the atomic.
+// If the ID is not yet cached, we compute it, then attempt to store it to the atomic.
+// The ID is stored using CAS so it is stored only once.
+// This function may panic if two goroutines compute inconsistent IDs.
+func (cache idCache) getID() Identifier {
 	// if ID is already computed and cached, return it
 	v := cache.id.Load()
 	if v != nil {
@@ -81,7 +105,7 @@ func (cache *idCache) getID(computeID func() Identifier) Identifier {
 	}
 
 	// compute the ID and attempt to store it
-	computedID := computeID()
+	computedID := cache.computeID()
 	if cache.id.CompareAndSwap(nil, &computedID) {
 		// we won the race and stored the value
 		return computedID

--- a/model/flow/entity.go
+++ b/model/flow/entity.go
@@ -75,7 +75,7 @@ type idCache struct {
 }
 
 // newIDCache returns a new idCache.
-// Caller is responsible for ensure that computeID always returns the same ID
+// Caller is responsible for ensuring that computeID always returns the same ID
 // (should be a deterministic hashing function over an immutable data structure).
 func newIDCache(computeID func() Identifier) idCache {
 	return idCache{


### PR DESCRIPTION
This PR implements a cache for entity IDs, using a lazy strategy of caching the ID when it is first requested, and using an atomic so the entity remains safe for concurrent use.

This approach has the outstanding problem that entities created from unmarshalling (from the database or network) do not generally use the constructor and consequently will not populate the `idCache` field 🤔. In this PR I have addressed this by over-riding un-marshalling to instantiate the cache field. Alternatively we could:
- change unmarshal points to use the constructor (this would be another per-type task to do as part of https://github.com/onflow/flow-go/issues/7269
- make `ID` safe if `idCache` is not initialized (just re-compute the hash every time, like it currently works on `master`)

---

There is another approach in https://github.com/onflow/flow-go/pull/7370, which computes the hash at construction. It has a similar problem that it requires the constructor be called.