### PR TITLE
[Storage] Optimize memory cache key creation and key format for some stores

### DIFF
--- a/storage/store/inmemory/unsynchronized/transaction_result_error_messages.go
+++ b/storage/store/inmemory/unsynchronized/transaction_result_error_messages.go
@@ -14,18 +14,18 @@ type TransactionResultErrorMessages struct {
 	// before any future reads. However, we're keeping it temporarily during active development
 	// for safety and debugging purposes. It will be removed once the implementation is finalized.
 	lock       sync.RWMutex
-	store      map[string]*flow.TransactionResultErrorMessage
-	indexStore map[string]*flow.TransactionResultErrorMessage
-	blockStore map[string][]flow.TransactionResultErrorMessage
+	store      map[store.TwoIdentifier]*flow.TransactionResultErrorMessage       // Key: blockID + txID
+	indexStore map[store.IdentifierAndUint32]*flow.TransactionResultErrorMessage // Key: blockID + txIndex
+	blockStore map[flow.Identifier][]flow.TransactionResultErrorMessage          // Key: blockID
 }
 
 var _ storage.TransactionResultErrorMessages = (*TransactionResultErrorMessages)(nil)
 
 func NewTransactionResultErrorMessages() *TransactionResultErrorMessages {
 	return &TransactionResultErrorMessages{
-		store:      make(map[string]*flow.TransactionResultErrorMessage),
-		indexStore: make(map[string]*flow.TransactionResultErrorMessage),
-		blockStore: make(map[string][]flow.TransactionResultErrorMessage),
+		store:      make(map[store.TwoIdentifier]*flow.TransactionResultErrorMessage),
+		indexStore: make(map[store.IdentifierAndUint32]*flow.TransactionResultErrorMessage),
+		blockStore: make(map[flow.Identifier][]flow.TransactionResultErrorMessage),
 	}
 }
 
@@ -91,11 +91,10 @@ func (t *TransactionResultErrorMessages) ByBlockIDTransactionIndex(
 // Expected errors during normal operation:
 //   - `storage.ErrNotFound` if no block was found.
 func (t *TransactionResultErrorMessages) ByBlockID(id flow.Identifier) ([]flow.TransactionResultErrorMessage, error) {
-	key := store.KeyFromBlockID(id)
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 
-	val, ok := t.blockStore[key]
+	val, ok := t.blockStore[id]
 	if !ok {
 		return nil, storage.ErrNotFound
 	}
@@ -110,11 +109,10 @@ func (t *TransactionResultErrorMessages) Store(
 	blockID flow.Identifier,
 	transactionResultErrorMessages []flow.TransactionResultErrorMessage,
 ) error {
-	key := store.KeyFromBlockID(blockID)
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	t.blockStore[key] = transactionResultErrorMessages
+	t.blockStore[blockID] = transactionResultErrorMessages
 	for i, txResult := range transactionResultErrorMessages {
 		txIDKey := store.KeyFromBlockIDTransactionID(blockID, txResult.TransactionID)
 		txIndexKey := store.KeyFromBlockIDIndex(blockID, uint32(i))

--- a/storage/store/transaction_results.go
+++ b/storage/store/transaction_results.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 
 	"github.com/onflow/flow-go/model/flow"
@@ -14,129 +13,89 @@ import (
 
 var _ storage.TransactionResults = (*TransactionResults)(nil)
 
+type TwoIdentifier [flow.IdentifierLen * 2]byte
+type IdentifierAndUint32 [flow.IdentifierLen + 4]byte
+
 type TransactionResults struct {
 	db         storage.DB
-	cache      *Cache[string, flow.TransactionResult]
-	indexCache *Cache[string, flow.TransactionResult]
-	blockCache *Cache[string, []flow.TransactionResult]
+	cache      *Cache[TwoIdentifier, flow.TransactionResult]       // Key: blockID + txID
+	indexCache *Cache[IdentifierAndUint32, flow.TransactionResult] // Key: blockID + txIndex
+	blockCache *Cache[flow.Identifier, []flow.TransactionResult]   // Key: blockID
 }
 
-func KeyFromBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) string {
-	return fmt.Sprintf("%x%x", blockID, txID)
+func KeyFromBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) TwoIdentifier {
+	var key TwoIdentifier
+	n := copy(key[:], blockID[:])
+	copy(key[n:], txID[:])
+	return key
 }
 
-func KeyFromBlockIDIndex(blockID flow.Identifier, txIndex uint32) string {
-	idData := make([]byte, 4) //uint32 fits into 4 bytes
-	binary.BigEndian.PutUint32(idData, txIndex)
-	return fmt.Sprintf("%x%x", blockID, idData)
+func KeyFromBlockIDIndex(blockID flow.Identifier, txIndex uint32) IdentifierAndUint32 {
+	var key IdentifierAndUint32
+	n := copy(key[:], blockID[:])
+	binary.BigEndian.PutUint32(key[n:], txIndex)
+	return key
 }
 
-func KeyFromBlockID(blockID flow.Identifier) string {
-	return blockID.String()
+func KeyToBlockIDTransactionID(key TwoIdentifier) (flow.Identifier, flow.Identifier) {
+	blockID := flow.Identifier(key[:flow.IdentifierLen])
+	transactionID := flow.Identifier(key[flow.IdentifierLen:])
+	return blockID, transactionID
 }
 
-func KeyToBlockIDTransactionID(key string) (flow.Identifier, flow.Identifier, error) {
-	blockIDStr := key[:64]
-	txIDStr := key[64:]
-	blockID, err := flow.HexStringToIdentifier(blockIDStr)
-	if err != nil {
-		return flow.ZeroID, flow.ZeroID, fmt.Errorf("could not get block ID: %w", err)
-	}
-
-	txID, err := flow.HexStringToIdentifier(txIDStr)
-	if err != nil {
-		return flow.ZeroID, flow.ZeroID, fmt.Errorf("could not get transaction id: %w", err)
-	}
-
-	return blockID, txID, nil
-}
-
-func KeyToBlockIDIndex(key string) (flow.Identifier, uint32, error) {
-	blockIDStr := key[:64]
-	indexStr := key[64:]
-	blockID, err := flow.HexStringToIdentifier(blockIDStr)
-	if err != nil {
-		return flow.ZeroID, 0, fmt.Errorf("could not get block ID: %w", err)
-	}
-
-	txIndexBytes, err := hex.DecodeString(indexStr)
-	if err != nil {
-		return flow.ZeroID, 0, fmt.Errorf("could not get transaction index: %w", err)
-	}
-	if len(txIndexBytes) != 4 {
-		return flow.ZeroID, 0, fmt.Errorf("could not get transaction index - invalid length: %d", len(txIndexBytes))
-	}
-
-	txIndex := binary.BigEndian.Uint32(txIndexBytes)
-
-	return blockID, txIndex, nil
-}
-
-func KeyToBlockID(key string) (flow.Identifier, error) {
-
-	blockID, err := flow.HexStringToIdentifier(key)
-	if err != nil {
-		return flow.ZeroID, fmt.Errorf("could not get block ID: %w", err)
-	}
-
-	return blockID, err
+func KeyToBlockIDIndex(key IdentifierAndUint32) (flow.Identifier, uint32) {
+	blockID := flow.Identifier(key[:flow.IdentifierLen])
+	txIndex := binary.BigEndian.Uint32(key[flow.IdentifierLen:])
+	return blockID, txIndex
 }
 
 func NewTransactionResults(collector module.CacheMetrics, db storage.DB, transactionResultsCacheSize uint) *TransactionResults {
-	retrieve := func(r storage.Reader, key string) (flow.TransactionResult, error) {
-		var txResult flow.TransactionResult
-		blockID, txID, err := KeyToBlockIDTransactionID(key)
-		if err != nil {
-			return flow.TransactionResult{}, fmt.Errorf("could not convert key: %w", err)
-		}
+	retrieve := func(r storage.Reader, key TwoIdentifier) (flow.TransactionResult, error) {
+		blockID, txID := KeyToBlockIDTransactionID(key)
 
-		err = operation.RetrieveTransactionResult(r, blockID, txID, &txResult)
+		var txResult flow.TransactionResult
+		err := operation.RetrieveTransactionResult(r, blockID, txID, &txResult)
 		if err != nil {
 			return flow.TransactionResult{}, err
 		}
 		return txResult, nil
 	}
-	retrieveIndex := func(r storage.Reader, key string) (flow.TransactionResult, error) {
-		var txResult flow.TransactionResult
-		blockID, txIndex, err := KeyToBlockIDIndex(key)
-		if err != nil {
-			return flow.TransactionResult{}, fmt.Errorf("could not convert index key: %w", err)
-		}
 
-		err = operation.RetrieveTransactionResultByIndex(r, blockID, txIndex, &txResult)
+	retrieveIndex := func(r storage.Reader, key IdentifierAndUint32) (flow.TransactionResult, error) {
+		blockID, txIndex := KeyToBlockIDIndex(key)
+
+		var txResult flow.TransactionResult
+		err := operation.RetrieveTransactionResultByIndex(r, blockID, txIndex, &txResult)
 		if err != nil {
 			return flow.TransactionResult{}, err
 		}
 		return txResult, nil
 	}
-	retrieveForBlock := func(r storage.Reader, key string) ([]flow.TransactionResult, error) {
+
+	retrieveForBlock := func(r storage.Reader, blockID flow.Identifier) ([]flow.TransactionResult, error) {
 		var txResults []flow.TransactionResult
-		blockID, err := KeyToBlockID(key)
-		if err != nil {
-			return nil, fmt.Errorf("could not convert index key: %w", err)
-		}
-
-		err = operation.LookupTransactionResultsByBlockIDUsingIndex(r, blockID, &txResults)
+		err := operation.LookupTransactionResultsByBlockIDUsingIndex(r, blockID, &txResults)
 		if err != nil {
 			return nil, err
 		}
 		return txResults, nil
 	}
+
 	return &TransactionResults{
 		db: db,
 		cache: newCache(collector, metrics.ResourceTransactionResults,
-			withLimit[string, flow.TransactionResult](transactionResultsCacheSize),
-			withStore(noopStore[string, flow.TransactionResult]),
+			withLimit[TwoIdentifier, flow.TransactionResult](transactionResultsCacheSize),
+			withStore(noopStore[TwoIdentifier, flow.TransactionResult]),
 			withRetrieve(retrieve),
 		),
 		indexCache: newCache(collector, metrics.ResourceTransactionResultIndices,
-			withLimit[string, flow.TransactionResult](transactionResultsCacheSize),
-			withStore(noopStore[string, flow.TransactionResult]),
+			withLimit[IdentifierAndUint32, flow.TransactionResult](transactionResultsCacheSize),
+			withStore(noopStore[IdentifierAndUint32, flow.TransactionResult]),
 			withRetrieve(retrieveIndex),
 		),
 		blockCache: newCache(collector, metrics.ResourceTransactionResultIndices,
-			withLimit[string, []flow.TransactionResult](transactionResultsCacheSize),
-			withStore(noopStore[string, []flow.TransactionResult]),
+			withLimit[flow.Identifier, []flow.TransactionResult](transactionResultsCacheSize),
+			withStore(noopStore[flow.Identifier, []flow.TransactionResult]),
 			withRetrieve(retrieveForBlock),
 		),
 	}
@@ -170,8 +129,7 @@ func (tr *TransactionResults) BatchStore(blockID flow.Identifier, transactionRes
 			tr.indexCache.Insert(keyIndex, result)
 		}
 
-		key := KeyFromBlockID(blockID)
-		tr.blockCache.Insert(key, transactionResults)
+		tr.blockCache.Insert(blockID, transactionResults)
 	})
 	return nil
 }
@@ -198,8 +156,7 @@ func (tr *TransactionResults) ByBlockIDTransactionIndex(blockID flow.Identifier,
 
 // ByBlockID gets all transaction results for a block, ordered by transaction index
 func (tr *TransactionResults) ByBlockID(blockID flow.Identifier) ([]flow.TransactionResult, error) {
-	key := KeyFromBlockID(blockID)
-	transactionResults, err := tr.blockCache.Get(tr.db.Reader(), key)
+	transactionResults, err := tr.blockCache.Get(tr.db.Reader(), blockID)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/store/transaction_results_test.go
+++ b/storage/store/transaction_results_test.go
@@ -90,8 +90,7 @@ func TestKeyConversion(t *testing.T) {
 	blockID := unittest.IdentifierFixture()
 	txID := unittest.IdentifierFixture()
 	key := store.KeyFromBlockIDTransactionID(blockID, txID)
-	bID, tID, err := store.KeyToBlockIDTransactionID(key)
-	require.NoError(t, err)
+	bID, tID := store.KeyToBlockIDTransactionID(key)
 	require.Equal(t, blockID, bID)
 	require.Equal(t, txID, tID)
 }
@@ -100,8 +99,79 @@ func TestIndexKeyConversion(t *testing.T) {
 	blockID := unittest.IdentifierFixture()
 	txIndex := mathRand.Uint32()
 	key := store.KeyFromBlockIDIndex(blockID, txIndex)
-	bID, tID, err := store.KeyToBlockIDIndex(key)
-	require.NoError(t, err)
+	bID, tID := store.KeyToBlockIDIndex(key)
 	require.Equal(t, blockID, bID)
 	require.Equal(t, txIndex, tID)
+}
+
+func BenchmarkTransactionResultCacheKey(b *testing.B) {
+	b.Run("new: create cache key", func(b *testing.B) {
+		blockID := unittest.IdentifierFixture()
+		txID := unittest.IdentifierFixture()
+
+		var key store.TwoIdentifier
+		for range b.N {
+			key = store.KeyFromBlockIDTransactionID(blockID, txID)
+		}
+		_ = key
+	})
+
+	b.Run("old: create cache key", func(b *testing.B) {
+		blockID := unittest.IdentifierFixture()
+		txID := unittest.IdentifierFixture()
+
+		var key string
+		for range b.N {
+			key = DeprecatedKeyFromBlockIDTransactionID(blockID, txID)
+		}
+		_ = key
+	})
+
+	b.Run("new: parse cache key", func(b *testing.B) {
+		blockID := unittest.IdentifierFixture()
+		txID := unittest.IdentifierFixture()
+		key := store.KeyFromBlockIDTransactionID(blockID, txID)
+
+		var id1, id2 flow.Identifier
+		for range b.N {
+			id1, id2 = store.KeyToBlockIDTransactionID(key)
+		}
+		_ = id1
+		_ = id2
+	})
+
+	b.Run("old: parse cache key", func(b *testing.B) {
+		blockID := unittest.IdentifierFixture()
+		txID := unittest.IdentifierFixture()
+		key := DeprecatedKeyFromBlockIDTransactionID(blockID, txID)
+
+		var id1, id2 flow.Identifier
+		for range b.N {
+			id1, id2, _ = DeprecatedKeyToBlockIDTransactionID(key)
+		}
+		_ = id1
+		_ = id2
+	})
+}
+
+// This deprecated function is for benchmark purpose.
+func DeprecatedKeyFromBlockIDTransactionID(blockID flow.Identifier, txID flow.Identifier) string {
+	return fmt.Sprintf("%x%x", blockID, txID)
+}
+
+// This deprecated function is for benchmark purpose.
+func DeprecatedKeyToBlockIDTransactionID(key string) (flow.Identifier, flow.Identifier, error) {
+	blockIDStr := key[:64]
+	txIDStr := key[64:]
+	blockID, err := flow.HexStringToIdentifier(blockIDStr)
+	if err != nil {
+		return flow.ZeroID, flow.ZeroID, fmt.Errorf("could not get block ID: %w", err)
+	}
+
+	txID, err := flow.HexStringToIdentifier(txIDStr)
+	if err != nil {
+		return flow.ZeroID, flow.ZeroID, fmt.Errorf("could not get transaction id: %w", err)
+	}
+
+	return blockID, txID, nil
 }


### PR DESCRIPTION
This speeds up key creation by ~372x and eliminates all memory allocs (used by key creation) for some stores. It also optimizes the cache key format to be smaller.

I found this "low-hanging fruit" optimization last week while working on a bugfix PR:
- #7324

Previously, memory cache key format for transaction results was inefficient and creates needless allocations by encoding to hex. Same issue exists for transaction result index cache and block cache. Light transaction results used by AN also use the same cache key format.

This PR optimizes cache key format for multiple stores:
- cache key format:
  - old: `hex(blockID) + hex(txID)`
  - new: `blockID + txID`
- index cache key format:
  - old `hex(blockID) + hex(txIndex)`
  - new `blockID + txIndex`
- block cache key format:
  - old `hex(blockID)`
  - new `blockID`

Updated stores include:
- `TransactionResults`
- `TransactionResultErrorMessages`
- `LightTransactionResults`

Since cache keys are created for every read or insert of transaction results, etc., it is good to reduce memory allocs when it doesn't sacrifice speed.

Benchmark stats for creating cache key:
```
                                               │    old.log    │               new.log               │
                                               │    sec/op     │   sec/op     vs base                │
TransactionResultCacheKey/_create_cache_key-12   882.000n ± 8%   2.368n ± 0%  -99.73% (p=0.000 n=10)

                                               │  old.log   │              new.log              │
                                               │    B/op    │   B/op    vs base                 │
TransactionResultCacheKey/_create_cache_key-12   576.0 ± 0%   0.0 ± 0%  -100.00% (p=0.000 n=10)

                                               │  old.log   │               new.log               │
                                               │ allocs/op  │ allocs/op   vs base                 │
TransactionResultCacheKey/_create_cache_key-12   9.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```