### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for Collection, QuorumCertificate and CollectionGuarantee structs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/engine/common/rpc/convert/collections.go
+++ b/engine/common/rpc/convert/collections.go
@@ -79,9 +79,8 @@ func MessageToFullCollection(m []*entities.Transaction, chain flow.Chain) (*flow
 		transactions[i] = &t
 	}
 
-	return &flow.Collection{
-		Transactions: transactions,
-	}, nil
+	collection := flow.NewCollection(transactions)
+	return &collection, nil
 }
 
 // CollectionGuaranteeToMessage converts a collection guarantee to a protobuf message

--- a/engine/common/rpc/convert/execution_data.go
+++ b/engine/common/rpc/convert/execution_data.go
@@ -238,7 +238,8 @@ func messageToTrustedCollection(
 ) (*flow.Collection, error) {
 	messages := m.GetTransactions()
 	if len(messages) == 0 {
-		return &flow.Collection{}, nil
+		empty := flow.NewCollection(nil)
+		return &empty, nil
 	}
 
 	transactions := make([]*flow.TransactionBody, len(messages))
@@ -250,7 +251,8 @@ func messageToTrustedCollection(
 		transactions[i] = &transaction
 	}
 
-	return &flow.Collection{Transactions: transactions}, nil
+	collection := flow.NewCollection(transactions)
+	return &collection, nil
 }
 
 // messageToTrustedTransaction converts a transaction message to a transaction body.

--- a/model/cluster/payload.go
+++ b/model/cluster/payload.go
@@ -47,9 +47,7 @@ func PayloadFromTransactions(refID flow.Identifier, transactions ...*flow.Transa
 		transactions = []*flow.TransactionBody{}
 	}
 	return Payload{
-		Collection: flow.Collection{
-			Transactions: transactions,
-		},
+		Collection:       flow.NewCollection(transactions),
 		ReferenceBlockID: refID,
 	}
 }

--- a/model/flow/collection.go
+++ b/model/flow/collection.go
@@ -3,18 +3,25 @@ package flow
 import "github.com/onflow/flow-go/model/fingerprint"
 
 // Collection is set of transactions.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type Collection struct {
 	Transactions []*TransactionBody
+}
+
+func NewCollection(transactions []*TransactionBody) Collection {
+	return Collection{Transactions: transactions}
 }
 
 // CollectionFromTransactions creates a new collection from the list of
 // transactions.
 func CollectionFromTransactions(transactions []*Transaction) Collection {
-	coll := Collection{Transactions: make([]*TransactionBody, 0, len(transactions))}
+	txs := make([]*TransactionBody, 0, len(transactions))
+
 	for _, tx := range transactions {
-		coll.Transactions = append(coll.Transactions, &tx.TransactionBody)
+		txs = append(txs, &tx.TransactionBody)
 	}
-	return coll
+	return NewCollection(txs)
 }
 
 // Light returns the light, reference-only version of the collection.

--- a/model/messages/collection.go
+++ b/model/messages/collection.go
@@ -42,17 +42,19 @@ type UntrustedClusterBlock struct {
 
 // ToInternal returns the internal representation of the type.
 func (ub *UntrustedClusterBlock) ToInternal() *cluster.Block {
-	block := &cluster.Block{
+	txs := make([]*flow.TransactionBody, len(ub.Payload.Collection))
+
+	for _, tx := range ub.Payload.Collection {
+		txs = append(txs, &tx)
+	}
+
+	return &cluster.Block{
 		Header: &ub.Header,
 		Payload: &cluster.Payload{
 			ReferenceBlockID: ub.Payload.ReferenceBlockID,
+			Collection:       flow.NewCollection(txs),
 		},
 	}
-	for _, tx := range ub.Payload.Collection {
-		tx := tx
-		block.Payload.Collection.Transactions = append(block.Payload.Collection.Transactions, &tx)
-	}
-	return block
 }
 
 // UntrustedClusterBlockFromInternal converts the internal cluster.Block representation

--- a/module/mempool/entity/executableblock.go
+++ b/module/mempool/entity/executableblock.go
@@ -40,7 +40,7 @@ type BlocksByCollection struct {
 }
 
 func (c CompleteCollection) Collection() flow.Collection {
-	return flow.Collection{Transactions: c.Transactions}
+	return flow.NewCollection(c.Transactions)
 }
 
 func (c CompleteCollection) IsCompleted() bool {
@@ -102,7 +102,8 @@ func (b *ExecutableBlock) CollectionAt(index int) *flow.Collection {
 	if cc == nil {
 		return nil
 	}
-	return &flow.Collection{Transactions: cc.Transactions}
+	collection := flow.NewCollection(cc.Transactions)
+	return &collection
 }
 
 // HasAllTransactions returns whether all the transactions for all collections

--- a/storage/badger/collections.go
+++ b/storage/badger/collections.go
@@ -46,8 +46,8 @@ func (c *Collections) Store(collection *flow.Collection) error {
 
 func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 	var (
-		light      flow.LightCollection
-		collection flow.Collection
+		light flow.LightCollection
+		txs   []*flow.TransactionBody
 	)
 
 	err := c.db.View(func(btx *badger.Txn) error {
@@ -56,13 +56,14 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 			return fmt.Errorf("could not retrieve collection: %w", err)
 		}
 
+		txs = make([]*flow.TransactionBody, 0, len(light.Transactions))
 		for _, txID := range light.Transactions {
 			tx, err := c.transactions.ByID(txID)
 			if err != nil {
 				return fmt.Errorf("could not retrieve transaction: %w", err)
 			}
 
-			collection.Transactions = append(collection.Transactions, tx)
+			txs = append(txs, tx)
 		}
 
 		return nil
@@ -71,6 +72,7 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 		return nil, err
 	}
 
+	collection := flow.NewCollection(txs)
 	return &collection, nil
 }
 

--- a/storage/store/collections.go
+++ b/storage/store/collections.go
@@ -64,8 +64,8 @@ func (c *Collections) Store(collection *flow.Collection) error {
 // ByID retrieves a collection by its ID.
 func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 	var (
-		light      flow.LightCollection
-		collection flow.Collection
+		light flow.LightCollection
+		txs   []*flow.TransactionBody
 	)
 
 	err := operation.RetrieveCollection(c.db.Reader(), colID, &light)
@@ -73,15 +73,17 @@ func (c *Collections) ByID(colID flow.Identifier) (*flow.Collection, error) {
 		return nil, fmt.Errorf("could not retrieve collection: %w", err)
 	}
 
+	txs = make([]*flow.TransactionBody, 0, len(light.Transactions))
 	for _, txID := range light.Transactions {
 		tx, err := c.transactions.ByID(txID)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve transaction %v: %w", txID, err)
 		}
 
-		collection.Transactions = append(collection.Transactions, tx)
+		txs = append(txs, tx)
 	}
 
+	collection := flow.NewCollection(txs)
 	return &collection, nil
 }
 


### PR DESCRIPTION
Closes: #7281 

## Context 

This PR introduces constructor functions for the following structs: `Collection`, `QuorumCertificate` and `CollectionGuarantee` structs. In addition, it removes all direct field assignments on these types outside of their constructors, enforcing immutability by construction.