### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for Chunk, ChunkDataPack and ExecutionResult structs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,12 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
+    - path: 'engine/execution/testutil/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/model/chunks/chunks.go
+++ b/model/chunks/chunks.go
@@ -8,10 +8,16 @@ import (
 // the commit
 func ChunkListFromCommit(commit flow.StateCommitment) flow.ChunkList {
 	chunks := flow.ChunkList{}
-	chunk := &flow.Chunk{
-		Index:    0,
-		EndState: commit,
-	}
+	chunk := flow.NewChunk(
+		flow.Identifier{},
+		0,
+		flow.StateCommitment{},
+		0,
+		flow.Identifier{},
+		0,
+		commit,
+		0,
+	)
 	chunks.Insert(chunk)
 
 	return chunks

--- a/model/flow/chunk.go
+++ b/model/flow/chunk.go
@@ -127,6 +127,7 @@ func (ch ChunkBody) EncodeRLP(w io.Writer) error {
 	return nil
 }
 
+//structwrite:immutable - mutations allowed only within the constructor
 type Chunk struct {
 	ChunkBody
 
@@ -137,7 +138,7 @@ type Chunk struct {
 
 // We TEMPORARILY implement the [rlp.Encoder] interface to implement backwards-compatible ID computation.
 // TODO(mainnet27, #6773): remove EncodeRLP methods on Chunk and ChunkBody https://github.com/onflow/flow-go/issues/6773
-var _ rlp.Encoder = &Chunk{}
+var _ rlp.Encoder = (*Chunk)(nil)
 
 // EncodeRLP defines custom encoding logic for the Chunk type.
 // This method exists only so that the embedded ChunkBody's EncodeRLP method is


### PR DESCRIPTION
closes: https://github.com/onflow/flow-go/issues/7279 https://github.com/onflow/flow-go/issues/7280 https://github.com/onflow/flow-go/issues/7290

## Context
In this PR were added constructor for `Chunk`, `ChunkDataPack` and `ExecutionResult` structs and removed non-constructor mutations for those structs.