### PR TITLE
[WIP] Removed non-constructor mutations for EpochRecover, EpochSetup and EpochCommit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/cmd/bootstrap/cmd/block.go
+++ b/cmd/bootstrap/cmd/block.go
@@ -45,20 +45,18 @@ func constructRootEpochEvents(
 	dkgData dkg.ThresholdKeySet,
 	dkgIndexMap flow.DKGIndexMap,
 ) (*flow.EpochSetup, *flow.EpochCommit) {
-
-	epochSetup := &flow.EpochSetup{
-		Counter:            flagEpochCounter,
-		FirstView:          firstView,
-		FinalView:          firstView + flagNumViewsInEpoch - 1,
-		DKGPhase1FinalView: firstView + flagNumViewsInStakingAuction + flagNumViewsInDKGPhase - 1,
-		DKGPhase2FinalView: firstView + flagNumViewsInStakingAuction + flagNumViewsInDKGPhase*2 - 1,
-		DKGPhase3FinalView: firstView + flagNumViewsInStakingAuction + flagNumViewsInDKGPhase*3 - 1,
-		Participants:       participants.Sort(flow.Canonical[flow.Identity]).ToSkeleton(),
-		Assignments:        assignments,
-		RandomSource:       GenerateRandomSeed(flow.EpochSetupRandomSourceLength),
-		TargetDuration:     flagEpochTimingDuration,
-		TargetEndTime:      rootEpochTargetEndTime(),
-	}
+	epochSetup := flow.NewEpochSetup(
+		flagEpochCounter,
+		firstView,
+		firstView+flagNumViewsInStakingAuction+flagNumViewsInDKGPhase-1,
+		firstView+flagNumViewsInStakingAuction+flagNumViewsInDKGPhase*2-1,
+		firstView+flagNumViewsInStakingAuction+flagNumViewsInDKGPhase*3-1,
+		firstView+flagNumViewsInEpoch-1,
+		participants.Sort(flow.Canonical[flow.Identity]).ToSkeleton(), assignments,
+		GenerateRandomSeed(flow.EpochSetupRandomSourceLength),
+		flagEpochTimingDuration,
+		rootEpochTargetEndTime(),
+	)
 
 	qcsWithSignerIDs := make([]*flow.QuorumCertificateWithSignerIDs, 0, len(clusterQCs))
 	for i, clusterQC := range clusterQCs {
@@ -82,7 +80,7 @@ func constructRootEpochEvents(
 		DKGParticipantKeys: dkgData.PubKeyShares,
 		DKGIndexMap:        dkgIndexMap,
 	}
-	return epochSetup, epochCommit
+	return &epochSetup, epochCommit
 }
 
 func parseChainID(chainID string) flow.ChainID {

--- a/model/convert/service_event.go
+++ b/model/convert/service_event.go
@@ -670,12 +670,10 @@ func convertServiceEventEpochRecover(event flow.Event) (*flow.ServiceEvent, erro
 	}
 
 	// create the service event
+	epochRecover := flow.NewEpochRecover(setup, commit)
 	serviceEvent := &flow.ServiceEvent{
-		Type: flow.ServiceEventRecover,
-		Event: &flow.EpochRecover{
-			EpochSetup:  setup,
-			EpochCommit: commit,
-		},
+		Type:  flow.ServiceEventRecover,
+		Event: &epochRecover,
 	}
 
 	return serviceEvent, nil

--- a/model/flow/epoch.go
+++ b/model/flow/epoch.go
@@ -199,9 +199,18 @@ func (setup *EpochSetup) EqualTo(other *EpochSetup) bool {
 // EpochRecover service event is emitted when network is in Epoch Fallback Mode(EFM) in an attempt to return to happy path.
 // It contains data from EpochSetup, and EpochCommit events to so replicas can create a committed epoch from which they
 // can continue operating on the happy path.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type EpochRecover struct {
 	EpochSetup  EpochSetup
 	EpochCommit EpochCommit
+}
+
+func NewEpochRecover(setup EpochSetup, commit EpochCommit) EpochRecover {
+	return EpochRecover{
+		EpochSetup:  setup,
+		EpochCommit: commit,
+	}
 }
 
 func (er *EpochRecover) ServiceEvent() ServiceEvent {

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2159,11 +2159,8 @@ func EpochRecoverFixture(opts ...func(setup *flow.EpochSetup)) *flow.EpochRecove
 		WithClusterQCsFromAssignments(setup.Assignments),
 	)
 
-	ev := &flow.EpochRecover{
-		EpochSetup:  *setup,
-		EpochCommit: *commit,
-	}
-	return ev
+	ev := flow.NewEpochRecover(*setup, *commit)
+	return &ev
 }
 
 func IndexFixture() *flow.Index {

--- a/utils/unittest/service_events_fixtures.go
+++ b/utils/unittest/service_events_fixtures.go
@@ -208,8 +208,8 @@ func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochRe
 	event := EventFixture(events.EpochRecover.EventType(), 1, 1, IdentifierFixture(), 0)
 	event.Payload = EpochRecoverFixtureCCF(randomSource)
 
-	expected := &flow.EpochRecover{
-		EpochSetup: flow.EpochSetup{
+	expected := flow.NewEpochRecover(
+		flow.EpochSetup{
 			Counter:            1,
 			FirstView:          100,
 			FinalView:          200,
@@ -288,7 +288,7 @@ func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochRe
 				},
 			},
 		},
-		EpochCommit: flow.EpochCommit{
+		flow.EpochCommit{
 			Counter: 1,
 			ClusterQCs: []flow.ClusterQCVoteData{
 				{
@@ -314,9 +314,9 @@ func EpochRecoverFixtureByChainID(chain flow.ChainID) (flow.Event, *flow.EpochRe
 				flow.MustHexStringToIdentifier("0000000000000000000000000000000000000000000000000000000000000011"): 0,
 			},
 		},
-	}
+	)
 
-	return event, expected
+	return event, &expected
 }
 
 // VersionBeaconFixtureByChainID returns a VersionTable service event as a Cadence event


### PR DESCRIPTION
**Please, do not review this PR, it is in progress and created only to check linter on CI.**

Closes: #7285, #7284, #7286

## Context
In this PR were added constructor for `EpochRecover`, `EpochSetup` and `EpochCommit` structs and removed non-constructor mutations for those structs.