### PR TITLE
[Storage] Fix Writer.Set() & Writer.Delete() args not being safe to modify (BadgerDB)

### DIFF
--- a/storage/operation/badgerimpl/writer_test.go
+++ b/storage/operation/badgerimpl/writer_test.go
@@ -1,0 +1,47 @@
+package badgerimpl_test
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/flow-go/utils/unittest"
+)
+
+// TestBadgerSetArgumentsNotSafeToModify verifies that WriteBatch.Set()
+// arguments are not safe to be modified before batch is committed.
+func TestBadgerSetArgumentsNotSafeToModify(t *testing.T) {
+	unittest.RunWithBadgerDB(t, func(db *badger.DB) {
+		b := db.NewWriteBatch()
+
+		k := []byte{0x01}
+		v := []byte{0x01, 0x02, 0x03}
+
+		// Insert k and v to batch.
+		err := b.Set(k, v)
+		require.NoError(t, err)
+
+		// Modify k and v before commit.
+		k[0] = 0x02
+		v[0] = 0x04
+
+		// Commit pending writes.
+		err = b.Flush()
+		require.NoError(t, err)
+
+		tx := db.NewTransaction(false)
+
+		// Retrieve value by original key returns ErrKeyNotFound error.
+		_, err = tx.Get([]byte{0x01})
+		require.ErrorIs(t, err, badger.ErrKeyNotFound)
+
+		// Retrieve value by modified key returns modified value.
+		item, err := tx.Get([]byte{0x02})
+		require.NoError(t, err, nil)
+
+		retrievedValue, err := item.ValueCopy(nil)
+		require.NoError(t, err, nil)
+		require.Equal(t, v, retrievedValue)
+	})
+}

--- a/storage/operation/writes_test.go
+++ b/storage/operation/writes_test.go
@@ -140,6 +140,7 @@ func TestBatchWriteArgumentCanBeModified(t *testing.T) {
 		// Retrieve value with original key.
 		retreivedValue, closer, err := db.Reader().Get([]byte{0x01})
 		defer closer.Close()
+		require.NoError(t, err)
 		require.Equal(t, []byte{0x02}, retreivedValue)
 	})
 }

--- a/storage/operation/writes_test.go
+++ b/storage/operation/writes_test.go
@@ -117,6 +117,78 @@ func TestBatchWrite(t *testing.T) {
 	})
 }
 
+func TestBatchWriteArgumentCanBeModified(t *testing.T) {
+	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		b := db.NewBatch()
+		defer b.Close()
+
+		k := []byte{0x01}
+		v := []byte{0x02}
+
+		// Insert k and v into batch.
+		err := b.Writer().Set(k, v)
+		require.NoError(t, err)
+
+		// Modify k and v.
+		k[0]++
+		v[0]++
+
+		// Commit batch.
+		err = b.Commit()
+		require.NoError(t, err)
+
+		// Retrieve value with original key.
+		retreivedValue, closer, err := db.Reader().Get([]byte{0x01})
+		defer closer.Close()
+		require.Equal(t, []byte{0x02}, retreivedValue)
+	})
+}
+
+func TestBatchDeleteArgumentCanBeModified(t *testing.T) {
+	dbtest.RunWithDB(t, func(t *testing.T, db storage.DB) {
+		{
+			b := db.NewBatch()
+			defer b.Close()
+
+			k := []byte{0x01}
+			v := []byte{0x02}
+
+			// Insert k and v into batch.
+			err := b.Writer().Set(k, v)
+			require.NoError(t, err)
+
+			// Commit batch.
+			err = b.Commit()
+			require.NoError(t, err)
+		}
+		{
+			// Create batch to remove records.
+			b := db.NewBatch()
+			defer b.Close()
+
+			k := []byte{0x01}
+
+			// Delete record.
+			err := b.Writer().Delete(k)
+			require.NoError(t, err)
+
+			// Modify k
+			k[0]++
+
+			// Commit batch.
+			err = b.Commit()
+			require.NoError(t, err)
+		}
+		{
+			// Retrieve value with original key
+			retreivedValue, closer, err := db.Reader().Get([]byte{0x01})
+			defer closer.Close()
+			require.ErrorIs(t, storage.ErrNotFound, err)
+			require.Nil(t, retreivedValue)
+		}
+	})
+}
+
 func TestRemove(t *testing.T) {
 	dbtest.RunWithStorages(t, func(t *testing.T, r storage.Reader, withWriter dbtest.WithWriter) {
 		e := Entity{ID: 1337}


### PR DESCRIPTION
Updates #7242

Currently, docs for `ReaderBatchWriter.Set()` promises it is safe to modify the key and value after `Set()` returns.  However, BadgerDB's docs for `WriteBatch.Set()` says users must not modify key and value until the end of transaction.

This PR clones arguments in badgerimpl's `ReaderBatchWriter.Set()` and `ReaderBatchWriter.Delete()` to allow the caller to modify the key and value as promised by our docs.

This bug hasn't surfaced yet because of the way the functions are currently used and leaving it as-is risks future problems.

The corresponding functions for Pebble don't need this fix because Pebble clones the same arguments under-the-hood.

I found this while getting familiar with storage code related to BadgerDB and Pebble (not looking for bugs).