### PR TITLE
[Access] Add compatilbility override for v0.41.4 - v0.41

### DIFF
--- a/engine/common/version/version_control.go
+++ b/engine/common/version/version_control.go
@@ -47,6 +47,7 @@ var defaultCompatibilityOverrides = map[string]struct{}{
 	"0.38.2":  {}, // mainnet, testnet
 	"0.38.3":  {}, // mainnet, testnet
 	"0.40.0":  {}, // mainnet, testnet
+	"0.41.4":  {}, // mainnet, testnet
 }
 
 // VersionControl manages the version control system for the node.


### PR DESCRIPTION
Add compatibility override for v0.41.4 which was missing when the private repo changes were merged.