### PR TITLE
[Access] Remove v0.41 compatibility override

### DIFF
--- a/engine/common/version/version_control.go
+++ b/engine/common/version/version_control.go
@@ -47,7 +47,6 @@ var defaultCompatibilityOverrides = map[string]struct{}{
 	"0.38.2":  {}, // mainnet, testnet
 	"0.38.3":  {}, // mainnet, testnet
 	"0.40.0":  {}, // mainnet, testnet
-	"0.41.0":  {}, // mainnet, testnet
 }
 
 // VersionControl manages the version control system for the node.


### PR DESCRIPTION
v0.41 has a backwards incompatible change for scripts. Queries for account data for blocks before the account was migrated in Feb 2025 will return empty results instead of the expected data.