### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for MinEpochStateEntry, EpochStateEntry and RichEpochStateEntry

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/consensus/integration/epoch_test.go
+++ b/consensus/integration/epoch_test.go
@@ -239,29 +239,32 @@ func withNextEpoch(
 	}
 
 	// Construct the new min epoch state entry
-	minEpochStateEntry := &flow.MinEpochStateEntry{
-		PreviousEpoch: rootProtocolState.EpochEntry.PreviousEpoch,
-		CurrentEpoch: flow.EpochStateContainer{
+	minEpochStateEntry := flow.NewMinEpochStateEntry(
+		rootProtocolState.EpochEntry.PreviousEpoch,
+		flow.EpochStateContainer{
 			SetupID:          currEpochSetup.ID(),
 			CommitID:         currEpochCommit.ID(),
 			ActiveIdentities: rootProtocolState.EpochEntry.CurrentEpoch.ActiveIdentities,
 			EpochExtensions:  rootProtocolState.EpochEntry.CurrentEpoch.EpochExtensions,
 		},
-		NextEpoch: &flow.EpochStateContainer{
+		&flow.EpochStateContainer{
 			SetupID:          nextEpochSetup.ID(),
 			CommitID:         nextEpochCommit.ID(),
 			ActiveIdentities: flow.DynamicIdentityEntryListFromIdentities(nextEpochIdentities),
 		},
-		EpochFallbackTriggered: false,
-	}
+		false,
+	)
 
 	// Construct the new epoch protocol state entry
 	epochStateEntry, err := flow.NewEpochStateEntry(
-		minEpochStateEntry,
+		&minEpochStateEntry,
 		rootProtocolState.EpochEntry.PreviousEpochSetup,
 		rootProtocolState.EpochEntry.PreviousEpochCommit,
-		currEpochSetup, currEpochCommit,
-		nextEpochSetup, nextEpochCommit)
+		currEpochSetup,
+		currEpochCommit,
+		nextEpochSetup,
+		nextEpochCommit,
+	)
 	require.NoError(t, err)
 	// Re-construct epoch protocol state with modified events (constructs ActiveIdentity fields)
 	epochRichProtocolState, err := flow.NewRichEpochStateEntry(epochStateEntry)

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -227,11 +227,27 @@ func NewEpochStateEntry(
 // the Identity Table additionally contains nodes (with weight zero) from the previous or
 // upcoming epoch, which are transitioning into / out of the network and are only allowed
 // to listen but not to actively contribute.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type RichEpochStateEntry struct {
 	*EpochStateEntry
 
 	CurrentEpochIdentityTable IdentityList
 	NextEpochIdentityTable    IdentityList
+}
+
+// NewRichEpochStateEntryWithIdentityTable creates a new instance of RichEpochStateEntry.
+// Construction RichEpochStateEntry allowed only within the constructor.
+func NewRichEpochStateEntryWithIdentityTable(
+	epochState *EpochStateEntry,
+	currentEpochIdentityTable IdentityList,
+	nextEpochIdentityTable IdentityList,
+) RichEpochStateEntry {
+	return RichEpochStateEntry{
+		EpochStateEntry:           epochState,
+		CurrentEpochIdentityTable: currentEpochIdentityTable,
+		NextEpochIdentityTable:    nextEpochIdentityTable,
+	}
 }
 
 // NewRichEpochStateEntry constructs a RichEpochStateEntry from an EpochStateEntry.
@@ -353,11 +369,12 @@ func (e *RichEpochStateEntry) Copy() *RichEpochStateEntry {
 	if e == nil {
 		return nil
 	}
-	return &RichEpochStateEntry{
-		EpochStateEntry:           e.EpochStateEntry.Copy(),
-		CurrentEpochIdentityTable: e.CurrentEpochIdentityTable.Copy(),
-		NextEpochIdentityTable:    e.NextEpochIdentityTable.Copy(),
-	}
+	richEpochStateEntry := NewRichEpochStateEntryWithIdentityTable(
+		e.EpochStateEntry.Copy(),
+		e.CurrentEpochIdentityTable.Copy(),
+		e.NextEpochIdentityTable.Copy(),
+	)
+	return &richEpochStateEntry
 }
 
 // CurrentEpochFinalView returns the final view of the current epoch, taking into account possible epoch extensions.

--- a/model/flow/protocol_state.go
+++ b/model/flow/protocol_state.go
@@ -138,7 +138,7 @@ func (c *EpochStateContainer) Copy() *EpochStateContainer {
 //   - PreviousEpochSetup and PreviousEpochCommit are for the same epoch. Can be nil.
 //   - NextEpochSetup and NextEpochCommit are for the same epoch. Can be nil.
 //
-//structwrite:immutable - mutations allowed only within the constructor
+//structwrite:immutable - mutations allowed only within the constructor.
 type EpochStateEntry struct {
 	*MinEpochStateEntry
 
@@ -375,16 +375,22 @@ func (e *EpochStateEntry) Copy() *EpochStateEntry {
 	if e == nil {
 		return nil
 	}
-	//nolint:structwrite // it is safe to construct EpochStateEntry outside constructor cause it does not change the ID
-	return &EpochStateEntry{
-		MinEpochStateEntry:  e.MinEpochStateEntry.Copy(),
-		PreviousEpochSetup:  e.PreviousEpochSetup,
-		PreviousEpochCommit: e.PreviousEpochCommit,
-		CurrentEpochSetup:   e.CurrentEpochSetup,
-		CurrentEpochCommit:  e.CurrentEpochCommit,
-		NextEpochSetup:      e.NextEpochSetup,
-		NextEpochCommit:     e.NextEpochCommit,
+
+	epochStateEntry, err := NewEpochStateEntry(
+		e.MinEpochStateEntry.Copy(),
+		e.PreviousEpochSetup,
+		e.PreviousEpochCommit,
+		e.CurrentEpochSetup,
+		e.CurrentEpochCommit,
+		e.NextEpochSetup,
+		e.NextEpochCommit,
+	)
+	if err != nil {
+		// Should never reach here
+		panic(err)
 	}
+
+	return epochStateEntry
 }
 
 // Copy returns a full copy of the RichEpochStateEntry.

--- a/model/flow/protocol_state_test.go
+++ b/model/flow/protocol_state_test.go
@@ -64,17 +64,18 @@ func TestNewRichProtocolStateEntry(t *testing.T) {
 				Ejected: false,
 			})
 		}
-		minStateEntry := &flow.MinEpochStateEntry{
-			PreviousEpoch: nil,
-			CurrentEpoch: flow.EpochStateContainer{
+		minStateEntry := flow.NewMinEpochStateEntry(
+			nil,
+			flow.EpochStateContainer{
 				SetupID:          setup.ID(),
 				CommitID:         currentEpochCommit.ID(),
 				ActiveIdentities: identities,
 			},
-			EpochFallbackTriggered: false,
-		}
+			nil,
+			false,
+		)
 		stateEntry, err := flow.NewEpochStateEntry(
-			minStateEntry,
+			&minStateEntry,
 			nil,
 			nil,
 			setup,

--- a/state/protocol/inmem/convert.go
+++ b/state/protocol/inmem/convert.go
@@ -191,14 +191,15 @@ func EpochProtocolStateFromServiceEvents(setup *flow.EpochSetup, commit *flow.Ep
 			Ejected: false,
 		})
 	}
-	return &flow.MinEpochStateEntry{
-		PreviousEpoch: nil,
-		CurrentEpoch: flow.EpochStateContainer{
+	minEpochStateEntry := flow.NewMinEpochStateEntry(
+		nil,
+		flow.EpochStateContainer{
 			SetupID:          setup.ID(),
 			CommitID:         commit.ID(),
 			ActiveIdentities: identities,
 		},
-		NextEpoch:              nil,
-		EpochFallbackTriggered: false,
-	}
+		nil,
+		false,
+	)
+	return &minEpochStateEntry
 }

--- a/state/protocol/inmem/epoch_protocol_state_test.go
+++ b/state/protocol/inmem/epoch_protocol_state_test.go
@@ -78,6 +78,7 @@ func TestEpochProtocolStateAdapter(t *testing.T) {
 		entry := unittest.EpochStateFixture(unittest.WithNextEpochProtocolState())
 		// cleanup the commit event, so we are in setup phase
 		entry.NextEpoch.CommitID = flow.ZeroID
+		entry.NextEpochCommit = nil
 
 		adapter := inmem.NewEpochProtocolStateAdapter(entry, globalParams)
 		assert.Equal(t, flow.EpochPhaseSetup, adapter.EpochPhase())

--- a/state/protocol/protocol_state/epochs/fallback_statemachine.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine.go
@@ -47,6 +47,7 @@ func NewFallbackStateMachine(
 		// not yet properly specified, which we have to clear out.
 		if !nextEpochCommitted {
 			nextEpoch = nil
+			// update corresponding service events
 			nextEpochSetup = nil
 			nextEpochCommit = nil
 		}
@@ -220,6 +221,7 @@ func (m *FallbackStateMachine) ProcessEpochRecover(epochRecover *flow.EpochRecov
 		EpochExtensions:  nil,
 	}
 
+	// update corresponding service events
 	nextEpochSetup := epochRecover.EpochSetup
 	nextEpochCommit := epochRecover.EpochCommit
 

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -654,7 +654,7 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 			nil,
 			true,
 		)
-		require.Equal(s.T(), expectedState, *parentProtocolState.MinEpochStateEntry)
+		require.Equal(s.T(), &expectedState, parentProtocolState.MinEpochStateEntry)
 		require.Greater(s.T(), parentProtocolState.CurrentEpochFinalView(), candidateView,
 			"final view should be greater than final view of test")
 	}

--- a/state/protocol/protocol_state/epochs/happy_path_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/happy_path_statemachine_test.go
@@ -494,7 +494,7 @@ func (s *ProtocolStateMachineSuite) TestEpochSetupAfterIdentityChange() {
 
 	// Construct a valid flow.RichEpochStateEntry for next block
 	// We do this by copying the parent protocol state and updating the identities manually
-	updatedRichProtocolState := flow.NewRichEpochStateEntryWithIdentityTable(
+	updatedRichProtocolState := flow.NewRichEpochStateEntryWithEpochIdentityTables(
 		updatedState,
 		s.parentProtocolState.CurrentEpochIdentityTable.Copy(),
 		flow.IdentityList{},

--- a/state/protocol/protocol_state/epochs/happy_path_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/happy_path_statemachine_test.go
@@ -494,11 +494,11 @@ func (s *ProtocolStateMachineSuite) TestEpochSetupAfterIdentityChange() {
 
 	// Construct a valid flow.RichEpochStateEntry for next block
 	// We do this by copying the parent protocol state and updating the identities manually
-	updatedRichProtocolState := &flow.RichEpochStateEntry{
-		EpochStateEntry:           updatedState,
-		CurrentEpochIdentityTable: s.parentProtocolState.CurrentEpochIdentityTable.Copy(),
-		NextEpochIdentityTable:    flow.IdentityList{},
-	}
+	updatedRichProtocolState := flow.NewRichEpochStateEntryWithIdentityTable(
+		updatedState,
+		s.parentProtocolState.CurrentEpochIdentityTable.Copy(),
+		flow.IdentityList{},
+	)
 	// Update enriched data with the changes made to the low-level updated table
 	for _, identity := range ejectedChanges {
 		toBeUpdated, _ := updatedRichProtocolState.CurrentEpochIdentityTable.ByNodeID(identity.NodeID)
@@ -507,7 +507,7 @@ func (s *ProtocolStateMachineSuite) TestEpochSetupAfterIdentityChange() {
 
 	// now we can use it to construct HappyPathStateMachine for next block, which will process epoch setup event.
 	nextBlock := unittest.BlockHeaderWithParentFixture(s.candidate)
-	s.stateMachine, err = NewHappyPathStateMachine(s.consumer, nextBlock.View, updatedRichProtocolState)
+	s.stateMachine, err = NewHappyPathStateMachine(s.consumer, nextBlock.View, &updatedRichProtocolState)
 	require.NoError(s.T(), err)
 
 	setup := unittest.EpochSetupFixture(

--- a/state/protocol/protocol_state/epochs/statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/statemachine_test.go
@@ -538,16 +538,16 @@ func (s *EpochStateMachineSuite) TestEvolveStateTransitionToNextEpoch_WithInvali
 	indexTxDeferredUpdate.On("Execute", mocks.Anything).Return(nil).Once()
 	s.epochStateDB.On("Index", s.candidate.ID(), mocks.Anything).Return(indexTxDeferredUpdate.Execute, nil).Once()
 
-	expectedEpochState := &flow.MinEpochStateEntry{
-		PreviousEpoch:          s.parentEpochState.CurrentEpoch.Copy(),
-		CurrentEpoch:           *s.parentEpochState.NextEpoch.Copy(),
-		NextEpoch:              nil,
-		EpochFallbackTriggered: true,
-	}
+	expectedEpochState := flow.NewMinEpochStateEntry(
+		s.parentEpochState.CurrentEpoch.Copy(),
+		*s.parentEpochState.NextEpoch.Copy(),
+		nil,
+		true,
+	)
 
 	storeTxDeferredUpdate := storagemock.NewDeferredDBUpdate(s.T())
 	storeTxDeferredUpdate.On("Execute", mocks.Anything).Return(nil).Once()
-	s.epochStateDB.On("StoreTx", expectedEpochState.ID(), expectedEpochState).Return(storeTxDeferredUpdate.Execute, nil).Once()
+	s.epochStateDB.On("StoreTx", expectedEpochState.ID(), &expectedEpochState).Return(storeTxDeferredUpdate.Execute, nil).Once()
 	s.mutator.On("SetEpochStateID", expectedEpochState.ID()).Return().Once()
 
 	dbOps, err := stateMachine.Build()

--- a/storage/badger/epoch_protocol_state.go
+++ b/storage/badger/epoch_protocol_state.go
@@ -245,7 +245,8 @@ func newRichEpochProtocolStateEntry(
 		currentEpochSetup,
 		currentEpochCommit,
 		nextEpochSetup,
-		nextEpochCommit)
+		nextEpochCommit,
+	)
 	if err != nil {
 		// observing an error here would be an indication of severe data corruption or bug in our code since
 		// all data should be available and correctly structured at this point.

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2730,8 +2730,8 @@ func RootEpochProtocolStateFixture() *flow.RichEpochStateEntry {
 			},
 		})
 	}
-	return &flow.RichEpochStateEntry{
-		EpochStateEntry: &flow.EpochStateEntry{
+	richEpochStateEntry := flow.NewRichEpochStateEntryWithIdentityTable(
+		&flow.EpochStateEntry{
 			MinEpochStateEntry: &flow.MinEpochStateEntry{
 				PreviousEpoch: nil,
 				CurrentEpoch: flow.EpochStateContainer{
@@ -2749,9 +2749,10 @@ func RootEpochProtocolStateFixture() *flow.RichEpochStateEntry {
 			NextEpochSetup:      nil,
 			NextEpochCommit:     nil,
 		},
-		CurrentEpochIdentityTable: allIdentities,
-		NextEpochIdentityTable:    flow.IdentityList{},
-	}
+		allIdentities,
+		flow.IdentityList{},
+	)
+	return &richEpochStateEntry
 }
 
 // EpochStateFixture creates a fixture with correctly structured data. The returned Identity Table

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -2898,6 +2898,8 @@ func WithValidDKG() func(*flow.RichEpochStateEntry) {
 			commit.DKGParticipantKeys = append(commit.DKGParticipantKeys, KeyFixture(crypto.BLSBLS12381).PublicKey())
 			commit.DKGIndexMap[nodeID] = index
 		}
+		// update CommitID according to new CurrentEpochCommit object
+		entry.MinEpochStateEntry.CurrentEpoch.CommitID = entry.CurrentEpochCommit.ID()
 	}
 }
 


### PR DESCRIPTION
Closes: #7293, #7295, #7296

## Context

In this PR were added constructors for `MinEpochStateEntry`, `EpochStateEntry` and `RichEpochStateEntry` structs and removed non-constructor mutations for those structs.