### PR TITLE
Reduce state extraction w/o migration by ~29 minutes (~2.5x speedup)

### DIFF
--- a/cmd/util/cmd/atree_inlined_status/cmd.go
+++ b/cmd/util/cmd/atree_inlined_status/cmd.go
@@ -115,7 +115,7 @@ func run(*cobra.Command, []string) {
 		log.Info().Msgf("Reading trie %s", flagStateCommitment)
 
 		stateCommitment := util.ParseStateCommitment(flagStateCommitment)
-		payloads, err = util.ReadTrie(flagState, stateCommitment)
+		payloads, err = util.ReadTrieForPayloads(flagState, stateCommitment)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to read state")
 		}

--- a/cmd/util/cmd/check-storage/cmd.go
+++ b/cmd/util/cmd/check-storage/cmd.go
@@ -156,7 +156,7 @@ func run(*cobra.Command, []string) {
 		log.Info().Msgf("Reading trie %s", flagStateCommitment)
 
 		stateCommitment := util.ParseStateCommitment(flagStateCommitment)
-		payloads, err = util.ReadTrie(flagState, stateCommitment)
+		payloads, err = util.ReadTrieForPayloads(flagState, stateCommitment)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to read state")
 		}

--- a/cmd/util/cmd/diff-states/cmd.go
+++ b/cmd/util/cmd/diff-states/cmd.go
@@ -273,7 +273,7 @@ func loadPayloads() (payloads1, payloads2 []*ledger.Payload) {
 			log.Info().Msg("Reading first trie")
 
 			stateCommitment := util.ParseStateCommitment(flagStateCommitment1)
-			payloads1, err = util.ReadTrie(flagState1, stateCommitment)
+			payloads1, err = util.ReadTrieForPayloads(flagState1, stateCommitment)
 		}
 		return
 	})
@@ -285,7 +285,7 @@ func loadPayloads() (payloads1, payloads2 []*ledger.Payload) {
 			log.Info().Msg("Reading second trie")
 
 			stateCommitment := util.ParseStateCommitment(flagStateCommitment2)
-			payloads2, err = util.ReadTrie(flagState2, stateCommitment)
+			payloads2, err = util.ReadTrieForPayloads(flagState2, stateCommitment)
 		}
 		return
 	})

--- a/cmd/util/cmd/execution-state-extract/execution_state_extract.go
+++ b/cmd/util/cmd/execution-state-extract/execution_state_extract.go
@@ -67,7 +67,7 @@ func newExecutionStateExtractor(
 }
 
 func (e *executionStateExtractor) extract() (bool, []*ledger.Payload, error) {
-	payloads, err := util.ReadTrie(e.dir, e.stateCommitment)
+	payloads, err := util.ReadTrieForPayloads(e.dir, e.stateCommitment)
 	if err != nil {
 		return false, nil, err
 	}

--- a/cmd/util/cmd/export-evm-state/cmd.go
+++ b/cmd/util/cmd/export-evm-state/cmd.go
@@ -82,7 +82,7 @@ func ExportEVMState(
 	storageRoot := evm.StorageAccountAddress(chainID)
 	rootOwner := string(storageRoot.Bytes())
 
-	payloads, err := util.ReadTrie(ledgerPath, util.ParseStateCommitment(targetState))
+	payloads, err := util.ReadTrieForPayloads(ledgerPath, util.ParseStateCommitment(targetState))
 	if err != nil {
 		return err
 	}

--- a/cmd/util/cmd/generate-authorization-fixes/cmd.go
+++ b/cmd/util/cmd/generate-authorization-fixes/cmd.go
@@ -196,7 +196,7 @@ func loadRegistersByAccount() *registers.ByAccount {
 		log.Info().Msgf("Reading trie %s", flagStateCommitment)
 
 		stateCommitment := util.ParseStateCommitment(flagStateCommitment)
-		payloads, err = util.ReadTrie(flagState, stateCommitment)
+		payloads, err = util.ReadTrieForPayloads(flagState, stateCommitment)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to read state")
 		}

--- a/cmd/util/cmd/run-script/cmd.go
+++ b/cmd/util/cmd/run-script/cmd.go
@@ -121,7 +121,7 @@ func run(*cobra.Command, []string) {
 		log.Info().Msg("reading trie")
 
 		stateCommitment := util.ParseStateCommitment(flagStateCommitment)
-		payloads, err = util.ReadTrie(flagState, stateCommitment)
+		payloads, err = util.ReadTrieForPayloads(flagState, stateCommitment)
 	}
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to read payloads")

--- a/cmd/util/ledger/util/state.go
+++ b/cmd/util/ledger/util/state.go
@@ -17,7 +17,7 @@ import (
 	"github.com/onflow/flow-go/module/metrics"
 )
 
-func ReadTrie(dir string, targetHash flow.StateCommitment) ([]*ledger.Payload, error) {
+func ReadTrie(dir string, targetHash flow.StateCommitment) (*mtrie.MTrie, error) {
 	log.Info().Msg("init WAL")
 
 	diskWal, err := wal.NewDiskWAL(
@@ -93,6 +93,14 @@ func ReadTrie(dir string, targetHash flow.StateCommitment) ([]*ledger.Payload, e
 		return nil, fmt.Errorf("cannot get trie at the given state commitment: %w", err)
 	}
 
+	return trie, nil
+}
+
+func ReadTrieForPayloads(dir string, targetHash flow.StateCommitment) ([]*ledger.Payload, error) {
+	trie, err := ReadTrie(dir, targetHash)
+	if err != nil {
+		return nil, err
+	}
 	return trie.AllPayloads(), nil
 }
 


### PR DESCRIPTION
Closes #7368

This PR can reduce state extraction duration by ~29 minutes:
- before: about ~49 minutes
- after:  about ~20 minutes

When state is extracted without migration, trie was needlessly rebuilt, which took about 29 minutes.

This PR avoids rebuilding trie (for this case) by creating checkpoint file from loaded trie.

Thanks @zhangchiqing for identifying this and opening issue #7368. :+1: 