### PR TITLE
[Malleability Immutable] Removed non-constructor mutations for ChunkDataPackRequest and ChunkDataPackResponse

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,9 @@ issues:
       linters:
         - unused
         - structwrite
+    - path: 'utils/unittest/*' # disable some linters on test files
+      linters:
+        - structwrite
     # typecheck currently not handling the way we do function inheritance well
     # disabling for now
     - path: 'cmd/access/node_build/*'

--- a/engine/verification/fetcher/engine.go
+++ b/engine/verification/fetcher/engine.go
@@ -572,21 +572,21 @@ func (e *Engine) requestChunkDataPack(chunkIndex uint64, chunkID flow.Identifier
 		return fmt.Errorf("could not fetch execution node ids at block %x: %w", blockID, err)
 	}
 
-	request := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
+	request := verification.NewChunkDataPackRequest(
+		chunks.Locator{
 			ResultID: resultID,
 			Index:    chunkIndex,
 		},
-		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
+		verification.ChunkDataPackRequestInfo{
 			ChunkID:   chunkID,
 			Height:    header.Height,
 			Agrees:    agrees,
 			Disagrees: disagrees,
 			Targets:   allExecutors,
 		},
-	}
+	)
 
-	e.requester.Request(request)
+	e.requester.Request(&request)
 
 	return nil
 }

--- a/engine/verification/fetcher/engine_test.go
+++ b/engine/verification/fetcher/engine_test.go
@@ -953,24 +953,27 @@ func chunkRequestsFixture(
 //
 // Agrees and disagrees are the list of execution node identifiers that generate the same and contradicting execution result
 // with the execution result that chunks belong to, respectively.
-func chunkRequestFixture(resultID flow.Identifier,
+func chunkRequestFixture(
+	resultID flow.Identifier,
 	status *verification.ChunkStatus,
 	agrees flow.IdentityList,
-	disagrees flow.IdentityList) *verification.ChunkDataPackRequest {
+	disagrees flow.IdentityList,
+) *verification.ChunkDataPackRequest {
 
-	return &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
+	request := verification.NewChunkDataPackRequest(
+		chunks.Locator{
 			ResultID: resultID,
 			Index:    status.ChunkIndex,
 		},
-		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
+		verification.ChunkDataPackRequestInfo{
 			ChunkID:   status.Chunk().ID(),
 			Height:    status.BlockHeight,
 			Agrees:    agrees.NodeIDs(),
 			Disagrees: disagrees.NodeIDs(),
 			Targets:   agrees.Union(disagrees),
 		},
-	}
+	)
+	return &request
 }
 
 // completeChunkStatusListFixture creates a reference block with an execution result associated with it.

--- a/engine/verification/fetcher/engine_test.go
+++ b/engine/verification/fetcher/engine_test.go
@@ -875,15 +875,16 @@ func chunkDataPackResponseFixture(t *testing.T,
 
 	require.Equal(t, collection != nil, !convert.IsSystemChunk(chunk.Index, result), "only non-system chunks must have a collection")
 
-	return &verification.ChunkDataPackResponse{
-		Locator: chunks.Locator{
+	response := verification.NewChunkDataPackResponse(
+		chunks.Locator{
 			ResultID: result.ID(),
 			Index:    chunk.Index,
 		},
-		Cdp: unittest.ChunkDataPackFixture(chunk.ID(),
+		unittest.ChunkDataPackFixture(chunk.ID(),
 			unittest.WithStartState(chunk.StartState),
 			unittest.WithChunkDataPackCollection(collection)),
-	}
+	)
+	return &response
 }
 
 // verifiableChunksFixture is a test helper that creates verifiable chunks and chunk data responses.

--- a/engine/verification/requester/requester.go
+++ b/engine/verification/requester/requester.go
@@ -198,10 +198,10 @@ func (e *Engine) handleChunkDataPack(originID flow.Identifier, chunkDataPack *fl
 	}
 
 	for _, locator := range locators {
-		response := verification.ChunkDataPackResponse{
-			Locator: *locator,
-			Cdp:     chunkDataPack,
-		}
+		response := verification.NewChunkDataPackResponse(
+			*locator,
+			chunkDataPack,
+		)
 
 		e.handler.HandleChunkDataPack(originID, &response)
 		e.metrics.OnChunkDataPackSentToFetcher()

--- a/engine/verification/requester/requester_test.go
+++ b/engine/verification/requester/requester_test.go
@@ -126,13 +126,14 @@ func TestHandleChunkDataPack_HappyPath(t *testing.T) {
 	}
 	s.pendingRequests.On("PopAll", response.ChunkDataPack.ChunkID).Return(locators, true).Once()
 
-	s.handler.On("HandleChunkDataPack", originID, &verification.ChunkDataPackResponse{
-		Locator: chunks.Locator{
+	chunkDataPackResponse := verification.NewChunkDataPackResponse(
+		chunks.Locator{
 			ResultID: request.ResultID,
 			Index:    request.Index,
 		},
-		Cdp: &response.ChunkDataPack,
-	}).Return().Once()
+		&response.ChunkDataPack,
+	)
+	s.handler.On("HandleChunkDataPack", originID, &chunkDataPackResponse).Return().Once()
 	s.metrics.On("OnChunkDataPackResponseReceivedFromNetworkByRequester").Return().Once()
 	s.metrics.On("OnChunkDataPackSentToFetcher").Return().Once()
 

--- a/model/verification/chunkDataPackRequest.go
+++ b/model/verification/chunkDataPackRequest.go
@@ -10,9 +10,23 @@ import (
 
 // ChunkDataPackRequest is an internal data structure in fetcher engine that is passed between the engine
 // and requester module. It conveys required information for requesting a chunk data pack.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type ChunkDataPackRequest struct {
 	chunks.Locator // uniquely identifies chunk
 	ChunkDataPackRequestInfo
+}
+
+// NewChunkDataPackRequest creates a new instance of ChunkDataPackRequest.
+// Construction ChunkDataPackRequest allowed only within the constructor.
+func NewChunkDataPackRequest(
+	locator chunks.Locator,
+	chunkDataPackRequestInfo ChunkDataPackRequestInfo,
+) ChunkDataPackRequest {
+	return ChunkDataPackRequest{
+		Locator:                  locator,
+		ChunkDataPackRequestInfo: chunkDataPackRequestInfo,
+	}
 }
 
 type ChunkDataPackRequestInfo struct {

--- a/model/verification/chunkDataPackResponse.go
+++ b/model/verification/chunkDataPackResponse.go
@@ -8,7 +8,21 @@ import (
 // ChunkDataPackResponse is an internal data structure in fetcher engine that is passed between the fetcher
 // and requester engine. It conveys requested chunk data pack as well as meta-data for fetcher engine to
 // process the chunk data pack.
+//
+//structwrite:immutable - mutations allowed only within the constructor
 type ChunkDataPackResponse struct {
 	chunks.Locator
 	Cdp *flow.ChunkDataPack
+}
+
+// NewChunkDataPackResponse creates a new instance of ChunkDataPackResponse.
+// Construction ChunkDataPackResponse allowed only within the constructor.
+func NewChunkDataPackResponse(
+	locator chunks.Locator,
+	cdp *flow.ChunkDataPack,
+) ChunkDataPackResponse {
+	return ChunkDataPackResponse{
+		Locator: locator,
+		Cdp:     cdp,
+	}
 }

--- a/module/mempool/stdmap/chunk_requests_test.go
+++ b/module/mempool/stdmap/chunk_requests_test.go
@@ -203,29 +203,30 @@ func TestAddingDuplicateChunkIDs(t *testing.T) {
 
 	// adding another request for the same tuple of (chunkID, resultID, chunkIndex)
 	// is deduplicated.
-	require.False(t, requests.Add(&verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
+	request := verification.NewChunkDataPackRequest(
+		chunks.Locator{
 			ResultID: thisReq.ResultID,
 			Index:    thisReq.Index,
 		},
-		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
+		verification.ChunkDataPackRequestInfo{
 			ChunkID: thisReq.ChunkID,
 		},
-	}))
+	)
+	require.False(t, requests.Add(&request))
 
 	// adding another request for the same chunk ID but different result ID is stored.
-	otherReq := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
+	otherReq := verification.NewChunkDataPackRequest(
+		chunks.Locator{
 			ResultID: unittest.IdentifierFixture(),
 			Index:    thisReq.Index,
 		},
-		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
+		verification.ChunkDataPackRequestInfo{
 			ChunkID:   thisReq.ChunkID,
 			Agrees:    unittest.IdentifierListFixture(2),
 			Disagrees: unittest.IdentifierListFixture(2),
 		},
-	}
-	require.True(t, requests.Add(otherReq))
+	)
+	require.True(t, requests.Add(&otherReq))
 
 	// mempool size is based on unique chunk ids, and we only store one
 	// chunk id.

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -1699,21 +1699,21 @@ func WithChunkID(chunkID flow.Identifier) func(*verification.ChunkDataPackReques
 func ChunkDataPackRequestFixture(opts ...func(*verification.ChunkDataPackRequest)) *verification.
 	ChunkDataPackRequest {
 
-	req := &verification.ChunkDataPackRequest{
-		Locator: chunks.Locator{
+	req := verification.NewChunkDataPackRequest(
+		chunks.Locator{
 			ResultID: IdentifierFixture(),
 			Index:    0,
 		},
-		ChunkDataPackRequestInfo: verification.ChunkDataPackRequestInfo{
+		verification.ChunkDataPackRequestInfo{
 			ChunkID:   IdentifierFixture(),
 			Height:    0,
 			Agrees:    IdentifierListFixture(1),
 			Disagrees: IdentifierListFixture(1),
 		},
-	}
+	)
 
 	for _, opt := range opts {
-		opt(req)
+		opt(&req)
 	}
 
 	// creates identity fixtures for target ids as union of agrees and disagrees
@@ -1728,7 +1728,7 @@ func ChunkDataPackRequestFixture(opts ...func(*verification.ChunkDataPackRequest
 
 	req.Targets = targets
 
-	return req
+	return &req
 }
 
 func WithChunkDataPackCollection(collection *flow.Collection) func(*flow.ChunkDataPack) {


### PR DESCRIPTION
Please note that the `cachedID` functionality has not yet been implemented for these types. The common `cachedID` functionality is in progress, but this pull request is ready for review removing non-constructor mutations.

Closes: #7305, #7306

## Context

In this PR were added constructors for `ChunkDataPackRequest` and `ChunkDataPackResponse` structs and removed non-constructor mutations for those structs.