### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for EpochProtocolStateAdapter, EpochStateContainer and Locator

### DIFF
--- a/consensus/integration/epoch_test.go
+++ b/consensus/integration/epoch_test.go
@@ -239,19 +239,21 @@ func withNextEpoch(
 	}
 
 	// Construct the new min epoch state entry
+	nextEpoch := flow.NewEpochStateContainer(
+		nextEpochSetup.ID(),
+		nextEpochCommit.ID(),
+		flow.DynamicIdentityEntryListFromIdentities(nextEpochIdentities),
+		nil,
+	)
 	minEpochStateEntry := &flow.MinEpochStateEntry{
 		PreviousEpoch: rootProtocolState.EpochEntry.PreviousEpoch,
-		CurrentEpoch: flow.EpochStateContainer{
-			SetupID:          currEpochSetup.ID(),
-			CommitID:         currEpochCommit.ID(),
-			ActiveIdentities: rootProtocolState.EpochEntry.CurrentEpoch.ActiveIdentities,
-			EpochExtensions:  rootProtocolState.EpochEntry.CurrentEpoch.EpochExtensions,
-		},
-		NextEpoch: &flow.EpochStateContainer{
-			SetupID:          nextEpochSetup.ID(),
-			CommitID:         nextEpochCommit.ID(),
-			ActiveIdentities: flow.DynamicIdentityEntryListFromIdentities(nextEpochIdentities),
-		},
+		CurrentEpoch: flow.NewEpochStateContainer(
+			currEpochSetup.ID(),
+			currEpochCommit.ID(),
+			rootProtocolState.EpochEntry.CurrentEpoch.ActiveIdentities,
+			rootProtocolState.EpochEntry.CurrentEpoch.EpochExtensions,
+		),
+		NextEpoch:              &nextEpoch,
 		EpochFallbackTriggered: false,
 	}
 

--- a/engine/verification/assigner/engine.go
+++ b/engine/verification/assigner/engine.go
@@ -123,13 +123,10 @@ func (e *Engine) processChunk(chunk *flow.Chunk, resultID flow.Identifier, block
 		Uint64("block_height", blockHeight).
 		Logger()
 
-	locator := &chunks.Locator{
-		ResultID: resultID,
-		Index:    chunk.Index,
-	}
+	locator := chunks.NewLocator(resultID, chunk.Index)
 
 	// pushes chunk locator to the chunks queue
-	ok, err := e.chunksQueue.StoreChunkLocator(locator)
+	ok, err := e.chunksQueue.StoreChunkLocator(&locator)
 	if err != nil {
 		return false, fmt.Errorf("could not push chunk locator to chunks queue: %w", err)
 	}

--- a/engine/verification/fetcher/chunkconsumer/consumer_test.go
+++ b/engine/verification/fetcher/chunkconsumer/consumer_test.go
@@ -23,8 +23,8 @@ import (
 // TestChunkLocatorToJob evaluates that a chunk locator can be converted to a job,
 // and its corresponding job can be converted back to the same locator.
 func TestChunkLocatorToJob(t *testing.T) {
-	locator := unittest.ChunkLocatorFixture(unittest.IdentifierFixture(), rand.Uint64())
-	actual, err := chunkconsumer.JobToChunkLocator(chunkconsumer.ChunkLocatorToJob(locator))
+	locator := chunks.NewLocator(unittest.IdentifierFixture(), rand.Uint64())
+	actual, err := chunkconsumer.JobToChunkLocator(chunkconsumer.ChunkLocatorToJob(&locator))
 	require.NoError(t, err)
 	require.Equal(t, locator, actual)
 }

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -573,10 +573,7 @@ func (e *Engine) requestChunkDataPack(chunkIndex uint64, chunkID flow.Identifier
 	}
 
 	request := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: resultID,
-			Index:    chunkIndex,
-		},
+		Locator: chunks.NewLocator(resultID, chunkIndex),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID:   chunkID,
 			Height:    header.Height,

--- a/engine/verification/fetcher/engine_test.go
+++ b/engine/verification/fetcher/engine_test.go
@@ -731,12 +731,14 @@ func mockVerifierEngine(t *testing.T,
 			require.True(t, ok)
 
 			// verifiable chunk data should be distinct.
-			_, ok = seen[chunks.ChunkLocatorID(vc.Result.ID(), vc.Chunk.Index)]
+			locatorID := chunks.NewLocator(vc.Result.ID(), vc.Chunk.Index).ID()
+
+			_, ok = seen[locatorID]
 			require.False(t, ok, "duplicated verifiable chunk received")
-			seen[chunks.ChunkLocatorID(vc.Result.ID(), vc.Chunk.Index)] = struct{}{}
+			seen[locatorID] = struct{}{}
 
 			// we should expect this verifiable chunk and its fields should match our expectation
-			expected, ok := verifiableChunks[chunks.ChunkLocatorID(vc.Result.ID(), vc.Chunk.Index)]
+			expected, ok := verifiableChunks[locatorID]
 			require.True(t, ok, "verifier engine received an unknown verifiable chunk data")
 
 			if vc.IsSystemChunk {

--- a/engine/verification/fetcher/engine_test.go
+++ b/engine/verification/fetcher/engine_test.go
@@ -522,14 +522,8 @@ func TestStopAtHeight(t *testing.T) {
 	mockBlockSealingStatus(s.state, s.headers, headerB, false)
 	mockResultsByIDs(s.results, []*flow.ExecutionResult{resultA, resultB})
 
-	locatorA := chunks.Locator{
-		ResultID: resultA.ID(),
-		Index:    0,
-	}
-	locatorB := chunks.Locator{
-		ResultID: resultB.ID(),
-		Index:    0,
-	}
+	locatorA := chunks.NewLocator(resultA.ID(), 0)
+	locatorB := chunks.NewLocator(resultB.ID(), 0)
 
 	// expects processing notifier being invoked upon sealed chunk detected,
 	// which means the termination of processing a sealed chunk on fetcher engine
@@ -876,10 +870,7 @@ func chunkDataPackResponseFixture(t *testing.T,
 	require.Equal(t, collection != nil, !convert.IsSystemChunk(chunk.Index, result), "only non-system chunks must have a collection")
 
 	return &verification.ChunkDataPackResponse{
-		Locator: chunks.Locator{
-			ResultID: result.ID(),
-			Index:    chunk.Index,
-		},
+		Locator: chunks.NewLocator(result.ID(), chunk.Index),
 		Cdp: unittest.ChunkDataPackFixture(chunk.ID(),
 			unittest.WithStartState(chunk.StartState),
 			unittest.WithChunkDataPackCollection(collection)),
@@ -959,10 +950,7 @@ func chunkRequestFixture(resultID flow.Identifier,
 	disagrees flow.IdentityList) *verification.ChunkDataPackRequest {
 
 	return &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: resultID,
-			Index:    status.ChunkIndex,
-		},
+		Locator: chunks.NewLocator(resultID, status.ChunkIndex),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID:   status.Chunk().ID(),
 			Height:    status.BlockHeight,

--- a/engine/verification/fetcher/execution_fork_test.go
+++ b/engine/verification/fetcher/execution_fork_test.go
@@ -83,15 +83,12 @@ func TestExecutionForkWithDuplicateAssignedChunks(t *testing.T) {
 	processWG := &sync.WaitGroup{}
 	processWG.Add(len(assignedChunkStatuses))
 	for _, status := range assignedChunkStatuses {
-		locator := &chunks.Locator{
-			Index:    status.ChunkIndex,
-			ResultID: status.ExecutionResult.ID(),
-		}
+		locator := chunks.NewLocator(status.ExecutionResult.ID(), status.ChunkIndex)
 
 		go func(l *chunks.Locator) {
 			e.ProcessAssignedChunk(l)
 			processWG.Done()
-		}(locator)
+		}(&locator)
 
 	}
 

--- a/engine/verification/requester/requester_test.go
+++ b/engine/verification/requester/requester_test.go
@@ -611,7 +611,7 @@ func mockChunkDataPackHandler(t *testing.T, handler *mockfetcher.ChunkDataPackHa
 			require.True(t, requests.ContainsChunkID(response.Cdp.ChunkID))
 
 			// invocation should be distinct per chunk ID
-			locatorID := chunks.ChunkLocatorID(response.ResultID, response.Index)
+			locatorID := chunks.NewLocator(response.ResultID, response.Index).ID()
 			_, ok = handledLocators[locatorID]
 			require.False(t, ok)
 
@@ -642,7 +642,7 @@ func mockNotifyBlockSealedHandler(t *testing.T, handler *mockfetcher.ChunkDataPa
 			require.True(t, requests.ContainsLocator(resultID, chunkIndex))
 
 			// invocation should be distinct per chunk ID
-			locatorID := chunks.ChunkLocatorID(resultID, chunkIndex)
+			locatorID := chunks.NewLocator(resultID, chunkIndex).ID()
 			_, ok = seen[locatorID]
 			require.False(t, ok)
 			seen[locatorID] = struct{}{}

--- a/engine/verification/requester/requester_test.go
+++ b/engine/verification/requester/requester_test.go
@@ -120,18 +120,13 @@ func TestHandleChunkDataPack_HappyPath(t *testing.T) {
 
 	// we remove pending request on receiving this response
 	locators := chunks.LocatorMap{}
-	locators[chunks.ChunkLocatorID(request.ResultID, request.Index)] = &chunks.Locator{
-		ResultID: request.ResultID,
-		Index:    request.Index,
-	}
+	locator := chunks.NewLocator(request.ResultID, request.Index)
+	locators[locator.ID()] = &locator
 	s.pendingRequests.On("PopAll", response.ChunkDataPack.ChunkID).Return(locators, true).Once()
 
 	s.handler.On("HandleChunkDataPack", originID, &verification.ChunkDataPackResponse{
-		Locator: chunks.Locator{
-			ResultID: request.ResultID,
-			Index:    request.Index,
-		},
-		Cdp: &response.ChunkDataPack,
+		Locator: chunks.NewLocator(request.ResultID, request.Index),
+		Cdp:     &response.ChunkDataPack,
 	}).Return().Once()
 	s.metrics.On("OnChunkDataPackResponseReceivedFromNetworkByRequester").Return().Once()
 	s.metrics.On("OnChunkDataPackSentToFetcher").Return().Once()

--- a/engine/verification/utils/unittest/helper.go
+++ b/engine/verification/utils/unittest/helper.go
@@ -347,10 +347,7 @@ func MockChunkAssignmentFixture(t *testing.T,
 
 			for _, chunk := range receipt.ExecutionResult.Chunks {
 				if isAssigned(chunk.Index, len(receipt.ExecutionResult.Chunks)) {
-					locatorID := chunks.Locator{
-						ResultID: receipt.ExecutionResult.ID(),
-						Index:    chunk.Index,
-					}.ID()
+					locatorID := chunks.NewLocator(receipt.ExecutionResult.ID(), chunk.Index).ID()
 					expectedLocatorIds = append(expectedLocatorIds, locatorID)
 					expectedChunkIds = append(expectedChunkIds, chunk.ID())
 					require.NoError(t, a.Add(chunk.Index, verIds.NodeIDs()))

--- a/model/chunks/chunkLocator.go
+++ b/model/chunks/chunkLocator.go
@@ -6,9 +6,23 @@ import (
 
 // Locator is used to locate a chunk by providing the execution result the chunk belongs to as well as the chunk index within that execution result.
 // Since a chunk is unique by the result ID and its index in the result's chunk list.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type Locator struct {
 	ResultID flow.Identifier // execution result id that chunk belongs to
 	Index    uint64          // index of chunk in the execution result
+}
+
+// NewLocator creates a new instance of Locator.
+// Construction Locator allowed only within the constructor.
+func NewLocator(
+	resultID flow.Identifier,
+	index uint64,
+) Locator {
+	return Locator{
+		ResultID: resultID,
+		Index:    index,
+	}
 }
 
 // ID returns a unique id for chunk locator.
@@ -24,10 +38,7 @@ func (c Locator) Checksum() flow.Identifier {
 // ChunkLocatorID is a util function that returns identifier of corresponding chunk locator to
 // the specified result and chunk index.
 func ChunkLocatorID(resultID flow.Identifier, chunkIndex uint64) flow.Identifier {
-	return Locator{
-		ResultID: resultID,
-		Index:    chunkIndex,
-	}.ID()
+	return NewLocator(resultID, chunkIndex).ID()
 }
 
 // LocatorMap maps keeps chunk locators based on their locator id.

--- a/model/chunks/chunkLocator.go
+++ b/model/chunks/chunkLocator.go
@@ -35,12 +35,6 @@ func (c Locator) Checksum() flow.Identifier {
 	return flow.MakeID(c)
 }
 
-// ChunkLocatorID is a util function that returns identifier of corresponding chunk locator to
-// the specified result and chunk index.
-func ChunkLocatorID(resultID flow.Identifier, chunkIndex uint64) flow.Identifier {
-	return NewLocator(resultID, chunkIndex).ID()
-}
-
 // LocatorMap maps keeps chunk locators based on their locator id.
 type LocatorMap map[flow.Identifier]*Locator
 

--- a/model/flow/protocol_state_test.go
+++ b/model/flow/protocol_state_test.go
@@ -66,11 +66,12 @@ func TestNewRichProtocolStateEntry(t *testing.T) {
 		}
 		minStateEntry := &flow.MinEpochStateEntry{
 			PreviousEpoch: nil,
-			CurrentEpoch: flow.EpochStateContainer{
-				SetupID:          setup.ID(),
-				CommitID:         currentEpochCommit.ID(),
-				ActiveIdentities: identities,
-			},
+			CurrentEpoch: flow.NewEpochStateContainer(
+				setup.ID(),
+				currentEpochCommit.ID(),
+				identities,
+				nil,
+			),
 			EpochFallbackTriggered: false,
 		}
 		stateEntry, err := flow.NewEpochStateEntry(

--- a/model/verification/chunkStatus.go
+++ b/model/verification/chunkStatus.go
@@ -17,7 +17,7 @@ func (s ChunkStatus) Chunk() *flow.Chunk {
 }
 
 func (s ChunkStatus) ChunkLocatorID() flow.Identifier {
-	return chunks.ChunkLocatorID(s.ExecutionResult.ID(), s.ChunkIndex)
+	return chunks.NewLocator(s.ExecutionResult.ID(), s.ChunkIndex).ID()
 }
 
 type ChunkStatusList []*ChunkStatus

--- a/module/mempool/stdmap/chunk_requests_test.go
+++ b/module/mempool/stdmap/chunk_requests_test.go
@@ -204,10 +204,7 @@ func TestAddingDuplicateChunkIDs(t *testing.T) {
 	// adding another request for the same tuple of (chunkID, resultID, chunkIndex)
 	// is deduplicated.
 	require.False(t, requests.Add(&verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: thisReq.ResultID,
-			Index:    thisReq.Index,
-		},
+		Locator: chunks.NewLocator(thisReq.ResultID, thisReq.Index),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID: thisReq.ChunkID,
 		},
@@ -215,10 +212,7 @@ func TestAddingDuplicateChunkIDs(t *testing.T) {
 
 	// adding another request for the same chunk ID but different result ID is stored.
 	otherReq := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: unittest.IdentifierFixture(),
-			Index:    thisReq.Index,
-		},
+		Locator: chunks.NewLocator(unittest.IdentifierFixture(), thisReq.Index),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID:   thisReq.ChunkID,
 			Agrees:    unittest.IdentifierListFixture(2),

--- a/module/mempool/stdmap/chunk_statuses.go
+++ b/module/mempool/stdmap/chunk_statuses.go
@@ -35,7 +35,8 @@ func chunkStatus(entity flow.Entity) *verification.ChunkStatus {
 // There is a one-to-one correspondence between the chunk statuses in memory, and
 // their pair of chunk index and result id.
 func (cs ChunkStatuses) Get(chunkIndex uint64, resultID flow.Identifier) (*verification.ChunkStatus, bool) {
-	entity, exists := cs.Backend.ByID(chunks.ChunkLocatorID(resultID, chunkIndex))
+	locator := chunks.NewLocator(resultID, chunkIndex)
+	entity, exists := cs.Backend.ByID(locator.ID())
 	if !exists {
 		return nil, false
 	}
@@ -60,7 +61,8 @@ func (cs *ChunkStatuses) Add(status *verification.ChunkStatus) bool {
 // If there is a chunk status associated with this pair, Remove removes it and returns true.
 // Otherwise, it returns false.
 func (cs *ChunkStatuses) Remove(chunkIndex uint64, resultID flow.Identifier) bool {
-	return cs.Backend.Remove(chunks.ChunkLocatorID(resultID, chunkIndex))
+	locator := chunks.NewLocator(resultID, chunkIndex)
+	return cs.Backend.Remove(locator.ID())
 }
 
 // All returns all chunk statuses stored in this memory pool.
@@ -94,9 +96,9 @@ type inMemChunkStatus struct {
 }
 
 func (s inMemChunkStatus) ID() flow.Identifier {
-	return chunks.ChunkLocatorID(s.ExecutionResult.ID(), s.ChunkIndex)
+	return chunks.NewLocator(s.ExecutionResult.ID(), s.ChunkIndex).ID()
 }
 
 func (s inMemChunkStatus) Checksum() flow.Identifier {
-	return chunks.ChunkLocatorID(s.ExecutionResult.ID(), s.ChunkIndex)
+	return chunks.NewLocator(s.ExecutionResult.ID(), s.ChunkIndex).ID()
 }

--- a/state/protocol/inmem/convert.go
+++ b/state/protocol/inmem/convert.go
@@ -193,11 +193,12 @@ func EpochProtocolStateFromServiceEvents(setup *flow.EpochSetup, commit *flow.Ep
 	}
 	return &flow.MinEpochStateEntry{
 		PreviousEpoch: nil,
-		CurrentEpoch: flow.EpochStateContainer{
-			SetupID:          setup.ID(),
-			CommitID:         commit.ID(),
-			ActiveIdentities: identities,
-		},
+		CurrentEpoch: flow.NewEpochStateContainer(
+			setup.ID(),
+			commit.ID(),
+			identities,
+			nil,
+		),
 		NextEpoch:              nil,
 		EpochFallbackTriggered: false,
 	}

--- a/state/protocol/inmem/epoch_protocol_state.go
+++ b/state/protocol/inmem/epoch_protocol_state.go
@@ -8,6 +8,8 @@ import (
 )
 
 // EpochProtocolStateAdapter implements protocol.EpochProtocolState by wrapping a flow.RichEpochStateEntry.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type EpochProtocolStateAdapter struct {
 	*flow.RichEpochStateEntry
 	params protocol.GlobalParams
@@ -15,6 +17,8 @@ type EpochProtocolStateAdapter struct {
 
 var _ protocol.EpochProtocolState = (*EpochProtocolStateAdapter)(nil)
 
+// NewEpochProtocolStateAdapter creates a new instance of EpochProtocolStateAdapter.
+// Construction EpochProtocolStateAdapter allowed only within the constructor.
 func NewEpochProtocolStateAdapter(entry *flow.RichEpochStateEntry, params protocol.GlobalParams) *EpochProtocolStateAdapter {
 	return &EpochProtocolStateAdapter{
 		RichEpochStateEntry: entry,

--- a/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
+++ b/state/protocol/protocol_state/epochs/fallback_statemachine_test.go
@@ -94,14 +94,16 @@ func (s *EpochFallbackStateMachineSuite) TestProcessEpochRecover() {
 	require.True(s.T(), hasChanges, "should have changes")
 	require.Equal(s.T(), updatedState.ID(), updatedStateID, "state ID should be equal to updated state ID")
 
+	nextEpoch := flow.NewEpochStateContainer(
+		epochRecover.EpochSetup.ID(),
+		epochRecover.EpochCommit.ID(),
+		flow.DynamicIdentityEntryListFromIdentities(nextEpochParticipants),
+		nil,
+	)
 	expectedState := &flow.MinEpochStateEntry{
-		PreviousEpoch: s.parentProtocolState.PreviousEpoch.Copy(),
-		CurrentEpoch:  s.parentProtocolState.CurrentEpoch,
-		NextEpoch: &flow.EpochStateContainer{
-			SetupID:          epochRecover.EpochSetup.ID(),
-			CommitID:         epochRecover.EpochCommit.ID(),
-			ActiveIdentities: flow.DynamicIdentityEntryListFromIdentities(nextEpochParticipants),
-		},
+		PreviousEpoch:          s.parentProtocolState.PreviousEpoch.Copy(),
+		CurrentEpoch:           s.parentProtocolState.CurrentEpoch,
+		NextEpoch:              &nextEpoch,
 		EpochFallbackTriggered: false,
 	}
 	require.Equal(s.T(), expectedState, updatedState.MinEpochStateEntry, "updatedState should be equal to expected one")
@@ -369,11 +371,12 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 
 		expectedProtocolState := &flow.MinEpochStateEntry{
 			PreviousEpoch: parentProtocolState.PreviousEpoch,
-			CurrentEpoch: flow.EpochStateContainer{
-				SetupID:          parentProtocolState.CurrentEpoch.SetupID,
-				CommitID:         parentProtocolState.CurrentEpoch.CommitID,
-				ActiveIdentities: parentProtocolState.CurrentEpoch.ActiveIdentities,
-			},
+			CurrentEpoch: flow.NewEpochStateContainer(
+				parentProtocolState.CurrentEpoch.SetupID,
+				parentProtocolState.CurrentEpoch.CommitID,
+				parentProtocolState.CurrentEpoch.ActiveIdentities,
+				nil,
+			),
 			NextEpoch:              nil,
 			EpochFallbackTriggered: true,
 		}
@@ -395,17 +398,17 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 
 		expectedProtocolState := &flow.MinEpochStateEntry{
 			PreviousEpoch: parentProtocolState.PreviousEpoch,
-			CurrentEpoch: flow.EpochStateContainer{
-				SetupID:          parentProtocolState.CurrentEpoch.SetupID,
-				CommitID:         parentProtocolState.CurrentEpoch.CommitID,
-				ActiveIdentities: parentProtocolState.CurrentEpoch.ActiveIdentities,
-				EpochExtensions: []flow.EpochExtension{
+			CurrentEpoch: flow.NewEpochStateContainer(
+				parentProtocolState.CurrentEpoch.SetupID,
+				parentProtocolState.CurrentEpoch.CommitID,
+				parentProtocolState.CurrentEpoch.ActiveIdentities,
+				[]flow.EpochExtension{
 					{
 						FirstView: parentProtocolState.CurrentEpochFinalView() + 1,
 						FinalView: parentProtocolState.CurrentEpochFinalView() + extensionViewCount,
 					},
 				},
-			},
+			),
 			NextEpoch:              nil,
 			EpochFallbackTriggered: true,
 		}
@@ -434,17 +437,17 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 
 		expectedProtocolState := &flow.MinEpochStateEntry{
 			PreviousEpoch: parentProtocolState.PreviousEpoch,
-			CurrentEpoch: flow.EpochStateContainer{
-				SetupID:          parentProtocolState.CurrentEpoch.SetupID,
-				CommitID:         parentProtocolState.CurrentEpoch.CommitID,
-				ActiveIdentities: parentProtocolState.CurrentEpoch.ActiveIdentities,
-				EpochExtensions: []flow.EpochExtension{
+			CurrentEpoch: flow.NewEpochStateContainer(
+				parentProtocolState.CurrentEpoch.SetupID,
+				parentProtocolState.CurrentEpoch.CommitID,
+				parentProtocolState.CurrentEpoch.ActiveIdentities,
+				[]flow.EpochExtension{
 					{
 						FirstView: parentProtocolState.CurrentEpochFinalView() + 1,
 						FinalView: parentProtocolState.CurrentEpochFinalView() + extensionViewCount,
 					},
 				},
-			},
+			),
 			NextEpoch:              nil,
 			EpochFallbackTriggered: true,
 		}
@@ -473,11 +476,12 @@ func (s *EpochFallbackStateMachineSuite) TestNewEpochFallbackStateMachine() {
 
 		expectedProtocolState := &flow.MinEpochStateEntry{
 			PreviousEpoch: parentProtocolState.PreviousEpoch,
-			CurrentEpoch: flow.EpochStateContainer{
-				SetupID:          parentProtocolState.CurrentEpoch.SetupID,
-				CommitID:         parentProtocolState.CurrentEpoch.CommitID,
-				ActiveIdentities: parentProtocolState.CurrentEpoch.ActiveIdentities,
-			},
+			CurrentEpoch: flow.NewEpochStateContainer(
+				parentProtocolState.CurrentEpoch.SetupID,
+				parentProtocolState.CurrentEpoch.CommitID,
+				parentProtocolState.CurrentEpoch.ActiveIdentities,
+				nil,
+			),
 			NextEpoch:              parentProtocolState.NextEpoch,
 			EpochFallbackTriggered: true,
 		}
@@ -552,12 +556,12 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 
 			expectedState := &flow.MinEpochStateEntry{
 				PreviousEpoch: originalParentState.PreviousEpoch,
-				CurrentEpoch: flow.EpochStateContainer{
-					SetupID:          originalParentState.CurrentEpoch.SetupID,
-					CommitID:         originalParentState.CurrentEpoch.CommitID,
-					ActiveIdentities: originalParentState.CurrentEpoch.ActiveIdentities,
-					EpochExtensions:  data.ExpectedExtensions,
-				},
+				CurrentEpoch: flow.NewEpochStateContainer(
+					originalParentState.CurrentEpoch.SetupID,
+					originalParentState.CurrentEpoch.CommitID,
+					originalParentState.CurrentEpoch.ActiveIdentities,
+					data.ExpectedExtensions,
+				),
 				NextEpoch:              nil,
 				EpochFallbackTriggered: true,
 			}
@@ -643,12 +647,12 @@ func (s *EpochFallbackStateMachineSuite) TestEpochFallbackStateMachineInjectsMul
 
 		expectedState := &flow.MinEpochStateEntry{
 			PreviousEpoch: originalParentState.CurrentEpoch.Copy(),
-			CurrentEpoch: flow.EpochStateContainer{
-				SetupID:          originalParentState.NextEpoch.SetupID,
-				CommitID:         originalParentState.NextEpoch.CommitID,
-				ActiveIdentities: originalParentState.NextEpoch.ActiveIdentities,
-				EpochExtensions:  data.ExpectedExtensions,
-			},
+			CurrentEpoch: flow.NewEpochStateContainer(
+				originalParentState.NextEpoch.SetupID,
+				originalParentState.NextEpoch.CommitID,
+				originalParentState.NextEpoch.ActiveIdentities,
+				data.ExpectedExtensions,
+			),
 			NextEpoch:              nil,
 			EpochFallbackTriggered: true,
 		}

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1371,25 +1371,18 @@ func ChunkLocatorListFixture(n uint) chunks.LocatorList {
 	locators := chunks.LocatorList{}
 	resultID := IdentifierFixture()
 	for i := uint64(0); i < uint64(n); i++ {
-		locator := ChunkLocatorFixture(resultID, i)
-		locators = append(locators, locator)
+		locator := chunks.NewLocator(resultID, i)
+		locators = append(locators, &locator)
 	}
 	return locators
-}
-
-func ChunkLocatorFixture(resultID flow.Identifier, index uint64) *chunks.Locator {
-	return &chunks.Locator{
-		ResultID: resultID,
-		Index:    index,
-	}
 }
 
 // ChunkStatusListToChunkLocatorFixture extracts chunk locators from a list of chunk statuses.
 func ChunkStatusListToChunkLocatorFixture(statuses []*verification.ChunkStatus) chunks.LocatorMap {
 	locators := chunks.LocatorMap{}
 	for _, status := range statuses {
-		locator := ChunkLocatorFixture(status.ExecutionResult.ID(), status.ChunkIndex)
-		locators[locator.ID()] = locator
+		locator := chunks.NewLocator(status.ExecutionResult.ID(), status.ChunkIndex)
+		locators[locator.ID()] = &locator
 	}
 
 	return locators
@@ -1700,10 +1693,7 @@ func ChunkDataPackRequestFixture(opts ...func(*verification.ChunkDataPackRequest
 	ChunkDataPackRequest {
 
 	req := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
-			ResultID: IdentifierFixture(),
-			Index:    0,
-		},
+		Locator: chunks.NewLocator(IdentifierFixture(), 0),
 		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
 			ChunkID:   IdentifierFixture(),
 			Height:    0,


### PR DESCRIPTION
Please note that the `cachedID` functionality has not yet been implemented for these types. The common `cachedID` functionality is in progress (PR https://github.com/onflow/flow-go/pull/7330), but this pull request is ready for review removing non-constructor mutations.

Closes: #7294, #7307, #7276

## Context

In this PR were added constructors for `EpochStateContainer`, `EpochProtocolStateAdapter` and `Locator` structs and removed non-constructor mutations for those structs.