### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for Attestation, ResultApprovalBody and ResultApproval structs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -265,16 +265,16 @@ func (e *Engine) verify(ctx context.Context, originID flow.Identifier,
 
 	// Generate result approval
 	span, _ = e.tracer.StartSpanFromContext(ctx, trace.VERVerGenerateResultApproval)
-	attestation := &flow.Attestation{
-		BlockID:           vc.Header.ID(),
-		ExecutionResultID: vc.Result.ID(),
-		ChunkIndex:        vc.Chunk.Index,
-	}
+	attestation := flow.NewAttestation(
+		vc.Header.ID(),
+		vc.Result.ID(),
+		vc.Chunk.Index,
+	)
 	approval, err := GenerateResultApproval(
 		e.me,
 		e.approvalHasher,
 		e.spockHasher,
-		attestation,
+		&attestation,
 		spockSecret)
 
 	span.End()

--- a/engine/verification/verifier/engine.go
+++ b/engine/verification/verifier/engine.go
@@ -337,12 +337,12 @@ func GenerateResultApproval(
 	}
 
 	// result approval body
-	body := flow.ResultApprovalBody{
-		Attestation:          *attestation,
-		ApproverID:           me.NodeID(),
-		AttestationSignature: atstSign,
-		Spock:                spock,
-	}
+	body := flow.NewResultApprovalBody(
+		*attestation,
+		me.NodeID(),
+		atstSign,
+		spock,
+	)
 
 	// generates a signature over result approval body
 	bodyID := body.ID()

--- a/model/flow/resultApproval.go
+++ b/model/flow/resultApproval.go
@@ -5,10 +5,20 @@ import (
 )
 
 // Attestation confirms correctness of a chunk of an exec result
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type Attestation struct {
 	BlockID           Identifier // ID of the block included the collection
 	ExecutionResultID Identifier // ID of the execution result
 	ChunkIndex        uint64     // index of the approved chunk
+}
+
+func NewAttestation(blockID Identifier, executionResultID Identifier, chunkIndex uint64) Attestation {
+	return Attestation{
+		BlockID:           blockID,
+		ExecutionResultID: executionResultID,
+		ChunkIndex:        chunkIndex,
+	}
 }
 
 // ID generates a unique identifier using attestation

--- a/model/flow/resultApproval.go
+++ b/model/flow/resultApproval.go
@@ -27,11 +27,26 @@ func (a Attestation) ID() Identifier {
 }
 
 // ResultApprovalBody holds body part of a result approval
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type ResultApprovalBody struct {
 	Attestation
 	ApproverID           Identifier       // node id generating this result approval
 	AttestationSignature crypto.Signature // signature over attestation, this has been separated for BLS aggregation
 	Spock                crypto.Signature // proof of re-computation, one per each chunk
+}
+
+func NewResultApprovalBody(
+	attestation Attestation,
+	approvalID Identifier,
+	attestSignature crypto.Signature,
+	spock crypto.Signature) ResultApprovalBody {
+	return ResultApprovalBody{
+		Attestation:          attestation,
+		ApproverID:           approvalID,
+		AttestationSignature: attestSignature,
+		Spock:                spock,
+	}
 }
 
 // PartialID generates a unique identifier using Attestation + ApproverID

--- a/module/validation/seal_validator.go
+++ b/module/validation/seal_validator.go
@@ -55,11 +55,11 @@ func (s *sealValidator) verifySealSignature(aggregatedSignatures *flow.Aggregate
 	chunk *flow.Chunk, executionResultID flow.Identifier) error {
 	// TODO: replace implementation once proper aggregation is used for Verifiers' attestation signatures.
 
-	atst := flow.Attestation{
-		BlockID:           chunk.BlockID,
-		ExecutionResultID: executionResultID,
-		ChunkIndex:        chunk.Index,
-	}
+	atst := flow.NewAttestation(
+		chunk.BlockID,
+		executionResultID,
+		chunk.Index,
+	)
 	atstID := atst.ID()
 
 	for i, signature := range aggregatedSignatures.VerifierSignatures {


### PR DESCRIPTION
closes: https://github.com/onflow/flow-go/issues/7298 https://github.com/onflow/flow-go/issues/7299 https://github.com/onflow/flow-go/issues/7300

##Context
In this PR were added constructor for `Attestation`, `ResultApprovalBody` and `ResultApproval` structs and removed non-constructor mutations for those structs.