### PR TITLE
[Execution] Disable halfway data migration from badger to pebble

### DIFF
--- a/cmd/execution_builder.go
+++ b/cmd/execution_builder.go
@@ -54,7 +54,6 @@ import (
 	"github.com/onflow/flow-go/engine/execution/ingestion/fetcher"
 	"github.com/onflow/flow-go/engine/execution/ingestion/stop"
 	"github.com/onflow/flow-go/engine/execution/ingestion/uploader"
-	"github.com/onflow/flow-go/engine/execution/migration"
 	exeprovider "github.com/onflow/flow-go/engine/execution/provider"
 	exepruner "github.com/onflow/flow-go/engine/execution/pruner"
 	"github.com/onflow/flow-go/engine/execution/rpc"
@@ -224,7 +223,6 @@ func (builder *ExecutionNodeBuilder) LoadComponentsAndModules() {
 		Module("blobservice peer manager dependencies", exeNode.LoadBlobservicePeerManagerDependencies).
 		Module("bootstrap", exeNode.LoadBootstrapper).
 		Module("register store", exeNode.LoadRegisterStore).
-		Module("migrate last executed block", exeNode.MigrateLastSealedExecutedResultToPebble).
 		AdminCommand("get-transactions", func(conf *NodeConfig) commands.AdminCommand {
 			return storageCommands.NewGetTransactionsCommand(conf.State, conf.Storage.Payloads, exeNode.collections)
 		}).
@@ -753,16 +751,6 @@ func (exeNode *ExecutionNode) LoadBlobservicePeerManagerDependencies(node *NodeC
 func (exeNode *ExecutionNode) LoadExecutionDataGetter(node *NodeConfig) error {
 	exeNode.executionDataBlobstore = blobs.NewBlobstore(exeNode.executionDataDatastore)
 	exeNode.executionDataStore = execution_data.NewExecutionDataStore(exeNode.executionDataBlobstore, execution_data.DefaultSerializer)
-	return nil
-}
-
-func (exeNode *ExecutionNode) MigrateLastSealedExecutedResultToPebble(node *NodeConfig) error {
-	// Migrate the last sealed executed
-	err := migration.MigrateLastSealedExecutedResultToPebble(node.Logger, node.DB, node.PebbleDB, node.State, node.RootSeal)
-	if err != nil {
-		return fmt.Errorf("could not migrate last sealed executed result to pebble: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Remove the badger to pebble halfway data migration for execution node.

"halfway" means, it only migrate a subset of data from badger to pebble, such as last executed block. This was suppose to allow EN to switch to pebble storage after a restart without a complete badger -> pebble data migration. However, as the [protocol data refactor is close to complete](https://github.com/onflow/flow-go/pulls/zhangchiqing), as well as [the migration util ](https://github.com/onflow/flow-go/pull/7413) , we can probably either do a dynamic bootstrapping or data migration to switch the storage from badger to pebble for EN's protocol database. This simply the logic, since the data is only stored in one place - either badger or pebble, therefore, we don't need the chained storage which queries both storages. 