### PR TITLE
[Malleability ] BlockFixture refactoring

### DIFF
--- a/admin/commands/storage/backfill_tx_error_messages_test.go
+++ b/admin/commands/storage/backfill_tx_error_messages_test.go
@@ -57,7 +57,7 @@ type BackfillTxErrorMessagesSuite struct {
 
 	blockHeadersMap map[uint64]*flow.Header
 
-	nodeRootBlock flow.Block
+	nodeRootBlock *flow.Block
 	sealedBlock   *flow.Block
 	blockCount    int
 }
@@ -79,8 +79,9 @@ func (suite *BackfillTxErrorMessagesSuite) SetupTest() {
 
 	suite.blockCount = 5
 	suite.blockHeadersMap = make(map[uint64]*flow.Header, suite.blockCount)
-	suite.nodeRootBlock = unittest.BlockFixture()
-	suite.nodeRootBlock.Header.Height = 0
+	suite.nodeRootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 	suite.blockHeadersMap[suite.nodeRootBlock.Header.Height] = suite.nodeRootBlock.ToHeader()
 
 	parent := suite.nodeRootBlock.ToHeader()

--- a/cmd/util/cmd/export-json-transactions/transactions/range_test.go
+++ b/cmd/util/cmd/export-json-transactions/transactions/range_test.go
@@ -23,27 +23,37 @@ func TestFindBlockTransactions(t *testing.T) {
 		col2 := unittest.ClusterPayloadFixture(2)
 		col3 := unittest.ClusterPayloadFixture(3)
 
-		b1 := unittest.BlockFixture()
-		b1.Payload.Guarantees = []*flow.CollectionGuarantee{
-			&flow.CollectionGuarantee{
-				CollectionID:     col1.Collection.ID(),
-				ReferenceBlockID: col1.ReferenceBlockID,
-			},
-			&flow.CollectionGuarantee{
-				CollectionID:     col2.Collection.ID(),
-				ReferenceBlockID: col2.ReferenceBlockID,
-			},
-		}
-		b1.Header.Height = 4
+		b1 := unittest.BlockFixture(
+			unittest.Block.WithHeight(4),
+			unittest.Block.WithPayload(
+				flow.Payload{
+					Guarantees: []*flow.CollectionGuarantee{
+						&flow.CollectionGuarantee{
+							CollectionID:     col1.Collection.ID(),
+							ReferenceBlockID: col1.ReferenceBlockID,
+						},
+						&flow.CollectionGuarantee{
+							CollectionID:     col2.Collection.ID(),
+							ReferenceBlockID: col2.ReferenceBlockID,
+						},
+					},
+				},
+			),
+		)
 
-		b2 := unittest.BlockFixture()
-		b2.Payload.Guarantees = []*flow.CollectionGuarantee{
-			&flow.CollectionGuarantee{
-				CollectionID:     col3.Collection.ID(),
-				ReferenceBlockID: col3.ReferenceBlockID,
-			},
-		}
-		b1.Header.Height = 5
+		b2 := unittest.BlockFixture(
+			unittest.Block.WithHeight(5),
+			unittest.Block.WithPayload(
+				flow.Payload{
+					Guarantees: []*flow.CollectionGuarantee{
+						&flow.CollectionGuarantee{
+							CollectionID:     col3.Collection.ID(),
+							ReferenceBlockID: col3.ReferenceBlockID,
+						},
+					},
+				},
+			),
+		)
 
 		// prepare dependencies
 		storages := common.InitStorages(db)

--- a/consensus/hotstuff/signature/block_signer_decoder_test.go
+++ b/consensus/hotstuff/signature/block_signer_decoder_test.go
@@ -26,7 +26,7 @@ type blockSignerDecoderSuite struct {
 	committee    *hotstuff.DynamicCommittee
 
 	decoder *BlockSignerDecoder
-	block   flow.Block
+	block   *flow.Block
 }
 
 func (s *blockSignerDecoderSuite) SetupTest() {

--- a/consensus/hotstuff/verification/combined_signer_v2_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v2_test.go
@@ -33,11 +33,12 @@ func TestCombinedSignWithBeaconKey(t *testing.T) {
 	proposerView := uint64(20)
 
 	proposerIdentity := identities[0]
-	fblock := unittest.BlockFixture()
-	fblock.Header.ProposerID = proposerIdentity.NodeID
-	fblock.Header.View = proposerView
-	fblock.Header.ParentView = proposerView - 1
-	fblock.Header.LastViewTC = nil
+	fblock := unittest.BlockFixture(
+		unittest.Block.WithParent(unittest.IdentifierFixture(), proposerView-1, 0),
+		unittest.Block.WithView(proposerView),
+		unittest.Block.WithProposerID(proposerIdentity.NodeID),
+		unittest.Block.WithLastViewTC(nil),
+	)
 	proposal := model.ProposalFromFlow(fblock.ToHeader())
 	signerID := fblock.Header.ProposerID
 
@@ -142,10 +143,11 @@ func TestCombinedSignWithNoBeaconKey(t *testing.T) {
 	pk := beaconKey.PublicKey()
 	proposerView := uint64(20)
 
-	fblock := unittest.BlockFixture()
-	fblock.Header.View = proposerView
-	fblock.Header.ParentView = proposerView - 1
-	fblock.Header.LastViewTC = nil
+	fblock := unittest.BlockFixture(
+		unittest.Block.WithParent(unittest.IdentifierFixture(), proposerView-1, 0),
+		unittest.Block.WithView(proposerView),
+		unittest.Block.WithLastViewTC(nil),
+	)
 	proposal := model.ProposalFromFlow(fblock.ToHeader())
 	signerID := fblock.Header.ProposerID
 

--- a/consensus/hotstuff/verification/combined_signer_v3_test.go
+++ b/consensus/hotstuff/verification/combined_signer_v3_test.go
@@ -31,8 +31,9 @@ func TestCombinedSignWithBeaconKeyV3(t *testing.T) {
 	pk := beaconKey.PublicKey()
 	proposerView := uint64(20)
 
-	fblock := unittest.BlockFixture()
-	fblock.Header.View = proposerView
+	fblock := unittest.BlockFixture(
+		unittest.Block.WithView(proposerView),
+	)
 	block := model.BlockFromFlow(fblock.ToHeader())
 	signerID := fblock.Header.ProposerID
 
@@ -90,8 +91,9 @@ func TestCombinedSignWithNoBeaconKeyV3(t *testing.T) {
 	pk := beaconKey.PublicKey()
 	proposerView := uint64(20)
 
-	fblock := unittest.BlockFixture()
-	fblock.Header.View = proposerView
+	fblock := unittest.BlockFixture(
+		unittest.Block.WithView(proposerView),
+	)
 	block := model.BlockFromFlow(fblock.ToHeader())
 	signerID := fblock.Header.ProposerID
 

--- a/engine/access/access_test.go
+++ b/engine/access/access_test.go
@@ -385,11 +385,11 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 
 		// test block1 get by ID
 		block1 := unittest.BlockFixture()
-		proposal1 := unittest.ProposalFromBlock(&block1)
+		proposal1 := unittest.ProposalFromBlock(block1)
 		// test block2 get by height
 		block2 := unittest.BlockFixture()
 		block2.Header.Height = 2
-		proposal2 := unittest.ProposalFromBlock(&block2)
+		proposal2 := unittest.ProposalFromBlock(block2)
 
 		require.NoError(suite.T(), all.Blocks.Store(proposal1))
 		require.NoError(suite.T(), all.Blocks.Store(proposal2))
@@ -466,7 +466,7 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 
 			resp, err := handler.GetBlockByID(context.Background(), req)
 
-			assertBlockResp(resp, err, &block1)
+			assertBlockResp(resp, err, block1)
 		})
 
 		suite.Run("get block light 1 by ID", func() {
@@ -478,7 +478,7 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 
 			resp, err := handler.GetBlockByID(context.Background(), req)
 
-			assertLightBlockResp(resp, err, &block1)
+			assertLightBlockResp(resp, err, block1)
 		})
 
 		suite.Run("get header 2 by height", func() {
@@ -502,7 +502,7 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 
 			resp, err := handler.GetBlockByHeight(context.Background(), req)
 
-			assertBlockResp(resp, err, &block2)
+			assertBlockResp(resp, err, block2)
 		})
 
 		suite.Run("get block 2 by height", func() {
@@ -513,7 +513,7 @@ func (suite *Suite) TestGetBlockByIDAndHeight() {
 
 			resp, err := handler.GetBlockByHeight(context.Background(), req)
 
-			assertLightBlockResp(resp, err, &block2)
+			assertLightBlockResp(resp, err, block2)
 		})
 	})
 }

--- a/engine/access/ingestion/engine_test.go
+++ b/engine/access/ingestion/engine_test.go
@@ -67,7 +67,7 @@ type Suite struct {
 	finalizedBlock *flow.Header
 	log            zerolog.Logger
 	blockMap       map[uint64]*flow.Block
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 
 	collectionExecutedMetric *indexer.CollectionExecutedMetricImpl
 
@@ -137,8 +137,9 @@ func (s *Suite) SetupTest() {
 
 	blockCount := 5
 	s.blockMap = make(map[uint64]*flow.Block, blockCount)
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 	parent := s.rootBlock.ToHeader()
 
 	for i := 0; i < blockCount; i++ {
@@ -219,7 +220,7 @@ func (s *Suite) initIngestionEngine(ctx irrecoverable.SignalerContext) *Engine {
 }
 
 // mockCollectionsForBlock mocks collections for block
-func (s *Suite) mockCollectionsForBlock(block flow.Block) {
+func (s *Suite) mockCollectionsForBlock(block *flow.Block) {
 	// we should query the block once and index the guarantee payload once
 	for _, g := range block.Payload.Guarantees {
 		collection := unittest.CollectionFixture(1)
@@ -229,7 +230,7 @@ func (s *Suite) mockCollectionsForBlock(block flow.Block) {
 }
 
 // generateBlock prepares block with payload and specified guarantee.SignerIndices
-func (s *Suite) generateBlock(clusterCommittee flow.IdentitySkeletonList, snap *protocol.Snapshot) flow.Block {
+func (s *Suite) generateBlock(clusterCommittee flow.IdentitySkeletonList, snap *protocol.Snapshot) *flow.Block {
 	block := unittest.BlockFixture(
 		unittest.Block.WithPayload(unittest.PayloadFixture(
 			unittest.WithGuarantees(unittest.CollectionGuaranteesFixture(4)...),
@@ -273,7 +274,7 @@ func (s *Suite) TestOnFinalizedBlockSingle() {
 
 	block := s.generateBlock(clusterCommittee, snap)
 	block.Header.Height = s.finalizedBlock.Height + 1
-	s.blockMap[block.Header.Height] = &block
+	s.blockMap[block.Header.Height] = block
 	s.mockCollectionsForBlock(block)
 	s.finalizedBlock = block.ToHeader()
 
@@ -329,13 +330,13 @@ func (s *Suite) TestOnFinalizedBlockSeveralBlocksAhead() {
 
 	newBlocksCount := 3
 	startHeight := s.finalizedBlock.Height + 1
-	blocks := make([]flow.Block, newBlocksCount)
+	blocks := make([]*flow.Block, newBlocksCount)
 
 	// generate the test blocks, cgs and collections
 	for i := 0; i < newBlocksCount; i++ {
 		block := s.generateBlock(clusterCommittee, snap)
 		block.Header.Height = startHeight + uint64(i)
-		s.blockMap[block.Header.Height] = &block
+		s.blockMap[block.Header.Height] = block
 		blocks[i] = block
 		s.mockCollectionsForBlock(block)
 		s.finalizedBlock = block.ToHeader()
@@ -517,7 +518,7 @@ func (s *Suite) TestRequestMissingCollections() {
 			unittest.Block.WithPayload(unittest.PayloadFixture(
 				unittest.WithGuarantees(unittest.CollectionGuaranteesFixture(4, unittest.WithCollRef(refBlockID))...)),
 			))
-		s.blockMap[block.Header.Height] = &block
+		s.blockMap[block.Header.Height] = block
 		s.finalizedBlock = block.ToHeader()
 
 		for _, c := range block.Payload.Guarantees {
@@ -633,7 +634,7 @@ func (s *Suite) TestProcessBackgroundCalls() {
 	blkCnt := 3
 	collPerBlk := 10
 	startHeight := uint64(1000)
-	blocks := make([]flow.Block, blkCnt)
+	blocks := make([]*flow.Block, blkCnt)
 	collMap := make(map[flow.Identifier]*flow.LightCollection, blkCnt*collPerBlk)
 
 	// prepare cluster committee members
@@ -662,7 +663,7 @@ func (s *Suite) TestProcessBackgroundCalls() {
 			unittest.Block.WithHeight(startHeight+uint64(i)),
 			unittest.Block.WithPayload(unittest.PayloadFixture(unittest.WithGuarantees(guarantees...))),
 		)
-		s.blockMap[block.Header.Height] = &block
+		s.blockMap[block.Header.Height] = block
 		blocks[i] = block
 		s.finalizedBlock = block.ToHeader()
 	}
@@ -774,10 +775,11 @@ func (s *Suite) TestProcessBackgroundCalls() {
 	})
 
 	// create new block
-	finalizedBlk := unittest.BlockFixture()
 	height := blocks[blkCnt-1].Header.Height + 1
-	finalizedBlk.Header.Height = height
-	s.blockMap[height] = &finalizedBlk
+	finalizedBlk := unittest.BlockFixture(
+		unittest.Block.WithHeight(height),
+	)
+	s.blockMap[height] = finalizedBlk
 
 	finalizedHeight = finalizedBlk.Header.Height
 	s.finalizedBlock = finalizedBlk.ToHeader()

--- a/engine/access/ingestion/tx_error_messages/tx_error_messages_core_test.go
+++ b/engine/access/ingestion/tx_error_messages/tx_error_messages_core_test.go
@@ -43,7 +43,7 @@ type TxErrorMessagesCoreSuite struct {
 	connFactory *connectionmock.ConnectionFactory
 
 	blockMap       map[uint64]*flow.Block
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 	finalizedBlock *flow.Header
 
 	ctx    context.Context
@@ -75,8 +75,9 @@ func (s *TxErrorMessagesCoreSuite) SetupTest() {
 	s.receipts = storage.NewExecutionReceipts(s.T())
 	s.txErrorMessages = storage.NewTransactionResultErrorMessages(s.T())
 
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 	s.finalizedBlock = unittest.BlockWithParentFixture(s.rootBlock.ToHeader()).ToHeader()
 
 	s.proto.state.On("Params").Return(s.proto.params)

--- a/engine/access/ingestion/tx_error_messages/tx_error_messages_engine_test.go
+++ b/engine/access/ingestion/tx_error_messages/tx_error_messages_engine_test.go
@@ -51,7 +51,7 @@ type TxErrorMessagesEngineSuite struct {
 	connFactory *connectionmock.ConnectionFactory
 
 	blockMap    map[uint64]*flow.Block
-	rootBlock   flow.Block
+	rootBlock   *flow.Block
 	sealedBlock *flow.Header
 
 	db    *badger.DB
@@ -89,8 +89,9 @@ func (s *TxErrorMessagesEngineSuite) SetupTest() {
 
 	blockCount := 5
 	s.blockMap = make(map[uint64]*flow.Block, blockCount)
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 	parent := s.rootBlock.ToHeader()
 
 	for i := 0; i < blockCount; i++ {

--- a/engine/access/integration_unsecure_grpc_server_test.go
+++ b/engine/access/integration_unsecure_grpc_server_test.go
@@ -148,7 +148,7 @@ func (suite *SameGRPCPortTestSuite) SetupTest() {
 	// generate blockCount consecutive blocks with associated seal, result and execution data
 	rootBlock := unittest.BlockFixture()
 	parent := rootBlock.ToHeader()
-	suite.blockMap[rootBlock.Header.Height] = &rootBlock
+	suite.blockMap[rootBlock.Header.Height] = rootBlock
 
 	for i := 0; i < blockCount; i++ {
 		block := unittest.BlockWithParentFixture(parent)

--- a/engine/access/rest/http/routes/blocks_test.go
+++ b/engine/access/rest/http/routes/blocks_test.go
@@ -241,9 +241,10 @@ func generateMocks(backend *mock.API, count int) ([]string, []string, []*flow.Bl
 	executionResults := make([]*flow.ExecutionResult, count)
 
 	for i := 0; i < count; i++ {
-		block := unittest.BlockFixture()
-		block.Header.Height = uint64(i)
-		blocks[i] = &block
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(uint64(i)),
+		)
+		blocks[i] = block
 		blockIDs[i] = block.ID().String()
 		heights[i] = fmt.Sprintf("%d", block.Header.Height)
 
@@ -251,8 +252,8 @@ func generateMocks(backend *mock.API, count int) ([]string, []string, []*flow.Bl
 		executionResult.BlockID = block.ID()
 		executionResults[i] = executionResult
 
-		backend.Mock.On("GetBlockByID", mocks.Anything, block.ID()).Return(&block, flow.BlockStatusSealed, nil)
-		backend.Mock.On("GetBlockByHeight", mocks.Anything, block.Header.Height).Return(&block, flow.BlockStatusSealed, nil)
+		backend.Mock.On("GetBlockByID", mocks.Anything, block.ID()).Return(block, flow.BlockStatusSealed, nil)
+		backend.Mock.On("GetBlockByHeight", mocks.Anything, block.Header.Height).Return(block, flow.BlockStatusSealed, nil)
 		backend.Mock.On("GetExecutionResultForBlockID", mocks.Anything, block.ID()).Return(executionResults[i], nil)
 	}
 

--- a/engine/access/rest/websockets/controller_test.go
+++ b/engine/access/rest/websockets/controller_test.go
@@ -554,7 +554,7 @@ func (s *WsControllerSuite) TestSubscribeBlocks() {
 		dataProvider.On("Close").Return(nil).Maybe()
 
 		// Simulate data provider write a block to the controller
-		expectedBlock := unittest.BlockFixture()
+		expectedBlock := *unittest.BlockFixture()
 		dataProvider.
 			On("Run", mock.Anything).
 			Run(func(args mock.Arguments) {

--- a/engine/access/rest/websockets/data_providers/account_statuses_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/account_statuses_provider_test.go
@@ -33,7 +33,7 @@ type AccountStatusesProviderSuite struct {
 	api *ssmock.API
 
 	chain          flow.Chain
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 	finalizedBlock *flow.Header
 
 	factory *DataProviderFactoryImpl
@@ -49,8 +49,9 @@ func (s *AccountStatusesProviderSuite) SetupTest() {
 
 	s.chain = flow.Testnet.Chain()
 
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 
 	s.factory = NewDataProviderFactory(
 		s.log,

--- a/engine/access/rest/websockets/data_providers/blocks_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/blocks_provider_test.go
@@ -35,7 +35,7 @@ type BlocksProviderSuite struct {
 
 	blocks []*flow.Block
 
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 	finalizedBlock *flow.Header
 
 	factory       *DataProviderFactoryImpl
@@ -54,8 +54,9 @@ func (s *BlocksProviderSuite) SetupTest() {
 	blockCount := 5
 	s.blocks = make([]*flow.Block, 0, blockCount)
 
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 	parent := s.rootBlock.ToHeader()
 
 	for i := 0; i < blockCount; i++ {

--- a/engine/access/rest/websockets/data_providers/events_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/events_provider_test.go
@@ -32,7 +32,7 @@ type EventsProviderSuite struct {
 	api *ssmock.API
 
 	chain          flow.Chain
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 	finalizedBlock *flow.Header
 
 	factory *DataProviderFactoryImpl
@@ -48,8 +48,9 @@ func (s *EventsProviderSuite) SetupTest() {
 
 	s.chain = flow.Testnet.Chain()
 
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 
 	s.factory = NewDataProviderFactory(
 		s.log,

--- a/engine/access/rest/websockets/data_providers/send_and_get_transaction_statuses_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/send_and_get_transaction_statuses_provider_test.go
@@ -28,7 +28,7 @@ type SendTransactionStatusesProviderSuite struct {
 	api *accessmock.API
 
 	chain          flow.Chain
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 	finalizedBlock *flow.Header
 
 	factory       *DataProviderFactoryImpl
@@ -46,8 +46,9 @@ func (s *SendTransactionStatusesProviderSuite) SetupTest() {
 
 	s.chain = flow.Testnet.Chain()
 
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 
 	s.factory = NewDataProviderFactory(
 		s.log,

--- a/engine/access/rest/websockets/data_providers/transaction_statuses_provider_test.go
+++ b/engine/access/rest/websockets/data_providers/transaction_statuses_provider_test.go
@@ -31,7 +31,7 @@ type TransactionStatusesProviderSuite struct {
 	api *accessmock.API
 
 	chain          flow.Chain
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 	finalizedBlock *flow.Header
 
 	factory       *DataProviderFactoryImpl
@@ -49,8 +49,9 @@ func (s *TransactionStatusesProviderSuite) SetupTest() {
 
 	s.chain = flow.Testnet.Chain()
 
-	s.rootBlock = unittest.BlockFixture()
-	s.rootBlock.Header.Height = 0
+	s.rootBlock = unittest.BlockFixture(
+		unittest.Block.WithHeight(0),
+	)
 
 	s.factory = NewDataProviderFactory(
 		s.log,
@@ -123,7 +124,7 @@ func (s *TransactionStatusesProviderSuite) requireTransactionStatuses(
 	require.Equal(s.T(), expectedResponsePayload.TransactionResult.BlockId, actualResponsePayload.TransactionResult.BlockId)
 }
 
-func backendTransactionStatusesResponse(block flow.Block) []*accessmodel.TransactionResult {
+func backendTransactionStatusesResponse(block *flow.Block) []*accessmodel.TransactionResult {
 	id := unittest.IdentifierFixture()
 	cid := unittest.IdentifierFixture()
 	txr := accessmodel.TransactionResult{

--- a/engine/access/rpc/backend/backend_accounts_test.go
+++ b/engine/access/rpc/backend/backend_accounts_test.go
@@ -66,9 +66,7 @@ func (s *BackendAccountsSuite) SetupTest() {
 
 	s.execClient = access.NewExecutionAPIClient(s.T())
 	s.executionNodes = unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
-
-	block := unittest.BlockFixture()
-	s.block = &block
+	s.block = unittest.BlockFixture()
 
 	var err error
 	s.account, err = unittest.AccountFixture()

--- a/engine/access/rpc/backend/backend_scripts_test.go
+++ b/engine/access/rpc/backend/backend_scripts_test.go
@@ -84,9 +84,7 @@ func (s *BackendScriptsSuite) SetupTest() {
 
 	s.execClient = access.NewExecutionAPIClient(s.T())
 	s.executionNodes = unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
-
-	block := unittest.BlockFixture()
-	s.block = &block
+	s.block = unittest.BlockFixture()
 
 	s.script = []byte("access(all) fun main() { return 1 }")
 	s.arguments = [][]byte{[]byte("arg1"), []byte("arg2")}

--- a/engine/access/rpc/backend/backend_stream_blocks_test.go
+++ b/engine/access/rpc/backend/backend_stream_blocks_test.go
@@ -49,7 +49,7 @@ type BackendBlocksSuite struct {
 	broadcaster *engine.Broadcaster
 	blocksArray []*flow.Block
 	blockMap    map[uint64]*flow.Block
-	rootBlock   flow.Block
+	rootBlock   *flow.Block
 
 	backend *Backend
 }
@@ -94,7 +94,7 @@ func (s *BackendBlocksSuite) SetupTest() {
 	// generate blockCount consecutive blocks with associated seal, result and execution data
 	s.rootBlock = unittest.BlockFixture()
 	parent := s.rootBlock.ToHeader()
-	s.blockMap[s.rootBlock.Header.Height] = &s.rootBlock
+	s.blockMap[s.rootBlock.Header.Height] = s.rootBlock
 
 	for i := 0; i < blockCount; i++ {
 		block := unittest.BlockWithParentFixture(parent)

--- a/engine/access/rpc/backend/backend_stream_transactions_test.go
+++ b/engine/access/rpc/backend/backend_stream_transactions_test.go
@@ -81,7 +81,7 @@ type TransactionStatusSuite struct {
 	chainID flow.ChainID
 
 	broadcaster    *engine.Broadcaster
-	rootBlock      flow.Block
+	rootBlock      *flow.Block
 	sealedBlock    *flow.Block
 	finalizedBlock *flow.Block
 
@@ -163,7 +163,7 @@ func (s *TransactionStatusSuite) initializeBackend() {
 	// to ensure the mock library handles the response type correctly
 	var receipts flow.ExecutionReceiptList //nolint:gosimple
 	executionNodes := unittest.IdentityListFixture(2, unittest.WithRole(flow.RoleExecution))
-	receipts = unittest.ReceiptsForBlockFixture(&s.rootBlock, executionNodes.NodeIDs())
+	receipts = unittest.ReceiptsForBlockFixture(s.rootBlock, executionNodes.NodeIDs())
 	s.receipts.On("ByBlockID", mock.AnythingOfType("flow.Identifier")).Return(receipts, nil).Maybe()
 	s.finalSnapshot.On("Identities", mock.Anything).Return(executionNodes, nil).Maybe()
 
@@ -172,7 +172,7 @@ func (s *TransactionStatusSuite) initializeBackend() {
 	s.lastFullBlockHeight, err = counters.NewPersistentStrictMonotonicCounter(progress)
 	require.NoError(s.T(), err)
 
-	s.sealedBlock = &s.rootBlock
+	s.sealedBlock = s.rootBlock
 	s.finalizedBlock = unittest.BlockWithParentFixture(s.sealedBlock.ToHeader())
 	s.blockMap = map[uint64]*flow.Block{
 		s.sealedBlock.Header.Height:    s.sealedBlock,

--- a/engine/access/rpc/backend/backend_test.go
+++ b/engine/access/rpc/backend/backend_test.go
@@ -919,9 +919,9 @@ func (suite *Suite) TestGetTransactionResultByIndex() {
 	// block storage returns the corresponding block
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -977,17 +977,18 @@ func (suite *Suite) TestGetTransactionResultsByBlockID() {
 
 	ctx := context.Background()
 
-	block := unittest.BlockFixture()
 	sporkRootBlockHeight := suite.state.Params().SporkRootBlockHeight()
-	block.Header.Height = sporkRootBlockHeight + 1
+	block := unittest.BlockFixture(
+		unittest.Block.WithHeight(sporkRootBlockHeight + 1),
+	)
 	blockId := block.ID()
 
 	// block storage returns the corresponding block
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -1078,11 +1079,11 @@ func (suite *Suite) TestTransactionStatusTransition() {
 	// block storage returns the corresponding block
 	suite.blocks.
 		On("ByCollectionID", collection.ID()).
-		Return(&block, nil)
+		Return(block, nil)
 
 	txID := transactionBody.ID()
 	blockID := block.ID()
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -1165,12 +1166,14 @@ func (suite *Suite) TestTransactionExpiredStatusTransition() {
 	ctx := context.Background()
 	collection := unittest.CollectionFixture(1)
 	transactionBody := collection.Transactions[0]
-	block := unittest.BlockFixture()
-	block.Header.Height = 2
+	block := unittest.BlockFixture(
+		unittest.Block.WithHeight(2),
+	)
 	transactionBody.SetReferenceBlockID(block.ID())
 
-	headBlock := unittest.BlockFixture()
-	headBlock.Header.Height = block.Header.Height - 1 // head is behind the current block
+	headBlock := unittest.BlockFixture(
+		unittest.Block.WithHeight(block.Header.Height - 1), // head is behind the current block
+	)
 
 	// set up GetLastFullBlockHeight mock
 	fullHeight := headBlock.Header.Height
@@ -1274,14 +1277,16 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 	blockID := block.ID()
 
 	// reference block to which the transaction points to
-	refBlock := unittest.BlockFixture()
+	refBlock := unittest.BlockFixture(
+		unittest.Block.WithHeight(2),
+	)
 	refBlockID := refBlock.ID()
-	refBlock.Header.Height = 2
 	transactionBody.SetReferenceBlockID(refBlockID)
 	txID := transactionBody.ID()
 
-	headBlock := unittest.BlockFixture()
-	headBlock.Header.Height = refBlock.Header.Height - 1 // head is behind the current refBlock
+	headBlock := unittest.BlockFixture(
+		unittest.Block.WithHeight(refBlock.Header.Height - 1), // head is behind the current refBlock
+	)
 
 	suite.snapshot.
 		On("Head").
@@ -1290,7 +1295,7 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 	snapshotAtBlock := new(protocol.Snapshot)
 	snapshotAtBlock.On("Head").Return(refBlock.ToHeader(), nil)
 
-	_, enIDs := suite.setupReceipts(&block)
+	_, enIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 
 	suite.snapshot.On("Identities", mock.Anything).Return(enIDs, nil)
@@ -1330,9 +1335,9 @@ func (suite *Suite) TestTransactionPendingToFinalizedStatusTransition() {
 	// refBlock storage returns the corresponding refBlock
 	suite.blocks.
 		On("ByCollectionID", collection.ID()).
-		Return(&block, nil)
+		Return(block, nil)
 
-	receipts, _ := suite.setupReceipts(&block)
+	receipts, _ := suite.setupReceipts(block)
 
 	exeEventReq := &execproto.GetTransactionResultRequest{
 		BlockId:       blockID[:],
@@ -1434,14 +1439,14 @@ func (suite *Suite) TestGetLatestFinalizedBlock() {
 
 		suite.blocks.
 			On("ByHeight", header.Height).
-			Return(&expected, nil)
+			Return(expected, nil)
 
 		// query the handler for the latest finalized header
 		actual, stat, err := backend.GetLatestBlock(context.Background(), false)
 		suite.checkResponse(actual, err)
 
 		// make sure we got the latest header
-		suite.Require().Equal(expected, *actual)
+		suite.Require().Equal(expected, actual)
 		suite.Assert().Equal(stat, flow.BlockStatusFinalized)
 
 		suite.assertAllExpectations()
@@ -1756,10 +1761,10 @@ func (suite *Suite) TestGetTransactionResultEventEncodingVersion() {
 	blockId := block.ID()
 
 	// reference block to which the transaction points to
-	refBlock := unittest.BlockFixture()
-	refBlockID := refBlock.ID()
-	refBlock.Header.Height = 2
-	transactionBody.SetReferenceBlockID(refBlockID)
+	refBlock := unittest.BlockFixture(
+		unittest.Block.WithHeight(2),
+	)
+	transactionBody.SetReferenceBlockID(refBlock.ID())
 	txId := transactionBody.ID()
 
 	// transaction storage returns the corresponding transaction
@@ -1775,9 +1780,9 @@ func (suite *Suite) TestGetTransactionResultEventEncodingVersion() {
 	// block storage returns the corresponding block
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -1838,9 +1843,9 @@ func (suite *Suite) TestGetTransactionResultByIndexAndBlockIdEventEncodingVersio
 	// block storage returns the corresponding block
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -1935,9 +1940,9 @@ func (suite *Suite) TestNodeCommunicator() {
 	// block storage returns the corresponding block
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 

--- a/engine/access/rpc/backend/backend_transactions_test.go
+++ b/engine/access/rpc/backend/backend_transactions_test.go
@@ -114,7 +114,7 @@ func (suite *Suite) TestGetTransactionResultReturnsTransactionError() {
 
 		suite.blocks.
 			On("ByID", block.ID()).
-			Return(&block, nil).
+			Return(block, nil).
 			Once()
 
 		suite.state.On("AtBlockID", block.ID()).Return(snap, nil).Once()
@@ -194,7 +194,7 @@ func (suite *Suite) withGetTransactionCachingTestSetup(f func(b *flow.Block, t *
 
 		suite.state.On("AtBlockID", block.ID()).Return(snap, nil).Once()
 
-		f(&block, &tx)
+		f(block, &tx)
 	})
 }
 
@@ -352,7 +352,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByTransactionID_HappyPath()
 	failedTxIndex := rand.Uint32()
 
 	// Setup mock receipts and execution node identities.
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -426,7 +426,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByTransactionID_FailedToFet
 	failedTxId := failedTx.ID()
 
 	// Setup mock receipts and execution node identities.
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -534,7 +534,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_HappyPath() {
 	failedTxIndex := rand.Uint32()
 
 	// Setup mock receipts and execution node identities.
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -609,7 +609,7 @@ func (suite *Suite) TestLookupTransactionErrorMessageByIndex_FailedToFetch() {
 	failedTxId := failedTx.ID()
 
 	// Setup mock receipts and execution node identities.
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -725,7 +725,7 @@ func (suite *Suite) TestLookupTransactionErrorMessagesByBlockID_HappyPath() {
 		})
 	}
 
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -824,7 +824,7 @@ func (suite *Suite) TestLookupTransactionErrorMessagesByBlockID_FailedToFetch() 
 	blockId := block.ID()
 
 	// Setup mock receipts and execution node identities.
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
 
@@ -1068,7 +1068,7 @@ func (suite *Suite) TestGetSystemTransactionResultFromStorage() {
 	// Mock the behavior of the blocks and transactionResults objects
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil).
+		Return(block, nil).
 		Once()
 
 	lightTxShouldFail := false
@@ -1237,7 +1237,7 @@ func (suite *Suite) TestGetSystemTransactionResult_FailedEncodingConversion() {
 func (suite *Suite) assertTransactionResultResponse(
 	err error,
 	response *accessmodel.TransactionResult,
-	block flow.Block,
+	block *flow.Block,
 	txId flow.Identifier,
 	txFailed bool,
 	eventsForTx []flow.Event,
@@ -1279,7 +1279,7 @@ func (suite *Suite) TestTransactionResultFromStorage() {
 	// Mock the behavior of the blocks and transactionResults objects
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 
 	suite.transactionResults.On("ByBlockIDTransactionID", blockId, txId).
 		Return(&flow.LightTransactionResult{
@@ -1308,7 +1308,7 @@ func (suite *Suite) TestTransactionResultFromStorage() {
 	suite.events.On("ByBlockIDTransactionID", blockId, txId).Return(eventsForTx, nil)
 
 	// Set up the state and snapshot mocks
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
@@ -1375,7 +1375,7 @@ func (suite *Suite) TestTransactionByIndexFromStorage() {
 	// Mock the behavior of the blocks and transactionResults objects
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 
 	suite.transactionResults.On("ByBlockIDTransactionIndex", blockId, txIndex).
 		Return(&flow.LightTransactionResult{
@@ -1396,7 +1396,7 @@ func (suite *Suite) TestTransactionByIndexFromStorage() {
 	suite.events.On("ByBlockIDTransactionIndex", blockId, txIndex).Return(eventsForTx, nil)
 
 	// Set up the state and snapshot mocks
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)
@@ -1455,7 +1455,7 @@ func (suite *Suite) TestTransactionResultsByBlockIDFromStorage() {
 	// Mock the behavior of the blocks, collections and light transaction results objects
 	suite.blocks.
 		On("ByID", blockId).
-		Return(&block, nil)
+		Return(block, nil)
 	lightCol := col.Light()
 	suite.collections.On("LightByID", mock.Anything).Return(&lightCol, nil)
 
@@ -1490,7 +1490,7 @@ func (suite *Suite) TestTransactionResultsByBlockIDFromStorage() {
 	suite.events.On("ByBlockIDTransactionID", blockId, mock.Anything).Return(eventsForTx, nil)
 
 	// Set up the state and snapshot mocks
-	_, fixedENIDs := suite.setupReceipts(&block)
+	_, fixedENIDs := suite.setupReceipts(block)
 	suite.state.On("Final").Return(suite.snapshot, nil).Maybe()
 	suite.state.On("Sealed").Return(suite.snapshot, nil).Maybe()
 	suite.snapshot.On("Identities", mock.Anything).Return(fixedENIDs, nil)

--- a/engine/access/state_stream/backend/backend_executiondata_test.go
+++ b/engine/access/state_stream/backend/backend_executiondata_test.go
@@ -76,7 +76,7 @@ type BackendExecutionDataSuite struct {
 	resultMap   map[flow.Identifier]*flow.ExecutionResult
 	registerID  flow.RegisterID
 
-	rootBlock          flow.Block
+	rootBlock          *flow.Block
 	highestBlockHeader *flow.Header
 }
 
@@ -171,7 +171,7 @@ func (s *BackendExecutionDataSuite) SetupTestSuite(blockCount int) {
 
 	// generate blockCount consecutive blocks with associated seal, result and execution data
 	s.rootBlock = unittest.BlockFixture()
-	s.blockMap[s.rootBlock.Header.Height] = &s.rootBlock
+	s.blockMap[s.rootBlock.Header.Height] = s.rootBlock
 	s.highestBlockHeader = s.rootBlock.ToHeader()
 
 	s.T().Logf("Generating %d blocks, root block: %d %s", blockCount, s.rootBlock.Header.Height, s.rootBlock.ID())

--- a/engine/collection/ingest/engine_test.go
+++ b/engine/collection/ingest/engine_test.go
@@ -276,9 +276,9 @@ func (suite *Suite) TestInvalidTransaction() {
 
 	suite.Run("expired reference block ID", func() {
 		// "finalize" a sufficiently high block that root block is expired
-		final := unittest.BlockFixture()
-		final.Header.Height = suite.root.Header.Height + flow.DefaultTransactionExpiry + 1
-		suite.final = &final
+		suite.final = unittest.BlockFixture(
+			unittest.Block.WithHeight(suite.root.Header.Height + flow.DefaultTransactionExpiry + 1),
+		)
 
 		tx := unittest.TransactionBodyFixture()
 		tx.ReferenceBlockID = suite.root.ID()

--- a/engine/common/follower/cache/cache_test.go
+++ b/engine/common/follower/cache/cache_test.go
@@ -110,7 +110,7 @@ func (s *CacheSuite) TestBlocksAreNotConnected() {
 // We expect that A will get certified after adding B.
 func (s *CacheSuite) TestChildCertifiesParent() {
 	block := unittest.BlockFixture()
-	proposal := unittest.ProposalFromBlock(&block)
+	proposal := unittest.ProposalFromBlock(block)
 	certifiedBatch, err := s.cache.AddBlocks([]*flow.BlockProposal{proposal})
 	require.NoError(s.T(), err)
 	require.Empty(s.T(), certifiedBatch)
@@ -283,7 +283,7 @@ func (s *CacheSuite) TestMultipleChildrenForSameParent() {
 	B := unittest.BlockWithParentFixture(A.ToHeader())
 	C := unittest.BlockWithParentFixture(A.ToHeader())
 	C.Header.View = B.Header.View + 1 // make sure views are different
-	Ap := unittest.ProposalFromBlock(&A)
+	Ap := unittest.ProposalFromBlock(A)
 	Bp := unittest.ProposalFromBlock(B)
 	Cp := unittest.ProposalFromBlock(C)
 
@@ -312,7 +312,7 @@ func (s *CacheSuite) TestChildEjectedBeforeAddingParent() {
 	C := unittest.BlockWithParentFixture(A.ToHeader())
 	C.Header.View = B.Header.View + 1 // make sure views are different
 
-	Ap := unittest.ProposalFromBlock(&A)
+	Ap := unittest.ProposalFromBlock(A)
 	Bp := unittest.ProposalFromBlock(B)
 	Cp := unittest.ProposalFromBlock(C)
 	_, err := s.cache.AddBlocks([]*flow.BlockProposal{Bp})

--- a/engine/common/follower/compliance_core_test.go
+++ b/engine/common/follower/compliance_core_test.go
@@ -111,9 +111,10 @@ func (s *CoreSuite) TestProcessingSingleBlock() {
 // TestAddFinalizedBlock tests that adding block below finalized height results in processing it, but since cache was pruned
 // to finalized view, it must be rejected by it.
 func (s *CoreSuite) TestAddFinalizedBlock() {
-	block := unittest.BlockFixture()
-	block.Header.View = s.finalizedBlock.View - 1 // block is below finalized view
-	proposal := unittest.ProposalFromBlock(&block)
+	block := unittest.BlockFixture(
+		unittest.Block.WithView(s.finalizedBlock.View - 1), // block is below finalized view
+	)
+	proposal := unittest.ProposalFromBlock(block)
 
 	// incoming block has to be validated
 	s.validator.On("ValidateProposal", model.SignedProposalFromBlock(proposal)).Return(nil).Once()

--- a/engine/common/rpc/execution_node_identities_provider_test.go
+++ b/engine/common/rpc/execution_node_identities_provider_test.go
@@ -57,15 +57,14 @@ func (suite *ENIdentitiesProviderSuite) TestExecutionNodesForBlockID() {
 	allExecutionNodes := unittest.IdentityListFixture(totalReceipts, unittest.WithRole(flow.RoleExecution))
 
 	// one execution result for all receipts for this block
-	executionResult := unittest.ExecutionResultFixture()
+	executionResult := *unittest.ExecutionResultFixture()
 
 	// generate execution receipts
 	receipts := make(flow.ExecutionReceiptList, totalReceipts)
 	for j := 0; j < totalReceipts; j++ {
-		r := unittest.ReceiptForBlockFixture(&block)
+		r := unittest.ReceiptForBlockFixture(block)
 		r.ExecutorID = allExecutionNodes[j].NodeID
-		er := *executionResult
-		r.ExecutionResult = er
+		r.ExecutionResult = executionResult
 		receipts[j] = r
 	}
 

--- a/engine/common/synchronization/engine_test.go
+++ b/engine/common/synchronization/engine_test.go
@@ -131,9 +131,10 @@ func (ss *SyncSuite) TestOnRangeRequest() {
 	// fill in blocks at heights -1 to -4 from head
 	ref := ss.head.Height
 	for height := ref; height >= ref-4; height-- {
-		block := unittest.BlockFixture()
-		block.Header.Height = height
-		ss.heights[height] = unittest.ProposalFromBlock(&block)
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(height),
+		)
+		ss.heights[height] = unittest.ProposalFromBlock(block)
 		ss.blockIDs[block.ID()] = ss.heights[height]
 	}
 
@@ -282,9 +283,10 @@ func (ss *SyncSuite) TestOnBatchRequest() {
 
 	// a non-empty request for existing block IDs should send right response
 	ss.T().Run("request for existing blocks", func(t *testing.T) {
-		block := unittest.BlockFixture()
-		block.Header.Height = ss.head.Height - 1
-		proposal := unittest.ProposalFromBlock(&block)
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(ss.head.Height - 1),
+		)
+		proposal := unittest.ProposalFromBlock(block)
 		req.BlockIDs = []flow.Identifier{block.ID()}
 		ss.blockIDs[block.ID()] = proposal
 		ss.con.On("Unicast", mock.Anything, mock.Anything).Return(nil).Run(
@@ -306,10 +308,11 @@ func (ss *SyncSuite) TestOnBatchRequest() {
 		ss.blockIDs = make(map[flow.Identifier]*flow.BlockProposal)
 		req.BlockIDs = make([]flow.Identifier, 5)
 		for i := 0; i < len(req.BlockIDs); i++ {
-			b := unittest.BlockFixture()
-			b.Header.Height = ss.head.Height - uint64(i)
+			b := unittest.BlockFixture(
+				unittest.Block.WithHeight(ss.head.Height - uint64(i)),
+			)
 			req.BlockIDs[i] = b.ID()
-			ss.blockIDs[b.ID()] = unittest.ProposalFromBlock(&b)
+			ss.blockIDs[b.ID()] = unittest.ProposalFromBlock(b)
 		}
 		ss.con.On("Unicast", mock.Anything, mock.Anything).Return(nil).Run(
 			func(args mock.Arguments) {

--- a/engine/consensus/approvals/request_tracker_test.go
+++ b/engine/consensus/approvals/request_tracker_test.go
@@ -40,7 +40,7 @@ func (s *RequestTrackerTestSuite) SetupTest() {
 func (s *RequestTrackerTestSuite) TestTryUpdate_CreateAndUpdate() {
 	executedBlock := unittest.BlockFixture()
 	s.headers.On("ByBlockID", executedBlock.ID()).Return(executedBlock.ToHeader(), nil)
-	result := unittest.ExecutionResultFixture(unittest.WithBlock(&executedBlock))
+	result := unittest.ExecutionResultFixture(unittest.WithBlock(executedBlock))
 	chunks := 5
 	for i := 0; i < chunks; i++ {
 		_, updated, err := s.tracker.TryUpdate(result, executedBlock.ID(), uint64(i))
@@ -66,7 +66,7 @@ func (s *RequestTrackerTestSuite) TestTryUpdate_ConcurrentTracking() {
 
 	executedBlock := unittest.BlockFixture()
 	s.headers.On("ByBlockID", executedBlock.ID()).Return(executedBlock.ToHeader(), nil)
-	result := unittest.ExecutionResultFixture(unittest.WithBlock(&executedBlock))
+	result := unittest.ExecutionResultFixture(unittest.WithBlock(executedBlock))
 	chunks := 5
 	var wg sync.WaitGroup
 	for times := 0; times < 10; times++ {
@@ -95,7 +95,7 @@ func (s *RequestTrackerTestSuite) TestTryUpdate_ConcurrentTracking() {
 func (s *RequestTrackerTestSuite) TestTryUpdate_UpdateForInvalidResult() {
 	executedBlock := unittest.BlockFixture()
 	s.headers.On("ByBlockID", executedBlock.ID()).Return(nil, storage.ErrNotFound)
-	result := unittest.ExecutionResultFixture(unittest.WithBlock(&executedBlock))
+	result := unittest.ExecutionResultFixture(unittest.WithBlock(executedBlock))
 	_, updated, err := s.tracker.TryUpdate(result, executedBlock.ID(), uint64(0))
 	require.Error(s.T(), err)
 	require.False(s.T(), updated)
@@ -108,7 +108,7 @@ func (s *RequestTrackerTestSuite) TestTryUpdate_UpdateForPrunedHeight() {
 	s.headers.On("ByBlockID", executedBlock.ID()).Return(executedBlock.ToHeader(), nil)
 	err := s.tracker.PruneUpToHeight(executedBlock.Header.Height + 1)
 	require.NoError(s.T(), err)
-	result := unittest.ExecutionResultFixture(unittest.WithBlock(&executedBlock))
+	result := unittest.ExecutionResultFixture(unittest.WithBlock(executedBlock))
 	_, updated, err := s.tracker.TryUpdate(result, executedBlock.ID(), uint64(0))
 	require.Error(s.T(), err)
 	require.True(s.T(), mempool.IsBelowPrunedThresholdError(err))
@@ -122,7 +122,7 @@ func (s *RequestTrackerTestSuite) TestPruneUpToHeight_Pruning() {
 	s.headers.On("ByBlockID", executedBlock.ID()).Return(executedBlock.ToHeader(), nil)
 	s.headers.On("ByBlockID", nextExecutedBlock.ID()).Return(nextExecutedBlock.ToHeader(), nil)
 
-	result := unittest.ExecutionResultFixture(unittest.WithBlock(&executedBlock))
+	result := unittest.ExecutionResultFixture(unittest.WithBlock(executedBlock))
 	nextResult := unittest.ExecutionResultFixture(unittest.WithBlock(nextExecutedBlock))
 
 	for _, r := range []*flow.ExecutionResult{result, nextResult} {

--- a/engine/consensus/compliance/core_test.go
+++ b/engine/consensus/compliance/core_test.go
@@ -335,9 +335,10 @@ func (cs *CoreSuite) TestOnBlockProposalSkipProposalThreshold() {
 
 	// create a proposal which is far enough ahead to be dropped
 	originID := cs.participants[1].NodeID
-	block := unittest.BlockFixture()
-	block.Header.View = cs.head.View + compliance.DefaultConfig().SkipNewProposalsThreshold + 1
-	proposal := unittest.ProposalFromBlock(&block)
+	block := unittest.BlockFixture(
+		unittest.Block.WithView(cs.head.View + compliance.DefaultConfig().SkipNewProposalsThreshold + 1),
+	)
+	proposal := unittest.ProposalFromBlock(block)
 
 	err := cs.core.OnBlockProposal(flow.Slashable[*messages.UntrustedProposal]{
 		OriginID: originID,

--- a/engine/consensus/matching/engine_test.go
+++ b/engine/consensus/matching/engine_test.go
@@ -123,7 +123,7 @@ func (s *MatchingEngineSuite) TestMultipleProcessingItems() {
 	for i := range receipts {
 		receipt := unittest.ExecutionReceiptFixture(
 			unittest.WithExecutorID(originID),
-			unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&block))),
+			unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(block))),
 		)
 		receipts[i] = receipt
 		s.core.On("ProcessReceipt", receipt).Return(nil).Once()

--- a/engine/consensus/sealing/engine_test.go
+++ b/engine/consensus/sealing/engine_test.go
@@ -152,7 +152,7 @@ func (s *SealingEngineSuite) TestMultipleProcessingItems() {
 	for i := range receipts {
 		receipt := unittest.ExecutionReceiptFixture(
 			unittest.WithExecutorID(originID),
-			unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&block))),
+			unittest.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(block))),
 		)
 		receipts[i] = receipt
 	}

--- a/engine/execution/computation/programs_test.go
+++ b/engine/execution/computation/programs_test.go
@@ -209,9 +209,8 @@ func TestPrograms_TestBlockForks(t *testing.T) {
 	execCtx := fvm.NewContext(
 		fvm.WithEVMEnabled(true),
 		fvm.WithBlockHeader(block.ToHeader()),
-		fvm.WithBlocks(blockProvider{map[uint64]*flow.Block{0: &block}}),
+		fvm.WithBlocks(blockProvider{map[uint64]*flow.Block{0: block}}),
 		fvm.WithChain(chain))
-
 	privateKeys, err := testutil.GenerateAccountPrivateKeys(1)
 	require.NoError(t, err)
 	snapshotTree, accounts, err := testutil.CreateAccounts(

--- a/engine/execution/ingestion/block_queue/queue_test.go
+++ b/engine/execution/ingestion/block_queue/queue_test.go
@@ -431,8 +431,7 @@ func makeChainABCDEFG() (GetBlock, GetCollection, GetCommit) {
 		return cs[name-1]
 	}
 
-	r := unittest.BlockFixture()
-	blockR := &r
+	blockR := unittest.BlockFixture()
 	bs := unittest.ChainBlockFixtureWithRoot(blockR.ToHeader(), 4)
 	blockA, blockB, blockC, blockD := bs[0], bs[1], bs[2], bs[3]
 	unittest.AddCollectionsToBlock(blockA, []*flow.Collection{c1})
@@ -493,8 +492,7 @@ func makeChainABCDEF() (GetBlock, GetCollection, GetCommit) {
 		return cs[name-1]
 	}
 
-	r := unittest.BlockFixture()
-	blockR := &r
+	blockR := unittest.BlockFixture()
 	bs := unittest.ChainBlockFixtureWithRoot(blockR.ToHeader(), 3)
 	blockA, blockB, blockC := bs[0], bs[1], bs[2]
 	unittest.AddCollectionsToBlock(blockB, []*flow.Collection{c1, c2})

--- a/engine/execution/rpc/engine_test.go
+++ b/engine/execution/rpc/engine_test.go
@@ -127,8 +127,9 @@ func (suite *Suite) TestGetEventsForBlockIDs() {
 
 	// setup the events storage mock
 	for i := range blockIDs {
-		block := unittest.BlockFixture()
-		block.Header.Height = uint64(i)
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(uint64(i)),
+		)
 		id := block.ID()
 		blockIDs[i] = id[:]
 		eventsForBlock := make([]flow.Event, eventsPerBlock)

--- a/engine/protocol/api_test.go
+++ b/engine/protocol/api_test.go
@@ -57,7 +57,7 @@ func (suite *Suite) TestGetLatestFinalizedBlock_Success() {
 
 	suite.blocks.
 		On("ByID", header.ID()).
-		Return(&block, nil).
+		Return(block, nil).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -67,7 +67,7 @@ func (suite *Suite) TestGetLatestFinalizedBlock_Success() {
 	suite.checkResponse(responseBlock, err)
 
 	// make sure we got the latest block
-	suite.Require().Equal(block, *responseBlock)
+	suite.Require().Equal(block, responseBlock)
 
 	suite.assertAllExpectations()
 }
@@ -86,7 +86,7 @@ func (suite *Suite) TestGetLatestSealedBlock_Success() {
 
 	suite.blocks.
 		On("ByID", header.ID()).
-		Return(&block, nil).
+		Return(block, nil).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -96,7 +96,7 @@ func (suite *Suite) TestGetLatestSealedBlock_Success() {
 	suite.checkResponse(responseBlock, err)
 
 	// make sure we got the latest block
-	suite.Require().Equal(block, *responseBlock)
+	suite.Require().Equal(block, responseBlock)
 
 	suite.assertAllExpectations()
 }
@@ -173,7 +173,7 @@ func (suite *Suite) TestGetBlockById_Success() {
 
 	suite.blocks.
 		On("ByID", block.ID()).
-		Return(&block, nil).
+		Return(block, nil).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -194,7 +194,7 @@ func (suite *Suite) TestGetBlockById_StorageNotFoundFailure() {
 
 	suite.blocks.
 		On("ByID", block.ID()).
-		Return(&block, storage.ErrNotFound).
+		Return(block, storage.ErrNotFound).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -213,7 +213,7 @@ func (suite *Suite) TestGetBlockById_CodesNotFoundFailure() {
 
 	suite.blocks.
 		On("ByID", block.ID()).
-		Return(&block, CodesNotFoundErr).
+		Return(block, CodesNotFoundErr).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -232,7 +232,7 @@ func (suite *Suite) TestGetBlockById_InternalFailure() {
 
 	suite.blocks.
 		On("ByID", block.ID()).
-		Return(&block, InternalErr).
+		Return(block, InternalErr).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -252,7 +252,7 @@ func (suite *Suite) TestGetBlockByHeight_Success() {
 
 	suite.blocks.
 		On("ByHeight", height).
-		Return(&block, nil).
+		Return(block, nil).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -274,7 +274,7 @@ func (suite *Suite) TestGetBlockByHeight_StorageNotFoundFailure() {
 
 	suite.blocks.
 		On("ByHeight", height).
-		Return(&block, StorageNotFoundErr).
+		Return(block, StorageNotFoundErr).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -294,7 +294,7 @@ func (suite *Suite) TestGetBlockByHeight_CodesNotFoundFailure() {
 
 	suite.blocks.
 		On("ByHeight", height).
-		Return(&block, CodesNotFoundErr).
+		Return(block, CodesNotFoundErr).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)
@@ -314,7 +314,7 @@ func (suite *Suite) TestGetBlockByHeight_InternalFailure() {
 
 	suite.blocks.
 		On("ByHeight", height).
-		Return(&block, InternalErr).
+		Return(block, InternalErr).
 		Once()
 
 	backend := New(suite.state, suite.blocks, suite.headers, nil)

--- a/engine/verification/assigner/blockconsumer/consumer_test.go
+++ b/engine/verification/assigner/blockconsumer/consumer_test.go
@@ -27,9 +27,9 @@ import (
 // and its corresponding job can be converted back to the same block.
 func TestBlockToJob(t *testing.T) {
 	block := unittest.BlockFixture()
-	actual, err := jobqueue.JobToBlock(jobqueue.BlockToJob(&block))
+	actual, err := jobqueue.JobToBlock(jobqueue.BlockToJob(block))
 	require.NoError(t, err)
-	require.Equal(t, &block, actual)
+	require.Equal(t, block, actual)
 }
 
 func TestProduceConsume(t *testing.T) {

--- a/engine/verification/assigner/engine_test.go
+++ b/engine/verification/assigner/engine_test.go
@@ -105,7 +105,7 @@ func createContainerBlock(options ...func(result *flow.ExecutionResult, assignme
 		),
 	)
 
-	return &block, assignment
+	return block, assignment
 }
 
 // NewAssignerEngine returns an assigner engine for testing.

--- a/fvm/evm/evm_test.go
+++ b/fvm/evm/evm_test.go
@@ -2737,8 +2737,9 @@ func TestCadenceArch(t *testing.T) {
 				// we must record a new heartbeat with a fixed block, we manually execute a transaction to do so,
 				// since doing this automatically would require a block computer and whole execution setup
 				height := uint64(1)
-				block1 := unittest.BlockFixture()
-				block1.Header.Height = height
+				block1 := unittest.BlockFixture(
+					unittest.Block.WithHeight(height),
+				)
 				ctx.BlockHeader = block1.ToHeader()
 				ctx.EntropyProvider = testutil.EntropyProviderFixture(entropy) // fix the entropy
 
@@ -2834,8 +2835,9 @@ func TestCadenceArch(t *testing.T) {
 				// we must record a new heartbeat with a fixed block, we manually execute a transaction to do so,
 				// since doing this automatically would require a block computer and whole execution setup
 				height := uint64(1)
-				block1 := unittest.BlockFixture()
-				block1.Header.Height = height
+				block1 := unittest.BlockFixture(
+					unittest.Block.WithHeight(height),
+				)
 				ctx.BlockHeader = block1.ToHeader()
 
 				txBody := flow.NewTransactionBody().

--- a/insecure/wintermute/attackOrchestrator_test.go
+++ b/insecure/wintermute/attackOrchestrator_test.go
@@ -566,7 +566,7 @@ func TestPassingThroughMiscellaneousEvents(t *testing.T) {
 		Protocol:          insecure.Protocol_MULTICAST,
 		TargetNum:         3,
 		TargetIds:         unittest.IdentifierListFixture(10),
-		FlowProtocolEvent: unittest.BlockFixture(),
+		FlowProtocolEvent: *unittest.BlockFixture(),
 	}
 
 	eventPassThrough := &sync.WaitGroup{}

--- a/model/flow/block_test.go
+++ b/model/flow/block_test.go
@@ -49,7 +49,7 @@ func TestBlockEncodingJSON(t *testing.T) {
 	require.NoError(t, err)
 	decodedID := decoded.ID()
 	assert.Equal(t, blockID, decodedID)
-	assert.Equal(t, block, decoded)
+	assert.Equal(t, block, &decoded)
 }
 
 func TestBlockEncodingMsgpack(t *testing.T) {
@@ -62,7 +62,7 @@ func TestBlockEncodingMsgpack(t *testing.T) {
 	require.NoError(t, err)
 	decodedID := decoded.ID()
 	assert.Equal(t, blockID, decodedID)
-	assert.Equal(t, block, decoded)
+	assert.Equal(t, block, &decoded)
 }
 
 func TestNilProducesSameHashAsEmptySlice(t *testing.T) {

--- a/module/builder/consensus/builder_test.go
+++ b/module/builder/consensus/builder_test.go
@@ -217,15 +217,15 @@ func (bs *BuilderSuite) SetupTest() {
 
 	// Construct the [first] block:
 	first := unittest.BlockFixture()
-	bs.storeBlock(&first)
+	bs.storeBlock(first)
 	bs.firstID = first.ID()
-	firstResult := unittest.ExecutionResultFixture(unittest.WithBlock(&first))
+	firstResult := unittest.ExecutionResultFixture(unittest.WithBlock(first))
 	bs.lastSeal = unittest.Seal.Fixture(unittest.Seal.WithResult(firstResult))
 	bs.resultForBlock[firstResult.BlockID] = firstResult
 	bs.resultByID[firstResult.ID()] = firstResult
 
 	// Construct finalized blocks [F0] ... [F4]
-	previous := &first
+	previous := first
 	for n := 0; n < numFinalizedBlocks; n++ {
 		finalized := bs.createAndRecordBlock(previous, n > 0) // Do not construct candidate seal for [first], as it is already sealed
 		bs.finalizedBlockIDs = append(bs.finalizedBlockIDs, finalized.ID())

--- a/module/chainsync/core_test.go
+++ b/module/chainsync/core_test.go
@@ -394,37 +394,41 @@ func (ss *SyncSuite) TestPrune() {
 	final.Height = 100
 
 	var (
-		prunableHeights  []flow.Block
-		prunableBlockIDs []flow.Block
-		unprunable       []flow.Block
+		prunableHeights  []*flow.Block
+		prunableBlockIDs []*flow.Block
+		unprunable       []*flow.Block
 	)
 
 	// add some finalized blocks by height
 	for i := 0; i < 3; i++ {
-		block := unittest.BlockFixture()
-		block.Header.Height = uint64(i + 1)
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(uint64(i + 1)),
+		)
 		ss.core.heights[block.Header.Height] = ss.QueuedStatus()
 		prunableHeights = append(prunableHeights, block)
 	}
 	// add some un-finalized blocks by height
 	for i := 0; i < 3; i++ {
-		block := unittest.BlockFixture()
-		block.Header.Height = final.Height + uint64(i+1)
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(final.Height + uint64(i+1)),
+		)
 		ss.core.heights[block.Header.Height] = ss.QueuedStatus()
 		unprunable = append(unprunable, block)
 	}
 
 	// add some finalized blocks by block ID
 	for i := 0; i < 3; i++ {
-		block := unittest.BlockFixture()
-		block.Header.Height = uint64(i + 1)
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(uint64(i + 1)),
+		)
 		ss.core.blockIDs[block.ID()] = ss.ReceivedStatus(block.ToHeader())
 		prunableBlockIDs = append(prunableBlockIDs, block)
 	}
 	// add some un-finalized, received blocks by block ID
 	for i := 0; i < 3; i++ {
-		block := unittest.BlockFixture()
-		block.Header.Height = 100 + uint64(i+1)
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(100 + uint64(i+1)),
+		)
 		ss.core.blockIDs[block.ID()] = ss.ReceivedStatus(block.ToHeader())
 		unprunable = append(unprunable, block)
 	}

--- a/module/chunks/chunkVerifier_test.go
+++ b/module/chunks/chunkVerifier_test.go
@@ -452,7 +452,7 @@ func blockFixture(collection *flow.Collection) *flow.Block {
 			flow.Payload{Guarantees: []*flow.CollectionGuarantee{guarantee}},
 		),
 	)
-	return &block
+	return block
 }
 
 func generateStateUpdates(t *testing.T, f *completeLedger.Ledger) (ledger.State, ledger.Proof, *ledger.Update) {

--- a/module/jobqueue/jobs_test.go
+++ b/module/jobqueue/jobs_test.go
@@ -20,7 +20,7 @@ func TestJobID(t *testing.T) {
 
 func TestBlockJob(t *testing.T) {
 	block := unittest.BlockFixture()
-	job := jobqueue.BlockToJob(&block)
+	job := jobqueue.BlockToJob(block)
 
 	t.Run("job is correct type", func(t *testing.T) {
 		assert.IsType(t, &jobqueue.BlockJob{}, job, "job is not a block job")
@@ -34,7 +34,7 @@ func TestBlockJob(t *testing.T) {
 	t.Run("job converts to block", func(t *testing.T) {
 		b, err := jobqueue.JobToBlock(job)
 		assert.NoError(t, err, "unexpected error converting notify job to block")
-		assert.Equal(t, block, *b, "converted block is not the same as the original block")
+		assert.Equal(t, block, b, "converted block is not the same as the original block")
 	})
 
 	t.Run("incorrect job type fails to convert to block", func(t *testing.T) {

--- a/module/mempool/consensus/exec_fork_suppressor_test.go
+++ b/module/mempool/consensus/exec_fork_suppressor_test.go
@@ -256,12 +256,12 @@ func Test_ForkDetectionPersisted(t *testing.T) {
 
 		// add seal
 		block := unittest.BlockFixture()
-		sealA := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&block))))
+		sealA := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(block))))
 		wrappedMempool.On("Add", sealA).Return(true, nil).Once()
 		_, _ = wrapper.Add(sealA)
 
 		// add conflicting seal
-		sealB := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&block))))
+		sealB := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(block))))
 		wrappedMempool.On("Add", sealB).Return(true, nil).Once()
 		added, _ := wrapper.Add(sealB) // should be rejected because it is conflicting with sealA
 		require.True(t, added)
@@ -366,7 +366,7 @@ func Test_ConflictingSeal_SmokeTest(t *testing.T) {
 		// two of them are non-conflicting but for same block and one is conflicting.
 
 		block := unittest.BlockFixture()
-		sealA := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&block))))
+		sealA := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(block))))
 		_, _ = wrapper.Add(sealA)
 
 		// different seal but for same result
@@ -390,7 +390,7 @@ func Test_ConflictingSeal_SmokeTest(t *testing.T) {
 		require.ElementsMatch(t, []*flow.IncorporatedResultSeal{sealA, sealB}, seals)
 
 		// add conflicting seal, which doesn't have any receipts yet
-		conflictingSeal := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(&block))))
+		conflictingSeal := unittest.IncorporatedResultSeal.Fixture(unittest.IncorporatedResultSeal.WithResult(unittest.ExecutionResultFixture(unittest.WithBlock(block))))
 		_, _ = wrapper.Add(conflictingSeal)
 
 		// conflicting seal doesn't have any receipts yet

--- a/module/mempool/stdmap/pending_receipts_test.go
+++ b/module/mempool/stdmap/pending_receipts_test.go
@@ -191,7 +191,7 @@ func TestPendingReceipts(t *testing.T) {
 		pool := NewPendingReceipts(headers, 100)
 		executedBlock := unittest.BlockFixture()
 		nextExecutedBlock := unittest.BlockWithParentFixture(executedBlock.ToHeader())
-		er := unittest.ExecutionResultFixture(unittest.WithBlock(&executedBlock))
+		er := unittest.ExecutionResultFixture(unittest.WithBlock(executedBlock))
 		headers.On("ByBlockID", executedBlock.ID()).Return(executedBlock.ToHeader(), nil)
 		headers.On("ByBlockID", nextExecutedBlock.ID()).Return(nextExecutedBlock.ToHeader(), nil)
 		ids := make(map[flow.Identifier]struct{})

--- a/module/metrics/example/consensus/main.go
+++ b/module/metrics/example/consensus/main.go
@@ -40,7 +40,7 @@ func main() {
 		for i := 0; i < 100; i++ {
 			block := unittest.BlockFixture()
 			collector.MempoolEntries(metrics.ResourceGuarantee, 22)
-			collector.BlockFinalized(&block)
+			collector.BlockFinalized(block)
 			collector.HotStuffBusyDuration(10, metrics.HotstuffEventTypeLocalTimeout)
 			collector.HotStuffWaitDuration(10, metrics.HotstuffEventTypeLocalTimeout)
 			collector.HotStuffIdleDuration(10)

--- a/network/codec/roundTripHeader_test.go
+++ b/network/codec/roundTripHeader_test.go
@@ -22,7 +22,7 @@ import (
 // next developer who wants to add a new serialization format :-)
 func roundTripHeaderViaCodec(t *testing.T, codec network.Codec) {
 	block := unittest.BlockFixture()
-	proposal := unittest.ProposalFromBlock(&block)
+	proposal := unittest.ProposalFromBlock(block)
 	message := messages.NewUntrustedProposal(proposal)
 	encoded, err := codec.Encode(message)
 	assert.NoError(t, err)

--- a/state/protocol/badger/mutator_test.go
+++ b/state/protocol/badger/mutator_test.go
@@ -551,7 +551,7 @@ func TestExtendMissingParent(t *testing.T) {
 			unittest.Block.WithView(2),
 		)
 
-		err := state.Extend(context.Background(), unittest.ProposalFromBlock(&extend))
+		err := state.Extend(context.Background(), unittest.ProposalFromBlock(extend))
 		require.Error(t, err)
 		require.False(t, st.IsInvalidExtensionError(err), err)
 		require.False(t, st.IsOutdatedExtensionError(err), err)
@@ -577,7 +577,7 @@ func TestExtendHeightTooSmall(t *testing.T) {
 			unittest.Block.WithView(1),
 			unittest.Block.WithPayload(unittest.PayloadFixture(unittest.WithProtocolStateID(rootProtocolStateID))))
 
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&extend))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(extend))
 		require.NoError(t, err)
 
 		// create another block with the same height and view, that is coming after
@@ -1002,7 +1002,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 				}),
 		)
 		// insert the block sealing the EpochSetup event
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block3))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block3))
 		require.NoError(t, err)
 
 		// now that the setup event has been emitted, we should be in the setup phase
@@ -1025,7 +1025,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.Error(t, err)
 
 		// insert B4
-		block4 := unittest.BlockWithParentProtocolState(&block3)
+		block4 := unittest.BlockWithParentProtocolState(block3)
 		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block4))
 		require.NoError(t, err)
 
@@ -1079,7 +1079,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block5.ID(), block6View, seals),
 				}),
 		)
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block6))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block6))
 		require.NoError(t, err)
 
 		// we should NOT be able to query epoch 2 commit info wrt blocks before 6
@@ -1098,7 +1098,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 		require.Equal(t, flow.EpochPhaseCommitted, phase)
 
 		// block 7 has the final view of the epoch, insert it, finalized after finalizing block 6
-		block7 := unittest.BlockWithParentProtocolState(&block6)
+		block7 := unittest.BlockWithParentProtocolState(block6)
 		block7.Header.View = epoch1FinalView
 		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block7))
 		require.NoError(t, err)
@@ -1137,7 +1137,7 @@ func TestExtendEpochTransitionValid(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block7.ID(), block8View, nil),
 				}),
 		)
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block8))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block8))
 		require.NoError(t, err)
 
 		// now, at long last, we are in epoch 2
@@ -1287,7 +1287,7 @@ func TestExtendConflictingEpochEvents(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block3.ID(), block5View, seals1),
 				}),
 		)
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block5))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block5))
 		require.NoError(t, err)
 
 		// block 6 builds on block 4, contains seal for block 2
@@ -1301,16 +1301,16 @@ func TestExtendConflictingEpochEvents(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block4.ID(), block6View, seals2),
 				}),
 		)
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block6))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block6))
 		require.NoError(t, err)
 
 		// block 7 builds on block 5, contains QC for block 5
-		block7 := unittest.BlockWithParentProtocolState(&block5)
+		block7 := unittest.BlockWithParentProtocolState(block5)
 		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block7))
 		require.NoError(t, err)
 
 		// block 8 builds on block 6, contains QC for block 6
-		block8 := unittest.BlockWithParentProtocolState(&block6)
+		block8 := unittest.BlockWithParentProtocolState(block6)
 		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block8))
 		require.NoError(t, err)
 
@@ -1423,7 +1423,7 @@ func TestExtendDuplicateEpochEvents(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block3.ID(), block5View, seals1),
 				}),
 		)
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block5))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block5))
 		require.NoError(t, err)
 
 		// block 6 builds on block 4, contains seal for block 2
@@ -1437,17 +1437,17 @@ func TestExtendDuplicateEpochEvents(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block4.ID(), block6View, seals2),
 				}),
 		)
-		err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block6))
+		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block6))
 		require.NoError(t, err)
 
 		// block 7 builds on block 5, contains QC for block 5
-		block7 := unittest.BlockWithParentProtocolState(&block5)
+		block7 := unittest.BlockWithParentProtocolState(block5)
 		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block7))
 		require.NoError(t, err)
 
 		// block 8 builds on block 6, contains QC for block 6
 		// at this point we are inserting the duplicate EpochSetup, should not error
-		block8 := unittest.BlockWithParentProtocolState(&block6)
+		block8 := unittest.BlockWithParentProtocolState(block6)
 		err = state.Extend(context.Background(), unittest.ProposalFromBlock(block8))
 		require.NoError(t, err)
 
@@ -1841,7 +1841,7 @@ func TestEpochFallbackMode(t *testing.T) {
 			protoEventsMock.On("EpochFallbackModeTriggered", epoch1Setup.Counter, block1.ToHeader()).Once()
 			protoEventsMock.On("EpochExtended", epoch1Setup.Counter, block1.ToHeader(), unittest.MatchEpochExtension(epoch1FinalView, epochExtensionViewCount)).Once()
 
-			err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block1))
+			err = state.Extend(context.Background(), unittest.ProposalFromBlock(block1))
 			require.NoError(t, err)
 			assertEpochFallbackTriggered(t, state.Final(), false) // not triggered before finalization
 			err = state.Finalize(context.Background(), block1.ID())
@@ -1850,7 +1850,7 @@ func TestEpochFallbackMode(t *testing.T) {
 			assertInPhase(t, state.Final(), flow.EpochPhaseFallback) // immediately enter fallback phase
 
 			// block 2 will be the first block past the first epoch boundary
-			block2 := unittest.BlockWithParentProtocolState(&block1)
+			block2 := unittest.BlockWithParentProtocolState(block1)
 			block2.Header.View = epoch1FinalView + 1
 			err = state.Extend(context.Background(), unittest.ProposalFromBlock(block2))
 			require.NoError(t, err)
@@ -1944,7 +1944,7 @@ func TestEpochFallbackMode(t *testing.T) {
 						ProtocolStateID: calculateExpectedStateId(t, mutableState)(block2.ID(), block3View, seals),
 					}),
 			)
-			err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block3))
+			err = state.Extend(context.Background(), unittest.ProposalFromBlock(block3))
 			require.NoError(t, err)
 
 			// finalizing block 3 should trigger EFM
@@ -1961,7 +1961,7 @@ func TestEpochFallbackMode(t *testing.T) {
 			assertInPhase(t, state.Final(), flow.EpochPhaseFallback)
 
 			// block 4 will be the first block past the first epoch boundary
-			block4 := unittest.BlockWithParentProtocolState(&block3)
+			block4 := unittest.BlockWithParentProtocolState(block3)
 			block4.Header.View = epoch1FinalView + 1
 			err = state.Extend(context.Background(), unittest.ProposalFromBlock(block4))
 			require.NoError(t, err)
@@ -2053,7 +2053,7 @@ func TestEpochFallbackMode(t *testing.T) {
 						ProtocolStateID: calculateExpectedStateId(t, mutableState)(block2.ID(), block3View, seals),
 					}),
 			)
-			err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block3))
+			err = state.Extend(context.Background(), unittest.ProposalFromBlock(block3))
 			require.NoError(t, err)
 
 			// incorporating the service event should trigger EFM
@@ -2077,7 +2077,7 @@ func TestEpochFallbackMode(t *testing.T) {
 						ProtocolStateID: calculateExpectedStateId(t, mutableState)(block3.ID(), block4View, nil),
 					}),
 			)
-			err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block4))
+			err = state.Extend(context.Background(), unittest.ProposalFromBlock(block4))
 			require.NoError(t, err)
 
 			// we add the epoch extension after the epoch transition
@@ -2145,7 +2145,7 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 						ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),
 					}),
 			)
-			unittest.InsertAndFinalize(t, state, &block1)
+			unittest.InsertAndFinalize(t, state, block1)
 
 			// add a participant for the next epoch
 			epoch2NewParticipant := unittest.IdentityFixture(unittest.WithRole(flow.RoleVerification))
@@ -2159,10 +2159,10 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 				unittest.WithFinalView(epoch1Setup.FinalView+1000),
 				unittest.WithFirstView(epoch1Setup.FinalView+1),
 			)
-			receipt, seal := unittest.ReceiptAndSealForBlock(&block1, invalidSetup.ServiceEvent())
+			receipt, seal := unittest.ReceiptAndSealForBlock(block1, invalidSetup.ServiceEvent())
 
 			// ingesting block 2 and 3, block 3 seals the invalid setup event
-			block2, block3 := unittest.SealBlock(t, state, mutableProtocolState, &block1, receipt, seal)
+			block2, block3 := unittest.SealBlock(t, state, mutableProtocolState, block1, receipt, seal)
 			assertEpochFallbackTriggered(t, state.AtBlockID(block2.ID()), false) // EFM shouldn't be triggered since block 2 only incorporates the event, sealing happens in block 3
 			assertEpochFallbackTriggered(t, state.AtBlockID(block3.ID()), true)  // EFM has to be triggered at block 3, since it seals the invalid setup event
 			assertEpochFallbackTriggered(t, state.Final(), false)                // EFM should still not be triggered for finalized state since the invalid service event does not have a finalized seal
@@ -2244,7 +2244,7 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 						ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),
 					}),
 			)
-			unittest.InsertAndFinalize(t, state, &block1)
+			unittest.InsertAndFinalize(t, state, block1)
 
 			// add a participant for the next epoch
 			epoch2NewParticipant := unittest.IdentityFixture(unittest.WithRole(flow.RoleVerification))
@@ -2259,10 +2259,10 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 				unittest.WithFinalView(epoch1Setup.FinalView+1000),
 				unittest.WithFirstView(epoch1Setup.FinalView+1),
 			)
-			receipt, seal := unittest.ReceiptAndSealForBlock(&block1, epoch2Setup.ServiceEvent())
+			receipt, seal := unittest.ReceiptAndSealForBlock(block1, epoch2Setup.ServiceEvent())
 
 			// ingesting block 2 and 3, block 3 seals the EpochSetup event
-			block2, block3 := unittest.SealBlock(t, state, mutableProtocolState, &block1, receipt, seal)
+			block2, block3 := unittest.SealBlock(t, state, mutableProtocolState, block1, receipt, seal)
 			err = state.Finalize(context.Background(), block2.ID())
 			require.NoError(t, err)
 
@@ -2389,7 +2389,7 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 						ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),
 					}),
 			)
-			unittest.InsertAndFinalize(t, state, &block1)
+			unittest.InsertAndFinalize(t, state, block1)
 
 			// add a participant for the next epoch
 			epoch2NewParticipant := unittest.IdentityFixture(unittest.WithRole(flow.RoleVerification))
@@ -2404,10 +2404,10 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 				unittest.WithFinalView(epoch1Setup.FinalView+1000),
 				unittest.WithFirstView(epoch1Setup.FinalView+1),
 			)
-			receipt, seal := unittest.ReceiptAndSealForBlock(&block1, epoch2Setup.ServiceEvent())
+			receipt, seal := unittest.ReceiptAndSealForBlock(block1, epoch2Setup.ServiceEvent())
 
 			// ingesting block 2 and 3, block 3 seals the `epochSetup` for the next epoch
-			block2, block3 := unittest.SealBlock(t, state, mutableProtocolState, &block1, receipt, seal)
+			block2, block3 := unittest.SealBlock(t, state, mutableProtocolState, block1, receipt, seal)
 			err = state.Finalize(context.Background(), block2.ID())
 			require.NoError(t, err)
 
@@ -2490,7 +2490,7 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 			protoEventsMock.On("EpochTransition", epoch2Setup.Counter, block8.ToHeader()).Once()
 
 			// epoch transition happens at this point
-			unittest.InsertAndFinalize(t, state, &block8)
+			unittest.InsertAndFinalize(t, state, block8)
 			assertInPhase(t, state.Final(), flow.EpochPhaseFallback) // enter fallback phase immediately after transition
 
 			metricsMock.AssertCalled(t, "CurrentEpochCounter", epoch2Setup.Counter)
@@ -2508,7 +2508,7 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 						ProtocolStateID: expectedStateIdCalculator(block8.ID(), block9View, nil),
 					}),
 			)
-			err = state.Extend(context.Background(), unittest.ProposalFromBlock(&block9))
+			err = state.Extend(context.Background(), unittest.ProposalFromBlock(block9))
 			require.NoError(t, err)
 
 			epochProtocolState, err := state.AtBlockID(block9.ID()).EpochProtocolState()
@@ -2535,7 +2535,7 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 			// We expect that the Protocol state at B12 switches `EpochFallbackTriggered` back to false.
 
 			// B10 will be the first block past the epoch extension
-			block10 := unittest.BlockWithParentProtocolState(&block9)
+			block10 := unittest.BlockWithParentProtocolState(block9)
 			block10.Header.View = epochExtensions[0].FirstView
 			unittest.InsertAndFinalize(t, state, block10)
 
@@ -2604,7 +2604,7 @@ func TestRecoveryFromEpochFallbackMode(t *testing.T) {
 			metricsMock.On("CurrentEpochFinalView", epochRecover.EpochSetup.FinalView).Once()
 			protoEventsMock.On("EpochTransition", epochRecover.EpochSetup.Counter, block14.ToHeader()).Once()
 
-			unittest.InsertAndFinalize(t, state, &block14)
+			unittest.InsertAndFinalize(t, state, block14)
 
 			epochProtocolState, err = state.Final().EpochProtocolState()
 			require.NoError(t, err)
@@ -2644,7 +2644,7 @@ func TestEpochTargetEndTime(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),
 				}),
 		)
-		unittest.InsertAndFinalize(t, state, &block1)
+		unittest.InsertAndFinalize(t, state, block1)
 
 		block1snap := state.Final()
 		assertEpochFallbackTriggered(t, block1snap, true)
@@ -2670,7 +2670,7 @@ func TestEpochTargetEndTime(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block1.ID(), block2View, nil),
 				}),
 		)
-		unittest.InsertAndFinalize(t, state, &block2)
+		unittest.InsertAndFinalize(t, state, block2)
 
 		block2snap := state.Final()
 		epochState, err = block2snap.EpochProtocolState()
@@ -2714,7 +2714,7 @@ func TestEpochTargetDuration(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(head.ID(), block1View, nil),
 				}),
 		)
-		unittest.InsertAndFinalize(t, state, &block1)
+		unittest.InsertAndFinalize(t, state, block1)
 
 		assertEpochFallbackTriggered(t, state.Final(), true)
 		assertInPhase(t, state.Final(), flow.EpochPhaseFallback)
@@ -2739,7 +2739,7 @@ func TestEpochTargetDuration(t *testing.T) {
 					ProtocolStateID: expectedStateIdCalculator(block1.ID(), block2View, nil),
 				}),
 		)
-		unittest.InsertAndFinalize(t, state, &block2)
+		unittest.InsertAndFinalize(t, state, block2)
 
 		epochState, err = state.Final().EpochProtocolState()
 		require.NoError(t, err)
@@ -2882,7 +2882,7 @@ func TestHeaderExtendMissingParent(t *testing.T) {
 			unittest.Block.WithView(2),
 		)
 
-		err := state.ExtendCertified(context.Background(), unittest.NewCertifiedBlock(&extend))
+		err := state.ExtendCertified(context.Background(), unittest.NewCertifiedBlock(extend))
 		require.Error(t, err)
 		require.False(t, st.IsInvalidExtensionError(err), err)
 

--- a/state/protocol/badger/snapshot_test.go
+++ b/state/protocol/badger/snapshot_test.go
@@ -362,7 +362,7 @@ func TestSealingSegment(t *testing.T) {
 						ProtocolStateID: calculateExpectedStateId(t, mutableState)(block2.ID(), block3View, seals),
 					}),
 			)
-			buildFinalizedBlock(t, state, &block3)
+			buildFinalizedBlock(t, state, block3)
 
 			segment, err := state.AtBlockID(block3.ID()).SealingSegment()
 			require.NoError(t, err)
@@ -371,11 +371,11 @@ func TestSealingSegment(t *testing.T) {
 			assert.Equal(t, segment.ExtraBlocks[0].Block.Header.Height, head.Height)
 
 			// build a valid child B3 to ensure we have a QC
-			buildBlock(t, state, unittest.BlockWithParentProtocolState(&block3))
+			buildBlock(t, state, unittest.BlockWithParentProtocolState(block3))
 
 			// sealing segment should contain B1, B2, B3
 			// B3 is reference of snapshot, B1 is latest sealed
-			unittest.AssertEqualBlockSequences(t, []*flow.Block{block1, block2, &block3}, segment.Blocks)
+			unittest.AssertEqualBlockSequences(t, []*flow.Block{block1, block2, block3}, segment.Blocks)
 			assert.Len(t, segment.ExecutionResults, 1)
 			assertSealingSegmentBlocksQueryableAfterBootstrap(t, state.AtBlockID(block3.ID()))
 		})

--- a/state/protocol/badger/state_test.go
+++ b/state/protocol/badger/state_test.go
@@ -365,9 +365,9 @@ func TestBootstrapNonRoot(t *testing.T) {
 						ProtocolStateID: calculateExpectedStateId(t, mutableState)(block2.ID(), block3View, seals),
 					}),
 			)
-			buildFinalizedBlock(t, state, &block3)
+			buildFinalizedBlock(t, state, block3)
 
-			child := unittest.BlockWithParentProtocolState(&block3)
+			child := unittest.BlockWithParentProtocolState(block3)
 			buildBlock(t, state, child)
 
 			return state.AtBlockID(block3.ID())
@@ -421,9 +421,9 @@ func TestBootstrapNonRoot(t *testing.T) {
 						ProtocolStateID: calculateExpectedStateId(t, mutableState)(block2.ID(), block3View, seals),
 					}),
 			)
-			buildFinalizedBlock(t, state, &block3)
+			buildFinalizedBlock(t, state, block3)
 
-			child := unittest.BlockWithParentProtocolState(&block3)
+			child := unittest.BlockWithParentProtocolState(block3)
 			buildBlock(t, state, child)
 
 			// ensure we have entered EFM

--- a/state/protocol/badger/validity_test.go
+++ b/state/protocol/badger/validity_test.go
@@ -69,8 +69,9 @@ func TestValidateVersionBeacon(t *testing.T) {
 	})
 	t.Run("valid version beacon is ok", func(t *testing.T) {
 		snap := new(mock.Snapshot)
-		block := unittest.BlockFixture()
-		block.Header.Height = 100
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(100),
+		)
 
 		vb := &flow.SealedVersionBeacon{
 			VersionBeacon: &flow.VersionBeacon{
@@ -93,8 +94,9 @@ func TestValidateVersionBeacon(t *testing.T) {
 	})
 	t.Run("height must be below highest block", func(t *testing.T) {
 		snap := new(mock.Snapshot)
-		block := unittest.BlockFixture()
-		block.Header.Height = 12
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(12),
+		)
 
 		vb := &flow.SealedVersionBeacon{
 			VersionBeacon: &flow.VersionBeacon{
@@ -118,8 +120,9 @@ func TestValidateVersionBeacon(t *testing.T) {
 	})
 	t.Run("version beacon must be valid", func(t *testing.T) {
 		snap := new(mock.Snapshot)
-		block := unittest.BlockFixture()
-		block.Header.Height = 12
+		block := unittest.BlockFixture(
+			unittest.Block.WithHeight(12),
+		)
 
 		vb := &flow.SealedVersionBeacon{
 			VersionBeacon: &flow.VersionBeacon{

--- a/storage/badger/receipts_test.go
+++ b/storage/badger/receipts_test.go
@@ -34,7 +34,7 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 	t.Run("store one get one", func(t *testing.T) {
 		withStore(t, func(store *bstorage.ExecutionReceipts) {
 			block := unittest.BlockFixture()
-			receipt1 := unittest.ReceiptForBlockFixture(&block)
+			receipt1 := unittest.ReceiptForBlockFixture(block)
 
 			err := store.Store(receipt1)
 			require.NoError(t, err)
@@ -58,8 +58,8 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 			executor1 := unittest.IdentifierFixture()
 			executor2 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block, executor2)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block, executor2)
 
 			err := store.Store(receipt1)
 			require.NoError(t, err)
@@ -82,8 +82,8 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 			executor1 := unittest.IdentifierFixture()
 			executor2 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block2, executor2)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block2, executor2)
 
 			err := store.Store(receipt1)
 			require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 			block1 := unittest.BlockFixture()
 
 			executor1 := unittest.IdentifierFixture()
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
 
 			err := store.Store(receipt1)
 			require.NoError(t, err)
@@ -128,8 +128,8 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 
 			executor1 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
 
 			err := store.Store(receipt1)
 			require.NoError(t, err)

--- a/storage/store/my_receipts_test.go
+++ b/storage/store/my_receipts_test.go
@@ -28,7 +28,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 	t.Run("myReceipts one get one", func(t *testing.T) {
 		withStore(t, func(myReceipts storage.MyExecutionReceipts, results storage.ExecutionResults, receipts storage.ExecutionReceipts, db storage.DB) {
 			block := unittest.BlockFixture()
-			receipt1 := unittest.ReceiptForBlockFixture(&block)
+			receipt1 := unittest.ReceiptForBlockFixture(block)
 
 			err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return myReceipts.BatchStoreMyReceipt(receipt1, rw)
@@ -55,7 +55,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 		withStore(t, func(myReceipts storage.MyExecutionReceipts, _ storage.ExecutionResults, _ storage.ExecutionReceipts, db storage.DB) {
 			block := unittest.BlockFixture()
 
-			receipt1 := unittest.ReceiptForBlockFixture(&block)
+			receipt1 := unittest.ReceiptForBlockFixture(block)
 
 			err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return myReceipts.BatchStoreMyReceipt(receipt1, rw)
@@ -76,8 +76,8 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 			executor1 := unittest.IdentifierFixture()
 			executor2 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block, executor2)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block, executor2)
 
 			err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 				return myReceipts.BatchStoreMyReceipt(receipt1, rw)
@@ -100,8 +100,8 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 			executor1 := unittest.IdentifierFixture()
 			executor2 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block, executor2)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block, executor2)
 
 			var wg sync.WaitGroup
 			errChan := make(chan error, 2)
@@ -152,7 +152,7 @@ func TestMyExecutionReceiptsStorage(t *testing.T) {
 
 					block := unittest.BlockFixture() // Each iteration gets a new block
 					executor := unittest.IdentifierFixture()
-					receipt := unittest.ReceiptForBlockExecutorFixture(&block, executor)
+					receipt := unittest.ReceiptForBlockExecutorFixture(block, executor)
 
 					err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 						return myReceipts.BatchStoreMyReceipt(receipt, rw)
@@ -181,8 +181,8 @@ func TestMyExecutionReceiptsStorageMultipleStoreInSameBatch(t *testing.T) {
 		myReceipts := store.NewMyExecutionReceipts(metrics, db, receipts)
 
 		block := unittest.BlockFixture()
-		receipt1 := unittest.ReceiptForBlockFixture(&block)
-		receipt2 := unittest.ReceiptForBlockFixture(&block)
+		receipt1 := unittest.ReceiptForBlockFixture(block)
+		receipt2 := unittest.ReceiptForBlockFixture(block)
 
 		err := db.WithReaderBatchWriter(func(rw storage.ReaderBatchWriter) error {
 			err := myReceipts.BatchStoreMyReceipt(receipt1, rw)

--- a/storage/store/receipts_test.go
+++ b/storage/store/receipts_test.go
@@ -35,7 +35,7 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 	t.Run("store1 one get one", func(t *testing.T) {
 		withStore(t, func(store1 *store.ExecutionReceipts) {
 			block := unittest.BlockFixture()
-			receipt1 := unittest.ReceiptForBlockFixture(&block)
+			receipt1 := unittest.ReceiptForBlockFixture(block)
 
 			err := store1.Store(receipt1)
 			require.NoError(t, err)
@@ -59,8 +59,8 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 			executor1 := unittest.IdentifierFixture()
 			executor2 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block, executor2)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block, executor2)
 
 			err := store1.Store(receipt1)
 			require.NoError(t, err)
@@ -83,8 +83,8 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 			executor1 := unittest.IdentifierFixture()
 			executor2 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block2, executor2)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block2, executor2)
 
 			err := store1.Store(receipt1)
 			require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 			block1 := unittest.BlockFixture()
 
 			executor1 := unittest.IdentifierFixture()
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
 
 			err := store1.Store(receipt1)
 			require.NoError(t, err)
@@ -129,8 +129,8 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 
 			executor1 := unittest.IdentifierFixture()
 
-			receipt1 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
-			receipt2 := unittest.ReceiptForBlockExecutorFixture(&block1, executor1)
+			receipt1 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
+			receipt2 := unittest.ReceiptForBlockExecutorFixture(block1, executor1)
 
 			err := store1.Store(receipt1)
 			require.NoError(t, err)
@@ -144,5 +144,4 @@ func TestExecutionReceiptsStorage(t *testing.T) {
 			require.ElementsMatch(t, []*flow.ExecutionReceipt{receipt1, receipt2}, receipts)
 		})
 	})
-
 }

--- a/utils/unittest/block.go
+++ b/utils/unittest/block.go
@@ -8,7 +8,7 @@ var Block blockFactory
 
 type blockFactory struct{}
 
-// BlockFixture initializes and returns a new flow.Block instance.
+// BlockFixture initializes and returns a new *flow.Block instance.
 func BlockFixture(opts ...func(*flow.Block)) *flow.Block {
 	header := BlockHeaderFixture()
 	block := BlockWithParentFixture(header)

--- a/utils/unittest/block.go
+++ b/utils/unittest/block.go
@@ -11,13 +11,13 @@ var Block blockFactory
 type blockFactory struct{}
 
 // BlockFixture initializes and returns a new flow.Block instance.
-func BlockFixture(opts ...func(*flow.Block)) flow.Block {
+func BlockFixture(opts ...func(*flow.Block)) *flow.Block {
 	header := BlockHeaderFixture()
 	block := BlockWithParentFixture(header)
 	for _, opt := range opts {
 		opt(block)
 	}
-	return *block
+	return block
 }
 
 func (f *blockFactory) WithParent(parentID flow.Identifier, parentView uint64, parentHeight uint64) func(*flow.Block) {
@@ -45,6 +45,18 @@ func (f *blockFactory) WithHeight(height uint64) func(*flow.Block) {
 func (f *blockFactory) WithPayload(payload flow.Payload) func(*flow.Block) {
 	return func(b *flow.Block) {
 		b.Payload = payload
+	}
+}
+
+func (f *blockFactory) WithProposerID(proposerID flow.Identifier) func(*flow.Block) {
+	return func(b *flow.Block) {
+		b.Header.ProposerID = proposerID
+	}
+}
+
+func (f *blockFactory) WithLastViewTC(lastViewTC *flow.TimeoutCertificate) func(*flow.Block) {
+	return func(block *flow.Block) {
+		block.Header.LastViewTC = lastViewTC
 	}
 }
 

--- a/utils/unittest/chain_suite.go
+++ b/utils/unittest/chain_suite.go
@@ -30,7 +30,7 @@ type BaseChainSuite struct {
 	Approvers  flow.IdentityList
 
 	// BLOCKS
-	RootBlock             flow.Block
+	RootBlock             *flow.Block
 	LatestSealedBlock     flow.Block
 	LatestFinalizedBlock  *flow.Block
 	UnfinalizedBlock      flow.Block
@@ -105,7 +105,7 @@ func (bc *BaseChainSuite) SetupChain() {
 	bc.UnfinalizedBlock = *BlockWithParentFixture(bc.LatestFinalizedBlock.ToHeader())
 
 	bc.Blocks = make(map[flow.Identifier]*flow.Block)
-	bc.Blocks[bc.RootBlock.ID()] = &bc.RootBlock
+	bc.Blocks[bc.RootBlock.ID()] = bc.RootBlock
 	bc.Blocks[bc.LatestSealedBlock.ID()] = &bc.LatestSealedBlock
 	bc.Blocks[bc.LatestFinalizedBlock.ID()] = bc.LatestFinalizedBlock
 	bc.Blocks[bc.UnfinalizedBlock.ID()] = &bc.UnfinalizedBlock
@@ -496,7 +496,7 @@ func (bc *BaseChainSuite) ValidSubgraphFixture() subgraphFixture {
 	)
 
 	// RESULTS for Blocks:
-	previousResult := ExecutionResultFixture(WithBlock(&parentBlock))
+	previousResult := ExecutionResultFixture(WithBlock(parentBlock))
 	result := ExecutionResultFixture(
 		WithBlock(block),
 		WithPreviousResult(*previousResult),
@@ -524,7 +524,7 @@ func (bc *BaseChainSuite) ValidSubgraphFixture() subgraphFixture {
 
 	return subgraphFixture{
 		Block:              block,
-		ParentBlock:        &parentBlock,
+		ParentBlock:        parentBlock,
 		Result:             result,
 		PreviousResult:     previousResult,
 		IncorporatedResult: incorporatedResult,

--- a/utils/unittest/fixtures.go
+++ b/utils/unittest/fixtures.go
@@ -225,7 +225,7 @@ func BlockFixtures(number int) []*flow.Block {
 	blocks := make([]*flow.Block, 0, number)
 	for range number {
 		block := BlockFixture()
-		blocks = append(blocks, &block)
+		blocks = append(blocks, block)
 	}
 	return blocks
 }
@@ -240,8 +240,7 @@ func ProposalFixtures(number int) []*flow.BlockProposal {
 }
 
 func ProposalFixture() *flow.BlockProposal {
-	block := BlockFixture()
-	return ProposalFromBlock(&block)
+	return ProposalFromBlock(BlockFixture())
 }
 
 func ProposalFromHeader(header *flow.Header) *flow.ProposalHeader {
@@ -269,7 +268,7 @@ func BlockchainFixture(length int) []*flow.Block {
 	blocks := make([]*flow.Block, length)
 
 	genesis := BlockFixture()
-	blocks[0] = &genesis
+	blocks[0] = genesis
 	for i := 1; i < length; i++ {
 		blocks[i] = BlockWithParentFixture(blocks[i-1].ToHeader())
 	}

--- a/utils/unittest/protocol_state.go
+++ b/utils/unittest/protocol_state.go
@@ -100,10 +100,10 @@ func SealBlock(t *testing.T, st protocol.ParticipantState, mutableProtocolState 
 				ProtocolStateID: updatedStateId,
 			}),
 	)
-	err = st.Extend(context.Background(), ProposalFromBlock(&block3))
+	err = st.Extend(context.Background(), ProposalFromBlock(block3))
 	require.NoError(t, err)
 
-	return block2, &block3
+	return block2, block3
 }
 
 // InsertAndFinalize inserts, then finalizes, the input block.


### PR DESCRIPTION
Closes: #7495

## Note
If this change is unnecessary, please feel free to close this pull request.

## Context
Previously, `flow.NewBlock` was modified to return a pointer and following this, according to [suggestion](https://github.com/onflow/flow-go/pull/7402#discussion_r2107974161), `FullBlockFixture` was updated to return a pointer for consistency. However, `BlockFixture` still returned a value. 
https://github.com/onflow/flow-go/blob/35e3770ffdd69c4f1ef99f92b35665ad50d2d2d9/utils/unittest/block.go#L11-L19
This pull request updates the `BlockFixture` helper function for consistency to return a pointer.

## Changes
-  Modified `BlockFixture` to return a pointer.
-  Added `WithProposerID` and `WithLastViewTC` test helpers for easily setup the `flow.Block`.
-  Updated all relevant tests and usages to accommodate the new pointer return type.

