### PR TITLE
[Storage] Optimize iteration and seeking with BadgerDB

### DIFF
--- a/storage/operation/badgerimpl/iterator.go
+++ b/storage/operation/badgerimpl/iterator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation"
 )
 
 type badgerIterator struct {
@@ -23,6 +24,7 @@ func newBadgerIterator(db *badger.DB, startPrefix, endPrefix []byte, ops storage
 	if ops.BadgerIterateKeyOnly {
 		options.PrefetchValues = false
 	}
+	options.Prefix = operation.CommonPrefix(startPrefix, endPrefix)
 
 	tx := db.NewTransaction(false)
 	iter := tx.NewIterator(options)

--- a/storage/operation/badgerimpl/seeker.go
+++ b/storage/operation/badgerimpl/seeker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dgraph-io/badger/v2"
 
 	"github.com/onflow/flow-go/storage"
+	"github.com/onflow/flow-go/storage/operation"
 )
 
 type badgerSeeker struct {
@@ -32,6 +33,7 @@ func (i *badgerSeeker) SeekLE(startPrefix, key []byte) ([]byte, error) {
 	options := badger.DefaultIteratorOptions
 	options.PrefetchValues = false
 	options.Reverse = true
+	options.Prefix = operation.CommonPrefix(startPrefix, key)
 
 	tx := i.db.NewTransaction(false)
 	iter := tx.NewIterator(options)

--- a/storage/operation/reads.go
+++ b/storage/operation/reads.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/vmihailenco/msgpack/v4"
 
@@ -234,4 +235,27 @@ func FindHighestAtOrBelowByPrefix(r storage.Reader, prefix []byte, height uint64
 	}
 
 	return nil
+}
+
+// CommonPrefix returns common prefix of startPrefix and endPrefix.
+// The common prefix is used to narrow down the SSTables that
+// BadgerDB's iterator picks up.
+func CommonPrefix(startPrefix, endPrefix []byte) []byte {
+	commonPrefixMaxLength := min(
+		len(startPrefix),
+		len(endPrefix),
+	)
+
+	commonPrefixLength := commonPrefixMaxLength
+	for i := range commonPrefixMaxLength {
+		if startPrefix[i] != endPrefix[i] {
+			commonPrefixLength = i
+			break
+		}
+	}
+
+	if commonPrefixLength == 0 {
+		return nil
+	}
+	return slices.Clone(startPrefix[:commonPrefixLength])
 }

--- a/storage/operation/reads_test.go
+++ b/storage/operation/reads_test.go
@@ -408,3 +408,26 @@ func TestFindHighestAtOrBelow(t *testing.T) {
 		}
 	})
 }
+
+func TestCommonPrefix(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		startPrefix          []byte
+		endPrefix            []byte
+		expectedCommonPrefix []byte
+	}{
+		{name: "both nil", expectedCommonPrefix: []byte(nil)},
+		{name: "startPrefix nil", endPrefix: []byte{0x00, 0x01}, expectedCommonPrefix: []byte(nil)},
+		{name: "identical", startPrefix: []byte{0x00, 0x01}, endPrefix: []byte{0x00, 0x01}, expectedCommonPrefix: []byte{0x00, 0x01}},
+		{name: "substring", startPrefix: []byte{0x00}, endPrefix: []byte{0x00, 0x01}, expectedCommonPrefix: []byte{0x00}},
+		{name: "has common prefix", startPrefix: []byte{0x00, 0x01, 0x02}, endPrefix: []byte{0x00, 0x01, 0x03}, expectedCommonPrefix: []byte{0x00, 0x01}},
+		{name: "no common prefix", startPrefix: []byte{0x00, 0x01}, endPrefix: []byte{0x02, 0x01}, expectedCommonPrefix: []byte(nil)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			commonPrefix := operation.CommonPrefix(tc.startPrefix, tc.endPrefix)
+			require.Equal(t, tc.expectedCommonPrefix, commonPrefix)
+		})
+	}
+}


### PR DESCRIPTION
Currently, `Iterator` and `Seeker` causes BadgerDB to needlessly create an iterator for every SSTables even for SSTables that don't contain required data.

This PR sets `IterationOptions.Prefix` for Iterator and Seeker in badgerimpl.  Prefix is used to narrow down the SSTables that iterator picks up.  This can speed up creating and closing BadgerDB iterators for databases that have many SSTables.

BadgerDB docs for `IterationOptions.Prefix` says:

```Go
// The following option is used to narrow down the SSTables that iterator picks up. If
// Prefix is specified, only tables which could have this prefix are picked based on their range
// of keys.
Prefix []byte // Only iterate over this given prefix.
```

I found this by taking a look at the profiling data related to version beacon.